### PR TITLE
fix(agents): raise SSE scan buffer

### DIFF
--- a/internal/agents/providers/sse.go
+++ b/internal/agents/providers/sse.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+const (
+	sseReaderInitialBufferSize = 64 * 1024
+	sseReaderMaxBufferSize     = 1024 * 1024
+)
+
 // SSEEvent represents a Server-Sent Event
 type SSEEvent struct {
 	Event string
@@ -20,8 +25,10 @@ type SSEReader struct {
 
 // newSSEReader creates a new SSE reader
 func newSSEReader(r io.Reader) *SSEReader {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, sseReaderInitialBufferSize), sseReaderMaxBufferSize)
 	return &SSEReader{
-		scanner: bufio.NewScanner(r),
+		scanner: scanner,
 	}
 }
 

--- a/internal/agents/providers/sse_test.go
+++ b/internal/agents/providers/sse_test.go
@@ -1,6 +1,8 @@
 package providers
 
 import (
+	"bufio"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -18,5 +20,15 @@ func TestSSEReaderAcceptsLargeDataLines(t *testing.T) {
 	}
 	if event.Data != payload {
 		t.Fatalf("event.Data length = %d, want %d", len(event.Data), len(payload))
+	}
+}
+
+func TestSSEReaderReturnsErrTooLongForOversizedDataLines(t *testing.T) {
+	payload := strings.Repeat("x", sseReaderMaxBufferSize+1)
+	reader := newSSEReader(strings.NewReader("data: " + payload + "\n\n"))
+
+	_, err := reader.Next()
+	if !errors.Is(err, bufio.ErrTooLong) {
+		t.Fatalf("expected ErrTooLong, got %v", err)
 	}
 }

--- a/internal/agents/providers/sse_test.go
+++ b/internal/agents/providers/sse_test.go
@@ -1,0 +1,22 @@
+package providers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSSEReaderAcceptsLargeDataLines(t *testing.T) {
+	payload := strings.Repeat("x", 70*1024)
+	reader := newSSEReader(strings.NewReader("data: " + payload + "\n\n"))
+
+	event, err := reader.Next()
+	if err != nil {
+		t.Fatalf("Next() error = %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event")
+	}
+	if event.Data != payload {
+		t.Fatalf("event.Data length = %d, want %d", len(event.Data), len(payload))
+	}
+}


### PR DESCRIPTION
## Summary
- configure the SSE reader scanner with a larger max token size for large streamed payloads
- add regression coverage for SSE data lines larger than the default scanner limit

## Testing
- go test ./internal/agents/providers
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #307