### PR TITLE
OpenAPI completion + Spectral contract lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,16 @@ jobs:
         with:
           go-version: '1.25.7'
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Verify OpenAPI matches registered routes
         run: go run ./scripts/openapi_route_parity.go
+
+      - name: Lint OpenAPI contract
+        run: npx --yes @stoplight/spectral-cli@6 lint --ruleset .spectral.yaml api/openapi.yaml
 
       - name: Ensure generated OpenAPI placeholders are removed
         shell: bash
@@ -211,6 +219,10 @@ jobs:
           set -euo pipefail
           if grep -n "x-cerebro-generated" api/openapi.yaml; then
             echo "OpenAPI still contains generated placeholders. Replace with real operation docs."
+            exit 1
+          fi
+          if grep -n "Undocumented" api/openapi.yaml; then
+            echo "OpenAPI still contains undocumented placeholder tags."
             exit 1
           fi
 

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,26 @@
+extends:
+  - spectral:oas
+
+rules:
+  operation-description: off
+  operation-operationId: off
+
+  no-undocumented-tag:
+    description: Placeholder tags are not allowed in committed OpenAPI contracts.
+    message: Remove `Undocumented` tag and provide concrete endpoint metadata.
+    severity: error
+    given: $.paths[*][*].tags[*]
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: ^Undocumented$
+
+  no-placeholder-summary:
+    description: Placeholder operation summaries are not allowed.
+    message: Replace placeholder summaries with endpoint-specific summaries.
+    severity: error
+    given: $.paths[*][*].summary
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: '[Pp][Ll][Aa][Cc][Ee][Hh][Oo][Ll][Dd][Ee][Rr]'

--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,17 @@ openapi-check:
 		echo "OpenAPI contains generated placeholders (x-cerebro-generated). Replace with real operation docs."; \
 		exit 1; \
 	fi
+	@if grep -n "Undocumented" api/openapi.yaml; then \
+		echo "OpenAPI contains undocumented operation tags. Replace with endpoint contracts."; \
+		exit 1; \
+	fi
+	$(MAKE) openapi-lint
 
 openapi-sync:
 	go run ./scripts/openapi_route_parity.go --write
+
+openapi-lint:
+	npx --yes @stoplight/spectral-cli@6 lint --ruleset .spectral.yaml api/openapi.yaml
 
 config-docs:
 	go run ./scripts/generate_config_docs/main.go

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -50,8 +50,6 @@ tags:
   description: Webhook management
 - name: Admin
   description: Administrative endpoints
-- name: Undocumented
-  description: Auto-generated placeholders pending endpoint-level contract documentation
 - name: Graph
   description: Security graph and risk intelligence endpoints
 - name: Runtime
@@ -699,103 +697,286 @@ paths:
   /api/v1/agents/sessions/{id}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Agents
+      summary: Get agent session
+      description: Return a specific agent session, including message and status metadata.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Agent session ID
       responses:
         '200':
-          description: OK
+          description: Agent session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentSession'
+        '404':
+          description: Session not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/agents/sessions/{id}/approve:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Agents
+      summary: Approve or deny pending tool call
+      description: Approve or deny a pending tool call for an agent session.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Agent session ID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentSessionApprovalRequest'
       responses:
         '200':
-          description: OK
+          description: Approval handled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Message'
+        '400':
+          description: Invalid approval request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Session not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to update session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/agents/{id}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Agents
+      summary: Get agent metadata
+      description: Return metadata for a registered investigation agent.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Agent ID
       responses:
         '200':
-          description: OK
+          description: Agent metadata
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Agent not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/attack-paths:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Graph
+      summary: List attack paths
+      description: Enumerate modeled attack paths and aggregate counts.
       responses:
         '200':
-          description: OK
+          description: Attack path list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
   /api/v1/attack-paths/analyze:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Graph
+      summary: Analyze attack paths
+      description: Run an attack-path analysis against optional high-value targets.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttackPathAnalyzeRequest'
       responses:
         '200':
-          description: OK
+          description: Analysis results
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid analysis request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/attack-paths/graph:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Graph
+      summary: Get attack graph nodes
+      description: Return the current attack graph node inventory.
       responses:
         '200':
-          description: OK
+          description: Graph node list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
   /api/v1/attack-paths/graph/edges:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Graph
+      summary: Add attack graph edge
+      description: Add a directed edge between attack graph nodes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Edge created
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid edge payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/attack-paths/graph/nodes:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Graph
+      summary: Add attack graph node
+      description: Add a node to the in-memory attack graph.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Node created
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid node payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/attack-paths/{id}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Graph
+      summary: Get attack path by ID
+      description: Return a specific computed attack path.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Attack path ID
+      - name: max_depth
+        in: query
+        required: false
+        schema:
+          type: integer
+        description: Optional maximum traversal depth
+      - name: targets
+        in: query
+        required: false
+        schema:
+          type: string
+        description: Comma-separated list of target node IDs
       responses:
         '200':
-          description: OK
+          description: Attack path details
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Attack path not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/audit:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: List audit logs
+      description: Query persisted audit entries, optionally filtered by resource.
+      parameters:
+      - name: resource_type
+        in: query
+        required: false
+        schema:
+          type: string
+        description: Filter by resource type
+      - name: resource_id
+        in: query
+        required: false
+        schema:
+          type: string
+        description: Filter by resource ID
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+        description: Maximum number of log entries to return
       responses:
         '200':
-          description: OK
+          description: Audit log entries
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '500':
+          description: Failed to fetch audit logs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/findings/export:
     get:
       tags:
@@ -1598,202 +1779,594 @@ paths:
   /api/v1/identity/reviews/{id}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Identity
+      summary: Get access review
+      description: Return an identity access review by ID.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Access review ID
       responses:
         '200':
-          description: OK
+          description: Access review
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessReview'
+        '404':
+          description: Review not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/identity/reviews/{id}/items:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Identity
+      summary: List review items
+      description: List all review items for an identity access review.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Access review ID
       responses:
         '200':
-          description: OK
+          description: Review item list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Review not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Identity
+      summary: Add review item
+      description: Add a principal/resource decision item to an access review.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Access review ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Review item created
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid review item payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to add review item
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/identity/reviews/{id}/items/{itemId}/decide:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Identity
+      summary: Record review decision
+      description: Record an approve/revoke decision for a review item.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Access review ID
+      - name: itemId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Review item ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
       responses:
         '200':
-          description: OK
+          description: Decision recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '400':
+          description: Invalid decision payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to persist decision
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/identity/reviews/{id}/start:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Identity
+      summary: Start access review
+      description: Transition an access review to active state.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Access review ID
       responses:
         '200':
-          description: OK
+          description: Review started
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '500':
+          description: Failed to start review
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/incidents:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Runtime
+      summary: Create incident
+      description: Create an incident record and generate an initial response playbook.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Incident created
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid incident payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to create incident
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/incidents/playbooks:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Runtime
+      summary: List incident playbooks
+      description: List available incident response playbooks.
       responses:
         '200':
-          description: OK
+          description: Playbook list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
   /api/v1/incidents/playbooks/{id}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Runtime
+      summary: Get incident playbook
+      description: Return a specific incident response playbook.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Playbook ID
       responses:
         '200':
-          description: OK
+          description: Playbook details
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Playbook not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/lineage/by-commit/{sha}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Graph
+      summary: List lineage by commit
+      description: Return lineage records linked to a commit SHA.
+      parameters:
+      - name: sha
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Commit SHA
       responses:
         '200':
-          description: OK
+          description: Lineage records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: true
+        '503':
+          description: Lineage service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/lineage/by-image/{digest}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Graph
+      summary: List lineage by image digest
+      description: Return lineage records linked to a container image digest.
+      parameters:
+      - name: digest
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Container image digest
       responses:
         '200':
-          description: OK
+          description: Lineage records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: true
+        '503':
+          description: Lineage service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/lineage/drift/{assetId}:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Graph
+      summary: Detect lineage drift
+      description: Compare current asset state against IaC state to detect drift.
+      parameters:
+      - name: assetId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Asset ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LineageDriftRequest'
       responses:
         '200':
-          description: OK
+          description: Drift detection result
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid drift request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: Lineage service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/lineage/{assetId}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Graph
+      summary: Get lineage for asset
+      description: Return the lineage graph for a specific asset.
+      parameters:
+      - name: assetId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Asset ID
       responses:
         '200':
-          description: OK
+          description: Asset lineage
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Lineage not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: Lineage service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/notifications:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: List notification channels
+      description: List configured notifier integrations and their metadata.
       responses:
         '200':
-          description: OK
+          description: Notifier list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
   /api/v1/notifications/digest:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Generate daily notification digest
+      description: Return the notification digest payload used by Slack integration.
       responses:
         '200':
-          description: OK
+          description: Digest payload
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
   /api/v1/notifications/test:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Send test notification
