### PR TITLE
test(internal): cover small utility packages

### DIFF
--- a/internal/autonomous/store_test.go
+++ b/internal/autonomous/store_test.go
@@ -1,0 +1,61 @@
+package autonomous
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSQLiteRunStoreRoundTrip(t *testing.T) {
+	store, err := NewSQLiteRunStore(filepath.Join(t.TempDir(), "autonomous.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteRunStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	run := &RunRecord{
+		ID:           "run-1",
+		WorkflowID:   WorkflowCredentialExposureResponse,
+		WorkflowName: "Credential Exposure Response",
+		Status:       RunStatusAwaitingApproval,
+		Stage:        RunStageAwaitingApproval,
+		RequestedBy:  "alice",
+		SubmittedAt:  now,
+		UpdatedAt:    now,
+		Provider:     "aws",
+	}
+
+	if err := store.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun() error = %v", err)
+	}
+	event, err := store.AppendEvent(context.Background(), run.ID, RunEvent{
+		Status:     run.Status,
+		Stage:      run.Stage,
+		Message:    "awaiting approval",
+		RecordedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+	if event.Sequence == 0 {
+		t.Fatal("expected persisted event sequence")
+	}
+
+	loadedRun, err := store.LoadRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("LoadRun() error = %v", err)
+	}
+	if loadedRun == nil || loadedRun.ID != run.ID || loadedRun.Provider != "aws" {
+		t.Fatalf("unexpected loaded run: %#v", loadedRun)
+	}
+
+	events, err := store.LoadEvents(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("LoadEvents() error = %v", err)
+	}
+	if len(events) != 1 || events[0].Message != "awaiting approval" {
+		t.Fatalf("unexpected loaded events: %#v", events)
+	}
+}

--- a/internal/executions/summary_test.go
+++ b/internal/executions/summary_test.go
@@ -1,0 +1,47 @@
+package executions
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/autonomous"
+	"github.com/writer/cerebro/internal/executionstore"
+)
+
+func TestSummarizeAutonomousWorkflowRun(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	payload, err := json.Marshal(autonomous.RunRecord{
+		ID:           "run-1",
+		WorkflowID:   autonomous.WorkflowCredentialExposureResponse,
+		RequestedBy:  "alice",
+		SecretNodeID: "secret:demo",
+		Provider:     "aws",
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	summary, ok, err := summarizeAutonomousWorkflowRun(executionstore.RunEnvelope{
+		Namespace:   executionstore.NamespaceAutonomousWorkflow,
+		RunID:       "run-1",
+		Kind:        string(autonomous.WorkflowCredentialExposureResponse),
+		Status:      string(autonomous.RunStatusAwaitingApproval),
+		Stage:       string(autonomous.RunStageAwaitingApproval),
+		SubmittedAt: now,
+		UpdatedAt:   now,
+		Payload:     payload,
+	})
+	if err != nil {
+		t.Fatalf("summarizeAutonomousWorkflowRun() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("expected autonomous workflow summary to be included")
+	}
+	if summary.DisplayName != "workflow:credential_exposure_response:secret:demo" {
+		t.Fatalf("DisplayName = %q", summary.DisplayName)
+	}
+	if summary.ScopeID != "secret:demo" || summary.RequestedBy != "alice" || summary.Provider != "aws" {
+		t.Fatalf("unexpected summary: %#v", summary)
+	}
+}

--- a/internal/jsonl/file_sink_test.go
+++ b/internal/jsonl/file_sink_test.go
@@ -1,0 +1,35 @@
+package jsonl
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFileSinkWriteAppendsJSONLines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events", "out.jsonl")
+	sink, err := NewFileSink(path)
+	if err != nil {
+		t.Fatalf("NewFileSink() error = %v", err)
+	}
+
+	if err := sink.Write(map[string]any{"id": 1}); err != nil {
+		t.Fatalf("first Write() error = %v", err)
+	}
+	if err := sink.Write(map[string]any{"id": 2}); err != nil {
+		t.Fatalf("second Write() error = %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 JSONL records, got %d from %q", len(lines), string(content))
+	}
+	if !strings.Contains(lines[0], `"id":1`) || !strings.Contains(lines[1], `"id":2`) {
+		t.Fatalf("unexpected JSONL contents: %q", string(content))
+	}
+}

--- a/internal/runtime/adapters/tags_test.go
+++ b/internal/runtime/adapters/tags_test.go
@@ -1,0 +1,14 @@
+package adapters
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCompactTagsTrimsDeduplicatesAndPreservesOrder(t *testing.T) {
+	got := CompactTags(" alpha ", "", "beta", "alpha", "beta", "gamma")
+	want := []string{"alpha", "beta", "gamma"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CompactTags() = %v, want %v", got, want)
+	}
+}

--- a/internal/setutil/strings_test.go
+++ b/internal/setutil/strings_test.go
@@ -1,0 +1,24 @@
+package setutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSortedStringsReturnsStableSortedSlice(t *testing.T) {
+	got := SortedStrings(map[string]struct{}{
+		"charlie": {},
+		"alpha":   {},
+		"bravo":   {},
+	})
+	want := []string{"alpha", "bravo", "charlie"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SortedStrings() = %v, want %v", got, want)
+	}
+}
+
+func TestSortedStringsNilForEmptySet(t *testing.T) {
+	if got := SortedStrings(nil); got != nil {
+		t.Fatalf("SortedStrings(nil) = %v, want nil", got)
+	}
+}

--- a/internal/textutil/nonempty_test.go
+++ b/internal/textutil/nonempty_test.go
@@ -1,0 +1,12 @@
+package textutil
+
+import "testing"
+
+func TestFirstNonEmptyTrimmed(t *testing.T) {
+	if got := FirstNonEmptyTrimmed("   ", "", " alpha ", "beta"); got != "alpha" {
+		t.Fatalf("FirstNonEmptyTrimmed() = %q, want alpha", got)
+	}
+	if got := FirstNonEmptyTrimmed(" ", "\t"); got != "" {
+		t.Fatalf("FirstNonEmptyTrimmed() = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add coverage for autonomous SQLite run-store round trips and autonomous execution summaries
- cover JSONL file sink writes plus small adapter and utility helpers
- raise baseline test coverage for previously untested internal packages

Closes #270
