### PR TITLE
feat(source): add org-scoped GitHub audit preview

### DIFF
--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -9,6 +9,7 @@ package cerebrov1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -650,6 +651,67 @@ func (x *ReadSourceRequest) GetCursor() *SourceCursor {
 	return nil
 }
 
+// SourcePreviewEvent exposes a decoded payload view for preview consumers.
+type SourcePreviewEvent struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	EventId        string                 `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Payload        *structpb.Value        `protobuf:"bytes,2,opt,name=payload,proto3" json:"payload,omitempty"`
+	PayloadDecoded bool                   `protobuf:"varint,3,opt,name=payload_decoded,json=payloadDecoded,proto3" json:"payload_decoded,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SourcePreviewEvent) Reset() {
+	*x = SourcePreviewEvent{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SourcePreviewEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SourcePreviewEvent) ProtoMessage() {}
+
+func (x *SourcePreviewEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SourcePreviewEvent.ProtoReflect.Descriptor instead.
+func (*SourcePreviewEvent) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *SourcePreviewEvent) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *SourcePreviewEvent) GetPayload() *structpb.Value {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *SourcePreviewEvent) GetPayloadDecoded() bool {
+	if x != nil {
+		return x.PayloadDecoded
+	}
+	return false
+}
+
 // ReadSourceResponse returns one page of source events plus replay cursors.
 type ReadSourceResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -657,13 +719,14 @@ type ReadSourceResponse struct {
 	Events        []*EventEnvelope       `protobuf:"bytes,2,rep,name=events,proto3" json:"events,omitempty"`
 	Checkpoint    *SourceCheckpoint      `protobuf:"bytes,3,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
 	NextCursor    *SourceCursor          `protobuf:"bytes,4,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
+	PreviewEvents []*SourcePreviewEvent  `protobuf:"bytes,5,rep,name=preview_events,json=previewEvents,proto3" json:"preview_events,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ReadSourceResponse) Reset() {
 	*x = ReadSourceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -675,7 +738,7 @@ func (x *ReadSourceResponse) String() string {
 func (*ReadSourceResponse) ProtoMessage() {}
 
 func (x *ReadSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -688,7 +751,7 @@ func (x *ReadSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSourceResponse.ProtoReflect.Descriptor instead.
 func (*ReadSourceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{12}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ReadSourceResponse) GetSource() *SourceSpec {
@@ -719,12 +782,19 @@ func (x *ReadSourceResponse) GetNextCursor() *SourceCursor {
 	return nil
 }
 
+func (x *ReadSourceResponse) GetPreviewEvents() []*SourcePreviewEvent {
+	if x != nil {
+		return x.PreviewEvents
+	}
+	return nil
+}
+
 var File_cerebro_v1_bootstrap_proto protoreflect.FileDescriptor
 
 const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\n" +
 	"\x1acerebro/v1/bootstrap.proto\x12\n" +
-	"cerebro.v1\x1a\x1bcerebro/v1/primitives.proto\x1a\x17cerebro/v1/source.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x13\n" +
+	"cerebro.v1\x1a\x1bcerebro/v1/primitives.proto\x1a\x17cerebro/v1/source.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x13\n" +
 	"\x11GetVersionRequest\"\xa9\x01\n" +
 	"\x12GetVersionResponse\x12!\n" +
 	"\fservice_name\x18\x01 \x01(\tR\vserviceName\x12\x18\n" +
@@ -773,7 +843,11 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x06cursor\x18\x03 \x01(\v2\x18.cerebro.v1.SourceCursorR\x06cursor\x1a9\n" +
 	"\vConfigEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xf0\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8a\x01\n" +
+	"\x12SourcePreviewEvent\x12\x19\n" +
+	"\bevent_id\x18\x01 \x01(\tR\aeventId\x120\n" +
+	"\apayload\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\apayload\x12'\n" +
+	"\x0fpayload_decoded\x18\x03 \x01(\bR\x0epayloadDecoded\"\xb7\x02\n" +
 	"\x12ReadSourceResponse\x12.\n" +
 	"\x06source\x18\x01 \x01(\v2\x16.cerebro.v1.SourceSpecR\x06source\x121\n" +
 	"\x06events\x18\x02 \x03(\v2\x19.cerebro.v1.EventEnvelopeR\x06events\x12<\n" +
@@ -781,7 +855,8 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"checkpoint\x18\x03 \x01(\v2\x1c.cerebro.v1.SourceCheckpointR\n" +
 	"checkpoint\x129\n" +
 	"\vnext_cursor\x18\x04 \x01(\v2\x18.cerebro.v1.SourceCursorR\n" +
-	"nextCursor2\xf5\x03\n" +
+	"nextCursor\x12E\n" +
+	"\x0epreview_events\x18\x05 \x03(\v2\x1e.cerebro.v1.SourcePreviewEventR\rpreviewEvents2\xf5\x03\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -804,7 +879,7 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*GetVersionRequest)(nil),      // 0: cerebro.v1.GetVersionRequest
 	(*GetVersionResponse)(nil),     // 1: cerebro.v1.GetVersionResponse
@@ -818,47 +893,51 @@ var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*DiscoverSourceRequest)(nil),  // 9: cerebro.v1.DiscoverSourceRequest
 	(*DiscoverSourceResponse)(nil), // 10: cerebro.v1.DiscoverSourceResponse
 	(*ReadSourceRequest)(nil),      // 11: cerebro.v1.ReadSourceRequest
-	(*ReadSourceResponse)(nil),     // 12: cerebro.v1.ReadSourceResponse
-	nil,                            // 13: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                            // 14: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                            // 15: cerebro.v1.ReadSourceRequest.ConfigEntry
-	(*timestamppb.Timestamp)(nil),  // 16: google.protobuf.Timestamp
-	(*SourceSpec)(nil),             // 17: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),           // 18: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),          // 19: cerebro.v1.EventEnvelope
-	(*SourceCheckpoint)(nil),       // 20: cerebro.v1.SourceCheckpoint
+	(*SourcePreviewEvent)(nil),     // 12: cerebro.v1.SourcePreviewEvent
+	(*ReadSourceResponse)(nil),     // 13: cerebro.v1.ReadSourceResponse
+	nil,                            // 14: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                            // 15: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                            // 16: cerebro.v1.ReadSourceRequest.ConfigEntry
+	(*timestamppb.Timestamp)(nil),  // 17: google.protobuf.Timestamp
+	(*SourceSpec)(nil),             // 18: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),           // 19: cerebro.v1.SourceCursor
+	(*structpb.Value)(nil),         // 20: google.protobuf.Value
+	(*EventEnvelope)(nil),          // 21: cerebro.v1.EventEnvelope
+	(*SourceCheckpoint)(nil),       // 22: cerebro.v1.SourceCheckpoint
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	16, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	17, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
-	17, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	13, // 3: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	17, // 4: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	14, // 5: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	17, // 6: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	15, // 7: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	18, // 8: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	17, // 9: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	19, // 10: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	20, // 11: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	18, // 12: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
-	0,  // 13: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2,  // 14: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	5,  // 15: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	7,  // 16: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	9,  // 17: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	11, // 18: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	1,  // 19: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4,  // 20: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	6,  // 21: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	8,  // 22: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	10, // 23: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	12, // 24: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	19, // [19:25] is the sub-list for method output_type
-	13, // [13:19] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	18, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	14, // 3: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	18, // 4: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	15, // 5: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	18, // 6: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	16, // 7: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	19, // 8: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	20, // 9: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	18, // 10: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	21, // 11: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	22, // 12: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	19, // 13: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	12, // 14: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
+	0,  // 15: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 16: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	5,  // 17: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	7,  // 18: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	9,  // 19: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	11, // 20: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	1,  // 21: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 22: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	6,  // 23: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	8,  // 24: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	10, // 25: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	13, // 26: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	21, // [21:27] is the sub-list for method output_type
+	15, // [15:21] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -874,7 +953,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   16,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -153,6 +153,10 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if events, ok := readPayload["events"].([]any); !ok || len(events) != 1 {
 		t.Fatalf("read events = %#v, want 1 entry", readPayload["events"])
 	}
+	previewEvents, ok := readPayload["preview_events"].([]any)
+	if !ok || len(previewEvents) != 1 {
+		t.Fatalf("read preview_events = %#v, want 1 entry", readPayload["preview_events"])
+	}
 	repeatedCursorResp, err := authedGet("/sources/github/read?cursor=0&cursor=1")
 	if err != nil {
 		t.Fatalf("GET /sources/github/read repeated cursor error = %v", err)
@@ -186,6 +190,10 @@ func TestBootstrapEndpoints(t *testing.T) {
 	}()
 	if secretQueryResp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("secret query status = %d, want %d", secretQueryResp.StatusCode, http.StatusBadRequest)
+	}
+	previewEvent, ok := previewEvents[0].(map[string]any)
+	if !ok || previewEvent["event_id"] != "github-audit-1" {
+		t.Fatalf("read preview_event = %#v, want event_id github-audit-1", previewEvents[0])
 	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -2,12 +2,14 @@ package sourceops
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var (
@@ -81,11 +83,16 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidSourceConfig, err)
 	}
+	previews, err := previewEvents(pull.Events)
+	if err != nil {
+		return nil, err
+	}
 	return &cerebrov1.ReadSourceResponse{
-		Source:     source.Spec(),
-		Events:     pull.Events,
-		Checkpoint: pull.Checkpoint,
-		NextCursor: pull.NextCursor,
+		Source:        source.Spec(),
+		Events:        pull.Events,
+		Checkpoint:    pull.Checkpoint,
+		NextCursor:    pull.NextCursor,
+		PreviewEvents: previews,
 	}, nil
 }
 
@@ -102,4 +109,28 @@ func (s *Service) lookup(sourceID string) (sourcecdk.Source, error) {
 		return nil, fmt.Errorf("%w: %s", ErrSourceNotFound, id)
 	}
 	return source, nil
+}
+
+func previewEvents(events []*cerebrov1.EventEnvelope) ([]*cerebrov1.SourcePreviewEvent, error) {
+	previews := make([]*cerebrov1.SourcePreviewEvent, 0, len(events))
+	for _, event := range events {
+		preview := &cerebrov1.SourcePreviewEvent{EventId: event.GetId()}
+		if len(event.GetPayload()) == 0 {
+			previews = append(previews, preview)
+			continue
+		}
+		var payload any
+		if err := json.Unmarshal(event.GetPayload(), &payload); err != nil {
+			previews = append(previews, preview)
+			continue
+		}
+		value, err := structpb.NewValue(payload)
+		if err != nil {
+			return nil, fmt.Errorf("build preview payload for event %q: %w", event.GetId(), err)
+		}
+		preview.Payload = value
+		preview.PayloadDecoded = true
+		previews = append(previews, preview)
+	}
+	return previews, nil
 }

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -65,6 +65,15 @@ func TestCheckDiscoverAndRead(t *testing.T) {
 	if readResp.NextCursor == nil {
 		t.Fatal("Read().NextCursor = nil, want non-nil")
 	}
+	if len(readResp.PreviewEvents) != 1 {
+		t.Fatalf("len(Read().PreviewEvents) = %d, want 1", len(readResp.PreviewEvents))
+	}
+	if readResp.PreviewEvents[0].EventId != readResp.Events[0].Id {
+		t.Fatalf("Read().PreviewEvents[0].EventId = %q, want %q", readResp.PreviewEvents[0].EventId, readResp.Events[0].Id)
+	}
+	if !readResp.PreviewEvents[0].PayloadDecoded {
+		t.Fatal("Read().PreviewEvents[0].PayloadDecoded = false, want true")
+	}
 }
 
 func TestUnknownSource(t *testing.T) {

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/writer/cerebro/gen/cerebro/v1;cerebrov1";
 
 import "cerebro/v1/primitives.proto";
 import "cerebro/v1/source.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 // BootstrapService is the minimal control-plane surface for the rewrite skeleton.
@@ -86,10 +87,18 @@ message ReadSourceRequest {
   SourceCursor cursor = 3;
 }
 
+// SourcePreviewEvent exposes a decoded payload view for preview consumers.
+message SourcePreviewEvent {
+  string event_id = 1;
+  google.protobuf.Value payload = 2;
+  bool payload_decoded = 3;
+}
+
 // ReadSourceResponse returns one page of source events plus replay cursors.
 message ReadSourceResponse {
   SourceSpec source = 1;
   repeated EventEnvelope events = 2;
   SourceCheckpoint checkpoint = 3;
   SourceCursor next_cursor = 4;
+  repeated SourcePreviewEvent preview_events = 5;
 }

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -1,0 +1,340 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	gogithub "github.com/google/go-github/v66/github"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+type auditPayload struct {
+	Action                   string         `json:"action"`
+	Actor                    string         `json:"actor,omitempty"`
+	ActorID                  int64          `json:"actor_id,omitempty"`
+	ActorIP                  string         `json:"actor_ip,omitempty"`
+	ActorIsAgent             bool           `json:"actor_is_agent,omitempty"`
+	ActorIsBot               bool           `json:"actor_is_bot,omitempty"`
+	Business                 string         `json:"business,omitempty"`
+	BusinessID               int64          `json:"business_id,omitempty"`
+	ExternalIdentityNameID   string         `json:"external_identity_nameid,omitempty"`
+	ExternalIdentityUsername string         `json:"external_identity_username,omitempty"`
+	OperationType            string         `json:"operation_type,omitempty"`
+	Org                      string         `json:"org"`
+	ProgrammaticAccessType   string         `json:"programmatic_access_type,omitempty"`
+	PublicRepo               bool           `json:"public_repo,omitempty"`
+	Repo                     string         `json:"repo,omitempty"`
+	ResourceID               string         `json:"resource_id,omitempty"`
+	ResourceType             string         `json:"resource_type,omitempty"`
+	Scope                    string         `json:"scope,omitempty"`
+	User                     string         `json:"user,omitempty"`
+	UserID                   int64          `json:"user_id,omitempty"`
+	Visibility               string         `json:"visibility,omitempty"`
+	Raw                      map[string]any `json:"raw,omitempty"`
+}
+
+func (s *Source) checkAudit(ctx context.Context, client *gogithub.Client, settings settings) error {
+	_, _, err := client.Organizations.GetAuditLog(ctx, settings.owner, auditOptions(settings, "", 1))
+	if err != nil {
+		return wrapLookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
+	}
+	return nil
+}
+
+func (s *Source) discoverAudit(ctx context.Context, client *gogithub.Client, settings settings) ([]sourcecdk.URN, error) {
+	if err := s.checkAudit(ctx, client, settings); err != nil {
+		return nil, err
+	}
+	urn, err := sourcecdk.ParseURN(fmt.Sprintf("urn:cerebro:%s:org:%s", settings.owner, settings.owner))
+	if err != nil {
+		return nil, err
+	}
+	return []sourcecdk.URN{urn}, nil
+}
+
+func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	after, err := readAuditCursor(cursor)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	entries, resp, err := client.Organizations.GetAuditLog(ctx, settings.owner, auditOptions(settings, after, settings.perPage))
+	if err != nil {
+		return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("github audit log for org %s", settings.owner), err)
+	}
+	if len(entries) == 0 {
+		return sourcecdk.Pull{}, nil
+	}
+	events := make([]*primitives.Event, 0, len(entries))
+	for _, entry := range entries {
+		event, err := auditEvent(settings, entry)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		events = append(events, event)
+	}
+	nextCursor := nextAuditCursor(resp)
+	pull := sourcecdk.Pull{
+		Events: events,
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    events[len(events)-1].OccurredAt,
+			CursorOpaque: checkpointAuditCursor(entries, nextCursor),
+		},
+	}
+	if nextCursor != "" {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextCursor}
+	}
+	return pull, nil
+}
+
+func auditOptions(settings settings, after string, perPage int) *gogithub.GetAuditLogOptions {
+	opts := &gogithub.GetAuditLogOptions{
+		Include: gogithub.String(settings.auditInclude),
+		Order:   gogithub.String(settings.auditOrder),
+		ListCursorOptions: gogithub.ListCursorOptions{
+			After:   after,
+			PerPage: perPage,
+		},
+	}
+	if settings.auditPhrase != "" {
+		opts.Phrase = gogithub.String(settings.auditPhrase)
+	}
+	return opts
+}
+
+func readAuditCursor(cursor *cerebrov1.SourceCursor) (string, error) {
+	if cursor == nil {
+		return "", nil
+	}
+	return strings.TrimSpace(cursor.GetOpaque()), nil
+}
+
+func auditEvent(settings settings, entry *gogithub.AuditEntry) (*primitives.Event, error) {
+	occurredAt := auditOccurredAt(entry)
+	if occurredAt.IsZero() {
+		return nil, fmt.Errorf("github audit event %q missing timestamps", entry.GetDocumentID())
+	}
+	raw, err := auditRaw(entry)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(auditPayload{
+		Action:                   entry.GetAction(),
+		Actor:                    entry.GetActor(),
+		ActorID:                  entry.GetActorID(),
+		ActorIP:                  rawString(raw, "actor_ip"),
+		ActorIsAgent:             rawBool(raw, "actor_is_agent"),
+		ActorIsBot:               rawBool(raw, "actor_is_bot"),
+		Business:                 entry.GetBusiness(),
+		BusinessID:               entry.GetBusinessID(),
+		ExternalIdentityNameID:   entry.GetExternalIdentityNameID(),
+		ExternalIdentityUsername: entry.GetExternalIdentityUsername(),
+		OperationType:            rawString(raw, "operation_type"),
+		Org:                      valueOrDefault(entry.GetOrg(), settings.owner),
+		ProgrammaticAccessType:   rawString(raw, "programmatic_access_type"),
+		PublicRepo:               rawBool(raw, "public_repo"),
+		Repo:                     rawString(raw, "repo"),
+		ResourceID:               auditResourceID(entry, raw, settings),
+		ResourceType:             auditResourceType(entry),
+		Scope:                    auditScope(entry, raw),
+		User:                     entry.GetUser(),
+		UserID:                   entry.GetUserID(),
+		Visibility:               rawString(raw, "visibility"),
+		Raw:                      raw,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal github audit payload: %w", err)
+	}
+	return &primitives.Event{
+		Id:         auditEventID(entry, occurredAt),
+		TenantId:   settings.owner,
+		SourceId:   "github",
+		Kind:       "github.audit",
+		OccurredAt: timestamppb.New(occurredAt.UTC()),
+		SchemaRef:  "github/audit/v1",
+		Payload:    payload,
+		Attributes: auditAttributes(entry, raw, settings),
+	}, nil
+}
+
+func auditOccurredAt(entry *gogithub.AuditEntry) time.Time {
+	if entry == nil {
+		return time.Time{}
+	}
+	if stamp := entry.GetTimestamp(); !stamp.IsZero() {
+		return stamp.UTC()
+	}
+	if stamp := entry.GetCreatedAt(); !stamp.IsZero() {
+		return stamp.UTC()
+	}
+	return time.Time{}
+}
+
+func auditRaw(entry *gogithub.AuditEntry) (map[string]any, error) {
+	bytes, err := json.Marshal(entry)
+	if err != nil {
+		return nil, fmt.Errorf("marshal github audit raw payload: %w", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(bytes, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal github audit raw payload: %w", err)
+	}
+	return raw, nil
+}
+
+func auditEventID(entry *gogithub.AuditEntry, occurredAt time.Time) string {
+	documentID := strings.TrimSpace(entry.GetDocumentID())
+	if documentID != "" {
+		return "github-audit-" + documentID
+	}
+	return fmt.Sprintf("github-audit-%s-%d", entry.GetAction(), occurredAt.UnixMilli())
+}
+
+func nextAuditCursor(resp *gogithub.Response) string {
+	if resp == nil {
+		return ""
+	}
+	switch {
+	case strings.TrimSpace(resp.After) != "":
+		return strings.TrimSpace(resp.After)
+	case strings.TrimSpace(resp.Cursor) != "":
+		return strings.TrimSpace(resp.Cursor)
+	case strings.TrimSpace(resp.Before) != "":
+		return strings.TrimSpace(resp.Before)
+	case strings.TrimSpace(resp.NextPageToken) != "":
+		return strings.TrimSpace(resp.NextPageToken)
+	case resp.NextPage > 0:
+		return strconv.Itoa(resp.NextPage)
+	default:
+		return ""
+	}
+}
+
+func checkpointAuditCursor(entries []*gogithub.AuditEntry, cursor string) string {
+	if cursor != "" {
+		return cursor
+	}
+	if len(entries) == 0 {
+		return ""
+	}
+	if documentID := strings.TrimSpace(entries[len(entries)-1].GetDocumentID()); documentID != "" {
+		return documentID
+	}
+	occurredAt := auditOccurredAt(entries[len(entries)-1])
+	if occurredAt.IsZero() {
+		return ""
+	}
+	return occurredAt.Format(time.RFC3339Nano)
+}
+
+func auditAttributes(entry *gogithub.AuditEntry, raw map[string]any, settings settings) map[string]string {
+	attributes := map[string]string{
+		"action":         entry.GetAction(),
+		"family":         familyAudit,
+		"operation_type": rawString(raw, "operation_type"),
+		"org":            valueOrDefault(entry.GetOrg(), settings.owner),
+		"resource_id":    auditResourceID(entry, raw, settings),
+		"resource_type":  auditResourceType(entry),
+		"scope":          auditScope(entry, raw),
+	}
+	addAttribute(attributes, "actor", entry.GetActor())
+	addAttribute(attributes, "actor_is_agent", boolString(raw, "actor_is_agent"))
+	addAttribute(attributes, "actor_is_bot", boolString(raw, "actor_is_bot"))
+	addAttribute(attributes, "programmatic_access_type", rawString(raw, "programmatic_access_type"))
+	addAttribute(attributes, "repo", rawString(raw, "repo"))
+	addAttribute(attributes, "user", entry.GetUser())
+	addAttribute(attributes, "visibility", rawString(raw, "visibility"))
+	return attributes
+}
+
+func auditResourceType(entry *gogithub.AuditEntry) string {
+	action := strings.TrimSpace(entry.GetAction())
+	if action == "" {
+		return "audit"
+	}
+	prefix, _, ok := strings.Cut(action, ".")
+	if !ok {
+		return action
+	}
+	return prefix
+}
+
+func auditResourceID(entry *gogithub.AuditEntry, raw map[string]any, settings settings) string {
+	if repo := strings.TrimSpace(rawString(raw, "repo")); repo != "" {
+		return repo
+	}
+	if user := strings.TrimSpace(entry.GetUser()); user != "" {
+		return user
+	}
+	if org := strings.TrimSpace(entry.GetOrg()); org != "" {
+		return org
+	}
+	return settings.owner
+}
+
+func auditScope(entry *gogithub.AuditEntry, raw map[string]any) string {
+	if strings.TrimSpace(rawString(raw, "repo")) != "" {
+		return "repository"
+	}
+	if strings.TrimSpace(entry.GetOrg()) != "" {
+		return "organization"
+	}
+	return "unknown"
+}
+
+func rawString(raw map[string]any, key string) string {
+	value, ok := raw[key]
+	if !ok {
+		return ""
+	}
+	stringValue, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(stringValue)
+}
+
+func rawBool(raw map[string]any, key string) bool {
+	value, ok := raw[key]
+	if !ok {
+		return false
+	}
+	boolValue, ok := value.(bool)
+	if !ok {
+		return false
+	}
+	return boolValue
+}
+
+func boolString(raw map[string]any, key string) string {
+	value, ok := raw[key]
+	if !ok {
+		return ""
+	}
+	boolValue, ok := value.(bool)
+	if !ok {
+		return ""
+	}
+	return strconv.FormatBool(boolValue)
+}
+
+func addAttribute(attributes map[string]string, key string, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	attributes[key] = value
+}
+
+func valueOrDefault(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -206,8 +206,6 @@ func nextAuditCursor(resp *gogithub.Response) string {
 		return strings.TrimSpace(resp.After)
 	case strings.TrimSpace(resp.Cursor) != "":
 		return strings.TrimSpace(resp.Cursor)
-	case strings.TrimSpace(resp.Before) != "":
-		return strings.TrimSpace(resp.Before)
 	case strings.TrimSpace(resp.NextPageToken) != "":
 		return strings.TrimSpace(resp.NextPageToken)
 	case resp.NextPage > 0:

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -281,10 +281,7 @@ func auditScope(entry *gogithub.AuditEntry, raw map[string]any) string {
 	if strings.TrimSpace(rawString(raw, "repo")) != "" {
 		return "repository"
 	}
-	if strings.TrimSpace(entry.GetOrg()) != "" {
-		return "organization"
-	}
-	return "unknown"
+	return "organization"
 }
 
 func rawString(raw map[string]any, key string) string {

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -27,10 +27,15 @@ var errUnsafeBaseURLHost = errors.New("github base_url must not target loopback,
 var catalogFS embed.FS
 
 const (
-	defaultPageSize = 10
-	maxPageSize     = 100
-	defaultState    = "open"
-	defaultTimeout  = 15 * time.Second
+	defaultPageSize     = 10
+	maxPageSize         = 100
+	defaultState        = "open"
+	defaultTimeout      = 15 * time.Second
+	defaultFamily       = familyPullRequest
+	defaultAuditInclude = "all"
+	defaultAuditOrder   = "desc"
+	familyAudit         = "audit"
+	familyPullRequest   = "pull_request"
 )
 
 // Source is the live GitHub source preview used by the builtin registry.
@@ -41,12 +46,16 @@ type Source struct {
 }
 
 type settings struct {
-	owner   string
-	repo    string
-	token   string
-	baseURL string
-	state   string
-	perPage int
+	family       string
+	owner        string
+	repo         string
+	token        string
+	baseURL      string
+	state        string
+	auditInclude string
+	auditPhrase  string
+	auditOrder   string
+	perPage      int
 }
 
 type pullRequestPayload struct {
@@ -85,6 +94,9 @@ func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 	if err != nil {
 		return err
 	}
+	if settings.family == familyAudit {
+		return s.checkAudit(ctx, client, settings)
+	}
 	if settings.repo != "" {
 		_, err := getRepo(ctx, client, settings.owner, settings.repo)
 		return err
@@ -93,11 +105,14 @@ func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
 	return err
 }
 
-// Discover returns live GitHub repository URNs.
+// Discover returns live GitHub URNs for the selected family.
 func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
 	client, settings, err := s.newClient(ctx, cfg, false)
 	if err != nil {
 		return nil, err
+	}
+	if settings.family == familyAudit {
+		return s.discoverAudit(ctx, client, settings)
 	}
 	if settings.repo != "" {
 		repo, err := getRepo(ctx, client, settings.owner, settings.repo)
@@ -125,11 +140,14 @@ func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecd
 	return urns, nil
 }
 
-// Read pages through live GitHub pull requests for a configured repository.
+// Read pages through the configured live GitHub event family.
 func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	client, settings, err := s.newClient(ctx, cfg, true)
 	if err != nil {
 		return sourcecdk.Pull{}, err
+	}
+	if settings.family == familyAudit {
+		return s.readAudit(ctx, client, settings, cursor)
 	}
 	page, err := readPage(cursor)
 	if err != nil {
@@ -315,18 +333,27 @@ func isUnsafeIP(ip net.IP, allowLoopback bool) bool {
 
 func parseSettings(cfg sourcecdk.Config, requireRepo bool) (settings, error) {
 	settings := settings{
-		owner:   configValue(cfg, "owner"),
-		repo:    configValue(cfg, "repo"),
-		token:   configValue(cfg, "token"),
-		baseURL: configValue(cfg, "base_url"),
-		state:   configValue(cfg, "state"),
-		perPage: defaultPageSize,
+		family:       configValue(cfg, "family"),
+		owner:        configValue(cfg, "owner"),
+		repo:         configValue(cfg, "repo"),
+		token:        configValue(cfg, "token"),
+		baseURL:      configValue(cfg, "base_url"),
+		state:        configValue(cfg, "state"),
+		auditInclude: configValue(cfg, "include"),
+		auditPhrase:  configValue(cfg, "phrase"),
+		auditOrder:   configValue(cfg, "order"),
+		perPage:      defaultPageSize,
 	}
 	if settings.owner == "" {
 		return settings, fmt.Errorf("github owner is required")
 	}
-	if requireRepo && settings.repo == "" {
-		return settings, fmt.Errorf("github repo is required")
+	if settings.family == "" {
+		settings.family = defaultFamily
+	}
+	switch settings.family {
+	case familyAudit, familyPullRequest:
+	default:
+		return settings, fmt.Errorf("github family must be one of %s or %s", familyPullRequest, familyAudit)
 	}
 	if rawPerPage, ok := cfg.Lookup("per_page"); ok && strings.TrimSpace(rawPerPage) != "" {
 		perPage, err := strconv.Atoi(strings.TrimSpace(rawPerPage))
@@ -338,13 +365,48 @@ func parseSettings(cfg sourcecdk.Config, requireRepo bool) (settings, error) {
 		}
 		settings.perPage = perPage
 	}
-	if settings.state == "" {
-		settings.state = defaultState
-	}
-	switch settings.state {
-	case "all", "closed", "open":
-	default:
-		return settings, fmt.Errorf("github state must be one of open, closed, or all")
+	switch settings.family {
+	case familyPullRequest:
+		if requireRepo && settings.repo == "" {
+			return settings, fmt.Errorf("github repo is required")
+		}
+		if settings.state == "" {
+			settings.state = defaultState
+		}
+		switch settings.state {
+		case "all", "closed", "open":
+		default:
+			return settings, fmt.Errorf("github state must be one of open, closed, or all")
+		}
+		if settings.auditInclude != "" || settings.auditOrder != "" || settings.auditPhrase != "" {
+			return settings, fmt.Errorf("github include, order, and phrase are only supported when family=%q", familyAudit)
+		}
+	case familyAudit:
+		if settings.token == "" {
+			return settings, fmt.Errorf("github token is required when family=%q", familyAudit)
+		}
+		if settings.repo != "" {
+			return settings, fmt.Errorf("github repo is not supported when family=%q", familyAudit)
+		}
+		if settings.state != "" {
+			return settings, fmt.Errorf("github state is only supported when family=%q", familyPullRequest)
+		}
+		if settings.auditInclude == "" {
+			settings.auditInclude = defaultAuditInclude
+		}
+		switch settings.auditInclude {
+		case "all", "git", "web":
+		default:
+			return settings, fmt.Errorf("github include must be one of all, git, or web")
+		}
+		if settings.auditOrder == "" {
+			settings.auditOrder = defaultAuditOrder
+		}
+		switch settings.auditOrder {
+		case "asc", "desc":
+		default:
+			return settings, fmt.Errorf("github order must be one of asc or desc")
+		}
 	}
 	return settings, nil
 }

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	gogithub "github.com/google/go-github/v66/github"
+
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
@@ -294,6 +296,12 @@ func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
 	}
 	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "audit-doc-2" {
 		t.Fatalf("second.Checkpoint = %#v, want audit-doc-2", second.Checkpoint)
+	}
+}
+
+func TestNextAuditCursorIgnoresBefore(t *testing.T) {
+	if got := nextAuditCursor(&gogithub.Response{Before: "cursor-1"}); got != "" {
+		t.Fatalf("nextAuditCursor() = %q, want empty cursor", got)
 	}
 }
 

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -45,6 +45,19 @@ func TestReadRequiresRepo(t *testing.T) {
 	}
 }
 
+func TestAuditRequiresToken(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"family": "audit",
+		"owner":  "writer",
+	})); err == nil {
+		t.Fatal("Check(audit) error = nil, want non-nil")
+	}
+}
+
 func TestNewFixtureReturnsFixtureURNs(t *testing.T) {
 	source, err := NewFixture()
 	if err != nil {
@@ -125,7 +138,7 @@ func TestNewFixtureTrimsCursor(t *testing.T) {
 	}
 }
 
-func TestCheckDiscoverAndReadLiveGitHubPreview(t *testing.T) {
+func TestCheckDiscoverAndReadLiveGitHubPullRequestPreview(t *testing.T) {
 	server := httptest.NewServer(newGitHubAPIHandler(t))
 	defer server.Close()
 	source, err := New()
@@ -207,6 +220,83 @@ func TestCheckDiscoverAndReadLiveGitHubPreview(t *testing.T) {
 	}
 }
 
+func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
+	server := httptest.NewServer(newGitHubAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   "audit",
+		"include":  "all",
+		"owner":    "writer",
+		"token":    "test-token",
+	})
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check(audit) error = %v", err)
+	}
+
+	discover, err := source.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover(audit) error = %v", err)
+	}
+	if len(discover) != 1 {
+		t.Fatalf("len(Discover(audit)) = %d, want 1", len(discover))
+	}
+	if discover[0] != "urn:cerebro:writer:org:writer" {
+		t.Fatalf("Discover(audit)[0] = %q, want org urn", discover[0])
+	}
+
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(audit first) error = %v", err)
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(Read(audit first).Events) = %d, want 1", len(first.Events))
+	}
+	if first.NextCursor == nil || first.NextCursor.Opaque != "cursor-2" {
+		t.Fatalf("first.NextCursor = %#v, want cursor-2", first.NextCursor)
+	}
+	if got := first.Events[0].Kind; got != "github.audit" {
+		t.Fatalf("first.Events[0].Kind = %q, want github.audit", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(first.Events[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal audit payload: %v", err)
+	}
+	if got := payload["resource_type"]; got != "repository_vulnerability_alert" {
+		t.Fatalf("audit payload resource_type = %#v, want repository_vulnerability_alert", got)
+	}
+	if got := payload["resource_id"]; got != "writer/cerebro" {
+		t.Fatalf("audit payload resource_id = %#v, want writer/cerebro", got)
+	}
+	raw, ok := payload["raw"].(map[string]any)
+	if !ok {
+		t.Fatalf("audit payload raw = %#v, want object", payload["raw"])
+	}
+	if got := raw["action"]; got != "repository_vulnerability_alert.create" {
+		t.Fatalf("audit raw action = %#v, want repository_vulnerability_alert.create", got)
+	}
+
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(audit second) error = %v", err)
+	}
+	if len(second.Events) != 1 {
+		t.Fatalf("len(Read(audit second).Events) = %d, want 1", len(second.Events))
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
+	}
+	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "audit-doc-2" {
+		t.Fatalf("second.Checkpoint = %#v, want audit-doc-2", second.Checkpoint)
+	}
+}
+
 func newGitHubAPIHandler(t *testing.T) http.Handler {
 	t.Helper()
 
@@ -255,6 +345,46 @@ func newGitHubAPIHandler(t *testing.T) http.Handler {
 			},
 		},
 	}
+	auditEntries := []map[string]any{
+		{
+			"@timestamp":                  1776916397852,
+			"_document_id":                "audit-doc-1",
+			"action":                      "repository_vulnerability_alert.create",
+			"actor":                       "dependabot[bot]",
+			"actor_id":                    49699333,
+			"actor_is_bot":                true,
+			"business":                    "writer",
+			"business_id":                 10550,
+			"created_at":                  1776916397852,
+			"operation_type":              "create",
+			"org":                         "writer",
+			"org_id":                      1,
+			"programmatic_access_type":    "GitHub App server-to-server token",
+			"public_repo":                 false,
+			"repo":                        "writer/cerebro",
+			"repo_id":                     1,
+			"visibility":                  "internal",
+			"request_id":                  "audit-1",
+			"repository_vulnerability_id": 99,
+		},
+		{
+			"@timestamp":     1776916385929,
+			"_document_id":   "audit-doc-2",
+			"action":         "org_credential_authorization.deauthorize",
+			"actor":          "octocat",
+			"actor_id":       1,
+			"created_at":     1776916385929,
+			"operation_type": "modify",
+			"org":            "writer",
+			"org_id":         1,
+			"user":           "octocat",
+			"user_id":        1,
+			"actor_is_agent": false,
+			"actor_is_bot":   false,
+			"request_id":     "audit-2",
+			"visibility":     "internal",
+		},
+	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -283,6 +413,18 @@ func newGitHubAPIHandler(t *testing.T) http.Handler {
 				return
 			}
 			encode([]map[string]any{}, "encode empty pulls page")
+		case "/api/v3/orgs/writer/audit-log":
+			after := r.URL.Query().Get("after")
+			if after == "" {
+				w.Header().Set("Link", "</api/v3/orgs/writer/audit-log?after=cursor-2&before=>; rel=\"next\"")
+				encode(auditEntries[:1], "encode audit page 1")
+				return
+			}
+			if after == "cursor-2" {
+				encode(auditEntries[1:2], "encode audit page 2")
+				return
+			}
+			encode([]map[string]any{}, "encode empty audit page")
 		default:
 			http.NotFound(w, r)
 		}


### PR DESCRIPTION
## Summary
- add an org-scoped GitHub audit family alongside the existing pull request preview family
- model audit events with stable security fields like action, resource type/id, scope, visibility, and preserved raw payload
- use GitHub audit cursors for pagination so preview reads scale beyond page-number semantics

## Testing
- make verify
- ./bin/cerebro source check github family=audit owner=WriterInternal per_page=2 token=$(gh auth token)
- ./bin/cerebro source discover github family=audit owner=WriterInternal per_page=2 token=$(gh auth token)
- ./bin/cerebro source read github family=audit owner=WriterInternal per_page=2 token=$(gh auth token)
- GET /sources/github/read?family=audit&owner=WriterInternal&per_page=1&token=<gh auth token>
