### PR TITLE
Bind runtime service identity context (#339)

### DIFF
--- a/internal/graph/edge_helpers.go
+++ b/internal/graph/edge_helpers.go
@@ -1,0 +1,27 @@
+package graph
+
+// AddEdgeIfMissing adds an edge only when both endpoints exist and there is no
+// active edge with the same ID or the same source/target/kind tuple already in
+// the graph. It returns true only when a new edge is accepted.
+func AddEdgeIfMissing(g *Graph, edge *Edge) bool {
+	if g == nil || edge == nil || edge.Source == "" || edge.Target == "" {
+		return false
+	}
+	if _, ok := g.GetNode(edge.Source); !ok {
+		return false
+	}
+	if _, ok := g.GetNode(edge.Target); !ok {
+		return false
+	}
+	for _, existing := range g.GetOutEdges(edge.Source) {
+		if existing == nil {
+			continue
+		}
+		if existing.ID == edge.ID || (existing.Target == edge.Target && existing.Kind == edge.Kind) {
+			return false
+		}
+	}
+	before := len(g.GetOutEdges(edge.Source))
+	g.AddEdge(edge)
+	return len(g.GetOutEdges(edge.Source)) > before
+}

--- a/internal/graph/edge_helpers_test.go
+++ b/internal/graph/edge_helpers_test.go
@@ -1,0 +1,45 @@
+package graph
+
+import "testing"
+
+func TestAddEdgeIfMissingAddsEdgeOnce(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "source", Kind: NodeKindWorkload})
+	g.AddNode(&Node{ID: "target", Kind: NodeKindObservation})
+
+	edge := &Edge{
+		ID:     "source->target:targets",
+		Source: "source",
+		Target: "target",
+		Kind:   EdgeKindTargets,
+		Effect: EdgeEffectAllow,
+	}
+
+	if !AddEdgeIfMissing(g, edge) {
+		t.Fatal("expected first AddEdgeIfMissing to add edge")
+	}
+	if AddEdgeIfMissing(g, edge) {
+		t.Fatal("expected duplicate AddEdgeIfMissing to return false")
+	}
+	if got := len(g.GetOutEdges("source")); got != 1 {
+		t.Fatalf("len(outEdges) = %d, want 1", got)
+	}
+}
+
+func TestAddEdgeIfMissingRequiresEndpoints(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "source", Kind: NodeKindWorkload})
+
+	if AddEdgeIfMissing(g, &Edge{
+		ID:     "source->missing:targets",
+		Source: "source",
+		Target: "missing",
+		Kind:   EdgeKindTargets,
+		Effect: EdgeEffectAllow,
+	}) {
+		t.Fatal("expected AddEdgeIfMissing to reject missing target")
+	}
+	if got := len(g.GetOutEdges("source")); got != 0 {
+		t.Fatalf("len(outEdges) = %d, want 0", got)
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -17,6 +18,9 @@ type Graph struct {
 	inEdges  map[string][]*Edge // target -> edges
 	mu       sync.RWMutex
 	metadata Metadata
+
+	activeNodeCount atomic.Int64
+	activeEdgeCount atomic.Int64
 
 	// Traversal cache for expensive reachability queries.
 	blastRadiusCache   sync.Map
@@ -141,6 +145,7 @@ func (g *Graph) RemoveNode(id string) bool {
 		return false
 	}
 
+	g.removeEdgesByNodeLocked(id)
 	now := temporalNowUTC()
 	node.DeletedAt = &now
 	node.UpdatedAt = now
@@ -148,7 +153,7 @@ func (g *Graph) RemoveNode(id string) bool {
 		node.Version = 1
 	}
 	node.Version++
-	g.removeEdgesByNodeLocked(id)
+	g.activeNodeCount.Add(-1)
 	g.markGraphChangedLocked()
 	return true
 }
@@ -161,17 +166,10 @@ func (g *Graph) RemoveEdge(source, target string, kind EdgeKind) bool {
 	removed := false
 	if edges, ok := g.outEdges[source]; ok {
 		for _, edge := range edges {
-			if edge == nil || edge.DeletedAt != nil {
-				continue
-			}
-			if edge.Source == source && edge.Target == target && edge.Kind == kind {
-				now := temporalNowUTC()
-				edge.DeletedAt = &now
-				if edge.Version <= 0 {
-					edge.Version = 1
+			if edge != nil && edge.Source == source && edge.Target == target && edge.Kind == kind {
+				if g.markEdgeDeletedLocked(edge) {
+					removed = true
 				}
-				edge.Version++
-				removed = true
 			}
 		}
 	}
@@ -376,31 +374,12 @@ func (g *Graph) GetAllEdges() map[string][]*Edge {
 
 // NodeCount returns the number of nodes
 func (g *Graph) NodeCount() int {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	count := 0
-	for _, node := range g.nodes {
-		if node == nil || node.DeletedAt != nil {
-			continue
-		}
-		count++
-	}
-	return count
+	return int(g.activeNodeCount.Load())
 }
 
 // EdgeCount returns the total number of edges
 func (g *Graph) EdgeCount() int {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	count := 0
-	for _, edges := range g.outEdges {
-		for _, edge := range edges {
-			if g.activeEdgeLocked(edge) {
-				count++
-			}
-		}
-	}
-	return count
+	return int(g.activeEdgeCount.Load())
 }
 
 // Clear removes all nodes and edges
@@ -410,6 +389,8 @@ func (g *Graph) Clear() {
 	g.nodes = make(map[string]*Node)
 	g.outEdges = make(map[string][]*Edge)
 	g.inEdges = make(map[string][]*Edge)
+	g.activeNodeCount.Store(0)
+	g.activeEdgeCount.Store(0)
 	g.markGraphChangedLocked()
 }
 
@@ -419,6 +400,7 @@ func (g *Graph) ClearEdges() {
 	defer g.mu.Unlock()
 	g.outEdges = make(map[string][]*Edge)
 	g.inEdges = make(map[string][]*Edge)
+	g.activeEdgeCount.Store(0)
 	g.markGraphChangedLocked()
 }
 
@@ -796,7 +778,9 @@ func (g *Graph) addNodeLocked(node *Node) bool {
 	}
 
 	now := temporalNowUTC()
+	wasActive := false
 	if existing, ok := g.nodes[node.ID]; ok && existing != nil {
+		wasActive = existing.DeletedAt == nil
 		if existing.CreatedAt.IsZero() {
 			existing.CreatedAt = now
 		}
@@ -832,6 +816,9 @@ func (g *Graph) addNodeLocked(node *Node) bool {
 	node.DeletedAt = nil
 	g.appendNodePropertiesHistoryLocked(node, node.UpdatedAt)
 	g.nodes[node.ID] = node
+	if !wasActive {
+		g.activeNodeCount.Add(1)
+	}
 	return true
 }
 
@@ -850,6 +837,7 @@ func (g *Graph) addEdgeLocked(edge *Edge) bool {
 	edge.DeletedAt = nil
 	g.outEdges[edge.Source] = append(g.outEdges[edge.Source], edge)
 	g.inEdges[edge.Target] = append(g.inEdges[edge.Target], edge)
+	g.activeEdgeCount.Add(1)
 	return true
 }
 
@@ -941,6 +929,7 @@ func (g *Graph) markEdgeDeletedLocked(edge *Edge) bool {
 		edge.Version = 1
 	}
 	edge.Version++
+	g.activeEdgeCount.Add(-1)
 	return true
 }
 

--- a/internal/graph/graph_counts_bench_test.go
+++ b/internal/graph/graph_counts_bench_test.go
@@ -1,0 +1,39 @@
+package graph
+
+import (
+	"strconv"
+	"testing"
+)
+
+func BenchmarkGraphNodeCount(b *testing.B) {
+	g := New()
+	for i := 0; i < 100000; i++ {
+		g.AddNode(&Node{ID: "node:" + strconv.Itoa(i), Kind: NodeKindWorkload})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = g.NodeCount()
+	}
+}
+
+func BenchmarkGraphEdgeCount(b *testing.B) {
+	g := New()
+	for i := 0; i < 100001; i++ {
+		g.AddNode(&Node{ID: "node:" + strconv.Itoa(i), Kind: NodeKindWorkload})
+	}
+	for i := 0; i < 100000; i++ {
+		g.AddEdge(&Edge{
+			ID:     "edge:" + strconv.Itoa(i),
+			Source: "node:" + strconv.Itoa(i),
+			Target: "node:" + strconv.Itoa(i+1),
+			Kind:   EdgeKindTargets,
+			Effect: EdgeEffectAllow,
+		})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = g.EdgeCount()
+	}
+}

--- a/internal/graph/graph_counts_test.go
+++ b/internal/graph/graph_counts_test.go
@@ -1,0 +1,91 @@
+package graph
+
+import "testing"
+
+func TestGraphCountsMatchFullScanAcrossMutations(t *testing.T) {
+	g := New()
+
+	assertCountsMatchScan := func(step string) {
+		t.Helper()
+		wantNodes, wantEdges := fullScanGraphCounts(g)
+		if got := g.NodeCount(); got != wantNodes {
+			t.Fatalf("%s: NodeCount = %d, want %d", step, got, wantNodes)
+		}
+		if got := g.EdgeCount(); got != wantEdges {
+			t.Fatalf("%s: EdgeCount = %d, want %d", step, got, wantEdges)
+		}
+	}
+
+	assertCountsMatchScan("empty")
+
+	g.AddNode(&Node{ID: "user:alice", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "role:admin", Kind: NodeKindRole})
+	g.AddNode(&Node{ID: "bucket:data", Kind: NodeKindBucket})
+	assertCountsMatchScan("after add nodes")
+
+	g.AddEdge(&Edge{ID: "e1", Source: "user:alice", Target: "role:admin", Kind: EdgeKindCanAssume, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "e2", Source: "role:admin", Target: "bucket:data", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "e3", Source: "bucket:data", Target: "user:alice", Kind: EdgeKindOwns, Effect: EdgeEffectAllow})
+	assertCountsMatchScan("after add edges")
+
+	g.SetNodeProperty("user:alice", "team", "platform")
+	assertCountsMatchScan("after property mutation")
+
+	if !g.RemoveEdge("user:alice", "role:admin", EdgeKindCanAssume) {
+		t.Fatal("expected RemoveEdge to remove edge")
+	}
+	assertCountsMatchScan("after remove edge")
+
+	if !g.RemoveNode("role:admin") {
+		t.Fatal("expected RemoveNode to remove node")
+	}
+	assertCountsMatchScan("after remove node")
+
+	g.AddNode(&Node{ID: "role:admin", Kind: NodeKindRole})
+	g.AddEdge(&Edge{ID: "e4", Source: "user:alice", Target: "role:admin", Kind: EdgeKindCanAssume, Effect: EdgeEffectAllow})
+	assertCountsMatchScan("after revive node and edge")
+
+	g.ClearEdges()
+	assertCountsMatchScan("after clear edges")
+
+	g.Clear()
+	assertCountsMatchScan("after clear graph")
+}
+
+func TestGraphCountsMatchFullScanAfterSnapshotRestore(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "a", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "b", Kind: NodeKindRole})
+	g.AddNode(&Node{ID: "c", Kind: NodeKindBucket})
+	g.AddEdge(&Edge{ID: "e1", Source: "a", Target: "b", Kind: EdgeKindCanAssume, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "e2", Source: "b", Target: "c", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+
+	restored := RestoreFromSnapshot(CreateSnapshot(g))
+	wantNodes, wantEdges := fullScanGraphCounts(restored)
+	if got := restored.NodeCount(); got != wantNodes {
+		t.Fatalf("restored NodeCount = %d, want %d", got, wantNodes)
+	}
+	if got := restored.EdgeCount(); got != wantEdges {
+		t.Fatalf("restored EdgeCount = %d, want %d", got, wantEdges)
+	}
+}
+
+func fullScanGraphCounts(g *Graph) (nodes int, edges int) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	for _, node := range g.nodes {
+		if node == nil || node.DeletedAt != nil {
+			continue
+		}
+		nodes++
+	}
+	for _, edgeList := range g.outEdges {
+		for _, edge := range edgeList {
+			if g.activeEdgeLocked(edge) {
+				edges++
+			}
+		}
+	}
+	return nodes, edges
+}

--- a/internal/runtime/observations.go
+++ b/internal/runtime/observations.go
@@ -442,12 +442,9 @@ func normalizeObservationContexts(observation *RuntimeObservation) {
 			observation.PrincipalID = observation.ControlPlane.User
 		}
 	}
-	if observation.Trace != nil {
-		observation.Trace.TraceID = strings.TrimSpace(observation.Trace.TraceID)
-		observation.Trace.SpanID = strings.TrimSpace(observation.Trace.SpanID)
-		observation.Trace.ServiceName = strings.TrimSpace(observation.Trace.ServiceName)
-	}
 	if observation.Metadata != nil {
+		serviceName := stringMapValue(observation.Metadata, "service_name")
+		serviceNamespace := stringMapValue(observation.Metadata, "service_namespace")
 		if observation.Cluster == "" {
 			observation.Cluster = firstNonEmptyRuntime(
 				stringMapValue(observation.Metadata, "cluster"),
@@ -490,6 +487,7 @@ func normalizeObservationContexts(observation *RuntimeObservation) {
 			observation.Namespace = firstNonEmptyRuntime(
 				stringMapValue(observation.Metadata, "namespace"),
 				stringMapValue(observation.Metadata, "kubernetes_namespace"),
+				serviceNamespace,
 			)
 		}
 		if observation.PrincipalID == "" {
@@ -501,7 +499,13 @@ func normalizeObservationContexts(observation *RuntimeObservation) {
 				stringMapValue(observation.Metadata, "user"),
 			)
 		}
+		if observation.Trace == nil {
+			observation.Trace = traceContextFromMetadata(observation.Metadata)
+		} else if observation.Trace.ServiceName == "" {
+			observation.Trace.ServiceName = serviceName
+		}
 	}
+	observation.Trace = normalizeTraceContext(observation.Trace)
 	if observation.WorkloadRef == "" {
 		if kind, namespace, _ := parseObservationResourceRef(observation.ResourceID); isWorkloadResourceKind(kind) {
 			observation.WorkloadRef = observation.ResourceID
@@ -521,6 +525,10 @@ func normalizeObservationContexts(observation *RuntimeObservation) {
 		if kind, _, name := parseObservationResourceRef(observation.ResourceID); kind == "container" {
 			observation.ContainerID = name
 		}
+	}
+	if observation.Trace != nil && observation.Trace.ServiceName != "" && observation.WorkloadRef == "" && observation.ContainerID == "" && controlPlaneResourceID(observation.ControlPlane) == "" {
+		observation.ResourceID = serviceObservationResourceID(observation)
+		observation.ResourceType = "service"
 	}
 	if observation.PrincipalID == "" {
 		observation.PrincipalID = firstNonEmptyRuntime(
@@ -569,6 +577,9 @@ func parseObservationResourceRef(value string) (string, string, string) {
 	if kind == "" || remainder == "" {
 		return "", "", ""
 	}
+	if kind == "container" {
+		return kind, "", remainder
+	}
 	namespace, name, hasNamespace := strings.Cut(remainder, "/")
 	if hasNamespace {
 		namespace = strings.TrimSpace(namespace)
@@ -583,11 +594,53 @@ func parseObservationResourceRef(value string) (string, string, string) {
 
 func isWorkloadResourceKind(kind string) bool {
 	switch strings.TrimSpace(kind) {
-	case "workload", "deployment", "daemonset", "statefulset", "replicaset", "job", "cronjob", "service":
+	case "workload", "deployment", "daemonset", "statefulset", "replicaset", "job", "cronjob":
 		return true
 	default:
 		return false
 	}
+}
+
+func traceContextFromMetadata(metadata map[string]any) *TraceContext {
+	if len(metadata) == 0 {
+		return nil
+	}
+	return normalizeTraceContext(&TraceContext{
+		TraceID:     stringMapValue(metadata, "trace_id"),
+		SpanID:      stringMapValue(metadata, "span_id"),
+		ServiceName: stringMapValue(metadata, "service_name"),
+	})
+}
+
+func normalizeTraceContext(trace *TraceContext) *TraceContext {
+	if trace == nil {
+		return nil
+	}
+	trace.TraceID = strings.TrimSpace(trace.TraceID)
+	trace.SpanID = strings.TrimSpace(trace.SpanID)
+	trace.ServiceName = strings.TrimSpace(trace.ServiceName)
+	if trace.TraceID == "" && trace.SpanID == "" && trace.ServiceName == "" {
+		return nil
+	}
+	return trace
+}
+
+func serviceObservationResourceID(observation *RuntimeObservation) string {
+	if observation == nil || observation.Trace == nil {
+		return ""
+	}
+	serviceName := strings.TrimSpace(observation.Trace.ServiceName)
+	if serviceName == "" {
+		return ""
+	}
+	namespace := strings.TrimSpace(observation.Namespace)
+	if namespace == "" && observation.Metadata != nil {
+		namespace = stringMapValue(observation.Metadata, "service_namespace")
+	}
+	if namespace != "" {
+		return "service:" + namespace + "/" + serviceName
+	}
+	return "service:" + serviceName
 }
 
 func (p *ProcessEvent) GetUser() string {

--- a/internal/runtime/observations_test.go
+++ b/internal/runtime/observations_test.go
@@ -811,6 +811,73 @@ func TestNormalizeObservationPrefersControlPlaneIdentityOverServiceIdentity(t *t
 	}
 }
 
+func TestNormalizeObservationSkipsWhitespaceMetadataBeforePrincipalFallback(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:     "falco",
+		ObservedAt: time.Date(2026, 3, 16, 9, 35, 15, 0, time.UTC),
+		Process: &ProcessEvent{
+			Name: "sh",
+			User: "root",
+		},
+		Metadata: map[string]any{
+			"principal_id": " ",
+			"user":         "\t",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeObservation: %v", err)
+	}
+	if observation.PrincipalID != "root" {
+		t.Fatalf("PrincipalID = %q, want root", observation.PrincipalID)
+	}
+}
+
+func TestNormalizeObservationSkipsWhitespaceMetadataBeforeWorkloadNamespaceBackfill(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:     "otel",
+		ObservedAt: time.Date(2026, 3, 16, 9, 35, 45, 0, time.UTC),
+		ResourceID: "deployment:backend/payments-api",
+		Process: &ProcessEvent{
+			Name: "payments-api",
+		},
+		Metadata: map[string]any{
+			"namespace": " ",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeObservation: %v", err)
+	}
+	if observation.WorkloadRef != "deployment:backend/payments-api" {
+		t.Fatalf("WorkloadRef = %q, want deployment:backend/payments-api", observation.WorkloadRef)
+	}
+	if observation.Namespace != "backend" {
+		t.Fatalf("Namespace = %q, want backend", observation.Namespace)
+	}
+}
+
+func TestNormalizeObservationSkipsWhitespaceMetadataBeforeContainerBackfill(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:     "otel",
+		ObservedAt: time.Date(2026, 3, 16, 9, 36, 0, 0, time.UTC),
+		ResourceID: "container:containerd://svc-123",
+		Process: &ProcessEvent{
+			Name: "payments-api",
+		},
+		Metadata: map[string]any{
+			"container_id": "\n",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeObservation: %v", err)
+	}
+	if observation.ContainerID != "containerd://svc-123" {
+		t.Fatalf("ContainerID = %q, want containerd://svc-123", observation.ContainerID)
+	}
+	if observation.ResourceType != "container" {
+		t.Fatalf("ResourceType = %q, want container", observation.ResourceType)
+	}
+}
+
 func TestNormalizeObservationRejectsWhitespaceOnlyTraceContext(t *testing.T) {
 	observation, err := NormalizeObservation(&RuntimeObservation{
 		Source:     "otel",

--- a/internal/runtime/observations_test.go
+++ b/internal/runtime/observations_test.go
@@ -560,6 +560,275 @@ func TestNormalizeObservationBindsNamespaceFromWorkloadRef(t *testing.T) {
 	}
 }
 
+func TestNormalizeObservationBindsServiceIdentityFromTraceContext(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:     "otel",
+		ObservedAt: time.Date(2026, 3, 16, 9, 30, 0, 0, time.UTC),
+		Trace: &TraceContext{
+			TraceID:     "abc123",
+			ServiceName: "payments-api",
+		},
+		Metadata: map[string]any{
+			"service_namespace": "backend",
+			"cluster_name":      "prod-west",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeObservation: %v", err)
+	}
+	if observation.ResourceType != "service" {
+		t.Fatalf("ResourceType = %q, want service", observation.ResourceType)
+	}
+	if observation.ResourceID != "service:backend/payments-api" {
+		t.Fatalf("ResourceID = %q, want service:backend/payments-api", observation.ResourceID)
+	}
+	if observation.WorkloadRef != "" {
+		t.Fatalf("WorkloadRef = %q, want empty", observation.WorkloadRef)
+	}
+	if observation.Namespace != "backend" {
+		t.Fatalf("Namespace = %q, want backend", observation.Namespace)
+	}
+	if observation.Cluster != "prod-west" {
+		t.Fatalf("Cluster = %q, want prod-west", observation.Cluster)
+	}
+}
+
+func TestObservationFromEventReconstructsServiceIdentityFromMetadata(t *testing.T) {
+	observation := mustObservationFromEvent(t, &RuntimeEvent{
+		ID:        "evt-service-1",
+		Timestamp: time.Date(2026, 3, 16, 9, 31, 0, 0, time.UTC),
+		Source:    "otel",
+		EventType: "span",
+		Metadata: map[string]any{
+			"trace_id":          " abc123 ",
+			"span_id":           " def456 ",
+			"service_name":      "checkout",
+			"service_namespace": "storefront",
+			"cluster_name":      "prod-east",
+		},
+	})
+	if observation.Trace == nil {
+		t.Fatal("expected trace context")
+	}
+	if observation.Trace.ServiceName != "checkout" {
+		t.Fatalf("Trace.ServiceName = %q, want checkout", observation.Trace.ServiceName)
+	}
+	if observation.Trace.TraceID != "abc123" || observation.Trace.SpanID != "def456" {
+		t.Fatalf("Trace IDs = %q/%q, want abc123/def456", observation.Trace.TraceID, observation.Trace.SpanID)
+	}
+	if observation.ResourceType != "service" {
+		t.Fatalf("ResourceType = %q, want service", observation.ResourceType)
+	}
+	if observation.ResourceID != "service:storefront/checkout" {
+		t.Fatalf("ResourceID = %q, want service:storefront/checkout", observation.ResourceID)
+	}
+	if observation.WorkloadRef != "" {
+		t.Fatalf("WorkloadRef = %q, want empty", observation.WorkloadRef)
+	}
+	if observation.Namespace != "storefront" {
+		t.Fatalf("Namespace = %q, want storefront", observation.Namespace)
+	}
+	if observation.Cluster != "prod-east" {
+		t.Fatalf("Cluster = %q, want prod-east", observation.Cluster)
+	}
+}
+
+func TestObservationFromEventRejectsWhitespaceOnlyTraceMetadata(t *testing.T) {
+	observation, err := ObservationFromEvent(&RuntimeEvent{
+		ID:        "evt-trace-whitespace-1",
+		Timestamp: time.Date(2026, 3, 16, 9, 31, 30, 0, time.UTC),
+		Source:    "otel",
+		EventType: "span",
+		Metadata: map[string]any{
+			"trace_id":     " ",
+			"span_id":      "\t",
+			"service_name": "\n",
+		},
+	})
+	if err == nil {
+		t.Fatalf("ObservationFromEvent() error = nil, want invalid observation")
+	}
+	if observation != nil {
+		t.Fatalf("ObservationFromEvent() observation = %#v, want nil", observation)
+	}
+}
+
+func TestNormalizeObservationPrefersWorkloadIdentityOverServiceIdentity(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:      "otel",
+		ObservedAt:  time.Date(2026, 3, 16, 9, 32, 0, 0, time.UTC),
+		WorkloadRef: "deployment:payments/api",
+		Trace: &TraceContext{
+			ServiceName: "payments-api",
+		},
+		Metadata: map[string]any{
+			"service_namespace": "backend",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeObservation: %v", err)
+	}
+	if observation.WorkloadRef != "deployment:payments/api" {
+		t.Fatalf("WorkloadRef = %q, want deployment:payments/api", observation.WorkloadRef)
+	}
+	if observation.ResourceID != "deployment:payments/api" {
+		t.Fatalf("ResourceID = %q, want workload identity preserved", observation.ResourceID)
+	}
+	if observation.ResourceType != "workload" {
+		t.Fatalf("ResourceType = %q, want workload", observation.ResourceType)
+	}
+}
+
+func TestNormalizeObservationPrefersContainerIdentityOverServiceIdentity(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:      "otel",
+		ObservedAt:  time.Date(2026, 3, 16, 9, 33, 0, 0, time.UTC),
+		ContainerID: "containerd://abc123",
+		Trace: &TraceContext{
+			ServiceName: "payments-api",
+		},
+		Metadata: map[string]any{
+			"service_namespace": "backend",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeObservation: %v", err)
+	}
+	if observation.ContainerID != "containerd://abc123" {
+		t.Fatalf("ContainerID = %q, want containerd://abc123", observation.ContainerID)
+	}
+	if observation.ResourceID != "container:containerd://abc123" {
+		t.Fatalf("ResourceID = %q, want container identity preserved", observation.ResourceID)
+	}
+	if observation.ResourceType != "container" {
+		t.Fatalf("ResourceType = %q, want container", observation.ResourceType)
+	}
+}
+
+func TestNormalizeObservationBindsServiceIdentityOverAdapterResourceID(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:       "hubble",
+		ObservedAt:   time.Date(2026, 3, 16, 9, 34, 0, 0, time.UTC),
+		ResourceID:   "pods:backend/payments-api-7f9d:exec",
+		ResourceType: "pods",
+		Trace: &TraceContext{
+			ServiceName: "payments-api",
+		},
+		Metadata: map[string]any{
+			"service_namespace": "backend",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeObservation: %v", err)
+	}
+	if observation.ResourceID != "service:backend/payments-api" {
+		t.Fatalf("ResourceID = %q, want service:backend/payments-api", observation.ResourceID)
+	}
+	if observation.ResourceType != "service" {
+		t.Fatalf("ResourceType = %q, want service", observation.ResourceType)
+	}
+	if observation.WorkloadRef != "" {
+		t.Fatalf("WorkloadRef = %q, want empty", observation.WorkloadRef)
+	}
+}
+
+func TestNormalizeObservationPrefersResourceIDBackfilledWorkloadOverServiceIdentity(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:     "otel",
+		ObservedAt: time.Date(2026, 3, 16, 9, 34, 30, 0, time.UTC),
+		ResourceID: "deployment:backend/payments-api",
+		Trace: &TraceContext{
+			ServiceName: "payments-api",
+		},
+		Metadata: map[string]any{
+			"service_namespace": "backend",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeObservation: %v", err)
+	}
+	if observation.WorkloadRef != "deployment:backend/payments-api" {
+		t.Fatalf("WorkloadRef = %q, want deployment:backend/payments-api", observation.WorkloadRef)
+	}
+	if observation.ResourceID != "deployment:backend/payments-api" {
+		t.Fatalf("ResourceID = %q, want deployment:backend/payments-api", observation.ResourceID)
+	}
+	if observation.ResourceType != "workload" {
+		t.Fatalf("ResourceType = %q, want workload", observation.ResourceType)
+	}
+}
+
+func TestNormalizeObservationPrefersResourceIDBackfilledContainerOverServiceIdentity(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:     "otel",
+		ObservedAt: time.Date(2026, 3, 16, 9, 34, 45, 0, time.UTC),
+		ResourceID: "container:containerd://svc-123",
+		Trace: &TraceContext{
+			ServiceName: "payments-api",
+		},
+		Metadata: map[string]any{
+			"service_namespace": "backend",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeObservation: %v", err)
+	}
+	if observation.ContainerID != "containerd://svc-123" {
+		t.Fatalf("ContainerID = %q, want containerd://svc-123", observation.ContainerID)
+	}
+	if observation.ResourceID != "container:containerd://svc-123" {
+		t.Fatalf("ResourceID = %q, want container:containerd://svc-123", observation.ResourceID)
+	}
+	if observation.ResourceType != "container" {
+		t.Fatalf("ResourceType = %q, want container", observation.ResourceType)
+	}
+}
+
+func TestNormalizeObservationPrefersControlPlaneIdentityOverServiceIdentity(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:     "k8s_audit",
+		ObservedAt: time.Date(2026, 3, 16, 9, 35, 0, 0, time.UTC),
+		ControlPlane: &ControlPlaneContext{
+			Resource:  "pods",
+			Namespace: "backend",
+			Name:      "payments-api-7f9d",
+		},
+		Trace: &TraceContext{
+			ServiceName: "payments-api",
+		},
+		Metadata: map[string]any{
+			"service_namespace": "backend",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeObservation: %v", err)
+	}
+	if observation.ResourceID != "pods:backend/payments-api-7f9d" {
+		t.Fatalf("ResourceID = %q, want pods:backend/payments-api-7f9d", observation.ResourceID)
+	}
+	if observation.ResourceType != "pods" {
+		t.Fatalf("ResourceType = %q, want pods", observation.ResourceType)
+	}
+}
+
+func TestNormalizeObservationRejectsWhitespaceOnlyTraceContext(t *testing.T) {
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		Source:     "otel",
+		ObservedAt: time.Date(2026, 3, 16, 9, 35, 30, 0, time.UTC),
+		Trace: &TraceContext{
+			TraceID:     " ",
+			SpanID:      "\t",
+			ServiceName: "\n",
+		},
+	})
+	if err == nil {
+		t.Fatalf("NormalizeObservation() error = nil, want invalid observation")
+	}
+	if observation != nil {
+		t.Fatalf("NormalizeObservation() observation = %#v, want nil", observation)
+	}
+}
+
 func TestDetectionEngineProcessObservationRejectsInvalidObservation(t *testing.T) {
 	engine := NewDetectionEngine()
 	findings := engine.ProcessObservation(context.Background(), &RuntimeObservation{

--- a/internal/runtime/response.go
+++ b/internal/runtime/response.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -830,8 +831,8 @@ func runtimeMapValueToString(values map[string]any, key string) string {
 
 func firstNonEmptyRuntime(values ...string) string {
 	for _, value := range values {
-		if value != "" {
-			return value
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
 		}
 	}
 	return ""

--- a/internal/runtimegraph/bench_test.go
+++ b/internal/runtimegraph/bench_test.go
@@ -1,0 +1,52 @@
+package runtimegraph
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+func BenchmarkMaterializeObservationsIntoGraphDeferredFinalize(b *testing.B) {
+	const batchSize = 50
+	const totalObservations = 10000
+
+	observations := make([]*runtime.RuntimeObservation, 0, totalObservations)
+	baseTime := time.Date(2026, 3, 16, 21, 0, 0, 0, time.UTC)
+	for i := 0; i < totalObservations; i++ {
+		observations = append(observations, &runtime.RuntimeObservation{
+			ID:          "runtime:process_exec:" + strconv.Itoa(i),
+			Source:      "tetragon",
+			Kind:        runtime.ObservationKindProcessExec,
+			ObservedAt:  baseTime.Add(time.Duration(i) * time.Second),
+			RecordedAt:  baseTime.Add(time.Duration(i)*time.Second + time.Millisecond),
+			WorkloadRef: "deployment:prod/api",
+			Process: &runtime.ProcessEvent{
+				Name: "sh",
+				Path: "/bin/sh",
+			},
+		})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g := graph.New()
+		g.AddNode(&graph.Node{
+			ID:   "deployment:prod/api",
+			Kind: graph.NodeKindDeployment,
+			Name: "api",
+		})
+		g.BuildIndex()
+
+		for start := 0; start < len(observations); start += batchSize {
+			end := start + batchSize
+			if end > len(observations) {
+				end = len(observations)
+			}
+			MaterializeObservationsIntoGraph(g, observations[start:end], baseTime)
+		}
+		FinalizeMaterializedGraph(g, baseTime)
+	}
+}

--- a/internal/runtimegraph/evidence.go
+++ b/internal/runtimegraph/evidence.go
@@ -1,0 +1,155 @@
+package runtimegraph
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+const runtimeFindingEvidenceSourceSystem = "cerebro_runtime_detection"
+
+var ErrInvalidFindingEvidence = errors.New("invalid runtime finding evidence")
+
+// EvidenceMaterializationResult summarizes one batch of runtime finding evidence writes.
+type EvidenceMaterializationResult struct {
+	FindingsConsidered    int   `json:"findings_considered"`
+	EvidenceNodesUpserted int   `json:"evidence_nodes_upserted"`
+	FindingsSkipped       int   `json:"findings_skipped"`
+	InvalidFindings       int   `json:"invalid_findings"`
+	LastError             error `json:"-"`
+}
+
+// BuildFindingEvidenceNode converts one runtime finding into a graph evidence node.
+func BuildFindingEvidenceNode(finding *runtime.RuntimeFinding) (*graph.Node, error) {
+	if finding == nil {
+		return nil, fmt.Errorf("%w: finding is required", ErrInvalidFindingEvidence)
+	}
+
+	observedAt := findingObservedAt(finding)
+	if observedAt.IsZero() {
+		return nil, fmt.Errorf("%w: missing observed_at", ErrInvalidFindingEvidence)
+	}
+	observedAt = observedAt.UTC()
+
+	sourceEventID := strings.TrimSpace(finding.ID)
+	metadata := graph.NormalizeWriteMetadata(
+		observedAt,
+		observedAt,
+		nil,
+		runtimeFindingEvidenceSourceSystem,
+		sourceEventID,
+		0.90,
+		graph.WriteMetadataDefaults{
+			Now:               observedAt,
+			RecordedAt:        observedAt,
+			TransactionFrom:   observedAt,
+			SourceSystem:      runtimeFindingEvidenceSourceSystem,
+			SourceEventID:     sourceEventID,
+			SourceEventPrefix: "runtime_finding",
+			DefaultConfidence: 0.90,
+		},
+	)
+
+	properties := metadata.PropertyMap()
+	properties["evidence_type"] = "runtime_finding"
+	properties["detail"] = firstNonEmpty(
+		strings.TrimSpace(finding.Description),
+		strings.TrimSpace(finding.RuleName),
+		string(finding.Category),
+	)
+	addMetadataString(properties, "rule_id", finding.RuleID)
+	addMetadataString(properties, "rule_name", finding.RuleName)
+	addMetadataString(properties, "category", string(finding.Category))
+	addMetadataString(properties, "severity", finding.Severity)
+	addMetadataString(properties, "resource_id", finding.ResourceID)
+	addMetadataString(properties, "resource_type", finding.ResourceType)
+	addMetadataString(properties, "remediation", finding.Remediation)
+	if finding.Suppressed {
+		properties["suppressed"] = true
+	}
+	if len(finding.MITRE) > 0 {
+		properties["mitre_attack"] = append([]string(nil), finding.MITRE...)
+	}
+	if finding.Observation != nil {
+		addMetadataString(properties, "observation_id", strings.TrimSpace(finding.Observation.ID))
+		addMetadataString(properties, "observation_kind", string(finding.Observation.Kind))
+		addMetadataString(properties, "runtime_source", strings.TrimSpace(finding.Observation.Source))
+	} else if finding.Event != nil {
+		addMetadataString(properties, "runtime_source", strings.TrimSpace(finding.Event.Source))
+	}
+
+	return &graph.Node{
+		ID:         findingEvidenceNodeID(finding, sourceEventID, observedAt),
+		Kind:       graph.NodeKindEvidence,
+		Name:       firstNonEmpty(strings.TrimSpace(finding.RuleName), strings.TrimSpace(finding.Description), "runtime finding"),
+		Provider:   runtimeFindingEvidenceSourceSystem,
+		Properties: properties,
+		Risk:       graph.RiskNone,
+	}, nil
+}
+
+// MaterializeFindingEvidenceIntoGraph projects runtime findings into graph evidence nodes.
+func MaterializeFindingEvidenceIntoGraph(g *graph.Graph, findings []*runtime.RuntimeFinding, now time.Time) EvidenceMaterializationResult {
+	result := EvidenceMaterializationResult{}
+	if g == nil || len(findings) == 0 {
+		return result
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	for _, finding := range findings {
+		result.FindingsConsidered++
+		node, err := BuildFindingEvidenceNode(finding)
+		if err != nil {
+			result.FindingsSkipped++
+			result.InvalidFindings++
+			result.LastError = err
+			continue
+		}
+		g.AddNode(node)
+		result.EvidenceNodesUpserted++
+	}
+
+	g.BuildIndex()
+	meta := g.Metadata()
+	meta.BuiltAt = now.UTC()
+	meta.NodeCount = g.NodeCount()
+	meta.EdgeCount = g.EdgeCount()
+	g.SetMetadata(meta)
+	return result
+}
+
+func findingObservedAt(finding *runtime.RuntimeFinding) time.Time {
+	if finding == nil {
+		return time.Time{}
+	}
+	if !finding.Timestamp.IsZero() {
+		return finding.Timestamp
+	}
+	if finding.Observation != nil && !finding.Observation.ObservedAt.IsZero() {
+		return finding.Observation.ObservedAt
+	}
+	if finding.Event != nil && !finding.Event.Timestamp.IsZero() {
+		return finding.Event.Timestamp
+	}
+	return time.Time{}
+}
+
+func findingEvidenceNodeID(finding *runtime.RuntimeFinding, sourceEventID string, observedAt time.Time) string {
+	if trimmed := strings.TrimSpace(sourceEventID); trimmed != "" {
+		return "evidence:runtime_finding:" + trimmed
+	}
+	digest := sha256.Sum256([]byte(strings.Join([]string{
+		strings.TrimSpace(finding.RuleID),
+		strings.TrimSpace(finding.ResourceID),
+		observedAt.UTC().Format(time.RFC3339Nano),
+	}, "|")))
+	return "evidence:runtime_finding:" + hex.EncodeToString(digest[:8])
+}

--- a/internal/runtimegraph/evidence.go
+++ b/internal/runtimegraph/evidence.go
@@ -20,6 +20,7 @@ var ErrInvalidFindingEvidence = errors.New("invalid runtime finding evidence")
 type EvidenceMaterializationResult struct {
 	FindingsConsidered    int   `json:"findings_considered"`
 	EvidenceNodesUpserted int   `json:"evidence_nodes_upserted"`
+	BasedOnEdgesCreated   int   `json:"based_on_edges_created"`
 	FindingsSkipped       int   `json:"findings_skipped"`
 	InvalidFindings       int   `json:"invalid_findings"`
 	LastError             error `json:"-"`
@@ -115,6 +116,10 @@ func MaterializeFindingEvidenceIntoGraph(g *graph.Graph, findings []*runtime.Run
 		}
 		g.AddNode(node)
 		result.EvidenceNodesUpserted++
+
+		if graph.AddEdgeIfMissing(g, buildFindingEvidenceBasedOnEdge(node, finding)) {
+			result.BasedOnEdgesCreated++
+		}
 	}
 
 	g.BuildIndex()
@@ -152,4 +157,42 @@ func findingEvidenceNodeID(finding *runtime.RuntimeFinding, sourceEventID string
 		observedAt.UTC().Format(time.RFC3339Nano),
 	}, "|")))
 	return "evidence:runtime_finding:" + hex.EncodeToString(digest[:8])
+}
+
+func buildFindingEvidenceBasedOnEdge(node *graph.Node, finding *runtime.RuntimeFinding) *graph.Edge {
+	if node == nil || finding == nil || finding.Observation == nil {
+		return nil
+	}
+	observationID := evidenceObservationNodeID(strings.TrimSpace(finding.Observation.ID))
+	if observationID == "" {
+		return nil
+	}
+
+	properties := map[string]any{
+		"source_system": runtimeFindingEvidenceSourceSystem,
+	}
+	addMetadataString(properties, "source_event_id", strings.TrimSpace(finding.ID))
+	addMetadataString(properties, "observed_at", metadataString(node.Properties, "observed_at"))
+	addMetadataString(properties, "valid_from", metadataString(node.Properties, "valid_from"))
+	addMetadataString(properties, "runtime_source", metadataString(node.Properties, "runtime_source"))
+
+	return &graph.Edge{
+		ID:         node.ID + "->" + observationID + ":" + string(graph.EdgeKindBasedOn),
+		Source:     node.ID,
+		Target:     observationID,
+		Kind:       graph.EdgeKindBasedOn,
+		Effect:     graph.EdgeEffectAllow,
+		Properties: properties,
+	}
+}
+
+func evidenceObservationNodeID(observationID string) string {
+	observationID = strings.TrimSpace(observationID)
+	if observationID == "" {
+		return ""
+	}
+	if strings.HasPrefix(observationID, "observation:") {
+		return observationID
+	}
+	return "observation:" + observationID
 }

--- a/internal/runtimegraph/evidence.go
+++ b/internal/runtimegraph/evidence.go
@@ -122,12 +122,7 @@ func MaterializeFindingEvidenceIntoGraph(g *graph.Graph, findings []*runtime.Run
 		}
 	}
 
-	g.BuildIndex()
-	meta := g.Metadata()
-	meta.BuiltAt = now.UTC()
-	meta.NodeCount = g.NodeCount()
-	meta.EdgeCount = g.EdgeCount()
-	g.SetMetadata(meta)
+	refreshMaterializedGraphMetadata(g, now)
 	return result
 }
 

--- a/internal/runtimegraph/evidence_test.go
+++ b/internal/runtimegraph/evidence_test.go
@@ -1,0 +1,243 @@
+package runtimegraph
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+func TestBuildFindingEvidenceNodeUsesDetectionProvenance(t *testing.T) {
+	finding := &runtime.RuntimeFinding{
+		ID:           "finding-1",
+		RuleID:       "crypto-mining-process",
+		RuleName:     "Cryptocurrency Mining Process",
+		Category:     runtime.CategoryCryptoMining,
+		Severity:     "high",
+		ResourceID:   "deployment:prod/api",
+		ResourceType: "workload",
+		Description:  "Detected miner process",
+		MITRE:        []string{"T1496"},
+		Remediation:  "Isolate workload",
+		Timestamp:    time.Date(2026, 3, 16, 20, 0, 0, 0, time.UTC),
+		Observation: &runtime.RuntimeObservation{
+			ID:         "runtime:process_exec:abc",
+			Kind:       runtime.ObservationKindProcessExec,
+			Source:     "tetragon",
+			ObservedAt: time.Date(2026, 3, 16, 19, 59, 55, 0, time.UTC),
+		},
+	}
+
+	node, err := BuildFindingEvidenceNode(finding)
+	if err != nil {
+		t.Fatalf("BuildFindingEvidenceNode returned error: %v", err)
+	}
+
+	if node.Kind != graph.NodeKindEvidence {
+		t.Fatalf("node.Kind = %q, want %q", node.Kind, graph.NodeKindEvidence)
+	}
+	if node.Provider != runtimeFindingEvidenceSourceSystem {
+		t.Fatalf("node.Provider = %q, want %q", node.Provider, runtimeFindingEvidenceSourceSystem)
+	}
+	if !strings.HasPrefix(node.ID, "evidence:runtime_finding:finding-1") {
+		t.Fatalf("node.ID = %q, want evidence:runtime_finding:finding-1*", node.ID)
+	}
+	if got := testMetadataString(node.Properties, "evidence_type"); got != "runtime_finding" {
+		t.Fatalf("evidence_type = %q, want runtime_finding", got)
+	}
+	if got := testMetadataString(node.Properties, "detail"); got != "Detected miner process" {
+		t.Fatalf("detail = %q, want Detected miner process", got)
+	}
+	if got := testMetadataString(node.Properties, "source_system"); got != runtimeFindingEvidenceSourceSystem {
+		t.Fatalf("source_system = %q, want %q", got, runtimeFindingEvidenceSourceSystem)
+	}
+	if got := testMetadataString(node.Properties, "runtime_source"); got != "tetragon" {
+		t.Fatalf("runtime_source = %q, want tetragon", got)
+	}
+	if got := testMetadataString(node.Properties, "rule_id"); got != "crypto-mining-process" {
+		t.Fatalf("rule_id = %q, want crypto-mining-process", got)
+	}
+	if got := testMetadataString(node.Properties, "severity"); got != "high" {
+		t.Fatalf("severity = %q, want high", got)
+	}
+	if got := testMetadataString(node.Properties, "observed_at"); got != "2026-03-16T20:00:00Z" {
+		t.Fatalf("observed_at = %q, want 2026-03-16T20:00:00Z", got)
+	}
+	if issues := graph.GlobalSchemaRegistry().ValidateNode(node); len(issues) != 0 {
+		t.Fatalf("ValidateNode returned issues: %+v", issues)
+	}
+}
+
+func TestBuildFindingEvidenceNodeFallsBackToObservationTimestamp(t *testing.T) {
+	finding := &runtime.RuntimeFinding{
+		ID:          "finding-2",
+		RuleID:      "reverse-shell",
+		RuleName:    "Reverse Shell",
+		Category:    runtime.CategoryReverseShell,
+		Severity:    "critical",
+		Description: "Detected reverse shell connection",
+		Observation: &runtime.RuntimeObservation{
+			ID:         "runtime:network_flow:def",
+			Kind:       runtime.ObservationKindNetworkFlow,
+			Source:     "falco",
+			ObservedAt: time.Date(2026, 3, 16, 20, 5, 0, 0, time.UTC),
+		},
+	}
+
+	node, err := BuildFindingEvidenceNode(finding)
+	if err != nil {
+		t.Fatalf("BuildFindingEvidenceNode returned error: %v", err)
+	}
+
+	if got := testMetadataString(node.Properties, "observed_at"); got != "2026-03-16T20:05:00Z" {
+		t.Fatalf("observed_at = %q, want 2026-03-16T20:05:00Z", got)
+	}
+	if got := testMetadataString(node.Properties, "runtime_source"); got != "falco" {
+		t.Fatalf("runtime_source = %q, want falco", got)
+	}
+}
+
+func TestBuildFindingEvidenceNodeUsesStableHashWhenFindingIDMissing(t *testing.T) {
+	finding := &runtime.RuntimeFinding{
+		RuleID:      "reverse-shell",
+		RuleName:    "Reverse Shell",
+		Category:    runtime.CategoryReverseShell,
+		Severity:    "critical",
+		ResourceID:  "deployment:prod/api",
+		Description: "Detected reverse shell connection",
+		Timestamp:   time.Date(2026, 3, 16, 20, 5, 0, 0, time.UTC),
+	}
+
+	first, err := BuildFindingEvidenceNode(finding)
+	if err != nil {
+		t.Fatalf("first BuildFindingEvidenceNode returned error: %v", err)
+	}
+	second, err := BuildFindingEvidenceNode(finding)
+	if err != nil {
+		t.Fatalf("second BuildFindingEvidenceNode returned error: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("evidence IDs differ for identical finding without ID: %q vs %q", first.ID, second.ID)
+	}
+	if strings.Contains(first.ID, "runtime_finding:runtime_finding:") {
+		t.Fatalf("node.ID = %q, want deterministic hash-based ID instead of synthetic source event ID", first.ID)
+	}
+
+	changed := *finding
+	changed.RuleID = "crypto-mining-process"
+	third, err := BuildFindingEvidenceNode(&changed)
+	if err != nil {
+		t.Fatalf("third BuildFindingEvidenceNode returned error: %v", err)
+	}
+	if first.ID == third.ID {
+		t.Fatalf("distinct finding content produced same evidence ID %q", first.ID)
+	}
+}
+
+func TestMaterializeFindingEvidenceIntoGraphAddsEvidenceNodes(t *testing.T) {
+	g := graph.New()
+	findings := []*runtime.RuntimeFinding{
+		{
+			ID:          "finding-3",
+			RuleID:      "container-escape-nsenter",
+			RuleName:    "Container Escape via nsenter",
+			Category:    runtime.CategoryContainerEscape,
+			Severity:    "critical",
+			Description: "Detected nsenter execution",
+			Timestamp:   time.Date(2026, 3, 16, 20, 10, 0, 0, time.UTC),
+		},
+	}
+
+	result := MaterializeFindingEvidenceIntoGraph(g, findings, time.Date(2026, 3, 16, 20, 11, 0, 0, time.UTC))
+	if result.FindingsConsidered != 1 {
+		t.Fatalf("FindingsConsidered = %d, want 1", result.FindingsConsidered)
+	}
+	if result.EvidenceNodesUpserted != 1 {
+		t.Fatalf("EvidenceNodesUpserted = %d, want 1", result.EvidenceNodesUpserted)
+	}
+	if result.FindingsSkipped != 0 {
+		t.Fatalf("FindingsSkipped = %d, want 0", result.FindingsSkipped)
+	}
+	if len(g.GetNodesByKind(graph.NodeKindEvidence)) != 1 {
+		t.Fatalf("evidence node count = %d, want 1", len(g.GetNodesByKind(graph.NodeKindEvidence)))
+	}
+	meta := g.Metadata()
+	if meta.BuiltAt.IsZero() {
+		t.Fatal("metadata.BuiltAt should not be zero")
+	}
+	if meta.NodeCount != g.NodeCount() || meta.EdgeCount != g.EdgeCount() {
+		t.Fatalf("metadata counts = %d/%d, want %d/%d", meta.NodeCount, meta.EdgeCount, g.NodeCount(), g.EdgeCount())
+	}
+}
+
+func TestMaterializeFindingEvidenceIntoGraphSkipsFindingsWithoutTemporalContext(t *testing.T) {
+	g := graph.New()
+	result := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{
+		{
+			ID:          "finding-4",
+			RuleID:      "container-drift-shell",
+			RuleName:    "Unexpected Shell",
+			Category:    runtime.CategoryContainerDrift,
+			Severity:    "medium",
+			Description: "Detected unexpected shell",
+		},
+	}, time.Date(2026, 3, 16, 20, 12, 0, 0, time.UTC))
+
+	if result.FindingsConsidered != 1 {
+		t.Fatalf("FindingsConsidered = %d, want 1", result.FindingsConsidered)
+	}
+	if result.EvidenceNodesUpserted != 0 {
+		t.Fatalf("EvidenceNodesUpserted = %d, want 0", result.EvidenceNodesUpserted)
+	}
+	if result.FindingsSkipped != 1 {
+		t.Fatalf("FindingsSkipped = %d, want 1", result.FindingsSkipped)
+	}
+	if result.InvalidFindings != 1 {
+		t.Fatalf("InvalidFindings = %d, want 1", result.InvalidFindings)
+	}
+}
+
+func TestMaterializeFindingEvidenceIntoGraphRefreshesBuiltAtOnSubsequentWrites(t *testing.T) {
+	g := graph.New()
+
+	firstNow := time.Date(2026, 3, 16, 20, 20, 0, 0, time.UTC)
+	secondNow := firstNow.Add(5 * time.Minute)
+
+	firstResult := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{
+		{
+			ID:          "finding-built-at-1",
+			RuleID:      "reverse-shell",
+			RuleName:    "Reverse Shell",
+			Category:    runtime.CategoryReverseShell,
+			Severity:    "high",
+			Description: "Detected reverse shell connection",
+			Timestamp:   firstNow.Add(-10 * time.Second),
+		},
+	}, firstNow)
+	if firstResult.EvidenceNodesUpserted != 1 {
+		t.Fatalf("first EvidenceNodesUpserted = %d, want 1", firstResult.EvidenceNodesUpserted)
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(firstNow) {
+		t.Fatalf("after first materialization BuiltAt = %s, want %s", got, firstNow)
+	}
+
+	secondResult := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{
+		{
+			ID:          "finding-built-at-2",
+			RuleID:      "crypto-mining-process",
+			RuleName:    "Cryptocurrency Mining Process",
+			Category:    runtime.CategoryCryptoMining,
+			Severity:    "high",
+			Description: "Detected miner process",
+			Timestamp:   secondNow.Add(-10 * time.Second),
+		},
+	}, secondNow)
+	if secondResult.EvidenceNodesUpserted != 1 {
+		t.Fatalf("second EvidenceNodesUpserted = %d, want 1", secondResult.EvidenceNodesUpserted)
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(secondNow) {
+		t.Fatalf("after second materialization BuiltAt = %s, want %s", got, secondNow)
+	}
+}

--- a/internal/runtimegraph/evidence_test.go
+++ b/internal/runtimegraph/evidence_test.go
@@ -325,3 +325,44 @@ func TestMaterializeFindingEvidenceIntoGraphRefreshesBuiltAtOnSubsequentWrites(t
 		t.Fatalf("after second materialization BuiltAt = %s, want %s", got, secondNow)
 	}
 }
+
+func TestMaterializeFindingEvidenceIntoGraphDefersIndexBuildToCaller(t *testing.T) {
+	g := graph.New()
+	g.BuildIndex()
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected initial graph index to be built")
+	}
+
+	now := time.Date(2026, 3, 16, 20, 25, 0, 0, time.UTC)
+	result := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{
+		{
+			ID:          "finding-defer-index",
+			RuleID:      "reverse-shell",
+			RuleName:    "Reverse Shell",
+			Category:    runtime.CategoryReverseShell,
+			Severity:    "high",
+			Description: "Detected reverse shell connection",
+			Timestamp:   now.Add(-10 * time.Second),
+		},
+	}, now)
+	if result.EvidenceNodesUpserted != 1 {
+		t.Fatalf("EvidenceNodesUpserted = %d, want 1", result.EvidenceNodesUpserted)
+	}
+	if g.IsIndexBuilt() {
+		t.Fatal("expected index to remain stale until caller finalizes materialized graph")
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(now) {
+		t.Fatalf("metadata.BuiltAt = %s, want %s", got, now)
+	}
+
+	FinalizeMaterializedGraph(g, now.Add(time.Minute))
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected FinalizeMaterializedGraph to rebuild indexes")
+	}
+	if got := len(g.GetNodesByKindIndexed(graph.NodeKindEvidence)); got != 1 {
+		t.Fatalf("len(GetNodesByKindIndexed(evidence)) = %d, want 1", got)
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(now.Add(time.Minute)) {
+		t.Fatalf("metadata.BuiltAt after finalize = %s, want %s", got, now.Add(time.Minute))
+	}
+}

--- a/internal/runtimegraph/evidence_test.go
+++ b/internal/runtimegraph/evidence_test.go
@@ -138,6 +138,11 @@ func TestBuildFindingEvidenceNodeUsesStableHashWhenFindingIDMissing(t *testing.T
 
 func TestMaterializeFindingEvidenceIntoGraphAddsEvidenceNodes(t *testing.T) {
 	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "observation:runtime:process_exec:seed",
+		Kind: graph.NodeKindObservation,
+		Name: "seed observation",
+	})
 	findings := []*runtime.RuntimeFinding{
 		{
 			ID:          "finding-3",
@@ -147,6 +152,9 @@ func TestMaterializeFindingEvidenceIntoGraphAddsEvidenceNodes(t *testing.T) {
 			Severity:    "critical",
 			Description: "Detected nsenter execution",
 			Timestamp:   time.Date(2026, 3, 16, 20, 10, 0, 0, time.UTC),
+			Observation: &runtime.RuntimeObservation{
+				ID: "runtime:process_exec:seed",
+			},
 		},
 	}
 
@@ -157,11 +165,22 @@ func TestMaterializeFindingEvidenceIntoGraphAddsEvidenceNodes(t *testing.T) {
 	if result.EvidenceNodesUpserted != 1 {
 		t.Fatalf("EvidenceNodesUpserted = %d, want 1", result.EvidenceNodesUpserted)
 	}
+	if result.BasedOnEdgesCreated != 1 {
+		t.Fatalf("BasedOnEdgesCreated = %d, want 1", result.BasedOnEdgesCreated)
+	}
 	if result.FindingsSkipped != 0 {
 		t.Fatalf("FindingsSkipped = %d, want 0", result.FindingsSkipped)
 	}
 	if len(g.GetNodesByKind(graph.NodeKindEvidence)) != 1 {
 		t.Fatalf("evidence node count = %d, want 1", len(g.GetNodesByKind(graph.NodeKindEvidence)))
+	}
+	evidenceNode := g.GetNodesByKind(graph.NodeKindEvidence)[0]
+	outEdges := g.GetOutEdges(evidenceNode.ID)
+	if len(outEdges) != 1 {
+		t.Fatalf("len(outEdges) = %d, want 1", len(outEdges))
+	}
+	if outEdges[0].Kind != graph.EdgeKindBasedOn || outEdges[0].Target != "observation:runtime:process_exec:seed" {
+		t.Fatalf("edge = %+v, want based_on edge to observation", outEdges[0])
 	}
 	meta := g.Metadata()
 	if meta.BuiltAt.IsZero() {
@@ -196,6 +215,71 @@ func TestMaterializeFindingEvidenceIntoGraphSkipsFindingsWithoutTemporalContext(
 	}
 	if result.InvalidFindings != 1 {
 		t.Fatalf("InvalidFindings = %d, want 1", result.InvalidFindings)
+	}
+}
+
+func TestMaterializeFindingEvidenceIntoGraphSkipsBasedOnEdgeWhenObservationMissing(t *testing.T) {
+	g := graph.New()
+	result := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{
+		{
+			ID:          "finding-missing-observation",
+			RuleID:      "container-drift-shell",
+			RuleName:    "Unexpected Shell",
+			Category:    runtime.CategoryContainerDrift,
+			Severity:    "medium",
+			Description: "Detected unexpected shell",
+			Timestamp:   time.Date(2026, 3, 16, 20, 12, 0, 0, time.UTC),
+			Observation: &runtime.RuntimeObservation{
+				ID: "runtime:process_exec:missing",
+			},
+		},
+	}, time.Date(2026, 3, 16, 20, 13, 0, 0, time.UTC))
+
+	if result.EvidenceNodesUpserted != 1 {
+		t.Fatalf("EvidenceNodesUpserted = %d, want 1", result.EvidenceNodesUpserted)
+	}
+	if result.BasedOnEdgesCreated != 0 {
+		t.Fatalf("BasedOnEdgesCreated = %d, want 0", result.BasedOnEdgesCreated)
+	}
+	evidenceNode := g.GetNodesByKind(graph.NodeKindEvidence)[0]
+	if got := len(g.GetOutEdges(evidenceNode.ID)); got != 0 {
+		t.Fatalf("len(outEdges) = %d, want 0", got)
+	}
+}
+
+func TestMaterializeFindingEvidenceIntoGraphDoesNotDuplicateBasedOnEdges(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "observation:runtime:process_exec:repeat",
+		Kind: graph.NodeKindObservation,
+		Name: "repeat observation",
+	})
+
+	finding := &runtime.RuntimeFinding{
+		ID:          "finding-repeat",
+		RuleID:      "container-drift-shell",
+		RuleName:    "Unexpected Shell",
+		Category:    runtime.CategoryContainerDrift,
+		Severity:    "medium",
+		Description: "Detected unexpected shell",
+		Timestamp:   time.Date(2026, 3, 16, 20, 12, 0, 0, time.UTC),
+		Observation: &runtime.RuntimeObservation{
+			ID: "runtime:process_exec:repeat",
+		},
+	}
+
+	first := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{finding}, time.Date(2026, 3, 16, 20, 13, 0, 0, time.UTC))
+	second := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{finding}, time.Date(2026, 3, 16, 20, 14, 0, 0, time.UTC))
+
+	if first.BasedOnEdgesCreated != 1 {
+		t.Fatalf("first BasedOnEdgesCreated = %d, want 1", first.BasedOnEdgesCreated)
+	}
+	if second.BasedOnEdgesCreated != 0 {
+		t.Fatalf("second BasedOnEdgesCreated = %d, want 0", second.BasedOnEdgesCreated)
+	}
+	evidenceNode := g.GetNodesByKind(graph.NodeKindEvidence)[0]
+	if got := len(g.GetOutEdges(evidenceNode.ID)); got != 1 {
+		t.Fatalf("len(outEdges) = %d, want 1", got)
 	}
 }
 

--- a/internal/runtimegraph/materializer.go
+++ b/internal/runtimegraph/materializer.go
@@ -1,0 +1,286 @@
+package runtimegraph
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+var ErrMissingObservationSubject = errors.New("runtime observation missing concrete graph subject")
+
+// BuildObservationWriteRequest converts one normalized runtime observation into
+// a first-class graph observation write request.
+func BuildObservationWriteRequest(observation *runtime.RuntimeObservation) (graph.ObservationWriteRequest, error) {
+	normalized, err := runtime.NormalizeObservation(observation)
+	if err != nil {
+		return graph.ObservationWriteRequest{}, err
+	}
+	if normalized == nil {
+		return graph.ObservationWriteRequest{}, fmt.Errorf("runtime observation is required")
+	}
+
+	subjectID := observationSubjectID(normalized)
+	if subjectID == "" {
+		return graph.ObservationWriteRequest{}, ErrMissingObservationSubject
+	}
+
+	return graph.ObservationWriteRequest{
+		ID:              "observation:" + normalized.ID,
+		SubjectID:       subjectID,
+		ObservationType: string(normalized.Kind),
+		Summary:         observationSummary(normalized),
+		SourceSystem:    normalized.Source,
+		SourceEventID:   normalized.ID,
+		ObservedAt:      normalized.ObservedAt,
+		ValidFrom:       normalized.ObservedAt,
+		RecordedAt:      normalized.RecordedAt,
+		TransactionFrom: normalized.RecordedAt,
+		Confidence:      1.0,
+		Metadata:        observationMetadata(normalized),
+	}, nil
+}
+
+func observationSubjectID(observation *runtime.RuntimeObservation) string {
+	if observation == nil {
+		return ""
+	}
+	if value := strings.TrimSpace(observation.WorkloadRef); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(observation.ContainerID); value != "" {
+		return "container:" + value
+	}
+	if value := strings.TrimSpace(observation.ResourceID); hasConcreteResourceID(value) {
+		return value
+	}
+	return ""
+}
+
+func hasConcreteResourceID(value string) bool {
+	kind, remainder, ok := strings.Cut(strings.TrimSpace(value), ":")
+	if !ok {
+		return false
+	}
+	kind = strings.TrimSpace(kind)
+	remainder = strings.TrimSpace(remainder)
+	return kind != "" && remainder != ""
+}
+
+func observationSummary(observation *runtime.RuntimeObservation) string {
+	if observation == nil {
+		return "runtime observation"
+	}
+	switch observation.Kind {
+	case runtime.ObservationKindProcessExec:
+		return "process exec " + firstNonEmpty(observation.Process.Path, observation.Process.Name, "process")
+	case runtime.ObservationKindProcessExit:
+		return "process exit " + firstNonEmpty(observation.Process.Path, observation.Process.Name, "process")
+	case runtime.ObservationKindFileOpen:
+		return "file open " + firstNonEmpty(observation.File.Path, "file")
+	case runtime.ObservationKindFileWrite:
+		return "file write " + firstNonEmpty(observation.File.Path, "file")
+	case runtime.ObservationKindDNSQuery:
+		return "dns query " + firstNonEmpty(observation.Network.Domain, observation.Network.DstIP, "lookup")
+	case runtime.ObservationKindNetworkFlow:
+		return fmt.Sprintf(
+			"network flow %s %s:%d -> %s:%d",
+			firstNonEmpty(observation.Network.Protocol, "unknown"),
+			firstNonEmpty(observation.Network.SrcIP, "unknown"),
+			observation.Network.SrcPort,
+			firstNonEmpty(observation.Network.DstIP, "unknown"),
+			observation.Network.DstPort,
+		)
+	case runtime.ObservationKindKubernetesAudit:
+		return fmt.Sprintf(
+			"k8s audit %s %s %s",
+			firstNonEmpty(observation.ControlPlane.Verb, "observe"),
+			firstNonEmpty(observation.ControlPlane.Resource, "resource"),
+			firstNonEmpty(joinNamespacedName(observation.ControlPlane.Namespace, observation.ControlPlane.Name), "cluster"),
+		)
+	case runtime.ObservationKindTraceLink:
+		return "trace link " + firstNonEmpty(observation.Trace.ServiceName, observation.Trace.TraceID, "service")
+	case runtime.ObservationKindResponseOutcome:
+		return "response outcome " + strings.TrimSpace(firstNonEmpty(
+			metadataString(observation.Metadata, "action_type")+" "+metadataString(observation.Metadata, "action_status"),
+			metadataString(observation.Metadata, "execution_id"),
+			"action",
+		))
+	case runtime.ObservationKindRuntimeAlert:
+		return "runtime alert " + firstNonEmpty(
+			metadataString(observation.Metadata, "signal_name"),
+			metadataString(observation.Metadata, "severity"),
+			"alert",
+		)
+	default:
+		return "runtime observation " + firstNonEmpty(string(observation.Kind), "unknown")
+	}
+}
+
+func observationMetadata(observation *runtime.RuntimeObservation) map[string]any {
+	metadata := map[string]any{
+		"runtime_observation_id": observation.ID,
+		"runtime_source":         observation.Source,
+	}
+	addMetadataString(metadata, "resource_id", observation.ResourceID)
+	addMetadataString(metadata, "resource_type", observation.ResourceType)
+	addMetadataString(metadata, "cluster", observation.Cluster)
+	addMetadataString(metadata, "namespace", observation.Namespace)
+	addMetadataString(metadata, "node_name", observation.NodeName)
+	addMetadataString(metadata, "workload_ref", observation.WorkloadRef)
+	addMetadataString(metadata, "workload_uid", observation.WorkloadUID)
+	addMetadataString(metadata, "container_id", observation.ContainerID)
+	addMetadataString(metadata, "image_ref", observation.ImageRef)
+	addMetadataString(metadata, "image_id", observation.ImageID)
+	addMetadataString(metadata, "principal_id", observation.PrincipalID)
+	addMetadataString(metadata, "trace_id", traceID(observation))
+	addMetadataString(metadata, "span_id", spanID(observation))
+	addMetadataString(metadata, "service_name", serviceName(observation))
+	addMetadataString(metadata, "process_name", processName(observation))
+	addMetadataString(metadata, "process_path", processPath(observation))
+	addMetadataString(metadata, "file_operation", fileOperation(observation))
+	addMetadataString(metadata, "file_path", filePath(observation))
+	addMetadataString(metadata, "network_protocol", networkProtocol(observation))
+	addMetadataString(metadata, "network_domain", networkDomain(observation))
+	addMetadataString(metadata, "audit_verb", auditVerb(observation))
+	addMetadataString(metadata, "audit_resource", auditResource(observation))
+	addMetadataString(metadata, "audit_user", auditUser(observation))
+
+	for _, key := range []string{
+		"execution_id",
+		"execution_status",
+		"action_type",
+		"action_status",
+		"policy_id",
+		"policy_name",
+		"signal_name",
+		"severity",
+	} {
+		addMetadataString(metadata, key, metadataString(observation.Metadata, key))
+	}
+	if len(observation.Tags) > 0 {
+		metadata["tags"] = append([]string(nil), observation.Tags...)
+	}
+	return metadata
+}
+
+func processName(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.Process == nil {
+		return ""
+	}
+	return observation.Process.Name
+}
+
+func processPath(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.Process == nil {
+		return ""
+	}
+	return observation.Process.Path
+}
+
+func fileOperation(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.File == nil {
+		return ""
+	}
+	return observation.File.Operation
+}
+
+func filePath(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.File == nil {
+		return ""
+	}
+	return observation.File.Path
+}
+
+func networkProtocol(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.Network == nil {
+		return ""
+	}
+	return observation.Network.Protocol
+}
+
+func networkDomain(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.Network == nil {
+		return ""
+	}
+	return observation.Network.Domain
+}
+
+func traceID(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.Trace == nil {
+		return ""
+	}
+	return observation.Trace.TraceID
+}
+
+func spanID(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.Trace == nil {
+		return ""
+	}
+	return observation.Trace.SpanID
+}
+
+func serviceName(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.Trace == nil {
+		return ""
+	}
+	return observation.Trace.ServiceName
+}
+
+func auditVerb(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.ControlPlane == nil {
+		return ""
+	}
+	return observation.ControlPlane.Verb
+}
+
+func auditResource(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.ControlPlane == nil {
+		return ""
+	}
+	return observation.ControlPlane.Resource
+}
+
+func auditUser(observation *runtime.RuntimeObservation) string {
+	if observation == nil || observation.ControlPlane == nil {
+		return ""
+	}
+	return observation.ControlPlane.User
+}
+
+func joinNamespacedName(namespace, name string) string {
+	namespace = strings.TrimSpace(namespace)
+	name = strings.TrimSpace(name)
+	if namespace == "" {
+		return name
+	}
+	if name == "" {
+		return namespace
+	}
+	return namespace + "/" + name
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func addMetadataString(metadata map[string]any, key, value string) {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		metadata[key] = trimmed
+	}
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	value, _ := metadata[key].(string)
+	return strings.TrimSpace(value)
+}

--- a/internal/runtimegraph/materializer.go
+++ b/internal/runtimegraph/materializer.go
@@ -4,12 +4,37 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/runtime"
 )
 
 var ErrMissingObservationSubject = errors.New("runtime observation missing concrete graph subject")
+
+// FinalizeMaterializedGraph rebuilds graph indexes and refreshes metadata after
+// one or more runtimegraph materialization batches.
+func FinalizeMaterializedGraph(g *graph.Graph, now time.Time) {
+	if g == nil {
+		return
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	g.BuildIndex()
+	refreshMaterializedGraphMetadata(g, now)
+}
+
+func refreshMaterializedGraphMetadata(g *graph.Graph, now time.Time) {
+	if g == nil {
+		return
+	}
+	meta := g.Metadata()
+	meta.BuiltAt = now.UTC()
+	meta.NodeCount = g.NodeCount()
+	meta.EdgeCount = g.EdgeCount()
+	g.SetMetadata(meta)
+}
 
 // BuildObservationWriteRequest converts one normalized runtime observation into
 // a first-class graph observation write request.

--- a/internal/runtimegraph/materializer_test.go
+++ b/internal/runtimegraph/materializer_test.go
@@ -1,0 +1,159 @@
+package runtimegraph
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+func TestBuildObservationWriteRequestPrefersWorkloadSubject(t *testing.T) {
+	observedAt := time.Date(2026, 3, 16, 18, 0, 0, 0, time.UTC)
+	recordedAt := observedAt.Add(2 * time.Second)
+
+	req, err := BuildObservationWriteRequest(&runtime.RuntimeObservation{
+		Source:      "tetragon",
+		Kind:        runtime.ObservationKindProcessExec,
+		ObservedAt:  observedAt,
+		RecordedAt:  recordedAt,
+		WorkloadRef: "deployment:prod/api",
+		ContainerID: "containerd://abc123",
+		Namespace:   "prod",
+		Cluster:     "prod-cluster",
+		PrincipalID: "root",
+		Process: &runtime.ProcessEvent{
+			Name:    "sh",
+			Path:    "/bin/sh",
+			Cmdline: "sh -c id",
+			User:    "root",
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildObservationWriteRequest returned error: %v", err)
+	}
+
+	if req.SubjectID != "deployment:prod/api" {
+		t.Fatalf("SubjectID = %q, want deployment:prod/api", req.SubjectID)
+	}
+	if req.ObservationType != string(runtime.ObservationKindProcessExec) {
+		t.Fatalf("ObservationType = %q, want %q", req.ObservationType, runtime.ObservationKindProcessExec)
+	}
+	if req.SourceSystem != "tetragon" {
+		t.Fatalf("SourceSystem = %q, want tetragon", req.SourceSystem)
+	}
+	if req.SourceEventID == "" {
+		t.Fatal("SourceEventID should not be empty")
+	}
+	if !strings.HasPrefix(req.ID, "observation:runtime:process_exec:") {
+		t.Fatalf("ID = %q, want observation:runtime:process_exec:*", req.ID)
+	}
+	if req.Summary != "process exec /bin/sh" {
+		t.Fatalf("Summary = %q, want process exec /bin/sh", req.Summary)
+	}
+	if got := testMetadataString(req.Metadata, "workload_ref"); got != "deployment:prod/api" {
+		t.Fatalf("metadata.workload_ref = %q, want deployment:prod/api", got)
+	}
+	if got := testMetadataString(req.Metadata, "container_id"); got != "containerd://abc123" {
+		t.Fatalf("metadata.container_id = %q, want containerd://abc123", got)
+	}
+	if got := testMetadataString(req.Metadata, "principal_id"); got != "root" {
+		t.Fatalf("metadata.principal_id = %q, want root", got)
+	}
+	if got := testMetadataString(req.Metadata, "process_path"); got != "/bin/sh" {
+		t.Fatalf("metadata.process_path = %q, want /bin/sh", got)
+	}
+	if !req.ObservedAt.Equal(observedAt) {
+		t.Fatalf("ObservedAt = %s, want %s", req.ObservedAt, observedAt)
+	}
+	if !req.RecordedAt.Equal(recordedAt) {
+		t.Fatalf("RecordedAt = %s, want %s", req.RecordedAt, recordedAt)
+	}
+}
+
+func TestBuildObservationWriteRequestFallsBackToServiceResourceID(t *testing.T) {
+	observedAt := time.Date(2026, 3, 16, 18, 5, 0, 0, time.UTC)
+
+	req, err := BuildObservationWriteRequest(&runtime.RuntimeObservation{
+		Source:     "otel",
+		Kind:       runtime.ObservationKindTraceLink,
+		ObservedAt: observedAt,
+		Metadata: map[string]any{
+			"service_namespace": "storefront",
+			"trace_id":          "abc123",
+			"span_id":           "def456",
+			"service_name":      "checkout",
+		},
+		Trace: &runtime.TraceContext{
+			TraceID:     "abc123",
+			SpanID:      "def456",
+			ServiceName: "checkout",
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildObservationWriteRequest returned error: %v", err)
+	}
+
+	if req.SubjectID != "service:storefront/checkout" {
+		t.Fatalf("SubjectID = %q, want service:storefront/checkout", req.SubjectID)
+	}
+	if req.Summary != "trace link checkout" {
+		t.Fatalf("Summary = %q, want trace link checkout", req.Summary)
+	}
+	if got := testMetadataString(req.Metadata, "trace_id"); got != "abc123" {
+		t.Fatalf("metadata.trace_id = %q, want abc123", got)
+	}
+	if got := testMetadataString(req.Metadata, "service_name"); got != "checkout" {
+		t.Fatalf("metadata.service_name = %q, want checkout", got)
+	}
+}
+
+func TestBuildObservationWriteRequestUsesConcreteControlPlaneResourceID(t *testing.T) {
+	observedAt := time.Date(2026, 3, 16, 18, 10, 0, 0, time.UTC)
+
+	req, err := BuildObservationWriteRequest(&runtime.RuntimeObservation{
+		Source:     "k8s_audit",
+		Kind:       runtime.ObservationKindKubernetesAudit,
+		ObservedAt: observedAt,
+		ControlPlane: &runtime.ControlPlaneContext{
+			Verb:      "delete",
+			Resource:  "pods",
+			Namespace: "prod",
+			Name:      "api-7f9d",
+			User:      "alice@example.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildObservationWriteRequest returned error: %v", err)
+	}
+
+	if req.SubjectID != "pods:prod/api-7f9d" {
+		t.Fatalf("SubjectID = %q, want pods:prod/api-7f9d", req.SubjectID)
+	}
+	if req.Summary != "k8s audit delete pods prod/api-7f9d" {
+		t.Fatalf("Summary = %q, want k8s audit delete pods prod/api-7f9d", req.Summary)
+	}
+}
+
+func TestBuildObservationWriteRequestRejectsMissingConcreteSubject(t *testing.T) {
+	_, err := BuildObservationWriteRequest(&runtime.RuntimeObservation{
+		Source:     "falco",
+		Kind:       runtime.ObservationKindRuntimeAlert,
+		ObservedAt: time.Date(2026, 3, 16, 18, 15, 0, 0, time.UTC),
+		Metadata: map[string]any{
+			"signal_name": "suspicious binary execution",
+		},
+	})
+	if !errors.Is(err, ErrMissingObservationSubject) {
+		t.Fatalf("error = %v, want ErrMissingObservationSubject", err)
+	}
+}
+
+func testMetadataString(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	value, _ := metadata[key].(string)
+	return value
+}

--- a/internal/runtimegraph/project.go
+++ b/internal/runtimegraph/project.go
@@ -11,12 +11,13 @@ import (
 
 // MaterializationResult summarizes one batch of runtime observation graph writes.
 type MaterializationResult struct {
-	ObservationsConsidered   int   `json:"observations_considered"`
-	ObservationsMaterialized int   `json:"observations_materialized"`
-	ObservationsSkipped      int   `json:"observations_skipped"`
-	MissingSubjects          int   `json:"missing_subjects"`
-	InvalidObservations      int   `json:"invalid_observations"`
-	LastError                error `json:"-"`
+	ObservationsConsidered     int   `json:"observations_considered"`
+	ObservationsMaterialized   int   `json:"observations_materialized"`
+	ObservationsSkipped        int   `json:"observations_skipped"`
+	WorkloadTargetEdgesCreated int   `json:"workload_target_edges_created"`
+	MissingSubjects            int   `json:"missing_subjects"`
+	InvalidObservations        int   `json:"invalid_observations"`
+	LastError                  error `json:"-"`
 }
 
 // MaterializeObservationsIntoGraph projects runtime observations into graph observation nodes.
@@ -62,6 +63,24 @@ func MaterializeObservationsIntoGraph(g *graph.Graph, observations []*runtime.Ru
 			continue
 		}
 
+		if subjectNode, ok := g.GetNode(req.SubjectID); ok && isWorkloadSubjectNode(subjectNode) {
+			if graph.AddEdgeIfMissing(g, &graph.Edge{
+				ID:     req.SubjectID + "->" + req.ID + ":" + string(graph.EdgeKindTargets),
+				Source: req.SubjectID,
+				Target: req.ID,
+				Kind:   graph.EdgeKindTargets,
+				Effect: graph.EdgeEffectAllow,
+				Properties: map[string]any{
+					"source_system":   req.SourceSystem,
+					"source_event_id": req.SourceEventID,
+					"observed_at":     req.ObservedAt.UTC().Format(time.RFC3339),
+					"valid_from":      req.ValidFrom.UTC().Format(time.RFC3339),
+				},
+			}) {
+				result.WorkloadTargetEdgesCreated++
+			}
+		}
+
 		result.ObservationsMaterialized++
 	}
 
@@ -89,4 +108,18 @@ func classifyObservationMaterializationError(err error) observationMaterializati
 		return observationMaterializationErrorMissingSubject
 	}
 	return observationMaterializationErrorInvalid
+}
+
+func isWorkloadSubjectNode(node *graph.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case graph.NodeKindWorkload,
+		graph.NodeKindDeployment,
+		graph.NodeKindPod:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/runtimegraph/project.go
+++ b/internal/runtimegraph/project.go
@@ -84,12 +84,7 @@ func MaterializeObservationsIntoGraph(g *graph.Graph, observations []*runtime.Ru
 		result.ObservationsMaterialized++
 	}
 
-	g.BuildIndex()
-	meta := g.Metadata()
-	meta.BuiltAt = now.UTC()
-	meta.NodeCount = g.NodeCount()
-	meta.EdgeCount = g.EdgeCount()
-	g.SetMetadata(meta)
+	refreshMaterializedGraphMetadata(g, now)
 	return result
 }
 

--- a/internal/runtimegraph/project.go
+++ b/internal/runtimegraph/project.go
@@ -1,0 +1,92 @@
+package runtimegraph
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+// MaterializationResult summarizes one batch of runtime observation graph writes.
+type MaterializationResult struct {
+	ObservationsConsidered   int   `json:"observations_considered"`
+	ObservationsMaterialized int   `json:"observations_materialized"`
+	ObservationsSkipped      int   `json:"observations_skipped"`
+	MissingSubjects          int   `json:"missing_subjects"`
+	InvalidObservations      int   `json:"invalid_observations"`
+	LastError                error `json:"-"`
+}
+
+// MaterializeObservationsIntoGraph projects runtime observations into graph observation nodes.
+func MaterializeObservationsIntoGraph(g *graph.Graph, observations []*runtime.RuntimeObservation, now time.Time) MaterializationResult {
+	result := MaterializationResult{}
+	if g == nil || len(observations) == 0 {
+		return result
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	for _, observation := range observations {
+		result.ObservationsConsidered++
+
+		req, err := BuildObservationWriteRequest(observation)
+		if err != nil {
+			result.ObservationsSkipped++
+			if errors.Is(err, ErrMissingObservationSubject) {
+				result.MissingSubjects++
+			} else {
+				result.InvalidObservations++
+			}
+			result.LastError = err
+			continue
+		}
+
+		if _, ok := g.GetNode(req.SubjectID); !ok {
+			result.ObservationsSkipped++
+			result.MissingSubjects++
+			result.LastError = ErrMissingObservationSubject
+			continue
+		}
+
+		if _, err := graph.WriteObservation(g, req); err != nil {
+			result.ObservationsSkipped++
+			if classifyObservationMaterializationError(err) == observationMaterializationErrorMissingSubject {
+				result.MissingSubjects++
+			} else {
+				result.InvalidObservations++
+			}
+			result.LastError = err
+			continue
+		}
+
+		result.ObservationsMaterialized++
+	}
+
+	g.BuildIndex()
+	meta := g.Metadata()
+	meta.BuiltAt = now.UTC()
+	meta.NodeCount = g.NodeCount()
+	meta.EdgeCount = g.EdgeCount()
+	g.SetMetadata(meta)
+	return result
+}
+
+type observationMaterializationErrorKind int
+
+const (
+	observationMaterializationErrorInvalid observationMaterializationErrorKind = iota
+	observationMaterializationErrorMissingSubject
+)
+
+func classifyObservationMaterializationError(err error) observationMaterializationErrorKind {
+	if err == nil {
+		return observationMaterializationErrorInvalid
+	}
+	if errors.Is(err, ErrMissingObservationSubject) || strings.HasPrefix(strings.TrimSpace(err.Error()), "subject not found:") {
+		return observationMaterializationErrorMissingSubject
+	}
+	return observationMaterializationErrorInvalid
+}

--- a/internal/runtimegraph/project_test.go
+++ b/internal/runtimegraph/project_test.go
@@ -1,0 +1,222 @@
+package runtimegraph
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+func TestMaterializeObservationsIntoGraphAddsObservationNode(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "deployment:prod/api",
+		Kind: graph.NodeKindDeployment,
+		Name: "api",
+	})
+
+	observation := &runtime.RuntimeObservation{
+		Source:      "tetragon",
+		Kind:        runtime.ObservationKindProcessExec,
+		ObservedAt:  time.Date(2026, 3, 16, 19, 0, 0, 0, time.UTC),
+		RecordedAt:  time.Date(2026, 3, 16, 19, 0, 1, 0, time.UTC),
+		WorkloadRef: "deployment:prod/api",
+		Namespace:   "prod",
+		Process: &runtime.ProcessEvent{
+			Name: "sh",
+			Path: "/bin/sh",
+		},
+	}
+
+	req, err := BuildObservationWriteRequest(observation)
+	if err != nil {
+		t.Fatalf("BuildObservationWriteRequest returned error: %v", err)
+	}
+
+	result := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, time.Date(2026, 3, 16, 19, 1, 0, 0, time.UTC))
+	if result.ObservationsConsidered != 1 {
+		t.Fatalf("ObservationsConsidered = %d, want 1", result.ObservationsConsidered)
+	}
+	if result.ObservationsMaterialized != 1 {
+		t.Fatalf("ObservationsMaterialized = %d, want 1", result.ObservationsMaterialized)
+	}
+	if result.ObservationsSkipped != 0 {
+		t.Fatalf("ObservationsSkipped = %d, want 0", result.ObservationsSkipped)
+	}
+	if result.MissingSubjects != 0 {
+		t.Fatalf("MissingSubjects = %d, want 0", result.MissingSubjects)
+	}
+
+	node, ok := g.GetNode(req.ID)
+	if !ok {
+		t.Fatalf("observation node %q not found", req.ID)
+	}
+	if node.Kind != graph.NodeKindObservation {
+		t.Fatalf("node.Kind = %q, want %q", node.Kind, graph.NodeKindObservation)
+	}
+	if node.Provider != "tetragon" {
+		t.Fatalf("node.Provider = %q, want tetragon", node.Provider)
+	}
+	if got := testMetadataString(node.Properties, "observation_type"); got != "process_exec" {
+		t.Fatalf("node.properties.observation_type = %q, want process_exec", got)
+	}
+	if got := testMetadataString(node.Properties, "subject_id"); got != "deployment:prod/api" {
+		t.Fatalf("node.properties.subject_id = %q, want deployment:prod/api", got)
+	}
+	if got := testMetadataString(node.Properties, "detail"); got != "process exec /bin/sh" {
+		t.Fatalf("node.properties.detail = %q, want process exec /bin/sh", got)
+	}
+	if issues := graph.GlobalSchemaRegistry().ValidateNode(node); len(issues) != 0 {
+		t.Fatalf("ValidateNode returned issues: %+v", issues)
+	}
+
+	outEdges := g.GetOutEdges(req.ID)
+	if len(outEdges) != 1 {
+		t.Fatalf("len(outEdges) = %d, want 1", len(outEdges))
+	}
+	if outEdges[0].Kind != graph.EdgeKindTargets || outEdges[0].Target != "deployment:prod/api" {
+		t.Fatalf("edge = %+v, want targets edge to deployment:prod/api", outEdges[0])
+	}
+	if issues := graph.GlobalSchemaRegistry().ValidateEdge(outEdges[0], node, mustNode(t, g, "deployment:prod/api")); len(issues) != 0 {
+		t.Fatalf("ValidateEdge returned issues: %+v", issues)
+	}
+
+	meta := g.Metadata()
+	if meta.BuiltAt.IsZero() {
+		t.Fatal("metadata.BuiltAt should not be zero")
+	}
+	if meta.NodeCount != g.NodeCount() || meta.EdgeCount != g.EdgeCount() {
+		t.Fatalf("metadata counts = %d/%d, want %d/%d", meta.NodeCount, meta.EdgeCount, g.NodeCount(), g.EdgeCount())
+	}
+}
+
+func TestMaterializeObservationsIntoGraphSkipsMissingSubjects(t *testing.T) {
+	g := graph.New()
+	observation := &runtime.RuntimeObservation{
+		Source:     "otel",
+		Kind:       runtime.ObservationKindTraceLink,
+		ObservedAt: time.Date(2026, 3, 16, 19, 5, 0, 0, time.UTC),
+		Trace: &runtime.TraceContext{
+			TraceID:     "abc123",
+			ServiceName: "checkout",
+		},
+		Metadata: map[string]any{
+			"service_namespace": "storefront",
+		},
+	}
+
+	result := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, time.Date(2026, 3, 16, 19, 6, 0, 0, time.UTC))
+	if result.ObservationsConsidered != 1 {
+		t.Fatalf("ObservationsConsidered = %d, want 1", result.ObservationsConsidered)
+	}
+	if result.ObservationsMaterialized != 0 {
+		t.Fatalf("ObservationsMaterialized = %d, want 0", result.ObservationsMaterialized)
+	}
+	if result.ObservationsSkipped != 1 {
+		t.Fatalf("ObservationsSkipped = %d, want 1", result.ObservationsSkipped)
+	}
+	if result.MissingSubjects != 1 {
+		t.Fatalf("MissingSubjects = %d, want 1", result.MissingSubjects)
+	}
+	if result.InvalidObservations != 0 {
+		t.Fatalf("InvalidObservations = %d, want 0", result.InvalidObservations)
+	}
+	if g.NodeCount() != 0 || g.EdgeCount() != 0 {
+		t.Fatalf("graph counts = %d/%d, want 0/0", g.NodeCount(), g.EdgeCount())
+	}
+}
+
+func TestMaterializeObservationsIntoGraphSkipsObservationsWithoutConcreteSubject(t *testing.T) {
+	g := graph.New()
+	observation := &runtime.RuntimeObservation{
+		Source:     "falco",
+		Kind:       runtime.ObservationKindRuntimeAlert,
+		ObservedAt: time.Date(2026, 3, 16, 19, 10, 0, 0, time.UTC),
+	}
+
+	result := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, time.Date(2026, 3, 16, 19, 11, 0, 0, time.UTC))
+	if result.ObservationsConsidered != 1 {
+		t.Fatalf("ObservationsConsidered = %d, want 1", result.ObservationsConsidered)
+	}
+	if result.ObservationsMaterialized != 0 {
+		t.Fatalf("ObservationsMaterialized = %d, want 0", result.ObservationsMaterialized)
+	}
+	if result.ObservationsSkipped != 1 {
+		t.Fatalf("ObservationsSkipped = %d, want 1", result.ObservationsSkipped)
+	}
+	if result.MissingSubjects != 1 {
+		t.Fatalf("MissingSubjects = %d, want 1", result.MissingSubjects)
+	}
+	if result.InvalidObservations != 0 {
+		t.Fatalf("InvalidObservations = %d, want 0", result.InvalidObservations)
+	}
+	if !errors.Is(result.LastError, ErrMissingObservationSubject) {
+		t.Fatalf("LastError = %v, want ErrMissingObservationSubject", result.LastError)
+	}
+}
+
+func TestMaterializeObservationsIntoGraphRefreshesBuiltAtOnSubsequentWrites(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "deployment:prod/api",
+		Kind: graph.NodeKindDeployment,
+		Name: "api",
+	})
+
+	firstNow := time.Date(2026, 3, 16, 19, 30, 0, 0, time.UTC)
+	secondNow := firstNow.Add(5 * time.Minute)
+
+	firstObservation := &runtime.RuntimeObservation{
+		Source:      "tetragon",
+		Kind:        runtime.ObservationKindProcessExec,
+		ObservedAt:  firstNow.Add(-10 * time.Second),
+		WorkloadRef: "deployment:prod/api",
+		Process: &runtime.ProcessEvent{
+			Name: "sh",
+			Path: "/bin/sh",
+		},
+	}
+	secondObservation := &runtime.RuntimeObservation{
+		Source:      "tetragon",
+		Kind:        runtime.ObservationKindProcessExec,
+		ObservedAt:  secondNow.Add(-10 * time.Second),
+		WorkloadRef: "deployment:prod/api",
+		Process: &runtime.ProcessEvent{
+			Name: "bash",
+			Path: "/bin/bash",
+		},
+	}
+
+	firstResult := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{firstObservation}, firstNow)
+	if firstResult.ObservationsMaterialized != 1 {
+		t.Fatalf("first ObservationsMaterialized = %d, want 1", firstResult.ObservationsMaterialized)
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(firstNow) {
+		t.Fatalf("after first materialization BuiltAt = %s, want %s", got, firstNow)
+	}
+
+	secondResult := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{secondObservation}, secondNow)
+	if secondResult.ObservationsMaterialized != 1 {
+		t.Fatalf("second ObservationsMaterialized = %d, want 1", secondResult.ObservationsMaterialized)
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(secondNow) {
+		t.Fatalf("after second materialization BuiltAt = %s, want %s", got, secondNow)
+	}
+}
+func TestClassifyObservationMaterializationErrorTreatsSubjectNotFoundAsMissingSubject(t *testing.T) {
+	if got := classifyObservationMaterializationError(fmt.Errorf("subject not found: service:storefront/checkout")); got != observationMaterializationErrorMissingSubject {
+		t.Fatalf("classifyObservationMaterializationError(subject not found) = %v, want %v", got, observationMaterializationErrorMissingSubject)
+	}
+}
+
+func mustNode(t *testing.T, g *graph.Graph, id string) *graph.Node {
+	t.Helper()
+	node, ok := g.GetNode(id)
+	if !ok {
+		t.Fatalf("node %q not found", id)
+	}
+	return node
+}

--- a/internal/runtimegraph/project_test.go
+++ b/internal/runtimegraph/project_test.go
@@ -285,6 +285,55 @@ func TestMaterializeObservationsIntoGraphDoesNotDuplicateReverseTargetEdges(t *t
 	}
 }
 
+func TestMaterializeObservationsIntoGraphDefersIndexBuildToCaller(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "deployment:prod/api",
+		Kind: graph.NodeKindDeployment,
+		Name: "api",
+	})
+	g.BuildIndex()
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected initial graph index to be built")
+	}
+
+	now := time.Date(2026, 3, 16, 19, 40, 0, 0, time.UTC)
+	observation := &runtime.RuntimeObservation{
+		ID:          "runtime:process_exec:defer-index",
+		Source:      "tetragon",
+		Kind:        runtime.ObservationKindProcessExec,
+		ObservedAt:  now.Add(-10 * time.Second),
+		RecordedAt:  now.Add(-5 * time.Second),
+		WorkloadRef: "deployment:prod/api",
+		Process: &runtime.ProcessEvent{
+			Name: "sh",
+			Path: "/bin/sh",
+		},
+	}
+
+	result := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, now)
+	if result.ObservationsMaterialized != 1 {
+		t.Fatalf("ObservationsMaterialized = %d, want 1", result.ObservationsMaterialized)
+	}
+	if g.IsIndexBuilt() {
+		t.Fatal("expected index to remain stale until caller finalizes materialized graph")
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(now) {
+		t.Fatalf("metadata.BuiltAt = %s, want %s", got, now)
+	}
+
+	FinalizeMaterializedGraph(g, now.Add(time.Minute))
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected FinalizeMaterializedGraph to rebuild indexes")
+	}
+	if got := len(g.GetNodesByKindIndexed(graph.NodeKindObservation)); got != 1 {
+		t.Fatalf("len(GetNodesByKindIndexed(observation)) = %d, want 1", got)
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(now.Add(time.Minute)) {
+		t.Fatalf("metadata.BuiltAt after finalize = %s, want %s", got, now.Add(time.Minute))
+	}
+}
+
 func TestGraphAddEdgeIfMissingReturnsFalseWhenSchemaRejectsEdge(t *testing.T) {
 	g := graph.New()
 	g.SetSchemaValidationMode(graph.SchemaValidationEnforce)

--- a/internal/runtimegraph/project_test.go
+++ b/internal/runtimegraph/project_test.go
@@ -49,6 +49,9 @@ func TestMaterializeObservationsIntoGraphAddsObservationNode(t *testing.T) {
 	if result.MissingSubjects != 0 {
 		t.Fatalf("MissingSubjects = %d, want 0", result.MissingSubjects)
 	}
+	if result.WorkloadTargetEdgesCreated != 1 {
+		t.Fatalf("WorkloadTargetEdgesCreated = %d, want 1", result.WorkloadTargetEdgesCreated)
+	}
 
 	node, ok := g.GetNode(req.ID)
 	if !ok {
@@ -82,6 +85,17 @@ func TestMaterializeObservationsIntoGraphAddsObservationNode(t *testing.T) {
 	}
 	if issues := graph.GlobalSchemaRegistry().ValidateEdge(outEdges[0], node, mustNode(t, g, "deployment:prod/api")); len(issues) != 0 {
 		t.Fatalf("ValidateEdge returned issues: %+v", issues)
+	}
+
+	workloadEdges := g.GetOutEdges("deployment:prod/api")
+	if len(workloadEdges) != 1 {
+		t.Fatalf("len(workloadEdges) = %d, want 1", len(workloadEdges))
+	}
+	if workloadEdges[0].Kind != graph.EdgeKindTargets || workloadEdges[0].Target != req.ID {
+		t.Fatalf("workload edge = %+v, want targets edge to %s", workloadEdges[0], req.ID)
+	}
+	if issues := graph.GlobalSchemaRegistry().ValidateEdge(workloadEdges[0], mustNode(t, g, "deployment:prod/api"), node); len(issues) != 0 {
+		t.Fatalf("ValidateEdge(workload edge) returned issues: %+v", issues)
 	}
 
 	meta := g.Metadata()
@@ -157,7 +171,6 @@ func TestMaterializeObservationsIntoGraphSkipsObservationsWithoutConcreteSubject
 		t.Fatalf("LastError = %v, want ErrMissingObservationSubject", result.LastError)
 	}
 }
-
 func TestMaterializeObservationsIntoGraphRefreshesBuiltAtOnSubsequentWrites(t *testing.T) {
 	g := graph.New()
 	g.AddNode(&graph.Node{
@@ -206,6 +219,96 @@ func TestMaterializeObservationsIntoGraphRefreshesBuiltAtOnSubsequentWrites(t *t
 		t.Fatalf("after second materialization BuiltAt = %s, want %s", got, secondNow)
 	}
 }
+
+func TestMaterializeObservationsIntoGraphDoesNotAddReverseTargetEdgeForServiceSubjects(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "service:storefront/checkout",
+		Kind: graph.NodeKindService,
+		Name: "checkout",
+	})
+
+	observation := &runtime.RuntimeObservation{
+		Source:     "otel",
+		Kind:       runtime.ObservationKindTraceLink,
+		ObservedAt: time.Date(2026, 3, 16, 19, 20, 0, 0, time.UTC),
+		Trace: &runtime.TraceContext{
+			TraceID:     "abc123",
+			ServiceName: "checkout",
+		},
+		Metadata: map[string]any{
+			"service_namespace": "storefront",
+		},
+	}
+
+	result := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, time.Date(2026, 3, 16, 19, 21, 0, 0, time.UTC))
+	if result.WorkloadTargetEdgesCreated != 0 {
+		t.Fatalf("WorkloadTargetEdgesCreated = %d, want 0", result.WorkloadTargetEdgesCreated)
+	}
+	if len(g.GetOutEdges("service:storefront/checkout")) != 0 {
+		t.Fatalf("service out edge count = %d, want 0", len(g.GetOutEdges("service:storefront/checkout")))
+	}
+}
+
+func TestMaterializeObservationsIntoGraphDoesNotDuplicateReverseTargetEdges(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "deployment:prod/api",
+		Kind: graph.NodeKindDeployment,
+		Name: "api",
+	})
+
+	observation := &runtime.RuntimeObservation{
+		ID:          "runtime:process_exec:abc",
+		Source:      "tetragon",
+		Kind:        runtime.ObservationKindProcessExec,
+		ObservedAt:  time.Date(2026, 3, 16, 19, 0, 0, 0, time.UTC),
+		RecordedAt:  time.Date(2026, 3, 16, 19, 0, 1, 0, time.UTC),
+		WorkloadRef: "deployment:prod/api",
+		Process: &runtime.ProcessEvent{
+			Name: "sh",
+			Path: "/bin/sh",
+		},
+	}
+
+	first := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, time.Date(2026, 3, 16, 19, 1, 0, 0, time.UTC))
+	second := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, time.Date(2026, 3, 16, 19, 2, 0, 0, time.UTC))
+
+	if first.WorkloadTargetEdgesCreated != 1 {
+		t.Fatalf("first WorkloadTargetEdgesCreated = %d, want 1", first.WorkloadTargetEdgesCreated)
+	}
+	if second.WorkloadTargetEdgesCreated != 0 {
+		t.Fatalf("second WorkloadTargetEdgesCreated = %d, want 0", second.WorkloadTargetEdgesCreated)
+	}
+	if got := len(g.GetOutEdges("deployment:prod/api")); got != 1 {
+		t.Fatalf("len(workload out edges) = %d, want 1", got)
+	}
+}
+
+func TestGraphAddEdgeIfMissingReturnsFalseWhenSchemaRejectsEdge(t *testing.T) {
+	g := graph.New()
+	g.SetSchemaValidationMode(graph.SchemaValidationEnforce)
+	g.AddNode(&graph.Node{
+		ID:   "deployment:prod/api",
+		Kind: graph.NodeKindDeployment,
+		Name: "api",
+	})
+
+	added := graph.AddEdgeIfMissing(g, &graph.Edge{
+		ID:     "deployment:prod/api->observation:missing:targets",
+		Source: "deployment:prod/api",
+		Target: "observation:missing",
+		Kind:   graph.EdgeKindTargets,
+		Effect: graph.EdgeEffectAllow,
+	})
+	if added {
+		t.Fatal("expected addRuntimeGraphEdgeIfMissing to report false when schema rejects edge")
+	}
+	if got := len(g.GetOutEdges("deployment:prod/api")); got != 0 {
+		t.Fatalf("len(workload out edges) = %d, want 0", got)
+	}
+}
+
 func TestClassifyObservationMaterializationErrorTreatsSubjectNotFoundAsMissingSubject(t *testing.T) {
 	if got := classifyObservationMaterializationError(fmt.Errorf("subject not found: service:storefront/checkout")); got != observationMaterializationErrorMissingSubject {
 		t.Fatalf("classifyObservationMaterializationError(subject not found) = %v, want %v", got, observationMaterializationErrorMissingSubject)

--- a/internal/workloadscan/credential_pivots.go
+++ b/internal/workloadscan/credential_pivots.go
@@ -39,7 +39,7 @@ func materializeSecretPivots(g *graph.Graph, workloadNode, scanNode *graph.Node,
 		g.AddNode(secretNode)
 		result.SecretNodesUpserted++
 
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(scanNode.ID, secretNode.ID, graph.EdgeKindTargets),
 			Source:     scanNode.ID,
 			Target:     secretNode.ID,
@@ -60,7 +60,7 @@ func materializeSecretPivots(g *graph.Graph, workloadNode, scanNode *graph.Node,
 			props["credential_type"] = secret.Type
 			props["credential_finding_id"] = secret.ID
 			props["match_fingerprint"] = matchFingerprint
-			if addEdgeIfMissing(g, &graph.Edge{
+			if graph.AddEdgeIfMissing(g, &graph.Edge{
 				ID:         edgeID(secretNode.ID, target.ID, graph.EdgeKindTargets),
 				Source:     secretNode.ID,
 				Target:     target.ID,
@@ -88,7 +88,7 @@ func materializeSecretPivots(g *graph.Graph, workloadNode, scanNode *graph.Node,
 			if strings.TrimSpace(target.reason) != "" {
 				props["resolution_reason"] = target.reason
 			}
-			if addEdgeIfMissing(g, &graph.Edge{
+			if graph.AddEdgeIfMissing(g, &graph.Edge{
 				ID:         credentialPivotEdgeID(workloadNode.ID, target.node.ID, secret.ID, target.viaPrincipalID),
 				Source:     workloadNode.ID,
 				Target:     target.node.ID,

--- a/internal/workloadscan/graph_materialization.go
+++ b/internal/workloadscan/graph_materialization.go
@@ -282,7 +282,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 	g.AddNode(scanNode)
 	result.ScanNodesUpserted++
 
-	if addEdgeIfMissing(g, &graph.Edge{
+	if graph.AddEdgeIfMissing(g, &graph.Edge{
 		ID:         edgeID(target.ID, scanNode.ID, graph.EdgeKindHasScan),
 		Source:     target.ID,
 		Target:     scanNode.ID,
@@ -317,7 +317,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		edgeProps["reachable"] = pkgAgg.record.Reachable
 		edgeProps["dependency_depth"] = pkgAgg.record.DependencyDepth
 		edgeProps["import_file_count"] = pkgAgg.record.ImportFileCount
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(scanNode.ID, pkgNode.ID, graph.EdgeKindContainsPkg),
 			Source:     scanNode.ID,
 			Target:     pkgNode.ID,
@@ -336,7 +336,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		if parentID == "" || childID == "" {
 			continue
 		}
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:     edgeID(parentID, childID, graph.EdgeKindDependsOn),
 			Source: parentID,
 			Target: childID,
@@ -381,7 +381,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		techEdgeProperties["category"] = techAgg.record.Category
 		techEdgeProperties["version"] = strings.TrimSpace(techAgg.record.Version)
 		techEdgeProperties["file_path"] = strings.TrimSpace(techAgg.record.Path)
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(target.ID, techNode.ID, graph.EdgeKindRuns),
 			Source:     target.ID,
 			Target:     techNode.ID,
@@ -413,7 +413,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		g.AddNode(vulnNode)
 		result.VulnNodesUpserted++
 		usage := vulnUsage[vulnKey]
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(scanNode.ID, vulnNode.ID, graph.EdgeKindFoundVuln),
 			Source:     scanNode.ID,
 			Target:     vulnNode.ID,
@@ -434,7 +434,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		vuln := vulnAgg.record
 		pkgID := packageNodeID(relation.pkg)
 		vulnID := vulnerabilityNodeID(vuln)
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:     packageVulnerabilityEdgeID(pkgID, vulnID),
 			Source: pkgID,
 			Target: vulnID,
@@ -477,7 +477,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		observationNode := buildIaCFindingObservationNode(scanNode, target, findingAgg.record, observationMeta)
 		g.AddNode(observationNode)
 		result.ObservationNodesUpserted++
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(observationNode.ID, scanNode.ID, graph.EdgeKindTargets),
 			Source:     observationNode.ID,
 			Target:     scanNode.ID,
@@ -508,7 +508,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		observationNode := buildMalwareObservationNode(scanNode, target, malwareAgg.record, observationMeta)
 		g.AddNode(observationNode)
 		result.ObservationNodesUpserted++
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(observationNode.ID, scanNode.ID, graph.EdgeKindTargets),
 			Source:     observationNode.ID,
 			Target:     scanNode.ID,
@@ -1425,22 +1425,6 @@ func applyVulnerabilityUsageSummaryProperties(properties map[string]any, ctx vul
 	properties["reachable_package_count"] = len(ctx.reachablePackageKeys)
 	properties["direct_reachable_package_count"] = len(ctx.directReachablePackageKeys)
 	return properties
-}
-
-func addEdgeIfMissing(g *graph.Graph, edge *graph.Edge) bool {
-	if g == nil || edge == nil {
-		return false
-	}
-	for _, existing := range g.GetOutEdges(edge.Source) {
-		if existing == nil {
-			continue
-		}
-		if existing.ID == edge.ID || (existing.Target == edge.Target && existing.Kind == edge.Kind) {
-			return false
-		}
-	}
-	g.AddEdge(edge)
-	return true
 }
 
 func cloneWorkloadAnyMap(values map[string]any) map[string]any {


### PR DESCRIPTION
* Bind runtime service identity context

* Respect container precedence in service binding

* Preserve control-plane precedence in service binding

* Preserve resource precedence in service binding

* Normalize empty runtime trace context
