### PR TITLE
fix(app): synchronize available table snapshots

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -208,6 +208,7 @@ type App struct {
 	apiCredentials                     atomic.Value // map[string]apiauth.Credential
 	apiCredentialStore                 *apiauth.ManagedCredentialStore
 	secretsLoader                      secretsLoader
+	availableTablesMu                  sync.RWMutex
 
 	// Cached table list from Snowflake (shared by graph builder + policy coverage)
 	AvailableTables []string

--- a/internal/app/app_available_tables.go
+++ b/internal/app/app_available_tables.go
@@ -1,0 +1,20 @@
+package app
+
+func (a *App) SetAvailableTables(tables []string) {
+	if a == nil {
+		return
+	}
+	cloned := append([]string(nil), tables...)
+	a.availableTablesMu.Lock()
+	a.AvailableTables = cloned
+	a.availableTablesMu.Unlock()
+}
+
+func (a *App) AvailableTablesSnapshot() []string {
+	if a == nil {
+		return nil
+	}
+	a.availableTablesMu.RLock()
+	defer a.availableTablesMu.RUnlock()
+	return append([]string(nil), a.AvailableTables...)
+}

--- a/internal/app/app_available_tables_test.go
+++ b/internal/app/app_available_tables_test.go
@@ -1,0 +1,22 @@
+package app
+
+import "testing"
+
+func TestAvailableTablesSnapshotClonesCachedTables(t *testing.T) {
+	application := &App{}
+
+	source := []string{"aws_s3_buckets", "aws_iam_roles"}
+	application.SetAvailableTables(source)
+	source[0] = "mutated"
+
+	snapshot := application.AvailableTablesSnapshot()
+	if len(snapshot) != 2 || snapshot[0] != "aws_s3_buckets" || snapshot[1] != "aws_iam_roles" {
+		t.Fatalf("unexpected snapshot contents: %#v", snapshot)
+	}
+
+	snapshot[1] = "changed"
+	fresh := application.AvailableTablesSnapshot()
+	if fresh[1] != "aws_iam_roles" {
+		t.Fatalf("expected cached tables to remain unchanged, got %#v", fresh)
+	}
+}

--- a/internal/app/app_scan_scheduler.go
+++ b/internal/app/app_scan_scheduler.go
@@ -688,10 +688,10 @@ func (a *App) resolveScanTables(ctx context.Context) []string {
 		tables = splitTables(a.Config.ScanTables)
 	}
 
-	available := a.AvailableTables
+	available := a.AvailableTablesSnapshot()
 	if a.Warehouse != nil {
 		if refreshed, err := a.Warehouse.ListAvailableTables(ctx); err == nil {
-			a.AvailableTables = refreshed
+			a.SetAvailableTables(refreshed)
 			available = refreshed
 		} else if ctx.Err() == nil {
 			a.Logger.Warn("failed to refresh available tables", "error", err)

--- a/internal/app/app_storage_graph.go
+++ b/internal/app/app_storage_graph.go
@@ -120,7 +120,7 @@ func (a *App) initAvailableTables(ctx context.Context) {
 		a.Logger.Warn("failed to list available tables", "error", err)
 		return
 	}
-	a.AvailableTables = tables
+	a.SetAvailableTables(tables)
 }
 
 // validatePolicyCoverage checks that required tables exist for loaded policies
@@ -131,13 +131,14 @@ func (a *App) validatePolicyCoverage(_ context.Context) error {
 		return nil
 	}
 
-	if a.AvailableTables == nil {
+	availableTables := a.AvailableTablesSnapshot()
+	if availableTables == nil {
 		a.Logger.Warn("skipping policy coverage validation - table list not available")
 		return nil
 	}
 
-	report := a.Policy.CoverageReport(a.AvailableTables)
-	orphanTables := policy.GlobalMappingRegistry().OrphanNativeTables(a.AvailableTables)
+	report := a.Policy.CoverageReport(availableTables)
+	orphanTables := policy.GlobalMappingRegistry().OrphanNativeTables(availableTables)
 	if report.TotalPolicies == 0 {
 		if len(orphanTables) == 0 {
 			return nil

--- a/internal/app/query_policy_scan.go
+++ b/internal/app/query_policy_scan.go
@@ -168,10 +168,10 @@ func (a *App) queryPolicyRowLimit() int {
 }
 
 func (a *App) queryPolicyAllowlist(ctx context.Context) map[string]struct{} {
-	tables := a.AvailableTables
+	tables := a.AvailableTablesSnapshot()
 	if len(tables) == 0 && a.Warehouse != nil {
 		if refreshed, err := a.Warehouse.ListAvailableTables(ctx); err == nil {
-			a.AvailableTables = refreshed
+			a.SetAvailableTables(refreshed)
 			tables = refreshed
 		} else if ctx.Err() == nil && a.Logger != nil {
 			a.Logger.Warn("failed to refresh query policy allowlist tables", "error", err)

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -165,13 +165,13 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	// Build set of available tables for filtering
 	availableSet := make(map[string]bool)
-	availableTables := application.AvailableTables
+	availableTables := application.AvailableTablesSnapshot()
 	if localMode {
 		availableTables = sortedDatasetTables(localDataset)
-		application.AvailableTables = append([]string(nil), availableTables...)
+		application.SetAvailableTables(availableTables)
 	} else if application.Snowflake != nil {
 		if tables, err := application.Snowflake.ListAvailableTables(ctx); err == nil {
-			application.AvailableTables = tables
+			application.SetAvailableTables(tables)
 			availableTables = tables
 		} else {
 			Warning("Failed to list available tables: %v", err)
@@ -482,8 +482,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 	slowTables := scanner.FilterSlowTables(tableProfiles, tuning.ProfileSlowThreshold)
 
 	var coverageReport *policy.CoverageReport
-	if application.AvailableTables != nil && application.Policy != nil {
-		report := application.Policy.CoverageReport(application.AvailableTables)
+	availableTables = application.AvailableTablesSnapshot()
+	if availableTables != nil && application.Policy != nil {
+		report := application.Policy.CoverageReport(availableTables)
 		coverageReport = &report
 	}
 

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -973,10 +973,10 @@ func runPostSyncScan(ctx context.Context, tableFilter []string) error {
 		return fmt.Errorf("warehouse not configured")
 	}
 
-	availableTables := application.AvailableTables
+	availableTables := application.AvailableTablesSnapshot()
 	if application.Warehouse != nil {
 		if refreshed, err := application.Warehouse.ListAvailableTables(ctx); err == nil {
-			application.AvailableTables = refreshed
+			application.SetAvailableTables(refreshed)
 			availableTables = refreshed
 		} else {
 			Warning("Failed to list available tables: %v", err)


### PR DESCRIPTION
## Summary
- guard cached available-table access with an App mutex and copy-on-read/write helpers
- route app and CLI refresh paths through synchronized available-table snapshots
- add regression coverage for snapshot cloning semantics

## Testing
- go test ./internal/app ./internal/cli
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #322