### PR TITLE
fix(cli): persist local scan findings and watermarks

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -362,7 +362,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 		duration  time.Duration
 	}
 	wmResultCh := make(chan watermarkResult, 1)
-	if !localMode && application.ScanWatermarks != nil {
+	if application.ScanWatermarks != nil {
 		go func() {
 			started := time.Now()
 			err := application.ScanWatermarks.PersistWatermarksWithRetry(ctx, scanner.DefaultWatermarkPersistOptions())

--- a/internal/cli/scan_local_mode.go
+++ b/internal/cli/scan_local_mode.go
@@ -325,6 +325,8 @@ func scanOneLocalTable(ctx context.Context, application *app.App, table string, 
 		assets = assets[:limit]
 	}
 
+	cursorTime, cursorID := scanner.ExtractScanCursor(assets)
+
 	result := application.Scanner.ScanAssets(tableCtx, assets)
 	profile.Batches = 1
 	profile.CacheSkipped = result.Skipped
@@ -350,6 +352,12 @@ func scanOneLocalTable(ctx context.Context, application *app.App, table string, 
 	}
 
 	if scanned > 0 {
+		if application.ScanWatermarks != nil {
+			if cursorTime.IsZero() {
+				cursorTime = time.Now().UTC()
+			}
+			application.ScanWatermarks.SetWatermark(table, cursorTime, cursorID, scanned)
+		}
 		fmt.Printf("  Scanned: %d, Violations: %d (%s)\n", scanned, violations, time.Since(start).Round(time.Millisecond))
 	}
 

--- a/internal/cli/scan_local_mode_test.go
+++ b/internal/cli/scan_local_mode_test.go
@@ -1,12 +1,15 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/writer/cerebro/internal/app"
+	"github.com/writer/cerebro/internal/findings"
 )
 
 func TestResolveLocalScanDataset_FromFixture(t *testing.T) {
@@ -102,5 +105,116 @@ func TestEvaluateScanPreflight_MissingSnowflake(t *testing.T) {
 	}
 	if len(result.MissingSnowflakeEnv) != 3 {
 		t.Fatalf("expected 3 missing env vars, got %v", result.MissingSnowflakeEnv)
+	}
+}
+
+func TestRunScan_LocalModePersistsFindingsAndWatermarksAcrossRestart(t *testing.T) {
+	state := snapshotScanCLIState()
+	t.Cleanup(func() { restoreScanCLIState(state) })
+
+	tempDir := t.TempDir()
+	policyDir := filepath.Join(tempDir, "policies")
+	if err := os.MkdirAll(policyDir, 0o750); err != nil {
+		t.Fatalf("mkdir policy dir: %v", err)
+	}
+
+	policyJSON := `{
+		"id": "local-public-bucket",
+		"name": "Local public bucket",
+		"description": "Public buckets should be flagged",
+		"effect": "forbid",
+		"resource": "aws::s3::bucket",
+		"condition_format": "cel",
+		"conditions": ["resource.public == true"],
+		"severity": "high"
+	}`
+	if err := os.WriteFile(filepath.Join(policyDir, "local-public-bucket.json"), []byte(policyJSON), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	scanTime := time.Date(2026, 3, 15, 10, 30, 0, 0, time.UTC)
+	fixturePath := filepath.Join(tempDir, "fixture.json")
+	fixture := map[string]interface{}{
+		"tables": map[string]interface{}{
+			"aws_s3_buckets": []map[string]interface{}{
+				{
+					"_cq_id":        "bucket-1",
+					"_cq_table":     "aws_s3_buckets",
+					"_cq_sync_time": scanTime.Format(time.RFC3339),
+					"type":          "aws::s3::bucket",
+					"id":            "bucket-1",
+					"name":          "public-bucket",
+					"public":        true,
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(fixturePath, data, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	t.Setenv(envCLIExecutionMode, string(cliExecutionModeDirect))
+	t.Setenv("SNOWFLAKE_PRIVATE_KEY", "")
+	t.Setenv("SNOWFLAKE_ACCOUNT", "")
+	t.Setenv("SNOWFLAKE_USER", "")
+	t.Setenv("API_AUTH_ENABLED", "false")
+	t.Setenv("API_KEYS", "")
+	t.Setenv("WAREHOUSE_BACKEND", "sqlite")
+	t.Setenv("WAREHOUSE_SQLITE_PATH", filepath.Join(tempDir, "warehouse.db"))
+	t.Setenv("EXECUTION_STORE_FILE", filepath.Join(tempDir, "executions.db"))
+	t.Setenv("GRAPH_SNAPSHOT_PATH", filepath.Join(tempDir, "graph-snapshots"))
+	t.Setenv("PLATFORM_REPORT_RUN_STATE_FILE", filepath.Join(tempDir, "report-runs.json"))
+	t.Setenv("PLATFORM_REPORT_SNAPSHOT_PATH", filepath.Join(tempDir, "report-snapshots"))
+	t.Setenv("CEREBRO_DB_PATH", filepath.Join(tempDir, "findings.db"))
+	t.Setenv("POLICIES_PATH", policyDir)
+
+	scanTables = []string{"aws_s3_buckets"}
+	scanLimit = 10
+	scanDryRun = false
+	scanOutput = FormatJSON
+	scanFull = false
+	scanToxicCombos = false
+	scanUseGraph = false
+	scanExtractRelationships = false
+	scanPreflight = false
+	scanLocalFixture = fixturePath
+	scanSnapshotDir = ""
+
+	_ = captureStdout(t, func() {
+		if err := runScan(scanCmd, nil); err != nil {
+			t.Fatalf("runScan failed: %v", err)
+		}
+	})
+
+	restarted, err := app.New(context.Background())
+	if err != nil {
+		t.Fatalf("restart app: %v", err)
+	}
+	defer func() { _ = restarted.Close() }()
+
+	if got := restarted.Findings.Stats().Total; got != 1 {
+		t.Fatalf("expected 1 persisted finding after restart, got %d", got)
+	}
+	persisted := restarted.Findings.List(findings.FindingFilter{})
+	if len(persisted) != 1 || persisted[0].PolicyID != "local-public-bucket" {
+		t.Fatalf("unexpected persisted findings after restart: %#v", persisted)
+	}
+
+	wm := restarted.ScanWatermarks.GetWatermark("aws_s3_buckets")
+	if wm == nil {
+		t.Fatal("expected persisted scan watermark after restart")
+	}
+	if !wm.LastScanTime.Equal(scanTime) {
+		t.Fatalf("expected watermark time %s, got %s", scanTime, wm.LastScanTime)
+	}
+	if wm.LastScanID != "bucket-1" {
+		t.Fatalf("expected watermark id bucket-1, got %q", wm.LastScanID)
+	}
+	if wm.RowsScanned != 1 {
+		t.Fatalf("expected watermark rows 1, got %d", wm.RowsScanned)
 	}
 }


### PR DESCRIPTION
## Summary
- persist local scan watermarks even in local mode
- persist local findings and watermarks across restarts
- add a restart regression test covering local-mode durability

## Testing
- go test ./internal/cli -run "TestRunScan_LocalModePersistsFindingsAndWatermarksAcrossRestart|TestResolveLocalScanDataset_FromFixture|TestResolveLocalScanDataset_FromSnapshotDir|TestEvaluateScanPreflight_WithLocalDataset|TestEvaluateScanPreflight_MissingSnowflake" -count=1
- golangci-lint run --timeout 10m ./internal/cli
- python3 scripts/devex.py run --mode changed --files internal/cli/scan.go internal/cli/scan_local_mode.go internal/cli/scan_local_mode_test.go

Closes #167