### PR TITLE
fix(events): recover panicking consumer handlers

### DIFF
--- a/internal/events/consumer.go
+++ b/internal/events/consumer.go
@@ -40,6 +40,8 @@ const (
 	defaultConsumerLagRefreshInterval  = 15 * time.Second
 )
 
+var errConsumerHandlerRequired = errors.New("consumer handler is required")
+
 type ConsumerConfig struct {
 	URLs                []string
 	Stream              string
@@ -169,7 +171,7 @@ type ConsumerHealthSnapshot struct {
 
 func NewJetStreamConsumer(cfg ConsumerConfig, logger *slog.Logger, handler EventHandler) (*Consumer, error) {
 	if handler == nil {
-		return nil, errors.New("consumer handler is required")
+		return nil, errConsumerHandlerRequired
 	}
 	config := cfg.withDefaults()
 	if err := config.validate(); err != nil {
@@ -593,7 +595,7 @@ func (c *Consumer) handleDecodedMessage(decoded consumerDecodedMessage) consumer
 
 	handlerCtx, handlerSpan := c.startTracingSpan(ingestCtx, "cerebro.event.handle", c.consumerEventAttributes(message, evt)...)
 	handlerCtx = telemetry.ContextWithAttributes(handlerCtx, c.consumerEventAttributes(message, evt)...)
-	if err := c.handler(handlerCtx, evt); err != nil {
+	if err := c.invokeHandler(handlerCtx, evt); err != nil {
 		consumerRecordSpanError(handlerSpan, err)
 		if delay, ok := retryDelay(err); ok && message.nakWithDelay != nil {
 			handlerSpan.End()
@@ -637,6 +639,18 @@ func (c *Consumer) handleDecodedMessage(decoded consumerDecodedMessage) consumer
 		EventTime:   evt.Time.UTC(),
 		ProcessedAt: processedAt,
 	}
+}
+
+func (c *Consumer) invokeHandler(ctx context.Context, evt CloudEvent) (err error) {
+	if c == nil || c.handler == nil {
+		return errConsumerHandlerRequired
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("consumer handler panic: %v", recovered)
+		}
+	}()
+	return c.handler(ctx, evt)
 }
 
 func (c *Consumer) processBatch(ctx context.Context, messages []consumerPipelineMessage) bool {

--- a/internal/events/consumer.go
+++ b/internal/events/consumer.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -436,6 +437,27 @@ type consumerDecodedMessage struct {
 	result  consumerMessageResult
 }
 
+type consumerHandlerPanicError struct {
+	recovered any
+	stack     []byte
+}
+
+func (e *consumerHandlerPanicError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("consumer handler panic: %v", e.recovered)
+}
+
+func consumerHandlerFailureLogArgs(err error) []any {
+	args := []any{"error", err}
+	var panicErr *consumerHandlerPanicError
+	if errors.As(err, &panicErr) && len(panicErr.stack) > 0 {
+		args = append(args, "stack", string(panicErr.stack))
+	}
+	return args
+}
+
 func (c *Consumer) handleMessage(ctx context.Context, subject string, payload []byte, ack func() error, nak func() error, inProgress func() error) consumerMessageResult {
 	decoded := c.decodePipelineMessage(ctx, consumerPipelineMessage{
 		subject:    subject,
@@ -612,7 +634,9 @@ func (c *Consumer) handleDecodedMessage(decoded consumerDecodedMessage) consumer
 			return consumerMessageResult{}
 		}
 		handlerSpan.End()
-		c.logger.Warn("tap consumer handler failed; message requeued", "error", err, "event_type", evt.Type)
+		c.logger.Warn("tap consumer handler failed; message requeued",
+			append(consumerHandlerFailureLogArgs(err), "event_type", evt.Type)...,
+		)
 		if nakErr := c.consumerAckWithTracing(ingestCtx, message, evt, "nak", message.nak); nakErr != nil {
 			c.logger.Warn("tap consumer nak failed", "error", nakErr, "event_type", evt.Type)
 		}
@@ -647,7 +671,10 @@ func (c *Consumer) invokeHandler(ctx context.Context, evt CloudEvent) (err error
 	}
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			err = fmt.Errorf("consumer handler panic: %v", recovered)
+			err = &consumerHandlerPanicError{
+				recovered: recovered,
+				stack:     debug.Stack(),
+			}
 		}
 	}()
 	return c.handler(ctx, evt)

--- a/internal/events/consumer_pipeline.go
+++ b/internal/events/consumer_pipeline.go
@@ -190,7 +190,7 @@ func (c *Consumer) transformDecodedBatchMessage(decoded consumerBatchDecodedMess
 
 	handlerCtx, handlerSpan := c.startTracingSpan(ingestCtx, "cerebro.event.handle", c.consumerEventAttributes(decoded.message, evt)...)
 	handlerCtx = telemetry.ContextWithAttributes(handlerCtx, c.consumerEventAttributes(decoded.message, evt)...)
-	if err := c.handler(handlerCtx, evt); err != nil {
+	if err := c.invokeHandler(handlerCtx, evt); err != nil {
 		consumerRecordSpanError(handlerSpan, err)
 		handlerSpan.End()
 		return consumerBatchPersistRecord{

--- a/internal/events/consumer_pipeline.go
+++ b/internal/events/consumer_pipeline.go
@@ -346,7 +346,9 @@ func (c *Consumer) persistBatchRecord(ctx context.Context, record consumerBatchP
 			}
 			return consumerMessageResult{}
 		}
-		c.logger.Warn("tap consumer handler failed; message requeued", "error", record.err, "event_type", record.event.Type)
+		c.logger.Warn("tap consumer handler failed; message requeued",
+			append(consumerHandlerFailureLogArgs(record.err), "event_type", record.event.Type)...,
+		)
 		if nakErr := c.consumerAckWithTracing(record.ctx, record.message, record.event, "nak", record.message.nak); nakErr != nil {
 			c.logger.Warn("tap consumer nak failed", "error", nakErr, "event_type", record.event.Type)
 		}

--- a/internal/events/consumer_test.go
+++ b/internal/events/consumer_test.go
@@ -1936,6 +1936,83 @@ func TestConsumerProcessBatchUsesDelayedNakForRetryWithDelayErrors(t *testing.T)
 	}
 }
 
+func TestConsumerHandleMessageRecoversPanickingHandler(t *testing.T) {
+	var logs strings.Builder
+	consumer := &Consumer{
+		config: ConsumerConfig{
+			Stream:  "ENSEMBLE_TAP_TEST",
+			Durable: "cerebro_panic_recovery_single_test",
+		},
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+		handler: func(context.Context, CloudEvent) error {
+			panic("boom")
+		},
+	}
+
+	payload, err := json.Marshal(testConsumerEvent("customer:a", 1, true))
+	if err != nil {
+		t.Fatalf("marshal cloud event: %v", err)
+	}
+
+	var acked atomic.Int64
+	var naks atomic.Int64
+	result := consumer.handleMessage(context.Background(), "ensemble.tap.test", payload, func() error {
+		acked.Add(1)
+		return nil
+	}, func() error {
+		naks.Add(1)
+		return nil
+	}, func() error { return nil })
+
+	if result.Processed {
+		t.Fatal("expected recovered panic result to remain unprocessed")
+	}
+	if acked.Load() != 0 {
+		t.Fatalf("expected recovered panic not to ack, got %d", acked.Load())
+	}
+	if naks.Load() != 1 {
+		t.Fatalf("expected recovered panic to trigger one nak, got %d", naks.Load())
+	}
+	if got := logs.String(); !containsAll(got, "consumer handler panic: boom", "stack=", "goroutine ") {
+		t.Fatalf("expected panic recovery log with stack, got %q", got)
+	}
+}
+
+func TestConsumerHandleMessageNaksWhenHandlerMissing(t *testing.T) {
+	consumer := &Consumer{
+		config: ConsumerConfig{
+			Stream:  "ENSEMBLE_TAP_TEST",
+			Durable: "cerebro_nil_handler_single_test",
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	payload, err := json.Marshal(testConsumerEvent("customer:a", 1, true))
+	if err != nil {
+		t.Fatalf("marshal cloud event: %v", err)
+	}
+
+	var acked atomic.Int64
+	var naks atomic.Int64
+	result := consumer.handleMessage(context.Background(), "ensemble.tap.test", payload, func() error {
+		acked.Add(1)
+		return nil
+	}, func() error {
+		naks.Add(1)
+		return nil
+	}, func() error { return nil })
+
+	if result.Processed {
+		t.Fatal("expected missing handler result to remain unprocessed")
+	}
+	if acked.Load() != 0 {
+		t.Fatalf("expected missing handler not to ack, got %d", acked.Load())
+	}
+	if naks.Load() != 1 {
+		t.Fatalf("expected missing handler to trigger one nak, got %d", naks.Load())
+	}
+}
+
 func TestConsumerProcessBatchRecoversPanickingHandler(t *testing.T) {
 	consumer := &Consumer{
 		config: ConsumerConfig{

--- a/internal/events/consumer_test.go
+++ b/internal/events/consumer_test.go
@@ -1936,6 +1936,73 @@ func TestConsumerProcessBatchUsesDelayedNakForRetryWithDelayErrors(t *testing.T)
 	}
 }
 
+func TestConsumerProcessBatchRecoversPanickingHandler(t *testing.T) {
+	consumer := &Consumer{
+		config: ConsumerConfig{
+			Stream:         "ENSEMBLE_TAP_TEST",
+			Durable:        "cerebro_panic_recovery_batch_test",
+			BatchSize:      1,
+			HandlerWorkers: 1,
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		handler: func(context.Context, CloudEvent) error {
+			panic("boom")
+		},
+	}
+
+	var acked atomic.Int64
+	var naks atomic.Int64
+	message := testConsumerPipelineMessage(t, 0, testConsumerEvent("customer:a", 1, true), func() error {
+		acked.Add(1)
+		return nil
+	})
+	message.nak = func() error {
+		naks.Add(1)
+		return nil
+	}
+
+	consumer.processBatch(context.Background(), []consumerPipelineMessage{message})
+
+	if acked.Load() != 0 {
+		t.Fatalf("expected recovered panic not to ack, got %d", acked.Load())
+	}
+	if naks.Load() != 1 {
+		t.Fatalf("expected recovered panic to trigger one nak, got %d", naks.Load())
+	}
+}
+
+func TestConsumerProcessBatchNaksWhenHandlerMissing(t *testing.T) {
+	consumer := &Consumer{
+		config: ConsumerConfig{
+			Stream:         "ENSEMBLE_TAP_TEST",
+			Durable:        "cerebro_nil_handler_batch_test",
+			BatchSize:      1,
+			HandlerWorkers: 1,
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	var acked atomic.Int64
+	var naks atomic.Int64
+	message := testConsumerPipelineMessage(t, 0, testConsumerEvent("customer:a", 1, true), func() error {
+		acked.Add(1)
+		return nil
+	})
+	message.nak = func() error {
+		naks.Add(1)
+		return nil
+	}
+
+	consumer.processBatch(context.Background(), []consumerPipelineMessage{message})
+
+	if acked.Load() != 0 {
+		t.Fatalf("expected missing handler not to ack, got %d", acked.Load())
+	}
+	if naks.Load() != 1 {
+		t.Fatalf("expected missing handler to trigger one nak, got %d", naks.Load())
+	}
+}
+
 func TestConsumerHandleMessagePropagatesEventAttributesIntoHandlerChildSpans(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))


### PR DESCRIPTION
## Summary
- recover panics and nil handlers before invoking event consumer callbacks
- route recovered handler failures through the existing retry/nak path in both single-message and batch processing
- add regression tests for panicking and missing handlers in the batch pipeline

## Validation
- go test ./internal/events
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Closes #362