### PR TITLE
Add Falco runtime adapter (#335)

### DIFF
--- a/docs/RUNTIME_VISIBILITY_ARCHITECTURE.md
+++ b/docs/RUNTIME_VISIBILITY_ARCHITECTURE.md
@@ -281,6 +281,8 @@ security signals:
 - resource attributes populate workload, service, cluster, namespace, node,
   container, and image context when those fields are present
 
+For `Falco`, normalize alert JSON into `runtime_alert` observations with extracted process, file, network, and container context from `output_fields`. Do not treat Falco as the canonical process/network/file substrate; it is a detection feed with useful execution context.
+
 ## Ingestion Pipeline
 
 Recommended pipeline:

--- a/internal/runtime/adapters/falco/adapter.go
+++ b/internal/runtime/adapters/falco/adapter.go
@@ -1,0 +1,527 @@
+package falco
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/runtime"
+	"github.com/writer/cerebro/internal/runtime/adapters"
+)
+
+const sourceName = "falco"
+
+type Adapter struct{}
+
+var _ adapters.Adapter = Adapter{}
+
+type payload struct {
+	Time         string         `json:"time"`
+	Rule         string         `json:"rule"`
+	Priority     string         `json:"priority"`
+	Output       string         `json:"output"`
+	Hostname     string         `json:"hostname"`
+	Source       string         `json:"source"`
+	Tags         []string       `json:"tags"`
+	OutputFields map[string]any `json:"output_fields"`
+}
+
+func (Adapter) Source() string {
+	return sourceName
+}
+
+func (Adapter) Normalize(_ context.Context, raw []byte) ([]*runtime.RuntimeObservation, error) {
+	var event payload
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return nil, fmt.Errorf("decode falco payload: %w", err)
+	}
+
+	observedAt, err := falcoObservedAt(event)
+	if err != nil {
+		return nil, err
+	}
+	if observedAt.IsZero() || strings.TrimSpace(event.Rule) == "" {
+		return nil, fmt.Errorf("decode falco payload: unsupported event")
+	}
+
+	outputFields := cloneAnyMap(event.OutputFields)
+	metadata := map[string]any{
+		"rule_name":           strings.TrimSpace(event.Rule),
+		"severity":            strings.TrimSpace(event.Priority),
+		"description":         strings.TrimSpace(event.Output),
+		"falco_event_source":  strings.TrimSpace(event.Source),
+		"falco_hostname":      strings.TrimSpace(event.Hostname),
+		"falco_rule_tags":     compactAnyStrings(event.Tags),
+		"falco_output_fields": outputFields,
+	}
+	if eventType := stringField(outputFields, "evt.type"); eventType != "" {
+		metadata["falco_event_type"] = eventType
+	}
+	if direction := falcoDirection(outputFields); direction != "" {
+		metadata["falco_event_direction"] = direction
+	}
+
+	observation := &runtime.RuntimeObservation{
+		Kind:       runtime.ObservationKindRuntimeAlert,
+		Source:     sourceName,
+		ObservedAt: observedAt,
+		NodeName:   strings.TrimSpace(event.Hostname),
+		Process:    falcoProcess(outputFields),
+		Network:    falcoNetwork(outputFields),
+		File:       falcoFile(outputFields),
+		Container:  falcoContainer(outputFields),
+		Metadata:   metadata,
+		Raw: map[string]any{
+			"output_fields": outputFields,
+		},
+		Provenance: map[string]any{
+			"rule":     strings.TrimSpace(event.Rule),
+			"priority": strings.TrimSpace(event.Priority),
+			"output":   strings.TrimSpace(event.Output),
+			"source":   strings.TrimSpace(event.Source),
+			"hostname": strings.TrimSpace(event.Hostname),
+			"tags":     compactAnyStrings(event.Tags),
+		},
+		Tags: adapters.CompactTags(append(
+			[]string{
+				sourceName,
+				strings.ToLower(strings.TrimSpace(event.Priority)),
+				strings.ToLower(strings.TrimSpace(event.Source)),
+			},
+			compactAnyStrings(event.Tags)...,
+		)...),
+	}
+
+	applyFalcoKubernetesContext(observation, outputFields)
+	applyFalcoPrincipalContext(observation, outputFields)
+
+	normalized, err := runtime.NormalizeObservation(observation)
+	if err != nil {
+		return nil, err
+	}
+	return []*runtime.RuntimeObservation{normalized}, nil
+}
+
+func falcoObservedAt(event payload) (time.Time, error) {
+	if timestamp := strings.TrimSpace(event.Time); timestamp != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, timestamp)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("decode falco payload: invalid time: %w", err)
+		}
+		return parsed.UTC(), nil
+	}
+	for _, key := range []string{"evt.time", "evt.rawtime"} {
+		value, ok := event.OutputFields[key]
+		if !ok {
+			continue
+		}
+		parsed, ok, err := anyUnixNano(value)
+		if err != nil {
+			continue
+		}
+		if ok {
+			return parsed.UTC(), nil
+		}
+	}
+	return time.Time{}, nil
+}
+
+func falcoProcess(fields map[string]any) *runtime.ProcessEvent {
+	process := &runtime.ProcessEvent{
+		PID:        intField(fields, "proc.pid"),
+		PPID:       intField(fields, "proc.ppid"),
+		Name:       stringField(fields, "proc.name"),
+		Path:       stringField(fields, "proc.exepath", "proc.exe"),
+		Cmdline:    stringField(fields, "proc.cmdline"),
+		User:       stringField(fields, "user.name"),
+		UID:        intField(fields, "user.uid"),
+		Hash:       stringField(fields, "proc.hash.sha256", "proc.hash"),
+		ParentName: stringField(fields, "proc.pname"),
+	}
+	if isEmptyProcess(process) {
+		return nil
+	}
+	return process
+}
+
+func falcoNetwork(fields map[string]any) *runtime.NetworkEvent {
+	if !hasNetworkFields(fields) {
+		return nil
+	}
+
+	direction := falcoDirection(fields)
+	localIP := stringField(fields, "fd.lip")
+	localPort := intField(fields, "fd.lport")
+	remoteIP := stringField(fields, "fd.rip")
+	remotePort := intField(fields, "fd.rport")
+	localFallbackIP, localFallbackPort, remoteFallbackIP, remoteFallbackPort := falcoDirectionalEndpointFallbacks(fields, direction)
+	if localIP == "" {
+		localIP = localFallbackIP
+	}
+	if localPort == 0 {
+		localPort = localFallbackPort
+	}
+	if remoteIP == "" {
+		remoteIP = remoteFallbackIP
+	}
+	if remotePort == 0 {
+		remotePort = remoteFallbackPort
+	}
+
+	network := &runtime.NetworkEvent{
+		Direction: direction,
+		Protocol:  strings.ToLower(stringField(fields, "fd.l4proto", "fd.type")),
+		Domain:    stringField(fields, "fd.cip.name", "fd.rip.name"),
+	}
+	switch direction {
+	case "inbound":
+		network.SrcIP = remoteIP
+		network.SrcPort = remotePort
+		network.DstIP = localIP
+		network.DstPort = localPort
+	default:
+		network.SrcIP = localIP
+		network.SrcPort = localPort
+		network.DstIP = remoteIP
+		network.DstPort = remotePort
+	}
+	if isEmptyNetwork(network) {
+		return nil
+	}
+	return network
+}
+
+func falcoFile(fields map[string]any) *runtime.FileEvent {
+	switch strings.ToLower(strings.TrimSpace(stringField(fields, "fd.type"))) {
+	case "unix", "ipv4", "ipv6":
+		return nil
+	}
+	path := stringField(fields, "fd.name", "fs.path.name")
+	if hasNetworkFields(fields) && looksLikeSocketDescriptor(path) {
+		return nil
+	}
+	operation := falcoFileOperation(stringField(fields, "evt.type"), stringField(fields, "evt.arg.flags"), boolField(fields, "evt.is_open_write"))
+	if path == "" || operation == "" {
+		return nil
+	}
+	return &runtime.FileEvent{
+		Operation: operation,
+		Path:      path,
+		User:      stringField(fields, "user.name"),
+		Size:      int64Field(fields, "fd.size", "file.size"),
+		Hash:      stringField(fields, "fd.hash", "file.sha256"),
+	}
+}
+
+func falcoContainer(fields map[string]any) *runtime.ContainerEvent {
+	image := strings.TrimSpace(stringField(fields, "container.image"))
+	if image == "" {
+		repository := stringField(fields, "container.image.repository")
+		tag := stringField(fields, "container.image.tag")
+		switch {
+		case repository != "" && tag != "":
+			image = repository + ":" + tag
+		case repository != "":
+			image = repository
+		}
+	}
+
+	container := &runtime.ContainerEvent{
+		ContainerID:   stringField(fields, "container.id", "container.full_id"),
+		ContainerName: stringField(fields, "container.name"),
+		Image:         image,
+		ImageID:       stringField(fields, "container.image.digest", "container.image.id"),
+		Namespace:     stringField(fields, "k8s.ns.name"),
+		PodName:       stringField(fields, "k8s.pod.name"),
+		Privileged:    boolField(fields, "container.privileged"),
+		Capabilities: compactAnyStrings([]string{
+			stringField(fields, "container.capabilities"),
+		}),
+	}
+	if isEmptyContainer(container) {
+		return nil
+	}
+	return container
+}
+
+func applyFalcoKubernetesContext(observation *runtime.RuntimeObservation, fields map[string]any) {
+	if observation == nil {
+		return
+	}
+	namespace := stringField(fields, "k8s.ns.name")
+	podName := stringField(fields, "k8s.pod.name")
+	if namespace != "" {
+		observation.Namespace = namespace
+	}
+	if observation.Metadata == nil {
+		observation.Metadata = make(map[string]any)
+	}
+	if podName != "" {
+		observation.Metadata["k8s_pod_name"] = podName
+		if namespace != "" {
+			observation.WorkloadRef = "pod:" + namespace + "/" + podName
+		} else {
+			observation.WorkloadRef = "pod:" + podName
+		}
+	}
+	if podUID := stringField(fields, "k8s.pod.uid"); podUID != "" {
+		observation.WorkloadUID = podUID
+	}
+	if cluster := stringField(fields, "k8s.cluster.name", "k8s.cluster.uid"); cluster != "" {
+		observation.Cluster = cluster
+	}
+}
+
+func applyFalcoPrincipalContext(observation *runtime.RuntimeObservation, fields map[string]any) {
+	if observation == nil {
+		return
+	}
+	observation.PrincipalID = stringField(fields, "user.name", "user.loginname")
+}
+
+func falcoDirection(fields map[string]any) string {
+	switch strings.ToLower(stringField(fields, "evt.type")) {
+	case "connect", "connectat", "sendto", "sendmsg", "sendmmsg":
+		return "outbound"
+	case "accept", "accept4", "listen", "recvfrom", "recvmsg", "recvmmsg":
+		return "inbound"
+	default:
+		return ""
+	}
+}
+
+func falcoDirectionalEndpointFallbacks(fields map[string]any, direction string) (string, int, string, int) {
+	switch direction {
+	case "outbound":
+		return stringField(fields, "fd.cip"), intField(fields, "fd.cport"), stringField(fields, "fd.sip"), intField(fields, "fd.sport")
+	case "inbound":
+		return stringField(fields, "fd.sip"), intField(fields, "fd.sport"), stringField(fields, "fd.cip"), intField(fields, "fd.cport")
+	default:
+		return stringField(fields, "fd.cip"), intField(fields, "fd.cport"), stringField(fields, "fd.sip"), intField(fields, "fd.sport")
+	}
+}
+
+func falcoFileOperation(eventType, flags string, openWrite bool) string {
+	eventType = strings.ToLower(strings.TrimSpace(eventType))
+	flags = strings.ToUpper(strings.TrimSpace(flags))
+
+	switch eventType {
+	case "creat":
+		return "modify"
+	case "open", "openat", "openat2":
+		if openWrite ||
+			strings.Contains(flags, "O_WRONLY") ||
+			strings.Contains(flags, "O_RDWR") ||
+			strings.Contains(flags, "O_CREAT") ||
+			strings.Contains(flags, "O_TRUNC") ||
+			strings.Contains(flags, "O_APPEND") {
+			return "modify"
+		}
+		return "read"
+	case "read", "pread", "preadv", "readv":
+		return "read"
+	case "write", "pwrite", "pwritev", "writev", "truncate", "ftruncate", "chmod", "fchmod", "chown", "fchown", "mkdir", "mkdirat", "rename", "renameat", "renameat2", "link", "linkat", "symlink", "symlinkat", "setxattr", "fsetxattr", "removexattr", "fremovexattr":
+		return "modify"
+	case "unlink", "unlinkat", "rmdir":
+		return "delete"
+	default:
+		return ""
+	}
+}
+
+func hasNetworkFields(fields map[string]any) bool {
+	fdType := strings.ToLower(stringField(fields, "fd.type"))
+	if fdType == "ipv4" || fdType == "ipv6" || fdType == "unix" {
+		return true
+	}
+	return hasAnyField(fields, "fd.l4proto", "fd.lip", "fd.rip", "fd.sip", "fd.cip", "fd.lport", "fd.rport", "fd.sport", "fd.cport")
+}
+
+func isEmptyProcess(process *runtime.ProcessEvent) bool {
+	return process == nil ||
+		(process.PID == 0 &&
+			process.PPID == 0 &&
+			process.Name == "" &&
+			process.Path == "" &&
+			process.Cmdline == "" &&
+			process.User == "" &&
+			process.UID == 0 &&
+			process.Hash == "" &&
+			process.ParentName == "")
+}
+
+func isEmptyNetwork(network *runtime.NetworkEvent) bool {
+	return network == nil ||
+		(network.Direction == "" &&
+			network.Protocol == "" &&
+			network.SrcIP == "" &&
+			network.SrcPort == 0 &&
+			network.DstIP == "" &&
+			network.DstPort == 0 &&
+			network.Domain == "")
+}
+
+func isEmptyContainer(container *runtime.ContainerEvent) bool {
+	return container == nil ||
+		(container.ContainerID == "" &&
+			container.ContainerName == "" &&
+			container.Image == "" &&
+			container.ImageID == "" &&
+			container.Namespace == "" &&
+			container.PodName == "" &&
+			!container.Privileged &&
+			len(container.Capabilities) == 0)
+}
+
+func stringField(fields map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := fields[key]
+		if !ok {
+			continue
+		}
+		switch typed := value.(type) {
+		case string:
+			if trimmed := strings.TrimSpace(typed); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+func boolField(fields map[string]any, key string) bool {
+	value, ok := fields[key]
+	if !ok {
+		return false
+	}
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		parsed, err := strconv.ParseBool(strings.TrimSpace(typed))
+		return err == nil && parsed
+	default:
+		return false
+	}
+}
+
+func intField(fields map[string]any, keys ...string) int {
+	for _, key := range keys {
+		value, ok := fields[key]
+		if !ok {
+			continue
+		}
+		if parsed, ok := anyInt64(value); ok {
+			return int(parsed)
+		}
+	}
+	return 0
+}
+
+func int64Field(fields map[string]any, keys ...string) int64 {
+	for _, key := range keys {
+		value, ok := fields[key]
+		if !ok {
+			continue
+		}
+		if parsed, ok := anyInt64(value); ok {
+			return parsed
+		}
+	}
+	return 0
+}
+
+func anyInt64(value any) (int64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		if typed < math.MinInt64 || typed > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(typed), true
+	case int:
+		return int64(typed), true
+	case int64:
+		return typed, true
+	case json.Number:
+		parsed, err := typed.Int64()
+		return parsed, err == nil
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func anyUnixNano(value any) (time.Time, bool, error) {
+	switch typed := value.(type) {
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return time.Time{}, false, nil
+		}
+		if parsed, err := time.Parse(time.RFC3339Nano, trimmed); err == nil {
+			return parsed.UTC(), true, nil
+		}
+		unixNano, err := strconv.ParseInt(trimmed, 10, 64)
+		if err != nil {
+			return time.Time{}, false, err
+		}
+		return time.Unix(0, unixNano).UTC(), true, nil
+	case float64:
+		if typed < math.MinInt64 || typed > math.MaxInt64 {
+			return time.Time{}, false, fmt.Errorf("timestamp %v overflows int64", typed)
+		}
+		return time.Unix(0, int64(typed)).UTC(), true, nil
+	case json.Number:
+		unixNano, err := typed.Int64()
+		if err != nil {
+			return time.Time{}, false, err
+		}
+		return time.Unix(0, unixNano).UTC(), true, nil
+	default:
+		return time.Time{}, false, nil
+	}
+}
+
+func cloneAnyMap(input map[string]any) map[string]any {
+	if len(input) == 0 {
+		return nil
+	}
+	cloned := make(map[string]any, len(input))
+	for key, value := range input {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func compactAnyStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	return adapters.CompactTags(values...)
+}
+
+func hasAnyField(fields map[string]any, keys ...string) bool {
+	for _, key := range keys {
+		if _, ok := fields[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeSocketDescriptor(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	if strings.Contains(path, "->") {
+		return true
+	}
+	return strings.HasPrefix(path, "unix://")
+}

--- a/internal/runtime/adapters/falco/adapter_test.go
+++ b/internal/runtime/adapters/falco/adapter_test.go
@@ -1,0 +1,474 @@
+package falco
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+func TestAdapterSource(t *testing.T) {
+	if got := (Adapter{}).Source(); got != sourceName {
+		t.Fatalf("Source() = %q, want %q", got, sourceName)
+	}
+}
+
+func TestAdapterNormalizeNetworkAlert(t *testing.T) {
+	raw := []byte(`{
+		"time": "2026-03-16T08:45:12.123456789Z",
+		"rule": "Unexpected outbound connection destination",
+		"priority": "Critical",
+		"output": "Unexpected outbound connection to api.example.com",
+		"hostname": "node-a",
+		"source": "syscall",
+		"tags": ["network", "mitre_command_and_control"],
+		"output_fields": {
+			"k8s.ns.name": "payments",
+			"k8s.pod.name": "payments-api-7f5c9d",
+			"k8s.pod.uid": "pod-123",
+			"container.id": "abc123",
+			"container.name": "payments-api",
+			"container.image.repository": "ghcr.io/evalops/payments",
+			"container.image.tag": "1.2.3",
+			"container.image.digest": "sha256:deadbeef",
+			"proc.pid": 173,
+			"proc.ppid": 1,
+			"proc.name": "curl",
+			"proc.pname": "bash",
+			"proc.exepath": "/usr/bin/curl",
+			"proc.cmdline": "curl https://api.example.com",
+			"user.name": "root",
+			"user.uid": 0,
+			"fd.l4proto": "tcp",
+			"fd.cip": "10.1.2.3",
+			"fd.cip.name": "api.example.com",
+			"fd.cport": 49832,
+			"fd.sip": "203.0.113.20",
+			"fd.sport": 443,
+			"evt.type": "connect",
+			"evt.dir": "<"
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+
+	observation := observations[0]
+	if observation.Kind != runtime.ObservationKindRuntimeAlert {
+		t.Fatalf("Kind = %q, want %q", observation.Kind, runtime.ObservationKindRuntimeAlert)
+	}
+	wantTime := time.Date(2026, 3, 16, 8, 45, 12, 123456789, time.UTC)
+	if !observation.ObservedAt.Equal(wantTime) {
+		t.Fatalf("ObservedAt = %s, want %s", observation.ObservedAt, wantTime)
+	}
+	if observation.NodeName != "node-a" {
+		t.Fatalf("NodeName = %q, want node-a", observation.NodeName)
+	}
+	if observation.Namespace != "payments" {
+		t.Fatalf("Namespace = %q, want payments", observation.Namespace)
+	}
+	if observation.WorkloadRef != "pod:payments/payments-api-7f5c9d" {
+		t.Fatalf("WorkloadRef = %q, want pod:payments/payments-api-7f5c9d", observation.WorkloadRef)
+	}
+	if observation.WorkloadUID != "pod-123" {
+		t.Fatalf("WorkloadUID = %q, want pod-123", observation.WorkloadUID)
+	}
+	if observation.ContainerID != "abc123" {
+		t.Fatalf("ContainerID = %q, want abc123", observation.ContainerID)
+	}
+	if observation.ImageRef != "ghcr.io/evalops/payments:1.2.3" {
+		t.Fatalf("ImageRef = %q, want ghcr.io/evalops/payments:1.2.3", observation.ImageRef)
+	}
+	if observation.ImageID != "sha256:deadbeef" {
+		t.Fatalf("ImageID = %q, want sha256:deadbeef", observation.ImageID)
+	}
+	if observation.PrincipalID != "root" {
+		t.Fatalf("PrincipalID = %q, want root", observation.PrincipalID)
+	}
+	if observation.Process == nil {
+		t.Fatal("expected process context")
+	}
+	if observation.Process.Name != "curl" || observation.Process.Path != "/usr/bin/curl" {
+		t.Fatalf("Process = %#v, want curl /usr/bin/curl", observation.Process)
+	}
+	if observation.Network == nil {
+		t.Fatal("expected network context")
+	}
+	if observation.Network.Direction != "outbound" {
+		t.Fatalf("Network.Direction = %q, want outbound", observation.Network.Direction)
+	}
+	if observation.Network.SrcIP != "10.1.2.3" || observation.Network.DstIP != "203.0.113.20" {
+		t.Fatalf("Network = %#v, want local->remote mapping", observation.Network)
+	}
+	if observation.Network.DstPort != 443 {
+		t.Fatalf("Network.DstPort = %d, want 443", observation.Network.DstPort)
+	}
+	if observation.Network.Domain != "api.example.com" {
+		t.Fatalf("Network.Domain = %q, want api.example.com", observation.Network.Domain)
+	}
+	if got := observation.Metadata["rule_name"]; got != "Unexpected outbound connection destination" {
+		t.Fatalf("rule_name = %#v, want rule name", got)
+	}
+	if got := observation.Metadata["severity"]; got != "Critical" {
+		t.Fatalf("severity = %#v, want Critical", got)
+	}
+	if !containsTag(observation.Tags, "network") || !containsTag(observation.Tags, "critical") {
+		t.Fatalf("Tags = %#v, want Falco tags plus priority", observation.Tags)
+	}
+}
+
+func TestAdapterNormalizeFileAlertWithOutputFieldTimestampFallback(t *testing.T) {
+	raw := []byte(`{
+		"rule": "Write below etc",
+		"priority": "Warning",
+		"output": "File below /etc opened for writing",
+		"hostname": "node-b",
+		"source": "syscall",
+		"output_fields": {
+			"evt.time": "not-a-timestamp",
+			"evt.rawtime": "1773620000000000000",
+			"evt.type": "openat",
+			"evt.arg.flags": "O_WRONLY|O_CREAT|O_TRUNC",
+			"fd.name": "/etc/shadow",
+			"proc.name": "vi",
+			"proc.exepath": "/usr/bin/vi",
+			"proc.pid": "921",
+			"user.name": "alice"
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+
+	observation := observations[0]
+	wantTime := time.Unix(0, 1773620000000000000).UTC()
+	if !observation.ObservedAt.Equal(wantTime) {
+		t.Fatalf("ObservedAt = %s, want %s", observation.ObservedAt, wantTime)
+	}
+	if observation.File == nil {
+		t.Fatal("expected file context")
+	}
+	if observation.File.Operation != "modify" {
+		t.Fatalf("File.Operation = %q, want modify", observation.File.Operation)
+	}
+	if observation.File.Path != "/etc/shadow" {
+		t.Fatalf("File.Path = %q, want /etc/shadow", observation.File.Path)
+	}
+	if observation.Process == nil || observation.Process.PID != 921 {
+		t.Fatalf("Process = %#v, want pid 921", observation.Process)
+	}
+	if observation.PrincipalID != "alice" {
+		t.Fatalf("PrincipalID = %q, want alice", observation.PrincipalID)
+	}
+	if observation.Network != nil {
+		t.Fatalf("Network = %#v, want nil for file-only Falco alert", observation.Network)
+	}
+	if rawFields, ok := observation.Raw["output_fields"].(map[string]any); !ok || rawFields["fd.name"] != "/etc/shadow" {
+		t.Fatalf("Raw output_fields = %#v, want fd.name preserved", observation.Raw["output_fields"])
+	}
+}
+
+func TestAdapterNormalizeCreatWithoutFlagsIsModify(t *testing.T) {
+	raw := []byte(`{
+		"time": "2026-03-16T09:00:12.123456789Z",
+		"rule": "Create suspicious file",
+		"priority": "Warning",
+		"output": "creat on suspicious file",
+		"hostname": "node-c",
+		"source": "syscall",
+		"output_fields": {
+			"evt.type": "creat",
+			"fd.name": "/tmp/dropper",
+			"proc.name": "python"
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+	if observations[0].File == nil {
+		t.Fatal("expected file context")
+	}
+	if observations[0].File.Operation != "modify" {
+		t.Fatalf("File.Operation = %q, want modify", observations[0].File.Operation)
+	}
+}
+
+func TestAdapterNormalizeDoesNotUseCWDAsFilePathFallback(t *testing.T) {
+	raw := []byte(`{
+		"time": "2026-03-16T09:01:12.123456789Z",
+		"rule": "Directory context only",
+		"priority": "Info",
+		"output": "cwd present without file path",
+		"hostname": "node-c",
+		"source": "syscall",
+		"output_fields": {
+			"evt.type": "unlink",
+			"proc.cwd": "/workspace/app",
+			"proc.name": "rm"
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+	if observations[0].File != nil {
+		t.Fatalf("File = %#v, want nil when only proc.cwd is present", observations[0].File)
+	}
+}
+
+func TestAdapterNormalizeUnixSocketAlertDoesNotCreateFileContext(t *testing.T) {
+	raw := []byte(`{
+		"time": "2026-03-16T09:02:12.123456789Z",
+		"rule": "Unix socket activity",
+		"priority": "Notice",
+		"output": "sendmsg on docker socket",
+		"hostname": "node-d",
+		"source": "syscall",
+		"output_fields": {
+			"evt.type": "sendmsg",
+			"fd.type": "unix",
+			"fd.name": "/var/run/docker.sock",
+			"proc.name": "docker"
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+	if observations[0].Network == nil {
+		t.Fatal("expected network context for unix socket alert")
+	}
+	if observations[0].File != nil {
+		t.Fatalf("File = %#v, want nil for unix socket alert", observations[0].File)
+	}
+}
+
+func TestAdapterNormalizeIPv4SocketWriteDoesNotCreateFileContext(t *testing.T) {
+	raw := []byte(`{
+		"time": "2026-03-16T09:03:12.123456789Z",
+		"rule": "Socket write activity",
+		"priority": "Notice",
+		"output": "write on remote socket",
+		"hostname": "node-e",
+		"source": "syscall",
+		"output_fields": {
+			"evt.type": "write",
+			"fd.type": "ipv4",
+			"fd.name": "10.1.2.3:49832->203.0.113.20:443",
+			"fd.cip": "10.1.2.3",
+			"fd.cport": 49832,
+			"fd.sip": "203.0.113.20",
+			"fd.sport": 443,
+			"proc.name": "curl"
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+	if observations[0].Network == nil {
+		t.Fatal("expected network context for ipv4 socket alert")
+	}
+	if observations[0].File != nil {
+		t.Fatalf("File = %#v, want nil for ipv4 socket alert", observations[0].File)
+	}
+}
+
+func TestAdapterNormalizeInboundNetworkAlertUsesServerClientFallbacks(t *testing.T) {
+	raw := []byte(`{
+		"time": "2026-03-16T08:50:12.123456789Z",
+		"rule": "Unexpected inbound listener activity",
+		"priority": "Error",
+		"output": "Accepted inbound connection on 8443",
+		"hostname": "node-b",
+		"source": "syscall",
+		"output_fields": {
+			"evt.type": "accept",
+			"evt.dir": "<",
+			"fd.type": "ipv4",
+			"fd.cip": "198.51.100.7",
+			"fd.cport": 55221,
+			"fd.sip": "10.1.2.4",
+			"fd.sport": 8443
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+
+	network := observations[0].Network
+	if network == nil {
+		t.Fatal("expected network context")
+	}
+	if network.Direction != "inbound" {
+		t.Fatalf("Network.Direction = %q, want inbound", network.Direction)
+	}
+	if network.SrcIP != "198.51.100.7" || network.SrcPort != 55221 {
+		t.Fatalf("Network source = %#v, want remote client", network)
+	}
+	if network.DstIP != "10.1.2.4" || network.DstPort != 8443 {
+		t.Fatalf("Network destination = %#v, want local server", network)
+	}
+}
+
+func TestAdapterNormalizeNetworkAlertWithNumericPortsOnly(t *testing.T) {
+	raw := []byte(`{
+		"time": "2026-03-16T08:55:12.123456789Z",
+		"rule": "Port-only socket activity",
+		"priority": "Info",
+		"output": "Connect with numeric ports only",
+		"hostname": "node-f",
+		"source": "syscall",
+		"output_fields": {
+			"evt.type": "connect",
+			"fd.cport": 49832,
+			"fd.sport": 443,
+			"proc.name": "curl"
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+
+	network := observations[0].Network
+	if network == nil {
+		t.Fatal("expected network context")
+	}
+	if network.Direction != "outbound" {
+		t.Fatalf("Network.Direction = %q, want outbound", network.Direction)
+	}
+	if network.SrcPort != 49832 || network.DstPort != 443 {
+		t.Fatalf("Network ports = %#v, want 49832 -> 443", network)
+	}
+}
+
+func TestAdapterNormalizeSocketTupleWithoutFDTypeDoesNotCreateFileContext(t *testing.T) {
+	raw := []byte(`{
+		"time": "2026-03-16T08:56:12.123456789Z",
+		"rule": "Socket tuple write",
+		"priority": "Notice",
+		"output": "write on socket tuple without fd.type",
+		"hostname": "node-g",
+		"source": "syscall",
+		"output_fields": {
+			"evt.type": "write",
+			"fd.name": "10.1.2.3:49832->203.0.113.20:443",
+			"fd.cip": "10.1.2.3",
+			"fd.cport": 49832,
+			"fd.sip": "203.0.113.20",
+			"fd.sport": 443,
+			"proc.name": "curl"
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+	if observations[0].Network == nil {
+		t.Fatal("expected network context")
+	}
+	if observations[0].File != nil {
+		t.Fatalf("File = %#v, want nil for socket tuple without fd.type", observations[0].File)
+	}
+}
+
+func TestAdapterNormalizeUnknownDirectionDoesNotSynthesizeSelfLoopEndpoints(t *testing.T) {
+	raw := []byte(`{
+		"time": "2026-03-16T08:57:12.123456789Z",
+		"rule": "Unknown direction socket metadata",
+		"priority": "Info",
+		"output": "socket tuple with only client endpoint fields",
+		"hostname": "node-h",
+		"source": "syscall",
+		"output_fields": {
+			"evt.type": "getsockopt",
+			"fd.cip": "10.1.2.3",
+			"fd.cport": 49832,
+			"proc.name": "curl"
+		}
+	}`)
+
+	observations, err := (Adapter{}).Normalize(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("len(observations) = %d, want 1", len(observations))
+	}
+
+	network := observations[0].Network
+	if network == nil {
+		t.Fatal("expected network context")
+	}
+	if network.Direction != "" {
+		t.Fatalf("Network.Direction = %q, want empty for unknown direction", network.Direction)
+	}
+	if network.SrcIP != "10.1.2.3" || network.SrcPort != 49832 {
+		t.Fatalf("Network source = %#v, want client endpoint preserved", network)
+	}
+	if network.DstIP != "" || network.DstPort != 0 {
+		t.Fatalf("Network destination = %#v, want empty destination instead of self-loop", network)
+	}
+}
+
+func TestAdapterNormalizeRejectsUnsupportedPayload(t *testing.T) {
+	_, err := (Adapter{}).Normalize(context.Background(), []byte(`{"priority":"Critical"}`))
+	if err == nil {
+		t.Fatal("expected unsupported payload error")
+	}
+	if !strings.Contains(err.Error(), "unsupported event") {
+		t.Fatalf("error = %v, want unsupported event", err)
+	}
+}
+
+func containsTag(tags []string, want string) bool {
+	for _, tag := range tags {
+		if tag == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/adapters/hubble/golden_test.go
+++ b/internal/runtime/adapters/hubble/golden_test.go
@@ -1,0 +1,163 @@
+package hubble
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+func TestAdapterNormalizeGoldenPayloads(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		fixture           string
+		wantKind          runtime.RuntimeObservationKind
+		wantResourceID    string
+		wantWorkloadRef   string
+		wantDirection     string
+		wantProtocol      string
+		wantDstIP         string
+		wantDstPort       int
+		wantVerdict       string
+		wantPrimaryID     int
+		wantPeerID        int
+		wantDomain        string
+		wantObservationAt string
+	}{
+		{
+			name:              "egress tcp",
+			fixture:           "egress_tcp.golden.json",
+			wantKind:          runtime.ObservationKindNetworkFlow,
+			wantResourceID:    "pod:default/xwing",
+			wantWorkloadRef:   "workload:default/xwing",
+			wantDirection:     "outbound",
+			wantProtocol:      "TCP",
+			wantDstIP:         "10.244.1.208",
+			wantDstPort:       80,
+			wantVerdict:       "DROPPED",
+			wantPrimaryID:     56030,
+			wantPeerID:        56031,
+			wantObservationAt: "2024-07-09T17:55:50.869739112Z",
+		},
+		{
+			name:              "ingress udp",
+			fixture:           "ingress_udp.golden.json",
+			wantKind:          runtime.ObservationKindNetworkFlow,
+			wantResourceID:    "pod:kube-system/coredns-56f8",
+			wantWorkloadRef:   "workload:kube-system/coredns",
+			wantDirection:     "inbound",
+			wantProtocol:      "UDP",
+			wantDstIP:         "10.244.2.19",
+			wantDstPort:       53,
+			wantVerdict:       "FORWARDED",
+			wantPrimaryID:     12938,
+			wantPeerID:        2,
+			wantObservationAt: "2024-07-09T18:01:00Z",
+		},
+		{
+			name:              "dns query",
+			fixture:           "dns_query.golden.json",
+			wantKind:          runtime.ObservationKindDNSQuery,
+			wantResourceID:    "pod:default/xwing",
+			wantWorkloadRef:   "workload:default/xwing",
+			wantDirection:     "outbound",
+			wantProtocol:      "UDP",
+			wantDstIP:         "10.96.0.10",
+			wantDstPort:       53,
+			wantVerdict:       "FORWARDED",
+			wantPrimaryID:     1234,
+			wantPeerID:        5678,
+			wantDomain:        "api.github.com.",
+			wantObservationAt: "2024-07-09T18:01:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := mustReadHubbleFixture(t, tt.fixture)
+			observations, err := (Adapter{}).Normalize(context.Background(), raw)
+			if err != nil {
+				t.Fatalf("Normalize(%s): %v", tt.fixture, err)
+			}
+			if len(observations) != 1 {
+				t.Fatalf("len(observations) = %d, want 1", len(observations))
+			}
+
+			observation := observations[0]
+			if observation.Kind != tt.wantKind {
+				t.Fatalf("kind = %s, want %s", observation.Kind, tt.wantKind)
+			}
+			if observation.ResourceID != tt.wantResourceID {
+				t.Fatalf("resource_id = %q, want %q", observation.ResourceID, tt.wantResourceID)
+			}
+			if observation.WorkloadRef != tt.wantWorkloadRef {
+				t.Fatalf("workload_ref = %q, want %q", observation.WorkloadRef, tt.wantWorkloadRef)
+			}
+			if got := observation.ObservedAt.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"); got != tt.wantObservationAt {
+				t.Fatalf("observed_at = %q, want %q", got, tt.wantObservationAt)
+			}
+			if observation.Network == nil {
+				t.Fatal("expected network context")
+			}
+			if observation.Network.Direction != tt.wantDirection {
+				t.Fatalf("network.direction = %q, want %q", observation.Network.Direction, tt.wantDirection)
+			}
+			if observation.Network.Protocol != tt.wantProtocol {
+				t.Fatalf("network.protocol = %q, want %q", observation.Network.Protocol, tt.wantProtocol)
+			}
+			if observation.Network.DstIP != tt.wantDstIP {
+				t.Fatalf("network.dst_ip = %q, want %q", observation.Network.DstIP, tt.wantDstIP)
+			}
+			if observation.Network.DstPort != tt.wantDstPort {
+				t.Fatalf("network.dst_port = %d, want %d", observation.Network.DstPort, tt.wantDstPort)
+			}
+			if tt.wantDomain != "" && observation.Network.Domain != tt.wantDomain {
+				t.Fatalf("network.domain = %q, want %q", observation.Network.Domain, tt.wantDomain)
+			}
+			if got := observation.Metadata["verdict"]; got != tt.wantVerdict {
+				t.Fatalf("metadata.verdict = %#v, want %q", got, tt.wantVerdict)
+			}
+			if got := observation.Metadata["primary_identity"]; !matchesIntMetadata(got, tt.wantPrimaryID) {
+				t.Fatalf("metadata.primary_identity = %#v, want %d", got, tt.wantPrimaryID)
+			}
+			if got := observation.Metadata["peer_identity"]; !matchesIntMetadata(got, tt.wantPeerID) {
+				t.Fatalf("metadata.peer_identity = %#v, want %d", got, tt.wantPeerID)
+			}
+		})
+	}
+}
+
+func mustReadHubbleFixture(t *testing.T, name string) []byte {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", name, err)
+	}
+	return raw
+}
+
+func matchesIntMetadata(got any, want int) bool {
+	switch value := got.(type) {
+	case int:
+		return value == want
+	case int32:
+		return int(value) == want
+	case int64:
+		return int(value) == want
+	case uint32:
+		return int(value) == want
+	case uint64:
+		return int(value) == want
+	case float64:
+		return int(value) == want
+	default:
+		return false
+	}
+}

--- a/internal/runtime/adapters/hubble/testdata/dns_query.golden.json
+++ b/internal/runtime/adapters/hubble/testdata/dns_query.golden.json
@@ -1,0 +1,83 @@
+{
+  "time": "2024-07-09T18:05:00Z",
+  "flow": {
+    "time": "2024-07-09T18:01:00Z",
+    "verdict": "FORWARDED",
+    "IP": {
+      "source": "10.244.0.10",
+      "destination": "10.96.0.10",
+      "ipVersion": "IPv4"
+    },
+    "l4": {
+      "UDP": {
+        "source_port": 53000,
+        "destination_port": 53
+      }
+    },
+    "source_names": [
+      "xwing.default"
+    ],
+    "destination_names": [
+      "api.github.com"
+    ],
+    "trace_observation_point": "TO_PROXY",
+    "l7": {
+      "type": "RESPONSE",
+      "dns": {
+        "query": "api.github.com.",
+        "ips": [
+          "140.82.114.5"
+        ],
+        "ttl": 300,
+        "cnames": [
+          "github.com."
+        ],
+        "observation_source": "proxy",
+        "rcode": 0,
+        "qtypes": [
+          "A"
+        ],
+        "rrtypes": [
+          "CNAME",
+          "A"
+        ]
+      }
+    },
+    "source": {
+      "ID": 101,
+      "identity": 1234,
+      "cluster_name": "prod-west",
+      "labels": [
+        "k8s:app=xwing"
+      ],
+      "namespace": "default",
+      "pod_name": "xwing",
+      "workloads": [
+        {
+          "name": "xwing",
+          "kind": "Deployment"
+        }
+      ]
+    },
+    "destination": {
+      "ID": 202,
+      "identity": 5678,
+      "cluster_name": "remote-east",
+      "labels": [
+        "k8s:app=coredns"
+      ],
+      "namespace": "kube-system",
+      "pod_name": "coredns-7d8f",
+      "workloads": [
+        {
+          "name": "coredns",
+          "kind": "Deployment"
+        }
+      ]
+    },
+    "Type": "L7",
+    "node_name": "worker-3",
+    "traffic_direction": "EGRESS"
+  },
+  "node_name": "worker-3"
+}

--- a/internal/runtime/adapters/hubble/testdata/egress_tcp.golden.json
+++ b/internal/runtime/adapters/hubble/testdata/egress_tcp.golden.json
@@ -1,0 +1,54 @@
+{
+  "flow": {
+    "time": "2024-07-09T17:55:50.869739112Z",
+    "uuid": "flow-123",
+    "verdict": "DROPPED",
+    "IP": {
+      "source": "10.244.3.187",
+      "destination": "10.244.1.208",
+      "ipVersion": "IPv4"
+    },
+    "l4": {
+      "TCP": {
+        "source_port": 44916,
+        "destination_port": 80
+      }
+    },
+    "source": {
+      "ID": 501,
+      "identity": 56030,
+      "namespace": "default",
+      "labels": [
+        "k8s:app=xwing"
+      ],
+      "pod_name": "xwing",
+      "workloads": [
+        {
+          "name": "xwing",
+          "kind": "Deployment"
+        }
+      ]
+    },
+    "destination": {
+      "ID": 777,
+      "identity": 56031,
+      "namespace": "default",
+      "labels": [
+        "k8s:app=deathstar"
+      ],
+      "pod_name": "deathstar-6c94dcc57b-ssqjd",
+      "workloads": [
+        {
+          "name": "deathstar",
+          "kind": "Deployment"
+        }
+      ]
+    },
+    "Type": "L3_L4",
+    "node_name": "kind-kind/kind-worker",
+    "traffic_direction": "EGRESS",
+    "drop_reason_desc": "POLICY_DENIED"
+  },
+  "node_name": "kind-kind/kind-worker",
+  "time": "2024-07-09T17:55:50.869739112Z"
+}

--- a/internal/runtime/adapters/hubble/testdata/ingress_udp.golden.json
+++ b/internal/runtime/adapters/hubble/testdata/ingress_udp.golden.json
@@ -1,0 +1,46 @@
+{
+  "flow": {
+    "time": "2024-07-09T18:01:00Z",
+    "verdict": "FORWARDED",
+    "IP": {
+      "source": "1.2.3.4",
+      "destination": "10.244.2.19",
+      "ipVersion": "IPv4"
+    },
+    "l4": {
+      "UDP": {
+        "source_port": 53000,
+        "destination_port": 53
+      }
+    },
+    "source": {
+      "ID": 17,
+      "identity": 2,
+      "labels": [
+        "reserved:world"
+      ]
+    },
+    "destination": {
+      "ID": 42,
+      "identity": 12938,
+      "namespace": "kube-system",
+      "pod_name": "coredns-56f8",
+      "workloads": [
+        {
+          "name": "coredns",
+          "kind": "Deployment"
+        }
+      ]
+    },
+    "Type": "L3_L4",
+    "traffic_direction": "INGRESS",
+    "source_names": [
+      "client.example.com"
+    ],
+    "destination_names": [
+      "kube-dns.kube-system.svc.cluster.local"
+    ]
+  },
+  "node_name": "worker-2",
+  "time": "2024-07-09T18:01:00Z"
+}


### PR DESCRIPTION
* Add Falco runtime adapter

* Tighten Falco network detection

* Correct Falco network normalization

* Drop Falco socket tuple as domain

* Harden Falco file normalization

* Avoid file context for Falco unix sockets

* Exclude socket descriptors from Falco file events

* Fix Falco network field detection

* Avoid Falco socket tuple file events

* Avoid Falco self-loop endpoint fallback
