### PR TITLE
fix(app): log autonomous persistence failures

### DIFF
--- a/internal/app/app_cerebro_tools_autonomous.go
+++ b/internal/app/app_cerebro_tools_autonomous.go
@@ -79,7 +79,7 @@ func (a *App) toolCerebroAutonomousCredentialResponse(ctx context.Context, args 
 	if err := store.SaveRun(ctx, run); err != nil {
 		return "", fmt.Errorf("save autonomous workflow run: %w", err)
 	}
-	_, _ = store.AppendEvent(ctx, run.ID, autonomous.RunEvent{
+	a.appendAutonomousRunEventBestEffort(ctx, store, run.ID, autonomous.RunEvent{
 		Status:     run.Status,
 		Stage:      run.Stage,
 		Message:    "credential exposure analysis started",
@@ -94,8 +94,8 @@ func (a *App) toolCerebroAutonomousCredentialResponse(ctx context.Context, args 
 		run.Error = err.Error()
 		run.CompletedAt = timePointer(time.Now().UTC())
 		run.UpdatedAt = *run.CompletedAt
-		_ = store.SaveRun(ctx, run)
-		_, _ = store.AppendEvent(ctx, run.ID, autonomous.RunEvent{
+		a.saveAutonomousRunBestEffort(ctx, store, run)
+		a.appendAutonomousRunEventBestEffort(ctx, store, run.ID, autonomous.RunEvent{
 			Status:     run.Status,
 			Stage:      run.Stage,
 			Message:    "failed to write graph artifacts",
@@ -115,8 +115,8 @@ func (a *App) toolCerebroAutonomousCredentialResponse(ctx context.Context, args 
 		run.Error = err.Error()
 		run.CompletedAt = timePointer(time.Now().UTC())
 		run.UpdatedAt = *run.CompletedAt
-		_ = store.SaveRun(ctx, run)
-		_, _ = store.AppendEvent(ctx, run.ID, autonomous.RunEvent{
+		a.saveAutonomousRunBestEffort(ctx, store, run)
+		a.appendAutonomousRunEventBestEffort(ctx, store, run.ID, autonomous.RunEvent{
 			Status:     run.Status,
 			Stage:      run.Stage,
 			Message:    "failed to start autonomous action execution",
@@ -134,7 +134,7 @@ func (a *App) toolCerebroAutonomousCredentialResponse(ctx context.Context, args 
 		if err := store.SaveRun(ctx, run); err != nil {
 			return "", fmt.Errorf("save pending autonomous workflow run: %w", err)
 		}
-		_, _ = store.AppendEvent(ctx, run.ID, autonomous.RunEvent{
+		a.appendAutonomousRunEventBestEffort(ctx, store, run.ID, autonomous.RunEvent{
 			Status:     run.Status,
 			Stage:      run.Stage,
 			Message:    "awaiting approval before revoking credentials",
@@ -232,8 +232,8 @@ func (a *App) toolCerebroAutonomousWorkflowApprove(ctx context.Context, args jso
 			now := time.Now().UTC()
 			run.CompletedAt = timePointer(now)
 			run.UpdatedAt = now
-			_ = store.SaveRun(ctx, run)
-			_, _ = store.AppendEvent(ctx, run.ID, autonomous.RunEvent{
+			a.saveAutonomousRunBestEffort(ctx, store, run)
+			a.appendAutonomousRunEventBestEffort(ctx, store, run.ID, autonomous.RunEvent{
 				Status:     run.Status,
 				Stage:      run.Stage,
 				Message:    "workflow approval failed during execution",
@@ -264,7 +264,7 @@ func (a *App) toolCerebroAutonomousWorkflowApprove(ctx context.Context, args jso
 	if err := store.SaveRun(ctx, run); err != nil {
 		return "", err
 	}
-	_, _ = store.AppendEvent(ctx, run.ID, autonomous.RunEvent{
+	a.appendAutonomousRunEventBestEffort(ctx, store, run.ID, autonomous.RunEvent{
 		Status:     run.Status,
 		Stage:      run.Stage,
 		Message:    "workflow approval rejected",
@@ -423,8 +423,8 @@ func (a *App) finalizeAutonomousCredentialResponse(ctx context.Context, run *aut
 			run.Stage = autonomous.RunStageClosed
 			run.Error = err.Error()
 			run.CompletedAt = timePointer(now)
-			_ = store.SaveRun(ctx, run)
-			_, _ = store.AppendEvent(ctx, run.ID, autonomous.RunEvent{
+			a.saveAutonomousRunBestEffort(ctx, store, run)
+			a.appendAutonomousRunEventBestEffort(ctx, store, run.ID, autonomous.RunEvent{
 				Status:     run.Status,
 				Stage:      run.Stage,
 				Message:    "credential revocation succeeded but graph closeout failed",
@@ -442,7 +442,7 @@ func (a *App) finalizeAutonomousCredentialResponse(ctx context.Context, run *aut
 		if err := store.SaveRun(ctx, run); err != nil {
 			return err
 		}
-		_, _ = store.AppendEvent(ctx, run.ID, autonomous.RunEvent{
+		a.appendAutonomousRunEventBestEffort(ctx, store, run.ID, autonomous.RunEvent{
 			Status:     run.Status,
 			Stage:      run.Stage,
 			Message:    "credential exposure workflow completed",
@@ -461,7 +461,7 @@ func (a *App) finalizeAutonomousCredentialResponse(ctx context.Context, run *aut
 		if err := store.SaveRun(ctx, run); err != nil {
 			return err
 		}
-		_, _ = store.AppendEvent(ctx, run.ID, autonomous.RunEvent{
+		a.appendAutonomousRunEventBestEffort(ctx, store, run.ID, autonomous.RunEvent{
 			Status:     run.Status,
 			Stage:      run.Stage,
 			Message:    "credential exposure workflow failed during actuation",
@@ -568,6 +568,31 @@ func (a *App) autonomousRunStore() (autonomous.RunStore, error) {
 		return nil, fmt.Errorf("open autonomous workflow store: %w", err)
 	}
 	return store, nil
+}
+
+func (a *App) saveAutonomousRunBestEffort(ctx context.Context, store autonomous.RunStore, run *autonomous.RunRecord) {
+	if store == nil || run == nil {
+		return
+	}
+	if err := store.SaveRun(ctx, run); err != nil {
+		a.warnAutonomousRunPersistence("persist autonomous workflow run failed", run.ID, err)
+	}
+}
+
+func (a *App) appendAutonomousRunEventBestEffort(ctx context.Context, store autonomous.RunStore, runID string, event autonomous.RunEvent) {
+	if store == nil {
+		return
+	}
+	if _, err := store.AppendEvent(ctx, runID, event); err != nil {
+		a.warnAutonomousRunPersistence("persist autonomous workflow event failed", runID, err)
+	}
+}
+
+func (a *App) warnAutonomousRunPersistence(message, runID string, err error) {
+	if err == nil || a == nil || a.Logger == nil {
+		return
+	}
+	a.Logger.Warn(message, "run_id", strings.TrimSpace(runID), "error", err)
 }
 
 func (a *App) autonomousRuntimeBlocklist() *runtime.Blocklist {

--- a/internal/app/app_cerebro_tools_autonomous_test.go
+++ b/internal/app/app_cerebro_tools_autonomous_test.go
@@ -1,0 +1,89 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/autonomous"
+)
+
+type autonomousRunStoreStub struct {
+	saveRunErr     error
+	appendEventErr error
+}
+
+func (s *autonomousRunStoreStub) SaveRun(context.Context, *autonomous.RunRecord) error {
+	return s.saveRunErr
+}
+
+func (s *autonomousRunStoreStub) LoadRun(context.Context, string) (*autonomous.RunRecord, error) {
+	return nil, nil
+}
+
+func (s *autonomousRunStoreStub) ListRuns(context.Context, autonomous.RunListOptions) ([]autonomous.RunRecord, error) {
+	return nil, nil
+}
+
+func (s *autonomousRunStoreStub) AppendEvent(context.Context, string, autonomous.RunEvent) (autonomous.RunEvent, error) {
+	return autonomous.RunEvent{}, s.appendEventErr
+}
+
+func (s *autonomousRunStoreStub) LoadEvents(context.Context, string) ([]autonomous.RunEvent, error) {
+	return nil, nil
+}
+
+func (s *autonomousRunStoreStub) Close() error {
+	return nil
+}
+
+func TestSaveAutonomousRunBestEffortLogsWarning(t *testing.T) {
+	var logs bytes.Buffer
+	application := &App{
+		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	}
+	store := &autonomousRunStoreStub{saveRunErr: errors.New("save failed")}
+
+	application.saveAutonomousRunBestEffort(context.Background(), store, &autonomous.RunRecord{ID: "run-123"})
+
+	output := logs.String()
+	if !strings.Contains(output, "persist autonomous workflow run failed") {
+		t.Fatalf("expected save warning log, got %q", output)
+	}
+	if !strings.Contains(output, "run-123") {
+		t.Fatalf("expected run id in warning log, got %q", output)
+	}
+}
+
+func TestAppendAutonomousRunEventBestEffortLogsWarning(t *testing.T) {
+	var logs bytes.Buffer
+	application := &App{
+		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	}
+	store := &autonomousRunStoreStub{appendEventErr: errors.New("append failed")}
+
+	application.appendAutonomousRunEventBestEffort(context.Background(), store, "run-456", autonomous.RunEvent{
+		Status:     autonomous.RunStatusFailed,
+		Stage:      autonomous.RunStageClosed,
+		Message:    "failed",
+		RecordedAt: time.Now().UTC(),
+	})
+
+	output := logs.String()
+	if !strings.Contains(output, "persist autonomous workflow event failed") {
+		t.Fatalf("expected append warning log, got %q", output)
+	}
+	if !strings.Contains(output, "run-456") {
+		t.Fatalf("expected run id in warning log, got %q", output)
+	}
+}
+
+func TestWarnAutonomousRunPersistenceSkipsNilLogger(t *testing.T) {
+	application := &App{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	application.warnAutonomousRunPersistence("ignored", "run-789", nil)
+}

--- a/internal/app/app_stream_consumer_identity_resolve.go
+++ b/internal/app/app_stream_consumer_identity_resolve.go
@@ -29,11 +29,11 @@ func (a *App) resolveTapMappingIdentityOnGraph(securityGraph *graph.Graph, raw s
 
 	email := strings.ToLower(strings.TrimSpace(raw))
 	if strings.Contains(email, "@") {
-		canonicalID := "person:" + email
+		canonicalNodeID := "person:" + email
 		if securityGraph != nil {
-			if _, ok := securityGraph.GetNode(canonicalID); !ok {
+			if _, ok := securityGraph.GetNode(canonicalNodeID); !ok {
 				securityGraph.AddNode(&graph.Node{
-					ID:       canonicalID,
+					ID:       canonicalNodeID,
 					Kind:     graph.NodeKindPerson,
 					Name:     email,
 					Provider: "org",
@@ -47,17 +47,19 @@ func (a *App) resolveTapMappingIdentityOnGraph(securityGraph *graph.Graph, raw s
 					},
 				})
 			}
-			_, _ = graph.ResolveIdentityAlias(securityGraph, graph.IdentityAliasAssertion{
+			if _, err := graph.ResolveIdentityAlias(securityGraph, graph.IdentityAliasAssertion{
 				SourceSystem:  firstNonEmpty(sourceSystemFromTapType(evt.Type), "tap"),
 				SourceEventID: strings.TrimSpace(evt.ID),
 				ExternalID:    email,
 				Email:         email,
-				CanonicalHint: canonicalID,
+				CanonicalHint: canonicalNodeID,
 				ObservedAt:    evt.Time.UTC(),
 				Confidence:    0.95,
-			}, graph.IdentityResolutionOptions{})
+			}, graph.IdentityResolutionOptions{}); err != nil && a != nil && a.Logger != nil {
+				a.Logger.Warn("resolve tap identity alias failed", "identity", email, "event_id", strings.TrimSpace(evt.ID), "error", err)
+			}
 		}
-		return canonicalID
+		return canonicalNodeID
 	}
 	return raw
 }

--- a/internal/repohistoryscan/runtime.go
+++ b/internal/repohistoryscan/runtime.go
@@ -317,7 +317,9 @@ func (r *Runner) cleanupCheckout(ctx context.Context, run *RunRecord) {
 	cleanedAt := r.now().UTC()
 	run.Checkout.CleanedUpAt = &cleanedAt
 	run.UpdatedAt = cleanedAt
-	_ = r.saveRun(ctx, run)
+	if err := r.saveRun(ctx, run); err != nil {
+		r.logger.Warn("persist repo history scan cleanup state failed", "run_id", run.ID, "error", err)
+	}
 }
 
 func (r *Runner) saveRun(ctx context.Context, run *RunRecord) error {

--- a/internal/reposcan/runtime.go
+++ b/internal/reposcan/runtime.go
@@ -293,7 +293,9 @@ func (r *Runner) cleanupCheckout(ctx context.Context, run *RunRecord) {
 	cleanedAt := r.now().UTC()
 	run.Checkout.CleanedUpAt = &cleanedAt
 	run.UpdatedAt = cleanedAt
-	_ = r.saveRun(ctx, run)
+	if err := r.saveRun(ctx, run); err != nil {
+		r.logger.Warn("persist repo scan cleanup state failed", "run_id", run.ID, "error", err)
+	}
 }
 
 func (r *Runner) saveRun(ctx context.Context, run *RunRecord) error {


### PR DESCRIPTION
## Summary
- log autonomous run persistence failures instead of dropping them silently
- emit warnings when tap identity alias resolution or cleanup persistence fails
- add regression coverage for the best-effort logging helpers

Closes #264
