### PR TITLE
fix(app): defer tap consumer startup until graph ready

### DIFF
--- a/internal/app/app_security_services.go
+++ b/internal/app/app_security_services.go
@@ -551,7 +551,10 @@ func (a *App) initSecurityGraph(ctx context.Context) {
 
 	// Build initial graph in background
 	go func() {
-		defer close(a.graphReady)
+		defer func() {
+			close(a.graphReady)
+			a.startTapGraphConsumer(graphCtx)
+		}()
 		a.graphUpdateMu.Lock()
 		defer a.graphUpdateMu.Unlock()
 

--- a/internal/app/app_stream_consumer_dispatch.go
+++ b/internal/app/app_stream_consumer_dispatch.go
@@ -36,9 +36,6 @@ func (a *App) handleTapCloudEvent(ctx context.Context, evt events.CloudEvent) er
 		return a.handleTapSchemaEvent(eventType, evt)
 	}
 	if err := a.waitForSecurityGraphReady(ctx); err != nil {
-		if ctx == nil || ctx.Err() == nil {
-			return events.RetryWithDelay(err, a.tapGraphReadyRetryDelay())
-		}
 		return err
 	}
 	if isTapInteractionType(eventType) {

--- a/internal/app/app_stream_consumer_dispatch.go
+++ b/internal/app/app_stream_consumer_dispatch.go
@@ -32,11 +32,14 @@ func (a *App) handleTapCloudEvent(ctx context.Context, evt events.CloudEvent) er
 	if !strings.HasPrefix(strings.ToLower(eventType), "ensemble.tap.") {
 		return nil
 	}
-	if err := a.waitForSecurityGraphReady(ctx); err != nil {
-		return err
-	}
 	if isTapSchemaEventType(eventType) {
 		return a.handleTapSchemaEvent(eventType, evt)
+	}
+	if err := a.waitForSecurityGraphReady(ctx); err != nil {
+		if ctx == nil || ctx.Err() == nil {
+			return events.RetryWithDelay(err, a.tapGraphReadyRetryDelay())
+		}
+		return err
 	}
 	if isTapInteractionType(eventType) {
 		return a.handleTapInteractionEvent(ctx, eventType, evt)

--- a/internal/app/app_stream_consumer_lifecycle.go
+++ b/internal/app/app_stream_consumer_lifecycle.go
@@ -23,6 +23,12 @@ func (a *App) initTapGraphConsumer(ctx context.Context) {
 		}
 		return
 	}
+	if !a.graphReadyClosed() {
+		if a.Logger != nil {
+			a.Logger.Info("deferring tap graph consumer until security graph is ready")
+		}
+		return
+	}
 	a.startTapGraphConsumer(ctx)
 }
 
@@ -30,10 +36,16 @@ func (a *App) startTapGraphConsumer(ctx context.Context) {
 	if a == nil || a.Config == nil {
 		return
 	}
+	if ctx != nil && ctx.Err() != nil {
+		return
+	}
 	if !a.Config.NATSConsumerEnabled {
 		return
 	}
 	if !a.graphWriterLeaseAllowsWrites() {
+		return
+	}
+	if !a.graphReadyClosed() {
 		return
 	}
 	a.tapConsumerMu.Lock()

--- a/internal/app/app_stream_consumer_runtime.go
+++ b/internal/app/app_stream_consumer_runtime.go
@@ -9,7 +9,6 @@ import (
 
 const (
 	defaultTapGraphReadyWaitTimeout = 15 * time.Second
-	defaultTapGraphReadyRetryDelay  = 5 * time.Second
 )
 
 func (a *App) ensureSecurityGraph() *graph.Graph {
@@ -62,11 +61,4 @@ func (a *App) tapGraphReadyWaitTimeout() time.Duration {
 		}
 	}
 	return defaultTapGraphReadyWaitTimeout
-}
-
-func (a *App) tapGraphReadyRetryDelay() time.Duration {
-	if a != nil && a.Config != nil && a.Config.NATSConsumerFetchTimeout > 0 {
-		return a.Config.NATSConsumerFetchTimeout
-	}
-	return defaultTapGraphReadyRetryDelay
 }

--- a/internal/app/app_stream_consumer_runtime.go
+++ b/internal/app/app_stream_consumer_runtime.go
@@ -2,8 +2,14 @@ package app
 
 import (
 	"context"
+	"time"
 
 	"github.com/writer/cerebro/internal/graph"
+)
+
+const (
+	defaultTapGraphReadyWaitTimeout = 15 * time.Second
+	defaultTapGraphReadyRetryDelay  = 5 * time.Second
 )
 
 func (a *App) ensureSecurityGraph() *graph.Graph {
@@ -28,10 +34,39 @@ func (a *App) waitForSecurityGraphReady(ctx context.Context) error {
 	if a == nil || a.graphReady == nil {
 		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	waitCtx := ctx
+	cancel := func() {}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		if timeout := a.tapGraphReadyWaitTimeout(); timeout > 0 {
+			waitCtx, cancel = context.WithTimeout(ctx, timeout)
+		}
+	}
+	defer cancel()
+
 	select {
 	case <-a.graphReady:
 		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	case <-waitCtx.Done():
+		return waitCtx.Err()
 	}
+}
+
+func (a *App) tapGraphReadyWaitTimeout() time.Duration {
+	if a != nil && a.Config != nil && a.Config.NATSConsumerAckWait > 0 {
+		if timeout := a.Config.NATSConsumerAckWait / 4; timeout > 0 && timeout < defaultTapGraphReadyWaitTimeout {
+			return timeout
+		}
+	}
+	return defaultTapGraphReadyWaitTimeout
+}
+
+func (a *App) tapGraphReadyRetryDelay() time.Duration {
+	if a != nil && a.Config != nil && a.Config.NATSConsumerFetchTimeout > 0 {
+		return a.Config.NATSConsumerFetchTimeout
+	}
+	return defaultTapGraphReadyRetryDelay
 }

--- a/internal/app/app_stream_consumer_test.go
+++ b/internal/app/app_stream_consumer_test.go
@@ -1,8 +1,10 @@
 package app
 
 import (
+	"bytes"
 	"context"
-	"errors"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -134,40 +136,25 @@ func TestHandleTapCloudEventSchemaEventBypassesGraphReadyWait(t *testing.T) {
 	}
 }
 
-func TestHandleTapCloudEventReturnsDelayedRetryWhenGraphNotReady(t *testing.T) {
+func TestInitTapGraphConsumerDefersUntilGraphReady(t *testing.T) {
+	var logs bytes.Buffer
 	a := &App{
 		graphReady: make(chan struct{}),
 		Config: &Config{
-			NATSConsumerAckWait:      20 * time.Millisecond,
-			NATSConsumerFetchTimeout: 7 * time.Millisecond,
+			NATSConsumerEnabled: true,
 		},
-	}
-	evt := events.CloudEvent{
-		Type: "ensemble.tap.salesforce.opportunity.updated",
-		Time: time.Now().UTC(),
-		Data: map[string]any{
-			"id": "opp-retry",
-			"snapshot": map[string]any{
-				"name": "Retry Opportunity",
-			},
-		},
+		Logger: slog.New(slog.NewTextHandler(&logs, nil)),
 	}
 
-	start := time.Now()
-	err := a.handleTapCloudEvent(context.Background(), evt)
-	if err == nil {
-		t.Fatal("expected delayed retry error")
+	a.initTapGraphConsumer(context.Background())
+	if a.TapConsumer != nil {
+		t.Fatal("expected tap consumer initialization to wait for graph readiness")
 	}
-	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
-		t.Fatalf("handleTapCloudEvent blocked too long: %s", elapsed)
+	if got := logs.String(); !strings.Contains(got, "deferring tap graph consumer until security graph is ready") {
+		t.Fatalf("initTapGraphConsumer() log = %q, want graph-ready deferral message", got)
 	}
-
-	var delayed interface{ RetryDelay() time.Duration }
-	if !errors.As(err, &delayed) {
-		t.Fatalf("expected delayed retry error, got %T: %v", err, err)
-	}
-	if delayed.RetryDelay() != 7*time.Millisecond {
-		t.Fatalf("retry delay = %s, want %s", delayed.RetryDelay(), 7*time.Millisecond)
+	if strings.Contains(logs.String(), "failed to initialize tap graph consumer") {
+		t.Fatalf("initTapGraphConsumer() log = %q, should not attempt consumer startup before graph readiness", logs.String())
 	}
 }
 

--- a/internal/app/app_stream_consumer_test.go
+++ b/internal/app/app_stream_consumer_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -102,6 +103,71 @@ func TestHandleTapCloudEventWaitsForGraphReady(t *testing.T) {
 	}
 	if _, ok := a.SecurityGraph.GetNode("salesforce:opportunity:opp-blocked"); !ok {
 		t.Fatal("expected tap event node to be applied after graph readiness")
+	}
+}
+
+func TestHandleTapCloudEventSchemaEventBypassesGraphReadyWait(t *testing.T) {
+	a := &App{graphReady: make(chan struct{})}
+	evt := events.CloudEvent{
+		Type: "ensemble.tap.schema.workday.updated",
+		Time: time.Now().UTC(),
+		Data: map[string]any{
+			"integration": "workday",
+			"entity_types": []any{
+				map[string]any{"kind": "tap_graph_ready_bypass_employee_v1"},
+			},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.handleTapCloudEvent(context.Background(), evt)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("schema event failed: %v", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected schema event to bypass graph readiness wait")
+	}
+}
+
+func TestHandleTapCloudEventReturnsDelayedRetryWhenGraphNotReady(t *testing.T) {
+	a := &App{
+		graphReady: make(chan struct{}),
+		Config: &Config{
+			NATSConsumerAckWait:      20 * time.Millisecond,
+			NATSConsumerFetchTimeout: 7 * time.Millisecond,
+		},
+	}
+	evt := events.CloudEvent{
+		Type: "ensemble.tap.salesforce.opportunity.updated",
+		Time: time.Now().UTC(),
+		Data: map[string]any{
+			"id": "opp-retry",
+			"snapshot": map[string]any{
+				"name": "Retry Opportunity",
+			},
+		},
+	}
+
+	start := time.Now()
+	err := a.handleTapCloudEvent(context.Background(), evt)
+	if err == nil {
+		t.Fatal("expected delayed retry error")
+	}
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Fatalf("handleTapCloudEvent blocked too long: %s", elapsed)
+	}
+
+	var delayed interface{ RetryDelay() time.Duration }
+	if !errors.As(err, &delayed) {
+		t.Fatalf("expected delayed retry error, got %T: %v", err, err)
+	}
+	if delayed.RetryDelay() != 7*time.Millisecond {
+		t.Fatalf("retry delay = %s, want %s", delayed.RetryDelay(), 7*time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Summary
- wait to start the tap graph consumer until the initial security graph build has completed
- keep the direct TAP handler readiness gate and schema-event bypass behavior
- avoid delayed requeues during graph warmup so same-entity event ordering stays intact across batches

## Validation
- go test ./internal/app
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #336