### PR TITLE
fix(config): default API security controls to safe values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,9 +33,12 @@ API_PORT=8080
 LOG_LEVEL=info
 POLICIES_PATH=policies
 QUERY_POLICY_ROW_LIMIT=1000
-API_AUTH_ENABLED=false
+API_AUTH_ENABLED=true
 # Comma-separated key[:user-id] entries, e.g. "key1:svc-ci,key2:security-bot"
 API_KEYS=
+# Local development opt-out (requires LOG_LEVEL=debug or CEREBRO_DEV_MODE_ACK=1)
+CEREBRO_DEV_MODE=
+CEREBRO_DEV_MODE_ACK=
 # CLI API mode: auto (default), api (require API), direct (bypass API)
 CEREBRO_CLI_MODE=auto
 # CLI API endpoint and auth (used when CEREBRO_CLI_MODE is auto/api)
@@ -131,7 +134,7 @@ CEREBRO_ACCESS_REVIEW_RETENTION_DAYS=0
 # =============================================================================
 # API RATE LIMITING (optional)
 # =============================================================================
-RATE_LIMIT_ENABLED=false
+RATE_LIMIT_ENABLED=true
 RATE_LIMIT_REQUESTS=1000
 RATE_LIMIT_WINDOW=1h
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ export SNOWFLAKE_ACCOUNT="myaccount.us-east-1"
 export SNOWFLAKE_USER="CEREBRO_APP"
 export SNOWFLAKE_PRIVATE_KEY="<paste-pem-private-key>"
 export SNOWFLAKE_WAREHOUSE="COMPUTE_WH"
+export API_KEYS="replace-me:operator"
 
 # Optional: AI agents
 export ANTHROPIC_API_KEY="sk-ant-..."
@@ -126,6 +127,8 @@ For local development, you can run Cerebro without Snowflake credentials:
 ```bash
 unset SNOWFLAKE_PRIVATE_KEY SNOWFLAKE_ACCOUNT SNOWFLAKE_USER
 export CEREBRO_DB_PATH=.cerebro/cerebro.db
+export LOG_LEVEL=debug
+export CEREBRO_DEV_MODE=1
 make serve
 ```
 
@@ -339,9 +342,9 @@ See [Development Guide](docs/DEVELOPMENT.md) for detailed instructions.
 | `POLICIES_PATH` | Policy directory | `policies` |
 | `ANTHROPIC_API_KEY` | Claude API key | - |
 | `OPENAI_API_KEY` | OpenAI API key | - |
-| `API_AUTH_ENABLED` | Require API key auth | `false`* |
+| `API_AUTH_ENABLED` | Require API key auth | `true`* |
 | `API_KEYS` | Comma-separated API keys | - |
-| `RATE_LIMIT_ENABLED` | Enable API rate limiting | `false` |
+| `RATE_LIMIT_ENABLED` | Enable API rate limiting | `true` |
 | `RATE_LIMIT_REQUESTS` | Requests per rate limit window | `1000` |
 | `RATE_LIMIT_WINDOW` | Rate limit duration window | `1h` |
 | `JIRA_BASE_URL` | Jira instance | - |
@@ -355,7 +358,7 @@ See [Development Guide](docs/DEVELOPMENT.md) for detailed instructions.
 | `JOB_WORKER_CONCURRENCY` | Concurrent jobs per worker | `4` |
 | `NATS_URLS` | Comma-separated NATS server URLs | `nats://127.0.0.1:4222` |
 
-`*` When `API_KEYS` is set, API auth auto-enables unless explicitly overridden.
+`*` `CEREBRO_DEV_MODE=1` forces API auth and rate limiting off for local development.
 
 See [Configuration](docs/CONFIGURATION.md) for all options.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -162,11 +162,22 @@ export SCAN_TABLES="aws_s3_buckets,aws_iam_users,gcp_storage_buckets"
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| `RATE_LIMIT_ENABLED` | Enable rate limiting | `false` | No |
+| `RATE_LIMIT_ENABLED` | Enable rate limiting | `true` | No |
 | `RATE_LIMIT_REQUESTS` | Requests per window | `1000` | No |
 | `RATE_LIMIT_WINDOW` | Time window | `1h` | No |
 
 **Window Format:** Go duration string (e.g., `1h`, `30m`, `24h`)
+
+### API Authentication and Dev Mode
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `API_AUTH_ENABLED` | Require API key authentication | `true` | No |
+| `API_KEYS` | Comma-separated `key[:user-id]` entries | - | Yes* |
+| `CEREBRO_DEV_MODE` | Local-development opt-out that disables API auth and rate limiting | `false` | No |
+| `CEREBRO_DEV_MODE_ACK` | Explicit acknowledgement for non-debug dev mode runs | `false` | No |
+
+`*` Required when serving the API outside dev mode.
 
 ---
 
@@ -179,6 +190,7 @@ export SCAN_TABLES="aws_s3_buckets,aws_iam_users,gcp_storage_buckets"
 export SNOWFLAKE_ACCOUNT="myaccount.us-east-1"
 export SNOWFLAKE_USER="CEREBRO_APP"
 export SNOWFLAKE_PRIVATE_KEY="<pem-private-key>"
+export API_KEYS="replace-me:operator"
 
 # Recommended
 export API_PORT="8080"
@@ -192,6 +204,7 @@ export SCAN_INTERVAL="1h"
 # Core
 export API_PORT="8080"
 export LOG_LEVEL="info"
+export API_KEYS="replace-me:operator"
 
 # Snowflake
 export SNOWFLAKE_ACCOUNT="myaccount.us-east-1"
@@ -237,6 +250,7 @@ export LOG_LEVEL="debug"
 export API_PORT="8080"
 export POLICIES_PATH="./policies"
 export QUERY_POLICY_ROW_LIMIT="1000"
+export CEREBRO_DEV_MODE="1"
 
 # Optional: Snowflake key-pair (leave unset to run in local SQLite mode)
 # export SNOWFLAKE_ACCOUNT="myaccount.us-east-1"
@@ -459,6 +473,7 @@ Cerebro uses presence-based feature flags. Features are enabled when their confi
 | PagerDuty alerts | `PAGERDUTY_ROUTING_KEY` is set |
 | Scheduled scanning | `SCAN_INTERVAL` is set |
 | Rate limiting | `RATE_LIMIT_ENABLED=true` |
+| Local dev mode | `CEREBRO_DEV_MODE=true` (disables API auth + rate limiting) |
 
 ---
 

--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -2,7 +2,7 @@
 
 Generated from `internal/app/app_config.go` (`LoadConfig`) via `go run ./scripts/generate_config_docs/main.go`.
 
-Total variables: **375**
+Total variables: **377**
 
 | Variable | Reader(s) | Default(s) | Config Field(s) | Validation rule(s) |
 |---|---|---|---|---|
@@ -23,7 +23,7 @@ Total variables: **375**
 | `ALERT_ROUTER_STATE_FILE` | `getEnv` | `filepath.Join(".cerebro", "alert-router", "state.db")` | `AlertRouterStateFile` | `-` |
 | `ANTHROPIC_API_KEY` | `getEnv` | `""` | `AnthropicAPIKey` | `-` |
 | `API_AUTHORIZATION_SERVERS` | `getEnv` | `""` | `APIAuthorizationServers` | `-` |
-| `API_AUTH_ENABLED` | `getEnvBool` | `len(apiKeys) > 0` | `-` | `-` |
+| `API_AUTH_ENABLED` | `getEnvBool` | `true` | `-` | `-` |
 | `API_CORS_ALLOWED_ORIGINS` | `getEnv` | `""` | `CORSAllowedOrigins` | `-` |
 | `API_CREDENTIALS_JSON` | `getEnv` | `""` | `-` | `-` |
 | `API_CREDENTIAL_STATE_FILE` | `getEnv` | `filepath.Join(".cerebro", "api-credentials", "state.json")` | `APICredentialStateFile` | `-` |
@@ -53,6 +53,8 @@ Total variables: **375**
 | `CEREBRO_CREDENTIAL_VAULT_NAMESPACE` | `bootstrapConfigValue` | `""` | `CredentialVaultNamespace` | `credential-source settings must be present and valid for the selected source backend` |
 | `CEREBRO_CREDENTIAL_VAULT_PATH` | `bootstrapConfigValue` | `""` | `CredentialVaultPath` | `credential-source settings must be present and valid for the selected source backend` |
 | `CEREBRO_CREDENTIAL_VAULT_TOKEN` | `bootstrapConfigValue` | `""` | `CredentialVaultToken` | `credential-source settings must be present and valid for the selected source backend` |
