### PR TITLE
fix(findings): expose attestation hooks on store interface

### DIFF
--- a/internal/api/tenant_findings_store.go
+++ b/internal/api/tenant_findings_store.go
@@ -130,3 +130,17 @@ func (s *tenantFindingStore) Stats() findings.Stats {
 func (s *tenantFindingStore) Sync(ctx context.Context) error {
 	return s.base.Sync(ctx)
 }
+
+func (s *tenantFindingStore) SetAttestor(attestor findings.FindingAttestor, attestReobserved bool) {
+	if s.base == nil {
+		return
+	}
+	s.base.SetAttestor(attestor, attestReobserved)
+}
+
+func (s *tenantFindingStore) SetSemanticDedup(enabled bool) {
+	if s.base == nil {
+		return
+	}
+	s.base.SetSemanticDedup(enabled)
+}

--- a/internal/app/app_init_core.go
+++ b/internal/app/app_init_core.go
@@ -353,36 +353,11 @@ func (a *App) configureFindingAttestation() {
 		return
 	}
 
-	configured := false
-	if store, ok := a.Findings.(*findings.Store); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-	if store, ok := a.Findings.(*findings.SQLiteStore); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-	if store, ok := a.Findings.(*findings.PostgresStore); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-	if store, ok := a.Findings.(*findings.SnowflakeStore); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-	if store, ok := a.Findings.(*findings.PostgresStore); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-	if store, ok := a.Findings.(*findings.FileStore); ok {
-		store.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
-		configured = true
-	}
-
-	if !configured {
+	if a.Findings == nil {
 		a.Logger.Warn("finding attestation enabled but findings store does not support attestations")
 		return
 	}
+	a.Findings.SetAttestor(attestor, a.Config.FindingAttestationAttestReobserved)
 
 	a.Logger.Info("finding attestation chain enabled",
 		"log_url", strings.TrimSpace(a.Config.FindingAttestationLogURL),

--- a/internal/app/app_init_core_test.go
+++ b/internal/app/app_init_core_test.go
@@ -3,8 +3,10 @@ package app
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/base64"
 	"io"
 	"log/slog"
 	"path/filepath"
@@ -67,6 +69,23 @@ func openPostgresStubDB(t *testing.T) *sql.DB {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	return db
+}
+
+type attestationTrackingFindingStore struct {
+	*findings.Store
+	attestor         findings.FindingAttestor
+	attestReobserved bool
+	setAttestorCalls int
+}
+
+func newAttestationTrackingFindingStore() *attestationTrackingFindingStore {
+	return &attestationTrackingFindingStore{Store: findings.NewStore()}
+}
+
+func (s *attestationTrackingFindingStore) SetAttestor(attestor findings.FindingAttestor, attestReobserved bool) {
+	s.attestor = attestor
+	s.attestReobserved = attestReobserved
+	s.setAttestorCalls++
 }
 
 func TestInitFindings_FallsBackToConfiguredWarehouseMetadata(t *testing.T) {
@@ -209,6 +228,40 @@ func TestNewInMemoryFindingsStore_WarnsOnExplicitUnlimitedConfig(t *testing.T) {
 
 	if !strings.Contains(logs.String(), "configured without size or retention bounds") {
 		t.Fatalf("expected unlimited findings warning, got %q", logs.String())
+	}
+}
+
+func TestConfigureFindingAttestationUsesFindingStoreInterface(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate signing key: %v", err)
+	}
+
+	store := newAttestationTrackingFindingStore()
+	var logs bytes.Buffer
+	a := &App{
+		Config: &Config{
+			FindingAttestationEnabled:          true,
+			FindingAttestationSigningKey:       base64.StdEncoding.EncodeToString(priv),
+			FindingAttestationAttestReobserved: true,
+		},
+		Logger:   slog.New(slog.NewTextHandler(&logs, nil)),
+		Findings: store,
+	}
+
+	a.configureFindingAttestation()
+
+	if store.setAttestorCalls != 1 {
+		t.Fatalf("expected SetAttestor to be called once, got %d", store.setAttestorCalls)
+	}
+	if store.attestor == nil {
+		t.Fatal("expected attestor to be configured on the findings store")
+	}
+	if !store.attestReobserved {
+		t.Fatal("expected attest_reobserved to be forwarded to the findings store")
+	}
+	if !strings.Contains(logs.String(), "finding attestation chain enabled") {
+		t.Fatalf("expected success log, got %q", logs.String())
 	}
 }
 

--- a/internal/findings/store.go
+++ b/internal/findings/store.go
@@ -48,6 +48,8 @@ type FindingStore interface {
 	Suppress(id string) bool
 	Stats() Stats
 	Sync(ctx context.Context) error // Sync to persistent storage
+	SetAttestor(attestor FindingAttestor, attestReobserved bool)
+	SetSemanticDedup(enabled bool)
 }
 
 const (

--- a/internal/notifications/slack_commands_test.go
+++ b/internal/notifications/slack_commands_test.go
@@ -40,7 +40,9 @@ func (m *mockFindingStore) Stats() findings.Stats {
 		ByStatus:   map[string]int{"open": 8, "resolved": 2},
 	}
 }
-func (m *mockFindingStore) Sync(ctx context.Context) error { return nil }
+func (m *mockFindingStore) Sync(ctx context.Context) error             { return nil }
+func (m *mockFindingStore) SetAttestor(findings.FindingAttestor, bool) {}
+func (m *mockFindingStore) SetSemanticDedup(bool)                      {}
 
 func TestSlackCommandHandler_VerifySignature(t *testing.T) {
 	secret := "8f742231b10e8888abcd99yyyzzz85a5"


### PR DESCRIPTION
## Summary
- add attestation and semantic-dedup configuration hooks to the `FindingStore` interface
- configure finding attestations through the interface instead of concrete type assertions, removing the duplicate postgres branch
- forward the new hooks through tenant and test store adapters and cover the interface path in app tests

## Validation
- go test ./internal/findings ./internal/app ./internal/api ./internal/notifications
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Closes #347