### PR TITLE
chore(build): align Go version and release flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,21 @@ jobs:
           print("Package-level coverage thresholds passed.")
           PY
 
+  go-version-docs:
+    name: go-version-docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Ensure README Go version matches go.mod
+        shell: bash
+        run: |
+          set -euo pipefail
+          GO_VERSION="$(awk '/^go [0-9]/{print $2; exit}' go.mod)"
+          GO_MINOR="$(printf '%s' "${GO_VERSION}" | cut -d. -f1,2)"
+          grep -q "Go-${GO_MINOR}+-" README.md
+          grep -q "Go ${GO_MINOR}+" README.md
+
   vendor-check:
     name: vendor-check
     runs-on: ubuntu-latest
@@ -679,7 +694,10 @@ jobs:
         run: |
           set -euo pipefail
           GO_VERSION="$(./scripts/go_version.sh)"
-          docker build --build-arg GO_VERSION="${GO_VERSION}" -f Dockerfile -t cerebro:ci .
+          VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
+          COMMIT="$(git rev-parse --short HEAD)"
+          DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          docker build --build-arg GO_VERSION="${GO_VERSION}" --build-arg VERSION="${VERSION}" --build-arg COMMIT="${COMMIT}" --build-arg DATE="${DATE}" -f Dockerfile -t cerebro:ci .
 
       - name: Run Trivy image scan
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
 
 WORKDIR /app
 
@@ -23,7 +26,9 @@ COPY internal ./internal
 RUN --mount=type=cache,id=cerebro-go-mod-cache,target=/go/pkg/mod,sharing=locked \
     --mount=type=cache,id=cerebro-go-build-cache,target=/root/.cache/go-build,sharing=locked \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -buildvcs=false -trimpath -ldflags="-s -w" -o /cerebro ./cmd/cerebro
+    go build -buildvcs=false -trimpath \
+    -ldflags="-s -w -X github.com/writer/cerebro/internal/cli.Version=${VERSION} -X github.com/writer/cerebro/internal/cli.Commit=${COMMIT} -X github.com/writer/cerebro/internal/cli.BuildDate=${DATE}" \
+    -o /cerebro ./cmd/cerebro
 
 # Runtime image
 FROM alpine:3.23

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
-.PHONY: build run test sync clean dev serve policy-list docker-build trivy-db security-scan security-scan-built security-scan-source vendor vendor-check oss-audit openapi-check openapi-sync api-contract-docs api-contract-docs-check api-contract-compat config-docs config-docs-check ontology-docs ontology-docs-check cloudevents-docs cloudevents-docs-check cloudevents-contract-compat report-contract-docs report-contract-docs-check report-contract-compat entity-facet-docs entity-facet-docs-check entity-facet-contract-compat agent-sdk-docs agent-sdk-docs-check agent-sdk-contract-compat agent-sdk-packages agent-sdk-packages-check connector-docs connector-docs-check graph-ontology-guardrails gosec govulncheck devex-codegen devex-codegen-check devex-changed devex-pr platform-up platform-down platform-logs platform-smoke hooks pre-commit verify
+.PHONY: build build-release build-size-report run test sync clean dev serve policy-list docker-build trivy-db security-scan security-scan-built security-scan-source vendor vendor-check oss-audit openapi-check openapi-sync api-contract-docs api-contract-docs-check api-contract-compat config-docs config-docs-check ontology-docs ontology-docs-check cloudevents-docs cloudevents-docs-check cloudevents-contract-compat report-contract-docs report-contract-docs-check report-contract-compat entity-facet-docs entity-facet-docs-check entity-facet-contract-compat agent-sdk-docs agent-sdk-docs-check agent-sdk-contract-compat agent-sdk-packages agent-sdk-packages-check connector-docs connector-docs-check graph-ontology-guardrails gosec govulncheck devex-codegen devex-codegen-check devex-changed devex-pr platform-up platform-down platform-logs platform-smoke hooks pre-commit verify
 
 # Version info
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS := -ldflags "-X github.com/writer/cerebro/internal/cli.Version=$(VERSION) \
-                     -X github.com/writer/cerebro/internal/cli.Commit=$(COMMIT) \
-                     -X github.com/writer/cerebro/internal/cli.BuildDate=$(DATE)"
+VERSION_LDFLAGS := -X github.com/writer/cerebro/internal/cli.Version=$(VERSION) \
+                   -X github.com/writer/cerebro/internal/cli.Commit=$(COMMIT) \
+                   -X github.com/writer/cerebro/internal/cli.BuildDate=$(DATE)
+LDFLAGS := -ldflags "$(VERSION_LDFLAGS)"
+RELEASE_LDFLAGS := -ldflags "-s -w $(VERSION_LDFLAGS)"
 
 TRIVY_IMAGE ?= aquasec/trivy:0.34.0
 TRIVY_CACHE_DIR ?= $(HOME)/.cache/trivy
