### PR TITLE
fix(appstate): serialize schema initialization

### DIFF
--- a/internal/agents/session_store_postgres.go
+++ b/internal/agents/session_store_postgres.go
@@ -6,14 +6,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 )
 
 const postgresSessionTable = "cerebro_agent_sessions"
 
 type PostgresSessionStore struct {
-	db         *sql.DB
-	rewriteSQL func(string) string
+	db          *sql.DB
+	rewriteSQL  func(string) string
+	schemaMu    sync.Mutex
+	schemaReady bool
 }
 
 func NewPostgresSessionStore(db *sql.DB) *PostgresSessionStore {
@@ -24,6 +27,13 @@ func (s *PostgresSessionStore) EnsureSchema(ctx context.Context) error {
 	if s == nil || s.db == nil {
 		return fmt.Errorf("postgres session store is not initialized")
 	}
+
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	if s.schemaReady {
+		return nil
+	}
+
 	_, err := s.db.ExecContext(ctx, s.q(`
 CREATE TABLE IF NOT EXISTS `+postgresSessionTable+` (
 	id TEXT PRIMARY KEY,
@@ -37,6 +47,9 @@ CREATE TABLE IF NOT EXISTS `+postgresSessionTable+` (
 );
 CREATE INDEX IF NOT EXISTS idx_`+postgresSessionTable+`_updated_at ON `+postgresSessionTable+` (updated_at);
 `))
+	if err == nil {
+		s.schemaReady = true
+	}
 	return err
 }
 

--- a/internal/agents/session_store_postgres_test.go
+++ b/internal/agents/session_store_postgres_test.go
@@ -3,7 +3,9 @@ package agents
 import (
 	"context"
 	"database/sql"
+	"path/filepath"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +16,41 @@ var sessionStoreDollarPlaceholderRe = regexp.MustCompile(`\$\d+`)
 
 func sessionStoreSQLiteRewrite(query string) string {
 	return sessionStoreDollarPlaceholderRe.ReplaceAllString(query, "?")
+}
+
+func newConcurrentSessionStoreTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "sessions.sqlite")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(16)
+	db.SetMaxIdleConns(16)
+	ctx := context.Background()
+	conns := make([]*sql.Conn, 0, 16)
+	for i := 0; i < 16; i++ {
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("open sqlite connection: %v", err)
+		}
+		if _, err := conn.ExecContext(ctx, "PRAGMA busy_timeout = 10000"); err != nil {
+			_ = conn.Close()
+			t.Fatalf("set busy_timeout: %v", err)
+		}
+		if _, err := conn.ExecContext(ctx, "PRAGMA journal_mode = WAL"); err != nil {
+			_ = conn.Close()
+			t.Fatalf("set journal_mode: %v", err)
+		}
+		conns = append(conns, conn)
+	}
+	for _, conn := range conns {
+		if err := conn.Close(); err != nil {
+			t.Fatalf("close sqlite connection: %v", err)
+		}
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
 }
 
 func newTestPostgresSessionStoreWithDB(t *testing.T) (*PostgresSessionStore, *sql.DB) {
@@ -164,5 +201,46 @@ func TestPostgresSessionStoreImportMissingDoesNotOverwriteExistingUpdates(t *tes
 	}
 	if len(got.Messages) != 1 || got.Messages[0].Content != "done" {
 		t.Fatalf("unexpected updated messages after repeat import: %#v", got.Messages)
+	}
+}
+
+func TestPostgresSessionStoreConcurrentFirstUseEnsuresSchema(t *testing.T) {
+	db := newConcurrentSessionStoreTestDB(t)
+	store := &PostgresSessionStore{
+		db:         db,
+		rewriteSQL: sessionStoreSQLiteRewrite,
+	}
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = store.Save(context.Background(), &Session{
+				ID:        "session-concurrent-" + string(rune('a'+i)),
+				AgentID:   "agent-1",
+				UserID:    "user-1",
+				Status:    "active",
+				CreatedAt: time.Now().UTC(),
+				UpdatedAt: time.Now().UTC(),
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: Save() error = %v", i, err)
+		}
+	}
+
+	var count int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM `+postgresSessionTable).Scan(&count); err != nil {
+		t.Fatalf("count query error = %v", err)
+	}
+	if count != n {
+		t.Fatalf("count = %d, want %d", count, n)
 	}
 }

--- a/internal/appstate/postgres.go
+++ b/internal/appstate/postgres.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,8 +23,10 @@ const (
 )
 
 type AuditRepository struct {
-	db         *sql.DB
-	rewriteSQL func(string) string
+	db          *sql.DB
+	rewriteSQL  func(string) string
+	schemaMu    sync.Mutex
+	schemaReady bool
 }
 
 func NewAuditRepository(db *sql.DB) *AuditRepository {
@@ -34,6 +37,13 @@ func (r *AuditRepository) EnsureSchema(ctx context.Context) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("audit repository is not initialized")
 	}
+
+	r.schemaMu.Lock()
+	defer r.schemaMu.Unlock()
+	if r.schemaReady {
+		return nil
+	}
+
 	_, err := r.db.ExecContext(ctx, r.q(`
 CREATE TABLE IF NOT EXISTS `+auditTable+` (
 	id TEXT PRIMARY KEY,
@@ -50,6 +60,9 @@ CREATE TABLE IF NOT EXISTS `+auditTable+` (
 CREATE INDEX IF NOT EXISTS idx_`+auditTable+`_resource ON `+auditTable+` (resource_type, resource_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_`+auditTable+`_created_at ON `+auditTable+` (created_at);
 `))
+	if err == nil {
+		r.schemaReady = true
+	}
 	return err
 }
 
@@ -179,8 +192,10 @@ func (r *AuditRepository) q(query string) string {
 }
 
 type PolicyHistoryRepository struct {
-	db         *sql.DB
-	rewriteSQL func(string) string
+	db          *sql.DB
+	rewriteSQL  func(string) string
+	schemaMu    sync.Mutex
+	schemaReady bool
 }
 
 func NewPolicyHistoryRepository(db *sql.DB) *PolicyHistoryRepository {
@@ -191,6 +206,13 @@ func (r *PolicyHistoryRepository) EnsureSchema(ctx context.Context) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("policy history repository is not initialized")
 	}
+
+	r.schemaMu.Lock()
+	defer r.schemaMu.Unlock()
+	if r.schemaReady {
+		return nil
+	}
+
 	_, err := r.db.ExecContext(ctx, r.q(`
 CREATE TABLE IF NOT EXISTS `+policyHistoryTable+` (
 	policy_id TEXT NOT NULL,
@@ -205,6 +227,9 @@ CREATE TABLE IF NOT EXISTS `+policyHistoryTable+` (
 );
 CREATE INDEX IF NOT EXISTS idx_`+policyHistoryTable+`_policy ON `+policyHistoryTable+` (policy_id, version DESC);
 `))
+	if err == nil {
+		r.schemaReady = true
+	}
 	return err
 }
 
@@ -338,8 +363,10 @@ func (r *PolicyHistoryRepository) q(query string) string {
 }
 
 type RiskEngineStateRepository struct {
-	db         *sql.DB
-	rewriteSQL func(string) string
+	db          *sql.DB
+	rewriteSQL  func(string) string
+	schemaMu    sync.Mutex
+	schemaReady bool
 }
 
 func NewRiskEngineStateRepository(db *sql.DB) *RiskEngineStateRepository {
@@ -350,6 +377,13 @@ func (r *RiskEngineStateRepository) EnsureSchema(ctx context.Context) error {
 	if r == nil || r.db == nil {
 		return fmt.Errorf("risk engine state repository is not initialized")
 	}
+
+	r.schemaMu.Lock()
+	defer r.schemaMu.Unlock()
+	if r.schemaReady {
+		return nil
+	}
+
 	_, err := r.db.ExecContext(ctx, r.q(`
 CREATE TABLE IF NOT EXISTS `+riskEngineStateTable+` (
 	graph_id TEXT PRIMARY KEY,
@@ -357,6 +391,9 @@ CREATE TABLE IF NOT EXISTS `+riskEngineStateTable+` (
 	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 `))
+	if err == nil {
+		r.schemaReady = true
+	}
 	return err
 }
 

--- a/internal/appstate/postgres_test.go
+++ b/internal/appstate/postgres_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
+	"path/filepath"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +20,41 @@ var appStateDollarPlaceholderRe = regexp.MustCompile(`\$\d+`)
 
 func appStateSQLiteRewrite(query string) string {
 	return appStateDollarPlaceholderRe.ReplaceAllString(query, "?")
+}
+
+func newConcurrentAppStateTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "appstate.sqlite")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(16)
+	db.SetMaxIdleConns(16)
+	ctx := context.Background()
+	conns := make([]*sql.Conn, 0, 16)
+	for i := 0; i < 16; i++ {
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("open sqlite connection: %v", err)
+		}
+		if _, err := conn.ExecContext(ctx, "PRAGMA busy_timeout = 10000"); err != nil {
+			_ = conn.Close()
+			t.Fatalf("set busy_timeout: %v", err)
+		}
+		if _, err := conn.ExecContext(ctx, "PRAGMA journal_mode = WAL"); err != nil {
+			_ = conn.Close()
+			t.Fatalf("set journal_mode: %v", err)
+		}
+		conns = append(conns, conn)
+	}
+	for _, conn := range conns {
+		if err := conn.Close(); err != nil {
+			t.Fatalf("close sqlite connection: %v", err)
+		}
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
 }
 
 func newTestAuditRepository(t *testing.T) *AuditRepository {
@@ -131,5 +169,121 @@ func TestRiskEngineStateRepositorySaveAndLoad(t *testing.T) {
 	}
 	if string(got) != string(payload) {
 		t.Fatalf("payload = %s, want %s", got, payload)
+	}
+}
+
+func TestAuditRepositoryConcurrentFirstUseEnsuresSchema(t *testing.T) {
+	db := newConcurrentAppStateTestDB(t)
+	repo := NewAuditRepository(db)
+	repo.rewriteSQL = appStateSQLiteRewrite
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = repo.Log(context.Background(), &snowflake.AuditEntry{
+				ID:           fmt.Sprintf("audit-%d", i),
+				Action:       "policy.evaluate",
+				ActorID:      "user",
+				ResourceType: "policy",
+				ResourceID:   "policy-1",
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: Log() error = %v", i, err)
+		}
+	}
+
+	entries, err := repo.List(context.Background(), "policy", "policy-1", n+10)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(entries) != n {
+		t.Fatalf("len(entries) = %d, want %d", len(entries), n)
+	}
+}
+
+func TestPolicyHistoryRepositoryConcurrentFirstUseEnsuresSchema(t *testing.T) {
+	db := newConcurrentAppStateTestDB(t)
+	repo := NewPolicyHistoryRepository(db)
+	repo.rewriteSQL = appStateSQLiteRewrite
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = repo.Upsert(context.Background(), &snowflake.PolicyHistoryRecord{
+				PolicyID:      "policy-concurrent",
+				Version:       i + 1,
+				Content:       []byte(`{"version":1}`),
+				EffectiveFrom: time.Now().UTC(),
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: Upsert() error = %v", i, err)
+		}
+	}
+
+	records, err := repo.List(context.Background(), "policy-concurrent", n+10)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != n {
+		t.Fatalf("len(records) = %d, want %d", len(records), n)
+	}
+}
+
+func TestRiskEngineStateRepositoryConcurrentFirstUseEnsuresSchema(t *testing.T) {
+	db := newConcurrentAppStateTestDB(t)
+	repo := NewRiskEngineStateRepository(db)
+	repo.rewriteSQL = appStateSQLiteRewrite
+
+	const graphID = "graph-concurrent"
+	const n = 20
+	var wg sync.WaitGroup
+	saveErrs := make([]error, n)
+	loadErrs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			saveErrs[i] = repo.SaveSnapshot(context.Background(), graphID, []byte(`{"i":1}`))
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			_, loadErrs[i] = repo.LoadSnapshot(context.Background(), graphID)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		if saveErrs[i] != nil {
+			t.Fatalf("save goroutine %d: SaveSnapshot() error = %v", i, saveErrs[i])
+		}
+		if loadErrs[i] != nil {
+			t.Fatalf("load goroutine %d: LoadSnapshot() error = %v", i, loadErrs[i])
+		}
+	}
+
+	got, err := repo.LoadSnapshot(context.Background(), graphID)
+	if err != nil {
+		t.Fatalf("final LoadSnapshot() error = %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected snapshot payload after concurrent first use")
 	}
 }


### PR DESCRIPTION
## Summary
- guard appstate and session-store EnsureSchema paths with one-time initialization mutexes
- only mark schema setup complete after successful DDL so transient failures can retry
- add concurrent first-use regressions for audit, policy history, risk state, and session stores

Closes #365