### PR TITLE
Guardrails: metric cardinality control and RBAC route coverage

### DIFF
--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -159,6 +159,17 @@ func (rw *responseWriter) WriteHeader(code int) {
 
 // normalizePath removes variable parts from paths for cardinality control
 func normalizePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if len(path) > 1 {
+		path = strings.TrimRight(path, "/")
+	}
+
 	switch {
 	case strings.HasPrefix(path, "/api/v1/assets/"):
 		return "/api/v1/assets/{table}"
@@ -166,6 +177,12 @@ func normalizePath(path string) string {
 		return "/api/v1/policies/{id}"
 	case strings.HasPrefix(path, "/api/v1/findings/"):
 		return "/api/v1/findings/{id}"
+	case strings.HasPrefix(path, "/api/v1/"):
+		parts := strings.Split(strings.Trim(path, "/"), "/")
+		if len(parts) >= 4 {
+			return "/" + strings.Join(parts[:3], "/") + "/{subpath}"
+		}
+		return path
 	default:
 		return path
 	}

--- a/internal/api/metrics_path_test.go
+++ b/internal/api/metrics_path_test.go
@@ -27,3 +27,20 @@ func TestMetricPath_FallsBackToNormalizedURLPath(t *testing.T) {
 		t.Fatalf("expected normalized path, got %q", got)
 	}
 }
+
+func TestMetricPath_FallbackCollapsesNestedAPISubpaths(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/webhooks/w-123/deliveries/retry", nil)
+
+	if got := metricPath(req); got != "/api/v1/webhooks/{subpath}" {
+		t.Fatalf("expected collapsed nested fallback path, got %q", got)
+	}
+}
+
+func TestNormalizePath_HandlesWhitespaceAndTrailingSlashes(t *testing.T) {
+	if got := normalizePath("  /api/v1/tickets/abc123/  "); got != "/api/v1/tickets/{subpath}" {
+		t.Fatalf("expected normalized path, got %q", got)
+	}
+	if got := normalizePath(" /health/ "); got != "/health" {
+		t.Fatalf("expected trimmed health path, got %q", got)
+	}
+}

--- a/internal/api/route_permission_guard_test.go
+++ b/internal/api/route_permission_guard_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type routeMethodSet map[string]map[string]struct{}
+
+var routeCallToHTTPMethod = map[string]string{
+	"Get":     http.MethodGet,
+	"Post":    http.MethodPost,
+	"Put":     http.MethodPut,
+	"Delete":  http.MethodDelete,
+	"Patch":   http.MethodPatch,
+	"Head":    http.MethodHead,
+	"Options": http.MethodOptions,
+}
+
+func TestRoutePermission_CoversAllRegisteredAPIRoutes(t *testing.T) {
+	routes, err := collectRegisteredRoutes("server_routes.go")
+	if err != nil {
+		t.Fatalf("collect routes: %v", err)
+	}
+	if len(routes) == 0 {
+		t.Fatal("no routes collected from server_routes.go")
+	}
+
+	missing := make([]string, 0)
+	for path, methods := range routes {
+		if !strings.HasPrefix(path, "/api/v1") {
+			continue
+		}
+		for method := range methods {
+			if routePermission(method, path) == "" {
+				missing = append(missing, method+" "+path)
+			}
+		}
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("routePermission missing mapping for routes: %s", strings.Join(missing, ", "))
+	}
+}
+
+func collectRegisteredRoutes(routesPath string) (routeMethodSet, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, routesPath, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	routes := make(routeMethodSet)
+	var setupRoutesDecl *ast.FuncDecl
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Name.Name != "setupRoutes" {
+			continue
+		}
+		setupRoutesDecl = fn
+		break
+	}
+	if setupRoutesDecl == nil || setupRoutesDecl.Body == nil {
+		return nil, nil
+	}
+
+	walkRouteStatements(setupRoutesDecl.Body.List, "", routes)
+	return routes, nil
+}
+
+func walkRouteStatements(stmts []ast.Stmt, prefix string, routes routeMethodSet) {
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.ExprStmt:
+			walkRouteExpr(s.X, prefix, routes)
+		case *ast.BlockStmt:
+			walkRouteStatements(s.List, prefix, routes)
+		case *ast.IfStmt:
+			walkRouteStatements(s.Body.List, prefix, routes)
+			if s.Else != nil {
+				walkRouteStatements([]ast.Stmt{s.Else}, prefix, routes)
+			}
+		case *ast.ForStmt:
+			walkRouteStatements(s.Body.List, prefix, routes)
+		case *ast.RangeStmt:
+			walkRouteStatements(s.Body.List, prefix, routes)
+		}
+	}
+}
+
+func walkRouteExpr(expr ast.Expr, prefix string, routes routeMethodSet) {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil {
+		return
+	}
+
+	switch sel.Sel.Name {
+	case "Route":
+		if len(call.Args) < 2 {
+			return
+		}
+		segment, ok := stringLiteral(call.Args[0])
+		if !ok {
+			return
+		}
+		fn, ok := call.Args[1].(*ast.FuncLit)
+		if !ok || fn.Body == nil {
+			return
+		}
+		walkRouteStatements(fn.Body.List, joinRoutePath(prefix, segment), routes)
+	default:
+		method, ok := routeCallToHTTPMethod[sel.Sel.Name]
+		if !ok || len(call.Args) < 1 {
+			return
+		}
+
+		segment, ok := stringLiteral(call.Args[0])
+		if !ok {
+			return
+		}
+
+		fullPath := joinRoutePath(prefix, segment)
+		if _, ok := routes[fullPath]; !ok {
+			routes[fullPath] = make(map[string]struct{})
+		}
+		routes[fullPath][method] = struct{}{}
+	}
+}
+
+func stringLiteral(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func joinRoutePath(base, segment string) string {
+	base = strings.TrimSpace(base)
+	segment = strings.TrimSpace(segment)
+
+	if base == "" {
+		return normalizeRoutePath(segment)
+	}
+	if segment == "" {
+		return normalizeRoutePath(base)
+	}
+	if base == "/" {
+		return normalizeRoutePath(segment)
+	}
+	if segment == "/" {
+		return normalizeRoutePath(base)
+	}
+
+	base = strings.TrimRight(base, "/")
+	if strings.HasPrefix(segment, "/") {
+		return normalizeRoutePath(base + segment)
+	}
+	return normalizeRoutePath(base + "/" + segment)
+}
+
+func normalizeRoutePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	path = strings.ReplaceAll(path, "//", "/")
+	if len(path) > 1 {
+		path = strings.TrimRight(path, "/")
+	}
+	return path
+}


### PR DESCRIPTION
## Summary
- harden API metric fallback normalization so unmatched nested /api/v1 paths collapse to bounded label shapes
- add tests for fallback path collapsing and normalizePath edge handling
- add an automated route-permission guard test that parses setupRoutes and asserts every /api/v1 route has an RBAC permission mapping

## Validation
- go test ./internal/api/...
