### PR TITLE
feat(source): add source preview surfaces

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -7,11 +7,17 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/bootstrap"
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceregistry"
 )
 
@@ -41,11 +47,13 @@ func run(args []string) error {
 	switch command {
 	case "serve":
 		return serve()
+	case "source":
+		return runSource(args[1:])
 	case "version":
 		fmt.Printf("%s %s\n", buildinfo.ServiceName, buildinfo.Version)
 		return nil
 	}
-	return usageError(fmt.Sprintf("usage: %s [serve|version]", os.Args[0]))
+	return usageError(fmt.Sprintf("usage: %s [serve|version|source]", os.Args[0]))
 }
 
 func serve() error {
@@ -93,4 +101,96 @@ func serve() error {
 		}
 		return nil
 	}
+}
+
+func runSource(args []string) error {
+	if len(args) == 0 {
+		return usageError(fmt.Sprintf("usage: %s source [list|check|discover|read] ...", os.Args[0]))
+	}
+	registry, err := sourceregistry.Builtin()
+	if err != nil {
+		return fmt.Errorf("open source registry: %w", err)
+	}
+	service := sourceops.New(registry)
+
+	switch args[0] {
+	case "list":
+		return printProto(service.List())
+	case "check":
+		sourceID, config, _, err := parseSourceCommandArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		response, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{
+			SourceId: sourceID,
+			Config:   config,
+		})
+		if err != nil {
+			return err
+		}
+		return printProto(response)
+	case "discover":
+		sourceID, config, _, err := parseSourceCommandArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		response, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{
+			SourceId: sourceID,
+			Config:   config,
+		})
+		if err != nil {
+			return err
+		}
+		return printProto(response)
+	case "read":
+		sourceID, config, cursor, err := parseSourceCommandArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		response, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
+			SourceId: sourceID,
+			Config:   config,
+			Cursor:   cursor,
+		})
+		if err != nil {
+			return err
+		}
+		return printProto(response)
+	default:
+		return usageError(fmt.Sprintf("usage: %s source [list|check|discover|read] ...", os.Args[0]))
+	}
+}
+
+func parseSourceCommandArgs(args []string) (string, map[string]string, *cerebrov1.SourceCursor, error) {
+	if len(args) == 0 {
+		return "", nil, nil, usageError(fmt.Sprintf("usage: %s source <command> <source-id> [key=value ...]", os.Args[0]))
+	}
+	config := make(map[string]string)
+	var cursor *cerebrov1.SourceCursor
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return "", nil, nil, fmt.Errorf("invalid source argument %q; want key=value", arg)
+		}
+		if key == "cursor" {
+			cursor = &cerebrov1.SourceCursor{Opaque: value}
+			continue
+		}
+		config[key] = value
+	}
+	return args[0], config, cursor, nil
+}
+
+func printProto(message proto.Message) error {
+	payload, err := protojson.MarshalOptions{
+		UseProtoNames:   true,
+		EmitUnpopulated: true,
+	}.Marshal(message)
+	if err != nil {
+		return fmt.Errorf("marshal response: %w", err)
+	}
+	if _, err := os.Stdout.Write(append(payload, '\n')); err != nil {
+		return fmt.Errorf("write response: %w", err)
+	}
+	return nil
 }

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -172,13 +172,51 @@ func parseSourceCommandArgs(args []string) (string, map[string]string, *cerebrov
 		if !ok {
 			return "", nil, nil, fmt.Errorf("invalid source argument %q; want key=value", arg)
 		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return "", nil, nil, fmt.Errorf("invalid source argument %q; key is required", arg)
+		}
 		if key == "cursor" {
 			cursor = &cerebrov1.SourceCursor{Opaque: value}
 			continue
 		}
-		config[key] = value
+		parsed, err := parseSourceConfigValue(key, value)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		config[key] = parsed
 	}
 	return args[0], config, cursor, nil
+}
+
+func parseSourceConfigValue(key string, value string) (string, error) {
+	const envPrefix = "env:"
+	if strings.HasPrefix(value, envPrefix) {
+		name := strings.TrimSpace(strings.TrimPrefix(value, envPrefix))
+		if name == "" {
+			return "", fmt.Errorf("source config key %q env var name is required", key)
+		}
+		envValue, ok := os.LookupEnv(name)
+		if !ok {
+			return "", fmt.Errorf("source config key %q env var %q is not set", key, name)
+		}
+		return envValue, nil
+	}
+	if sensitiveSourceConfigKey(key) {
+		return "", fmt.Errorf("source config key %q must be supplied as %s=env:VAR", key, key)
+	}
+	return value, nil
+}
+
+func sensitiveSourceConfigKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	if normalized == "" {
+		return false
+	}
+	if strings.Contains(normalized, "token") || strings.Contains(normalized, "secret") || strings.Contains(normalized, "password") || strings.Contains(normalized, "session") {
+		return true
+	}
+	return normalized == "key" || strings.HasSuffix(normalized, "_key")
 }
 
 func printProto(message proto.Message) error {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+func TestParseSourceCommandArgsRejectsSensitiveLiteral(t *testing.T) {
+	_, _, _, err := parseSourceCommandArgs([]string{"github", "token=secret"})
+	if err == nil {
+		t.Fatal("parseSourceCommandArgs() error = nil, want non-nil")
+	}
+}
+
+func TestParseSourceCommandArgsReadsSensitiveEnv(t *testing.T) {
+	t.Setenv("CEREBRO_TEST_SOURCE_TOKEN", "secret")
+	sourceID, config, cursor, err := parseSourceCommandArgs([]string{
+		"github",
+		"token=env:CEREBRO_TEST_SOURCE_TOKEN",
+		"owner=writer",
+		"cursor=2",
+	})
+	if err != nil {
+		t.Fatalf("parseSourceCommandArgs() error = %v", err)
+	}
+	if sourceID != "github" {
+		t.Fatalf("sourceID = %q, want github", sourceID)
+	}
+	if config["token"] != "secret" {
+		t.Fatalf("config[token] = %q, want secret", config["token"])
+	}
+	if config["owner"] != "writer" {
+		t.Fatalf("config[owner] = %q, want writer", config["owner"])
+	}
+	if cursor == nil || cursor.GetOpaque() != "2" {
+		t.Fatalf("cursor = %#v, want opaque 2", cursor)
+	}
+}

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -377,12 +377,354 @@ func (x *ListSourcesResponse) GetSources() []*SourceSpec {
 	return nil
 }
 
+// CheckSourceRequest validates source configuration for a named source.
+type CheckSourceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SourceId      string                 `protobuf:"bytes,1,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
+	Config        map[string]string      `protobuf:"bytes,2,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckSourceRequest) Reset() {
+	*x = CheckSourceRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckSourceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckSourceRequest) ProtoMessage() {}
+
+func (x *CheckSourceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckSourceRequest.ProtoReflect.Descriptor instead.
+func (*CheckSourceRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *CheckSourceRequest) GetSourceId() string {
+	if x != nil {
+		return x.SourceId
+	}
+	return ""
+}
+
+func (x *CheckSourceRequest) GetConfig() map[string]string {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+// CheckSourceResponse returns the validated source metadata.
+type CheckSourceResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Source        *SourceSpec            `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
+	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckSourceResponse) Reset() {
+	*x = CheckSourceResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckSourceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckSourceResponse) ProtoMessage() {}
+
+func (x *CheckSourceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckSourceResponse.ProtoReflect.Descriptor instead.
+func (*CheckSourceResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *CheckSourceResponse) GetSource() *SourceSpec {
+	if x != nil {
+		return x.Source
+	}
+	return nil
+}
+
+func (x *CheckSourceResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+// DiscoverSourceRequest requests the current URNs for a named source.
+type DiscoverSourceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SourceId      string                 `protobuf:"bytes,1,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
+	Config        map[string]string      `protobuf:"bytes,2,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiscoverSourceRequest) Reset() {
+	*x = DiscoverSourceRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscoverSourceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscoverSourceRequest) ProtoMessage() {}
+
+func (x *DiscoverSourceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscoverSourceRequest.ProtoReflect.Descriptor instead.
+func (*DiscoverSourceRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *DiscoverSourceRequest) GetSourceId() string {
+	if x != nil {
+		return x.SourceId
+	}
+	return ""
+}
+
+func (x *DiscoverSourceRequest) GetConfig() map[string]string {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+// DiscoverSourceResponse returns the discovered URNs for a source.
+type DiscoverSourceResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Source        *SourceSpec            `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
+	Urns          []string               `protobuf:"bytes,2,rep,name=urns,proto3" json:"urns,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiscoverSourceResponse) Reset() {
+	*x = DiscoverSourceResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscoverSourceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscoverSourceResponse) ProtoMessage() {}
+
+func (x *DiscoverSourceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscoverSourceResponse.ProtoReflect.Descriptor instead.
+func (*DiscoverSourceResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *DiscoverSourceResponse) GetSource() *SourceSpec {
+	if x != nil {
+		return x.Source
+	}
+	return nil
+}
+
+func (x *DiscoverSourceResponse) GetUrns() []string {
+	if x != nil {
+		return x.Urns
+	}
+	return nil
+}
+
+// ReadSourceRequest requests one page of source events.
+type ReadSourceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SourceId      string                 `protobuf:"bytes,1,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
+	Config        map[string]string      `protobuf:"bytes,2,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Cursor        *SourceCursor          `protobuf:"bytes,3,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReadSourceRequest) Reset() {
+	*x = ReadSourceRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReadSourceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReadSourceRequest) ProtoMessage() {}
+
+func (x *ReadSourceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReadSourceRequest.ProtoReflect.Descriptor instead.
+func (*ReadSourceRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ReadSourceRequest) GetSourceId() string {
+	if x != nil {
+		return x.SourceId
+	}
+	return ""
+}
+
+func (x *ReadSourceRequest) GetConfig() map[string]string {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+func (x *ReadSourceRequest) GetCursor() *SourceCursor {
+	if x != nil {
+		return x.Cursor
+	}
+	return nil
+}
+
+// ReadSourceResponse returns one page of source events plus replay cursors.
+type ReadSourceResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Source        *SourceSpec            `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
+	Events        []*EventEnvelope       `protobuf:"bytes,2,rep,name=events,proto3" json:"events,omitempty"`
+	Checkpoint    *SourceCheckpoint      `protobuf:"bytes,3,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
+	NextCursor    *SourceCursor          `protobuf:"bytes,4,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReadSourceResponse) Reset() {
+	*x = ReadSourceResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReadSourceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReadSourceResponse) ProtoMessage() {}
+
+func (x *ReadSourceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReadSourceResponse.ProtoReflect.Descriptor instead.
+func (*ReadSourceResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ReadSourceResponse) GetSource() *SourceSpec {
+	if x != nil {
+		return x.Source
+	}
+	return nil
+}
+
+func (x *ReadSourceResponse) GetEvents() []*EventEnvelope {
+	if x != nil {
+		return x.Events
+	}
+	return nil
+}
+
+func (x *ReadSourceResponse) GetCheckpoint() *SourceCheckpoint {
+	if x != nil {
+		return x.Checkpoint
+	}
+	return nil
+}
+
+func (x *ReadSourceResponse) GetNextCursor() *SourceCursor {
+	if x != nil {
+		return x.NextCursor
+	}
+	return nil
+}
+
 var File_cerebro_v1_bootstrap_proto protoreflect.FileDescriptor
 
 const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\n" +
 	"\x1acerebro/v1/bootstrap.proto\x12\n" +
-	"cerebro.v1\x1a\x17cerebro/v1/source.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x13\n" +
+	"cerebro.v1\x1a\x1bcerebro/v1/primitives.proto\x1a\x17cerebro/v1/source.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x13\n" +
 	"\x11GetVersionRequest\"\xa9\x01\n" +
 	"\x12GetVersionResponse\x12!\n" +
 	"\fservice_name\x18\x01 \x01(\tR\vserviceName\x12\x18\n" +
@@ -406,12 +748,49 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"components\"\x14\n" +
 	"\x12ListSourcesRequest\"G\n" +
 	"\x13ListSourcesResponse\x120\n" +
-	"\asources\x18\x01 \x03(\v2\x16.cerebro.v1.SourceSpecR\asources2\xff\x01\n" +
+	"\asources\x18\x01 \x03(\v2\x16.cerebro.v1.SourceSpecR\asources\"\xb0\x01\n" +
+	"\x12CheckSourceRequest\x12\x1b\n" +
+	"\tsource_id\x18\x01 \x01(\tR\bsourceId\x12B\n" +
+	"\x06config\x18\x02 \x03(\v2*.cerebro.v1.CheckSourceRequest.ConfigEntryR\x06config\x1a9\n" +
+	"\vConfigEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"]\n" +
+	"\x13CheckSourceResponse\x12.\n" +
+	"\x06source\x18\x01 \x01(\v2\x16.cerebro.v1.SourceSpecR\x06source\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\tR\x06status\"\xb6\x01\n" +
+	"\x15DiscoverSourceRequest\x12\x1b\n" +
+	"\tsource_id\x18\x01 \x01(\tR\bsourceId\x12E\n" +
+	"\x06config\x18\x02 \x03(\v2-.cerebro.v1.DiscoverSourceRequest.ConfigEntryR\x06config\x1a9\n" +
+	"\vConfigEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\\\n" +
+	"\x16DiscoverSourceResponse\x12.\n" +
+	"\x06source\x18\x01 \x01(\v2\x16.cerebro.v1.SourceSpecR\x06source\x12\x12\n" +
+	"\x04urns\x18\x02 \x03(\tR\x04urns\"\xe0\x01\n" +
+	"\x11ReadSourceRequest\x12\x1b\n" +
+	"\tsource_id\x18\x01 \x01(\tR\bsourceId\x12A\n" +
+	"\x06config\x18\x02 \x03(\v2).cerebro.v1.ReadSourceRequest.ConfigEntryR\x06config\x120\n" +
+	"\x06cursor\x18\x03 \x01(\v2\x18.cerebro.v1.SourceCursorR\x06cursor\x1a9\n" +
+	"\vConfigEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xf0\x01\n" +
+	"\x12ReadSourceResponse\x12.\n" +
+	"\x06source\x18\x01 \x01(\v2\x16.cerebro.v1.SourceSpecR\x06source\x121\n" +
+	"\x06events\x18\x02 \x03(\v2\x19.cerebro.v1.EventEnvelopeR\x06events\x12<\n" +
+	"\n" +
+	"checkpoint\x18\x03 \x01(\v2\x1c.cerebro.v1.SourceCheckpointR\n" +
+	"checkpoint\x129\n" +
+	"\vnext_cursor\x18\x04 \x01(\v2\x18.cerebro.v1.SourceCursorR\n" +
+	"nextCursor2\xf5\x03\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
 	"\vCheckHealth\x12\x1e.cerebro.v1.CheckHealthRequest\x1a\x1f.cerebro.v1.CheckHealthResponse\x12N\n" +
-	"\vListSources\x12\x1e.cerebro.v1.ListSourcesRequest\x1a\x1f.cerebro.v1.ListSourcesResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
+	"\vListSources\x12\x1e.cerebro.v1.ListSourcesRequest\x1a\x1f.cerebro.v1.ListSourcesResponse\x12N\n" +
+	"\vCheckSource\x12\x1e.cerebro.v1.CheckSourceRequest\x1a\x1f.cerebro.v1.CheckSourceResponse\x12W\n" +
+	"\x0eDiscoverSource\x12!.cerebro.v1.DiscoverSourceRequest\x1a\".cerebro.v1.DiscoverSourceResponse\x12K\n" +
+	"\n" +
+	"ReadSource\x12\x1d.cerebro.v1.ReadSourceRequest\x1a\x1e.cerebro.v1.ReadSourceResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
 
 var (
 	file_cerebro_v1_bootstrap_proto_rawDescOnce sync.Once
@@ -425,33 +804,61 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
-	(*GetVersionRequest)(nil),     // 0: cerebro.v1.GetVersionRequest
-	(*GetVersionResponse)(nil),    // 1: cerebro.v1.GetVersionResponse
-	(*CheckHealthRequest)(nil),    // 2: cerebro.v1.CheckHealthRequest
-	(*ComponentStatus)(nil),       // 3: cerebro.v1.ComponentStatus
-	(*CheckHealthResponse)(nil),   // 4: cerebro.v1.CheckHealthResponse
-	(*ListSourcesRequest)(nil),    // 5: cerebro.v1.ListSourcesRequest
-	(*ListSourcesResponse)(nil),   // 6: cerebro.v1.ListSourcesResponse
-	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
-	(*SourceSpec)(nil),            // 8: cerebro.v1.SourceSpec
+	(*GetVersionRequest)(nil),      // 0: cerebro.v1.GetVersionRequest
+	(*GetVersionResponse)(nil),     // 1: cerebro.v1.GetVersionResponse
+	(*CheckHealthRequest)(nil),     // 2: cerebro.v1.CheckHealthRequest
+	(*ComponentStatus)(nil),        // 3: cerebro.v1.ComponentStatus
+	(*CheckHealthResponse)(nil),    // 4: cerebro.v1.CheckHealthResponse
+	(*ListSourcesRequest)(nil),     // 5: cerebro.v1.ListSourcesRequest
+	(*ListSourcesResponse)(nil),    // 6: cerebro.v1.ListSourcesResponse
+	(*CheckSourceRequest)(nil),     // 7: cerebro.v1.CheckSourceRequest
+	(*CheckSourceResponse)(nil),    // 8: cerebro.v1.CheckSourceResponse
+	(*DiscoverSourceRequest)(nil),  // 9: cerebro.v1.DiscoverSourceRequest
+	(*DiscoverSourceResponse)(nil), // 10: cerebro.v1.DiscoverSourceResponse
+	(*ReadSourceRequest)(nil),      // 11: cerebro.v1.ReadSourceRequest
+	(*ReadSourceResponse)(nil),     // 12: cerebro.v1.ReadSourceResponse
+	nil,                            // 13: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                            // 14: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                            // 15: cerebro.v1.ReadSourceRequest.ConfigEntry
+	(*timestamppb.Timestamp)(nil),  // 16: google.protobuf.Timestamp
+	(*SourceSpec)(nil),             // 17: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),           // 18: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),          // 19: cerebro.v1.EventEnvelope
+	(*SourceCheckpoint)(nil),       // 20: cerebro.v1.SourceCheckpoint
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	7, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
-	3, // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
-	8, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	0, // 3: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2, // 4: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	5, // 5: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	1, // 6: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4, // 7: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	6, // 8: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	6, // [6:9] is the sub-list for method output_type
-	3, // [3:6] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	16, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
+	17, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	13, // 3: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	17, // 4: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	14, // 5: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	17, // 6: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	15, // 7: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	18, // 8: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	17, // 9: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	19, // 10: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	20, // 11: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	18, // 12: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	0,  // 13: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 14: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	5,  // 15: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	7,  // 16: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	9,  // 17: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	11, // 18: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	1,  // 19: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 20: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	6,  // 21: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	8,  // 22: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	10, // 23: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	12, // 24: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	19, // [19:25] is the sub-list for method output_type
+	13, // [13:19] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -459,6 +866,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 	if File_cerebro_v1_bootstrap_proto != nil {
 		return
 	}
+	file_cerebro_v1_primitives_proto_init()
 	file_cerebro_v1_source_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -466,7 +874,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -42,6 +42,15 @@ const (
 	// BootstrapServiceListSourcesProcedure is the fully-qualified name of the BootstrapService's
 	// ListSources RPC.
 	BootstrapServiceListSourcesProcedure = "/cerebro.v1.BootstrapService/ListSources"
+	// BootstrapServiceCheckSourceProcedure is the fully-qualified name of the BootstrapService's
+	// CheckSource RPC.
+	BootstrapServiceCheckSourceProcedure = "/cerebro.v1.BootstrapService/CheckSource"
+	// BootstrapServiceDiscoverSourceProcedure is the fully-qualified name of the BootstrapService's
+	// DiscoverSource RPC.
+	BootstrapServiceDiscoverSourceProcedure = "/cerebro.v1.BootstrapService/DiscoverSource"
+	// BootstrapServiceReadSourceProcedure is the fully-qualified name of the BootstrapService's
+	// ReadSource RPC.
+	BootstrapServiceReadSourceProcedure = "/cerebro.v1.BootstrapService/ReadSource"
 )
 
 // BootstrapServiceClient is a client for the cerebro.v1.BootstrapService service.
@@ -49,6 +58,9 @@ type BootstrapServiceClient interface {
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
 	CheckHealth(context.Context, *connect.Request[v1.CheckHealthRequest]) (*connect.Response[v1.CheckHealthResponse], error)
 	ListSources(context.Context, *connect.Request[v1.ListSourcesRequest]) (*connect.Response[v1.ListSourcesResponse], error)
+	CheckSource(context.Context, *connect.Request[v1.CheckSourceRequest]) (*connect.Response[v1.CheckSourceResponse], error)
+	DiscoverSource(context.Context, *connect.Request[v1.DiscoverSourceRequest]) (*connect.Response[v1.DiscoverSourceResponse], error)
+	ReadSource(context.Context, *connect.Request[v1.ReadSourceRequest]) (*connect.Response[v1.ReadSourceResponse], error)
 }
 
 // NewBootstrapServiceClient constructs a client for the cerebro.v1.BootstrapService service. By
@@ -80,14 +92,35 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("ListSources")),
 			connect.WithClientOptions(opts...),
 		),
+		checkSource: connect.NewClient[v1.CheckSourceRequest, v1.CheckSourceResponse](
+			httpClient,
+			baseURL+BootstrapServiceCheckSourceProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("CheckSource")),
+			connect.WithClientOptions(opts...),
+		),
+		discoverSource: connect.NewClient[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse](
+			httpClient,
+			baseURL+BootstrapServiceDiscoverSourceProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("DiscoverSource")),
+			connect.WithClientOptions(opts...),
+		),
+		readSource: connect.NewClient[v1.ReadSourceRequest, v1.ReadSourceResponse](
+			httpClient,
+			baseURL+BootstrapServiceReadSourceProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("ReadSource")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // bootstrapServiceClient implements BootstrapServiceClient.
 type bootstrapServiceClient struct {
-	getVersion  *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
-	checkHealth *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
-	listSources *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
+	getVersion     *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
+	checkHealth    *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
+	listSources    *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
+	checkSource    *connect.Client[v1.CheckSourceRequest, v1.CheckSourceResponse]
+	discoverSource *connect.Client[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse]
+	readSource     *connect.Client[v1.ReadSourceRequest, v1.ReadSourceResponse]
 }
 
 // GetVersion calls cerebro.v1.BootstrapService.GetVersion.
@@ -105,11 +138,29 @@ func (c *bootstrapServiceClient) ListSources(ctx context.Context, req *connect.R
 	return c.listSources.CallUnary(ctx, req)
 }
 
+// CheckSource calls cerebro.v1.BootstrapService.CheckSource.
+func (c *bootstrapServiceClient) CheckSource(ctx context.Context, req *connect.Request[v1.CheckSourceRequest]) (*connect.Response[v1.CheckSourceResponse], error) {
+	return c.checkSource.CallUnary(ctx, req)
+}
+
+// DiscoverSource calls cerebro.v1.BootstrapService.DiscoverSource.
+func (c *bootstrapServiceClient) DiscoverSource(ctx context.Context, req *connect.Request[v1.DiscoverSourceRequest]) (*connect.Response[v1.DiscoverSourceResponse], error) {
+	return c.discoverSource.CallUnary(ctx, req)
+}
+
+// ReadSource calls cerebro.v1.BootstrapService.ReadSource.
+func (c *bootstrapServiceClient) ReadSource(ctx context.Context, req *connect.Request[v1.ReadSourceRequest]) (*connect.Response[v1.ReadSourceResponse], error) {
+	return c.readSource.CallUnary(ctx, req)
+}
+
 // BootstrapServiceHandler is an implementation of the cerebro.v1.BootstrapService service.
 type BootstrapServiceHandler interface {
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
 	CheckHealth(context.Context, *connect.Request[v1.CheckHealthRequest]) (*connect.Response[v1.CheckHealthResponse], error)
 	ListSources(context.Context, *connect.Request[v1.ListSourcesRequest]) (*connect.Response[v1.ListSourcesResponse], error)
+	CheckSource(context.Context, *connect.Request[v1.CheckSourceRequest]) (*connect.Response[v1.CheckSourceResponse], error)
+	DiscoverSource(context.Context, *connect.Request[v1.DiscoverSourceRequest]) (*connect.Response[v1.DiscoverSourceResponse], error)
+	ReadSource(context.Context, *connect.Request[v1.ReadSourceRequest]) (*connect.Response[v1.ReadSourceResponse], error)
 }
 
 // NewBootstrapServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -137,6 +188,24 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		connect.WithSchema(bootstrapServiceMethods.ByName("ListSources")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bootstrapServiceCheckSourceHandler := connect.NewUnaryHandler(
+		BootstrapServiceCheckSourceProcedure,
+		svc.CheckSource,
+		connect.WithSchema(bootstrapServiceMethods.ByName("CheckSource")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceDiscoverSourceHandler := connect.NewUnaryHandler(
+		BootstrapServiceDiscoverSourceProcedure,
+		svc.DiscoverSource,
+		connect.WithSchema(bootstrapServiceMethods.ByName("DiscoverSource")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceReadSourceHandler := connect.NewUnaryHandler(
+		BootstrapServiceReadSourceProcedure,
+		svc.ReadSource,
+		connect.WithSchema(bootstrapServiceMethods.ByName("ReadSource")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/cerebro.v1.BootstrapService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case BootstrapServiceGetVersionProcedure:
@@ -145,6 +214,12 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceCheckHealthHandler.ServeHTTP(w, r)
 		case BootstrapServiceListSourcesProcedure:
 			bootstrapServiceListSourcesHandler.ServeHTTP(w, r)
+		case BootstrapServiceCheckSourceProcedure:
+			bootstrapServiceCheckSourceHandler.ServeHTTP(w, r)
+		case BootstrapServiceDiscoverSourceProcedure:
+			bootstrapServiceDiscoverSourceHandler.ServeHTTP(w, r)
+		case BootstrapServiceReadSourceProcedure:
+			bootstrapServiceReadSourceHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -164,4 +239,16 @@ func (UnimplementedBootstrapServiceHandler) CheckHealth(context.Context, *connec
 
 func (UnimplementedBootstrapServiceHandler) ListSources(context.Context, *connect.Request[v1.ListSourcesRequest]) (*connect.Response[v1.ListSourcesResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListSources is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) CheckSource(context.Context, *connect.Request[v1.CheckSourceRequest]) (*connect.Response[v1.CheckSourceResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.CheckSource is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) DiscoverSource(context.Context, *connect.Request[v1.DiscoverSourceRequest]) (*connect.Response[v1.DiscoverSourceResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.DiscoverSource is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) ReadSource(context.Context, *connect.Request[v1.ReadSourceRequest]) (*connect.Response[v1.ReadSourceResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ReadSource is not implemented"))
 }

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -3,7 +3,9 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -91,9 +93,14 @@ func (a *App) handleSources(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleCheckSource(w http.ResponseWriter, r *http.Request) {
+	config, err := sourceConfigFromQuery(r)
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
 	response, err := a.sourceService().Check(r.Context(), &cerebrov1.CheckSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   sourceConfigFromQuery(r),
+		Config:   config,
 	})
 	if err != nil {
 		writeSourceError(w, err)
@@ -103,9 +110,14 @@ func (a *App) handleCheckSource(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleDiscoverSource(w http.ResponseWriter, r *http.Request) {
+	config, err := sourceConfigFromQuery(r)
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
 	response, err := a.sourceService().Discover(r.Context(), &cerebrov1.DiscoverSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   sourceConfigFromQuery(r),
+		Config:   config,
 	})
 	if err != nil {
 		writeSourceError(w, err)
@@ -115,9 +127,14 @@ func (a *App) handleDiscoverSource(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleReadSource(w http.ResponseWriter, r *http.Request) {
+	config, err := sourceConfigFromQuery(r)
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
 	request := &cerebrov1.ReadSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   sourceConfigFromQuery(r),
+		Config:   config,
 	}
 	rawCursors := r.URL.Query()["cursor"]
 	if len(rawCursors) > 0 {
@@ -155,7 +172,7 @@ func (s *bootstrapService) ListSources(_ context.Context, _ *connect.Request[cer
 func (s *bootstrapService) CheckSource(ctx context.Context, req *connect.Request[cerebrov1.CheckSourceRequest]) (*connect.Response[cerebrov1.CheckSourceResponse], error) {
 	response, err := sourceops.New(s.sources).Check(ctx, req.Msg)
 	if err != nil {
-		return nil, err
+		return nil, sourceConnectError(err)
 	}
 	return connect.NewResponse(response), nil
 }
@@ -163,7 +180,7 @@ func (s *bootstrapService) CheckSource(ctx context.Context, req *connect.Request
 func (s *bootstrapService) DiscoverSource(ctx context.Context, req *connect.Request[cerebrov1.DiscoverSourceRequest]) (*connect.Response[cerebrov1.DiscoverSourceResponse], error) {
 	response, err := sourceops.New(s.sources).Discover(ctx, req.Msg)
 	if err != nil {
-		return nil, err
+		return nil, sourceConnectError(err)
 	}
 	return connect.NewResponse(response), nil
 }
@@ -171,7 +188,7 @@ func (s *bootstrapService) DiscoverSource(ctx context.Context, req *connect.Requ
 func (s *bootstrapService) ReadSource(ctx context.Context, req *connect.Request[cerebrov1.ReadSourceRequest]) (*connect.Response[cerebrov1.ReadSourceResponse], error) {
 	response, err := sourceops.New(s.sources).Read(ctx, req.Msg)
 	if err != nil {
-		return nil, err
+		return nil, sourceConnectError(err)
 	}
 	return connect.NewResponse(response), nil
 }
@@ -211,15 +228,47 @@ func (a *App) sourceService() *sourceops.Service {
 	return sourceops.New(a.sources)
 }
 
-func sourceConfigFromQuery(r *http.Request) map[string]string {
+func sourceConfigFromQuery(r *http.Request) (map[string]string, error) {
 	values := make(map[string]string)
 	for key, rawValues := range r.URL.Query() {
 		if key == "cursor" || len(rawValues) == 0 {
 			continue
 		}
+		if sensitiveSourceConfigKey(key) {
+			return nil, fmt.Errorf("source config key %q must not be passed as a query parameter", key)
+		}
 		values[key] = rawValues[len(rawValues)-1]
 	}
-	return values
+	if token := bearerToken(r.Header.Get("Authorization")); token != "" {
+		values["token"] = token
+	}
+	return values, nil
+}
+
+func bearerToken(header string) string {
+	header = strings.TrimSpace(header)
+	if len(header) < len("Bearer ") || !strings.EqualFold(header[:len("Bearer ")], "Bearer ") {
+		return ""
+	}
+	return strings.TrimSpace(header[len("Bearer "):])
+}
+
+func sensitiveSourceConfigKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	if normalized == "" {
+		return false
+	}
+	if strings.Contains(normalized, "token") || strings.Contains(normalized, "secret") || strings.Contains(normalized, "password") || strings.Contains(normalized, "session") {
+		return true
+	}
+	return normalized == "key" || strings.HasSuffix(normalized, "_key")
+}
+
+func sourceConnectError(err error) error {
+	if errors.Is(err, sourceops.ErrSourceNotFound) {
+		return connect.NewError(connect.CodeNotFound, err)
+	}
+	return err
 }
 
 func writeSourceError(w http.ResponseWriter, err error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -265,6 +265,9 @@ func sensitiveSourceConfigKey(key string) bool {
 }
 
 func sourceConnectError(err error) error {
+	if errors.Is(err, sourceops.ErrInvalidSourceID) {
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	}
 	if errors.Is(err, sourceops.ErrSourceNotFound) {
 		return connect.NewError(connect.CodeNotFound, err)
 	}

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceops"
 )
 
 // Dependencies are the future store/log boundaries that will be wired into the rewrite.
@@ -51,6 +52,9 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("/health", app.handleHealth)
 	mux.HandleFunc("/healthz", app.handleHealth)
 	mux.HandleFunc("/sources", app.handleSources)
+	mux.HandleFunc("GET /sources/{sourceID}/check", app.handleCheckSource)
+	mux.HandleFunc("GET /sources/{sourceID}/discover", app.handleDiscoverSource)
+	mux.HandleFunc("GET /sources/{sourceID}/read", app.handleReadSource)
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           mux,
@@ -83,9 +87,45 @@ func (a *App) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleSources(w http.ResponseWriter, r *http.Request) {
-	response := &cerebrov1.ListSourcesResponse{}
-	if a.sources != nil {
-		response.Sources = a.sources.List()
+	writeProtoJSON(w, http.StatusOK, a.sourceService().List())
+}
+
+func (a *App) handleCheckSource(w http.ResponseWriter, r *http.Request) {
+	response, err := a.sourceService().Check(r.Context(), &cerebrov1.CheckSourceRequest{
+		SourceId: r.PathValue("sourceID"),
+		Config:   sourceConfigFromQuery(r),
+	})
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleDiscoverSource(w http.ResponseWriter, r *http.Request) {
+	response, err := a.sourceService().Discover(r.Context(), &cerebrov1.DiscoverSourceRequest{
+		SourceId: r.PathValue("sourceID"),
+		Config:   sourceConfigFromQuery(r),
+	})
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleReadSource(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.ReadSourceRequest{
+		SourceId: r.PathValue("sourceID"),
+		Config:   sourceConfigFromQuery(r),
+	}
+	if cursor := r.URL.Query().Get("cursor"); cursor != "" {
+		request.Cursor = &cerebrov1.SourceCursor{Opaque: cursor}
+	}
+	response, err := a.sourceService().Read(r.Context(), request)
+	if err != nil {
+		writeSourceError(w, err)
+		return
 	}
 	writeProtoJSON(w, http.StatusOK, response)
 }
@@ -105,9 +145,29 @@ func (s *bootstrapService) CheckHealth(ctx context.Context, _ *connect.Request[c
 }
 
 func (s *bootstrapService) ListSources(_ context.Context, _ *connect.Request[cerebrov1.ListSourcesRequest]) (*connect.Response[cerebrov1.ListSourcesResponse], error) {
-	response := &cerebrov1.ListSourcesResponse{}
-	if s.sources != nil {
-		response.Sources = s.sources.List()
+	return connect.NewResponse(sourceops.New(s.sources).List()), nil
+}
+
+func (s *bootstrapService) CheckSource(ctx context.Context, req *connect.Request[cerebrov1.CheckSourceRequest]) (*connect.Response[cerebrov1.CheckSourceResponse], error) {
+	response, err := sourceops.New(s.sources).Check(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (s *bootstrapService) DiscoverSource(ctx context.Context, req *connect.Request[cerebrov1.DiscoverSourceRequest]) (*connect.Response[cerebrov1.DiscoverSourceResponse], error) {
+	response, err := sourceops.New(s.sources).Discover(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (s *bootstrapService) ReadSource(ctx context.Context, req *connect.Request[cerebrov1.ReadSourceRequest]) (*connect.Response[cerebrov1.ReadSourceResponse], error) {
+	response, err := sourceops.New(s.sources).Read(ctx, req.Msg)
+	if err != nil {
+		return nil, err
 	}
 	return connect.NewResponse(response), nil
 }
@@ -141,6 +201,29 @@ func writeProtoJSON(w http.ResponseWriter, statusCode int, message proto.Message
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	_, _ = w.Write(payload)
+}
+
+func (a *App) sourceService() *sourceops.Service {
+	return sourceops.New(a.sources)
+}
+
+func sourceConfigFromQuery(r *http.Request) map[string]string {
+	values := make(map[string]string)
+	for key, rawValues := range r.URL.Query() {
+		if key == "cursor" || len(rawValues) == 0 {
+			continue
+		}
+		values[key] = rawValues[len(rawValues)-1]
+	}
+	return values
+}
+
+func writeSourceError(w http.ResponseWriter, err error) {
+	statusCode := http.StatusBadRequest
+	if errors.Is(err, sourceops.ErrSourceNotFound) {
+		statusCode = http.StatusNotFound
+	}
+	http.Error(w, err.Error(), statusCode)
 }
 
 type pinger interface {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -265,7 +265,7 @@ func sensitiveSourceConfigKey(key string) bool {
 }
 
 func sourceConnectError(err error) error {
-	if errors.Is(err, sourceops.ErrInvalidSourceID) {
+	if errors.Is(err, sourceops.ErrInvalidSourceID) || errors.Is(err, sourceops.ErrInvalidSourceConfig) {
 		return connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if errors.Is(err, sourceops.ErrSourceNotFound) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -119,8 +119,12 @@ func (a *App) handleReadSource(w http.ResponseWriter, r *http.Request) {
 		SourceId: r.PathValue("sourceID"),
 		Config:   sourceConfigFromQuery(r),
 	}
-	if cursor := r.URL.Query().Get("cursor"); cursor != "" {
-		request.Cursor = &cerebrov1.SourceCursor{Opaque: cursor}
+	rawCursors := r.URL.Query()["cursor"]
+	if len(rawCursors) > 0 {
+		cursor := rawCursors[len(rawCursors)-1]
+		if cursor != "" {
+			request.Cursor = &cerebrov1.SourceCursor{Opaque: cursor}
+		}
 	}
 	response, err := a.sourceService().Read(r.Context(), request)
 	if err != nil {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -225,6 +225,20 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("CheckSource(empty) code = %v, want %v", connect.CodeOf(err), connect.CodeInvalidArgument)
 	}
+
+	_, err = client.CheckSource(context.Background(), connect.NewRequest(&cerebrov1.CheckSourceRequest{SourceId: "github"}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("CheckSource(missing token) code = %v, want %v", connect.CodeOf(err), connect.CodeInvalidArgument)
+	}
+
+	_, err = client.ReadSource(context.Background(), connect.NewRequest(&cerebrov1.ReadSourceRequest{
+		SourceId: "github",
+		Config:   map[string]string{"token": "test"},
+		Cursor:   &cerebrov1.SourceCursor{Opaque: "-1"},
+	}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("ReadSource(invalid cursor) code = %v, want %v", connect.CodeOf(err), connect.CodeInvalidArgument)
+	}
 }
 
 func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -39,6 +39,14 @@ func TestBootstrapEndpoints(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
+	authedGet := func(path string) (*http.Response, error) {
+		req, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer test")
+		return server.Client().Do(req)
+	}
 
 	resp, err := server.Client().Get(server.URL + "/health")
 	if err != nil {
@@ -76,7 +84,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if !ok || len(entries) != 1 {
 		t.Fatalf("/sources entries = %#v, want single entry", sourcesPayload["sources"])
 	}
-	checkResp, err := server.Client().Get(server.URL + "/sources/github/check?token=test")
+	checkResp, err := authedGet("/sources/github/check")
 	if err != nil {
 		t.Fatalf("GET /sources/github/check error = %v", err)
 	}
@@ -92,7 +100,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if checkPayload["status"] != "ok" {
 		t.Fatalf("check status = %#v, want %q", checkPayload["status"], "ok")
 	}
-	discoverResp, err := server.Client().Get(server.URL + "/sources/github/discover?token=test")
+	discoverResp, err := authedGet("/sources/github/discover")
 	if err != nil {
 		t.Fatalf("GET /sources/github/discover error = %v", err)
 	}
@@ -108,7 +116,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if urns, ok := discoverPayload["urns"].([]any); !ok || len(urns) != 2 {
 		t.Fatalf("discover urns = %#v, want 2 entries", discoverPayload["urns"])
 	}
-	readResp, err := server.Client().Get(server.URL + "/sources/github/read?token=test")
+	readResp, err := authedGet("/sources/github/read")
 	if err != nil {
 		t.Fatalf("GET /sources/github/read error = %v", err)
 	}
@@ -124,7 +132,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if events, ok := readPayload["events"].([]any); !ok || len(events) != 1 {
 		t.Fatalf("read events = %#v, want 1 entry", readPayload["events"])
 	}
-	repeatedCursorResp, err := server.Client().Get(server.URL + "/sources/github/read?token=test&cursor=0&cursor=1")
+	repeatedCursorResp, err := authedGet("/sources/github/read?cursor=0&cursor=1")
 	if err != nil {
 		t.Fatalf("GET /sources/github/read repeated cursor error = %v", err)
 	}
@@ -144,6 +152,19 @@ func TestBootstrapEndpoints(t *testing.T) {
 	repeatedCursorEvent, ok := repeatedCursorEvents[0].(map[string]any)
 	if !ok || repeatedCursorEvent["id"] != "github-pr-1" {
 		t.Fatalf("repeated cursor event = %#v, want github-pr-1", repeatedCursorEvents[0])
+	}
+
+	secretQueryResp, err := server.Client().Get(server.URL + "/sources/github/check?token=test")
+	if err != nil {
+		t.Fatalf("GET /sources/github/check secret query error = %v", err)
+	}
+	defer func() {
+		if closeErr := secretQueryResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close secret query response body: %v", closeErr)
+		}
+	}()
+	if secretQueryResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("secret query status = %d, want %d", secretQueryResp.StatusCode, http.StatusBadRequest)
 	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
-	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceregistry"
 )
 
 type stubAppendLog struct {
@@ -31,23 +31,10 @@ type stubStore struct {
 
 func (s stubStore) Ping(context.Context) error { return s.err }
 
-type stubSource struct {
-	spec *cerebrov1.SourceSpec
-}
-
-func (s stubSource) Spec() *cerebrov1.SourceSpec                   { return s.spec }
-func (s stubSource) Check(context.Context, sourcecdk.Config) error { return nil }
-func (s stubSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
-	return nil, nil
-}
-func (s stubSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-	return sourcecdk.Pull{}, nil
-}
-
 func TestBootstrapEndpoints(t *testing.T) {
-	registry, err := sourcecdk.NewRegistry(stubSource{spec: &cerebrov1.SourceSpec{Id: "github", Name: "GitHub"}})
+	registry, err := sourceregistry.Builtin()
 	if err != nil {
-		t.Fatalf("NewRegistry() error = %v", err)
+		t.Fatalf("Builtin() error = %v", err)
 	}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, registry)
 	server := httptest.NewServer(app.Handler())
@@ -89,6 +76,54 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if !ok || len(entries) != 1 {
 		t.Fatalf("/sources entries = %#v, want single entry", sourcesPayload["sources"])
 	}
+	checkResp, err := server.Client().Get(server.URL + "/sources/github/check?token=test")
+	if err != nil {
+		t.Fatalf("GET /sources/github/check error = %v", err)
+	}
+	defer func() {
+		if closeErr := checkResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /sources/github/check response body: %v", closeErr)
+		}
+	}()
+	var checkPayload map[string]any
+	if err := json.NewDecoder(checkResp.Body).Decode(&checkPayload); err != nil {
+		t.Fatalf("decode /sources/github/check response: %v", err)
+	}
+	if checkPayload["status"] != "ok" {
+		t.Fatalf("check status = %#v, want %q", checkPayload["status"], "ok")
+	}
+	discoverResp, err := server.Client().Get(server.URL + "/sources/github/discover?token=test")
+	if err != nil {
+		t.Fatalf("GET /sources/github/discover error = %v", err)
+	}
+	defer func() {
+		if closeErr := discoverResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /sources/github/discover response body: %v", closeErr)
+		}
+	}()
+	var discoverPayload map[string]any
+	if err := json.NewDecoder(discoverResp.Body).Decode(&discoverPayload); err != nil {
+		t.Fatalf("decode /sources/github/discover response: %v", err)
+	}
+	if urns, ok := discoverPayload["urns"].([]any); !ok || len(urns) != 2 {
+		t.Fatalf("discover urns = %#v, want 2 entries", discoverPayload["urns"])
+	}
+	readResp, err := server.Client().Get(server.URL + "/sources/github/read?token=test")
+	if err != nil {
+		t.Fatalf("GET /sources/github/read error = %v", err)
+	}
+	defer func() {
+		if closeErr := readResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /sources/github/read response body: %v", closeErr)
+		}
+	}()
+	var readPayload map[string]any
+	if err := json.NewDecoder(readResp.Body).Decode(&readPayload); err != nil {
+		t.Fatalf("decode /sources/github/read response: %v", err)
+	}
+	if events, ok := readPayload["events"].([]any); !ok || len(events) != 1 {
+		t.Fatalf("read events = %#v, want 1 entry", readPayload["events"])
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	versionResp, err := client.GetVersion(context.Background(), connect.NewRequest(&cerebrov1.GetVersionRequest{}))
@@ -112,6 +147,36 @@ func TestBootstrapEndpoints(t *testing.T) {
 	}
 	if len(listResp.Msg.Sources) != 1 {
 		t.Fatalf("len(ListSources.Sources) = %d, want 1", len(listResp.Msg.Sources))
+	}
+	checkSourceResp, err := client.CheckSource(context.Background(), connect.NewRequest(&cerebrov1.CheckSourceRequest{
+		SourceId: "github",
+		Config:   map[string]string{"token": "test"},
+	}))
+	if err != nil {
+		t.Fatalf("CheckSource() error = %v", err)
+	}
+	if checkSourceResp.Msg.Status != "ok" {
+		t.Fatalf("CheckSource status = %q, want %q", checkSourceResp.Msg.Status, "ok")
+	}
+	discoverSourceResp, err := client.DiscoverSource(context.Background(), connect.NewRequest(&cerebrov1.DiscoverSourceRequest{
+		SourceId: "github",
+		Config:   map[string]string{"token": "test"},
+	}))
+	if err != nil {
+		t.Fatalf("DiscoverSource() error = %v", err)
+	}
+	if len(discoverSourceResp.Msg.Urns) != 2 {
+		t.Fatalf("len(DiscoverSource.Urns) = %d, want 2", len(discoverSourceResp.Msg.Urns))
+	}
+	readSourceResp, err := client.ReadSource(context.Background(), connect.NewRequest(&cerebrov1.ReadSourceRequest{
+		SourceId: "github",
+		Config:   map[string]string{"token": "test"},
+	}))
+	if err != nil {
+		t.Fatalf("ReadSource() error = %v", err)
+	}
+	if len(readSourceResp.Msg.Events) != 1 {
+		t.Fatalf("len(ReadSource.Events) = %d, want 1", len(readSourceResp.Msg.Events))
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -220,6 +220,11 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if len(readSourceResp.Msg.Events) != 1 {
 		t.Fatalf("len(ReadSource.Events) = %d, want 1", len(readSourceResp.Msg.Events))
 	}
+
+	_, err = client.CheckSource(context.Background(), connect.NewRequest(&cerebrov1.CheckSourceRequest{}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("CheckSource(empty) code = %v, want %v", connect.CodeOf(err), connect.CodeInvalidArgument)
+	}
 }
 
 func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -124,6 +124,27 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if events, ok := readPayload["events"].([]any); !ok || len(events) != 1 {
 		t.Fatalf("read events = %#v, want 1 entry", readPayload["events"])
 	}
+	repeatedCursorResp, err := server.Client().Get(server.URL + "/sources/github/read?token=test&cursor=0&cursor=1")
+	if err != nil {
+		t.Fatalf("GET /sources/github/read repeated cursor error = %v", err)
+	}
+	defer func() {
+		if closeErr := repeatedCursorResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close repeated cursor response body: %v", closeErr)
+		}
+	}()
+	var repeatedCursorPayload map[string]any
+	if err := json.NewDecoder(repeatedCursorResp.Body).Decode(&repeatedCursorPayload); err != nil {
+		t.Fatalf("decode repeated cursor response: %v", err)
+	}
+	repeatedCursorEvents, ok := repeatedCursorPayload["events"].([]any)
+	if !ok || len(repeatedCursorEvents) != 1 {
+		t.Fatalf("repeated cursor events = %#v, want 1 entry", repeatedCursorPayload["events"])
+	}
+	repeatedCursorEvent, ok := repeatedCursorEvents[0].(map[string]any)
+	if !ok || repeatedCursorEvent["id"] != "github-pr-1" {
+		t.Fatalf("repeated cursor event = %#v, want github-pr-1", repeatedCursorEvents[0])
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	versionResp, err := client.GetVersion(context.Background(), connect.NewRequest(&cerebrov1.GetVersionRequest{}))

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -1,0 +1,101 @@
+package sourceops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+var ErrSourceNotFound = errors.New("source not found")
+
+// Service exposes typed source preview operations over a registry.
+type Service struct {
+	registry *sourcecdk.Registry
+}
+
+// New constructs a source operations service.
+func New(registry *sourcecdk.Registry) *Service {
+	return &Service{registry: registry}
+}
+
+// List returns the registered source catalog.
+func (s *Service) List() *cerebrov1.ListSourcesResponse {
+	response := &cerebrov1.ListSourcesResponse{}
+	if s == nil || s.registry == nil {
+		return response
+	}
+	response.Sources = s.registry.List()
+	return response
+}
+
+// Check validates configuration for a named source.
+func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) (*cerebrov1.CheckSourceResponse, error) {
+	source, err := s.lookup(req.GetSourceId())
+	if err != nil {
+		return nil, err
+	}
+	if err := source.Check(ctx, sourcecdk.NewConfig(req.GetConfig())); err != nil {
+		return nil, err
+	}
+	return &cerebrov1.CheckSourceResponse{
+		Source: source.Spec(),
+		Status: "ok",
+	}, nil
+}
+
+// Discover returns the current URNs for a named source.
+func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceRequest) (*cerebrov1.DiscoverSourceResponse, error) {
+	source, err := s.lookup(req.GetSourceId())
+	if err != nil {
+		return nil, err
+	}
+	urns, err := source.Discover(ctx, sourcecdk.NewConfig(req.GetConfig()))
+	if err != nil {
+		return nil, err
+	}
+	values := make([]string, 0, len(urns))
+	for _, urn := range urns {
+		values = append(values, urn.String())
+	}
+	return &cerebrov1.DiscoverSourceResponse{
+		Source: source.Spec(),
+		Urns:   values,
+	}, nil
+}
+
+// Read returns one page of events for a named source.
+func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*cerebrov1.ReadSourceResponse, error) {
+	source, err := s.lookup(req.GetSourceId())
+	if err != nil {
+		return nil, err
+	}
+	pull, err := source.Read(ctx, sourcecdk.NewConfig(req.GetConfig()), req.GetCursor())
+	if err != nil {
+		return nil, err
+	}
+	return &cerebrov1.ReadSourceResponse{
+		Source:     source.Spec(),
+		Events:     pull.Events,
+		Checkpoint: pull.Checkpoint,
+		NextCursor: pull.NextCursor,
+	}, nil
+}
+
+func (s *Service) lookup(sourceID string) (sourcecdk.Source, error) {
+	id := strings.TrimSpace(sourceID)
+	if id == "" {
+		return nil, fmt.Errorf("source id is required")
+	}
+	if s == nil || s.registry == nil {
+		return nil, fmt.Errorf("%w: %s", ErrSourceNotFound, id)
+	}
+	source, ok := s.registry.Get(id)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrSourceNotFound, id)
+	}
+	return source, nil
+}

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	ErrInvalidSourceID = errors.New("source id is required")
-	ErrSourceNotFound  = errors.New("source not found")
+	ErrInvalidSourceID     = errors.New("source id is required")
+	ErrInvalidSourceConfig = errors.New("invalid source config")
+	ErrSourceNotFound      = errors.New("source not found")
 )
 
 // Service exposes typed source preview operations over a registry.
@@ -42,7 +43,7 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 		return nil, err
 	}
 	if err := source.Check(ctx, sourcecdk.NewConfig(req.GetConfig())); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrInvalidSourceConfig, err)
 	}
 	return &cerebrov1.CheckSourceResponse{
 		Source: source.Spec(),
@@ -58,7 +59,7 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 	}
 	urns, err := source.Discover(ctx, sourcecdk.NewConfig(req.GetConfig()))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrInvalidSourceConfig, err)
 	}
 	values := make([]string, 0, len(urns))
 	for _, urn := range urns {
@@ -78,7 +79,7 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*
 	}
 	pull, err := source.Read(ctx, sourcecdk.NewConfig(req.GetConfig()), req.GetCursor())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrInvalidSourceConfig, err)
 	}
 	return &cerebrov1.ReadSourceResponse{
 		Source:     source.Spec(),

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -10,7 +10,10 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
-var ErrSourceNotFound = errors.New("source not found")
+var (
+	ErrInvalidSourceID = errors.New("source id is required")
+	ErrSourceNotFound  = errors.New("source not found")
+)
 
 // Service exposes typed source preview operations over a registry.
 type Service struct {
@@ -88,7 +91,7 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*
 func (s *Service) lookup(sourceID string) (sourcecdk.Source, error) {
 	id := strings.TrimSpace(sourceID)
 	if id == "" {
-		return nil, fmt.Errorf("source id is required")
+		return nil, ErrInvalidSourceID
 	}
 	if s == nil || s.registry == nil {
 		return nil, fmt.Errorf("%w: %s", ErrSourceNotFound, id)

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -75,6 +75,24 @@ func TestUnknownSource(t *testing.T) {
 	}
 }
 
+func TestSourceValidationErrorsAreInvalidConfig(t *testing.T) {
+	registry, err := newGitHubRegistry()
+	if err != nil {
+		t.Fatalf("newGitHubRegistry() error = %v", err)
+	}
+	service := New(registry)
+	if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "github"}); !errors.Is(err, ErrInvalidSourceConfig) {
+		t.Fatalf("Check() error = %v, want ErrInvalidSourceConfig", err)
+	}
+	if _, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
+		SourceId: "github",
+		Config:   map[string]string{"token": "test"},
+		Cursor:   &cerebrov1.SourceCursor{Opaque: "-1"},
+	}); !errors.Is(err, ErrInvalidSourceConfig) {
+		t.Fatalf("Read() error = %v, want ErrInvalidSourceConfig", err)
+	}
+}
+
 func newGitHubRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.New()
 	if err != nil {

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -1,0 +1,84 @@
+package sourceops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	githubsource "github.com/writer/cerebro/sources/github"
+)
+
+func TestList(t *testing.T) {
+	registry, err := newGitHubRegistry()
+	if err != nil {
+		t.Fatalf("newGitHubRegistry() error = %v", err)
+	}
+	service := New(registry)
+	response := service.List()
+	if len(response.Sources) != 1 {
+		t.Fatalf("len(List().Sources) = %d, want 1", len(response.Sources))
+	}
+}
+
+func TestCheckDiscoverAndRead(t *testing.T) {
+	registry, err := newGitHubRegistry()
+	if err != nil {
+		t.Fatalf("newGitHubRegistry() error = %v", err)
+	}
+	service := New(registry)
+	ctx := context.Background()
+
+	checkResp, err := service.Check(ctx, &cerebrov1.CheckSourceRequest{
+		SourceId: "github",
+		Config:   map[string]string{"token": "test"},
+	})
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if checkResp.Status != "ok" {
+		t.Fatalf("Check().Status = %q, want %q", checkResp.Status, "ok")
+	}
+
+	discoverResp, err := service.Discover(ctx, &cerebrov1.DiscoverSourceRequest{
+		SourceId: "github",
+		Config:   map[string]string{"token": "test"},
+	})
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(discoverResp.Urns) != 2 {
+		t.Fatalf("len(Discover().Urns) = %d, want 2", len(discoverResp.Urns))
+	}
+
+	readResp, err := service.Read(ctx, &cerebrov1.ReadSourceRequest{
+		SourceId: "github",
+		Config:   map[string]string{"token": "test"},
+	})
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(readResp.Events) != 1 {
+		t.Fatalf("len(Read().Events) = %d, want 1", len(readResp.Events))
+	}
+	if readResp.NextCursor == nil {
+		t.Fatal("Read().NextCursor = nil, want non-nil")
+	}
+}
+
+func TestUnknownSource(t *testing.T) {
+	service := New(nil)
+	_, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "github"})
+	if !errors.Is(err, ErrSourceNotFound) {
+		t.Fatalf("Check() error = %v, want ErrSourceNotFound", err)
+	}
+}
+
+func newGitHubRegistry() (*sourcecdk.Registry, error) {
+	source, err := githubsource.New()
+	if err != nil {
+		return nil, err
+	}
+	return sourcecdk.NewRegistry(source)
+}

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -4,6 +4,7 @@ package cerebro.v1;
 
 option go_package = "github.com/writer/cerebro/gen/cerebro/v1;cerebrov1";
 
+import "cerebro/v1/primitives.proto";
 import "cerebro/v1/source.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -12,6 +13,9 @@ service BootstrapService {
   rpc GetVersion(GetVersionRequest) returns (GetVersionResponse);
   rpc CheckHealth(CheckHealthRequest) returns (CheckHealthResponse);
   rpc ListSources(ListSourcesRequest) returns (ListSourcesResponse);
+  rpc CheckSource(CheckSourceRequest) returns (CheckSourceResponse);
+  rpc DiscoverSource(DiscoverSourceRequest) returns (DiscoverSourceResponse);
+  rpc ReadSource(ReadSourceRequest) returns (ReadSourceResponse);
 }
 
 // GetVersionRequest requests static build metadata from the running service.
@@ -49,4 +53,43 @@ message ListSourcesRequest {}
 // ListSourcesResponse returns the registered in-process source specs.
 message ListSourcesResponse {
   repeated SourceSpec sources = 1;
+}
+
+// CheckSourceRequest validates source configuration for a named source.
+message CheckSourceRequest {
+  string source_id = 1;
+  map<string, string> config = 2;
+}
+
+// CheckSourceResponse returns the validated source metadata.
+message CheckSourceResponse {
+  SourceSpec source = 1;
+  string status = 2;
+}
+
+// DiscoverSourceRequest requests the current URNs for a named source.
+message DiscoverSourceRequest {
+  string source_id = 1;
+  map<string, string> config = 2;
+}
+
+// DiscoverSourceResponse returns the discovered URNs for a source.
+message DiscoverSourceResponse {
+  SourceSpec source = 1;
+  repeated string urns = 2;
+}
+
+// ReadSourceRequest requests one page of source events.
+message ReadSourceRequest {
+  string source_id = 1;
+  map<string, string> config = 2;
+  SourceCursor cursor = 3;
+}
+
+// ReadSourceResponse returns one page of source events plus replay cursors.
+message ReadSourceResponse {
+  SourceSpec source = 1;
+  repeated EventEnvelope events = 2;
+  SourceCheckpoint checkpoint = 3;
+  SourceCursor next_cursor = 4;
 }


### PR DESCRIPTION
## Summary
- add preview-oriented source operations for check, discover, and read
- expose those operations over HTTP and Connect on the bootstrap app
- add a `cerebro source` CLI so the GitHub fixture source is usable end-to-end locally

## Testing
- make verify
- ./bin/cerebro source list
- ./bin/cerebro source check github token=test
- ./bin/cerebro source discover github token=test
- ./bin/cerebro source read github token=test
