### PR TITLE
refactor(graph): remove EnsureIndexes implementation and related test…

### DIFF
--- a/internal/graph/store_neptune.go
+++ b/internal/graph/store_neptune.go
@@ -725,11 +725,7 @@ func (s *NeptuneGraphStore) EnsureIndexes(ctx context.Context) error {
 	if s == nil || s.exec == nil {
 		return ErrStoreUnavailable
 	}
-	for _, query := range neptuneEnsureIndexQueries() {
-		if _, err := s.exec.ExecuteOpenCypher(ctx, query, nil); err != nil {
-			return err
-		}
-	}
+	// Neptune openCypher does not support CREATE INDEX DDL.
 	return nil
 }
 
@@ -2366,46 +2362,4 @@ func neptuneTemporalRangePredicate(alias string) string {
 		"coalesce(%[1]s.valid_from, %[1]s.observed_at, %[1]s.created_at) <= $to AND (coalesce(%[1]s.valid_to, %[1]s.expires_at, %[1]s.deleted_at) IS NULL OR coalesce(%[1]s.valid_to, %[1]s.expires_at, %[1]s.deleted_at) >= $from)",
 		alias,
 	)
-}
-
-func neptuneEnsureIndexQueries() []string {
-	return []string{
-		neptuneNodeIndexQuery("id"),
-		neptuneNodeIndexQuery("kind"),
-		neptuneNodeIndexQuery("tenant_id"),
-		neptuneNodeIndexQuery("deleted_at"),
-		neptuneEdgeIndexQuery("id"),
-		neptuneEdgeIndexQuery("kind"),
-		neptuneEdgeIndexQuery("deleted_at"),
-		neptuneEdgeIndexQuery("observed_at"),
-		neptuneEdgeIndexQuery("valid_from"),
-		neptuneEdgeIndexQuery("valid_to"),
-		neptuneEdgeIndexQuery("expires_at"),
-		neptuneEdgeIndexQuery("recorded_at"),
-		neptuneEdgeIndexQuery("transaction_from"),
-		neptuneEdgeIndexQuery("transaction_to"),
-	}
-}
-
-func neptuneNodeIndexQuery(property string) string {
-	return fmt.Sprintf(
-		"CREATE INDEX %s IF NOT EXISTS FOR (n:%s) ON (n.%s)",
-		neptuneIndexName("node", property),
-		neptuneNodeLabel,
-		property,
-	)
-}
-
-func neptuneEdgeIndexQuery(property string) string {
-	return fmt.Sprintf(
-		"CREATE INDEX %s IF NOT EXISTS FOR ()-[r:%s]-() ON (r.%s)",
-		neptuneIndexName("edge", property),
-		neptuneEdgeType,
-		property,
-	)
-}
-
-func neptuneIndexName(scope, property string) string {
-	replacer := strings.NewReplacer(":", "_", "-", "_", ".", "_")
-	return fmt.Sprintf("neptune_%s_%s_idx", replacer.Replace(scope), replacer.Replace(strings.TrimSpace(property)))
 }

--- a/internal/graph/store_neptune_test.go
+++ b/internal/graph/store_neptune_test.go
@@ -1602,15 +1602,6 @@ func newTemporalTraversalTestGraph() *Graph {
 	return g
 }
 
-func neptuneCallsContainFragment(calls []fakeNeptuneCall, fragment string) bool {
-	for _, call := range calls {
-		if strings.Contains(call.query, fragment) {
-			return true
-		}
-	}
-	return false
-}
-
 func neptuneCallQueries(calls []fakeNeptuneCall) []string {
 	out := make([]string, 0, len(calls))
 	for _, call := range calls {

--- a/internal/graph/store_neptune_test.go
+++ b/internal/graph/store_neptune_test.go
@@ -1041,7 +1041,7 @@ func TestNeptuneGraphStoreTraversalMethodsUseBoundedTraversalQueries(t *testing.
 	})
 }
 
-func TestNeptuneGraphStoreEnsureIndexesCreatesCoreAndTemporalEdgeIndexes(t *testing.T) {
+func TestNeptuneGraphStoreEnsureIndexesIsNoOp(t *testing.T) {
 	exec := &fakeNeptuneExecutor{}
 	store := NewNeptuneGraphStore(exec)
 
@@ -1049,30 +1049,8 @@ func TestNeptuneGraphStoreEnsureIndexesCreatesCoreAndTemporalEdgeIndexes(t *test
 		t.Fatalf("EnsureIndexes() error = %v", err)
 	}
 
-	if len(exec.calls) < 10 {
-		t.Fatalf("EnsureIndexes() executed %d statements, want core and temporal index DDL", len(exec.calls))
-	}
-
-	wantFragments := []string{
-		"FOR (n:" + neptuneNodeLabel + ") ON (n.id)",
-		"FOR (n:" + neptuneNodeLabel + ") ON (n.kind)",
-		"FOR (n:" + neptuneNodeLabel + ") ON (n.tenant_id)",
-		"FOR (n:" + neptuneNodeLabel + ") ON (n.deleted_at)",
-		"FOR ()-[r:" + neptuneEdgeType + "]-() ON (r.id)",
-		"FOR ()-[r:" + neptuneEdgeType + "]-() ON (r.kind)",
-		"FOR ()-[r:" + neptuneEdgeType + "]-() ON (r.deleted_at)",
-		"FOR ()-[r:" + neptuneEdgeType + "]-() ON (r.observed_at)",
-		"FOR ()-[r:" + neptuneEdgeType + "]-() ON (r.valid_from)",
-		"FOR ()-[r:" + neptuneEdgeType + "]-() ON (r.valid_to)",
-		"FOR ()-[r:" + neptuneEdgeType + "]-() ON (r.expires_at)",
-		"FOR ()-[r:" + neptuneEdgeType + "]-() ON (r.recorded_at)",
-		"FOR ()-[r:" + neptuneEdgeType + "]-() ON (r.transaction_from)",
-		"FOR ()-[r:" + neptuneEdgeType + "]-() ON (r.transaction_to)",
-	}
-	for _, fragment := range wantFragments {
-		if !neptuneCallsContainFragment(exec.calls, fragment) {
-			t.Fatalf("EnsureIndexes() missing index DDL fragment %q in calls %#v", fragment, neptuneCallQueries(exec.calls))
-		}
+	if len(exec.calls) != 0 {
+		t.Fatalf("EnsureIndexes() executed %d statements, want 0", len(exec.calls))
 	}
 }
 


### PR DESCRIPTION
…s for NeptuneGraphStore

The EnsureIndexes method is now a no-op as Neptune's openCypher does not support CREATE INDEX DDL. Updated the corresponding test to reflect this change, ensuring it verifies that no statements are executed.