@@ -19,6 +21,13 @@ export GOFLAGS
 # Build the cerebro binary
 build:
 	go build $(LDFLAGS) -o bin/cerebro ./cmd/cerebro
+
+build-release:
+	CGO_ENABLED=0 go build -buildvcs=false -trimpath $(RELEASE_LDFLAGS) -o bin/cerebro ./cmd/cerebro
+
+build-size-report: build
+	ls -lh bin/cerebro
+	go tool nm -size bin/cerebro 2>/dev/null | head -20
 
 # Run the API server
 serve: build
@@ -85,7 +94,7 @@ dev:
 
 # Docker build
 docker-build:
-	docker build --build-arg GO_VERSION=$(GO_VERSION) -t cerebro:latest .
+	docker build --build-arg GO_VERSION=$(GO_VERSION) --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) -t cerebro:latest .
 
 # Download/update Trivy vulnerability database cache
 trivy-db:
@@ -99,7 +108,7 @@ trivy-db:
 security-scan: security-scan-built
 
 security-scan-built: trivy-db
-	docker build --build-arg GO_VERSION=$(GO_VERSION) -f Dockerfile -t $(SECURITY_SCAN_IMAGE) .
+	docker build --build-arg GO_VERSION=$(GO_VERSION) --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) -f Dockerfile -t $(SECURITY_SCAN_IMAGE) .
 	docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v "$(TRIVY_CACHE_DIR):/root/.cache" \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Cerebro is a unified operations platform that combines data ingestion from cloud
 
 > **Origin:** This is Writer's original Cerebro repository. Cerebro began as a security-focused cloud posture management tool and now handles broader operational signals too — from cloud misconfigurations to stale deals, SLA breaches, payment failures, and business entity drift.
 
