### PR TITLE
fix(scan): use warehouse-backed direct scans

### DIFF
--- a/internal/app/app_scan_scheduler.go
+++ b/internal/app/app_scan_scheduler.go
@@ -271,7 +271,7 @@ func (a *App) runScheduledGraphAnalyses(ctx context.Context, tuning ScanTuning, 
 
 func (a *App) runScheduledScan(ctx context.Context, tables []string) error {
 	if a.Warehouse == nil {
-		return fmt.Errorf("snowflake not configured")
+		return fmt.Errorf("warehouse not configured")
 	}
 
 	scanStart := time.Now()

--- a/internal/cli/row_helpers.go
+++ b/internal/cli/row_helpers.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"strings"
+	"time"
+)
+
+func scheduleRowValue(row map[string]interface{}, key string) interface{} {
+	for candidate, value := range row {
+		if strings.EqualFold(candidate, key) {
+			return value
+		}
+	}
+	return nil
+}
+
+func getTime(row map[string]interface{}, key string) time.Time {
+	switch value := scheduleRowValue(row, key).(type) {
+	case time.Time:
+		return value.UTC()
+	case *time.Time:
+		if value != nil {
+			return value.UTC()
+		}
+	case string:
+		if value == "" {
+			return time.Time{}
+		}
+		if ts, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return ts.UTC()
+		}
+		if ts, err := time.Parse(time.RFC3339, value); err == nil {
+			return ts.UTC()
+		}
+		if ts, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", value); err == nil {
+			return ts.UTC()
+		}
+		if ts, err := time.Parse("2006-01-02 15:04:05.999999999", value); err == nil {
+			return ts.UTC()
+		}
+		if ts, err := time.Parse("2006-01-02 15:04:05", value); err == nil {
+			return ts.UTC()
+		}
+	case []byte:
+		text := string(value)
+		if text == "" {
+			return time.Time{}
+		}
+		if ts, err := time.Parse(time.RFC3339Nano, text); err == nil {
+			return ts.UTC()
+		}
+		if ts, err := time.Parse(time.RFC3339, text); err == nil {
+			return ts.UTC()
+		}
+		if ts, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", text); err == nil {
+			return ts.UTC()
+		}
+		if ts, err := time.Parse("2006-01-02 15:04:05.999999999", text); err == nil {
+			return ts.UTC()
+		}
+		if ts, err := time.Parse("2006-01-02 15:04:05", text); err == nil {
+			return ts.UTC()
+		}
+	}
+	return time.Time{}
+}

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -19,12 +19,13 @@ import (
 	"github.com/writer/cerebro/internal/scanner"
 	"github.com/writer/cerebro/internal/snowflake"
 	nativesync "github.com/writer/cerebro/internal/sync"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 var scanCmd = &cobra.Command{
 	Use:   "scan",
 	Short: "Scan assets against security policies",
-	Long: `Scan cloud assets from Snowflake against Cedar security policies.
+	Long: `Scan cloud assets from the configured warehouse against Cedar security policies.
 
 Examples:
   cerebro scan                           # Scan all tables
@@ -70,7 +71,7 @@ func init() {
 	scanCmd.Flags().BoolVar(&scanUseGraph, "graph", true, "Use security graph for enhanced analysis (attack paths, blast radius)")
 	scanCmd.Flags().BoolVar(&scanExtractRelationships, "extract-relationships", false, "Extract resource relationships before scanning")
 	scanCmd.Flags().BoolVar(&scanPreflight, "preflight", false, "Validate scan prerequisites and exit")
-	scanCmd.Flags().StringVar(&scanLocalFixture, "local-fixture", "", "Path to local scan fixture JSON (table->assets) for scanning without Snowflake")
+	scanCmd.Flags().StringVar(&scanLocalFixture, "local-fixture", "", "Path to local scan fixture JSON (table->assets) for scanning without a live warehouse")
 	scanCmd.Flags().StringVar(&scanSnapshotDir, "snapshot-dir", "", "Directory containing provider snapshot JSON files (<table>.json) for local scan mode")
 }
 
@@ -117,7 +118,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 		return runScanPreflight(application, localDataset)
 	}
 
-	if application.Snowflake == nil && !localMode && (mode == cliExecutionModeDirect || !apiCompatible || apiFallbackToDirect) {
+	if application.Warehouse == nil && !localMode && (mode == cliExecutionModeDirect || !apiCompatible || apiFallbackToDirect) {
 		preflight := evaluateScanPreflight(application, nil)
 		return fmt.Errorf("scan preflight failed: %s (run 'cerebro scan --preflight' for details)", preflight.Message)
 	}
@@ -128,11 +129,11 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	// Extract relationships if requested
 	if scanExtractRelationships {
-		if application.Snowflake == nil {
-			Warning("Skipping relationship extraction in local scan mode (Snowflake not configured)")
+		if application.Warehouse == nil {
+			Warning("Skipping relationship extraction in local scan mode (warehouse not configured)")
 		} else {
 			Info("Extracting resource relationships from synced data...")
-			relExtractor := nativesync.NewRelationshipExtractor(application.Snowflake, application.Logger)
+			relExtractor := nativesync.NewRelationshipExtractor(application.Warehouse, application.Logger)
 			relCount, err := relExtractor.ExtractAndPersist(ctx)
 			if err != nil {
 				Warning("Relationship extraction had errors: %v", err)
@@ -169,8 +170,8 @@ func runScan(cmd *cobra.Command, args []string) error {
 	if localMode {
 		availableTables = sortedDatasetTables(localDataset)
 		application.AvailableTables = append([]string(nil), availableTables...)
-	} else if application.Snowflake != nil {
-		if tables, err := application.Snowflake.ListAvailableTables(ctx); err == nil {
+	} else if application.Warehouse != nil {
+		if tables, err := application.Warehouse.ListAvailableTables(ctx); err == nil {
 			application.AvailableTables = tables
 			availableTables = tables
 		} else {
@@ -197,7 +198,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 		tables = nativesync.SupportedTableNames()
 	}
 
-	// Filter to only tables that actually exist in Snowflake
+	// Filter to only tables that actually exist in the configured warehouse
 	if len(availableSet) > 0 {
 		var valid []string
 		skipped := 0
@@ -212,7 +213,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 			if localMode {
 				Info("Skipped %d tables not present in local dataset", skipped)
 			} else {
-				Info("Skipped %d tables not present in Snowflake", skipped)
+				Info("Skipped %d tables not present in the configured warehouse", skipped)
 			}
 		}
 		tables = valid
@@ -310,14 +311,14 @@ func runScan(cmd *cobra.Command, args []string) error {
 	sqlToxicRiskSets := make(map[string][]map[string]bool)
 
 	// Relationship-based toxic combination detection (SQL query approach)
-	if !localMode && scanToxicCombos && application.Snowflake != nil {
+	if !localMode && scanToxicCombos && warehouse.Dialect(application.Warehouse) == warehouse.SQLDialectSnowflake {
 		var toxicCursor *scanner.ToxicScanCursor
 		if application.ScanWatermarks != nil {
 			if wm := application.ScanWatermarks.GetWatermark("_toxic_relationships"); wm != nil {
 				toxicCursor = &scanner.ToxicScanCursor{SinceTime: wm.LastScanTime, SinceID: wm.LastScanID}
 			}
 		}
-		toxicResult, err := scanner.DetectRelationshipToxicCombinations(ctx, application.Snowflake, toxicCursor)
+		toxicResult, err := scanner.DetectRelationshipToxicCombinations(ctx, application.Warehouse, toxicCursor)
 		if err != nil {
 			Warning("Failed to detect toxic combinations from relationships: %v", err)
 		} else if len(toxicResult.Findings) > 0 {
@@ -935,7 +936,7 @@ func runScanViaAPI(ctx context.Context, tables []string) error {
 	return nil
 }
 
-// scanOneTable fetches assets from one Snowflake table, evaluates policies, and returns results.
+// scanOneTable fetches assets from one warehouse table, evaluates policies, and returns results.
 func scanOneTable(ctx context.Context, application *app.App, table string, full bool, limit int, toxicCombos, graphAvailable bool, tuning app.ScanTuning) (scanned, violations int64, findings []map[string]interface{}, profile scanner.TableScanProfile) {
 	fmt.Printf("\n%s Scanning %s...\n", color(colorCyan, "→"), table)
 
@@ -968,54 +969,40 @@ func scanOneTable(ctx context.Context, application *app.App, table string, full 
 	}
 
 	filter := snowflake.AssetFilter{Limit: batchSize, Columns: columns}
-	useCDC := false
-	var cdcCursor time.Time
-	var cdcIDs []string
-
 	if !full && application.ScanWatermarks != nil {
 		if wm := application.ScanWatermarks.GetWatermark(table); wm != nil {
 			filter.Since = wm.LastScanTime
 			filter.SinceID = wm.LastScanID
-
-			cdcEvents, attempts, err := scanner.WithRetryValue(tableCtx, tuning.RetryOptions, func() ([]snowflake.CDCEvent, error) {
-				return application.Snowflake.GetCDCEvents(tableCtx, table, wm.LastScanTime, batchSize)
-			})
-			profile.RetryAttempts += retryCount(attempts)
-			if err != nil {
-				profile.FetchErrors++
-				Warning("Failed to query CDC events for %s, falling back to sync_time: %v", table, err)
-			} else if len(cdcEvents) > 0 && len(cdcEvents) < batchSize {
-				useCDC = true
-				cdcIDs, cdcCursor = filterCDCEvents(cdcEvents)
-			}
 		}
 	}
 
 	remaining := int64(limit)
 	var cursorTime time.Time
 	var cursorID string
-
-	if useCDC && !full {
-		if len(cdcIDs) == 0 {
-			if !cdcCursor.IsZero() && application.ScanWatermarks != nil {
-				application.ScanWatermarks.SetWatermark(table, cdcCursor, "", 0)
-			}
-			fmt.Printf("  No assets to scan for CDC changes\n")
-			return 0, 0, nil, profile
+	for !limitActive || remaining > 0 {
+		if tableCtx.Err() != nil {
+			break
+		}
+		if limitActive && remaining < int64(batchSize) {
+			filter.Limit = int(remaining)
+		} else {
+			filter.Limit = batchSize
 		}
 
 		assets, attempts, err := scanner.WithRetryValue(tableCtx, tuning.RetryOptions, func() ([]map[string]interface{}, error) {
-			return application.Snowflake.GetAssetsByIDs(tableCtx, table, cdcIDs, columns)
+			return application.Warehouse.GetAssets(tableCtx, table, filter)
 		})
 		profile.RetryAttempts += retryCount(attempts)
 		if err != nil {
 			profile.FetchErrors++
 			Warning("Failed to fetch %s: %v", table, err)
-			return 0, 0, nil, profile
+			break
 		}
 		if len(assets) == 0 {
-			fmt.Printf("  No new assets found\n")
-			return 0, 0, nil, profile
+			if scanned == 0 {
+				fmt.Printf("  No new assets found\n")
+			}
+			break
 		}
 
 		result := application.Scanner.ScanAssets(tableCtx, assets)
@@ -1042,88 +1029,35 @@ func scanOneTable(ctx context.Context, application *app.App, table string, full 
 			}
 		}
 
-		cursorTime, cursorID = scanner.ExtractScanCursor(assets)
-	} else {
-		for !limitActive || remaining > 0 {
-			if tableCtx.Err() != nil {
+		batchTime, batchID := scanner.ExtractScanCursor(assets)
+		if scanner.IsCursorAfter(batchTime, batchID, cursorTime, cursorID) {
+			cursorTime = batchTime
+			cursorID = batchID
+		}
+
+		// Advance cursor for next batch (keyset pagination).
+		if !filter.Since.IsZero() {
+			if batchTime.IsZero() {
 				break
 			}
-			if limitActive && remaining < int64(batchSize) {
-				filter.Limit = int(remaining)
-			} else {
-				filter.Limit = batchSize
-			}
-
-			assets, attempts, err := scanner.WithRetryValue(tableCtx, tuning.RetryOptions, func() ([]map[string]interface{}, error) {
-				return application.Snowflake.GetAssets(tableCtx, table, filter)
-			})
-			profile.RetryAttempts += retryCount(attempts)
-			if err != nil {
-				profile.FetchErrors++
-				Warning("Failed to fetch %s: %v", table, err)
+			filter.Since = batchTime
+			filter.SinceID = batchID
+		} else {
+			if batchTime.IsZero() {
 				break
 			}
-			if len(assets) == 0 {
-				if scanned == 0 {
-					fmt.Printf("  No new assets found\n")
-				}
+			filter.CursorSyncTime = batchTime
+			filter.CursorID = batchID
+		}
+
+		if limitActive {
+			remaining -= result.Scanned
+			if remaining <= 0 {
 				break
 			}
-
-			result := application.Scanner.ScanAssets(tableCtx, assets)
-			profile.Batches++
-			profile.CacheSkipped += result.Skipped
-			profile.ScanErrors += len(result.Errors)
-			scanned += result.Scanned
-			violations += result.Violations
-
-			for _, f := range result.Findings {
-				application.Findings.Upsert(tableCtx, f)
-				findings = append(findings, policyFindingToMap(f, findingSourcePolicy, nil))
-			}
-
-			if toxicCombos && !graphAvailable {
-				toxicFindings := application.Scanner.DetectToxicCombinations(tableCtx, assets)
-				violations += int64(len(toxicFindings))
-				for _, f := range toxicFindings {
-					application.Findings.Upsert(tableCtx, f)
-					findings = append(findings, policyFindingToMap(f, findingSourceToxicCombo, map[string]interface{}{
-						"toxic_combo": true,
-						"graph_based": false,
-					}))
-				}
-			}
-
-			batchTime, batchID := scanner.ExtractScanCursor(assets)
-			if scanner.IsCursorAfter(batchTime, batchID, cursorTime, cursorID) {
-				cursorTime = batchTime
-				cursorID = batchID
-			}
-
-			// Advance cursor for next batch (keyset pagination)
-			if !filter.Since.IsZero() {
-				if batchTime.IsZero() {
-					break
-				}
-				filter.Since = batchTime
-				filter.SinceID = batchID
-			} else {
-				if batchTime.IsZero() {
-					break
-				}
-				filter.CursorSyncTime = batchTime
-				filter.CursorID = batchID
-			}
-
-			if limitActive {
-				remaining -= result.Scanned
-				if remaining <= 0 {
-					break
-				}
-			}
-			if len(assets) < filter.Limit {
-				break
-			}
+		}
+		if len(assets) < filter.Limit {
+			break
 		}
 	}
 
@@ -1137,12 +1071,6 @@ func scanOneTable(ctx context.Context, application *app.App, table string, full 
 	}
 
 	if application.ScanWatermarks != nil && scanned > 0 {
-		if useCDC && !full && !cdcCursor.IsZero() {
-			if scanner.IsCursorAfter(cdcCursor, "", cursorTime, cursorID) {
-				cursorTime = cdcCursor
-				cursorID = ""
-			}
-		}
 		if cursorTime.IsZero() {
 			cursorTime = time.Now().UTC()
 		}

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -969,10 +969,28 @@ func scanOneTable(ctx context.Context, application *app.App, table string, full 
 	}
 
 	filter := snowflake.AssetFilter{Limit: batchSize, Columns: columns}
+	var cdcCursor time.Time
 	if !full && application.ScanWatermarks != nil {
 		if wm := application.ScanWatermarks.GetWatermark(table); wm != nil {
 			filter.Since = wm.LastScanTime
 			filter.SinceID = wm.LastScanID
+
+			cdcEvents, attempts, err := scanner.WithRetryValue(tableCtx, tuning.RetryOptions, func() ([]snowflake.CDCEvent, error) {
+				return loadWarehouseCDCEvents(tableCtx, application, table, wm.LastScanTime, batchSize)
+			})
+			profile.RetryAttempts += retryCount(attempts)
+			if err != nil {
+				profile.FetchErrors++
+				Warning("Failed to query CDC events for %s, falling back to sync_time: %v", table, err)
+			} else if len(cdcEvents) > 0 && len(cdcEvents) < batchSize {
+				cdcIDs, maxCDCEventTime := filterCDCEvents(cdcEvents)
+				cdcCursor = maxCDCEventTime
+				if len(cdcIDs) == 0 && !cdcCursor.IsZero() {
+					application.ScanWatermarks.SetWatermark(table, cdcCursor, "", 0)
+					fmt.Printf("  No assets to scan for CDC changes\n")
+					return 0, 0, nil, profile
+				}
+			}
 		}
 	}
 
@@ -1071,6 +1089,10 @@ func scanOneTable(ctx context.Context, application *app.App, table string, full 
 	}
 
 	if application.ScanWatermarks != nil && scanned > 0 {
+		if !cdcCursor.IsZero() && scanner.IsCursorAfter(cdcCursor, "", cursorTime, cursorID) {
+			cursorTime = cdcCursor
+			cursorID = ""
+		}
 		if cursorTime.IsZero() {
 			cursorTime = time.Now().UTC()
 		}

--- a/internal/cli/scan_helpers.go
+++ b/internal/cli/scan_helpers.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 	"github.com/writer/cerebro/internal/policy"
 	"github.com/writer/cerebro/internal/scanner"
 	"github.com/writer/cerebro/internal/snowflake"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 func sevRank(sev string) int {
@@ -565,6 +567,49 @@ func filterCDCEvents(events []snowflake.CDCEvent) ([]string, time.Time) {
 	}
 
 	return dedupeStrings(ids), maxTime
+}
+
+func loadWarehouseCDCEvents(ctx context.Context, application *app.App, table string, since time.Time, limit int) ([]snowflake.CDCEvent, error) {
+	if application == nil || application.Warehouse == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 1000
+	}
+
+	query := `SELECT resource_id, change_type, event_time FROM cdc_events`
+	var (
+		conditions []string
+		args       []any
+	)
+	if table = strings.TrimSpace(table); table != "" {
+		conditions = append(conditions, "table_name = "+warehouse.Placeholder(application.Warehouse, len(args)+1))
+		args = append(args, table)
+	}
+	if !since.IsZero() {
+		conditions = append(conditions, "event_time > "+warehouse.Placeholder(application.Warehouse, len(args)+1))
+		args = append(args, since)
+	}
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	query += " ORDER BY event_time ASC LIMIT " + warehouse.Placeholder(application.Warehouse, len(args)+1)
+	args = append(args, limit)
+
+	result, err := application.Warehouse.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	events := make([]snowflake.CDCEvent, 0, len(result.Rows))
+	for _, row := range result.Rows {
+		events = append(events, snowflake.CDCEvent{
+			TableName:  table,
+			ResourceID: strings.TrimSpace(toString(row["resource_id"])),
+			ChangeType: strings.TrimSpace(toString(row["change_type"])),
+			EventTime:  getTime(row, "event_time"),
+		})
+	}
+	return events, nil
 }
 
 func dedupeStrings(values []string) []string {

--- a/internal/cli/scan_local_mode.go
+++ b/internal/cli/scan_local_mode.go
@@ -21,15 +21,13 @@ type localScanDataset struct {
 }
 
 type scanPreflightResult struct {
-	Ready               bool     `json:"ready"`
-	Mode                string   `json:"mode"`
-	Message             string   `json:"message"`
-	SnowflakeConfigured bool     `json:"snowflake_configured"`
-	SnowflakeConnected  bool     `json:"snowflake_connected"`
-	MissingSnowflakeEnv []string `json:"missing_snowflake_env,omitempty"`
-	LocalDatasetLoaded  bool     `json:"local_dataset_loaded"`
-	LocalDatasetTables  int      `json:"local_dataset_tables,omitempty"`
-	LocalDatasetSource  string   `json:"local_dataset_source,omitempty"`
+	Ready              bool   `json:"ready"`
+	Mode               string `json:"mode"`
+	Message            string `json:"message"`
+	WarehouseConnected bool   `json:"warehouse_connected"`
+	LocalDatasetLoaded bool   `json:"local_dataset_loaded"`
+	LocalDatasetTables int    `json:"local_dataset_tables,omitempty"`
+	LocalDatasetSource string `json:"local_dataset_source,omitempty"`
 }
 
 func resolveLocalScanDataset() (*localScanDataset, error) {
@@ -208,7 +206,6 @@ func sortedDatasetTables(dataset *localScanDataset) []string {
 }
 
 func evaluateScanPreflight(application *app.App, dataset *localScanDataset) scanPreflightResult {
-	missing := missingSnowflakeEnv(application.Config)
 	localTables := 0
 	localSource := ""
 	if dataset != nil {
@@ -217,12 +214,10 @@ func evaluateScanPreflight(application *app.App, dataset *localScanDataset) scan
 	}
 
 	result := scanPreflightResult{
-		SnowflakeConfigured: len(missing) == 0,
-		SnowflakeConnected:  application.Snowflake != nil,
-		MissingSnowflakeEnv: missing,
-		LocalDatasetLoaded:  localTables > 0,
-		LocalDatasetTables:  localTables,
-		LocalDatasetSource:  localSource,
+		WarehouseConnected: application != nil && application.Warehouse != nil,
+		LocalDatasetLoaded: localTables > 0,
+		LocalDatasetTables: localTables,
+		LocalDatasetSource: localSource,
 	}
 
 	if result.LocalDatasetLoaded {
@@ -232,37 +227,15 @@ func evaluateScanPreflight(application *app.App, dataset *localScanDataset) scan
 		return result
 	}
 
-	result.Mode = "snowflake"
-	if result.SnowflakeConnected {
+	result.Mode = "warehouse"
+	if result.WarehouseConnected {
 		result.Ready = true
-		result.Message = "ready: snowflake scan mode available"
+		result.Message = "ready: direct warehouse scan mode available"
 		return result
 	}
 
-	if len(result.MissingSnowflakeEnv) > 0 {
-		result.Message = fmt.Sprintf("missing required snowflake env vars: %s", strings.Join(result.MissingSnowflakeEnv, ", "))
-	} else {
-		result.Message = "snowflake credentials are set but connection failed"
-	}
+	result.Message = "warehouse not configured"
 	return result
-}
-
-func missingSnowflakeEnv(cfg *app.Config) []string {
-	if cfg == nil {
-		return []string{"SNOWFLAKE_PRIVATE_KEY", "SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER"}
-	}
-
-	missing := make([]string, 0, 3)
-	if strings.TrimSpace(cfg.SnowflakePrivateKey) == "" {
-		missing = append(missing, "SNOWFLAKE_PRIVATE_KEY")
-	}
-	if strings.TrimSpace(cfg.SnowflakeAccount) == "" {
-		missing = append(missing, "SNOWFLAKE_ACCOUNT")
-	}
-	if strings.TrimSpace(cfg.SnowflakeUser) == "" {
-		missing = append(missing, "SNOWFLAKE_USER")
-	}
-	return missing
 }
 
 func runScanPreflight(application *app.App, dataset *localScanDataset) error {
@@ -277,14 +250,11 @@ func runScanPreflight(application *app.App, dataset *localScanDataset) error {
 		fmt.Println(strings.Repeat("-", 40))
 		fmt.Printf("Mode:                %s\n", result.Mode)
 		fmt.Printf("Ready:               %t\n", result.Ready)
-		fmt.Printf("Snowflake connected: %t\n", result.SnowflakeConnected)
+		fmt.Printf("Warehouse connected: %t\n", result.WarehouseConnected)
 		fmt.Printf("Local dataset:       %t\n", result.LocalDatasetLoaded)
 		if result.LocalDatasetLoaded {
 			fmt.Printf("  Tables:            %d\n", result.LocalDatasetTables)
 			fmt.Printf("  Source:            %s\n", result.LocalDatasetSource)
-		}
-		if len(result.MissingSnowflakeEnv) > 0 {
-			fmt.Printf("Missing env vars:    %s\n", strings.Join(result.MissingSnowflakeEnv, ", "))
 		}
 		fmt.Printf("Message:             %s\n", result.Message)
 	}

--- a/internal/cli/scan_local_mode_test.go
+++ b/internal/cli/scan_local_mode_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/writer/cerebro/internal/app"
 	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 func TestResolveLocalScanDataset_FromFixture(t *testing.T) {
@@ -96,15 +97,42 @@ func TestEvaluateScanPreflight_WithLocalDataset(t *testing.T) {
 	}
 }
 
-func TestEvaluateScanPreflight_MissingSnowflake(t *testing.T) {
+func TestEvaluateScanPreflight_MissingWarehouse(t *testing.T) {
 	application := &app.App{Config: &app.Config{}}
 
 	result := evaluateScanPreflight(application, nil)
 	if result.Ready {
 		t.Fatalf("expected preflight not ready, got ready: %+v", result)
 	}
-	if len(result.MissingSnowflakeEnv) != 3 {
-		t.Fatalf("expected 3 missing env vars, got %v", result.MissingSnowflakeEnv)
+	if result.Mode != "warehouse" {
+		t.Fatalf("expected warehouse mode, got %s", result.Mode)
+	}
+	if result.WarehouseConnected {
+		t.Fatalf("expected warehouse to be disconnected, got %+v", result)
+	}
+	if result.Message != "warehouse not configured" {
+		t.Fatalf("unexpected preflight message %q", result.Message)
+	}
+}
+
+func TestEvaluateScanPreflight_WithWarehouse(t *testing.T) {
+	application := &app.App{
+		Config:    &app.Config{},
+		Warehouse: &warehouse.MemoryWarehouse{SchemaValue: "RAW"},
+	}
+
+	result := evaluateScanPreflight(application, nil)
+	if !result.Ready {
+		t.Fatalf("expected preflight ready, got %+v", result)
+	}
+	if result.Mode != "warehouse" {
+		t.Fatalf("expected warehouse mode, got %s", result.Mode)
+	}
+	if !result.WarehouseConnected {
+		t.Fatalf("expected warehouse to be connected, got %+v", result)
+	}
+	if result.Message != "ready: direct warehouse scan mode available" {
+		t.Fatalf("unexpected preflight message %q", result.Message)
 	}
 }
 
@@ -201,6 +229,126 @@ func TestRunScan_LocalModePersistsFindingsAndWatermarksAcrossRestart(t *testing.
 	}
 	persisted := restarted.Findings.List(findings.FindingFilter{})
 	if len(persisted) != 1 || persisted[0].PolicyID != "local-public-bucket" {
+		t.Fatalf("unexpected persisted findings after restart: %#v", persisted)
+	}
+
+	wm := restarted.ScanWatermarks.GetWatermark("aws_s3_buckets")
+	if wm == nil {
+		t.Fatal("expected persisted scan watermark after restart")
+	}
+	if !wm.LastScanTime.Equal(scanTime) {
+		t.Fatalf("expected watermark time %s, got %s", scanTime, wm.LastScanTime)
+	}
+	if wm.LastScanID != "bucket-1" {
+		t.Fatalf("expected watermark id bucket-1, got %q", wm.LastScanID)
+	}
+	if wm.RowsScanned != 1 {
+		t.Fatalf("expected watermark rows 1, got %d", wm.RowsScanned)
+	}
+}
+
+func TestRunScan_WarehouseModePersistsFindingsAndWatermarksAcrossRestart(t *testing.T) {
+	state := snapshotScanCLIState()
+	t.Cleanup(func() { restoreScanCLIState(state) })
+
+	tempDir := t.TempDir()
+	policyDir := filepath.Join(tempDir, "policies")
+	if err := os.MkdirAll(policyDir, 0o750); err != nil {
+		t.Fatalf("mkdir policy dir: %v", err)
+	}
+
+	policyJSON := `{
+		"id": "warehouse-name-match",
+		"name": "Warehouse name match",
+		"description": "Warehouse-backed scans should evaluate policies without Snowflake",
+		"effect": "forbid",
+		"resource": "aws::s3::bucket",
+		"condition_format": "cel",
+		"conditions": ["resource.name == 'public-bucket'"],
+		"severity": "high"
+	}`
+	if err := os.WriteFile(filepath.Join(policyDir, "warehouse-name-match.json"), []byte(policyJSON), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	warehousePath := filepath.Join(tempDir, "warehouse.db")
+	store, err := warehouse.NewSQLiteWarehouse(warehouse.SQLiteWarehouseConfig{Path: warehousePath})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	scanTime := time.Date(2026, 3, 16, 9, 45, 0, 0, time.UTC)
+	if _, err := store.Exec(context.Background(), `
+		CREATE TABLE aws_s3_buckets (
+			_cq_id TEXT,
+			_cq_sync_time TEXT,
+			id TEXT,
+			type TEXT,
+			name TEXT
+		)
+	`); err != nil {
+		t.Fatalf("create warehouse table: %v", err)
+	}
+	if _, err := store.Exec(
+		context.Background(),
+		`INSERT INTO aws_s3_buckets (_cq_id, _cq_sync_time, id, type, name) VALUES (?, ?, ?, ?, ?)`,
+		"bucket-1",
+		scanTime.Format(time.RFC3339Nano),
+		"bucket-1",
+		"aws::s3::bucket",
+		"public-bucket",
+	); err != nil {
+		t.Fatalf("insert warehouse asset: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close seeded warehouse: %v", err)
+	}
+
+	t.Setenv(envCLIExecutionMode, string(cliExecutionModeDirect))
+	t.Setenv("SNOWFLAKE_PRIVATE_KEY", "")
+	t.Setenv("SNOWFLAKE_ACCOUNT", "")
+	t.Setenv("SNOWFLAKE_USER", "")
+	t.Setenv("API_AUTH_ENABLED", "false")
+	t.Setenv("API_KEYS", "")
+	t.Setenv("WAREHOUSE_BACKEND", "sqlite")
+	t.Setenv("WAREHOUSE_SQLITE_PATH", warehousePath)
+	t.Setenv("EXECUTION_STORE_FILE", filepath.Join(tempDir, "executions.db"))
+	t.Setenv("GRAPH_SNAPSHOT_PATH", filepath.Join(tempDir, "graph-snapshots"))
+	t.Setenv("PLATFORM_REPORT_RUN_STATE_FILE", filepath.Join(tempDir, "report-runs.json"))
+	t.Setenv("PLATFORM_REPORT_SNAPSHOT_PATH", filepath.Join(tempDir, "report-snapshots"))
+	t.Setenv("CEREBRO_DB_PATH", filepath.Join(tempDir, "findings.db"))
+	t.Setenv("POLICIES_PATH", policyDir)
+
+	scanTables = []string{"aws_s3_buckets"}
+	scanLimit = 10
+	scanDryRun = false
+	scanOutput = FormatJSON
+	scanFull = false
+	scanToxicCombos = false
+	scanUseGraph = false
+	scanExtractRelationships = false
+	scanPreflight = false
+	scanLocalFixture = ""
+	scanSnapshotDir = ""
+
+	_ = captureStdout(t, func() {
+		if err := runScan(scanCmd, nil); err != nil {
+			t.Fatalf("runScan failed: %v", err)
+		}
+	})
+
+	restarted, err := app.New(context.Background())
+	if err != nil {
+		t.Fatalf("restart app: %v", err)
+	}
+	defer func() { _ = restarted.Close() }()
+
+	if got := restarted.Findings.Stats().Total; got != 1 {
+		t.Fatalf("expected 1 persisted finding after restart, got %d", got)
+	}
+	persisted := restarted.Findings.List(findings.FindingFilter{})
+	if len(persisted) != 1 || persisted[0].PolicyID != "warehouse-name-match" {
 		t.Fatalf("unexpected persisted findings after restart: %#v", persisted)
 	}
 

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -1,13 +1,18 @@
 package cli
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/writer/cerebro/internal/app"
 	"github.com/writer/cerebro/internal/policy"
 	"github.com/writer/cerebro/internal/scanner"
 	"github.com/writer/cerebro/internal/snowflake"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 func TestResourceToTables_KnownMappings(t *testing.T) {
@@ -408,6 +413,62 @@ func TestFilterCDCEvents_Empty(t *testing.T) {
 	}
 	if !maxTime.IsZero() {
 		t.Errorf("maxTime should be zero")
+	}
+}
+
+func TestScanOneTableAdvancesWatermarkForDeleteOnlyCDCWindow(t *testing.T) {
+	deleteTime := time.Date(2026, 3, 18, 12, 0, 0, 0, time.UTC)
+	wm := scanner.NewWatermarkStore(nil)
+	wm.SetWatermark("aws_s3_buckets", deleteTime.Add(-time.Hour), "bucket-old", 1)
+
+	store := &warehouse.MemoryWarehouse{
+		DialectValue: warehouse.SQLDialectSQLite,
+		QueryFunc: func(_ context.Context, query string, args ...any) (*snowflake.QueryResult, error) {
+			if !strings.Contains(strings.ToLower(query), "cdc_events") {
+				t.Fatalf("expected CDC query, got %q", query)
+			}
+			return &snowflake.QueryResult{
+				Rows: []map[string]any{
+					{
+						"resource_id": "bucket-deleted",
+						"change_type": "deleted",
+						"event_time":  deleteTime.Format(time.RFC3339Nano),
+					},
+				},
+				Count: 1,
+			}, nil
+		},
+		GetAssetsFunc: func(context.Context, string, snowflake.AssetFilter) ([]map[string]interface{}, error) {
+			t.Fatal("expected delete-only CDC path to avoid asset fetch")
+			return nil, nil
+		},
+		DescribeColumnsFunc: func(context.Context, string) ([]string, error) {
+			return []string{"_cq_id", "_cq_sync_time"}, nil
+		},
+	}
+
+	application := &app.App{
+		Logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Warehouse:      store,
+		Policy:         policy.NewEngine(),
+		Scanner:        scanner.NewScanner(policy.NewEngine(), scanner.ScanConfig{Workers: 1, BatchSize: 1}, slog.New(slog.NewTextHandler(io.Discard, nil))),
+		ScanWatermarks: wm,
+	}
+
+	scanned, violations, findings, _ := scanOneTable(context.Background(), application, "aws_s3_buckets", false, 100, false, false, app.ScanTuning{})
+	if scanned != 0 || violations != 0 || len(findings) != 0 {
+		t.Fatalf("expected no scanned assets or findings, got scanned=%d violations=%d findings=%d", scanned, violations, len(findings))
+	}
+
+	got := wm.GetWatermark("aws_s3_buckets")
+	if got == nil {
+		t.Fatal("expected watermark to remain set")
+	}
+	if !got.LastScanTime.Equal(deleteTime) {
+		t.Fatalf("expected watermark at %v, got %v", deleteTime, got.LastScanTime)
+	}
+	if got.LastScanID != "" {
+		t.Fatalf("expected delete-only CDC watermark cursor id to be empty, got %q", got.LastScanID)
 	}
 }
 

--- a/internal/warehouse/asset_queries.go
+++ b/internal/warehouse/asset_queries.go
@@ -1,0 +1,114 @@
+package warehouse
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/snowflake"
+)
+
+func buildGetAssetsQuery(target any, table string, filter snowflake.AssetFilter) (string, []any, error) {
+	table, err := normalizeAssetTableName(table)
+	if err != nil {
+		return "", nil, err
+	}
+
+	query := `WITH deduped_assets AS (
+SELECT *, ROW_NUMBER() OVER (
+	PARTITION BY ` + quoteSQLiteIdentifier("_cq_id") + `
+	ORDER BY ` + quoteSQLiteIdentifier("_cq_sync_time") + ` DESC
+) AS ` + quoteSQLiteIdentifier("_cq_latest_rank") + `
+FROM ` + quoteSQLiteIdentifier(table)
+
+	conditions := make([]string, 0, 4)
+	args := make([]any, 0, 8)
+
+	if account := strings.TrimSpace(filter.Account); account != "" {
+		conditions = append(conditions, quoteSQLiteIdentifier("account_id")+" = "+Placeholder(target, len(args)+1))
+		args = append(args, account)
+	}
+	if region := strings.TrimSpace(filter.Region); region != "" {
+		conditions = append(conditions, quoteSQLiteIdentifier("region")+" = "+Placeholder(target, len(args)+1))
+		args = append(args, region)
+	}
+	if !filter.Since.IsZero() {
+		sinceCondition := quoteSQLiteIdentifier("_cq_sync_time") + " > " + Placeholder(target, len(args)+1)
+		args = append(args, warehouseTimeArg(target, filter.Since))
+		if filter.SinceID != "" {
+			sinceCondition = "(" + sinceCondition + " OR (" +
+				quoteSQLiteIdentifier("_cq_sync_time") + " = " + Placeholder(target, len(args)+1) + " AND " +
+				quoteSQLiteIdentifier("_cq_id") + " > " + Placeholder(target, len(args)+2) + "))"
+			args = append(args, warehouseTimeArg(target, filter.Since), filter.SinceID)
+		}
+		conditions = append(conditions, sinceCondition)
+	}
+	if !filter.CursorSyncTime.IsZero() {
+		cursorCondition := quoteSQLiteIdentifier("_cq_sync_time") + " > " + Placeholder(target, len(args)+1)
+		args = append(args, warehouseTimeArg(target, filter.CursorSyncTime))
+		if filter.CursorID != "" {
+			cursorCondition = "(" + cursorCondition + " OR (" +
+				quoteSQLiteIdentifier("_cq_sync_time") + " = " + Placeholder(target, len(args)+1) + " AND " +
+				quoteSQLiteIdentifier("_cq_id") + " > " + Placeholder(target, len(args)+2) + "))"
+			args = append(args, warehouseTimeArg(target, filter.CursorSyncTime), filter.CursorID)
+		}
+		conditions = append(conditions, cursorCondition)
+	}
+
+	if len(conditions) > 0 {
+		query += `
+WHERE ` + strings.Join(conditions, " AND ")
+	}
+
+	query += `
+)
+SELECT ` + assetSelectClause(filter.Columns) + `
+FROM deduped_assets
+WHERE ` + quoteSQLiteIdentifier("_cq_latest_rank") + ` = 1
+ORDER BY ` + quoteSQLiteIdentifier("_cq_sync_time") + ` ASC, ` + quoteSQLiteIdentifier("_cq_id") + ` ASC`
+
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	query += fmt.Sprintf("\nLIMIT %d", limit)
+	if filter.Offset > 0 && filter.Since.IsZero() && filter.CursorSyncTime.IsZero() {
+		query += fmt.Sprintf("\nOFFSET %d", filter.Offset)
+	}
+
+	return query, args, nil
+}
+
+func assetSelectClause(columns []string) string {
+	if len(columns) == 0 {
+		return "*"
+	}
+
+	validated := make([]string, 0, len(columns))
+	for _, column := range columns {
+		normalized, err := normalizeSQLiteIdentifier(column)
+		if err != nil {
+			continue
+		}
+		validated = append(validated, quoteSQLiteIdentifier(normalized))
+	}
+	if len(validated) == 0 {
+		return "*"
+	}
+	return strings.Join(validated, ", ")
+}
+
+func finalizeAssetRows(table string, rows []map[string]interface{}) []map[string]interface{} {
+	for i := range rows {
+		delete(rows[i], "_cq_latest_rank")
+		rows[i]["_cq_table"] = table
+	}
+	return rows
+}
+
+func warehouseTimeArg(target any, value time.Time) any {
+	if Dialect(target) == SQLDialectSQLite {
+		return value.UTC().Format(time.RFC3339Nano)
+	}
+	return value
+}

--- a/internal/warehouse/postgres.go
+++ b/internal/warehouse/postgres.go
@@ -194,54 +194,15 @@ func (w *PostgresWarehouse) GetAssets(ctx context.Context, table string, filter 
 	if err != nil {
 		return nil, err
 	}
-
-	selectExpr := "*"
-	if len(filter.Columns) > 0 {
-		quoted := make([]string, 0, len(filter.Columns))
-		for _, column := range filter.Columns {
-			normalized, err := normalizeSQLiteIdentifier(column)
-			if err != nil {
-				continue
-			}
-			quoted = append(quoted, quoteSQLiteIdentifier(normalized))
-		}
-		if len(quoted) > 0 {
-			selectExpr = strings.Join(quoted, ", ")
-		}
+	query, args, err := buildGetAssetsQuery(w, table, filter)
+	if err != nil {
+		return nil, err
 	}
-
-	query := "SELECT " + selectExpr + " FROM " + quoteSQLiteIdentifier(table)
-	var (
-		conditions []string
-		args       []any
-		argIndex   = 1
-	)
-	if strings.TrimSpace(filter.Account) != "" {
-		conditions = append(conditions, fmt.Sprintf("%s = $%d", quoteSQLiteIdentifier("account_id"), argIndex))
-		args = append(args, filter.Account)
-		argIndex++
-	}
-	if strings.TrimSpace(filter.Region) != "" {
-		conditions = append(conditions, fmt.Sprintf("%s = $%d", quoteSQLiteIdentifier("region"), argIndex))
-		args = append(args, filter.Region)
-	}
-	if len(conditions) > 0 {
-		query += " WHERE " + strings.Join(conditions, " AND ")
-	}
-	limit := filter.Limit
-	if limit <= 0 {
-		limit = 100
-	}
-	query += fmt.Sprintf(" LIMIT %d", limit)
-	if filter.Offset > 0 {
-		query += fmt.Sprintf(" OFFSET %d", filter.Offset)
-	}
-
 	result, err := w.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
-	return result.Rows, nil
+	return finalizeAssetRows(table, result.Rows), nil
 }
 
 func (w *PostgresWarehouse) GetAssetByID(ctx context.Context, table, id string) (map[string]interface{}, error) {

--- a/internal/warehouse/sqlite.go
+++ b/internal/warehouse/sqlite.go
@@ -210,52 +210,15 @@ func (w *SQLiteWarehouse) GetAssets(ctx context.Context, table string, filter sn
 	if err != nil {
 		return nil, err
 	}
-
-	selectExpr := "*"
-	if len(filter.Columns) > 0 {
-		quoted := make([]string, 0, len(filter.Columns))
-		for _, column := range filter.Columns {
-			normalized, err := normalizeSQLiteIdentifier(column)
-			if err != nil {
-				continue
-			}
-			quoted = append(quoted, quoteSQLiteIdentifier(normalized))
-		}
-		if len(quoted) > 0 {
-			selectExpr = strings.Join(quoted, ", ")
-		}
+	query, args, err := buildGetAssetsQuery(w, table, filter)
+	if err != nil {
+		return nil, err
 	}
-
-	query := "SELECT " + selectExpr + " FROM " + quoteSQLiteIdentifier(table)
-	var (
-		conditions []string
-		args       []any
-	)
-	if strings.TrimSpace(filter.Account) != "" {
-		conditions = append(conditions, quoteSQLiteIdentifier("account_id")+" = ?")
-		args = append(args, filter.Account)
-	}
-	if strings.TrimSpace(filter.Region) != "" {
-		conditions = append(conditions, quoteSQLiteIdentifier("region")+" = ?")
-		args = append(args, filter.Region)
-	}
-	if len(conditions) > 0 {
-		query += " WHERE " + strings.Join(conditions, " AND ")
-	}
-	limit := filter.Limit
-	if limit <= 0 {
-		limit = 100
-	}
-	query += fmt.Sprintf(" LIMIT %d", limit)
-	if filter.Offset > 0 {
-		query += fmt.Sprintf(" OFFSET %d", filter.Offset)
-	}
-
 	result, err := w.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
-	return result.Rows, nil
+	return finalizeAssetRows(table, result.Rows), nil
 }
 
 func (w *SQLiteWarehouse) GetAssetByID(ctx context.Context, table, id string) (map[string]interface{}, error) {

--- a/internal/warehouse/sqlite_test.go
+++ b/internal/warehouse/sqlite_test.go
@@ -118,3 +118,137 @@ func TestSQLiteWarehouseRejectsNonAssetTables(t *testing.T) {
 		t.Fatal("expected non-asset table to be rejected")
 	}
 }
+
+func TestSQLiteWarehouseGetAssetsAppliesIncrementalFiltersAndAddsCQTable(t *testing.T) {
+	store, err := NewSQLiteWarehouse(SQLiteWarehouseConfig{
+		Path: filepath.Join(t.TempDir(), "warehouse.db"),
+	})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	if _, err := store.Exec(ctx, `
+		CREATE TABLE aws_s3_buckets (
+			_cq_id TEXT,
+			_cq_sync_time TEXT,
+			id TEXT,
+			type TEXT,
+			name TEXT
+		)
+	`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	rows := []struct {
+		id   string
+		at   string
+		name string
+	}{
+		{id: "bucket-a", at: "2026-03-27T10:00:00Z", name: "bucket-a-older"},
+		{id: "bucket-a", at: "2026-03-27T11:00:00Z", name: "bucket-a-latest"},
+		{id: "bucket-b", at: "2026-03-27T11:00:00Z", name: "bucket-b"},
+		{id: "bucket-c", at: "2026-03-27T12:00:00Z", name: "bucket-c"},
+	}
+	for _, row := range rows {
+		if _, err := store.Exec(
+			ctx,
+			`INSERT INTO aws_s3_buckets (_cq_id, _cq_sync_time, id, type, name) VALUES (?, ?, ?, ?, ?)`,
+			row.id,
+			row.at,
+			row.id,
+			"aws::s3::bucket",
+			row.name,
+		); err != nil {
+			t.Fatalf("insert row %s: %v", row.id, err)
+		}
+	}
+
+	assets, err := store.GetAssets(ctx, "aws_s3_buckets", snowflake.AssetFilter{
+		Since:   time.Date(2026, 3, 27, 11, 0, 0, 0, time.UTC),
+		SinceID: "bucket-a",
+		Limit:   10,
+		Columns: []string{"_cq_id", "_cq_sync_time", "name"},
+	})
+	if err != nil {
+		t.Fatalf("get assets: %v", err)
+	}
+	if len(assets) != 2 {
+		t.Fatalf("expected 2 incremental assets, got %#v", assets)
+	}
+	if got := assets[0]["_cq_id"]; got != "bucket-b" {
+		t.Fatalf("expected first asset bucket-b, got %#v", got)
+	}
+	if got := assets[1]["_cq_id"]; got != "bucket-c" {
+		t.Fatalf("expected second asset bucket-c, got %#v", got)
+	}
+	if got := assets[0]["_cq_table"]; got != "aws_s3_buckets" {
+		t.Fatalf("expected _cq_table to be added, got %#v", got)
+	}
+	if _, ok := assets[0]["_cq_latest_rank"]; ok {
+		t.Fatalf("expected helper rank column to be stripped, got %#v", assets[0])
+	}
+}
+
+func TestSQLiteWarehouseGetAssetsAppliesCursorPagination(t *testing.T) {
+	store, err := NewSQLiteWarehouse(SQLiteWarehouseConfig{
+		Path: filepath.Join(t.TempDir(), "warehouse.db"),
+	})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	if _, err := store.Exec(ctx, `
+		CREATE TABLE aws_s3_buckets (
+			_cq_id TEXT,
+			_cq_sync_time TEXT,
+			id TEXT,
+			type TEXT,
+			name TEXT
+		)
+	`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	rows := []struct {
+		id   string
+		at   string
+		name string
+	}{
+		{id: "bucket-a", at: "2026-03-27T10:00:00Z", name: "bucket-a"},
+		{id: "bucket-b", at: "2026-03-27T11:00:00Z", name: "bucket-b"},
+		{id: "bucket-c", at: "2026-03-27T12:00:00Z", name: "bucket-c"},
+	}
+	for _, row := range rows {
+		if _, err := store.Exec(
+			ctx,
+			`INSERT INTO aws_s3_buckets (_cq_id, _cq_sync_time, id, type, name) VALUES (?, ?, ?, ?, ?)`,
+			row.id,
+			row.at,
+			row.id,
+			"aws::s3::bucket",
+			row.name,
+		); err != nil {
+			t.Fatalf("insert row %s: %v", row.id, err)
+		}
+	}
+
+	assets, err := store.GetAssets(ctx, "aws_s3_buckets", snowflake.AssetFilter{
+		CursorSyncTime: time.Date(2026, 3, 27, 11, 0, 0, 0, time.UTC),
+		CursorID:       "bucket-b",
+		Limit:          10,
+		Columns:        []string{"_cq_id", "_cq_sync_time", "name"},
+	})
+	if err != nil {
+		t.Fatalf("get assets: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected 1 paged asset, got %#v", assets)
+	}
+	if got := assets[0]["_cq_id"]; got != "bucket-c" {
+		t.Fatalf("expected paged asset bucket-c, got %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- switch direct scan and scan preflight from Snowflake-only wiring to the configured warehouse so sqlite/postgres backends can run scans without a Snowflake client
- add shared warehouse asset-query helpers that preserve `_cq_table`, dedupe on latest `_cq_sync_time`, and honor incremental/keyset scan cursors on sqlite/postgres
- add regression coverage for warehouse-backed direct scans plus sqlite incremental pagination/filter behavior

## Validation
- go test ./...
- GOTOOLCHAIN=go1.26.1 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run --timeout 5m ./...
- go run ./scripts/check_agent_sdk_contract_compat/main.go --require-baseline --base-ref=writer/main
- make agent-sdk-docs-check
- make agent-sdk-packages-check
- go run ./scripts/check_api_contract_compat/main.go --require-baseline --base-ref=writer/main
- make api-contract-docs-check
- make config-docs-check
- make devex-codegen-check
- go test ./internal/app -run "Test(PreCommitHookRunsFastLintOnStagedGoFiles|PrePushHookRunsChangedDevexPreflight|DockerBuildCommandsPassGoVersionBuildArg|DevelopmentGuideDocumentsDevexPreflight|DevexScriptPlansRelevantChecks|DevexScriptChangedModeIncludesWorkspaceDiffSources)"
- make openapi-check
- go run ./scripts/check_report_contract_compat/main.go --require-baseline --base-ref=writer/main
- make report-contract-docs-check
- make vendor-check