### PR TITLE
feat(workloadscan): detect iac artifacts during scans

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,198 @@ Owner: @haasonsaas
 Mode: implement in full, keep CI green
 Status: executed end-to-end via PR workflow
 
+## Deep Review Cycle 79 - Filesystem IaC Detection During Workload Scans (2026-03-13)
+
+### Review findings
+- [x] Gap: issue `#228` was still leaving obvious filesystem-level IaC and config evidence on the floor even though the workload scan walk already touches those files.
+- [x] Gap: waiting for a separate `trivy config` parser would unnecessarily block a first shippable cut because the existing analyzer already has deterministic content and file-type heuristics available locally.
+- [x] Gap: the scan graph still had no first-class representation for IaC findings, so scan nodes could report misconfiguration counts without any durable graph object to inspect.
+- [x] Gap: IaC-only scans could still collapse to `risk:none` because workload-scan risk was driven primarily by vulnerability aggregates.
+
+### Execution plan
+- [x] Extend filesystem analyzer outputs with typed IaC artifact inventory:
+  - [x] add `iac_artifacts` to analyzer reports
+  - [x] track `iac_artifact_count` in scan summaries
+- [x] Detect common IaC/config surfaces during the existing filesystem walk:
+  - [x] Terraform and Terraform state
+  - [x] CloudFormation and Kubernetes manifests
+  - [x] Helm, Docker, Ansible, `.env`, and common app-config files
+- [x] Add deterministic IaC/config findings without a new scan pipeline:
+  - [x] flag Terraform state files as high severity
+  - [x] flag public exposure patterns such as `0.0.0.0/0`
+  - [x] flag public storage principals / ACLs
+  - [x] flag bucket definitions missing explicit encryption settings
+- [x] Materialize IaC findings into the graph:
+  - [x] create `observation` nodes with `workload_iac_finding`
+  - [x] link findings to the workload-scan node with `targets`
+  - [x] surface `iac_artifact_count` on workload-scan nodes
+- [x] Fix risk semantics so IaC-only findings raise workload-scan risk appropriately.
+- [x] Add regression coverage for analyzer detection and graph materialization.
+
+### Review findings
+- [x] Gap: issue `#252` was still compliance-by-findings, even though the graph already held the stronger substrate for many control questions: bucket encryption, public exposure, logging, versioning, sensitive-data posture, database exposure, and parts of GCP IAM.
+- [x] Gap: leaving compliance on the findings path created a split-brain model: the graph could answer the control question, but exports and pre-audit checks still only knew how to count policy violations.
+- [x] Gap: the right first cut is graph-first with explicit fallback, not a fake “all controls are graph-native now” rewrite. Unsupported controls should stay visible as findings-backed until the graph substrate actually earns the migration.
+- [x] Gap: upstream graph/security platforms converge on the same lesson:
+  - [x] `cartography-cncf/cartography` gets leverage when inventory relationships become reusable compliance evidence instead of remaining isolated snapshots.
+  - [x] `cloudquery/cloudquery` reinforces that control logic becomes composable when it runs over normalized resource state rather than one-off scan outputs.
+  - [x] `stackrox/stackrox` and similar posture systems keep the strongest checks close to the resource graph and use exported evidence as a downstream view, not the source of truth.
+
+### Execution plan
+- [x] Add a typed graph-backed compliance evaluator:
+  - [x] evaluate per-control status as `passing|failing|partial|not_applicable|unknown`
+  - [x] attach structured evidence entities, policy IDs, reasons, and evaluation source
+  - [x] cache entity materialization per provider/kind slice instead of embedding logic in API handlers
+- [x] Support the first graph-native control tranche:
+  - [x] AWS S3 encryption, public access, policy public exposure, logging, and versioning
+  - [x] AWS RDS encryption and public exposure
+  - [x] DSPM sensitive-data public/unencrypted posture
+  - [x] GCP service-account admin privilege, key rotation, and user-managed-key minimization
+  - [x] GCP storage public-access checks
+- [x] Keep findings fallback explicit where graph support is not yet real:
+  - [x] unsupported policies remain findings-backed
+  - [x] mixed controls are labeled `hybrid` when graph + fallback are both involved
+- [x] Rewire existing compliance surfaces onto the evaluator:
+  - [x] `/api/v1/compliance/frameworks/{id}/report`
+  - [x] `/api/v1/compliance/frameworks/{id}/pre-audit`
+  - [x] `/api/v1/compliance/frameworks/{id}/export`
+  - [x] legacy `/api/v1/reports/compliance/{framework}` compatibility view
+- [x] Tighten exported evidence:
+  - [x] carry control evidence into audit-package ZIP exports
+  - [x] preserve evaluation source and last-evaluated timestamps
+- [x] Add regression coverage:
+  - [x] mixed graph + findings-fallback control evaluation
+  - [x] DSPM + GCP graph-backed control evaluation
+  - [x] API test proving compliance report/export can fail from graph state without findings
+- [ ] Next compliance depth cuts after this slice:
+  - [ ] persist control-evaluation history on graph rebuilds instead of evaluating only at request time
+  - [ ] add control-detail and history endpoints (`/status`, `/controls/{id}`, `/history`)
+  - [ ] emit control-status-change events for alert routing and report drift
+  - [ ] replace remaining findings fallbacks by deepening graph coverage for IAM MFA, CloudTrail/Config, flow logs, and Cloud SQL/Secrets posture
+
+## Deep Review Cycle 77 - Autonomous Credential Exposure Workflow Demo (2026-03-13)
+
+### Review findings
+- [x] Gap: issue `#219` did not need a speculative orchestration framework first; Cerebro already had the core substrate pieces for one real autonomous loop:
+  - [x] workload-secret detection and credential pivot edges
+  - [x] first-class observation / claim / decision / outcome writes
+  - [x] durable action execution with approval gates
+  - [x] shared execution-store infrastructure
+- [x] Gap: there was still no durable autonomous workflow resource tying those pieces together into one inspectable run with status, events, and approval continuation.
+- [x] Gap: the first workflow should prove graph leverage, not just generic automation. Credential exposure response was the right entry cut because the graph can already trace secret -> principal -> impacted targets.
+- [x] Gap: upstream patterns reinforce the same shape:
+  - [x] `argoproj/argo-workflows` keeps workflow state and approval continuation as durable execution resources rather than implicit handler-local state.
+  - [x] `StackStorm/st2` shows the value of explicit execution records and audit trails around automated action chains.
+  - [x] `smithy-security/smithy` and `turbot/flowpipe` reinforce that security workflows get differentiated by graph/context-rich decisioning, not just generic task runners.
+
+### Execution plan
+- [x] Add a durable autonomous workflow substrate:
+  - [x] add `autonomous_workflow` execution-store namespace
+  - [x] add typed run + event records for autonomous workflows
+  - [x] add durable run store on top of the shared execution store
+- [x] Implement the first end-to-end workflow:
+  - [x] add `credential_exposure_response` workflow ID
+  - [x] analyze discovered secret nodes through `has_credential_for` pivots
+  - [x] persist workflow run summary, impacted targets, and linked action execution
+- [x] Stitch graph evidence trail into the workflow:
+  - [x] write detection observation
+  - [x] write detection claim
+  - [x] write decision node
+  - [x] on success, write remediation claim + outcome
+- [x] Add tool surfaces for the demo loop:
+  - [x] `cerebro.autonomous_credential_response`
+  - [x] `cerebro.autonomous_workflow_approve`
+  - [x] `cerebro.autonomous_workflow_status`
+- [x] Reuse the configured runtime action handler when present:
+  - [x] add `ResponseEngine.ActionHandler()` getter
+  - [x] make autonomous workflow execution use the app-configured runtime handler before falling back to a default handler
+  - [x] keep approval/execution durable under the shared action engine
+- [x] Add regression coverage:
+  - [x] start workflow -> awaiting approval -> durable run/action persistence
+  - [x] approve workflow -> revoke credentials -> remediation claim/outcome persistence
+  - [x] status tool returns workflow and action events
+- [x] Keep generated SDK contracts in sync:
+  - [x] regenerate Agent SDK docs/contracts/packages for the three new autonomous tools
+- [ ] Next autonomous depth cuts after this slice:
+  - [ ] add the second demo workflow: CVE response with blast-radius prioritization
+  - [ ] add Slack/notification approval routing instead of tool-only approval continuation
+  - [ ] add post-remediation validation step and explicit validation-stage run semantics
+  - [ ] surface autonomous workflow runs through platform execution/report APIs, not only tools
+
+## Deep Review Cycle 76 - Durable Graph-Powered Access Review Campaigns (2026-03-13)
+
+### Review findings
+- [x] Gap: issue `#253` was not blocked on another identity microservice; the repo already had graph access-review generation, identity review APIs, stale-access analytics, and effective-permissions calculation, but they lived in two disconnected implementations.
+- [x] Gap: the graph access-review handlers still stored campaigns in a process-local map, which breaks restart durability and contradicts the shared execution-store direction already established for reports, scans, and action execution.
+- [x] Gap: existing review items were under-enriched for real certification workflows: they lacked stable reviewer candidates, recommendation metadata, last-activity context, and graph risk signals such as toxic-combination involvement.
+- [x] Gap: upstream authorization/identity projects converged on the same structural lesson:
+  - [x] `openfga/openfga` keeps relationship state explicit and queryable rather than burying access decisions in application-local handlers.
+  - [x] `infrahq/infra` and `gravitational/teleport` both reinforce that reviewability needs durable execution state and owner-aware access context, not just raw permission lists.
+
+### Execution plan
+- [x] Collapse duplicate access-review implementations onto one shared service:
+  - [x] keep one identity review service as the durable workflow entry point
+  - [x] route graph access-review endpoints through that same service instead of a local map
+  - [x] move campaign persistence to the shared execution store namespace
+- [x] Deepen review campaign data model:
+  - [x] add scope mode support for `all`, `account`, `principal`, `resource`, `high_risk`, `cross_account`, and `privilege_creep`
+  - [x] persist review events for `created`, `started`, `item_decided`, and `completed`
+  - [x] add item-level recommendations, reviewer candidates, path context, and metadata
+- [x] Generate graph-powered review items from existing substrate:
+  - [x] reuse graph access-review generation and blast-radius caching
+  - [x] enrich items with effective-permission grants, last-activity signals, and resource owners
+  - [x] attach toxic-combination/attack-path context for risk-based prioritization
+- [x] Eliminate ephemeral tool/API seams:
+  - [x] make `/api/v1/graph/access-reviews/*` delegate to the shared identity service
+  - [x] make the `cerebro.access_review` tool create durable campaigns instead of ad hoc graph payloads
+- [x] Add regression coverage:
+  - [x] graph-generated campaign enrichment and recommendation tests
+  - [x] shared execution-store persistence tests for review state and events
+  - [x] API test proving graph access-review routes use the shared durable service
+- [ ] Next access-governance depth cuts after this slice:
+  - [ ] resource-owner auto-assignment and overdue escalation scheduling
+  - [ ] compliance evidence export from completed access reviews
+  - [ ] auto-remediation handoff for approved revocation/reduction actions
+  - [ ] provider-specific last-used evidence (AWS, GCP, Azure, SaaS) beyond principal-level activity
+
+## Deep Review Cycle 75 - GCP Hierarchy and Inherited IAM Foundations (2026-03-13)
+
+### Review findings
+- [x] Gap: issue `#245` is broader than one inventory backlog, but the first enterprise-grade credibility seam is still structural: Cerebro had GCP resources and project IAM, yet no first-class `organization`, `folder`, or `project` graph nodes to anchor inheritance.
+- [x] Gap: org/folder/project hierarchy was already partially present in raw sync context (`runGCPOrgSync`, Cloud Asset `parent_full_name`, org policy parent references), but it was not normalized into reusable platform nodes and `located_in` edges.
+- [x] Gap: GCP IAM inheritance above the project was absent, so the graph systematically understated permissions that actually apply at folder or organization scope.
+- [x] Gap: upstream patterns converged on the same structural lesson:
+  - [x] `cartography-cncf/cartography` models GCP CRM resources explicitly and treats org, folder, and project hierarchy as first-class graph structure instead of implicit provider metadata.
+  - [x] `forseti-security/forseti-security` split hierarchy/IAM analysis from project-local checks, reinforcing that inherited policy scope has to be queryable as graph material, not reconstructed ad hoc later.
+
+### Execution plan
+- [x] Add first-class hierarchy ontology kinds:
+  - [x] add `organization`, `folder`, and `project` node kinds
+  - [x] register schema definitions so hierarchy nodes can emit `located_in`
+- [x] Sync GCP Resource Manager hierarchy metadata per project:
+  - [x] add native tables for projects, folders, and organizations
+  - [x] resolve project ancestry with Resource Manager APIs instead of guessing from one project row
+  - [x] preserve ancestor path and folder IDs for downstream reasoning
+- [x] Sync inherited IAM policy scopes:
+  - [x] add folder-level IAM policy table
+  - [x] add organization-level IAM policy table
+  - [x] preserve binding conditions and hierarchy provenance in stored rows
+- [x] Materialize hierarchy and inherited permissions in the graph:
+  - [x] create `organization` / `folder` / `project` nodes
+  - [x] add `located_in` hierarchy edges
+  - [x] fan folder/org IAM bindings out to descendant project resources with `hierarchy_policy` provenance
+- [x] Add regression coverage:
+  - [x] lineage ordering and ancestor-path tests for Resource Manager fetch helpers
+  - [x] builder tests for hierarchy nodes/edges
+  - [x] builder tests for inherited folder/org IAM edge materialization
+- [ ] Next GCP enterprise-depth cuts after this slice:
+  - [ ] Secret Manager nodes + access controls
+  - [ ] Pub/Sub and KMS resource-level IAM edges
+  - [ ] service-account impersonation chain modeling (`iam.serviceAccounts.actAs`, `iam.serviceAccountTokenCreator`)
+  - [ ] Workload Identity Federation trust edges
+  - [ ] billing-account and service-enablement modeling
+
+>>>>>>> bf45aad98 (Detect IaC artifacts during workload filesystem scans (#271))
 ## Deep Review Cycle 74 - Credential Pivot Graph Materialization (2026-03-13)
 
 ### Review findings

--- a/internal/filesystemanalyzer/analyzer.go
+++ b/internal/filesystemanalyzer/analyzer.go
@@ -205,6 +205,15 @@ func (a *Analyzer) Analyze(ctx context.Context, rootfsPath string) (*Report, err
 				inv.metadataErrors = append(inv.metadataErrors, err.Error())
 			}
 		}
+		if shouldInspectIaCFile(filePath, info.Mode(), info.Size(), a.maxSecretFileBytes) {
+			if data, ok, err := readLimitedFile(root, filePath, a.maxSecretFileBytes); err == nil && ok {
+				artifacts, findings := inspectIaCFile(filePath, data)
+				inv.addIaCArtifacts(artifacts...)
+				inv.addConfigs(findings...)
+			} else if err != nil {
+				inv.metadataErrors = append(inv.metadataErrors, err.Error())
+			}
+		}
 		if shouldSecretScan(filePath, info.Mode(), info.Size(), a.maxSecretFileBytes) {
 			if data, ok, err := readLimitedFile(root, filePath, a.maxSecretFileBytes); err == nil && ok {
 				inv.addSecrets(scanSecrets(filePath, data)...)
@@ -253,6 +262,7 @@ func (a *Analyzer) Analyze(ctx context.Context, rootfsPath string) (*Report, err
 	}
 	report.Secrets = inv.secrets
 	report.Misconfigurations = inv.configs
+	report.IaCArtifacts = inv.iacArtifacts
 	report.Malware = inv.malware
 	report.SBOM = buildSBOM(report.GeneratedAt, report.Packages)
 	report.Findings = dedupeFindings(append(report.Findings, inv.findings...))
@@ -261,6 +271,7 @@ func (a *Analyzer) Analyze(ctx context.Context, rootfsPath string) (*Report, err
 		VulnerabilityCount:    len(report.Vulnerabilities),
 		SecretCount:           len(report.Secrets),
 		MisconfigurationCount: len(report.Misconfigurations),
+		IaCArtifactCount:      len(report.IaCArtifacts),
 		MalwareCount:          len(report.Malware),
 		Truncated:             inv.truncated,
 	}
@@ -278,8 +289,10 @@ type inventory struct {
 	generatedAt    time.Time
 	os             OSInfo
 	packages       map[string]PackageRecord
+	iacArtifactIDs map[string]struct{}
 	secrets        []SecretFinding
 	configs        []ConfigFinding
+	iacArtifacts   []IaCArtifact
 	malware        []MalwareFinding
 	findings       []scanner.ContainerFinding
 	entriesVisited int
@@ -289,8 +302,9 @@ type inventory struct {
 
 func newInventory(now time.Time) *inventory {
 	return &inventory{
-		generatedAt: now,
-		packages:    make(map[string]PackageRecord),
+		generatedAt:    now,
+		packages:       make(map[string]PackageRecord),
+		iacArtifactIDs: make(map[string]struct{}),
 	}
 }
 
@@ -338,6 +352,22 @@ func (i *inventory) addConfig(finding ConfigFinding) {
 func (i *inventory) addConfigs(findings ...ConfigFinding) {
 	for _, finding := range findings {
 		i.addConfig(finding)
+	}
+}
+
+func (i *inventory) addIaCArtifacts(artifacts ...IaCArtifact) {
+	for _, artifact := range artifacts {
+		artifact.ID = strings.TrimSpace(artifact.ID)
+		artifact.Type = strings.TrimSpace(artifact.Type)
+		artifact.Path = strings.TrimSpace(artifact.Path)
+		if artifact.ID == "" || artifact.Type == "" || artifact.Path == "" {
+			continue
+		}
+		if _, exists := i.iacArtifactIDs[artifact.ID]; exists {
+			continue
+		}
+		i.iacArtifactIDs[artifact.ID] = struct{}{}
+		i.iacArtifacts = append(i.iacArtifacts, artifact)
 	}
 }
 
@@ -459,6 +489,38 @@ func shouldParseConfigFile(filePath string) bool {
 		return true
 	}
 	return false
+}
+
+func shouldInspectIaCFile(filePath string, mode fs.FileMode, size int64, maxBytes int64) bool {
+	if mode&fs.ModeSymlink != 0 || mode.IsDir() || size <= 0 || size > maxBytes {
+		return false
+	}
+	if strings.Contains(filePath, "/testdata/") || strings.Contains(filePath, "/fixtures/") || strings.Contains(filePath, "/examples/") {
+		return false
+	}
+	lowerPath := strings.ToLower(strings.TrimSpace(filePath))
+	base := path.Base(lowerPath)
+	switch {
+	case strings.HasSuffix(lowerPath, ".tf"),
+		strings.HasSuffix(lowerPath, ".tfvars"),
+		strings.HasSuffix(lowerPath, ".tfstate"),
+		strings.HasSuffix(lowerPath, ".tfstate.backup"),
+		strings.HasSuffix(lowerPath, ".template"):
+		return true
+	}
+	switch base {
+	case "dockerfile", "docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml",
+		"chart.yaml", "values.yaml", "playbook.yml", "playbook.yaml", "site.yml", "site.yaml",
+		"inventory", ".env", "config.json", "application.properties", "ansible.cfg":
+		return true
+	}
+	ext := strings.ToLower(path.Ext(lowerPath))
+	switch ext {
+	case ".yaml", ".yml", ".json":
+		return true
+	default:
+		return false
+	}
 }
 
 func shouldSecretScan(filePath string, mode fs.FileMode, size int64, maxBytes int64) bool {
@@ -851,6 +913,233 @@ func parseConfigFindings(filePath string, data []byte) []ConfigFinding {
 		}
 	}
 	return findings
+}
+
+func inspectIaCFile(filePath string, data []byte) ([]IaCArtifact, []ConfigFinding) {
+	if looksBinary(data) {
+		return nil, nil
+	}
+	artifacts := detectIaCArtifacts(filePath, data)
+	findings := parseIaCFindings(filePath, data, artifacts)
+	return artifacts, findings
+}
+
+func detectIaCArtifacts(filePath string, data []byte) []IaCArtifact {
+	lowerPath := strings.ToLower(strings.TrimSpace(filePath))
+	base := path.Base(lowerPath)
+	ext := strings.ToLower(path.Ext(lowerPath))
+	format := "text"
+	switch ext {
+	case ".tf", ".tfvars":
+		format = "hcl"
+	case ".yaml", ".yml", ".template":
+		format = "yaml"
+	case ".json", ".tfstate", ".backup":
+		format = "json"
+	case ".properties":
+		format = "properties"
+	}
+
+	artifacts := make([]IaCArtifact, 0, 1)
+	appendArtifact := func(kind, artifactFormat, resourceType string) {
+		kind = strings.TrimSpace(kind)
+		if kind == "" {
+			return
+		}
+		if artifactFormat == "" {
+			artifactFormat = format
+		}
+		artifacts = append(artifacts, IaCArtifact{
+			ID:           findingID("iac_artifact", kind+":"+filePath),
+			Type:         kind,
+			Path:         filePath,
+			Format:       artifactFormat,
+			ResourceType: strings.TrimSpace(resourceType),
+		})
+	}
+
+	switch {
+	case strings.HasSuffix(lowerPath, ".tf"):
+		appendArtifact("terraform", "hcl", inferIaCResourceType(lowerPath, string(data)))
+	case strings.HasSuffix(lowerPath, ".tfvars"):
+		appendArtifact("terraform_variables", "hcl", "")
+	case strings.HasSuffix(lowerPath, ".tfstate"), strings.HasSuffix(lowerPath, ".tfstate.backup"):
+		appendArtifact("terraform_state", "json", "terraform_state")
+	case base == "dockerfile":
+		appendArtifact("dockerfile", "dockerfile", "container_image")
+	case base == "docker-compose.yml" || base == "docker-compose.yaml" || base == "compose.yml" || base == "compose.yaml":
+		appendArtifact("docker_compose", "yaml", "container_service")
+	case base == "chart.yaml":
+		appendArtifact("helm_chart", "yaml", "helm_chart")
+	case base == "values.yaml":
+		appendArtifact("helm_values", "yaml", "")
+	case base == "playbook.yml" || base == "playbook.yaml" || base == "site.yml" || base == "site.yaml" || base == "inventory" || base == "ansible.cfg" || strings.Contains(lowerPath, "/roles/"):
+		appendArtifact("ansible", format, "configuration")
+	case base == ".env":
+		appendArtifact("environment_file", "env", "configuration")
+	case base == "config.json":
+		appendArtifact("json_config", "json", "configuration")
+	case base == "application.properties":
+		appendArtifact("application_properties", "properties", "configuration")
+	default:
+		text := string(data)
+		lowerText := strings.ToLower(text)
+		switch {
+		case strings.Contains(text, "AWSTemplateFormatVersion"):
+			appendArtifact("cloudformation", format, inferIaCResourceType(lowerPath, text))
+		case strings.Contains(text, "apiVersion:") && strings.Contains(text, "kind:"):
+			appendArtifact("kubernetes_manifest", format, inferIaCResourceType(lowerPath, text))
+		case strings.Contains(lowerPath, "/templates/") && (ext == ".yaml" || ext == ".yml"):
+			appendArtifact("helm_template", "yaml", inferIaCResourceType(lowerPath, text))
+		case ext == ".json" && (strings.Contains(lowerText, "\"resources\"") || strings.Contains(lowerText, "\"terraform_version\"")):
+			appendArtifact("terraform_json", "json", inferIaCResourceType(lowerPath, text))
+		}
+	}
+	return artifacts
+}
+
+func parseIaCFindings(filePath string, data []byte, artifacts []IaCArtifact) []ConfigFinding {
+	if len(artifacts) == 0 {
+		return nil
+	}
+	text := string(data)
+	lowerText := strings.ToLower(text)
+	resourceType := ""
+	artifactType := ""
+	format := ""
+	for _, artifact := range artifacts {
+		resourceType = firstNonEmpty(resourceType, artifact.ResourceType)
+		artifactType = firstNonEmpty(artifactType, artifact.Type)
+		format = firstNonEmpty(format, artifact.Format)
+	}
+
+	findings := make([]ConfigFinding, 0, 3)
+	appendFinding := func(kind, severity, title, description, remediation, findingResourceType string) {
+		findings = append(findings, ConfigFinding{
+			ID:           findingID(kind, filePath),
+			Type:         kind,
+			Severity:     severity,
+			Path:         filePath,
+			Title:        title,
+			Description:  description,
+			Remediation:  remediation,
+			ResourceType: firstNonEmpty(findingResourceType, resourceType),
+			ArtifactType: artifactType,
+			Format:       format,
+		})
+	}
+
+	if artifactType == "terraform_state" {
+		appendFinding(
+			"terraform_state",
+			"high",
+			"Terraform state file detected",
+			"Terraform state frequently persists provider credentials, infrastructure metadata, and plaintext secrets.",
+			"Remove state files from deployed artifacts and store state only in encrypted remote backends with access controls.",
+			"terraform_state",
+		)
+	}
+
+	if hasIaCPublicExposure(lowerText) {
+		appendFinding(
+			"iac_public_exposure",
+			"high",
+			"Public network exposure in IaC or config",
+			"IaC or configuration content allows unrestricted ingress or public exposure.",
+			"Replace public CIDRs or principals with scoped identities, private networking, or tightly bounded ranges.",
+			firstNonEmpty(inferPublicExposureResourceType(lowerText), resourceType),
+		)
+	}
+
+	if hasPublicStorageExposure(lowerText) {
+		appendFinding(
+			"iac_public_storage",
+			"high",
+			"Public storage access configured",
+			"Template or configuration grants public read access to storage resources.",
+			"Remove public principals and ACLs, then require authenticated access through scoped identities or signed requests.",
+			"bucket",
+		)
+	}
+
+	if supportsBucketEncryptionCheck(artifactType) && missingBucketEncryption(lowerText) {
+		appendFinding(
+			"iac_missing_bucket_encryption",
+			"medium",
+			"Bucket definition missing encryption setting",
+			"Storage bucket configuration is present without an explicit encryption setting.",
+			"Enable provider-managed encryption or a customer-managed KMS key in the IaC definition.",
+			"bucket",
+		)
+	}
+
+	return findings
+}
+
+func supportsBucketEncryptionCheck(artifactType string) bool {
+	switch strings.TrimSpace(artifactType) {
+	case "terraform", "terraform_json", "cloudformation":
+		return true
+	default:
+		return false
+	}
+}
+
+func inferIaCResourceType(filePath, text string) string {
+	lowerText := strings.ToLower(text)
+	switch {
+	case strings.Contains(lowerText, "aws_security_group"), strings.Contains(lowerText, "google_compute_firewall"), strings.Contains(lowerText, "networksecuritygroup"):
+		return "firewall_rule"
+	case strings.Contains(lowerText, "aws_s3_bucket"), strings.Contains(lowerText, "google_storage_bucket"), strings.Contains(lowerText, "azurerm_storage_account"), strings.Contains(lowerText, "aws::s3::bucket"):
+		return "bucket"
+	case strings.Contains(lowerText, "kind: service"), strings.Contains(lowerText, "kind: ingress"), strings.Contains(lowerText, "kind: networkpolicy"):
+		return "kubernetes_network"
+	case strings.Contains(strings.ToLower(filePath), "dockerfile"), strings.Contains(lowerText, "services:"):
+		return "container_service"
+	default:
+		return ""
+	}
+}
+
+func hasIaCPublicExposure(lowerText string) bool {
+	return strings.Contains(lowerText, "0.0.0.0/0") ||
+		strings.Contains(lowerText, "::/0") ||
+		strings.Contains(lowerText, "\"cidr\": \"0.0.0.0/0\"") ||
+		strings.Contains(lowerText, "host: 0.0.0.0") ||
+		strings.Contains(lowerText, "listen_address=0.0.0.0") ||
+		strings.Contains(lowerText, "source_ranges") && strings.Contains(lowerText, "0.0.0.0/0")
+}
+
+func hasPublicStorageExposure(lowerText string) bool {
+	return strings.Contains(lowerText, "allusers") ||
+		strings.Contains(lowerText, "allauthenticatedusers") ||
+		strings.Contains(lowerText, "public-read") ||
+		strings.Contains(lowerText, "\"principal\": \"*\"") && strings.Contains(lowerText, "s3:getobject")
+}
+
+func inferPublicExposureResourceType(lowerText string) string {
+	switch {
+	case strings.Contains(lowerText, "aws_security_group"), strings.Contains(lowerText, "google_compute_firewall"), strings.Contains(lowerText, "networksecuritygroup"), strings.Contains(lowerText, "source_ranges"):
+		return "firewall_rule"
+	case strings.Contains(lowerText, "kind: service"), strings.Contains(lowerText, "kind: ingress"):
+		return "kubernetes_service"
+	default:
+		return ""
+	}
+}
+
+func missingBucketEncryption(lowerText string) bool {
+	hasBucket := strings.Contains(lowerText, "aws_s3_bucket") ||
+		strings.Contains(lowerText, "google_storage_bucket") ||
+		strings.Contains(lowerText, "aws::s3::bucket")
+	if !hasBucket {
+		return false
+	}
+	return !strings.Contains(lowerText, "server_side_encryption_configuration") &&
+		!strings.Contains(lowerText, "bucketencryption") &&
+		!strings.Contains(lowerText, "default_kms_key_name") &&
+		!strings.Contains(lowerText, "kms_key_name") &&
+		!strings.Contains(lowerText, "encryption")
 }
 
 func scanSecrets(filePath string, data []byte) []SecretFinding {

--- a/internal/filesystemanalyzer/analyzer_test.go
+++ b/internal/filesystemanalyzer/analyzer_test.go
@@ -254,6 +254,100 @@ func TestShouldSecretScanUsesConfiguredMaxBytes(t *testing.T) {
 	}
 }
 
+func TestAnalyzerDetectsIaCArtifactsAndMisconfigurations(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "infra", "main.tf"), strings.Join([]string{
+		`resource "aws_security_group" "public" {`,
+		`  ingress {`,
+		`    cidr_blocks = ["0.0.0.0/0"]`,
+		`  }`,
+		`}`,
+		`resource "aws_s3_bucket" "logs" {`,
+		`  bucket = "prod-logs"`,
+		`}`,
+	}, "\n"))
+	mustWriteFile(t, filepath.Join(root, "infra", "terraform.tfstate"), `{"version":4,"terraform_version":"1.8.0","resources":[{"type":"aws_s3_bucket","name":"logs"}]}`)
+	mustWriteFile(t, filepath.Join(root, "deploy", "service.yaml"), "apiVersion: v1\nkind: Service\nmetadata:\n  name: api\n")
+	mustWriteFile(t, filepath.Join(root, "app", ".env"), "DATABASE_PASSWORD=super-secret-password\n")
+
+	report, err := New(Options{}).Analyze(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.Summary.IaCArtifactCount != 4 {
+		t.Fatalf("expected four IaC/config artifacts, got %#v", report.IaCArtifacts)
+	}
+
+	artifactTypes := make(map[string]IaCArtifact, len(report.IaCArtifacts))
+	for _, artifact := range report.IaCArtifacts {
+		artifactTypes[artifact.Type] = artifact
+	}
+	for _, kind := range []string{"terraform", "terraform_state", "kubernetes_manifest", "environment_file"} {
+		if _, ok := artifactTypes[kind]; !ok {
+			t.Fatalf("expected artifact %q, got %#v", kind, report.IaCArtifacts)
+		}
+	}
+
+	findingTypes := make(map[string]ConfigFinding, len(report.Misconfigurations))
+	for _, finding := range report.Misconfigurations {
+		findingTypes[finding.Type] = finding
+	}
+	if finding, ok := findingTypes["terraform_state"]; !ok {
+		t.Fatalf("expected terraform_state finding, got %#v", report.Misconfigurations)
+	} else if finding.ArtifactType != "terraform_state" || finding.ResourceType != "terraform_state" {
+		t.Fatalf("expected terraform_state metadata, got %#v", finding)
+	}
+	if _, ok := findingTypes["iac_public_exposure"]; !ok {
+		t.Fatalf("expected public exposure finding, got %#v", report.Misconfigurations)
+	}
+	if finding, ok := findingTypes["iac_missing_bucket_encryption"]; !ok {
+		t.Fatalf("expected missing bucket encryption finding, got %#v", report.Misconfigurations)
+	} else if finding.ResourceType != "bucket" {
+		t.Fatalf("expected bucket resource type, got %#v", finding)
+	}
+
+	foundMisconfigFinding := false
+	for _, finding := range report.Findings {
+		if finding.Type == "misconfiguration" && strings.Contains(strings.ToLower(finding.Title), "terraform state") {
+			foundMisconfigFinding = true
+			break
+		}
+	}
+	if !foundMisconfigFinding {
+		t.Fatalf("expected terraform state finding in container findings, got %#v", report.Findings)
+	}
+}
+
+func TestAnalyzerDoesNotFlagBucketEncryptionForHelmValuesReference(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "charts", "api", "values.yaml"), strings.Join([]string{
+		"# terraform module provisions aws_s3_bucket elsewhere",
+		"bucketName: app-logs",
+	}, "\n"))
+
+	report, err := New(Options{}).Analyze(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	foundHelmValues := false
+	for _, artifact := range report.IaCArtifacts {
+		if artifact.Type == "helm_values" {
+			foundHelmValues = true
+			break
+		}
+	}
+	if !foundHelmValues {
+		t.Fatalf("expected helm_values artifact, got %#v", report.IaCArtifacts)
+	}
+
+	for _, finding := range report.Misconfigurations {
+		if finding.Type == "iac_missing_bucket_encryption" {
+			t.Fatalf("expected no bucket encryption finding for Helm values reference, got %#v", report.Misconfigurations)
+		}
+	}
+}
+
 func mustWriteFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/filesystemanalyzer/types.go
+++ b/internal/filesystemanalyzer/types.go
@@ -68,13 +68,24 @@ type SecretReference struct {
 }
 
 type ConfigFinding struct {
-	ID          string `json:"id"`
-	Type        string `json:"type"`
-	Severity    string `json:"severity"`
-	Path        string `json:"path"`
-	Title       string `json:"title"`
-	Description string `json:"description,omitempty"`
-	Remediation string `json:"remediation,omitempty"`
+	ID           string `json:"id"`
+	Type         string `json:"type"`
+	Severity     string `json:"severity"`
+	Path         string `json:"path"`
+	Title        string `json:"title"`
+	Description  string `json:"description,omitempty"`
+	Remediation  string `json:"remediation,omitempty"`
+	ResourceType string `json:"resource_type,omitempty"`
+	ArtifactType string `json:"artifact_type,omitempty"`
+	Format       string `json:"format,omitempty"`
+}
+
+type IaCArtifact struct {
+	ID           string `json:"id"`
+	Type         string `json:"type"`
+	Path         string `json:"path"`
+	Format       string `json:"format,omitempty"`
+	ResourceType string `json:"resource_type,omitempty"`
 }
 
 type MalwareFinding struct {
@@ -110,6 +121,7 @@ type Summary struct {
 	VulnerabilityCount    int  `json:"vulnerability_count"`
 	SecretCount           int  `json:"secret_count"`
 	MisconfigurationCount int  `json:"misconfiguration_count"`
+	IaCArtifactCount      int  `json:"iac_artifact_count"`
 	MalwareCount          int  `json:"malware_count"`
 	Truncated             bool `json:"truncated,omitempty"`
 }
@@ -123,6 +135,7 @@ type Report struct {
 	Findings          []scanner.ContainerFinding   `json:"findings,omitempty"`
 	Secrets           []SecretFinding              `json:"secrets,omitempty"`
 	Misconfigurations []ConfigFinding              `json:"misconfigurations,omitempty"`
+	IaCArtifacts      []IaCArtifact                `json:"iac_artifacts,omitempty"`
 	Malware           []MalwareFinding             `json:"malware,omitempty"`
 	SBOM              SBOMDocument                 `json:"sbom"`
 	Summary           Summary                      `json:"summary"`

--- a/internal/workloadscan/graph_materialization.go
+++ b/internal/workloadscan/graph_materialization.go
@@ -16,23 +16,25 @@ const graphMaterializationSourceSystem = "cerebro_workload_scan"
 
 // GraphMaterializationResult summarizes one batch of graph writes derived from workload scans.
 type GraphMaterializationResult struct {
-	RunsConsidered         int `json:"runs_considered"`
-	RunsMaterialized       int `json:"runs_materialized"`
-	RunsSkipped            int `json:"runs_skipped"`
-	TargetLinksCreated     int `json:"target_links_created"`
-	ScanNodesUpserted      int `json:"scan_nodes_upserted"`
-	SecretNodesUpserted    int `json:"secret_nodes_upserted"`
-	PackageNodesUpserted   int `json:"package_nodes_upserted"`
-	VulnNodesUpserted      int `json:"vulnerability_nodes_upserted"`
-	ScanSecretEdges        int `json:"scan_secret_edges"`
-	SecretTargetEdges      int `json:"secret_target_edges"`
-	CredentialPivotEdges   int `json:"credential_pivot_edges"`
-	ScanPackageEdges       int `json:"scan_package_edges"`
-	ScanVulnEdges          int `json:"scan_vulnerability_edges"`
-	PackageVulnEdges       int `json:"package_vulnerability_edges"`
-	SkippedUnresolvedRuns  int `json:"skipped_unresolved_runs"`
-	SkippedIncompleteRuns  int `json:"skipped_incomplete_runs"`
-	SkippedUnsupportedRuns int `json:"skipped_unsupported_runs"`
+	RunsConsidered           int `json:"runs_considered"`
+	RunsMaterialized         int `json:"runs_materialized"`
+	RunsSkipped              int `json:"runs_skipped"`
+	TargetLinksCreated       int `json:"target_links_created"`
+	ScanNodesUpserted        int `json:"scan_nodes_upserted"`
+	ObservationNodesUpserted int `json:"observation_nodes_upserted"`
+	SecretNodesUpserted      int `json:"secret_nodes_upserted"`
+	PackageNodesUpserted     int `json:"package_nodes_upserted"`
+	VulnNodesUpserted        int `json:"vulnerability_nodes_upserted"`
+	ScanObservationEdges     int `json:"scan_observation_edges"`
+	ScanSecretEdges          int `json:"scan_secret_edges"`
+	SecretTargetEdges        int `json:"secret_target_edges"`
+	CredentialPivotEdges     int `json:"credential_pivot_edges"`
+	ScanPackageEdges         int `json:"scan_package_edges"`
+	ScanVulnEdges            int `json:"scan_vulnerability_edges"`
+	PackageVulnEdges         int `json:"package_vulnerability_edges"`
+	SkippedUnresolvedRuns    int `json:"skipped_unresolved_runs"`
+	SkippedIncompleteRuns    int `json:"skipped_incomplete_runs"`
+	SkippedUnsupportedRuns   int `json:"skipped_unsupported_runs"`
 }
 
 type resolvedRun struct {
@@ -50,6 +52,10 @@ type secretAggregate struct {
 
 type vulnerabilityAggregate struct {
 	record scanner.ImageVulnerability
+}
+
+type configAggregate struct {
+	record filesystemanalyzer.ConfigFinding
 }
 
 type packageVulnerabilityAggregate struct {
@@ -71,6 +77,7 @@ type scanSummary struct {
 	FixableCount               int
 	SecretCount                int
 	MisconfigurationCount      int
+	IaCArtifactCount           int
 	MalwareCount               int
 	FindingCount               int64
 	OSName                     string
@@ -137,9 +144,11 @@ func MaterializeRunsIntoGraph(g *graph.Graph, runs []RunRecord, now time.Time) G
 			result.RunsSkipped += batch.RunsSkipped
 			result.TargetLinksCreated += batch.TargetLinksCreated
 			result.ScanNodesUpserted += batch.ScanNodesUpserted
+			result.ObservationNodesUpserted += batch.ObservationNodesUpserted
 			result.SecretNodesUpserted += batch.SecretNodesUpserted
 			result.PackageNodesUpserted += batch.PackageNodesUpserted
 			result.VulnNodesUpserted += batch.VulnNodesUpserted
+			result.ScanObservationEdges += batch.ScanObservationEdges
 			result.ScanSecretEdges += batch.ScanSecretEdges
 			result.SecretTargetEdges += batch.SecretTargetEdges
 			result.CredentialPivotEdges += batch.CredentialPivotEdges
@@ -173,7 +182,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		return result
 	}
 	validFrom := runValidFrom(run, seenAt)
-	summary, secrets, packages, vulns, relations := summarizeRun(run)
+	summary, findings, secrets, packages, vulns, relations := summarizeRun(run)
 	sourceEventID := fmt.Sprintf("workload_scan:%s", firstNonEmpty(strings.TrimSpace(run.ID), syntheticRunKey(run)))
 	writeMeta := graph.NormalizeWriteMetadata(
 		seenAt,
@@ -224,6 +233,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 			"fixable_vulnerability_count":     summary.FixableCount,
 			"secret_count":                    summary.SecretCount,
 			"misconfiguration_count":          summary.MisconfigurationCount,
+			"iac_artifact_count":              summary.IaCArtifactCount,
 			"malware_count":                   summary.MalwareCount,
 			"finding_count":                   summary.FindingCount,
 			"sbom_ref":                        summary.SBOMRef,
@@ -335,6 +345,37 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		}
 	}
 
+	for _, findingAgg := range findings {
+		observationMeta := graph.NormalizeWriteMetadata(
+			seenAt,
+			validFrom,
+			nil,
+			graphMaterializationSourceSystem,
+			fmt.Sprintf("%s:iac_finding:%s", sourceEventID, slugify(findingAgg.record.ID)),
+			1.0,
+			graph.WriteMetadataDefaults{
+				Now:             now,
+				RecordedAt:      seenAt,
+				TransactionFrom: seenAt,
+				SourceSystem:    graphMaterializationSourceSystem,
+			},
+		)
+		observationNode := buildIaCFindingObservationNode(scanNode, target, findingAgg.record, observationMeta)
+		g.AddNode(observationNode)
+		result.ObservationNodesUpserted++
+		if addEdgeIfMissing(g, &graph.Edge{
+			ID:         edgeID(observationNode.ID, scanNode.ID, graph.EdgeKindTargets),
+			Source:     observationNode.ID,
+			Target:     scanNode.ID,
+			Kind:       graph.EdgeKindTargets,
+			Effect:     graph.EdgeEffectAllow,
+			Properties: cloneWorkloadAnyMap(observationMeta.PropertyMap()),
+			Risk:       observationNode.Risk,
+		}) {
+			result.ScanObservationEdges++
+		}
+	}
+
 	secretResult := materializeSecretPivots(g, target, scanNode, secrets, writeMeta, now)
 	result.SecretNodesUpserted += secretResult.SecretNodesUpserted
 	result.ScanSecretEdges += secretResult.ScanSecretEdges
@@ -399,15 +440,17 @@ func resolveTargetNode(g *graph.Graph, run RunRecord) (*graph.Node, bool) {
 	return nil, false
 }
 
-func summarizeRun(run RunRecord) (scanSummary, map[string]secretAggregate, map[string]packageAggregate, map[string]vulnerabilityAggregate, map[string]packageVulnerabilityAggregate) {
+func summarizeRun(run RunRecord) (scanSummary, map[string]configAggregate, map[string]secretAggregate, map[string]packageAggregate, map[string]vulnerabilityAggregate, map[string]packageVulnerabilityAggregate) {
 	summary := scanSummary{
 		FindingCount: run.Summary.Findings,
 		Risk:         graph.RiskNone,
 	}
+	findings := make(map[string]configAggregate)
 	secrets := make(map[string]secretAggregate)
 	packages := make(map[string]packageAggregate)
 	vulns := make(map[string]vulnerabilityAggregate)
 	relations := make(map[string]packageVulnerabilityAggregate)
+	iacArtifacts := make(map[string]filesystemanalyzer.IaCArtifact)
 
 	for _, volume := range run.Volumes {
 		if volume.Analysis == nil || volume.Analysis.Catalog == nil {
@@ -425,6 +468,15 @@ func summarizeRun(run RunRecord) (scanSummary, map[string]secretAggregate, map[s
 		summary.SecretCount += len(catalog.Secrets)
 		summary.MisconfigurationCount += len(catalog.Misconfigurations)
 		summary.MalwareCount += len(catalog.Malware)
+		for _, artifact := range catalog.IaCArtifacts {
+			artifactID := strings.TrimSpace(artifact.ID)
+			if artifactID == "" {
+				continue
+			}
+			if _, exists := iacArtifacts[artifactID]; !exists {
+				iacArtifacts[artifactID] = artifact
+			}
+		}
 		for _, secret := range catalog.Secrets {
 			secretID := strings.TrimSpace(secret.ID)
 			if secretID == "" {
@@ -433,6 +485,19 @@ func summarizeRun(run RunRecord) (scanSummary, map[string]secretAggregate, map[s
 			if _, exists := secrets[secretID]; !exists {
 				secrets[secretID] = secretAggregate{record: secret}
 			}
+			summary.Risk = maxRiskLevel(summary.Risk, severityToRisk(secret.Severity, false))
+		}
+		for _, finding := range catalog.Misconfigurations {
+			summary.Risk = maxRiskLevel(summary.Risk, severityToRisk(finding.Severity, false))
+			if strings.TrimSpace(finding.ID) == "" || strings.TrimSpace(finding.ArtifactType) == "" {
+				continue
+			}
+			if _, exists := findings[finding.ID]; !exists {
+				findings[finding.ID] = configAggregate{record: finding}
+			}
+		}
+		for _, malware := range catalog.Malware {
+			summary.Risk = maxRiskLevel(summary.Risk, severityToRisk(malware.Severity, false))
 		}
 
 		for _, pkg := range catalog.Packages {
@@ -470,6 +535,7 @@ func summarizeRun(run RunRecord) (scanSummary, map[string]secretAggregate, map[s
 		}
 	}
 
+	summary.IaCArtifactCount = len(iacArtifacts)
 	summary.PackageCount = len(packages)
 	summary.VulnerabilityCount = len(vulns)
 	for _, vulnAgg := range vulns {
@@ -495,8 +561,8 @@ func summarizeRun(run RunRecord) (scanSummary, map[string]secretAggregate, map[s
 			summary.FixableCount++
 		}
 	}
-	summary.Risk = summaryRisk(summary)
-	return summary, secrets, packages, vulns, relations
+	summary.Risk = maxRiskLevel(summary.Risk, summaryRisk(summary))
+	return summary, findings, secrets, packages, vulns, relations
 }
 
 func mergeVulnerabilityRecord(existing, incoming scanner.ImageVulnerability) scanner.ImageVulnerability {
@@ -577,11 +643,43 @@ func buildVulnerabilityNode(vuln scanner.ImageVulnerability, target *graph.Node,
 	}
 }
 
+func buildIaCFindingObservationNode(scanNode, target *graph.Node, finding filesystemanalyzer.ConfigFinding, metadata graph.WriteMetadata) *graph.Node {
+	properties := map[string]any{
+		"observation_type": "workload_iac_finding",
+		"subject_id":       scanNode.ID,
+		"detail":           finding.Title,
+		"finding_id":       strings.TrimSpace(finding.ID),
+		"finding_type":     strings.TrimSpace(finding.Type),
+		"severity":         normalizeSeverity(finding.Severity),
+		"file_path":        strings.TrimSpace(finding.Path),
+		"description":      strings.TrimSpace(finding.Description),
+		"remediation":      strings.TrimSpace(finding.Remediation),
+		"resource_type":    strings.TrimSpace(finding.ResourceType),
+		"artifact_type":    strings.TrimSpace(finding.ArtifactType),
+		"format":           strings.TrimSpace(finding.Format),
+	}
+	metadata.ApplyTo(properties)
+	return &graph.Node{
+		ID:         iacFindingObservationNodeID(scanNode.ID, finding),
+		Kind:       graph.NodeKindObservation,
+		Name:       firstNonEmpty(strings.TrimSpace(finding.Title), strings.TrimSpace(finding.Type), "workload iac finding"),
+		Provider:   target.Provider,
+		Account:    target.Account,
+		Region:     target.Region,
+		Risk:       severityToRisk(finding.Severity, false),
+		Properties: properties,
+	}
+}
+
 func nodeID(run RunRecord) string {
 	if id := strings.TrimSpace(run.ID); id != "" {
 		return id
 	}
 	return "workload_scan:" + syntheticRunKey(run)
+}
+
+func iacFindingObservationNodeID(scanNodeID string, finding filesystemanalyzer.ConfigFinding) string {
+	return fmt.Sprintf("observation:iac:%s:%s", slugify(scanNodeID), slugify(firstNonEmpty(strings.TrimSpace(finding.ID), strings.TrimSpace(finding.Path), strings.TrimSpace(finding.Title))))
 }
 
 func packageNodeID(pkg filesystemanalyzer.PackageRecord) string {

--- a/internal/workloadscan/graph_materialization_test.go
+++ b/internal/workloadscan/graph_materialization_test.go
@@ -237,6 +237,125 @@ func TestMaterializeRunsIntoGraphAddsCredentialPivotEdges(t *testing.T) {
 	}
 }
 
+func TestMaterializeRunsIntoGraphAddsIaCFindingObservations(t *testing.T) {
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:       "arn:aws:ec2:us-east-1:123456789012:instance/i-abc123",
+		Kind:     graph.NodeKindInstance,
+		Name:     "i-abc123",
+		Provider: "aws",
+		Account:  "123456789012",
+		Region:   "us-east-1",
+	})
+	g.BuildIndex()
+
+	run := buildGraphMaterializationTestRun("workload_scan:run-iac", now.Add(-2*time.Hour), 0)
+	run.Summary.Findings = 2
+	run.Volumes[0].Analysis.FindingCount = 2
+	run.Volumes[0].Analysis.Catalog.IaCArtifacts = []filesystemanalyzer.IaCArtifact{
+		{ID: "artifact:terraform", Type: "terraform", Path: "infra/main.tf", Format: "hcl", ResourceType: "firewall_rule"},
+		{ID: "artifact:terraform-state", Type: "terraform_state", Path: "infra/terraform.tfstate", Format: "json", ResourceType: "terraform_state"},
+	}
+	run.Volumes[0].Analysis.Catalog.Misconfigurations = []filesystemanalyzer.ConfigFinding{
+		{
+			ID:           "finding:terraform-state",
+			Type:         "terraform_state",
+			Severity:     "high",
+			Path:         "infra/terraform.tfstate",
+			Title:        "Terraform state file detected",
+			ArtifactType: "terraform_state",
+			Format:       "json",
+			ResourceType: "terraform_state",
+		},
+		{
+			ID:           "finding:public-exposure",
+			Type:         "iac_public_exposure",
+			Severity:     "high",
+			Path:         "infra/main.tf",
+			Title:        "Public network exposure in IaC or config",
+			ArtifactType: "terraform",
+			Format:       "hcl",
+			ResourceType: "firewall_rule",
+		},
+	}
+
+	summary := MaterializeRunsIntoGraph(g, []RunRecord{run}, now)
+	if summary.ObservationNodesUpserted != 2 {
+		t.Fatalf("expected two IaC observation nodes, got %#v", summary)
+	}
+	if summary.ScanObservationEdges != 2 {
+		t.Fatalf("expected two IaC observation edges, got %#v", summary)
+	}
+
+	scanNode, ok := g.GetNode(run.ID)
+	if !ok {
+		t.Fatalf("expected workload scan node %q", run.ID)
+	}
+	if scanNode.Risk != graph.RiskHigh {
+		t.Fatalf("expected scan node risk high from IaC findings, got %#v", scanNode)
+	}
+	if got := graphValueInt(scanNode.Properties["iac_artifact_count"]); got != 2 {
+		t.Fatalf("expected iac_artifact_count=2, got %#v", scanNode.Properties)
+	}
+
+	observationID := iacFindingObservationNodeID(run.ID, run.Volumes[0].Analysis.Catalog.Misconfigurations[0])
+	observationNode, ok := g.GetNode(observationID)
+	if !ok {
+		t.Fatalf("expected observation node %q", observationID)
+	}
+	if observationNode.Kind != graph.NodeKindObservation {
+		t.Fatalf("expected observation kind, got %#v", observationNode)
+	}
+	if got := graphValueString(observationNode.Properties["observation_type"]); got != "workload_iac_finding" {
+		t.Fatalf("expected observation_type workload_iac_finding, got %#v", observationNode.Properties)
+	}
+	if got := graphValueString(observationNode.Properties["resource_type"]); got != "terraform_state" {
+		t.Fatalf("expected observation resource_type terraform_state, got %#v", observationNode.Properties)
+	}
+	if edge := findOutEdge(g, observationID, graph.EdgeKindTargets, run.ID); edge == nil {
+		t.Fatalf("expected observation to target scan node, got %#v", g.GetOutEdges(observationID))
+	}
+}
+
+func TestMaterializeRunsIntoGraphAppliesLegacyMisconfigurationRiskWithoutObservation(t *testing.T) {
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:       "arn:aws:ec2:us-east-1:123456789012:instance/i-abc123",
+		Kind:     graph.NodeKindInstance,
+		Name:     "i-abc123",
+		Provider: "aws",
+		Account:  "123456789012",
+		Region:   "us-east-1",
+	})
+	g.BuildIndex()
+
+	run := buildGraphMaterializationTestRun("workload_scan:run-legacy-misconfig", now.Add(-2*time.Hour), 0)
+	run.Summary.Findings = 1
+	run.Volumes[0].Analysis.FindingCount = 1
+	run.Volumes[0].Analysis.Catalog.Misconfigurations = []filesystemanalyzer.ConfigFinding{{
+		ID:       "finding:ssh-root-login",
+		Type:     "ssh",
+		Severity: "high",
+		Path:     "etc/ssh/sshd_config",
+		Title:    "SSH root login enabled",
+	}}
+
+	summary := MaterializeRunsIntoGraph(g, []RunRecord{run}, now)
+	if summary.ObservationNodesUpserted != 0 {
+		t.Fatalf("expected no IaC observations for legacy config finding, got %#v", summary)
+	}
+
+	scanNode, ok := g.GetNode(run.ID)
+	if !ok {
+		t.Fatalf("expected workload scan node %q", run.ID)
+	}
+	if scanNode.Risk != graph.RiskHigh {
+		t.Fatalf("expected legacy misconfiguration to raise scan risk, got %#v", scanNode)
+	}
+}
+
 func TestMaterializeRunsIntoGraphMapsDatabaseConnectionStrings(t *testing.T) {
 	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
 	g := graph.New()


### PR DESCRIPTION
## Summary
- detect Terraform, Kubernetes, Helm, Docker, Ansible, env, and related IaC/config artifacts during workload filesystem scans and surface typed findings directly from the existing analyzer walk
- materialize workload IaC findings into graph observation nodes and workload scan summaries so IaC-only scans raise durable graph-visible risk
- extend analyzer and graph-materialization regression coverage for IaC detection, risk semantics, and artifact counting

## Testing
- go test ./internal/filesystemanalyzer ./internal/workloadscan -count=1
- make devex-pr
- python3 scripts/oss_audit.py
