### PR TITLE
refactor(execution): unify shared execution store seams

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,32 @@ Owner: @haasonsaas
 Mode: implement in full, keep CI green
 Status: executed end-to-end via PR workflow
 
+## Deep Review Cycle 66 - Shared Execution Store Convergence (2026-03-12)
+
+### Review findings
+- [x] Gap: issue `#209` was still only partially true; the repo had a shared execution-store package, but report runs, action executions, consumer dedupe, and scan materialization still reopened concrete SQLite stores and therefore kept backend assumptions in leaf services.
+- [x] Gap: that concrete `*executionstore.SQLiteStore` coupling would make a future multi-worker backend migration harder than it needs to be, which matters because SQLite is an acceptable default but not the long-term answer for larger customers.
+- [x] Gap: API/server tests were still proving persistence behavior through wrapper ownership assumptions instead of the actual shared execution-store boundary.
+- [x] Gap: GitHub/wider-project references reinforce the right seam:
+  - [x] `dagster-io/dagster` keeps run state on a generic storage contract while layering richer indexes/tags on top.
+  - [x] `argoproj/argo-workflows` keeps execution status and node state explicit rather than hiding orchestration state in process memory.
+  - [x] the Wiz schema dump in `/Users/jonathanhaas/Downloads/other/wiz.graphql` is a useful reminder that broad query surfaces stay tractable only when the underlying execution resources remain typed and inspectable.
+
+### Execution plan
+- [x] Extract a backend-neutral shared execution-store contract:
+  - [x] add `executionstore.Store`
+  - [x] move callers off concrete `*executionstore.SQLiteStore` dependencies where they only need the shared contract
+- [x] Centralize app-level shared execution-store ownership:
+  - [x] initialize one shared app execution store from `EXECUTION_STORE_FILE`
+  - [x] thread that shared handle into API/report/action/consumer paths when they point at the same underlying store
+  - [x] keep wrapper-specific `Close()` semantics from accidentally closing borrowed shared stores
+- [x] Preserve durable behavior while removing wrapper-owned assumptions:
+  - [x] update report-run persistence tests to fail through the shared store itself
+  - [x] keep scan/action/report/consumer paths green under the shared contract
+- [x] Add follow-on scale direction to the backlog:
+  - [x] document that SQLite remains the default implementation for now
+  - [x] make “higher-scale backend behind `executionstore.Store`” the next scale seam instead of deepening SQLite-only code paths
+
 ## Deep Review Cycle 65 - Durable CloudEvent Deduplication for NATS Consumer (2026-03-12)
 
 ### Review findings

--- a/internal/actionengine/store.go
+++ b/internal/actionengine/store.go
@@ -21,8 +21,9 @@ type Store interface {
 }
 
 type SQLiteStore struct {
-	store     *executionstore.SQLiteStore
+	store     executionstore.Store
 	namespace string
+	ownsStore bool
 }
 
 func NewSQLiteStore(path, namespace string) (*SQLiteStore, error) {
@@ -30,15 +31,21 @@ func NewSQLiteStore(path, namespace string) (*SQLiteStore, error) {
 	if err != nil {
 		return nil, err
 	}
+	sqliteStore := NewSQLiteStoreWithExecutionStore(store, namespace)
+	sqliteStore.ownsStore = true
+	return sqliteStore, nil
+}
+
+func NewSQLiteStoreWithExecutionStore(store executionstore.Store, namespace string) *SQLiteStore {
 	namespace = strings.TrimSpace(namespace)
 	if namespace == "" {
 		namespace = DefaultNamespace
 	}
-	return &SQLiteStore{store: store, namespace: namespace}, nil
+	return &SQLiteStore{store: store, namespace: namespace}
 }
 
 func (s *SQLiteStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -85,12 +85,20 @@ func NewServerWithDependencies(deps serverDependencies) *Server {
 		agentSDKReportProgress: make(map[string]agentSDKReportProgressSubscription),
 	}
 	if cfg := deps.Config; cfg != nil {
-		store, err := reports.NewReportRunStore(cfg.ExecutionStoreFile, cfg.PlatformReportSnapshotPath, cfg.PlatformReportRunStateFile)
+		var (
+			store *reports.ReportRunStore
+			err   error
+		)
+		if deps.ExecutionStore != nil {
+			store = reports.NewReportRunStoreWithExecutionStore(deps.ExecutionStore, cfg.ExecutionStoreFile, cfg.PlatformReportSnapshotPath, cfg.PlatformReportRunStateFile)
+		} else {
+			store, err = reports.NewReportRunStore(cfg.ExecutionStoreFile, cfg.PlatformReportSnapshotPath, cfg.PlatformReportRunStateFile)
+		}
 		if err != nil {
 			if deps.Logger != nil {
 				deps.Logger.Warn("failed to initialize shared platform report execution store", "execution_store", cfg.ExecutionStoreFile, "legacy_state_file", cfg.PlatformReportRunStateFile, "snapshot_dir", cfg.PlatformReportSnapshotPath, "error", err)
 			}
-		} else {
+		} else if store != nil {
 			s.platformReportStore = store
 			if restoredRuns, err := s.platformReportStore.Load(); err != nil {
 				if deps.Logger != nil {

--- a/internal/api/server_dependencies.go
+++ b/internal/api/server_dependencies.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/attackpath"
 	"github.com/writer/cerebro/internal/auth"
 	"github.com/writer/cerebro/internal/cache"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/graph/builders"
@@ -69,12 +70,13 @@ type serverDependencies struct {
 	Config *app.Config
 	Logger *slog.Logger
 
-	Snowflake *snowflake.Client
-	Warehouse warehouse.DataWarehouse
-	Policy    *policy.Engine
-	Findings  findings.FindingStore
-	Scanner   *scanner.Scanner
-	Cache     *cache.PolicyCache
+	Snowflake      *snowflake.Client
+	Warehouse      warehouse.DataWarehouse
+	Policy         *policy.Engine
+	Findings       findings.FindingStore
+	Scanner        *scanner.Scanner
+	Cache          *cache.PolicyCache
+	ExecutionStore executionstore.Store
 
 	Agents         *agents.AgentRegistry
 	Ticketing      *ticketing.Service
@@ -135,6 +137,7 @@ func newServerDependenciesFromApp(application *app.App) serverDependencies {
 		Findings:             application.Findings,
 		Scanner:              application.Scanner,
 		Cache:                application.Cache,
+		ExecutionStore:       application.ExecutionStore,
 		Agents:               application.Agents,
 		Ticketing:            application.Ticketing,
 		Identity:             application.Identity,

--- a/internal/api/server_handlers_graph_intelligence_test.go
+++ b/internal/api/server_handlers_graph_intelligence_test.go
@@ -1996,8 +1996,11 @@ func TestPlatformReportRunUpdateRollsBackOnPersistenceFailure(t *testing.T) {
 	// Force a deterministic persistence failure by making the underlying shared
 	// execution store unavailable, while leaving the in-memory cache intact so we
 	// can verify the update path does not partially mutate durable state.
-	if err := s.platformReportStore.Close(); err != nil {
-		t.Fatalf("platformReportStore.Close(): %v", err)
+	if application.ExecutionStore == nil {
+		t.Fatal("expected shared execution store to be configured")
+	}
+	if err := application.ExecutionStore.Close(); err != nil {
+		t.Fatalf("ExecutionStore.Close(): %v", err)
 	}
 
 	err := s.updatePlatformReportRun(run.ID, func(run *reports.ReportRun) {

--- a/internal/api/server_handlers_platform_executions.go
+++ b/internal/api/server_handlers_platform_executions.go
@@ -19,13 +19,16 @@ func (s *Server) listPlatformExecutions(w http.ResponseWriter, r *http.Request) 
 		s.error(w, http.StatusInternalServerError, "platform execution store not configured")
 		return
 	}
-	store, err := executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
-	if err != nil {
-		s.error(w, http.StatusInternalServerError, "platform execution store unavailable")
-		return
+	store := s.app.ExecutionStore
+	if store == nil {
+		var err error
+		store, err = executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
+		if err != nil {
+			s.error(w, http.StatusInternalServerError, "platform execution store unavailable")
+			return
+		}
+		defer func() { _ = store.Close() }()
 	}
-	defer func() { _ = store.Close() }()
-
 	limit := 50
 	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
 		parsed, err := strconv.Atoi(raw)

--- a/internal/api/server_handlers_platform_test.go
+++ b/internal/api/server_handlers_platform_test.go
@@ -80,11 +80,10 @@ func TestPlatformExecutionsListsSharedExecutionStoreRuns(t *testing.T) {
 		t.Fatalf("storePlatformReportRun: %v", err)
 	}
 
-	sharedStore, err := executionstore.NewSQLiteStore(s.app.Config.ExecutionStoreFile)
-	if err != nil {
-		t.Fatalf("NewSQLiteStore: %v", err)
+	sharedStore := s.app.ExecutionStore
+	if sharedStore == nil {
+		t.Fatal("expected shared execution store")
 	}
-	defer func() { _ = sharedStore.Close() }()
 
 	workloadRun := workloadscan.RunRecord{
 		ID:          "workload_scan:test-execution-list",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -51,6 +51,7 @@ import (
 	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/dspm"
 	"github.com/writer/cerebro/internal/events"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/graph/builders"
@@ -90,13 +91,14 @@ type App struct {
 	Logger *slog.Logger
 
 	// Core services
-	Snowflake *snowflake.Client
-	Warehouse warehouse.DataWarehouse
-	Policy    *policy.Engine
-	Findings  findings.FindingStore
-	Scanner   *scanner.Scanner
-	DSPM      *dspm.Scanner
-	Cache     *cache.PolicyCache
+	Snowflake      *snowflake.Client
+	Warehouse      warehouse.DataWarehouse
+	Policy         *policy.Engine
+	Findings       findings.FindingStore
+	Scanner        *scanner.Scanner
+	DSPM           *dspm.Scanner
+	Cache          *cache.PolicyCache
+	ExecutionStore executionstore.Store
 
 	// Feature services
 	Agents         *agents.AgentRegistry

--- a/internal/app/app_cerebro_tools_executions.go
+++ b/internal/app/app_cerebro_tools_executions.go
@@ -30,12 +30,15 @@ func (a *App) toolCerebroExecutionStatus(ctx context.Context, args json.RawMessa
 	if limit > 100 {
 		return "", fmt.Errorf("limit must be <= 100")
 	}
-	store, err := executionstore.NewSQLiteStore(a.Config.ExecutionStoreFile)
-	if err != nil {
-		return "", fmt.Errorf("open shared execution store: %w", err)
+	store := a.ExecutionStore
+	if store == nil {
+		var err error
+		store, err = executionstore.NewSQLiteStore(a.Config.ExecutionStoreFile)
+		if err != nil {
+			return "", fmt.Errorf("open shared execution store: %w", err)
+		}
+		defer func() { _ = store.Close() }()
 	}
-	defer func() { _ = store.Close() }()
-
 	summaries, err := executions.List(ctx, store, executions.ListOptions{
 		Namespaces:         req.Namespace,
 		Statuses:           req.Status,

--- a/internal/app/app_cerebro_tools_test.go
+++ b/internal/app/app_cerebro_tools_test.go
@@ -849,7 +849,10 @@ func TestCerebroExecutionStatusTool(t *testing.T) {
 		t.Fatalf("UpsertRun: %v", err)
 	}
 
-	application := &App{Config: &Config{ExecutionStoreFile: filepath.Join(dir, "executions.db")}}
+	application := &App{
+		Config:         &Config{ExecutionStoreFile: filepath.Join(dir, "executions.db")},
+		ExecutionStore: store,
+	}
 	tool := findCerebroTool(application.AgentSDKTools(), "cerebro.execution_status")
 	if tool == nil {
 		t.Fatal("expected cerebro.execution_status tool")

--- a/internal/app/app_execution_store.go
+++ b/internal/app/app_execution_store.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+func (a *App) initExecutionStore() {
+	if a == nil || a.Config == nil {
+		return
+	}
+	path := strings.TrimSpace(a.Config.ExecutionStoreFile)
+	if path == "" {
+		return
+	}
+	store, err := executionstore.NewSQLiteStore(path)
+	if err != nil {
+		if a.Logger != nil {
+			a.Logger.Warn("failed to initialize shared execution store", "error", err, "path", path)
+		}
+		return
+	}
+	a.ExecutionStore = store
+	if a.Logger != nil {
+		a.Logger.Info("shared execution store initialized", "path", path)
+	}
+}
+
+func (a *App) executionStoreForPath(path string) executionstore.Store {
+	if a == nil || a.ExecutionStore == nil || a.Config == nil {
+		return nil
+	}
+	if sameExecutionStorePath(a.Config.ExecutionStoreFile, path) {
+		return a.ExecutionStore
+	}
+	return nil
+}
+
+func sameExecutionStorePath(left, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	leftAbs, leftErr := filepath.Abs(filepath.Clean(left))
+	rightAbs, rightErr := filepath.Abs(filepath.Clean(right))
+	if leftErr == nil && rightErr == nil {
+		return leftAbs == rightAbs
+	}
+	return filepath.Clean(left) == filepath.Clean(right)
+}

--- a/internal/app/app_graph_updates.go
+++ b/internal/app/app_graph_updates.go
@@ -130,7 +130,7 @@ func (a *App) maybeStartGraphConsistencyCheck(trigger string, summary graph.Grap
 	a.graphConsistencyCancel = cancel
 	a.graphConsistencyMu.Unlock()
 
-	go func() {
+	go func(checkCtx context.Context, cancel context.CancelFunc) {
 		defer a.graphConsistencyWG.Done()
 		defer func() {
 			a.graphConsistencyMu.Lock()
@@ -174,7 +174,7 @@ func (a *App) maybeStartGraphConsistencyCheck(trigger string, summary graph.Grap
 			"edges_added", len(diff.EdgesAdded),
 			"edges_removed", len(diff.EdgesRemoved),
 		)
-	}()
+	}(checkCtx, cancel)
 }
 
 func graphDiffHasChanges(diff *graph.GraphDiff) bool {

--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -54,6 +54,8 @@ func (a *App) initPhase1(ctx context.Context) error {
 }
 
 func (a *App) initPhase2a(ctx context.Context) error {
+	a.initExecutionStore()
+
 	if err := runInitTasksConcurrently(ctx, []concurrentInitTask{
 		{name: "cache", run: func(context.Context) { a.initCache() }},
 		{name: "ticketing", run: func(taskCtx context.Context) { a.initTicketing(taskCtx) }},

--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -22,6 +22,9 @@ import (
 )
 
 func (a *App) newSharedActionExecutor() *actionengine.Executor {
+	if a != nil && a.ExecutionStore != nil {
+		return actionengine.NewExecutor(actionengine.NewSQLiteStoreWithExecutionStore(a.ExecutionStore, actionengine.DefaultNamespace))
+	}
 	store, err := actionengine.NewSQLiteStore(a.Config.ExecutionStoreFile, actionengine.DefaultNamespace)
 	if err != nil {
 		a.Logger.Warn("failed to initialize shared action execution store; falling back to in-memory", "error", err, "path", a.Config.ExecutionStoreFile)

--- a/internal/app/app_storage_graph.go
+++ b/internal/app/app_storage_graph.go
@@ -294,6 +294,11 @@ func (a *App) Close() error {
 			errs = append(errs, fmt.Errorf("alert router: %w", err))
 		}
 	}
+	if a.ExecutionStore != nil {
+		if err := a.ExecutionStore.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("execution store: %w", err))
+		}
+	}
 
 	// Close findings store if it implements io.Closer (e.g., SQLiteStore)
 	if closer, ok := a.Findings.(interface{ Close() error }); ok {

--- a/internal/app/app_stream_consumer.go
+++ b/internal/app/app_stream_consumer.go
@@ -44,6 +44,7 @@ func (a *App) initTapGraphConsumer(ctx context.Context) {
 		DeadLetterPath:        a.Config.NATSConsumerDeadLetterPath,
 		DedupEnabled:          a.Config.NATSConsumerDedupEnabled,
 		DedupStateFile:        a.Config.NATSConsumerDedupStateFile,
+		DedupStore:            a.executionStoreForPath(a.Config.NATSConsumerDedupStateFile),
 		DedupTTL:              a.Config.NATSConsumerDedupTTL,
 		DedupMaxRecords:       a.Config.NATSConsumerDedupMaxRecords,
 		DropHealthLookback:    a.Config.NATSConsumerDropHealthLookback,

--- a/internal/app/app_workload_scan_graph.go
+++ b/internal/app/app_workload_scan_graph.go
@@ -16,9 +16,17 @@ func (a *App) materializePersistedWorkloadScans(ctx context.Context, g *graph.Gr
 	if storePath == "" {
 		return workloadscan.GraphMaterializationResult{}, nil
 	}
-	store, err := workloadscan.NewSQLiteRunStore(storePath)
-	if err != nil {
-		return workloadscan.GraphMaterializationResult{}, err
+	var (
+		store workloadscan.RunStore
+		err   error
+	)
+	if shared := a.executionStoreForPath(storePath); shared != nil {
+		store = workloadscan.NewSQLiteRunStoreWithExecutionStore(shared)
+	} else {
+		store, err = workloadscan.NewSQLiteRunStore(storePath)
+		if err != nil {
+			return workloadscan.GraphMaterializationResult{}, err
+		}
 	}
 	defer func() { _ = store.Close() }()
 

--- a/internal/apptest/apptest.go
+++ b/internal/apptest/apptest.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/attackpath"
 	"github.com/writer/cerebro/internal/auth"
 	"github.com/writer/cerebro/internal/cache"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/health"
@@ -64,8 +65,12 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 	pe := policy.NewEngine()
 	fs := findings.NewStore()
 	sc := scanner.NewScanner(pe, scanner.ScanConfig{Workers: 2}, logger)
+	executionStore, err := executionstore.NewSQLiteStore(cfg.ExecutionStoreFile)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
 
-	return &app.App{
+	application := &app.App{
 		Config:         cfg,
 		Logger:         logger,
 		Warehouse:      store,
@@ -73,6 +78,7 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 		Findings:       fs,
 		Scanner:        sc,
 		Cache:          cache.NewPolicyCache(1000, 5*time.Minute),
+		ExecutionStore: executionStore,
 		Agents:         agents.NewAgentRegistry(),
 		RBAC:           auth.NewRBAC(),
 		Webhooks:       webhooks.NewServiceForTesting(),
@@ -91,4 +97,6 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 		ScanWatermarks: scanner.NewWatermarkStore(nil),
 		ThreatIntel:    threatintel.NewThreatIntelService(),
 	}
+	t.Cleanup(func() { _ = application.Close() })
+	return application
 }

--- a/internal/events/consumer.go
+++ b/internal/events/consumer.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/jsonl"
 	"github.com/writer/cerebro/internal/metrics"
 )
@@ -48,6 +49,7 @@ type ConsumerConfig struct {
 	PayloadPreviewBytes int
 	DedupEnabled        bool
 	DedupStateFile      string
+	DedupStore          executionstore.Store
 	DedupTTL            time.Duration
 	DedupMaxRecords     int
 
@@ -125,9 +127,13 @@ func NewJetStreamConsumer(cfg ConsumerConfig, logger *slog.Logger, handler Event
 	}
 	var deduper *consumerProcessedEventDeduper
 	if config.DedupEnabled {
-		deduper, err = newConsumerProcessedEventDeduper(config.DedupStateFile, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
-		if err != nil {
-			return nil, err
+		if config.DedupStore != nil {
+			deduper = newConsumerProcessedEventDeduperWithStore(config.DedupStore, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
+		} else {
+			deduper, err = newConsumerProcessedEventDeduper(config.DedupStateFile, config.Stream, config.Durable, config.DedupTTL, config.DedupMaxRecords)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/events/consumer_dedup.go
+++ b/internal/events/consumer_dedup.go
@@ -13,10 +13,11 @@ import (
 )
 
 type consumerProcessedEventDeduper struct {
-	store      *executionstore.SQLiteStore
+	store      executionstore.Store
 	namespace  string
 	ttl        time.Duration
 	maxRecords int
+	ownsStore  bool
 }
 
 func newConsumerProcessedEventDeduper(path, stream, durable string, ttl time.Duration, maxRecords int) (*consumerProcessedEventDeduper, error) {
@@ -34,16 +35,22 @@ func newConsumerProcessedEventDeduper(path, stream, durable string, ttl time.Dur
 	if err != nil {
 		return nil, err
 	}
+	deduper := newConsumerProcessedEventDeduperWithStore(store, stream, durable, ttl, maxRecords)
+	deduper.ownsStore = true
+	return deduper, nil
+}
+
+func newConsumerProcessedEventDeduperWithStore(store executionstore.Store, stream, durable string, ttl time.Duration, maxRecords int) *consumerProcessedEventDeduper {
 	return &consumerProcessedEventDeduper{
 		store:      store,
 		namespace:  fmt.Sprintf("%s:%s:%s", executionstore.NamespaceProcessedCloudEvent, strings.TrimSpace(stream), strings.TrimSpace(durable)),
 		ttl:        ttl,
 		maxRecords: maxRecords,
-	}, nil
+	}
 }
 
 func (d *consumerProcessedEventDeduper) Close() error {
-	if d == nil || d.store == nil {
+	if d == nil || d.store == nil || !d.ownsStore {
 		return nil
 	}
 	return d.store.Close()

--- a/internal/executions/summary.go
+++ b/internal/executions/summary.go
@@ -47,7 +47,7 @@ type Summary struct {
 	Target        string     `json:"target,omitempty"`
 }
 
-func List(ctx context.Context, store *executionstore.SQLiteStore, opts ListOptions) ([]Summary, error) {
+func List(ctx context.Context, store executionstore.Store, opts ListOptions) ([]Summary, error) {
 	if store == nil {
 		return nil, nil
 	}

--- a/internal/executionstore/store.go
+++ b/internal/executionstore/store.go
@@ -1,0 +1,26 @@
+package executionstore
+
+import (
+	"context"
+	"time"
+)
+
+// Store is the durable execution-state substrate interface. SQLite is the
+// current implementation, but higher-scale backends should satisfy the same
+// contract instead of forcing callers to depend on SQLite directly.
+type Store interface {
+	Close() error
+	UpsertRun(context.Context, RunEnvelope) error
+	ReplaceRunWithEvents(context.Context, RunEnvelope, []EventEnvelope) error
+	LoadRun(context.Context, string, string) (*RunEnvelope, error)
+	ListRuns(context.Context, string, RunListOptions) ([]RunEnvelope, error)
+	ListAllRuns(context.Context, RunListOptions) ([]RunEnvelope, error)
+	DeleteRun(context.Context, string, string) error
+	DeleteEvents(context.Context, string, string) error
+	SaveEvent(context.Context, EventEnvelope) (EventEnvelope, error)
+	LoadEvents(context.Context, string, string) ([]EventEnvelope, error)
+	LookupProcessedEvent(context.Context, string, string, time.Time) (*ProcessedEventRecord, error)
+	TouchProcessedEvent(context.Context, string, string, time.Time, time.Duration) error
+	RememberProcessedEvent(context.Context, ProcessedEventRecord, int) error
+	DeleteProcessedEvent(context.Context, string, string) error
+}

--- a/internal/functionscan/store.go
+++ b/internal/functionscan/store.go
@@ -20,7 +20,8 @@ type RunStore interface {
 }
 
 type SQLiteRunStore struct {
-	store *executionstore.SQLiteStore
+	store     executionstore.Store
+	ownsStore bool
 }
 
 func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
@@ -28,7 +29,13 @@ func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SQLiteRunStore{store: store}, nil
+	runStore := NewSQLiteRunStoreWithExecutionStore(store)
+	runStore.ownsStore = true
+	return runStore, nil
+}
+
+func NewSQLiteRunStoreWithExecutionStore(store executionstore.Store) *SQLiteRunStore {
+	return &SQLiteRunStore{store: store}
 }
 
 func (s *SQLiteRunStore) SaveRun(ctx context.Context, run *RunRecord) error {
@@ -142,7 +149,7 @@ func (s *SQLiteRunStore) LoadEvents(ctx context.Context, runID string) ([]RunEve
 }
 
 func (s *SQLiteRunStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()

--- a/internal/graph/reports/report_run_store.go
+++ b/internal/graph/reports/report_run_store.go
@@ -25,7 +25,8 @@ type ReportRunStore struct {
 	executionFile string
 	legacyState   string
 	snapshotDir   string
-	execution     *executionstore.SQLiteStore
+	execution     executionstore.Store
+	ownsExecution bool
 }
 
 type persistedReportRunRecord struct {
@@ -56,16 +57,22 @@ func NewReportRunStore(executionFile, snapshotDir, legacyStateFile string) (*Rep
 	if err != nil {
 		return nil, err
 	}
+	reportStore := NewReportRunStoreWithExecutionStore(store, executionFile, snapshotDir, legacyStateFile)
+	reportStore.ownsExecution = true
+	return reportStore, nil
+}
+
+func NewReportRunStoreWithExecutionStore(store executionstore.Store, executionFile, snapshotDir, legacyStateFile string) *ReportRunStore {
 	return &ReportRunStore{
 		executionFile: strings.TrimSpace(executionFile),
 		legacyState:   strings.TrimSpace(legacyStateFile),
 		snapshotDir:   strings.TrimSpace(snapshotDir),
 		execution:     store,
-	}, nil
+	}
 }
 
 func (s *ReportRunStore) Close() error {
-	if s == nil || s.execution == nil {
+	if s == nil || s.execution == nil || !s.ownsExecution {
 		return nil
 	}
 	return s.execution.Close()

--- a/internal/graph/reports/report_run_store_test.go
+++ b/internal/graph/reports/report_run_store_test.go
@@ -188,6 +188,33 @@ func TestReportRunStoreSaveRunReplacesPersistedEvents(t *testing.T) {
 	}
 }
 
+func TestReportRunStoreWithSharedExecutionStoreDoesNotOwnClose(t *testing.T) {
+	stateDir := t.TempDir()
+	executionStore, err := executionstore.NewSQLiteStore(filepath.Join(stateDir, "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = executionStore.Close() }()
+
+	store := NewReportRunStoreWithExecutionStore(executionStore, filepath.Join(stateDir, "executions.db"), filepath.Join(stateDir, "snapshots"), filepath.Join(stateDir, "legacy-state.json"))
+	if err := store.Close(); err != nil {
+		t.Fatalf("ReportRunStore.Close(): %v", err)
+	}
+
+	if err := executionStore.UpsertRun(t.Context(), executionstore.RunEnvelope{
+		Namespace:   executionstore.NamespacePlatformReportRun,
+		RunID:       "report_run:shared-close",
+		Kind:        "quality",
+		Status:      string(ReportRunStatusQueued),
+		Stage:       string(ReportRunStatusQueued),
+		SubmittedAt: time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 3, 12, 9, 0, 0, 0, time.UTC),
+		Payload:     []byte(`{"run":{"id":"report_run:shared-close","report_id":"quality","status":"queued","submitted_at":"2026-03-12T09:00:00Z"}}`),
+	}); err != nil {
+		t.Fatalf("UpsertRun after borrowed store close: %v", err)
+	}
+}
+
 func timePtr(value time.Time) *time.Time {
 	return &value
 }

--- a/internal/imagescan/store.go
+++ b/internal/imagescan/store.go
@@ -20,7 +20,8 @@ type RunStore interface {
 }
 
 type SQLiteRunStore struct {
-	store *executionstore.SQLiteStore
+	store     executionstore.Store
+	ownsStore bool
 }
 
 func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
@@ -28,7 +29,13 @@ func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SQLiteRunStore{store: store}, nil
+	runStore := NewSQLiteRunStoreWithExecutionStore(store)
+	runStore.ownsStore = true
+	return runStore, nil
+}
+
+func NewSQLiteRunStoreWithExecutionStore(store executionstore.Store) *SQLiteRunStore {
+	return &SQLiteRunStore{store: store}
 }
 
 func (s *SQLiteRunStore) SaveRun(ctx context.Context, run *RunRecord) error {
@@ -142,7 +149,7 @@ func (s *SQLiteRunStore) LoadEvents(ctx context.Context, runID string) ([]RunEve
 }
 
 func (s *SQLiteRunStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()

--- a/internal/workloadscan/store.go
+++ b/internal/workloadscan/store.go
@@ -20,7 +20,8 @@ type RunStore interface {
 }
 
 type SQLiteRunStore struct {
-	store *executionstore.SQLiteStore
+	store     executionstore.Store
+	ownsStore bool
 }
 
 func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
@@ -28,7 +29,13 @@ func NewSQLiteRunStore(path string) (*SQLiteRunStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SQLiteRunStore{store: store}, nil
+	runStore := NewSQLiteRunStoreWithExecutionStore(store)
+	runStore.ownsStore = true
+	return runStore, nil
+}
+
+func NewSQLiteRunStoreWithExecutionStore(store executionstore.Store) *SQLiteRunStore {
+	return &SQLiteRunStore{store: store}
 }
 
 func (s *SQLiteRunStore) SaveRun(ctx context.Context, run *RunRecord) error {
@@ -142,7 +149,7 @@ func (s *SQLiteRunStore) LoadEvents(ctx context.Context, runID string) ([]RunEve
 }
 
 func (s *SQLiteRunStore) Close() error {
-	if s == nil || s.store == nil {
+	if s == nil || s.store == nil || !s.ownsStore {
 		return nil
 	}
 	return s.store.Close()


### PR DESCRIPTION
## Summary
- introduce a backend-neutral `executionstore.Store` interface and thread the shared execution store through reports, scans, action executions, and consumer dedupe paths
- add app-level shared execution store initialization and borrow-vs-own helpers so wrappers stop closing the shared store accidentally
- update tests around shared-store ownership and report/run listing behavior to exercise the new seam consistently

## Testing
- go test ./internal/actionengine ./internal/api ./internal/app ./internal/apptest ./internal/events ./internal/executionstore ./internal/functionscan ./internal/graph/reports ./internal/imagescan ./internal/workloadscan -count=1
- make devex-pr
- python3 scripts/oss_audit.py
