### PR TITLE
feat(bootstrap): expose the source registry

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/writer/cerebro/internal/bootstrap"
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/sourceregistry"
 )
 
 type usageError string
@@ -61,8 +62,12 @@ func serve() error {
 			log.Printf("close dependencies: %v", err)
 		}
 	}()
+	sources, err := sourceregistry.Builtin()
+	if err != nil {
+		return fmt.Errorf("open source registry: %w", err)
+	}
 
-	app := bootstrap.New(cfg, deps)
+	app := bootstrap.New(cfg, deps, sources)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -295,12 +295,94 @@ func (x *CheckHealthResponse) GetComponents() []*ComponentStatus {
 	return nil
 }
 
+// ListSourcesRequest requests the currently registered source catalog.
+type ListSourcesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSourcesRequest) Reset() {
+	*x = ListSourcesRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSourcesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSourcesRequest) ProtoMessage() {}
+
+func (x *ListSourcesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSourcesRequest.ProtoReflect.Descriptor instead.
+func (*ListSourcesRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{5}
+}
+
+// ListSourcesResponse returns the registered in-process source specs.
+type ListSourcesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sources       []*SourceSpec          `protobuf:"bytes,1,rep,name=sources,proto3" json:"sources,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSourcesResponse) Reset() {
+	*x = ListSourcesResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSourcesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSourcesResponse) ProtoMessage() {}
+
+func (x *ListSourcesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSourcesResponse.ProtoReflect.Descriptor instead.
+func (*ListSourcesResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ListSourcesResponse) GetSources() []*SourceSpec {
+	if x != nil {
+		return x.Sources
+	}
+	return nil
+}
+
 var File_cerebro_v1_bootstrap_proto protoreflect.FileDescriptor
 
 const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\n" +
 	"\x1acerebro/v1/bootstrap.proto\x12\n" +
-	"cerebro.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x13\n" +
+	"cerebro.v1\x1a\x17cerebro/v1/source.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x13\n" +
 	"\x11GetVersionRequest\"\xa9\x01\n" +
 	"\x12GetVersionResponse\x12!\n" +
 	"\fservice_name\x18\x01 \x01(\tR\vserviceName\x12\x18\n" +
@@ -321,11 +403,15 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"checked_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcheckedAt\x12;\n" +
 	"\n" +
 	"components\x18\x03 \x03(\v2\x1b.cerebro.v1.ComponentStatusR\n" +
-	"components2\xaf\x01\n" +
+	"components\"\x14\n" +
+	"\x12ListSourcesRequest\"G\n" +
+	"\x13ListSourcesResponse\x120\n" +
+	"\asources\x18\x01 \x03(\v2\x16.cerebro.v1.SourceSpecR\asources2\xff\x01\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
-	"\vCheckHealth\x12\x1e.cerebro.v1.CheckHealthRequest\x1a\x1f.cerebro.v1.CheckHealthResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
+	"\vCheckHealth\x12\x1e.cerebro.v1.CheckHealthRequest\x1a\x1f.cerebro.v1.CheckHealthResponse\x12N\n" +
+	"\vListSources\x12\x1e.cerebro.v1.ListSourcesRequest\x1a\x1f.cerebro.v1.ListSourcesResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
 
 var (
 	file_cerebro_v1_bootstrap_proto_rawDescOnce sync.Once
@@ -339,27 +425,33 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*GetVersionRequest)(nil),     // 0: cerebro.v1.GetVersionRequest
 	(*GetVersionResponse)(nil),    // 1: cerebro.v1.GetVersionResponse
 	(*CheckHealthRequest)(nil),    // 2: cerebro.v1.CheckHealthRequest
 	(*ComponentStatus)(nil),       // 3: cerebro.v1.ComponentStatus
 	(*CheckHealthResponse)(nil),   // 4: cerebro.v1.CheckHealthResponse
-	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
+	(*ListSourcesRequest)(nil),    // 5: cerebro.v1.ListSourcesRequest
+	(*ListSourcesResponse)(nil),   // 6: cerebro.v1.ListSourcesResponse
+	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
+	(*SourceSpec)(nil),            // 8: cerebro.v1.SourceSpec
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	5, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	7, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3, // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
-	0, // 2: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2, // 3: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	1, // 4: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4, // 5: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	8, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	0, // 3: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2, // 4: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	5, // 5: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	1, // 6: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4, // 7: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	6, // 8: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	6, // [6:9] is the sub-list for method output_type
+	3, // [3:6] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -367,13 +459,14 @@ func file_cerebro_v1_bootstrap_proto_init() {
 	if File_cerebro_v1_bootstrap_proto != nil {
 		return
 	}
+	file_cerebro_v1_source_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -39,12 +39,16 @@ const (
 	// BootstrapServiceCheckHealthProcedure is the fully-qualified name of the BootstrapService's
 	// CheckHealth RPC.
 	BootstrapServiceCheckHealthProcedure = "/cerebro.v1.BootstrapService/CheckHealth"
+	// BootstrapServiceListSourcesProcedure is the fully-qualified name of the BootstrapService's
+	// ListSources RPC.
+	BootstrapServiceListSourcesProcedure = "/cerebro.v1.BootstrapService/ListSources"
 )
 
 // BootstrapServiceClient is a client for the cerebro.v1.BootstrapService service.
 type BootstrapServiceClient interface {
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
 	CheckHealth(context.Context, *connect.Request[v1.CheckHealthRequest]) (*connect.Response[v1.CheckHealthResponse], error)
+	ListSources(context.Context, *connect.Request[v1.ListSourcesRequest]) (*connect.Response[v1.ListSourcesResponse], error)
 }
 
 // NewBootstrapServiceClient constructs a client for the cerebro.v1.BootstrapService service. By
@@ -70,6 +74,12 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("CheckHealth")),
 			connect.WithClientOptions(opts...),
 		),
+		listSources: connect.NewClient[v1.ListSourcesRequest, v1.ListSourcesResponse](
+			httpClient,
+			baseURL+BootstrapServiceListSourcesProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("ListSources")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -77,6 +87,7 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 type bootstrapServiceClient struct {
 	getVersion  *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
 	checkHealth *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
+	listSources *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
 }
 
 // GetVersion calls cerebro.v1.BootstrapService.GetVersion.
@@ -89,10 +100,16 @@ func (c *bootstrapServiceClient) CheckHealth(ctx context.Context, req *connect.R
 	return c.checkHealth.CallUnary(ctx, req)
 }
 
+// ListSources calls cerebro.v1.BootstrapService.ListSources.
+func (c *bootstrapServiceClient) ListSources(ctx context.Context, req *connect.Request[v1.ListSourcesRequest]) (*connect.Response[v1.ListSourcesResponse], error) {
+	return c.listSources.CallUnary(ctx, req)
+}
+
 // BootstrapServiceHandler is an implementation of the cerebro.v1.BootstrapService service.
 type BootstrapServiceHandler interface {
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
 	CheckHealth(context.Context, *connect.Request[v1.CheckHealthRequest]) (*connect.Response[v1.CheckHealthResponse], error)
+	ListSources(context.Context, *connect.Request[v1.ListSourcesRequest]) (*connect.Response[v1.ListSourcesResponse], error)
 }
 
 // NewBootstrapServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -114,12 +131,20 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		connect.WithSchema(bootstrapServiceMethods.ByName("CheckHealth")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bootstrapServiceListSourcesHandler := connect.NewUnaryHandler(
+		BootstrapServiceListSourcesProcedure,
+		svc.ListSources,
+		connect.WithSchema(bootstrapServiceMethods.ByName("ListSources")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/cerebro.v1.BootstrapService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case BootstrapServiceGetVersionProcedure:
 			bootstrapServiceGetVersionHandler.ServeHTTP(w, r)
 		case BootstrapServiceCheckHealthProcedure:
 			bootstrapServiceCheckHealthHandler.ServeHTTP(w, r)
+		case BootstrapServiceListSourcesProcedure:
+			bootstrapServiceListSourcesHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -135,4 +160,8 @@ func (UnimplementedBootstrapServiceHandler) GetVersion(context.Context, *connect
 
 func (UnimplementedBootstrapServiceHandler) CheckHealth(context.Context, *connect.Request[v1.CheckHealthRequest]) (*connect.Response[v1.CheckHealthResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.CheckHealth is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) ListSources(context.Context, *connect.Request[v1.ListSourcesRequest]) (*connect.Response[v1.ListSourcesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListSources is not implemented"))
 }

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -8,6 +8,7 @@ import (
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -15,6 +16,7 @@ import (
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
 // Dependencies are the future store/log boundaries that will be wired into the rewrite.
@@ -26,26 +28,29 @@ type Dependencies struct {
 
 // App is the minimal Connect/bootstrap composition root for the rewrite skeleton.
 type App struct {
-	cfg    config.Config
-	deps   Dependencies
-	mux    *http.ServeMux
-	server *http.Server
+	cfg     config.Config
+	deps    Dependencies
+	sources *sourcecdk.Registry
+	mux     *http.ServeMux
+	server  *http.Server
 }
 
 type bootstrapService struct {
-	deps Dependencies
+	deps    Dependencies
+	sources *sourcecdk.Registry
 }
 
 // New constructs the minimal bootstrap app and registers the Connect handlers.
-func New(cfg config.Config, deps Dependencies) *App {
+func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App {
 	mux := http.NewServeMux()
-	service := &bootstrapService{deps: deps}
+	service := &bootstrapService{deps: deps, sources: sources}
 	path, handler := cerebrov1connect.NewBootstrapServiceHandler(service)
 	mux.Handle(path, handler)
 
-	app := &App{cfg: cfg, deps: deps, mux: mux}
+	app := &App{cfg: cfg, deps: deps, sources: sources, mux: mux}
 	mux.HandleFunc("/health", app.handleHealth)
 	mux.HandleFunc("/healthz", app.handleHealth)
+	mux.HandleFunc("/sources", app.handleSources)
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           mux,
@@ -74,14 +79,15 @@ func (a *App) Shutdown(ctx context.Context) error {
 
 func (a *App) handleHealth(w http.ResponseWriter, r *http.Request) {
 	response := healthResponse(r.Context(), a.deps)
-	payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(response)
-	if err != nil {
-		http.Error(w, "failed to encode health", http.StatusInternalServerError)
-		return
+	writeProtoJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleSources(w http.ResponseWriter, r *http.Request) {
+	response := &cerebrov1.ListSourcesResponse{}
+	if a.sources != nil {
+		response.Sources = a.sources.List()
 	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(payload)
+	writeProtoJSON(w, http.StatusOK, response)
 }
 
 func (s *bootstrapService) GetVersion(_ context.Context, _ *connect.Request[cerebrov1.GetVersionRequest]) (*connect.Response[cerebrov1.GetVersionResponse], error) {
@@ -96,6 +102,14 @@ func (s *bootstrapService) GetVersion(_ context.Context, _ *connect.Request[cere
 
 func (s *bootstrapService) CheckHealth(ctx context.Context, _ *connect.Request[cerebrov1.CheckHealthRequest]) (*connect.Response[cerebrov1.CheckHealthResponse], error) {
 	return connect.NewResponse(healthResponse(ctx, s.deps)), nil
+}
+
+func (s *bootstrapService) ListSources(_ context.Context, _ *connect.Request[cerebrov1.ListSourcesRequest]) (*connect.Response[cerebrov1.ListSourcesResponse], error) {
+	response := &cerebrov1.ListSourcesResponse{}
+	if s.sources != nil {
+		response.Sources = s.sources.List()
+	}
+	return connect.NewResponse(response), nil
 }
 
 func healthResponse(ctx context.Context, deps Dependencies) *cerebrov1.CheckHealthResponse {
@@ -116,6 +130,17 @@ func healthResponse(ctx context.Context, deps Dependencies) *cerebrov1.CheckHeal
 		CheckedAt:  timestamppb.Now(),
 		Components: components,
 	}
+}
+
+func writeProtoJSON(w http.ResponseWriter, statusCode int, message proto.Message) {
+	payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(message)
+	if err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_, _ = w.Write(payload)
 }
 
 type pinger interface {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
 type stubAppendLog struct {
@@ -30,8 +31,25 @@ type stubStore struct {
 
 func (s stubStore) Ping(context.Context) error { return s.err }
 
+type stubSource struct {
+	spec *cerebrov1.SourceSpec
+}
+
+func (s stubSource) Spec() *cerebrov1.SourceSpec                   { return s.spec }
+func (s stubSource) Check(context.Context, sourcecdk.Config) error { return nil }
+func (s stubSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+func (s stubSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{}, nil
+}
+
 func TestBootstrapEndpoints(t *testing.T) {
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{})
+	registry, err := sourcecdk.NewRegistry(stubSource{spec: &cerebrov1.SourceSpec{Id: "github", Name: "GitHub"}})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -54,6 +72,23 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if payload["status"] != "ready" {
 		t.Fatalf("health status = %#v, want %q", payload["status"], "ready")
 	}
+	sourcesResp, err := server.Client().Get(server.URL + "/sources")
+	if err != nil {
+		t.Fatalf("GET /sources error = %v", err)
+	}
+	defer func() {
+		if closeErr := sourcesResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /sources response body: %v", closeErr)
+		}
+	}()
+	var sourcesPayload map[string]any
+	if err := json.NewDecoder(sourcesResp.Body).Decode(&sourcesPayload); err != nil {
+		t.Fatalf("decode /sources response: %v", err)
+	}
+	entries, ok := sourcesPayload["sources"].([]any)
+	if !ok || len(entries) != 1 {
+		t.Fatalf("/sources entries = %#v, want single entry", sourcesPayload["sources"])
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	versionResp, err := client.GetVersion(context.Background(), connect.NewRequest(&cerebrov1.GetVersionRequest{}))
@@ -71,6 +106,13 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if healthResp.Msg.Status != "ready" {
 		t.Fatalf("CheckHealth status = %q, want %q", healthResp.Msg.Status, "ready")
 	}
+	listResp, err := client.ListSources(context.Background(), connect.NewRequest(&cerebrov1.ListSourcesRequest{}))
+	if err != nil {
+		t.Fatalf("ListSources() error = %v", err)
+	}
+	if len(listResp.Msg.Sources) != 1 {
+		t.Fatalf("len(ListSources.Sources) = %d, want 1", len(listResp.Msg.Sources))
+	}
 }
 
 func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
@@ -78,7 +120,7 @@ func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
 		AppendLog:  stubAppendLog{},
 		StateStore: stubStore{err: errors.New("state store unavailable")},
 		GraphStore: stubStore{},
-	})
+	}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 

--- a/internal/sourceregistry/registry.go
+++ b/internal/sourceregistry/registry.go
@@ -1,0 +1,17 @@
+package sourceregistry
+
+import (
+	"fmt"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+	githubsource "github.com/writer/cerebro/sources/github"
+)
+
+// Builtin constructs the in-process source registry for the rewrite skeleton.
+func Builtin() (*sourcecdk.Registry, error) {
+	github, err := githubsource.New()
+	if err != nil {
+		return nil, fmt.Errorf("load github source: %w", err)
+	}
+	return sourcecdk.NewRegistry(github)
+}

--- a/internal/sourceregistry/registry_test.go
+++ b/internal/sourceregistry/registry_test.go
@@ -1,0 +1,17 @@
+package sourceregistry
+
+import "testing"
+
+func TestBuiltin(t *testing.T) {
+	registry, err := Builtin()
+	if err != nil {
+		t.Fatalf("Builtin() error = %v", err)
+	}
+	source, ok := registry.Get("github")
+	if !ok {
+		t.Fatal("Get(github) = false, want true")
+	}
+	if source.Spec().Name != "GitHub" {
+		t.Fatalf("Spec().Name = %q, want %q", source.Spec().Name, "GitHub")
+	}
+}

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -4,12 +4,14 @@ package cerebro.v1;
 
 option go_package = "github.com/writer/cerebro/gen/cerebro/v1;cerebrov1";
 
+import "cerebro/v1/source.proto";
 import "google/protobuf/timestamp.proto";
 
 // BootstrapService is the minimal control-plane surface for the rewrite skeleton.
 service BootstrapService {
   rpc GetVersion(GetVersionRequest) returns (GetVersionResponse);
   rpc CheckHealth(CheckHealthRequest) returns (CheckHealthResponse);
+  rpc ListSources(ListSourcesRequest) returns (ListSourcesResponse);
 }
 
 // GetVersionRequest requests static build metadata from the running service.
@@ -39,4 +41,12 @@ message CheckHealthResponse {
   string status = 1;
   google.protobuf.Timestamp checked_at = 2;
   repeated ComponentStatus components = 3;
+}
+
+// ListSourcesRequest requests the currently registered source catalog.
+message ListSourcesRequest {}
+
+// ListSourcesResponse returns the registered in-process source specs.
+message ListSourcesResponse {
+  repeated SourceSpec sources = 1;
 }


### PR DESCRIPTION
## Summary
- add a built-in source registry package that wires the in-process GitHub source into bootstrap startup
- extend the bootstrap Connect surface with `ListSources` and add a matching `/sources` JSON endpoint
- cover source listing through bootstrap tests and local loopback smoke tests

## Testing
- `make proto-generate`
- `make verify`
- started `./bin/cerebro serve` locally and hit `/sources`
- exercised `BootstrapService/ListSources` over Connect
