### PR TITLE
refactor(app): schedule init subsystems by dependency wave

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -276,10 +276,9 @@ func NewWithOptions(ctx context.Context, opts ...Option) (*App, error) {
 	}
 
 	if err := app.initialize(initCtx); err != nil {
-		if app.graphCancel != nil {
-			app.graphCancel()
+		if closeErr := app.Close(); closeErr != nil {
+			logger.Warn("application cleanup after failed initialization", "error", closeErr)
 		}
-		app.stopThreatIntelSync()
 		if errors.Is(err, context.DeadlineExceeded) || initCtx.Err() == context.DeadlineExceeded {
 			logger.Error("application initialization timed out", "timeout", cfg.InitTimeout, "error", err)
 		}

--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -74,42 +74,36 @@ func (a *App) initPhase2a(ctx context.Context) error {
 	if err := graphSubsystem.Init(ctx); err != nil {
 		return err
 	}
-
-	if err := runSubsystemInitConcurrently(ctx,
-		initOnlySubsystem("cache", func(context.Context) { a.initCache() }),
-		initOnlySubsystem("ticketing", func(taskCtx context.Context) { a.initTicketing(taskCtx) }),
-		initOnlySubsystem("identity", func(context.Context) { a.initIdentity() }),
-		initOnlySubsystem("attackpath", func(context.Context) { a.initAttackPath() }),
-		initOnlySubsystem("webhooks", func(context.Context) { a.initWebhooks() }),
-		initOnlySubsystem("notifications", func(context.Context) { a.initNotifications() }),
-		initOnlySubsystem("rbac", func(context.Context) { a.initRBAC() }),
-		initOnlySubsystem("compliance", func(context.Context) { a.initCompliance() }),
-		initOnlySubsystem("health", func(context.Context) { a.initHealth() }),
-		initOnlySubsystem("lineage", func(context.Context) { a.initLineage() }),
-		a.runtimeSubsystem(),
-		initOnlySubsystem("findings", func(context.Context) { a.initFindings() }),
-		initOnlySubsystem("providers", func(taskCtx context.Context) { a.initProviders(taskCtx) }),
-		initOnlySubsystem("scheduler", func(taskCtx context.Context) { a.initScheduler(taskCtx) }),
-		initOnlySubsystem("snowflake_findings", func(taskCtx context.Context) { a.initSnowflakeFindings(taskCtx) }),
-		initOnlySubsystem("scan_watermarks", func(taskCtx context.Context) { a.initScanWatermarks(taskCtx) }),
-		initOnlySubsystem("threatintel", func(context.Context) { a.initThreatIntel(ctx) }),
-		initOnlySubsystem("available_tables", func(taskCtx context.Context) { a.initAvailableTables(taskCtx) }),
-	); err != nil {
-		return fmt.Errorf("phase 2a init failed: %w", err)
-	}
 	if err := appState.Start(ctx); err != nil {
 		return err
+	}
+	if _, err := executeLifecycleStages(ctx, a.Logger, lifecycleStage{
+		phase:        "phase2a.init",
+		action:       lifecycleActionInit,
+		preSatisfied: []string{"appstate", "graph"},
+		subsystems:   a.phase2aInitSubsystems(),
+	}); err != nil {
+		return fmt.Errorf("phase 2a init failed: %w", err)
 	}
 	return nil
 }
 
 func (a *App) initPhase2b(ctx context.Context) error {
-	remediation := a.remediationSubsystem()
-	if err := runSubsystemInitConcurrently(ctx, remediation, a.agentsSubsystem()); err != nil {
-		return fmt.Errorf("phase 2b init failed: %w", err)
-	}
-	if err := runSubsystemStartSequentially(ctx, remediation, a.eventsSubsystem()); err != nil {
-		return fmt.Errorf("phase 2b start failed: %w", err)
+	if _, err := executeLifecycleStages(ctx, a.Logger,
+		lifecycleStage{
+			phase:        "phase2b.init",
+			action:       lifecycleActionInit,
+			preSatisfied: []string{"findings", "notifications", "runtime", "ticketing", "webhooks"},
+			subsystems:   a.phase2bInitSubsystems(),
+		},
+		lifecycleStage{
+			phase:        "phase2b.start",
+			action:       lifecycleActionStart,
+			preSatisfied: []string{"graph", "webhooks"},
+			subsystems:   a.phase2bStartSubsystems(),
+		},
+	); err != nil {
+		return fmt.Errorf("phase 2b lifecycle failed: %w", err)
 	}
 	return nil
 }
@@ -123,6 +117,49 @@ func (a *App) initPhase4(ctx context.Context) error {
 		return err
 	}
 	return a.validatePolicyCoverage(ctx)
+}
+
+func (a *App) phase2aInitSubsystems() []lifecycleSubsystem {
+	return []lifecycleSubsystem{
+		initOnlySubsystem("cache", func(context.Context) { a.initCache() }),
+		initOnlySubsystem("ticketing", func(taskCtx context.Context) { a.initTicketing(taskCtx) }),
+		initOnlySubsystem("identity", func(context.Context) { a.initIdentity() }),
+		initOnlySubsystem("attackpath", func(context.Context) { a.initAttackPath() }),
+		initOnlySubsystem("webhooks", func(context.Context) { a.initWebhooks() }),
+		initOnlySubsystem("notifications", func(context.Context) { a.initNotifications() }),
+		initOnlySubsystem("rbac", func(context.Context) { a.initRBAC() }),
+		initOnlySubsystem("compliance", func(context.Context) { a.initCompliance() }),
+		initOnlySubsystem("health", func(context.Context) { a.initHealth() }),
+		initOnlySubsystem("lineage", func(context.Context) { a.initLineage() }),
+		wrapInitSubsystem(a.runtimeSubsystem()),
+		initOnlySubsystem("findings", func(context.Context) { a.initFindings() }),
+		initOnlySubsystem("providers", func(taskCtx context.Context) { a.initProviders(taskCtx) }),
+		initOnlySubsystemWithDeps("snowflake_findings", []string{"findings"}, func(taskCtx context.Context) {
+			a.initSnowflakeFindings(taskCtx)
+		}),
+		initOnlySubsystem("scan_watermarks", func(taskCtx context.Context) { a.initScanWatermarks(taskCtx) }),
+		initOnlySubsystemWithDeps("threatintel", []string{"webhooks"}, func(taskCtx context.Context) {
+			a.initThreatIntel(taskCtx)
+		}),
+		initOnlySubsystem("available_tables", func(taskCtx context.Context) { a.initAvailableTables(taskCtx) }),
+		initOnlySubsystemWithDeps("scheduler", []string{"appstate", "available_tables", "findings", "health", "notifications", "scan_watermarks"}, func(taskCtx context.Context) {
+			a.initScheduler(taskCtx)
+		}),
+	}
+}
+
+func (a *App) phase2bInitSubsystems() []lifecycleSubsystem {
+	return []lifecycleSubsystem{
+		wrapInitSubsystem(a.remediationSubsystem(), "findings", "notifications", "runtime", "ticketing", "webhooks"),
+		wrapInitSubsystem(a.agentsSubsystem(), "remediation", "runtime"),
+	}
+}
+
+func (a *App) phase2bStartSubsystems() []lifecycleSubsystem {
+	return []lifecycleSubsystem{
+		wrapStartSubsystem(a.remediationSubsystem()),
+		wrapStartSubsystem(a.eventsSubsystem(), "remediation"),
+	}
 }
 
 func runInitTasksConcurrently(ctx context.Context, tasks []concurrentInitTask) error {

--- a/internal/app/app_init_phases.go
+++ b/internal/app/app_init_phases.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/sync/errgroup"
 )
 
 type concurrentInitTask struct {
@@ -63,62 +61,56 @@ func (a *App) initPhase1(ctx context.Context) error {
 }
 
 func (a *App) initPhase2a(ctx context.Context) error {
+	appState := a.appStateSubsystem()
+	graphSubsystem := a.graphSubsystem()
+
 	a.initExecutionStore()
-	a.initGraphPersistenceStore()
-	if err := runInitErrorStep("app_state_db", func() error { return a.initAppStateDB(ctx) }); err != nil {
+	if err := appState.Init(ctx); err != nil {
 		return err
 	}
 	if err := runInitErrorStep("legacy_snowflake", func() error { return a.initLegacySnowflake(ctx) }); err != nil {
 		a.Logger.Warn("legacy snowflake initialization failed", "error", err)
 	}
-	if err := runInitErrorStep("graph_store_backend", func() error { return a.initConfiguredSecurityGraphStore(ctx) }); err != nil {
-		return err
-	}
-	if err := runInitErrorStep("graph_writer_lease", func() error { return a.initGraphWriterLease(ctx) }); err != nil {
-		return err
-	}
-	if err := runInitErrorStep("entity_search_backend", func() error { return a.initEntitySearchBackend(ctx) }); err != nil {
+	if err := graphSubsystem.Init(ctx); err != nil {
 		return err
 	}
 
-	if err := runInitTasksConcurrently(ctx, []concurrentInitTask{
-		{name: "cache", run: func(context.Context) { a.initCache() }},
-		{name: "ticketing", run: func(taskCtx context.Context) { a.initTicketing(taskCtx) }},
-		{name: "identity", run: func(context.Context) { a.initIdentity() }},
-		{name: "attackpath", run: func(context.Context) { a.initAttackPath() }},
-		{name: "webhooks", run: func(context.Context) { a.initWebhooks() }},
-		{name: "notifications", run: func(context.Context) { a.initNotifications() }},
-		{name: "rbac", run: func(context.Context) { a.initRBAC() }},
-		{name: "compliance", run: func(context.Context) { a.initCompliance() }},
-		{name: "health", run: func(context.Context) { a.initHealth() }},
-		{name: "lineage", run: func(context.Context) { a.initLineage() }},
-		{name: "runtime", run: func(context.Context) { a.initRuntime() }},
-		{name: "findings", run: func(context.Context) { a.initFindings() }},
-		{name: "providers", run: func(taskCtx context.Context) { a.initProviders(taskCtx) }},
-		{name: "scheduler", run: func(taskCtx context.Context) { a.initScheduler(taskCtx) }},
-		{name: "repositories", run: func(context.Context) { a.initRepositories() }},
-		{name: "snowflake_findings", run: func(taskCtx context.Context) { a.initSnowflakeFindings(taskCtx) }},
-		{name: "scan_watermarks", run: func(taskCtx context.Context) { a.initScanWatermarks(taskCtx) }},
-		{name: "threatintel", run: func(context.Context) { a.initThreatIntel(ctx) }},
-		{name: "available_tables", run: func(taskCtx context.Context) { a.initAvailableTables(taskCtx) }},
-	}); err != nil {
+	if err := runSubsystemInitConcurrently(ctx,
+		initOnlySubsystem("cache", func(context.Context) { a.initCache() }),
+		initOnlySubsystem("ticketing", func(taskCtx context.Context) { a.initTicketing(taskCtx) }),
+		initOnlySubsystem("identity", func(context.Context) { a.initIdentity() }),
+		initOnlySubsystem("attackpath", func(context.Context) { a.initAttackPath() }),
+		initOnlySubsystem("webhooks", func(context.Context) { a.initWebhooks() }),
+		initOnlySubsystem("notifications", func(context.Context) { a.initNotifications() }),
+		initOnlySubsystem("rbac", func(context.Context) { a.initRBAC() }),
+		initOnlySubsystem("compliance", func(context.Context) { a.initCompliance() }),
+		initOnlySubsystem("health", func(context.Context) { a.initHealth() }),
+		initOnlySubsystem("lineage", func(context.Context) { a.initLineage() }),
+		a.runtimeSubsystem(),
+		initOnlySubsystem("findings", func(context.Context) { a.initFindings() }),
+		initOnlySubsystem("providers", func(taskCtx context.Context) { a.initProviders(taskCtx) }),
+		initOnlySubsystem("scheduler", func(taskCtx context.Context) { a.initScheduler(taskCtx) }),
+		initOnlySubsystem("snowflake_findings", func(taskCtx context.Context) { a.initSnowflakeFindings(taskCtx) }),
+		initOnlySubsystem("scan_watermarks", func(taskCtx context.Context) { a.initScanWatermarks(taskCtx) }),
+		initOnlySubsystem("threatintel", func(context.Context) { a.initThreatIntel(ctx) }),
+		initOnlySubsystem("available_tables", func(taskCtx context.Context) { a.initAvailableTables(taskCtx) }),
+	); err != nil {
 		return fmt.Errorf("phase 2a init failed: %w", err)
 	}
-	if err := runInitErrorStep("app_state_migration", func() error { return a.migrateAppState(ctx) }); err != nil {
+	if err := appState.Start(ctx); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (a *App) initPhase2b(ctx context.Context) error {
-	if err := runInitTasksConcurrently(ctx, []concurrentInitTask{
-		{name: "remediation", run: func(context.Context) { a.initRemediation() }},
-		{name: "agents", run: func(taskCtx context.Context) { a.initAgents(taskCtx) }},
-	}); err != nil {
+	remediation := a.remediationSubsystem()
+	if err := runSubsystemInitConcurrently(ctx, remediation, a.agentsSubsystem()); err != nil {
 		return fmt.Errorf("phase 2b init failed: %w", err)
 	}
-	a.startEventRemediation(ctx)
-	a.startEventAlertRouting(ctx)
+	if err := runSubsystemStartSequentially(ctx, remediation, a.eventsSubsystem()); err != nil {
+		return fmt.Errorf("phase 2b start failed: %w", err)
+	}
 	return nil
 }
 
@@ -127,24 +119,17 @@ func (a *App) initPhase3() {
 }
 
 func (a *App) initPhase4(ctx context.Context) error {
-	a.initSecurityGraph(ctx)
-	a.initTapGraphConsumer(ctx)
+	if err := runSubsystemStartSequentially(ctx, a.graphSubsystem()); err != nil {
+		return err
+	}
 	return a.validatePolicyCoverage(ctx)
 }
 
 func runInitTasksConcurrently(ctx context.Context, tasks []concurrentInitTask) error {
-	if len(tasks) == 0 {
-		return nil
-	}
-
-	g, gctx := errgroup.WithContext(ctx)
+	subsystems := make([]initSubsystem, 0, len(tasks))
 	for _, task := range tasks {
 		task := task
-		g.Go(func() error {
-			return runInitStep(task.name, func() {
-				task.run(gctx)
-			})
-		})
+		subsystems = append(subsystems, initOnlySubsystem(task.name, task.run))
 	}
-	return g.Wait()
+	return runSubsystemInitConcurrently(ctx, subsystems...)
 }

--- a/internal/app/app_lifecycle.go
+++ b/internal/app/app_lifecycle.go
@@ -2,8 +2,12 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
+	"sort"
 	"strings"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -28,10 +32,37 @@ type closeSubsystem interface {
 }
 
 type lifecycleSubsystem struct {
-	name  string
-	init  func(context.Context) error
-	start func(context.Context) error
-	close func(context.Context) error
+	name     string
+	requires []string
+	init     func(context.Context) error
+	start    func(context.Context) error
+	close    func(context.Context) error
+}
+
+type lifecycleAction string
+
+const (
+	lifecycleActionInit  lifecycleAction = "init"
+	lifecycleActionStart lifecycleAction = "start"
+)
+
+type lifecycleStage struct {
+	phase        string
+	action       lifecycleAction
+	subsystems   []lifecycleSubsystem
+	preSatisfied []string
+}
+
+type lifecycleStageReport struct {
+	Phase     string
+	Action    string
+	Waves     [][]string
+	Succeeded []string
+}
+
+type lifecycleExecutionReport struct {
+	Stages []lifecycleStageReport
+	Closed []string
 }
 
 func (s lifecycleSubsystem) Name() string {
@@ -40,6 +71,13 @@ func (s lifecycleSubsystem) Name() string {
 		return "subsystem"
 	}
 	return name
+}
+
+func (s lifecycleSubsystem) Requires() []string {
+	if len(s.requires) == 0 {
+		return nil
+	}
+	return append([]string(nil), s.requires...)
 }
 
 func (s lifecycleSubsystem) Init(ctx context.Context) error {
@@ -63,6 +101,25 @@ func (s lifecycleSubsystem) Close(ctx context.Context) error {
 	return s.close(ctx)
 }
 
+func (a lifecycleAction) String() string {
+	action := strings.TrimSpace(string(a))
+	if action == "" {
+		return "lifecycle"
+	}
+	return action
+}
+
+func (a lifecycleAction) run(ctx context.Context, subsystem lifecycleSubsystem) error {
+	switch a {
+	case lifecycleActionInit:
+		return subsystem.Init(ctx)
+	case lifecycleActionStart:
+		return subsystem.Start(ctx)
+	default:
+		return nil
+	}
+}
+
 func runLifecycleErrorStep(phase, name string, fn func() error) (err error) {
 	phase = strings.TrimSpace(phase)
 	if phase == "" {
@@ -78,6 +135,280 @@ func runLifecycleErrorStep(phase, name string, fn func() error) (err error) {
 		}
 	}()
 	return fn()
+}
+
+func buildSubsystemWaves(subsystems []lifecycleSubsystem, preSatisfied ...string) ([][]lifecycleSubsystem, error) {
+	if len(subsystems) == 0 {
+		return nil, nil
+	}
+
+	specs := make(map[string]lifecycleSubsystem, len(subsystems))
+	order := make(map[string]int, len(subsystems))
+	dependents := make(map[string][]string, len(subsystems))
+	indegree := make(map[string]int, len(subsystems))
+	satisfied := make(map[string]struct{}, len(preSatisfied))
+
+	for _, name := range preSatisfied {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		satisfied[name] = struct{}{}
+	}
+
+	for idx, subsystem := range subsystems {
+		name := subsystem.Name()
+		if _, exists := specs[name]; exists {
+			return nil, fmt.Errorf("duplicate subsystem %q", name)
+		}
+		specs[name] = subsystem
+		order[name] = idx
+		indegree[name] = 0
+	}
+
+	for _, subsystem := range subsystems {
+		name := subsystem.Name()
+		for _, dep := range normalizeLifecycleDependencies(subsystem.Requires()) {
+			if dep == name {
+				return nil, fmt.Errorf("subsystem %q cannot require itself", name)
+			}
+			if _, ok := specs[dep]; ok {
+				dependents[dep] = append(dependents[dep], name)
+				indegree[name]++
+				continue
+			}
+			if _, ok := satisfied[dep]; ok {
+				continue
+			}
+			return nil, fmt.Errorf("subsystem %q requires unknown dependency %q", name, dep)
+		}
+	}
+
+	remaining := make(map[string]struct{}, len(subsystems))
+	for name := range specs {
+		remaining[name] = struct{}{}
+	}
+
+	ready := orderedReadySubsystems(remaining, indegree, order)
+	waves := make([][]lifecycleSubsystem, 0, len(subsystems))
+	for len(ready) > 0 {
+		wave := make([]lifecycleSubsystem, 0, len(ready))
+		nextCandidates := make(map[string]struct{})
+		for _, name := range ready {
+			delete(remaining, name)
+			wave = append(wave, specs[name])
+			for _, dependent := range dependents[name] {
+				indegree[dependent]--
+				if indegree[dependent] == 0 {
+					if _, ok := remaining[dependent]; ok {
+						nextCandidates[dependent] = struct{}{}
+					}
+				}
+			}
+		}
+		waves = append(waves, wave)
+		ready = orderedReadyCandidateNames(nextCandidates, order)
+	}
+
+	if len(remaining) > 0 {
+		names := orderedReadyCandidateNames(remaining, order)
+		return nil, fmt.Errorf("subsystem dependency cycle: %s", strings.Join(names, ", "))
+	}
+
+	return waves, nil
+}
+
+func executeLifecycleStages(ctx context.Context, logger *slog.Logger, stages ...lifecycleStage) (lifecycleExecutionReport, error) {
+	report := lifecycleExecutionReport{}
+	seenClosers := make(map[string]struct{})
+	successfulClosers := make([]lifecycleSubsystem, 0)
+
+	for _, stage := range stages {
+		stageReport, closers, err := runLifecycleStage(ctx, logger, stage)
+		report.Stages = append(report.Stages, stageReport)
+		for _, subsystem := range closers {
+			if subsystem.close == nil {
+				continue
+			}
+			name := subsystem.Name()
+			if _, ok := seenClosers[name]; ok {
+				continue
+			}
+			seenClosers[name] = struct{}{}
+			successfulClosers = append(successfulClosers, subsystem)
+		}
+		if err != nil {
+			closed, closeErrs := closeLifecycleSubsystems(ctx, successfulClosers)
+			report.Closed = closed
+			if len(closeErrs) > 0 {
+				return report, errors.Join(append([]error{err}, closeErrs...)...)
+			}
+			return report, err
+		}
+	}
+
+	return report, nil
+}
+
+func runLifecycleStage(ctx context.Context, logger *slog.Logger, stage lifecycleStage) (lifecycleStageReport, []lifecycleSubsystem, error) {
+	report := lifecycleStageReport{
+		Phase:  strings.TrimSpace(stage.phase),
+		Action: stage.action.String(),
+	}
+
+	waves, err := buildSubsystemWaves(stage.subsystems, stage.preSatisfied...)
+	if err != nil {
+		return report, nil, err
+	}
+	report.Waves = subsystemWaveNames(waves)
+	logLifecycleStagePlan(logger, stage, report.Waves)
+
+	successful := make([]lifecycleSubsystem, 0, len(stage.subsystems))
+	for _, wave := range waves {
+		names, subsystems, err := runLifecycleWave(ctx, stage.action, wave)
+		report.Succeeded = append(report.Succeeded, names...)
+		successful = append(successful, subsystems...)
+		if err != nil {
+			return report, successful, err
+		}
+	}
+
+	return report, successful, nil
+}
+
+func runLifecycleWave(ctx context.Context, action lifecycleAction, wave []lifecycleSubsystem) ([]string, []lifecycleSubsystem, error) {
+	if len(wave) == 0 {
+		return nil, nil, nil
+	}
+
+	type success struct {
+		index     int
+		subsystem lifecycleSubsystem
+	}
+
+	var (
+		mu        sync.Mutex
+		successes []success
+	)
+
+	g, gctx := errgroup.WithContext(ctx)
+	for idx, subsystem := range wave {
+		idx := idx
+		subsystem := subsystem
+		g.Go(func() error {
+			err := runLifecycleErrorStep(action.String(), subsystem.Name(), func() error {
+				return action.run(gctx, subsystem)
+			})
+			if err == nil {
+				mu.Lock()
+				successes = append(successes, success{index: idx, subsystem: subsystem})
+				mu.Unlock()
+			}
+			return err
+		})
+	}
+
+	err := g.Wait()
+	sort.Slice(successes, func(i, j int) bool {
+		return successes[i].index < successes[j].index
+	})
+
+	names := make([]string, 0, len(successes))
+	subsystems := make([]lifecycleSubsystem, 0, len(successes))
+	for _, success := range successes {
+		names = append(names, success.subsystem.Name())
+		subsystems = append(subsystems, success.subsystem)
+	}
+	return names, subsystems, err
+}
+
+func closeLifecycleSubsystems(ctx context.Context, subsystems []lifecycleSubsystem) ([]string, []error) {
+	if len(subsystems) == 0 {
+		return nil, nil
+	}
+
+	ordered := make([]closeSubsystem, 0, len(subsystems))
+	closed := make([]string, 0, len(subsystems))
+	for i := len(subsystems) - 1; i >= 0; i-- {
+		subsystem := subsystems[i]
+		if subsystem.close == nil {
+			continue
+		}
+		ordered = append(ordered, subsystem)
+		closed = append(closed, subsystem.Name())
+	}
+	if len(ordered) == 0 {
+		return nil, nil
+	}
+	return closed, runSubsystemCloseSequentially(ctx, ordered...)
+}
+
+func logLifecycleStagePlan(logger *slog.Logger, stage lifecycleStage, waves [][]string) {
+	if logger == nil || !logger.Enabled(context.Background(), slog.LevelDebug) {
+		return
+	}
+	logger.Debug("computed subsystem lifecycle plan",
+		"phase", strings.TrimSpace(stage.phase),
+		"action", stage.action.String(),
+		"pre_satisfied", normalizeLifecycleDependencies(stage.preSatisfied),
+		"waves", waves,
+	)
+}
+
+func subsystemWaveNames(waves [][]lifecycleSubsystem) [][]string {
+	if len(waves) == 0 {
+		return nil
+	}
+	result := make([][]string, 0, len(waves))
+	for _, wave := range waves {
+		names := make([]string, 0, len(wave))
+		for _, subsystem := range wave {
+			names = append(names, subsystem.Name())
+		}
+		result = append(result, names)
+	}
+	return result
+}
+
+func orderedReadySubsystems(remaining map[string]struct{}, indegree map[string]int, order map[string]int) []string {
+	candidates := make(map[string]struct{})
+	for name := range remaining {
+		if indegree[name] == 0 {
+			candidates[name] = struct{}{}
+		}
+	}
+	return orderedReadyCandidateNames(candidates, order)
+}
+
+func orderedReadyCandidateNames(candidates map[string]struct{}, order map[string]int) []string {
+	names := make([]string, 0, len(candidates))
+	for name := range candidates {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		return order[names[i]] < order[names[j]]
+	})
+	return names
+}
+
+func normalizeLifecycleDependencies(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	return normalized
 }
 
 func runSubsystemInitConcurrently(ctx context.Context, subsystems ...initSubsystem) error {
@@ -142,5 +473,33 @@ func initOnlySubsystem(name string, init func(context.Context)) lifecycleSubsyst
 			}
 			return nil
 		},
+	}
+}
+
+func initOnlySubsystemWithDeps(name string, requires []string, init func(context.Context)) lifecycleSubsystem {
+	subsystem := initOnlySubsystem(name, init)
+	subsystem.requires = normalizeLifecycleDependencies(requires)
+	return subsystem
+}
+
+func wrapInitSubsystem(subsystem initSubsystem, requires ...string) lifecycleSubsystem {
+	if subsystem == nil {
+		return lifecycleSubsystem{}
+	}
+	return lifecycleSubsystem{
+		name:     subsystem.Name(),
+		requires: normalizeLifecycleDependencies(requires),
+		init:     subsystem.Init,
+	}
+}
+
+func wrapStartSubsystem(subsystem startSubsystem, requires ...string) lifecycleSubsystem {
+	if subsystem == nil {
+		return lifecycleSubsystem{}
+	}
+	return lifecycleSubsystem{
+		name:     subsystem.Name(),
+		requires: normalizeLifecycleDependencies(requires),
+		start:    subsystem.Start,
 	}
 }

--- a/internal/app/app_lifecycle.go
+++ b/internal/app/app_lifecycle.go
@@ -1,0 +1,146 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type namedSubsystem interface {
+	Name() string
+}
+
+type initSubsystem interface {
+	namedSubsystem
+	Init(context.Context) error
+}
+
+type startSubsystem interface {
+	namedSubsystem
+	Start(context.Context) error
+}
+
+type closeSubsystem interface {
+	namedSubsystem
+	Close(context.Context) error
+}
+
+type lifecycleSubsystem struct {
+	name  string
+	init  func(context.Context) error
+	start func(context.Context) error
+	close func(context.Context) error
+}
+
+func (s lifecycleSubsystem) Name() string {
+	name := strings.TrimSpace(s.name)
+	if name == "" {
+		return "subsystem"
+	}
+	return name
+}
+
+func (s lifecycleSubsystem) Init(ctx context.Context) error {
+	if s.init == nil {
+		return nil
+	}
+	return s.init(ctx)
+}
+
+func (s lifecycleSubsystem) Start(ctx context.Context) error {
+	if s.start == nil {
+		return nil
+	}
+	return s.start(ctx)
+}
+
+func (s lifecycleSubsystem) Close(ctx context.Context) error {
+	if s.close == nil {
+		return nil
+	}
+	return s.close(ctx)
+}
+
+func runLifecycleErrorStep(phase, name string, fn func() error) (err error) {
+	phase = strings.TrimSpace(phase)
+	if phase == "" {
+		phase = "lifecycle"
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = "subsystem"
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%s %s panic: %v", name, phase, r)
+		}
+	}()
+	return fn()
+}
+
+func runSubsystemInitConcurrently(ctx context.Context, subsystems ...initSubsystem) error {
+	if len(subsystems) == 0 {
+		return nil
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	for _, subsystem := range subsystems {
+		subsystem := subsystem
+		if subsystem == nil {
+			continue
+		}
+		g.Go(func() error {
+			return runLifecycleErrorStep("init", subsystem.Name(), func() error {
+				return subsystem.Init(gctx)
+			})
+		})
+	}
+	return g.Wait()
+}
+
+func runSubsystemStartSequentially(ctx context.Context, subsystems ...startSubsystem) error {
+	for _, subsystem := range subsystems {
+		if subsystem == nil {
+			continue
+		}
+		if err := runLifecycleErrorStep("start", subsystem.Name(), func() error {
+			return subsystem.Start(ctx)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runSubsystemCloseSequentially(ctx context.Context, subsystems ...closeSubsystem) []error {
+	if len(subsystems) == 0 {
+		return nil
+	}
+
+	var errs []error
+	for _, subsystem := range subsystems {
+		if subsystem == nil {
+			continue
+		}
+		if err := runLifecycleErrorStep("close", subsystem.Name(), func() error {
+			return subsystem.Close(ctx)
+		}); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func initOnlySubsystem(name string, init func(context.Context)) lifecycleSubsystem {
+	return lifecycleSubsystem{
+		name: name,
+		init: func(ctx context.Context) error {
+			if init != nil {
+				init(ctx)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/app/app_lifecycle_test.go
+++ b/internal/app/app_lifecycle_test.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRunSubsystemInitConcurrently_RunsAllSubsystems(t *testing.T) {
+	var called atomic.Int32
+
+	err := runSubsystemInitConcurrently(context.Background(),
+		initOnlySubsystem("cache", func(context.Context) { called.Add(1) }),
+		initOnlySubsystem("runtime", func(context.Context) { called.Add(1) }),
+		initOnlySubsystem("events", func(context.Context) { called.Add(1) }),
+	)
+	if err != nil {
+		t.Fatalf("runSubsystemInitConcurrently() error = %v", err)
+	}
+	if got, want := called.Load(), int32(3); got != want {
+		t.Fatalf("subsystem init count = %d, want %d", got, want)
+	}
+}
+
+func TestRunSubsystemInitConcurrently_PropagatesError(t *testing.T) {
+	want := errors.New("boom")
+
+	err := runSubsystemInitConcurrently(context.Background(),
+		lifecycleSubsystem{
+			name: "graph",
+			init: func(context.Context) error {
+				return want
+			},
+		},
+	)
+	if !errors.Is(err, want) {
+		t.Fatalf("runSubsystemInitConcurrently() error = %v, want wrapped %v", err, want)
+	}
+}
+
+func TestRunSubsystemStartSequentially_RunsInOrder(t *testing.T) {
+	var order []string
+
+	err := runSubsystemStartSequentially(context.Background(),
+		lifecycleSubsystem{
+			name: "remediation",
+			start: func(context.Context) error {
+				order = append(order, "remediation")
+				return nil
+			},
+		},
+		lifecycleSubsystem{
+			name: "events",
+			start: func(context.Context) error {
+				order = append(order, "events")
+				return nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("runSubsystemStartSequentially() error = %v", err)
+	}
+	if want := []string{"remediation", "events"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("start order = %v, want %v", order, want)
+	}
+}
+
+func TestRunSubsystemCloseSequentially_CollectsErrors(t *testing.T) {
+	errs := runSubsystemCloseSequentially(context.Background(),
+		lifecycleSubsystem{
+			name: "agents",
+			close: func(context.Context) error {
+				return errors.New("close failed")
+			},
+		},
+	)
+	if len(errs) != 1 {
+		t.Fatalf("close errors len = %d, want 1", len(errs))
+	}
+	if errs[0] == nil || errs[0].Error() == "" {
+		t.Fatalf("expected non-empty close error, got %v", errs[0])
+	}
+}

--- a/internal/app/app_lifecycle_test.go
+++ b/internal/app/app_lifecycle_test.go
@@ -3,6 +3,8 @@ package app
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"reflect"
 	"sync/atomic"
 	"testing"
@@ -81,5 +83,135 @@ func TestRunSubsystemCloseSequentially_CollectsErrors(t *testing.T) {
 	}
 	if errs[0] == nil || errs[0].Error() == "" {
 		t.Fatalf("expected non-empty close error, got %v", errs[0])
+	}
+}
+
+func TestBuildSubsystemWaves_OrdersDependencies(t *testing.T) {
+	subsystems := []lifecycleSubsystem{
+		initOnlySubsystem("cache", nil),
+		initOnlySubsystemWithDeps("scheduler", []string{"cache", "health"}, nil),
+		initOnlySubsystem("health", nil),
+		initOnlySubsystemWithDeps("agents", []string{"runtime"}, nil),
+		initOnlySubsystem("runtime", nil),
+	}
+
+	waves, err := buildSubsystemWaves(subsystems)
+	if err != nil {
+		t.Fatalf("buildSubsystemWaves() error = %v", err)
+	}
+
+	got := subsystemWaveNames(waves)
+	want := [][]string{
+		{"cache", "health", "runtime"},
+		{"scheduler", "agents"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildSubsystemWaves() = %v, want %v", got, want)
+	}
+}
+
+func TestBuildSubsystemWaves_RejectsUnknownDependency(t *testing.T) {
+	_, err := buildSubsystemWaves([]lifecycleSubsystem{
+		initOnlySubsystemWithDeps("scheduler", []string{"missing"}, nil),
+	})
+	if err == nil || err.Error() == "" {
+		t.Fatal("expected unknown dependency error")
+	}
+}
+
+func TestBuildSubsystemWaves_RejectsCycle(t *testing.T) {
+	_, err := buildSubsystemWaves([]lifecycleSubsystem{
+		initOnlySubsystemWithDeps("cache", []string{"runtime"}, nil),
+		initOnlySubsystemWithDeps("runtime", []string{"cache"}, nil),
+	})
+	if err == nil || err.Error() == "" {
+		t.Fatal("expected dependency cycle error")
+	}
+}
+
+func TestPhase2aSubsystemWaves(t *testing.T) {
+	a := &App{
+		Config: &Config{},
+		Logger: slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+
+	waves, err := buildSubsystemWaves(a.phase2aInitSubsystems(), "appstate", "graph")
+	if err != nil {
+		t.Fatalf("buildSubsystemWaves(phase2a) error = %v", err)
+	}
+
+	gotWaveBySubsystem := make(map[string]int)
+	for waveIdx, wave := range subsystemWaveNames(waves) {
+		for _, name := range wave {
+			gotWaveBySubsystem[name] = waveIdx
+		}
+	}
+
+	wantWaveBySubsystem := map[string]int{
+		"cache":              0,
+		"ticketing":          0,
+		"identity":           0,
+		"attackpath":         0,
+		"webhooks":           0,
+		"notifications":      0,
+		"rbac":               0,
+		"compliance":         0,
+		"health":             0,
+		"lineage":            0,
+		"runtime":            0,
+		"findings":           0,
+		"providers":          0,
+		"scan_watermarks":    0,
+		"available_tables":   0,
+		"snowflake_findings": 1,
+		"threatintel":        1,
+		"scheduler":          1,
+	}
+	if !reflect.DeepEqual(gotWaveBySubsystem, wantWaveBySubsystem) {
+		t.Fatalf("phase2a wave plan = %v, want %v", gotWaveBySubsystem, wantWaveBySubsystem)
+	}
+}
+
+func TestInitialize_partial_failure(t *testing.T) {
+	report, err := executeLifecycleStages(context.Background(), nil, lifecycleStage{
+		phase:  "initialize",
+		action: lifecycleActionInit,
+		subsystems: []lifecycleSubsystem{
+			{
+				name: "appstate",
+				init: func(context.Context) error { return nil },
+				close: func(context.Context) error {
+					return nil
+				},
+			},
+			{
+				name:     "runtime",
+				requires: []string{"appstate"},
+				init:     func(context.Context) error { return nil },
+				close: func(context.Context) error {
+					return nil
+				},
+			},
+			{
+				name:     "agents",
+				requires: []string{"runtime"},
+				init: func(context.Context) error {
+					return errors.New("boom")
+				},
+				close: func(context.Context) error {
+					t.Fatal("failed subsystem should not be closed")
+					return nil
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected initialize failure")
+	}
+	if got, want := report.Closed, []string{"runtime", "appstate"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("closed subsystems = %v, want %v", got, want)
+	}
+	if got, want := report.Stages[0].Succeeded, []string{"appstate", "runtime"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("successful subsystems = %v, want %v", got, want)
 	}
 }

--- a/internal/app/app_subsystem_config.go
+++ b/internal/app/app_subsystem_config.go
@@ -1,0 +1,150 @@
+package app
+
+import (
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/agents"
+	"github.com/writer/cerebro/internal/graph"
+)
+
+// SubsystemConfig provides grouped, subsystem-scoped views over the env-backed
+// top-level app config without changing the external config surface.
+type SubsystemConfig struct {
+	Agents   AgentConfig
+	Runtime  RuntimeConfig
+	Graph    GraphConfig
+	AppState AppStateConfig
+	Events   EventConfig
+}
+
+type AgentConfig struct {
+	AnthropicAPIKey string
+	OpenAIAPIKey    string
+	GitHubToken     string
+	GitLabToken     string
+	GitLabBaseURL   string
+	RemoteTools     agents.RemoteToolProviderConfig
+	ToolPublisher   agents.ToolPublisherConfig
+}
+
+func (c AgentConfig) HasModelProvider() bool {
+	return strings.TrimSpace(c.AnthropicAPIKey) != "" || strings.TrimSpace(c.OpenAIAPIKey) != ""
+}
+
+func (c AgentConfig) RemoteToolingEnabled() bool {
+	return c.RemoteTools.Enabled || c.ToolPublisher.Enabled
+}
+
+type RuntimeConfig struct {
+	ExecutionStoreFile string
+}
+
+type GraphConfig struct {
+	SnapshotPath                 string
+	SnapshotMaxRetained          int
+	StoreBackend                 graph.StoreBackend
+	SearchBackend                graph.EntitySearchBackendType
+	SchemaValidationMode         string
+	PropertyHistoryMaxEntries    int
+	PropertyHistoryTTL           time.Duration
+	WriterLeaseEnabled           bool
+	WriterLeaseName              string
+	WriterLeaseOwnerID           string
+	WriterLeaseTTL               time.Duration
+	WriterLeaseHeartbeat         time.Duration
+	MigrateLegacyActivityOnStart bool
+}
+
+type AppStateConfig struct {
+	JobDatabaseURL       string
+	WarehouseBackend     string
+	WarehousePostgresDSN string
+}
+
+func (c AppStateConfig) DatabaseURL() string {
+	if dsn := strings.TrimSpace(c.JobDatabaseURL); dsn != "" {
+		return dsn
+	}
+	if strings.EqualFold(strings.TrimSpace(c.WarehouseBackend), "postgres") {
+		return strings.TrimSpace(c.WarehousePostgresDSN)
+	}
+	return ""
+}
+
+type EventConfig struct {
+	NATSJetStreamEnabled     bool
+	NATSConsumerEnabled      bool
+	NATSConsumerSubjects     []string
+	NATSConsumerDurable      string
+	NATSConsumerDrainTimeout time.Duration
+	AlertRouterEnabled       bool
+	AlertRouterConfigPath    string
+	AlertRouterNotifyPrefix  string
+}
+
+func (c EventConfig) AlertRoutingEnabled() bool {
+	return c.AlertRouterEnabled && c.NATSJetStreamEnabled
+}
+
+func (c EventConfig) TapGraphConsumerEnabled() bool {
+	return c.NATSConsumerEnabled
+}
+
+func (c *Config) BuildSubsystemConfig() SubsystemConfig {
+	if c == nil {
+		return SubsystemConfig{}
+	}
+
+	return SubsystemConfig{
+		Agents: AgentConfig{
+			AnthropicAPIKey: c.AnthropicAPIKey,
+			OpenAIAPIKey:    c.OpenAIAPIKey,
+			GitHubToken:     c.GitHubToken,
+			GitLabToken:     c.GitLabToken,
+			GitLabBaseURL:   c.GitLabBaseURL,
+			RemoteTools:     remoteToolProviderConfigFromConfig(c),
+			ToolPublisher:   toolPublisherConfigFromConfig(c),
+		},
+		Runtime: RuntimeConfig{
+			ExecutionStoreFile: c.ExecutionStoreFile,
+		},
+		Graph: GraphConfig{
+			SnapshotPath:                 c.GraphSnapshotPath,
+			SnapshotMaxRetained:          c.GraphSnapshotMaxRetained,
+			StoreBackend:                 c.graphStoreBackend(),
+			SearchBackend:                c.graphSearchBackend(),
+			SchemaValidationMode:         c.GraphSchemaValidationMode,
+			PropertyHistoryMaxEntries:    c.GraphPropertyHistoryMaxEntries,
+			PropertyHistoryTTL:           c.GraphPropertyHistoryTTL,
+			WriterLeaseEnabled:           c.GraphWriterLeaseEnabled,
+			WriterLeaseName:              c.GraphWriterLeaseName,
+			WriterLeaseOwnerID:           c.GraphWriterLeaseOwnerID,
+			WriterLeaseTTL:               c.GraphWriterLeaseTTL,
+			WriterLeaseHeartbeat:         c.GraphWriterLeaseHeartbeat,
+			MigrateLegacyActivityOnStart: c.GraphMigrateLegacyActivityOnStart,
+		},
+		AppState: AppStateConfig{
+			JobDatabaseURL:       c.JobDatabaseURL,
+			WarehouseBackend:     c.WarehouseBackend,
+			WarehousePostgresDSN: c.WarehousePostgresDSN,
+		},
+		Events: EventConfig{
+			NATSJetStreamEnabled:     c.NATSJetStreamEnabled,
+			NATSConsumerEnabled:      c.NATSConsumerEnabled,
+			NATSConsumerSubjects:     append([]string(nil), c.NATSConsumerSubjects...),
+			NATSConsumerDurable:      c.NATSConsumerDurable,
+			NATSConsumerDrainTimeout: c.NATSConsumerDrainTimeout,
+			AlertRouterEnabled:       c.AlertRouterEnabled,
+			AlertRouterConfigPath:    c.AlertRouterConfigPath,
+			AlertRouterNotifyPrefix:  c.AlertRouterNotifyPrefix,
+		},
+	}
+}
+
+func (a *App) subsystemConfig() SubsystemConfig {
+	if a == nil || a.Config == nil {
+		return SubsystemConfig{}
+	}
+	return a.Config.BuildSubsystemConfig()
+}

--- a/internal/app/app_subsystem_config_test.go
+++ b/internal/app/app_subsystem_config_test.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBuildSubsystemConfig_GroupsSubsystemViews(t *testing.T) {
+	cfg := &Config{
+		AnthropicAPIKey:                   "anthropic-key",
+		GitHubToken:                       "github-token",
+		GitLabToken:                       "gitlab-token",
+		GitLabBaseURL:                     "https://gitlab.example.com",
+		AgentRemoteToolsEnabled:           true,
+		AgentToolPublisherEnabled:         true,
+		GraphSnapshotPath:                 "/tmp/graph",
+		GraphSnapshotMaxRetained:          7,
+		GraphStoreBackend:                 "sqlite",
+		GraphSearchBackend:                "opensearch",
+		GraphSchemaValidationMode:         "strict",
+		GraphPropertyHistoryMaxEntries:    42,
+		GraphPropertyHistoryTTL:           15 * time.Minute,
+		GraphWriterLeaseEnabled:           true,
+		GraphWriterLeaseName:              "writer-lease",
+		GraphWriterLeaseOwnerID:           "writer-a",
+		GraphWriterLeaseTTL:               30 * time.Second,
+		GraphWriterLeaseHeartbeat:         10 * time.Second,
+		GraphMigrateLegacyActivityOnStart: true,
+		JobDatabaseURL:                    "postgres://jobs",
+		ExecutionStoreFile:                "/tmp/executions.db",
+		NATSJetStreamEnabled:              true,
+		NATSConsumerEnabled:               true,
+		NATSConsumerSubjects:              []string{"graph.events", "graph.rebuilds"},
+		NATSConsumerDurable:               "graph-worker",
+		NATSConsumerDrainTimeout:          12 * time.Second,
+		AlertRouterEnabled:                true,
+		AlertRouterConfigPath:             "/tmp/alert-router.yaml",
+		AlertRouterNotifyPrefix:           "ensemble.notify",
+	}
+
+	subsystems := cfg.BuildSubsystemConfig()
+
+	if !subsystems.Agents.HasModelProvider() {
+		t.Fatal("expected agent config to report a configured model provider")
+	}
+	if !subsystems.Agents.RemoteToolingEnabled() {
+		t.Fatal("expected agent config to report remote tooling enabled")
+	}
+	if got, want := subsystems.Runtime.ExecutionStoreFile, cfg.ExecutionStoreFile; got != want {
+		t.Fatalf("runtime execution store file = %q, want %q", got, want)
+	}
+	if got, want := subsystems.AppState.DatabaseURL(), cfg.JobDatabaseURL; got != want {
+		t.Fatalf("appstate database url = %q, want %q", got, want)
+	}
+	if got, want := subsystems.Graph.SnapshotPath, cfg.GraphSnapshotPath; got != want {
+		t.Fatalf("graph snapshot path = %q, want %q", got, want)
+	}
+	if got, want := subsystems.Graph.PropertyHistoryTTL, cfg.GraphPropertyHistoryTTL; got != want {
+		t.Fatalf("graph history ttl = %s, want %s", got, want)
+	}
+	if !subsystems.Events.AlertRoutingEnabled() {
+		t.Fatal("expected alert routing to be enabled when JetStream is enabled")
+	}
+	if !subsystems.Events.TapGraphConsumerEnabled() {
+		t.Fatal("expected tap graph consumer to be enabled")
+	}
+	if got, want := subsystems.Events.NATSConsumerDurable, cfg.NATSConsumerDurable; got != want {
+		t.Fatalf("tap durable = %q, want %q", got, want)
+	}
+	if got, want := subsystems.Events.NATSConsumerSubjects, cfg.NATSConsumerSubjects; !reflect.DeepEqual(got, want) {
+		t.Fatalf("tap subjects = %v, want %v", got, want)
+	}
+
+	subsystems.Events.NATSConsumerSubjects[0] = "changed"
+	if cfg.NATSConsumerSubjects[0] != "graph.events" {
+		t.Fatal("expected event subjects to be copied when building subsystem config")
+	}
+}
+
+func TestAppStateConfigDatabaseURLFallsBackToWarehousePostgresDSN(t *testing.T) {
+	cfg := AppStateConfig{
+		WarehouseBackend:     "postgres",
+		WarehousePostgresDSN: "postgres://warehouse",
+	}
+
+	if got, want := cfg.DatabaseURL(), "postgres://warehouse"; got != want {
+		t.Fatalf("DatabaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestEventConfigAlertRoutingEnabledRequiresJetStream(t *testing.T) {
+	cfg := EventConfig{
+		NATSJetStreamEnabled: false,
+		AlertRouterEnabled:   true,
+	}
+
+	if cfg.AlertRoutingEnabled() {
+		t.Fatal("expected alert routing to require JetStream")
+	}
+}

--- a/internal/app/app_subsystems.go
+++ b/internal/app/app_subsystems.go
@@ -1,0 +1,194 @@
+package app
+
+import "context"
+
+type appStateLifecycle struct {
+	app *App
+	cfg AppStateConfig
+}
+
+func (a *App) appStateSubsystem() appStateLifecycle {
+	return appStateLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().AppState,
+	}
+}
+
+func (s appStateLifecycle) Name() string {
+	return "appstate"
+}
+
+func (s appStateLifecycle) Init(ctx context.Context) error {
+	if s.app == nil || s.cfg.DatabaseURL() == "" {
+		return nil
+	}
+	return runInitErrorStep("app_state_db", func() error {
+		return s.app.initAppStateDB(ctx)
+	})
+}
+
+func (s appStateLifecycle) Start(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initRepositories()
+	if s.cfg.DatabaseURL() == "" {
+		return nil
+	}
+	return runInitErrorStep("app_state_migration", func() error {
+		return s.app.migrateAppState(ctx)
+	})
+}
+
+type agentsLifecycle struct {
+	app *App
+	cfg AgentConfig
+}
+
+func (a *App) agentsSubsystem() agentsLifecycle {
+	return agentsLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().Agents,
+	}
+}
+
+func (s agentsLifecycle) Name() string {
+	return "agents"
+}
+
+func (s agentsLifecycle) Init(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initAgents(ctx)
+	return nil
+}
+
+type runtimeLifecycle struct {
+	app *App
+	cfg RuntimeConfig
+}
+
+func (a *App) runtimeSubsystem() runtimeLifecycle {
+	return runtimeLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().Runtime,
+	}
+}
+
+func (s runtimeLifecycle) Name() string {
+	return "runtime"
+}
+
+func (s runtimeLifecycle) Init(context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initRuntime()
+	return nil
+}
+
+type remediationLifecycle struct {
+	app *App
+}
+
+func (a *App) remediationSubsystem() remediationLifecycle {
+	return remediationLifecycle{app: a}
+}
+
+func (s remediationLifecycle) Name() string {
+	return "remediation"
+}
+
+func (s remediationLifecycle) Init(context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initRemediation()
+	return nil
+}
+
+func (s remediationLifecycle) Start(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.startEventRemediation(ctx)
+	return nil
+}
+
+type graphLifecycle struct {
+	app    *App
+	cfg    GraphConfig
+	events EventConfig
+}
+
+func (a *App) graphSubsystem() graphLifecycle {
+	cfg := a.subsystemConfig()
+	return graphLifecycle{
+		app:    a,
+		cfg:    cfg.Graph,
+		events: cfg.Events,
+	}
+}
+
+func (s graphLifecycle) Name() string {
+	return "graph"
+}
+
+func (s graphLifecycle) Init(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initGraphPersistenceStore()
+	if err := runInitErrorStep("graph_store_backend", func() error {
+		return s.app.initConfiguredSecurityGraphStore(ctx)
+	}); err != nil {
+		return err
+	}
+	if err := runInitErrorStep("graph_writer_lease", func() error {
+		return s.app.initGraphWriterLease(ctx)
+	}); err != nil {
+		return err
+	}
+	if err := runInitErrorStep("entity_search_backend", func() error {
+		return s.app.initEntitySearchBackend(ctx)
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s graphLifecycle) Start(ctx context.Context) error {
+	if s.app == nil {
+		return nil
+	}
+	s.app.initSecurityGraph(ctx)
+	if s.events.TapGraphConsumerEnabled() {
+		s.app.initTapGraphConsumer(ctx)
+	}
+	return nil
+}
+
+type eventLifecycle struct {
+	app *App
+	cfg EventConfig
+}
+
+func (a *App) eventsSubsystem() eventLifecycle {
+	return eventLifecycle{
+		app: a,
+		cfg: a.subsystemConfig().Events,
+	}
+}
+
+func (s eventLifecycle) Name() string {
+	return "events"
+}
+
+func (s eventLifecycle) Start(ctx context.Context) error {
+	if s.app == nil || !s.cfg.AlertRoutingEnabled() {
+		return nil
+	}
+	s.app.startEventAlertRouting(ctx)
+	return nil
+}


### PR DESCRIPTION
## Summary
- replace the flat phase-2 init errgroups with dependency-aware subsystem waves
- declare concrete phase-2a and phase-2b dependencies, log the computed wave plan at DEBUG, and validate the DAG in tests
- run cleanup on initialization failure through the normal app shutdown path so partial startup unwinds consistently

## Testing
- go test ./internal/app/...
- go vet ./internal/app/...
- python3 ./scripts/devex.py run --mode changed --base-ref refactor/app-subsystem-lifecycle-seams

Closes #388
