### PR TITLE
feat(events): add durable cloudevent deduplication

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,32 @@ Owner: @haasonsaas
 Mode: implement in full, keep CI green
 Status: executed end-to-end via PR workflow
 
+## Deep Review Cycle 66 - Shared Execution Store Convergence (2026-03-12)
+
+### Review findings
+- [x] Gap: issue `#209` was still only partially true; the repo had a shared execution-store package, but report runs, action executions, consumer dedupe, and scan materialization still reopened concrete SQLite stores and therefore kept backend assumptions in leaf services.
+- [x] Gap: that concrete `*executionstore.SQLiteStore` coupling would make a future multi-worker backend migration harder than it needs to be, which matters because SQLite is an acceptable default but not the long-term answer for larger customers.
+- [x] Gap: API/server tests were still proving persistence behavior through wrapper ownership assumptions instead of the actual shared execution-store boundary.
+- [x] Gap: GitHub/wider-project references reinforce the right seam:
+  - [x] `dagster-io/dagster` keeps run state on a generic storage contract while layering richer indexes/tags on top.
+  - [x] `argoproj/argo-workflows` keeps execution status and node state explicit rather than hiding orchestration state in process memory.
+  - [x] the Wiz schema dump in `/Users/jonathanhaas/Downloads/other/wiz.graphql` is a useful reminder that broad query surfaces stay tractable only when the underlying execution resources remain typed and inspectable.
+
+### Execution plan
+- [x] Extract a backend-neutral shared execution-store contract:
+  - [x] add `executionstore.Store`
+  - [x] move callers off concrete `*executionstore.SQLiteStore` dependencies where they only need the shared contract
+- [x] Centralize app-level shared execution-store ownership:
+  - [x] initialize one shared app execution store from `EXECUTION_STORE_FILE`
+  - [x] thread that shared handle into API/report/action/consumer paths when they point at the same underlying store
+  - [x] keep wrapper-specific `Close()` semantics from accidentally closing borrowed shared stores
+- [x] Preserve durable behavior while removing wrapper-owned assumptions:
+  - [x] update report-run persistence tests to fail through the shared store itself
+  - [x] keep scan/action/report/consumer paths green under the shared contract
+- [x] Add follow-on scale direction to the backlog:
+  - [x] document that SQLite remains the default implementation for now
+  - [x] make “higher-scale backend behind `executionstore.Store`” the next scale seam instead of deepening SQLite-only code paths
+
 ## Deep Review Cycle 65 - Durable CloudEvent Deduplication for NATS Consumer (2026-03-12)
 
 ### Review findings

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,88 @@ Owner: @haasonsaas
 Mode: implement in full, keep CI green
 Status: executed end-to-end via PR workflow
 
+## Deep Review Cycle 65 - Durable CloudEvent Deduplication for NATS Consumer (2026-03-12)
+
+### Review findings
+- [x] Gap: issue `#248` was still materially open because the JetStream consumer acknowledged events after handler success but had no durable CloudEvent-ID suppression, so transient ack failures and consumer restarts could re-run the same mutation path.
+- [x] Gap: the issue proposal allowed an in-memory sliding window with periodic persistence, but that would still leave a correctness hole on restart and does not match the broader platform direction toward shared execution state.
+- [x] Gap: consumer observability exposed redeliveries and dropped messages, but not the actual successful-vs-deduplicated throughput split needed to prove the pipeline is suppressing duplicates instead of just retrying them.
+- [x] Gap: external references were directionally useful but not prescriptive here:
+  - [x] `argoproj/argo-events` reinforces durable event-processing state over process-local memory when workflows restart.
+  - [x] `OpenLineage/OpenLineage` reinforces treating event identity as a first-class contract surface instead of an incidental transport detail.
+  - [x] the Wiz schema dump in `/Users/jonathanhaas/Downloads/other/wiz.graphql` is a useful caution that very broad event/query surfaces become harder to reason about unless identity and processing contracts are explicit and inspectable.
+
+### Execution plan
+- [x] Add durable processed-event storage in the shared execution store:
+  - [x] add `processed_events` persistence + indexes in the SQLite execution store
+  - [x] add processed-event lookup/remember helpers with TTL and bounded retention
+- [x] Add consumer-level CloudEvent dedupe:
+  - [x] derive a deterministic dedupe key from tenant/source/event ID
+  - [x] skip handler execution when the CloudEvent is already recorded in the dedupe window
+  - [x] log payload-hash mismatches for duplicate IDs carrying different payloads
+- [x] Expose config and metrics:
+  - [x] add NATS consumer dedupe env/config fields with validation
+  - [x] add processed and deduplicated Prometheus counters
+  - [x] document the new config in `docs/CONFIG_ENV_VARS.md`
+- [x] Add regression coverage:
+  - [x] execution-store round trip + bounded retention tests
+  - [x] consumer duplicate suppression tests
+  - [x] metrics registration coverage
+
+### Detailed follow-on backlog
+- [ ] Track A - Stronger idempotency semantics
+  - Exit criteria:
+  - [ ] add durable in-flight / completed processing states instead of completed-event memory only
+  - [ ] thread idempotency keys into graph mutation write paths so handler replay becomes a true no-op
+- [ ] Track B - Dedupe lifecycle observability
+  - Exit criteria:
+  - [ ] add dedupe-store health metrics and storage-pressure telemetry
+  - [ ] expose dedupe hit/miss posture in consumer health/readiness reporting
+- [ ] Track C - Ordered entity-local sequencing
+  - Exit criteria:
+  - [ ] add per-entity ordering windows for create/update/delete event families that cannot tolerate reorder
+  - [ ] keep that sequencing logic separate from the generic dedupe window
+
+## Deep Review Cycle 64 - Coverage Ratchet for Critical Packages: Sync + API (2026-03-12)
+
+### Review findings
+- [x] Gap: issue `#152` was still open even after warehouse/test seams improved because CI was still enforcing stale package floors: `internal/api` at `40%` despite already exceeding `55%`, and `internal/sync` at `11.5%` despite the highest orchestration complexity in the repo.
+- [x] Gap: the real blocker was not `internal/api`; shared app test helpers already existed via `internal/apptest`, and package coverage was already above the requested floor.
+- [x] Gap: `internal/sync` needed honest coverage work in the warehouse-backed orchestration seams we actually rely on today: sync coordination, CDC event emission, scoped persistence helpers, and provider-specific change-history paths.
+- [x] Gap: external references reinforced the same discipline from different angles:
+  - [x] `openfga/openfga` keeps transport and service seams narrow enough that handler/service tests are cheap instead of requiring full-process integration.
+  - [x] `grafana/grafana` is the warning case for broad surface area where package-level ratchets only work if helper seams exist first.
+  - [x] the Wiz schema dump in `/Users/jonathanhaas/Downloads/wiz.graphql` remains the opposite cautionary example: large ambient surfaces become difficult to test rigorously unless they are broken into explicit modules and query seams.
+
+### Execution plan
+- [x] Raise real sync coverage with warehouse-backed tests:
+  - [x] add CDC builder tests for event IDs, payload extraction, and scope fallback
+  - [x] add sync engine tests for change history, partial fetch backfill, and CDC emission
+  - [x] add scoped table operation tests for scoped deletes, provider change history, and merge behavior
+  - [x] add GCP/Kubernetes provider tests covering CDC emission and shared persistence helpers
+  - [x] add helper/fetch-wrapper tests for retry helpers, region-limit helpers, and thin provider fetch delegates
+- [x] Re-measure package coverage before touching CI:
+  - [x] `internal/sync` now measures `21.0%`
+  - [x] `internal/api` measures `64.4%`
+- [x] Ratchet CI floors to measured reality:
+  - [x] raise `internal/api` threshold from `40.0` to `55.0`
+  - [x] raise `internal/sync` threshold from `11.5` to `20.0`
+
+### Detailed follow-on backlog
+- [ ] Track A - Next sync coverage ratchet to `30%`
+  - Exit criteria:
+  - [ ] add deeper relationship extraction tests for AWS/GCP relationship builders
+  - [ ] add more provider fetch/retry edge-case coverage around partial-page and auth failure handling
+  - [ ] raise the `internal/sync` CI floor from `20.0` to `30.0` only after measured package coverage holds above that mark with headroom
+- [ ] Track B - Coverage by package seam, not full-process setup
+  - Exit criteria:
+  - [ ] keep using `internal/apptest` / warehouse memory doubles instead of reintroducing full Snowflake/process dependencies into unit suites
+  - [ ] extract any remaining broad setup helpers only where a new handler or sync surface still cannot be tested cheaply
+- [ ] Track C - Package split pressure
+  - Exit criteria:
+  - [ ] use the next `internal/sync` coverage wave to identify the worst ambient files for later package extraction
+  - [ ] keep coverage work aligned with the larger graph/app package-boundary cleanup instead of growing more monolithic provider files
+
 ## Deep Review Cycle 63 - Graph Package Split Phase 1: Reports Extraction (2026-03-12)
 
 ### Review findings

--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -2,7 +2,7 @@
 
 Generated from `internal/app/app_config.go` (`LoadConfig`) via `go run ./scripts/generate_config_docs/main.go`.
 
-Total variables: **307**
+Total variables: **311**
 
 | Variable | Reader(s) | Default(s) | Config Field(s) | Validation rule(s) |
 |---|---|---|---|---|
@@ -75,7 +75,7 @@ Total variables: **307**
 | `ENTRA_CLIENT_ID` | `getEnv` | `""` | `EntraClientID` | `-` |
 | `ENTRA_CLIENT_SECRET` | `getEnv` | `""` | `EntraClientSecret` | `-` |
 | `ENTRA_TENANT_ID` | `getEnv` | `""` | `EntraTenantID` | `-` |
-| `EXECUTION_STORE_FILE` | `getEnv` | `filepath.Join(".cerebro", "executions.db")` | `ExecutionStoreFile`, `FunctionScanStateFile`, `ImageScanStateFile`, `WorkloadScanStateFile` | `-` |
+| `EXECUTION_STORE_FILE` | `getEnv` | `filepath.Join(".cerebro", "executions.db")` | `ExecutionStoreFile`, `FunctionScanStateFile`, `ImageScanStateFile`, `NATSConsumerDedupStateFile`, `WorkloadScanStateFile` | `-` |
 | `FIGMA_API_TOKEN` | `getEnv` | `""` | `FigmaAPIToken` | `-` |
 | `FIGMA_BASE_URL` | `getEnv` | `"https://api.figma.com"` | `FigmaBaseURL` | `-` |
 | `FIGMA_TEAM_ID` | `getEnv` | `""` | `FigmaTeamID` | `-` |
@@ -151,22 +151,26 @@ Total variables: **307**
 | `LINEAR_API_KEY` | `getEnv` | `""` | `LinearAPIKey` | `-` |
 | `LINEAR_TEAM_ID` | `getEnv` | `""` | `LinearTeamID` | `-` |
 | `LOG_LEVEL` | `getEnv` | `"info"` | `LogLevel` | `must be one of debug, info, warn, error` |
-| `NATS_CONSUMER_ACK_WAIT` | `getEnvDuration` | `120 * time.Second` | `NATSConsumerAckWait` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_BATCH_SIZE` | `getEnvInt` | `50` | `NATSConsumerBatchSize` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
+| `NATS_CONSUMER_ACK_WAIT` | `getEnvDuration` | `120 * time.Second` | `NATSConsumerAckWait` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_BATCH_SIZE` | `getEnvInt` | `50` | `NATSConsumerBatchSize` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
 | `NATS_CONSUMER_DEAD_LETTER_PATH` | `getEnv` | `filepath.Join(findings.DefaultFilePath(), "nats-consumer.dlq.jsonl")` | `NATSConsumerDeadLetterPath` | `-` |
-| `NATS_CONSUMER_DRAIN_TIMEOUT` | `getEnvDuration` | `30 * time.Second` | `NATSConsumerDrainTimeout` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_DROP_HEALTH_LOOKBACK` | `getEnvDuration` | `5 * time.Minute` | `NATSConsumerDropHealthLookback` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_DROP_HEALTH_THRESHOLD` | `getEnvInt` | `1` | `NATSConsumerDropHealthThreshold` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_DURABLE` | `getEnv` | `"cerebro_graph_builder"` | `NATSConsumerDurable` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_ENABLED` | `getEnvBool` | `false` | `NATSConsumerEnabled` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_FETCH_TIMEOUT` | `getEnvDuration` | `2 * time.Second` | `NATSConsumerFetchTimeout` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_GRAPH_STALENESS_THRESHOLD` | `getEnvDuration` | `15 * time.Minute` | `NATSConsumerGraphStalenessThreshold` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_IN_PROGRESS_INTERVAL` | `getEnvDuration` | `15 * time.Second` | `NATSConsumerInProgressInterval` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_STREAM` | `getEnv` | `"ENSEMBLE_TAP"` | `NATSConsumerStream` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
-| `NATS_CONSUMER_SUBJECTS` | `getEnv` | `"ensemble.tap.>"` | `NATSConsumerSubjects` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative` |
+| `NATS_CONSUMER_DEDUP_ENABLED` | `getEnvBool` | `true` | `NATSConsumerDedupEnabled` | `-` |
+| `NATS_CONSUMER_DEDUP_MAX_RECORDS` | `getEnvInt` | `100000` | `NATSConsumerDedupMaxRecords` | `-` |
+| `NATS_CONSUMER_DEDUP_STATE_FILE` | `getEnv` | `getEnv("EXECUTION_STORE_FILE", filepath.Join(".cerebro", "executions.db"))` | `NATSConsumerDedupStateFile` | `-` |
+| `NATS_CONSUMER_DEDUP_TTL` | `getEnvDuration` | `24 * time.Hour` | `NATSConsumerDedupTTL` | `-` |
+| `NATS_CONSUMER_DRAIN_TIMEOUT` | `getEnvDuration` | `30 * time.Second` | `NATSConsumerDrainTimeout` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_DROP_HEALTH_LOOKBACK` | `getEnvDuration` | `5 * time.Minute` | `NATSConsumerDropHealthLookback` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_DROP_HEALTH_THRESHOLD` | `getEnvInt` | `1` | `NATSConsumerDropHealthThreshold` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_DURABLE` | `getEnv` | `"cerebro_graph_builder"` | `NATSConsumerDurable` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_ENABLED` | `getEnvBool` | `false` | `NATSConsumerEnabled` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_FETCH_TIMEOUT` | `getEnvDuration` | `2 * time.Second` | `NATSConsumerFetchTimeout` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_GRAPH_STALENESS_THRESHOLD` | `getEnvDuration` | `15 * time.Minute` | `NATSConsumerGraphStalenessThreshold` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_IN_PROGRESS_INTERVAL` | `getEnvDuration` | `15 * time.Second` | `NATSConsumerInProgressInterval` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_STREAM` | `getEnv` | `"ENSEMBLE_TAP"` | `NATSConsumerStream` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
+| `NATS_CONSUMER_SUBJECTS` | `getEnv` | `"ensemble.tap.>"` | `NATSConsumerSubjects` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled` |
 | `NATS_JETSTREAM_AUTH_MODE` | `getEnv` | `"none"` | `NATSJetStreamAuthMode` | `-` |
 | `NATS_JETSTREAM_CONNECT_TIMEOUT` | `getEnvDuration` | `5 * time.Second` | `NATSJetStreamConnectTimeout` | `when NATS_JETSTREAM_ENABLED=true, required values must be present and timing/retention values must be positive` |
-| `NATS_JETSTREAM_ENABLED` | `getEnvBool` | `false` | `NATSJetStreamEnabled` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative`, `when NATS_JETSTREAM_ENABLED=true, required values must be present and timing/retention values must be positive` |
+| `NATS_JETSTREAM_ENABLED` | `getEnvBool` | `false` | `NATSJetStreamEnabled` | `when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled`, `when NATS_JETSTREAM_ENABLED=true, required values must be present and timing/retention values must be positive` |
 | `NATS_JETSTREAM_FLUSH_INTERVAL` | `getEnvDuration` | `10 * time.Second` | `NATSJetStreamFlushInterval` | `when NATS_JETSTREAM_ENABLED=true, required values must be present and timing/retention values must be positive` |
 | `NATS_JETSTREAM_NKEY_SEED` | `getEnv` | `""` | `NATSJetStreamNKeySeed` | `-` |
 | `NATS_JETSTREAM_OUTBOX_CRITICAL_AGE` | `getEnvDuration` | `6 * time.Hour` | `NATSJetStreamOutboxCriticalAge` | `-` |

--- a/internal/actionengine/store.go
+++ b/internal/actionengine/store.go
@@ -21,8 +21,9 @@ type Store interface {
 }
 
 type SQLiteStore struct {
-	store     *executionstore.SQLiteStore
+	store     executionstore.Store
 	namespace string
+	ownsStore bool
 }
 
 func NewSQLiteStore(path, namespace string) (*SQLiteStore, error) {
@@ -30,15 +31,21 @@ func NewSQLiteStore(path, namespace string) (*SQLiteStore, error) {
 	if err != nil {
 		return nil, err
 	}
+	sqliteStore := NewSQLiteStoreWithExecutionStore(store, namespace)
+	sqliteStore.ownsStore = true
+	return sqliteStore, nil
+}
+
+func NewSQLiteStoreWithExecutionStore(store executionstore.Store, namespace string) *SQLiteStore {
 	namespace = strings.TrimSpace(namespace)
 	if namespace == "" {
 		namespace = DefaultNamespace
 	}
-	return &SQLiteStore{store: store, namespace: namespace}, nil
+	return &SQLiteStore{store: store, namespace: namespace}
 }
 
 func (s *SQLiteStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -85,12 +85,20 @@ func NewServerWithDependencies(deps serverDependencies) *Server {
 		agentSDKReportProgress: make(map[string]agentSDKReportProgressSubscription),
 	}
 	if cfg := deps.Config; cfg != nil {
-		store, err := reports.NewReportRunStore(cfg.ExecutionStoreFile, cfg.PlatformReportSnapshotPath, cfg.PlatformReportRunStateFile)
+		var (
+			store *reports.ReportRunStore
+			err   error
+		)
+		if deps.ExecutionStore != nil {
+			store = reports.NewReportRunStoreWithExecutionStore(deps.ExecutionStore, cfg.ExecutionStoreFile, cfg.PlatformReportSnapshotPath, cfg.PlatformReportRunStateFile)
+		} else {
+			store, err = reports.NewReportRunStore(cfg.ExecutionStoreFile, cfg.PlatformReportSnapshotPath, cfg.PlatformReportRunStateFile)
+		}
 		if err != nil {
 			if deps.Logger != nil {
 				deps.Logger.Warn("failed to initialize shared platform report execution store", "execution_store", cfg.ExecutionStoreFile, "legacy_state_file", cfg.PlatformReportRunStateFile, "snapshot_dir", cfg.PlatformReportSnapshotPath, "error", err)
 			}
-		} else {
+		} else if store != nil {
 			s.platformReportStore = store
 			if restoredRuns, err := s.platformReportStore.Load(); err != nil {
 				if deps.Logger != nil {

--- a/internal/api/server_dependencies.go
+++ b/internal/api/server_dependencies.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/attackpath"
 	"github.com/writer/cerebro/internal/auth"
 	"github.com/writer/cerebro/internal/cache"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/graph/builders"
@@ -69,12 +70,13 @@ type serverDependencies struct {
 	Config *app.Config
 	Logger *slog.Logger
 
-	Snowflake *snowflake.Client
-	Warehouse warehouse.DataWarehouse
-	Policy    *policy.Engine
-	Findings  findings.FindingStore
-	Scanner   *scanner.Scanner
-	Cache     *cache.PolicyCache
+	Snowflake      *snowflake.Client
+	Warehouse      warehouse.DataWarehouse
+	Policy         *policy.Engine
+	Findings       findings.FindingStore
+	Scanner        *scanner.Scanner
+	Cache          *cache.PolicyCache
+	ExecutionStore executionstore.Store
 
 	Agents         *agents.AgentRegistry
 	Ticketing      *ticketing.Service
@@ -135,6 +137,7 @@ func newServerDependenciesFromApp(application *app.App) serverDependencies {
 		Findings:             application.Findings,
 		Scanner:              application.Scanner,
 		Cache:                application.Cache,
+		ExecutionStore:       application.ExecutionStore,
 		Agents:               application.Agents,
 		Ticketing:            application.Ticketing,
 		Identity:             application.Identity,

--- a/internal/api/server_handlers_graph_intelligence_test.go
+++ b/internal/api/server_handlers_graph_intelligence_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -1250,6 +1249,55 @@ func TestPlatformIntelligenceReportRunRetrySync(t *testing.T) {
 	}
 }
 
+func waitForPlatformJobTerminalStatus(t *testing.T, s *Server, jobURL, wantStatus string) map[string]any {
+	t.Helper()
+	if strings.TrimSpace(jobURL) == "" {
+		t.Fatal("expected non-empty jobURL")
+	}
+	var latest map[string]any
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		resp := do(t, s, http.MethodGet, jobURL, nil)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("expected 200 for platform job lookup, got %d: %s", resp.Code, resp.Body.String())
+		}
+		latest = decodeJSON(t, resp)
+		status, _ := latest["status"].(string)
+		if status == wantStatus {
+			return latest
+		}
+		if status == "failed" || status == "canceled" {
+			t.Fatalf("expected platform job status %q, got terminal status %q: %#v", wantStatus, status, latest)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for platform job status %q, last payload: %#v", wantStatus, latest)
+	return nil
+}
+
+func waitForPlatformReportRunStatus(t *testing.T, s *Server, statusURL, wantStatus string) map[string]any {
+	t.Helper()
+	if strings.TrimSpace(statusURL) == "" {
+		t.Fatal("expected non-empty statusURL")
+	}
+	var latest map[string]any
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		resp := do(t, s, http.MethodGet, statusURL, nil)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("expected 200 for report run lookup, got %d: %s", resp.Code, resp.Body.String())
+		}
+		latest = decodeJSON(t, resp)
+		status, _ := latest["status"].(string)
+		if status == wantStatus {
+			return latest
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for report run status %q, last payload: %#v", wantStatus, latest)
+	return nil
+}
+
 func TestPlatformIntelligenceReportRunRetryAsyncIncludesBackoffMetadata(t *testing.T) {
 	s := newTestServer(t)
 	g := s.app.SecurityGraph
@@ -1291,26 +1339,13 @@ func TestPlatformIntelligenceReportRunRetryAsyncIncludesBackoffMetadata(t *testi
 		t.Fatalf("expected 202 for initial async run, got %d: %s", create.Code, create.Body.String())
 	}
 	created := decodeJSON(t, create)
+	jobURL, _ := created["job_status_url"].(string)
 	statusURL, _ := created["status_url"].(string)
-	if statusURL == "" {
-		t.Fatalf("expected status_url, got %#v", created["status_url"])
+	if statusURL == "" || jobURL == "" {
+		t.Fatalf("expected async run URLs, got status=%#v job=%#v", created["status_url"], created["job_status_url"])
 	}
-
-	var failedRun map[string]any
-	for i := 0; i < 600; i++ {
-		status := do(t, s, http.MethodGet, statusURL, nil)
-		if status.Code != http.StatusOK {
-			t.Fatalf("expected 200 for async run lookup, got %d: %s", status.Code, status.Body.String())
-		}
-		failedRun = decodeJSON(t, status)
-		if failedRun["status"] == reports.ReportRunStatusFailed {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if got := failedRun["status"]; got != reports.ReportRunStatusFailed {
-		t.Fatalf("expected initial async run to fail, got %#v", got)
-	}
+	waitForPlatformJobTerminalStatus(t, s, jobURL, "failed")
+	waitForPlatformReportRunStatus(t, s, statusURL, reports.ReportRunStatusFailed)
 
 	retry := do(t, s, http.MethodPost, statusURL+":retry", map[string]any{
 		"execution_mode": "async",
@@ -1325,11 +1360,15 @@ func TestPlatformIntelligenceReportRunRetryAsyncIncludesBackoffMetadata(t *testi
 		t.Fatalf("expected 202 for async retry, got %d: %s", retry.Code, retry.Body.String())
 	}
 	retried := decodeJSON(t, retry)
+	retryJobURL, _ := retried["job_status_url"].(string)
 	if got := retried["status"]; got != reports.ReportRunStatusQueued {
 		t.Fatalf("expected queued retry response, got %#v", got)
 	}
 	if got := retried["attempt_count"]; got != float64(2) {
 		t.Fatalf("expected attempt_count=2 after retry queue, got %#v", got)
+	}
+	if retryJobURL == "" {
+		t.Fatalf("expected retry job_status_url, got %#v", retried["job_status_url"])
 	}
 
 	attemptsResp := do(t, s, http.MethodGet, statusURL+"/attempts", nil)
@@ -1355,21 +1394,8 @@ func TestPlatformIntelligenceReportRunRetryAsyncIncludesBackoffMetadata(t *testi
 		t.Fatalf("expected scheduled second attempt status, got %#v", got)
 	}
 
-	var latest map[string]any
-	for i := 0; i < 600; i++ {
-		status := do(t, s, http.MethodGet, statusURL, nil)
-		if status.Code != http.StatusOK {
-			t.Fatalf("expected 200 for async retry lookup, got %d: %s", status.Code, status.Body.String())
-		}
-		latest = decodeJSON(t, status)
-		if latest["status"] == reports.ReportRunStatusSucceeded {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if got := latest["status"]; got != reports.ReportRunStatusSucceeded {
-		t.Fatalf("expected async retry to succeed, got %#v", got)
-	}
+	waitForPlatformJobTerminalStatus(t, s, retryJobURL, "succeeded")
+	latest := waitForPlatformReportRunStatus(t, s, statusURL, reports.ReportRunStatusSucceeded)
 	sections, ok := latest["sections"].([]any)
 	if !ok || len(sections) == 0 {
 		t.Fatalf("expected sections on retried run, got %#v", latest["sections"])
@@ -1952,6 +1978,9 @@ func TestPlatformIntelligenceReportRunLifecycleEvents(t *testing.T) {
 func TestPlatformReportRunUpdateRollsBackOnPersistenceFailure(t *testing.T) {
 	application := newTestApp(t)
 	s := NewServer(application)
+	if s.platformReportStore == nil {
+		t.Fatal("expected platformReportStore to be configured")
+	}
 	run := &reports.ReportRun{
 		ID:            "report_run:test-rollback",
 		ReportID:      "quality",
@@ -1964,13 +1993,12 @@ func TestPlatformReportRunUpdateRollsBackOnPersistenceFailure(t *testing.T) {
 		t.Fatalf("storePlatformReportRun() failed: %v", err)
 	}
 
-	stateDir := filepath.Dir(application.Config.ExecutionStoreFile)
-	if err := os.Chmod(stateDir, 0o500); err != nil {
-		t.Fatalf("chmod state dir read-only: %v", err)
+	// Force a deterministic persistence failure by making the underlying shared
+	// execution store unavailable, while leaving the in-memory cache intact so we
+	// can verify the update path does not partially mutate durable state.
+	if err := s.platformReportStore.Close(); err != nil {
+		t.Fatalf("platformReportStore.Close(): %v", err)
 	}
-	defer func() {
-		_ = os.Chmod(stateDir, 0o700)
-	}()
 
 	err := s.updatePlatformReportRun(run.ID, func(run *reports.ReportRun) {
 		run.Status = reports.ReportRunStatusRunning

--- a/internal/api/server_handlers_graph_intelligence_test.go
+++ b/internal/api/server_handlers_graph_intelligence_test.go
@@ -1996,8 +1996,11 @@ func TestPlatformReportRunUpdateRollsBackOnPersistenceFailure(t *testing.T) {
 	// Force a deterministic persistence failure by making the underlying shared
 	// execution store unavailable, while leaving the in-memory cache intact so we
 	// can verify the update path does not partially mutate durable state.
-	if err := s.platformReportStore.Close(); err != nil {
-		t.Fatalf("platformReportStore.Close(): %v", err)
+	if application.ExecutionStore == nil {
+		t.Fatal("expected shared execution store to be configured")
+	}
+	if err := application.ExecutionStore.Close(); err != nil {
+		t.Fatalf("ExecutionStore.Close(): %v", err)
 	}
 
 	err := s.updatePlatformReportRun(run.ID, func(run *reports.ReportRun) {

--- a/internal/api/server_handlers_platform_executions.go
+++ b/internal/api/server_handlers_platform_executions.go
@@ -19,13 +19,16 @@ func (s *Server) listPlatformExecutions(w http.ResponseWriter, r *http.Request) 
 		s.error(w, http.StatusInternalServerError, "platform execution store not configured")
 		return
 	}
-	store, err := executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
-	if err != nil {
-		s.error(w, http.StatusInternalServerError, "platform execution store unavailable")
-		return
+	store := s.app.ExecutionStore
+	if store == nil {
+		var err error
+		store, err = executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
+		if err != nil {
+			s.error(w, http.StatusInternalServerError, "platform execution store unavailable")
+			return
+		}
+		defer func() { _ = store.Close() }()
 	}
-	defer func() { _ = store.Close() }()
-
 	limit := 50
 	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
 		parsed, err := strconv.Atoi(raw)

--- a/internal/api/server_handlers_platform_test.go
+++ b/internal/api/server_handlers_platform_test.go
@@ -80,11 +80,10 @@ func TestPlatformExecutionsListsSharedExecutionStoreRuns(t *testing.T) {
 		t.Fatalf("storePlatformReportRun: %v", err)
 	}
 
-	sharedStore, err := executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
-	if err != nil {
-		t.Fatalf("NewSQLiteStore: %v", err)
+	sharedStore := s.app.ExecutionStore
+	if sharedStore == nil {
+		t.Fatal("expected shared execution store")
 	}
-	defer func() { _ = sharedStore.Close() }()
 
 	workloadRun := workloadscan.RunRecord{
 		ID:          "workload_scan:test-execution-list",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -51,6 +51,7 @@ import (
 	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/dspm"
 	"github.com/writer/cerebro/internal/events"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/graph/builders"
@@ -90,13 +91,14 @@ type App struct {
 	Logger *slog.Logger
 
 	// Core services
-	Snowflake *snowflake.Client
-	Warehouse warehouse.DataWarehouse
-	Policy    *policy.Engine
-	Findings  findings.FindingStore
-	Scanner   *scanner.Scanner
-	DSPM      *dspm.Scanner
-	Cache     *cache.PolicyCache
+	Snowflake      *snowflake.Client
+	Warehouse      warehouse.DataWarehouse
+	Policy         *policy.Engine
+	Findings       findings.FindingStore
+	Scanner        *scanner.Scanner
+	DSPM           *dspm.Scanner
+	Cache          *cache.PolicyCache
+	ExecutionStore executionstore.Store
 
 	// Feature services
 	Agents         *agents.AgentRegistry

--- a/internal/app/app_cerebro_tools_executions.go
+++ b/internal/app/app_cerebro_tools_executions.go
@@ -30,12 +30,15 @@ func (a *App) toolCerebroExecutionStatus(ctx context.Context, args json.RawMessa
 	if limit > 100 {
 		return "", fmt.Errorf("limit must be <= 100")
 	}
-	store, err := executionstore.NewSQLiteStore(a.Config.ExecutionStoreFile)
-	if err != nil {
-		return "", fmt.Errorf("open shared execution store: %w", err)
+	store := a.ExecutionStore
+	if store == nil {
+		var err error
+		store, err = executionstore.NewSQLiteStore(a.Config.ExecutionStoreFile)
+		if err != nil {
+			return "", fmt.Errorf("open shared execution store: %w", err)
+		}
+		defer func() { _ = store.Close() }()
 	}
-	defer func() { _ = store.Close() }()
-
 	summaries, err := executions.List(ctx, store, executions.ListOptions{
 		Namespaces:         req.Namespace,
 		Statuses:           req.Status,

--- a/internal/app/app_cerebro_tools_test.go
+++ b/internal/app/app_cerebro_tools_test.go
@@ -849,7 +849,10 @@ func TestCerebroExecutionStatusTool(t *testing.T) {
 		t.Fatalf("UpsertRun: %v", err)
 	}
 
-	application := &App{Config: &Config{ExecutionStoreFile: filepath.Join(dir, "executions.db")}}
+	application := &App{
+		Config:         &Config{ExecutionStoreFile: filepath.Join(dir, "executions.db")},
+		ExecutionStore: store,
+	}
 	tool := findCerebroTool(application.AgentSDKTools(), "cerebro.execution_status")
 	if tool == nil {
 		t.Fatal("expected cerebro.execution_status tool")

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -324,6 +324,10 @@ type Config struct {
 	NATSConsumerInProgressInterval      time.Duration
 	NATSConsumerDrainTimeout            time.Duration
 	NATSConsumerDeadLetterPath          string
+	NATSConsumerDedupEnabled            bool
+	NATSConsumerDedupStateFile          string
+	NATSConsumerDedupTTL                time.Duration
+	NATSConsumerDedupMaxRecords         int
 	NATSConsumerDropHealthLookback      time.Duration
 	NATSConsumerDropHealthThreshold     int
 	NATSConsumerGraphStalenessThreshold time.Duration
@@ -679,6 +683,10 @@ func LoadConfig() *Config {
 			NATSConsumerInProgressInterval:      getEnvDuration("NATS_CONSUMER_IN_PROGRESS_INTERVAL", 15*time.Second),
 			NATSConsumerDrainTimeout:            getEnvDuration("NATS_CONSUMER_DRAIN_TIMEOUT", 30*time.Second),
 			NATSConsumerDeadLetterPath:          getEnv("NATS_CONSUMER_DEAD_LETTER_PATH", filepath.Join(findings.DefaultFilePath(), "nats-consumer.dlq.jsonl")),
+			NATSConsumerDedupEnabled:            getEnvBool("NATS_CONSUMER_DEDUP_ENABLED", true),
+			NATSConsumerDedupStateFile:          getEnv("NATS_CONSUMER_DEDUP_STATE_FILE", getEnv("EXECUTION_STORE_FILE", filepath.Join(".cerebro", "executions.db"))),
+			NATSConsumerDedupTTL:                getEnvDuration("NATS_CONSUMER_DEDUP_TTL", 24*time.Hour),
+			NATSConsumerDedupMaxRecords:         getEnvInt("NATS_CONSUMER_DEDUP_MAX_RECORDS", 100000),
 			NATSConsumerDropHealthLookback:      getEnvDuration("NATS_CONSUMER_DROP_HEALTH_LOOKBACK", 5*time.Minute),
 			NATSConsumerDropHealthThreshold:     getEnvInt("NATS_CONSUMER_DROP_HEALTH_THRESHOLD", 1),
 			NATSConsumerGraphStalenessThreshold: getEnvDuration("NATS_CONSUMER_GRAPH_STALENESS_THRESHOLD", 15*time.Minute),

--- a/internal/app/app_config_validation.go
+++ b/internal/app/app_config_validation.go
@@ -100,7 +100,7 @@ func ConfigValidationRules() []ConfigValidationRule {
 				"NATS_CONSUMER_DROP_HEALTH_THRESHOLD",
 				"NATS_CONSUMER_GRAPH_STALENESS_THRESHOLD",
 			},
-			Summary:  "when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative",
+			Summary:  "when NATS_CONSUMER_ENABLED=true, JetStream must also be enabled; identifiers must be present; durations must be positive; drop threshold must be non-negative; dedupe settings must be valid when enabled",
 			Category: "dependency",
 		},
 		{
@@ -241,6 +241,17 @@ func (c *Config) Validate() error {
 		}
 		if c.NATSConsumerDropHealthThreshold < 0 {
 			problems = addConfigProblem(problems, "NATS_CONSUMER_DROP_HEALTH_THRESHOLD must be >= 0 when NATS_CONSUMER_ENABLED=true")
+		}
+		if c.NATSConsumerDedupEnabled {
+			if strings.TrimSpace(c.NATSConsumerDedupStateFile) == "" {
+				problems = addConfigProblem(problems, "NATS_CONSUMER_DEDUP_STATE_FILE is required when NATS_CONSUMER_DEDUP_ENABLED=true")
+			}
+			if c.NATSConsumerDedupTTL <= 0 {
+				problems = addConfigProblem(problems, "NATS_CONSUMER_DEDUP_TTL must be > 0 when NATS_CONSUMER_DEDUP_ENABLED=true")
+			}
+			if c.NATSConsumerDedupMaxRecords <= 0 {
+				problems = addConfigProblem(problems, "NATS_CONSUMER_DEDUP_MAX_RECORDS must be > 0 when NATS_CONSUMER_DEDUP_ENABLED=true")
+			}
 		}
 		if c.NATSConsumerGraphStalenessThreshold <= 0 {
 			problems = addConfigProblem(problems, "NATS_CONSUMER_GRAPH_STALENESS_THRESHOLD must be > 0 when NATS_CONSUMER_ENABLED=true")

--- a/internal/app/app_execution_store.go
+++ b/internal/app/app_execution_store.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+func (a *App) initExecutionStore() {
+	if a == nil || a.Config == nil {
+		return
+	}
+	path := strings.TrimSpace(a.Config.ExecutionStoreFile)
+	if path == "" {
+		return
+	}
+	store, err := executionstore.NewSQLiteStore(path)
+	if err != nil {
+		if a.Logger != nil {
+			a.Logger.Warn("failed to initialize shared execution store", "error", err, "path", path)
+		}
+		return
+	}
+	a.ExecutionStore = store
+	if a.Logger != nil {
+		a.Logger.Info("shared execution store initialized", "path", path)
+	}
+}
+
+func (a *App) executionStoreForPath(path string) executionstore.Store {
+	if a == nil || a.ExecutionStore == nil || a.Config == nil {
+		return nil
+	}
+	if sameExecutionStorePath(a.Config.ExecutionStoreFile, path) {
+		return a.ExecutionStore
+	}
+	return nil
+}
+
+func sameExecutionStorePath(left, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	leftAbs, leftErr := filepath.Abs(filepath.Clean(left))
+	rightAbs, rightErr := filepath.Abs(filepath.Clean(right))
+	if leftErr == nil && rightErr == nil {
+		return leftAbs == rightAbs
+	}
+	return filepath.Clean(left) == filepath.Clean(right)
+}

--- a/internal/app/app_graph_updates.go
+++ b/internal/app/app_graph_updates.go
@@ -130,7 +130,7 @@ func (a *App) maybeStartGraphConsistencyCheck(trigger string, summary graph.Grap
 	a.graphConsistencyCancel = cancel
 	a.graphConsistencyMu.Unlock()
 
-	go func() {
+	go func(checkCtx context.Context, cancel context.CancelFunc) {
 		defer a.graphConsistencyWG.Done()
 		defer func() {
 			a.graphConsistencyMu.Lock()
@@ -174,7 +174,7 @@ func (a *App) maybeStartGraphConsistencyCheck(trigger string, summary graph.Grap
 			"edges_added", len(diff.EdgesAdded),
 			"edges_removed", len(diff.EdgesRemoved),
 		)
-	}()
+	}(checkCtx, cancel)
 }
 
 func graphDiffHasChanges(diff *graph.GraphDiff) bool {

--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -54,6 +54,8 @@ func (a *App) initPhase1(ctx context.Context) error {
 }
 
 func (a *App) initPhase2a(ctx context.Context) error {
+	a.initExecutionStore()
+
 	if err := runInitTasksConcurrently(ctx, []concurrentInitTask{
 		{name: "cache", run: func(context.Context) { a.initCache() }},
 		{name: "ticketing", run: func(taskCtx context.Context) { a.initTicketing(taskCtx) }},

--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -22,6 +22,9 @@ import (
 )
 
 func (a *App) newSharedActionExecutor() *actionengine.Executor {
+	if a != nil && a.ExecutionStore != nil {
+		return actionengine.NewExecutor(actionengine.NewSQLiteStoreWithExecutionStore(a.ExecutionStore, actionengine.DefaultNamespace))
+	}
 	store, err := actionengine.NewSQLiteStore(a.Config.ExecutionStoreFile, actionengine.DefaultNamespace)
 	if err != nil {
 		a.Logger.Warn("failed to initialize shared action execution store; falling back to in-memory", "error", err, "path", a.Config.ExecutionStoreFile)

--- a/internal/app/app_storage_graph.go
+++ b/internal/app/app_storage_graph.go
@@ -294,6 +294,11 @@ func (a *App) Close() error {
 			errs = append(errs, fmt.Errorf("alert router: %w", err))
 		}
 	}
+	if a.ExecutionStore != nil {
+		if err := a.ExecutionStore.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("execution store: %w", err))
+		}
+	}
 
 	// Close findings store if it implements io.Closer (e.g., SQLiteStore)
 	if closer, ok := a.Findings.(interface{ Close() error }); ok {

--- a/internal/app/app_stream_consumer.go
+++ b/internal/app/app_stream_consumer.go
@@ -42,6 +42,10 @@ func (a *App) initTapGraphConsumer(ctx context.Context) {
 		FetchTimeout:          a.Config.NATSConsumerFetchTimeout,
 		InProgressInterval:    a.Config.NATSConsumerInProgressInterval,
 		DeadLetterPath:        a.Config.NATSConsumerDeadLetterPath,
+		DedupEnabled:          a.Config.NATSConsumerDedupEnabled,
+		DedupStateFile:        a.Config.NATSConsumerDedupStateFile,
+		DedupTTL:              a.Config.NATSConsumerDedupTTL,
+		DedupMaxRecords:       a.Config.NATSConsumerDedupMaxRecords,
 		DropHealthLookback:    a.Config.NATSConsumerDropHealthLookback,
 		DropHealthThreshold:   a.Config.NATSConsumerDropHealthThreshold,
 		ConnectTimeout:        a.Config.NATSJetStreamConnectTimeout,
@@ -104,6 +108,7 @@ func (a *App) initTapGraphConsumer(ctx context.Context) {
 		"subject", subject,
 		"durable", a.Config.NATSConsumerDurable,
 		"batch_size", a.Config.NATSConsumerBatchSize,
+		"dedupe_enabled", a.Config.NATSConsumerDedupEnabled,
 	)
 
 	_ = ctx

--- a/internal/app/app_stream_consumer.go
+++ b/internal/app/app_stream_consumer.go
@@ -44,6 +44,7 @@ func (a *App) initTapGraphConsumer(ctx context.Context) {
 		DeadLetterPath:        a.Config.NATSConsumerDeadLetterPath,
 		DedupEnabled:          a.Config.NATSConsumerDedupEnabled,
 		DedupStateFile:        a.Config.NATSConsumerDedupStateFile,
+		DedupStore:            a.executionStoreForPath(a.Config.NATSConsumerDedupStateFile),
 		DedupTTL:              a.Config.NATSConsumerDedupTTL,
 		DedupMaxRecords:       a.Config.NATSConsumerDedupMaxRecords,
 		DropHealthLookback:    a.Config.NATSConsumerDropHealthLookback,

--- a/internal/app/app_workload_scan_graph.go
+++ b/internal/app/app_workload_scan_graph.go
@@ -16,9 +16,17 @@ func (a *App) materializePersistedWorkloadScans(ctx context.Context, g *graph.Gr
 	if storePath == "" {
 		return workloadscan.GraphMaterializationResult{}, nil
 	}
-	store, err := workloadscan.NewSQLiteRunStore(storePath)
-	if err != nil {
-		return workloadscan.GraphMaterializationResult{}, err
+	var (
+		store workloadscan.RunStore
+		err   error
+	)
+	if shared := a.executionStoreForPath(storePath); shared != nil {
+		store = workloadscan.NewSQLiteRunStoreWithExecutionStore(shared)
+	} else {
+		store, err = workloadscan.NewSQLiteRunStore(storePath)
+		if err != nil {
+			return workloadscan.GraphMaterializationResult{}, err
+		}
 	}
 	defer func() { _ = store.Close() }()
 

--- a/internal/apptest/apptest.go
+++ b/internal/apptest/apptest.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/attackpath"
 	"github.com/writer/cerebro/internal/auth"
 	"github.com/writer/cerebro/internal/cache"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/health"
@@ -64,8 +65,12 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 	pe := policy.NewEngine()
 	fs := findings.NewStore()
 	sc := scanner.NewScanner(pe, scanner.ScanConfig{Workers: 2}, logger)
+	executionStore, err := executionstore.NewSQLiteStore(cfg.ExecutionStoreFile)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
 
-	return &app.App{
+	application := &app.App{
 		Config:         cfg,
 		Logger:         logger,
 		Warehouse:      store,
@@ -73,6 +78,7 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 		Findings:       fs,
 		Scanner:        sc,
 		Cache:          cache.NewPolicyCache(1000, 5*time.Minute),
+		ExecutionStore: executionStore,
 		Agents:         agents.NewAgentRegistry(),
 		RBAC:           auth.NewRBAC(),
 		Webhooks:       webhooks.NewServiceForTesting(),
@@ -91,4 +97,6 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 		ScanWatermarks: scanner.NewWatermarkStore(nil),
 		ThreatIntel:    threatintel.NewThreatIntelService(),
 	}
+	t.Cleanup(func() { _ = application.Close() })
+	return application
 }

--- a/internal/events/consumer.go
+++ b/internal/events/consumer.go
@@ -46,6 +46,10 @@ type ConsumerConfig struct {
 	DropHealthLookback  time.Duration
 	DropHealthThreshold int
 	PayloadPreviewBytes int
+	DedupEnabled        bool
+	DedupStateFile      string
+	DedupTTL            time.Duration
+	DedupMaxRecords     int
 
 	AuthMode string
 	Username string
@@ -88,6 +92,7 @@ type Consumer struct {
 	lastEventTime   time.Time
 	consumerLag     int
 	consumerLagAge  time.Duration
+	deduper         *consumerProcessedEventDeduper
 }
 
 type ConsumerHealthSnapshot struct {
@@ -117,6 +122,13 @@ func NewJetStreamConsumer(cfg ConsumerConfig, logger *slog.Logger, handler Event
 	dlq, err := newConsumerDeadLetterSink(config.DeadLetterPath)
 	if err != nil {
 		return nil, err
+	}
+	var deduper *consumerProcessedEventDeduper
+	if config.DedupEnabled {
+		deduper, err = newConsumerProcessedEventDeduper(config.DedupStateFile, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	base := JetStreamConfig{
@@ -155,6 +167,7 @@ func NewJetStreamConsumer(cfg ConsumerConfig, logger *slog.Logger, handler Event
 		config:  config,
 		handler: handler,
 		dlq:     dlq,
+		deduper: deduper,
 		nc:      nc,
 		js:      js,
 		stopCh:  make(chan struct{}),
@@ -236,6 +249,11 @@ func (c *Consumer) cleanup() error {
 			closeErr = errors.Join(closeErr, fmt.Errorf("drain consumer nats connection: %w", err))
 		}
 		c.nc.Close()
+	}
+	if c.deduper != nil {
+		if err := c.deduper.Close(); err != nil {
+			closeErr = errors.Join(closeErr, fmt.Errorf("close consumer dedupe store: %w", err))
+		}
 	}
 	return closeErr
 }
@@ -353,6 +371,74 @@ func (c *Consumer) handleMessage(ctx context.Context, subject string, payload []
 		}
 		return consumerMessageResult{}
 	}
+	if c.deduper != nil {
+		record, hashMismatch, err := c.deduper.Lookup(ctx, evt, payload, time.Now().UTC())
+		if err != nil {
+			c.logger.Warn("tap consumer dedupe lookup failed; continuing without duplicate suppression",
+				"error", err,
+				"event_id", evt.ID,
+				"event_type", evt.Type,
+			)
+		} else if record != nil {
+			if hashMismatch {
+				if err := c.deduper.Forget(ctx, evt); err != nil {
+					c.logger.Error("tap consumer failed to clear conflicting dedupe state; message requeued",
+						"error", err,
+						"event_id", evt.ID,
+						"event_type", evt.Type,
+						"source", evt.Source,
+						"processed_at", record.ProcessedAt.UTC().Format(time.RFC3339Nano),
+					)
+					if nakErr := nak(); nakErr != nil {
+						c.logger.Warn("tap consumer nak failed after dedupe hash mismatch state clear failure", "error", nakErr, "event_type", evt.Type)
+					}
+					return consumerMessageResult{}
+				}
+				if dlqErr := c.dlq.Write(consumerDeadLetterRecord{
+					RecordedAt: time.Now().UTC(),
+					Stream:     c.config.Stream,
+					Durable:    c.config.Durable,
+					Subject:    subject,
+					Reason:     "dedupe_hash_mismatch",
+					Error:      fmt.Sprintf("duplicate event key matched different payload hash: processed_at=%s", record.ProcessedAt.UTC().Format(time.RFC3339Nano)),
+					Payload:    string(payload),
+				}); dlqErr != nil {
+					c.logger.Error("tap consumer failed to dead-letter duplicate hash mismatch; message requeued",
+						"error", dlqErr,
+						"event_id", evt.ID,
+						"event_type", evt.Type,
+						"source", evt.Source,
+					)
+					if nakErr := nak(); nakErr != nil {
+						c.logger.Warn("tap consumer nak failed after dedupe hash mismatch dead-letter error", "error", nakErr, "event_type", evt.Type)
+					}
+					return consumerMessageResult{}
+				}
+				c.logger.Error("tap consumer dead-lettered duplicate event key with different payload hash",
+					"event_id", evt.ID,
+					"event_type", evt.Type,
+					"source", evt.Source,
+					"processed_at", record.ProcessedAt.UTC().Format(time.RFC3339Nano),
+				)
+				if nakErr := nak(); nakErr != nil {
+					c.logger.Warn("tap consumer nak failed after clearing dedupe hash mismatch state", "error", nakErr, "event_type", evt.Type)
+				}
+				return consumerMessageResult{}
+			}
+			if err := c.deduper.ObserveDuplicate(ctx, evt, time.Now().UTC()); err != nil {
+				c.logger.Warn("tap consumer failed to refresh duplicate dedupe state",
+					"error", err,
+					"event_id", evt.ID,
+					"event_type", evt.Type,
+				)
+			}
+			metrics.RecordNATSConsumerDeduplicated(c.config.Stream, c.config.Durable)
+			if err := ack(); err != nil {
+				c.logger.Warn("tap consumer ack failed after duplicate suppression", "error", err, "event_type", evt.Type)
+			}
+			return consumerMessageResult{}
+		}
+	}
 	stopHeartbeat := c.startInProgressHeartbeat(ctx, inProgress)
 	defer stopHeartbeat()
 	if err := c.handler(ctx, evt); err != nil {
@@ -363,6 +449,16 @@ func (c *Consumer) handleMessage(ctx context.Context, subject string, payload []
 		return consumerMessageResult{}
 	}
 	processedAt := time.Now().UTC()
+	metrics.RecordNATSConsumerProcessed(c.config.Stream, c.config.Durable)
+	if c.deduper != nil {
+		if err := c.deduper.Remember(ctx, evt, payload, processedAt); err != nil {
+			c.logger.Warn("tap consumer failed to persist processed event dedupe state",
+				"error", err,
+				"event_id", evt.ID,
+				"event_type", evt.Type,
+			)
+		}
+	}
 	if err := ack(); err != nil {
 		c.logger.Warn("tap consumer ack failed", "error", err, "event_type", evt.Type)
 	}
@@ -692,6 +788,12 @@ func (c ConsumerConfig) withDefaults() ConsumerConfig {
 	if cfg.PayloadPreviewBytes <= 0 {
 		cfg.PayloadPreviewBytes = defaultConsumerPayloadPreviewBytes
 	}
+	if cfg.DedupTTL <= 0 {
+		cfg.DedupTTL = 24 * time.Hour
+	}
+	if cfg.DedupMaxRecords <= 0 {
+		cfg.DedupMaxRecords = 100_000
+	}
 	if cfg.MaxAckPending <= 0 {
 		cfg.MaxAckPending = cfg.BatchSize * 10
 	}
@@ -725,6 +827,17 @@ func (c ConsumerConfig) validate() error {
 	}
 	if c.FetchTimeout <= 0 {
 		return errors.New("consumer fetch timeout must be > 0")
+	}
+	if c.DedupEnabled {
+		if strings.TrimSpace(c.DedupStateFile) == "" {
+			return errors.New("consumer dedupe state file is required when dedupe is enabled")
+		}
+		if c.DedupTTL <= 0 {
+			return errors.New("consumer dedupe ttl must be > 0 when dedupe is enabled")
+		}
+		if c.DedupMaxRecords <= 0 {
+			return errors.New("consumer dedupe max records must be > 0 when dedupe is enabled")
+		}
 	}
 	return nil
 }

--- a/internal/events/consumer.go
+++ b/internal/events/consumer.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/jsonl"
 	"github.com/writer/cerebro/internal/metrics"
 )
@@ -48,6 +49,7 @@ type ConsumerConfig struct {
 	PayloadPreviewBytes int
 	DedupEnabled        bool
 	DedupStateFile      string
+	DedupStore          executionstore.Store
 	DedupTTL            time.Duration
 	DedupMaxRecords     int
 
@@ -125,9 +127,13 @@ func NewJetStreamConsumer(cfg ConsumerConfig, logger *slog.Logger, handler Event
 	}
 	var deduper *consumerProcessedEventDeduper
 	if config.DedupEnabled {
-		deduper, err = newConsumerProcessedEventDeduper(config.DedupStateFile, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
-		if err != nil {
-			return nil, err
+		if config.DedupStore != nil {
+			deduper = newConsumerProcessedEventDeduperWithStore(config.DedupStore, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
+		} else {
+			deduper, err = newConsumerProcessedEventDeduper(config.DedupStateFile, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/events/consumer_dedup.go
+++ b/internal/events/consumer_dedup.go
@@ -13,10 +13,11 @@ import (
 )
 
 type consumerProcessedEventDeduper struct {
-	store      *executionstore.SQLiteStore
+	store      executionstore.Store
 	namespace  string
 	ttl        time.Duration
 	maxRecords int
+	ownsStore  bool
 }
 
 func newConsumerProcessedEventDeduper(path, stream, durable string, ttl time.Duration, maxRecords int) (*consumerProcessedEventDeduper, error) {
@@ -34,16 +35,22 @@ func newConsumerProcessedEventDeduper(path, stream, durable string, ttl time.Dur
 	if err != nil {
 		return nil, err
 	}
+	deduper := newConsumerProcessedEventDeduperWithStore(store, stream, durable, ttl, maxRecords)
+	deduper.ownsStore = true
+	return deduper, nil
+}
+
+func newConsumerProcessedEventDeduperWithStore(store executionstore.Store, stream, durable string, ttl time.Duration, maxRecords int) *consumerProcessedEventDeduper {
 	return &consumerProcessedEventDeduper{
 		store:      store,
 		namespace:  fmt.Sprintf("%s:%s:%s", executionstore.NamespaceProcessedCloudEvent, strings.TrimSpace(stream), strings.TrimSpace(durable)),
 		ttl:        ttl,
 		maxRecords: maxRecords,
-	}, nil
+	}
 }
 
 func (d *consumerProcessedEventDeduper) Close() error {
-	if d == nil || d.store == nil {
+	if d == nil || d.store == nil || !d.ownsStore {
 		return nil
 	}
 	return d.store.Close()

--- a/internal/events/consumer_dedup.go
+++ b/internal/events/consumer_dedup.go
@@ -1,0 +1,142 @@
+package events
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+type consumerProcessedEventDeduper struct {
+	store      *executionstore.SQLiteStore
+	namespace  string
+	ttl        time.Duration
+	maxRecords int
+}
+
+func newConsumerProcessedEventDeduper(path, stream, durable string, ttl time.Duration, maxRecords int) (*consumerProcessedEventDeduper, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("consumer dedupe state file is required")
+	}
+	if ttl <= 0 {
+		return nil, fmt.Errorf("consumer dedupe ttl must be > 0")
+	}
+	if maxRecords <= 0 {
+		return nil, fmt.Errorf("consumer dedupe max records must be > 0")
+	}
+	store, err := executionstore.NewSQLiteStore(path)
+	if err != nil {
+		return nil, err
+	}
+	return &consumerProcessedEventDeduper{
+		store:      store,
+		namespace:  fmt.Sprintf("%s:%s:%s", executionstore.NamespaceProcessedCloudEvent, strings.TrimSpace(stream), strings.TrimSpace(durable)),
+		ttl:        ttl,
+		maxRecords: maxRecords,
+	}, nil
+}
+
+func (d *consumerProcessedEventDeduper) Close() error {
+	if d == nil || d.store == nil {
+		return nil
+	}
+	return d.store.Close()
+}
+
+func (d *consumerProcessedEventDeduper) Lookup(ctx context.Context, evt CloudEvent, payload []byte, now time.Time) (*executionstore.ProcessedEventRecord, bool, error) {
+	if d == nil || d.store == nil {
+		return nil, false, nil
+	}
+	key, ok := consumerProcessedEventKey(evt)
+	if !ok {
+		return nil, false, nil
+	}
+	record, err := d.store.LookupProcessedEvent(ctx, d.namespace, key, now)
+	if err != nil || record == nil {
+		return record, false, err
+	}
+	return record, record.PayloadHash != consumerProcessedEventPayloadHash(payload), nil
+}
+
+func (d *consumerProcessedEventDeduper) ObserveDuplicate(ctx context.Context, evt CloudEvent, now time.Time) error {
+	if d == nil || d.store == nil {
+		return nil
+	}
+	key, ok := consumerProcessedEventKey(evt)
+	if !ok {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	return d.store.TouchProcessedEvent(ctx, d.namespace, key, now, d.ttl)
+}
+
+func (d *consumerProcessedEventDeduper) Remember(ctx context.Context, evt CloudEvent, payload []byte, processedAt time.Time) error {
+	if d == nil || d.store == nil {
+		return nil
+	}
+	key, ok := consumerProcessedEventKey(evt)
+	if !ok {
+		return nil
+	}
+	if processedAt.IsZero() {
+		processedAt = time.Now().UTC()
+	} else {
+		processedAt = processedAt.UTC()
+	}
+	return d.store.RememberProcessedEvent(ctx, executionstore.ProcessedEventRecord{
+		Namespace:   d.namespace,
+		EventKey:    key,
+		PayloadHash: consumerProcessedEventPayloadHash(payload),
+		FirstSeenAt: processedAt,
+		LastSeenAt:  processedAt,
+		ProcessedAt: processedAt,
+		ExpiresAt:   processedAt.Add(d.ttl),
+	}, d.maxRecords)
+}
+
+func (d *consumerProcessedEventDeduper) Forget(ctx context.Context, evt CloudEvent) error {
+	if d == nil || d.store == nil {
+		return nil
+	}
+	key, ok := consumerProcessedEventKey(evt)
+	if !ok {
+		return nil
+	}
+	return d.store.DeleteProcessedEvent(ctx, d.namespace, key)
+}
+
+func consumerProcessedEventKey(evt CloudEvent) (string, bool) {
+	eventID := strings.TrimSpace(evt.ID)
+	if eventID == "" {
+		return "", false
+	}
+	source := strings.TrimSpace(evt.Source)
+	if source == "" {
+		source = "unknown"
+	}
+	tenantID := strings.TrimSpace(evt.TenantID)
+	if tenantID == "" {
+		tenantID = "default"
+	}
+	keyPayload, err := json.Marshal([]string{tenantID, source, eventID})
+	if err != nil {
+		return "", false
+	}
+	sum := sha256.Sum256(keyPayload)
+	return "sha256:" + hex.EncodeToString(sum[:]), true
+}
+
+func consumerProcessedEventPayloadHash(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/events/consumer_test.go
+++ b/internal/events/consumer_test.go
@@ -41,6 +41,16 @@ func TestConsumerConfigWithDefaultsPreservesZeroDropHealthThreshold(t *testing.T
 	}
 }
 
+func TestConsumerConfigWithDefaultsSetsDedupDefaults(t *testing.T) {
+	cfg := (ConsumerConfig{DedupEnabled: true}).withDefaults()
+	if cfg.DedupTTL <= 0 {
+		t.Fatalf("expected positive dedupe ttl, got %s", cfg.DedupTTL)
+	}
+	if cfg.DedupMaxRecords <= 0 {
+		t.Fatalf("expected positive dedupe max records, got %d", cfg.DedupMaxRecords)
+	}
+}
+
 func TestConsumerConfigValidate(t *testing.T) {
 	valid := (ConsumerConfig{
 		URLs:           []string{"nats://127.0.0.1:4222"},
@@ -48,6 +58,7 @@ func TestConsumerConfigValidate(t *testing.T) {
 		Subject:        "ensemble.tap.>",
 		Durable:        "cerebro_graph_builder",
 		DeadLetterPath: t.TempDir() + "/consumer.dlq.jsonl",
+		DedupStateFile: t.TempDir() + "/executions.db",
 		BatchSize:      10,
 		AckWait:        5,
 		FetchTimeout:   5,
@@ -277,6 +288,247 @@ func TestConsumerStartBatchInProgressHeartbeatSkipsDeactivatedEntries(t *testing
 	}
 	if firstCount.Load() != firstBefore {
 		t.Fatalf("expected deactivated batch heartbeat to stop extending first message, got before=%d after=%d", firstBefore, firstCount.Load())
+	}
+}
+
+func TestConsumerHandleMessageSkipsAlreadyProcessedCloudEvent(t *testing.T) {
+	cfg := (ConsumerConfig{
+		Stream:         "ENSEMBLE_TAP",
+		Durable:        "cerebro_graph_builder",
+		DeadLetterPath: t.TempDir() + "/consumer.dlq.jsonl",
+		DedupStateFile: t.TempDir() + "/executions.db",
+	}).withDefaults()
+	deduper, err := newConsumerProcessedEventDeduper(cfg.DedupStateFile, cfg.Stream, cfg.Durable, cfg.DedupTTL, cfg.DedupMaxRecords)
+	if err != nil {
+		t.Fatalf("new deduper: %v", err)
+	}
+	defer func() { _ = deduper.Close() }()
+
+	consumer := &Consumer{
+		config:  cfg,
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		dlq:     &consumerDeadLetterSink{},
+		deduper: deduper,
+	}
+
+	evt := CloudEvent{
+		SpecVersion: cloudEventSpecVersion,
+		ID:          "evt-dedup-1",
+		Source:      "urn:cerebro:test",
+		Type:        "ensemble.tap.test",
+		Time:        time.Now().UTC(),
+		DataSchema:  "urn:cerebro:events:test",
+		TenantID:    "tenant-a",
+		Data:        map[string]any{"id": "1"},
+	}
+	payload, err := json.Marshal(evt)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	var handlerCalls int
+	consumer.handler = func(context.Context, CloudEvent) error {
+		handlerCalls++
+		return nil
+	}
+	var ackCalls int
+	ack := func() error {
+		ackCalls++
+		return nil
+	}
+
+	first := consumer.handleMessage(context.Background(), "ensemble.tap.test", payload, ack, func() error { return nil }, func() error { return nil })
+	if !first.Processed {
+		t.Fatalf("expected first event to be processed, got %+v", first)
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("expected handler call count 1, got %d", handlerCalls)
+	}
+
+	before := counterValue(t, metrics.NATSConsumerDeduplicatedTotal.WithLabelValues(cfg.Stream, cfg.Durable))
+	second := consumer.handleMessage(context.Background(), "ensemble.tap.test", payload, ack, func() error { return nil }, func() error { return nil })
+	if second.Processed {
+		t.Fatalf("expected duplicate event to be skipped, got %+v", second)
+	}
+	after := counterValue(t, metrics.NATSConsumerDeduplicatedTotal.WithLabelValues(cfg.Stream, cfg.Durable))
+	if after != before+1 {
+		t.Fatalf("expected deduplicated counter to increment from %v to %v", before, after)
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("expected duplicate event to avoid handler, got %d calls", handlerCalls)
+	}
+	if ackCalls != 2 {
+		t.Fatalf("expected both events to ack, got %d", ackCalls)
+	}
+}
+
+func TestConsumerHandleMessageDeadLettersDuplicateKeyPayloadMismatch(t *testing.T) {
+	cfg := (ConsumerConfig{
+		Stream:         "ENSEMBLE_TAP",
+		Durable:        "cerebro_graph_builder",
+		DeadLetterPath: t.TempDir() + "/consumer.dlq.jsonl",
+		DedupStateFile: t.TempDir() + "/executions.db",
+	}).withDefaults()
+	deduper, err := newConsumerProcessedEventDeduper(cfg.DedupStateFile, cfg.Stream, cfg.Durable, cfg.DedupTTL, cfg.DedupMaxRecords)
+	if err != nil {
+		t.Fatalf("new deduper: %v", err)
+	}
+	defer func() { _ = deduper.Close() }()
+
+	dlq, err := newConsumerDeadLetterSink(cfg.DeadLetterPath)
+	if err != nil {
+		t.Fatalf("new consumer dead-letter sink: %v", err)
+	}
+
+	consumer := &Consumer{
+		config:  cfg,
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		dlq:     dlq,
+		deduper: deduper,
+	}
+
+	firstEvent := CloudEvent{
+		SpecVersion: cloudEventSpecVersion,
+		ID:          "evt-dedup-collision-1",
+		Source:      "urn:cerebro:test",
+		Type:        "ensemble.tap.test",
+		Time:        time.Now().UTC(),
+		DataSchema:  "urn:cerebro:events:test",
+		TenantID:    "tenant-a",
+		Data:        map[string]any{"id": "1", "value": "first"},
+	}
+	firstPayload, err := json.Marshal(firstEvent)
+	if err != nil {
+		t.Fatalf("marshal first event: %v", err)
+	}
+
+	secondEvent := firstEvent
+	secondEvent.Type = "ensemble.tap.test.updated"
+	secondEvent.Data = map[string]any{"id": "1", "value": "second"}
+	secondPayload, err := json.Marshal(secondEvent)
+	if err != nil {
+		t.Fatalf("marshal second event: %v", err)
+	}
+
+	var handlerCalls int
+	consumer.handler = func(context.Context, CloudEvent) error {
+		handlerCalls++
+		return nil
+	}
+	var ackCalls int
+	var nakCalls int
+	ack := func() error {
+		ackCalls++
+		return nil
+	}
+	nak := func() error {
+		nakCalls++
+		return nil
+	}
+
+	first := consumer.handleMessage(context.Background(), "ensemble.tap.test", firstPayload, ack, nak, func() error { return nil })
+	if !first.Processed {
+		t.Fatalf("expected first event to be processed, got %+v", first)
+	}
+
+	beforeDedup := counterValue(t, metrics.NATSConsumerDeduplicatedTotal.WithLabelValues(cfg.Stream, cfg.Durable))
+	beforeDropped := counterValue(t, metrics.NATSConsumerDroppedTotal.WithLabelValues(cfg.Stream, cfg.Durable, "dedupe_hash_mismatch"))
+	second := consumer.handleMessage(context.Background(), "ensemble.tap.test", secondPayload, ack, nak, func() error { return nil })
+	if second.Processed {
+		t.Fatalf("expected hash-mismatch duplicate to avoid normal processing, got %+v", second)
+	}
+
+	afterDedup := counterValue(t, metrics.NATSConsumerDeduplicatedTotal.WithLabelValues(cfg.Stream, cfg.Durable))
+	if afterDedup != beforeDedup {
+		t.Fatalf("expected deduplicated counter unchanged on hash mismatch, before=%v after=%v", beforeDedup, afterDedup)
+	}
+	afterDropped := counterValue(t, metrics.NATSConsumerDroppedTotal.WithLabelValues(cfg.Stream, cfg.Durable, "dedupe_hash_mismatch"))
+	if afterDropped != beforeDropped {
+		t.Fatalf("expected hash mismatch to requeue instead of drop, before=%v after=%v", beforeDropped, afterDropped)
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("expected handler to run only for first event, got %d calls", handlerCalls)
+	}
+	if ackCalls != 1 {
+		t.Fatalf("expected only the first event to ack before requeue, got %d", ackCalls)
+	}
+	if nakCalls != 1 {
+		t.Fatalf("expected hash mismatch to requeue once, got %d nacks", nakCalls)
+	}
+
+	payload, err := os.ReadFile(cfg.DeadLetterPath)
+	if err != nil {
+		t.Fatalf("read consumer dead-letter file: %v", err)
+	}
+	if got := string(payload); !containsAll(got, "\"reason\":\"dedupe_hash_mismatch\"", "\"subject\":\"ensemble.tap.test\"", "ensemble.tap.test.updated", "\\\"value\\\":\\\"second\\\"") {
+		t.Fatalf("expected hash mismatch payload to be written to dead-letter file, got %s", got)
+	}
+
+	snapshot := consumer.HealthSnapshot(time.Now().UTC())
+	if snapshot.LastDropReason != "" {
+		t.Fatalf("expected hash mismatch requeue not to mark a drop, got %q", snapshot.LastDropReason)
+	}
+
+	eventKey, ok := consumerProcessedEventKey(firstEvent)
+	if !ok {
+		t.Fatal("expected event key for first event")
+	}
+	record, err := deduper.store.LookupProcessedEvent(context.Background(), deduper.namespace, eventKey, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent after hash mismatch: %v", err)
+	}
+	if record != nil {
+		t.Fatalf("expected hash mismatch to clear processed event record, got %#v", record)
+	}
+
+	third := consumer.handleMessage(context.Background(), "ensemble.tap.test", secondPayload, ack, nak, func() error { return nil })
+	if !third.Processed {
+		t.Fatalf("expected replayed hash-mismatch event to process after dedupe reset, got %+v", third)
+	}
+	if handlerCalls != 2 {
+		t.Fatalf("expected handler to run again after hash-mismatch reset, got %d calls", handlerCalls)
+	}
+	if ackCalls != 2 {
+		t.Fatalf("expected replayed event to ack after processing, got %d", ackCalls)
+	}
+	if nakCalls != 1 {
+		t.Fatalf("expected only one hash-mismatch requeue, got %d", nakCalls)
+	}
+
+	record, err = deduper.store.LookupProcessedEvent(context.Background(), deduper.namespace, eventKey, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent after replayed hash mismatch: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected replayed hash-mismatch event to persist a new processed event record")
+	}
+	if record.DuplicateCount != 0 {
+		t.Fatalf("expected replayed hash-mismatch event to persist without duplicate count, got %#v", record)
+	}
+}
+
+func TestConsumerProcessedEventKeyIsUnambiguous(t *testing.T) {
+	first, ok := consumerProcessedEventKey(CloudEvent{
+		ID:       "d",
+		Source:   "c",
+		TenantID: "a|b",
+	})
+	if !ok {
+		t.Fatal("expected first dedupe key")
+	}
+	second, ok := consumerProcessedEventKey(CloudEvent{
+		ID:       "d",
+		Source:   "b|c",
+		TenantID: "a",
+	})
+	if !ok {
+		t.Fatal("expected second dedupe key")
+	}
+	if first == second {
+		t.Fatalf("expected canonical dedupe keys to differ, both were %q", first)
+	}
+	if !strings.HasPrefix(first, "sha256:") || !strings.HasPrefix(second, "sha256:") {
+		t.Fatalf("expected canonical hashed dedupe keys, got %q and %q", first, second)
 	}
 }
 

--- a/internal/executions/summary.go
+++ b/internal/executions/summary.go
@@ -47,7 +47,7 @@ type Summary struct {
 	Target        string     `json:"target,omitempty"`
 }
 
-func List(ctx context.Context, store *executionstore.SQLiteStore, opts ListOptions) ([]Summary, error) {
+func List(ctx context.Context, store executionstore.Store, opts ListOptions) ([]Summary, error) {
 	if store == nil {
 		return nil, nil
 	}

--- a/internal/executionstore/namespaces.go
+++ b/internal/executionstore/namespaces.go
@@ -1,9 +1,10 @@
 package executionstore
 
 const (
-	NamespacePlatformReportRun = "report_run"
-	NamespaceWorkloadScan      = "workload_scan"
-	NamespaceImageScan         = "image_scan"
-	NamespaceFunctionScan      = "function_scan"
-	NamespaceActionEngine      = "action_engine"
+	NamespacePlatformReportRun   = "report_run"
+	NamespaceWorkloadScan        = "workload_scan"
+	NamespaceImageScan           = "image_scan"
+	NamespaceFunctionScan        = "function_scan"
+	NamespaceActionEngine        = "action_engine"
+	NamespaceProcessedCloudEvent = "processed_cloud_event"
 )

--- a/internal/executionstore/processed_events.go
+++ b/internal/executionstore/processed_events.go
@@ -1,0 +1,244 @@
+package executionstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ProcessedEventRecord struct {
+	Namespace      string
+	EventKey       string
+	PayloadHash    string
+	FirstSeenAt    time.Time
+	LastSeenAt     time.Time
+	ProcessedAt    time.Time
+	ExpiresAt      time.Time
+	DuplicateCount int
+}
+
+func (s *SQLiteStore) LookupProcessedEvent(ctx context.Context, namespace, eventKey string, observedAt time.Time) (*ProcessedEventRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	eventKey = strings.TrimSpace(eventKey)
+	if namespace == "" || eventKey == "" {
+		return nil, fmt.Errorf("processed event namespace and key are required")
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	} else {
+		observedAt = observedAt.UTC()
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin processed event lookup tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND expires_at <= ?
+	`, namespace, observedAt); err != nil {
+		return nil, fmt.Errorf("prune expired processed events: %w", err)
+	}
+
+	var record ProcessedEventRecord
+	err = tx.QueryRowContext(ctx, `
+		SELECT namespace, event_key, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
+		FROM processed_events
+		WHERE namespace = ? AND event_key = ?
+	`, namespace, eventKey).Scan(
+		&record.Namespace,
+		&record.EventKey,
+		&record.PayloadHash,
+		&record.FirstSeenAt,
+		&record.LastSeenAt,
+		&record.ProcessedAt,
+		&record.ExpiresAt,
+		&record.DuplicateCount,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit processed event lookup: %w", err)
+		}
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load processed event: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit processed event lookup: %w", err)
+	}
+	return &record, nil
+}
+
+func (s *SQLiteStore) TouchProcessedEvent(ctx context.Context, namespace, eventKey string, observedAt time.Time, ttl time.Duration) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	eventKey = strings.TrimSpace(eventKey)
+	if namespace == "" || eventKey == "" {
+		return fmt.Errorf("processed event namespace and key are required")
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	} else {
+		observedAt = observedAt.UTC()
+	}
+	if ttl <= 0 {
+		return fmt.Errorf("processed event ttl must be > 0")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin processed event touch tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND expires_at <= ?
+	`, namespace, observedAt); err != nil {
+		return fmt.Errorf("prune expired processed events: %w", err)
+	}
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE processed_events
+		SET last_seen_at = ?,
+			expires_at = ?,
+			duplicate_count = duplicate_count + 1
+		WHERE namespace = ? AND event_key = ?
+	`, observedAt, observedAt.Add(ttl), namespace, eventKey)
+	if err != nil {
+		return fmt.Errorf("touch processed event: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read touched processed event rows: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("processed event %s/%s not found", namespace, eventKey)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit processed event touch: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) RememberProcessedEvent(ctx context.Context, record ProcessedEventRecord, maxRecords int) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	record.Namespace = strings.TrimSpace(record.Namespace)
+	record.EventKey = strings.TrimSpace(record.EventKey)
+	record.PayloadHash = strings.TrimSpace(record.PayloadHash)
+	if record.Namespace == "" || record.EventKey == "" {
+		return fmt.Errorf("processed event namespace and key are required")
+	}
+	if record.FirstSeenAt.IsZero() {
+		record.FirstSeenAt = time.Now().UTC()
+	} else {
+		record.FirstSeenAt = record.FirstSeenAt.UTC()
+	}
+	if record.LastSeenAt.IsZero() {
+		record.LastSeenAt = record.FirstSeenAt
+	} else {
+		record.LastSeenAt = record.LastSeenAt.UTC()
+	}
+	if record.ProcessedAt.IsZero() {
+		record.ProcessedAt = record.LastSeenAt
+	} else {
+		record.ProcessedAt = record.ProcessedAt.UTC()
+	}
+	if record.ExpiresAt.IsZero() {
+		record.ExpiresAt = record.ProcessedAt
+	} else {
+		record.ExpiresAt = record.ExpiresAt.UTC()
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin processed event remember tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND expires_at <= ?
+	`, record.Namespace, record.ProcessedAt); err != nil {
+		return fmt.Errorf("prune expired processed events: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO processed_events (
+			namespace, event_key, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(namespace, event_key) DO UPDATE SET
+			payload_hash = excluded.payload_hash,
+			last_seen_at = excluded.last_seen_at,
+			processed_at = excluded.processed_at,
+			expires_at = excluded.expires_at
+	`, record.Namespace, record.EventKey, record.PayloadHash, record.FirstSeenAt, record.LastSeenAt, record.ProcessedAt, record.ExpiresAt, record.DuplicateCount); err != nil {
+		return fmt.Errorf("persist processed event: %w", err)
+	}
+
+	if maxRecords > 0 {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM processed_events
+			WHERE namespace = ?
+			  AND event_key IN (
+				SELECT event_key
+				FROM processed_events
+				WHERE namespace = ?
+				ORDER BY processed_at DESC, event_key DESC
+				LIMIT -1 OFFSET ?
+			  )
+		`, record.Namespace, record.Namespace, maxRecords); err != nil {
+			return fmt.Errorf("trim processed events: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit processed event remember: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteProcessedEvent(ctx context.Context, namespace, eventKey string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	eventKey = strings.TrimSpace(eventKey)
+	if namespace == "" || eventKey == "" {
+		return fmt.Errorf("processed event namespace and key are required")
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND event_key = ?
+	`, namespace, eventKey); err != nil {
+		return fmt.Errorf("delete processed event: %w", err)
+	}
+	return nil
+}

--- a/internal/executionstore/processed_events_test.go
+++ b/internal/executionstore/processed_events_test.go
@@ -1,0 +1,131 @@
+package executionstore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSQLiteStoreProcessedEventsRoundTripAndTouch(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Date(2026, 3, 12, 2, 0, 0, 0, time.UTC)
+	err = store.RememberProcessedEvent(context.Background(), ProcessedEventRecord{
+		Namespace:   NamespaceProcessedCloudEvent,
+		EventKey:    "stream|durable|tenant|source|evt-1",
+		PayloadHash: "hash-a",
+		FirstSeenAt: now,
+		LastSeenAt:  now,
+		ProcessedAt: now,
+		ExpiresAt:   now.Add(24 * time.Hour),
+	}, 100)
+	if err != nil {
+		t.Fatalf("RememberProcessedEvent: %v", err)
+	}
+
+	record, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "stream|durable|tenant|source|evt-1", now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected processed event record")
+	}
+	if record.PayloadHash != "hash-a" {
+		t.Fatalf("expected payload hash hash-a, got %#v", record)
+	}
+	if record.DuplicateCount != 0 {
+		t.Fatalf("expected read-only lookup to preserve duplicate count, got %#v", record)
+	}
+
+	if err := store.TouchProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "stream|durable|tenant|source|evt-1", now.Add(2*time.Hour), 24*time.Hour); err != nil {
+		t.Fatalf("TouchProcessedEvent: %v", err)
+	}
+
+	touched, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "stream|durable|tenant|source|evt-1", now.Add(3*time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent after touch: %v", err)
+	}
+	if touched == nil {
+		t.Fatal("expected touched processed event record")
+	}
+	if touched.DuplicateCount != 1 {
+		t.Fatalf("expected duplicate count increment to 1 after touch, got %#v", touched)
+	}
+}
+
+func TestSQLiteStoreProcessedEventsTrimOldest(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	base := time.Date(2026, 3, 12, 2, 0, 0, 0, time.UTC)
+	for i, key := range []string{"evt-1", "evt-2", "evt-3"} {
+		ts := base.Add(time.Duration(i) * time.Minute)
+		if err := store.RememberProcessedEvent(context.Background(), ProcessedEventRecord{
+			Namespace:   NamespaceProcessedCloudEvent,
+			EventKey:    key,
+			PayloadHash: key,
+			FirstSeenAt: ts,
+			LastSeenAt:  ts,
+			ProcessedAt: ts,
+			ExpiresAt:   ts.Add(24 * time.Hour),
+		}, 2); err != nil {
+			t.Fatalf("RememberProcessedEvent %s: %v", key, err)
+		}
+	}
+
+	first, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-1", base.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent first: %v", err)
+	}
+	if first != nil {
+		t.Fatalf("expected oldest processed event to be trimmed, got %#v", first)
+	}
+	last, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-3", base.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent last: %v", err)
+	}
+	if last == nil {
+		t.Fatal("expected newest processed event to remain after trim")
+	}
+}
+
+func TestSQLiteStoreDeleteProcessedEvent(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Date(2026, 3, 12, 4, 0, 0, 0, time.UTC)
+	if err := store.RememberProcessedEvent(context.Background(), ProcessedEventRecord{
+		Namespace:   NamespaceProcessedCloudEvent,
+		EventKey:    "evt-delete",
+		PayloadHash: "hash-a",
+		FirstSeenAt: now,
+		LastSeenAt:  now,
+		ProcessedAt: now,
+		ExpiresAt:   now.Add(24 * time.Hour),
+	}, 100); err != nil {
+		t.Fatalf("RememberProcessedEvent: %v", err)
+	}
+
+	if err := store.DeleteProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-delete"); err != nil {
+		t.Fatalf("DeleteProcessedEvent: %v", err)
+	}
+
+	record, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-delete", now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent after delete: %v", err)
+	}
+	if record != nil {
+		t.Fatalf("expected processed event to be deleted, got %#v", record)
+	}
+}

--- a/internal/executionstore/sqlite.go
+++ b/internal/executionstore/sqlite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,6 +47,8 @@ type SQLiteStore struct {
 	db *sql.DB
 }
 
+const sqliteBusyTimeoutMS = 5000
+
 func NewSQLiteStore(path string) (*SQLiteStore, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -54,7 +57,7 @@ func NewSQLiteStore(path string) (*SQLiteStore, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return nil, fmt.Errorf("create execution store directory: %w", err)
 	}
-	db, err := sql.Open("sqlite", path)
+	db, err := sql.Open("sqlite", sqliteStoreDSN(path))
 	if err != nil {
 		return nil, fmt.Errorf("open execution sqlite: %w", err)
 	}
@@ -63,6 +66,20 @@ func NewSQLiteStore(path string) (*SQLiteStore, error) {
 		return nil, err
 	}
 	return &SQLiteStore{db: db}, nil
+}
+
+func sqliteStoreDSN(path string) string {
+	absPath, err := filepath.Abs(path)
+	if err == nil {
+		path = absPath
+	}
+	u := url.URL{Scheme: "file", Path: filepath.ToSlash(path)}
+	query := u.Query()
+	query.Add("_pragma", "journal_mode(WAL)")
+	query.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", sqliteBusyTimeoutMS))
+	query.Add("_pragma", "synchronous(NORMAL)")
+	u.RawQuery = query.Encode()
+	return u.String()
 }
 
 func initSQLiteStore(db *sql.DB) error {
@@ -95,6 +112,21 @@ func initSQLiteStore(db *sql.DB) error {
 		payload JSON NOT NULL,
 		PRIMARY KEY (namespace, run_id, sequence)
 	);
+	CREATE TABLE IF NOT EXISTS processed_events (
+		namespace TEXT NOT NULL,
+		event_key TEXT NOT NULL,
+		payload_hash TEXT NOT NULL,
+		first_seen_at TIMESTAMP NOT NULL,
+		last_seen_at TIMESTAMP NOT NULL,
+		processed_at TIMESTAMP NOT NULL,
+		expires_at TIMESTAMP NOT NULL,
+		duplicate_count INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (namespace, event_key)
+	);
+	CREATE INDEX IF NOT EXISTS idx_processed_events_namespace_expires
+		ON processed_events(namespace, expires_at ASC);
+	CREATE INDEX IF NOT EXISTS idx_processed_events_namespace_processed
+		ON processed_events(namespace, processed_at DESC, event_key DESC);
 	`
 	if _, err := db.ExecContext(context.Background(), schema); err != nil {
 		return fmt.Errorf("init execution sqlite schema: %w", err)

--- a/internal/executionstore/sqlite_test.go
+++ b/internal/executionstore/sqlite_test.go
@@ -3,9 +3,34 @@ package executionstore
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestSQLiteStoreConfiguresWALAndBusyTimeout(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	var journalMode string
+	if err := store.DB().QueryRowContext(context.Background(), "PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatalf("PRAGMA journal_mode: %v", err)
+	}
+	if strings.ToLower(strings.TrimSpace(journalMode)) != "wal" {
+		t.Fatalf("expected journal_mode WAL, got %q", journalMode)
+	}
+
+	var busyTimeout int
+	if err := store.DB().QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+		t.Fatalf("PRAGMA busy_timeout: %v", err)
+	}
+	if busyTimeout != sqliteBusyTimeoutMS {
+		t.Fatalf("expected busy_timeout %d, got %d", sqliteBusyTimeoutMS, busyTimeout)
+	}
+}
 
 func TestSQLiteStoreIsolatesNamespaces(t *testing.T) {
 	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))

--- a/internal/executionstore/store.go
+++ b/internal/executionstore/store.go
@@ -1,0 +1,26 @@
+package executionstore
+
+import (
+	"context"
+	"time"
+)
+
+// Store is the durable execution-state substrate interface. SQLite is the
+// current implementation, but higher-scale backends should satisfy the same
+// contract instead of forcing callers to depend on SQLite directly.
+type Store interface {
+	Close() error
+	UpsertRun(context.Context, RunEnvelope) error
+	ReplaceRunWithEvents(context.Context, RunEnvelope, []EventEnvelope) error
+	LoadRun(context.Context, string, string) (*RunEnvelope, error)
+	ListRuns(context.Context, string, RunListOptions) ([]RunEnvelope, error)
+	ListAllRuns(context.Context, RunListOptions) ([]RunEnvelope, error)
+	DeleteRun(context.Context, string, string) error
+	DeleteEvents(context.Context, string, string) error
+	SaveEvent(context.Context, EventEnvelope) (EventEnvelope, error)
+	LoadEvents(context.Context, string, string) ([]EventEnvelope, error)
+	LookupProcessedEvent(context.Context, string, string, time.Time) (*ProcessedEventRecord, error)
+	TouchProcessedEvent(context.Context, string, string, time.Time, time.Duration) error
+	RememberProcessedEvent(context.Context, ProcessedEventRecord, int) error
+	DeleteProcessedEvent(context.Context, string, string) error
+}

--- a/internal/functionscan/store.go
+++ b/internal/functionscan/store.go
@@ -20,7 +20,8 @@ type RunStore interface {
 }
 
 type SQLiteRunStore struct {
-	store *executionstore.SQLiteStore
+	store     executionstore.Store
+	ownsStore bool
 }
 
 func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
@@ -28,7 +29,13 @@ func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SQLiteRunStore{store: store}, nil
+	runStore := NewSQLiteRunStoreWithExecutionStore(store)
+	runStore.ownsStore = true
+	return runStore, nil
+}
+
+func NewSQLiteRunStoreWithExecutionStore(store executionstore.Store) *SQLiteRunStore {
+	return &SQLiteRunStore{store: store}
 }
 
 func (s *SQLiteRunStore) SaveRun(ctx context.Context, run *RunRecord) error {
@@ -142,7 +149,7 @@ func (s *SQLiteRunStore) LoadEvents(ctx context.Context, runID string) ([]RunEve
 }
 
 func (s *SQLiteRunStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()

--- a/internal/graph/reports/report_run_store.go
+++ b/internal/graph/reports/report_run_store.go
@@ -25,7 +25,8 @@ type ReportRunStore struct {
 	executionFile string
 	legacyState   string
 	snapshotDir   string
-	execution     *executionstore.SQLiteStore
+	execution     executionstore.Store
+	ownsExecution bool
 }
 
 type persistedReportRunRecord struct {
@@ -56,16 +57,22 @@ func NewReportRunStore(executionFile, snapshotDir, legacyStateFile string) (*Rep
 	if err != nil {
 		return nil, err
 	}
+	reportStore := NewReportRunStoreWithExecutionStore(store, executionFile, snapshotDir, legacyStateFile)
+	reportStore.ownsExecution = true
+	return reportStore, nil
+}
+
+func NewReportRunStoreWithExecutionStore(store executionstore.Store, executionFile, snapshotDir, legacyStateFile string) *ReportRunStore {
 	return &ReportRunStore{
 		executionFile: strings.TrimSpace(executionFile),
 		legacyState:   strings.TrimSpace(legacyStateFile),
 		snapshotDir:   strings.TrimSpace(snapshotDir),
 		execution:     store,
-	}, nil
+	}
 }
 
 func (s *ReportRunStore) Close() error {
-	if s == nil || s.execution == nil {
+	if s == nil || s.execution == nil || !s.ownsExecution {
 		return nil
 	}
 	return s.execution.Close()

--- a/internal/graph/reports/report_run_store_test.go
+++ b/internal/graph/reports/report_run_store_test.go
@@ -188,6 +188,33 @@ func TestReportRunStoreSaveRunReplacesPersistedEvents(t *testing.T) {
 	}
 }
 
+func TestReportRunStoreWithSharedExecutionStoreDoesNotOwnClose(t *testing.T) {
+	stateDir := t.TempDir()
+	executionStore, err := executionstore.NewSQLiteStore(filepath.Join(stateDir, "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = executionStore.Close() }()
+
+	store := NewReportRunStoreWithExecutionStore(executionStore, filepath.Join(stateDir, "executions.db"), filepath.Join(stateDir, "snapshots"), filepath.Join(stateDir, "legacy-state.json"))
+	if err := store.Close(); err != nil {
+		t.Fatalf("ReportRunStore.Close(): %v", err)
+	}
+
+	if err := executionStore.UpsertRun(t.Context(), executionstore.RunEnvelope{
+		Namespace:   executionstore.NamespacePlatformReportRun,
+		RunID:       "report_run:shared-close",
+		Kind:        "quality",
+		Status:      string(ReportRunStatusQueued),
+		Stage:       string(ReportRunStatusQueued),
+		SubmittedAt: time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC),
+		Payload:     []byte(`{"run":{"id":"report_run:shared-close","report_id":"quality","status":"queued","submitted_at":"2026-03-12T09:00:00Z"}}`),
+	}); err != nil {
+		t.Fatalf("UpsertRun after borrowed store close: %v", err)
+	}
+}
+
 func timePtr(value time.Time) *time.Time {
 	return &value
 }

--- a/internal/imagescan/store.go
+++ b/internal/imagescan/store.go
@@ -20,7 +20,8 @@ type RunStore interface {
 }
 
 type SQLiteRunStore struct {
-	store *executionstore.SQLiteStore
+	store     executionstore.Store
+	ownsStore bool
 }
 
 func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
@@ -28,7 +29,13 @@ func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SQLiteRunStore{store: store}, nil
+	runStore := NewSQLiteRunStoreWithExecutionStore(store)
+	runStore.ownsStore = true
+	return runStore, nil
+}
+
+func NewSQLiteRunStoreWithExecutionStore(store executionstore.Store) *SQLiteRunStore {
+	return &SQLiteRunStore{store: store}
 }
 
 func (s *SQLiteRunStore) SaveRun(ctx context.Context, run *RunRecord) error {
@@ -142,7 +149,7 @@ func (s *SQLiteRunStore) LoadEvents(ctx context.Context, runID string) ([]RunEve
 }
 
 func (s *SQLiteRunStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -284,6 +284,22 @@ var (
 		[]string{"stream", "durable"},
 	)
 
+	NATSConsumerProcessedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cerebro_nats_consumer_processed_total",
+			Help: "Total number of NATS consumer messages processed successfully",
+		},
+		[]string{"stream", "durable"},
+	)
+
+	NATSConsumerDeduplicatedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cerebro_nats_consumer_deduplicated_total",
+			Help: "Total number of NATS consumer messages skipped because the CloudEvent was already processed",
+		},
+		[]string{"stream", "durable"},
+	)
+
 	NATSConsumerLag = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cerebro_nats_consumer_lag",
@@ -542,6 +558,8 @@ func Register() {
 			JetStreamBackpressureAlertsTotal,
 			NATSConsumerDroppedTotal,
 			NATSConsumerRedeliveriesTotal,
+			NATSConsumerProcessedTotal,
+			NATSConsumerDeduplicatedTotal,
 			NATSConsumerLag,
 			NATSConsumerLagSeconds,
 			GraphBuildStatus,
@@ -806,6 +824,26 @@ func RecordNATSConsumerRedelivery(stream, durable string) {
 		durable = "unknown"
 	}
 	NATSConsumerRedeliveriesTotal.WithLabelValues(stream, durable).Inc()
+}
+
+func RecordNATSConsumerProcessed(stream, durable string) {
+	if strings.TrimSpace(stream) == "" {
+		stream = "unknown"
+	}
+	if strings.TrimSpace(durable) == "" {
+		durable = "unknown"
+	}
+	NATSConsumerProcessedTotal.WithLabelValues(stream, durable).Inc()
+}
+
+func RecordNATSConsumerDeduplicated(stream, durable string) {
+	if strings.TrimSpace(stream) == "" {
+		stream = "unknown"
+	}
+	if strings.TrimSpace(durable) == "" {
+		durable = "unknown"
+	}
+	NATSConsumerDeduplicatedTotal.WithLabelValues(stream, durable).Inc()
 }
 
 func SetNATSConsumerLag(stream, durable string, lag int) {

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -279,6 +279,8 @@ func TestJetStreamMetrics(t *testing.T) {
 	RecordJetStreamBackpressureAlert("CEREBRO_EVENTS", "warning")
 	RecordJetStreamBackpressureAlert("CEREBRO_EVENTS", "critical")
 	RecordJetStreamBackpressureAlert("CEREBRO_EVENTS", "recovered")
+	RecordNATSConsumerProcessed("ENSEMBLE_TAP", "cerebro_graph_builder")
+	RecordNATSConsumerDeduplicated("ENSEMBLE_TAP", "cerebro_graph_builder")
 }
 
 func TestSetGraphLastUpdateDoesNotRegress(t *testing.T) {

--- a/internal/workloadscan/store.go
+++ b/internal/workloadscan/store.go
@@ -20,7 +20,8 @@ type RunStore interface {
 }
 
 type SQLiteRunStore struct {
-	store *executionstore.SQLiteStore
+	store     executionstore.Store
+	ownsStore bool
 }
 
 func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
@@ -28,7 +29,13 @@ func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SQLiteRunStore{store: store}, nil
+	runStore := NewSQLiteRunStoreWithExecutionStore(store)
+	runStore.ownsStore = true
+	return runStore, nil
+}
+
+func NewSQLiteRunStoreWithExecutionStore(store executionstore.Store) *SQLiteRunStore {
+	return &SQLiteRunStore{store: store}
 }
 
 func (s *SQLiteRunStore) SaveRun(ctx context.Context, run *RunRecord) error {
@@ -142,7 +149,7 @@ func (s *SQLiteRunStore) LoadEvents(ctx context.Context, runID string) ([]RunEve
 }
 
 func (s *SQLiteRunStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()


### PR DESCRIPTION
## Summary
- add durable CloudEvent deduplication for the NATS consumer on top of the shared execution store with TTL and bounded retention
- expose dedupe configuration, persisted processed-event records, and processed/deduplicated Prometheus counters
- add regression coverage for dedupe behavior, processed-event persistence, and metrics/config validation

## Testing
- go test ./internal/events ./internal/executionstore ./internal/metrics ./internal/app ./internal/api -count=1
- make devex-pr
- python3 scripts/oss_audit.py
