### PR TITLE
enhance(remediation): explain unsupported terraform delivery

### DIFF
--- a/internal/remediation/terraform.go
+++ b/internal/remediation/terraform.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/writer/cerebro/internal/iacrender"
@@ -61,22 +62,28 @@ type terraformArtifactRendererKey struct {
 	ResourceFamily string
 }
 
-var terraformArtifactRenderers = map[terraformArtifactRendererKey]terraformArtifactRenderer{
-	{
+var (
+	terraformRestrictPublicStorageAccessAWSBucketKey = terraformArtifactRendererKey{
 		ActionType:     ActionRestrictPublicStorageAccess,
 		Provider:       "aws",
 		ResourceFamily: "bucket",
-	}: renderTerraformRestrictPublicStorageAccessActionArtifact,
-	{
+	}
+	terraformEnableBucketDefaultEncryptionAWSBucketKey = terraformArtifactRendererKey{
 		ActionType:     ActionEnableBucketDefaultEncryption,
 		Provider:       "aws",
 		ResourceFamily: "bucket",
-	}: renderTerraformBucketDefaultEncryptionActionArtifact,
-	{
+	}
+	terraformRestrictPublicSecurityGroupIngressAWSSecurityGroupKey = terraformArtifactRendererKey{
 		ActionType:     ActionRestrictPublicSecurityGroupIngress,
 		Provider:       "aws",
 		ResourceFamily: "security_group",
-	}: renderTerraformRestrictPublicSecurityGroupIngressActionArtifact,
+	}
+)
+
+var terraformArtifactRenderers = map[terraformArtifactRendererKey]terraformArtifactRenderer{
+	terraformRestrictPublicStorageAccessAWSBucketKey:               renderTerraformRestrictPublicStorageAccessActionArtifact,
+	terraformEnableBucketDefaultEncryptionAWSBucketKey:             renderTerraformBucketDefaultEncryptionActionArtifact,
+	terraformRestrictPublicSecurityGroupIngressAWSSecurityGroupKey: renderTerraformRestrictPublicSecurityGroupIngressActionArtifact,
 }
 
 func actionDeliveryMode(action Action, execution *Execution, entry CatalogEntry) DeliveryMode {
@@ -425,10 +432,24 @@ func terraformArtifactRendererLookupKey(actionType ActionType, execution *Execut
 func validateTerraformArtifactContext(actionType ActionType, execution *Execution, expectedProvider, expectedResourceFamily string) error {
 	key := terraformArtifactRendererLookupKey(actionType, execution)
 	if expectedProvider != "" && key.Provider != "" && key.Provider != expectedProvider {
-		return fmt.Errorf("terraform delivery for %s is only implemented for %s %ss, got %s", actionType, expectedProvider, expectedResourceFamily, key.Provider)
+		return fmt.Errorf(
+			"terraform delivery for %s is only implemented for %s %ss, got %s; %s",
+			actionType,
+			expectedProvider,
+			expectedResourceFamily,
+			key.Provider,
+			terraformSupportedContextsHelp(actionType),
+		)
 	}
 	if expectedResourceFamily != "" && key.ResourceFamily != "" && key.ResourceFamily != expectedResourceFamily {
-		return fmt.Errorf("terraform delivery for %s is only implemented for %s %ss, got %s", actionType, expectedProvider, expectedResourceFamily, key.ResourceFamily)
+		return fmt.Errorf(
+			"terraform delivery for %s is only implemented for %s %ss, got %s; %s",
+			actionType,
+			expectedProvider,
+			expectedResourceFamily,
+			key.ResourceFamily,
+			terraformSupportedContextsHelp(actionType),
+		)
 	}
 	return nil
 }
@@ -449,20 +470,54 @@ func terraformUnsupportedContextError(actionType ActionType, key terraformArtifa
 	}
 	if len(providers) == 1 && len(resourceFamilies) == 1 {
 		return fmt.Errorf(
-			"terraform delivery for %s is only implemented for %s %ss, got provider=%s resource_family=%s",
+			"terraform delivery for %s is only implemented for %s %ss, got provider=%s resource_family=%s; %s",
 			actionType,
 			firstMapKey(providers),
 			firstMapKey(resourceFamilies),
 			firstNonEmpty(key.Provider, "unknown"),
 			firstNonEmpty(key.ResourceFamily, "unknown"),
+			terraformSupportedContextsHelp(actionType),
 		)
 	}
 	return fmt.Errorf(
-		"terraform delivery is not implemented for %s (provider=%s resource_family=%s)",
+		"terraform delivery is not implemented for %s (provider=%s resource_family=%s); %s",
 		actionType,
 		firstNonEmpty(key.Provider, "unknown"),
 		firstNonEmpty(key.ResourceFamily, "unknown"),
+		terraformSupportedContextsHelp(actionType),
 	)
+}
+
+func terraformSupportedContextsHelp(actionType ActionType) string {
+	supported := terraformSupportedContexts(actionType)
+	if len(supported) == 0 {
+		return "no Terraform delivery combinations are currently supported; consider remote_apply or manual remediation"
+	}
+	return fmt.Sprintf(
+		"supported combinations: %s; consider remote_apply or manual remediation",
+		strings.Join(supported, ", "),
+	)
+}
+
+func terraformSupportedContexts(actionType ActionType) []string {
+	candidates := []terraformArtifactRendererKey{
+		terraformRestrictPublicStorageAccessAWSBucketKey,
+		terraformEnableBucketDefaultEncryptionAWSBucketKey,
+		terraformRestrictPublicSecurityGroupIngressAWSSecurityGroupKey,
+	}
+	supported := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.ActionType != actionType {
+			continue
+		}
+		supported = append(supported, fmt.Sprintf(
+			"%s/%s",
+			firstNonEmpty(candidate.Provider, "unknown"),
+			firstNonEmpty(candidate.ResourceFamily, "unknown"),
+		))
+	}
+	sort.Strings(supported)
+	return supported
 }
 
 func firstMapKey(values map[string]struct{}) string {

--- a/internal/remediation/terraform.go
+++ b/internal/remediation/terraform.go
@@ -491,10 +491,10 @@ func terraformUnsupportedContextError(actionType ActionType, key terraformArtifa
 func terraformSupportedContextsHelp(actionType ActionType) string {
 	supported := terraformSupportedContexts(actionType)
 	if len(supported) == 0 {
-		return "no Terraform delivery combinations are currently supported; consider remote_apply or manual remediation"
+		return "no Terraform delivery combinations are currently supported; use manual remediation"
 	}
 	return fmt.Sprintf(
-		"supported combinations: %s; consider remote_apply or manual remediation",
+		"supported combinations: %s; use manual remediation when Terraform delivery is unavailable",
 		strings.Join(supported, ", "),
 	)
 }

--- a/internal/remediation/terraform_test.go
+++ b/internal/remediation/terraform_test.go
@@ -160,7 +160,7 @@ func TestRenderTerraformArtifact_EnableBucketDefaultEncryptionRejectsNonAWSProvi
 	if !strings.Contains(err.Error(), "supported combinations: aws/bucket") {
 		t.Fatalf("expected supported combinations in error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "consider remote_apply or manual remediation") {
+	if !strings.Contains(err.Error(), "use manual remediation when Terraform delivery is unavailable") {
 		t.Fatalf("expected remediation guidance in error, got %v", err)
 	}
 }
@@ -185,7 +185,7 @@ func TestRenderTerraformArtifact_RestrictPublicSecurityGroupIngressUnsupportedRe
 	if !strings.Contains(err.Error(), "supported combinations: aws/security_group") {
 		t.Fatalf("expected supported combinations in error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "consider remote_apply or manual remediation") {
+	if !strings.Contains(err.Error(), "use manual remediation when Terraform delivery is unavailable") {
 		t.Fatalf("expected remediation guidance in error, got %v", err)
 	}
 }

--- a/internal/remediation/terraform_test.go
+++ b/internal/remediation/terraform_test.go
@@ -157,6 +157,37 @@ func TestRenderTerraformArtifact_EnableBucketDefaultEncryptionRejectsNonAWSProvi
 	if !strings.Contains(err.Error(), "only implemented for aws buckets") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if !strings.Contains(err.Error(), "supported combinations: aws/bucket") {
+		t.Fatalf("expected supported combinations in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "consider remote_apply or manual remediation") {
+		t.Fatalf("expected remediation guidance in error, got %v", err)
+	}
+}
+
+func TestRenderTerraformArtifact_RestrictPublicSecurityGroupIngressUnsupportedResourceListsSupportedCombinations(t *testing.T) {
+	_, err := renderTerraformArtifact(Action{
+		Type: ActionRestrictPublicSecurityGroupIngress,
+	}, &Execution{
+		TriggerData: map[string]any{
+			"resource_id":       "bucket:audit-logs",
+			"resource_type":     "bucket",
+			"resource_platform": "aws",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected unsupported resource family rejection")
+		return
+	}
+	if !strings.Contains(err.Error(), "provider=aws resource_family=bucket") {
+		t.Fatalf("expected provider/resource family details, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "supported combinations: aws/security_group") {
+		t.Fatalf("expected supported combinations in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "consider remote_apply or manual remediation") {
+		t.Fatalf("expected remediation guidance in error, got %v", err)
+	}
 }
 
 func TestRenderTerraformBucketDefaultEncryptionArtifact_UsesIaCStateIDModulePath(t *testing.T) {


### PR DESCRIPTION
## Summary
- enrich unsupported Terraform remediation errors with the supported provider/resource-family combinations for that action
- add explicit guidance to fall back to remote_apply or manual remediation when Terraform delivery is unavailable
- cover both provider mismatch and unsupported resource-family paths with regression tests

Closes #271