-[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 ---
@@ -79,7 +79,7 @@ Cerebro is a unified operations platform that combines data ingestion from cloud
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - Snowflake account (or use local SQLite mode)
 
 ### Installation
@@ -365,7 +365,7 @@ See [Configuration](docs/CONFIGURATION.md) for all options.
 
 | Component | Technology |
 |-----------|------------|
-| Language | Go 1.25+ |
+| Language | Go 1.26+ |
 | API Framework | Chi |
 | Database | Snowflake / SQLite (local) |
 | Graph Store | Neptune |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - Docker & Docker Compose (optional)
 - Snowflake account (for full functionality)
 - Make
@@ -730,7 +730,7 @@ jobs:
         run: make build
       
       - name: Build Docker image
-        run: docker build --build-arg GO_VERSION="$(./scripts/go_version.sh)" -t cerebro:${{ github.sha }} .
+        run: GO_VERSION="$(./scripts/go_version.sh)" && VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)" && COMMIT="$(git rev-parse --short HEAD)" && DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" && docker build --build-arg GO_VERSION="${GO_VERSION}" --build-arg VERSION="${VERSION}" --build-arg COMMIT="${COMMIT}" --build-arg DATE="${DATE}" -t cerebro:${{ github.sha }} .
 ```
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/writer/cerebro
 
-go 1.26.0
+go 1.26.2
 
 require (
 	cloud.google.com/go/artifactregistry v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/writer/cerebro
 
 go 1.26.0
 
-toolchain go1.26.2
-
 require (
 	cloud.google.com/go/artifactregistry v1.19.0
 	cloud.google.com/go/asset v1.22.0

--- a/internal/app/devex_static_test.go
+++ b/internal/app/devex_static_test.go
@@ -254,17 +254,45 @@ func TestGoVersionScriptMatchesGoMod(t *testing.T) {
 	}
 	text := string(content)
 
-	if !strings.Contains(text, "toolchain go") {
-		t.Fatalf("expected go_version.sh to parse toolchain directive")
-	}
 	if !strings.Contains(text, "version=\"$(awk '/^go [0-9]/{print $2; exit}'") {
-		t.Fatalf("expected go_version.sh to fall back to go directive")
+		t.Fatalf("expected go_version.sh to parse the go directive")
 	}
 	if !strings.Contains(text, "printf '%s\\n' \"${version}\"") {
 		t.Fatalf("expected go_version.sh to print parsed version")
 	}
 	if expected == "" {
 		t.Fatalf("expected non-empty go.mod version")
+	}
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Dir = root
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run go_version.sh: %v", err)
+	}
+	if got := strings.TrimSpace(string(output)); got != expected {
+		t.Fatalf("go_version.sh = %q, want %q", got, expected)
+	}
+}
+
+func TestREADMEGoVersionMatchesGoMod(t *testing.T) {
+	root := repoRoot(t)
+	expectedMinor := expectedGoMinorVersionFromGoMod(t, root)
+
+	readmePath := filepath.Join(root, "README.md")
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README.md: %v", err)
+	}
+	text := string(content)
+
+	for _, needle := range []string{
+		"Go-" + expectedMinor + "+-",
+		"Go " + expectedMinor + "+",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("expected README.md to contain %q", needle)
+		}
 	}
 }
 
@@ -282,6 +310,17 @@ func TestDockerfileUsesGoVersionBuildArg(t *testing.T) {
 	}
 	if !strings.Contains(text, "golang:${GO_VERSION}-alpine") {
 		t.Fatalf("expected Dockerfile builder image to use GO_VERSION build arg")
+	}
+	for _, needle := range []string{
+		"ARG VERSION=dev",
+		"ARG COMMIT=unknown",
+		"ARG DATE=unknown",
+		"go build -buildvcs=false -trimpath",
+		"-ldflags=\"-s -w -X github.com/writer/cerebro/internal/cli.Version=${VERSION}",
+	} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("expected Dockerfile to contain %q", needle)
+		}
 	}
 }
 
@@ -304,7 +343,7 @@ func TestWorkflowsUseGoVersionFileFromGoMod(t *testing.T) {
 		if !strings.Contains(text, "go-version-file: go.mod") {
 			t.Fatalf("expected workflow %s to use go-version-file: go.mod", rel)
 		}
-		if strings.Contains(text, "go-version: '1.26.1'") {
+		if strings.Contains(text, "go-version: '") || strings.Contains(text, "go-version: \"") {
 			t.Fatalf("expected workflow %s to avoid hardcoded Go version", rel)
 		}
 	}
@@ -346,10 +385,19 @@ func TestDockerBuildCommandsPassGoVersionBuildArg(t *testing.T) {
 	if !strings.Contains(makefileText, "GO_VERSION ?= $(shell ./scripts/go_version.sh)") {
 		t.Fatalf("expected Makefile to derive GO_VERSION from scripts/go_version.sh")
 	}
-	if !strings.Contains(makefileText, "docker build --build-arg GO_VERSION=$(GO_VERSION) -t cerebro:latest .") {
+	if !strings.Contains(makefileText, "build-release:") {
+		t.Fatalf("expected Makefile to define build-release")
+	}
+	if !strings.Contains(makefileText, "go build -buildvcs=false -trimpath $(RELEASE_LDFLAGS) -o bin/cerebro ./cmd/cerebro") {
+		t.Fatalf("expected Makefile build-release target to use trimpath and release ldflags")
+	}
+	if !strings.Contains(makefileText, "build-size-report: build") {
+		t.Fatalf("expected Makefile to define build-size-report")
+	}
+	if !strings.Contains(makefileText, "docker build --build-arg GO_VERSION=$(GO_VERSION) --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) -t cerebro:latest .") {
 		t.Fatalf("expected Makefile docker-build target to pass GO_VERSION build arg")
 	}
-	if !strings.Contains(makefileText, "docker build --build-arg GO_VERSION=$(GO_VERSION) -f Dockerfile -t $(SECURITY_SCAN_IMAGE) .") {
+	if !strings.Contains(makefileText, "docker build --build-arg GO_VERSION=$(GO_VERSION) --build-arg VERSION=$(VERSION) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) -f Dockerfile -t $(SECURITY_SCAN_IMAGE) .") {
 		t.Fatalf("expected Makefile security scan image build to pass GO_VERSION build arg")
 	}
 	for _, target := range []string{"gosec:", "govulncheck:", "graph-ontology-guardrails:", "devex-codegen:", "devex-codegen-check:", "devex-changed:", "devex-pr:"} {
@@ -382,7 +430,10 @@ func TestDockerBuildCommandsPassGoVersionBuildArg(t *testing.T) {
 	if !strings.Contains(ciText, "GO_VERSION=\"$(./scripts/go_version.sh)\"") {
 		t.Fatalf("expected CI workflow to derive GO_VERSION from go.mod via script")
 	}
-	if !strings.Contains(ciText, "docker build --build-arg GO_VERSION=\"${GO_VERSION}\" -f Dockerfile -t cerebro:ci .") {
+	if !strings.Contains(ciText, "Ensure README Go version matches go.mod") {
+		t.Fatalf("expected CI workflow to check README Go version drift")
+	}
+	if !strings.Contains(ciText, "docker build --build-arg GO_VERSION=\"${GO_VERSION}\" --build-arg VERSION=\"${VERSION}\" --build-arg COMMIT=\"${COMMIT}\" --build-arg DATE=\"${DATE}\" -f Dockerfile -t cerebro:ci .") {
 		t.Fatalf("expected CI workflow Docker build to pass GO_VERSION build arg")
 	}
 }
@@ -702,20 +753,24 @@ func expectedGoVersionFromGoMod(t *testing.T, root string) string {
 		t.Fatalf("read go.mod: %v", err)
 	}
 
-	fallback := ""
 	for _, raw := range strings.Split(string(content), "\n") {
 		line := strings.TrimSpace(raw)
-		if strings.HasPrefix(line, "toolchain go") {
-			return strings.TrimPrefix(line, "toolchain go")
-		}
 		if strings.HasPrefix(line, "go ") {
-			fallback = strings.TrimSpace(strings.TrimPrefix(line, "go "))
+			return strings.TrimSpace(strings.TrimPrefix(line, "go "))
 		}
 	}
-	if fallback == "" {
-		t.Fatal("go.mod missing both toolchain and go directives")
+	t.Fatal("go.mod missing go directive")
+	return ""
+}
+
+func expectedGoMinorVersionFromGoMod(t *testing.T, root string) string {
+	t.Helper()
+
+	parts := strings.Split(expectedGoVersionFromGoMod(t, root), ".")
+	if len(parts) < 2 {
+		t.Fatalf("expected go version to include major and minor components, got %q", expectedGoVersionFromGoMod(t, root))
 	}
-	return fallback
+	return strings.Join(parts[:2], ".")
 }
 
 func repoRoot(t *testing.T) string {

--- a/scripts/go_version.sh
+++ b/scripts/go_version.sh
@@ -9,10 +9,7 @@ if [ ! -f "${go_mod}" ]; then
   exit 1
 fi
 
-version="$(awk '/^toolchain go[0-9]/{sub(/^toolchain go/, "", $0); print $1; exit}' "${go_mod}")"
-if [ -z "${version}" ]; then
-  version="$(awk '/^go [0-9]/{print $2; exit}' "${go_mod}")"
-fi
+version="$(awk '/^go [0-9]/{print $2; exit}' "${go_mod}")"
 
 if [ -z "${version}" ]; then
   echo "unable to determine Go version from ${go_mod}" >&2


### PR DESCRIPTION
## Summary
- make the `go` directive in `go.mod` the single source of truth for the supported Go version and add CI/static checks for README drift
- add a reproducible `build-release` target plus aligned Docker release flags and build args for version metadata
- refresh README/development docs and Makefile helpers to match the new version/build flow

Closes #392