### PR TITLE
fix(api): sanitize sync response error details

### DIFF
--- a/internal/api/server_handlers_sync.go
+++ b/internal/api/server_handlers_sync.go
@@ -333,7 +333,7 @@ func (s *Server) syncAWS(w http.ResponseWriter, r *http.Request) {
 		"relationships_extracted": result.RelationshipsExtracted,
 	}
 	if result.RelationshipsSkippedReason != "" {
-		resp["relationships_skipped_reason"] = result.RelationshipsSkippedReason
+		resp["relationships_skipped_reason"] = s.sanitizeSyncRelationshipsSkippedReason("aws", result.RelationshipsSkippedReason)
 	}
 	if graphUpdate := result.GraphUpdate; graphUpdate != nil {
 		resp["graph_update"] = graphUpdate
@@ -508,7 +508,7 @@ func (s *Server) syncAWSOrg(w http.ResponseWriter, r *http.Request) {
 		"results":  result.Results,
 	}
 	if len(result.AccountErrors) > 0 {
-		resp["account_errors"] = result.AccountErrors
+		resp["account_errors"] = s.sanitizeSyncAccountErrors("aws_org", result.AccountErrors)
 	}
 	if graphUpdate := result.GraphUpdate; graphUpdate != nil {
 		resp["graph_update"] = graphUpdate
@@ -737,13 +737,62 @@ func (s *Server) syncGCP(w http.ResponseWriter, r *http.Request) {
 		"relationships_extracted": result.RelationshipsExtracted,
 	}
 	if result.RelationshipsSkippedReason != "" {
-		resp["relationships_skipped_reason"] = result.RelationshipsSkippedReason
+		resp["relationships_skipped_reason"] = s.sanitizeSyncRelationshipsSkippedReason("gcp", result.RelationshipsSkippedReason)
 	}
 	if graphUpdate := result.GraphUpdate; graphUpdate != nil {
 		resp["graph_update"] = graphUpdate
 	}
 
 	s.json(w, http.StatusOK, resp)
+}
+
+func (s *Server) sanitizeSyncRelationshipsSkippedReason(provider, reason string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return ""
+	}
+	if !strings.HasPrefix(strings.ToLower(reason), "relationship extraction failed:") {
+		return reason
+	}
+	if s != nil && s.app != nil && s.app.Logger != nil {
+		s.app.Logger.Warn("post-sync relationship extraction failed", "provider", provider, "details", reason)
+	}
+	return "relationship extraction failed"
+}
+
+func (s *Server) sanitizeSyncAccountErrors(provider string, accountErrors []string) []string {
+	if len(accountErrors) == 0 {
+		return nil
+	}
+	raw := make([]string, 0, len(accountErrors))
+	sanitized := make([]string, 0, len(accountErrors))
+	for _, accountError := range accountErrors {
+		accountError = strings.TrimSpace(accountError)
+		if accountError == "" {
+			continue
+		}
+		raw = append(raw, accountError)
+		sanitized = append(sanitized, sanitizeSyncAccountError(accountError))
+	}
+	if len(raw) > 0 && s != nil && s.app != nil && s.app.Logger != nil {
+		s.app.Logger.Warn("organization sync completed with account errors", "provider", provider, "details", raw)
+	}
+	return sanitized
+}
+
+func sanitizeSyncAccountError(accountError string) string {
+	accountError = strings.TrimSpace(accountError)
+	if accountError == "" {
+		return "account sync failed"
+	}
+	prefix, _, found := strings.Cut(accountError, ":")
+	if found {
+		prefix = strings.TrimSpace(prefix)
+		if strings.HasPrefix(prefix, "account ") {
+			return prefix + ": sync failed"
+		}
+	}
+	return "account sync failed"
 }
 
 func appendGCPPermissionUsageRequestOptions(options []nativesync.GCPEngineOption, lookbackDays int, removalThresholdDays int, targetGroups []string) []nativesync.GCPEngineOption {

--- a/internal/api/server_handlers_sync.go
+++ b/internal/api/server_handlers_sync.go
@@ -329,7 +329,7 @@ func (s *Server) syncAWS(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]interface{}{
 		"provider":                "aws",
 		"validate":                req.Validate,
-		"results":                 result.Results,
+		"results":                 s.sanitizeSyncResults("aws", result.Results),
 		"relationships_extracted": result.RelationshipsExtracted,
 	}
 	if result.RelationshipsSkippedReason != "" {
@@ -505,7 +505,7 @@ func (s *Server) syncAWSOrg(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]interface{}{
 		"provider": "aws_org",
 		"validate": req.Validate,
-		"results":  result.Results,
+		"results":  s.sanitizeSyncResults("aws_org", result.Results),
 	}
 	if len(result.AccountErrors) > 0 {
 		resp["account_errors"] = s.sanitizeSyncAccountErrors("aws_org", result.AccountErrors)
@@ -733,7 +733,7 @@ func (s *Server) syncGCP(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]interface{}{
 		"provider":                "gcp",
 		"validate":                req.Validate,
-		"results":                 result.Results,
+		"results":                 s.sanitizeSyncResults("gcp", result.Results),
 		"relationships_extracted": result.RelationshipsExtracted,
 	}
 	if result.RelationshipsSkippedReason != "" {
@@ -793,6 +793,26 @@ func sanitizeSyncAccountError(accountError string) string {
 		}
 	}
 	return "account sync failed"
+}
+
+func (s *Server) sanitizeSyncResults(provider string, results []nativesync.SyncResult) []nativesync.SyncResult {
+	if len(results) == 0 {
+		return nil
+	}
+	sanitized := make([]nativesync.SyncResult, len(results))
+	raw := make([]string, 0)
+	for i, result := range results {
+		sanitized[i] = result
+		if strings.TrimSpace(result.Error) == "" {
+			continue
+		}
+		raw = append(raw, fmt.Sprintf("table=%s region=%s error=%s", result.Table, result.Region, result.Error))
+		sanitized[i].Error = "sync failed"
+	}
+	if len(raw) > 0 && s != nil && s.app != nil && s.app.Logger != nil {
+		s.app.Logger.Warn("sync completed with table errors", "provider", provider, "details", raw)
+	}
+	return sanitized
 }
 
 func appendGCPPermissionUsageRequestOptions(options []nativesync.GCPEngineOption, lookbackDays int, removalThresholdDays int, targetGroups []string) []nativesync.GCPEngineOption {

--- a/internal/api/server_handlers_sync_test.go
+++ b/internal/api/server_handlers_sync_test.go
@@ -407,6 +407,54 @@ func TestSyncAWS_SanitizesRelationshipExtractionFailureReason(t *testing.T) {
 	}
 }
 
+func TestSyncAWS_SanitizesTableLevelErrorsInResults(t *testing.T) {
+	s := newTestServer(t)
+	setSnowflakeWarehouseDeps(s.app)
+
+	var logs bytes.Buffer
+	s.app.Logger = slog.New(slog.NewTextHandler(&logs, nil))
+
+	originalRun := runAWSSyncWithOptions
+	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
+
+	rawError := "SQL compilation error: Object 'RAW.INTERNAL_ONLY' does not exist"
+	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+		return &awsSyncOutcome{
+			Results: []nativesync.SyncResult{{
+				Table:  "aws_s3_buckets",
+				Region: "us-east-1",
+				Error:  rawError,
+			}},
+		}, nil
+	}
+
+	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
+		"region": "us-east-1",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	results, ok := body["results"].([]interface{})
+	if !ok || len(results) != 1 {
+		t.Fatalf("expected single sync result, got %#v", body["results"])
+	}
+	result, ok := results[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected sync result object, got %#v", results[0])
+	}
+	if result["Error"] != "sync failed" {
+		t.Fatalf("expected sanitized sync error, got %#v", result["Error"])
+	}
+	if strings.Contains(w.Body.String(), rawError) {
+		t.Fatalf("expected response to omit raw sync error, got %s", w.Body.String())
+	}
+	if !strings.Contains(logs.String(), rawError) {
+		t.Fatalf("expected logs to retain raw sync error, got %s", logs.String())
+	}
+}
+
 func TestSyncAWS_AppliesIncrementalGraphChangesAfterSync(t *testing.T) {
 	s := newTestServer(t)
 	setSnowflakeWarehouseDeps(s.app)
@@ -923,6 +971,53 @@ func TestSyncAWSOrg_SanitizesAccountErrorsInResponse(t *testing.T) {
 	}
 }
 
+func TestSyncAWSOrg_SanitizesTableLevelErrorsInResults(t *testing.T) {
+	s := newTestServer(t)
+	setSnowflakeWarehouseDeps(s.app)
+
+	var logs bytes.Buffer
+	s.app.Logger = slog.New(slog.NewTextHandler(&logs, nil))
+
+	originalRun := runAWSOrgSyncWithOptions
+	t.Cleanup(func() { runAWSOrgSyncWithOptions = originalRun })
+
+	rawError := "AccessDenied: cannot query table RAW.SECRET_BUCKETS"
+	runAWSOrgSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error) {
+		return &awsOrgSyncOutcome{
+			Results: []nativesync.SyncResult{{
+				Table: "aws_iam_users",
+				Error: rawError,
+			}},
+		}, nil
+	}
+
+	w := do(t, s, http.MethodPost, "/api/v1/sync/aws-org", map[string]interface{}{
+		"org_role": "OrganizationAccountAccessRole",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	results, ok := body["results"].([]interface{})
+	if !ok || len(results) != 1 {
+		t.Fatalf("expected single sync result, got %#v", body["results"])
+	}
+	result, ok := results[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected sync result object, got %#v", results[0])
+	}
+	if result["Error"] != "sync failed" {
+		t.Fatalf("expected sanitized sync error, got %#v", result["Error"])
+	}
+	if strings.Contains(w.Body.String(), rawError) {
+		t.Fatalf("expected response to omit raw sync error, got %s", w.Body.String())
+	}
+	if !strings.Contains(logs.String(), rawError) {
+		t.Fatalf("expected logs to retain raw sync error, got %s", logs.String())
+	}
+}
+
 func TestSyncGCP_RequiresSnowflake(t *testing.T) {
 	s := newTestServer(t)
 
@@ -1044,6 +1139,53 @@ func TestSyncGCP_SanitizesRelationshipExtractionFailureReason(t *testing.T) {
 	}
 	if !strings.Contains(logs.String(), rawReason) {
 		t.Fatalf("expected logs to retain raw extraction failure, got %s", logs.String())
+	}
+}
+
+func TestSyncGCP_SanitizesTableLevelErrorsInResults(t *testing.T) {
+	s := newTestServer(t)
+	setSnowflakeWarehouseDeps(s.app)
+
+	var logs bytes.Buffer
+	s.app.Logger = slog.New(slog.NewTextHandler(&logs, nil))
+
+	originalRun := runGCPSyncWithOptions
+	t.Cleanup(func() { runGCPSyncWithOptions = originalRun })
+
+	rawError := "permission denied reading gs://internal-only-bucket"
+	runGCPSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req gcpSyncRequest) (*gcpSyncOutcome, error) {
+		return &gcpSyncOutcome{
+			Results: []nativesync.SyncResult{{
+				Table: "gcp_compute_instances",
+				Error: rawError,
+			}},
+		}, nil
+	}
+
+	w := do(t, s, http.MethodPost, "/api/v1/sync/gcp", map[string]interface{}{
+		"project": "proj-123",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	results, ok := body["results"].([]interface{})
+	if !ok || len(results) != 1 {
+		t.Fatalf("expected single sync result, got %#v", body["results"])
+	}
+	result, ok := results[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected sync result object, got %#v", results[0])
+	}
+	if result["Error"] != "sync failed" {
+		t.Fatalf("expected sanitized sync error, got %#v", result["Error"])
+	}
+	if strings.Contains(w.Body.String(), rawError) {
+		t.Fatalf("expected response to omit raw sync error, got %s", w.Body.String())
+	}
+	if !strings.Contains(logs.String(), rawError) {
+		t.Fatalf("expected logs to retain raw sync error, got %s", logs.String())
 	}
 }
 

--- a/internal/api/server_handlers_sync_test.go
+++ b/internal/api/server_handlers_sync_test.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -365,6 +367,43 @@ func TestSyncAWS_UsesRequestOptions(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), `"relationships_extracted":11`) {
 		t.Fatalf("expected relationships count in response body, got %s", w.Body.String())
+	}
+}
+
+func TestSyncAWS_SanitizesRelationshipExtractionFailureReason(t *testing.T) {
+	s := newTestServer(t)
+	setSnowflakeWarehouseDeps(s.app)
+
+	var logs bytes.Buffer
+	s.app.Logger = slog.New(slog.NewTextHandler(&logs, nil))
+
+	originalRun := runAWSSyncWithOptions
+	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
+
+	rawReason := "relationship extraction failed: sqlite open /tmp/cerebro-secrets.db: permission denied"
+	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+		return &awsSyncOutcome{
+			Results:                    []nativesync.SyncResult{{Table: "aws_s3_buckets", Synced: 1}},
+			RelationshipsSkippedReason: rawReason,
+		}, nil
+	}
+
+	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
+		"region": "us-east-1",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	if body["relationships_skipped_reason"] != "relationship extraction failed" {
+		t.Fatalf("expected sanitized relationship skip reason, got %#v", body["relationships_skipped_reason"])
+	}
+	if strings.Contains(w.Body.String(), "/tmp/cerebro-secrets.db") {
+		t.Fatalf("expected response to omit raw extraction details, got %s", w.Body.String())
+	}
+	if !strings.Contains(logs.String(), rawReason) {
+		t.Fatalf("expected logs to retain raw extraction failure, got %s", logs.String())
 	}
 }
 
@@ -838,8 +877,49 @@ func TestSyncAWSOrg_UsesRequestOptions(t *testing.T) {
 	if !strings.Contains(w.Body.String(), `"provider":"aws_org"`) {
 		t.Fatalf("expected provider in response body, got %s", w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), `"account_errors":["account 999999999999: access denied"]`) {
+	if !strings.Contains(w.Body.String(), `"account_errors":["account 999999999999: sync failed"]`) {
 		t.Fatalf("expected account errors in response body, got %s", w.Body.String())
+	}
+}
+
+func TestSyncAWSOrg_SanitizesAccountErrorsInResponse(t *testing.T) {
+	s := newTestServer(t)
+	setSnowflakeWarehouseDeps(s.app)
+
+	var logs bytes.Buffer
+	s.app.Logger = slog.New(slog.NewTextHandler(&logs, nil))
+
+	originalRun := runAWSOrgSyncWithOptions
+	t.Cleanup(func() { runAWSOrgSyncWithOptions = originalRun })
+
+	rawError := "account 999999999999: AccessDenied: failed to assume role arn:aws:iam::999999999999:role/OrganizationAccountAccessRole"
+	runAWSOrgSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error) {
+		return &awsOrgSyncOutcome{
+			Results:       []nativesync.SyncResult{{Table: "aws_iam_users", Synced: 4}},
+			AccountErrors: []string{rawError},
+		}, nil
+	}
+
+	w := do(t, s, http.MethodPost, "/api/v1/sync/aws-org", map[string]interface{}{
+		"org_role": "OrganizationAccountAccessRole",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	accountErrors, ok := body["account_errors"].([]interface{})
+	if !ok || len(accountErrors) != 1 {
+		t.Fatalf("expected single sanitized account error, got %#v", body["account_errors"])
+	}
+	if accountErrors[0] != "account 999999999999: sync failed" {
+		t.Fatalf("expected sanitized account error, got %#v", accountErrors[0])
+	}
+	if strings.Contains(w.Body.String(), "OrganizationAccountAccessRole") {
+		t.Fatalf("expected response to omit raw account error details, got %s", w.Body.String())
+	}
+	if !strings.Contains(logs.String(), rawError) {
+		t.Fatalf("expected logs to retain raw account error, got %s", logs.String())
 	}
 }
 
@@ -927,6 +1007,43 @@ func TestSyncGCP_UsesRequestOptions(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), `"relationships_extracted":8`) {
 		t.Fatalf("expected relationships count in response body, got %s", w.Body.String())
+	}
+}
+
+func TestSyncGCP_SanitizesRelationshipExtractionFailureReason(t *testing.T) {
+	s := newTestServer(t)
+	setSnowflakeWarehouseDeps(s.app)
+
+	var logs bytes.Buffer
+	s.app.Logger = slog.New(slog.NewTextHandler(&logs, nil))
+
+	originalRun := runGCPSyncWithOptions
+	t.Cleanup(func() { runGCPSyncWithOptions = originalRun })
+
+	rawReason := "relationship extraction failed: googleapi: could not read gs://internal-artifacts/private"
+	runGCPSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req gcpSyncRequest) (*gcpSyncOutcome, error) {
+		return &gcpSyncOutcome{
+			Results:                    []nativesync.SyncResult{{Table: "gcp_compute_instances", Synced: 6}},
+			RelationshipsSkippedReason: rawReason,
+		}, nil
+	}
+
+	w := do(t, s, http.MethodPost, "/api/v1/sync/gcp", map[string]interface{}{
+		"project": "proj-123",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := decodeJSON(t, w)
+	if body["relationships_skipped_reason"] != "relationship extraction failed" {
+		t.Fatalf("expected sanitized relationship skip reason, got %#v", body["relationships_skipped_reason"])
+	}
+	if strings.Contains(w.Body.String(), "gs://internal-artifacts/private") {
+		t.Fatalf("expected response to omit raw extraction details, got %s", w.Body.String())
+	}
+	if !strings.Contains(logs.String(), rawReason) {
+		t.Fatalf("expected logs to retain raw extraction failure, got %s", logs.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- sanitize relationship extraction failure reasons before returning sync responses
- sanitize AWS org account error details while logging the raw failures server-side
- add regression coverage for AWS, AWS org, and GCP sync sanitization paths

## Testing
- go test ./internal/api -run 'TestSync(AWS|AWSOrg|GCP)_(UsesRequestOptions|SanitizesRelationshipExtractionFailureReason|SanitizesAccountErrorsInResponse)$'
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #267