### PR TITLE
feat: add scheduled security digest notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,9 @@ SLACK_SIGNING_SECRET=
 # Scan interval (e.g., "1h", "30m", "6h")
 SCAN_INTERVAL=
 
+# Security digest notification interval (e.g., "24h", "168h")
+SECURITY_DIGEST_INTERVAL=
+
 # Comma-separated list of tables to scan
 SCAN_TABLES=aws_s3_buckets,aws_ec2_instances,aws_iam_users
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ See [Development Guide](docs/DEVELOPMENT.md) for detailed instructions.
 | `JIRA_BASE_URL` | Jira instance | - |
 | `SLACK_WEBHOOK_URL` | Slack webhook | - |
 | `SCAN_INTERVAL` | Scan frequency | - |
+| `SECURITY_DIGEST_INTERVAL` | Security digest frequency | - |
 | `JOB_QUEUE_URL` | SQS queue URL for distributed jobs | - |
 | `JOB_TABLE_NAME` | DynamoDB table for job state | - |
 | `JOB_REGION` | AWS region for job infrastructure | - |

--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -2,7 +2,7 @@
 
 Generated from `internal/app/app.go` (`LoadConfig`) via `go run ./scripts/generate_config_docs/main.go`.
 
-Total variables: **219**
+Total variables: **220**
 
 | Variable | Reader(s) | Default(s) | Config Field(s) |
 |---|---|---|---|
@@ -178,6 +178,7 @@ Total variables: **219**
 | `SCAN_RETRY_MAX_BACKOFF` | `getEnvDuration` | `30 * time.Second` | `ScanRetryMaxBackoff` |
 | `SCAN_TABLES` | `getEnv` | `""` | `ScanTables` |
 | `SCAN_TABLE_TIMEOUT` | `getEnvDuration` | `30 * time.Minute` | `ScanTableTimeout` |
