### PR TITLE
api: align rate limiting with public endpoint and auth key parsing

### DIFF
--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -145,8 +145,8 @@ func RateLimitMiddlewareWithLimiter(cfg RateLimitConfig, rl *RateLimiter) func(h
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Skip rate limiting for health endpoints
-			if r.URL.Path == "/health" || r.URL.Path == "/ready" || r.URL.Path == "/metrics" {
+			// Skip rate limiting for public endpoints.
+			if isPublicEndpoint(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -174,12 +174,10 @@ func RateLimitMiddlewareWithLimiter(cfg RateLimitConfig, rl *RateLimiter) func(h
 
 // getClientKey extracts the rate limit key from the request
 func getClientKey(r *http.Request) string {
-	// Prefer API key if present
-	if key := r.Header.Get("X-API-Key"); key != "" {
+	// Canonicalize API key extraction across Authorization and X-API-Key
+	// so the same key always maps to the same rate limit bucket.
+	if key, err := extractAPIKeyStrict(r); err == nil && key != "" {
 		return "apikey:" + key
-	}
-	if auth := r.Header.Get("Authorization"); auth != "" {
-		return "auth:" + auth
 	}
 
 	// Fall back to IP address

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -170,7 +170,7 @@ func TestRateLimitMiddlewareDisabled(t *testing.T) {
 	}
 }
 
-func TestRateLimitMiddlewareSkipsHealthEndpoints(t *testing.T) {
+func TestRateLimitMiddlewareSkipsPublicEndpoints(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -189,28 +189,38 @@ func TestRateLimitMiddlewareSkipsHealthEndpoints(t *testing.T) {
 
 	wrapped := middleware(handler)
 
-	// Health endpoint should always work
-	for i := 0; i < 5; i++ {
-		req := httptest.NewRequest("GET", "/health", nil)
-		w := httptest.NewRecorder()
+	publicPaths := []string{"/health", "/ready", "/metrics", "/docs", "/openapi.yaml"}
+	for _, path := range publicPaths {
+		for i := 0; i < 5; i++ {
+			req := httptest.NewRequest("GET", path, nil)
+			w := httptest.NewRecorder()
 
-		wrapped.ServeHTTP(w, req)
+			wrapped.ServeHTTP(w, req)
 
-		if w.Code != http.StatusOK {
-			t.Errorf("/health request %d: expected 200, got %d", i+1, w.Code)
+			if w.Code != http.StatusOK {
+				t.Errorf("%s request %d: expected 200, got %d", path, i+1, w.Code)
+			}
+			if got := w.Header().Get("X-RateLimit-Limit"); got != "" {
+				t.Errorf("%s request %d: expected no rate limit headers for bypassed endpoint, got X-RateLimit-Limit=%q", path, i+1, got)
+			}
 		}
 	}
 
-	// Same for /ready
-	for i := 0; i < 5; i++ {
-		req := httptest.NewRequest("GET", "/ready", nil)
-		w := httptest.NewRecorder()
+	// Public endpoint traffic should not consume API route quota.
+	req := httptest.NewRequest("GET", "/api/v1/test", nil)
+	req.RemoteAddr = "192.168.1.1:1234"
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first protected route request: expected 200, got %d", w.Code)
+	}
 
-		wrapped.ServeHTTP(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Errorf("/ready request %d: expected 200, got %d", i+1, w.Code)
-		}
+	req2 := httptest.NewRequest("GET", "/api/v1/test", nil)
+	req2.RemoteAddr = "192.168.1.1:1234"
+	w2 := httptest.NewRecorder()
+	wrapped.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second protected route request: expected 429, got %d", w2.Code)
 	}
 }
 
@@ -229,7 +239,12 @@ func TestGetClientKey(t *testing.T) {
 		{
 			name:     "Authorization header",
 			headers:  map[string]string{"Authorization": "Bearer token123"},
-			expected: "auth:Bearer token123",
+			expected: "apikey:token123",
+		},
+		{
+			name:     "Authorization header with extra spaces",
+			headers:  map[string]string{"Authorization": "   Bearer   token123   "},
+			expected: "apikey:token123",
 		},
 		{
 			name:     "X-Forwarded-For header",
@@ -251,6 +266,22 @@ func TestGetClientKey(t *testing.T) {
 			name:     "X-API-Key takes precedence",
 			headers:  map[string]string{"X-API-Key": "key", "X-Forwarded-For": "1.2.3.4"},
 			expected: "apikey:key",
+		},
+		{
+			name:     "matching Authorization and X-API-Key canonicalize to one key",
+			headers:  map[string]string{"Authorization": "Bearer key", "X-API-Key": "key"},
+			expected: "apikey:key",
+		},
+		{
+			name:     "malformed Authorization falls back to IP key",
+			headers:  map[string]string{"Authorization": "Token token123", "X-Forwarded-For": "1.2.3.4"},
+			expected: "ip:1.2.3.4",
+		},
+		{
+			name:     "conflicting API credentials fall back to IP key",
+			headers:  map[string]string{"Authorization": "Bearer token123", "X-API-Key": "other"},
+			addr:     "192.168.1.1:1234",
+			expected: "ip:192.168.1.1:1234",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- use the shared `isPublicEndpoint` helper in rate-limit middleware to avoid drift from auth/RBAC public endpoint rules
- canonicalize rate-limit API-key extraction via `extractAPIKeyStrict` so `Authorization: Bearer <key>` and `X-API-Key: <key>` share one bucket
- expand rate-limit tests to cover `/docs` and `/openapi.yaml` bypass behavior plus malformed/conflicting credential fallback to IP keying

## Testing
- go test ./internal/api/...
- go test ./...
