### PR TITLE
fix(graph): reject private public IPs

### DIFF
--- a/internal/graph/builders/builder.go
+++ b/internal/graph/builders/builder.go
@@ -728,10 +728,17 @@ func isNodePublic(node *Node) bool {
 	return false
 }
 
-// isValidPublicIP returns true if the string is a valid, non-placeholder IP address.
+// isValidPublicIP returns true if the string is a valid, publicly routable IP address.
 func isValidPublicIP(s string) bool {
 	s = strings.TrimSpace(s)
-	return s != "" && net.ParseIP(s) != nil
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return false
+	}
+	return !ip.IsLoopback() &&
+		!ip.IsPrivate() &&
+		!ip.IsLinkLocalUnicast() &&
+		!ip.IsUnspecified()
 }
 
 func toString(v any) string {

--- a/internal/graph/builders/builder_test.go
+++ b/internal/graph/builders/builder_test.go
@@ -700,8 +700,6 @@ func TestIsValidPublicIP(t *testing.T) {
 		"54.239.28.85",
 		"203.0.113.1",
 		"2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-		"::1",
-		"0.0.0.0",
 	}
 	for _, ip := range valid {
 		if !isValidPublicIP(ip) {
@@ -720,6 +718,13 @@ func TestIsValidPublicIP(t *testing.T) {
 		"version 2",
 		"192.168.1.",
 		"abc.def.ghi.jkl",
+		"10.0.0.8",
+		"172.16.4.10",
+		"192.168.1.20",
+		"169.254.10.2",
+		"::1",
+		"fe80::1",
+		"0.0.0.0",
 	}
 	for _, ip := range invalid {
 		if isValidPublicIP(ip) {
@@ -757,6 +762,11 @@ func TestIsNodePublic(t *testing.T) {
 		{
 			name:   "empty public_ip",
 			node:   &Node{ID: "i3", Kind: NodeKindInstance, Properties: map[string]any{"public_ip": ""}},
+			public: false,
+		},
+		{
+			name:   "private public_ip",
+			node:   &Node{ID: "i4", Kind: NodeKindInstance, Properties: map[string]any{"public_ip": "10.0.0.8"}},
 			public: false,
 		},
 		{


### PR DESCRIPTION
## Summary
- treat only publicly routable IPs as public graph exposure signals
- exclude private, link-local, loopback, and unspecified addresses from `isValidPublicIP`
- add regression coverage for private-address false positives in node public detection

## Validation
- go test ./internal/graph/builders
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Closes #343