### PR TITLE
fix(app): remove dead compliance wiring

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -49,7 +49,6 @@ import (
 	"github.com/writer/cerebro/internal/attackpath"
 	"github.com/writer/cerebro/internal/auth"
 	"github.com/writer/cerebro/internal/cache"
-	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/dspm"
 	"github.com/writer/cerebro/internal/events"
 	"github.com/writer/cerebro/internal/executionstore"
@@ -149,7 +148,6 @@ type App struct {
 	// New services
 	RBAC                *auth.RBAC
 	ThreatIntel         *threatintel.ThreatIntelService
-	Compliance          *compliance.ComplianceReport
 	Health              *health.Registry
 	Lineage             *lineage.LineageMapper
 	Remediation         *remediation.Engine

--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -83,7 +83,6 @@ func (a *App) initPhase2a(ctx context.Context) error {
 		initOnlySubsystem("webhooks", func(context.Context) { a.initWebhooks() }),
 		initOnlySubsystem("notifications", func(context.Context) { a.initNotifications() }),
 		initOnlySubsystem("rbac", func(context.Context) { a.initRBAC() }),
-		initOnlySubsystem("compliance", func(context.Context) { a.initCompliance() }),
 		initOnlySubsystem("health", func(context.Context) { a.initHealth() }),
 		initOnlySubsystem("lineage", func(context.Context) { a.initLineage() }),
 		a.runtimeSubsystem(),

--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/sync/errgroup"
 )
 
 type concurrentInitTask struct {
@@ -63,62 +61,56 @@ func (a *App) initPhase1(ctx context.Context) error {
 }
 
 func (a *App) initPhase2a(ctx context.Context) error {
+	appState := a.appStateSubsystem()
+	graphSubsystem := a.graphSubsystem()
+
 	a.initExecutionStore()
-	a.initGraphPersistenceStore()
-	if err := runInitErrorStep("app_state_db", func() error { return a.initAppStateDB(ctx) }); err != nil {
+	if err := appState.Init(ctx); err != nil {
 		return err
 	}
 	if err := runInitErrorStep("legacy_snowflake", func() error { return a.initLegacySnowflake(ctx) }); err != nil {
 		a.Logger.Warn("legacy snowflake initialization failed", "error", err)
 	}
-	if err := runInitErrorStep("graph_store_backend", func() error { return a.initConfiguredSecurityGraphStore(ctx) }); err != nil {
-		return err
-	}
-	if err := runInitErrorStep("graph_writer_lease", func() error { return a.initGraphWriterLease(ctx) }); err != nil {
-		return err
-	}
-	if err := runInitErrorStep("entity_search_backend", func() error { return a.initEntitySearchBackend(ctx) }); err != nil {
+	if err := graphSubsystem.Init(ctx); err != nil {
 		return err
 	}
 
-	if err := runInitTasksConcurrently(ctx, []concurrentInitTask{
-		{name: "cache", run: func(context.Context) { a.initCache() }},
-		{name: "ticketing", run: func(taskCtx context.Context) { a.initTicketing(taskCtx) }},
-		{name: "identity", run: func(context.Context) { a.initIdentity() }},
-		{name: "attackpath", run: func(context.Context) { a.initAttackPath() }},
-		{name: "webhooks", run: func(context.Context) { a.initWebhooks() }},
-		{name: "notifications", run: func(context.Context) { a.initNotifications() }},
-		{name: "rbac", run: func(context.Context) { a.initRBAC() }},
-		{name: "compliance", run: func(context.Context) { a.initCompliance() }},
-		{name: "health", run: func(context.Context) { a.initHealth() }},
-		{name: "lineage", run: func(context.Context) { a.initLineage() }},
-		{name: "runtime", run: func(context.Context) { a.initRuntime() }},
-		{name: "findings", run: func(context.Context) { a.initFindings() }},
-		{name: "providers", run: func(taskCtx context.Context) { a.initProviders(taskCtx) }},
-		{name: "scheduler", run: func(taskCtx context.Context) { a.initScheduler(taskCtx) }},
-		{name: "repositories", run: func(context.Context) { a.initRepositories() }},
-		{name: "snowflake_findings", run: func(taskCtx context.Context) { a.initSnowflakeFindings(taskCtx) }},
-		{name: "scan_watermarks", run: func(taskCtx context.Context) { a.initScanWatermarks(taskCtx) }},
-		{name: "threatintel", run: func(context.Context) { a.initThreatIntel(ctx) }},
-		{name: "available_tables", run: func(taskCtx context.Context) { a.initAvailableTables(taskCtx) }},
-	}); err != nil {
+	if err := runSubsystemInitConcurrently(ctx,
+		initOnlySubsystem("cache", func(context.Context) { a.initCache() }),
+		initOnlySubsystem("ticketing", func(taskCtx context.Context) { a.initTicketing(taskCtx) }),
+		initOnlySubsystem("identity", func(context.Context) { a.initIdentity() }),
+		initOnlySubsystem("attackpath", func(context.Context) { a.initAttackPath() }),
+		initOnlySubsystem("webhooks", func(context.Context) { a.initWebhooks() }),
+		initOnlySubsystem("notifications", func(context.Context) { a.initNotifications() }),
+		initOnlySubsystem("rbac", func(context.Context) { a.initRBAC() }),
+		initOnlySubsystem("compliance", func(context.Context) { a.initCompliance() }),
+		initOnlySubsystem("health", func(context.Context) { a.initHealth() }),
+		initOnlySubsystem("lineage", func(context.Context) { a.initLineage() }),
+		a.runtimeSubsystem(),
+		initOnlySubsystem("findings", func(context.Context) { a.initFindings() }),
+		initOnlySubsystem("providers", func(taskCtx context.Context) { a.initProviders(taskCtx) }),
+		initOnlySubsystem("scheduler", func(taskCtx context.Context) { a.initScheduler(taskCtx) }),
+		initOnlySubsystem("snowflake_findings", func(taskCtx context.Context) { a.initSnowflakeFindings(taskCtx) }),
+		initOnlySubsystem("scan_watermarks", func(taskCtx context.Context) { a.initScanWatermarks(taskCtx) }),
+		initOnlySubsystem("threatintel", func(context.Context) { a.initThreatIntel(ctx) }),
+		initOnlySubsystem("available_tables", func(taskCtx context.Context) { a.initAvailableTables(taskCtx) }),
+	); err != nil {
 		return fmt.Errorf("phase 2a init failed: %w", err)
 	}
-	if err := runInitErrorStep("app_state_migration", func() error { return a.migrateAppState(ctx) }); err != nil {
+	if err := appState.Start(ctx); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (a *App) initPhase2b(ctx context.Context) error {
-	if err := runInitTasksConcurrently(ctx, []concurrentInitTask{
-		{name: "remediation", run: func(context.Context) { a.initRemediation() }},
-		{name: "agents", run: func(taskCtx context.Context) { a.initAgents(taskCtx) }},
-	}); err != nil {
+	remediation := a.remediationSubsystem()
+	if err := runSubsystemInitConcurrently(ctx, remediation, a.agentsSubsystem()); err != nil {
 		return fmt.Errorf("phase 2b init failed: %w", err)
 	}
-	a.startEventRemediation(ctx)
-	a.startEventAlertRouting(ctx)
+	if err := runSubsystemStartSequentially(ctx, remediation, a.eventsSubsystem()); err != nil {
+		return fmt.Errorf("phase 2b start failed: %w", err)
+	}
 	return nil
 }
 
@@ -127,24 +119,17 @@ func (a *App) initPhase3() {
 }
 
 func (a *App) initPhase4(ctx context.Context) error {
-	a.initSecurityGraph(ctx)
-	a.initTapGraphConsumer(ctx)
+	if err := runSubsystemStartSequentially(ctx, a.graphSubsystem()); err != nil {
+		return err
+	}
 	return a.validatePolicyCoverage(ctx)
 }
 
 func runInitTasksConcurrently(ctx context.Context, tasks []concurrentInitTask) error {
-	if len(tasks) == 0 {
-		return nil
-	}
-
-	g, gctx := errgroup.WithContext(ctx)
+	subsystems := make([]initSubsystem, 0, len(tasks))
 	for _, task := range tasks {
 		task := task
-		g.Go(func() error {
-			return runInitStep(task.name, func() {
-				task.run(gctx)
-			})
-		})
+		subsystems = append(subsystems, initOnlySubsystem(task.name, task.run))
 	}
-	return g.Wait()
+	return runSubsystemInitConcurrently(ctx, subsystems...)
 }

--- a/internal/app/app_lifecycle.go
+++ b/internal/app/app_lifecycle.go
@@ -1,0 +1,146 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type namedSubsystem interface {
+	Name() string
+}
+
+type initSubsystem interface {
+	namedSubsystem
+	Init(context.Context) error
+}
+
+type startSubsystem interface {
+	namedSubsystem
+	Start(context.Context) error
+}
+
+type closeSubsystem interface {
+	namedSubsystem
+	Close(context.Context) error
+}
+
+type lifecycleSubsystem struct {
+	name  string
+	init  func(context.Context) error
+	start func(context.Context) error
+	close func(context.Context) error
+}
+
+func (s lifecycleSubsystem) Name() string {
+	name := strings.TrimSpace(s.name)
+	if name == "" {
+		return "subsystem"
+	}
+	return name
+}
+
+func (s lifecycleSubsystem) Init(ctx context.Context) error {
+	if s.init == nil {
+		return nil
+	}
+	return s.init(ctx)
+}
+
+func (s lifecycleSubsystem) Start(ctx context.Context) error {
+	if s.start == nil {
+		return nil
+	}
+	return s.start(ctx)
+}
+
+func (s lifecycleSubsystem) Close(ctx context.Context) error {
+	if s.close == nil {
+		return nil
+	}
+	return s.close(ctx)
+}
+
+func runLifecycleErrorStep(phase, name string, fn func() error) (err error) {
+	phase = strings.TrimSpace(phase)
+	if phase == "" {
+		phase = "lifecycle"
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = "subsystem"
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%s %s panic: %v", name, phase, r)
+		}
+	}()
+	return fn()
+}
+
+func runSubsystemInitConcurrently(ctx context.Context, subsystems ...initSubsystem) error {
+	if len(subsystems) == 0 {
+		return nil
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	for _, subsystem := range subsystems {
+		subsystem := subsystem
+		if subsystem == nil {
+			continue
+		}
+		g.Go(func() error {
+			return runLifecycleErrorStep("init", subsystem.Name(), func() error {
+				return subsystem.Init(gctx)
+			})
+		})
+	}
+	return g.Wait()
+}
+
+func runSubsystemStartSequentially(ctx context.Context, subsystems ...startSubsystem) error {
+	for _, subsystem := range subsystems {
+		if subsystem == nil {
+			continue
+		}
+		if err := runLifecycleErrorStep("start", subsystem.Name(), func() error {
+			return subsystem.Start(ctx)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runSubsystemCloseSequentially(ctx context.Context, subsystems ...closeSubsystem) []error {
+	if len(subsystems) == 0 {
+		return nil
+	}
+
+	var errs []error
+	for _, subsystem := range subsystems {
+		if subsystem == nil {
+			continue
+		}
+		if err := runLifecycleErrorStep("close", subsystem.Name(), func() error {
+			return subsystem.Close(ctx)
+		}); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func initOnlySubsystem(name string, init func(context.Context)) lifecycleSubsystem {
+	return lifecycleSubsystem{
+		name: name,
+		init: func(ctx context.Context) error {
+			if init != nil {
+				init(ctx)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/app/app_lifecycle_test.go
+++ b/internal/app/app_lifecycle_test.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRunSubsystemInitConcurrently_RunsAllSubsystems(t *testing.T) {
+	var called atomic.Int32
+
+	err := runSubsystemInitConcurrently(context.Background(),
+		initOnlySubsystem("cache", func(context.Context) { called.Add(1) }),
+		initOnlySubsystem("runtime", func(context.Context) { called.Add(1) }),
+		initOnlySubsystem("events", func(context.Context) { called.Add(1) }),
+	)
+	if err != nil {
+		t.Fatalf("runSubsystemInitConcurrently() error = %v", err)
+	}
+	if got, want := called.Load(), int32(3); got != want {
+		t.Fatalf("subsystem init count = %d, want %d", got, want)
+	}
+}
+
+func TestRunSubsystemInitConcurrently_PropagatesError(t *testing.T) {
+	want := errors.New("boom")
+
+	err := runSubsystemInitConcurrently(context.Background(),
+		lifecycleSubsystem{
+			name: "graph",
+			init: func(context.Context) error {
+				return want
+			},
+		},
+	)
+	if !errors.Is(err, want) {
+		t.Fatalf("runSubsystemInitConcurrently() error = %v, want wrapped %v", err, want)
+	}
+}
+
+func TestRunSubsystemStartSequentially_RunsInOrder(t *testing.T) {
+	var order []string
+
+	err := runSubsystemStartSequentially(context.Background(),
+		lifecycleSubsystem{
+			name: "remediation",
+			start: func(context.Context) error {
+				order = append(order, "remediation")
+				return nil
+			},
+		},
+		lifecycleSubsystem{
+			name: "events",
+			start: func(context.Context) error {
+				order = append(order, "events")
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("runSubsystemStartSequentially() error = %v", err)
+	}
+	if want := []string{"remediation", "events"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("start order = %v, want %v", order, want)
+	}
+}
+
+func TestRunSubsystemCloseSequentially_CollectsErrors(t *testing.T) {
+	errs := runSubsystemCloseSequentially(context.Background(),
+		lifecycleSubsystem{
+			name: "agents",
+			close: func(context.Context) error {
+				return errors.New("close failed")
+			},
+		},
+	)
+	if len(errs) != 1 {
+		t.Fatalf("close errors len = %d, want 1", len(errs))
+	}
+	if errs[0] == nil || errs[0].Error() == "" {
+		t.Fatalf("expected non-empty close error, got %v", errs[0])
+	}
+}

--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -100,11 +100,6 @@ func (a *App) initThreatIntel(ctx context.Context) {
 	}()
 }
 
-func (a *App) initCompliance() {
-	// Compliance reports are generated on-demand, not stored
-	a.Logger.Info("compliance service ready")
-}
-
 func (a *App) initHealth() {
 	a.Health = health.NewRegistry()
 

--- a/internal/app/app_service_groups.go
+++ b/internal/app/app_service_groups.go
@@ -5,7 +5,6 @@ import (
 	"github.com/writer/cerebro/internal/attackpath"
 	"github.com/writer/cerebro/internal/auth"
 	"github.com/writer/cerebro/internal/cache"
-	"github.com/writer/cerebro/internal/compliance"
 	"github.com/writer/cerebro/internal/dspm"
 	"github.com/writer/cerebro/internal/events"
 	"github.com/writer/cerebro/internal/findings"
@@ -59,7 +58,6 @@ type FeatureServices struct {
 type SecurityServices struct {
 	RBAC                *auth.RBAC
 	ThreatIntel         *threatintel.ThreatIntelService
-	Compliance          *compliance.ComplianceReport
 	Health              *health.Registry
 	Lineage             *lineage.LineageMapper
 	Remediation         *remediation.Engine
@@ -114,7 +112,6 @@ func (a *App) SecurityServices() SecurityServices {
 	return SecurityServices{
 		RBAC:                a.RBAC,
 		ThreatIntel:         a.ThreatIntel,
-		Compliance:          a.Compliance,
 		Health:              a.Health,
 		Lineage:             a.Lineage,
 		Remediation:         a.Remediation,

--- a/internal/app/app_subsystem_config.go
+++ b/internal/app/app_subsystem_config.go
@@ -1,0 +1,150 @@
+package app
+
+import (
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/agents"
+	"github.com/writer/cerebro/internal/graph"
+)
+
+// SubsystemConfig provides grouped, subsystem-scoped views over the env-backed
+// top-level app config without changing the external config surface.
+type SubsystemConfig struct {
+	Agents   AgentConfig
+	Runtime  RuntimeConfig
+	Graph    GraphConfig
+	AppState AppStateConfig
+	Events   EventConfig
+}
+
+type AgentConfig struct {
+	AnthropicAPIKey string
+	OpenAIAPIKey    string
+	GitHubToken     string
+	GitLabToken     string
+	GitLabBaseURL   string
+	RemoteTools     agents.RemoteToolProviderConfig
+	ToolPublisher   agents.ToolPublisherConfig
+}
+
+func (c AgentConfig) HasModelProvider() bool {
+	return strings.TrimSpace(c.AnthropicAPIKey) != "" || strings.TrimSpace(c.OpenAIAPIKey) != ""
+}
+
+func (c AgentConfig) RemoteToolingEnabled() bool {
+	return c.RemoteTools.Enabled || c.ToolPublisher.Enabled
+}
+
+type RuntimeConfig struct {
+	ExecutionStoreFile string
+}
+
+type GraphConfig struct {
+	SnapshotPath                 string
+	SnapshotMaxRetained          int
+	StoreBackend                 graph.StoreBackend
+	SearchBackend                graph.EntitySearchBackendType
+	SchemaValidationMode         string
+	PropertyHistoryMaxEntries    int
+	PropertyHistoryTTL           time.Duration
+	WriterLeaseEnabled           bool
+	WriterLeaseName              string
+	WriterLeaseOwnerID           string
+	WriterLeaseTTL               time.Duration
+	WriterLeaseHeartbeat         time.Duration
+	MigrateLegacyActivityOnStart bool
+}
+
+type AppStateConfig struct {
+	JobDatabaseURL       string
+	WarehouseBackend     string
+	WarehousePostgresDSN string
+}
+
+func (c AppStateConfig) DatabaseURL() string {
+	if dsn := strings.TrimSpace(c.JobDatabaseURL); dsn != "" {
+		return dsn
+	}
+	if strings.EqualFold(strings.TrimSpace(c.WarehouseBackend), "postgres") {
+		return strings.TrimSpace(c.WarehousePostgresDSN)
+	}
+	return ""
+}
+
+type EventConfig struct {
+	NATSJetStreamEnabled     bool
+	NATSConsumerEnabled      bool
+	NATSConsumerSubjects     []string
+	NATSConsumerDurable      string
+	NATSConsumerDrainTimeout time.Duration
+	AlertRouterEnabled       bool
+	AlertRouterConfigPath    string
+	AlertRouterNotifyPrefix  string
+}
+
+func (c EventConfig) AlertRoutingEnabled() bool {
+	return c.AlertRouterEnabled && c.NATSJetStreamEnabled
+}
+
+func (c EventConfig) TapGraphConsumerEnabled() bool {
+	return c.NATSConsumerEnabled
+}
+
+func (c *Config) BuildSubsystemConfig() SubsystemConfig {
+	if c == nil {
+		return SubsystemConfig{}
+	}
+
+	return SubsystemConfig{
+		Agents: AgentConfig{
+			AnthropicAPIKey: c.AnthropicAPIKey,
+			OpenAIAPIKey:    c.OpenAIAPIKey,
+			GitHubToken:     c.GitHubToken,
+			GitLabToken:     c.GitLabToken,
+			GitLabBaseURL:   c.GitLabBaseURL,
+			RemoteTools:     remoteToolProviderConfigFromConfig(c),
+			ToolPublisher:   toolPublisherConfigFromConfig(c),
+		},
+		Runtime: RuntimeConfig{
+			ExecutionStoreFile: c.ExecutionStoreFile,
+		},
+		Graph: GraphConfig{
+			SnapshotPath:                 c.GraphSnapshotPath,
+			SnapshotMaxRetained:          c.GraphSnapshotMaxRetained,
+			StoreBackend:                 c.graphStoreBackend(),
+			SearchBackend:                c.graphSearchBackend(),
+			SchemaValidationMode:         c.GraphSchemaValidationMode,
+			PropertyHistoryMaxEntries:    c.GraphPropertyHistoryMaxEntries,
+			PropertyHistoryTTL:           c.GraphPropertyHistoryTTL,
+			WriterLeaseEnabled:           c.GraphWriterLeaseEnabled,
+			WriterLeaseName:              c.GraphWriterLeaseName,
+			WriterLeaseOwnerID:           c.GraphWriterLeaseOwnerID,
+			WriterLeaseTTL:               c.GraphWriterLeaseTTL,
+			WriterLeaseHeartbeat:         c.GraphWriterLeaseHeartbeat,
+			MigrateLegacyActivityOnStart: c.GraphMigrateLegacyActivityOnStart,
+		},
+		AppState: AppStateConfig{
+			JobDatabaseURL:       c.JobDatabaseURL,
+			WarehouseBackend:     c.WarehouseBackend,
+			WarehousePostgresDSN: c.WarehousePostgresDSN,
+		},
+		Events: EventConfig{
+			NATSJetStreamEnabled:     c.NATSJetStreamEnabled,
+			NATSConsumerEnabled:      c.NATSConsumerEnabled,
+			NATSConsumerSubjects:     append([]string(nil), c.NATSConsumerSubjects...),
+			NATSConsumerDurable:      c.NATSConsumerDurable,
+			NATSConsumerDrainTimeout: c.NATSConsumerDrainTimeout,
+			AlertRouterEnabled:       c.AlertRouterEnabled,
+			AlertRouterConfigPath:    c.AlertRouterConfigPath,
+			AlertRouterNotifyPrefix:  c.AlertRouterNotifyPrefix,
+		},
+	}
+}
+
+func (a *App) subsystemConfig() SubsystemConfig {
+	if a == nil || a.Config == nil {
+		return SubsystemConfig{}
+	}
+	return a.Config.BuildSubsystemConfig()
+}

--- a/internal/app/app_subsystem_config_test.go
+++ b/internal/app/app_subsystem_config_test.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBuildSubsystemConfig_GroupsSubsystemViews(t *testing.T) {
+	cfg := &Config{
+		AnthropicAPIKey:                   "anthropic-key",
+		GitHubToken:                       "github-token",
+		GitLabToken:                       "gitlab-token",
+		GitLabBaseURL:                     "https://gitlab.example.com",
+		AgentRemoteToolsEnabled:           true,
+		AgentToolPublisherEnabled:         true,
+		GraphSnapshotPath:                 "/tmp/graph",
+		GraphSnapshotMaxRetained:          7,
+		GraphStoreBackend:                 "sqlite",
+		GraphSearchBackend:                "opensearch",
+		GraphSchemaValidationMode:         "strict",
+		GraphPropertyHistoryMaxEntries:    42,
+		GraphPropertyHistoryTTL:           15 * time.Minute,
+		GraphWriterLeaseEnabled:           true,
+		GraphWriterLeaseName:              "writer-lease",
+		GraphWriterLeaseOwnerID:           "writer-a",
+		GraphWriterLeaseTTL:               30 * time.Second,
+		GraphWriterLeaseHeartbeat:         10 * time.Second,
+		GraphMigrateLegacyActivityOnStart: true,
+		JobDatabaseURL:                    "postgres://jobs",
+		ExecutionStoreFile:                "/tmp/executions.db",
+		NATSJetStreamEnabled:              true,
+		NATSConsumerEnabled:               true,
+		NATSConsumerSubjects:              []string{"graph.events", "graph.rebuilds"},
+		NATSConsumerDurable:               "graph-worker",
+		NATSConsumerDrainTimeout:          12 * time.Second,
+		AlertRouterEnabled:                true,
+		AlertRouterConfigPath:             "/tmp/alert-router.yaml",
+		AlertRouterNotifyPrefix:           "ensemble.notify",
+	}
+
+	subsystems := cfg.BuildSubsystemConfig()
+
+	if !subsystems.Agents.HasModelProvider() {
+		t.Fatal("expected agent config to report a configured model provider")
+	}
+	if !subsystems.Agents.RemoteToolingEnabled() {
+		t.Fatal("expected agent config to report remote tooling enabled")
+	}
+	if got, want := subsystems.Runtime.ExecutionStoreFile, cfg.ExecutionStoreFile; got != want {
+		t.Fatalf("runtime execution store file = %q, want %q", got, want)
+	}
+	if got, want := subsystems.AppState.DatabaseURL(), cfg.JobDatabaseURL; got != want {
+		t.Fatalf("appstate database url = %q, want %q", got, want)
+	}
+	if got, want := subsystems.Graph.SnapshotPath, cfg.GraphSnapshotPath; got != want {
+		t.Fatalf("graph snapshot path = %q, want %q", got, want)
+	}
+	if got, want := subsystems.Graph.PropertyHistoryTTL, cfg.GraphPropertyHistoryTTL; got != want {
+		t.Fatalf("graph history ttl = %s, want %s", got, want)
+	}
+	if !subsystems.Events.AlertRoutingEnabled() {
+		t.Fatal("expected alert routing to be enabled when JetStream is enabled")
+	}
+	if !subsystems.Events.TapGraphConsumerEnabled() {
+		t.Fatal("expected tap graph consumer to be enabled")
+	}
+	if got, want := subsystems.Events.NATSConsumerDurable, cfg.NATSConsumerDurable; got != want {
+		t.Fatalf("tap durable = %q, want %q", got, want)
+	}
+	if got, want := subsystems.Events.NATSConsumerSubjects, cfg.NATSConsumerSubjects; !reflect.DeepEqual(got, want) {
+		t.Fatalf("tap subjects = %v, want %v", got, want)
+	}
+
+	subsystems.Events.NATSConsumerSubjects[0] = "changed"
+	if cfg.NATSConsumerSubjects[0] != "graph.events" {
+		t.Fatal("expected event subjects to be copied when building subsystem config")
+	}
+}
+
+func TestAppStateConfigDatabaseURLFallsBackToWarehousePostgresDSN(t *testing.T) {
+	cfg := AppStateConfig{
+		WarehouseBackend:     "postgres",
+		WarehousePostgresDSN: "postgres://warehouse",
+	}
+
+	if got, want := cfg.DatabaseURL(), "postgres://warehouse"; got != want {
+		t.Fatalf("DatabaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestEventConfigAlertRoutingEnabledRequiresJetStream(t *testing.T) {
+	cfg := EventConfig{
+		NATSJetStreamEnabled: false,
+		AlertRouterEnabled:   true,
+	}
+
+	if cfg.AlertRoutingEnabled() {
+		t.Fatal("expected alert routing to require JetStream")
+	}
+}

--- a/internal/app/app_subsystems.go
+++ b/internal/app/app_subsystems.go
@@ -1,0 +1,194 @@
+package app
+
+import "context"
+
+type appStateLifecycle struct {
+	app *App
+	cfg AppStateConfig
+}
+
+func (a *App) appStateSubsystem() appStateLifecycle {
+	return appStateLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().AppState,
+	}
+}
+
+func (s appStateLifecycle) Name() string {
+	return "appstate"
+}
+
+func (s appStateLifecycle) Init(ctx context.Context) error {
+	if s.app == nil || s.cfg.DatabaseURL() == "" {
+		return nil
+	}
+	return runInitErrorStep("app_state_db", func() error {
+		return s.app.initAppStateDB(ctx)
+	})
+}
+
+func (s appStateLifecycle) Start(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initRepositories()
+	if s.cfg.DatabaseURL() == "" {
+		return nil
+	}
+	return runInitErrorStep("app_state_migration", func() error {
+		return s.app.migrateAppState(ctx)
+	})
+}
+
+type agentsLifecycle struct {
+	app *App
+	cfg AgentConfig
+}
+
+func (a *App) agentsSubsystem() agentsLifecycle {
+	return agentsLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().Agents,
+	}
+}
+
+func (s agentsLifecycle) Name() string {
+	return "agents"
+}
+
+func (s agentsLifecycle) Init(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initAgents(ctx)
+	return nil
+}
+
+type runtimeLifecycle struct {
+	app *App
+	cfg RuntimeConfig
+}
+
+func (a *App) runtimeSubsystem() runtimeLifecycle {
+	return runtimeLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().Runtime,
+	}
+}
+
+func (s runtimeLifecycle) Name() string {
+	return "runtime"
+}
+
+func (s runtimeLifecycle) Init(context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initRuntime()
+	return nil
+}
+
+type remediationLifecycle struct {
+	app *App
+}
+
+func (a *App) remediationSubsystem() remediationLifecycle {
+	return remediationLifecycle{app: a}
+}
+
+func (s remediationLifecycle) Name() string {
+	return "remediation"
+}
+
+func (s remediationLifecycle) Init(context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initRemediation()
+	return nil
+}
+
+func (s remediationLifecycle) Start(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.startEventRemediation(ctx)
+	return nil
+}
+
+type graphLifecycle struct {
+	app    *App
+	cfg    GraphConfig
+	events EventConfig
+}
+
+func (a *App) graphSubsystem() graphLifecycle {
+	cfg := a.subsystemConfig()
+	return graphLifecycle{
+		app:    a,
+		cfg:    cfg.Graph,
+		events: cfg.Events,
+	}
+}
+
+func (s graphLifecycle) Name() string {
+	return "graph"
+}
+
+func (s graphLifecycle) Init(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initGraphPersistenceStore()
+	if err := runInitErrorStep("graph_store_backend", func() error {
+		return s.app.initConfiguredSecurityGraphStore(ctx)
+	}); err != nil {
+		return err
+	}
+	if err := runInitErrorStep("graph_writer_lease", func() error {
+		return s.app.initGraphWriterLease(ctx)
+	}); err != nil {
+		return err
+	}
+	if err := runInitErrorStep("entity_search_backend", func() error {
+		return s.app.initEntitySearchBackend(ctx)
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s graphLifecycle) Start(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initSecurityGraph(ctx)
+	if s.events.TapGraphConsumerEnabled() {
+		s.app.initTapGraphConsumer(ctx)
+	}
+	return nil
+}
+
+type eventLifecycle struct {
+	app *App
+	cfg EventConfig
+}
+
+func (a *App) eventsSubsystem() eventLifecycle {
+	return eventLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().Events,
+	}
+}
+
+func (s eventLifecycle) Name() string {
+	return "events"
+}
+
+func (s eventLifecycle) Start(ctx context.Context) error {
+	if s.app == nil || !s.cfg.AlertRoutingEnabled() {
+		return nil
+	}
+	s.app.startEventAlertRouting(ctx)
+	return nil
+}


### PR DESCRIPTION
## Summary
- remove the unused App.Compliance field and the matching SecurityServices field
- drop the no-op compliance init task and initCompliance helper
- keep the app wiring aligned with the on-demand compliance reporting model

## Testing
- go test ./internal/app
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #323