### PR TITLE
Deduplicate runtime source payload ingestion (#331)

### DIFF
--- a/internal/api/server_handlers_threat_runtime.go
+++ b/internal/api/server_handlers_threat_runtime.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -107,6 +110,8 @@ func (s *Server) ingestRuntimeEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	dedupeStore := s.runtimeIngestStore()
+
 	var event runtime.RuntimeEvent
 	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
 		s.error(w, http.StatusBadRequest, "invalid event")
@@ -124,6 +129,10 @@ func (s *Server) ingestRuntimeEvent(w http.ResponseWriter, r *http.Request) {
 		session = nil
 	}
 
+	payloadHash, hashErr := runtimeSourceEventPayloadHash(&event)
+	if hashErr != nil {
+		s.warnRuntimeIngestPersistence("hash_source_event", hashErr, "source", "runtime_event", "event_id", event.ID, "run_id", session.runID())
+	}
 	observation, err := runtime.ObservationFromEvent(&event)
 	if err != nil {
 		s.warnInvalidRuntimeObservation("runtime_event", err, "event_id", event.ID, "resource_id", event.ResourceID, "resource_type", event.ResourceType)
@@ -135,6 +144,47 @@ func (s *Server) ingestRuntimeEvent(w http.ResponseWriter, r *http.Request) {
 		}
 		s.error(w, http.StatusBadRequest, "invalid event")
 		return
+	}
+	if dedupeStore != nil && event.ID != "" && payloadHash != "" {
+		duplicate, dedupeErr := dedupeStore.ClaimSourceEventProcessing(r.Context(), runtimeSourceEventSource(&event, "runtime_event"), event.ID, payloadHash, event.Timestamp)
+		if dedupeErr != nil {
+			s.warnRuntimeIngestPersistence("check_duplicate_source_event", dedupeErr, "source", "runtime_event", "event_id", event.ID, "run_id", session.runID())
+			if rejectErr := session.recordRejectedObservation(r.Context(), &event, 1, fmt.Errorf("dedupe check: %w", dedupeErr)); rejectErr != nil {
+				s.warnRuntimeIngestPersistence("record_rejected_observation", rejectErr, "source", "runtime_event", "event_id", event.ID, "run_id", session.runID())
+			}
+			session.fail(r.Context(), "dedupe", dedupeErr)
+			s.error(w, http.StatusServiceUnavailable, "runtime ingest dedupe unavailable")
+			return
+		} else if duplicate {
+			if err := session.recordDuplicateObservation(r.Context(), &event, 1); err != nil {
+				s.warnRuntimeIngestPersistence("record_duplicate_observation", err, "source", "runtime_event", "event_id", event.ID, "run_id", session.runID())
+			}
+			if session != nil {
+				if err := session.complete(r.Context(), runtime.IngestCheckpoint{
+					Cursor: event.ID,
+					Metadata: map[string]string{
+						"processed_events": "0",
+						"duplicate_events": "1",
+						"finding_count":    "0",
+					},
+				}); err != nil {
+					session.fail(r.Context(), "complete", err)
+					s.warnRuntimeIngestPersistence("complete", err, "source", "runtime_event", "event_id", event.ID, "run_id", session.runID())
+					session = nil
+				}
+			}
+
+			response := map[string]interface{}{
+				"processed": false,
+				"duplicate": true,
+				"findings":  0,
+			}
+			if session != nil && session.run != nil {
+				response["run_id"] = session.run.ID
+			}
+			s.json(w, http.StatusOK, response)
+			return
+		}
 	}
 	findings := s.app.RuntimeDetect.ProcessNormalizedObservation(r.Context(), observation)
 	if session != nil {
@@ -151,11 +201,24 @@ func (s *Server) ingestRuntimeEvent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if dedupeStore != nil && event.ID != "" && payloadHash != "" {
+		if err := dedupeStore.MarkSourceEventProcessed(r.Context(), runtimeSourceEventSource(&event, "runtime_event"), event.ID, payloadHash, event.Timestamp); err != nil {
+			s.warnRuntimeIngestPersistence("mark_source_event_processed", err, "source", "runtime_event", "event_id", event.ID, "run_id", session.runID())
+			if rejectErr := session.recordRejectedObservation(r.Context(), &event, 1, fmt.Errorf("mark processed: %w", err)); rejectErr != nil {
+				s.warnRuntimeIngestPersistence("record_rejected_observation", rejectErr, "source", "runtime_event", "event_id", event.ID, "run_id", session.runID())
+			}
+			session.fail(r.Context(), "dedupe", err)
+			s.error(w, http.StatusServiceUnavailable, "runtime ingest dedupe unavailable")
+			return
+		}
+	}
+
 	if session != nil {
 		if err := session.complete(r.Context(), runtime.IngestCheckpoint{
 			Cursor: observation.ID,
 			Metadata: map[string]string{
 				"processed_events": "1",
+				"duplicate_events": "0",
 				"finding_count":    strconv.Itoa(len(findings)),
 			},
 		}); err != nil {
@@ -180,6 +243,7 @@ func (s *Server) ingestRuntimeEvent(w http.ResponseWriter, r *http.Request) {
 
 	response := map[string]interface{}{
 		"processed": true,
+		"duplicate": false,
 		"findings":  len(findings),
 	}
 	if session != nil && session.run != nil {
@@ -238,6 +302,8 @@ func (s *Server) disableResponsePolicy(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) ingestTelemetry(w http.ResponseWriter, r *http.Request) {
+	dedupeStore := s.runtimeIngestStore()
+
 	var payload struct {
 		Events       []runtime.RuntimeEvent `json:"events"`
 		Node         string                 `json:"node"`
@@ -264,8 +330,13 @@ func (s *Server) ingestTelemetry(w http.ResponseWriter, r *http.Request) {
 	totalFindings := 0
 	processedEvents := 0
 	rejectedEvents := 0
+	duplicateEvents := 0
 	if s.app.RuntimeDetect != nil {
 		for idx, event := range payload.Events {
+			payloadHash, hashErr := runtimeSourceEventPayloadHash(&event)
+			if hashErr != nil {
+				s.warnRuntimeIngestPersistence("hash_source_event", hashErr, "source", "telemetry", "event_id", event.ID, "index", idx+1, "run_id", session.runID())
+			}
 			observation, err := runtime.ObservationFromEvent(&event)
 			if err != nil {
 				rejectedEvents++
@@ -280,9 +351,27 @@ func (s *Server) ingestTelemetry(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			observation = enrichRuntimeObservation(observation, payload.Cluster, payload.Node, payload.AgentVersion)
+			if dedupeStore != nil && event.ID != "" && payloadHash != "" {
+				duplicate, dedupeErr := dedupeStore.ClaimSourceEventProcessing(r.Context(), runtimeSourceEventSource(&event, "telemetry"), event.ID, payloadHash, event.Timestamp)
+				if dedupeErr != nil {
+					rejectedEvents++
+					s.warnRuntimeIngestPersistence("check_duplicate_source_event", dedupeErr, "source", "telemetry", "event_id", event.ID, "index", idx+1, "run_id", session.runID())
+					if rejectErr := session.recordRejectedObservation(r.Context(), &event, idx+1, fmt.Errorf("dedupe check: %w", dedupeErr)); rejectErr != nil {
+						session.fail(r.Context(), "dedupe", dedupeErr)
+						s.warnRuntimeIngestPersistence("record_rejected_observation", rejectErr, "source", "telemetry", "event_id", event.ID, "index", idx+1, "run_id", session.runID())
+						session = nil
+					}
+					continue
+				} else if duplicate {
+					duplicateEvents++
+					if err := session.recordDuplicateObservation(r.Context(), &event, idx+1); err != nil {
+						s.warnRuntimeIngestPersistence("record_duplicate_observation", err, "source", "telemetry", "event_id", event.ID, "index", idx+1, "run_id", session.runID())
+					}
+					continue
+				}
+			}
 			findings := s.app.RuntimeDetect.ProcessNormalizedObservation(r.Context(), observation)
 			totalFindings += len(findings)
-			processedEvents++
 			if session != nil {
 				if err := session.recordObservation(r.Context(), observation, len(findings), idx+1); err != nil {
 					session.fail(r.Context(), "detect", err)
@@ -296,6 +385,19 @@ func (s *Server) ingestTelemetry(w http.ResponseWriter, r *http.Request) {
 					_, _ = s.app.RuntimeRespond.ProcessFinding(r.Context(), &f)
 				}
 			}
+			if dedupeStore != nil && event.ID != "" && payloadHash != "" {
+				if err := dedupeStore.MarkSourceEventProcessed(r.Context(), runtimeSourceEventSource(&event, "telemetry"), event.ID, payloadHash, event.Timestamp); err != nil {
+					rejectedEvents++
+					s.warnRuntimeIngestPersistence("mark_source_event_processed", err, "source", "telemetry", "event_id", event.ID, "index", idx+1, "run_id", session.runID())
+					if rejectErr := session.recordRejectedObservation(r.Context(), &event, idx+1, fmt.Errorf("mark processed: %w", err)); rejectErr != nil {
+						session.fail(r.Context(), "dedupe", err)
+						s.warnRuntimeIngestPersistence("record_rejected_observation", rejectErr, "source", "telemetry", "event_id", event.ID, "index", idx+1, "run_id", session.runID())
+						session = nil
+					}
+					continue
+				}
+			}
+			processedEvents++
 		}
 	}
 
@@ -309,6 +411,7 @@ func (s *Server) ingestTelemetry(w http.ResponseWriter, r *http.Request) {
 			Metadata: map[string]string{
 				"processed_events": strconv.Itoa(processedEvents),
 				"rejected_events":  strconv.Itoa(rejectedEvents),
+				"duplicate_events": strconv.Itoa(duplicateEvents),
 				"finding_count":    strconv.Itoa(totalFindings),
 				"cluster":          payload.Cluster,
 				"node":             payload.Node,
@@ -325,6 +428,7 @@ func (s *Server) ingestTelemetry(w http.ResponseWriter, r *http.Request) {
 			"source":           "telemetry",
 			"events_processed": processedEvents,
 			"events_rejected":  rejectedEvents,
+			"events_duplicate": duplicateEvents,
 			"findings":         totalFindings,
 			"node":             payload.Node,
 			"cluster":          payload.Cluster,
@@ -338,9 +442,10 @@ func (s *Server) ingestTelemetry(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := map[string]interface{}{
-		"processed": processedEvents,
-		"rejected":  rejectedEvents,
-		"findings":  totalFindings,
+		"processed":  processedEvents,
+		"rejected":   rejectedEvents,
+		"duplicates": duplicateEvents,
+		"findings":   totalFindings,
 	}
 	if session != nil && session.run != nil {
 		response["run_id"] = session.run.ID
@@ -364,4 +469,26 @@ func (s *Server) warnInvalidRuntimeObservation(source string, err error, args ..
 	fields := []any{"source", strings.TrimSpace(source), "error", err}
 	fields = append(fields, args...)
 	s.app.Logger.Warn("runtime observation rejected during normalization", fields...)
+}
+
+func runtimeSourceEventPayloadHash(event *runtime.RuntimeEvent) (string, error) {
+	if event == nil {
+		return "", nil
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func runtimeSourceEventSource(event *runtime.RuntimeEvent, fallback string) string {
+	if event == nil {
+		return fallback
+	}
+	if source := strings.TrimSpace(event.Source); source != "" {
+		return source
+	}
+	return strings.TrimSpace(fallback)
 }

--- a/internal/api/server_handlers_threat_runtime_ingest.go
+++ b/internal/api/server_handlers_threat_runtime_ingest.go
@@ -165,6 +165,51 @@ func (r *runtimeIngestSession) recordRejectedObservation(ctx context.Context, ev
 	return nil
 }
 
+func (r *runtimeIngestSession) recordDuplicateObservation(ctx context.Context, event *runtime.RuntimeEvent, index int) error {
+	if r == nil || r.store == nil || r.run == nil {
+		return nil
+	}
+
+	recordedAt := time.Now().UTC()
+	r.run.UpdatedAt = recordedAt
+
+	data := map[string]any{
+		"index": index,
+	}
+	if event != nil {
+		if event.ID != "" {
+			data["event_id"] = strings.TrimSpace(event.ID)
+		}
+		if observedAt := event.Timestamp.UTC(); !observedAt.IsZero() {
+			data["observed_at"] = observedAt.Format(time.RFC3339Nano)
+		}
+		if source := strings.TrimSpace(event.Source); source != "" {
+			data["source"] = source
+		}
+		if eventType := strings.TrimSpace(event.EventType); eventType != "" {
+			data["event_type"] = eventType
+		}
+		if resourceID := strings.TrimSpace(event.ResourceID); resourceID != "" {
+			data["resource_id"] = resourceID
+		}
+		if resourceType := strings.TrimSpace(event.ResourceType); resourceType != "" {
+			data["resource_type"] = resourceType
+		}
+	}
+
+	if err := r.store.SaveRun(ctx, r.run); err != nil {
+		return fmt.Errorf("save runtime ingest duplicate progress: %w", err)
+	}
+	if _, err := r.store.AppendEvent(ctx, r.run.ID, runtime.IngestEvent{
+		Type:       "observation_duplicate",
+		RecordedAt: recordedAt,
+		Data:       data,
+	}); err != nil {
+		return fmt.Errorf("append runtime ingest duplicate event: %w", err)
+	}
+	return nil
+}
+
 func (r *runtimeIngestSession) complete(ctx context.Context, checkpoint runtime.IngestCheckpoint) error {
 	if r == nil || r.store == nil || r.run == nil {
 		return nil

--- a/internal/api/server_handlers_threat_runtime_test.go
+++ b/internal/api/server_handlers_threat_runtime_test.go
@@ -78,6 +78,14 @@ func (s *failingRuntimeIngestStore) LoadCheckpoint(context.Context, string) (*ru
 	return nil, nil
 }
 
+func (s *failingRuntimeIngestStore) ClaimSourceEventProcessing(context.Context, string, string, string, time.Time) (bool, error) {
+	return false, nil
+}
+
+func (s *failingRuntimeIngestStore) MarkSourceEventProcessed(context.Context, string, string, string, time.Time) error {
+	return nil
+}
+
 type nilReloadRuntimeIngestStore struct {
 	saveRunCalls        int
 	saveCheckpointCalls int
@@ -125,6 +133,59 @@ func (s *nilReloadRuntimeIngestStore) SaveCheckpoint(context.Context, string, ru
 
 func (s *nilReloadRuntimeIngestStore) LoadCheckpoint(context.Context, string) (*runtime.IngestCheckpoint, error) {
 	return nil, nil
+}
+
+func (s *nilReloadRuntimeIngestStore) ClaimSourceEventProcessing(context.Context, string, string, string, time.Time) (bool, error) {
+	return false, nil
+}
+
+func (s *nilReloadRuntimeIngestStore) MarkSourceEventProcessed(context.Context, string, string, string, time.Time) error {
+	return nil
+}
+
+type duplicateCheckErrorStore struct {
+	runtime.IngestStore
+	checkDuplicateErr       error
+	checkDuplicateErrOnCall int
+	checkDuplicateCalls     int
+}
+
+func (s *duplicateCheckErrorStore) ClaimSourceEventProcessing(ctx context.Context, source, eventID, payloadHash string, observedAt time.Time) (bool, error) {
+	s.checkDuplicateCalls++
+	if s.checkDuplicateErr != nil && (s.checkDuplicateErrOnCall == 0 || s.checkDuplicateErrOnCall == s.checkDuplicateCalls) {
+		return false, s.checkDuplicateErr
+	}
+	return s.IngestStore.ClaimSourceEventProcessing(ctx, source, eventID, payloadHash, observedAt)
+}
+
+type markProcessedErrorStore struct {
+	runtime.IngestStore
+	markProcessedErr       error
+	markProcessedErrOnCall int
+	markProcessedCalls     int
+}
+
+func (s *markProcessedErrorStore) MarkSourceEventProcessed(ctx context.Context, source, eventID, payloadHash string, observedAt time.Time) error {
+	s.markProcessedCalls++
+	if s.markProcessedErr != nil && (s.markProcessedErrOnCall == 0 || s.markProcessedErrOnCall == s.markProcessedCalls) {
+		return s.markProcessedErr
+	}
+	return s.IngestStore.MarkSourceEventProcessed(ctx, source, eventID, payloadHash, observedAt)
+}
+
+type appendEventErrorStore struct {
+	runtime.IngestStore
+	appendEventErr       error
+	appendEventErrOnCall int
+	appendEventCalls     int
+}
+
+func (s *appendEventErrorStore) AppendEvent(ctx context.Context, runID string, event runtime.IngestEvent) (runtime.IngestEvent, error) {
+	s.appendEventCalls++
+	if s.appendEventErr != nil && (s.appendEventErrOnCall == 0 || s.appendEventErrOnCall == s.appendEventCalls) {
+		return runtime.IngestEvent{}, s.appendEventErr
+	}
+	return s.IngestStore.AppendEvent(ctx, runID, event)
 }
 
 func TestIngestRuntimeEventPersistsIngestRun(t *testing.T) {
@@ -256,6 +317,51 @@ func TestIngestRuntimeEventRejectsInvalidObservationAndFailsRun(t *testing.T) {
 	}
 	if events[2].Type != "ingest_failed" {
 		t.Fatalf("events[2].Type = %q, want ingest_failed", events[2].Type)
+	}
+}
+
+func TestIngestRuntimeEventInvalidRetryDoesNotTurnIntoDuplicate(t *testing.T) {
+	a := newTestApp(t)
+	s := NewServer(a)
+
+	request := map[string]any{
+		"id":            "evt-invalid-retry",
+		"timestamp":     "2026-03-15T19:35:00Z",
+		"source":        "hubble",
+		"resource_id":   "pod/default/miner-0",
+		"resource_type": "pod",
+		"event_type":    "network",
+	}
+
+	first := do(t, s, http.MethodPost, "/api/v1/runtime/events", request)
+	if first.Code != http.StatusBadRequest {
+		t.Fatalf("expected first 400, got %d: %s", first.Code, first.Body.String())
+	}
+	retry := do(t, s, http.MethodPost, "/api/v1/runtime/events", request)
+	if retry.Code != http.StatusBadRequest {
+		t.Fatalf("expected retry 400, got %d: %s", retry.Code, retry.Body.String())
+	}
+
+	runs, err := a.RuntimeIngest.ListRuns(context.Background(), runtime.IngestRunListOptions{})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("len(runs) = %d, want 2", len(runs))
+	}
+	for i, run := range runs {
+		if run.Status != runtime.IngestRunStatusFailed {
+			t.Fatalf("runs[%d].status = %q, want failed", i, run.Status)
+		}
+		events, err := a.RuntimeIngest.LoadEvents(context.Background(), run.ID)
+		if err != nil {
+			t.Fatalf("LoadEvents(%d): %v", i, err)
+		}
+		for _, event := range events {
+			if event.Type == "observation_duplicate" {
+				t.Fatalf("runs[%d] unexpectedly recorded duplicate event: %#v", i, event)
+			}
+		}
 	}
 }
 
@@ -445,6 +551,888 @@ func TestTelemetryIngestTracksRejectedObservationsSeparately(t *testing.T) {
 	}
 	if events[2].Type != "observation_processed" {
 		t.Fatalf("events[2].Type = %q, want observation_processed", events[2].Type)
+	}
+}
+
+func TestIngestRuntimeEventMarksDuplicateSourcePayloads(t *testing.T) {
+	a := newTestApp(t)
+	s := NewServer(a)
+
+	payload := map[string]any{
+		"id":            "evt-dup-1",
+		"timestamp":     "2026-03-15T19:35:00Z",
+		"source":        "tetragon",
+		"resource_id":   "pod/default/miner-0",
+		"resource_type": "pod",
+		"event_type":    "process",
+		"process": map[string]any{
+			"pid":  4242,
+			"name": "xmrig",
+			"path": "/usr/bin/xmrig",
+		},
+		"container": map[string]any{
+			"container_id": "container-1",
+			"namespace":    "default",
+			"pod_name":     "miner-0",
+			"image":        "ghcr.io/acme/miner:latest",
+		},
+	}
+
+	first := do(t, s, http.MethodPost, "/api/v1/runtime/events", payload)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first ingest expected 200, got %d: %s", first.Code, first.Body.String())
+	}
+	firstBody := decodeJSON(t, first)
+	firstRunID, ok := firstBody["run_id"].(string)
+	if !ok || firstRunID == "" {
+		t.Fatalf("expected first run_id, got %#v", firstBody["run_id"])
+	}
+
+	second := do(t, s, http.MethodPost, "/api/v1/runtime/events", payload)
+	if second.Code != http.StatusOK {
+		t.Fatalf("second ingest expected 200, got %d: %s", second.Code, second.Body.String())
+	}
+	secondBody := decodeJSON(t, second)
+	if got := secondBody["processed"]; got != false {
+		t.Fatalf("processed = %#v, want false", got)
+	}
+	if got := secondBody["duplicate"]; got != true {
+		t.Fatalf("duplicate = %#v, want true", got)
+	}
+	if got := secondBody["findings"]; got != float64(0) && got != 0 {
+		t.Fatalf("findings = %#v, want 0", got)
+	}
+	secondRunID, ok := secondBody["run_id"].(string)
+	if !ok || secondRunID == "" {
+		t.Fatalf("expected second run_id, got %#v", secondBody["run_id"])
+	}
+	if secondRunID == firstRunID {
+		t.Fatalf("duplicate run_id = %q, want a new ingest run", secondRunID)
+	}
+
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 1 {
+		t.Fatalf("recent findings = %d, want 1 after duplicate suppression", got)
+	}
+
+	run, err := a.RuntimeIngest.LoadRun(context.Background(), secondRunID)
+	if err != nil {
+		t.Fatalf("LoadRun duplicate run: %v", err)
+	}
+	if run == nil {
+		t.Fatal("expected duplicate run")
+	}
+	if run.Status != runtime.IngestRunStatusCompleted {
+		t.Fatalf("status = %q, want %q", run.Status, runtime.IngestRunStatusCompleted)
+	}
+	if run.ObservationCount != 0 {
+		t.Fatalf("observation_count = %d, want 0", run.ObservationCount)
+	}
+	if run.FindingCount != 0 {
+		t.Fatalf("finding_count = %d, want 0", run.FindingCount)
+	}
+	if run.LastCheckpoint == nil {
+		t.Fatal("expected duplicate checkpoint")
+	}
+	if got := run.LastCheckpoint.Metadata["processed_events"]; got != "0" {
+		t.Fatalf("checkpoint processed_events = %q, want 0", got)
+	}
+	if got := run.LastCheckpoint.Metadata["duplicate_events"]; got != "1" {
+		t.Fatalf("checkpoint duplicate_events = %q, want 1", got)
+	}
+
+	events, err := a.RuntimeIngest.LoadEvents(context.Background(), secondRunID)
+	if err != nil {
+		t.Fatalf("LoadEvents duplicate run: %v", err)
+	}
+	if len(events) != 4 {
+		t.Fatalf("len(events) = %d, want 4", len(events))
+	}
+	if events[1].Type != "observation_duplicate" {
+		t.Fatalf("events[1].Type = %q, want observation_duplicate", events[1].Type)
+	}
+}
+
+func TestIngestRuntimeEventRejectsWhenDuplicateCheckFails(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = &duplicateCheckErrorStore{
+		IngestStore:             a.RuntimeIngest,
+		checkDuplicateErr:       errors.New("dedupe unavailable"),
+		checkDuplicateErrOnCall: 1,
+	}
+	s := NewServerWithDependencies(deps)
+
+	w := do(t, s, http.MethodPost, "/api/v1/runtime/events", map[string]any{
+		"id":            "evt-dedupe-err-1",
+		"timestamp":     "2026-03-15T19:35:00Z",
+		"source":        "tetragon",
+		"resource_id":   "pod/default/miner-0",
+		"resource_type": "pod",
+		"event_type":    "process",
+		"process": map[string]any{
+			"pid":  4242,
+			"name": "xmrig",
+			"path": "/usr/bin/xmrig",
+		},
+	})
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 0 {
+		t.Fatalf("recent findings = %d, want 0", got)
+	}
+	if got := len(s.app.RuntimeRespond.ListExecutions(10)); got != 0 {
+		t.Fatalf("response executions = %d, want 0", got)
+	}
+
+	runs, err := a.RuntimeIngest.ListRuns(context.Background(), runtime.IngestRunListOptions{})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("len(runs) = %d, want 1", len(runs))
+	}
+	run := runs[0]
+	if run.Status != runtime.IngestRunStatusFailed {
+		t.Fatalf("status = %q, want %q", run.Status, runtime.IngestRunStatusFailed)
+	}
+	if run.Stage != "dedupe" {
+		t.Fatalf("stage = %q, want dedupe", run.Stage)
+	}
+
+	events, err := a.RuntimeIngest.LoadEvents(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("len(events) = %d, want 3", len(events))
+	}
+	if events[1].Type != "observation_rejected" {
+		t.Fatalf("events[1].Type = %q, want observation_rejected", events[1].Type)
+	}
+	if got := events[1].Data["error"]; got != "dedupe check: dedupe unavailable" {
+		t.Fatalf("events[1].Data[error] = %#v, want dedupe rejection", got)
+	}
+	if events[2].Type != "ingest_failed" {
+		t.Fatalf("events[2].Type = %q, want ingest_failed", events[2].Type)
+	}
+}
+
+func TestIngestRuntimeEventRejectsWhenMarkProcessedFails(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = &markProcessedErrorStore{
+		IngestStore:            a.RuntimeIngest,
+		markProcessedErr:       errors.New("mark unavailable"),
+		markProcessedErrOnCall: 1,
+	}
+	s := NewServerWithDependencies(deps)
+
+	w := do(t, s, http.MethodPost, "/api/v1/runtime/events", map[string]any{
+		"id":            "evt-mark-err-1",
+		"timestamp":     "2026-03-15T19:35:00Z",
+		"source":        "tetragon",
+		"resource_id":   "pod/default/miner-0",
+		"resource_type": "pod",
+		"event_type":    "process",
+		"process": map[string]any{
+			"pid":  4242,
+			"name": "xmrig",
+			"path": "/usr/bin/xmrig",
+		},
+	})
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 1 {
+		t.Fatalf("recent findings = %d, want 1", got)
+	}
+	if got := len(s.app.RuntimeRespond.ListExecutions(10)); got != 1 {
+		t.Fatalf("response executions = %d, want 1", got)
+	}
+
+	runs, err := a.RuntimeIngest.ListRuns(context.Background(), runtime.IngestRunListOptions{})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("len(runs) = %d, want 1", len(runs))
+	}
+	run := runs[0]
+	if run.Status != runtime.IngestRunStatusFailed {
+		t.Fatalf("status = %q, want %q", run.Status, runtime.IngestRunStatusFailed)
+	}
+	if run.Stage != "dedupe" {
+		t.Fatalf("stage = %q, want dedupe", run.Stage)
+	}
+
+	events, err := a.RuntimeIngest.LoadEvents(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 4 {
+		t.Fatalf("len(events) = %d, want 4", len(events))
+	}
+	if events[1].Type != "observation_processed" {
+		t.Fatalf("events[1].Type = %q, want observation_processed", events[1].Type)
+	}
+	if events[2].Type != "observation_rejected" {
+		t.Fatalf("events[2].Type = %q, want observation_rejected", events[2].Type)
+	}
+	if got := events[2].Data["error"]; got != "mark processed: mark unavailable" {
+		t.Fatalf("events[1].Data[error] = %#v, want mark rejection", got)
+	}
+	if events[3].Type != "ingest_failed" {
+		t.Fatalf("events[3].Type = %q, want ingest_failed", events[3].Type)
+	}
+
+	retry := do(t, s, http.MethodPost, "/api/v1/runtime/events", map[string]any{
+		"id":            "evt-mark-err-1",
+		"timestamp":     "2026-03-15T19:35:00Z",
+		"source":        "tetragon",
+		"resource_id":   "pod/default/miner-0",
+		"resource_type": "pod",
+		"event_type":    "process",
+		"process": map[string]any{
+			"pid":  4242,
+			"name": "xmrig",
+			"path": "/usr/bin/xmrig",
+		},
+	})
+	if retry.Code != http.StatusOK {
+		t.Fatalf("expected retry 200, got %d: %s", retry.Code, retry.Body.String())
+	}
+	retryBody := decodeJSON(t, retry)
+	if got := retryBody["duplicate"]; got != true {
+		t.Fatalf("retry duplicate = %#v, want true", got)
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 1 {
+		t.Fatalf("recent findings after retry = %d, want 1", got)
+	}
+	if got := len(s.app.RuntimeRespond.ListExecutions(10)); got != 1 {
+		t.Fatalf("response executions after retry = %d, want 1", got)
+	}
+}
+
+func TestTelemetryIngestSuppressesDuplicateSourcePayloadsInBatch(t *testing.T) {
+	a := newTestApp(t)
+	s := NewServer(a)
+
+	w := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-dup-1",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  100,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+			{
+				"id":            "telemetry-dup-1",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  100,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	runID, ok := body["run_id"].(string)
+	if !ok || runID == "" {
+		t.Fatalf("expected run_id in response, got %#v", body["run_id"])
+	}
+	if got := body["processed"]; got != float64(1) && got != 1 {
+		t.Fatalf("processed = %#v, want 1", got)
+	}
+	if got := body["rejected"]; got != float64(0) && got != 0 {
+		t.Fatalf("rejected = %#v, want 0", got)
+	}
+	if got := body["duplicates"]; got != float64(1) && got != 1 {
+		t.Fatalf("duplicates = %#v, want 1", got)
+	}
+	if got := body["findings"]; got != float64(1) && got != 1 {
+		t.Fatalf("findings = %#v, want 1", got)
+	}
+
+	run, err := a.RuntimeIngest.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run == nil {
+		t.Fatal("expected persisted run")
+	}
+	if run.ObservationCount != 1 {
+		t.Fatalf("observation_count = %d, want 1", run.ObservationCount)
+	}
+	if run.FindingCount != 1 {
+		t.Fatalf("finding_count = %d, want 1", run.FindingCount)
+	}
+	if run.LastCheckpoint == nil {
+		t.Fatal("expected checkpoint")
+	}
+	if got := run.LastCheckpoint.Metadata["processed_events"]; got != "1" {
+		t.Fatalf("checkpoint processed_events = %q, want 1", got)
+	}
+	if got := run.LastCheckpoint.Metadata["duplicate_events"]; got != "1" {
+		t.Fatalf("checkpoint duplicate_events = %q, want 1", got)
+	}
+	if got := run.LastCheckpoint.Metadata["rejected_events"]; got != "0" {
+		t.Fatalf("checkpoint rejected_events = %q, want 0", got)
+	}
+
+	events, err := a.RuntimeIngest.LoadEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 5 {
+		t.Fatalf("len(events) = %d, want 5", len(events))
+	}
+	if events[1].Type != "observation_processed" {
+		t.Fatalf("events[1].Type = %q, want observation_processed", events[1].Type)
+	}
+	if events[2].Type != "observation_duplicate" {
+		t.Fatalf("events[2].Type = %q, want observation_duplicate", events[2].Type)
+	}
+}
+
+func TestTelemetryIngestRejectsEventWhenDuplicateCheckFails(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = &duplicateCheckErrorStore{
+		IngestStore:             a.RuntimeIngest,
+		checkDuplicateErr:       errors.New("dedupe unavailable"),
+		checkDuplicateErrOnCall: 1,
+	}
+	s := NewServerWithDependencies(deps)
+
+	w := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-dedupe-err-1",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  100,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+			{
+				"id":            "telemetry-dedupe-ok-2",
+				"timestamp":     "2026-03-15T19:36:01Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  101,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	runID, ok := body["run_id"].(string)
+	if !ok || runID == "" {
+		t.Fatalf("expected run_id in response, got %#v", body["run_id"])
+	}
+	if got := body["processed"]; got != float64(1) && got != 1 {
+		t.Fatalf("processed = %#v, want 1", got)
+	}
+	if got := body["rejected"]; got != float64(1) && got != 1 {
+		t.Fatalf("rejected = %#v, want 1", got)
+	}
+	if got := body["duplicates"]; got != float64(0) && got != 0 {
+		t.Fatalf("duplicates = %#v, want 0", got)
+	}
+	if got := body["findings"]; got != float64(1) && got != 1 {
+		t.Fatalf("findings = %#v, want 1", got)
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 1 {
+		t.Fatalf("recent findings = %d, want 1", got)
+	}
+
+	run, err := a.RuntimeIngest.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run == nil {
+		t.Fatal("expected persisted run")
+	}
+	if run.Status != runtime.IngestRunStatusCompleted {
+		t.Fatalf("status = %q, want %q", run.Status, runtime.IngestRunStatusCompleted)
+	}
+	if got := run.LastCheckpoint.Metadata["processed_events"]; got != "1" {
+		t.Fatalf("checkpoint processed_events = %q, want 1", got)
+	}
+	if got := run.LastCheckpoint.Metadata["rejected_events"]; got != "1" {
+		t.Fatalf("checkpoint rejected_events = %q, want 1", got)
+	}
+	if got := run.LastCheckpoint.Metadata["duplicate_events"]; got != "0" {
+		t.Fatalf("checkpoint duplicate_events = %q, want 0", got)
+	}
+
+	events, err := a.RuntimeIngest.LoadEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 5 {
+		t.Fatalf("len(events) = %d, want 5", len(events))
+	}
+	if events[1].Type != "observation_rejected" {
+		t.Fatalf("events[1].Type = %q, want observation_rejected", events[1].Type)
+	}
+	if got := events[1].Data["error"]; got != "dedupe check: dedupe unavailable" {
+		t.Fatalf("events[1].Data[error] = %#v, want dedupe rejection", got)
+	}
+	if events[2].Type != "observation_processed" {
+		t.Fatalf("events[2].Type = %q, want observation_processed", events[2].Type)
+	}
+}
+
+func TestTelemetryIngestInvalidRetryDoesNotTurnIntoDuplicate(t *testing.T) {
+	a := newTestApp(t)
+	s := NewServer(a)
+
+	request := map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-invalid-retry",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "network",
+			},
+		},
+	}
+
+	first := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", request)
+	if first.Code != http.StatusOK {
+		t.Fatalf("expected first 200, got %d: %s", first.Code, first.Body.String())
+	}
+	firstBody := decodeJSON(t, first)
+	if got := firstBody["processed"]; got != float64(0) && got != 0 {
+		t.Fatalf("first processed = %#v, want 0", got)
+	}
+	if got := firstBody["rejected"]; got != float64(1) && got != 1 {
+		t.Fatalf("first rejected = %#v, want 1", got)
+	}
+	if got := firstBody["duplicates"]; got != float64(0) && got != 0 {
+		t.Fatalf("first duplicates = %#v, want 0", got)
+	}
+
+	retry := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", request)
+	if retry.Code != http.StatusOK {
+		t.Fatalf("expected retry 200, got %d: %s", retry.Code, retry.Body.String())
+	}
+	retryBody := decodeJSON(t, retry)
+	if got := retryBody["processed"]; got != float64(0) && got != 0 {
+		t.Fatalf("retry processed = %#v, want 0", got)
+	}
+	if got := retryBody["rejected"]; got != float64(1) && got != 1 {
+		t.Fatalf("retry rejected = %#v, want 1", got)
+	}
+	if got := retryBody["duplicates"]; got != float64(0) && got != 0 {
+		t.Fatalf("retry duplicates = %#v, want 0", got)
+	}
+}
+
+func TestTelemetryIngestRejectsEventWhenMarkProcessedFails(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = &markProcessedErrorStore{
+		IngestStore:            a.RuntimeIngest,
+		markProcessedErr:       errors.New("mark unavailable"),
+		markProcessedErrOnCall: 1,
+	}
+	s := NewServerWithDependencies(deps)
+
+	w := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-mark-err-1",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  100,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+			{
+				"id":            "telemetry-mark-ok-2",
+				"timestamp":     "2026-03-15T19:36:01Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  101,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	runID, ok := body["run_id"].(string)
+	if !ok || runID == "" {
+		t.Fatalf("expected run_id in response, got %#v", body["run_id"])
+	}
+	if got := body["processed"]; got != float64(1) && got != 1 {
+		t.Fatalf("processed = %#v, want 1", got)
+	}
+	if got := body["rejected"]; got != float64(1) && got != 1 {
+		t.Fatalf("rejected = %#v, want 1", got)
+	}
+	if got := body["duplicates"]; got != float64(0) && got != 0 {
+		t.Fatalf("duplicates = %#v, want 0", got)
+	}
+	if got := body["findings"]; got != float64(2) && got != 2 {
+		t.Fatalf("findings = %#v, want 2", got)
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 2 {
+		t.Fatalf("recent findings = %d, want 2", got)
+	}
+	if got := len(s.app.RuntimeRespond.ListExecutions(10)); got != 2 {
+		t.Fatalf("response executions = %d, want 2", got)
+	}
+
+	run, err := a.RuntimeIngest.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run == nil {
+		t.Fatal("expected persisted run")
+	}
+	if run.Status != runtime.IngestRunStatusCompleted {
+		t.Fatalf("status = %q, want %q", run.Status, runtime.IngestRunStatusCompleted)
+	}
+	if got := run.FindingCount; got != 2 {
+		t.Fatalf("finding_count = %d, want 2", got)
+	}
+	if got := run.LastCheckpoint.Metadata["processed_events"]; got != "1" {
+		t.Fatalf("checkpoint processed_events = %q, want 1", got)
+	}
+	if got := run.LastCheckpoint.Metadata["rejected_events"]; got != "1" {
+		t.Fatalf("checkpoint rejected_events = %q, want 1", got)
+	}
+	if got := run.LastCheckpoint.Metadata["duplicate_events"]; got != "0" {
+		t.Fatalf("checkpoint duplicate_events = %q, want 0", got)
+	}
+
+	events, err := a.RuntimeIngest.LoadEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 6 {
+		t.Fatalf("len(events) = %d, want 6", len(events))
+	}
+	if events[1].Type != "observation_processed" {
+		t.Fatalf("events[1].Type = %q, want observation_processed", events[1].Type)
+	}
+	if events[2].Type != "observation_rejected" {
+		t.Fatalf("events[2].Type = %q, want observation_rejected", events[2].Type)
+	}
+	if got := events[2].Data["error"]; got != "mark processed: mark unavailable" {
+		t.Fatalf("events[1].Data[error] = %#v, want mark rejection", got)
+	}
+	if events[3].Type != "observation_processed" {
+		t.Fatalf("events[3].Type = %q, want observation_processed", events[3].Type)
+	}
+
+	retry := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-mark-err-1",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  100,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+		},
+	})
+	if retry.Code != http.StatusOK {
+		t.Fatalf("expected retry 200, got %d: %s", retry.Code, retry.Body.String())
+	}
+	retryBody := decodeJSON(t, retry)
+	if got := retryBody["processed"]; got != float64(0) && got != 0 {
+		t.Fatalf("retry processed = %#v, want 0", got)
+	}
+	if got := retryBody["duplicates"]; got != float64(1) && got != 1 {
+		t.Fatalf("retry duplicates = %#v, want 1", got)
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 2 {
+		t.Fatalf("recent findings after retry = %d, want 2", got)
+	}
+	if got := len(s.app.RuntimeRespond.ListExecutions(10)); got != 2 {
+		t.Fatalf("response executions after retry = %d, want 2", got)
+	}
+}
+
+func TestTelemetryIngestKeepsLaterDedupeWhenDuplicateRecordingFails(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = &appendEventErrorStore{
+		IngestStore:          a.RuntimeIngest,
+		appendEventErr:       errors.New("append unavailable"),
+		appendEventErrOnCall: 3,
+	}
+	s := NewServerWithDependencies(deps)
+
+	first := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-dup-log-1",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  100,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+			{
+				"id":            "telemetry-dup-log-1",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  100,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+			{
+				"id":            "telemetry-later-2",
+				"timestamp":     "2026-03-15T19:36:01Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  101,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+		},
+	})
+	if first.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", first.Code, first.Body.String())
+	}
+	firstBody := decodeJSON(t, first)
+	if got := firstBody["processed"]; got != float64(2) && got != 2 {
+		t.Fatalf("processed = %#v, want 2", got)
+	}
+	if got := firstBody["duplicates"]; got != float64(1) && got != 1 {
+		t.Fatalf("duplicates = %#v, want 1", got)
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 2 {
+		t.Fatalf("recent findings after first ingest = %d, want 2", got)
+	}
+
+	second := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-later-2",
+				"timestamp":     "2026-03-15T19:36:01Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  101,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+		},
+	})
+	if second.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", second.Code, second.Body.String())
+	}
+	secondBody := decodeJSON(t, second)
+	if got := secondBody["processed"]; got != float64(0) && got != 0 {
+		t.Fatalf("processed = %#v, want 0", got)
+	}
+	if got := secondBody["duplicates"]; got != float64(1) && got != 1 {
+		t.Fatalf("duplicates = %#v, want 1", got)
+	}
+	if got := len(s.app.RuntimeDetect.RecentFindings(10)); got != 2 {
+		t.Fatalf("recent findings after duplicate replay = %d, want 2", got)
+	}
+}
+
+func TestTelemetryIngestPreservesRootCauseWhenRejectedObservationLoggingFailsOnDedupeCheck(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = &duplicateCheckErrorStore{
+		IngestStore: &appendEventErrorStore{
+			IngestStore:          a.RuntimeIngest,
+			appendEventErr:       errors.New("append unavailable"),
+			appendEventErrOnCall: 2,
+		},
+		checkDuplicateErr:       errors.New("dedupe unavailable"),
+		checkDuplicateErrOnCall: 1,
+	}
+	s := NewServerWithDependencies(deps)
+
+	w := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-dedupe-root-cause-1",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  100,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	runs, err := a.RuntimeIngest.ListRuns(context.Background(), runtime.IngestRunListOptions{})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("len(runs) = %d, want 1", len(runs))
+	}
+	run := runs[0]
+	if run.Status != runtime.IngestRunStatusFailed {
+		t.Fatalf("status = %q, want %q", run.Status, runtime.IngestRunStatusFailed)
+	}
+	if run.Error != "dedupe unavailable" {
+		t.Fatalf("run.Error = %q, want dedupe unavailable", run.Error)
+	}
+}
+
+func TestTelemetryIngestPreservesRootCauseWhenRejectedObservationLoggingFailsOnMarkProcessed(t *testing.T) {
+	a := newTestApp(t)
+	deps := newServerDependenciesFromApp(a)
+	deps.RuntimeIngest = &markProcessedErrorStore{
+		IngestStore: &appendEventErrorStore{
+			IngestStore:          a.RuntimeIngest,
+			appendEventErr:       errors.New("append unavailable"),
+			appendEventErrOnCall: 3,
+		},
+		markProcessedErr:       errors.New("mark unavailable"),
+		markProcessedErrOnCall: 1,
+	}
+	s := NewServerWithDependencies(deps)
+
+	w := do(t, s, http.MethodPost, "/api/v1/telemetry/ingest", map[string]any{
+		"cluster":       "prod-west",
+		"node":          "worker-7",
+		"agent_version": "1.4.2",
+		"events": []map[string]any{
+			{
+				"id":            "telemetry-mark-root-cause-1",
+				"timestamp":     "2026-03-15T19:36:00Z",
+				"source":        "runtime-agent",
+				"resource_id":   "pod/default/api-0",
+				"resource_type": "pod",
+				"event_type":    "process",
+				"process": map[string]any{
+					"pid":  100,
+					"name": "xmrig",
+					"path": "/usr/bin/xmrig",
+				},
+			},
+		},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	runs, err := a.RuntimeIngest.ListRuns(context.Background(), runtime.IngestRunListOptions{})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("len(runs) = %d, want 1", len(runs))
+	}
+	run := runs[0]
+	if run.Status != runtime.IngestRunStatusFailed {
+		t.Fatalf("status = %q, want %q", run.Status, runtime.IngestRunStatusFailed)
+	}
+	if run.Error != "mark unavailable" {
+		t.Fatalf("run.Error = %q, want mark unavailable", run.Error)
 	}
 }
 

--- a/internal/executionstore/namespaces.go
+++ b/internal/executionstore/namespaces.go
@@ -11,5 +11,6 @@ const (
 	NamespaceRuntimeIngest          = "runtime_ingest"
 	NamespaceRuntimeReplay          = "runtime_replay"
 	NamespaceRuntimeMaterialization = "runtime_materialization"
+	NamespaceProcessedRuntimeEvent  = "processed_runtime_event"
 	NamespaceProcessedCloudEvent    = "processed_cloud_event"
 )

--- a/internal/executionstore/processed_events.go
+++ b/internal/executionstore/processed_events.go
@@ -12,6 +12,7 @@ import (
 type ProcessedEventRecord struct {
 	Namespace      string
 	EventKey       string
+	Status         string
 	PayloadHash    string
 	FirstSeenAt    time.Time
 	LastSeenAt     time.Time
@@ -19,6 +20,11 @@ type ProcessedEventRecord struct {
 	ExpiresAt      time.Time
 	DuplicateCount int
 }
+
+const (
+	ProcessedEventStatusProcessing = "processing"
+	ProcessedEventStatusProcessed  = "processed"
+)
 
 func (s *SQLiteStore) LookupProcessedEvent(ctx context.Context, namespace, eventKey string, observedAt time.Time) (*ProcessedEventRecord, error) {
 	if s == nil || s.db == nil {
@@ -53,12 +59,13 @@ func (s *SQLiteStore) LookupProcessedEvent(ctx context.Context, namespace, event
 
 	var record ProcessedEventRecord
 	err = tx.QueryRowContext(ctx, `
-		SELECT namespace, event_key, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
+		SELECT namespace, event_key, status, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
 		FROM processed_events
 		WHERE namespace = ? AND event_key = ?
 	`, namespace, eventKey).Scan(
 		&record.Namespace,
 		&record.EventKey,
+		&record.Status,
 		&record.PayloadHash,
 		&record.FirstSeenAt,
 		&record.LastSeenAt,
@@ -140,6 +147,134 @@ func (s *SQLiteStore) TouchProcessedEvent(ctx context.Context, namespace, eventK
 	return nil
 }
 
+func (s *SQLiteStore) ClaimProcessedEvent(ctx context.Context, record ProcessedEventRecord, maxRecords int) (bool, *ProcessedEventRecord, error) {
+	if s == nil || s.db == nil {
+		return true, nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	record.Namespace = strings.TrimSpace(record.Namespace)
+	record.EventKey = strings.TrimSpace(record.EventKey)
+	record.PayloadHash = strings.TrimSpace(record.PayloadHash)
+	record.Status = strings.TrimSpace(record.Status)
+	if record.Namespace == "" || record.EventKey == "" {
+		return false, nil, fmt.Errorf("processed event namespace and key are required")
+	}
+	if record.Status == "" {
+		record.Status = ProcessedEventStatusProcessing
+	}
+	claimAt := time.Now().UTC()
+	if record.FirstSeenAt.IsZero() {
+		record.FirstSeenAt = claimAt
+	} else {
+		record.FirstSeenAt = record.FirstSeenAt.UTC()
+	}
+	if record.LastSeenAt.IsZero() {
+		record.LastSeenAt = record.FirstSeenAt
+	} else {
+		record.LastSeenAt = record.LastSeenAt.UTC()
+	}
+	if record.ProcessedAt.IsZero() {
+		record.ProcessedAt = claimAt
+	} else {
+		record.ProcessedAt = record.ProcessedAt.UTC()
+	}
+	if record.ExpiresAt.IsZero() {
+		record.ExpiresAt = claimAt
+	} else {
+		record.ExpiresAt = record.ExpiresAt.UTC()
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, nil, fmt.Errorf("begin processed event claim tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM processed_events
+		WHERE namespace = ? AND expires_at <= ?
+	`, record.Namespace, claimAt); err != nil {
+		return false, nil, fmt.Errorf("prune expired processed events: %w", err)
+	}
+
+	var existing ProcessedEventRecord
+	err = tx.QueryRowContext(ctx, `
+		SELECT namespace, event_key, status, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
+		FROM processed_events
+		WHERE namespace = ? AND event_key = ?
+	`, record.Namespace, record.EventKey).Scan(
+		&existing.Namespace,
+		&existing.EventKey,
+		&existing.Status,
+		&existing.PayloadHash,
+		&existing.FirstSeenAt,
+		&existing.LastSeenAt,
+		&existing.ProcessedAt,
+		&existing.ExpiresAt,
+		&existing.DuplicateCount,
+	)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, nil, fmt.Errorf("load processed event for claim: %w", err)
+	}
+
+	claimed := false
+	if errors.Is(err, sql.ErrNoRows) {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO processed_events (
+				namespace, event_key, status, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, record.Namespace, record.EventKey, record.Status, record.PayloadHash, record.FirstSeenAt, record.LastSeenAt, record.ProcessedAt, record.ExpiresAt, record.DuplicateCount); err != nil {
+			return false, nil, fmt.Errorf("insert processed event claim: %w", err)
+		}
+		claimed = true
+	} else {
+		existing.PayloadHash = strings.TrimSpace(existing.PayloadHash)
+		if record.PayloadHash == "" || existing.PayloadHash == "" || existing.PayloadHash != record.PayloadHash {
+			if strings.TrimSpace(existing.Status) == ProcessedEventStatusProcessing {
+				if err := tx.Commit(); err != nil {
+					return false, nil, fmt.Errorf("commit processed event claim: %w", err)
+				}
+				return false, &existing, nil
+			}
+			if _, err := tx.ExecContext(ctx, `
+				UPDATE processed_events
+				SET status = ?, payload_hash = ?, first_seen_at = ?, last_seen_at = ?, processed_at = ?, expires_at = ?, duplicate_count = ?
+				WHERE namespace = ? AND event_key = ?
+			`, record.Status, record.PayloadHash, existing.FirstSeenAt, record.LastSeenAt, record.ProcessedAt, record.ExpiresAt, record.DuplicateCount, record.Namespace, record.EventKey); err != nil {
+				return false, nil, fmt.Errorf("replace processed event claim: %w", err)
+			}
+			claimed = true
+			existing = ProcessedEventRecord{}
+		}
+	}
+
+	if maxRecords > 0 && claimed {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM processed_events
+			WHERE namespace = ?
+			  AND event_key IN (
+				SELECT event_key
+				FROM processed_events
+				WHERE namespace = ?
+				ORDER BY processed_at DESC, event_key DESC
+				LIMIT -1 OFFSET ?
+			  )
+		`, record.Namespace, record.Namespace, maxRecords); err != nil {
+			return false, nil, fmt.Errorf("trim processed events: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, nil, fmt.Errorf("commit processed event claim: %w", err)
+	}
+	if claimed {
+		return true, nil, nil
+	}
+	return false, &existing, nil
+}
+
 func (s *SQLiteStore) RememberProcessedEvent(ctx context.Context, record ProcessedEventRecord, maxRecords int) error {
 	if s == nil || s.db == nil {
 		return nil
@@ -149,9 +284,13 @@ func (s *SQLiteStore) RememberProcessedEvent(ctx context.Context, record Process
 	}
 	record.Namespace = strings.TrimSpace(record.Namespace)
 	record.EventKey = strings.TrimSpace(record.EventKey)
+	record.Status = strings.TrimSpace(record.Status)
 	record.PayloadHash = strings.TrimSpace(record.PayloadHash)
 	if record.Namespace == "" || record.EventKey == "" {
 		return fmt.Errorf("processed event namespace and key are required")
+	}
+	if record.Status == "" {
+		record.Status = ProcessedEventStatusProcessed
 	}
 	if record.FirstSeenAt.IsZero() {
 		record.FirstSeenAt = time.Now().UTC()
@@ -189,14 +328,15 @@ func (s *SQLiteStore) RememberProcessedEvent(ctx context.Context, record Process
 
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO processed_events (
-			namespace, event_key, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			namespace, event_key, status, payload_hash, first_seen_at, last_seen_at, processed_at, expires_at, duplicate_count
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(namespace, event_key) DO UPDATE SET
+			status = excluded.status,
 			payload_hash = excluded.payload_hash,
 			last_seen_at = excluded.last_seen_at,
 			processed_at = excluded.processed_at,
 			expires_at = excluded.expires_at
-	`, record.Namespace, record.EventKey, record.PayloadHash, record.FirstSeenAt, record.LastSeenAt, record.ProcessedAt, record.ExpiresAt, record.DuplicateCount); err != nil {
+	`, record.Namespace, record.EventKey, record.Status, record.PayloadHash, record.FirstSeenAt, record.LastSeenAt, record.ProcessedAt, record.ExpiresAt, record.DuplicateCount); err != nil {
 		return fmt.Errorf("persist processed event: %w", err)
 	}
 

--- a/internal/executionstore/processed_events_test.go
+++ b/internal/executionstore/processed_events_test.go
@@ -1,0 +1,250 @@
+package executionstore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSQLiteStoreProcessedEventsRoundTripAndTouch(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Date(2026, 3, 12, 2, 0, 0, 0, time.UTC)
+	err = store.RememberProcessedEvent(context.Background(), ProcessedEventRecord{
+		Namespace:   NamespaceProcessedCloudEvent,
+		EventKey:    "stream|durable|tenant|source|evt-1",
+		PayloadHash: "hash-a",
+		FirstSeenAt: now,
+		LastSeenAt:  now,
+		ProcessedAt: now,
+		ExpiresAt:   now.Add(24 * time.Hour),
+	}, 100)
+	if err != nil {
+		t.Fatalf("RememberProcessedEvent: %v", err)
+	}
+
+	record, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "stream|durable|tenant|source|evt-1", now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected processed event record")
+	}
+	if record.PayloadHash != "hash-a" {
+		t.Fatalf("expected payload hash hash-a, got %#v", record)
+	}
+	if record.DuplicateCount != 0 {
+		t.Fatalf("expected read-only lookup to preserve duplicate count, got %#v", record)
+	}
+
+	if err := store.TouchProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "stream|durable|tenant|source|evt-1", now.Add(2*time.Hour), 24*time.Hour); err != nil {
+		t.Fatalf("TouchProcessedEvent: %v", err)
+	}
+
+	touched, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "stream|durable|tenant|source|evt-1", now.Add(3*time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent after touch: %v", err)
+	}
+	if touched == nil {
+		t.Fatal("expected touched processed event record")
+	}
+	if touched.DuplicateCount != 1 {
+		t.Fatalf("expected duplicate count increment to 1 after touch, got %#v", touched)
+	}
+}
+
+func TestSQLiteStoreProcessedEventsTrimOldest(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	base := time.Date(2026, 3, 12, 2, 0, 0, 0, time.UTC)
+	for i, key := range []string{"evt-1", "evt-2", "evt-3"} {
+		ts := base.Add(time.Duration(i) * time.Minute)
+		if err := store.RememberProcessedEvent(context.Background(), ProcessedEventRecord{
+			Namespace:   NamespaceProcessedCloudEvent,
+			EventKey:    key,
+			PayloadHash: key,
+			FirstSeenAt: ts,
+			LastSeenAt:  ts,
+			ProcessedAt: ts,
+			ExpiresAt:   ts.Add(24 * time.Hour),
+		}, 2); err != nil {
+			t.Fatalf("RememberProcessedEvent %s: %v", key, err)
+		}
+	}
+
+	first, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-1", base.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent first: %v", err)
+	}
+	if first != nil {
+		t.Fatalf("expected oldest processed event to be trimmed, got %#v", first)
+	}
+	last, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-3", base.Add(2*time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent last: %v", err)
+	}
+	if last == nil {
+		t.Fatal("expected newest processed event to remain after trim")
+	}
+}
+
+func TestSQLiteStoreDeleteProcessedEvent(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Date(2026, 3, 12, 4, 0, 0, 0, time.UTC)
+	if err := store.RememberProcessedEvent(context.Background(), ProcessedEventRecord{
+		Namespace:   NamespaceProcessedCloudEvent,
+		EventKey:    "evt-delete",
+		PayloadHash: "hash-a",
+		FirstSeenAt: now,
+		LastSeenAt:  now,
+		ProcessedAt: now,
+		ExpiresAt:   now.Add(24 * time.Hour),
+	}, 100); err != nil {
+		t.Fatalf("RememberProcessedEvent: %v", err)
+	}
+
+	if err := store.DeleteProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-delete"); err != nil {
+		t.Fatalf("DeleteProcessedEvent: %v", err)
+	}
+
+	record, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-delete", now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent after delete: %v", err)
+	}
+	if record != nil {
+		t.Fatalf("expected processed event to be deleted, got %#v", record)
+	}
+}
+
+func TestSQLiteStoreClaimProcessedEventPreservesFirstSeenAtOnHashReplacement(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	firstSeen := time.Now().UTC().Add(-2 * time.Hour)
+	if err := store.RememberProcessedEvent(context.Background(), ProcessedEventRecord{
+		Namespace:   NamespaceProcessedCloudEvent,
+		EventKey:    "evt-replace",
+		Status:      ProcessedEventStatusProcessed,
+		PayloadHash: "hash-a",
+		FirstSeenAt: firstSeen,
+		LastSeenAt:  firstSeen,
+		ProcessedAt: firstSeen,
+		ExpiresAt:   firstSeen.Add(24 * time.Hour),
+	}, 100); err != nil {
+		t.Fatalf("RememberProcessedEvent: %v", err)
+	}
+
+	claimed, existing, err := store.ClaimProcessedEvent(context.Background(), ProcessedEventRecord{
+		Namespace:   NamespaceProcessedCloudEvent,
+		EventKey:    "evt-replace",
+		Status:      ProcessedEventStatusProcessing,
+		PayloadHash: "hash-b",
+		FirstSeenAt: firstSeen.Add(2 * time.Hour),
+		LastSeenAt:  firstSeen.Add(2 * time.Hour),
+		ProcessedAt: firstSeen.Add(2 * time.Hour),
+		ExpiresAt:   time.Now().UTC().Add(2 * time.Hour),
+	}, 100)
+	if err != nil {
+		t.Fatalf("ClaimProcessedEvent: %v", err)
+	}
+	if !claimed {
+		t.Fatalf("claimed = %v, want true", claimed)
+	}
+	if existing != nil {
+		t.Fatalf("existing = %#v, want nil on successful replacement", existing)
+	}
+
+	record, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-replace", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected processed event record")
+	}
+	if !record.FirstSeenAt.Equal(firstSeen) {
+		t.Fatalf("first_seen_at = %s, want %s", record.FirstSeenAt, firstSeen)
+	}
+	if record.PayloadHash != "hash-b" {
+		t.Fatalf("payload_hash = %q, want hash-b", record.PayloadHash)
+	}
+}
+
+func TestSQLiteStoreClaimProcessedEventDoesNotReplaceActiveMismatchedClaim(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "executions.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC()
+	claimed, existing, err := store.ClaimProcessedEvent(context.Background(), ProcessedEventRecord{
+		Namespace:   NamespaceProcessedCloudEvent,
+		EventKey:    "evt-processing",
+		Status:      ProcessedEventStatusProcessing,
+		PayloadHash: "hash-a",
+		FirstSeenAt: now,
+		LastSeenAt:  now,
+		ProcessedAt: now,
+		ExpiresAt:   now.Add(5 * time.Minute),
+	}, 100)
+	if err != nil {
+		t.Fatalf("ClaimProcessedEvent first: %v", err)
+	}
+	if !claimed || existing != nil {
+		t.Fatalf("first claim = (%v, %#v), want (true, nil)", claimed, existing)
+	}
+
+	claimed, existing, err = store.ClaimProcessedEvent(context.Background(), ProcessedEventRecord{
+		Namespace:   NamespaceProcessedCloudEvent,
+		EventKey:    "evt-processing",
+		Status:      ProcessedEventStatusProcessing,
+		PayloadHash: "hash-b",
+		FirstSeenAt: now.Add(time.Minute),
+		LastSeenAt:  now.Add(time.Minute),
+		ProcessedAt: now.Add(time.Minute),
+		ExpiresAt:   now.Add(6 * time.Minute),
+	}, 100)
+	if err != nil {
+		t.Fatalf("ClaimProcessedEvent second: %v", err)
+	}
+	if claimed {
+		t.Fatal("expected active mismatched claim to stay unclaimed")
+	}
+	if existing == nil {
+		t.Fatal("expected existing active claim")
+	}
+	if existing.PayloadHash != "hash-a" {
+		t.Fatalf("existing payload_hash = %q, want hash-a", existing.PayloadHash)
+	}
+	if existing.Status != ProcessedEventStatusProcessing {
+		t.Fatalf("existing status = %q, want processing", existing.Status)
+	}
+
+	record, err := store.LookupProcessedEvent(context.Background(), NamespaceProcessedCloudEvent, "evt-processing", now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected processed event record")
+	}
+	if record.PayloadHash != "hash-a" {
+		t.Fatalf("payload_hash = %q, want hash-a", record.PayloadHash)
+	}
+}

--- a/internal/executionstore/sqlite.go
+++ b/internal/executionstore/sqlite.go
@@ -115,6 +115,7 @@ func initSQLiteStore(db *sql.DB) error {
 	CREATE TABLE IF NOT EXISTS processed_events (
 		namespace TEXT NOT NULL,
 		event_key TEXT NOT NULL,
+		status TEXT NOT NULL DEFAULT 'processed',
 		payload_hash TEXT NOT NULL,
 		first_seen_at TIMESTAMP NOT NULL,
 		last_seen_at TIMESTAMP NOT NULL,
@@ -130,6 +131,9 @@ func initSQLiteStore(db *sql.DB) error {
 	`
 	if _, err := db.ExecContext(context.Background(), schema); err != nil {
 		return fmt.Errorf("init execution sqlite schema: %w", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `ALTER TABLE processed_events ADD COLUMN status TEXT NOT NULL DEFAULT 'processed'`); err != nil && !strings.Contains(err.Error(), "duplicate column name: status") {
+		return fmt.Errorf("migrate processed_events status column: %w", err)
 	}
 	return nil
 }

--- a/internal/executionstore/store.go
+++ b/internal/executionstore/store.go
@@ -22,6 +22,7 @@ type Store interface {
 	LoadEvents(context.Context, string, string) ([]EventEnvelope, error)
 	LookupProcessedEvent(context.Context, string, string, time.Time) (*ProcessedEventRecord, error)
 	TouchProcessedEvent(context.Context, string, string, time.Time, time.Duration) error
+	ClaimProcessedEvent(context.Context, ProcessedEventRecord, int) (bool, *ProcessedEventRecord, error)
 	RememberProcessedEvent(context.Context, ProcessedEventRecord, int) error
 	DeleteProcessedEvent(context.Context, string, string) error
 }

--- a/internal/runtime/store.go
+++ b/internal/runtime/store.go
@@ -13,8 +13,15 @@ import (
 
 const runtimeIngestNamespace = executionstore.NamespaceRuntimeIngest
 const (
-	runtimeReplayNamespace      = executionstore.NamespaceRuntimeReplay
-	runtimeMaterializeNamespace = executionstore.NamespaceRuntimeMaterialization
+	runtimeReplayNamespace         = executionstore.NamespaceRuntimeReplay
+	runtimeMaterializeNamespace    = executionstore.NamespaceRuntimeMaterialization
+	runtimeProcessedEventNamespace = executionstore.NamespaceProcessedRuntimeEvent
+)
+
+const (
+	runtimeProcessedEventTTL        = 7 * 24 * time.Hour
+	runtimeProcessingClaimTTL       = 5 * time.Minute
+	runtimeProcessedEventMaxRecords = 100000
 )
 
 type IngestRunStatus string
@@ -108,6 +115,8 @@ type IngestStore interface {
 	LoadEvents(context.Context, string) ([]IngestEvent, error)
 	SaveCheckpoint(context.Context, string, IngestCheckpoint) (IngestCheckpoint, error)
 	LoadCheckpoint(context.Context, string) (*IngestCheckpoint, error)
+	ClaimSourceEventProcessing(context.Context, string, string, string, time.Time) (bool, error)
+	MarkSourceEventProcessed(context.Context, string, string, string, time.Time) error
 }
 
 type SQLiteIngestStore struct {
@@ -353,6 +362,109 @@ func (s *SQLiteIngestStore) SaveCheckpoint(ctx context.Context, runID string, ch
 	return checkpoint, fmt.Errorf("save runtime ingest checkpoint: concurrent update conflict")
 }
 
+func (s *SQLiteIngestStore) checkDuplicateSourceEvent(ctx context.Context, source, eventID, payloadHash string) (bool, error) {
+	if s == nil || s.store == nil {
+		return false, nil
+	}
+	eventKey := runtimeProcessedEventKey(source, eventID)
+	if eventKey == "" {
+		return false, nil
+	}
+	lookupAt := time.Now().UTC()
+	record, err := s.store.LookupProcessedEvent(ctx, runtimeProcessedEventNamespace, eventKey, lookupAt)
+	if err != nil {
+		return false, err
+	}
+	if record == nil {
+		return false, nil
+	}
+	payloadHash = strings.TrimSpace(payloadHash)
+	recordHash := strings.TrimSpace(record.PayloadHash)
+	if payloadHash != "" && recordHash != "" && recordHash != payloadHash {
+		return false, nil
+	}
+	if strings.TrimSpace(record.Status) != executionstore.ProcessedEventStatusProcessed {
+		return true, nil
+	}
+	if err := s.store.TouchProcessedEvent(ctx, runtimeProcessedEventNamespace, eventKey, lookupAt, runtimeProcessedEventTTL); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *SQLiteIngestStore) ClaimSourceEventProcessing(ctx context.Context, source, eventID, payloadHash string, observedAt time.Time) (bool, error) {
+	if s == nil || s.store == nil {
+		return false, nil
+	}
+	eventKey := runtimeProcessedEventKey(source, eventID)
+	if eventKey == "" {
+		return false, nil
+	}
+	claimAt := time.Now().UTC()
+	if observedAt.IsZero() {
+		observedAt = claimAt
+	} else {
+		observedAt = observedAt.UTC()
+	}
+	claimed, existing, err := s.store.ClaimProcessedEvent(ctx, executionstore.ProcessedEventRecord{
+		Namespace:      runtimeProcessedEventNamespace,
+		EventKey:       eventKey,
+		Status:         executionstore.ProcessedEventStatusProcessing,
+		PayloadHash:    strings.TrimSpace(payloadHash),
+		FirstSeenAt:    observedAt,
+		LastSeenAt:     observedAt,
+		ProcessedAt:    claimAt,
+		ExpiresAt:      claimAt.Add(runtimeProcessingClaimTTL),
+		DuplicateCount: 0,
+	}, runtimeProcessedEventMaxRecords)
+	if err != nil {
+		return false, err
+	}
+	if claimed {
+		return false, nil
+	}
+	if existing == nil {
+		return false, nil
+	}
+	recordHash := strings.TrimSpace(existing.PayloadHash)
+	payloadHash = strings.TrimSpace(payloadHash)
+	if payloadHash != "" && recordHash != "" && recordHash != payloadHash {
+		return false, nil
+	}
+	if strings.TrimSpace(existing.Status) == executionstore.ProcessedEventStatusProcessed {
+		if err := s.store.TouchProcessedEvent(ctx, runtimeProcessedEventNamespace, eventKey, claimAt, runtimeProcessedEventTTL); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func (s *SQLiteIngestStore) MarkSourceEventProcessed(ctx context.Context, source, eventID, payloadHash string, observedAt time.Time) error {
+	if s == nil || s.store == nil {
+		return nil
+	}
+	eventKey := runtimeProcessedEventKey(source, eventID)
+	if eventKey == "" {
+		return nil
+	}
+	processedAt := time.Now().UTC()
+	if observedAt.IsZero() {
+		observedAt = processedAt
+	} else {
+		observedAt = observedAt.UTC()
+	}
+	return s.store.RememberProcessedEvent(ctx, executionstore.ProcessedEventRecord{
+		Namespace:   runtimeProcessedEventNamespace,
+		EventKey:    eventKey,
+		Status:      executionstore.ProcessedEventStatusProcessed,
+		PayloadHash: strings.TrimSpace(payloadHash),
+		FirstSeenAt: observedAt,
+		LastSeenAt:  observedAt,
+		ProcessedAt: processedAt,
+		ExpiresAt:   processedAt.Add(runtimeProcessedEventTTL),
+	}, runtimeProcessedEventMaxRecords)
+}
+
 func runtimeIngestRunEnvelope(run *IngestRunRecord) (executionstore.RunEnvelope, error) {
 	payload, err := json.Marshal(run)
 	if err != nil {
@@ -471,4 +583,13 @@ func runtimeJobNamespaces(types []IngestJobType) []string {
 		return nil
 	}
 	return namespaces
+}
+
+func runtimeProcessedEventKey(source, eventID string) string {
+	source = strings.TrimSpace(source)
+	eventID = strings.TrimSpace(eventID)
+	if source == "" || eventID == "" {
+		return ""
+	}
+	return source + "|" + eventID
 }

--- a/internal/runtime/store_test.go
+++ b/internal/runtime/store_test.go
@@ -109,6 +109,10 @@ func (s *listAllRunsExecutionStore) TouchProcessedEvent(context.Context, string,
 	return nil
 }
 
+func (s *listAllRunsExecutionStore) ClaimProcessedEvent(context.Context, executionstore.ProcessedEventRecord, int) (bool, *executionstore.ProcessedEventRecord, error) {
+	return true, nil, nil
+}
+
 func (s *listAllRunsExecutionStore) RememberProcessedEvent(context.Context, executionstore.ProcessedEventRecord, int) error {
 	return nil
 }
@@ -139,6 +143,10 @@ func (s *casConflictExecutionStore) LookupProcessedEvent(context.Context, string
 
 func (s *casConflictExecutionStore) TouchProcessedEvent(context.Context, string, string, time.Time, time.Duration) error {
 	return nil
+}
+
+func (s *casConflictExecutionStore) ClaimProcessedEvent(context.Context, executionstore.ProcessedEventRecord, int) (bool, *executionstore.ProcessedEventRecord, error) {
+	return true, nil, nil
 }
 
 func (s *casConflictExecutionStore) RememberProcessedEvent(context.Context, executionstore.ProcessedEventRecord, int) error {
@@ -619,5 +627,174 @@ func TestSQLiteIngestStoreSaveCheckpointRetriesCompareAndSwap(t *testing.T) {
 	}
 	if storedRun.LastCheckpoint == nil || storedRun.LastCheckpoint.Cursor != "cursor-99" {
 		t.Fatalf("stored payload checkpoint = %#v, want cursor-99", storedRun.LastCheckpoint)
+	}
+}
+
+func TestSQLiteIngestStoreSourceEventDedupesMatchingPayloadHashes(t *testing.T) {
+	store, err := NewSQLiteIngestStore(filepath.Join(t.TempDir(), "runtime-ingest.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteIngestStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	observedAt := time.Date(2026, 3, 15, 18, 0, 0, 0, time.UTC)
+	if err := store.MarkSourceEventProcessed(context.Background(), "telemetry", "evt-1", "hash-a", observedAt); err != nil {
+		t.Fatalf("MarkSourceEventProcessed: %v", err)
+	}
+
+	duplicate, err := store.checkDuplicateSourceEvent(context.Background(), "telemetry", "evt-1", "hash-a")
+	if err != nil {
+		t.Fatalf("checkDuplicateSourceEvent: %v", err)
+	}
+	if !duplicate {
+		t.Fatal("expected duplicate match for same source/id/hash")
+	}
+
+	record, err := store.store.LookupProcessedEvent(context.Background(), runtimeProcessedEventNamespace, runtimeProcessedEventKey("telemetry", "evt-1"), observedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected processed event record")
+	}
+	if record.DuplicateCount != 1 {
+		t.Fatalf("duplicate_count = %d, want 1", record.DuplicateCount)
+	}
+}
+
+func TestSQLiteIngestStoreClaimSourceEventProcessingDedupesActiveClaim(t *testing.T) {
+	store, err := NewSQLiteIngestStore(filepath.Join(t.TempDir(), "runtime-ingest.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteIngestStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	observedAt := time.Date(2026, 3, 15, 18, 0, 0, 0, time.UTC)
+	duplicate, err := store.ClaimSourceEventProcessing(context.Background(), "telemetry", "evt-claim-1", "hash-a", observedAt)
+	if err != nil {
+		t.Fatalf("ClaimSourceEventProcessing first: %v", err)
+	}
+	if duplicate {
+		t.Fatal("expected first claim to be accepted")
+	}
+
+	duplicate, err = store.ClaimSourceEventProcessing(context.Background(), "telemetry", "evt-claim-1", "hash-a", observedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("ClaimSourceEventProcessing second: %v", err)
+	}
+	if !duplicate {
+		t.Fatal("expected active claim to suppress duplicate")
+	}
+
+	record, err := store.store.LookupProcessedEvent(context.Background(), runtimeProcessedEventNamespace, runtimeProcessedEventKey("telemetry", "evt-claim-1"), observedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected processed event claim record")
+	}
+	if record.Status != executionstore.ProcessedEventStatusProcessing {
+		t.Fatalf("status = %q, want %q", record.Status, executionstore.ProcessedEventStatusProcessing)
+	}
+	if record.DuplicateCount != 0 {
+		t.Fatalf("duplicate_count = %d, want 0 for in-flight claim", record.DuplicateCount)
+	}
+}
+
+func TestSQLiteIngestStoreSourceEventAllowsSameIDWithDifferentPayloadHash(t *testing.T) {
+	store, err := NewSQLiteIngestStore(filepath.Join(t.TempDir(), "runtime-ingest.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteIngestStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	observedAt := time.Date(2026, 3, 15, 18, 0, 0, 0, time.UTC)
+	if err := store.MarkSourceEventProcessed(context.Background(), "telemetry", "evt-1", "hash-a", observedAt); err != nil {
+		t.Fatalf("MarkSourceEventProcessed: %v", err)
+	}
+
+	duplicate, err := store.checkDuplicateSourceEvent(context.Background(), "telemetry", "evt-1", "hash-b")
+	if err != nil {
+		t.Fatalf("checkDuplicateSourceEvent: %v", err)
+	}
+	if duplicate {
+		t.Fatal("expected hash mismatch to bypass duplicate suppression")
+	}
+
+	record, err := store.store.LookupProcessedEvent(context.Background(), runtimeProcessedEventNamespace, runtimeProcessedEventKey("telemetry", "evt-1"), observedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected processed event record")
+	}
+	if record.DuplicateCount != 0 {
+		t.Fatalf("duplicate_count = %d, want 0", record.DuplicateCount)
+	}
+}
+
+func TestSQLiteIngestStoreSourceEventDuplicateTouchUsesWallClockTTL(t *testing.T) {
+	store, err := NewSQLiteIngestStore(filepath.Join(t.TempDir(), "runtime-ingest.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteIngestStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	now := time.Now().UTC()
+	staleObservedAt := now.Add(-(runtimeProcessedEventTTL + 24*time.Hour))
+	if err := store.MarkSourceEventProcessed(context.Background(), "telemetry", "evt-stale", "hash-a", staleObservedAt); err != nil {
+		t.Fatalf("MarkSourceEventProcessed: %v", err)
+	}
+
+	duplicate, err := store.checkDuplicateSourceEvent(context.Background(), "telemetry", "evt-stale", "hash-a")
+	if err != nil {
+		t.Fatalf("checkDuplicateSourceEvent: %v", err)
+	}
+	if !duplicate {
+		t.Fatal("expected duplicate match for stale observed_at")
+	}
+
+	record, err := store.store.LookupProcessedEvent(context.Background(), runtimeProcessedEventNamespace, runtimeProcessedEventKey("telemetry", "evt-stale"), now)
+	if err != nil {
+		t.Fatalf("LookupProcessedEvent: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected processed event record to remain after duplicate touch")
+	}
+	if !record.ExpiresAt.After(now) {
+		t.Fatalf("expires_at = %s, want after %s", record.ExpiresAt, now)
+	}
+	if record.DuplicateCount != 1 {
+		t.Fatalf("duplicate_count = %d, want 1", record.DuplicateCount)
+	}
+}
+
+func TestSQLiteIngestStoreSourceEventDuplicateComparisonTrimsStoredHash(t *testing.T) {
+	store, err := NewSQLiteIngestStore(filepath.Join(t.TempDir(), "runtime-ingest.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteIngestStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	now := time.Now().UTC()
+	if err := store.store.RememberProcessedEvent(context.Background(), executionstore.ProcessedEventRecord{
+		Namespace:   runtimeProcessedEventNamespace,
+		EventKey:    runtimeProcessedEventKey("telemetry", "evt-trim-1"),
+		Status:      executionstore.ProcessedEventStatusProcessed,
+		PayloadHash: "  hash-a  ",
+		FirstSeenAt: now,
+		LastSeenAt:  now,
+		ProcessedAt: now,
+		ExpiresAt:   now.Add(runtimeProcessedEventTTL),
+	}, runtimeProcessedEventMaxRecords); err != nil {
+		t.Fatalf("RememberProcessedEvent: %v", err)
+	}
+
+	duplicate, err := store.checkDuplicateSourceEvent(context.Background(), "telemetry", "evt-trim-1", "hash-a")
+	if err != nil {
+		t.Fatalf("checkDuplicateSourceEvent: %v", err)
+	}
+	if !duplicate {
+		t.Fatal("expected trimmed stored hash to match trimmed input")
 	}
 }


### PR DESCRIPTION
* Deduplicate runtime source payload ingestion

* Keep runtime dedupe TTL on wall clock

* Reject runtime events when dedupe checks fail

* Mark runtime events before detection side effects

* Tighten runtime dedupe store contract

* Harden runtime source dedupe semantics

* Preserve root dedupe failure causes

* Add runtime ingest processing claims

* Trim runtime ingest store interface

* Trim runtime dedupe helper surface

* Delay runtime dedupe claims until validation

* Harden processed event claims
