### PR TITLE
fix(config): sync job worker env example with postgres/nats runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,9 +138,15 @@ RATE_LIMIT_WINDOW=1h
 # =============================================================================
 # DISTRIBUTED JOB WORKERS (optional)
 # =============================================================================
-JOB_QUEUE_URL=
-JOB_TABLE_NAME=
-JOB_REGION=
+# Requires Postgres job state plus NATS JetStream connectivity
+JOB_DATABASE_URL=
+NATS_URLS=nats://127.0.0.1:4222
+JOB_NATS_STREAM=CEREBRO_JOBS
+JOB_NATS_SUBJECT=cerebro.jobs
+JOB_NATS_CONSUMER=job-worker
 JOB_WORKER_CONCURRENCY=4
+JOB_VISIBILITY_TIMEOUT=30s
+JOB_POLL_WAIT=10s
+JOB_MAX_ATTEMPTS=3
 
 # See docs/CONFIGURATION.md for the complete environment variable matrix.


### PR DESCRIPTION
## Summary
- replace the legacy distributed job queue example vars with the current Postgres and NATS settings
- document the default job stream, subject, consumer, and worker timing knobs in `.env.example`

## Testing
- python3 scripts/oss_audit.py
- python3 scripts/devex.py run --mode pr --base-ref fix/writer-main-neptune-pg-cutover-20260330