### PR TITLE
feat(platform): unify execution state in shared store

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,32 @@ Owner: @haasonsaas
 Mode: implement in full, keep CI green
 Status: executed end-to-end via PR workflow
 
+## Deep Review Cycle 66 - Shared Execution Store Convergence (2026-03-12)
+
+### Review findings
+- [x] Gap: issue `#209` was still only partially true; the repo had a shared execution-store package, but report runs, action executions, consumer dedupe, and scan materialization still reopened concrete SQLite stores and therefore kept backend assumptions in leaf services.
+- [x] Gap: that concrete `*executionstore.SQLiteStore` coupling would make a future multi-worker backend migration harder than it needs to be, which matters because SQLite is an acceptable default but not the long-term answer for larger customers.
+- [x] Gap: API/server tests were still proving persistence behavior through wrapper ownership assumptions instead of the actual shared execution-store boundary.
+- [x] Gap: GitHub/wider-project references reinforce the right seam:
+  - [x] `dagster-io/dagster` keeps run state on a generic storage contract while layering richer indexes/tags on top.
+  - [x] `argoproj/argo-workflows` keeps execution status and node state explicit rather than hiding orchestration state in process memory.
+  - [x] the Wiz schema dump in `/Users/jonathanhaas/Downloads/other/wiz.graphql` is a useful reminder that broad query surfaces stay tractable only when the underlying execution resources remain typed and inspectable.
+
+### Execution plan
+- [x] Extract a backend-neutral shared execution-store contract:
+  - [x] add `executionstore.Store`
+  - [x] move callers off concrete `*executionstore.SQLiteStore` dependencies where they only need the shared contract
+- [x] Centralize app-level shared execution-store ownership:
+  - [x] initialize one shared app execution store from `EXECUTION_STORE_FILE`
+  - [x] thread that shared handle into API/report/action/consumer paths when they point at the same underlying store
+  - [x] keep wrapper-specific `Close()` semantics from accidentally closing borrowed shared stores
+- [x] Preserve durable behavior while removing wrapper-owned assumptions:
+  - [x] update report-run persistence tests to fail through the shared store itself
+  - [x] keep scan/action/report/consumer paths green under the shared contract
+- [x] Add follow-on scale direction to the backlog:
+  - [x] document that SQLite remains the default implementation for now
+  - [x] make “higher-scale backend behind `executionstore.Store`” the next scale seam instead of deepening SQLite-only code paths
+
 ## Deep Review Cycle 65 - Durable CloudEvent Deduplication for NATS Consumer (2026-03-12)
 
 ### Review findings

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,88 @@ Owner: @haasonsaas
 Mode: implement in full, keep CI green
 Status: executed end-to-end via PR workflow
 
+## Deep Review Cycle 65 - Durable CloudEvent Deduplication for NATS Consumer (2026-03-12)
+
+### Review findings
+- [x] Gap: issue `#248` was still materially open because the JetStream consumer acknowledged events after handler success but had no durable CloudEvent-ID suppression, so transient ack failures and consumer restarts could re-run the same mutation path.
+- [x] Gap: the issue proposal allowed an in-memory sliding window with periodic persistence, but that would still leave a correctness hole on restart and does not match the broader platform direction toward shared execution state.
+- [x] Gap: consumer observability exposed redeliveries and dropped messages, but not the actual successful-vs-deduplicated throughput split needed to prove the pipeline is suppressing duplicates instead of just retrying them.
+- [x] Gap: external references were directionally useful but not prescriptive here:
+  - [x] `argoproj/argo-events` reinforces durable event-processing state over process-local memory when workflows restart.
+  - [x] `OpenLineage/OpenLineage` reinforces treating event identity as a first-class contract surface instead of an incidental transport detail.
+  - [x] the Wiz schema dump in `/Users/jonathanhaas/Downloads/other/wiz.graphql` is a useful caution that very broad event/query surfaces become harder to reason about unless identity and processing contracts are explicit and inspectable.
+
+### Execution plan
+- [x] Add durable processed-event storage in the shared execution store:
+  - [x] add `processed_events` persistence + indexes in the SQLite execution store
+  - [x] add processed-event lookup/remember helpers with TTL and bounded retention
+- [x] Add consumer-level CloudEvent dedupe:
+  - [x] derive a deterministic dedupe key from tenant/source/event ID
+  - [x] skip handler execution when the CloudEvent is already recorded in the dedupe window
+  - [x] log payload-hash mismatches for duplicate IDs carrying different payloads
+- [x] Expose config and metrics:
+  - [x] add NATS consumer dedupe env/config fields with validation
+  - [x] add processed and deduplicated Prometheus counters
+  - [x] document the new config in `docs/CONFIG_ENV_VARS.md`
+- [x] Add regression coverage:
+  - [x] execution-store round trip + bounded retention tests
+  - [x] consumer duplicate suppression tests
+  - [x] metrics registration coverage
+
+### Detailed follow-on backlog
+- [ ] Track A - Stronger idempotency semantics
+  - Exit criteria:
+  - [ ] add durable in-flight / completed processing states instead of completed-event memory only
+  - [ ] thread idempotency keys into graph mutation write paths so handler replay becomes a true no-op
+- [ ] Track B - Dedupe lifecycle observability
+  - Exit criteria:
+  - [ ] add dedupe-store health metrics and storage-pressure telemetry
+  - [ ] expose dedupe hit/miss posture in consumer health/readiness reporting
+- [ ] Track C - Ordered entity-local sequencing
+  - Exit criteria:
+  - [ ] add per-entity ordering windows for create/update/delete event families that cannot tolerate reorder
+  - [ ] keep that sequencing logic separate from the generic dedupe window
+
+## Deep Review Cycle 64 - Coverage Ratchet for Critical Packages: Sync + API (2026-03-12)
+
+### Review findings
+- [x] Gap: issue `#152` was still open even after warehouse/test seams improved because CI was still enforcing stale package floors: `internal/api` at `40%` despite already exceeding `55%`, and `internal/sync` at `11.5%` despite the highest orchestration complexity in the repo.
+- [x] Gap: the real blocker was not `internal/api`; shared app test helpers already existed via `internal/apptest`, and package coverage was already above the requested floor.
+- [x] Gap: `internal/sync` needed honest coverage work in the warehouse-backed orchestration seams we actually rely on today: sync coordination, CDC event emission, scoped persistence helpers, and provider-specific change-history paths.
+- [x] Gap: external references reinforced the same discipline from different angles:
+  - [x] `openfga/openfga` keeps transport and service seams narrow enough that handler/service tests are cheap instead of requiring full-process integration.
+  - [x] `grafana/grafana` is the warning case for broad surface area where package-level ratchets only work if helper seams exist first.
+  - [x] the Wiz schema dump in `/Users/jonathanhaas/Downloads/wiz.graphql` remains the opposite cautionary example: large ambient surfaces become difficult to test rigorously unless they are broken into explicit modules and query seams.
+
+### Execution plan
+- [x] Raise real sync coverage with warehouse-backed tests:
+  - [x] add CDC builder tests for event IDs, payload extraction, and scope fallback
+  - [x] add sync engine tests for change history, partial fetch backfill, and CDC emission
+  - [x] add scoped table operation tests for scoped deletes, provider change history, and merge behavior
+  - [x] add GCP/Kubernetes provider tests covering CDC emission and shared persistence helpers
+  - [x] add helper/fetch-wrapper tests for retry helpers, region-limit helpers, and thin provider fetch delegates
+- [x] Re-measure package coverage before touching CI:
+  - [x] `internal/sync` now measures `21.0%`
+  - [x] `internal/api` measures `64.4%`
+- [x] Ratchet CI floors to measured reality:
+  - [x] raise `internal/api` threshold from `40.0` to `55.0`
+  - [x] raise `internal/sync` threshold from `11.5` to `20.0`
+
+### Detailed follow-on backlog
+- [ ] Track A - Next sync coverage ratchet to `30%`
+  - Exit criteria:
+  - [ ] add deeper relationship extraction tests for AWS/GCP relationship builders
+  - [ ] add more provider fetch/retry edge-case coverage around partial-page and auth failure handling
+  - [ ] raise the `internal/sync` CI floor from `20.0` to `30.0` only after measured package coverage holds above that mark with headroom
+- [ ] Track B - Coverage by package seam, not full-process setup
+  - Exit criteria:
+  - [ ] keep using `internal/apptest` / warehouse memory doubles instead of reintroducing full Snowflake/process dependencies into unit suites
+  - [ ] extract any remaining broad setup helpers only where a new handler or sync surface still cannot be tested cheaply
+- [ ] Track C - Package split pressure
+  - Exit criteria:
+  - [ ] use the next `internal/sync` coverage wave to identify the worst ambient files for later package extraction
+  - [ ] keep coverage work aligned with the larger graph/app package-boundary cleanup instead of growing more monolithic provider files
+
 ## Deep Review Cycle 63 - Graph Package Split Phase 1: Reports Extraction (2026-03-12)
 
 ### Review findings

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6949,6 +6949,76 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /api/v1/platform/executions:
+    get:
+      tags:
+        - Platform
+      summary: List shared platform executions across reports, scans, and action workflows
+      parameters:
+        - name: namespace
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional comma-separated execution namespaces.
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional comma-separated statuses to include.
+        - name: exclude_status
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional comma-separated statuses to exclude.
+        - name: report_id
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional report definition filter for report executions.
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - updated
+              - submitted
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: Shared execution listing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformExecutionCollection'
+        '400':
+          description: Invalid execution listing parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Failed to load shared execution state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /api/v1/graph/actuate/recommendation:
     post:
       tags:
@@ -14335,6 +14405,71 @@ components:
           type: string
         status_url:
           type: string
+    PlatformExecutionSummary:
+      type: object
+      additionalProperties: false
+      properties:
+        namespace:
+          type: string
+        run_id:
+          type: string
+        kind:
+          type: string
+        status:
+          type: string
+        stage:
+          type: string
+        submitted_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        display_name:
+          type: string
+        scope_id:
+          type: string
+        requested_by:
+          type: string
+        execution_mode:
+          type: string
+        status_url:
+          type: string
+        job_id:
+          type: string
+        error:
+          type: string
+        provider:
+          type: string
+        target:
+          type: string
+      required:
+        - namespace
+        - run_id
+        - kind
+        - status
+        - stage
+        - submitted_at
+        - updated_at
+    PlatformExecutionCollection:
+      type: object
+      additionalProperties: false
+      properties:
+        count:
+          type: integer
+        executions:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlatformExecutionSummary'
+      required:
+        - count
+        - executions
     PlatformReportRunRequest:
       type: object
       additionalProperties: false

--- a/docs/AGENT_SDK_AUTOGEN.md
+++ b/docs/AGENT_SDK_AUTOGEN.md
@@ -5,7 +5,7 @@ Generated from the shared `App.AgentSDKTools()` registry and `internal/agentsdk`
 - Catalog API version: **cerebro.agent-sdk.contracts/v1alpha1**
 - Catalog kind: **AgentSDKCatalog**
 - MCP protocol version: **2025-06-18**
-- Tools: **26**
+- Tools: **27**
 - Resources: **5**
 - MCP methods + notifications: **7**
 
@@ -23,6 +23,7 @@ Generated from the shared `App.AgentSDKTools()` registry and `internal/agentsdk`
 | `cerebro_correlate_events` | `1.0.0` | `cerebro.correlate_events` | `correlate_events` | `query` | `direct_tool` | false | false | ` ` | `sdk.context.read` |
 | `cerebro_decide` | `1.0.0` | `cerebro.record_decision` | `decide` | `writeback` | `direct_tool` | false | false | `POST /api/v1/agent-sdk/decisions` | `sdk.worldmodel.write` |
 | `cerebro_entity_history` | `1.0.0` | `cerebro.entity_history` | `entity_history` | `query` | `direct_tool` | false | false | ` ` | `sdk.context.read` |
+| `cerebro_execution_status` | `1.0.0` | `cerebro.execution_status` | `execution_status` | `query` | `direct_tool` | false | false | ` ` | `sdk.context.read` |
 | `cerebro_findings` | `1.0.0` | `cerebro.findings` | `findings` | `query` | `direct_tool` | false | false | ` ` | `sdk.context.read` |
 | `cerebro_graph_changelog` | `1.0.0` | `cerebro.graph_changelog` | `graph_changelog` | `query` | `direct_tool` | false | false | ` ` | `sdk.context.read` |
 | `cerebro_graph_query` | `1.0.0` | `cerebro.graph_query` | `graph_query` | `query` | `direct_tool` | false | false | ` ` | `sdk.context.read` |
@@ -243,6 +244,22 @@ Generated from the shared `App.AgentSDKTools()` registry and `internal/agentsdk`
   "recorded_at": "recorded_at",
   "timestamp": "timestamp",
   "to": "to"
+}
+```
+
+### `cerebro_execution_status`
+
+```json
+{
+  "limit": 20,
+  "namespace": [
+    "namespace"
+  ],
+  "order": "updated",
+  "report_id": "insights",
+  "status": [
+    "status"
+  ]
 }
 ```
 

--- a/docs/AGENT_SDK_CONTRACTS.json
+++ b/docs/AGENT_SDK_CONTRACTS.json
@@ -647,6 +647,65 @@
       "execution_kind": "direct_tool"
     },
     {
+      "id": "cerebro_execution_status",
+      "version": "1.0.0",
+      "tool_name": "cerebro.execution_status",
+      "sdk_method": "execution_status",
+      "title": "Execution Status",
+      "description": "List recent shared-platform executions across report runs, scans, and action workflows",
+      "category": "query",
+      "required_permission": "sdk.context.read",
+      "input_schema": {
+        "properties": {
+          "limit": {
+            "default": 20,
+            "description": "Maximum executions to return (1-100).",
+            "type": "integer"
+          },
+          "namespace": {
+            "description": "Optional execution namespaces to filter, for example report_run, workload_scan, image_scan, function_scan, action_engine.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "order": {
+            "default": "updated",
+            "description": "Sort order: updated or submitted.",
+            "enum": [
+              "updated",
+              "submitted"
+            ],
+            "type": "string"
+          },
+          "report_id": {
+            "description": "Optional report definition ID filter for report executions.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Optional execution statuses to include.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "example_input": {
+        "limit": 20,
+        "namespace": [
+          "namespace"
+        ],
+        "order": "updated",
+        "report_id": "insights",
+        "status": [
+          "status"
+        ]
+      },
+      "execution_kind": "direct_tool"
+    },
+    {
       "id": "cerebro_findings",
       "version": "1.0.0",
       "tool_name": "cerebro.findings",

--- a/docs/AGENT_SDK_PACKAGES_AUTOGEN.md
+++ b/docs/AGENT_SDK_PACKAGES_AUTOGEN.md
@@ -2,7 +2,7 @@
 
 Generated from `docs/AGENT_SDK_CONTRACTS.json` via `go run ./scripts/generate_agent_sdk_packages/main.go`.
 
-- Tool bindings: **26**
+- Tool bindings: **27**
 - Package paths:
   - `sdk/go/cerebro`
   - `sdk/python/cerebro_sdk`
@@ -23,6 +23,7 @@ Generated from `docs/AGENT_SDK_CONTRACTS.json` via `go run ./scripts/generate_ag
 | `cerebro_correlate_events` | `CorrelateEvents` | `correlate_events` | `correlateEvents` |
 | `cerebro_decide` | `Decide` | `decide` | `decide` |
 | `cerebro_entity_history` | `EntityHistory` | `entity_history` | `entityHistory` |
+| `cerebro_execution_status` | `ExecutionStatus` | `execution_status` | `executionStatus` |
 | `cerebro_findings` | `Findings` | `findings` | `findings` |
 | `cerebro_graph_changelog` | `GraphChangelog` | `graph_changelog` | `graphChangelog` |
 | `cerebro_graph_query` | `GraphQuery` | `graph_query` | `graphQuery` |

--- a/docs/API_CONTRACTS.json
+++ b/docs/API_CONTRACTS.json
@@ -2,7 +2,7 @@
   "api_version": "devex.cerebro/v1alpha1",
   "kind": "HTTPAPIContractCatalog",
   "generated_at": "0001-01-01T00:00:00Z",
-  "endpoint_count": 296,
+  "endpoint_count": 297,
   "endpoints": [
     {
       "id": "DELETE /api/v1/findings/{id}",
@@ -8472,6 +8472,142 @@
             },
             {
               "path": "to",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GET /api/v1/platform/executions",
+      "path": "/api/v1/platform/executions",
+      "method": "GET",
+      "query_params": [
+        {
+          "name": "exclude_status",
+          "required": false,
+          "schema_type": "string"
+        },
+        {
+          "name": "limit",
+          "required": false,
+          "schema_type": "integer"
+        },
+        {
+          "name": "namespace",
+          "required": false,
+          "schema_type": "string"
+        },
+        {
+          "name": "offset",
+          "required": false,
+          "schema_type": "integer"
+        },
+        {
+          "name": "order",
+          "required": false,
+          "schema_type": "string"
+        },
+        {
+          "name": "report_id",
+          "required": false,
+          "schema_type": "string"
+        },
+        {
+          "name": "status",
+          "required": false,
+          "schema_type": "string"
+        }
+      ],
+      "success_responses": [
+        {
+          "status_code": "200",
+          "content_types": [
+            "application/json"
+          ],
+          "fields": [
+            {
+              "path": "count",
+              "type": "integer"
+            },
+            {
+              "path": "executions",
+              "type": "array"
+            },
+            {
+              "path": "executions[]",
+              "type": "object"
+            },
+            {
+              "path": "executions[].completed_at",
+              "type": "string"
+            },
+            {
+              "path": "executions[].display_name",
+              "type": "string"
+            },
+            {
+              "path": "executions[].error",
+              "type": "string"
+            },
+            {
+              "path": "executions[].execution_mode",
+              "type": "string"
+            },
+            {
+              "path": "executions[].job_id",
+              "type": "string"
+            },
+            {
+              "path": "executions[].kind",
+              "type": "string"
+            },
+            {
+              "path": "executions[].namespace",
+              "type": "string"
+            },
+            {
+              "path": "executions[].provider",
+              "type": "string"
+            },
+            {
+              "path": "executions[].requested_by",
+              "type": "string"
+            },
+            {
+              "path": "executions[].run_id",
+              "type": "string"
+            },
+            {
+              "path": "executions[].scope_id",
+              "type": "string"
+            },
+            {
+              "path": "executions[].stage",
+              "type": "string"
+            },
+            {
+              "path": "executions[].started_at",
+              "type": "string"
+            },
+            {
+              "path": "executions[].status",
+              "type": "string"
+            },
+            {
+              "path": "executions[].status_url",
+              "type": "string"
+            },
+            {
+              "path": "executions[].submitted_at",
+              "type": "string"
+            },
+            {
+              "path": "executions[].target",
+              "type": "string"
+            },
+            {
+              "path": "executions[].updated_at",
               "type": "string"
             }
           ]

--- a/docs/API_CONTRACTS_AUTOGEN.md
+++ b/docs/API_CONTRACTS_AUTOGEN.md
@@ -4,7 +4,7 @@ Generated from `api/openapi.yaml` via `go run ./scripts/generate_api_contract_do
 
 - Catalog API version: **devex.cerebro/v1alpha1**
 - Catalog kind: **HTTPAPIContractCatalog**
-- Endpoints: **296**
+- Endpoints: **297**
 
 ## Endpoint Summary
 
@@ -105,6 +105,7 @@ Generated from `api/openapi.yaml` via `go run ./scripts/generate_api_contract_do
 | `GET /api/v1/platform/entities/{entity_id}` | 2 | 0 | `200` |
 | `GET /api/v1/platform/entities/{entity_id}/at` | 2 | 0 | `200` |
 | `GET /api/v1/platform/entities/{entity_id}/diff` | 3 | 0 | `200` |
+| `GET /api/v1/platform/executions` | 7 | 0 | `200` |
 | `GET /api/v1/platform/graph/changelog` | 7 | 0 | `200` |
 | `GET /api/v1/platform/graph/diffs/{diff_id}` | 0 | 0 | `200` |
 | `GET /api/v1/platform/graph/diffs/{diff_id}/details` | 3 | 0 | `200` |

--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -2,7 +2,7 @@
 
 Generated from `internal/app/app_config.go` (`LoadConfig`) via `go run ./scripts/generate_config_docs/main.go`.
 
-Total variables: **307**
+Total variables: **311**
 
 | Variable | Reader(s) | Default(s) | Config Field(s) | Validation rule(s) |
 |---|---|---|---|---|
@@ -75,7 +75,7 @@ Total variables: **307**
 | `ENTRA_CLIENT_ID` | `getEnv` | `""` | `EntraClientID` | `-` |
 | `ENTRA_CLIENT_SECRET` | `getEnv` | `""` | `EntraClientSecret` | `-` |
 | `ENTRA_TENANT_ID` | `getEnv` | `""` | `EntraTenantID` | `-` |
-| `EXECUTION_STORE_FILE` | `getEnv` | `filepath.Join(".cerebro", "executions.db")` | `ExecutionStoreFile`, `FunctionScanStateFile`, `ImageScanStateFile`, `WorkloadScanStateFile` | `-` |
+| `EXECUTION_STORE_FILE` | `getEnv` | `filepath.Join(".cerebro", "executions.db")` | `ExecutionStoreFile`, `FunctionScanStateFile`, `ImageScanStateFile`, `NATSConsumerDedupStateFile`, `WorkloadScanStateFile` | `-` |
 | `FIGMA_API_TOKEN` | `getEnv` | `""` | `FigmaAPIToken` | `-` |
 | `FIGMA_BASE_URL` | `getEnv` | `"https://api.figma.com"` | `FigmaBaseURL` | `-` |
 | `FIGMA_TEAM_ID` | `getEnv` | `""` | `FigmaTeamID` | `-` |
@@ -151,22 +151,26 @@ Total variables: **307**
 | `LINEAR_API_KEY` | `getEnv` | `""` | `LinearAPIKey` | `-` |
 | `LINEAR_TEAM_ID` | `getEnv` | `""` | `LinearTeamID` | `-` |
 | `LOG_LEVEL` | `getEnv` | `"info"` | `LogLevel` | `must be one of debug, info, warn, error` |
-| `NATS_CONSUMER_ACK_WAIT` | `getEnvDuration` | `120 * time.Second` | `NATSConsumerAckWait` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_BATCH_SIZE` | `getEnvInt` | `50` | `NATSConsumerBatchSize` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
+| `NATS_CONSUMER_ACK_WAIT` | `getEnvDuration` | `120 * time.Second` | `NATSConsumerAckWait` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_BATCH_SIZE` | `getEnvInt` | `50` | `NATSConsumerBatchSize` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
 | `NATS_CONSUMER_DEAD_LETTER_PATH` | `getEnv` | `filepath.Join(findings.DefaultFilePath(), "nats-consumer.dlq.jsonl")` | `NATSConsumerDeadLetterPath` | `-` |
-| `NATS_CONSUMER_DRAIN_TIMEOUT` | `getEnvDuration` | `30 * time.Second` | `NATSConsumerDrainTimeout` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_DROP_HEALTH_LOOKBACK` | `getEnvDuration` | `5 * time.Minute` | `NATSConsumerDropHealthLookback` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_DROP_HEALTH_THRESHOLD` | `getEnvInt` | `1` | `NATSConsumerDropHealthThreshold` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_DURABLE` | `getEnv` | `"cerebro_graph_builder"` | `NATSConsumerDurable` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_ENABLED` | `getEnvBool` | `false` | `NATSConsumerEnabled` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_FETCH_TIMEOUT` | `getEnvDuration` | `2 * time.Second` | `NATSConsumerFetchTimeout` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_GRAPH_STALENESS_THRESHOLD` | `getEnvDuration` | `15 * time.Minute` | `NATSConsumerGraphStalenessThreshold` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_IN_PROGRESS_INTERVAL` | `getEnvDuration` | `15 * time.Second` | `NATSConsumerInProgressInterval` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_STREAM` | `getEnv` | `"ENSEMBLE_TAP"` | `NATSConsumerStream` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_SUBJECTS` | `getEnv` | `"ensemble.tap.>"` | `NATSConsumerSubjects` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
+| `NATS_CONSUMER_DEDUP_ENABLED` | `getEnvBool` | `true` | `NATSConsumerDedupEnabled` | `-` |
+| `NATS_CONSUMER_DEDUP_MAX_RECORDS` | `getEnvInt` | `100000` | `NATSConsumerDedupMaxRecords` | `-` |
+| `NATS_CONSUMER_DEDUP_STATE_FILE` | `getEnv` | `getEnv("EXECUTION_STORE_FILE", filepath.Join(".cerebro", "executions.db"))` | `NATSConsumerDedupStateFile` | `-` |
+| `NATS_CONSUMER_DEDUP_TTL` | `getEnvDuration` | `24 * time.Hour` | `NATSConsumerDedupTTL` | `-` |
+| `NATS_CONSUMER_DRAIN_TIMEOUT` | `getEnvDuration` | `30 * time.Second` | `NATSConsumerDrainTimeout` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_DROP_HEALTH_LOOKBACK` | `getEnvDuration` | `5 * time.Minute` | `NATSConsumerDropHealthLookback` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_DROP_HEALTH_THRESHOLD` | `getEnvInt` | `1` | `NATSConsumerDropHealthThreshold` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_DURABLE` | `getEnv` | `"cerebro_graph_builder"` | `NATSConsumerDurable` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_ENABLED` | `getEnvBool` | `false` | `NATSConsumerEnabled` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_FETCH_TIMEOUT` | `getEnvDuration` | `2 * time.Second` | `NATSConsumerFetchTimeout` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_GRAPH_STALENESS_THRESHOLD` | `getEnvDuration` | `15 * time.Minute` | `NATSConsumerGraphStalenessThreshold` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_IN_PROGRESS_INTERVAL` | `getEnvDuration` | `15 * time.Second` | `NATSConsumerInProgressInterval` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_STREAM` | `getEnv` | `"ENSEMBLE_TAP"` | `NATSConsumerStream` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_SUBJECTS` | `getEnv` | `"ensemble.tap.>"` | `NATSConsumerSubjects` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
 | `NATS_JETSTREAM_AUTH_MODE` | `getEnv` | `"none"` | `NATSJetStreamAuthMode` | `-` |
 | `NATS_JETSTREAM_CONNECT_TIMEOUT` | `getEnvDuration` | `5 * time.Second` | `NATSJetStreamConnectTimeout` | `when NATS_JETSTREAM_ENABLED=true, required values must be present and timing/retention values must be positive` |
-| `NATS_JETSTREAM_ENABLED` | `getEnvBool` | `false` | `NATSJetStreamEnabled` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative`, `when NATS_JETSTREAM_ENABLED=true, required values must be present and timing/retention values must be positive` |
+| `NATS_JETSTREAM_ENABLED` | `getEnvBool` | `false` | `NATSJetStreamEnabled` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled`, `when NATS_JETSTREAM_ENABLED=true, required values must be present and timing/retention values must be positive` |
 | `NATS_JETSTREAM_FLUSH_INTERVAL` | `getEnvDuration` | `10 * time.Second` | `NATSJetStreamFlushInterval` | `when NATS_JETSTREAM_ENABLED=true, required values must be present and timing/retention values must be positive` |
 | `NATS_JETSTREAM_NKEY_SEED` | `getEnv` | `""` | `NATSJetStreamNKeySeed` | `-` |
 | `NATS_JETSTREAM_OUTBOX_CRITICAL_AGE` | `getEnvDuration` | `6 * time.Hour` | `NATSJetStreamOutboxCriticalAge` | `-` |

--- a/internal/actionengine/store.go
+++ b/internal/actionengine/store.go
@@ -21,8 +21,9 @@ type Store interface {
 }
 
 type SQLiteStore struct {
-	store     *executionstore.SQLiteStore
+	store     executionstore.Store
 	namespace string
+	ownsStore bool
 }
 
 func NewSQLiteStore(path, namespace string) (*SQLiteStore, error) {
@@ -30,15 +31,21 @@ func NewSQLiteStore(path, namespace string) (*SQLiteStore, error) {
 	if err != nil {
 		return nil, err
 	}
+	sqliteStore := NewSQLiteStoreWithExecutionStore(store, namespace)
+	sqliteStore.ownsStore = true
+	return sqliteStore, nil
+}
+
+func NewSQLiteStoreWithExecutionStore(store executionstore.Store, namespace string) *SQLiteStore {
 	namespace = strings.TrimSpace(namespace)
 	if namespace == "" {
 		namespace = DefaultNamespace
 	}
-	return &SQLiteStore{store: store, namespace: namespace}, nil
+	return &SQLiteStore{store: store, namespace: namespace}
 }
 
 func (s *SQLiteStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -393,6 +393,8 @@ func routePermission(method, path string) string {
 			return "platform.intelligence.run"
 		}
 		return "platform.intelligence.read"
+	case strings.HasPrefix(path, "/api/v1/platform/executions"):
+		return "platform.jobs.read"
 	case strings.HasPrefix(path, "/api/v1/platform/jobs"):
 		return "platform.jobs.read"
 	case strings.HasPrefix(path, "/api/v1/platform/knowledge"):

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -85,12 +85,20 @@ func NewServerWithDependencies(deps serverDependencies) *Server {
 		agentSDKReportProgress: make(map[string]agentSDKReportProgressSubscription),
 	}
 	if cfg := deps.Config; cfg != nil {
-		store, err := reports.NewReportRunStore(cfg.ExecutionStoreFile, cfg.PlatformReportSnapshotPath, cfg.PlatformReportRunStateFile)
+		var (
+			store *reports.ReportRunStore
+			err   error
+		)
+		if deps.ExecutionStore != nil {
+			store = reports.NewReportRunStoreWithExecutionStore(deps.ExecutionStore, cfg.ExecutionStoreFile, cfg.PlatformReportSnapshotPath, cfg.PlatformReportRunStateFile)
+		} else {
+			store, err = reports.NewReportRunStore(cfg.ExecutionStoreFile, cfg.PlatformReportSnapshotPath, cfg.PlatformReportRunStateFile)
+		}
 		if err != nil {
 			if deps.Logger != nil {
 				deps.Logger.Warn("failed to initialize shared platform report execution store", "execution_store", cfg.ExecutionStoreFile, "legacy_state_file", cfg.PlatformReportRunStateFile, "snapshot_dir", cfg.PlatformReportSnapshotPath, "error", err)
 			}
-		} else {
+		} else if store != nil {
 			s.platformReportStore = store
 			if restoredRuns, err := s.platformReportStore.Load(); err != nil {
 				if deps.Logger != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -85,13 +85,20 @@ func NewServerWithDependencies(deps serverDependencies) *Server {
 		agentSDKReportProgress: make(map[string]agentSDKReportProgressSubscription),
 	}
 	if cfg := deps.Config; cfg != nil {
-		s.platformReportStore = reports.NewReportRunStore(cfg.PlatformReportRunStateFile, cfg.PlatformReportSnapshotPath)
-		if restoredRuns, err := s.platformReportStore.Load(); err != nil {
+		store, err := reports.NewReportRunStore(cfg.ExecutionStoreFile, cfg.PlatformReportSnapshotPath, cfg.PlatformReportRunStateFile)
+		if err != nil {
 			if deps.Logger != nil {
-				deps.Logger.Warn("failed to load persisted platform report runs", "state_file", s.platformReportStore.StateFile(), "snapshot_dir", s.platformReportStore.SnapshotDir(), "error", err)
+				deps.Logger.Warn("failed to initialize shared platform report execution store", "execution_store", cfg.ExecutionStoreFile, "legacy_state_file", cfg.PlatformReportRunStateFile, "snapshot_dir", cfg.PlatformReportSnapshotPath, "error", err)
 			}
 		} else {
-			s.platformReportRuns = restoredRuns
+			s.platformReportStore = store
+			if restoredRuns, err := s.platformReportStore.Load(); err != nil {
+				if deps.Logger != nil {
+					deps.Logger.Warn("failed to load persisted platform report runs", "execution_store", s.platformReportStore.StateFile(), "legacy_state_file", s.platformReportStore.LegacyStateFile(), "snapshot_dir", s.platformReportStore.SnapshotDir(), "error", err)
+				}
+			} else {
+				s.platformReportRuns = restoredRuns
+			}
 		}
 	}
 	s.platformReportHandlers = map[string]http.HandlerFunc{
@@ -137,6 +144,9 @@ func (s *Server) Close() {
 		s.cancelPlatformJob(jobID, "server shutdown")
 	}
 	s.platformJobWG.Wait()
+	if s.platformReportStore != nil {
+		_ = s.platformReportStore.Close()
+	}
 }
 
 func (s *Server) Run() error {

--- a/internal/api/server_dependencies.go
+++ b/internal/api/server_dependencies.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/attackpath"
 	"github.com/writer/cerebro/internal/auth"
 	"github.com/writer/cerebro/internal/cache"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/graph/builders"
@@ -69,12 +70,13 @@ type serverDependencies struct {
 	Config *app.Config
 	Logger *slog.Logger
 
-	Snowflake *snowflake.Client
-	Warehouse warehouse.DataWarehouse
-	Policy    *policy.Engine
-	Findings  findings.FindingStore
-	Scanner   *scanner.Scanner
-	Cache     *cache.PolicyCache
+	Snowflake      *snowflake.Client
+	Warehouse      warehouse.DataWarehouse
+	Policy         *policy.Engine
+	Findings       findings.FindingStore
+	Scanner        *scanner.Scanner
+	Cache          *cache.PolicyCache
+	ExecutionStore executionstore.Store
 
 	Agents         *agents.AgentRegistry
 	Ticketing      *ticketing.Service
@@ -135,6 +137,7 @@ func newServerDependenciesFromApp(application *app.App) serverDependencies {
 		Findings:             application.Findings,
 		Scanner:              application.Scanner,
 		Cache:                application.Cache,
+		ExecutionStore:       application.ExecutionStore,
 		Agents:               application.Agents,
 		Ticketing:            application.Ticketing,
 		Identity:             application.Identity,

--- a/internal/api/server_handlers_graph_intelligence_test.go
+++ b/internal/api/server_handlers_graph_intelligence_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -1250,6 +1249,55 @@ func TestPlatformIntelligenceReportRunRetrySync(t *testing.T) {
 	}
 }
 
+func waitForPlatformJobTerminalStatus(t *testing.T, s *Server, jobURL, wantStatus string) map[string]any {
+	t.Helper()
+	if strings.TrimSpace(jobURL) == "" {
+		t.Fatal("expected non-empty jobURL")
+	}
+	var latest map[string]any
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		resp := do(t, s, http.MethodGet, jobURL, nil)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("expected 200 for platform job lookup, got %d: %s", resp.Code, resp.Body.String())
+		}
+		latest = decodeJSON(t, resp)
+		status, _ := latest["status"].(string)
+		if status == wantStatus {
+			return latest
+		}
+		if status == "failed" || status == "canceled" {
+			t.Fatalf("expected platform job status %q, got terminal status %q: %#v", wantStatus, status, latest)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for platform job status %q, last payload: %#v", wantStatus, latest)
+	return nil
+}
+
+func waitForPlatformReportRunStatus(t *testing.T, s *Server, statusURL, wantStatus string) map[string]any {
+	t.Helper()
+	if strings.TrimSpace(statusURL) == "" {
+		t.Fatal("expected non-empty statusURL")
+	}
+	var latest map[string]any
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		resp := do(t, s, http.MethodGet, statusURL, nil)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("expected 200 for report run lookup, got %d: %s", resp.Code, resp.Body.String())
+		}
+		latest = decodeJSON(t, resp)
+		status, _ := latest["status"].(string)
+		if status == wantStatus {
+			return latest
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for report run status %q, last payload: %#v", wantStatus, latest)
+	return nil
+}
+
 func TestPlatformIntelligenceReportRunRetryAsyncIncludesBackoffMetadata(t *testing.T) {
 	s := newTestServer(t)
 	g := s.app.SecurityGraph
@@ -1291,26 +1339,13 @@ func TestPlatformIntelligenceReportRunRetryAsyncIncludesBackoffMetadata(t *testi
 		t.Fatalf("expected 202 for initial async run, got %d: %s", create.Code, create.Body.String())
 	}
 	created := decodeJSON(t, create)
+	jobURL, _ := created["job_status_url"].(string)
 	statusURL, _ := created["status_url"].(string)
-	if statusURL == "" {
-		t.Fatalf("expected status_url, got %#v", created["status_url"])
+	if statusURL == "" || jobURL == "" {
+		t.Fatalf("expected async run URLs, got status=%#v job=%#v", created["status_url"], created["job_status_url"])
 	}
-
-	var failedRun map[string]any
-	for i := 0; i < 600; i++ {
-		status := do(t, s, http.MethodGet, statusURL, nil)
-		if status.Code != http.StatusOK {
-			t.Fatalf("expected 200 for async run lookup, got %d: %s", status.Code, status.Body.String())
-		}
-		failedRun = decodeJSON(t, status)
-		if failedRun["status"] == reports.ReportRunStatusFailed {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if got := failedRun["status"]; got != reports.ReportRunStatusFailed {
-		t.Fatalf("expected initial async run to fail, got %#v", got)
-	}
+	waitForPlatformJobTerminalStatus(t, s, jobURL, "failed")
+	waitForPlatformReportRunStatus(t, s, statusURL, reports.ReportRunStatusFailed)
 
 	retry := do(t, s, http.MethodPost, statusURL+":retry", map[string]any{
 		"execution_mode": "async",
@@ -1325,11 +1360,15 @@ func TestPlatformIntelligenceReportRunRetryAsyncIncludesBackoffMetadata(t *testi
 		t.Fatalf("expected 202 for async retry, got %d: %s", retry.Code, retry.Body.String())
 	}
 	retried := decodeJSON(t, retry)
+	retryJobURL, _ := retried["job_status_url"].(string)
 	if got := retried["status"]; got != reports.ReportRunStatusQueued {
 		t.Fatalf("expected queued retry response, got %#v", got)
 	}
 	if got := retried["attempt_count"]; got != float64(2) {
 		t.Fatalf("expected attempt_count=2 after retry queue, got %#v", got)
+	}
+	if retryJobURL == "" {
+		t.Fatalf("expected retry job_status_url, got %#v", retried["job_status_url"])
 	}
 
 	attemptsResp := do(t, s, http.MethodGet, statusURL+"/attempts", nil)
@@ -1355,21 +1394,8 @@ func TestPlatformIntelligenceReportRunRetryAsyncIncludesBackoffMetadata(t *testi
 		t.Fatalf("expected scheduled second attempt status, got %#v", got)
 	}
 
-	var latest map[string]any
-	for i := 0; i < 600; i++ {
-		status := do(t, s, http.MethodGet, statusURL, nil)
-		if status.Code != http.StatusOK {
-			t.Fatalf("expected 200 for async retry lookup, got %d: %s", status.Code, status.Body.String())
-		}
-		latest = decodeJSON(t, status)
-		if latest["status"] == reports.ReportRunStatusSucceeded {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if got := latest["status"]; got != reports.ReportRunStatusSucceeded {
-		t.Fatalf("expected async retry to succeed, got %#v", got)
-	}
+	waitForPlatformJobTerminalStatus(t, s, retryJobURL, "succeeded")
+	latest := waitForPlatformReportRunStatus(t, s, statusURL, reports.ReportRunStatusSucceeded)
 	sections, ok := latest["sections"].([]any)
 	if !ok || len(sections) == 0 {
 		t.Fatalf("expected sections on retried run, got %#v", latest["sections"])
@@ -1952,6 +1978,9 @@ func TestPlatformIntelligenceReportRunLifecycleEvents(t *testing.T) {
 func TestPlatformReportRunUpdateRollsBackOnPersistenceFailure(t *testing.T) {
 	application := newTestApp(t)
 	s := NewServer(application)
+	if s.platformReportStore == nil {
+		t.Fatal("expected platformReportStore to be configured")
+	}
 	run := &reports.ReportRun{
 		ID:            "report_run:test-rollback",
 		ReportID:      "quality",
@@ -1964,13 +1993,12 @@ func TestPlatformReportRunUpdateRollsBackOnPersistenceFailure(t *testing.T) {
 		t.Fatalf("storePlatformReportRun() failed: %v", err)
 	}
 
-	stateDir := filepath.Dir(application.Config.ExecutionStoreFile)
-	if err := os.Chmod(stateDir, 0o500); err != nil {
-		t.Fatalf("chmod state dir read-only: %v", err)
+	// Force a deterministic persistence failure by making the underlying shared
+	// execution store unavailable, while leaving the in-memory cache intact so we
+	// can verify the update path does not partially mutate durable state.
+	if err := s.platformReportStore.Close(); err != nil {
+		t.Fatalf("platformReportStore.Close(): %v", err)
 	}
-	defer func() {
-		_ = os.Chmod(stateDir, 0o700)
-	}()
 
 	err := s.updatePlatformReportRun(run.ID, func(run *reports.ReportRun) {
 		run.Status = reports.ReportRunStatusRunning

--- a/internal/api/server_handlers_graph_intelligence_test.go
+++ b/internal/api/server_handlers_graph_intelligence_test.go
@@ -1996,8 +1996,11 @@ func TestPlatformReportRunUpdateRollsBackOnPersistenceFailure(t *testing.T) {
 	// Force a deterministic persistence failure by making the underlying shared
 	// execution store unavailable, while leaving the in-memory cache intact so we
 	// can verify the update path does not partially mutate durable state.
-	if err := s.platformReportStore.Close(); err != nil {
-		t.Fatalf("platformReportStore.Close(): %v", err)
+	if application.ExecutionStore == nil {
+		t.Fatal("expected shared execution store to be configured")
+	}
+	if err := application.ExecutionStore.Close(); err != nil {
+		t.Fatalf("ExecutionStore.Close(): %v", err)
 	}
 
 	err := s.updatePlatformReportRun(run.ID, func(run *reports.ReportRun) {

--- a/internal/api/server_handlers_graph_intelligence_test.go
+++ b/internal/api/server_handlers_graph_intelligence_test.go
@@ -1028,7 +1028,7 @@ func TestPlatformIntelligenceReportRunAsync(t *testing.T) {
 	}
 
 	var runBody map[string]any
-	for i := 0; i < 50; i++ {
+	for i := 0; i < 600; i++ {
 		runResp := do(t, s, http.MethodGet, statusURL, nil)
 		if runResp.Code != http.StatusOK {
 			t.Fatalf("expected 200 for async run lookup, got %d: %s", runResp.Code, runResp.Body.String())
@@ -1089,19 +1089,14 @@ func TestPlatformIntelligenceReportRunAsync(t *testing.T) {
 
 func TestPlatformIntelligenceReportRunStreamEmitsSections(t *testing.T) {
 	s := newTestServer(t)
-	original := s.platformReportHandlers["quality"]
-	s.platformReportHandlers["quality"] = func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(75 * time.Millisecond)
-		original(w, r)
-	}
 	server := httptest.NewServer(s)
 	defer server.Close()
 
 	createResp := doAuthenticatedHTTP(t, server.URL, http.MethodPost, "/api/v1/platform/intelligence/reports/quality/runs", map[string]any{
-		"execution_mode": "async",
+		"execution_mode": "sync",
 	}, nil)
-	if createResp.Code != http.StatusAccepted {
-		t.Fatalf("expected 202 for async run create, got %d: %s", createResp.Code, createResp.Body.String())
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for sync run create, got %d: %s", createResp.Code, createResp.Body.String())
 	}
 	createBody := decodeJSON(t, createResp)
 	statusURL, _ := createBody["status_url"].(string)
@@ -1302,7 +1297,7 @@ func TestPlatformIntelligenceReportRunRetryAsyncIncludesBackoffMetadata(t *testi
 	}
 
 	var failedRun map[string]any
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 600; i++ {
 		status := do(t, s, http.MethodGet, statusURL, nil)
 		if status.Code != http.StatusOK {
 			t.Fatalf("expected 200 for async run lookup, got %d: %s", status.Code, status.Body.String())
@@ -1361,7 +1356,7 @@ func TestPlatformIntelligenceReportRunRetryAsyncIncludesBackoffMetadata(t *testi
 	}
 
 	var latest map[string]any
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 600; i++ {
 		status := do(t, s, http.MethodGet, statusURL, nil)
 		if status.Code != http.StatusOK {
 			t.Fatalf("expected 200 for async retry lookup, got %d: %s", status.Code, status.Body.String())
@@ -1445,6 +1440,12 @@ func TestPlatformIntelligenceReportRunRetryRechecksMaxAttemptsInsideUpdate(t *te
 	stored.AttemptCount = len(stored.Attempts)
 	s.platformReportRuns[run.ID] = stored
 	s.platformReportRunMu.Unlock()
+	if s.platformReportStore != nil {
+		if err := s.platformReportStore.SaveRun(stored); err != nil {
+			s.platformReportSaveMu.Unlock()
+			t.Fatalf("SaveRun() failed: %v", err)
+		}
+	}
 	s.platformReportSaveMu.Unlock()
 
 	resp := <-done
@@ -1681,6 +1682,12 @@ func TestPlatformIntelligenceReportRunCancelDoesNotOverwriteSucceededRun(t *test
 	stored.AttemptCount = len(stored.Attempts)
 	s.platformReportRuns[run.ID] = stored
 	s.platformReportRunMu.Unlock()
+	if s.platformReportStore != nil {
+		if err := s.platformReportStore.SaveRun(stored); err != nil {
+			s.platformReportSaveMu.Unlock()
+			t.Fatalf("SaveRun() failed: %v", err)
+		}
+	}
 	s.platformReportSaveMu.Unlock()
 
 	resp := <-done
@@ -1957,7 +1964,7 @@ func TestPlatformReportRunUpdateRollsBackOnPersistenceFailure(t *testing.T) {
 		t.Fatalf("storePlatformReportRun() failed: %v", err)
 	}
 
-	stateDir := filepath.Dir(application.Config.PlatformReportRunStateFile)
+	stateDir := filepath.Dir(application.Config.ExecutionStoreFile)
 	if err := os.Chmod(stateDir, 0o500); err != nil {
 		t.Fatalf("chmod state dir read-only: %v", err)
 	}

--- a/internal/api/server_handlers_platform.go
+++ b/internal/api/server_handlers_platform.go
@@ -1443,17 +1443,13 @@ func (s *Server) storePlatformReportRun(run *reports.ReportRun) error {
 	}
 	s.platformReportSaveMu.Lock()
 	defer s.platformReportSaveMu.Unlock()
-	s.platformReportRunMu.Lock()
-	snapshot := s.clonePlatformReportRunsLocked()
-	s.platformReportRunMu.Unlock()
-	snapshot[run.ID] = reports.CloneReportRun(run)
-	if err := s.persistPlatformReportRuns(snapshot); err != nil {
-		return fmt.Errorf("persist report run %q: %w", run.ID, err)
+	if s.platformReportStore != nil {
+		if err := s.platformReportStore.SaveRun(run); err != nil {
+			return fmt.Errorf("persist report run %q: %w", run.ID, err)
+		}
 	}
 	s.syncPlatformJobWithReportRun(run)
-	s.platformReportRunMu.Lock()
-	s.platformReportRuns[run.ID] = reports.CloneReportRun(run)
-	s.platformReportRunMu.Unlock()
+	s.cachePlatformReportRun(run)
 	return nil
 }
 
@@ -1465,28 +1461,44 @@ func (s *Server) updatePlatformReportRun(runID string, apply func(*reports.Repor
 func (s *Server) updatePlatformReportRunSnapshot(runID string, apply func(*reports.ReportRun)) (*reports.ReportRun, error) {
 	s.platformReportSaveMu.Lock()
 	defer s.platformReportSaveMu.Unlock()
-	s.platformReportRunMu.Lock()
-	run, ok := s.platformReportRuns[runID]
-	if !ok {
-		s.platformReportRunMu.Unlock()
+	var (
+		run *reports.ReportRun
+		err error
+	)
+	if s.platformReportStore != nil {
+		run, err = s.platformReportStore.LoadRun(runID)
+		if err != nil {
+			return nil, fmt.Errorf("load report run %q: %w", runID, err)
+		}
+	}
+	if run == nil {
+		s.platformReportRunMu.RLock()
+		run = reports.CloneReportRun(s.platformReportRuns[runID])
+		s.platformReportRunMu.RUnlock()
+	}
+	if run == nil {
 		return nil, fmt.Errorf("report run not found: %s", runID)
 	}
 	updated := reports.CloneReportRun(run)
 	apply(updated)
-	snapshot := s.clonePlatformReportRunsLocked()
-	s.platformReportRunMu.Unlock()
-	snapshot[runID] = reports.CloneReportRun(updated)
-	if err := s.persistPlatformReportRuns(snapshot); err != nil {
-		return nil, fmt.Errorf("persist report run %q: %w", runID, err)
+	if s.platformReportStore != nil {
+		if err := s.platformReportStore.SaveRun(updated); err != nil {
+			return nil, fmt.Errorf("persist report run %q: %w", runID, err)
+		}
 	}
 	s.syncPlatformJobWithReportRun(updated)
-	s.platformReportRunMu.Lock()
-	s.platformReportRuns[runID] = reports.CloneReportRun(updated)
-	s.platformReportRunMu.Unlock()
+	s.cachePlatformReportRun(updated)
 	return reports.CloneReportRun(updated), nil
 }
 
 func (s *Server) platformReportRunSnapshot(reportID, runID string) (*reports.ReportRun, bool) {
+	if s.platformReportStore != nil {
+		run, err := s.platformReportStore.LoadRun(runID)
+		if err == nil && run != nil && run.ReportID == reportID {
+			s.cachePlatformReportRun(run)
+			return reports.CloneReportRun(run), true
+		}
+	}
 	s.platformReportRunMu.RLock()
 	defer s.platformReportRunMu.RUnlock()
 	run, ok := s.platformReportRuns[runID]
@@ -1558,6 +1570,26 @@ func (s *Server) syncPlatformJobWithReportRun(run *reports.ReportRun) {
 }
 
 func (s *Server) platformReportRunSummaries(reportID string) []reports.ReportRunSummary {
+	if s.platformReportStore != nil {
+		runs, err := s.platformReportStore.ListRuns(reportID)
+		if err == nil {
+			s.cachePlatformReportRuns(runs)
+			summaries := make([]reports.ReportRunSummary, 0, len(runs))
+			for _, run := range runs {
+				if run == nil {
+					continue
+				}
+				summaries = append(summaries, reports.SummarizeReportRun(*run))
+			}
+			sort.Slice(summaries, func(i, j int) bool {
+				if summaries[i].SubmittedAt.Equal(summaries[j].SubmittedAt) {
+					return summaries[i].ID > summaries[j].ID
+				}
+				return summaries[i].SubmittedAt.After(summaries[j].SubmittedAt)
+			})
+			return summaries
+		}
+	}
 	s.platformReportRunMu.RLock()
 	defer s.platformReportRunMu.RUnlock()
 	runs := make([]reports.ReportRunSummary, 0)
@@ -1583,11 +1615,22 @@ func (s *Server) reusablePlatformReportRun(reportID, cacheKey string, lineage re
 	if reportID == "" || cacheKey == "" {
 		return nil
 	}
-	s.platformReportRunMu.RLock()
-	defer s.platformReportRunMu.RUnlock()
-
+	candidates := make([]*reports.ReportRun, 0)
+	if s.platformReportStore != nil {
+		if storedRuns, err := s.platformReportStore.ListRuns(reportID); err == nil {
+			s.cachePlatformReportRuns(storedRuns)
+			candidates = append(candidates, storedRuns...)
+		}
+	}
+	if len(candidates) == 0 {
+		s.platformReportRunMu.RLock()
+		for _, candidate := range s.platformReportRuns {
+			candidates = append(candidates, reports.CloneReportRun(candidate))
+		}
+		s.platformReportRunMu.RUnlock()
+	}
 	var best *reports.ReportRun
-	for _, candidate := range s.platformReportRuns {
+	for _, candidate := range candidates {
 		if candidate == nil {
 			continue
 		}
@@ -1735,13 +1778,6 @@ func (s *Server) platformGraphSnapshot(snapshotID string) (*graph.GraphSnapshotR
 	}
 	snapshot := *record
 	return &snapshot, true
-}
-
-func (s *Server) persistPlatformReportRuns(runs map[string]*reports.ReportRun) error {
-	if s == nil || s.platformReportStore == nil {
-		return nil
-	}
-	return s.platformReportStore.SaveAll(runs)
 }
 
 func (s *Server) emitPlatformReportRunLifecycleEvent(ctx context.Context, eventType webhooks.EventType, reportID, runID string) {
@@ -2057,4 +2093,27 @@ func platformReportTriggerSurface(run *reports.ReportRun) string {
 		return strings.TrimSpace(attempt.TriggerSurface)
 	}
 	return "api.request"
+}
+
+func (s *Server) cachePlatformReportRun(run *reports.ReportRun) {
+	if s == nil || run == nil || strings.TrimSpace(run.ID) == "" {
+		return
+	}
+	s.platformReportRunMu.Lock()
+	s.platformReportRuns[run.ID] = reports.CloneReportRun(run)
+	s.platformReportRunMu.Unlock()
+}
+
+func (s *Server) cachePlatformReportRuns(runs []*reports.ReportRun) {
+	if s == nil || len(runs) == 0 {
+		return
+	}
+	s.platformReportRunMu.Lock()
+	defer s.platformReportRunMu.Unlock()
+	for _, run := range runs {
+		if run == nil || strings.TrimSpace(run.ID) == "" {
+			continue
+		}
+		s.platformReportRuns[run.ID] = reports.CloneReportRun(run)
+	}
 }

--- a/internal/api/server_handlers_platform_executions.go
+++ b/internal/api/server_handlers_platform_executions.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/writer/cerebro/internal/executions"
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+type platformExecutionCollection struct {
+	Count      int                  `json:"count"`
+	Executions []executions.Summary `json:"executions"`
+}
+
+func (s *Server) listPlatformExecutions(w http.ResponseWriter, r *http.Request) {
+	if s == nil || s.app == nil || s.app.Config == nil {
+		s.error(w, http.StatusInternalServerError, "platform execution store not configured")
+		return
+	}
+	store, err := executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
+	if err != nil {
+		s.error(w, http.StatusInternalServerError, "platform execution store unavailable")
+		return
+	}
+	defer func() { _ = store.Close() }()
+
+	limit := 50
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 || parsed > 200 {
+			s.error(w, http.StatusBadRequest, "limit must be between 1 and 200")
+			return
+		}
+		limit = parsed
+	}
+	offset := 0
+	if raw := strings.TrimSpace(r.URL.Query().Get("offset")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			s.error(w, http.StatusBadRequest, "offset must be >= 0")
+			return
+		}
+		offset = parsed
+	}
+	orderBySubmittedAt := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("order")), "submitted")
+	opts := executions.ListOptions{
+		Namespaces:         queryCSVValues(r, "namespace"),
+		Statuses:           queryCSVValues(r, "status"),
+		ExcludeStatuses:    queryCSVValues(r, "exclude_status"),
+		ReportID:           strings.TrimSpace(r.URL.Query().Get("report_id")),
+		Limit:              limit,
+		Offset:             offset,
+		OrderBySubmittedAt: orderBySubmittedAt,
+	}
+	summaries, err := executions.List(r.Context(), store, opts)
+	if err != nil {
+		s.error(w, http.StatusInternalServerError, "failed to list platform executions")
+		return
+	}
+	s.json(w, http.StatusOK, platformExecutionCollection{
+		Count:      len(summaries),
+		Executions: summaries,
+	})
+}
+
+func queryCSVValues(r *http.Request, key string) []string {
+	if r == nil {
+		return nil
+	}
+	rawValues := r.URL.Query()[key]
+	if len(rawValues) == 0 {
+		return nil
+	}
+	values := make([]string, 0, len(rawValues))
+	seen := make(map[string]struct{}, len(rawValues))
+	for _, raw := range rawValues {
+		for _, part := range strings.Split(raw, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			if _, ok := seen[part]; ok {
+				continue
+			}
+			seen[part] = struct{}{}
+			values = append(values, part)
+		}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}

--- a/internal/api/server_handlers_platform_executions.go
+++ b/internal/api/server_handlers_platform_executions.go
@@ -19,13 +19,16 @@ func (s *Server) listPlatformExecutions(w http.ResponseWriter, r *http.Request) 
 		s.error(w, http.StatusInternalServerError, "platform execution store not configured")
 		return
 	}
-	store, err := executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
-	if err != nil {
-		s.error(w, http.StatusInternalServerError, "platform execution store unavailable")
-		return
+	store := s.app.ExecutionStore
+	if store == nil {
+		var err error
+		store, err = executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
+		if err != nil {
+			s.error(w, http.StatusInternalServerError, "platform execution store unavailable")
+			return
+		}
+		defer func() { _ = store.Close() }()
 	}
-	defer func() { _ = store.Close() }()
-
 	limit := 50
 	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
 		parsed, err := strconv.Atoi(raw)

--- a/internal/api/server_handlers_platform_graph_snapshots.go
+++ b/internal/api/server_handlers_platform_graph_snapshots.go
@@ -470,6 +470,27 @@ func (s *Server) platformGraphSnapshotRecords() map[string]*graph.GraphSnapshotR
 }
 
 func (s *Server) platformReportRunSnapshotMap() map[string]*reports.ReportRun {
+	if s.platformReportStore != nil {
+		runs, err := s.platformReportStore.ListRuns("")
+		if err == nil {
+			records := make(map[string]*reports.ReportRun, len(runs))
+			for _, run := range runs {
+				if run == nil || strings.TrimSpace(run.ID) == "" {
+					continue
+				}
+				records[run.ID] = reports.CloneReportRun(run)
+			}
+			s.platformReportRunMu.RLock()
+			for id, run := range s.platformReportRuns {
+				if run == nil {
+					continue
+				}
+				records[id] = reports.CloneReportRun(run)
+			}
+			s.platformReportRunMu.RUnlock()
+			return records
+		}
+	}
 	s.platformReportRunMu.RLock()
 	defer s.platformReportRunMu.RUnlock()
 	return s.clonePlatformReportRunsLocked()

--- a/internal/api/server_handlers_platform_stream.go
+++ b/internal/api/server_handlers_platform_stream.go
@@ -115,6 +115,17 @@ func (s *Server) streamPlatformIntelligenceReportRun(w http.ResponseWriter, r *h
 	}
 	s.writePlatformReportStreamEvent(w, "ready", ready)
 	flusher.Flush()
+	for _, message := range s.platformReportStreamReplayMessages(run) {
+		eventName := "message"
+		switch message.Type {
+		case "lifecycle":
+			eventName = "lifecycle"
+		case "section":
+			eventName = "section"
+		}
+		s.writePlatformReportStreamEvent(w, eventName, message)
+		flusher.Flush()
+	}
 
 	keepAlive := time.NewTicker(15 * time.Second)
 	defer keepAlive.Stop()
@@ -138,6 +149,55 @@ func (s *Server) streamPlatformIntelligenceReportRun(w http.ResponseWriter, r *h
 			flusher.Flush()
 		}
 	}
+}
+
+func (s *Server) platformReportStreamReplayMessages(run *reports.ReportRun) []platformReportStreamMessage {
+	if run == nil {
+		return nil
+	}
+	switch run.Status {
+	case reports.ReportRunStatusSucceeded, reports.ReportRunStatusFailed, reports.ReportRunStatusCanceled:
+	default:
+		return nil
+	}
+	if len(run.Sections) == 0 {
+		return nil
+	}
+	emittedAt := time.Now().UTC()
+	if run.CompletedAt != nil {
+		emittedAt = run.CompletedAt.UTC()
+	} else if run.StartedAt != nil {
+		emittedAt = run.StartedAt.UTC()
+	}
+	emissions := reports.BuildReportSectionEmissionsFromResults(run.Sections, run.Result, emittedAt)
+	messages := make([]platformReportStreamMessage, 0, len(emissions))
+	for _, emission := range emissions {
+		data := map[string]any{
+			"status_url":    run.StatusURL,
+			"snapshot_id":   reportSnapshotID(run),
+			"section_key":   emission.Section.Key,
+			"envelope_kind": emission.Section.EnvelopeKind,
+			"content_type":  emission.Section.ContentType,
+			"item_count":    emission.Section.ItemCount,
+			"field_count":   emission.Section.FieldCount,
+		}
+		for key, value := range platformReportSectionMetadataPayload(emission.Section) {
+			data[key] = value
+		}
+		emissionCopy := reports.CloneReportSectionEmissions([]reports.ReportSectionEmission{emission})[0]
+		messages = append(messages, platformReportStreamMessage{
+			Type:      "section",
+			RunID:     run.ID,
+			ReportID:  run.ReportID,
+			Status:    run.Status,
+			EventType: string(webhooks.EventPlatformReportSectionEmitted),
+			Timestamp: emissionCopy.EmittedAt,
+			Progress:  emissionCopy.ProgressPercent,
+			Data:      data,
+			Section:   &emissionCopy,
+		})
+	}
+	return messages
 }
 
 func (s *Server) writePlatformReportStreamEvent(w http.ResponseWriter, event string, payload platformReportStreamMessage) {

--- a/internal/api/server_handlers_platform_test.go
+++ b/internal/api/server_handlers_platform_test.go
@@ -1,11 +1,15 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/graph"
+	reports "github.com/writer/cerebro/internal/graph/reports"
+	"github.com/writer/cerebro/internal/workloadscan"
 )
 
 func TestSecurityAttackPathJobAndPlatformJobStatus(t *testing.T) {
@@ -53,5 +57,133 @@ func TestSecurityAttackPathJobAndPlatformJobStatus(t *testing.T) {
 	}
 	if count, ok := result["total_paths"].(float64); !ok || count < 1 {
 		t.Fatalf("expected at least one attack path, got %#v", result["total_paths"])
+	}
+}
+
+func TestPlatformExecutionsListsSharedExecutionStoreRuns(t *testing.T) {
+	s := newTestServer(t)
+
+	reportRun := &reports.ReportRun{
+		ID:            "report_run:test-execution-list",
+		ReportID:      "quality",
+		Status:        reports.ReportRunStatusSucceeded,
+		ExecutionMode: reports.ReportExecutionModeSync,
+		SubmittedAt:   time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC),
+		RequestedBy:   "alice",
+		StatusURL:     "/api/v1/platform/intelligence/reports/quality/runs/report_run:test-execution-list",
+	}
+	reportStartedAt := time.Date(2026, 3, 12, 9, 0, 5, 0, time.UTC)
+	reportCompletedAt := time.Date(2026, 3, 12, 9, 0, 10, 0, time.UTC)
+	reportRun.StartedAt = &reportStartedAt
+	reportRun.CompletedAt = &reportCompletedAt
+	if err := s.storePlatformReportRun(reportRun); err != nil {
+		t.Fatalf("storePlatformReportRun: %v", err)
+	}
+
+	sharedStore, err := executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = sharedStore.Close() }()
+
+	workloadRun := workloadscan.RunRecord{
+		ID:          "workload_scan:test-execution-list",
+		Provider:    workloadscan.ProviderAWS,
+		Status:      workloadscan.RunStatusRunning,
+		Stage:       workloadscan.RunStageAnalyze,
+		Target:      workloadscan.VMTarget{Provider: workloadscan.ProviderAWS, Region: "us-east-1", InstanceID: "i-123"},
+		RequestedBy: "bob",
+		SubmittedAt: time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 3, 12, 10, 0, 30, 0, time.UTC),
+	}
+	workloadPayload, err := json.Marshal(workloadRun)
+	if err != nil {
+		t.Fatalf("marshal workload run: %v", err)
+	}
+	if err := sharedStore.UpsertRun(t.Context(), executionstore.RunEnvelope{
+		Namespace:   executionstore.NamespaceWorkloadScan,
+		RunID:       workloadRun.ID,
+		Kind:        string(workloadRun.Provider),
+		Status:      string(workloadRun.Status),
+		Stage:       string(workloadRun.Stage),
+		SubmittedAt: workloadRun.SubmittedAt,
+		UpdatedAt:   workloadRun.UpdatedAt,
+		Payload:     workloadPayload,
+	}); err != nil {
+		t.Fatalf("UpsertRun workload: %v", err)
+	}
+
+	resp := do(t, s, http.MethodGet, "/api/v1/platform/executions?namespace=report_run,workload_scan&order=submitted", nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	body := decodeJSON(t, resp)
+	if got := int(body["count"].(float64)); got != 2 {
+		t.Fatalf("expected 2 executions, got %#v", body)
+	}
+	executions, ok := body["executions"].([]any)
+	if !ok || len(executions) != 2 {
+		t.Fatalf("expected executions array, got %#v", body["executions"])
+	}
+	first := executions[0].(map[string]any)
+	if first["namespace"] != executionstore.NamespaceWorkloadScan {
+		t.Fatalf("expected workload scan first when ordered by submitted time, got %#v", first)
+	}
+	second := executions[1].(map[string]any)
+	if second["namespace"] != executionstore.NamespacePlatformReportRun {
+		t.Fatalf("expected report run second, got %#v", second)
+	}
+
+	filtered := do(t, s, http.MethodGet, "/api/v1/platform/executions?namespace=report_run&report_id=quality", nil)
+	if filtered.Code != http.StatusOK {
+		t.Fatalf("expected 200 for report-only listing, got %d: %s", filtered.Code, filtered.Body.String())
+	}
+	filteredBody := decodeJSON(t, filtered)
+	if got := int(filteredBody["count"].(float64)); got != 1 {
+		t.Fatalf("expected one filtered execution, got %#v", filteredBody)
+	}
+}
+
+func TestPlatformGraphSnapshotRecordsIncludePersistedReportRuns(t *testing.T) {
+	s := newTestServer(t)
+	builtAt := time.Date(2026, 3, 12, 11, 0, 0, 0, time.UTC)
+	s.app.SecurityGraph.SetMetadata(graph.Metadata{
+		BuiltAt:   builtAt,
+		NodeCount: 1,
+		EdgeCount: 0,
+	})
+
+	run := &reports.ReportRun{
+		ID:            "report_run:graph-snapshot-persisted",
+		ReportID:      "quality",
+		Status:        reports.ReportRunStatusSucceeded,
+		ExecutionMode: reports.ReportExecutionModeSync,
+		SubmittedAt:   builtAt.Add(5 * time.Minute),
+		RequestedBy:   "alice",
+		Lineage: reports.ReportLineage{
+			GraphSnapshotID:         "graph_snapshot:historic",
+			GraphSchemaVersion:      3,
+			OntologyContractVersion: "2026-03-12",
+			GraphBuiltAt:            &builtAt,
+		},
+	}
+	if err := s.storePlatformReportRun(run); err != nil {
+		t.Fatalf("storePlatformReportRun: %v", err)
+	}
+
+	s.platformReportRunMu.Lock()
+	s.platformReportRuns = map[string]*reports.ReportRun{}
+	s.platformReportRunMu.Unlock()
+
+	records := s.platformGraphSnapshotRecords()
+	record, ok := records["graph_snapshot:historic"]
+	if !ok || record == nil {
+		t.Fatalf("expected persisted report-run lineage snapshot to be present, got %#v", records)
+	}
+	if got := record.ObservedRunCount; got < 1 {
+		t.Fatalf("expected observed run count from persisted report run, got %#v", got)
+	}
+	if len(record.ObservedReportIDs) == 0 || record.ObservedReportIDs[0] != "quality" {
+		t.Fatalf("expected observed report id to include quality, got %#v", record.ObservedReportIDs)
 	}
 }

--- a/internal/api/server_handlers_platform_test.go
+++ b/internal/api/server_handlers_platform_test.go
@@ -80,11 +80,10 @@ func TestPlatformExecutionsListsSharedExecutionStoreRuns(t *testing.T) {
 		t.Fatalf("storePlatformReportRun: %v", err)
 	}
 
-	sharedStore, err := executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
-	if err != nil {
-		t.Fatalf("NewSQLiteStore: %v", err)
+	sharedStore := s.app.ExecutionStore
+	if sharedStore == nil {
+		t.Fatal("expected shared execution store")
 	}
-	defer func() { _ = sharedStore.Close() }()
 
 	workloadRun := workloadscan.RunRecord{
 		ID:          "workload_scan:test-execution-list",

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -351,6 +351,7 @@ func (s *Server) setupRoutes() {
 
 		// Shared platform primitives
 		r.Route("/platform", func(r chi.Router) {
+			r.Get("/executions", s.listPlatformExecutions)
 			r.Get("/entities", s.listPlatformEntities)
 			r.Get("/entities/search", s.searchPlatformEntities)
 			r.Get("/entities/suggest", s.suggestPlatformEntities)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -51,6 +51,7 @@ import (
 	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/dspm"
 	"github.com/writer/cerebro/internal/events"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/graph/builders"
@@ -90,13 +91,14 @@ type App struct {
 	Logger *slog.Logger
 
 	// Core services
-	Snowflake *snowflake.Client
-	Warehouse warehouse.DataWarehouse
-	Policy    *policy.Engine
-	Findings  findings.FindingStore
-	Scanner   *scanner.Scanner
-	DSPM      *dspm.Scanner
-	Cache     *cache.PolicyCache
+	Snowflake      *snowflake.Client
+	Warehouse      warehouse.DataWarehouse
+	Policy         *policy.Engine
+	Findings       findings.FindingStore
+	Scanner        *scanner.Scanner
+	DSPM           *dspm.Scanner
+	Cache          *cache.PolicyCache
+	ExecutionStore executionstore.Store
 
 	// Feature services
 	Agents         *agents.AgentRegistry

--- a/internal/app/app_cerebro_tools.go
+++ b/internal/app/app_cerebro_tools.go
@@ -186,6 +186,41 @@ func (a *App) cerebroTools() []agents.Tool {
 			Handler: a.toolCerebroGraphQueryTemplates,
 		},
 		{
+			Name:        "cerebro.execution_status",
+			Description: "List recent shared-platform executions across report runs, scans, and action workflows",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"namespace": map[string]any{
+						"type":        "array",
+						"description": "Optional execution namespaces to filter, for example report_run, workload_scan, image_scan, function_scan, action_engine.",
+						"items":       map[string]any{"type": "string"},
+					},
+					"status": map[string]any{
+						"type":        "array",
+						"description": "Optional execution statuses to include.",
+						"items":       map[string]any{"type": "string"},
+					},
+					"report_id": map[string]any{
+						"type":        "string",
+						"description": "Optional report definition ID filter for report executions.",
+					},
+					"limit": map[string]any{
+						"type":        "integer",
+						"description": "Maximum executions to return (1-100).",
+						"default":     20,
+					},
+					"order": map[string]any{
+						"type":        "string",
+						"description": "Sort order: updated or submitted.",
+						"enum":        []string{"updated", "submitted"},
+						"default":     "updated",
+					},
+				},
+			},
+			Handler: a.toolCerebroExecutionStatus,
+		},
+		{
 			Name:        "cerebro.graph_changelog",
 			Description: "Inspect recent graph snapshot changes or one stored/derived graph diff in detail",
 			Parameters: map[string]any{

--- a/internal/app/app_cerebro_tools_executions.go
+++ b/internal/app/app_cerebro_tools_executions.go
@@ -30,12 +30,15 @@ func (a *App) toolCerebroExecutionStatus(ctx context.Context, args json.RawMessa
 	if limit > 100 {
 		return "", fmt.Errorf("limit must be <= 100")
 	}
-	store, err := executionstore.NewSQLiteStore(a.Config.ExecutionStoreFile)
-	if err != nil {
-		return "", fmt.Errorf("open shared execution store: %w", err)
+	store := a.ExecutionStore
+	if store == nil {
+		var err error
+		store, err = executionstore.NewSQLiteStore(a.Config.ExecutionStoreFile)
+		if err != nil {
+			return "", fmt.Errorf("open shared execution store: %w", err)
+		}
+		defer func() { _ = store.Close() }()
 	}
-	defer func() { _ = store.Close() }()
-
 	summaries, err := executions.List(ctx, store, executions.ListOptions{
 		Namespaces:         req.Namespace,
 		Statuses:           req.Status,

--- a/internal/app/app_cerebro_tools_executions.go
+++ b/internal/app/app_cerebro_tools_executions.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/writer/cerebro/internal/executions"
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+func (a *App) toolCerebroExecutionStatus(ctx context.Context, args json.RawMessage) (string, error) {
+	if a == nil || a.Config == nil {
+		return "", fmt.Errorf("app config not initialized")
+	}
+	var req struct {
+		Namespace []string `json:"namespace,omitempty"`
+		Status    []string `json:"status,omitempty"`
+		ReportID  string   `json:"report_id,omitempty"`
+		Limit     int      `json:"limit,omitempty"`
+		Order     string   `json:"order,omitempty"`
+	}
+	if err := decodeToolArgs(args, &req); err != nil {
+		return "", err
+	}
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		return "", fmt.Errorf("limit must be <= 100")
+	}
+	store, err := executionstore.NewSQLiteStore(a.Config.ExecutionStoreFile)
+	if err != nil {
+		return "", fmt.Errorf("open shared execution store: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	summaries, err := executions.List(ctx, store, executions.ListOptions{
+		Namespaces:         req.Namespace,
+		Statuses:           req.Status,
+		ReportID:           req.ReportID,
+		Limit:              limit,
+		OrderBySubmittedAt: req.Order == "submitted",
+	})
+	if err != nil {
+		return "", err
+	}
+	return marshalToolResponse(map[string]any{
+		"count":      len(summaries),
+		"executions": summaries,
+	})
+}

--- a/internal/app/app_cerebro_tools_test.go
+++ b/internal/app/app_cerebro_tools_test.go
@@ -849,7 +849,10 @@ func TestCerebroExecutionStatusTool(t *testing.T) {
 		t.Fatalf("UpsertRun: %v", err)
 	}
 
-	application := &App{Config: &Config{ExecutionStoreFile: filepath.Join(dir, "executions.db")}}
+	application := &App{
+		Config:         &Config{ExecutionStoreFile: filepath.Join(dir, "executions.db")},
+		ExecutionStore: store,
+	}
 	tool := findCerebroTool(application.AgentSDKTools(), "cerebro.execution_status")
 	if tool == nil {
 		t.Fatal("expected cerebro.execution_status tool")

--- a/internal/app/app_cerebro_tools_test.go
+++ b/internal/app/app_cerebro_tools_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/writer/cerebro/internal/agents"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/imagescan"
 	"github.com/writer/cerebro/internal/policy"
 )
 
@@ -808,6 +811,68 @@ func TestCerebroWriteClaimTool(t *testing.T) {
 	conflicts, ok := payload["conflicts_detected"].([]any)
 	if !ok || len(conflicts) == 0 {
 		t.Fatalf("expected conflicts_detected, got %#v", payload["conflicts_detected"])
+	}
+}
+
+func TestCerebroExecutionStatusTool(t *testing.T) {
+	dir := t.TempDir()
+	store, err := executionstore.NewSQLiteStore(filepath.Join(dir, "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	run := imagescan.RunRecord{
+		ID:          "image_scan:test-tool",
+		Registry:    imagescan.RegistryECR,
+		Status:      imagescan.RunStatusRunning,
+		Stage:       imagescan.RunStageAnalyze,
+		Target:      imagescan.ScanTarget{Registry: imagescan.RegistryECR, Repository: "payments/app", Tag: "latest"},
+		RequestedBy: "alice",
+		SubmittedAt: time.Date(2026, 3, 12, 8, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 3, 12, 8, 1, 0, 0, time.UTC),
+	}
+	payload, err := json.Marshal(run)
+	if err != nil {
+		t.Fatalf("marshal image run: %v", err)
+	}
+	if err := store.UpsertRun(context.Background(), executionstore.RunEnvelope{
+		Namespace:   executionstore.NamespaceImageScan,
+		RunID:       run.ID,
+		Kind:        string(run.Registry),
+		Status:      string(run.Status),
+		Stage:       string(run.Stage),
+		SubmittedAt: run.SubmittedAt,
+		UpdatedAt:   run.UpdatedAt,
+		Payload:     payload,
+	}); err != nil {
+		t.Fatalf("UpsertRun: %v", err)
+	}
+
+	application := &App{Config: &Config{ExecutionStoreFile: filepath.Join(dir, "executions.db")}}
+	tool := findCerebroTool(application.AgentSDKTools(), "cerebro.execution_status")
+	if tool == nil {
+		t.Fatal("expected cerebro.execution_status tool")
+	}
+	result, err := tool.Handler(context.Background(), json.RawMessage(`{"namespace":["image_scan"],"limit":5}`))
+	if err != nil {
+		t.Fatalf("execution_status returned error: %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal([]byte(result), &body); err != nil {
+		t.Fatalf("decode tool payload: %v", err)
+	}
+	if got := int(body["count"].(float64)); got != 1 {
+		t.Fatalf("expected one execution, got %#v", body)
+	}
+	execs, ok := body["executions"].([]any)
+	if !ok || len(execs) != 1 {
+		t.Fatalf("expected executions array, got %#v", body["executions"])
+	}
+	entry := execs[0].(map[string]any)
+	if entry["namespace"] != executionstore.NamespaceImageScan {
+		t.Fatalf("expected image_scan namespace, got %#v", entry)
 	}
 }
 

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -324,6 +324,10 @@ type Config struct {
 	NATSConsumerInProgressInterval      time.Duration
 	NATSConsumerDrainTimeout            time.Duration
 	NATSConsumerDeadLetterPath          string
+	NATSConsumerDedupEnabled            bool
+	NATSConsumerDedupStateFile          string
+	NATSConsumerDedupTTL                time.Duration
+	NATSConsumerDedupMaxRecords         int
 	NATSConsumerDropHealthLookback      time.Duration
 	NATSConsumerDropHealthThreshold     int
 	NATSConsumerGraphStalenessThreshold time.Duration
@@ -679,6 +683,10 @@ func LoadConfig() *Config {
 			NATSConsumerInProgressInterval:      getEnvDuration("NATS_CONSUMER_IN_PROGRESS_INTERVAL", 15*time.Second),
 			NATSConsumerDrainTimeout:            getEnvDuration("NATS_CONSUMER_DRAIN_TIMEOUT", 30*time.Second),
 			NATSConsumerDeadLetterPath:          getEnv("NATS_CONSUMER_DEAD_LETTER_PATH", filepath.Join(findings.DefaultFilePath(), "nats-consumer.dlq.jsonl")),
+			NATSConsumerDedupEnabled:            getEnvBool("NATS_CONSUMER_DEDUP_ENABLED", true),
+			NATSConsumerDedupStateFile:          getEnv("NATS_CONSUMER_DEDUP_STATE_FILE", getEnv("EXECUTION_STORE_FILE", filepath.Join(".cerebro", "executions.db"))),
+			NATSConsumerDedupTTL:                getEnvDuration("NATS_CONSUMER_DEDUP_TTL", 24*time.Hour),
+			NATSConsumerDedupMaxRecords:         getEnvInt("NATS_CONSUMER_DEDUP_MAX_RECORDS", 100000),
 			NATSConsumerDropHealthLookback:      getEnvDuration("NATS_CONSUMER_DROP_HEALTH_LOOKBACK", 5*time.Minute),
 			NATSConsumerDropHealthThreshold:     getEnvInt("NATS_CONSUMER_DROP_HEALTH_THRESHOLD", 1),
 			NATSConsumerGraphStalenessThreshold: getEnvDuration("NATS_CONSUMER_GRAPH_STALENESS_THRESHOLD", 15*time.Minute),

--- a/internal/app/app_config_validation.go
+++ b/internal/app/app_config_validation.go
@@ -100,7 +100,7 @@ func ConfigValidationRules() []ConfigValidationRule {
 				"NATS_CONSUMER_DROP_HEALTH_THRESHOLD",
 				"NATS_CONSUMER_GRAPH_STALENESS_THRESHOLD",
 			},
-			Summary:  "when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative",
+			Summary:  "when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled",
 			Category: "dependency",
 		},
 		{
@@ -241,6 +241,17 @@ func (c *Config) Validate() error {
 		}
 		if c.NATSConsumerDropHealthThreshold < 0 {
 			problems = addConfigProblem(problems, "NATS_CONSUMER_DROP_HEALTH_THRESHOLD must be >= 0 when NATS_CONSUMER_ENABLED=true")
+		}
+		if c.NATSConsumerDedupEnabled {
+			if strings.TrimSpace(c.NATSConsumerDedupStateFile) == "" {
+				problems = addConfigProblem(problems, "NATS_CONSUMER_DEDUP_STATE_FILE is required when NATS_CONSUMER_DEDUP_ENABLED=true")
+			}
+			if c.NATSConsumerDedupTTL <= 0 {
+				problems = addConfigProblem(problems, "NATS_CONSUMER_DEDUP_TTL must be > 0 when NATS_CONSUMER_DEDUP_ENABLED=true")
+			}
+			if c.NATSConsumerDedupMaxRecords <= 0 {
+				problems = addConfigProblem(problems, "NATS_CONSUMER_DEDUP_MAX_RECORDS must be > 0 when NATS_CONSUMER_DEDUP_ENABLED=true")
+			}
 		}
 		if c.NATSConsumerGraphStalenessThreshold <= 0 {
 			problems = addConfigProblem(problems, "NATS_CONSUMER_GRAPH_STALENESS_THRESHOLD must be > 0 when NATS_CONSUMER_ENABLED=true")

--- a/internal/app/app_execution_store.go
+++ b/internal/app/app_execution_store.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+func (a *App) initExecutionStore() {
+	if a == nil || a.Config == nil {
+		return
+	}
+	path := strings.TrimSpace(a.Config.ExecutionStoreFile)
+	if path == "" {
+		return
+	}
+	store, err := executionstore.NewSQLiteStore(path)
+	if err != nil {
+		if a.Logger != nil {
+			a.Logger.Warn("failed to initialize shared execution store", "error", err, "path", path)
+		}
+		return
+	}
+	a.ExecutionStore = store
+	if a.Logger != nil {
+		a.Logger.Info("shared execution store initialized", "path", path)
+	}
+}
+
+func (a *App) executionStoreForPath(path string) executionstore.Store {
+	if a == nil || a.ExecutionStore == nil || a.Config == nil {
+		return nil
+	}
+	if sameExecutionStorePath(a.Config.ExecutionStoreFile, path) {
+		return a.ExecutionStore
+	}
+	return nil
+}
+
+func sameExecutionStorePath(left, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	leftAbs, leftErr := filepath.Abs(filepath.Clean(left))
+	rightAbs, rightErr := filepath.Abs(filepath.Clean(right))
+	if leftErr == nil && rightErr == nil {
+		return leftAbs == rightAbs
+	}
+	return filepath.Clean(left) == filepath.Clean(right)
+}

--- a/internal/app/app_graph_updates.go
+++ b/internal/app/app_graph_updates.go
@@ -130,7 +130,7 @@ func (a *App) maybeStartGraphConsistencyCheck(trigger string, summary graph.Grap
 	a.graphConsistencyCancel = cancel
 	a.graphConsistencyMu.Unlock()
 
-	go func() {
+	go func(checkCtx context.Context, cancel context.CancelFunc) {
 		defer a.graphConsistencyWG.Done()
 		defer func() {
 			a.graphConsistencyMu.Lock()
@@ -174,7 +174,7 @@ func (a *App) maybeStartGraphConsistencyCheck(trigger string, summary graph.Grap
 			"edges_added", len(diff.EdgesAdded),
 			"edges_removed", len(diff.EdgesRemoved),
 		)
-	}()
+	}(checkCtx, cancel)
 }
 
 func graphDiffHasChanges(diff *graph.GraphDiff) bool {

--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -54,6 +54,8 @@ func (a *App) initPhase1(ctx context.Context) error {
 }
 
 func (a *App) initPhase2a(ctx context.Context) error {
+	a.initExecutionStore()
+
 	if err := runInitTasksConcurrently(ctx, []concurrentInitTask{
 		{name: "cache", run: func(context.Context) { a.initCache() }},
 		{name: "ticketing", run: func(taskCtx context.Context) { a.initTicketing(taskCtx) }},

--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -22,6 +22,9 @@ import (
 )
 
 func (a *App) newSharedActionExecutor() *actionengine.Executor {
+	if a != nil && a.ExecutionStore != nil {
+		return actionengine.NewExecutor(actionengine.NewSQLiteStoreWithExecutionStore(a.ExecutionStore, actionengine.DefaultNamespace))
+	}
 	store, err := actionengine.NewSQLiteStore(a.Config.ExecutionStoreFile, actionengine.DefaultNamespace)
 	if err != nil {
 		a.Logger.Warn("failed to initialize shared action execution store; falling back to in-memory", "error", err, "path", a.Config.ExecutionStoreFile)

--- a/internal/app/app_storage_graph.go
+++ b/internal/app/app_storage_graph.go
@@ -294,6 +294,11 @@ func (a *App) Close() error {
 			errs = append(errs, fmt.Errorf("alert router: %w", err))
 		}
 	}
+	if a.ExecutionStore != nil {
+		if err := a.ExecutionStore.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("execution store: %w", err))
+		}
+	}
 
 	// Close findings store if it implements io.Closer (e.g., SQLiteStore)
 	if closer, ok := a.Findings.(interface{ Close() error }); ok {

--- a/internal/app/app_stream_consumer.go
+++ b/internal/app/app_stream_consumer.go
@@ -42,6 +42,10 @@ func (a *App) initTapGraphConsumer(ctx context.Context) {
 		FetchTimeout:          a.Config.NATSConsumerFetchTimeout,
 		InProgressInterval:    a.Config.NATSConsumerInProgressInterval,
 		DeadLetterPath:        a.Config.NATSConsumerDeadLetterPath,
+		DedupEnabled:          a.Config.NATSConsumerDedupEnabled,
+		DedupStateFile:        a.Config.NATSConsumerDedupStateFile,
+		DedupTTL:              a.Config.NATSConsumerDedupTTL,
+		DedupMaxRecords:       a.Config.NATSConsumerDedupMaxRecords,
 		DropHealthLookback:    a.Config.NATSConsumerDropHealthLookback,
 		DropHealthThreshold:   a.Config.NATSConsumerDropHealthThreshold,
 		ConnectTimeout:        a.Config.NATSJetStreamConnectTimeout,
@@ -104,6 +108,7 @@ func (a *App) initTapGraphConsumer(ctx context.Context) {
 		"subject", subject,
 		"durable", a.Config.NATSConsumerDurable,
 		"batch_size", a.Config.NATSConsumerBatchSize,
+		"dedupe_enabled", a.Config.NATSConsumerDedupEnabled,
 	)
 
 	_ = ctx

--- a/internal/app/app_stream_consumer.go
+++ b/internal/app/app_stream_consumer.go
@@ -44,6 +44,7 @@ func (a *App) initTapGraphConsumer(ctx context.Context) {
 		DeadLetterPath:        a.Config.NATSConsumerDeadLetterPath,
 		DedupEnabled:          a.Config.NATSConsumerDedupEnabled,
 		DedupStateFile:        a.Config.NATSConsumerDedupStateFile,
+		DedupStore:            a.executionStoreForPath(a.Config.NATSConsumerDedupStateFile),
 		DedupTTL:              a.Config.NATSConsumerDedupTTL,
 		DedupMaxRecords:       a.Config.NATSConsumerDedupMaxRecords,
 		DropHealthLookback:    a.Config.NATSConsumerDropHealthLookback,

--- a/internal/app/app_workload_scan_graph.go
+++ b/internal/app/app_workload_scan_graph.go
@@ -16,9 +16,17 @@ func (a *App) materializePersistedWorkloadScans(ctx context.Context, g *graph.Gr
 	if storePath == "" {
 		return workloadscan.GraphMaterializationResult{}, nil
 	}
-	store, err := workloadscan.NewSQLiteRunStore(storePath)
-	if err != nil {
-		return workloadscan.GraphMaterializationResult{}, err
+	var (
+		store workloadscan.RunStore
+		err   error
+	)
+	if shared := a.executionStoreForPath(storePath); shared != nil {
+		store = workloadscan.NewSQLiteRunStoreWithExecutionStore(shared)
+	} else {
+		store, err = workloadscan.NewSQLiteRunStore(storePath)
+		if err != nil {
+			return workloadscan.GraphMaterializationResult{}, err
+		}
 	}
 	defer func() { _ = store.Close() }()
 

--- a/internal/apptest/apptest.go
+++ b/internal/apptest/apptest.go
@@ -43,6 +43,7 @@ func NewConfig(t *testing.T) *app.Config {
 	return &app.Config{
 		LogLevel:                   "error",
 		Port:                       0,
+		ExecutionStoreFile:         filepath.Join(reportStateDir, "executions.db"),
 		PlatformReportRunStateFile: filepath.Join(reportStateDir, "state.json"),
 		PlatformReportSnapshotPath: filepath.Join(reportStateDir, "snapshots"),
 	}

--- a/internal/apptest/apptest.go
+++ b/internal/apptest/apptest.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/attackpath"
 	"github.com/writer/cerebro/internal/auth"
 	"github.com/writer/cerebro/internal/cache"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/health"
@@ -64,8 +65,12 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 	pe := policy.NewEngine()
 	fs := findings.NewStore()
 	sc := scanner.NewScanner(pe, scanner.ScanConfig{Workers: 2}, logger)
+	executionStore, err := executionstore.NewSQLiteStore(cfg.ExecutionStoreFile)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
 
-	return &app.App{
+	application := &app.App{
 		Config:         cfg,
 		Logger:         logger,
 		Warehouse:      store,
@@ -73,6 +78,7 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 		Findings:       fs,
 		Scanner:        sc,
 		Cache:          cache.NewPolicyCache(1000, 5*time.Minute),
+		ExecutionStore: executionStore,
 		Agents:         agents.NewAgentRegistry(),
 		RBAC:           auth.NewRBAC(),
 		Webhooks:       webhooks.NewServiceForTesting(),
@@ -91,4 +97,6 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 		ScanWatermarks: scanner.NewWatermarkStore(nil),
 		ThreatIntel:    threatintel.NewThreatIntelService(),
 	}
+	t.Cleanup(func() { _ = application.Close() })
+	return application
 }

--- a/internal/events/consumer.go
+++ b/internal/events/consumer.go
@@ -46,6 +46,10 @@ type ConsumerConfig struct {
 	DropHealthLookback  time.Duration
 	DropHealthThreshold int
 	PayloadPreviewBytes int
+	DedupEnabled        bool
+	DedupStateFile      string
+	DedupTTL            time.Duration
+	DedupMaxRecords     int
 
 	AuthMode string
 	Username string
@@ -88,6 +92,7 @@ type Consumer struct {
 	lastEventTime   time.Time
 	consumerLag     int
 	consumerLagAge  time.Duration
+	deduper         *consumerProcessedEventDeduper
 }
 
 type ConsumerHealthSnapshot struct {
@@ -117,6 +122,13 @@ func NewJetStreamConsumer(cfg ConsumerConfig, logger *slog.Logger, handler Event
 	dlq, err := newConsumerDeadLetterSink(config.DeadLetterPath)
 	if err != nil {
 		return nil, err
+	}
+	var deduper *consumerProcessedEventDeduper
+	if config.DedupEnabled {
+		deduper, err = newConsumerProcessedEventDeduper(config.DedupStateFile, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	base := JetStreamConfig{
@@ -155,6 +167,7 @@ func NewJetStreamConsumer(cfg ConsumerConfig, logger *slog.Logger, handler Event
 		config:  config,
 		handler: handler,
 		dlq:     dlq,
+		deduper: deduper,
 		nc:      nc,
 		js:      js,
 		stopCh:  make(chan struct{}),
@@ -236,6 +249,11 @@ func (c *Consumer) cleanup() error {
 			closeErr = errors.Join(closeErr, fmt.Errorf("drain consumer nats connection: %w", err))
 		}
 		c.nc.Close()
+	}
+	if c.deduper != nil {
+		if err := c.deduper.Close(); err != nil {
+			closeErr = errors.Join(closeErr, fmt.Errorf("close consumer dedupe store: %w", err))
+		}
 	}
 	return closeErr
 }
@@ -353,6 +371,74 @@ func (c *Consumer) handleMessage(ctx context.Context, subject string, payload []
 		}
 		return consumerMessageResult{}
 	}
+	if c.deduper != nil {
+		record, hashMismatch, err := c.deduper.Lookup(ctx, evt, payload, time.Now().UTC())
+		if err != nil {
+			c.logger.Warn("tap consumer dedupe lookup failed; continuing without duplicate suppression",
+				"error", err,
+				"event_id", evt.ID,
+				"event_type", evt.Type,
+			)
+		} else if record != nil {
+			if hashMismatch {
+				if err := c.deduper.Forget(ctx, evt); err != nil {
+					c.logger.Error("tap consumer failed to clear conflicting dedupe state; message requeued",
+						"error", err,
+						"event_id", evt.ID,
+						"event_type", evt.Type,
+						"source", evt.Source,
+						"processed_at", record.ProcessedAt.UTC().Format(time.RFC3339Nano),
+					)
+					if nakErr := nak(); nakErr != nil {
+						c.logger.Warn("tap consumer nak failed after dedupe hash mismatch state clear failure", "error", nakErr, "event_type", evt.Type)
+					}
+					return consumerMessageResult{}
+				}
+				if dlqErr := c.dlq.Write(consumerDeadLetterRecord{
+					RecordedAt: time.Now().UTC(),
+					Stream:     c.config.Stream,
+					Durable:    c.config.Durable,
+					Subject:    subject,
+					Reason:     "dedupe_hash_mismatch",
+					Error:      fmt.Sprintf("duplicate event key matched different payload hash: processed_at=%s", record.ProcessedAt.UTC().Format(time.RFC3339Nano)),
+					Payload:    string(payload),
+				}); dlqErr != nil {
+					c.logger.Error("tap consumer failed to dead-letter duplicate hash mismatch; message requeued",
+						"error", dlqErr,
+						"event_id", evt.ID,
+						"event_type", evt.Type,
+						"source", evt.Source,
+					)
+					if nakErr := nak(); nakErr != nil {
+						c.logger.Warn("tap consumer nak failed after dedupe hash mismatch dead-letter error", "error", nakErr, "event_type", evt.Type)
+					}
+					return consumerMessageResult{}
+				}
+				c.logger.Error("tap consumer dead-lettered duplicate event key with different payload hash",
+					"event_id", evt.ID,
+					"event_type", evt.Type,
+					"source", evt.Source,
+					"processed_at", record.ProcessedAt.UTC().Format(time.RFC3339Nano),
+				)
+				if nakErr := nak(); nakErr != nil {
+					c.logger.Warn("tap consumer nak failed after clearing dedupe hash mismatch state", "error", nakErr, "event_type", evt.Type)
+				}
+				return consumerMessageResult{}
+			}
+			if err := c.deduper.ObserveDuplicate(ctx, evt, time.Now().UTC()); err != nil {
+				c.logger.Warn("tap consumer failed to refresh duplicate dedupe state",
+					"error", err,
+					"event_id", evt.ID,
+					"event_type", evt.Type,
+				)
+			}
+			metrics.RecordNATSConsumerDeduplicated(c.config.Stream, c.config.Durable)
+			if err := ack(); err != nil {
+				c.logger.Warn("tap consumer ack failed after duplicate suppression", "error", err, "event_type", evt.Type)
+			}
+			return consumerMessageResult{}
+		}
+	}
 	stopHeartbeat := c.startInProgressHeartbeat(ctx, inProgress)
 	defer stopHeartbeat()
 	if err := c.handler(ctx, evt); err != nil {
@@ -363,6 +449,16 @@ func (c *Consumer) handleMessage(ctx context.Context, subject string, payload []
 		return consumerMessageResult{}
 	}
 	processedAt := time.Now().UTC()
+	metrics.RecordNATSConsumerProcessed(c.config.Stream, c.config.Durable)
+	if c.deduper != nil {
+		if err := c.deduper.Remember(ctx, evt, payload, processedAt); err != nil {
+			c.logger.Warn("tap consumer failed to persist processed event dedupe state",
+				"error", err,
+				"event_id", evt.ID,
+				"event_type", evt.Type,
+			)
+		}
+	}
 	if err := ack(); err != nil {
 		c.logger.Warn("tap consumer ack failed", "error", err, "event_type", evt.Type)
 	}
@@ -692,6 +788,12 @@ func (c ConsumerConfig) withDefaults() ConsumerConfig {
 	if cfg.PayloadPreviewBytes <= 0 {
 		cfg.PayloadPreviewBytes = defaultConsumerPayloadPreviewBytes
 	}
+	if cfg.DedupTTL <= 0 {
+		cfg.DedupTTL = 24 * time.Hour
+	}
+	if cfg.DedupMaxRecords <= 0 {
+		cfg.DedupMaxRecords = 100_000
+	}
 	if cfg.MaxAckPending <= 0 {
 		cfg.MaxAckPending = cfg.BatchSize * 10
 	}
@@ -725,6 +827,17 @@ func (c ConsumerConfig) validate() error {
 	}
 	if c.FetchTimeout <= 0 {
 		return errors.New("consumer fetch timeout must be > 0")
+	}
+	if c.DedupEnabled {
+		if strings.TrimSpace(c.DedupStateFile) == "" {
+			return errors.New("consumer dedupe state file is required when dedupe is enabled")
+		}
+		if c.DedupTTL <= 0 {
+			return errors.New("consumer dedupe ttl must be > 0 when dedupe is enabled")
+		}
+		if c.DedupMaxRecords <= 0 {
+			return errors.New("consumer dedupe max records must be > 0 when dedupe is enabled")
+		}
 	}
 	return nil
 }

--- a/internal/events/consumer.go
+++ b/internal/events/consumer.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/jsonl"
 	"github.com/writer/cerebro/internal/metrics"
 )
@@ -48,6 +49,7 @@ type ConsumerConfig struct {
 	PayloadPreviewBytes int
 	DedupEnabled        bool
 	DedupStateFile      string
+	DedupStore          executionstore.Store
 	DedupTTL            time.Duration
 	DedupMaxRecords     int
 
@@ -125,9 +127,13 @@ func NewJetStreamConsumer(cfg ConsumerConfig, logger *slog.Logger, handler Event
 	}
 	var deduper *consumerProcessedEventDeduper
 	if config.DedupEnabled {
-		deduper, err = newConsumerProcessedEventDeduper(config.DedupStateFile, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
-		if err != nil {
-			return nil, err
+		if config.DedupStore != nil {
+			deduper = newConsumerProcessedEventDeduperWithStore(config.DedupStore, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
+		} else {
+			deduper, err = newConsumerProcessedEventDeduper(config.DedupStateFile, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/events/consumer_dedup.go
+++ b/internal/events/consumer_dedup.go
@@ -13,10 +13,11 @@ import (
 )
 
 type consumerProcessedEventDeduper struct {
-	store      *executionstore.SQLiteStore
+	store      executionstore.Store
 	namespace  string
 	ttl        time.Duration
 	maxRecords int
+	ownsStore  bool
 }
 
 func newConsumerProcessedEventDeduper(path, stream, durable string, ttl time.Duration, maxRecords int) (*consumerProcessedEventDeduper, error) {
@@ -34,16 +35,22 @@ func newConsumerProcessedEventDeduper(path, stream, durable string, ttl time.Dur
 	if err != nil {
 		return nil, err
 	}
+	deduper := newConsumerProcessedEventDeduperWithStore(store, stream, durable, ttl, maxRecords)
+	deduper.ownsStore = true
+	return deduper, nil
+}
+
+func newConsumerProcessedEventDeduperWithStore(store executionstore.Store, stream, durable string, ttl time.Duration, maxRecords int) *consumerProcessedEventDeduper {
 	return &consumerProcessedEventDeduper{
 		store:      store,
 		namespace:  fmt.Sprintf("%s:%s:%s", executionstore.NamespaceProcessedCloudEvent, strings.TrimSpace(stream), strings.TrimSpace(durable)),
 		ttl:        ttl,
 		maxRecords: maxRecords,
-	}, nil
+	}
 }
 
 func (d *consumerProcessedEventDeduper) Close() error {
-	if d == nil || d.store == nil {
+	if d == nil || d.store == nil || !d.ownsStore {
 		return nil
 	}
 	return d.store.Close()

--- a/internal/events/consumer_dedup.go
+++ b/internal/events/consumer_dedup.go
@@ -1,0 +1,142 @@
+package events
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+type consumerProcessedEventDeduper struct {
+	store      *executionstore.SQLiteStore
+	namespace  string
+	ttl        time.Duration
+	maxRecords int
+}
+
+func newConsumerProcessedEventDeduper(path, stream, durable string, ttl time.Duration, maxRecords int) (*consumerProcessedEventDeduper, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("consumer dedupe state file is required")
+	}
+	if ttl <= 0 {
+		return nil, fmt.Errorf("consumer dedupe ttl must be > 0")
+	}
+	if maxRecords <= 0 {
+		return nil, fmt.Errorf("consumer dedupe max records must be > 0")
+	}
+	store, err := executionstore.NewSQLiteStore(path)
+	if err != nil {
+		return nil, err
+	}
+	return &consumerProcessedEventDeduper{
+		store:      store,
+		namespace:  fmt.Sprintf("%s:%s:%s", executionstore.NamespaceProcessedCloudEvent, strings.TrimSpace(stream), strings.TrimSpace(durable)),
+		ttl:        ttl,
+		maxRecords: maxRecords,
+	}, nil
+}
+
+func (d *consumerProcessedEventDeduper) Close() error {
+	if d == nil || d.store == nil {
+		return nil
+	}
+	return d.store.Close()
+}
+
+func (d *consumerProcessedEventDeduper) Lookup(ctx context.Context, evt CloudEvent, payload []byte, now time.Time) (*executionstore.ProcessedEventRecord, bool, error) {
+	if d == nil || d.store == nil {
+		return nil, false, nil
+	}
+	key, ok := consumerProcessedEventKey(evt)
+	if !ok {
+		return nil, false, nil
+	}
+	record, err := d.store.LookupProcessedEvent(ctx, d.namespace, key, now)
+	if err != nil || record == nil {
+		return record, false, err
+	}
+	return record, record.PayloadHash != consumerProcessedEventPayloadHash(payload), nil
+}
+
+func (d *consumerProcessedEventDeduper) ObserveDuplicate(ctx context.Context, evt CloudEvent, now time.Time) error {
+	if d == nil || d.store == nil {
+		return nil
+	}
+	key, ok := consumerProcessedEventKey(evt)
+	if !ok {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	return d.store.TouchProcessedEvent(ctx, d.namespace, key, now, d.ttl)
+}
+
+func (d *consumerProcessedEventDeduper) Remember(ctx context.Context, evt CloudEvent, payload []byte, processedAt time.Time) error {
+	if d == nil || d.store == nil {
+		return nil
+	}
+	key, ok := consumerProcessedEventKey(evt)
+	if !ok {
+		return nil
+	}
+	if processedAt.IsZero() {
+		processedAt = time.Now().UTC()
+	} else {
+		processedAt = processedAt.UTC()
+	}
+	return d.store.RememberProcessedEvent(ctx, executionstore.ProcessedEventRecord{
+		Namespace:   d.namespace,
+		EventKey:    key,
+		PayloadHash: consumerProcessedEventPayloadHash(payload),
+		FirstSeenAt: processedAt,
+		LastSeenAt:  processedAt,
+		ProcessedAt: processedAt,
+		ExpiresAt:   processedAt.Add(d.ttl),
+	}, d.maxRecords)
+}
+
+func (d *consumerProcessedEventDeduper) Forget(ctx context.Context, evt CloudEvent) error {
+	if d == nil || d.store == nil {
+		return nil
+	}
+	key, ok := consumerProcessedEventKey(evt)
+	if !ok {
+		return nil
+	}
+	return d.store.DeleteProcessedEvent(ctx, d.namespace, key)
+}
+
+func consumerProcessedEventKey(evt CloudEvent) (string, bool) {
+	eventID := strings.TrimSpace(evt.ID)
+	if eventID == "" {
+		return "", false
+	}
+	source := strings.TrimSpace(evt.Source)
+	if source == "" {
+		source = "unknown"
+	}
+	tenantID := strings.TrimSpace(evt.TenantID)
+	if tenantID == "" {
+		tenantID = "default"
+	}
+	keyPayload, err := json.Marshal([]string{tenantID, source, eventID})
+	if err != nil {
+		return "", false
+	}
+	sum := sha256.Sum256(keyPayload)
+	return "sha256:" + hex.EncodeToString(sum[:]), true
+}
+
+func consumerProcessedEventPayloadHash(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/events/consumer_test.go
+++ b/internal/events/consumer_test.go
@@ -41,6 +41,16 @@ func TestConsumerConfigWithDefaultsPreservesZeroDropHealthThreshold(t *testing.T
 	}
 }
 
+func TestConsumerConfigWithDefaultsSetsDedupDefaults(t *testing.T) {
+	cfg := (ConsumerConfig{DedupEnabled: true}).withDefaults()
+	if cfg.DedupTTL <= 0 {
+		t.Fatalf("expected positive dedupe ttl, got %s", cfg.DedupTTL)
+	}
+	if cfg.DedupMaxRecords <= 0 {
+		t.Fatalf("expected positive dedupe max records, got %d", cfg.DedupMaxRecords)
+	}
+}
+
 func TestConsumerConfigValidate(t *testing.T) {
 	valid := (ConsumerConfig{
 		URLs:           []string{"nats://127.0.0.1:4222"},
@@ -48,6 +58,7 @@ func TestConsumerConfigValidate(t *testing.T) {
 		Subject:        "ensemble.tap.>",
 		Durable:        "cerebro_graph_builder",
 		DeadLetterPath: t.TempDir() + "/consumer.dlq.jsonl",
+		DedupStateFile: t.TempDir() + "/executions.db",
 		BatchSize:      10,
 		AckWait:        5,
 		FetchTimeout:   5,
@@ -277,6 +288,247 @@ func TestConsumerStartBatchInProgressHeartbeatSkipsDeactivatedEntries(t *testing
 	}
 	if firstCount.Load() != firstBefore {
 		t.Fatalf("expected deactivated batch heartbeat to stop extending first message, got before=%d after=%d", firstBefore, firstCount.Load())
+	}
+}
+
+func TestConsumerHandleMessageSkipsAlreadyProcessedCloudEvent(t *testing.T) {
+	cfg := (ConsumerConfig{
+		Stream:         "ENSEMBLE_TAP",
+		Durable:        "cerebro_graph_builder",
+		DeadLetterPath: t.TempDir() + "/consumer.dlq.jsonl",
+		DedupStateFile: t.TempDir() + "/executions.db",
+	}).withDefaults()
+	deduper, err := newConsumerProcessedEventDeduper(cfg.DedupStateFile, cfg.Stream, cfg.Durable, cfg.DedupTTL, cfg.DedupMaxRecords)
+	if err != nil {
+		t.Fatalf("new deduper: %v", err)
+	}
+	defer func() { _ = deduper.Close() }()
+
+	consumer := &Consumer{
+		config:  cfg,
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		dlq:     &consumerDeadLetterSink{},
+		deduper: deduper,
+	}
+
+	evt := CloudEvent{
+		SpecVersion: cloudEventSpecVersion,
+		ID:          "evt-dedup-1",
+		Source:      "urn:cerebro:test",
+		Type:        "ensemble.tap.test",
+		Time:        time.Now().UTC(),
+		DataSchema:  "urn:cerebro:events:test",
+		TenantID:    "tenant-a",
+		Data:        map[string]any{"id": "1"},
+	}
+	payload, err := json.Marshal(evt)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	var handlerCalls int
+	consumer.handler = func(context.Context, CloudEvent) error {
+		handlerCalls++
+		return nil
+	}
+	var ackCalls int
+	ack := func() error {
+		ackCalls++
+		return nil
+	}
+
+	first := consumer.handleMessage(context.Background(), "ensemble.tap.test", payload, ack, func() error { return nil }, func() error { return nil })
+	if !first.Processed {
+		t.Fatalf("expected first event to be processed, got %+v", first)
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("expected handler call count 1, got %d", handlerCalls)
+	}
+
+	before := counterValue(t, metrics.NATSConsumerDeduplicatedTotal.WithLabelValues(cfg.Stream, cfg.Durable))
+	second := consumer.handleMessage(context.Background(), "ensemble.tap.test", payload, ack, func() error { return nil }, func() error { return nil })
+	if second.Processed {
+		t.Fatalf("expected duplicate event to be skipped, got %+v", second)
+	}
+	after := counterValue(t, metrics.NATSConsumerDeduplicatedTotal.WithLabelValues(cfg.Stream, cfg.Durable))
+	if after != before+1 {
+		t.Fatalf("expected deduplicated counter to increment from %v to %v", before, after)
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("expected duplicate event to avoid handler, got %d calls", handlerCalls)
+	}
+	if ackCalls != 2 {
+		t.Fatalf("expected both events to ack, got %d", ackCalls)
+	}
+}
+
+func TestConsumerHandleMessageDeadLettersDuplicateKeyPayloadMismatch(t *testing.T) {
+	cfg := (ConsumerConfig{
+		Stream:         "ENSEMBLE_TAP",
+		Durable:        "cerebro_graph_builder",
+		DeadLetterPath: t.TempDir() + "/consumer.dlq.jsonl",
+		DedupStateFile: t.TempDir() + "/executions.db",
+	}).withDefaults()
+	deduper, err := newConsumerProcessedEventDeduper(cfg.DedupStateFile, cfg.Stream, cfg.Durable, cfg.DedupTTL, cfg.DedupMaxRecords)
+	if err != nil {
+		t.Fatalf("new deduper: %v", err)
+	}
+	defer func() { _ = deduper.Close() }()
+
+	dlq, err := newConsumerDeadLetterSink(cfg.DeadLetterPath)
+	if err != nil {
+		t.Fatalf("new consumer dead-letter sink: %v", err)
+	}
+
+	consumer := &Consumer{
+		config:  cfg,
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		dlq:     dlq,
+		deduper: deduper,
+	}
+
+	firstEvent := CloudEvent{
+		SpecVersion: cloudEventSpecVersion,
+		ID:          "evt-dedup-collision-1",
+		Source:      "urn:cerebro:test",
+		Type:        "ensemble.tap.test",
+		Time:        time.Now().UTC(),
+		DataSchema:  "urn:cerebro:events:test",
+		TenantID:    "tenant-a",
+		Data:        map[string]any{"id": "1", "value": "first"},
+	}
+	firstPayload, err := json.Marshal(firstEvent)
+	if err != nil {
+		t.Fatalf("marshal first event: %v", err)
+	}
+
+	secondEvent := firstEvent
+	secondEvent.Type = "ensemble.tap.test.updated"
+	secondEvent.Data = map[string]any{"id": "1", "value": "second"}
+	secondPayload, err := json.Marshal(secondEvent)
+	if err != nil {
+		t.Fatalf("marshal second event: %v", err)
+	}
+
+	var handlerCalls int
+	consumer.handler = func(context.Context, CloudEvent) error {
+		handlerCalls++
+		return nil
+	}
+	var ackCalls int
+	var nakCalls int
+	ack := func() error {
+		ackCalls++
+		return nil
+	}
+	nak := func() error {
+		nakCalls++
+		return nil
+	}
+
+	first := consumer.handleMessage(context.Background(), "ensemble.tap.test", firstPayload, ack, nak, func() error { return nil })
+	if !first.Processed {
+		t.Fatalf("expected first event to be processed, got %+v", first)
+	}
+
+	beforeDedup := counterValue(t, metrics.NATSConsumerDeduplicatedTotal.WithLabelValues(cfg.Stream, cfg.Durable))
+	beforeDropped := counterValue(t, metrics.NATSConsumerDroppedTotal.WithLabelValues(cfg.Stream, cfg.Durable, "dedupe_hash_mismatch"))
+	second := consumer.handleMessage(context.Background(), "ensemble.tap.test", secondPayload, ack, nak, func() error { return nil })
+	if second.Processed {
+		t.Fatalf("expected hash-mismatch duplicate to avoid normal processing, got %+v", second)
+	}
+
+	afterDedup := counterValue(t, metrics.NATSConsumerDeduplicatedTotal.WithLabelValues(cfg.Stream, cfg.Durable))
+	if afterDedup != beforeDedup {
+		t.Fatalf("expected deduplicated counter unchanged on hash mismatch, before=%v after=%v", beforeDedup, afterDedup)
+	}
+	afterDropped := counterValue(t, metrics.NATSConsumerDroppedTotal.WithLabelValues(cfg.Stream, cfg.Durable, "dedupe_hash_mismatch"))
+	if afterDropped != beforeDropped {
+		t.Fatalf("expected hash mismatch to requeue instead of drop, before=%v after=%v", beforeDropped, afterDropped)
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("expected handler to run only for first event, got %d calls", handlerCalls)
+	}
+	if ackCalls != 1 {
+		t.Fatalf("expected only the first event to ack before requeue, got %d", ackCalls)
+	}
+	if nakCalls != 1 {
+		t.Fatalf("expected hash mismatch to requeue once, got %d nacks", nakCalls)
+	}
+
+	payload, err := os.ReadFile(cfg.DeadLetterPath)
+	if err != nil {
+		t.Fatalf("read consumer dead-letter file: %v", err)
+	}
+	if got := string(payload); !containsAll(got, "\"reason\":\"dedupe_hash_mismatch\"", "\"subject\":\"ensemble.tap.test\"", "ensemble.tap.test.updated", "\\\"value\\\":\\\"second\\\"") {
+		t.Fatalf("expected hash mismatch payload to be written to dead-letter file, got %s", got)
+	}
+
+	snapshot := consumer.HealthSnapshot(time.Now().UTC())
+	if snapshot.LastDropReason != "" {
+		t.Fatalf("expected hash mismatch requeue not to mark a drop, got %q", snapshot.LastDropReason)
+	}
+
+	eventKey, ok := consumerProcessedEventKey(firstEvent)
+	if !ok {
+		t.Fatal("expected event key for first event")
+	}
+	record, err := deduper.store.LookupProcessedEvent(context.Background(), deduper.namespace, eventKey, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent after hash mismatch: %v", err)
+	}
+	if record != nil {
+		t.Fatalf("expected hash mismatch to clear processed event record, got %#v", record)
+	}
+
+	third := consumer.handleMessage(context.Background(), "ensemble.tap.test", secondPayload, ack, nak, func() error { return nil })
+	if !third.Processed {
+		t.Fatalf("expected replayed hash-mismatch event to process after dedupe reset, got %+v", third)
+	}
+	if handlerCalls != 2 {
+		t.Fatalf("expected handler to run again after hash-mismatch reset, got %d calls", handlerCalls)
+	}
+	if ackCalls != 2 {
+		t.Fatalf("expected replayed event to ack after processing, got %d", ackCalls)
+	}
+	if nakCalls != 1 {
+		t.Fatalf("expected only one hash-mismatch requeue, got %d", nakCalls)
+	}
+
+	record, err = deduper.store.LookupProcessedEvent(context.Background(), deduper.namespace, eventKey, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent after replayed hash mismatch: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected replayed hash-mismatch event to persist a new processed event record")
+	}
+	if record.DuplicateCount != 0 {
+		t.Fatalf("expected replayed hash-mismatch event to persist without duplicate count, got %#v", record)
+	}
+}
+
+func TestConsumerProcessedEventKeyIsUnambiguous(t *testing.T) {
+	first, ok := consumerProcessedEventKey(CloudEvent{
+		ID:       "d",
+		Source:   "c",
+		TenantID: "a|b",
+	})
+	if !ok {
+		t.Fatal("expected first dedupe key")
+	}
+	second, ok := consumerProcessedEventKey(CloudEvent{
+		ID:       "d",
+		Source:   "b|c",
+		TenantID: "a",
+	})
+	if !ok {
+		t.Fatal("expected second dedupe key")
+	}
+	if first == second {
+		t.Fatalf("expected canonical dedupe keys to differ, both were %q", first)
+	}
+	if !strings.HasPrefix(first, "sha256:") || !strings.HasPrefix(second, "sha256:") {
+		t.Fatalf("expected canonical hashed dedupe keys, got %q and %q", first, second)
 	}
 }
 

--- a/internal/executions/summary.go
+++ b/internal/executions/summary.go
@@ -1,0 +1,258 @@
+package executions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/actionengine"
+	"github.com/writer/cerebro/internal/executionstore"
+	"github.com/writer/cerebro/internal/functionscan"
+	reports "github.com/writer/cerebro/internal/graph/reports"
+	"github.com/writer/cerebro/internal/imagescan"
+	"github.com/writer/cerebro/internal/workloadscan"
+)
+
+type ListOptions struct {
+	Namespaces         []string
+	Statuses           []string
+	ExcludeStatuses    []string
+	ReportID           string
+	Limit              int
+	Offset             int
+	OrderBySubmittedAt bool
+}
+
+type Summary struct {
+	Namespace     string     `json:"namespace"`
+	RunID         string     `json:"run_id"`
+	Kind          string     `json:"kind"`
+	Status        string     `json:"status"`
+	Stage         string     `json:"stage"`
+	SubmittedAt   time.Time  `json:"submitted_at"`
+	StartedAt     *time.Time `json:"started_at,omitempty"`
+	CompletedAt   *time.Time `json:"completed_at,omitempty"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+	DisplayName   string     `json:"display_name,omitempty"`
+	ScopeID       string     `json:"scope_id,omitempty"`
+	RequestedBy   string     `json:"requested_by,omitempty"`
+	ExecutionMode string     `json:"execution_mode,omitempty"`
+	StatusURL     string     `json:"status_url,omitempty"`
+	JobID         string     `json:"job_id,omitempty"`
+	Error         string     `json:"error,omitempty"`
+	Provider      string     `json:"provider,omitempty"`
+	Target        string     `json:"target,omitempty"`
+}
+
+func List(ctx context.Context, store *executionstore.SQLiteStore, opts ListOptions) ([]Summary, error) {
+	if store == nil {
+		return nil, nil
+	}
+	envs, err := store.ListAllRuns(ctx, executionstore.RunListOptions{
+		Namespaces:         opts.Namespaces,
+		Statuses:           opts.Statuses,
+		ExcludeStatuses:    opts.ExcludeStatuses,
+		Limit:              opts.Limit,
+		Offset:             opts.Offset,
+		OrderBySubmittedAt: opts.OrderBySubmittedAt,
+	})
+	if err != nil {
+		return nil, err
+	}
+	summaries := make([]Summary, 0, len(envs))
+	for _, env := range envs {
+		summary, ok, err := summarizeEnvelope(env, opts)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		summaries = append(summaries, summary)
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if opts.OrderBySubmittedAt {
+			if summaries[i].SubmittedAt.Equal(summaries[j].SubmittedAt) {
+				return summaries[i].RunID > summaries[j].RunID
+			}
+			return summaries[i].SubmittedAt.After(summaries[j].SubmittedAt)
+		}
+		if summaries[i].UpdatedAt.Equal(summaries[j].UpdatedAt) {
+			return summaries[i].RunID > summaries[j].RunID
+		}
+		return summaries[i].UpdatedAt.After(summaries[j].UpdatedAt)
+	})
+	return summaries, nil
+}
+
+func summarizeEnvelope(env executionstore.RunEnvelope, opts ListOptions) (Summary, bool, error) {
+	switch env.Namespace {
+	case executionstore.NamespacePlatformReportRun:
+		return summarizeReportRun(env, opts)
+	case executionstore.NamespaceWorkloadScan:
+		return summarizeWorkloadRun(env)
+	case executionstore.NamespaceImageScan:
+		return summarizeImageRun(env)
+	case executionstore.NamespaceFunctionScan:
+		return summarizeFunctionRun(env)
+	case executionstore.NamespaceActionEngine:
+		return summarizeActionExecution(env)
+	default:
+		return Summary{
+			Namespace:   env.Namespace,
+			RunID:       env.RunID,
+			Kind:        env.Kind,
+			Status:      env.Status,
+			Stage:       env.Stage,
+			SubmittedAt: env.SubmittedAt,
+			StartedAt:   env.StartedAt,
+			CompletedAt: env.CompletedAt,
+			UpdatedAt:   env.UpdatedAt,
+			DisplayName: env.RunID,
+		}, true, nil
+	}
+}
+
+func summarizeReportRun(env executionstore.RunEnvelope, opts ListOptions) (Summary, bool, error) {
+	var payload struct {
+		Run *reports.ReportRun `json:"run"`
+	}
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		return Summary{}, false, fmt.Errorf("decode report execution %q: %w", env.RunID, err)
+	}
+	if payload.Run == nil {
+		return Summary{}, false, nil
+	}
+	reportID := strings.TrimSpace(payload.Run.ReportID)
+	if filter := strings.TrimSpace(opts.ReportID); filter != "" && filter != reportID {
+		return Summary{}, false, nil
+	}
+	return Summary{
+		Namespace:     env.Namespace,
+		RunID:         env.RunID,
+		Kind:          firstNonEmpty(strings.TrimSpace(payload.Run.ReportID), env.Kind),
+		Status:        env.Status,
+		Stage:         env.Stage,
+		SubmittedAt:   env.SubmittedAt,
+		StartedAt:     env.StartedAt,
+		CompletedAt:   env.CompletedAt,
+		UpdatedAt:     env.UpdatedAt,
+		DisplayName:   "report:" + reportID,
+		ScopeID:       reportID,
+		RequestedBy:   strings.TrimSpace(payload.Run.RequestedBy),
+		ExecutionMode: strings.TrimSpace(payload.Run.ExecutionMode),
+		StatusURL:     strings.TrimSpace(payload.Run.StatusURL),
+		JobID:         strings.TrimSpace(payload.Run.JobID),
+		Error:         strings.TrimSpace(payload.Run.Error),
+	}, true, nil
+}
+
+func summarizeWorkloadRun(env executionstore.RunEnvelope) (Summary, bool, error) {
+	var run workloadscan.RunRecord
+	if err := json.Unmarshal(env.Payload, &run); err != nil {
+		return Summary{}, false, fmt.Errorf("decode workload execution %q: %w", env.RunID, err)
+	}
+	return Summary{
+		Namespace:   env.Namespace,
+		RunID:       env.RunID,
+		Kind:        env.Kind,
+		Status:      env.Status,
+		Stage:       env.Stage,
+		SubmittedAt: env.SubmittedAt,
+		StartedAt:   env.StartedAt,
+		CompletedAt: env.CompletedAt,
+		UpdatedAt:   env.UpdatedAt,
+		DisplayName: "workload:" + run.Target.Identity(),
+		ScopeID:     run.Target.Identity(),
+		RequestedBy: strings.TrimSpace(run.RequestedBy),
+		Error:       strings.TrimSpace(run.Error),
+		Provider:    string(run.Provider),
+		Target:      run.Target.Identity(),
+	}, true, nil
+}
+
+func summarizeImageRun(env executionstore.RunEnvelope) (Summary, bool, error) {
+	var run imagescan.RunRecord
+	if err := json.Unmarshal(env.Payload, &run); err != nil {
+		return Summary{}, false, fmt.Errorf("decode image execution %q: %w", env.RunID, err)
+	}
+	target := run.Target.Reference()
+	return Summary{
+		Namespace:   env.Namespace,
+		RunID:       env.RunID,
+		Kind:        env.Kind,
+		Status:      env.Status,
+		Stage:       env.Stage,
+		SubmittedAt: env.SubmittedAt,
+		StartedAt:   env.StartedAt,
+		CompletedAt: env.CompletedAt,
+		UpdatedAt:   env.UpdatedAt,
+		DisplayName: "image:" + target,
+		ScopeID:     target,
+		RequestedBy: strings.TrimSpace(run.RequestedBy),
+		Error:       strings.TrimSpace(run.Error),
+		Provider:    string(run.Registry),
+		Target:      target,
+	}, true, nil
+}
+
+func summarizeFunctionRun(env executionstore.RunEnvelope) (Summary, bool, error) {
+	var run functionscan.RunRecord
+	if err := json.Unmarshal(env.Payload, &run); err != nil {
+		return Summary{}, false, fmt.Errorf("decode function execution %q: %w", env.RunID, err)
+	}
+	target := run.Target.Identity()
+	return Summary{
+		Namespace:   env.Namespace,
+		RunID:       env.RunID,
+		Kind:        env.Kind,
+		Status:      env.Status,
+		Stage:       env.Stage,
+		SubmittedAt: env.SubmittedAt,
+		StartedAt:   env.StartedAt,
+		CompletedAt: env.CompletedAt,
+		UpdatedAt:   env.UpdatedAt,
+		DisplayName: "function:" + target,
+		ScopeID:     target,
+		RequestedBy: strings.TrimSpace(run.RequestedBy),
+		Error:       strings.TrimSpace(run.Error),
+		Provider:    string(run.Provider),
+		Target:      target,
+	}, true, nil
+}
+
+func summarizeActionExecution(env executionstore.RunEnvelope) (Summary, bool, error) {
+	var execution actionengine.Execution
+	if err := json.Unmarshal(env.Payload, &execution); err != nil {
+		return Summary{}, false, fmt.Errorf("decode action execution %q: %w", env.RunID, err)
+	}
+	scopeID := firstNonEmpty(strings.TrimSpace(execution.ResourceID), strings.TrimSpace(execution.SignalID))
+	return Summary{
+		Namespace:   env.Namespace,
+		RunID:       env.RunID,
+		Kind:        firstNonEmpty(env.Kind, "action_execution"),
+		Status:      env.Status,
+		Stage:       env.Stage,
+		SubmittedAt: env.SubmittedAt,
+		StartedAt:   env.StartedAt,
+		CompletedAt: env.CompletedAt,
+		UpdatedAt:   env.UpdatedAt,
+		DisplayName: firstNonEmpty(strings.TrimSpace(execution.PlaybookName), strings.TrimSpace(execution.PlaybookID), env.RunID),
+		ScopeID:     scopeID,
+		Error:       strings.TrimSpace(execution.Error),
+		Target:      scopeID,
+	}, true, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/executions/summary.go
+++ b/internal/executions/summary.go
@@ -47,7 +47,7 @@ type Summary struct {
 	Target        string     `json:"target,omitempty"`
 }
 
-func List(ctx context.Context, store *executionstore.SQLiteStore, opts ListOptions) ([]Summary, error) {
+func List(ctx context.Context, store executionstore.Store, opts ListOptions) ([]Summary, error) {
 	if store == nil {
 		return nil, nil
 	}

--- a/internal/executionstore/namespaces.go
+++ b/internal/executionstore/namespaces.go
@@ -1,9 +1,10 @@
 package executionstore
 
 const (
-	NamespacePlatformReportRun = "report_run"
-	NamespaceWorkloadScan      = "workload_scan"
-	NamespaceImageScan         = "image_scan"
-	NamespaceFunctionScan      = "function_scan"
-	NamespaceActionEngine      = "action_engine"
+	NamespacePlatformReportRun   = "report_run"
+	NamespaceWorkloadScan        = "workload_scan"
+	NamespaceImageScan           = "image_scan"
+	NamespaceFunctionScan        = "function_scan"
+	NamespaceActionEngine        = "action_engine"
+	NamespaceProcessedCloudEvent = "processed_cloud_event"
 )

--- a/internal/executionstore/namespaces.go
+++ b/internal/executionstore/namespaces.go
@@ -1,0 +1,9 @@
+package executionstore
+
+const (
+	NamespacePlatformReportRun = "report_run"
+	NamespaceWorkloadScan      = "workload_scan"
+	NamespaceImageScan         = "image_scan"
+	NamespaceFunctionScan      = "function_scan"
+	NamespaceActionEngine      = "action_engine"
+)

--- a/internal/executionstore/processed_events.go
+++ b/internal/executionstore/processed_events.go
@@ -1,0 +1,244 @@
+package executionstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ProcessedEventRecord struct {
+	Namespace      string
+	EventKey       string
+	PayloadHash    string
+	FirstSeenAt    time.Time
+	LastSeenAt     time.Time
+	ProcessedAt    time.Time
+	ExpiresAt      time.Time
+	DuplicateCount int
+}
+
+func (s *SQLiteStore) LookupProcessedEvent(ctx context.Context, namespace, eventKey string, observedAt time.Time) (*ProcessedEventRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	eventKey = strings.TrimSpace(eventKey)
+	if namespace == "" || eventKey == "" {
+		return nil, fmt.Errorf("processed event namespace and key are required")
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	} else {
+		observedAt = observedAt.UTC()
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin processed event lookup tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND expires_at <= ?
+	`, namespace, observedAt); err != nil {
+		return nil, fmt.Errorf("prune expired processed events: %w", err)
+	}
+
+	var record ProcessedEventRecord
+	err = tx.QueryRowContext(ctx, `
+		SELECT namespace, event_key, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
+		FROM processed_events
+		WHERE namespace = ? AND event_key = ?
+	`, namespace, eventKey).Scan(
+		&record.Namespace,
+		&record.EventKey,
+		&record.PayloadHash,
+		&record.FirstSeenAt,
+		&record.LastSeenAt,
+		&record.ProcessedAt,
+		&record.ExpiresAt,
+		&record.DuplicateCount,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit processed event lookup: %w", err)
+		}
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load processed event: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit processed event lookup: %w", err)
+	}
+	return &record, nil
+}
+
+func (s *SQLiteStore) TouchProcessedEvent(ctx context.Context, namespace, eventKey string, observedAt time.Time, ttl time.Duration) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	eventKey = strings.TrimSpace(eventKey)
+	if namespace == "" || eventKey == "" {
+		return fmt.Errorf("processed event namespace and key are required")
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	} else {
+		observedAt = observedAt.UTC()
+	}
+	if ttl <= 0 {
+		return fmt.Errorf("processed event ttl must be > 0")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin processed event touch tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND expires_at <= ?
+	`, namespace, observedAt); err != nil {
+		return fmt.Errorf("prune expired processed events: %w", err)
+	}
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE processed_events
+		SET last_seen_at = ?,
+			expires_at = ?,
+			duplicate_count = duplicate_count + 1
+		WHERE namespace = ? AND event_key = ?
+	`, observedAt, observedAt.Add(ttl), namespace, eventKey)
+	if err != nil {
+		return fmt.Errorf("touch processed event: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read touched processed event rows: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("processed event %s/%s not found", namespace, eventKey)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit processed event touch: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) RememberProcessedEvent(ctx context.Context, record ProcessedEventRecord, maxRecords int) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	record.Namespace = strings.TrimSpace(record.Namespace)
+	record.EventKey = strings.TrimSpace(record.EventKey)
+	record.PayloadHash = strings.TrimSpace(record.PayloadHash)
+	if record.Namespace == "" || record.EventKey == "" {
+		return fmt.Errorf("processed event namespace and key are required")
+	}
+	if record.FirstSeenAt.IsZero() {
+		record.FirstSeenAt = time.Now().UTC()
+	} else {
+		record.FirstSeenAt = record.FirstSeenAt.UTC()
+	}
+	if record.LastSeenAt.IsZero() {
+		record.LastSeenAt = record.FirstSeenAt
+	} else {
+		record.LastSeenAt = record.LastSeenAt.UTC()
+	}
+	if record.ProcessedAt.IsZero() {
+		record.ProcessedAt = record.LastSeenAt
+	} else {
+		record.ProcessedAt = record.ProcessedAt.UTC()
+	}
+	if record.ExpiresAt.IsZero() {
+		record.ExpiresAt = record.ProcessedAt
+	} else {
+		record.ExpiresAt = record.ExpiresAt.UTC()
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin processed event remember tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND expires_at <= ?
+	`, record.Namespace, record.ProcessedAt); err != nil {
+		return fmt.Errorf("prune expired processed events: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO processed_events (
+			namespace, event_key, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(namespace, event_key) DO UPDATE SET
+			payload_hash = excluded.payload_hash,
+			last_seen_at = excluded.last_seen_at,
+			processed_at = excluded.processed_at,
+			expires_at = excluded.expires_at
+	`, record.Namespace, record.EventKey, record.PayloadHash, record.FirstSeenAt, record.LastSeenAt, record.ProcessedAt, record.ExpiresAt, record.DuplicateCount); err != nil {
+		return fmt.Errorf("persist processed event: %w", err)
+	}
+
+	if maxRecords > 0 {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM processed_events
+			WHERE namespace = ?
+			  AND event_key IN (
+				SELECT event_key
+				FROM processed_events
+				WHERE namespace = ?
+				ORDER BY processed_at DESC, event_key DESC
+				LIMIT -1 OFFSET ?
+			  )
+		`, record.Namespace, record.Namespace, maxRecords); err != nil {
+			return fmt.Errorf("trim processed events: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit processed event remember: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteProcessedEvent(ctx context.Context, namespace, eventKey string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	eventKey = strings.TrimSpace(eventKey)
+	if namespace == "" || eventKey == "" {
+		return fmt.Errorf("processed event namespace and key are required")
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND event_key = ?
+	`, namespace, eventKey); err != nil {
+		return fmt.Errorf("delete processed event: %w", err)
+	}
+	return nil
+}

--- a/internal/executionstore/processed_events_test.go
+++ b/internal/executionstore/processed_events_test.go
@@ -1,0 +1,131 @@
+package executionstore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSQLiteStoreProcessedEventsRoundTripAndTouch(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Date(2026, 3, 12, 2, 0, 0, 0, time.UTC)
+	err = store.RememberProcessedEvent(context.Background(), ProcessedEventRecord{
+		Namespace:   NamespaceProcessedCloudEvent,
+		EventKey:    "stream|durable|tenant|source|evt-1",
+		PayloadHash: "hash-a",
+		FirstSeenAt: now,
+		LastSeenAt:  now,
+		ProcessedAt: now,
+		ExpiresAt:   now.Add(24 * time.Hour),
+	}, 100)
+	if err != nil {
+		t.Fatalf("RememberProcessedEvent: %v", err)
+	}
+
+	record, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "stream|durable|tenant|source|evt-1", now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected processed event record")
+	}
+	if record.PayloadHash != "hash-a" {
+		t.Fatalf("expected payload hash hash-a, got %#v", record)
+	}
+	if record.DuplicateCount != 0 {
+		t.Fatalf("expected read-only lookup to preserve duplicate count, got %#v", record)
+	}
+
+	if err := store.TouchProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "stream|durable|tenant|source|evt-1", now.Add(2*time.Hour), 24*time.Hour); err != nil {
+		t.Fatalf("TouchProcessedEvent: %v", err)
+	}
+
+	touched, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "stream|durable|tenant|source|evt-1", now.Add(3*time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent after touch: %v", err)
+	}
+	if touched == nil {
+		t.Fatal("expected touched processed event record")
+	}
+	if touched.DuplicateCount != 1 {
+		t.Fatalf("expected duplicate count increment to 1 after touch, got %#v", touched)
+	}
+}
+
+func TestSQLiteStoreProcessedEventsTrimOldest(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	base := time.Date(2026, 3, 12, 2, 0, 0, 0, time.UTC)
+	for i, key := range []string{"evt-1", "evt-2", "evt-3"} {
+		ts := base.Add(time.Duration(i) * time.Minute)
+		if err := store.RememberProcessedEvent(context.Background(), ProcessedEventRecord{
+			Namespace:   NamespaceProcessedCloudEvent,
+			EventKey:    key,
+			PayloadHash: key,
+			FirstSeenAt: ts,
+			LastSeenAt:  ts,
+			ProcessedAt: ts,
+			ExpiresAt:   ts.Add(24 * time.Hour),
+		}, 2); err != nil {
+			t.Fatalf("RememberProcessedEvent %s: %v", key, err)
+		}
+	}
+
+	first, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-1", base.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent first: %v", err)
+	}
+	if first != nil {
+		t.Fatalf("expected oldest processed event to be trimmed, got %#v", first)
+	}
+	last, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-3", base.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent last: %v", err)
+	}
+	if last == nil {
+		t.Fatal("expected newest processed event to remain after trim")
+	}
+}
+
+func TestSQLiteStoreDeleteProcessedEvent(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Date(2026, 3, 12, 4, 0, 0, 0, time.UTC)
+	if err := store.RememberProcessedEvent(context.Background(), ProcessedEventRecord{
+		Namespace:   NamespaceProcessedCloudEvent,
+		EventKey:    "evt-delete",
+		PayloadHash: "hash-a",
+		FirstSeenAt: now,
+		LastSeenAt:  now,
+		ProcessedAt: now,
+		ExpiresAt:   now.Add(24 * time.Hour),
+	}, 100); err != nil {
+		t.Fatalf("RememberProcessedEvent: %v", err)
+	}
+
+	if err := store.DeleteProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-delete"); err != nil {
+		t.Fatalf("DeleteProcessedEvent: %v", err)
+	}
+
+	record, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-delete", now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent after delete: %v", err)
+	}
+	if record != nil {
+		t.Fatalf("expected processed event to be deleted, got %#v", record)
+	}
+}

--- a/internal/executionstore/sqlite.go
+++ b/internal/executionstore/sqlite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,6 +47,8 @@ type SQLiteStore struct {
 	db *sql.DB
 }
 
+const sqliteBusyTimeoutMS = 5000
+
 func NewSQLiteStore(path string) (*SQLiteStore, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -54,7 +57,7 @@ func NewSQLiteStore(path string) (*SQLiteStore, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return nil, fmt.Errorf("create execution store directory: %w", err)
 	}
-	db, err := sql.Open("sqlite", path)
+	db, err := sql.Open("sqlite", sqliteStoreDSN(path))
 	if err != nil {
 		return nil, fmt.Errorf("open execution sqlite: %w", err)
 	}
@@ -63,6 +66,20 @@ func NewSQLiteStore(path string) (*SQLiteStore, error) {
 		return nil, err
 	}
 	return &SQLiteStore{db: db}, nil
+}
+
+func sqliteStoreDSN(path string) string {
+	absPath, err := filepath.Abs(path)
+	if err == nil {
+		path = absPath
+	}
+	u := url.URL{Scheme: "file", Path: filepath.ToSlash(path)}
+	query := u.Query()
+	query.Add("_pragma", "journal_mode(WAL)")
+	query.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", sqliteBusyTimeoutMS))
+	query.Add("_pragma", "synchronous(NORMAL)")
+	u.RawQuery = query.Encode()
+	return u.String()
 }
 
 func initSQLiteStore(db *sql.DB) error {
@@ -95,6 +112,21 @@ func initSQLiteStore(db *sql.DB) error {
 		payload JSON NOT NULL,
 		PRIMARY KEY (namespace, run_id, sequence)
 	);
+	CREATE TABLE IF NOT EXISTS processed_events (
+		namespace TEXT NOT NULL,
+		event_key TEXT NOT NULL,
+		payload_hash TEXT NOT NULL,
+		first_seen_at TIMESTAMP NOT NULL,
+		last_seen_at TIMESTAMP NOT NULL,
+		processed_at TIMESTAMP NOT NULL,
+		expires_at TIMESTAMP NOT NULL,
+		duplicate_count INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (namespace, event_key)
+	);
+	CREATE INDEX IF NOT EXISTS idx_processed_events_namespace_expires
+		ON processed_events(namespace, expires_at ASC);
+	CREATE INDEX IF NOT EXISTS idx_processed_events_namespace_processed
+		ON processed_events(namespace, processed_at DESC, event_key DESC);
 	`
 	if _, err := db.ExecContext(context.Background(), schema); err != nil {
 		return fmt.Errorf("init execution sqlite schema: %w", err)

--- a/internal/executionstore/sqlite.go
+++ b/internal/executionstore/sqlite.go
@@ -34,6 +34,7 @@ type EventEnvelope struct {
 }
 
 type RunListOptions struct {
+	Namespaces         []string
 	Statuses           []string
 	ExcludeStatuses    []string
 	Limit              int
@@ -145,6 +146,91 @@ func (s *SQLiteStore) UpsertRun(ctx context.Context, env RunEnvelope) error {
 	return nil
 }
 
+func (s *SQLiteStore) ReplaceRunWithEvents(ctx context.Context, env RunEnvelope, events []EventEnvelope) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	env.Namespace = strings.TrimSpace(env.Namespace)
+	env.RunID = strings.TrimSpace(env.RunID)
+	if env.Namespace == "" || env.RunID == "" {
+		return fmt.Errorf("execution run namespace and id are required")
+	}
+	env.Kind = strings.TrimSpace(env.Kind)
+	env.Status = strings.TrimSpace(env.Status)
+	env.Stage = strings.TrimSpace(env.Stage)
+	env.SubmittedAt = env.SubmittedAt.UTC()
+	env.UpdatedAt = env.UpdatedAt.UTC()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin execution run replacement tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO execution_runs (
+			namespace, run_id, kind, status, stage, submitted_at, started_at, completed_at, updated_at, payload
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(namespace, run_id) DO UPDATE SET
+			kind = excluded.kind,
+			status = excluded.status,
+			stage = excluded.stage,
+			submitted_at = excluded.submitted_at,
+			started_at = excluded.started_at,
+			completed_at = excluded.completed_at,
+			updated_at = excluded.updated_at,
+			payload = excluded.payload
+	`, env.Namespace, env.RunID, env.Kind, env.Status, env.Stage, env.SubmittedAt, nullableTime(env.StartedAt), nullableTime(env.CompletedAt), env.UpdatedAt, env.Payload); err != nil {
+		return fmt.Errorf("persist execution run: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM execution_events
+		WHERE namespace = ? AND run_id = ?
+	`, env.Namespace, env.RunID); err != nil {
+		return fmt.Errorf("delete execution events: %w", err)
+	}
+
+	for index, event := range events {
+		event.Namespace = strings.TrimSpace(event.Namespace)
+		if event.Namespace == "" {
+			event.Namespace = env.Namespace
+		}
+		event.RunID = strings.TrimSpace(event.RunID)
+		if event.RunID == "" {
+			event.RunID = env.RunID
+		}
+		if event.Namespace != env.Namespace || event.RunID != env.RunID {
+			return fmt.Errorf("execution event namespace/run mismatch for %s/%s", event.Namespace, event.RunID)
+		}
+		if event.RecordedAt.IsZero() {
+			event.RecordedAt = time.Now().UTC()
+		} else {
+			event.RecordedAt = event.RecordedAt.UTC()
+		}
+		if event.Sequence <= 0 {
+			event.Sequence = int64(index + 1)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO execution_events (namespace, run_id, sequence, recorded_at, payload)
+			VALUES (?, ?, ?, ?, ?)
+			ON CONFLICT(namespace, run_id, sequence) DO UPDATE SET
+				recorded_at = excluded.recorded_at,
+				payload = excluded.payload
+		`, event.Namespace, event.RunID, event.Sequence, event.RecordedAt, event.Payload); err != nil {
+			return fmt.Errorf("persist execution event: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit execution run replacement: %w", err)
+	}
+	return nil
+}
+
 func (s *SQLiteStore) LoadRun(ctx context.Context, namespace, runID string) (*RunEnvelope, error) {
 	if s == nil || s.db == nil {
 		return nil, nil
@@ -173,6 +259,14 @@ func (s *SQLiteStore) LoadRun(ctx context.Context, namespace, runID string) (*Ru
 }
 
 func (s *SQLiteStore) ListRuns(ctx context.Context, namespace string, opts RunListOptions) ([]RunEnvelope, error) {
+	return s.listRunsWithNamespaces(ctx, []string{namespace}, opts)
+}
+
+func (s *SQLiteStore) ListAllRuns(ctx context.Context, opts RunListOptions) ([]RunEnvelope, error) {
+	return s.listRunsWithNamespaces(ctx, opts.Namespaces, opts)
+}
+
+func (s *SQLiteStore) listRunsWithNamespaces(ctx context.Context, namespaces []string, opts RunListOptions) ([]RunEnvelope, error) {
 	if s == nil || s.db == nil {
 		return nil, nil
 	}
@@ -182,9 +276,18 @@ func (s *SQLiteStore) ListRuns(ctx context.Context, namespace string, opts RunLi
 	query := `
 		SELECT namespace, run_id, kind, status, stage, submitted_at, started_at, completed_at, updated_at, payload
 		FROM execution_runs
-		WHERE namespace = ?
+		WHERE 1 = 1
 	`
-	args := []any{strings.TrimSpace(namespace)}
+	args := make([]any, 0)
+	namespaces = normalizeNamespaces(namespaces, opts.Namespaces)
+	if len(namespaces) > 0 {
+		placeholders := make([]string, 0, len(namespaces))
+		for _, namespace := range namespaces {
+			placeholders = append(placeholders, "?")
+			args = append(args, namespace)
+		}
+		query += ` AND namespace IN (` + strings.Join(placeholders, ",") + `)` // #nosec G202 -- fixed placeholders; values remain parameterized.
+	}
 	if len(opts.Statuses) > 0 {
 		placeholders := make([]string, 0, len(opts.Statuses))
 		for _, status := range opts.Statuses {
@@ -239,6 +342,48 @@ func (s *SQLiteStore) ListRuns(ctx context.Context, namespace string, opts RunLi
 		return nil, fmt.Errorf("iterate execution runs: %w", err)
 	}
 	return runs, nil
+}
+
+func (s *SQLiteStore) DeleteRun(ctx context.Context, namespace, runID string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	runID = strings.TrimSpace(runID)
+	if namespace == "" || runID == "" {
+		return fmt.Errorf("execution run namespace and id are required")
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		DELETE FROM execution_runs
+		WHERE namespace = ? AND run_id = ?
+	`, namespace, runID); err != nil {
+		return fmt.Errorf("delete execution run: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteEvents(ctx context.Context, namespace, runID string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	runID = strings.TrimSpace(runID)
+	if namespace == "" || runID == "" {
+		return fmt.Errorf("execution event namespace and run id are required")
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		DELETE FROM execution_events
+		WHERE namespace = ? AND run_id = ?
+	`, namespace, runID); err != nil {
+		return fmt.Errorf("delete execution events: %w", err)
+	}
+	return nil
 }
 
 func (s *SQLiteStore) SaveEvent(ctx context.Context, env EventEnvelope) (EventEnvelope, error) {
@@ -347,4 +492,28 @@ func nullableTimeValue(value sql.NullTime) *time.Time {
 	}
 	ts := value.Time.UTC()
 	return &ts
+}
+
+func normalizeNamespaces(primary []string, secondary []string) []string {
+	values := append(append([]string(nil), primary...), secondary...)
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
 }

--- a/internal/executionstore/sqlite_test.go
+++ b/internal/executionstore/sqlite_test.go
@@ -3,9 +3,34 @@ package executionstore
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestSQLiteStoreConfiguresWALAndBusyTimeout(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	var journalMode string
+	if err := store.DB().QueryRowContext(context.Background(), "PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatalf("PRAGMA journal_mode: %v", err)
+	}
+	if strings.ToLower(strings.TrimSpace(journalMode)) != "wal" {
+		t.Fatalf("expected journal_mode WAL, got %q", journalMode)
+	}
+
+	var busyTimeout int
+	if err := store.DB().QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+		t.Fatalf("PRAGMA busy_timeout: %v", err)
+	}
+	if busyTimeout != sqliteBusyTimeoutMS {
+		t.Fatalf("expected busy_timeout %d, got %d", sqliteBusyTimeoutMS, busyTimeout)
+	}
+}
 
 func TestSQLiteStoreIsolatesNamespaces(t *testing.T) {
 	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))

--- a/internal/executionstore/sqlite_test.go
+++ b/internal/executionstore/sqlite_test.go
@@ -122,3 +122,149 @@ func TestSQLiteStoreAllocatesEventSequencesPerRun(t *testing.T) {
 		t.Fatalf("unexpected sequences: first=%d second=%d other=%d", first.Sequence, second.Sequence, other.Sequence)
 	}
 }
+
+func TestSQLiteStoreListsAcrossNamespaces(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC()
+	for _, env := range []RunEnvelope{
+		{Namespace: NamespacePlatformReportRun, RunID: "report-1", Kind: "quality", Status: "succeeded", Stage: "succeeded", SubmittedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Minute), Payload: []byte(`{"kind":"report"}`)},
+		{Namespace: NamespaceWorkloadScan, RunID: "scan-1", Kind: "aws", Status: "running", Stage: "analyze", SubmittedAt: now, UpdatedAt: now, Payload: []byte(`{"kind":"workload"}`)},
+	} {
+		if err := store.UpsertRun(context.Background(), env); err != nil {
+			t.Fatalf("UpsertRun %s: %v", env.RunID, err)
+		}
+	}
+
+	runs, err := store.ListAllRuns(context.Background(), RunListOptions{
+		Namespaces:         []string{NamespacePlatformReportRun, NamespaceWorkloadScan},
+		OrderBySubmittedAt: true,
+	})
+	if err != nil {
+		t.Fatalf("ListAllRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs, got %#v", runs)
+	}
+	if runs[0].RunID != "scan-1" || runs[1].RunID != "report-1" {
+		t.Fatalf("unexpected ordering across namespaces: %#v", runs)
+	}
+}
+
+func TestSQLiteStoreDeleteRunAndEvents(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC()
+	if err := store.UpsertRun(context.Background(), RunEnvelope{
+		Namespace:   NamespacePlatformReportRun,
+		RunID:       "run-delete",
+		Kind:        "quality",
+		Status:      "queued",
+		Stage:       "queued",
+		SubmittedAt: now,
+		UpdatedAt:   now,
+		Payload:     []byte(`{"id":"run-delete"}`),
+	}); err != nil {
+		t.Fatalf("UpsertRun: %v", err)
+	}
+	if _, err := store.SaveEvent(context.Background(), EventEnvelope{
+		Namespace:  NamespacePlatformReportRun,
+		RunID:      "run-delete",
+		RecordedAt: now,
+		Payload:    []byte(`{"message":"queued"}`),
+	}); err != nil {
+		t.Fatalf("SaveEvent: %v", err)
+	}
+	if err := store.DeleteEvents(context.Background(), NamespacePlatformReportRun, "run-delete"); err != nil {
+		t.Fatalf("DeleteEvents: %v", err)
+	}
+	if err := store.DeleteRun(context.Background(), NamespacePlatformReportRun, "run-delete"); err != nil {
+		t.Fatalf("DeleteRun: %v", err)
+	}
+	run, err := store.LoadRun(context.Background(), NamespacePlatformReportRun, "run-delete")
+	if err != nil {
+		t.Fatalf("LoadRun after delete: %v", err)
+	}
+	if run != nil {
+		t.Fatalf("expected run to be deleted, got %#v", run)
+	}
+	events, err := store.LoadEvents(context.Background(), NamespacePlatformReportRun, "run-delete")
+	if err != nil {
+		t.Fatalf("LoadEvents after delete: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected no events after delete, got %#v", events)
+	}
+}
+
+func TestSQLiteStoreReplaceRunWithEventsReplacesEventSetAtomically(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := store.ReplaceRunWithEvents(context.Background(), RunEnvelope{
+		Namespace:   NamespacePlatformReportRun,
+		RunID:       "run-replace",
+		Kind:        "quality",
+		Status:      "queued",
+		Stage:       "queued",
+		SubmittedAt: now,
+		UpdatedAt:   now,
+		Payload:     []byte(`{"id":"run-replace","status":"queued"}`),
+	}, []EventEnvelope{
+		{Sequence: 1, RecordedAt: now, Payload: []byte(`{"type":"queued"}`)},
+	}); err != nil {
+		t.Fatalf("ReplaceRunWithEvents initial: %v", err)
+	}
+
+	later := now.Add(2 * time.Minute)
+	if err := store.ReplaceRunWithEvents(context.Background(), RunEnvelope{
+		Namespace:   NamespacePlatformReportRun,
+		RunID:       "run-replace",
+		Kind:        "quality",
+		Status:      "succeeded",
+		Stage:       "succeeded",
+		SubmittedAt: now,
+		StartedAt:   &now,
+		CompletedAt: &later,
+		UpdatedAt:   later,
+		Payload:     []byte(`{"id":"run-replace","status":"succeeded"}`),
+	}, []EventEnvelope{
+		{Sequence: 1, RecordedAt: now, Payload: []byte(`{"type":"queued"}`)},
+		{Sequence: 2, RecordedAt: later, Payload: []byte(`{"type":"completed"}`)},
+	}); err != nil {
+		t.Fatalf("ReplaceRunWithEvents updated: %v", err)
+	}
+
+	run, err := store.LoadRun(context.Background(), NamespacePlatformReportRun, "run-replace")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run == nil || run.Status != "succeeded" {
+		t.Fatalf("expected updated run envelope, got %#v", run)
+	}
+	events, err := store.LoadEvents(context.Background(), NamespacePlatformReportRun, "run-replace")
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected replaced event set, got %#v", events)
+	}
+	if events[0].Sequence != 1 || string(events[0].Payload) != `{"type":"queued"}` {
+		t.Fatalf("unexpected first event after replace: %#v", events[0])
+	}
+	if events[1].Sequence != 2 || string(events[1].Payload) != `{"type":"completed"}` {
+		t.Fatalf("unexpected second event after replace: %#v", events[1])
+	}
+}

--- a/internal/executionstore/store.go
+++ b/internal/executionstore/store.go
@@ -1,0 +1,26 @@
+package executionstore
+
+import (
+	"context"
+	"time"
+)
+
+// Store is the durable execution-state substrate interface. SQLite is the
+// current implementation, but higher-scale backends should satisfy the same
+// contract instead of forcing callers to depend on SQLite directly.
+type Store interface {
+	Close() error
+	UpsertRun(context.Context, RunEnvelope) error
+	ReplaceRunWithEvents(context.Context, RunEnvelope, []EventEnvelope) error
+	LoadRun(context.Context, string, string) (*RunEnvelope, error)
+	ListRuns(context.Context, string, RunListOptions) ([]RunEnvelope, error)
+	ListAllRuns(context.Context, RunListOptions) ([]RunEnvelope, error)
+	DeleteRun(context.Context, string, string) error
+	DeleteEvents(context.Context, string, string) error
+	SaveEvent(context.Context, EventEnvelope) (EventEnvelope, error)
+	LoadEvents(context.Context, string, string) ([]EventEnvelope, error)
+	LookupProcessedEvent(context.Context, string, string, time.Time) (*ProcessedEventRecord, error)
+	TouchProcessedEvent(context.Context, string, string, time.Time, time.Duration) error
+	RememberProcessedEvent(context.Context, ProcessedEventRecord, int) error
+	DeleteProcessedEvent(context.Context, string, string) error
+}

--- a/internal/functionscan/store.go
+++ b/internal/functionscan/store.go
@@ -20,7 +20,8 @@ type RunStore interface {
 }
 
 type SQLiteRunStore struct {
-	store *executionstore.SQLiteStore
+	store     executionstore.Store
+	ownsStore bool
 }
 
 func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
@@ -28,7 +29,13 @@ func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SQLiteRunStore{store: store}, nil
+	runStore := NewSQLiteRunStoreWithExecutionStore(store)
+	runStore.ownsStore = true
+	return runStore, nil
+}
+
+func NewSQLiteRunStoreWithExecutionStore(store executionstore.Store) *SQLiteRunStore {
+	return &SQLiteRunStore{store: store}
 }
 
 func (s *SQLiteRunStore) SaveRun(ctx context.Context, run *RunRecord) error {
@@ -142,7 +149,7 @@ func (s *SQLiteRunStore) LoadEvents(ctx context.Context, runID string) ([]RunEve
 }
 
 func (s *SQLiteRunStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()

--- a/internal/graph/reports/core_exports.go
+++ b/internal/graph/reports/core_exports.go
@@ -145,7 +145,6 @@ var (
 	hasNodeMetadataProfile        = HasNodeMetadataProfile
 	matchesPropertyType           = MatchesPropertyType
 	sliceContainsString           = SliceContainsString
-	writeJSONAtomic               = WriteJSONAtomic
 )
 
 func cloneTimePtr(value *time.Time) *time.Time {

--- a/internal/graph/reports/report_run_store.go
+++ b/internal/graph/reports/report_run_store.go
@@ -25,7 +25,8 @@ type ReportRunStore struct {
 	executionFile string
 	legacyState   string
 	snapshotDir   string
-	execution     *executionstore.SQLiteStore
+	execution     executionstore.Store
+	ownsExecution bool
 }
 
 type persistedReportRunRecord struct {
@@ -56,16 +57,22 @@ func NewReportRunStore(executionFile, snapshotDir, legacyStateFile string) (*Rep
 	if err != nil {
 		return nil, err
 	}
+	reportStore := NewReportRunStoreWithExecutionStore(store, executionFile, snapshotDir, legacyStateFile)
+	reportStore.ownsExecution = true
+	return reportStore, nil
+}
+
+func NewReportRunStoreWithExecutionStore(store executionstore.Store, executionFile, snapshotDir, legacyStateFile string) *ReportRunStore {
 	return &ReportRunStore{
 		executionFile: strings.TrimSpace(executionFile),
 		legacyState:   strings.TrimSpace(legacyStateFile),
 		snapshotDir:   strings.TrimSpace(snapshotDir),
 		execution:     store,
-	}, nil
+	}
 }
 
 func (s *ReportRunStore) Close() error {
-	if s == nil || s.execution == nil {
+	if s == nil || s.execution == nil || !s.ownsExecution {
 		return nil
 	}
 	return s.execution.Close()

--- a/internal/graph/reports/report_run_store.go
+++ b/internal/graph/reports/report_run_store.go
@@ -2,6 +2,7 @@ package reports
 
 import (
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,30 +10,36 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/writer/cerebro/internal/executionstore"
 )
 
 const (
-	reportRunStoreVersion        = "1"
+	reportRunStoreVersion        = "2"
 	reportSnapshotPayloadVersion = "1"
 )
 
-// ReportRunStore persists report-run metadata separately from materialized result payloads.
+// ReportRunStore persists report-run metadata in the shared execution store
+// while keeping materialized result payloads as separate filesystem artifacts.
 type ReportRunStore struct {
-	stateFile   string
-	snapshotDir string
+	executionFile string
+	legacyState   string
+	snapshotDir   string
+	execution     *executionstore.SQLiteStore
+}
+
+type persistedReportRunRecord struct {
+	Version      string             `json:"version,omitempty"`
+	Run          *ReportRun         `json:"run"`
+	SnapshotFile string             `json:"snapshot_file,omitempty"`
+	Attempts     []ReportRunAttempt `json:"attempts,omitempty"`
+	Events       []ReportRunEvent   `json:"events,omitempty"`
 }
 
 type persistedReportRunStore struct {
 	Version string                     `json:"version"`
 	SavedAt time.Time                  `json:"saved_at"`
 	Runs    []persistedReportRunRecord `json:"runs"`
-}
-
-type persistedReportRunRecord struct {
-	Run          *ReportRun         `json:"run"`
-	SnapshotFile string             `json:"snapshot_file,omitempty"`
-	Attempts     []ReportRunAttempt `json:"attempts,omitempty"`
-	Events       []ReportRunEvent   `json:"events,omitempty"`
 }
 
 type persistedReportSnapshotPayload struct {
@@ -44,23 +51,41 @@ type persistedReportSnapshotPayload struct {
 	Result       map[string]any `json:"result"`
 }
 
-// NewReportRunStore creates a new report-run persistence store.
-func NewReportRunStore(stateFile, snapshotDir string) *ReportRunStore {
-	return &ReportRunStore{
-		stateFile:   strings.TrimSpace(stateFile),
-		snapshotDir: strings.TrimSpace(snapshotDir),
+func NewReportRunStore(executionFile, snapshotDir, legacyStateFile string) (*ReportRunStore, error) {
+	store, err := executionstore.NewSQLiteStore(strings.TrimSpace(executionFile))
+	if err != nil {
+		return nil, err
 	}
+	return &ReportRunStore{
+		executionFile: strings.TrimSpace(executionFile),
+		legacyState:   strings.TrimSpace(legacyStateFile),
+		snapshotDir:   strings.TrimSpace(snapshotDir),
+		execution:     store,
+	}, nil
 }
 
-// StateFile returns the configured report-run state path.
+func (s *ReportRunStore) Close() error {
+	if s == nil || s.execution == nil {
+		return nil
+	}
+	return s.execution.Close()
+}
+
+// StateFile returns the shared execution store path backing report metadata.
 func (s *ReportRunStore) StateFile() string {
 	if s == nil {
 		return ""
 	}
-	return s.stateFile
+	return s.executionFile
 }
 
-// SnapshotDir returns the configured report-snapshot directory.
+func (s *ReportRunStore) LegacyStateFile() string {
+	if s == nil {
+		return ""
+	}
+	return s.legacyState
+}
+
 func (s *ReportRunStore) SnapshotDir() string {
 	if s == nil {
 		return ""
@@ -68,25 +93,278 @@ func (s *ReportRunStore) SnapshotDir() string {
 	return s.snapshotDir
 }
 
-// Load restores persisted report runs and any materialized snapshots.
 func (s *ReportRunStore) Load() (map[string]*ReportRun, error) {
 	runs := make(map[string]*ReportRun)
-	if s == nil || strings.TrimSpace(s.stateFile) == "" {
+	if s == nil || s.execution == nil {
 		return runs, nil
 	}
-	data, err := os.ReadFile(s.stateFile)
+	storedRuns, err := s.ListRuns("")
+	if err != nil {
+		return nil, err
+	}
+	for _, run := range storedRuns {
+		if run == nil || strings.TrimSpace(run.ID) == "" {
+			continue
+		}
+		runs[run.ID] = run
+	}
+	if len(runs) > 0 || strings.TrimSpace(s.legacyState) == "" {
+		return runs, nil
+	}
+	legacyRuns, err := s.loadLegacyState()
+	if err != nil {
+		return nil, err
+	}
+	if len(legacyRuns) == 0 {
+		return runs, nil
+	}
+	if err := s.SaveAll(legacyRuns); err != nil {
+		return nil, fmt.Errorf("import legacy report run state: %w", err)
+	}
+	return legacyRuns, nil
+}
+
+func (s *ReportRunStore) LoadRun(runID string) (*ReportRun, error) {
+	if s == nil || s.execution == nil {
+		return nil, nil
+	}
+	env, err := s.execution.LoadRun(context.Background(), executionstore.NamespacePlatformReportRun, strings.TrimSpace(runID))
+	if err != nil || env == nil {
+		return nil, err
+	}
+	return s.decodeRunEnvelope(*env)
+}
+
+func (s *ReportRunStore) ListRuns(reportID string) ([]*ReportRun, error) {
+	if s == nil || s.execution == nil {
+		return nil, nil
+	}
+	envs, err := s.execution.ListRuns(context.Background(), executionstore.NamespacePlatformReportRun, executionstore.RunListOptions{
+		OrderBySubmittedAt: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	runs := make([]*ReportRun, 0, len(envs))
+	reportID = strings.TrimSpace(reportID)
+	for _, env := range envs {
+		run, err := s.decodeRunEnvelope(env)
+		if err != nil {
+			return nil, err
+		}
+		if run == nil {
+			continue
+		}
+		if reportID != "" && strings.TrimSpace(run.ReportID) != reportID {
+			continue
+		}
+		runs = append(runs, run)
+	}
+	return runs, nil
+}
+
+func (s *ReportRunStore) SaveRun(run *ReportRun) error {
+	if s == nil || s.execution == nil || run == nil {
+		return nil
+	}
+	previous, err := s.LoadRun(run.ID)
+	if err != nil {
+		return err
+	}
+	retainedSnapshots := make(map[string]struct{})
+	if err := s.persistRun(context.Background(), run, retainedSnapshots); err != nil {
+		return err
+	}
+	if previous != nil && previous.Snapshot != nil {
+		if name := filepath.Base(strings.TrimSpace(previous.Snapshot.StoragePath)); name != "" {
+			if run.Snapshot == nil || filepath.Base(strings.TrimSpace(run.Snapshot.StoragePath)) != name {
+				if err := os.Remove(filepath.Join(s.snapshotRoot(), name)); err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("remove superseded report snapshot %s: %w", name, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// SaveAll persists the current report-run set into the shared execution store.
+func (s *ReportRunStore) SaveAll(runs map[string]*ReportRun) error {
+	if s == nil || s.execution == nil {
+		return nil
+	}
+	ctx := context.Background()
+	existing, err := s.execution.ListRuns(ctx, executionstore.NamespacePlatformReportRun, executionstore.RunListOptions{})
+	if err != nil {
+		return fmt.Errorf("list report runs: %w", err)
+	}
+	retainedRuns := make(map[string]struct{}, len(runs))
+	retainedSnapshots := make(map[string]struct{}, len(runs))
+	ids := make([]string, 0, len(runs))
+	for id := range runs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		run := runs[id]
+		if run == nil {
+			continue
+		}
+		retainedRuns[strings.TrimSpace(run.ID)] = struct{}{}
+		if err := s.persistRun(ctx, run, retainedSnapshots); err != nil {
+			return err
+		}
+	}
+	for _, env := range existing {
+		if _, ok := retainedRuns[strings.TrimSpace(env.RunID)]; ok {
+			continue
+		}
+		if err := s.execution.DeleteEvents(ctx, executionstore.NamespacePlatformReportRun, env.RunID); err != nil {
+			return fmt.Errorf("delete report run events %q: %w", env.RunID, err)
+		}
+		if err := s.execution.DeleteRun(ctx, executionstore.NamespacePlatformReportRun, env.RunID); err != nil {
+			return fmt.Errorf("delete report run %q: %w", env.RunID, err)
+		}
+	}
+	if err := s.cleanupSnapshotFiles(retainedSnapshots); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *ReportRunStore) persistRun(ctx context.Context, input *ReportRun, retainedSnapshots map[string]struct{}) error {
+	run := CloneReportRun(input)
+	if run == nil {
+		return nil
+	}
+	record := persistedReportRunRecord{
+		Version:  reportRunStoreVersion,
+		Run:      run,
+		Attempts: CloneReportRunAttempts(run.Attempts),
+	}
+	if run.Snapshot != nil {
+		snapshotPath := strings.TrimSpace(run.Snapshot.StoragePath)
+		if snapshotPath == "" {
+			snapshotPath = s.snapshotPathForRun(run.ReportID, run.ID)
+			run.Snapshot.StoragePath = snapshotPath
+		}
+		record.SnapshotFile = filepath.Base(snapshotPath)
+		if retainedSnapshots != nil {
+			retainedSnapshots[record.SnapshotFile] = struct{}{}
+		}
+		if run.Result != nil {
+			payload := persistedReportSnapshotPayload{
+				Version:      reportSnapshotPayloadVersion,
+				RunID:        run.ID,
+				ReportID:     run.ReportID,
+				ResultSchema: run.Snapshot.ResultSchema,
+				GeneratedAt:  run.Snapshot.GeneratedAt,
+				Result:       cloneReportResult(run.Result),
+			}
+			if err := saveReportSnapshotPayload(snapshotPath, payload); err != nil {
+				return err
+			}
+		}
+	}
+	record.Run.Result = nil
+
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("encode report run %q: %w", run.ID, err)
+	}
+	runEnv := executionstore.RunEnvelope{
+		Namespace:   executionstore.NamespacePlatformReportRun,
+		RunID:       strings.TrimSpace(run.ID),
+		Kind:        strings.TrimSpace(run.ReportID),
+		Status:      strings.TrimSpace(run.Status),
+		Stage:       reportRunStage(run),
+		SubmittedAt: run.SubmittedAt.UTC(),
+		StartedAt:   run.StartedAt,
+		CompletedAt: run.CompletedAt,
+		UpdatedAt:   reportRunUpdatedAt(run),
+		Payload:     payload,
+	}
+	eventEnvs := make([]executionstore.EventEnvelope, 0, len(run.Events))
+	for _, event := range run.Events {
+		eventPayload, err := json.Marshal(event)
+		if err != nil {
+			return fmt.Errorf("encode report run event %q/%d: %w", run.ID, event.Sequence, err)
+		}
+		eventEnvs = append(eventEnvs, executionstore.EventEnvelope{
+			Namespace:  executionstore.NamespacePlatformReportRun,
+			RunID:      run.ID,
+			Sequence:   int64(event.Sequence),
+			RecordedAt: event.Timestamp.UTC(),
+			Payload:    eventPayload,
+		})
+	}
+	if err := s.execution.ReplaceRunWithEvents(ctx, runEnv, eventEnvs); err != nil {
+		return fmt.Errorf("persist report run %q: %w", run.ID, err)
+	}
+	return nil
+}
+
+func (s *ReportRunStore) decodeRunEnvelope(env executionstore.RunEnvelope) (*ReportRun, error) {
+	var record persistedReportRunRecord
+	if err := json.Unmarshal(env.Payload, &record); err != nil {
+		return nil, fmt.Errorf("decode report run payload %q: %w", env.RunID, err)
+	}
+	if record.Run == nil || strings.TrimSpace(record.Run.ID) == "" {
+		return nil, nil
+	}
+	run := CloneReportRun(record.Run)
+	run.Attempts = CloneReportRunAttempts(record.Attempts)
+	run.AttemptCount = len(run.Attempts)
+	events, err := s.execution.LoadEvents(context.Background(), executionstore.NamespacePlatformReportRun, run.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load report run events %q: %w", run.ID, err)
+	}
+	run.Events = decodeReportRunEvents(events)
+	if len(run.Events) == 0 {
+		run.Events = CloneReportRunEvents(record.Events)
+	}
+	run.EventCount = len(run.Events)
+	if run.Snapshot != nil && strings.TrimSpace(record.SnapshotFile) != "" {
+		run.Snapshot.StoragePath = filepath.Join(s.snapshotRoot(), strings.TrimSpace(record.SnapshotFile))
+		payload, err := loadReportSnapshotPayload(run.Snapshot.StoragePath)
+		if err == nil {
+			run.Result = cloneReportResult(payload.Result)
+		}
+	}
+	return run, nil
+}
+
+func decodeReportRunEvents(envs []executionstore.EventEnvelope) []ReportRunEvent {
+	events := make([]ReportRunEvent, 0, len(envs))
+	for _, env := range envs {
+		var event ReportRunEvent
+		if err := json.Unmarshal(env.Payload, &event); err != nil {
+			continue
+		}
+		event.Sequence = int(env.Sequence)
+		if event.Timestamp.IsZero() {
+			event.Timestamp = env.RecordedAt.UTC()
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func (s *ReportRunStore) loadLegacyState() (map[string]*ReportRun, error) {
+	runs := make(map[string]*ReportRun)
+	path := strings.TrimSpace(s.legacyState)
+	if path == "" {
+		return runs, nil
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- legacy state path is platform-controlled local storage configuration.
 	if err != nil {
 		if os.IsNotExist(err) {
 			return runs, nil
 		}
-		return nil, fmt.Errorf("read report run state: %w", err)
+		return nil, fmt.Errorf("read legacy report run state: %w", err)
 	}
 	var state persistedReportRunStore
 	if err := json.Unmarshal(data, &state); err != nil {
-		return nil, fmt.Errorf("decode report run state: %w", err)
-	}
-	if version := strings.TrimSpace(state.Version); version != "" && version != reportRunStoreVersion {
-		return nil, fmt.Errorf("unsupported report run state version %q", version)
+		return nil, fmt.Errorf("decode legacy report run state: %w", err)
 	}
 	for _, record := range state.Runs {
 		if record.Run == nil || strings.TrimSpace(record.Run.ID) == "" {
@@ -94,11 +372,11 @@ func (s *ReportRunStore) Load() (map[string]*ReportRun, error) {
 		}
 		run := CloneReportRun(record.Run)
 		run.Attempts = CloneReportRunAttempts(record.Attempts)
-		run.Events = CloneReportRunEvents(record.Events)
 		run.AttemptCount = len(run.Attempts)
+		run.Events = CloneReportRunEvents(record.Events)
 		run.EventCount = len(run.Events)
 		if run.Snapshot != nil && strings.TrimSpace(record.SnapshotFile) != "" {
-			run.Snapshot.StoragePath = filepath.Join(s.snapshotDir, strings.TrimSpace(record.SnapshotFile))
+			run.Snapshot.StoragePath = filepath.Join(s.snapshotRoot(), strings.TrimSpace(record.SnapshotFile))
 			payload, err := loadReportSnapshotPayload(run.Snapshot.StoragePath)
 			if err == nil {
 				run.Result = cloneReportResult(payload.Result)
@@ -109,76 +387,47 @@ func (s *ReportRunStore) Load() (map[string]*ReportRun, error) {
 	return runs, nil
 }
 
-// SaveAll persists the full report-run index and any retained snapshot payloads.
-func (s *ReportRunStore) SaveAll(runs map[string]*ReportRun) error {
-	if s == nil || strings.TrimSpace(s.stateFile) == "" {
-		return nil
+func reportRunStage(run *ReportRun) string {
+	if run == nil {
+		return ""
 	}
-	state := persistedReportRunStore{
-		Version: reportRunStoreVersion,
-		SavedAt: time.Now().UTC(),
-		Runs:    make([]persistedReportRunRecord, 0, len(runs)),
+	if attempt := LatestReportRunAttempt(run); attempt != nil && strings.TrimSpace(attempt.Status) != "" {
+		return strings.TrimSpace(attempt.Status)
 	}
-	ids := make([]string, 0, len(runs))
-	for id := range runs {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
+	return strings.TrimSpace(run.Status)
+}
 
-	retainedSnapshots := make(map[string]struct{})
-	for _, id := range ids {
-		run := CloneReportRun(runs[id])
-		if run == nil {
-			continue
-		}
-		record := persistedReportRunRecord{Run: run}
-		record.Attempts = CloneReportRunAttempts(run.Attempts)
-		record.Events = CloneReportRunEvents(run.Events)
-		if run.Snapshot != nil {
-			snapshotPath := strings.TrimSpace(run.Snapshot.StoragePath)
-			if snapshotPath == "" {
-				snapshotPath = s.snapshotPathForRun(run.ReportID, run.ID)
-				run.Snapshot.StoragePath = snapshotPath
-			}
-			record.SnapshotFile = filepath.Base(snapshotPath)
-			retainedSnapshots[record.SnapshotFile] = struct{}{}
-			if run.Result != nil {
-				payload := persistedReportSnapshotPayload{
-					Version:      reportSnapshotPayloadVersion,
-					RunID:        run.ID,
-					ReportID:     run.ReportID,
-					ResultSchema: run.Snapshot.ResultSchema,
-					GeneratedAt:  run.Snapshot.GeneratedAt,
-					Result:       cloneReportResult(run.Result),
-				}
-				if err := saveReportSnapshotPayload(snapshotPath, payload); err != nil {
-					return err
-				}
-			}
-		}
-		run.Result = nil
-		state.Runs = append(state.Runs, record)
+func reportRunUpdatedAt(run *ReportRun) time.Time {
+	if run == nil {
+		return time.Now().UTC()
 	}
-	if err := s.cleanupSnapshotFiles(retainedSnapshots); err != nil {
-		return err
+	if run.CompletedAt != nil && !run.CompletedAt.IsZero() {
+		return run.CompletedAt.UTC()
 	}
-	return writeJSONAtomic(s.stateFile, state)
+	if len(run.Events) > 0 {
+		return run.Events[len(run.Events)-1].Timestamp.UTC()
+	}
+	if run.StartedAt != nil && !run.StartedAt.IsZero() {
+		return run.StartedAt.UTC()
+	}
+	return run.SubmittedAt.UTC()
+}
+
+func (s *ReportRunStore) snapshotRoot() string {
+	dir := strings.TrimSpace(s.snapshotDir)
+	if dir == "" {
+		dir = filepath.Join(filepath.Dir(s.executionFile), "report-snapshots")
+	}
+	return dir
 }
 
 func (s *ReportRunStore) snapshotPathForRun(reportID, runID string) string {
-	dir := strings.TrimSpace(s.snapshotDir)
-	if dir == "" {
-		dir = filepath.Join(filepath.Dir(s.stateFile), "snapshots")
-	}
 	filename := sanitizeReportFileName(reportID) + "-" + sanitizeReportFileName(runID) + ".json.gz"
-	return filepath.Join(dir, filename)
+	return filepath.Join(s.snapshotRoot(), filename)
 }
 
 func (s *ReportRunStore) cleanupSnapshotFiles(retained map[string]struct{}) error {
-	dir := strings.TrimSpace(s.snapshotDir)
-	if dir == "" {
-		return nil
-	}
+	dir := s.snapshotRoot()
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -206,7 +455,7 @@ func saveReportSnapshotPayload(path string, payload persistedReportSnapshotPaylo
 		return fmt.Errorf("create report snapshot dir: %w", err)
 	}
 	tmpFile := path + ".tmp"
-	file, err := os.Create(tmpFile) // #nosec G304 -- report snapshot path is configured by the local platform operator and intentionally file-system based.
+	file, err := os.Create(tmpFile) // #nosec G304 -- report snapshot path is platform-controlled local storage.
 	if err != nil {
 		return fmt.Errorf("create report snapshot file: %w", err)
 	}
@@ -234,7 +483,7 @@ func saveReportSnapshotPayload(path string, payload persistedReportSnapshotPaylo
 }
 
 func loadReportSnapshotPayload(path string) (*persistedReportSnapshotPayload, error) {
-	file, err := os.Open(path) // #nosec G304 -- report snapshot path is configured by the local platform operator and intentionally file-system based.
+	file, err := os.Open(path) // #nosec G304 -- report snapshot path is platform-controlled local storage.
 	if err != nil {
 		return nil, fmt.Errorf("open report snapshot payload: %w", err)
 	}

--- a/internal/graph/reports/report_run_store_test.go
+++ b/internal/graph/reports/report_run_store_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/writer/cerebro/internal/executionstore"
 )
 
 func TestReportRunStoreRoundTrip(t *testing.T) {
@@ -64,7 +66,11 @@ func TestReportRunStoreRoundTrip(t *testing.T) {
 	run.Snapshot.Storage = CloneReportStoragePolicy(run.Storage)
 
 	stateDir := t.TempDir()
-	store := NewReportRunStore(filepath.Join(stateDir, "state.json"), filepath.Join(stateDir, "snapshots"))
+	store, err := NewReportRunStore(filepath.Join(stateDir, "executions.db"), filepath.Join(stateDir, "snapshots"), filepath.Join(stateDir, "legacy-state.json"))
+	if err != nil {
+		t.Fatalf("NewReportRunStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
 	if err := store.SaveAll(map[string]*ReportRun{run.ID: run}); err != nil {
 		t.Fatalf("save report runs: %v", err)
 	}
@@ -116,6 +122,69 @@ func TestReportRunStoreRoundTrip(t *testing.T) {
 	}
 	if loaded.Snapshot.Storage.StorageClass != "local_durable" {
 		t.Fatalf("expected restored snapshot storage, got %+v", loaded.Snapshot.Storage)
+	}
+
+	executionStore, err := executionstore.NewSQLiteStore(store.StateFile())
+	if err != nil {
+		t.Fatalf("open shared execution store: %v", err)
+	}
+	defer func() { _ = executionStore.Close() }()
+	envs, err := executionStore.ListRuns(t.Context(), executionstore.NamespacePlatformReportRun, executionstore.RunListOptions{})
+	if err != nil {
+		t.Fatalf("ListRuns report namespace: %v", err)
+	}
+	if len(envs) != 1 || envs[0].RunID != run.ID {
+		t.Fatalf("expected persisted report run in shared execution store, got %#v", envs)
+	}
+}
+
+func TestReportRunStoreSaveRunReplacesPersistedEvents(t *testing.T) {
+	now := time.Date(2026, 3, 10, 1, 0, 0, 0, time.UTC)
+	run := &ReportRun{
+		ID:            "report_run:replace-events",
+		ReportID:      "quality",
+		Status:        ReportRunStatusQueued,
+		ExecutionMode: ReportExecutionModeAsync,
+		SubmittedAt:   now,
+	}
+	AppendReportRunEvent(run, "platform.report_run.queued", ReportRunStatusQueued, "api.request", "alice", now, nil)
+	run.EventCount = len(run.Events)
+
+	stateDir := t.TempDir()
+	store, err := NewReportRunStore(filepath.Join(stateDir, "executions.db"), filepath.Join(stateDir, "snapshots"), filepath.Join(stateDir, "legacy-state.json"))
+	if err != nil {
+		t.Fatalf("NewReportRunStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveRun(run); err != nil {
+		t.Fatalf("SaveRun initial: %v", err)
+	}
+
+	run.Status = ReportRunStatusSucceeded
+	run.CompletedAt = timePtr(now.Add(2 * time.Minute))
+	AppendReportRunEvent(run, "platform.report_run.completed", ReportRunStatusSucceeded, "api.request", "alice", now.Add(2*time.Minute), nil)
+	run.EventCount = len(run.Events)
+
+	if err := store.SaveRun(run); err != nil {
+		t.Fatalf("SaveRun updated: %v", err)
+	}
+
+	loaded, err := store.LoadRun(run.ID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected saved run")
+	}
+	if loaded.Status != ReportRunStatusSucceeded {
+		t.Fatalf("expected updated status, got %+v", loaded)
+	}
+	if len(loaded.Events) != 2 {
+		t.Fatalf("expected replaced persisted events, got %+v", loaded.Events)
+	}
+	if loaded.Events[0].Type != "platform.report_run.queued" || loaded.Events[1].Type != "platform.report_run.completed" {
+		t.Fatalf("unexpected persisted event ordering: %+v", loaded.Events)
 	}
 }
 

--- a/internal/graph/reports/report_run_store_test.go
+++ b/internal/graph/reports/report_run_store_test.go
@@ -188,6 +188,33 @@ func TestReportRunStoreSaveRunReplacesPersistedEvents(t *testing.T) {
 	}
 }
 
+func TestReportRunStoreWithSharedExecutionStoreDoesNotOwnClose(t *testing.T) {
+	stateDir := t.TempDir()
+	executionStore, err := executionstore.NewSQLiteStore(filepath.Join(stateDir, "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = executionStore.Close() }()
+
+	store := NewReportRunStoreWithExecutionStore(executionStore, filepath.Join(stateDir, "executions.db"), filepath.Join(stateDir, "snapshots"), filepath.Join(stateDir, "legacy-state.json"))
+	if err := store.Close(); err != nil {
+		t.Fatalf("ReportRunStore.Close(): %v", err)
+	}
+
+	if err := executionStore.UpsertRun(t.Context(), executionstore.RunEnvelope{
+		Namespace:   executionstore.NamespacePlatformReportRun,
+		RunID:       "report_run:shared-close",
+		Kind:        "quality",
+		Status:      string(ReportRunStatusQueued),
+		Stage:       string(ReportRunStatusQueued),
+		SubmittedAt: time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC),
+		Payload:     []byte(`{"run":{"id":"report_run:shared-close","report_id":"quality","status":"queued","submitted_at":"2026-03-12T09:00:00Z"}}`),
+	}); err != nil {
+		t.Fatalf("UpsertRun after borrowed store close: %v", err)
+	}
+}
+
 func timePtr(value time.Time) *time.Time {
 	return &value
 }

--- a/internal/imagescan/store.go
+++ b/internal/imagescan/store.go
@@ -20,7 +20,8 @@ type RunStore interface {
 }
 
 type SQLiteRunStore struct {
-	store *executionstore.SQLiteStore
+	store     executionstore.Store
+	ownsStore bool
 }
 
 func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
@@ -28,7 +29,13 @@ func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SQLiteRunStore{store: store}, nil
+	runStore := NewSQLiteRunStoreWithExecutionStore(store)
+	runStore.ownsStore = true
+	return runStore, nil
+}
+
+func NewSQLiteRunStoreWithExecutionStore(store executionstore.Store) *SQLiteRunStore {
+	return &SQLiteRunStore{store: store}
 }
 
 func (s *SQLiteRunStore) SaveRun(ctx context.Context, run *RunRecord) error {
@@ -142,7 +149,7 @@ func (s *SQLiteRunStore) LoadEvents(ctx context.Context, runID string) ([]RunEve
 }
 
 func (s *SQLiteRunStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -284,6 +284,22 @@ var (
 		[]string{"stream", "durable"},
 	)
 
+	NATSConsumerProcessedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cerebro_nats_consumer_processed_total",
+			Help: "Total number of NATS consumer messages processed successfully",
+		},
+		[]string{"stream", "durable"},
+	)
+
+	NATSConsumerDeduplicatedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cerebro_nats_consumer_deduplicated_total",
+			Help: "Total number of NATS consumer messages skipped because the CloudEvent was already processed",
+		},
+		[]string{"stream", "durable"},
+	)
+
 	NATSConsumerLag = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cerebro_nats_consumer_lag",
@@ -542,6 +558,8 @@ func Register() {
 			JetStreamBackpressureAlertsTotal,
 			NATSConsumerDroppedTotal,
 			NATSConsumerRedeliveriesTotal,
+			NATSConsumerProcessedTotal,
+			NATSConsumerDeduplicatedTotal,
 			NATSConsumerLag,
 			NATSConsumerLagSeconds,
 			GraphBuildStatus,
@@ -806,6 +824,26 @@ func RecordNATSConsumerRedelivery(stream, durable string) {
 		durable = "unknown"
 	}
 	NATSConsumerRedeliveriesTotal.WithLabelValues(stream, durable).Inc()
+}
+
+func RecordNATSConsumerProcessed(stream, durable string) {
+	if strings.TrimSpace(stream) == "" {
+		stream = "unknown"
+	}
+	if strings.TrimSpace(durable) == "" {
+		durable = "unknown"
+	}
+	NATSConsumerProcessedTotal.WithLabelValues(stream, durable).Inc()
+}
+
+func RecordNATSConsumerDeduplicated(stream, durable string) {
+	if strings.TrimSpace(stream) == "" {
+		stream = "unknown"
+	}
+	if strings.TrimSpace(durable) == "" {
+		durable = "unknown"
+	}
+	NATSConsumerDeduplicatedTotal.WithLabelValues(stream, durable).Inc()
 }
 
 func SetNATSConsumerLag(stream, durable string, lag int) {

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -279,6 +279,8 @@ func TestJetStreamMetrics(t *testing.T) {
 	RecordJetStreamBackpressureAlert("CEREBRO_EVENTS", "warning")
 	RecordJetStreamBackpressureAlert("CEREBRO_EVENTS", "critical")
 	RecordJetStreamBackpressureAlert("CEREBRO_EVENTS", "recovered")
+	RecordNATSConsumerProcessed("ENSEMBLE_TAP", "cerebro_graph_builder")
+	RecordNATSConsumerDeduplicated("ENSEMBLE_TAP", "cerebro_graph_builder")
 }
 
 func TestSetGraphLastUpdateDoesNotRegress(t *testing.T) {

--- a/internal/workloadscan/store.go
+++ b/internal/workloadscan/store.go
@@ -20,7 +20,8 @@ type RunStore interface {
 }
 
 type SQLiteRunStore struct {
-	store *executionstore.SQLiteStore
+	store     executionstore.Store
+	ownsStore bool
 }
 
 func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
@@ -28,7 +29,13 @@ func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SQLiteRunStore{store: store}, nil
+	runStore := NewSQLiteRunStoreWithExecutionStore(store)
+	runStore.ownsStore = true
+	return runStore, nil
+}
+
+func NewSQLiteRunStoreWithExecutionStore(store executionstore.Store) *SQLiteRunStore {
+	return &SQLiteRunStore{store: store}
 }
 
 func (s *SQLiteRunStore) SaveRun(ctx context.Context, run *RunRecord) error {
@@ -142,7 +149,7 @@ func (s *SQLiteRunStore) LoadEvents(ctx context.Context, runID string) ([]RunEve
 }
 
 func (s *SQLiteRunStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()

--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -112,6 +112,10 @@ class Client:
         return self.call_tool("cerebro_entity_history", args)
 
 
+    def execution_status(self, args: Any) -> Any:
+        return self.call_tool("cerebro_execution_status", args)
+
+
     def findings(self, args: Any) -> Any:
         return self.call_tool("cerebro_findings", args)
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -187,6 +187,11 @@ export class Client {
   }
 
 
+  async executionStatus(args: unknown): Promise<ToolCallResponse> {
+    return this.callTool("cerebro_execution_status", args);
+  }
+
+
   async findings(args: unknown): Promise<ToolCallResponse> {
     return this.callTool("cerebro_findings", args);
   }


### PR DESCRIPTION
## Summary
- move platform report metadata and cross-surface execution state onto the shared execution store with a new execution namespace catalog
- add `/api/v1/platform/executions` plus `cerebro.execution_status` so platform, agent SDK, and tools can list reports, scans, and action runs through one surface
- regenerate API and Agent SDK contracts/packages and add persistence coverage for shared execution-store report runs

## Testing
- go test ./internal/api ./internal/app ./internal/apptest ./internal/executionstore ./internal/graph/reports ./internal/executions -count=1
- make devex-pr
- python3 scripts/oss_audit.py
