### PR TITLE
feat(graph): add distributed graph persistence foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ go.work
 *.swp
 *.swo
 .factory/
+**/.cerebro/
 
 # OS
 .DS_Store

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,56 @@ Owner: @haasonsaas
 Mode: implement in full, keep CI green
 Status: executed end-to-end via PR workflow
 
+## Deep Review Cycle 68 - Distributed Graph Persistence Foundation and Replica Recovery (2026-03-12)
+
+### Review findings
+- [x] Gap: issue `#246` was still conceptually correct but operationally hollow; snapshot artifacts existed, yet the live graph did not actually depend on a shared graph-persistence seam for activation, recovery, or API/tool reads.
+- [x] Gap: snapshot usage was fragmented across API handlers, graph intelligence handlers, replay code, and tool paths via ad hoc `GRAPH_SNAPSHOT_PATH` lookups instead of a shared store owned at the application layer.
+- [x] Gap: the graph had no replica-aware recovery path. Losing the local snapshot directory still meant rebuilding from the warehouse even though the issue explicitly called for replicated durability.
+- [x] Gap: the right abstractions were visible in upstream references:
+  - [x] `dagster-io/dagster` keeps durable run storage behind one seam even while the execution/runtime layer stays hot and in-process.
+  - [x] `temporalio/temporal` treats recovery and coordination state as infrastructure, not handler-local glue.
+  - [x] the local Wiz schema dump in `/Users/jonathanhaas/Downloads/other/wiz.graphql` reinforces that broad graph/intelligence query surfaces only stay operable when snapshot/entity state is typed, inspectable, and recoverable.
+
+### Execution plan
+- [x] Add a shared graph persistence store:
+  - [x] add `internal/graph/persistence_store.go`
+  - [x] keep the current local snapshot store as the hot/local durability layer
+  - [x] add replica backends for `file://`, `s3://`, and `gs://`
+- [x] Deepen the snapshot substrate:
+  - [x] add reusable compressed snapshot encode/decode helpers
+  - [x] teach `SnapshotStore` to return typed persisted records/manifests for the latest saved snapshot
+  - [x] expose latest-snapshot record loading for recovery and status
+- [x] Move graph persistence to the app boundary:
+  - [x] add shared config-backed `App.GraphSnapshots`
+  - [x] initialize it during app bootstrap next to the shared execution store
+  - [x] persist graph snapshots automatically on graph activation
+  - [x] recover from the latest persisted snapshot before the warehouse rebuild completes
+- [x] Move graph read surfaces onto the shared store:
+  - [x] platform graph snapshot APIs
+  - [x] graph intelligence temporal diff path
+  - [x] tool temporal graph-diff helpers
+- [x] Add health and regression coverage:
+  - [x] register `graph_persistence` health
+  - [x] add replica fallback tests
+  - [x] add activation-time persistence tests
+
+### Detailed follow-on backlog
+- [ ] Track A - complete `#246` HA control plane
+  - Exit criteria:
+  - [ ] add one-writer lease semantics for rebuild / CDC apply
+  - [ ] add follower hydration mode and readiness gates on replica freshness
+  - [ ] add replica integrity verification sweeps and background repair
+- [ ] Track B - persistence substrate hardening
+  - Exit criteria:
+  - [ ] move diff artifacts onto the shared graph persistence path instead of sibling local-only storage
+  - [ ] add explicit replica lag / hydration metrics
+  - [ ] add object-store integration coverage for `s3://` and `gs://` backends
+- [ ] Track C - downstream partitioning and tenancy
+  - Exit criteria:
+  - [ ] land `#247` on top of the shared graph persistence seam rather than directly on raw in-memory graphs
+  - [ ] push tenant/account partition keys into snapshot manifests and hydration boundaries
+
 ## Deep Review Cycle 67 - Graph Horizontal Scaling Path and Persistence Decision Gate (2026-03-12)
 
 ### Review findings

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,46 @@
 # Cerebro Intelligence Layer Execution TODO
 
-Last updated: 2026-03-12 (America/Los_Angeles)
+Last updated: 2026-03-13 (America/Los_Angeles)
 Owner: @haasonsaas
 Mode: implement in full, keep CI green
 Status: executed end-to-end via PR workflow
+
+## Deep Review Cycle 69 - Tenant-Scoped Graph Reads and Cross-Tenant Audit Guards (2026-03-13)
+
+### Review findings
+- [x] Gap: issue `#247` still had the classic half-secure shape: tenant context existed in middleware, but the graph/entity/intelligence/risk read surfaces were still free to operate on the full graph.
+- [x] Gap: cross-tenant routes were reachable through generic graph permissions instead of one explicit permission boundary, which made the audit story weaker than the API shape implied.
+- [x] Gap: the right upstream patterns are consistent:
+  - [x] `openfga/openfga` keeps storage/authorization seams explicit instead of relying on ambient context in downstream handlers.
+  - [x] `authzed/spicedb` treats multi-backend datastore structure as a first-class contract, which is the right lead-in for `#250` after tenant scoping is correct.
+  - [x] `dagster-io/dagster` keeps execution/storage boundaries explicit, which matches the current shared execution-store and graph-persistence direction.
+  - [x] the local Wiz schema dump in `/Users/jonathanhaas/Downloads/other/wiz.graphql` reinforces that project/issue/entity surfaces stay usable only when tenant/project boundaries are first-class in the graph substrate.
+
+### Execution plan
+- [x] Add first-class tenant metadata to graph nodes:
+  - [x] add `tenant_id` to `graph.Node`
+  - [x] normalize `tenant_id` from node properties on write
+  - [x] preserve `tenant_id` through cloned/scoped graph views
+- [x] Add one shared tenant-scope graph helper:
+  - [x] add `Graph.SubgraphForTenant(...)`
+  - [x] treat untagged nodes as shared/global for the incremental rollout
+  - [x] rebuild indexes on scoped graph views so entity search/suggest stay correct
+- [x] Enforce tenant-scoped reads on high-value graph surfaces:
+  - [x] platform entity list/search/detail/time-diff
+  - [x] platform intelligence event/risk/report query surfaces
+  - [x] graph risk traversal/query surfaces (`blast-radius`, `attack-paths`, `toxic-combinations`, etc.)
+  - [x] platform knowledge read/diff surfaces
+- [x] Add explicit cross-tenant authorization and audit:
+  - [x] add `platform.cross_tenant.read`
+  - [x] add `platform.cross_tenant.write`
+  - [x] route `/api/v1/graph/cross-tenant/*` through explicit permissions instead of generic graph read/write
+  - [x] add structured audit entries for allowed cross-tenant reads
+  - [x] add Prometheus access counters by operation and requesting/target tenant pair
+- [x] Add regression coverage:
+  - [x] graph tenant normalization/scoping tests
+  - [x] platform entity tenant isolation tests
+  - [x] intelligence/risk tenant isolation tests
+  - [x] cross-tenant audit + metrics tests
 
 ## Deep Review Cycle 68 - Distributed Graph Persistence Foundation and Replica Recovery (2026-03-12)
 
@@ -98,8 +135,8 @@ Status: executed end-to-end via PR workflow
 - [ ] Track B - `#247` tenant/account partitioning
   - Exit criteria:
   - [ ] add tenant/account partition keys to graph snapshot and query paths
-  - [ ] enforce tenant-scoped query guards on platform graph reads
-  - [ ] add explicit audited cross-tenant read/report paths rather than ambient joins
+  - [x] enforce tenant-scoped query guards on platform graph reads
+  - [x] add explicit audited cross-tenant read/report paths rather than ambient joins
 - [ ] Track C - graph persistence backend decision
   - Exit criteria:
   - [ ] keep the hot graph in memory for low-latency traversals

--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -2,7 +2,7 @@
 
 Generated from `internal/app/app_config.go` (`LoadConfig`) via `go run ./scripts/generate_config_docs/main.go`.
 
-Total variables: **307**
+Total variables: **310**
 
 | Variable | Reader(s) | Default(s) | Config Field(s) | Validation rule(s) |
 |---|---|---|---|---|
@@ -118,6 +118,9 @@ Total variables: **307**
 | `GRAPH_EVENT_MAPPER_VALIDATION_MODE` | `getEnv` | `"enforce"` | `GraphEventMapperValidationMode` | `must be one of warn, enforce` |
 | `GRAPH_MIGRATE_LEGACY_ACTIVITY_ON_START` | `getEnvBool` | `false` | `GraphMigrateLegacyActivityOnStart` | `-` |
 | `GRAPH_SCHEMA_VALIDATION_MODE` | `getEnv` | `"warn"` | `GraphSchemaValidationMode` | `must be one of off, warn, enforce` |
+| `GRAPH_SNAPSHOT_MAX_RETAINED` | `getEnvInt` | `10` | `GraphSnapshotMaxRetained` | `-` |
+| `GRAPH_SNAPSHOT_PATH` | `getEnv` | `filepath.Join(".cerebro", "graph-snapshots")` | `GraphSnapshotPath` | `-` |
+| `GRAPH_SNAPSHOT_REPLICA_URI` | `getEnv` | `""` | `GraphSnapshotReplicaURI` | `-` |
 | `IMAGE_SCAN_CLEANUP_TIMEOUT` | `getEnvDuration` | `2 * time.Minute` | `ImageScanCleanupTimeout` | `-` |
 | `IMAGE_SCAN_ROOTFS_BASE_PATH` | `getEnv` | `filepath.Join(".cerebro", "image-scan", "rootfs")` | `ImageScanRootFSBasePath` | `-` |
 | `IMAGE_SCAN_STATE_FILE` | `getEnv` | `getEnv("EXECUTION_STORE_FILE", filepath.Join(".cerebro", "executions.db"))` | `ImageScanStateFile` | `-` |

--- a/docs/GRAPH_HORIZONTAL_SCALING_ARCHITECTURE.md
+++ b/docs/GRAPH_HORIZONTAL_SCALING_ARCHITECTURE.md
@@ -187,6 +187,36 @@ The hybrid path uses existing seams and keeps optionality open.
 
 It should not start by replacing the query engine.
 
+## What `#246` Now Implements
+
+The first concrete `#246` cut is now in the repo:
+
+- a shared app-owned graph persistence store, parallel to the shared execution store
+- automatic snapshot persistence on graph activation
+- recovery from the latest persisted snapshot before the warehouse rebuild completes
+- replica-aware fallback for graph snapshot APIs, temporal diff paths, and tool diff helpers
+- pluggable replica backends for:
+  - local filesystem mirrors (`file://` or plain path)
+  - Amazon S3 (`s3://bucket/prefix`)
+  - Google Cloud Storage (`gs://bucket/prefix`)
+- persistence health reporting through the app health registry
+
+That means Cerebro now has the first durable graph-runtime seam needed for:
+
+- rolling deployments without throwing away the only durable graph artifact
+- follower/read replica hydration in a later cut
+- one-writer lease semantics in a later cut
+- tenant/account partitioned hydration in `#247`
+
+It still intentionally does **not** solve:
+
+- lease election / writer fencing
+- follower promotion logic
+- replica lag metrics and automatic repair
+- tenant/account graph partitioning
+
+Those remain the next layers on top of the shared persistence substrate.
+
 ## What `#247` Should Actually Build
 
 `#247` should implement:

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -380,6 +380,11 @@ func routePermission(method, path string) string {
 		return "sdk.worldmodel.write"
 	case strings.HasPrefix(path, "/api/v1/mcp"):
 		return "sdk.invoke"
+	case strings.HasPrefix(path, "/api/v1/graph/cross-tenant"):
+		if isWrite {
+			return "platform.cross_tenant.write"
+		}
+		return "platform.cross_tenant.read"
 	case isWrite && path == "/api/v1/platform/graph/diffs":
 		return "platform.graph.write"
 	case strings.HasPrefix(path, "/api/v1/platform/graph"):

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -400,6 +400,8 @@ func TestRoutePermissionCoverage(t *testing.T) {
 		{name: "platform intelligence", method: http.MethodGet, path: "/api/v1/platform/intelligence/leverage", expectedRB: "platform.intelligence.read"},
 		{name: "platform intelligence run", method: http.MethodPost, path: "/api/v1/platform/intelligence/reports/quality/runs", expectedRB: "platform.intelligence.run"},
 		{name: "platform graph diff materialize", method: http.MethodPost, path: "/api/v1/platform/graph/diffs", expectedRB: "platform.graph.write"},
+		{name: "cross tenant read", method: http.MethodGet, path: "/api/v1/graph/cross-tenant/patterns", expectedRB: "platform.cross_tenant.read"},
+		{name: "cross tenant write", method: http.MethodPost, path: "/api/v1/graph/cross-tenant/patterns/ingest", expectedRB: "platform.cross_tenant.write"},
 		{name: "platform knowledge read", method: http.MethodGet, path: "/api/v1/platform/knowledge/claims", expectedRB: "platform.knowledge.read"},
 		{name: "platform knowledge write", method: http.MethodPost, path: "/api/v1/platform/knowledge/claims", expectedRB: "platform.knowledge.write"},
 		{name: "org expertise read", method: http.MethodGet, path: "/api/v1/org/expertise/queries", expectedRB: "org.expertise.read"},

--- a/internal/api/server_dependencies.go
+++ b/internal/api/server_dependencies.go
@@ -69,12 +69,13 @@ type serverDependencies struct {
 	Config *app.Config
 	Logger *slog.Logger
 
-	Snowflake *snowflake.Client
-	Warehouse warehouse.DataWarehouse
-	Policy    *policy.Engine
-	Findings  findings.FindingStore
-	Scanner   *scanner.Scanner
-	Cache     *cache.PolicyCache
+	Snowflake      *snowflake.Client
+	Warehouse      warehouse.DataWarehouse
+	Policy         *policy.Engine
+	Findings       findings.FindingStore
+	Scanner        *scanner.Scanner
+	Cache          *cache.PolicyCache
+	GraphSnapshots *graph.GraphPersistenceStore
 
 	Agents         *agents.AgentRegistry
 	Ticketing      *ticketing.Service
@@ -135,6 +136,7 @@ func newServerDependenciesFromApp(application *app.App) serverDependencies {
 		Findings:             application.Findings,
 		Scanner:              application.Scanner,
 		Cache:                application.Cache,
+		GraphSnapshots:       application.GraphSnapshots,
 		Agents:               application.Agents,
 		Ticketing:            application.Ticketing,
 		Identity:             application.Identity,

--- a/internal/api/server_handlers_graph_cross_tenant.go
+++ b/internal/api/server_handlers_graph_cross_tenant.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/metrics"
+	"github.com/writer/cerebro/internal/snowflake"
 )
 
 type crossTenantBuildRequest struct {
@@ -50,9 +52,11 @@ func (s *Server) buildCrossTenantPatternSamples(w http.ResponseWriter, r *http.R
 
 	samples, err := engine.BuildAnonymizedPatternSamples(req.TenantID, time.Duration(req.WindowDays)*24*time.Hour)
 	if err != nil {
+		s.logCrossTenantRead(r.Context(), r, "build_samples", req.TenantID, 0, "error")
 		s.error(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	s.logCrossTenantRead(r.Context(), r, "build_samples", req.TenantID, len(samples), "allowed")
 	s.json(w, http.StatusOK, map[string]any{
 		"count":   len(samples),
 		"samples": samples,
@@ -130,6 +134,7 @@ func (s *Server) listCrossTenantPatterns(w http.ResponseWriter, r *http.Request)
 
 	patterns := engine.CrossTenantPatterns(minTenants)
 	metrics.RecordGraphCrossTenantPatterns(len(patterns))
+	s.logCrossTenantRead(r.Context(), r, "list_patterns", "aggregate_library", len(patterns), "allowed")
 	s.json(w, http.StatusOK, map[string]any{
 		"count":    len(patterns),
 		"patterns": patterns,
@@ -168,8 +173,86 @@ func (s *Server) matchCrossTenantPatterns(w http.ResponseWriter, r *http.Request
 
 	matches := engine.MatchCrossTenantPatterns(minProbability, limit)
 	metrics.RecordGraphCrossTenantMatches(len(matches))
+	s.logCrossTenantRead(r.Context(), r, "match_patterns", "aggregate_library", len(matches), "allowed")
 	s.json(w, http.StatusOK, map[string]any{
 		"count":   len(matches),
 		"matches": matches,
 	})
+}
+
+func (s *Server) logCrossTenantRead(ctx context.Context, r *http.Request, operation, targetTenant string, resultCount int, outcome string) {
+	requestingTenant := strings.TrimSpace(GetTenantID(ctx))
+	auditRequestingTenant := requestingTenant
+	if auditRequestingTenant == "" {
+		auditRequestingTenant = "unknown"
+	}
+	targetTenant = strings.TrimSpace(targetTenant)
+	auditTargetTenant := targetTenant
+	if auditTargetTenant == "" {
+		auditTargetTenant = "unknown"
+	}
+	outcome = strings.TrimSpace(strings.ToLower(outcome))
+	if outcome == "" {
+		outcome = "unknown"
+	}
+
+	metrics.RecordGraphCrossTenantRead(
+		operation,
+		crossTenantRequestScope(requestingTenant),
+		crossTenantTargetScope(targetTenant),
+		outcome,
+	)
+
+	details := map[string]any{
+		"requesting_tenant": auditRequestingTenant,
+		"target_tenant":     auditTargetTenant,
+		"operation":         strings.TrimSpace(operation),
+		"result_count":      resultCount,
+		"outcome":           outcome,
+		"timestamp":         time.Now().UTC().Format(time.RFC3339Nano),
+	}
+
+	if auditLoggerIsNil(s.auditLogger) {
+		if s.app != nil && s.app.Logger != nil {
+			s.app.Logger.Info("cross-tenant graph read", "requesting_tenant", auditRequestingTenant, "target_tenant", auditTargetTenant, "operation", operation, "result_count", resultCount, "outcome", outcome)
+		}
+		return
+	}
+
+	actorID := strings.TrimSpace(GetUserID(ctx))
+	if actorID == "" {
+		actorID = "api"
+	}
+	entry := &snowflake.AuditEntry{
+		Action:       "graph.cross_tenant.read",
+		ActorID:      actorID,
+		ActorType:    "user",
+		ResourceType: "graph_cross_tenant",
+		ResourceID:   strings.TrimSpace(operation) + ":" + auditTargetTenant,
+		Details:      details,
+		IPAddress:    r.RemoteAddr,
+		UserAgent:    r.UserAgent(),
+	}
+	if err := s.auditLogger.Log(ctx, entry); err != nil && s.app != nil && s.app.Logger != nil {
+		s.app.Logger.Warn("failed to persist cross-tenant graph audit log", "error", err, "operation", operation, "requesting_tenant", auditRequestingTenant, "target_tenant", auditTargetTenant)
+	}
+}
+
+func crossTenantRequestScope(requestingTenant string) string {
+	if strings.TrimSpace(requestingTenant) == "" {
+		return "global"
+	}
+	return "tenant"
+}
+
+func crossTenantTargetScope(targetTenant string) string {
+	targetTenant = strings.TrimSpace(targetTenant)
+	switch targetTenant {
+	case "":
+		return "unknown"
+	case "aggregate_library":
+		return "aggregate"
+	default:
+		return "tenant"
+	}
 }

--- a/internal/api/server_handlers_graph_intelligence.go
+++ b/internal/api/server_handlers_graph_intelligence.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -219,11 +217,11 @@ func (s *Server) graphIntelligenceInsights(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
-		snapshotPath := strings.TrimSpace(os.Getenv("GRAPH_SNAPSHOT_PATH"))
-		if snapshotPath == "" {
-			snapshotPath = filepath.Join(".cerebro", "graph-snapshots")
+		store := s.platformGraphSnapshotStore()
+		if store == nil {
+			s.error(w, http.StatusNotFound, "graph snapshot store not configured")
+			return
 		}
-		store := graph.NewSnapshotStore(snapshotPath, 10)
 		diff, err := store.DiffByTime(from, to)
 		if err != nil {
 			status := http.StatusInternalServerError

--- a/internal/api/server_handlers_graph_intelligence.go
+++ b/internal/api/server_handlers_graph_intelligence.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -18,15 +19,15 @@ func (s *Server) graphIntelligenceEventPatterns(w http.ResponseWriter, _ *http.R
 	s.json(w, http.StatusOK, graph.EventCorrelationPatternCatalogSnapshot(time.Now().UTC()))
 }
 
-func (s *Server) currentGraphIntelligenceGraph() *graph.Graph {
+func (s *Server) currentGraphIntelligenceGraph(ctx context.Context) *graph.Graph {
 	if s == nil || s.graphIntelligence == nil {
 		return nil
 	}
-	return s.graphIntelligence.CurrentGraph()
+	return s.tenantScopedGraph(ctx, s.graphIntelligence.CurrentGraph())
 }
 
 func (s *Server) graphIntelligenceEventCorrelations(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -79,6 +80,18 @@ func (s *Server) graphIntelligenceEventCorrelations(w http.ResponseWriter, r *ht
 		s.error(w, http.StatusBadRequest, "event_id or entity_id is required")
 		return
 	}
+	if eventID != "" {
+		if _, ok := g.GetNode(eventID); !ok {
+			s.error(w, http.StatusNotFound, "event not found in selected scope")
+			return
+		}
+	}
+	if entityID != "" {
+		if _, ok := g.GetNode(entityID); !ok {
+			s.error(w, http.StatusNotFound, "entity not found in selected scope")
+			return
+		}
+	}
 
 	result := graph.QueryEventCorrelations(g, time.Now().UTC(), graph.EventCorrelationQuery{
 		EventID:          eventID,
@@ -93,7 +106,7 @@ func (s *Server) graphIntelligenceEventCorrelations(w http.ResponseWriter, r *ht
 }
 
 func (s *Server) graphIntelligenceEventAnomalies(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -135,13 +148,13 @@ func (s *Server) graphIntelligenceEventAnomalies(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) graphIntelligenceInsights(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 
-	engine := s.graphRiskEngine()
+	engine := s.currentTenantRiskEngine(r.Context())
 	if engine == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -247,7 +260,7 @@ func (s *Server) graphIntelligenceInsights(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) graphIntelligenceQuality(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -292,7 +305,7 @@ func (s *Server) graphIntelligenceQuality(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) graphIntelligenceMetadataQuality(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -315,7 +328,7 @@ func (s *Server) graphIntelligenceMetadataQuality(w http.ResponseWriter, r *http
 }
 
 func (s *Server) graphIntelligenceClaimConflicts(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -382,7 +395,7 @@ func (s *Server) graphIntelligenceClaimConflicts(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) graphIntelligenceEntitySummary(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -391,6 +404,10 @@ func (s *Server) graphIntelligenceEntitySummary(w http.ResponseWriter, r *http.R
 	entityID := strings.TrimSpace(r.URL.Query().Get("entity_id"))
 	if entityID == "" {
 		s.error(w, http.StatusBadRequest, "entity_id is required")
+		return
+	}
+	if _, ok := g.GetNode(entityID); !ok {
+		s.error(w, http.StatusNotFound, "entity not found in selected scope")
 		return
 	}
 
@@ -429,7 +446,7 @@ func (s *Server) graphIntelligenceEntitySummary(w http.ResponseWriter, r *http.R
 }
 
 func (s *Server) graphIntelligenceLeverage(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -660,12 +677,12 @@ func (s *Server) graphIngestContracts(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) graphIntelligenceWeeklyCalibration(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
-	engine := s.graphRiskEngine()
+	engine := s.currentTenantRiskEngine(r.Context())
 	if engine == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -810,7 +827,7 @@ type graphQueryNeighborResult struct {
 }
 
 func (s *Server) graphQuery(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return

--- a/internal/api/server_handlers_graph_risk.go
+++ b/internal/api/server_handlers_graph_risk.go
@@ -10,12 +10,13 @@ import (
 )
 
 func (s *Server) graphStats(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 
-	meta := s.app.SecurityGraph.Metadata()
+	meta := g.Metadata()
 	s.json(w, http.StatusOK, map[string]interface{}{
 		"built_at":       meta.BuiltAt,
 		"node_count":     meta.NodeCount,
@@ -27,7 +28,8 @@ func (s *Server) graphStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) blastRadius(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
@@ -45,12 +47,13 @@ func (s *Server) blastRadius(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result := graph.BlastRadius(s.app.SecurityGraph, principalID, maxDepth)
+	result := graph.BlastRadius(g, principalID, maxDepth)
 	s.json(w, http.StatusOK, result)
 }
 
 func (s *Server) cascadingBlastRadius(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
@@ -68,12 +71,13 @@ func (s *Server) cascadingBlastRadius(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result := graph.CascadingBlastRadius(s.app.SecurityGraph, principalID, maxDepth)
+	result := graph.CascadingBlastRadius(g, principalID, maxDepth)
 	s.json(w, http.StatusOK, result)
 }
 
 func (s *Server) reverseAccess(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
@@ -91,7 +95,7 @@ func (s *Server) reverseAccess(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result := graph.ReverseAccess(s.app.SecurityGraph, resourceID, maxDepth)
+	result := graph.ReverseAccess(g, resourceID, maxDepth)
 	s.json(w, http.StatusOK, result)
 }
 
@@ -119,30 +123,36 @@ func (s *Server) rebuildGraph(w http.ResponseWriter, r *http.Request) {
 // Risk Intelligence endpoints
 
 func (s *Server) riskReport(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 
-	engine := s.graphRiskEngine()
+	engine := s.currentTenantRiskEngine(r.Context())
 	if engine == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 	report := engine.Analyze()
-	s.persistRiskEngineState(r.Context(), engine)
+	// Persist only for global requests. Context-derived scope is stable even if the
+	// live graph pointer changes during a concurrent rebuild.
+	if !requestUsesTenantScope(r.Context()) {
+		s.persistRiskEngineState(r.Context(), engine)
+	}
 	s.json(w, http.StatusOK, report)
 }
 
 func (s *Server) listToxicCombinations(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 	pagination := ParsePagination(r, 100, 1000)
 
 	engine := graph.NewToxicCombinationEngine()
-	results := engine.Analyze(s.app.SecurityGraph)
+	results := engine.Analyze(g)
 
 	// Filter by severity if requested
 	severityFilter := r.URL.Query().Get("severity")
@@ -168,12 +178,13 @@ func (s *Server) listToxicCombinations(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listGraphAttackPaths(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 
-	simulator := graph.NewAttackPathSimulator(s.app.SecurityGraph)
+	simulator := graph.NewAttackPathSimulator(g)
 
 	maxDepth := 6
 	if depthStr := r.URL.Query().Get("max_depth"); depthStr != "" {
@@ -217,7 +228,8 @@ func (s *Server) listGraphAttackPaths(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) simulateAttackPathFix(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
@@ -228,7 +240,7 @@ func (s *Server) simulateAttackPathFix(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	simulator := graph.NewAttackPathSimulator(s.app.SecurityGraph)
+	simulator := graph.NewAttackPathSimulator(g)
 	result := simulator.Simulate(6)
 	fixSim := simulator.SimulateFix(result, nodeID)
 
@@ -236,12 +248,13 @@ func (s *Server) simulateAttackPathFix(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listChokepoints(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 
-	simulator := graph.NewAttackPathSimulator(s.app.SecurityGraph)
+	simulator := graph.NewAttackPathSimulator(g)
 	result := simulator.Simulate(6)
 
 	limit := 20

--- a/internal/api/server_handlers_graph_tenant_scope_test.go
+++ b/internal/api/server_handlers_graph_tenant_scope_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/metrics"
+	"github.com/writer/cerebro/internal/snowflake"
+)
+
+func doWithTenantContext(t *testing.T, s *Server, method, path string, body any, tenantID string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		reader = bytes.NewReader(payload)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req = req.WithContext(context.WithValue(req.Context(), contextKeyTenant, tenantID))
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	return w
+}
+
+func TestGraphRiskHandlersUseTenantScopedGraph(t *testing.T) {
+	s := newTestServer(t)
+	g := s.app.SecurityGraph
+	g.AddNode(&graph.Node{ID: "user:shared", Kind: graph.NodeKindUser, Name: "Shared User"})
+	g.AddNode(&graph.Node{ID: "service:tenant-a", Kind: graph.NodeKindService, Name: "Tenant A", TenantID: "tenant-a"})
+	g.AddNode(&graph.Node{ID: "service:tenant-b", Kind: graph.NodeKindService, Name: "Tenant B", TenantID: "tenant-b"})
+	g.AddEdge(&graph.Edge{ID: "shared-a", Source: "user:shared", Target: "service:tenant-a", Kind: graph.EdgeKindCanRead, Effect: graph.EdgeEffectAllow})
+	g.AddEdge(&graph.Edge{ID: "shared-b", Source: "user:shared", Target: "service:tenant-b", Kind: graph.EdgeKindCanRead, Effect: graph.EdgeEffectAllow})
+
+	resp := doWithTenantContext(t, s, http.MethodGet, "/api/v1/graph/blast-radius/user:shared?max_depth=2", nil, "tenant-a")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected tenant-scoped blast radius 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	body := decodeJSON(t, resp)
+	reachable, ok := body["reachable_nodes"].([]any)
+	if !ok || len(reachable) != 1 {
+		t.Fatalf("expected one tenant-visible reachable node, got %#v", body["reachable_nodes"])
+	}
+	node := reachable[0].(map[string]any)["node"].(map[string]any)
+	if node["id"] != "service:tenant-a" {
+		t.Fatalf("expected tenant-a node only, got %#v", node)
+	}
+}
+
+func TestGraphIntelligenceHandlersUseTenantScopedGraph(t *testing.T) {
+	s := newTestServer(t)
+	g := s.app.SecurityGraph
+	base := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	g.AddNode(&graph.Node{ID: "service:tenant-a", Kind: graph.NodeKindService, Name: "Tenant A", TenantID: "tenant-a"})
+	g.AddNode(&graph.Node{ID: "service:tenant-b", Kind: graph.NodeKindService, Name: "Tenant B", TenantID: "tenant-b"})
+	g.AddNode(&graph.Node{
+		ID:       "pull_request:tenant-b:42",
+		Kind:     graph.NodeKindPullRequest,
+		TenantID: "tenant-b",
+		Properties: map[string]any{
+			"repository":  "tenant-b",
+			"number":      "42",
+			"state":       "merged",
+			"observed_at": base.Format(time.RFC3339),
+			"valid_from":  base.Format(time.RFC3339),
+		},
+	})
+	g.AddNode(&graph.Node{
+		ID:       "deployment:tenant-b:deploy-1",
+		Kind:     graph.NodeKindDeploymentRun,
+		TenantID: "tenant-b",
+		Properties: map[string]any{
+			"deploy_id":   "deploy-1",
+			"service_id":  "tenant-b",
+			"environment": "prod",
+			"status":      "succeeded",
+			"observed_at": base.Add(5 * time.Minute).Format(time.RFC3339),
+			"valid_from":  base.Add(5 * time.Minute).Format(time.RFC3339),
+		},
+	})
+	g.AddNode(&graph.Node{
+		ID:       "incident:tenant-b:1",
+		Kind:     graph.NodeKindIncident,
+		TenantID: "tenant-b",
+		Properties: map[string]any{
+			"incident_id": "incident-b-1",
+			"service_id":  "tenant-b",
+			"observed_at": base.Add(7 * time.Minute).Format(time.RFC3339),
+			"valid_from":  base.Add(7 * time.Minute).Format(time.RFC3339),
+		},
+	})
+	g.AddEdge(&graph.Edge{ID: "pr-b-service", Source: "pull_request:tenant-b:42", Target: "service:tenant-b", Kind: graph.EdgeKindTargets, Effect: graph.EdgeEffectAllow})
+	g.AddEdge(&graph.Edge{ID: "deploy-b-service", Source: "deployment:tenant-b:deploy-1", Target: "service:tenant-b", Kind: graph.EdgeKindTargets, Effect: graph.EdgeEffectAllow})
+	g.AddEdge(&graph.Edge{ID: "incident-b-service", Source: "incident:tenant-b:1", Target: "service:tenant-b", Kind: graph.EdgeKindTargets, Effect: graph.EdgeEffectAllow})
+	graph.MaterializeEventCorrelations(g, base.Add(10*time.Minute))
+
+	resp := doWithTenantContext(t, s, http.MethodGet, "/api/v1/platform/intelligence/event-correlations?event_id=incident:tenant-b:1&limit=10", nil, "tenant-a")
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected tenant-scoped event correlation lookup to hide foreign tenant event, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestCrossTenantReadOperationsEmitAuditAndMetrics(t *testing.T) {
+	s := newTestServer(t)
+	s.auditLogger = &captureAuditLogger{}
+	seedGraphRiskFeedbackGraph(s.app.SecurityGraph)
+
+	for i := 0; i < 5; i++ {
+		w := do(t, s, http.MethodGet, "/api/v1/graph/risk-report", nil)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected risk report 200, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+	record := do(t, s, http.MethodPost, "/api/v1/graph/outcomes", map[string]any{
+		"entity_id":   "customer:acme",
+		"outcome":     "churn",
+		"occurred_at": time.Now().UTC().Add(4 * time.Hour),
+	})
+	if record.Code != http.StatusOK {
+		t.Fatalf("expected outcome record 200, got %d: %s", record.Code, record.Body.String())
+	}
+
+	build := doWithTenantContext(t, s, http.MethodPost, "/api/v1/graph/cross-tenant/patterns/build", map[string]any{
+		"tenant_id":   "tenant-beta",
+		"window_days": 365,
+	}, "tenant-admin")
+	if build.Code != http.StatusOK {
+		t.Fatalf("expected build response 200, got %d: %s", build.Code, build.Body.String())
+	}
+	list := doWithTenantContext(t, s, http.MethodGet, "/api/v1/graph/cross-tenant/patterns", nil, "tenant-admin")
+	if list.Code != http.StatusOK {
+		t.Fatalf("expected list response 200, got %d: %s", list.Code, list.Body.String())
+	}
+
+	logger := s.auditLogger.(*captureAuditLogger)
+	if len(logger.entries) != 2 {
+		t.Fatalf("expected two cross-tenant audit entries, got %d", len(logger.entries))
+	}
+	entry := logger.entries[0]
+	if entry.Action != "graph.cross_tenant.read" {
+		t.Fatalf("expected cross-tenant audit action, got %#v", entry.Action)
+	}
+	if entry.Details["requesting_tenant"] != "tenant-admin" || entry.Details["target_tenant"] != "tenant-beta" {
+		t.Fatalf("unexpected audit details: %#v", entry.Details)
+	}
+	if logger.entries[1].Details["target_tenant"] != "aggregate_library" {
+		t.Fatalf("expected aggregate-library audit detail, got %#v", logger.entries[1].Details)
+	}
+
+	metric := metrics.GraphCrossTenantReadsTotal.WithLabelValues("build_samples", "tenant", "tenant", "allowed")
+	snapshot := &dto.Metric{}
+	if err := metric.Write(snapshot); err != nil {
+		t.Fatalf("read metric: %v", err)
+	}
+	if got := snapshot.GetCounter().GetValue(); got < 1 {
+		t.Fatalf("expected cross-tenant metric increment, got %f", got)
+	}
+
+	aggregateMetric := metrics.GraphCrossTenantReadsTotal.WithLabelValues("list_patterns", "tenant", "aggregate", "allowed")
+	aggregateSnapshot := &dto.Metric{}
+	if err := aggregateMetric.Write(aggregateSnapshot); err != nil {
+		t.Fatalf("read aggregate metric: %v", err)
+	}
+	if got := aggregateSnapshot.GetCounter().GetValue(); got < 1 {
+		t.Fatalf("expected aggregate cross-tenant metric increment, got %f", got)
+	}
+}
+
+func TestRiskReportPersistsOnlyForGlobalRequests(t *testing.T) {
+	s := newTestServer(t)
+	seedGraphRiskFeedbackGraph(s.app.SecurityGraph)
+	s.app.RiskEngineStateRepo = &snowflake.RiskEngineStateRepository{}
+
+	saveFailed := metrics.GraphStatePersistenceTotal.WithLabelValues("save_failed")
+	before := &dto.Metric{}
+	if err := saveFailed.Write(before); err != nil {
+		t.Fatalf("read initial persistence metric: %v", err)
+	}
+
+	global := do(t, s, http.MethodGet, "/api/v1/graph/risk-report", nil)
+	if global.Code != http.StatusOK {
+		t.Fatalf("expected global risk report 200, got %d: %s", global.Code, global.Body.String())
+	}
+
+	afterGlobal := &dto.Metric{}
+	if err := saveFailed.Write(afterGlobal); err != nil {
+		t.Fatalf("read global persistence metric: %v", err)
+	}
+	if afterGlobal.GetCounter().GetValue() <= before.GetCounter().GetValue() {
+		t.Fatalf("expected global risk report to attempt persistence, before=%f after=%f", before.GetCounter().GetValue(), afterGlobal.GetCounter().GetValue())
+	}
+
+	tenant := doWithTenantContext(t, s, http.MethodGet, "/api/v1/graph/risk-report", nil, "tenant-a")
+	if tenant.Code != http.StatusOK {
+		t.Fatalf("expected tenant risk report 200, got %d: %s", tenant.Code, tenant.Body.String())
+	}
+
+	afterTenant := &dto.Metric{}
+	if err := saveFailed.Write(afterTenant); err != nil {
+		t.Fatalf("read tenant persistence metric: %v", err)
+	}
+	if afterTenant.GetCounter().GetValue() != afterGlobal.GetCounter().GetValue() {
+		t.Fatalf("expected tenant-scoped risk report to skip persistence, global=%f tenant=%f", afterGlobal.GetCounter().GetValue(), afterTenant.GetCounter().GetValue())
+	}
+}

--- a/internal/api/server_handlers_platform_entities.go
+++ b/internal/api/server_handlers_platform_entities.go
@@ -20,7 +20,7 @@ func platformEntityQueryLengthExceeds(value string) bool {
 }
 
 func (s *Server) listPlatformEntities(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -36,7 +36,7 @@ func (s *Server) listPlatformEntities(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) searchPlatformEntities(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -51,7 +51,7 @@ func (s *Server) searchPlatformEntities(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) suggestPlatformEntities(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -84,7 +84,7 @@ func (s *Server) getPlatformEntityFacet(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) getPlatformEntity(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -116,7 +116,7 @@ func (s *Server) getPlatformEntity(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getPlatformEntityAtTime(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -147,7 +147,7 @@ func (s *Server) getPlatformEntityAtTime(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) getPlatformEntityTimeDiff(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return

--- a/internal/api/server_handlers_platform_entities_test.go
+++ b/internal/api/server_handlers_platform_entities_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -299,6 +301,49 @@ func TestPlatformEntitySearchAndSuggest(t *testing.T) {
 	suggestion := suggestBody["suggestions"].([]any)[0].(map[string]any)
 	if suggestion["entity_id"] != "person:alice@example.com" {
 		t.Fatalf("expected alice suggestion, got %#v", suggestion)
+	}
+}
+
+func TestPlatformEntitiesAreTenantScoped(t *testing.T) {
+	s := newTestServer(t)
+	g := s.app.SecurityGraph
+	g.AddNode(&graph.Node{ID: "service:tenant-a", Kind: graph.NodeKindService, Name: "Tenant A", TenantID: "tenant-a"})
+	g.AddNode(&graph.Node{ID: "service:tenant-b", Kind: graph.NodeKindService, Name: "Tenant B", TenantID: "tenant-b"})
+	g.AddNode(&graph.Node{ID: "service:shared", Kind: graph.NodeKindService, Name: "Shared"})
+	g.BuildIndex()
+
+	doWithTenant := func(path, tenantID string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req = req.WithContext(context.WithValue(req.Context(), contextKeyTenant, tenantID))
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		return w
+	}
+
+	list := doWithTenant("/api/v1/platform/entities?category=resource&limit=10", "tenant-a")
+	if list.Code != http.StatusOK {
+		t.Fatalf("expected tenant-scoped list 200, got %d: %s", list.Code, list.Body.String())
+	}
+	body := decodeJSON(t, list)
+	entities, ok := body["entities"].([]any)
+	if !ok || len(entities) != 2 {
+		t.Fatalf("expected shared and tenant-a entities only, got %#v", body["entities"])
+	}
+	if list.Body.String() == "" || strings.Contains(list.Body.String(), "service:tenant-b") {
+		t.Fatalf("expected tenant-b entity to be excluded, got %s", list.Body.String())
+	}
+
+	search := doWithTenant("/api/v1/platform/entities/search?q=tenant&limit=10", "tenant-a")
+	if search.Code != http.StatusOK {
+		t.Fatalf("expected tenant-scoped search 200, got %d: %s", search.Code, search.Body.String())
+	}
+	if strings.Contains(search.Body.String(), "service:tenant-b") {
+		t.Fatalf("expected tenant-b search result to be excluded, got %s", search.Body.String())
+	}
+
+	detail := doWithTenant("/api/v1/platform/entities/service:tenant-b", "tenant-a")
+	if detail.Code != http.StatusNotFound {
+		t.Fatalf("expected tenant-b detail to be hidden, got %d: %s", detail.Code, detail.Body.String())
 	}
 }
 

--- a/internal/api/server_handlers_platform_graph_snapshots.go
+++ b/internal/api/server_handlers_platform_graph_snapshots.go
@@ -280,6 +280,9 @@ func (s *Server) platformGraphSnapshotDiffByID(diffID string) (*graph.GraphSnaps
 
 func (s *Server) platformGraphDiffStore() *graph.GraphSnapshotDiffStore {
 	snapshotPath := strings.TrimSpace(os.Getenv("GRAPH_SNAPSHOT_PATH"))
+	if s != nil && s.app != nil && s.app.Config != nil && strings.TrimSpace(s.app.Config.GraphSnapshotPath) != "" {
+		snapshotPath = strings.TrimSpace(s.app.Config.GraphSnapshotPath)
+	}
 	if snapshotPath == "" {
 		snapshotPath = filepath.Join(".cerebro", "graph-snapshots")
 	}
@@ -432,12 +435,31 @@ func (s *Server) platformGraphSnapshotDiffWithSnapshots(fromSnapshotID, toSnapsh
 	return record, snapshots, 0, nil
 }
 
-func (s *Server) platformGraphSnapshotStore() *graph.SnapshotStore {
+func (s *Server) platformGraphSnapshotStore() *graph.GraphPersistenceStore {
+	if s != nil && s.app != nil && s.app.GraphSnapshots != nil {
+		return s.app.GraphSnapshots
+	}
 	snapshotPath := strings.TrimSpace(os.Getenv("GRAPH_SNAPSHOT_PATH"))
+	maxSnapshots := 10
+	if s != nil && s.app != nil && s.app.Config != nil {
+		if configured := strings.TrimSpace(s.app.Config.GraphSnapshotPath); configured != "" {
+			snapshotPath = configured
+		}
+		if s.app.Config.GraphSnapshotMaxRetained > 0 {
+			maxSnapshots = s.app.Config.GraphSnapshotMaxRetained
+		}
+	}
 	if snapshotPath == "" {
 		snapshotPath = filepath.Join(".cerebro", "graph-snapshots")
 	}
-	return graph.NewSnapshotStore(snapshotPath, 10)
+	store, err := graph.NewGraphPersistenceStore(graph.GraphPersistenceOptions{
+		LocalPath:    snapshotPath,
+		MaxSnapshots: maxSnapshots,
+	})
+	if err != nil {
+		return nil
+	}
+	return store
 }
 
 func (s *Server) platformGraphSnapshotRecords() map[string]*graph.GraphSnapshotRecord {

--- a/internal/api/server_handlers_platform_graph_snapshots_test.go
+++ b/internal/api/server_handlers_platform_graph_snapshots_test.go
@@ -19,7 +19,7 @@ func TestPlatformGraphSnapshotAncestryAndDiffEndpoints(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAPH_SNAPSHOT_PATH", dir)
 
-	base := time.Date(2026, 3, 7, 0, 0, 0, 0, time.UTC)
+	base := time.Now().UTC().Add(-6 * 24 * time.Hour).Truncate(time.Minute)
 	older := &graph.Snapshot{
 		Version:   "1.0",
 		CreatedAt: base.Add(5 * time.Minute),
@@ -395,7 +395,7 @@ func TestPlatformGraphChangelogAndDiffDetailsEndpoints(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAPH_SNAPSHOT_PATH", dir)
 
-	base := time.Date(2026, 3, 7, 0, 0, 0, 0, time.UTC)
+	base := time.Now().UTC().Add(-6 * 24 * time.Hour).Truncate(time.Minute)
 	older := &graph.Snapshot{
 		Version:   "1.0",
 		CreatedAt: base.Add(5 * time.Minute),
@@ -526,7 +526,7 @@ func TestPlatformGraphChangelogUsesExplicitParentSnapshotLineage(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAPH_SNAPSHOT_PATH", dir)
 
-	base := time.Date(2026, 3, 7, 7, 0, 0, 0, time.UTC)
+	base := time.Now().UTC().Add(-6 * 24 * time.Hour).Truncate(time.Minute)
 	root := &graph.Snapshot{
 		Version:   "1.0",
 		CreatedAt: base.Add(5 * time.Minute),

--- a/internal/api/server_handlers_platform_knowledge.go
+++ b/internal/api/server_handlers_platform_knowledge.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *Server) listPlatformKnowledgeClaims(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -30,7 +30,7 @@ func (s *Server) listPlatformKnowledgeClaims(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) listPlatformKnowledgeEvidence(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -50,7 +50,7 @@ func (s *Server) getPlatformKnowledgeEvidence(w http.ResponseWriter, r *http.Req
 }
 
 func (s *Server) listPlatformKnowledgeObservations(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -70,7 +70,7 @@ func (s *Server) getPlatformKnowledgeObservation(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) getPlatformKnowledgeClaim(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -102,7 +102,7 @@ func (s *Server) getPlatformKnowledgeClaim(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) listPlatformKnowledgeClaimGroups(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -118,7 +118,7 @@ func (s *Server) listPlatformKnowledgeClaimGroups(w http.ResponseWriter, r *http
 }
 
 func (s *Server) getPlatformKnowledgeClaimGroup(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -155,7 +155,7 @@ func (s *Server) getPlatformKnowledgeClaimGroup(w http.ResponseWriter, r *http.R
 }
 
 func (s *Server) getPlatformKnowledgeClaimTimeline(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -182,7 +182,7 @@ func (s *Server) getPlatformKnowledgeClaimTimeline(w http.ResponseWriter, r *htt
 }
 
 func (s *Server) getPlatformKnowledgeClaimExplanation(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -214,7 +214,7 @@ func (s *Server) getPlatformKnowledgeClaimExplanation(w http.ResponseWriter, r *
 }
 
 func (s *Server) getPlatformKnowledgeClaimProofs(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -241,7 +241,7 @@ func (s *Server) getPlatformKnowledgeClaimProofs(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) listPlatformKnowledgeClaimDiffs(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -257,7 +257,7 @@ func (s *Server) listPlatformKnowledgeClaimDiffs(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) listPlatformKnowledgeDiffs(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -287,8 +287,8 @@ func (s *Server) listPlatformKnowledgeDiffs(w http.ResponseWriter, r *http.Reque
 			}
 			return
 		}
-		fromGraph = graph.GraphViewFromSnapshot(snapshots[opts.FromSnapshotID])
-		toGraph = graph.GraphViewFromSnapshot(snapshots[opts.ToSnapshotID])
+		fromGraph = s.tenantScopedGraph(r.Context(), graph.GraphViewFromSnapshot(snapshots[opts.FromSnapshotID]))
+		toGraph = s.tenantScopedGraph(r.Context(), graph.GraphViewFromSnapshot(snapshots[opts.ToSnapshotID]))
 		opts.FromValidAt = snapshotKnowledgeComparisonTime(snapshots[opts.FromSnapshotID], records[opts.FromSnapshotID])
 		opts.FromRecordedAt = opts.FromValidAt
 		opts.ToValidAt = snapshotKnowledgeComparisonTime(snapshots[opts.ToSnapshotID], records[opts.ToSnapshotID])
@@ -309,6 +309,12 @@ func (s *Server) adjudicatePlatformKnowledgeClaimGroup(w http.ResponseWriter, r 
 	if groupID == "" {
 		s.error(w, http.StatusBadRequest, "group id required")
 		return
+	}
+	if scoped := s.currentTenantSecurityGraph(r.Context()); scoped != nil {
+		if _, ok := graph.GetClaimGroupRecord(scoped, groupID, time.Time{}, time.Time{}, true); !ok {
+			s.error(w, http.StatusNotFound, "claim group not found")
+			return
+		}
 	}
 
 	var req graph.ClaimAdjudicationWriteRequest
@@ -674,7 +680,7 @@ func parsePlatformKnowledgeDiffQueryOptions(r *http.Request) (graph.KnowledgeDif
 }
 
 func (s *Server) getPlatformKnowledgeArtifact(w http.ResponseWriter, r *http.Request, kind graph.NodeKind) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return

--- a/internal/api/tenant_graph.go
+++ b/internal/api/tenant_graph.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"context"
+	"strings"
+
+	"github.com/writer/cerebro/internal/graph"
+)
+
+func (s *Server) tenantScopedGraph(ctx context.Context, g *graph.Graph) *graph.Graph {
+	if s == nil || g == nil {
+		return nil
+	}
+	tenantID := currentTenantScopeID(ctx)
+	return g.SubgraphForTenant(tenantID)
+}
+
+func currentTenantScopeID(ctx context.Context) string {
+	return strings.TrimSpace(GetTenantID(ctx))
+}
+
+func requestUsesTenantScope(ctx context.Context) bool {
+	return currentTenantScopeID(ctx) != ""
+}
+
+func (s *Server) currentTenantSecurityGraph(ctx context.Context) *graph.Graph {
+	if s == nil || s.app == nil {
+		return nil
+	}
+	return s.tenantScopedGraph(ctx, s.app.CurrentSecurityGraph())
+}
+
+func (s *Server) currentTenantRiskEngine(ctx context.Context) *graph.RiskEngine {
+	if s == nil || s.app == nil {
+		return nil
+	}
+	if !requestUsesTenantScope(ctx) {
+		return s.graphRiskEngine()
+	}
+	g := s.currentTenantSecurityGraph(ctx)
+	if g == nil {
+		return nil
+	}
+	engine := graph.NewRiskEngine(g)
+	if s.app.Config != nil {
+		engine.SetCrossTenantPrivacyConfig(graph.CrossTenantPrivacyConfig{
+			MinTenantCount:    s.app.Config.GraphCrossTenantMinTenants,
+			MinPatternSupport: s.app.Config.GraphCrossTenantMinSupport,
+		})
+	}
+	return engine
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -90,13 +90,14 @@ type App struct {
 	Logger *slog.Logger
 
 	// Core services
-	Snowflake *snowflake.Client
-	Warehouse warehouse.DataWarehouse
-	Policy    *policy.Engine
-	Findings  findings.FindingStore
-	Scanner   *scanner.Scanner
-	DSPM      *dspm.Scanner
-	Cache     *cache.PolicyCache
+	Snowflake      *snowflake.Client
+	Warehouse      warehouse.DataWarehouse
+	Policy         *policy.Engine
+	Findings       findings.FindingStore
+	Scanner        *scanner.Scanner
+	DSPM           *dspm.Scanner
+	Cache          *cache.PolicyCache
+	GraphSnapshots *graph.GraphPersistenceStore
 
 	// Feature services
 	Agents         *agents.AgentRegistry

--- a/internal/app/app_cerebro_tools_temporal.go
+++ b/internal/app/app_cerebro_tools_temporal.go
@@ -329,16 +329,38 @@ func (a *App) platformGraphSnapshotRecordsForTool(now time.Time) []graph.GraphSn
 	return append([]graph.GraphSnapshotRecord(nil), collection.Snapshots...)
 }
 
-func (a *App) platformGraphSnapshotStoreForTool() *graph.SnapshotStore {
+func (a *App) platformGraphSnapshotStoreForTool() *graph.GraphPersistenceStore {
+	if a != nil && a.GraphSnapshots != nil {
+		return a.GraphSnapshots
+	}
 	snapshotPath := strings.TrimSpace(os.Getenv("GRAPH_SNAPSHOT_PATH"))
+	maxSnapshots := 10
+	if a != nil && a.Config != nil {
+		if configured := strings.TrimSpace(a.Config.GraphSnapshotPath); configured != "" {
+			snapshotPath = configured
+		}
+		if a.Config.GraphSnapshotMaxRetained > 0 {
+			maxSnapshots = a.Config.GraphSnapshotMaxRetained
+		}
+	}
 	if snapshotPath == "" {
 		snapshotPath = filepath.Join(".cerebro", "graph-snapshots")
 	}
-	return graph.NewSnapshotStore(snapshotPath, 10)
+	store, err := graph.NewGraphPersistenceStore(graph.GraphPersistenceOptions{
+		LocalPath:    snapshotPath,
+		MaxSnapshots: maxSnapshots,
+	})
+	if err != nil {
+		return nil
+	}
+	return store
 }
 
 func (a *App) platformGraphDiffStoreForTool() *graph.GraphSnapshotDiffStore {
 	snapshotPath := strings.TrimSpace(os.Getenv("GRAPH_SNAPSHOT_PATH"))
+	if a != nil && a.Config != nil && strings.TrimSpace(a.Config.GraphSnapshotPath) != "" {
+		snapshotPath = strings.TrimSpace(a.Config.GraphSnapshotPath)
+	}
 	if snapshotPath == "" {
 		snapshotPath = filepath.Join(".cerebro", "graph-snapshots")
 	}

--- a/internal/app/app_cerebro_tools_temporal_test.go
+++ b/internal/app/app_cerebro_tools_temporal_test.go
@@ -96,7 +96,7 @@ func TestCerebroGraphChangelogTool(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAPH_SNAPSHOT_PATH", dir)
 
-	base := time.Date(2026, 3, 7, 0, 0, 0, 0, time.UTC)
+	base := time.Now().UTC().Add(-6 * 24 * time.Hour).Truncate(time.Minute)
 	older := &graph.Snapshot{
 		Version:   "1.0",
 		CreatedAt: base.Add(5 * time.Minute),

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -440,6 +440,9 @@ type Config struct {
 	GraphCrossTenantReplayTTL           time.Duration
 	GraphCrossTenantMinTenants          int
 	GraphCrossTenantMinSupport          int
+	GraphSnapshotPath                   string
+	GraphSnapshotMaxRetained            int
+	GraphSnapshotReplicaURI             string
 	GraphSchemaValidationMode           string
 	GraphEventMapperValidationMode      string
 	GraphEventMapperDeadLetterPath      string
@@ -769,6 +772,9 @@ func LoadConfig() *Config {
 			GraphCrossTenantReplayTTL:           getEnvDuration("GRAPH_CROSS_TENANT_REPLAY_TTL", 24*time.Hour),
 			GraphCrossTenantMinTenants:          getEnvInt("GRAPH_CROSS_TENANT_MIN_TENANTS", 2),
 			GraphCrossTenantMinSupport:          getEnvInt("GRAPH_CROSS_TENANT_MIN_SUPPORT", 2),
+			GraphSnapshotPath:                   getEnv("GRAPH_SNAPSHOT_PATH", filepath.Join(".cerebro", "graph-snapshots")),
+			GraphSnapshotMaxRetained:            getEnvInt("GRAPH_SNAPSHOT_MAX_RETAINED", 10),
+			GraphSnapshotReplicaURI:             getEnv("GRAPH_SNAPSHOT_REPLICA_URI", ""),
 			GraphSchemaValidationMode:           getEnv("GRAPH_SCHEMA_VALIDATION_MODE", "warn"),
 			GraphEventMapperValidationMode:      getEnv("GRAPH_EVENT_MAPPER_VALIDATION_MODE", "enforce"),
 			GraphEventMapperDeadLetterPath:      getEnv("GRAPH_EVENT_MAPPER_DEAD_LETTER_PATH", filepath.Join(findings.DefaultFilePath(), "graph-event-mapper.dlq.jsonl")),

--- a/internal/app/app_graph_persistence.go
+++ b/internal/app/app_graph_persistence.go
@@ -1,0 +1,32 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/writer/cerebro/internal/graph"
+)
+
+func (a *App) initGraphPersistenceStore() {
+	if a == nil || a.Config == nil {
+		return
+	}
+	path := strings.TrimSpace(a.Config.GraphSnapshotPath)
+	if path == "" {
+		return
+	}
+	store, err := graph.NewGraphPersistenceStore(graph.GraphPersistenceOptions{
+		LocalPath:    path,
+		MaxSnapshots: a.Config.GraphSnapshotMaxRetained,
+		ReplicaURI:   a.Config.GraphSnapshotReplicaURI,
+	})
+	if err != nil {
+		if a.Logger != nil {
+			a.Logger.Warn("failed to initialize graph persistence store", "error", err, "path", path, "replica_uri", strings.TrimSpace(a.Config.GraphSnapshotReplicaURI))
+		}
+		return
+	}
+	a.GraphSnapshots = store
+	if a.Logger != nil {
+		a.Logger.Info("graph persistence store initialized", "path", path, "replica_uri", strings.TrimSpace(a.Config.GraphSnapshotReplicaURI))
+	}
+}

--- a/internal/app/app_graph_updates.go
+++ b/internal/app/app_graph_updates.go
@@ -126,6 +126,7 @@ func (a *App) maybeStartGraphConsistencyCheck(trigger string, summary graph.Grap
 	if baseCtx == nil {
 		baseCtx = context.Background()
 	}
+	// #nosec G118 -- cancel is stored for shutdown coordination and also deferred inside the check goroutine.
 	checkCtx, cancel := context.WithTimeout(baseCtx, 30*time.Minute)
 	a.graphConsistencyCancel = cancel
 	a.graphConsistencyMu.Unlock()

--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -54,6 +54,7 @@ func (a *App) initPhase1(ctx context.Context) error {
 }
 
 func (a *App) initPhase2a(ctx context.Context) error {
+	a.initGraphPersistenceStore()
 	if err := runInitTasksConcurrently(ctx, []concurrentInitTask{
 		{name: "cache", run: func(context.Context) { a.initCache() }},
 		{name: "ticketing", run: func(taskCtx context.Context) { a.initTicketing(taskCtx) }},

--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -234,6 +234,53 @@ func (a *App) initHealth() {
 		result.Latency = time.Since(start)
 		return result
 	})
+	a.Health.Register("graph_persistence", func(_ context.Context) health.CheckResult {
+		start := time.Now().UTC()
+		result := health.CheckResult{
+			Name:      "graph_persistence",
+			Timestamp: start,
+		}
+		if a.Warehouse == nil {
+			result.Status = health.StatusHealthy
+			result.Message = "graph disabled - warehouse not configured"
+			result.Latency = time.Since(start)
+			return result
+		}
+		if a.GraphSnapshots == nil {
+			result.Status = health.StatusDegraded
+			result.Message = "graph persistence store not configured"
+			result.Latency = time.Since(start)
+			return result
+		}
+		status := a.GraphSnapshots.Status()
+		switch {
+		case status.ReplicaConfigured && status.LastReplicationError != "":
+			result.Status = health.StatusDegraded
+			result.Message = "local snapshot persistence healthy; replica sync failing"
+		case status.ReplicaConfigured && status.LastReplicatedSnapshot == "":
+			records, err := a.GraphSnapshots.ListGraphSnapshotRecords()
+			switch {
+			case err == nil && len(records) > 0:
+				result.Status = health.StatusHealthy
+				result.Message = "replicated snapshot persistence active"
+			default:
+				result.Status = health.StatusDegraded
+				result.Message = "replica configured but not seeded yet"
+			}
+		default:
+			result.Status = health.StatusHealthy
+			message := "local snapshot persistence active"
+			if status.ReplicaConfigured {
+				message = "replicated snapshot persistence active"
+			}
+			if status.LastRecoverySource != "" {
+				message += " (last recovery: " + status.LastRecoverySource + ")"
+			}
+			result.Message = message
+		}
+		result.Latency = time.Since(start)
+		return result
+	})
 
 	a.Logger.Info("health service initialized")
 }
@@ -479,6 +526,25 @@ func (a *App) initSecurityGraph(ctx context.Context) {
 	securityGraph := a.SecurityGraphBuilder.Graph()
 	a.configureGraphSchemaValidation(securityGraph)
 	a.setSecurityGraph(securityGraph)
+	if a.GraphSnapshots != nil {
+		recovered, record, recoverySource, err := a.GraphSnapshots.LoadLatestSnapshot()
+		if err != nil {
+			a.Logger.Warn("failed to recover persisted security graph snapshot", "error", err)
+		} else if recovered != nil {
+			recoveredGraph := graph.RestoreFromSnapshot(recovered)
+			a.configureGraphSchemaValidation(recoveredGraph)
+			a.setSecurityGraph(recoveredGraph)
+			if record != nil && record.BuiltAt != nil {
+				a.setGraphBuildState(GraphBuildSuccess, record.BuiltAt.UTC(), nil)
+			}
+			a.Logger.Info("recovered persisted security graph snapshot",
+				"source", recoverySource,
+				"snapshot_id", recordID(record),
+				"nodes", recoveredGraph.NodeCount(),
+				"edges", recoveredGraph.EdgeCount(),
+			)
+		}
+	}
 
 	graphCtx, cancel := context.WithCancel(backgroundWorkContext(ctx))
 	a.graphCtx = graphCtx
@@ -618,9 +684,27 @@ func (a *App) activateBuiltSecurityGraph(ctx context.Context, securityGraph *gra
 	a.rematerializeEventCorrelations(securityGraph, "graph_activation")
 	a.configureGraphSchemaValidation(securityGraph)
 	a.setSecurityGraph(securityGraph)
+	if a.GraphSnapshots != nil {
+		if record, err := a.GraphSnapshots.SaveGraph(securityGraph); err != nil {
+			if record != nil {
+				a.Logger.Warn("replicated security graph snapshot failed after local persist", "snapshot_id", record.ID, "error", err)
+			} else {
+				a.Logger.Warn("failed to persist security graph snapshot", "error", err)
+			}
+		} else if record != nil {
+			a.Logger.Info("persisted security graph snapshot", "snapshot_id", record.ID)
+		}
+	}
 	meta := securityGraph.Metadata()
 	a.setGraphBuildState(GraphBuildSuccess, meta.BuiltAt, nil)
 	return meta, nil
+}
+
+func recordID(record *graph.GraphSnapshotRecord) string {
+	if record == nil {
+		return ""
+	}
+	return record.ID
 }
 
 func (a *App) rematerializeEventCorrelations(securityGraph *graph.Graph, reason string) {

--- a/internal/app/app_security_services_test.go
+++ b/internal/app/app_security_services_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -140,6 +142,132 @@ func TestInitHealthRegistersGraphBuildCheck(t *testing.T) {
 	}
 }
 
+func TestInitHealthRegistersGraphPersistenceCheck(t *testing.T) {
+	dir := t.TempDir()
+	store, err := graph.NewGraphPersistenceStore(graph.GraphPersistenceOptions{
+		LocalPath: dir,
+	})
+	if err != nil {
+		t.Fatalf("new graph persistence store: %v", err)
+	}
+
+	application := &App{
+		Config:         &Config{},
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Warehouse:      &warehouse.MemoryWarehouse{},
+		GraphSnapshots: store,
+	}
+	application.initHealth()
+
+	results := application.Health.RunAll(context.Background())
+	check, ok := results["graph_persistence"]
+	if !ok {
+		t.Fatal("expected graph_persistence health check to be registered")
+	}
+	if check.Status != health.StatusHealthy {
+		t.Fatalf("expected graph_persistence health to be healthy, got %#v", check)
+	}
+}
+
+func TestGraphPersistenceHealthDegradesOnReplicaSyncFailure(t *testing.T) {
+	localDir := t.TempDir()
+	badReplicaBase := filepath.Join(t.TempDir(), "replica-file")
+	if err := os.WriteFile(badReplicaBase, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("seed bad replica path: %v", err)
+	}
+	store, err := graph.NewGraphPersistenceStore(graph.GraphPersistenceOptions{
+		LocalPath:    localDir,
+		MaxSnapshots: 4,
+		ReplicaURI:   badReplicaBase,
+	})
+	if err != nil {
+		t.Fatalf("new graph persistence store: %v", err)
+	}
+
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "service:payments", Kind: graph.NodeKindService, Name: "payments"})
+	g.SetMetadata(graph.Metadata{
+		BuiltAt:       time.Date(2026, 3, 12, 23, 5, 0, 0, time.UTC),
+		NodeCount:     1,
+		EdgeCount:     0,
+		Providers:     []string{"aws"},
+		Accounts:      []string{"prod"},
+		BuildDuration: time.Second,
+	})
+	if _, err := store.SaveGraph(g); err == nil {
+		t.Fatal("expected replica sync failure")
+	}
+
+	application := &App{
+		Config:         &Config{},
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Warehouse:      &warehouse.MemoryWarehouse{},
+		GraphSnapshots: store,
+	}
+	application.initHealth()
+
+	results := application.Health.RunAll(context.Background())
+	check := results["graph_persistence"]
+	if check.Status != health.StatusDegraded {
+		t.Fatalf("expected degraded graph persistence health, got %#v", check)
+	}
+	if check.Message != "local snapshot persistence healthy; replica sync failing" {
+		t.Fatalf("expected replica sync message, got %#v", check)
+	}
+	if strings.Contains(check.Message, badReplicaBase) || strings.Contains(strings.ToLower(check.Message), "not a directory") {
+		t.Fatalf("expected sanitized replica failure message, got %#v", check)
+	}
+}
+
+func TestGraphPersistenceHealthDoesNotDegradeWhenReplicaAlreadySeeded(t *testing.T) {
+	localDir := t.TempDir()
+	replicaDir := t.TempDir()
+	seedStore, err := graph.NewGraphPersistenceStore(graph.GraphPersistenceOptions{
+		LocalPath:    localDir,
+		MaxSnapshots: 4,
+		ReplicaURI:   replicaDir,
+	})
+	if err != nil {
+		t.Fatalf("new seed graph persistence store: %v", err)
+	}
+	g := graph.New()
+	g.AddNode(&graph.Node{ID: "service:seeded", Kind: graph.NodeKindService, Name: "seeded"})
+	g.SetMetadata(graph.Metadata{
+		BuiltAt:       time.Date(2026, 3, 12, 23, 10, 0, 0, time.UTC),
+		NodeCount:     1,
+		EdgeCount:     0,
+		Providers:     []string{"aws"},
+		Accounts:      []string{"prod"},
+		BuildDuration: time.Second,
+	})
+	if _, err := seedStore.SaveGraph(g); err != nil {
+		t.Fatalf("seed graph snapshot: %v", err)
+	}
+
+	restartedStore, err := graph.NewGraphPersistenceStore(graph.GraphPersistenceOptions{
+		LocalPath:    localDir,
+		MaxSnapshots: 4,
+		ReplicaURI:   replicaDir,
+	})
+	if err != nil {
+		t.Fatalf("new restarted graph persistence store: %v", err)
+	}
+
+	application := &App{
+		Config:         &Config{},
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Warehouse:      &warehouse.MemoryWarehouse{},
+		GraphSnapshots: restartedStore,
+	}
+	application.initHealth()
+
+	results := application.Health.RunAll(context.Background())
+	check := results["graph_persistence"]
+	if check.Status != health.StatusHealthy {
+		t.Fatalf("expected healthy graph persistence health, got %#v", check)
+	}
+}
+
 func TestActivateBuiltSecurityGraphDoesNotReplaceLiveGraphWithNil(t *testing.T) {
 	liveGraph := graph.New()
 	liveGraph.AddNode(&graph.Node{ID: "service:payments", Kind: graph.NodeKindService, Name: "payments"})
@@ -157,6 +285,52 @@ func TestActivateBuiltSecurityGraphDoesNotReplaceLiveGraphWithNil(t *testing.T) 
 	}
 	if snapshot := application.GraphBuildSnapshot(); snapshot.State != GraphBuildFailed {
 		t.Fatalf("expected graph build state failed, got %#v", snapshot)
+	}
+}
+
+func TestActivateBuiltSecurityGraphPersistsSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	store, err := graph.NewGraphPersistenceStore(graph.GraphPersistenceOptions{
+		LocalPath:    dir,
+		MaxSnapshots: 4,
+	})
+	if err != nil {
+		t.Fatalf("new graph persistence store: %v", err)
+	}
+
+	builtGraph := graph.New()
+	builtGraph.AddNode(&graph.Node{ID: "service:payments", Kind: graph.NodeKindService, Name: "payments"})
+	builtGraph.SetMetadata(graph.Metadata{
+		BuiltAt:       time.Date(2026, 3, 12, 22, 5, 0, 0, time.UTC),
+		NodeCount:     1,
+		EdgeCount:     0,
+		Providers:     []string{"aws"},
+		Accounts:      []string{"prod"},
+		BuildDuration: 1500 * time.Millisecond,
+	})
+
+	application := &App{
+		Config:         &Config{GraphSnapshotPath: dir, GraphSnapshotMaxRetained: 4},
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		GraphSnapshots: store,
+	}
+
+	if _, err := application.activateBuiltSecurityGraph(context.Background(), builtGraph); err != nil {
+		t.Fatalf("activateBuiltSecurityGraph failed: %v", err)
+	}
+
+	records, err := store.ListGraphSnapshotRecords()
+	if err != nil {
+		t.Fatalf("list persisted graph snapshots: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected one persisted graph snapshot, got %#v", records)
+	}
+	if records[0].ID == "" {
+		t.Fatalf("expected persisted graph snapshot id, got %#v", records[0])
+	}
+	if status := store.Status(); status.LastPersistedSnapshot == "" {
+		t.Fatalf("expected persistence status to track last persisted snapshot, got %#v", status)
 	}
 }
 

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -266,6 +266,8 @@ func defaultPermissions() []Permission {
 
 		{ID: "platform.graph.read", Resource: "platform.graph", Action: "read"},
 		{ID: "platform.graph.write", Resource: "platform.graph", Action: "write"},
+		{ID: "platform.cross_tenant.read", Resource: "platform.cross_tenant", Action: "read"},
+		{ID: "platform.cross_tenant.write", Resource: "platform.cross_tenant", Action: "write"},
 		{ID: "platform.intelligence.read", Resource: "platform.intelligence", Action: "read"},
 		{ID: "platform.intelligence.run", Resource: "platform.intelligence", Action: "run"},
 		{ID: "platform.jobs.read", Resource: "platform.jobs", Action: "read"},
@@ -332,7 +334,7 @@ func defaultAdminRolePermissions() []string {
 		"assets:read", "compliance:read", "compliance:export",
 		"admin:users", "admin:roles",
 
-		"platform.graph.read", "platform.graph.write", "platform.intelligence.read",
+		"platform.graph.read", "platform.graph.write", "platform.cross_tenant.read", "platform.cross_tenant.write", "platform.intelligence.read",
 		"platform.intelligence.run",
 		"platform.jobs.read", "platform.knowledge.read", "platform.knowledge.write", "platform.workflow.write",
 		"platform.schema.read", "platform.schema.manage", "platform.identity.review",

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -791,6 +791,7 @@ func (g *Graph) GetResourceNodesByARNPrefix(prefix string) []*Node {
 }
 
 func (g *Graph) addNodeLocked(node *Node) bool {
+	normalizeNodeTenantID(node)
 	if !g.applyNodeSchemaValidationLocked(node) {
 		return false
 	}

--- a/internal/graph/node.go
+++ b/internal/graph/node.go
@@ -110,6 +110,7 @@ type Node struct {
 	ID                 string                        `json:"id"`
 	Kind               NodeKind                      `json:"kind"`
 	Name               string                        `json:"name"`
+	TenantID           string                        `json:"tenant_id,omitempty"`
 	Provider           string                        `json:"provider"`
 	Account            string                        `json:"account"`
 	Region             string                        `json:"region,omitempty"`

--- a/internal/graph/persistence_store.go
+++ b/internal/graph/persistence_store.go
@@ -1,0 +1,972 @@
+package graph
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	gcs "cloud.google.com/go/storage"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"google.golang.org/api/iterator"
+)
+
+const (
+	graphRecoverySourceLocal   = "local"
+	graphRecoverySourceReplica = "replica"
+)
+
+type GraphPersistenceOptions struct {
+	LocalPath    string
+	MaxSnapshots int
+	ReplicaURI   string
+}
+
+type GraphPersistenceStatus struct {
+	Configured             bool       `json:"configured"`
+	LocalPath              string     `json:"local_path,omitempty"`
+	ReplicaConfigured      bool       `json:"replica_configured,omitempty"`
+	ReplicaURI             string     `json:"replica_uri,omitempty"`
+	LastPersistedSnapshot  string     `json:"last_persisted_snapshot_id,omitempty"`
+	LastPersistedAt        *time.Time `json:"last_persisted_at,omitempty"`
+	LastReplicatedSnapshot string     `json:"last_replicated_snapshot_id,omitempty"`
+	LastReplicatedAt       *time.Time `json:"last_replicated_at,omitempty"`
+	LastReplicationError   string     `json:"last_replication_error,omitempty"`
+	LastRecoverySource     string     `json:"last_recovery_source,omitempty"`
+	LastRecoveredSnapshot  string     `json:"last_recovered_snapshot_id,omitempty"`
+	LastRecoveredAt        *time.Time `json:"last_recovered_at,omitempty"`
+	LastRecoveryError      string     `json:"last_recovery_error,omitempty"`
+}
+
+type GraphPersistenceStore struct {
+	local   *SnapshotStore
+	replica graphSnapshotReplica
+
+	statusMu sync.RWMutex
+	status   GraphPersistenceStatus
+}
+
+type graphSnapshotReplica interface {
+	URI() string
+	PutFile(ctx context.Context, key, localPath, contentType string) error
+	PutBytes(ctx context.Context, key string, payload []byte, contentType string) error
+	Open(ctx context.Context, key string) (io.ReadCloser, error)
+	ListKeys(ctx context.Context, prefix string) ([]string, error)
+	DeleteKeys(ctx context.Context, keys ...string) error
+}
+
+func NewGraphPersistenceStore(opts GraphPersistenceOptions) (*GraphPersistenceStore, error) {
+	localPath := strings.TrimSpace(opts.LocalPath)
+	if localPath == "" {
+		return nil, fmt.Errorf("graph persistence local path required")
+	}
+	local := NewSnapshotStore(localPath, opts.MaxSnapshots)
+	store := &GraphPersistenceStore{
+		local: local,
+		status: GraphPersistenceStatus{
+			Configured: true,
+			LocalPath:  local.BasePath(),
+		},
+	}
+	replicaURI := strings.TrimSpace(opts.ReplicaURI)
+	if replicaURI == "" {
+		return store, nil
+	}
+	replica, err := newGraphSnapshotReplica(replicaURI)
+	if err != nil {
+		return nil, err
+	}
+	store.replica = replica
+	store.status.ReplicaConfigured = true
+	store.status.ReplicaURI = replica.URI()
+	return store, nil
+}
+
+func (s *GraphPersistenceStore) LocalStore() *SnapshotStore {
+	if s == nil {
+		return nil
+	}
+	return s.local
+}
+
+func (s *GraphPersistenceStore) Status() GraphPersistenceStatus {
+	if s == nil {
+		return GraphPersistenceStatus{}
+	}
+	s.statusMu.RLock()
+	defer s.statusMu.RUnlock()
+	status := s.status
+	status.LastPersistedAt = cloneTimePtr(status.LastPersistedAt)
+	status.LastReplicatedAt = cloneTimePtr(status.LastReplicatedAt)
+	status.LastRecoveredAt = cloneTimePtr(status.LastRecoveredAt)
+	return status
+}
+
+func (s *GraphPersistenceStore) Save(g *Graph) error {
+	_, err := s.SaveGraph(g)
+	return err
+}
+
+func (s *GraphPersistenceStore) SaveGraph(g *Graph) (*GraphSnapshotRecord, error) {
+	if s == nil || s.local == nil {
+		return nil, fmt.Errorf("graph persistence store not configured")
+	}
+	record, _, err := s.local.SaveGraph(g)
+	if err != nil {
+		return nil, err
+	}
+	s.recordPersisted(record)
+	if s.replica == nil {
+		return record, nil
+	}
+	if err := s.syncReplica(context.Background()); err != nil {
+		s.recordReplicationError(err)
+		return record, err
+	}
+	s.recordReplicated(record)
+	return record, nil
+}
+
+func (s *GraphPersistenceStore) LoadLatest() (*Graph, error) {
+	snapshot, _, _, err := s.LoadLatestSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	return RestoreFromSnapshot(snapshot), nil
+}
+
+func (s *GraphPersistenceStore) LoadLatestSnapshot() (*Snapshot, *GraphSnapshotRecord, string, error) {
+	if s == nil {
+		return nil, nil, "", fmt.Errorf("graph persistence store not configured")
+	}
+	if s.local != nil {
+		snapshot, record, err := s.local.LoadLatestSnapshot()
+		if err == nil {
+			s.recordRecovered(record, graphRecoverySourceLocal, nil)
+			return snapshot, record, graphRecoverySourceLocal, nil
+		}
+		if s.replica == nil {
+			s.recordRecovered(nil, graphRecoverySourceLocal, err)
+			return nil, nil, "", err
+		}
+	}
+	if s.replica == nil {
+		return nil, nil, "", fmt.Errorf("graph persistence replica not configured")
+	}
+	snapshot, record, err := s.loadLatestSnapshotFromReplica(context.Background())
+	if err != nil {
+		s.recordRecovered(nil, graphRecoverySourceReplica, err)
+		return nil, nil, "", err
+	}
+	s.recordRecovered(record, graphRecoverySourceReplica, nil)
+	return snapshot, record, graphRecoverySourceReplica, nil
+}
+
+func (s *GraphPersistenceStore) ListGraphSnapshotRecords() ([]GraphSnapshotRecord, error) {
+	if s == nil {
+		return nil, fmt.Errorf("graph persistence store not configured")
+	}
+	if s.local != nil {
+		records, err := s.local.ListGraphSnapshotRecords()
+		if err == nil && len(records) > 0 {
+			return records, nil
+		}
+		if err == nil && s.replica == nil {
+			return records, nil
+		}
+	}
+	if s.replica == nil {
+		return nil, fmt.Errorf("graph persistence replica not configured")
+	}
+	index, err := s.loadReplicaIndex(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	records := make([]GraphSnapshotRecord, 0, len(index.Snapshots))
+	for _, manifest := range index.Snapshots {
+		records = append(records, manifest.Record)
+	}
+	return records, nil
+}
+
+func (s *GraphPersistenceStore) LoadSnapshotsByRecordIDs(snapshotIDs ...string) (map[string]*Snapshot, map[string]*GraphSnapshotRecord, error) {
+	if s == nil {
+		return nil, nil, fmt.Errorf("graph persistence store not configured")
+	}
+	if s.local != nil {
+		snapshots, records, err := s.local.LoadSnapshotsByRecordIDs(snapshotIDs...)
+		if err == nil {
+			return snapshots, records, nil
+		}
+		if s.replica == nil {
+			return nil, nil, err
+		}
+	}
+	if s.replica == nil {
+		return nil, nil, fmt.Errorf("graph persistence replica not configured")
+	}
+	return s.loadSnapshotsByRecordIDsFromReplica(context.Background(), snapshotIDs...)
+}
+
+func (s *GraphPersistenceStore) DiffByTime(t1, t2 time.Time) (*GraphDiff, error) {
+	if s == nil {
+		return nil, fmt.Errorf("graph persistence store not configured")
+	}
+	if s.local != nil {
+		diff, err := s.local.DiffByTime(t1, t2)
+		if err == nil {
+			return diff, nil
+		}
+		if s.replica == nil {
+			return nil, err
+		}
+	}
+	if s.replica == nil {
+		return nil, fmt.Errorf("graph persistence replica not configured")
+	}
+	before, err := s.loadClosestSnapshotAtReplica(context.Background(), t1)
+	if err != nil {
+		return nil, err
+	}
+	after, err := s.loadClosestSnapshotAtReplica(context.Background(), t2)
+	if err != nil {
+		return nil, err
+	}
+	return DiffSnapshots(before, after), nil
+}
+
+func (s *GraphPersistenceStore) syncReplica(ctx context.Context) error {
+	index, err := s.local.loadOrRebuildSnapshotIndex()
+	if err != nil {
+		return err
+	}
+	previousIndex, err := s.loadReplicaIndexIfPresent(ctx)
+	if err != nil {
+		return err
+	}
+	keep := map[string]struct{}{
+		"index.json": {},
+	}
+	localBase := s.local.BasePath()
+	for _, manifest := range index.Snapshots {
+		artifactKey, err := normalizeReplicaKey(manifest.ArtifactPath)
+		if err != nil {
+			return fmt.Errorf("invalid snapshot artifact path for %s: %w", manifest.SnapshotID, err)
+		}
+		localArtifactPath, err := resolveReplicaLocalPath(localBase, artifactKey)
+		if err != nil {
+			return fmt.Errorf("resolve local snapshot artifact %s: %w", manifest.SnapshotID, err)
+		}
+		manifest.ArtifactPath = artifactKey
+		manifestKey := path.Join("manifests", sanitizeReportFileName(manifest.SnapshotID)+".json")
+		keep[manifestKey] = struct{}{}
+		keep[artifactKey] = struct{}{}
+
+		if err := s.replica.PutFile(ctx, artifactKey, localArtifactPath, "application/gzip"); err != nil {
+			return fmt.Errorf("replicate snapshot artifact %s: %w", manifest.SnapshotID, err)
+		}
+		payload, err := json.MarshalIndent(manifest, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal snapshot manifest %s: %w", manifest.SnapshotID, err)
+		}
+		if err := s.replica.PutBytes(ctx, manifestKey, append(payload, '\n'), "application/json"); err != nil {
+			return fmt.Errorf("replicate snapshot manifest %s: %w", manifest.SnapshotID, err)
+		}
+	}
+	indexPayload, err := os.ReadFile(filepath.Join(localBase, "index.json")) // #nosec G304 -- local graph snapshot index path is store-owned.
+	if err != nil {
+		return fmt.Errorf("read local snapshot index: %w", err)
+	}
+	if err := s.replica.PutBytes(ctx, "index.json", indexPayload, "application/json"); err != nil {
+		return fmt.Errorf("replicate snapshot index: %w", err)
+	}
+	stale := make([]string, 0)
+	if previousIndex != nil {
+		for _, key := range replicaTrackedKeysFromIndex(*previousIndex) {
+			if _, ok := keep[key]; !ok {
+				stale = append(stale, key)
+			}
+		}
+	}
+	if len(stale) > 0 {
+		if err := s.replica.DeleteKeys(ctx, stale...); err != nil {
+			return fmt.Errorf("delete stale replica artifacts: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *GraphPersistenceStore) loadLatestSnapshotFromReplica(ctx context.Context) (*Snapshot, *GraphSnapshotRecord, error) {
+	index, err := s.loadReplicaIndex(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(index.Snapshots) == 0 {
+		return nil, nil, fmt.Errorf("no replica snapshots found")
+	}
+	manifest := index.Snapshots[len(index.Snapshots)-1]
+	return s.loadSnapshotFromReplicaManifest(ctx, manifest)
+}
+
+func (s *GraphPersistenceStore) loadSnapshotsByRecordIDsFromReplica(ctx context.Context, snapshotIDs ...string) (map[string]*Snapshot, map[string]*GraphSnapshotRecord, error) {
+	requested := make(map[string]struct{}, len(snapshotIDs))
+	for _, snapshotID := range snapshotIDs {
+		snapshotID = strings.TrimSpace(snapshotID)
+		if snapshotID != "" {
+			requested[snapshotID] = struct{}{}
+		}
+	}
+	if len(requested) == 0 {
+		return nil, nil, fmt.Errorf("at least one snapshot id required")
+	}
+	index, err := s.loadReplicaIndex(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	snapshots := make(map[string]*Snapshot, len(requested))
+	records := make(map[string]*GraphSnapshotRecord, len(requested))
+	for _, manifest := range index.Snapshots {
+		if len(snapshots) == len(requested) {
+			break
+		}
+		id := strings.TrimSpace(manifest.Record.ID)
+		if _, ok := requested[id]; !ok {
+			continue
+		}
+		snapshot, record, err := s.loadSnapshotFromReplicaManifest(ctx, manifest)
+		if err != nil {
+			return nil, nil, err
+		}
+		snapshots[id] = snapshot
+		records[id] = record
+	}
+	for snapshotID := range requested {
+		if _, ok := snapshots[snapshotID]; !ok {
+			return nil, nil, fmt.Errorf("snapshot %q not found", snapshotID)
+		}
+	}
+	return snapshots, records, nil
+}
+
+func (s *GraphPersistenceStore) loadClosestSnapshotAtReplica(ctx context.Context, ts time.Time) (*Snapshot, error) {
+	if ts.IsZero() {
+		return nil, fmt.Errorf("timestamp required")
+	}
+	index, err := s.loadReplicaIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(index.Snapshots) == 0 {
+		return nil, fmt.Errorf("no replica snapshots found")
+	}
+	var (
+		closestBefore *GraphSnapshotManifest
+		closestAfter  *GraphSnapshotManifest
+	)
+	for i := range index.Snapshots {
+		manifest := index.Snapshots[i]
+		recordTime := graphSnapshotManifestSortTime(manifest)
+		if recordTime.IsZero() {
+			continue
+		}
+		switch {
+		case !recordTime.After(ts):
+			if closestBefore == nil || recordTime.After(graphSnapshotManifestSortTime(*closestBefore)) {
+				manifestCopy := manifest
+				closestBefore = &manifestCopy
+			}
+		default:
+			if closestAfter == nil || recordTime.Before(graphSnapshotManifestSortTime(*closestAfter)) {
+				manifestCopy := manifest
+				closestAfter = &manifestCopy
+			}
+		}
+	}
+	if closestBefore != nil {
+		snapshot, _, err := s.loadSnapshotFromReplicaManifest(ctx, *closestBefore)
+		return snapshot, err
+	}
+	if closestAfter != nil {
+		snapshot, _, err := s.loadSnapshotFromReplicaManifest(ctx, *closestAfter)
+		return snapshot, err
+	}
+	return nil, fmt.Errorf("no readable replica snapshots found")
+}
+
+func (s *GraphPersistenceStore) loadSnapshotFromReplicaManifest(ctx context.Context, manifest GraphSnapshotManifest) (*Snapshot, *GraphSnapshotRecord, error) {
+	artifactKey, err := normalizeReplicaKey(manifest.ArtifactPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid replica snapshot artifact path for %s: %w", manifest.SnapshotID, err)
+	}
+	reader, err := s.replica.Open(ctx, artifactKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open replica snapshot artifact %s: %w", manifest.SnapshotID, err)
+	}
+	defer func() { _ = reader.Close() }()
+	snapshot, err := loadSnapshotFromCompressedReader(reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	record := manifest.Record
+	return snapshot, &record, nil
+}
+
+func (s *GraphPersistenceStore) loadReplicaIndex(ctx context.Context) (*graphSnapshotIndex, error) {
+	reader, err := s.replica.Open(ctx, "index.json")
+	if err != nil {
+		return nil, fmt.Errorf("open replica snapshot index: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+	var index graphSnapshotIndex
+	if err := json.NewDecoder(reader).Decode(&index); err != nil {
+		return nil, fmt.Errorf("decode replica snapshot index: %w", err)
+	}
+	if version := strings.TrimSpace(index.APIVersion); version != "" && version != graphSnapshotIndexAPIVersion {
+		return nil, fmt.Errorf("unsupported replica snapshot index version %q", version)
+	}
+	for i := range index.Snapshots {
+		artifactKey, err := normalizeReplicaKey(index.Snapshots[i].ArtifactPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid replica snapshot artifact path for %s: %w", index.Snapshots[i].SnapshotID, err)
+		}
+		index.Snapshots[i].ArtifactPath = artifactKey
+	}
+	return &index, nil
+}
+
+func (s *GraphPersistenceStore) loadReplicaIndexIfPresent(ctx context.Context) (*graphSnapshotIndex, error) {
+	keys, err := s.replica.ListKeys(ctx, "index.json")
+	if err != nil {
+		return nil, fmt.Errorf("list replica snapshot index: %w", err)
+	}
+	for _, key := range keys {
+		normalized, err := normalizeReplicaKey(key)
+		if err != nil {
+			continue
+		}
+		if normalized == "index.json" {
+			return s.loadReplicaIndex(ctx)
+		}
+	}
+	return nil, nil
+}
+
+func replicaTrackedKeysFromIndex(index graphSnapshotIndex) []string {
+	tracked := map[string]struct{}{
+		"index.json": {},
+	}
+	for _, manifest := range index.Snapshots {
+		artifactKey, err := normalizeReplicaKey(manifest.ArtifactPath)
+		if err != nil {
+			continue
+		}
+		tracked[artifactKey] = struct{}{}
+		tracked[path.Join("manifests", sanitizeReportFileName(manifest.SnapshotID)+".json")] = struct{}{}
+	}
+	keys := make([]string, 0, len(tracked))
+	for key := range tracked {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func (s *GraphPersistenceStore) recordPersisted(record *GraphSnapshotRecord) {
+	s.statusMu.Lock()
+	defer s.statusMu.Unlock()
+	s.status.Configured = true
+	if record != nil {
+		now := time.Now().UTC()
+		s.status.LastPersistedSnapshot = strings.TrimSpace(record.ID)
+		s.status.LastPersistedAt = &now
+	}
+}
+
+func (s *GraphPersistenceStore) recordReplicated(record *GraphSnapshotRecord) {
+	s.statusMu.Lock()
+	defer s.statusMu.Unlock()
+	now := time.Now().UTC()
+	s.status.LastReplicationError = ""
+	if record != nil {
+		s.status.LastReplicatedSnapshot = strings.TrimSpace(record.ID)
+	}
+	s.status.LastReplicatedAt = &now
+}
+
+func (s *GraphPersistenceStore) recordReplicationError(err error) {
+	s.statusMu.Lock()
+	defer s.statusMu.Unlock()
+	if err == nil {
+		s.status.LastReplicationError = ""
+		return
+	}
+	s.status.LastReplicationError = strings.TrimSpace(err.Error())
+}
+
+func (s *GraphPersistenceStore) recordRecovered(record *GraphSnapshotRecord, source string, err error) {
+	s.statusMu.Lock()
+	defer s.statusMu.Unlock()
+	s.status.LastRecoverySource = strings.TrimSpace(source)
+	if err != nil {
+		s.status.LastRecoveryError = strings.TrimSpace(err.Error())
+		return
+	}
+	now := time.Now().UTC()
+	s.status.LastRecoveryError = ""
+	s.status.LastRecoveredAt = &now
+	if record != nil {
+		s.status.LastRecoveredSnapshot = strings.TrimSpace(record.ID)
+	}
+}
+
+func newGraphSnapshotReplica(raw string) (graphSnapshotReplica, error) {
+	raw = strings.TrimSpace(raw)
+	switch {
+	case raw == "":
+		return nil, fmt.Errorf("replica uri required")
+	case strings.HasPrefix(raw, "s3://"):
+		return newS3GraphSnapshotReplica(raw)
+	case strings.HasPrefix(raw, "gs://"):
+		return newGCSGraphSnapshotReplica(raw)
+	case strings.HasPrefix(raw, "file://"):
+		return newFileGraphSnapshotReplica(strings.TrimPrefix(raw, "file://")), nil
+	default:
+		return newFileGraphSnapshotReplica(raw), nil
+	}
+}
+
+type fileGraphSnapshotReplica struct {
+	basePath string
+}
+
+func newFileGraphSnapshotReplica(basePath string) *fileGraphSnapshotReplica {
+	return &fileGraphSnapshotReplica{basePath: filepath.Clean(strings.TrimSpace(basePath))}
+}
+
+func (r *fileGraphSnapshotReplica) URI() string { return "file://" + r.basePath }
+
+func (r *fileGraphSnapshotReplica) PutFile(_ context.Context, key, localPath, _ string) error {
+	keyPath, err := r.keyPath(key)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o750); err != nil {
+		return err
+	}
+	src, err := os.Open(localPath) // #nosec G304 -- local snapshot artifact path is store-owned.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = src.Close() }()
+	tmp := keyPath + ".tmp"
+	dst, err := os.Create(tmp) // #nosec G304 -- replica temp file path is resolved under the configured replica root.
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		_ = dst.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := dst.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, keyPath)
+}
+
+func (r *fileGraphSnapshotReplica) PutBytes(_ context.Context, key string, payload []byte, _ string) error {
+	keyPath, err := r.keyPath(key)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o750); err != nil { // #nosec G301,G304,G703 -- replica path is validated and contained under the configured replica root.
+		return err
+	}
+	tmp := keyPath + ".tmp"
+	if err := os.WriteFile(tmp, payload, 0o600); err != nil { // #nosec G304,G703 -- validated replica temp path stays within the configured replica root.
+		return err
+	}
+	return os.Rename(tmp, keyPath) // #nosec G304,G703 -- validated replica destination path stays within the configured replica root.
+}
+
+func (r *fileGraphSnapshotReplica) Open(_ context.Context, key string) (io.ReadCloser, error) {
+	keyPath, err := r.keyPath(key)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(keyPath) // #nosec G304 -- replica key is resolved under the configured replica root.
+}
+
+func (r *fileGraphSnapshotReplica) ListKeys(_ context.Context, prefix string) ([]string, error) {
+	keys := make([]string, 0)
+	err := filepath.WalkDir(r.basePath, func(current string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(r.basePath, current)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if prefix == "" || strings.HasPrefix(rel, prefix) {
+			keys = append(keys, rel)
+		}
+		return nil
+	})
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	return keys, err
+}
+
+func (r *fileGraphSnapshotReplica) DeleteKeys(_ context.Context, keys ...string) error {
+	for _, key := range keys {
+		keyPath, err := r.keyPath(key)
+		if err != nil {
+			return err
+		}
+		if err := os.Remove(keyPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *fileGraphSnapshotReplica) keyPath(key string) (string, error) {
+	return resolveReplicaLocalPath(r.basePath, key)
+}
+
+type s3GraphSnapshotReplica struct {
+	uri    string
+	bucket string
+	prefix string
+	client *s3.Client
+}
+
+func newS3GraphSnapshotReplica(raw string) (*s3GraphSnapshotReplica, error) {
+	bucket, prefix, err := parseBucketURI(raw, "s3://")
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("load aws config for graph snapshot replica: %w", err)
+	}
+	return &s3GraphSnapshotReplica{
+		uri:    raw,
+		bucket: bucket,
+		prefix: prefix,
+		client: s3.NewFromConfig(cfg),
+	}, nil
+}
+
+func (r *s3GraphSnapshotReplica) URI() string { return r.uri }
+
+func (r *s3GraphSnapshotReplica) PutFile(ctx context.Context, key, localPath, contentType string) error {
+	objectKey, err := r.objectKey(key)
+	if err != nil {
+		return err
+	}
+	file, err := os.Open(localPath) // #nosec G304 -- local snapshot artifact path is store-owned.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	_, err = r.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      &r.bucket,
+		Key:         strPtr(objectKey),
+		Body:        file,
+		ContentType: strPtr(contentType),
+	})
+	return err
+}
+
+func (r *s3GraphSnapshotReplica) PutBytes(ctx context.Context, key string, payload []byte, contentType string) error {
+	objectKey, err := r.objectKey(key)
+	if err != nil {
+		return err
+	}
+	_, err = r.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      &r.bucket,
+		Key:         strPtr(objectKey),
+		Body:        bytes.NewReader(payload),
+		ContentType: strPtr(contentType),
+	})
+	return err
+}
+
+func (r *s3GraphSnapshotReplica) Open(ctx context.Context, key string) (io.ReadCloser, error) {
+	objectKey, err := r.objectKey(key)
+	if err != nil {
+		return nil, err
+	}
+	out, err := r.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &r.bucket,
+		Key:    strPtr(objectKey),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.Body, nil
+}
+
+func (r *s3GraphSnapshotReplica) ListKeys(ctx context.Context, prefix string) ([]string, error) {
+	objectPrefix, err := r.objectKey(prefix)
+	if err != nil {
+		return nil, err
+	}
+	input := &s3.ListObjectsV2Input{
+		Bucket: &r.bucket,
+		Prefix: strPtr(objectPrefix),
+	}
+	paginator := s3.NewListObjectsV2Paginator(r.client, input)
+	keys := make([]string, 0)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, object := range page.Contents {
+			if object.Key == nil {
+				continue
+			}
+			keys = append(keys, strings.TrimPrefix(strings.TrimPrefix(*object.Key, r.prefix), "/"))
+		}
+	}
+	return keys, nil
+}
+
+func (r *s3GraphSnapshotReplica) DeleteKeys(ctx context.Context, keys ...string) error {
+	for _, key := range keys {
+		objectKey, err := r.objectKey(key)
+		if err != nil {
+			return err
+		}
+		_, err = r.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: &r.bucket,
+			Key:    strPtr(objectKey),
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *s3GraphSnapshotReplica) objectKey(key string) (string, error) {
+	if strings.TrimSpace(key) == "" {
+		return r.prefix, nil
+	}
+	key, err := normalizeReplicaKey(key)
+	if err != nil {
+		return "", err
+	}
+	if r.prefix == "" {
+		return key, nil
+	}
+	return path.Join(r.prefix, key), nil
+}
+
+type gcsGraphSnapshotReplica struct {
+	uri    string
+	bucket string
+	prefix string
+	client *gcs.Client
+}
+
+func newGCSGraphSnapshotReplica(raw string) (*gcsGraphSnapshotReplica, error) {
+	bucket, prefix, err := parseBucketURI(raw, "gs://")
+	if err != nil {
+		return nil, err
+	}
+	client, err := gcs.NewClient(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("load gcs client for graph snapshot replica: %w", err)
+	}
+	return &gcsGraphSnapshotReplica{
+		uri:    raw,
+		bucket: bucket,
+		prefix: prefix,
+		client: client,
+	}, nil
+}
+
+func (r *gcsGraphSnapshotReplica) URI() string { return r.uri }
+
+func (r *gcsGraphSnapshotReplica) PutFile(ctx context.Context, key, localPath, contentType string) error {
+	objectKey, err := r.objectKey(key)
+	if err != nil {
+		return err
+	}
+	file, err := os.Open(localPath) // #nosec G304 -- local snapshot artifact path is store-owned.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	writer := r.client.Bucket(r.bucket).Object(objectKey).NewWriter(ctx)
+	writer.ContentType = contentType
+	if _, err := io.Copy(writer, file); err != nil {
+		_ = writer.Close()
+		return err
+	}
+	return writer.Close()
+}
+
+func (r *gcsGraphSnapshotReplica) PutBytes(ctx context.Context, key string, payload []byte, contentType string) error {
+	objectKey, err := r.objectKey(key)
+	if err != nil {
+		return err
+	}
+	writer := r.client.Bucket(r.bucket).Object(objectKey).NewWriter(ctx)
+	writer.ContentType = contentType
+	if _, err := writer.Write(payload); err != nil {
+		_ = writer.Close()
+		return err
+	}
+	return writer.Close()
+}
+
+func (r *gcsGraphSnapshotReplica) Open(ctx context.Context, key string) (io.ReadCloser, error) {
+	objectKey, err := r.objectKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return r.client.Bucket(r.bucket).Object(objectKey).NewReader(ctx)
+}
+
+func (r *gcsGraphSnapshotReplica) ListKeys(ctx context.Context, prefix string) ([]string, error) {
+	objectPrefix, err := r.objectKey(prefix)
+	if err != nil {
+		return nil, err
+	}
+	query := &gcs.Query{Prefix: objectPrefix}
+	it := r.client.Bucket(r.bucket).Objects(ctx, query)
+	keys := make([]string, 0)
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			return keys, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, strings.TrimPrefix(strings.TrimPrefix(attrs.Name, r.prefix), "/"))
+	}
+}
+
+func (r *gcsGraphSnapshotReplica) DeleteKeys(ctx context.Context, keys ...string) error {
+	for _, key := range keys {
+		objectKey, err := r.objectKey(key)
+		if err != nil {
+			return err
+		}
+		if err := r.client.Bucket(r.bucket).Object(objectKey).Delete(ctx); err != nil && !errors.Is(err, gcs.ErrObjectNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *gcsGraphSnapshotReplica) objectKey(key string) (string, error) {
+	if strings.TrimSpace(key) == "" {
+		return r.prefix, nil
+	}
+	key, err := normalizeReplicaKey(key)
+	if err != nil {
+		return "", err
+	}
+	if r.prefix == "" {
+		return key, nil
+	}
+	return path.Join(r.prefix, key), nil
+}
+
+func parseBucketURI(raw, prefix string) (string, string, error) {
+	trimmed := strings.TrimSpace(strings.TrimPrefix(raw, prefix))
+	parts := strings.SplitN(trimmed, "/", 2)
+	bucket := strings.TrimSpace(parts[0])
+	if bucket == "" {
+		return "", "", fmt.Errorf("invalid replica uri %q: missing bucket", raw)
+	}
+	objectPrefix := ""
+	if len(parts) == 2 {
+		objectPrefix = strings.Trim(strings.TrimSpace(parts[1]), "/")
+		if objectPrefix != "" {
+			var err error
+			objectPrefix, err = normalizeReplicaKey(objectPrefix)
+			if err != nil {
+				return "", "", fmt.Errorf("invalid replica prefix %q: %w", raw, err)
+			}
+		}
+	}
+	return bucket, objectPrefix, nil
+}
+
+func normalizeReplicaKey(key string) (string, error) {
+	key = filepath.ToSlash(strings.TrimSpace(key))
+	if key == "" {
+		return "", fmt.Errorf("replica key required")
+	}
+	if strings.ContainsRune(key, 0) {
+		return "", fmt.Errorf("replica key contains NUL byte")
+	}
+	if strings.HasPrefix(key, "/") || path.IsAbs(key) {
+		return "", fmt.Errorf("replica key must be relative")
+	}
+	clean := path.Clean(key)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("replica key escapes configured prefix")
+	}
+	if strings.Contains(clean, ":") {
+		return "", fmt.Errorf("replica key contains invalid drive separator")
+	}
+	return clean, nil
+}
+
+func resolveReplicaLocalPath(basePath, key string) (string, error) {
+	normalized, err := normalizeReplicaKey(key)
+	if err != nil {
+		return "", err
+	}
+	baseAbs, err := filepath.Abs(strings.TrimSpace(basePath))
+	if err != nil {
+		return "", err
+	}
+	full := filepath.Join(baseAbs, filepath.FromSlash(normalized))
+	fullAbs, err := filepath.Abs(full)
+	if err != nil {
+		return "", err
+	}
+	if fullAbs != baseAbs && !strings.HasPrefix(fullAbs, baseAbs+string(os.PathSeparator)) {
+		return "", fmt.Errorf("replica key escapes configured base path")
+	}
+	return fullAbs, nil
+}
+
+func strPtr(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func graphSnapshotManifestSortTime(manifest GraphSnapshotManifest) time.Time {
+	recordTime := graphSnapshotSortTime(manifest.Record)
+	if recordTime.IsZero() && manifest.Record.CapturedAt != nil {
+		return manifest.Record.CapturedAt.UTC()
+	}
+	return recordTime
+}

--- a/internal/graph/persistence_store_test.go
+++ b/internal/graph/persistence_store_test.go
@@ -1,0 +1,306 @@
+package graph
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGraphPersistenceStoreReplicatesAndRecoversFromFileReplica(t *testing.T) {
+	localDir := t.TempDir()
+	replicaDir := t.TempDir()
+
+	store, err := NewGraphPersistenceStore(GraphPersistenceOptions{
+		LocalPath:    localDir,
+		MaxSnapshots: 4,
+		ReplicaURI:   replicaDir,
+	})
+	if err != nil {
+		t.Fatalf("new graph persistence store: %v", err)
+	}
+
+	g := New()
+	g.AddNode(&Node{ID: "service:payments", Kind: NodeKindService, Name: "payments"})
+	g.SetMetadata(Metadata{
+		BuiltAt:       time.Date(2026, 3, 12, 22, 0, 0, 0, time.UTC),
+		NodeCount:     1,
+		EdgeCount:     0,
+		Providers:     []string{"aws"},
+		Accounts:      []string{"prod"},
+		BuildDuration: 2 * time.Second,
+	})
+
+	record, err := store.SaveGraph(g)
+	if err != nil {
+		t.Fatalf("save graph snapshot: %v", err)
+	}
+	if record == nil || record.ID == "" {
+		t.Fatalf("expected persisted snapshot record, got %#v", record)
+	}
+
+	status := store.Status()
+	if status.LastReplicatedSnapshot != record.ID {
+		t.Fatalf("expected last replicated snapshot %q, got %#v", record.ID, status)
+	}
+
+	if err := os.RemoveAll(localDir); err != nil {
+		t.Fatalf("remove local snapshot dir: %v", err)
+	}
+
+	recoveredStore, err := NewGraphPersistenceStore(GraphPersistenceOptions{
+		LocalPath:    localDir,
+		MaxSnapshots: 4,
+		ReplicaURI:   replicaDir,
+	})
+	if err != nil {
+		t.Fatalf("new recovered graph persistence store: %v", err)
+	}
+
+	snapshot, recoveredRecord, source, err := recoveredStore.LoadLatestSnapshot()
+	if err != nil {
+		t.Fatalf("load latest snapshot from replica: %v", err)
+	}
+	if source != graphRecoverySourceReplica {
+		t.Fatalf("expected replica recovery source, got %q", source)
+	}
+	if recoveredRecord == nil || recoveredRecord.ID != record.ID {
+		t.Fatalf("expected recovered record %q, got %#v", record.ID, recoveredRecord)
+	}
+	if snapshot == nil || len(snapshot.Nodes) != 1 {
+		t.Fatalf("expected one-node recovered snapshot, got %#v", snapshot)
+	}
+
+	records, err := recoveredStore.ListGraphSnapshotRecords()
+	if err != nil {
+		t.Fatalf("list graph snapshot records from replica: %v", err)
+	}
+	if len(records) != 1 || records[0].ID != record.ID {
+		t.Fatalf("expected persisted record list to include %q, got %#v", record.ID, records)
+	}
+
+	replicaIndex := filepath.Join(replicaDir, "index.json")
+	if _, err := os.Stat(replicaIndex); err != nil {
+		t.Fatalf("expected replica index at %s: %v", replicaIndex, err)
+	}
+}
+
+func TestGraphPersistenceStoreSaveGraphReturnsRecordWhenReplicaSyncFails(t *testing.T) {
+	localDir := t.TempDir()
+	badReplicaBase := filepath.Join(t.TempDir(), "replica-file")
+	if err := os.WriteFile(badReplicaBase, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("seed bad replica path: %v", err)
+	}
+
+	store, err := NewGraphPersistenceStore(GraphPersistenceOptions{
+		LocalPath:    localDir,
+		MaxSnapshots: 4,
+		ReplicaURI:   badReplicaBase,
+	})
+	if err != nil {
+		t.Fatalf("new graph persistence store: %v", err)
+	}
+
+	g := New()
+	g.AddNode(&Node{ID: "service:billing", Kind: NodeKindService, Name: "billing"})
+	g.SetMetadata(Metadata{
+		BuiltAt:       time.Date(2026, 3, 12, 23, 0, 0, 0, time.UTC),
+		NodeCount:     1,
+		EdgeCount:     0,
+		Providers:     []string{"aws"},
+		Accounts:      []string{"prod"},
+		BuildDuration: time.Second,
+	})
+
+	record, err := store.SaveGraph(g)
+	if err == nil {
+		t.Fatal("expected replica sync failure")
+	}
+	if record == nil || record.ID == "" {
+		t.Fatalf("expected local persisted record despite replica failure, got %#v", record)
+	}
+	status := store.Status()
+	if status.LastPersistedSnapshot != record.ID {
+		t.Fatalf("expected persisted snapshot id %q in status, got %#v", record.ID, status)
+	}
+	if status.LastReplicationError == "" {
+		t.Fatalf("expected replication error in status, got %#v", status)
+	}
+}
+
+func TestGraphPersistenceStoreRejectsTraversalArtifactPathFromReplicaIndex(t *testing.T) {
+	localDir := t.TempDir()
+	replicaDir := t.TempDir()
+	index := graphSnapshotIndex{
+		APIVersion:  graphSnapshotIndexAPIVersion,
+		GeneratedAt: time.Now().UTC(),
+		Snapshots: []GraphSnapshotManifest{
+			{
+				APIVersion:   graphSnapshotManifestAPIVersion,
+				Kind:         graphSnapshotManifestKind,
+				SnapshotID:   "snap-1",
+				ArtifactPath: "../escape.json.gz",
+				Record: GraphSnapshotRecord{
+					ID: "snap-1",
+				},
+			},
+		},
+	}
+	payload, err := json.Marshal(index)
+	if err != nil {
+		t.Fatalf("marshal replica index: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(replicaDir, "index.json"), payload, 0o600); err != nil {
+		t.Fatalf("write replica index: %v", err)
+	}
+	store, err := NewGraphPersistenceStore(GraphPersistenceOptions{
+		LocalPath:    localDir,
+		MaxSnapshots: 4,
+		ReplicaURI:   replicaDir,
+	})
+	if err != nil {
+		t.Fatalf("new graph persistence store: %v", err)
+	}
+	if _, err := store.ListGraphSnapshotRecords(); err == nil || !strings.Contains(err.Error(), "invalid replica snapshot artifact path") {
+		t.Fatalf("expected invalid artifact path error, got %v", err)
+	}
+}
+
+func TestFileGraphSnapshotReplicaRejectsTraversalKeys(t *testing.T) {
+	replica := newFileGraphSnapshotReplica(t.TempDir())
+	if err := replica.PutBytes(context.Background(), "../escape", []byte("payload"), "application/octet-stream"); err == nil {
+		t.Fatal("expected traversal key rejection on put")
+	}
+	if _, err := replica.Open(context.Background(), "../escape"); err == nil {
+		t.Fatal("expected traversal key rejection on open")
+	}
+	if err := replica.DeleteKeys(context.Background(), "../escape"); err == nil {
+		t.Fatal("expected traversal key rejection on delete")
+	}
+}
+
+func TestParseBucketURIAllowsBucketRootTrailingSlash(t *testing.T) {
+	tests := []struct {
+		raw          string
+		prefix       string
+		wantBucket   string
+		wantObjPrfix string
+	}{
+		{raw: "s3://bucket/", prefix: "s3://", wantBucket: "bucket", wantObjPrfix: ""},
+		{raw: "gcs://bucket/", prefix: "gcs://", wantBucket: "bucket", wantObjPrfix: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			bucket, objectPrefix, err := parseBucketURI(tt.raw, tt.prefix)
+			if err != nil {
+				t.Fatalf("parseBucketURI(%q): %v", tt.raw, err)
+			}
+			if bucket != tt.wantBucket {
+				t.Fatalf("expected bucket %q, got %q", tt.wantBucket, bucket)
+			}
+			if objectPrefix != tt.wantObjPrfix {
+				t.Fatalf("expected object prefix %q, got %q", tt.wantObjPrfix, objectPrefix)
+			}
+		})
+	}
+}
+
+func TestGraphPersistenceStoreSyncReplicaDeletesOnlyPreviouslyTrackedKeys(t *testing.T) {
+	localDir := t.TempDir()
+	replicaDir := t.TempDir()
+
+	previousIndex := graphSnapshotIndex{
+		APIVersion:  graphSnapshotIndexAPIVersion,
+		GeneratedAt: time.Now().UTC(),
+		Snapshots: []GraphSnapshotManifest{
+			{
+				APIVersion:   graphSnapshotManifestAPIVersion,
+				Kind:         graphSnapshotManifestKind,
+				SnapshotID:   "old-snap",
+				ArtifactPath: "graph-old.json.gz",
+				Record: GraphSnapshotRecord{
+					ID: "old-snap",
+				},
+			},
+		},
+	}
+	indexPayload, err := json.Marshal(previousIndex)
+	if err != nil {
+		t.Fatalf("marshal previous index: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(replicaDir, "index.json"), indexPayload, 0o600); err != nil {
+		t.Fatalf("write previous replica index: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(replicaDir, "manifests"), 0o750); err != nil {
+		t.Fatalf("create replica manifests dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(replicaDir, "graph-old.json.gz"), []byte("old"), 0o600); err != nil {
+		t.Fatalf("write previous snapshot artifact: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(replicaDir, "manifests", "old-snap.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write previous manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(replicaDir, "shared.json.gz"), []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write unrelated shared object: %v", err)
+	}
+
+	store, err := NewGraphPersistenceStore(GraphPersistenceOptions{
+		LocalPath:    localDir,
+		MaxSnapshots: 4,
+		ReplicaURI:   replicaDir,
+	})
+	if err != nil {
+		t.Fatalf("new graph persistence store: %v", err)
+	}
+
+	g := New()
+	g.AddNode(&Node{ID: "service:payments", Kind: NodeKindService, Name: "payments"})
+	g.SetMetadata(Metadata{
+		BuiltAt:   time.Now().UTC(),
+		NodeCount: 1,
+	})
+	if _, err := store.SaveGraph(g); err != nil {
+		t.Fatalf("save graph with replica sync: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(replicaDir, "shared.json.gz")); err != nil {
+		t.Fatalf("expected unrelated shared object to remain: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(replicaDir, "graph-old.json.gz")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected previously tracked stale artifact to be removed, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(replicaDir, "manifests", "old-snap.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected previously tracked stale manifest to be removed, got %v", err)
+	}
+}
+
+type failOnSecondWriteWriter struct {
+	writes int
+}
+
+func (w *failOnSecondWriteWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes >= 2 {
+		return 0, errors.New("flush failed")
+	}
+	return len(p), nil
+}
+
+func TestSnapshotWriteCompressedPropagatesCloseError(t *testing.T) {
+	snapshot := &Snapshot{
+		Version:   snapshotVersion,
+		CreatedAt: time.Unix(0, 0).UTC(),
+	}
+	err := snapshot.writeCompressed(&failOnSecondWriteWriter{})
+	if err == nil {
+		t.Fatal("expected close error from compressed writer")
+	}
+	if !strings.Contains(err.Error(), "close compressed snapshot") {
+		t.Fatalf("expected close compressed snapshot error, got %v", err)
+	}
+}

--- a/internal/graph/reports/intelligence_report_test.go
+++ b/internal/graph/reports/intelligence_report_test.go
@@ -126,7 +126,7 @@ func TestBuildIntelligenceReport_DeterministicInsightOrderAndIDs(t *testing.T) {
 }
 
 func TestBuildIntelligenceReport_FreshnessPenalizesConfidence(t *testing.T) {
-	now := time.Date(2026, 3, 8, 22, 0, 0, 0, time.UTC)
+	now := time.Now().UTC().Truncate(time.Second)
 
 	fresh := New()
 	fresh.AddNode(&Node{ID: "service:fresh", Kind: NodeKindService, Name: "Fresh", Properties: map[string]any{

--- a/internal/graph/snapshot.go
+++ b/internal/graph/snapshot.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"bufio"
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
@@ -115,28 +116,32 @@ func (s *Snapshot) SaveToFile(path string) error {
 	if err != nil {
 		return fmt.Errorf("create file: %w", err)
 	}
-	defer func() { _ = f.Close() }()
 
-	gw := gzip.NewWriter(f)
-	defer func() { _ = gw.Close() }()
-
-	encoder := json.NewEncoder(gw)
-	if err := encoder.Encode(s); err != nil {
-		return fmt.Errorf("encode snapshot: %w", err)
+	if err := s.writeCompressed(f); err != nil {
+		_ = f.Close()
+		return err
 	}
-
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close snapshot file: %w", err)
+	}
 	return nil
 }
 
-// LoadSnapshotFromFile loads a snapshot from a compressed file
-func LoadSnapshotFromFile(path string) (*Snapshot, error) {
-	f, err := os.Open(path) // #nosec G304 -- snapshot path is controlled by caller-facing API and intentionally file-system based
-	if err != nil {
-		return nil, fmt.Errorf("open file: %w", err)
+func (s *Snapshot) writeCompressed(w io.Writer) error {
+	gw := gzip.NewWriter(w)
+	encoder := json.NewEncoder(gw)
+	if err := encoder.Encode(s); err != nil {
+		_ = gw.Close()
+		return fmt.Errorf("encode snapshot: %w", err)
 	}
-	defer func() { _ = f.Close() }()
+	if err := gw.Close(); err != nil {
+		return fmt.Errorf("close compressed snapshot: %w", err)
+	}
+	return nil
+}
 
-	gr, err := gzip.NewReader(f)
+func loadSnapshotFromCompressedReader(r io.Reader) (*Snapshot, error) {
+	gr, err := gzip.NewReader(bufio.NewReader(r))
 	if err != nil {
 		return nil, fmt.Errorf("create gzip reader: %w", err)
 	}
@@ -153,6 +158,17 @@ func LoadSnapshotFromFile(path string) (*Snapshot, error) {
 	}
 
 	return &snapshot, nil
+}
+
+// LoadSnapshotFromFile loads a snapshot from a compressed file
+func LoadSnapshotFromFile(path string) (*Snapshot, error) {
+	f, err := os.Open(path) // #nosec G304 -- snapshot path is controlled by caller-facing API and intentionally file-system based
+	if err != nil {
+		return nil, fmt.Errorf("open file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	return loadSnapshotFromCompressedReader(f)
 }
 
 // SnapshotStore manages graph snapshots
@@ -174,47 +190,74 @@ func NewSnapshotStore(basePath string, maxSnapshots int) *SnapshotStore {
 
 // Save saves a graph snapshot
 func (s *SnapshotStore) Save(g *Graph) error {
+	_, _, err := s.SaveGraph(g)
+	return err
+}
+
+// SaveGraph saves a graph snapshot and returns the typed snapshot record and
+// manifest generated for the newest retained artifact.
+func (s *SnapshotStore) SaveGraph(g *Graph) (*GraphSnapshotRecord, *GraphSnapshotManifest, error) {
 	snapshot := CreateSnapshot(g)
 	filename := fmt.Sprintf("graph-%s.json.gz", snapshot.CreatedAt.Format("20060102-150405.000000000"))
 	path := filepath.Join(s.basePath, filename)
 
 	if err := snapshot.SaveToFile(path); err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	// Clean up old snapshots
 	if err := s.cleanup(); err != nil {
-		return err
+		return nil, nil, err
 	}
-	_, err := s.rebuildSnapshotIndex(nil)
-	return err
+	index, err := s.rebuildSnapshotIndex(nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if index == nil || len(index.Snapshots) == 0 {
+		return nil, nil, fmt.Errorf("snapshot index missing saved record")
+	}
+	manifest := index.Snapshots[len(index.Snapshots)-1]
+	record := manifest.Record
+	return &record, &manifest, nil
 }
 
 // LoadLatest loads the most recent snapshot
 func (s *SnapshotStore) LoadLatest() (*Graph, error) {
-	files, err := filepath.Glob(filepath.Join(s.basePath, "graph-*.json.gz"))
-	if err != nil {
-		return nil, fmt.Errorf("glob snapshots: %w", err)
-	}
-
-	if len(files) == 0 {
-		return nil, fmt.Errorf("no snapshots found")
-	}
-
-	// Find most recent by filename (sorted by timestamp)
-	var latest string
-	for _, f := range files {
-		if f > latest {
-			latest = f
-		}
-	}
-
-	snapshot, err := LoadSnapshotFromFile(latest)
+	snapshot, _, err := s.LoadLatestSnapshot()
 	if err != nil {
 		return nil, err
 	}
 
 	return RestoreFromSnapshot(snapshot), nil
+}
+
+// LoadLatestSnapshot loads the newest retained snapshot and its typed record.
+func (s *SnapshotStore) LoadLatestSnapshot() (*Snapshot, *GraphSnapshotRecord, error) {
+	index, err := s.loadOrRebuildSnapshotIndex()
+	if err != nil {
+		return nil, nil, err
+	}
+	if index == nil || len(index.Snapshots) == 0 {
+		return nil, nil, fmt.Errorf("no snapshots found")
+	}
+	manifest := index.Snapshots[len(index.Snapshots)-1]
+	path := manifest.ArtifactPath
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(s.basePath, path)
+	}
+	snapshot, err := LoadSnapshotFromFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	record := manifest.Record
+	return snapshot, &record, nil
+}
+
+func (s *SnapshotStore) BasePath() string {
+	if s == nil {
+		return ""
+	}
+	return s.basePath
 }
 
 // List returns all available snapshots

--- a/internal/graph/tenant_scope.go
+++ b/internal/graph/tenant_scope.go
@@ -1,0 +1,115 @@
+package graph
+
+import (
+	"sort"
+	"strings"
+)
+
+const tenantPropertyKey = "tenant_id"
+
+func normalizeNodeTenantID(node *Node) {
+	if node == nil {
+		return
+	}
+	tenantID := strings.TrimSpace(node.TenantID)
+	if tenantID == "" && node.Properties != nil {
+		tenantID = strings.TrimSpace(readString(node.Properties, tenantPropertyKey))
+	}
+	node.TenantID = tenantID
+	if tenantID == "" {
+		return
+	}
+	if node.Properties == nil {
+		node.Properties = make(map[string]any, 1)
+	}
+	node.Properties[tenantPropertyKey] = tenantID
+}
+
+func nodeTenantID(node *Node) string {
+	if node == nil {
+		return ""
+	}
+	if tenantID := strings.TrimSpace(node.TenantID); tenantID != "" {
+		return tenantID
+	}
+	if node.Properties == nil {
+		return ""
+	}
+	return strings.TrimSpace(readString(node.Properties, tenantPropertyKey))
+}
+
+// NodeVisibleToTenant returns true when a node is visible to a tenant-scoped query.
+// Empty tenant scope keeps the full graph visible. Untagged nodes are treated as shared.
+func NodeVisibleToTenant(node *Node, tenantID string) bool {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return true
+	}
+	nodeTenant := nodeTenantID(node)
+	return nodeTenant == "" || nodeTenant == tenantID
+}
+
+// SubgraphForTenant returns one graph view scoped to nodes visible to the tenant.
+// Empty tenant scope returns the original graph to avoid unnecessary cloning.
+func (g *Graph) SubgraphForTenant(tenantID string) *Graph {
+	tenantID = strings.TrimSpace(tenantID)
+	if g == nil {
+		return nil
+	}
+	if tenantID == "" {
+		return g
+	}
+
+	out := New()
+	out.SetSchemaValidationMode(g.SchemaValidationMode())
+	for _, node := range g.GetAllNodes() {
+		if !NodeVisibleToTenant(node, tenantID) {
+			continue
+		}
+		out.AddNode(cloneNode(node))
+	}
+	for _, node := range out.GetAllNodes() {
+		for _, edge := range g.GetOutEdges(node.ID) {
+			if edge == nil {
+				continue
+			}
+			if _, ok := out.GetNode(edge.Source); !ok {
+				continue
+			}
+			if _, ok := out.GetNode(edge.Target); !ok {
+				continue
+			}
+			out.AddEdge(cloneEdge(edge))
+		}
+	}
+
+	meta := g.Metadata()
+	meta.NodeCount = out.NodeCount()
+	meta.EdgeCount = out.EdgeCount()
+	meta.Accounts = uniqueNonEmptyNodeStrings(out.GetAllNodes(), func(node *Node) string { return node.Account })
+	meta.Providers = uniqueNonEmptyNodeStrings(out.GetAllNodes(), func(node *Node) string { return node.Provider })
+	out.SetMetadata(meta)
+	out.BuildIndex()
+	return out
+}
+
+func uniqueNonEmptyNodeStrings(nodes []*Node, value func(*Node) string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		candidate := strings.TrimSpace(value(node))
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		out = append(out, candidate)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/graph/tenant_scope_test.go
+++ b/internal/graph/tenant_scope_test.go
@@ -1,0 +1,51 @@
+package graph
+
+import "testing"
+
+func TestAddNodeNormalizesTenantIDFromProperties(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{
+		ID:   "service:payments",
+		Kind: NodeKindService,
+		Properties: map[string]any{
+			"tenant_id": "tenant-a",
+		},
+	})
+
+	node, ok := g.GetNode("service:payments")
+	if !ok {
+		t.Fatal("expected node to be present")
+	}
+	if node.TenantID != "tenant-a" {
+		t.Fatalf("expected tenant_id to normalize onto node, got %q", node.TenantID)
+	}
+	if got := readString(node.Properties, "tenant_id"); got != "tenant-a" {
+		t.Fatalf("expected tenant_id property to remain set, got %q", got)
+	}
+}
+
+func TestSubgraphForTenantFiltersTenantScopedNodes(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "user:shared", Kind: NodeKindUser, Name: "shared"})
+	g.AddNode(&Node{ID: "service:tenant-a", Kind: NodeKindService, Name: "a", TenantID: "tenant-a"})
+	g.AddNode(&Node{ID: "service:tenant-b", Kind: NodeKindService, Name: "b", TenantID: "tenant-b"})
+	g.AddEdge(&Edge{ID: "shared-a", Source: "user:shared", Target: "service:tenant-a", Kind: EdgeKindTargets, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "shared-b", Source: "user:shared", Target: "service:tenant-b", Kind: EdgeKindTargets, Effect: EdgeEffectAllow})
+
+	scoped := g.SubgraphForTenant("tenant-a")
+	if scoped == nil {
+		t.Fatal("expected scoped graph")
+	}
+	if _, ok := scoped.GetNode("service:tenant-a"); !ok {
+		t.Fatal("expected tenant-a node to remain visible")
+	}
+	if _, ok := scoped.GetNode("user:shared"); !ok {
+		t.Fatal("expected shared node to remain visible")
+	}
+	if _, ok := scoped.GetNode("service:tenant-b"); ok {
+		t.Fatal("expected tenant-b node to be filtered out")
+	}
+	if got := len(scoped.GetOutEdges("user:shared")); got != 1 {
+		t.Fatalf("expected only one remaining shared edge, got %d", got)
+	}
+}

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -475,6 +475,14 @@ var (
 		},
 	)
 
+	GraphCrossTenantReadsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cerebro_graph_cross_tenant_reads_total",
+			Help: "Total number of allowed cross-tenant graph reads by operation and bounded access scope",
+		},
+		[]string{"operation", "request_scope", "target_scope", "outcome"},
+	)
+
 	GraphStatePersistenceTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cerebro_graph_state_persistence_total",
@@ -570,6 +578,7 @@ func Register() {
 			GraphCrossTenantIngestSamplesTotal,
 			GraphCrossTenantPatterns,
 			GraphCrossTenantMatches,
+			GraphCrossTenantReadsTotal,
 			GraphStatePersistenceTotal,
 			// Build
 			BuildInfo,
@@ -734,6 +743,26 @@ func RecordGraphCrossTenantMatches(count int) {
 		count = 0
 	}
 	GraphCrossTenantMatches.Set(float64(count))
+}
+
+func RecordGraphCrossTenantRead(operation, requestScope, targetScope, outcome string) {
+	operation = strings.TrimSpace(strings.ToLower(operation))
+	if operation == "" {
+		operation = "unknown"
+	}
+	requestScope = strings.TrimSpace(strings.ToLower(requestScope))
+	if requestScope == "" {
+		requestScope = "unknown"
+	}
+	targetScope = strings.TrimSpace(strings.ToLower(targetScope))
+	if targetScope == "" {
+		targetScope = "unknown"
+	}
+	outcome = strings.TrimSpace(strings.ToLower(outcome))
+	if outcome == "" {
+		outcome = "unknown"
+	}
+	GraphCrossTenantReadsTotal.WithLabelValues(operation, requestScope, targetScope, outcome).Inc()
 }
 
 func RecordGraphStatePersistence(result string) {


### PR DESCRIPTION
## Summary
- add a graph persistence store that separates local snapshot retention from optional replica synchronization and exposes health/status through the app wiring
- thread the persistence store into graph snapshot handlers and temporal tooling so snapshot reads and writes use the new durable substrate
- extend graph snapshot behavior, config, and scaling docs for replica URIs, ownership checks, and persistence health coverage

## Testing
- go test ./internal/graph ./internal/app ./internal/api -count=1
- make devex-pr
- python3 scripts/oss_audit.py
