### PR TITLE
fix(agents): use warehouse-backed query surfaces

### DIFF
--- a/internal/agents/tools.go
+++ b/internal/agents/tools.go
@@ -369,7 +369,7 @@ func (st *SecurityTools) queryAssets(ctx context.Context, args json.RawMessage) 
 		return "", err
 	}
 
-	boundedQuery, boundedLimit, err := snowflake.BuildReadOnlyLimitedQuery(params.Query, params.Limit)
+	boundedQuery, boundedLimit, err := warehouse.BuildReadOnlyLimitedQuery(params.Query, params.Limit)
 	if err != nil {
 		return "", err
 	}
@@ -378,7 +378,7 @@ func (st *SecurityTools) queryAssets(ctx context.Context, args json.RawMessage) 
 		return "", fmt.Errorf("warehouse not configured")
 	}
 
-	queryCtx, cancel := context.WithTimeout(ctx, snowflake.ClampReadOnlyQueryTimeout(params.TimeoutSeconds))
+	queryCtx, cancel := context.WithTimeout(ctx, warehouse.ClampReadOnlyQueryTimeout(params.TimeoutSeconds))
 	defer cancel()
 
 	result, err := st.warehouse.Query(queryCtx, boundedQuery)
@@ -452,6 +452,9 @@ func (st *SecurityTools) getAssetContext(ctx context.Context, args json.RawMessa
 	asset, err := st.warehouse.GetAssetByID(ctx, params.AssetType, params.AssetID)
 	if err != nil {
 		return "", err
+	}
+	if asset == nil {
+		return "", fmt.Errorf("asset not found")
 	}
 
 	output, _ := json.Marshal(asset)

--- a/internal/agents/tools.go
+++ b/internal/agents/tools.go
@@ -11,6 +11,7 @@ import (
 	"github.com/writer/cerebro/internal/policy"
 	"github.com/writer/cerebro/internal/scm"
 	"github.com/writer/cerebro/internal/snowflake"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 // PolicyEvaluator captures the policy evaluation surface the agent tools need.
@@ -20,17 +21,24 @@ type PolicyEvaluator interface {
 
 var _ PolicyEvaluator = (*policy.Engine)(nil)
 
+type QueryAssetWarehouse interface {
+	warehouse.QueryWarehouse
+	GetAssetByID(ctx context.Context, table, id string) (map[string]interface{}, error)
+}
+
+var _ QueryAssetWarehouse = (*snowflake.Client)(nil)
+
 // SecurityTools provides investigation tools for agents
 type SecurityTools struct {
-	snowflake *snowflake.Client
+	warehouse QueryAssetWarehouse
 	findings  findings.FindingStore
 	policies  PolicyEvaluator
 	scm       scm.Client
 }
 
-func NewSecurityTools(sf *snowflake.Client, fs findings.FindingStore, pe PolicyEvaluator, sc scm.Client) *SecurityTools {
+func NewSecurityTools(wh QueryAssetWarehouse, fs findings.FindingStore, pe PolicyEvaluator, sc scm.Client) *SecurityTools {
 	return &SecurityTools{
-		snowflake: sf,
+		warehouse: wh,
 		findings:  fs,
 		policies:  pe,
 		scm:       sc,
@@ -366,14 +374,14 @@ func (st *SecurityTools) queryAssets(ctx context.Context, args json.RawMessage) 
 		return "", err
 	}
 
-	if st.snowflake == nil {
-		return "", fmt.Errorf("snowflake not configured")
+	if st.warehouse == nil {
+		return "", fmt.Errorf("warehouse not configured")
 	}
 
 	queryCtx, cancel := context.WithTimeout(ctx, snowflake.ClampReadOnlyQueryTimeout(params.TimeoutSeconds))
 	defer cancel()
 
-	result, err := st.snowflake.Query(queryCtx, boundedQuery)
+	result, err := st.warehouse.Query(queryCtx, boundedQuery)
 	if err != nil {
 		return "", err
 	}
@@ -437,11 +445,11 @@ func (st *SecurityTools) getAssetContext(ctx context.Context, args json.RawMessa
 		return "", err
 	}
 
-	if st.snowflake == nil {
-		return "", fmt.Errorf("snowflake not configured")
+	if st.warehouse == nil {
+		return "", fmt.Errorf("warehouse not configured")
 	}
 
-	asset, err := st.snowflake.GetAssetByID(ctx, params.AssetType, params.AssetID)
+	asset, err := st.warehouse.GetAssetByID(ctx, params.AssetType, params.AssetID)
 	if err != nil {
 		return "", err
 	}

--- a/internal/agents/tools_query_test.go
+++ b/internal/agents/tools_query_test.go
@@ -15,7 +15,7 @@ func TestQueryAssetsRejectsUnsafeQuery(t *testing.T) {
 	args := json.RawMessage(`{"query":"DROP TABLE users"}`)
 
 	_, err := st.queryAssets(context.Background(), args)
-	if !errors.Is(err, snowflake.ErrNonSelectQuery) {
+	if !errors.Is(err, warehouse.ErrNonSelectQuery) {
 		t.Fatalf("expected ErrNonSelectQuery, got %v", err)
 	}
 }
@@ -76,5 +76,21 @@ func TestGetAssetContextUsesWarehouse(t *testing.T) {
 	}
 	if output == "" {
 		t.Fatal("expected asset payload")
+	}
+}
+
+func TestGetAssetContextReturnsNotFoundWhenWarehouseReturnsNil(t *testing.T) {
+	store := &warehouse.MemoryWarehouse{
+		GetAssetByIDFunc: func(_ context.Context, table, id string) (map[string]interface{}, error) {
+			if table != "aws_s3_buckets" || id != "bucket-missing" {
+				t.Fatalf("unexpected asset lookup %s/%s", table, id)
+			}
+			return nil, nil
+		},
+	}
+	st := NewSecurityTools(store, nil, nil, nil)
+
+	if _, err := st.getAssetContext(context.Background(), json.RawMessage(`{"asset_type":"aws_s3_buckets","asset_id":"bucket-missing"}`)); err == nil || err.Error() != "asset not found" {
+		t.Fatalf("expected asset not found error, got %v", err)
 	}
 }

--- a/internal/agents/tools_query_test.go
+++ b/internal/agents/tools_query_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/writer/cerebro/internal/snowflake"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 func TestQueryAssetsRejectsUnsafeQuery(t *testing.T) {
@@ -19,12 +20,61 @@ func TestQueryAssetsRejectsUnsafeQuery(t *testing.T) {
 	}
 }
 
-func TestQueryAssetsRequiresSnowflakeForValidQuery(t *testing.T) {
+func TestQueryAssetsRequiresWarehouseForValidQuery(t *testing.T) {
 	st := &SecurityTools{}
 	args := json.RawMessage(`{"query":"SELECT * FROM users"}`)
 
 	_, err := st.queryAssets(context.Background(), args)
-	if err == nil || err.Error() != "snowflake not configured" {
-		t.Fatalf("expected snowflake not configured error, got %v", err)
+	if err == nil || err.Error() != "warehouse not configured" {
+		t.Fatalf("expected warehouse not configured error, got %v", err)
+	}
+}
+
+func TestQueryAssetsUsesWarehouseQuery(t *testing.T) {
+	store := &warehouse.MemoryWarehouse{
+		QueryFunc: func(_ context.Context, query string, _ ...any) (*snowflake.QueryResult, error) {
+			if query != "SELECT * FROM (SELECT name FROM aws_s3_buckets) AS cerebro_readonly_query LIMIT 25" {
+				t.Fatalf("unexpected bounded query %q", query)
+			}
+			return &snowflake.QueryResult{
+				Columns: []string{"name"},
+				Rows:    []map[string]interface{}{{"name": "bucket-a"}},
+				Count:   1,
+			}, nil
+		},
+	}
+	st := NewSecurityTools(store, nil, nil, nil)
+
+	output, err := st.queryAssets(context.Background(), json.RawMessage(`{"query":"SELECT name FROM aws_s3_buckets","limit":25}`))
+	if err != nil {
+		t.Fatalf("query assets: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(output), &payload); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if payload["count"].(float64) != 1 {
+		t.Fatalf("expected count=1, got %v", payload["count"])
+	}
+}
+
+func TestGetAssetContextUsesWarehouse(t *testing.T) {
+	store := &warehouse.MemoryWarehouse{
+		GetAssetByIDFunc: func(_ context.Context, table, id string) (map[string]interface{}, error) {
+			if table != "aws_s3_buckets" || id != "bucket-1" {
+				t.Fatalf("unexpected asset lookup %s/%s", table, id)
+			}
+			return map[string]interface{}{"id": id, "name": "bucket-1"}, nil
+		},
+	}
+	st := NewSecurityTools(store, nil, nil, nil)
+
+	output, err := st.getAssetContext(context.Background(), json.RawMessage(`{"asset_type":"aws_s3_buckets","asset_id":"bucket-1"}`))
+	if err != nil {
+		t.Fatalf("get asset context: %v", err)
+	}
+	if output == "" {
+		t.Fatal("expected asset payload")
 	}
 }

--- a/internal/api/query_validation.go
+++ b/internal/api/query_validation.go
@@ -1,14 +1,14 @@
 package api
 
-import "github.com/writer/cerebro/internal/snowflake"
+import "github.com/writer/cerebro/internal/warehouse"
 
 var (
-	ErrEmptyQuery     = snowflake.ErrEmptyQuery
-	ErrNonSelectQuery = snowflake.ErrNonSelectQuery
-	ErrSQLInjection   = snowflake.ErrSQLInjection
+	ErrEmptyQuery     = warehouse.ErrEmptyQuery
+	ErrNonSelectQuery = warehouse.ErrNonSelectQuery
+	ErrSQLInjection   = warehouse.ErrSQLInjection
 )
 
 // ValidateReadOnlyQuery validates that a query is a safe read-only statement.
 func ValidateReadOnlyQuery(query string) error {
-	return snowflake.ValidateReadOnlyQuery(query)
+	return warehouse.ValidateReadOnlyQuery(query)
 }

--- a/internal/api/server_dependencies.go
+++ b/internal/api/server_dependencies.go
@@ -79,7 +79,6 @@ type serverDependencies struct {
 	Config *app.Config
 	Logger *slog.Logger
 
-	Snowflake      *snowflake.Client
 	Warehouse      warehouse.DataWarehouse
 	Policy         *policy.Engine
 	Findings       findings.FindingStore
@@ -172,7 +171,6 @@ func newServerDependenciesFromApp(application *app.App) serverDependencies {
 	deps := serverDependencies{
 		Config:               application.Config,
 		Logger:               application.Logger,
-		Snowflake:            application.Snowflake,
 		Warehouse:            application.Warehouse,
 		Policy:               application.Policy,
 		Findings:             application.Findings,

--- a/internal/api/server_error_paths_test.go
+++ b/internal/api/server_error_paths_test.go
@@ -34,9 +34,9 @@ func TestThreatIntelEndpoints_Return503WhenServiceMissing(t *testing.T) {
 	}
 }
 
-func TestScanCoverage_Return503WithoutSnowflake(t *testing.T) {
+func TestScanCoverage_Return503WithoutWarehouse(t *testing.T) {
 	a := newTestApp(t)
-	a.Snowflake = nil
+	a.Warehouse = nil
 	s := NewServer(a)
 
 	w := do(t, s, http.MethodGet, "/api/v1/scan/coverage", nil)

--- a/internal/api/server_handlers_data.go
+++ b/internal/api/server_handlers_data.go
@@ -15,6 +15,7 @@ import (
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/policy"
 	"github.com/writer/cerebro/internal/snowflake"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 func (s *Server) syncStatus(w http.ResponseWriter, r *http.Request) {
@@ -173,13 +174,13 @@ func (s *Server) executeQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	boundedQuery, boundedLimit, err := snowflake.BuildReadOnlyLimitedQuery(req.Query, req.Limit)
+	boundedQuery, boundedLimit, err := warehouse.BuildReadOnlyLimitedQuery(req.Query, req.Limit)
 	if err != nil {
 		s.error(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	queryCtx, cancel := context.WithTimeout(r.Context(), snowflake.ClampReadOnlyQueryTimeout(req.TimeoutSeconds))
+	queryCtx, cancel := context.WithTimeout(r.Context(), warehouse.ClampReadOnlyQueryTimeout(req.TimeoutSeconds))
 	defer cancel()
 
 	result, err := s.app.Warehouse.Query(queryCtx, boundedQuery)
@@ -231,6 +232,10 @@ func (s *Server) getAsset(w http.ResponseWriter, r *http.Request) {
 	asset, err := s.app.Warehouse.GetAssetByID(r.Context(), table, id)
 	if err != nil {
 		s.error(w, http.StatusNotFound, err.Error())
+		return
+	}
+	if asset == nil {
+		s.error(w, http.StatusNotFound, "asset not found")
 		return
 	}
 	s.json(w, http.StatusOK, asset)

--- a/internal/api/server_handlers_data.go
+++ b/internal/api/server_handlers_data.go
@@ -137,7 +137,7 @@ func parseLastSyncValue(value interface{}) time.Time {
 
 func (s *Server) listTables(w http.ResponseWriter, r *http.Request) {
 	if s.app.Warehouse == nil {
-		s.error(w, http.StatusServiceUnavailable, "snowflake not configured")
+		s.error(w, http.StatusServiceUnavailable, "warehouse not configured")
 		return
 	}
 	pagination := ParsePagination(r, 100, 1000)
@@ -160,7 +160,7 @@ func (s *Server) listTables(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) executeQuery(w http.ResponseWriter, r *http.Request) {
 	if s.app.Warehouse == nil {
-		s.error(w, http.StatusServiceUnavailable, "snowflake not configured")
+		s.error(w, http.StatusServiceUnavailable, "warehouse not configured")
 		return
 	}
 
@@ -201,7 +201,7 @@ func (s *Server) executeQuery(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) listAssets(w http.ResponseWriter, r *http.Request) {
 	if s.app.Warehouse == nil {
-		s.error(w, http.StatusServiceUnavailable, "snowflake not configured")
+		s.error(w, http.StatusServiceUnavailable, "warehouse not configured")
 		return
 	}
 
@@ -222,7 +222,7 @@ func (s *Server) listAssets(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getAsset(w http.ResponseWriter, r *http.Request) {
 	if s.app.Warehouse == nil {
-		s.error(w, http.StatusServiceUnavailable, "snowflake not configured")
+		s.error(w, http.StatusServiceUnavailable, "warehouse not configured")
 		return
 	}
 

--- a/internal/api/server_handlers_data_test.go
+++ b/internal/api/server_handlers_data_test.go
@@ -98,3 +98,21 @@ func TestListAssets_RejectsNonAssetTable(t *testing.T) {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestGetAssetReturnsNotFoundWhenWarehouseMisses(t *testing.T) {
+	a := newTestApp(t)
+	a.Warehouse = &warehouse.MemoryWarehouse{
+		GetAssetByIDFunc: func(_ context.Context, table, id string) (map[string]interface{}, error) {
+			if table != "aws_s3_buckets" || id != "bucket-missing" {
+				t.Fatalf("unexpected asset lookup %s/%s", table, id)
+			}
+			return nil, nil
+		},
+	}
+	s := NewServer(a)
+
+	w := do(t, s, http.MethodGet, "/api/v1/assets/aws_s3_buckets/bucket-missing", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/server_handlers_identity_attack_webhooks.go
+++ b/internal/api/server_handlers_identity_attack_webhooks.go
@@ -21,7 +21,7 @@ import (
 
 func (s *Server) detectStaleAccess(w http.ResponseWriter, r *http.Request) {
 	if s.app.Warehouse == nil {
-		s.error(w, http.StatusServiceUnavailable, "snowflake not configured")
+		s.error(w, http.StatusServiceUnavailable, "warehouse not configured")
 		return
 	}
 

--- a/internal/api/server_handlers_sync_test.go
+++ b/internal/api/server_handlers_sync_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/writer/cerebro/internal/app"
 	"github.com/writer/cerebro/internal/graph"
 	"github.com/writer/cerebro/internal/graph/builders"
-	"github.com/writer/cerebro/internal/snowflake"
 	nativesync "github.com/writer/cerebro/internal/sync"
 	"github.com/writer/cerebro/internal/warehouse"
 )
@@ -23,24 +22,6 @@ type syncGraphSource struct {
 	events []map[string]any
 	err    error
 	block  bool
-}
-
-func setSnowflakeWarehouseDeps(deps *serverDependencies) *snowflake.Client {
-	client := &snowflake.Client{}
-	if deps != nil {
-		deps.Snowflake = client
-		deps.Warehouse = client
-	}
-	return client
-}
-
-func setSnowflakeWarehouseApp(application *app.App) *snowflake.Client {
-	client := &snowflake.Client{}
-	if application != nil {
-		application.Snowflake = client
-		application.Warehouse = client
-	}
-	return client
 }
 
 func (s *syncGraphSource) Query(ctx context.Context, query string, args ...any) (*builders.DataQueryResult, error) {
@@ -74,7 +55,20 @@ func (s *syncGraphSource) Query(ctx context.Context, query string, args ...any) 
 	return &builders.DataQueryResult{Rows: []map[string]any{}}, nil
 }
 
-func TestBackfillRelationshipIDs_RequiresSnowflake(t *testing.T) {
+func attachTestWarehouse(target any) *warehouse.MemoryWarehouse {
+	store := &warehouse.MemoryWarehouse{}
+	switch typed := target.(type) {
+	case *app.App:
+		typed.Warehouse = store
+	case *serverDependencies:
+		typed.Warehouse = store
+	default:
+		panic("unsupported warehouse attachment target")
+	}
+	return store
+}
+
+func TestBackfillRelationshipIDs_RequiresWarehouse(t *testing.T) {
 	s := newTestServer(t)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/backfill-relationships", map[string]interface{}{
@@ -94,7 +88,7 @@ func TestBackfillRelationshipIDs_InvalidRequest(t *testing.T) {
 	}
 }
 
-func TestSyncAzure_RequiresSnowflake(t *testing.T) {
+func TestSyncAzure_RequiresWarehouse(t *testing.T) {
 	s := newTestServer(t)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/azure", map[string]interface{}{
@@ -118,7 +112,7 @@ func TestSyncAzure_InvalidRequest(t *testing.T) {
 
 func TestSyncAzure_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	warehouseStore := attachTestWarehouse(s.app)
 
 	originalRun := runAzureSyncWithOptions
 	t.Cleanup(func() { runAzureSyncWithOptions = originalRun })
@@ -126,8 +120,8 @@ func TestSyncAzure_UsesRequestOptions(t *testing.T) {
 	called := false
 	runAzureSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req azureSyncRequest) ([]nativesync.SyncResult, error) {
 		called = true
-		if client != s.app.Snowflake {
-			t.Fatalf("expected server snowflake client to be passed through")
+		if client != warehouseStore {
+			t.Fatalf("expected server warehouse to be passed through")
 		}
 		if len(req.Subscriptions) != 1 || req.Subscriptions[0] != "sub-123" {
 			t.Fatalf("expected normalized subscriptions, got %#v", req.Subscriptions)
@@ -168,7 +162,7 @@ func TestSyncAzure_UsesRequestOptions(t *testing.T) {
 
 func TestSyncAzure_RejectsMixedManagementGroupAndSubscriptions(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	attachTestWarehouse(s.app)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/azure", map[string]interface{}{
 		"management_group": "mg-platform",
@@ -181,14 +175,14 @@ func TestSyncAzure_RejectsMixedManagementGroupAndSubscriptions(t *testing.T) {
 
 func TestSyncAzure_NormalizesSubscriptionsCaseInsensitively(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	warehouseStore := attachTestWarehouse(s.app)
 
 	originalRun := runAzureSyncWithOptions
 	t.Cleanup(func() { runAzureSyncWithOptions = originalRun })
 
 	runAzureSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req azureSyncRequest) ([]nativesync.SyncResult, error) {
-		if client != s.app.Snowflake {
-			t.Fatalf("expected server snowflake client to be passed through")
+		if client != warehouseStore {
+			t.Fatalf("expected server warehouse to be passed through")
 		}
 		want := []string{"SUB-A", "Sub-B"}
 		if len(req.Subscriptions) != len(want) {
@@ -211,7 +205,7 @@ func TestSyncAzure_NormalizesSubscriptionsCaseInsensitively(t *testing.T) {
 	}
 }
 
-func TestSyncK8s_RequiresSnowflake(t *testing.T) {
+func TestSyncK8s_RequiresWarehouse(t *testing.T) {
 	s := newTestServer(t)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/k8s", map[string]interface{}{
@@ -235,7 +229,7 @@ func TestSyncK8s_InvalidRequest(t *testing.T) {
 
 func TestSyncK8s_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	warehouseStore := attachTestWarehouse(s.app)
 
 	originalRun := runK8sSyncWithOptions
 	t.Cleanup(func() { runK8sSyncWithOptions = originalRun })
@@ -243,8 +237,8 @@ func TestSyncK8s_UsesRequestOptions(t *testing.T) {
 	called := false
 	runK8sSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req k8sSyncRequest) ([]nativesync.SyncResult, error) {
 		called = true
-		if client != s.app.Snowflake {
-			t.Fatalf("expected server snowflake client to be passed through")
+		if client != warehouseStore {
+			t.Fatalf("expected server warehouse to be passed through")
 		}
 		if req.Kubeconfig != "/tmp/kubeconfig" {
 			t.Fatalf("expected kubeconfig /tmp/kubeconfig, got %q", req.Kubeconfig)
@@ -286,7 +280,7 @@ func TestSyncK8s_UsesRequestOptions(t *testing.T) {
 	}
 }
 
-func TestSyncAWS_RequiresSnowflake(t *testing.T) {
+func TestSyncAWS_RequiresWarehouse(t *testing.T) {
 	s := newTestServer(t)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
@@ -310,7 +304,7 @@ func TestSyncAWS_InvalidRequest(t *testing.T) {
 
 func TestSyncAWS_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	warehouseStore := attachTestWarehouse(s.app)
 
 	originalRun := runAWSSyncWithOptions
 	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
@@ -318,8 +312,8 @@ func TestSyncAWS_UsesRequestOptions(t *testing.T) {
 	called := false
 	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
 		called = true
-		if client != s.app.Snowflake {
-			t.Fatalf("expected server snowflake client to be passed through")
+		if client != warehouseStore {
+			t.Fatalf("expected server warehouse to be passed through")
 		}
 		if req.Profile != "prod-profile" {
 			t.Fatalf("expected profile prod-profile, got %q", req.Profile)
@@ -370,7 +364,7 @@ func TestSyncAWS_UsesRequestOptions(t *testing.T) {
 
 func TestSyncAWS_AppliesIncrementalGraphChangesAfterSync(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	attachTestWarehouse(s.app)
 
 	source := &syncGraphSource{}
 	builder := builders.NewBuilder(source, s.app.Logger)
@@ -428,7 +422,7 @@ func TestSyncAWS_AppliesIncrementalGraphChangesAfterSync(t *testing.T) {
 
 func TestSyncAWS_GraphUpdateFailureIsSanitized(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	attachTestWarehouse(s.app)
 
 	source := &syncGraphSource{block: true}
 	builder := builders.NewBuilder(source, s.app.Logger)
@@ -473,7 +467,7 @@ func TestSyncAWS_GraphUpdateFailureIsSanitized(t *testing.T) {
 
 func TestSyncAWS_GraphUpdateBusyReturnsBusyStatus(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	attachTestWarehouse(s.app)
 
 	source := &syncGraphSource{block: true}
 	builder := builders.NewBuilder(source, s.app.Logger)
@@ -539,7 +533,7 @@ func TestSyncAWS_GraphUpdateBusyReturnsBusyStatus(t *testing.T) {
 
 func TestSyncAWS_GraphUpdateNoopSummaryUsesEmptyTablesArray(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	attachTestWarehouse(s.app)
 
 	source := &syncGraphSource{}
 	builder := builders.NewBuilder(source, s.app.Logger)
@@ -584,7 +578,7 @@ func TestSyncAWS_GraphUpdateNoopSummaryUsesEmptyTablesArray(t *testing.T) {
 
 func TestSyncAWS_GraphUpdateFailureReportsFailedStatus(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	attachTestWarehouse(s.app)
 
 	source := &syncGraphSource{err: errors.New("cdc unavailable")}
 	builder := builders.NewBuilder(source, s.app.Logger)
@@ -627,7 +621,7 @@ func TestSyncAWS_GraphUpdateFailureReportsFailedStatus(t *testing.T) {
 
 func TestSyncAWS_AppliesGraphUpdateUsingRuntimeWithoutLocalBuilder(t *testing.T) {
 	application := newTestApp(t)
-	setSnowflakeWarehouseApp(application)
+	attachTestWarehouse(application)
 
 	deps := newServerDependenciesFromApp(application)
 	deps.SecurityGraph = nil
@@ -683,7 +677,7 @@ func TestSyncAWS_AppliesGraphUpdateUsingRuntimeWithoutLocalBuilder(t *testing.T)
 
 func TestSyncAWS_SkipsGraphUpdateWithoutRuntimeOrLocalBuilder(t *testing.T) {
 	application := newTestApp(t)
-	setSnowflakeWarehouseApp(application)
+	attachTestWarehouse(application)
 
 	deps := newServerDependenciesFromApp(application)
 	deps.SecurityGraph = nil
@@ -715,11 +709,9 @@ func TestSyncAWS_SkipsGraphUpdateWithoutRuntimeOrLocalBuilder(t *testing.T) {
 }
 
 func TestSyncAWS_SkipsGraphUpdateWhenRuntimeAdapterHasNoApplyCapability(t *testing.T) {
-	client := &snowflake.Client{}
 	application := &app.App{
 		Config:    &app.Config{},
-		Snowflake: client,
-		Warehouse: client,
+		Warehouse: &warehouse.MemoryWarehouse{},
 	}
 
 	deps := newServerDependenciesFromApp(application)
@@ -748,7 +740,7 @@ func TestSyncAWS_SkipsGraphUpdateWhenRuntimeAdapterHasNoApplyCapability(t *testi
 	}
 }
 
-func TestSyncAWSOrg_RequiresSnowflake(t *testing.T) {
+func TestSyncAWSOrg_RequiresWarehouse(t *testing.T) {
 	s := newTestServer(t)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws-org", map[string]interface{}{
@@ -770,7 +762,7 @@ func TestSyncAWSOrg_InvalidRequest(t *testing.T) {
 
 func TestSyncAWSOrg_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	warehouseStore := attachTestWarehouse(s.app)
 
 	originalRun := runAWSOrgSyncWithOptions
 	t.Cleanup(func() { runAWSOrgSyncWithOptions = originalRun })
@@ -778,8 +770,8 @@ func TestSyncAWSOrg_UsesRequestOptions(t *testing.T) {
 	called := false
 	runAWSOrgSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error) {
 		called = true
-		if client != s.app.Snowflake {
-			t.Fatalf("expected server snowflake client to be passed through")
+		if client != warehouseStore {
+			t.Fatalf("expected server warehouse to be passed through")
 		}
 		if req.Profile != "prod-profile" {
 			t.Fatalf("expected profile prod-profile, got %q", req.Profile)
@@ -843,7 +835,7 @@ func TestSyncAWSOrg_UsesRequestOptions(t *testing.T) {
 	}
 }
 
-func TestSyncGCP_RequiresSnowflake(t *testing.T) {
+func TestSyncGCP_RequiresWarehouse(t *testing.T) {
 	s := newTestServer(t)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/gcp", map[string]interface{}{
@@ -867,7 +859,7 @@ func TestSyncGCP_InvalidRequest(t *testing.T) {
 
 func TestSyncGCP_RequiresProject(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	attachTestWarehouse(s.app)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/gcp", map[string]interface{}{
 		"concurrency": 4,
@@ -880,7 +872,7 @@ func TestSyncGCP_RequiresProject(t *testing.T) {
 
 func TestSyncGCP_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	warehouseStore := attachTestWarehouse(s.app)
 
 	originalRun := runGCPSyncWithOptions
 	t.Cleanup(func() { runGCPSyncWithOptions = originalRun })
@@ -888,8 +880,8 @@ func TestSyncGCP_UsesRequestOptions(t *testing.T) {
 	called := false
 	runGCPSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req gcpSyncRequest) (*gcpSyncOutcome, error) {
 		called = true
-		if client != s.app.Snowflake {
-			t.Fatalf("expected server snowflake client to be passed through")
+		if client != warehouseStore {
+			t.Fatalf("expected server warehouse to be passed through")
 		}
 		if req.Project != "proj-123" {
 			t.Fatalf("expected project proj-123, got %q", req.Project)
@@ -930,7 +922,7 @@ func TestSyncGCP_UsesRequestOptions(t *testing.T) {
 	}
 }
 
-func TestSyncGCPAsset_RequiresSnowflake(t *testing.T) {
+func TestSyncGCPAsset_RequiresWarehouse(t *testing.T) {
 	s := newTestServer(t)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/gcp-asset", map[string]interface{}{
@@ -954,7 +946,7 @@ func TestSyncGCPAsset_InvalidRequest(t *testing.T) {
 
 func TestSyncGCPAsset_RequiresProjects(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	attachTestWarehouse(s.app)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/gcp-asset", map[string]interface{}{
 		"concurrency": 4,
@@ -967,7 +959,7 @@ func TestSyncGCPAsset_RequiresProjects(t *testing.T) {
 
 func TestSyncGCPAsset_RejectsMixedOrganizationAndProjects(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	attachTestWarehouse(s.app)
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/gcp-asset", map[string]interface{}{
 		"organization": "1234567890",
@@ -980,7 +972,7 @@ func TestSyncGCPAsset_RejectsMixedOrganizationAndProjects(t *testing.T) {
 
 func TestSyncGCPAsset_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	warehouseStore := attachTestWarehouse(s.app)
 
 	originalRun := runGCPAssetSyncWithOptions
 	t.Cleanup(func() { runGCPAssetSyncWithOptions = originalRun })
@@ -988,8 +980,8 @@ func TestSyncGCPAsset_UsesRequestOptions(t *testing.T) {
 	called := false
 	runGCPAssetSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
 		called = true
-		if client != s.app.Snowflake {
-			t.Fatalf("expected server snowflake client to be passed through")
+		if client != warehouseStore {
+			t.Fatalf("expected server warehouse to be passed through")
 		}
 		if len(req.Projects) != 2 || req.Projects[0] != "proj-123" || req.Projects[1] != "proj-456" {
 			t.Fatalf("unexpected projects: %#v", req.Projects)
@@ -1025,7 +1017,7 @@ func TestSyncGCPAsset_UsesRequestOptions(t *testing.T) {
 
 func TestSyncGCPAsset_UsesOrganizationScope(t *testing.T) {
 	s := newTestServer(t)
-	setSnowflakeWarehouseDeps(s.app)
+	warehouseStore := attachTestWarehouse(s.app)
 
 	originalRun := runGCPAssetSyncWithOptions
 	t.Cleanup(func() { runGCPAssetSyncWithOptions = originalRun })
@@ -1033,8 +1025,8 @@ func TestSyncGCPAsset_UsesOrganizationScope(t *testing.T) {
 	called := false
 	runGCPAssetSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
 		called = true
-		if client != s.app.Snowflake {
-			t.Fatalf("expected server snowflake client to be passed through")
+		if client != warehouseStore {
+			t.Fatalf("expected server warehouse to be passed through")
 		}
 		if req.Organization != "1234567890" {
 			t.Fatalf("expected organization 1234567890, got %q", req.Organization)

--- a/internal/app/app_init_agents.go
+++ b/internal/app/app_init_agents.go
@@ -26,7 +26,7 @@ func (a *App) initAgents(ctx context.Context) {
 	}
 
 	scmClient := scm.NewConfiguredClient(a.Config.GitHubToken, a.Config.GitLabToken, a.Config.GitLabBaseURL)
-	toolset := agents.NewSecurityTools(a.Snowflake, a.Findings, a.Policy, scmClient)
+	toolset := agents.NewSecurityTools(a.Warehouse, a.Findings, a.Policy, scmClient)
 	agentTools := toolset.GetTools()
 
 	remoteProvider, err := agents.NewRemoteToolProvider(remoteToolProviderConfigFromConfig(a.Config), a.Logger)

--- a/internal/app/app_service_groups_test.go
+++ b/internal/app/app_service_groups_test.go
@@ -38,6 +38,7 @@ func TestAppServiceGroupAccessors(t *testing.T) {
 	schedulerSvc := &scheduler.Scheduler{}
 	rbac := auth.NewRBAC()
 	securityGraph := graph.New()
+	securityGraph.AddNode(&graph.Node{ID: "service:security", Kind: graph.NodeKindService})
 	auditRepo := &snowflake.AuditRepository{}
 	riskEngineStateRepo := &snowflake.RiskEngineStateRepository{}
 	retention := noopRetentionCleaner{}

--- a/internal/app/providers_registry.go
+++ b/internal/app/providers_registry.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/writer/cerebro/internal/metrics"
 	"github.com/writer/cerebro/internal/providers"
-	"github.com/writer/cerebro/internal/snowflake"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 type providerRegistration struct {
@@ -47,8 +47,8 @@ func (a *App) registerConfiguredProviders(ctx context.Context, cfg *Config, regi
 			return
 		}
 
-		if setter, ok := p.(interface{ SetSnowflakeClient(*snowflake.Client) }); ok {
-			setter.SetSnowflakeClient(a.Snowflake)
+		if setter, ok := p.(interface{ SetWarehouse(warehouse.DataWarehouse) }); ok {
+			setter.SetWarehouse(a.Warehouse)
 		}
 		if err := p.Configure(ctx, config); err != nil {
 			a.Logger.Warn("provider configuration failed, skipping registration",

--- a/internal/app/query_policy_scan.go
+++ b/internal/app/query_policy_scan.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	queryPolicyDefaultRowLimit = snowflake.MaxReadOnlyQueryLimit
+	queryPolicyDefaultRowLimit = warehouse.MaxReadOnlyQueryLimit
 	queryPolicyMetaFindingID   = "query-result-limit"
 )
 
@@ -68,12 +68,12 @@ func (a *App) ScanQueryPolicies(ctx context.Context) QueryPolicyScanResult {
 			}
 		}
 
-		boundedQuery, boundedLimit, err := snowflake.BuildReadOnlyLimitedQuery(queryPolicy.Query, rowLimit)
+		boundedQuery, boundedLimit, err := warehouse.BuildReadOnlyLimitedQuery(queryPolicy.Query, rowLimit)
 		if err != nil {
 			return nil, fmt.Errorf("invalid read-only query: %w", err)
 		}
 
-		queryCtx, cancel := context.WithTimeout(runCtx, snowflake.ClampReadOnlyQueryTimeout(0))
+		queryCtx, cancel := context.WithTimeout(runCtx, warehouse.ClampReadOnlyQueryTimeout(0))
 		defer cancel()
 
 		queryResult, attempts, err := scanner.WithRetryValue(queryCtx, tuning.RetryOptions, func() (*snowflake.QueryResult, error) {

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -73,7 +73,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 
 	// 4. Initialize Tools
 	tools := agents.NewSecurityTools(
-		application.Snowflake,
+		application.Warehouse,
 		application.Findings,
 		application.Policy,
 		scmClient,

--- a/internal/cli/agent_run.go
+++ b/internal/cli/agent_run.go
@@ -77,7 +77,7 @@ func runAgentFlow(cmd *cobra.Command, args []string) error {
 		application.Config.GitLabToken,
 		application.Config.GitLabBaseURL,
 	)
-	tools := agents.NewSecurityTools(application.Snowflake, application.Findings, application.Policy, scmClient)
+	tools := agents.NewSecurityTools(application.Warehouse, application.Findings, application.Policy, scmClient)
 	useDistributed := agentRunDistributed || distributedJobsConfigured(application.Config)
 	if useDistributed {
 		return runDistributedAgentFlow(ctx, application, tools)

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -39,6 +39,21 @@ var (
 	runQueryDirectFn = runQueryDirect
 )
 
+var allowedReadOnlyPRAGMAs = map[string]struct{}{
+	"TABLE_INFO":       {},
+	"TABLE_XINFO":      {},
+	"TABLE_LIST":       {},
+	"INDEX_LIST":       {},
+	"INDEX_INFO":       {},
+	"INDEX_XINFO":      {},
+	"FOREIGN_KEY_LIST": {},
+	"DATABASE_LIST":    {},
+	"COMPILE_OPTIONS":  {},
+	"FUNCTION_LIST":    {},
+	"MODULE_LIST":      {},
+	"PRAGMA_LIST":      {},
+}
+
 func init() {
 	queryCmd.Flags().StringVarP(&queryFormat, "format", "f", "table", "Output format: table, json, csv")
 	queryCmd.Flags().IntVarP(&queryLimit, "limit", "l", 100, "Limit results")
@@ -90,9 +105,18 @@ func runQueryDirect(cmd *cobra.Command, args []string) error {
 	}
 
 	query := strings.Join(args, " ")
-	query, _, err = warehouse.BuildReadOnlyLimitedQuery(query, queryLimit)
-	if err != nil {
+	rawQuery := false
+	if metadataQuery, executeRaw, handled, err := prepareDirectMetadataQuery(query); err != nil {
 		return err
+	} else if handled {
+		query = metadataQuery
+		rawQuery = executeRaw
+	}
+	if !rawQuery {
+		query, _, err = warehouse.BuildReadOnlyLimitedQuery(query, queryLimit)
+		if err != nil {
+			return err
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(commandContextOrBackground(cmd), warehouse.ClampReadOnlyQueryTimeout(int((60*time.Second)/time.Second)))
@@ -104,6 +128,79 @@ func runQueryDirect(cmd *cobra.Command, args []string) error {
 	}
 
 	return renderQueryResult(result)
+}
+
+func prepareDirectMetadataQuery(query string) (string, bool, bool, error) {
+	candidate := strings.TrimSpace(query)
+	candidateUpper := strings.ToUpper(candidate)
+	if !strings.HasPrefix(candidateUpper, "SHOW") && !strings.HasPrefix(candidateUpper, "PRAGMA") {
+		return "", false, false, nil
+	}
+
+	trimmed, err := normalizeDirectMetadataQuery(query)
+	if err != nil {
+		return "", false, false, err
+	}
+
+	upper := strings.ToUpper(strings.Join(strings.Fields(trimmed), " "))
+	if upper == "SHOW TABLES" {
+		return "SELECT table_name FROM information_schema.tables ORDER BY table_name", false, true, nil
+	}
+
+	if strings.HasPrefix(strings.ToUpper(trimmed), "PRAGMA ") {
+		if !isAllowedReadOnlyPRAGMA(trimmed) {
+			return "", false, false, fmt.Errorf("only read-only PRAGMA metadata queries are supported")
+		}
+		return trimmed, true, true, nil
+	}
+
+	return "", false, false, nil
+}
+
+func normalizeDirectMetadataQuery(query string) (string, error) {
+	if strings.TrimSpace(query) == "" {
+		return "", warehouse.ErrEmptyQuery
+	}
+	if strings.Contains(query, "--") || strings.Contains(query, "/*") || strings.Contains(query, "*/") {
+		return "", warehouse.ErrSQLInjection
+	}
+
+	trimmed := strings.TrimSpace(query)
+	semicolonCount := strings.Count(trimmed, ";")
+	if semicolonCount > 1 {
+		return "", warehouse.ErrSQLInjection
+	}
+	if semicolonCount == 1 {
+		if !strings.HasSuffix(trimmed, ";") {
+			return "", warehouse.ErrSQLInjection
+		}
+		trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, ";"))
+	}
+
+	return trimmed, nil
+}
+
+func isAllowedReadOnlyPRAGMA(query string) bool {
+	trimmed := strings.TrimSpace(query)
+	if strings.Contains(trimmed, "=") {
+		return false
+	}
+
+	fields := strings.Fields(trimmed)
+	if len(fields) < 2 || !strings.EqualFold(fields[0], "PRAGMA") {
+		return false
+	}
+
+	name := fields[1]
+	if idx := strings.IndexAny(name, "(;"); idx >= 0 {
+		name = name[:idx]
+	}
+	if parts := strings.Split(name, "."); len(parts) > 0 {
+		name = parts[len(parts)-1]
+	}
+	name = strings.ToUpper(strings.TrimSpace(name))
+	_, ok := allowedReadOnlyPRAGMAs[name]
+	return ok
 }
 
 func renderQueryResult(result *snowflake.QueryResult) error {

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -9,14 +9,15 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/writer/cerebro/internal/app"
 	apiclient "github.com/writer/cerebro/internal/client"
 	"github.com/writer/cerebro/internal/snowflake"
 )
 
 var queryCmd = &cobra.Command{
 	Use:   "query [sql]",
-	Short: "Execute SQL query against Snowflake",
-	Long: `Execute a SQL query against the Snowflake data warehouse.
+	Short: "Execute SQL query against the configured warehouse",
+	Long: `Execute a SQL query against the configured warehouse.
 
 The query results are displayed in table format by default, with support
 for JSON and CSV output. A LIMIT clause is automatically appended if not present.
@@ -76,24 +77,16 @@ func runQuery(cmd *cobra.Command, args []string) error {
 }
 
 func runQueryDirect(cmd *cobra.Command, args []string) error {
-	dsnCfg := snowflake.DSNConfigFromEnv()
-	if missing := dsnCfg.MissingFields(); len(missing) > 0 {
-		return fmt.Errorf("snowflake not configured: set %s", strings.Join(missing, ", "))
-	}
-
-	client, err := snowflake.NewClient(snowflake.ClientConfig{
-		Account:    dsnCfg.Account,
-		User:       dsnCfg.User,
-		PrivateKey: dsnCfg.PrivateKey,
-		Database:   dsnCfg.Database,
-		Schema:     dsnCfg.Schema,
-		Warehouse:  dsnCfg.Warehouse,
-		Role:       dsnCfg.Role,
-	})
+	queryWarehouse, err := app.OpenWarehouse(commandContextOrBackground(cmd), nil, nil)
 	if err != nil {
-		return fmt.Errorf("connect to snowflake: %w", err)
+		return fmt.Errorf("failed to initialize warehouse: %w", err)
 	}
-	defer func() { _ = client.Close() }()
+	if queryWarehouse == nil {
+		return fmt.Errorf("warehouse not configured")
+	}
+	if closer, ok := queryWarehouse.(interface{ Close() error }); ok {
+		defer func() { _ = closer.Close() }()
+	}
 
 	query := strings.Join(args, " ")
 	upperQuery := strings.ToUpper(strings.TrimSpace(query))
@@ -105,7 +98,7 @@ func runQueryDirect(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(commandContextOrBackground(cmd), 60*time.Second)
 	defer cancel()
 
-	result, err := client.Query(ctx, query)
+	result, err := queryWarehouse.Query(ctx, query)
 	if err != nil {
 		return fmt.Errorf("query failed: %w", err)
 	}

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -12,6 +12,7 @@ import (
 	"github.com/writer/cerebro/internal/app"
 	apiclient "github.com/writer/cerebro/internal/client"
 	"github.com/writer/cerebro/internal/snowflake"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 var queryCmd = &cobra.Command{
@@ -89,13 +90,12 @@ func runQueryDirect(cmd *cobra.Command, args []string) error {
 	}
 
 	query := strings.Join(args, " ")
-	upperQuery := strings.ToUpper(strings.TrimSpace(query))
-	// Only add LIMIT to SELECT queries that don't already have one
-	if strings.HasPrefix(upperQuery, "SELECT") && !strings.Contains(upperQuery, "LIMIT") && queryLimit > 0 {
-		query = fmt.Sprintf("%s LIMIT %d", query, queryLimit)
+	query, _, err = warehouse.BuildReadOnlyLimitedQuery(query, queryLimit)
+	if err != nil {
+		return err
 	}
 
-	ctx, cancel := context.WithTimeout(commandContextOrBackground(cmd), 60*time.Second)
+	ctx, cancel := context.WithTimeout(commandContextOrBackground(cmd), warehouse.ClampReadOnlyQueryTimeout(int((60*time.Second)/time.Second)))
 	defer cancel()
 
 	result, err := queryWarehouse.Query(ctx, query)

--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -106,23 +106,32 @@ func runQueryDirect(cmd *cobra.Command, args []string) error {
 
 	query := strings.Join(args, " ")
 	rawQuery := false
-	if metadataQuery, executeRaw, handled, err := prepareDirectMetadataQuery(query); err != nil {
+	queryArgs := []any(nil)
+	if metadataQuery, metadataArgs, executeRaw, handled, err := prepareDirectMetadataQueryWithArgs(query); err != nil {
 		return err
 	} else if handled {
 		query = metadataQuery
+		queryArgs = metadataArgs
 		rawQuery = executeRaw
 	}
 	if !rawQuery {
-		query, _, err = warehouse.BuildReadOnlyLimitedQuery(query, queryLimit)
-		if err != nil {
-			return err
+		if warehouse.HasTopLevelLimit(query) {
+			query, err = warehouse.NormalizeReadOnlyQuery(query)
+			if err != nil {
+				return err
+			}
+		} else {
+			query, _, err = warehouse.BuildReadOnlyLimitedQuery(query, queryLimit)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
 	ctx, cancel := context.WithTimeout(commandContextOrBackground(cmd), warehouse.ClampReadOnlyQueryTimeout(int((60*time.Second)/time.Second)))
 	defer cancel()
 
-	result, err := queryWarehouse.Query(ctx, query)
+	result, err := queryWarehouse.Query(ctx, query, queryArgs...)
 	if err != nil {
 		return fmt.Errorf("query failed: %w", err)
 	}
@@ -131,30 +140,65 @@ func runQueryDirect(cmd *cobra.Command, args []string) error {
 }
 
 func prepareDirectMetadataQuery(query string) (string, bool, bool, error) {
+	metadataQuery, _, executeRaw, handled, err := prepareDirectMetadataQueryWithArgs(query)
+	return metadataQuery, executeRaw, handled, err
+}
+
+func prepareDirectMetadataQueryWithArgs(query string) (string, []any, bool, bool, error) {
 	candidate := strings.TrimSpace(query)
 	candidateUpper := strings.ToUpper(candidate)
-	if !strings.HasPrefix(candidateUpper, "SHOW") && !strings.HasPrefix(candidateUpper, "PRAGMA") {
-		return "", false, false, nil
+	if !strings.HasPrefix(candidateUpper, "SHOW") &&
+		!strings.HasPrefix(candidateUpper, "PRAGMA") &&
+		!strings.HasPrefix(candidateUpper, "DESCRIBE") &&
+		!strings.HasPrefix(candidateUpper, "DESC") {
+		return "", nil, false, false, nil
 	}
 
 	trimmed, err := normalizeDirectMetadataQuery(query)
 	if err != nil {
-		return "", false, false, err
+		return "", nil, false, false, err
 	}
 
 	upper := strings.ToUpper(strings.Join(strings.Fields(trimmed), " "))
 	if upper == "SHOW TABLES" {
-		return "SELECT table_name FROM information_schema.tables ORDER BY table_name", false, true, nil
+		return "SELECT table_name FROM information_schema.tables ORDER BY table_name", nil, false, true, nil
+	}
+
+	if strings.HasPrefix(upper, "DESCRIBE TABLE ") || strings.HasPrefix(upper, "DESC TABLE ") {
+		tableName, err := directMetadataTableName(trimmed)
+		if err != nil {
+			return "", nil, false, false, err
+		}
+		return "SELECT column_name FROM information_schema.columns WHERE table_name = ? ORDER BY column_name", []any{tableName}, false, true, nil
 	}
 
 	if strings.HasPrefix(strings.ToUpper(trimmed), "PRAGMA ") {
 		if !isAllowedReadOnlyPRAGMA(trimmed) {
-			return "", false, false, fmt.Errorf("only read-only PRAGMA metadata queries are supported")
+			return "", nil, false, false, fmt.Errorf("only read-only PRAGMA metadata queries are supported")
 		}
-		return trimmed, true, true, nil
+		return trimmed, nil, true, true, nil
 	}
 
-	return "", false, false, nil
+	return "", nil, false, false, nil
+}
+
+func directMetadataTableName(query string) (string, error) {
+	fields := strings.Fields(query)
+	if len(fields) < 3 || !strings.EqualFold(fields[1], "TABLE") {
+		return "", fmt.Errorf("expected DESCRIBE TABLE <table>")
+	}
+	tableName := strings.TrimSpace(strings.Join(fields[2:], " "))
+	if tableName == "" {
+		return "", fmt.Errorf("expected DESCRIBE TABLE <table>")
+	}
+	if idx := strings.LastIndex(tableName, "."); idx >= 0 {
+		tableName = tableName[idx+1:]
+	}
+	tableName = strings.TrimSpace(strings.Trim(tableName, "`\""))
+	if tableName == "" {
+		return "", fmt.Errorf("expected DESCRIBE TABLE <table>")
+	}
+	return tableName, nil
 }
 
 func normalizeDirectMetadataQuery(query string) (string, error) {

--- a/internal/cli/query_direct_test.go
+++ b/internal/cli/query_direct_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/warehouse"
+)
+
+func TestRunQueryDirect_UsesConfiguredWarehouse(t *testing.T) {
+	state := snapshotQueryCLIState()
+	t.Cleanup(func() { restoreQueryCLIState(state) })
+
+	tempDir := t.TempDir()
+	warehousePath := filepath.Join(tempDir, "warehouse.db")
+	store, err := warehouse.NewSQLiteWarehouse(warehouse.SQLiteWarehouseConfig{Path: warehousePath})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if _, err := store.Exec(context.Background(), `
+		CREATE TABLE aws_s3_buckets (
+			id TEXT,
+			name TEXT
+		)
+	`); err != nil {
+		t.Fatalf("create warehouse table: %v", err)
+	}
+	if _, err := store.Exec(context.Background(), `INSERT INTO aws_s3_buckets (id, name) VALUES (?, ?)`, "bucket-1", "bucket-a"); err != nil {
+		t.Fatalf("insert warehouse row: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close seeded warehouse: %v", err)
+	}
+
+	policyDir := filepath.Join(tempDir, "policies")
+	if err := os.MkdirAll(policyDir, 0o750); err != nil {
+		t.Fatalf("mkdir policy dir: %v", err)
+	}
+
+	t.Setenv("SNOWFLAKE_PRIVATE_KEY", "")
+	t.Setenv("SNOWFLAKE_ACCOUNT", "")
+	t.Setenv("SNOWFLAKE_USER", "")
+	t.Setenv("API_AUTH_ENABLED", "false")
+	t.Setenv("API_KEYS", "")
+	t.Setenv("WAREHOUSE_BACKEND", "sqlite")
+	t.Setenv("WAREHOUSE_SQLITE_PATH", warehousePath)
+	t.Setenv("EXECUTION_STORE_FILE", filepath.Join(tempDir, "executions.db"))
+	t.Setenv("GRAPH_SNAPSHOT_PATH", filepath.Join(tempDir, "graph-snapshots"))
+	t.Setenv("PLATFORM_REPORT_RUN_STATE_FILE", filepath.Join(tempDir, "report-runs.json"))
+	t.Setenv("PLATFORM_REPORT_SNAPSHOT_PATH", filepath.Join(tempDir, "report-snapshots"))
+	t.Setenv("CEREBRO_DB_PATH", filepath.Join(tempDir, "findings.db"))
+	t.Setenv("POLICIES_PATH", policyDir)
+
+	queryFormat = FormatJSON
+	queryLimit = 10
+
+	output := captureStdout(t, func() {
+		if err := runQueryDirect(queryCmd, []string{"SELECT name FROM aws_s3_buckets"}); err != nil {
+			t.Fatalf("runQueryDirect failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "bucket-a") {
+		t.Fatalf("expected warehouse query output to include bucket-a, got %s", output)
+	}
+}

--- a/internal/cli/query_direct_test.go
+++ b/internal/cli/query_direct_test.go
@@ -138,6 +138,80 @@ func TestRunQueryDirect_AllowsReadOnlyPragmaMetadata(t *testing.T) {
 	}
 }
 
+func TestRunQueryDirect_SupportsDescribeTable(t *testing.T) {
+	state := snapshotQueryCLIState()
+	t.Cleanup(func() { restoreQueryCLIState(state) })
+
+	tempDir := t.TempDir()
+	warehousePath := filepath.Join(tempDir, "warehouse.db")
+	store, err := warehouse.NewSQLiteWarehouse(warehouse.SQLiteWarehouseConfig{Path: warehousePath})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if _, err := store.Exec(context.Background(), `CREATE TABLE aws_s3_buckets (id TEXT, name TEXT)`); err != nil {
+		t.Fatalf("create warehouse table: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close seeded warehouse: %v", err)
+	}
+
+	configureDirectQuerySQLiteEnv(t, tempDir, warehousePath)
+	queryFormat = FormatJSON
+	queryLimit = 10
+
+	output := captureStdout(t, func() {
+		if err := runQueryDirect(queryCmd, []string{"DESCRIBE", "TABLE", "aws_s3_buckets"}); err != nil {
+			t.Fatalf("runQueryDirect failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, `"column_name": "id"`) || !strings.Contains(output, `"column_name": "name"`) {
+		t.Fatalf("expected DESCRIBE TABLE output to include table columns, got %s", output)
+	}
+}
+
+func TestRunQueryDirect_PreservesExplicitLimit(t *testing.T) {
+	state := snapshotQueryCLIState()
+	t.Cleanup(func() { restoreQueryCLIState(state) })
+
+	tempDir := t.TempDir()
+	warehousePath := filepath.Join(tempDir, "warehouse.db")
+	store, err := warehouse.NewSQLiteWarehouse(warehouse.SQLiteWarehouseConfig{Path: warehousePath})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if _, err := store.Exec(context.Background(), `CREATE TABLE aws_s3_buckets (id TEXT, name TEXT)`); err != nil {
+		t.Fatalf("create warehouse table: %v", err)
+	}
+	if _, err := store.Exec(context.Background(), `INSERT INTO aws_s3_buckets (id, name) VALUES (?, ?)`, "bucket-1", "bucket-a"); err != nil {
+		t.Fatalf("insert warehouse row: %v", err)
+	}
+	if _, err := store.Exec(context.Background(), `INSERT INTO aws_s3_buckets (id, name) VALUES (?, ?)`, "bucket-2", "bucket-b"); err != nil {
+		t.Fatalf("insert warehouse row: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close seeded warehouse: %v", err)
+	}
+
+	configureDirectQuerySQLiteEnv(t, tempDir, warehousePath)
+	queryFormat = FormatJSON
+	queryLimit = 1
+
+	output := captureStdout(t, func() {
+		if err := runQueryDirect(queryCmd, []string{"SELECT", "name", "FROM", "aws_s3_buckets", "LIMIT", "2"}); err != nil {
+			t.Fatalf("runQueryDirect failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, `"count": 2`) {
+		t.Fatalf("expected direct query to preserve explicit limit, got %s", output)
+	}
+}
+
 func TestPrepareDirectMetadataQuery_RejectsMutatingPragma(t *testing.T) {
 	if _, _, _, err := prepareDirectMetadataQuery("PRAGMA journal_mode=WAL"); err == nil || !strings.Contains(err.Error(), "read-only PRAGMA") {
 		t.Fatalf("expected read-only PRAGMA rejection, got %v", err)

--- a/internal/cli/query_direct_test.go
+++ b/internal/cli/query_direct_test.go
@@ -69,3 +69,100 @@ func TestRunQueryDirect_UsesConfiguredWarehouse(t *testing.T) {
 		t.Fatalf("expected warehouse query output to include bucket-a, got %s", output)
 	}
 }
+
+func TestRunQueryDirect_SupportsShowTables(t *testing.T) {
+	state := snapshotQueryCLIState()
+	t.Cleanup(func() { restoreQueryCLIState(state) })
+
+	tempDir := t.TempDir()
+	warehousePath := filepath.Join(tempDir, "warehouse.db")
+	store, err := warehouse.NewSQLiteWarehouse(warehouse.SQLiteWarehouseConfig{Path: warehousePath})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if _, err := store.Exec(context.Background(), `CREATE TABLE aws_s3_buckets (id TEXT)`); err != nil {
+		t.Fatalf("create warehouse table: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close seeded warehouse: %v", err)
+	}
+
+	configureDirectQuerySQLiteEnv(t, tempDir, warehousePath)
+	queryFormat = FormatJSON
+	queryLimit = 10
+
+	output := captureStdout(t, func() {
+		if err := runQueryDirect(queryCmd, []string{"SHOW", "TABLES"}); err != nil {
+			t.Fatalf("runQueryDirect failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "aws_s3_buckets") {
+		t.Fatalf("expected SHOW TABLES output to include aws_s3_buckets, got %s", output)
+	}
+}
+
+func TestRunQueryDirect_AllowsReadOnlyPragmaMetadata(t *testing.T) {
+	state := snapshotQueryCLIState()
+	t.Cleanup(func() { restoreQueryCLIState(state) })
+
+	tempDir := t.TempDir()
+	warehousePath := filepath.Join(tempDir, "warehouse.db")
+	store, err := warehouse.NewSQLiteWarehouse(warehouse.SQLiteWarehouseConfig{Path: warehousePath})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if _, err := store.Exec(context.Background(), `CREATE TABLE aws_s3_buckets (id TEXT, name TEXT)`); err != nil {
+		t.Fatalf("create warehouse table: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close seeded warehouse: %v", err)
+	}
+
+	configureDirectQuerySQLiteEnv(t, tempDir, warehousePath)
+	queryFormat = FormatJSON
+	queryLimit = 10
+
+	output := captureStdout(t, func() {
+		if err := runQueryDirect(queryCmd, []string{"PRAGMA", "table_info(aws_s3_buckets)"}); err != nil {
+			t.Fatalf("runQueryDirect failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, `"name": "id"`) || !strings.Contains(output, `"name": "name"`) {
+		t.Fatalf("expected PRAGMA output to include table columns, got %s", output)
+	}
+}
+
+func TestPrepareDirectMetadataQuery_RejectsMutatingPragma(t *testing.T) {
+	if _, _, _, err := prepareDirectMetadataQuery("PRAGMA journal_mode=WAL"); err == nil || !strings.Contains(err.Error(), "read-only PRAGMA") {
+		t.Fatalf("expected read-only PRAGMA rejection, got %v", err)
+	}
+}
+
+func configureDirectQuerySQLiteEnv(t *testing.T, tempDir, warehousePath string) {
+	t.Helper()
+
+	policyDir := filepath.Join(tempDir, "policies")
+	if err := os.MkdirAll(policyDir, 0o750); err != nil {
+		t.Fatalf("mkdir policy dir: %v", err)
+	}
+
+	t.Setenv("SNOWFLAKE_PRIVATE_KEY", "")
+	t.Setenv("SNOWFLAKE_ACCOUNT", "")
+	t.Setenv("SNOWFLAKE_USER", "")
+	t.Setenv("API_AUTH_ENABLED", "false")
+	t.Setenv("API_KEYS", "")
+	t.Setenv("WAREHOUSE_BACKEND", "sqlite")
+	t.Setenv("WAREHOUSE_SQLITE_PATH", warehousePath)
+	t.Setenv("EXECUTION_STORE_FILE", filepath.Join(tempDir, "executions.db"))
+	t.Setenv("GRAPH_SNAPSHOT_PATH", filepath.Join(tempDir, "graph-snapshots"))
+	t.Setenv("PLATFORM_REPORT_RUN_STATE_FILE", filepath.Join(tempDir, "report-runs.json"))
+	t.Setenv("PLATFORM_REPORT_SNAPSHOT_PATH", filepath.Join(tempDir, "report-snapshots"))
+	t.Setenv("CEREBRO_DB_PATH", filepath.Join(tempDir, "findings.db"))
+	t.Setenv("POLICIES_PATH", policyDir)
+}

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -112,7 +112,7 @@ func runWorker(cmd *cobra.Command, args []string) error {
 
 	// Create security tools for job execution
 	tools := agents.NewSecurityTools(
-		application.Snowflake,
+		application.Warehouse,
 		application.Findings,
 		application.Policy,
 		scm.NewConfiguredClient(

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/writer/cerebro/internal/snowflake"
+	"github.com/writer/cerebro/internal/warehouse"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -181,7 +181,7 @@ type BaseProvider struct {
 	provType   ProviderType
 	config     map[string]interface{}
 	configured bool
-	snowflake  *snowflake.Client
+	warehouse  warehouse.DataWarehouse
 	mu         sync.RWMutex
 }
 

--- a/internal/providers/storage.go
+++ b/internal/providers/storage.go
@@ -42,8 +42,7 @@ func (b *BaseProvider) syncTable(ctx context.Context, schema TableSchema, rows [
 		return result, nil
 	}
 
-	columns := schemaColumnNames(schema.Columns)
-	if err := ensureProviderTable(ctx, store, schema.Name, columns); err != nil {
+	if err := ensureProviderTable(ctx, store, schema.Name, schema.Columns); err != nil {
 		return result, err
 	}
 
@@ -60,7 +59,7 @@ func (b *BaseProvider) syncTable(ctx context.Context, schema TableSchema, rows [
 	newIDs := providerRowIDSet(prepared)
 
 	// Atomic upsert via dialect-specific merge/upsert; no delete-before-insert window.
-	if err := mergeProviderRows(ctx, store, schema.Name, prepared); err != nil {
+	if err := mergeProviderRows(ctx, store, schema.Name, schema.Columns, prepared); err != nil {
 		return result, err
 	}
 
@@ -88,8 +87,11 @@ func schemaColumnNames(columns []ColumnSchema) []string {
 	return names
 }
 
-func ensureProviderTable(ctx context.Context, store providerWarehouseClient, table string, columns []string) error {
-	err := tableops.EnsureVariantTable(ctx, store, table, columns, tableops.EnsureVariantTableOptions{
+func ensureProviderTable(ctx context.Context, store providerWarehouseClient, table string, columns []ColumnSchema) error {
+	if providerUsesTypedStorage(store) {
+		return ensureTypedProviderTable(ctx, store, table, columns)
+	}
+	err := tableops.EnsureVariantTable(ctx, store, table, schemaColumnNames(columns), tableops.EnsureVariantTableOptions{
 		AddMissingColumns: true,
 	})
 	if err == nil {
@@ -296,8 +298,15 @@ func formatProviderIDValue(value interface{}) string {
 	}
 }
 
-func mergeProviderRows(ctx context.Context, store providerWarehouseClient, table string, rows []map[string]interface{}) error {
+func mergeProviderRows(ctx context.Context, store providerWarehouseClient, table string, columns []ColumnSchema, rows []map[string]interface{}) error {
+	if providerUsesTypedStorage(store) {
+		return mergeTypedProviderRows(ctx, store, table, columns, rows)
+	}
 	return tableops.MergeVariantRowsBatch(ctx, store, table, rows, nil, providerInsertBatchSize)
+}
+
+func providerUsesTypedStorage(store providerWarehouseClient) bool {
+	return warehouse.Dialect(store) != warehouse.SQLDialectSnowflake
 }
 
 func hashProviderRow(row map[string]interface{}) string {

--- a/internal/providers/storage.go
+++ b/internal/providers/storage.go
@@ -164,7 +164,7 @@ func deleteProviderRowsByID(ctx context.Context, store providerWarehouseClient, 
 		}
 
 		batch := keys[start:end]
-		placeholders := strings.TrimRight(strings.Repeat("?,", len(batch)), ",")
+		placeholders := strings.Join(warehouse.Placeholders(store, 1, len(batch)), ",")
 		args := make([]interface{}, 0, len(batch))
 		for _, id := range batch {
 			args = append(args, id)

--- a/internal/providers/storage.go
+++ b/internal/providers/storage.go
@@ -3,7 +3,6 @@ package providers
 import (
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -13,37 +12,38 @@ import (
 
 	"github.com/writer/cerebro/internal/snowflake"
 	"github.com/writer/cerebro/internal/snowflake/tableops"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 const providerInsertBatchSize = 200
 
-type providerSnowflakeClient interface {
-	Exec(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
-	Query(ctx context.Context, query string, args ...interface{}) (*snowflake.QueryResult, error)
+type providerWarehouseClient interface {
+	warehouse.ExecWarehouse
+	warehouse.QueryWarehouse
 }
 
-func (b *BaseProvider) SetSnowflakeClient(client *snowflake.Client) {
+func (b *BaseProvider) SetWarehouse(store warehouse.DataWarehouse) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.snowflake = client
+	b.warehouse = store
 }
 
-func (b *BaseProvider) getSnowflakeClient() *snowflake.Client {
+func (b *BaseProvider) getWarehouse() warehouse.DataWarehouse {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
-	return b.snowflake
+	return b.warehouse
 }
 
 func (b *BaseProvider) syncTable(ctx context.Context, schema TableSchema, rows []map[string]interface{}) (*TableResult, error) {
 	result := &TableResult{Name: schema.Name, Rows: int64(len(rows))}
-	sf := b.getSnowflakeClient()
-	if sf == nil {
+	store := b.getWarehouse()
+	if store == nil {
 		result.Inserted = result.Rows
 		return result, nil
 	}
 
 	columns := schemaColumnNames(schema.Columns)
-	if err := ensureProviderTable(ctx, sf, schema.Name, columns); err != nil {
+	if err := ensureProviderTable(ctx, store, schema.Name, columns); err != nil {
 		return result, err
 	}
 
@@ -52,15 +52,15 @@ func (b *BaseProvider) syncTable(ctx context.Context, schema TableSchema, rows [
 		result.Rows = int64(len(prepared))
 	}
 
-	existingIDs, err := listProviderExistingIDs(ctx, sf, schema.Name)
+	existingIDs, err := listProviderExistingIDs(ctx, store, schema.Name)
 	if err != nil {
 		return result, err
 	}
 
 	newIDs := providerRowIDSet(prepared)
 
-	// Atomic upsert via MERGE - no delete-before-insert window.
-	if err := mergeProviderRows(ctx, sf, schema.Name, prepared); err != nil {
+	// Atomic upsert via dialect-specific merge/upsert; no delete-before-insert window.
+	if err := mergeProviderRows(ctx, store, schema.Name, prepared); err != nil {
 		return result, err
 	}
 
@@ -70,7 +70,7 @@ func (b *BaseProvider) syncTable(ctx context.Context, schema TableSchema, rows [
 			removedIDs[id] = struct{}{}
 		}
 	}
-	if err := deleteProviderRowsByID(ctx, sf, schema.Name, removedIDs); err != nil {
+	if err := deleteProviderRowsByID(ctx, store, schema.Name, removedIDs); err != nil {
 		return result, err
 	}
 
@@ -88,8 +88,8 @@ func schemaColumnNames(columns []ColumnSchema) []string {
 	return names
 }
 
-func ensureProviderTable(ctx context.Context, sf providerSnowflakeClient, table string, columns []string) error {
-	err := tableops.EnsureVariantTable(ctx, sf, table, columns, tableops.EnsureVariantTableOptions{
+func ensureProviderTable(ctx context.Context, store providerWarehouseClient, table string, columns []string) error {
+	err := tableops.EnsureVariantTable(ctx, store, table, columns, tableops.EnsureVariantTableOptions{
 		AddMissingColumns: true,
 	})
 	if err == nil {
@@ -101,13 +101,13 @@ func ensureProviderTable(ctx context.Context, sf providerSnowflakeClient, table 
 	return err
 }
 
-func listProviderExistingIDs(ctx context.Context, sf providerSnowflakeClient, table string) (map[string]struct{}, error) {
+func listProviderExistingIDs(ctx context.Context, store providerWarehouseClient, table string) (map[string]struct{}, error) {
 	if err := snowflake.ValidateTableName(table); err != nil {
 		return nil, fmt.Errorf("invalid table name %s: %w", table, err)
 	}
 
 	query := fmt.Sprintf("SELECT _CQ_ID FROM %s", table)
-	result, err := sf.Query(ctx, query)
+	result, err := store.Query(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("list existing provider rows: %w", err)
 	}
@@ -137,7 +137,7 @@ func providerRowIDSet(rows []map[string]interface{}) map[string]struct{} {
 	return ids
 }
 
-func deleteProviderRowsByID(ctx context.Context, sf providerSnowflakeClient, table string, ids map[string]struct{}) error {
+func deleteProviderRowsByID(ctx context.Context, store providerWarehouseClient, table string, ids map[string]struct{}) error {
 	if len(ids) == 0 {
 		return nil
 	}
@@ -170,7 +170,7 @@ func deleteProviderRowsByID(ctx context.Context, sf providerSnowflakeClient, tab
 			args = append(args, id)
 		}
 		query := fmt.Sprintf("DELETE FROM %s WHERE _CQ_ID IN (%s)", table, placeholders)
-		if _, err := sf.Exec(ctx, query, args...); err != nil {
+		if _, err := store.Exec(ctx, query, args...); err != nil {
 			return fmt.Errorf("delete provider rows by id: %w", err)
 		}
 	}
@@ -296,8 +296,8 @@ func formatProviderIDValue(value interface{}) string {
 	}
 }
 
-func mergeProviderRows(ctx context.Context, sf providerSnowflakeClient, table string, rows []map[string]interface{}) error {
-	return tableops.MergeVariantRowsBatch(ctx, sf, table, rows, nil, providerInsertBatchSize)
+func mergeProviderRows(ctx context.Context, store providerWarehouseClient, table string, rows []map[string]interface{}) error {
+	return tableops.MergeVariantRowsBatch(ctx, store, table, rows, nil, providerInsertBatchSize)
 }
 
 func hashProviderRow(row map[string]interface{}) string {

--- a/internal/providers/storage_test.go
+++ b/internal/providers/storage_test.go
@@ -49,7 +49,7 @@ func (f *fakeSnowflakeClient) Query(ctx context.Context, query string, args ...i
 func TestEnsureProviderTable_PropagatesColumnError(t *testing.T) {
 	client := &fakeSnowflakeClient{queryErr: errors.New("query failed")}
 
-	err := ensureProviderTable(context.Background(), client, "okta_users", []string{"id"})
+	err := ensureProviderTable(context.Background(), client, "okta_users", []ColumnSchema{{Name: "id", Type: "string"}})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -99,7 +99,7 @@ func TestEnsureProviderTable_UsesIdempotentAlter(t *testing.T) {
 		{"column_name": "_CQ_ID"},
 	}}}
 
-	if err := ensureProviderTable(context.Background(), client, "okta_users", []string{"id"}); err != nil {
+	if err := ensureProviderTable(context.Background(), client, "okta_users", []ColumnSchema{{Name: "id", Type: "string"}}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -121,7 +121,7 @@ func TestEnsureProviderTable_SkipsExistingColumnsCaseInsensitive(t *testing.T) {
 		{"column_name": "_CQ_HASH"},
 	}}}
 
-	if err := ensureProviderTable(context.Background(), client, "okta_users", []string{"id"}); err != nil {
+	if err := ensureProviderTable(context.Background(), client, "okta_users", []ColumnSchema{{Name: "id", Type: "string"}}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -142,6 +142,7 @@ func TestBaseProviderSyncTable_UsesConfiguredWarehouse(t *testing.T) {
 				{"column_name": "_CQ_HASH"},
 				{"column_name": "ID"},
 				{"column_name": "EMAIL"},
+				{"column_name": "ACCOUNT_ENABLED"},
 			}}, nil
 		},
 	})
@@ -149,12 +150,13 @@ func TestBaseProviderSyncTable_UsesConfiguredWarehouse(t *testing.T) {
 	result, err := provider.syncTable(context.Background(), TableSchema{
 		Name: "okta_users",
 		Columns: []ColumnSchema{
-			{Name: "id"},
-			{Name: "email"},
+			{Name: "id", Type: "string"},
+			{Name: "email", Type: "string"},
+			{Name: "account_enabled", Type: "boolean"},
 		},
 		PrimaryKey: []string{"id"},
 	}, []map[string]interface{}{
-		{"id": "user-1", "email": "user@example.com"},
+		{"id": "user-1", "email": "user@example.com", "account_enabled": true},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -168,14 +170,65 @@ func TestBaseProviderSyncTable_UsesConfiguredWarehouse(t *testing.T) {
 		t.Fatal("expected configured memory warehouse")
 	}
 	foundUpsert := false
+	foundTypedCreate := false
+	foundNativeBoolArg := false
 	for _, call := range mem.Execs {
 		if strings.Contains(call.Statement, "ON CONFLICT (_CQ_ID) DO UPDATE") {
 			foundUpsert = true
-			break
+		}
+		if strings.Contains(call.Statement, "ACCOUNT_ENABLED BOOLEAN") {
+			foundTypedCreate = true
+		}
+		for _, arg := range call.Args {
+			if typed, ok := arg.(bool); ok && typed {
+				foundNativeBoolArg = true
+			}
 		}
 	}
 	if !foundUpsert {
 		t.Fatalf("expected postgres upsert query, got %#v", mem.Execs)
+	}
+	if !foundTypedCreate {
+		t.Fatalf("expected typed boolean provider column, got %#v", mem.Execs)
+	}
+	if !foundNativeBoolArg {
+		t.Fatalf("expected native bool argument, got %#v", mem.Execs)
+	}
+}
+
+func TestBaseProviderSyncTable_StoresTypedProviderColumnsInSQLite(t *testing.T) {
+	store, err := warehouse.NewSQLiteWarehouse(warehouse.SQLiteWarehouseConfig{
+		Path: filepath.Join(t.TempDir(), "providers.db"),
+	})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	provider := NewBaseProvider("entra", ProviderTypeIdentity)
+	provider.SetWarehouse(store)
+
+	_, err = provider.syncTable(context.Background(), TableSchema{
+		Name: "entra_users",
+		Columns: []ColumnSchema{
+			{Name: "id", Type: "string"},
+			{Name: "account_enabled", Type: "boolean"},
+			{Name: "display_name", Type: "string"},
+		},
+		PrimaryKey: []string{"id"},
+	}, []map[string]interface{}{
+		{"id": "user-1", "account_enabled": true, "display_name": "User One"},
+	})
+	if err != nil {
+		t.Fatalf("syncTable() error = %v", err)
+	}
+
+	result, err := store.Query(context.Background(), "SELECT id FROM entra_users WHERE account_enabled = true")
+	if err != nil {
+		t.Fatalf("query typed provider column: %v", err)
+	}
+	if result.Count != 1 || result.Rows[0]["id"] != "user-1" {
+		t.Fatalf("expected native boolean query to match synced row, got %#v", result.Rows)
 	}
 }
 

--- a/internal/providers/storage_test.go
+++ b/internal/providers/storage_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/writer/cerebro/internal/snowflake"
+	"github.com/writer/cerebro/internal/warehouse"
 )
 
 type fakeSnowflakeResult struct{}
@@ -128,5 +129,52 @@ func TestEnsureProviderTable_SkipsExistingColumnsCaseInsensitive(t *testing.T) {
 		if strings.Contains(query, "ALTER TABLE okta_users ADD COLUMN IF NOT EXISTS ID VARIANT") {
 			t.Fatalf("did not expect alter for existing column, queries: %v", client.execQueries)
 		}
+	}
+}
+
+func TestBaseProviderSyncTable_UsesConfiguredWarehouse(t *testing.T) {
+	provider := NewBaseProvider("okta", ProviderTypeIdentity)
+	provider.SetWarehouse(&warehouse.MemoryWarehouse{
+		DialectValue: warehouse.SQLDialectPostgres,
+		QueryFunc: func(ctx context.Context, query string, args ...any) (*snowflake.QueryResult, error) {
+			return &snowflake.QueryResult{Rows: []map[string]interface{}{
+				{"column_name": "_CQ_ID"},
+				{"column_name": "_CQ_HASH"},
+				{"column_name": "ID"},
+				{"column_name": "EMAIL"},
+			}}, nil
+		},
+	})
+
+	result, err := provider.syncTable(context.Background(), TableSchema{
+		Name: "okta_users",
+		Columns: []ColumnSchema{
+			{Name: "id"},
+			{Name: "email"},
+		},
+		PrimaryKey: []string{"id"},
+	}, []map[string]interface{}{
+		{"id": "user-1", "email": "user@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Inserted != 1 {
+		t.Fatalf("Inserted = %d, want 1", result.Inserted)
+	}
+
+	mem, ok := provider.getWarehouse().(*warehouse.MemoryWarehouse)
+	if !ok {
+		t.Fatal("expected configured memory warehouse")
+	}
+	foundUpsert := false
+	for _, call := range mem.Execs {
+		if strings.Contains(call.Statement, "ON CONFLICT (_CQ_ID) DO UPDATE") {
+			foundUpsert = true
+			break
+		}
+	}
+	if !foundUpsert {
+		t.Fatalf("expected postgres upsert query, got %#v", mem.Execs)
 	}
 }

--- a/internal/providers/storage_test.go
+++ b/internal/providers/storage_test.go
@@ -178,3 +178,32 @@ func TestBaseProviderSyncTable_UsesConfiguredWarehouse(t *testing.T) {
 		t.Fatalf("expected postgres upsert query, got %#v", mem.Execs)
 	}
 }
+
+func TestDeleteProviderRowsByIDUsesDialectAwarePlaceholders(t *testing.T) {
+	tests := []struct {
+		name      string
+		dialect   warehouse.SQLDialect
+		wantQuery string
+	}{
+		{name: "postgres", dialect: warehouse.SQLDialectPostgres, wantQuery: "DELETE FROM okta_users WHERE _CQ_ID IN ($1,$2)"},
+		{name: "sqlite", dialect: warehouse.SQLDialectSQLite, wantQuery: "DELETE FROM okta_users WHERE _CQ_ID IN (?,?)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &warehouse.MemoryWarehouse{DialectValue: tt.dialect}
+			if err := deleteProviderRowsByID(context.Background(), store, "okta_users", map[string]struct{}{
+				"user-1": {},
+				"user-2": {},
+			}); err != nil {
+				t.Fatalf("deleteProviderRowsByID() error = %v", err)
+			}
+			if len(store.Execs) != 1 {
+				t.Fatalf("expected one delete exec, got %#v", store.Execs)
+			}
+			if store.Execs[0].Statement != tt.wantQuery {
+				t.Fatalf("delete query = %q, want %q", store.Execs[0].Statement, tt.wantQuery)
+			}
+		})
+	}
+}

--- a/internal/providers/storage_typed.go
+++ b/internal/providers/storage_typed.go
@@ -1,0 +1,496 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/snowflake"
+	"github.com/writer/cerebro/internal/warehouse"
+)
+
+func ensureTypedProviderTable(ctx context.Context, store providerWarehouseClient, table string, columns []ColumnSchema) error {
+	if err := snowflake.ValidateTableName(table); err != nil {
+		return fmt.Errorf("invalid table name: %w", err)
+	}
+
+	normalizedColumns := normalizedProviderColumns(columns)
+	if err := validateProviderColumns(normalizedColumns); err != nil {
+		return err
+	}
+
+	columnDefs := make([]string, 0, len(normalizedColumns)+3)
+	columnDefs = append(columnDefs,
+		"_CQ_ID VARCHAR PRIMARY KEY",
+		fmt.Sprintf("_CQ_SYNC_TIME %s DEFAULT CURRENT_TIMESTAMP()", warehouse.TimestampColumnType(store)),
+		"_CQ_HASH VARCHAR",
+	)
+	for _, column := range normalizedColumns {
+		columnDefs = append(columnDefs, fmt.Sprintf("%s %s", column.Name, providerColumnSQLType(store, column)))
+	}
+
+	createQuery := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n\t%s\n)", table, strings.Join(columnDefs, ",\n\t"))
+	if _, err := store.Exec(ctx, createQuery); err != nil {
+		return fmt.Errorf("create table: %w", err)
+	}
+
+	existingColumns, err := providerTableColumns(ctx, store, table)
+	if err != nil {
+		return fmt.Errorf("get existing columns: %w", err)
+	}
+
+	desiredColumns := append([]ColumnSchema{{Name: "_CQ_HASH", Type: "string"}}, normalizedColumns...)
+	for _, column := range providerColumnsMissingFromSchema(existingColumns, desiredColumns) {
+		query := fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s", table, column.Name, providerColumnSQLType(store, column))
+		if _, err := store.Exec(ctx, query); err != nil {
+			return fmt.Errorf("add column %s: %w", column.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func mergeTypedProviderRows(ctx context.Context, store providerWarehouseClient, table string, columns []ColumnSchema, rows []map[string]interface{}) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	if err := snowflake.ValidateTableName(table); err != nil {
+		return fmt.Errorf("invalid table name: %w", err)
+	}
+
+	normalizedColumns := normalizedProviderColumns(columns)
+	if err := validateProviderColumns(normalizedColumns); err != nil {
+		return err
+	}
+
+	for start := 0; start < len(rows); start += providerInsertBatchSize {
+		end := start + providerInsertBatchSize
+		if end > len(rows) {
+			end = len(rows)
+		}
+
+		query, args, err := buildTypedProviderUpsertQuery(rows[start:end], normalizedColumns, store, table)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(query) == "" {
+			continue
+		}
+		if _, err := store.Exec(ctx, query, args...); err != nil {
+			return fmt.Errorf("merge rows: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func buildTypedProviderUpsertQuery(batch []map[string]interface{}, columns []ColumnSchema, store providerWarehouseClient, table string) (string, []interface{}, error) {
+	allColumns := make([]string, 0, len(columns)+2)
+	allColumns = append(allColumns, "_CQ_ID", "_CQ_HASH")
+	for _, column := range columns {
+		allColumns = append(allColumns, column.Name)
+	}
+
+	values := make([]string, 0, len(batch))
+	args := make([]interface{}, 0, len(batch)*len(allColumns))
+
+	for _, row := range batch {
+		idValue, _ := lookupProviderValue(row, "_cq_id")
+		id := strings.TrimSpace(providerStringValue(idValue))
+		if id == "" {
+			continue
+		}
+
+		hashValue, _ := lookupProviderValue(row, "_cq_hash")
+		hash := providerStringValue(hashValue)
+
+		valueParts := make([]string, 0, len(allColumns))
+		valueParts = append(valueParts, warehouse.Placeholder(store, len(args)+1), warehouse.Placeholder(store, len(args)+2))
+		args = append(args, id, hash)
+
+		for _, column := range columns {
+			rawValue, _ := lookupProviderValue(row, column.Name)
+			valueParts = append(valueParts, providerColumnPlaceholder(store, column, len(args)+1))
+			args = append(args, coerceProviderColumnValue(column, rawValue))
+		}
+
+		values = append(values, "("+strings.Join(valueParts, ", ")+")")
+	}
+
+	if len(values) == 0 {
+		return "", nil, nil
+	}
+
+	updateParts := make([]string, 0, len(columns)+1)
+	updateParts = append(updateParts, "_CQ_HASH = EXCLUDED._CQ_HASH")
+	for _, column := range columns {
+		updateParts = append(updateParts, fmt.Sprintf("%s = EXCLUDED.%s", column.Name, column.Name))
+	}
+
+	query := fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES %s ON CONFLICT (_CQ_ID) DO UPDATE SET %s",
+		table,
+		strings.Join(allColumns, ", "),
+		strings.Join(values, ", "),
+		strings.Join(updateParts, ", "),
+	)
+	return query, args, nil
+}
+
+func providerTableColumns(ctx context.Context, store providerWarehouseClient, table string) ([]string, error) {
+	query := `
+		SELECT COLUMN_NAME
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_NAME = ` + warehouse.Placeholder(store, 1) + `
+		AND TABLE_SCHEMA = CURRENT_SCHEMA()
+	`
+
+	result, err := store.Query(ctx, query, strings.ToUpper(table))
+	if err != nil {
+		return nil, err
+	}
+
+	columns := make([]string, 0, len(result.Rows))
+	for _, row := range result.Rows {
+		value, _ := lookupProviderValue(row, "column_name")
+		if name := strings.TrimSpace(providerStringValue(value)); name != "" {
+			columns = append(columns, name)
+		}
+	}
+	return columns, nil
+}
+
+func normalizedProviderColumns(columns []ColumnSchema) []ColumnSchema {
+	seen := make(map[string]struct{}, len(columns))
+	normalized := make([]ColumnSchema, 0, len(columns))
+	for _, column := range columns {
+		name := strings.ToUpper(strings.TrimSpace(column.Name))
+		if name == "" || isProviderReservedColumn(name) {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		column.Name = name
+		normalized = append(normalized, column)
+	}
+	return normalized
+}
+
+func validateProviderColumns(columns []ColumnSchema) error {
+	for _, column := range columns {
+		if err := snowflake.ValidateColumnName(column.Name); err != nil {
+			return fmt.Errorf("invalid column name %q: %w", column.Name, err)
+		}
+	}
+	return nil
+}
+
+func providerColumnsMissingFromSchema(existing []string, desired []ColumnSchema) []ColumnSchema {
+	existingSet := make(map[string]struct{}, len(existing))
+	for _, column := range existing {
+		existingSet[strings.ToUpper(strings.TrimSpace(column))] = struct{}{}
+	}
+
+	missing := make([]ColumnSchema, 0, len(desired))
+	for _, column := range desired {
+		name := strings.ToUpper(strings.TrimSpace(column.Name))
+		if name == "" {
+			continue
+		}
+		if _, exists := existingSet[name]; exists {
+			continue
+		}
+		column.Name = name
+		missing = append(missing, column)
+	}
+	return missing
+}
+
+func providerColumnSQLType(target any, column ColumnSchema) string {
+	if strings.EqualFold(column.Name, "_CQ_HASH") {
+		return "VARCHAR"
+	}
+
+	switch normalizedProviderColumnType(column.Type) {
+	case "", "string":
+		if warehouse.Dialect(target) == warehouse.SQLDialectSnowflake {
+			return "VARCHAR"
+		}
+		return "TEXT"
+	case "boolean":
+		return "BOOLEAN"
+	case "integer":
+		return warehouse.IntegerColumnType(target)
+	case "number":
+		if warehouse.Dialect(target) == warehouse.SQLDialectSnowflake {
+			return "NUMBER"
+		}
+		return "NUMERIC"
+	case "float":
+		switch warehouse.Dialect(target) {
+		case warehouse.SQLDialectPostgres:
+			return "DOUBLE PRECISION"
+		case warehouse.SQLDialectSQLite:
+			return "REAL"
+		default:
+			return "FLOAT"
+		}
+	case "timestamp":
+		return warehouse.TimestampColumnType(target)
+	case "date":
+		if warehouse.Dialect(target) == warehouse.SQLDialectPostgres {
+			return "DATE"
+		}
+		if warehouse.Dialect(target) == warehouse.SQLDialectSnowflake {
+			return "DATE"
+		}
+		return "TEXT"
+	case "json", "object", "array", "variant":
+		return warehouse.JSONColumnType(target)
+	default:
+		return warehouse.JSONColumnType(target)
+	}
+}
+
+func providerColumnPlaceholder(target any, column ColumnSchema, position int) string {
+	switch normalizedProviderColumnType(column.Type) {
+	case "json", "object", "array", "variant":
+		return warehouse.JSONPlaceholder(target, position)
+	default:
+		return warehouse.Placeholder(target, position)
+	}
+}
+
+func normalizedProviderColumnType(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func coerceProviderColumnValue(column ColumnSchema, value interface{}) interface{} {
+	switch normalizedProviderColumnType(column.Type) {
+	case "", "string":
+		return coerceProviderStringValue(value)
+	case "boolean":
+		return coerceProviderBooleanValue(value)
+	case "integer":
+		return coerceProviderIntegerValue(value)
+	case "number", "float":
+		return coerceProviderFloatValue(value)
+	case "timestamp", "date":
+		return coerceProviderTimestampValue(value)
+	case "json", "object", "array", "variant":
+		return coerceProviderJSONValue(value)
+	default:
+		return coerceProviderJSONValue(value)
+	}
+}
+
+func coerceProviderStringValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case string:
+		return typed
+	case []byte:
+		return string(typed)
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+func coerceProviderBooleanValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case bool:
+		return typed
+	case string:
+		if parsed, err := strconv.ParseBool(strings.TrimSpace(typed)); err == nil {
+			return parsed
+		}
+	case []byte:
+		if parsed, err := strconv.ParseBool(strings.TrimSpace(string(typed))); err == nil {
+			return parsed
+		}
+	case int:
+		return typed != 0
+	case int8:
+		return typed != 0
+	case int16:
+		return typed != 0
+	case int32:
+		return typed != 0
+	case int64:
+		return typed != 0
+	case uint:
+		return typed != 0
+	case uint8:
+		return typed != 0
+	case uint16:
+		return typed != 0
+	case uint32:
+		return typed != 0
+	case uint64:
+		return typed != 0
+	case float32:
+		return typed != 0
+	case float64:
+		return typed != 0
+	case json.Number:
+		if parsed, err := typed.Int64(); err == nil {
+			return parsed != 0
+		}
+		if parsed, err := typed.Float64(); err == nil {
+			return parsed != 0
+		}
+	}
+	return value
+}
+
+func coerceProviderIntegerValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case int:
+		return int64(typed)
+	case int8:
+		return int64(typed)
+	case int16:
+		return int64(typed)
+	case int32:
+		return int64(typed)
+	case int64:
+		return typed
+	case uint:
+		return int64(typed)
+	case uint8:
+		return int64(typed)
+	case uint16:
+		return int64(typed)
+	case uint32:
+		return int64(typed)
+	case uint64:
+		if typed <= uint64(^uint64(0)>>1) {
+			return int64(typed)
+		}
+	case float32:
+		return int64(typed)
+	case float64:
+		return int64(typed)
+	case json.Number:
+		if parsed, err := typed.Int64(); err == nil {
+			return parsed
+		}
+		if parsed, err := typed.Float64(); err == nil {
+			return int64(parsed)
+		}
+	case string:
+		if parsed, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64); err == nil {
+			return parsed
+		}
+	case []byte:
+		if parsed, err := strconv.ParseInt(strings.TrimSpace(string(typed)), 10, 64); err == nil {
+			return parsed
+		}
+	}
+	return value
+}
+
+func coerceProviderFloatValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case float32:
+		return float64(typed)
+	case float64:
+		return typed
+	case int:
+		return float64(typed)
+	case int8:
+		return float64(typed)
+	case int16:
+		return float64(typed)
+	case int32:
+		return float64(typed)
+	case int64:
+		return float64(typed)
+	case uint:
+		return float64(typed)
+	case uint8:
+		return float64(typed)
+	case uint16:
+		return float64(typed)
+	case uint32:
+		return float64(typed)
+	case uint64:
+		return float64(typed)
+	case json.Number:
+		if parsed, err := typed.Float64(); err == nil {
+			return parsed
+		}
+		if parsed, err := typed.Int64(); err == nil {
+			return float64(parsed)
+		}
+	case string:
+		if parsed, err := strconv.ParseFloat(strings.TrimSpace(typed), 64); err == nil {
+			return parsed
+		}
+	case []byte:
+		if parsed, err := strconv.ParseFloat(strings.TrimSpace(string(typed)), 64); err == nil {
+			return parsed
+		}
+	}
+	return value
+}
+
+func coerceProviderTimestampValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case time.Time:
+		return typed.UTC().Format(time.RFC3339Nano)
+	case *time.Time:
+		if typed == nil {
+			return nil
+		}
+		return typed.UTC().Format(time.RFC3339Nano)
+	case string:
+		return strings.TrimSpace(typed)
+	case []byte:
+		return strings.TrimSpace(string(typed))
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+func coerceProviderJSONValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case json.RawMessage:
+		return string(typed)
+	case []byte:
+		trimmed := strings.TrimSpace(string(typed))
+		if json.Valid([]byte(trimmed)) {
+			return trimmed
+		}
+		value = string(typed)
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if json.Valid([]byte(trimmed)) {
+			return trimmed
+		}
+	}
+
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprint(value)
+	}
+	return string(encoded)
+}

--- a/internal/warehouse/dialect.go
+++ b/internal/warehouse/dialect.go
@@ -14,6 +14,8 @@ const (
 )
 
 var currentTimestampCallPattern = regexp.MustCompile(`(?i)CURRENT_TIMESTAMP\(\)`)
+var nowCallPattern = regexp.MustCompile(`(?i)\bNOW\s*\(\s*\)`)
+var sqliteCurrentTimestampIntervalPattern = regexp.MustCompile(`(?i)CURRENT_TIMESTAMP\s*([+-])\s*INTERVAL\s*'([0-9]+)\s+([a-z]+)'`)
 
 func DialectFor(schema SchemaWarehouse) string {
 	if schema == nil {
@@ -60,7 +62,9 @@ func rewriteForPostgres(query string) string {
 }
 
 func rewriteForSQLite(query string) string {
-	rewritten := currentTimestampCallPattern.ReplaceAllString(query, "CURRENT_TIMESTAMP")
+	rewritten := nowCallPattern.ReplaceAllString(query, "CURRENT_TIMESTAMP")
+	rewritten = currentTimestampCallPattern.ReplaceAllString(rewritten, "CURRENT_TIMESTAMP")
+	rewritten = rewriteSQLiteCurrentTimestampIntervals(rewritten)
 	rewritten = replaceKeyword(rewritten, "TIMESTAMP_TZ", "TEXT")
 	rewritten = replaceKeyword(rewritten, "TIMESTAMP_NTZ", "TEXT")
 	rewritten = replaceKeyword(rewritten, "VARIANT", "JSON")
@@ -68,6 +72,17 @@ func rewriteForSQLite(query string) string {
 	rewritten = rewriteJSONFunctions(rewritten, DialectSQLite)
 	rewritten = strings.ReplaceAll(rewritten, "::TIMESTAMP_TZ", "")
 	return rewritten
+}
+
+func rewriteSQLiteCurrentTimestampIntervals(query string) string {
+	return sqliteCurrentTimestampIntervalPattern.ReplaceAllStringFunc(query, func(match string) string {
+		parts := sqliteCurrentTimestampIntervalPattern.FindStringSubmatch(match)
+		if len(parts) != 4 {
+			return match
+		}
+		modifier := fmt.Sprintf("%s%s %s", parts[1], parts[2], strings.ToLower(parts[3]))
+		return fmt.Sprintf("DATETIME(CURRENT_TIMESTAMP, '%s')", modifier)
+	})
 }
 
 func rewriteQuestionPlaceholders(query string) string {

--- a/internal/warehouse/dialect_test.go
+++ b/internal/warehouse/dialect_test.go
@@ -28,3 +28,12 @@ func TestRewriteQueryForDialect_SQLite(t *testing.T) {
 		t.Fatalf("expected timestamp rewrite, got %q", got)
 	}
 }
+
+func TestRewriteQueryForDialect_SQLiteInterval(t *testing.T) {
+	query := `SELECT id FROM assets WHERE seen_at < NOW() - INTERVAL '7 days'`
+	got := RewriteQueryForDialect(query, DialectSQLite)
+
+	if !strings.Contains(got, "DATETIME(CURRENT_TIMESTAMP, '-7 days')") {
+		t.Fatalf("expected sqlite interval rewrite, got %q", got)
+	}
+}

--- a/internal/warehouse/postgres.go
+++ b/internal/warehouse/postgres.go
@@ -213,12 +213,12 @@ func (w *PostgresWarehouse) GetAssetByID(ctx context.Context, table, id string) 
 	if err != nil {
 		return nil, err
 	}
-	result, err := w.Query(ctx, "SELECT * FROM "+quoteSQLiteIdentifier(table)+" WHERE "+quoteSQLiteIdentifier("id")+" = $1 LIMIT 1", id)
+	result, err := w.Query(ctx, "SELECT * FROM "+quoteSQLiteIdentifier(table)+" WHERE "+quoteSQLiteIdentifier("_cq_id")+" = $1 LIMIT 1", id)
 	if err != nil {
 		return nil, err
 	}
 	if len(result.Rows) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("asset not found")
 	}
 	return result.Rows[0], nil
 }

--- a/internal/warehouse/query_validation.go
+++ b/internal/warehouse/query_validation.go
@@ -3,6 +3,7 @@ package warehouse
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -99,6 +100,9 @@ func BuildReadOnlyLimitedQuery(query string, limit int) (string, int, error) {
 
 	boundedLimit := ClampReadOnlyQueryLimit(limit)
 	trimmed := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(normalizedQuery), ";"))
+	if existingLimit, ok := topLevelLimitValue(trimmed); ok && existingLimit <= boundedLimit {
+		return trimmed, boundedLimit, nil
+	}
 
 	boundedQuery := fmt.Sprintf("SELECT * FROM (%s) AS cerebro_readonly_query LIMIT %d", trimmed, boundedLimit)
 	return boundedQuery, boundedLimit, nil
@@ -269,4 +273,89 @@ func normalizeReadOnlyDialect(query string) string {
 
 func isWordChar(c byte) bool {
 	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+func topLevelLimitValue(query string) (int, bool) {
+	if query == "" {
+		return 0, false
+	}
+
+	inSingleQuoted := false
+	inDoubleQuoted := false
+	depth := 0
+
+	for i := 0; i < len(query); i++ {
+		ch := query[i]
+
+		if inSingleQuoted {
+			if ch == '\'' {
+				if i+1 < len(query) && query[i+1] == '\'' {
+					i++
+					continue
+				}
+				inSingleQuoted = false
+			}
+			continue
+		}
+
+		if inDoubleQuoted {
+			if ch == '"' {
+				if i+1 < len(query) && query[i+1] == '"' {
+					i++
+					continue
+				}
+				inDoubleQuoted = false
+			}
+			continue
+		}
+
+		switch ch {
+		case '\'':
+			inSingleQuoted = true
+			continue
+		case '"':
+			inDoubleQuoted = true
+			continue
+		case '(':
+			depth++
+			continue
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+
+		if depth != 0 || i+5 > len(query) || !strings.EqualFold(query[i:i+5], "LIMIT") {
+			continue
+		}
+
+		beforeOK := i == 0 || !isWordChar(query[i-1])
+		afterIndex := i + 5
+		afterOK := afterIndex >= len(query) || !isWordChar(query[afterIndex])
+		if !beforeOK || !afterOK {
+			continue
+		}
+
+		j := afterIndex
+		for j < len(query) && (query[j] == ' ' || query[j] == '\t' || query[j] == '\n' || query[j] == '\r') {
+			j++
+		}
+
+		start := j
+		for j < len(query) && query[j] >= '0' && query[j] <= '9' {
+			j++
+		}
+		if start == j {
+			return 0, false
+		}
+
+		value, err := strconv.Atoi(query[start:j])
+		if err != nil {
+			return 0, false
+		}
+		return value, true
+	}
+
+	return 0, false
 }

--- a/internal/warehouse/query_validation.go
+++ b/internal/warehouse/query_validation.go
@@ -1,0 +1,272 @@
+package warehouse
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultReadOnlyQueryLimit   = 100
+	MaxReadOnlyQueryLimit       = 1000
+	DefaultReadOnlyQueryTimeout = 15 * time.Second
+	MaxReadOnlyQueryTimeout     = 60 * time.Second
+)
+
+var (
+	ErrEmptyQuery     = errors.New("query cannot be empty")
+	ErrNonSelectQuery = errors.New("only SELECT and WITH queries are allowed")
+	ErrSQLInjection   = errors.New("potential SQL injection detected")
+)
+
+var forbiddenReadOnlyKeywords = []string{
+	"INSERT", "UPDATE", "DELETE", "DROP", "TRUNCATE",
+	"CREATE", "ALTER", "GRANT", "REVOKE", "EXECUTE",
+	"CALL", "MERGE", "COPY", "PUT", "GET", "EXEC",
+}
+
+// ValidateReadOnlyQuery validates that a query is a safe read-only statement.
+func ValidateReadOnlyQuery(query string) error {
+	if strings.TrimSpace(query) == "" {
+		return ErrEmptyQuery
+	}
+
+	if strings.Contains(query, "--") || strings.Contains(query, "/*") || strings.Contains(query, "*/") {
+		return ErrSQLInjection
+	}
+
+	normalized := normalizeQuery(query)
+	if normalized == "" {
+		return ErrEmptyQuery
+	}
+
+	semicolonCount := strings.Count(normalized, ";")
+	if semicolonCount > 1 {
+		return ErrSQLInjection
+	}
+	if semicolonCount == 1 {
+		if !strings.HasSuffix(normalized, ";") {
+			return ErrSQLInjection
+		}
+		normalized = strings.TrimSpace(strings.TrimSuffix(normalized, ";"))
+	}
+
+	upper := strings.ToUpper(normalized)
+	if !strings.HasPrefix(upper, "SELECT") && !strings.HasPrefix(upper, "WITH") {
+		return ErrNonSelectQuery
+	}
+	sanitizedForKeywords := strings.ToUpper(stripQuotedLiterals(normalized))
+
+	for _, keyword := range forbiddenReadOnlyKeywords {
+		if containsKeyword(sanitizedForKeywords, keyword) {
+			return ErrSQLInjection
+		}
+	}
+
+	return nil
+}
+
+// ClampReadOnlyQueryLimit bounds query limits to safe defaults.
+func ClampReadOnlyQueryLimit(limit int) int {
+	if limit <= 0 {
+		return DefaultReadOnlyQueryLimit
+	}
+	if limit > MaxReadOnlyQueryLimit {
+		return MaxReadOnlyQueryLimit
+	}
+	return limit
+}
+
+// ClampReadOnlyQueryTimeout bounds per-request query timeout in seconds.
+func ClampReadOnlyQueryTimeout(timeoutSeconds int) time.Duration {
+	if timeoutSeconds <= 0 {
+		return DefaultReadOnlyQueryTimeout
+	}
+	timeout := time.Duration(timeoutSeconds) * time.Second
+	if timeout > MaxReadOnlyQueryTimeout {
+		return MaxReadOnlyQueryTimeout
+	}
+	return timeout
+}
+
+// BuildReadOnlyLimitedQuery validates read-only SQL and enforces row-limit pushdown.
+func BuildReadOnlyLimitedQuery(query string, limit int) (string, int, error) {
+	normalizedQuery := normalizeReadOnlyDialect(strings.TrimSpace(query))
+	if err := ValidateReadOnlyQuery(normalizedQuery); err != nil {
+		return "", 0, err
+	}
+
+	boundedLimit := ClampReadOnlyQueryLimit(limit)
+	trimmed := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(normalizedQuery), ";"))
+
+	boundedQuery := fmt.Sprintf("SELECT * FROM (%s) AS cerebro_readonly_query LIMIT %d", trimmed, boundedLimit)
+	return boundedQuery, boundedLimit, nil
+}
+
+func normalizeQuery(query string) string {
+	fields := strings.Fields(query)
+	return strings.Join(fields, " ")
+}
+
+func containsKeyword(sql, keyword string) bool {
+	idx := 0
+	for {
+		pos := strings.Index(sql[idx:], keyword)
+		if pos == -1 {
+			return false
+		}
+		pos += idx
+
+		validBefore := pos == 0 || !isWordChar(sql[pos-1])
+		validAfter := pos+len(keyword) >= len(sql) || !isWordChar(sql[pos+len(keyword)])
+
+		if validBefore && validAfter {
+			return true
+		}
+
+		idx = pos + 1
+		if idx >= len(sql) {
+			return false
+		}
+	}
+}
+
+func stripQuotedLiterals(query string) string {
+	if query == "" {
+		return ""
+	}
+
+	var out strings.Builder
+	out.Grow(len(query))
+
+	inSingleQuoted := false
+	inDoubleQuoted := false
+
+	for i := 0; i < len(query); i++ {
+		ch := query[i]
+
+		if inSingleQuoted {
+			if ch == '\'' {
+				if i+1 < len(query) && query[i+1] == '\'' {
+					i++
+					continue
+				}
+				inSingleQuoted = false
+			}
+			out.WriteByte(' ')
+			continue
+		}
+
+		if inDoubleQuoted {
+			if ch == '"' {
+				if i+1 < len(query) && query[i+1] == '"' {
+					i++
+					continue
+				}
+				inDoubleQuoted = false
+			}
+			out.WriteByte(' ')
+			continue
+		}
+
+		switch ch {
+		case '\'':
+			inSingleQuoted = true
+			out.WriteByte(' ')
+		case '"':
+			inDoubleQuoted = true
+			out.WriteByte(' ')
+		default:
+			out.WriteByte(ch)
+		}
+	}
+
+	return out.String()
+}
+
+func normalizeReadOnlyDialect(query string) string {
+	if query == "" {
+		return ""
+	}
+
+	var out strings.Builder
+	out.Grow(len(query) + 16)
+
+	inSingleQuoted := false
+	inDoubleQuoted := false
+
+	for i := 0; i < len(query); i++ {
+		ch := query[i]
+
+		if inSingleQuoted {
+			out.WriteByte(ch)
+			if ch == '\'' {
+				if i+1 < len(query) && query[i+1] == '\'' {
+					i++
+					out.WriteByte(query[i])
+					continue
+				}
+				inSingleQuoted = false
+			}
+			continue
+		}
+
+		if inDoubleQuoted {
+			out.WriteByte(ch)
+			if ch == '"' {
+				if i+1 < len(query) && query[i+1] == '"' {
+					i++
+					out.WriteByte(query[i])
+					continue
+				}
+				inDoubleQuoted = false
+			}
+			continue
+		}
+
+		if ch == '\'' {
+			inSingleQuoted = true
+			out.WriteByte(ch)
+			continue
+		}
+		if ch == '"' {
+			inDoubleQuoted = true
+			out.WriteByte(ch)
+			continue
+		}
+
+		if i+2 < len(query) && (query[i] == 'N' || query[i] == 'n') && (query[i+1] == 'O' || query[i+1] == 'o') && (query[i+2] == 'W' || query[i+2] == 'w') {
+			prevIsWord := i > 0 && isWordChar(query[i-1])
+			nextIndex := i + 3
+			if !prevIsWord {
+				for nextIndex < len(query) && (query[nextIndex] == ' ' || query[nextIndex] == '\t' || query[nextIndex] == '\n' || query[nextIndex] == '\r') {
+					nextIndex++
+				}
+				if nextIndex+1 < len(query) && query[nextIndex] == '(' {
+					close := nextIndex + 1
+					for close < len(query) && (query[close] == ' ' || query[close] == '\t' || query[close] == '\n' || query[close] == '\r') {
+						close++
+					}
+					if close < len(query) && query[close] == ')' {
+						after := close + 1
+						nextIsWord := after < len(query) && isWordChar(query[after])
+						if !nextIsWord {
+							out.WriteString("CURRENT_TIMESTAMP()")
+							i = close
+							continue
+						}
+					}
+				}
+			}
+		}
+
+		out.WriteByte(ch)
+	}
+
+	return out.String()
+}
+
+func isWordChar(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_'
+}

--- a/internal/warehouse/query_validation.go
+++ b/internal/warehouse/query_validation.go
@@ -93,19 +93,36 @@ func ClampReadOnlyQueryTimeout(timeoutSeconds int) time.Duration {
 
 // BuildReadOnlyLimitedQuery validates read-only SQL and enforces row-limit pushdown.
 func BuildReadOnlyLimitedQuery(query string, limit int) (string, int, error) {
-	normalizedQuery := normalizeReadOnlyDialect(strings.TrimSpace(query))
-	if err := ValidateReadOnlyQuery(normalizedQuery); err != nil {
+	trimmed, err := NormalizeReadOnlyQuery(query)
+	if err != nil {
 		return "", 0, err
 	}
-
 	boundedLimit := ClampReadOnlyQueryLimit(limit)
-	trimmed := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(normalizedQuery), ";"))
 	if existingLimit, ok := topLevelLimitValue(trimmed); ok && existingLimit <= boundedLimit {
 		return trimmed, boundedLimit, nil
 	}
 
 	boundedQuery := fmt.Sprintf("SELECT * FROM (%s) AS cerebro_readonly_query LIMIT %d", trimmed, boundedLimit)
 	return boundedQuery, boundedLimit, nil
+}
+
+// NormalizeReadOnlyQuery applies read-only SQL normalization and validation without changing limits.
+func NormalizeReadOnlyQuery(query string) (string, error) {
+	normalizedQuery := normalizeReadOnlyDialect(strings.TrimSpace(query))
+	if err := ValidateReadOnlyQuery(normalizedQuery); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(normalizedQuery), ";")), nil
+}
+
+// HasTopLevelLimit reports whether the query already includes a top-level LIMIT clause.
+func HasTopLevelLimit(query string) bool {
+	trimmed, err := NormalizeReadOnlyQuery(query)
+	if err != nil {
+		return false
+	}
+	_, ok := topLevelLimitValue(trimmed)
+	return ok
 }
 
 func normalizeQuery(query string) string {

--- a/internal/warehouse/query_validation_test.go
+++ b/internal/warehouse/query_validation_test.go
@@ -1,0 +1,168 @@
+package warehouse
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateReadOnlyQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		wantErr error
+	}{
+		{name: "valid select", query: "SELECT * FROM users", wantErr: nil},
+		{name: "valid with cte", query: "WITH recent AS (SELECT * FROM events) SELECT * FROM recent", wantErr: nil},
+		{name: "valid trailing semicolon", query: "SELECT * FROM users;", wantErr: nil},
+		{name: "empty query", query: "", wantErr: ErrEmptyQuery},
+		{name: "non read only query", query: "UPDATE users SET admin=true", wantErr: ErrNonSelectQuery},
+		{name: "inline comment rejected", query: "SELECT * FROM users -- test", wantErr: ErrSQLInjection},
+		{name: "block comment rejected", query: "SELECT /* test */ * FROM users", wantErr: ErrSQLInjection},
+		{name: "statement chaining rejected", query: "SELECT * FROM users; DROP TABLE users;", wantErr: ErrSQLInjection},
+		{name: "forbidden keyword rejected", query: "WITH x AS (SELECT * FROM users) DELETE FROM users", wantErr: ErrSQLInjection},
+		{name: "keyword in string literal allowed", query: "SELECT * FROM okta_system_logs WHERE event_type = 'policy.rule.delete'", wantErr: nil},
+		{name: "keyword in quoted identifier allowed", query: "SELECT \"grant\" FROM permissions", wantErr: nil},
+		{name: "keyword in escaped string literal allowed", query: "SELECT * FROM logs WHERE message = 'it''s safe to update'", wantErr: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateReadOnlyQuery(tt.query)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestBuildReadOnlyLimitedQuery(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		limit         int
+		wantErr       error
+		wantLimit     int
+		wantQueryPart string
+	}{
+		{
+			name:          "builds bounded query",
+			query:         "SELECT id FROM assets",
+			limit:         25,
+			wantLimit:     25,
+			wantQueryPart: "FROM (SELECT id FROM assets) AS cerebro_readonly_query LIMIT 25",
+		},
+		{
+			name:          "trims trailing semicolon",
+			query:         "SELECT * FROM findings;",
+			limit:         10,
+			wantLimit:     10,
+			wantQueryPart: "FROM (SELECT * FROM findings) AS cerebro_readonly_query LIMIT 10",
+		},
+		{
+			name:          "normalizes now function",
+			query:         "SELECT id FROM sentinelone_agents WHERE last_active_date < NOW() - INTERVAL '7 days'",
+			limit:         50,
+			wantLimit:     50,
+			wantQueryPart: "CURRENT_TIMESTAMP() - INTERVAL '7 days'",
+		},
+		{
+			name:          "applies default limit",
+			query:         "SELECT * FROM findings",
+			limit:         0,
+			wantLimit:     DefaultReadOnlyQueryLimit,
+			wantQueryPart: "LIMIT 100",
+		},
+		{
+			name:          "clamps max limit",
+			query:         "SELECT * FROM findings",
+			limit:         99999,
+			wantLimit:     MaxReadOnlyQueryLimit,
+			wantQueryPart: "LIMIT 1000",
+		},
+		{
+			name:    "rejects unsafe query",
+			query:   "DROP TABLE findings",
+			limit:   10,
+			wantErr: ErrNonSelectQuery,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotQuery, gotLimit, err := BuildReadOnlyLimitedQuery(tt.query, tt.limit)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if gotLimit != tt.wantLimit {
+				t.Fatalf("expected limit %d, got %d", tt.wantLimit, gotLimit)
+			}
+			if !strings.Contains(gotQuery, tt.wantQueryPart) {
+				t.Fatalf("expected query %q to contain %q", gotQuery, tt.wantQueryPart)
+			}
+		})
+	}
+}
+
+func TestNormalizeReadOnlyDialect(t *testing.T) {
+	input := "SELECT NOW(), 'NOW() in string', \"NOW\", now ( ) FROM dual"
+	normalized := normalizeReadOnlyDialect(input)
+
+	if strings.Count(normalized, "CURRENT_TIMESTAMP()") != 2 {
+		t.Fatalf("expected two NOW() replacements, got %q", normalized)
+	}
+	if !strings.Contains(normalized, "'NOW() in string'") {
+		t.Fatalf("expected single-quoted literal to remain untouched, got %q", normalized)
+	}
+	if !strings.Contains(normalized, "\"NOW\"") {
+		t.Fatalf("expected double-quoted identifier to remain untouched, got %q", normalized)
+	}
+}
+
+func TestStripQuotedLiterals(t *testing.T) {
+	query := "SELECT * FROM logs WHERE event_type = 'policy.rule.delete' AND \"grant\" = 'ok'"
+	stripped := stripQuotedLiterals(query)
+
+	if strings.Contains(strings.ToUpper(stripped), "DELETE") {
+		t.Fatalf("expected DELETE in string literal to be stripped, got %q", stripped)
+	}
+	if strings.Contains(strings.ToUpper(stripped), "GRANT\"") {
+		t.Fatalf("expected quoted identifier content to be stripped, got %q", stripped)
+	}
+}
+
+func TestClampReadOnlyQueryTimeout(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  int
+		expect time.Duration
+	}{
+		{name: "default when unset", input: 0, expect: DefaultReadOnlyQueryTimeout},
+		{name: "uses provided timeout", input: 5, expect: 5 * time.Second},
+		{name: "clamps max timeout", input: 999, expect: MaxReadOnlyQueryTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClampReadOnlyQueryTimeout(tt.input)
+			if got != tt.expect {
+				t.Fatalf("ClampReadOnlyQueryTimeout(%d) = %v, want %v", tt.input, got, tt.expect)
+			}
+		})
+	}
+}

--- a/internal/warehouse/query_validation_test.go
+++ b/internal/warehouse/query_validation_test.go
@@ -89,6 +89,13 @@ func TestBuildReadOnlyLimitedQuery(t *testing.T) {
 			wantQueryPart: "LIMIT 1000",
 		},
 		{
+			name:          "preserves explicit top level limit within bound",
+			query:         "SELECT * FROM findings LIMIT 10",
+			limit:         100,
+			wantLimit:     100,
+			wantQueryPart: "SELECT * FROM findings LIMIT 10",
+		},
+		{
 			name:    "rejects unsafe query",
 			query:   "DROP TABLE findings",
 			limit:   10,
@@ -114,6 +121,9 @@ func TestBuildReadOnlyLimitedQuery(t *testing.T) {
 			}
 			if !strings.Contains(gotQuery, tt.wantQueryPart) {
 				t.Fatalf("expected query %q to contain %q", gotQuery, tt.wantQueryPart)
+			}
+			if tt.name == "preserves explicit top level limit within bound" && strings.Contains(gotQuery, "cerebro_readonly_query") {
+				t.Fatalf("expected explicit limit query to avoid extra wrapper, got %q", gotQuery)
 			}
 		})
 	}

--- a/internal/warehouse/sqlite.go
+++ b/internal/warehouse/sqlite.go
@@ -229,12 +229,12 @@ func (w *SQLiteWarehouse) GetAssetByID(ctx context.Context, table, id string) (m
 	if err != nil {
 		return nil, err
 	}
-	result, err := w.Query(ctx, "SELECT * FROM "+quoteSQLiteIdentifier(table)+" WHERE "+quoteSQLiteIdentifier("id")+" = ? LIMIT 1", id)
+	result, err := w.Query(ctx, "SELECT * FROM "+quoteSQLiteIdentifier(table)+" WHERE "+quoteSQLiteIdentifier("_cq_id")+" = ? LIMIT 1", id)
 	if err != nil {
 		return nil, err
 	}
 	if len(result.Rows) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("asset not found")
 	}
 	return result.Rows[0], nil
 }

--- a/internal/warehouse/sqlite_test.go
+++ b/internal/warehouse/sqlite_test.go
@@ -99,7 +99,7 @@ func TestSQLiteWarehouseQueryRewritesTimestampIntervals(t *testing.T) {
 	}
 	if _, err := store.Exec(ctx, `INSERT INTO sentinelone_agents (id, last_active_date) VALUES (?, ?), (?, ?)`,
 		"agent-old", "2026-03-01T00:00:00Z",
-		"agent-new", "2026-04-12T00:00:00Z",
+		"agent-new", time.Now().UTC().Add(-48*time.Hour).Format(time.RFC3339),
 	); err != nil {
 		t.Fatalf("insert rows: %v", err)
 	}

--- a/internal/warehouse/sqlite_test.go
+++ b/internal/warehouse/sqlite_test.go
@@ -252,3 +252,39 @@ func TestSQLiteWarehouseGetAssetsAppliesCursorPagination(t *testing.T) {
 		t.Fatalf("expected paged asset bucket-c, got %#v", got)
 	}
 }
+
+func TestSQLiteWarehouseGetAssetByIDUsesCQIDAndReturnsNotFound(t *testing.T) {
+	store, err := NewSQLiteWarehouse(SQLiteWarehouseConfig{
+		Path: filepath.Join(t.TempDir(), "warehouse.db"),
+	})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	if _, err := store.Exec(ctx, `
+		CREATE TABLE aws_s3_buckets (
+			_cq_id TEXT,
+			id TEXT,
+			name TEXT
+		)
+	`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := store.Exec(ctx, `INSERT INTO aws_s3_buckets (_cq_id, id, name) VALUES (?, ?, ?)`, "bucket-cq-id", "bucket-natural-id", "bucket-1"); err != nil {
+		t.Fatalf("insert row: %v", err)
+	}
+
+	asset, err := store.GetAssetByID(ctx, "aws_s3_buckets", "bucket-cq-id")
+	if err != nil {
+		t.Fatalf("GetAssetByID() error = %v", err)
+	}
+	if got := asset["_cq_id"]; got != "bucket-cq-id" {
+		t.Fatalf("expected _cq_id match, got %#v", got)
+	}
+
+	if _, err := store.GetAssetByID(ctx, "aws_s3_buckets", "bucket-natural-id"); err == nil || err.Error() != "asset not found" {
+		t.Fatalf("expected asset not found for natural id lookup, got %v", err)
+	}
+}

--- a/internal/warehouse/sqlite_test.go
+++ b/internal/warehouse/sqlite_test.go
@@ -84,6 +84,35 @@ func TestSQLiteWarehouseInsertCDCEvents(t *testing.T) {
 	}
 }
 
+func TestSQLiteWarehouseQueryRewritesTimestampIntervals(t *testing.T) {
+	store, err := NewSQLiteWarehouse(SQLiteWarehouseConfig{
+		Path: filepath.Join(t.TempDir(), "warehouse.db"),
+	})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	if _, err := store.Exec(ctx, `CREATE TABLE sentinelone_agents (id TEXT, last_active_date TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := store.Exec(ctx, `INSERT INTO sentinelone_agents (id, last_active_date) VALUES (?, ?), (?, ?)`,
+		"agent-old", "2026-03-01T00:00:00Z",
+		"agent-new", "2026-04-12T00:00:00Z",
+	); err != nil {
+		t.Fatalf("insert rows: %v", err)
+	}
+
+	result, err := store.Query(ctx, `SELECT id FROM sentinelone_agents WHERE last_active_date < NOW() - INTERVAL '7 days' ORDER BY id`)
+	if err != nil {
+		t.Fatalf("interval query: %v", err)
+	}
+	if result.Count != 1 || result.Rows[0]["id"] != "agent-old" {
+		t.Fatalf("expected rewritten interval query to match only old agent, got %#v", result.Rows)
+	}
+}
+
 func TestSQLiteWarehouseRestrictsFilePermissions(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "warehouse.db")
 	store, err := NewSQLiteWarehouse(SQLiteWarehouseConfig{Path: path})


### PR DESCRIPTION
## Summary
- switch agent query/get-asset tools and their CLI/job wiring from Snowflake clients to the generic warehouse read surface
- add a lightweight `app.OpenWarehouse` helper so direct `cerebro query` uses the configured warehouse backend without booting the full app
- add regression coverage for warehouse-backed agent queries and direct sqlite-backed CLI queries

## Validation
- go test ./...
- GOTOOLCHAIN=go1.26.1 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run --timeout 5m ./...
- go run ./scripts/check_agent_sdk_contract_compat/main.go --require-baseline --base-ref=writer/main
- make agent-sdk-docs-check
- make agent-sdk-packages-check
- go run ./scripts/check_api_contract_compat/main.go --require-baseline --base-ref=writer/main
- make api-contract-docs-check
- make config-docs-check
- make devex-codegen-check
- go test ./internal/app -run "Test(PreCommitHookRunsFastLintOnStagedGoFiles|PrePushHookRunsChangedDevexPreflight|DockerBuildCommandsPassGoVersionBuildArg|DevelopmentGuideDocumentsDevexPreflight|DevexScriptPlansRelevantChecks|DevexScriptChangedModeIncludesWorkspaceDiffSources)"
- make openapi-check
- go run ./scripts/check_report_contract_compat/main.go --require-baseline --base-ref=writer/main
- make report-contract-docs-check
- make vendor-check