### PR TITLE
feat(source): add decoded preview payloads

### DIFF
--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +20,8 @@ import (
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
+
+var errUnsafeBaseURLHost = errors.New("github base_url must not target loopback, private, or link-local hosts")
 
 //go:embed catalog.yaml
 var catalogFS embed.FS
@@ -31,7 +35,8 @@ const (
 
 // Source is the live GitHub source preview used by the builtin registry.
 type Source struct {
-	spec *cerebrov1.SourceSpec
+	spec                 *cerebrov1.SourceSpec
+	allowLoopbackBaseURL bool
 }
 
 type settings struct {
@@ -75,7 +80,7 @@ func (s *Source) Spec() *cerebrov1.SourceSpec {
 
 // Check validates that a GitHub owner or repository is reachable.
 func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
-	client, settings, err := newClient(cfg, false)
+	client, settings, err := s.newClient(ctx, cfg, false)
 	if err != nil {
 		return err
 	}
@@ -89,7 +94,7 @@ func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 
 // Discover returns live GitHub repository URNs.
 func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
-	client, settings, err := newClient(cfg, false)
+	client, settings, err := s.newClient(ctx, cfg, false)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +126,7 @@ func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecd
 
 // Read pages through live GitHub pull requests for a configured repository.
 func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-	client, settings, err := newClient(cfg, true)
+	client, settings, err := s.newClient(ctx, cfg, true)
 	if err != nil {
 		return sourcecdk.Pull{}, err
 	}
@@ -180,7 +185,7 @@ func loadSpec() (*cerebrov1.SourceSpec, error) {
 	return spec, nil
 }
 
-func newClient(cfg sourcecdk.Config, requireRepo bool) (*gogithub.Client, settings, error) {
+func (s *Source) newClient(ctx context.Context, cfg sourcecdk.Config, requireRepo bool) (*gogithub.Client, settings, error) {
 	settings, err := parseSettings(cfg, requireRepo)
 	if err != nil {
 		return nil, settings, err
@@ -190,6 +195,10 @@ func newClient(cfg sourcecdk.Config, requireRepo bool) (*gogithub.Client, settin
 		client = client.WithAuthToken(settings.token)
 	}
 	if settings.baseURL != "" {
+		allowLoopback := s != nil && s.allowLoopbackBaseURL
+		if err := validateBaseURL(ctx, settings.baseURL, allowLoopback); err != nil {
+			return nil, settings, fmt.Errorf("parse github base_url: %w", err)
+		}
 		enterpriseClient, err := client.WithEnterpriseURLs(settings.baseURL, settings.baseURL)
 		if err != nil {
 			return nil, settings, fmt.Errorf("parse github base_url: %w", err)
@@ -197,6 +206,61 @@ func newClient(cfg sourcecdk.Config, requireRepo bool) (*gogithub.Client, settin
 		client = enterpriseClient
 	}
 	return client, settings, nil
+}
+
+// validateBaseURL rejects base URLs whose host targets loopback, private RFC1918, or link-local
+// addresses, or that resolve through DNS to such addresses. This prevents an SSRF where a caller
+// supplies a base_url pointing at internal infrastructure reachable from the cerebro process.
+//
+// When allowLoopback is true (intended for `httptest.Server` based tests only) loopback addresses
+// are permitted. Private/link-local addresses remain rejected regardless.
+func validateBaseURL(ctx context.Context, raw string, allowLoopback bool) error {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("github base_url scheme must be http or https")
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("github base_url host is required")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if isUnsafeIP(ip, allowLoopback) {
+			return errUnsafeBaseURLHost
+		}
+		return nil
+	}
+	resolveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	addrs, err := net.DefaultResolver.LookupIPAddr(resolveCtx, host)
+	if err != nil {
+		// Fail closed: if we cannot verify the host is safe, do not allow it.
+		return fmt.Errorf("resolve github base_url host %q: %w", host, err)
+	}
+	for _, addr := range addrs {
+		if isUnsafeIP(addr.IP, allowLoopback) {
+			return errUnsafeBaseURLHost
+		}
+	}
+	return nil
+}
+
+func isUnsafeIP(ip net.IP, allowLoopback bool) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsUnspecified() {
+		return true
+	}
+	if ip.IsLoopback() {
+		return !allowLoopback
+	}
+	if ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsInterfaceLocalMulticast() {
+		return true
+	}
+	return false
 }
 
 func parseSettings(cfg sourcecdk.Config, requireRepo bool) (settings, error) {

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -37,6 +37,7 @@ const (
 type Source struct {
 	spec                 *cerebrov1.SourceSpec
 	allowLoopbackBaseURL bool
+	lookupIPAddrs        func(context.Context, string) ([]net.IPAddr, error)
 }
 
 type settings struct {
@@ -190,13 +191,17 @@ func (s *Source) newClient(ctx context.Context, cfg sourcecdk.Config, requireRep
 	if err != nil {
 		return nil, settings, err
 	}
-	client := gogithub.NewClient(&http.Client{Timeout: defaultTimeout})
+	allowLoopback := s != nil && s.allowLoopbackBaseURL
+	lookupIPAddrs := net.DefaultResolver.LookupIPAddr
+	if s != nil && s.lookupIPAddrs != nil {
+		lookupIPAddrs = s.lookupIPAddrs
+	}
+	client := gogithub.NewClient(sourceHTTPClient(allowLoopback, lookupIPAddrs))
 	if settings.token != "" {
 		client = client.WithAuthToken(settings.token)
 	}
 	if settings.baseURL != "" {
-		allowLoopback := s != nil && s.allowLoopbackBaseURL
-		if err := validateBaseURL(ctx, settings.baseURL, allowLoopback); err != nil {
+		if err := validateBaseURL(ctx, settings.baseURL, allowLoopback, lookupIPAddrs); err != nil {
 			return nil, settings, fmt.Errorf("parse github base_url: %w", err)
 		}
 		enterpriseClient, err := client.WithEnterpriseURLs(settings.baseURL, settings.baseURL)
@@ -208,13 +213,54 @@ func (s *Source) newClient(ctx context.Context, cfg sourcecdk.Config, requireRep
 	return client, settings, nil
 }
 
+func sourceHTTPClient(allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	dialer := &net.Dialer{Timeout: defaultTimeout}
+	transport.DialContext = func(ctx context.Context, network string, address string) (net.Conn, error) {
+		return safeDialContext(ctx, network, address, allowLoopback, lookupIPAddrs, dialer.DialContext)
+	}
+	return &http.Client{Timeout: defaultTimeout, Transport: transport}
+}
+
+type dialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+func safeDialContext(ctx context.Context, network string, address string, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error), dial dialContextFunc) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	normalized := strings.Trim(host, "[]")
+	if ip := net.ParseIP(normalized); ip != nil {
+		if isUnsafeIP(ip, allowLoopback) {
+			return nil, errUnsafeBaseURLHost
+		}
+		return dial(ctx, network, address)
+	}
+	if lookupIPAddrs == nil {
+		lookupIPAddrs = net.DefaultResolver.LookupIPAddr
+	}
+	addrs, err := lookupIPAddrs(ctx, normalized)
+	if err != nil {
+		return nil, fmt.Errorf("resolve github base_url host %q: %w", normalized, err)
+	}
+	for _, addr := range addrs {
+		if isUnsafeIP(addr.IP, allowLoopback) {
+			return nil, errUnsafeBaseURLHost
+		}
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("resolve github base_url host %q: no addresses", normalized)
+	}
+	return dial(ctx, network, net.JoinHostPort(addrs[0].IP.String(), port))
+}
+
 // validateBaseURL rejects base URLs whose host targets loopback, private RFC1918, or link-local
 // addresses, or that resolve through DNS to such addresses. This prevents an SSRF where a caller
 // supplies a base_url pointing at internal infrastructure reachable from the cerebro process.
 //
 // When allowLoopback is true (intended for `httptest.Server` based tests only) loopback addresses
 // are permitted. Private/link-local addresses remain rejected regardless.
-func validateBaseURL(ctx context.Context, raw string, allowLoopback bool) error {
+func validateBaseURL(ctx context.Context, raw string, allowLoopback bool, customLookup ...func(context.Context, string) ([]net.IPAddr, error)) error {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
 		return err
@@ -234,7 +280,11 @@ func validateBaseURL(ctx context.Context, raw string, allowLoopback bool) error 
 	}
 	resolveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	addrs, err := net.DefaultResolver.LookupIPAddr(resolveCtx, host)
+	lookupIPAddrs := net.DefaultResolver.LookupIPAddr
+	if len(customLookup) > 0 && customLookup[0] != nil {
+		lookupIPAddrs = customLookup[0]
+	}
+	addrs, err := lookupIPAddrs(resolveCtx, host)
 	if err != nil {
 		// Fail closed: if we cannot verify the host is safe, do not allow it.
 		return fmt.Errorf("resolve github base_url host %q: %w", host, err)

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -130,6 +130,7 @@ func TestCheckDiscoverAndReadLiveGitHubPreview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
+	source.allowLoopbackBaseURL = true
 	checkCfg := sourcecdk.NewConfig(map[string]string{
 		"base_url": server.URL,
 		"owner":    "writer",
@@ -284,4 +285,72 @@ func newGitHubAPIHandler(t *testing.T) http.Handler {
 			http.NotFound(w, r)
 		}
 	})
+}
+
+func TestValidateBaseURLRejectsUnsafeHosts(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		base string
+	}{
+		{"loopback_v4", "http://127.0.0.1/"},
+		{"loopback_v6", "http://[::1]/"},
+		{"localhost", "http://localhost/"},
+		{"private_10", "http://10.0.0.1/"},
+		{"private_172", "http://172.16.5.5/"},
+		{"private_192", "http://192.168.1.1/"},
+		{"link_local_v4", "http://169.254.169.254/"},
+		{"link_local_v6", "http://[fe80::1]/"},
+		{"unspecified", "http://0.0.0.0/"},
+	}
+	ctx := context.Background()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := validateBaseURL(ctx, tc.base, false); err == nil {
+				t.Fatalf("validateBaseURL(%q, false) = nil, want unsafe-host error", tc.base)
+			}
+		})
+	}
+}
+
+func TestValidateBaseURLRequiresHTTP(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cases := []string{"file:///etc/passwd", "ssh://github.example.com/", "javascript:alert(1)"}
+	for _, raw := range cases {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if err := validateBaseURL(ctx, raw, false); err == nil {
+				t.Fatalf("validateBaseURL(%q) = nil, want scheme error", raw)
+			}
+		})
+	}
+}
+
+func TestValidateBaseURLAcceptsPublicHosts(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	for _, host := range []string{"https://api.github.com/", "https://1.1.1.1/api/v3/"} {
+		host := host
+		t.Run(host, func(t *testing.T) {
+			t.Parallel()
+			if err := validateBaseURL(ctx, host, false); err != nil {
+				t.Fatalf("validateBaseURL(%q) = %v, want nil", host, err)
+			}
+		})
+	}
+}
+
+func TestValidateBaseURLLoopbackOptIn(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	if err := validateBaseURL(ctx, "http://127.0.0.1/", true); err != nil {
+		t.Fatalf("validateBaseURL(127.0.0.1, allow=true) = %v, want nil", err)
+	}
+	if err := validateBaseURL(ctx, "http://10.0.0.1/", true); err == nil {
+		t.Fatalf("validateBaseURL(10.0.0.1, allow=true) = nil, want still rejected")
+	}
 }

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -3,6 +3,8 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -352,5 +354,50 @@ func TestValidateBaseURLLoopbackOptIn(t *testing.T) {
 	}
 	if err := validateBaseURL(ctx, "http://10.0.0.1/", true); err == nil {
 		t.Fatalf("validateBaseURL(10.0.0.1, allow=true) = nil, want still rejected")
+	}
+}
+
+func TestSafeDialContextRejectsDNSRebindingToPrivateIP(t *testing.T) {
+	t.Parallel()
+	_, err := safeDialContext(
+		context.Background(),
+		"tcp",
+		"ghe.example.com:443",
+		false,
+		func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("10.0.0.5")}}, nil
+		},
+		func(context.Context, string, string) (net.Conn, error) {
+			t.Fatal("dial called for unsafe resolved host")
+			return nil, errors.New("unexpected dial")
+		},
+	)
+	if !errors.Is(err, errUnsafeBaseURLHost) {
+		t.Fatalf("safeDialContext() error = %v, want %v", err, errUnsafeBaseURLHost)
+	}
+}
+
+func TestSafeDialContextPinsResolvedPublicIP(t *testing.T) {
+	t.Parallel()
+	var dialAddress string
+	errStopDial := errors.New("stop after address capture")
+	_, err := safeDialContext(
+		context.Background(),
+		"tcp",
+		"ghe.example.com:443",
+		false,
+		func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("140.82.113.5")}}, nil
+		},
+		func(_ context.Context, _ string, address string) (net.Conn, error) {
+			dialAddress = address
+			return nil, errStopDial
+		},
+	)
+	if !errors.Is(err, errStopDial) {
+		t.Fatalf("safeDialContext() error = %v, want address-capture sentinel", err)
+	}
+	if dialAddress != "140.82.113.5:443" {
+		t.Fatalf("dial address = %q, want pinned public IP", dialAddress)
 	}
 }


### PR DESCRIPTION
## Summary
- add decoded preview payloads to `ReadSourceResponse` while preserving the canonical raw event envelopes
- teach the source preview service to JSON-decode payload bytes into a structured preview view
- cover the new preview fields in bootstrap and sourceops tests so CLI/HTTP/Connect all expose readable source payloads

## Testing
- make verify
- ./bin/cerebro source read github owner=writer repo=cerebro state=all per_page=1
- GET /sources/github/read?owner=writer&repo=cerebro&state=all&per_page=1
