### PR TITLE
refactor(api): inject SyncRunner into sync handlers

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -189,6 +189,9 @@ func NewServerWithDependencies(deps serverDependencies) *Server {
 	if threatRuntime == nil {
 		threatRuntime = newThreatRuntimeService(&deps)
 	}
+	if deps.syncRunner == nil {
+		deps.syncRunner = newSyncRunner(&deps)
+	}
 	syncHandlers := deps.syncHandlers
 	if syncHandlers == nil {
 		syncHandlers = newSyncHandlerService(&deps)

--- a/internal/api/server_dependencies.go
+++ b/internal/api/server_dependencies.go
@@ -148,6 +148,7 @@ type serverDependencies struct {
 	rbacAdmin             rbacAdminService
 	remediationOperations remediationOperationsService
 	schedulerOperations   schedulerOperationsService
+	syncRunner            syncRunner
 	syncHandlers          syncHandlerService
 	ticketingOps          ticketingService
 	threatRuntime         threatRuntimeService

--- a/internal/api/server_handlers_sync.go
+++ b/internal/api/server_handlers_sync.go
@@ -57,7 +57,8 @@ type azureSyncRequest struct {
 	Validate                bool     `json:"validate"`
 }
 
-var runAzureSyncWithOptions = func(ctx context.Context, store warehouse.SyncWarehouse, req azureSyncRequest) ([]nativesync.SyncResult, error) {
+func runAzureSyncWithOptions(ctx context.Context, store warehouse.SyncWarehouse, logger *slog.Logger, req azureSyncRequest) ([]nativesync.SyncResult, error) {
+	logger = syncRunnerLogger(logger)
 	opts := []nativesync.AzureEngineOption{}
 	switch len(req.Subscriptions) {
 	case 1:
@@ -80,7 +81,7 @@ var runAzureSyncWithOptions = func(ctx context.Context, store warehouse.SyncWare
 		opts = append(opts, nativesync.WithAzureTableFilter(req.Tables))
 	}
 
-	syncer, err := nativesync.NewAzureSyncEngine(store, slog.Default(), opts...)
+	syncer, err := nativesync.NewAzureSyncEngine(store, logger, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create azure sync engine: %w", err)
 	}
@@ -146,7 +147,8 @@ type k8sSyncRequest struct {
 	Validate    bool     `json:"validate"`
 }
 
-var runK8sSyncWithOptions = func(ctx context.Context, store warehouse.SyncWarehouse, req k8sSyncRequest) ([]nativesync.SyncResult, error) {
+func runK8sSyncWithOptions(ctx context.Context, store warehouse.SyncWarehouse, logger *slog.Logger, req k8sSyncRequest) ([]nativesync.SyncResult, error) {
+	logger = syncRunnerLogger(logger)
 	opts := []nativesync.K8sEngineOption{}
 	if req.Kubeconfig != "" {
 		opts = append(opts, nativesync.WithK8sKubeconfig(req.Kubeconfig))
@@ -164,7 +166,7 @@ var runK8sSyncWithOptions = func(ctx context.Context, store warehouse.SyncWareho
 		opts = append(opts, nativesync.WithK8sTableFilter(req.Tables))
 	}
 
-	syncer := nativesync.NewK8sSyncEngine(store, slog.Default(), opts...)
+	syncer := nativesync.NewK8sSyncEngine(store, logger, opts...)
 	if req.Validate {
 		results, err := syncer.ValidateTables(ctx)
 		if err != nil {
@@ -232,7 +234,8 @@ type awsSyncOutcome struct {
 	RelationshipsSkippedReason string
 }
 
-var runAWSSyncWithOptions = func(ctx context.Context, store warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+func runAWSSyncWithOptions(ctx context.Context, store warehouse.SyncWarehouse, logger *slog.Logger, req awsSyncRequest) (*awsSyncOutcome, error) {
+	logger = syncRunnerLogger(logger)
 	loadOptions := make([]func(*config.LoadOptions) error, 0, 2)
 	if req.Profile != "" {
 		loadOptions = append(loadOptions, config.WithSharedConfigProfile(req.Profile))
@@ -266,7 +269,7 @@ var runAWSSyncWithOptions = func(ctx context.Context, store warehouse.SyncWareho
 	}
 	opts = appendAWSPermissionUsageRequestOptions(opts, req.PermissionUsageLookbackDays, req.PermissionRemovalThresholdDays, req.AWSIdentityCenterPermissionSetsInclude, req.AWSIdentityCenterPermissionSetsExclude)
 
-	syncer := nativesync.NewSyncEngine(store, slog.Default(), opts...)
+	syncer := nativesync.NewSyncEngine(store, logger, opts...)
 	if req.Validate {
 		results, err := syncer.ValidateTablesWithConfig(ctx, awsCfg)
 		if err != nil {
@@ -292,7 +295,7 @@ var runAWSSyncWithOptions = func(ctx context.Context, store warehouse.SyncWareho
 		return outcome, nil
 	}
 
-	extractor := nativesync.NewRelationshipExtractor(store, slog.Default())
+	extractor := nativesync.NewRelationshipExtractor(store, logger)
 	relCount, err := extractor.ExtractAndPersist(ctx)
 	if err != nil {
 		outcome.RelationshipsSkippedReason = fmt.Sprintf("relationship extraction failed: %v", err)
@@ -364,7 +367,8 @@ type awsOrgSyncOutcome struct {
 	AccountErrors []string
 }
 
-var runAWSOrgSyncWithOptions = func(ctx context.Context, store warehouse.SyncWarehouse, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error) {
+func runAWSOrgSyncWithOptions(ctx context.Context, store warehouse.SyncWarehouse, logger *slog.Logger, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error) {
+	logger = syncRunnerLogger(logger)
 	loadOptions := make([]func(*config.LoadOptions) error, 0, 2)
 	if req.Profile != "" {
 		loadOptions = append(loadOptions, config.WithSharedConfigProfile(req.Profile))
@@ -401,7 +405,7 @@ var runAWSOrgSyncWithOptions = func(ctx context.Context, store warehouse.SyncWar
 
 	if req.Validate {
 		options := buildAWSEngineOptionsForRequest(region, req)
-		syncer := nativesync.NewSyncEngine(store, slog.Default(), options...)
+		syncer := nativesync.NewSyncEngine(store, logger, options...)
 		results, err := syncer.ValidateTablesWithConfig(ctx, awsCfg)
 		if err != nil {
 			return nil, fmt.Errorf("validation failed: %w", err)
@@ -449,7 +453,7 @@ var runAWSOrgSyncWithOptions = func(ctx context.Context, store warehouse.SyncWar
 				accountCfg = assumedCfg
 			}
 
-			syncer := nativesync.NewSyncEngine(store, slog.Default(), options...)
+			syncer := nativesync.NewSyncEngine(store, logger, options...)
 			accountResults, syncErr := syncer.SyncAllWithConfig(ctx, accountCfg)
 
 			mu.Lock()
@@ -660,7 +664,8 @@ type gcpSyncOutcome struct {
 	RelationshipsSkippedReason string
 }
 
-var runGCPSyncWithOptions = func(ctx context.Context, store warehouse.SyncWarehouse, req gcpSyncRequest) (*gcpSyncOutcome, error) {
+func runGCPSyncWithOptions(ctx context.Context, store warehouse.SyncWarehouse, logger *slog.Logger, req gcpSyncRequest) (*gcpSyncOutcome, error) {
+	logger = syncRunnerLogger(logger)
 	if req.Project == "" {
 		return nil, fmt.Errorf("project is required")
 	}
@@ -674,7 +679,7 @@ var runGCPSyncWithOptions = func(ctx context.Context, store warehouse.SyncWareho
 	}
 	opts = appendGCPPermissionUsageRequestOptions(opts, req.PermissionUsageLookbackDays, req.PermissionRemovalThresholdDays, req.GCPIAMTargetGroups)
 
-	syncer := nativesync.NewGCPSyncEngine(store, slog.Default(), opts...)
+	syncer := nativesync.NewGCPSyncEngine(store, logger, opts...)
 	if req.Validate {
 		results, err := syncer.ValidateTables(ctx)
 		if err != nil {
@@ -694,7 +699,7 @@ var runGCPSyncWithOptions = func(ctx context.Context, store warehouse.SyncWareho
 		return outcome, nil
 	}
 
-	extractor := nativesync.NewRelationshipExtractor(store, slog.Default())
+	extractor := nativesync.NewRelationshipExtractor(store, logger)
 	relCount, err := extractor.ExtractAndPersist(ctx)
 	if err != nil {
 		outcome.RelationshipsSkippedReason = fmt.Sprintf("relationship extraction failed: %v", err)
@@ -767,7 +772,8 @@ type gcpAssetSyncRequest struct {
 	Validate     bool     `json:"validate"`
 }
 
-var runGCPAssetSyncWithOptions = func(ctx context.Context, store warehouse.SyncWarehouse, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
+func runGCPAssetSyncWithOptions(ctx context.Context, store warehouse.SyncWarehouse, logger *slog.Logger, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
+	logger = syncRunnerLogger(logger)
 	organization := strings.TrimSpace(req.Organization)
 	if len(req.Projects) == 0 && organization == "" {
 		return nil, fmt.Errorf("projects or organization are required")
@@ -786,7 +792,7 @@ var runGCPAssetSyncWithOptions = func(ctx context.Context, store warehouse.SyncW
 		opts = append(opts, nativesync.WithAssetTypeFilter(req.Tables))
 	}
 
-	syncer := nativesync.NewGCPAssetInventoryEngine(store, slog.Default(), opts...)
+	syncer := nativesync.NewGCPAssetInventoryEngine(store, logger, opts...)
 	if req.Validate {
 		results, err := syncer.ValidateTables(ctx)
 		if err != nil {

--- a/internal/api/server_handlers_sync_test.go
+++ b/internal/api/server_handlers_sync_test.go
@@ -25,6 +25,117 @@ type syncGraphSource struct {
 	block  bool
 }
 
+type stubSyncRunner struct {
+	azureFunc    func(context.Context, azureSyncRequest) ([]nativesync.SyncResult, error)
+	k8sFunc      func(context.Context, k8sSyncRequest) ([]nativesync.SyncResult, error)
+	awsFunc      func(context.Context, awsSyncRequest) (*awsSyncOutcome, error)
+	awsOrgFunc   func(context.Context, awsOrgSyncRequest) (*awsOrgSyncOutcome, error)
+	gcpFunc      func(context.Context, gcpSyncRequest) (*gcpSyncOutcome, error)
+	gcpAssetFunc func(context.Context, gcpAssetSyncRequest) ([]nativesync.SyncResult, error)
+}
+
+func (s stubSyncRunner) RunAzure(ctx context.Context, req azureSyncRequest) ([]nativesync.SyncResult, error) {
+	if s.azureFunc != nil {
+		return s.azureFunc(ctx, req)
+	}
+	return nil, nil
+}
+
+func (s stubSyncRunner) RunK8s(ctx context.Context, req k8sSyncRequest) ([]nativesync.SyncResult, error) {
+	if s.k8sFunc != nil {
+		return s.k8sFunc(ctx, req)
+	}
+	return nil, nil
+}
+
+func (s stubSyncRunner) RunAWS(ctx context.Context, req awsSyncRequest) (*awsSyncOutcome, error) {
+	if s.awsFunc != nil {
+		return s.awsFunc(ctx, req)
+	}
+	return nil, nil
+}
+
+func (s stubSyncRunner) RunAWSOrg(ctx context.Context, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error) {
+	if s.awsOrgFunc != nil {
+		return s.awsOrgFunc(ctx, req)
+	}
+	return nil, nil
+}
+
+func (s stubSyncRunner) RunGCP(ctx context.Context, req gcpSyncRequest) (*gcpSyncOutcome, error) {
+	if s.gcpFunc != nil {
+		return s.gcpFunc(ctx, req)
+	}
+	return nil, nil
+}
+
+func (s stubSyncRunner) RunGCPAsset(ctx context.Context, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
+	if s.gcpAssetFunc != nil {
+		return s.gcpAssetFunc(ctx, req)
+	}
+	return nil, nil
+}
+
+func setSyncRunner(t *testing.T, s *Server, runner syncRunner) {
+	t.Helper()
+	s.app.syncRunner = runner
+	s.syncHandlers = newSyncHandlerService(s.app)
+}
+
+func stubAzureSyncRunner(t *testing.T, s *Server, fn func(context.Context, warehouse.SyncWarehouse, azureSyncRequest) ([]nativesync.SyncResult, error)) {
+	t.Helper()
+	setSyncRunner(t, s, stubSyncRunner{
+		azureFunc: func(ctx context.Context, req azureSyncRequest) ([]nativesync.SyncResult, error) {
+			return fn(ctx, s.app.Warehouse, req)
+		},
+	})
+}
+
+func stubK8sSyncRunner(t *testing.T, s *Server, fn func(context.Context, warehouse.SyncWarehouse, k8sSyncRequest) ([]nativesync.SyncResult, error)) {
+	t.Helper()
+	setSyncRunner(t, s, stubSyncRunner{
+		k8sFunc: func(ctx context.Context, req k8sSyncRequest) ([]nativesync.SyncResult, error) {
+			return fn(ctx, s.app.Warehouse, req)
+		},
+	})
+}
+
+func stubAWSSyncRunner(t *testing.T, s *Server, fn func(context.Context, warehouse.SyncWarehouse, awsSyncRequest) (*awsSyncOutcome, error)) {
+	t.Helper()
+	setSyncRunner(t, s, stubSyncRunner{
+		awsFunc: func(ctx context.Context, req awsSyncRequest) (*awsSyncOutcome, error) {
+			return fn(ctx, s.app.Warehouse, req)
+		},
+	})
+}
+
+func stubAWSOrgSyncRunner(t *testing.T, s *Server, fn func(context.Context, warehouse.SyncWarehouse, awsOrgSyncRequest) (*awsOrgSyncOutcome, error)) {
+	t.Helper()
+	setSyncRunner(t, s, stubSyncRunner{
+		awsOrgFunc: func(ctx context.Context, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error) {
+			return fn(ctx, s.app.Warehouse, req)
+		},
+	})
+}
+
+func stubGCPSyncRunner(t *testing.T, s *Server, fn func(context.Context, warehouse.SyncWarehouse, gcpSyncRequest) (*gcpSyncOutcome, error)) {
+	t.Helper()
+	setSyncRunner(t, s, stubSyncRunner{
+		gcpFunc: func(ctx context.Context, req gcpSyncRequest) (*gcpSyncOutcome, error) {
+			return fn(ctx, s.app.Warehouse, req)
+		},
+	})
+}
+
+func stubGCPAssetSyncRunner(t *testing.T, s *Server, fn func(context.Context, warehouse.SyncWarehouse, gcpAssetSyncRequest) ([]nativesync.SyncResult, error)) {
+	t.Helper()
+	setSyncRunner(t, s, stubSyncRunner{
+		gcpAssetFunc: func(ctx context.Context, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
+			return fn(ctx, s.app.Warehouse, req)
+		},
+	})
+}
+
 func setSnowflakeWarehouseDeps(deps *serverDependencies) *snowflake.Client {
 	client := &snowflake.Client{}
 	if deps != nil {
@@ -120,11 +231,8 @@ func TestSyncAzure_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
 	setSnowflakeWarehouseDeps(s.app)
 
-	originalRun := runAzureSyncWithOptions
-	t.Cleanup(func() { runAzureSyncWithOptions = originalRun })
-
 	called := false
-	runAzureSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req azureSyncRequest) ([]nativesync.SyncResult, error) {
+	stubAzureSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req azureSyncRequest) ([]nativesync.SyncResult, error) {
 		called = true
 		if client != s.app.Snowflake {
 			t.Fatalf("expected server snowflake client to be passed through")
@@ -145,7 +253,7 @@ func TestSyncAzure_UsesRequestOptions(t *testing.T) {
 			t.Fatal("expected validate=true")
 		}
 		return []nativesync.SyncResult{{Table: "azure_vm_instances", Synced: 3}}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/azure", map[string]interface{}{
 		"subscription":             "  sub-123  ",
@@ -183,10 +291,7 @@ func TestSyncAzure_NormalizesSubscriptionsCaseInsensitively(t *testing.T) {
 	s := newTestServer(t)
 	setSnowflakeWarehouseDeps(s.app)
 
-	originalRun := runAzureSyncWithOptions
-	t.Cleanup(func() { runAzureSyncWithOptions = originalRun })
-
-	runAzureSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req azureSyncRequest) ([]nativesync.SyncResult, error) {
+	stubAzureSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req azureSyncRequest) ([]nativesync.SyncResult, error) {
 		if client != s.app.Snowflake {
 			t.Fatalf("expected server snowflake client to be passed through")
 		}
@@ -200,7 +305,7 @@ func TestSyncAzure_NormalizesSubscriptionsCaseInsensitively(t *testing.T) {
 			}
 		}
 		return []nativesync.SyncResult{{Table: "azure_vm_instances", Synced: 1}}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/azure", map[string]interface{}{
 		"subscription":  " sub-b ",
@@ -237,11 +342,8 @@ func TestSyncK8s_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
 	setSnowflakeWarehouseDeps(s.app)
 
-	originalRun := runK8sSyncWithOptions
-	t.Cleanup(func() { runK8sSyncWithOptions = originalRun })
-
 	called := false
-	runK8sSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req k8sSyncRequest) ([]nativesync.SyncResult, error) {
+	stubK8sSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req k8sSyncRequest) ([]nativesync.SyncResult, error) {
 		called = true
 		if client != s.app.Snowflake {
 			t.Fatalf("expected server snowflake client to be passed through")
@@ -265,7 +367,7 @@ func TestSyncK8s_UsesRequestOptions(t *testing.T) {
 			t.Fatal("expected validate=true")
 		}
 		return []nativesync.SyncResult{{Table: "k8s_pods", Synced: 2}}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/k8s", map[string]interface{}{
 		"kubeconfig":  " /tmp/kubeconfig ",
@@ -312,11 +414,8 @@ func TestSyncAWS_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
 	setSnowflakeWarehouseDeps(s.app)
 
-	originalRun := runAWSSyncWithOptions
-	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
-
 	called := false
-	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+	stubAWSSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
 		called = true
 		if client != s.app.Snowflake {
 			t.Fatalf("expected server snowflake client to be passed through")
@@ -344,7 +443,7 @@ func TestSyncAWS_UsesRequestOptions(t *testing.T) {
 			RelationshipsExtracted:     11,
 			RelationshipsSkippedReason: "test reason",
 		}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
 		"profile":      " prod-profile ",
@@ -398,13 +497,11 @@ func TestSyncAWS_AppliesIncrementalGraphChangesAfterSync(t *testing.T) {
 		"event_time": base.Add(30 * time.Second),
 	}}
 
-	originalRun := runAWSSyncWithOptions
-	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
-	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+	stubAWSSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
 		return &awsSyncOutcome{
 			Results: []nativesync.SyncResult{{Table: "aws_s3_buckets", Synced: 1}},
 		}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
 		"region": "us-east-1",
@@ -435,13 +532,11 @@ func TestSyncAWS_GraphUpdateFailureIsSanitized(t *testing.T) {
 	s.app.SecurityGraphBuilder = builder
 	s.app.SecurityGraph = builder.Graph()
 
-	originalRun := runAWSSyncWithOptions
-	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
-	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+	stubAWSSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
 		return &awsSyncOutcome{
 			Results: []nativesync.SyncResult{{Table: "aws_s3_buckets", Synced: 1}},
 		}, nil
-	}
+	})
 
 	s.app.Config.GraphPostSyncUpdateTimeout = 5 * time.Millisecond
 
@@ -499,13 +594,11 @@ func TestSyncAWS_GraphUpdateBusyReturnsBusyStatus(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	originalRun := runAWSSyncWithOptions
-	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
-	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+	stubAWSSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
 		return &awsSyncOutcome{
 			Results: []nativesync.SyncResult{{Table: "aws_s3_buckets", Synced: 1}},
 		}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
 		"region": "us-east-1",
@@ -546,13 +639,11 @@ func TestSyncAWS_GraphUpdateNoopSummaryUsesEmptyTablesArray(t *testing.T) {
 	s.app.SecurityGraphBuilder = builder
 	s.app.SecurityGraph = builder.Graph()
 
-	originalRun := runAWSSyncWithOptions
-	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
-	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+	stubAWSSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
 		return &awsSyncOutcome{
 			Results: []nativesync.SyncResult{{Table: "aws_s3_buckets", Synced: 1}},
 		}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
 		"region": "us-east-1",
@@ -591,13 +682,11 @@ func TestSyncAWS_GraphUpdateFailureReportsFailedStatus(t *testing.T) {
 	s.app.SecurityGraphBuilder = builder
 	s.app.SecurityGraph = builder.Graph()
 
-	originalRun := runAWSSyncWithOptions
-	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
-	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+	stubAWSSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
 		return &awsSyncOutcome{
 			Results: []nativesync.SyncResult{{Table: "aws_s3_buckets", Synced: 1}},
 		}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
 		"region": "us-east-1",
@@ -649,13 +738,11 @@ func TestSyncAWS_AppliesGraphUpdateUsingRuntimeWithoutLocalBuilder(t *testing.T)
 	s := NewServerWithDependencies(deps)
 	t.Cleanup(func() { s.Close() })
 
-	originalRun := runAWSSyncWithOptions
-	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
-	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+	stubAWSSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
 		return &awsSyncOutcome{
 			Results: []nativesync.SyncResult{{Table: "aws_s3_buckets", Synced: 1}},
 		}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
 		"region": "us-east-1",
@@ -693,13 +780,11 @@ func TestSyncAWS_SkipsGraphUpdateWithoutRuntimeOrLocalBuilder(t *testing.T) {
 	s := NewServerWithDependencies(deps)
 	t.Cleanup(func() { s.Close() })
 
-	originalRun := runAWSSyncWithOptions
-	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
-	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+	stubAWSSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
 		return &awsSyncOutcome{
 			Results: []nativesync.SyncResult{{Table: "aws_s3_buckets", Synced: 1}},
 		}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
 		"region": "us-east-1",
@@ -727,13 +812,11 @@ func TestSyncAWS_SkipsGraphUpdateWhenRuntimeAdapterHasNoApplyCapability(t *testi
 	s := NewServerWithDependencies(deps)
 	t.Cleanup(func() { s.Close() })
 
-	originalRun := runAWSSyncWithOptions
-	t.Cleanup(func() { runAWSSyncWithOptions = originalRun })
-	runAWSSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
+	stubAWSSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req awsSyncRequest) (*awsSyncOutcome, error) {
 		return &awsSyncOutcome{
 			Results: []nativesync.SyncResult{{Table: "aws_s3_buckets", Synced: 1}},
 		}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws", map[string]interface{}{
 		"region": "us-east-1",
@@ -772,11 +855,8 @@ func TestSyncAWSOrg_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
 	setSnowflakeWarehouseDeps(s.app)
 
-	originalRun := runAWSOrgSyncWithOptions
-	t.Cleanup(func() { runAWSOrgSyncWithOptions = originalRun })
-
 	called := false
-	runAWSOrgSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error) {
+	stubAWSOrgSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error) {
 		called = true
 		if client != s.app.Snowflake {
 			t.Fatalf("expected server snowflake client to be passed through")
@@ -815,7 +895,7 @@ func TestSyncAWSOrg_UsesRequestOptions(t *testing.T) {
 			Results:       []nativesync.SyncResult{{Table: "aws_iam_users", Synced: 4}},
 			AccountErrors: []string{"account 999999999999: access denied"},
 		}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/aws-org", map[string]interface{}{
 		"profile":             " prod-profile ",
@@ -882,11 +962,8 @@ func TestSyncGCP_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
 	setSnowflakeWarehouseDeps(s.app)
 
-	originalRun := runGCPSyncWithOptions
-	t.Cleanup(func() { runGCPSyncWithOptions = originalRun })
-
 	called := false
-	runGCPSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req gcpSyncRequest) (*gcpSyncOutcome, error) {
+	stubGCPSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req gcpSyncRequest) (*gcpSyncOutcome, error) {
 		called = true
 		if client != s.app.Snowflake {
 			t.Fatalf("expected server snowflake client to be passed through")
@@ -908,7 +985,7 @@ func TestSyncGCP_UsesRequestOptions(t *testing.T) {
 			RelationshipsExtracted:     8,
 			RelationshipsSkippedReason: "test reason",
 		}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/gcp", map[string]interface{}{
 		"project":     "  proj-123  ",
@@ -982,11 +1059,8 @@ func TestSyncGCPAsset_UsesRequestOptions(t *testing.T) {
 	s := newTestServer(t)
 	setSnowflakeWarehouseDeps(s.app)
 
-	originalRun := runGCPAssetSyncWithOptions
-	t.Cleanup(func() { runGCPAssetSyncWithOptions = originalRun })
-
 	called := false
-	runGCPAssetSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
+	stubGCPAssetSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
 		called = true
 		if client != s.app.Snowflake {
 			t.Fatalf("expected server snowflake client to be passed through")
@@ -1004,7 +1078,7 @@ func TestSyncGCPAsset_UsesRequestOptions(t *testing.T) {
 			t.Fatal("expected validate=true")
 		}
 		return []nativesync.SyncResult{{Table: "gcp_compute_instances", Synced: 6}}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/gcp-asset", map[string]interface{}{
 		"projects":    []string{"  proj-123  ", "PROJ-123", "proj-456"},
@@ -1027,11 +1101,8 @@ func TestSyncGCPAsset_UsesOrganizationScope(t *testing.T) {
 	s := newTestServer(t)
 	setSnowflakeWarehouseDeps(s.app)
 
-	originalRun := runGCPAssetSyncWithOptions
-	t.Cleanup(func() { runGCPAssetSyncWithOptions = originalRun })
-
 	called := false
-	runGCPAssetSyncWithOptions = func(ctx context.Context, client warehouse.SyncWarehouse, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
+	stubGCPAssetSyncRunner(t, s, func(ctx context.Context, client warehouse.SyncWarehouse, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
 		called = true
 		if client != s.app.Snowflake {
 			t.Fatalf("expected server snowflake client to be passed through")
@@ -1043,7 +1114,7 @@ func TestSyncGCPAsset_UsesOrganizationScope(t *testing.T) {
 			t.Fatalf("did not expect explicit projects, got %#v", req.Projects)
 		}
 		return []nativesync.SyncResult{{Table: "gcp_compute_instances", Synced: 6}}, nil
-	}
+	})
 
 	w := do(t, s, http.MethodPost, "/api/v1/sync/gcp-asset", map[string]interface{}{
 		"organization": " 1234567890 ",

--- a/internal/api/server_services_sync.go
+++ b/internal/api/server_services_sync.go
@@ -15,6 +15,15 @@ import (
 
 var errSyncWarehouseUnavailable = errors.New("warehouse not configured")
 
+type syncRunner interface {
+	RunAzure(ctx context.Context, req azureSyncRequest) ([]nativesync.SyncResult, error)
+	RunK8s(ctx context.Context, req k8sSyncRequest) ([]nativesync.SyncResult, error)
+	RunAWS(ctx context.Context, req awsSyncRequest) (*awsSyncOutcome, error)
+	RunAWSOrg(ctx context.Context, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error)
+	RunGCP(ctx context.Context, req gcpSyncRequest) (*gcpSyncOutcome, error)
+	RunGCPAsset(ctx context.Context, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error)
+}
+
 type syncHandlerService interface {
 	BackfillRelationshipIDs(ctx context.Context, batchSize int) (syncBackfillResult, error)
 	SyncAzure(ctx context.Context, req azureSyncRequest) (syncRunResult, error)
@@ -58,11 +67,15 @@ type gcpSyncRunResult struct {
 }
 
 type serverSyncHandlerService struct {
-	deps *serverDependencies
+	deps   *serverDependencies
+	runner syncRunner
 }
 
 func newSyncHandlerService(deps *serverDependencies) syncHandlerService {
-	return serverSyncHandlerService{deps: deps}
+	return serverSyncHandlerService{
+		deps:   deps,
+		runner: newSyncRunner(deps),
+	}
 }
 
 func (s serverSyncHandlerService) BackfillRelationshipIDs(ctx context.Context, batchSize int) (syncBackfillResult, error) {
@@ -84,11 +97,10 @@ func (s serverSyncHandlerService) BackfillRelationshipIDs(ctx context.Context, b
 }
 
 func (s serverSyncHandlerService) SyncAzure(ctx context.Context, req azureSyncRequest) (syncRunResult, error) {
-	store, err := s.warehouse()
-	if err != nil {
-		return syncRunResult{}, err
+	if s.runner == nil {
+		return syncRunResult{}, errSyncWarehouseUnavailable
 	}
-	results, err := runAzureSyncWithOptions(ctx, store, req)
+	results, err := s.runner.RunAzure(ctx, req)
 	if err != nil {
 		return syncRunResult{}, err
 	}
@@ -99,11 +111,10 @@ func (s serverSyncHandlerService) SyncAzure(ctx context.Context, req azureSyncRe
 }
 
 func (s serverSyncHandlerService) SyncK8s(ctx context.Context, req k8sSyncRequest) (syncRunResult, error) {
-	store, err := s.warehouse()
-	if err != nil {
-		return syncRunResult{}, err
+	if s.runner == nil {
+		return syncRunResult{}, errSyncWarehouseUnavailable
 	}
-	results, err := runK8sSyncWithOptions(ctx, store, req)
+	results, err := s.runner.RunK8s(ctx, req)
 	if err != nil {
 		return syncRunResult{}, err
 	}
@@ -114,11 +125,10 @@ func (s serverSyncHandlerService) SyncK8s(ctx context.Context, req k8sSyncReques
 }
 
 func (s serverSyncHandlerService) SyncAWS(ctx context.Context, req awsSyncRequest) (awsSyncRunResult, error) {
-	store, err := s.warehouse()
-	if err != nil {
-		return awsSyncRunResult{}, err
+	if s.runner == nil {
+		return awsSyncRunResult{}, errSyncWarehouseUnavailable
 	}
-	outcome, err := runAWSSyncWithOptions(ctx, store, req)
+	outcome, err := s.runner.RunAWS(ctx, req)
 	if err != nil {
 		return awsSyncRunResult{}, err
 	}
@@ -134,11 +144,10 @@ func (s serverSyncHandlerService) SyncAWS(ctx context.Context, req awsSyncReques
 }
 
 func (s serverSyncHandlerService) SyncAWSOrg(ctx context.Context, req awsOrgSyncRequest) (awsOrgSyncRunResult, error) {
-	store, err := s.warehouse()
-	if err != nil {
-		return awsOrgSyncRunResult{}, err
+	if s.runner == nil {
+		return awsOrgSyncRunResult{}, errSyncWarehouseUnavailable
 	}
-	outcome, err := runAWSOrgSyncWithOptions(ctx, store, req)
+	outcome, err := s.runner.RunAWSOrg(ctx, req)
 	if err != nil {
 		return awsOrgSyncRunResult{}, err
 	}
@@ -153,11 +162,10 @@ func (s serverSyncHandlerService) SyncAWSOrg(ctx context.Context, req awsOrgSync
 }
 
 func (s serverSyncHandlerService) SyncGCP(ctx context.Context, req gcpSyncRequest) (gcpSyncRunResult, error) {
-	store, err := s.warehouse()
-	if err != nil {
-		return gcpSyncRunResult{}, err
+	if s.runner == nil {
+		return gcpSyncRunResult{}, errSyncWarehouseUnavailable
 	}
-	outcome, err := runGCPSyncWithOptions(ctx, store, req)
+	outcome, err := s.runner.RunGCP(ctx, req)
 	if err != nil {
 		return gcpSyncRunResult{}, err
 	}
@@ -173,11 +181,10 @@ func (s serverSyncHandlerService) SyncGCP(ctx context.Context, req gcpSyncReques
 }
 
 func (s serverSyncHandlerService) SyncGCPAsset(ctx context.Context, req gcpAssetSyncRequest) (syncRunResult, error) {
-	store, err := s.warehouse()
-	if err != nil {
-		return syncRunResult{}, err
+	if s.runner == nil {
+		return syncRunResult{}, errSyncWarehouseUnavailable
 	}
-	results, err := runGCPAssetSyncWithOptions(ctx, store, req)
+	results, err := s.runner.RunGCPAsset(ctx, req)
 	if err != nil {
 		return syncRunResult{}, err
 	}
@@ -245,4 +252,56 @@ func (s serverSyncHandlerService) graphPostSyncUpdateTimeout() time.Duration {
 		return s.deps.Config.GraphPostSyncUpdateTimeoutOrDefault()
 	}
 	return (*app.Config)(nil).GraphPostSyncUpdateTimeoutOrDefault()
+}
+
+type defaultSyncRunner struct {
+	warehouse warehouse.SyncWarehouse
+	logger    *slog.Logger
+}
+
+func newSyncRunner(deps *serverDependencies) syncRunner {
+	if deps == nil {
+		return nil
+	}
+	if deps.syncRunner != nil {
+		return deps.syncRunner
+	}
+	if deps.Warehouse == nil {
+		return nil
+	}
+	return defaultSyncRunner{
+		warehouse: deps.Warehouse,
+		logger:    deps.Logger,
+	}
+}
+
+func syncRunnerLogger(logger *slog.Logger) *slog.Logger {
+	if logger != nil {
+		return logger
+	}
+	return slog.Default()
+}
+
+func (r defaultSyncRunner) RunAzure(ctx context.Context, req azureSyncRequest) ([]nativesync.SyncResult, error) {
+	return runAzureSyncWithOptions(ctx, r.warehouse, r.logger, req)
+}
+
+func (r defaultSyncRunner) RunK8s(ctx context.Context, req k8sSyncRequest) ([]nativesync.SyncResult, error) {
+	return runK8sSyncWithOptions(ctx, r.warehouse, r.logger, req)
+}
+
+func (r defaultSyncRunner) RunAWS(ctx context.Context, req awsSyncRequest) (*awsSyncOutcome, error) {
+	return runAWSSyncWithOptions(ctx, r.warehouse, r.logger, req)
+}
+
+func (r defaultSyncRunner) RunAWSOrg(ctx context.Context, req awsOrgSyncRequest) (*awsOrgSyncOutcome, error) {
+	return runAWSOrgSyncWithOptions(ctx, r.warehouse, r.logger, req)
+}
+
+func (r defaultSyncRunner) RunGCP(ctx context.Context, req gcpSyncRequest) (*gcpSyncOutcome, error) {
+	return runGCPSyncWithOptions(ctx, r.warehouse, r.logger, req)
+}
+
+func (r defaultSyncRunner) RunGCPAsset(ctx context.Context, req gcpAssetSyncRequest) ([]nativesync.SyncResult, error) {
+	return runGCPAssetSyncWithOptions(ctx, r.warehouse, r.logger, req)
 }


### PR DESCRIPTION
## Summary
- replace package-var sync test hooks with an injected SyncRunner seam
- move sync handler tests over to per-provider runner stubs instead of mutating globals
- keep handler behavior and API contracts unchanged while validating the new seam

## Testing
- go test ./internal/api
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main

Closes #390