### PR TITLE
fix(app): narrow snowflake missing-table detection

### DIFF
--- a/internal/app/app_state_postgres.go
+++ b/internal/app/app_state_postgres.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+	sf "github.com/snowflakedb/gosnowflake"
 
 	"github.com/writer/cerebro/internal/agents"
 	"github.com/writer/cerebro/internal/appstate"
@@ -25,7 +26,10 @@ const (
 	appStateMigrationStateTable          = "cerebro_app_state_migrations"
 	legacySnowflakeAppStateMigrationName = "legacy_snowflake"
 	legacySnowflakeAppStateStartedName   = "legacy_snowflake_started"
+	snowflakeErrObjectNotExist           = 2003
 )
+
+var missingSnowflakeAppStateTablePattern = regexp.MustCompile(`(?i)\b(?:cerebro_findings|findings|agent_sessions|audit_log|policy_history|risk_engine_state)\b`)
 
 func (a *App) appStateMigrationSnowflake() *snowflake.Client {
 	if a == nil {
@@ -299,13 +303,20 @@ func isMissingSnowflakeTableErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	message := strings.ToLower(err.Error())
+	var snowflakeErr *sf.SnowflakeError
+	if !errors.As(err, &snowflakeErr) {
+		return false
+	}
+	message := strings.ToLower(snowflakeErr.Error())
 	if strings.Contains(message, "not authorized") {
 		return false
 	}
-	return strings.Contains(message, "does not exist") ||
-		strings.Contains(message, "unknown table") ||
-		strings.Contains(message, "not exist")
+	switch snowflakeErr.Number {
+	case snowflakeErrObjectNotExist, sf.ErrObjectNotExistOrAuthorized:
+		return missingSnowflakeAppStateTablePattern.MatchString(message)
+	default:
+		return false
+	}
 }
 
 var postgresIdentifierRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)

--- a/internal/app/app_state_postgres_test.go
+++ b/internal/app/app_state_postgres_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	sf "github.com/snowflakedb/gosnowflake"
 	_ "modernc.org/sqlite"
 
 	"github.com/writer/cerebro/internal/findings"
@@ -161,16 +163,64 @@ func TestAppStateDatabaseURLUsesWarehousePostgresDSNAcrossBackends(t *testing.T)
 	}
 }
 
-func TestIsMissingSnowflakeTableErrRejectsAuthorizationErrors(t *testing.T) {
-	err := errors.New("SQL compilation error: Object 'DB.SCHEMA.CEREBRO_FINDINGS' does not exist or not authorized.")
-	if isMissingSnowflakeTableErr(err) {
-		t.Fatal("expected authorization errors to fail migration instead of being treated as missing tables")
+func TestIsMissingSnowflakeTableErr(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "wrapped app state table lookup failure",
+			err: fmt.Errorf("query failed: %w", &sf.SnowflakeError{
+				Number:  snowflakeErrObjectNotExist,
+				Message: "Object 'DB.SCHEMA.CEREBRO_FINDINGS' does not exist.",
+			}),
+			want: true,
+		},
+		{
+			name: "not authorized responses are not swallowed",
+			err: &sf.SnowflakeError{
+				Number:  sf.ErrObjectNotExistOrAuthorized,
+				Message: "Object 'DB.SCHEMA.AGENT_SESSIONS' does not exist or not authorized.",
+			},
+			want: false,
+		},
+		{
+			name: "driver object missing code matches known tables",
+			err: &sf.SnowflakeError{
+				Number:  sf.ErrObjectNotExistOrAuthorized,
+				Message: "Object 'DB.SCHEMA.AGENT_SESSIONS' does not exist.",
+			},
+			want: true,
+		},
+		{
+			name: "non table object failures are not swallowed",
+			err: &sf.SnowflakeError{
+				Number:  snowflakeErrObjectNotExist,
+				Message: "Database 'DB' does not exist.",
+			},
+			want: false,
+		},
+		{
+			name: "other snowflake error codes are not treated as missing tables",
+			err: &sf.SnowflakeError{
+				Number:  sf.ErrRoleNotExist,
+				Message: "Role 'ANALYST' does not exist.",
+			},
+			want: false,
+		},
+		{
+			name: "plain string errors are ignored",
+			err:  errors.New("SQL compilation error: unknown table FOO"),
+			want: false,
+		},
 	}
-}
 
-func TestIsMissingSnowflakeTableErrAcceptsMissingTableErrors(t *testing.T) {
-	err := errors.New("SQL compilation error: Object 'DB.SCHEMA.CEREBRO_FINDINGS' does not exist.")
-	if !isMissingSnowflakeTableErr(err) {
-		t.Fatal("expected missing table error to be treated as skippable migration input")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isMissingSnowflakeTableErr(tc.err); got != tc.want {
+				t.Fatalf("isMissingSnowflakeTableErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- replace broad missing-table string matching with structured Snowflake error inspection
- only treat known app-state tables as skippable missing-table inputs
- keep authorization and unrelated object errors visible with focused regression coverage

## Testing
- go test ./internal/app
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #353