### PR TITLE
fix(policy): preserve empty-description violations

### DIFF
--- a/internal/policy/empty_description_regression_test.go
+++ b/internal/policy/empty_description_regression_test.go
@@ -1,0 +1,68 @@
+package policy
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEvaluateAssetReportsViolationsWithEmptyDescription(t *testing.T) {
+	engine := NewEngine()
+	engine.AddPolicy(&Policy{
+		ID:              "no-desc",
+		Name:            "No description policy",
+		Effect:          "forbid",
+		Resource:        "aws::s3::bucket",
+		ConditionFormat: ConditionFormatCEL,
+		Conditions:      []string{`cmp_eq(path(resource, "public"), true)`},
+		Severity:        "high",
+	})
+	engine.AddPolicy(&Policy{
+		ID:              "has-desc",
+		Name:            "Has description policy",
+		Description:     "Public bucket detected",
+		Effect:          "forbid",
+		Resource:        "aws::s3::bucket",
+		ConditionFormat: ConditionFormatCEL,
+		Conditions:      []string{`cmp_eq(path(resource, "public"), true)`},
+		Severity:        "high",
+	})
+
+	findings, err := engine.EvaluateAsset(context.Background(), map[string]interface{}{
+		"_cq_id":    "res-1",
+		"_cq_table": "aws_s3_buckets",
+		"public":    true,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateAsset() error = %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("expected 2 findings for matching policies, got %d", len(findings))
+	}
+}
+
+func TestEvaluatePolicyAgainstAssetsCountsViolationsWithEmptyDescription(t *testing.T) {
+	engine := NewEngine()
+	assets := []map[string]interface{}{
+		{
+			"_cq_id":    "res-1",
+			"_cq_table": "aws_s3_buckets",
+			"public":    true,
+		},
+	}
+
+	result, err := engine.evaluatePolicyAgainstAssets(context.Background(), &Policy{
+		ID:              "no-desc",
+		Name:            "No description policy",
+		Effect:          "forbid",
+		Resource:        "aws::s3::bucket",
+		ConditionFormat: ConditionFormatCEL,
+		Conditions:      []string{`cmp_eq(path(resource, "public"), true)`},
+		Severity:        "high",
+	}, assets)
+	if err != nil {
+		t.Fatalf("evaluatePolicyAgainstAssets() error = %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 matching asset, got %d", len(result))
+	}
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -802,7 +802,7 @@ func (e *Engine) EvaluateAsset(ctx context.Context, asset map[string]interface{}
 			}
 		}
 
-		if violation := e.checkAssetViolation(p, asset); violation != "" {
+		if violation, matched := e.checkAssetViolation(p, asset); matched {
 			// Extract resource identifiers
 			resourceID := extractResourceID(asset)
 			resourceName := extractResourceName(asset)
@@ -842,18 +842,18 @@ func (e *Engine) matchPolicy(p *Policy, req *EvalRequest) bool {
 	return true
 }
 
-func (e *Engine) checkAssetViolation(p *Policy, asset map[string]interface{}) string {
+func (e *Engine) checkAssetViolation(p *Policy, asset map[string]interface{}) (string, bool) {
 	// All conditions must match for a violation (AND logic)
 	if len(p.Conditions) == 0 {
-		return ""
+		return "", false
 	}
 	if normalizeConditionFormat(p.ConditionFormat) != ConditionFormatCEL {
-		return ""
+		return "", false
 	}
 	if !e.evaluateCELConditions(p, asset) {
-		return ""
+		return "", false
 	}
-	return p.Description // All conditions matched - violation
+	return p.Description, true // All conditions matched - violation
 }
 
 func normalizeLogicalOperators(condition string) string {

--- a/internal/policy/versioning.go
+++ b/internal/policy/versioning.go
@@ -376,7 +376,7 @@ func (e *Engine) evaluatePolicyAgainstAssets(ctx context.Context, p *Policy, ass
 		if len(asset) == 0 || !policyAppliesToAssetTable(p, asset) {
 			continue
 		}
-		if violation := preparedEngine.checkAssetViolation(preparedPolicy, asset); violation == "" {
+		if _, matched := preparedEngine.checkAssetViolation(preparedPolicy, asset); !matched {
 			continue
 		}
 		findingID := fmt.Sprintf("%s-%v", policyID, asset["_cq_id"])


### PR DESCRIPTION
## Summary
- separate violation matching from the optional description payload in policy evaluation
- keep versioning candidate evaluation aligned with that behavior
- add regression coverage for empty-description policies in both evaluation paths

## Testing
- go test ./internal/policy
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #364