### PR TITLE
fix(app): derive background work from root context

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -208,6 +208,7 @@ type App struct {
 	apiCredentials                     atomic.Value // map[string]apiauth.Credential
 	apiCredentialStore                 *apiauth.ManagedCredentialStore
 	secretsLoader                      secretsLoader
+	rootCtx                            context.Context
 
 	// Cached table list from Snowflake (shared by graph builder + policy coverage)
 	AvailableTables []string
@@ -247,6 +248,10 @@ func NewWithOptions(ctx context.Context, opts ...Option) (*App, error) {
 	if cfg.APIAuthEnabled && len(cfg.APIKeys) == 0 && len(managedCredentialStore.List()) == 0 {
 		return nil, fmt.Errorf("api auth enabled but no API_KEYS configured")
 	}
+	rootCtx := ctx
+	if rootCtx == nil {
+		rootCtx = context.Background()
+	}
 
 	logger := options.logger
 	if logger == nil {
@@ -255,8 +260,9 @@ func NewWithOptions(ctx context.Context, opts ...Option) (*App, error) {
 	logUnboundedRetentionWarnings(logger, cfg)
 
 	app := &App{
-		Config: cfg,
-		Logger: logger,
+		Config:  cfg,
+		Logger:  logger,
+		rootCtx: rootCtx,
 	}
 	app.secretsLoader = options.secretsLoader
 	app.apiCredentialStore = managedCredentialStore
@@ -266,10 +272,7 @@ func NewWithOptions(ctx context.Context, opts ...Option) (*App, error) {
 		app.setAPIKeys(cfg.APIKeys)
 	}
 
-	initCtx := ctx
-	if initCtx == nil {
-		initCtx = context.Background()
-	}
+	initCtx := rootCtx
 	if cfg.InitTimeout > 0 {
 		var cancel context.CancelFunc
 		initCtx, cancel = context.WithTimeout(initCtx, cfg.InitTimeout)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -294,7 +294,7 @@ func NewWithOptions(ctx context.Context, opts ...Option) (*App, error) {
 		"snowflake", app.Snowflake != nil,
 		"policies", len(app.Policy.ListPolicies()),
 	)
-	app.startSecretsReloader(ctx)
+	app.startSecretsReloader(rootCtx)
 
 	return app, nil
 }

--- a/internal/app/app_background_context.go
+++ b/internal/app/app_background_context.go
@@ -1,0 +1,15 @@
+package app
+
+import "context"
+
+func (a *App) backgroundContext() context.Context {
+	if a != nil {
+		if a.rootCtx != nil {
+			return backgroundWorkContext(a.rootCtx)
+		}
+		if a.graphCtx != nil {
+			return backgroundWorkContext(a.graphCtx)
+		}
+	}
+	return context.Background()
+}

--- a/internal/app/app_background_context_test.go
+++ b/internal/app/app_background_context_test.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"context"
+	"testing"
+)
+
+type backgroundContextKey string
+
+func TestAppBackgroundContextPreservesValuesWithoutCancellation(t *testing.T) {
+	base := context.WithValue(context.Background(), backgroundContextKey("trace"), "trace-123")
+	cancelable, cancel := context.WithCancel(base)
+	application := &App{rootCtx: cancelable}
+
+	cancel()
+
+	ctx := application.backgroundContext()
+	if got := ctx.Value(backgroundContextKey("trace")); got != "trace-123" {
+		t.Fatalf("backgroundContext() value = %v, want trace-123", got)
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("backgroundContext() should ignore parent cancellation, got %v", err)
+	}
+}

--- a/internal/app/app_background_context_test.go
+++ b/internal/app/app_background_context_test.go
@@ -2,10 +2,28 @@ package app
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type backgroundContextKey string
+
+type countingSecretsLoader struct {
+	loads  int32
+	config *Config
+}
+
+func (l *countingSecretsLoader) LoadConfig() *Config {
+	if l == nil {
+		return &Config{}
+	}
+	atomic.AddInt32(&l.loads, 1)
+	if l.config != nil {
+		return l.config
+	}
+	return &Config{}
+}
 
 func TestAppBackgroundContextPreservesValuesWithoutCancellation(t *testing.T) {
 	base := context.WithValue(context.Background(), backgroundContextKey("trace"), "trace-123")
@@ -20,5 +38,56 @@ func TestAppBackgroundContextPreservesValuesWithoutCancellation(t *testing.T) {
 	}
 	if err := ctx.Err(); err != nil {
 		t.Fatalf("backgroundContext() should ignore parent cancellation, got %v", err)
+	}
+}
+
+func TestStartSecretsReloaderIgnoresParentCancellation(t *testing.T) {
+	loader := &countingSecretsLoader{config: &Config{}}
+	application := &App{
+		Config:        &Config{SecretsReloadInterval: 10 * time.Millisecond},
+		secretsLoader: loader,
+	}
+	parent, cancel := context.WithCancel(context.Background())
+	application.startSecretsReloader(parent)
+	defer application.stopSecretsReloader()
+
+	cancel()
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&loader.loads) > 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	t.Fatal("expected secrets reloader to continue after parent cancellation")
+}
+
+func TestInitEventCorrelationRefreshLoopIgnoresParentCancellation(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	application := &App{Config: &Config{}}
+
+	application.initEventCorrelationRefreshLoop(parent)
+	if application.eventCorrelationRefreshQueue == nil {
+		t.Fatal("expected event correlation refresh queue to initialize")
+	}
+	application.eventCorrelationRefreshQueue.debounce = 10 * time.Millisecond
+	processed := make(chan string, 1)
+	application.eventCorrelationRefreshQueue.process = func(reason string) {
+		processed <- reason
+	}
+	defer application.stopEventCorrelationRefreshLoop()
+
+	cancel()
+	application.queueEventCorrelationRefresh("tap_mapping")
+
+	select {
+	case got := <-processed:
+		if got != "tap_mapping" {
+			t.Fatalf("unexpected refresh reason %q", got)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected refresh loop to continue after parent cancellation")
 	}
 }

--- a/internal/app/app_dspm_graph.go
+++ b/internal/app/app_dspm_graph.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"reflect"
 	"strings"
 
@@ -30,7 +29,7 @@ func (a *App) enrichSecurityGraphWithDSPMResult(target *dspm.ScanTarget, result 
 		return
 	}
 	if !a.retainHotSecurityGraph() {
-		if _, err := a.MutateSecurityGraphMaybe(context.Background(), func(g *graph.Graph) (bool, error) {
+		if _, err := a.MutateSecurityGraphMaybe(a.backgroundContext(), func(g *graph.Graph) (bool, error) {
 			return applyDSPMPropertiesToGraph(g, target, exactNodeIDs, fallbackNames, props), nil
 		}); err != nil && a.Logger != nil {
 			a.Logger.Warn("failed to enrich persistent security graph with DSPM result", "target_id", target.ID, "error", err)
@@ -48,7 +47,7 @@ func (a *App) enrichSecurityGraphWithDSPMResult(target *dspm.ScanTarget, result 
 	}
 
 	if current != nil || builderSecurityGraph == nil {
-		candidate, err := a.MutateSecurityGraphMaybe(context.Background(), func(g *graph.Graph) (bool, error) {
+		candidate, err := a.MutateSecurityGraphMaybe(a.backgroundContext(), func(g *graph.Graph) (bool, error) {
 			return applyDSPMPropertiesToGraph(g, target, exactNodeIDs, fallbackNames, props), nil
 		})
 		if err != nil {

--- a/internal/app/app_graph_mutation.go
+++ b/internal/app/app_graph_mutation.go
@@ -30,7 +30,7 @@ func (a *App) MutateSecurityGraphMaybe(ctx context.Context, mutate func(*graph.G
 		return a.CurrentSecurityGraph(), nil
 	}
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = a.backgroundContext()
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/internal/app/app_graph_store_sync.go
+++ b/internal/app/app_graph_store_sync.go
@@ -14,7 +14,7 @@ func (a *App) syncConfiguredSecurityGraphStore(ctx context.Context, g *graph.Gra
 		return nil
 	}
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = a.backgroundContext()
 	}
 	store := a.configuredSecurityGraphStore
 	if err := store.EnsureIndexes(ctx); err != nil {

--- a/internal/app/app_graph_updates.go
+++ b/internal/app/app_graph_updates.go
@@ -133,7 +133,7 @@ func (a *App) maybeStartGraphConsistencyCheck(trigger string, summary graph.Grap
 	a.graphConsistencyWG.Add(1)
 	baseCtx := a.graphCtx
 	if baseCtx == nil {
-		baseCtx = context.Background()
+		baseCtx = a.backgroundContext()
 	}
 	checkCtx, cancel := context.WithTimeout(baseCtx, a.Config.GraphConsistencyCheckTimeoutOrDefault())
 	a.graphConsistencyCancel = cancel

--- a/internal/app/app_graph_view.go
+++ b/internal/app/app_graph_view.go
@@ -30,7 +30,7 @@ func (a *App) currentOrStoredPassiveGraphSnapshotRecord() (*graph.GraphSnapshotR
 	if current := graph.CurrentGraphSnapshotRecord(a.currentLiveSecurityGraph()); current != nil {
 		return current, nil
 	}
-	if snapshot, err := a.currentConfiguredSecurityGraphSnapshot(context.Background()); err == nil && snapshot != nil {
+	if snapshot, err := a.currentConfiguredSecurityGraphSnapshot(a.backgroundContext()); err == nil && snapshot != nil {
 		if current := graph.CurrentGraphSnapshotRecord(graph.GraphViewFromSnapshot(snapshot)); current != nil {
 			return current, nil
 		}
@@ -49,7 +49,7 @@ func (a *App) currentOrStoredSecurityGraphViewWithSnapshotLoader(loadSnapshot fu
 	if current != nil && (current.NodeCount() > 0 || current.EdgeCount() > 0) {
 		return current, nil
 	}
-	if view, err := a.currentConfiguredSecurityGraphView(context.Background()); err != nil {
+	if view, err := a.currentConfiguredSecurityGraphView(a.backgroundContext()); err != nil {
 		return nil, err
 	} else if view != nil {
 		return view, nil
@@ -120,7 +120,7 @@ func (a *App) WaitForReadableSecurityGraph(ctx context.Context) *graph.Graph {
 		return nil
 	}
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = a.backgroundContext()
 	}
 	if current := a.currentLiveSecurityGraph(); current != nil {
 		if a.graphReady == nil {

--- a/internal/app/app_init_core.go
+++ b/internal/app/app_init_core.go
@@ -224,7 +224,7 @@ func (a *App) initFindings() {
 	if a.appStateDB != nil {
 		store := findings.NewPostgresStore(a.appStateDB)
 		store.SetSemanticDedup(a.Config.FindingsSemanticDedupEnabled)
-		if err := store.Load(context.Background()); err != nil {
+		if err := store.Load(a.backgroundContext()); err != nil {
 			a.Logger.Warn("failed to load postgres findings store", "error", err)
 		}
 		a.Findings = store
@@ -407,7 +407,7 @@ func (a *App) initCache() {
 
 func (a *App) initTicketing(ctx context.Context) {
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = a.backgroundContext()
 	}
 	a.Ticketing = ticketing.NewService()
 

--- a/internal/app/app_secrets.go
+++ b/internal/app/app_secrets.go
@@ -98,7 +98,7 @@ func (a *App) startSecretsReloader(parent context.Context) {
 		return
 	}
 	if parent == nil {
-		parent = context.Background()
+		parent = a.backgroundContext()
 	}
 
 	ctx, cancel := context.WithCancel(parent)
@@ -144,7 +144,7 @@ func (a *App) ReloadSecrets(ctx context.Context) error {
 		return fmt.Errorf("app is nil")
 	}
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = a.backgroundContext()
 	}
 
 	a.reloadMu.Lock()
@@ -280,7 +280,7 @@ func (a *App) rebindAgentSessionStore(ctx context.Context, activeSnowflake *snow
 		return
 	}
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = a.backgroundContext()
 	}
 	switch {
 	case a.appStateDB != nil:
@@ -312,7 +312,7 @@ func (a *App) rotateSnowflakeClient(ctx context.Context, cfg *Config) error {
 		return nil
 	}
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = a.backgroundContext()
 	}
 
 	oldClient := a.Snowflake

--- a/internal/app/app_secrets.go
+++ b/internal/app/app_secrets.go
@@ -99,6 +99,8 @@ func (a *App) startSecretsReloader(parent context.Context) {
 	}
 	if parent == nil {
 		parent = a.backgroundContext()
+	} else {
+		parent = backgroundWorkContext(parent)
 	}
 
 	ctx, cancel := context.WithCancel(parent)

--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -802,7 +802,7 @@ func (a *App) initEventCorrelationRefreshLoop(ctx context.Context) {
 		return
 	}
 	if ctx == nil {
-		ctx = context.Background()
+		ctx = a.backgroundContext()
 	}
 	loopCtx, cancel := context.WithCancel(ctx) // #nosec G118 -- cancel is stored on App and invoked by stopEventCorrelationRefreshLoop during shutdown.
 	queue := newEventCorrelationRefreshQueue(a.refreshCurrentEventCorrelations)
@@ -861,7 +861,7 @@ func (a *App) refreshCurrentEventCorrelations(reason string) {
 	}
 	baseCtx := a.graphCtx
 	if baseCtx == nil {
-		baseCtx = context.Background()
+		baseCtx = a.backgroundContext()
 	}
 	var summary graph.EventCorrelationMaterializationSummary
 	_, err := a.MutateSecurityGraphMaybe(baseCtx, func(candidate *graph.Graph) (bool, error) {

--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -803,6 +803,8 @@ func (a *App) initEventCorrelationRefreshLoop(ctx context.Context) {
 	}
 	if ctx == nil {
 		ctx = a.backgroundContext()
+	} else {
+		ctx = backgroundWorkContext(ctx)
 	}
 	loopCtx, cancel := context.WithCancel(ctx) // #nosec G118 -- cancel is stored on App and invoked by stopEventCorrelationRefreshLoop during shutdown.
 	queue := newEventCorrelationRefreshQueue(a.refreshCurrentEventCorrelations)


### PR DESCRIPTION
## Summary
- retain the app root context so background work can inherit values without inheriting cancellation
- route nil-context graph, ticketing, secret, and refresh paths through the derived background context helper
- add a regression test covering value preservation across cancellation

Closes #269
