### PR TITLE
fix(api): return 500 when JSON responses fail to encode

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"crypto/subtle"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -20,12 +19,15 @@ type APIError struct {
 }
 
 func writeJSONError(w http.ResponseWriter, status int, code, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(APIError{
+	payload, err := encodeJSONPayload(APIError{
 		Error: message,
 		Code:  code,
 	})
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSONPayload(w, status, payload, nil)
 }
 
 type contextKey string

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -105,7 +105,9 @@ func (s *Server) writeJSONEncodingError(w http.ResponseWriter, err error) {
 
 func encodeJSONPayload(data any) ([]byte, error) {
 	var payload bytes.Buffer
-	if err := json.NewEncoder(&payload).Encode(data); err != nil {
+	encoder := json.NewEncoder(&payload)
+	encoder.SetEscapeHTML(true)
+	if err := encoder.Encode(data); err != nil {
 		return nil, err
 	}
 	return payload.Bytes(), nil
@@ -119,5 +121,5 @@ func writeJSONPayload(w http.ResponseWriter, status int, payload []byte, headers
 		w.Header().Set("Content-Type", "application/json")
 	}
 	w.WriteHeader(status)
-	_, _ = w.Write(payload)
+	_, _ = w.Write(payload) // #nosec G705 -- payload is JSON encoded with html escaping enabled in encodeJSONPayload.
 }

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -10,9 +11,12 @@ import (
 )
 
 func (s *Server) json(w http.ResponseWriter, status int, data interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(data)
+	payload, err := encodeJSONPayload(data)
+	if err != nil {
+		s.writeJSONEncodingError(w, err)
+		return
+	}
+	writeJSONPayload(w, status, payload, nil)
 }
 
 func (s *Server) error(w http.ResponseWriter, status int, message string) {
@@ -81,4 +85,39 @@ func httpStatusToCode(status int) string {
 	default:
 		return "error"
 	}
+}
+
+func (s *Server) writeJSONEncodingError(w http.ResponseWriter, err error) {
+	if s.app != nil && s.app.Logger != nil {
+		s.app.Logger.Error("api json encoding failed", "error", err)
+	}
+
+	payload, marshalErr := encodeJSONPayload(APIError{
+		Error: "internal server error",
+		Code:  httpStatusToCode(http.StatusInternalServerError),
+	})
+	if marshalErr != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	writeJSONPayload(w, http.StatusInternalServerError, payload, nil)
+}
+
+func encodeJSONPayload(data any) ([]byte, error) {
+	var payload bytes.Buffer
+	if err := json.NewEncoder(&payload).Encode(data); err != nil {
+		return nil, err
+	}
+	return payload.Bytes(), nil
+}
+
+func writeJSONPayload(w http.ResponseWriter, status int, payload []byte, headers map[string]string) {
+	for key, value := range headers {
+		w.Header().Set(key, value)
+	}
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write(payload)
 }

--- a/internal/api/responses_test.go
+++ b/internal/api/responses_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -127,5 +128,27 @@ func TestErrorFromErr_ResponseMapping(t *testing.T) {
 				t.Fatalf("expected original error message for status %d", tc.wantStatus)
 			}
 		})
+	}
+}
+
+func TestJSONEncodingFailureReturnsInternalServerError(t *testing.T) {
+	s := &Server{}
+	w := httptest.NewRecorder()
+
+	s.json(w, http.StatusOK, map[string]float64{"value": math.NaN()})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content type = %q, want application/json", got)
+	}
+
+	body := decodeAPIErrorResponse(t, w)
+	if body.Code != "internal_error" {
+		t.Fatalf("code = %q, want internal_error", body.Code)
+	}
+	if body.Error != "internal server error" {
+		t.Fatalf("error = %q, want internal server error", body.Error)
 	}
 }

--- a/internal/api/responses_test.go
+++ b/internal/api/responses_test.go
@@ -152,3 +152,15 @@ func TestJSONEncodingFailureReturnsInternalServerError(t *testing.T) {
 		t.Fatalf("error = %q, want internal server error", body.Error)
 	}
 }
+
+func TestEncodeJSONPayloadEscapesHTML(t *testing.T) {
+	payload, err := encodeJSONPayload(map[string]string{
+		"value": "<script>alert(1)</script>",
+	})
+	if err != nil {
+		t.Fatalf("encodeJSONPayload() error = %v", err)
+	}
+	if got := string(payload); got != "{\"value\":\"\\u003cscript\\u003ealert(1)\\u003c/script\\u003e\"}\n" {
+		t.Fatalf("encodeJSONPayload() = %q", got)
+	}
+}

--- a/internal/api/server_handlers_agent_sdk.go
+++ b/internal/api/server_handlers_agent_sdk.go
@@ -606,10 +606,15 @@ func (s *Server) readAgentSDKResource(r *http.Request, uri string) (agentSDKReso
 }
 
 func (s *Server) writeAgentSDKMCPResponse(w http.ResponseWriter, resp agentSDKMCPResponse) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("MCP-Protocol-Version", agentSDKMCPProtocolVersion)
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(resp)
+	payload, err := encodeJSONPayload(resp)
+	if err != nil {
+		w.Header().Set("MCP-Protocol-Version", agentSDKMCPProtocolVersion)
+		s.writeJSONEncodingError(w, err)
+		return
+	}
+	writeJSONPayload(w, http.StatusOK, payload, map[string]string{
+		"MCP-Protocol-Version": agentSDKMCPProtocolVersion,
+	})
 }
 
 func (s *Server) handleAgentSDKToolError(w http.ResponseWriter, err error) {
@@ -630,9 +635,12 @@ func (s *Server) handleAgentSDKToolError(w http.ResponseWriter, err error) {
 		if toolErr.Code == "approval_required" {
 			status = http.StatusConflict
 		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(status)
-		_ = json.NewEncoder(w).Encode(toolErr.AsMap())
+		payload, encodeErr := encodeJSONPayload(toolErr.AsMap())
+		if encodeErr != nil {
+			s.writeJSONEncodingError(w, encodeErr)
+			return
+		}
+		writeJSONPayload(w, status, payload, nil)
 		return
 	}
 

--- a/internal/api/server_handlers_agent_sdk_test.go
+++ b/internal/api/server_handlers_agent_sdk_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -190,6 +191,32 @@ func TestAgentSDKMCPToolsAndResources(t *testing.T) {
 	firstContent, ok := contents[0].(map[string]any)
 	if !ok || !strings.Contains(firstContent["text"].(string), "\"kind\"") {
 		t.Fatalf("expected JSON schema text payload, got %#v", contents[0])
+	}
+}
+
+func TestWriteAgentSDKMCPResponseEncodingFailureReturnsInternalServerError(t *testing.T) {
+	s := &Server{}
+	w := httptest.NewRecorder()
+
+	s.writeAgentSDKMCPResponse(w, agentSDKMCPResponse{
+		JSONRPC: "2.0",
+		ID:      "bad-1",
+		Result:  map[string]float64{"value": math.NaN()},
+	})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+	if got := w.Header().Get("MCP-Protocol-Version"); got != agentSDKMCPProtocolVersion {
+		t.Fatalf("MCP-Protocol-Version = %q, want %q", got, agentSDKMCPProtocolVersion)
+	}
+
+	body := decodeJSON(t, w)
+	if body["code"] != "internal_error" {
+		t.Fatalf("code = %#v, want internal_error", body["code"])
+	}
+	if body["error"] != "internal server error" {
+		t.Fatalf("error = %#v, want internal server error", body["error"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- buffer JSON payloads before writing headers so encoding failures do not send partial 200 responses
- log encoding failures and return a sanitized JSON 500 response
- add regression coverage for NaN encoding failures

Closes #372