### PR TITLE
fix(events): publish alert routing through jetstream

### DIFF
--- a/internal/app/app_event_routing.go
+++ b/internal/app/app_event_routing.go
@@ -26,7 +26,10 @@ func (a *App) startEventAlertRouting(_ context.Context) {
 		return
 	}
 
+	subjectPrefix := strings.TrimSpace(a.Config.AlertRouterNotifyPrefix)
 	notifier, err := events.NewNATSAlertNotifier(events.AlertNotifierConfig{
+		Stream:                a.Config.NATSJetStreamStream,
+		SubjectPrefix:         subjectPrefix,
 		URLs:                  a.Config.NATSJetStreamURLs,
 		ConnectTimeout:        a.Config.NATSJetStreamConnectTimeout,
 		AuthMode:              a.Config.NATSJetStreamAuthMode,
@@ -46,7 +49,6 @@ func (a *App) startEventAlertRouting(_ context.Context) {
 		return
 	}
 
-	subjectPrefix := strings.TrimSpace(a.Config.AlertRouterNotifyPrefix)
 	stateStore, err := events.NewSQLiteAlertRouterStateStore(a.Config.AlertRouterStateFile)
 	if err != nil {
 		a.Logger.Warn("failed to initialize alert router state store", "error", err, "path", a.Config.AlertRouterStateFile)

--- a/internal/events/router.go
+++ b/internal/events/router.go
@@ -29,6 +29,10 @@ const (
 	defaultAlertEscalationReason    = "alert_unacknowledged"
 )
 
+func normalizeAlertSubjectPrefix(value string) string {
+	return strings.Trim(strings.TrimSpace(value), ".")
+}
+
 type AlertRoutingConfig struct {
 	Routes []AlertRoute `json:"routes" yaml:"routes"`
 }
@@ -217,7 +221,7 @@ func NewAlertRouter(options AlertRouterOptions) (*AlertRouter, error) {
 		logger = slog.Default()
 	}
 
-	subjectPrefix := strings.Trim(strings.TrimSpace(options.SubjectPrefix), ".")
+	subjectPrefix := normalizeAlertSubjectPrefix(options.SubjectPrefix)
 	if subjectPrefix == "" {
 		subjectPrefix = defaultAlertNotifySubjectPrefix
 	}
@@ -1211,7 +1215,8 @@ func NewNATSAlertNotifier(cfg AlertNotifierConfig, logger *slog.Logger) (*NATSAl
 		TLSServerName:         cfg.TLSServerName,
 		TLSInsecureSkipVerify: cfg.TLSInsecureSkipVerify,
 	}.withDefaults()
-	if strings.TrimSpace(cfg.SubjectPrefix) == "" {
+	base.SubjectPrefix = normalizeAlertSubjectPrefix(base.SubjectPrefix)
+	if base.SubjectPrefix == "" {
 		base.SubjectPrefix = defaultAlertNotifySubjectPrefix
 	}
 	options, err := base.natsOptions()
@@ -1301,7 +1306,8 @@ func (n *NATSAlertNotifier) ensureStream() error {
 		return errors.New("alert notifier subject prefix is required")
 	}
 
-	streamSubject := strings.TrimSpace(n.subjectPrefix) + ".>"
+	n.subjectPrefix = normalizeAlertSubjectPrefix(n.subjectPrefix)
+	streamSubject := n.subjectPrefix + ".>"
 	stream, err := n.js.StreamInfo(n.stream)
 	if err == nil {
 		if streamHasSubject(stream.Config.Subjects, streamSubject) {

--- a/internal/events/router.go
+++ b/internal/events/router.go
@@ -85,6 +85,8 @@ type AlertRouterOptions struct {
 }
 
 type AlertNotifierConfig struct {
+	Stream         string
+	SubjectPrefix  string
 	URLs           []string
 	ConnectTimeout time.Duration
 	AuthMode       string
@@ -102,8 +104,11 @@ type AlertNotifierConfig struct {
 }
 
 type NATSAlertNotifier struct {
-	nc     *nats.Conn
-	logger *slog.Logger
+	nc            *nats.Conn
+	js            nats.JetStreamContext
+	stream        string
+	subjectPrefix string
+	logger        *slog.Logger
 }
 
 type AlertRouter struct {
@@ -1190,6 +1195,8 @@ func cloneMap(value map[string]interface{}) map[string]interface{} {
 
 func NewNATSAlertNotifier(cfg AlertNotifierConfig, logger *slog.Logger) (*NATSAlertNotifier, error) {
 	base := JetStreamConfig{
+		Stream:                cfg.Stream,
+		SubjectPrefix:         cfg.SubjectPrefix,
 		URLs:                  cfg.URLs,
 		ConnectTimeout:        cfg.ConnectTimeout,
 		AuthMode:              cfg.AuthMode,
@@ -1204,6 +1211,9 @@ func NewNATSAlertNotifier(cfg AlertNotifierConfig, logger *slog.Logger) (*NATSAl
 		TLSServerName:         cfg.TLSServerName,
 		TLSInsecureSkipVerify: cfg.TLSInsecureSkipVerify,
 	}.withDefaults()
+	if strings.TrimSpace(cfg.SubjectPrefix) == "" {
+		base.SubjectPrefix = defaultAlertNotifySubjectPrefix
+	}
 	options, err := base.natsOptions()
 	if err != nil {
 		return nil, err
@@ -1213,20 +1223,34 @@ func NewNATSAlertNotifier(cfg AlertNotifierConfig, logger *slog.Logger) (*NATSAl
 	if err != nil {
 		return nil, fmt.Errorf("connect alert notifier to nats: %w", err)
 	}
+	js, err := nc.JetStream()
+	if err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("initialize alert notifier jetstream context: %w", err)
+	}
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &NATSAlertNotifier{
-		nc:     nc,
-		logger: logger,
-	}, nil
+	notifier := &NATSAlertNotifier{
+		nc:            nc,
+		js:            js,
+		stream:        base.Stream,
+		subjectPrefix: base.SubjectPrefix,
+		logger:        logger,
+	}
+	if err := notifier.ensureStream(); err != nil {
+		nc.Close()
+		return nil, err
+	}
+	return notifier, nil
 }
 
 func (n *NATSAlertNotifier) Send(ctx context.Context, subject string, payload []byte) error {
-	if n == nil || n.nc == nil {
+	if n == nil || n.nc == nil || n.js == nil {
 		return errors.New("alert notifier not initialized")
 	}
-	if strings.TrimSpace(subject) == "" {
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
 		return errors.New("alert notifier subject is required")
 	}
 	if ctx == nil {
@@ -1238,10 +1262,17 @@ func (n *NATSAlertNotifier) Send(ctx context.Context, subject string, payload []
 	default:
 	}
 
-	if err := n.nc.Publish(strings.TrimSpace(subject), payload); err != nil {
+	publish := func() error {
+		_, err := n.js.Publish(subject, payload, nats.Context(ctx))
 		return err
 	}
-	if err := n.nc.Flush(); err != nil {
+	if err := publish(); err != nil {
+		if shouldEnsureJetStreamStream(err) {
+			if ensureErr := n.ensureStream(); ensureErr != nil {
+				return errors.Join(err, ensureErr)
+			}
+			return publish()
+		}
 		return err
 	}
 	return nil
@@ -1256,6 +1287,53 @@ func (n *NATSAlertNotifier) Close() error {
 		return err
 	}
 	n.nc.Close()
+	return nil
+}
+
+func (n *NATSAlertNotifier) ensureStream() error {
+	if n == nil || n.js == nil {
+		return errors.New("alert notifier not initialized")
+	}
+	if strings.TrimSpace(n.stream) == "" {
+		return errors.New("alert notifier stream is required")
+	}
+	if strings.TrimSpace(n.subjectPrefix) == "" {
+		return errors.New("alert notifier subject prefix is required")
+	}
+
+	streamSubject := strings.TrimSpace(n.subjectPrefix) + ".>"
+	stream, err := n.js.StreamInfo(n.stream)
+	if err == nil {
+		if streamHasSubject(stream.Config.Subjects, streamSubject) {
+			return nil
+		}
+		updated := stream.Config
+		updated.Subjects = append(append([]string(nil), stream.Config.Subjects...), streamSubject)
+		if _, err := n.js.UpdateStream(&updated); err != nil {
+			return fmt.Errorf("update alert notifier stream %s subjects: %w", n.stream, err)
+		}
+		n.logger.Info("updated alert notifier stream subjects",
+			"stream", n.stream,
+			"stream_subjects", updated.Subjects,
+			"added_subject", streamSubject,
+		)
+		return nil
+	}
+	if !errors.Is(err, nats.ErrStreamNotFound) {
+		return fmt.Errorf("lookup alert notifier stream %s: %w", n.stream, err)
+	}
+
+	_, err = n.js.AddStream(&nats.StreamConfig{
+		Name:      n.stream,
+		Subjects:  []string{streamSubject},
+		Storage:   nats.FileStorage,
+		Retention: nats.LimitsPolicy,
+		Discard:   nats.DiscardOld,
+	})
+	if err != nil {
+		return fmt.Errorf("create alert notifier stream %s: %w", n.stream, err)
+	}
+	n.logger.Info("created alert notifier stream", "stream", n.stream, "subject", streamSubject)
 	return nil
 }
 

--- a/internal/events/router_jetstream_integration_test.go
+++ b/internal/events/router_jetstream_integration_test.go
@@ -1,0 +1,91 @@
+package events
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+func TestNATSAlertNotifierIntegrationUpdatesExistingStreamSubjects(t *testing.T) {
+	natsURL := startJetStreamServer(t)
+
+	nc, err := nats.Connect(natsURL)
+	if err != nil {
+		t.Fatalf("connect nats: %v", err)
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("jetstream context: %v", err)
+	}
+	if _, err := js.AddStream(&nats.StreamConfig{
+		Name:      "TEST_ALERTS",
+		Subjects:  []string{"cerebro.events.>"},
+		Storage:   nats.FileStorage,
+		Retention: nats.LimitsPolicy,
+	}); err != nil {
+		t.Fatalf("add stream: %v", err)
+	}
+
+	notifier, err := NewNATSAlertNotifier(AlertNotifierConfig{
+		URLs:          []string{natsURL},
+		Stream:        "TEST_ALERTS",
+		SubjectPrefix: "ensemble.notify",
+	}, nil)
+	if err != nil {
+		t.Fatalf("new notifier: %v", err)
+	}
+	defer func() { _ = notifier.Close() }()
+
+	info, err := js.StreamInfo("TEST_ALERTS")
+	if err != nil {
+		t.Fatalf("stream info: %v", err)
+	}
+	if !streamHasSubject(info.Config.Subjects, "cerebro.events.>") {
+		t.Fatalf("expected original stream subject to be preserved, got %v", info.Config.Subjects)
+	}
+	if !streamHasSubject(info.Config.Subjects, "ensemble.notify.>") {
+		t.Fatalf("expected alert stream subject to be added, got %v", info.Config.Subjects)
+	}
+}
+
+func TestNATSAlertNotifierIntegrationPublishesAlertsToJetStream(t *testing.T) {
+	natsURL := startJetStreamServer(t)
+
+	notifier, err := NewNATSAlertNotifier(AlertNotifierConfig{
+		URLs:          []string{natsURL},
+		Stream:        "TEST_ALERTS",
+		SubjectPrefix: "ensemble.notify",
+	}, nil)
+	if err != nil {
+		t.Fatalf("new notifier: %v", err)
+	}
+	defer func() { _ = notifier.Close() }()
+
+	payload := []byte(`{"alert":"test"}`)
+	if err := notifier.Send(context.Background(), "ensemble.notify.dm", payload); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	info, err := notifier.js.StreamInfo("TEST_ALERTS")
+	if err != nil {
+		t.Fatalf("stream info: %v", err)
+	}
+	if info.State.Msgs != 1 {
+		t.Fatalf("expected 1 alert message, got %d", info.State.Msgs)
+	}
+
+	rawMessage, err := notifier.js.GetMsg("TEST_ALERTS", 1)
+	if err != nil {
+		t.Fatalf("get stream message: %v", err)
+	}
+	if rawMessage.Subject != "ensemble.notify.dm" {
+		t.Fatalf("expected alert subject ensemble.notify.dm, got %s", rawMessage.Subject)
+	}
+	if !bytes.Equal(rawMessage.Data, payload) {
+		t.Fatalf("expected alert payload %q, got %q", payload, rawMessage.Data)
+	}
+}

--- a/internal/events/router_jetstream_integration_test.go
+++ b/internal/events/router_jetstream_integration_test.go
@@ -89,3 +89,32 @@ func TestNATSAlertNotifierIntegrationPublishesAlertsToJetStream(t *testing.T) {
 		t.Fatalf("expected alert payload %q, got %q", payload, rawMessage.Data)
 	}
 }
+
+func TestNATSAlertNotifierIntegrationNormalizesSubjectPrefix(t *testing.T) {
+	natsURL := startJetStreamServer(t)
+
+	notifier, err := NewNATSAlertNotifier(AlertNotifierConfig{
+		URLs:          []string{natsURL},
+		Stream:        "TEST_ALERTS",
+		SubjectPrefix: ".ensemble.notify.",
+	}, nil)
+	if err != nil {
+		t.Fatalf("new notifier: %v", err)
+	}
+	defer func() { _ = notifier.Close() }()
+
+	if notifier.subjectPrefix != "ensemble.notify" {
+		t.Fatalf("expected normalized subject prefix, got %q", notifier.subjectPrefix)
+	}
+
+	info, err := notifier.js.StreamInfo("TEST_ALERTS")
+	if err != nil {
+		t.Fatalf("stream info: %v", err)
+	}
+	if !streamHasSubject(info.Config.Subjects, "ensemble.notify.>") {
+		t.Fatalf("expected normalized stream subject, got %v", info.Config.Subjects)
+	}
+	if streamHasSubject(info.Config.Subjects, ".ensemble.notify.>") || streamHasSubject(info.Config.Subjects, "ensemble.notify..>") {
+		t.Fatalf("expected only normalized stream subjects, got %v", info.Config.Subjects)
+	}
+}


### PR DESCRIPTION
## Summary
- publish alert routing notifications through JetStream instead of plain NATS publish calls
- ensure the configured stream accepts the alert subject prefix and add integration coverage for stream updates and alert delivery

## Testing
- go test ./internal/events -run "TestNATSAlertNotifierIntegration|TestAlertRouter" -count=1
- python3 scripts/devex.py run --mode changed --base-ref fix/writer-main-neptune-pg-cutover-20260330
- python3 scripts/devex.py run --mode pr --base-ref fix/writer-main-neptune-pg-cutover-20260330