### PR TITLE
fix: configure timeouts for fallback HTTP clients

### DIFF
--- a/internal/cli/connector.go
+++ b/internal/cli/connector.go
@@ -62,6 +62,8 @@ var connectorValidateCmd = &cobra.Command{
 	RunE:      runConnectorValidate,
 }
 
+var connectorHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 var (
 	connectorOutput string
 
@@ -734,7 +736,7 @@ func doAzureRequest(ctx context.Context, token, url string) ([]byte, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := connectorHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/connector_test.go
+++ b/internal/cli/connector_test.go
@@ -57,6 +57,15 @@ type connectorTestState struct {
 	runAzure               func(context.Context) (connectorValidationReport, error)
 }
 
+func TestConnectorHTTPClientHasTimeout(t *testing.T) {
+	if connectorHTTPClient == nil {
+		t.Fatal("expected connector HTTP client")
+	}
+	if connectorHTTPClient.Timeout != 30*time.Second {
+		t.Fatalf("timeout = %s, want %s", connectorHTTPClient.Timeout, 30*time.Second)
+	}
+}
+
 func snapshotConnectorTestState() connectorTestState {
 	return connectorTestState{
 		output:                 connectorOutput,

--- a/internal/scanner/container.go
+++ b/internal/scanner/container.go
@@ -181,12 +181,14 @@ type CVEInfo struct {
 
 var manifestParseFailures atomic.Int64
 
+func newRegistryHTTPClient() *http.Client {
+	return &http.Client{Timeout: 60 * time.Second}
+}
+
 func NewContainerScanner() *ContainerScanner {
 	return &ContainerScanner{
 		registries: make(map[string]RegistryClient),
-		client: &http.Client{
-			Timeout: 60 * time.Second,
-		},
+		client:     newRegistryHTTPClient(),
 	}
 }
 
@@ -645,19 +647,20 @@ type ecrAPI interface {
 
 // ECRClient implements RegistryClient for AWS ECR
 type ECRClient struct {
-	region    string
-	accountID string
-	client    ecrAPI
-	initOnce  sync.Once
-	initErr   error
+	region     string
+	accountID  string
+	client     ecrAPI
+	httpClient *http.Client
+	initOnce   sync.Once
+	initErr    error
 }
 
 func NewECRClient(region, accountID string) *ECRClient {
-	return &ECRClient{region: region, accountID: accountID}
+	return &ECRClient{region: region, accountID: accountID, httpClient: newRegistryHTTPClient()}
 }
 
 func NewECRClientWithAPI(region, accountID string, api ecrAPI) *ECRClient {
-	return &ECRClient{region: region, accountID: accountID, client: api}
+	return &ECRClient{region: region, accountID: accountID, client: api, httpClient: newRegistryHTTPClient()}
 }
 
 func (c *ECRClient) Name() string { return "ecr" }
@@ -784,7 +787,12 @@ func (c *ECRClient) DownloadBlob(ctx context.Context, repo, digest string) (io.R
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client := c.httpClient
+	if client == nil {
+		client = newRegistryHTTPClient()
+		c.httpClient = client
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, sanitizeTransportError(err)
 	}

--- a/internal/scanner/container_test.go
+++ b/internal/scanner/container_test.go
@@ -304,6 +304,16 @@ func TestECRClient_QualifyImageRef(t *testing.T) {
 	}
 }
 
+func TestNewECRClientConfiguresHTTPTimeout(t *testing.T) {
+	client := NewECRClient("us-west-2", "123456789012")
+	if client.httpClient == nil {
+		t.Fatal("expected ECR client HTTP client to be configured")
+	}
+	if client.httpClient.Timeout != 60*time.Second {
+		t.Fatalf("timeout = %s, want %s", client.httpClient.Timeout, 60*time.Second)
+	}
+}
+
 func TestECRClientListRepositoriesError(t *testing.T) {
 	stub := &stubECR{
 		describeRepositoriesFn: func(_ *ecr.DescribeRepositoriesInput) (*ecr.DescribeRepositoriesOutput, error) {
@@ -692,8 +702,7 @@ func TestDockerHubClientSuccess(t *testing.T) {
 }
 
 func TestECRClientDownloadBlobSanitizesPresignedURLTransportErrors(t *testing.T) {
-	originalClient := http.DefaultClient
-	http.DefaultClient = &http.Client{
+	httpClient := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			return nil, &url.Error{
 				Op:  req.Method,
@@ -702,9 +711,6 @@ func TestECRClientDownloadBlobSanitizesPresignedURLTransportErrors(t *testing.T)
 			}
 		}),
 	}
-	t.Cleanup(func() {
-		http.DefaultClient = originalClient
-	})
 
 	stub := &stubECR{
 		getDownloadURLForLayerFn: func(input *ecr.GetDownloadUrlForLayerInput) (*ecr.GetDownloadUrlForLayerOutput, error) {
@@ -717,6 +723,7 @@ func TestECRClientDownloadBlobSanitizesPresignedURLTransportErrors(t *testing.T)
 		},
 	}
 	client := NewECRClientWithAPI("us-west-2", "", stub)
+	client.httpClient = httpClient
 	_, err := client.DownloadBlob(context.Background(), "repo", "sha256:layer")
 	if err == nil {
 		t.Fatal("expected transport error")

--- a/internal/scm/client.go
+++ b/internal/scm/client.go
@@ -13,7 +13,35 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+var strippedGitEnvKeys = map[string]struct{}{
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES": {},
+	"GIT_COMMON_DIR":                   {},
+	"GIT_DIR":                          {},
+	"GIT_INDEX_FILE":                   {},
+	"GIT_OBJECT_DIRECTORY":             {},
+	"GIT_PREFIX":                       {},
+	"GIT_WORK_TREE":                    {},
+}
+
+func gitCommandEnv(extra ...string) []string {
+	env := make([]string, 0, len(os.Environ())+len(extra)+1)
+	for _, entry := range os.Environ() {
+		key := entry
+		if idx := strings.IndexByte(entry, '='); idx >= 0 {
+			key = entry[:idx]
+		}
+		if _, blocked := strippedGitEnvKeys[key]; blocked {
+			continue
+		}
+		env = append(env, entry)
+	}
+	env = append(env, "GIT_TERMINAL_PROMPT=0")
+	env = append(env, extra...)
+	return env
+}
 
 // Client defines the interface for SCM interactions
 type Client interface {
@@ -183,7 +211,7 @@ func (c *GitHubClient) cloneURL(repoURL string) (string, error) {
 
 func (c *GitHubClient) runGitWithOptionalAuth(ctx context.Context, args []string) error {
 	cmd := exec.CommandContext(ctx, "git", args...) //#nosec G204 -- fixed binary/args
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = gitCommandEnv()
 	cleanup := func() {}
 	if c.Token != "" {
 		askPassPath, err := gitAskPassScriptWithUsername("x-access-token", "GITHUB_TOKEN")
@@ -210,11 +238,19 @@ type GitLabClient struct {
 	httpClient *http.Client
 }
 
+func newGitLabHTTPClient() *http.Client {
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
 func NewGitLabClient(token, baseURL string) *GitLabClient {
 	if strings.TrimSpace(baseURL) == "" {
 		baseURL = "https://gitlab.com"
 	}
-	return &GitLabClient{Token: token, BaseURL: strings.TrimRight(baseURL, "/")}
+	return &GitLabClient{
+		Token:      token,
+		BaseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: newGitLabHTTPClient(),
+	}
 }
 
 func (c *GitLabClient) Clone(ctx context.Context, repoURL string, dest string) error {
@@ -240,7 +276,7 @@ func (c *GitLabClient) CloneWithOptions(ctx context.Context, repoURL string, des
 	args = append(args, cloneURL, dest)
 
 	cmd := exec.CommandContext(ctx, "git", args...) //#nosec G204 -- args are sanitized repo/dest strings
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = gitCommandEnv()
 	cleanup := func() {}
 	if c.Token != "" {
 		askPassPath, err := gitAskPassScriptWithUsername("oauth2", "GITLAB_TOKEN")
@@ -457,7 +493,7 @@ esac
 
 func (c *GitLabClient) runGitWithOptionalAuth(ctx context.Context, args []string) error {
 	cmd := exec.CommandContext(ctx, "git", args...) //#nosec G204 -- fixed binary/args
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = gitCommandEnv()
 	cleanup := func() {}
 	if c.Token != "" {
 		askPassPath, err := gitAskPassScriptWithUsername("oauth2", "GITLAB_TOKEN")
@@ -488,7 +524,7 @@ func (c *GitLabClient) doRequest(ctx context.Context, endpoint string) (*http.Re
 	}
 	client := c.httpClient
 	if client == nil {
-		client = http.DefaultClient
+		client = newGitLabHTTPClient()
 	}
 	return client.Do(req)
 }
@@ -662,7 +698,7 @@ func (c *LocalClient) CloneWithOptions(ctx context.Context, repoURL, dest string
 	args = append(args, localCloneURL(repoURL, opts.Depth > 0), dest)
 
 	cmd := exec.CommandContext(ctx, "git", args...) //#nosec G204 -- args are sanitized repo/dest strings
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = gitCommandEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git clone failed: %s: %w", string(out), err)
 	}
@@ -686,7 +722,7 @@ func localCloneURL(repoURL string, shallow bool) string {
 
 func (c *LocalClient) Fetch(ctx context.Context, repoURL, dest string) error {
 	cmd := exec.CommandContext(ctx, "git", "-C", dest, "fetch", "--prune", "--tags", "origin") //#nosec G204 -- args are sanitized repo/dest strings
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = gitCommandEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git fetch failed: %s: %w", string(out), err)
 	}

--- a/internal/scm/client_test.go
+++ b/internal/scm/client_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func createTestRepo(t *testing.T) string {
@@ -31,8 +32,19 @@ func createTestRepo(t *testing.T) string {
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...) //#nosec G204 -- test helper
+	cmd.Env = gitCommandEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v failed: %s: %v", args, string(out), err)
+	}
+}
+
+func TestNewGitLabClientConfiguresDefaultHTTPClient(t *testing.T) {
+	client := NewGitLabClient("token", "https://gitlab.example.com")
+	if client.httpClient == nil {
+		t.Fatal("expected GitLab HTTP client to be configured")
+	}
+	if client.httpClient.Timeout != 30*time.Second {
+		t.Fatalf("timeout = %s, want %s", client.httpClient.Timeout, 30*time.Second)
 	}
 }
 

--- a/internal/sync/azure.go
+++ b/internal/sync/azure.go
@@ -51,6 +51,10 @@ type AzureSyncEngine struct {
 // AzureEngineOption configures the Azure sync engine
 type AzureEngineOption func(*AzureSyncEngine)
 
+func newAzureHTTPClient() *http.Client {
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
 func WithAzureSubscription(subscriptionID string) AzureEngineOption {
 	return func(e *AzureSyncEngine) { e.subscriptionID = subscriptionID }
 }
@@ -87,7 +91,7 @@ func NewAzureSyncEngine(sf warehouse.SyncWarehouse, logger *slog.Logger, opts ..
 		concurrency:             10,
 		subscriptionConcurrency: 4,
 		credential:              cred,
-		httpClient:              http.DefaultClient,
+		httpClient:              newAzureHTTPClient(),
 		tokenCredential:         cred,
 	}
 	for _, opt := range opts {

--- a/internal/sync/azure_management_group_test.go
+++ b/internal/sync/azure_management_group_test.go
@@ -35,6 +35,16 @@ func rewriteAzureManagementHost(target *url.URL, base http.RoundTripper) http.Ro
 	})
 }
 
+func TestNewAzureHTTPClientConfiguresTimeout(t *testing.T) {
+	client := newAzureHTTPClient()
+	if client == nil {
+		t.Fatal("expected Azure HTTP client")
+	}
+	if client.Timeout != 30*time.Second {
+		t.Fatalf("timeout = %s, want %s", client.Timeout, 30*time.Second)
+	}
+}
+
 func TestListManagementGroupSubscriptionsFiltersCaseInsensitively(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {


### PR DESCRIPTION
## Summary
- replace fallback uses of http.DefaultClient with timeout-configured clients in scanner, sync, SCM, and connector paths
- add regression coverage for the configured timeouts and sanitize inherited GIT_* env when SCM code shells out to git
- harden SCM tests so nested git repos do not mutate the worktree under hook-provided git environment variables

Closes #309