### PR TITLE
fix(app): fail fast on explicit snowflake init errors

### DIFF
--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -44,8 +45,16 @@ func (a *App) initialize(ctx context.Context) error {
 }
 
 func (a *App) initPhase1(ctx context.Context) error {
+	warehouseBackend := strings.ToLower(strings.TrimSpace(a.Config.WarehouseBackend))
+
 	if err := runInitErrorStep("warehouse", func() error { return a.initWarehouse(ctx) }); err != nil {
+		if warehouseBackend == "snowflake" {
+			return fmt.Errorf("warehouse initialization failed for backend %s: %w", warehouseBackend, err)
+		}
 		a.Logger.Warn("warehouse initialization failed", "error", err, "backend", a.Config.WarehouseBackend)
+	}
+	if warehouseBackend == "snowflake" && a.Snowflake == nil {
+		return fmt.Errorf("warehouse initialization failed for backend %s: snowflake client was not initialized", warehouseBackend)
 	}
 	if err := runInitErrorStep("policy", a.initPolicy); err != nil {
 		return err

--- a/internal/app/app_startup_test.go
+++ b/internal/app/app_startup_test.go
@@ -86,6 +86,30 @@ func TestNew_MissingSnowflakeConfigStartsWithSQLiteWarehouse(t *testing.T) {
 	}
 }
 
+func TestNew_ExplicitSnowflakeBackendFailsFastWhenSnowflakeInitFails(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("SNOWFLAKE_PRIVATE_KEY", "not-a-valid-private-key")
+	t.Setenv("SNOWFLAKE_ACCOUNT", "acct")
+	t.Setenv("SNOWFLAKE_USER", "user")
+	t.Setenv("API_AUTH_ENABLED", "false")
+	t.Setenv("API_KEYS", "")
+	t.Setenv("WAREHOUSE_BACKEND", "snowflake")
+	t.Setenv("WAREHOUSE_SQLITE_PATH", filepath.Join(tempDir, "warehouse.db"))
+	t.Setenv("EXECUTION_STORE_FILE", filepath.Join(tempDir, "executions.db"))
+	t.Setenv("GRAPH_SNAPSHOT_PATH", filepath.Join(tempDir, "graph-snapshots"))
+	t.Setenv("PLATFORM_REPORT_RUN_STATE_FILE", filepath.Join(tempDir, "report-runs.json"))
+	t.Setenv("PLATFORM_REPORT_SNAPSHOT_PATH", filepath.Join(tempDir, "report-snapshots"))
+	t.Setenv("CEREBRO_DB_PATH", filepath.Join(tempDir, "findings.db"))
+
+	_, err := New(context.Background())
+	if err == nil {
+		t.Fatal("expected startup to fail fast when WAREHOUSE_BACKEND=snowflake but snowflake initialization fails")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "snowflake") {
+		t.Fatalf("expected snowflake initialization error, got: %v", err)
+	}
+}
+
 func TestInitRBAC_InvalidStateFileFallsBackToInMemory(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "rbac-state.json")
 	if err := os.WriteFile(statePath, []byte("invalid-json"), 0o600); err != nil {


### PR DESCRIPTION
## Summary
- fail startup fast when the configured warehouse backend is snowflake and initialization fails
- prevent the app from silently proceeding with a sqlite warehouse when snowflake was explicitly requested
- add a regression test that reproduces the writer/main startup behavior and locks in the fail-fast path

## Testing
- go test ./internal/app -run "TestNew_ExplicitSnowflakeBackendFailsFastWhenSnowflakeInitFails" -count=1
- go test -count=1 ./internal/app
- golangci-lint run --timeout 10m ./internal/app
- python3 scripts/devex.py run --mode changed --files internal/app/app_init_phases.go internal/app/app_startup_test.go

Closes #164