### PR TITLE
Add runtime observation substrate and initial adapters (#321)

### DIFF
--- a/docs/GRAPH_INTELLIGENCE_LAYER.md
+++ b/docs/GRAPH_INTELLIGENCE_LAYER.md
@@ -3,6 +3,7 @@
 This document defines how Cerebro's graph becomes the organization's intelligence layer: decision-grade, evidence-backed, and action-oriented.
 
 See [GRAPH_ONTOLOGY_ARCHITECTURE.md](./GRAPH_ONTOLOGY_ARCHITECTURE.md) for ontology layering, extension workflow, and metadata contract details, [GRAPH_REPORT_EXTENSIBILITY_RESEARCH.md](./GRAPH_REPORT_EXTENSIBILITY_RESEARCH.md) for the report registry/module model that should sit on top of the graph, [GRAPH_ASSET_DEEPENING_RESEARCH.md](./GRAPH_ASSET_DEEPENING_RESEARCH.md) for external asset-model patterns, and [GRAPH_ENTITY_FACET_ARCHITECTURE.md](./GRAPH_ENTITY_FACET_ARCHITECTURE.md) for the current entity/facet/report layering.
+See [RUNTIME_VISIBILITY_ARCHITECTURE.md](./RUNTIME_VISIBILITY_ARCHITECTURE.md) for the runtime observation, sensor, and graph-projection design that should back the runtime execution graph described here.
 
 ## Principles
 - Every insight must be **decision-grade**: include evidence, confidence, coverage, and clear next actions.

--- a/docs/RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md
+++ b/docs/RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 Issue `#154` is the first concrete executor layer on top of the shared action engine from issue `#143`.
 
+See [RUNTIME_VISIBILITY_ARCHITECTURE.md](./RUNTIME_VISIBILITY_ARCHITECTURE.md) for the complementary sensor, ingest, graph-projection, and response-outcome design that should feed this execution layer.
+
 The design goal is practical:
 
 - make default runtime response policies capable of taking real action

--- a/docs/RUNTIME_VISIBILITY_ARCHITECTURE.md
+++ b/docs/RUNTIME_VISIBILITY_ARCHITECTURE.md
@@ -1,0 +1,514 @@
+# Runtime Visibility Architecture
+
+This document defines how Cerebro should add runtime visibility without creating a second disconnected security subsystem.
+
+The design goal is practical:
+
+- reuse the existing runtime detection, response, action-execution, and graph seams
+- ingest richer runtime telemetry than the current `RuntimeEvent` shape can represent safely
+- project runtime observations and response outcomes into the graph as durable evidence
+- keep high-volume raw telemetry out of the graph and out of the shared execution store hot path
+- make runtime visibility provider-pluggable instead of coupling the system to one sensor
+
+This document complements [RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md](./RUNTIME_RESPONSE_EXECUTION_ARCHITECTURE.md) and [GRAPH_INTELLIGENCE_LAYER.md](./GRAPH_INTELLIGENCE_LAYER.md).
+
+## Why This Needs A Separate Architecture
+
+Today Cerebro already has:
+
+- runtime event ingest under `POST /api/v1/runtime/events`
+- rule-based runtime detections in `internal/runtime`
+- runtime response execution through the shared action engine
+- durable execution state through `internal/executionstore`
+- graph-level causal modeling through `triggered_by` and `caused_by`
+
+That is the right control-plane skeleton, but it is not yet runtime visibility.
+
+Current gaps:
+
+- `RuntimeEvent` is too narrow for real process, file, network, audit, and trace correlation data.
+- raw runtime observations are not durably modeled as a first-class substrate.
+- runtime observations are not projected into the graph as `observation` or `evidence`.
+- response outcomes are not joined back into the same causal graph.
+- the shared execution store is the right place for ingestion jobs and checkpoints, not the right place for every raw runtime event.
+
+## Principles
+
+- One canonical normalized runtime observation contract should sit behind all providers.
+- Detection, graph projection, and response execution should remain separate stages.
+- Raw event retention should be short-lived and queryable; durable graph state should be promoted, summarized, and bounded.
+- Runtime visibility should bind to existing graph identities: workload, image, package, principal, vendor, deployment, and service.
+- The first production cut should prefer proven upstream sensors over bespoke collection code.
+
+## Visibility Layers
+
+Runtime visibility should be modeled as four complementary layers.
+
+### 1. Control-Plane Visibility
+
+Purpose:
+
+- answer who initiated change or access
+- capture API intent before or around runtime behavior
+
+Primary sources:
+
+- Kubernetes audit logs
+- cloud audit trails where they materially affect runtime identity or containment
+
+Examples:
+
+- `kubectl exec`
+- pod spec mutation
+- RBAC changes
+- ephemeral debugging actions
+
+### 2. Runtime Sensor Visibility
+
+Purpose:
+
+- capture what the workload actually did inside the kernel/runtime boundary
+
+Primary sources:
+
+- eBPF-backed process/file/security telemetry
+
+Examples:
+
+- process exec and exit
+- privilege escalation attempts
+- namespace escape indicators
+- credential file access
+- unexpected binary execution
+
+### 3. Network Flow Visibility
+
+Purpose:
+
+- capture who the workload talked to and how
+
+Primary sources:
+
+- CNI/service-mesh flow telemetry
+
+Examples:
+
+- external egress
+- east-west service calls
+- DNS requests
+- long-lived suspicious connections
+
+### 4. Application Correlation Visibility
+
+Purpose:
+
+- bind runtime behavior to service-level request context and workload identity
+
+Primary sources:
+
+- OpenTelemetry traces, logs, and resource metadata
+
+Examples:
+
+- trace/span linkage
+- service name
+- deployment environment
+- pod/container identity normalization
+
+OpenTelemetry is useful here, but it is not the primary runtime security signal source.
+
+## Recommended Source Stack
+
+### First Choices
+
+- `Tetragon` for process/file/runtime security telemetry
+- `Hubble` for network flows
+- `Kubernetes audit` for control-plane activity
+- `OpenTelemetry` for service and trace correlation
+
+### Secondary / Optional Sources
+
+- `Falco` as a detection feed adapter
+- `Tracee` as an alternate runtime sensor
+- `osquery` for host-state and selective event augmentation
+- managed cloud runtime feeds such as AWS GuardDuty Runtime Monitoring
+
+## Why Tetragon First
+
+Tetragon is the best first runtime sensor because it already provides:
+
+- Kubernetes-aware workload identity
+- process, file, and security event coverage
+- kernel-level visibility without Cerebro owning an eBPF implementation
+- stable export surfaces through JSON export and gRPC
+
+The initial production recommendation is:
+
+- use JSON export or a collector-fed JSON path first
+- normalize that into Cerebro's internal runtime observation contract
+- defer direct gRPC streaming until the normalized event model and backpressure rules are proven
+
+## Why Hubble Next To Tetragon
+
+Tetragon is not a full network flow substrate. Hubble fills that gap well:
+
+- workload-aware network flows
+- DNS visibility
+- service-to-service pathing
+- Cilium identity context
+
+Cluster-wide Cerebro integration should prefer Hubble Relay or exported flow pipelines rather than node-local direct consumers.
+
+## Why Kubernetes Audit Must Be In Scope
+
+Pure runtime telemetry cannot answer control-plane causality well enough.
+
+Examples:
+
+- a shell spawned because an attacker executed code inside the container
+- a shell spawned because a legitimate operator ran `kubectl exec`
+
+Those are not equivalent. Kubernetes audit is the authoritative source for that distinction.
+
+## Why OpenTelemetry Is Complementary, Not Sufficient
+
+OpenTelemetry gives:
+
+- standard resource identity
+- traces, logs, metrics
+- request context
+- service-level correlation
+
+It does not replace:
+
+- kernel/runtime process visibility
+- file activity visibility
+- network enforcement and low-level flow evidence
+- direct containment-target context
+
+The right use is enrichment and correlation, not making OTel the only runtime source.
+
+## Canonical Internal Contract
+
+Introduce a normalized contract behind provider adapters.
+
+Illustrative shape:
+
+```go
+type RuntimeObservation struct {
+	ID          string                 `json:"id"`
+	Kind        string                 `json:"kind"`
+	Source      string                 `json:"source"`
+	ObservedAt  time.Time              `json:"observed_at"`
+	RecordedAt  time.Time              `json:"recorded_at"`
+
+	Cluster     string                 `json:"cluster,omitempty"`
+	Namespace   string                 `json:"namespace,omitempty"`
+	NodeName    string                 `json:"node_name,omitempty"`
+
+	WorkloadRef string                 `json:"workload_ref,omitempty"`
+	WorkloadUID string                 `json:"workload_uid,omitempty"`
+	ContainerID string                 `json:"container_id,omitempty"`
+	ImageRef    string                 `json:"image_ref,omitempty"`
+	ImageID     string                 `json:"image_id,omitempty"`
+
+	PrincipalID string                 `json:"principal_id,omitempty"`
+	TraceID     string                 `json:"trace_id,omitempty"`
+	SpanID      string                 `json:"span_id,omitempty"`
+
+	Process     *ProcessContext        `json:"process,omitempty"`
+	File        *FileContext           `json:"file,omitempty"`
+	Network     *NetworkContext        `json:"network,omitempty"`
+	Audit       *ControlPlaneContext   `json:"audit,omitempty"`
+
+	Tags        []string               `json:"tags,omitempty"`
+	Metadata    map[string]any         `json:"metadata,omitempty"`
+	Raw         map[string]any         `json:"raw,omitempty"`
+	Provenance  map[string]any         `json:"provenance,omitempty"`
+}
+```
+
+Important rule:
+
+- `internal/runtime.RuntimeEvent` should become a compatibility envelope or derived simplified view, not the canonical ingest model.
+
+## Observation Kinds
+
+The normalized contract should support at least:
+
+- `process_exec`
+- `process_exit`
+- `file_open`
+- `file_write`
+- `network_flow`
+- `dns_query`
+- `k8s_audit`
+- `runtime_alert`
+- `trace_link`
+- `response_outcome`
+
+Do not overload one generic `event_type` string forever. Use a stable enum-like contract with bounded extension.
+
+## Provider Adapter Seams
+
+Add provider adapters under a dedicated package such as:
+
+- `internal/runtime/adapters/tetragon`
+- `internal/runtime/adapters/hubble`
+- `internal/runtime/adapters/k8saudit`
+- `internal/runtime/adapters/otel`
+- `internal/runtime/adapters/falco`
+
+Each adapter should do only three things:
+
+1. decode upstream payloads
+2. normalize them into `RuntimeObservation`
+3. preserve raw provider data in bounded provenance/raw payloads
+
+Detection logic should not live in the adapters.
+
+## Ingestion Pipeline
+
+Recommended pipeline:
+
+1. provider adapter emits normalized `RuntimeObservation`
+2. observation is written to a streaming ingest path
+3. checkpoint/run metadata is persisted through `internal/executionstore`
+4. raw observations go to bounded short-retention storage
+5. detection engine evaluates normalized observations
+6. graph materialization promotes selected observations into graph state
+7. response engine executes on derived findings
+8. response outcomes are fed back as runtime observations and graph evidence
+
+## Storage Boundaries
+
+### Use `executionstore` For
+
+- ingestion run metadata
+- source checkpoints and cursors
+- backfill jobs
+- materialization jobs
+- response execution history
+- replay and reconciliation state
+
+### Do Not Use `executionstore` For
+
+- every raw runtime observation at production event rates
+- long retention of packet/process/file event streams
+
+The current backend-neutral execution contract is the right control-plane seam, not the raw telemetry lake.
+
+## Raw Retention Strategy
+
+Use a short-retention raw observation store or stream-backed sink for:
+
+- recent incident pivoting
+- replay into detectors/materializers
+- source debugging
+
+Use graph materialization for:
+
+- durable evidence
+- summarized process/network relationships
+- causal links
+- high-confidence promoted observations
+
+## Graph Projection Model
+
+Do not start by making every process or flow a permanent top-level node kind.
+
+Phase 1 should prefer:
+
+- `observation` nodes for normalized runtime observations that matter durably
+- `evidence` nodes for promoted security-relevant observations
+- existing `workload`, `service`, `image`, `package`, `deployment_run`, `incident`, `vendor`, and `identity_alias` nodes as the durable spine
+
+Recommended first edges:
+
+- `workload -> targets -> observation`
+- `observation -> based_on -> evidence`
+- `finding -> based_on -> evidence`
+- `response action/execution -> targets -> workload`
+- `response action/execution -> caused_by -> finding`
+- `observation -> triggered_by -> deployment_run`
+- `observation -> triggered_by -> control-plane audit event`
+- `incident -> caused_by -> finding`
+
+If query pressure later justifies it, add a durable `process_instance` node kind after the observation model proves stable.
+
+## Identity Binding Requirements
+
+Runtime visibility is only useful if the observation can bind to the world model.
+
+Minimum identity-binding targets:
+
+- workload
+- namespace
+- cluster
+- image
+- package when process path can be mapped back to installed component context
+- principal or actor where control-plane or delegated identity exists
+- deployment run when temporal correlation is strong
+- vendor when the runtime behavior materially touches third-party integrations
+
+This is why the graph integration matters. Runtime visibility without entity binding becomes another alert silo.
+
+## Detection Integration
+
+The current detection engine should evolve from:
+
+- direct evaluation of narrow `RuntimeEvent`
+
+to:
+
+- evaluation of normalized `RuntimeObservation`
+- optional provider-specific enrichers that run before rule evaluation
+- rule packs that can target process/file/network/audit/trace fields consistently
+
+Practical migration path:
+
+1. add normalized observation ingest
+2. derive the current `RuntimeEvent` view from it where possible
+3. migrate built-in rules onto the new contract
+4. retire direct raw `RuntimeEvent` assumptions gradually
+
+## Response Integration
+
+Runtime response should not become its own data island.
+
+Every response execution should emit a response outcome observation that captures:
+
+- action type
+- target identity
+- execution mode
+- approval state
+- success/failure
+- response latency
+- actuator/provider details
+
+That outcome should then feed:
+
+- graph evidence
+- causal correlation
+- future confidence scoring
+- autonomous workflow/adjudication loops
+
+## Confidence And Outcome Loops
+
+Runtime visibility should improve graph intelligence quality, not just add more data.
+
+Examples:
+
+- if a response repeatedly fails against a target class, reduce confidence in future auto-containment recommendations for that class
+- if Kubernetes audit shows a human-approved `kubectl exec`, reduce incident confidence for the subsequent shell event
+- if Hubble and Tetragon agree on suspicious egress from the same workload, raise confidence for the finding
+
+## Phased Implementation Plan
+
+### Phase 1. Normalize And Persist Runtime Observation Control State
+
+- define `RuntimeObservation`
+- add provider adapter seams
+- add ingestion-run/checkpoint persistence via `executionstore`
+- keep current `/api/v1/runtime/events` as a compatibility path
+
+### Phase 2. First Real Sensor Path
+
+- add `Tetragon -> RuntimeObservation`
+- add `Kubernetes audit -> RuntimeObservation`
+- bind observations to workload/image/namespace identities
+- emit promoted runtime `observation` / `evidence` graph records
+
+### Phase 3. Close The Loop
+
+- emit response outcome observations from runtime response execution
+- project response outcomes into graph causal chains
+- expose runtime visibility health/coverage through platform intelligence
+
+### Phase 4. Network And Correlation Depth
+
+- add `Hubble -> RuntimeObservation`
+- add OpenTelemetry trace/resource correlation
+- materialize suspicious egress and service-call path evidence
+
+### Phase 5. Provider And Platform Expansion
+
+- optional Falco adapter
+- optional Tracee adapter
+- managed cloud runtime feeds where they add coverage
+- drift/anomaly layers on top of the observation graph
+
+## First Experiments
+
+The first experiments should prove architecture, not UI.
+
+### Experiment 1. Tetragon Process Exec Path
+
+Goal:
+
+- ingest process exec events
+- bind them to workload/image/container identity
+- drive one existing runtime rule from normalized observations
+
+Success criteria:
+
+- the same process exec is queryable as raw observation, finding evidence, and response target context
+
+### Experiment 2. Control-Plane Causality
+
+Goal:
+
+- correlate Kubernetes audit `kubectl exec` or workload mutation activity with subsequent runtime observations
+
+Success criteria:
+
+- graph can answer whether a shell was operator-initiated or suspicious
+
+### Experiment 3. Network + Process Correlation
+
+Goal:
+
+- correlate Hubble egress flow with the process/workload that produced it
+
+Success criteria:
+
+- graph can explain suspicious egress as a concrete process chain rather than a flat alert
+
+## Anti-Patterns To Avoid
+
+- Do not make OpenTelemetry the only runtime source.
+- Do not treat Falco alerts as the canonical runtime graph model.
+- Do not write every raw runtime event into SQLite-backed execution state.
+- Do not create a second orchestration/execution subsystem beside `internal/actionengine`.
+- Do not store every syscall or flow forever in the graph.
+
+## Initial API Direction
+
+Near-term compatibility:
+
+- preserve `POST /api/v1/runtime/events`
+- add a typed internal ingest path for normalized observations
+
+Longer-term platform direction:
+
+- `/api/v1/platform/runtime/observations`
+- `/api/v1/platform/runtime/sources`
+- `/api/v1/platform/runtime/coverage`
+- `/api/v1/platform/runtime/replays`
+
+The platform-facing resources should describe the shared runtime substrate, while `/api/v1/security/runtime/*` should remain the application surface for detections, policies, containment, and investigations.
+
+## Research References
+
+- OpenTelemetry Logs Data Model: <https://opentelemetry.io/docs/specs/otel/logs/data-model/>
+- OpenTelemetry OTLP: <https://opentelemetry.io/docs/specs/otlp/>
+- OpenTelemetry resource semantic conventions: <https://opentelemetry.io/docs/specs/semconv/resource/>
+- OpenTelemetry Kubernetes collector components: <https://opentelemetry.io/docs/platforms/kubernetes/collector/components/>
+- Kubernetes Auditing: <https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/>
+- Tetragon Overview: <https://tetragon.io/docs/overview/>
+- Tetragon Events: <https://tetragon.io/docs/concepts/events/>
+- Tetragon gRPC API: <https://tetragon.io/docs/reference/grpc-api/>
+- Hubble CLI and observability docs: <https://docs.cilium.io/en/stable/observability/hubble/hubble-cli.html>
+- Falco Output Channels: <https://falco.org/docs/concepts/outputs/channels/>
+- osquery Process Auditing: <https://osquery.readthedocs.io/en/stable/deployment/process-auditing/>
+- AWS GuardDuty Runtime Monitoring: <https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring.html>

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"runtime"
+	goruntime "runtime"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +20,7 @@ import (
 	risk "github.com/writer/cerebro/internal/graph/risk"
 	"github.com/writer/cerebro/internal/health"
 	"github.com/writer/cerebro/internal/metrics"
+	cerebroruntime "github.com/writer/cerebro/internal/runtime"
 	"github.com/writer/cerebro/internal/snowflake"
 )
 
@@ -55,7 +56,7 @@ type auditLogWriter interface {
 	Log(ctx context.Context, entry *snowflake.AuditEntry) error
 }
 
-var runtimeNumGoroutine = runtime.NumGoroutine
+var runtimeNumGoroutine = goruntime.NumGoroutine
 
 // NewServer creates a new server with all services wired
 func NewServer(application *app.App) *Server {
@@ -68,6 +69,9 @@ func NewServer(application *app.App) *Server {
 func NewServerWithDependencies(deps serverDependencies) *Server {
 	if deps.Logger == nil {
 		deps.Logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	if deps.RuntimeIngest == nil && deps.ExecutionStore != nil {
+		deps.RuntimeIngest = cerebroruntime.NewSQLiteIngestStoreWithExecutionStore(deps.ExecutionStore)
 	}
 	if adapter, ok := deps.graphRuntime.(*graphRuntimeAdapter); ok {
 		adapter.deps = &deps

--- a/internal/api/server_dependencies.go
+++ b/internal/api/server_dependencies.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/attackpath"
 	"github.com/writer/cerebro/internal/auth"
 	"github.com/writer/cerebro/internal/cache"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/graph/builders"
@@ -69,12 +70,13 @@ type serverDependencies struct {
 	Config *app.Config
 	Logger *slog.Logger
 
-	Snowflake *snowflake.Client
-	Warehouse warehouse.DataWarehouse
-	Policy    *policy.Engine
-	Findings  findings.FindingStore
-	Scanner   *scanner.Scanner
-	Cache     *cache.PolicyCache
+	Snowflake      *snowflake.Client
+	Warehouse      warehouse.DataWarehouse
+	Policy         *policy.Engine
+	Findings       findings.FindingStore
+	Scanner        *scanner.Scanner
+	Cache          *cache.PolicyCache
+	ExecutionStore executionstore.Store
 
 	Agents         *agents.AgentRegistry
 	Ticketing      *ticketing.Service
@@ -97,6 +99,7 @@ type serverDependencies struct {
 	Lineage        *lineage.LineageMapper
 	Remediation    *remediation.Engine
 	RuntimeDetect  *runtime.DetectionEngine
+	RuntimeIngest  runtime.IngestStore
 	RuntimeRespond *runtime.ResponseEngine
 
 	RemediationExecutor *remediation.Executor
@@ -135,6 +138,7 @@ func newServerDependenciesFromApp(application *app.App) serverDependencies {
 		Findings:             application.Findings,
 		Scanner:              application.Scanner,
 		Cache:                application.Cache,
+		ExecutionStore:       application.ExecutionStore,
 		Agents:               application.Agents,
 		Ticketing:            application.Ticketing,
 		Identity:             application.Identity,
@@ -155,6 +159,7 @@ func newServerDependenciesFromApp(application *app.App) serverDependencies {
 		Remediation:          application.Remediation,
 		RemediationExecutor:  application.RemediationExecutor,
 		RuntimeDetect:        application.RuntimeDetect,
+		RuntimeIngest:        application.RuntimeIngest,
 		RuntimeRespond:       application.RuntimeRespond,
 		SecurityGraph:        application.SecurityGraph,
 		SecurityGraphBuilder: application.SecurityGraphBuilder,

--- a/internal/api/server_dependencies_test.go
+++ b/internal/api/server_dependencies_test.go
@@ -67,3 +67,19 @@ func TestNewServerWithDependencies_DefaultsLoggerWhenNil(t *testing.T) {
 		t.Fatalf("expected constructor to default logger, got %#v", s.app)
 	}
 }
+
+func TestNewServerWithDependencies_InitializesRuntimeIngestFromExecutionStore(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = nil
+
+	s := NewServerWithDependencies(deps)
+	t.Cleanup(func() { s.Close() })
+
+	if s.app == nil || s.app.RuntimeIngest == nil {
+		t.Fatalf("expected constructor to initialize runtime ingest store, got %#v", s.app)
+	}
+	if got := s.runtimeIngestStore(); got == nil {
+		t.Fatal("expected runtimeIngestStore to return initialized store")
+	}
+}

--- a/internal/api/server_handlers_threat_runtime.go
+++ b/internal/api/server_handlers_threat_runtime.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -112,7 +113,26 @@ func (s *Server) ingestRuntimeEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	findings := s.app.RuntimeDetect.ProcessEvent(r.Context(), &event)
+	session, err := s.startRuntimeIngestSession(r.Context(), "runtime_event", map[string]string{
+		"event_type":    event.EventType,
+		"resource_id":   event.ResourceID,
+		"resource_type": event.ResourceType,
+		"source":        event.Source,
+	})
+	if err != nil {
+		s.warnRuntimeIngestPersistence("start", err, "source", "runtime_event", "event_id", event.ID)
+		session = nil
+	}
+
+	observation := runtime.ObservationFromEvent(&event)
+	findings := s.app.RuntimeDetect.ProcessObservation(r.Context(), observation)
+	if session != nil {
+		if err := session.recordObservation(r.Context(), observation, len(findings), 1); err != nil {
+			session.fail(r.Context(), "detect", err)
+			s.warnRuntimeIngestPersistence("record_observation", err, "source", "runtime_event", "event_id", event.ID, "run_id", session.runID())
+			session = nil
+		}
+	}
 
 	if s.app.RuntimeRespond != nil {
 		for _, f := range findings {
@@ -120,19 +140,41 @@ func (s *Server) ingestRuntimeEvent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if session != nil {
+		if err := session.complete(r.Context(), runtime.IngestCheckpoint{
+			Cursor: observation.ID,
+			Metadata: map[string]string{
+				"processed_events": "1",
+				"finding_count":    strconv.Itoa(len(findings)),
+			},
+		}); err != nil {
+			session.fail(r.Context(), "complete", err)
+			s.warnRuntimeIngestPersistence("complete", err, "source", "runtime_event", "event_id", event.ID, "run_id", session.runID())
+			session = nil
+		}
+	}
+
 	if s.app.Webhooks != nil {
-		if err := s.app.Webhooks.EmitWithErrors(r.Context(), webhooks.EventRuntimeIngested, map[string]interface{}{
+		webhookPayload := map[string]interface{}{
 			"source":   "runtime_event",
 			"findings": len(findings),
-		}); err != nil {
+		}
+		if session != nil && session.run != nil {
+			webhookPayload["run_id"] = session.run.ID
+		}
+		if err := s.app.Webhooks.EmitWithErrors(r.Context(), webhooks.EventRuntimeIngested, webhookPayload); err != nil {
 			s.app.Logger.Warn("failed to emit runtime ingest event", "error", err)
 		}
 	}
 
-	s.json(w, http.StatusOK, map[string]interface{}{
+	response := map[string]interface{}{
 		"processed": true,
 		"findings":  len(findings),
-	})
+	}
+	if session != nil && session.run != nil {
+		response["run_id"] = session.run.ID
+	}
+	s.json(w, http.StatusOK, response)
 }
 
 func (s *Server) listRuntimeFindings(w http.ResponseWriter, r *http.Request) {
@@ -197,11 +239,30 @@ func (s *Server) ingestTelemetry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	session, err := s.startRuntimeIngestSession(r.Context(), "telemetry", map[string]string{
+		"cluster":       payload.Cluster,
+		"node":          payload.Node,
+		"agent_version": payload.AgentVersion,
+		"event_count":   strconv.Itoa(len(payload.Events)),
+	})
+	if err != nil {
+		s.warnRuntimeIngestPersistence("start", err, "source", "telemetry", "event_count", len(payload.Events), "cluster", payload.Cluster, "node", payload.Node)
+		session = nil
+	}
+
 	totalFindings := 0
 	if s.app.RuntimeDetect != nil {
-		for _, event := range payload.Events {
-			findings := s.app.RuntimeDetect.ProcessEvent(r.Context(), &event)
+		for idx, event := range payload.Events {
+			observation := enrichRuntimeObservation(runtime.ObservationFromEvent(&event), payload.Cluster, payload.Node, payload.AgentVersion)
+			findings := s.app.RuntimeDetect.ProcessObservation(r.Context(), observation)
 			totalFindings += len(findings)
+			if session != nil {
+				if err := session.recordObservation(r.Context(), observation, len(findings), idx+1); err != nil {
+					session.fail(r.Context(), "detect", err)
+					s.warnRuntimeIngestPersistence("record_observation", err, "source", "telemetry", "event_id", event.ID, "index", idx+1, "run_id", session.runID())
+					session = nil
+				}
+			}
 
 			if s.app.RuntimeRespond != nil {
 				for _, f := range findings {
@@ -211,20 +272,57 @@ func (s *Server) ingestTelemetry(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	lastCursor := ""
+	if count := len(payload.Events); count > 0 {
+		lastCursor = payload.Events[count-1].ID
+	}
+	if session != nil {
+		if err := session.complete(r.Context(), runtime.IngestCheckpoint{
+			Cursor: lastCursor,
+			Metadata: map[string]string{
+				"processed_events": strconv.Itoa(len(payload.Events)),
+				"finding_count":    strconv.Itoa(totalFindings),
+				"cluster":          payload.Cluster,
+				"node":             payload.Node,
+			},
+		}); err != nil {
+			session.fail(r.Context(), "complete", err)
+			s.warnRuntimeIngestPersistence("complete", err, "source", "telemetry", "event_count", len(payload.Events), "run_id", session.runID())
+			session = nil
+		}
+	}
+
 	if s.app.Webhooks != nil {
-		if err := s.app.Webhooks.EmitWithErrors(r.Context(), webhooks.EventRuntimeIngested, map[string]interface{}{
+		webhookPayload := map[string]interface{}{
 			"source":           "telemetry",
 			"events_processed": len(payload.Events),
 			"findings":         totalFindings,
 			"node":             payload.Node,
 			"cluster":          payload.Cluster,
-		}); err != nil {
+		}
+		if session != nil && session.run != nil {
+			webhookPayload["run_id"] = session.run.ID
+		}
+		if err := s.app.Webhooks.EmitWithErrors(r.Context(), webhooks.EventRuntimeIngested, webhookPayload); err != nil {
 			s.app.Logger.Warn("failed to emit telemetry ingest event", "error", err)
 		}
 	}
 
-	s.json(w, http.StatusOK, map[string]interface{}{
+	response := map[string]interface{}{
 		"processed": len(payload.Events),
 		"findings":  totalFindings,
-	})
+	}
+	if session != nil && session.run != nil {
+		response["run_id"] = session.run.ID
+	}
+	s.json(w, http.StatusOK, response)
+}
+
+func (s *Server) warnRuntimeIngestPersistence(stage string, err error, args ...any) {
+	if s == nil || s.app == nil || s.app.Logger == nil || err == nil {
+		return
+	}
+	fields := []any{"stage", strings.TrimSpace(stage), "error", err}
+	fields = append(fields, args...)
+	s.app.Logger.Warn("runtime ingest persistence degraded; continuing detection and response", fields...)
 }

--- a/internal/api/server_handlers_threat_runtime_ingest.go
+++ b/internal/api/server_handlers_threat_runtime_ingest.go
@@ -1,0 +1,239 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+type runtimeIngestSession struct {
+	store runtime.IngestStore
+	run   *runtime.IngestRunRecord
+}
+
+func (r *runtimeIngestSession) runID() string {
+	if r == nil || r.run == nil {
+		return ""
+	}
+	return r.run.ID
+}
+
+func (s *Server) runtimeIngestStore() runtime.IngestStore {
+	if s == nil || s.app == nil {
+		return nil
+	}
+	return s.app.RuntimeIngest
+}
+
+func (s *Server) startRuntimeIngestSession(ctx context.Context, source string, metadata map[string]string) (*runtimeIngestSession, error) {
+	store := s.runtimeIngestStore()
+	if store == nil {
+		return nil, nil
+	}
+
+	now := time.Now().UTC()
+	run := &runtime.IngestRunRecord{
+		ID:          "runtime_ingest:" + uuid.NewString(),
+		Source:      strings.TrimSpace(source),
+		Status:      runtime.IngestRunStatusRunning,
+		Stage:       "detect",
+		SubmittedAt: now,
+		StartedAt:   &now,
+		UpdatedAt:   now,
+		Metadata:    cloneRuntimeIngestMetadata(metadata),
+	}
+	if err := store.SaveRun(ctx, run); err != nil {
+		return nil, fmt.Errorf("save runtime ingest run: %w", err)
+	}
+	if _, err := store.AppendEvent(ctx, run.ID, runtime.IngestEvent{
+		Type:       "ingest_started",
+		RecordedAt: now,
+		Data: map[string]any{
+			"source":   run.Source,
+			"metadata": cloneRuntimeIngestMetadata(metadata),
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("append runtime ingest start event: %w", err)
+	}
+	return &runtimeIngestSession{store: store, run: run}, nil
+}
+
+func (r *runtimeIngestSession) recordObservation(ctx context.Context, observation *runtime.RuntimeObservation, findings int, index int) error {
+	if r == nil || r.store == nil || r.run == nil {
+		return nil
+	}
+
+	processedAt := time.Now().UTC()
+
+	r.run.ObservationCount++
+	r.run.FindingCount += findings
+	r.run.UpdatedAt = processedAt
+
+	data := map[string]any{
+		"index":         index,
+		"finding_count": findings,
+	}
+	if observation != nil {
+		if !observation.ObservedAt.IsZero() {
+			data["observed_at"] = observation.ObservedAt.UTC().Format(time.RFC3339Nano)
+		}
+		if observation.ID != "" {
+			data["observation_id"] = observation.ID
+		}
+		if observation.Kind != "" {
+			data["kind"] = observation.Kind
+		}
+		if observation.ResourceID != "" {
+			data["resource_id"] = observation.ResourceID
+		}
+		if observation.ResourceType != "" {
+			data["resource_type"] = observation.ResourceType
+		}
+		if observation.Cluster != "" {
+			data["cluster"] = observation.Cluster
+		}
+		if observation.NodeName != "" {
+			data["node_name"] = observation.NodeName
+		}
+		if observation.WorkloadRef != "" {
+			data["workload_ref"] = observation.WorkloadRef
+		}
+	}
+
+	if err := r.store.SaveRun(ctx, r.run); err != nil {
+		return fmt.Errorf("save runtime ingest progress: %w", err)
+	}
+	if _, err := r.store.AppendEvent(ctx, r.run.ID, runtime.IngestEvent{
+		Type:       "observation_processed",
+		RecordedAt: processedAt,
+		Data:       data,
+	}); err != nil {
+		return fmt.Errorf("append runtime ingest observation event: %w", err)
+	}
+	return nil
+}
+
+func (r *runtimeIngestSession) complete(ctx context.Context, checkpoint runtime.IngestCheckpoint) error {
+	if r == nil || r.store == nil || r.run == nil {
+		return nil
+	}
+
+	completedAt := time.Now().UTC()
+	if checkpoint.RecordedAt.IsZero() {
+		checkpoint.RecordedAt = completedAt
+	}
+	if checkpoint.Cursor == "" {
+		checkpoint.Cursor = "observations:" + strconv.Itoa(r.run.ObservationCount)
+	}
+	if _, err := r.store.SaveCheckpoint(ctx, r.run.ID, checkpoint); err != nil {
+		return fmt.Errorf("save runtime ingest checkpoint: %w", err)
+	}
+
+	updated, err := r.store.LoadRun(ctx, r.run.ID)
+	if err != nil {
+		return fmt.Errorf("reload runtime ingest run: %w", err)
+	}
+	if updated == nil {
+		return fmt.Errorf("reload runtime ingest run: missing run after checkpoint save")
+	}
+	r.run = updated
+	r.run.Status = runtime.IngestRunStatusCompleted
+	r.run.Stage = "completed"
+	r.run.CompletedAt = &completedAt
+	r.run.UpdatedAt = completedAt
+	if err := r.store.SaveRun(ctx, r.run); err != nil {
+		return fmt.Errorf("save completed runtime ingest run: %w", err)
+	}
+	if _, err := r.store.AppendEvent(ctx, r.run.ID, runtime.IngestEvent{
+		Type:       "ingest_completed",
+		RecordedAt: completedAt,
+		Data: map[string]any{
+			"observations": r.run.ObservationCount,
+			"findings":     r.run.FindingCount,
+		},
+	}); err != nil {
+		return fmt.Errorf("append runtime ingest completed event: %w", err)
+	}
+	return nil
+}
+
+func (r *runtimeIngestSession) fail(ctx context.Context, stage string, runErr error) {
+	if r == nil || r.store == nil || r.run == nil {
+		return
+	}
+	failedAt := time.Now().UTC()
+	r.run.Status = runtime.IngestRunStatusFailed
+	r.run.Stage = strings.TrimSpace(stage)
+	r.run.Error = strings.TrimSpace(errorString(runErr))
+	r.run.CompletedAt = &failedAt
+	r.run.UpdatedAt = failedAt
+	_ = r.store.SaveRun(ctx, r.run)
+	_, _ = r.store.AppendEvent(ctx, r.run.ID, runtime.IngestEvent{
+		Type:       "ingest_failed",
+		RecordedAt: failedAt,
+		Data: map[string]any{
+			"stage": r.run.Stage,
+			"error": r.run.Error,
+		},
+	})
+}
+
+func cloneRuntimeIngestMetadata(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		if trimmedKey := strings.TrimSpace(key); trimmedKey != "" {
+			cloned[trimmedKey] = strings.TrimSpace(value)
+		}
+	}
+	if len(cloned) == 0 {
+		return nil
+	}
+	return cloned
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func enrichRuntimeObservation(observation *runtime.RuntimeObservation, cluster, node, agentVersion string) *runtime.RuntimeObservation {
+	if observation == nil {
+		return nil
+	}
+	if observation.Metadata == nil {
+		observation.Metadata = make(map[string]any)
+	}
+	cluster = strings.TrimSpace(cluster)
+	node = strings.TrimSpace(node)
+	agentVersion = strings.TrimSpace(agentVersion)
+	if observation.Cluster == "" && cluster != "" {
+		observation.Cluster = cluster
+	}
+	if observation.NodeName == "" && node != "" {
+		observation.NodeName = node
+	}
+	if observation.Cluster != "" {
+		observation.Metadata["cluster"] = observation.Cluster
+	}
+	if observation.NodeName != "" {
+		observation.Metadata["node_name"] = observation.NodeName
+	}
+	if agentVersion != "" {
+		observation.Metadata["agent_version"] = agentVersion
+	}
+	if observation.Namespace == "" && observation.Container != nil {
+		observation.Namespace = strings.TrimSpace(observation.Container.Namespace)
+	}
+	return observation
+}

--- a/internal/api/server_handlers_threat_runtime_test.go
+++ b/internal/api/server_handlers_threat_runtime_test.go
@@ -1,0 +1,513 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+type failingRuntimeIngestStore struct {
+	saveRunErr       error
+	saveRunErrOnCall int
+	saveRunCalls     int
+
+	appendEventErr       error
+	appendEventErrOnCall int
+	appendEventCalls     int
+
+	saveCheckpointErr       error
+	saveCheckpointErrOnCall int
+	saveCheckpointCalls     int
+}
+
+func (s *failingRuntimeIngestStore) Close() error { return nil }
+
+func (s *failingRuntimeIngestStore) SaveRun(context.Context, *runtime.IngestRunRecord) error {
+	s.saveRunCalls++
+	if s.saveRunErr != nil && (s.saveRunErrOnCall == 0 || s.saveRunErrOnCall == s.saveRunCalls) {
+		return s.saveRunErr
+	}
+	return nil
+}
+
+func (s *failingRuntimeIngestStore) LoadRun(context.Context, string) (*runtime.IngestRunRecord, error) {
+	return nil, nil
+}
+
+func (s *failingRuntimeIngestStore) ListRuns(context.Context, runtime.IngestRunListOptions) ([]runtime.IngestRunRecord, error) {
+	return nil, nil
+}
+
+func (s *failingRuntimeIngestStore) AppendEvent(context.Context, string, runtime.IngestEvent) (runtime.IngestEvent, error) {
+	s.appendEventCalls++
+	if s.appendEventErr != nil && (s.appendEventErrOnCall == 0 || s.appendEventErrOnCall == s.appendEventCalls) {
+		return runtime.IngestEvent{}, s.appendEventErr
+	}
+	return runtime.IngestEvent{}, nil
+}
+
+func (s *failingRuntimeIngestStore) LoadEvents(context.Context, string) ([]runtime.IngestEvent, error) {
+	return nil, nil
+}
+
+func (s *failingRuntimeIngestStore) SaveCheckpoint(context.Context, string, runtime.IngestCheckpoint) (runtime.IngestCheckpoint, error) {
+	s.saveCheckpointCalls++
+	if s.saveCheckpointErr != nil && (s.saveCheckpointErrOnCall == 0 || s.saveCheckpointErrOnCall == s.saveCheckpointCalls) {
+		return runtime.IngestCheckpoint{}, s.saveCheckpointErr
+	}
+	return runtime.IngestCheckpoint{}, nil
+}
+
+func (s *failingRuntimeIngestStore) LoadCheckpoint(context.Context, string) (*runtime.IngestCheckpoint, error) {
+	return nil, nil
+}
+
+type nilReloadRuntimeIngestStore struct {
+	saveRunCalls        int
+	saveCheckpointCalls int
+}
+
+func (s *nilReloadRuntimeIngestStore) Close() error { return nil }
+
+func (s *nilReloadRuntimeIngestStore) SaveRun(context.Context, *runtime.IngestRunRecord) error {
+	s.saveRunCalls++
+	return nil
+}
+
+func (s *nilReloadRuntimeIngestStore) LoadRun(context.Context, string) (*runtime.IngestRunRecord, error) {
+	return nil, nil
+}
+
+func (s *nilReloadRuntimeIngestStore) ListRuns(context.Context, runtime.IngestRunListOptions) ([]runtime.IngestRunRecord, error) {
+	return nil, nil
+}
+
+func (s *nilReloadRuntimeIngestStore) AppendEvent(context.Context, string, runtime.IngestEvent) (runtime.IngestEvent, error) {
+	return runtime.IngestEvent{}, nil
+}
+
+func (s *nilReloadRuntimeIngestStore) LoadEvents(context.Context, string) ([]runtime.IngestEvent, error) {
+	return nil, nil
+}
+
+func (s *nilReloadRuntimeIngestStore) SaveCheckpoint(context.Context, string, runtime.IngestCheckpoint) (runtime.IngestCheckpoint, error) {
+	s.saveCheckpointCalls++
+	return runtime.IngestCheckpoint{}, nil
+}
+
+func (s *nilReloadRuntimeIngestStore) LoadCheckpoint(context.Context, string) (*runtime.IngestCheckpoint, error) {
+	return nil, nil
+}
+
+func TestIngestRuntimeEventPersistsIngestRun(t *testing.T) {
+	a := newTestApp(t)
+	s := NewServer(a)
+
+	w := do(t, s, http.MethodPost, "/api/v1/runtime/events", map[string]any{
+		"id":            "evt-1",
+		"timestamp":     "2026-03-15T19:35:00Z",
+		"source":        "tetragon",
+		"resource_id":   "pod/default/miner-0",
+		"resource_type": "pod",
+		"event_type":    "process",
+		"process": map[string]any{
+			"pid":  4242,
+			"name": "xmrig",
+			"path": "/usr/bin/xmrig",
+		},
+		"container": map[string]any{
+			"container_id": "container-1",
+			"namespace":    "default",
+			"pod_name":     "miner-0",
+			"image":        "ghcr.io/acme/miner:latest",
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	runID, ok := body["run_id"].(string)
+	if !ok || runID == "" {
+		t.Fatalf("expected run_id in response, got %#v", body["run_id"])
+	}
+
+	run, err := a.RuntimeIngest.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run == nil {
+		t.Fatal("expected persisted run")
+	}
+	if run.Source != "runtime_event" {
+		t.Fatalf("source = %q, want runtime_event", run.Source)
+	}
+	if run.Status != runtime.IngestRunStatusCompleted {
+		t.Fatalf("status = %q, want %q", run.Status, runtime.IngestRunStatusCompleted)
+	}
+	if run.ObservationCount != 1 {
+		t.Fatalf("observation_count = %d, want 1", run.ObservationCount)
+	}
+	if run.FindingCount != 1 {
+		t.Fatalf("finding_count = %d, want 1", run.FindingCount)
+	}
+	if run.LastCheckpoint == nil || run.LastCheckpoint.Cursor != "evt-1" {
+		t.Fatalf("last checkpoint = %#v, want cursor evt-1", run.LastCheckpoint)
+	}
+
+	events, err := a.RuntimeIngest.LoadEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 4 {
+		t.Fatalf("len(events) = %d, want 4", len(events))
+	}
+	if events[0].Type != "ingest_started" {
+		t.Fatalf("events[0].Type = %q, want ingest_started", events[0].Type)
+	}
+	if events[1].Type != "observation_processed" {
+		t.Fatalf("events[1].Type = %q, want observation_processed", events[1].Type)
+	}
+	if got := events[1].Data["finding_count"]; got != float64(1) && got != 1 {
+		t.Fatalf("observation event finding_count = %#v, want 1", got)
+	}
+	if events[2].Type != "checkpoint_saved" {
+		t.Fatalf("events[2].Type = %q, want checkpoint_saved", events[2].Type)
+	}
+	if events[3].Type != "ingest_completed" {
+		t.Fatalf("events[3].Type = %q, want ingest_completed", events[3].Type)
+	}
+}
+
+func TestTelemetryIngestPersistsRunMetadataAndCheckpoint(t *testing.T) {
+	a := newTestApp(t)
+	s := NewServer(a)
+
+	w := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-1",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  100,
+					"name": "sh",
+					"path": "/bin/sh",
+				},
+			},
+			{
+				"id":            "telemetry-2",
+				"timestamp":     "2026-03-15T19:36:05Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  101,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	runID, ok := body["run_id"].(string)
+	if !ok || runID == "" {
+		t.Fatalf("expected run_id in response, got %#v", body["run_id"])
+	}
+
+	run, err := a.RuntimeIngest.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run == nil {
+		t.Fatal("expected persisted run")
+	}
+	if run.Source != "telemetry" {
+		t.Fatalf("source = %q, want telemetry", run.Source)
+	}
+	if run.Metadata["cluster"] != "prod-west" {
+		t.Fatalf("cluster metadata = %q, want prod-west", run.Metadata["cluster"])
+	}
+	if run.Metadata["node"] != "worker-7" {
+		t.Fatalf("node metadata = %q, want worker-7", run.Metadata["node"])
+	}
+	if run.Metadata["agent_version"] != "1.4.2" {
+		t.Fatalf("agent_version metadata = %q, want 1.4.2", run.Metadata["agent_version"])
+	}
+	if run.ObservationCount != 2 {
+		t.Fatalf("observation_count = %d, want 2", run.ObservationCount)
+	}
+	if run.FindingCount != 1 {
+		t.Fatalf("finding_count = %d, want 1", run.FindingCount)
+	}
+	if run.LastCheckpoint == nil || run.LastCheckpoint.Cursor != "telemetry-2" {
+		t.Fatalf("last checkpoint = %#v, want cursor telemetry-2", run.LastCheckpoint)
+	}
+	if run.LastCheckpoint.Metadata["cluster"] != "prod-west" {
+		t.Fatalf("checkpoint cluster = %q, want prod-west", run.LastCheckpoint.Metadata["cluster"])
+	}
+	if run.LastCheckpoint.Metadata["processed_events"] != "2" {
+		t.Fatalf("checkpoint processed_events = %q, want 2", run.LastCheckpoint.Metadata["processed_events"])
+	}
+
+	events, err := a.RuntimeIngest.LoadEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 5 {
+		t.Fatalf("len(events) = %d, want 5", len(events))
+	}
+	if got := events[1].Data["cluster"]; got != "prod-west" {
+		t.Fatalf("first observation cluster = %#v, want prod-west", got)
+	}
+	if got := events[1].Data["node_name"]; got != "worker-7" {
+		t.Fatalf("first observation node_name = %#v, want worker-7", got)
+	}
+}
+
+func TestRuntimeIngestSessionRecordObservationUsesProcessingTimeForRunUpdates(t *testing.T) {
+	a := newTestApp(t)
+	s := NewServer(a)
+
+	session, err := s.startRuntimeIngestSession(context.Background(), "telemetry", map[string]string{"cluster": "prod-west"})
+	if err != nil {
+		t.Fatalf("startRuntimeIngestSession: %v", err)
+	}
+	if session == nil || session.run == nil {
+		t.Fatal("expected runtime ingest session")
+	}
+
+	historicalObservedAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	beforeRecord := time.Now().UTC()
+	err = session.recordObservation(context.Background(), &runtime.RuntimeObservation{
+		ID:         "historic-1",
+		Kind:       runtime.ObservationKindProcessExec,
+		Source:     "tetragon",
+		ObservedAt: historicalObservedAt,
+		ResourceID: "pod:default/api-0",
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("recordObservation: %v", err)
+	}
+	afterRecord := time.Now().UTC()
+
+	if session.run.UpdatedAt.Before(beforeRecord) || session.run.UpdatedAt.After(afterRecord) {
+		t.Fatalf("run.UpdatedAt = %s, want processing time between %s and %s", session.run.UpdatedAt, beforeRecord, afterRecord)
+	}
+
+	events, err := a.RuntimeIngest.LoadEvents(context.Background(), session.run.ID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if events[1].Type != "observation_processed" {
+		t.Fatalf("events[1].Type = %q, want observation_processed", events[1].Type)
+	}
+	if events[1].RecordedAt.Before(beforeRecord) || events[1].RecordedAt.After(afterRecord) {
+		t.Fatalf("events[1].RecordedAt = %s, want processing time between %s and %s", events[1].RecordedAt, beforeRecord, afterRecord)
+	}
+	if got := events[1].Data["observed_at"]; got != historicalObservedAt.Format(time.RFC3339Nano) {
+		t.Fatalf("events[1].Data[observed_at] = %#v, want %q", got, historicalObservedAt.Format(time.RFC3339Nano))
+	}
+}
+
+func TestEnrichRuntimeObservationPreservesExistingClusterAndNodeMetadata(t *testing.T) {
+	observation := &runtime.RuntimeObservation{
+		Cluster:  "event-cluster",
+		NodeName: "event-node",
+		Metadata: map[string]any{
+			"cluster":   "event-cluster",
+			"node_name": "event-node",
+		},
+	}
+
+	enriched := enrichRuntimeObservation(observation, "payload-cluster", "payload-node", "1.4.2")
+	if enriched == nil {
+		t.Fatal("expected enriched observation")
+	}
+	if enriched.Cluster != "event-cluster" {
+		t.Fatalf("cluster = %q, want %q", enriched.Cluster, "event-cluster")
+	}
+	if enriched.NodeName != "event-node" {
+		t.Fatalf("node_name = %q, want %q", enriched.NodeName, "event-node")
+	}
+	if got := enriched.Metadata["cluster"]; got != "event-cluster" {
+		t.Fatalf("metadata cluster = %#v, want %q", got, "event-cluster")
+	}
+	if got := enriched.Metadata["node_name"]; got != "event-node" {
+		t.Fatalf("metadata node_name = %#v, want %q", got, "event-node")
+	}
+	if got := enriched.Metadata["agent_version"]; got != "1.4.2" {
+		t.Fatalf("metadata agent_version = %#v, want %q", got, "1.4.2")
+	}
+}
+
+func TestRuntimeIngestSessionCompleteFailsWhenReloadLosesCheckpointedRun(t *testing.T) {
+	store := &nilReloadRuntimeIngestStore{}
+	session := &runtimeIngestSession{
+		store: store,
+		run: &runtime.IngestRunRecord{
+			ID:          "run-1",
+			Source:      "runtime_event",
+			Status:      runtime.IngestRunStatusRunning,
+			Stage:       "detect",
+			SubmittedAt: time.Now().UTC(),
+			UpdatedAt:   time.Now().UTC(),
+		},
+	}
+
+	err := session.complete(context.Background(), runtime.IngestCheckpoint{Cursor: "evt-1"})
+	if err == nil {
+		t.Fatal("expected complete to fail when reloading checkpointed run returns nil")
+	}
+	if err.Error() != "reload runtime ingest run: missing run after checkpoint save" {
+		t.Fatalf("complete error = %q, want missing run reload error", err.Error())
+	}
+	if store.saveCheckpointCalls != 1 {
+		t.Fatalf("saveCheckpointCalls = %d, want 1", store.saveCheckpointCalls)
+	}
+	if store.saveRunCalls != 0 {
+		t.Fatalf("saveRunCalls = %d, want 0", store.saveRunCalls)
+	}
+}
+
+func TestIngestRuntimeEventContinuesWhenRunPersistenceFails(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = &failingRuntimeIngestStore{saveRunErr: errors.New("boom"), saveRunErrOnCall: 1}
+	s := NewServerWithDependencies(deps)
+
+	w := do(t, s, http.MethodPost, "/api/v1/runtime/events", map[string]any{
+		"id":            "evt-err",
+		"timestamp":     "2026-03-15T19:37:00Z",
+		"source":        "tetragon",
+		"resource_id":   "pod/default/api-0",
+		"resource_type": "pod",
+		"event_type":    "process",
+		"process": map[string]any{
+			"pid":  4242,
+			"name": "xmrig",
+			"path": "/usr/bin/xmrig",
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	if got := body["findings"]; got != float64(1) && got != 1 {
+		t.Fatalf("findings = %#v, want 1", got)
+	}
+	if _, ok := body["run_id"]; ok {
+		t.Fatalf("expected no run_id when ingest run start fails, got %#v", body["run_id"])
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 1 {
+		t.Fatalf("recent findings = %d, want 1", got)
+	}
+	if s.app.RuntimeRespond == nil {
+		t.Fatal("expected runtime response engine")
+	}
+	if got := len(s.app.RuntimeRespond.ListExecutions(10)); got != 1 {
+		t.Fatalf("response executions = %d, want 1", got)
+	}
+}
+
+func TestIngestRuntimeEventContinuesWhenObservationPersistenceFails(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = &failingRuntimeIngestStore{saveRunErr: errors.New("boom"), saveRunErrOnCall: 2}
+	s := NewServerWithDependencies(deps)
+
+	w := do(t, s, http.MethodPost, "/api/v1/runtime/events", map[string]any{
+		"id":            "evt-record-err",
+		"timestamp":     "2026-03-15T19:37:00Z",
+		"source":        "tetragon",
+		"resource_id":   "pod/default/api-0",
+		"resource_type": "pod",
+		"event_type":    "process",
+		"process": map[string]any{
+			"pid":  4242,
+			"name": "xmrig",
+			"path": "/usr/bin/xmrig",
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	if got := body["findings"]; got != float64(1) && got != 1 {
+		t.Fatalf("findings = %#v, want 1", got)
+	}
+	if _, ok := body["run_id"]; ok {
+		t.Fatalf("expected run_id to be omitted after ingest persistence degrades, got %#v", body["run_id"])
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 1 {
+		t.Fatalf("recent findings = %d, want 1", got)
+	}
+	if got := len(s.app.RuntimeRespond.ListExecutions(10)); got != 1 {
+		t.Fatalf("response executions = %d, want 1", got)
+	}
+}
+
+func TestIngestTelemetryContinuesWhenObservationPersistenceFails(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = &failingRuntimeIngestStore{saveRunErr: errors.New("boom"), saveRunErrOnCall: 2}
+	s := NewServerWithDependencies(deps)
+
+	w := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-err-1",
+				"timestamp":     "2026-03-15T19:36:05Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  101,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	if got := body["processed"]; got != float64(1) && got != 1 {
+		t.Fatalf("processed = %#v, want 1", got)
+	}
+	if got := body["findings"]; got != float64(1) && got != 1 {
+		t.Fatalf("findings = %#v, want 1", got)
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 1 {
+		t.Fatalf("recent findings = %d, want 1", got)
+	}
+	if got := len(s.app.RuntimeRespond.ListExecutions(10)); got != 1 {
+		t.Fatalf("response executions = %d, want 1", got)
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -51,6 +51,7 @@ import (
 	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/dspm"
 	"github.com/writer/cerebro/internal/events"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/graph/builders"
@@ -90,13 +91,14 @@ type App struct {
 	Logger *slog.Logger
 
 	// Core services
-	Snowflake *snowflake.Client
-	Warehouse warehouse.DataWarehouse
-	Policy    *policy.Engine
-	Findings  findings.FindingStore
-	Scanner   *scanner.Scanner
-	DSPM      *dspm.Scanner
-	Cache     *cache.PolicyCache
+	Snowflake      *snowflake.Client
+	Warehouse      warehouse.DataWarehouse
+	Policy         *policy.Engine
+	Findings       findings.FindingStore
+	Scanner        *scanner.Scanner
+	DSPM           *dspm.Scanner
+	Cache          *cache.PolicyCache
+	ExecutionStore executionstore.Store
 
 	// Feature services
 	Agents         *agents.AgentRegistry
@@ -136,6 +138,7 @@ type App struct {
 	Remediation         *remediation.Engine
 	RemediationExecutor *remediation.Executor
 	RuntimeDetect       *runtime.DetectionEngine
+	RuntimeIngest       runtime.IngestStore
 	RuntimeRespond      *runtime.ResponseEngine
 
 	// Security Graph

--- a/internal/app/app_execution_store.go
+++ b/internal/app/app_execution_store.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+func (a *App) initExecutionStore() {
+	if a == nil || a.Config == nil {
+		return
+	}
+	path := strings.TrimSpace(a.Config.ExecutionStoreFile)
+	if path == "" {
+		return
+	}
+	store, err := executionstore.NewSQLiteStore(path)
+	if err != nil {
+		if a.Logger != nil {
+			a.Logger.Warn("failed to initialize shared execution store", "error", err, "path", path)
+		}
+		return
+	}
+	a.ExecutionStore = store
+	if a.Logger != nil {
+		a.Logger.Info("shared execution store initialized", "path", path)
+	}
+}

--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -54,6 +54,8 @@ func (a *App) initPhase1(ctx context.Context) error {
 }
 
 func (a *App) initPhase2a(ctx context.Context) error {
+	a.initExecutionStore()
+
 	if err := runInitTasksConcurrently(ctx, []concurrentInitTask{
 		{name: "cache", run: func(context.Context) { a.initCache() }},
 		{name: "ticketing", run: func(taskCtx context.Context) { a.initTicketing(taskCtx) }},

--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -452,6 +452,9 @@ func (a *App) initRemediation() {
 
 func (a *App) initRuntime() {
 	a.RuntimeDetect = runtime.NewDetectionEngine()
+	if a.ExecutionStore != nil {
+		a.RuntimeIngest = runtime.NewSQLiteIngestStoreWithExecutionStore(a.ExecutionStore)
+	}
 	a.RuntimeRespond = runtime.NewResponseEngine()
 	a.RuntimeRespond.SetSharedExecutor(a.newSharedActionExecutor())
 	a.RuntimeRespond.SetActionHandler(runtime.NewDefaultActionHandler(runtime.DefaultActionHandlerOptions{
@@ -459,6 +462,9 @@ func (a *App) initRuntime() {
 		RemoteCaller: a.RemoteTools,
 	}))
 	a.Logger.Info("runtime detection initialized", "rules", len(a.RuntimeDetect.ListRules()))
+	if a.RuntimeIngest != nil {
+		a.Logger.Info("runtime ingest initialized", "store", "executionstore")
+	}
 	a.Logger.Info("runtime response initialized", "policies", len(a.RuntimeRespond.ListPolicies()))
 }
 

--- a/internal/app/app_service_groups.go
+++ b/internal/app/app_service_groups.go
@@ -65,6 +65,7 @@ type SecurityServices struct {
 	Remediation         *remediation.Engine
 	RemediationExecutor *remediation.Executor
 	RuntimeDetect       *runtime.DetectionEngine
+	RuntimeIngest       runtime.IngestStore
 	RuntimeRespond      *runtime.ResponseEngine
 	SecurityGraph       *graph.Graph
 	GraphBuilder        *builders.Builder
@@ -121,6 +122,7 @@ func (a *App) SecurityServices() SecurityServices {
 		Remediation:         a.Remediation,
 		RemediationExecutor: a.RemediationExecutor,
 		RuntimeDetect:       a.RuntimeDetect,
+		RuntimeIngest:       a.RuntimeIngest,
 		RuntimeRespond:      a.RuntimeRespond,
 		SecurityGraph:       a.CurrentSecurityGraph(),
 		GraphBuilder:        a.SecurityGraphBuilder,

--- a/internal/app/app_storage_graph.go
+++ b/internal/app/app_storage_graph.go
@@ -294,6 +294,16 @@ func (a *App) Close() error {
 			errs = append(errs, fmt.Errorf("alert router: %w", err))
 		}
 	}
+	if a.RuntimeIngest != nil {
+		if err := a.RuntimeIngest.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("runtime ingest store: %w", err))
+		}
+	}
+	if a.ExecutionStore != nil {
+		if err := a.ExecutionStore.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("execution store: %w", err))
+		}
+	}
 
 	// Close findings store if it implements io.Closer (e.g., SQLiteStore)
 	if closer, ok := a.Findings.(interface{ Close() error }); ok {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -699,6 +699,10 @@ func TestNew_WithoutSnowflake(t *testing.T) {
 		t.Error("RuntimeDetect should be initialized")
 	}
 
+	if app.RuntimeIngest == nil {
+		t.Error("RuntimeIngest should be initialized")
+	}
+
 	if app.RuntimeRespond == nil {
 		t.Error("RuntimeRespond should be initialized")
 	}

--- a/internal/apptest/apptest.go
+++ b/internal/apptest/apptest.go
@@ -14,6 +14,7 @@ import (
 	"github.com/writer/cerebro/internal/attackpath"
 	"github.com/writer/cerebro/internal/auth"
 	"github.com/writer/cerebro/internal/cache"
+	"github.com/writer/cerebro/internal/executionstore"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/health"
@@ -40,8 +41,8 @@ func NewConfig(t *testing.T) *app.Config {
 	graphSnapshotPath := strings.TrimSpace(os.Getenv("GRAPH_SNAPSHOT_PATH"))
 	if graphSnapshotPath == "" {
 		graphSnapshotPath = filepath.Join(stateDir, "graph-snapshots")
-		t.Setenv("GRAPH_SNAPSHOT_PATH", graphSnapshotPath)
 	}
+	t.Setenv("GRAPH_SNAPSHOT_PATH", graphSnapshotPath)
 
 	return &app.Config{
 		LogLevel:                   "error",
@@ -69,8 +70,12 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 	pe := policy.NewEngine()
 	fs := findings.NewStore()
 	sc := scanner.NewScanner(pe, scanner.ScanConfig{Workers: 2}, logger)
+	executionStore, err := executionstore.NewSQLiteStore(cfg.ExecutionStoreFile)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
 
-	return &app.App{
+	application := &app.App{
 		Config:         cfg,
 		Logger:         logger,
 		Warehouse:      store,
@@ -78,22 +83,26 @@ func NewAppWithWarehouse(t *testing.T, store warehouse.DataWarehouse) *app.App {
 		Findings:       fs,
 		Scanner:        sc,
 		Cache:          cache.NewPolicyCache(1000, 5*time.Minute),
+		ExecutionStore: executionStore,
 		Agents:         agents.NewAgentRegistry(),
 		RBAC:           auth.NewRBAC(),
 		Webhooks:       webhooks.NewServiceForTesting(),
 		Notifications:  notifications.NewManager(),
 		Scheduler:      scheduler.NewScheduler(logger),
 		Ticketing:      ticketing.NewService(),
-		Identity:       identity.NewService(),
 		AttackPath:     attackpath.NewGraph(),
 		Providers:      providers.NewRegistry(),
 		Health:         health.NewRegistry(),
 		Lineage:        lineage.NewLineageMapper(),
 		Remediation:    remediation.NewEngine(logger),
 		RuntimeDetect:  runtime.NewDetectionEngine(),
+		RuntimeIngest:  runtime.NewSQLiteIngestStoreWithExecutionStore(executionStore),
 		RuntimeRespond: runtime.NewResponseEngine(),
 		SecurityGraph:  graph.New(),
 		ScanWatermarks: scanner.NewWatermarkStore(nil),
 		ThreatIntel:    threatintel.NewThreatIntelService(),
 	}
+	application.Identity = identity.NewService()
+	t.Cleanup(func() { _ = application.Close() })
+	return application
 }

--- a/internal/executionstore/namespaces.go
+++ b/internal/executionstore/namespaces.go
@@ -1,0 +1,13 @@
+package executionstore
+
+const (
+	NamespacePlatformReportRun    = "report_run"
+	NamespaceWorkloadScan         = "workload_scan"
+	NamespaceImageScan            = "image_scan"
+	NamespaceFunctionScan         = "function_scan"
+	NamespaceActionEngine         = "action_engine"
+	NamespaceIdentityAccessReview = "identity_access_review"
+	NamespaceAutonomousWorkflow   = "autonomous_workflow"
+	NamespaceRuntimeIngest        = "runtime_ingest"
+	NamespaceProcessedCloudEvent  = "processed_cloud_event"
+)

--- a/internal/executionstore/processed_events.go
+++ b/internal/executionstore/processed_events.go
@@ -1,0 +1,244 @@
+package executionstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ProcessedEventRecord struct {
+	Namespace      string
+	EventKey       string
+	PayloadHash    string
+	FirstSeenAt    time.Time
+	LastSeenAt     time.Time
+	ProcessedAt    time.Time
+	ExpiresAt      time.Time
+	DuplicateCount int
+}
+
+func (s *SQLiteStore) LookupProcessedEvent(ctx context.Context, namespace, eventKey string, observedAt time.Time) (*ProcessedEventRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	eventKey = strings.TrimSpace(eventKey)
+	if namespace == "" || eventKey == "" {
+		return nil, fmt.Errorf("processed event namespace and key are required")
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	} else {
+		observedAt = observedAt.UTC()
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin processed event lookup tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND expires_at <= ?
+	`, namespace, observedAt); err != nil {
+		return nil, fmt.Errorf("prune expired processed events: %w", err)
+	}
+
+	var record ProcessedEventRecord
+	err = tx.QueryRowContext(ctx, `
+		SELECT namespace, event_key, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
+		FROM processed_events
+		WHERE namespace = ? AND event_key = ?
+	`, namespace, eventKey).Scan(
+		&record.Namespace,
+		&record.EventKey,
+		&record.PayloadHash,
+		&record.FirstSeenAt,
+		&record.LastSeenAt,
+		&record.ProcessedAt,
+		&record.ExpiresAt,
+		&record.DuplicateCount,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit processed event lookup: %w", err)
+		}
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load processed event: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit processed event lookup: %w", err)
+	}
+	return &record, nil
+}
+
+func (s *SQLiteStore) TouchProcessedEvent(ctx context.Context, namespace, eventKey string, observedAt time.Time, ttl time.Duration) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	eventKey = strings.TrimSpace(eventKey)
+	if namespace == "" || eventKey == "" {
+		return fmt.Errorf("processed event namespace and key are required")
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	} else {
+		observedAt = observedAt.UTC()
+	}
+	if ttl <= 0 {
+		return fmt.Errorf("processed event ttl must be > 0")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin processed event touch tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND expires_at <= ?
+	`, namespace, observedAt); err != nil {
+		return fmt.Errorf("prune expired processed events: %w", err)
+	}
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE processed_events
+		SET last_seen_at = ?,
+			expires_at = ?,
+			duplicate_count = duplicate_count + 1
+		WHERE namespace = ? AND event_key = ?
+	`, observedAt, observedAt.Add(ttl), namespace, eventKey)
+	if err != nil {
+		return fmt.Errorf("touch processed event: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read touched processed event rows: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("processed event %s/%s not found", namespace, eventKey)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit processed event touch: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) RememberProcessedEvent(ctx context.Context, record ProcessedEventRecord, maxRecords int) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	record.Namespace = strings.TrimSpace(record.Namespace)
+	record.EventKey = strings.TrimSpace(record.EventKey)
+	record.PayloadHash = strings.TrimSpace(record.PayloadHash)
+	if record.Namespace == "" || record.EventKey == "" {
+		return fmt.Errorf("processed event namespace and key are required")
+	}
+	if record.FirstSeenAt.IsZero() {
+		record.FirstSeenAt = time.Now().UTC()
+	} else {
+		record.FirstSeenAt = record.FirstSeenAt.UTC()
+	}
+	if record.LastSeenAt.IsZero() {
+		record.LastSeenAt = record.FirstSeenAt
+	} else {
+		record.LastSeenAt = record.LastSeenAt.UTC()
+	}
+	if record.ProcessedAt.IsZero() {
+		record.ProcessedAt = record.LastSeenAt
+	} else {
+		record.ProcessedAt = record.ProcessedAt.UTC()
+	}
+	if record.ExpiresAt.IsZero() {
+		record.ExpiresAt = record.ProcessedAt
+	} else {
+		record.ExpiresAt = record.ExpiresAt.UTC()
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin processed event remember tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND expires_at <= ?
+	`, record.Namespace, record.ProcessedAt); err != nil {
+		return fmt.Errorf("prune expired processed events: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO processed_events (
+			namespace, event_key, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(namespace, event_key) DO UPDATE SET
+			payload_hash = excluded.payload_hash,
+			last_seen_at = excluded.last_seen_at,
+			processed_at = excluded.processed_at,
+			expires_at = excluded.expires_at
+	`, record.Namespace, record.EventKey, record.PayloadHash, record.FirstSeenAt, record.LastSeenAt, record.ProcessedAt, record.ExpiresAt, record.DuplicateCount); err != nil {
+		return fmt.Errorf("persist processed event: %w", err)
+	}
+
+	if maxRecords > 0 {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM processed_events
+			WHERE namespace = ?
+			  AND event_key IN (
+				SELECT event_key
+				FROM processed_events
+				WHERE namespace = ?
+				ORDER BY processed_at DESC, event_key DESC
+				LIMIT -1 OFFSET ?
+			  )
+		`, record.Namespace, record.Namespace, maxRecords); err != nil {
+			return fmt.Errorf("trim processed events: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit processed event remember: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteProcessedEvent(ctx context.Context, namespace, eventKey string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	eventKey = strings.TrimSpace(eventKey)
+	if namespace == "" || eventKey == "" {
+		return fmt.Errorf("processed event namespace and key are required")
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND event_key = ?
+	`, namespace, eventKey); err != nil {
+		return fmt.Errorf("delete processed event: %w", err)
+	}
+	return nil
+}

--- a/internal/executionstore/sqlite.go
+++ b/internal/executionstore/sqlite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,6 +35,7 @@ type EventEnvelope struct {
 }
 
 type RunListOptions struct {
+	Namespaces         []string
 	Statuses           []string
 	ExcludeStatuses    []string
 	Limit              int
@@ -45,6 +47,8 @@ type SQLiteStore struct {
 	db *sql.DB
 }
 
+const sqliteBusyTimeoutMS = 5000
+
 func NewSQLiteStore(path string) (*SQLiteStore, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -53,7 +57,7 @@ func NewSQLiteStore(path string) (*SQLiteStore, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return nil, fmt.Errorf("create execution store directory: %w", err)
 	}
-	db, err := sql.Open("sqlite", path)
+	db, err := sql.Open("sqlite", sqliteStoreDSN(path))
 	if err != nil {
 		return nil, fmt.Errorf("open execution sqlite: %w", err)
 	}
@@ -62,6 +66,20 @@ func NewSQLiteStore(path string) (*SQLiteStore, error) {
 		return nil, err
 	}
 	return &SQLiteStore{db: db}, nil
+}
+
+func sqliteStoreDSN(path string) string {
+	absPath, err := filepath.Abs(path)
+	if err == nil {
+		path = absPath
+	}
+	u := url.URL{Scheme: "file", Path: filepath.ToSlash(path)}
+	query := u.Query()
+	query.Add("_pragma", "journal_mode(WAL)")
+	query.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", sqliteBusyTimeoutMS))
+	query.Add("_pragma", "synchronous(NORMAL)")
+	u.RawQuery = query.Encode()
+	return u.String()
 }
 
 func initSQLiteStore(db *sql.DB) error {
@@ -94,6 +112,21 @@ func initSQLiteStore(db *sql.DB) error {
 		payload JSON NOT NULL,
 		PRIMARY KEY (namespace, run_id, sequence)
 	);
+	CREATE TABLE IF NOT EXISTS processed_events (
+		namespace TEXT NOT NULL,
+		event_key TEXT NOT NULL,
+		payload_hash TEXT NOT NULL,
+		first_seen_at TIMESTAMP NOT NULL,
+		last_seen_at TIMESTAMP NOT NULL,
+		processed_at TIMESTAMP NOT NULL,
+		expires_at TIMESTAMP NOT NULL,
+		duplicate_count INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (namespace, event_key)
+	);
+	CREATE INDEX IF NOT EXISTS idx_processed_events_namespace_expires
+		ON processed_events(namespace, expires_at ASC);
+	CREATE INDEX IF NOT EXISTS idx_processed_events_namespace_processed
+		ON processed_events(namespace, processed_at DESC, event_key DESC);
 	`
 	if _, err := db.ExecContext(context.Background(), schema); err != nil {
 		return fmt.Errorf("init execution sqlite schema: %w", err)
@@ -145,6 +178,154 @@ func (s *SQLiteStore) UpsertRun(ctx context.Context, env RunEnvelope) error {
 	return nil
 }
 
+func (s *SQLiteStore) CompareAndSwapRun(ctx context.Context, current, next RunEnvelope) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	current.Namespace = strings.TrimSpace(current.Namespace)
+	current.RunID = strings.TrimSpace(current.RunID)
+	next.Namespace = strings.TrimSpace(next.Namespace)
+	next.RunID = strings.TrimSpace(next.RunID)
+	if current.Namespace == "" || current.RunID == "" || next.Namespace == "" || next.RunID == "" {
+		return false, fmt.Errorf("execution run namespace and id are required")
+	}
+	if current.Namespace != next.Namespace || current.RunID != next.RunID {
+		return false, fmt.Errorf("execution compare-and-swap requires matching namespace and run id")
+	}
+	current.Kind = strings.TrimSpace(current.Kind)
+	current.Status = strings.TrimSpace(current.Status)
+	current.Stage = strings.TrimSpace(current.Stage)
+	next.Kind = strings.TrimSpace(next.Kind)
+	next.Status = strings.TrimSpace(next.Status)
+	next.Stage = strings.TrimSpace(next.Stage)
+	next.SubmittedAt = next.SubmittedAt.UTC()
+	next.UpdatedAt = next.UpdatedAt.UTC()
+
+	query := `
+		UPDATE execution_runs
+		SET kind = ?, status = ?, stage = ?, submitted_at = ?, started_at = ?, completed_at = ?, updated_at = ?, payload = ?
+		WHERE namespace = ? AND run_id = ? AND kind = ? AND status = ? AND stage = ?
+	`
+	args := []any{
+		next.Kind,
+		next.Status,
+		next.Stage,
+		next.SubmittedAt,
+		nullableTime(next.StartedAt),
+		nullableTime(next.CompletedAt),
+		next.UpdatedAt,
+		next.Payload,
+		current.Namespace,
+		current.RunID,
+		current.Kind,
+		current.Status,
+		current.Stage,
+	}
+	if current.CompletedAt == nil {
+		query += ` AND completed_at IS NULL`
+	} else {
+		query += ` AND completed_at = ?`
+		args = append(args, current.CompletedAt.UTC())
+	}
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, fmt.Errorf("compare-and-swap execution run: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("inspect execution run compare-and-swap result: %w", err)
+	}
+	return rows == 1, nil
+}
+
+func (s *SQLiteStore) ReplaceRunWithEvents(ctx context.Context, env RunEnvelope, events []EventEnvelope) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	env.Namespace = strings.TrimSpace(env.Namespace)
+	env.RunID = strings.TrimSpace(env.RunID)
+	if env.Namespace == "" || env.RunID == "" {
+		return fmt.Errorf("execution run namespace and id are required")
+	}
+	env.Kind = strings.TrimSpace(env.Kind)
+	env.Status = strings.TrimSpace(env.Status)
+	env.Stage = strings.TrimSpace(env.Stage)
+	env.SubmittedAt = env.SubmittedAt.UTC()
+	env.UpdatedAt = env.UpdatedAt.UTC()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin execution run replacement tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO execution_runs (
+			namespace, run_id, kind, status, stage, submitted_at, started_at, completed_at, updated_at, payload
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(namespace, run_id) DO UPDATE SET
+			kind = excluded.kind,
+			status = excluded.status,
+			stage = excluded.stage,
+			submitted_at = excluded.submitted_at,
+			started_at = excluded.started_at,
+			completed_at = excluded.completed_at,
+			updated_at = excluded.updated_at,
+			payload = excluded.payload
+	`, env.Namespace, env.RunID, env.Kind, env.Status, env.Stage, env.SubmittedAt, nullableTime(env.StartedAt), nullableTime(env.CompletedAt), env.UpdatedAt, env.Payload); err != nil {
+		return fmt.Errorf("persist execution run: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM execution_events
+		WHERE namespace = ? AND run_id = ?
+	`, env.Namespace, env.RunID); err != nil {
+		return fmt.Errorf("delete execution events: %w", err)
+	}
+
+	for index, event := range events {
+		event.Namespace = strings.TrimSpace(event.Namespace)
+		if event.Namespace == "" {
+			event.Namespace = env.Namespace
+		}
+		event.RunID = strings.TrimSpace(event.RunID)
+		if event.RunID == "" {
+			event.RunID = env.RunID
+		}
+		if event.Namespace != env.Namespace || event.RunID != env.RunID {
+			return fmt.Errorf("execution event namespace/run mismatch for %s/%s", event.Namespace, event.RunID)
+		}
+		if event.RecordedAt.IsZero() {
+			event.RecordedAt = time.Now().UTC()
+		} else {
+			event.RecordedAt = event.RecordedAt.UTC()
+		}
+		if event.Sequence <= 0 {
+			event.Sequence = int64(index + 1)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO execution_events (namespace, run_id, sequence, recorded_at, payload)
+			VALUES (?, ?, ?, ?, ?)
+			ON CONFLICT(namespace, run_id, sequence) DO UPDATE SET
+				recorded_at = excluded.recorded_at,
+				payload = excluded.payload
+		`, event.Namespace, event.RunID, event.Sequence, event.RecordedAt, event.Payload); err != nil {
+			return fmt.Errorf("persist execution event: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit execution run replacement: %w", err)
+	}
+	return nil
+}
+
 func (s *SQLiteStore) LoadRun(ctx context.Context, namespace, runID string) (*RunEnvelope, error) {
 	if s == nil || s.db == nil {
 		return nil, nil
@@ -173,6 +354,14 @@ func (s *SQLiteStore) LoadRun(ctx context.Context, namespace, runID string) (*Ru
 }
 
 func (s *SQLiteStore) ListRuns(ctx context.Context, namespace string, opts RunListOptions) ([]RunEnvelope, error) {
+	return s.listRunsWithNamespaces(ctx, []string{namespace}, opts)
+}
+
+func (s *SQLiteStore) ListAllRuns(ctx context.Context, opts RunListOptions) ([]RunEnvelope, error) {
+	return s.listRunsWithNamespaces(ctx, opts.Namespaces, opts)
+}
+
+func (s *SQLiteStore) listRunsWithNamespaces(ctx context.Context, namespaces []string, opts RunListOptions) ([]RunEnvelope, error) {
 	if s == nil || s.db == nil {
 		return nil, nil
 	}
@@ -182,9 +371,18 @@ func (s *SQLiteStore) ListRuns(ctx context.Context, namespace string, opts RunLi
 	query := `
 		SELECT namespace, run_id, kind, status, stage, submitted_at, started_at, completed_at, updated_at, payload
 		FROM execution_runs
-		WHERE namespace = ?
+		WHERE 1 = 1
 	`
-	args := []any{strings.TrimSpace(namespace)}
+	args := make([]any, 0)
+	namespaces = normalizeNamespaces(namespaces, opts.Namespaces)
+	if len(namespaces) > 0 {
+		placeholders := make([]string, 0, len(namespaces))
+		for _, namespace := range namespaces {
+			placeholders = append(placeholders, "?")
+			args = append(args, namespace)
+		}
+		query += ` AND namespace IN (` + strings.Join(placeholders, ",") + `)` // #nosec G202 -- fixed placeholders; values remain parameterized.
+	}
 	if len(opts.Statuses) > 0 {
 		placeholders := make([]string, 0, len(opts.Statuses))
 		for _, status := range opts.Statuses {
@@ -239,6 +437,48 @@ func (s *SQLiteStore) ListRuns(ctx context.Context, namespace string, opts RunLi
 		return nil, fmt.Errorf("iterate execution runs: %w", err)
 	}
 	return runs, nil
+}
+
+func (s *SQLiteStore) DeleteRun(ctx context.Context, namespace, runID string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	runID = strings.TrimSpace(runID)
+	if namespace == "" || runID == "" {
+		return fmt.Errorf("execution run namespace and id are required")
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		DELETE FROM execution_runs
+		WHERE namespace = ? AND run_id = ?
+	`, namespace, runID); err != nil {
+		return fmt.Errorf("delete execution run: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteEvents(ctx context.Context, namespace, runID string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	namespace = strings.TrimSpace(namespace)
+	runID = strings.TrimSpace(runID)
+	if namespace == "" || runID == "" {
+		return fmt.Errorf("execution event namespace and run id are required")
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		DELETE FROM execution_events
+		WHERE namespace = ? AND run_id = ?
+	`, namespace, runID); err != nil {
+		return fmt.Errorf("delete execution events: %w", err)
+	}
+	return nil
 }
 
 func (s *SQLiteStore) SaveEvent(ctx context.Context, env EventEnvelope) (EventEnvelope, error) {
@@ -347,4 +587,28 @@ func nullableTimeValue(value sql.NullTime) *time.Time {
 	}
 	ts := value.Time.UTC()
 	return &ts
+}
+
+func normalizeNamespaces(primary []string, secondary []string) []string {
+	values := append(append([]string(nil), primary...), secondary...)
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
 }

--- a/internal/executionstore/store.go
+++ b/internal/executionstore/store.go
@@ -1,0 +1,27 @@
+package executionstore
+
+import (
+	"context"
+	"time"
+)
+
+// Store is the durable execution-state substrate interface. SQLite is the
+// current implementation, but higher-scale backends should satisfy the same
+// contract instead of forcing callers to depend on SQLite directly.
+type Store interface {
+	Close() error
+	UpsertRun(context.Context, RunEnvelope) error
+	CompareAndSwapRun(context.Context, RunEnvelope, RunEnvelope) (bool, error)
+	ReplaceRunWithEvents(context.Context, RunEnvelope, []EventEnvelope) error
+	LoadRun(context.Context, string, string) (*RunEnvelope, error)
+	ListRuns(context.Context, string, RunListOptions) ([]RunEnvelope, error)
+	ListAllRuns(context.Context, RunListOptions) ([]RunEnvelope, error)
+	DeleteRun(context.Context, string, string) error
+	DeleteEvents(context.Context, string, string) error
+	SaveEvent(context.Context, EventEnvelope) (EventEnvelope, error)
+	LoadEvents(context.Context, string, string) ([]EventEnvelope, error)
+	LookupProcessedEvent(context.Context, string, string, time.Time) (*ProcessedEventRecord, error)
+	TouchProcessedEvent(context.Context, string, string, time.Time, time.Duration) error
+	RememberProcessedEvent(context.Context, ProcessedEventRecord, int) error
+	DeleteProcessedEvent(context.Context, string, string) error
+}

--- a/internal/runtime/adapters/adapter.go
+++ b/internal/runtime/adapters/adapter.go
@@ -1,0 +1,13 @@
+package adapters
+
+import (
+	"context"
+
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+// Adapter normalizes provider-specific payloads into runtime observations.
+type Adapter interface {
+	Source() string
+	Normalize(context.Context, []byte) ([]*runtime.RuntimeObservation, error)
+}

--- a/internal/runtime/adapters/k8saudit/adapter.go
+++ b/internal/runtime/adapters/k8saudit/adapter.go
@@ -1,0 +1,156 @@
+package k8saudit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/runtime"
+	"github.com/writer/cerebro/internal/runtime/adapters"
+)
+
+const sourceName = "kubernetes_audit"
+
+type Adapter struct{}
+
+var _ adapters.Adapter = Adapter{}
+
+type payload struct {
+	Items json.RawMessage `json:"items"`
+}
+
+type event struct {
+	AuditID           string            `json:"auditID"`
+	Stage             string            `json:"stage"`
+	Verb              string            `json:"verb"`
+	RequestURI        string            `json:"requestURI"`
+	UserAgent         string            `json:"userAgent"`
+	SourceIPs         []string          `json:"sourceIPs"`
+	Annotations       map[string]string `json:"annotations"`
+	RequestReceivedAt time.Time         `json:"requestReceivedTimestamp"`
+	StageAt           time.Time         `json:"stageTimestamp"`
+	User              userInfo          `json:"user"`
+	ImpersonatedUser  userInfo          `json:"impersonatedUser"`
+	ObjectRef         objectRef         `json:"objectRef"`
+}
+
+type userInfo struct {
+	Username string   `json:"username"`
+	Groups   []string `json:"groups"`
+}
+
+type objectRef struct {
+	Resource    string `json:"resource"`
+	Namespace   string `json:"namespace"`
+	Name        string `json:"name"`
+	Subresource string `json:"subresource"`
+	APIGroup    string `json:"apiGroup"`
+	APIVersion  string `json:"apiVersion"`
+}
+
+func (Adapter) Source() string {
+	return sourceName
+}
+
+func (Adapter) Normalize(_ context.Context, raw []byte) ([]*runtime.RuntimeObservation, error) {
+	events, err := decode(raw)
+	if err != nil {
+		return nil, err
+	}
+	observations := make([]*runtime.RuntimeObservation, 0, len(events))
+	for _, evt := range events {
+		observations = append(observations, observationFromEvent(evt))
+	}
+	return observations, nil
+}
+
+func decode(raw []byte) ([]event, error) {
+	var list payload
+	if err := json.Unmarshal(raw, &list); err == nil {
+		if list.Items != nil {
+			trimmed := bytes.TrimSpace(list.Items)
+			if bytes.Equal(trimmed, []byte("null")) {
+				return []event{}, nil
+			}
+			var items []event
+			if err := json.Unmarshal(trimmed, &items); err != nil {
+				return nil, fmt.Errorf("decode kubernetes audit list payload: %w", err)
+			}
+			return items, nil
+		}
+	}
+
+	var single event
+	if err := json.Unmarshal(raw, &single); err != nil {
+		return nil, fmt.Errorf("decode kubernetes audit payload: %w", err)
+	}
+	return []event{single}, nil
+}
+
+func observationFromEvent(evt event) *runtime.RuntimeObservation {
+	observedAt := evt.StageAt
+	if observedAt.IsZero() {
+		observedAt = evt.RequestReceivedAt
+	}
+	resourceType := strings.ToLower(evt.ObjectRef.Resource)
+	resourceID := objectRefID(evt.ObjectRef)
+	tags := make([]string, 0, 2)
+	if evt.ObjectRef.Subresource == "exec" {
+		tags = append(tags, "kubectl_exec")
+	}
+	if evt.ObjectRef.Subresource == "attach" {
+		tags = append(tags, "kubectl_attach")
+	}
+
+	return &runtime.RuntimeObservation{
+		ID:           evt.AuditID,
+		Kind:         runtime.ObservationKindKubernetesAudit,
+		Source:       sourceName,
+		ObservedAt:   observedAt,
+		ResourceID:   resourceID,
+		ResourceType: resourceType,
+		Namespace:    evt.ObjectRef.Namespace,
+		PrincipalID:  evt.User.Username,
+		ControlPlane: &runtime.ControlPlaneContext{
+			Source:           sourceName,
+			Verb:             evt.Verb,
+			Stage:            evt.Stage,
+			User:             evt.User.Username,
+			ImpersonatedUser: evt.ImpersonatedUser.Username,
+			UserAgent:        evt.UserAgent,
+			RequestURI:       evt.RequestURI,
+			Resource:         resourceType,
+			Namespace:        evt.ObjectRef.Namespace,
+			Name:             evt.ObjectRef.Name,
+			Subresource:      evt.ObjectRef.Subresource,
+			SourceIPs:        append([]string(nil), evt.SourceIPs...),
+			Annotations:      runtime.CloneStringMap(evt.Annotations),
+		},
+		Tags: tags,
+		Metadata: map[string]any{
+			"audit_api_group":   evt.ObjectRef.APIGroup,
+			"audit_api_version": evt.ObjectRef.APIVersion,
+			"user_groups":       append([]string(nil), evt.User.Groups...),
+		},
+	}
+}
+
+func objectRefID(ref objectRef) string {
+	if ref.Resource == "" {
+		return ""
+	}
+	parts := []string{strings.ToLower(ref.Resource)}
+	if ref.Namespace != "" {
+		parts = append(parts, ref.Namespace)
+	}
+	if ref.Name != "" {
+		parts = append(parts, ref.Name)
+	}
+	if ref.Subresource != "" {
+		parts = append(parts, ref.Subresource)
+	}
+	return strings.Join(parts, ":")
+}

--- a/internal/runtime/adapters/k8saudit/adapter_test.go
+++ b/internal/runtime/adapters/k8saudit/adapter_test.go
@@ -1,0 +1,110 @@
+package k8saudit
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAdapterNormalizeExecEvent(t *testing.T) {
+	raw := []byte(`{
+		"auditID": "audit-1",
+		"stage": "ResponseComplete",
+		"verb": "create",
+		"requestURI": "/api/v1/namespaces/prod/pods/web-7f9f/exec",
+		"userAgent": "kubectl/v1.31.0",
+		"sourceIPs": ["203.0.113.5"],
+		"requestReceivedTimestamp": "2026-03-15T18:25:00Z",
+		"user": {"username": "alice@example.com", "groups": ["system:authenticated"]},
+		"objectRef": {
+			"resource": "pods",
+			"namespace": "prod",
+			"name": "web-7f9f",
+			"subresource": "exec",
+			"apiVersion": "v1"
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+	observation := observations[0]
+	if observation.Kind != "k8s_audit" {
+		t.Fatalf("kind = %s, want k8s_audit", observation.Kind)
+	}
+	if observation.PrincipalID != "alice@example.com" {
+		t.Fatalf("principal_id = %q, want %q", observation.PrincipalID, "alice@example.com")
+	}
+	if observation.ResourceID != "pods:prod:web-7f9f:exec" {
+		t.Fatalf("resource_id = %q, want %q", observation.ResourceID, "pods:prod:web-7f9f:exec")
+	}
+	if len(observation.Tags) != 1 || observation.Tags[0] != "kubectl_exec" {
+		t.Fatalf("tags = %#v, want [kubectl_exec]", observation.Tags)
+	}
+	if observation.ControlPlane == nil || observation.ControlPlane.RequestURI == "" {
+		t.Fatalf("control plane context missing: %#v", observation.ControlPlane)
+	}
+}
+
+func TestAdapterNormalizeListPayload(t *testing.T) {
+	raw := []byte(`{
+		"items": [
+			{
+				"auditID": "audit-1",
+				"verb": "get",
+				"stage": "ResponseComplete",
+				"requestReceivedTimestamp": "2026-03-15T18:25:00Z",
+				"user": {"username": "alice@example.com"},
+				"objectRef": {"resource": "pods", "namespace": "prod", "name": "web-1"}
+			},
+			{
+				"auditID": "audit-2",
+				"verb": "delete",
+				"stage": "ResponseComplete",
+				"requestReceivedTimestamp": "2026-03-15T18:26:00Z",
+				"user": {"username": "bob@example.com"},
+				"objectRef": {"resource": "deployments", "namespace": "prod", "name": "api"}
+			}
+		]
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if len(observations) != 2 {
+		t.Fatalf("len(observations) = %d, want 2", len(observations))
+	}
+	if observations[1].ResourceID != "deployments:prod:api" {
+		t.Fatalf("second resource_id = %q, want %q", observations[1].ResourceID, "deployments:prod:api")
+	}
+}
+
+func TestAdapterNormalizeEmptyListPayload(t *testing.T) {
+	observations, err := (Adapter{}).Normalize(context.Background(), []byte(`{"items":[]}`))
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if len(observations) != 0 {
+		t.Fatalf("len(observations) = %d, want 0", len(observations))
+	}
+}
+
+func TestAdapterNormalizeNullListPayload(t *testing.T) {
+	observations, err := (Adapter{}).Normalize(context.Background(), []byte(`{"items":null}`))
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if len(observations) != 0 {
+		t.Fatalf("len(observations) = %d, want 0", len(observations))
+	}
+}
+
+func TestAdapterNormalizeRejectsMalformedPayload(t *testing.T) {
+	if _, err := (Adapter{}).Normalize(context.Background(), []byte(`{`)); err == nil {
+		t.Fatal("expected error for malformed payload")
+	}
+}

--- a/internal/runtime/adapters/tetragon/adapter.go
+++ b/internal/runtime/adapters/tetragon/adapter.go
@@ -1,0 +1,154 @@
+package tetragon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/runtime"
+	"github.com/writer/cerebro/internal/runtime/adapters"
+)
+
+const sourceName = "tetragon"
+
+type Adapter struct{}
+
+var _ adapters.Adapter = Adapter{}
+
+type payload struct {
+	ProcessExec *processExecEnvelope `json:"process_exec,omitempty"`
+	NodeName    string               `json:"node_name"`
+	Time        time.Time            `json:"time"`
+}
+
+type processExecEnvelope struct {
+	Process processInfo `json:"process"`
+	Parent  processInfo `json:"parent"`
+}
+
+type processInfo struct {
+	ExecID       string    `json:"exec_id"`
+	ParentExecID string    `json:"parent_exec_id"`
+	PID          int       `json:"pid"`
+	UID          int       `json:"uid"`
+	CWD          string    `json:"cwd"`
+	Binary       string    `json:"binary"`
+	Arguments    string    `json:"arguments"`
+	Flags        string    `json:"flags"`
+	StartTime    time.Time `json:"start_time"`
+	Pod          podInfo   `json:"pod"`
+	Docker       string    `json:"docker"`
+}
+
+type podInfo struct {
+	Namespace string            `json:"namespace"`
+	Name      string            `json:"name"`
+	Workload  string            `json:"workload"`
+	Labels    map[string]string `json:"pod_labels"`
+	Container containerInfo     `json:"container"`
+}
+
+type containerInfo struct {
+	ID    string    `json:"id"`
+	Name  string    `json:"name"`
+	Image imageInfo `json:"image"`
+}
+
+type imageInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (Adapter) Source() string {
+	return sourceName
+}
+
+func (Adapter) Normalize(_ context.Context, raw []byte) ([]*runtime.RuntimeObservation, error) {
+	var event payload
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return nil, fmt.Errorf("decode tetragon payload: %w", err)
+	}
+	if event.ProcessExec == nil {
+		return nil, fmt.Errorf("decode tetragon payload: unsupported event")
+	}
+	return []*runtime.RuntimeObservation{observationFromProcessExec(event)}, nil
+}
+
+func observationFromProcessExec(event payload) *runtime.RuntimeObservation {
+	process := event.ProcessExec.Process
+	parent := event.ProcessExec.Parent
+	observedAt := event.Time
+	if observedAt.IsZero() {
+		observedAt = process.StartTime
+	}
+
+	processName := baseNameOrEmpty(process.Binary)
+	parentName := baseNameOrEmpty(parent.Binary)
+	cmdline := strings.TrimSpace(strings.Join([]string{process.Binary, process.Arguments}, " "))
+	resourceID := podResourceID(process.Pod.Namespace, process.Pod.Name)
+	metadata := map[string]any{
+		"exec_id":        process.ExecID,
+		"parent_exec_id": process.ParentExecID,
+		"cwd":            process.CWD,
+		"flags":          process.Flags,
+		"workload_name":  process.Pod.Workload,
+		"pod_labels":     runtime.CloneStringMap(process.Pod.Labels),
+		"node_name":      event.NodeName,
+	}
+
+	workloadRef := ""
+	if process.Pod.Namespace != "" && process.Pod.Workload != "" {
+		workloadRef = "workload:" + process.Pod.Namespace + "/" + process.Pod.Workload
+	}
+
+	return &runtime.RuntimeObservation{
+		ID:           process.ExecID,
+		Kind:         runtime.ObservationKindProcessExec,
+		Source:       sourceName,
+		ObservedAt:   observedAt,
+		ResourceID:   resourceID,
+		ResourceType: "pod",
+		Namespace:    process.Pod.Namespace,
+		NodeName:     event.NodeName,
+		WorkloadRef:  workloadRef,
+		ContainerID:  runtime.FirstNonEmpty(process.Pod.Container.ID, process.Docker),
+		ImageRef:     process.Pod.Container.Image.Name,
+		ImageID:      process.Pod.Container.Image.ID,
+		Process: &runtime.ProcessEvent{
+			PID:        process.PID,
+			Name:       processName,
+			Path:       process.Binary,
+			Cmdline:    cmdline,
+			UID:        process.UID,
+			ParentName: parentName,
+		},
+		Container: &runtime.ContainerEvent{
+			ContainerID:   runtime.FirstNonEmpty(process.Pod.Container.ID, process.Docker),
+			ContainerName: process.Pod.Container.Name,
+			Image:         process.Pod.Container.Image.Name,
+			ImageID:       process.Pod.Container.Image.ID,
+			Namespace:     process.Pod.Namespace,
+			PodName:       process.Pod.Name,
+		},
+		Metadata: metadata,
+		Tags:     []string{"tetragon", "process_exec"},
+	}
+}
+
+func podResourceID(namespace, name string) string {
+	if namespace == "" || name == "" {
+		return ""
+	}
+	return "pod:" + namespace + "/" + name
+}
+
+func baseNameOrEmpty(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	return filepath.Base(path)
+}

--- a/internal/runtime/adapters/tetragon/adapter_test.go
+++ b/internal/runtime/adapters/tetragon/adapter_test.go
@@ -1,0 +1,125 @@
+package tetragon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+func TestAdapterNormalizeProcessExec(t *testing.T) {
+	raw := []byte(`{
+		"process_exec": {
+			"process": {
+				"exec_id": "exec-1",
+				"pid": 52699,
+				"uid": 0,
+				"cwd": "/",
+				"binary": "/usr/bin/curl",
+				"arguments": "https://ebpf.io/applications/#tetragon",
+				"flags": "execve rootcwd",
+				"start_time": "2023-10-06T22:03:57.700327580Z",
+				"pod": {
+					"namespace": "default",
+					"name": "xwing",
+					"workload": "xwing",
+					"container": {
+						"id": "containerd://abc",
+						"name": "spaceship",
+						"image": {
+							"id": "docker.io/tgraf/netperf@sha256:deadbeef",
+							"name": "docker.io/tgraf/netperf:latest"
+						}
+					},
+					"pod_labels": {
+						"app.kubernetes.io/name": "xwing"
+					}
+				},
+				"docker": "abc",
+				"parent_exec_id": "parent-1"
+			},
+			"parent": {
+				"binary": "/bin/bash",
+				"arguments": "-c curl https://ebpf.io/applications/#tetragon"
+			}
+		},
+		"node_name": "worker-1",
+		"time": "2023-10-06T22:03:57.700326678Z"
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+	observation := observations[0]
+	if observation.Kind != runtime.ObservationKindProcessExec {
+		t.Fatalf("kind = %s, want %s", observation.Kind, runtime.ObservationKindProcessExec)
+	}
+	if observation.ResourceID != "pod:default/xwing" {
+		t.Fatalf("resource_id = %q, want %q", observation.ResourceID, "pod:default/xwing")
+	}
+	if observation.Process == nil || observation.Process.Name != "curl" {
+		t.Fatalf("process = %#v, want curl", observation.Process)
+	}
+	if observation.Process.ParentName != "bash" {
+		t.Fatalf("parent_name = %q, want %q", observation.Process.ParentName, "bash")
+	}
+	if observation.WorkloadRef != "workload:default/xwing" {
+		t.Fatalf("workload_ref = %q, want %q", observation.WorkloadRef, "workload:default/xwing")
+	}
+}
+
+func TestAdapterNormalizeUnsupportedEvent(t *testing.T) {
+	raw := []byte(`{"process_exit":{"process":{"exec_id":"exec-1"}}}`)
+	if _, err := (Adapter{}).Normalize(context.Background(), raw); err == nil {
+		t.Fatal("expected unsupported event error")
+	}
+}
+
+func TestAdapterNormalizeEmptyBinaryDoesNotEmitDotNames(t *testing.T) {
+	raw := []byte(`{
+		"process_exec": {
+			"process": {
+				"exec_id": "exec-2",
+				"pid": 100,
+				"uid": 0,
+				"binary": "",
+				"arguments": "",
+				"pod": {
+					"namespace": "default",
+					"name": "xwing",
+					"container": {
+						"id": "containerd://abc",
+						"name": "spaceship",
+						"image": {
+							"id": "sha256:deadbeef",
+							"name": "docker.io/tgraf/netperf:latest"
+						}
+					}
+				}
+			},
+			"parent": {
+				"binary": ""
+			}
+		},
+		"time": "2023-10-06T22:03:57.700326678Z"
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	observation := observations[0]
+	if observation.Process == nil {
+		t.Fatal("expected process context")
+	}
+	if observation.Process.Name != "" {
+		t.Fatalf("process name = %q, want empty", observation.Process.Name)
+	}
+	if observation.Process.ParentName != "" {
+		t.Fatalf("parent name = %q, want empty", observation.Process.ParentName)
+	}
+}

--- a/internal/runtime/detections.go
+++ b/internal/runtime/detections.go
@@ -155,19 +155,20 @@ type ContainerEvent struct {
 
 // RuntimeFinding represents a detected threat
 type RuntimeFinding struct {
-	ID           string            `json:"id"`
-	RuleID       string            `json:"rule_id"`
-	RuleName     string            `json:"rule_name"`
-	Category     DetectionCategory `json:"category"`
-	Severity     string            `json:"severity"`
-	ResourceID   string            `json:"resource_id"`
-	ResourceType string            `json:"resource_type"`
-	Description  string            `json:"description"`
-	Event        *RuntimeEvent     `json:"event"`
-	MITRE        []string          `json:"mitre_attack"`
-	Remediation  string            `json:"remediation"`
-	Suppressed   bool              `json:"suppressed"`
-	Timestamp    time.Time         `json:"timestamp"`
+	ID           string              `json:"id"`
+	RuleID       string              `json:"rule_id"`
+	RuleName     string              `json:"rule_name"`
+	Category     DetectionCategory   `json:"category"`
+	Severity     string              `json:"severity"`
+	ResourceID   string              `json:"resource_id"`
+	ResourceType string              `json:"resource_type"`
+	Description  string              `json:"description"`
+	Event        *RuntimeEvent       `json:"event"`
+	Observation  *RuntimeObservation `json:"observation,omitempty"`
+	MITRE        []string            `json:"mitre_attack"`
+	Remediation  string              `json:"remediation"`
+	Suppressed   bool                `json:"suppressed"`
+	Timestamp    time.Time           `json:"timestamp"`
 }
 
 func NewDetectionEngine() *DetectionEngine {
@@ -473,6 +474,22 @@ func (e *DetectionEngine) loadDefaultRules() {
 
 // ProcessEvent evaluates an event against all rules and stores resulting findings
 func (e *DetectionEngine) ProcessEvent(ctx context.Context, event *RuntimeEvent) []RuntimeFinding {
+	return e.process(ctx, event, ObservationFromEvent(event))
+}
+
+// ProcessObservation evaluates a normalized runtime observation against all
+// rules while preserving a legacy event representation for existing consumers.
+func (e *DetectionEngine) ProcessObservation(ctx context.Context, observation *RuntimeObservation) []RuntimeFinding {
+	if observation == nil {
+		return nil
+	}
+	return e.process(ctx, observation.AsRuntimeEvent(), observation)
+}
+
+func (e *DetectionEngine) process(_ context.Context, event *RuntimeEvent, observation *RuntimeObservation) []RuntimeFinding {
+	if event == nil {
+		return nil
+	}
 	var findings []RuntimeFinding
 
 	for _, rule := range e.rules {
@@ -491,6 +508,7 @@ func (e *DetectionEngine) ProcessEvent(ctx context.Context, event *RuntimeEvent)
 				ResourceType: event.ResourceType,
 				Description:  rule.Description,
 				Event:        event,
+				Observation:  observation,
 				MITRE:        rule.MITRE,
 				Remediation:  getRemediation(rule),
 				Suppressed:   e.suppressions[rule.ID],

--- a/internal/runtime/helpers.go
+++ b/internal/runtime/helpers.go
@@ -1,0 +1,9 @@
+package runtime
+
+func CloneStringMap(input map[string]string) map[string]string {
+	return cloneRuntimeStringMap(input)
+}
+
+func FirstNonEmpty(values ...string) string {
+	return firstNonEmptyRuntime(values...)
+}

--- a/internal/runtime/observations.go
+++ b/internal/runtime/observations.go
@@ -1,0 +1,353 @@
+package runtime
+
+import (
+	"strings"
+	"time"
+)
+
+const runtimeObservationLegacyEventTypeKey = "legacy_event_type"
+
+type RuntimeObservationKind string
+
+const (
+	ObservationKindProcessExec     RuntimeObservationKind = "process_exec"
+	ObservationKindProcessExit     RuntimeObservationKind = "process_exit"
+	ObservationKindFileOpen        RuntimeObservationKind = "file_open"
+	ObservationKindFileWrite       RuntimeObservationKind = "file_write"
+	ObservationKindNetworkFlow     RuntimeObservationKind = "network_flow"
+	ObservationKindDNSQuery        RuntimeObservationKind = "dns_query"
+	ObservationKindKubernetesAudit RuntimeObservationKind = "k8s_audit"
+	ObservationKindRuntimeAlert    RuntimeObservationKind = "runtime_alert"
+	ObservationKindTraceLink       RuntimeObservationKind = "trace_link"
+	ObservationKindResponseOutcome RuntimeObservationKind = "response_outcome"
+	ObservationKindUnknown         RuntimeObservationKind = "unknown"
+)
+
+type ControlPlaneContext struct {
+	Source           string            `json:"source,omitempty"`
+	Verb             string            `json:"verb,omitempty"`
+	Stage            string            `json:"stage,omitempty"`
+	User             string            `json:"user,omitempty"`
+	ImpersonatedUser string            `json:"impersonated_user,omitempty"`
+	UserAgent        string            `json:"user_agent,omitempty"`
+	RequestURI       string            `json:"request_uri,omitempty"`
+	Resource         string            `json:"resource,omitempty"`
+	Namespace        string            `json:"namespace,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Subresource      string            `json:"subresource,omitempty"`
+	SourceIPs        []string          `json:"source_ips,omitempty"`
+	Annotations      map[string]string `json:"annotations,omitempty"`
+}
+
+type TraceContext struct {
+	TraceID     string `json:"trace_id,omitempty"`
+	SpanID      string `json:"span_id,omitempty"`
+	ServiceName string `json:"service_name,omitempty"`
+}
+
+type RuntimeObservation struct {
+	ID           string                 `json:"id"`
+	Kind         RuntimeObservationKind `json:"kind"`
+	Source       string                 `json:"source"`
+	ObservedAt   time.Time              `json:"observed_at"`
+	RecordedAt   time.Time              `json:"recorded_at,omitempty"`
+	ResourceID   string                 `json:"resource_id,omitempty"`
+	ResourceType string                 `json:"resource_type,omitempty"`
+
+	Cluster     string `json:"cluster,omitempty"`
+	Namespace   string `json:"namespace,omitempty"`
+	NodeName    string `json:"node_name,omitempty"`
+	WorkloadRef string `json:"workload_ref,omitempty"`
+	WorkloadUID string `json:"workload_uid,omitempty"`
+	ContainerID string `json:"container_id,omitempty"`
+	ImageRef    string `json:"image_ref,omitempty"`
+	ImageID     string `json:"image_id,omitempty"`
+	PrincipalID string `json:"principal_id,omitempty"`
+
+	Process      *ProcessEvent        `json:"process,omitempty"`
+	Network      *NetworkEvent        `json:"network,omitempty"`
+	File         *FileEvent           `json:"file,omitempty"`
+	Container    *ContainerEvent      `json:"container,omitempty"`
+	ControlPlane *ControlPlaneContext `json:"control_plane,omitempty"`
+	Trace        *TraceContext        `json:"trace,omitempty"`
+	Tags         []string             `json:"tags,omitempty"`
+	Metadata     map[string]any       `json:"metadata,omitempty"`
+	Raw          map[string]any       `json:"raw,omitempty"`
+	Provenance   map[string]any       `json:"provenance,omitempty"`
+}
+
+func ObservationFromEvent(event *RuntimeEvent) *RuntimeObservation {
+	if event == nil {
+		return nil
+	}
+
+	observation := &RuntimeObservation{
+		ID:           event.ID,
+		Kind:         observationKindFromEvent(event),
+		Source:       event.Source,
+		ObservedAt:   event.Timestamp,
+		ResourceID:   event.ResourceID,
+		ResourceType: event.ResourceType,
+		Process:      cloneProcessEvent(event.Process),
+		Network:      cloneNetworkEvent(event.Network),
+		File:         cloneFileEvent(event.File),
+		Container:    cloneContainerEvent(event.Container),
+		Metadata:     cloneRuntimeAnyMap(event.Metadata),
+	}
+	if strings.TrimSpace(event.EventType) != "" {
+		if observation.Metadata == nil {
+			observation.Metadata = make(map[string]any, 1)
+		}
+		observation.Metadata[runtimeObservationLegacyEventTypeKey] = strings.TrimSpace(event.EventType)
+	}
+
+	if event.Container != nil {
+		observation.Namespace = event.Container.Namespace
+		observation.ContainerID = event.Container.ContainerID
+		observation.ImageRef = event.Container.Image
+		observation.ImageID = event.Container.ImageID
+	}
+
+	if observation.Metadata != nil {
+		observation.Cluster = stringMapValue(observation.Metadata, "cluster")
+		observation.NodeName = firstNonEmptyRuntime(stringMapValue(observation.Metadata, "node_name"), stringMapValue(observation.Metadata, "node"))
+		observation.WorkloadRef = stringMapValue(observation.Metadata, "workload_ref")
+		observation.WorkloadUID = stringMapValue(observation.Metadata, "workload_uid")
+		observation.PrincipalID = firstNonEmptyRuntime(
+			stringMapValue(observation.Metadata, "principal_id"),
+			stringMapValue(observation.Metadata, "credential_id"),
+			stringMapValue(observation.Metadata, "access_key_id"),
+		)
+		if observation.Namespace == "" {
+			observation.Namespace = firstNonEmptyRuntime(
+				stringMapValue(observation.Metadata, "namespace"),
+				stringMapValue(observation.Metadata, "kubernetes_namespace"),
+			)
+		}
+	}
+
+	return observation
+}
+
+func (o *RuntimeObservation) AsRuntimeEvent() *RuntimeEvent {
+	if o == nil {
+		return nil
+	}
+
+	event := &RuntimeEvent{
+		ID:           o.ID,
+		Timestamp:    o.ObservedAt,
+		Source:       o.Source,
+		ResourceID:   firstNonEmptyRuntime(o.ResourceID, o.WorkloadRef, o.ContainerID),
+		ResourceType: firstNonEmptyRuntime(o.ResourceType, observationResourceType(o)),
+		EventType:    legacyEventTypeFromObservation(o),
+		Process:      cloneProcessEvent(o.Process),
+		Network:      cloneNetworkEvent(o.Network),
+		File:         cloneFileEvent(o.File),
+		Container:    cloneContainerEvent(o.Container),
+		Metadata:     cloneRuntimeAnyMap(o.Metadata),
+	}
+
+	if event.Metadata == nil {
+		event.Metadata = make(map[string]any)
+	}
+	addMetadataString(event.Metadata, "cluster", o.Cluster)
+	addMetadataString(event.Metadata, "node_name", o.NodeName)
+	addMetadataString(event.Metadata, "namespace", o.Namespace)
+	addMetadataString(event.Metadata, "workload_ref", o.WorkloadRef)
+	addMetadataString(event.Metadata, "workload_uid", o.WorkloadUID)
+	addMetadataString(event.Metadata, "principal_id", o.PrincipalID)
+	addMetadataString(event.Metadata, "container_id", o.ContainerID)
+	addMetadataString(event.Metadata, "image_ref", o.ImageRef)
+	addMetadataString(event.Metadata, "image_id", o.ImageID)
+
+	if o.Trace != nil {
+		addMetadataString(event.Metadata, "trace_id", o.Trace.TraceID)
+		addMetadataString(event.Metadata, "span_id", o.Trace.SpanID)
+		addMetadataString(event.Metadata, "service_name", o.Trace.ServiceName)
+	}
+	if o.ControlPlane != nil {
+		addMetadataString(event.Metadata, "audit_source", o.ControlPlane.Source)
+		addMetadataString(event.Metadata, "audit_verb", o.ControlPlane.Verb)
+		addMetadataString(event.Metadata, "audit_stage", o.ControlPlane.Stage)
+		addMetadataString(event.Metadata, "audit_user", o.ControlPlane.User)
+		addMetadataString(event.Metadata, "audit_impersonated_user", o.ControlPlane.ImpersonatedUser)
+		addMetadataString(event.Metadata, "audit_user_agent", o.ControlPlane.UserAgent)
+		addMetadataString(event.Metadata, "audit_request_uri", o.ControlPlane.RequestURI)
+		addMetadataString(event.Metadata, "audit_resource", o.ControlPlane.Resource)
+		addMetadataString(event.Metadata, "audit_subresource", o.ControlPlane.Subresource)
+		if len(o.ControlPlane.SourceIPs) > 0 {
+			event.Metadata["audit_source_ips"] = append([]string(nil), o.ControlPlane.SourceIPs...)
+		}
+		if len(o.ControlPlane.Annotations) > 0 {
+			event.Metadata["audit_annotations"] = cloneRuntimeStringMap(o.ControlPlane.Annotations)
+		}
+	}
+
+	return event
+}
+
+func observationFromResponseExecution(execution *ResponseExecution, action *ActionExecution) *RuntimeObservation {
+	if execution == nil || action == nil {
+		return nil
+	}
+
+	observedAt := action.StartTime
+	if action.EndTime != nil {
+		observedAt = *action.EndTime
+	} else if execution.EndTime != nil {
+		observedAt = *execution.EndTime
+	}
+
+	metadata := map[string]any{
+		"policy_id":        execution.PolicyID,
+		"policy_name":      execution.PolicyName,
+		"execution_id":     execution.ID,
+		"execution_status": execution.Status,
+		"trigger_event":    execution.TriggerEvent,
+		"action_type":      action.Type,
+		"action_status":    action.Status,
+		"approved_by":      execution.ApprovedBy,
+		"approved_at":      execution.ApprovedAt,
+	}
+	if action.Output != "" {
+		metadata["action_output"] = action.Output
+	}
+	if action.Error != "" {
+		metadata["action_error"] = action.Error
+	}
+	if execution.Error != "" {
+		metadata["execution_error"] = execution.Error
+	}
+
+	return &RuntimeObservation{
+		ID:           execution.ID + ":" + string(action.Type),
+		Kind:         ObservationKindResponseOutcome,
+		Source:       "runtime_response",
+		ObservedAt:   observedAt,
+		ResourceID:   execution.ResourceID,
+		ResourceType: execution.ResourceType,
+		Metadata:     metadata,
+		Tags:         []string{"response_outcome"},
+	}
+}
+
+func observationKindFromEvent(event *RuntimeEvent) RuntimeObservationKind {
+	if event == nil {
+		return ObservationKindUnknown
+	}
+	switch event.EventType {
+	case "process":
+		return ObservationKindProcessExec
+	case "network":
+		if event.Network != nil && event.Network.Domain != "" {
+			return ObservationKindDNSQuery
+		}
+		return ObservationKindNetworkFlow
+	case "file":
+		if event.File != nil && event.File.Operation == "read" {
+			return ObservationKindFileOpen
+		}
+		return ObservationKindFileWrite
+	default:
+		return ObservationKindUnknown
+	}
+}
+
+func legacyEventTypeFromObservation(observation *RuntimeObservation) string {
+	if observation == nil {
+		return ""
+	}
+	if eventType := stringMapValue(observation.Metadata, runtimeObservationLegacyEventTypeKey); eventType != "" {
+		return eventType
+	}
+	switch observation.Kind {
+	case ObservationKindProcessExec, ObservationKindProcessExit:
+		return "process"
+	case ObservationKindNetworkFlow, ObservationKindDNSQuery:
+		return "network"
+	case ObservationKindFileOpen, ObservationKindFileWrite:
+		return "file"
+	default:
+		switch {
+		case observation.Process != nil:
+			return "process"
+		case observation.Network != nil:
+			return "network"
+		case observation.File != nil:
+			return "file"
+		default:
+			return string(observation.Kind)
+		}
+	}
+}
+
+func observationResourceType(observation *RuntimeObservation) string {
+	switch {
+	case observation.ContainerID != "":
+		return "container"
+	case observation.WorkloadRef != "":
+		return "workload"
+	case observation.ControlPlane != nil && observation.ControlPlane.Resource != "":
+		return observation.ControlPlane.Resource
+	default:
+		return ""
+	}
+}
+
+func addMetadataString(metadata map[string]any, key, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	metadata[key] = value
+}
+
+func stringMapValue(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	value, ok := metadata[key]
+	if !ok {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return ""
+	}
+}
+
+func cloneProcessEvent(input *ProcessEvent) *ProcessEvent {
+	if input == nil {
+		return nil
+	}
+	cloned := *input
+	cloned.Ancestors = append([]string(nil), input.Ancestors...)
+	return &cloned
+}
+
+func cloneNetworkEvent(input *NetworkEvent) *NetworkEvent {
+	if input == nil {
+		return nil
+	}
+	cloned := *input
+	return &cloned
+}
+
+func cloneFileEvent(input *FileEvent) *FileEvent {
+	if input == nil {
+		return nil
+	}
+	cloned := *input
+	return &cloned
+}
+
+func cloneContainerEvent(input *ContainerEvent) *ContainerEvent {
+	if input == nil {
+		return nil
+	}
+	cloned := *input
+	cloned.Capabilities = append([]string(nil), input.Capabilities...)
+	return &cloned
+}

--- a/internal/runtime/observations_test.go
+++ b/internal/runtime/observations_test.go
@@ -1,0 +1,256 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestObservationRoundTripPreservesDetectionFields(t *testing.T) {
+	event := &RuntimeEvent{
+		ID:           "event-1",
+		Timestamp:    time.Date(2026, 3, 15, 20, 0, 0, 0, time.UTC),
+		Source:       "agent-1",
+		ResourceID:   "pod:prod/web",
+		ResourceType: "pod",
+		EventType:    "process",
+		Process: &ProcessEvent{
+			Name:       "xmrig",
+			Cmdline:    "xmrig --url pool.example.com",
+			ParentName: "bash",
+		},
+		Container: &ContainerEvent{
+			ContainerID: "ctr-1",
+			Namespace:   "prod",
+			Image:       "ghcr.io/acme/web:1.2.3",
+			ImageID:     "sha256:abc",
+		},
+		Metadata: map[string]any{
+			"cluster":      "prod-west",
+			"principal_id": "system:serviceaccount:prod:web",
+			"trace_id":     "trace-1",
+		},
+	}
+
+	observation := ObservationFromEvent(event)
+	if observation == nil {
+		t.Fatal("expected observation")
+	}
+	if observation.Kind != ObservationKindProcessExec {
+		t.Fatalf("kind = %s, want %s", observation.Kind, ObservationKindProcessExec)
+	}
+	if observation.PrincipalID != "system:serviceaccount:prod:web" {
+		t.Fatalf("principal_id = %q, want %q", observation.PrincipalID, "system:serviceaccount:prod:web")
+	}
+
+	roundTrip := observation.AsRuntimeEvent()
+	if roundTrip == nil {
+		t.Fatal("expected round-trip event")
+	}
+	if roundTrip.Process == nil || roundTrip.Process.Name != "xmrig" {
+		t.Fatalf("round-trip process = %#v", roundTrip.Process)
+	}
+	if roundTrip.Metadata["cluster"] != "prod-west" {
+		t.Fatalf("cluster metadata = %#v, want %q", roundTrip.Metadata["cluster"], "prod-west")
+	}
+}
+
+func TestObservationRoundTripPreservesCustomEventType(t *testing.T) {
+	event := &RuntimeEvent{
+		ID:           "event-custom-1",
+		Timestamp:    time.Date(2026, 3, 15, 20, 1, 0, 0, time.UTC),
+		Source:       "custom-agent",
+		ResourceID:   "pod:prod/web",
+		ResourceType: "pod",
+		EventType:    "tracepoint",
+		Process: &ProcessEvent{
+			Name:    "xmrig",
+			Cmdline: "xmrig --url pool.example.com",
+		},
+	}
+
+	observation := ObservationFromEvent(event)
+	if observation == nil {
+		t.Fatal("expected observation")
+	}
+	if got := stringMapValue(observation.Metadata, runtimeObservationLegacyEventTypeKey); got != "tracepoint" {
+		t.Fatalf("legacy event type metadata = %q, want %q", got, "tracepoint")
+	}
+
+	roundTrip := observation.AsRuntimeEvent()
+	if roundTrip == nil {
+		t.Fatal("expected round-trip event")
+	}
+	if roundTrip.EventType != "tracepoint" {
+		t.Fatalf("round-trip event_type = %q, want %q", roundTrip.EventType, "tracepoint")
+	}
+
+	findings := NewDetectionEngine().ProcessObservation(context.Background(), observation)
+	if len(findings) != 1 {
+		t.Fatalf("len(findings) = %d, want 1", len(findings))
+	}
+	if findings[0].Event == nil {
+		t.Fatal("expected finding event")
+	}
+	if findings[0].Event.EventType != "tracepoint" {
+		t.Fatalf("finding event_type = %q, want %q", findings[0].Event.EventType, "tracepoint")
+	}
+}
+
+func TestLegacyEventTypeFromObservationNil(t *testing.T) {
+	if got := legacyEventTypeFromObservation(nil); got != "" {
+		t.Fatalf("legacyEventTypeFromObservation(nil) = %q, want empty string", got)
+	}
+}
+
+func TestObservationRoundTripDoesNotAliasMutableFields(t *testing.T) {
+	event := &RuntimeEvent{
+		ID:           "event-1",
+		Timestamp:    time.Date(2026, 3, 15, 20, 0, 0, 0, time.UTC),
+		Source:       "agent-1",
+		ResourceID:   "pod:prod/web",
+		ResourceType: "pod",
+		EventType:    "process",
+		Process: &ProcessEvent{
+			Name:      "xmrig",
+			Ancestors: []string{"containerd", "bash"},
+		},
+		Network: &NetworkEvent{
+			DstIP:   "203.0.113.10",
+			DstPort: 443,
+		},
+		File: &FileEvent{
+			Operation: "write",
+			Path:      "/tmp/miner",
+		},
+		Container: &ContainerEvent{
+			ContainerID:  "ctr-1",
+			Namespace:    "prod",
+			Capabilities: []string{"CAP_NET_RAW"},
+		},
+		Metadata: map[string]any{
+			"cluster": "prod-west",
+		},
+	}
+
+	observation := ObservationFromEvent(event)
+	if observation == nil {
+		t.Fatal("expected observation")
+	}
+	if observation.Process == event.Process || observation.Network == event.Network || observation.File == event.File || observation.Container == event.Container {
+		t.Fatal("expected observation conversion to clone mutable event sub-structs")
+	}
+
+	event.Process.Name = "bash"
+	event.Process.Ancestors[0] = "mutated"
+	event.Network.DstIP = "198.51.100.10"
+	event.File.Path = "/tmp/other"
+	event.Container.Namespace = "other"
+	event.Container.Capabilities[0] = "CAP_SYS_ADMIN"
+	if observation.Process.Name != "xmrig" || observation.Process.Ancestors[0] != "containerd" {
+		t.Fatalf("observation process mutated with event: %#v", observation.Process)
+	}
+	if observation.Network.DstIP != "203.0.113.10" {
+		t.Fatalf("observation network mutated with event: %#v", observation.Network)
+	}
+	if observation.File.Path != "/tmp/miner" {
+		t.Fatalf("observation file mutated with event: %#v", observation.File)
+	}
+	if observation.Container.Namespace != "prod" || observation.Container.Capabilities[0] != "CAP_NET_RAW" {
+		t.Fatalf("observation container mutated with event: %#v", observation.Container)
+	}
+
+	roundTrip := observation.AsRuntimeEvent()
+	if roundTrip == nil {
+		t.Fatal("expected round-trip event")
+	}
+	if roundTrip.Process == observation.Process || roundTrip.Network == observation.Network || roundTrip.File == observation.File || roundTrip.Container == observation.Container {
+		t.Fatal("expected runtime event conversion to clone mutable observation sub-structs")
+	}
+
+	observation.Process.Name = "curl"
+	observation.Process.Ancestors[0] = "changed"
+	observation.Network.DstIP = "192.0.2.1"
+	observation.File.Path = "/tmp/final"
+	observation.Container.Namespace = "staging"
+	observation.Container.Capabilities[0] = "CAP_CHOWN"
+	if roundTrip.Process.Name != "xmrig" || roundTrip.Process.Ancestors[0] != "containerd" {
+		t.Fatalf("round-trip process mutated with observation: %#v", roundTrip.Process)
+	}
+	if roundTrip.Network.DstIP != "203.0.113.10" {
+		t.Fatalf("round-trip network mutated with observation: %#v", roundTrip.Network)
+	}
+	if roundTrip.File.Path != "/tmp/miner" {
+		t.Fatalf("round-trip file mutated with observation: %#v", roundTrip.File)
+	}
+	if roundTrip.Container.Namespace != "prod" || roundTrip.Container.Capabilities[0] != "CAP_NET_RAW" {
+		t.Fatalf("round-trip container mutated with observation: %#v", roundTrip.Container)
+	}
+}
+
+func TestDetectionEngineProcessObservation(t *testing.T) {
+	engine := NewDetectionEngine()
+	observation := &RuntimeObservation{
+		ID:         "obs-1",
+		Kind:       ObservationKindProcessExec,
+		Source:     "tetragon",
+		ObservedAt: time.Now(),
+		Process: &ProcessEvent{
+			Name:    "xmrig",
+			Cmdline: "xmrig --pool stratum://pool.example.com",
+		},
+		Container: &ContainerEvent{
+			ContainerID: "ctr-1",
+		},
+	}
+
+	findings := engine.ProcessObservation(context.Background(), observation)
+	if len(findings) != 1 {
+		t.Fatalf("len(findings) = %d, want 1", len(findings))
+	}
+	if findings[0].Observation == nil {
+		t.Fatal("expected finding observation to be populated")
+	}
+	if findings[0].Event == nil || findings[0].Event.Process == nil {
+		t.Fatalf("expected legacy event compatibility on finding, got %#v", findings[0].Event)
+	}
+	if findings[0].Event.Process == findings[0].Observation.Process {
+		t.Fatal("expected finding event and observation to keep independent process structs")
+	}
+}
+
+func TestObservationFromResponseExecution(t *testing.T) {
+	endTime := time.Date(2026, 3, 15, 21, 0, 0, 0, time.UTC)
+	execution := &ResponseExecution{
+		ID:           "exec-1",
+		PolicyID:     "policy-1",
+		PolicyName:   "Block suspicious egress",
+		TriggerEvent: "finding-1",
+		Status:       StatusCompleted,
+		ResourceID:   "deployment:prod/web",
+		ResourceType: "deployment",
+		ApprovedBy:   "alice",
+		EndTime:      &endTime,
+	}
+	action := &ActionExecution{
+		Type:      ActionBlockIP,
+		Status:    StatusCompleted,
+		StartTime: endTime.Add(-5 * time.Second),
+		EndTime:   &endTime,
+		Output:    "blocked 203.0.113.10",
+	}
+
+	observation := observationFromResponseExecution(execution, action)
+	if observation == nil {
+		t.Fatal("expected observation")
+	}
+	if observation.Kind != ObservationKindResponseOutcome {
+		t.Fatalf("kind = %s, want %s", observation.Kind, ObservationKindResponseOutcome)
+	}
+	if observation.Metadata["action_type"] != ActionBlockIP {
+		t.Fatalf("action_type = %#v, want %s", observation.Metadata["action_type"], ActionBlockIP)
+	}
+	if observation.ResourceID != "deployment:prod/web" {
+		t.Fatalf("resource_id = %q, want %q", observation.ResourceID, "deployment:prod/web")
+	}
+}

--- a/internal/runtime/store.go
+++ b/internal/runtime/store.go
@@ -1,0 +1,298 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+const runtimeIngestNamespace = executionstore.NamespaceRuntimeIngest
+
+type IngestRunStatus string
+
+const (
+	IngestRunStatusQueued    IngestRunStatus = "queued"
+	IngestRunStatusRunning   IngestRunStatus = "running"
+	IngestRunStatusCompleted IngestRunStatus = "completed"
+	IngestRunStatusFailed    IngestRunStatus = "failed"
+)
+
+type IngestRunRecord struct {
+	ID               string            `json:"id"`
+	Source           string            `json:"source"`
+	Status           IngestRunStatus   `json:"status"`
+	Stage            string            `json:"stage"`
+	SubmittedAt      time.Time         `json:"submitted_at"`
+	StartedAt        *time.Time        `json:"started_at,omitempty"`
+	CompletedAt      *time.Time        `json:"completed_at,omitempty"`
+	UpdatedAt        time.Time         `json:"updated_at"`
+	ObservationCount int               `json:"observation_count,omitempty"`
+	FindingCount     int               `json:"finding_count,omitempty"`
+	Error            string            `json:"error,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+	LastCheckpoint   *IngestCheckpoint `json:"last_checkpoint,omitempty"`
+}
+
+type IngestCheckpoint struct {
+	Cursor     string            `json:"cursor"`
+	RecordedAt time.Time         `json:"recorded_at"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+}
+
+type IngestEvent struct {
+	Type       string         `json:"type"`
+	Sequence   int64          `json:"sequence"`
+	RecordedAt time.Time      `json:"recorded_at"`
+	Data       map[string]any `json:"data,omitempty"`
+}
+
+type IngestRunListOptions struct {
+	Statuses           []IngestRunStatus
+	Limit              int
+	Offset             int
+	OrderBySubmittedAt bool
+	ActiveOnly         bool
+}
+
+type IngestStore interface {
+	Close() error
+	SaveRun(context.Context, *IngestRunRecord) error
+	LoadRun(context.Context, string) (*IngestRunRecord, error)
+	ListRuns(context.Context, IngestRunListOptions) ([]IngestRunRecord, error)
+	AppendEvent(context.Context, string, IngestEvent) (IngestEvent, error)
+	LoadEvents(context.Context, string) ([]IngestEvent, error)
+	SaveCheckpoint(context.Context, string, IngestCheckpoint) (IngestCheckpoint, error)
+	LoadCheckpoint(context.Context, string) (*IngestCheckpoint, error)
+}
+
+type SQLiteIngestStore struct {
+	store     executionstore.Store
+	ownsStore bool
+}
+
+func NewSQLiteIngestStore(path string) (*SQLiteIngestStore, error) {
+	store, err := executionstore.NewSQLiteStore(path)
+	if err != nil {
+		return nil, err
+	}
+	ingestStore := NewSQLiteIngestStoreWithExecutionStore(store)
+	ingestStore.ownsStore = true
+	return ingestStore, nil
+}
+
+func NewSQLiteIngestStoreWithExecutionStore(store executionstore.Store) *SQLiteIngestStore {
+	return &SQLiteIngestStore{store: store}
+}
+
+func (s *SQLiteIngestStore) Close() error {
+	if s == nil || s.store == nil || !s.ownsStore {
+		return nil
+	}
+	return s.store.Close()
+}
+
+func (s *SQLiteIngestStore) SaveRun(ctx context.Context, run *IngestRunRecord) error {
+	if s == nil || s.store == nil || run == nil {
+		return nil
+	}
+	env, err := runtimeIngestRunEnvelope(run)
+	if err != nil {
+		return err
+	}
+	return s.store.UpsertRun(ctx, env)
+}
+
+func (s *SQLiteIngestStore) LoadRun(ctx context.Context, runID string) (*IngestRunRecord, error) {
+	if s == nil || s.store == nil {
+		return nil, nil
+	}
+	env, err := s.store.LoadRun(ctx, runtimeIngestNamespace, strings.TrimSpace(runID))
+	if err != nil {
+		return nil, err
+	}
+	if env == nil {
+		return nil, nil
+	}
+	return runtimeIngestRunFromEnvelope(env)
+}
+
+func (s *SQLiteIngestStore) ListRuns(ctx context.Context, opts IngestRunListOptions) ([]IngestRunRecord, error) {
+	if s == nil || s.store == nil {
+		return nil, nil
+	}
+	query := executionstore.RunListOptions{
+		Statuses:           ingestStatusesToStrings(opts.Statuses),
+		Limit:              opts.Limit,
+		Offset:             opts.Offset,
+		OrderBySubmittedAt: opts.OrderBySubmittedAt,
+	}
+	if opts.ActiveOnly {
+		query.ExcludeStatuses = []string{string(IngestRunStatusCompleted), string(IngestRunStatusFailed)}
+	}
+	envs, err := s.store.ListRuns(ctx, runtimeIngestNamespace, query)
+	if err != nil {
+		return nil, err
+	}
+	runs := make([]IngestRunRecord, 0, len(envs))
+	for _, env := range envs {
+		run, err := runtimeIngestRunFromEnvelope(&env)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, *run)
+	}
+	return runs, nil
+}
+
+func (s *SQLiteIngestStore) AppendEvent(ctx context.Context, runID string, event IngestEvent) (IngestEvent, error) {
+	if s == nil || s.store == nil {
+		return event, nil
+	}
+	if event.RecordedAt.IsZero() {
+		event.RecordedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return event, fmt.Errorf("encode runtime ingest event: %w", err)
+	}
+	env, err := s.store.SaveEvent(ctx, executionstore.EventEnvelope{
+		Namespace:  runtimeIngestNamespace,
+		RunID:      strings.TrimSpace(runID),
+		Sequence:   event.Sequence,
+		RecordedAt: event.RecordedAt,
+		Payload:    payload,
+	})
+	if err != nil {
+		return event, err
+	}
+	event.Sequence = env.Sequence
+	event.RecordedAt = env.RecordedAt
+	return event, nil
+}
+
+func (s *SQLiteIngestStore) LoadEvents(ctx context.Context, runID string) ([]IngestEvent, error) {
+	if s == nil || s.store == nil {
+		return nil, nil
+	}
+	envs, err := s.store.LoadEvents(ctx, runtimeIngestNamespace, strings.TrimSpace(runID))
+	if err != nil {
+		return nil, err
+	}
+	events := make([]IngestEvent, 0, len(envs))
+	for _, env := range envs {
+		var event IngestEvent
+		if err := json.Unmarshal(env.Payload, &event); err != nil {
+			return nil, fmt.Errorf("decode runtime ingest event payload: %w", err)
+		}
+		event.Sequence = env.Sequence
+		event.RecordedAt = env.RecordedAt
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+func (s *SQLiteIngestStore) SaveCheckpoint(ctx context.Context, runID string, checkpoint IngestCheckpoint) (IngestCheckpoint, error) {
+	if s == nil || s.store == nil {
+		return checkpoint, nil
+	}
+	if checkpoint.RecordedAt.IsZero() {
+		checkpoint.RecordedAt = time.Now().UTC()
+	}
+	runID = strings.TrimSpace(runID)
+	const maxCheckpointAttempts = 8
+	for attempt := 0; attempt < maxCheckpointAttempts; attempt++ {
+		currentEnv, err := s.store.LoadRun(ctx, runtimeIngestNamespace, runID)
+		if err != nil {
+			return checkpoint, err
+		}
+		if currentEnv == nil {
+			return checkpoint, fmt.Errorf("runtime ingest run not found")
+		}
+		run, err := runtimeIngestRunFromEnvelope(currentEnv)
+		if err != nil {
+			return checkpoint, err
+		}
+		run.LastCheckpoint = &IngestCheckpoint{
+			Cursor:     checkpoint.Cursor,
+			RecordedAt: checkpoint.RecordedAt,
+			Metadata:   cloneRuntimeStringMap(checkpoint.Metadata),
+		}
+		run.UpdatedAt = checkpoint.RecordedAt
+		nextEnv, err := runtimeIngestRunEnvelope(run)
+		if err != nil {
+			return checkpoint, err
+		}
+		swapped, err := s.store.CompareAndSwapRun(ctx, *currentEnv, nextEnv)
+		if err != nil {
+			return checkpoint, err
+		}
+		if swapped {
+			_, err = s.AppendEvent(ctx, runID, IngestEvent{
+				Type:       "checkpoint_saved",
+				RecordedAt: checkpoint.RecordedAt,
+				Data: map[string]any{
+					"cursor":   checkpoint.Cursor,
+					"metadata": cloneRuntimeStringMap(checkpoint.Metadata),
+				},
+			})
+			if err != nil {
+				return checkpoint, err
+			}
+			return checkpoint, nil
+		}
+	}
+	return checkpoint, fmt.Errorf("save runtime ingest checkpoint: concurrent update conflict")
+}
+
+func runtimeIngestRunEnvelope(run *IngestRunRecord) (executionstore.RunEnvelope, error) {
+	payload, err := json.Marshal(run)
+	if err != nil {
+		return executionstore.RunEnvelope{}, fmt.Errorf("encode runtime ingest run: %w", err)
+	}
+	return executionstore.RunEnvelope{
+		Namespace:   runtimeIngestNamespace,
+		RunID:       strings.TrimSpace(run.ID),
+		Kind:        strings.TrimSpace(run.Source),
+		Status:      string(run.Status),
+		Stage:       strings.TrimSpace(run.Stage),
+		SubmittedAt: run.SubmittedAt,
+		StartedAt:   run.StartedAt,
+		CompletedAt: run.CompletedAt,
+		UpdatedAt:   run.UpdatedAt,
+		Payload:     payload,
+	}, nil
+}
+
+func runtimeIngestRunFromEnvelope(env *executionstore.RunEnvelope) (*IngestRunRecord, error) {
+	if env == nil {
+		return nil, nil
+	}
+	var run IngestRunRecord
+	if err := json.Unmarshal(env.Payload, &run); err != nil {
+		return nil, fmt.Errorf("decode runtime ingest run: %w", err)
+	}
+	return &run, nil
+}
+
+func (s *SQLiteIngestStore) LoadCheckpoint(ctx context.Context, runID string) (*IngestCheckpoint, error) {
+	run, err := s.LoadRun(ctx, runID)
+	if err != nil || run == nil {
+		return nil, err
+	}
+	return run.LastCheckpoint, nil
+}
+
+func ingestStatusesToStrings(statuses []IngestRunStatus) []string {
+	if len(statuses) == 0 {
+		return nil
+	}
+	values := make([]string, 0, len(statuses))
+	for _, status := range statuses {
+		values = append(values, string(status))
+	}
+	return values
+}

--- a/internal/runtime/store_test.go
+++ b/internal/runtime/store_test.go
@@ -1,0 +1,324 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+type casConflictExecutionStore struct {
+	env          executionstore.RunEnvelope
+	events       []executionstore.EventEnvelope
+	compareCalls int
+}
+
+func (s *casConflictExecutionStore) Close() error { return nil }
+
+func (s *casConflictExecutionStore) UpsertRun(_ context.Context, env executionstore.RunEnvelope) error {
+	s.env = env
+	return nil
+}
+
+func (s *casConflictExecutionStore) CompareAndSwapRun(_ context.Context, _ executionstore.RunEnvelope, next executionstore.RunEnvelope) (bool, error) {
+	s.compareCalls++
+	if s.compareCalls == 1 {
+		return false, nil
+	}
+	s.env = next
+	return true, nil
+}
+
+func (s *casConflictExecutionStore) ReplaceRunWithEvents(_ context.Context, env executionstore.RunEnvelope, events []executionstore.EventEnvelope) error {
+	s.env = env
+	s.events = append([]executionstore.EventEnvelope(nil), events...)
+	return nil
+}
+
+func (s *casConflictExecutionStore) LoadRun(_ context.Context, _, _ string) (*executionstore.RunEnvelope, error) {
+	if s.env.RunID == "" {
+		return nil, nil
+	}
+	cloned := s.env
+	cloned.Payload = append([]byte(nil), s.env.Payload...)
+	return &cloned, nil
+}
+
+func (s *casConflictExecutionStore) ListRuns(context.Context, string, executionstore.RunListOptions) ([]executionstore.RunEnvelope, error) {
+	return nil, nil
+}
+
+func (s *casConflictExecutionStore) ListAllRuns(context.Context, executionstore.RunListOptions) ([]executionstore.RunEnvelope, error) {
+	return nil, nil
+}
+
+func (s *casConflictExecutionStore) DeleteRun(context.Context, string, string) error { return nil }
+
+func (s *casConflictExecutionStore) DeleteEvents(context.Context, string, string) error { return nil }
+
+func (s *casConflictExecutionStore) SaveEvent(_ context.Context, env executionstore.EventEnvelope) (executionstore.EventEnvelope, error) {
+	if env.Sequence <= 0 {
+		env.Sequence = int64(len(s.events) + 1)
+	}
+	s.events = append(s.events, env)
+	return env, nil
+}
+
+func (s *casConflictExecutionStore) LoadEvents(_ context.Context, _, _ string) ([]executionstore.EventEnvelope, error) {
+	return append([]executionstore.EventEnvelope(nil), s.events...), nil
+}
+
+func (s *casConflictExecutionStore) LookupProcessedEvent(context.Context, string, string, time.Time) (*executionstore.ProcessedEventRecord, error) {
+	return nil, nil
+}
+
+func (s *casConflictExecutionStore) TouchProcessedEvent(context.Context, string, string, time.Time, time.Duration) error {
+	return nil
+}
+
+func (s *casConflictExecutionStore) RememberProcessedEvent(context.Context, executionstore.ProcessedEventRecord, int) error {
+	return nil
+}
+
+func (s *casConflictExecutionStore) DeleteProcessedEvent(context.Context, string, string) error {
+	return nil
+}
+
+func TestSQLiteIngestStoreSaveLoadRunAndEvents(t *testing.T) {
+	store, err := NewSQLiteIngestStore(filepath.Join(t.TempDir(), "runtime-ingest.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteIngestStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	startedAt := time.Date(2026, 3, 15, 18, 0, 0, 0, time.UTC)
+	run := &IngestRunRecord{
+		ID:               "run-1",
+		Source:           "kubernetes_audit",
+		Status:           IngestRunStatusRunning,
+		Stage:            "normalize",
+		SubmittedAt:      startedAt,
+		StartedAt:        &startedAt,
+		UpdatedAt:        startedAt,
+		ObservationCount: 12,
+		FindingCount:     2,
+		Metadata: map[string]string{
+			"cluster": "prod-west",
+		},
+	}
+	if err := store.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	loaded, err := store.LoadRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected loaded run")
+	}
+	if loaded.Source != "kubernetes_audit" {
+		t.Fatalf("source = %q, want %q", loaded.Source, "kubernetes_audit")
+	}
+	if loaded.ObservationCount != 12 {
+		t.Fatalf("observation_count = %d, want 12", loaded.ObservationCount)
+	}
+
+	first, err := store.AppendEvent(context.Background(), run.ID, IngestEvent{
+		Type:       "normalized",
+		RecordedAt: startedAt.Add(time.Second),
+		Data: map[string]any{
+			"observations": 12,
+		},
+	})
+	if err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	if first.Sequence != 1 {
+		t.Fatalf("first sequence = %d, want 1", first.Sequence)
+	}
+
+	second, err := store.AppendEvent(context.Background(), run.ID, IngestEvent{
+		Type:       "detected",
+		RecordedAt: startedAt.Add(2 * time.Second),
+		Data: map[string]any{
+			"findings": 2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("AppendEvent second: %v", err)
+	}
+	if second.Sequence != 2 {
+		t.Fatalf("second sequence = %d, want 2", second.Sequence)
+	}
+
+	events, err := store.LoadEvents(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if events[1].Type != "detected" {
+		t.Fatalf("second event type = %q, want %q", events[1].Type, "detected")
+	}
+}
+
+func TestSQLiteIngestStoreCheckpointPersistence(t *testing.T) {
+	store, err := NewSQLiteIngestStore(filepath.Join(t.TempDir(), "runtime-ingest.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteIngestStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	now := time.Date(2026, 3, 15, 18, 0, 0, 0, time.UTC)
+	run := &IngestRunRecord{
+		ID:          "run-1",
+		Source:      "tetragon",
+		Status:      IngestRunStatusRunning,
+		Stage:       "ingest",
+		SubmittedAt: now,
+		UpdatedAt:   now,
+	}
+	if err := store.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	checkpoint, err := store.SaveCheckpoint(context.Background(), run.ID, IngestCheckpoint{
+		Cursor:     "cursor-42",
+		RecordedAt: now.Add(time.Minute),
+		Metadata: map[string]string{
+			"stream": "default",
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+	if checkpoint.Cursor != "cursor-42" {
+		t.Fatalf("cursor = %q, want %q", checkpoint.Cursor, "cursor-42")
+	}
+
+	loaded, err := store.LoadCheckpoint(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("LoadCheckpoint: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected checkpoint")
+	}
+	if loaded.Metadata["stream"] != "default" {
+		t.Fatalf("stream metadata = %q, want %q", loaded.Metadata["stream"], "default")
+	}
+
+	events, err := store.LoadEvents(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if events[0].Type != "checkpoint_saved" {
+		t.Fatalf("event type = %q, want %q", events[0].Type, "checkpoint_saved")
+	}
+}
+
+func TestSQLiteIngestStoreListRunsActiveOnly(t *testing.T) {
+	store, err := NewSQLiteIngestStore(filepath.Join(t.TempDir(), "runtime-ingest.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteIngestStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	now := time.Date(2026, 3, 15, 18, 0, 0, 0, time.UTC)
+	for _, run := range []*IngestRunRecord{
+		{ID: "run-queued", Source: "kubernetes_audit", Status: IngestRunStatusQueued, Stage: "queued", SubmittedAt: now, UpdatedAt: now},
+		{ID: "run-running", Source: "tetragon", Status: IngestRunStatusRunning, Stage: "normalize", SubmittedAt: now.Add(time.Minute), UpdatedAt: now.Add(time.Minute)},
+		{ID: "run-completed", Source: "tetragon", Status: IngestRunStatusCompleted, Stage: "completed", SubmittedAt: now.Add(2 * time.Minute), UpdatedAt: now.Add(2 * time.Minute)},
+	} {
+		if err := store.SaveRun(context.Background(), run); err != nil {
+			t.Fatalf("SaveRun(%s): %v", run.ID, err)
+		}
+	}
+
+	active, err := store.ListRuns(context.Background(), IngestRunListOptions{
+		ActiveOnly:         true,
+		OrderBySubmittedAt: true,
+	})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(active) != 2 {
+		t.Fatalf("len(active) = %d, want 2", len(active))
+	}
+	if active[0].ID != "run-running" || active[1].ID != "run-queued" {
+		t.Fatalf("active runs = %#v", active)
+	}
+}
+
+func TestSQLiteIngestStoreSaveCheckpointRetriesCompareAndSwap(t *testing.T) {
+	now := time.Date(2026, 3, 15, 18, 0, 0, 0, time.UTC)
+	run := &IngestRunRecord{
+		ID:          "run-cas",
+		Source:      "tetragon",
+		Status:      IngestRunStatusRunning,
+		Stage:       "ingest",
+		SubmittedAt: now,
+		UpdatedAt:   now,
+	}
+	env, err := runtimeIngestRunEnvelope(run)
+	if err != nil {
+		t.Fatalf("runtimeIngestRunEnvelope: %v", err)
+	}
+
+	fakeStore := &casConflictExecutionStore{env: env}
+	store := NewSQLiteIngestStoreWithExecutionStore(fakeStore)
+
+	checkpoint, err := store.SaveCheckpoint(context.Background(), run.ID, IngestCheckpoint{
+		Cursor:     "cursor-99",
+		RecordedAt: now.Add(time.Minute),
+		Metadata: map[string]string{
+			"stream": "audit",
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+	if fakeStore.compareCalls != 2 {
+		t.Fatalf("compareCalls = %d, want 2", fakeStore.compareCalls)
+	}
+
+	loaded, err := store.LoadRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if loaded == nil || loaded.LastCheckpoint == nil {
+		t.Fatalf("loaded checkpoint missing: %#v", loaded)
+	}
+	if loaded.LastCheckpoint.Cursor != "cursor-99" {
+		t.Fatalf("cursor = %q, want cursor-99", loaded.LastCheckpoint.Cursor)
+	}
+	if checkpoint.Metadata["stream"] != "audit" {
+		t.Fatalf("checkpoint metadata = %#v, want stream=audit", checkpoint.Metadata)
+	}
+
+	events, err := store.LoadEvents(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if events[0].Type != "checkpoint_saved" {
+		t.Fatalf("event type = %q, want checkpoint_saved", events[0].Type)
+	}
+
+	var storedRun IngestRunRecord
+	if err := json.Unmarshal(fakeStore.env.Payload, &storedRun); err != nil {
+		t.Fatalf("Unmarshal fake store payload: %v", err)
+	}
+	if storedRun.LastCheckpoint == nil || storedRun.LastCheckpoint.Cursor != "cursor-99" {
+		t.Fatalf("stored payload checkpoint = %#v, want cursor-99", storedRun.LastCheckpoint)
+	}
+}


### PR DESCRIPTION
* Add runtime observation substrate and adapters

* Add runtime ingest store and checkpoints

* Fix runtime adapter review findings

* Persist runtime ingest runs in API handlers

* Harden runtime ingest progress timestamps

* Fix stale intelligence freshness test

* Fix runtime observation isolation and ingest wiring

* Decouple runtime detection from ingest persistence

* Harden runtime ingest completion and event compatibility

* Guard nil runtime observation event type lookups

* Keep runtime observation metadata and helpers aligned

* Make runtime adapter contract explicit