+      description: Send a test notification through configured channels.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationTestRequest'
       responses:
         '200':
-          description: OK
+          description: Notification delivery result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
   /api/v1/providers:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: List providers
+      description: List configured providers and sync maturity metadata.
+      parameters:
+      - name: include_incomplete
+        in: query
+        required: false
+        schema:
+          type: boolean
+        description: Include providers marked as incomplete
       responses:
         '200':
-          description: OK
+          description: Provider list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
   /api/v1/providers/{name}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Get provider
+      description: Return provider metadata and schema details.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Provider name
+      - name: include_incomplete
+        in: query
+        required: false
+        schema:
+          type: boolean
+        description: Include providers marked as incomplete
       responses:
         '200':
-          description: OK
+          description: Provider details
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Provider not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/providers/{name}/configure:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Configure provider
+      description: Persist provider-specific configuration values.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Provider name
+      - name: include_incomplete
+        in: query
+        required: false
+        schema:
+          type: boolean
+        description: Include providers marked as incomplete
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
       responses:
         '200':
-          description: OK
+          description: Provider configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '400':
+          description: Invalid provider config payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Provider not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to configure provider
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/providers/{name}/schema:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Get provider table schema
+      description: Return table schema information for a provider.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Provider name
+      - name: include_incomplete
+        in: query
+        required: false
+        schema:
+          type: boolean
+        description: Include providers marked as incomplete
       responses:
         '200':
-          description: OK
+          description: Provider schema
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Provider not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/providers/{name}/sync:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Trigger provider sync
+      description: Run an immediate full sync for a provider.
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Provider name
+      - name: include_incomplete
+        in: query
+        required: false
+        schema:
+          type: boolean
+        description: Include providers marked as incomplete
       responses:
         '200':
-          description: OK
+          description: Sync result
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Provider not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to sync provider
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/providers/{name}/test:
     post:
       tags:
@@ -1997,92 +2570,240 @@ paths:
   /api/v1/remediation/executions:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: List remediation executions
+      description: List recent remediation execution records.
+      parameters:
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+        description: Maximum execution records to return
       responses:
         '200':
-          description: OK
+          description: Remediation execution list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
   /api/v1/remediation/executions/{id}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Get remediation execution
+      description: Return a remediation execution by ID.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Remediation execution ID
       responses:
         '200':
-          description: OK
+          description: Remediation execution
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Execution not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/remediation/executions/{id}/approve:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Approve remediation execution
+      description: Approve a remediation execution waiting for human approval.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Remediation execution ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemediationApproveRequest'
       responses:
         '200':
-          description: OK
+          description: Execution approved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '400':
+          description: Invalid approval request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/remediation/executions/{id}/reject:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Reject remediation execution
+      description: Reject a remediation execution and provide a reason.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Remediation execution ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemediationRejectRequest'
       responses:
         '200':
-          description: OK
+          description: Execution rejected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '400':
+          description: Invalid rejection request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/remediation/rules:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: List remediation rules
+      description: List automation rules used to trigger remediations.
       responses:
         '200':
-          description: OK
+          description: Remediation rule list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Create remediation rule
+      description: Create a new remediation automation rule.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Rule created
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid rule payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to create rule
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/remediation/rules/{id}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Get remediation rule
+      description: Return a remediation rule by ID.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Remediation rule ID
       responses:
         '200':
-          description: OK
+          description: Remediation rule
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Rule not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/remediation/rules/{id}/disable:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Disable remediation rule
+      description: Disable a remediation rule by ID.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Remediation rule ID
       responses:
         '200':
-          description: OK
+          description: Rule disabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '404':
+          description: Rule not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/remediation/rules/{id}/enable:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Enable remediation rule
+      description: Enable a remediation rule by ID.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Remediation rule ID
       responses:
         '200':
-          description: OK
+          description: Rule enabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '404':
+          description: Rule not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/reports/compliance/{framework}:
     get:
       tags:
@@ -2396,13 +3117,37 @@ paths:
   /api/v1/slack/commands:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Admin
+      summary: Handle Slack command
+      description: Process a Slack slash-command request and return an immediate response payload.
+      requestBody:
+        required: false
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
       responses:
         '200':
-          description: OK
+          description: Command handled
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid command payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Slack signature validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/telemetry/ingest:
     post:
       tags:
@@ -2582,81 +3327,279 @@ paths:
   /api/v1/tickets:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Tickets
