### PR TITLE
Add explicit vendor nodes for graph-derived third-party risk (#312)

### DIFF
--- a/docs/GRAPH_ONTOLOGY_AUTOGEN.md
+++ b/docs/GRAPH_ONTOLOGY_AUTOGEN.md
@@ -2,7 +2,7 @@
 
 Generated from `graph.RegisteredNodeKinds()`, `graph.RegisteredEdgeKinds()`, and `internal/graphingest/mappings.yaml` via `go run ./scripts/generate_graph_ontology_docs/main.go`.
 
-- Node kinds: **68**
+- Node kinds: **69**
 - Edge kinds: **44**
 - Mapping rules: **13**
 - Source domains: **9**
@@ -76,6 +76,7 @@ Generated from `graph.RegisteredNodeKinds()`, `graph.RegisteredEdgeKinds()`, and
 | `technology` | resource | `category`, `observed_at`, `recorded_at`, `technology_id`, `technology_name`, `transaction_from`, `valid_from` | `based_on` |
 | `ticket` | business | - | - |
 | `user` | identity | - | - |
+| `vendor` | business | - | - |
 | `vulnerability` | resource | `observed_at`, `recorded_at`, `severity`, `transaction_from`, `valid_from`, `vulnerability_id` | `based_on` |
 | `workload` | resource | `observed_at`, `runtime`, `valid_from`, `workload_id` | `connects_to`, `depends_on`, `targets` |
 | `workload_scan` | resource | `observed_at`, `recorded_at`, `scan_id`, `status`, `target_id`, `target_kind`, `transaction_from`, `valid_from` | `based_on`, `contains_package`, `found_vulnerability`, `has_scan`, `targets` |
@@ -185,7 +186,7 @@ Generated from `graph.RegisteredNodeKinds()`, `graph.RegisteredEdgeKinds()`, and
 
 ## Unmapped Built-in Node Kinds
 
-Total unmapped kinds: **45**
+Total unmapped kinds: **46**
 
 - `activity`
 - `application`
@@ -230,5 +231,6 @@ Total unmapped kinds: **45**
 - `source`
 - `technology`
 - `user`
+- `vendor`
 - `vulnerability`
 - `workload_scan`

--- a/internal/graph/builders/builder.go
+++ b/internal/graph/builders/builder.go
@@ -168,6 +168,7 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 		"edges", working.graph.EdgeCount(),
 		"duration", time.Since(edgeStart))
 
+	working.buildVendorNodes()
 	working.buildIAMPermissionUsageKnowledge(ctx)
 
 	// Build unified person graph overlay (person nodes + projected edges).

