### PR TITLE
api: normalize rate-limit client IP extraction

### DIFF
--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -180,14 +182,39 @@ func getClientKey(r *http.Request) string {
 		return "apikey:" + key
 	}
 
-	// Fall back to IP address
-	if ip := r.Header.Get("X-Forwarded-For"); ip != "" {
+	// Fall back to client IP address.
+	if ip := forwardedClientIP(r.Header.Get("X-Forwarded-For")); ip != "" {
 		return "ip:" + ip
 	}
-	if ip := r.Header.Get("X-Real-IP"); ip != "" {
+	if ip := strings.TrimSpace(r.Header.Get("X-Real-IP")); ip != "" {
 		return "ip:" + ip
 	}
-	return "ip:" + r.RemoteAddr
+	if ip := remoteAddrHost(r.RemoteAddr); ip != "" {
+		return "ip:" + ip
+	}
+	return "ip:unknown"
+}
+
+func forwardedClientIP(xff string) string {
+	for _, raw := range strings.Split(xff, ",") {
+		if ip := strings.TrimSpace(raw); ip != "" {
+			return ip
+		}
+	}
+	return ""
+}
+
+func remoteAddrHost(remoteAddr string) string {
+	remoteAddr = strings.TrimSpace(remoteAddr)
+	if remoteAddr == "" {
+		return ""
+	}
+
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return host
 }
 
 // Pagination helpers

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -224,6 +224,44 @@ func TestRateLimitMiddlewareSkipsPublicEndpoints(t *testing.T) {
 	}
 }
 
+func TestRateLimitMiddleware_UsesRemoteIPWithoutPort(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rl := NewRateLimiter(RateLimitConfig{
+		RequestsPerWindow: 1,
+		Window:            time.Minute,
+		Enabled:           true,
+	})
+	t.Cleanup(rl.Close)
+	middleware := RateLimitMiddlewareWithLimiter(RateLimitConfig{
+		RequestsPerWindow: 1,
+		Window:            time.Minute,
+		Enabled:           true,
+	}, rl)
+
+	wrapped := middleware(handler)
+
+	// Requests from the same client IP but different source ports must share
+	// one bucket so opening new connections cannot bypass limits.
+	req := httptest.NewRequest("GET", "/api/v1/test", nil)
+	req.RemoteAddr = "192.168.1.1:10001"
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", w.Code)
+	}
+
+	req2 := httptest.NewRequest("GET", "/api/v1/test", nil)
+	req2.RemoteAddr = "192.168.1.1:10002"
+	w2 := httptest.NewRecorder()
+	wrapped.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request from same IP with different port: expected 429, got %d", w2.Code)
+	}
+}
+
 func TestGetClientKey(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -252,6 +290,11 @@ func TestGetClientKey(t *testing.T) {
 			expected: "ip:1.2.3.4",
 		},
 		{
+			name:     "X-Forwarded-For uses first IP",
+			headers:  map[string]string{"X-Forwarded-For": "1.2.3.4, 5.6.7.8"},
+			expected: "ip:1.2.3.4",
+		},
+		{
 			name:     "X-Real-IP header",
 			headers:  map[string]string{"X-Real-IP": "5.6.7.8"},
 			expected: "ip:5.6.7.8",
@@ -260,7 +303,19 @@ func TestGetClientKey(t *testing.T) {
 			name:     "RemoteAddr fallback",
 			headers:  map[string]string{},
 			addr:     "192.168.1.1:1234",
-			expected: "ip:192.168.1.1:1234",
+			expected: "ip:192.168.1.1",
+		},
+		{
+			name:     "RemoteAddr fallback keeps host when no port",
+			headers:  map[string]string{},
+			addr:     "192.168.1.1",
+			expected: "ip:192.168.1.1",
+		},
+		{
+			name:     "RemoteAddr fallback supports IPv6 host:port",
+			headers:  map[string]string{},
+			addr:     "[2001:db8::1]:1234",
+			expected: "ip:2001:db8::1",
 		},
 		{
 			name:     "X-API-Key takes precedence",
@@ -281,7 +336,7 @@ func TestGetClientKey(t *testing.T) {
 			name:     "conflicting API credentials fall back to IP key",
 			headers:  map[string]string{"Authorization": "Bearer token123", "X-API-Key": "other"},
 			addr:     "192.168.1.1:1234",
-			expected: "ip:192.168.1.1:1234",
+			expected: "ip:192.168.1.1",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- normalize rate-limit client keying to use client IP (not `RemoteAddr` with ephemeral source port)
- parse `X-Forwarded-For` and use the first hop when present; trim `X-Real-IP`
- canonicalize remote address host extraction (including IPv6 host:port) and add `ip:unknown` fallback
- add regression tests to ensure same-IP/different-port requests share one bucket and cannot bypass limits

## Testing
- go test ./internal/api/...
- go test ./...