+| `SECURITY_DIGEST_INTERVAL` | `getEnv` | `""` | `SecurityDigestInterval` |
 | `SEMGREP_API_TOKEN` | `getEnv` | `""` | `SemgrepAPIToken` |
 | `SENTINELONE_API_TOKEN` | `getEnv` | `""` | `SentinelOneAPIToken` |
 | `SENTINELONE_BASE_URL` | `getEnv` | `""` | `SentinelOneBaseURL` |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -423,6 +423,7 @@ type Config struct {
 
 	// Scheduler
 	ScanInterval            string // e.g., "1h", "30m"
+	SecurityDigestInterval  string // e.g., "24h", "168h"
 	ScanTables              string // comma-separated list of tables to scan
 	ScanTableTimeout        time.Duration
 	ScanMaxConcurrent       int
@@ -653,6 +654,7 @@ func LoadConfig() *Config {
 		SlackSigningSecret:                 getEnv("SLACK_SIGNING_SECRET", ""),
 		PagerDutyKey:                       getEnv("PAGERDUTY_ROUTING_KEY", ""),
 		ScanInterval:                       getEnv("SCAN_INTERVAL", ""),
+		SecurityDigestInterval:             getEnv("SECURITY_DIGEST_INTERVAL", ""),
 		ScanTables:                         getEnv("SCAN_TABLES", ""),
 		ScanTableTimeout:                   getEnvDuration("SCAN_TABLE_TIMEOUT", 30*time.Minute),
 		ScanMaxConcurrent:                  getEnvInt("SCAN_MAX_CONCURRENCY", 6),

--- a/internal/app/app_scan_scheduler.go
+++ b/internal/app/app_scan_scheduler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/notifications"
 	"github.com/writer/cerebro/internal/scanner"
 	"github.com/writer/cerebro/internal/scheduler"
@@ -39,6 +40,19 @@ func (a *App) initScheduler(_ context.Context) {
 			a.Logger.Info("scheduled scanning enabled", "interval", interval, "tables", splitTables(a.Config.ScanTables))
 		} else {
 			a.Logger.Info("scheduled scanning enabled", "interval", interval, "table_source", "available_tables")
+		}
+	}
+
+	// Add security digest job if interval configured
+	if a.Config.SecurityDigestInterval != "" {
+		interval, err := parseDuration(a.Config.SecurityDigestInterval)
+		if err != nil {
+			a.Logger.Warn("invalid security digest interval", "value", a.Config.SecurityDigestInterval, "error", err)
+		} else {
+			a.Scheduler.AddJob("security-digest", interval, func(ctx context.Context) error {
+				return a.sendSecurityDigest(ctx)
+			})
+			a.Logger.Info("scheduled security digest enabled", "interval", interval)
 		}
 	}
 
@@ -376,6 +390,78 @@ func (a *App) runScheduledScan(ctx context.Context, tables []string) error {
 	}
 
 	return nil
+}
+
+func (a *App) sendSecurityDigest(ctx context.Context) error {
+	if a.Findings == nil || a.Notifications == nil {
+		return nil
+	}
+
+	openTotal := a.Findings.Count(findings.FindingFilter{Status: "open"})
+	criticalOpen := a.Findings.Count(findings.FindingFilter{Severity: "critical", Status: "open"})
+	highOpen := a.Findings.Count(findings.FindingFilter{Severity: "high", Status: "open"})
+	mediumOpen := a.Findings.Count(findings.FindingFilter{Severity: "medium", Status: "open"})
+	lowOpen := a.Findings.Count(findings.FindingFilter{Severity: "low", Status: "open"})
+
+	highlights := append([]string{},
+		formatDigestHighlights(a.Findings.List(findings.FindingFilter{Severity: "critical", Status: "open"}), "critical", 3)...,
+	)
+	highlights = append(highlights, formatDigestHighlights(a.Findings.List(findings.FindingFilter{Severity: "high", Status: "open"}), "high", 3)...)
+
+	message := fmt.Sprintf(
+		"Open findings: %d (critical: %d, high: %d, medium: %d, low: %d)",
+		openTotal,
+		criticalOpen,
+		highOpen,
+		mediumOpen,
+		lowOpen,
+	)
+	if len(highlights) > 0 {
+		message = fmt.Sprintf("%s. Top priorities: %s", message, strings.Join(highlights, "; "))
+	}
+
+	return a.Notifications.Send(ctx, notifications.Event{
+		Type:     notifications.EventSecurityDigest,
+		Severity: "info",
+		Title:    "Scheduled Security Digest",
+		Message:  message,
+		Data: map[string]interface{}{
+			"open_total": openTotal,
+			"critical":   criticalOpen,
+			"high":       highOpen,
+			"medium":     mediumOpen,
+			"low":        lowOpen,
+			"highlights": highlights,
+		},
+	})
+}
+
+func formatDigestHighlights(list []*findings.Finding, severity string, limit int) []string {
+	if len(list) == 0 || limit <= 0 {
+		return nil
+	}
+
+	entries := make([]string, 0, len(list))
+	for _, finding := range list {
+		title := strings.TrimSpace(finding.PolicyName)
+		if title == "" {
+			title = strings.TrimSpace(finding.PolicyID)
+		}
+		if title == "" {
+			title = finding.ID
+		}
+		entries = append(entries, fmt.Sprintf("%s (%s)", title, finding.ID))
+	}
+	sort.Strings(entries)
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+
+	result := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, fmt.Sprintf("%s: %s", severity, entry))
+	}
+	return result
 }
 
 func parseDuration(s string) (time.Duration, error) {

--- a/internal/app/app_scan_scheduler_digest_test.go
+++ b/internal/app/app_scan_scheduler_digest_test.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/notifications"
+	"github.com/writer/cerebro/internal/policy"
+)
+
+func TestInitScheduler_AddsSecurityDigestJob(t *testing.T) {
+	app := &App{
+		Config: &Config{
+			SecurityDigestInterval: "24h",
+		},
+		Logger: schedulerDigestTestLogger(),
+	}
+
+	app.initScheduler(context.Background())
+
+	job, ok := app.Scheduler.GetJob("security-digest")
+	if !ok {
+		t.Fatal("expected security-digest job to be registered")
+	}
+	if job.Interval != 24*time.Hour {
+		t.Fatalf("expected security-digest interval 24h, got %v", job.Interval)
+	}
+	if _, ok := app.Scheduler.GetJob("graph-rebuild"); !ok {
+		t.Fatal("expected graph-rebuild job to remain registered")
+	}
+}
+
+func TestInitScheduler_InvalidSecurityDigestIntervalSkipsJob(t *testing.T) {
+	app := &App{
+		Config: &Config{
+			SecurityDigestInterval: "not-a-duration",
+		},
+		Logger: schedulerDigestTestLogger(),
+	}
+
+	app.initScheduler(context.Background())
+
+	if _, ok := app.Scheduler.GetJob("security-digest"); ok {
+		t.Fatal("expected security-digest job to be skipped for invalid interval")
+	}
+}
+
+func TestSendSecurityDigest_SendsSummary(t *testing.T) {
+	ctx := context.Background()
+	store := findings.NewStore()
+	upsert := func(f policy.Finding) {
+		store.Upsert(ctx, f)
+	}
+
+	upsert(policy.Finding{
+		ID:          "finding-critical-1",
+		PolicyID:    "policy-critical",
+		PolicyName:  "Critical Policy",
+		Description: "Critical issue",
+		Severity:    "critical",
+		Resource:    map[string]interface{}{"id": "resource-critical-1"},
+	})
+	upsert(policy.Finding{
+		ID:          "finding-high-1",
+		PolicyID:    "policy-high",
+		PolicyName:  "High Policy",
+		Description: "High issue",
+		Severity:    "high",
+		Resource:    map[string]interface{}{"id": "resource-high-1"},
+	})
+	upsert(policy.Finding{
+		ID:          "finding-medium-1",
+		PolicyID:    "policy-medium",
+		PolicyName:  "Medium Policy",
+		Description: "Medium issue",
+		Severity:    "medium",
+		Resource:    map[string]interface{}{"id": "resource-medium-1"},
+	})
+	upsert(policy.Finding{
+		ID:          "finding-low-1",
+		PolicyID:    "policy-low",
+		PolicyName:  "Low Policy",
+		Description: "Low issue",
+		Severity:    "low",
+		Resource:    map[string]interface{}{"id": "resource-low-1"},
+	})
+	upsert(policy.Finding{
+		ID:          "finding-resolved-high",
+		PolicyID:    "policy-resolved",
+		PolicyName:  "Resolved High Policy",
+		Description: "Resolved high issue",
+		Severity:    "high",
+		Resource:    map[string]interface{}{"id": "resource-resolved-high"},
+	})
+	if !store.Resolve("finding-resolved-high") {
+		t.Fatal("expected resolved test finding to be resolvable")
+	}
+
+	capture := &captureNotifier{}
+	manager := notifications.NewManager()
+	manager.AddNotifier(capture)
+
+	app := &App{
+		Findings:      store,
+		Notifications: manager,
+	}
+
+	if err := app.sendSecurityDigest(ctx); err != nil {
+		t.Fatalf("sendSecurityDigest returned error: %v", err)
+	}
+
+	if len(capture.events) != 1 {
+		t.Fatalf("expected 1 notification event, got %d", len(capture.events))
+	}
+
+	event := capture.events[0]
+	if event.Type != notifications.EventSecurityDigest {
+		t.Fatalf("expected event type %q, got %q", notifications.EventSecurityDigest, event.Type)
+	}
+	if event.Severity != "info" {
+		t.Fatalf("expected severity info, got %q", event.Severity)
+	}
+	if event.Title != "Scheduled Security Digest" {
+		t.Fatalf("expected digest title, got %q", event.Title)
+	}
+	for _, want := range []string{
+		"Open findings: 4",
+		"critical: 1",
+		"high: 1",
+		"medium: 1",
+		"low: 1",
+		"Top priorities:",
+	} {
+		if !strings.Contains(event.Message, want) {
+			t.Fatalf("expected digest message to contain %q, got %q", want, event.Message)
+		}
+	}
+
+	openTotal, ok := event.Data["open_total"].(int)
+	if !ok || openTotal != 4 {
+		t.Fatalf("expected open_total=4, got %#v", event.Data["open_total"])
+	}
+
+	highlights, ok := event.Data["highlights"].([]string)
+	if !ok {
+		t.Fatalf("expected highlights to be []string, got %#v", event.Data["highlights"])
+	}
+	if len(highlights) != 2 {
+		t.Fatalf("expected 2 highlights (critical + high), got %d", len(highlights))
+	}
+}
+
+func schedulerDigestTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type captureNotifier struct {
+	events []notifications.Event
+}
+
+func (c *captureNotifier) Send(_ context.Context, event notifications.Event) error {
+	c.events = append(c.events, event)
+	return nil
+}
+
+func (c *captureNotifier) Name() string {
+	return "capture"
+}
+
+func (c *captureNotifier) Test(_ context.Context) error {
+	return nil
+}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -20,10 +20,12 @@ func TestLoadConfig(t *testing.T) {
 	os.Setenv("API_PORT", "9999")
 	os.Setenv("LOG_LEVEL", "debug")
 	os.Setenv("RBAC_STATE_FILE", "/tmp/rbac-state.json")
+	os.Setenv("SECURITY_DIGEST_INTERVAL", "24h")
 	defer func() {
 		os.Unsetenv("API_PORT")
 		os.Unsetenv("LOG_LEVEL")
 		os.Unsetenv("RBAC_STATE_FILE")
+		os.Unsetenv("SECURITY_DIGEST_INTERVAL")
 	}()
 
 	cfg := LoadConfig()
@@ -38,6 +40,10 @@ func TestLoadConfig(t *testing.T) {
 
 	if cfg.RBACStateFile != "/tmp/rbac-state.json" {
 		t.Errorf("expected RBAC state file to be set, got %s", cfg.RBACStateFile)
+	}
+
+	if cfg.SecurityDigestInterval != "24h" {
+		t.Errorf("expected security digest interval 24h, got %s", cfg.SecurityDigestInterval)
 	}
 }
 
@@ -824,16 +830,17 @@ func TestSplitTables(t *testing.T) {
 
 func TestConfig_Fields(t *testing.T) {
 	cfg := &Config{ //nolint:govet // false positive - all fields are tested below
-		Port:               8080,
-		LogLevel:           "info",
-		SnowflakeDatabase:  "CEREBRO",
-		SnowflakeSchema:    "CEREBRO",
-		PoliciesPath:       "policies",
-		ScanInterval:       "1h",
-		RateLimitEnabled:   true,
-		RateLimitRequests:  1000,
-		RateLimitWindow:    time.Hour,
-		CORSAllowedOrigins: []string{"https://app.example.com"},
+		Port:                   8080,
+		LogLevel:               "info",
+		SnowflakeDatabase:      "CEREBRO",
+		SnowflakeSchema:        "CEREBRO",
+		PoliciesPath:           "policies",
+		ScanInterval:           "1h",
+		SecurityDigestInterval: "24h",
+		RateLimitEnabled:       true,
+		RateLimitRequests:      1000,
+		RateLimitWindow:        time.Hour,
+		CORSAllowedOrigins:     []string{"https://app.example.com"},
 	}
 
 	if cfg.Port != 8080 {
@@ -853,6 +860,9 @@ func TestConfig_Fields(t *testing.T) {
 	}
 	if cfg.ScanInterval != "1h" {
 		t.Error("ScanInterval field incorrect")
+	}
+	if cfg.SecurityDigestInterval != "24h" {
+		t.Error("SecurityDigestInterval field incorrect")
 	}
 	if cfg.RateLimitEnabled != true {
 		t.Error("RateLimitEnabled field incorrect")

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -34,6 +34,7 @@ const (
 	EventFindingResolved EventType = "finding.resolved"
 	EventScanCompleted   EventType = "scan.completed"
 	EventScanFailed      EventType = "scan.failed"
+	EventSecurityDigest  EventType = "security.digest"
 	EventAttackPathFound EventType = "attack_path.found"
 	EventReviewRequired  EventType = "review.required"
 )

--- a/internal/notifications/notifier_test.go
+++ b/internal/notifications/notifier_test.go
@@ -101,6 +101,7 @@ func TestEventType_Constants(t *testing.T) {
 		EventFindingResolved,
 		EventScanCompleted,
 		EventScanFailed,
+		EventSecurityDigest,
 		EventAttackPathFound,
 		EventReviewRequired,
 	}


### PR DESCRIPTION
## Summary
- add `SECURITY_DIGEST_INTERVAL` config/env support
- register a new `security-digest` scheduler job when configured
- send periodic `security.digest` notifications with open finding counts and critical/high highlights
- add scheduler + digest unit tests and update notifier event constant coverage
- document the new env var in `.env.example`, README, and generated config env docs

## Testing
- go test ./internal/app/...
- go test ./...
