### PR TITLE
feat(graph): scope tenant graph reads and audit cross-tenant access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ go.work
 *.swp
 *.swo
 .factory/
+**/.cerebro/
 
 # OS
 .DS_Store

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,46 @@
 # Cerebro Intelligence Layer Execution TODO
 
-Last updated: 2026-03-12 (America/Los_Angeles)
+Last updated: 2026-03-13 (America/Los_Angeles)
 Owner: @haasonsaas
 Mode: implement in full, keep CI green
 Status: executed end-to-end via PR workflow
+
+## Deep Review Cycle 69 - Tenant-Scoped Graph Reads and Cross-Tenant Audit Guards (2026-03-13)
+
+### Review findings
+- [x] Gap: issue `#247` still had the classic half-secure shape: tenant context existed in middleware, but the graph/entity/intelligence/risk read surfaces were still free to operate on the full graph.
+- [x] Gap: cross-tenant routes were reachable through generic graph permissions instead of one explicit permission boundary, which made the audit story weaker than the API shape implied.
+- [x] Gap: the right upstream patterns are consistent:
+  - [x] `openfga/openfga` keeps storage/authorization seams explicit instead of relying on ambient context in downstream handlers.
+  - [x] `authzed/spicedb` treats multi-backend datastore structure as a first-class contract, which is the right lead-in for `#250` after tenant scoping is correct.
+  - [x] `dagster-io/dagster` keeps execution/storage boundaries explicit, which matches the current shared execution-store and graph-persistence direction.
+  - [x] the local Wiz schema dump in `/Users/jonathanhaas/Downloads/other/wiz.graphql` reinforces that project/issue/entity surfaces stay usable only when tenant/project boundaries are first-class in the graph substrate.
+
+### Execution plan
+- [x] Add first-class tenant metadata to graph nodes:
+  - [x] add `tenant_id` to `graph.Node`
+  - [x] normalize `tenant_id` from node properties on write
+  - [x] preserve `tenant_id` through cloned/scoped graph views
+- [x] Add one shared tenant-scope graph helper:
+  - [x] add `Graph.SubgraphForTenant(...)`
+  - [x] treat untagged nodes as shared/global for the incremental rollout
+  - [x] rebuild indexes on scoped graph views so entity search/suggest stay correct
+- [x] Enforce tenant-scoped reads on high-value graph surfaces:
+  - [x] platform entity list/search/detail/time-diff
+  - [x] platform intelligence event/risk/report query surfaces
+  - [x] graph risk traversal/query surfaces (`blast-radius`, `attack-paths`, `toxic-combinations`, etc.)
+  - [x] platform knowledge read/diff surfaces
+- [x] Add explicit cross-tenant authorization and audit:
+  - [x] add `platform.cross_tenant.read`
+  - [x] add `platform.cross_tenant.write`
+  - [x] route `/api/v1/graph/cross-tenant/*` through explicit permissions instead of generic graph read/write
+  - [x] add structured audit entries for allowed cross-tenant reads
+  - [x] add Prometheus access counters by operation and requesting/target tenant pair
+- [x] Add regression coverage:
+  - [x] graph tenant normalization/scoping tests
+  - [x] platform entity tenant isolation tests
+  - [x] intelligence/risk tenant isolation tests
+  - [x] cross-tenant audit + metrics tests
 
 ## Deep Review Cycle 68 - Distributed Graph Persistence Foundation and Replica Recovery (2026-03-12)
 
@@ -98,8 +135,8 @@ Status: executed end-to-end via PR workflow
 - [ ] Track B - `#247` tenant/account partitioning
   - Exit criteria:
   - [ ] add tenant/account partition keys to graph snapshot and query paths
-  - [ ] enforce tenant-scoped query guards on platform graph reads
-  - [ ] add explicit audited cross-tenant read/report paths rather than ambient joins
+  - [x] enforce tenant-scoped query guards on platform graph reads
+  - [x] add explicit audited cross-tenant read/report paths rather than ambient joins
 - [ ] Track C - graph persistence backend decision
   - Exit criteria:
   - [ ] keep the hot graph in memory for low-latency traversals

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -380,6 +380,11 @@ func routePermission(method, path string) string {
 		return "sdk.worldmodel.write"
 	case strings.HasPrefix(path, "/api/v1/mcp"):
 		return "sdk.invoke"
+	case strings.HasPrefix(path, "/api/v1/graph/cross-tenant"):
+		if isWrite {
+			return "platform.cross_tenant.write"
+		}
+		return "platform.cross_tenant.read"
 	case isWrite && path == "/api/v1/platform/graph/diffs":
 		return "platform.graph.write"
 	case strings.HasPrefix(path, "/api/v1/platform/graph"):

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -400,6 +400,8 @@ func TestRoutePermissionCoverage(t *testing.T) {
 		{name: "platform intelligence", method: http.MethodGet, path: "/api/v1/platform/intelligence/leverage", expectedRB: "platform.intelligence.read"},
 		{name: "platform intelligence run", method: http.MethodPost, path: "/api/v1/platform/intelligence/reports/quality/runs", expectedRB: "platform.intelligence.run"},
 		{name: "platform graph diff materialize", method: http.MethodPost, path: "/api/v1/platform/graph/diffs", expectedRB: "platform.graph.write"},
+		{name: "cross tenant read", method: http.MethodGet, path: "/api/v1/graph/cross-tenant/patterns", expectedRB: "platform.cross_tenant.read"},
+		{name: "cross tenant write", method: http.MethodPost, path: "/api/v1/graph/cross-tenant/patterns/ingest", expectedRB: "platform.cross_tenant.write"},
 		{name: "platform knowledge read", method: http.MethodGet, path: "/api/v1/platform/knowledge/claims", expectedRB: "platform.knowledge.read"},
 		{name: "platform knowledge write", method: http.MethodPost, path: "/api/v1/platform/knowledge/claims", expectedRB: "platform.knowledge.write"},
 		{name: "org expertise read", method: http.MethodGet, path: "/api/v1/org/expertise/queries", expectedRB: "org.expertise.read"},

--- a/internal/api/server_handlers_graph_cross_tenant.go
+++ b/internal/api/server_handlers_graph_cross_tenant.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/metrics"
+	"github.com/writer/cerebro/internal/snowflake"
 )
 
 type crossTenantBuildRequest struct {
@@ -50,9 +52,11 @@ func (s *Server) buildCrossTenantPatternSamples(w http.ResponseWriter, r *http.R
 
 	samples, err := engine.BuildAnonymizedPatternSamples(req.TenantID, time.Duration(req.WindowDays)*24*time.Hour)
 	if err != nil {
+		s.logCrossTenantRead(r.Context(), r, "build_samples", req.TenantID, 0, "error")
 		s.error(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	s.logCrossTenantRead(r.Context(), r, "build_samples", req.TenantID, len(samples), "allowed")
 	s.json(w, http.StatusOK, map[string]any{
 		"count":   len(samples),
 		"samples": samples,
@@ -130,6 +134,7 @@ func (s *Server) listCrossTenantPatterns(w http.ResponseWriter, r *http.Request)
 
 	patterns := engine.CrossTenantPatterns(minTenants)
 	metrics.RecordGraphCrossTenantPatterns(len(patterns))
+	s.logCrossTenantRead(r.Context(), r, "list_patterns", "aggregate_library", len(patterns), "allowed")
 	s.json(w, http.StatusOK, map[string]any{
 		"count":    len(patterns),
 		"patterns": patterns,
@@ -168,8 +173,86 @@ func (s *Server) matchCrossTenantPatterns(w http.ResponseWriter, r *http.Request
 
 	matches := engine.MatchCrossTenantPatterns(minProbability, limit)
 	metrics.RecordGraphCrossTenantMatches(len(matches))
+	s.logCrossTenantRead(r.Context(), r, "match_patterns", "aggregate_library", len(matches), "allowed")
 	s.json(w, http.StatusOK, map[string]any{
 		"count":   len(matches),
 		"matches": matches,
 	})
+}
+
+func (s *Server) logCrossTenantRead(ctx context.Context, r *http.Request, operation, targetTenant string, resultCount int, outcome string) {
+	requestingTenant := strings.TrimSpace(GetTenantID(ctx))
+	auditRequestingTenant := requestingTenant
+	if auditRequestingTenant == "" {
+		auditRequestingTenant = "unknown"
+	}
+	targetTenant = strings.TrimSpace(targetTenant)
+	auditTargetTenant := targetTenant
+	if auditTargetTenant == "" {
+		auditTargetTenant = "unknown"
+	}
+	outcome = strings.TrimSpace(strings.ToLower(outcome))
+	if outcome == "" {
+		outcome = "unknown"
+	}
+
+	metrics.RecordGraphCrossTenantRead(
+		operation,
+		crossTenantRequestScope(requestingTenant),
+		crossTenantTargetScope(targetTenant),
+		outcome,
+	)
+
+	details := map[string]any{
+		"requesting_tenant": auditRequestingTenant,
+		"target_tenant":     auditTargetTenant,
+		"operation":         strings.TrimSpace(operation),
+		"result_count":      resultCount,
+		"outcome":           outcome,
+		"timestamp":         time.Now().UTC().Format(time.RFC3339Nano),
+	}
+
+	if auditLoggerIsNil(s.auditLogger) {
+		if s.app != nil && s.app.Logger != nil {
+			s.app.Logger.Info("cross-tenant graph read", "requesting_tenant", auditRequestingTenant, "target_tenant", auditTargetTenant, "operation", operation, "result_count", resultCount, "outcome", outcome)
+		}
+		return
+	}
+
+	actorID := strings.TrimSpace(GetUserID(ctx))
+	if actorID == "" {
+		actorID = "api"
+	}
+	entry := &snowflake.AuditEntry{
+		Action:       "graph.cross_tenant.read",
+		ActorID:      actorID,
+		ActorType:    "user",
+		ResourceType: "graph_cross_tenant",
+		ResourceID:   strings.TrimSpace(operation) + ":" + auditTargetTenant,
+		Details:      details,
+		IPAddress:    r.RemoteAddr,
+		UserAgent:    r.UserAgent(),
+	}
+	if err := s.auditLogger.Log(ctx, entry); err != nil && s.app != nil && s.app.Logger != nil {
+		s.app.Logger.Warn("failed to persist cross-tenant graph audit log", "error", err, "operation", operation, "requesting_tenant", auditRequestingTenant, "target_tenant", auditTargetTenant)
+	}
+}
+
+func crossTenantRequestScope(requestingTenant string) string {
+	if strings.TrimSpace(requestingTenant) == "" {
+		return "global"
+	}
+	return "tenant"
+}
+
+func crossTenantTargetScope(targetTenant string) string {
+	targetTenant = strings.TrimSpace(targetTenant)
+	switch targetTenant {
+	case "":
+		return "unknown"
+	case "aggregate_library":
+		return "aggregate"
+	default:
+		return "tenant"
+	}
 }

--- a/internal/api/server_handlers_graph_intelligence.go
+++ b/internal/api/server_handlers_graph_intelligence.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -18,15 +19,15 @@ func (s *Server) graphIntelligenceEventPatterns(w http.ResponseWriter, _ *http.R
 	s.json(w, http.StatusOK, graph.EventCorrelationPatternCatalogSnapshot(time.Now().UTC()))
 }
 
-func (s *Server) currentGraphIntelligenceGraph() *graph.Graph {
+func (s *Server) currentGraphIntelligenceGraph(ctx context.Context) *graph.Graph {
 	if s == nil || s.graphIntelligence == nil {
 		return nil
 	}
-	return s.graphIntelligence.CurrentGraph()
+	return s.tenantScopedGraph(ctx, s.graphIntelligence.CurrentGraph())
 }
 
 func (s *Server) graphIntelligenceEventCorrelations(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -79,6 +80,18 @@ func (s *Server) graphIntelligenceEventCorrelations(w http.ResponseWriter, r *ht
 		s.error(w, http.StatusBadRequest, "event_id or entity_id is required")
 		return
 	}
+	if eventID != "" {
+		if _, ok := g.GetNode(eventID); !ok {
+			s.error(w, http.StatusNotFound, "event not found in selected scope")
+			return
+		}
+	}
+	if entityID != "" {
+		if _, ok := g.GetNode(entityID); !ok {
+			s.error(w, http.StatusNotFound, "entity not found in selected scope")
+			return
+		}
+	}
 
 	result := graph.QueryEventCorrelations(g, time.Now().UTC(), graph.EventCorrelationQuery{
 		EventID:          eventID,
@@ -93,7 +106,7 @@ func (s *Server) graphIntelligenceEventCorrelations(w http.ResponseWriter, r *ht
 }
 
 func (s *Server) graphIntelligenceEventAnomalies(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -135,13 +148,13 @@ func (s *Server) graphIntelligenceEventAnomalies(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) graphIntelligenceInsights(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 
-	engine := s.graphRiskEngine()
+	engine := s.currentTenantRiskEngine(r.Context())
 	if engine == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -247,7 +260,7 @@ func (s *Server) graphIntelligenceInsights(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) graphIntelligenceQuality(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -292,7 +305,7 @@ func (s *Server) graphIntelligenceQuality(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) graphIntelligenceMetadataQuality(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -315,7 +328,7 @@ func (s *Server) graphIntelligenceMetadataQuality(w http.ResponseWriter, r *http
 }
 
 func (s *Server) graphIntelligenceClaimConflicts(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -382,7 +395,7 @@ func (s *Server) graphIntelligenceClaimConflicts(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) graphIntelligenceEntitySummary(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -391,6 +404,10 @@ func (s *Server) graphIntelligenceEntitySummary(w http.ResponseWriter, r *http.R
 	entityID := strings.TrimSpace(r.URL.Query().Get("entity_id"))
 	if entityID == "" {
 		s.error(w, http.StatusBadRequest, "entity_id is required")
+		return
+	}
+	if _, ok := g.GetNode(entityID); !ok {
+		s.error(w, http.StatusNotFound, "entity not found in selected scope")
 		return
 	}
 
@@ -429,7 +446,7 @@ func (s *Server) graphIntelligenceEntitySummary(w http.ResponseWriter, r *http.R
 }
 
 func (s *Server) graphIntelligenceLeverage(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -660,12 +677,12 @@ func (s *Server) graphIngestContracts(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) graphIntelligenceWeeklyCalibration(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
-	engine := s.graphRiskEngine()
+	engine := s.currentTenantRiskEngine(r.Context())
 	if engine == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -810,7 +827,7 @@ type graphQueryNeighborResult struct {
 }
 
 func (s *Server) graphQuery(w http.ResponseWriter, r *http.Request) {
-	g := s.currentGraphIntelligenceGraph()
+	g := s.currentGraphIntelligenceGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return

--- a/internal/api/server_handlers_graph_risk.go
+++ b/internal/api/server_handlers_graph_risk.go
@@ -10,12 +10,13 @@ import (
 )
 
 func (s *Server) graphStats(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 
-	meta := s.app.SecurityGraph.Metadata()
+	meta := g.Metadata()
 	s.json(w, http.StatusOK, map[string]interface{}{
 		"built_at":       meta.BuiltAt,
 		"node_count":     meta.NodeCount,
@@ -27,7 +28,8 @@ func (s *Server) graphStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) blastRadius(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
@@ -45,12 +47,13 @@ func (s *Server) blastRadius(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result := graph.BlastRadius(s.app.SecurityGraph, principalID, maxDepth)
+	result := graph.BlastRadius(g, principalID, maxDepth)
 	s.json(w, http.StatusOK, result)
 }
 
 func (s *Server) cascadingBlastRadius(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
@@ -68,12 +71,13 @@ func (s *Server) cascadingBlastRadius(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result := graph.CascadingBlastRadius(s.app.SecurityGraph, principalID, maxDepth)
+	result := graph.CascadingBlastRadius(g, principalID, maxDepth)
 	s.json(w, http.StatusOK, result)
 }
 
 func (s *Server) reverseAccess(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
@@ -91,7 +95,7 @@ func (s *Server) reverseAccess(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result := graph.ReverseAccess(s.app.SecurityGraph, resourceID, maxDepth)
+	result := graph.ReverseAccess(g, resourceID, maxDepth)
 	s.json(w, http.StatusOK, result)
 }
 
@@ -119,30 +123,36 @@ func (s *Server) rebuildGraph(w http.ResponseWriter, r *http.Request) {
 // Risk Intelligence endpoints
 
 func (s *Server) riskReport(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 
-	engine := s.graphRiskEngine()
+	engine := s.currentTenantRiskEngine(r.Context())
 	if engine == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 	report := engine.Analyze()
-	s.persistRiskEngineState(r.Context(), engine)
+	// Persist only for global requests. Context-derived scope is stable even if the
+	// live graph pointer changes during a concurrent rebuild.
+	if !requestUsesTenantScope(r.Context()) {
+		s.persistRiskEngineState(r.Context(), engine)
+	}
 	s.json(w, http.StatusOK, report)
 }
 
 func (s *Server) listToxicCombinations(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 	pagination := ParsePagination(r, 100, 1000)
 
 	engine := graph.NewToxicCombinationEngine()
-	results := engine.Analyze(s.app.SecurityGraph)
+	results := engine.Analyze(g)
 
 	// Filter by severity if requested
 	severityFilter := r.URL.Query().Get("severity")
@@ -168,12 +178,13 @@ func (s *Server) listToxicCombinations(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listGraphAttackPaths(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 
-	simulator := graph.NewAttackPathSimulator(s.app.SecurityGraph)
+	simulator := graph.NewAttackPathSimulator(g)
 
 	maxDepth := 6
 	if depthStr := r.URL.Query().Get("max_depth"); depthStr != "" {
@@ -217,7 +228,8 @@ func (s *Server) listGraphAttackPaths(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) simulateAttackPathFix(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
@@ -228,7 +240,7 @@ func (s *Server) simulateAttackPathFix(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	simulator := graph.NewAttackPathSimulator(s.app.SecurityGraph)
+	simulator := graph.NewAttackPathSimulator(g)
 	result := simulator.Simulate(6)
 	fixSim := simulator.SimulateFix(result, nodeID)
 
@@ -236,12 +248,13 @@ func (s *Server) simulateAttackPathFix(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listChokepoints(w http.ResponseWriter, r *http.Request) {
-	if s.app.SecurityGraph == nil {
+	g := s.currentTenantSecurityGraph(r.Context())
+	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
 	}
 
-	simulator := graph.NewAttackPathSimulator(s.app.SecurityGraph)
+	simulator := graph.NewAttackPathSimulator(g)
 	result := simulator.Simulate(6)
 
 	limit := 20

--- a/internal/api/server_handlers_graph_tenant_scope_test.go
+++ b/internal/api/server_handlers_graph_tenant_scope_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/metrics"
+	"github.com/writer/cerebro/internal/snowflake"
+)
+
+func doWithTenantContext(t *testing.T, s *Server, method, path string, body any, tenantID string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		reader = bytes.NewReader(payload)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req = req.WithContext(context.WithValue(req.Context(), contextKeyTenant, tenantID))
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	return w
+}
+
+func TestGraphRiskHandlersUseTenantScopedGraph(t *testing.T) {
+	s := newTestServer(t)
+	g := s.app.SecurityGraph
+	g.AddNode(&graph.Node{ID: "user:shared", Kind: graph.NodeKindUser, Name: "Shared User"})
+	g.AddNode(&graph.Node{ID: "service:tenant-a", Kind: graph.NodeKindService, Name: "Tenant A", TenantID: "tenant-a"})
+	g.AddNode(&graph.Node{ID: "service:tenant-b", Kind: graph.NodeKindService, Name: "Tenant B", TenantID: "tenant-b"})
+	g.AddEdge(&graph.Edge{ID: "shared-a", Source: "user:shared", Target: "service:tenant-a", Kind: graph.EdgeKindCanRead, Effect: graph.EdgeEffectAllow})
+	g.AddEdge(&graph.Edge{ID: "shared-b", Source: "user:shared", Target: "service:tenant-b", Kind: graph.EdgeKindCanRead, Effect: graph.EdgeEffectAllow})
+
+	resp := doWithTenantContext(t, s, http.MethodGet, "/api/v1/graph/blast-radius/user:shared?max_depth=2", nil, "tenant-a")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected tenant-scoped blast radius 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	body := decodeJSON(t, resp)
+	reachable, ok := body["reachable_nodes"].([]any)
+	if !ok || len(reachable) != 1 {
+		t.Fatalf("expected one tenant-visible reachable node, got %#v", body["reachable_nodes"])
+	}
+	node := reachable[0].(map[string]any)["node"].(map[string]any)
+	if node["id"] != "service:tenant-a" {
+		t.Fatalf("expected tenant-a node only, got %#v", node)
+	}
+}
+
+func TestGraphIntelligenceHandlersUseTenantScopedGraph(t *testing.T) {
+	s := newTestServer(t)
+	g := s.app.SecurityGraph
+	base := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
+	g.AddNode(&graph.Node{ID: "service:tenant-a", Kind: graph.NodeKindService, Name: "Tenant A", TenantID: "tenant-a"})
+	g.AddNode(&graph.Node{ID: "service:tenant-b", Kind: graph.NodeKindService, Name: "Tenant B", TenantID: "tenant-b"})
+	g.AddNode(&graph.Node{
+		ID:       "pull_request:tenant-b:42",
+		Kind:     graph.NodeKindPullRequest,
+		TenantID: "tenant-b",
+		Properties: map[string]any{
+			"repository":  "tenant-b",
+			"number":      "42",
+			"state":       "merged",
+			"observed_at": base.Format(time.RFC3339),
+			"valid_from":  base.Format(time.RFC3339),
+		},
+	})
+	g.AddNode(&graph.Node{
+		ID:       "deployment:tenant-b:deploy-1",
+		Kind:     graph.NodeKindDeploymentRun,
+		TenantID: "tenant-b",
+		Properties: map[string]any{
+			"deploy_id":   "deploy-1",
+			"service_id":  "tenant-b",
+			"environment": "prod",
+			"status":      "succeeded",
+			"observed_at": base.Add(5 * time.Minute).Format(time.RFC3339),
+			"valid_from":  base.Add(5 * time.Minute).Format(time.RFC3339),
+		},
+	})
+	g.AddNode(&graph.Node{
+		ID:       "incident:tenant-b:1",
+		Kind:     graph.NodeKindIncident,
+		TenantID: "tenant-b",
+		Properties: map[string]any{
+			"incident_id": "incident-b-1",
+			"service_id":  "tenant-b",
+			"observed_at": base.Add(7 * time.Minute).Format(time.RFC3339),
+			"valid_from":  base.Add(7 * time.Minute).Format(time.RFC3339),
+		},
+	})
+	g.AddEdge(&graph.Edge{ID: "pr-b-service", Source: "pull_request:tenant-b:42", Target: "service:tenant-b", Kind: graph.EdgeKindTargets, Effect: graph.EdgeEffectAllow})
+	g.AddEdge(&graph.Edge{ID: "deploy-b-service", Source: "deployment:tenant-b:deploy-1", Target: "service:tenant-b", Kind: graph.EdgeKindTargets, Effect: graph.EdgeEffectAllow})
+	g.AddEdge(&graph.Edge{ID: "incident-b-service", Source: "incident:tenant-b:1", Target: "service:tenant-b", Kind: graph.EdgeKindTargets, Effect: graph.EdgeEffectAllow})
+	graph.MaterializeEventCorrelations(g, base.Add(10*time.Minute))
+
+	resp := doWithTenantContext(t, s, http.MethodGet, "/api/v1/platform/intelligence/event-correlations?event_id=incident:tenant-b:1&limit=10", nil, "tenant-a")
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected tenant-scoped event correlation lookup to hide foreign tenant event, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestCrossTenantReadOperationsEmitAuditAndMetrics(t *testing.T) {
+	s := newTestServer(t)
+	s.auditLogger = &captureAuditLogger{}
+	seedGraphRiskFeedbackGraph(s.app.SecurityGraph)
+
+	for i := 0; i < 5; i++ {
+		w := do(t, s, http.MethodGet, "/api/v1/graph/risk-report", nil)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected risk report 200, got %d: %s", w.Code, w.Body.String())
+		}
+	}
+	record := do(t, s, http.MethodPost, "/api/v1/graph/outcomes", map[string]any{
+		"entity_id":   "customer:acme",
+		"outcome":     "churn",
+		"occurred_at": time.Now().UTC().Add(4 * time.Hour),
+	})
+	if record.Code != http.StatusOK {
+		t.Fatalf("expected outcome record 200, got %d: %s", record.Code, record.Body.String())
+	}
+
+	build := doWithTenantContext(t, s, http.MethodPost, "/api/v1/graph/cross-tenant/patterns/build", map[string]any{
+		"tenant_id":   "tenant-beta",
+		"window_days": 365,
+	}, "tenant-admin")
+	if build.Code != http.StatusOK {
+		t.Fatalf("expected build response 200, got %d: %s", build.Code, build.Body.String())
+	}
+	list := doWithTenantContext(t, s, http.MethodGet, "/api/v1/graph/cross-tenant/patterns", nil, "tenant-admin")
+	if list.Code != http.StatusOK {
+		t.Fatalf("expected list response 200, got %d: %s", list.Code, list.Body.String())
+	}
+
+	logger := s.auditLogger.(*captureAuditLogger)
+	if len(logger.entries) != 2 {
+		t.Fatalf("expected two cross-tenant audit entries, got %d", len(logger.entries))
+	}
+	entry := logger.entries[0]
+	if entry.Action != "graph.cross_tenant.read" {
+		t.Fatalf("expected cross-tenant audit action, got %#v", entry.Action)
+	}
+	if entry.Details["requesting_tenant"] != "tenant-admin" || entry.Details["target_tenant"] != "tenant-beta" {
+		t.Fatalf("unexpected audit details: %#v", entry.Details)
+	}
+	if logger.entries[1].Details["target_tenant"] != "aggregate_library" {
+		t.Fatalf("expected aggregate-library audit detail, got %#v", logger.entries[1].Details)
+	}
+
+	metric := metrics.GraphCrossTenantReadsTotal.WithLabelValues("build_samples", "tenant", "tenant", "allowed")
+	snapshot := &dto.Metric{}
+	if err := metric.Write(snapshot); err != nil {
+		t.Fatalf("read metric: %v", err)
+	}
+	if got := snapshot.GetCounter().GetValue(); got < 1 {
+		t.Fatalf("expected cross-tenant metric increment, got %f", got)
+	}
+
+	aggregateMetric := metrics.GraphCrossTenantReadsTotal.WithLabelValues("list_patterns", "tenant", "aggregate", "allowed")
+	aggregateSnapshot := &dto.Metric{}
+	if err := aggregateMetric.Write(aggregateSnapshot); err != nil {
+		t.Fatalf("read aggregate metric: %v", err)
+	}
+	if got := aggregateSnapshot.GetCounter().GetValue(); got < 1 {
+		t.Fatalf("expected aggregate cross-tenant metric increment, got %f", got)
+	}
+}
+
+func TestRiskReportPersistsOnlyForGlobalRequests(t *testing.T) {
+	s := newTestServer(t)
+	seedGraphRiskFeedbackGraph(s.app.SecurityGraph)
+	s.app.RiskEngineStateRepo = &snowflake.RiskEngineStateRepository{}
+
+	saveFailed := metrics.GraphStatePersistenceTotal.WithLabelValues("save_failed")
+	before := &dto.Metric{}
+	if err := saveFailed.Write(before); err != nil {
+		t.Fatalf("read initial persistence metric: %v", err)
+	}
+
+	global := do(t, s, http.MethodGet, "/api/v1/graph/risk-report", nil)
+	if global.Code != http.StatusOK {
+		t.Fatalf("expected global risk report 200, got %d: %s", global.Code, global.Body.String())
+	}
+
+	afterGlobal := &dto.Metric{}
+	if err := saveFailed.Write(afterGlobal); err != nil {
+		t.Fatalf("read global persistence metric: %v", err)
+	}
+	if afterGlobal.GetCounter().GetValue() <= before.GetCounter().GetValue() {
+		t.Fatalf("expected global risk report to attempt persistence, before=%f after=%f", before.GetCounter().GetValue(), afterGlobal.GetCounter().GetValue())
+	}
+
+	tenant := doWithTenantContext(t, s, http.MethodGet, "/api/v1/graph/risk-report", nil, "tenant-a")
+	if tenant.Code != http.StatusOK {
+		t.Fatalf("expected tenant risk report 200, got %d: %s", tenant.Code, tenant.Body.String())
+	}
+
+	afterTenant := &dto.Metric{}
+	if err := saveFailed.Write(afterTenant); err != nil {
+		t.Fatalf("read tenant persistence metric: %v", err)
+	}
+	if afterTenant.GetCounter().GetValue() != afterGlobal.GetCounter().GetValue() {
+		t.Fatalf("expected tenant-scoped risk report to skip persistence, global=%f tenant=%f", afterGlobal.GetCounter().GetValue(), afterTenant.GetCounter().GetValue())
+	}
+}

--- a/internal/api/server_handlers_platform_entities.go
+++ b/internal/api/server_handlers_platform_entities.go
@@ -20,7 +20,7 @@ func platformEntityQueryLengthExceeds(value string) bool {
 }
 
 func (s *Server) listPlatformEntities(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -36,7 +36,7 @@ func (s *Server) listPlatformEntities(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) searchPlatformEntities(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -51,7 +51,7 @@ func (s *Server) searchPlatformEntities(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) suggestPlatformEntities(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -84,7 +84,7 @@ func (s *Server) getPlatformEntityFacet(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) getPlatformEntity(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -116,7 +116,7 @@ func (s *Server) getPlatformEntity(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getPlatformEntityAtTime(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -147,7 +147,7 @@ func (s *Server) getPlatformEntityAtTime(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) getPlatformEntityTimeDiff(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return

--- a/internal/api/server_handlers_platform_entities_test.go
+++ b/internal/api/server_handlers_platform_entities_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -299,6 +301,49 @@ func TestPlatformEntitySearchAndSuggest(t *testing.T) {
 	suggestion := suggestBody["suggestions"].([]any)[0].(map[string]any)
 	if suggestion["entity_id"] != "person:alice@example.com" {
 		t.Fatalf("expected alice suggestion, got %#v", suggestion)
+	}
+}
+
+func TestPlatformEntitiesAreTenantScoped(t *testing.T) {
+	s := newTestServer(t)
+	g := s.app.SecurityGraph
+	g.AddNode(&graph.Node{ID: "service:tenant-a", Kind: graph.NodeKindService, Name: "Tenant A", TenantID: "tenant-a"})
+	g.AddNode(&graph.Node{ID: "service:tenant-b", Kind: graph.NodeKindService, Name: "Tenant B", TenantID: "tenant-b"})
+	g.AddNode(&graph.Node{ID: "service:shared", Kind: graph.NodeKindService, Name: "Shared"})
+	g.BuildIndex()
+
+	doWithTenant := func(path, tenantID string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req = req.WithContext(context.WithValue(req.Context(), contextKeyTenant, tenantID))
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, req)
+		return w
+	}
+
+	list := doWithTenant("/api/v1/platform/entities?category=resource&limit=10", "tenant-a")
+	if list.Code != http.StatusOK {
+		t.Fatalf("expected tenant-scoped list 200, got %d: %s", list.Code, list.Body.String())
+	}
+	body := decodeJSON(t, list)
+	entities, ok := body["entities"].([]any)
+	if !ok || len(entities) != 2 {
+		t.Fatalf("expected shared and tenant-a entities only, got %#v", body["entities"])
+	}
+	if list.Body.String() == "" || strings.Contains(list.Body.String(), "service:tenant-b") {
+		t.Fatalf("expected tenant-b entity to be excluded, got %s", list.Body.String())
+	}
+
+	search := doWithTenant("/api/v1/platform/entities/search?q=tenant&limit=10", "tenant-a")
+	if search.Code != http.StatusOK {
+		t.Fatalf("expected tenant-scoped search 200, got %d: %s", search.Code, search.Body.String())
+	}
+	if strings.Contains(search.Body.String(), "service:tenant-b") {
+		t.Fatalf("expected tenant-b search result to be excluded, got %s", search.Body.String())
+	}
+
+	detail := doWithTenant("/api/v1/platform/entities/service:tenant-b", "tenant-a")
+	if detail.Code != http.StatusNotFound {
+		t.Fatalf("expected tenant-b detail to be hidden, got %d: %s", detail.Code, detail.Body.String())
 	}
 }
 

--- a/internal/api/server_handlers_platform_graph_snapshots_test.go
+++ b/internal/api/server_handlers_platform_graph_snapshots_test.go
@@ -19,7 +19,7 @@ func TestPlatformGraphSnapshotAncestryAndDiffEndpoints(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAPH_SNAPSHOT_PATH", dir)
 
-	base := time.Date(2026, 3, 7, 0, 0, 0, 0, time.UTC)
+	base := time.Now().UTC().Add(-6 * 24 * time.Hour).Truncate(time.Minute)
 	older := &graph.Snapshot{
 		Version:   "1.0",
 		CreatedAt: base.Add(5 * time.Minute),
@@ -395,7 +395,7 @@ func TestPlatformGraphChangelogAndDiffDetailsEndpoints(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAPH_SNAPSHOT_PATH", dir)
 
-	base := time.Date(2026, 3, 7, 0, 0, 0, 0, time.UTC)
+	base := time.Now().UTC().Add(-6 * 24 * time.Hour).Truncate(time.Minute)
 	older := &graph.Snapshot{
 		Version:   "1.0",
 		CreatedAt: base.Add(5 * time.Minute),
@@ -526,7 +526,7 @@ func TestPlatformGraphChangelogUsesExplicitParentSnapshotLineage(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAPH_SNAPSHOT_PATH", dir)
 
-	base := time.Date(2026, 3, 7, 7, 0, 0, 0, time.UTC)
+	base := time.Now().UTC().Add(-6 * 24 * time.Hour).Truncate(time.Minute)
 	root := &graph.Snapshot{
 		Version:   "1.0",
 		CreatedAt: base.Add(5 * time.Minute),

--- a/internal/api/server_handlers_platform_knowledge.go
+++ b/internal/api/server_handlers_platform_knowledge.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *Server) listPlatformKnowledgeClaims(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -30,7 +30,7 @@ func (s *Server) listPlatformKnowledgeClaims(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) listPlatformKnowledgeEvidence(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -50,7 +50,7 @@ func (s *Server) getPlatformKnowledgeEvidence(w http.ResponseWriter, r *http.Req
 }
 
 func (s *Server) listPlatformKnowledgeObservations(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -70,7 +70,7 @@ func (s *Server) getPlatformKnowledgeObservation(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) getPlatformKnowledgeClaim(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -102,7 +102,7 @@ func (s *Server) getPlatformKnowledgeClaim(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) listPlatformKnowledgeClaimGroups(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -118,7 +118,7 @@ func (s *Server) listPlatformKnowledgeClaimGroups(w http.ResponseWriter, r *http
 }
 
 func (s *Server) getPlatformKnowledgeClaimGroup(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -155,7 +155,7 @@ func (s *Server) getPlatformKnowledgeClaimGroup(w http.ResponseWriter, r *http.R
 }
 
 func (s *Server) getPlatformKnowledgeClaimTimeline(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -182,7 +182,7 @@ func (s *Server) getPlatformKnowledgeClaimTimeline(w http.ResponseWriter, r *htt
 }
 
 func (s *Server) getPlatformKnowledgeClaimExplanation(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -214,7 +214,7 @@ func (s *Server) getPlatformKnowledgeClaimExplanation(w http.ResponseWriter, r *
 }
 
 func (s *Server) getPlatformKnowledgeClaimProofs(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -241,7 +241,7 @@ func (s *Server) getPlatformKnowledgeClaimProofs(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) listPlatformKnowledgeClaimDiffs(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -257,7 +257,7 @@ func (s *Server) listPlatformKnowledgeClaimDiffs(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) listPlatformKnowledgeDiffs(w http.ResponseWriter, r *http.Request) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return
@@ -287,8 +287,8 @@ func (s *Server) listPlatformKnowledgeDiffs(w http.ResponseWriter, r *http.Reque
 			}
 			return
 		}
-		fromGraph = graph.GraphViewFromSnapshot(snapshots[opts.FromSnapshotID])
-		toGraph = graph.GraphViewFromSnapshot(snapshots[opts.ToSnapshotID])
+		fromGraph = s.tenantScopedGraph(r.Context(), graph.GraphViewFromSnapshot(snapshots[opts.FromSnapshotID]))
+		toGraph = s.tenantScopedGraph(r.Context(), graph.GraphViewFromSnapshot(snapshots[opts.ToSnapshotID]))
 		opts.FromValidAt = snapshotKnowledgeComparisonTime(snapshots[opts.FromSnapshotID], records[opts.FromSnapshotID])
 		opts.FromRecordedAt = opts.FromValidAt
 		opts.ToValidAt = snapshotKnowledgeComparisonTime(snapshots[opts.ToSnapshotID], records[opts.ToSnapshotID])
@@ -309,6 +309,12 @@ func (s *Server) adjudicatePlatformKnowledgeClaimGroup(w http.ResponseWriter, r 
 	if groupID == "" {
 		s.error(w, http.StatusBadRequest, "group id required")
 		return
+	}
+	if scoped := s.currentTenantSecurityGraph(r.Context()); scoped != nil {
+		if _, ok := graph.GetClaimGroupRecord(scoped, groupID, time.Time{}, time.Time{}, true); !ok {
+			s.error(w, http.StatusNotFound, "claim group not found")
+			return
+		}
 	}
 
 	var req graph.ClaimAdjudicationWriteRequest
@@ -674,7 +680,7 @@ func parsePlatformKnowledgeDiffQueryOptions(r *http.Request) (graph.KnowledgeDif
 }
 
 func (s *Server) getPlatformKnowledgeArtifact(w http.ResponseWriter, r *http.Request, kind graph.NodeKind) {
-	g := s.app.CurrentSecurityGraph()
+	g := s.currentTenantSecurityGraph(r.Context())
 	if g == nil {
 		s.error(w, http.StatusServiceUnavailable, "graph platform not initialized")
 		return

--- a/internal/api/tenant_graph.go
+++ b/internal/api/tenant_graph.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"context"
+	"strings"
+
+	"github.com/writer/cerebro/internal/graph"
+)
+
+func (s *Server) tenantScopedGraph(ctx context.Context, g *graph.Graph) *graph.Graph {
+	if s == nil || g == nil {
+		return nil
+	}
+	tenantID := currentTenantScopeID(ctx)
+	return g.SubgraphForTenant(tenantID)
+}
+
+func currentTenantScopeID(ctx context.Context) string {
+	return strings.TrimSpace(GetTenantID(ctx))
+}
+
+func requestUsesTenantScope(ctx context.Context) bool {
+	return currentTenantScopeID(ctx) != ""
+}
+
+func (s *Server) currentTenantSecurityGraph(ctx context.Context) *graph.Graph {
+	if s == nil || s.app == nil {
+		return nil
+	}
+	return s.tenantScopedGraph(ctx, s.app.CurrentSecurityGraph())
+}
+
+func (s *Server) currentTenantRiskEngine(ctx context.Context) *graph.RiskEngine {
+	if s == nil || s.app == nil {
+		return nil
+	}
+	if !requestUsesTenantScope(ctx) {
+		return s.graphRiskEngine()
+	}
+	g := s.currentTenantSecurityGraph(ctx)
+	if g == nil {
+		return nil
+	}
+	engine := graph.NewRiskEngine(g)
+	if s.app.Config != nil {
+		engine.SetCrossTenantPrivacyConfig(graph.CrossTenantPrivacyConfig{
+			MinTenantCount:    s.app.Config.GraphCrossTenantMinTenants,
+			MinPatternSupport: s.app.Config.GraphCrossTenantMinSupport,
+		})
+	}
+	return engine
+}

--- a/internal/app/app_cerebro_tools_temporal_test.go
+++ b/internal/app/app_cerebro_tools_temporal_test.go
@@ -96,7 +96,7 @@ func TestCerebroGraphChangelogTool(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAPH_SNAPSHOT_PATH", dir)
 
-	base := time.Date(2026, 3, 7, 0, 0, 0, 0, time.UTC)
+	base := time.Now().UTC().Add(-6 * 24 * time.Hour).Truncate(time.Minute)
 	older := &graph.Snapshot{
 		Version:   "1.0",
 		CreatedAt: base.Add(5 * time.Minute),

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -266,6 +266,8 @@ func defaultPermissions() []Permission {
 
 		{ID: "platform.graph.read", Resource: "platform.graph", Action: "read"},
 		{ID: "platform.graph.write", Resource: "platform.graph", Action: "write"},
+		{ID: "platform.cross_tenant.read", Resource: "platform.cross_tenant", Action: "read"},
+		{ID: "platform.cross_tenant.write", Resource: "platform.cross_tenant", Action: "write"},
 		{ID: "platform.intelligence.read", Resource: "platform.intelligence", Action: "read"},
 		{ID: "platform.intelligence.run", Resource: "platform.intelligence", Action: "run"},
 		{ID: "platform.jobs.read", Resource: "platform.jobs", Action: "read"},
@@ -332,7 +334,7 @@ func defaultAdminRolePermissions() []string {
 		"assets:read", "compliance:read", "compliance:export",
 		"admin:users", "admin:roles",
 
-		"platform.graph.read", "platform.graph.write", "platform.intelligence.read",
+		"platform.graph.read", "platform.graph.write", "platform.cross_tenant.read", "platform.cross_tenant.write", "platform.intelligence.read",
 		"platform.intelligence.run",
 		"platform.jobs.read", "platform.knowledge.read", "platform.knowledge.write", "platform.workflow.write",
 		"platform.schema.read", "platform.schema.manage", "platform.identity.review",

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -791,6 +791,7 @@ func (g *Graph) GetResourceNodesByARNPrefix(prefix string) []*Node {
 }
 
 func (g *Graph) addNodeLocked(node *Node) bool {
+	normalizeNodeTenantID(node)
 	if !g.applyNodeSchemaValidationLocked(node) {
 		return false
 	}

--- a/internal/graph/node.go
+++ b/internal/graph/node.go
@@ -110,6 +110,7 @@ type Node struct {
 	ID                 string                        `json:"id"`
 	Kind               NodeKind                      `json:"kind"`
 	Name               string                        `json:"name"`
+	TenantID           string                        `json:"tenant_id,omitempty"`
 	Provider           string                        `json:"provider"`
 	Account            string                        `json:"account"`
 	Region             string                        `json:"region,omitempty"`

--- a/internal/graph/reports/intelligence_report_test.go
+++ b/internal/graph/reports/intelligence_report_test.go
@@ -126,7 +126,7 @@ func TestBuildIntelligenceReport_DeterministicInsightOrderAndIDs(t *testing.T) {
 }
 
 func TestBuildIntelligenceReport_FreshnessPenalizesConfidence(t *testing.T) {
-	now := time.Date(2026, 3, 8, 22, 0, 0, 0, time.UTC)
+	now := time.Now().UTC().Truncate(time.Second)
 
 	fresh := New()
 	fresh.AddNode(&Node{ID: "service:fresh", Kind: NodeKindService, Name: "Fresh", Properties: map[string]any{

--- a/internal/graph/tenant_scope.go
+++ b/internal/graph/tenant_scope.go
@@ -1,0 +1,115 @@
+package graph
+
+import (
+	"sort"
+	"strings"
+)
+
+const tenantPropertyKey = "tenant_id"
+
+func normalizeNodeTenantID(node *Node) {
+	if node == nil {
+		return
+	}
+	tenantID := strings.TrimSpace(node.TenantID)
+	if tenantID == "" && node.Properties != nil {
+		tenantID = strings.TrimSpace(readString(node.Properties, tenantPropertyKey))
+	}
+	node.TenantID = tenantID
+	if tenantID == "" {
+		return
+	}
+	if node.Properties == nil {
+		node.Properties = make(map[string]any, 1)
+	}
+	node.Properties[tenantPropertyKey] = tenantID
+}
+
+func nodeTenantID(node *Node) string {
+	if node == nil {
+		return ""
+	}
+	if tenantID := strings.TrimSpace(node.TenantID); tenantID != "" {
+		return tenantID
+	}
+	if node.Properties == nil {
+		return ""
+	}
+	return strings.TrimSpace(readString(node.Properties, tenantPropertyKey))
+}
+
+// NodeVisibleToTenant returns true when a node is visible to a tenant-scoped query.
+// Empty tenant scope keeps the full graph visible. Untagged nodes are treated as shared.
+func NodeVisibleToTenant(node *Node, tenantID string) bool {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return true
+	}
+	nodeTenant := nodeTenantID(node)
+	return nodeTenant == "" || nodeTenant == tenantID
+}
+
+// SubgraphForTenant returns one graph view scoped to nodes visible to the tenant.
+// Empty tenant scope returns the original graph to avoid unnecessary cloning.
+func (g *Graph) SubgraphForTenant(tenantID string) *Graph {
+	tenantID = strings.TrimSpace(tenantID)
+	if g == nil {
+		return nil
+	}
+	if tenantID == "" {
+		return g
+	}
+
+	out := New()
+	out.SetSchemaValidationMode(g.SchemaValidationMode())
+	for _, node := range g.GetAllNodes() {
+		if !NodeVisibleToTenant(node, tenantID) {
+			continue
+		}
+		out.AddNode(cloneNode(node))
+	}
+	for _, node := range out.GetAllNodes() {
+		for _, edge := range g.GetOutEdges(node.ID) {
+			if edge == nil {
+				continue
+			}
+			if _, ok := out.GetNode(edge.Source); !ok {
+				continue
+			}
+			if _, ok := out.GetNode(edge.Target); !ok {
+				continue
+			}
+			out.AddEdge(cloneEdge(edge))
+		}
+	}
+
+	meta := g.Metadata()
+	meta.NodeCount = out.NodeCount()
+	meta.EdgeCount = out.EdgeCount()
+	meta.Accounts = uniqueNonEmptyNodeStrings(out.GetAllNodes(), func(node *Node) string { return node.Account })
+	meta.Providers = uniqueNonEmptyNodeStrings(out.GetAllNodes(), func(node *Node) string { return node.Provider })
+	out.SetMetadata(meta)
+	out.BuildIndex()
+	return out
+}
+
+func uniqueNonEmptyNodeStrings(nodes []*Node, value func(*Node) string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
+		candidate := strings.TrimSpace(value(node))
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		out = append(out, candidate)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/graph/tenant_scope_test.go
+++ b/internal/graph/tenant_scope_test.go
@@ -1,0 +1,51 @@
+package graph
+
+import "testing"
+
+func TestAddNodeNormalizesTenantIDFromProperties(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{
+		ID:   "service:payments",
+		Kind: NodeKindService,
+		Properties: map[string]any{
+			"tenant_id": "tenant-a",
+		},
+	})
+
+	node, ok := g.GetNode("service:payments")
+	if !ok {
+		t.Fatal("expected node to be present")
+	}
+	if node.TenantID != "tenant-a" {
+		t.Fatalf("expected tenant_id to normalize onto node, got %q", node.TenantID)
+	}
+	if got := readString(node.Properties, "tenant_id"); got != "tenant-a" {
+		t.Fatalf("expected tenant_id property to remain set, got %q", got)
+	}
+}
+
+func TestSubgraphForTenantFiltersTenantScopedNodes(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "user:shared", Kind: NodeKindUser, Name: "shared"})
+	g.AddNode(&Node{ID: "service:tenant-a", Kind: NodeKindService, Name: "a", TenantID: "tenant-a"})
+	g.AddNode(&Node{ID: "service:tenant-b", Kind: NodeKindService, Name: "b", TenantID: "tenant-b"})
+	g.AddEdge(&Edge{ID: "shared-a", Source: "user:shared", Target: "service:tenant-a", Kind: EdgeKindTargets, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "shared-b", Source: "user:shared", Target: "service:tenant-b", Kind: EdgeKindTargets, Effect: EdgeEffectAllow})
+
+	scoped := g.SubgraphForTenant("tenant-a")
+	if scoped == nil {
+		t.Fatal("expected scoped graph")
+	}
+	if _, ok := scoped.GetNode("service:tenant-a"); !ok {
+		t.Fatal("expected tenant-a node to remain visible")
+	}
+	if _, ok := scoped.GetNode("user:shared"); !ok {
+		t.Fatal("expected shared node to remain visible")
+	}
+	if _, ok := scoped.GetNode("service:tenant-b"); ok {
+		t.Fatal("expected tenant-b node to be filtered out")
+	}
+	if got := len(scoped.GetOutEdges("user:shared")); got != 1 {
+		t.Fatalf("expected only one remaining shared edge, got %d", got)
+	}
+}

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -475,6 +475,14 @@ var (
 		},
 	)
 
+	GraphCrossTenantReadsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cerebro_graph_cross_tenant_reads_total",
+			Help: "Total number of allowed cross-tenant graph reads by operation and bounded access scope",
+		},
+		[]string{"operation", "request_scope", "target_scope", "outcome"},
+	)
+
 	GraphStatePersistenceTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cerebro_graph_state_persistence_total",
@@ -570,6 +578,7 @@ func Register() {
 			GraphCrossTenantIngestSamplesTotal,
 			GraphCrossTenantPatterns,
 			GraphCrossTenantMatches,
+			GraphCrossTenantReadsTotal,
 			GraphStatePersistenceTotal,
 			// Build
 			BuildInfo,
@@ -734,6 +743,26 @@ func RecordGraphCrossTenantMatches(count int) {
 		count = 0
 	}
 	GraphCrossTenantMatches.Set(float64(count))
+}
+
+func RecordGraphCrossTenantRead(operation, requestScope, targetScope, outcome string) {
+	operation = strings.TrimSpace(strings.ToLower(operation))
+	if operation == "" {
+		operation = "unknown"
+	}
+	requestScope = strings.TrimSpace(strings.ToLower(requestScope))
+	if requestScope == "" {
+		requestScope = "unknown"
+	}
+	targetScope = strings.TrimSpace(strings.ToLower(targetScope))
+	if targetScope == "" {
+		targetScope = "unknown"
+	}
+	outcome = strings.TrimSpace(strings.ToLower(outcome))
+	if outcome == "" {
+		outcome = "unknown"
+	}
+	GraphCrossTenantReadsTotal.WithLabelValues(operation, requestScope, targetScope, outcome).Inc()
 }
 
 func RecordGraphStatePersistence(result string) {


### PR DESCRIPTION
## Summary
- scope graph reads, risk queries, and platform entity/knowledge surfaces to the requesting tenant and add cross-tenant audit paths
- add tenant-scope graph helpers, RBAC route permissions, and coverage for scoped graph handlers plus cross-tenant access metrics
- harden time-sensitive graph changelog and freshness tests, and ignore generated `.cerebro` artifacts in git

## Testing
- go test ./internal/api ./internal/graph ./internal/metrics ./internal/auth -count=1
- go test ./internal/app -run TestCerebroGraphChangelogTool -count=1 -v
- go test ./internal/graph/reports -run TestBuildIntelligenceReport_FreshnessPenalizesConfidence -count=1 -v
- make devex-pr
- python3 scripts/oss_audit.py
