### PR TITLE
fix(appstate): serialize first schema creation

### DIFF
--- a/internal/agents/session_store_bench_test.go
+++ b/internal/agents/session_store_bench_test.go
@@ -1,0 +1,48 @@
+package agents
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func newBenchmarkSessionSQLiteDB(b *testing.B) *sql.DB {
+	b.Helper()
+	dbPath := filepath.Join(b.TempDir(), "sessions.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		b.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(8)
+	b.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func BenchmarkPostgresSessionStoreEnsureSchemaReady(b *testing.B) {
+	store := NewPostgresSessionStore(newBenchmarkSessionSQLiteDB(b))
+	store.rewriteSQL = sessionStoreSQLiteRewrite
+	if err := store.EnsureSchema(context.Background()); err != nil {
+		b.Fatalf("seed EnsureSchema(): %v", err)
+	}
+
+	b.Run("serial", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := store.EnsureSchema(context.Background()); err != nil {
+				b.Fatalf("EnsureSchema(): %v", err)
+			}
+		}
+	})
+
+	b.Run("parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if err := store.EnsureSchema(context.Background()); err != nil {
+					b.Fatalf("EnsureSchema(): %v", err)
+				}
+			}
+		})
+	})
+}

--- a/internal/agents/session_store_first_use_concurrency_test.go
+++ b/internal/agents/session_store_first_use_concurrency_test.go
@@ -1,0 +1,50 @@
+package agents
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func newConcurrentSessionSQLiteDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(8)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestTDDSessionStore_ConcurrentFirstGetOnFreshDB(t *testing.T) {
+	store := NewPostgresSessionStore(newConcurrentSessionSQLiteDB(t))
+	store.rewriteSQL = sessionStoreSQLiteRewrite
+
+	const n = 20
+	start := make(chan struct{})
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, errs[i] = store.Get(context.Background(), fmt.Sprintf("session-first-use-%d", i))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: Get() error = %v", i, err)
+		}
+	}
+}

--- a/internal/agents/session_store_first_use_concurrency_test.go
+++ b/internal/agents/session_store_first_use_concurrency_test.go
@@ -3,10 +3,12 @@ package agents
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -47,4 +49,29 @@ func TestTDDSessionStore_ConcurrentFirstGetOnFreshDB(t *testing.T) {
 			t.Fatalf("goroutine %d: Get() error = %v", i, err)
 		}
 	}