--- a/internal/graph/builders/builder_azure.go
+++ b/internal/graph/builders/builder_azure.go
@@ -603,12 +603,12 @@ func (b *Builder) buildAzureIdentityNodes(ctx context.Context) {
 	b.loadAzurePreferredIdentityNodes(ctx, []nodeQuery{
 		{
 			table: "azure_graph_service_principals",
-			query: `SELECT id, display_name, app_id, service_principal_type, account_enabled, app_owner_organization_id, publisher_name, created_date_time, tags, subscription_id FROM azure_graph_service_principals`,
+			query: `SELECT id, display_name, app_id, service_principal_type, account_enabled, app_owner_organization_id, app_role_assignment_required, publisher_name, created_date_time, tags, subscription_id FROM azure_graph_service_principals`,
 			parse: parseAzureServicePrincipalNodes,
 		},
 		{
 			table: "entra_service_principals",
-			query: `SELECT id, display_name, app_id, service_principal_type, account_enabled, app_role_assignment_required, created_datetime, tags FROM entra_service_principals`,
+			query: `SELECT id, display_name, app_id, service_principal_type, account_enabled, app_owner_organization_id, app_role_assignment_required, publisher_name, created_datetime, tags FROM entra_service_principals`,
 			parse: parseAzureServicePrincipalNodes,
 		},
 		{
@@ -1087,13 +1087,15 @@ func parseAzureServicePrincipalNodes(rows []map[string]any) []*Node {
 		}
 		servicePrincipalType := firstNonEmpty(queryRowString(sp, "service_principal_type"), queryRowString(sp, "type"))
 		properties := map[string]any{
-			"app_id":              queryRow(sp, "app_id"),
-			"type":                servicePrincipalType,
-			"account_enabled":     queryRow(sp, "account_enabled"),
-			"tags":                queryRow(sp, "tags"),
-			"publisher_name":      queryRow(sp, "publisher_name"),
-			"created_datetime":    firstNonEmpty(queryRowString(sp, "created_datetime"), queryRowString(sp, "created_date_time")),
-			"azure_resource_type": "service_principal",
+			"app_id":                       queryRow(sp, "app_id"),
+			"type":                         servicePrincipalType,
+			"account_enabled":              queryRow(sp, "account_enabled"),
+			"app_owner_organization_id":    queryRow(sp, "app_owner_organization_id"),
+			"app_role_assignment_required": queryRow(sp, "app_role_assignment_required"),
+			"tags":                         queryRow(sp, "tags"),
+			"publisher_name":               queryRow(sp, "publisher_name"),
+			"created_datetime":             firstNonEmpty(queryRowString(sp, "created_datetime"), queryRowString(sp, "created_date_time")),
+			"azure_resource_type":          "service_principal",
 		}
 		if strings.Contains(strings.ToLower(servicePrincipalType), "managed") {
 			properties["identity_type"] = servicePrincipalType

--- a/internal/graph/builders/builder_azure_test.go
+++ b/internal/graph/builders/builder_azure_test.go
@@ -14,13 +14,16 @@ func TestBuilder_AzureBuildsScopesRBACPoliciesAndVaultEdges(t *testing.T) {
 	source := newMockDataSource()
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	source.setResult(`SELECT id, display_name, app_id, service_principal_type, account_enabled, app_owner_organization_id, publisher_name, created_date_time, tags, subscription_id FROM azure_graph_service_principals`, &DataQueryResult{
+	source.setResult(`SELECT id, display_name, app_id, service_principal_type, account_enabled, app_owner_organization_id, app_role_assignment_required, publisher_name, created_date_time, tags, subscription_id FROM azure_graph_service_principals`, &DataQueryResult{
 		Rows: []map[string]any{{
-			"id":                     "sp-managed",
-			"display_name":           "vm-managed-identity",
-			"app_id":                 "app-1",
-			"service_principal_type": "ManagedIdentity",
-			"subscription_id":        "sub-1",
+			"id":                           "sp-managed",
+			"display_name":                 "vm-managed-identity",
+			"app_id":                       "app-1",
+			"service_principal_type":       "ManagedIdentity",
+			"app_owner_organization_id":    "tenant-local",
+			"app_role_assignment_required": true,
+			"publisher_name":               "Microsoft",
+			"subscription_id":              "sub-1",
 		}},
 	})
 	source.setResult(`SELECT id, user_principal_name, display_name, mail, department, job_title, account_enabled, user_type, last_sign_in_datetime FROM entra_users`, &DataQueryResult{
@@ -196,6 +199,12 @@ func TestBuilder_AzureBuildsScopesRBACPoliciesAndVaultEdges(t *testing.T) {
 	if len(assignments) != 1 {
 		t.Fatalf("expected one RBAC role assignment on managed identity, got %#v", spNode.Properties["role_assignments"])
 	}
+	if got := queryRowString(spNode.Properties, "app_owner_organization_id"); got != "tenant-local" {
+		t.Fatalf("expected app owner organization to be preserved, got %#v", spNode.Properties)
+	}
+	if got, _ := spNode.Properties["app_role_assignment_required"].(bool); !got {
+		t.Fatalf("expected app role assignment requirement to be preserved, got %#v", spNode.Properties)
+	}
 }
 
 func TestBuilder_AzureRelationshipEdgesCreatePlaceholderNodes(t *testing.T) {
@@ -238,10 +247,13 @@ func TestCDCEventToNode_AzureModernTables(t *testing.T) {
 	spNode := cdcEventToNode("azure_graph_service_principals", cdcEvent{
 		ResourceID: "sp-managed",
 		Payload: map[string]any{
-			"id":                     "sp-managed",
-			"display_name":           "vm-managed-identity",
-			"service_principal_type": "ManagedIdentity",
-			"subscription_id":        "sub-1",
+			"id":                           "sp-managed",
+			"display_name":                 "vm-managed-identity",
+			"service_principal_type":       "ManagedIdentity",
+			"app_owner_organization_id":    "tenant-local",
+			"app_role_assignment_required": true,
+			"publisher_name":               "Microsoft",
+			"subscription_id":              "sub-1",
 		},
 	})
 	if spNode == nil || spNode.Kind != NodeKindServiceAccount {
@@ -249,6 +261,33 @@ func TestCDCEventToNode_AzureModernTables(t *testing.T) {
 	}
 	if got := queryRowString(spNode.Properties, "identity_type"); got != "ManagedIdentity" {
 		t.Fatalf("expected managed identity marker on service principal, got %#v", spNode.Properties)
+	}
+	if got := queryRowString(spNode.Properties, "app_owner_organization_id"); got != "tenant-local" {
+		t.Fatalf("expected app owner organization to be preserved, got %#v", spNode.Properties)
+	}
+	if got, _ := spNode.Properties["app_role_assignment_required"].(bool); !got {
+		t.Fatalf("expected app role assignment requirement to be preserved, got %#v", spNode.Properties)
+	}
+
+	entraNode := cdcEventToNode("entra_service_principals", cdcEvent{
+		ResourceID: "sp-app",
+		Payload: map[string]any{
+			"id":                           "sp-app",
+			"display_name":                 "Slack Enterprise Grid",
+			"service_principal_type":       "Application",
+			"app_owner_organization_id":    "tenant-vendor",
+			"app_role_assignment_required": false,
+			"publisher_name":               "Slack",
+		},
+	})
+	if entraNode == nil || entraNode.Kind != NodeKindServiceAccount {
+		t.Fatalf("expected service account node from Entra service principal, got %#v", entraNode)
+	}
+	if got := queryRowString(entraNode.Properties, "app_owner_organization_id"); got != "tenant-vendor" {
+		t.Fatalf("expected Entra owner organization to be preserved, got %#v", entraNode.Properties)
+	}
+	if got := queryRowString(entraNode.Properties, "publisher_name"); got != "Slack" {
+		t.Fatalf("expected Entra publisher name to be preserved, got %#v", entraNode.Properties)
 	}
 
 	policyNode := cdcEventToNode("azure_policy_assignments", cdcEvent{
@@ -269,6 +308,45 @@ func TestCDCEventToNode_AzureModernTables(t *testing.T) {
 	}
 }
 
+func TestBuilder_AzureIdentityFallsBackToEntraServicePrincipalsWithVendorMetadata(t *testing.T) {
+	t.Parallel()
+
+	source := newMockDataSource()
+	builder := NewBuilder(source, nil)
+
+	source.setResult(`SELECT id, display_name, app_id, service_principal_type, account_enabled, app_owner_organization_id, app_role_assignment_required, publisher_name, created_datetime, tags FROM entra_service_principals`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":                           "sp-slack",
+			"display_name":                 "Slack Enterprise Grid",
+			"app_id":                       "app-slack",
+			"service_principal_type":       "Application",
+			"account_enabled":              true,
+			"app_owner_organization_id":    "tenant-vendor",
+			"app_role_assignment_required": true,
+			"publisher_name":               "Slack",
+			"created_datetime":             "2026-03-01T00:00:00Z",
+		}},
+	})
+
+	if err := builder.Build(context.Background()); err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	spNode, ok := builder.Graph().GetNode("sp-slack")
+	if !ok || spNode.Kind != NodeKindServiceAccount {
+		t.Fatalf("expected service principal node from Entra fallback query, got %#v", spNode)
+	}
+	if got := queryRowString(spNode.Properties, "app_owner_organization_id"); got != "tenant-vendor" {
+		t.Fatalf("expected Entra owner organization to be preserved, got %#v", spNode.Properties)
+	}
+	if got, _ := spNode.Properties["app_role_assignment_required"].(bool); !got {
+		t.Fatalf("expected Entra app role assignment requirement to be preserved, got %#v", spNode.Properties)
+	}
+	if got := queryRowString(spNode.Properties, "publisher_name"); got != "Slack" {
+		t.Fatalf("expected Entra publisher name to be preserved, got %#v", spNode.Properties)
+	}
+}
+
 func TestBuilder_AzureRBACResourceScopeDoesNotOvergrantResourceGroup(t *testing.T) {
 	t.Parallel()
 
@@ -279,7 +357,7 @@ func TestBuilder_AzureRBACResourceScopeDoesNotOvergrantResourceGroup(t *testing.
 	keyID := vaultID + "/keys/key-1"
 	vmID := "/subscriptions/sub-1/resourceGroups/rg-app/providers/Microsoft.Compute/virtualMachines/vm-1"
 
-	source.setResult(`SELECT id, display_name, app_id, service_principal_type, account_enabled, app_owner_organization_id, publisher_name, created_date_time, tags, subscription_id FROM azure_graph_service_principals`, &DataQueryResult{
+	source.setResult(`SELECT id, display_name, app_id, service_principal_type, account_enabled, app_owner_organization_id, app_role_assignment_required, publisher_name, created_date_time, tags, subscription_id FROM azure_graph_service_principals`, &DataQueryResult{
 		Rows: []map[string]any{{
 			"id":                     "sp-managed",
 			"display_name":           "vm-managed-identity",

--- a/internal/graph/builders/builder_cdc.go
+++ b/internal/graph/builders/builder_cdc.go
@@ -359,11 +359,11 @@ func (b *Builder) rebuildEdges(ctx context.Context) error {
 		return err
 	}
 
+	b.buildVendorNodes()
 	b.buildIAMPermissionUsageKnowledge(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-
 	b.buildUnifiedPersonGraph(ctx)
 	if err := ctx.Err(); err != nil {
 		return err
@@ -647,13 +647,15 @@ func cdcEventToNode(table string, event cdcEvent) *Node {
 		id := cdcNodeID(table, payload, event.ResourceID)
 		servicePrincipalType := firstNonEmpty(queryRowString(payload, "service_principal_type"), queryRowString(payload, "type"))
 		properties := map[string]any{
-			"app_id":              queryRow(payload, "app_id"),
-			"type":                servicePrincipalType,
-			"account_enabled":     queryRow(payload, "account_enabled"),
-			"publisher_name":      queryRow(payload, "publisher_name"),
-			"tags":                queryRow(payload, "tags"),
-			"created_datetime":    firstNonEmpty(queryRowString(payload, "created_datetime"), queryRowString(payload, "created_date_time")),
-			"azure_resource_type": "service_principal",
+			"app_id":                       queryRow(payload, "app_id"),
+			"type":                         servicePrincipalType,
+			"account_enabled":              queryRow(payload, "account_enabled"),
+			"app_owner_organization_id":    queryRow(payload, "app_owner_organization_id"),
+			"app_role_assignment_required": queryRow(payload, "app_role_assignment_required"),
+			"publisher_name":               queryRow(payload, "publisher_name"),
+			"tags":                         queryRow(payload, "tags"),
+			"created_datetime":             firstNonEmpty(queryRowString(payload, "created_datetime"), queryRowString(payload, "created_date_time")),
+			"azure_resource_type":          "service_principal",
 		}
 		if strings.Contains(strings.ToLower(servicePrincipalType), "managed") {
 			properties["identity_type"] = servicePrincipalType

--- a/internal/graph/builders/builder_vendor.go
+++ b/internal/graph/builders/builder_vendor.go
@@ -3,16 +3,58 @@ package builders
 import (
 	"sort"
 	"strings"
+	"unicode"
 )
 
 const vendorProjectionSourceSystem = "graph_builder_vendor_projection"
 
+var vendorLegalSuffixTokens = map[string]struct{}{
+	"ag":           {},
+	"bv":           {},
+	"co":           {},
+	"company":      {},
+	"corp":         {},
+	"corporation":  {},
+	"gmbh":         {},
+	"inc":          {},
+	"incorporated": {},
+	"limited":      {},
+	"llc":          {},
+	"ltd":          {},
+	"plc":          {},
+	"pty":          {},
+	"sarl":         {},
+	"sas":          {},
+	"spa":          {},
+	"srl":          {},
+}
+
+var vendorCorporateSuffixPhrases = [][]string{
+	{"video", "communications"},
+	{"communications"},
+	{"technology"},
+	{"technologies"},
+	{"software"},
+	{"systems"},
+}
+
+type vendorIdentity struct {
+	rawName         string
+	aliasKey        string
+	ownerOrgID      string
+	integrationType string
+}
+
 type vendorProjection struct {
-	id               string
-	name             string
-	sourceProviders  map[string]struct{}
-	integrationTypes map[string]struct{}
-	managedNodeIDs   map[string]struct{}
+	id                   string
+	name                 string
+	aliasKey             string
+	rawNames             map[string]struct{}
+	aliasKeys            map[string]struct{}
+	ownerOrganizationIDs map[string]struct{}
+	sourceProviders      map[string]struct{}
+	integrationTypes     map[string]struct{}
+	managedNodeIDs       map[string]struct{}
 }
 
 func (b *Builder) buildVendorNodes() {
@@ -31,44 +73,35 @@ func (b *Builder) buildVendorNodes() {
 		b.graph.RemoveNode(node.ID)
 	}
 
-	projections := make(map[string]*vendorProjection)
+	var projections []*vendorProjection
 	for _, node := range candidates {
 		if node == nil || node.Kind == NodeKindVendor {
 			continue
 		}
-		name, integrationType, ok := vendorIdentityForNode(node)
+		identity, ok := vendorIdentityForNode(node)
 		if !ok {
 			continue
 		}
-		vendorID := vendorNodeID(name)
-		if vendorID == "" {
-			continue
-		}
-
-		projection, exists := projections[vendorID]
-		if !exists {
+		projection := matchVendorProjection(projections, identity)
+		if projection == nil {
 			projection = &vendorProjection{
-				id:               vendorID,
-				name:             strings.TrimSpace(name),
-				sourceProviders:  make(map[string]struct{}),
-				integrationTypes: make(map[string]struct{}),
-				managedNodeIDs:   make(map[string]struct{}),
+				rawNames:             make(map[string]struct{}),
+				aliasKeys:            make(map[string]struct{}),
+				ownerOrganizationIDs: make(map[string]struct{}),
+				sourceProviders:      make(map[string]struct{}),
+				integrationTypes:     make(map[string]struct{}),
+				managedNodeIDs:       make(map[string]struct{}),
 			}
-			projections[vendorID] = projection
+			projections = append(projections, projection)
 		}
-		if projection.name == "" {
-			projection.name = strings.TrimSpace(name)
-		}
-		if provider := strings.TrimSpace(node.Provider); provider != "" {
-			projection.sourceProviders[provider] = struct{}{}
-		}
-		if integrationType != "" {
-			projection.integrationTypes[integrationType] = struct{}{}
-		}
-		projection.managedNodeIDs[node.ID] = struct{}{}
+		projection.absorb(identity, node)
 	}
 
 	for _, projection := range projections {
+		projection.finalize()
+		if projection.id == "" || strings.TrimSpace(projection.name) == "" {
+			continue
+		}
 		vendor := b.ensureVendorNode(projection)
 		if vendor == nil {
 			continue
@@ -93,6 +126,337 @@ func (b *Builder) buildVendorNodes() {
 	}
 }
 
+func (p *vendorProjection) absorb(identity vendorIdentity, node *Node) {
+	if p == nil || node == nil {
+		return
+	}
+	if rawName := strings.TrimSpace(identity.rawName); rawName != "" {
+		p.rawNames[rawName] = struct{}{}
+	}
+	if aliasKey := strings.TrimSpace(identity.aliasKey); aliasKey != "" {
+		p.aliasKeys[aliasKey] = struct{}{}
+	}
+	if ownerOrgID := strings.TrimSpace(identity.ownerOrgID); ownerOrgID != "" {
+		p.ownerOrganizationIDs[ownerOrgID] = struct{}{}
+	}
+	if provider := strings.TrimSpace(node.Provider); provider != "" {
+		p.sourceProviders[provider] = struct{}{}
+	}
+	if identity.integrationType != "" {
+		p.integrationTypes[identity.integrationType] = struct{}{}
+	}
+	p.managedNodeIDs[node.ID] = struct{}{}
+}
+
+func (p *vendorProjection) finalize() {
+	if p == nil {
+		return
+	}
+	p.aliasKey = chooseCanonicalVendorAliasKey(p.aliasKeys)
+	if p.aliasKey == "" {
+		p.aliasKey = chooseCanonicalVendorAliasKey(vendorAliasSetFromRawNames(p.rawNames))
+	}
+	p.name = chooseCanonicalVendorDisplayName(p.rawNames, p.aliasKey)
+	if strings.TrimSpace(p.name) == "" {
+		p.name = p.aliasKey
+	}
+	p.id = vendorNodeID(p.name)
+}
+
+func matchVendorProjection(projections []*vendorProjection, identity vendorIdentity) *vendorProjection {
+	for _, projection := range projections {
+		if projection == nil {
+			continue
+		}
+		if identity.ownerOrgID != "" {
+			if _, ok := projection.ownerOrganizationIDs[identity.ownerOrgID]; ok {
+				return projection
+			}
+		}
+	}
+	for _, projection := range projections {
+		if projection == nil {
+			continue
+		}
+		if identity.aliasKey == "" {
+			continue
+		}
+		for aliasKey := range projection.aliasKeys {
+			if vendorAliasKeysMatch(aliasKey, identity.aliasKey) {
+				return projection
+			}
+		}
+	}
+	return nil
+}
+
+func vendorAliasKeysMatch(left, right string) bool {
+	return strings.EqualFold(strings.TrimSpace(left), strings.TrimSpace(right))
+}
+
+func vendorAliasSetFromRawNames(rawNames map[string]struct{}) map[string]struct{} {
+	aliases := make(map[string]struct{}, len(rawNames))
+	for rawName := range rawNames {
+		if aliasKey := vendorAliasKey(rawName); aliasKey != "" {
+			aliases[aliasKey] = struct{}{}
+		}
+	}
+	return aliases
+}
+
+func chooseCanonicalVendorAliasKey(aliasKeys map[string]struct{}) string {
+	best := ""
+	bestTokens := 0
+	for aliasKey := range aliasKeys {
+		aliasKey = strings.TrimSpace(aliasKey)
+		if aliasKey == "" {
+			continue
+		}
+		tokenCount := len(strings.Fields(aliasKey))
+		if best == "" || tokenCount < bestTokens || (tokenCount == bestTokens && len(aliasKey) < len(best)) || (tokenCount == bestTokens && len(aliasKey) == len(best) && aliasKey < best) {
+			best = aliasKey
+			bestTokens = tokenCount
+		}
+	}
+	return best
+}
+
+func chooseCanonicalVendorDisplayName(rawNames map[string]struct{}, canonicalAliasKey string) string {
+	best := ""
+	for rawName := range rawNames {
+		rawName = strings.TrimSpace(rawName)
+		if rawName == "" {
+			continue
+		}
+		if canonicalAliasKey != "" && vendorAliasKey(rawName) != canonicalAliasKey {
+			continue
+		}
+		if best == "" || len(rawName) < len(best) || (len(rawName) == len(best) && rawName < best) {
+			best = rawName
+		}
+	}
+	if best != "" {
+		return best
+	}
+	for rawName := range rawNames {
+		rawName = strings.TrimSpace(rawName)
+		if rawName == "" {
+			continue
+		}
+		if best == "" || len(rawName) < len(best) || (len(rawName) == len(best) && rawName < best) {
+			best = rawName
+		}
+	}
+	return best
+}
+
+func vendorAliasKey(value string) string {
+	tokens := vendorNameTokens(value)
+	tokens = trimVendorAliasSuffixTokens(tokens)
+	if len(tokens) == 0 {
+		return ""
+	}
+	return strings.Join(tokens, " ")
+}
+
+func trimVendorAliasSuffixTokens(tokens []string) []string {
+	tokens = trimVendorLegalSuffixTokens(tokens)
+	for {
+		trimmed := trimVendorCorporateSuffixPhrase(tokens)
+		if len(trimmed) == len(tokens) {
+			return tokens
+		}
+		tokens = trimVendorLegalSuffixTokens(trimmed)
+	}
+}
+
+func trimVendorLegalSuffixTokens(tokens []string) []string {
+	for len(tokens) > 0 {
+		if _, ok := vendorLegalSuffixTokens[tokens[len(tokens)-1]]; !ok {
+			break
+		}
+		tokens = tokens[:len(tokens)-1]
+	}
+	return tokens
+}
+
+func trimVendorCorporateSuffixPhrase(tokens []string) []string {
+	for _, phrase := range vendorCorporateSuffixPhrases {
+		if len(tokens) <= len(phrase) {
+			continue
+		}
+		offset := len(tokens) - len(phrase)
+		match := true
+		for i := range phrase {
+			if tokens[offset+i] != phrase[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return tokens[:offset]
+		}
+	}
+	return tokens
+}
+
+func vendorNameTokens(value string) []string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return nil
+	}
+	var tokens []string
+	var current strings.Builder
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			current.WriteRune(r)
+			continue
+		}
+		if current.Len() == 0 {
+			continue
+		}
+		tokens = append(tokens, current.String())
+		current.Reset()
+	}
+	if current.Len() > 0 {
+		tokens = append(tokens, current.String())
+	}
+	return tokens
+}
+
+func vendorDisplayAliases(rawNames map[string]struct{}, canonicalName string) []string {
+	aliases := make([]string, 0, len(rawNames))
+	for rawName := range rawNames {
+		rawName = strings.TrimSpace(rawName)
+		if rawName == "" || rawName == canonicalName {
+			continue
+		}
+		aliases = append(aliases, rawName)
+	}
+	sort.Strings(aliases)
+	return aliases
+}
+
+func vendorCategory(integrationTypes map[string]struct{}) string {
+	if len(integrationTypes) == 0 {
+		return ""
+	}
+	return "saas_integration"
+}
+
+func vendorPermissionLevel(readCount, writeCount, adminCount int) string {
+	switch {
+	case adminCount > 0:
+		return "admin"
+	case writeCount > 0:
+		return "write"
+	case readCount > 0:
+		return "read"
+	default:
+		return "none"
+	}
+}
+
+func vendorTargetIsSensitive(node *Node) bool {
+	if node == nil {
+		return false
+	}
+	switch strings.ToLower(propertyString(node.Properties, "data_classification")) {
+	case "confidential", "restricted", "sensitive":
+		return true
+	}
+	for _, key := range []string{"contains_pii", "contains_phi", "contains_pci", "contains_secrets"} {
+		if value, ok := node.Properties[key].(bool); ok && value {
+			return true
+		}
+	}
+	return node.Kind == NodeKindSecret
+}
+
+func boolPropertyValue(properties map[string]any, key string) (bool, bool) {
+	if properties == nil {
+		return false, false
+	}
+	value, ok := properties[key]
+	if !ok {
+		return false, false
+	}
+	typed, ok := value.(bool)
+	if !ok {
+		return false, false
+	}
+	return typed, true
+}
+
+func targetKindsForEdges(g *Graph, edges []*Edge) map[string]struct{} {
+	kinds := make(map[string]struct{})
+	for _, edge := range edges {
+		if edge == nil {
+			continue
+		}
+		target, ok := g.GetNode(edge.Target)
+		if !ok || target == nil || strings.TrimSpace(string(target.Kind)) == "" {
+			continue
+		}
+		kinds[string(target.Kind)] = struct{}{}
+	}
+	return kinds
+}
+
+func sensitiveTargetsForEdges(g *Graph, edges []*Edge) map[string]struct{} {
+	targets := make(map[string]struct{})
+	for _, edge := range edges {
+		if edge == nil {
+			continue
+		}
+		target, ok := g.GetNode(edge.Target)
+		if !ok || target == nil || !vendorTargetIsSensitive(target) {
+			continue
+		}
+		targets[edge.Target] = struct{}{}
+	}
+	return targets
+}
+
+func permissionEdges(edges []*Edge) []*Edge {
+	filtered := make([]*Edge, 0, len(edges))
+	for _, edge := range edges {
+		if edge == nil {
+			continue
+		}
+		switch edge.Kind {
+		case EdgeKindCanRead, EdgeKindCanWrite, EdgeKindCanAdmin, EdgeKindCanDelete:
+			filtered = append(filtered, edge)
+		}
+	}
+	return filtered
+}
+
+func edgesByPermission(edges []*Edge) (map[string]struct{}, map[string]struct{}, map[string]struct{}, map[string]struct{}) {
+	accessibleTargets := make(map[string]struct{})
+	readableTargets := make(map[string]struct{})
+	writableTargets := make(map[string]struct{})
+	adminTargets := make(map[string]struct{})
+
+	for _, edge := range edges {
+		if edge == nil {
+			continue
+		}
+		switch edge.Kind {
+		case EdgeKindCanRead:
+			accessibleTargets[edge.Target] = struct{}{}
+			readableTargets[edge.Target] = struct{}{}
+		case EdgeKindCanWrite:
+			accessibleTargets[edge.Target] = struct{}{}
+			writableTargets[edge.Target] = struct{}{}
+		case EdgeKindCanAdmin, EdgeKindCanDelete:
+			accessibleTargets[edge.Target] = struct{}{}
+			adminTargets[edge.Target] = struct{}{}
+		}
+	}
+	return accessibleTargets, readableTargets, writableTargets, adminTargets
+}
+
 func (b *Builder) ensureVendorNode(projection *vendorProjection) *Node {
 	if projection == nil {
 		return nil
@@ -102,9 +466,7 @@ func (b *Builder) ensureVendorNode(projection *vendorProjection) *Node {
 			existing.Properties = make(map[string]any)
 		}
 		existing.Kind = NodeKindVendor
-		if strings.TrimSpace(existing.Name) == "" {
-			existing.Name = projection.name
-		}
+		existing.Name = projection.name
 		existing.Properties["source_system"] = vendorProjectionSourceSystem
 		return existing
 	}
@@ -136,10 +498,14 @@ func (b *Builder) refreshVendorSignals(vendor *Node, projection *vendorProjectio
 
 	var managedApplicationCount int
 	var managedServiceAccountCount int
+	var appRoleAssignmentRequiredCount int
+	var appRoleAssignmentOptionalCount int
+	accessibleTargets := make(map[string]struct{})
 	readableTargets := make(map[string]struct{})
 	writableTargets := make(map[string]struct{})
 	adminTargets := make(map[string]struct{})
-	accessibleTargets := make(map[string]struct{})
+	accessibleResourceKinds := make(map[string]struct{})
+	sensitiveTargets := make(map[string]struct{})
 
 	for managedNodeID := range projection.managedNodeIDs {
 		node, ok := b.graph.GetNode(managedNodeID)
@@ -152,68 +518,100 @@ func (b *Builder) refreshVendorSignals(vendor *Node, projection *vendorProjectio
 		case NodeKindServiceAccount:
 			managedServiceAccountCount++
 		}
-		for _, edge := range b.graph.GetOutEdges(managedNodeID) {
-			if edge == nil {
-				continue
+		if node.Kind == NodeKindServiceAccount {
+			if required, ok := boolPropertyValue(node.Properties, "app_role_assignment_required"); ok {
+				if required {
+					appRoleAssignmentRequiredCount++
+				} else {
+					appRoleAssignmentOptionalCount++
+				}
 			}
-			switch edge.Kind {
-			case EdgeKindCanRead:
-				accessibleTargets[edge.Target] = struct{}{}
-				readableTargets[edge.Target] = struct{}{}
-			case EdgeKindCanWrite:
-				accessibleTargets[edge.Target] = struct{}{}
-				writableTargets[edge.Target] = struct{}{}
-			case EdgeKindCanAdmin, EdgeKindCanDelete:
-				accessibleTargets[edge.Target] = struct{}{}
-				adminTargets[edge.Target] = struct{}{}
-			}
+		}
+		outEdges := permissionEdges(b.graph.GetOutEdges(managedNodeID))
+		nodeAccessibleTargets, nodeReadableTargets, nodeWritableTargets, nodeAdminTargets := edgesByPermission(outEdges)
+		for target := range nodeAccessibleTargets {
+			accessibleTargets[target] = struct{}{}
+		}
+		for target := range nodeReadableTargets {
+			readableTargets[target] = struct{}{}
+		}
+		for target := range nodeWritableTargets {
+			writableTargets[target] = struct{}{}
+		}
+		for target := range nodeAdminTargets {
+			adminTargets[target] = struct{}{}
+		}
+		for kind := range targetKindsForEdges(b.graph, outEdges) {
+			accessibleResourceKinds[kind] = struct{}{}
+		}
+		for target := range sensitiveTargetsForEdges(b.graph, outEdges) {
+			sensitiveTargets[target] = struct{}{}
 		}
 	}
 
 	vendor.Properties["canonical_name"] = vendor.Name
 	vendor.Properties["source_system"] = vendorProjectionSourceSystem
+	vendor.Properties["aliases"] = vendorDisplayAliases(projection.rawNames, vendor.Name)
+	vendor.Properties["owner_organization_ids"] = sortedVendorKeys(projection.ownerOrganizationIDs)
 	vendor.Properties["source_providers"] = sortedVendorKeys(projection.sourceProviders)
 	vendor.Properties["integration_types"] = sortedVendorKeys(projection.integrationTypes)
+	vendor.Properties["vendor_category"] = vendorCategory(projection.integrationTypes)
 	vendor.Properties["managed_node_count"] = len(projection.managedNodeIDs)
 	vendor.Properties["managed_application_count"] = managedApplicationCount
 	vendor.Properties["managed_service_account_count"] = managedServiceAccountCount
+	vendor.Properties["app_role_assignment_required_count"] = appRoleAssignmentRequiredCount
+	vendor.Properties["app_role_assignment_optional_count"] = appRoleAssignmentOptionalCount
 	vendor.Properties["accessible_resource_count"] = len(accessibleTargets)
+	vendor.Properties["accessible_resource_kinds"] = sortedVendorKeys(accessibleResourceKinds)
+	vendor.Properties["sensitive_resource_count"] = len(sensitiveTargets)
 	vendor.Properties["read_access_count"] = len(readableTargets)
 	vendor.Properties["write_access_count"] = len(writableTargets)
 	vendor.Properties["admin_access_count"] = len(adminTargets)
+	vendor.Properties["permission_level"] = vendorPermissionLevel(len(readableTargets), len(writableTargets), len(adminTargets))
 	vendor.Risk = vendorRiskLevel(len(readableTargets), len(writableTargets), len(adminTargets))
 }
 
-func vendorIdentityForNode(node *Node) (string, string, bool) {
+func vendorIdentityForNode(node *Node) (vendorIdentity, bool) {
 	if node == nil {
-		return "", "", false
+		return vendorIdentity{}, false
 	}
 
 	switch {
 	case node.Provider == "okta" && node.Kind == NodeKindApplication:
-		name := strings.TrimSpace(node.Name)
-		if name == "" {
-			return "", "", false
+		rawName := strings.TrimSpace(node.Name)
+		aliasKey := vendorAliasKey(rawName)
+		if rawName == "" || aliasKey == "" {
+			return vendorIdentity{}, false
 		}
-		return name, "okta_application", true
+		return vendorIdentity{
+			rawName:         rawName,
+			aliasKey:        aliasKey,
+			integrationType: "okta_application",
+		}, true
 	case node.Provider == "azure" && node.Kind == NodeKindServiceAccount:
 		if !strings.EqualFold(propertyString(node.Properties, "azure_resource_type"), "service_principal") {
-			return "", "", false
+			return vendorIdentity{}, false
 		}
 		principalType := strings.ToLower(strings.TrimSpace(firstNonEmpty(
 			propertyString(node.Properties, "identity_type"),
 			propertyString(node.Properties, "type"),
 		)))
 		if strings.Contains(principalType, "managed") {
-			return "", "", false
+			return vendorIdentity{}, false
 		}
-		name := strings.TrimSpace(propertyString(node.Properties, "publisher_name"))
-		if name == "" {
-			return "", "", false
+		rawName := strings.TrimSpace(propertyString(node.Properties, "publisher_name"))
+		aliasKey := vendorAliasKey(rawName)
+		if rawName == "" || aliasKey == "" {
+			return vendorIdentity{}, false
 		}
-		return name, "entra_service_principal", true
+		return vendorIdentity{
+			rawName:         rawName,
+			aliasKey:        aliasKey,
+			ownerOrgID:      strings.TrimSpace(propertyString(node.Properties, "app_owner_organization_id")),
+			integrationType: "entra_service_principal",
+		}, true
 	default:
-		return "", "", false
+		return vendorIdentity{}, false
 	}
 }
 

--- a/internal/graph/builders/builder_vendor.go
+++ b/internal/graph/builders/builder_vendor.go
@@ -1,0 +1,261 @@
+package builders
+
+import (
+	"sort"
+	"strings"
+)
+
+const vendorProjectionSourceSystem = "graph_builder_vendor_projection"
+
+type vendorProjection struct {
+	id               string
+	name             string
+	sourceProviders  map[string]struct{}
+	integrationTypes map[string]struct{}
+	managedNodeIDs   map[string]struct{}
+}
+
+func (b *Builder) buildVendorNodes() {
+	if b == nil || b.graph == nil {
+		return
+	}
+
+	candidates := b.graph.GetAllNodes()
+	for _, node := range candidates {
+		if node == nil || node.Kind != NodeKindVendor {
+			continue
+		}
+		if !strings.EqualFold(propertyString(node.Properties, "source_system"), vendorProjectionSourceSystem) {
+			continue
+		}
+		b.graph.RemoveNode(node.ID)
+	}
+
+	projections := make(map[string]*vendorProjection)
+	for _, node := range candidates {
+		if node == nil || node.Kind == NodeKindVendor {
+			continue
+		}
+		name, integrationType, ok := vendorIdentityForNode(node)
+		if !ok {
+			continue
+		}
+		vendorID := vendorNodeID(name)
+		if vendorID == "" {
+			continue
+		}
+
+		projection, exists := projections[vendorID]
+		if !exists {
+			projection = &vendorProjection{
+				id:               vendorID,
+				name:             strings.TrimSpace(name),
+				sourceProviders:  make(map[string]struct{}),
+				integrationTypes: make(map[string]struct{}),
+				managedNodeIDs:   make(map[string]struct{}),
+			}
+			projections[vendorID] = projection
+		}
+		if projection.name == "" {
+			projection.name = strings.TrimSpace(name)
+		}
+		if provider := strings.TrimSpace(node.Provider); provider != "" {
+			projection.sourceProviders[provider] = struct{}{}
+		}
+		if integrationType != "" {
+			projection.integrationTypes[integrationType] = struct{}{}
+		}
+		projection.managedNodeIDs[node.ID] = struct{}{}
+	}
+
+	for _, projection := range projections {
+		vendor := b.ensureVendorNode(projection)
+		if vendor == nil {
+			continue
+		}
+		for managedNodeID := range projection.managedNodeIDs {
+			b.addEdgeIfMissing(&Edge{
+				Source: managedNodeID,
+				Target: vendor.ID,
+				Kind:   EdgeKindManagedBy,
+				Effect: EdgeEffectAllow,
+				Properties: map[string]any{
+					"relationship":    "vendor",
+					"source_system":   vendorProjectionSourceSystem,
+					"cross_system":    true,
+					"vendor_node_id":  vendor.ID,
+					"vendor_name":     vendor.Name,
+					"managed_node_id": managedNodeID,
+				},
+			})
+		}
+		b.refreshVendorSignals(vendor, projection)
+	}
+}
+
+func (b *Builder) ensureVendorNode(projection *vendorProjection) *Node {
+	if projection == nil {
+		return nil
+	}
+	if existing, ok := b.graph.GetNode(projection.id); ok && existing != nil {
+		if existing.Properties == nil {
+			existing.Properties = make(map[string]any)
+		}
+		existing.Kind = NodeKindVendor
+		if strings.TrimSpace(existing.Name) == "" {
+			existing.Name = projection.name
+		}
+		existing.Properties["source_system"] = vendorProjectionSourceSystem
+		return existing
+	}
+
+	vendor := &Node{
+		ID:   projection.id,
+		Kind: NodeKindVendor,
+		Name: projection.name,
+		Properties: map[string]any{
+			"canonical_name": projection.name,
+			"source_system":  vendorProjectionSourceSystem,
+		},
+	}
+	b.graph.AddNode(vendor)
+	resolved, _ := b.graph.GetNode(projection.id)
+	if resolved == nil {
+		return nil
+	}
+	return resolved
+}
+
+func (b *Builder) refreshVendorSignals(vendor *Node, projection *vendorProjection) {
+	if vendor == nil || projection == nil {
+		return
+	}
+	if vendor.Properties == nil {
+		vendor.Properties = make(map[string]any)
+	}
+
+	var managedApplicationCount int
+	var managedServiceAccountCount int
+	readableTargets := make(map[string]struct{})
+	writableTargets := make(map[string]struct{})
+	adminTargets := make(map[string]struct{})
+	accessibleTargets := make(map[string]struct{})
+
+	for managedNodeID := range projection.managedNodeIDs {
+		node, ok := b.graph.GetNode(managedNodeID)
+		if !ok || node == nil {
+			continue
+		}
+		switch node.Kind {
+		case NodeKindApplication:
+			managedApplicationCount++
+		case NodeKindServiceAccount:
+			managedServiceAccountCount++
+		}
+		for _, edge := range b.graph.GetOutEdges(managedNodeID) {
+			if edge == nil {
+				continue
+			}
+			switch edge.Kind {
+			case EdgeKindCanRead:
+				accessibleTargets[edge.Target] = struct{}{}
+				readableTargets[edge.Target] = struct{}{}
+			case EdgeKindCanWrite:
+				accessibleTargets[edge.Target] = struct{}{}
+				writableTargets[edge.Target] = struct{}{}
+			case EdgeKindCanAdmin, EdgeKindCanDelete:
+				accessibleTargets[edge.Target] = struct{}{}
+				adminTargets[edge.Target] = struct{}{}
+			}
+		}
+	}
+
+	vendor.Properties["canonical_name"] = vendor.Name
+	vendor.Properties["source_system"] = vendorProjectionSourceSystem
+	vendor.Properties["source_providers"] = sortedVendorKeys(projection.sourceProviders)
+	vendor.Properties["integration_types"] = sortedVendorKeys(projection.integrationTypes)
+	vendor.Properties["managed_node_count"] = len(projection.managedNodeIDs)
+	vendor.Properties["managed_application_count"] = managedApplicationCount
+	vendor.Properties["managed_service_account_count"] = managedServiceAccountCount
+	vendor.Properties["accessible_resource_count"] = len(accessibleTargets)
+	vendor.Properties["read_access_count"] = len(readableTargets)
+	vendor.Properties["write_access_count"] = len(writableTargets)
+	vendor.Properties["admin_access_count"] = len(adminTargets)
+	vendor.Risk = vendorRiskLevel(len(readableTargets), len(writableTargets), len(adminTargets))
+}
+
+func vendorIdentityForNode(node *Node) (string, string, bool) {
+	if node == nil {
+		return "", "", false
+	}
+
+	switch {
+	case node.Provider == "okta" && node.Kind == NodeKindApplication:
+		name := strings.TrimSpace(node.Name)
+		if name == "" {
+			return "", "", false
+		}
+		return name, "okta_application", true
+	case node.Provider == "azure" && node.Kind == NodeKindServiceAccount:
+		if !strings.EqualFold(propertyString(node.Properties, "azure_resource_type"), "service_principal") {
+			return "", "", false
+		}
+		principalType := strings.ToLower(strings.TrimSpace(firstNonEmpty(
+			propertyString(node.Properties, "identity_type"),
+			propertyString(node.Properties, "type"),
+		)))
+		if strings.Contains(principalType, "managed") {
+			return "", "", false
+		}
+		name := strings.TrimSpace(propertyString(node.Properties, "publisher_name"))
+		if name == "" {
+			return "", "", false
+		}
+		return name, "entra_service_principal", true
+	default:
+		return "", "", false
+	}
+}
+
+func vendorNodeID(name string) string {
+	normalized := normalizeOrgKey(name)
+	if normalized == "" {
+		return ""
+	}
+	return "vendor:" + normalized
+}
+
+func vendorRiskLevel(readCount, writeCount, adminCount int) RiskLevel {
+	switch {
+	case adminCount > 0:
+		return RiskHigh
+	case writeCount > 0:
+		return RiskMedium
+	case readCount > 0:
+		return RiskLow
+	default:
+		return RiskNone
+	}
+}
+
+func propertyString(properties map[string]any, key string) string {
+	if properties == nil {
+		return ""
+	}
+	return strings.TrimSpace(queryRowString(properties, key))
+}
+
+func sortedVendorKeys(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/graph/builders/builder_vendor_test.go
+++ b/internal/graph/builders/builder_vendor_test.go
@@ -1,0 +1,251 @@
+package builders
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestBuilder_ProjectsVendorNodesFromIdentityIntegrations(t *testing.T) {
+	t.Parallel()
+
+	source := newMockDataSource()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	source.setResult(`SELECT id, label, name, status, sign_on_mode FROM okta_applications`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":           "okta-app-slack",
+			"label":        "Slack",
+			"name":         "slack",
+			"status":       "ACTIVE",
+			"sign_on_mode": "SAML_2_0",
+		}},
+	})
+	source.setResult(`SELECT id, display_name, app_id, service_principal_type, account_enabled, app_owner_organization_id, app_role_assignment_required, publisher_name, created_date_time, tags, subscription_id FROM azure_graph_service_principals`, &DataQueryResult{
+		Rows: []map[string]any{
+			{
+				"id":                        "sp-slack",
+				"display_name":              "Slack Enterprise Grid",
+				"app_id":                    "app-slack",
+				"service_principal_type":    "Application",
+				"account_enabled":           true,
+				"app_owner_organization_id": "tenant-vendor",
+				"publisher_name":            "Slack",
+				"subscription_id":           "sub-1",
+			},
+			{
+				"id":                        "sp-managed",
+				"display_name":              "aks-workload-identity",
+				"app_id":                    "app-managed",
+				"service_principal_type":    "ManagedIdentity",
+				"account_enabled":           true,
+				"app_owner_organization_id": "tenant-local",
+				"publisher_name":            "Microsoft",
+				"subscription_id":           "sub-1",
+			},
+		},
+	})
+	source.setResult(`
+		SELECT source_id, source_type, target_id, target_type, rel_type, properties
+		FROM resource_relationships
+	`, &DataQueryResult{
+		Rows: []map[string]any{
+			{
+				"source_id":   "sp-slack",
+				"source_type": "entra:service_principal",
+				"target_id":   "/subscriptions/sub-1/resourceGroups/rg-app/providers/Microsoft.Storage/storageAccounts/data",
+				"target_type": "azure:storage:account",
+				"rel_type":    "READS_FROM",
+			},
+			{
+				"source_id":   "sp-slack",
+				"source_type": "entra:service_principal",
+				"target_id":   "/subscriptions/sub-1/resourceGroups/rg-app/providers/Microsoft.KeyVault/vaults/prod",
+				"target_type": "azure:keyvault:vault",
+				"rel_type":    "HAS_PERMISSION",
+			},
+		},
+	})
+
+	builder := NewBuilder(source, logger)
+	if err := builder.Build(context.Background()); err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	g := builder.Graph()
+	vendor, ok := g.GetNode("vendor:slack")
+	if !ok {
+		t.Fatal("expected vendor node for Slack")
+	}
+	if vendor.Kind != NodeKindVendor {
+		t.Fatalf("expected vendor node kind, got %#v", vendor)
+	}
+	if vendor.Name != "Slack" {
+		t.Fatalf("expected canonical vendor name to be preserved, got %q", vendor.Name)
+	}
+	assertStringSliceProperty(t, vendor.Properties, "source_providers", []string{"azure", "okta"})
+	assertStringSliceProperty(t, vendor.Properties, "integration_types", []string{"entra_service_principal", "okta_application"})
+	if got := intProperty(t, vendor.Properties, "managed_node_count"); got != 2 {
+		t.Fatalf("expected two managed nodes, got %d", got)
+	}
+	if got := intProperty(t, vendor.Properties, "managed_application_count"); got != 1 {
+		t.Fatalf("expected one managed application, got %d", got)
+	}
+	if got := intProperty(t, vendor.Properties, "managed_service_account_count"); got != 1 {
+		t.Fatalf("expected one managed service account, got %d", got)
+	}
+	if got := intProperty(t, vendor.Properties, "accessible_resource_count"); got != 2 {
+		t.Fatalf("expected two accessible resources, got %d", got)
+	}
+	if got := intProperty(t, vendor.Properties, "read_access_count"); got != 1 {
+		t.Fatalf("expected one readable resource, got %d", got)
+	}
+	if got := intProperty(t, vendor.Properties, "admin_access_count"); got != 1 {
+		t.Fatalf("expected one admin resource, got %d", got)
+	}
+	if vendor.Risk != RiskHigh {
+		t.Fatalf("expected high vendor risk from admin access, got %s", vendor.Risk)
+	}
+
+	assertEdgeExists(t, g, "okta-app-slack", "vendor:slack", EdgeKindManagedBy)
+	assertEdgeExists(t, g, "sp-slack", "vendor:slack", EdgeKindManagedBy)
+	for _, edge := range g.GetOutEdges("sp-managed") {
+		if edge.Target == "vendor:microsoft" && edge.Kind == EdgeKindManagedBy {
+			t.Fatalf("expected managed identities to avoid vendor projection, got %#v", edge)
+		}
+	}
+	if _, ok := g.GetNode("vendor:microsoft"); ok {
+		t.Fatal("expected managed identity publisher to avoid vendor node creation")
+	}
+}
+
+func TestBuilder_ApplyChangesReprojectsDerivedVendorNodes(t *testing.T) {
+	t.Parallel()
+
+	source := newMockDataSource()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	source.setResult(`SELECT id, label, name, status, sign_on_mode FROM okta_applications`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":           "okta-app-1",
+			"label":        "Slack",
+			"name":         "slack",
+			"status":       "ACTIVE",
+			"sign_on_mode": "SAML_2_0",
+		}},
+	})
+
+	builder := NewBuilder(source, logger)
+	if err := builder.Build(context.Background()); err != nil {
+		t.Fatalf("initial build failed: %v", err)
+	}
+
+	if _, ok := builder.Graph().GetNode("vendor:slack"); !ok {
+		t.Fatal("expected initial derived vendor node")
+	}
+
+	source.setResult(`SELECT id, label, name, status, sign_on_mode FROM okta_applications`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":           "okta-app-1",
+			"label":        "Notion",
+			"name":         "notion",
+			"status":       "ACTIVE",
+			"sign_on_mode": "SAML_2_0",
+		}},
+	})
+	cdcQuery := `
+		SELECT event_id, table_name, resource_id, change_type, provider, region, account_id, payload, event_time,
+		       COALESCE(ingested_at, event_time) AS ingested_at
+		FROM CDC_EVENTS
+		WHERE (
+			event_time > ?
+			OR (event_time = ? AND COALESCE(ingested_at, event_time) > ?)
+			OR (event_time = ? AND COALESCE(ingested_at, event_time) = ? AND event_id > ?)
+		) ORDER BY event_time ASC, ingested_at ASC, event_id ASC`
+	now := time.Now().UTC()
+	source.setResult(cdcQuery, &DataQueryResult{
+		Rows: []map[string]any{{
+			"event_id":    "evt-1",
+			"table_name":  "okta_applications",
+			"resource_id": "okta-app-1",
+			"change_type": "modified",
+			"provider":    "okta",
+			"payload": map[string]any{
+				"id":           "okta-app-1",
+				"label":        "Notion",
+				"name":         "notion",
+				"status":       "ACTIVE",
+				"sign_on_mode": "SAML_2_0",
+			},
+			"event_time":  now,
+			"ingested_at": now,
+		}},
+	})
+
+	if _, err := builder.ApplyChanges(context.Background(), time.Time{}); err != nil {
+		t.Fatalf("apply changes failed: %v", err)
+	}
+
+	if _, ok := builder.Graph().GetNode("vendor:notion"); !ok {
+		t.Fatal("expected renamed vendor node after incremental rebuild")
+	}
+	if _, ok := builder.Graph().GetNode("vendor:slack"); ok {
+		t.Fatal("expected stale derived vendor node to be removed")
+	}
+}
+
+func assertStringSliceProperty(t *testing.T, properties map[string]any, key string, want []string) {
+	t.Helper()
+
+	value, ok := properties[key]
+	if !ok {
+		t.Fatalf("expected property %q to be present", key)
+	}
+
+	var got []string
+	switch typed := value.(type) {
+	case []string:
+		got = append(got, typed...)
+	case []any:
+		for _, item := range typed {
+			if text, ok := item.(string); ok && text != "" {
+				got = append(got, text)
+			}
+		}
+	default:
+		t.Fatalf("expected property %q to be string slice, got %#v", key, value)
+	}
+
+	sort.Strings(got)
+	sortedWant := append([]string(nil), want...)
+	sort.Strings(sortedWant)
+	if !reflect.DeepEqual(got, sortedWant) {
+		t.Fatalf("unexpected property %q: got %#v want %#v", key, got, sortedWant)
+	}
+}
+
+func intProperty(t *testing.T, properties map[string]any, key string) int {
+	t.Helper()
+
+	value, ok := properties[key]
+	if !ok {
+		t.Fatalf("expected property %q to be present", key)
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int32:
+		return int(typed)
+	case int64:
+		return int(typed)
+	case float64:
+		return int(typed)
+	default:
+		t.Fatalf("expected property %q to be numeric, got %#v", key, value)
+		return 0
+	}
+}

--- a/internal/graph/builders/builder_vendor_test.go
+++ b/internal/graph/builders/builder_vendor_test.go
@@ -89,6 +89,8 @@ func TestBuilder_ProjectsVendorNodesFromIdentityIntegrations(t *testing.T) {
 	}
 	assertStringSliceProperty(t, vendor.Properties, "source_providers", []string{"azure", "okta"})
 	assertStringSliceProperty(t, vendor.Properties, "integration_types", []string{"entra_service_principal", "okta_application"})
+	assertStringSliceProperty(t, vendor.Properties, "owner_organization_ids", []string{"tenant-vendor"})
+	assertStringSliceProperty(t, vendor.Properties, "accessible_resource_kinds", []string{"bucket", "secret"})
 	if got := intProperty(t, vendor.Properties, "managed_node_count"); got != 2 {
 		t.Fatalf("expected two managed nodes, got %d", got)
 	}
@@ -107,6 +109,18 @@ func TestBuilder_ProjectsVendorNodesFromIdentityIntegrations(t *testing.T) {
 	if got := intProperty(t, vendor.Properties, "admin_access_count"); got != 1 {
 		t.Fatalf("expected one admin resource, got %d", got)
 	}
+	if got := intProperty(t, vendor.Properties, "app_role_assignment_required_count"); got != 0 {
+		t.Fatalf("expected no assignment-required integrations in this fixture, got %d", got)
+	}
+	if got := intProperty(t, vendor.Properties, "app_role_assignment_optional_count"); got != 0 {
+		t.Fatalf("expected no assignment-optional integrations in this fixture, got %d", got)
+	}
+	if got, _ := vendor.Properties["permission_level"].(string); got != "admin" {
+		t.Fatalf("expected permission level admin, got %#v", vendor.Properties["permission_level"])
+	}
+	if got, _ := vendor.Properties["vendor_category"].(string); got != "saas_integration" {
+		t.Fatalf("expected saas integration category, got %#v", vendor.Properties["vendor_category"])
+	}
 	if vendor.Risk != RiskHigh {
 		t.Fatalf("expected high vendor risk from admin access, got %s", vendor.Risk)
 	}
@@ -120,6 +134,148 @@ func TestBuilder_ProjectsVendorNodesFromIdentityIntegrations(t *testing.T) {
 	}
 	if _, ok := g.GetNode("vendor:microsoft"); ok {
 		t.Fatal("expected managed identity publisher to avoid vendor node creation")
+	}
+}
+
+func TestBuilder_CanonicalizesVendorAliasesAndAggregatesProvenance(t *testing.T) {
+	t.Parallel()
+
+	source := newMockDataSource()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	source.setResult(`SELECT id, label, name, status, sign_on_mode FROM okta_applications`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":           "okta-app-zoom",
+			"label":        "Zoom",
+			"name":         "zoom",
+			"status":       "ACTIVE",
+			"sign_on_mode": "SAML_2_0",
+		}},
+	})
+	source.setResult(`SELECT id, display_name, app_id, service_principal_type, account_enabled, app_owner_organization_id, app_role_assignment_required, publisher_name, created_date_time, tags, subscription_id FROM azure_graph_service_principals`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":                           "sp-zoom",
+			"display_name":                 "Zoom for Enterprise",
+			"app_id":                       "app-zoom",
+			"service_principal_type":       "Application",
+			"account_enabled":              true,
+			"app_owner_organization_id":    "tenant-zoom",
+			"app_role_assignment_required": true,
+			"publisher_name":               "Zoom Video Communications, Inc.",
+			"subscription_id":              "sub-1",
+		}},
+	})
+	source.setResult(`
+		SELECT arn, name, account_id, region
+		FROM aws_secretsmanager_secrets
+	`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"arn":        "arn:aws:secretsmanager:us-east-1:111111111111:secret:zoom-api",
+			"name":       "zoom-api",
+			"account_id": "111111111111",
+			"region":     "us-east-1",
+		}},
+	})
+	source.setResult(`
+		SELECT source_id, source_type, target_id, target_type, rel_type, properties
+		FROM resource_relationships
+	`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"source_id":   "sp-zoom",
+			"source_type": "entra:service_principal",
+			"target_id":   "arn:aws:secretsmanager:us-east-1:111111111111:secret:zoom-api",
+			"target_type": "aws:secretsmanager:secret",
+			"rel_type":    "READS_FROM",
+		}},
+	})
+
+	builder := NewBuilder(source, logger)
+	if err := builder.Build(context.Background()); err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	g := builder.Graph()
+	vendor, ok := g.GetNode("vendor:zoom")
+	if !ok {
+		t.Fatal("expected canonical vendor node for Zoom")
+	}
+	if _, ok := g.GetNode("vendor:zoom-video-communications"); ok {
+		t.Fatal("expected alias form to collapse into canonical vendor node")
+	}
+	if vendor.Name != "Zoom" {
+		t.Fatalf("expected canonical vendor display name Zoom, got %q", vendor.Name)
+	}
+	assertStringSliceProperty(t, vendor.Properties, "aliases", []string{"Zoom Video Communications, Inc."})
+	assertStringSliceProperty(t, vendor.Properties, "owner_organization_ids", []string{"tenant-zoom"})
+	assertStringSliceProperty(t, vendor.Properties, "accessible_resource_kinds", []string{"secret"})
+	if got := intProperty(t, vendor.Properties, "sensitive_resource_count"); got != 1 {
+		t.Fatalf("expected one sensitive resource, got %d", got)
+	}
+	if got := intProperty(t, vendor.Properties, "app_role_assignment_required_count"); got != 1 {
+		t.Fatalf("expected one assignment-required integration, got %d", got)
+	}
+	if got, _ := vendor.Properties["permission_level"].(string); got != "read" {
+		t.Fatalf("expected permission level read, got %#v", vendor.Properties["permission_level"])
+	}
+	assertEdgeExists(t, g, "okta-app-zoom", "vendor:zoom", EdgeKindManagedBy)
+	assertEdgeExists(t, g, "sp-zoom", "vendor:zoom", EdgeKindManagedBy)
+}
+
+func TestBuilder_KeepsDistinctVendorProductAliasesSeparate(t *testing.T) {
+	t.Parallel()
+
+	source := newMockDataSource()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	source.setResult(`SELECT id, label, name, status, sign_on_mode FROM okta_applications`, &DataQueryResult{
+		Rows: []map[string]any{
+			{
+				"id":           "okta-app-google",
+				"label":        "Google",
+				"name":         "google",
+				"status":       "ACTIVE",
+				"sign_on_mode": "SAML_2_0",
+			},
+			{
+				"id":           "okta-app-google-analytics",
+				"label":        "Google Analytics",
+				"name":         "google_analytics",
+				"status":       "ACTIVE",
+				"sign_on_mode": "SAML_2_0",
+			},
+		},
+	})
+
+	builder := NewBuilder(source, logger)
+	if err := builder.Build(context.Background()); err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	g := builder.Graph()
+	assertEdgeExists(t, g, "okta-app-google", "vendor:google", EdgeKindManagedBy)
+	assertEdgeExists(t, g, "okta-app-google-analytics", "vendor:google-analytics", EdgeKindManagedBy)
+	if _, ok := g.GetNode("vendor:google"); !ok {
+		t.Fatal("expected vendor node for Google")
+	}
+	if _, ok := g.GetNode("vendor:google-analytics"); !ok {
+		t.Fatal("expected separate vendor node for Google Analytics")
+	}
+}
+
+func TestVendorAliasKey_TrimsCorporateSuffixesConservatively(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"Zoom Video Communications, Inc.": "zoom",
+		"Slack Technologies, LLC":         "slack",
+		"Google Analytics":                "google analytics",
+		"Palo Alto Networks, Inc.":        "palo alto networks",
+	}
+
+	for input, want := range cases {
+		if got := vendorAliasKey(input); got != want {
+			t.Fatalf("vendorAliasKey(%q) = %q, want %q", input, got, want)
+		}
 	}
 }
 

--- a/internal/graph/builders/core_exports.go
+++ b/internal/graph/builders/core_exports.go
@@ -35,6 +35,7 @@ const (
 	EdgeKindExposedTo      = graph.EdgeKindExposedTo
 	EdgeKindInteractedWith = graph.EdgeKindInteractedWith
 	EdgeKindLocatedIn      = graph.EdgeKindLocatedIn
+	EdgeKindManagedBy      = graph.EdgeKindManagedBy
 	EdgeKindMemberOf       = graph.EdgeKindMemberOf
 	EdgeKindReportsTo      = graph.EdgeKindReportsTo
 	EdgeKindResolvesTo     = graph.EdgeKindResolvesTo
@@ -69,8 +70,10 @@ const (
 	NodeKindServiceAccount     = graph.NodeKindServiceAccount
 	NodeKindUser               = graph.NodeKindUser
 	NodeKindFolder             = graph.NodeKindFolder
+	NodeKindVendor             = graph.NodeKindVendor
 
 	RiskNone     = graph.RiskNone
+	RiskLow      = graph.RiskLow
 	RiskMedium   = graph.RiskMedium
 	RiskHigh     = graph.RiskHigh
 	RiskCritical = graph.RiskCritical

--- a/internal/graph/impact_paths.go
+++ b/internal/graph/impact_paths.go
@@ -169,7 +169,7 @@ func (a *ImpactPathAnalyzer) isScenarioTarget(scenario ImpactScenario, node *Nod
 	case ImpactScenarioRevenueImpact:
 		return node.Kind == NodeKindCustomer || node.Kind == NodeKindCompany || node.Kind == NodeKindDeal || node.Kind == NodeKindOpportunity
 	case ImpactScenarioIncidentBlast:
-		return node.Kind == NodeKindCustomer || node.Kind == NodeKindCompany || node.Kind == NodeKindSubscription
+		return node.Kind == NodeKindCustomer || node.Kind == NodeKindCompany || node.Kind == NodeKindVendor || node.Kind == NodeKindSubscription
 	default:
 		return node.IsBusinessEntity()
 	}

--- a/internal/graph/impact_paths_test.go
+++ b/internal/graph/impact_paths_test.go
@@ -30,15 +30,17 @@ func TestImpactPathAnalyzer_IncidentBlastRadius(t *testing.T) {
 	g.AddNode(&Node{ID: "service-1", Kind: NodeKindApplication, Name: "API Service", Properties: map[string]any{"outage_detected": true}})
 	g.AddNode(&Node{ID: "customer-1", Kind: NodeKindCustomer, Name: "Acme", Properties: map[string]any{"arr": 500000}})
 	g.AddNode(&Node{ID: "customer-2", Kind: NodeKindCustomer, Name: "Beta", Properties: map[string]any{"arr": 400000}})
+	g.AddNode(&Node{ID: "vendor-1", Kind: NodeKindVendor, Name: "Slack"})
 
 	g.AddEdge(&Edge{ID: "s-c1", Source: "service-1", Target: "customer-1", Kind: EdgeKindOwns, Effect: EdgeEffectAllow})
 	g.AddEdge(&Edge{ID: "s-c2", Source: "service-1", Target: "customer-2", Kind: EdgeKindOwns, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "s-v1", Source: "service-1", Target: "vendor-1", Kind: EdgeKindOwns, Effect: EdgeEffectAllow})
 
 	analyzer := NewImpactPathAnalyzer(g)
 	result := analyzer.Analyze("service-1", ImpactScenarioIncidentBlast, 3)
 
-	if result.TotalAffectedEntities < 2 {
-		t.Fatalf("expected at least 2 affected entities, got %d", result.TotalAffectedEntities)
+	if result.TotalAffectedEntities < 3 {
+		t.Fatalf("expected at least 3 affected entities, got %d", result.TotalAffectedEntities)
 	}
 	if len(result.Paths) == 0 {
 		t.Fatal("expected at least one incident impact path")

--- a/internal/graph/node.go
+++ b/internal/graph/node.go
@@ -65,6 +65,7 @@ const (
 	NodeKindCustomer      NodeKind = "customer"
 	NodeKindContact       NodeKind = "contact"
 	NodeKindCompany       NodeKind = "company"
+	NodeKindVendor        NodeKind = "vendor"
 	NodeKindDeal          NodeKind = "deal"
 	NodeKindOpportunity   NodeKind = "opportunity"
 	NodeKindSubscription  NodeKind = "subscription"

--- a/internal/graph/node_edge_helpers_test.go
+++ b/internal/graph/node_edge_helpers_test.go
@@ -7,6 +7,7 @@ func TestNodeIsBusinessEntity(t *testing.T) {
 		NodeKindCustomer,
 		NodeKindContact,
 		NodeKindCompany,
+		NodeKindVendor,
 		NodeKindDeal,
 		NodeKindOpportunity,
 		NodeKindSubscription,

--- a/internal/graph/org_health.go
+++ b/internal/graph/org_health.go
@@ -860,7 +860,7 @@ func orgHealthTargets(g *Graph) []*Node {
 
 func isOrgHealthTargetKind(kind NodeKind) bool {
 	switch kind {
-	case NodeKindRepository, NodeKindApplication, NodeKindDatabase, NodeKindFunction, NodeKindBucket, NodeKindCustomer, NodeKindCompany:
+	case NodeKindRepository, NodeKindApplication, NodeKindDatabase, NodeKindFunction, NodeKindBucket, NodeKindCustomer, NodeKindCompany, NodeKindVendor:
 		return true
 	default:
 		return false

--- a/internal/graph/reports/core_exports.go
+++ b/internal/graph/reports/core_exports.go
@@ -68,6 +68,7 @@ const (
 	NodeKindBucket                = graph.NodeKindBucket
 	NodeKindDatabase              = graph.NodeKindDatabase
 	NodeKindCompany               = graph.NodeKindCompany
+	NodeKindVendor                = graph.NodeKindVendor
 	NodeKindActivity              = graph.NodeKindActivity
 	NodeKindDecision              = graph.NodeKindDecision
 	NodeKindOutcome               = graph.NodeKindOutcome

--- a/internal/graph/schema_registry.go
+++ b/internal/graph/schema_registry.go
@@ -1912,6 +1912,7 @@ var builtInNodeKinds = []NodeKindDefinition{
 	{Kind: NodeKindCustomer, Categories: []NodeKindCategory{NodeCategoryBusiness}},
 	{Kind: NodeKindContact, Categories: []NodeKindCategory{NodeCategoryBusiness}},
 	{Kind: NodeKindCompany, Categories: []NodeKindCategory{NodeCategoryBusiness}},
+	{Kind: NodeKindVendor, Categories: []NodeKindCategory{NodeCategoryBusiness}},
 	{Kind: NodeKindDeal, Categories: []NodeKindCategory{NodeCategoryBusiness}},
 	{Kind: NodeKindOpportunity, Categories: []NodeKindCategory{NodeCategoryBusiness}},
 	{Kind: NodeKindSubscription, Categories: []NodeKindCategory{NodeCategoryBusiness}},

--- a/internal/graph/schema_registry_test.go
+++ b/internal/graph/schema_registry_test.go
@@ -66,6 +66,7 @@ func TestSchemaRegistry_IntelligenceSpineBuiltins(t *testing.T) {
 		NodeKindSource,
 		NodeKindClaim,
 		NodeKindAction,
+		NodeKindVendor,
 	}
 	for _, kind := range requiredNodeKinds {
 		if !reg.IsNodeKindRegistered(kind) {

--- a/internal/providers/entra_id.go
+++ b/internal/providers/entra_id.go
@@ -106,7 +106,9 @@ func (e *EntraIDProvider) Schema() []TableSchema {
 				{Name: "display_name", Type: "string"},
 				{Name: "service_principal_type", Type: "string"},
 				{Name: "account_enabled", Type: "boolean"},
+				{Name: "app_owner_organization_id", Type: "string"},
 				{Name: "app_role_assignment_required", Type: "boolean"},
+				{Name: "publisher_name", Type: "string"},
 				{Name: "created_datetime", Type: "timestamp"},
 				{Name: "tags", Type: "array"},
 			},
@@ -454,7 +456,7 @@ func (e *EntraIDProvider) syncServicePrincipals(ctx context.Context) (*TableResu
 		return result, err
 	}
 
-	sps, err := e.listAll(ctx, "/v1.0/servicePrincipals?$select=id,appId,displayName,servicePrincipalType,accountEnabled,appRoleAssignmentRequired,createdDateTime,tags")
+	sps, err := e.listAll(ctx, "/v1.0/servicePrincipals?$select=id,appId,displayName,servicePrincipalType,accountEnabled,appOwnerOrganizationId,appRoleAssignmentRequired,publisherName,createdDateTime,tags")
 	if err != nil {
 		return result, err
 	}

--- a/internal/sync/azure_extras.go
+++ b/internal/sync/azure_extras.go
@@ -135,15 +135,16 @@ type azureGraphServicePrincipalListResponse struct {
 }
 
 type azureGraphServicePrincipal struct {
-	ID                     *string  `json:"id"`
-	AppID                  *string  `json:"appId"`
-	DisplayName            *string  `json:"displayName"`
-	ServicePrincipalType   *string  `json:"servicePrincipalType"`
-	AccountEnabled         *bool    `json:"accountEnabled"`
-	AppOwnerOrganizationID *string  `json:"appOwnerOrganizationId"`
-	PublisherName          *string  `json:"publisherName"`
-	CreatedDateTime        *string  `json:"createdDateTime"`
-	Tags                   []string `json:"tags"`
+	ID                        *string  `json:"id"`
+	AppID                     *string  `json:"appId"`
+	DisplayName               *string  `json:"displayName"`
+	ServicePrincipalType      *string  `json:"servicePrincipalType"`
+	AccountEnabled            *bool    `json:"accountEnabled"`
+	AppOwnerOrganizationID    *string  `json:"appOwnerOrganizationId"`
+	AppRoleAssignmentRequired *bool    `json:"appRoleAssignmentRequired"`
+	PublisherName             *string  `json:"publisherName"`
+	CreatedDateTime           *string  `json:"createdDateTime"`
+	Tags                      []string `json:"tags"`
 }
 
 type azureDefenderAssessmentListResponse struct {
@@ -547,6 +548,7 @@ func (e *AzureSyncEngine) azureGraphServicePrincipalTable() AzureTableSpec {
 			"service_principal_type",
 			"account_enabled",
 			"app_owner_organization_id",
+			"app_role_assignment_required",
 			"publisher_name",
 			"created_date_time",
 			"tags",
@@ -582,6 +584,9 @@ func (e *AzureSyncEngine) azureGraphServicePrincipalTable() AzureTableSpec {
 
 				if principal.AccountEnabled != nil {
 					row["account_enabled"] = *principal.AccountEnabled
+				}
+				if principal.AppRoleAssignmentRequired != nil {
+					row["app_role_assignment_required"] = *principal.AppRoleAssignmentRequired
 				}
 				if len(principal.Tags) > 0 {
 					row["tags"] = principal.Tags
@@ -981,7 +986,7 @@ func listAzureGraphServicePrincipals(ctx context.Context, cred *azidentity.Defau
 		return nil, err
 	}
 
-	nextURL := "https://graph.microsoft.com/v1.0/servicePrincipals?$select=id,appId,displayName,servicePrincipalType,accountEnabled,appOwnerOrganizationId,publisherName,createdDateTime,tags"
+	nextURL := "https://graph.microsoft.com/v1.0/servicePrincipals?$select=id,appId,displayName,servicePrincipalType,accountEnabled,appOwnerOrganizationId,appRoleAssignmentRequired,publisherName,createdDateTime,tags"
 	servicePrincipals := make([]azureGraphServicePrincipal, 0)
 	for nextURL != "" {
 		var page azureGraphServicePrincipalListResponse


### PR DESCRIPTION
* Add explicit vendor nodes to the graph

* Align Azure service principal vendor metadata

* Guard derived vendor node creation
