### PR TITLE
fix(findings): expose store attestation setters

### DIFF
--- a/internal/api/tenant_findings_store.go
+++ b/internal/api/tenant_findings_store.go
@@ -127,6 +127,14 @@ func (s *tenantFindingStore) Stats() findings.Stats {
 	return stats
 }
 
+func (s *tenantFindingStore) SetAttestor(attestor findings.FindingAttestor, attestReobserved bool) {
+	s.base.SetAttestor(attestor, attestReobserved)
+}
+
+func (s *tenantFindingStore) SetSemanticDedup(enabled bool) {
+	s.base.SetSemanticDedup(enabled)
+}
+
 func (s *tenantFindingStore) Sync(ctx context.Context) error {
 	return s.base.Sync(ctx)
 }

--- a/internal/app/app_init_core.go
+++ b/internal/app/app_init_core.go
@@ -353,36 +353,11 @@ func (a *App) configureFindingAttestation() {
 		return
 	}
 
-	configured := false
-	if store, ok := a.Findings.(*findings.Store); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-	if store, ok := a.Findings.(*findings.SQLiteStore); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-	if store, ok := a.Findings.(*findings.PostgresStore); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-	if store, ok := a.Findings.(*findings.SnowflakeStore); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-	if store, ok := a.Findings.(*findings.PostgresStore); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-	if store, ok := a.Findings.(*findings.FileStore); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-
-	if !configured {
+	if a.Findings == nil {
 		a.Logger.Warn("finding attestation enabled but findings store does not support attestations")
 		return
 	}
+	a.Findings.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
 
 	a.Logger.Info("finding attestation chain enabled",
 		"log_url", strings.TrimSpace(a.Config.FindingAttestationLogURL),

--- a/internal/findings/store.go
+++ b/internal/findings/store.go
@@ -47,6 +47,8 @@ type FindingStore interface {
 	Resolve(id string) bool
 	Suppress(id string) bool
 	Stats() Stats
+	SetAttestor(attestor FindingAttestor, attestReobserved bool)
+	SetSemanticDedup(enabled bool)
 	Sync(ctx context.Context) error // Sync to persistent storage
 }
 

--- a/internal/notifications/slack_commands_test.go
+++ b/internal/notifications/slack_commands_test.go
@@ -40,7 +40,9 @@ func (m *mockFindingStore) Stats() findings.Stats {
 		ByStatus:   map[string]int{"open": 8, "resolved": 2},
 	}
 }
-func (m *mockFindingStore) Sync(ctx context.Context) error { return nil }
+func (m *mockFindingStore) SetAttestor(attestor findings.FindingAttestor, attestReobserved bool) {}
+func (m *mockFindingStore) SetSemanticDedup(enabled bool)                                        {}
+func (m *mockFindingStore) Sync(ctx context.Context) error                                       { return nil }
 
 func TestSlackCommandHandler_VerifySignature(t *testing.T) {
 	secret := "8f742231b10e8888abcd99yyyzzz85a5"


### PR DESCRIPTION
## Summary
- add attestation and semantic-dedup setter methods to the FindingStore interface
- route tenant finding stores through those interface methods
- simplify app attestation setup and remove the duplicated PostgresStore branch

## Testing
- go test ./internal/app ./internal/findings ./internal/api ./internal/notifications
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #347