### PR TITLE
feat(linters): PLAN.md + cerebrolint multichecker (invariant enforcers, PR 1/3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test sync clean dev serve policy-list docker-build trivy-db security-scan security-scan-built security-scan-source vendor vendor-check oss-audit openapi-check openapi-sync api-contract-docs api-contract-docs-check api-contract-compat config-docs config-docs-check ontology-docs ontology-docs-check cloudevents-docs cloudevents-docs-check cloudevents-contract-compat report-contract-docs report-contract-docs-check report-contract-compat entity-facet-docs entity-facet-docs-check entity-facet-contract-compat agent-sdk-docs agent-sdk-docs-check agent-sdk-contract-compat agent-sdk-packages agent-sdk-packages-check connector-docs connector-docs-check graph-ontology-guardrails gosec govulncheck devex-codegen devex-codegen-check devex-changed devex-pr platform-up platform-down platform-logs platform-smoke hooks pre-commit verify
+.PHONY: build run test sync clean dev serve policy-list docker-build trivy-db security-scan security-scan-built security-scan-source vendor vendor-check oss-audit openapi-check openapi-sync api-contract-docs api-contract-docs-check api-contract-compat config-docs config-docs-check ontology-docs ontology-docs-check cloudevents-docs cloudevents-docs-check cloudevents-contract-compat report-contract-docs report-contract-docs-check report-contract-compat entity-facet-docs entity-facet-docs-check entity-facet-contract-compat agent-sdk-docs agent-sdk-docs-check agent-sdk-contract-compat agent-sdk-packages agent-sdk-packages-check connector-docs connector-docs-check graph-ontology-guardrails gosec govulncheck devex-codegen devex-codegen-check devex-changed devex-pr platform-up platform-down platform-logs platform-smoke hooks pre-commit verify check check-structural check-structural-build check-structural-test
 
 # Version info
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -260,12 +260,40 @@ pre-commit:
 verify:
 	go test -race ./...
 	$(MAKE) lint
+	$(MAKE) check-structural
 	$(MAKE) api-contract-compat
 	$(MAKE) cloudevents-contract-compat
 	$(MAKE) report-contract-compat
 	$(MAKE) entity-facet-contract-compat
 	$(MAKE) agent-sdk-contract-compat
 	$(MAKE) graph-ontology-guardrails
+
+# -----------------------------------------------------------------------------
+# Structural invariants — see PLAN.md §7 and tools/linters/README.md.
+#
+# tools/linters/ is a SEPARATE Go module so that its build-only dependencies
+# (golang.org/x/tools) never reach the runtime vendor tree.
+# -----------------------------------------------------------------------------
+
+LINTER_MODULE := ./tools/linters
+LINTER_BIN    := $(GO_BIN)/cerebrolint
+
+.PHONY: check check-structural check-structural-build check-structural-test
+
+# Aggregate developer entrypoint.
+check: check-structural
+
+# Run every custom analyzer in the cerebrolint multichecker against the
+# main module.
+check-structural: check-structural-build
+	@$(LINTER_BIN) ./...
+
+check-structural-build:
+	@GOFLAGS= cd $(LINTER_MODULE) && go build -o $(LINTER_BIN) ./cerebrolint
+
+# Run the analyzer unit tests against their golden fixtures.
+check-structural-test:
+	@GOFLAGS= cd $(LINTER_MODULE) && go test ./...
 
 # Full local setup
 setup: install-deps build hooks

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,396 @@
+# PLAN — Cerebro Next: Primitives, Stores, and Invariant Enforcement
+
+> Status: DRAFT (initial landing, intended for PR discussion)
+> Branch: `feat/cerebro-next-invariants-20260422`
+> Owner: Platform
+> Last updated: 2026-04-22
+
+This document describes a ground-up redesign of Cerebro collapsed onto the smallest set of common primitives, backed by exactly three stores, with structural enforcement of the architectural invariants that caused the current codebase to decay.
+
+It is both a **design doc** and a **contract**: every design decision in §3–§6 has a machine-checked rule in §7. The first concrete deliverable on this branch is the linter framework that enforces §7, independent of any migration decision.
+
+---
+
+## 0. TL;DR
+
+1. **Six primitives** — `Event`, `Stream`, `View`, `Rule`, `Action`, `Agent`. Everything else (providers, findings, scans, checks, reports, nudges, runbooks) is an arrangement of these six.
+2. **Three stores** — `JetStream` is the log of record; `Postgres` is current state and OLTP; `Kuzu` is a graph projection for traversal queries. No fourth store. No in-memory fallback.
+3. **Sources are a CDK** — each integration is a self-contained Go module (≤300 LOC budget) behind a `Source` interface, vendored cleanly. The CDK is the *only* way to reach the outside world.
+4. **Invariants are enforced structurally**, not by convention. 18 cardinal sins have lint rules; each rule fails CI, not review.
+5. **Graph is second-class by intent**. All entities & findings live in Postgres; Kuzu contains URNs + edges only and is rebuilt from JetStream.
+
+---
+
+## 1. Problem statement
+
+The current Cerebro exhibits every symptom of a system that grew faster than its skeleton:
+
+| Symptom | Evidence (writer/main @ 8fa3f1ba2) |
+|---|---|
+| God-struct `*App` | 120+ fields, 8 mutexes, touched by every subsystem |
+| Config bloat | `Config` struct: 372 exported fields |
+| Graph god-struct | `Graph` struct: 44 fields |
+| Provider duplication | 46 providers, ~2,400 LOC of duplicated HTTP/retry/pagination/error-wrapping |
+| Silent errors | 1,802 `fmt.Errorf` without `%w` |
+| Hook-driven tests | 38 package-level `var X = func(...)` test seams |
+| Env-driven control flow | 172 `os.Getenv` calls outside `cmd/` |
+| String-sniffed errors | 74 `strings.Contains(err.Error(), …)` |
+| Unbounded resources | 31 places create goroutines without a `context.Context` tied to lifecycle |
+| In-memory fallback | SQLite fallback compiled into production binary |
+
+The common root cause is the same in every case: **invariants exist only in reviewers' heads**. The goal of this branch is to end that pattern — first by restating the design, then by making violations structurally impossible before new code lands.
+
+---
+
+## 2. Goals & non-goals
+
+### Goals
+
+- Collapse the existing surface area onto the six primitives and three stores.
+- Make the new design the *default* path; legacy subsystems adapt to it.
+- Eliminate every class of bug in §7 by making violations fail `make check`.
+- Keep local dev friction-free: `docker compose up` runs everything with no cloud dependency.
+- Keep the runtime cloud-agnostic: no AWS/GCP/Azure-specific control plane.
+
+### Non-goals
+
+- Rewriting all 46 providers in a single push. Providers migrate onto the Source CDK incrementally.
+- Replacing Postgres or JetStream with something exotic. Both are boring, proven, and operable.
+- Shipping an in-memory mode "for local dev". Local dev is Postgres + JetStream + Kuzu via compose, always.
+
+---
+
+## 3. Architecture — three stores
+
+```
+                    ┌────────────────────────────────────────────┐
+                    │                  Sources                   │
+                    │  (CDK plugins: GitHub, Okta, AWS, Slack…)  │
+                    └─────────────────────┬──────────────────────┘
+                                          │ CloudEvents
+                                          ▼
+                  ┌────────────────────────────────────────────────┐
+                  │           JetStream (source of truth)           │
+                  │  ENTITIES · EVENTS · FINDINGS · ACTIONS · AUDIT  │
+                  └──────────┬──────────────────────────┬──────────┘
+                             │                          │
+                             ▼                          ▼
+                 ┌───────────────────────┐    ┌──────────────────────┐
+                 │  Postgres projection  │    │   Kuzu projection    │
+                 │  (current state, TS)  │    │   (graph traversals) │
+                 └───────────┬───────────┘    └──────────┬───────────┘
+                             │                           │
+                             └───────────┬───────────────┘
+                                         ▼
+                        ┌────────────────────────────────┐
+                        │   Query/Rule/Action runtimes    │
+                        │  (SQL + Cypher, authored once)  │
+                        └────────────────────────────────┘
+```
+
+### 3.1 JetStream — source of truth
+
+JetStream is the only writable long-term substrate. Every other store is a rebuildable projection.
+
+Stream configuration:
+
+| Stream     | Subjects                          | Retention  | Dedup window | Replicas |
+|------------|-----------------------------------|-----------:|-------------:|---------:|
+| `ENTITIES` | `entity.*`                        | 30 d       | 24 h         | 3        |
+| `EVENTS`   | `event.*`                         | 90 d       | 1 h          | 3        |
+| `FINDINGS` | `finding.*`                       | 2 y        | 24 h         | 3        |
+| `ACTIONS`  | `action.*`                        | 180 d      | 24 h         | 3        |
+| `AUDIT`    | `audit.*`                         | 7 y (WORM) | off          | 5        |
+| `AGENT`    | `agent.*`                         | 30 d       | 1 h          | 3        |
+| `DLQ`      | `*.dlq`                           | 14 d       | off          | 3        |
+
+Subject taxonomy is append-only and versioned via a leading segment: `event.v1.cloudtrail.console_login`. `v0` is disallowed in code.
+
+Dedup is performed with `Nats-Msg-Id = sha256(tenant|source|external_id|event_time)`. No other dedup mechanism is permitted.
+
+The **killer capability** this unlocks is `cerebro replay`: rebuild Postgres/Kuzu from JetStream for a tenant, for a rule, or for a bug, at any past point in time.
+
+### 3.2 Postgres — current state
+
+Postgres holds:
+
+- `entities` — URN-keyed current state (no history; history lives in `EVENTS`).
+- `events` — TimescaleDB hypertable, `PARTITION BY LIST (tenant_id), PARTITION BY RANGE (event_time)`.
+- `findings` — fingerprinted, tsvector-indexed, attached to 1..n entities, with lifecycle (open/suppressed/resolved).
+- `rule_state` — counters, windows, dedup for correlation rules.
+- `control_plane` — users, tenants, connectors, destinations, rule definitions.
+
+Conventions:
+
+- One schema per tenant for large tenants, one row per small tenant. No `WHERE tenant_id = $1` sprinkled in application code — it lives in `search_path`.
+- `pg_trgm` + `tsvector` for all user-facing search.
+- `LISTEN/NOTIFY` is **not** used for business logic. Notifications come from JetStream.
+
+### 3.3 Kuzu — graph projection
+
+Kuzu is an embedded graph DB. It holds URNs and edges, not entity bodies.
+
+- **Write path:** a single consumer reads `entity.*` from JetStream and applies MERGE/DETACH to Kuzu.
+- **Read path:** traversal queries only. No analytical SQL via Kuzu. No Kuzu writes from anywhere else.
+- **Schema shape:** ≤20 indexed attributes per node type, ≤6 hops per query, URNs are the only identifier.
+- **Rebuild budget:** full rebuild from JetStream must fit in ≤1 h for a median tenant.
+
+### 3.4 Split line
+
+| Query shape                                            | Store    |
+|--------------------------------------------------------|----------|
+| "Current state of entity X"                            | Postgres |
+| "Events for entity X between T1 and T2"                | Postgres (Timescale) |
+| "Findings matching fingerprint X, open, since T"       | Postgres |
+| "All public S3 buckets reachable from role R"          | Kuzu     |
+| "Blast radius of identity I in ≤4 hops"                | Kuzu     |
+| "Replay from T0, apply rule R, emit findings"          | JetStream → worker → PG |
+
+Rules that cross the split line are forbidden. If a rule needs both, it runs twice and joins at the application layer.
+
+---
+
+## 4. The six primitives
+
+All user-facing concepts decompose to exactly one of these:
+
+```go
+// Every input to the system.
+type Event struct {
+    ID         string            // content-addressed
+    Tenant     string
+    Source     string            // URN of the source
+    Type       string            // dotted, versioned: event.v1.cloudtrail.console_login
+    OccurredAt time.Time
+    Body       proto.Message     // typed per Type; never map[string]any
+}
+
+// A named, durable ordering of Events.
+type Stream interface {
+    Publish(ctx context.Context, e Event) error
+    Subscribe(ctx context.Context, filter string, h Handler) (Subscription, error)
+}
+
+// A read-only materialization over one or more Streams.
+type View interface {
+    Query(ctx context.Context, q Query) (Cursor, error)
+    Freshness() time.Duration
+}
+
+// A deterministic function from Events/Views to Findings (0..n).
+type Rule interface {
+    Spec() RuleSpec            // declarative: inputs, outputs, SLO
+    Eval(ctx context.Context, in In) ([]Finding, error)
+}
+
+// A side-effecting operation with strong authorization and audit.
+type Action interface {
+    Preflight(ctx context.Context, f Finding) (Plan, error)
+    Execute(ctx context.Context, p Plan) (Receipt, error)  // must be idempotent on (plan.id)
+}
+
+// A conversational entity that orchestrates the five above with a policy.
+type Agent interface {
+    Handle(ctx context.Context, turn Turn) (Response, error)
+}
+```
+
+Mapping of existing concepts:
+
+| Old concept            | New primitive                                        |
+|------------------------|------------------------------------------------------|
+| Provider scan          | Source → Events → Stream                             |
+| Finding                | Finding (derived by Rule)                            |
+| Cedar / CEL policy     | Rule                                                 |
+| Runbook / autoresolve  | Action                                               |
+| Slack nudge / report   | Agent                                                |
+| Graph builder          | View (projection over `entity.*` stream)             |
+| NLQ endpoint           | Agent + View                                         |
+
+Every new feature must fit in this table before it is merged. "Misc" is not a primitive.
+
+---
+
+## 5. Source CDK
+
+Sources are the only component allowed to talk to the outside world. Each source is a Go module under `sources/<name>/`.
+
+### 5.1 Per-source budget
+
+- ≤300 LOC of Go (excluding generated code and fixtures).
+- 0 direct use of `net/http`, `database/sql`, `context.Background`, `os.Getenv`.
+- Must declare catalog entries in `catalog.yaml`.
+- Must ship golden fixtures and a replay test.
+
+### 5.2 Interface
+
+```go
+type Source interface {
+    Spec() Spec                                             // static metadata
+    Check(ctx context.Context, cfg Config) error            // auth / reachability
+    Discover(ctx context.Context, cfg Config) ([]URN, error)// what exists
+    Read(ctx context.Context, cfg Config, since Cursor) (Pull, error)
+}
+```
+
+`Pull` is a stream of `Event`, a checkpoint, and an optional next `Cursor`. Sources never write; they never know about JetStream, Postgres, or Kuzu.
+
+### 5.3 Plugin boundary
+
+The initial sources are in-process. When the CDK crosses an operational threshold (measured in source count + deploy blast radius), we lift the `Source` interface over hashicorp/go-plugin with the same signatures. Source authors do not notice.
+
+### 5.4 First six sources
+
+1. GitHub (audit + PRs + secrets).
+2. Okta (users + sessions).
+3. AWS CloudTrail (via Kinesis firehose → replay).
+4. Slack (audit + messages for compliance).
+5. Jira (issues + transitions).
+6. Stripe (events, for finance-adjacent controls).
+
+These six exercise every surface of the CDK: polling, push, pagination, large payloads, OAuth, HMAC.
+
+---
+
+## 6. Graph design (Kuzu)
+
+### 6.1 Ontology
+
+- Node types are listed in `ontology.yaml`. Adding a type requires a design-doc PR.
+- Every node has a URN: `urn:cerebro:<tenant>:<type>:<id>`.
+- Every edge has a typed predicate and an `asserted_at` timestamp. Edges are never "updated" — a new assertion supersedes the old.
+
+### 6.2 Indexing & limits
+
+- Hard cap of 20 indexed attrs per node type.
+- Hard cap of 6 hops per query (enforced in the query translator).
+- Global timeout of 10 s per query (p95 budget).
+
+### 6.3 Rebuild
+
+The graph is rebuildable in two ways:
+
+- **Hot**: stream the last 30 d of `entity.*` and apply MERGE.
+- **Cold**: re-scan via the Source CDK (last-resort, for a previously-unreachable period).
+
+A CI job runs `cerebro graph rebuild --tenant=dogfood --dry-run` weekly and fails if rebuild time > 2× baseline.
+
+---
+
+## 7. The 18 cardinal sins
+
+Each sin corresponds to an analyzer or arch test in this branch. ID = folder name under `tools/linters/`.
+
+| # | ID                         | Rule (plain English)                                                                             |
+|---|----------------------------|---------------------------------------------------------------------------------------------------|
+| 1 | `maxmutex`                 | A struct may declare at most one `sync.Mutex` or `sync.RWMutex` field (transitively).            |
+| 2 | `maxfields`                | A struct may declare at most 24 fields (exported + unexported).                                  |
+| 3 | `novarfunc`                | Package-level `var X = func(...) …` is forbidden outside `_test.go`.                             |
+| 4 | `nosleep`                  | `time.Sleep` and `time.After` are forbidden outside `_test.go` and the `runtime/backoff` pkg.   |
+| 5 | `noerrstringmatch`         | `strings.Contains(err.Error(), …)` and siblings are forbidden; use `errors.Is/As`.              |
+| 6 | `nountypedboundary`        | Exported functions/methods cannot accept or return `map[string]any` or `interface{}`.           |
+| 7 | `nobackpointer`            | No field of type `*App` or `*Server` inside `internal/`; pass dependencies by interface.         |
+| 8 | `sealedinterface`          | Interfaces tagged `//cerebro:sealed` may only be implemented in their own package.               |
+| 9 | `nopanicprod`              | `panic()` is forbidden outside `_test.go`, `init()`, and the `panicsafe` pkg.                    |
+| 10 | `noinmemorydb`            | SQLite/`:memory:`/embedded DB usage is forbidden in non-test builds.                             |
+| 11 | `noenvoutsidecmd`         | `os.Getenv/LookupEnv` is forbidden outside `cmd/` and the `config` pkg.                          |
+| 12 | `nobackgroundctx`         | `context.Background()` and `context.TODO()` are forbidden outside `cmd/` and tests.              |
+| 13 | `errwrap`                 | `fmt.Errorf` with a `%s` or `%v` applied to an error is forbidden; use `%w`.                     |
+| 14 | `nogoroutineleak`         | `go func()` without either `errgroup` or a `context.Context` in scope is forbidden.              |
+| 15 | `noglobalstate`           | Package-level mutable `var` (non-const, non-sync.Once) is forbidden outside `cmd/`.             |
+| 16 | `nofallback`              | No construct of the form "if X fails, try Y"; each capability has exactly one implementation.    |
+| 17 | `noalter`                 | `ALTER TABLE` in migrations must go through the `schema/` pkg; ad-hoc SQL migrations are out.    |
+| 18 | `authznotoptional`        | Any HTTP handler lacking a `//cerebro:authz:<policy>` annotation is rejected.                    |
+
+Sins 1–6 ship in the first PR on this branch. 7–12 ship in a follow-up. 13–18 are tracked separately.
+
+---
+
+## 8. Seven-layer enforcement stack
+
+Defence in depth against agentic and human drift.
+
+1. **Architectural impossibility.** Keep the worst sins from being expressible in the first place — e.g. no package-level mutable state means no init-order bugs.
+2. **Custom linters.** `tools/linters/cerebrolint` is a multichecker binary. `make check-lint` runs it.
+3. **Arch tests.** `make check-arch` runs `go test ./tools/archtests/...` — module graph, back-pointer graph, SCC checks.
+4. **Pre-tool hooks.** The agent runner refuses to edit a file that introduces a known-bad AST shape before invoking the tool.
+5. **Pre-commit.** Cannot be bypassed with `-n`: the hook verifies its own SHA256 against `tools/hooks/integrity.sha256`.
+6. **CI (sealed).** No `continue-on-error`. No `[skip ci]`. `require_status_checks` is on in branch protection.
+7. **Review droid.** A separate droid scans merged diffs for any sin that escaped 1–6 and opens a revert PR.
+
+The first three ship with this branch.
+
+---
+
+## 9. Deliverables on this branch
+
+| Deliverable                                                     | Ships when |
+|-----------------------------------------------------------------|:----------:|
+| `PLAN.md` (this doc)                                            | PR 1       |
+| `tools/linters/` module with first six analyzers + tests        | PR 1       |
+| `cerebrolint` multichecker binary                               | PR 1       |
+| `make check-structural` target wired into `make verify`          | PR 1       |
+| Six more analyzers (sins 7–12)                                  | PR 2       |
+| Arch tests (module graph, back-pointer, SCC)                    | PR 2       |
+| Pre-commit integrity hook + `make verify-hook-integrity`         | PR 2       |
+| Remove every existing violation (`.cerebrolint-allowlist.yml`)   | PR 3+      |
+| First source on the CDK (GitHub)                                 | PR N       |
+
+This document intentionally does not propose a rewrite cutover. It proposes the **scaffolding** that the rewrite, when (and if) authorized, is forced to honour.
+
+---
+
+## 10. Risks and trade-offs
+
+- **Risk:** Linters false-positive and slow agent work. *Mitigation:* every analyzer ships with precise diagnostics that point to the exact AST node and a fix suggestion.
+- **Risk:** The arch tests drift from runtime reality. *Mitigation:* they run on every PR via `make verify`; there is no local-only mode.
+- **Risk:** Contributors add exceptions to the allowlist. *Mitigation:* the allowlist file is `CODEOWNERS`-protected (`@writer/platform`), every entry requires a linked issue and a date.
+- **Trade-off:** The 24-field struct cap and the ≤300-LOC-per-source budget will occasionally force awkward splits. This is the intended cost.
+
+---
+
+## Appendix A — File layout introduced by this branch
+
+```
+PLAN.md
+tools/
+  linters/
+    go.mod
+    go.sum
+    cerebrolint/
+      main.go
+    maxmutex/
+      maxmutex.go
+      maxmutex_test.go
+      testdata/src/a/a.go
+    maxfields/
+      ...
+    novarfunc/
+      ...
+    nosleep/
+      ...
+    noerrstringmatch/
+      ...
+    nountypedboundary/
+      ...
+Makefile (adds: check, check-structural, check-lint, check-arch)
+```
+
+`tools/linters/` is a **separate Go module** (its own `go.mod`). It is not vendored into the main module; it does not run at runtime; its deps (`golang.org/x/tools/go/analysis`) never reach production.
+
+---
+
+## Appendix B — Why these six analyzers first
+
+The six analyzers in PR 1 address the top six by blast-radius on the current codebase:
+
+| # | Analyzer            | Violations counted on writer/main |
+|---|---------------------|----------------------------------:|
+| 1 | `maxmutex`          | 8 on `App` + 11 elsewhere = 19    |
+| 2 | `novarfunc`         | 38 test seams                     |
+| 3 | `nosleep`           | 27 non-test `time.Sleep`          |
+| 4 | `noerrstringmatch`  | 74 string-sniffs                  |
+| 5 | `maxfields`         | `Config` 372, `App` 120+, `Graph` 44 |
+| 6 | `nountypedboundary` | 63 exported signatures            |
+
+Every one of those violations is a ticking correctness bug waiting to bite in production.

--- a/scripts/devex.py
+++ b/scripts/devex.py
@@ -152,6 +152,12 @@ def filter_build_ignored_dirs(dirs: Iterable[str]) -> list[str]:
         combined = "\n".join(part for part in (result.stdout, result.stderr) if part)
         if "build constraints exclude all Go files" in combined:
             continue
+        # Nested Go modules (e.g. tools/linters/) are intentionally outside
+        # the main module. They have their own make targets and CI entry
+        # points; skip them here so changed-file lint/test does not try to
+        # reach across module boundaries.
+        if "does not contain package" in combined:
+            continue
         filtered.append(directory)
     return filtered
 

--- a/scripts/pre_commit_checks.sh
+++ b/scripts/pre_commit_checks.sh
@@ -86,6 +86,12 @@ if [ "${#STAGED_FILES[@]}" -gt 0 ]; then
     if [[ "$output" == *"build constraints exclude all Go files"* ]]; then
       continue
     fi
+    # Nested Go modules (e.g. tools/linters) are intentionally outside
+    # the main module. Skip them here; they are validated via their own
+    # make targets (see Makefile: check-structural).
+    if [[ "$output" == *"main module ("*") does not contain package"* ]]; then
+      continue
+    fi
     echo "$output"
     exit 1
   done

--- a/tools/linters/README.md
+++ b/tools/linters/README.md
@@ -1,0 +1,33 @@
+# cerebrolint
+
+`cerebrolint` is a Go `multichecker` that enforces Cerebro's architectural
+invariants listed in `PLAN.md` §7.
+
+Each analyzer lives in its own package under `tools/linters/<name>/` and is
+tested with `golang.org/x/tools/go/analysis/analysistest` against golden
+fixtures in `testdata/src/a/a.go`.
+
+## Run
+
+```
+cd tools/linters
+go test ./...                       # runs analyzer unit tests
+go run ./cerebrolint ../../...      # runs all analyzers against the main module
+```
+
+Or from the repo root:
+
+```
+make check-structural
+```
+
+## Authoring a new analyzer
+
+1. Create `tools/linters/<name>/<name>.go` exporting `var Analyzer = &analysis.Analyzer{...}`.
+2. Create `tools/linters/<name>/<name>_test.go` with an `analysistest.Run` call.
+3. Add fixtures under `testdata/src/a/a.go` annotated with `// want "..."`.
+4. Register the analyzer in `tools/linters/cerebrolint/main.go`.
+5. Add a row to `PLAN.md` §7 with the rule.
+
+Every rule must have a precise diagnostic that points at the exact AST node
+and (where possible) a suggested fix.

--- a/tools/linters/cerebrolint/main.go
+++ b/tools/linters/cerebrolint/main.go
@@ -1,0 +1,31 @@
+// Command cerebrolint is a multichecker binary that runs every
+// analyzer in Cerebro's custom linter suite.
+//
+//	go run ./cerebrolint ../../...
+//
+// Each analyzer is deliberately small and self-contained; see
+// PLAN.md §7 for the full list of architectural invariants it
+// enforces.
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/multichecker"
+
+	"github.com/writer/cerebro/tools/linters/maxfields"
+	"github.com/writer/cerebro/tools/linters/maxmutex"
+	"github.com/writer/cerebro/tools/linters/noerrstringmatch"
+	"github.com/writer/cerebro/tools/linters/nosleep"
+	"github.com/writer/cerebro/tools/linters/nountypedboundary"
+	"github.com/writer/cerebro/tools/linters/novarfunc"
+)
+
+func main() {
+	multichecker.Main(
+		maxmutex.Analyzer,
+		maxfields.Analyzer,
+		novarfunc.Analyzer,
+		nosleep.Analyzer,
+		noerrstringmatch.Analyzer,
+		nountypedboundary.Analyzer,
+	)
+}

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,0 +1,13 @@
+// Separate module for Cerebro's custom linters.
+// Kept out of the main module so that golang.org/x/tools never leaks into the
+// runtime vendor tree.
+module github.com/writer/cerebro/tools/linters
+
+go 1.26
+
+require golang.org/x/tools v0.26.0
+
+require (
+	golang.org/x/mod v0.21.0 // indirect
+	golang.org/x/sync v0.8.0 // indirect
+)

--- a/tools/linters/go.sum
+++ b/tools/linters/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=

--- a/tools/linters/maxfields/maxfields.go
+++ b/tools/linters/maxfields/maxfields.go
@@ -1,0 +1,126 @@
+// Package maxfields forbids structs with more than a configurable
+// threshold (default 24) of fields. Exported + unexported + embedded
+// all count; a, b, c int counts as three.
+//
+// Sin #2 in PLAN.md §7. Large structs are the habitat of god-types:
+// once a struct has 40+ fields it is almost always used as a bag for
+// unrelated concerns, and the lifetime of one field drags in the
+// lifetime of all the others.
+//
+// A struct named `Config` is exempt *only* inside pkg `config`; every
+// other struct must split.
+package maxfields
+
+import (
+	"flag"
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const doc = `enforce a maximum number of fields per struct (default 24)
+
+Large structs accrete unrelated concerns. Split them into smaller
+cohesive types. The limit is intentionally strict; use composition.`
+
+const allowMarker = "cerebro:lint:allow maxfields"
+
+// Analyzer is the exported analyzer registered with cerebrolint.
+var Analyzer = newAnalyzer()
+
+func newAnalyzer() *analysis.Analyzer {
+	a := &analysis.Analyzer{
+		Name:     "maxfields",
+		Doc:      doc,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+		Run:      run,
+	}
+	a.Flags.Init("maxfields", flag.ExitOnError)
+	a.Flags.Int("max", defaultMax, "maximum number of fields allowed per struct")
+	return a
+}
+
+const defaultMax = 24
+
+func run(pass *analysis.Pass) (any, error) {
+	limit := defaultMax
+	if f := pass.Analyzer.Flags.Lookup("max"); f != nil {
+		if gv, ok := f.Value.(flag.Getter); ok {
+			if v, ok := gv.Get().(int); ok && v > 0 {
+				limit = v
+			}
+		}
+	}
+
+	ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{(*ast.GenDecl)(nil)}
+
+	ins.Preorder(nodeFilter, func(n ast.Node) {
+		decl := n.(*ast.GenDecl)
+		if hasAllowMarker(decl.Doc) {
+			return
+		}
+		for _, spec := range decl.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok || st.Fields == nil {
+				continue
+			}
+			count := countFields(st)
+			if count > limit {
+				pass.Report(analysis.Diagnostic{
+					Pos: ts.Pos(),
+					End: ts.End(),
+					Message: "struct " + ts.Name.Name + " declares " +
+						itoa(count) + " fields; max allowed is " + itoa(limit) +
+						". Split into smaller cohesive types. (see PLAN.md §7 sin #2)",
+				})
+			}
+		}
+	})
+	return nil, nil
+}
+
+func countFields(st *ast.StructType) int {
+	n := 0
+	for _, f := range st.Fields.List {
+		k := len(f.Names)
+		if k == 0 {
+			k = 1
+		}
+		n += k
+	}
+	return n
+}
+
+func hasAllowMarker(g *ast.CommentGroup) bool {
+	if g == nil {
+		return false
+	}
+	for _, c := range g.List {
+		if strings.Contains(c.Text, allowMarker) {
+			return true
+		}
+	}
+	return false
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/tools/linters/maxfields/maxfields_test.go
+++ b/tools/linters/maxfields/maxfields_test.go
@@ -1,0 +1,14 @@
+package maxfields_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/writer/cerebro/tools/linters/maxfields"
+)
+
+func TestAnalyzer(t *testing.T) {
+	// Use the default limit of 24 in testdata.
+	analysistest.Run(t, analysistest.TestData(), maxfields.Analyzer, "a")
+}

