### PR TITLE
Auth/OpenAPI parity: keep docs, spec, and metrics public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,16 @@ jobs:
             exit 1
           fi
 
+          for public_path in /metrics /docs /openapi.yaml; do
+            public_status=$(curl -sS -o "/tmp/api-auth-smoke-public-$(echo "$public_path" | tr '/.' '__').json" -w "%{http_code}" \
+              "http://127.0.0.1:${API_PORT}${public_path}")
+            if [ "$public_status" -ne "200" ]; then
+              echo "expected 200 for public endpoint ${public_path}, got $public_status"
+              cat /tmp/cerebro-api-auth-smoke.log || true
+              exit 1
+            fi
+          done
+
   api-auth-rbac-smoke:
     name: api-auth-rbac-smoke
     runs-on: ubuntu-latest

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -46,8 +46,7 @@ func APIKeyAuth(cfg AuthConfig) func(http.Handler) http.Handler {
 				return
 			}
 
-			// Skip auth for health endpoints
-			if r.URL.Path == "/health" || r.URL.Path == "/ready" {
+			if isPublicEndpoint(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -151,10 +150,7 @@ const DefaultMaxBodySize = 10 * 1024 * 1024
 func RBACMiddleware(rbac *auth.RBAC) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Skip RBAC for health/metrics/docs endpoints
-			if r.URL.Path == "/health" || r.URL.Path == "/ready" ||
-				r.URL.Path == "/metrics" || r.URL.Path == "/docs" ||
-				r.URL.Path == "/openapi.yaml" {
+			if isPublicEndpoint(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -180,6 +176,12 @@ func RBACMiddleware(rbac *auth.RBAC) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func isPublicEndpoint(path string) bool {
+	return path == "/health" || path == "/ready" ||
+		path == "/metrics" || path == "/docs" ||
+		path == "/openapi.yaml"
 }
 
 // routePermission maps an HTTP method + path to the required RBAC permission.

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -101,6 +101,24 @@ func TestAPIKeyAuth(t *testing.T) {
 			apiKey:     "",
 			wantStatus: http.StatusOK,
 		},
+		{
+			name:       "Metrics endpoint - no auth required",
+			path:       "/metrics",
+			apiKey:     "",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "Docs endpoint - no auth required",
+			path:       "/docs",
+			apiKey:     "",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "OpenAPI endpoint - no auth required",
+			path:       "/openapi.yaml",
+			apiKey:     "",
+			wantStatus: http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/server_public_endpoints_test.go
+++ b/internal/api/server_public_endpoints_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestPublicEndpoints_RemainAccessibleWhenAPIAuthEnabled(t *testing.T) {
+	a := newTestApp(t)
+	a.Config.APIAuthEnabled = true
+	a.Config.APIKeys = map[string]string{
+		"smoke-key": "smoke-user",
+	}
+
+	s := NewServer(a)
+
+	cases := []struct {
+		path       string
+		wantStatus int
+	}{
+		{path: "/health", wantStatus: http.StatusOK},
+		{path: "/ready", wantStatus: http.StatusOK},
+		{path: "/metrics", wantStatus: http.StatusOK},
+		{path: "/docs", wantStatus: http.StatusOK},
+		// openapi.yaml is served from a relative file path in tests and may 404,
+		// but auth middleware must not block it.
+		{path: "/openapi.yaml", wantStatus: 0},
+	}
+
+	for _, tc := range cases {
+		w := do(t, s, http.MethodGet, tc.path, nil)
+		if tc.wantStatus != 0 && w.Code != tc.wantStatus {
+			t.Fatalf("expected %d for public endpoint %s, got %d", tc.wantStatus, tc.path, w.Code)
+		}
+		if w.Code == http.StatusUnauthorized {
+			t.Fatalf("expected auth bypass for public endpoint %s, got 401", tc.path)
+		}
+	}
+
+	protected := do(t, s, http.MethodGet, "/api/v1/policies/", nil)
+	if protected.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for protected endpoint, got %d", protected.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- align runtime auth behavior with the OpenAPI contract for public endpoints
- treat `/docs`, `/openapi.yaml`, and `/metrics` as public endpoints in API key auth middleware
- deduplicate public-endpoint checks between API auth and RBAC middleware
- extend API auth smoke CI to assert those public endpoints stay accessible without auth
- add API tests for public endpoint behavior when auth is enabled

## Why
OpenAPI currently marks these routes with `security: []`, but runtime auth previously returned 401 for them when auth was enabled.

## Validation
- go test ./internal/api/...
- make openapi-check
- parsed .github/workflows/ci.yml with Python YAML loader
- manual smoke: unauthenticated `/metrics`, `/docs`, `/openapi.yaml` return 200 while protected API routes remain auth-gated
