### PR TITLE
fix(sync): share S3 bucket discovery across tables

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -30,6 +30,7 @@ type SyncEngine struct {
 	regions                             []string
 	accountID                           string
 	tableInit                           sync.Map
+	s3BucketInventory                   sync.Map
 	tableFilter                         map[string]struct{}
 	rateLimiter                         *rate.Limiter
 	retryOptions                        retryOptions
@@ -139,6 +140,7 @@ func (e *SyncEngine) SyncAll(ctx context.Context) ([]SyncResult, error) {
 func (e *SyncEngine) SyncAllWithConfig(ctx context.Context, cfg aws.Config) ([]SyncResult, error) {
 	// Get account ID
 	e.accountID = e.getAccountID(ctx, cfg)
+	e.s3BucketInventory = sync.Map{}
 
 	if len(e.regions) == 0 {
 		region := cfg.Region

--- a/internal/sync/s3_bucket_inventory.go
+++ b/internal/sync/s3_bucket_inventory.go
@@ -1,0 +1,195 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+type s3BucketClient interface {
+	ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
+	GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+	GetBucketPolicy(ctx context.Context, params *s3.GetBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error)
+	GetBucketAcl(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	GetBucketEncryption(ctx context.Context, params *s3.GetBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error)
+	GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
+	GetBucketLogging(ctx context.Context, params *s3.GetBucketLoggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error)
+	GetPublicAccessBlock(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error)
+	GetBucketOwnershipControls(ctx context.Context, params *s3.GetBucketOwnershipControlsInput, optFns ...func(*s3.Options)) (*s3.GetBucketOwnershipControlsOutput, error)
+	GetBucketPolicyStatus(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
+	GetBucketNotificationConfiguration(ctx context.Context, params *s3.GetBucketNotificationConfigurationInput, optFns ...func(*s3.Options)) (*s3.GetBucketNotificationConfigurationOutput, error)
+	ListBucketInventoryConfigurations(ctx context.Context, params *s3.ListBucketInventoryConfigurationsInput, optFns ...func(*s3.Options)) (*s3.ListBucketInventoryConfigurationsOutput, error)
+	GetObjectLockConfiguration(ctx context.Context, params *s3.GetObjectLockConfigurationInput, optFns ...func(*s3.Options)) (*s3.GetObjectLockConfigurationOutput, error)
+	GetBucketLifecycleConfiguration(ctx context.Context, params *s3.GetBucketLifecycleConfigurationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLifecycleConfigurationOutput, error)
+	GetBucketReplication(ctx context.Context, params *s3.GetBucketReplicationInput, optFns ...func(*s3.Options)) (*s3.GetBucketReplicationOutput, error)
+	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	GetBucketCors(ctx context.Context, params *s3.GetBucketCorsInput, optFns ...func(*s3.Options)) (*s3.GetBucketCorsOutput, error)
+	GetBucketWebsite(ctx context.Context, params *s3.GetBucketWebsiteInput, optFns ...func(*s3.Options)) (*s3.GetBucketWebsiteOutput, error)
+}
+
+var newS3BucketClient = func(cfg aws.Config, optFns ...func(*s3.Options)) s3BucketClient {
+	return s3.NewFromConfig(cfg, optFns...)
+}
+
+type s3BucketDescriptor struct {
+	Name         string
+	Region       string
+	CreationDate *time.Time
+}
+
+type s3BucketInventoryState struct {
+	mu      sync.Mutex
+	ready   bool
+	buckets []s3BucketDescriptor
+	err     error
+}
+
+func (e *SyncEngine) s3Buckets(ctx context.Context, cfg aws.Config) ([]s3BucketDescriptor, error) {
+	cacheKey := strings.TrimSpace(e.getAccountIDFromConfig(ctx, cfg))
+	if cacheKey == "" {
+		cacheKey = "default"
+	}
+
+	rawState, _ := e.s3BucketInventory.LoadOrStore(cacheKey, &s3BucketInventoryState{})
+	state := rawState.(*s3BucketInventoryState)
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	if state.ready {
+		return cloneS3BucketDescriptors(state.buckets), state.err
+	}
+
+	discoveryCfg := cfg.Copy()
+	discoveryCfg.Region = "us-east-1"
+	client := newS3BucketClient(discoveryCfg)
+
+	out, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	buckets := make([]s3BucketDescriptor, 0, len(out.Buckets))
+	for _, bucket := range out.Buckets {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		name := strings.TrimSpace(aws.ToString(bucket.Name))
+		if name == "" {
+			continue
+		}
+
+		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
+			Bucket: aws.String(name),
+		})
+		if err != nil {
+			e.warnS3BucketOperation("", name, "", "GetBucketLocation", err)
+			buckets = append(buckets, s3BucketDescriptor{
+				Name:         name,
+				CreationDate: bucket.CreationDate,
+			})
+			continue
+		}
+
+		buckets = append(buckets, s3BucketDescriptor{
+			Name:         name,
+			Region:       normalizeS3BucketRegion(locOut.LocationConstraint),
+			CreationDate: bucket.CreationDate,
+		})
+	}
+
+	state.buckets = buckets
+	state.err = nil
+	state.ready = true
+	return cloneS3BucketDescriptors(buckets), nil
+}
+
+func (e *SyncEngine) s3BucketsInRegion(ctx context.Context, cfg aws.Config, region string) ([]s3BucketDescriptor, error) {
+	buckets, err := e.s3Buckets(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(region) == "" {
+		return buckets, nil
+	}
+
+	filtered := make([]s3BucketDescriptor, 0, len(buckets))
+	for _, bucket := range buckets {
+		if strings.EqualFold(bucket.Region, region) {
+			filtered = append(filtered, bucket)
+		}
+	}
+	return filtered, nil
+}
+
+func cloneS3BucketDescriptors(buckets []s3BucketDescriptor) []s3BucketDescriptor {
+	if len(buckets) == 0 {
+		return nil
+	}
+	cloned := make([]s3BucketDescriptor, len(buckets))
+	copy(cloned, buckets)
+	return cloned
+}
+
+func newS3BucketRegionalClient(cfg aws.Config, region string) s3BucketClient {
+	regionalCfg := cfg.Copy()
+	if strings.TrimSpace(region) != "" {
+		regionalCfg.Region = region
+	}
+	return newS3BucketClient(regionalCfg)
+}
+
+func normalizeS3BucketRegion(location types.BucketLocationConstraint) string {
+	region := strings.TrimSpace(string(location))
+	switch strings.ToUpper(region) {
+	case "", "US", "US-EAST-1":
+		return "us-east-1"
+	case "EU":
+		return "eu-west-1"
+	default:
+		return strings.ToLower(region)
+	}
+}
+
+func (e *SyncEngine) warnS3BucketOperation(table, bucket, region, operation string, err error, expectedCodes ...string) {
+	if err == nil || isS3ExpectedBucketError(err, expectedCodes...) || e.logger == nil {
+		return
+	}
+
+	args := []any{"bucket", bucket, "operation", operation, "error", err}
+	if region != "" {
+		args = append(args, "region", region)
+	}
+	if table != "" {
+		args = append([]any{"table", table}, args...)
+	}
+	e.logger.Warn("s3 bucket operation failed", args...)
+}
+
+func isS3ExpectedBucketError(err error, expectedCodes ...string) bool {
+	if len(expectedCodes) == 0 || err == nil {
+		return false
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	code := strings.ToLower(strings.TrimSpace(apiErr.ErrorCode()))
+	for _, expected := range expectedCodes {
+		if code == strings.ToLower(strings.TrimSpace(expected)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sync/s3_bucket_inventory_test.go
+++ b/internal/sync/s3_bucket_inventory_test.go
@@ -1,0 +1,526 @@
+package sync
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+type mockS3BucketClient struct {
+	listBucketsFn                        func(context.Context, *s3.ListBucketsInput, ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
+	getBucketLocationFn                  func(context.Context, *s3.GetBucketLocationInput, ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+	getBucketPolicyFn                    func(context.Context, *s3.GetBucketPolicyInput, ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error)
+	getBucketAclFn                       func(context.Context, *s3.GetBucketAclInput, ...func(*s3.Options)) (*s3.GetBucketAclOutput, error)
+	getBucketEncryptionFn                func(context.Context, *s3.GetBucketEncryptionInput, ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error)
+	getBucketVersioningFn                func(context.Context, *s3.GetBucketVersioningInput, ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
+	getBucketLoggingFn                   func(context.Context, *s3.GetBucketLoggingInput, ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error)
+	getPublicAccessBlockFn               func(context.Context, *s3.GetPublicAccessBlockInput, ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error)
+	getBucketOwnershipControlsFn         func(context.Context, *s3.GetBucketOwnershipControlsInput, ...func(*s3.Options)) (*s3.GetBucketOwnershipControlsOutput, error)
+	getBucketPolicyStatusFn              func(context.Context, *s3.GetBucketPolicyStatusInput, ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error)
+	getBucketNotificationConfigurationFn func(context.Context, *s3.GetBucketNotificationConfigurationInput, ...func(*s3.Options)) (*s3.GetBucketNotificationConfigurationOutput, error)
+	listBucketInventoryConfigurationsFn  func(context.Context, *s3.ListBucketInventoryConfigurationsInput, ...func(*s3.Options)) (*s3.ListBucketInventoryConfigurationsOutput, error)
+	getObjectLockConfigurationFn         func(context.Context, *s3.GetObjectLockConfigurationInput, ...func(*s3.Options)) (*s3.GetObjectLockConfigurationOutput, error)
+	getBucketLifecycleConfigurationFn    func(context.Context, *s3.GetBucketLifecycleConfigurationInput, ...func(*s3.Options)) (*s3.GetBucketLifecycleConfigurationOutput, error)
+	getBucketReplicationFn               func(context.Context, *s3.GetBucketReplicationInput, ...func(*s3.Options)) (*s3.GetBucketReplicationOutput, error)
+	listObjectsV2Fn                      func(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	getBucketCorsFn                      func(context.Context, *s3.GetBucketCorsInput, ...func(*s3.Options)) (*s3.GetBucketCorsOutput, error)
+	getBucketWebsiteFn                   func(context.Context, *s3.GetBucketWebsiteInput, ...func(*s3.Options)) (*s3.GetBucketWebsiteOutput, error)
+}
+
+func unexpectedS3Method(name string) error {
+	return fmt.Errorf("unexpected S3 call: %s", name)
+}
+
+func (m *mockS3BucketClient) ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+	if m.listBucketsFn != nil {
+		return m.listBucketsFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("ListBuckets")
+}
+
+func (m *mockS3BucketClient) GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+	if m.getBucketLocationFn != nil {
+		return m.getBucketLocationFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketLocation")
+}
+
+func (m *mockS3BucketClient) GetBucketPolicy(ctx context.Context, params *s3.GetBucketPolicyInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {
+	if m.getBucketPolicyFn != nil {
+		return m.getBucketPolicyFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketPolicy")
+}
+
+func (m *mockS3BucketClient) GetBucketAcl(ctx context.Context, params *s3.GetBucketAclInput, optFns ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
+	if m.getBucketAclFn != nil {
+		return m.getBucketAclFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketAcl")
+}
+
+func (m *mockS3BucketClient) GetBucketEncryption(ctx context.Context, params *s3.GetBucketEncryptionInput, optFns ...func(*s3.Options)) (*s3.GetBucketEncryptionOutput, error) {
+	if m.getBucketEncryptionFn != nil {
+		return m.getBucketEncryptionFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketEncryption")
+}
+
+func (m *mockS3BucketClient) GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+	if m.getBucketVersioningFn != nil {
+		return m.getBucketVersioningFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketVersioning")
+}
+
+func (m *mockS3BucketClient) GetBucketLogging(ctx context.Context, params *s3.GetBucketLoggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error) {
+	if m.getBucketLoggingFn != nil {
+		return m.getBucketLoggingFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketLogging")
+}
+
+func (m *mockS3BucketClient) GetPublicAccessBlock(ctx context.Context, params *s3.GetPublicAccessBlockInput, optFns ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+	if m.getPublicAccessBlockFn != nil {
+		return m.getPublicAccessBlockFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetPublicAccessBlock")
+}
+
+func (m *mockS3BucketClient) GetBucketOwnershipControls(ctx context.Context, params *s3.GetBucketOwnershipControlsInput, optFns ...func(*s3.Options)) (*s3.GetBucketOwnershipControlsOutput, error) {
+	if m.getBucketOwnershipControlsFn != nil {
+		return m.getBucketOwnershipControlsFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketOwnershipControls")
+}
+
+func (m *mockS3BucketClient) GetBucketPolicyStatus(ctx context.Context, params *s3.GetBucketPolicyStatusInput, optFns ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
+	if m.getBucketPolicyStatusFn != nil {
+		return m.getBucketPolicyStatusFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketPolicyStatus")
+}
+
+func (m *mockS3BucketClient) GetBucketNotificationConfiguration(ctx context.Context, params *s3.GetBucketNotificationConfigurationInput, optFns ...func(*s3.Options)) (*s3.GetBucketNotificationConfigurationOutput, error) {
+	if m.getBucketNotificationConfigurationFn != nil {
+		return m.getBucketNotificationConfigurationFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketNotificationConfiguration")
+}
+
+func (m *mockS3BucketClient) ListBucketInventoryConfigurations(ctx context.Context, params *s3.ListBucketInventoryConfigurationsInput, optFns ...func(*s3.Options)) (*s3.ListBucketInventoryConfigurationsOutput, error) {
+	if m.listBucketInventoryConfigurationsFn != nil {
+		return m.listBucketInventoryConfigurationsFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("ListBucketInventoryConfigurations")
+}
+
+func (m *mockS3BucketClient) GetObjectLockConfiguration(ctx context.Context, params *s3.GetObjectLockConfigurationInput, optFns ...func(*s3.Options)) (*s3.GetObjectLockConfigurationOutput, error) {
+	if m.getObjectLockConfigurationFn != nil {
+		return m.getObjectLockConfigurationFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetObjectLockConfiguration")
+}
+
+func (m *mockS3BucketClient) GetBucketLifecycleConfiguration(ctx context.Context, params *s3.GetBucketLifecycleConfigurationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLifecycleConfigurationOutput, error) {
+	if m.getBucketLifecycleConfigurationFn != nil {
+		return m.getBucketLifecycleConfigurationFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketLifecycleConfiguration")
+}
+
+func (m *mockS3BucketClient) GetBucketReplication(ctx context.Context, params *s3.GetBucketReplicationInput, optFns ...func(*s3.Options)) (*s3.GetBucketReplicationOutput, error) {
+	if m.getBucketReplicationFn != nil {
+		return m.getBucketReplicationFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketReplication")
+}
+
+func (m *mockS3BucketClient) ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	if m.listObjectsV2Fn != nil {
+		return m.listObjectsV2Fn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("ListObjectsV2")
+}
+
+func (m *mockS3BucketClient) GetBucketCors(ctx context.Context, params *s3.GetBucketCorsInput, optFns ...func(*s3.Options)) (*s3.GetBucketCorsOutput, error) {
+	if m.getBucketCorsFn != nil {
+		return m.getBucketCorsFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketCors")
+}
+
+func (m *mockS3BucketClient) GetBucketWebsite(ctx context.Context, params *s3.GetBucketWebsiteInput, optFns ...func(*s3.Options)) (*s3.GetBucketWebsiteOutput, error) {
+	if m.getBucketWebsiteFn != nil {
+		return m.getBucketWebsiteFn(ctx, params, optFns...)
+	}
+	return nil, unexpectedS3Method("GetBucketWebsite")
+}
+
+func withMockS3BucketClientFactory(t *testing.T, factory func(aws.Config, ...func(*s3.Options)) s3BucketClient) {
+	t.Helper()
+	original := newS3BucketClient
+	newS3BucketClient = factory
+	t.Cleanup(func() {
+		newS3BucketClient = original
+	})
+}
+
+func TestS3BucketFetchersReuseBucketInventoryAcrossTables(t *testing.T) {
+	var listBucketsCalls int
+	var getBucketLocationCalls int
+	var policyBuckets []string
+	var versioningBuckets []string
+
+	mockClient := &mockS3BucketClient{
+		listBucketsFn: func(context.Context, *s3.ListBucketsInput, ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+			listBucketsCalls++
+			createdAt := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+			return &s3.ListBucketsOutput{
+				Buckets: []types.Bucket{
+					{Name: aws.String("west-bucket"), CreationDate: &createdAt},
+					{Name: aws.String("east-bucket"), CreationDate: &createdAt},
+				},
+			}, nil
+		},
+		getBucketLocationFn: func(_ context.Context, input *s3.GetBucketLocationInput, _ ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+			getBucketLocationCalls++
+			switch aws.ToString(input.Bucket) {
+			case "west-bucket":
+				return &s3.GetBucketLocationOutput{LocationConstraint: types.BucketLocationConstraintUsWest2}, nil
+			case "east-bucket":
+				return &s3.GetBucketLocationOutput{}, nil
+			default:
+				return nil, fmt.Errorf("unexpected bucket %q", aws.ToString(input.Bucket))
+			}
+		},
+		getBucketPolicyFn: func(_ context.Context, input *s3.GetBucketPolicyInput, _ ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {
+			policyBuckets = append(policyBuckets, aws.ToString(input.Bucket))
+			return &s3.GetBucketPolicyOutput{Policy: aws.String(`{"Version":"2012-10-17"}`)}, nil
+		},
+		getBucketVersioningFn: func(_ context.Context, input *s3.GetBucketVersioningInput, _ ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+			versioningBuckets = append(versioningBuckets, aws.ToString(input.Bucket))
+			return &s3.GetBucketVersioningOutput{Status: types.BucketVersioningStatusEnabled}, nil
+		},
+	}
+
+	withMockS3BucketClientFactory(t, func(aws.Config, ...func(*s3.Options)) s3BucketClient {
+		return mockClient
+	})
+
+	engine := &SyncEngine{
+		accountID: "123456789012",
+		logger:    slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+	}
+
+	rows, err := engine.fetchS3BucketPolicies(context.Background(), aws.Config{}, "us-west-2")
+	if err != nil {
+		t.Fatalf("fetchS3BucketPolicies returned error: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["bucket"] != "west-bucket" {
+		t.Fatalf("unexpected policy rows: %+v", rows)
+	}
+
+	rows, err = engine.fetchS3BucketVersioning(context.Background(), aws.Config{}, "us-west-2")
+	if err != nil {
+		t.Fatalf("fetchS3BucketVersioning returned error: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["bucket"] != "west-bucket" {
+		t.Fatalf("unexpected versioning rows: %+v", rows)
+	}
+
+	if listBucketsCalls != 1 {
+		t.Fatalf("expected ListBuckets to run once across fetchers, got %d", listBucketsCalls)
+	}
+	if getBucketLocationCalls != 2 {
+		t.Fatalf("expected GetBucketLocation to run once per bucket, got %d", getBucketLocationCalls)
+	}
+	if len(policyBuckets) != 1 || policyBuckets[0] != "west-bucket" {
+		t.Fatalf("unexpected GetBucketPolicy calls: %v", policyBuckets)
+	}
+	if len(versioningBuckets) != 1 || versioningBuckets[0] != "west-bucket" {
+		t.Fatalf("unexpected GetBucketVersioning calls: %v", versioningBuckets)
+	}
+}
+
+func TestFetchS3BucketsUsesRegionalClientsForPerBucketCalls(t *testing.T) {
+	eastVersioningBuckets := []string{}
+	westVersioningBuckets := []string{}
+	eastPublicAccessBuckets := []string{}
+	westPublicAccessBuckets := []string{}
+	eastLoggingBuckets := []string{}
+	westLoggingBuckets := []string{}
+
+	eastClient := &mockS3BucketClient{
+		listBucketsFn: func(context.Context, *s3.ListBucketsInput, ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+			createdAt := time.Date(2024, time.January, 2, 0, 0, 0, 0, time.UTC)
+			return &s3.ListBucketsOutput{
+				Buckets: []types.Bucket{
+					{Name: aws.String("east-bucket"), CreationDate: &createdAt},
+					{Name: aws.String("west-bucket"), CreationDate: &createdAt},
+				},
+			}, nil
+		},
+		getBucketLocationFn: func(_ context.Context, input *s3.GetBucketLocationInput, _ ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+			switch aws.ToString(input.Bucket) {
+			case "east-bucket":
+				return &s3.GetBucketLocationOutput{}, nil
+			case "west-bucket":
+				return &s3.GetBucketLocationOutput{LocationConstraint: types.BucketLocationConstraintUsWest2}, nil
+			default:
+				return nil, fmt.Errorf("unexpected bucket %q", aws.ToString(input.Bucket))
+			}
+		},
+		getPublicAccessBlockFn: func(_ context.Context, input *s3.GetPublicAccessBlockInput, _ ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+			eastPublicAccessBuckets = append(eastPublicAccessBuckets, aws.ToString(input.Bucket))
+			return &s3.GetPublicAccessBlockOutput{
+				PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{
+					BlockPublicAcls:       aws.Bool(true),
+					BlockPublicPolicy:     aws.Bool(true),
+					IgnorePublicAcls:      aws.Bool(true),
+					RestrictPublicBuckets: aws.Bool(true),
+				},
+			}, nil
+		},
+		getBucketVersioningFn: func(_ context.Context, input *s3.GetBucketVersioningInput, _ ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+			eastVersioningBuckets = append(eastVersioningBuckets, aws.ToString(input.Bucket))
+			return &s3.GetBucketVersioningOutput{Status: types.BucketVersioningStatusEnabled}, nil
+		},
+		getBucketLoggingFn: func(_ context.Context, input *s3.GetBucketLoggingInput, _ ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error) {
+			eastLoggingBuckets = append(eastLoggingBuckets, aws.ToString(input.Bucket))
+			return &s3.GetBucketLoggingOutput{
+				LoggingEnabled: &types.LoggingEnabled{
+					TargetBucket: aws.String("logs-east"),
+					TargetPrefix: aws.String("east/"),
+				},
+			}, nil
+		},
+	}
+
+	westClient := &mockS3BucketClient{
+		getPublicAccessBlockFn: func(_ context.Context, input *s3.GetPublicAccessBlockInput, _ ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+			westPublicAccessBuckets = append(westPublicAccessBuckets, aws.ToString(input.Bucket))
+			return &s3.GetPublicAccessBlockOutput{
+				PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{
+					BlockPublicAcls:       aws.Bool(false),
+					BlockPublicPolicy:     aws.Bool(false),
+					IgnorePublicAcls:      aws.Bool(false),
+					RestrictPublicBuckets: aws.Bool(false),
+				},
+			}, nil
+		},
+		getBucketVersioningFn: func(_ context.Context, input *s3.GetBucketVersioningInput, _ ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+			westVersioningBuckets = append(westVersioningBuckets, aws.ToString(input.Bucket))
+			return &s3.GetBucketVersioningOutput{Status: types.BucketVersioningStatusSuspended}, nil
+		},
+		getBucketLoggingFn: func(_ context.Context, input *s3.GetBucketLoggingInput, _ ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error) {
+			westLoggingBuckets = append(westLoggingBuckets, aws.ToString(input.Bucket))
+			return &s3.GetBucketLoggingOutput{
+				LoggingEnabled: &types.LoggingEnabled{
+					TargetBucket: aws.String("logs-west"),
+					TargetPrefix: aws.String("west/"),
+				},
+			}, nil
+		},
+	}
+
+	withMockS3BucketClientFactory(t, func(cfg aws.Config, _ ...func(*s3.Options)) s3BucketClient {
+		if cfg.Region == "us-west-2" {
+			return westClient
+		}
+		return eastClient
+	})
+
+	engine := &SyncEngine{
+		accountID: "123456789012",
+		logger:    slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+	}
+
+	rows, err := engine.fetchS3Buckets(context.Background(), aws.Config{Region: "us-east-1"}, "us-east-1")
+	if err != nil {
+		t.Fatalf("fetchS3Buckets returned error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 bucket rows, got %d", len(rows))
+	}
+
+	if strings.Join(eastPublicAccessBuckets, ",") != "east-bucket" || strings.Join(eastVersioningBuckets, ",") != "east-bucket" || strings.Join(eastLoggingBuckets, ",") != "east-bucket" {
+		t.Fatalf("expected east client to service only east bucket, got pab=%v versioning=%v logging=%v", eastPublicAccessBuckets, eastVersioningBuckets, eastLoggingBuckets)
+	}
+	if strings.Join(westPublicAccessBuckets, ",") != "west-bucket" || strings.Join(westVersioningBuckets, ",") != "west-bucket" || strings.Join(westLoggingBuckets, ",") != "west-bucket" {
+		t.Fatalf("expected west client to service only west bucket, got pab=%v versioning=%v logging=%v", westPublicAccessBuckets, westVersioningBuckets, westLoggingBuckets)
+	}
+
+	rowByBucket := make(map[string]map[string]interface{}, len(rows))
+	for _, row := range rows {
+		rowByBucket[row["name"].(string)] = row
+	}
+	if got := rowByBucket["east-bucket"]["region"]; got != "us-east-1" {
+		t.Fatalf("expected east-bucket region us-east-1, got %v", got)
+	}
+	if got := rowByBucket["west-bucket"]["region"]; got != "us-west-2" {
+		t.Fatalf("expected west-bucket region us-west-2, got %v", got)
+	}
+	if got := rowByBucket["west-bucket"]["versioning_status"]; got != string(types.BucketVersioningStatusSuspended) {
+		t.Fatalf("expected west-bucket versioning from west client, got %v", got)
+	}
+}
+
+func TestFetchS3BucketPoliciesLogsUnexpectedBucketErrors(t *testing.T) {
+	var logs bytes.Buffer
+
+	mockClient := &mockS3BucketClient{
+		listBucketsFn: func(context.Context, *s3.ListBucketsInput, ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+			createdAt := time.Date(2024, time.January, 3, 0, 0, 0, 0, time.UTC)
+			return &s3.ListBucketsOutput{
+				Buckets: []types.Bucket{{Name: aws.String("policy-bucket"), CreationDate: &createdAt}},
+			}, nil
+		},
+		getBucketLocationFn: func(context.Context, *s3.GetBucketLocationInput, ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+			return &s3.GetBucketLocationOutput{LocationConstraint: types.BucketLocationConstraintUsWest2}, nil
+		},
+		getBucketPolicyFn: func(context.Context, *s3.GetBucketPolicyInput, ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {
+			return nil, &smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"}
+		},
+	}
+
+	withMockS3BucketClientFactory(t, func(aws.Config, ...func(*s3.Options)) s3BucketClient {
+		return mockClient
+	})
+
+	engine := &SyncEngine{
+		accountID: "123456789012",
+		logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	}
+
+	rows, err := engine.fetchS3BucketPolicies(context.Background(), aws.Config{}, "us-west-2")
+	if err != nil {
+		t.Fatalf("fetchS3BucketPolicies returned error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected no rows on denied bucket policy fetch, got %d", len(rows))
+	}
+
+	output := logs.String()
+	if !strings.Contains(output, "table=aws_s3_bucket_policies") || !strings.Contains(output, "bucket=policy-bucket") || !strings.Contains(output, "operation=GetBucketPolicy") {
+		t.Fatalf("expected warning log for denied bucket policy fetch, got %q", output)
+	}
+}
+
+func TestS3BucketsDoesNotCacheDiscoveryFailures(t *testing.T) {
+	var listBucketsCalls int
+
+	mockClient := &mockS3BucketClient{
+		listBucketsFn: func(context.Context, *s3.ListBucketsInput, ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+			listBucketsCalls++
+			if listBucketsCalls == 1 {
+				return nil, fmt.Errorf("temporary failure")
+			}
+			createdAt := time.Date(2024, time.January, 4, 0, 0, 0, 0, time.UTC)
+			return &s3.ListBucketsOutput{
+				Buckets: []types.Bucket{{Name: aws.String("retry-bucket"), CreationDate: &createdAt}},
+			}, nil
+		},
+		getBucketLocationFn: func(context.Context, *s3.GetBucketLocationInput, ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+			return &s3.GetBucketLocationOutput{LocationConstraint: types.BucketLocationConstraintUsWest2}, nil
+		},
+	}
+
+	withMockS3BucketClientFactory(t, func(aws.Config, ...func(*s3.Options)) s3BucketClient {
+		return mockClient
+	})
+
+	engine := &SyncEngine{
+		accountID: "123456789012",
+		logger:    slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+	}
+
+	if _, err := engine.s3Buckets(context.Background(), aws.Config{}); err == nil {
+		t.Fatal("expected first discovery call to fail")
+	}
+
+	buckets, err := engine.s3Buckets(context.Background(), aws.Config{})
+	if err != nil {
+		t.Fatalf("expected second discovery call to succeed, got %v", err)
+	}
+	if listBucketsCalls != 2 {
+		t.Fatalf("expected discovery to retry after failure, got %d ListBuckets calls", listBucketsCalls)
+	}
+	if len(buckets) != 1 || buckets[0].Name != "retry-bucket" {
+		t.Fatalf("unexpected buckets after retry: %+v", buckets)
+	}
+}
+
+func TestFetchS3BucketsPreservesBucketsWhenLocationLookupFails(t *testing.T) {
+	var logs bytes.Buffer
+
+	mockClient := &mockS3BucketClient{
+		listBucketsFn: func(context.Context, *s3.ListBucketsInput, ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
+			createdAt := time.Date(2024, time.January, 5, 0, 0, 0, 0, time.UTC)
+			return &s3.ListBucketsOutput{
+				Buckets: []types.Bucket{{Name: aws.String("unknown-region-bucket"), CreationDate: &createdAt}},
+			}, nil
+		},
+		getBucketLocationFn: func(context.Context, *s3.GetBucketLocationInput, ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+			return nil, &smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"}
+		},
+		getPublicAccessBlockFn: func(context.Context, *s3.GetPublicAccessBlockInput, ...func(*s3.Options)) (*s3.GetPublicAccessBlockOutput, error) {
+			return &s3.GetPublicAccessBlockOutput{
+				PublicAccessBlockConfiguration: &types.PublicAccessBlockConfiguration{
+					BlockPublicAcls: aws.Bool(true),
+				},
+			}, nil
+		},
+		getBucketVersioningFn: func(context.Context, *s3.GetBucketVersioningInput, ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+			return &s3.GetBucketVersioningOutput{Status: types.BucketVersioningStatusEnabled}, nil
+		},
+		getBucketLoggingFn: func(context.Context, *s3.GetBucketLoggingInput, ...func(*s3.Options)) (*s3.GetBucketLoggingOutput, error) {
+			return &s3.GetBucketLoggingOutput{
+				LoggingEnabled: &types.LoggingEnabled{
+					TargetBucket: aws.String("logs"),
+					TargetPrefix: aws.String("prefix/"),
+				},
+			}, nil
+		},
+	}
+
+	withMockS3BucketClientFactory(t, func(aws.Config, ...func(*s3.Options)) s3BucketClient {
+		return mockClient
+	})
+
+	engine := &SyncEngine{
+		accountID: "123456789012",
+		logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	}
+
+	rows, err := engine.fetchS3Buckets(context.Background(), aws.Config{Region: "us-east-1"}, "us-east-1")
+	if err != nil {
+		t.Fatalf("fetchS3Buckets returned error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected one bucket row, got %d", len(rows))
+	}
+
+	row := rows[0]
+	if row["name"] != "unknown-region-bucket" {
+		t.Fatalf("unexpected bucket row: %+v", row)
+	}
+	if _, ok := row["region"]; ok {
+		t.Fatalf("expected bucket row without region when location lookup fails, got %+v", row)
+	}
+	if row["versioning_status"] != string(types.BucketVersioningStatusEnabled) {
+		t.Fatalf("expected follow-on bucket calls to still populate row, got %+v", row)
+	}
+	if !strings.Contains(logs.String(), "operation=GetBucketLocation") {
+		t.Fatalf("expected location warning log, got %q", logs.String())
+	}
+}

--- a/internal/sync/tables_s3.go
+++ b/internal/sync/tables_s3.go
@@ -20,37 +20,23 @@ func (e *SyncEngine) s3BucketPolicyTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketPolicies(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		// Get bucket location to filter by region
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		policyOut, err := client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_policies", bucketName, bucketRegion, "GetBucketPolicy", err, "NoSuchBucketPolicy")
 			continue // No policy
 		}
 
@@ -77,36 +63,23 @@ func (e *SyncEngine) s3BucketGrantTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketGrants(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		aclOut, err := client.GetBucketAcl(ctx, &s3.GetBucketAclInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_grants", bucketName, bucketRegion, "GetBucketAcl", err)
 			continue
 		}
 
@@ -147,36 +120,23 @@ func (e *SyncEngine) s3BucketEncryptionTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketEncryption(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		encOut, err := client.GetBucketEncryption(ctx, &s3.GetBucketEncryptionInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_encryption_rules", bucketName, bucketRegion, "GetBucketEncryption", err, "ServerSideEncryptionConfigurationNotFoundError")
 			continue // No encryption config
 		}
 
@@ -219,36 +179,23 @@ func (e *SyncEngine) s3BucketVersioningTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketVersioning(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		verOut, err := client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_versionings", bucketName, bucketRegion, "GetBucketVersioning", err)
 			continue
 		}
 
@@ -276,36 +223,23 @@ func (e *SyncEngine) s3BucketLoggingTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketLogging(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		logOut, err := client.GetBucketLogging(ctx, &s3.GetBucketLoggingInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_loggings", bucketName, bucketRegion, "GetBucketLogging", err)
 			continue
 		}
 
@@ -339,36 +273,23 @@ func (e *SyncEngine) s3BucketPublicAccessBlockTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketPublicAccessBlock(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		pabOut, err := client.GetPublicAccessBlock(ctx, &s3.GetPublicAccessBlockInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_public_access_blocks", bucketName, bucketRegion, "GetPublicAccessBlock", err, "NoSuchPublicAccessBlockConfiguration")
 			// No public access block config - record as all false
 			arn := fmt.Sprintf("arn:aws:s3:::%s/public-access-block", bucketName)
 			rows = append(rows, map[string]interface{}{
@@ -412,37 +333,24 @@ func (e *SyncEngine) s3BucketOwnershipControlsTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketOwnershipControls(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		var rules interface{}
 		objectOwnership := ""
 		ownershipOut, err := client.GetBucketOwnershipControls(ctx, &s3.GetBucketOwnershipControlsInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
+		e.warnS3BucketOperation("aws_s3_bucket_ownership_controls", bucketName, bucketRegion, "GetBucketOwnershipControls", err, "OwnershipControlsNotFoundError")
 		if err == nil && ownershipOut.OwnershipControls != nil {
 			rules = ownershipOut.OwnershipControls.Rules
 			if len(ownershipOut.OwnershipControls.Rules) > 0 {
@@ -475,36 +383,23 @@ func (e *SyncEngine) s3BucketPolicyStatusTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketPolicyStatuses(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		isPublic := false
 		statusOut, err := client.GetBucketPolicyStatus(ctx, &s3.GetBucketPolicyStatusInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
+		e.warnS3BucketOperation("aws_s3_bucket_policy_statuses", bucketName, bucketRegion, "GetBucketPolicyStatus", err, "NoSuchBucketPolicy")
 		if err == nil && statusOut.PolicyStatus != nil {
 			isPublic = aws.ToBool(statusOut.PolicyStatus.IsPublic)
 		}
@@ -533,36 +428,23 @@ func (e *SyncEngine) s3BucketNotificationTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketNotifications(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		conf, err := client.GetBucketNotificationConfiguration(ctx, &s3.GetBucketNotificationConfigurationInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_notifications", bucketName, bucketRegion, "GetBucketNotificationConfiguration", err)
 			continue
 		}
 
@@ -593,39 +475,26 @@ func (e *SyncEngine) s3BucketInventoryTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketInventoryConfigurations(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		var continuationToken *string
 		for {
 			out, err := client.ListBucketInventoryConfigurations(ctx, &s3.ListBucketInventoryConfigurationsInput{
-				Bucket:            bucket.Name,
+				Bucket:            aws.String(bucketName),
 				ContinuationToken: continuationToken,
 			})
 			if err != nil {
+				e.warnS3BucketOperation("aws_s3_bucket_inventory_configurations", bucketName, bucketRegion, "ListBucketInventoryConfigurations", err)
 				break
 			}
 			for _, cfg := range out.InventoryConfigurationList {
@@ -667,35 +536,22 @@ func (e *SyncEngine) s3BucketObjectLockTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketObjectLockConfigurations(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		lockOut, err := client.GetObjectLockConfiguration(ctx, &s3.GetObjectLockConfigurationInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
+		e.warnS3BucketOperation("aws_s3_bucket_object_lock_configurations", bucketName, bucketRegion, "GetObjectLockConfiguration", err, "ObjectLockConfigurationNotFoundError")
 		if err != nil || lockOut.ObjectLockConfiguration == nil {
 			continue
 		}
@@ -811,36 +667,23 @@ func (e *SyncEngine) s3BucketLifecycleTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketLifecycle(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		lcOut, err := client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_lifecycles", bucketName, bucketRegion, "GetBucketLifecycleConfiguration", err, "NoSuchLifecycleConfiguration")
 			continue // No lifecycle config
 		}
 
@@ -917,36 +760,23 @@ func (e *SyncEngine) s3BucketReplicationTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketReplication(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		repOut, err := client.GetBucketReplication(ctx, &s3.GetBucketReplicationInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_replications", bucketName, bucketRegion, "GetBucketReplication", err, "ReplicationConfigurationNotFoundError")
 			continue // No replication config
 		}
 
@@ -985,38 +815,20 @@ func (e *SyncEngine) s3ObjectTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3Objects(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
-
-		bucketClient := s3.NewFromConfig(cfg, func(o *s3.Options) {
-			o.Region = bucketRegion
-		})
-
-		pager := s3.NewListObjectsV2Paginator(bucketClient, &s3.ListObjectsV2Input{
-			Bucket: bucket.Name,
+		pager := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{
+			Bucket: aws.String(bucketName),
 		})
 
 		for pager.HasMorePages() {
@@ -1064,36 +876,23 @@ func (e *SyncEngine) fetchS3Objects(ctx context.Context, cfg aws.Config, region 
 }
 
 func (e *SyncEngine) fetchS3BucketCors(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		corsOut, err := client.GetBucketCors(ctx, &s3.GetBucketCorsInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_cors_rules", bucketName, bucketRegion, "GetBucketCors", err, "NoSuchCORSConfiguration")
 			continue // No CORS config
 		}
 
@@ -1126,36 +925,23 @@ func (e *SyncEngine) s3BucketWebsiteTable() TableSpec {
 }
 
 func (e *SyncEngine) fetchS3BucketWebsite(ctx context.Context, cfg aws.Config, region string) ([]map[string]interface{}, error) {
-	client := s3.NewFromConfig(cfg)
+	client := newS3BucketRegionalClient(cfg, region)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	bucketsOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3BucketsInRegion(ctx, cfg, region)
 	if err != nil {
 		return nil, err
 	}
 
 	var rows []map[string]interface{}
-	for _, bucket := range bucketsOut.Buckets {
-		bucketName := aws.ToString(bucket.Name)
-
-		locOut, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-			Bucket: bucket.Name,
-		})
-		if err != nil {
-			continue
-		}
-		bucketRegion := string(locOut.LocationConstraint)
-		if bucketRegion == "" {
-			bucketRegion = "us-east-1"
-		}
-		if bucketRegion != region {
-			continue
-		}
+	for _, bucket := range buckets {
+		bucketName := bucket.Name
+		bucketRegion := bucket.Region
 
 		webOut, err := client.GetBucketWebsite(ctx, &s3.GetBucketWebsiteInput{
-			Bucket: bucket.Name,
+			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
+			e.warnS3BucketOperation("aws_s3_bucket_websites", bucketName, bucketRegion, "GetBucketWebsite", err, "NoSuchWebsiteConfiguration")
 			continue // No website config
 		}
 

--- a/internal/sync/tables_storage.go
+++ b/internal/sync/tables_storage.go
@@ -22,18 +22,25 @@ func (e *SyncEngine) fetchS3Buckets(ctx context.Context, cfg aws.Config, region 
 		return nil, nil
 	}
 
-	client := s3.NewFromConfig(cfg)
 	accountID := e.getAccountIDFromConfig(ctx, cfg)
-
-	listOut, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	buckets, err := e.s3Buckets(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	rows := make([]map[string]interface{}, 0, len(listOut.Buckets))
-	for _, bucket := range listOut.Buckets {
-		name := aws.ToString(bucket.Name)
+	clientByRegion := make(map[string]s3BucketClient)
+	rows := make([]map[string]interface{}, 0, len(buckets))
+	for _, bucket := range buckets {
+		name := bucket.Name
 		arn := fmt.Sprintf("arn:aws:s3:::%s", name)
+		bucketRegion := bucket.Region
+		clientRegion := bucketRegion
+		if clientRegion == "" {
+			clientRegion = cfg.Region
+		}
+		if clientRegion == "" {
+			clientRegion = "us-east-1"
+		}
 
 		row := map[string]interface{}{
 			"_cq_id":        arn,
@@ -42,14 +49,14 @@ func (e *SyncEngine) fetchS3Buckets(ctx context.Context, cfg aws.Config, region 
 			"account_id":    accountID,
 			"creation_date": bucket.CreationDate,
 		}
-
-		// Get bucket location
-		if loc, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{Bucket: &name}); err == nil {
-			bucketRegion := string(loc.LocationConstraint)
-			if bucketRegion == "" {
-				bucketRegion = "us-east-1"
-			}
+		if bucketRegion != "" {
 			row["region"] = bucketRegion
+		}
+
+		client := clientByRegion[clientRegion]
+		if client == nil {
+			client = newS3BucketRegionalClient(cfg, clientRegion)
+			clientByRegion[clientRegion] = client
 		}
 
 		// Get public access block
@@ -59,6 +66,7 @@ func (e *SyncEngine) fetchS3Buckets(ctx context.Context, cfg aws.Config, region 
 			row["ignore_public_acls"] = aws.ToBool(pab.PublicAccessBlockConfiguration.IgnorePublicAcls)
 			row["restrict_public_buckets"] = aws.ToBool(pab.PublicAccessBlockConfiguration.RestrictPublicBuckets)
 		} else {
+			e.warnS3BucketOperation("aws_s3_buckets", name, bucketRegion, "GetPublicAccessBlock", err, "NoSuchPublicAccessBlockConfiguration")
 			row["block_public_acls"] = false
 			row["block_public_policy"] = false
 			row["ignore_public_acls"] = false
@@ -69,12 +77,16 @@ func (e *SyncEngine) fetchS3Buckets(ctx context.Context, cfg aws.Config, region 
 		if vers, err := client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: &name}); err == nil {
 			row["versioning_status"] = string(vers.Status)
 			row["versioning_mfa_delete"] = string(vers.MFADelete)
+		} else {
+			e.warnS3BucketOperation("aws_s3_buckets", name, bucketRegion, "GetBucketVersioning", err)
 		}
 
 		// Get logging
 		if log, err := client.GetBucketLogging(ctx, &s3.GetBucketLoggingInput{Bucket: &name}); err == nil && log.LoggingEnabled != nil {
 			row["logging_target_bucket"] = aws.ToString(log.LoggingEnabled.TargetBucket)
 			row["logging_target_prefix"] = aws.ToString(log.LoggingEnabled.TargetPrefix)
+		} else if err != nil {
+			e.warnS3BucketOperation("aws_s3_buckets", name, bucketRegion, "GetBucketLogging", err)
 		}
 
 		rows = append(rows, row)


### PR DESCRIPTION
## Summary
- cache S3 bucket discovery on the sync engine so S3 table fetchers reuse one ListBuckets/GetBucketLocation pass per run
- reuse discovered bucket regions to scope per-table S3 fetches and use region-aware clients for the global aws_s3_buckets table
- warn on unexpected per-bucket S3 API failures and add regressions for cache reuse, regional clients, warning paths, retry behavior, and location lookup failures

Closes #346

## Testing
- go test ./internal/sync
- python3 ./scripts/devex.py run --mode changed --base-ref writer/main