### PR TITLE
build: make security-scan-source use govulncheck binary mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,12 @@ security-scan-built: trivy-db
 		--severity CRITICAL,HIGH \
 		$(SECURITY_SCAN_IMAGE)
 
-# Optional heavier source scan (kept explicit to avoid default local laptop instability)
-security-scan-source:
-	$(GO_BIN)/govulncheck ./...
+# Optional heavier security scan (kept explicit to avoid default local laptop instability)
+security-scan-source: build
+	go build -o bin/policy-enhancer ./cmd/policy-enhancer
+	# govulncheck source mode can fail on this dependency graph; binary mode is deterministic.
+	$(GO_BIN)/govulncheck -mode binary ./bin/cerebro
+	$(GO_BIN)/govulncheck -mode binary ./bin/policy-enhancer
 	$(GO_BIN)/gosec -severity medium -confidence medium -exclude-generated ./...
 
 oss-audit:


### PR DESCRIPTION
## Summary
- update `make security-scan-source` to run `govulncheck` in binary mode against `bin/cerebro` and `bin/policy-enhancer`
- keep `gosec` source scan unchanged after govulncheck
- document why binary mode is used (source-mode instability on current dependency graph)

## Why
`govulncheck ./...` was failing with internal analysis errors in this repo. Binary mode is stable and still validates vulnerabilities in linked modules for shipped binaries.

## Validation
- make security-scan-source