+      summary: List tickets
+      description: List tickets from the configured ticketing provider.
+      parameters:
+      - name: status
+        in: query
+        required: false
+        schema:
+          type: string
+        description: Filter by ticket status
+      - name: priority
+        in: query
+        required: false
+        schema:
+          type: string
+        description: Filter by ticket priority
       responses:
         '200':
-          description: OK
+          description: Ticket list
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '500':
+          description: Failed to list tickets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Tickets
+      summary: Create ticket
+      description: Create a ticket in the configured ticketing provider.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TicketCreateRequest'
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Ticket created
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid ticket request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to create ticket
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: Ticketing provider not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/tickets/{id}:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Tickets
+      summary: Get ticket
+      description: Retrieve a ticket by ID.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Ticket ID
       responses:
         '200':
-          description: OK
+          description: Ticket details
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '404':
+          description: Ticket not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: Ticketing provider not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     put:
       tags:
-      - Undocumented
-      summary: PUT endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Tickets
+      summary: Update ticket
+      description: Update fields on an existing ticket.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Ticket ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
       responses:
         '200':
-          description: OK
+          description: Ticket updated
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          description: Invalid ticket update payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to update ticket
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: Ticketing provider not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/tickets/{id}/close:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Tickets
+      summary: Close ticket
+      description: Close an existing ticket with an optional resolution.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Ticket ID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TicketCloseRequest'
       responses:
         '200':
-          description: OK
+          description: Ticket closed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '500':
+          description: Failed to close ticket
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: Ticketing provider not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/tickets/{id}/comments:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Tickets
+      summary: Add ticket comment
+      description: Add a comment to an existing ticket.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Ticket ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TicketCommentRequest'
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Comment added
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '400':
+          description: Invalid comment payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to add comment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          description: Ticketing provider not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/webhooks/test:
     post:
       tags:
-      - Undocumented
-      summary: POST endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Webhooks
+      summary: Send webhook test event
+      description: Emit a test webhook event to validate delivery wiring.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookTestRequest'
       responses:
         '200':
-          description: OK
+          description: Test event sent
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        '400':
+          description: Invalid webhook test payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/webhooks/{id}/deliveries:
     get:
       tags:
-      - Undocumented
-      summary: GET endpoint (placeholder)
-      description: Auto-generated placeholder to keep OpenAPI route coverage in sync
-        with server routes.
+      - Webhooks
+      summary: List webhook deliveries
+      description: Return recent delivery attempts for a webhook.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Webhook ID
       responses:
         '200':
-          description: OK
+          description: Delivery attempts
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
   /docs:
     get:
       tags:
@@ -3122,6 +4065,92 @@ components:
             type: string
         context:
           type: object
+    AgentSessionApprovalRequest:
+      type: object
+      properties:
+        approve:
+          type: boolean
+          description: Set false to deny the pending tool call
+    AttackPathAnalyzeRequest:
+      type: object
+      properties:
+        high_value_targets:
+          type: array
+          items:
+            type: string
+        max_depth:
+          type: integer
+          minimum: 1
+    LineageDriftRequest:
+      type: object
+      required:
+      - current_state
+      - iac_state
+      properties:
+        current_state:
+          type: object
+          additionalProperties: true
+        iac_state:
+          type: object
+          additionalProperties: true
+    NotificationTestRequest:
+      type: object
+      properties:
+        message:
+          type: string
+        severity:
+          type: string
+    RemediationApproveRequest:
+      type: object
+      required:
+      - approver_id
+      properties:
+        approver_id:
+          type: string
+    RemediationRejectRequest:
+      type: object
+      required:
+      - rejecter_id
+      properties:
+        rejecter_id:
+          type: string
+        reason:
+          type: string
+    TicketCreateRequest:
+      type: object
+      required:
+      - title
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        priority:
+          type: string
+        finding_ids:
+          type: array
+          items:
+            type: string
+    TicketCloseRequest:
+      type: object
+      properties:
+        resolution:
+          type: string
+    TicketCommentRequest:
+      type: object
+      required:
+      - body
+      properties:
+        body:
+          type: string
+    WebhookTestRequest:
+      type: object
+      required:
+      - url
+      properties:
+        url:
+          type: string
+          format: uri
     Message:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- replace all remaining placeholder OpenAPI operations with concrete endpoint contracts
- add missing request/response schemas for newly documented operations
- add Spectral ruleset (.spectral.yaml) and wire linting into make openapi-check and CI
- enforce that Undocumented placeholder tags are not committed

## Validation
- make openapi-check
- go test ./internal/api/...