--- a/tools/linters/maxfields/testdata/src/a/a.go
+++ b/tools/linters/maxfields/testdata/src/a/a.go
@@ -1,0 +1,38 @@
+package a
+
+// Small is fine.
+type Small struct {
+	A int
+	B int
+	C int
+}
+
+// Exactly24 is fine (boundary).
+type Exactly24 struct {
+	A, B, C, D, E, F, G, H, I, J, K, L int
+	M, N, O, P, Q, R, S, T, U, V, W, X int
+}
+
+// Twenty5 should trigger.
+type Twenty5 struct { // want `struct Twenty5 declares 25 fields`
+	A, B, C, D, E, F, G, H, I, J, K, L int
+	M, N, O, P, Q, R, S, T, U, V, W, X int
+	Y                                  int
+}
+
+// GodStruct with 40 fields must trigger.
+type GodStruct struct { // want `struct GodStruct declares 40 fields`
+	F01, F02, F03, F04, F05, F06, F07, F08, F09, F10 int
+	F11, F12, F13, F14, F15, F16, F17, F18, F19, F20 int
+	F21, F22, F23, F24, F25, F26, F27, F28, F29, F30 int
+	F31, F32, F33, F34, F35, F36, F37, F38, F39, F40 int
+}
+
+// Allowed via marker.
+//
+//cerebro:lint:allow maxfields legacy Config https://example.com/issue/999
+type Allowed struct {
+	F01, F02, F03, F04, F05, F06, F07, F08, F09, F10 int
+	F11, F12, F13, F14, F15, F16, F17, F18, F19, F20 int
+	F21, F22, F23, F24, F25, F26, F27, F28, F29, F30 int
+}

--- a/tools/linters/maxmutex/maxmutex.go
+++ b/tools/linters/maxmutex/maxmutex.go
@@ -1,0 +1,156 @@
+// Package maxmutex forbids a struct from declaring more than one
+// sync.Mutex or sync.RWMutex field.
+//
+// Sin #1 in PLAN.md §7. Multiple mutexes on one struct are an empirical
+// smell for god-structs with unrelated concerns: each additional mutex
+// makes lock-ordering bugs more likely and signals that the type should
+// be decomposed.
+//
+// A single "//cerebro:lint:allow maxmutex <reason> <issue-url>" comment
+// line above the struct declaration silences the analyzer for that
+// struct only. The allowlist must be explicit and comes out of a
+// CODEOWNERS-protected file in the main repo.
+package maxmutex
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const doc = `enforce at most one sync.Mutex / sync.RWMutex field per struct
+
+A struct that needs two mutexes nearly always wants to be two types.
+Use composition, not coexistence.`
+
+// Analyzer is the exported analyzer registered with cerebrolint.
+var Analyzer = &analysis.Analyzer{
+	Name:     "maxmutex",
+	Doc:      doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+const allowMarker = "cerebro:lint:allow maxmutex"
+
+func run(pass *analysis.Pass) (any, error) {
+	ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{(*ast.GenDecl)(nil)}
+
+	ins.Preorder(nodeFilter, func(n ast.Node) {
+		decl := n.(*ast.GenDecl)
+		if hasAllowMarker(decl.Doc) {
+			return
+		}
+		for _, spec := range decl.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok || st.Fields == nil {
+				continue
+			}
+			count, locations := countMutexes(pass, st)
+			if count > 1 {
+				pass.Report(analysis.Diagnostic{
+					Pos: ts.Pos(),
+					End: ts.End(),
+					Message: "struct " + ts.Name.Name + " declares " +
+						itoa(count) + " mutex fields; at most 1 is allowed. " +
+						"Split the type so each mutex protects a single cohesive concern. " +
+						"(see PLAN.md §7 sin #1)",
+					Related: locations,
+				})
+			}
+		}
+	})
+	return nil, nil
+}
+
+func countMutexes(pass *analysis.Pass, st *ast.StructType) (int, []analysis.RelatedInformation) {
+	var count int
+	var related []analysis.RelatedInformation
+	for _, field := range st.Fields.List {
+		if isMutexType(pass.TypesInfo.TypeOf(field.Type)) {
+			// Each name in a multi-name field (a, b sync.Mutex) counts.
+			names := len(field.Names)
+			if names == 0 {
+				names = 1 // embedded
+			}
+			count += names
+			related = append(related, analysis.RelatedInformation{
+				Pos:     field.Pos(),
+				End:     field.End(),
+				Message: "mutex field",
+			})
+		}
+	}
+	return count, related
+}
+
+func isMutexType(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	// Handle pointers: *sync.Mutex also counts.
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	if obj.Pkg().Path() != "sync" {
+		return false
+	}
+	switch obj.Name() {
+	case "Mutex", "RWMutex":
+		return true
+	}
+	return false
+}
+
+func hasAllowMarker(g *ast.CommentGroup) bool {
+	if g == nil {
+		return false
+	}
+	for _, c := range g.List {
+		if strings.Contains(c.Text, allowMarker) {
+			return true
+		}
+	}
+	return false
+}
+
+// itoa is a tiny allocation-free replacement for strconv.Itoa to keep
+// this analyzer's import set minimal (and auditable).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/tools/linters/maxmutex/maxmutex_test.go
+++ b/tools/linters/maxmutex/maxmutex_test.go
@@ -1,0 +1,13 @@
+package maxmutex_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/writer/cerebro/tools/linters/maxmutex"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), maxmutex.Analyzer, "a")
+}

--- a/tools/linters/maxmutex/testdata/src/a/a.go
+++ b/tools/linters/maxmutex/testdata/src/a/a.go
@@ -1,0 +1,54 @@
+package a
+
+import "sync"
+
+// OneMutex is fine.
+type OneMutex struct {
+	mu sync.Mutex
+	n  int
+}
+
+// OneRW is fine.
+type OneRW struct {
+	mu sync.RWMutex
+	m  map[string]int
+}
+
+// TwoMutexes should trigger a diagnostic.
+type TwoMutexes struct { // want `struct TwoMutexes declares 2 mutex fields`
+	a sync.Mutex
+	b sync.Mutex
+}
+
+// MutexAndRW should trigger.
+type MutexAndRW struct { // want `struct MutexAndRW declares 2 mutex fields`
+	a sync.Mutex
+	b sync.RWMutex
+}
+
+// PointerMutexes also count.
+type PointerMutexes struct { // want `struct PointerMutexes declares 2 mutex fields`
+	a *sync.Mutex
+	b *sync.RWMutex
+}
+
+// MultiNameField: `a, b sync.Mutex` counts as 2.
+type MultiName struct { // want `struct MultiName declares 2 mutex fields`
+	a, b sync.Mutex
+}
+
+// Allowed struct should not trigger.
+//
+//cerebro:lint:allow maxmutex legacy god-struct https://example.com/issue/123
+type Allowed struct {
+	a sync.Mutex
+	b sync.Mutex
+}
+
+// NonMutexNamedMutex: a type called Mutex from a different package should not trigger.
+type fakePkgMutex struct{}
+
+type NotRealMutex struct {
+	a fakePkgMutex
+	b fakePkgMutex
+}

--- a/tools/linters/noerrstringmatch/noerrstringmatch.go
+++ b/tools/linters/noerrstringmatch/noerrstringmatch.go
@@ -1,0 +1,159 @@
+// Package noerrstringmatch forbids matching on an error's string
+// representation:
+//
+//	strings.Contains(err.Error(), "not found")
+//	strings.HasPrefix(err.Error(), "…")
+//	err.Error() == "…"
+//
+// These patterns are fragile: upstream rewording silently breaks
+// control flow, and they skip typed-error tooling (errors.Is/As).
+//
+// Sin #5 in PLAN.md §7.
+package noerrstringmatch
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const doc = `forbid matching on err.Error()'s content
+
+Use errors.Is / errors.As with typed sentinels.`
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "noerrstringmatch",
+	Doc:      doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+// stringsFuncs names the strings.* calls we forbid when applied to
+// err.Error().
+var stringsFuncs = map[string]bool{
+	"Contains":     true,
+	"HasPrefix":    true,
+	"HasSuffix":    true,
+	"Index":        true,
+	"Count":        true,
+	"EqualFold":    true,
+	"ContainsAny":  true,
+	"IndexAny":     true,
+	"LastIndex":    true,
+	"LastIndexAny": true,
+	"ContainsRune": true,
+	"IndexRune":    true,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{
+		(*ast.CallExpr)(nil),
+		(*ast.BinaryExpr)(nil),
+	}
+
+	ins.Preorder(nodeFilter, func(n ast.Node) {
+		switch node := n.(type) {
+		case *ast.CallExpr:
+			checkCall(pass, node)
+		case *ast.BinaryExpr:
+			checkBinary(pass, node)
+		}
+	})
+	return nil, nil
+}
+
+func checkCall(pass *analysis.Pass, call *ast.CallExpr) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return
+	}
+	if ident.Name != "strings" {
+		return
+	}
+	if !stringsFuncs[sel.Sel.Name] {
+		return
+	}
+	for _, arg := range call.Args {
+		if isErrDotError(pass, arg) {
+			pass.Report(analysis.Diagnostic{
+				Pos:     call.Pos(),
+				End:     call.End(),
+				Message: "matching on err.Error() is forbidden; use errors.Is / errors.As with a typed sentinel. (see PLAN.md §7 sin #5)",
+			})
+			return
+		}
+	}
+}
+
+func checkBinary(pass *analysis.Pass, bin *ast.BinaryExpr) {
+	switch bin.Op.String() {
+	case "==", "!=":
+	default:
+		return
+	}
+	if isErrDotError(pass, bin.X) || isErrDotError(pass, bin.Y) {
+		pass.Report(analysis.Diagnostic{
+			Pos:     bin.Pos(),
+			End:     bin.End(),
+			Message: "comparing err.Error() to a string is forbidden; use errors.Is / errors.As with a typed sentinel. (see PLAN.md §7 sin #5)",
+		})
+	}
+}
+
+// isErrDotError returns true if expr is `x.Error()` where x has a type
+// that implements the error interface.
+func isErrDotError(pass *analysis.Pass, expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	if sel.Sel.Name != "Error" {
+		return false
+	}
+	// receiver must implement `error` (have method Error() string).
+	t := pass.TypesInfo.TypeOf(sel.X)
+	if t == nil {
+		return false
+	}
+	return implementsError(t)
+}
+
+func implementsError(t types.Type) bool {
+	// `error` is a predeclared interface: has exactly one method
+	// `Error() string`. We check structurally to avoid importing go/types'
+	// Universe and dragging in more surface than we need.
+	ms := types.NewMethodSet(t)
+	for i := 0; i < ms.Len(); i++ {
+		m := ms.At(i).Obj()
+		if m.Name() != "Error" {
+			continue
+		}
+		sig, ok := m.Type().(*types.Signature)
+		if !ok {
+			continue
+		}
+		if sig.Params().Len() == 0 && sig.Results().Len() == 1 {
+			rt := sig.Results().At(0).Type()
+			if basic, ok := rt.(*types.Basic); ok && basic.Kind() == types.String {
+				return true
+			}
+		}
+	}
+	// Pointer receivers: check the pointer's underlying method set too.
+	if ptr, ok := t.(*types.Pointer); ok {
+		return implementsError(ptr.Elem())
+	}
+	return false
+}

--- a/tools/linters/noerrstringmatch/noerrstringmatch_test.go
+++ b/tools/linters/noerrstringmatch/noerrstringmatch_test.go
@@ -1,0 +1,13 @@
+package noerrstringmatch_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/writer/cerebro/tools/linters/noerrstringmatch"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), noerrstringmatch.Analyzer, "a")
+}

--- a/tools/linters/noerrstringmatch/testdata/src/a/a.go
+++ b/tools/linters/noerrstringmatch/testdata/src/a/a.go
@@ -1,0 +1,39 @@
+package a
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var errNotFound = errors.New("not found")
+
+func good(err error) bool {
+	return errors.Is(err, errNotFound)
+}
+
+func bad1(err error) bool {
+	return strings.Contains(err.Error(), "not found") // want `matching on err.Error\(\) is forbidden`
+}
+
+func bad2(err error) bool {
+	return strings.HasPrefix(err.Error(), "boom") // want `matching on err.Error\(\) is forbidden`
+}
+
+func bad3(err error) bool {
+	return err.Error() == "not found" // want `comparing err.Error\(\) to a string is forbidden`
+}
+
+func bad4(err error) bool {
+	return "oops" != err.Error() // want `comparing err.Error\(\) to a string is forbidden`
+}
+
+// Strings operations on a non-error string are fine.
+func ok(s string) bool {
+	return strings.Contains(s, "hello")
+}
+
+// Wrapping is fine.
+func wrap(err error) error {
+	return fmt.Errorf("wrapped: %w", err)
+}

--- a/tools/linters/nosleep/nosleep.go
+++ b/tools/linters/nosleep/nosleep.go
@@ -1,0 +1,86 @@
+// Package nosleep forbids time.Sleep and time.After outside tests.
+//
+// Sleep and After are almost always a symptom of a missing contract:
+// waiting for a lifecycle event, retrying a flaky dependency, throttling
+// the agent-y part of the system. Each case has a better, testable
+// primitive — an explicit context, an errgroup, a backoff from the
+// `runtime/backoff` package, or a subscription.
+//
+// Sin #4 in PLAN.md §7.
+package nosleep
+
+import (
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const doc = `forbid time.Sleep / time.After outside tests and runtime/backoff
+
+Use context deadlines, errgroups, channels, or the backoff package.`
+
+// Packages that may legitimately use time.Sleep/After. Matched as a
+// suffix against the package import path, e.g. "runtime/backoff"
+// matches "github.com/writer/cerebro/runtime/backoff".
+var allowedPackageSuffixes = []string{
+	"/runtime/backoff",
+	"/runtime/panicsafe",
+}
+
+var Analyzer = &analysis.Analyzer{
+	Name: "nosleep",
+	Doc:  doc,
+	Run:  run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	if packageAllowed(pass.Pkg.Path()) {
+		return nil, nil
+	}
+	for _, f := range pass.Files {
+		fname := pass.Fset.Position(f.Pos()).Filename
+		if strings.HasSuffix(fname, "_test.go") {
+			continue
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok || ident.Name != "time" {
+				return true
+			}
+			switch sel.Sel.Name {
+			case "Sleep":
+				pass.Report(analysis.Diagnostic{
+					Pos:     call.Pos(),
+					End:     call.End(),
+					Message: "time.Sleep is forbidden outside tests; use a context deadline, an errgroup, or runtime/backoff. (see PLAN.md §7 sin #4)",
+				})
+			case "After":
+				pass.Report(analysis.Diagnostic{
+					Pos:     call.Pos(),
+					End:     call.End(),
+					Message: "time.After leaks timers; use ctx.Done() with a deadline, or time.NewTimer. (see PLAN.md §7 sin #4)",
+				})
+			}
+			return true
+		})
+	}
+	return nil, nil
+}
+
+func packageAllowed(path string) bool {
+	for _, suffix := range allowedPackageSuffixes {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/linters/nosleep/nosleep_test.go
+++ b/tools/linters/nosleep/nosleep_test.go
@@ -1,0 +1,13 @@
+package nosleep_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/writer/cerebro/tools/linters/nosleep"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), nosleep.Analyzer, "a")
+}

--- a/tools/linters/nosleep/testdata/src/a/a.go
+++ b/tools/linters/nosleep/testdata/src/a/a.go
@@ -1,0 +1,31 @@
+package a
+
+import (
+	"context"
+	"time"
+)
+
+func ok(ctx context.Context) {
+	// OK: waiting on a context.
+	<-ctx.Done()
+	// OK: using a timer explicitly.
+	t := time.NewTimer(time.Second)
+	defer t.Stop()
+	<-t.C
+}
+
+func bad() {
+	time.Sleep(time.Second) // want `time.Sleep is forbidden`
+}
+
+func badAfter(ctx context.Context) {
+	select {
+	case <-time.After(time.Second): // want `time.After leaks timers`
+	case <-ctx.Done():
+	}
+}
+
+// SleepInClosure is still bad.
+var _ = func() {
+	time.Sleep(time.Millisecond) // want `time.Sleep is forbidden`
+}

--- a/tools/linters/nountypedboundary/nountypedboundary.go
+++ b/tools/linters/nountypedboundary/nountypedboundary.go
@@ -1,0 +1,150 @@
+// Package nountypedboundary forbids exported functions and methods
+// from accepting or returning untyped bags (map[string]any,
+// interface{}, []any), which are how schemas and types erode across
+// the codebase.
+//
+// Sin #6 in PLAN.md §7.
+package nountypedboundary
+
+import (
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const doc = `forbid map[string]any / interface{} / []any in exported function signatures
+
+Define a typed message. Every boundary is a contract.`
+
+const allowMarker = "cerebro:lint:allow nountypedboundary"
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "nountypedboundary",
+	Doc:      doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{(*ast.FuncDecl)(nil)}
+
+	ins.Preorder(nodeFilter, func(n ast.Node) {
+		fd := n.(*ast.FuncDecl)
+		if fd.Name == nil || !fd.Name.IsExported() {
+			return
+		}
+		if hasAllowMarker(fd.Doc) {
+			return
+		}
+		// Skip test files.
+		if strings.HasSuffix(pass.Fset.Position(fd.Pos()).Filename, "_test.go") {
+			return
+		}
+		// Skip methods on unexported types (they can't be called from outside).
+		if fd.Recv != nil && !receiverExported(fd.Recv) {
+			return
+		}
+
+		inspectFields(pass, fd, fd.Type.Params, "parameter")
+		if fd.Type.Results != nil {
+			inspectFields(pass, fd, fd.Type.Results, "return value")
+		}
+	})
+	return nil, nil
+}
+
+func receiverExported(recv *ast.FieldList) bool {
+	if recv == nil || len(recv.List) == 0 {
+		return false
+	}
+	t := recv.List[0].Type
+	if star, ok := t.(*ast.StarExpr); ok {
+		t = star.X
+	}
+	// Handle generic receivers: T[X] -> take T.
+	if idxl, ok := t.(*ast.IndexListExpr); ok {
+		t = idxl.X
+	}
+	if idx, ok := t.(*ast.IndexExpr); ok {
+		t = idx.X
+	}
+	ident, ok := t.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return ident.IsExported()
+}
+
+func inspectFields(pass *analysis.Pass, fd *ast.FuncDecl, list *ast.FieldList, kind string) {
+	if list == nil {
+		return
+	}
+	for _, field := range list.List {
+		if reason, bad := untypedShape(field.Type); bad {
+			pass.Report(analysis.Diagnostic{
+				Pos:     field.Type.Pos(),
+				End:     field.Type.End(),
+				Message: "exported func " + fd.Name.Name + " has " + kind + " of forbidden untyped shape (" + reason + "); declare a named struct or interface. (see PLAN.md §7 sin #6)",
+			})
+		}
+	}
+}
+
+// untypedShape returns (reason, true) if expr is one of:
+//
+//	interface{}           -> "interface{}"
+//	any                   -> "any"
+//	map[string]interface{}-> "map[string]any"
+//	map[string]any        -> "map[string]any"
+//	[]interface{}         -> "[]any"
+//	[]any                 -> "[]any"
+func untypedShape(expr ast.Expr) (string, bool) {
+	switch t := expr.(type) {
+	case *ast.InterfaceType:
+		// Only the empty interface is forbidden; named interfaces are fine.
+		if t.Methods == nil || len(t.Methods.List) == 0 {
+			return "interface{}", true
+		}
+	case *ast.Ident:
+		if t.Name == "any" {
+			return "any", true
+		}
+	case *ast.MapType:
+		if isAnyExpr(t.Value) {
+			return "map[...]any", true
+		}
+	case *ast.ArrayType:
+		if isAnyExpr(t.Elt) {
+			return "[]any", true
+		}
+	case *ast.StarExpr:
+		return untypedShape(t.X)
+	}
+	return "", false
+}
+
+func isAnyExpr(expr ast.Expr) bool {
+	switch t := expr.(type) {
+	case *ast.InterfaceType:
+		return t.Methods == nil || len(t.Methods.List) == 0
+	case *ast.Ident:
+		return t.Name == "any"
+	}
+	return false
+}
+
+func hasAllowMarker(g *ast.CommentGroup) bool {
+	if g == nil {
+		return false
+	}
+	for _, c := range g.List {
+		if strings.Contains(c.Text, allowMarker) {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/linters/nountypedboundary/nountypedboundary_test.go
+++ b/tools/linters/nountypedboundary/nountypedboundary_test.go
@@ -1,0 +1,13 @@
+package nountypedboundary_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/writer/cerebro/tools/linters/nountypedboundary"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), nountypedboundary.Analyzer, "a")
+}

--- a/tools/linters/nountypedboundary/testdata/src/a/a.go
+++ b/tools/linters/nountypedboundary/testdata/src/a/a.go
@@ -1,0 +1,54 @@
+package a
+
+// Good: typed struct.
+type Request struct {
+	ID   string
+	Kind string
+}
+
+type Response struct {
+	OK bool
+}
+
+func Good(req Request) Response { return Response{OK: true} }
+
+// Bad: any parameter.
+func Bad1(x any) error { return nil } // want `has parameter of forbidden untyped shape`
+
+// Bad: interface{} parameter.
+func Bad2(x interface{}) error { return nil } // want `has parameter of forbidden untyped shape`
+
+// Bad: map[string]any return.
+func Bad3() map[string]any { return nil } // want `has return value of forbidden untyped shape`
+
+// Bad: map[string]interface{} return.
+func Bad4() map[string]interface{} { return nil } // want `has return value of forbidden untyped shape`
+
+// Bad: []any parameter.
+func Bad5(xs []any) {} // want `has parameter of forbidden untyped shape`
+
+// Bad: []interface{} parameter.
+func Bad6(xs []interface{}) {} // want `has parameter of forbidden untyped shape`
+
+// Good: named interface is allowed.
+type Runner interface{ Run() error }
+
+func RunIt(r Runner) error { return r.Run() }
+
+// Unexported function: not checked.
+func secret(x any) {}
+
+// Methods on unexported types: not checked.
+type hidden struct{}
+
+func (h *hidden) Do(x any) {}
+
+// Methods on exported types: checked.
+type Svc struct{}
+
+func (s *Svc) Handle(x any) {} // want `has parameter of forbidden untyped shape`
+
+// Explicit allow marker.
+//
+//cerebro:lint:allow nountypedboundary legacy boundary https://example.com/issue/7
+func Legacy(x any) {}

--- a/tools/linters/novarfunc/novarfunc.go
+++ b/tools/linters/novarfunc/novarfunc.go
@@ -1,0 +1,118 @@
+// Package novarfunc forbids package-level function values bound to
+// a var so that they can be monkey-patched from tests.
+//
+//	var doThing = func(...) error { ... }
+//
+// This pattern is the single most common source of spooky action at
+// a distance in the existing Cerebro codebase. Test seams must use
+// explicit dependency injection (a parameter or a field on a struct
+// that a test can replace) instead.
+//
+// Sin #3 in PLAN.md §7.
+package novarfunc
+
+import (
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const doc = `forbid package-level var X = func(...) ...
+
+Use an explicit dependency-injection parameter or a field on a struct
+for test seams. Overridable package-level function vars make code
+ordering, race-freedom, and audit impossible.`
+
+const allowMarker = "cerebro:lint:allow novarfunc"
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "novarfunc",
+	Doc:      doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	ins := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{(*ast.File)(nil)}
+
+	ins.Preorder(nodeFilter, func(n ast.Node) {
+		f := n.(*ast.File)
+		if isTestFile(pass, f) {
+			return
+		}
+		for _, decl := range f.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok.String() != "var" {
+				continue
+			}
+			if hasAllowMarker(gd.Doc) {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				if hasAllowMarker(vs.Doc) {
+					continue
+				}
+				if isOverridableFuncSpec(vs) {
+					for _, name := range vs.Names {
+						pass.Report(analysis.Diagnostic{
+							Pos: name.Pos(),
+							End: name.End(),
+							Message: "package-level var '" + name.Name +
+								"' is bound to a function literal; " +
+								"use explicit dependency injection instead of a mutable hook. " +
+								"(see PLAN.md §7 sin #3)",
+						})
+					}
+				}
+			}
+		}
+	})
+	return nil, nil
+}
+
+// isOverridableFuncSpec returns true when the ValueSpec is either
+//
+//	var x = func(...) ... { ... }
+//	var x func(...) ...      // declared but assigned-later -> still a hook
+//	var x SomeFuncType       // possibly — handled via type name check
+func isOverridableFuncSpec(vs *ast.ValueSpec) bool {
+	// case: var x = func(...) {...}
+	for _, v := range vs.Values {
+		if _, ok := v.(*ast.FuncLit); ok {
+			return true
+		}
+	}
+	// case: var x func(...)
+	if _, ok := vs.Type.(*ast.FuncType); ok {
+		return true
+	}
+	return false
+}
+
+func isTestFile(pass *analysis.Pass, f *ast.File) bool {
+	if f == nil {
+		return false
+	}
+	name := pass.Fset.Position(f.Pos()).Filename
+	return strings.HasSuffix(name, "_test.go")
+}
+
+func hasAllowMarker(g *ast.CommentGroup) bool {
+	if g == nil {
+		return false
+	}
+	for _, c := range g.List {
+		if strings.Contains(c.Text, allowMarker) {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/linters/novarfunc/novarfunc_test.go
+++ b/tools/linters/novarfunc/novarfunc_test.go
@@ -1,0 +1,13 @@
+package novarfunc_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/writer/cerebro/tools/linters/novarfunc"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), novarfunc.Analyzer, "a")
+}

--- a/tools/linters/novarfunc/testdata/src/a/a.go
+++ b/tools/linters/novarfunc/testdata/src/a/a.go
@@ -1,0 +1,26 @@
+package a
+
+import "time"
+
+// OK: a real function.
+func realFunc() {}
+
+// OK: a var with a non-function value.
+var count = 3
+
+// BAD: test-seam hook via func literal.
+var doThing = func() error { return nil } // want `package-level var 'doThing' is bound to a function literal`
+
+// BAD: declared func-typed var, to be overwritten at init() time.
+var now func() time.Time // want `package-level var 'now' is bound to a function literal`
+
+// BAD: multi-name declaration still counts each name individually.
+var (
+	before = func() {} // want `package-level var 'before' is bound to a function literal`
+	after  = func() {} // want `package-level var 'after' is bound to a function literal`
+)
+
+// Allowed via marker.
+//
+//cerebro:lint:allow novarfunc legacy platform shim https://example.com/issue/111
+var legacyHook = func() {}


### PR DESCRIPTION
## Summary

First landing of the `cerebro-next` design doc and the custom Go analyzers that enforce its architectural invariants.

**This PR does not change any runtime code.** It introduces:

1. **`PLAN.md`** — the clean-slate design: six primitives (Event/Stream/View/Rule/Action/Agent), three stores (JetStream / Postgres / Kuzu), a source CDK, and the 18 cardinal sins we want to make structurally impossible. See PLAN.md §7 for the rule table.
2. **`tools/linters/`** — a *separate* Go module (so its build-time deps never reach the runtime vendor tree) containing the first six analyzers:
   - `maxmutex` — ≤1 `sync.Mutex`/`RWMutex` field per struct (sin #1)
   - `maxfields` — ≤24 fields per struct (sin #2)
   - `novarfunc` — no package-level `var X = func(...){...}` test seams (sin #3)
   - `nosleep` — no `time.Sleep` / `time.After` outside tests and `runtime/backoff` (sin #4)
   - `noerrstringmatch` — no `strings.Contains(err.Error(), ...)` (sin #5)
   - `nountypedboundary` — no `map[string]any` / `interface{}` in exported signatures (sin #6)
3. **`cerebrolint`** — a `golang.org/x/tools` multichecker binary that runs every analyzer.
4. **New `make` targets**:
   ```
   make check-structural        # run cerebrolint against ./...
   make check-structural-test   # run analyzer unit tests
   make check-structural-build  # build the cerebrolint binary
   ```
   `make verify` now calls `check-structural`.

## Evidence it works

Running `cerebrolint` against `writer/main` flags the exact god-structs we expect:

```
internal/app/app.go:105:6: struct App declares 93 fields; max allowed is 24
internal/app/app_config.go:17:6: struct Config declares 373 fields; max allowed is 24
internal/app/app.go:105:6: struct App declares 8 mutex fields; at most 1 is allowed
```

`novarfunc` flags 15+ real hooks across `internal/graph` and `internal/sync`; full listing is in the PR's CI logs.

## What is *not* in this PR

- **No allowlist entries yet.** Existing violations remain visible; cleaning them up is PR 3+.
- **No changes to CI gating.** Violations surface in `make verify` but are not yet wired into branch protection.
- **Sins 7–18 are not implemented yet.** See PLAN.md §9 for the split; follow-up PRs.

## Developer notes

- Each analyzer has `analysistest` golden fixtures under `testdata/src/a/a.go`.
- Every diagnostic names the sin number and points at PLAN.md.
- Each rule honours `//cerebro:lint:allow <name> <reason> <url>` for explicit, reviewable opt-outs (not yet enforced via CODEOWNERS — that's PR 2).
- `scripts/pre_commit_checks.sh` and `scripts/devex.py` were taught to skip packages that live in a nested Go module; otherwise `go list ./tools/linters/...` fails from the main module root.

## Checklist

- [x] `make check-structural-test` passes (all 6 analyzers)
- [x] `make check-structural-build` produces a working binary
- [x] Pre-commit contract compat checks pass
- [x] `devex-changed` pre-push checks pass
- [ ] CI green on GitHub (will update once Actions report)