### PR TITLE
api: guard limit query params against non-positive values

### DIFF
--- a/internal/api/query_params.go
+++ b/internal/api/query_params.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+func queryPositiveInt(r *http.Request, key string, defaultValue int) int {
+	raw := strings.TrimSpace(r.URL.Query().Get(key))
+	if raw == "" {
+		return defaultValue
+	}
+
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return defaultValue
+	}
+	return value
+}

--- a/internal/api/query_params_test.go
+++ b/internal/api/query_params_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestQueryPositiveInt(t *testing.T) {
+	tests := []struct {
+		name         string
+		rawQuery     string
+		defaultValue int
+		want         int
+	}{
+		{
+			name:         "missing value uses default",
+			rawQuery:     "",
+			defaultValue: 100,
+			want:         100,
+		},
+		{
+			name:         "empty value uses default",
+			rawQuery:     "limit=",
+			defaultValue: 100,
+			want:         100,
+		},
+		{
+			name:         "invalid value uses default",
+			rawQuery:     "limit=abc",
+			defaultValue: 100,
+			want:         100,
+		},
+		{
+			name:         "zero uses default",
+			rawQuery:     "limit=0",
+			defaultValue: 100,
+			want:         100,
+		},
+		{
+			name:         "negative uses default",
+			rawQuery:     "limit=-5",
+			defaultValue: 100,
+			want:         100,
+		},
+		{
+			name:         "valid positive value",
+			rawQuery:     "limit=25",
+			defaultValue: 100,
+			want:         25,
+		},
+		{
+			name:         "whitespace value",
+			rawQuery:     "limit=%2025%20",
+			defaultValue: 100,
+			want:         25,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := "/"
+			if tt.rawQuery != "" {
+				url += "?" + tt.rawQuery
+			}
+			req := httptest.NewRequest("GET", url, nil)
+
+			if got := queryPositiveInt(req, "limit", tt.defaultValue); got != tt.want {
+				t.Fatalf("queryPositiveInt(...): got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/server_handlers_data.go
+++ b/internal/api/server_handlers_data.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -193,10 +192,7 @@ func (s *Server) listAssets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	table := chi.URLParam(r, "table")
-	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
-	if limit == 0 {
-		limit = 100
-	}
+	limit := queryPositiveInt(r, "limit", 100)
 
 	assets, err := s.app.Snowflake.GetAssets(r.Context(), table, snowflake.AssetFilter{
 		Limit:   limit,

--- a/internal/api/server_handlers_identity_attack_webhooks.go
+++ b/internal/api/server_handlers_identity_attack_webhooks.go
@@ -323,10 +323,7 @@ func (s *Server) listAuditLogs(w http.ResponseWriter, r *http.Request) {
 
 	resourceType := r.URL.Query().Get("resource_type")
 	resourceID := r.URL.Query().Get("resource_id")
-	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
-	if limit == 0 {
-		limit = 100
-	}
+	limit := queryPositiveInt(r, "limit", 100)
 
 	logs, err := s.app.AuditRepo.List(r.Context(), resourceType, resourceID, limit)
 	if err != nil {

--- a/internal/snowflake/repository.go
+++ b/internal/snowflake/repository.go
@@ -331,7 +331,7 @@ func (r *AuditRepository) Log(ctx context.Context, entry *AuditEntry) error {
 }
 
 func (r *AuditRepository) List(ctx context.Context, resourceType, resourceID string, limit int) ([]*AuditEntry, error) {
-	if limit == 0 {
+	if limit <= 0 {
 		limit = 100
 	}
 


### PR DESCRIPTION
## Summary
- add `queryPositiveInt` helper for consistent positive-int query parsing with sane defaults
- use it in `listAssets` and `listAuditLogs` so invalid/zero/negative `limit` inputs no longer pass through
- harden `snowflake.AuditRepository.List` to treat `limit <= 0` as default `100` as a defense-in-depth guard
- add table-driven unit tests for query limit parsing behavior

## Why
Negative `limit` values could previously flow into audit listing internals and create invalid slice capacities. This change prevents that code path at both handler and repository layers.

## Testing
- go test ./internal/api/...
- go test ./internal/snowflake/...
- go test ./...
