### PR TITLE
fix(findings): snapshot dirty rows before sync

### DIFF
--- a/internal/findings/postgres_store.go
+++ b/internal/findings/postgres_store.go
@@ -986,24 +986,10 @@ func (s *PostgresStore) Sync(ctx context.Context) error {
 	}
 
 	s.mu.Lock()
-	dirtyIDs := make([]string, 0, len(s.dirty))
-	for id := range s.dirty {
-		dirtyIDs = append(dirtyIDs, id)
-	}
+	findings, err := snapshotDirtyFindings(s.cache, s.dirty)
 	s.mu.Unlock()
-
-	if len(dirtyIDs) == 0 {
-		return nil
-	}
-
-	findings := make([]*Finding, 0, len(dirtyIDs))
-	for _, id := range dirtyIDs {
-		s.mu.RLock()
-		finding, ok := s.cache[id]
-		s.mu.RUnlock()
-		if ok {
-			findings = append(findings, finding)
-		}
+	if err != nil {
+		return fmt.Errorf("snapshot dirty findings: %w", err)
 	}
 	if len(findings) == 0 {
 		return nil

--- a/internal/findings/snowflake_store.go
+++ b/internal/findings/snowflake_store.go
@@ -353,24 +353,10 @@ func (s *SnowflakeStore) Stats() Stats {
 // Sync persists dirty findings to Snowflake
 func (s *SnowflakeStore) Sync(ctx context.Context) error {
 	s.mu.Lock()
-	dirtyIDs := make([]string, 0, len(s.dirty))
-	for id := range s.dirty {
-		dirtyIDs = append(dirtyIDs, id)
-	}
+	findings, err := snapshotDirtyFindings(s.cache, s.dirty)
 	s.mu.Unlock()
-
-	if len(dirtyIDs) == 0 {
-		return nil
-	}
-
-	findings := make([]*Finding, 0, len(dirtyIDs))
-	for _, id := range dirtyIDs {
-		s.mu.RLock()
-		f, ok := s.cache[id]
-		s.mu.RUnlock()
-		if ok {
-			findings = append(findings, f)
-		}
+	if err != nil {
+		return fmt.Errorf("snapshot dirty findings: %w", err)
 	}
 	if len(findings) == 0 {
 		return nil

--- a/internal/findings/sync_snapshot.go
+++ b/internal/findings/sync_snapshot.go
@@ -1,0 +1,42 @@
+package findings
+
+import "encoding/json"
+
+func cloneFindingForSync(f *Finding) (*Finding, error) {
+	if f == nil {
+		return nil, nil
+	}
+
+	raw, err := json.Marshal(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var clone Finding
+	if err := json.Unmarshal(raw, &clone); err != nil {
+		return nil, err
+	}
+	clone.resourceJSONRaw = cloneBytes(f.resourceJSONRaw)
+	return &clone, nil
+}
+
+func snapshotDirtyFindings(cache map[string]*Finding, dirty map[string]bool) ([]*Finding, error) {
+	if len(dirty) == 0 {
+		return nil, nil
+	}
+
+	findings := make([]*Finding, 0, len(dirty))
+	for id := range dirty {
+		finding, ok := cache[id]
+		if !ok || finding == nil {
+			continue
+		}
+
+		clone, err := cloneFindingForSync(finding)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, clone)
+	}
+	return findings, nil
+}

--- a/internal/findings/sync_snapshot_test.go
+++ b/internal/findings/sync_snapshot_test.go
@@ -1,0 +1,71 @@
+package findings
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSnapshotDirtyFindingsDetachesMutableState(t *testing.T) {
+	dueAt := time.Date(2026, time.April, 16, 12, 0, 0, 0, time.UTC)
+	original := &Finding{
+		ID:                 "finding-1",
+		Status:             "OPEN",
+		DueAt:              &dueAt,
+		Resource:           map[string]interface{}{"nested": map[string]interface{}{"name": "before"}},
+		ResourceJSON:       map[string]interface{}{"nested": map[string]interface{}{"state": "before"}},
+		ResourceTags:       map[string]string{"env": "prod"},
+		ObservedFindingIDs: []string{"obs-1"},
+		Evidence: []Evidence{{
+			Type: "snapshot",
+			Data: map[string]interface{}{"status": "before"},
+		}},
+		resourceJSONRaw: []byte(`{"name":"before"}`),
+	}
+
+	snapshots, err := snapshotDirtyFindings(
+		map[string]*Finding{original.ID: original},
+		map[string]bool{original.ID: true},
+	)
+	if err != nil {
+		t.Fatalf("snapshotDirtyFindings() error = %v", err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("len(snapshots) = %d, want 1", len(snapshots))
+	}
+
+	snapshot := snapshots[0]
+	updatedDueAt := dueAt.Add(2 * time.Hour)
+	original.Status = "RESOLVED"
+	original.DueAt = &updatedDueAt
+	original.Resource["nested"].(map[string]interface{})["name"] = "after"
+	original.ResourceJSON["nested"].(map[string]interface{})["state"] = "after"
+	original.ResourceTags["env"] = "stage"
+	original.ObservedFindingIDs[0] = "obs-2"
+	original.Evidence[0].Data["status"] = "after"
+	original.resourceJSONRaw[2] = 'X'
+
+	if snapshot.Status != "OPEN" {
+		t.Fatalf("snapshot status = %q, want OPEN", snapshot.Status)
+	}
+	if snapshot.DueAt == nil || !snapshot.DueAt.Equal(dueAt) {
+		t.Fatalf("snapshot DueAt = %v, want %s", snapshot.DueAt, dueAt)
+	}
+	if got := snapshot.Resource["nested"].(map[string]interface{})["name"]; got != "before" {
+		t.Fatalf("snapshot resource name = %#v, want before", got)
+	}
+	if got := snapshot.ResourceJSON["nested"].(map[string]interface{})["state"]; got != "before" {
+		t.Fatalf("snapshot resource json state = %#v, want before", got)
+	}
+	if got := snapshot.ResourceTags["env"]; got != "prod" {
+		t.Fatalf("snapshot resource tag = %q, want prod", got)
+	}
+	if got := snapshot.ObservedFindingIDs[0]; got != "obs-1" {
+		t.Fatalf("snapshot observed finding id = %q, want obs-1", got)
+	}
+	if got := snapshot.Evidence[0].Data["status"]; got != "before" {
+		t.Fatalf("snapshot evidence status = %#v, want before", got)
+	}
+	if got := string(snapshot.resourceJSONRaw); got != `{"name":"before"}` {
+		t.Fatalf("snapshot resourceJSONRaw = %q, want original bytes", got)
+	}
+}


### PR DESCRIPTION
## Summary
- snapshot dirty findings into detached clones before building Postgres and Snowflake sync batches
- reuse a shared sync snapshot helper so concurrent cache mutations cannot tear persisted rows
- add regression coverage that verifies mutable maps, slices, pointers, and cached JSON bytes are detached from the live store

## Validation
- go test ./internal/findings
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Closes #341