### PR TITLE
fix(app): detect missing snowflake tables by code

### DIFF
--- a/internal/app/app_state_postgres.go
+++ b/internal/app/app_state_postgres.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+	sf "github.com/snowflakedb/gosnowflake"
 
 	"github.com/writer/cerebro/internal/agents"
 	"github.com/writer/cerebro/internal/appstate"
@@ -299,13 +300,20 @@ func isMissingSnowflakeTableErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	message := strings.ToLower(err.Error())
-	if strings.Contains(message, "not authorized") {
+
+	var sfErr *sf.SnowflakeError
+	if !errors.As(err, &sfErr) {
 		return false
 	}
-	return strings.Contains(message, "does not exist") ||
-		strings.Contains(message, "unknown table") ||
-		strings.Contains(message, "not exist")
+	if sfErr.Number != 2003 {
+		return false
+	}
+
+	message := strings.ToLower(strings.TrimSpace(sfErr.Message))
+	if message == "" {
+		message = strings.ToLower(err.Error())
+	}
+	return strings.Contains(message, "does not exist") && !strings.Contains(message, "not authorized")
 }
 
 var postgresIdentifierRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)

--- a/internal/app/app_state_postgres_test.go
+++ b/internal/app/app_state_postgres_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	sf "github.com/snowflakedb/gosnowflake"
 	_ "modernc.org/sqlite"
 
 	"github.com/writer/cerebro/internal/findings"
@@ -162,15 +164,28 @@ func TestAppStateDatabaseURLUsesWarehousePostgresDSNAcrossBackends(t *testing.T)
 }
 
 func TestIsMissingSnowflakeTableErrRejectsAuthorizationErrors(t *testing.T) {
-	err := errors.New("SQL compilation error: Object 'DB.SCHEMA.CEREBRO_FINDINGS' does not exist or not authorized.")
+	err := &sf.SnowflakeError{
+		Number:  2003,
+		Message: "SQL compilation error: Object 'DB.SCHEMA.CEREBRO_FINDINGS' does not exist or not authorized.",
+	}
 	if isMissingSnowflakeTableErr(err) {
 		t.Fatal("expected authorization errors to fail migration instead of being treated as missing tables")
 	}
 }
 
 func TestIsMissingSnowflakeTableErrAcceptsMissingTableErrors(t *testing.T) {
-	err := errors.New("SQL compilation error: Object 'DB.SCHEMA.CEREBRO_FINDINGS' does not exist.")
+	err := fmt.Errorf("wrapped: %w", &sf.SnowflakeError{
+		Number:  2003,
+		Message: "SQL compilation error: Object 'DB.SCHEMA.CEREBRO_FINDINGS' does not exist.",
+	})
 	if !isMissingSnowflakeTableErr(err) {
 		t.Fatal("expected missing table error to be treated as skippable migration input")
+	}
+}
+
+func TestIsMissingSnowflakeTableErrRejectsGenericStringErrors(t *testing.T) {
+	err := errors.New("SQL compilation error: Object 'DB.SCHEMA.CEREBRO_FINDINGS' does not exist.")
+	if isMissingSnowflakeTableErr(err) {
+		t.Fatal("expected generic string errors not to be treated as missing snowflake tables")
 	}
 }


### PR DESCRIPTION
## Summary
- require a wrapped `gosnowflake.SnowflakeError` when deciding whether to skip legacy app-state migrations
- only treat Snowflake object-does-not-exist errors as skippable and keep authorization-style failures visible
- add regression coverage for wrapped driver errors and generic string errors

## Validation
- go test ./internal/app
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Closes #353