### PR TITLE
fix(policy): surface CEL env init errors

### DIFF
--- a/internal/policy/conditions_cel.go
+++ b/internal/policy/conditions_cel.go
@@ -13,7 +13,7 @@ const (
 	ConditionFormatCEL    = "cel"
 )
 
-func newPolicyConditionEnv() (*cel.Env, error) {
+var newPolicyConditionEnv = func() (*cel.Env, error) {
 	return cel.NewEnv(
 		cel.Variable("resource", cel.DynType),
 		ext.Strings(),
@@ -47,11 +47,16 @@ func (e *Engine) ensureConditionEnvLocked() error {
 	if e.celEnv != nil {
 		return nil
 	}
+	if e.celEnvErr != nil {
+		return e.celEnvErr
+	}
 	env, err := newPolicyConditionEnv()
 	if err != nil {
-		return fmt.Errorf("initialize CEL environment: %w", err)
+		e.celEnvErr = fmt.Errorf("initialize CEL environment: %w", err)
+		return e.celEnvErr
 	}
 	e.celEnv = env
+	e.celEnvErr = nil
 	return nil
 }
 
@@ -72,9 +77,13 @@ func (e *Engine) validatePolicyConditionPrograms(p *Policy) error {
 func (e *Engine) conditionEnvForValidation() (*cel.Env, error) {
 	e.mu.RLock()
 	env := e.celEnv
+	envErr := e.celEnvErr
 	e.mu.RUnlock()
 	if env != nil {
 		return env, nil
+	}
+	if envErr != nil {
+		return nil, envErr
 	}
 	var err error
 	env, err = newPolicyConditionEnv()

--- a/internal/policy/conditions_cel_validation_test.go
+++ b/internal/policy/conditions_cel_validation_test.go
@@ -1,8 +1,11 @@
 package policy
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/google/cel-go/cel"
 )
 
 func TestValidatePolicyDefinitionRejectsInvalidCELCondition(t *testing.T) {
@@ -59,5 +62,43 @@ func TestValidatePolicyConditionProgramsUsesReusableEnv(t *testing.T) {
 	}
 	if err := validatePolicyConditionProgramsWithEnv(env, policy); err != nil {
 		t.Fatalf("validatePolicyConditionProgramsWithEnv failed: %v", err)
+	}
+}
+
+func TestNewEngineDefersCELEnvInitError(t *testing.T) {
+	original := newPolicyConditionEnv
+	newPolicyConditionEnv = func() (*cel.Env, error) {
+		return nil, errors.New("boom")
+	}
+	t.Cleanup(func() { newPolicyConditionEnv = original })
+
+	engine := NewEngine()
+	if engine == nil {
+		t.Fatal("expected engine to be created")
+	}
+	if engine.celEnv != nil {
+		t.Fatal("expected CEL env to remain unset on init failure")
+	}
+	if err := engine.ensureConditionEnvLocked(); err == nil {
+		t.Fatal("expected deferred CEL env init error")
+	} else if !strings.Contains(err.Error(), "initialize CEL environment: boom") {
+		t.Fatalf("unexpected env init error: %v", err)
+	}
+}
+
+func TestLoadPoliciesReturnsDeferredCELEnvInitError(t *testing.T) {
+	original := newPolicyConditionEnv
+	newPolicyConditionEnv = func() (*cel.Env, error) {
+		return nil, errors.New("boom")
+	}
+	t.Cleanup(func() { newPolicyConditionEnv = original })
+
+	engine := NewEngine()
+	err := engine.LoadPolicies(t.TempDir())
+	if err == nil {
+		t.Fatal("expected LoadPolicies to return CEL env init error")
+	}
+	if !strings.Contains(err.Error(), "initialize CEL environment: boom") {
+		t.Fatalf("unexpected LoadPolicies error: %v", err)
 	}
 }

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -60,6 +60,7 @@ type Engine struct {
 	history     map[string][]PolicyEvent // Version history indexed by policy ID
 	celPrograms map[string][]cel.Program // Compiled CEL programs indexed by policy ID
 	celEnv      *cel.Env                 // Shared CEL environment for condition validation/eval
+	celEnvErr   error                    // Deferred CEL environment initialization error
 	mu          sync.RWMutex             // Protects policies/history maps
 }
 
@@ -169,17 +170,18 @@ type Finding struct {
 
 func NewEngine() *Engine {
 	MustValidateStartupMappings()
-	celEnv, err := newPolicyConditionEnv()
-	if err != nil {
-		panic(fmt.Sprintf("initialize CEL environment: %v", err))
-	}
-
-	return &Engine{
+	engine := &Engine{
 		policies:    make(map[string]*Policy),
 		history:     make(map[string][]PolicyEvent),
 		celPrograms: make(map[string][]cel.Program),
-		celEnv:      celEnv,
 	}
+	celEnv, err := newPolicyConditionEnv()
+	if err != nil {
+		engine.celEnvErr = fmt.Errorf("initialize CEL environment: %w", err)
+		return engine
+	}
+	engine.celEnv = celEnv
+	return engine
 }
 
 func (e *Engine) LoadPolicies(dir string) error {


### PR DESCRIPTION
## Summary
- stop panicking when CEL environment initialization fails during policy engine construction
- preserve the initialization error on the engine and return it through policy loading/validation paths
- add regression coverage for deferred CEL environment initialization failures

## Testing
- go test ./internal/policy
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #313