### PR TITLE
fix(warehouse): harden dialect rewrites

### DIFF
--- a/internal/warehouse/dialect.go
+++ b/internal/warehouse/dialect.go
@@ -73,31 +73,20 @@ func rewriteForSQLite(query string) string {
 func rewriteQuestionPlaceholders(query string) string {
 	var b strings.Builder
 	b.Grow(len(query) + 8)
-	index := 1
-	inSingle := false
-	inDouble := false
-	for i := 0; i < len(query); i++ {
-		ch := query[i]
-		switch ch {
-		case '\'':
-			if !inDouble {
-				inSingle = !inSingle
-			}
-			b.WriteByte(ch)
-		case '"':
-			if !inSingle {
-				inDouble = !inDouble
-			}
-			b.WriteByte(ch)
+	index := maxDollarPlaceholderIndex(query) + 1
+	for i := 0; i < len(query); {
+		switch query[i] {
+		case '\'', '"':
+			end := skipSQLQuotedSection(query, i)
+			b.WriteString(query[i:end])
+			i = end
 		case '?':
-			if inSingle || inDouble {
-				b.WriteByte(ch)
-				continue
-			}
 			_, _ = fmt.Fprintf(&b, "$%d", index)
 			index++
+			i++
 		default:
-			b.WriteByte(ch)
+			b.WriteByte(query[i])
+			i++
 		}
 	}
 	return b.String()
@@ -105,24 +94,174 @@ func rewriteQuestionPlaceholders(query string) string {
 
 func replaceKeyword(query, oldWord, newWord string) string {
 	pattern := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(oldWord) + `\b`)
-	return pattern.ReplaceAllString(query, newWord)
+	return applyOutsideSQLQuotedSections(query, func(segment string) string {
+		return pattern.ReplaceAllString(segment, newWord)
+	})
 }
 
 func rewriteJSONFunctions(query, dialect string) string {
-	pattern := regexp.MustCompile(`(?i)(TRY_PARSE_JSON|PARSE_JSON)\(([^()]+)\)`)
-	return pattern.ReplaceAllStringFunc(query, func(match string) string {
-		submatches := pattern.FindStringSubmatch(match)
-		if len(submatches) != 3 {
-			return match
-		}
-		expr := strings.TrimSpace(submatches[2])
-		switch dialect {
-		case DialectPostgres:
-			return "CAST(" + expr + " AS JSONB)"
-		case DialectSQLite:
-			return expr
+	var b strings.Builder
+	for i := 0; i < len(query); {
+		switch query[i] {
+		case '\'', '"':
+			end := skipSQLQuotedSection(query, i)
+			b.WriteString(query[i:end])
+			i = end
 		default:
-			return match
+			nameLen := matchedJSONFunctionNameLength(query, i)
+			if nameLen == 0 {
+				b.WriteByte(query[i])
+				i++
+				continue
+			}
+
+			open := i + nameLen
+			for open < len(query) && isSQLWhitespace(query[open]) {
+				open++
+			}
+			if open >= len(query) || query[open] != '(' {
+				b.WriteByte(query[i])
+				i++
+				continue
+			}
+
+			close, ok := findMatchingSQLParen(query, open)
+			if !ok {
+				b.WriteByte(query[i])
+				i++
+				continue
+			}
+
+			expr := strings.TrimSpace(rewriteJSONFunctions(query[open+1:close], dialect))
+			switch dialect {
+			case DialectPostgres:
+				b.WriteString("CAST(" + expr + " AS JSONB)")
+			case DialectSQLite:
+				b.WriteString(expr)
+			default:
+				b.WriteString(query[i : close+1])
+			}
+			i = close + 1
 		}
+	}
+	return b.String()
+}
+
+func maxDollarPlaceholderIndex(query string) int {
+	max := 0
+	_ = applyOutsideSQLQuotedSections(query, func(segment string) string {
+		if value := maxDollarPlaceholderIndexInSegment(segment); value > max {
+			max = value
+		}
+		return segment
 	})
+	return max
+}
+
+func maxDollarPlaceholderIndexInSegment(segment string) int {
+	max := 0
+	for i := 0; i < len(segment); i++ {
+		if segment[i] != '$' || i+1 >= len(segment) || segment[i+1] < '0' || segment[i+1] > '9' {
+			continue
+		}
+		value := 0
+		for j := i + 1; j < len(segment) && segment[j] >= '0' && segment[j] <= '9'; j++ {
+			value = value*10 + int(segment[j]-'0')
+			i = j
+		}
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}
+
+func applyOutsideSQLQuotedSections(query string, rewrite func(string) string) string {
+	var b strings.Builder
+	last := 0
+	for i := 0; i < len(query); {
+		switch query[i] {
+		case '\'', '"':
+			if last < i {
+				b.WriteString(rewrite(query[last:i]))
+			}
+			end := skipSQLQuotedSection(query, i)
+			b.WriteString(query[i:end])
+			i = end
+			last = end
+		default:
+			i++
+		}
+	}
+	if last < len(query) {
+		b.WriteString(rewrite(query[last:]))
+	}
+	return b.String()
+}
+
+func skipSQLQuotedSection(query string, start int) int {
+	if start < 0 || start >= len(query) {
+		return len(query)
+	}
+	quote := query[start]
+	for i := start + 1; i < len(query); i++ {
+		if query[i] != quote {
+			continue
+		}
+		if i+1 < len(query) && query[i+1] == quote {
+			i++
+			continue
+		}
+		return i + 1
+	}
+	return len(query)
+}
+
+func matchedJSONFunctionNameLength(query string, start int) int {
+	if start > 0 && isSQLWordCharacter(query[start-1]) {
+		return 0
+	}
+	for _, name := range []string{"TRY_PARSE_JSON", "PARSE_JSON"} {
+		if start+len(name) <= len(query) && strings.EqualFold(query[start:start+len(name)], name) {
+			return len(name)
+		}
+	}
+	return 0
+}
+
+func findMatchingSQLParen(query string, open int) (int, bool) {
+	if open < 0 || open >= len(query) || query[open] != '(' {
+		return 0, false
+	}
+	depth := 0
+	for i := open; i < len(query); i++ {
+		switch query[i] {
+		case '\'', '"':
+			i = skipSQLQuotedSection(query, i) - 1
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func isSQLWhitespace(ch byte) bool {
+	switch ch {
+	case ' ', '\n', '\r', '\t', '\f':
+		return true
+	default:
+		return false
+	}
+}
+
+func isSQLWordCharacter(ch byte) bool {
+	return ch == '_' ||
+		(ch >= 'a' && ch <= 'z') ||
+		(ch >= 'A' && ch <= 'Z') ||
+		(ch >= '0' && ch <= '9')
 }

--- a/internal/warehouse/dialect.go
+++ b/internal/warehouse/dialect.go
@@ -2,6 +2,7 @@ package warehouse
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -14,6 +15,24 @@ const (
 )
 
 var currentTimestampCallPattern = regexp.MustCompile(`(?i)CURRENT_TIMESTAMP\(\)`)
+
+var ErrUnsupportedSnowflakeDialectRewrite = errors.New("warehouse query requires a dialect-specific implementation")
+
+var unsupportedSnowflakeDialectPatterns = []struct {
+	name    string
+	pattern *regexp.Regexp
+}{
+	{name: "QUALIFY", pattern: regexp.MustCompile(`(?i)\bQUALIFY\b`)},
+	{name: "FLATTEN", pattern: regexp.MustCompile(`(?i)\b(?:LATERAL\s+)?FLATTEN\s*\(`)},
+	{name: "GET_PATH", pattern: regexp.MustCompile(`(?i)\bGET_PATH\s*\(`)},
+	{name: "OBJECT_CONSTRUCT", pattern: regexp.MustCompile(`(?i)\bOBJECT_CONSTRUCT\s*\(`)},
+	{name: "TRY_CAST", pattern: regexp.MustCompile(`(?i)\bTRY_CAST\s*\(`)},
+	{name: "IFF", pattern: regexp.MustCompile(`(?i)\bIFF\s*\(`)},
+	{name: "MERGE INTO", pattern: regexp.MustCompile(`(?i)\bMERGE\s+INTO\b`)},
+	{name: "CREATE OR REPLACE TABLE", pattern: regexp.MustCompile(`(?i)\bCREATE\s+OR\s+REPLACE\s+TABLE\b`)},
+	{name: "COPY INTO", pattern: regexp.MustCompile(`(?i)\bCOPY\s+INTO\b`)},
+	{name: "Snowflake JSON : operator", pattern: regexp.MustCompile(`(?i)\b[A-Za-z_][A-Za-z0-9_\.]*\s*:\s*[A-Za-z_][A-Za-z0-9_]*`)},
+}
 
 func DialectFor(schema SchemaWarehouse) string {
 	if schema == nil {
@@ -46,6 +65,16 @@ func RewriteQueryForDialect(query, dialect string) string {
 	default:
 		return query
 	}
+}
+
+func validateQueryForDialect(query, dialect string) error {
+	if dialect == DialectSnowflake {
+		return nil
+	}
+	if construct := unsupportedSnowflakeConstruct(query); construct != "" {
+		return fmt.Errorf("%w for %s: unsupported Snowflake construct %s", ErrUnsupportedSnowflakeDialectRewrite, dialect, construct)
+	}
+	return nil
 }
 
 func rewriteForPostgres(query string) string {
@@ -156,6 +185,23 @@ func maxDollarPlaceholderIndex(query string) int {
 		return segment
 	})
 	return max
+}
+
+func unsupportedSnowflakeConstruct(query string) string {
+	var construct string
+	_ = applyOutsideSQLQuotedSections(query, func(segment string) string {
+		if construct != "" {
+			return segment
+		}
+		for _, candidate := range unsupportedSnowflakeDialectPatterns {
+			if candidate.pattern.FindStringIndex(segment) != nil {
+				construct = candidate.name
+				break
+			}
+		}
+		return segment
+	})
+	return construct
 }
 
 func maxDollarPlaceholderIndexInSegment(segment string) int {

--- a/internal/warehouse/dialect.go
+++ b/internal/warehouse/dialect.go
@@ -22,11 +22,11 @@ var unsupportedSnowflakeDialectPatterns = []struct {
 	name    string
 	pattern *regexp.Regexp
 }{
-	{name: "QUALIFY", pattern: regexp.MustCompile(`(?i)\bQUALIFY\b`)},
 	{name: "FLATTEN", pattern: regexp.MustCompile(`(?i)\b(?:LATERAL\s+)?FLATTEN\s*\(`)},
 	{name: "GET_PATH", pattern: regexp.MustCompile(`(?i)\bGET_PATH\s*\(`)},
 	{name: "OBJECT_CONSTRUCT", pattern: regexp.MustCompile(`(?i)\bOBJECT_CONSTRUCT\s*\(`)},
 	{name: "TRY_CAST", pattern: regexp.MustCompile(`(?i)\bTRY_CAST\s*\(`)},
+	{name: "DATEDIFF", pattern: regexp.MustCompile(`(?i)\bDATEDIFF\s*\(`)},
 	{name: "IFF", pattern: regexp.MustCompile(`(?i)\bIFF\s*\(`)},
 	{name: "MERGE INTO", pattern: regexp.MustCompile(`(?i)\bMERGE\s+INTO\b`)},
 	{name: "CREATE OR REPLACE TABLE", pattern: regexp.MustCompile(`(?i)\bCREATE\s+OR\s+REPLACE\s+TABLE\b`)},

--- a/internal/warehouse/dialect_test.go
+++ b/internal/warehouse/dialect_test.go
@@ -1,6 +1,7 @@
 package warehouse
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -55,5 +56,53 @@ func TestRewriteQueryForDialect_PostgresContinuesDollarPlaceholderSequence(t *te
 
 	if got != want {
 		t.Fatalf("expected placeholder rewrite %q, got %q", want, got)
+	}
+}
+
+func TestValidateQueryForDialect_RejectsUnsupportedSnowflakeConstructs(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		wantConstruct string
+	}{
+		{
+			name:          "qualify",
+			query:         `SELECT * FROM demo QUALIFY ROW_NUMBER() OVER (PARTITION BY tenant_id ORDER BY created_at DESC) = 1`,
+			wantConstruct: "QUALIFY",
+		},
+		{
+			name:          "flatten",
+			query:         `SELECT value FROM LATERAL FLATTEN(input => payload)`,
+			wantConstruct: "FLATTEN",
+		},
+		{
+			name:          "json operator",
+			query:         `SELECT payload:key::STRING FROM demo`,
+			wantConstruct: "Snowflake JSON : operator",
+		},
+		{
+			name:          "create or replace table",
+			query:         `CREATE OR REPLACE TABLE demo (id NUMBER)`,
+			wantConstruct: "CREATE OR REPLACE TABLE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateQueryForDialect(tt.query, DialectPostgres)
+			if !errors.Is(err, ErrUnsupportedSnowflakeDialectRewrite) {
+				t.Fatalf("expected unsupported rewrite error, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantConstruct) {
+				t.Fatalf("expected error to mention %q, got %v", tt.wantConstruct, err)
+			}
+		})
+	}
+}
+
+func TestValidateQueryForDialect_IgnoresQuotedUnsupportedConstructs(t *testing.T) {
+	query := `SELECT 'QUALIFY payload:key::STRING' AS demo`
+	if err := validateQueryForDialect(query, DialectPostgres); err != nil {
+		t.Fatalf("expected quoted text to be ignored, got %v", err)
 	}
 }

--- a/internal/warehouse/dialect_test.go
+++ b/internal/warehouse/dialect_test.go
@@ -66,9 +66,9 @@ func TestValidateQueryForDialect_RejectsUnsupportedSnowflakeConstructs(t *testin
 		wantConstruct string
 	}{
 		{
-			name:          "qualify",
-			query:         `SELECT * FROM demo QUALIFY ROW_NUMBER() OVER (PARTITION BY tenant_id ORDER BY created_at DESC) = 1`,
-			wantConstruct: "QUALIFY",
+			name:          "datediff",
+			query:         `SELECT * FROM demo WHERE ABS(DATEDIFF('hour', created_at, updated_at)) < 24`,
+			wantConstruct: "DATEDIFF",
 		},
 		{
 			name:          "flatten",
@@ -104,5 +104,12 @@ func TestValidateQueryForDialect_IgnoresQuotedUnsupportedConstructs(t *testing.T
 	query := `SELECT 'QUALIFY payload:key::STRING' AS demo`
 	if err := validateQueryForDialect(query, DialectPostgres); err != nil {
 		t.Fatalf("expected quoted text to be ignored, got %v", err)
+	}
+}
+
+func TestValidateQueryForDialect_AllowsQualifyIdentifier(t *testing.T) {
+	query := `SELECT qualify FROM demo`
+	if err := validateQueryForDialect(query, DialectPostgres); err != nil {
+		t.Fatalf("expected qualify identifier to remain allowed, got %v", err)
 	}
 }

--- a/internal/warehouse/dialect_test.go
+++ b/internal/warehouse/dialect_test.go
@@ -28,3 +28,32 @@ func TestRewriteQueryForDialect_SQLite(t *testing.T) {
 		t.Fatalf("expected timestamp rewrite, got %q", got)
 	}
 }
+
+func TestRewriteQueryForDialect_PostgresHandlesNestedParseJSON(t *testing.T) {
+	query := `SELECT PARSE_JSON(PARSE_JSON(col)) FROM demo`
+	got := RewriteQueryForDialect(query, DialectPostgres)
+	want := `SELECT CAST(CAST(col AS JSONB) AS JSONB) FROM demo`
+
+	if got != want {
+		t.Fatalf("expected nested PARSE_JSON rewrite %q, got %q", want, got)
+	}
+}
+
+func TestRewriteQueryForDialect_PostgresPreservesQuotedIdentifiers(t *testing.T) {
+	query := `SELECT "VARIANT", "NUMBER" FROM demo`
+	got := RewriteQueryForDialect(query, DialectPostgres)
+
+	if got != query {
+		t.Fatalf("expected quoted identifiers to remain unchanged, got %q", got)
+	}
+}
+
+func TestRewriteQueryForDialect_PostgresContinuesDollarPlaceholderSequence(t *testing.T) {
+	query := `SELECT * FROM demo WHERE tenant_id = $1 AND payload = ? AND severity = ?`
+	got := RewriteQueryForDialect(query, DialectPostgres)
+	want := `SELECT * FROM demo WHERE tenant_id = $1 AND payload = $2 AND severity = $3`
+
+	if got != want {
+		t.Fatalf("expected placeholder rewrite %q, got %q", want, got)
+	}
+}

--- a/internal/warehouse/postgres.go
+++ b/internal/warehouse/postgres.go
@@ -548,6 +548,9 @@ func (w *PostgresWarehouse) Query(ctx context.Context, query string, args ...any
 	if query == "" {
 		return &snowflake.QueryResult{}, nil
 	}
+	if err := validateQueryForDialect(query, DialectPostgres); err != nil {
+		return nil, err
+	}
 	query = RewriteQueryForDialect(query, DialectPostgres)
 	rows, err := w.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -560,6 +563,10 @@ func (w *PostgresWarehouse) Query(ctx context.Context, query string, args ...any
 func (w *PostgresWarehouse) Exec(ctx context.Context, query string, args ...any) (sql.Result, error) {
 	if w == nil || w.db == nil {
 		return nil, fmt.Errorf("postgres warehouse is not initialized")
+	}
+	query = strings.TrimSpace(query)
+	if err := validateQueryForDialect(query, DialectPostgres); err != nil {
+		return nil, err
 	}
 	query = RewriteQueryForDialect(query, DialectPostgres)
 	return w.db.ExecContext(ctx, query, args...)

--- a/internal/warehouse/sqlite.go
+++ b/internal/warehouse/sqlite.go
@@ -110,6 +110,9 @@ func (w *SQLiteWarehouse) Query(ctx context.Context, query string, args ...any) 
 	if query == "" {
 		return &snowflake.QueryResult{}, nil
 	}
+	if err := validateQueryForDialect(query, DialectSQLite); err != nil {
+		return nil, err
+	}
 	query = RewriteQueryForDialect(query, DialectSQLite)
 	if isInformationSchemaTablesQuery(query) {
 		return w.queryInformationSchemaTables(ctx)
@@ -129,6 +132,10 @@ func (w *SQLiteWarehouse) Query(ctx context.Context, query string, args ...any) 
 func (w *SQLiteWarehouse) Exec(ctx context.Context, query string, args ...any) (sql.Result, error) {
 	if w == nil || w.db == nil {
 		return nil, fmt.Errorf("sqlite warehouse is not initialized")
+	}
+	query = strings.TrimSpace(query)
+	if err := validateQueryForDialect(query, DialectSQLite); err != nil {
+		return nil, err
 	}
 	query = RewriteQueryForDialect(query, DialectSQLite)
 	return w.db.ExecContext(ctx, query, args...)

--- a/internal/warehouse/sqlite_test.go
+++ b/internal/warehouse/sqlite_test.go
@@ -140,6 +140,32 @@ func TestSQLiteWarehouseQueryRejectsUnsupportedSnowflakeConstructs(t *testing.T)
 	}
 }
 
+func TestSQLiteWarehouseQueryAllowsQualifyIdentifier(t *testing.T) {
+	store, err := NewSQLiteWarehouse(SQLiteWarehouseConfig{
+		Path: filepath.Join(t.TempDir(), "warehouse.db"),
+	})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	if _, err := store.Exec(ctx, `CREATE TABLE demo (qualify TEXT)`); err != nil {
+		t.Fatalf("create demo table: %v", err)
+	}
+	if _, err := store.Exec(ctx, `INSERT INTO demo (qualify) VALUES ('ok')`); err != nil {
+		t.Fatalf("insert demo row: %v", err)
+	}
+
+	result, err := store.Query(ctx, `SELECT qualify FROM demo`)
+	if err != nil {
+		t.Fatalf("select qualify column: %v", err)
+	}
+	if result.Count != 1 || result.Rows[0]["qualify"] != "ok" {
+		t.Fatalf("unexpected result: %#v", result.Rows)
+	}
+}
+
 func TestSQLiteWarehouseExecRejectsUnsupportedSnowflakeConstructs(t *testing.T) {
 	store, err := NewSQLiteWarehouse(SQLiteWarehouseConfig{
 		Path: filepath.Join(t.TempDir(), "warehouse.db"),

--- a/internal/warehouse/sqlite_test.go
+++ b/internal/warehouse/sqlite_test.go
@@ -2,8 +2,10 @@ package warehouse
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -117,5 +119,41 @@ func TestSQLiteWarehouseRejectsNonAssetTables(t *testing.T) {
 	if _, err := store.GetAssets(ctx, "cdc_events", snowflake.AssetFilter{Limit: 1}); err == nil {
 		t.Fatal("expected non-asset table to be rejected")
 		return
+	}
+}
+
+func TestSQLiteWarehouseQueryRejectsUnsupportedSnowflakeConstructs(t *testing.T) {
+	store, err := NewSQLiteWarehouse(SQLiteWarehouseConfig{
+		Path: filepath.Join(t.TempDir(), "warehouse.db"),
+	})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	_, err = store.Query(context.Background(), `SELECT payload:key::STRING FROM demo`)
+	if !errors.Is(err, ErrUnsupportedSnowflakeDialectRewrite) {
+		t.Fatalf("expected unsupported rewrite error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Snowflake JSON : operator") {
+		t.Fatalf("expected error to mention JSON operator, got %v", err)
+	}
+}
+
+func TestSQLiteWarehouseExecRejectsUnsupportedSnowflakeConstructs(t *testing.T) {
+	store, err := NewSQLiteWarehouse(SQLiteWarehouseConfig{
+		Path: filepath.Join(t.TempDir(), "warehouse.db"),
+	})
+	if err != nil {
+		t.Fatalf("new sqlite warehouse: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	_, err = store.Exec(context.Background(), `CREATE OR REPLACE TABLE demo (id NUMBER)`)
+	if !errors.Is(err, ErrUnsupportedSnowflakeDialectRewrite) {
+		t.Fatalf("expected unsupported rewrite error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "CREATE OR REPLACE TABLE") {
+		t.Fatalf("expected error to mention CREATE OR REPLACE TABLE, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- preserve quoted identifiers during dialect keyword replacement
- continue placeholder numbering after existing `$n` parameters
- rewrite nested `PARSE_JSON`/`TRY_PARSE_JSON` calls and cover regressions with tests
- reject unsupported Snowflake-only constructs early so complex queries fail fast instead of being silently mis-rewritten

## Validation
- go test ./internal/warehouse
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Closes #355
Closes #358
Closes #359
Closes #360