+}
+
+func TestTDDSessionStore_SaveHonorsContextWhileWaitingForSchema(t *testing.T) {
+	store := NewPostgresSessionStore(newConcurrentSessionSQLiteDB(t))
+	store.rewriteSQL = sessionStoreSQLiteRewrite
+	state := &schemaInitState{done: make(chan struct{})}
+	store.schemaInit = state
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := store.Save(ctx, &Session{
+		ID:      "session-1",
+		AgentID: "agent",
+		UserID:  "user",
+		Status:  "active",
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	if waited := time.Since(start); waited > 200*time.Millisecond {
+		t.Fatalf("waited too long for context cancellation: %s", waited)
+	}
+	close(state.done)
 }

--- a/internal/agents/session_store_postgres.go
+++ b/internal/agents/session_store_postgres.go
@@ -6,14 +6,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 )
 
 const postgresSessionTable = "cerebro_agent_sessions"
 
 type PostgresSessionStore struct {
-	db         *sql.DB
-	rewriteSQL func(string) string
+	db          *sql.DB
+	rewriteSQL  func(string) string
+	schemaMu    sync.Mutex
+	schemaReady bool
 }
 
 func NewPostgresSessionStore(db *sql.DB) *PostgresSessionStore {
@@ -23,6 +26,11 @@ func NewPostgresSessionStore(db *sql.DB) *PostgresSessionStore {
 func (s *PostgresSessionStore) EnsureSchema(ctx context.Context) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("postgres session store is not initialized")
+	}
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	if s.schemaReady {
+		return nil
 	}
 	_, err := s.db.ExecContext(ctx, s.q(`
 CREATE TABLE IF NOT EXISTS `+postgresSessionTable+` (
@@ -37,6 +45,9 @@ CREATE TABLE IF NOT EXISTS `+postgresSessionTable+` (
 );
 CREATE INDEX IF NOT EXISTS idx_`+postgresSessionTable+`_updated_at ON `+postgresSessionTable+` (updated_at);
 `))
+	if err == nil {
+		s.schemaReady = true
+	}
 	return err
 }
 

--- a/internal/agents/session_store_postgres.go
+++ b/internal/agents/session_store_postgres.go
@@ -12,11 +12,17 @@ import (
 
 const postgresSessionTable = "cerebro_agent_sessions"
 
+type schemaInitState struct {
+	done chan struct{}
+	err  error
+}
+
 type PostgresSessionStore struct {
 	db          *sql.DB
 	rewriteSQL  func(string) string
 	schemaMu    sync.Mutex
 	schemaReady bool
+	schemaInit  *schemaInitState
 }
 
 func NewPostgresSessionStore(db *sql.DB) *PostgresSessionStore {
@@ -27,11 +33,43 @@ func (s *PostgresSessionStore) EnsureSchema(ctx context.Context) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("postgres session store is not initialized")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	s.schemaMu.Lock()
-	defer s.schemaMu.Unlock()
 	if s.schemaReady {
+		s.schemaMu.Unlock()
 		return nil
 	}
+	if state := s.schemaInit; state != nil {
+		s.schemaMu.Unlock()
+		select {
+		case <-state.done:
+			return state.err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	state := &schemaInitState{done: make(chan struct{})}
+	s.schemaInit = state
+	s.schemaMu.Unlock()
+
+	state.err = s.ensureSchemaDDL(ctx)
+
+	s.schemaMu.Lock()
+	if state.err == nil {
+		s.schemaReady = true
+	}
+	if s.schemaInit == state {
+		s.schemaInit = nil
+	}
+	s.schemaMu.Unlock()
+	close(state.done)
+	return state.err
+}
+
+func (s *PostgresSessionStore) ensureSchemaDDL(ctx context.Context) error {
 	_, err := s.db.ExecContext(ctx, s.q(`
 CREATE TABLE IF NOT EXISTS `+postgresSessionTable+` (
 	id TEXT PRIMARY KEY,
@@ -45,9 +83,6 @@ CREATE TABLE IF NOT EXISTS `+postgresSessionTable+` (
 );
 CREATE INDEX IF NOT EXISTS idx_`+postgresSessionTable+`_updated_at ON `+postgresSessionTable+` (updated_at);
 `))
-	if err == nil {
-		s.schemaReady = true
-	}
 	return err
 }
 

--- a/internal/appstate/postgres.go
+++ b/internal/appstate/postgres.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,8 +23,10 @@ const (
 )
 
 type AuditRepository struct {
-	db         *sql.DB
-	rewriteSQL func(string) string
+	db          *sql.DB
+	rewriteSQL  func(string) string
+	schemaMu    sync.Mutex
+	schemaReady bool
 }
 
 func NewAuditRepository(db *sql.DB) *AuditRepository {
@@ -33,6 +36,11 @@ func NewAuditRepository(db *sql.DB) *AuditRepository {
 func (r *AuditRepository) EnsureSchema(ctx context.Context) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("audit repository is not initialized")
+	}
+	r.schemaMu.Lock()
+	defer r.schemaMu.Unlock()
+	if r.schemaReady {
+		return nil
 	}
 	_, err := r.db.ExecContext(ctx, r.q(`
 CREATE TABLE IF NOT EXISTS `+auditTable+` (
@@ -50,6 +58,9 @@ CREATE TABLE IF NOT EXISTS `+auditTable+` (
 CREATE INDEX IF NOT EXISTS idx_`+auditTable+`_resource ON `+auditTable+` (resource_type, resource_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_`+auditTable+`_created_at ON `+auditTable+` (created_at);
 `))
+	if err == nil {
+		r.schemaReady = true
+	}
 	return err
 }
 
@@ -179,8 +190,10 @@ func (r *AuditRepository) q(query string) string {
 }
 
 type PolicyHistoryRepository struct {
-	db         *sql.DB
-	rewriteSQL func(string) string
+	db          *sql.DB
+	rewriteSQL  func(string) string
+	schemaMu    sync.Mutex
+	schemaReady bool
 }
 
 func NewPolicyHistoryRepository(db *sql.DB) *PolicyHistoryRepository {
@@ -190,6 +203,11 @@ func NewPolicyHistoryRepository(db *sql.DB) *PolicyHistoryRepository {
 func (r *PolicyHistoryRepository) EnsureSchema(ctx context.Context) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("policy history repository is not initialized")
+	}
+	r.schemaMu.Lock()
+	defer r.schemaMu.Unlock()
+	if r.schemaReady {
+		return nil
 	}
 	_, err := r.db.ExecContext(ctx, r.q(`
 CREATE TABLE IF NOT EXISTS `+policyHistoryTable+` (
@@ -205,6 +223,9 @@ CREATE TABLE IF NOT EXISTS `+policyHistoryTable+` (
 );
 CREATE INDEX IF NOT EXISTS idx_`+policyHistoryTable+`_policy ON `+policyHistoryTable+` (policy_id, version DESC);
 `))
+	if err == nil {
+		r.schemaReady = true
+	}
 	return err
 }
 
@@ -338,8 +359,10 @@ func (r *PolicyHistoryRepository) q(query string) string {
 }
 
 type RiskEngineStateRepository struct {
-	db         *sql.DB
-	rewriteSQL func(string) string
+	db          *sql.DB
+	rewriteSQL  func(string) string
+	schemaMu    sync.Mutex
+	schemaReady bool
 }
 
 func NewRiskEngineStateRepository(db *sql.DB) *RiskEngineStateRepository {
@@ -350,6 +373,11 @@ func (r *RiskEngineStateRepository) EnsureSchema(ctx context.Context) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("risk engine state repository is not initialized")
 	}
+	r.schemaMu.Lock()
+	defer r.schemaMu.Unlock()
+	if r.schemaReady {
+		return nil
+	}
 	_, err := r.db.ExecContext(ctx, r.q(`
 CREATE TABLE IF NOT EXISTS `+riskEngineStateTable+` (
 	graph_id TEXT PRIMARY KEY,
@@ -357,6 +385,9 @@ CREATE TABLE IF NOT EXISTS `+riskEngineStateTable+` (
 	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 `))
+	if err == nil {
+		r.schemaReady = true
+	}
 	return err
 }
 

--- a/internal/appstate/postgres.go
+++ b/internal/appstate/postgres.go
@@ -22,11 +22,17 @@ const (
 	sessionTable         = "cerebro_agent_sessions"
 )
 
+type schemaInitState struct {
+	done chan struct{}
+	err  error
+}
+
 type AuditRepository struct {
 	db          *sql.DB
 	rewriteSQL  func(string) string
 	schemaMu    sync.Mutex
 	schemaReady bool
+	schemaInit  *schemaInitState
 }
 
 func NewAuditRepository(db *sql.DB) *AuditRepository {
@@ -37,11 +43,43 @@ func (r *AuditRepository) EnsureSchema(ctx context.Context) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("audit repository is not initialized")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	r.schemaMu.Lock()
-	defer r.schemaMu.Unlock()
 	if r.schemaReady {
+		r.schemaMu.Unlock()
 		return nil
 	}
+	if state := r.schemaInit; state != nil {
+		r.schemaMu.Unlock()
+		select {
+		case <-state.done:
+			return state.err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	state := &schemaInitState{done: make(chan struct{})}
+	r.schemaInit = state
+	r.schemaMu.Unlock()
+
+	state.err = r.ensureSchemaDDL(ctx)
+
+	r.schemaMu.Lock()
+	if state.err == nil {
+		r.schemaReady = true
+	}
+	if r.schemaInit == state {
+		r.schemaInit = nil
+	}
+	r.schemaMu.Unlock()
+	close(state.done)
+	return state.err
+}
+
+func (r *AuditRepository) ensureSchemaDDL(ctx context.Context) error {
 	_, err := r.db.ExecContext(ctx, r.q(`
 CREATE TABLE IF NOT EXISTS `+auditTable+` (
 	id TEXT PRIMARY KEY,
@@ -58,9 +96,6 @@ CREATE TABLE IF NOT EXISTS `+auditTable+` (
 CREATE INDEX IF NOT EXISTS idx_`+auditTable+`_resource ON `+auditTable+` (resource_type, resource_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_`+auditTable+`_created_at ON `+auditTable+` (created_at);
 `))
-	if err == nil {
-		r.schemaReady = true
-	}
 	return err
 }
 
@@ -194,6 +229,7 @@ type PolicyHistoryRepository struct {
 	rewriteSQL  func(string) string
 	schemaMu    sync.Mutex
 	schemaReady bool
+	schemaInit  *schemaInitState
 }
 
 func NewPolicyHistoryRepository(db *sql.DB) *PolicyHistoryRepository {
@@ -204,11 +240,43 @@ func (r *PolicyHistoryRepository) EnsureSchema(ctx context.Context) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("policy history repository is not initialized")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	r.schemaMu.Lock()
-	defer r.schemaMu.Unlock()
 	if r.schemaReady {
+		r.schemaMu.Unlock()
 		return nil
 	}
+	if state := r.schemaInit; state != nil {
+		r.schemaMu.Unlock()
+		select {
+		case <-state.done:
+			return state.err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	state := &schemaInitState{done: make(chan struct{})}
+	r.schemaInit = state
+	r.schemaMu.Unlock()
+
+	state.err = r.ensureSchemaDDL(ctx)
+
+	r.schemaMu.Lock()
+	if state.err == nil {
+		r.schemaReady = true
+	}
+	if r.schemaInit == state {
+		r.schemaInit = nil
+	}
+	r.schemaMu.Unlock()
+	close(state.done)
+	return state.err
+}
+
+func (r *PolicyHistoryRepository) ensureSchemaDDL(ctx context.Context) error {
 	_, err := r.db.ExecContext(ctx, r.q(`
 CREATE TABLE IF NOT EXISTS `+policyHistoryTable+` (
 	policy_id TEXT NOT NULL,
@@ -223,9 +291,6 @@ CREATE TABLE IF NOT EXISTS `+policyHistoryTable+` (
 );
 CREATE INDEX IF NOT EXISTS idx_`+policyHistoryTable+`_policy ON `+policyHistoryTable+` (policy_id, version DESC);
 `))
-	if err == nil {
-		r.schemaReady = true
-	}
 	return err
 }
 
@@ -363,6 +428,7 @@ type RiskEngineStateRepository struct {
 	rewriteSQL  func(string) string
 	schemaMu    sync.Mutex
 	schemaReady bool
+	schemaInit  *schemaInitState
 }
 
 func NewRiskEngineStateRepository(db *sql.DB) *RiskEngineStateRepository {
@@ -373,11 +439,43 @@ func (r *RiskEngineStateRepository) EnsureSchema(ctx context.Context) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("risk engine state repository is not initialized")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	r.schemaMu.Lock()
-	defer r.schemaMu.Unlock()
 	if r.schemaReady {
+		r.schemaMu.Unlock()
 		return nil
 	}
+	if state := r.schemaInit; state != nil {
+		r.schemaMu.Unlock()
+		select {
+		case <-state.done:
+			return state.err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	state := &schemaInitState{done: make(chan struct{})}
+	r.schemaInit = state
+	r.schemaMu.Unlock()
+
+	state.err = r.ensureSchemaDDL(ctx)
+
+	r.schemaMu.Lock()
+	if state.err == nil {
+		r.schemaReady = true
+	}
+	if r.schemaInit == state {
+		r.schemaInit = nil
+	}
+	r.schemaMu.Unlock()
+	close(state.done)
+	return state.err
+}
+
+func (r *RiskEngineStateRepository) ensureSchemaDDL(ctx context.Context) error {
 	_, err := r.db.ExecContext(ctx, r.q(`
 CREATE TABLE IF NOT EXISTS `+riskEngineStateTable+` (
 	graph_id TEXT PRIMARY KEY,
@@ -385,9 +483,6 @@ CREATE TABLE IF NOT EXISTS `+riskEngineStateTable+` (
 	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 `))
-	if err == nil {
-		r.schemaReady = true
-	}
 	return err
 }
 

--- a/internal/appstate/schema_bench_test.go
+++ b/internal/appstate/schema_bench_test.go
@@ -1,0 +1,65 @@
+package appstate
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func newBenchmarkAppStateSQLiteDB(b *testing.B, name string) *sql.DB {
+	b.Helper()
+	dbPath := filepath.Join(b.TempDir(), name)
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		b.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(8)
+	b.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func benchmarkEnsureSchemaReady(b *testing.B, ensure func(context.Context) error) {
+	b.Helper()
+	if err := ensure(context.Background()); err != nil {
+		b.Fatalf("seed EnsureSchema(): %v", err)
+	}
+
+	b.Run("serial", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := ensure(context.Background()); err != nil {
+				b.Fatalf("EnsureSchema(): %v", err)
+			}
+		}
+	})
+
+	b.Run("parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if err := ensure(context.Background()); err != nil {
+					b.Fatalf("EnsureSchema(): %v", err)
+				}
+			}
+		})
+	})
+}
+
+func BenchmarkAuditRepositoryEnsureSchemaReady(b *testing.B) {
+	repo := NewAuditRepository(newBenchmarkAppStateSQLiteDB(b, "audit.db"))
+	repo.rewriteSQL = appStateSQLiteRewrite
+	benchmarkEnsureSchemaReady(b, repo.EnsureSchema)
+}
+
+func BenchmarkPolicyHistoryRepositoryEnsureSchemaReady(b *testing.B) {
+	repo := NewPolicyHistoryRepository(newBenchmarkAppStateSQLiteDB(b, "policy_history.db"))
+	repo.rewriteSQL = appStateSQLiteRewrite
+	benchmarkEnsureSchemaReady(b, repo.EnsureSchema)
+}
+
+func BenchmarkRiskEngineStateRepositoryEnsureSchemaReady(b *testing.B) {
+	repo := NewRiskEngineStateRepository(newBenchmarkAppStateSQLiteDB(b, "risk_engine_state.db"))
+	repo.rewriteSQL = appStateSQLiteRewrite
+	benchmarkEnsureSchemaReady(b, repo.EnsureSchema)
+}

--- a/internal/appstate/schema_first_use_concurrency_test.go
+++ b/internal/appstate/schema_first_use_concurrency_test.go
@@ -1,0 +1,102 @@
+package appstate
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func newConcurrentAppStateSQLiteDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "appstate.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(8)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestTDDAuditRepository_ConcurrentFirstListOnFreshDB(t *testing.T) {
+	repo := NewAuditRepository(newConcurrentAppStateSQLiteDB(t))
+	repo.rewriteSQL = appStateSQLiteRewrite
+
+	const n = 20
+	start := make(chan struct{})
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, errs[i] = repo.List(context.Background(), "", "", 10)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: List() error = %v", i, err)
+		}
+	}
+}
+
+func TestTDDRiskEngineStateRepository_ConcurrentFirstUseOnFreshDB(t *testing.T) {
+	repo := NewRiskEngineStateRepository(newConcurrentAppStateSQLiteDB(t))
+	repo.rewriteSQL = appStateSQLiteRewrite
+
+	const n = 20
+	start := make(chan struct{})
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, errs[i] = repo.LoadSnapshot(context.Background(), "security-graph")
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: LoadSnapshot() error = %v", i, err)
+		}
+	}
+}
+
+func TestTDDPolicyHistoryRepository_ConcurrentFirstListOnFreshDB(t *testing.T) {
+	repo := NewPolicyHistoryRepository(newConcurrentAppStateSQLiteDB(t))
+	repo.rewriteSQL = appStateSQLiteRewrite
+
+	const n = 20
+	start := make(chan struct{})
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, errs[i] = repo.List(context.Background(), fmt.Sprintf("policy-%d", i), 10)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: List() error = %v", i, err)
+		}
+	}
+}

--- a/internal/appstate/schema_first_use_concurrency_test.go
+++ b/internal/appstate/schema_first_use_concurrency_test.go
@@ -3,12 +3,16 @@ package appstate
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
+
+	"github.com/writer/cerebro/internal/snowflake"
 )
 
 func newConcurrentAppStateSQLiteDB(t *testing.T) *sql.DB {
@@ -99,4 +103,74 @@ func TestTDDPolicyHistoryRepository_ConcurrentFirstListOnFreshDB(t *testing.T) {
 			t.Fatalf("goroutine %d: List() error = %v", i, err)
 		}
 	}
+}
+
+func TestTDDAuditRepository_LogHonorsContextWhileWaitingForSchema(t *testing.T) {
+	repo := NewAuditRepository(newConcurrentAppStateSQLiteDB(t))
+	repo.rewriteSQL = appStateSQLiteRewrite
+	state := &schemaInitState{done: make(chan struct{})}
+	repo.schemaInit = state
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := repo.Log(ctx, &snowflake.AuditEntry{
+		Action:       "concurrent.action",
+		ActorID:      "user",
+		ResourceType: "race",
+		ResourceID:   "r1",
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	if waited := time.Since(start); waited > 200*time.Millisecond {
+		t.Fatalf("waited too long for context cancellation: %s", waited)
+	}
+	close(state.done)
+}
+
+func TestTDDPolicyHistoryRepository_UpsertHonorsContextWhileWaitingForSchema(t *testing.T) {
+	repo := NewPolicyHistoryRepository(newConcurrentAppStateSQLiteDB(t))
+	repo.rewriteSQL = appStateSQLiteRewrite
+	state := &schemaInitState{done: make(chan struct{})}
+	repo.schemaInit = state
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := repo.Upsert(ctx, &snowflake.PolicyHistoryRecord{
+		PolicyID:      "policy-1",
+		Version:       1,
+		Content:       []byte(`{"version":1}`),
+		EffectiveFrom: time.Now().UTC(),
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	if waited := time.Since(start); waited > 200*time.Millisecond {
+		t.Fatalf("waited too long for context cancellation: %s", waited)
+	}
+	close(state.done)
+}
+
+func TestTDDRiskEngineStateRepository_SaveHonorsContextWhileWaitingForSchema(t *testing.T) {
+	repo := NewRiskEngineStateRepository(newConcurrentAppStateSQLiteDB(t))
+	repo.rewriteSQL = appStateSQLiteRewrite
+	state := &schemaInitState{done: make(chan struct{})}
+	repo.schemaInit = state
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := repo.SaveSnapshot(ctx, "security-graph", []byte(`{"score":42}`))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	if waited := time.Since(start); waited > 200*time.Millisecond {
+		t.Fatalf("waited too long for context cancellation: %s", waited)
+	}
+	close(state.done)
 }


### PR DESCRIPTION
## Summary
- serialize first-time EnsureSchema execution in appstate repositories and the postgres session store
- cache successful schema initialization so later reads and writes skip duplicate DDL
- add fresh-database concurrency regressions for the first List/Get/Load paths

## Testing
- go test ./internal/agents ./internal/appstate
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #365