### PR TITLE
fix(providers): guard pagination loops

### DIFF
--- a/internal/providers/entra_id.go
+++ b/internal/providers/entra_id.go
@@ -648,8 +648,16 @@ func (e *EntraIDProvider) syncSignInLogs(ctx context.Context) (*TableResult, err
 func (e *EntraIDProvider) listAll(ctx context.Context, path string) ([]map[string]interface{}, error) {
 	var allItems []map[string]interface{}
 	nextLink := path
+	guard := newPaginationGuard("entra_id", path)
 
 	for nextLink != "" {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		body, err := e.request(ctx, nextLink)
 		if err != nil {
 			return nil, err
@@ -668,6 +676,9 @@ func (e *EntraIDProvider) listAll(ctx context.Context, path string) ([]map[strin
 		// Handle pagination
 		if resp.NextLink != "" {
 			nextLink = strings.TrimPrefix(resp.NextLink, "https://graph.microsoft.com")
+			if err := guard.nextToken(nextLink); err != nil {
+				return nil, err
+			}
 		} else {
 			nextLink = ""
 		}

--- a/internal/providers/google_workspace.go
+++ b/internal/providers/google_workspace.go
@@ -624,8 +624,16 @@ func (g *GoogleWorkspaceProvider) listTokenActivities(ctx context.Context, since
 	baseURL := "https://admin.googleapis.com/admin/reports/v1/activity/users/all/applications/token"
 	pageToken := ""
 	rows := make([]map[string]interface{}, 0)
+	guard := newPaginationGuard("google_workspace", baseURL)
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		parsed, err := url.Parse(baseURL)
 		if err != nil {
 			return nil, err
@@ -662,6 +670,9 @@ func (g *GoogleWorkspaceProvider) listTokenActivities(ctx context.Context, since
 
 		if strings.TrimSpace(resp.NextPageToken) == "" {
 			break
+		}
+		if err := guard.nextToken(resp.NextPageToken); err != nil {
+			return nil, err
 		}
 		pageToken = resp.NextPageToken
 	}
@@ -874,8 +885,16 @@ func (g *GoogleWorkspaceProvider) listCalendarEvents(ctx context.Context, calend
 	baseURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events", url.PathEscape(calendarID))
 	pageToken := ""
 	events := make([]map[string]interface{}, 0)
+	guard := newPaginationGuard("google_workspace", baseURL)
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		parsed, err := url.Parse(baseURL)
 		if err != nil {
 			return nil, err
@@ -909,6 +928,9 @@ func (g *GoogleWorkspaceProvider) listCalendarEvents(ctx context.Context, calend
 		if resp.NextPageToken == "" {
 			break
 		}
+		if err := guard.nextToken(resp.NextPageToken); err != nil {
+			return nil, err
+		}
 		pageToken = resp.NextPageToken
 	}
 
@@ -918,8 +940,16 @@ func (g *GoogleWorkspaceProvider) listCalendarEvents(ctx context.Context, calend
 func (g *GoogleWorkspaceProvider) listAll(ctx context.Context, baseURL string, params map[string]string, itemsKey string) ([]map[string]interface{}, error) {
 	var allItems []map[string]interface{}
 	pageToken := ""
+	guard := newPaginationGuard("google_workspace", baseURL)
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		parsed, err := url.Parse(baseURL)
 		if err != nil {
 			return nil, err
@@ -952,6 +982,9 @@ func (g *GoogleWorkspaceProvider) listAll(ctx context.Context, baseURL string, p
 		}
 
 		if nextToken, ok := resp["nextPageToken"].(string); ok && nextToken != "" {
+			if err := guard.nextToken(nextToken); err != nil {
+				return nil, err
+			}
 			pageToken = nextToken
 		} else {
 			break

--- a/internal/providers/intune.go
+++ b/internal/providers/intune.go
@@ -315,8 +315,16 @@ func (i *IntuneProvider) syncDetectedApps(ctx context.Context) (*TableResult, er
 func (i *IntuneProvider) listAll(ctx context.Context, path string) ([]map[string]interface{}, error) {
 	var allItems []map[string]interface{}
 	nextLink := path
+	guard := newPaginationGuard("intune", path)
 
 	for nextLink != "" {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		body, err := i.request(ctx, nextLink)
 		if err != nil {
 			return nil, err
@@ -334,6 +342,9 @@ func (i *IntuneProvider) listAll(ctx context.Context, path string) ([]map[string
 
 		if resp.NextLink != "" {
 			nextLink = strings.TrimPrefix(resp.NextLink, "https://graph.microsoft.com")
+			if err := guard.nextToken(nextLink); err != nil {
+				return nil, err
+			}
 		} else {
 			nextLink = ""
 		}

--- a/internal/providers/kandji.go
+++ b/internal/providers/kandji.go
@@ -460,8 +460,16 @@ func (k *KandjiProvider) listAllDevices(ctx context.Context) ([]map[string]inter
 	var allDevices []map[string]interface{}
 	offset := 0
 	limit := 300
+	guard := newPaginationGuard("kandji", "/devices")
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		body, err := k.request(ctx, fmt.Sprintf("/devices?limit=%d&offset=%d", limit, offset))
 		if err != nil {
 			return nil, err
@@ -478,6 +486,9 @@ func (k *KandjiProvider) listAllDevices(ctx context.Context) ([]map[string]inter
 			break
 		}
 		offset += limit
+		if err := guard.nextOffset(offset); err != nil {
+			return nil, err
+		}
 	}
 
 	return allDevices, nil
@@ -485,10 +496,17 @@ func (k *KandjiProvider) listAllDevices(ctx context.Context) ([]map[string]inter
 
 func (k *KandjiProvider) listAllResults(ctx context.Context, path string) ([]map[string]interface{}, error) {
 	currentPath := path
-	seen := make(map[string]struct{})
+	guard := newPaginationGuard("kandji", path)
 	allItems := make([]map[string]interface{}, 0)
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		body, err := k.request(ctx, currentPath)
 		if err != nil {
 			return nil, err
@@ -508,10 +526,9 @@ func (k *KandjiProvider) listAllResults(ctx context.Context, path string) ([]map
 		if err != nil {
 			return nil, err
 		}
-		if _, ok := seen[nextPath]; ok {
-			break
+		if err := guard.nextToken(nextPath); err != nil {
+			return nil, err
 		}
-		seen[nextPath] = struct{}{}
 		currentPath = nextPath
 	}
 

--- a/internal/providers/okta.go
+++ b/internal/providers/okta.go
@@ -1150,8 +1150,16 @@ func (o *OktaProvider) request(ctx context.Context, path string) ([]byte, error)
 func (o *OktaProvider) requestAll(ctx context.Context, path string) ([]map[string]interface{}, error) {
 	nextURL := fmt.Sprintf("https://%s%s", o.domain, path)
 	items := make([]map[string]interface{}, 0)
+	guard := newPaginationGuard("okta", path)
 
 	for nextURL != "" {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		body, headers, err := o.requestWithResponse(ctx, nextURL)
 		if err != nil {
 			return nil, err
@@ -1164,6 +1172,9 @@ func (o *OktaProvider) requestAll(ctx context.Context, path string) ([]map[strin
 
 		items = append(items, page...)
 		nextURL = parseNextLink(headers.Get("Link"))
+		if err := guard.nextToken(nextURL); err != nil {
+			return nil, err
+		}
 	}
 
 	return items, nil

--- a/internal/providers/pagination_guard.go
+++ b/internal/providers/pagination_guard.go
@@ -1,0 +1,54 @@
+package providers
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var providerPaginationMaxPages = 1000
+
+type paginationGuard struct {
+	provider string
+	resource string
+	maxPages int
+	pages    int
+	seen     map[string]struct{}
+}
+
+func newPaginationGuard(provider, resource string) *paginationGuard {
+	maxPages := providerPaginationMaxPages
+	if maxPages <= 0 {
+		maxPages = 1000
+	}
+	return &paginationGuard{
+		provider: provider,
+		resource: resource,
+		maxPages: maxPages,
+		seen:     make(map[string]struct{}),
+	}
+}
+
+func (g *paginationGuard) nextPage() error {
+	if g.pages >= g.maxPages {
+		return fmt.Errorf("%s pagination exceeded %d pages for %s", g.provider, g.maxPages, g.resource)
+	}
+	g.pages++
+	return nil
+}
+
+func (g *paginationGuard) nextToken(token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	if _, exists := g.seen[token]; exists {
+		return fmt.Errorf("%s pagination loop detected for %s", g.provider, g.resource)
+	}
+	g.seen[token] = struct{}{}
+	return nil
+}
+
+func (g *paginationGuard) nextOffset(offset int) error {
+	return g.nextToken(strconv.Itoa(offset))
+}

--- a/internal/providers/pagination_guard_test.go
+++ b/internal/providers/pagination_guard_test.go
@@ -1,0 +1,151 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSlackListAllUsersRejectsPaginationLoop(t *testing.T) {
+	provider := NewSlackProvider()
+	provider.token = "token"
+	provider.apiURL = "https://slack.example.com"
+	provider.client = &http.Client{Transport: providerRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/users.list" {
+			t.Fatalf("unexpected path %q", req.URL.Path)
+		}
+		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{
+			"ok":      true,
+			"members": []map[string]interface{}{{"id": "user-1"}},
+			"response_metadata": map[string]interface{}{
+				"next_cursor": "repeat-token",
+			},
+		})
+	})}
+
+	_, err := provider.listAllUsers(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "pagination loop") {
+		t.Fatalf("expected pagination loop error, got %v", err)
+	}
+}
+
+func TestRipplingListAllRejectsPaginationLoop(t *testing.T) {
+	provider := NewRipplingProvider()
+	provider.apiToken = "token"
+	provider.apiURL = "https://api.rippling.example.com"
+	provider.client = &http.Client{Transport: providerRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/platform/api/employees" {
+			t.Fatalf("unexpected path %q", req.URL.Path)
+		}
+		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{
+			"data":        []map[string]interface{}{{"id": "emp-1"}},
+			"next_cursor": "repeat-token",
+		})
+	})}
+
+	_, err := provider.listAll(context.Background(), "/platform/api/employees?employment_status=ACTIVE")
+	if err == nil || !strings.Contains(err.Error(), "pagination loop") {
+		t.Fatalf("expected pagination loop error, got %v", err)
+	}
+}
+
+func TestGoogleWorkspaceListAllRejectsPaginationLoop(t *testing.T) {
+	provider := NewGoogleWorkspaceProvider()
+	provider.client = &http.Client{Transport: providerRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/admin/directory/v1/users" {
+			t.Fatalf("unexpected path %q", req.URL.Path)
+		}
+		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{
+			"users": []map[string]interface{}{
+				{"id": "user-1", "primaryEmail": "user-1@example.com"},
+			},
+			"nextPageToken": "repeat-token",
+		})
+	})}
+
+	_, err := provider.listAll(context.Background(), "https://admin.googleapis.com/admin/directory/v1/users", map[string]string{
+		"domain": "example.com",
+	}, "users")
+	if err == nil || !strings.Contains(err.Error(), "pagination loop") {
+		t.Fatalf("expected pagination loop error, got %v", err)
+	}
+}
+
+func TestIntuneListAllRejectsPaginationLoop(t *testing.T) {
+	provider := NewIntuneProvider()
+	provider.accessToken = "token"
+	provider.tokenExpiry = time.Now().Add(time.Hour)
+	provider.client = &http.Client{Transport: providerRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1.0/devices" {
+			t.Fatalf("unexpected path %q", req.URL.Path)
+		}
+		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{
+			"value":           []map[string]interface{}{{"id": "device-1"}},
+			"@odata.nextLink": "https://graph.microsoft.com/v1.0/devices?$skiptoken=repeat",
+		})
+	})}
+
+	_, err := provider.listAll(context.Background(), "/v1.0/devices")
+	if err == nil || !strings.Contains(err.Error(), "pagination loop") {
+		t.Fatalf("expected pagination loop error, got %v", err)
+	}
+}
+
+func TestEntraListAllRejectsPaginationLoop(t *testing.T) {
+	provider := NewEntraIDProvider()
+	provider.accessToken = "token"
+	provider.tokenExpiry = time.Now().Add(time.Hour)
+	provider.client = &http.Client{Transport: providerRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/v1.0/users" {
+			t.Fatalf("unexpected path %q", req.URL.Path)
+		}
+		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{
+			"value":           []map[string]interface{}{{"id": "user-1"}},
+			"@odata.nextLink": "https://graph.microsoft.com/v1.0/users?$skiptoken=repeat",
+		})
+	})}
+
+	_, err := provider.listAll(context.Background(), "/v1.0/users")
+	if err == nil || !strings.Contains(err.Error(), "pagination loop") {
+		t.Fatalf("expected pagination loop error, got %v", err)
+	}
+}
+
+func TestKandjiListAllResultsRejectsPaginationLoop(t *testing.T) {
+	provider := NewKandjiProvider()
+	provider.apiToken = "token"
+	provider.apiURL = "https://tenant.kandji.example.com"
+	provider.client = &http.Client{Transport: providerRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/audit/events" {
+			t.Fatalf("unexpected path %q", req.URL.Path)
+		}
+		return jsonHTTPResponse(http.StatusOK, map[string]interface{}{
+			"results": []map[string]interface{}{{"id": "evt-1"}},
+			"next":    "?cursor=repeat-token",
+		})
+	})}
+
+	_, err := provider.listAllResults(context.Background(), "/audit/events?limit=500")
+	if err == nil || !strings.Contains(err.Error(), "pagination loop") {
+		t.Fatalf("expected pagination loop error, got %v", err)
+	}
+}
+
+func TestOktaRequestAllRejectsPaginationLoop(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", "<"+server.URL+"/api/v1/users>; rel=\"next\"")
+		_, _ = w.Write([]byte(`[{"id":"user-1"}]`))
+	}))
+	defer server.Close()
+
+	provider := newTLSTestOktaProvider(t, server)
+	_, err := provider.requestAll(context.Background(), "/api/v1/users")
+	if err == nil || !strings.Contains(err.Error(), "pagination loop") {
+		t.Fatalf("expected pagination loop error, got %v", err)
+	}
+}

--- a/internal/providers/rippling.go
+++ b/internal/providers/rippling.go
@@ -209,8 +209,16 @@ func (r *RipplingProvider) syncTerminations(ctx context.Context, opts SyncOption
 func (r *RipplingProvider) listAll(ctx context.Context, path string) ([]map[string]interface{}, error) {
 	var allItems []map[string]interface{}
 	cursor := ""
+	guard := newPaginationGuard("rippling", path)
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		url := path
 		if cursor != "" {
 			url += "&cursor=" + cursor
@@ -243,6 +251,9 @@ func (r *RipplingProvider) listAll(ctx context.Context, path string) ([]map[stri
 
 		if resp.NextCursor == "" {
 			break
+		}
+		if err := guard.nextToken(resp.NextCursor); err != nil {
+			return nil, err
 		}
 		cursor = resp.NextCursor
 	}

--- a/internal/providers/slack.go
+++ b/internal/providers/slack.go
@@ -246,8 +246,16 @@ func (s *SlackProvider) syncTeam(ctx context.Context) (*TableResult, error) {
 func (s *SlackProvider) listAllUsers(ctx context.Context) ([]map[string]interface{}, error) {
 	var allUsers []map[string]interface{}
 	cursor := ""
+	guard := newPaginationGuard("slack", "/users.list")
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		params := url.Values{}
 		params.Set("limit", "200")
 		if cursor != "" {
@@ -280,6 +288,9 @@ func (s *SlackProvider) listAllUsers(ctx context.Context) ([]map[string]interfac
 		if resp.ResponseMetadata.NextCursor == "" {
 			break
 		}
+		if err := guard.nextToken(resp.ResponseMetadata.NextCursor); err != nil {
+			return nil, err
+		}
 		cursor = resp.ResponseMetadata.NextCursor
 	}
 
@@ -289,8 +300,16 @@ func (s *SlackProvider) listAllUsers(ctx context.Context) ([]map[string]interfac
 func (s *SlackProvider) listAllChannels(ctx context.Context) ([]map[string]interface{}, error) {
 	var allChannels []map[string]interface{}
 	cursor := ""
+	guard := newPaginationGuard("slack", "/conversations.list")
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := guard.nextPage(); err != nil {
+			return nil, err
+		}
+
 		params := url.Values{}
 		params.Set("limit", "200")
 		params.Set("types", "public_channel,private_channel")
@@ -323,6 +342,9 @@ func (s *SlackProvider) listAllChannels(ctx context.Context) ([]map[string]inter
 
 		if resp.ResponseMetadata.NextCursor == "" {
 			break
+		}
+		if err := guard.nextToken(resp.ResponseMetadata.NextCursor); err != nil {
+			return nil, err
 		}
 		cursor = resp.ResponseMetadata.NextCursor
 	}


### PR DESCRIPTION
## Summary
- add a shared pagination guard that enforces per-collection page limits, checks context cancellation between pages, and detects repeated cursors/links/offsets
- apply the guard to the remaining unprotected Entra ID, Google Workspace, Intune, Kandji, Okta, Rippling, and Slack pagination loops
- add regression tests covering repeated pagination tokens/links across the affected providers

## Testing
- go test ./internal/providers
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Fixes #308