### PR TITLE
Add runtime observation target and evidence links (#365)

### DIFF
--- a/internal/graph/edge_helpers.go
+++ b/internal/graph/edge_helpers.go
@@ -1,0 +1,27 @@
+package graph
+
+// AddEdgeIfMissing adds an edge only when both endpoints exist and there is no
+// active edge with the same ID or the same source/target/kind tuple already in
+// the graph. It returns true only when a new edge is accepted.
+func AddEdgeIfMissing(g *Graph, edge *Edge) bool {
+	if g == nil || edge == nil || edge.Source == "" || edge.Target == "" {
+		return false
+	}
+	if _, ok := g.GetNode(edge.Source); !ok {
+		return false
+	}
+	if _, ok := g.GetNode(edge.Target); !ok {
+		return false
+	}
+	for _, existing := range g.GetOutEdges(edge.Source) {
+		if existing == nil {
+			continue
+		}
+		if existing.ID == edge.ID || (existing.Target == edge.Target && existing.Kind == edge.Kind) {
+			return false
+		}
+	}
+	before := len(g.GetOutEdges(edge.Source))
+	g.AddEdge(edge)
+	return len(g.GetOutEdges(edge.Source)) > before
+}

--- a/internal/graph/edge_helpers_test.go
+++ b/internal/graph/edge_helpers_test.go
@@ -1,0 +1,45 @@
+package graph
+
+import "testing"
+
+func TestAddEdgeIfMissingAddsEdgeOnce(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "source", Kind: NodeKindWorkload})
+	g.AddNode(&Node{ID: "target", Kind: NodeKindObservation})
+
+	edge := &Edge{
+		ID:     "source->target:targets",
+		Source: "source",
+		Target: "target",
+		Kind:   EdgeKindTargets,
+		Effect: EdgeEffectAllow,
+	}
+
+	if !AddEdgeIfMissing(g, edge) {
+		t.Fatal("expected first AddEdgeIfMissing to add edge")
+	}
+	if AddEdgeIfMissing(g, edge) {
+		t.Fatal("expected duplicate AddEdgeIfMissing to return false")
+	}
+	if got := len(g.GetOutEdges("source")); got != 1 {
+		t.Fatalf("len(outEdges) = %d, want 1", got)
+	}
+}
+
+func TestAddEdgeIfMissingRequiresEndpoints(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "source", Kind: NodeKindWorkload})
+
+	if AddEdgeIfMissing(g, &Edge{
+		ID:     "source->missing:targets",
+		Source: "source",
+		Target: "missing",
+		Kind:   EdgeKindTargets,
+		Effect: EdgeEffectAllow,
+	}) {
+		t.Fatal("expected AddEdgeIfMissing to reject missing target")
+	}
+	if got := len(g.GetOutEdges("source")); got != 0 {
+		t.Fatalf("len(outEdges) = %d, want 0", got)
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -17,6 +18,9 @@ type Graph struct {
 	inEdges  map[string][]*Edge // target -> edges
 	mu       sync.RWMutex
 	metadata Metadata
+
+	activeNodeCount atomic.Int64
+	activeEdgeCount atomic.Int64
 
 	// Traversal cache for expensive reachability queries.
 	blastRadiusCache   sync.Map
@@ -141,6 +145,7 @@ func (g *Graph) RemoveNode(id string) bool {
 		return false
 	}
 
+	g.removeEdgesByNodeLocked(id)
 	now := temporalNowUTC()
 	node.DeletedAt = &now
 	node.UpdatedAt = now
@@ -148,7 +153,7 @@ func (g *Graph) RemoveNode(id string) bool {
 		node.Version = 1
 	}
 	node.Version++
-	g.removeEdgesByNodeLocked(id)
+	g.activeNodeCount.Add(-1)
 	g.markGraphChangedLocked()
 	return true
 }
@@ -161,17 +166,10 @@ func (g *Graph) RemoveEdge(source, target string, kind EdgeKind) bool {
 	removed := false
 	if edges, ok := g.outEdges[source]; ok {
 		for _, edge := range edges {
-			if edge == nil || edge.DeletedAt != nil {
-				continue
-			}
-			if edge.Source == source && edge.Target == target && edge.Kind == kind {
-				now := temporalNowUTC()
-				edge.DeletedAt = &now
-				if edge.Version <= 0 {
-					edge.Version = 1
+			if edge != nil && edge.Source == source && edge.Target == target && edge.Kind == kind {
+				if g.markEdgeDeletedLocked(edge) {
+					removed = true
 				}
-				edge.Version++
-				removed = true
 			}
 		}
 	}
@@ -376,31 +374,12 @@ func (g *Graph) GetAllEdges() map[string][]*Edge {
 
 // NodeCount returns the number of nodes
 func (g *Graph) NodeCount() int {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	count := 0
-	for _, node := range g.nodes {
-		if node == nil || node.DeletedAt != nil {
-			continue
-		}
-		count++
-	}
-	return count
+	return int(g.activeNodeCount.Load())
 }
 
 // EdgeCount returns the total number of edges
 func (g *Graph) EdgeCount() int {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	count := 0
-	for _, edges := range g.outEdges {
-		for _, edge := range edges {
-			if g.activeEdgeLocked(edge) {
-				count++
-			}
-		}
-	}
-	return count
+	return int(g.activeEdgeCount.Load())
 }
 
 // Clear removes all nodes and edges
@@ -410,6 +389,8 @@ func (g *Graph) Clear() {
 	g.nodes = make(map[string]*Node)
 	g.outEdges = make(map[string][]*Edge)
 	g.inEdges = make(map[string][]*Edge)
+	g.activeNodeCount.Store(0)
+	g.activeEdgeCount.Store(0)
 	g.markGraphChangedLocked()
 }
 
@@ -419,6 +400,7 @@ func (g *Graph) ClearEdges() {
 	defer g.mu.Unlock()
 	g.outEdges = make(map[string][]*Edge)
 	g.inEdges = make(map[string][]*Edge)
+	g.activeEdgeCount.Store(0)
 	g.markGraphChangedLocked()
 }
 
@@ -796,7 +778,9 @@ func (g *Graph) addNodeLocked(node *Node) bool {
 	}
 
 	now := temporalNowUTC()
+	wasActive := false
 	if existing, ok := g.nodes[node.ID]; ok && existing != nil {
+		wasActive = existing.DeletedAt == nil
 		if existing.CreatedAt.IsZero() {
 			existing.CreatedAt = now
 		}
@@ -832,6 +816,9 @@ func (g *Graph) addNodeLocked(node *Node) bool {
 	node.DeletedAt = nil
 	g.appendNodePropertiesHistoryLocked(node, node.UpdatedAt)
 	g.nodes[node.ID] = node
+	if !wasActive {
+		g.activeNodeCount.Add(1)
+	}
 	return true
 }
 
@@ -850,6 +837,7 @@ func (g *Graph) addEdgeLocked(edge *Edge) bool {
 	edge.DeletedAt = nil
 	g.outEdges[edge.Source] = append(g.outEdges[edge.Source], edge)
 	g.inEdges[edge.Target] = append(g.inEdges[edge.Target], edge)
+	g.activeEdgeCount.Add(1)
 	return true
 }
 
@@ -941,6 +929,7 @@ func (g *Graph) markEdgeDeletedLocked(edge *Edge) bool {
 		edge.Version = 1
 	}
 	edge.Version++
+	g.activeEdgeCount.Add(-1)
 	return true
 }
 

--- a/internal/graph/graph_counts_bench_test.go
+++ b/internal/graph/graph_counts_bench_test.go
@@ -1,0 +1,39 @@
+package graph
+
+import (
+	"strconv"
+	"testing"
+)
+
+func BenchmarkGraphNodeCount(b *testing.B) {
+	g := New()
+	for i := 0; i < 100000; i++ {
+		g.AddNode(&Node{ID: "node:" + strconv.Itoa(i), Kind: NodeKindWorkload})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = g.NodeCount()
+	}
+}
+
+func BenchmarkGraphEdgeCount(b *testing.B) {
+	g := New()
+	for i := 0; i < 100001; i++ {
+		g.AddNode(&Node{ID: "node:" + strconv.Itoa(i), Kind: NodeKindWorkload})
+	}
+	for i := 0; i < 100000; i++ {
+		g.AddEdge(&Edge{
+			ID:     "edge:" + strconv.Itoa(i),
+			Source: "node:" + strconv.Itoa(i),
+			Target: "node:" + strconv.Itoa(i+1),
+			Kind:   EdgeKindTargets,
+			Effect: EdgeEffectAllow,
+		})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = g.EdgeCount()
+	}
+}

--- a/internal/graph/graph_counts_test.go
+++ b/internal/graph/graph_counts_test.go
@@ -1,0 +1,91 @@
+package graph
+
+import "testing"
+
+func TestGraphCountsMatchFullScanAcrossMutations(t *testing.T) {
+	g := New()
+
+	assertCountsMatchScan := func(step string) {
+		t.Helper()
+		wantNodes, wantEdges := fullScanGraphCounts(g)
+		if got := g.NodeCount(); got != wantNodes {
+			t.Fatalf("%s: NodeCount = %d, want %d", step, got, wantNodes)
+		}
+		if got := g.EdgeCount(); got != wantEdges {
+			t.Fatalf("%s: EdgeCount = %d, want %d", step, got, wantEdges)
+		}
+	}
+
+	assertCountsMatchScan("empty")
+
+	g.AddNode(&Node{ID: "user:alice", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "role:admin", Kind: NodeKindRole})
+	g.AddNode(&Node{ID: "bucket:data", Kind: NodeKindBucket})
+	assertCountsMatchScan("after add nodes")
+
+	g.AddEdge(&Edge{ID: "e1", Source: "user:alice", Target: "role:admin", Kind: EdgeKindCanAssume, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "e2", Source: "role:admin", Target: "bucket:data", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "e3", Source: "bucket:data", Target: "user:alice", Kind: EdgeKindOwns, Effect: EdgeEffectAllow})
+	assertCountsMatchScan("after add edges")
+
+	g.SetNodeProperty("user:alice", "team", "platform")
+	assertCountsMatchScan("after property mutation")
+
+	if !g.RemoveEdge("user:alice", "role:admin", EdgeKindCanAssume) {
+		t.Fatal("expected RemoveEdge to remove edge")
+	}
+	assertCountsMatchScan("after remove edge")
+
+	if !g.RemoveNode("role:admin") {
+		t.Fatal("expected RemoveNode to remove node")
+	}
+	assertCountsMatchScan("after remove node")
+
+	g.AddNode(&Node{ID: "role:admin", Kind: NodeKindRole})
+	g.AddEdge(&Edge{ID: "e4", Source: "user:alice", Target: "role:admin", Kind: EdgeKindCanAssume, Effect: EdgeEffectAllow})
+	assertCountsMatchScan("after revive node and edge")
+
+	g.ClearEdges()
+	assertCountsMatchScan("after clear edges")
+
+	g.Clear()
+	assertCountsMatchScan("after clear graph")
+}
+
+func TestGraphCountsMatchFullScanAfterSnapshotRestore(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "a", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "b", Kind: NodeKindRole})
+	g.AddNode(&Node{ID: "c", Kind: NodeKindBucket})
+	g.AddEdge(&Edge{ID: "e1", Source: "a", Target: "b", Kind: EdgeKindCanAssume, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "e2", Source: "b", Target: "c", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+
+	restored := RestoreFromSnapshot(CreateSnapshot(g))
+	wantNodes, wantEdges := fullScanGraphCounts(restored)
+	if got := restored.NodeCount(); got != wantNodes {
+		t.Fatalf("restored NodeCount = %d, want %d", got, wantNodes)
+	}
+	if got := restored.EdgeCount(); got != wantEdges {
+		t.Fatalf("restored EdgeCount = %d, want %d", got, wantEdges)
+	}
+}
+
+func fullScanGraphCounts(g *Graph) (nodes int, edges int) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	for _, node := range g.nodes {
+		if node == nil || node.DeletedAt != nil {
+			continue
+		}
+		nodes++
+	}
+	for _, edgeList := range g.outEdges {
+		for _, edge := range edgeList {
+			if g.activeEdgeLocked(edge) {
+				edges++
+			}
+		}
+	}
+	return nodes, edges
+}

--- a/internal/runtimegraph/bench_test.go
+++ b/internal/runtimegraph/bench_test.go
@@ -1,0 +1,52 @@
+package runtimegraph
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/runtime"
+)
+
+func BenchmarkMaterializeObservationsIntoGraphDeferredFinalize(b *testing.B) {
+	const batchSize = 50
+	const totalObservations = 10000
+
+	observations := make([]*runtime.RuntimeObservation, 0, totalObservations)
+	baseTime := time.Date(2026, 3, 16, 21, 0, 0, 0, time.UTC)
+	for i := 0; i < totalObservations; i++ {
+		observations = append(observations, &runtime.RuntimeObservation{
+			ID:          "runtime:process_exec:" + strconv.Itoa(i),
+			Source:      "tetragon",
+			Kind:        runtime.ObservationKindProcessExec,
+			ObservedAt:  baseTime.Add(time.Duration(i) * time.Second),
+			RecordedAt:  baseTime.Add(time.Duration(i)*time.Second + time.Millisecond),
+			WorkloadRef: "deployment:prod/api",
+			Process: &runtime.ProcessEvent{
+				Name: "sh",
+				Path: "/bin/sh",
+			},
+		})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g := graph.New()
+		g.AddNode(&graph.Node{
+			ID:   "deployment:prod/api",
+			Kind: graph.NodeKindDeployment,
+			Name: "api",
+		})
+		g.BuildIndex()
+
+		for start := 0; start < len(observations); start += batchSize {
+			end := start + batchSize
+			if end > len(observations) {
+				end = len(observations)
+			}
+			MaterializeObservationsIntoGraph(g, observations[start:end], baseTime)
+		}
+		FinalizeMaterializedGraph(g, baseTime)
+	}
+}

--- a/internal/runtimegraph/evidence.go
+++ b/internal/runtimegraph/evidence.go
@@ -20,6 +20,7 @@ var ErrInvalidFindingEvidence = errors.New("invalid runtime finding evidence")
 type EvidenceMaterializationResult struct {
 	FindingsConsidered    int   `json:"findings_considered"`
 	EvidenceNodesUpserted int   `json:"evidence_nodes_upserted"`
+	BasedOnEdgesCreated   int   `json:"based_on_edges_created"`
 	FindingsSkipped       int   `json:"findings_skipped"`
 	InvalidFindings       int   `json:"invalid_findings"`
 	LastError             error `json:"-"`
@@ -115,6 +116,10 @@ func MaterializeFindingEvidenceIntoGraph(g *graph.Graph, findings []*runtime.Run
 		}
 		g.AddNode(node)
 		result.EvidenceNodesUpserted++
+
+		if graph.AddEdgeIfMissing(g, buildFindingEvidenceBasedOnEdge(node, finding)) {
+			result.BasedOnEdgesCreated++
+		}
 	}
 
 	g.BuildIndex()
@@ -152,4 +157,42 @@ func findingEvidenceNodeID(finding *runtime.RuntimeFinding, sourceEventID string
 		observedAt.UTC().Format(time.RFC3339Nano),
 	}, "|")))
 	return "evidence:runtime_finding:" + hex.EncodeToString(digest[:8])
+}
+
+func buildFindingEvidenceBasedOnEdge(node *graph.Node, finding *runtime.RuntimeFinding) *graph.Edge {
+	if node == nil || finding == nil || finding.Observation == nil {
+		return nil
+	}
+	observationID := evidenceObservationNodeID(strings.TrimSpace(finding.Observation.ID))
+	if observationID == "" {
+		return nil
+	}
+
+	properties := map[string]any{
+		"source_system": runtimeFindingEvidenceSourceSystem,
+	}
+	addMetadataString(properties, "source_event_id", strings.TrimSpace(finding.ID))
+	addMetadataString(properties, "observed_at", metadataString(node.Properties, "observed_at"))
+	addMetadataString(properties, "valid_from", metadataString(node.Properties, "valid_from"))
+	addMetadataString(properties, "runtime_source", metadataString(node.Properties, "runtime_source"))
+
+	return &graph.Edge{
+		ID:         node.ID + "->" + observationID + ":" + string(graph.EdgeKindBasedOn),
+		Source:     node.ID,
+		Target:     observationID,
+		Kind:       graph.EdgeKindBasedOn,
+		Effect:     graph.EdgeEffectAllow,
+		Properties: properties,
+	}
+}
+
+func evidenceObservationNodeID(observationID string) string {
+	observationID = strings.TrimSpace(observationID)
+	if observationID == "" {
+		return ""
+	}
+	if strings.HasPrefix(observationID, "observation:") {
+		return observationID
+	}
+	return "observation:" + observationID
 }

--- a/internal/runtimegraph/evidence.go
+++ b/internal/runtimegraph/evidence.go
@@ -122,12 +122,7 @@ func MaterializeFindingEvidenceIntoGraph(g *graph.Graph, findings []*runtime.Run
 		}
 	}
 
-	g.BuildIndex()
-	meta := g.Metadata()
-	meta.BuiltAt = now.UTC()
-	meta.NodeCount = g.NodeCount()
-	meta.EdgeCount = g.EdgeCount()
-	g.SetMetadata(meta)
+	refreshMaterializedGraphMetadata(g, now)
 	return result
 }
 

--- a/internal/runtimegraph/evidence_test.go
+++ b/internal/runtimegraph/evidence_test.go
@@ -325,3 +325,44 @@ func TestMaterializeFindingEvidenceIntoGraphRefreshesBuiltAtOnSubsequentWrites(t
 		t.Fatalf("after second materialization BuiltAt = %s, want %s", got, secondNow)
 	}
 }
+
+func TestMaterializeFindingEvidenceIntoGraphDefersIndexBuildToCaller(t *testing.T) {
+	g := graph.New()
+	g.BuildIndex()
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected initial graph index to be built")
+	}
+
+	now := time.Date(2026, 3, 16, 20, 25, 0, 0, time.UTC)
+	result := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{
+		{
+			ID:          "finding-defer-index",
+			RuleID:      "reverse-shell",
+			RuleName:    "Reverse Shell",
+			Category:    runtime.CategoryReverseShell,
+			Severity:    "high",
+			Description: "Detected reverse shell connection",
+			Timestamp:   now.Add(-10 * time.Second),
+		},
+	}, now)
+	if result.EvidenceNodesUpserted != 1 {
+		t.Fatalf("EvidenceNodesUpserted = %d, want 1", result.EvidenceNodesUpserted)
+	}
+	if g.IsIndexBuilt() {
+		t.Fatal("expected index to remain stale until caller finalizes materialized graph")
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(now) {
+		t.Fatalf("metadata.BuiltAt = %s, want %s", got, now)
+	}
+
+	FinalizeMaterializedGraph(g, now.Add(time.Minute))
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected FinalizeMaterializedGraph to rebuild indexes")
+	}
+	if got := len(g.GetNodesByKindIndexed(graph.NodeKindEvidence)); got != 1 {
+		t.Fatalf("len(GetNodesByKindIndexed(evidence)) = %d, want 1", got)
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(now.Add(time.Minute)) {
+		t.Fatalf("metadata.BuiltAt after finalize = %s, want %s", got, now.Add(time.Minute))
+	}
+}

--- a/internal/runtimegraph/evidence_test.go
+++ b/internal/runtimegraph/evidence_test.go
@@ -138,6 +138,11 @@ func TestBuildFindingEvidenceNodeUsesStableHashWhenFindingIDMissing(t *testing.T
 
 func TestMaterializeFindingEvidenceIntoGraphAddsEvidenceNodes(t *testing.T) {
 	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "observation:runtime:process_exec:seed",
+		Kind: graph.NodeKindObservation,
+		Name: "seed observation",
+	})
 	findings := []*runtime.RuntimeFinding{
 		{
 			ID:          "finding-3",
@@ -147,6 +152,9 @@ func TestMaterializeFindingEvidenceIntoGraphAddsEvidenceNodes(t *testing.T) {
 			Severity:    "critical",
 			Description: "Detected nsenter execution",
 			Timestamp:   time.Date(2026, 3, 16, 20, 10, 0, 0, time.UTC),
+			Observation: &runtime.RuntimeObservation{
+				ID: "runtime:process_exec:seed",
+			},
 		},
 	}
 
@@ -157,11 +165,22 @@ func TestMaterializeFindingEvidenceIntoGraphAddsEvidenceNodes(t *testing.T) {
 	if result.EvidenceNodesUpserted != 1 {
 		t.Fatalf("EvidenceNodesUpserted = %d, want 1", result.EvidenceNodesUpserted)
 	}
+	if result.BasedOnEdgesCreated != 1 {
+		t.Fatalf("BasedOnEdgesCreated = %d, want 1", result.BasedOnEdgesCreated)
+	}
 	if result.FindingsSkipped != 0 {
 		t.Fatalf("FindingsSkipped = %d, want 0", result.FindingsSkipped)
 	}
 	if len(g.GetNodesByKind(graph.NodeKindEvidence)) != 1 {
 		t.Fatalf("evidence node count = %d, want 1", len(g.GetNodesByKind(graph.NodeKindEvidence)))
+	}
+	evidenceNode := g.GetNodesByKind(graph.NodeKindEvidence)[0]
+	outEdges := g.GetOutEdges(evidenceNode.ID)
+	if len(outEdges) != 1 {
+		t.Fatalf("len(outEdges) = %d, want 1", len(outEdges))
+	}
+	if outEdges[0].Kind != graph.EdgeKindBasedOn || outEdges[0].Target != "observation:runtime:process_exec:seed" {
+		t.Fatalf("edge = %+v, want based_on edge to observation", outEdges[0])
 	}
 	meta := g.Metadata()
 	if meta.BuiltAt.IsZero() {
@@ -196,6 +215,71 @@ func TestMaterializeFindingEvidenceIntoGraphSkipsFindingsWithoutTemporalContext(
 	}
 	if result.InvalidFindings != 1 {
 		t.Fatalf("InvalidFindings = %d, want 1", result.InvalidFindings)
+	}
+}
+
+func TestMaterializeFindingEvidenceIntoGraphSkipsBasedOnEdgeWhenObservationMissing(t *testing.T) {
+	g := graph.New()
+	result := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{
+		{
+			ID:          "finding-missing-observation",
+			RuleID:      "container-drift-shell",
+			RuleName:    "Unexpected Shell",
+			Category:    runtime.CategoryContainerDrift,
+			Severity:    "medium",
+			Description: "Detected unexpected shell",
+			Timestamp:   time.Date(2026, 3, 16, 20, 12, 0, 0, time.UTC),
+			Observation: &runtime.RuntimeObservation{
+				ID: "runtime:process_exec:missing",
+			},
+		},
+	}, time.Date(2026, 3, 16, 20, 13, 0, 0, time.UTC))
+
+	if result.EvidenceNodesUpserted != 1 {
+		t.Fatalf("EvidenceNodesUpserted = %d, want 1", result.EvidenceNodesUpserted)
+	}
+	if result.BasedOnEdgesCreated != 0 {
+		t.Fatalf("BasedOnEdgesCreated = %d, want 0", result.BasedOnEdgesCreated)
+	}
+	evidenceNode := g.GetNodesByKind(graph.NodeKindEvidence)[0]
+	if got := len(g.GetOutEdges(evidenceNode.ID)); got != 0 {
+		t.Fatalf("len(outEdges) = %d, want 0", got)
+	}
+}
+
+func TestMaterializeFindingEvidenceIntoGraphDoesNotDuplicateBasedOnEdges(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "observation:runtime:process_exec:repeat",
+		Kind: graph.NodeKindObservation,
+		Name: "repeat observation",
+	})
+
+	finding := &runtime.RuntimeFinding{
+		ID:          "finding-repeat",
+		RuleID:      "container-drift-shell",
+		RuleName:    "Unexpected Shell",
+		Category:    runtime.CategoryContainerDrift,
+		Severity:    "medium",
+		Description: "Detected unexpected shell",
+		Timestamp:   time.Date(2026, 3, 16, 20, 12, 0, 0, time.UTC),
+		Observation: &runtime.RuntimeObservation{
+			ID: "runtime:process_exec:repeat",
+		},
+	}
+
+	first := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{finding}, time.Date(2026, 3, 16, 20, 13, 0, 0, time.UTC))
+	second := MaterializeFindingEvidenceIntoGraph(g, []*runtime.RuntimeFinding{finding}, time.Date(2026, 3, 16, 20, 14, 0, 0, time.UTC))
+
+	if first.BasedOnEdgesCreated != 1 {
+		t.Fatalf("first BasedOnEdgesCreated = %d, want 1", first.BasedOnEdgesCreated)
+	}
+	if second.BasedOnEdgesCreated != 0 {
+		t.Fatalf("second BasedOnEdgesCreated = %d, want 0", second.BasedOnEdgesCreated)
+	}
+	evidenceNode := g.GetNodesByKind(graph.NodeKindEvidence)[0]
+	if got := len(g.GetOutEdges(evidenceNode.ID)); got != 1 {
+		t.Fatalf("len(outEdges) = %d, want 1", got)
 	}
 }
 

--- a/internal/runtimegraph/materializer.go
+++ b/internal/runtimegraph/materializer.go
@@ -4,12 +4,37 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/runtime"
 )
 
 var ErrMissingObservationSubject = errors.New("runtime observation missing concrete graph subject")
+
+// FinalizeMaterializedGraph rebuilds graph indexes and refreshes metadata after
+// one or more runtimegraph materialization batches.
+func FinalizeMaterializedGraph(g *graph.Graph, now time.Time) {
+	if g == nil {
+		return
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	g.BuildIndex()
+	refreshMaterializedGraphMetadata(g, now)
+}
+
+func refreshMaterializedGraphMetadata(g *graph.Graph, now time.Time) {
+	if g == nil {
+		return
+	}
+	meta := g.Metadata()
+	meta.BuiltAt = now.UTC()
+	meta.NodeCount = g.NodeCount()
+	meta.EdgeCount = g.EdgeCount()
+	g.SetMetadata(meta)
+}
 
 // BuildObservationWriteRequest converts one normalized runtime observation into
 // a first-class graph observation write request.

--- a/internal/runtimegraph/project.go
+++ b/internal/runtimegraph/project.go
@@ -11,12 +11,13 @@ import (
 
 // MaterializationResult summarizes one batch of runtime observation graph writes.
 type MaterializationResult struct {
-	ObservationsConsidered   int   `json:"observations_considered"`
-	ObservationsMaterialized int   `json:"observations_materialized"`
-	ObservationsSkipped      int   `json:"observations_skipped"`
-	MissingSubjects          int   `json:"missing_subjects"`
-	InvalidObservations      int   `json:"invalid_observations"`
-	LastError                error `json:"-"`
+	ObservationsConsidered     int   `json:"observations_considered"`
+	ObservationsMaterialized   int   `json:"observations_materialized"`
+	ObservationsSkipped        int   `json:"observations_skipped"`
+	WorkloadTargetEdgesCreated int   `json:"workload_target_edges_created"`
+	MissingSubjects            int   `json:"missing_subjects"`
+	InvalidObservations        int   `json:"invalid_observations"`
+	LastError                  error `json:"-"`
 }
 
 // MaterializeObservationsIntoGraph projects runtime observations into graph observation nodes.
@@ -62,6 +63,24 @@ func MaterializeObservationsIntoGraph(g *graph.Graph, observations []*runtime.Ru
 			continue
 		}
 
+		if subjectNode, ok := g.GetNode(req.SubjectID); ok && isWorkloadSubjectNode(subjectNode) {
+			if graph.AddEdgeIfMissing(g, &graph.Edge{
+				ID:     req.SubjectID + "->" + req.ID + ":" + string(graph.EdgeKindTargets),
+				Source: req.SubjectID,
+				Target: req.ID,
+				Kind:   graph.EdgeKindTargets,
+				Effect: graph.EdgeEffectAllow,
+				Properties: map[string]any{
+					"source_system":   req.SourceSystem,
+					"source_event_id": req.SourceEventID,
+					"observed_at":     req.ObservedAt.UTC().Format(time.RFC3339),
+					"valid_from":      req.ValidFrom.UTC().Format(time.RFC3339),
+				},
+			}) {
+				result.WorkloadTargetEdgesCreated++
+			}
+		}
+
 		result.ObservationsMaterialized++
 	}
 
@@ -89,4 +108,18 @@ func classifyObservationMaterializationError(err error) observationMaterializati
 		return observationMaterializationErrorMissingSubject
 	}
 	return observationMaterializationErrorInvalid
+}
+
+func isWorkloadSubjectNode(node *graph.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case graph.NodeKindWorkload,
+		graph.NodeKindDeployment,
+		graph.NodeKindPod:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/runtimegraph/project.go
+++ b/internal/runtimegraph/project.go
@@ -84,12 +84,7 @@ func MaterializeObservationsIntoGraph(g *graph.Graph, observations []*runtime.Ru
 		result.ObservationsMaterialized++
 	}
 
-	g.BuildIndex()
-	meta := g.Metadata()
-	meta.BuiltAt = now.UTC()
-	meta.NodeCount = g.NodeCount()
-	meta.EdgeCount = g.EdgeCount()
-	g.SetMetadata(meta)
+	refreshMaterializedGraphMetadata(g, now)
 	return result
 }
 

--- a/internal/runtimegraph/project_test.go
+++ b/internal/runtimegraph/project_test.go
@@ -285,6 +285,55 @@ func TestMaterializeObservationsIntoGraphDoesNotDuplicateReverseTargetEdges(t *t
 	}
 }
 
+func TestMaterializeObservationsIntoGraphDefersIndexBuildToCaller(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "deployment:prod/api",
+		Kind: graph.NodeKindDeployment,
+		Name: "api",
+	})
+	g.BuildIndex()
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected initial graph index to be built")
+	}
+
+	now := time.Date(2026, 3, 16, 19, 40, 0, 0, time.UTC)
+	observation := &runtime.RuntimeObservation{
+		ID:          "runtime:process_exec:defer-index",
+		Source:      "tetragon",
+		Kind:        runtime.ObservationKindProcessExec,
+		ObservedAt:  now.Add(-10 * time.Second),
+		RecordedAt:  now.Add(-5 * time.Second),
+		WorkloadRef: "deployment:prod/api",
+		Process: &runtime.ProcessEvent{
+			Name: "sh",
+			Path: "/bin/sh",
+		},
+	}
+
+	result := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, now)
+	if result.ObservationsMaterialized != 1 {
+		t.Fatalf("ObservationsMaterialized = %d, want 1", result.ObservationsMaterialized)
+	}
+	if g.IsIndexBuilt() {
+		t.Fatal("expected index to remain stale until caller finalizes materialized graph")
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(now) {
+		t.Fatalf("metadata.BuiltAt = %s, want %s", got, now)
+	}
+
+	FinalizeMaterializedGraph(g, now.Add(time.Minute))
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected FinalizeMaterializedGraph to rebuild indexes")
+	}
+	if got := len(g.GetNodesByKindIndexed(graph.NodeKindObservation)); got != 1 {
+		t.Fatalf("len(GetNodesByKindIndexed(observation)) = %d, want 1", got)
+	}
+	if got := g.Metadata().BuiltAt; !got.Equal(now.Add(time.Minute)) {
+		t.Fatalf("metadata.BuiltAt after finalize = %s, want %s", got, now.Add(time.Minute))
+	}
+}
+
 func TestGraphAddEdgeIfMissingReturnsFalseWhenSchemaRejectsEdge(t *testing.T) {
 	g := graph.New()
 	g.SetSchemaValidationMode(graph.SchemaValidationEnforce)

--- a/internal/runtimegraph/project_test.go
+++ b/internal/runtimegraph/project_test.go
@@ -49,6 +49,9 @@ func TestMaterializeObservationsIntoGraphAddsObservationNode(t *testing.T) {
 	if result.MissingSubjects != 0 {
 		t.Fatalf("MissingSubjects = %d, want 0", result.MissingSubjects)
 	}
+	if result.WorkloadTargetEdgesCreated != 1 {
+		t.Fatalf("WorkloadTargetEdgesCreated = %d, want 1", result.WorkloadTargetEdgesCreated)
+	}
 
 	node, ok := g.GetNode(req.ID)
 	if !ok {
@@ -82,6 +85,17 @@ func TestMaterializeObservationsIntoGraphAddsObservationNode(t *testing.T) {
 	}
 	if issues := graph.GlobalSchemaRegistry().ValidateEdge(outEdges[0], node, mustNode(t, g, "deployment:prod/api")); len(issues) != 0 {
 		t.Fatalf("ValidateEdge returned issues: %+v", issues)
+	}
+
+	workloadEdges := g.GetOutEdges("deployment:prod/api")
+	if len(workloadEdges) != 1 {
+		t.Fatalf("len(workloadEdges) = %d, want 1", len(workloadEdges))
+	}
+	if workloadEdges[0].Kind != graph.EdgeKindTargets || workloadEdges[0].Target != req.ID {
+		t.Fatalf("workload edge = %+v, want targets edge to %s", workloadEdges[0], req.ID)
+	}
+	if issues := graph.GlobalSchemaRegistry().ValidateEdge(workloadEdges[0], mustNode(t, g, "deployment:prod/api"), node); len(issues) != 0 {
+		t.Fatalf("ValidateEdge(workload edge) returned issues: %+v", issues)
 	}
 
 	meta := g.Metadata()
@@ -157,7 +171,6 @@ func TestMaterializeObservationsIntoGraphSkipsObservationsWithoutConcreteSubject
 		t.Fatalf("LastError = %v, want ErrMissingObservationSubject", result.LastError)
 	}
 }
-
 func TestMaterializeObservationsIntoGraphRefreshesBuiltAtOnSubsequentWrites(t *testing.T) {
 	g := graph.New()
 	g.AddNode(&graph.Node{
@@ -206,6 +219,96 @@ func TestMaterializeObservationsIntoGraphRefreshesBuiltAtOnSubsequentWrites(t *t
 		t.Fatalf("after second materialization BuiltAt = %s, want %s", got, secondNow)
 	}
 }
+
+func TestMaterializeObservationsIntoGraphDoesNotAddReverseTargetEdgeForServiceSubjects(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "service:storefront/checkout",
+		Kind: graph.NodeKindService,
+		Name: "checkout",
+	})
+
+	observation := &runtime.RuntimeObservation{
+		Source:     "otel",
+		Kind:       runtime.ObservationKindTraceLink,
+		ObservedAt: time.Date(2026, 3, 16, 19, 20, 0, 0, time.UTC),
+		Trace: &runtime.TraceContext{
+			TraceID:     "abc123",
+			ServiceName: "checkout",
+		},
+		Metadata: map[string]any{
+			"service_namespace": "storefront",
+		},
+	}
+
+	result := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, time.Date(2026, 3, 16, 19, 21, 0, 0, time.UTC))
+	if result.WorkloadTargetEdgesCreated != 0 {
+		t.Fatalf("WorkloadTargetEdgesCreated = %d, want 0", result.WorkloadTargetEdgesCreated)
+	}
+	if len(g.GetOutEdges("service:storefront/checkout")) != 0 {
+		t.Fatalf("service out edge count = %d, want 0", len(g.GetOutEdges("service:storefront/checkout")))
+	}
+}
+
+func TestMaterializeObservationsIntoGraphDoesNotDuplicateReverseTargetEdges(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID:   "deployment:prod/api",
+		Kind: graph.NodeKindDeployment,
+		Name: "api",
+	})
+
+	observation := &runtime.RuntimeObservation{
+		ID:          "runtime:process_exec:abc",
+		Source:      "tetragon",
+		Kind:        runtime.ObservationKindProcessExec,
+		ObservedAt:  time.Date(2026, 3, 16, 19, 0, 0, 0, time.UTC),
+		RecordedAt:  time.Date(2026, 3, 16, 19, 0, 1, 0, time.UTC),
+		WorkloadRef: "deployment:prod/api",
+		Process: &runtime.ProcessEvent{
+			Name: "sh",
+			Path: "/bin/sh",
+		},
+	}
+
+	first := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, time.Date(2026, 3, 16, 19, 1, 0, 0, time.UTC))
+	second := MaterializeObservationsIntoGraph(g, []*runtime.RuntimeObservation{observation}, time.Date(2026, 3, 16, 19, 2, 0, 0, time.UTC))
+
+	if first.WorkloadTargetEdgesCreated != 1 {
+		t.Fatalf("first WorkloadTargetEdgesCreated = %d, want 1", first.WorkloadTargetEdgesCreated)
+	}
+	if second.WorkloadTargetEdgesCreated != 0 {
+		t.Fatalf("second WorkloadTargetEdgesCreated = %d, want 0", second.WorkloadTargetEdgesCreated)
+	}
+	if got := len(g.GetOutEdges("deployment:prod/api")); got != 1 {
+		t.Fatalf("len(workload out edges) = %d, want 1", got)
+	}
+}
+
+func TestGraphAddEdgeIfMissingReturnsFalseWhenSchemaRejectsEdge(t *testing.T) {
+	g := graph.New()
+	g.SetSchemaValidationMode(graph.SchemaValidationEnforce)
+	g.AddNode(&graph.Node{
+		ID:   "deployment:prod/api",
+		Kind: graph.NodeKindDeployment,
+		Name: "api",
+	})
+
+	added := graph.AddEdgeIfMissing(g, &graph.Edge{
+		ID:     "deployment:prod/api->observation:missing:targets",
+		Source: "deployment:prod/api",
+		Target: "observation:missing",
+		Kind:   graph.EdgeKindTargets,
+		Effect: graph.EdgeEffectAllow,
+	})
+	if added {
+		t.Fatal("expected addRuntimeGraphEdgeIfMissing to report false when schema rejects edge")
+	}
+	if got := len(g.GetOutEdges("deployment:prod/api")); got != 0 {
+		t.Fatalf("len(workload out edges) = %d, want 0", got)
+	}
+}
+
 func TestClassifyObservationMaterializationErrorTreatsSubjectNotFoundAsMissingSubject(t *testing.T) {
 	if got := classifyObservationMaterializationError(fmt.Errorf("subject not found: service:storefront/checkout")); got != observationMaterializationErrorMissingSubject {
 		t.Fatalf("classifyObservationMaterializationError(subject not found) = %v, want %v", got, observationMaterializationErrorMissingSubject)

--- a/internal/workloadscan/credential_pivots.go
+++ b/internal/workloadscan/credential_pivots.go
@@ -39,7 +39,7 @@ func materializeSecretPivots(g *graph.Graph, workloadNode, scanNode *graph.Node,
 		g.AddNode(secretNode)
 		result.SecretNodesUpserted++
 
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(scanNode.ID, secretNode.ID, graph.EdgeKindTargets),
 			Source:     scanNode.ID,
 			Target:     secretNode.ID,
@@ -60,7 +60,7 @@ func materializeSecretPivots(g *graph.Graph, workloadNode, scanNode *graph.Node,
 			props["credential_type"] = secret.Type
 			props["credential_finding_id"] = secret.ID
 			props["match_fingerprint"] = matchFingerprint
-			if addEdgeIfMissing(g, &graph.Edge{
+			if graph.AddEdgeIfMissing(g, &graph.Edge{
 				ID:         edgeID(secretNode.ID, target.ID, graph.EdgeKindTargets),
 				Source:     secretNode.ID,
 				Target:     target.ID,
@@ -88,7 +88,7 @@ func materializeSecretPivots(g *graph.Graph, workloadNode, scanNode *graph.Node,
 			if strings.TrimSpace(target.reason) != "" {
 				props["resolution_reason"] = target.reason
 			}
-			if addEdgeIfMissing(g, &graph.Edge{
+			if graph.AddEdgeIfMissing(g, &graph.Edge{
 				ID:         credentialPivotEdgeID(workloadNode.ID, target.node.ID, secret.ID, target.viaPrincipalID),
 				Source:     workloadNode.ID,
 				Target:     target.node.ID,

--- a/internal/workloadscan/graph_materialization.go
+++ b/internal/workloadscan/graph_materialization.go
@@ -282,7 +282,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 	g.AddNode(scanNode)
 	result.ScanNodesUpserted++
 
-	if addEdgeIfMissing(g, &graph.Edge{
+	if graph.AddEdgeIfMissing(g, &graph.Edge{
 		ID:         edgeID(target.ID, scanNode.ID, graph.EdgeKindHasScan),
 		Source:     target.ID,
 		Target:     scanNode.ID,
@@ -317,7 +317,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		edgeProps["reachable"] = pkgAgg.record.Reachable
 		edgeProps["dependency_depth"] = pkgAgg.record.DependencyDepth
 		edgeProps["import_file_count"] = pkgAgg.record.ImportFileCount
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(scanNode.ID, pkgNode.ID, graph.EdgeKindContainsPkg),
 			Source:     scanNode.ID,
 			Target:     pkgNode.ID,
@@ -336,7 +336,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		if parentID == "" || childID == "" {
 			continue
 		}
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:     edgeID(parentID, childID, graph.EdgeKindDependsOn),
 			Source: parentID,
 			Target: childID,
@@ -381,7 +381,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		techEdgeProperties["category"] = techAgg.record.Category
 		techEdgeProperties["version"] = strings.TrimSpace(techAgg.record.Version)
 		techEdgeProperties["file_path"] = strings.TrimSpace(techAgg.record.Path)
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(target.ID, techNode.ID, graph.EdgeKindRuns),
 			Source:     target.ID,
 			Target:     techNode.ID,
@@ -413,7 +413,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		g.AddNode(vulnNode)
 		result.VulnNodesUpserted++
 		usage := vulnUsage[vulnKey]
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(scanNode.ID, vulnNode.ID, graph.EdgeKindFoundVuln),
 			Source:     scanNode.ID,
 			Target:     vulnNode.ID,
@@ -434,7 +434,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		vuln := vulnAgg.record
 		pkgID := packageNodeID(relation.pkg)
 		vulnID := vulnerabilityNodeID(vuln)
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:     packageVulnerabilityEdgeID(pkgID, vulnID),
 			Source: pkgID,
 			Target: vulnID,
@@ -477,7 +477,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		observationNode := buildIaCFindingObservationNode(scanNode, target, findingAgg.record, observationMeta)
 		g.AddNode(observationNode)
 		result.ObservationNodesUpserted++
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(observationNode.ID, scanNode.ID, graph.EdgeKindTargets),
 			Source:     observationNode.ID,
 			Target:     scanNode.ID,
@@ -508,7 +508,7 @@ func materializeOneRun(g *graph.Graph, target *graph.Node, run RunRecord, validT
 		observationNode := buildMalwareObservationNode(scanNode, target, malwareAgg.record, observationMeta)
 		g.AddNode(observationNode)
 		result.ObservationNodesUpserted++
-		if addEdgeIfMissing(g, &graph.Edge{
+		if graph.AddEdgeIfMissing(g, &graph.Edge{
 			ID:         edgeID(observationNode.ID, scanNode.ID, graph.EdgeKindTargets),
 			Source:     observationNode.ID,
 			Target:     scanNode.ID,
@@ -1425,22 +1425,6 @@ func applyVulnerabilityUsageSummaryProperties(properties map[string]any, ctx vul
 	properties["reachable_package_count"] = len(ctx.reachablePackageKeys)
 	properties["direct_reachable_package_count"] = len(ctx.directReachablePackageKeys)
 	return properties
-}
-
-func addEdgeIfMissing(g *graph.Graph, edge *graph.Edge) bool {
-	if g == nil || edge == nil {
-		return false
-	}
-	for _, existing := range g.GetOutEdges(edge.Source) {
-		if existing == nil {
-			continue
-		}
-		if existing.ID == edge.ID || (existing.Target == edge.Target && existing.Kind == edge.Kind) {
-			return false
-		}
-	}
-	g.AddEdge(edge)
-	return true
 }
 
 func cloneWorkloadAnyMap(values map[string]any) map[string]any {


### PR DESCRIPTION
* Add workload observation target edges

* Deduplicate runtime workload target edges

* Share graph edge dedupe helper

* Link runtime evidence to observations
