### PR TITLE
fix(scanner): cap streamed blob and artifact responses

### DIFF
--- a/internal/functionscan/http.go
+++ b/internal/functionscan/http.go
@@ -73,7 +73,7 @@ func openHTTPArtifact(ctx context.Context, client *http.Client, rawURL string) (
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 16*1024))
 		return nil, fmt.Errorf("artifact download failed %d: %s", resp.StatusCode, sanitizeEmbeddedURL(strings.TrimSpace(string(body))))
 	}
-	return resp.Body, nil
+	return newMaxBytesReadCloser(resp.Body, maxArtifactResponseBodyBytes, "artifact download"), nil
 }
 
 func cloneArtifactTransport(base http.RoundTripper) *http.Transport {

--- a/internal/functionscan/max_bytes_read_closer.go
+++ b/internal/functionscan/max_bytes_read_closer.go
@@ -1,0 +1,58 @@
+package functionscan
+
+import (
+	"fmt"
+	"io"
+)
+
+var maxArtifactResponseBodyBytes int64 = 5 << 30
+
+type maxBytesReadCloser struct {
+	body        io.ReadCloser
+	description string
+	maxBytes    int64
+	remaining   int64
+}
+
+func newMaxBytesReadCloser(body io.ReadCloser, maxBytes int64, description string) io.ReadCloser {
+	if body == nil || maxBytes <= 0 {
+		return body
+	}
+	return &maxBytesReadCloser{
+		body:        body,
+		description: description,
+		maxBytes:    maxBytes,
+		remaining:   maxBytes,
+	}
+}
+
+func (r *maxBytesReadCloser) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if r.remaining < 0 {
+		return 0, fmt.Errorf("%s exceeds max size of %d bytes", r.description, r.maxBytes)
+	}
+
+	limit := r.remaining + 1
+	if int64(len(p)) > limit {
+		p = p[:limit]
+	}
+
+	n, err := r.body.Read(p)
+	if int64(n) <= r.remaining {
+		r.remaining -= int64(n)
+		return n, err
+	}
+
+	allowed := int(r.remaining)
+	r.remaining = -1
+	if allowed > 0 {
+		return allowed, fmt.Errorf("%s exceeds max size of %d bytes", r.description, r.maxBytes)
+	}
+	return 0, fmt.Errorf("%s exceeds max size of %d bytes", r.description, r.maxBytes)
+}
+
+func (r *maxBytesReadCloser) Close() error {
+	return r.body.Close()
+}

--- a/internal/functionscan/runtime_test.go
+++ b/internal/functionscan/runtime_test.go
@@ -323,6 +323,36 @@ func TestOpenHTTPArtifactValidatesDialTarget(t *testing.T) {
 	}
 }
 
+func TestOpenHTTPArtifactRejectsOversizedResponseBody(t *testing.T) {
+	originalValidator := artifactURLValidator
+	artifactURLValidator = func(string) error { return nil }
+	defer func() { artifactURLValidator = originalValidator }()
+
+	originalLimit := maxArtifactResponseBodyBytes
+	maxArtifactResponseBodyBytes = 4
+	defer func() { maxArtifactResponseBodyBytes = originalLimit }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "oversized")
+	}))
+	defer server.Close()
+
+	reader, err := openHTTPArtifact(context.Background(), server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("openHTTPArtifact: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	body, err := io.ReadAll(reader)
+	if err == nil || !strings.Contains(err.Error(), "artifact download exceeds max size of 4 bytes") {
+		t.Fatalf("expected oversized artifact error, got body %q err %v", string(body), err)
+	}
+	if string(body) != "over" {
+		t.Fatalf("expected body to stop at limit, got %q", string(body))
+	}
+}
+
 func TestLocalMaterializerRejectsOversizedArchiveEntry(t *testing.T) {
 	originalEntryBytes := maxArchiveEntryBytes
 	maxArchiveEntryBytes = 8

--- a/internal/scanner/container.go
+++ b/internal/scanner/container.go
@@ -793,7 +793,7 @@ func (c *ECRClient) DownloadBlob(ctx context.Context, repo, digest string) (io.R
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("ecr layer download failed %d: %s", resp.StatusCode, string(body))
 	}
-	return resp.Body, nil
+	return newMaxBytesReadCloser(resp.Body, maxRegistryBlobDownloadBytes, "registry blob download"), nil
 }
 
 func (c *ECRClient) fetchManifest(ctx context.Context, repo, reference string) ([]byte, http.Header, error) {
@@ -1012,7 +1012,7 @@ func (c *GCRClient) DownloadBlob(ctx context.Context, repo, digest string) (io.R
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("registry API error %d: %s", resp.StatusCode, string(body))
 	}
-	return resp.Body, nil
+	return newMaxBytesReadCloser(resp.Body, maxRegistryBlobDownloadBytes, "registry blob download"), nil
 }
 
 func (c *GCRClient) GetVulnerabilities(ctx context.Context, repo, tag string) ([]ImageVulnerability, error) {
@@ -1180,7 +1180,7 @@ func (c *ACRClient) DownloadBlob(ctx context.Context, repo, digest string) (io.R
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("registry API error %d: %s", resp.StatusCode, string(body))
 	}
-	return resp.Body, nil
+	return newMaxBytesReadCloser(resp.Body, maxRegistryBlobDownloadBytes, "registry blob download"), nil
 }
 
 func (c *ACRClient) GetVulnerabilities(ctx context.Context, repo, tag string) ([]ImageVulnerability, error) {

--- a/internal/scanner/container_dockerhub.go
+++ b/internal/scanner/container_dockerhub.go
@@ -141,7 +141,7 @@ func (c *DockerHubClient) DownloadBlob(ctx context.Context, repo, digest string)
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("registry API error %d: %s", resp.StatusCode, string(body))
 	}
-	return resp.Body, nil
+	return newMaxBytesReadCloser(resp.Body, maxRegistryBlobDownloadBytes, "registry blob download"), nil
 }
 
 func (c *DockerHubClient) GetVulnerabilities(context.Context, string, string) ([]ImageVulnerability, error) {

--- a/internal/scanner/container_test.go
+++ b/internal/scanner/container_test.go
@@ -601,6 +601,35 @@ func TestGCRClientDownloadBlobQualifiesRepository(t *testing.T) {
 	}
 }
 
+func TestGCRClientDownloadBlobRejectsOversizedBody(t *testing.T) {
+	originalLimit := maxRegistryBlobDownloadBytes
+	maxRegistryBlobDownloadBytes = 4
+	defer func() { maxRegistryBlobDownloadBytes = originalLimit }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("oversized"))
+	}))
+	defer server.Close()
+
+	client := NewGCRClient("my-project")
+	client.SetRegistryHost(server.URL)
+	client.client = server.Client()
+
+	reader, err := client.DownloadBlob(context.Background(), "repo", "sha256:layer")
+	if err != nil {
+		t.Fatalf("DownloadBlob: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	body, err := io.ReadAll(reader)
+	if err == nil || !strings.Contains(err.Error(), "registry blob download exceeds max size of 4 bytes") {
+		t.Fatalf("expected oversized blob error, got body %q err %v", string(body), err)
+	}
+	if string(body) != "over" {
+		t.Fatalf("expected body to stop at limit, got %q", string(body))
+	}
+}
+
 func TestDockerHubClientSuccess(t *testing.T) {
 	manifestPayload := registryManifest{
 		MediaType: "application/vnd.docker.distribution.manifest.v2+json",

--- a/internal/scanner/max_bytes_read_closer.go
+++ b/internal/scanner/max_bytes_read_closer.go
@@ -1,0 +1,58 @@
+package scanner
+
+import (
+	"fmt"
+	"io"
+)
+
+var maxRegistryBlobDownloadBytes int64 = 5 << 30
+
+type maxBytesReadCloser struct {
+	body        io.ReadCloser
+	description string
+	maxBytes    int64
+	remaining   int64
+}
+
+func newMaxBytesReadCloser(body io.ReadCloser, maxBytes int64, description string) io.ReadCloser {
+	if body == nil || maxBytes <= 0 {
+		return body
+	}
+	return &maxBytesReadCloser{
+		body:        body,
+		description: description,
+		maxBytes:    maxBytes,
+		remaining:   maxBytes,
+	}
+}
+
+func (r *maxBytesReadCloser) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if r.remaining < 0 {
+		return 0, fmt.Errorf("%s exceeds max size of %d bytes", r.description, r.maxBytes)
+	}
+
+	limit := r.remaining + 1
+	if int64(len(p)) > limit {
+		p = p[:limit]
+	}
+
+	n, err := r.body.Read(p)
+	if int64(n) <= r.remaining {
+		r.remaining -= int64(n)
+		return n, err
+	}
+
+	allowed := int(r.remaining)
+	r.remaining = -1
+	if allowed > 0 {
+		return allowed, fmt.Errorf("%s exceeds max size of %d bytes", r.description, r.maxBytes)
+	}
+	return 0, fmt.Errorf("%s exceeds max size of %d bytes", r.description, r.maxBytes)
+}
+
+func (r *maxBytesReadCloser) Close() error {
+	return r.body.Close()
+}


### PR DESCRIPTION
## Summary
- wrap streamed registry layer downloads in scanner clients with a shared max-size read closer before handing them to callers
- apply the same capped streaming behavior to HTTP function artifact downloads so raw response bodies are no longer unbounded
- add regression tests that force tiny limits and fail if oversized responses read past the configured cap

## Testing
- go test ./internal/scanner ./internal/functionscan
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #312