### PR TITLE
Compact deleted graph nodes (#393)

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -206,6 +206,16 @@ func (g *Graph) CompactDeletedEdges() {
 	g.compactDeletedEdgesLocked()
 }
 
+// CompactDeletedNodes removes soft-deleted node tombstones from the backing
+// node map to keep long-lived graphs from accumulating dead entries.
+func (g *Graph) CompactDeletedNodes() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.compactDeletedNodesLocked() {
+		g.markGraphChangedLocked()
+	}
+}
+
 // SetNodeProperty sets or updates a single property on a node.
 func (g *Graph) SetNodeProperty(id string, key string, value any) bool {
 	g.mu.Lock()
@@ -1005,6 +1015,26 @@ func edgePointerPresentLocked(edges []*Edge, target *Edge) bool {
 		}
 	}
 	return false
+}
+
+func (g *Graph) compactDeletedNodesLocked() bool {
+	removed := false
+	for id, node := range g.nodes {
+		if node != nil && node.DeletedAt == nil {
+			continue
+		}
+		for _, edge := range g.outEdges[id] {
+			g.evictEdgeIDLocked(edge)
+		}
+		for _, edge := range g.inEdges[id] {
+			g.evictEdgeIDLocked(edge)
+		}
+		delete(g.nodes, id)
+		delete(g.outEdges, id)
+		delete(g.inEdges, id)
+		removed = true
+	}
+	return removed
 }
 
 func (g *Graph) removeEdgesByNodeLocked(nodeID string) bool {

--- a/internal/graph/snapshot.go
+++ b/internal/graph/snapshot.go
@@ -57,16 +57,24 @@ func CreateSnapshot(g *Graph) *Snapshot {
 // RestoreFromSnapshot restores a graph from a snapshot
 func RestoreFromSnapshot(snapshot *Snapshot) *Graph {
 	g := New()
+	g.mu.Lock()
+	defer g.mu.Unlock()
 
 	for _, node := range snapshot.Nodes {
-		g.AddNode(node)
+		if node == nil || node.ID == "" {
+			continue
+		}
+		g.addNodeLocked(node)
 	}
 
 	for _, edge := range snapshot.Edges {
-		g.AddEdge(edge)
+		if edge == nil || edge.Source == "" || edge.Target == "" {
+			continue
+		}
+		g.addEdgeLocked(edge)
 	}
 
-	g.SetMetadata(snapshot.Metadata)
+	g.metadata = snapshot.Metadata
 
 	return g
 }

--- a/internal/graph/snapshot_restore_test.go
+++ b/internal/graph/snapshot_restore_test.go
@@ -1,0 +1,74 @@
+package graph
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRestoreFromSnapshotSkipsInvalidEntries(t *testing.T) {
+	snapshot := &Snapshot{
+		Nodes: []*Node{
+			nil,
+			{ID: "", Kind: NodeKindUser},
+			{ID: "user:alice", Kind: NodeKindUser},
+		},
+		Edges: []*Edge{
+			nil,
+			{ID: "missing-source", Target: "user:alice", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow},
+			{ID: "missing-target", Source: "user:alice", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow},
+			{ID: "valid", Source: "user:alice", Target: "user:alice", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow},
+		},
+		Metadata: Metadata{NodeCount: 1, EdgeCount: 1},
+	}
+
+	restored := RestoreFromSnapshot(snapshot)
+
+	if got := restored.NodeCount(); got != 1 {
+		t.Fatalf("NodeCount = %d, want 1", got)
+	}
+	if got := restored.EdgeCount(); got != 1 {
+		t.Fatalf("EdgeCount = %d, want 1", got)
+	}
+	if restored.Metadata().NodeCount != 1 || restored.Metadata().EdgeCount != 1 {
+		t.Fatalf("metadata not preserved, got %#v", restored.Metadata())
+	}
+}
+
+func BenchmarkRestoreFromSnapshot(b *testing.B) {
+	snapshot := benchmarkGraphSnapshot(2000, 4000)
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		restored := RestoreFromSnapshot(snapshot)
+		if restored.NodeCount() != 2000 || restored.EdgeCount() != 4000 {
+			b.Fatalf("unexpected restored counts: nodes=%d edges=%d", restored.NodeCount(), restored.EdgeCount())
+		}
+	}
+}
+
+func benchmarkGraphSnapshot(nodeCount, edgeCount int) *Snapshot {
+	g := New()
+	nodes := make([]*Node, 0, nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		nodes = append(nodes, &Node{
+			ID:   fmt.Sprintf("node:%d", i),
+			Kind: NodeKindWorkload,
+		})
+	}
+	g.AddNodesBatch(nodes)
+
+	edges := make([]*Edge, 0, edgeCount)
+	for i := 0; i < edgeCount; i++ {
+		source := fmt.Sprintf("node:%d", i%nodeCount)
+		target := fmt.Sprintf("node:%d", (i+1)%nodeCount)
+		edges = append(edges, &Edge{
+			ID:     fmt.Sprintf("edge:%d", i),
+			Source: source,
+			Target: target,
+			Kind:   EdgeKindTargets,
+			Effect: EdgeEffectAllow,
+		})
+	}
+	g.AddEdgesBatch(edges)
+	return CreateSnapshot(g)
+}

--- a/internal/graph/temporal_test.go
+++ b/internal/graph/temporal_test.go
@@ -192,3 +192,122 @@ func TestGraphTemporalNodesAliases(t *testing.T) {
 		t.Fatalf("expected NodesIncludingDeleted() to include soft-deleted nodes")
 	}
 }
+
+func TestGraphTemporalCompactDeletedNodesRemovesTombstones(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "user:alice", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:bob", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:carol", Kind: NodeKindUser})
+
+	if !g.RemoveNode("user:bob") {
+		t.Fatal("expected RemoveNode to succeed")
+	}
+	if !g.RemoveNode("user:carol") {
+		t.Fatal("expected RemoveNode to succeed")
+	}
+
+	if got := g.NodeCount(); got != 1 {
+		t.Fatalf("expected active node count 1 before compaction, got %d", got)
+	}
+	if got := len(g.GetAllNodesIncludingDeleted()); got != 3 {
+		t.Fatalf("expected 3 nodes including tombstones before compaction, got %d", got)
+	}
+
+	g.CompactDeletedNodes()
+
+	if got := g.NodeCount(); got != 1 {
+		t.Fatalf("expected active node count to stay 1 after compaction, got %d", got)
+	}
+	if got := len(g.GetAllNodesIncludingDeleted()); got != 1 {
+		t.Fatalf("expected only active nodes to remain after compaction, got %d", got)
+	}
+	if _, ok := g.GetNodeIncludingDeleted("user:bob"); ok {
+		t.Fatal("expected compacted tombstone to be removed from the node map")
+	}
+	if _, ok := g.GetNodeIncludingDeleted("user:carol"); ok {
+		t.Fatal("expected compacted tombstone to be removed from the node map")
+	}
+}
+
+func TestGraphTemporalCompactDeletedNodesRemovesAdjacencyBuckets(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "user:alice", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:bob", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:carol", Kind: NodeKindUser})
+	g.AddEdge(&Edge{ID: "alice-bob", Source: "user:alice", Target: "user:bob", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "bob-carol", Source: "user:bob", Target: "user:carol", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+
+	if !g.RemoveNode("user:bob") {
+		t.Fatal("expected RemoveNode to succeed")
+	}
+	if _, ok := g.outEdges["user:bob"]; !ok {
+		t.Fatal("expected deleted node source bucket to exist before compaction")
+	}
+	if _, ok := g.inEdges["user:bob"]; !ok {
+		t.Fatal("expected deleted node target bucket to exist before compaction")
+	}
+
+	g.CompactDeletedNodes()
+
+	if _, ok := g.outEdges["user:bob"]; ok {
+		t.Fatal("expected deleted node source bucket to be removed during compaction")
+	}
+	if _, ok := g.inEdges["user:bob"]; ok {
+		t.Fatal("expected deleted node target bucket to be removed during compaction")
+	}
+}
+
+func TestGraphTemporalCompactDeletedNodesEvictsDeletedEdgeIDs(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "user:alice", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:bob", Kind: NodeKindUser})
+	g.AddNode(&Node{ID: "user:carol", Kind: NodeKindUser})
+	g.AddEdge(&Edge{ID: "alice-bob", Source: "user:alice", Target: "user:bob", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+	g.AddEdge(&Edge{ID: "bob-carol", Source: "user:bob", Target: "user:carol", Kind: EdgeKindCanRead, Effect: EdgeEffectAllow})
+
+	if !g.RemoveNode("user:bob") {
+		t.Fatal("expected RemoveNode to succeed")
+	}
+	if _, ok := g.edgeByID["alice-bob"]; !ok {
+		t.Fatal("expected deleted edge ID to remain indexed before compaction")
+	}
+	if _, ok := g.edgeByID["bob-carol"]; !ok {
+		t.Fatal("expected deleted edge ID to remain indexed before compaction")
+	}
+
+	g.CompactDeletedNodes()
+
+	if _, ok := g.edgeByID["alice-bob"]; ok {
+		t.Fatal("expected compacted deleted source edge ID to be evicted")
+	}
+	if _, ok := g.edgeByID["bob-carol"]; ok {
+		t.Fatal("expected compacted deleted target edge ID to be evicted")
+	}
+}
+
+func TestGraphTemporalCompactDeletedNodesInvalidatesIndexOnlyOnChange(t *testing.T) {
+	g := New()
+	g.AddNode(&Node{ID: "user:alice", Kind: NodeKindUser})
+	g.BuildIndex()
+
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected index to start built")
+	}
+
+	g.CompactDeletedNodes()
+
+	if !g.IsIndexBuilt() {
+		t.Fatal("expected no-op node compaction to leave index current")
+	}
+
+	g.nodes["nil-entry"] = nil
+
+	g.CompactDeletedNodes()
+
+	if g.IsIndexBuilt() {
+		t.Fatal("expected compaction that removes entries to invalidate the index")
+	}
+	if _, ok := g.GetNodeIncludingDeleted("nil-entry"); ok {
+		t.Fatal("expected nil node entry to be removed during compaction")
+	}
+}


### PR DESCRIPTION
## Summary
- compact deleted graph nodes
- compact graph adjacency buckets with node tombstones
- evict edge IDs during node compaction

## Validation
- covered by PR CI