### PR TITLE
feat(endpoint): correlate software vulnerabilities across providers

### DIFF
--- a/internal/api/handlers_providers.go
+++ b/internal/api/handlers_providers.go
@@ -11,7 +11,17 @@ import (
 	"github.com/writer/cerebro/internal/providers"
 )
 
-// Provider endpoints
+// Provider endpoints.
+//
+// Endpoint software/CVE workflows generally use this control plane first:
+//   1. POST /api/v1/providers/{name}/sync to materialize provider rows
+//   2. GET /api/v1/providers/{name}/schema to discover table names and columns
+//   3. POST /api/v1/query (or GET /api/v1/assets/{table} for spot checks) to
+//      join device/agent, application, and vulnerability tables
+//
+// Today the provider layer preserves provider-native software names and versions.
+// That keeps ingest lossless, but cross-provider patch-target correlation usually
+// needs an extra normalization step above these endpoints.
 
 func (s *Server) listProviders(w http.ResponseWriter, r *http.Request) {
 	providerList := s.app.Providers.List()

--- a/internal/api/server_handlers_data.go
+++ b/internal/api/server_handlers_data.go
@@ -132,7 +132,16 @@ func parseLastSyncValue(value interface{}) time.Time {
 	return time.Time{}
 }
 
-// Query endpoints
+// Query endpoints.
+//
+// For endpoint patching/vulnerability flows, POST /api/v1/query is the main
+// data-plane surface after provider sync has materialized rows. Typical joins:
+//   - Kandji: kandji_devices -> kandji_device_apps -> kandji_vulnerabilities
+//   - SentinelOne: sentinelone_agents -> sentinelone_applications -> sentinelone_vulnerabilities
+//
+// GET /api/v1/tables helps discover which provider tables are present, while
+// GET /api/v1/assets/{table} is better for small spot checks than for multi-table
+// correlation work.
 
 func (s *Server) listTables(w http.ResponseWriter, r *http.Request) {
 	if s.app.Warehouse == nil {

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -71,7 +71,9 @@ func (s *Server) setupRoutes() {
 	s.router.Get("/.well-known/oauth-protected-resource", s.agentSDKProtectedResourceMetadata)
 
 	s.router.Route("/api/v1", func(r chi.Router) {
-		// Query endpoints
+		// Query endpoints. For endpoint inventory + vulnerability correlation the
+		// typical flow is: sync providers under /providers, discover tables here,
+		// then use /query for joins and /assets/{table} for spot checks.
 		r.Get("/tables", s.listTables)
 		r.Post("/query", s.executeQuery)
 		r.Get("/status/freshness", s.statusFreshness)
@@ -206,7 +208,8 @@ func (s *Server) setupRoutes() {
 		})
 		r.Post("/impact-analysis", s.impactAnalysis)
 
-		// Provider endpoints
+		// Provider endpoints expose the control plane for materializing endpoint
+		// inventory, application, and vulnerability rows before querying them.
 		r.Route("/providers", func(r chi.Router) {
 			r.Get("/", s.listProviders)
 			r.Get("/{name}", s.getProvider)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -70,6 +70,7 @@ import (
 	"github.com/writer/cerebro/internal/snowflake"
 	"github.com/writer/cerebro/internal/threatintel"
 	"github.com/writer/cerebro/internal/ticketing"
+	"github.com/writer/cerebro/internal/vulndb"
 	"github.com/writer/cerebro/internal/warehouse"
 	"github.com/writer/cerebro/internal/webhooks"
 )
@@ -150,6 +151,7 @@ type App struct {
 	// New services
 	RBAC                *auth.RBAC
 	ThreatIntel         *threatintel.ThreatIntelService
+	VulnDB              *vulndb.Service
 	Compliance          *compliance.ComplianceReport
 	Health              *health.Registry
 	Lineage             *lineage.LineageMapper
@@ -208,6 +210,8 @@ type App struct {
 	apiCredentials                     atomic.Value // map[string]apiauth.Credential
 	apiCredentialStore                 *apiauth.ManagedCredentialStore
 	secretsLoader                      secretsLoader
+	vulnDBStore                        interface{ Close() error }
+	endpointVulnRefreshMu              sync.Mutex
 
 	// Cached table list from Snowflake (shared by graph builder + policy coverage)
 	AvailableTables []string

--- a/internal/app/app_endpoint_vulnerabilities.go
+++ b/internal/app/app_endpoint_vulnerabilities.go
@@ -1,0 +1,70 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/endpointvuln"
+	"github.com/writer/cerebro/internal/providers"
+)
+
+const endpointVulnerabilityRefreshTimeout = 2 * time.Minute
+
+func (a *App) refreshEndpointVulnerabilityTables(ctx context.Context, trigger string) error {
+	if a == nil || a.Warehouse == nil {
+		return nil
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = backgroundWorkContext(ctx)
+
+	refreshCtx, cancel := context.WithTimeout(ctx, endpointVulnerabilityRefreshTimeout)
+	defer cancel()
+
+	trigger = strings.TrimSpace(trigger)
+	if trigger == "" {
+		trigger = "unspecified"
+	}
+
+	start := time.Now()
+	a.endpointVulnRefreshMu.Lock()
+	defer a.endpointVulnRefreshMu.Unlock()
+
+	refresher := endpointvuln.Refresher{
+		Warehouse:   a.Warehouse,
+		ThreatIntel: a.ThreatIntel,
+		Advisories:  a.VulnDB,
+		Logger:      a.Logger,
+	}
+	if err := refresher.Refresh(refreshCtx); err != nil {
+		return err
+	}
+
+	if tables, err := a.Warehouse.ListAvailableTables(refreshCtx); err == nil {
+		a.AvailableTables = tables
+	} else if refreshCtx.Err() == nil && a.Logger != nil {
+		a.Logger.Warn("failed to refresh available tables after endpoint vulnerability refresh",
+			"trigger", trigger,
+			"error", err,
+		)
+	}
+
+	if a.Logger != nil {
+		a.Logger.Info("refreshed endpoint vulnerability correlation tables",
+			"trigger", trigger,
+			"duration", time.Since(start),
+		)
+	}
+
+	return nil
+}
+
+func (a *App) endpointProviderSyncHook(ctx context.Context, provider providers.Provider, _ *providers.SyncResult, syncErr error) error {
+	if syncErr != nil || provider == nil {
+		return nil
+	}
+	return a.refreshEndpointVulnerabilityTables(ctx, "provider_sync:"+provider.Name())
+}

--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -100,11 +100,17 @@ func (a *App) initPhase2a(ctx context.Context) error {
 		{name: "snowflake_findings", run: func(taskCtx context.Context) { a.initSnowflakeFindings(taskCtx) }},
 		{name: "scan_watermarks", run: func(taskCtx context.Context) { a.initScanWatermarks(taskCtx) }},
 		{name: "threatintel", run: func(context.Context) { a.initThreatIntel(ctx) }},
+		{name: "vulndb", run: func(context.Context) { a.initVulnDB() }},
 		{name: "available_tables", run: func(taskCtx context.Context) { a.initAvailableTables(taskCtx) }},
 	}); err != nil {
 		return fmt.Errorf("phase 2a init failed: %w", err)
 	}
 	if err := runInitErrorStep("app_state_migration", func() error { return a.migrateAppState(ctx) }); err != nil {
+		return err
+	}
+	if err := runInitErrorStep("endpoint_vulnerability_tables", func() error {
+		return a.refreshEndpointVulnerabilityTables(ctx, "startup")
+	}); err != nil {
 		return err
 	}
 	return nil

--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -18,6 +18,7 @@ import (
 	"github.com/writer/cerebro/internal/remediation"
 	"github.com/writer/cerebro/internal/runtime"
 	"github.com/writer/cerebro/internal/threatintel"
+	"github.com/writer/cerebro/internal/vulndb"
 	"github.com/writer/cerebro/internal/webhooks"
 )
 
@@ -96,8 +97,27 @@ func (a *App) initThreatIntel(ctx context.Context) {
 				a.Logger.Warn("failed to emit threat intel synced event", "error", err)
 			}
 		}
+		if err := a.refreshEndpointVulnerabilityTables(runCtx, "threatintel_sync"); err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			a.Logger.Warn("failed to refresh endpoint vulnerability tables after threat intel sync", "error", err)
+		}
 		a.Logger.Info("threat intel feeds synced", "indicators", stats["total_indicators"])
 	}()
+}
+
+func (a *App) initVulnDB() {
+	if a == nil || a.Config == nil {
+		return
+	}
+
+	store, err := vulndb.NewSQLiteStore(strings.TrimSpace(a.Config.VulnDBStateFile))
+	if err != nil {
+		a.Logger.Warn("failed to initialize vulnerability advisory database", "error", err, "path", a.Config.VulnDBStateFile)
+		return
+	}
+
+	a.VulnDB = vulndb.NewService(store)
+	a.vulnDBStore = store
+	a.Logger.Info("vulnerability advisory database initialized", "path", a.Config.VulnDBStateFile)
 }
 
 func (a *App) initCompliance() {

--- a/internal/app/app_storage_graph.go
+++ b/internal/app/app_storage_graph.go
@@ -340,6 +340,11 @@ func (a *App) Close() error {
 			}
 		}
 	}
+	if a.vulnDBStore != nil {
+		if err := a.vulnDBStore.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("vulnerability advisory db: %w", err))
+		}
+	}
 
 	if a.RemoteTools != nil {
 		if err := a.RemoteTools.Close(); err != nil {

--- a/internal/app/providers_registry.go
+++ b/internal/app/providers_registry.go
@@ -56,7 +56,11 @@ func (a *App) registerConfiguredProviders(ctx context.Context, cfg *Config, regi
 				"error", err)
 			return
 		}
-		registry.Register(p)
+		registeredProvider := p
+		if p.Type() == providers.ProviderTypeEndpoint {
+			registeredProvider = providers.WithSyncHook(p, a.endpointProviderSyncHook)
+		}
+		registry.Register(registeredProvider)
 		a.Logger.Info("provider registered", "provider", name, "maturity", metadata.Maturity)
 	}
 

--- a/internal/endpointvuln/service.go
+++ b/internal/endpointvuln/service.go
@@ -79,6 +79,7 @@ type vulnerabilitySourceRecord struct {
 	SoftwareName      string
 	SoftwareVersion   string
 	Severity          string
+	Status            string
 	CVSSScore         float64
 	ExploitedInWild   bool
 	DetectedAt        time.Time
@@ -486,6 +487,28 @@ func (r Refresher) loadSourceData(ctx context.Context, available map[string]stru
 		}
 	}
 
+	if rows, err := loadRows("crowdstrike_hosts"); err != nil {
+		return nil, nil, nil, err
+	} else {
+		for _, row := range rows {
+			record := endpointSourceRecord{
+				Provider:                 "crowdstrike",
+				ProviderAssetID:          rowString(row, "device_id"),
+				Hostname:                 firstNonEmpty(rowString(row, "hostname"), rowString(row, "device_name")),
+				DisplayName:              firstNonEmpty(rowString(row, "hostname"), rowString(row, "device_name")),
+				OSType:                   normalizeOSType(firstNonEmpty(rowString(row, "platform_name"), rowString(row, "os_name"), rowString(row, "platform"))),
+				OSVersion:                rowString(row, "os_version"),
+				LastSeenAt:               rowTime(row, "last_seen"),
+				EDRInstalled:             boolPtr(true),
+				MalwareProtectionEnabled: boolPtr(true),
+				AntimalwareInstalled:     boolPtr(true),
+			}
+			if record.ProviderAssetID != "" {
+				endpoints = append(endpoints, record)
+			}
+		}
+	}
+
 	if rows, err := loadRows("kandji_device_apps"); err != nil {
 		return nil, nil, nil, err
 	} else {
@@ -555,11 +578,35 @@ func (r Refresher) loadSourceData(ctx context.Context, available map[string]stru
 				SoftwareName:      firstNonEmpty(rowString(row, "application_name"), rowString(row, "name")),
 				SoftwareVersion:   firstNonEmpty(rowString(row, "application_version"), rowString(row, "version")),
 				Severity:          rowString(row, "severity"),
+				Status:            rowString(row, "status"),
 				CVSSScore:         rowFloat(row, "cvss_score"),
 				ExploitedInWild:   rowBool(row, "exploited_in_wild"),
 				DetectedAt:        rowTime(row, "detected_at"),
 				DaysSinceDetected: rowInt(row, "days_since_detection"),
 				RemediationAction: rowString(row, "remediation_action"),
+			}
+			if record.ProviderAssetID != "" && record.CVEID != "" {
+				vulnerabilities = append(vulnerabilities, record)
+			}
+		}
+	}
+
+	if rows, err := loadRows("crowdstrike_vulnerabilities"); err != nil {
+		return nil, nil, nil, err
+	} else {
+		for _, row := range rows {
+			record := vulnerabilitySourceRecord{
+				Provider:          "crowdstrike",
+				ProviderAssetID:   firstNonEmpty(rowString(row, "host_id"), rowString(row, "device_id")),
+				CVEID:             rowString(row, "cve_id"),
+				SoftwareName:      rowString(row, "app_name"),
+				SoftwareVersion:   rowString(row, "app_version"),
+				Severity:          rowString(row, "severity"),
+				Status:            rowString(row, "status"),
+				ExploitedInWild:   rowBool(row, "exploit_available"),
+				DetectedAt:        rowTime(row, "created_at", "first_found"),
+				LastDetectedAt:    rowTime(row, "updated_at", "last_found"),
+				RemediationAction: rowString(row, "remediation_action", "solution"),
 			}
 			if record.ProviderAssetID != "" && record.CVEID != "" {
 				vulnerabilities = append(vulnerabilities, record)
@@ -762,7 +809,7 @@ func correlateVulnerabilities(records []vulnerabilitySourceRecord, endpoints map
 				AssetID:               endpointID,
 				EndpointID:            endpointID,
 				Hostname:              "",
-				Status:                "open",
+				Status:                "",
 				Providers:             make(map[string]struct{}),
 				ProviderRecords:       make(map[string]struct{}),
 				CorrelationBasis:      "provider_id",
@@ -784,6 +831,7 @@ func correlateVulnerabilities(records []vulnerabilitySourceRecord, endpoints map
 		aggregate.SoftwareVersion = firstNonEmpty(aggregate.SoftwareVersion, softwareVersion)
 		aggregate.Publisher = firstNonEmpty(aggregate.Publisher, publisher)
 		aggregate.BundleID = firstNonEmpty(aggregate.BundleID, bundleID)
+		aggregate.Status = mergeVulnerabilityStatus(aggregate.Status, record.Status)
 		aggregate.Severity = chooseHigherSeverity(aggregate.Severity, record.Severity)
 		if record.CVSSScore > aggregate.CVSSScore {
 			aggregate.CVSSScore = record.CVSSScore
@@ -809,6 +857,9 @@ func correlateVulnerabilities(records []vulnerabilitySourceRecord, endpoints map
 
 	list := make([]*vulnerabilityAggregate, 0, len(aggregates))
 	for _, aggregate := range aggregates {
+		if aggregate.Status == "" {
+			aggregate.Status = "open"
+		}
 		enrichVulnerability(aggregate, intel, advisories, now)
 		list = append(list, aggregate)
 	}
@@ -1384,6 +1435,35 @@ func normalizeSeverity(value string) string {
 		return "LOW"
 	default:
 		return value
+	}
+}
+
+func normalizeVulnerabilityStatus(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "":
+		return ""
+	case "new", "open", "active", "reopened", "unresolved", "in_progress":
+		return "open"
+	case "closed", "resolved", "fixed", "remediated":
+		return "resolved"
+	default:
+		return value
+	}
+}
+
+func mergeVulnerabilityStatus(current, candidate string) string {
+	current = normalizeVulnerabilityStatus(current)
+	candidate = normalizeVulnerabilityStatus(candidate)
+	switch {
+	case current == "":
+		return candidate
+	case candidate == "":
+		return current
+	case current == "open" || candidate == "open":
+		return "open"
+	default:
+		return candidate
 	}
 }
 

--- a/internal/endpointvuln/service.go
+++ b/internal/endpointvuln/service.go
@@ -1,0 +1,1532 @@
+package endpointvuln
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/writer/cerebro/internal/scanner"
+	"github.com/writer/cerebro/internal/threatintel"
+	"github.com/writer/cerebro/internal/warehouse"
+)
+
+const (
+	endpointsTableName         = "endpoints"
+	endpointSoftwareTableName  = "endpoint_software_inventory"
+	vulnerabilitiesTableName   = "vulnerabilities"
+	defaultBatchInsertRowCount = 200
+)
+
+type threatIntelLookup interface {
+	LookupCVE(cve string) (*threatintel.Indicator, bool)
+	IsKEV(cve string) bool
+}
+
+type advisoryLookup interface {
+	LookupCVE(cve string) (*scanner.CVEInfo, bool)
+	IsKEV(cve string) bool
+}
+
+type Refresher struct {
+	Warehouse   warehouse.DataWarehouse
+	ThreatIntel threatIntelLookup
+	Advisories  advisoryLookup
+	Logger      *slog.Logger
+	Now         func() time.Time
+}
+
+type endpointSourceRecord struct {
+	Provider                 string
+	ProviderAssetID          string
+	Hostname                 string
+	DisplayName              string
+	SerialNumber             string
+	OSType                   string
+	OSVersion                string
+	UserName                 string
+	UserEmail                string
+	LastSeenAt               time.Time
+	MDMEnrolled              *bool
+	EDRInstalled             *bool
+	MalwareProtectionEnabled *bool
+	AntimalwareInstalled     *bool
+	FirewallEnabled          *bool
+	DiskEncryptionEnabled    *bool
+}
+
+type softwareSourceRecord struct {
+	Provider        string
+	ProviderAssetID string
+	Name            string
+	Version         string
+	Publisher       string
+	BundleID        string
+	InstalledAt     time.Time
+}
+
+type vulnerabilitySourceRecord struct {
+	Provider          string
+	ProviderAssetID   string
+	CVEID             string
+	SoftwareName      string
+	SoftwareVersion   string
+	Severity          string
+	CVSSScore         float64
+	ExploitedInWild   bool
+	DetectedAt        time.Time
+	LastDetectedAt    time.Time
+	DaysSinceDetected int
+	RemediationAction string
+	Description       string
+	Reference         string
+}
+
+type endpointAggregate struct {
+	ID                       string
+	Hostname                 string
+	DisplayName              string
+	SerialNumber             string
+	OSType                   string
+	OSVersion                string
+	UserName                 string
+	UserEmail                string
+	LastSeenAt               time.Time
+	CorrelationBasis         string
+	CorrelationConfidence    string
+	Providers                map[string]struct{}
+	ProviderRecords          map[string]struct{}
+	MDMEnrolled              bool
+	EDRInstalled             bool
+	MalwareProtectionEnabled bool
+	AntimalwareInstalled     bool
+	FirewallEnabled          bool
+	DiskEncryptionEnabled    bool
+}
+
+type softwareAggregate struct {
+	ID                     string
+	EndpointID             string
+	Hostname               string
+	SoftwareName           string
+	SoftwareNameNormalized string
+	SoftwareVersion        string
+	Publisher              string
+	BundleID               string
+	InstalledAt            time.Time
+	LastSeenAt             time.Time
+	CorrelationBasis       string
+	CorrelationConfidence  string
+	Providers              map[string]struct{}
+	ProviderRecords        map[string]struct{}
+}
+
+type vulnerabilityAggregate struct {
+	ID                     string
+	CVEID                  string
+	AssetID                string
+	EndpointID             string
+	Hostname               string
+	UserEmail              string
+	OSType                 string
+	SoftwareName           string
+	SoftwareNameNormalized string
+	SoftwareVersion        string
+	Publisher              string
+	BundleID               string
+	Severity               string
+	CVSSScore              float64
+	EPSSScore              float64
+	EPSSPercentile         float64
+	IsKEV                  bool
+	KEVDueDate             string
+	ExploitedInWild        bool
+	HasPublicExploit       bool
+	Priority               string
+	PriorityScore          float64
+	Status                 string
+	DetectedAt             time.Time
+	LastDetectedAt         time.Time
+	DaysOpen               int
+	CorrelationBasis       string
+	CorrelationConfidence  string
+	Providers              map[string]struct{}
+	ProviderRecords        map[string]struct{}
+	RemediationAction      string
+	FixedVersion           string
+	Description            string
+	References             map[string]struct{}
+}
+
+type softwareLookup struct {
+	byExact    map[string]*softwareAggregate
+	byEndpoint map[string][]*softwareAggregate
+}
+
+type tableSpec struct {
+	Name    string
+	Create  string
+	Columns []string
+}
+
+var endpointTableSpec = tableSpec{
+	Name: endpointsTableName,
+	Create: `
+CREATE TABLE IF NOT EXISTS endpoints (
+	id TEXT,
+	hostname TEXT,
+	display_name TEXT,
+	serial_number TEXT,
+	os_type TEXT,
+	os_version TEXT,
+	user_name TEXT,
+	user_email TEXT,
+	last_seen_at TIMESTAMP_TZ,
+	provider_count INTEGER,
+	providers TEXT,
+	provider_records TEXT,
+	correlation_basis TEXT,
+	correlation_confidence TEXT,
+	mdm_enrolled BOOLEAN,
+	edr_installed BOOLEAN,
+	malware_protection_enabled BOOLEAN,
+	antimalware_installed BOOLEAN,
+	firewall_enabled BOOLEAN,
+	disk_encryption_enabled BOOLEAN,
+	refreshed_at TIMESTAMP_TZ
+)`,
+	Columns: []string{
+		"id",
+		"hostname",
+		"display_name",
+		"serial_number",
+		"os_type",
+		"os_version",
+		"user_name",
+		"user_email",
+		"last_seen_at",
+		"provider_count",
+		"providers",
+		"provider_records",
+		"correlation_basis",
+		"correlation_confidence",
+		"mdm_enrolled",
+		"edr_installed",
+		"malware_protection_enabled",
+		"antimalware_installed",
+		"firewall_enabled",
+		"disk_encryption_enabled",
+		"refreshed_at",
+	},
+}
+
+var endpointSoftwareTableSpec = tableSpec{
+	Name: endpointSoftwareTableName,
+	Create: `
+CREATE TABLE IF NOT EXISTS endpoint_software_inventory (
+	id TEXT,
+	endpoint_id TEXT,
+	hostname TEXT,
+	software_name TEXT,
+	software_name_normalized TEXT,
+	software_version TEXT,
+	publisher TEXT,
+	bundle_id TEXT,
+	installed_at TIMESTAMP_TZ,
+	last_seen_at TIMESTAMP_TZ,
+	provider_count INTEGER,
+	providers TEXT,
+	provider_records TEXT,
+	correlation_basis TEXT,
+	correlation_confidence TEXT,
+	refreshed_at TIMESTAMP_TZ
+)`,
+	Columns: []string{
+		"id",
+		"endpoint_id",
+		"hostname",
+		"software_name",
+		"software_name_normalized",
+		"software_version",
+		"publisher",
+		"bundle_id",
+		"installed_at",
+		"last_seen_at",
+		"provider_count",
+		"providers",
+		"provider_records",
+		"correlation_basis",
+		"correlation_confidence",
+		"refreshed_at",
+	},
+}
+
+var vulnerabilityTableSpec = tableSpec{
+	Name: vulnerabilitiesTableName,
+	Create: `
+CREATE TABLE IF NOT EXISTS vulnerabilities (
+	id TEXT,
+	cve_id TEXT,
+	asset_id TEXT,
+	endpoint_id TEXT,
+	hostname TEXT,
+	user_email TEXT,
+	os_type TEXT,
+	software_name TEXT,
+	software_name_normalized TEXT,
+	software_version TEXT,
+	publisher TEXT,
+	bundle_id TEXT,
+	severity TEXT,
+	cvss_score FLOAT,
+	epss_score FLOAT,
+	epss_percentile FLOAT,
+	is_kev BOOLEAN,
+	kev_due_date TEXT,
+	exploited_in_wild BOOLEAN,
+	has_public_exploit BOOLEAN,
+	priority TEXT,
+	priority_score FLOAT,
+	status TEXT,
+	detected_at TIMESTAMP_TZ,
+	last_detected_at TIMESTAMP_TZ,
+	days_open INTEGER,
+	provider_count INTEGER,
+	providers TEXT,
+	provider_records TEXT,
+	correlation_basis TEXT,
+	correlation_confidence TEXT,
+	remediation_action TEXT,
+	fixed_version TEXT,
+	description TEXT,
+	references_json TEXT,
+	refreshed_at TIMESTAMP_TZ
+)`,
+	Columns: []string{
+		"id",
+		"cve_id",
+		"asset_id",
+		"endpoint_id",
+		"hostname",
+		"user_email",
+		"os_type",
+		"software_name",
+		"software_name_normalized",
+		"software_version",
+		"publisher",
+		"bundle_id",
+		"severity",
+		"cvss_score",
+		"epss_score",
+		"epss_percentile",
+		"is_kev",
+		"kev_due_date",
+		"exploited_in_wild",
+		"has_public_exploit",
+		"priority",
+		"priority_score",
+		"status",
+		"detected_at",
+		"last_detected_at",
+		"days_open",
+		"provider_count",
+		"providers",
+		"provider_records",
+		"correlation_basis",
+		"correlation_confidence",
+		"remediation_action",
+		"fixed_version",
+		"description",
+		"references_json",
+		"refreshed_at",
+	},
+}
+
+func (r Refresher) Refresh(ctx context.Context) error {
+	if r.Warehouse == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	now := time.Now().UTC()
+	if r.Now != nil {
+		now = r.Now().UTC()
+	}
+
+	available, err := r.availableTables(ctx)
+	if err != nil {
+		return fmt.Errorf("list available tables: %w", err)
+	}
+
+	endpoints, software, vulnerabilities, err := r.loadSourceData(ctx, available)
+	if err != nil {
+		return err
+	}
+
+	endpointAggs, endpointIDs := correlateEndpoints(endpoints)
+	softwareAggs, softwareIndex := correlateSoftware(software, endpointAggs, endpointIDs)
+	vulnerabilityAggs := correlateVulnerabilities(vulnerabilities, endpointAggs, endpointIDs, softwareIndex, r.ThreatIntel, r.Advisories, now)
+
+	if err := r.replaceRows(ctx, endpointTableSpec, endpointRows(endpointAggs, now)); err != nil {
+		return err
+	}
+	if err := r.replaceRows(ctx, endpointSoftwareTableSpec, softwareRows(softwareAggs, now)); err != nil {
+		return err
+	}
+	if err := r.replaceRows(ctx, vulnerabilityTableSpec, vulnerabilityRows(vulnerabilityAggs, now)); err != nil {
+		return err
+	}
+
+	if r.Logger != nil {
+		r.Logger.Info("refreshed normalized endpoint vulnerability tables",
+			"endpoints", len(endpointAggs),
+			"software", len(softwareAggs),
+			"vulnerabilities", len(vulnerabilityAggs),
+		)
+	}
+
+	return nil
+}
+
+func (r Refresher) availableTables(ctx context.Context) (map[string]struct{}, error) {
+	tables, err := r.Warehouse.ListAvailableTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]struct{}, len(tables))
+	for _, table := range tables {
+		normalized := strings.ToLower(strings.TrimSpace(table))
+		if normalized == "" {
+			continue
+		}
+		set[normalized] = struct{}{}
+	}
+	return set, nil
+}
+
+func (r Refresher) loadSourceData(ctx context.Context, available map[string]struct{}) ([]endpointSourceRecord, []softwareSourceRecord, []vulnerabilitySourceRecord, error) {
+	var (
+		endpoints       []endpointSourceRecord
+		software        []softwareSourceRecord
+		vulnerabilities []vulnerabilitySourceRecord
+	)
+
+	loadRows := func(table string) ([]map[string]interface{}, error) {
+		if _, ok := available[table]; !ok {
+			return nil, nil
+		}
+		result, err := r.Warehouse.Query(ctx, "SELECT * FROM "+table)
+		if err != nil {
+			return nil, fmt.Errorf("query %s: %w", table, err)
+		}
+		if result == nil {
+			return nil, nil
+		}
+		return result.Rows, nil
+	}
+
+	if rows, err := loadRows("kandji_devices"); err != nil {
+		return nil, nil, nil, err
+	} else {
+		for _, row := range rows {
+			record := endpointSourceRecord{
+				Provider:                 "kandji",
+				ProviderAssetID:          rowString(row, "device_id"),
+				Hostname:                 firstNonEmpty(rowString(row, "device_name"), rowString(row, "serial_number")),
+				DisplayName:              rowString(row, "device_name"),
+				SerialNumber:             rowString(row, "serial_number"),
+				OSType:                   normalizeOSType(firstNonEmpty(rowString(row, "platform"), rowString(row, "os_type"))),
+				OSVersion:                rowString(row, "os_version"),
+				UserName:                 rowString(row, "user_name"),
+				UserEmail:                rowString(row, "user_email"),
+				LastSeenAt:               rowTime(row, "last_check_in"),
+				MDMEnrolled:              boolPtr(true),
+				EDRInstalled:             rowBoolPointer(row, "agent_installed"),
+				MalwareProtectionEnabled: rowBoolPointer(row, "agent_installed"),
+				AntimalwareInstalled:     rowBoolPointer(row, "agent_installed"),
+				FirewallEnabled:          rowBoolPointer(row, "firewall_enabled"),
+				DiskEncryptionEnabled:    rowBoolPointer(row, "filevault_enabled"),
+			}
+			if record.ProviderAssetID != "" {
+				endpoints = append(endpoints, record)
+			}
+		}
+	}
+
+	if rows, err := loadRows("sentinelone_agents"); err != nil {
+		return nil, nil, nil, err
+	} else {
+		for _, row := range rows {
+			record := endpointSourceRecord{
+				Provider:                 "sentinelone",
+				ProviderAssetID:          rowString(row, "id"),
+				Hostname:                 firstNonEmpty(rowString(row, "computer_name"), rowString(row, "uuid")),
+				DisplayName:              rowString(row, "computer_name"),
+				SerialNumber:             rowString(row, "serial_number"),
+				OSType:                   normalizeOSType(firstNonEmpty(rowString(row, "os_type"), rowString(row, "os_name"))),
+				OSVersion:                rowString(row, "os_version"),
+				LastSeenAt:               rowTime(row, "last_active_date", "registered_at"),
+				EDRInstalled:             boolPtr(true),
+				MalwareProtectionEnabled: boolPtr(rowBool(row, "is_active")),
+				AntimalwareInstalled:     boolPtr(rowBool(row, "is_active")),
+				FirewallEnabled:          rowBoolPointer(row, "firewall_enabled"),
+			}
+			if record.ProviderAssetID != "" {
+				endpoints = append(endpoints, record)
+			}
+		}
+	}
+
+	if rows, err := loadRows("kandji_device_apps"); err != nil {
+		return nil, nil, nil, err
+	} else {
+		for _, row := range rows {
+			record := softwareSourceRecord{
+				Provider:        "kandji",
+				ProviderAssetID: rowString(row, "device_id"),
+				Name:            rowString(row, "app_name"),
+				Version:         rowString(row, "version"),
+				BundleID:        rowString(row, "bundle_id"),
+			}
+			if record.ProviderAssetID != "" && record.Name != "" {
+				software = append(software, record)
+			}
+		}
+	}
+
+	if rows, err := loadRows("sentinelone_applications"); err != nil {
+		return nil, nil, nil, err
+	} else {
+		for _, row := range rows {
+			record := softwareSourceRecord{
+				Provider:        "sentinelone",
+				ProviderAssetID: rowString(row, "agent_id"),
+				Name:            firstNonEmpty(rowString(row, "name"), rowString(row, "application_name")),
+				Version:         firstNonEmpty(rowString(row, "version"), rowString(row, "application_version")),
+				Publisher:       rowString(row, "publisher"),
+				BundleID:        rowString(row, "bundle_id"),
+				InstalledAt:     rowTime(row, "installed_date"),
+			}
+			if record.ProviderAssetID != "" && record.Name != "" {
+				software = append(software, record)
+			}
+		}
+	}
+
+	if rows, err := loadRows("kandji_vulnerabilities"); err != nil {
+		return nil, nil, nil, err
+	} else {
+		for _, row := range rows {
+			record := vulnerabilitySourceRecord{
+				Provider:        "kandji",
+				ProviderAssetID: rowString(row, "device_id"),
+				CVEID:           rowString(row, "cve_id"),
+				SoftwareName:    firstNonEmpty(rowString(row, "software_name"), rowString(row, "app_name")),
+				SoftwareVersion: firstNonEmpty(rowString(row, "software_version"), rowString(row, "version")),
+				Severity:        rowString(row, "cvss_severity"),
+				CVSSScore:       rowFloat(row, "cvss_score"),
+				DetectedAt:      rowTime(row, "first_detection_date"),
+				LastDetectedAt:  rowTime(row, "latest_detection_date"),
+				Reference:       rowString(row, "cve_link"),
+			}
+			if record.ProviderAssetID != "" && record.CVEID != "" {
+				vulnerabilities = append(vulnerabilities, record)
+			}
+		}
+	}
+
+	if rows, err := loadRows("sentinelone_vulnerabilities"); err != nil {
+		return nil, nil, nil, err
+	} else {
+		for _, row := range rows {
+			record := vulnerabilitySourceRecord{
+				Provider:          "sentinelone",
+				ProviderAssetID:   rowString(row, "agent_id"),
+				CVEID:             rowString(row, "cve_id"),
+				SoftwareName:      firstNonEmpty(rowString(row, "application_name"), rowString(row, "name")),
+				SoftwareVersion:   firstNonEmpty(rowString(row, "application_version"), rowString(row, "version")),
+				Severity:          rowString(row, "severity"),
+				CVSSScore:         rowFloat(row, "cvss_score"),
+				ExploitedInWild:   rowBool(row, "exploited_in_wild"),
+				DetectedAt:        rowTime(row, "detected_at"),
+				DaysSinceDetected: rowInt(row, "days_since_detection"),
+				RemediationAction: rowString(row, "remediation_action"),
+			}
+			if record.ProviderAssetID != "" && record.CVEID != "" {
+				vulnerabilities = append(vulnerabilities, record)
+			}
+		}
+	}
+
+	return endpoints, software, vulnerabilities, nil
+}
+
+func correlateEndpoints(records []endpointSourceRecord) (map[string]*endpointAggregate, map[string]string) {
+	hostToSerial := make(map[string]string)
+	ambiguousHosts := make(map[string]struct{})
+
+	for _, record := range records {
+		hostKey := endpointHostKey(record)
+		serialKey := endpointSerialKey(record)
+		if hostKey == "" || serialKey == "" {
+			continue
+		}
+		if existing, ok := hostToSerial[hostKey]; ok && existing != serialKey {
+			ambiguousHosts[hostKey] = struct{}{}
+			continue
+		}
+		hostToSerial[hostKey] = serialKey
+	}
+	for hostKey := range ambiguousHosts {
+		delete(hostToSerial, hostKey)
+	}
+
+	aggregates := make(map[string]*endpointAggregate)
+	endpointIDs := make(map[string]string)
+
+	for _, record := range records {
+		if strings.TrimSpace(record.ProviderAssetID) == "" {
+			continue
+		}
+		identityKey, basis, confidence := endpointIdentity(record, hostToSerial)
+		aggregateID := "endpoint-" + stableHash(identityKey)
+		endpointIDs[providerRecordKey(record.Provider, record.ProviderAssetID)] = aggregateID
+
+		aggregate, ok := aggregates[aggregateID]
+		if !ok {
+			aggregate = &endpointAggregate{
+				ID:                    aggregateID,
+				CorrelationBasis:      basis,
+				CorrelationConfidence: confidence,
+				Providers:             make(map[string]struct{}),
+				ProviderRecords:       make(map[string]struct{}),
+			}
+			aggregates[aggregateID] = aggregate
+		}
+
+		aggregate.Hostname = preferLongerString(aggregate.Hostname, normalizeDisplayName(record.Hostname))
+		aggregate.DisplayName = preferLongerString(aggregate.DisplayName, normalizeDisplayName(record.DisplayName))
+		aggregate.SerialNumber = firstNonEmpty(aggregate.SerialNumber, record.SerialNumber)
+		aggregate.OSType = firstNonEmpty(aggregate.OSType, normalizeOSType(record.OSType))
+		aggregate.OSVersion = firstNonEmpty(aggregate.OSVersion, record.OSVersion)
+		aggregate.UserName = firstNonEmpty(aggregate.UserName, record.UserName)
+		aggregate.UserEmail = firstNonEmpty(aggregate.UserEmail, record.UserEmail)
+		if record.LastSeenAt.After(aggregate.LastSeenAt) {
+			aggregate.LastSeenAt = record.LastSeenAt.UTC()
+		}
+		if confidenceRank(confidence) > confidenceRank(aggregate.CorrelationConfidence) {
+			aggregate.CorrelationConfidence = confidence
+			aggregate.CorrelationBasis = basis
+		}
+		aggregate.Providers[record.Provider] = struct{}{}
+		aggregate.ProviderRecords[providerRecordKey(record.Provider, record.ProviderAssetID)] = struct{}{}
+		aggregate.MDMEnrolled = aggregate.MDMEnrolled || derefBool(record.MDMEnrolled)
+		aggregate.EDRInstalled = aggregate.EDRInstalled || derefBool(record.EDRInstalled)
+		aggregate.MalwareProtectionEnabled = aggregate.MalwareProtectionEnabled || derefBool(record.MalwareProtectionEnabled)
+		aggregate.AntimalwareInstalled = aggregate.AntimalwareInstalled || derefBool(record.AntimalwareInstalled)
+		aggregate.FirewallEnabled = aggregate.FirewallEnabled || derefBool(record.FirewallEnabled)
+		aggregate.DiskEncryptionEnabled = aggregate.DiskEncryptionEnabled || derefBool(record.DiskEncryptionEnabled)
+	}
+
+	return aggregates, endpointIDs
+}
+
+func correlateSoftware(records []softwareSourceRecord, endpoints map[string]*endpointAggregate, endpointIDs map[string]string) ([]*softwareAggregate, softwareLookup) {
+	aggregates := make(map[string]*softwareAggregate)
+	for _, record := range records {
+		endpointID := endpointIDs[providerRecordKey(record.Provider, record.ProviderAssetID)]
+		if endpointID == "" {
+			continue
+		}
+
+		name := strings.TrimSpace(record.Name)
+		version := strings.TrimSpace(record.Version)
+		canonicalName := canonicalSoftwareName(record.Name, record.BundleID)
+		if canonicalName == "" {
+			continue
+		}
+		key := strings.Join([]string{endpointID, canonicalName, normalizeVersion(version)}, "|")
+		aggregateID := "software-" + stableHash(key)
+
+		aggregate, ok := aggregates[aggregateID]
+		if !ok {
+			aggregate = &softwareAggregate{
+				ID:                     aggregateID,
+				EndpointID:             endpointID,
+				SoftwareNameNormalized: normalizeSoftwareName(name),
+				SoftwareVersion:        version,
+				Providers:              make(map[string]struct{}),
+				ProviderRecords:        make(map[string]struct{}),
+			}
+			if endpoint := endpoints[endpointID]; endpoint != nil {
+				aggregate.Hostname = endpoint.Hostname
+				aggregate.LastSeenAt = endpoint.LastSeenAt
+				aggregate.CorrelationBasis = endpoint.CorrelationBasis
+				aggregate.CorrelationConfidence = endpoint.CorrelationConfidence
+			}
+			aggregates[aggregateID] = aggregate
+		}
+
+		aggregate.SoftwareName = preferLongerString(aggregate.SoftwareName, name)
+		aggregate.SoftwareNameNormalized = firstNonEmpty(aggregate.SoftwareNameNormalized, normalizeSoftwareName(name))
+		aggregate.SoftwareVersion = firstNonEmpty(aggregate.SoftwareVersion, version)
+		aggregate.Publisher = firstNonEmpty(aggregate.Publisher, record.Publisher)
+		aggregate.BundleID = firstNonEmpty(aggregate.BundleID, record.BundleID)
+		if !record.InstalledAt.IsZero() && (aggregate.InstalledAt.IsZero() || record.InstalledAt.Before(aggregate.InstalledAt)) {
+			aggregate.InstalledAt = record.InstalledAt.UTC()
+		}
+		if record.InstalledAt.After(aggregate.LastSeenAt) {
+			aggregate.LastSeenAt = record.InstalledAt.UTC()
+		}
+		aggregate.Providers[record.Provider] = struct{}{}
+		aggregate.ProviderRecords[providerRecordKey(record.Provider, record.ProviderAssetID)] = struct{}{}
+	}
+
+	list := make([]*softwareAggregate, 0, len(aggregates))
+	lookup := softwareLookup{
+		byExact:    make(map[string]*softwareAggregate, len(aggregates)),
+		byEndpoint: make(map[string][]*softwareAggregate),
+	}
+	for _, aggregate := range aggregates {
+		list = append(list, aggregate)
+		exactKey := strings.Join([]string{aggregate.EndpointID, aggregate.SoftwareNameNormalized, normalizeVersion(aggregate.SoftwareVersion)}, "|")
+		lookup.byExact[exactKey] = aggregate
+		lookup.byEndpoint[aggregate.EndpointID] = append(lookup.byEndpoint[aggregate.EndpointID], aggregate)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].ID < list[j].ID })
+	for endpointID := range lookup.byEndpoint {
+		sort.Slice(lookup.byEndpoint[endpointID], func(i, j int) bool {
+			return lookup.byEndpoint[endpointID][i].ID < lookup.byEndpoint[endpointID][j].ID
+		})
+	}
+	return list, lookup
+}
+
+func correlateVulnerabilities(records []vulnerabilitySourceRecord, endpoints map[string]*endpointAggregate, endpointIDs map[string]string, softwareIndex softwareLookup, intel threatIntelLookup, advisories advisoryLookup, now time.Time) []*vulnerabilityAggregate {
+	aggregates := make(map[string]*vulnerabilityAggregate)
+
+	for _, record := range records {
+		endpointID := endpointIDs[providerRecordKey(record.Provider, record.ProviderAssetID)]
+		if endpointID == "" {
+			continue
+		}
+		cveID := normalizeCVE(record.CVEID)
+		if cveID == "" {
+			continue
+		}
+
+		endpoint := endpoints[endpointID]
+		matchedSoftware := softwareIndex.match(endpointID, record.SoftwareName, record.SoftwareVersion)
+
+		softwareName := strings.TrimSpace(record.SoftwareName)
+		softwareVersion := strings.TrimSpace(record.SoftwareVersion)
+		softwareNameNormalized := normalizeSoftwareName(softwareName)
+		publisher := ""
+		bundleID := ""
+		if matchedSoftware != nil {
+			softwareName = firstNonEmpty(matchedSoftware.SoftwareName, softwareName)
+			softwareVersion = firstNonEmpty(matchedSoftware.SoftwareVersion, softwareVersion)
+			softwareNameNormalized = firstNonEmpty(matchedSoftware.SoftwareNameNormalized, softwareNameNormalized)
+			publisher = matchedSoftware.Publisher
+			bundleID = matchedSoftware.BundleID
+		}
+		if softwareNameNormalized == "" {
+			softwareNameNormalized = normalizeSoftwareName(softwareName)
+		}
+		if softwareNameNormalized == "" {
+			softwareNameNormalized = "unknown"
+		}
+
+		key := strings.Join([]string{
+			endpointID,
+			cveID,
+			softwareNameNormalized,
+			normalizeVersion(softwareVersion),
+		}, "|")
+		aggregateID := "vuln-" + stableHash(key)
+
+		aggregate, ok := aggregates[aggregateID]
+		if !ok {
+			aggregate = &vulnerabilityAggregate{
+				ID:                    aggregateID,
+				CVEID:                 cveID,
+				AssetID:               endpointID,
+				EndpointID:            endpointID,
+				Hostname:              "",
+				Status:                "open",
+				Providers:             make(map[string]struct{}),
+				ProviderRecords:       make(map[string]struct{}),
+				CorrelationBasis:      "provider_id",
+				CorrelationConfidence: "low",
+				References:            make(map[string]struct{}),
+			}
+			if endpoint != nil {
+				aggregate.Hostname = endpoint.Hostname
+				aggregate.UserEmail = endpoint.UserEmail
+				aggregate.OSType = endpoint.OSType
+				aggregate.CorrelationBasis = endpoint.CorrelationBasis
+				aggregate.CorrelationConfidence = endpoint.CorrelationConfidence
+			}
+			aggregates[aggregateID] = aggregate
+		}
+
+		aggregate.SoftwareName = preferLongerString(aggregate.SoftwareName, softwareName)
+		aggregate.SoftwareNameNormalized = firstNonEmpty(aggregate.SoftwareNameNormalized, softwareNameNormalized)
+		aggregate.SoftwareVersion = firstNonEmpty(aggregate.SoftwareVersion, softwareVersion)
+		aggregate.Publisher = firstNonEmpty(aggregate.Publisher, publisher)
+		aggregate.BundleID = firstNonEmpty(aggregate.BundleID, bundleID)
+		aggregate.Severity = chooseHigherSeverity(aggregate.Severity, record.Severity)
+		if record.CVSSScore > aggregate.CVSSScore {
+			aggregate.CVSSScore = record.CVSSScore
+		}
+		aggregate.ExploitedInWild = aggregate.ExploitedInWild || record.ExploitedInWild
+		aggregate.RemediationAction = firstNonEmpty(aggregate.RemediationAction, record.RemediationAction)
+		aggregate.Description = firstNonEmpty(aggregate.Description, record.Description)
+		if reference := strings.TrimSpace(record.Reference); reference != "" {
+			aggregate.References[reference] = struct{}{}
+		}
+
+		detectedAt, lastDetectedAt := detectionWindow(record, endpoint, now)
+		if aggregate.DetectedAt.IsZero() || (!detectedAt.IsZero() && detectedAt.Before(aggregate.DetectedAt)) {
+			aggregate.DetectedAt = detectedAt
+		}
+		if lastDetectedAt.After(aggregate.LastDetectedAt) {
+			aggregate.LastDetectedAt = lastDetectedAt
+		}
+
+		aggregate.Providers[record.Provider] = struct{}{}
+		aggregate.ProviderRecords[providerRecordKey(record.Provider, record.ProviderAssetID)] = struct{}{}
+	}
+
+	list := make([]*vulnerabilityAggregate, 0, len(aggregates))
+	for _, aggregate := range aggregates {
+		enrichVulnerability(aggregate, intel, advisories, now)
+		list = append(list, aggregate)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].ID < list[j].ID })
+	return list
+}
+
+func endpointRows(aggregates map[string]*endpointAggregate, refreshedAt time.Time) []map[string]any {
+	keys := make([]string, 0, len(aggregates))
+	for key := range aggregates {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	rows := make([]map[string]any, 0, len(keys))
+	for _, key := range keys {
+		aggregate := aggregates[key]
+		rows = append(rows, map[string]any{
+			"id":                         aggregate.ID,
+			"hostname":                   nullableString(aggregate.Hostname),
+			"display_name":               nullableString(firstNonEmpty(aggregate.DisplayName, aggregate.Hostname)),
+			"serial_number":              nullableString(aggregate.SerialNumber),
+			"os_type":                    nullableString(aggregate.OSType),
+			"os_version":                 nullableString(aggregate.OSVersion),
+			"user_name":                  nullableString(aggregate.UserName),
+			"user_email":                 nullableString(aggregate.UserEmail),
+			"last_seen_at":               nullableTime(aggregate.LastSeenAt),
+			"provider_count":             len(aggregate.Providers),
+			"providers":                  providersString(aggregate.Providers),
+			"provider_records":           jsonString(sortedKeys(aggregate.ProviderRecords)),
+			"correlation_basis":          aggregate.CorrelationBasis,
+			"correlation_confidence":     aggregate.CorrelationConfidence,
+			"mdm_enrolled":               aggregate.MDMEnrolled,
+			"edr_installed":              aggregate.EDRInstalled,
+			"malware_protection_enabled": aggregate.MalwareProtectionEnabled,
+			"antimalware_installed":      aggregate.AntimalwareInstalled,
+			"firewall_enabled":           aggregate.FirewallEnabled,
+			"disk_encryption_enabled":    aggregate.DiskEncryptionEnabled,
+			"refreshed_at":               refreshedAt.UTC(),
+		})
+	}
+	return rows
+}
+
+func softwareRows(aggregates []*softwareAggregate, refreshedAt time.Time) []map[string]any {
+	rows := make([]map[string]any, 0, len(aggregates))
+	for _, aggregate := range aggregates {
+		rows = append(rows, map[string]any{
+			"id":                       aggregate.ID,
+			"endpoint_id":              aggregate.EndpointID,
+			"hostname":                 nullableString(aggregate.Hostname),
+			"software_name":            nullableString(aggregate.SoftwareName),
+			"software_name_normalized": aggregate.SoftwareNameNormalized,
+			"software_version":         nullableString(aggregate.SoftwareVersion),
+			"publisher":                nullableString(aggregate.Publisher),
+			"bundle_id":                nullableString(aggregate.BundleID),
+			"installed_at":             nullableTime(aggregate.InstalledAt),
+			"last_seen_at":             nullableTime(aggregate.LastSeenAt),
+			"provider_count":           len(aggregate.Providers),
+			"providers":                providersString(aggregate.Providers),
+			"provider_records":         jsonString(sortedKeys(aggregate.ProviderRecords)),
+			"correlation_basis":        aggregate.CorrelationBasis,
+			"correlation_confidence":   aggregate.CorrelationConfidence,
+			"refreshed_at":             refreshedAt.UTC(),
+		})
+	}
+	return rows
+}
+
+func vulnerabilityRows(aggregates []*vulnerabilityAggregate, refreshedAt time.Time) []map[string]any {
+	rows := make([]map[string]any, 0, len(aggregates))
+	for _, aggregate := range aggregates {
+		rows = append(rows, map[string]any{
+			"id":                       aggregate.ID,
+			"cve_id":                   aggregate.CVEID,
+			"asset_id":                 aggregate.AssetID,
+			"endpoint_id":              aggregate.EndpointID,
+			"hostname":                 nullableString(aggregate.Hostname),
+			"user_email":               nullableString(aggregate.UserEmail),
+			"os_type":                  nullableString(aggregate.OSType),
+			"software_name":            nullableString(aggregate.SoftwareName),
+			"software_name_normalized": aggregate.SoftwareNameNormalized,
+			"software_version":         nullableString(aggregate.SoftwareVersion),
+			"publisher":                nullableString(aggregate.Publisher),
+			"bundle_id":                nullableString(aggregate.BundleID),
+			"severity":                 aggregate.Severity,
+			"cvss_score":               aggregate.CVSSScore,
+			"epss_score":               aggregate.EPSSScore,
+			"epss_percentile":          aggregate.EPSSPercentile,
+			"is_kev":                   aggregate.IsKEV,
+			"kev_due_date":             nullableString(aggregate.KEVDueDate),
+			"exploited_in_wild":        aggregate.ExploitedInWild,
+			"has_public_exploit":       aggregate.HasPublicExploit,
+			"priority":                 aggregate.Priority,
+			"priority_score":           aggregate.PriorityScore,
+			"status":                   aggregate.Status,
+			"detected_at":              nullableTime(aggregate.DetectedAt),
+			"last_detected_at":         nullableTime(aggregate.LastDetectedAt),
+			"days_open":                aggregate.DaysOpen,
+			"provider_count":           len(aggregate.Providers),
+			"providers":                providersString(aggregate.Providers),
+			"provider_records":         jsonString(sortedKeys(aggregate.ProviderRecords)),
+			"correlation_basis":        aggregate.CorrelationBasis,
+			"correlation_confidence":   aggregate.CorrelationConfidence,
+			"remediation_action":       nullableString(aggregate.RemediationAction),
+			"fixed_version":            nullableString(aggregate.FixedVersion),
+			"description":              nullableString(aggregate.Description),
+			"references_json":          jsonString(sortedKeys(aggregate.References)),
+			"refreshed_at":             refreshedAt.UTC(),
+		})
+	}
+	return rows
+}
+
+func (r Refresher) replaceRows(ctx context.Context, spec tableSpec, rows []map[string]any) error {
+	if _, err := r.Warehouse.Exec(ctx, spec.Create); err != nil {
+		return fmt.Errorf("ensure %s: %w", spec.Name, err)
+	}
+	if _, err := r.Warehouse.Exec(ctx, "DELETE FROM "+spec.Name); err != nil {
+		return fmt.Errorf("clear %s: %w", spec.Name, err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	insertQuery := fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES (%s)",
+		spec.Name,
+		strings.Join(spec.Columns, ", "),
+		strings.TrimRight(strings.Repeat("?, ", len(spec.Columns)), ", "),
+	)
+
+	for start := 0; start < len(rows); start += defaultBatchInsertRowCount {
+		end := start + defaultBatchInsertRowCount
+		if end > len(rows) {
+			end = len(rows)
+		}
+		for _, row := range rows[start:end] {
+			args := make([]any, 0, len(spec.Columns))
+			for _, column := range spec.Columns {
+				args = append(args, row[column])
+			}
+			if _, err := r.Warehouse.Exec(ctx, insertQuery, args...); err != nil {
+				return fmt.Errorf("insert into %s: %w", spec.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func enrichVulnerability(aggregate *vulnerabilityAggregate, intel threatIntelLookup, advisories advisoryLookup, now time.Time) {
+	if aggregate == nil {
+		return
+	}
+
+	if advisories != nil {
+		if advisory, ok := advisories.LookupCVE(aggregate.CVEID); ok && advisory != nil {
+			aggregate.CVSSScore = maxFloat(aggregate.CVSSScore, advisory.CVSS)
+			aggregate.EPSSScore = maxFloat(aggregate.EPSSScore, advisory.EPSSScore)
+			aggregate.EPSSPercentile = maxFloat(aggregate.EPSSPercentile, advisory.EPSSPercentile)
+			aggregate.IsKEV = aggregate.IsKEV || advisory.InKEV || advisories.IsKEV(aggregate.CVEID)
+			aggregate.ExploitedInWild = aggregate.ExploitedInWild || advisory.Exploitable || aggregate.IsKEV
+			aggregate.Severity = chooseHigherSeverity(aggregate.Severity, advisory.Severity)
+			aggregate.Description = firstNonEmpty(aggregate.Description, advisory.Description)
+			for _, reference := range advisory.References {
+				if trimmed := strings.TrimSpace(reference); trimmed != "" {
+					aggregate.References[trimmed] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if intel != nil {
+		if indicator, ok := intel.LookupCVE(aggregate.CVEID); ok && indicator != nil {
+			aggregate.IsKEV = aggregate.IsKEV || intel.IsKEV(aggregate.CVEID)
+			aggregate.Description = firstNonEmpty(aggregate.Description, indicator.Description)
+			if dueDate := strings.TrimSpace(indicator.Metadata["due_date"]); dueDate != "" {
+				aggregate.KEVDueDate = dueDate
+			}
+		}
+	}
+
+	if aggregate.CVSSScore > 0 {
+		aggregate.Severity = chooseHigherSeverity(aggregate.Severity, severityFromScore(aggregate.CVSSScore))
+	}
+	if aggregate.Severity == "" {
+		aggregate.Severity = "UNKNOWN"
+	}
+
+	aggregate.HasPublicExploit = aggregate.HasPublicExploit || aggregate.ExploitedInWild || aggregate.IsKEV
+	aggregate.ExploitedInWild = aggregate.ExploitedInWild || aggregate.IsKEV
+
+	if aggregate.DetectedAt.IsZero() && !aggregate.LastDetectedAt.IsZero() {
+		aggregate.DetectedAt = aggregate.LastDetectedAt
+	}
+	if aggregate.LastDetectedAt.IsZero() && !aggregate.DetectedAt.IsZero() {
+		aggregate.LastDetectedAt = aggregate.DetectedAt
+	}
+	if !aggregate.DetectedAt.IsZero() {
+		aggregate.DaysOpen = int(now.Sub(aggregate.DetectedAt).Hours() / 24)
+		if aggregate.DaysOpen < 0 {
+			aggregate.DaysOpen = 0
+		}
+	}
+
+	var epss *threatintel.EPSSScore
+	if aggregate.EPSSScore > 0 || aggregate.EPSSPercentile > 0 {
+		epss = &threatintel.EPSSScore{
+			CVE:        aggregate.CVEID,
+			EPSS:       aggregate.EPSSScore,
+			Percentile: aggregate.EPSSPercentile,
+		}
+	}
+	risk := threatintel.CalculateVulnerabilityRisk(aggregate.CVSSScore, epss, aggregate.IsKEV, aggregate.HasPublicExploit)
+	if risk != nil {
+		aggregate.Priority = firstNonEmpty(aggregate.Priority, strings.TrimSpace(risk.Priority))
+		aggregate.PriorityScore = maxFloat(aggregate.PriorityScore, risk.CompositeScore)
+	}
+	if aggregate.Priority == "" {
+		aggregate.Priority = strings.ToLower(strings.TrimSpace(aggregate.Severity))
+	}
+}
+
+func (l softwareLookup) match(endpointID, name, version string) *softwareAggregate {
+	nameKey := normalizeSoftwareName(name)
+	versionKey := normalizeVersion(version)
+	if endpointID == "" || nameKey == "" {
+		return nil
+	}
+	if exact, ok := l.byExact[strings.Join([]string{endpointID, nameKey, versionKey}, "|")]; ok {
+		return exact
+	}
+	for _, candidate := range l.byEndpoint[endpointID] {
+		if candidate == nil {
+			continue
+		}
+		if versionKey != "" && normalizeVersion(candidate.SoftwareVersion) != versionKey {
+			continue
+		}
+		candidateName := candidate.SoftwareNameNormalized
+		if candidateName == "" {
+			candidateName = normalizeSoftwareName(candidate.SoftwareName)
+		}
+		if candidateName == nameKey || strings.Contains(candidateName, nameKey) || strings.Contains(nameKey, candidateName) {
+			return candidate
+		}
+	}
+	return nil
+}
+
+func endpointIdentity(record endpointSourceRecord, hostToSerial map[string]string) (string, string, string) {
+	if serialKey := endpointSerialKey(record); serialKey != "" {
+		return serialKey, "serial_number", "high"
+	}
+	if hostKey := endpointHostKey(record); hostKey != "" {
+		if serialKey, ok := hostToSerial[hostKey]; ok && serialKey != "" {
+			return serialKey, "hostname_os", "medium"
+		}
+		return hostKey, "hostname_os", "medium"
+	}
+	return "provider:" + providerRecordKey(record.Provider, record.ProviderAssetID), "provider_id", "low"
+}
+
+func endpointSerialKey(record endpointSourceRecord) string {
+	serial := normalizeIdentifier(record.SerialNumber)
+	if serial == "" {
+		return ""
+	}
+	return "serial:" + serial
+}
+
+func endpointHostKey(record endpointSourceRecord) string {
+	host := normalizeHostname(firstNonEmpty(record.Hostname, record.DisplayName))
+	if host == "" {
+		return ""
+	}
+	osType := normalizeOSType(record.OSType)
+	if osType == "" {
+		return ""
+	}
+	return "host:" + host + "|os:" + osType
+}
+
+func canonicalSoftwareName(name, bundleID string) string {
+	if normalizedName := normalizeSoftwareName(name); normalizedName != "" {
+		return "name:" + normalizedName
+	}
+	if normalizedBundle := strings.ToLower(strings.TrimSpace(bundleID)); normalizedBundle != "" {
+		return "bundle:" + normalizedBundle
+	}
+	return ""
+}
+
+func detectionWindow(record vulnerabilitySourceRecord, endpoint *endpointAggregate, now time.Time) (time.Time, time.Time) {
+	detectedAt := record.DetectedAt
+	lastDetectedAt := record.LastDetectedAt
+	if detectedAt.IsZero() && record.DaysSinceDetected > 0 {
+		detectedAt = now.AddDate(0, 0, -record.DaysSinceDetected)
+	}
+	if detectedAt.IsZero() && endpoint != nil && !endpoint.LastSeenAt.IsZero() {
+		detectedAt = endpoint.LastSeenAt
+	}
+	if detectedAt.IsZero() {
+		detectedAt = now
+	}
+	if lastDetectedAt.IsZero() {
+		lastDetectedAt = detectedAt
+	}
+	return detectedAt.UTC(), lastDetectedAt.UTC()
+}
+
+func rowValue(row map[string]interface{}, keys ...string) (interface{}, bool) {
+	for _, key := range keys {
+		if value, ok := row[key]; ok {
+			return value, true
+		}
+		lower := strings.ToLower(key)
+		if value, ok := row[lower]; ok {
+			return value, true
+		}
+		for existingKey, value := range row {
+			if strings.EqualFold(existingKey, key) {
+				return value, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func rowString(row map[string]interface{}, keys ...string) string {
+	value, ok := rowValue(row, keys...)
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case []byte:
+		return strings.TrimSpace(string(typed))
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", value))
+	}
+}
+
+func rowBoolPointer(row map[string]interface{}, keys ...string) *bool {
+	value, ok := rowValue(row, keys...)
+	if !ok {
+		return nil
+	}
+	parsed := boolPtr(parseBool(value))
+	return parsed
+}
+
+func rowBool(row map[string]interface{}, keys ...string) bool {
+	value, ok := rowValue(row, keys...)
+	if !ok {
+		return false
+	}
+	return parseBool(value)
+}
+
+func rowFloat(row map[string]interface{}, keys ...string) float64 {
+	value, ok := rowValue(row, keys...)
+	if !ok {
+		return 0
+	}
+	return parseFloat(value)
+}
+
+func rowInt(row map[string]interface{}, keys ...string) int {
+	value, ok := rowValue(row, keys...)
+	if !ok {
+		return 0
+	}
+	return int(parseFloat(value))
+}
+
+func rowTime(row map[string]interface{}, keys ...string) time.Time {
+	value, ok := rowValue(row, keys...)
+	if !ok || value == nil {
+		return time.Time{}
+	}
+	switch typed := value.(type) {
+	case time.Time:
+		return typed.UTC()
+	case string:
+		return parseTimeString(typed)
+	case []byte:
+		return parseTimeString(string(typed))
+	case int64:
+		return time.Unix(typed, 0).UTC()
+	case float64:
+		return time.Unix(int64(typed), 0).UTC()
+	default:
+		return parseTimeString(fmt.Sprintf("%v", value))
+	}
+}
+
+func parseBool(value interface{}) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case int:
+		return typed != 0
+	case int64:
+		return typed != 0
+	case float64:
+		return typed != 0
+	case []byte:
+		switch strings.ToLower(strings.TrimSpace(string(typed))) {
+		case "1", "true", "t", "yes", "y":
+			return true
+		default:
+			return false
+		}
+	case string:
+		switch strings.ToLower(strings.TrimSpace(typed)) {
+		case "1", "true", "t", "yes", "y":
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
+func parseFloat(value interface{}) float64 {
+	switch typed := value.(type) {
+	case float64:
+		return typed
+	case float32:
+		return float64(typed)
+	case int:
+		return float64(typed)
+	case int64:
+		return float64(typed)
+	case int32:
+		return float64(typed)
+	case json.Number:
+		parsed, _ := typed.Float64()
+		return parsed
+	case string:
+		parsed, _ := strconv.ParseFloat(strings.TrimSpace(typed), 64)
+		return parsed
+	case []byte:
+		parsed, _ := strconv.ParseFloat(strings.TrimSpace(string(typed)), 64)
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func parseTimeString(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+		time.DateOnly,
+	}
+	for _, layout := range layouts {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func normalizeHostname(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	if idx := strings.Index(value, "."); idx > 0 {
+		value = value[:idx]
+	}
+	return value
+}
+
+func normalizeDisplayName(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func normalizeOSType(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case value == "":
+		return ""
+	case strings.Contains(value, "mac"):
+		return "macos"
+	case strings.Contains(value, "windows"):
+		return "windows"
+	case strings.Contains(value, "linux"):
+		return "linux"
+	default:
+		return value
+	}
+}
+
+func normalizeSoftwareName(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	var builder strings.Builder
+	prevSpace := false
+	for _, r := range value {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			builder.WriteRune(r)
+			prevSpace = false
+		default:
+			if !prevSpace && builder.Len() > 0 {
+				builder.WriteByte(' ')
+				prevSpace = true
+			}
+		}
+	}
+	return strings.Join(strings.Fields(builder.String()), " ")
+}
+
+func normalizeVersion(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	value = strings.TrimPrefix(value, "v")
+	return value
+}
+
+func normalizeIdentifier(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	var builder strings.Builder
+	prevDash := false
+	for _, r := range value {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			builder.WriteRune(r)
+			prevDash = false
+		case r == '-' || r == '_' || r == '.' || r == '/':
+			if builder.Len() > 0 && !prevDash {
+				builder.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func normalizeCVE(value string) string {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	if value == "" {
+		return ""
+	}
+	return value
+}
+
+func normalizeSeverity(value string) string {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	switch value {
+	case "":
+		return "UNKNOWN"
+	case "MODERATE":
+		return "MEDIUM"
+	case "INFO", "INFORMATIONAL", "NEGLIGIBLE":
+		return "LOW"
+	default:
+		return value
+	}
+}
+
+func chooseHigherSeverity(current, candidate string) string {
+	current = normalizeSeverity(current)
+	candidate = normalizeSeverity(candidate)
+	if severityRank(candidate) > severityRank(current) {
+		return candidate
+	}
+	return current
+}
+
+func severityRank(value string) int {
+	switch normalizeSeverity(value) {
+	case "CRITICAL":
+		return 4
+	case "HIGH":
+		return 3
+	case "MEDIUM":
+		return 2
+	case "LOW":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func severityFromScore(score float64) string {
+	switch {
+	case score >= 9:
+		return "CRITICAL"
+	case score >= 7:
+		return "HIGH"
+	case score >= 4:
+		return "MEDIUM"
+	case score > 0:
+		return "LOW"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func confidenceRank(value string) int {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func providerRecordKey(provider, id string) string {
+	return strings.TrimSpace(provider) + ":" + strings.TrimSpace(id)
+}
+
+func providersString(values map[string]struct{}) string {
+	return strings.Join(sortedKeys(values), ",")
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return []string{}
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func stableHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:8])
+}
+
+func jsonString(values []string) string {
+	if len(values) == 0 {
+		return "[]"
+	}
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		return "[]"
+	}
+	return string(encoded)
+}
+
+func nullableString(value string) interface{} {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
+}
+
+func nullableTime(value time.Time) interface{} {
+	if value.IsZero() {
+		return nil
+	}
+	return value.UTC()
+}
+
+func preferLongerString(current, candidate string) string {
+	current = strings.TrimSpace(current)
+	candidate = strings.TrimSpace(candidate)
+	switch {
+	case current == "":
+		return candidate
+	case candidate == "":
+		return current
+	case len(candidate) > len(current):
+		return candidate
+	default:
+		return current
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func maxFloat(current, candidate float64) float64 {
+	if candidate > current {
+		return candidate
+	}
+	return current
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func derefBool(value *bool) bool {
+	return value != nil && *value
+}

--- a/internal/endpointvuln/service.go
+++ b/internal/endpointvuln/service.go
@@ -3,6 +3,7 @@ package endpointvuln
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -41,6 +42,11 @@ type Refresher struct {
 	Advisories  advisoryLookup
 	Logger      *slog.Logger
 	Now         func() time.Time
+}
+
+type tableRefresh struct {
+	spec tableSpec
+	rows []map[string]any
 }
 
 type endpointSourceRecord struct {
@@ -377,13 +383,12 @@ func (r Refresher) Refresh(ctx context.Context) error {
 	softwareAggs, softwareIndex := correlateSoftware(software, endpointAggs, endpointIDs)
 	vulnerabilityAggs := correlateVulnerabilities(vulnerabilities, endpointAggs, endpointIDs, softwareIndex, r.ThreatIntel, r.Advisories, now)
 
-	if err := r.replaceRows(ctx, endpointTableSpec, endpointRows(endpointAggs, now)); err != nil {
-		return err
+	refreshes := []tableRefresh{
+		{spec: endpointTableSpec, rows: endpointRows(endpointAggs, now)},
+		{spec: endpointSoftwareTableSpec, rows: softwareRows(softwareAggs, now)},
+		{spec: vulnerabilityTableSpec, rows: vulnerabilityRows(vulnerabilityAggs, now)},
 	}
-	if err := r.replaceRows(ctx, endpointSoftwareTableSpec, softwareRows(softwareAggs, now)); err != nil {
-		return err
-	}
-	if err := r.replaceRows(ctx, vulnerabilityTableSpec, vulnerabilityRows(vulnerabilityAggs, now)); err != nil {
+	if err := r.replaceRowsAtomically(ctx, refreshes); err != nil {
 		return err
 	}
 
@@ -974,11 +979,41 @@ func vulnerabilityRows(aggregates []*vulnerabilityAggregate, refreshedAt time.Ti
 	return rows
 }
 
-func (r Refresher) replaceRows(ctx context.Context, spec tableSpec, rows []map[string]any) error {
-	if _, err := r.Warehouse.Exec(ctx, spec.Create); err != nil {
-		return fmt.Errorf("ensure %s: %w", spec.Name, err)
+func (r Refresher) replaceRowsAtomically(ctx context.Context, refreshes []tableRefresh) error {
+	db := r.Warehouse.DB()
+	if db == nil {
+		return fmt.Errorf("warehouse database is not initialized")
 	}
-	if _, err := r.Warehouse.Exec(ctx, "DELETE FROM "+spec.Name); err != nil {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin normalized table refresh: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	dialect := warehouse.DialectFor(r.Warehouse)
+	for _, refresh := range refreshes {
+		if err := execWarehouseTx(ctx, tx, dialect, refresh.spec.Create); err != nil {
+			return fmt.Errorf("ensure %s: %w", refresh.spec.Name, err)
+		}
+		if err := r.replaceRowsTx(ctx, tx, dialect, refresh.spec, refresh.rows); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit normalized table refresh: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (r Refresher) replaceRowsTx(ctx context.Context, tx *sql.Tx, dialect string, spec tableSpec, rows []map[string]any) error {
+	if err := execWarehouseTx(ctx, tx, dialect, "DELETE FROM "+spec.Name); err != nil {
 		return fmt.Errorf("clear %s: %w", spec.Name, err)
 	}
 	if len(rows) == 0 {
@@ -1002,12 +1037,22 @@ func (r Refresher) replaceRows(ctx context.Context, spec tableSpec, rows []map[s
 			for _, column := range spec.Columns {
 				args = append(args, row[column])
 			}
-			if _, err := r.Warehouse.Exec(ctx, insertQuery, args...); err != nil {
+			if err := execWarehouseTx(ctx, tx, dialect, insertQuery, args...); err != nil {
 				return fmt.Errorf("insert into %s: %w", spec.Name, err)
 			}
 		}
 	}
 
+	return nil
+}
+
+func execWarehouseTx(ctx context.Context, tx *sql.Tx, dialect string, query string, args ...any) error {
+	if tx == nil {
+		return fmt.Errorf("warehouse transaction is not initialized")
+	}
+	if _, err := tx.ExecContext(ctx, warehouse.RewriteQueryForDialect(query, dialect), args...); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/endpointvuln/service_test.go
+++ b/internal/endpointvuln/service_test.go
@@ -1,0 +1,330 @@
+package endpointvuln
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/scanner"
+	"github.com/writer/cerebro/internal/threatintel"
+	"github.com/writer/cerebro/internal/warehouse"
+)
+
+type fakeThreatIntel struct {
+	indicators map[string]*threatintel.Indicator
+}
+
+func (f fakeThreatIntel) LookupCVE(cve string) (*threatintel.Indicator, bool) {
+	indicator, ok := f.indicators[normalizeCVE(cve)]
+	return indicator, ok
+}
+
+func (f fakeThreatIntel) IsKEV(cve string) bool {
+	indicator, ok := f.LookupCVE(cve)
+	return ok && indicator != nil && indicator.Source == "cisa-kev"
+}
+
+type fakeAdvisories struct {
+	entries map[string]*scanner.CVEInfo
+}
+
+func (f fakeAdvisories) LookupCVE(cve string) (*scanner.CVEInfo, bool) {
+	info, ok := f.entries[normalizeCVE(cve)]
+	return info, ok
+}
+
+func (f fakeAdvisories) IsKEV(cve string) bool {
+	info, ok := f.LookupCVE(cve)
+	return ok && info != nil && info.InKEV
+}
+
+func TestRefresherBuildsCorrelatedEndpointVulnerabilityTables(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestWarehouse(t)
+	seedEndpointVulnSourceTables(t, ctx, store)
+
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	refresher := Refresher{
+		Warehouse: store,
+		ThreatIntel: fakeThreatIntel{
+			indicators: map[string]*threatintel.Indicator{
+				"CVE-2026-0001": {
+					ID:     "CVE-2026-0001",
+					Type:   threatintel.IndicatorTypeCVE,
+					Value:  "CVE-2026-0001",
+					Source: "cisa-kev",
+					Metadata: map[string]string{
+						"due_date": "2026-04-20",
+					},
+				},
+			},
+		},
+		Advisories: fakeAdvisories{
+			entries: map[string]*scanner.CVEInfo{
+				"CVE-2026-0001": {
+					ID:             "CVE-2026-0001",
+					Severity:       "critical",
+					Description:    "Actively exploited browser issue",
+					CVSS:           9.8,
+					EPSSScore:      0.97,
+					EPSSPercentile: 0.99,
+					Exploitable:    true,
+					InKEV:          true,
+					References:     []string{"https://example.com/CVE-2026-0001"},
+				},
+			},
+		},
+		Now: func() time.Time { return now },
+	}
+
+	if err := refresher.Refresh(ctx); err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+
+	tables, err := store.ListAvailableTables(ctx)
+	if err != nil {
+		t.Fatalf("list tables failed: %v", err)
+	}
+	for _, table := range []string{endpointsTableName, endpointSoftwareTableName, vulnerabilitiesTableName} {
+		if !containsString(tables, table) {
+			t.Fatalf("expected table %q in %#v", table, tables)
+		}
+	}
+
+	endpointsResult, err := store.Query(ctx, "SELECT * FROM endpoints")
+	if err != nil {
+		t.Fatalf("query endpoints failed: %v", err)
+	}
+	if endpointsResult.Count != 1 {
+		t.Fatalf("expected 1 endpoint row, got %#v", endpointsResult.Rows)
+	}
+	endpoint := endpointsResult.Rows[0]
+	if got := rowInt(endpoint, "provider_count"); got != 2 {
+		t.Fatalf("endpoint provider_count = %d, want 2", got)
+	}
+	if got := rowString(endpoint, "providers"); got != "kandji,sentinelone" {
+		t.Fatalf("endpoint providers = %q, want kandji,sentinelone", got)
+	}
+	if !rowBool(endpoint, "mdm_enrolled") || !rowBool(endpoint, "edr_installed") || !rowBool(endpoint, "malware_protection_enabled") {
+		t.Fatalf("expected merged endpoint protections, got %#v", endpoint)
+	}
+	if got := rowString(endpoint, "correlation_confidence"); got != "high" {
+		t.Fatalf("endpoint correlation_confidence = %q, want high", got)
+	}
+
+	softwareResult, err := store.Query(ctx, "SELECT * FROM endpoint_software_inventory")
+	if err != nil {
+		t.Fatalf("query endpoint software failed: %v", err)
+	}
+	if softwareResult.Count != 1 {
+		t.Fatalf("expected 1 software row, got %#v", softwareResult.Rows)
+	}
+	software := softwareResult.Rows[0]
+	if got := rowInt(software, "provider_count"); got != 2 {
+		t.Fatalf("software provider_count = %d, want 2", got)
+	}
+	if got := rowString(software, "software_name"); got != "Chrome" {
+		t.Fatalf("software_name = %q, want Chrome", got)
+	}
+
+	vulnResult, err := store.Query(ctx, "SELECT * FROM vulnerabilities")
+	if err != nil {
+		t.Fatalf("query vulnerabilities failed: %v", err)
+	}
+	if vulnResult.Count != 1 {
+		t.Fatalf("expected 1 vulnerability row, got %#v", vulnResult.Rows)
+	}
+	vulnerability := vulnResult.Rows[0]
+	if got := rowString(vulnerability, "cve_id"); got != "CVE-2026-0001" {
+		t.Fatalf("cve_id = %q, want CVE-2026-0001", got)
+	}
+	if got := rowString(vulnerability, "severity"); got != "CRITICAL" {
+		t.Fatalf("severity = %q, want CRITICAL", got)
+	}
+	if got := rowString(vulnerability, "priority"); got != "critical" {
+		t.Fatalf("priority = %q, want critical", got)
+	}
+	if !rowBool(vulnerability, "is_kev") || !rowBool(vulnerability, "exploited_in_wild") {
+		t.Fatalf("expected KEV/exploit enrichment, got %#v", vulnerability)
+	}
+	if got := rowString(vulnerability, "kev_due_date"); got != "2026-04-20" {
+		t.Fatalf("kev_due_date = %q, want 2026-04-20", got)
+	}
+	if got := rowInt(vulnerability, "provider_count"); got != 2 {
+		t.Fatalf("vulnerability provider_count = %d, want 2", got)
+	}
+	if got := rowInt(vulnerability, "days_open"); got != 9 {
+		t.Fatalf("days_open = %d, want 9", got)
+	}
+	if got := rowString(vulnerability, "providers"); got != "kandji,sentinelone" {
+		t.Fatalf("vulnerability providers = %q, want kandji,sentinelone", got)
+	}
+	if got := rowString(vulnerability, "references_json"); !strings.Contains(got, "CVE-2026-0001") {
+		t.Fatalf("expected references_json to contain advisory reference, got %q", got)
+	}
+}
+
+func TestRefresherCreatesEmptyNormalizedTablesWithoutSourceTables(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestWarehouse(t)
+
+	refresher := Refresher{
+		Warehouse: store,
+		Now:       func() time.Time { return time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC) },
+	}
+	if err := refresher.Refresh(ctx); err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+
+	for _, table := range []string{endpointsTableName, endpointSoftwareTableName, vulnerabilitiesTableName} {
+		result, err := store.Query(ctx, "SELECT * FROM "+table)
+		if err != nil {
+			t.Fatalf("query %s failed: %v", table, err)
+		}
+		if result.Count != 0 {
+			t.Fatalf("expected %s to be empty, got %#v", table, result.Rows)
+		}
+	}
+}
+
+func newTestWarehouse(t *testing.T) *warehouse.SQLiteWarehouse {
+	t.Helper()
+
+	store, err := warehouse.NewSQLiteWarehouse(warehouse.SQLiteWarehouseConfig{
+		Path:      filepath.Join(t.TempDir(), "warehouse.db"),
+		Database:  "sqlite",
+		Schema:    "RAW",
+		AppSchema: "CEREBRO",
+	})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func seedEndpointVulnSourceTables(t *testing.T, ctx context.Context, store *warehouse.SQLiteWarehouse) {
+	t.Helper()
+
+	statements := []string{
+		`CREATE TABLE kandji_devices (
+			device_id TEXT,
+			device_name TEXT,
+			serial_number TEXT,
+			platform TEXT,
+			os_version TEXT,
+			last_check_in TEXT,
+			user_name TEXT,
+			user_email TEXT,
+			agent_installed BOOLEAN,
+			firewall_enabled BOOLEAN,
+			filevault_enabled BOOLEAN
+		)`,
+		`CREATE TABLE kandji_device_apps (
+			device_id TEXT,
+			app_name TEXT,
+			version TEXT,
+			bundle_id TEXT
+		)`,
+		`CREATE TABLE kandji_vulnerabilities (
+			device_id TEXT,
+			cve_id TEXT,
+			software_name TEXT,
+			software_version TEXT,
+			cvss_score FLOAT,
+			cvss_severity TEXT,
+			first_detection_date TEXT,
+			latest_detection_date TEXT,
+			cve_link TEXT
+		)`,
+		`CREATE TABLE sentinelone_agents (
+			id TEXT,
+			computer_name TEXT,
+			os_type TEXT,
+			os_version TEXT,
+			is_active BOOLEAN,
+			last_active_date TEXT,
+			firewall_enabled BOOLEAN
+		)`,
+		`CREATE TABLE sentinelone_applications (
+			agent_id TEXT,
+			name TEXT,
+			version TEXT,
+			publisher TEXT,
+			installed_date TEXT
+		)`,
+		`CREATE TABLE sentinelone_vulnerabilities (
+			agent_id TEXT,
+			cve_id TEXT,
+			application_name TEXT,
+			application_version TEXT,
+			severity TEXT,
+			cvss_score FLOAT,
+			exploited_in_wild BOOLEAN,
+			days_since_detection INTEGER,
+			remediation_action TEXT,
+			detected_at TEXT
+		)`,
+	}
+
+	for _, statement := range statements {
+		if _, err := store.Exec(ctx, statement); err != nil {
+			t.Fatalf("exec %q: %v", statement, err)
+		}
+	}
+
+	inserts := []struct {
+		query string
+		args  []any
+	}{
+		{
+			query: `INSERT INTO kandji_devices (device_id, device_name, serial_number, platform, os_version, last_check_in, user_name, user_email, agent_installed, firewall_enabled, filevault_enabled)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: []any{"device-1", "host-1.corp.example", "SERIAL-1", "macOS", "14.4", "2026-04-14T08:00:00Z", "Jane Doe", "jane@example.com", true, true, true},
+		},
+		{
+			query: `INSERT INTO kandji_device_apps (device_id, app_name, version, bundle_id) VALUES (?, ?, ?, ?)`,
+			args:  []any{"device-1", "Chrome", "1.2.3", "com.google.Chrome"},
+		},
+		{
+			query: `INSERT INTO kandji_vulnerabilities (device_id, cve_id, software_name, software_version, cvss_score, cvss_severity, first_detection_date, latest_detection_date, cve_link)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: []any{"device-1", "CVE-2026-0001", "Chrome", "1.2.3", 7.2, "high", "2026-04-05T00:00:00Z", "2026-04-14T00:00:00Z", "https://kandji.example/CVE-2026-0001"},
+		},
+		{
+			query: `INSERT INTO sentinelone_agents (id, computer_name, os_type, os_version, is_active, last_active_date, firewall_enabled)
+				VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			args: []any{"agent-1", "host-1", "macos", "14.4", true, "2026-04-14T09:30:00Z", true},
+		},
+		{
+			query: `INSERT INTO sentinelone_applications (agent_id, name, version, publisher, installed_date) VALUES (?, ?, ?, ?, ?)`,
+			args:  []any{"agent-1", "Chrome", "1.2.3", "Google", "2026-04-01T00:00:00Z"},
+		},
+		{
+			query: `INSERT INTO sentinelone_vulnerabilities (agent_id, cve_id, application_name, application_version, severity, cvss_score, exploited_in_wild, days_since_detection, remediation_action, detected_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: []any{"agent-1", "CVE-2026-0001", "Chrome", "1.2.3", "high", 8.4, true, 9, "Update Chrome to a patched release", "2026-04-05T00:00:00Z"},
+		},
+	}
+
+	for _, insert := range inserts {
+		if _, err := store.Exec(ctx, insert.query, insert.args...); err != nil {
+			t.Fatalf("insert source row failed: %v", err)
+		}
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/endpointvuln/service_test.go
+++ b/internal/endpointvuln/service_test.go
@@ -103,11 +103,11 @@ func TestRefresherBuildsCorrelatedEndpointVulnerabilityTables(t *testing.T) {
 		t.Fatalf("expected 1 endpoint row, got %#v", endpointsResult.Rows)
 	}
 	endpoint := endpointsResult.Rows[0]
-	if got := rowInt(endpoint, "provider_count"); got != 2 {
-		t.Fatalf("endpoint provider_count = %d, want 2", got)
+	if got := rowInt(endpoint, "provider_count"); got != 3 {
+		t.Fatalf("endpoint provider_count = %d, want 3", got)
 	}
-	if got := rowString(endpoint, "providers"); got != "kandji,sentinelone" {
-		t.Fatalf("endpoint providers = %q, want kandji,sentinelone", got)
+	if got := rowString(endpoint, "providers"); got != "crowdstrike,kandji,sentinelone" {
+		t.Fatalf("endpoint providers = %q, want crowdstrike,kandji,sentinelone", got)
 	}
 	if !rowBool(endpoint, "mdm_enrolled") || !rowBool(endpoint, "edr_installed") || !rowBool(endpoint, "malware_protection_enabled") {
 		t.Fatalf("expected merged endpoint protections, got %#v", endpoint)
@@ -154,14 +154,14 @@ func TestRefresherBuildsCorrelatedEndpointVulnerabilityTables(t *testing.T) {
 	if got := rowString(vulnerability, "kev_due_date"); got != "2026-04-20" {
 		t.Fatalf("kev_due_date = %q, want 2026-04-20", got)
 	}
-	if got := rowInt(vulnerability, "provider_count"); got != 2 {
-		t.Fatalf("vulnerability provider_count = %d, want 2", got)
+	if got := rowInt(vulnerability, "provider_count"); got != 3 {
+		t.Fatalf("vulnerability provider_count = %d, want 3", got)
 	}
 	if got := rowInt(vulnerability, "days_open"); got != 9 {
 		t.Fatalf("days_open = %d, want 9", got)
 	}
-	if got := rowString(vulnerability, "providers"); got != "kandji,sentinelone" {
-		t.Fatalf("vulnerability providers = %q, want kandji,sentinelone", got)
+	if got := rowString(vulnerability, "providers"); got != "crowdstrike,kandji,sentinelone" {
+		t.Fatalf("vulnerability providers = %q, want crowdstrike,kandji,sentinelone", got)
 	}
 	if got := rowString(vulnerability, "references_json"); !strings.Contains(got, "CVE-2026-0001") {
 		t.Fatalf("expected references_json to contain advisory reference, got %q", got)
@@ -271,6 +271,26 @@ func seedEndpointVulnSourceTables(t *testing.T, ctx context.Context, store *ware
 			remediation_action TEXT,
 			detected_at TEXT
 		)`,
+		`CREATE TABLE crowdstrike_hosts (
+			device_id TEXT,
+			hostname TEXT,
+			platform_name TEXT,
+			os_version TEXT,
+			last_seen TEXT
+		)`,
+		`CREATE TABLE crowdstrike_vulnerabilities (
+			id TEXT,
+			cve_id TEXT,
+			host_id TEXT,
+			severity TEXT,
+			status TEXT,
+			app_name TEXT,
+			app_version TEXT,
+			exploit_available BOOLEAN,
+			created_at TEXT,
+			updated_at TEXT,
+			remediation_action TEXT
+		)`,
 	}
 
 	for _, statement := range statements {
@@ -310,6 +330,15 @@ func seedEndpointVulnSourceTables(t *testing.T, ctx context.Context, store *ware
 			query: `INSERT INTO sentinelone_vulnerabilities (agent_id, cve_id, application_name, application_version, severity, cvss_score, exploited_in_wild, days_since_detection, remediation_action, detected_at)
 				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			args: []any{"agent-1", "CVE-2026-0001", "Chrome", "1.2.3", "high", 8.4, true, 9, "Update Chrome to a patched release", "2026-04-05T00:00:00Z"},
+		},
+		{
+			query: `INSERT INTO crowdstrike_hosts (device_id, hostname, platform_name, os_version, last_seen) VALUES (?, ?, ?, ?, ?)`,
+			args:  []any{"device-cs-1", "host-1", "Mac", "14.4", "2026-04-14T10:00:00Z"},
+		},
+		{
+			query: `INSERT INTO crowdstrike_vulnerabilities (id, cve_id, host_id, severity, status, app_name, app_version, exploit_available, created_at, updated_at, remediation_action)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			args: []any{"device-cs-1|CVE-2026-0001|Chrome|1.2.3", "CVE-2026-0001", "device-cs-1", "critical", "open", "Chrome", "1.2.3", true, "2026-04-06T00:00:00Z", "2026-04-14T00:00:00Z", "Upgrade Chrome"},
 		},
 	}
 

--- a/internal/endpointvuln/service_test.go
+++ b/internal/endpointvuln/service_test.go
@@ -193,6 +193,73 @@ func TestRefresherCreatesEmptyNormalizedTablesWithoutSourceTables(t *testing.T) 
 	}
 }
 
+func TestRefresherRefreshKeepsNormalizedTablesAtomicOnInsertFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newTestWarehouse(t)
+	seedEndpointVulnSourceTables(t, ctx, store)
+
+	refresher := Refresher{
+		Warehouse: store,
+		Now:       func() time.Time { return time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC) },
+	}
+	if err := refresher.Refresh(ctx); err != nil {
+		t.Fatalf("initial refresh failed: %v", err)
+	}
+
+	if _, err := store.Exec(ctx, `INSERT INTO kandji_devices (
+		device_id, device_name, serial_number, platform, os_version, last_check_in, user_name, user_email, agent_installed, firewall_enabled, filevault_enabled
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"device-2", "macbook-02", "SERIAL-2", "macOS", "14.4", "2026-04-14T12:00:00Z", "analyst", "analyst@example.com", true, true, true,
+	); err != nil {
+		t.Fatalf("seed second device: %v", err)
+	}
+	if _, err := store.Exec(ctx, `INSERT INTO kandji_device_apps (device_id, app_name, version, bundle_id) VALUES (?, ?, ?, ?)`,
+		"device-2", "Firefox", "125.0", "org.mozilla.firefox",
+	); err != nil {
+		t.Fatalf("seed second app: %v", err)
+	}
+	if _, err := store.Exec(ctx, `INSERT INTO kandji_vulnerabilities (
+		device_id, cve_id, software_name, software_version, cvss_score, cvss_severity, first_detection_date, latest_detection_date, cve_link
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"device-2", "CVE-2026-9999", "Firefox", "125.0", 7.8, "high", "2026-04-13T00:00:00Z", "2026-04-14T00:00:00Z", "https://example.com/CVE-2026-9999",
+	); err != nil {
+		t.Fatalf("seed second vulnerability: %v", err)
+	}
+	if _, err := store.Exec(ctx, `
+		CREATE TRIGGER fail_vulnerabilities_insert
+		BEFORE INSERT ON vulnerabilities
+		BEGIN
+			SELECT RAISE(FAIL, 'vulnerability refresh blocked');
+		END;
+	`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+
+	err := refresher.Refresh(ctx)
+	if err == nil || !strings.Contains(err.Error(), "insert into vulnerabilities") {
+		t.Fatalf("expected vulnerability insert failure, got %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		want int
+	}{
+		{name: endpointsTableName, want: 1},
+		{name: endpointSoftwareTableName, want: 1},
+		{name: vulnerabilitiesTableName, want: 1},
+	} {
+		result, queryErr := store.Query(ctx, "SELECT * FROM "+tc.name)
+		if queryErr != nil {
+			t.Fatalf("query %s failed: %v", tc.name, queryErr)
+		}
+		if result.Count != tc.want {
+			t.Fatalf("%s count = %d, want %d", tc.name, result.Count, tc.want)
+		}
+	}
+}
+
 func newTestWarehouse(t *testing.T) *warehouse.SQLiteWarehouse {
 	t.Helper()
 

--- a/internal/providers/crowdstrike.go
+++ b/internal/providers/crowdstrike.go
@@ -100,10 +100,22 @@ func (c *CrowdStrikeProvider) Schema() []TableSchema {
 				{Name: "status", Type: "string"},
 				{Name: "app_name", Type: "string"},
 				{Name: "app_version", Type: "string"},
+				{Name: "exploit_available", Type: "boolean"},
+				{Name: "created_at", Type: "timestamp"},
+				{Name: "updated_at", Type: "timestamp"},
+				{Name: "remediation_action", Type: "string"},
 			},
 			PrimaryKey: []string{"id"},
 		},
 	}
+}
+
+func (c *CrowdStrikeProvider) schemaFor(name string) (TableSchema, error) {
+	schema, ok := schemaByName(c.Schema(), name)
+	if !ok {
+		return TableSchema{}, fmt.Errorf("schema not found: %s", name)
+	}
+	return schema, nil
 }
 
 func (c *CrowdStrikeProvider) Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
@@ -136,6 +148,15 @@ func (c *CrowdStrikeProvider) Sync(ctx context.Context, opts SyncOptions) (*Sync
 	} else {
 		result.Tables = append(result.Tables, *detections)
 		result.TotalRows += detections.Rows
+	}
+
+	// Sync vulnerabilities
+	vulnerabilities, err := c.syncVulnerabilities(ctx)
+	if err != nil {
+		result.Errors = append(result.Errors, "vulnerabilities: "+err.Error())
+	} else {
+		result.Tables = append(result.Tables, *vulnerabilities)
+		result.TotalRows += vulnerabilities.Rows
 	}
 
 	result.CompletedAt = time.Now()
@@ -184,59 +205,328 @@ func (c *CrowdStrikeProvider) authenticate(ctx context.Context) (string, error) 
 }
 
 func (c *CrowdStrikeProvider) syncHosts(ctx context.Context) (*TableResult, error) {
+	schema, err := c.schemaFor("crowdstrike_hosts")
 	result := &TableResult{Name: "crowdstrike_hosts"}
-
-	// Get host IDs
-	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/devices/queries/devices/v1", nil)
 	if err != nil {
 		return result, err
 	}
-	c.setAuth(req)
 
-	resp, err := c.client.Do(req)
+	ids, err := c.queryResources(ctx, "/devices/queries/devices/v1")
 	if err != nil {
 		return result, err
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var queryResult struct {
-		Resources []string `json:"resources"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&queryResult); err != nil {
+	hosts, err := c.fetchEntities(ctx, "/devices/entities/devices/v2", ids)
+	if err != nil {
 		return result, err
 	}
 
-	result.Rows = int64(len(queryResult.Resources))
-	return result, nil
+	rows := make([]map[string]interface{}, 0, len(hosts))
+	for _, host := range hosts {
+		row := normalizeCrowdStrikeRow(host)
+		deviceID := firstCrowdStrikeString(row, "device_id", "device_id.id", "aid", "id")
+		if deviceID == "" {
+			continue
+		}
+		rows = append(rows, map[string]interface{}{
+			"device_id":     deviceID,
+			"hostname":      firstCrowdStrikeValue(row, "hostname", "device_name", "local_hostname"),
+			"platform_name": firstCrowdStrikeValue(row, "platform_name", "platform", "os.platform", "os_name"),
+			"os_version":    firstCrowdStrikeValue(row, "os_version", "os.version", "os_build"),
+			"agent_version": firstCrowdStrikeValue(row, "agent_version", "product_type_desc", "agent_version_major"),
+			"last_seen":     firstCrowdStrikeValue(row, "last_seen", "modified_timestamp", "first_seen"),
+			"status":        firstCrowdStrikeValue(row, "status", "sensor_status", "device_status"),
+			"tags":          firstCrowdStrikeValue(row, "tags", "groups"),
+		})
+	}
+
+	return c.syncTable(ctx, schema, rows)
 }
 
 func (c *CrowdStrikeProvider) syncDetections(ctx context.Context) (*TableResult, error) {
+	schema, err := c.schemaFor("crowdstrike_detections")
 	result := &TableResult{Name: "crowdstrike_detections"}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/detects/queries/detects/v1", nil)
 	if err != nil {
 		return result, err
+	}
+
+	ids, err := c.queryResources(ctx, "/detects/queries/detects/v1")
+	if err != nil {
+		return result, err
+	}
+	detections, err := c.fetchEntities(ctx, "/detects/entities/summaries/GET/v1", ids)
+	if err != nil {
+		return result, err
+	}
+
+	rows := make([]map[string]interface{}, 0, len(detections))
+	for _, detection := range detections {
+		row := normalizeCrowdStrikeRow(detection)
+		detectionID := firstCrowdStrikeString(row, "detection_id", "id")
+		if detectionID == "" {
+			continue
+		}
+		rows = append(rows, map[string]interface{}{
+			"detection_id": detectionID,
+			"device_id":    firstCrowdStrikeValue(row, "device_id", "aid"),
+			"severity":     firstCrowdStrikeValue(row, "severity", "max_severity"),
+			"status":       firstCrowdStrikeValue(row, "status"),
+			"tactic":       firstCrowdStrikeValue(row, "tactic", "tactics"),
+			"technique":    firstCrowdStrikeValue(row, "technique", "techniques"),
+			"description":  firstCrowdStrikeValue(row, "description", "name"),
+			"created_at":   firstCrowdStrikeValue(row, "created_at", "first_behavior", "behaviors.0.timestamp"),
+		})
+	}
+
+	return c.syncTable(ctx, schema, rows)
+}
+
+func (c *CrowdStrikeProvider) syncVulnerabilities(ctx context.Context) (*TableResult, error) {
+	schema, err := c.schemaFor("crowdstrike_vulnerabilities")
+	result := &TableResult{Name: "crowdstrike_vulnerabilities"}
+	if err != nil {
+		return result, err
+	}
+
+	vulnerabilities, err := c.listCombinedVulnerabilities(ctx)
+	if err != nil {
+		return result, err
+	}
+
+	rows := make([]map[string]interface{}, 0, len(vulnerabilities))
+	for _, vulnerability := range vulnerabilities {
+		row := normalizeCrowdStrikeRow(vulnerability)
+		hostID := firstCrowdStrikeString(row, "host_id", "aid", "device_id")
+		cveID := firstCrowdStrikeString(row, "cve_id", "cve", "cve.id")
+		appName := firstCrowdStrikeString(row, "app_name", "application_name", "app.name", "product_name")
+		appVersion := firstCrowdStrikeString(row, "app_version", "application_version", "app.version", "version")
+		if hostID == "" || cveID == "" {
+			continue
+		}
+		rows = append(rows, map[string]interface{}{
+			"id":                 buildCrowdStrikeVulnerabilityID(hostID, cveID, appName, appVersion),
+			"cve_id":             cveID,
+			"host_id":            hostID,
+			"severity":           firstCrowdStrikeValue(row, "severity", "severity_name"),
+			"status":             firstCrowdStrikeValue(row, "status"),
+			"app_name":           nullableCrowdStrikeValue(appName),
+			"app_version":        nullableCrowdStrikeValue(appVersion),
+			"exploit_available":  firstCrowdStrikeValue(row, "exploit_available", "public_exploit"),
+			"created_at":         firstCrowdStrikeValue(row, "created_at", "first_found", "first_seen"),
+			"updated_at":         firstCrowdStrikeValue(row, "updated_at", "last_found", "last_seen"),
+			"remediation_action": firstCrowdStrikeValue(row, "remediation_action", "remediation", "solution"),
+		})
+	}
+
+	return c.syncTable(ctx, schema, rows)
+}
+
+func (c *CrowdStrikeProvider) request(ctx context.Context, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, err
 	}
 	c.setAuth(req)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("crowdstrike API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+func (c *CrowdStrikeProvider) queryResources(ctx context.Context, path string) ([]string, error) {
+	body, err := c.request(ctx, path)
+	if err != nil {
+		return nil, err
+	}
 
 	var queryResult struct {
 		Resources []string `json:"resources"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&queryResult); err != nil {
-		return result, err
+	if err := json.Unmarshal(body, &queryResult); err != nil {
+		return nil, err
+	}
+	return queryResult.Resources, nil
+}
+
+func (c *CrowdStrikeProvider) fetchEntities(ctx context.Context, path string, ids []string) ([]map[string]interface{}, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	const batchSize = 100
+
+	rows := make([]map[string]interface{}, 0, len(ids))
+	for start := 0; start < len(ids); start += batchSize {
+		end := start + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		params := url.Values{}
+		for _, id := range ids[start:end] {
+			if strings.TrimSpace(id) != "" {
+				params.Add("ids", id)
+			}
+		}
+		if len(params) == 0 {
+			continue
+		}
+
+		body, err := c.request(ctx, path+"?"+params.Encode())
+		if err != nil {
+			return nil, err
+		}
+		var response struct {
+			Resources []map[string]interface{} `json:"resources"`
+		}
+		if err := json.Unmarshal(body, &response); err != nil {
+			return nil, err
+		}
+		rows = append(rows, response.Resources...)
 	}
 
-	result.Rows = int64(len(queryResult.Resources))
-	return result, nil
+	return rows, nil
+}
+
+func (c *CrowdStrikeProvider) listCombinedVulnerabilities(ctx context.Context) ([]map[string]interface{}, error) {
+	rows := make([]map[string]interface{}, 0)
+	seenAfter := make(map[string]struct{})
+	after := ""
+
+	for {
+		params := url.Values{}
+		params.Set("limit", "5000")
+		if after != "" {
+			params.Set("after", after)
+		}
+
+		body, err := c.request(ctx, "/spotlight/combined/vulnerabilities/v1?"+params.Encode())
+		if err != nil {
+			return nil, err
+		}
+
+		var payload map[string]interface{}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return nil, err
+		}
+		rows = append(rows, crowdStrikeMapSlice(payload["resources"])...)
+
+		nextAfter := extractCrowdStrikeAfter(payload)
+		if nextAfter == "" {
+			break
+		}
+		if _, seen := seenAfter[nextAfter]; seen {
+			break
+		}
+		seenAfter[nextAfter] = struct{}{}
+		after = nextAfter
+	}
+
+	return rows, nil
 }
 
 func (c *CrowdStrikeProvider) setAuth(req *http.Request) {
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Content-Type", "application/json")
+}
+
+func normalizeCrowdStrikeRow(row map[string]interface{}) map[string]interface{} {
+	normalized, _ := normalizeMapKeys(row).(map[string]interface{})
+	if normalized == nil {
+		return map[string]interface{}{}
+	}
+	return normalized
+}
+
+func firstCrowdStrikeValue(row map[string]interface{}, keys ...string) interface{} {
+	for _, key := range keys {
+		if value, ok := crowdStrikeValue(row, key); ok && value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func firstCrowdStrikeString(row map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := crowdStrikeValue(row, key); ok {
+			switch typed := value.(type) {
+			case string:
+				if trimmed := strings.TrimSpace(typed); trimmed != "" {
+					return trimmed
+				}
+			case []byte:
+				if trimmed := strings.TrimSpace(string(typed)); trimmed != "" {
+					return trimmed
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func crowdStrikeValue(row map[string]interface{}, key string) (interface{}, bool) {
+	current := interface{}(row)
+	for _, part := range strings.Split(key, ".") {
+		currentMap, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		value, ok := currentMap[part]
+		if !ok {
+			return nil, false
+		}
+		current = value
+	}
+	return current, true
+}
+
+func crowdStrikeMapSlice(value interface{}) []map[string]interface{} {
+	items, ok := value.([]interface{})
+	if !ok {
+		if typed, ok := value.([]map[string]interface{}); ok {
+			return typed
+		}
+		return nil
+	}
+	rows := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		if row, ok := item.(map[string]interface{}); ok {
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func extractCrowdStrikeAfter(payload map[string]interface{}) string {
+	for _, key := range []string{"meta", "pagination"} {
+		value, ok := payload[key]
+		if !ok {
+			continue
+		}
+		if nested, ok := value.(map[string]interface{}); ok {
+			if after := firstCrowdStrikeString(nested, "pagination.after", "after", "offset"); after != "" {
+				return after
+			}
+		}
+	}
+	return firstCrowdStrikeString(payload, "after", "offset")
+}
+
+func buildCrowdStrikeVulnerabilityID(hostID, cveID, appName, appVersion string) string {
+	parts := []string{strings.TrimSpace(hostID), strings.TrimSpace(cveID), strings.TrimSpace(appName), strings.TrimSpace(appVersion)}
+	return strings.Join(parts, "|")
+}
+
+func nullableCrowdStrikeValue(value string) interface{} {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return value
 }

--- a/internal/providers/crowdstrike_test.go
+++ b/internal/providers/crowdstrike_test.go
@@ -2,8 +2,10 @@ package providers
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -72,6 +74,99 @@ func TestCrowdStrikeAuthenticateRetriesReplayableBody(t *testing.T) {
 	for i, body := range requestBodies {
 		if body != "client_id=client-id&client_secret=client-secret" {
 			t.Fatalf("request body %d = %q", i+1, body)
+		}
+	}
+}
+
+func TestCrowdStrikeProviderSync_MaterializesEndpointTables(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/oauth2/token":
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"access_token":"token","expires_in":300}`)
+		case "/devices/queries/devices/v1":
+			_ = json.NewEncoder(w).Encode(map[string]any{"resources": []string{"device-1"}})
+		case "/devices/entities/devices/v2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resources": []map[string]any{{
+					"device_id":     "device-1",
+					"hostname":      "host-1",
+					"platform_name": "Mac",
+					"os_version":    "14.4",
+					"agent_version": "7.0.0",
+					"last_seen":     "2026-04-14T10:00:00Z",
+					"status":        "normal",
+					"tags":          []string{"corp"},
+				}},
+			})
+		case "/detects/queries/detects/v1":
+			_ = json.NewEncoder(w).Encode(map[string]any{"resources": []string{"det-1"}})
+		case "/detects/entities/summaries/GET/v1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resources": []map[string]any{{
+					"detection_id": "det-1",
+					"device_id":    "device-1",
+					"severity":     5,
+					"status":       "new",
+					"tactic":       "execution",
+					"technique":    "t1059",
+					"description":  "Suspicious activity",
+					"created_at":   "2026-04-14T10:30:00Z",
+				}},
+			})
+		case "/spotlight/combined/vulnerabilities/v1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resources": []map[string]any{{
+					"aid":         "device-1",
+					"cve":         "CVE-2026-1111",
+					"app_name":    "Chrome",
+					"app_version": "1.2.4",
+					"severity":    "high",
+					"status":      "open",
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewCrowdStrikeProvider()
+	if err := provider.Configure(context.Background(), map[string]interface{}{
+		"client_id":     "client-id",
+		"client_secret": "client-secret",
+		"base_url":      server.URL,
+	}); err != nil {
+		t.Fatalf("configure failed: %v", err)
+	}
+
+	result, err := provider.Sync(context.Background(), SyncOptions{FullSync: true})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected sync errors: %v", result.Errors)
+	}
+
+	rowsByTable := map[string]int64{}
+	for _, table := range result.Tables {
+		rowsByTable[table.Name] = table.Rows
+	}
+	for _, table := range []string{
+		"crowdstrike_hosts",
+		"crowdstrike_detections",
+		"crowdstrike_vulnerabilities",
+	} {
+		if got := rowsByTable[table]; got != 1 {
+			t.Fatalf("%s rows = %d, want 1", table, got)
 		}
 	}
 }

--- a/internal/providers/hooks.go
+++ b/internal/providers/hooks.go
@@ -1,0 +1,34 @@
+package providers
+
+import "context"
+
+// SyncHook runs after the wrapped provider finishes Sync.
+type SyncHook func(ctx context.Context, provider Provider, result *SyncResult, syncErr error) error
+
+// WithSyncHook wraps a provider so callers can attach post-sync behavior without
+// changing existing provider implementations.
+func WithSyncHook(provider Provider, after SyncHook) Provider {
+	if provider == nil || after == nil {
+		return provider
+	}
+	return syncHookProvider{Provider: provider, after: after}
+}
+
+type syncHookProvider struct {
+	Provider
+	after SyncHook
+}
+
+func (p syncHookProvider) Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
+	result, err := p.Provider.Sync(ctx, opts)
+	if p.after == nil {
+		return result, err
+	}
+	if hookErr := p.after(ctx, p.Provider, result, err); hookErr != nil {
+		if result == nil {
+			result = &SyncResult{Provider: p.Name()}
+		}
+		result.Errors = append(result.Errors, hookErr.Error())
+	}
+	return result, err
+}

--- a/internal/providers/hooks_test.go
+++ b/internal/providers/hooks_test.go
@@ -1,0 +1,83 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type hookTestProvider struct {
+	name   string
+	typ    ProviderType
+	result *SyncResult
+	err    error
+	calls  int
+}
+
+func (p *hookTestProvider) Name() string { return p.name }
+
+func (p *hookTestProvider) Type() ProviderType { return p.typ }
+
+func (p *hookTestProvider) Configure(context.Context, map[string]interface{}) error { return nil }
+
+func (p *hookTestProvider) Sync(context.Context, SyncOptions) (*SyncResult, error) {
+	p.calls++
+	return p.result, p.err
+}
+
+func (p *hookTestProvider) Test(context.Context) error { return nil }
+
+func (p *hookTestProvider) Schema() []TableSchema { return nil }
+
+func TestWithSyncHookAppendsHookErrors(t *testing.T) {
+	t.Parallel()
+
+	provider := &hookTestProvider{
+		name: "sentinelone",
+		typ:  ProviderTypeEndpoint,
+		result: &SyncResult{
+			Provider: "sentinelone",
+		},
+	}
+
+	wrapped := WithSyncHook(provider, func(context.Context, Provider, *SyncResult, error) error {
+		return errors.New("refresh endpoint vulnerability tables: boom")
+	})
+
+	result, err := wrapped.Sync(context.Background(), SyncOptions{FullSync: true})
+	if err != nil {
+		t.Fatalf("unexpected sync error: %v", err)
+	}
+	if provider.calls != 1 {
+		t.Fatalf("expected one underlying sync call, got %d", provider.calls)
+	}
+	if result == nil || len(result.Errors) != 1 {
+		t.Fatalf("expected hook error to be appended to result, got %#v", result)
+	}
+	if result.Errors[0] != "refresh endpoint vulnerability tables: boom" {
+		t.Fatalf("unexpected hook error: %#v", result.Errors)
+	}
+}
+
+func TestWithSyncHookPreservesUnderlyingSyncError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("provider sync failed")
+	provider := &hookTestProvider{
+		name: "kandji",
+		typ:  ProviderTypeEndpoint,
+		err:  expectedErr,
+	}
+
+	wrapped := WithSyncHook(provider, func(context.Context, Provider, *SyncResult, error) error {
+		return nil
+	})
+
+	result, err := wrapped.Sync(context.Background(), SyncOptions{FullSync: true})
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected underlying sync error, got %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result when provider returned nil result, got %#v", result)
+	}
+}

--- a/internal/providers/kandji.go
+++ b/internal/providers/kandji.go
@@ -50,6 +50,17 @@ func (k *KandjiProvider) Test(ctx context.Context) error {
 }
 
 func (k *KandjiProvider) Schema() []TableSchema {
+	// Endpoint app/CVE correlation in Kandji is provider-native and starts from
+	// these tables:
+	//   - kandji_devices: canonical endpoint rows keyed by device_id
+	//   - kandji_device_apps: installed application inventory keyed by device_id
+	//   - kandji_vulnerabilities: CVE detections keyed by cve_id + device_id
+	//
+	// A patch-target query typically joins kandji_devices -> kandji_device_apps
+	// on device_id, then maps kandji_vulnerabilities back onto the same device_id
+	// using software_name/software_version. software_* fields are preserved from
+	// the Kandji API, so cross-provider joins usually need an extra normalization
+	// layer for name/version matching.
 	return []TableSchema{
 		{
 			Name:        "kandji_devices",
@@ -365,6 +376,9 @@ func (k *KandjiProvider) syncVulnerabilities(ctx context.Context) (*TableResult,
 		return result, err
 	}
 
+	// Kandji exposes vulnerability detections separately from app inventory. We
+	// keep both datasets as-is so callers can decide how strict software name and
+	// version matching should be when building patch-target views.
 	detections, err := k.listAllResults(ctx, "/vulnerability-management/detections?size=300")
 	if err != nil {
 		if isKandjiIgnorableError(err) {

--- a/internal/providers/sentinelone.go
+++ b/internal/providers/sentinelone.go
@@ -42,6 +42,16 @@ func (s *SentinelOneProvider) Test(ctx context.Context) error {
 }
 
 func (s *SentinelOneProvider) Schema() []TableSchema {
+	// Endpoint software/CVE correlation in SentinelOne typically uses:
+	//   - sentinelone_agents: canonical endpoint rows keyed by id
+	//   - sentinelone_applications: installed application inventory keyed by agent_id
+	//   - sentinelone_vulnerabilities: provider-reported CVEs keyed by agent_id
+	//
+	// A patch-target query usually joins sentinelone_agents -> sentinelone_applications
+	// on id/agent_id, then joins sentinelone_vulnerabilities on agent_id and
+	// matches application_name/application_version back to the installed app row.
+	// Names are intentionally preserved from the provider API, so cross-provider
+	// deduplication may require additional normalization.
 	return []TableSchema{
 		{
 			Name:        "sentinelone_agents",
@@ -336,6 +346,9 @@ func (s *SentinelOneProvider) syncApplications(ctx context.Context) (*TableResul
 		return result, err
 	}
 
+	// Installed applications are synced independently from vulnerability rows so
+	// callers can choose how to reconcile provider-native names, versions, and
+	// publishers when building patching and exposure reports.
 	applications, err := s.listCollection(ctx, "/web/api/v2.1/installed-applications?limit=1000", "")
 	if err != nil {
 		return result, err
@@ -364,6 +377,9 @@ func (s *SentinelOneProvider) syncVulnerabilities(ctx context.Context) (*TableRe
 		return result, err
 	}
 
+	// Vulnerabilities are preserved as reported so downstream queries can decide
+	// whether to trust SentinelOne's application linkage directly or normalize it
+	// against sentinelone_applications for stricter patch-target correlation.
 	vulnerabilities, err := s.listCollection(ctx, "/web/api/v2.1/vulnerabilities?limit=1000", "")
 	if err != nil {
 		return result, err


### PR DESCRIPTION
## Summary
- materialize normalized `endpoints`, `endpoint_software_inventory`, and `vulnerabilities` tables from Kandji and SentinelOne provider data
- dedupe endpoint/software/CVE rows across providers and enrich them with advisory and KEV metadata for patch-priority queries
- refresh the normalized tables on startup, endpoint provider sync, and threat intel sync while preserving the existing workflow documentation comments

## Validation
- python3 scripts/devex.py run --mode changed --files internal/app/app.go internal/app/app_endpoint_vulnerabilities.go internal/app/app_init_phases.go internal/app/app_security_services.go internal/app/app_storage_graph.go internal/app/providers_registry.go internal/endpointvuln/service.go internal/endpointvuln/service_test.go internal/providers/hooks.go internal/providers/hooks_test.go
- pre-commit hooks on `git commit`
- pre-push checks on `git push`

Refs #261