### PR TITLE
fix(ci): stabilize time-sensitive main checks

### DIFF
--- a/.github/workflows/security-source-scan.yml
+++ b/.github/workflows/security-source-scan.yml
@@ -10,8 +10,14 @@ permissions:
 
 jobs:
   gosec-source-scan:
+    name: gosec-source-scan shard ${{ matrix.shard_index }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [0, 1, 2, 3]
+        shard_total: [4]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -19,25 +25,40 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.24.7
 
-      - name: Run gosec (JSON report)
+      - name: Run gosec shard (JSON report)
         shell: bash
         run: |
           set -euo pipefail
-          $(go env GOPATH)/bin/gosec -severity medium -confidence medium -exclude-generated -fmt=json -out gosec-report.json ./... || true
+          report_path="gosec-report-${{ matrix.shard_index }}.json"
+          mapfile -t all_packages < <(go list -f '{{.Dir}}' ./...)
+          selected=()
+          for i in "${!all_packages[@]}"; do
+            if (( i % ${{ matrix.shard_total }} == ${{ matrix.shard_index }} )); then
+              selected+=("${all_packages[$i]}")
+            fi
+          done
+          echo "Running gosec shard ${{ matrix.shard_index }} with ${#selected[@]} packages"
+          printf '{"Issues":[]}' > "${report_path}"
+          if [ "${#selected[@]}" -eq 0 ]; then
+            exit 0
+          fi
+          $(go env GOPATH)/bin/gosec -severity medium -confidence medium -exclude-generated -fmt=json -out "${report_path}" "${selected[@]}" || true
 
       - name: Fail on HIGH findings
         shell: bash
         run: |
           set -euo pipefail
-          python3 - <<'PY'
+          report_path="gosec-report-${{ matrix.shard_index }}.json"
+          python3 - "${report_path}" <<'PY'
           import json
           import sys
 
-          with open('gosec-report.json', 'r', encoding='utf-8') as f:
+          with open(sys.argv[1], 'r', encoding='utf-8') as f:
               data = json.load(f)
 
           issues = data.get('Issues') or []
@@ -58,5 +79,5 @@ jobs:
       - name: Upload gosec report artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: gosec-report
-          path: gosec-report.json
+          name: gosec-report-${{ matrix.shard_index }}
+          path: gosec-report-${{ matrix.shard_index }}.json

--- a/internal/api/server_handlers_platform_graph_snapshots_test.go
+++ b/internal/api/server_handlers_platform_graph_snapshots_test.go
@@ -458,7 +458,11 @@ func TestPlatformGraphChangelogAndDiffDetailsEndpoints(t *testing.T) {
 		}
 		return nil
 	})
-	changelog := do(t, s, http.MethodGet, "/api/v1/platform/graph/changelog?last=7d&provider=aws&limit=1", nil)
+	changelog := do(t, s, http.MethodGet, fmt.Sprintf(
+		"/api/v1/platform/graph/changelog?since=%s&until=%s&provider=aws&limit=1",
+		base.Add(-time.Hour).Format(time.RFC3339),
+		base.Add(3*time.Hour).Format(time.RFC3339),
+	), nil)
 	if changelog.Code != http.StatusOK {
 		t.Fatalf("expected 200 for graph changelog, got %d: %s", changelog.Code, changelog.Body.String())
 	}
@@ -572,7 +576,11 @@ func TestPlatformGraphChangelogUsesExplicitParentSnapshotLineage(t *testing.T) {
 	})
 
 	s := newTestServer(t)
-	changelog := do(t, s, http.MethodGet, "/api/v1/platform/graph/changelog?last=7d&provider=aws&limit=1", nil)
+	changelog := do(t, s, http.MethodGet, fmt.Sprintf(
+		"/api/v1/platform/graph/changelog?since=%s&until=%s&provider=aws&limit=1",
+		base.Add(-time.Hour).Format(time.RFC3339),
+		base.Add(3*time.Hour).Format(time.RFC3339),
+	), nil)
 	if changelog.Code != http.StatusOK {
 		t.Fatalf("expected 200 for graph changelog, got %d: %s", changelog.Code, changelog.Body.String())
 	}

--- a/internal/app/app_cerebro_tools_temporal_test.go
+++ b/internal/app/app_cerebro_tools_temporal_test.go
@@ -157,7 +157,15 @@ func TestCerebroGraphChangelogTool(t *testing.T) {
 		t.Fatal("expected cerebro.graph_changelog tool")
 	}
 
-	result, err := tool.Handler(context.Background(), json.RawMessage(`{"last":"7d","provider":"aws","limit":1}`))
+	result, err := tool.Handler(context.Background(), json.RawMessage(fmt.Sprintf(`{
+		"since":%q,
+		"until":%q,
+		"provider":"aws",
+		"limit":1
+	}`,
+		base.Add(-time.Hour).Format(time.RFC3339),
+		base.Add(3*time.Hour).Format(time.RFC3339),
+	)))
 	if err != nil {
 		t.Fatalf("graph_changelog returned error: %v", err)
 	}

--- a/internal/graph/intelligence_report_test.go
+++ b/internal/graph/intelligence_report_test.go
@@ -126,7 +126,7 @@ func TestBuildIntelligenceReport_DeterministicInsightOrderAndIDs(t *testing.T) {
 }
 
 func TestBuildIntelligenceReport_FreshnessPenalizesConfidence(t *testing.T) {
-	now := time.Date(2026, 3, 8, 22, 0, 0, 0, time.UTC)
+	now := time.Now().UTC().Truncate(time.Second)
 
 	fresh := New()
 	fresh.AddNode(&Node{ID: "service:fresh", Kind: NodeKindService, Name: "Fresh", Properties: map[string]any{


### PR DESCRIPTION
## Summary
- replace date-sensitive `last=7d` changelog test windows with explicit `since`/`until` ranges
- make the freshness confidence test relative to the current clock so it stays meaningful over time
- pin and shard the scheduled source gosec scan to avoid the flaky runner-shutdown behavior on main

## Validation
- `go test ./... -count=1`
- `$(go env GOPATH)/bin/golangci-lint run --timeout 15m ./cmd/... ./internal/... ./api/...`