+| `CEREBRO_DEV_MODE` | `getEnvBool` | `false` | `-` | `when CEREBRO_DEV_MODE=true, LOG_LEVEL must be debug unless CEREBRO_DEV_MODE_ACK=true` |
+| `CEREBRO_DEV_MODE_ACK` | `getEnvBool` | `false` | `-` | `when CEREBRO_DEV_MODE=true, LOG_LEVEL must be debug unless CEREBRO_DEV_MODE_ACK=true` |
 | `CEREBRO_GRAPH_FRESHNESS_DEFAULT_SLA` | `getEnvDuration` | `6 * time.Hour` | `GraphFreshnessDefaultSLA` | `-` |
 | `CEREBRO_GRAPH_RETENTION_DAYS` | `getEnvInt` | `180` | `GraphRetentionDays` | `-` |
 | `CEREBRO_HEALTH_CHECK_TIMEOUT` | `getEnvDuration` | `defaultHealthCheckTimeout` | `HealthCheckTimeout` | `health checks must not outlive the API request timeout`, `must be greater than 0` |
@@ -205,7 +207,7 @@ Total variables: **375**
 | `KOLIDE_BASE_URL` | `getEnv` | `"https://api.kolide.com/v1"` | `KolideBaseURL` | `-` |
 | `LINEAR_API_KEY` | `getEnv` | `""` | `LinearAPIKey` | `-` |
 | `LINEAR_TEAM_ID` | `getEnv` | `""` | `LinearTeamID` | `-` |
-| `LOG_LEVEL` | `getEnv` | `"info"` | `LogLevel` | `must be one of debug, info, warn, error` |
+| `LOG_LEVEL` | `getEnv` | `"info"` | `LogLevel` | `must be one of debug, info, warn, error`, `when CEREBRO_DEV_MODE=true, LOG_LEVEL must be debug unless CEREBRO_DEV_MODE_ACK=true` |
 | `MALWARE_SCAN_CLAMAV_HOST` | `getEnv` | `""` | `MalwareScanClamAVHost` | `-` |
 | `MALWARE_SCAN_CLAMAV_PORT` | `getEnvInt` | `0` | `MalwareScanClamAVPort` | `-` |
 | `MALWARE_SCAN_VIRUSTOTAL_API_KEY` | `getEnv` | `""` | `MalwareScanVirusTotalAPIKey` | `-` |
@@ -289,7 +291,7 @@ Total variables: **375**
 | `RAMP_CLIENT_ID` | `getEnv` | `""` | `RampClientID` | `-` |
 | `RAMP_CLIENT_SECRET` | `getEnv` | `""` | `RampClientSecret` | `-` |
 | `RAMP_TOKEN_URL` | `getEnv` | `"https://api.ramp.com/developer/v1/token"` | `RampTokenURL` | `-` |
-| `RATE_LIMIT_ENABLED` | `getEnvBool` | `false` | `RateLimitEnabled` | `when RATE_LIMIT_ENABLED=true, requests and window must be positive` |
+| `RATE_LIMIT_ENABLED` | `getEnvBool` | `true` | `-` | `when RATE_LIMIT_ENABLED=true, requests and window must be positive` |
 | `RATE_LIMIT_REQUESTS` | `getEnvInt` | `1000` | `RateLimitRequests` | `when RATE_LIMIT_ENABLED=true, requests and window must be positive` |
 | `RATE_LIMIT_TRUSTED_PROXIES` | `getEnv` | `""` | `RateLimitTrustedProxies` | `-` |
 | `RATE_LIMIT_WINDOW` | `getEnvDuration` | `time.Hour` | `RateLimitWindow` | `when RATE_LIMIT_ENABLED=true, requests and window must be positive` |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -245,7 +245,7 @@ func NewWithOptions(ctx context.Context, opts ...Option) (*App, error) {
 		return nil, fmt.Errorf("load managed api credential state: %w", err)
 	}
 	if cfg.APIAuthEnabled && len(cfg.APIKeys) == 0 && len(managedCredentialStore.List()) == 0 {
-		return nil, fmt.Errorf("api auth enabled but no API_KEYS configured")
+		return nil, fmt.Errorf("api auth enabled but no API_KEYS configured; configure API_KEYS or set CEREBRO_DEV_MODE=1 for local development")
 	}
 
 	logger := options.logger

--- a/internal/app/app_config.go
+++ b/internal/app/app_config.go
@@ -458,6 +458,8 @@ type Config struct {
 	JobMaxAttempts       int
 
 	// Rate Limiting
+	DevMode                 bool
+	DevModeAck              bool
 	RateLimitEnabled        bool
 	RateLimitRequests       int
 	RateLimitWindow         time.Duration
@@ -559,7 +561,14 @@ func LoadConfig() *Config {
 				}
 			}
 			apiKeys = apiauth.CredentialsToUserMap(apiCredentials)
-			apiAuthEnabled := getEnvBool("API_AUTH_ENABLED", len(apiKeys) > 0)
+			devMode := getEnvBool("CEREBRO_DEV_MODE", false)
+			devModeAck := getEnvBool("CEREBRO_DEV_MODE_ACK", false)
+			apiAuthEnabled := getEnvBool("API_AUTH_ENABLED", true)
+			rateLimitEnabled := getEnvBool("RATE_LIMIT_ENABLED", true)
+			if devMode {
+				apiAuthEnabled = false
+				rateLimitEnabled = false
+			}
 			snowflakeAccount := getEnv("SNOWFLAKE_ACCOUNT", "")
 			snowflakeUser := getEnv("SNOWFLAKE_USER", "")
 			snowflakePrivateKey := normalizePrivateKey(getEnv("SNOWFLAKE_PRIVATE_KEY", ""))
@@ -874,7 +883,9 @@ func LoadConfig() *Config {
 				JobVisibilityTimeout:                     getEnvDuration("JOB_VISIBILITY_TIMEOUT", 30*time.Second),
 				JobPollWait:                              getEnvDuration("JOB_POLL_WAIT", 10*time.Second),
 				JobMaxAttempts:                           getEnvInt("JOB_MAX_ATTEMPTS", 3),
-				RateLimitEnabled:                         getEnvBool("RATE_LIMIT_ENABLED", false),
+				DevMode:                                  devMode,
+				DevModeAck:                               devModeAck,
+				RateLimitEnabled:                         rateLimitEnabled,
 				RateLimitRequests:                        getEnvInt("RATE_LIMIT_REQUESTS", 1000),
 				RateLimitWindow:                          getEnvDuration("RATE_LIMIT_WINDOW", time.Hour),
 				RateLimitTrustedProxies:                  splitCSV(getEnv("RATE_LIMIT_TRUSTED_PROXIES", "")),

--- a/internal/app/app_config_validation.go
+++ b/internal/app/app_config_validation.go
@@ -175,6 +175,11 @@ func ConfigValidationRules() []ConfigValidationRule {
 			Category: "dependency",
 		},
 		{
+			EnvVars:  []string{"CEREBRO_DEV_MODE", "LOG_LEVEL", "CEREBRO_DEV_MODE_ACK"},
+			Summary:  "when CEREBRO_DEV_MODE=true, LOG_LEVEL must be debug unless CEREBRO_DEV_MODE_ACK=true",
+			Category: "dependency",
+		},
+		{
 			EnvVars: []string{
 				"GRAPH_CROSS_TENANT_REQUIRE_SIGNED_INGEST",
 				"GRAPH_CROSS_TENANT_SIGNING_KEY",
@@ -521,6 +526,17 @@ func (c *Config) Validate() error {
 		}
 		if c.RateLimitWindow <= 0 {
 			problems = addConfigProblem(problems, "RATE_LIMIT_WINDOW must be > 0 when RATE_LIMIT_ENABLED=true")
+		}
+	}
+	if c.DevMode {
+		if c.APIAuthEnabled {
+			problems = addConfigProblem(problems, "API_AUTH_ENABLED must be false when CEREBRO_DEV_MODE=true")
+		}
+		if c.RateLimitEnabled {
+			problems = addConfigProblem(problems, "RATE_LIMIT_ENABLED must be false when CEREBRO_DEV_MODE=true")
+		}
+		if !strings.EqualFold(strings.TrimSpace(c.LogLevel), "debug") && !c.DevModeAck {
+			problems = addConfigProblem(problems, "CEREBRO_DEV_MODE requires LOG_LEVEL=debug or CEREBRO_DEV_MODE_ACK=1")
 		}
 	}
 

--- a/internal/app/app_options_test.go
+++ b/internal/app/app_options_test.go
@@ -37,7 +37,7 @@ func TestNewWithOptions_APIAuthEnabledWithoutKeys(t *testing.T) {
 		t.Fatal("expected error when API auth is enabled with no API keys")
 		return
 	}
-	if !strings.Contains(err.Error(), "api auth enabled but no API_KEYS configured") {
+	if !strings.Contains(err.Error(), "configure API_KEYS or set CEREBRO_DEV_MODE=1") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/app/app_security_defaults_test.go
+++ b/internal/app/app_security_defaults_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadConfigDefaultsEnableAPISecurityControls(t *testing.T) {
+	cfg := LoadConfig()
+	if !cfg.APIAuthEnabled {
+		t.Fatal("expected API auth to default to enabled")
+	}
+	if !cfg.RateLimitEnabled {
+		t.Fatal("expected rate limiting to default to enabled")
+	}
+	if cfg.DevMode {
+		t.Fatal("expected dev mode to default to disabled")
+	}
+}
+
+func TestLoadConfigDevModeDisablesAPISecurityControls(t *testing.T) {
+	t.Setenv("CEREBRO_DEV_MODE", "true")
+
+	cfg := LoadConfig()
+	if !cfg.DevMode {
+		t.Fatal("expected dev mode to be enabled")
+	}
+	if cfg.APIAuthEnabled {
+		t.Fatal("expected dev mode to disable API auth")
+	}
+	if cfg.RateLimitEnabled {
+		t.Fatal("expected dev mode to disable rate limiting")
+	}
+}
+
+func TestValidateDevModeRequiresDebugOrAck(t *testing.T) {
+	cfg := LoadConfig()
+	cfg.DevMode = true
+	cfg.APIAuthEnabled = false
+	cfg.RateLimitEnabled = false
+	cfg.LogLevel = "info"
+	cfg.DevModeAck = false
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error when dev mode is enabled without debug logging or ack")
+	}
+	if !strings.Contains(err.Error(), "CEREBRO_DEV_MODE requires LOG_LEVEL=debug or CEREBRO_DEV_MODE_ACK=1") {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+
+	cfg.LogLevel = "debug"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected debug logging to satisfy dev mode validation, got %v", err)
+	}
+
+	cfg.LogLevel = "info"
+	cfg.DevModeAck = true
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected explicit ack to satisfy dev mode validation, got %v", err)
+	}
+}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1169,6 +1169,7 @@ func TestNew_WithoutSnowflake(t *testing.T) {
 	t.Setenv("SNOWFLAKE_PRIVATE_KEY", "")
 	t.Setenv("SNOWFLAKE_ACCOUNT", "")
 	t.Setenv("SNOWFLAKE_USER", "")
+	t.Setenv("API_AUTH_ENABLED", "false")
 
 	ctx := context.Background()
 	app, err := New(ctx)
@@ -1269,6 +1270,7 @@ func TestNew_WebhookURLs(t *testing.T) {
 	t.Setenv("WEBHOOK_URLS", "https://1.1.1.1/hook")
 	t.Setenv("SLACK_WEBHOOK_URL", "")
 	t.Setenv("PAGERDUTY_ROUTING_KEY", "")
+	t.Setenv("API_AUTH_ENABLED", "false")
 
 	ctx := context.Background()
 	app, err := New(ctx)
@@ -1301,6 +1303,7 @@ func TestNew_ServicesWired(t *testing.T) {
 	t.Setenv("SNOWFLAKE_PRIVATE_KEY", "")
 	t.Setenv("SNOWFLAKE_ACCOUNT", "")
 	t.Setenv("SNOWFLAKE_USER", "")
+	t.Setenv("API_AUTH_ENABLED", "false")
 
 	ctx := context.Background()
 	app, err := New(ctx)
@@ -1350,6 +1353,7 @@ func TestNew_ExplicitMappingsOnlyFailsOnUnmappedPolicy(t *testing.T) {
 	t.Setenv("SNOWFLAKE_ACCOUNT", "")
 	t.Setenv("SNOWFLAKE_USER", "")
 
+	t.Setenv("API_AUTH_ENABLED", "false")
 	policiesDir := t.TempDir()
 	policyJSON := `{
 		"id": "strict-unmapped",
@@ -1758,6 +1762,7 @@ func TestApp_Close(t *testing.T) {
 	t.Setenv("SNOWFLAKE_PRIVATE_KEY", "")
 	t.Setenv("SNOWFLAKE_ACCOUNT", "")
 	t.Setenv("SNOWFLAKE_USER", "")
+	t.Setenv("API_AUTH_ENABLED", "false")
 
 	ctx := context.Background()
 	app, _ := New(ctx)

--- a/internal/app/devex_static_test.go
+++ b/internal/app/devex_static_test.go
@@ -437,6 +437,26 @@ func TestDevelopmentGuideDocumentsDevexPreflight(t *testing.T) {
 	}
 }
 
+func TestEnvExampleKeepsAPISecurityControlsEnabledByDefault(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, ".env.example")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read .env.example: %v", err)
+	}
+	text := string(content)
+
+	if strings.Contains(text, "API_AUTH_ENABLED=false") {
+		t.Fatal("expected .env.example to avoid disabling API auth by default")
+	}
+	if strings.Contains(text, "RATE_LIMIT_ENABLED=false") {
+		t.Fatal("expected .env.example to avoid disabling rate limiting by default")
+	}
+	if !strings.Contains(text, "CEREBRO_DEV_MODE=") {
+		t.Fatal("expected .env.example to document CEREBRO_DEV_MODE for local development")
+	}
+}
+
 func TestDevexScriptPlansRelevantChecks(t *testing.T) {
 	root := repoRoot(t)
 	cmd := exec.Command("python3", "./scripts/devex.py", "plan", "--mode", "changed", "--json", "--files", "api/openapi.yaml", "internal/graph/entity_facets.go", "devex/codegen_catalog.json", ".githooks/pre-push")

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -18,6 +16,20 @@ import (
 )
 
 var servePort int
+
+func validateServeSecurityMode(cfg *app.Config) error {
+	if cfg == nil || cfg.APIAuthEnabled || cfg.DevMode {
+		return nil
+	}
+	return fmt.Errorf("api authentication is disabled; configure API_KEYS/API_AUTH_ENABLED=true or explicitly set CEREBRO_DEV_MODE=1 for local development")
+}
+
+func serveSecurityWarning(cfg *app.Config) string {
+	if cfg == nil || !cfg.DevMode {
+		return ""
+	}
+	return "DEV MODE: API authentication and rate limiting are disabled"
+}
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
@@ -67,17 +79,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	if !application.Config.APIAuthEnabled {
-		allowInsecure := false
-		if raw := strings.TrimSpace(os.Getenv("ALLOW_INSECURE_API")); raw != "" {
-			allowInsecure, _ = strconv.ParseBool(raw)
-		}
-
-		if !allowInsecure {
-			return fmt.Errorf("api authentication is disabled; configure API_KEYS/API_AUTH_ENABLED=true or explicitly set ALLOW_INSECURE_API=true")
-		}
-
-		application.Logger.Warn("starting API server with authentication disabled")
+	if err := validateServeSecurityMode(application.Config); err != nil {
+		return err
+	}
+	if warning := serveSecurityWarning(application.Config); warning != "" {
+		application.Logger.Warn(warning)
 	}
 
 	// Start scheduler in background if configured

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/app"
+)
+
+func TestValidateServeSecurityMode(t *testing.T) {
+	t.Run("rejects disabled auth outside dev mode", func(t *testing.T) {
+		err := validateServeSecurityMode(&app.Config{APIAuthEnabled: false})
+		if err == nil {
+			t.Fatal("expected serve security validation error")
+		}
+		if !strings.Contains(err.Error(), "CEREBRO_DEV_MODE=1") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("allows dev mode", func(t *testing.T) {
+		if err := validateServeSecurityMode(&app.Config{APIAuthEnabled: false, DevMode: true}); err != nil {
+			t.Fatalf("expected dev mode to bypass serve guard, got %v", err)
+		}
+	})
+}
+
+func TestServeSecurityWarning(t *testing.T) {
+	if got := serveSecurityWarning(&app.Config{DevMode: true}); got != "DEV MODE: API authentication and rate limiting are disabled" {
+		t.Fatalf("unexpected dev mode warning %q", got)
+	}
+	if got := serveSecurityWarning(&app.Config{DevMode: false}); got != "" {
+		t.Fatalf("expected no warning when dev mode is disabled, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- default API auth and rate limiting to enabled, with an explicit `CEREBRO_DEV_MODE` opt-out that also adds startup warnings and validation guardrails
- update serve/app error paths plus regression tests so missing API keys fail clearly and dev mode remains an explicit local-only escape hatch
- refresh `.env.example`, README, configuration docs, and generated config env-var docs to reflect the safer defaults

Closes #386