### PR TITLE
OpenAPI embed + strict auth header handling + smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,40 @@ jobs:
             exit 1
           fi
 
+          malformed_auth_status=$(curl -sS \
+            -H "Authorization: Token malformed" \
+            -H "X-API-Key: smoke-key" \
+            -o /tmp/api-auth-smoke-malformed-auth.json \
+            -w "%{http_code}" \
+            "http://127.0.0.1:${API_PORT}/api/v1/policies/")
+          if [ "$malformed_auth_status" != "401" ]; then
+            echo "expected 401 for malformed Authorization header, got $malformed_auth_status"
+            cat /tmp/cerebro-api-auth-smoke.log || true
+            exit 1
+          fi
+
+          conflicting_headers_status=$(curl -sS \
+            -H "Authorization: Bearer smoke-key" \
+            -H "X-API-Key: not-smoke-key" \
+            -o /tmp/api-auth-smoke-conflicting-headers.json \
+            -w "%{http_code}" \
+            "http://127.0.0.1:${API_PORT}/api/v1/policies/")
+          if [ "$conflicting_headers_status" != "401" ]; then
+            echo "expected 401 for conflicting auth headers, got $conflicting_headers_status"
+            cat /tmp/cerebro-api-auth-smoke.log || true
+            exit 1
+          fi
+
+          for public_path in /metrics /docs /openapi.yaml; do
+            public_status=$(curl -sS -o "/tmp/api-auth-smoke-public-$(echo "$public_path" | tr '/.' '__').json" -w "%{http_code}" \
+              "http://127.0.0.1:${API_PORT}${public_path}")
+            if [ "$public_status" -ne "200" ]; then
+              echo "expected 200 for public endpoint ${public_path}, got $public_status"
+              cat /tmp/cerebro-api-auth-smoke.log || true
+              exit 1
+            fi
+          done
+
   api-auth-rbac-smoke:
     name: api-auth-rbac-smoke
     runs-on: ubuntu-latest

--- a/api/spec_embed.go
+++ b/api/spec_embed.go
@@ -1,0 +1,8 @@
+package apicontract
+
+import _ "embed"
+
+// OpenAPIYAML contains the embedded OpenAPI contract served by /openapi.yaml.
+//
+//go:embed openapi.yaml
+var OpenAPIYAML []byte

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -46,13 +47,23 @@ func APIKeyAuth(cfg AuthConfig) func(http.Handler) http.Handler {
 				return
 			}
 
-			// Skip auth for health endpoints
-			if r.URL.Path == "/health" || r.URL.Path == "/ready" {
+			if isPublicEndpoint(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			apiKey := extractAPIKey(r)
+			apiKey, err := extractAPIKeyStrict(r)
+			if err != nil {
+				switch {
+				case errors.Is(err, errMalformedAuthorizationHeader):
+					writeJSONError(w, http.StatusUnauthorized, "invalid_authorization_header", "Authorization header must use the format 'Bearer <token>'")
+				case errors.Is(err, errConflictingAPICredentials):
+					writeJSONError(w, http.StatusUnauthorized, "conflicting_api_credentials", "Authorization and X-API-Key credentials must match when both are provided")
+				default:
+					writeJSONError(w, http.StatusUnauthorized, "invalid_api_key", "API key is invalid or expired")
+				}
+				return
+			}
 			if apiKey == "" {
 				writeJSONError(w, http.StatusUnauthorized, "missing_api_key", "API key is required")
 				return
@@ -89,18 +100,54 @@ func SecurityHeaders() func(http.Handler) http.Handler {
 }
 
 func extractAPIKey(r *http.Request) string {
-	// Check Authorization header
-	auth := r.Header.Get("Authorization")
-	if strings.HasPrefix(auth, "Bearer ") {
-		return strings.TrimPrefix(auth, "Bearer ")
+	key, err := extractAPIKeyStrict(r)
+	if err != nil {
+		return ""
+	}
+	return key
+}
+
+var (
+	errMalformedAuthorizationHeader = errors.New("malformed authorization header")
+	errConflictingAPICredentials    = errors.New("conflicting api credentials")
+)
+
+func extractAPIKeyStrict(r *http.Request) (string, error) {
+	authKey, hasAuth, err := bearerTokenFromAuthorization(r.Header.Get("Authorization"))
+	if err != nil {
+		return "", err
 	}
 
-	// Check X-API-Key header
-	if key := r.Header.Get("X-API-Key"); key != "" {
-		return key
+	headerKey := strings.TrimSpace(r.Header.Get("X-API-Key"))
+	hasHeaderKey := headerKey != ""
+
+	if hasAuth && hasHeaderKey {
+		if subtle.ConstantTimeCompare([]byte(authKey), []byte(headerKey)) != 1 {
+			return "", errConflictingAPICredentials
+		}
+		return authKey, nil
+	}
+	if hasAuth {
+		return authKey, nil
+	}
+	if hasHeaderKey {
+		return headerKey, nil
+	}
+	return "", nil
+}
+
+func bearerTokenFromAuthorization(raw string) (string, bool, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false, nil
 	}
 
-	return ""
+	parts := strings.Fields(raw)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || strings.TrimSpace(parts[1]) == "" {
+		return "", false, errMalformedAuthorizationHeader
+	}
+
+	return parts[1], true, nil
 }
 
 func validateAPIKey(keys map[string]string, key string) (string, bool) {
@@ -151,10 +198,7 @@ const DefaultMaxBodySize = 10 * 1024 * 1024
 func RBACMiddleware(rbac *auth.RBAC) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Skip RBAC for health/metrics/docs endpoints
-			if r.URL.Path == "/health" || r.URL.Path == "/ready" ||
-				r.URL.Path == "/metrics" || r.URL.Path == "/docs" ||
-				r.URL.Path == "/openapi.yaml" {
+			if isPublicEndpoint(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -180,6 +224,12 @@ func RBACMiddleware(rbac *auth.RBAC) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func isPublicEndpoint(path string) bool {
+	return path == "/health" || path == "/ready" ||
+		path == "/metrics" || path == "/docs" ||
+		path == "/openapi.yaml"
 }
 
 // routePermission maps an HTTP method + path to the required RBAC permission.

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/writer/cerebro/internal/auth"
@@ -22,11 +23,41 @@ func TestExtractAPIKey(t *testing.T) {
 			expected: "test-key-123",
 		},
 		{
+			name: "Bearer token (case-insensitive scheme)",
+			setup: func(r *http.Request) {
+				r.Header.Set("Authorization", "bearer test-key-123")
+			},
+			expected: "test-key-123",
+		},
+		{
+			name: "Bearer token (extra whitespace)",
+			setup: func(r *http.Request) {
+				r.Header.Set("Authorization", "  Bearer   spaced-key  ")
+			},
+			expected: "spaced-key",
+		},
+		{
 			name: "X-API-Key header",
 			setup: func(r *http.Request) {
 				r.Header.Set("X-API-Key", "header-key-456")
 			},
 			expected: "header-key-456",
+		},
+		{
+			name: "Malformed Authorization does not fall back",
+			setup: func(r *http.Request) {
+				r.Header.Set("Authorization", "Token malformed")
+				r.Header.Set("X-API-Key", "header-key-456")
+			},
+			expected: "",
+		},
+		{
+			name: "Conflicting headers rejected",
+			setup: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer auth-key")
+				r.Header.Set("X-API-Key", "header-key-456")
+			},
+			expected: "",
 		},
 		{
 			name:     "No key",
@@ -101,6 +132,24 @@ func TestAPIKeyAuth(t *testing.T) {
 			apiKey:     "",
 			wantStatus: http.StatusOK,
 		},
+		{
+			name:       "Metrics endpoint - no auth required",
+			path:       "/metrics",
+			apiKey:     "",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "Docs endpoint - no auth required",
+			path:       "/docs",
+			apiKey:     "",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "OpenAPI endpoint - no auth required",
+			path:       "/openapi.yaml",
+			apiKey:     "",
+			wantStatus: http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {
@@ -144,7 +193,7 @@ func TestAPIKeyAuthDisabled(t *testing.T) {
 	}
 }
 
-func TestAPIKeyAuth_FallsBackToXAPIKeyWhenAuthorizationIsMalformed(t *testing.T) {
+func TestAPIKeyAuth_RejectsMalformedAuthorizationEvenWithXAPIKey(t *testing.T) {
 	cfg := AuthConfig{
 		Enabled: true,
 		APIKeys: map[string]string{
@@ -165,11 +214,67 @@ func TestAPIKeyAuth_FallsBackToXAPIKeyWhenAuthorizationIsMalformed(t *testing.T)
 
 	w := httptest.NewRecorder()
 	middleware.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	if body := w.Body.String(); body == "" || !strings.Contains(body, "invalid_authorization_header") {
+		t.Fatalf("expected invalid_authorization_header body, got %q", body)
+	}
+}
+
+func TestAPIKeyAuth_RejectsConflictingCredentials(t *testing.T) {
+	cfg := AuthConfig{
+		Enabled: true,
+		APIKeys: map[string]string{
+			"valid-key": "user-1",
+		},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := APIKeyAuth(cfg)(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req.Header.Set("Authorization", "Bearer valid-key")
+	req.Header.Set("X-API-Key", "different-key")
+
+	w := httptest.NewRecorder()
+	middleware.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	if body := w.Body.String(); body == "" || !strings.Contains(body, "conflicting_api_credentials") {
+		t.Fatalf("expected conflicting_api_credentials body, got %q", body)
+	}
+}
+
+func TestAPIKeyAuth_AllowsMatchingCredentialsFromBothHeaders(t *testing.T) {
+	cfg := AuthConfig{
+		Enabled: true,
+		APIKeys: map[string]string{
+			"valid-key": "user-1",
+		},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(GetUserID(r.Context())))
+	})
+
+	middleware := APIKeyAuth(cfg)(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req.Header.Set("Authorization", "Bearer valid-key")
+	req.Header.Set("X-API-Key", "valid-key")
+
+	w := httptest.NewRecorder()
+	middleware.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 	if got := w.Body.String(); got != "user-1" {
-		t.Fatalf("expected user-1 from X-API-Key fallback, got %q", got)
+		t.Fatalf("expected user-1, got %q", got)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	apicontract "github.com/writer/cerebro/api"
 	"github.com/writer/cerebro/internal/app"
 	"github.com/writer/cerebro/internal/metrics"
 	"github.com/writer/cerebro/internal/snowflake"
@@ -108,7 +109,8 @@ func (s *Server) metrics(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) openAPISpec(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/yaml")
-	http.ServeFile(w, r, "api/openapi.yaml")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(apicontract.OpenAPIYAML)
 }
 
 func (s *Server) swaggerUI(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server_metrics_endpoint_test.go
+++ b/internal/api/server_metrics_endpoint_test.go
@@ -17,3 +17,18 @@ func TestMetricsEndpoint_ReturnsPrometheusPayload(t *testing.T) {
 		t.Fatalf("expected prometheus payload to include cerebro metrics, got: %s", w.Body.String())
 	}
 }
+
+func TestOpenAPIEndpoint_ReturnsEmbeddedSpec(t *testing.T) {
+	s := newTestServer(t)
+
+	w := do(t, s, http.MethodGet, "/openapi.yaml", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 from /openapi.yaml, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); !strings.Contains(got, "application/yaml") {
+		t.Fatalf("expected application/yaml content type, got %q", got)
+	}
+	if !strings.Contains(w.Body.String(), "openapi: 3.0.3") {
+		t.Fatalf("expected OpenAPI header in spec body, got: %s", w.Body.String())
+	}
+}

--- a/internal/api/server_public_endpoints_test.go
+++ b/internal/api/server_public_endpoints_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestPublicEndpoints_RemainAccessibleWhenAPIAuthEnabled(t *testing.T) {
+	a := newTestApp(t)
+	a.Config.APIAuthEnabled = true
+	a.Config.APIKeys = map[string]string{
+		"smoke-key": "smoke-user",
+	}
+
+	s := NewServer(a)
+
+	publicPaths := []string{"/health", "/ready", "/metrics", "/docs", "/openapi.yaml"}
+	for _, path := range publicPaths {
+		w := do(t, s, http.MethodGet, path, nil)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 for public endpoint %s, got %d", path, w.Code)
+		}
+	}
+
+	protected := do(t, s, http.MethodGet, "/api/v1/policies/", nil)
+	if protected.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for protected endpoint, got %d", protected.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- embed `api/openapi.yaml` into the binary and serve `/openapi.yaml` from embedded bytes (no cwd dependency)
- make API auth parsing strict:
  - require `Authorization: Bearer <token>` when Authorization is present
  - reject conflicting `Authorization` and `X-API-Key` values
  - still allow either header alone
- treat `/metrics`, `/docs`, and `/openapi.yaml` as public endpoints in auth middleware (matching OpenAPI `security: []`)
- extend CI auth smoke to assert malformed/conflicting header paths return 401
- extend CI auth smoke to assert `/metrics`, `/docs`, and `/openapi.yaml` remain publicly accessible

## Validation
- go test ./internal/api/...
- go test ./...
- make openapi-check
- parsed CI workflow YAML with Python
- manual runtime smoke for public endpoints + auth edge cases
