### PR TITLE
fix(events): trace delayed retry handler failures

### DIFF
--- a/internal/events/consumer.go
+++ b/internal/events/consumer.go
@@ -594,6 +594,7 @@ func (c *Consumer) handleDecodedMessage(decoded consumerDecodedMessage) consumer
 	handlerCtx, handlerSpan := c.startTracingSpan(ingestCtx, "cerebro.event.handle", c.consumerEventAttributes(message, evt)...)
 	handlerCtx = telemetry.ContextWithAttributes(handlerCtx, c.consumerEventAttributes(message, evt)...)
 	if err := c.handler(handlerCtx, evt); err != nil {
+		consumerRecordSpanError(handlerSpan, err)
 		if delay, ok := retryDelay(err); ok && message.nakWithDelay != nil {
 			handlerSpan.End()
 			c.logger.Info("tap consumer handler deferred; message requeued with delay",
@@ -608,7 +609,6 @@ func (c *Consumer) handleDecodedMessage(decoded consumerDecodedMessage) consumer
 			}
 			return consumerMessageResult{}
 		}
-		consumerRecordSpanError(handlerSpan, err)
 		handlerSpan.End()
 		c.logger.Warn("tap consumer handler failed; message requeued", "error", err, "event_type", evt.Type)
 		if nakErr := c.consumerAckWithTracing(ingestCtx, message, evt, "nak", message.nak); nakErr != nil {

--- a/internal/events/consumer_test.go
+++ b/internal/events/consumer_test.go
@@ -1720,6 +1720,88 @@ func TestConsumerHandleMessageTracesNakOnHandlerFailure(t *testing.T) {
 	}
 }
 
+func TestConsumerHandleDecodedMessageTracesDelayedNakForRetryWithDelayErrors(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	prevProvider := otel.GetTracerProvider()
+	prevPropagator := otel.GetTextMapPropagator()
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(traceContextPropagator())
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevProvider)
+		otel.SetTextMapPropagator(prevPropagator)
+		_ = tp.Shutdown(t.Context())
+	})
+
+	const retryDelay = 5 * time.Second
+
+	consumer := &Consumer{
+		config: ConsumerConfig{
+			Stream:  "ENSEMBLE_TAP_TEST",
+			Durable: "cerebro_retry_delay_trace_test",
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		handler: func(context.Context, CloudEvent) error {
+			return RetryWithDelay(errors.New("deferred"), retryDelay)
+		},
+	}
+
+	event := CloudEvent{
+		SpecVersion: cloudEventSpecVersion,
+		ID:          "evt-retry-delay-trace-1",
+		Source:      "cerebro.events.test",
+		Type:        "tap.test",
+		Time:        time.Now().UTC(),
+		DataSchema:  "urn:cerebro:events:test",
+		TenantID:    "tenant-a",
+		TraceParent: "00-4bf92f3577b34da6a3ce929d0e0e4736-1111111111111111-01",
+	}
+	payload, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal cloud event: %v", err)
+	}
+
+	var delayedNaks atomic.Int64
+	decoded := consumer.decodePipelineMessage(context.Background(), consumerPipelineMessage{
+		subject: "ensemble.tap.retry.event",
+		payload: payload,
+		ack: func() error {
+			t.Fatal("expected deferred handler failure not to ack")
+			return nil
+		},
+		nak: func() error {
+			t.Fatal("expected deferred handler failure not to use immediate nak")
+			return nil
+		},
+		nakWithDelay: func(delay time.Duration) error {
+			if delay != retryDelay {
+				t.Fatalf("delayed nak used delay %s, want %s", delay, retryDelay)
+			}
+			delayedNaks.Add(1)
+			return nil
+		},
+		inProgress: func() error { return nil },
+	})
+
+	result := consumer.handleDecodedMessage(decoded)
+	if result.Processed {
+		t.Fatal("expected deferred handler result to remain unprocessed")
+	}
+	if delayedNaks.Load() != 1 {
+		t.Fatalf("expected one delayed nak, got %d", delayedNaks.Load())
+	}
+
+	spans := exporter.GetSpans()
+	handleSpan := testConsumerSpanByName(t, spans, "cerebro.event.handle")
+	if handleSpan.Status.Code != codes.Error {
+		t.Fatalf("handler span status = %v, want error", handleSpan.Status.Code)
+	}
+	ackSpan := testConsumerSpanByName(t, spans, "cerebro.event.ack")
+	if got, ok := testConsumerSpanAttribute(ackSpan, "cerebro.event.ack_operation"); !ok || got != "nak_with_delay" {
+		t.Fatalf("ack span operation = %q, ok=%t", got, ok)
+	}
+}
+
 func TestConsumerHandleDecodedMessageUsesDelayedNakForRetryWithDelayErrors(t *testing.T) {
 	const retryDelay = 5 * time.Second
 


### PR DESCRIPTION
## Summary
- mark consumer handler spans as errors before delayed retry handling
- add regression coverage for RetryWithDelay paths that emit nak_with_delay
- keep delayed retry semantics unchanged while restoring tracing visibility

Closes #172

## Testing
- go test ./internal/events -count=1
- /Users/jonathan/go/bin/golangci-lint run --timeout 5m ./internal/events