### PR TITLE
fix(graph): use postgres CDC queries for incremental updates

### DIFF
--- a/internal/graph/builders/builder_cdc.go
+++ b/internal/graph/builders/builder_cdc.go
@@ -82,6 +82,25 @@ func queryCDCWatermark(current cdcWatermark, since time.Time) cdcWatermark {
 	return queryWatermark
 }
 
+type cdcQuerySource interface {
+	cdcEventsTable() string
+	cdcPlaceholder(index int) string
+}
+
+func cdcEventsTable(source DataSource) string {
+	if source, ok := source.(cdcQuerySource); ok {
+		return source.cdcEventsTable()
+	}
+	return "CDC_EVENTS"
+}
+
+func cdcPlaceholder(source DataSource, index int) string {
+	if source, ok := source.(cdcQuerySource); ok {
+		return source.cdcPlaceholder(index)
+	}
+	return "?"
+}
+
 // ApplyChanges updates the current graph from CDC_EVENTS without full node reload.
 func (b *Builder) ApplyChanges(ctx context.Context, since time.Time) (GraphMutationSummary, error) {
 	if ctx == nil {
@@ -241,10 +260,10 @@ func (b *Builder) ApplyChanges(ctx context.Context, since time.Time) (GraphMutat
 }
 
 func (b *Builder) queryCDCEvents(ctx context.Context, since cdcWatermark) ([]cdcEvent, error) {
-	query := `
+	query := fmt.Sprintf(`
 		SELECT event_id, table_name, resource_id, change_type, provider, region, account_id, payload, event_time,
 		       COALESCE(ingested_at, event_time) AS ingested_at
-		FROM CDC_EVENTS`
+		FROM %s`, cdcEventsTable(b.source))
 	args := make([]any, 0, 6)
 	since = effectiveCDCWatermark(time.Time{}, since)
 	if !since.EventTime.IsZero() {
@@ -252,12 +271,19 @@ func (b *Builder) queryCDCEvents(ctx context.Context, since cdcWatermark) ([]cdc
 		if sinceIngestedAt.IsZero() {
 			sinceIngestedAt = since.EventTime
 		}
-		query += `
+		query += fmt.Sprintf(`
 		WHERE (
-			event_time > ?
-			OR (event_time = ? AND COALESCE(ingested_at, event_time) > ?)
-			OR (event_time = ? AND COALESCE(ingested_at, event_time) = ? AND event_id > ?)
-		)`
+			event_time > %s
+			OR (event_time = %s AND COALESCE(ingested_at, event_time) > %s)
+			OR (event_time = %s AND COALESCE(ingested_at, event_time) = %s AND event_id > %s)
+		)`,
+			cdcPlaceholder(b.source, 1),
+			cdcPlaceholder(b.source, 2),
+			cdcPlaceholder(b.source, 3),
+			cdcPlaceholder(b.source, 4),
+			cdcPlaceholder(b.source, 5),
+			cdcPlaceholder(b.source, 6),
+		)
 		args = append(args,
 			since.EventTime,
 			since.EventTime,
@@ -294,12 +320,12 @@ func (b *Builder) queryCDCEvents(ctx context.Context, since cdcWatermark) ([]cdc
 }
 
 func (b *Builder) queryLatestCDCWatermark(ctx context.Context) (cdcWatermark, error) {
-	result, err := b.source.Query(ctx, `
+	result, err := b.source.Query(ctx, fmt.Sprintf(`
 		SELECT event_time, COALESCE(ingested_at, event_time) AS ingested_at, event_id
-		FROM CDC_EVENTS
+		FROM %s
 		ORDER BY event_time DESC, ingested_at DESC, event_id DESC
 		LIMIT 1
-	`)
+	`, cdcEventsTable(b.source)))
 	if err != nil || len(result.Rows) == 0 {
 		return cdcWatermark{}, err
 	}

--- a/internal/graph/builders/builder_cdc_postgres_test.go
+++ b/internal/graph/builders/builder_cdc_postgres_test.go
@@ -1,0 +1,88 @@
+package builders
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/snowflake"
+)
+
+type postgresCDCQueryWarehouse struct {
+	mu      sync.Mutex
+	queries []string
+}
+
+func (w *postgresCDCQueryWarehouse) Query(ctx context.Context, query string, args ...any) (*snowflake.QueryResult, error) {
+	_ = ctx
+	_ = args
+
+	w.mu.Lock()
+	w.queries = append(w.queries, query)
+	w.mu.Unlock()
+
+	lower := strings.ToLower(query)
+	if strings.Contains(query, "?") {
+		return nil, fmt.Errorf("postgres query used snowflake placeholders: %s", query)
+	}
+	if strings.Contains(lower, "from cdc_events") && !strings.Contains(lower, "from cerebro.cdc_events") {
+		return nil, fmt.Errorf("postgres query used unqualified cdc_events table: %s", query)
+	}
+
+	return &snowflake.QueryResult{Rows: []map[string]any{}}, nil
+}
+
+func (w *postgresCDCQueryWarehouse) Dialect() string {
+	return "postgres"
+}
+
+func (w *postgresCDCQueryWarehouse) AppSchema() string {
+	return "cerebro"
+}
+
+func (w *postgresCDCQueryWarehouse) allQueries() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	out := make([]string, len(w.queries))
+	copy(out, w.queries)
+	return out
+}
+
+func TestBuilderApplyChanges_PostgresCDCQueriesUseQualifiedTableAndDollarPlaceholders(t *testing.T) {
+	warehouse := &postgresCDCQueryWarehouse{}
+	builder := NewBuilder(NewSnowflakeSource(warehouse), nil)
+
+	since := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
+	summary, err := builder.ApplyChanges(context.Background(), since)
+	if err != nil {
+		t.Fatalf("ApplyChanges failed: %v", err)
+	}
+	if summary.EventsProcessed != 0 {
+		t.Fatalf("expected no CDC events, got %d", summary.EventsProcessed)
+	}
+
+	queries := warehouse.allQueries()
+	foundCDCQuery := false
+	for _, query := range queries {
+		lower := strings.ToLower(query)
+		if !strings.Contains(lower, "cdc_events") {
+			continue
+		}
+		foundCDCQuery = true
+		if !strings.Contains(lower, "from cerebro.cdc_events") {
+			t.Fatalf("expected Postgres CDC query to qualify cerebro.cdc_events, got %q", query)
+		}
+		for idx := 1; idx <= 6; idx++ {
+			if !strings.Contains(query, fmt.Sprintf("$%d", idx)) {
+				t.Fatalf("expected Postgres CDC query to use $%d placeholder, got %q", idx, query)
+			}
+		}
+	}
+	if !foundCDCQuery {
+		t.Fatalf("expected a CDC query, got %v", queries)
+	}
+}

--- a/internal/graph/builders/snowflake_source.go
+++ b/internal/graph/builders/snowflake_source.go
@@ -2,6 +2,7 @@ package builders
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -13,12 +14,27 @@ import (
 type SnowflakeSource struct {
 	client              warehouse.QueryWarehouse
 	normalizeTableNames bool
+	cdcEventsTableRef   string
+	useDollarBinds      bool
 }
 
 // NewSnowflakeSource creates a new Snowflake data source
 func NewSnowflakeSource(client warehouse.QueryWarehouse) *SnowflakeSource {
 	_, shouldNormalize := client.(*snowflake.Client)
-	return &SnowflakeSource{client: client, normalizeTableNames: shouldNormalize}
+	source := &SnowflakeSource{client: client, normalizeTableNames: shouldNormalize}
+
+	if dialectSource, ok := client.(interface{ Dialect() string }); ok && strings.EqualFold(strings.TrimSpace(dialectSource.Dialect()), "postgres") {
+		source.useDollarBinds = true
+		source.cdcEventsTableRef = "cerebro.cdc_events"
+		if schemaSource, ok := client.(interface{ AppSchema() string }); ok {
+			schema := strings.TrimSpace(schemaSource.AppSchema())
+			if schema != "" && snowflake.ValidateTableName(schema) == nil {
+				source.cdcEventsTableRef = strings.ToLower(schema) + ".cdc_events"
+			}
+		}
+	}
+
+	return source
 }
 
 // tableNamePattern matches table names in common clauses (FROM/JOIN/UPDATE/INTO)
@@ -55,4 +71,18 @@ func (s *SnowflakeSource) Query(ctx context.Context, query string, args ...any) 
 		Rows:    result.Rows,
 		Count:   result.Count,
 	}, nil
+}
+
+func (s *SnowflakeSource) cdcEventsTable() string {
+	if strings.TrimSpace(s.cdcEventsTableRef) != "" {
+		return s.cdcEventsTableRef
+	}
+	return "CDC_EVENTS"
+}
+
+func (s *SnowflakeSource) cdcPlaceholder(index int) string {
+	if s.useDollarBinds {
+		return fmt.Sprintf("$%d", index)
+	}
+	return "?"
 }

--- a/internal/warehouse/postgres.go
+++ b/internal/warehouse/postgres.go
@@ -146,6 +146,10 @@ func (w *PostgresWarehouse) AppSchema() string {
 	return w.appSchema
 }
 
+func (w *PostgresWarehouse) Dialect() string {
+	return "postgres"
+}
+
 func (w *PostgresWarehouse) ListTables(ctx context.Context) ([]string, error) {
 	return w.listUserTables(ctx)
 }


### PR DESCRIPTION
## Summary
- use schema-qualified CDC table names for Postgres-backed incremental updates
- switch CDC placeholders to Postgres-style bind variables when the warehouse dialect is Postgres
- add a focused regression test covering Postgres CDC query generation

## Testing
- GOFLAGS=-mod=vendor go test ./internal/graph/builders -run "TestBuilderApplyChanges_PostgresCDCQueriesUseQualifiedTableAndDollarPlaceholders" -count=1
- GOFLAGS=-mod=vendor go test ./internal/warehouse -count=1
- golangci-lint run --timeout 10m ./internal/graph/builders ./internal/warehouse
- python3 scripts/devex.py run --mode changed --files internal/graph/builders/builder_cdc.go internal/graph/builders/builder_cdc_postgres_test.go internal/graph/builders/snowflake_source.go internal/warehouse/postgres.go

Closes #165