### PR TITLE
refactor(app): add subsystem lifecycle seams

### DIFF
--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/sync/errgroup"
 )
 
 type concurrentInitTask struct {
@@ -63,48 +61,43 @@ func (a *App) initPhase1(ctx context.Context) error {
 }
 
 func (a *App) initPhase2a(ctx context.Context) error {
+	appState := a.appStateSubsystem()
+	graphSubsystem := a.graphSubsystem()
+
 	a.initExecutionStore()
-	a.initGraphPersistenceStore()
-	if err := runInitErrorStep("app_state_db", func() error { return a.initAppStateDB(ctx) }); err != nil {
+	if err := appState.Init(ctx); err != nil {
 		return err
 	}
 	if err := a.initLegacySnowflakeForAppState(ctx); err != nil {
 		return err
 	}
-	if err := runInitErrorStep("graph_store_backend", func() error { return a.initConfiguredSecurityGraphStore(ctx) }); err != nil {
-		return err
-	}
-	if err := runInitErrorStep("graph_writer_lease", func() error { return a.initGraphWriterLease(ctx) }); err != nil {
-		return err
-	}
-	if err := runInitErrorStep("entity_search_backend", func() error { return a.initEntitySearchBackend(ctx) }); err != nil {
+	if err := graphSubsystem.Init(ctx); err != nil {
 		return err
 	}
 
-	if err := runInitTasksConcurrently(ctx, []concurrentInitTask{
-		{name: "cache", run: func(context.Context) { a.initCache() }},
-		{name: "ticketing", run: func(taskCtx context.Context) { a.initTicketing(taskCtx) }},
-		{name: "identity", run: func(context.Context) { a.initIdentity() }},
-		{name: "attackpath", run: func(context.Context) { a.initAttackPath() }},
-		{name: "webhooks", run: func(context.Context) { a.initWebhooks() }},
-		{name: "notifications", run: func(context.Context) { a.initNotifications() }},
-		{name: "rbac", run: func(context.Context) { a.initRBAC() }},
-		{name: "compliance", run: func(context.Context) { a.initCompliance() }},
-		{name: "health", run: func(context.Context) { a.initHealth() }},
-		{name: "lineage", run: func(context.Context) { a.initLineage() }},
-		{name: "runtime", run: func(context.Context) { a.initRuntime() }},
-		{name: "findings", run: func(context.Context) { a.initFindings() }},
-		{name: "providers", run: func(taskCtx context.Context) { a.initProviders(taskCtx) }},
-		{name: "scheduler", run: func(taskCtx context.Context) { a.initScheduler(taskCtx) }},
-		{name: "repositories", run: func(context.Context) { a.initRepositories() }},
-		{name: "snowflake_findings", run: func(taskCtx context.Context) { a.initSnowflakeFindings(taskCtx) }},
-		{name: "scan_watermarks", run: func(taskCtx context.Context) { a.initScanWatermarks(taskCtx) }},
-		{name: "threatintel", run: func(context.Context) { a.initThreatIntel(ctx) }},
-		{name: "available_tables", run: func(taskCtx context.Context) { a.initAvailableTables(taskCtx) }},
-	}); err != nil {
+	if err := runSubsystemInitConcurrently(ctx,
+		initOnlySubsystem("cache", func(context.Context) { a.initCache() }),
+		initOnlySubsystem("ticketing", func(taskCtx context.Context) { a.initTicketing(taskCtx) }),
+		initOnlySubsystem("identity", func(context.Context) { a.initIdentity() }),
+		initOnlySubsystem("attackpath", func(context.Context) { a.initAttackPath() }),
+		initOnlySubsystem("webhooks", func(context.Context) { a.initWebhooks() }),
+		initOnlySubsystem("notifications", func(context.Context) { a.initNotifications() }),
+		initOnlySubsystem("rbac", func(context.Context) { a.initRBAC() }),
+		initOnlySubsystem("compliance", func(context.Context) { a.initCompliance() }),
+		initOnlySubsystem("health", func(context.Context) { a.initHealth() }),
+		initOnlySubsystem("lineage", func(context.Context) { a.initLineage() }),
+		a.runtimeSubsystem(),
+		initOnlySubsystem("findings", func(context.Context) { a.initFindings() }),
+		initOnlySubsystem("providers", func(taskCtx context.Context) { a.initProviders(taskCtx) }),
+		initOnlySubsystem("scheduler", func(taskCtx context.Context) { a.initScheduler(taskCtx) }),
+		initOnlySubsystem("snowflake_findings", func(taskCtx context.Context) { a.initSnowflakeFindings(taskCtx) }),
+		initOnlySubsystem("scan_watermarks", func(taskCtx context.Context) { a.initScanWatermarks(taskCtx) }),
+		initOnlySubsystem("threatintel", func(context.Context) { a.initThreatIntel(ctx) }),
+		initOnlySubsystem("available_tables", func(taskCtx context.Context) { a.initAvailableTables(taskCtx) }),
+	); err != nil {
 		return fmt.Errorf("phase 2a init failed: %w", err)
 	}
-	if err := runInitErrorStep("app_state_migration", func() error { return a.migrateAppState(ctx) }); err != nil {
+	if err := appState.Start(ctx); err != nil {
 		return err
 	}
 	return nil
@@ -210,14 +203,13 @@ func isAppStateWarehouseTable(name string) bool {
 
 func (a *App) initPhase2b(ctx context.Context) error {
 	// Agent tooling rebinds remediation remote callers, so remediation must be ready first.
-	if err := runInitStep("remediation", func() { a.initRemediation() }); err != nil {
+	remediation := a.remediationSubsystem()
+	if err := runSubsystemInitSequentially(ctx, remediation, a.agentsSubsystem()); err != nil {
 		return fmt.Errorf("phase 2b init failed: %w", err)
 	}
-	if err := runInitStep("agents", func() { a.initAgents(ctx) }); err != nil {
-		return fmt.Errorf("phase 2b init failed: %w", err)
+	if err := runSubsystemStartSequentially(ctx, remediation, a.eventsSubsystem()); err != nil {
+		return fmt.Errorf("phase 2b start failed: %w", err)
 	}
-	a.startEventRemediation(ctx)
-	a.startEventAlertRouting(ctx)
 	return nil
 }
 
@@ -226,24 +218,17 @@ func (a *App) initPhase3() {
 }
 
 func (a *App) initPhase4(ctx context.Context) error {
-	a.initSecurityGraph(ctx)
-	a.initTapGraphConsumer(ctx)
+	if err := runSubsystemStartSequentially(ctx, a.graphSubsystem()); err != nil {
+		return err
+	}
 	return a.validatePolicyCoverage(ctx)
 }
 
 func runInitTasksConcurrently(ctx context.Context, tasks []concurrentInitTask) error {
-	if len(tasks) == 0 {
-		return nil
-	}
-
-	g, gctx := errgroup.WithContext(ctx)
+	subsystems := make([]initSubsystem, 0, len(tasks))
 	for _, task := range tasks {
 		task := task
-		g.Go(func() error {
-			return runInitStep(task.name, func() {
-				task.run(gctx)
-			})
-		})
+		subsystems = append(subsystems, initOnlySubsystem(task.name, task.run))
 	}
-	return g.Wait()
+	return runSubsystemInitConcurrently(ctx, subsystems...)
 }

--- a/internal/app/app_lifecycle.go
+++ b/internal/app/app_lifecycle.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type namedSubsystem interface {
+	Name() string
+}
+
+type initSubsystem interface {
+	namedSubsystem
+	Init(context.Context) error
+}
+
+type startSubsystem interface {
+	namedSubsystem
+	Start(context.Context) error
+}
+
+type closeSubsystem interface {
+	namedSubsystem
+	Close(context.Context) error
+}
+
+type lifecycleSubsystem struct {
+	name  string
+	init  func(context.Context) error
+	start func(context.Context) error
+	close func(context.Context) error
+}
+
+func (s lifecycleSubsystem) Name() string {
+	name := strings.TrimSpace(s.name)
+	if name == "" {
+		return "subsystem"
+	}
+	return name
+}
+
+func (s lifecycleSubsystem) Init(ctx context.Context) error {
+	if s.init == nil {
+		return nil
+	}
+	return s.init(ctx)
+}
+
+func (s lifecycleSubsystem) Start(ctx context.Context) error {
+	if s.start == nil {
+		return nil
+	}
+	return s.start(ctx)
+}
+
+func (s lifecycleSubsystem) Close(ctx context.Context) error {
+	if s.close == nil {
+		return nil
+	}
+	return s.close(ctx)
+}
+
+func runLifecycleErrorStep(phase, name string, fn func() error) (err error) {
+	phase = strings.TrimSpace(phase)
+	if phase == "" {
+		phase = "lifecycle"
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = "subsystem"
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%s %s panic: %v", name, phase, r)
+		}
+	}()
+	return fn()
+}
+
+func runSubsystemInitConcurrently(ctx context.Context, subsystems ...initSubsystem) error {
+	if len(subsystems) == 0 {
+		return nil
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	for _, subsystem := range subsystems {
+		subsystem := subsystem
+		if subsystem == nil {
+			continue
+		}
+		g.Go(func() error {
+			return runLifecycleErrorStep("init", subsystem.Name(), func() error {
+				return subsystem.Init(gctx)
+			})
+		})
+	}
+	return g.Wait()
+}
+
+func runSubsystemInitSequentially(ctx context.Context, subsystems ...initSubsystem) error {
+	for _, subsystem := range subsystems {
+		if subsystem == nil {
+			continue
+		}
+		if err := runLifecycleErrorStep("init", subsystem.Name(), func() error {
+			return subsystem.Init(ctx)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runSubsystemStartSequentially(ctx context.Context, subsystems ...startSubsystem) error {
+	for _, subsystem := range subsystems {
+		if subsystem == nil {
+			continue
+		}
+		if err := runLifecycleErrorStep("start", subsystem.Name(), func() error {
+			return subsystem.Start(ctx)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runSubsystemCloseSequentially(ctx context.Context, subsystems ...closeSubsystem) []error {
+	if len(subsystems) == 0 {
+		return nil
+	}
+
+	var errs []error
+	for _, subsystem := range subsystems {
+		if subsystem == nil {
+			continue
+		}
+		if err := runLifecycleErrorStep("close", subsystem.Name(), func() error {
+			return subsystem.Close(ctx)
+		}); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func initOnlySubsystem(name string, init func(context.Context)) lifecycleSubsystem {
+	return lifecycleSubsystem{
+		name: name,
+		init: func(ctx context.Context) error {
+			if init != nil {
+				init(ctx)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/app/app_lifecycle_test.go
+++ b/internal/app/app_lifecycle_test.go
@@ -1,0 +1,112 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRunSubsystemInitConcurrently_RunsAllSubsystems(t *testing.T) {
+	var called atomic.Int32
+
+	err := runSubsystemInitConcurrently(context.Background(),
+		initOnlySubsystem("cache", func(context.Context) { called.Add(1) }),
+		initOnlySubsystem("runtime", func(context.Context) { called.Add(1) }),
+		initOnlySubsystem("events", func(context.Context) { called.Add(1) }),
+	)
+	if err != nil {
+		t.Fatalf("runSubsystemInitConcurrently() error = %v", err)
+	}
+	if got, want := called.Load(), int32(3); got != want {
+		t.Fatalf("subsystem init count = %d, want %d", got, want)
+	}
+}
+
+func TestRunSubsystemInitConcurrently_PropagatesError(t *testing.T) {
+	want := errors.New("boom")
+
+	err := runSubsystemInitConcurrently(context.Background(),
+		lifecycleSubsystem{
+			name: "graph",
+			init: func(context.Context) error {
+				return want
+			},
+		},
+	)
+	if !errors.Is(err, want) {
+		t.Fatalf("runSubsystemInitConcurrently() error = %v, want wrapped %v", err, want)
+	}
+}
+
+func TestRunSubsystemInitSequentially_RunsInOrder(t *testing.T) {
+	var order []string
+
+	err := runSubsystemInitSequentially(context.Background(),
+		lifecycleSubsystem{
+			name: "remediation",
+			init: func(context.Context) error {
+				order = append(order, "remediation")
+				return nil
+			},
+		},
+		lifecycleSubsystem{
+			name: "agents",
+			init: func(context.Context) error {
+				order = append(order, "agents")
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("runSubsystemInitSequentially() error = %v", err)
+	}
+	if want := []string{"remediation", "agents"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("init order = %v, want %v", order, want)
+	}
+}
+
+func TestRunSubsystemStartSequentially_RunsInOrder(t *testing.T) {
+	var order []string
+
+	err := runSubsystemStartSequentially(context.Background(),
+		lifecycleSubsystem{
+			name: "remediation",
+			start: func(context.Context) error {
+				order = append(order, "remediation")
+				return nil
+			},
+		},
+		lifecycleSubsystem{
+			name: "events",
+			start: func(context.Context) error {
+				order = append(order, "events")
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("runSubsystemStartSequentially() error = %v", err)
+	}
+	if want := []string{"remediation", "events"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("start order = %v, want %v", order, want)
+	}
+}
+
+func TestRunSubsystemCloseSequentially_CollectsErrors(t *testing.T) {
+	errs := runSubsystemCloseSequentially(context.Background(),
+		lifecycleSubsystem{
+			name: "agents",
+			close: func(context.Context) error {
+				return errors.New("close failed")
+			},
+		},
+	)
+	if len(errs) != 1 {
+		t.Fatalf("close errors len = %d, want 1", len(errs))
+	}
+	if errs[0] == nil || errs[0].Error() == "" {
+		t.Fatalf("expected non-empty close error, got %v", errs[0])
+	}
+}

--- a/internal/app/app_subsystem_config.go
+++ b/internal/app/app_subsystem_config.go
@@ -57,19 +57,17 @@ type GraphConfig struct {
 }
 
 type AppStateConfig struct {
-	JobDatabaseURL       string
 	WarehouseBackend     string
 	WarehousePostgresDSN string
 }
 
 func (c AppStateConfig) DatabaseURL() string {
-	if dsn := strings.TrimSpace(c.JobDatabaseURL); dsn != "" {
-		return dsn
-	}
-	if strings.EqualFold(strings.TrimSpace(c.WarehouseBackend), "postgres") {
+	switch strings.ToLower(strings.TrimSpace(c.WarehouseBackend)) {
+	case "postgres", "snowflake":
 		return strings.TrimSpace(c.WarehousePostgresDSN)
+	default:
+		return ""
 	}
-	return ""
 }
 
 type EventConfig struct {
@@ -125,7 +123,6 @@ func (c *Config) BuildSubsystemConfig() SubsystemConfig {
 			MigrateLegacyActivityOnStart: c.GraphMigrateLegacyActivityOnStart,
 		},
 		AppState: AppStateConfig{
-			JobDatabaseURL:       c.JobDatabaseURL,
 			WarehouseBackend:     c.WarehouseBackend,
 			WarehousePostgresDSN: c.WarehousePostgresDSN,
 		},

--- a/internal/app/app_subsystem_config.go
+++ b/internal/app/app_subsystem_config.go
@@ -1,0 +1,150 @@
+package app
+
+import (
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/agents"
+	"github.com/writer/cerebro/internal/graph"
+)
+
+// SubsystemConfig provides grouped, subsystem-scoped views over the env-backed
+// top-level app config without changing the external config surface.
+type SubsystemConfig struct {
+	Agents   AgentConfig
+	Runtime  RuntimeConfig
+	Graph    GraphConfig
+	AppState AppStateConfig
+	Events   EventConfig
+}
+
+type AgentConfig struct {
+	AnthropicAPIKey string
+	OpenAIAPIKey    string
+	GitHubToken     string
+	GitLabToken     string
+	GitLabBaseURL   string
+	RemoteTools     agents.RemoteToolProviderConfig
+	ToolPublisher   agents.ToolPublisherConfig
+}
+
+func (c AgentConfig) HasModelProvider() bool {
+	return strings.TrimSpace(c.AnthropicAPIKey) != "" || strings.TrimSpace(c.OpenAIAPIKey) != ""
+}
+
+func (c AgentConfig) RemoteToolingEnabled() bool {
+	return c.RemoteTools.Enabled || c.ToolPublisher.Enabled
+}
+
+type RuntimeConfig struct {
+	ExecutionStoreFile string
+}
+
+type GraphConfig struct {
+	SnapshotPath                 string
+	SnapshotMaxRetained          int
+	StoreBackend                 graph.StoreBackend
+	SearchBackend                graph.EntitySearchBackendType
+	SchemaValidationMode         string
+	PropertyHistoryMaxEntries    int
+	PropertyHistoryTTL           time.Duration
+	WriterLeaseEnabled           bool
+	WriterLeaseName              string
+	WriterLeaseOwnerID           string
+	WriterLeaseTTL               time.Duration
+	WriterLeaseHeartbeat         time.Duration
+	MigrateLegacyActivityOnStart bool
+}
+
+type AppStateConfig struct {
+	JobDatabaseURL       string
+	WarehouseBackend     string
+	WarehousePostgresDSN string
+}
+
+func (c AppStateConfig) DatabaseURL() string {
+	if dsn := strings.TrimSpace(c.JobDatabaseURL); dsn != "" {
+		return dsn
+	}
+	if strings.EqualFold(strings.TrimSpace(c.WarehouseBackend), "postgres") {
+		return strings.TrimSpace(c.WarehousePostgresDSN)
+	}
+	return ""
+}
+
+type EventConfig struct {
+	NATSJetStreamEnabled     bool
+	NATSConsumerEnabled      bool
+	NATSConsumerSubjects     []string
+	NATSConsumerDurable      string
+	NATSConsumerDrainTimeout time.Duration
+	AlertRouterEnabled       bool
+	AlertRouterConfigPath    string
+	AlertRouterNotifyPrefix  string
+}
+
+func (c EventConfig) AlertRoutingEnabled() bool {
+	return c.AlertRouterEnabled && c.NATSJetStreamEnabled
+}
+
+func (c EventConfig) TapGraphConsumerEnabled() bool {
+	return c.NATSConsumerEnabled
+}
+
+func (c *Config) BuildSubsystemConfig() SubsystemConfig {
+	if c == nil {
+		return SubsystemConfig{}
+	}
+
+	return SubsystemConfig{
+		Agents: AgentConfig{
+			AnthropicAPIKey: c.AnthropicAPIKey,
+			OpenAIAPIKey:    c.OpenAIAPIKey,
+			GitHubToken:     c.GitHubToken,
+			GitLabToken:     c.GitLabToken,
+			GitLabBaseURL:   c.GitLabBaseURL,
+			RemoteTools:     remoteToolProviderConfigFromConfig(c),
+			ToolPublisher:   toolPublisherConfigFromConfig(c),
+		},
+		Runtime: RuntimeConfig{
+			ExecutionStoreFile: c.ExecutionStoreFile,
+		},
+		Graph: GraphConfig{
+			SnapshotPath:                 c.GraphSnapshotPath,
+			SnapshotMaxRetained:          c.GraphSnapshotMaxRetained,
+			StoreBackend:                 c.graphStoreBackend(),
+			SearchBackend:                c.graphSearchBackend(),
+			SchemaValidationMode:         c.GraphSchemaValidationMode,
+			PropertyHistoryMaxEntries:    c.GraphPropertyHistoryMaxEntries,
+			PropertyHistoryTTL:           c.GraphPropertyHistoryTTL,
+			WriterLeaseEnabled:           c.GraphWriterLeaseEnabled,
+			WriterLeaseName:              c.GraphWriterLeaseName,
+			WriterLeaseOwnerID:           c.GraphWriterLeaseOwnerID,
+			WriterLeaseTTL:               c.GraphWriterLeaseTTL,
+			WriterLeaseHeartbeat:         c.GraphWriterLeaseHeartbeat,
+			MigrateLegacyActivityOnStart: c.GraphMigrateLegacyActivityOnStart,
+		},
+		AppState: AppStateConfig{
+			JobDatabaseURL:       c.JobDatabaseURL,
+			WarehouseBackend:     c.WarehouseBackend,
+			WarehousePostgresDSN: c.WarehousePostgresDSN,
+		},
+		Events: EventConfig{
+			NATSJetStreamEnabled:     c.NATSJetStreamEnabled,
+			NATSConsumerEnabled:      c.NATSConsumerEnabled,
+			NATSConsumerSubjects:     append([]string(nil), c.NATSConsumerSubjects...),
+			NATSConsumerDurable:      c.NATSConsumerDurable,
+			NATSConsumerDrainTimeout: c.NATSConsumerDrainTimeout,
+			AlertRouterEnabled:       c.AlertRouterEnabled,
+			AlertRouterConfigPath:    c.AlertRouterConfigPath,
+			AlertRouterNotifyPrefix:  c.AlertRouterNotifyPrefix,
+		},
+	}
+}
+
+func (a *App) subsystemConfig() SubsystemConfig {
+	if a == nil || a.Config == nil {
+		return SubsystemConfig{}
+	}
+	return a.Config.BuildSubsystemConfig()
+}

--- a/internal/app/app_subsystem_config_test.go
+++ b/internal/app/app_subsystem_config_test.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBuildSubsystemConfig_GroupsSubsystemViews(t *testing.T) {
+	cfg := &Config{
+		AnthropicAPIKey:                   "anthropic-key",
+		GitHubToken:                       "github-token",
+		GitLabToken:                       "gitlab-token",
+		GitLabBaseURL:                     "https://gitlab.example.com",
+		AgentRemoteToolsEnabled:           true,
+		AgentToolPublisherEnabled:         true,
+		GraphSnapshotPath:                 "/tmp/graph",
+		GraphSnapshotMaxRetained:          7,
+		GraphStoreBackend:                 "sqlite",
+		GraphSearchBackend:                "opensearch",
+		GraphSchemaValidationMode:         "strict",
+		GraphPropertyHistoryMaxEntries:    42,
+		GraphPropertyHistoryTTL:           15 * time.Minute,
+		GraphWriterLeaseEnabled:           true,
+		GraphWriterLeaseName:              "writer-lease",
+		GraphWriterLeaseOwnerID:           "writer-a",
+		GraphWriterLeaseTTL:               30 * time.Second,
+		GraphWriterLeaseHeartbeat:         10 * time.Second,
+		GraphMigrateLegacyActivityOnStart: true,
+		JobDatabaseURL:                    "postgres://jobs",
+		ExecutionStoreFile:                "/tmp/executions.db",
+		NATSJetStreamEnabled:              true,
+		NATSConsumerEnabled:               true,
+		NATSConsumerSubjects:              []string{"graph.events", "graph.rebuilds"},
+		NATSConsumerDurable:               "graph-worker",
+		NATSConsumerDrainTimeout:          12 * time.Second,
+		AlertRouterEnabled:                true,
+		AlertRouterConfigPath:             "/tmp/alert-router.yaml",
+		AlertRouterNotifyPrefix:           "ensemble.notify",
+	}
+
+	subsystems := cfg.BuildSubsystemConfig()
+
+	if !subsystems.Agents.HasModelProvider() {
+		t.Fatal("expected agent config to report a configured model provider")
+	}
+	if !subsystems.Agents.RemoteToolingEnabled() {
+		t.Fatal("expected agent config to report remote tooling enabled")
+	}
+	if got, want := subsystems.Runtime.ExecutionStoreFile, cfg.ExecutionStoreFile; got != want {
+		t.Fatalf("runtime execution store file = %q, want %q", got, want)
+	}
+	if got, want := subsystems.AppState.DatabaseURL(), cfg.JobDatabaseURL; got != want {
+		t.Fatalf("appstate database url = %q, want %q", got, want)
+	}
+	if got, want := subsystems.Graph.SnapshotPath, cfg.GraphSnapshotPath; got != want {
+		t.Fatalf("graph snapshot path = %q, want %q", got, want)
+	}
+	if got, want := subsystems.Graph.PropertyHistoryTTL, cfg.GraphPropertyHistoryTTL; got != want {
+		t.Fatalf("graph history ttl = %s, want %s", got, want)
+	}
+	if !subsystems.Events.AlertRoutingEnabled() {
+		t.Fatal("expected alert routing to be enabled when JetStream is enabled")
+	}
+	if !subsystems.Events.TapGraphConsumerEnabled() {
+		t.Fatal("expected tap graph consumer to be enabled")
+	}
+	if got, want := subsystems.Events.NATSConsumerDurable, cfg.NATSConsumerDurable; got != want {
+		t.Fatalf("tap durable = %q, want %q", got, want)
+	}
+	if got, want := subsystems.Events.NATSConsumerSubjects, cfg.NATSConsumerSubjects; !reflect.DeepEqual(got, want) {
+		t.Fatalf("tap subjects = %v, want %v", got, want)
+	}
+
+	subsystems.Events.NATSConsumerSubjects[0] = "changed"
+	if cfg.NATSConsumerSubjects[0] != "graph.events" {
+		t.Fatal("expected event subjects to be copied when building subsystem config")
+	}
+}
+
+func TestAppStateConfigDatabaseURLFallsBackToWarehousePostgresDSN(t *testing.T) {
+	cfg := AppStateConfig{
+		WarehouseBackend:     "postgres",
+		WarehousePostgresDSN: "postgres://warehouse",
+	}
+
+	if got, want := cfg.DatabaseURL(), "postgres://warehouse"; got != want {
+		t.Fatalf("DatabaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestEventConfigAlertRoutingEnabledRequiresJetStream(t *testing.T) {
+	cfg := EventConfig{
+		NATSJetStreamEnabled: false,
+		AlertRouterEnabled:   true,
+	}
+
+	if cfg.AlertRoutingEnabled() {
+		t.Fatal("expected alert routing to require JetStream")
+	}
+}

--- a/internal/app/app_subsystem_config_test.go
+++ b/internal/app/app_subsystem_config_test.go
@@ -27,6 +27,8 @@ func TestBuildSubsystemConfig_GroupsSubsystemViews(t *testing.T) {
 		GraphWriterLeaseTTL:               30 * time.Second,
 		GraphWriterLeaseHeartbeat:         10 * time.Second,
 		GraphMigrateLegacyActivityOnStart: true,
+		WarehouseBackend:                  "snowflake",
+		WarehousePostgresDSN:              "postgres://app-state",
 		JobDatabaseURL:                    "postgres://jobs",
 		ExecutionStoreFile:                "/tmp/executions.db",
 		NATSJetStreamEnabled:              true,
@@ -50,7 +52,7 @@ func TestBuildSubsystemConfig_GroupsSubsystemViews(t *testing.T) {
 	if got, want := subsystems.Runtime.ExecutionStoreFile, cfg.ExecutionStoreFile; got != want {
 		t.Fatalf("runtime execution store file = %q, want %q", got, want)
 	}
-	if got, want := subsystems.AppState.DatabaseURL(), cfg.JobDatabaseURL; got != want {
+	if got, want := subsystems.AppState.DatabaseURL(), cfg.WarehousePostgresDSN; got != want {
 		t.Fatalf("appstate database url = %q, want %q", got, want)
 	}
 	if got, want := subsystems.Graph.SnapshotPath, cfg.GraphSnapshotPath; got != want {
@@ -78,14 +80,44 @@ func TestBuildSubsystemConfig_GroupsSubsystemViews(t *testing.T) {
 	}
 }
 
-func TestAppStateConfigDatabaseURLFallsBackToWarehousePostgresDSN(t *testing.T) {
-	cfg := AppStateConfig{
-		WarehouseBackend:     "postgres",
-		WarehousePostgresDSN: "postgres://warehouse",
+func TestAppStateConfigDatabaseURLMatchesAppStateContract(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  AppStateConfig
+		want string
+	}{
+		{
+			name: "postgres backend uses warehouse dsn",
+			cfg: AppStateConfig{
+				WarehouseBackend:     "postgres",
+				WarehousePostgresDSN: "postgres://warehouse",
+			},
+			want: "postgres://warehouse",
+		},
+		{
+			name: "snowflake backend also uses warehouse dsn for app state",
+			cfg: AppStateConfig{
+				WarehouseBackend:     "snowflake",
+				WarehousePostgresDSN: "postgres://app-state",
+			},
+			want: "postgres://app-state",
+		},
+		{
+			name: "sqlite backend disables app-state dsn",
+			cfg: AppStateConfig{
+				WarehouseBackend:     "sqlite",
+				WarehousePostgresDSN: "postgres://unused",
+			},
+			want: "",
+		},
 	}
 
-	if got, want := cfg.DatabaseURL(), "postgres://warehouse"; got != want {
-		t.Fatalf("DatabaseURL() = %q, want %q", got, want)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.DatabaseURL(); got != tc.want {
+				t.Fatalf("DatabaseURL() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/app/app_subsystems.go
+++ b/internal/app/app_subsystems.go
@@ -1,0 +1,194 @@
+package app
+
+import "context"
+
+type appStateLifecycle struct {
+	app *App
+	cfg AppStateConfig
+}
+
+func (a *App) appStateSubsystem() appStateLifecycle {
+	return appStateLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().AppState,
+	}
+}
+
+func (s appStateLifecycle) Name() string {
+	return "appstate"
+}
+
+func (s appStateLifecycle) Init(ctx context.Context) error {
+	if s.app == nil || s.cfg.DatabaseURL() == "" {
+		return nil
+	}
+	return runInitErrorStep("app_state_db", func() error {
+		return s.app.initAppStateDB(ctx)
+	})
+}
+
+func (s appStateLifecycle) Start(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initRepositories()
+	if s.cfg.DatabaseURL() == "" {
+		return nil
+	}
+	return runInitErrorStep("app_state_migration", func() error {
+		return s.app.migrateAppState(ctx)
+	})
+}
+
+type agentsLifecycle struct {
+	app *App
+	cfg AgentConfig
+}
+
+func (a *App) agentsSubsystem() agentsLifecycle {
+	return agentsLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().Agents,
+	}
+}
+
+func (s agentsLifecycle) Name() string {
+	return "agents"
+}
+
+func (s agentsLifecycle) Init(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initAgents(ctx)
+	return nil
+}
+
+type runtimeLifecycle struct {
+	app *App
+	cfg RuntimeConfig
+}
+
+func (a *App) runtimeSubsystem() runtimeLifecycle {
+	return runtimeLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().Runtime,
+	}
+}
+
+func (s runtimeLifecycle) Name() string {
+	return "runtime"
+}
+
+func (s runtimeLifecycle) Init(context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initRuntime()
+	return nil
+}
+
+type remediationLifecycle struct {
+	app *App
+}
+
+func (a *App) remediationSubsystem() remediationLifecycle {
+	return remediationLifecycle{app: a}
+}
+
+func (s remediationLifecycle) Name() string {
+	return "remediation"
+}
+
+func (s remediationLifecycle) Init(context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initRemediation()
+	return nil
+}
+
+func (s remediationLifecycle) Start(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.startEventRemediation(ctx)
+	return nil
+}
+
+type graphLifecycle struct {
+	app    *App
+	cfg    GraphConfig
+	events EventConfig
+}
+
+func (a *App) graphSubsystem() graphLifecycle {
+	cfg := a.subsystemConfig()
+	return graphLifecycle{
+		app:    a,
+		cfg:    cfg.Graph,
+		events: cfg.Events,
+	}
+}
+
+func (s graphLifecycle) Name() string {
+	return "graph"
+}
+
+func (s graphLifecycle) Init(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initGraphPersistenceStore()
+	if err := runInitErrorStep("graph_store_backend", func() error {
+		return s.app.initConfiguredSecurityGraphStore(ctx)
+	}); err != nil {
+		return err
+	}
+	if err := runInitErrorStep("graph_writer_lease", func() error {
+		return s.app.initGraphWriterLease(ctx)
+	}); err != nil {
+		return err
+	}
+	if err := runInitErrorStep("entity_search_backend", func() error {
+		return s.app.initEntitySearchBackend(ctx)
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s graphLifecycle) Start(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initSecurityGraph(ctx)
+	if s.events.TapGraphConsumerEnabled() {
+		s.app.initTapGraphConsumer(ctx)
+	}
+	return nil
+}
+
+type eventLifecycle struct {
+	app *App
+	cfg EventConfig
+}
+
+func (a *App) eventsSubsystem() eventLifecycle {
+	return eventLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().Events,
+	}
+}
+
+func (s eventLifecycle) Name() string {
+	return "events"
+}
+
+func (s eventLifecycle) Start(ctx context.Context) error {
+	if s.app == nil || !s.cfg.AlertRoutingEnabled() {
+		return nil
+	}
+	s.app.startEventAlertRouting(ctx)
+	return nil
+}


### PR DESCRIPTION
## Summary
- add reusable subsystem lifecycle helpers for explicit init/start sequencing in `internal/app`
- introduce grouped subsystem-scoped config views for agents, runtime, graph, appstate, and events
- route app initialization through subsystem wrappers and add tests for the new lifecycle/config seams

## Validation
- `go test ./internal/app`
- `go test -count=1 ./internal/app`
- `go vet ./internal/app`
- `/Users/jonathan/go/bin/golangci-lint run --timeout 5m ./internal/app`
- pre-push changed-file checks for `./internal/app ./internal/findings`

Refs WriterInternal/cerebro#420
