### PR TITLE
fix(iacrender): return template render errors

### DIFF
--- a/internal/connectors/render.go
+++ b/internal/connectors/render.go
@@ -55,10 +55,22 @@ func RenderAWSBundle(opts AWSRenderOptions) (Bundle, error) {
 		"ManagedTagKey": textutil.FirstNonEmptyTrimmed(strings.TrimSpace(opts.ManagedTagKey), "CerebroManagedBy"),
 		"ManagedTagVal": textutil.FirstNonEmptyTrimmed(strings.TrimSpace(opts.ManagedTagVal), "cerebro"),
 	}
+	stackset, err := renderTemplate("aws/stackset.yaml", awsStackSetTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
+	parameters, err := renderJSONTemplate("aws/parameters.example.json", awsParametersTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
+	readme, err := renderTemplate("aws/README.md", awsReadmeTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
 	files := []GeneratedFile{
-		{Path: filepath.ToSlash("aws/stackset.yaml"), Content: renderTemplate(awsStackSetTemplate, data)},
-		{Path: filepath.ToSlash("aws/parameters.example.json"), Content: renderJSONTemplate(awsParametersTemplate, data)},
-		{Path: filepath.ToSlash("aws/README.md"), Content: renderTemplate(awsReadmeTemplate, data)},
+		{Path: filepath.ToSlash("aws/stackset.yaml"), Content: stackset},
+		{Path: filepath.ToSlash("aws/parameters.example.json"), Content: parameters},
+		{Path: filepath.ToSlash("aws/README.md"), Content: readme},
 	}
 	return Bundle{Provider: ProviderAWS, Summary: "AWS cross-account snapshot connector bundle", Files: files}, nil
 }
@@ -75,11 +87,27 @@ func RenderGCPBundle(opts GCPRenderOptions) (Bundle, error) {
 		"WorkloadIdentityAudience":   textutil.FirstNonEmptyTrimmed(strings.TrimSpace(opts.WorkloadIdentityAudience), "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/cerebro-workload-pool/providers/cerebro-oidc"),
 		"PrincipalSubject":           textutil.FirstNonEmptyTrimmed(strings.TrimSpace(opts.PrincipalSubject), "repo:your-org/your-repo:ref:refs/heads/main"),
 	}
+	mainTF, err := renderTemplate("gcp/main.tf", gcpMainTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
+	variablesTF, err := renderTemplate("gcp/variables.tf", gcpVariablesTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
+	outputsTF, err := renderTemplate("gcp/outputs.tf", gcpOutputsTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
+	readme, err := renderTemplate("gcp/README.md", gcpReadmeTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
 	files := []GeneratedFile{
-		{Path: filepath.ToSlash("gcp/main.tf"), Content: renderTemplate(gcpMainTemplate, data)},
-		{Path: filepath.ToSlash("gcp/variables.tf"), Content: renderTemplate(gcpVariablesTemplate, data)},
-		{Path: filepath.ToSlash("gcp/outputs.tf"), Content: renderTemplate(gcpOutputsTemplate, data)},
-		{Path: filepath.ToSlash("gcp/README.md"), Content: renderTemplate(gcpReadmeTemplate, data)},
+		{Path: filepath.ToSlash("gcp/main.tf"), Content: mainTF},
+		{Path: filepath.ToSlash("gcp/variables.tf"), Content: variablesTF},
+		{Path: filepath.ToSlash("gcp/outputs.tf"), Content: outputsTF},
+		{Path: filepath.ToSlash("gcp/README.md"), Content: readme},
 	}
 	return Bundle{Provider: ProviderGCP, Summary: "GCP snapshot connector Terraform bundle", Files: files}, nil
 }
@@ -92,23 +120,47 @@ func RenderAzureBundle(opts AzureRenderOptions) (Bundle, error) {
 		"PrincipalDisplayName": textutil.FirstNonEmptyTrimmed(strings.TrimSpace(opts.PrincipalDisplayName), "cerebro-workload-scan"),
 		"CustomRoleName":       textutil.FirstNonEmptyTrimmed(strings.TrimSpace(opts.CustomRoleName), "Cerebro Snapshot Operator"),
 	}
+	armTemplate, err := renderJSONTemplate("azure/arm-template.json", azureARMTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
+	parameters, err := renderJSONTemplate("azure/parameters.example.json", azureARMParametersTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
+	mainTF, err := renderTemplate("azure/main.tf", azureMainTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
+	variablesTF, err := renderTemplate("azure/variables.tf", azureVariablesTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
+	outputsTF, err := renderTemplate("azure/outputs.tf", azureOutputsTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
+	readme, err := renderTemplate("azure/README.md", azureReadmeTemplate, data)
+	if err != nil {
+		return Bundle{}, err
+	}
 	files := []GeneratedFile{
-		{Path: filepath.ToSlash("azure/arm-template.json"), Content: renderJSONTemplate(azureARMTemplate, data)},
-		{Path: filepath.ToSlash("azure/parameters.example.json"), Content: renderJSONTemplate(azureARMParametersTemplate, data)},
-		{Path: filepath.ToSlash("azure/main.tf"), Content: renderTemplate(azureMainTemplate, data)},
-		{Path: filepath.ToSlash("azure/variables.tf"), Content: renderTemplate(azureVariablesTemplate, data)},
-		{Path: filepath.ToSlash("azure/outputs.tf"), Content: renderTemplate(azureOutputsTemplate, data)},
-		{Path: filepath.ToSlash("azure/README.md"), Content: renderTemplate(azureReadmeTemplate, data)},
+		{Path: filepath.ToSlash("azure/arm-template.json"), Content: armTemplate},
+		{Path: filepath.ToSlash("azure/parameters.example.json"), Content: parameters},
+		{Path: filepath.ToSlash("azure/main.tf"), Content: mainTF},
+		{Path: filepath.ToSlash("azure/variables.tf"), Content: variablesTF},
+		{Path: filepath.ToSlash("azure/outputs.tf"), Content: outputsTF},
+		{Path: filepath.ToSlash("azure/README.md"), Content: readme},
 	}
 	return Bundle{Provider: ProviderAzure, Summary: "Azure snapshot connector ARM + Terraform bundle", Files: files}, nil
 }
 
-func renderTemplate(src string, data any) string {
-	return iacrender.RenderTemplate("bundle", src, data)
+func renderTemplate(name, src string, data any) (string, error) {
+	return iacrender.RenderTemplate(name, src, data)
 }
 
-func renderJSONTemplate(src string, data any) string {
-	return iacrender.RenderTemplate("bundle", src, data)
+func renderJSONTemplate(name, src string, data any) (string, error) {
+	return iacrender.RenderTemplate(name, src, data)
 }
 
 const awsStackSetTemplate = `AWSTemplateFormatVersion: '2010-09-09'

--- a/internal/iacrender/template.go
+++ b/internal/iacrender/template.go
@@ -8,13 +8,16 @@ import (
 	"text/template"
 )
 
-func RenderTemplate(name, src string, data any) string {
-	tmpl := template.Must(template.New(name).Funcs(FuncMap()).Parse(src))
+func RenderTemplate(name, src string, data any) (string, error) {
+	tmpl, err := template.New(name).Funcs(FuncMap()).Parse(src)
+	if err != nil {
+		return "", fmt.Errorf("parse template %s: %w", name, err)
+	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
-		panic(err)
+		return "", fmt.Errorf("execute template %s: %w", name, err)
 	}
-	return strings.TrimLeft(buf.String(), "\n")
+	return strings.TrimLeft(buf.String(), "\n"), nil
 }
 
 func FuncMap() template.FuncMap {
@@ -25,19 +28,20 @@ func FuncMap() template.FuncMap {
 	}
 }
 
-func JSONString(value any) string {
+func JSONString(value any) (string, error) {
 	encoded, err := json.Marshal(value)
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("marshal template JSON value: %w", err)
 	}
-	return string(encoded)
+	return string(encoded), nil
 }
 
 func HCLString(value any) string {
 	text := AsString(value)
 	text = strings.ReplaceAll(text, "${", "$${")
 	text = strings.ReplaceAll(text, "%{", "%%{")
-	return JSONString(text)
+	encoded, _ := json.Marshal(text)
+	return string(encoded)
 }
 
 func AsString(value any) string {

--- a/internal/iacrender/template_test.go
+++ b/internal/iacrender/template_test.go
@@ -1,11 +1,47 @@
 package iacrender
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestHCLStringEscapesInterpolationAndDirectives(t *testing.T) {
 	got := HCLString(`repo:${danger} %{ if danger }`)
 	want := `"repo:$${danger} %%{ if danger }"`
 	if got != want {
 		t.Fatalf("HCLString() = %q, want %q", got, want)
+	}
+}
+
+func TestJSONStringReturnsErrorOnUnsupportedValue(t *testing.T) {
+	_, err := JSONString(make(chan int))
+	if err == nil {
+		t.Fatal("expected JSONString to return an error")
+	}
+	if !strings.Contains(err.Error(), "marshal template JSON value") {
+		t.Fatalf("expected wrapped marshal error, got %v", err)
+	}
+}
+
+func TestRenderTemplateReturnsParseError(t *testing.T) {
+	_, err := RenderTemplate("broken", `{{ if .Value }}`, map[string]string{"Value": "x"})
+	if err == nil {
+		t.Fatal("expected template parse error")
+	}
+	if !strings.Contains(err.Error(), "parse template broken") {
+		t.Fatalf("expected parse context in error, got %v", err)
+	}
+}
+
+func TestRenderTemplateReturnsExecutionError(t *testing.T) {
+	_, err := RenderTemplate("broken", `{{ jsonString .Value }}`, map[string]any{"Value": make(chan int)})
+	if err == nil {
+		t.Fatal("expected template execution error")
+	}
+	if !strings.Contains(err.Error(), "execute template broken") {
+		t.Fatalf("expected execution context in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "unsupported type") {
+		t.Fatalf("expected marshal cause in error, got %v", err)
 	}
 }

--- a/internal/remediation/terraform.go
+++ b/internal/remediation/terraform.go
@@ -163,12 +163,19 @@ func renderTerraformPublicStorageAccessArtifact(execution *Execution) (Terraform
 		resourceName = existingName
 	}
 	path := terraformArtifactPath(execution, "cerebro_s3_bucket_public_access_block_"+terraformIdentifier(bucketName)+".tf")
-	content := iacrender.RenderTemplate("terraform", terraformBucketPublicAccessBlockTemplate, map[string]string{
+	content, err := iacrender.RenderTemplate("terraform_s3_bucket_public_access_block", terraformBucketPublicAccessBlockTemplate, map[string]string{
 		"BucketReference":   terraformBucketArgument(execution, bucketName),
 		"ResourceName":      resourceName,
 		"ExistingIaCFile":   iacFile,
 		"ExistingIaCModule": iacModule,
 	})
+	if err != nil {
+		return TerraformArtifact{}, fmt.Errorf("render public access block terraform artifact: %w", err)
+	}
+	stateReconciliation, err := terraformStateReconciliation(address, bucketName)
+	if err != nil {
+		return TerraformArtifact{}, fmt.Errorf("build public access block terraform reconciliation: %w", err)
+	}
 
 	notes := []string{
 		"Run terraform plan before apply.",
@@ -195,7 +202,7 @@ func renderTerraformPublicStorageAccessArtifact(execution *Execution) (Terraform
 		IaCFile:             iacFile,
 		IaCModule:           iacModule,
 		IaCStateID:          iacStateID,
-		StateReconciliation: terraformStateReconciliation(address, bucketName),
+		StateReconciliation: stateReconciliation,
 	}, nil
 }
 
@@ -226,7 +233,7 @@ func renderTerraformBucketDefaultEncryptionArtifact(execution *Execution, sseAlg
 		resourceName = existingName
 	}
 	path := terraformArtifactPath(execution, "cerebro_s3_bucket_default_encryption_"+terraformIdentifier(bucketName)+".tf")
-	content := iacrender.RenderTemplate("terraform", terraformBucketDefaultEncryptionTemplate, map[string]string{
+	content, err := iacrender.RenderTemplate("terraform_s3_bucket_default_encryption", terraformBucketDefaultEncryptionTemplate, map[string]string{
 		"BucketReference":   terraformBucketArgument(execution, bucketName),
 		"ResourceName":      resourceName,
 		"SSEAlgorithm":      iacrender.HCLString(firstNonEmpty(strings.TrimSpace(sseAlgorithm), "AES256")),
@@ -237,6 +244,13 @@ func renderTerraformBucketDefaultEncryptionArtifact(execution *Execution, sseAlg
 		"ExistingIaCFile":   iacFile,
 		"ExistingIaCModule": iacModule,
 	})
+	if err != nil {
+		return TerraformArtifact{}, fmt.Errorf("render default encryption terraform artifact: %w", err)
+	}
+	stateReconciliation, err := terraformStateReconciliation(address, bucketName)
+	if err != nil {
+		return TerraformArtifact{}, fmt.Errorf("build default encryption terraform reconciliation: %w", err)
+	}
 
 	notes := []string{
 		"Run terraform plan before apply.",
@@ -262,7 +276,7 @@ func renderTerraformBucketDefaultEncryptionArtifact(execution *Execution, sseAlg
 		IaCFile:             iacFile,
 		IaCModule:           iacModule,
 		IaCStateID:          iacStateID,
-		StateReconciliation: terraformStateReconciliation(address, bucketName),
+		StateReconciliation: stateReconciliation,
 	}, nil
 }
 
@@ -276,9 +290,12 @@ func renderTerraformRestrictPublicSecurityGroupIngressArtifact(execution *Execut
 	}
 	resourceName := terraformRuleArtifactName(execution)
 	path := terraformArtifactPath(execution, "cerebro_remove_public_ingress_"+resourceName+".tf")
-	content := iacrender.RenderTemplate("terraform", terraformRemoveManagedResourceTemplate, map[string]string{
+	content, err := iacrender.RenderTemplate("terraform_remove_managed_resource", terraformRemoveManagedResourceTemplate, map[string]string{
 		"ResourceAddress": ruleAddress,
 	})
+	if err != nil {
+		return TerraformArtifact{}, fmt.Errorf("render removed resource terraform artifact: %w", err)
+	}
 	iacFile := ""
 	iacModule := ""
 	iacStateID := ""
@@ -341,11 +358,15 @@ func terraformArtifactMetadata(artifact TerraformArtifact) map[string]any {
 	})
 }
 
-func terraformStateReconciliation(address, importID string) *TerraformStateReconciliation {
+func terraformStateReconciliation(address, importID string) (*TerraformStateReconciliation, error) {
 	address = strings.TrimSpace(address)
 	importID = strings.TrimSpace(importID)
 	if address == "" || importID == "" {
-		return nil
+		return nil, nil
+	}
+	importBlock, err := terraformImportBlock(address, importID)
+	if err != nil {
+		return nil, err
 	}
 	return &TerraformStateReconciliation{
 		StateShow: terraformCommand("terraform", "state", "show", address),
@@ -353,10 +374,10 @@ func terraformStateReconciliation(address, importID string) *TerraformStateRecon
 		Imports: []TerraformImportInstruction{{
 			To:      address,
 			ID:      importID,
-			HCL:     terraformImportBlock(address, importID),
+			HCL:     importBlock,
 			Command: terraformCommand("terraform", "import", address, importID),
 		}},
-	}
+	}, nil
 }
 
 func terraformRemovalStateReconciliation(address string) *TerraformStateReconciliation {
@@ -407,11 +428,15 @@ func terraformCommandMetadata(command TerraformCommand) map[string]any {
 	})
 }
 
-func terraformImportBlock(address, importID string) string {
-	return strings.TrimSpace(iacrender.RenderTemplate("terraform", terraformImportBlockTemplate, map[string]string{
+func terraformImportBlock(address, importID string) (string, error) {
+	content, err := iacrender.RenderTemplate("terraform_import_block", terraformImportBlockTemplate, map[string]string{
 		"To": address,
 		"ID": iacrender.HCLString(strings.TrimSpace(importID)),
-	}))
+	})
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(content), nil
 }
 
 func terraformArtifactRendererLookupKey(actionType ActionType, execution *Execution) terraformArtifactRendererKey {


### PR DESCRIPTION
## Summary
- replace iacrender panics with wrapped parse, execute, and JSON marshal errors
- propagate template rendering failures through remediation and connector bundle callers
- add regression coverage for parse, execution, and marshal failures

## Testing
- go test ./internal/iacrender ./internal/connectors ./internal/remediation
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #319