### PR TITLE
fix(policy): emit findings without descriptions

### DIFF
--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -802,7 +802,7 @@ func (e *Engine) EvaluateAsset(ctx context.Context, asset map[string]interface{}
 			}
 		}
 
-		if violation := e.checkAssetViolation(p, asset); violation != "" {
+		if violation, ok := e.checkAssetViolation(p, asset); ok {
 			// Extract resource identifiers
 			resourceID := extractResourceID(asset)
 			resourceName := extractResourceName(asset)
@@ -842,18 +842,31 @@ func (e *Engine) matchPolicy(p *Policy, req *EvalRequest) bool {
 	return true
 }
 
-func (e *Engine) checkAssetViolation(p *Policy, asset map[string]interface{}) string {
+func (e *Engine) checkAssetViolation(p *Policy, asset map[string]interface{}) (string, bool) {
 	// All conditions must match for a violation (AND logic)
 	if len(p.Conditions) == 0 {
-		return ""
+		return "", false
 	}
 	if normalizeConditionFormat(p.ConditionFormat) != ConditionFormatCEL {
-		return ""
+		return "", false
 	}
 	if !e.evaluateCELConditions(p, asset) {
+		return "", false
+	}
+	return policyViolationDescription(p), true
+}
+
+func policyViolationDescription(p *Policy) string {
+	if p == nil {
 		return ""
 	}
-	return p.Description // All conditions matched - violation
+	if description := strings.TrimSpace(p.Description); description != "" {
+		return description
+	}
+	if name := strings.TrimSpace(p.Name); name != "" {
+		return name
+	}
+	return strings.TrimSpace(p.ID)
 }
 
 func normalizeLogicalOperators(condition string) string {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -138,6 +138,37 @@ func TestAddPolicyDefaultsMissingConditionFormatToCEL(t *testing.T) {
 	}
 }
 
+func TestEvaluateAssetUsesPolicyNameWhenDescriptionIsEmpty(t *testing.T) {
+	engine := NewEngine()
+	engine.AddPolicy(&Policy{
+		ID:              "empty-description",
+		Name:            "Policy without description",
+		Effect:          "forbid",
+		Resource:        "aws::s3::bucket",
+		ConditionFormat: ConditionFormatCEL,
+		Conditions: []string{
+			"resource.public == true",
+		},
+		Severity: "high",
+	})
+
+	findings, err := engine.EvaluateAsset(context.Background(), map[string]interface{}{
+		"_cq_id":    "bucket-empty-description",
+		"_cq_table": "aws_s3_buckets",
+		"type":      "aws::s3::bucket",
+		"public":    true,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateAsset failed: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Description != "Policy without description" {
+		t.Fatalf("description = %q, want policy name fallback", findings[0].Description)
+	}
+}
+
 func TestPublicVMPolicies(t *testing.T) {
 	engine := NewEngine()
 

--- a/internal/policy/versioning.go
+++ b/internal/policy/versioning.go
@@ -376,7 +376,7 @@ func (e *Engine) evaluatePolicyAgainstAssets(ctx context.Context, p *Policy, ass
 		if len(asset) == 0 || !policyAppliesToAssetTable(p, asset) {
 			continue
 		}
-		if violation := preparedEngine.checkAssetViolation(preparedPolicy, asset); violation == "" {
+		if _, ok := preparedEngine.checkAssetViolation(preparedPolicy, asset); !ok {
 			continue
 		}
 		findingID := fmt.Sprintf("%s-%v", policyID, asset["_cq_id"])

--- a/internal/policy/versioning_test.go
+++ b/internal/policy/versioning_test.go
@@ -338,6 +338,36 @@ func TestDryRunPolicyChange_ComputesImpactDelta(t *testing.T) {
 	}
 }
 
+func TestDryRunPolicyChange_UsesPolicyNameWhenDescriptionIsEmpty(t *testing.T) {
+	engine := NewEngine()
+
+	candidate := &Policy{
+		ID:              "policy-dry-run-empty-description",
+		Name:            "Candidate fallback description",
+		Effect:          "forbid",
+		Resource:        "aws::s3::bucket",
+		ConditionFormat: ConditionFormatCEL,
+		Conditions:      []string{"resource.public == true"},
+		Severity:        "high",
+	}
+
+	assets := []map[string]interface{}{
+		{"_cq_id": "bucket-a", "_cq_table": "aws_s3_buckets", "public": true},
+	}
+
+	impact, err := engine.DryRunPolicyChange(context.Background(), nil, candidate, assets)
+	if err != nil {
+		t.Fatalf("dry-run failed: %v", err)
+	}
+
+	if impact.AfterMatches != 1 {
+		t.Fatalf("expected 1 match after, got %d", impact.AfterMatches)
+	}
+	if len(impact.AddedFindingIDs) != 1 {
+		t.Fatalf("expected 1 added finding, got %d", len(impact.AddedFindingIDs))
+	}
+}
+
 func TestGetPolicyVersionAndDiffPolicyVersions(t *testing.T) {
 	engine := NewEngine()
 	engine.AddPolicy(&Policy{


### PR DESCRIPTION
## Summary
- separate violation detection from finding description generation
- fall back to the policy name or ID when descriptions are empty
- add regression coverage for direct evaluation and dry-run impact analysis

Closes #364