### PR TITLE
fix(graph): fail partial builds on query errors

### DIFF
--- a/internal/graph/builders/builder.go
+++ b/internal/graph/builders/builder.go
@@ -31,9 +31,12 @@ type Builder struct {
 	logger           *slog.Logger
 	stateMu          sync.RWMutex
 	updateMu         sync.Mutex
+	buildErrMu       sync.Mutex
 	graph            *Graph
 	availableTables  map[string]bool // populated tables, skips queries for missing ones
-	lastBuildTime    time.Time       // event_time watermark for the last successful build (or build completion when CDC watermark is unavailable)
+	buildErr         error
+	buildCancel      context.CancelCauseFunc
+	lastBuildTime    time.Time // event_time watermark for the last successful build (or build completion when CDC watermark is unavailable)
 	lastCDCWatermark cdcWatermark
 	lastMutation     GraphMutationSummary
 }
@@ -93,7 +96,72 @@ func (b *Builder) queryIfExists(ctx context.Context, table, query string) (*Data
 	if !b.hasTable(table) {
 		return &DataQueryResult{}, nil
 	}
-	return b.source.Query(ctx, query)
+	result, err := b.source.Query(ctx, query)
+	if err != nil {
+		b.recordBuildError(fmt.Errorf("query %s: %w", table, err))
+		return nil, err
+	}
+	return result, nil
+}
+
+func (b *Builder) recordBuildError(err error) {
+	if err == nil || b.shouldIgnoreBuildError(err) {
+		return
+	}
+
+	b.buildErrMu.Lock()
+	if b.buildErr != nil {
+		b.buildErrMu.Unlock()
+		return
+	}
+	b.buildErr = err
+	cancel := b.buildCancel
+	b.buildErrMu.Unlock()
+
+	if cancel != nil {
+		cancel(err)
+	}
+}
+
+func (b *Builder) shouldIgnoreBuildError(err error) bool {
+	return b.availableTables == nil && isMissingTableQueryError(err)
+}
+
+func (b *Builder) buildPhaseError(ctx context.Context) error {
+	b.buildErrMu.Lock()
+	defer b.buildErrMu.Unlock()
+	if b.buildErr != nil {
+		return b.buildErr
+	}
+	if ctx == nil || ctx.Err() == nil {
+		return nil
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	return ctx.Err()
+}
+
+func isMissingTableQueryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "not authorized") || strings.Contains(msg, "permission denied") {
+		return false
+	}
+	switch {
+	case strings.Contains(msg, "no such table"),
+		strings.Contains(msg, "unknown table"),
+		strings.Contains(msg, "undefined table"),
+		strings.Contains(msg, "sqlstate 42p01"),
+		strings.Contains(msg, "object ") && strings.Contains(msg, " does not exist"),
+		strings.Contains(msg, "relation ") && strings.Contains(msg, " does not exist"),
+		strings.Contains(msg, "table ") && strings.Contains(msg, " does not exist"):
+		return true
+	default:
+		return false
+	}
 }
 
 // BuildCandidate constructs a fresh graph instance from the data source without
@@ -105,6 +173,8 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 	if err := ctx.Err(); err != nil {
 		return nil, GraphMutationSummary{}, err
 	}
+	buildCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
 
 	validationMode := SchemaValidationWarn
 	b.stateMu.RLock()
@@ -114,9 +184,10 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 	b.stateMu.RUnlock()
 
 	working := &Builder{
-		source: b.source,
-		graph:  New(),
-		logger: b.logger,
+		source:      b.source,
+		graph:       New(),
+		logger:      b.logger,
+		buildCancel: cancel,
 	}
 	working.graph.SetSchemaValidationMode(validationMode)
 	start := time.Now()
@@ -124,13 +195,13 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 	working.logger.Info("building graph platform")
 
 	// Phase 1: discover which tables have data (1 round-trip)
-	working.discoverTables(ctx)
-	if err := ctx.Err(); err != nil {
+	working.discoverTables(buildCtx)
+	if err := working.buildPhaseError(buildCtx); err != nil {
 		return nil, GraphMutationSummary{}, err
 	}
 
 	// Phase 2: load all nodes in parallel
-	g, gctx := errgroup.WithContext(ctx)
+	g, gctx := errgroup.WithContext(buildCtx)
 	g.Go(func() error { working.buildAWSNodes(gctx); return nil })
 	g.Go(func() error { working.buildGCPNodes(gctx); return nil })
 	g.Go(func() error { working.buildAzureNodes(gctx); return nil })
@@ -138,7 +209,7 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 	g.Go(func() error { working.buildGoogleWorkspaceNodes(gctx); return nil })
 	g.Go(func() error { working.buildK8sNodes(gctx); return nil })
 	_ = g.Wait()
-	if err := ctx.Err(); err != nil {
+	if err := working.buildPhaseError(buildCtx); err != nil {
 		return nil, GraphMutationSummary{}, err
 	}
 
@@ -154,14 +225,14 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 
 	// Phase 4: build provider edges in parallel
 	edgeStart := time.Now()
-	eg, ectx := errgroup.WithContext(ctx)
+	eg, ectx := errgroup.WithContext(buildCtx)
 	eg.Go(func() error { working.buildAWSEdges(ectx); return nil })
 	eg.Go(func() error { working.buildGCPEdges(ectx); return nil })
 	eg.Go(func() error { working.buildAzureEdges(ectx); return nil })
 	eg.Go(func() error { working.buildKubernetesEdges(ectx); return nil })
 	eg.Go(func() error { working.buildRelationshipEdges(ectx); return nil })
 	_ = eg.Wait()
-	if err := ctx.Err(); err != nil {
+	if err := working.buildPhaseError(buildCtx); err != nil {
 		return nil, GraphMutationSummary{}, err
 	}
 
@@ -169,31 +240,40 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 		"edges", working.graph.EdgeCount(),
 		"duration", time.Since(edgeStart))
 
-	working.buildIAMPermissionUsageKnowledge(ctx)
+	working.buildIAMPermissionUsageKnowledge(buildCtx)
+	if err := working.buildPhaseError(buildCtx); err != nil {
+		return nil, GraphMutationSummary{}, err
+	}
 
 	working.buildVendorNodes()
 
 	// Build unified person graph overlay (person nodes + projected edges).
-	if err := ctx.Err(); err != nil {
+	if err := working.buildPhaseError(buildCtx); err != nil {
 		return nil, GraphMutationSummary{}, err
 	}
-	working.buildUnifiedPersonGraph(ctx)
-	working.buildPersonInteractionEdges(ctx)
+	working.buildUnifiedPersonGraph(buildCtx)
+	working.buildPersonInteractionEdges(buildCtx)
+	if err := working.buildPhaseError(buildCtx); err != nil {
+		return nil, GraphMutationSummary{}, err
+	}
 
 	// Phase 5: inferred edges (these iterate nodes, run sequentially)
 	inferStart := time.Now()
-	if err := ctx.Err(); err != nil {
+	if err := working.buildPhaseError(buildCtx); err != nil {
 		return nil, GraphMutationSummary{}, err
 	}
-	working.buildAPIEndpointNodes(ctx)
-	if err := ctx.Err(); err != nil {
+	working.buildAPIEndpointNodes(buildCtx)
+	if err := working.buildPhaseError(buildCtx); err != nil {
 		return nil, GraphMutationSummary{}, err
 	}
-	working.buildExposureEdges(ctx)
-	if err := ctx.Err(); err != nil {
+	working.buildExposureEdges(buildCtx)
+	if err := working.buildPhaseError(buildCtx); err != nil {
 		return nil, GraphMutationSummary{}, err
 	}
 	working.buildSCMInference()
+	if err := working.buildPhaseError(buildCtx); err != nil {
+		return nil, GraphMutationSummary{}, err
+	}
 	normalization := NormalizeEntityAssetSupport(working.graph, temporalNowUTC())
 
 	working.logger.Info("graph inferred edges built",

--- a/internal/graph/builders/builder_test.go
+++ b/internal/graph/builders/builder_test.go
@@ -55,6 +55,81 @@ func (s *blockingBuildSource) Query(ctx context.Context, query string, args ...a
 	return &DataQueryResult{Rows: []map[string]any{}}, nil
 }
 
+type nodeFailureBuildSource struct {
+	siblingCanceled     chan struct{}
+	siblingCanceledOnce sync.Once
+}
+
+func (s *nodeFailureBuildSource) Query(ctx context.Context, query string, args ...any) (*DataQueryResult, error) {
+	_ = args
+	lower := strings.ToLower(query)
+	switch {
+	case strings.Contains(lower, "information_schema.tables"):
+		return &DataQueryResult{Rows: []map[string]any{
+			{"table_name": "AWS_IAM_USERS"},
+			{"table_name": "AWS_IAM_ROLES"},
+		}}, nil
+	case strings.Contains(lower, "from aws_iam_users"):
+		return nil, errors.New("aws users query failed")
+	case strings.Contains(lower, "from aws_iam_roles"):
+		<-ctx.Done()
+		s.siblingCanceledOnce.Do(func() { close(s.siblingCanceled) })
+		return nil, ctx.Err()
+	default:
+		return &DataQueryResult{Rows: []map[string]any{}}, nil
+	}
+}
+
+type edgeFailureBuildSource struct {
+	siblingCanceled     chan struct{}
+	siblingCanceledOnce sync.Once
+}
+
+func (s *edgeFailureBuildSource) Query(ctx context.Context, query string, args ...any) (*DataQueryResult, error) {
+	_ = args
+	lower := strings.ToLower(query)
+	switch {
+	case strings.Contains(lower, "information_schema.tables"):
+		return &DataQueryResult{Rows: []map[string]any{
+			{"table_name": "AWS_IAM_POLICY_VERSIONS"},
+			{"table_name": "AWS_IAM_USER_ATTACHED_POLICIES"},
+			{"table_name": "AWS_IAM_ROLE_ATTACHED_POLICIES"},
+		}}, nil
+	case strings.Contains(lower, "from aws_iam_policy_versions"):
+		return &DataQueryResult{Rows: []map[string]any{}}, nil
+	case strings.Contains(lower, "from aws_iam_user_attached_policies"):
+		return nil, errors.New("aws user attached policies query failed")
+	case strings.Contains(lower, "from aws_iam_role_attached_policies"):
+		<-ctx.Done()
+		s.siblingCanceledOnce.Do(func() { close(s.siblingCanceled) })
+		return nil, ctx.Err()
+	default:
+		return &DataQueryResult{Rows: []map[string]any{}}, nil
+	}
+}
+
+type missingTableBuildSource struct{}
+
+func (s *missingTableBuildSource) Query(ctx context.Context, query string, args ...any) (*DataQueryResult, error) {
+	_ = ctx
+	_ = args
+	if strings.Contains(strings.ToLower(query), "information_schema.tables") {
+		return nil, errors.New("information schema unavailable")
+	}
+	return nil, errors.New(`Object 'RAW.OPTIONAL_TABLE' does not exist`)
+}
+
+type unauthorizedBuildSource struct{}
+
+func (s *unauthorizedBuildSource) Query(ctx context.Context, query string, args ...any) (*DataQueryResult, error) {
+	_ = ctx
+	_ = args
+	if strings.Contains(strings.ToLower(query), "information_schema.tables") {
+		return nil, errors.New("information schema unavailable")
+	}
+	return nil, errors.New(`Object 'RAW.AWS_IAM_USERS' does not exist or not authorized`)
+}
+
 func TestBuilder_BuildWithMockData(t *testing.T) {
 	ctx := context.Background()
 	source := newMockDataSource()
@@ -268,6 +343,83 @@ func TestBuilder_BuildReturnsContextErrorWhenCanceled(t *testing.T) {
 	err := builder.Build(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestBuilder_BuildReturnsNodeQueryFailureAndCancelsSiblingQueries(t *testing.T) {
+	source := &nodeFailureBuildSource{siblingCanceled: make(chan struct{})}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	builder := NewBuilder(source, logger)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- builder.Build(context.Background())
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "query aws_iam_users: aws users query failed") {
+			t.Fatalf("expected aws_iam_users query failure, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for build to fail on node query error")
+	}
+
+	select {
+	case <-source.siblingCanceled:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected sibling node query to be canceled")
+	}
+}
+
+func TestBuilder_BuildReturnsEdgeQueryFailureAndCancelsSiblingQueries(t *testing.T) {
+	source := &edgeFailureBuildSource{siblingCanceled: make(chan struct{})}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	builder := NewBuilder(source, logger)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- builder.Build(context.Background())
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "query aws_iam_user_attached_policies: aws user attached policies query failed") {
+			t.Fatalf("expected aws_iam_user_attached_policies query failure, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for build to fail on edge query error")
+	}
+
+	select {
+	case <-source.siblingCanceled:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected sibling edge query to be canceled")
+	}
+}
+
+func TestBuilder_BuildIgnoresMissingTableErrorsWhenDiscoveryUnavailable(t *testing.T) {
+	source := &missingTableBuildSource{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	builder := NewBuilder(source, logger)
+
+	if err := builder.Build(context.Background()); err != nil {
+		t.Fatalf("expected missing-table errors to be ignored when discovery is unavailable, got %v", err)
+	}
+
+	if got := builder.Graph().NodeCount(); got != 1 {
+		t.Fatalf("expected only internet node after ignored missing-table errors, got %d nodes", got)
+	}
+}
+
+func TestBuilder_BuildDoesNotIgnoreAuthorizationErrorsWhenDiscoveryUnavailable(t *testing.T) {
+	source := &unauthorizedBuildSource{}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	builder := NewBuilder(source, logger)
+
+	err := builder.Build(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "not authorized") {
+		t.Fatalf("expected authorization error to fail the build, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- record the first graph-build query failure, cancel the in-flight build context, and return that error instead of silently succeeding with partial data
- keep missing-table misses non-fatal when table discovery is unavailable, while still failing authorization and other real query errors
- add regressions covering node-phase cancellation, edge-phase cancellation, and the discovery-unavailable fallback behavior

## Testing
- go test ./internal/graph/builders
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #306