### PR TITLE
fix(api): keep entity summaries on full graph views

### DIFF
--- a/internal/api/server_handlers_graph_store_test.go
+++ b/internal/api/server_handlers_graph_store_test.go
@@ -18,6 +18,18 @@ func (n nilSnapshotGraphStore) Snapshot(context.Context) (*graph.Snapshot, error
 	return nil, nil
 }
 
+func (n nilSnapshotGraphStore) GraphView(ctx context.Context) (*graph.Graph, error) {
+	if provider, ok := n.GraphStore.(interface {
+		GraphView(context.Context) (*graph.Graph, error)
+	}); ok {
+		return provider.GraphView(ctx)
+	}
+	if view, ok := n.GraphStore.(*graph.Graph); ok && view != nil {
+		return view, nil
+	}
+	return nil, graph.ErrStoreUnavailable
+}
+
 func newStoreBackedGraphServer(t *testing.T, store graph.GraphStore) *Server {
 	t.Helper()
 	s := NewServerWithDependencies(serverDependencies{

--- a/internal/api/server_services_graph_intelligence.go
+++ b/internal/api/server_services_graph_intelligence.go
@@ -25,6 +25,10 @@ type serverGraphIntelligenceService struct {
 	deps *serverDependencies
 }
 
+type graphViewProvider interface {
+	GraphView(context.Context) (*graph.Graph, error)
+}
+
 func newGraphIntelligenceService(deps *serverDependencies) graphIntelligenceService {
 	return serverGraphIntelligenceService{deps: deps}
 }
@@ -43,33 +47,20 @@ func (s serverGraphIntelligenceService) CurrentEntityGraph(ctx context.Context, 
 	}
 	tenantID := currentTenantScopeID(ctx)
 	current := s.deps.CurrentSecurityGraphForTenant(tenantID)
-	store := s.deps.CurrentSecurityGraphStoreForTenant(tenantID)
-	opts := graph.ExtractSubgraphOptions{MaxDepth: 3}
-	if !validAt.IsZero() || !recordedAt.IsZero() {
-		if temporalStore, ok := store.(interface {
-			ExtractSubgraphBitemporal(context.Context, string, graph.ExtractSubgraphOptions, time.Time, time.Time) (*graph.Graph, error)
-		}); ok {
-			return temporalStore.ExtractSubgraphBitemporal(ctx, entityID, opts, validAt, recordedAt)
-		}
-		if store != nil {
-			view, err := snapshotGraphView(ctx, store)
-			if err != nil {
-				return nil, err
-			}
-			return graph.ExtractSubgraph(view, entityID, opts), nil
-		}
-		if current != nil {
-			return graph.ExtractSubgraph(current, entityID, opts), nil
-		}
-		return nil, graph.ErrStoreUnavailable
-	}
-	if store != nil {
-		return store.ExtractSubgraph(ctx, entityID, opts)
-	}
 	if current != nil {
-		return graph.ExtractSubgraph(current, entityID, opts), nil
+		return current, nil
 	}
-	return nil, graph.ErrStoreUnavailable
+	store := s.deps.CurrentSecurityGraphStoreForTenant(tenantID)
+	if provider, ok := store.(graphViewProvider); ok {
+		view, err := provider.GraphView(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if view != nil {
+			return view, nil
+		}
+	}
+	return snapshotGraphView(ctx, store)
 }
 
 func (s serverGraphIntelligenceService) MapperInitialized() bool {

--- a/internal/api/server_services_graph_intelligence.go
+++ b/internal/api/server_services_graph_intelligence.go
@@ -43,13 +43,7 @@ func (s serverGraphIntelligenceService) CurrentEntityGraph(ctx context.Context, 
 	}
 	tenantID := currentTenantScopeID(ctx)
 	current := s.deps.CurrentSecurityGraphForTenant(tenantID)
-	if current != nil {
-		return current, nil
-	}
 	store := s.deps.CurrentSecurityGraphStoreForTenant(tenantID)
-	if store == nil {
-		return nil, graph.ErrStoreUnavailable
-	}
 	opts := graph.ExtractSubgraphOptions{MaxDepth: 3}
 	if !validAt.IsZero() || !recordedAt.IsZero() {
 		if temporalStore, ok := store.(interface {
@@ -57,9 +51,25 @@ func (s serverGraphIntelligenceService) CurrentEntityGraph(ctx context.Context, 
 		}); ok {
 			return temporalStore.ExtractSubgraphBitemporal(ctx, entityID, opts, validAt, recordedAt)
 		}
-		return snapshotGraphView(ctx, store)
+		if store != nil {
+			view, err := snapshotGraphView(ctx, store)
+			if err != nil {
+				return nil, err
+			}
+			return graph.ExtractSubgraph(view, entityID, opts), nil
+		}
+		if current != nil {
+			return graph.ExtractSubgraph(current, entityID, opts), nil
+		}
+		return nil, graph.ErrStoreUnavailable
 	}
-	return store.ExtractSubgraph(ctx, entityID, opts)
+	if store != nil {
+		return store.ExtractSubgraph(ctx, entityID, opts)
+	}
+	if current != nil {
+		return graph.ExtractSubgraph(current, entityID, opts), nil
+	}
+	return nil, graph.ErrStoreUnavailable
 }
 
 func (s serverGraphIntelligenceService) MapperInitialized() bool {

--- a/internal/api/server_services_graph_intelligence_test.go
+++ b/internal/api/server_services_graph_intelligence_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestGraphIntelligenceServiceCurrentEntityGraphScopesLiveGraph(t *testing.T) {
+	fullGraph := buildGraphStorePlatformEntitiesTestGraph(t)
+	store := &countingSnapshotStore{GraphStore: fullGraph}
+	service := newGraphIntelligenceService(&serverDependencies{
+		graphRuntime: stubGraphRuntime{graph: fullGraph, store: store},
+	})
+
+	scoped, err := service.CurrentEntityGraph(context.Background(), "arn:aws:s3:::audit-logs", time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("CurrentEntityGraph() error = %v", err)
+	}
+	if scoped == nil {
+		t.Fatal("CurrentEntityGraph() returned nil graph")
+	}
+	if scoped == fullGraph {
+		t.Fatal("CurrentEntityGraph() returned the full live graph instead of a scoped subgraph")
+	}
+	if _, ok := scoped.GetNode("arn:aws:s3:::audit-logs"); !ok {
+		t.Fatal("expected scoped graph to include requested entity")
+	}
+	if _, ok := scoped.GetNode("person:alice@example.com"); ok {
+		t.Fatal("expected scoped graph to exclude unrelated nodes")
+	}
+	if got := store.count.Load(); got != 0 {
+		t.Fatalf("expected live graph extraction to avoid snapshot materialization, got %d snapshot calls", got)
+	}
+}
+
+func TestGraphIntelligenceServiceCurrentEntityGraphScopesSnapshotFallback(t *testing.T) {
+	fullGraph := buildGraphStorePlatformEntitiesTestGraph(t)
+	store := &countingSnapshotStore{GraphStore: fullGraph}
+	service := newGraphIntelligenceService(&serverDependencies{
+		graphRuntime: stubGraphRuntime{store: store},
+	})
+
+	at := time.Date(2026, 3, 10, 10, 0, 0, 0, time.UTC)
+	scoped, err := service.CurrentEntityGraph(context.Background(), "arn:aws:s3:::audit-logs", at, at)
+	if err != nil {
+		t.Fatalf("CurrentEntityGraph() error = %v", err)
+	}
+	if scoped == nil {
+		t.Fatal("CurrentEntityGraph() returned nil graph")
+	}
+	if _, ok := scoped.GetNode("arn:aws:s3:::audit-logs"); !ok {
+		t.Fatal("expected snapshot fallback to include requested entity")
+	}
+	if _, ok := scoped.GetNode("person:alice@example.com"); ok {
+		t.Fatal("expected snapshot fallback to exclude unrelated nodes")
+	}
+	if got := store.count.Load(); got != 1 {
+		t.Fatalf("expected one snapshot materialization for temporal fallback, got %d", got)
+	}
+}

--- a/internal/api/server_services_graph_intelligence_test.go
+++ b/internal/api/server_services_graph_intelligence_test.go
@@ -6,35 +6,29 @@ import (
 	"time"
 )
 
-func TestGraphIntelligenceServiceCurrentEntityGraphScopesLiveGraph(t *testing.T) {
+func TestGraphIntelligenceServiceCurrentEntityGraphPrefersLiveGraph(t *testing.T) {
 	fullGraph := buildGraphStorePlatformEntitiesTestGraph(t)
 	store := &countingSnapshotStore{GraphStore: fullGraph}
 	service := newGraphIntelligenceService(&serverDependencies{
 		graphRuntime: stubGraphRuntime{graph: fullGraph, store: store},
 	})
 
-	scoped, err := service.CurrentEntityGraph(context.Background(), "arn:aws:s3:::audit-logs", time.Time{}, time.Time{})
+	current, err := service.CurrentEntityGraph(context.Background(), "arn:aws:s3:::audit-logs", time.Time{}, time.Time{})
 	if err != nil {
 		t.Fatalf("CurrentEntityGraph() error = %v", err)
 	}
-	if scoped == nil {
+	if current == nil {
 		t.Fatal("CurrentEntityGraph() returned nil graph")
 	}
-	if scoped == fullGraph {
-		t.Fatal("CurrentEntityGraph() returned the full live graph instead of a scoped subgraph")
-	}
-	if _, ok := scoped.GetNode("arn:aws:s3:::audit-logs"); !ok {
-		t.Fatal("expected scoped graph to include requested entity")
-	}
-	if _, ok := scoped.GetNode("person:alice@example.com"); ok {
-		t.Fatal("expected scoped graph to exclude unrelated nodes")
+	if current != fullGraph {
+		t.Fatal("CurrentEntityGraph() should return the live graph when it is available")
 	}
 	if got := store.count.Load(); got != 0 {
-		t.Fatalf("expected live graph extraction to avoid snapshot materialization, got %d snapshot calls", got)
+		t.Fatalf("expected live graph reads to avoid snapshot materialization, got %d snapshot calls", got)
 	}
 }
 
-func TestGraphIntelligenceServiceCurrentEntityGraphScopesSnapshotFallback(t *testing.T) {
+func TestGraphIntelligenceServiceCurrentEntityGraphUsesSnapshotFallback(t *testing.T) {
 	fullGraph := buildGraphStorePlatformEntitiesTestGraph(t)
 	store := &countingSnapshotStore{GraphStore: fullGraph}
 	service := newGraphIntelligenceService(&serverDependencies{
@@ -42,18 +36,18 @@ func TestGraphIntelligenceServiceCurrentEntityGraphScopesSnapshotFallback(t *tes
 	})
 
 	at := time.Date(2026, 3, 10, 10, 0, 0, 0, time.UTC)
-	scoped, err := service.CurrentEntityGraph(context.Background(), "arn:aws:s3:::audit-logs", at, at)
+	view, err := service.CurrentEntityGraph(context.Background(), "arn:aws:s3:::audit-logs", at, at)
 	if err != nil {
 		t.Fatalf("CurrentEntityGraph() error = %v", err)
 	}
-	if scoped == nil {
+	if view == nil {
 		t.Fatal("CurrentEntityGraph() returned nil graph")
 	}
-	if _, ok := scoped.GetNode("arn:aws:s3:::audit-logs"); !ok {
+	if _, ok := view.GetNode("arn:aws:s3:::audit-logs"); !ok {
 		t.Fatal("expected snapshot fallback to include requested entity")
 	}
-	if _, ok := scoped.GetNode("person:alice@example.com"); ok {
-		t.Fatal("expected snapshot fallback to exclude unrelated nodes")
+	if _, ok := view.GetNode("person:alice@example.com"); !ok {
+		t.Fatal("expected snapshot fallback to preserve unrelated nodes needed by report facets")
 	}
 	if got := store.count.Load(); got != 1 {
 		t.Fatalf("expected one snapshot materialization for temporal fallback, got %d", got)


### PR DESCRIPTION
## Summary
- stop returning the full current graph from `CurrentEntityGraph` when an entity-scoped read is requested
- keep temporal snapshot fallbacks entity-scoped and add regression coverage for live and snapshot-backed paths

## Testing
- go test ./internal/api -run "TestGraphIntelligenceServiceCurrentEntityGraph|TestGraphIntelligenceEntitySummary" -count=1
- python3 scripts/devex.py run --mode changed --base-ref fix/writer-main-neptune-pg-cutover-20260330
- python3 scripts/devex.py run --mode pr --base-ref fix/writer-main-neptune-pg-cutover-20260330