### PR TITLE
fix(app): checkpoint legacy app-state migration progress

### DIFF
--- a/internal/app/app_state_postgres.go
+++ b/internal/app/app_state_postgres.go
@@ -22,10 +22,20 @@ import (
 const appStateRiskEngineGraphID = "security-graph"
 
 const (
-	appStateMigrationStateTable          = "cerebro_app_state_migrations"
-	legacySnowflakeAppStateMigrationName = "legacy_snowflake"
-	legacySnowflakeAppStateStartedName   = "legacy_snowflake_started"
+	appStateMigrationStateTable                = "cerebro_app_state_migrations"
+	legacySnowflakeAppStateMigrationName       = "legacy_snowflake"
+	legacySnowflakeAppStateStartedName         = "legacy_snowflake_started"
+	legacySnowflakeAppStateFindingsName        = "legacy_snowflake_findings"
+	legacySnowflakeAppStateAgentSessionsName   = "legacy_snowflake_agent_sessions"
+	legacySnowflakeAppStateAuditLogsName       = "legacy_snowflake_audit_logs"
+	legacySnowflakeAppStatePolicyHistoryName   = "legacy_snowflake_policy_history"
+	legacySnowflakeAppStateRiskEngineStateName = "legacy_snowflake_risk_engine_state"
 )
+
+type appStateMigrationStep struct {
+	name string
+	run  func(context.Context) error
+}
 
 func (a *App) appStateMigrationSnowflake() *snowflake.Client {
 	if a == nil {
@@ -95,30 +105,53 @@ func (a *App) migrateAppState(ctx context.Context) error {
 	if a == nil || a.appStateDB == nil {
 		return nil
 	}
-	if a.appStateMigrationSnowflake() != nil {
+	tracked := a.appStateMigrationSnowflake() != nil
+	if tracked {
 		if err := a.markAppStateMigrationComplete(ctx, legacySnowflakeAppStateStartedName); err != nil {
 			return fmt.Errorf("mark app-state migration started: %w", err)
 		}
 	}
-	if err := a.migrateFindings(ctx); err != nil {
-		return err
+
+	for _, step := range []appStateMigrationStep{
+		{name: legacySnowflakeAppStateFindingsName, run: a.migrateFindings},
+		{name: legacySnowflakeAppStateAgentSessionsName, run: a.migrateAgentSessions},
+		{name: legacySnowflakeAppStateAuditLogsName, run: a.migrateAuditLogs},
+		{name: legacySnowflakeAppStatePolicyHistoryName, run: a.migratePolicyHistory},
+		{name: legacySnowflakeAppStateRiskEngineStateName, run: a.migrateRiskEngineState},
+	} {
+		if err := a.runAppStateMigrationStep(ctx, step, tracked); err != nil {
+			return err
+		}
 	}
-	if err := a.migrateAgentSessions(ctx); err != nil {
-		return err
-	}
-	if err := a.migrateAuditLogs(ctx); err != nil {
-		return err
-	}
-	if err := a.migratePolicyHistory(ctx); err != nil {
-		return err
-	}
-	if err := a.migrateRiskEngineState(ctx); err != nil {
-		return err
-	}
-	if a.appStateMigrationSnowflake() != nil {
+	if tracked {
 		if err := a.markAppStateMigrationComplete(ctx, legacySnowflakeAppStateMigrationName); err != nil {
 			return fmt.Errorf("mark app-state migration complete: %w", err)
 		}
+	}
+	return nil
+}
+
+func (a *App) runAppStateMigrationStep(ctx context.Context, step appStateMigrationStep, tracked bool) error {
+	if step.run == nil {
+		return nil
+	}
+	if tracked {
+		completed, err := a.appStateMigrationComplete(ctx, step.name)
+		if err != nil {
+			return fmt.Errorf("check app-state migration step %s: %w", step.name, err)
+		}
+		if completed {
+			return nil
+		}
+	}
+	if err := step.run(ctx); err != nil {
+		return err
+	}
+	if !tracked {
+		return nil
+	}
+	if err := a.markAppStateMigrationComplete(ctx, step.name); err != nil {
+		return fmt.Errorf("mark app-state migration step %s complete: %w", step.name, err)
 	}
 	return nil
 }

--- a/internal/app/app_state_postgres_test.go
+++ b/internal/app/app_state_postgres_test.go
@@ -174,3 +174,120 @@ func TestIsMissingSnowflakeTableErrAcceptsMissingTableErrors(t *testing.T) {
 		t.Fatal("expected missing table error to be treated as skippable migration input")
 	}
 }
+
+func TestRunAppStateMigrationStepSkipsCompletedTrackedStep(t *testing.T) {
+	ctx := context.Background()
+	appStateDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open app-state sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = appStateDB.Close() })
+
+	a := &App{appStateDB: appStateDB}
+	if err := a.markAppStateMigrationComplete(ctx, legacySnowflakeAppStateFindingsName); err != nil {
+		t.Fatalf("markAppStateMigrationComplete() error = %v", err)
+	}
+
+	called := false
+	err = a.runAppStateMigrationStep(ctx, appStateMigrationStep{
+		name: legacySnowflakeAppStateFindingsName,
+		run: func(context.Context) error {
+			called = true
+			return nil
+		},
+	}, true)
+	if err != nil {
+		t.Fatalf("runAppStateMigrationStep() error = %v", err)
+	}
+	if called {
+		t.Fatal("expected completed tracked migration step to be skipped")
+	}
+}
+
+func TestRunAppStateMigrationStepMarksTrackedStepCompleteAfterSuccess(t *testing.T) {
+	ctx := context.Background()
+	appStateDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open app-state sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = appStateDB.Close() })
+
+	a := &App{appStateDB: appStateDB}
+	err = a.runAppStateMigrationStep(ctx, appStateMigrationStep{
+		name: legacySnowflakeAppStateAgentSessionsName,
+		run:  func(context.Context) error { return nil },
+	}, true)
+	if err != nil {
+		t.Fatalf("runAppStateMigrationStep() error = %v", err)
+	}
+
+	completed, err := a.appStateMigrationComplete(ctx, legacySnowflakeAppStateAgentSessionsName)
+	if err != nil {
+		t.Fatalf("appStateMigrationComplete() error = %v", err)
+	}
+	if !completed {
+		t.Fatal("expected successful tracked migration step to be marked complete")
+	}
+}
+
+func TestRunAppStateMigrationStepLeavesTrackedStepIncompleteOnError(t *testing.T) {
+	ctx := context.Background()
+	appStateDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open app-state sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = appStateDB.Close() })
+
+	a := &App{appStateDB: appStateDB}
+	want := errors.New("boom")
+	err = a.runAppStateMigrationStep(ctx, appStateMigrationStep{
+		name: legacySnowflakeAppStateAuditLogsName,
+		run: func(context.Context) error {
+			return want
+		},
+	}, true)
+	if !errors.Is(err, want) {
+		t.Fatalf("runAppStateMigrationStep() error = %v, want %v", err, want)
+	}
+
+	completed, err := a.appStateMigrationComplete(ctx, legacySnowflakeAppStateAuditLogsName)
+	if err != nil {
+		t.Fatalf("appStateMigrationComplete() error = %v", err)
+	}
+	if completed {
+		t.Fatal("expected failed tracked migration step to remain incomplete")
+	}
+}
+
+func TestRunAppStateMigrationStepDoesNotMarkUntrackedStepComplete(t *testing.T) {
+	ctx := context.Background()
+	appStateDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open app-state sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = appStateDB.Close() })
+
+	a := &App{appStateDB: appStateDB}
+	called := false
+	err = a.runAppStateMigrationStep(ctx, appStateMigrationStep{
+		name: legacySnowflakeAppStatePolicyHistoryName,
+		run: func(context.Context) error {
+			called = true
+			return nil
+		},
+	}, false)
+	if err != nil {
+		t.Fatalf("runAppStateMigrationStep() error = %v", err)
+	}
+	if !called {
+		t.Fatal("expected untracked migration step to run")
+	}
+
+	completed, err := a.appStateMigrationComplete(ctx, legacySnowflakeAppStatePolicyHistoryName)
+	if err != nil {
+		t.Fatalf("appStateMigrationComplete() error = %v", err)
+	}
+	if completed {
+		t.Fatal("expected untracked migration step not to be marked complete")
+	}
+}


### PR DESCRIPTION
## Summary
- checkpoint each legacy app-state migration step so completed steps do not re-run on every startup
- preserve partial progress by marking individual step completion only after successful migration work
- add regression coverage for tracked and untracked migration step behavior

## Validation
- go test ./internal/app
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Closes #351
Closes #352