### PR TITLE
Add Terraform-backed S3 encryption remediation (#299)

### DIFF
--- a/internal/remediation/catalog.go
+++ b/internal/remediation/catalog.go
@@ -11,22 +11,24 @@ const (
 )
 
 type CatalogEntry struct {
-	ID                   string            `json:"id"`
-	ActionType           ActionType        `json:"action_type"`
-	Name                 string            `json:"name"`
-	Description          string            `json:"description"`
-	Providers            []string          `json:"providers,omitempty"`
-	ResourceTypes        []string          `json:"resource_types,omitempty"`
-	SafeByDefault        bool              `json:"safe_by_default"`
-	SupportsDryRun       bool              `json:"supports_dry_run"`
-	SupportsRollback     bool              `json:"supports_rollback"`
-	RequiresApproval     bool              `json:"requires_approval"`
-	BlastRadius          BlastRadiusClass  `json:"blast_radius"`
-	Preconditions        []string          `json:"preconditions,omitempty"`
-	RollbackSteps        []string          `json:"rollback_steps,omitempty"`
-	EvidenceFields       []string          `json:"evidence_fields,omitempty"`
-	DefaultRemoteTools   map[string]string `json:"default_remote_tools,omitempty"`
-	BlastRadiusRationale string            `json:"blast_radius_rationale,omitempty"`
+	ID                     string            `json:"id"`
+	ActionType             ActionType        `json:"action_type"`
+	Name                   string            `json:"name"`
+	Description            string            `json:"description"`
+	Providers              []string          `json:"providers,omitempty"`
+	ResourceTypes          []string          `json:"resource_types,omitempty"`
+	SafeByDefault          bool              `json:"safe_by_default"`
+	SupportsDryRun         bool              `json:"supports_dry_run"`
+	SupportsRollback       bool              `json:"supports_rollback"`
+	RequiresApproval       bool              `json:"requires_approval"`
+	BlastRadius            BlastRadiusClass  `json:"blast_radius"`
+	Preconditions          []string          `json:"preconditions,omitempty"`
+	RollbackSteps          []string          `json:"rollback_steps,omitempty"`
+	EvidenceFields         []string          `json:"evidence_fields,omitempty"`
+	DefaultRemoteTools     map[string]string `json:"default_remote_tools,omitempty"`
+	SupportedDeliveryModes []DeliveryMode    `json:"supported_delivery_modes,omitempty"`
+	DefaultDeliveryMode    DeliveryMode      `json:"default_delivery_mode,omitempty"`
+	BlastRadiusRationale   string            `json:"blast_radius_rationale,omitempty"`
 }
 
 var remediationCatalog = []CatalogEntry{
@@ -60,6 +62,10 @@ var remediationCatalog = []CatalogEntry{
 			"before",
 			"after",
 		},
+		SupportedDeliveryModes: []DeliveryMode{
+			DeliveryModeRemoteApply,
+		},
+		DefaultDeliveryMode: DeliveryModeRemoteApply,
 		DefaultRemoteTools: map[string]string{
 			"aws":   "aws.s3.block_public_access",
 			"gcp":   "gcp.storage.remove_public_access",
@@ -98,11 +104,57 @@ var remediationCatalog = []CatalogEntry{
 			"before",
 			"after",
 		},
+		SupportedDeliveryModes: []DeliveryMode{
+			DeliveryModeRemoteApply,
+		},
+		DefaultDeliveryMode: DeliveryModeRemoteApply,
 		DefaultRemoteTools: map[string]string{
 			"aws": "aws.iam.disable_access_key",
 			"gcp": "gcp.iam.disable_service_account_key",
 		},
 		BlastRadiusRationale: "Disables one stale credential instead of deleting an identity or broadening access.",
+	},
+	{
+		ID:               "enable_bucket_default_encryption",
+		ActionType:       ActionEnableBucketDefaultEncryption,
+		Name:             "Enable bucket default encryption",
+		Description:      "Configure default server-side encryption on a cloud bucket so new objects are encrypted at rest.",
+		Providers:        []string{"aws"},
+		ResourceTypes:    []string{"bucket", "storage/bucket", "storage_bucket", "aws:s3:bucket"},
+		SafeByDefault:    true,
+		SupportsDryRun:   true,
+		SupportsRollback: true,
+		RequiresApproval: true,
+		BlastRadius:      BlastRadiusLow,
+		Preconditions: []string{
+			"The bucket still does not have default encryption configured.",
+			"The bucket identifier and provider are known.",
+		},
+		RollbackSteps: []string{
+			"Restore the previous bucket encryption configuration from the captured evidence snapshot.",
+			"Remove the newly applied default encryption configuration only if the change was intentional and validated.",
+		},
+		EvidenceFields: []string{
+			"policy_id",
+			"resource_id",
+			"resource_name",
+			"provider",
+			"sse_algorithm",
+			"kms_master_key_id",
+			"bucket_key_enabled",
+			"artifact",
+			"before",
+			"after",
+		},
+		SupportedDeliveryModes: []DeliveryMode{
+			DeliveryModeTerraform,
+			DeliveryModeRemoteApply,
+		},
+		DefaultDeliveryMode: DeliveryModeTerraform,
+		DefaultRemoteTools: map[string]string{
+			"aws": "aws.s3.put_bucket_encryption",
+		},
+		BlastRadiusRationale: "Applies default encryption to one bucket for future writes without deleting data or changing access.",
 	},
 	{
 		ID:               "restrict_public_security_group_ingress",
@@ -135,6 +187,10 @@ var remediationCatalog = []CatalogEntry{
 			"before",
 			"after",
 		},
+		SupportedDeliveryModes: []DeliveryMode{
+			DeliveryModeRemoteApply,
+		},
+		DefaultDeliveryMode: DeliveryModeRemoteApply,
 		DefaultRemoteTools: map[string]string{
 			"aws": "aws.ec2.revoke_security_group_ingress",
 		},
@@ -172,6 +228,7 @@ func cloneCatalogEntry(entry CatalogEntry) CatalogEntry {
 	entry.Preconditions = append([]string(nil), entry.Preconditions...)
 	entry.RollbackSteps = append([]string(nil), entry.RollbackSteps...)
 	entry.EvidenceFields = append([]string(nil), entry.EvidenceFields...)
+	entry.SupportedDeliveryModes = append([]DeliveryMode(nil), entry.SupportedDeliveryModes...)
 	if len(entry.DefaultRemoteTools) > 0 {
 		clonedTools := make(map[string]string, len(entry.DefaultRemoteTools))
 		for key, value := range entry.DefaultRemoteTools {

--- a/internal/remediation/catalog_actions.go
+++ b/internal/remediation/catalog_actions.go
@@ -15,6 +15,7 @@ type catalogActionPlan struct {
 	resourceID        string
 	resourceName      string
 	resourceType      string
+	deliveryMode      DeliveryMode
 	tool              string
 	dryRun            bool
 	approvalRequired  bool
@@ -32,6 +33,9 @@ func (ex *Executor) executeCatalogAction(ctx context.Context, action Action, exe
 	switch action.Type {
 	case ActionRestrictPublicStorageAccess:
 		output, metadata, err := ex.restrictPublicStorageAccess(ctx, action, execution)
+		return output, metadata, err, true
+	case ActionEnableBucketDefaultEncryption:
+		output, metadata, err := ex.enableBucketDefaultEncryption(ctx, action, execution)
 		return output, metadata, err, true
 	case ActionDisableStaleAccessKey:
 		output, metadata, err := ex.disableStaleAccessKey(ctx, action, execution)
@@ -76,6 +80,80 @@ func (ex *Executor) restrictPublicStorageAccess(ctx context.Context, action Acti
 		return "", metadata, err
 	}
 	return firstNonEmpty(strings.TrimSpace(output), "Public access restricted"), metadata, nil
+}
+
+func (ex *Executor) enableBucketDefaultEncryption(ctx context.Context, action Action, execution *Execution) (string, map[string]any, error) {
+	entry, _ := CatalogEntryByAction(action.Type)
+	plan := newCatalogActionPlan(action, execution, entry, ex.actionRequiresApproval(action))
+	sseAlgorithm := firstNonEmpty(strings.TrimSpace(action.Config["sse_algorithm"]), "AES256")
+	kmsMasterKeyID := strings.TrimSpace(action.Config["kms_master_key_id"])
+	bucketKeyEnabled := configBool(action.Config["bucket_key_enabled"])
+	plan.before = captureBucketEncryptionEvidence(execution)
+
+	disabled, detail := bucketDefaultEncryptionStillDisabled(execution)
+	plan.preconditionCheck = append(plan.preconditionCheck,
+		preconditionResult("resource identifier available", plan.resourceID != "", firstNonEmpty(plan.resourceID, "missing resource identifier")),
+		preconditionResult("provider supported", plan.provider == "aws" && (plan.deliveryMode == DeliveryModeTerraform || plan.tool != ""), firstNonEmpty(plan.provider, "missing provider")),
+		preconditionResult("bucket default encryption still disabled", disabled, detail),
+	)
+	metadata := plan.metadata(map[string]any{
+		"sse_algorithm":      sseAlgorithm,
+		"kms_master_key_id":  kmsMasterKeyID,
+		"bucket_key_enabled": bucketKeyEnabled,
+	})
+	if !catalogSupportsDeliveryMode(entry, plan.deliveryMode) {
+		return "", compactAnyMap(metadata), fmt.Errorf("delivery mode %q is not supported for %s", plan.deliveryMode, action.Type)
+	}
+	metadata = compactAnyMap(metadata)
+	if !allPreconditionsPassed(plan.preconditionCheck) {
+		return "", metadata, fmt.Errorf("enable bucket default encryption precondition failed")
+	}
+
+	enrichExecutionWithCatalogPlan(execution, plan)
+	if execution.TriggerData == nil {
+		execution.TriggerData = map[string]any{}
+	}
+	execution.TriggerData["sse_algorithm"] = sseAlgorithm
+	if kmsMasterKeyID != "" {
+		execution.TriggerData["kms_master_key_id"] = kmsMasterKeyID
+	}
+	if bucketKeyEnabled {
+		execution.TriggerData["bucket_key_enabled"] = true
+	}
+
+	if plan.deliveryMode == DeliveryModeTerraform {
+		artifact, err := renderTerraformBucketDefaultEncryptionArtifact(execution, sseAlgorithm, kmsMasterKeyID, bucketKeyEnabled)
+		if err != nil {
+			return "", compactAnyMap(metadata), err
+		}
+		metadata["artifact"] = terraformArtifactMetadata(artifact)
+		metadata["after"] = map[string]any{
+			"planned":          true,
+			"delivery_mode":    string(plan.deliveryMode),
+			"change":           "terraform configuration generated for bucket default encryption",
+			"artifact_path":    artifact.Path,
+			"resource_address": artifact.ResourceAddress,
+		}
+		return fmt.Sprintf("Generated Terraform remediation at %s", artifact.Path), compactAnyMap(metadata), nil
+	}
+
+	if plan.dryRun {
+		metadata["after"] = map[string]any{
+			"planned":            true,
+			"change":             "bucket default encryption would be enabled",
+			"sse_algorithm":      sseAlgorithm,
+			"kms_master_key_id":  kmsMasterKeyID,
+			"bucket_key_enabled": bucketKeyEnabled,
+		}
+		return fmt.Sprintf("Dry-run: would invoke %s", plan.tool), compactAnyMap(metadata), nil
+	}
+
+	output, err := ex.executeCatalogRemoteAction(ctx, action, execution, plan)
+	metadata["after"] = catalogAfterState(output, err)
+	if err != nil {
+		return "", compactAnyMap(metadata), err
+	}
+	return firstNonEmpty(strings.TrimSpace(output), fmt.Sprintf("Enabled bucket default encryption using %s", sseAlgorithm)), compactAnyMap(metadata), nil
 }
 
 func (ex *Executor) restrictPublicSecurityGroupIngress(ctx context.Context, action Action, execution *Execution) (string, map[string]any, error) {
@@ -193,13 +271,19 @@ func (ex *Executor) executeCatalogRemoteAction(ctx context.Context, action Actio
 
 func newCatalogActionPlan(action Action, execution *Execution, entry CatalogEntry, approvalRequired bool) catalogActionPlan {
 	provider := inferProvider(execution)
+	deliveryMode := actionDeliveryMode(action, entry)
+	tool := ""
+	if deliveryMode == DeliveryModeRemoteApply {
+		tool = firstNonEmpty(action.Config["tool"], catalogToolForProvider(entry, provider))
+	}
 	return catalogActionPlan{
 		entry:            entry,
 		provider:         provider,
 		resourceID:       firstNonEmpty(remediationMapValueToString(execution.TriggerData, "entity_id"), remediationMapValueToString(execution.TriggerData, "resource_id"), remediationMapValueToString(execution.TriggerData, "resource_external_id")),
 		resourceName:     remediationMapValueToString(execution.TriggerData, "resource_name"),
 		resourceType:     remediationMapValueToString(execution.TriggerData, "resource_type"),
-		tool:             firstNonEmpty(action.Config["tool"], catalogToolForProvider(entry, provider)),
+		deliveryMode:     deliveryMode,
+		tool:             tool,
 		dryRun:           dryRunEnabled(action, execution),
 		approvalRequired: approvalRequired,
 	}
@@ -213,6 +297,7 @@ func (p catalogActionPlan) metadata(extra map[string]any) map[string]any {
 		"resource_id":         p.resourceID,
 		"resource_name":       p.resourceName,
 		"resource_type":       p.resourceType,
+		"delivery_mode":       string(p.deliveryMode),
 		"dry_run":             p.dryRun,
 		"requires_approval":   p.approvalRequired,
 		"blast_radius":        p.entry.BlastRadius,
@@ -339,6 +424,22 @@ func captureStorageAccessEvidence(execution *Execution) map[string]any {
 	return compactAnyMap(evidence)
 }
 
+func captureBucketEncryptionEvidence(execution *Execution) map[string]any {
+	evidence := map[string]any{
+		"resource_id":          firstNonEmpty(remediationMapValueToString(execution.TriggerData, "entity_id"), remediationMapValueToString(execution.TriggerData, "resource_id")),
+		"resource_name":        remediationMapValueToString(execution.TriggerData, "resource_name"),
+		"resource_type":        remediationMapValueToString(execution.TriggerData, "resource_type"),
+		"resource_platform":    remediationMapValueToString(execution.TriggerData, "resource_platform"),
+		"resource_external_id": remediationMapValueToString(execution.TriggerData, "resource_external_id"),
+		"policy_id":            remediationMapValueToString(execution.TriggerData, "policy_id"),
+	}
+	copyFields(evidence, execution.TriggerData, "encrypted", "default_encryption", "default_encryption_enabled", "encryption_enabled", "server_side_encryption_enabled", "kms_encrypted", "encryption", "sse_algorithm", "encryption_algorithm", "kms_master_key_id", "encryption_key_id", "bucket_key_enabled", "server_side_encryption_configuration", "encryption_configuration")
+	if resource, ok := execution.TriggerData["resource"].(map[string]any); ok && len(resource) > 0 {
+		evidence["resource"] = cloneAnyMap(resource)
+	}
+	return compactAnyMap(evidence)
+}
+
 func captureSecurityGroupIngressEvidence(execution *Execution, matches []map[string]any) map[string]any {
 	evidence := map[string]any{
 		"resource_id":          firstNonEmpty(remediationMapValueToString(execution.TriggerData, "entity_id"), remediationMapValueToString(execution.TriggerData, "resource_id")),
@@ -408,6 +509,66 @@ func publicSecurityGroupIngressMatches(execution *Execution) ([]map[string]any, 
 		return nil, "current security group data does not confirm a matching public ingress rule"
 	}
 	return nil, "no matching public ingress rule found in trigger data"
+}
+
+func bucketDefaultEncryptionStillDisabled(execution *Execution) (bool, string) {
+	if execution == nil {
+		return false, "missing execution context"
+	}
+	data := execution.TriggerData
+	if value, detail, ok := bucketDefaultEncryptionFromValue(data["resource"], "resource payload"); ok {
+		return value, detail
+	}
+	if resource, ok := anyMap(data["resource"]); ok {
+		if value, detail, ok := bucketDefaultEncryptionFromValue(resource["resource_json"], "resource payload resource_json"); ok {
+			return value, detail
+		}
+	}
+	if value, detail, ok := bucketDefaultEncryptionFromValue(data["resource_json"], "trigger data resource_json"); ok {
+		return value, detail
+	}
+	if value, detail, ok := bucketDefaultEncryptionFromValue(data, "trigger data"); ok {
+		return value, detail
+	}
+	if strings.EqualFold(strings.TrimSpace(remediationMapValueToString(data, "policy_id")), "aws-s3-bucket-encryption-enabled") {
+		return true, "current bucket data does not show default encryption enabled"
+	}
+	return false, "current bucket data does not confirm default encryption is disabled"
+}
+
+func bucketDefaultEncryptionFromValue(raw any, source string) (bool, string, bool) {
+	values, ok := anyMap(raw)
+	if !ok {
+		return false, "", false
+	}
+	enabled, known := bucketDefaultEncryptionEnabled(values)
+	if !known {
+		return false, "", false
+	}
+	if enabled {
+		return false, fmt.Sprintf("%s shows default encryption enabled", source), true
+	}
+	return true, fmt.Sprintf("%s does not show default encryption enabled", source), true
+}
+
+func bucketDefaultEncryptionEnabled(values map[string]any) (bool, bool) {
+	if len(values) == 0 {
+		return false, false
+	}
+	if enabled, ok := firstBool(values, "encrypted", "default_encryption", "default_encryption_enabled", "encryption_enabled", "server_side_encryption_enabled", "kms_encrypted"); ok {
+		return enabled, true
+	}
+	for _, key := range []string{"server_side_encryption_configuration", "encryption_configuration"} {
+		if raw, ok := values[key]; ok {
+			return hasStructuredValue(raw), true
+		}
+	}
+	for _, key := range []string{"sse_algorithm", "encryption_algorithm", "kms_master_key_id", "encryption_key_id", "encryption"} {
+		if raw, ok := values[key]; ok {
+			return strings.TrimSpace(stringValue(raw)) != "", true
+		}
+	}
+	return false, false
 }
 
 func securityGroupMatchesFromPermissions(raw any, policyID string) []map[string]any {
@@ -905,5 +1066,23 @@ func configBool(raw string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func hasStructuredValue(raw any) bool {
+	switch typed := raw.(type) {
+	case nil:
+		return false
+	case string:
+		text := strings.TrimSpace(typed)
+		return text != "" && text != "null"
+	case []any:
+		return len(typed) > 0
+	case []map[string]any:
+		return len(typed) > 0
+	case map[string]any:
+		return len(typed) > 0
+	default:
+		return strings.TrimSpace(stringValue(raw)) != ""
 	}
 }

--- a/internal/remediation/catalog_actions_test.go
+++ b/internal/remediation/catalog_actions_test.go
@@ -15,6 +15,60 @@ func TestPublicStorageAccessStillEnabled_ParsesResourceJSON(t *testing.T) {
 	}
 }
 
+func TestBucketDefaultEncryptionStillDisabled_MatchesPolicySignalWithoutConfig(t *testing.T) {
+	execution := &Execution{
+		TriggerData: map[string]any{
+			"policy_id": "aws-s3-bucket-encryption-enabled",
+			"resource": map[string]any{
+				"name": "audit-logs",
+			},
+		},
+	}
+
+	disabled, detail := bucketDefaultEncryptionStillDisabled(execution)
+	if !disabled {
+		t.Fatalf("disabled = false, want true (detail=%q)", detail)
+	}
+}
+
+func TestBucketDefaultEncryptionStillDisabled_DetectsExistingConfig(t *testing.T) {
+	execution := &Execution{
+		TriggerData: map[string]any{
+			"policy_id": "aws-s3-bucket-encryption-enabled",
+			"resource": map[string]any{
+				"sse_algorithm": "AES256",
+			},
+		},
+	}
+
+	disabled, detail := bucketDefaultEncryptionStillDisabled(execution)
+	if disabled {
+		t.Fatalf("disabled = true, want false (detail=%q)", detail)
+	}
+}
+
+func TestBucketDefaultEncryptionStillDisabled_DetectsExistingConfigInResourceJSON(t *testing.T) {
+	execution := &Execution{
+		TriggerData: map[string]any{
+			"policy_id": "aws-s3-bucket-encryption-enabled",
+			"resource": map[string]any{
+				"resource_json": map[string]any{
+					"encryption_configuration": map[string]any{
+						"rules": []any{
+							map[string]any{"sse_algorithm": "AES256"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	disabled, detail := bucketDefaultEncryptionStillDisabled(execution)
+	if disabled {
+		t.Fatalf("disabled = true, want false (detail=%q)", detail)
+	}
+}
+
 func TestPublicSecurityGroupIngressMatchesRuleRows(t *testing.T) {
 	execution := &Execution{
 		TriggerData: map[string]any{

--- a/internal/remediation/catalog_test.go
+++ b/internal/remediation/catalog_test.go
@@ -38,6 +38,26 @@ func TestCatalogIncludesSafeCloudRemediations(t *testing.T) {
 		t.Fatalf("unexpected gcp tool mapping: %q", got)
 	}
 
+	encryption, ok := byAction[ActionEnableBucketDefaultEncryption]
+	if !ok {
+		t.Fatal("expected bucket default encryption catalog entry")
+	}
+	if !encryption.SafeByDefault || !encryption.SupportsDryRun || !encryption.SupportsRollback {
+		t.Fatalf("expected bucket encryption entry to be safe dry-run rollback capable, got %+v", encryption)
+	}
+	if encryption.BlastRadius != BlastRadiusLow {
+		t.Fatalf("expected bucket encryption action blast radius to be low, got %s", encryption.BlastRadius)
+	}
+	if encryption.DefaultDeliveryMode != DeliveryModeTerraform {
+		t.Fatalf("expected bucket encryption default delivery mode to be terraform, got %s", encryption.DefaultDeliveryMode)
+	}
+	if len(encryption.SupportedDeliveryModes) != 2 || encryption.SupportedDeliveryModes[0] != DeliveryModeTerraform || encryption.SupportedDeliveryModes[1] != DeliveryModeRemoteApply {
+		t.Fatalf("unexpected supported delivery modes: %#v", encryption.SupportedDeliveryModes)
+	}
+	if got := encryption.DefaultRemoteTools["aws"]; got != "aws.s3.put_bucket_encryption" {
+		t.Fatalf("unexpected aws bucket encryption tool mapping: %q", got)
+	}
+
 	ingress, ok := byAction[ActionRestrictPublicSecurityGroupIngress]
 	if !ok {
 		t.Fatal("expected public security group ingress catalog entry")

--- a/internal/remediation/engine.go
+++ b/internal/remediation/engine.go
@@ -106,6 +106,7 @@ const (
 	ActionSendCustomerComm  ActionType = "send_customer_comm"
 
 	ActionRestrictPublicStorageAccess        ActionType = "restrict_public_storage_access"
+	ActionEnableBucketDefaultEncryption      ActionType = "enable_bucket_default_encryption"
 	ActionDisableStaleAccessKey              ActionType = "disable_stale_access_key"
 	ActionRestrictPublicSecurityGroupIngress ActionType = "restrict_public_security_group_ingress"
 )
@@ -265,6 +266,54 @@ func (e *Engine) loadDefaultRules() {
 					Type: ActionRestrictPublicStorageAccess,
 					Config: map[string]string{
 						"approval_mode": "required",
+					},
+					RequiresApproval: false,
+				},
+			},
+		},
+		{
+			ID:          "s3-encryption-notify",
+			Name:        "Alert on unencrypted S3 bucket",
+			Description: "Create tracking for S3 buckets that do not have default encryption enabled",
+			Enabled:     true,
+			Trigger: Trigger{
+				Type:     TriggerFindingCreated,
+				PolicyID: "aws-s3-bucket-encryption-enabled",
+			},
+			Actions: []Action{
+				{
+					Type: ActionNotifySlack,
+					Config: map[string]string{
+						"channel": "#security-alerts",
+						"message": "UNENCRYPTED S3 BUCKET DETECTED - Approval required for default encryption",
+					},
+					RequiresApproval: false,
+				},
+				{
+					Type: ActionCreateTicket,
+					Config: map[string]string{
+						"priority": "high",
+						"labels":   "s3,encryption,data-protection",
+					},
+					RequiresApproval: false,
+				},
+			},
+		},
+		{
+			ID:          "s3-encryption-terraform",
+			Name:        "Generate Terraform for S3 bucket encryption",
+			Description: "Generate Terraform code for enabling default S3 bucket encryption using the existing IaC context when available",
+			Enabled:     true,
+			Trigger: Trigger{
+				Type:     TriggerFindingCreated,
+				PolicyID: "aws-s3-bucket-encryption-enabled",
+			},
+			Actions: []Action{
+				{
+					Type: ActionEnableBucketDefaultEncryption,
+					Config: map[string]string{
+						"delivery_mode": "terraform",
+						"sse_algorithm": "AES256",
 					},
 					RequiresApproval: false,
 				},

--- a/internal/remediation/engine_test.go
+++ b/internal/remediation/engine_test.go
@@ -36,6 +36,8 @@ func TestEngine_ListRules(t *testing.T) {
 		"auto-ticket-high",
 		"s3-public-notify",
 		"s3-public-restrict",
+		"s3-encryption-notify",
+		"s3-encryption-terraform",
 		"gcs-public-notify",
 		"gcs-public-restrict",
 		"gcs-public-principal-notify",
@@ -82,6 +84,17 @@ func TestEngine_DefaultSafeCatalogRulesIncludeApprovalGatedActions(t *testing.T)
 	}
 	if len(s3RestrictRule.Actions) != 1 || s3RestrictRule.Actions[0].Type != ActionRestrictPublicStorageAccess {
 		t.Fatalf("expected dedicated restrict action rule, got %+v", s3RestrictRule.Actions)
+	}
+
+	s3EncryptionRule, ok := engine.GetRule("s3-encryption-terraform")
+	if !ok {
+		t.Fatal("expected s3-encryption-terraform rule")
+	}
+	if len(s3EncryptionRule.Actions) != 1 || s3EncryptionRule.Actions[0].Type != ActionEnableBucketDefaultEncryption {
+		t.Fatalf("expected dedicated encryption action rule, got %+v", s3EncryptionRule.Actions)
+	}
+	if s3EncryptionRule.Actions[0].Config["delivery_mode"] != "terraform" {
+		t.Fatalf("expected bucket encryption rule to default to terraform delivery, got %#v", s3EncryptionRule.Actions[0].Config)
 	}
 
 	keyRule, ok := engine.GetRule("aws-unused-access-key-disable")
@@ -143,6 +156,24 @@ func TestEngine_ApprovalCatalogRulesDoNotBlockNotificationRules(t *testing.T) {
 	restrictPlaybook := remediationPlaybookFromRule(*restrictRule, executor)
 	if !executor.shared.RequiresApproval(restrictPlaybook) {
 		t.Fatal("expected s3-public-restrict playbook to require approval")
+	}
+
+	notifyEncryptionRule, ok := engine.GetRule("s3-encryption-notify")
+	if !ok {
+		t.Fatal("expected s3-encryption-notify rule")
+	}
+	notifyEncryptionPlaybook := remediationPlaybookFromRule(*notifyEncryptionRule, executor)
+	if executor.shared.RequiresApproval(notifyEncryptionPlaybook) {
+		t.Fatal("expected s3-encryption-notify playbook not to require approval")
+	}
+
+	enableEncryptionRule, ok := engine.GetRule("s3-encryption-terraform")
+	if !ok {
+		t.Fatal("expected s3-encryption-terraform rule")
+	}
+	enableEncryptionPlaybook := remediationPlaybookFromRule(*enableEncryptionRule, executor)
+	if executor.shared.RequiresApproval(enableEncryptionPlaybook) {
+		t.Fatal("expected s3-encryption-terraform playbook not to require approval")
 	}
 
 	notifyKeyRule, ok := engine.GetRule("aws-unused-access-key-notify")

--- a/internal/remediation/ensemble_executor.go
+++ b/internal/remediation/ensemble_executor.go
@@ -48,7 +48,7 @@ func (e *EnsembleExecutor) HasRemoteCaller() bool {
 
 func (e *EnsembleExecutor) ActionRequiresApproval(actionType ActionType) bool {
 	switch actionType {
-	case ActionPauseSubscription, ActionSendCustomerComm, ActionRestrictPublicStorageAccess, ActionDisableStaleAccessKey, ActionRestrictPublicSecurityGroupIngress:
+	case ActionPauseSubscription, ActionSendCustomerComm, ActionRestrictPublicStorageAccess, ActionEnableBucketDefaultEncryption, ActionDisableStaleAccessKey, ActionRestrictPublicSecurityGroupIngress:
 		return true
 	default:
 		return false
@@ -111,7 +111,7 @@ func (e *EnsembleExecutor) ExecuteWithOutput(ctx context.Context, action Action,
 		tool := firstNonEmpty(action.Config["tool"], "slack.send_message")
 		return e.callWithRetry(ctx, tool, action, execution, args, timeout)
 
-	case ActionRestrictPublicStorageAccess, ActionDisableStaleAccessKey, ActionRestrictPublicSecurityGroupIngress:
+	case ActionRestrictPublicStorageAccess, ActionEnableBucketDefaultEncryption, ActionDisableStaleAccessKey, ActionRestrictPublicSecurityGroupIngress:
 		tool := strings.TrimSpace(action.Config["tool"])
 		if tool == "" {
 			return "", fmt.Errorf("ensemble tool name is required")

--- a/internal/remediation/executor.go
+++ b/internal/remediation/executor.go
@@ -123,7 +123,12 @@ func (ex *Executor) actionRequiresApproval(action Action) bool {
 	case "required", "manual":
 		return true
 	}
-	if action.RequiresApproval {
+	entry, _ := CatalogEntryByAction(action.Type)
+	mode := actionDeliveryMode(action, entry)
+	if catalogSupportsDeliveryMode(entry, mode) && mode == DeliveryModeTerraform {
+		return false
+	}
+	if action.RequiresApproval || entry.RequiresApproval {
 		return true
 	}
 	if ex != nil && ex.ensemble != nil {

--- a/internal/remediation/executor_test.go
+++ b/internal/remediation/executor_test.go
@@ -491,7 +491,6 @@ func TestExecutor_NonCatalogTerraformDeliveryDoesNotBypassApproval(t *testing.T)
 		t.Fatal("expected non-catalog action to keep approval requirement")
 	}
 }
-
 func TestExecutor_EnableBucketDefaultEncryptionRemoteApplyRequiresApprovalByDefault(t *testing.T) {
 	engine := NewEngine(testutil.Logger())
 	rule := Rule{

--- a/internal/remediation/executor_test.go
+++ b/internal/remediation/executor_test.go
@@ -346,6 +346,347 @@ func TestExecutor_RestrictPublicStorageAccessDoesNotTrustStalePolicyWithoutCurre
 	}
 }
 
+func TestExecutor_EnableBucketDefaultEncryptionTerraformModeCapturesArtifact(t *testing.T) {
+	engine := NewEngine(testutil.Logger())
+	rule := Rule{
+		ID:      "enable-bucket-default-encryption-terraform",
+		Name:    "Enable Bucket Default Encryption Terraform",
+		Enabled: true,
+		Trigger: Trigger{Type: TriggerManual},
+		Actions: []Action{{
+			Type: ActionEnableBucketDefaultEncryption,
+			Config: map[string]string{
+				"delivery_mode": "terraform",
+			},
+		}},
+	}
+	if err := engine.AddRule(rule); err != nil {
+		t.Fatalf("add rule: %v", err)
+	}
+
+	executions, err := engine.Evaluate(context.Background(), Event{
+		Type:     TriggerManual,
+		PolicyID: "aws-s3-bucket-encryption-enabled",
+		EntityID: "bucket:audit-logs",
+		Data: map[string]any{
+			"resource_id":       "bucket:audit-logs",
+			"resource_name":     "audit-logs",
+			"resource_type":     "bucket",
+			"resource_platform": "aws",
+			"iac_file":          "infra/storage/main.tf",
+			"iac_module":        "storage",
+			"resource": map[string]any{
+				"default_encryption_enabled": false,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	execution := executions[0]
+	executor := NewExecutor(engine, nil, nil, nil, nil)
+
+	if err := executor.Execute(context.Background(), execution); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if execution.Status != ExecutionCompleted {
+		t.Fatalf("status = %s, want %s", execution.Status, ExecutionCompleted)
+	}
+	if len(execution.Actions) != 1 {
+		t.Fatalf("expected one action result, got %d", len(execution.Actions))
+	}
+	metadata := execution.Actions[0].Metadata
+	if metadata["delivery_mode"] != "terraform" {
+		t.Fatalf("expected terraform delivery mode, got %#v", metadata["delivery_mode"])
+	}
+	if requiresApproval, _ := metadata["requires_approval"].(bool); requiresApproval {
+		t.Fatalf("expected terraform generation not to require approval by default, got %#v", metadata)
+	}
+	if plannedTool := stringValue(metadata["planned_tool"]); plannedTool != "" {
+		t.Fatalf("expected no planned tool for terraform delivery, got %#v", metadata["planned_tool"])
+	}
+	if metadata["sse_algorithm"] != "AES256" {
+		t.Fatalf("unexpected sse_algorithm metadata: %#v", metadata["sse_algorithm"])
+	}
+	artifact, _ := metadata["artifact"].(map[string]any)
+	if artifact["path"] != "infra/storage/cerebro_s3_bucket_default_encryption_audit_logs.tf" {
+		t.Fatalf("unexpected terraform artifact path: %#v", artifact["path"])
+	}
+	if artifact["resource_address"] != "aws_s3_bucket_server_side_encryption_configuration.audit_logs_default_encryption" {
+		t.Fatalf("unexpected terraform resource address: %#v", artifact["resource_address"])
+	}
+	content, _ := artifact["content"].(string)
+	if !strings.Contains(content, `resource "aws_s3_bucket_server_side_encryption_configuration" "audit_logs_default_encryption"`) {
+		t.Fatalf("expected terraform resource block, got %q", content)
+	}
+	after, _ := metadata["after"].(map[string]any)
+	if planned, _ := after["planned"].(bool); !planned {
+		t.Fatalf("expected planned after-state metadata, got %#v", after)
+	}
+}
+
+func TestExecutor_EnableBucketDefaultEncryptionUsesCatalogDefaultTerraformMode(t *testing.T) {
+	engine := NewEngine(testutil.Logger())
+	rule := Rule{
+		ID:      "enable-bucket-default-encryption-catalog-default",
+		Name:    "Enable Bucket Default Encryption Catalog Default",
+		Enabled: true,
+		Trigger: Trigger{Type: TriggerManual},
+		Actions: []Action{{
+			Type: ActionEnableBucketDefaultEncryption,
+		}},
+	}
+	if err := engine.AddRule(rule); err != nil {
+		t.Fatalf("add rule: %v", err)
+	}
+
+	executions, err := engine.Evaluate(context.Background(), Event{
+		Type:     TriggerManual,
+		PolicyID: "aws-s3-bucket-encryption-enabled",
+		EntityID: "bucket:audit-logs",
+		Data: map[string]any{
+			"resource_id":       "bucket:audit-logs",
+			"resource_name":     "audit-logs",
+			"resource_type":     "bucket",
+			"resource_platform": "aws",
+			"iac_state_id":      "module.platform.module.storage.aws_s3_bucket.audit_logs",
+			"resource": map[string]any{
+				"default_encryption_enabled": false,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	execution := executions[0]
+	executor := NewExecutor(engine, nil, nil, nil, nil)
+
+	if err := executor.Execute(context.Background(), execution); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if execution.Status != ExecutionCompleted {
+		t.Fatalf("status = %s, want %s", execution.Status, ExecutionCompleted)
+	}
+	metadata := execution.Actions[0].Metadata
+	if metadata["delivery_mode"] != "terraform" {
+		t.Fatalf("expected catalog default terraform delivery mode, got %#v", metadata["delivery_mode"])
+	}
+	if requiresApproval, _ := metadata["requires_approval"].(bool); requiresApproval {
+		t.Fatalf("expected catalog default terraform delivery not to require approval, got %#v", metadata)
+	}
+	artifact, _ := metadata["artifact"].(map[string]any)
+	if artifact["path"] != "generated/terraform/platform/storage/cerebro_s3_bucket_default_encryption_audit_logs.tf" {
+		t.Fatalf("unexpected terraform artifact path: %#v", artifact["path"])
+	}
+}
+
+func TestExecutor_NonCatalogTerraformDeliveryDoesNotBypassApproval(t *testing.T) {
+	executor := NewExecutor(NewEngine(testutil.Logger()), nil, nil, nil, nil)
+	if !executor.actionRequiresApproval(Action{
+		Type: ActionPauseSubscription,
+		Config: map[string]string{
+			"delivery_mode": "terraform",
+		},
+	}) {
+		t.Fatal("expected non-catalog action to keep approval requirement")
+	}
+}
+
+func TestExecutor_EnableBucketDefaultEncryptionRemoteApplyRequiresApprovalByDefault(t *testing.T) {
+	engine := NewEngine(testutil.Logger())
+	rule := Rule{
+		ID:      "enable-bucket-default-encryption",
+		Name:    "Enable Bucket Default Encryption",
+		Enabled: true,
+		Trigger: Trigger{Type: TriggerManual},
+		Actions: []Action{{
+			Type: ActionEnableBucketDefaultEncryption,
+			Config: map[string]string{
+				"delivery_mode": "remote_apply",
+			},
+		}},
+	}
+	if err := engine.AddRule(rule); err != nil {
+		t.Fatalf("add rule: %v", err)
+	}
+
+	executions, err := engine.Evaluate(context.Background(), Event{
+		Type:     TriggerManual,
+		PolicyID: "aws-s3-bucket-encryption-enabled",
+		EntityID: "arn:aws:s3:::audit-logs",
+		Data: map[string]any{
+			"resource_id":       "arn:aws:s3:::audit-logs",
+			"resource_name":     "audit-logs",
+			"resource_type":     "bucket",
+			"resource_platform": "aws",
+			"resource": map[string]any{
+				"default_encryption_enabled": false,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	execution := executions[0]
+	caller := &fakeRemoteCaller{
+		responses: map[string][]fakeRemoteCallResult{
+			"aws.s3.put_bucket_encryption": {{output: `{"changed":true}`}},
+		},
+	}
+	executor := NewExecutor(engine, nil, nil, nil, nil)
+	executor.SetRemoteCaller(caller)
+
+	if err := executor.Execute(context.Background(), execution); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if execution.Status != ExecutionApproval {
+		t.Fatalf("status = %s, want %s", execution.Status, ExecutionApproval)
+	}
+	if len(caller.calls) != 0 {
+		t.Fatalf("expected no remote call before approval, got %v", caller.calls)
+	}
+
+	if err := executor.Approve(context.Background(), execution.ID, "security@example.com"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if execution.Status != ExecutionCompleted {
+		t.Fatalf("status = %s, want %s", execution.Status, ExecutionCompleted)
+	}
+	if len(caller.calls) != 1 || caller.calls[0] != "aws.s3.put_bucket_encryption" {
+		t.Fatalf("unexpected remote calls: %v", caller.calls)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(caller.payloads[0], &payload); err != nil {
+		t.Fatalf("unmarshal remote payload: %v", err)
+	}
+	triggerData, _ := payload["trigger_data"].(map[string]any)
+	if triggerData["sse_algorithm"] != "AES256" {
+		t.Fatalf("expected default sse_algorithm in trigger data, got %#v", triggerData["sse_algorithm"])
+	}
+}
+
+func TestExecutor_EnableBucketDefaultEncryptionTerraformModeHonorsExplicitApprovalOverride(t *testing.T) {
+	engine := NewEngine(testutil.Logger())
+	rule := Rule{
+		ID:      "enable-bucket-default-encryption-terraform-approval",
+		Name:    "Enable Bucket Default Encryption Terraform Approval",
+		Enabled: true,
+		Trigger: Trigger{Type: TriggerManual},
+		Actions: []Action{{
+			Type: ActionEnableBucketDefaultEncryption,
+			Config: map[string]string{
+				"delivery_mode": "terraform",
+				"approval_mode": "required",
+			},
+		}},
+	}
+	if err := engine.AddRule(rule); err != nil {
+		t.Fatalf("add rule: %v", err)
+	}
+
+	executions, err := engine.Evaluate(context.Background(), Event{
+		Type:     TriggerManual,
+		PolicyID: "aws-s3-bucket-encryption-enabled",
+		EntityID: "arn:aws:s3:::audit-logs",
+		Data: map[string]any{
+			"resource_id":       "arn:aws:s3:::audit-logs",
+			"resource_name":     "audit-logs",
+			"resource_type":     "bucket",
+			"resource_platform": "aws",
+			"iac_file":          "infra/storage/main.tf",
+			"resource": map[string]any{
+				"default_encryption_enabled": false,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	execution := executions[0]
+	executor := NewExecutor(engine, nil, nil, nil, nil)
+
+	if err := executor.Execute(context.Background(), execution); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if execution.Status != ExecutionApproval {
+		t.Fatalf("status = %s, want %s", execution.Status, ExecutionApproval)
+	}
+
+	if err := executor.Approve(context.Background(), execution.ID, "security@example.com"); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if execution.Status != ExecutionCompleted {
+		t.Fatalf("status = %s, want %s", execution.Status, ExecutionCompleted)
+	}
+	artifact, _ := execution.Actions[0].Metadata["artifact"].(map[string]any)
+	if artifact["path"] != "infra/storage/cerebro_s3_bucket_default_encryption_audit_logs.tf" {
+		t.Fatalf("unexpected terraform artifact path after approval: %#v", artifact["path"])
+	}
+}
+
+func TestExecutor_EnableBucketDefaultEncryptionDoesNotTrustStalePolicyWhenResourceJSONShowsEncrypted(t *testing.T) {
+	engine := NewEngine(testutil.Logger())
+	rule := Rule{
+		ID:      "enable-bucket-default-encryption-stale-policy",
+		Name:    "Enable Bucket Default Encryption Stale Policy",
+		Enabled: true,
+		Trigger: Trigger{Type: TriggerManual},
+		Actions: []Action{{
+			Type: ActionEnableBucketDefaultEncryption,
+			Config: map[string]string{
+				"delivery_mode": "terraform",
+			},
+		}},
+	}
+	if err := engine.AddRule(rule); err != nil {
+		t.Fatalf("add rule: %v", err)
+	}
+
+	executions, err := engine.Evaluate(context.Background(), Event{
+		Type:     TriggerManual,
+		PolicyID: "aws-s3-bucket-encryption-enabled",
+		EntityID: "bucket:audit-logs",
+		Data: map[string]any{
+			"resource_id":       "bucket:audit-logs",
+			"resource_name":     "audit-logs",
+			"resource_type":     "bucket",
+			"resource_platform": "aws",
+			"resource": map[string]any{
+				"resource_json": map[string]any{
+					"encryption_configuration": map[string]any{
+						"rules": []any{
+							map[string]any{"sse_algorithm": "AES256"},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	execution := executions[0]
+	executor := NewExecutor(engine, nil, nil, nil, nil)
+
+	err = executor.Execute(context.Background(), execution)
+	if err == nil {
+		t.Fatal("expected precondition failure")
+	}
+	if !strings.Contains(err.Error(), "precondition failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if execution.Status != ExecutionFailed {
+		t.Fatalf("status = %s, want %s", execution.Status, ExecutionFailed)
+	}
+	if len(execution.Actions) != 1 || execution.Actions[0].Metadata == nil {
+		t.Fatalf("expected failed action metadata, got %#v", execution.Actions)
+	}
+	preconditions, _ := execution.Actions[0].Metadata["preconditions"].([]map[string]any)
+	if len(preconditions) == 0 {
+		t.Fatalf("expected preconditions metadata, got %#v", execution.Actions[0].Metadata)
+	}
+}
+
 func TestExecutor_RestrictPublicSecurityGroupIngressDryRunCapturesMetadata(t *testing.T) {
 	engine := NewEngine(testutil.Logger())
 	rule := Rule{

--- a/internal/remediation/terraform.go
+++ b/internal/remediation/terraform.go
@@ -1,0 +1,306 @@
+package remediation
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+type DeliveryMode string
+
+const (
+	DeliveryModeRemoteApply DeliveryMode = "remote_apply"
+	DeliveryModeTerraform   DeliveryMode = "terraform"
+)
+
+type TerraformArtifact struct {
+	Kind            string   `json:"kind"`
+	IaCType         string   `json:"iac_type"`
+	Format          string   `json:"format"`
+	Path            string   `json:"path"`
+	ResourceType    string   `json:"resource_type"`
+	ResourceAddress string   `json:"resource_address"`
+	ImportID        string   `json:"import_id,omitempty"`
+	Summary         string   `json:"summary"`
+	Content         string   `json:"content"`
+	Notes           []string `json:"notes,omitempty"`
+	IaCFile         string   `json:"iac_file,omitempty"`
+	IaCModule       string   `json:"iac_module,omitempty"`
+	IaCStateID      string   `json:"iac_state_id,omitempty"`
+}
+
+var terraformIdentifierUnsafeChars = regexp.MustCompile(`[^0-9A-Za-z_]+`)
+
+func actionDeliveryMode(action Action, entry CatalogEntry) DeliveryMode {
+	raw := strings.ToLower(strings.TrimSpace(action.Config["delivery_mode"]))
+	switch DeliveryMode(raw) {
+	case DeliveryModeRemoteApply, DeliveryModeTerraform:
+		return DeliveryMode(raw)
+	}
+	if entry.DefaultDeliveryMode != "" {
+		return entry.DefaultDeliveryMode
+	}
+	return DeliveryModeRemoteApply
+}
+
+func catalogSupportsDeliveryMode(entry CatalogEntry, mode DeliveryMode) bool {
+	if mode == "" {
+		return false
+	}
+	if len(entry.SupportedDeliveryModes) == 0 {
+		return mode == DeliveryModeRemoteApply
+	}
+	for _, candidate := range entry.SupportedDeliveryModes {
+		if candidate == mode {
+			return true
+		}
+	}
+	return false
+}
+
+func renderTerraformBucketDefaultEncryptionArtifact(execution *Execution, sseAlgorithm, kmsMasterKeyID string, bucketKeyEnabled bool) (TerraformArtifact, error) {
+	bucketName := bucketNameFromExecution(execution)
+	if bucketName == "" {
+		return TerraformArtifact{}, fmt.Errorf("missing bucket identifier for terraform artifact")
+	}
+	iacFile := ""
+	iacModule := ""
+	iacStateID := ""
+	if execution != nil {
+		iacFile = strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "iac_file"))
+		iacModule = firstNonEmpty(
+			strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "iac_module")),
+			terraformModuleAddressFromStateID(strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "iac_state_id"))),
+		)
+		iacStateID = strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "iac_state_id"))
+	}
+
+	resourceName := terraformIdentifier(bucketName + "_default_encryption")
+	address := "aws_s3_bucket_server_side_encryption_configuration." + resourceName
+	path := terraformArtifactPath(execution, "cerebro_s3_bucket_default_encryption_"+terraformIdentifier(bucketName)+".tf")
+	content := renderTerraformTemplate(terraformBucketDefaultEncryptionTemplate, map[string]string{
+		"BucketName":        terraformString(bucketName),
+		"ResourceName":      resourceName,
+		"SSEAlgorithm":      terraformString(firstNonEmpty(strings.TrimSpace(sseAlgorithm), "AES256")),
+		"KMSMasterKeyID":    terraformString(strings.TrimSpace(kmsMasterKeyID)),
+		"BucketKeyEnabled":  fmt.Sprintf("%t", bucketKeyEnabled),
+		"ImportAddress":     address,
+		"ImportIdentifier":  terraformString(bucketName),
+		"ExistingIaCFile":   iacFile,
+		"ExistingIaCModule": iacModule,
+	})
+
+	notes := []string{
+		"Run terraform plan before apply.",
+		fmt.Sprintf("Import the existing encryption configuration before apply: terraform import %s %s", address, bucketName),
+	}
+	if iacFile != "" {
+		notes = append(notes, fmt.Sprintf("Co-locate the generated resource with the existing IaC file %s if that file manages the bucket.", iacFile))
+	} else if iacModule != "" {
+		notes = append(notes, fmt.Sprintf("Place the generated resource in the Terraform module %s so it stays with the bucket definition.", iacModule))
+	}
+
+	return TerraformArtifact{
+		Kind:            "terraform_hcl",
+		IaCType:         "terraform",
+		Format:          "hcl",
+		Path:            path,
+		ResourceType:    "bucket",
+		ResourceAddress: address,
+		ImportID:        bucketName,
+		Summary:         fmt.Sprintf("Terraform patch for enabling default encryption on S3 bucket %s", bucketName),
+		Content:         content,
+		Notes:           notes,
+		IaCFile:         iacFile,
+		IaCModule:       iacModule,
+		IaCStateID:      iacStateID,
+	}, nil
+}
+
+func terraformArtifactMetadata(artifact TerraformArtifact) map[string]any {
+	return compactAnyMap(map[string]any{
+		"kind":             artifact.Kind,
+		"iac_type":         artifact.IaCType,
+		"format":           artifact.Format,
+		"path":             artifact.Path,
+		"resource_type":    artifact.ResourceType,
+		"resource_address": artifact.ResourceAddress,
+		"import_id":        artifact.ImportID,
+		"summary":          artifact.Summary,
+		"content":          artifact.Content,
+		"notes":            append([]string(nil), artifact.Notes...),
+		"iac_file":         artifact.IaCFile,
+		"iac_module":       artifact.IaCModule,
+		"iac_state_id":     artifact.IaCStateID,
+	})
+}
+
+func bucketNameFromExecution(execution *Execution) string {
+	if execution == nil {
+		return ""
+	}
+	candidates := []string{
+		strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "resource_name")),
+		strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "bucket")),
+		strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "resource_external_id")),
+		strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "resource_id")),
+		strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "entity_id")),
+	}
+	for _, candidate := range candidates {
+		if bucketName := normalizeBucketIdentifier(candidate); bucketName != "" {
+			return bucketName
+		}
+	}
+	return ""
+}
+
+func normalizeBucketIdentifier(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return ""
+	}
+	switch {
+	case strings.HasPrefix(value, "arn:aws:s3:::"):
+		return strings.TrimSpace(strings.TrimPrefix(value, "arn:aws:s3:::"))
+	case strings.HasPrefix(value, "s3://"):
+		return strings.TrimSpace(strings.TrimPrefix(value, "s3://"))
+	case strings.HasPrefix(value, "bucket:"):
+		return strings.TrimSpace(strings.TrimPrefix(value, "bucket:"))
+	default:
+		return strings.Trim(value, "/")
+	}
+}
+
+func terraformArtifactPath(execution *Execution, fileName string) string {
+	fileName = strings.TrimSpace(fileName)
+	if fileName == "" {
+		fileName = "cerebro_remediation.tf"
+	}
+	if execution != nil {
+		if iacFile := strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "iac_file")); iacFile != "" {
+			dir := filepath.Dir(iacFile)
+			if dir == "." || dir == "" {
+				return filepath.ToSlash(fileName)
+			}
+			return filepath.ToSlash(filepath.Join(dir, fileName))
+		}
+		moduleSegments := terraformModulePathSegments(firstNonEmpty(
+			strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "iac_module")),
+			terraformModuleAddressFromStateID(strings.TrimSpace(remediationMapValueToString(execution.TriggerData, "iac_state_id"))),
+		))
+		if len(moduleSegments) > 0 {
+			pathParts := append([]string{"generated", "terraform"}, moduleSegments...)
+			pathParts = append(pathParts, fileName)
+			return filepath.ToSlash(filepath.Join(pathParts...))
+		}
+	}
+	return filepath.ToSlash(filepath.Join("generated", "terraform", "aws", fileName))
+}
+
+func terraformModuleAddressFromStateID(stateID string) string {
+	segments := terraformModulePathSegments(stateID)
+	if len(segments) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(segments)*2)
+	for _, segment := range segments {
+		parts = append(parts, "module", segment)
+	}
+	return strings.Join(parts, ".")
+}
+
+func terraformModulePathSegments(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if strings.Contains(raw, "module.") {
+		parts := strings.Split(raw, ".")
+		segments := make([]string, 0)
+		for idx := 0; idx < len(parts)-1; idx++ {
+			if parts[idx] != "module" {
+				continue
+			}
+			name := terraformAddressSegment(parts[idx+1])
+			if name == "" {
+				continue
+			}
+			segments = append(segments, name)
+			idx++
+		}
+		return segments
+	}
+
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		name := terraformAddressSegment(part)
+		if name == "" {
+			continue
+		}
+		segments = append(segments, name)
+	}
+	return segments
+}
+
+func terraformAddressSegment(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if idx := strings.IndexRune(raw, '['); idx >= 0 {
+		raw = raw[:idx]
+	}
+	raw = strings.Trim(raw, `"'`)
+	return terraformIdentifier(raw)
+}
+
+func terraformIdentifier(raw string) string {
+	text := terraformIdentifierUnsafeChars.ReplaceAllString(strings.TrimSpace(raw), "_")
+	text = strings.Trim(text, "_")
+	if text == "" {
+		return "generated"
+	}
+	if text[0] >= '0' && text[0] <= '9' {
+		return "r_" + text
+	}
+	return text
+}
+
+func terraformString(value string) string {
+	encoded, _ := json.Marshal(strings.TrimSpace(value))
+	return string(encoded)
+}
+
+func renderTerraformTemplate(src string, data map[string]string) string {
+	tmpl := template.Must(template.New("terraform").Parse(src))
+	var builder strings.Builder
+	if err := tmpl.Execute(&builder, data); err != nil {
+		panic(err)
+	}
+	return strings.TrimLeft(builder.String(), "\n")
+}
+
+const terraformBucketDefaultEncryptionTemplate = `
+# Generated by Cerebro. Review, import existing state, and run terraform plan before apply.
+resource "aws_s3_bucket_server_side_encryption_configuration" "{{ .ResourceName }}" {
+  bucket = {{ .BucketName }}
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = {{ .SSEAlgorithm }}
+{{- if ne .KMSMasterKeyID "\"\"" }}
+      kms_master_key_id = {{ .KMSMasterKeyID }}
+{{- end }}
+    }
+{{- if eq .BucketKeyEnabled "true" }}
+    bucket_key_enabled = true
+{{- end }}
+  }
+}
+`

--- a/internal/remediation/terraform.go
+++ b/internal/remediation/terraform.go
@@ -201,6 +201,10 @@ func terraformArtifactPath(execution *Execution, fileName string) string {
 }
 
 func terraformModuleAddressFromStateID(stateID string) string {
+	stateID = strings.TrimSpace(stateID)
+	if stateID == "" || !strings.Contains(stateID, "module.") {
+		return ""
+	}
 	segments := terraformModulePathSegments(stateID)
 	if len(segments) == 0 {
 		return ""

--- a/internal/remediation/terraform_test.go
+++ b/internal/remediation/terraform_test.go
@@ -50,3 +50,22 @@ func TestRenderTerraformBucketDefaultEncryptionArtifact_UsesIaCStateIDModulePath
 		t.Fatalf("unexpected artifact path: %#v", artifact.Path)
 	}
 }
+
+func TestRenderTerraformBucketDefaultEncryptionArtifact_DoesNotTreatRootStateIDAsModulePath(t *testing.T) {
+	artifact, err := renderTerraformBucketDefaultEncryptionArtifact(&Execution{
+		TriggerData: map[string]any{
+			"resource_id":  "bucket:audit-logs",
+			"iac_state_id": "aws_s3_bucket.audit_logs",
+		},
+	}, "AES256", "", false)
+	if err != nil {
+		t.Fatalf("render artifact: %v", err)
+	}
+
+	if artifact.IaCModule != "" {
+		t.Fatalf("expected empty inferred module for root state id, got %#v", artifact.IaCModule)
+	}
+	if artifact.Path != "generated/terraform/aws/cerebro_s3_bucket_default_encryption_audit_logs.tf" {
+		t.Fatalf("unexpected artifact path: %#v", artifact.Path)
+	}
+}

--- a/internal/remediation/terraform_test.go
+++ b/internal/remediation/terraform_test.go
@@ -1,0 +1,52 @@
+package remediation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderTerraformBucketDefaultEncryptionArtifact_InfersBucketNameFromARN(t *testing.T) {
+	artifact, err := renderTerraformBucketDefaultEncryptionArtifact(&Execution{
+		TriggerData: map[string]any{
+			"resource_id": "arn:aws:s3:::audit-logs",
+		},
+	}, "AES256", "", false)
+	if err != nil {
+		t.Fatalf("render artifact: %v", err)
+	}
+
+	if artifact.ImportID != "audit-logs" {
+		t.Fatalf("unexpected import id: %#v", artifact.ImportID)
+	}
+	if artifact.Path != "generated/terraform/aws/cerebro_s3_bucket_default_encryption_audit_logs.tf" {
+		t.Fatalf("unexpected artifact path: %#v", artifact.Path)
+	}
+	if !strings.Contains(artifact.Content, `bucket = "audit-logs"`) {
+		t.Fatalf("expected bucket reference in artifact content, got %q", artifact.Content)
+	}
+}
+
+func TestActionDeliveryModeDefaultsToCatalogEntry(t *testing.T) {
+	mode := actionDeliveryMode(Action{Type: ActionEnableBucketDefaultEncryption}, CatalogEntry{
+		DefaultDeliveryMode: DeliveryModeTerraform,
+	})
+	if mode != DeliveryModeTerraform {
+		t.Fatalf("unexpected delivery mode: %s", mode)
+	}
+}
+
+func TestRenderTerraformBucketDefaultEncryptionArtifact_UsesIaCStateIDModulePath(t *testing.T) {
+	artifact, err := renderTerraformBucketDefaultEncryptionArtifact(&Execution{
+		TriggerData: map[string]any{
+			"resource_id":  "bucket:audit-logs",
+			"iac_state_id": "module.platform.module.storage.aws_s3_bucket.audit_logs",
+		},
+	}, "AES256", "", false)
+	if err != nil {
+		t.Fatalf("render artifact: %v", err)
+	}
+
+	if artifact.Path != "generated/terraform/platform/storage/cerebro_s3_bucket_default_encryption_audit_logs.tf" {
+		t.Fatalf("unexpected artifact path: %#v", artifact.Path)
+	}
+}


### PR DESCRIPTION
* Add S3 default encryption remediation

* Add Terraform delivery mode for remediations

* Align remediation metadata with precondition assembly

* Tighten terraform remediation approval defaults

* Constrain terraform approval bypass to catalog actions