### PR TITLE
Cap graph property history with TTL and depth controls (#381)

### DIFF
--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -2,7 +2,7 @@
 
 Generated from `internal/app/app_config.go` (`LoadConfig`) via `go run ./scripts/generate_config_docs/main.go`.
 
-Total variables: **316**
+Total variables: **318**
 
 | Variable | Reader(s) | Default(s) | Config Field(s) | Validation rule(s) |
 |---|---|---|---|---|
@@ -119,6 +119,8 @@ Total variables: **316**
 | `GRAPH_EVENT_MAPPER_DEAD_LETTER_PATH` | `getEnv` | `filepath.Join(findings.DefaultFilePath(), "graph-event-mapper.dlq.jsonl")` | `GraphEventMapperDeadLetterPath` | `-` |
 | `GRAPH_EVENT_MAPPER_VALIDATION_MODE` | `getEnv` | `"enforce"` | `GraphEventMapperValidationMode` | `must be one of warn, enforce` |
 | `GRAPH_MIGRATE_LEGACY_ACTIVITY_ON_START` | `getEnvBool` | `false` | `GraphMigrateLegacyActivityOnStart` | `-` |
+| `GRAPH_PROPERTY_HISTORY_MAX_ENTRIES` | `getEnvInt` | `graph.DefaultTemporalHistoryMaxEntries` | `GraphPropertyHistoryMaxEntries` | `non-positive values fall back to the default max property-history depth` |
+| `GRAPH_PROPERTY_HISTORY_TTL` | `getEnvDuration` | `graph.DefaultTemporalHistoryTTL` | `GraphPropertyHistoryTTL` | `non-positive values fall back to the default property-history TTL` |
 | `GRAPH_SCHEMA_VALIDATION_MODE` | `getEnv` | `"warn"` | `GraphSchemaValidationMode` | `must be one of off, warn, enforce` |
 | `IMAGE_SCAN_CLAMAV_BINARY` | `getEnv` | `""` | `ImageScanClamAVBinary` | `-` |
 | `IMAGE_SCAN_CLEANUP_TIMEOUT` | `getEnvDuration` | `2 * time.Minute` | `ImageScanCleanupTimeout` | `-` |

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/writer/cerebro/internal/apiauth"
 	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/providers"
 	"github.com/writer/cerebro/internal/snowflake"
 )
@@ -449,6 +450,8 @@ type Config struct {
 	GraphCrossTenantReplayTTL           time.Duration
 	GraphCrossTenantMinTenants          int
 	GraphCrossTenantMinSupport          int
+	GraphPropertyHistoryMaxEntries      int
+	GraphPropertyHistoryTTL             time.Duration
 	GraphSchemaValidationMode           string
 	GraphEventMapperValidationMode      string
 	GraphEventMapperDeadLetterPath      string
@@ -787,6 +790,8 @@ func LoadConfig() *Config {
 			GraphCrossTenantReplayTTL:           getEnvDuration("GRAPH_CROSS_TENANT_REPLAY_TTL", 24*time.Hour),
 			GraphCrossTenantMinTenants:          getEnvInt("GRAPH_CROSS_TENANT_MIN_TENANTS", 2),
 			GraphCrossTenantMinSupport:          getEnvInt("GRAPH_CROSS_TENANT_MIN_SUPPORT", 2),
+			GraphPropertyHistoryMaxEntries:      getEnvInt("GRAPH_PROPERTY_HISTORY_MAX_ENTRIES", graph.DefaultTemporalHistoryMaxEntries),
+			GraphPropertyHistoryTTL:             getEnvDuration("GRAPH_PROPERTY_HISTORY_TTL", graph.DefaultTemporalHistoryTTL),
 			GraphSchemaValidationMode:           getEnv("GRAPH_SCHEMA_VALIDATION_MODE", "warn"),
 			GraphEventMapperValidationMode:      getEnv("GRAPH_EVENT_MAPPER_VALIDATION_MODE", "enforce"),
 			GraphEventMapperDeadLetterPath:      getEnv("GRAPH_EVENT_MAPPER_DEAD_LETTER_PATH", filepath.Join(findings.DefaultFilePath(), "graph-event-mapper.dlq.jsonl")),

--- a/internal/app/app_config_validation.go
+++ b/internal/app/app_config_validation.go
@@ -125,6 +125,8 @@ func ConfigValidationRules() []ConfigValidationRule {
 			Summary:  "when GRAPH_CROSS_TENANT_REQUIRE_SIGNED_INGEST=true, signing key is required and skew/TTL/support thresholds must be positive",
 			Category: "dependency",
 		},
+		{EnvVars: []string{"GRAPH_PROPERTY_HISTORY_MAX_ENTRIES"}, Summary: "non-positive values fall back to the default max property-history depth", Category: "behavior"},
+		{EnvVars: []string{"GRAPH_PROPERTY_HISTORY_TTL"}, Summary: "non-positive values fall back to the default property-history TTL", Category: "behavior"},
 		{EnvVars: []string{"GRAPH_SCHEMA_VALIDATION_MODE"}, Summary: "must be one of off, warn, enforce", Category: "enum"},
 		{EnvVars: []string{"GRAPH_EVENT_MAPPER_VALIDATION_MODE"}, Summary: "must be one of warn, enforce", Category: "enum"},
 	}
@@ -161,6 +163,12 @@ func (c *Config) Validate() error {
 	}
 	if c.FindingsResolvedRetention < 0 {
 		problems = addConfigProblem(problems, "FINDINGS_RESOLVED_RETENTION must be >= 0")
+	}
+	if c.GraphPropertyHistoryMaxEntries < 0 {
+		problems = addConfigProblem(problems, "GRAPH_PROPERTY_HISTORY_MAX_ENTRIES must be >= 0")
+	}
+	if c.GraphPropertyHistoryTTL < 0 {
+		problems = addConfigProblem(problems, "GRAPH_PROPERTY_HISTORY_TTL must be >= 0")
 	}
 
 	hasSnowflakeAuth := strings.TrimSpace(c.SnowflakeAccount) != "" ||

--- a/internal/app/app_graph_mutation.go
+++ b/internal/app/app_graph_mutation.go
@@ -36,11 +36,11 @@ func (a *App) MutateSecurityGraphMaybe(ctx context.Context, mutate func(*graph.G
 	current := a.CurrentSecurityGraph()
 	if current == nil {
 		current = graph.New()
-		a.configureGraphSchemaValidation(current)
+		a.configureGraphRuntimeBehavior(current)
 	}
 
 	candidate := current.Clone()
-	a.configureGraphSchemaValidation(candidate)
+	a.configureGraphRuntimeBehavior(candidate)
 
 	changed, err := mutate(candidate)
 	if err != nil {

--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -15,6 +15,7 @@ import (
 	reports "github.com/writer/cerebro/internal/graph/reports"
 	"github.com/writer/cerebro/internal/health"
 	"github.com/writer/cerebro/internal/lineage"
+	"github.com/writer/cerebro/internal/metrics"
 	"github.com/writer/cerebro/internal/remediation"
 	"github.com/writer/cerebro/internal/runtime"
 	"github.com/writer/cerebro/internal/threatintel"
@@ -483,7 +484,7 @@ func (a *App) initSecurityGraph(ctx context.Context) {
 	source := builders.NewSnowflakeSource(a.Warehouse)
 	a.SecurityGraphBuilder = builders.NewBuilder(source, a.Logger)
 	securityGraph := a.SecurityGraphBuilder.Graph()
-	a.configureGraphSchemaValidation(securityGraph)
+	a.configureGraphRuntimeBehavior(securityGraph)
 	a.setSecurityGraph(securityGraph)
 
 	graphCtx, cancel := context.WithCancel(backgroundWorkContext(ctx))
@@ -539,16 +540,26 @@ func backgroundWorkContext(ctx context.Context) context.Context {
 	return context.WithoutCancel(ctx)
 }
 
-func (a *App) configureGraphSchemaValidation(g *graph.Graph) {
+func (a *App) configureGraphRuntimeBehavior(g *graph.Graph) {
 	if g == nil {
 		return
 	}
 
 	mode := graph.SchemaValidationWarn
+	maxEntries := graph.DefaultTemporalHistoryMaxEntries
+	ttl := graph.DefaultTemporalHistoryTTL
 	if a != nil && a.Config != nil {
 		mode = graph.ParseSchemaValidationMode(a.Config.GraphSchemaValidationMode)
+		if a.Config.GraphPropertyHistoryMaxEntries > 0 {
+			maxEntries = a.Config.GraphPropertyHistoryMaxEntries
+		}
+		if a.Config.GraphPropertyHistoryTTL > 0 {
+			ttl = a.Config.GraphPropertyHistoryTTL
+		}
 	}
 	g.SetSchemaValidationMode(mode)
+	g.SetTemporalHistoryConfig(maxEntries, ttl)
+	metrics.SetGraphPropertyHistoryDepth(maxEntries)
 }
 
 // WaitForGraph blocks until the initial graph build completes (or ctx is cancelled).
@@ -622,7 +633,7 @@ func (a *App) activateBuiltSecurityGraph(ctx context.Context, securityGraph *gra
 		)
 	}
 	a.rematerializeEventCorrelations(securityGraph, "graph_activation")
-	a.configureGraphSchemaValidation(securityGraph)
+	a.configureGraphRuntimeBehavior(securityGraph)
 	a.setSecurityGraph(securityGraph)
 	meta := securityGraph.Metadata()
 	a.setGraphBuildState(GraphBuildSuccess, meta.BuiltAt, nil)

--- a/internal/app/app_stream_consumer.go
+++ b/internal/app/app_stream_consumer.go
@@ -129,7 +129,7 @@ func (a *App) ensureSecurityGraph() *graph.Graph {
 
 	if a.SecurityGraph == nil {
 		a.SecurityGraph = graph.New()
-		a.configureGraphSchemaValidation(a.SecurityGraph)
+		a.configureGraphRuntimeBehavior(a.SecurityGraph)
 	}
 	return a.SecurityGraph
 }

--- a/internal/app/app_stream_replay.go
+++ b/internal/app/app_stream_replay.go
@@ -23,7 +23,7 @@ func NewTapReplayApp(cfg *Config, logger *slog.Logger) *App {
 		Logger:        logger,
 		SecurityGraph: securityGraph,
 	}
-	app.configureGraphSchemaValidation(securityGraph)
+	app.configureGraphRuntimeBehavior(securityGraph)
 	return app
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -12,8 +12,11 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/writer/cerebro/internal/apiauth"
 	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/metrics"
 	"github.com/writer/cerebro/internal/policy"
 	"github.com/writer/cerebro/internal/snowflake"
 	"github.com/writer/cerebro/internal/warehouse"
@@ -208,6 +211,19 @@ func TestLoadConfigGraphSchemaValidationMode(t *testing.T) {
 	cfg := LoadConfig()
 	if cfg.GraphSchemaValidationMode != "enforce" {
 		t.Fatalf("expected graph schema validation mode enforce, got %q", cfg.GraphSchemaValidationMode)
+	}
+}
+
+func TestLoadConfigGraphPropertyHistoryControls(t *testing.T) {
+	t.Setenv("GRAPH_PROPERTY_HISTORY_MAX_ENTRIES", "17")
+	t.Setenv("GRAPH_PROPERTY_HISTORY_TTL", "36h")
+
+	cfg := LoadConfig()
+	if cfg.GraphPropertyHistoryMaxEntries != 17 {
+		t.Fatalf("expected graph property history max entries 17, got %d", cfg.GraphPropertyHistoryMaxEntries)
+	}
+	if cfg.GraphPropertyHistoryTTL != 36*time.Hour {
+		t.Fatalf("expected graph property history ttl 36h, got %s", cfg.GraphPropertyHistoryTTL)
 	}
 }
 
@@ -530,6 +546,8 @@ func TestLoadConfigValidateAggregatesProblems(t *testing.T) {
 	t.Setenv("NATS_CONSUMER_ENABLED", "true")
 	t.Setenv("NATS_JETSTREAM_ENABLED", "false")
 	t.Setenv("GRAPH_CROSS_TENANT_REQUIRE_SIGNED_INGEST", "true")
+	t.Setenv("GRAPH_PROPERTY_HISTORY_MAX_ENTRIES", "-1")
+	t.Setenv("GRAPH_PROPERTY_HISTORY_TTL", "-1s")
 
 	cfg := LoadConfig()
 	err := cfg.Validate()
@@ -548,6 +566,8 @@ func TestLoadConfigValidateAggregatesProblems(t *testing.T) {
 		"QUERY_POLICY_ROW_LIMIT must be greater than 0",
 		"NATS_JETSTREAM_ENABLED must be true when NATS_CONSUMER_ENABLED=true",
 		"GRAPH_CROSS_TENANT_SIGNING_KEY is required when GRAPH_CROSS_TENANT_REQUIRE_SIGNED_INGEST=true",
+		"GRAPH_PROPERTY_HISTORY_MAX_ENTRIES must be >= 0",
+		"GRAPH_PROPERTY_HISTORY_TTL must be >= 0",
 	}
 	for _, want := range wantProblems {
 		found := false
@@ -561,6 +581,44 @@ func TestLoadConfigValidateAggregatesProblems(t *testing.T) {
 			t.Fatalf("expected validation problem containing %q, got %#v", want, validationErr.Problems)
 		}
 	}
+}
+
+func TestConfigureGraphRuntimeBehaviorAppliesPropertyHistoryConfig(t *testing.T) {
+	metrics.Register()
+
+	application := &App{
+		Config: &Config{
+			GraphSchemaValidationMode:      "enforce",
+			GraphPropertyHistoryMaxEntries: 17,
+			GraphPropertyHistoryTTL:        3 * time.Hour,
+		},
+	}
+	g := graph.New()
+
+	application.configureGraphRuntimeBehavior(g)
+
+	if g.SchemaValidationMode() != graph.SchemaValidationEnforce {
+		t.Fatalf("expected graph schema validation enforce, got %q", g.SchemaValidationMode())
+	}
+	maxEntries, ttl := g.TemporalHistoryConfig()
+	if maxEntries != 17 {
+		t.Fatalf("expected graph property history max entries 17, got %d", maxEntries)
+	}
+	if ttl != 3*time.Hour {
+		t.Fatalf("expected graph property history ttl 3h, got %s", ttl)
+	}
+	if got := gaugeValue(t, metrics.GraphPropertyHistoryDepth); got != 17 {
+		t.Fatalf("expected graph property history depth gauge 17, got %v", got)
+	}
+}
+
+func gaugeValue(t *testing.T, gauge interface{ Write(*dto.Metric) error }) float64 {
+	t.Helper()
+	var metric dto.Metric
+	if err := gauge.Write(&metric); err != nil {
+		t.Fatalf("write gauge metric: %v", err)
+	}
+	return metric.GetGauge().GetValue()
 }
 
 func TestNewWithConfigFailsFastOnInvalidConfig(t *testing.T) {

--- a/internal/graph/entities/temporal_test.go
+++ b/internal/graph/entities/temporal_test.go
@@ -113,7 +113,7 @@ func TestGetEntityRecordAtTimeHonorsTransactionTo(t *testing.T) {
 }
 
 func TestGetEntityRecordAtTimeUsesRecordedAtHistoryAndTombstones(t *testing.T) {
-	base := time.Date(2026, 3, 10, 9, 0, 0, 0, time.UTC)
+	base := time.Now().UTC().Add(-6 * 24 * time.Hour).Truncate(time.Second)
 	correctionAt := base.Add(2 * time.Hour)
 	g := graph.New()
 	g.AddNode(&graph.Node{

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -206,6 +206,16 @@ func (g *Graph) CompactDeletedEdges() {
 	g.compactDeletedEdgesLocked()
 }
 
+// CompactDeletedNodes removes soft-deleted node tombstones from the backing
+// node map to keep long-lived graphs from accumulating dead entries.
+func (g *Graph) CompactDeletedNodes() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.compactDeletedNodesLocked() {
+		g.markGraphChangedLocked()
+	}
+}
+
 // SetNodeProperty sets or updates a single property on a node.
 func (g *Graph) SetNodeProperty(id string, key string, value any) bool {
 	g.mu.Lock()
@@ -1005,6 +1015,26 @@ func edgePointerPresentLocked(edges []*Edge, target *Edge) bool {
 		}
 	}
 	return false
+}
+
+func (g *Graph) compactDeletedNodesLocked() bool {
+	removed := false
+	for id, node := range g.nodes {
+		if node != nil && node.DeletedAt == nil {
+			continue
+		}
+		for _, edge := range g.outEdges[id] {
+			g.evictEdgeIDLocked(edge)
+		}
+		for _, edge := range g.inEdges[id] {
+			g.evictEdgeIDLocked(edge)
+		}
+		delete(g.nodes, id)
+		delete(g.outEdges, id)
+		delete(g.inEdges, id)
+		removed = true
+	}
+	return removed
 }
 
 func (g *Graph) removeEdgesByNodeLocked(nodeID string) bool {

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -44,6 +44,10 @@ type Graph struct {
 	// Runtime ontology validation behavior and counters.
 	schemaValidationMode  SchemaValidationMode
 	schemaValidationStats SchemaValidationStats
+
+	// Property history retention controls.
+	temporalHistoryMaxEntries int
+	temporalHistoryTTL        time.Duration
 }
 
 // Metadata contains information about the graph
@@ -60,12 +64,14 @@ type Metadata struct {
 func New() *Graph {
 	mode := SchemaValidationWarn
 	return &Graph{
-		nodes:                 make(map[string]*Node),
-		outEdges:              make(map[string][]*Edge),
-		inEdges:               make(map[string][]*Edge),
-		blastRadiusVersion:    1,
-		schemaValidationMode:  mode,
-		schemaValidationStats: newSchemaValidationStats(mode),
+		nodes:                     make(map[string]*Node),
+		outEdges:                  make(map[string][]*Edge),
+		inEdges:                   make(map[string][]*Edge),
+		blastRadiusVersion:        1,
+		schemaValidationMode:      mode,
+		schemaValidationStats:     newSchemaValidationStats(mode),
+		temporalHistoryMaxEntries: DefaultTemporalHistoryMaxEntries,
+		temporalHistoryTTL:        DefaultTemporalHistoryTTL,
 	}
 }
 

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -16,6 +16,7 @@ type Graph struct {
 	nodes    map[string]*Node
 	outEdges map[string][]*Edge // source -> edges
 	inEdges  map[string][]*Edge // target -> edges
+	edgeByID map[string]*Edge
 	mu       sync.RWMutex
 	metadata Metadata
 
@@ -67,6 +68,7 @@ func New() *Graph {
 		nodes:                     make(map[string]*Node),
 		outEdges:                  make(map[string][]*Edge),
 		inEdges:                   make(map[string][]*Edge),
+		edgeByID:                  make(map[string]*Edge),
 		blastRadiusVersion:        1,
 		schemaValidationMode:      mode,
 		schemaValidationStats:     newSchemaValidationStats(mode),
@@ -397,6 +399,7 @@ func (g *Graph) Clear() {
 	g.inEdges = make(map[string][]*Edge)
 	g.activeNodeCount.Store(0)
 	g.activeEdgeCount.Store(0)
+	g.edgeByID = make(map[string]*Edge)
 	g.markGraphChangedLocked()
 }
 
@@ -407,6 +410,7 @@ func (g *Graph) ClearEdges() {
 	g.outEdges = make(map[string][]*Edge)
 	g.inEdges = make(map[string][]*Edge)
 	g.activeEdgeCount.Store(0)
+	g.edgeByID = make(map[string]*Edge)
 	g.markGraphChangedLocked()
 }
 
@@ -834,6 +838,11 @@ func (g *Graph) addEdgeLocked(edge *Edge) bool {
 	}
 
 	now := temporalNowUTC()
+	if edge.ID != "" {
+		if existing := g.edgeByID[edge.ID]; existing != nil {
+			return g.replaceEdgeLocked(existing, edge, now)
+		}
+	}
 	if edge.CreatedAt.IsZero() {
 		edge.CreatedAt = now
 	}
@@ -844,6 +853,60 @@ func (g *Graph) addEdgeLocked(edge *Edge) bool {
 	g.outEdges[edge.Source] = append(g.outEdges[edge.Source], edge)
 	g.inEdges[edge.Target] = append(g.inEdges[edge.Target], edge)
 	g.activeEdgeCount.Add(1)
+	if edge.ID != "" {
+		g.edgeByID[edge.ID] = edge
+	}
+	return true
+}
+
+func (g *Graph) replaceEdgeLocked(existing *Edge, next *Edge, now time.Time) bool {
+	if existing == nil || next == nil {
+		return false
+	}
+
+	oldSource := existing.Source
+	oldTarget := existing.Target
+
+	if next.CreatedAt.IsZero() {
+		if existing.CreatedAt.IsZero() {
+			next.CreatedAt = now
+		} else {
+			next.CreatedAt = existing.CreatedAt
+		}
+	}
+	if next.Version <= 0 {
+		if existing.Version > 0 {
+			next.Version = existing.Version + 1
+		} else {
+			next.Version = 1
+		}
+	}
+	next.DeletedAt = nil
+	if existing.DeletedAt != nil {
+		g.activeEdgeCount.Add(1)
+	}
+
+	if oldSource != next.Source {
+		g.outEdges[oldSource] = removeEdgePointerLocked(g.outEdges[oldSource], existing)
+		if len(g.outEdges[oldSource]) == 0 {
+			delete(g.outEdges, oldSource)
+		}
+	}
+	if oldTarget != next.Target {
+		g.inEdges[oldTarget] = removeEdgePointerLocked(g.inEdges[oldTarget], existing)
+		if len(g.inEdges[oldTarget]) == 0 {
+			delete(g.inEdges, oldTarget)
+		}
+	}
+
+	*existing = *next
+	if !edgePointerPresentLocked(g.outEdges[next.Source], existing) {
+		g.outEdges[next.Source] = append(g.outEdges[next.Source], existing)
+	}
+	if !edgePointerPresentLocked(g.inEdges[next.Target], existing) {
+		g.inEdges[next.Target] = append(g.inEdges[next.Target], existing)
+	}
+	g.edgeByID[next.ID] = existing
 	return true
 }
 
@@ -877,7 +940,11 @@ func (g *Graph) compactDeletedEdgesLocked() {
 	for source, edges := range g.outEdges {
 		compacted := edges[:0]
 		for _, edge := range edges {
-			if edge == nil || edge.DeletedAt != nil {
+			if edge == nil {
+				continue
+			}
+			if edge.DeletedAt != nil {
+				g.evictEdgeIDLocked(edge)
 				continue
 			}
 			compacted = append(compacted, edge)
@@ -891,7 +958,11 @@ func (g *Graph) compactDeletedEdgesLocked() {
 	for target, edges := range g.inEdges {
 		compacted := edges[:0]
 		for _, edge := range edges {
-			if edge == nil || edge.DeletedAt != nil {
+			if edge == nil {
+				continue
+			}
+			if edge.DeletedAt != nil {
+				g.evictEdgeIDLocked(edge)
 				continue
 			}
 			compacted = append(compacted, edge)
@@ -902,6 +973,38 @@ func (g *Graph) compactDeletedEdgesLocked() {
 		}
 		g.inEdges[target] = compacted
 	}
+}
+
+func (g *Graph) evictEdgeIDLocked(edge *Edge) {
+	if edge == nil || edge.ID == "" {
+		return
+	}
+	if g.edgeByID[edge.ID] == edge {
+		delete(g.edgeByID, edge.ID)
+	}
+}
+
+func removeEdgePointerLocked(edges []*Edge, target *Edge) []*Edge {
+	if len(edges) == 0 || target == nil {
+		return edges
+	}
+	compacted := edges[:0]
+	for _, edge := range edges {
+		if edge == target {
+			continue
+		}
+		compacted = append(compacted, edge)
+	}
+	return compacted
+}
+
+func edgePointerPresentLocked(edges []*Edge, target *Edge) bool {
+	for _, edge := range edges {
+		if edge == target {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *Graph) removeEdgesByNodeLocked(nodeID string) bool {

--- a/internal/graph/graph_edge_dedup_bench_test.go
+++ b/internal/graph/graph_edge_dedup_bench_test.go
@@ -1,0 +1,43 @@
+package graph
+
+import (
+	"strconv"
+	"testing"
+)
+
+func BenchmarkGraphAddEdgeSameIDUpdate(b *testing.B) {
+	g := New()
+	g.AddEdge(&Edge{
+		ID:     "edge-1",
+		Source: "node:a",
+		Target: "node:b",
+		Kind:   EdgeKindTargets,
+		Effect: EdgeEffectAllow,
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g.AddEdge(&Edge{
+			ID:     "edge-1",
+			Source: "node:a",
+			Target: "node:b",
+			Kind:   EdgeKindTargets,
+			Effect: EdgeEffectAllow,
+		})
+	}
+}
+
+func BenchmarkGraphAddEdgeDistinctIDs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		g := New()
+		for j := 0; j < 1024; j++ {
+			g.AddEdge(&Edge{
+				ID:     "edge-" + strconv.Itoa(j),
+				Source: "node:a",
+				Target: "node:b",
+				Kind:   EdgeKindTargets,
+				Effect: EdgeEffectAllow,
+			})
+		}
+	}
+}

--- a/internal/graph/graph_edge_dedup_test.go
+++ b/internal/graph/graph_edge_dedup_test.go
@@ -1,0 +1,192 @@
+package graph
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestGraphAddEdgeReusesExistingID(t *testing.T) {
+	g := New()
+
+	g.AddEdge(&Edge{
+		ID:         "edge-1",
+		Source:     "node:a",
+		Target:     "node:b",
+		Kind:       EdgeKindTargets,
+		Effect:     EdgeEffectAllow,
+		Properties: map[string]any{"state": "first"},
+	})
+
+	first := g.GetOutEdges("node:a")[0]
+	if first.CreatedAt.IsZero() {
+		t.Fatal("expected first edge to receive created_at")
+	}
+
+	g.AddEdge(&Edge{
+		ID:         "edge-1",
+		Source:     "node:a",
+		Target:     "node:b",
+		Kind:       EdgeKindTargets,
+		Effect:     EdgeEffectDeny,
+		Priority:   100,
+		Properties: map[string]any{"state": "updated"},
+	})
+
+	out := g.GetOutEdges("node:a")
+	if len(out) != 1 {
+		t.Fatalf("expected one active edge after same-ID update, got %d", len(out))
+	}
+	if got := len(g.outEdges["node:a"]); got != 1 {
+		t.Fatalf("expected one stored out-edge after same-ID update, got %d", got)
+	}
+	if got := len(g.inEdges["node:b"]); got != 1 {
+		t.Fatalf("expected one stored in-edge after same-ID update, got %d", got)
+	}
+	if out[0].Effect != EdgeEffectDeny {
+		t.Fatalf("expected updated effect %q, got %q", EdgeEffectDeny, out[0].Effect)
+	}
+	if out[0].Priority != 100 {
+		t.Fatalf("expected updated priority 100, got %d", out[0].Priority)
+	}
+	if got := out[0].Properties["state"]; got != "updated" {
+		t.Fatalf("expected updated properties, got %#v", out[0].Properties)
+	}
+	if out[0].Version != 2 {
+		t.Fatalf("expected version 2 after same-ID update, got %d", out[0].Version)
+	}
+	if !out[0].CreatedAt.Equal(first.CreatedAt) {
+		t.Fatalf("expected created_at to be preserved, got %s want %s", out[0].CreatedAt, first.CreatedAt)
+	}
+}
+
+func TestGraphAddEdgeAllowsDistinctIDsForSameTuple(t *testing.T) {
+	g := New()
+
+	g.AddEdge(&Edge{
+		ID:     "allow-edge",
+		Source: "node:a",
+		Target: "node:b",
+		Kind:   EdgeKindCanRead,
+		Effect: EdgeEffectAllow,
+	})
+	g.AddEdge(&Edge{
+		ID:       "deny-edge",
+		Source:   "node:a",
+		Target:   "node:b",
+		Kind:     EdgeKindCanRead,
+		Effect:   EdgeEffectDeny,
+		Priority: 100,
+	})
+
+	out := g.GetOutEdges("node:a")
+	if len(out) != 2 {
+		t.Fatalf("expected distinct IDs on same tuple to coexist, got %d edges", len(out))
+	}
+}
+
+func TestGraphAddEdgeRevivesDeletedEdgeWithoutAppendingDuplicate(t *testing.T) {
+	g := New()
+
+	g.AddEdge(&Edge{
+		ID:     "edge-1",
+		Source: "node:a",
+		Target: "node:b",
+		Kind:   EdgeKindTargets,
+		Effect: EdgeEffectAllow,
+	})
+	if !g.RemoveEdge("node:a", "node:b", EdgeKindTargets) {
+		t.Fatal("expected initial edge removal to succeed")
+	}
+
+	g.AddEdge(&Edge{
+		ID:     "edge-1",
+		Source: "node:a",
+		Target: "node:b",
+		Kind:   EdgeKindTargets,
+		Effect: EdgeEffectAllow,
+	})
+
+	out := g.GetOutEdges("node:a")
+	if len(out) != 1 {
+		t.Fatalf("expected revived edge to be active once, got %d", len(out))
+	}
+	if got := len(g.outEdges["node:a"]); got != 1 {
+		t.Fatalf("expected one stored out-edge after revive, got %d", got)
+	}
+	if got := len(g.inEdges["node:b"]); got != 1 {
+		t.Fatalf("expected one stored in-edge after revive, got %d", got)
+	}
+	if out[0].DeletedAt != nil {
+		t.Fatalf("expected revived edge to be active, got deleted_at=%v", out[0].DeletedAt)
+	}
+}
+
+func TestGraphAddEdgeRelinksAdjacencyWhenSameIDMoves(t *testing.T) {
+	g := New()
+
+	g.AddEdge(&Edge{
+		ID:     "edge-1",
+		Source: "node:a",
+		Target: "node:b",
+		Kind:   EdgeKindTargets,
+		Effect: EdgeEffectAllow,
+	})
+
+	g.AddEdge(&Edge{
+		ID:     "edge-1",
+		Source: "node:c",
+		Target: "node:d",
+		Kind:   EdgeKindBasedOn,
+		Effect: EdgeEffectAllow,
+	})
+
+	if got := len(g.GetOutEdges("node:a")); got != 0 {
+		t.Fatalf("expected moved edge to leave old source empty, got %d", got)
+	}
+	if got := len(g.GetInEdges("node:b")); got != 0 {
+		t.Fatalf("expected moved edge to leave old target empty, got %d", got)
+	}
+
+	out := g.GetOutEdges("node:c")
+	if len(out) != 1 {
+		t.Fatalf("expected moved edge on new source, got %d", len(out))
+	}
+	if out[0].Target != "node:d" || out[0].Kind != EdgeKindBasedOn {
+		t.Fatalf("expected moved edge to point at node:d with based_on kind, got %+v", out[0])
+	}
+	if got := len(g.outEdges["node:c"]); got != 1 {
+		t.Fatalf("expected one stored out-edge on new source, got %d", got)
+	}
+	if got := len(g.inEdges["node:d"]); got != 1 {
+		t.Fatalf("expected one stored in-edge on new target, got %d", got)
+	}
+}
+
+func TestGraphCompactDeletedEdgesEvictsDeletedEdgeIDs(t *testing.T) {
+	g := New()
+
+	for i := 0; i < 32; i++ {
+		id := "edge-" + strconv.Itoa(i)
+		target := "node:" + strconv.Itoa(i)
+		g.AddEdge(&Edge{
+			ID:     id,
+			Source: "node:source",
+			Target: target,
+			Kind:   EdgeKindTargets,
+			Effect: EdgeEffectAllow,
+		})
+		if !g.RemoveEdge("node:source", target, EdgeKindTargets) {
+			t.Fatalf("expected remove to succeed for %s", id)
+		}
+	}
+
+	if got := len(g.edgeByID); got != 32 {
+		t.Fatalf("expected deleted edges to remain indexed before compaction, got %d", got)
+	}
+
+	g.CompactDeletedEdges()
+
+	if got := len(g.edgeByID); got != 0 {
+		t.Fatalf("expected compacted deleted edge IDs to be evicted, got %d", got)
+	}
+}

--- a/internal/graph/knowledge_observations.go
+++ b/internal/graph/knowledge_observations.go
@@ -84,7 +84,7 @@ func WriteObservation(g *Graph, req ObservationWriteRequest) (ObservationWriteRe
 		Target:     request.SubjectID,
 		Kind:       EdgeKindTargets,
 		Effect:     EdgeEffectAllow,
-		Properties: cloneAnyMap(edgeProperties),
+		Properties: edgeProperties,
 	})
 
 	return ObservationWriteResult{

--- a/internal/graph/snapshot.go
+++ b/internal/graph/snapshot.go
@@ -57,16 +57,24 @@ func CreateSnapshot(g *Graph) *Snapshot {
 // RestoreFromSnapshot restores a graph from a snapshot
 func RestoreFromSnapshot(snapshot *Snapshot) *Graph {
 	g := New()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 
 	for _, node := range snapshot.Nodes {
-		g.AddNode(node)
+		if node == nil || node.ID == "" {
+			continue
+		}
+		g.addNodeLocked(node)
 	}
 
 	for _, edge := range snapshot.Edges {
-		g.AddEdge(edge)
+		if edge == nil || edge.Source == "" || edge.Target == "" {
+			continue
+		}
+		g.addEdgeLocked(edge)
 	}
 
-	g.SetMetadata(snapshot.Metadata)
+	g.metadata = snapshot.Metadata
 
 	return g
 }

--- a/internal/graph/snapshot_restore_test.go
+++ b/internal/graph/snapshot_restore_test.go
@@ -1,0 +1,74 @@
+package graph
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRestoreFromSnapshotSkipsInvalidEntries(t *testing.T) {
+	snapshot := &Snapshot{
+		Nodes: []*Node{
+			nil,
+			{ID: "", Kind: NodeKindUser},
+			{ID: "user:alice", Kind: NodeKindUser},
+		},
+		Edges: []*Edge{
+			nil,
+			{ID: "missing-source", Target: "user:alice", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow},
+			{ID: "missing-target", Source: "user:alice", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow},
+			{ID: "valid", Source: "user:alice", Target: "user:alice", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow},
+		},
+		Metadata: Metadata{NodeCount: 1, EdgeCount: 1},
+	}
+
+	restored := RestoreFromSnapshot(snapshot)
+
+	if got := restored.NodeCount(); got != 1 {
+		t.Fatalf("NodeCount = %d, want 1", got)
+	}
+	if got := restored.EdgeCount(); got != 1 {
+		t.Fatalf("EdgeCount = %d, want 1", got)
+	}
+	if restored.Metadata().NodeCount != 1 || restored.Metadata().EdgeCount != 1 {
+		t.Fatalf("metadata not preserved, got %#v", restored.Metadata())
+	}
+}
+
+func BenchmarkRestoreFromSnapshot(b *testing.B) {
+	snapshot := benchmarkGraphSnapshot(2000, 4000)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		restored := RestoreFromSnapshot(snapshot)
+		if restored.NodeCount() != 2000 || restored.EdgeCount() != 4000 {
+			b.Fatalf("unexpected restored counts: nodes=%d edges=%d", restored.NodeCount(), restored.EdgeCount())
+		}
+	}
+}
+
+func benchmarkGraphSnapshot(nodeCount, edgeCount int) *Snapshot {
+	g := New()
+	nodes := make([]*Node, 0, nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		nodes = append(nodes, &Node{
+			ID:   fmt.Sprintf("node:%d", i),
+			Kind: NodeKindWorkload,
+		})
+	}
+	g.AddNodesBatch(nodes)
+
+	edges := make([]*Edge, 0, edgeCount)
+	for i := 0; i < edgeCount; i++ {
+		source := fmt.Sprintf("node:%d", i%nodeCount)
+		target := fmt.Sprintf("node:%d", (i+1)%nodeCount)
+		edges = append(edges, &Edge{
+			ID:     fmt.Sprintf("edge:%d", i),
+			Source: source,
+			Target: target,
+			Kind:   EdgeKindTargets,
+			Effect: EdgeEffectAllow,
+		})
+	}
+	g.AddEdgesBatch(edges)
+	return CreateSnapshot(g)
+}

--- a/internal/graph/temporal_history.go
+++ b/internal/graph/temporal_history.go
@@ -8,7 +8,73 @@ import (
 	"time"
 )
 
-const maxTemporalHistoryPerProperty = 256
+const (
+	DefaultTemporalHistoryMaxEntries = 50
+	DefaultTemporalHistoryTTL        = 7 * 24 * time.Hour
+)
+
+func sanitizeTemporalHistoryConfig(maxEntries int, ttl time.Duration) (int, time.Duration) {
+	if maxEntries <= 0 {
+		maxEntries = DefaultTemporalHistoryMaxEntries
+	}
+	if ttl <= 0 {
+		ttl = DefaultTemporalHistoryTTL
+	}
+	return maxEntries, ttl
+}
+
+func (g *Graph) SetTemporalHistoryConfig(maxEntries int, ttl time.Duration) {
+	if g == nil {
+		return
+	}
+	maxEntries, ttl = sanitizeTemporalHistoryConfig(maxEntries, ttl)
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.temporalHistoryMaxEntries = maxEntries
+	g.temporalHistoryTTL = ttl
+}
+
+func (g *Graph) TemporalHistoryConfig() (int, time.Duration) {
+	if g == nil {
+		return sanitizeTemporalHistoryConfig(0, 0)
+	}
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return sanitizeTemporalHistoryConfig(g.temporalHistoryMaxEntries, g.temporalHistoryTTL)
+}
+
+func (g *Graph) temporalHistoryConfigLocked() (int, time.Duration) {
+	if g == nil {
+		return sanitizeTemporalHistoryConfig(0, 0)
+	}
+	return sanitizeTemporalHistoryConfig(g.temporalHistoryMaxEntries, g.temporalHistoryTTL)
+}
+
+func (g *Graph) trimTemporalHistoryLocked(history []PropertySnapshot, _ time.Time) []PropertySnapshot {
+	if len(history) == 0 {
+		return nil
+	}
+	maxEntries, ttl := g.temporalHistoryConfigLocked()
+
+	if ttl > 0 {
+		cutoff := temporalNowUTC().UTC().Add(-ttl)
+		trimmed := history[:0]
+		for _, snapshot := range history {
+			if snapshot.Timestamp.Before(cutoff) {
+				continue
+			}
+			trimmed = append(trimmed, snapshot)
+		}
+		history = trimmed
+	}
+	if len(history) > maxEntries {
+		history = history[len(history)-maxEntries:]
+	}
+	if len(history) == 0 {
+		return nil
+	}
+	return history
+}
 
 // GetNodePropertyHistory returns timestamped values for one node property.
 // When window > 0, only snapshots within [now-window, now] are returned.
@@ -176,9 +242,7 @@ func (g *Graph) CompactTemporalHistory(retention, rollup time.Duration) {
 				}
 			}
 			combined = append(combined, recent...)
-			if len(combined) > maxTemporalHistoryPerProperty {
-				combined = combined[len(combined)-maxTemporalHistoryPerProperty:]
-			}
+			combined = g.trimTemporalHistoryLocked(combined, now)
 			if len(combined) == 0 {
 				delete(node.PropertyHistory, property)
 			} else {
@@ -274,15 +338,22 @@ func (g *Graph) appendNodePropertySnapshotLocked(node *Node, property string, sn
 		if last.Deleted == snapshot.Deleted && reflect.DeepEqual(last.Value, snapshot.Value) {
 			if snapshot.Timestamp.After(last.Timestamp) {
 				history[len(history)-1].Timestamp = snapshot.Timestamp
-				node.PropertyHistory[property] = history
+				history = g.trimTemporalHistoryLocked(history, snapshot.Timestamp)
+				if len(history) == 0 {
+					delete(node.PropertyHistory, property)
+				} else {
+					node.PropertyHistory[property] = history
+				}
 			}
 			return
 		}
 	}
 
 	history = append(history, snapshot)
-	if len(history) > maxTemporalHistoryPerProperty {
-		history = history[len(history)-maxTemporalHistoryPerProperty:]
+	history = g.trimTemporalHistoryLocked(history, snapshot.Timestamp)
+	if len(history) == 0 {
+		delete(node.PropertyHistory, property)
+		return
 	}
 	node.PropertyHistory[property] = history
 }

--- a/internal/graph/temporal_history_test.go
+++ b/internal/graph/temporal_history_test.go
@@ -205,6 +205,128 @@ func TestSnapshotDeepCopiesPropertyHistory(t *testing.T) {
 	}
 }
 
+func TestTemporalHistoryRespectsConfiguredMaxEntries(t *testing.T) {
+	origNow := temporalNowUTC
+	defer func() { temporalNowUTC = origNow }()
+
+	base := time.Date(2026, 3, 8, 9, 0, 0, 0, time.UTC)
+	now := base
+	temporalNowUTC = func() time.Time { return now }
+
+	g := New()
+	g.SetTemporalHistoryConfig(3, 7*24*time.Hour)
+	g.AddNode(&Node{
+		ID:         "customer:umbrella",
+		Kind:       NodeKindCustomer,
+		Properties: map[string]any{"health_score": 100.0},
+	})
+
+	now = base.Add(1 * time.Hour)
+	g.SetNodeProperty("customer:umbrella", "health_score", 90.0)
+	now = base.Add(2 * time.Hour)
+	g.SetNodeProperty("customer:umbrella", "health_score", 80.0)
+	now = base.Add(3 * time.Hour)
+	g.SetNodeProperty("customer:umbrella", "health_score", 70.0)
+
+	history := g.GetNodePropertyHistory("customer:umbrella", "health_score", 0)
+	if len(history) != 3 {
+		t.Fatalf("expected 3 snapshots after cap enforcement, got %d", len(history))
+	}
+	if history[0].Value != 90.0 || history[1].Value != 80.0 || history[2].Value != 70.0 {
+		t.Fatalf("unexpected capped history: %#v", history)
+	}
+}
+
+func TestTemporalHistoryTrimsExpiredSnapshotsOnWrite(t *testing.T) {
+	origNow := temporalNowUTC
+	defer func() { temporalNowUTC = origNow }()
+
+	base := time.Date(2026, 3, 8, 9, 0, 0, 0, time.UTC)
+	now := base
+	temporalNowUTC = func() time.Time { return now }
+
+	g := New()
+	g.SetTemporalHistoryConfig(50, 2*time.Hour)
+	g.AddNode(&Node{
+		ID:         "customer:stark",
+		Kind:       NodeKindCustomer,
+		Properties: map[string]any{"health_score": 100.0},
+	})
+
+	now = base.Add(30 * time.Minute)
+	g.SetNodeProperty("customer:stark", "health_score", 95.0)
+	now = base.Add(4 * time.Hour)
+	g.SetNodeProperty("customer:stark", "health_score", 80.0)
+
+	history := g.GetNodePropertyHistory("customer:stark", "health_score", 0)
+	if len(history) != 1 {
+		t.Fatalf("expected expired snapshots to be trimmed on write, got %d", len(history))
+	}
+	if history[0].Value != 80.0 {
+		t.Fatalf("expected only current snapshot after ttl trim, got %#v", history)
+	}
+}
+
+func TestTemporalHistoryTrimsExpiredHistoricalSnapshotsAgainstWallClock(t *testing.T) {
+	origNow := temporalNowUTC
+	defer func() { temporalNowUTC = origNow }()
+
+	wallClock := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
+	temporalNowUTC = func() time.Time { return wallClock }
+
+	g := New()
+	g.SetTemporalHistoryConfig(50, 7*24*time.Hour)
+	g.AddNode(&Node{
+		ID:        "customer:historical",
+		Kind:      NodeKindCustomer,
+		CreatedAt: wallClock.Add(-30 * 24 * time.Hour),
+		UpdatedAt: wallClock.Add(-30 * 24 * time.Hour),
+		Properties: map[string]any{
+			"health_score": 100.0,
+		},
+	})
+
+	history := g.GetNodePropertyHistory("customer:historical", "health_score", 0)
+	if len(history) != 0 {
+		t.Fatalf("expected historical snapshot outside TTL to be trimmed, got %#v", history)
+	}
+}
+
+func TestSnapshotShrinksAfterTemporalHistoryTTLEnforcement(t *testing.T) {
+	origNow := temporalNowUTC
+	defer func() { temporalNowUTC = origNow }()
+
+	base := time.Date(2026, 3, 8, 9, 0, 0, 0, time.UTC)
+	now := base
+	temporalNowUTC = func() time.Time { return now }
+
+	g := New()
+	g.SetTemporalHistoryConfig(50, 90*time.Minute)
+	g.AddNode(&Node{
+		ID:         "customer:wayne",
+		Kind:       NodeKindCustomer,
+		Properties: map[string]any{"health_score": 100.0},
+	})
+
+	now = base.Add(30 * time.Minute)
+	g.SetNodeProperty("customer:wayne", "health_score", 90.0)
+	now = base.Add(3 * time.Hour)
+	g.SetNodeProperty("customer:wayne", "health_score", 80.0)
+
+	snapshot := CreateSnapshot(g)
+	snapshotNode := findSnapshotNode(snapshot, "customer:wayne")
+	if snapshotNode == nil {
+		t.Fatal("expected node in snapshot")
+	}
+	history := snapshotNode.PropertyHistory["health_score"]
+	if len(history) != 1 {
+		t.Fatalf("expected ttl-trimmed snapshot history, got %d", len(history))
+	}
+	if history[0].Value != 80.0 {
+		t.Fatalf("expected only current snapshot value 80.0, got %#v", history)
+	}
+}
+
 func findSnapshotNode(snapshot *Snapshot, id string) *Node {
 	if snapshot == nil {
 		return nil

--- a/internal/graph/temporal_test.go
+++ b/internal/graph/temporal_test.go
@@ -192,3 +192,122 @@ func TestGraphTemporalNodesAliases(t *testing.T) {
 		t.Fatalf("expected NodesIncludingDeleted() to include soft-deleted nodes")
 	}
 }
+
+func TestGraphTemporalCompactDeletedNodesRemovesTombstones(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "user:alice", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:bob", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:carol", Kind: NodeKindUser})
+
+	if !g.RemoveNode("user:bob") {
+		t.Fatal("expected RemoveNode to succeed")
+	}
+	if !g.RemoveNode("user:carol") {
+		t.Fatal("expected RemoveNode to succeed")
+	}
+
+	if got := g.NodeCount(); got != 1 {
+		t.Fatalf("expected active node count 1 before compaction, got %d", got)
+	}
+	if got := len(g.GetAllNodesIncludingDeleted()); got != 3 {
+		t.Fatalf("expected 3 nodes including tombstones before compaction, got %d", got)
+	}
+
+	g.CompactDeletedNodes()
+
+	if got := g.NodeCount(); got != 1 {
+		t.Fatalf("expected active node count to stay 1 after compaction, got %d", got)
+	}
+	if got := len(g.GetAllNodesIncludingDeleted()); got != 1 {
+		t.Fatalf("expected only active nodes to remain after compaction, got %d", got)
+	}
+	if _, ok := g.GetNodeIncludingDeleted("user:bob"); ok {
+		t.Fatal("expected compacted tombstone to be removed from the node map")
+	}
+	if _, ok := g.GetNodeIncludingDeleted("user:carol"); ok {
+		t.Fatal("expected compacted tombstone to be removed from the node map")
+	}
+}
+
+func TestGraphTemporalCompactDeletedNodesRemovesAdjacencyBuckets(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "user:alice", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:bob", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:carol", Kind: NodeKindUser})
+	g.AddEdge(&Edge{ID: "alice-bob", Source: "user:alice", Target: "user:bob", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "bob-carol", Source: "user:bob", Target: "user:carol", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+
+	if !g.RemoveNode("user:bob") {
+		t.Fatal("expected RemoveNode to succeed")
+	}
+	if _, ok := g.outEdges["user:bob"]; !ok {
+		t.Fatal("expected deleted node source bucket to exist before compaction")
+	}
+	if _, ok := g.inEdges["user:bob"]; !ok {
+		t.Fatal("expected deleted node target bucket to exist before compaction")
+	}
+
+	g.CompactDeletedNodes()
+
+	if _, ok := g.outEdges["user:bob"]; ok {
+		t.Fatal("expected deleted node source bucket to be removed during compaction")
+	}
+	if _, ok := g.inEdges["user:bob"]; ok {
+		t.Fatal("expected deleted node target bucket to be removed during compaction")
+	}
+}
+
+func TestGraphTemporalCompactDeletedNodesEvictsDeletedEdgeIDs(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "user:alice", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:bob", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:carol", Kind: NodeKindUser})
+	g.AddEdge(&Edge{ID: "alice-bob", Source: "user:alice", Target: "user:bob", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "bob-carol", Source: "user:bob", Target: "user:carol", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+
+	if !g.RemoveNode("user:bob") {
+		t.Fatal("expected RemoveNode to succeed")
+	}
+	if _, ok := g.edgeByID["alice-bob"]; !ok {
+		t.Fatal("expected deleted edge ID to remain indexed before compaction")
+	}
+	if _, ok := g.edgeByID["bob-carol"]; !ok {
+		t.Fatal("expected deleted edge ID to remain indexed before compaction")
+	}
+
+	g.CompactDeletedNodes()
+
+	if _, ok := g.edgeByID["alice-bob"]; ok {
+		t.Fatal("expected compacted deleted source edge ID to be evicted")
+	}
+	if _, ok := g.edgeByID["bob-carol"]; ok {
+		t.Fatal("expected compacted deleted target edge ID to be evicted")
+	}
+}
+
+func TestGraphTemporalCompactDeletedNodesInvalidatesIndexOnlyOnChange(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "user:alice", Kind: NodeKindUser})
+	g.BuildIndex()
+
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected index to start built")
+	}
+
+	g.CompactDeletedNodes()
+
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected no-op node compaction to leave index current")
+	}
+
+	g.nodes["nil-entry"] = nil
+
+	g.CompactDeletedNodes()
+
+	if g.IsIndexBuilt() {
+		t.Fatal("expected compaction that removes entries to invalidate the index")
+	}
+	if _, ok := g.GetNodeIncludingDeleted("nil-entry"); ok {
+		t.Fatal("expected nil node entry to be removed during compaction")
+	}
+}

--- a/internal/graph/toxic_combinations_test.go
+++ b/internal/graph/toxic_combinations_test.go
@@ -1332,6 +1332,7 @@ func TestToxicCombination_BusinessTrajectoryDeterioration(t *testing.T) {
 
 	engine := NewToxicCombinationEngine()
 	g := New()
+	g.SetTemporalHistoryConfig(DefaultTemporalHistoryMaxEntries, 45*24*time.Hour)
 
 	g.AddNode(&Node{
 		ID:   "customer-trajectory",

--- a/internal/graph/write_metadata.go
+++ b/internal/graph/write_metadata.go
@@ -118,15 +118,14 @@ func NormalizeWriteMetadata(observedAt, validFrom time.Time, validTo *time.Time,
 
 // PropertyMap returns metadata as normalized graph property key/value pairs.
 func (m WriteMetadata) PropertyMap() map[string]any {
-	properties := map[string]any{
-		"source_system":    m.SourceSystem,
-		"source_event_id":  m.SourceEventID,
-		"observed_at":      m.ObservedAt.UTC().Format(time.RFC3339),
-		"valid_from":       m.ValidFrom.UTC().Format(time.RFC3339),
-		"recorded_at":      m.RecordedAt.UTC().Format(time.RFC3339),
-		"transaction_from": m.TransactionFrom.UTC().Format(time.RFC3339),
-		"confidence":       m.Confidence,
-	}
+	properties := make(map[string]any, 9)
+	properties["source_system"] = m.SourceSystem
+	properties["source_event_id"] = m.SourceEventID
+	properties["observed_at"] = m.ObservedAt.UTC().Format(time.RFC3339)
+	properties["valid_from"] = m.ValidFrom.UTC().Format(time.RFC3339)
+	properties["recorded_at"] = m.RecordedAt.UTC().Format(time.RFC3339)
+	properties["transaction_from"] = m.TransactionFrom.UTC().Format(time.RFC3339)
+	properties["confidence"] = m.Confidence
 	if m.ValidTo != nil && !m.ValidTo.IsZero() {
 		properties["valid_to"] = m.ValidTo.UTC().Format(time.RFC3339)
 	}
@@ -141,7 +140,17 @@ func (m WriteMetadata) ApplyTo(properties map[string]any) {
 	if properties == nil {
 		return
 	}
-	for key, value := range m.PropertyMap() {
-		properties[key] = value
+	properties["source_system"] = m.SourceSystem
+	properties["source_event_id"] = m.SourceEventID
+	properties["observed_at"] = m.ObservedAt.UTC().Format(time.RFC3339)
+	properties["valid_from"] = m.ValidFrom.UTC().Format(time.RFC3339)
+	properties["recorded_at"] = m.RecordedAt.UTC().Format(time.RFC3339)
+	properties["transaction_from"] = m.TransactionFrom.UTC().Format(time.RFC3339)
+	properties["confidence"] = m.Confidence
+	if m.ValidTo != nil && !m.ValidTo.IsZero() {
+		properties["valid_to"] = m.ValidTo.UTC().Format(time.RFC3339)
+	}
+	if m.TransactionTo != nil && !m.TransactionTo.IsZero() {
+		properties["transaction_to"] = m.TransactionTo.UTC().Format(time.RFC3339)
 	}
 }

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -321,6 +321,13 @@ var (
 		},
 	)
 
+	GraphPropertyHistoryDepth = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "cerebro_graph_property_history_depth",
+			Help: "Configured maximum number of property-history snapshots retained per node property",
+		},
+	)
+
 	GraphFreshnessByProvider = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "cerebro_graph_freshness_by_provider",
@@ -637,6 +644,7 @@ func Register() {
 			GraphBuildStatus,
 			GraphLastUpdateTimestamp,
 			GraphStalenessSeconds,
+			GraphPropertyHistoryDepth,
 			GraphFreshnessByProvider,
 			GraphOldestNodeAgeSeconds,
 			GraphProviderLastSyncTimestamp,
@@ -1065,6 +1073,13 @@ func SetGraphStaleness(age time.Duration) {
 		age = 0
 	}
 	GraphStalenessSeconds.Set(age.Seconds())
+}
+
+func SetGraphPropertyHistoryDepth(depth int) {
+	if depth < 0 {
+		depth = 0
+	}
+	GraphPropertyHistoryDepth.Set(float64(depth))
 }
 
 func ResetGraphFreshnessProviderMetrics() {

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -381,6 +381,20 @@ func TestSetGraphLastUpdatePublishesStoredTimestamp(t *testing.T) {
 	}
 }
 
+func TestSetGraphPropertyHistoryDepth(t *testing.T) {
+	Register()
+
+	SetGraphPropertyHistoryDepth(17)
+	if got := gaugeValue(t, GraphPropertyHistoryDepth); got != 17 {
+		t.Fatalf("expected graph property history depth gauge 17, got %v", got)
+	}
+
+	SetGraphPropertyHistoryDepth(-1)
+	if got := gaugeValue(t, GraphPropertyHistoryDepth); got != 0 {
+		t.Fatalf("expected negative depth to clamp to 0, got %v", got)
+	}
+}
+
 func counterValue(t *testing.T, vec *prometheus.CounterVec, labels ...string) float64 {
 	t.Helper()
 	counter, err := vec.GetMetricWithLabelValues(labels...)

--- a/internal/runtime/detections.go
+++ b/internal/runtime/detections.go
@@ -38,7 +38,8 @@ import (
 //
 // Thread-safe for concurrent event processing.
 type DetectionEngine struct {
-	rules          []DetectionRule  // Active detection rules
+	rules          []DetectionRule // Active detection rules
+	rulesByMask    [16][]DetectionRule
 	suppressions   map[string]bool  // Rule IDs that are suppressed
 	recentFindings []RuntimeFinding // Recent findings ring buffer
 	maxFindings    int              // Max findings to retain
@@ -52,15 +53,16 @@ type DetectionEngine struct {
 // Each rule includes MITRE ATT&CK technique IDs for threat intelligence
 // correlation and incident response prioritization.
 type DetectionRule struct {
-	ID          string            `json:"id"`           // Unique rule identifier
-	Name        string            `json:"name"`         // Human-readable rule name
-	Description string            `json:"description"`  // Detailed description of what the rule detects
-	Category    DetectionCategory `json:"category"`     // Threat category for grouping/filtering
-	Severity    string            `json:"severity"`     // critical, high, medium, low
-	Enabled     bool              `json:"enabled"`      // Whether rule is active
-	Conditions  []Condition       `json:"conditions"`   // Conditions that must match
-	MITRE       []string          `json:"mitre_attack"` // MITRE ATT&CK technique IDs (e.g., T1496)
-	Response    ResponseAction    `json:"response"`     // Automated response configuration
+	ID           string            `json:"id"`           // Unique rule identifier
+	Name         string            `json:"name"`         // Human-readable rule name
+	Description  string            `json:"description"`  // Detailed description of what the rule detects
+	Category     DetectionCategory `json:"category"`     // Threat category for grouping/filtering
+	Severity     string            `json:"severity"`     // critical, high, medium, low
+	Enabled      bool              `json:"enabled"`      // Whether rule is active
+	Conditions   []Condition       `json:"conditions"`   // Conditions that must match
+	MITRE        []string          `json:"mitre_attack"` // MITRE ATT&CK technique IDs (e.g., T1496)
+	Response     ResponseAction    `json:"response"`     // Automated response configuration
+	requiredMask detectionFieldMask
 }
 
 // DetectionCategory classifies the type of threat being detected.
@@ -84,15 +86,25 @@ const (
 )
 
 type Condition struct {
-	Field    string `json:"field"`
-	Operator string `json:"operator"` // eq, neq, contains, regex, gt, lt
-	Value    string `json:"value"`
+	Field         string `json:"field"`
+	Operator      string `json:"operator"` // eq, neq, contains, regex, gt, lt
+	Value         string `json:"value"`
+	compiledRegex *regexp.Regexp
 }
 
 type ResponseAction struct {
 	Type        string `json:"type"` // alert, isolate, kill, quarantine
 	AutoExecute bool   `json:"auto_execute"`
 }
+
+type detectionFieldMask uint8
+
+const (
+	detectionFieldProcess detectionFieldMask = 1 << iota
+	detectionFieldNetwork
+	detectionFieldFile
+	detectionFieldContainer
+)
 
 // RuntimeEvent represents a telemetry event from agents
 type RuntimeEvent struct {
@@ -183,7 +195,7 @@ func NewDetectionEngine() *DetectionEngine {
 }
 
 func (e *DetectionEngine) loadDefaultRules() {
-	e.rules = []DetectionRule{
+	e.rules = e.prepareRules([]DetectionRule{
 		// Crypto Mining Detection
 		{
 			ID:          "crypto-mining-process",
@@ -469,7 +481,8 @@ func (e *DetectionEngine) loadDefaultRules() {
 			MITRE:    []string{"T1552.001"},
 			Response: ResponseAction{Type: "alert", AutoExecute: true},
 		},
-	}
+	})
+	e.rebuildRuleMaskIndex()
 }
 
 // ProcessEvent evaluates an event against all rules and stores resulting findings
@@ -508,7 +521,7 @@ func (e *DetectionEngine) process(_ context.Context, event *RuntimeEvent, observ
 	}
 	var findings []RuntimeFinding
 
-	for _, rule := range e.rules {
+	for _, rule := range e.candidateRulesForEvent(event) {
 		if !rule.Enabled {
 			continue
 		}
@@ -584,6 +597,9 @@ func (e *DetectionEngine) evaluateCondition(event *RuntimeEvent, cond Condition)
 	case "contains":
 		return strings.Contains(value, cond.Value)
 	case "regex":
+		if cond.compiledRegex != nil {
+			return cond.compiledRegex.MatchString(value)
+		}
 		matched, _ := regexp.MatchString(cond.Value, value)
 		return matched
 	case "gt":
@@ -670,7 +686,9 @@ func (e *DetectionEngine) extractField(event *RuntimeEvent, field string) string
 }
 
 func (e *DetectionEngine) AddRule(rule DetectionRule) {
-	e.rules = append(e.rules, rule)
+	prepared := e.prepareRule(rule)
+	e.rules = append(e.rules, prepared)
+	e.addRuleToMaskIndex(prepared)
 }
 
 func (e *DetectionEngine) SetSuppression(ruleID string, suppressed bool) {
@@ -679,6 +697,112 @@ func (e *DetectionEngine) SetSuppression(ruleID string, suppressed bool) {
 
 func (e *DetectionEngine) ListRules() []DetectionRule {
 	return e.rules
+}
+
+func (e *DetectionEngine) candidateRulesForEvent(event *RuntimeEvent) []DetectionRule {
+	return e.rulesByMask[eventFieldMask(event)]
+}
+
+func (e *DetectionEngine) prepareRules(rules []DetectionRule) []DetectionRule {
+	prepared := make([]DetectionRule, 0, len(rules))
+	for _, rule := range rules {
+		prepared = append(prepared, e.prepareRule(rule))
+	}
+	return prepared
+}
+
+func (e *DetectionEngine) prepareRule(rule DetectionRule) DetectionRule {
+	conditions := make([]Condition, 0, len(rule.Conditions))
+	var mask detectionFieldMask
+	for _, cond := range rule.Conditions {
+		cond.compiledRegex = nil
+		if cond.Operator == "regex" {
+			if compiled, err := regexp.Compile(cond.Value); err == nil {
+				cond.compiledRegex = compiled
+			}
+		}
+		if !conditionCanMatchEmpty(cond) {
+			mask |= conditionFieldMask(cond.Field)
+		}
+		conditions = append(conditions, cond)
+	}
+	rule.Conditions = conditions
+	rule.requiredMask = mask
+	return rule
+}
+
+func (e *DetectionEngine) rebuildRuleMaskIndex() {
+	e.rulesByMask = [16][]DetectionRule{}
+	for _, rule := range e.rules {
+		e.addRuleToMaskIndex(rule)
+	}
+}
+
+func (e *DetectionEngine) addRuleToMaskIndex(rule DetectionRule) {
+	for mask := detectionFieldMask(0); mask < 16; mask++ {
+		if mask&rule.requiredMask != rule.requiredMask {
+			continue
+		}
+		e.rulesByMask[mask] = append(e.rulesByMask[mask], rule)
+	}
+}
+
+func eventFieldMask(event *RuntimeEvent) detectionFieldMask {
+	if event == nil {
+		return 0
+	}
+	var mask detectionFieldMask
+	if event.Process != nil {
+		mask |= detectionFieldProcess
+	}
+	if event.Network != nil {
+		mask |= detectionFieldNetwork
+	}
+	if event.File != nil {
+		mask |= detectionFieldFile
+	}
+	if event.Container != nil {
+		mask |= detectionFieldContainer
+	}
+	return mask
+}
+
+func conditionFieldMask(field string) detectionFieldMask {
+	switch strings.SplitN(field, ".", 2)[0] {
+	case "process":
+		return detectionFieldProcess
+	case "network":
+		return detectionFieldNetwork
+	case "file":
+		return detectionFieldFile
+	case "container":
+		return detectionFieldContainer
+	default:
+		return 0
+	}
+}
+
+func conditionCanMatchEmpty(cond Condition) bool {
+	switch cond.Operator {
+	case "eq":
+		return cond.Value == ""
+	case "neq":
+		return cond.Value != ""
+	case "contains":
+		return cond.Value == ""
+	case "regex":
+		if cond.compiledRegex != nil {
+			return cond.compiledRegex.MatchString("")
+		}
+		matched, err := regexp.MatchString(cond.Value, "")
+		return err == nil && matched
+	case "gt":
+		return false
+	case "lt":
+		return len(cond.Value) > 0
+	default:
+		return false
+	}
 }
 
 func generateFindingID(ruleID string, event *RuntimeEvent) string {

--- a/internal/runtime/detections_test.go
+++ b/internal/runtime/detections_test.go
@@ -254,3 +254,177 @@ func TestDetectionEngineProcessNormalizedObservation(t *testing.T) {
 		t.Fatalf("finding observation = %#v, want normalized observation id %q", findings[0].Observation, observation.ID)
 	}
 }
+
+func TestDetectionEngineCandidateRulesForEventSkipsStrictlyRequiredDomains(t *testing.T) {
+	engine := &DetectionEngine{
+		suppressions:   make(map[string]bool),
+		recentFindings: make([]RuntimeFinding, 0),
+		maxFindings:    100,
+	}
+	engine.AddRule(DetectionRule{
+		ID:      "process-only",
+		Enabled: true,
+		Conditions: []Condition{
+			{Field: "process.name", Operator: "eq", Value: "bash"},
+		},
+	})
+	engine.AddRule(DetectionRule{
+		ID:      "network-only",
+		Enabled: true,
+		Conditions: []Condition{
+			{Field: "network.dst_port", Operator: "eq", Value: "443"},
+		},
+	})
+	engine.AddRule(DetectionRule{
+		ID:      "process-and-container",
+		Enabled: true,
+		Conditions: []Condition{
+			{Field: "process.name", Operator: "eq", Value: "bash"},
+			{Field: "container.container_id", Operator: "neq", Value: ""},
+		},
+	})
+	engine.AddRule(DetectionRule{
+		ID:      "network-and-process-neq",
+		Enabled: true,
+		Conditions: []Condition{
+			{Field: "network.dst_port", Operator: "eq", Value: "22"},
+			{Field: "process.name", Operator: "neq", Value: "ssh"},
+		},
+	})
+	engine.AddRule(DetectionRule{
+		ID:      "network-and-process-eq",
+		Enabled: true,
+		Conditions: []Condition{
+			{Field: "network.dst_port", Operator: "eq", Value: "22"},
+			{Field: "process.name", Operator: "eq", Value: "ssh"},
+		},
+	})
+
+	candidates := engine.candidateRulesForEvent(&RuntimeEvent{
+		ID:        "evt-1",
+		Timestamp: time.Now(),
+		Network:   &NetworkEvent{DstPort: 22},
+	})
+
+	got := make(map[string]bool, len(candidates))
+	for _, candidate := range candidates {
+		got[candidate.ID] = true
+	}
+
+	if !got["network-only"] {
+		t.Fatal("expected network-only rule to remain a candidate")
+	}
+	if !got["network-and-process-neq"] {
+		t.Fatal("expected cross-domain neq rule to remain a candidate on partial events")
+	}
+	if got["process-only"] {
+		t.Fatal("did not expect process-only rule for network-only event")
+	}
+	if got["process-and-container"] {
+		t.Fatal("did not expect process-and-container rule for network-only event")
+	}
+	if got["network-and-process-eq"] {
+		t.Fatal("did not expect cross-domain eq rule without process data")
+	}
+}
+
+func TestDetectionEngineProcessEventKeepsPartialDomainNeqCoverage(t *testing.T) {
+	engine := &DetectionEngine{
+		suppressions:   make(map[string]bool),
+		recentFindings: make([]RuntimeFinding, 0),
+		maxFindings:    100,
+	}
+	engine.AddRule(DetectionRule{
+		ID:       "lateral-movement-ssh-unusual",
+		Name:     "Unusual SSH Connection",
+		Category: CategoryLateralMovement,
+		Severity: "medium",
+		Enabled:  true,
+		Conditions: []Condition{
+			{Field: "network.dst_port", Operator: "eq", Value: "22"},
+			{Field: "process.name", Operator: "neq", Value: "ssh"},
+		},
+	})
+
+	findings := engine.ProcessEvent(context.Background(), &RuntimeEvent{
+		ID:        "evt-ssh",
+		Timestamp: time.Now(),
+		Network:   &NetworkEvent{DstPort: 22},
+	})
+
+	if len(findings) != 1 {
+		t.Fatalf("len(findings) = %d, want 1", len(findings))
+	}
+	if findings[0].RuleID != "lateral-movement-ssh-unusual" {
+		t.Fatalf("finding rule id = %q, want lateral-movement-ssh-unusual", findings[0].RuleID)
+	}
+}
+
+func TestDetectionEngineAddRulePrecompilesRegexConditions(t *testing.T) {
+	engine := &DetectionEngine{
+		suppressions:   make(map[string]bool),
+		recentFindings: make([]RuntimeFinding, 0),
+		maxFindings:    100,
+	}
+
+	engine.AddRule(DetectionRule{
+		ID:      "regex-rule",
+		Enabled: true,
+		Conditions: []Condition{
+			{Field: "process.name", Operator: "regex", Value: "^bash$"},
+		},
+	})
+
+	if len(engine.rules) != 1 {
+		t.Fatalf("len(engine.rules) = %d, want 1", len(engine.rules))
+	}
+	if engine.rules[0].Conditions[0].compiledRegex == nil {
+		t.Fatal("expected regex condition to be compiled during rule registration")
+	}
+}
+
+func BenchmarkDetectionEngineProcessNormalizedObservationProcessOnly(b *testing.B) {
+	engine := NewDetectionEngine()
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		ID:         "bench-process",
+		Kind:       ObservationKindProcessExec,
+		Source:     "tetragon",
+		ObservedAt: time.Now(),
+		Process: &ProcessEvent{
+			Name:    "nginx",
+			Cmdline: "nginx: worker process",
+		},
+	})
+	if err != nil {
+		b.Fatalf("NormalizeObservation: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = engine.ProcessNormalizedObservation(context.Background(), observation)
+	}
+}
+
+func BenchmarkDetectionEngineProcessNormalizedObservationFileOnly(b *testing.B) {
+	engine := NewDetectionEngine()
+	observation, err := NormalizeObservation(&RuntimeObservation{
+		ID:         "bench-file",
+		Kind:       ObservationKindFileWrite,
+		Source:     "tetragon",
+		ObservedAt: time.Now(),
+		File: &FileEvent{
+			Operation: "modify",
+			Path:      "/tmp/app.log",
+		},
+	})
+	if err != nil {
+		b.Fatalf("NormalizeObservation: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = engine.ProcessNormalizedObservation(context.Background(), observation)
+	}
+}

--- a/internal/runtimegraph/bench_test.go
+++ b/internal/runtimegraph/bench_test.go
@@ -50,3 +50,78 @@ func BenchmarkMaterializeObservationsIntoGraphDeferredFinalize(b *testing.B) {
 		FinalizeMaterializedGraph(g, baseTime)
 	}
 }
+
+func BenchmarkBuildObservationWriteRequest(b *testing.B) {
+	observation := &runtime.RuntimeObservation{
+		ID:          "runtime:process_exec:bench",
+		Source:      "tetragon",
+		Kind:        runtime.ObservationKindProcessExec,
+		ObservedAt:  time.Date(2026, 3, 16, 21, 30, 0, 0, time.UTC),
+		RecordedAt:  time.Date(2026, 3, 16, 21, 30, 0, int(time.Millisecond), time.UTC),
+		WorkloadRef: "deployment:prod/api",
+		WorkloadUID: "uid-api",
+		Cluster:     "prod-cluster",
+		Namespace:   "prod",
+		NodeName:    "worker-a",
+		ContainerID: "containerd://bench",
+		ImageRef:    "ghcr.io/evalops/api:latest",
+		ImageID:     "sha256:bench",
+		PrincipalID: "root",
+		Metadata: map[string]any{
+			"signal_name": "process_exec",
+			"severity":    "medium",
+		},
+		Process: &runtime.ProcessEvent{
+			Name:    "sh",
+			Path:    "/bin/sh",
+			Cmdline: "sh -c id",
+			User:    "root",
+		},
+		Tags: []string{"runtime", "process"},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := BuildObservationWriteRequest(observation); err != nil {
+			b.Fatalf("BuildObservationWriteRequest: %v", err)
+		}
+	}
+}
+
+func BenchmarkWriteObservation(b *testing.B) {
+	req, err := BuildObservationWriteRequest(&runtime.RuntimeObservation{
+		ID:          "runtime:process_exec:write",
+		Source:      "tetragon",
+		Kind:        runtime.ObservationKindProcessExec,
+		ObservedAt:  time.Date(2026, 3, 16, 21, 45, 0, 0, time.UTC),
+		RecordedAt:  time.Date(2026, 3, 16, 21, 45, 0, int(time.Millisecond), time.UTC),
+		WorkloadRef: "deployment:prod/api",
+		Cluster:     "prod-cluster",
+		Namespace:   "prod",
+		ContainerID: "containerd://bench",
+		Process: &runtime.ProcessEvent{
+			Name:    "sh",
+			Path:    "/bin/sh",
+			Cmdline: "sh -c id",
+			User:    "root",
+		},
+	})
+	if err != nil {
+		b.Fatalf("BuildObservationWriteRequest: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g := graph.New()
+		g.AddNode(&graph.Node{
+			ID:   "deployment:prod/api",
+			Kind: graph.NodeKindDeployment,
+			Name: "api",
+		})
+		if _, err := graph.WriteObservation(g, req); err != nil {
+			b.Fatalf("WriteObservation: %v", err)
+		}
+	}
+}

--- a/internal/runtimegraph/materializer.go
+++ b/internal/runtimegraph/materializer.go
@@ -145,10 +145,9 @@ func observationSummary(observation *runtime.RuntimeObservation) string {
 }
 
 func observationMetadata(observation *runtime.RuntimeObservation) map[string]any {
-	metadata := map[string]any{
-		"runtime_observation_id": observation.ID,
-		"runtime_source":         observation.Source,
-	}
+	metadata := make(map[string]any, 35)
+	metadata["runtime_observation_id"] = observation.ID
+	metadata["runtime_source"] = observation.Source
 	addMetadataString(metadata, "resource_id", observation.ResourceID)
 	addMetadataString(metadata, "resource_type", observation.ResourceType)
 	addMetadataString(metadata, "cluster", observation.Cluster)


### PR DESCRIPTION
* Cap graph property history with TTL and depth controls

* Trim temporal history against wall clock
