### PR TITLE
chore(docs): focus CLAUDE on repo-specific guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,36 @@
-# Cerebro - Business Intelligence Engine
+# Cerebro repo notes
 
-## Quick Reference
-```bash
-make build                # Build the Go binary
-make test                 # Run tests
-make lint                 # Run linters
-make docker-build         # Build Docker image
-make run                  # Run locally
-```
+Only repo-specific, non-obvious guidance lives here.
 
-## Architecture
-- **Language**: Go
-- **Event ingestion**: NATS JetStream (CloudEvents format)
-- **Analytics store**: ClickHouse
-- **Deployment**: Docker → k3s via ArgoCD
-- **Connected to**: Ensemble (agent platform), Platform (core SaaS)
+## High-signal context
 
-## Purpose
-Cerebro is the "brain" of Writer — it ingests organizational events, processes them through analyzers, and produces business intelligence. Think of it as giving a 2-person startup the BI capabilities of a much larger company.
+- This is Writer's original public `cerebro` repo. Do not describe it as a fork or downstream mirror.
+- The repo is Go, but many validations are repo-specific and should usually be run via `make`/DevEx wrappers rather than ad-hoc commands.
+- Go dependencies are vendored (`GOFLAGS=-mod=vendor`), so dependency changes should usually be checked with `make vendor-check`.
 
-## Key Directories
-- `cmd/` — CLI entrypoints
-- `api/` — HTTP API handlers
-- `internal/` — Core business logic, analyzers, event processing
-- `policies/` — Policy definitions
-- `scripts/` — Operational scripts
+## Preferred validation entrypoints
 
-## Conventions
-- Follow idiomatic Go (gofmt, golint, govet)
-- Use CloudEvents spec for all event types
-- ClickHouse tables use ReplacingMergeTree — always query with FINAL for dedup
-- All config via environment variables (see `internal/config/`)
+- Use `make devex-changed` for diff-aware local preflight.
+- Use `make devex-pr` for broader PR-parity validation.
+- Prefer `make openapi-check` / `make openapi-sync` instead of hand-editing route placeholders.
+- Run `python3 scripts/oss_audit.py` after public-facing docs/config/example changes.
+
+## Generated / contract-governed surfaces
+
+If you touch these areas, expect generated artifacts and compatibility checks:
+
+- OpenAPI contract
+- config env-var docs
+- graph ontology docs/contracts
+- CloudEvents docs/contracts
+- report contract docs/contracts
+- entity facet docs/contracts
+- Agent SDK docs/contracts/packages
+- DevEx codegen catalog
+
+Check the corresponding `Makefile` `*-check` / `*-compat` targets before finishing.
+
+## Runtime notes
+
+- Full-featured runs expect Snowflake, but local SQLite mode exists for lighter local development.
+- Some CLI paths use repo-specific env wrappers in `make`, so prefer documented make targets when available.


### PR DESCRIPTION
## Summary
- reduce `CLAUDE.md` to repo-specific, non-obvious guidance
- keep the notes focused on validation entrypoints, vendoring, generated surfaces, and Writer-origin wording

## Validation
- `python3 scripts/oss_audit.py`
- `git diff --check`
