### PR TITLE
fix(app): guard insecure NATS TLS overrides

### DIFF
--- a/internal/agents/remote_tools.go
+++ b/internal/agents/remote_tools.go
@@ -45,6 +45,7 @@ type RemoteToolProviderConfig struct {
 	TLSKeyFile            string
 	TLSServerName         string
 	TLSInsecureSkipVerify bool
+	AllowInsecureTLS      bool
 }
 
 type RemoteToolProvider struct {
@@ -368,7 +369,7 @@ func signerFromSeed(seed string) (string, func([]byte) ([]byte, error), error) {
 }
 
 func (c RemoteToolProviderConfig) tlsConfig() (*tls.Config, error) {
-	if c.TLSInsecureSkipVerify && !allowInsecureTLSOverride() {
+	if c.TLSInsecureSkipVerify && !allowInsecureTLSOverride(c.AllowInsecureTLS) {
 		return nil, fmt.Errorf("remote tools tls insecure skip verify requires CEREBRO_ALLOW_INSECURE_TLS=true")
 	}
 	tlsConfig := &tls.Config{
@@ -404,6 +405,6 @@ func (c RemoteToolProviderConfig) tlsConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func allowInsecureTLSOverride() bool {
-	return strings.EqualFold(strings.TrimSpace(os.Getenv("CEREBRO_ALLOW_INSECURE_TLS")), "true")
+func allowInsecureTLSOverride(explicit bool) bool {
+	return explicit || strings.EqualFold(strings.TrimSpace(os.Getenv("CEREBRO_ALLOW_INSECURE_TLS")), "true")
 }

--- a/internal/agents/remote_tools.go
+++ b/internal/agents/remote_tools.go
@@ -368,6 +368,9 @@ func signerFromSeed(seed string) (string, func([]byte) ([]byte, error), error) {
 }
 
 func (c RemoteToolProviderConfig) tlsConfig() (*tls.Config, error) {
+	if c.TLSInsecureSkipVerify && !allowInsecureTLSOverride() {
+		return nil, fmt.Errorf("remote tools tls insecure skip verify requires CEREBRO_ALLOW_INSECURE_TLS=true")
+	}
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: c.TLSInsecureSkipVerify,
@@ -399,4 +402,8 @@ func (c RemoteToolProviderConfig) tlsConfig() (*tls.Config, error) {
 	}
 
 	return tlsConfig, nil
+}
+
+func allowInsecureTLSOverride() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("CEREBRO_ALLOW_INSECURE_TLS")), "true")
 }

--- a/internal/agents/remote_tools_test.go
+++ b/internal/agents/remote_tools_test.go
@@ -63,6 +63,22 @@ func TestRemoteToolProviderConfigRejectsInsecureTLSWithoutOverride(t *testing.T)
 	}
 }
 
+func TestRemoteToolProviderConfigAllowsInsecureTLSWithExplicitOverride(t *testing.T) {
+	cfg := (RemoteToolProviderConfig{
+		Enabled:               true,
+		URLs:                  []string{"nats://127.0.0.1:4222"},
+		ManifestSubject:       "ensemble.tools.manifest",
+		RequestPrefix:         "ensemble.tools.request",
+		TLSEnabled:            true,
+		TLSInsecureSkipVerify: true,
+		AllowInsecureTLS:      true,
+	}).withDefaults()
+
+	if _, err := cfg.natsOptions(); err != nil {
+		t.Fatalf("expected explicit insecure TLS override to succeed, got %v", err)
+	}
+}
+
 func TestDecodeRemoteManifest(t *testing.T) {
 	asArray := []byte(`[
 	  {"name":"hubspot_get_company","description":"Get company","parameters":{"type":"object"},"requires_approval":false}

--- a/internal/agents/remote_tools_test.go
+++ b/internal/agents/remote_tools_test.go
@@ -48,6 +48,21 @@ func TestRemoteToolProviderConfigValidate(t *testing.T) {
 	}
 }
 
+func TestRemoteToolProviderConfigRejectsInsecureTLSWithoutOverride(t *testing.T) {
+	cfg := (RemoteToolProviderConfig{
+		Enabled:               true,
+		URLs:                  []string{"nats://127.0.0.1:4222"},
+		ManifestSubject:       "ensemble.tools.manifest",
+		RequestPrefix:         "ensemble.tools.request",
+		TLSEnabled:            true,
+		TLSInsecureSkipVerify: true,
+	}).withDefaults()
+
+	if _, err := cfg.natsOptions(); err == nil {
+		t.Fatal("expected insecure TLS override error")
+	}
+}
+
 func TestDecodeRemoteManifest(t *testing.T) {
 	asArray := []byte(`[
 	  {"name":"hubspot_get_company","description":"Get company","parameters":{"type":"object"},"requires_approval":false}

--- a/internal/agents/tool_publisher.go
+++ b/internal/agents/tool_publisher.go
@@ -44,6 +44,7 @@ type ToolPublisherConfig struct {
 	TLSKeyFile            string
 	TLSServerName         string
 	TLSInsecureSkipVerify bool
+	AllowInsecureTLS      bool
 }
 
 // ToolPublisher exposes a manifest and request handlers for local Cerebro tools
@@ -441,7 +442,7 @@ func (c ToolPublisherConfig) authOptions() ([]nats.Option, error) {
 }
 
 func (c ToolPublisherConfig) tlsConfig() (*tls.Config, error) {
-	if c.TLSInsecureSkipVerify && !allowInsecureTLSOverride() {
+	if c.TLSInsecureSkipVerify && !allowInsecureTLSOverride(c.AllowInsecureTLS) {
 		return nil, fmt.Errorf("tool publisher tls insecure skip verify requires CEREBRO_ALLOW_INSECURE_TLS=true")
 	}
 	tlsConfig := &tls.Config{

--- a/internal/agents/tool_publisher.go
+++ b/internal/agents/tool_publisher.go
@@ -441,6 +441,9 @@ func (c ToolPublisherConfig) authOptions() ([]nats.Option, error) {
 }
 
 func (c ToolPublisherConfig) tlsConfig() (*tls.Config, error) {
+	if c.TLSInsecureSkipVerify && !allowInsecureTLSOverride() {
+		return nil, fmt.Errorf("tool publisher tls insecure skip verify requires CEREBRO_ALLOW_INSECURE_TLS=true")
+	}
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: c.TLSInsecureSkipVerify,

--- a/internal/agents/tool_publisher_test.go
+++ b/internal/agents/tool_publisher_test.go
@@ -48,6 +48,21 @@ func TestToolPublisherConfigValidate(t *testing.T) {
 	}
 }
 
+func TestToolPublisherConfigRejectsInsecureTLSWithoutOverride(t *testing.T) {
+	cfg := (ToolPublisherConfig{
+		Enabled:               true,
+		URLs:                  []string{"nats://127.0.0.1:4222"},
+		ManifestSubject:       "cerebro.tools.manifest",
+		RequestPrefix:         "cerebro.tools.request",
+		TLSEnabled:            true,
+		TLSInsecureSkipVerify: true,
+	}).withDefaults()
+
+	if _, err := cfg.natsOptions(); err == nil {
+		t.Fatal("expected insecure TLS override error")
+	}
+}
+
 func TestDecodeToolInvocationRequest_WrappedArguments(t *testing.T) {
 	req, args, err := decodeToolInvocationRequest([]byte(`{"tool":"cerebro.blast_radius","arguments":{"principal_id":"user:1","max_depth":4}}`))
 	if err != nil {

--- a/internal/agents/tool_publisher_test.go
+++ b/internal/agents/tool_publisher_test.go
@@ -63,6 +63,22 @@ func TestToolPublisherConfigRejectsInsecureTLSWithoutOverride(t *testing.T) {
 	}
 }
 
+func TestToolPublisherConfigAllowsInsecureTLSWithExplicitOverride(t *testing.T) {
+	cfg := (ToolPublisherConfig{
+		Enabled:               true,
+		URLs:                  []string{"nats://127.0.0.1:4222"},
+		ManifestSubject:       "cerebro.tools.manifest",
+		RequestPrefix:         "cerebro.tools.request",
+		TLSEnabled:            true,
+		TLSInsecureSkipVerify: true,
+		AllowInsecureTLS:      true,
+	}).withDefaults()
+
+	if _, err := cfg.natsOptions(); err != nil {
+		t.Fatalf("expected explicit insecure TLS override to succeed, got %v", err)
+	}
+}
+
 func TestDecodeToolInvocationRequest_WrappedArguments(t *testing.T) {
 	req, args, err := decodeToolInvocationRequest([]byte(`{"tool":"cerebro.blast_radius","arguments":{"principal_id":"user:1","max_depth":4}}`))
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -253,6 +253,7 @@ func NewWithOptions(ctx context.Context, opts ...Option) (*App, error) {
 		logger = newDefaultAppLogger(cfg.LogLevel)
 	}
 	logUnboundedRetentionWarnings(logger, cfg)
+	logInsecureTLSWarnings(logger, cfg)
 
 	app := &App{
 		Config: cfg,
@@ -294,4 +295,13 @@ func NewWithOptions(ctx context.Context, opts ...Option) (*App, error) {
 	app.startSecretsReloader(ctx)
 
 	return app, nil
+}
+
+func logInsecureTLSWarnings(logger *slog.Logger, cfg *Config) {
+	if logger == nil || cfg == nil {
+		return
+	}
+	if cfg.NATSJetStreamTLSEnabled && cfg.NATSJetStreamTLSInsecure && getEnvBool("CEREBRO_ALLOW_INSECURE_TLS", false) {
+		logger.Warn("insecure TLS verification bypass enabled for NATS clients", "env_var", "NATS_JETSTREAM_TLS_INSECURE_SKIP_VERIFY")
+	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -301,7 +301,30 @@ func logInsecureTLSWarnings(logger *slog.Logger, cfg *Config) {
 	if logger == nil || cfg == nil {
 		return
 	}
-	if cfg.NATSJetStreamTLSEnabled && cfg.NATSJetStreamTLSInsecure && getEnvBool("CEREBRO_ALLOW_INSECURE_TLS", false) {
+	if cfg.usesNATSInsecureTLS() && cfg.allowInsecureTLSOverride() {
 		logger.Warn("insecure TLS verification bypass enabled for NATS clients", "env_var", "NATS_JETSTREAM_TLS_INSECURE_SKIP_VERIFY")
 	}
+}
+
+func (c *Config) allowInsecureTLSOverride() bool {
+	if c == nil {
+		return getEnvBool("CEREBRO_ALLOW_INSECURE_TLS", false)
+	}
+	return c.AllowInsecureTLS || getEnvBool("CEREBRO_ALLOW_INSECURE_TLS", false)
+}
+
+func (c *Config) usesNATSInsecureTLS() bool {
+	return c != nil && c.NATSJetStreamTLSEnabled && c.NATSJetStreamTLSInsecure
+}
+
+func (c *Config) usesNATSTransportSettings() bool {
+	if c == nil {
+		return false
+	}
+	return c.NATSJetStreamEnabled ||
+		c.NATSConsumerEnabled ||
+		c.AlertRouterEnabled ||
+		c.AgentRemoteToolsEnabled ||
+		c.AgentToolPublisherEnabled ||
+		c.GraphWriterLeaseEnabled
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -323,7 +323,6 @@ func (c *Config) usesNATSTransportSettings() bool {
 	}
 	return c.NATSJetStreamEnabled ||
 		c.NATSConsumerEnabled ||
-		c.AlertRouterEnabled ||
 		c.AgentRemoteToolsEnabled ||
 		c.AgentToolPublisherEnabled ||
 		c.GraphWriterLeaseEnabled

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -337,6 +337,7 @@ type Config struct {
 	NATSJetStreamTLSKeyFile            string
 	NATSJetStreamTLSServerName         string
 	NATSJetStreamTLSInsecure           bool
+	AllowInsecureTLS                   bool
 
 	// NATS JetStream consumer for ensemble-tap ingestion
 	NATSConsumerEnabled                 bool

--- a/internal/app/app_config_validation.go
+++ b/internal/app/app_config_validation.go
@@ -427,6 +427,9 @@ func (c *Config) Validate() error {
 		if c.NATSJetStreamOutboxMaxRetry < 0 {
 			problems = addConfigProblem(problems, "NATS_JETSTREAM_OUTBOX_MAX_RETRY must be >= 0 when NATS_JETSTREAM_ENABLED=true")
 		}
+		if c.NATSJetStreamTLSEnabled && c.NATSJetStreamTLSInsecure && !getEnvBool("CEREBRO_ALLOW_INSECURE_TLS", false) {
+			problems = addConfigProblem(problems, "NATS_JETSTREAM_TLS_INSECURE_SKIP_VERIFY requires CEREBRO_ALLOW_INSECURE_TLS=true")
+		}
 	}
 
 	if c.NATSConsumerEnabled {

--- a/internal/app/app_config_validation.go
+++ b/internal/app/app_config_validation.go
@@ -427,9 +427,10 @@ func (c *Config) Validate() error {
 		if c.NATSJetStreamOutboxMaxRetry < 0 {
 			problems = addConfigProblem(problems, "NATS_JETSTREAM_OUTBOX_MAX_RETRY must be >= 0 when NATS_JETSTREAM_ENABLED=true")
 		}
-		if c.NATSJetStreamTLSEnabled && c.NATSJetStreamTLSInsecure && !getEnvBool("CEREBRO_ALLOW_INSECURE_TLS", false) {
-			problems = addConfigProblem(problems, "NATS_JETSTREAM_TLS_INSECURE_SKIP_VERIFY requires CEREBRO_ALLOW_INSECURE_TLS=true")
-		}
+	}
+
+	if c.usesNATSTransportSettings() && c.usesNATSInsecureTLS() && !c.allowInsecureTLSOverride() {
+		problems = addConfigProblem(problems, "NATS_JETSTREAM_TLS_INSECURE_SKIP_VERIFY requires CEREBRO_ALLOW_INSECURE_TLS=true")
 	}
 
 	if c.NATSConsumerEnabled {

--- a/internal/app/app_event_routing.go
+++ b/internal/app/app_event_routing.go
@@ -43,6 +43,7 @@ func (a *App) startEventAlertRouting(_ context.Context) {
 		TLSKeyFile:            a.Config.NATSJetStreamTLSKeyFile,
 		TLSServerName:         a.Config.NATSJetStreamTLSServerName,
 		TLSInsecureSkipVerify: a.Config.NATSJetStreamTLSInsecure,
+		AllowInsecureTLS:      a.Config.AllowInsecureTLS,
 	}, a.Logger)
 	if err != nil {
 		a.Logger.Warn("failed to initialize alert notifier", "error", err)

--- a/internal/app/app_init_agents.go
+++ b/internal/app/app_init_agents.go
@@ -195,6 +195,7 @@ func remoteToolProviderConfigFromConfig(cfg *Config) agents.RemoteToolProviderCo
 		TLSKeyFile:            cfg.NATSJetStreamTLSKeyFile,
 		TLSServerName:         cfg.NATSJetStreamTLSServerName,
 		TLSInsecureSkipVerify: cfg.NATSJetStreamTLSInsecure,
+		AllowInsecureTLS:      cfg.AllowInsecureTLS,
 	}
 }
 
@@ -217,6 +218,7 @@ func toolPublisherConfigFromConfig(cfg *Config) agents.ToolPublisherConfig {
 		TLSKeyFile:            cfg.NATSJetStreamTLSKeyFile,
 		TLSServerName:         cfg.NATSJetStreamTLSServerName,
 		TLSInsecureSkipVerify: cfg.NATSJetStreamTLSInsecure,
+		AllowInsecureTLS:      cfg.AllowInsecureTLS,
 	}
 }
 

--- a/internal/app/app_init_agents_test.go
+++ b/internal/app/app_init_agents_test.go
@@ -39,6 +39,7 @@ func TestRemoteToolProviderConfigFromConfig(t *testing.T) {
 		NATSJetStreamTLSKeyFile:         "/tmp/key.pem",
 		NATSJetStreamTLSServerName:      "nats.internal",
 		NATSJetStreamTLSInsecure:        true,
+		AllowInsecureTLS:                true,
 	}
 
 	got := remoteToolProviderConfigFromConfig(cfg)
@@ -62,6 +63,7 @@ func TestRemoteToolProviderConfigFromConfig(t *testing.T) {
 		TLSKeyFile:            "/tmp/key.pem",
 		TLSServerName:         "nats.internal",
 		TLSInsecureSkipVerify: true,
+		AllowInsecureTLS:      true,
 	}
 
 	if !reflect.DeepEqual(got, want) {
@@ -88,6 +90,7 @@ func TestToolPublisherConfigFromConfig(t *testing.T) {
 		NATSJetStreamTLSKeyFile:           "/tmp/key2.pem",
 		NATSJetStreamTLSServerName:        "nats.tools.internal",
 		NATSJetStreamTLSInsecure:          true,
+		AllowInsecureTLS:                  true,
 	}
 
 	got := toolPublisherConfigFromConfig(cfg)
@@ -109,6 +112,7 @@ func TestToolPublisherConfigFromConfig(t *testing.T) {
 		TLSKeyFile:            "/tmp/key2.pem",
 		TLSServerName:         "nats.tools.internal",
 		TLSInsecureSkipVerify: true,
+		AllowInsecureTLS:      true,
 	}
 
 	if !reflect.DeepEqual(got, want) {

--- a/internal/app/app_init_core.go
+++ b/internal/app/app_init_core.go
@@ -530,6 +530,7 @@ func (a *App) initJetStreamEventPublisher() {
 		TLSKeyFile:            a.Config.NATSJetStreamTLSKeyFile,
 		TLSServerName:         a.Config.NATSJetStreamTLSServerName,
 		TLSInsecureSkipVerify: a.Config.NATSJetStreamTLSInsecure,
+		AllowInsecureTLS:      a.Config.AllowInsecureTLS,
 	}, a.Logger)
 	if err != nil {
 		a.Logger.Warn("failed to initialize jetstream event publisher", "error", err)

--- a/internal/app/app_insecure_tls_test.go
+++ b/internal/app/app_insecure_tls_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfigValidateRejectsInsecureTLSWithoutOverride(t *testing.T) {
+	t.Setenv("NATS_JETSTREAM_ENABLED", "true")
+	t.Setenv("NATS_JETSTREAM_TLS_ENABLED", "true")
+	t.Setenv("NATS_JETSTREAM_TLS_INSECURE_SKIP_VERIFY", "true")
+	t.Setenv("CEREBRO_ALLOW_INSECURE_TLS", "false")
+
+	cfg := LoadConfig()
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected config validation error")
+	}
+	if !strings.Contains(err.Error(), "NATS_JETSTREAM_TLS_INSECURE_SKIP_VERIFY requires CEREBRO_ALLOW_INSECURE_TLS=true") {
+		t.Fatalf("expected insecure TLS validation failure, got %v", err)
+	}
+}
+
+func TestLoadConfigValidateAllowsInsecureTLSWithOverride(t *testing.T) {
+	t.Setenv("NATS_JETSTREAM_ENABLED", "true")
+	t.Setenv("NATS_JETSTREAM_TLS_ENABLED", "true")
+	t.Setenv("NATS_JETSTREAM_TLS_INSECURE_SKIP_VERIFY", "true")
+	t.Setenv("CEREBRO_ALLOW_INSECURE_TLS", "true")
+
+	cfg := LoadConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected insecure TLS override to validate, got %v", err)
+	}
+}
+
+func TestLogInsecureTLSWarnings(t *testing.T) {
+	t.Setenv("CEREBRO_ALLOW_INSECURE_TLS", "true")
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	logInsecureTLSWarnings(logger, &Config{
+		NATSJetStreamTLSEnabled:  true,
+		NATSJetStreamTLSInsecure: true,
+	})
+
+	output := logs.String()
+	if !strings.Contains(output, "insecure TLS verification bypass enabled for NATS clients") {
+		t.Fatalf("expected insecure TLS warning, got %q", output)
+	}
+}

--- a/internal/app/app_insecure_tls_test.go
+++ b/internal/app/app_insecure_tls_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoadConfigValidateRejectsInsecureTLSWithoutOverride(t *testing.T) {
@@ -35,6 +36,45 @@ func TestLoadConfigValidateAllowsInsecureTLSWithOverride(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsInsecureTLSForAgentTransportsWithoutOverride(t *testing.T) {
+	cfg := &Config{
+		AgentRemoteToolsEnabled:  true,
+		NATSJetStreamTLSEnabled:  true,
+		NATSJetStreamTLSInsecure: true,
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected config validation error")
+	}
+	if !strings.Contains(err.Error(), "NATS_JETSTREAM_TLS_INSECURE_SKIP_VERIFY requires CEREBRO_ALLOW_INSECURE_TLS=true") {
+		t.Fatalf("expected insecure TLS validation failure, got %v", err)
+	}
+}
+
+func TestConfigValidateAllowsInsecureTLSWithExplicitOverride(t *testing.T) {
+	t.Setenv("CEREBRO_ALLOW_INSECURE_TLS", "false")
+
+	cfg := LoadConfig()
+	cfg.NATSJetStreamEnabled = true
+	cfg.NATSJetStreamURLs = []string{"nats://127.0.0.1:4222"}
+	cfg.NATSJetStreamStream = "CEREBRO_EVENTS"
+	cfg.NATSJetStreamSubjectPrefix = "cerebro.events"
+	cfg.NATSJetStreamPublishTimeout = 3 * time.Second
+	cfg.NATSJetStreamConnectTimeout = 5 * time.Second
+	cfg.NATSJetStreamFlushInterval = 10 * time.Second
+	cfg.NATSJetStreamOutboxMaxAge = time.Second
+	cfg.NATSJetStreamOutboxMaxItems = 1
+	cfg.NATSJetStreamOutboxMaxRetry = 0
+	cfg.NATSJetStreamTLSEnabled = true
+	cfg.NATSJetStreamTLSInsecure = true
+	cfg.AllowInsecureTLS = true
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected explicit insecure TLS override to validate, got %v", err)
+	}
+}
+
 func TestLogInsecureTLSWarnings(t *testing.T) {
 	t.Setenv("CEREBRO_ALLOW_INSECURE_TLS", "true")
 
@@ -44,6 +84,22 @@ func TestLogInsecureTLSWarnings(t *testing.T) {
 	logInsecureTLSWarnings(logger, &Config{
 		NATSJetStreamTLSEnabled:  true,
 		NATSJetStreamTLSInsecure: true,
+	})
+
+	output := logs.String()
+	if !strings.Contains(output, "insecure TLS verification bypass enabled for NATS clients") {
+		t.Fatalf("expected insecure TLS warning, got %q", output)
+	}
+}
+
+func TestLogInsecureTLSWarningsWithExplicitOverride(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	logInsecureTLSWarnings(logger, &Config{
+		NATSJetStreamTLSEnabled:  true,
+		NATSJetStreamTLSInsecure: true,
+		AllowInsecureTLS:         true,
 	})
 
 	output := logs.String()

--- a/internal/app/app_insecure_tls_test.go
+++ b/internal/app/app_insecure_tls_test.go
@@ -52,6 +52,18 @@ func TestConfigValidateRejectsInsecureTLSForAgentTransportsWithoutOverride(t *te
 	}
 }
 
+func TestConfigValidateAllowsAlertRouterWithoutJetStreamWhenTLSIsInsecure(t *testing.T) {
+	cfg := LoadConfig()
+	cfg.AlertRouterEnabled = true
+	cfg.NATSJetStreamEnabled = false
+	cfg.NATSJetStreamTLSEnabled = true
+	cfg.NATSJetStreamTLSInsecure = true
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected alert router alone not to require insecure TLS override, got %v", err)
+	}
+}
+
 func TestConfigValidateAllowsInsecureTLSWithExplicitOverride(t *testing.T) {
 	t.Setenv("CEREBRO_ALLOW_INSECURE_TLS", "false")
 

--- a/internal/app/app_stream_consumer_lifecycle.go
+++ b/internal/app/app_stream_consumer_lifecycle.go
@@ -87,6 +87,7 @@ func (a *App) startTapGraphConsumer(ctx context.Context) {
 		TLSKeyFile:            a.Config.NATSJetStreamTLSKeyFile,
 		TLSServerName:         a.Config.NATSJetStreamTLSServerName,
 		TLSInsecureSkipVerify: a.Config.NATSJetStreamTLSInsecure,
+		AllowInsecureTLS:      a.Config.AllowInsecureTLS,
 	}, a.Logger, handler)
 	if err != nil {
 		a.Logger.Warn("failed to initialize tap graph consumer", "error", err)

--- a/internal/app/graph_writer_lease_nats.go
+++ b/internal/app/graph_writer_lease_nats.go
@@ -41,6 +41,7 @@ func newNATSGraphWriterLeaseStore(cfg *Config) (*natsGraphWriterLeaseStore, erro
 		TLSKeyFile:            cfg.NATSJetStreamTLSKeyFile,
 		TLSServerName:         cfg.NATSJetStreamTLSServerName,
 		TLSInsecureSkipVerify: cfg.NATSJetStreamTLSInsecure,
+		AllowInsecureTLS:      cfg.AllowInsecureTLS,
 	}
 	options, err := base.NATSOptions()
 	if err != nil {

--- a/internal/cli/ingest_replay.go
+++ b/internal/cli/ingest_replay.go
@@ -210,6 +210,7 @@ func replayJetStream(opts replayStreamOptions) (replayStreamReport, error) {
 		TLSKeyFile:             cfg.NATSJetStreamTLSKeyFile,
 		TLSServerName:          cfg.NATSJetStreamTLSServerName,
 		TLSInsecureSkipVerify:  cfg.NATSJetStreamTLSInsecure,
+		AllowInsecureTLS:       cfg.AllowInsecureTLS,
 		ContinueOnHandlerError: true,
 	}, func(ctx context.Context, evt events.ReplayEvent) error {
 		if err := replayApp.ReplayTapCloudEvent(ctx, evt.CloudEvent); err != nil {

--- a/internal/cli/job_runtime.go
+++ b/internal/cli/job_runtime.go
@@ -83,6 +83,7 @@ func openJobRuntime(ctx context.Context, cfg *app.Config) (*jobRuntime, error) {
 		TLSKeyFile:            cfg.NATSJetStreamTLSKeyFile,
 		TLSServerName:         cfg.NATSJetStreamTLSServerName,
 		TLSInsecureSkipVerify: cfg.NATSJetStreamTLSInsecure,
+		AllowInsecureTLS:      cfg.AllowInsecureTLS,
 	}
 	natsOptions, err := jetStreamCfg.NATSOptions()
 	if err != nil {

--- a/internal/cli/workload_scan.go
+++ b/internal/cli/workload_scan.go
@@ -604,6 +604,7 @@ func newWorkloadScanEmitter(cfg *app.Config, logger *slog.Logger) (*webhooks.Ser
 		TLSKeyFile:            cfg.NATSJetStreamTLSKeyFile,
 		TLSServerName:         cfg.NATSJetStreamTLSServerName,
 		TLSInsecureSkipVerify: cfg.NATSJetStreamTLSInsecure,
+		AllowInsecureTLS:      cfg.AllowInsecureTLS,
 	}, logger)
 	if err != nil {
 		return nil, fmt.Errorf("initialize workload scan event publisher: %w", err)

--- a/internal/events/consumer.go
+++ b/internal/events/consumer.go
@@ -75,6 +75,7 @@ type ConsumerConfig struct {
 	TLSKeyFile            string
 	TLSServerName         string
 	TLSInsecureSkipVerify bool
+	AllowInsecureTLS      bool
 }
 
 type EventHandler func(context.Context, CloudEvent) error
@@ -208,6 +209,7 @@ func NewJetStreamConsumer(cfg ConsumerConfig, logger *slog.Logger, handler Event
 		TLSKeyFile:            config.TLSKeyFile,
 		TLSServerName:         config.TLSServerName,
 		TLSInsecureSkipVerify: config.TLSInsecureSkipVerify,
+		AllowInsecureTLS:      config.AllowInsecureTLS,
 	}.withDefaults()
 
 	natsOptions, err := base.natsOptions()

--- a/internal/events/jetstream.go
+++ b/internal/events/jetstream.go
@@ -909,6 +909,9 @@ func signerFromSeed(seed string) (string, func([]byte) ([]byte, error), error) {
 }
 
 func (c JetStreamConfig) tlsConfig() (*tls.Config, error) {
+	if c.TLSInsecureSkipVerify && !allowInsecureTLSOverride() {
+		return nil, errors.New("tls insecure skip verify requires CEREBRO_ALLOW_INSECURE_TLS=true")
+	}
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: c.TLSInsecureSkipVerify,
@@ -940,6 +943,10 @@ func (c JetStreamConfig) tlsConfig() (*tls.Config, error) {
 	}
 
 	return tlsConfig, nil
+}
+
+func allowInsecureTLSOverride() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("CEREBRO_ALLOW_INSECURE_TLS")), "true")
 }
 
 func (p *Publisher) canPublishLive() bool {

--- a/internal/events/jetstream.go
+++ b/internal/events/jetstream.go
@@ -106,6 +106,7 @@ type JetStreamConfig struct {
 	TLSKeyFile            string
 	TLSServerName         string
 	TLSInsecureSkipVerify bool
+	AllowInsecureTLS      bool
 
 	OutboxDLQPath         string
 	OutboxMaxRecords      int
@@ -909,7 +910,7 @@ func signerFromSeed(seed string) (string, func([]byte) ([]byte, error), error) {
 }
 
 func (c JetStreamConfig) tlsConfig() (*tls.Config, error) {
-	if c.TLSInsecureSkipVerify && !allowInsecureTLSOverride() {
+	if c.TLSInsecureSkipVerify && !allowInsecureTLSOverride(c.AllowInsecureTLS) {
 		return nil, errors.New("tls insecure skip verify requires CEREBRO_ALLOW_INSECURE_TLS=true")
 	}
 	tlsConfig := &tls.Config{
@@ -945,8 +946,8 @@ func (c JetStreamConfig) tlsConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func allowInsecureTLSOverride() bool {
-	return strings.EqualFold(strings.TrimSpace(os.Getenv("CEREBRO_ALLOW_INSECURE_TLS")), "true")
+func allowInsecureTLSOverride(explicit bool) bool {
+	return explicit || strings.EqualFold(strings.TrimSpace(os.Getenv("CEREBRO_ALLOW_INSECURE_TLS")), "true")
 }
 
 func (p *Publisher) canPublishLive() bool {

--- a/internal/events/jetstream_test.go
+++ b/internal/events/jetstream_test.go
@@ -135,6 +135,18 @@ func TestJetStreamConfigValidateTLSPair(t *testing.T) {
 	}
 }
 
+func TestJetStreamConfigRejectsInsecureTLSWithoutOverride(t *testing.T) {
+	cfg := JetStreamConfig{
+		URLs:                  []string{"tls://127.0.0.1:4222"},
+		TLSEnabled:            true,
+		TLSInsecureSkipVerify: true,
+	}.withDefaults()
+
+	if _, err := cfg.NATSOptions(); err == nil {
+		t.Fatal("expected insecure TLS override error")
+	}
+}
+
 func TestJetStreamConfigNKeyAuthOption(t *testing.T) {
 	kp, err := nkeys.CreateUser()
 	if err != nil {

--- a/internal/events/jetstream_test.go
+++ b/internal/events/jetstream_test.go
@@ -147,6 +147,19 @@ func TestJetStreamConfigRejectsInsecureTLSWithoutOverride(t *testing.T) {
 	}
 }
 
+func TestJetStreamConfigAllowsInsecureTLSWithExplicitOverride(t *testing.T) {
+	cfg := JetStreamConfig{
+		URLs:                  []string{"tls://127.0.0.1:4222"},
+		TLSEnabled:            true,
+		TLSInsecureSkipVerify: true,
+		AllowInsecureTLS:      true,
+	}.withDefaults()
+
+	if _, err := cfg.NATSOptions(); err != nil {
+		t.Fatalf("expected explicit insecure TLS override to succeed, got %v", err)
+	}
+}
+
 func TestJetStreamConfigNKeyAuthOption(t *testing.T) {
 	kp, err := nkeys.CreateUser()
 	if err != nil {

--- a/internal/events/replay.go
+++ b/internal/events/replay.go
@@ -36,6 +36,7 @@ type ReplayConfig struct {
 	TLSKeyFile            string
 	TLSServerName         string
 	TLSInsecureSkipVerify bool
+	AllowInsecureTLS      bool
 
 	ContinueOnHandlerError bool
 }
@@ -97,6 +98,7 @@ func ReplayJetStreamHistory(ctx context.Context, cfg ReplayConfig, handler Repla
 		TLSKeyFile:            config.TLSKeyFile,
 		TLSServerName:         config.TLSServerName,
 		TLSInsecureSkipVerify: config.TLSInsecureSkipVerify,
+		AllowInsecureTLS:      config.AllowInsecureTLS,
 	}.withDefaults()
 
 	natsOptions, err := base.natsOptions()

--- a/internal/events/router.go
+++ b/internal/events/router.go
@@ -125,6 +125,7 @@ type AlertNotifierConfig struct {
 	TLSKeyFile            string
 	TLSServerName         string
 	TLSInsecureSkipVerify bool
+	AllowInsecureTLS      bool
 }
 
 type NATSAlertNotifier struct {
@@ -1239,6 +1240,7 @@ func NewNATSAlertNotifier(cfg AlertNotifierConfig, logger *slog.Logger) (*NATSAl
 		TLSKeyFile:            cfg.TLSKeyFile,
 		TLSServerName:         cfg.TLSServerName,
 		TLSInsecureSkipVerify: cfg.TLSInsecureSkipVerify,
+		AllowInsecureTLS:      cfg.AllowInsecureTLS,
 	}.withDefaults()
 	options, err := base.natsOptions()
 	if err != nil {


### PR DESCRIPTION
## Summary
- reject insecure NATS TLS skip-verify settings unless CEREBRO_ALLOW_INSECURE_TLS=true is set
- enforce the same guardrail across JetStream, remote tools, and tool publisher transports
- log an explicit startup warning and add regression coverage for the override path

Closes #268
