### PR TITLE
fix(app): protect migration snowflake lifecycle

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -203,6 +203,7 @@ type App struct {
 	tapConsumerDurable                 string
 	tapConsumerSubjects                []string
 	securityGraphInitMu                sync.RWMutex
+	appStateMigrationSourceMu          sync.RWMutex
 	reloadMu                           sync.Mutex
 	apiKeys                            atomic.Value // map[string]string
 	apiCredentials                     atomic.Value // map[string]apiauth.Credential

--- a/internal/app/app_init_core.go
+++ b/internal/app/app_init_core.go
@@ -88,8 +88,10 @@ func (a *App) initSnowflake(ctx context.Context) error {
 		return err
 	}
 
+	a.appStateMigrationSourceMu.Lock()
 	a.Snowflake = client
 	a.LegacySnowflake = nil
+	a.appStateMigrationSourceMu.Unlock()
 	a.Warehouse = client
 	return nil
 }
@@ -102,7 +104,9 @@ func (a *App) initLegacySnowflake(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	a.appStateMigrationSourceMu.Lock()
 	a.LegacySnowflake = client
+	a.appStateMigrationSourceMu.Unlock()
 	return nil
 }
 

--- a/internal/app/app_secrets.go
+++ b/internal/app/app_secrets.go
@@ -315,32 +315,41 @@ func (a *App) rotateSnowflakeClient(ctx context.Context, cfg *Config) error {
 		ctx = context.Background()
 	}
 
+	a.appStateMigrationSourceMu.Lock()
 	oldClient := a.Snowflake
 	oldLegacyClient := a.LegacySnowflake
 	if !hasSnowflakeCredentials(cfg) {
 		if !strings.EqualFold(strings.TrimSpace(cfg.WarehouseBackend), "snowflake") {
 			if a.appStateDB != nil && legacySnowflakeRetentionEnabled(cfg) && (oldLegacyClient != nil || oldClient != nil) {
+				a.appStateMigrationSourceMu.Unlock()
 				return fmt.Errorf("legacy snowflake source is required while graph or access-review retention remains enabled")
 			}
 			a.Snowflake = nil
 			a.LegacySnowflake = nil
+			a.appStateMigrationSourceMu.Unlock()
 			a.initRepositories()
 			a.rebindAgentSessionStore(ctx, nil)
 			a.refreshConfiguredAgentTools(cfg)
 			a.closeSnowflakeClients(oldClient, oldLegacyClient, nil)
 			return nil
 		}
+		a.appStateMigrationSourceMu.Unlock()
 		return fmt.Errorf("snowflake rotation requires SNOWFLAKE_PRIVATE_KEY, SNOWFLAKE_ACCOUNT, and SNOWFLAKE_USER")
 	}
+	a.appStateMigrationSourceMu.Unlock()
 
 	newClient, err := openConfiguredSnowflakeClient(ctx, cfg)
 	if err != nil {
 		return err
 	}
 
+	a.appStateMigrationSourceMu.Lock()
+	oldClient = a.Snowflake
+	oldLegacyClient = a.LegacySnowflake
 	if strings.EqualFold(strings.TrimSpace(cfg.WarehouseBackend), "snowflake") {
 		a.Snowflake = newClient
 		a.LegacySnowflake = nil
+		a.appStateMigrationSourceMu.Unlock()
 		a.Warehouse = newClient
 		a.initRepositories()
 
@@ -367,6 +376,7 @@ func (a *App) rotateSnowflakeClient(ctx context.Context, cfg *Config) error {
 		a.initSecurityGraph(ctx)
 	} else {
 		a.LegacySnowflake = newClient
+		a.appStateMigrationSourceMu.Unlock()
 		a.initRepositories()
 		a.rebindAgentSessionStore(ctx, nil)
 		a.refreshConfiguredAgentTools(cfg)

--- a/internal/app/app_startup_test.go
+++ b/internal/app/app_startup_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/graph"
+	"github.com/writer/cerebro/internal/snowflake"
 )
 
 func TestRunInitStep_RecoversPanic(t *testing.T) {
@@ -262,6 +263,36 @@ func TestClose_LogsWarningWhenGraphShutdownTimesOut(t *testing.T) {
 
 	if !strings.Contains(logs.String(), "timed out waiting for security graph shutdown") {
 		t.Fatalf("expected graph shutdown timeout warning, got logs: %s", logs.String())
+	}
+}
+
+func TestClose_WaitsForAppStateMigrationSourceReaders(t *testing.T) {
+	a := &App{
+		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		LegacySnowflake: new(snowflake.Client),
+	}
+
+	a.appStateMigrationSourceMu.RLock()
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Close()
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("expected Close to wait for app-state migration readers, got early result: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	a.appStateMigrationSourceMu.RUnlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Close() returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close() did not resume after app-state migration readers finished")
 	}
 }
 

--- a/internal/app/app_state_postgres.go
+++ b/internal/app/app_state_postgres.go
@@ -31,6 +31,8 @@ func (a *App) appStateMigrationSnowflake() *snowflake.Client {
 	if a == nil {
 		return nil
 	}
+	a.appStateMigrationSourceMu.RLock()
+	defer a.appStateMigrationSourceMu.RUnlock()
 	if a.LegacySnowflake != nil {
 		return a.LegacySnowflake
 	}
@@ -95,6 +97,8 @@ func (a *App) migrateAppState(ctx context.Context) error {
 	if a == nil || a.appStateDB == nil {
 		return nil
 	}
+	a.appStateMigrationSourceMu.RLock()
+	defer a.appStateMigrationSourceMu.RUnlock()
 	if a.appStateMigrationSnowflake() != nil {
 		if err := a.markAppStateMigrationComplete(ctx, legacySnowflakeAppStateStartedName); err != nil {
 			return fmt.Errorf("mark app-state migration started: %w", err)

--- a/internal/app/app_storage_graph.go
+++ b/internal/app/app_storage_graph.go
@@ -322,7 +322,8 @@ func (a *App) Close() error {
 
 	a.stopThreatIntelSync()
 
-	// Close Snowflake connection
+	a.appStateMigrationSourceMu.Lock()
+	// Close Snowflake connections after any in-flight app-state migration source readers finish.
 	if a.Snowflake != nil {
 		if err := a.Snowflake.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("snowflake: %w", err))
@@ -333,6 +334,7 @@ func (a *App) Close() error {
 			errs = append(errs, fmt.Errorf("legacy snowflake: %w", err))
 		}
 	}
+	a.appStateMigrationSourceMu.Unlock()
 	if closer, ok := a.Warehouse.(interface{ Close() error }); ok {
 		if a.Snowflake == nil || any(a.Warehouse) != any(a.Snowflake) {
 			if err := closer.Close(); err != nil {


### PR DESCRIPTION
## Summary
- guard app-state migration source reads with a dedicated lifecycle RW mutex
- block shutdown and Snowflake rotation from closing migration clients while app-state migration is in flight
- add regression coverage that verifies Close waits for active migration-source readers

## Validation
- go test ./internal/app
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Closes #354