### PR TITLE
feat(source): add Okta preview and projected runtime sync

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourceops"
+	"github.com/writer/cerebro/internal/sourceprojection"
 	"github.com/writer/cerebro/internal/sourceregistry"
 	"github.com/writer/cerebro/internal/sourceruntime"
 )
@@ -187,7 +188,12 @@ func runSourceRuntime(args []string) error {
 	if err != nil {
 		return fmt.Errorf("open source registry: %w", err)
 	}
-	service := sourceruntime.New(registry, sourceRuntimeStore(deps.StateStore), deps.AppendLog)
+	service := sourceruntime.New(
+		registry,
+		sourceRuntimeStore(deps.StateStore),
+		deps.AppendLog,
+		sourceProjector(deps.StateStore, deps.GraphStore),
+	)
 
 	switch args[0] {
 	case "put":
@@ -287,7 +293,7 @@ func sensitiveSourceConfigKey(key string) bool {
 
 func parseSourceRuntimePutArgs(args []string) (*cerebrov1.SourceRuntime, error) {
 	if len(args) < 2 {
-		return nil, usageError(fmt.Sprintf("usage: %s source-runtime put <runtime-id> <source-id> [key=value ...]", os.Args[0]))
+		return nil, usageError(fmt.Sprintf("usage: %s source-runtime put <runtime-id> <source-id> [tenant_id=<tenant-id>] [key=value ...]", os.Args[0]))
 	}
 	runtime := &cerebrov1.SourceRuntime{
 		Id:       strings.TrimSpace(args[0]),
@@ -295,12 +301,16 @@ func parseSourceRuntimePutArgs(args []string) (*cerebrov1.SourceRuntime, error) 
 		Config:   make(map[string]string),
 	}
 	if runtime.GetId() == "" || runtime.GetSourceId() == "" {
-		return nil, usageError(fmt.Sprintf("usage: %s source-runtime put <runtime-id> <source-id> [key=value ...]", os.Args[0]))
+		return nil, usageError(fmt.Sprintf("usage: %s source-runtime put <runtime-id> <source-id> [tenant_id=<tenant-id>] [key=value ...]", os.Args[0]))
 	}
 	for _, arg := range args[2:] {
 		key, value, ok := strings.Cut(arg, "=")
 		if !ok {
 			return nil, fmt.Errorf("invalid source runtime argument %q; want key=value", arg)
+		}
+		if key == "tenant_id" {
+			runtime.TenantId = strings.TrimSpace(value)
+			continue
 		}
 		runtime.Config[key] = value
 	}
@@ -336,6 +346,31 @@ func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {
 		return nil
 	}
 	return runtimeStore
+}
+
+func sourceProjectionStateStore(store ports.StateStore) ports.ProjectionStateStore {
+	projectionStore, ok := store.(ports.ProjectionStateStore)
+	if !ok {
+		return nil
+	}
+	return projectionStore
+}
+
+func sourceProjectionGraphStore(store ports.GraphStore) ports.ProjectionGraphStore {
+	projectionStore, ok := store.(ports.ProjectionGraphStore)
+	if !ok {
+		return nil
+	}
+	return projectionStore
+}
+
+func sourceProjector(stateStore ports.StateStore, graphStore ports.GraphStore) ports.SourceProjector {
+	state := sourceProjectionStateStore(stateStore)
+	graph := sourceProjectionGraphStore(graphStore)
+	if state == nil && graph == nil {
+		return nil
+	}
+	return sourceprojection.New(state, graph)
 }
 
 func printProto(message proto.Message) error {

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -17,8 +18,10 @@ import (
 	"github.com/writer/cerebro/internal/bootstrap"
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceregistry"
+	"github.com/writer/cerebro/internal/sourceruntime"
 )
 
 type usageError string
@@ -49,11 +52,13 @@ func run(args []string) error {
 		return serve()
 	case "source":
 		return runSource(args[1:])
+	case "source-runtime":
+		return runSourceRuntime(args[1:])
 	case "version":
 		fmt.Printf("%s %s\n", buildinfo.ServiceName, buildinfo.Version)
 		return nil
 	}
-	return usageError(fmt.Sprintf("usage: %s [serve|version|source]", os.Args[0]))
+	return usageError(fmt.Sprintf("usage: %s [serve|version|source|source-runtime]", os.Args[0]))
 }
 
 func serve() error {
@@ -161,6 +166,67 @@ func runSource(args []string) error {
 	}
 }
 
+func runSourceRuntime(args []string) error {
+	if len(args) == 0 {
+		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|sync] ...", os.Args[0]))
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	deps, closeDeps, err := bootstrap.OpenDependencies(context.Background(), cfg)
+	if err != nil {
+		return fmt.Errorf("open dependencies: %w", err)
+	}
+	defer func() {
+		if err := closeDeps(); err != nil {
+			log.Printf("close dependencies: %v", err)
+		}
+	}()
+	registry, err := sourceregistry.Builtin()
+	if err != nil {
+		return fmt.Errorf("open source registry: %w", err)
+	}
+	service := sourceruntime.New(registry, sourceRuntimeStore(deps.StateStore), deps.AppendLog)
+
+	switch args[0] {
+	case "put":
+		runtime, err := parseSourceRuntimePutArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		response, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: runtime})
+		if err != nil {
+			return err
+		}
+		return printProto(response)
+	case "get":
+		if len(args) < 2 || strings.TrimSpace(args[1]) == "" {
+			return usageError(fmt.Sprintf("usage: %s source-runtime get <runtime-id>", os.Args[0]))
+		}
+		response, err := service.Get(context.Background(), &cerebrov1.GetSourceRuntimeRequest{Id: strings.TrimSpace(args[1])})
+		if err != nil {
+			return err
+		}
+		return printProto(response)
+	case "sync":
+		runtimeID, pageLimit, err := parseSourceRuntimeSyncArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		response, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
+			Id:        runtimeID,
+			PageLimit: pageLimit,
+		})
+		if err != nil {
+			return err
+		}
+		return printProto(response)
+	default:
+		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|sync] ...", os.Args[0]))
+	}
+}
+
 func parseSourceCommandArgs(args []string) (string, map[string]string, *cerebrov1.SourceCursor, error) {
 	if len(args) == 0 {
 		return "", nil, nil, usageError(fmt.Sprintf("usage: %s source <command> <source-id> [key=value ...]", os.Args[0]))
@@ -217,6 +283,59 @@ func sensitiveSourceConfigKey(key string) bool {
 		return true
 	}
 	return normalized == "key" || strings.HasSuffix(normalized, "_key")
+}
+
+func parseSourceRuntimePutArgs(args []string) (*cerebrov1.SourceRuntime, error) {
+	if len(args) < 2 {
+		return nil, usageError(fmt.Sprintf("usage: %s source-runtime put <runtime-id> <source-id> [key=value ...]", os.Args[0]))
+	}
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       strings.TrimSpace(args[0]),
+		SourceId: strings.TrimSpace(args[1]),
+		Config:   make(map[string]string),
+	}
+	if runtime.GetId() == "" || runtime.GetSourceId() == "" {
+		return nil, usageError(fmt.Sprintf("usage: %s source-runtime put <runtime-id> <source-id> [key=value ...]", os.Args[0]))
+	}
+	for _, arg := range args[2:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid source runtime argument %q; want key=value", arg)
+		}
+		runtime.Config[key] = value
+	}
+	return runtime, nil
+}
+
+func parseSourceRuntimeSyncArgs(args []string) (string, uint32, error) {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return "", 0, usageError(fmt.Sprintf("usage: %s source-runtime sync <runtime-id> [page_limit=N]", os.Args[0]))
+	}
+	runtimeID := strings.TrimSpace(args[0])
+	var pageLimit uint32
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return "", 0, fmt.Errorf("invalid source runtime argument %q; want key=value", arg)
+		}
+		if key != "page_limit" {
+			return "", 0, fmt.Errorf("unsupported source runtime argument %q", key)
+		}
+		parsed, err := strconv.ParseUint(value, 10, 32)
+		if err != nil {
+			return "", 0, fmt.Errorf("parse page_limit: %w", err)
+		}
+		pageLimit = uint32(parsed)
+	}
+	return runtimeID, pageLimit, nil
+}
+
+func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {
+	runtimeStore, ok := store.(ports.SourceRuntimeStore)
+	if !ok {
+		return nil
+	}
+	return runtimeStore
 }
 
 func printProto(message proto.Message) error {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -33,3 +33,26 @@ func TestParseSourceCommandArgsReadsSensitiveEnv(t *testing.T) {
 		t.Fatalf("cursor = %#v, want opaque 2", cursor)
 	}
 }
+
+func TestParseSourceRuntimePutArgsSeparatesTenantID(t *testing.T) {
+	runtime, err := parseSourceRuntimePutArgs([]string{
+		"writer-okta-users",
+		"okta",
+		"tenant_id=writer",
+		"domain=writer.okta.com",
+		"family=user",
+		"token=test",
+	})
+	if err != nil {
+		t.Fatalf("parseSourceRuntimePutArgs() error = %v", err)
+	}
+	if got := runtime.GetTenantId(); got != "writer" {
+		t.Fatalf("runtime.TenantId = %q, want %q", got, "writer")
+	}
+	if got := runtime.GetConfig()["domain"]; got != "writer.okta.com" {
+		t.Fatalf("runtime.Config[domain] = %q, want %q", got, "writer.okta.com")
+	}
+	if _, ok := runtime.GetConfig()["tenant_id"]; ok {
+		t.Fatal("runtime.Config[tenant_id] present, want omitted")
+	}
+}

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -794,10 +794,11 @@ type SourceRuntime struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	SourceId      string                 `protobuf:"bytes,2,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
-	Config        map[string]string      `protobuf:"bytes,3,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Checkpoint    *SourceCheckpoint      `protobuf:"bytes,4,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
-	NextCursor    *SourceCursor          `protobuf:"bytes,5,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
-	LastSyncedAt  *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=last_synced_at,json=lastSyncedAt,proto3" json:"last_synced_at,omitempty"`
+	TenantId      string                 `protobuf:"bytes,3,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	Config        map[string]string      `protobuf:"bytes,4,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Checkpoint    *SourceCheckpoint      `protobuf:"bytes,5,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
+	NextCursor    *SourceCursor          `protobuf:"bytes,6,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
+	LastSyncedAt  *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=last_synced_at,json=lastSyncedAt,proto3" json:"last_synced_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -842,6 +843,13 @@ func (x *SourceRuntime) GetId() string {
 func (x *SourceRuntime) GetSourceId() string {
 	if x != nil {
 		return x.SourceId
+	}
+	return ""
+}
+
+func (x *SourceRuntime) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
 	}
 	return ""
 }
@@ -1109,13 +1117,15 @@ func (x *SyncSourceRuntimeRequest) GetPageLimit() uint32 {
 
 // SyncSourceRuntimeResponse returns the updated runtime and sync totals.
 type SyncSourceRuntimeResponse struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	Runtime        *SourceRuntime         `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
-	Source         *SourceSpec            `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
-	PagesRead      uint32                 `protobuf:"varint,3,opt,name=pages_read,json=pagesRead,proto3" json:"pages_read,omitempty"`
-	EventsAppended uint32                 `protobuf:"varint,4,opt,name=events_appended,json=eventsAppended,proto3" json:"events_appended,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Runtime           *SourceRuntime         `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
+	Source            *SourceSpec            `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	PagesRead         uint32                 `protobuf:"varint,3,opt,name=pages_read,json=pagesRead,proto3" json:"pages_read,omitempty"`
+	EventsAppended    uint32                 `protobuf:"varint,4,opt,name=events_appended,json=eventsAppended,proto3" json:"events_appended,omitempty"`
+	EntitiesProjected uint32                 `protobuf:"varint,5,opt,name=entities_projected,json=entitiesProjected,proto3" json:"entities_projected,omitempty"`
+	LinksProjected    uint32                 `protobuf:"varint,6,opt,name=links_projected,json=linksProjected,proto3" json:"links_projected,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *SyncSourceRuntimeResponse) Reset() {
@@ -1172,6 +1182,20 @@ func (x *SyncSourceRuntimeResponse) GetPagesRead() uint32 {
 func (x *SyncSourceRuntimeResponse) GetEventsAppended() uint32 {
 	if x != nil {
 		return x.EventsAppended
+	}
+	return 0
+}
+
+func (x *SyncSourceRuntimeResponse) GetEntitiesProjected() uint32 {
+	if x != nil {
+		return x.EntitiesProjected
+	}
+	return 0
+}
+
+func (x *SyncSourceRuntimeResponse) GetLinksProjected() uint32 {
+	if x != nil {
+		return x.LinksProjected
 	}
 	return 0
 }
@@ -1243,17 +1267,18 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"checkpoint\x129\n" +
 	"\vnext_cursor\x18\x04 \x01(\v2\x18.cerebro.v1.SourceCursorR\n" +
 	"nextCursor\x12E\n" +
-	"\x0epreview_events\x18\x05 \x03(\v2\x1e.cerebro.v1.SourcePreviewEventR\rpreviewEvents\"\xf1\x02\n" +
+	"\x0epreview_events\x18\x05 \x03(\v2\x1e.cerebro.v1.SourcePreviewEventR\rpreviewEvents\"\x8e\x03\n" +
 	"\rSourceRuntime\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
-	"\tsource_id\x18\x02 \x01(\tR\bsourceId\x12=\n" +
-	"\x06config\x18\x03 \x03(\v2%.cerebro.v1.SourceRuntime.ConfigEntryR\x06config\x12<\n" +
+	"\tsource_id\x18\x02 \x01(\tR\bsourceId\x12\x1b\n" +
+	"\ttenant_id\x18\x03 \x01(\tR\btenantId\x12=\n" +
+	"\x06config\x18\x04 \x03(\v2%.cerebro.v1.SourceRuntime.ConfigEntryR\x06config\x12<\n" +
 	"\n" +
-	"checkpoint\x18\x04 \x01(\v2\x1c.cerebro.v1.SourceCheckpointR\n" +
+	"checkpoint\x18\x05 \x01(\v2\x1c.cerebro.v1.SourceCheckpointR\n" +
 	"checkpoint\x129\n" +
-	"\vnext_cursor\x18\x05 \x01(\v2\x18.cerebro.v1.SourceCursorR\n" +
+	"\vnext_cursor\x18\x06 \x01(\v2\x18.cerebro.v1.SourceCursorR\n" +
 	"nextCursor\x12@\n" +
-	"\x0elast_synced_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncedAt\x1a9\n" +
+	"\x0elast_synced_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncedAt\x1a9\n" +
 	"\vConfigEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"N\n" +
@@ -1268,13 +1293,15 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x18SyncSourceRuntimeRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
-	"page_limit\x18\x02 \x01(\rR\tpageLimit\"\xc8\x01\n" +
+	"page_limit\x18\x02 \x01(\rR\tpageLimit\"\xa0\x02\n" +
 	"\x19SyncSourceRuntimeResponse\x123\n" +
 	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\x12.\n" +
 	"\x06source\x18\x02 \x01(\v2\x16.cerebro.v1.SourceSpecR\x06source\x12\x1d\n" +
 	"\n" +
 	"pages_read\x18\x03 \x01(\rR\tpagesRead\x12'\n" +
-	"\x0fevents_appended\x18\x04 \x01(\rR\x0eeventsAppended2\x95\x06\n" +
+	"\x0fevents_appended\x18\x04 \x01(\rR\x0eeventsAppended\x12-\n" +
+	"\x12entities_projected\x18\x05 \x01(\rR\x11entitiesProjected\x12'\n" +
+	"\x0flinks_projected\x18\x06 \x01(\rR\x0elinksProjected2\x95\x06\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -789,6 +789,393 @@ func (x *ReadSourceResponse) GetPreviewEvents() []*SourcePreviewEvent {
 	return nil
 }
 
+// SourceRuntime stores source configuration plus the latest durable sync progress.
+type SourceRuntime struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	SourceId      string                 `protobuf:"bytes,2,opt,name=source_id,json=sourceId,proto3" json:"source_id,omitempty"`
+	Config        map[string]string      `protobuf:"bytes,3,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Checkpoint    *SourceCheckpoint      `protobuf:"bytes,4,opt,name=checkpoint,proto3" json:"checkpoint,omitempty"`
+	NextCursor    *SourceCursor          `protobuf:"bytes,5,opt,name=next_cursor,json=nextCursor,proto3" json:"next_cursor,omitempty"`
+	LastSyncedAt  *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=last_synced_at,json=lastSyncedAt,proto3" json:"last_synced_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SourceRuntime) Reset() {
+	*x = SourceRuntime{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SourceRuntime) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SourceRuntime) ProtoMessage() {}
+
+func (x *SourceRuntime) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SourceRuntime.ProtoReflect.Descriptor instead.
+func (*SourceRuntime) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *SourceRuntime) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *SourceRuntime) GetSourceId() string {
+	if x != nil {
+		return x.SourceId
+	}
+	return ""
+}
+
+func (x *SourceRuntime) GetConfig() map[string]string {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+func (x *SourceRuntime) GetCheckpoint() *SourceCheckpoint {
+	if x != nil {
+		return x.Checkpoint
+	}
+	return nil
+}
+
+func (x *SourceRuntime) GetNextCursor() *SourceCursor {
+	if x != nil {
+		return x.NextCursor
+	}
+	return nil
+}
+
+func (x *SourceRuntime) GetLastSyncedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastSyncedAt
+	}
+	return nil
+}
+
+// PutSourceRuntimeRequest stores or updates one source runtime definition.
+type PutSourceRuntimeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Runtime       *SourceRuntime         `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PutSourceRuntimeRequest) Reset() {
+	*x = PutSourceRuntimeRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PutSourceRuntimeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PutSourceRuntimeRequest) ProtoMessage() {}
+
+func (x *PutSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PutSourceRuntimeRequest.ProtoReflect.Descriptor instead.
+func (*PutSourceRuntimeRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *PutSourceRuntimeRequest) GetRuntime() *SourceRuntime {
+	if x != nil {
+		return x.Runtime
+	}
+	return nil
+}
+
+// PutSourceRuntimeResponse returns the stored runtime view.
+type PutSourceRuntimeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Runtime       *SourceRuntime         `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PutSourceRuntimeResponse) Reset() {
+	*x = PutSourceRuntimeResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PutSourceRuntimeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PutSourceRuntimeResponse) ProtoMessage() {}
+
+func (x *PutSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PutSourceRuntimeResponse.ProtoReflect.Descriptor instead.
+func (*PutSourceRuntimeResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *PutSourceRuntimeResponse) GetRuntime() *SourceRuntime {
+	if x != nil {
+		return x.Runtime
+	}
+	return nil
+}
+
+// GetSourceRuntimeRequest looks up one stored source runtime definition.
+type GetSourceRuntimeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSourceRuntimeRequest) Reset() {
+	*x = GetSourceRuntimeRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSourceRuntimeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSourceRuntimeRequest) ProtoMessage() {}
+
+func (x *GetSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSourceRuntimeRequest.ProtoReflect.Descriptor instead.
+func (*GetSourceRuntimeRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *GetSourceRuntimeRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+// GetSourceRuntimeResponse returns the stored runtime view.
+type GetSourceRuntimeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Runtime       *SourceRuntime         `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSourceRuntimeResponse) Reset() {
+	*x = GetSourceRuntimeResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSourceRuntimeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSourceRuntimeResponse) ProtoMessage() {}
+
+func (x *GetSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSourceRuntimeResponse.ProtoReflect.Descriptor instead.
+func (*GetSourceRuntimeResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *GetSourceRuntimeResponse) GetRuntime() *SourceRuntime {
+	if x != nil {
+		return x.Runtime
+	}
+	return nil
+}
+
+// SyncSourceRuntimeRequest advances one stored source runtime.
+type SyncSourceRuntimeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	PageLimit     uint32                 `protobuf:"varint,2,opt,name=page_limit,json=pageLimit,proto3" json:"page_limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SyncSourceRuntimeRequest) Reset() {
+	*x = SyncSourceRuntimeRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SyncSourceRuntimeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SyncSourceRuntimeRequest) ProtoMessage() {}
+
+func (x *SyncSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SyncSourceRuntimeRequest.ProtoReflect.Descriptor instead.
+func (*SyncSourceRuntimeRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *SyncSourceRuntimeRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *SyncSourceRuntimeRequest) GetPageLimit() uint32 {
+	if x != nil {
+		return x.PageLimit
+	}
+	return 0
+}
+
+// SyncSourceRuntimeResponse returns the updated runtime and sync totals.
+type SyncSourceRuntimeResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Runtime        *SourceRuntime         `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
+	Source         *SourceSpec            `protobuf:"bytes,2,opt,name=source,proto3" json:"source,omitempty"`
+	PagesRead      uint32                 `protobuf:"varint,3,opt,name=pages_read,json=pagesRead,proto3" json:"pages_read,omitempty"`
+	EventsAppended uint32                 `protobuf:"varint,4,opt,name=events_appended,json=eventsAppended,proto3" json:"events_appended,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SyncSourceRuntimeResponse) Reset() {
+	*x = SyncSourceRuntimeResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SyncSourceRuntimeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SyncSourceRuntimeResponse) ProtoMessage() {}
+
+func (x *SyncSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SyncSourceRuntimeResponse.ProtoReflect.Descriptor instead.
+func (*SyncSourceRuntimeResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *SyncSourceRuntimeResponse) GetRuntime() *SourceRuntime {
+	if x != nil {
+		return x.Runtime
+	}
+	return nil
+}
+
+func (x *SyncSourceRuntimeResponse) GetSource() *SourceSpec {
+	if x != nil {
+		return x.Source
+	}
+	return nil
+}
+
+func (x *SyncSourceRuntimeResponse) GetPagesRead() uint32 {
+	if x != nil {
+		return x.PagesRead
+	}
+	return 0
+}
+
+func (x *SyncSourceRuntimeResponse) GetEventsAppended() uint32 {
+	if x != nil {
+		return x.EventsAppended
+	}
+	return 0
+}
+
 var File_cerebro_v1_bootstrap_proto protoreflect.FileDescriptor
 
 const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
@@ -856,7 +1243,38 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"checkpoint\x129\n" +
 	"\vnext_cursor\x18\x04 \x01(\v2\x18.cerebro.v1.SourceCursorR\n" +
 	"nextCursor\x12E\n" +
-	"\x0epreview_events\x18\x05 \x03(\v2\x1e.cerebro.v1.SourcePreviewEventR\rpreviewEvents2\xf5\x03\n" +
+	"\x0epreview_events\x18\x05 \x03(\v2\x1e.cerebro.v1.SourcePreviewEventR\rpreviewEvents\"\xf1\x02\n" +
+	"\rSourceRuntime\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
+	"\tsource_id\x18\x02 \x01(\tR\bsourceId\x12=\n" +
+	"\x06config\x18\x03 \x03(\v2%.cerebro.v1.SourceRuntime.ConfigEntryR\x06config\x12<\n" +
+	"\n" +
+	"checkpoint\x18\x04 \x01(\v2\x1c.cerebro.v1.SourceCheckpointR\n" +
+	"checkpoint\x129\n" +
+	"\vnext_cursor\x18\x05 \x01(\v2\x18.cerebro.v1.SourceCursorR\n" +
+	"nextCursor\x12@\n" +
+	"\x0elast_synced_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncedAt\x1a9\n" +
+	"\vConfigEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"N\n" +
+	"\x17PutSourceRuntimeRequest\x123\n" +
+	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\"O\n" +
+	"\x18PutSourceRuntimeResponse\x123\n" +
+	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\")\n" +
+	"\x17GetSourceRuntimeRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"O\n" +
+	"\x18GetSourceRuntimeResponse\x123\n" +
+	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\"I\n" +
+	"\x18SyncSourceRuntimeRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
+	"\n" +
+	"page_limit\x18\x02 \x01(\rR\tpageLimit\"\xc8\x01\n" +
+	"\x19SyncSourceRuntimeResponse\x123\n" +
+	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\x12.\n" +
+	"\x06source\x18\x02 \x01(\v2\x16.cerebro.v1.SourceSpecR\x06source\x12\x1d\n" +
+	"\n" +
+	"pages_read\x18\x03 \x01(\rR\tpagesRead\x12'\n" +
+	"\x0fevents_appended\x18\x04 \x01(\rR\x0eeventsAppended2\x95\x06\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -865,7 +1283,10 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\vCheckSource\x12\x1e.cerebro.v1.CheckSourceRequest\x1a\x1f.cerebro.v1.CheckSourceResponse\x12W\n" +
 	"\x0eDiscoverSource\x12!.cerebro.v1.DiscoverSourceRequest\x1a\".cerebro.v1.DiscoverSourceResponse\x12K\n" +
 	"\n" +
-	"ReadSource\x12\x1d.cerebro.v1.ReadSourceRequest\x1a\x1e.cerebro.v1.ReadSourceResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
+	"ReadSource\x12\x1d.cerebro.v1.ReadSourceRequest\x1a\x1e.cerebro.v1.ReadSourceResponse\x12]\n" +
+	"\x10PutSourceRuntime\x12#.cerebro.v1.PutSourceRuntimeRequest\x1a$.cerebro.v1.PutSourceRuntimeResponse\x12]\n" +
+	"\x10GetSourceRuntime\x12#.cerebro.v1.GetSourceRuntimeRequest\x1a$.cerebro.v1.GetSourceRuntimeResponse\x12`\n" +
+	"\x11SyncSourceRuntime\x12$.cerebro.v1.SyncSourceRuntimeRequest\x1a%.cerebro.v1.SyncSourceRuntimeResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
 
 var (
 	file_cerebro_v1_bootstrap_proto_rawDescOnce sync.Once
@@ -879,65 +1300,88 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
-	(*GetVersionRequest)(nil),      // 0: cerebro.v1.GetVersionRequest
-	(*GetVersionResponse)(nil),     // 1: cerebro.v1.GetVersionResponse
-	(*CheckHealthRequest)(nil),     // 2: cerebro.v1.CheckHealthRequest
-	(*ComponentStatus)(nil),        // 3: cerebro.v1.ComponentStatus
-	(*CheckHealthResponse)(nil),    // 4: cerebro.v1.CheckHealthResponse
-	(*ListSourcesRequest)(nil),     // 5: cerebro.v1.ListSourcesRequest
-	(*ListSourcesResponse)(nil),    // 6: cerebro.v1.ListSourcesResponse
-	(*CheckSourceRequest)(nil),     // 7: cerebro.v1.CheckSourceRequest
-	(*CheckSourceResponse)(nil),    // 8: cerebro.v1.CheckSourceResponse
-	(*DiscoverSourceRequest)(nil),  // 9: cerebro.v1.DiscoverSourceRequest
-	(*DiscoverSourceResponse)(nil), // 10: cerebro.v1.DiscoverSourceResponse
-	(*ReadSourceRequest)(nil),      // 11: cerebro.v1.ReadSourceRequest
-	(*SourcePreviewEvent)(nil),     // 12: cerebro.v1.SourcePreviewEvent
-	(*ReadSourceResponse)(nil),     // 13: cerebro.v1.ReadSourceResponse
-	nil,                            // 14: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                            // 15: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                            // 16: cerebro.v1.ReadSourceRequest.ConfigEntry
-	(*timestamppb.Timestamp)(nil),  // 17: google.protobuf.Timestamp
-	(*SourceSpec)(nil),             // 18: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),           // 19: cerebro.v1.SourceCursor
-	(*structpb.Value)(nil),         // 20: google.protobuf.Value
-	(*EventEnvelope)(nil),          // 21: cerebro.v1.EventEnvelope
-	(*SourceCheckpoint)(nil),       // 22: cerebro.v1.SourceCheckpoint
+	(*GetVersionRequest)(nil),         // 0: cerebro.v1.GetVersionRequest
+	(*GetVersionResponse)(nil),        // 1: cerebro.v1.GetVersionResponse
+	(*CheckHealthRequest)(nil),        // 2: cerebro.v1.CheckHealthRequest
+	(*ComponentStatus)(nil),           // 3: cerebro.v1.ComponentStatus
+	(*CheckHealthResponse)(nil),       // 4: cerebro.v1.CheckHealthResponse
+	(*ListSourcesRequest)(nil),        // 5: cerebro.v1.ListSourcesRequest
+	(*ListSourcesResponse)(nil),       // 6: cerebro.v1.ListSourcesResponse
+	(*CheckSourceRequest)(nil),        // 7: cerebro.v1.CheckSourceRequest
+	(*CheckSourceResponse)(nil),       // 8: cerebro.v1.CheckSourceResponse
+	(*DiscoverSourceRequest)(nil),     // 9: cerebro.v1.DiscoverSourceRequest
+	(*DiscoverSourceResponse)(nil),    // 10: cerebro.v1.DiscoverSourceResponse
+	(*ReadSourceRequest)(nil),         // 11: cerebro.v1.ReadSourceRequest
+	(*SourcePreviewEvent)(nil),        // 12: cerebro.v1.SourcePreviewEvent
+	(*ReadSourceResponse)(nil),        // 13: cerebro.v1.ReadSourceResponse
+	(*SourceRuntime)(nil),             // 14: cerebro.v1.SourceRuntime
+	(*PutSourceRuntimeRequest)(nil),   // 15: cerebro.v1.PutSourceRuntimeRequest
+	(*PutSourceRuntimeResponse)(nil),  // 16: cerebro.v1.PutSourceRuntimeResponse
+	(*GetSourceRuntimeRequest)(nil),   // 17: cerebro.v1.GetSourceRuntimeRequest
+	(*GetSourceRuntimeResponse)(nil),  // 18: cerebro.v1.GetSourceRuntimeResponse
+	(*SyncSourceRuntimeRequest)(nil),  // 19: cerebro.v1.SyncSourceRuntimeRequest
+	(*SyncSourceRuntimeResponse)(nil), // 20: cerebro.v1.SyncSourceRuntimeResponse
+	nil,                               // 21: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                               // 22: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                               // 23: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                               // 24: cerebro.v1.SourceRuntime.ConfigEntry
+	(*timestamppb.Timestamp)(nil),     // 25: google.protobuf.Timestamp
+	(*SourceSpec)(nil),                // 26: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),              // 27: cerebro.v1.SourceCursor
+	(*structpb.Value)(nil),            // 28: google.protobuf.Value
+	(*EventEnvelope)(nil),             // 29: cerebro.v1.EventEnvelope
+	(*SourceCheckpoint)(nil),          // 30: cerebro.v1.SourceCheckpoint
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	17, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	25, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
-	18, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	14, // 3: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	18, // 4: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	15, // 5: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	18, // 6: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	16, // 7: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	19, // 8: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	20, // 9: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	18, // 10: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	21, // 11: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	22, // 12: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	19, // 13: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	26, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	21, // 3: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	26, // 4: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	22, // 5: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	26, // 6: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	23, // 7: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	27, // 8: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	28, // 9: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	26, // 10: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	29, // 11: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	30, // 12: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	27, // 13: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
 	12, // 14: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	0,  // 15: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2,  // 16: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	5,  // 17: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	7,  // 18: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	9,  // 19: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	11, // 20: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	1,  // 21: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4,  // 22: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	6,  // 23: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	8,  // 24: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	10, // 25: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	13, // 26: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	21, // [21:27] is the sub-list for method output_type
-	15, // [15:21] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	24, // 15: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	30, // 16: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	27, // 17: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	25, // 18: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	14, // 19: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
+	14, // 20: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	14, // 21: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	14, // 22: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	26, // 23: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	0,  // 24: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 25: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	5,  // 26: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	7,  // 27: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	9,  // 28: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	11, // 29: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	15, // 30: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	17, // 31: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	19, // 32: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	1,  // 33: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 34: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	6,  // 35: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	8,  // 36: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	10, // 37: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	13, // 38: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	16, // 39: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	18, // 40: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	20, // 41: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	33, // [33:42] is the sub-list for method output_type
+	24, // [24:33] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -953,7 +1397,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   17,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -51,6 +51,15 @@ const (
 	// BootstrapServiceReadSourceProcedure is the fully-qualified name of the BootstrapService's
 	// ReadSource RPC.
 	BootstrapServiceReadSourceProcedure = "/cerebro.v1.BootstrapService/ReadSource"
+	// BootstrapServicePutSourceRuntimeProcedure is the fully-qualified name of the BootstrapService's
+	// PutSourceRuntime RPC.
+	BootstrapServicePutSourceRuntimeProcedure = "/cerebro.v1.BootstrapService/PutSourceRuntime"
+	// BootstrapServiceGetSourceRuntimeProcedure is the fully-qualified name of the BootstrapService's
+	// GetSourceRuntime RPC.
+	BootstrapServiceGetSourceRuntimeProcedure = "/cerebro.v1.BootstrapService/GetSourceRuntime"
+	// BootstrapServiceSyncSourceRuntimeProcedure is the fully-qualified name of the BootstrapService's
+	// SyncSourceRuntime RPC.
+	BootstrapServiceSyncSourceRuntimeProcedure = "/cerebro.v1.BootstrapService/SyncSourceRuntime"
 )
 
 // BootstrapServiceClient is a client for the cerebro.v1.BootstrapService service.
@@ -61,6 +70,9 @@ type BootstrapServiceClient interface {
 	CheckSource(context.Context, *connect.Request[v1.CheckSourceRequest]) (*connect.Response[v1.CheckSourceResponse], error)
 	DiscoverSource(context.Context, *connect.Request[v1.DiscoverSourceRequest]) (*connect.Response[v1.DiscoverSourceResponse], error)
 	ReadSource(context.Context, *connect.Request[v1.ReadSourceRequest]) (*connect.Response[v1.ReadSourceResponse], error)
+	PutSourceRuntime(context.Context, *connect.Request[v1.PutSourceRuntimeRequest]) (*connect.Response[v1.PutSourceRuntimeResponse], error)
+	GetSourceRuntime(context.Context, *connect.Request[v1.GetSourceRuntimeRequest]) (*connect.Response[v1.GetSourceRuntimeResponse], error)
+	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
 }
 
 // NewBootstrapServiceClient constructs a client for the cerebro.v1.BootstrapService service. By
@@ -110,17 +122,38 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("ReadSource")),
 			connect.WithClientOptions(opts...),
 		),
+		putSourceRuntime: connect.NewClient[v1.PutSourceRuntimeRequest, v1.PutSourceRuntimeResponse](
+			httpClient,
+			baseURL+BootstrapServicePutSourceRuntimeProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("PutSourceRuntime")),
+			connect.WithClientOptions(opts...),
+		),
+		getSourceRuntime: connect.NewClient[v1.GetSourceRuntimeRequest, v1.GetSourceRuntimeResponse](
+			httpClient,
+			baseURL+BootstrapServiceGetSourceRuntimeProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("GetSourceRuntime")),
+			connect.WithClientOptions(opts...),
+		),
+		syncSourceRuntime: connect.NewClient[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse](
+			httpClient,
+			baseURL+BootstrapServiceSyncSourceRuntimeProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("SyncSourceRuntime")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // bootstrapServiceClient implements BootstrapServiceClient.
 type bootstrapServiceClient struct {
-	getVersion     *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
-	checkHealth    *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
-	listSources    *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
-	checkSource    *connect.Client[v1.CheckSourceRequest, v1.CheckSourceResponse]
-	discoverSource *connect.Client[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse]
-	readSource     *connect.Client[v1.ReadSourceRequest, v1.ReadSourceResponse]
+	getVersion        *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
+	checkHealth       *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
+	listSources       *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
+	checkSource       *connect.Client[v1.CheckSourceRequest, v1.CheckSourceResponse]
+	discoverSource    *connect.Client[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse]
+	readSource        *connect.Client[v1.ReadSourceRequest, v1.ReadSourceResponse]
+	putSourceRuntime  *connect.Client[v1.PutSourceRuntimeRequest, v1.PutSourceRuntimeResponse]
+	getSourceRuntime  *connect.Client[v1.GetSourceRuntimeRequest, v1.GetSourceRuntimeResponse]
+	syncSourceRuntime *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
 }
 
 // GetVersion calls cerebro.v1.BootstrapService.GetVersion.
@@ -153,6 +186,21 @@ func (c *bootstrapServiceClient) ReadSource(ctx context.Context, req *connect.Re
 	return c.readSource.CallUnary(ctx, req)
 }
 
+// PutSourceRuntime calls cerebro.v1.BootstrapService.PutSourceRuntime.
+func (c *bootstrapServiceClient) PutSourceRuntime(ctx context.Context, req *connect.Request[v1.PutSourceRuntimeRequest]) (*connect.Response[v1.PutSourceRuntimeResponse], error) {
+	return c.putSourceRuntime.CallUnary(ctx, req)
+}
+
+// GetSourceRuntime calls cerebro.v1.BootstrapService.GetSourceRuntime.
+func (c *bootstrapServiceClient) GetSourceRuntime(ctx context.Context, req *connect.Request[v1.GetSourceRuntimeRequest]) (*connect.Response[v1.GetSourceRuntimeResponse], error) {
+	return c.getSourceRuntime.CallUnary(ctx, req)
+}
+
+// SyncSourceRuntime calls cerebro.v1.BootstrapService.SyncSourceRuntime.
+func (c *bootstrapServiceClient) SyncSourceRuntime(ctx context.Context, req *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error) {
+	return c.syncSourceRuntime.CallUnary(ctx, req)
+}
+
 // BootstrapServiceHandler is an implementation of the cerebro.v1.BootstrapService service.
 type BootstrapServiceHandler interface {
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
@@ -161,6 +209,9 @@ type BootstrapServiceHandler interface {
 	CheckSource(context.Context, *connect.Request[v1.CheckSourceRequest]) (*connect.Response[v1.CheckSourceResponse], error)
 	DiscoverSource(context.Context, *connect.Request[v1.DiscoverSourceRequest]) (*connect.Response[v1.DiscoverSourceResponse], error)
 	ReadSource(context.Context, *connect.Request[v1.ReadSourceRequest]) (*connect.Response[v1.ReadSourceResponse], error)
+	PutSourceRuntime(context.Context, *connect.Request[v1.PutSourceRuntimeRequest]) (*connect.Response[v1.PutSourceRuntimeResponse], error)
+	GetSourceRuntime(context.Context, *connect.Request[v1.GetSourceRuntimeRequest]) (*connect.Response[v1.GetSourceRuntimeResponse], error)
+	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
 }
 
 // NewBootstrapServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -206,6 +257,24 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		connect.WithSchema(bootstrapServiceMethods.ByName("ReadSource")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bootstrapServicePutSourceRuntimeHandler := connect.NewUnaryHandler(
+		BootstrapServicePutSourceRuntimeProcedure,
+		svc.PutSourceRuntime,
+		connect.WithSchema(bootstrapServiceMethods.ByName("PutSourceRuntime")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceGetSourceRuntimeHandler := connect.NewUnaryHandler(
+		BootstrapServiceGetSourceRuntimeProcedure,
+		svc.GetSourceRuntime,
+		connect.WithSchema(bootstrapServiceMethods.ByName("GetSourceRuntime")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceSyncSourceRuntimeHandler := connect.NewUnaryHandler(
+		BootstrapServiceSyncSourceRuntimeProcedure,
+		svc.SyncSourceRuntime,
+		connect.WithSchema(bootstrapServiceMethods.ByName("SyncSourceRuntime")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/cerebro.v1.BootstrapService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case BootstrapServiceGetVersionProcedure:
@@ -220,6 +289,12 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceDiscoverSourceHandler.ServeHTTP(w, r)
 		case BootstrapServiceReadSourceProcedure:
 			bootstrapServiceReadSourceHandler.ServeHTTP(w, r)
+		case BootstrapServicePutSourceRuntimeProcedure:
+			bootstrapServicePutSourceRuntimeHandler.ServeHTTP(w, r)
+		case BootstrapServiceGetSourceRuntimeProcedure:
+			bootstrapServiceGetSourceRuntimeHandler.ServeHTTP(w, r)
+		case BootstrapServiceSyncSourceRuntimeProcedure:
+			bootstrapServiceSyncSourceRuntimeHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -251,4 +326,16 @@ func (UnimplementedBootstrapServiceHandler) DiscoverSource(context.Context, *con
 
 func (UnimplementedBootstrapServiceHandler) ReadSource(context.Context, *connect.Request[v1.ReadSourceRequest]) (*connect.Response[v1.ReadSourceResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ReadSource is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) PutSourceRuntime(context.Context, *connect.Request[v1.PutSourceRuntimeRequest]) (*connect.Response[v1.PutSourceRuntimeResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.PutSourceRuntime is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) GetSourceRuntime(context.Context, *connect.Request[v1.GetSourceRuntimeRequest]) (*connect.Response[v1.GetSourceRuntimeResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.GetSourceRuntime is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.SyncSourceRuntime is not implemented"))
 }

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -412,8 +412,10 @@ func sourceConnectError(err error) error {
 }
 
 func writeSourceRuntimeError(w http.ResponseWriter, err error) {
-	statusCode := http.StatusBadRequest
+	statusCode := http.StatusInternalServerError
 	switch {
+	case errors.Is(err, sourceruntime.ErrInvalidRequest):
+		statusCode = http.StatusBadRequest
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound), errors.Is(err, sourceops.ErrSourceNotFound):
 		statusCode = http.StatusNotFound
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable):

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -3,9 +3,12 @@ package bootstrap
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -98,9 +101,14 @@ func (a *App) handleSources(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleCheckSource(w http.ResponseWriter, r *http.Request) {
+	config, err := sourceConfigFromRequest(r)
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
 	response, err := a.sourceService().Check(r.Context(), &cerebrov1.CheckSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   sourceConfigFromQuery(r),
+		Config:   config,
 	})
 	if err != nil {
 		writeSourceError(w, err)
@@ -110,9 +118,14 @@ func (a *App) handleCheckSource(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleDiscoverSource(w http.ResponseWriter, r *http.Request) {
+	config, err := sourceConfigFromRequest(r)
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
 	response, err := a.sourceService().Discover(r.Context(), &cerebrov1.DiscoverSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   sourceConfigFromQuery(r),
+		Config:   config,
 	})
 	if err != nil {
 		writeSourceError(w, err)
@@ -122,9 +135,14 @@ func (a *App) handleDiscoverSource(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleReadSource(w http.ResponseWriter, r *http.Request) {
+	config, err := sourceConfigFromRequest(r)
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
 	request := &cerebrov1.ReadSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   sourceConfigFromQuery(r),
+		Config:   config,
 	}
 	if cursor := r.URL.Query().Get("cursor"); cursor != "" {
 		request.Cursor = &cerebrov1.SourceCursor{Opaque: cursor}
@@ -309,15 +327,35 @@ func (a *App) runtimeService() *sourceruntime.Service {
 	)
 }
 
-func sourceConfigFromQuery(r *http.Request) map[string]string {
+func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {
 	values := make(map[string]string)
 	for key, rawValues := range r.URL.Query() {
 		if key == "cursor" || len(rawValues) == 0 {
 			continue
 		}
+		if sensitiveSourceConfigKey(key) {
+			return nil, fmt.Errorf("source config key %q must not be supplied in query parameters", key)
+		}
 		values[key] = rawValues[len(rawValues)-1]
 	}
-	return values
+	if rawConfig := strings.TrimSpace(r.Header.Get("X-Cerebro-Source-Config")); rawConfig != "" {
+		headerValues := map[string]string{}
+		if err := json.Unmarshal([]byte(rawConfig), &headerValues); err != nil {
+			return nil, fmt.Errorf("decode source config header: %w", err)
+		}
+		for key, value := range headerValues {
+			trimmedKey := strings.TrimSpace(key)
+			if trimmedKey != "" {
+				values[trimmedKey] = value
+			}
+		}
+	}
+	return values, nil
+}
+
+func sensitiveSourceConfigKey(key string) bool {
+	value := strings.ToLower(strings.TrimSpace(key))
+	return strings.Contains(value, "token") || strings.Contains(value, "secret") || strings.Contains(value, "password")
 }
 
 func writeSourceError(w http.ResponseWriter, err error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -419,7 +419,7 @@ func writeSourceRuntimeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable
 	}
-	http.Error(w, err.Error(), statusCode)
+	http.Error(w, http.StatusText(statusCode), statusCode)
 }
 
 func readProtoJSON(r *http.Request, message proto.Message) error {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -330,7 +330,7 @@ func (a *App) runtimeService() *sourceruntime.Service {
 func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {
 	values := make(map[string]string)
 	for key, rawValues := range r.URL.Query() {
-		if key == "cursor" || len(rawValues) == 0 {
+		if reservedSourceConfigKey(key) || len(rawValues) == 0 {
 			continue
 		}
 		if sensitiveSourceConfigKey(key) {
@@ -345,12 +345,28 @@ func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {
 		}
 		for key, value := range headerValues {
 			trimmedKey := strings.TrimSpace(key)
-			if trimmedKey != "" {
+			if trimmedKey != "" && !reservedSourceConfigKey(trimmedKey) {
 				values[trimmedKey] = value
 			}
 		}
 	}
+	if token := bearerToken(r.Header.Get("Authorization")); token != "" {
+		values["token"] = token
+	}
 	return values, nil
+}
+
+func bearerToken(header string) string {
+	header = strings.TrimSpace(header)
+	if len(header) < len("Bearer ") || !strings.EqualFold(header[:len("Bearer ")], "Bearer ") {
+		return ""
+	}
+	return strings.TrimSpace(header[len("Bearer "):])
+}
+
+func reservedSourceConfigKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	return normalized == "cursor" || normalized == "base_url"
 }
 
 func sensitiveSourceConfigKey(key string) bool {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -252,7 +252,7 @@ func (s *bootstrapService) PutSourceRuntime(ctx context.Context, req *connect.Re
 		sourceProjector(s.deps.StateStore, s.deps.GraphStore),
 	).Put(ctx, req.Msg)
 	if err != nil {
-		return nil, err
+		return nil, sourceRuntimeConnectError(err)
 	}
 	return connect.NewResponse(response), nil
 }
@@ -265,7 +265,7 @@ func (s *bootstrapService) GetSourceRuntime(ctx context.Context, req *connect.Re
 		sourceProjector(s.deps.StateStore, s.deps.GraphStore),
 	).Get(ctx, req.Msg)
 	if err != nil {
-		return nil, err
+		return nil, sourceRuntimeConnectError(err)
 	}
 	return connect.NewResponse(response), nil
 }
@@ -278,7 +278,7 @@ func (s *bootstrapService) SyncSourceRuntime(ctx context.Context, req *connect.R
 		sourceProjector(s.deps.StateStore, s.deps.GraphStore),
 	).Sync(ctx, req.Msg)
 	if err != nil {
-		return nil, err
+		return nil, sourceRuntimeConnectError(err)
 	}
 	return connect.NewResponse(response), nil
 }
@@ -356,6 +356,19 @@ func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {
 func sensitiveSourceConfigKey(key string) bool {
 	value := strings.ToLower(strings.TrimSpace(key))
 	return strings.Contains(value, "token") || strings.Contains(value, "secret") || strings.Contains(value, "password")
+}
+
+func sourceRuntimeConnectError(err error) error {
+	switch {
+	case errors.Is(err, ports.ErrSourceRuntimeNotFound), errors.Is(err, sourceops.ErrSourceNotFound):
+		return connect.NewError(connect.CodeNotFound, err)
+	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable):
+		return connect.NewError(connect.CodeUnavailable, err)
+	case errors.Is(err, sourceruntime.ErrInvalidRequest):
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	default:
+		return connect.NewError(connect.CodeInternal, err)
+	}
 }
 
 func writeSourceError(w http.ResponseWriter, err error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceops"
+	"github.com/writer/cerebro/internal/sourceprojection"
 	"github.com/writer/cerebro/internal/sourceruntime"
 )
 
@@ -226,7 +227,12 @@ func (s *bootstrapService) ReadSource(ctx context.Context, req *connect.Request[
 }
 
 func (s *bootstrapService) PutSourceRuntime(ctx context.Context, req *connect.Request[cerebrov1.PutSourceRuntimeRequest]) (*connect.Response[cerebrov1.PutSourceRuntimeResponse], error) {
-	response, err := sourceruntime.New(s.sources, sourceRuntimeStore(s.deps.StateStore), s.deps.AppendLog).Put(ctx, req.Msg)
+	response, err := sourceruntime.New(
+		s.sources,
+		sourceRuntimeStore(s.deps.StateStore),
+		s.deps.AppendLog,
+		sourceProjector(s.deps.StateStore, s.deps.GraphStore),
+	).Put(ctx, req.Msg)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +240,12 @@ func (s *bootstrapService) PutSourceRuntime(ctx context.Context, req *connect.Re
 }
 
 func (s *bootstrapService) GetSourceRuntime(ctx context.Context, req *connect.Request[cerebrov1.GetSourceRuntimeRequest]) (*connect.Response[cerebrov1.GetSourceRuntimeResponse], error) {
-	response, err := sourceruntime.New(s.sources, sourceRuntimeStore(s.deps.StateStore), s.deps.AppendLog).Get(ctx, req.Msg)
+	response, err := sourceruntime.New(
+		s.sources,
+		sourceRuntimeStore(s.deps.StateStore),
+		s.deps.AppendLog,
+		sourceProjector(s.deps.StateStore, s.deps.GraphStore),
+	).Get(ctx, req.Msg)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +253,12 @@ func (s *bootstrapService) GetSourceRuntime(ctx context.Context, req *connect.Re
 }
 
 func (s *bootstrapService) SyncSourceRuntime(ctx context.Context, req *connect.Request[cerebrov1.SyncSourceRuntimeRequest]) (*connect.Response[cerebrov1.SyncSourceRuntimeResponse], error) {
-	response, err := sourceruntime.New(s.sources, sourceRuntimeStore(s.deps.StateStore), s.deps.AppendLog).Sync(ctx, req.Msg)
+	response, err := sourceruntime.New(
+		s.sources,
+		sourceRuntimeStore(s.deps.StateStore),
+		s.deps.AppendLog,
+		sourceProjector(s.deps.StateStore, s.deps.GraphStore),
+	).Sync(ctx, req.Msg)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +301,12 @@ func (a *App) sourceService() *sourceops.Service {
 }
 
 func (a *App) runtimeService() *sourceruntime.Service {
-	return sourceruntime.New(a.sources, sourceRuntimeStore(a.deps.StateStore), a.deps.AppendLog)
+	return sourceruntime.New(
+		a.sources,
+		sourceRuntimeStore(a.deps.StateStore),
+		a.deps.AppendLog,
+		sourceProjector(a.deps.StateStore, a.deps.GraphStore),
+	)
 }
 
 func sourceConfigFromQuery(r *http.Request) map[string]string {
@@ -351,6 +372,31 @@ func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {
 		return nil
 	}
 	return runtimeStore
+}
+
+func sourceProjectionStateStore(store ports.StateStore) ports.ProjectionStateStore {
+	projectionStore, ok := store.(ports.ProjectionStateStore)
+	if !ok {
+		return nil
+	}
+	return projectionStore
+}
+
+func sourceProjectionGraphStore(store ports.GraphStore) ports.ProjectionGraphStore {
+	projectionStore, ok := store.(ports.ProjectionGraphStore)
+	if !ok {
+		return nil
+	}
+	return projectionStore
+}
+
+func sourceProjector(stateStore ports.StateStore, graphStore ports.GraphStore) ports.SourceProjector {
+	state := sourceProjectionStateStore(stateStore)
+	graph := sourceProjectionGraphStore(graphStore)
+	if state == nil && graph == nil {
+		return nil
+	}
+	return sourceprojection.New(state, graph)
 }
 
 type pinger interface {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -49,6 +49,8 @@ type bootstrapService struct {
 	sources *sourcecdk.Registry
 }
 
+const maxProtoJSONBodyBytes = 1 << 20
+
 // New constructs the minimal bootstrap app and registers the Connect handlers.
 func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App {
 	mux := http.NewServeMux()
@@ -377,6 +379,10 @@ func sensitiveSourceConfigKey(key string) bool {
 }
 
 func sourceRuntimeConnectError(err error) error {
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		return err
+	}
 	switch {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound), errors.Is(err, sourceops.ErrSourceNotFound):
 		return connect.NewError(connect.CodeNotFound, err)
@@ -431,14 +437,20 @@ func writeSourceRuntimeError(w http.ResponseWriter, err error) {
 }
 
 func readProtoJSON(r *http.Request, message proto.Message) error {
-	body, err := io.ReadAll(r.Body)
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxProtoJSONBodyBytes+1))
 	if err != nil {
 		return err
+	}
+	if len(body) > maxProtoJSONBodyBytes {
+		return fmt.Errorf("%w: request body too large", sourceruntime.ErrInvalidRequest)
 	}
 	if len(bytes.TrimSpace(body)) == 0 {
 		return nil
 	}
-	return protojson.Unmarshal(body, message)
+	if err := protojson.Unmarshal(body, message); err != nil {
+		return fmt.Errorf("%w: decode request body: %w", sourceruntime.ErrInvalidRequest, err)
+	}
+	return nil
 }
 
 func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -159,7 +159,7 @@ func (a *App) handleReadSource(w http.ResponseWriter, r *http.Request) {
 func (a *App) handlePutSourceRuntime(w http.ResponseWriter, r *http.Request) {
 	request := &cerebrov1.PutSourceRuntimeRequest{}
 	if err := readProtoJSON(r, request); err != nil {
-		writeSourceRuntimeError(w, err)
+		writeSourceRuntimeError(w, fmt.Errorf("%w: decode request body", sourceruntime.ErrInvalidRequest))
 		return
 	}
 	if request.Runtime == nil {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1,11 +1,11 @@
 package bootstrap
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"fmt"
+	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceops"
+	"github.com/writer/cerebro/internal/sourceruntime"
 )
 
 // Dependencies are the future store/log boundaries that will be wired into the rewrite.
@@ -57,6 +58,9 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("GET /sources/{sourceID}/check", app.handleCheckSource)
 	mux.HandleFunc("GET /sources/{sourceID}/discover", app.handleDiscoverSource)
 	mux.HandleFunc("GET /sources/{sourceID}/read", app.handleReadSource)
+	mux.HandleFunc("PUT /source-runtimes/{runtimeID}", app.handlePutSourceRuntime)
+	mux.HandleFunc("GET /source-runtimes/{runtimeID}", app.handleGetSourceRuntime)
+	mux.HandleFunc("POST /source-runtimes/{runtimeID}/sync", app.handleSyncSourceRuntime)
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           mux,
@@ -93,14 +97,9 @@ func (a *App) handleSources(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleCheckSource(w http.ResponseWriter, r *http.Request) {
-	config, err := sourceConfigFromQuery(r)
-	if err != nil {
-		writeSourceError(w, err)
-		return
-	}
 	response, err := a.sourceService().Check(r.Context(), &cerebrov1.CheckSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   config,
+		Config:   sourceConfigFromQuery(r),
 	})
 	if err != nil {
 		writeSourceError(w, err)
@@ -110,14 +109,9 @@ func (a *App) handleCheckSource(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleDiscoverSource(w http.ResponseWriter, r *http.Request) {
-	config, err := sourceConfigFromQuery(r)
-	if err != nil {
-		writeSourceError(w, err)
-		return
-	}
 	response, err := a.sourceService().Discover(r.Context(), &cerebrov1.DiscoverSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   config,
+		Config:   sourceConfigFromQuery(r),
 	})
 	if err != nil {
 		writeSourceError(w, err)
@@ -127,25 +121,63 @@ func (a *App) handleDiscoverSource(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleReadSource(w http.ResponseWriter, r *http.Request) {
-	config, err := sourceConfigFromQuery(r)
-	if err != nil {
-		writeSourceError(w, err)
-		return
-	}
 	request := &cerebrov1.ReadSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   config,
+		Config:   sourceConfigFromQuery(r),
 	}
-	rawCursors := r.URL.Query()["cursor"]
-	if len(rawCursors) > 0 {
-		cursor := rawCursors[len(rawCursors)-1]
-		if cursor != "" {
-			request.Cursor = &cerebrov1.SourceCursor{Opaque: cursor}
-		}
+	if cursor := r.URL.Query().Get("cursor"); cursor != "" {
+		request.Cursor = &cerebrov1.SourceCursor{Opaque: cursor}
 	}
 	response, err := a.sourceService().Read(r.Context(), request)
 	if err != nil {
 		writeSourceError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handlePutSourceRuntime(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.PutSourceRuntimeRequest{}
+	if err := readProtoJSON(r, request); err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	if request.Runtime == nil {
+		request.Runtime = &cerebrov1.SourceRuntime{}
+	}
+	request.Runtime.Id = r.PathValue("runtimeID")
+	response, err := a.runtimeService().Put(r.Context(), request)
+	if err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleGetSourceRuntime(w http.ResponseWriter, r *http.Request) {
+	response, err := a.runtimeService().Get(r.Context(), &cerebrov1.GetSourceRuntimeRequest{
+		Id: r.PathValue("runtimeID"),
+	})
+	if err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleSyncSourceRuntime(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.SyncSourceRuntimeRequest{}
+	if pageLimit := r.URL.Query().Get("page_limit"); pageLimit != "" {
+		body := []byte(`{"page_limit":` + pageLimit + `}`)
+		if err := protojson.Unmarshal(body, request); err != nil {
+			writeSourceRuntimeError(w, err)
+			return
+		}
+	}
+	request.Id = r.PathValue("runtimeID")
+	response, err := a.runtimeService().Sync(r.Context(), request)
+	if err != nil {
+		writeSourceRuntimeError(w, err)
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, response)
@@ -170,14 +202,7 @@ func (s *bootstrapService) ListSources(_ context.Context, _ *connect.Request[cer
 }
 
 func (s *bootstrapService) CheckSource(ctx context.Context, req *connect.Request[cerebrov1.CheckSourceRequest]) (*connect.Response[cerebrov1.CheckSourceResponse], error) {
-	config, err := sanitizePreviewSourceConfig(req.Msg.Config)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	response, err := sourceops.New(s.sources).Check(ctx, &cerebrov1.CheckSourceRequest{
-		SourceId: req.Msg.SourceId,
-		Config:   config,
-	})
+	response, err := sourceops.New(s.sources).Check(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceConnectError(err)
 	}
@@ -185,14 +210,7 @@ func (s *bootstrapService) CheckSource(ctx context.Context, req *connect.Request
 }
 
 func (s *bootstrapService) DiscoverSource(ctx context.Context, req *connect.Request[cerebrov1.DiscoverSourceRequest]) (*connect.Response[cerebrov1.DiscoverSourceResponse], error) {
-	config, err := sanitizePreviewSourceConfig(req.Msg.Config)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	response, err := sourceops.New(s.sources).Discover(ctx, &cerebrov1.DiscoverSourceRequest{
-		SourceId: req.Msg.SourceId,
-		Config:   config,
-	})
+	response, err := sourceops.New(s.sources).Discover(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceConnectError(err)
 	}
@@ -200,17 +218,33 @@ func (s *bootstrapService) DiscoverSource(ctx context.Context, req *connect.Requ
 }
 
 func (s *bootstrapService) ReadSource(ctx context.Context, req *connect.Request[cerebrov1.ReadSourceRequest]) (*connect.Response[cerebrov1.ReadSourceResponse], error) {
-	config, err := sanitizePreviewSourceConfig(req.Msg.Config)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	response, err := sourceops.New(s.sources).Read(ctx, &cerebrov1.ReadSourceRequest{
-		SourceId: req.Msg.SourceId,
-		Config:   config,
-		Cursor:   req.Msg.Cursor,
-	})
+	response, err := sourceops.New(s.sources).Read(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceConnectError(err)
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (s *bootstrapService) PutSourceRuntime(ctx context.Context, req *connect.Request[cerebrov1.PutSourceRuntimeRequest]) (*connect.Response[cerebrov1.PutSourceRuntimeResponse], error) {
+	response, err := sourceruntime.New(s.sources, sourceRuntimeStore(s.deps.StateStore), s.deps.AppendLog).Put(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (s *bootstrapService) GetSourceRuntime(ctx context.Context, req *connect.Request[cerebrov1.GetSourceRuntimeRequest]) (*connect.Response[cerebrov1.GetSourceRuntimeResponse], error) {
+	response, err := sourceruntime.New(s.sources, sourceRuntimeStore(s.deps.StateStore), s.deps.AppendLog).Get(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (s *bootstrapService) SyncSourceRuntime(ctx context.Context, req *connect.Request[cerebrov1.SyncSourceRuntimeRequest]) (*connect.Response[cerebrov1.SyncSourceRuntimeResponse], error) {
+	response, err := sourceruntime.New(s.sources, sourceRuntimeStore(s.deps.StateStore), s.deps.AppendLog).Sync(ctx, req.Msg)
+	if err != nil {
+		return nil, err
 	}
 	return connect.NewResponse(response), nil
 }
@@ -250,58 +284,27 @@ func (a *App) sourceService() *sourceops.Service {
 	return sourceops.New(a.sources)
 }
 
-func sourceConfigFromQuery(r *http.Request) (map[string]string, error) {
+func (a *App) runtimeService() *sourceruntime.Service {
+	return sourceruntime.New(a.sources, sourceRuntimeStore(a.deps.StateStore), a.deps.AppendLog)
+}
+
+func sourceConfigFromQuery(r *http.Request) map[string]string {
 	values := make(map[string]string)
 	for key, rawValues := range r.URL.Query() {
-		if key == "cursor" || key == "base_url" || len(rawValues) == 0 {
+		if key == "cursor" || len(rawValues) == 0 {
 			continue
-		}
-		if sensitiveSourceConfigKey(key) {
-			return nil, fmt.Errorf("source config key %q must not be passed as a query parameter", key)
 		}
 		values[key] = rawValues[len(rawValues)-1]
 	}
-	if token := bearerToken(r.Header.Get("Authorization")); token != "" {
-		values["token"] = token
-	}
-	return values, nil
+	return values
 }
 
-func sanitizePreviewSourceConfig(values map[string]string) (map[string]string, error) {
-	if len(values) == 0 {
-		return nil, nil
+func writeSourceError(w http.ResponseWriter, err error) {
+	statusCode := http.StatusBadRequest
+	if errors.Is(err, sourceops.ErrSourceNotFound) {
+		statusCode = http.StatusNotFound
 	}
-	sanitized := make(map[string]string, len(values))
-	for key, value := range values {
-		if blockedPreviewSourceConfigKey(key) {
-			return nil, fmt.Errorf("source config key %q is not allowed for preview requests", key)
-		}
-		sanitized[key] = value
-	}
-	return sanitized, nil
-}
-
-func bearerToken(header string) string {
-	header = strings.TrimSpace(header)
-	if len(header) < len("Bearer ") || !strings.EqualFold(header[:len("Bearer ")], "Bearer ") {
-		return ""
-	}
-	return strings.TrimSpace(header[len("Bearer "):])
-}
-
-func sensitiveSourceConfigKey(key string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(key))
-	if normalized == "" {
-		return false
-	}
-	if strings.Contains(normalized, "token") || strings.Contains(normalized, "secret") || strings.Contains(normalized, "password") || strings.Contains(normalized, "session") {
-		return true
-	}
-	return normalized == "key" || strings.HasSuffix(normalized, "_key")
-}
-
-func blockedPreviewSourceConfigKey(key string) bool {
-	return strings.EqualFold(strings.TrimSpace(key), "base_url")
+	http.Error(w, err.Error(), statusCode)
 }
 
 func sourceConnectError(err error) error {
@@ -320,12 +323,34 @@ func sourceConnectError(err error) error {
 	}
 }
 
-func writeSourceError(w http.ResponseWriter, err error) {
+func writeSourceRuntimeError(w http.ResponseWriter, err error) {
 	statusCode := http.StatusBadRequest
-	if errors.Is(err, sourceops.ErrSourceNotFound) {
+	switch {
+	case errors.Is(err, ports.ErrSourceRuntimeNotFound), errors.Is(err, sourceops.ErrSourceNotFound):
 		statusCode = http.StatusNotFound
+	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable):
+		statusCode = http.StatusServiceUnavailable
 	}
 	http.Error(w, err.Error(), statusCode)
+}
+
+func readProtoJSON(r *http.Request, message proto.Message) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+	return protojson.Unmarshal(body, message)
+}
+
+func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {
+	runtimeStore, ok := store.(ports.SourceRuntimeStore)
+	if !ok {
+		return nil
+	}
+	return runtimeStore
 }
 
 type pinger interface {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -389,7 +389,7 @@ func sourceRuntimeConnectError(err error) error {
 	case errors.Is(err, context.DeadlineExceeded):
 		return connect.NewError(connect.CodeDeadlineExceeded, err)
 	default:
-		return connect.NewError(connect.CodeInternal, err)
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 }
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -187,11 +188,12 @@ func (a *App) handleGetSourceRuntime(w http.ResponseWriter, r *http.Request) {
 func (a *App) handleSyncSourceRuntime(w http.ResponseWriter, r *http.Request) {
 	request := &cerebrov1.SyncSourceRuntimeRequest{}
 	if pageLimit := r.URL.Query().Get("page_limit"); pageLimit != "" {
-		body := []byte(`{"page_limit":` + pageLimit + `}`)
-		if err := protojson.Unmarshal(body, request); err != nil {
-			writeSourceRuntimeError(w, err)
+		parsed, err := strconv.ParseUint(strings.TrimSpace(pageLimit), 10, 32)
+		if err != nil {
+			writeSourceRuntimeError(w, fmt.Errorf("%w: invalid page_limit", sourceruntime.ErrInvalidRequest))
 			return
 		}
+		request.PageLimit = uint32(parsed)
 	}
 	request.Id = r.PathValue("runtimeID")
 	response, err := a.runtimeService().Sync(r.Context(), request)

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -384,6 +384,10 @@ func sourceRuntimeConnectError(err error) error {
 		return connect.NewError(connect.CodeUnavailable, err)
 	case errors.Is(err, sourceruntime.ErrInvalidRequest):
 		return connect.NewError(connect.CodeInvalidArgument, err)
+	case errors.Is(err, context.Canceled):
+		return connect.NewError(connect.CodeCanceled, err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return connect.NewError(connect.CodeDeadlineExceeded, err)
 	default:
 		return connect.NewError(connect.CodeInternal, err)
 	}

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -650,6 +650,32 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	}
 }
 
+func TestSourceRuntimeRPCErrorCodes(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	service := &bootstrapService{
+		sources: registry,
+		deps: Dependencies{
+			StateStore: &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{}},
+			AppendLog:  &recordingAppendLog{},
+		},
+	}
+
+	if _, err := service.GetSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.GetSourceRuntimeRequest{Id: "missing"})); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("GetSourceRuntime() code = %v, want %v", connect.CodeOf(err), connect.CodeNotFound)
+	}
+	if _, err := service.SyncSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.SyncSourceRuntimeRequest{})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("SyncSourceRuntime() empty request code = %v, want %v", connect.CodeOf(err), connect.CodeInvalidArgument)
+	}
+
+	unavailable := &bootstrapService{sources: registry}
+	if _, err := unavailable.SyncSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.SyncSourceRuntimeRequest{Id: "runtime"})); connect.CodeOf(err) != connect.CodeUnavailable {
+		t.Fatalf("SyncSourceRuntime() unavailable code = %v, want %v", connect.CodeOf(err), connect.CodeUnavailable)
+	}
+}
+
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.NewFixture()
 	if err != nil {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -720,6 +720,21 @@ func TestSourceRuntimeRPCErrorCodes(t *testing.T) {
 	}
 }
 
+func TestWriteSourceRuntimeErrorHidesInternalDetails(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writeSourceRuntimeError(recorder, errors.New("dial postgres://user:secret@db.internal:5432"))
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+	if got := recorder.Body.String(); got != http.StatusText(http.StatusBadRequest)+"\n" {
+		t.Fatalf("body = %q, want generic status text", got)
+	}
+	if bytes.Contains(recorder.Body.Bytes(), []byte("secret")) || bytes.Contains(recorder.Body.Bytes(), []byte("db.internal")) {
+		t.Fatalf("body exposed internal error details: %q", recorder.Body.String())
+	}
+}
+
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.NewFixture()
 	if err != nil {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -540,6 +541,24 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
+
+	badPutReq, err := http.NewRequest(http.MethodPut, server.URL+"/source-runtimes/writer-okta-users", strings.NewReader("{"))
+	if err != nil {
+		t.Fatalf("new bad put request: %v", err)
+	}
+	badPutReq.Header.Set("Content-Type", "application/json")
+	badPutResp, err := server.Client().Do(badPutReq)
+	if err != nil {
+		t.Fatalf("PUT /source-runtimes/{id} malformed body error = %v", err)
+	}
+	defer func() {
+		if closeErr := badPutResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close bad put runtime response body: %v", closeErr)
+		}
+	}()
+	if badPutResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("bad put status = %d, want %d", badPutResp.StatusCode, http.StatusBadRequest)
+	}
 
 	putBody, err := protojson.Marshal(&cerebrov1.PutSourceRuntimeRequest{
 		Runtime: &cerebrov1.SourceRuntime{

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceruntime"
 	githubsource "github.com/writer/cerebro/sources/github"
 	oktasource "github.com/writer/cerebro/sources/okta"
 )
@@ -724,14 +725,20 @@ func TestWriteSourceRuntimeErrorHidesInternalDetails(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	writeSourceRuntimeError(recorder, errors.New("dial tcp credential@db.internal:5432: i/o timeout"))
 
-	if recorder.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
 	}
-	if got := recorder.Body.String(); got != http.StatusText(http.StatusBadRequest)+"\n" {
+	if got := recorder.Body.String(); got != http.StatusText(http.StatusInternalServerError)+"\n" {
 		t.Fatalf("body = %q, want generic status text", got)
 	}
 	if bytes.Contains(recorder.Body.Bytes(), []byte("credential")) || bytes.Contains(recorder.Body.Bytes(), []byte("db.internal")) {
 		t.Fatalf("body exposed internal error details: %q", recorder.Body.String())
+	}
+
+	invalid := httptest.NewRecorder()
+	writeSourceRuntimeError(invalid, sourceruntime.ErrInvalidRequest)
+	if invalid.Code != http.StatusBadRequest {
+		t.Fatalf("invalid request status = %d, want %d", invalid.Code, http.StatusBadRequest)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -55,6 +55,8 @@ func (s *recordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnv
 type stubRuntimeStore struct {
 	err      error
 	runtimes map[string]*cerebrov1.SourceRuntime
+	entities map[string]*ports.ProjectedEntity
+	links    map[string]*ports.ProjectedLink
 }
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
@@ -79,6 +81,72 @@ func (s *stubRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*cere
 		return nil, ports.ErrSourceRuntimeNotFound
 	}
 	return proto.Clone(runtime).(*cerebrov1.SourceRuntime), nil
+}
+
+func (s *stubRuntimeStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if s.err != nil {
+		return s.err
+	}
+	if entity == nil {
+		return nil
+	}
+	if s.entities == nil {
+		s.entities = make(map[string]*ports.ProjectedEntity)
+	}
+	s.entities[entity.URN] = cloneProjectedEntity(entity)
+	return nil
+}
+
+func (s *stubRuntimeStore) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if s.err != nil {
+		return s.err
+	}
+	if link == nil {
+		return nil
+	}
+	if s.links == nil {
+		s.links = make(map[string]*ports.ProjectedLink)
+	}
+	s.links[projectedLinkKey(link)] = cloneProjectedLink(link)
+	return nil
+}
+
+type stubGraphStore struct {
+	err      error
+	entities map[string]*ports.ProjectedEntity
+	links    map[string]*ports.ProjectedLink
+}
+
+func (s *stubGraphStore) Ping(context.Context) error {
+	return s.err
+}
+
+func (s *stubGraphStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if s.err != nil {
+		return s.err
+	}
+	if entity == nil {
+		return nil
+	}
+	if s.entities == nil {
+		s.entities = make(map[string]*ports.ProjectedEntity)
+	}
+	s.entities[entity.URN] = cloneProjectedEntity(entity)
+	return nil
+}
+
+func (s *stubGraphStore) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if s.err != nil {
+		return s.err
+	}
+	if link == nil {
+		return nil
+	}
+	if s.links == nil {
+		s.links = make(map[string]*ports.ProjectedLink)
+	}
+	s.links[projectedLinkKey(link)] = cloneProjectedLink(link)
+	return nil
 }
 
 func TestBootstrapEndpoints(t *testing.T) {
@@ -391,9 +459,11 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	}
 	appendLog := &recordingAppendLog{}
 	runtimeStore := &stubRuntimeStore{}
+	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
 		AppendLog:  appendLog,
 		StateStore: runtimeStore,
+		GraphStore: graphStore,
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -401,6 +471,7 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	putBody, err := protojson.Marshal(&cerebrov1.PutSourceRuntimeRequest{
 		Runtime: &cerebrov1.SourceRuntime{
 			SourceId: "okta",
+			TenantId: "writer",
 			Config: map[string]string{
 				"domain": "writer.okta.com",
 				"family": "user",
@@ -440,6 +511,9 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	if got := configPayload["token"]; got != "[redacted]" {
 		t.Fatalf("put runtime token = %#v, want [redacted]", got)
 	}
+	if got := runtimePayload["tenant_id"]; got != "writer" {
+		t.Fatalf("put runtime tenant_id = %#v, want writer", got)
+	}
 
 	getResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-okta-users")
 	if err != nil {
@@ -460,6 +534,9 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	}
 	if got := getRuntimePayload["source_id"]; got != "okta" {
 		t.Fatalf("get runtime source_id = %#v, want okta", got)
+	}
+	if got := getRuntimePayload["tenant_id"]; got != "writer" {
+		t.Fatalf("get runtime tenant_id = %#v, want writer", got)
 	}
 
 	syncReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-users/sync?page_limit=1", nil)
@@ -482,12 +559,19 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	if got := syncPayload["events_appended"]; got != float64(1) {
 		t.Fatalf("sync events_appended = %#v, want 1", got)
 	}
+	if got := syncPayload["entities_projected"]; got != float64(3) {
+		t.Fatalf("sync entities_projected = %#v, want 3", got)
+	}
+	if got := syncPayload["links_projected"]; got != float64(2) {
+		t.Fatalf("sync links_projected = %#v, want 2", got)
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	putRuntimeResp, err := client.PutSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.PutSourceRuntimeRequest{
 		Runtime: &cerebrov1.SourceRuntime{
 			Id:       "writer-github",
 			SourceId: "github",
+			TenantId: "writer",
 			Config:   map[string]string{"token": "test"},
 		},
 	}))
@@ -496,6 +580,9 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	}
 	if got := putRuntimeResp.Msg.GetRuntime().GetConfig()["token"]; got != "[redacted]" {
 		t.Fatalf("PutSourceRuntime token = %q, want [redacted]", got)
+	}
+	if got := putRuntimeResp.Msg.GetRuntime().GetTenantId(); got != "writer" {
+		t.Fatalf("PutSourceRuntime tenant_id = %q, want writer", got)
 	}
 
 	getRuntimeResp, err := client.GetSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.GetSourceRuntimeRequest{
@@ -506,6 +593,9 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	}
 	if got := getRuntimeResp.Msg.GetRuntime().GetSourceId(); got != "okta" {
 		t.Fatalf("GetSourceRuntime source_id = %q, want okta", got)
+	}
+	if got := getRuntimeResp.Msg.GetRuntime().GetTenantId(); got != "writer" {
+		t.Fatalf("GetSourceRuntime tenant_id = %q, want writer", got)
 	}
 
 	syncRuntimeResp, err := client.SyncSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.SyncSourceRuntimeRequest{
@@ -518,8 +608,17 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	if syncRuntimeResp.Msg.GetEventsAppended() != 1 {
 		t.Fatalf("SyncSourceRuntime events_appended = %d, want 1", syncRuntimeResp.Msg.GetEventsAppended())
 	}
+	if syncRuntimeResp.Msg.GetEntitiesProjected() != 3 {
+		t.Fatalf("SyncSourceRuntime entities_projected = %d, want 3", syncRuntimeResp.Msg.GetEntitiesProjected())
+	}
+	if syncRuntimeResp.Msg.GetLinksProjected() != 2 {
+		t.Fatalf("SyncSourceRuntime links_projected = %d, want 2", syncRuntimeResp.Msg.GetLinksProjected())
+	}
 	if len(appendLog.events) != 2 {
 		t.Fatalf("len(appendLog.events) = %d, want 2", len(appendLog.events))
+	}
+	if len(runtimeStore.entities) == 0 || len(graphStore.entities) == 0 {
+		t.Fatalf("projected entities = state:%d graph:%d, want non-zero", len(runtimeStore.entities), len(graphStore.entities))
 	}
 }
 
@@ -533,4 +632,44 @@ func newFixtureRegistry() (*sourcecdk.Registry, error) {
 		return nil, err
 	}
 	return sourcecdk.NewRegistry(source, okta)
+}
+
+func cloneProjectedEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
+	if entity == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(entity.Attributes))
+	for key, value := range entity.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedEntity{
+		URN:        entity.URN,
+		TenantID:   entity.TenantID,
+		SourceID:   entity.SourceID,
+		EntityType: entity.EntityType,
+		Label:      entity.Label,
+		Attributes: attributes,
+	}
+}
+
+func cloneProjectedLink(link *ports.ProjectedLink) *ports.ProjectedLink {
+	if link == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(link.Attributes))
+	for key, value := range link.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedLink{
+		TenantID:   link.TenantID,
+		SourceID:   link.SourceID,
+		FromURN:    link.FromURN,
+		ToURN:      link.ToURN,
+		Relation:   link.Relation,
+		Attributes: attributes,
+	}
+}
+
+func projectedLinkKey(link *ports.ProjectedLink) string {
+	return link.FromURN + "|" + link.Relation + "|" + link.ToURN
 }

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -165,6 +165,50 @@ func (s *stubGraphStore) UpsertProjectedLink(_ context.Context, link *ports.Proj
 	return nil
 }
 
+func TestSourceConfigFromRequestDropsBaseURL(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/sources/github/read?owner=writer&base_url=http://127.0.0.1:1&cursor=2", nil)
+	req.Header.Set("Authorization", "Bearer test")
+	config, err := sourceConfigFromRequest(req)
+	if err != nil {
+		t.Fatalf("sourceConfigFromRequest() error = %v", err)
+	}
+	if _, ok := config["base_url"]; ok {
+		t.Fatalf("sourceConfigFromRequest() included base_url")
+	}
+	if _, ok := config["cursor"]; ok {
+		t.Fatalf("sourceConfigFromRequest() included cursor")
+	}
+	if got := config["token"]; got != "test" {
+		t.Fatalf("sourceConfigFromRequest()[token] = %q, want test", got)
+	}
+	if got := config["owner"]; got != "writer" {
+		t.Fatalf("sourceConfigFromRequest()[owner] = %q, want writer", got)
+	}
+	badReq := httptest.NewRequest(http.MethodGet, "/sources/github/read?token=test", nil)
+	if _, err := sourceConfigFromRequest(badReq); err == nil {
+		t.Fatal("sourceConfigFromRequest(token query) error = nil, want error")
+	}
+}
+
+func TestSourceConfigFromRequestDropsReservedHeaderKeys(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/sources/github/read?owner=writer", nil)
+	req.Header.Set("X-Cerebro-Source-Config", `{"base_url":"http://127.0.0.1:1","cursor":"2","family":"audit"}`)
+
+	config, err := sourceConfigFromRequest(req)
+	if err != nil {
+		t.Fatalf("sourceConfigFromRequest() error = %v", err)
+	}
+	if _, ok := config["base_url"]; ok {
+		t.Fatal("sourceConfigFromRequest() included header base_url")
+	}
+	if _, ok := config["cursor"]; ok {
+		t.Fatal("sourceConfigFromRequest() included header cursor")
+	}
+	if got := config["family"]; got != "audit" {
+		t.Fatalf("sourceConfigFromRequest()[family] = %q, want audit", got)
+	}
+}
+
 func TestBootstrapEndpoints(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -24,6 +24,22 @@ import (
 	oktasource "github.com/writer/cerebro/sources/okta"
 )
 
+func sourceGet(t *testing.T, server *httptest.Server, path string, config map[string]string) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(config) > 0 {
+		payload, err := json.Marshal(config)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("X-Cerebro-Source-Config", string(payload))
+	}
+	return server.Client().Do(req)
+}
+
 type stubAppendLog struct {
 	err error
 }
@@ -194,7 +210,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if !ok || len(entries) != 2 {
 		t.Fatalf("/sources entries = %#v, want 2 entries", sourcesPayload["sources"])
 	}
-	checkResp, err := server.Client().Get(server.URL + "/sources/github/check?token=test")
+	checkResp, err := sourceGet(t, server, "/sources/github/check", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/github/check error = %v", err)
 	}
@@ -210,7 +226,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if checkPayload["status"] != "ok" {
 		t.Fatalf("check status = %#v, want %q", checkPayload["status"], "ok")
 	}
-	discoverResp, err := server.Client().Get(server.URL + "/sources/github/discover?token=test")
+	discoverResp, err := sourceGet(t, server, "/sources/github/discover", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/github/discover error = %v", err)
 	}
@@ -226,7 +242,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if urns, ok := discoverPayload["urns"].([]any); !ok || len(urns) != 2 {
 		t.Fatalf("discover urns = %#v, want 2 entries", discoverPayload["urns"])
 	}
-	readResp, err := server.Client().Get(server.URL + "/sources/github/read?token=test")
+	readResp, err := sourceGet(t, server, "/sources/github/read", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/github/read error = %v", err)
 	}
@@ -246,7 +262,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if !ok || len(previewEvents) != 1 {
 		t.Fatalf("read preview_events = %#v, want 1 entry", readPayload["preview_events"])
 	}
-	oktaCheckResp, err := server.Client().Get(server.URL + "/sources/okta/check?domain=writer.okta.com&family=user&token=test")
+	oktaCheckResp, err := sourceGet(t, server, "/sources/okta/check?domain=writer.okta.com&family=user", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/okta/check error = %v", err)
 	}
@@ -262,7 +278,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if oktaCheckPayload["status"] != "ok" {
 		t.Fatalf("okta check status = %#v, want %q", oktaCheckPayload["status"], "ok")
 	}
-	oktaDiscoverResp, err := server.Client().Get(server.URL + "/sources/okta/discover?domain=writer.okta.com&family=user&token=test")
+	oktaDiscoverResp, err := sourceGet(t, server, "/sources/okta/discover?domain=writer.okta.com&family=user", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/okta/discover error = %v", err)
 	}
@@ -278,7 +294,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if urns, ok := oktaDiscoverPayload["urns"].([]any); !ok || len(urns) != 2 {
 		t.Fatalf("okta discover urns = %#v, want 2 entries", oktaDiscoverPayload["urns"])
 	}
-	oktaReadResp, err := server.Client().Get(server.URL + "/sources/okta/read?domain=writer.okta.com&family=user&token=test")
+	oktaReadResp, err := sourceGet(t, server, "/sources/okta/read?domain=writer.okta.com&family=user", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/okta/read error = %v", err)
 	}
@@ -297,6 +313,18 @@ func TestBootstrapEndpoints(t *testing.T) {
 	oktaPreviewEvents, ok := oktaReadPayload["preview_events"].([]any)
 	if !ok || len(oktaPreviewEvents) != 1 {
 		t.Fatalf("okta read preview_events = %#v, want 1 entry", oktaReadPayload["preview_events"])
+	}
+	leakyQueryResp, err := server.Client().Get(server.URL + "/sources/github/check?token=secret")
+	if err != nil {
+		t.Fatalf("GET /sources/github/check leaky query error = %v", err)
+	}
+	defer func() {
+		if closeErr := leakyQueryResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close leaky query response body: %v", closeErr)
+		}
+	}()
+	if leakyQueryResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("leaky query status = %d, want %d", leakyQueryResp.StatusCode, http.StatusBadRequest)
 	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -639,6 +639,23 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 		t.Fatalf("sync links_projected = %#v, want 2", got)
 	}
 
+	badSyncReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-users/sync?page_limit=not-a-number", nil)
+	if err != nil {
+		t.Fatalf("new bad sync request: %v", err)
+	}
+	badSyncResp, err := server.Client().Do(badSyncReq)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/sync bad page_limit error = %v", err)
+	}
+	defer func() {
+		if closeErr := badSyncResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close bad sync runtime response body: %v", closeErr)
+		}
+	}()
+	if badSyncResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("bad sync status = %d, want %d", badSyncResp.StatusCode, http.StatusBadRequest)
+	}
+
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	putRuntimeResp, err := client.PutSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.PutSourceRuntimeRequest{
 		Runtime: &cerebrov1.SourceRuntime{

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,13 +11,15 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
-	"github.com/writer/cerebro/internal/sourceops"
 	githubsource "github.com/writer/cerebro/sources/github"
 	oktasource "github.com/writer/cerebro/sources/okta"
 )
@@ -34,23 +37,48 @@ type stubStore struct {
 
 func (s stubStore) Ping(context.Context) error { return s.err }
 
-func TestSourceConfigFromQueryDropsBaseURL(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/sources/github/read?base_url=http://127.0.0.1:1&cursor=2", nil)
-	req.Header.Set("Authorization", "Bearer test")
+type recordingAppendLog struct {
+	err    error
+	events []*cerebrov1.EventEnvelope
+}
 
-	config, err := sourceConfigFromQuery(req)
-	if err != nil {
-		t.Fatalf("sourceConfigFromQuery() error = %v", err)
+func (s *recordingAppendLog) Ping(context.Context) error { return s.err }
+
+func (s *recordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) error {
+	if s.err != nil {
+		return s.err
 	}
-	if _, ok := config["base_url"]; ok {
-		t.Fatalf("sourceConfigFromQuery() included base_url")
+	s.events = append(s.events, proto.Clone(event).(*cerebrov1.EventEnvelope))
+	return nil
+}
+
+type stubRuntimeStore struct {
+	err      error
+	runtimes map[string]*cerebrov1.SourceRuntime
+}
+
+func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
+
+func (s *stubRuntimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {
+	if s.err != nil {
+		return s.err
 	}
-	if _, ok := config["cursor"]; ok {
-		t.Fatalf("sourceConfigFromQuery() included cursor")
+	if s.runtimes == nil {
+		s.runtimes = make(map[string]*cerebrov1.SourceRuntime)
 	}
-	if got := config["token"]; got != "test" {
-		t.Fatalf("sourceConfigFromQuery()[token] = %q, want test", got)
+	s.runtimes[runtime.GetId()] = proto.Clone(runtime).(*cerebrov1.SourceRuntime)
+	return nil
+}
+
+func (s *stubRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov1.SourceRuntime, error) {
+	if s.err != nil {
+		return nil, s.err
 	}
+	runtime, ok := s.runtimes[id]
+	if !ok {
+		return nil, ports.ErrSourceRuntimeNotFound
+	}
+	return proto.Clone(runtime).(*cerebrov1.SourceRuntime), nil
 }
 
 func TestBootstrapEndpoints(t *testing.T) {
@@ -61,14 +89,6 @@ func TestBootstrapEndpoints(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
-	authedGet := func(path string) (*http.Response, error) {
-		req, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Authorization", "Bearer test")
-		return server.Client().Do(req)
-	}
 
 	resp, err := server.Client().Get(server.URL + "/health")
 	if err != nil {
@@ -106,7 +126,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if !ok || len(entries) != 2 {
 		t.Fatalf("/sources entries = %#v, want 2 entries", sourcesPayload["sources"])
 	}
-	checkResp, err := authedGet("/sources/github/check")
+	checkResp, err := server.Client().Get(server.URL + "/sources/github/check?token=test")
 	if err != nil {
 		t.Fatalf("GET /sources/github/check error = %v", err)
 	}
@@ -122,7 +142,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if checkPayload["status"] != "ok" {
 		t.Fatalf("check status = %#v, want %q", checkPayload["status"], "ok")
 	}
-	discoverResp, err := authedGet("/sources/github/discover")
+	discoverResp, err := server.Client().Get(server.URL + "/sources/github/discover?token=test")
 	if err != nil {
 		t.Fatalf("GET /sources/github/discover error = %v", err)
 	}
@@ -138,7 +158,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if urns, ok := discoverPayload["urns"].([]any); !ok || len(urns) != 2 {
 		t.Fatalf("discover urns = %#v, want 2 entries", discoverPayload["urns"])
 	}
-	readResp, err := authedGet("/sources/github/read")
+	readResp, err := server.Client().Get(server.URL + "/sources/github/read?token=test")
 	if err != nil {
 		t.Fatalf("GET /sources/github/read error = %v", err)
 	}
@@ -158,46 +178,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if !ok || len(previewEvents) != 1 {
 		t.Fatalf("read preview_events = %#v, want 1 entry", readPayload["preview_events"])
 	}
-	repeatedCursorResp, err := authedGet("/sources/github/read?cursor=0&cursor=1")
-	if err != nil {
-		t.Fatalf("GET /sources/github/read repeated cursor error = %v", err)
-	}
-	defer func() {
-		if closeErr := repeatedCursorResp.Body.Close(); closeErr != nil {
-			t.Fatalf("close repeated cursor response body: %v", closeErr)
-		}
-	}()
-	var repeatedCursorPayload map[string]any
-	if err := json.NewDecoder(repeatedCursorResp.Body).Decode(&repeatedCursorPayload); err != nil {
-		t.Fatalf("decode repeated cursor response: %v", err)
-	}
-	repeatedCursorEvents, ok := repeatedCursorPayload["events"].([]any)
-	if !ok || len(repeatedCursorEvents) != 1 {
-		t.Fatalf("repeated cursor events = %#v, want 1 entry", repeatedCursorPayload["events"])
-	}
-	repeatedCursorEvent, ok := repeatedCursorEvents[0].(map[string]any)
-	if !ok || repeatedCursorEvent["id"] != "github-pr-1" {
-		t.Fatalf("repeated cursor event = %#v, want github-pr-1", repeatedCursorEvents[0])
-	}
-
-	secretQueryResp, err := server.Client().Get(server.URL + "/sources/github/check?token=test")
-	if err != nil {
-		t.Fatalf("GET /sources/github/check secret query error = %v", err)
-	}
-	defer func() {
-		if closeErr := secretQueryResp.Body.Close(); closeErr != nil {
-			t.Fatalf("close secret query response body: %v", closeErr)
-		}
-	}()
-	if secretQueryResp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("secret query status = %d, want %d", secretQueryResp.StatusCode, http.StatusBadRequest)
-	}
-	previewEvent, ok := previewEvents[0].(map[string]any)
-	if !ok || previewEvent["event_id"] != "github-audit-1" {
-		t.Fatalf("read preview_event = %#v, want event_id github-audit-1", previewEvents[0])
-	}
-
-	oktaCheckResp, err := authedGet("/sources/okta/check?domain=writer.okta.com&family=user")
+	oktaCheckResp, err := server.Client().Get(server.URL + "/sources/okta/check?domain=writer.okta.com&family=user&token=test")
 	if err != nil {
 		t.Fatalf("GET /sources/okta/check error = %v", err)
 	}
@@ -213,7 +194,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if oktaCheckPayload["status"] != "ok" {
 		t.Fatalf("okta check status = %#v, want %q", oktaCheckPayload["status"], "ok")
 	}
-	oktaDiscoverResp, err := authedGet("/sources/okta/discover?domain=writer.okta.com&family=user")
+	oktaDiscoverResp, err := server.Client().Get(server.URL + "/sources/okta/discover?domain=writer.okta.com&family=user&token=test")
 	if err != nil {
 		t.Fatalf("GET /sources/okta/discover error = %v", err)
 	}
@@ -229,7 +210,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if urns, ok := oktaDiscoverPayload["urns"].([]any); !ok || len(urns) != 2 {
 		t.Fatalf("okta discover urns = %#v, want 2 entries", oktaDiscoverPayload["urns"])
 	}
-	oktaReadResp, err := authedGet("/sources/okta/read?domain=writer.okta.com&family=user")
+	oktaReadResp, err := server.Client().Get(server.URL + "/sources/okta/read?domain=writer.okta.com&family=user&token=test")
 	if err != nil {
 		t.Fatalf("GET /sources/okta/read error = %v", err)
 	}
@@ -303,10 +284,11 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if len(readSourceResp.Msg.Events) != 1 {
 		t.Fatalf("len(ReadSource.Events) = %d, want 1", len(readSourceResp.Msg.Events))
 	}
-
-	_, err = client.CheckSource(context.Background(), connect.NewRequest(&cerebrov1.CheckSourceRequest{}))
-	if connect.CodeOf(err) != connect.CodeInvalidArgument {
-		t.Fatalf("CheckSource(empty) code = %v, want %v", connect.CodeOf(err), connect.CodeInvalidArgument)
+	if len(readSourceResp.Msg.PreviewEvents) != 1 {
+		t.Fatalf("len(ReadSource.PreviewEvents) = %d, want 1", len(readSourceResp.Msg.PreviewEvents))
+	}
+	if !readSourceResp.Msg.PreviewEvents[0].PayloadDecoded {
+		t.Fatal("ReadSource.PreviewEvents[0].PayloadDecoded = false, want true")
 	}
 
 	_, err = client.CheckSource(context.Background(), connect.NewRequest(&cerebrov1.CheckSourceRequest{SourceId: "github"}))
@@ -402,6 +384,145 @@ func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
 	}
 }
 
+func TestSourceRuntimeEndpoints(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	appendLog := &recordingAppendLog{}
+	runtimeStore := &stubRuntimeStore{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  appendLog,
+		StateStore: runtimeStore,
+	}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	putBody, err := protojson.Marshal(&cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			SourceId: "okta",
+			Config: map[string]string{
+				"domain": "writer.okta.com",
+				"family": "user",
+				"token":  "test",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal put runtime body: %v", err)
+	}
+	putReq, err := http.NewRequest(http.MethodPut, server.URL+"/source-runtimes/writer-okta-users", bytes.NewReader(putBody))
+	if err != nil {
+		t.Fatalf("new put request: %v", err)
+	}
+	putReq.Header.Set("Content-Type", "application/json")
+	putResp, err := server.Client().Do(putReq)
+	if err != nil {
+		t.Fatalf("PUT /source-runtimes/{id} error = %v", err)
+	}
+	defer func() {
+		if closeErr := putResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close put runtime response body: %v", closeErr)
+		}
+	}()
+	var putPayload map[string]any
+	if err := json.NewDecoder(putResp.Body).Decode(&putPayload); err != nil {
+		t.Fatalf("decode put runtime response: %v", err)
+	}
+	runtimePayload, ok := putPayload["runtime"].(map[string]any)
+	if !ok {
+		t.Fatalf("put runtime payload = %#v, want object", putPayload["runtime"])
+	}
+	configPayload, ok := runtimePayload["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("put runtime config = %#v, want object", runtimePayload["config"])
+	}
+	if got := configPayload["token"]; got != "[redacted]" {
+		t.Fatalf("put runtime token = %#v, want [redacted]", got)
+	}
+
+	getResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-okta-users")
+	if err != nil {
+		t.Fatalf("GET /source-runtimes/{id} error = %v", err)
+	}
+	defer func() {
+		if closeErr := getResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close get runtime response body: %v", closeErr)
+		}
+	}()
+	var getPayload map[string]any
+	if err := json.NewDecoder(getResp.Body).Decode(&getPayload); err != nil {
+		t.Fatalf("decode get runtime response: %v", err)
+	}
+	getRuntimePayload, ok := getPayload["runtime"].(map[string]any)
+	if !ok {
+		t.Fatalf("get runtime payload = %#v, want object", getPayload["runtime"])
+	}
+	if got := getRuntimePayload["source_id"]; got != "okta" {
+		t.Fatalf("get runtime source_id = %#v, want okta", got)
+	}
+
+	syncReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-users/sync?page_limit=1", nil)
+	if err != nil {
+		t.Fatalf("new sync request: %v", err)
+	}
+	syncResp, err := server.Client().Do(syncReq)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/sync error = %v", err)
+	}
+	defer func() {
+		if closeErr := syncResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close sync runtime response body: %v", closeErr)
+		}
+	}()
+	var syncPayload map[string]any
+	if err := json.NewDecoder(syncResp.Body).Decode(&syncPayload); err != nil {
+		t.Fatalf("decode sync runtime response: %v", err)
+	}
+	if got := syncPayload["events_appended"]; got != float64(1) {
+		t.Fatalf("sync events_appended = %#v, want 1", got)
+	}
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	putRuntimeResp, err := client.PutSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-github",
+			SourceId: "github",
+			Config:   map[string]string{"token": "test"},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("PutSourceRuntime() error = %v", err)
+	}
+	if got := putRuntimeResp.Msg.GetRuntime().GetConfig()["token"]; got != "[redacted]" {
+		t.Fatalf("PutSourceRuntime token = %q, want [redacted]", got)
+	}
+
+	getRuntimeResp, err := client.GetSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.GetSourceRuntimeRequest{
+		Id: "writer-okta-users",
+	}))
+	if err != nil {
+		t.Fatalf("GetSourceRuntime() error = %v", err)
+	}
+	if got := getRuntimeResp.Msg.GetRuntime().GetSourceId(); got != "okta" {
+		t.Fatalf("GetSourceRuntime source_id = %q, want okta", got)
+	}
+
+	syncRuntimeResp, err := client.SyncSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.SyncSourceRuntimeRequest{
+		Id:        "writer-okta-users",
+		PageLimit: 1,
+	}))
+	if err != nil {
+		t.Fatalf("SyncSourceRuntime() error = %v", err)
+	}
+	if syncRuntimeResp.Msg.GetEventsAppended() != 1 {
+		t.Fatalf("SyncSourceRuntime events_appended = %d, want 1", syncRuntimeResp.Msg.GetEventsAppended())
+	}
+	if len(appendLog.events) != 2 {
+		t.Fatalf("len(appendLog.events) = %d, want 2", len(appendLog.events))
+	}
+}
+
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.NewFixture()
 	if err != nil {
@@ -412,42 +533,4 @@ func newFixtureRegistry() (*sourcecdk.Registry, error) {
 		return nil, err
 	}
 	return sourcecdk.NewRegistry(source, okta)
-}
-
-func TestSourceConnectErrorMapping(t *testing.T) {
-	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	deadlineCtx, deadlineCancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
-	defer deadlineCancel()
-	cases := []struct {
-		name string
-		err  error
-		want connect.Code
-	}{
-		{"invalid_id", sourceops.ErrInvalidSourceID, connect.CodeInvalidArgument},
-		{"not_found", sourceops.ErrSourceNotFound, connect.CodeNotFound},
-		{"invalid_config", sourceops.ErrInvalidSourceConfig, connect.CodeInvalidArgument},
-		{"wrapped_invalid_config", errors.Join(sourceops.ErrInvalidSourceConfig, errors.New("repository is required")), connect.CodeInvalidArgument},
-		{"canceled", ctx.Err(), connect.CodeCanceled},
-		{"deadline", deadlineCtx.Err(), connect.CodeDeadlineExceeded},
-		{"opaque", errors.New("internal token leak boom"), connect.CodeInternal},
-	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			got := sourceConnectError(tc.err)
-			var connectErr *connect.Error
-			if !errors.As(got, &connectErr) {
-				t.Fatalf("sourceConnectError(%v) = %v, want connect.Error", tc.err, got)
-			}
-			if connectErr.Code() != tc.want {
-				t.Fatalf("code = %v, want %v", connectErr.Code(), tc.want)
-			}
-			if tc.name == "opaque" && connectErr.Message() != "internal error" {
-				t.Fatalf("message = %q, want %q", connectErr.Message(), "internal error")
-			}
-		})
-	}
 }

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -560,6 +560,24 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 		t.Fatalf("bad put status = %d, want %d", badPutResp.StatusCode, http.StatusBadRequest)
 	}
 
+	largePutReq, err := http.NewRequest(http.MethodPut, server.URL+"/source-runtimes/writer-okta-users", bytes.NewReader(bytes.Repeat([]byte("a"), maxProtoJSONBodyBytes+1)))
+	if err != nil {
+		t.Fatalf("new large put request: %v", err)
+	}
+	largePutReq.Header.Set("Content-Type", "application/json")
+	largePutResp, err := server.Client().Do(largePutReq)
+	if err != nil {
+		t.Fatalf("PUT /source-runtimes/{id} large body error = %v", err)
+	}
+	defer func() {
+		if closeErr := largePutResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close large put runtime response body: %v", closeErr)
+		}
+	}()
+	if largePutResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("large put status = %d, want %d", largePutResp.StatusCode, http.StatusBadRequest)
+	}
+
 	putBody, err := protojson.Marshal(&cerebrov1.PutSourceRuntimeRequest{
 		Runtime: &cerebrov1.SourceRuntime{
 			SourceId: "okta",
@@ -760,6 +778,15 @@ func TestSourceRuntimeRPCErrorCodes(t *testing.T) {
 	}
 	if got := connect.CodeOf(sourceRuntimeConnectError(context.DeadlineExceeded)); got != connect.CodeDeadlineExceeded {
 		t.Fatalf("sourceRuntimeConnectError(context.DeadlineExceeded) code = %v, want %v", got, connect.CodeDeadlineExceeded)
+	}
+	preserved := connect.NewError(connect.CodeFailedPrecondition, errors.New("already wrapped"))
+	got := sourceRuntimeConnectError(preserved)
+	var preservedErr *connect.Error
+	if !errors.As(got, &preservedErr) {
+		t.Fatalf("sourceRuntimeConnectError(connect error) = %T, want *connect.Error", got)
+	}
+	if preservedErr.Code() != preserved.Code() || preservedErr.Message() != preserved.Message() {
+		t.Fatalf("sourceRuntimeConnectError(connect error) = %v, want preserved connect error", got)
 	}
 	internalErr := sourceRuntimeConnectError(errors.New("dial tcp credential@db.internal:5432: i/o timeout"))
 	if got := connect.CodeOf(internalErr); got != connect.CodeInternal {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceops"
 	githubsource "github.com/writer/cerebro/sources/github"
+	oktasource "github.com/writer/cerebro/sources/okta"
 )
 
 type stubAppendLog struct {
@@ -102,8 +103,8 @@ func TestBootstrapEndpoints(t *testing.T) {
 		t.Fatalf("decode /sources response: %v", err)
 	}
 	entries, ok := sourcesPayload["sources"].([]any)
-	if !ok || len(entries) != 1 {
-		t.Fatalf("/sources entries = %#v, want single entry", sourcesPayload["sources"])
+	if !ok || len(entries) != 2 {
+		t.Fatalf("/sources entries = %#v, want 2 entries", sourcesPayload["sources"])
 	}
 	checkResp, err := authedGet("/sources/github/check")
 	if err != nil {
@@ -196,6 +197,59 @@ func TestBootstrapEndpoints(t *testing.T) {
 		t.Fatalf("read preview_event = %#v, want event_id github-audit-1", previewEvents[0])
 	}
 
+	oktaCheckResp, err := authedGet("/sources/okta/check?domain=writer.okta.com&family=user")
+	if err != nil {
+		t.Fatalf("GET /sources/okta/check error = %v", err)
+	}
+	defer func() {
+		if closeErr := oktaCheckResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /sources/okta/check response body: %v", closeErr)
+		}
+	}()
+	var oktaCheckPayload map[string]any
+	if err := json.NewDecoder(oktaCheckResp.Body).Decode(&oktaCheckPayload); err != nil {
+		t.Fatalf("decode /sources/okta/check response: %v", err)
+	}
+	if oktaCheckPayload["status"] != "ok" {
+		t.Fatalf("okta check status = %#v, want %q", oktaCheckPayload["status"], "ok")
+	}
+	oktaDiscoverResp, err := authedGet("/sources/okta/discover?domain=writer.okta.com&family=user")
+	if err != nil {
+		t.Fatalf("GET /sources/okta/discover error = %v", err)
+	}
+	defer func() {
+		if closeErr := oktaDiscoverResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /sources/okta/discover response body: %v", closeErr)
+		}
+	}()
+	var oktaDiscoverPayload map[string]any
+	if err := json.NewDecoder(oktaDiscoverResp.Body).Decode(&oktaDiscoverPayload); err != nil {
+		t.Fatalf("decode /sources/okta/discover response: %v", err)
+	}
+	if urns, ok := oktaDiscoverPayload["urns"].([]any); !ok || len(urns) != 2 {
+		t.Fatalf("okta discover urns = %#v, want 2 entries", oktaDiscoverPayload["urns"])
+	}
+	oktaReadResp, err := authedGet("/sources/okta/read?domain=writer.okta.com&family=user")
+	if err != nil {
+		t.Fatalf("GET /sources/okta/read error = %v", err)
+	}
+	defer func() {
+		if closeErr := oktaReadResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /sources/okta/read response body: %v", closeErr)
+		}
+	}()
+	var oktaReadPayload map[string]any
+	if err := json.NewDecoder(oktaReadResp.Body).Decode(&oktaReadPayload); err != nil {
+		t.Fatalf("decode /sources/okta/read response: %v", err)
+	}
+	if events, ok := oktaReadPayload["events"].([]any); !ok || len(events) != 1 {
+		t.Fatalf("okta read events = %#v, want 1 entry", oktaReadPayload["events"])
+	}
+	oktaPreviewEvents, ok := oktaReadPayload["preview_events"].([]any)
+	if !ok || len(oktaPreviewEvents) != 1 {
+		t.Fatalf("okta read preview_events = %#v, want 1 entry", oktaReadPayload["preview_events"])
+	}
+
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	versionResp, err := client.GetVersion(context.Background(), connect.NewRequest(&cerebrov1.GetVersionRequest{}))
 	if err != nil {
@@ -216,8 +270,8 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListSources() error = %v", err)
 	}
-	if len(listResp.Msg.Sources) != 1 {
-		t.Fatalf("len(ListSources.Sources) = %d, want 1", len(listResp.Msg.Sources))
+	if len(listResp.Msg.Sources) != 2 {
+		t.Fatalf("len(ListSources.Sources) = %d, want 2", len(listResp.Msg.Sources))
 	}
 	checkSourceResp, err := client.CheckSource(context.Background(), connect.NewRequest(&cerebrov1.CheckSourceRequest{
 		SourceId: "github",
@@ -276,6 +330,54 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if connect.CodeOf(err) != connect.CodeInvalidArgument {
 		t.Fatalf("CheckSource(base_url) code = %v, want %v", connect.CodeOf(err), connect.CodeInvalidArgument)
 	}
+	oktaCheckSourceResp, err := client.CheckSource(context.Background(), connect.NewRequest(&cerebrov1.CheckSourceRequest{
+		SourceId: "okta",
+		Config: map[string]string{
+			"domain": "writer.okta.com",
+			"family": "user",
+			"token":  "test",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("CheckSource(okta) error = %v", err)
+	}
+	if oktaCheckSourceResp.Msg.Status != "ok" {
+		t.Fatalf("CheckSource(okta) status = %q, want %q", oktaCheckSourceResp.Msg.Status, "ok")
+	}
+	oktaDiscoverSourceResp, err := client.DiscoverSource(context.Background(), connect.NewRequest(&cerebrov1.DiscoverSourceRequest{
+		SourceId: "okta",
+		Config: map[string]string{
+			"domain": "writer.okta.com",
+			"family": "user",
+			"token":  "test",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("DiscoverSource(okta) error = %v", err)
+	}
+	if len(oktaDiscoverSourceResp.Msg.Urns) != 2 {
+		t.Fatalf("len(DiscoverSource(okta).Urns) = %d, want 2", len(oktaDiscoverSourceResp.Msg.Urns))
+	}
+	oktaReadSourceResp, err := client.ReadSource(context.Background(), connect.NewRequest(&cerebrov1.ReadSourceRequest{
+		SourceId: "okta",
+		Config: map[string]string{
+			"domain": "writer.okta.com",
+			"family": "user",
+			"token":  "test",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("ReadSource(okta) error = %v", err)
+	}
+	if len(oktaReadSourceResp.Msg.Events) != 1 {
+		t.Fatalf("len(ReadSource(okta).Events) = %d, want 1", len(oktaReadSourceResp.Msg.Events))
+	}
+	if len(oktaReadSourceResp.Msg.PreviewEvents) != 1 {
+		t.Fatalf("len(ReadSource(okta).PreviewEvents) = %d, want 1", len(oktaReadSourceResp.Msg.PreviewEvents))
+	}
+	if !oktaReadSourceResp.Msg.PreviewEvents[0].PayloadDecoded {
+		t.Fatal("ReadSource(okta).PreviewEvents[0].PayloadDecoded = false, want true")
+	}
 }
 
 func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
@@ -305,7 +407,11 @@ func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	if err != nil {
 		return nil, err
 	}
-	return sourcecdk.NewRegistry(source)
+	okta, err := oktasource.NewFixture()
+	if err != nil {
+		return nil, err
+	}
+	return sourcecdk.NewRegistry(source, okta)
 }
 
 func TestSourceConnectErrorMapping(t *testing.T) {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -761,6 +761,20 @@ func TestSourceRuntimeRPCErrorCodes(t *testing.T) {
 	if got := connect.CodeOf(sourceRuntimeConnectError(context.DeadlineExceeded)); got != connect.CodeDeadlineExceeded {
 		t.Fatalf("sourceRuntimeConnectError(context.DeadlineExceeded) code = %v, want %v", got, connect.CodeDeadlineExceeded)
 	}
+	internalErr := sourceRuntimeConnectError(errors.New("dial tcp credential@db.internal:5432: i/o timeout"))
+	if got := connect.CodeOf(internalErr); got != connect.CodeInternal {
+		t.Fatalf("sourceRuntimeConnectError(internal) code = %v, want %v", got, connect.CodeInternal)
+	}
+	var connectErr *connect.Error
+	if !errors.As(internalErr, &connectErr) {
+		t.Fatalf("sourceRuntimeConnectError(internal) = %T, want *connect.Error", internalErr)
+	}
+	if strings.Contains(connectErr.Message(), "credential") || strings.Contains(connectErr.Message(), "db.internal") {
+		t.Fatalf("sourceRuntimeConnectError(internal) exposed details: %q", connectErr.Message())
+	}
+	if !strings.Contains(connectErr.Message(), "internal error") {
+		t.Fatalf("sourceRuntimeConnectError(internal) message = %q, want generic internal error", connectErr.Message())
+	}
 }
 
 func TestWriteSourceRuntimeErrorHidesInternalDetails(t *testing.T) {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -722,7 +722,7 @@ func TestSourceRuntimeRPCErrorCodes(t *testing.T) {
 
 func TestWriteSourceRuntimeErrorHidesInternalDetails(t *testing.T) {
 	recorder := httptest.NewRecorder()
-	writeSourceRuntimeError(recorder, errors.New("dial postgres://user:secret@db.internal:5432"))
+	writeSourceRuntimeError(recorder, errors.New("dial tcp credential@db.internal:5432: i/o timeout"))
 
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
@@ -730,7 +730,7 @@ func TestWriteSourceRuntimeErrorHidesInternalDetails(t *testing.T) {
 	if got := recorder.Body.String(); got != http.StatusText(http.StatusBadRequest)+"\n" {
 		t.Fatalf("body = %q, want generic status text", got)
 	}
-	if bytes.Contains(recorder.Body.Bytes(), []byte("secret")) || bytes.Contains(recorder.Body.Bytes(), []byte("db.internal")) {
+	if bytes.Contains(recorder.Body.Bytes(), []byte("credential")) || bytes.Contains(recorder.Body.Bytes(), []byte("db.internal")) {
 		t.Fatalf("body exposed internal error details: %q", recorder.Body.String())
 	}
 }

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -755,6 +755,12 @@ func TestSourceRuntimeRPCErrorCodes(t *testing.T) {
 	if _, err := unavailable.SyncSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.SyncSourceRuntimeRequest{Id: "runtime"})); connect.CodeOf(err) != connect.CodeUnavailable {
 		t.Fatalf("SyncSourceRuntime() unavailable code = %v, want %v", connect.CodeOf(err), connect.CodeUnavailable)
 	}
+	if got := connect.CodeOf(sourceRuntimeConnectError(context.Canceled)); got != connect.CodeCanceled {
+		t.Fatalf("sourceRuntimeConnectError(context.Canceled) code = %v, want %v", got, connect.CodeCanceled)
+	}
+	if got := connect.CodeOf(sourceRuntimeConnectError(context.DeadlineExceeded)); got != connect.CodeDeadlineExceeded {
+		t.Fatalf("sourceRuntimeConnectError(context.DeadlineExceeded) code = %v, want %v", got, connect.CodeDeadlineExceeded)
+	}
 }
 
 func TestWriteSourceRuntimeErrorHidesInternalDetails(t *testing.T) {

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -105,7 +105,11 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 	if err := s.ensureProjectionSchema(ctx); err != nil {
 		return err
 	}
-	attributesJSON, err := graphAttributesJSON(entity.Attributes)
+	attributes, err := s.mergedEntityAttributes(ctx, urn, entity.Attributes)
+	if err != nil {
+		return err
+	}
+	attributesJSON, err := graphAttributesJSON(attributes)
 	if err != nil {
 		return fmt.Errorf("marshal projected entity attributes: %w", err)
 	}
@@ -126,6 +130,27 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 		return fmt.Errorf("upsert projected entity %q: %w", urn, err)
 	}
 	return nil
+}
+
+func (s *Store) mergedEntityAttributes(ctx context.Context, urn string, attributes map[string]string) (map[string]string, error) {
+	merged := make(map[string]string, len(attributes))
+	var raw string
+	err := s.db.QueryRowContext(ctx, fmt.Sprintf("MATCH (e:entity {urn: %s}) RETURN e.attributes_json", cypherString(urn))).Scan(&raw)
+	switch {
+	case err == nil:
+		if strings.TrimSpace(raw) != "" {
+			if err := json.Unmarshal([]byte(raw), &merged); err != nil {
+				return nil, fmt.Errorf("decode existing projected entity attributes %q: %w", urn, err)
+			}
+		}
+	case errors.Is(err, sql.ErrNoRows):
+	default:
+		return nil, fmt.Errorf("load projected entity attributes %q: %w", urn, err)
+	}
+	for key, value := range attributes {
+		merged[key] = value
+	}
+	return merged, nil
 }
 
 // UpsertProjectedLink upserts one normalized link in the graph store.

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -186,6 +186,8 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	if err := s.ensureProjectionSchema(ctx); err != nil {
 		return err
 	}
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
 	merged, err := s.mergedRelationAttributes(ctx, fromURN, toURN, relation, link.Attributes)
 	if err != nil {
 		return err

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -105,6 +105,8 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 	if err := s.ensureProjectionSchema(ctx); err != nil {
 		return err
 	}
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
 	attributes, err := s.mergedEntityAttributes(ctx, urn, entity.Attributes)
 	if err != nil {
 		return err

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -186,7 +186,11 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	if err := s.ensureProjectionSchema(ctx); err != nil {
 		return err
 	}
-	attributesJSON, err := graphAttributesJSON(link.Attributes)
+	merged, err := s.mergedRelationAttributes(ctx, fromURN, toURN, relation, link.Attributes)
+	if err != nil {
+		return err
+	}
+	attributesJSON, err := graphAttributesJSON(merged)
 	if err != nil {
 		return fmt.Errorf("marshal projected link attributes: %w", err)
 	}
@@ -203,6 +207,30 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 		return fmt.Errorf("upsert projected link %q %q %q: %w", fromURN, relation, toURN, err)
 	}
 	return nil
+}
+
+func (s *Store) mergedRelationAttributes(ctx context.Context, fromURN, toURN, relation string, attributes map[string]string) (map[string]string, error) {
+	merged := make(map[string]string, len(attributes))
+	var raw sql.NullString
+	err := s.db.QueryRowContext(ctx, fmt.Sprintf(
+		"MATCH (src:entity {urn: %s})-[r:relation {relation: %s}]->(dst:entity {urn: %s}) RETURN r.attributes_json",
+		cypherString(fromURN), cypherString(relation), cypherString(toURN),
+	)).Scan(&raw)
+	switch {
+	case err == nil:
+		if strings.TrimSpace(raw.String) != "" {
+			if err := json.Unmarshal([]byte(raw.String), &merged); err != nil {
+				return nil, fmt.Errorf("decode existing projected link attributes %q %q %q: %w", fromURN, relation, toURN, err)
+			}
+		}
+	case errors.Is(err, sql.ErrNoRows):
+	default:
+		return nil, fmt.Errorf("load projected link attributes %q %q %q: %w", fromURN, relation, toURN, err)
+	}
+	for key, value := range attributes {
+		merged[key] = value
+	}
+	return merged, nil
 }
 
 func (s *Store) ensureProjectionSchema(ctx context.Context) error {

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -5,21 +5,26 @@ package kuzu
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	kuzudb "github.com/kuzudb/go-kuzu"
 
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 // Store is the Kuzu-backed graph projection store implementation.
 type Store struct {
-	db *sql.DB
+	db          *sql.DB
+	schemaMu    sync.Mutex
+	schemaReady bool
 }
 
 // Open opens a Kuzu-backed graph projection store.
@@ -71,4 +76,204 @@ func kuzuDSN(absPath string) string {
 		Scheme: "kuzu",
 		Path:   filepath.ToSlash(absPath),
 	}).String()
+}
+
+// UpsertProjectedEntity upserts one normalized entity in the graph store.
+func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.ProjectedEntity) error {
+	if entity == nil {
+		return errors.New("projected entity is required")
+	}
+	urn := strings.TrimSpace(entity.URN)
+	if urn == "" {
+		return errors.New("projected entity urn is required")
+	}
+	tenantID := strings.TrimSpace(entity.TenantID)
+	if tenantID == "" {
+		return errors.New("projected entity tenant id is required")
+	}
+	sourceID := strings.TrimSpace(entity.SourceID)
+	if sourceID == "" {
+		return errors.New("projected entity source id is required")
+	}
+	entityType := strings.TrimSpace(entity.EntityType)
+	if entityType == "" {
+		return errors.New("projected entity type is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("kuzu is not configured")
+	}
+	if err := s.ensureProjectionSchema(ctx); err != nil {
+		return err
+	}
+	attributesJSON, err := graphAttributesJSON(entity.Attributes)
+	if err != nil {
+		return fmt.Errorf("marshal projected entity attributes: %w", err)
+	}
+	label := strings.TrimSpace(entity.Label)
+	if label == "" {
+		label = urn
+	}
+	statement := fmt.Sprintf(
+		"MERGE (e:entity {urn: %s}) SET e.tenant_id = %s, e.source_id = %s, e.entity_type = %s, e.label = %s, e.attributes_json = %s",
+		cypherString(urn),
+		cypherString(tenantID),
+		cypherString(sourceID),
+		cypherString(entityType),
+		cypherString(label),
+		cypherString(attributesJSON),
+	)
+	if _, err := s.db.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("upsert projected entity %q: %w", urn, err)
+	}
+	return nil
+}
+
+// UpsertProjectedLink upserts one normalized link in the graph store.
+func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return errors.New("projected link is required")
+	}
+	fromURN := strings.TrimSpace(link.FromURN)
+	if fromURN == "" {
+		return errors.New("projected link from urn is required")
+	}
+	toURN := strings.TrimSpace(link.ToURN)
+	if toURN == "" {
+		return errors.New("projected link to urn is required")
+	}
+	relation := strings.TrimSpace(link.Relation)
+	if relation == "" {
+		return errors.New("projected link relation is required")
+	}
+	tenantID := strings.TrimSpace(link.TenantID)
+	if tenantID == "" {
+		return errors.New("projected link tenant id is required")
+	}
+	sourceID := strings.TrimSpace(link.SourceID)
+	if sourceID == "" {
+		return errors.New("projected link source id is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("kuzu is not configured")
+	}
+	if err := s.ensureProjectionSchema(ctx); err != nil {
+		return err
+	}
+	attributesJSON, err := graphAttributesJSON(link.Attributes)
+	if err != nil {
+		return fmt.Errorf("marshal projected link attributes: %w", err)
+	}
+	statement := fmt.Sprintf(
+		"MATCH (src:entity {urn: %s}), (dst:entity {urn: %s}) MERGE (src)-[r:relation {relation: %s}]->(dst) SET r.tenant_id = %s, r.source_id = %s, r.attributes_json = %s",
+		cypherString(fromURN),
+		cypherString(toURN),
+		cypherString(relation),
+		cypherString(tenantID),
+		cypherString(sourceID),
+		cypherString(attributesJSON),
+	)
+	if _, err := s.db.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("upsert projected link %q %q %q: %w", fromURN, relation, toURN, err)
+	}
+	return nil
+}
+
+func (s *Store) ensureProjectionSchema(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return errors.New("kuzu is not configured")
+	}
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	if s.schemaReady {
+		return nil
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return err
+	}
+	if !tables["entity"] {
+		if _, err := s.db.ExecContext(ctx, "CREATE NODE TABLE entity(urn STRING, tenant_id STRING, source_id STRING, entity_type STRING, label STRING, attributes_json STRING, PRIMARY KEY (urn))"); err != nil {
+			return fmt.Errorf("create entity node table: %w", err)
+		}
+	}
+	if !tables["relation"] {
+		if _, err := s.db.ExecContext(ctx, "CREATE REL TABLE relation(FROM entity TO entity, relation STRING, tenant_id STRING, source_id STRING, attributes_json STRING)"); err != nil {
+			return fmt.Errorf("create relation table: %w", err)
+		}
+	}
+	s.schemaReady = true
+	return nil
+}
+
+func (s *Store) graphTables(ctx context.Context) (_ map[string]bool, err error) {
+	rows, err := s.db.QueryContext(ctx, "CALL show_tables() RETURN *")
+	if err != nil {
+		return nil, fmt.Errorf("show kuzu tables: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close kuzu tables: %w", closeErr)
+		}
+	}()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("list kuzu table columns: %w", err)
+	}
+	tables := make(map[string]bool)
+	for rows.Next() {
+		values := make([]any, len(columns))
+		scanArgs := make([]any, len(columns))
+		for i := range values {
+			scanArgs[i] = &values[i]
+		}
+		if err := rows.Scan(scanArgs...); err != nil {
+			return nil, fmt.Errorf("scan kuzu tables: %w", err)
+		}
+		for idx, name := range columns {
+			if name != "name" {
+				continue
+			}
+			tableName := stringColumn(values[idx])
+			if tableName != "" {
+				tables[tableName] = true
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate kuzu tables: %w", err)
+	}
+	return tables, nil
+}
+
+func graphAttributesJSON(attributes map[string]string) (string, error) {
+	if len(attributes) == 0 {
+		return `{}`, nil
+	}
+	payload, err := json.Marshal(attributes)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func stringColumn(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case []byte:
+		return string(typed)
+	default:
+		return ""
+	}
+}
+
+func cypherString(value string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		"'", "\\'",
+		"\n", "\\n",
+		"\r", "\\r",
+	)
+	return "'" + replacer.Replace(value) + "'"
 }

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -164,7 +164,7 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 		return fmt.Errorf("marshal projected link attributes: %w", err)
 	}
 	statement := fmt.Sprintf(
-		"MATCH (src:entity {urn: %s}), (dst:entity {urn: %s}) MERGE (src)-[r:relation {relation: %s}]->(dst) SET r.tenant_id = %s, r.source_id = %s, r.attributes_json = %s",
+		"MERGE (src:entity {urn: %s}) MERGE (dst:entity {urn: %s}) MERGE (src)-[r:relation {relation: %s}]->(dst) SET r.tenant_id = %s, r.source_id = %s, r.attributes_json = %s",
 		cypherString(fromURN),
 		cypherString(toURN),
 		cypherString(relation),

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -134,12 +134,12 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 
 func (s *Store) mergedEntityAttributes(ctx context.Context, urn string, attributes map[string]string) (map[string]string, error) {
 	merged := make(map[string]string, len(attributes))
-	var raw string
+	var raw sql.NullString
 	err := s.db.QueryRowContext(ctx, fmt.Sprintf("MATCH (e:entity {urn: %s}) RETURN e.attributes_json", cypherString(urn))).Scan(&raw)
 	switch {
 	case err == nil:
-		if strings.TrimSpace(raw) != "" {
-			if err := json.Unmarshal([]byte(raw), &merged); err != nil {
+		if strings.TrimSpace(raw.String) != "" {
+			if err := json.Unmarshal([]byte(raw.String), &merged); err != nil {
 				return nil, fmt.Errorf("decode existing projected entity attributes %q: %w", urn, err)
 			}
 		}

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -2,6 +2,7 @@ package kuzu
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -75,6 +76,28 @@ func TestUpsertProjectedEntityAndLink(t *testing.T) {
 	}
 	if label != "Alice Example" {
 		t.Fatalf("projected entity label = %q, want %q", label, "Alice Example")
+	}
+	enrichedUser := *user
+	enrichedUser.Attributes = map[string]string{"resource_type": "user"}
+	if err := store.UpsertProjectedEntity(ctx, &enrichedUser); err != nil {
+		t.Fatalf("UpsertProjectedEntity(enrichedUser) error = %v", err)
+	}
+	var attributesJSON string
+	if err := store.db.QueryRowContext(
+		ctx,
+		fmt.Sprintf("MATCH (e:entity {urn: %s}) RETURN e.attributes_json", cypherString(user.URN)),
+	).Scan(&attributesJSON); err != nil {
+		t.Fatalf("query projected entity attributes: %v", err)
+	}
+	attributes := map[string]string{}
+	if err := json.Unmarshal([]byte(attributesJSON), &attributes); err != nil {
+		t.Fatalf("unmarshal projected entity attributes: %v", err)
+	}
+	if got := attributes["login"]; got != "alice" {
+		t.Fatalf("projected entity login attribute = %q, want alice", got)
+	}
+	if got := attributes["resource_type"]; got != "user" {
+		t.Fatalf("projected entity resource_type attribute = %q, want user", got)
 	}
 
 	var linkCount int64

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -160,6 +160,17 @@ func TestUpsertProjectedLinkMergesMissingEndpoints(t *testing.T) {
 			t.Fatalf("endpoint %q count = %d, want 1", urn, nodeCount)
 		}
 	}
+	entity := &ports.ProjectedEntity{
+		URN:        link.FromURN,
+		TenantID:   "writer",
+		SourceID:   "github",
+		EntityType: "github.user",
+		Label:      "Alice",
+		Attributes: map[string]string{"login": "alice"},
+	}
+	if err := store.UpsertProjectedEntity(ctx, entity); err != nil {
+		t.Fatalf("UpsertProjectedEntity(endpoint after link) error = %v", err)
+	}
 }
 
 func TestUpsertProjectedEntityRejectsNilEntity(t *testing.T) {

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -89,6 +89,56 @@ func TestUpsertProjectedEntityAndLink(t *testing.T) {
 	}
 }
 
+func TestUpsertProjectedLinkMergesMissingEndpoints(t *testing.T) {
+	store, err := Open(config.GraphStoreConfig{
+		Driver:   config.GraphStoreDriverKuzu,
+		KuzuPath: filepath.Join(t.TempDir(), "graph"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() {
+		if closeErr := store.Close(); closeErr != nil {
+			t.Fatalf("Close() error = %v", closeErr)
+		}
+	}()
+
+	ctx := context.Background()
+	link := &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "github",
+		FromURN:  "urn:cerebro:writer:github_user:alice",
+		ToURN:    "urn:cerebro:writer:github_repo:writer/cerebro",
+		Relation: "belongs_to",
+	}
+	if err := store.UpsertProjectedLink(ctx, link); err != nil {
+		t.Fatalf("UpsertProjectedLink() error = %v", err)
+	}
+	if err := store.UpsertProjectedLink(ctx, link); err != nil {
+		t.Fatalf("UpsertProjectedLink(idempotent) error = %v", err)
+	}
+
+	var linkCount int64
+	if err := store.db.QueryRowContext(ctx, "MATCH (:entity)-[r:relation]->(:entity) RETURN COUNT(r)").Scan(&linkCount); err != nil {
+		t.Fatalf("query projected link count: %v", err)
+	}
+	if linkCount != 1 {
+		t.Fatalf("projected link count = %d, want 1", linkCount)
+	}
+	for _, urn := range []string{link.FromURN, link.ToURN} {
+		var nodeCount int64
+		if err := store.db.QueryRowContext(
+			ctx,
+			fmt.Sprintf("MATCH (e:entity {urn: %s}) RETURN COUNT(e)", cypherString(urn)),
+		).Scan(&nodeCount); err != nil {
+			t.Fatalf("query endpoint %q: %v", urn, err)
+		}
+		if nodeCount != 1 {
+			t.Fatalf("endpoint %q count = %d, want 1", urn, nodeCount)
+		}
+	}
+}
+
 func TestUpsertProjectedEntityRejectsNilEntity(t *testing.T) {
 	store := &Store{}
 	if err := store.UpsertProjectedEntity(context.Background(), nil); err == nil {

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -1,0 +1,110 @@
+package kuzu
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestUpsertProjectedEntityAndLink(t *testing.T) {
+	store, err := Open(config.GraphStoreConfig{
+		Driver:   config.GraphStoreDriverKuzu,
+		KuzuPath: filepath.Join(t.TempDir(), "graph"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() {
+		if closeErr := store.Close(); closeErr != nil {
+			t.Fatalf("Close() error = %v", closeErr)
+		}
+	}()
+
+	ctx := context.Background()
+	user := &ports.ProjectedEntity{
+		URN:        "urn:cerebro:writer:github_user:alice",
+		TenantID:   "writer",
+		SourceID:   "github",
+		EntityType: "github.user",
+		Label:      "Alice",
+		Attributes: map[string]string{"login": "alice"},
+	}
+	repo := &ports.ProjectedEntity{
+		URN:        "urn:cerebro:writer:github_repo:writer/cerebro",
+		TenantID:   "writer",
+		SourceID:   "github",
+		EntityType: "github.repo",
+		Label:      "writer/cerebro",
+	}
+	if err := store.UpsertProjectedEntity(ctx, user); err != nil {
+		t.Fatalf("UpsertProjectedEntity(user) error = %v", err)
+	}
+	updatedUser := *user
+	updatedUser.Label = "Alice Example"
+	if err := store.UpsertProjectedEntity(ctx, &updatedUser); err != nil {
+		t.Fatalf("UpsertProjectedEntity(updatedUser) error = %v", err)
+	}
+	if err := store.UpsertProjectedEntity(ctx, repo); err != nil {
+		t.Fatalf("UpsertProjectedEntity(repo) error = %v", err)
+	}
+	link := &ports.ProjectedLink{
+		TenantID:   "writer",
+		SourceID:   "github",
+		FromURN:    user.URN,
+		ToURN:      repo.URN,
+		Relation:   "belongs_to",
+		Attributes: map[string]string{"event_id": "evt-1"},
+	}
+	if err := store.UpsertProjectedLink(ctx, link); err != nil {
+		t.Fatalf("UpsertProjectedLink() error = %v", err)
+	}
+	if err := store.UpsertProjectedLink(ctx, link); err != nil {
+		t.Fatalf("UpsertProjectedLink(idempotent) error = %v", err)
+	}
+
+	var label string
+	if err := store.db.QueryRowContext(
+		ctx,
+		fmt.Sprintf("MATCH (e:entity {urn: %s}) RETURN e.label", cypherString(user.URN)),
+	).Scan(&label); err != nil {
+		t.Fatalf("query projected entity label: %v", err)
+	}
+	if label != "Alice Example" {
+		t.Fatalf("projected entity label = %q, want %q", label, "Alice Example")
+	}
+
+	var linkCount int64
+	if err := store.db.QueryRowContext(
+		ctx,
+		"MATCH (:entity)-[r:relation]->(:entity) RETURN COUNT(r)",
+	).Scan(&linkCount); err != nil {
+		t.Fatalf("query projected link count: %v", err)
+	}
+	if linkCount != 1 {
+		t.Fatalf("projected link count = %d, want 1", linkCount)
+	}
+}
+
+func TestUpsertProjectedEntityRejectsNilEntity(t *testing.T) {
+	store := &Store{}
+	if err := store.UpsertProjectedEntity(context.Background(), nil); err == nil {
+		t.Fatal("UpsertProjectedEntity() error = nil, want non-nil")
+	}
+}
+
+func TestUpsertProjectedLinkRejectsMissingFromURN(t *testing.T) {
+	store := &Store{}
+	err := store.UpsertProjectedLink(context.Background(), &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "github",
+		Relation: "belongs_to",
+		ToURN:    "urn:cerebro:writer:github_repo:writer/cerebro",
+	})
+	if err == nil {
+		t.Fatal("UpsertProjectedLink() error = nil, want non-nil")
+	}
+}

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -2,6 +2,7 @@ package kuzu
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -190,5 +191,61 @@ func TestUpsertProjectedLinkRejectsMissingFromURN(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("UpsertProjectedLink() error = nil, want non-nil")
+	}
+}
+
+func TestUpsertProjectedLinkPreservesAttributesOnRepeatedUpserts(t *testing.T) {
+	store, err := Open(config.GraphStoreConfig{
+		Driver:   config.GraphStoreDriverKuzu,
+		KuzuPath: filepath.Join(t.TempDir(), "graph"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() {
+		if closeErr := store.Close(); closeErr != nil {
+			t.Fatalf("Close() error = %v", closeErr)
+		}
+	}()
+
+	ctx := context.Background()
+	first := &ports.ProjectedLink{
+		TenantID:   "writer",
+		SourceID:   "github",
+		FromURN:    "urn:cerebro:writer:github_user:alice",
+		ToURN:      "urn:cerebro:writer:github_repo:writer/cerebro",
+		Relation:   "belongs_to",
+		Attributes: map[string]string{"role": "admin"},
+	}
+	second := &ports.ProjectedLink{
+		TenantID:   "writer",
+		SourceID:   "github",
+		FromURN:    first.FromURN,
+		ToURN:      first.ToURN,
+		Relation:   first.Relation,
+		Attributes: map[string]string{"team": "platform"},
+	}
+	if err := store.UpsertProjectedLink(ctx, first); err != nil {
+		t.Fatalf("UpsertProjectedLink(first) error = %v", err)
+	}
+	if err := store.UpsertProjectedLink(ctx, second); err != nil {
+		t.Fatalf("UpsertProjectedLink(second) error = %v", err)
+	}
+	var raw sql.NullString
+	if err := store.db.QueryRowContext(ctx, fmt.Sprintf(
+		"MATCH (src:entity {urn: %s})-[r:relation {relation: %s}]->(dst:entity {urn: %s}) RETURN r.attributes_json",
+		cypherString(first.FromURN), cypherString(first.Relation), cypherString(first.ToURN),
+	)).Scan(&raw); err != nil {
+		t.Fatalf("query projected link attributes: %v", err)
+	}
+	got := map[string]string{}
+	if err := json.Unmarshal([]byte(raw.String), &got); err != nil {
+		t.Fatalf("decode attributes_json: %v", err)
+	}
+	if got["role"] != "admin" {
+		t.Fatalf("attributes role = %q, want admin (lost on repeated upsert)", got["role"])
+	}
+	if got["team"] != "platform" {
+		t.Fatalf("attributes team = %q, want platform", got["team"])
 	}
 }

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -1,0 +1,52 @@
+package ports
+
+import (
+	"context"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+// ProjectedEntity is the normalized current-state and graph entity shape.
+type ProjectedEntity struct {
+	URN        string
+	TenantID   string
+	SourceID   string
+	EntityType string
+	Label      string
+	Attributes map[string]string
+}
+
+// ProjectedLink is the normalized graph edge shape.
+type ProjectedLink struct {
+	TenantID   string
+	SourceID   string
+	FromURN    string
+	ToURN      string
+	Relation   string
+	Attributes map[string]string
+}
+
+// ProjectionResult reports how many entities and links were materialized.
+type ProjectionResult struct {
+	EntitiesProjected uint32
+	LinksProjected    uint32
+}
+
+// ProjectionStateStore persists normalized current-state entities and links.
+type ProjectionStateStore interface {
+	StateStore
+	UpsertProjectedEntity(context.Context, *ProjectedEntity) error
+	UpsertProjectedLink(context.Context, *ProjectedLink) error
+}
+
+// ProjectionGraphStore persists normalized entities and links into the graph.
+type ProjectionGraphStore interface {
+	GraphStore
+	UpsertProjectedEntity(context.Context, *ProjectedEntity) error
+	UpsertProjectedLink(context.Context, *ProjectedLink) error
+}
+
+// SourceProjector materializes source events into current-state and graph stores.
+type SourceProjector interface {
+	Project(context.Context, *cerebrov1.EventEnvelope) (ProjectionResult, error)
+}

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -1,0 +1,18 @@
+package ports
+
+import (
+	"context"
+	"errors"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+// ErrSourceRuntimeNotFound indicates that a stored source runtime does not exist.
+var ErrSourceRuntimeNotFound = errors.New("source runtime not found")
+
+// SourceRuntimeStore persists source runtime configuration and checkpoints.
+type SourceRuntimeStore interface {
+	StateStore
+	PutSourceRuntime(context.Context, *cerebrov1.SourceRuntime) error
+	GetSourceRuntime(context.Context, string) (*cerebrov1.SourceRuntime, error)
+}

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -44,6 +44,9 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 	if err != nil {
 		return nil, err
 	}
+	if err := validatePreviewConfig(req.GetConfig()); err != nil {
+		return nil, err
+	}
 	if err := source.Check(ctx, sourcecdk.NewConfig(req.GetConfig())); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidSourceConfig, err)
 	}
@@ -57,6 +60,9 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceRequest) (*cerebrov1.DiscoverSourceResponse, error) {
 	source, err := s.lookup(req.GetSourceId())
 	if err != nil {
+		return nil, err
+	}
+	if err := validatePreviewConfig(req.GetConfig()); err != nil {
 		return nil, err
 	}
 	urns, err := source.Discover(ctx, sourcecdk.NewConfig(req.GetConfig()))
@@ -79,6 +85,9 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*
 	if err != nil {
 		return nil, err
 	}
+	if err := validatePreviewConfig(req.GetConfig()); err != nil {
+		return nil, err
+	}
 	pull, err := source.Read(ctx, sourcecdk.NewConfig(req.GetConfig()), req.GetCursor())
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidSourceConfig, err)
@@ -94,6 +103,15 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*
 		NextCursor:    pull.NextCursor,
 		PreviewEvents: previews,
 	}, nil
+}
+
+func validatePreviewConfig(config map[string]string) error {
+	for key := range config {
+		if strings.EqualFold(strings.TrimSpace(key), "base_url") {
+			return fmt.Errorf("%w: source config key %q is not allowed for previews", ErrInvalidSourceConfig, key)
+		}
+	}
+	return nil
 }
 
 func (s *Service) lookup(sourceID string) (sourcecdk.Source, error) {

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -8,24 +8,25 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	githubsource "github.com/writer/cerebro/sources/github"
+	oktasource "github.com/writer/cerebro/sources/okta"
 )
 
 func TestList(t *testing.T) {
-	registry, err := newGitHubRegistry()
+	registry, err := newFixtureRegistry()
 	if err != nil {
-		t.Fatalf("newGitHubRegistry() error = %v", err)
+		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
 	service := New(registry)
 	response := service.List()
-	if len(response.Sources) != 1 {
-		t.Fatalf("len(List().Sources) = %d, want 1", len(response.Sources))
+	if len(response.Sources) != 2 {
+		t.Fatalf("len(List().Sources) = %d, want 2", len(response.Sources))
 	}
 }
 
 func TestCheckDiscoverAndRead(t *testing.T) {
-	registry, err := newGitHubRegistry()
+	registry, err := newFixtureRegistry()
 	if err != nil {
-		t.Fatalf("newGitHubRegistry() error = %v", err)
+		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
 	service := New(registry)
 	ctx := context.Background()
@@ -76,6 +77,60 @@ func TestCheckDiscoverAndRead(t *testing.T) {
 	}
 }
 
+func TestCheckDiscoverAndReadOkta(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	service := New(registry)
+	ctx := context.Background()
+
+	config := map[string]string{
+		"domain": "writer.okta.com",
+		"family": "user",
+		"token":  "test",
+	}
+
+	checkResp, err := service.Check(ctx, &cerebrov1.CheckSourceRequest{
+		SourceId: "okta",
+		Config:   config,
+	})
+	if err != nil {
+		t.Fatalf("Check(okta) error = %v", err)
+	}
+	if checkResp.Status != "ok" {
+		t.Fatalf("Check(okta).Status = %q, want %q", checkResp.Status, "ok")
+	}
+
+	discoverResp, err := service.Discover(ctx, &cerebrov1.DiscoverSourceRequest{
+		SourceId: "okta",
+		Config:   config,
+	})
+	if err != nil {
+		t.Fatalf("Discover(okta) error = %v", err)
+	}
+	if len(discoverResp.Urns) != 2 {
+		t.Fatalf("len(Discover(okta).Urns) = %d, want 2", len(discoverResp.Urns))
+	}
+
+	readResp, err := service.Read(ctx, &cerebrov1.ReadSourceRequest{
+		SourceId: "okta",
+		Config:   config,
+	})
+	if err != nil {
+		t.Fatalf("Read(okta) error = %v", err)
+	}
+	if len(readResp.Events) != 1 {
+		t.Fatalf("len(Read(okta).Events) = %d, want 1", len(readResp.Events))
+	}
+	if len(readResp.PreviewEvents) != 1 {
+		t.Fatalf("len(Read(okta).PreviewEvents) = %d, want 1", len(readResp.PreviewEvents))
+	}
+	if !readResp.PreviewEvents[0].PayloadDecoded {
+		t.Fatal("Read(okta).PreviewEvents[0].PayloadDecoded = false, want true")
+	}
+}
+
 func TestUnknownSource(t *testing.T) {
 	service := New(nil)
 	_, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "github"})
@@ -85,9 +140,9 @@ func TestUnknownSource(t *testing.T) {
 }
 
 func TestSourceValidationErrorsAreInvalidConfig(t *testing.T) {
-	registry, err := newGitHubRegistry()
+	registry, err := newFixtureRegistry()
 	if err != nil {
-		t.Fatalf("newGitHubRegistry() error = %v", err)
+		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
 	service := New(registry)
 	if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "github"}); !errors.Is(err, ErrInvalidSourceConfig) {
@@ -102,10 +157,14 @@ func TestSourceValidationErrorsAreInvalidConfig(t *testing.T) {
 	}
 }
 
-func newGitHubRegistry() (*sourcecdk.Registry, error) {
+func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.NewFixture()
 	if err != nil {
 		return nil, err
 	}
-	return sourcecdk.NewRegistry(source)
+	okta, err := oktasource.NewFixture()
+	if err != nil {
+		return nil, err
+	}
+	return sourcecdk.NewRegistry(source, okta)
 }

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -102,8 +102,9 @@ func githubPullRequestProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 
-	orgURN := projectionURN(tenantID, "github_org", owner)
+	orgURN := ""
 	if owner != "" {
+		orgURN = projectionURN(tenantID, "github_org", owner)
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        orgURN,
 			TenantID:   tenantID,

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -1,0 +1,618 @@
+package sourceprojection
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	relationActedOn       = "acted_on"
+	relationAuthored      = "authored"
+	relationBelongsTo     = "belongs_to"
+	relationHasIdentifier = "has_identifier"
+	relationTargeted      = "targeted"
+)
+
+// Service materializes synced source events into current-state and graph stores.
+type Service struct {
+	state ports.ProjectionStateStore
+	graph ports.ProjectionGraphStore
+}
+
+// New constructs a source projector.
+func New(state ports.ProjectionStateStore, graph ports.ProjectionGraphStore) *Service {
+	return &Service{state: state, graph: graph}
+}
+
+// Project applies one source event to the configured state and graph stores.
+func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
+	if event == nil {
+		return ports.ProjectionResult{}, fmt.Errorf("event is required")
+	}
+	if s == nil || (s.state == nil && s.graph == nil) {
+		return ports.ProjectionResult{}, nil
+	}
+	entities, links, err := projectionsForEvent(event)
+	if err != nil {
+		return ports.ProjectionResult{}, err
+	}
+	for _, entity := range entities {
+		if s.state != nil {
+			if err := s.state.UpsertProjectedEntity(ctx, entity); err != nil {
+				return ports.ProjectionResult{}, err
+			}
+		}
+		if s.graph != nil {
+			if err := s.graph.UpsertProjectedEntity(ctx, entity); err != nil {
+				return ports.ProjectionResult{}, err
+			}
+		}
+	}
+	for _, link := range links {
+		if s.state != nil {
+			if err := s.state.UpsertProjectedLink(ctx, link); err != nil {
+				return ports.ProjectionResult{}, err
+			}
+		}
+		if s.graph != nil {
+			if err := s.graph.UpsertProjectedLink(ctx, link); err != nil {
+				return ports.ProjectionResult{}, err
+			}
+		}
+	}
+	return ports.ProjectionResult{
+		EntitiesProjected: uint32(len(entities)),
+		LinksProjected:    uint32(len(links)),
+	}, nil
+}
+
+func projectionsForEvent(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	switch strings.TrimSpace(event.GetKind()) {
+	case "github.pull_request":
+		return githubPullRequestProjections(event)
+	case "github.audit":
+		return githubAuditProjections(event)
+	case "okta.user":
+		return oktaUserProjections(event)
+	case "okta.audit":
+		return oktaAuditProjections(event)
+	default:
+		return nil, nil, nil
+	}
+}
+
+func githubPullRequestProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	payload := payloadMap(event)
+	owner := strings.TrimSpace(attributes["owner"])
+	repository := strings.TrimSpace(attributes["repository"])
+	pullNumber := strings.TrimSpace(attributes["pull_number"])
+	author := strings.TrimSpace(attributes["author"])
+
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	orgURN := projectionURN(tenantID, "github_org", owner)
+	if owner != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        orgURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "github.org",
+			Label:      owner,
+			Attributes: map[string]string{"org": owner},
+		})
+	}
+
+	repoURN := projectionURN(tenantID, "github_repo", repository)
+	if repository != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        repoURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "github.repo",
+			Label:      repository,
+			Attributes: map[string]string{"repository": repository},
+		})
+		if orgURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), repoURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+
+	prURN := projectionURN(tenantID, "github_pull_request", repository+"#"+pullNumber)
+	if repository != "" && pullNumber != "" {
+		label := firstNonEmpty(stringValue(payload, "title"), repository+"#"+pullNumber)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        prURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "github.pull_request",
+			Label:      label,
+			Attributes: map[string]string{
+				"html_url":    strings.TrimSpace(attributes["html_url"]),
+				"pull_number": pullNumber,
+				"repository":  repository,
+				"state":       strings.TrimSpace(attributes["state"]),
+			},
+		})
+		if repoURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), prURN, repoURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+
+	authorURN := githubUserURN(tenantID, author)
+	if authorURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        authorURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "github.user",
+			Label:      author,
+			Attributes: map[string]string{"login": author},
+		})
+		if prURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), authorURN, prURN, relationAuthored, map[string]string{"event_id": event.GetId()}))
+		}
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), authorURN, author)
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	org := strings.TrimSpace(attributes["org"])
+	repo := strings.TrimSpace(attributes["repo"])
+	resourceID := strings.TrimSpace(attributes["resource_id"])
+	resourceType := strings.TrimSpace(attributes["resource_type"])
+	actor := strings.TrimSpace(attributes["actor"])
+	targetUser := strings.TrimSpace(attributes["user"])
+
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	orgURN := projectionURN(tenantID, "github_org", org)
+	if org != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        orgURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "github.org",
+			Label:      org,
+			Attributes: map[string]string{"org": org},
+		})
+	}
+
+	repoURN := projectionURN(tenantID, "github_repo", firstNonEmpty(repo, resourceID))
+	if repo != "" || (resourceID != "" && strings.Contains(resourceID, "/")) {
+		label := firstNonEmpty(repo, resourceID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        repoURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "github.repo",
+			Label:      label,
+			Attributes: map[string]string{"repository": label},
+		})
+		if orgURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), repoURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+
+	resourceURN := githubResourceURN(tenantID, resourceType, resourceID, repoURN)
+	if resourceURN != "" {
+		label := firstNonEmpty(resourceID, resourceType)
+		entityType := "github.resource"
+		if repoURN != "" && resourceURN == repoURN {
+			entityType = "github.repo"
+			label = firstNonEmpty(repo, resourceID)
+		}
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        resourceURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: entityType,
+			Label:      label,
+			Attributes: map[string]string{
+				"resource_id":   resourceID,
+				"resource_type": resourceType,
+			},
+		})
+		if orgURN != "" && repoURN == "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+		if repoURN != "" && resourceURN != repoURN {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, repoURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+
+	actorURN := githubUserURN(tenantID, actor)
+	if actorURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        actorURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "github.user",
+			Label:      actor,
+			Attributes: map[string]string{"login": actor},
+		})
+		if resourceURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, map[string]string{
+				"action":   strings.TrimSpace(attributes["action"]),
+				"event_id": event.GetId(),
+			}))
+		}
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), actorURN, actor)
+	}
+
+	targetURN := githubUserURN(tenantID, targetUser)
+	if targetURN != "" && targetURN != actorURN {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        targetURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "github.user",
+			Label:      targetUser,
+			Attributes: map[string]string{"login": targetUser},
+		})
+		if resourceURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, resourceURN, relationTargeted, map[string]string{"event_id": event.GetId()}))
+		}
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), targetURN, targetUser)
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func oktaUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	domain := strings.TrimSpace(attributes["domain"])
+	userID := strings.TrimSpace(attributes["user_id"])
+	email := strings.TrimSpace(attributes["email"])
+	login := strings.TrimSpace(attributes["login"])
+
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	orgURN := projectionURN(tenantID, "okta_org", domain)
+	if domain != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        orgURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "okta.org",
+			Label:      domain,
+			Attributes: map[string]string{"domain": domain},
+		})
+	}
+
+	userURN := oktaUserURN(tenantID, userID)
+	if userURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        userURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "okta.user",
+			Label:      firstNonEmpty(email, login, userID),
+			Attributes: map[string]string{
+				"email":  email,
+				"login":  login,
+				"status": strings.TrimSpace(attributes["status"]),
+			},
+		})
+		if orgURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), userURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), userURN, email)
+		if !sameIdentifier(email, login) {
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), userURN, login)
+		}
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	domain := strings.TrimSpace(attributes["domain"])
+	actorID := strings.TrimSpace(attributes["actor_id"])
+	actorType := strings.TrimSpace(attributes["actor_type"])
+	actorAlternateID := strings.TrimSpace(attributes["actor_alternate_id"])
+	actorDisplayName := strings.TrimSpace(attributes["actor_display_name"])
+	resourceID := strings.TrimSpace(attributes["resource_id"])
+	resourceType := strings.TrimSpace(attributes["resource_type"])
+
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	orgURN := projectionURN(tenantID, "okta_org", domain)
+	if domain != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        orgURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "okta.org",
+			Label:      domain,
+			Attributes: map[string]string{"domain": domain},
+		})
+	}
+
+	resourceURN := oktaResourceURN(tenantID, resourceType, resourceID)
+	if resourceURN != "" {
+		entityType := "okta.resource"
+		if strings.EqualFold(resourceType, "user") {
+			entityType = "okta.user"
+		}
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        resourceURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: entityType,
+			Label:      firstNonEmpty(resourceID, resourceType),
+			Attributes: map[string]string{
+				"resource_id":   resourceID,
+				"resource_type": resourceType,
+			},
+		})
+		if orgURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+
+	actorURN := oktaActorURN(tenantID, actorType, actorID)
+	if actorURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        actorURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: oktaActorEntityType(actorType),
+			Label:      firstNonEmpty(actorAlternateID, actorDisplayName, actorID),
+			Attributes: map[string]string{
+				"actor_id":           actorID,
+				"actor_type":         actorType,
+				"actor_alternate_id": actorAlternateID,
+			},
+		})
+		if orgURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+		if resourceURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, map[string]string{
+				"event_id":   event.GetId(),
+				"event_type": strings.TrimSpace(attributes["event_type"]),
+			}))
+		}
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), actorURN, actorAlternateID)
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func entitiesAndLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink) ([]*ports.ProjectedEntity, []*ports.ProjectedLink) {
+	projectedEntities := make([]*ports.ProjectedEntity, 0, len(entities))
+	for _, entity := range entities {
+		projectedEntities = append(projectedEntities, entity)
+	}
+	projectedLinks := make([]*ports.ProjectedLink, 0, len(links))
+	for _, link := range links {
+		projectedLinks = append(projectedLinks, link)
+	}
+	return projectedEntities, projectedLinks
+}
+
+func tenantID(event *cerebrov1.EventEnvelope) (string, error) {
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	if tenantID == "" {
+		return "", fmt.Errorf("event %q tenant_id is required for projection", event.GetId())
+	}
+	return tenantID, nil
+}
+
+func addEntity(entities map[string]*ports.ProjectedEntity, entity *ports.ProjectedEntity) {
+	if entity == nil || strings.TrimSpace(entity.URN) == "" {
+		return
+	}
+	entities[entity.URN] = entity
+}
+
+func addLink(links map[string]*ports.ProjectedLink, link *ports.ProjectedLink) {
+	if link == nil || strings.TrimSpace(link.FromURN) == "" || strings.TrimSpace(link.ToURN) == "" || strings.TrimSpace(link.Relation) == "" {
+		return
+	}
+	key := link.FromURN + "|" + link.Relation + "|" + link.ToURN
+	links[key] = link
+}
+
+func addIdentifierLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, fromURN string, value string) {
+	identifierURN, identifierType, label := identifierURN(tenantID, value)
+	if identifierURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        identifierURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: identifierType,
+		Label:      label,
+		Attributes: map[string]string{"value": label},
+	})
+	addLink(links, projectedLink(tenantID, sourceID, fromURN, identifierURN, relationHasIdentifier, nil))
+}
+
+func projectedLink(tenantID string, sourceID string, fromURN string, toURN string, relation string, attributes map[string]string) *ports.ProjectedLink {
+	return &ports.ProjectedLink{
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		FromURN:    fromURN,
+		ToURN:      toURN,
+		Relation:   relation,
+		Attributes: attributes,
+	}
+}
+
+func githubUserURN(tenantID string, login string) string {
+	value := strings.TrimSpace(login)
+	if value == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "github_user", value)
+}
+
+func oktaUserURN(tenantID string, userID string) string {
+	value := strings.TrimSpace(userID)
+	if value == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "okta_user", value)
+}
+
+func oktaActorURN(tenantID string, actorType string, actorID string) string {
+	switch {
+	case strings.EqualFold(actorType, "user"):
+		return oktaUserURN(tenantID, actorID)
+	case strings.TrimSpace(actorID) == "":
+		return ""
+	default:
+		return projectionURN(tenantID, "okta_actor", normalizeIdentifier(actorType), strings.TrimSpace(actorID))
+	}
+}
+
+func oktaActorEntityType(actorType string) string {
+	if strings.EqualFold(actorType, "user") {
+		return "okta.user"
+	}
+	if strings.TrimSpace(actorType) == "" {
+		return "okta.actor"
+	}
+	return "okta." + normalizeIdentifier(actorType)
+}
+
+func githubResourceURN(tenantID string, resourceType string, resourceID string, repoURN string) string {
+	if repoURN != "" && (strings.Contains(strings.ToLower(resourceType), "repository") || strings.Contains(resourceID, "/")) {
+		return repoURN
+	}
+	if strings.TrimSpace(resourceID) == "" && strings.TrimSpace(resourceType) == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "github_resource", normalizeIdentifier(resourceType), strings.TrimSpace(resourceID))
+}
+
+func oktaResourceURN(tenantID string, resourceType string, resourceID string) string {
+	if strings.TrimSpace(resourceID) == "" {
+		return ""
+	}
+	if strings.EqualFold(resourceType, "user") {
+		return oktaUserURN(tenantID, resourceID)
+	}
+	return projectionURN(tenantID, "okta_resource", normalizeIdentifier(resourceType), strings.TrimSpace(resourceID))
+}
+
+func projectionURN(tenantID string, kind string, parts ...string) string {
+	tenant := strings.TrimSpace(tenantID)
+	entityKind := strings.TrimSpace(kind)
+	if tenant == "" || entityKind == "" {
+		return ""
+	}
+	values := make([]string, 0, len(parts)+3)
+	values = append(values, "urn", "cerebro", tenant, entityKind)
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		values = append(values, value)
+	}
+	return strings.Join(values, ":")
+}
+
+func identifierURN(tenantID string, raw string) (string, string, string) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", "", ""
+	}
+	if looksLikeEmail(value) {
+		normalized := normalizeIdentifier(value)
+		return projectionURN(tenantID, "identifier", "email", normalized), "identifier.email", normalized
+	}
+	normalized := normalizeIdentifier(value)
+	return projectionURN(tenantID, "identifier", "login", normalized), "identifier.login", normalized
+}
+
+func looksLikeEmail(value string) bool {
+	return strings.Contains(strings.TrimSpace(value), "@")
+}
+
+func sameIdentifier(left string, right string) bool {
+	if strings.TrimSpace(left) == "" || strings.TrimSpace(right) == "" {
+		return false
+	}
+	return normalizeIdentifier(left) == normalizeIdentifier(right)
+}
+
+func normalizeIdentifier(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func payloadMap(event *cerebrov1.EventEnvelope) map[string]any {
+	if len(event.GetPayload()) == 0 {
+		return nil
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(event.GetPayload(), &payload); err != nil {
+		return nil
+	}
+	return payload
+}
+
+func stringValue(values map[string]any, key string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	value, ok := values[key]
+	if !ok {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	default:
+		return ""
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -188,8 +188,9 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 
-	orgURN := projectionURN(tenantID, "github_org", org)
+	orgURN := ""
 	if org != "" {
+		orgURN = projectionURN(tenantID, "github_org", org)
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        orgURN,
 			TenantID:   tenantID,
@@ -200,9 +201,11 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 		})
 	}
 
-	repoURN := projectionURN(tenantID, "github_repo", firstNonEmpty(repo, resourceID))
+	repoLabel := firstNonEmpty(repo, resourceID)
+	repoURN := ""
 	if repo != "" || (resourceID != "" && strings.Contains(resourceID, "/")) {
-		label := firstNonEmpty(repo, resourceID)
+		repoURN = projectionURN(tenantID, "github_repo", repoLabel)
+		label := repoLabel
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        repoURN,
 			TenantID:   tenantID,
@@ -296,8 +299,9 @@ func oktaUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnti
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 
-	orgURN := projectionURN(tenantID, "okta_org", domain)
+	orgURN := ""
 	if domain != "" {
+		orgURN = projectionURN(tenantID, "okta_org", domain)
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        orgURN,
 			TenantID:   tenantID,
@@ -352,8 +356,9 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 
-	orgURN := projectionURN(tenantID, "okta_org", domain)
+	orgURN := ""
 	if domain != "" {
+		orgURN = projectionURN(tenantID, "okta_org", domain)
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        orgURN,
 			TenantID:   tenantID,

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -439,6 +439,29 @@ func addEntity(entities map[string]*ports.ProjectedEntity, entity *ports.Project
 	if entity == nil || strings.TrimSpace(entity.URN) == "" {
 		return
 	}
+	if existing := entities[entity.URN]; existing != nil {
+		if strings.TrimSpace(entity.TenantID) != "" {
+			existing.TenantID = entity.TenantID
+		}
+		if strings.TrimSpace(entity.SourceID) != "" {
+			existing.SourceID = entity.SourceID
+		}
+		if strings.TrimSpace(entity.EntityType) != "" {
+			existing.EntityType = entity.EntityType
+		}
+		if strings.TrimSpace(entity.Label) != "" {
+			existing.Label = entity.Label
+		}
+		if len(entity.Attributes) != 0 {
+			if existing.Attributes == nil {
+				existing.Attributes = map[string]string{}
+			}
+			for key, value := range entity.Attributes {
+				existing.Attributes[key] = value
+			}
+		}
+		return
+	}
 	entities[entity.URN] = entity
 }
 

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -130,8 +130,9 @@ func githubPullRequestProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 		}
 	}
 
-	prURN := projectionURN(tenantID, "github_pull_request", repository+"#"+pullNumber)
+	prURN := ""
 	if repository != "" && pullNumber != "" {
+		prURN = projectionURN(tenantID, "github_pull_request", repository+"#"+pullNumber)
 		label := firstNonEmpty(stringValue(payload, "title"), repository+"#"+pullNumber)
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        prURN,

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -1,0 +1,185 @@
+package sourceprojection
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type projectionRecorder struct {
+	entities map[string]*ports.ProjectedEntity
+	links    map[string]*ports.ProjectedLink
+}
+
+func (r *projectionRecorder) Ping(context.Context) error {
+	return nil
+}
+
+func (r *projectionRecorder) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if entity == nil {
+		return nil
+	}
+	if r.entities == nil {
+		r.entities = make(map[string]*ports.ProjectedEntity)
+	}
+	r.entities[entity.URN] = cloneProjectedEntity(entity)
+	return nil
+}
+
+func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	if r.links == nil {
+		r.links = make(map[string]*ports.ProjectedLink)
+	}
+	r.links[projectedLinkKey(link)] = cloneProjectedLink(link)
+	return nil
+}
+
+func TestProjectGitHubPullRequest(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	service := New(state, graph)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-pr-447",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.pull_request",
+		Payload: mustJSON(t, map[string]any{
+			"title": "Add Okta runtime sync",
+		}),
+		Attributes: map[string]string{
+			"author":      "alice",
+			"owner":       "writer",
+			"pull_number": "447",
+			"repository":  "writer/cerebro",
+			"state":       "open",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesProjected != 5 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 5", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 4 {
+		t.Fatalf("Project().LinksProjected = %d, want 4", result.LinksProjected)
+	}
+
+	prURN := "urn:cerebro:writer:github_pull_request:writer/cerebro#447"
+	identifierURN := "urn:cerebro:writer:identifier:login:alice"
+	if _, ok := state.entities[prURN]; !ok {
+		t.Fatalf("state entity %q missing", prURN)
+	}
+	if _, ok := graph.entities[prURN]; !ok {
+		t.Fatalf("graph entity %q missing", prURN)
+	}
+	if _, ok := state.links["urn:cerebro:writer:github_user:alice|"+relationHasIdentifier+"|"+identifierURN]; !ok {
+		t.Fatalf("state identifier link missing for %q", identifierURN)
+	}
+}
+
+func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	events := []*cerebrov1.EventEnvelope{
+		{
+			Id:       "github-audit-1",
+			TenantId: "writer",
+			SourceId: "github",
+			Kind:     "github.audit",
+			Attributes: map[string]string{
+				"actor":         "alice@writer.com",
+				"org":           "writer",
+				"repo":          "writer/cerebro",
+				"resource_id":   "writer/cerebro",
+				"resource_type": "repository",
+			},
+		},
+		{
+			Id:       "okta-user-1",
+			TenantId: "writer",
+			SourceId: "okta",
+			Kind:     "okta.user",
+			Attributes: map[string]string{
+				"domain":  "writer.okta.com",
+				"email":   "alice@writer.com",
+				"login":   "alice@writer.com",
+				"status":  "ACTIVE",
+				"user_id": "00u1",
+			},
+		},
+	}
+
+	for _, event := range events {
+		if _, err := service.Project(context.Background(), event); err != nil {
+			t.Fatalf("Project(%q) error = %v", event.GetId(), err)
+		}
+	}
+
+	identifierURN := "urn:cerebro:writer:identifier:email:alice@writer.com"
+	if _, ok := state.entities[identifierURN]; !ok {
+		t.Fatalf("identifier entity %q missing", identifierURN)
+	}
+	if _, ok := state.links["urn:cerebro:writer:github_user:alice@writer.com|"+relationHasIdentifier+"|"+identifierURN]; !ok {
+		t.Fatalf("github identifier link missing for %q", identifierURN)
+	}
+	if _, ok := state.links["urn:cerebro:writer:okta_user:00u1|"+relationHasIdentifier+"|"+identifierURN]; !ok {
+		t.Fatalf("okta identifier link missing for %q", identifierURN)
+	}
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return payload
+}
+
+func cloneProjectedEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
+	if entity == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(entity.Attributes))
+	for key, value := range entity.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedEntity{
+		URN:        entity.URN,
+		TenantID:   entity.TenantID,
+		SourceID:   entity.SourceID,
+		EntityType: entity.EntityType,
+		Label:      entity.Label,
+		Attributes: attributes,
+	}
+}
+
+func cloneProjectedLink(link *ports.ProjectedLink) *ports.ProjectedLink {
+	if link == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(link.Attributes))
+	for key, value := range link.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedLink{
+		TenantID:   link.TenantID,
+		SourceID:   link.SourceID,
+		FromURN:    link.FromURN,
+		ToURN:      link.ToURN,
+		Relation:   link.Relation,
+		Attributes: attributes,
+	}
+}
+
+func projectedLinkKey(link *ports.ProjectedLink) string {
+	return link.FromURN + "|" + link.Relation + "|" + link.ToURN
+}

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -136,6 +136,98 @@ func TestProjectSkipsPlaceholderPullRequestLinks(t *testing.T) {
 	}
 }
 
+func TestProjectGitHubAuditWithoutOrgOrRepoSkipsPlaceholderEntities(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-audit-1",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"actor":         "alice",
+			"resource_type": "repository_vulnerability_alert",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	emptyOrgURN := "urn:cerebro:writer:github_org"
+	emptyRepoURN := "urn:cerebro:writer:github_repo"
+	if _, ok := state.entities[emptyOrgURN]; ok {
+		t.Fatalf("empty org entity %q should not be projected", emptyOrgURN)
+	}
+	if _, ok := state.entities[emptyRepoURN]; ok {
+		t.Fatalf("empty repo entity %q should not be projected", emptyRepoURN)
+	}
+	for key := range state.links {
+		if strings.Contains(key, emptyOrgURN) || strings.Contains(key, emptyRepoURN) {
+			t.Fatalf("placeholder github link %q should not be projected", key)
+		}
+	}
+}
+
+func TestProjectOktaUserWithoutDomainDoesNotLinkPlaceholderOrg(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "okta-user-1",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.user",
+		Attributes: map[string]string{
+			"email":   "alice@writer.com",
+			"login":   "alice@writer.com",
+			"status":  "ACTIVE",
+			"user_id": "00u1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	emptyOrgURN := "urn:cerebro:writer:okta_org"
+	if _, ok := state.entities[emptyOrgURN]; ok {
+		t.Fatalf("empty org entity %q should not be projected", emptyOrgURN)
+	}
+	for key := range state.links {
+		if strings.Contains(key, emptyOrgURN) {
+			t.Fatalf("placeholder okta user link %q should not be projected", key)
+		}
+	}
+}
+
+func TestProjectOktaAuditWithoutDomainDoesNotLinkPlaceholderOrg(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "okta-audit-1",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.audit",
+		Attributes: map[string]string{
+			"actor_id":      "00u1",
+			"actor_type":    "user",
+			"resource_id":   "app1",
+			"resource_type": "app",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	emptyOrgURN := "urn:cerebro:writer:okta_org"
+	if _, ok := state.entities[emptyOrgURN]; ok {
+		t.Fatalf("empty org entity %q should not be projected", emptyOrgURN)
+	}
+	for key := range state.links {
+		if strings.Contains(key, emptyOrgURN) {
+			t.Fatalf("placeholder okta audit link %q should not be projected", key)
+		}
+	}
+}
+
 func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -156,6 +156,17 @@ func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
 	if _, ok := state.entities[identifierURN]; !ok {
 		t.Fatalf("identifier entity %q missing", identifierURN)
 	}
+	repoURN := "urn:cerebro:writer:github_repo:writer/cerebro"
+	repo := state.entities[repoURN]
+	if repo == nil {
+		t.Fatalf("repository entity %q missing", repoURN)
+	}
+	if got := repo.Attributes["repository"]; got != "writer/cerebro" {
+		t.Fatalf("repository attribute = %q, want writer/cerebro", got)
+	}
+	if got := repo.Attributes["resource_type"]; got != "repository" {
+		t.Fatalf("resource_type attribute = %q, want repository", got)
+	}
 	if _, ok := state.links["urn:cerebro:writer:github_user:alice@writer.com|"+relationHasIdentifier+"|"+identifierURN]; !ok {
 		t.Fatalf("github identifier link missing for %q", identifierURN)
 	}

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -3,6 +3,7 @@ package sourceprojection
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -81,6 +82,34 @@ func TestProjectGitHubPullRequest(t *testing.T) {
 	}
 	if _, ok := state.links["urn:cerebro:writer:github_user:alice|"+relationHasIdentifier+"|"+identifierURN]; !ok {
 		t.Fatalf("state identifier link missing for %q", identifierURN)
+	}
+}
+
+func TestProjectGitHubPullRequestWithoutOwnerDoesNotLinkEmptyOrg(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-pr-447",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.pull_request",
+		Attributes: map[string]string{
+			"pull_number": "447",
+			"repository":  "writer/cerebro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	emptyOrgURN := "urn:cerebro:writer:github_org:"
+	if _, ok := state.entities[emptyOrgURN]; ok {
+		t.Fatalf("empty org entity %q should not be projected", emptyOrgURN)
+	}
+	for key := range state.links {
+		if strings.Contains(key, emptyOrgURN) {
+			t.Fatalf("empty org link %q should not be projected", key)
+		}
 	}
 }
 

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -113,6 +113,29 @@ func TestProjectGitHubPullRequestWithoutOwnerDoesNotLinkEmptyOrg(t *testing.T) {
 	}
 }
 
+func TestProjectSkipsPlaceholderPullRequestLinks(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-pr-missing-repo",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.pull_request",
+		Attributes: map[string]string{
+			"author": "alice",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	for key := range state.links {
+		if strings.Contains(key, "github_pull_request") {
+			t.Fatalf("placeholder pull request link %q should not be projected", key)
+		}
+	}
+}
+
 func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceregistry/registry.go
+++ b/internal/sourceregistry/registry.go
@@ -5,13 +5,38 @@ import (
 
 	"github.com/writer/cerebro/internal/sourcecdk"
 	githubsource "github.com/writer/cerebro/sources/github"
+	oktasource "github.com/writer/cerebro/sources/okta"
 )
+
+type builtinSourceLoader struct {
+	name string
+	load func() (sourcecdk.Source, error)
+}
+
+var builtinSourceLoaders = []builtinSourceLoader{
+	{
+		name: "github",
+		load: func() (sourcecdk.Source, error) {
+			return githubsource.New()
+		},
+	},
+	{
+		name: "okta",
+		load: func() (sourcecdk.Source, error) {
+			return oktasource.New()
+		},
+	},
+}
 
 // Builtin constructs the in-process source registry for the rewrite skeleton.
 func Builtin() (*sourcecdk.Registry, error) {
-	github, err := githubsource.New()
-	if err != nil {
-		return nil, fmt.Errorf("load github source: %w", err)
+	sources := make([]sourcecdk.Source, 0, len(builtinSourceLoaders))
+	for _, loader := range builtinSourceLoaders {
+		source, err := loader.load()
+		if err != nil {
+			return nil, fmt.Errorf("load %s source: %w", loader.name, err)
+		}
+		sources = append(sources, source)
 	}
-	return sourcecdk.NewRegistry(github)
+	return sourcecdk.NewRegistry(sources...)
 }

--- a/internal/sourceregistry/registry_test.go
+++ b/internal/sourceregistry/registry_test.go
@@ -7,11 +7,18 @@ func TestBuiltin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Builtin() error = %v", err)
 	}
-	source, ok := registry.Get("github")
+	github, ok := registry.Get("github")
 	if !ok {
 		t.Fatal("Get(github) = false, want true")
 	}
-	if source.Spec().Name != "GitHub" {
-		t.Fatalf("Spec().Name = %q, want %q", source.Spec().Name, "GitHub")
+	if github.Spec().Name != "GitHub" {
+		t.Fatalf("github Spec().Name = %q, want %q", github.Spec().Name, "GitHub")
+	}
+	okta, ok := registry.Get("okta")
+	if !ok {
+		t.Fatal("Get(okta) = false, want true")
+	}
+	if okta.Spec().Name != "Okta" {
+		t.Fatalf("okta Spec().Name = %q, want %q", okta.Spec().Name, "Okta")
 	}
 }

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -55,6 +55,9 @@ func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeReques
 	if runtime.GetId() == "" {
 		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
 	}
+	if reservedKey := reservedConfigKey(runtime.GetConfig()); reservedKey != "" {
+		return nil, fmt.Errorf("%w: source runtime config key %q is reserved", ErrInvalidRequest, reservedKey)
+	}
 	source, err := s.lookupSource(runtime.GetSourceId())
 	if err != nil {
 		return nil, err
@@ -248,6 +251,16 @@ func sameConfig(left map[string]string, right map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func reservedConfigKey(config map[string]string) string {
+	for key := range config {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "base_url" || normalized == "cursor" {
+			return key
+		}
+	}
+	return ""
 }
 
 func redactRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -1,0 +1,266 @@
+package sourceruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceops"
+)
+
+const (
+	defaultPageLimit = 1
+	maxPageLimit     = 100
+	redactedValue    = "[redacted]"
+)
+
+// ErrRuntimeUnavailable indicates that the runtime dependencies are not configured.
+var ErrRuntimeUnavailable = errors.New("source runtime is unavailable")
+
+// Service persists and executes source runtimes against the append log.
+type Service struct {
+	registry  *sourcecdk.Registry
+	store     ports.SourceRuntimeStore
+	appendLog ports.AppendLog
+}
+
+// New constructs a source runtime service.
+func New(registry *sourcecdk.Registry, store ports.SourceRuntimeStore, appendLog ports.AppendLog) *Service {
+	return &Service{registry: registry, store: store, appendLog: appendLog}
+}
+
+// Put validates and stores a source runtime definition.
+func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeRequest) (*cerebrov1.PutSourceRuntimeResponse, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	if req == nil || req.GetRuntime() == nil {
+		return nil, fmt.Errorf("source runtime is required")
+	}
+	runtime := cloneRuntime(req.GetRuntime())
+	runtime.Id = strings.TrimSpace(runtime.GetId())
+	runtime.SourceId = strings.TrimSpace(runtime.GetSourceId())
+	if runtime.GetId() == "" {
+		return nil, fmt.Errorf("source runtime id is required")
+	}
+	source, err := s.lookupSource(runtime.GetSourceId())
+	if err != nil {
+		return nil, err
+	}
+	if err := source.Check(ctx, sourcecdk.NewConfig(runtime.GetConfig())); err != nil {
+		return nil, err
+	}
+	existing, err := s.lookupRuntime(ctx, runtime.GetId())
+	switch {
+	case err == nil:
+		runtime = mergeRuntime(existing, runtime)
+	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
+	default:
+		return nil, err
+	}
+	if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
+		return nil, err
+	}
+	return &cerebrov1.PutSourceRuntimeResponse{Runtime: redactRuntime(runtime)}, nil
+}
+
+// Get returns one stored source runtime definition.
+func (s *Service) Get(ctx context.Context, req *cerebrov1.GetSourceRuntimeRequest) (*cerebrov1.GetSourceRuntimeResponse, error) {
+	runtime, err := s.lookupRuntime(ctx, req.GetId())
+	if err != nil {
+		return nil, err
+	}
+	return &cerebrov1.GetSourceRuntimeResponse{Runtime: redactRuntime(runtime)}, nil
+}
+
+// Sync advances one stored source runtime and appends emitted events.
+func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequest) (*cerebrov1.SyncSourceRuntimeResponse, error) {
+	if s == nil || s.store == nil || s.appendLog == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtime, err := s.lookupRuntime(ctx, req.GetId())
+	if err != nil {
+		return nil, err
+	}
+	source, err := s.lookupSource(runtime.GetSourceId())
+	if err != nil {
+		return nil, err
+	}
+	pageLimit, err := normalizePageLimit(req.GetPageLimit())
+	if err != nil {
+		return nil, err
+	}
+	cursor := cloneCursor(runtime.GetNextCursor())
+	var (
+		eventsAppended uint32
+		pagesRead      uint32
+	)
+	for i := uint32(0); i < pageLimit; i++ {
+		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtime.GetConfig()), cursor)
+		if err != nil {
+			return nil, err
+		}
+		if pull.Checkpoint != nil {
+			runtime.Checkpoint = cloneCheckpoint(pull.Checkpoint)
+		}
+		runtime.NextCursor = cloneCursor(pull.NextCursor)
+		if len(pull.Events) == 0 {
+			break
+		}
+		pagesRead++
+		for _, event := range pull.Events {
+			if err := s.appendLog.Append(ctx, event); err != nil {
+				return nil, fmt.Errorf("append source event %q: %w", event.GetId(), err)
+			}
+			eventsAppended++
+		}
+		if pull.NextCursor == nil {
+			break
+		}
+		cursor = cloneCursor(pull.NextCursor)
+	}
+	runtime.LastSyncedAt = timestamppb.Now()
+	if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
+		return nil, err
+	}
+	return &cerebrov1.SyncSourceRuntimeResponse{
+		Runtime:        redactRuntime(runtime),
+		Source:         source.Spec(),
+		PagesRead:      pagesRead,
+		EventsAppended: eventsAppended,
+	}, nil
+}
+
+func (s *Service) lookupSource(sourceID string) (sourcecdk.Source, error) {
+	id := strings.TrimSpace(sourceID)
+	if id == "" {
+		return nil, fmt.Errorf("source id is required")
+	}
+	if s == nil || s.registry == nil {
+		return nil, fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, id)
+	}
+	source, ok := s.registry.Get(id)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, id)
+	}
+	return source, nil
+}
+
+func (s *Service) lookupRuntime(ctx context.Context, runtimeID string) (*cerebrov1.SourceRuntime, error) {
+	id := strings.TrimSpace(runtimeID)
+	if id == "" {
+		return nil, fmt.Errorf("source runtime id is required")
+	}
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtime, err := s.store.GetSourceRuntime(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return runtime, nil
+}
+
+func normalizePageLimit(pageLimit uint32) (uint32, error) {
+	if pageLimit == 0 {
+		return defaultPageLimit, nil
+	}
+	if pageLimit > maxPageLimit {
+		return 0, fmt.Errorf("page_limit must be between 1 and %d", maxPageLimit)
+	}
+	return pageLimit, nil
+}
+
+func mergeRuntime(existing *cerebrov1.SourceRuntime, incoming *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {
+	if existing == nil {
+		return incoming
+	}
+	resetProgress := existing.GetSourceId() != incoming.GetSourceId() || !sameConfig(existing.GetConfig(), incoming.GetConfig())
+	if !resetProgress {
+		if incoming.GetCheckpoint() == nil {
+			incoming.Checkpoint = cloneCheckpoint(existing.GetCheckpoint())
+		}
+		if incoming.GetNextCursor() == nil {
+			incoming.NextCursor = cloneCursor(existing.GetNextCursor())
+		}
+		if incoming.GetLastSyncedAt() == nil {
+			incoming.LastSyncedAt = cloneTimestamp(existing.GetLastSyncedAt())
+		}
+	}
+	return incoming
+}
+
+func sameConfig(left map[string]string, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, value := range left {
+		if right[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func redactRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {
+	cloned := cloneRuntime(runtime)
+	if cloned == nil {
+		return nil
+	}
+	redacted := make(map[string]string, len(cloned.GetConfig()))
+	for key, value := range cloned.GetConfig() {
+		if sensitiveConfigKey(key) {
+			redacted[key] = redactedValue
+			continue
+		}
+		redacted[key] = value
+	}
+	cloned.Config = redacted
+	return cloned
+}
+
+func sensitiveConfigKey(key string) bool {
+	value := strings.ToLower(strings.TrimSpace(key))
+	if value == "" {
+		return false
+	}
+	if strings.Contains(value, "token") || strings.Contains(value, "secret") || strings.Contains(value, "password") {
+		return true
+	}
+	return value == "key" || strings.HasSuffix(value, "_key")
+}
+
+func cloneRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {
+	if runtime == nil {
+		return nil
+	}
+	return proto.Clone(runtime).(*cerebrov1.SourceRuntime)
+}
+
+func cloneCursor(cursor *cerebrov1.SourceCursor) *cerebrov1.SourceCursor {
+	if cursor == nil {
+		return nil
+	}
+	return proto.Clone(cursor).(*cerebrov1.SourceCursor)
+}
+
+func cloneCheckpoint(checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {
+	if checkpoint == nil {
+		return nil
+	}
+	return proto.Clone(checkpoint).(*cerebrov1.SourceCheckpoint)
+}
+
+func cloneTimestamp(value *timestamppb.Timestamp) *timestamppb.Timestamp {
+	if value == nil {
+		return nil
+	}
+	return proto.Clone(value).(*timestamppb.Timestamp)
+}

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -275,7 +275,7 @@ func sensitiveConfigKey(key string) bool {
 	if strings.Contains(value, "token") || strings.Contains(value, "secret") || strings.Contains(value, "password") {
 		return true
 	}
-	return value == "key" || strings.HasSuffix(value, "_key")
+	return value == "key" || strings.HasSuffix(value, "_key") || strings.HasSuffix(value, "key")
 }
 
 func cloneRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -133,6 +133,9 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		pagesRead++
 		for _, event := range pull.Events {
 			syncedEvent := materializeEvent(runtime, event)
+			if syncedEvent == nil {
+				return nil, fmt.Errorf("%w: source %q returned nil event", ErrInvalidRequest, runtime.GetSourceId())
+			}
 			if err := s.appendLog.Append(ctx, syncedEvent); err != nil {
 				return nil, fmt.Errorf("append source event %q: %w", syncedEvent.GetId(), err)
 			}

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -29,11 +29,12 @@ type Service struct {
 	registry  *sourcecdk.Registry
 	store     ports.SourceRuntimeStore
 	appendLog ports.AppendLog
+	projector ports.SourceProjector
 }
 
 // New constructs a source runtime service.
-func New(registry *sourcecdk.Registry, store ports.SourceRuntimeStore, appendLog ports.AppendLog) *Service {
-	return &Service{registry: registry, store: store, appendLog: appendLog}
+func New(registry *sourcecdk.Registry, store ports.SourceRuntimeStore, appendLog ports.AppendLog, projector ports.SourceProjector) *Service {
+	return &Service{registry: registry, store: store, appendLog: appendLog, projector: projector}
 }
 
 // Put validates and stores a source runtime definition.
@@ -47,6 +48,7 @@ func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeReques
 	runtime := cloneRuntime(req.GetRuntime())
 	runtime.Id = strings.TrimSpace(runtime.GetId())
 	runtime.SourceId = strings.TrimSpace(runtime.GetSourceId())
+	runtime.TenantId = strings.TrimSpace(runtime.GetTenantId())
 	if runtime.GetId() == "" {
 		return nil, fmt.Errorf("source runtime id is required")
 	}
@@ -99,8 +101,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	}
 	cursor := cloneCursor(runtime.GetNextCursor())
 	var (
-		eventsAppended uint32
-		pagesRead      uint32
+		eventsAppended    uint32
+		pagesRead         uint32
+		entitiesProjected uint32
+		linksProjected    uint32
 	)
 	for i := uint32(0); i < pageLimit; i++ {
 		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtime.GetConfig()), cursor)
@@ -116,10 +120,19 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		}
 		pagesRead++
 		for _, event := range pull.Events {
-			if err := s.appendLog.Append(ctx, event); err != nil {
-				return nil, fmt.Errorf("append source event %q: %w", event.GetId(), err)
+			syncedEvent := materializeEvent(runtime, event)
+			if err := s.appendLog.Append(ctx, syncedEvent); err != nil {
+				return nil, fmt.Errorf("append source event %q: %w", syncedEvent.GetId(), err)
 			}
 			eventsAppended++
+			if s.projector != nil {
+				result, err := s.projector.Project(ctx, syncedEvent)
+				if err != nil {
+					return nil, fmt.Errorf("project source event %q: %w", syncedEvent.GetId(), err)
+				}
+				entitiesProjected += result.EntitiesProjected
+				linksProjected += result.LinksProjected
+			}
 		}
 		if pull.NextCursor == nil {
 			break
@@ -131,10 +144,12 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		return nil, err
 	}
 	return &cerebrov1.SyncSourceRuntimeResponse{
-		Runtime:        redactRuntime(runtime),
-		Source:         source.Spec(),
-		PagesRead:      pagesRead,
-		EventsAppended: eventsAppended,
+		Runtime:           redactRuntime(runtime),
+		Source:            source.Spec(),
+		PagesRead:         pagesRead,
+		EventsAppended:    eventsAppended,
+		EntitiesProjected: entitiesProjected,
+		LinksProjected:    linksProjected,
 	}, nil
 }
 
@@ -182,7 +197,12 @@ func mergeRuntime(existing *cerebrov1.SourceRuntime, incoming *cerebrov1.SourceR
 	if existing == nil {
 		return incoming
 	}
-	resetProgress := existing.GetSourceId() != incoming.GetSourceId() || !sameConfig(existing.GetConfig(), incoming.GetConfig())
+	if strings.TrimSpace(incoming.GetTenantId()) == "" {
+		incoming.TenantId = strings.TrimSpace(existing.GetTenantId())
+	}
+	resetProgress := existing.GetSourceId() != incoming.GetSourceId() ||
+		existing.GetTenantId() != incoming.GetTenantId() ||
+		!sameConfig(existing.GetConfig(), incoming.GetConfig())
 	if !resetProgress {
 		if incoming.GetCheckpoint() == nil {
 			incoming.Checkpoint = cloneCheckpoint(existing.GetCheckpoint())
@@ -195,6 +215,17 @@ func mergeRuntime(existing *cerebrov1.SourceRuntime, incoming *cerebrov1.SourceR
 		}
 	}
 	return incoming
+}
+
+func materializeEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) *cerebrov1.EventEnvelope {
+	if event == nil {
+		return nil
+	}
+	cloned := proto.Clone(event).(*cerebrov1.EventEnvelope)
+	if runtime != nil && strings.TrimSpace(runtime.GetTenantId()) != "" {
+		cloned.TenantId = strings.TrimSpace(runtime.GetTenantId())
+	}
+	return cloned
 }
 
 func sameConfig(left map[string]string, right map[string]string) bool {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -24,6 +24,9 @@ const (
 // ErrRuntimeUnavailable indicates that the runtime dependencies are not configured.
 var ErrRuntimeUnavailable = errors.New("source runtime is unavailable")
 
+// ErrInvalidRequest indicates that a source runtime request is malformed.
+var ErrInvalidRequest = errors.New("invalid source runtime request")
+
 // Service persists and executes source runtimes against the append log.
 type Service struct {
 	registry  *sourcecdk.Registry
@@ -43,21 +46,21 @@ func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeReques
 		return nil, ErrRuntimeUnavailable
 	}
 	if req == nil || req.GetRuntime() == nil {
-		return nil, fmt.Errorf("source runtime is required")
+		return nil, fmt.Errorf("%w: source runtime is required", ErrInvalidRequest)
 	}
 	runtime := cloneRuntime(req.GetRuntime())
 	runtime.Id = strings.TrimSpace(runtime.GetId())
 	runtime.SourceId = strings.TrimSpace(runtime.GetSourceId())
 	runtime.TenantId = strings.TrimSpace(runtime.GetTenantId())
 	if runtime.GetId() == "" {
-		return nil, fmt.Errorf("source runtime id is required")
+		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
 	}
 	source, err := s.lookupSource(runtime.GetSourceId())
 	if err != nil {
 		return nil, err
 	}
 	if err := source.Check(ctx, sourcecdk.NewConfig(runtime.GetConfig())); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: source check failed: %w", ErrInvalidRequest, err)
 	}
 	existing, err := s.lookupRuntime(ctx, runtime.GetId())
 	switch {
@@ -75,6 +78,9 @@ func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeReques
 
 // Get returns one stored source runtime definition.
 func (s *Service) Get(ctx context.Context, req *cerebrov1.GetSourceRuntimeRequest) (*cerebrov1.GetSourceRuntimeResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
+	}
 	runtime, err := s.lookupRuntime(ctx, req.GetId())
 	if err != nil {
 		return nil, err
@@ -87,6 +93,9 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	if s == nil || s.store == nil || s.appendLog == nil {
 		return nil, ErrRuntimeUnavailable
 	}
+	if req == nil {
+		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
+	}
 	runtime, err := s.lookupRuntime(ctx, req.GetId())
 	if err != nil {
 		return nil, err
@@ -97,7 +106,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	}
 	pageLimit, err := normalizePageLimit(req.GetPageLimit())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 	}
 	cursor := cloneCursor(runtime.GetNextCursor())
 	var (
@@ -156,7 +165,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 func (s *Service) lookupSource(sourceID string) (sourcecdk.Source, error) {
 	id := strings.TrimSpace(sourceID)
 	if id == "" {
-		return nil, fmt.Errorf("source id is required")
+		return nil, fmt.Errorf("%w: source id is required", ErrInvalidRequest)
 	}
 	if s == nil || s.registry == nil {
 		return nil, fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, id)
@@ -171,7 +180,7 @@ func (s *Service) lookupSource(sourceID string) (sourcecdk.Source, error) {
 func (s *Service) lookupRuntime(ctx context.Context, runtimeID string) (*cerebrov1.SourceRuntime, error) {
 	id := strings.TrimSpace(runtimeID)
 	if id == "" {
-		return nil, fmt.Errorf("source runtime id is required")
+		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
 	}
 	if s == nil || s.store == nil {
 		return nil, ErrRuntimeUnavailable

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -62,16 +62,34 @@ func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeReques
 	if err != nil {
 		return nil, err
 	}
-	if err := source.Check(ctx, sourcecdk.NewConfig(runtime.GetConfig())); err != nil {
-		return nil, fmt.Errorf("%w: source check failed: %w", ErrInvalidRequest, err)
-	}
 	existing, err := s.lookupRuntime(ctx, runtime.GetId())
 	switch {
 	case err == nil:
-		runtime = mergeRuntime(existing, runtime)
+		if runtime.Config == nil {
+			runtime.Config = map[string]string{}
+		}
+		for key, value := range existing.GetConfig() {
+			if !sensitiveConfigKey(key) {
+				continue
+			}
+			incoming, ok := runtime.Config[key]
+			if !ok || incoming == redactedValue {
+				runtime.Config[key] = value
+			}
+		}
+		runtime.Checkpoint = nil
+		runtime.NextCursor = nil
+		runtime.LastSyncedAt = nil
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
+		existing = nil
 	default:
 		return nil, err
+	}
+	if err := source.Check(ctx, sourcecdk.NewConfig(runtime.GetConfig())); err != nil {
+		return nil, fmt.Errorf("%w: source check failed: %w", ErrInvalidRequest, err)
+	}
+	if existing != nil {
+		runtime = mergeRuntime(existing, runtime)
 	}
 	if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
 		return nil, err
@@ -148,6 +166,9 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 				entitiesProjected += result.EntitiesProjected
 				linksProjected += result.LinksProjected
 			}
+		}
+		if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
+			return nil, err
 		}
 		if pull.NextCursor == nil {
 			break

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -111,7 +111,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 	}
-	cursor := cloneCursor(runtime.GetNextCursor())
+	cursor := resumeCursor(runtime)
 	var (
 		eventsAppended    uint32
 		pagesRead         uint32
@@ -306,6 +306,19 @@ func cloneCursor(cursor *cerebrov1.SourceCursor) *cerebrov1.SourceCursor {
 		return nil
 	}
 	return proto.Clone(cursor).(*cerebrov1.SourceCursor)
+}
+
+func resumeCursor(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceCursor {
+	if runtime == nil {
+		return nil
+	}
+	if cursor := cloneCursor(runtime.GetNextCursor()); cursor != nil {
+		return cursor
+	}
+	if runtime.GetCheckpoint().GetCursorOpaque() == "" {
+		return nil
+	}
+	return &cerebrov1.SourceCursor{Opaque: runtime.GetCheckpoint().GetCursorOpaque()}
 }
 
 func cloneCheckpoint(checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -233,7 +233,8 @@ func sameConfig(left map[string]string, right map[string]string) bool {
 		return false
 	}
 	for key, value := range left {
-		if right[key] != value {
+		other, ok := right[key]
+		if !ok || other != value {
 			return false
 		}
 	}

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1,0 +1,207 @@
+package sourceruntime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	githubsource "github.com/writer/cerebro/sources/github"
+	oktasource "github.com/writer/cerebro/sources/okta"
+)
+
+type runtimeStore struct {
+	runtimes map[string]*cerebrov1.SourceRuntime
+	err      error
+}
+
+func (s *runtimeStore) Ping(context.Context) error {
+	return s.err
+}
+
+func (s *runtimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {
+	if s.err != nil {
+		return s.err
+	}
+	if s.runtimes == nil {
+		s.runtimes = make(map[string]*cerebrov1.SourceRuntime)
+	}
+	s.runtimes[runtime.GetId()] = proto.Clone(runtime).(*cerebrov1.SourceRuntime)
+	return nil
+}
+
+func (s *runtimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov1.SourceRuntime, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	runtime, ok := s.runtimes[id]
+	if !ok {
+		return nil, ports.ErrSourceRuntimeNotFound
+	}
+	return proto.Clone(runtime).(*cerebrov1.SourceRuntime), nil
+}
+
+type appendLog struct {
+	err    error
+	events []*cerebrov1.EventEnvelope
+}
+
+func (l *appendLog) Ping(context.Context) error {
+	return l.err
+}
+
+func (l *appendLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) error {
+	if l.err != nil {
+		return l.err
+	}
+	l.events = append(l.events, proto.Clone(event).(*cerebrov1.EventEnvelope))
+	return nil
+}
+
+func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	store := &runtimeStore{}
+	service := New(registry, store, nil)
+
+	putResp, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-okta-users",
+			SourceId: "okta",
+			Config: map[string]string{
+				"domain": "writer.okta.com",
+				"family": "user",
+				"token":  "super-secret",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if got := putResp.GetRuntime().GetConfig()["token"]; got != redactedValue {
+		t.Fatalf("Put().Runtime.Config[token] = %q, want %q", got, redactedValue)
+	}
+
+	getResp, err := service.Get(context.Background(), &cerebrov1.GetSourceRuntimeRequest{Id: "writer-okta-users"})
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got := getResp.GetRuntime().GetConfig()["token"]; got != redactedValue {
+		t.Fatalf("Get().Runtime.Config[token] = %q, want %q", got, redactedValue)
+	}
+	if got := store.runtimes["writer-okta-users"].GetConfig()["token"]; got != "super-secret" {
+		t.Fatalf("stored runtime token = %q, want %q", got, "super-secret")
+	}
+}
+
+func TestPutPreservesProgressWhenConfigIsUnchanged(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				Config:   map[string]string{"token": "test"},
+				Checkpoint: &cerebrov1.SourceCheckpoint{
+					CursorOpaque: "1",
+				},
+				NextCursor:   &cerebrov1.SourceCursor{Opaque: "1"},
+				LastSyncedAt: timestamppb.Now(),
+			},
+		},
+	}
+	service := New(registry, store, nil)
+
+	resp, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-github",
+			SourceId: "github",
+			Config:   map[string]string{"token": "test"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if resp.GetRuntime().GetNextCursor().GetOpaque() != "1" {
+		t.Fatalf("Put().Runtime.NextCursor = %#v, want cursor 1", resp.GetRuntime().GetNextCursor())
+	}
+}
+
+func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				Config:   map[string]string{"token": "test"},
+			},
+		},
+	}
+	log := &appendLog{}
+	service := New(registry, store, log)
+
+	resp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
+		Id:        "writer-github",
+		PageLimit: 2,
+	})
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if resp.GetEventsAppended() != 2 {
+		t.Fatalf("Sync().EventsAppended = %d, want 2", resp.GetEventsAppended())
+	}
+	if resp.GetPagesRead() != 2 {
+		t.Fatalf("Sync().PagesRead = %d, want 2", resp.GetPagesRead())
+	}
+	if len(log.events) != 2 {
+		t.Fatalf("len(appendLog.events) = %d, want 2", len(log.events))
+	}
+	runtime := store.runtimes["writer-github"]
+	if runtime.GetCheckpoint().GetCursorOpaque() != "2" {
+		t.Fatalf("stored checkpoint cursor = %q, want %q", runtime.GetCheckpoint().GetCursorOpaque(), "2")
+	}
+	if runtime.GetNextCursor() != nil {
+		t.Fatalf("stored next cursor = %#v, want nil", runtime.GetNextCursor())
+	}
+	if runtime.GetLastSyncedAt() == nil {
+		t.Fatal("stored last_synced_at = nil, want non-nil")
+	}
+}
+
+func TestSyncRuntimeRequiresDependencies(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	service := New(registry, nil, nil)
+	_, err = service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-github"})
+	if !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("Sync() error = %v, want ErrRuntimeUnavailable", err)
+	}
+}
+
+func newFixtureRegistry() (*sourcecdk.Registry, error) {
+	github, err := githubsource.NewFixture()
+	if err != nil {
+		return nil, err
+	}
+	okta, err := oktasource.NewFixture()
+	if err != nil {
+		return nil, err
+	}
+	return sourcecdk.NewRegistry(github, okta)
+}

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -90,9 +90,11 @@ func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 			Id:       "writer-okta-users",
 			SourceId: "okta",
 			Config: map[string]string{
-				"domain": "writer.okta.com",
-				"family": "user",
-				"token":  "super-secret",
+				"apiKey":     "api-key-value",
+				"domain":     "writer.okta.com",
+				"family":     "user",
+				"privateKey": "private-key-value",
+				"token":      "super-secret",
 			},
 		},
 	})
@@ -102,6 +104,12 @@ func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 	if got := putResp.GetRuntime().GetConfig()["token"]; got != redactedValue {
 		t.Fatalf("Put().Runtime.Config[token] = %q, want %q", got, redactedValue)
 	}
+	if got := putResp.GetRuntime().GetConfig()["apiKey"]; got != redactedValue {
+		t.Fatalf("Put().Runtime.Config[apiKey] = %q, want %q", got, redactedValue)
+	}
+	if got := putResp.GetRuntime().GetConfig()["privateKey"]; got != redactedValue {
+		t.Fatalf("Put().Runtime.Config[privateKey] = %q, want %q", got, redactedValue)
+	}
 
 	getResp, err := service.Get(context.Background(), &cerebrov1.GetSourceRuntimeRequest{Id: "writer-okta-users"})
 	if err != nil {
@@ -110,8 +118,17 @@ func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 	if got := getResp.GetRuntime().GetConfig()["token"]; got != redactedValue {
 		t.Fatalf("Get().Runtime.Config[token] = %q, want %q", got, redactedValue)
 	}
+	if got := getResp.GetRuntime().GetConfig()["apiKey"]; got != redactedValue {
+		t.Fatalf("Get().Runtime.Config[apiKey] = %q, want %q", got, redactedValue)
+	}
+	if got := getResp.GetRuntime().GetConfig()["privateKey"]; got != redactedValue {
+		t.Fatalf("Get().Runtime.Config[privateKey] = %q, want %q", got, redactedValue)
+	}
 	if got := store.runtimes["writer-okta-users"].GetConfig()["token"]; got != "super-secret" {
 		t.Fatalf("stored runtime token = %q, want %q", got, "super-secret")
+	}
+	if got := store.runtimes["writer-okta-users"].GetConfig()["apiKey"]; got != "api-key-value" {
+		t.Fatalf("stored runtime apiKey = %q, want api-key-value", got)
 	}
 }
 

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -306,6 +306,12 @@ func TestSyncRuntimeRequiresDependencies(t *testing.T) {
 	}
 }
 
+func TestSameConfigComparesKeyPresence(t *testing.T) {
+	if sameConfig(map[string]string{"a": ""}, map[string]string{"b": ""}) {
+		t.Fatal("sameConfig() = true, want false for different key sets")
+	}
+}
+
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	github, err := githubsource.NewFixture()
 	if err != nil {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -132,6 +132,28 @@ func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 	}
 }
 
+func TestPutRejectsReservedConfigKeys(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	service := New(registry, &runtimeStore{}, nil, nil)
+
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-github",
+			SourceId: "github",
+			Config: map[string]string{
+				"base_url": "https://attacker.example.com",
+				"token":    "test",
+			},
+		},
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Put() error = %v, want %v", err, ErrInvalidRequest)
+	}
+}
+
 func TestPutPreservesProgressWhenConfigIsUnchanged(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -77,6 +77,22 @@ func (p *projector) Project(_ context.Context, event *cerebrov1.EventEnvelope) (
 	return p.result, nil
 }
 
+type nilEventSource struct{}
+
+func (nilEventSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "nil-events", Name: "Nil Events"}
+}
+
+func (nilEventSource) Check(context.Context, sourcecdk.Config) error { return nil }
+
+func (nilEventSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (nilEventSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{Events: []*cerebrov1.EventEnvelope{nil}}, nil
+}
+
 func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
@@ -330,6 +346,35 @@ func TestSyncRuntimeProjectsWithRuntimeTenant(t *testing.T) {
 	}
 	if got := projector.events[0].GetTenantId(); got != "writer" {
 		t.Fatalf("projected event tenant_id = %q, want %q", got, "writer")
+	}
+}
+
+func TestSyncRuntimeRejectsNilSourceEvent(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(nilEventSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-nil-events": {
+				Id:       "writer-nil-events",
+				SourceId: "nil-events",
+				TenantId: "writer",
+			},
+		},
+	}
+	log := &appendLog{}
+	service := New(registry, store, log, nil)
+
+	_, err = service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-nil-events"})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Sync() error = %v, want ErrInvalidRequest", err)
+	}
+	if len(log.events) != 0 {
+		t.Fatalf("len(appendLog.events) = %d, want 0", len(log.events))
+	}
+	if got := store.runtimes["writer-nil-events"].GetLastSyncedAt(); got != nil {
+		t.Fatalf("stored last_synced_at = %#v, want nil", got)
 	}
 }
 

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -253,6 +253,27 @@ func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 	if runtime.GetLastSyncedAt() == nil {
 		t.Fatal("stored last_synced_at = nil, want non-nil")
 	}
+
+	secondResp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
+		Id:        "writer-github",
+		PageLimit: 1,
+	})
+	if err != nil {
+		t.Fatalf("Sync(second) error = %v", err)
+	}
+	if secondResp.GetEventsAppended() != 0 {
+		t.Fatalf("Sync(second).EventsAppended = %d, want 0", secondResp.GetEventsAppended())
+	}
+	if secondResp.GetPagesRead() != 0 {
+		t.Fatalf("Sync(second).PagesRead = %d, want 0", secondResp.GetPagesRead())
+	}
+	if len(log.events) != 2 {
+		t.Fatalf("len(appendLog.events) after second sync = %d, want 2", len(log.events))
+	}
+	runtime = store.runtimes["writer-github"]
+	if runtime.GetCheckpoint().GetCursorOpaque() != "2" {
+		t.Fatalf("stored checkpoint cursor after second sync = %q, want %q", runtime.GetCheckpoint().GetCursorOpaque(), "2")
+	}
 }
 
 func TestPutResetsProgressWhenTenantChanges(t *testing.T) {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -47,8 +47,10 @@ func (s *runtimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov
 }
 
 type appendLog struct {
-	err    error
-	events []*cerebrov1.EventEnvelope
+	err        error
+	events     []*cerebrov1.EventEnvelope
+	calls      int
+	failOnCall int
 }
 
 func (l *appendLog) Ping(context.Context) error {
@@ -58,6 +60,10 @@ func (l *appendLog) Ping(context.Context) error {
 func (l *appendLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) error {
 	if l.err != nil {
 		return l.err
+	}
+	l.calls++
+	if l.failOnCall > 0 && l.calls == l.failOnCall {
+		return errors.New("append failed")
 	}
 	l.events = append(l.events, proto.Clone(event).(*cerebrov1.EventEnvelope))
 	return nil
@@ -210,6 +216,70 @@ func TestPutPreservesProgressWhenConfigIsUnchanged(t *testing.T) {
 	}
 }
 
+func TestPutPreservesSensitiveConfigAndServerProgressOnUpdate(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	syncedAt := timestamppb.Now()
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-users": {
+				Id:       "writer-okta-users",
+				SourceId: "okta",
+				TenantId: "writer",
+				Config: map[string]string{
+					"domain": "writer.okta.com",
+					"family": "user",
+					"token":  "super-secret",
+				},
+				Checkpoint:   &cerebrov1.SourceCheckpoint{CursorOpaque: "1"},
+				NextCursor:   &cerebrov1.SourceCursor{Opaque: "1"},
+				LastSyncedAt: syncedAt,
+			},
+		},
+	}
+	service := New(registry, store, nil, nil)
+
+	resp, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-okta-users",
+			SourceId: "okta",
+			Config: map[string]string{
+				"domain": "writer.okta.com",
+				"family": "user",
+			},
+			Checkpoint:   &cerebrov1.SourceCheckpoint{CursorOpaque: "999"},
+			NextCursor:   &cerebrov1.SourceCursor{Opaque: "999"},
+			LastSyncedAt: timestamppb.Now(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if got := resp.GetRuntime().GetConfig()["token"]; got != redactedValue {
+		t.Fatalf("Put().Runtime.Config[token] = %q, want %q", got, redactedValue)
+	}
+	if got := resp.GetRuntime().GetCheckpoint().GetCursorOpaque(); got != "1" {
+		t.Fatalf("Put().Runtime.Checkpoint = %#v, want cursor 1", resp.GetRuntime().GetCheckpoint())
+	}
+	if got := resp.GetRuntime().GetNextCursor().GetOpaque(); got != "1" {
+		t.Fatalf("Put().Runtime.NextCursor = %#v, want cursor 1", resp.GetRuntime().GetNextCursor())
+	}
+	if got := store.runtimes["writer-okta-users"].GetConfig()["token"]; got != "super-secret" {
+		t.Fatalf("stored runtime token = %q, want super-secret", got)
+	}
+	if got := store.runtimes["writer-okta-users"].GetCheckpoint().GetCursorOpaque(); got != "1" {
+		t.Fatalf("stored checkpoint = %#v, want cursor 1", store.runtimes["writer-okta-users"].GetCheckpoint())
+	}
+	if got := store.runtimes["writer-okta-users"].GetNextCursor().GetOpaque(); got != "1" {
+		t.Fatalf("stored next cursor = %#v, want cursor 1", store.runtimes["writer-okta-users"].GetNextCursor())
+	}
+	if got := store.runtimes["writer-okta-users"].GetLastSyncedAt(); got == nil || !got.AsTime().Equal(syncedAt.AsTime()) {
+		t.Fatalf("stored last_synced_at = %#v, want existing timestamp", got)
+	}
+}
+
 func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
@@ -273,6 +343,63 @@ func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 	runtime = store.runtimes["writer-github"]
 	if runtime.GetCheckpoint().GetCursorOpaque() != "2" {
 		t.Fatalf("stored checkpoint cursor after second sync = %q, want %q", runtime.GetCheckpoint().GetCursorOpaque(), "2")
+	}
+}
+
+func TestSyncRuntimePersistsProgressAfterEachPage(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				Config:   map[string]string{"token": "test"},
+			},
+		},
+	}
+	log := &appendLog{failOnCall: 2}
+	service := New(registry, store, log, nil)
+
+	if _, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
+		Id:        "writer-github",
+		PageLimit: 2,
+	}); err == nil {
+		t.Fatal("Sync() error = nil, want append failure")
+	}
+	if len(log.events) != 1 {
+		t.Fatalf("len(appendLog.events) = %d, want 1", len(log.events))
+	}
+	runtime := store.runtimes["writer-github"]
+	if got := runtime.GetCheckpoint().GetCursorOpaque(); got != "1" {
+		t.Fatalf("stored checkpoint cursor = %q, want %q", got, "1")
+	}
+	if got := runtime.GetNextCursor().GetOpaque(); got != "1" {
+		t.Fatalf("stored next cursor = %#v, want cursor 1", runtime.GetNextCursor())
+	}
+	if got := runtime.GetLastSyncedAt(); got != nil {
+		t.Fatalf("stored last_synced_at = %#v, want nil", got)
+	}
+
+	log.failOnCall = 0
+	resp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
+		Id:        "writer-github",
+		PageLimit: 2,
+	})
+	if err != nil {
+		t.Fatalf("Sync(retry) error = %v", err)
+	}
+	if resp.GetEventsAppended() != 1 {
+		t.Fatalf("Sync(retry).EventsAppended = %d, want 1", resp.GetEventsAppended())
+	}
+	if len(log.events) != 2 {
+		t.Fatalf("len(appendLog.events) after retry = %d, want 2", len(log.events))
+	}
+	runtime = store.runtimes["writer-github"]
+	if got := runtime.GetCheckpoint().GetCursorOpaque(); got != "2" {
+		t.Fatalf("stored checkpoint cursor after retry = %q, want %q", got, "2")
 	}
 }
 

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -63,13 +63,27 @@ func (l *appendLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) er
 	return nil
 }
 
+type projector struct {
+	err    error
+	result ports.ProjectionResult
+	events []*cerebrov1.EventEnvelope
+}
+
+func (p *projector) Project(_ context.Context, event *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
+	if p.err != nil {
+		return ports.ProjectionResult{}, p.err
+	}
+	p.events = append(p.events, proto.Clone(event).(*cerebrov1.EventEnvelope))
+	return p.result, nil
+}
+
 func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
 		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
 	store := &runtimeStore{}
-	service := New(registry, store, nil)
+	service := New(registry, store, nil, nil)
 
 	putResp, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
 		Runtime: &cerebrov1.SourceRuntime{
@@ -111,6 +125,7 @@ func TestPutPreservesProgressWhenConfigIsUnchanged(t *testing.T) {
 			"writer-github": {
 				Id:       "writer-github",
 				SourceId: "github",
+				TenantId: "writer",
 				Config:   map[string]string{"token": "test"},
 				Checkpoint: &cerebrov1.SourceCheckpoint{
 					CursorOpaque: "1",
@@ -120,7 +135,7 @@ func TestPutPreservesProgressWhenConfigIsUnchanged(t *testing.T) {
 			},
 		},
 	}
-	service := New(registry, store, nil)
+	service := New(registry, store, nil, nil)
 
 	resp, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
 		Runtime: &cerebrov1.SourceRuntime{
@@ -131,6 +146,9 @@ func TestPutPreservesProgressWhenConfigIsUnchanged(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Put() error = %v", err)
+	}
+	if resp.GetRuntime().GetTenantId() != "writer" {
+		t.Fatalf("Put().Runtime.TenantId = %q, want %q", resp.GetRuntime().GetTenantId(), "writer")
 	}
 	if resp.GetRuntime().GetNextCursor().GetOpaque() != "1" {
 		t.Fatalf("Put().Runtime.NextCursor = %#v, want cursor 1", resp.GetRuntime().GetNextCursor())
@@ -152,7 +170,7 @@ func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 		},
 	}
 	log := &appendLog{}
-	service := New(registry, store, log)
+	service := New(registry, store, log, nil)
 
 	resp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
 		Id:        "writer-github",
@@ -182,12 +200,106 @@ func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 	}
 }
 
+func TestPutResetsProgressWhenTenantChanges(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				TenantId: "writer",
+				Config:   map[string]string{"token": "test"},
+				Checkpoint: &cerebrov1.SourceCheckpoint{
+					CursorOpaque: "1",
+				},
+				NextCursor:   &cerebrov1.SourceCursor{Opaque: "1"},
+				LastSyncedAt: timestamppb.Now(),
+			},
+		},
+	}
+	service := New(registry, store, nil, nil)
+
+	resp, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-github",
+			SourceId: "github",
+			TenantId: "writer-next",
+			Config:   map[string]string{"token": "test"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if got := resp.GetRuntime().GetCheckpoint(); got != nil {
+		t.Fatalf("Put().Runtime.Checkpoint = %#v, want nil", got)
+	}
+	if got := resp.GetRuntime().GetNextCursor(); got != nil {
+		t.Fatalf("Put().Runtime.NextCursor = %#v, want nil", got)
+	}
+	if got := resp.GetRuntime().GetLastSyncedAt(); got != nil {
+		t.Fatalf("Put().Runtime.LastSyncedAt = %#v, want nil", got)
+	}
+}
+
+func TestSyncRuntimeProjectsWithRuntimeTenant(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-users": {
+				Id:       "writer-okta-users",
+				SourceId: "okta",
+				TenantId: "writer",
+				Config: map[string]string{
+					"domain": "writer.okta.com",
+					"family": "user",
+					"token":  "test",
+				},
+			},
+		},
+	}
+	log := &appendLog{}
+	projector := &projector{result: ports.ProjectionResult{EntitiesProjected: 3, LinksProjected: 2}}
+	service := New(registry, store, log, projector)
+
+	resp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
+		Id:        "writer-okta-users",
+		PageLimit: 1,
+	})
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if resp.GetEntitiesProjected() != 3 {
+		t.Fatalf("Sync().EntitiesProjected = %d, want 3", resp.GetEntitiesProjected())
+	}
+	if resp.GetLinksProjected() != 2 {
+		t.Fatalf("Sync().LinksProjected = %d, want 2", resp.GetLinksProjected())
+	}
+	if len(log.events) != 1 {
+		t.Fatalf("len(appendLog.events) = %d, want 1", len(log.events))
+	}
+	if got := log.events[0].GetTenantId(); got != "writer" {
+		t.Fatalf("appended event tenant_id = %q, want %q", got, "writer")
+	}
+	if len(projector.events) != 1 {
+		t.Fatalf("len(projector.events) = %d, want 1", len(projector.events))
+	}
+	if got := projector.events[0].GetTenantId(); got != "writer" {
+		t.Fatalf("projected event tenant_id = %q, want %q", got, "writer")
+	}
+}
+
 func TestSyncRuntimeRequiresDependencies(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
 		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
-	service := New(registry, nil, nil)
+	service := New(registry, nil, nil, nil)
 	_, err = service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-github"})
 	if !errors.Is(err, ErrRuntimeUnavailable) {
 		t.Fatalf("Sync() error = %v, want ErrRuntimeUnavailable", err)

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -306,6 +306,24 @@ func TestSyncRuntimeRequiresDependencies(t *testing.T) {
 	}
 }
 
+func TestGetRejectsNilRequest(t *testing.T) {
+	service := New(nil, &runtimeStore{}, nil, nil)
+	if _, err := service.Get(context.Background(), nil); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Get() error = %v, want ErrInvalidRequest", err)
+	}
+}
+
+func TestSyncRejectsNilRequest(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	service := New(registry, &runtimeStore{}, &appendLog{}, nil)
+	if _, err := service.Sync(context.Background(), nil); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Sync() error = %v, want ErrInvalidRequest", err)
+	}
+}
+
 func TestSameConfigComparesKeyPresence(t *testing.T) {
 	if sameConfig(map[string]string{"a": ""}, map[string]string{"b": ""}) {
 		t.Fatal("sameConfig() = true, want false for different key sets")

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 
@@ -14,7 +15,9 @@ import (
 
 // Store is the Postgres-backed current-state store implementation.
 type Store struct {
-	db *sql.DB
+	db                    *sql.DB
+	projectionTablesMu    sync.Mutex
+	projectionTablesReady bool
 }
 
 // Open opens a Postgres-backed current-state store.

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -16,8 +16,9 @@ import (
 // Store is the Postgres-backed current-state store implementation.
 type Store struct {
 	db                    *sql.DB
-	projectionTablesMu    sync.Mutex
+	schemaMu              sync.Mutex
 	projectionTablesReady bool
+	sourceRuntimeReady    bool
 }
 
 // Open opens a Postgres-backed current-state store.

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -78,7 +78,7 @@ DO UPDATE SET
   source_id = EXCLUDED.source_id,
   entity_type = EXCLUDED.entity_type,
   label = EXCLUDED.label,
-  attributes_json = EXCLUDED.attributes_json,
+  attributes_json = entities.attributes_json || EXCLUDED.attributes_json,
   updated_at = NOW()`, urn, tenantID, sourceID, entityType, label, attributesJSON); err != nil {
 		return fmt.Errorf("upsert projected entity %q: %w", urn, err)
 	}

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -135,8 +135,8 @@ DO UPDATE SET
 }
 
 func (s *Store) ensureProjectionTables(ctx context.Context) error {
-	s.projectionTablesMu.Lock()
-	defer s.projectionTablesMu.Unlock()
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
 	if s.projectionTablesReady {
 		return nil
 	}

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -135,11 +135,17 @@ DO UPDATE SET
 }
 
 func (s *Store) ensureProjectionTables(ctx context.Context) error {
+	s.projectionTablesMu.Lock()
+	defer s.projectionTablesMu.Unlock()
+	if s.projectionTablesReady {
+		return nil
+	}
 	for _, statement := range ensureProjectionStatements {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {
 			return fmt.Errorf("ensure projection tables: %w", err)
 		}
 	}
+	s.projectionTablesReady = true
 	return nil
 }
 

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -1,0 +1,155 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureProjectionStatements = []string{
+	`CREATE TABLE IF NOT EXISTS entities (
+  urn TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  label TEXT NOT NULL,
+  attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS entities_tenant_type_idx ON entities (tenant_id, entity_type)`,
+	`CREATE TABLE IF NOT EXISTS entity_links (
+  from_urn TEXT NOT NULL,
+  relation TEXT NOT NULL,
+  to_urn TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (from_urn, relation, to_urn)
+)`,
+	`CREATE INDEX IF NOT EXISTS entity_links_tenant_relation_idx ON entity_links (tenant_id, relation)`,
+}
+
+// UpsertProjectedEntity persists one normalized entity in the current-state store.
+func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.ProjectedEntity) error {
+	if entity == nil {
+		return errors.New("projected entity is required")
+	}
+	urn := strings.TrimSpace(entity.URN)
+	if urn == "" {
+		return errors.New("projected entity urn is required")
+	}
+	tenantID := strings.TrimSpace(entity.TenantID)
+	if tenantID == "" {
+		return errors.New("projected entity tenant id is required")
+	}
+	sourceID := strings.TrimSpace(entity.SourceID)
+	if sourceID == "" {
+		return errors.New("projected entity source id is required")
+	}
+	entityType := strings.TrimSpace(entity.EntityType)
+	if entityType == "" {
+		return errors.New("projected entity type is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureProjectionTables(ctx); err != nil {
+		return err
+	}
+	attributesJSON, err := projectionAttributesJSON(entity.Attributes)
+	if err != nil {
+		return fmt.Errorf("marshal projected entity attributes: %w", err)
+	}
+	label := strings.TrimSpace(entity.Label)
+	if label == "" {
+		label = urn
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO entities (urn, tenant_id, source_id, entity_type, label, attributes_json)
+VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+ON CONFLICT (urn)
+DO UPDATE SET
+  tenant_id = EXCLUDED.tenant_id,
+  source_id = EXCLUDED.source_id,
+  entity_type = EXCLUDED.entity_type,
+  label = EXCLUDED.label,
+  attributes_json = EXCLUDED.attributes_json,
+  updated_at = NOW()`, urn, tenantID, sourceID, entityType, label, attributesJSON); err != nil {
+		return fmt.Errorf("upsert projected entity %q: %w", urn, err)
+	}
+	return nil
+}
+
+// UpsertProjectedLink persists one normalized link in the current-state store.
+func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return errors.New("projected link is required")
+	}
+	fromURN := strings.TrimSpace(link.FromURN)
+	if fromURN == "" {
+		return errors.New("projected link from urn is required")
+	}
+	toURN := strings.TrimSpace(link.ToURN)
+	if toURN == "" {
+		return errors.New("projected link to urn is required")
+	}
+	relation := strings.TrimSpace(link.Relation)
+	if relation == "" {
+		return errors.New("projected link relation is required")
+	}
+	tenantID := strings.TrimSpace(link.TenantID)
+	if tenantID == "" {
+		return errors.New("projected link tenant id is required")
+	}
+	sourceID := strings.TrimSpace(link.SourceID)
+	if sourceID == "" {
+		return errors.New("projected link source id is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureProjectionTables(ctx); err != nil {
+		return err
+	}
+	attributesJSON, err := projectionAttributesJSON(link.Attributes)
+	if err != nil {
+		return fmt.Errorf("marshal projected link attributes: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO entity_links (from_urn, relation, to_urn, tenant_id, source_id, attributes_json)
+VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+ON CONFLICT (from_urn, relation, to_urn)
+DO UPDATE SET
+  tenant_id = EXCLUDED.tenant_id,
+  source_id = EXCLUDED.source_id,
+  attributes_json = EXCLUDED.attributes_json,
+  updated_at = NOW()`, fromURN, relation, toURN, tenantID, sourceID, attributesJSON); err != nil {
+		return fmt.Errorf("upsert projected link %q %q %q: %w", fromURN, relation, toURN, err)
+	}
+	return nil
+}
+
+func (s *Store) ensureProjectionTables(ctx context.Context) error {
+	for _, statement := range ensureProjectionStatements {
+		if _, err := s.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("ensure projection tables: %w", err)
+		}
+	}
+	return nil
+}
+
+func projectionAttributesJSON(attributes map[string]string) (string, error) {
+	if len(attributes) == 0 {
+		return `{}`, nil
+	}
+	payload, err := json.Marshal(attributes)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -127,7 +127,7 @@ ON CONFLICT (from_urn, relation, to_urn)
 DO UPDATE SET
   tenant_id = EXCLUDED.tenant_id,
   source_id = EXCLUDED.source_id,
-  attributes_json = EXCLUDED.attributes_json,
+  attributes_json = entity_links.attributes_json || EXCLUDED.attributes_json,
   updated_at = NOW()`, fromURN, relation, toURN, tenantID, sourceID, attributesJSON); err != nil {
 		return fmt.Errorf("upsert projected link %q %q %q: %w", fromURN, relation, toURN, err)
 	}

--- a/internal/statestore/postgres/projection_test.go
+++ b/internal/statestore/postgres/projection_test.go
@@ -1,0 +1,41 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestUpsertProjectedEntityRejectsNilEntity(t *testing.T) {
+	store := &Store{}
+	if err := store.UpsertProjectedEntity(context.Background(), nil); err == nil {
+		t.Fatal("UpsertProjectedEntity() error = nil, want non-nil")
+	}
+}
+
+func TestUpsertProjectedEntityRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	err := store.UpsertProjectedEntity(context.Background(), &ports.ProjectedEntity{
+		URN:        "urn:cerebro:writer:github_user:alice",
+		TenantID:   "writer",
+		SourceID:   "github",
+		EntityType: "github.user",
+	})
+	if err == nil {
+		t.Fatal("UpsertProjectedEntity() error = nil, want non-nil")
+	}
+}
+
+func TestUpsertProjectedLinkRejectsMissingRelation(t *testing.T) {
+	store := &Store{}
+	err := store.UpsertProjectedLink(context.Background(), &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "github",
+		FromURN:  "urn:cerebro:writer:github_user:alice",
+		ToURN:    "urn:cerebro:writer:github_repo:writer/cerebro",
+	})
+	if err == nil {
+		t.Fatal("UpsertProjectedLink() error = nil, want non-nil")
+	}
+}

--- a/internal/statestore/postgres/projection_test.go
+++ b/internal/statestore/postgres/projection_test.go
@@ -80,6 +80,27 @@ func TestUpsertProjectedRecordsEnsureProjectionTablesOnce(t *testing.T) {
 	}
 }
 
+func TestUpsertProjectedEntityMergesAttributesOnConflict(t *testing.T) {
+	recorder := &projectionSQLRecorder{}
+	store := newProjectionTestStore(t, recorder)
+
+	entity := &ports.ProjectedEntity{
+		URN:        "urn:cerebro:writer:github_repo:writer/cerebro",
+		TenantID:   "writer",
+		SourceID:   "github",
+		EntityType: "github.repo",
+		Attributes: map[string]string{"resource_type": "repository"},
+	}
+	if err := store.UpsertProjectedEntity(context.Background(), entity); err != nil {
+		t.Fatalf("UpsertProjectedEntity() error = %v", err)
+	}
+
+	query := recorder.lastUpsert()
+	if !strings.Contains(query, "attributes_json = entities.attributes_json || EXCLUDED.attributes_json") {
+		t.Fatalf("entity upsert query does not merge attributes_json: %s", query)
+	}
+}
+
 func TestUpsertProjectedRetriesEnsureAfterFailure(t *testing.T) {
 	recorder := &projectionSQLRecorder{failNextDDL: true}
 	store := newProjectionTestStore(t, recorder)
@@ -157,6 +178,7 @@ type projectionSQLRecorder struct {
 	mu          sync.Mutex
 	ddlExecs    int
 	upserts     int
+	upsertSQL   []string
 	failNextDDL bool
 }
 
@@ -172,6 +194,7 @@ func (r *projectionSQLRecorder) exec(query string) (driver.Result, error) {
 		return driver.RowsAffected(1), nil
 	}
 	r.upserts++
+	r.upsertSQL = append(r.upsertSQL, query)
 	return driver.RowsAffected(1), nil
 }
 
@@ -179,4 +202,13 @@ func (r *projectionSQLRecorder) counts() (int, int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.ddlExecs, r.upserts
+}
+
+func (r *projectionSQLRecorder) lastUpsert() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.upsertSQL) == 0 {
+		return ""
+	}
+	return r.upsertSQL[len(r.upsertSQL)-1]
 }

--- a/internal/statestore/postgres/projection_test.go
+++ b/internal/statestore/postgres/projection_test.go
@@ -101,6 +101,28 @@ func TestUpsertProjectedEntityMergesAttributesOnConflict(t *testing.T) {
 	}
 }
 
+func TestUpsertProjectedLinkMergesAttributesOnConflict(t *testing.T) {
+	recorder := &projectionSQLRecorder{}
+	store := newProjectionTestStore(t, recorder)
+
+	link := &ports.ProjectedLink{
+		TenantID:   "writer",
+		SourceID:   "github",
+		FromURN:    "urn:cerebro:writer:github_user:alice",
+		Relation:   "member_of",
+		ToURN:      "urn:cerebro:writer:github_org:writer",
+		Attributes: map[string]string{"role": "maintainer"},
+	}
+	if err := store.UpsertProjectedLink(context.Background(), link); err != nil {
+		t.Fatalf("UpsertProjectedLink() error = %v", err)
+	}
+
+	query := recorder.lastUpsert()
+	if !strings.Contains(query, "attributes_json = entity_links.attributes_json || EXCLUDED.attributes_json") {
+		t.Fatalf("link upsert query does not merge attributes_json: %s", query)
+	}
+}
+
 func TestUpsertProjectedRetriesEnsureAfterFailure(t *testing.T) {
 	recorder := &projectionSQLRecorder{failNextDDL: true}
 	store := newProjectionTestStore(t, recorder)

--- a/internal/statestore/postgres/projection_test.go
+++ b/internal/statestore/postgres/projection_test.go
@@ -2,6 +2,13 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -38,4 +45,138 @@ func TestUpsertProjectedLinkRejectsMissingRelation(t *testing.T) {
 	if err == nil {
 		t.Fatal("UpsertProjectedLink() error = nil, want non-nil")
 	}
+}
+
+func TestUpsertProjectedRecordsEnsureProjectionTablesOnce(t *testing.T) {
+	recorder := &projectionSQLRecorder{}
+	store := newProjectionTestStore(t, recorder)
+
+	entity := &ports.ProjectedEntity{
+		URN:        "urn:cerebro:writer:github_user:alice",
+		TenantID:   "writer",
+		SourceID:   "github",
+		EntityType: "github.user",
+	}
+	if err := store.UpsertProjectedEntity(context.Background(), entity); err != nil {
+		t.Fatalf("UpsertProjectedEntity() error = %v", err)
+	}
+	link := &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "github",
+		FromURN:  "urn:cerebro:writer:github_user:alice",
+		Relation: "member_of",
+		ToURN:    "urn:cerebro:writer:github_org:writer",
+	}
+	if err := store.UpsertProjectedLink(context.Background(), link); err != nil {
+		t.Fatalf("UpsertProjectedLink() error = %v", err)
+	}
+
+	ddlExecs, upserts := recorder.counts()
+	if ddlExecs != len(ensureProjectionStatements) {
+		t.Fatalf("projection DDL executions = %d, want %d", ddlExecs, len(ensureProjectionStatements))
+	}
+	if upserts != 2 {
+		t.Fatalf("upsert executions = %d, want 2", upserts)
+	}
+}
+
+func TestUpsertProjectedRetriesEnsureAfterFailure(t *testing.T) {
+	recorder := &projectionSQLRecorder{failNextDDL: true}
+	store := newProjectionTestStore(t, recorder)
+	entity := &ports.ProjectedEntity{
+		URN:        "urn:cerebro:writer:github_user:alice",
+		TenantID:   "writer",
+		SourceID:   "github",
+		EntityType: "github.user",
+	}
+
+	if err := store.UpsertProjectedEntity(context.Background(), entity); err == nil {
+		t.Fatal("UpsertProjectedEntity(first) error = nil, want non-nil")
+	}
+	if err := store.UpsertProjectedEntity(context.Background(), entity); err != nil {
+		t.Fatalf("UpsertProjectedEntity(second) error = %v", err)
+	}
+
+	ddlExecs, upserts := recorder.counts()
+	wantDDL := len(ensureProjectionStatements) + 1
+	if ddlExecs != wantDDL {
+		t.Fatalf("projection DDL executions = %d, want %d", ddlExecs, wantDDL)
+	}
+	if upserts != 1 {
+		t.Fatalf("upsert executions = %d, want 1", upserts)
+	}
+}
+
+var projectionSQLDriverSeq int64
+
+func newProjectionTestStore(t *testing.T, recorder *projectionSQLRecorder) *Store {
+	t.Helper()
+	driverName := fmt.Sprintf("projection-test-%d", atomic.AddInt64(&projectionSQLDriverSeq, 1))
+	sql.Register(driverName, projectionSQLDriver{recorder: recorder})
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("open projection test db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("close projection test db: %v", err)
+		}
+	})
+	return &Store{db: db}
+}
+
+type projectionSQLDriver struct {
+	recorder *projectionSQLRecorder
+}
+
+func (d projectionSQLDriver) Open(string) (driver.Conn, error) {
+	return projectionSQLConn(d), nil
+}
+
+type projectionSQLConn struct {
+	recorder *projectionSQLRecorder
+}
+
+func (c projectionSQLConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare is not supported")
+}
+
+func (c projectionSQLConn) Close() error {
+	return nil
+}
+
+func (c projectionSQLConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions are not supported")
+}
+
+func (c projectionSQLConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	return c.recorder.exec(query)
+}
+
+type projectionSQLRecorder struct {
+	mu          sync.Mutex
+	ddlExecs    int
+	upserts     int
+	failNextDDL bool
+}
+
+func (r *projectionSQLRecorder) exec(query string) (driver.Result, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if strings.HasPrefix(strings.TrimSpace(query), "CREATE ") {
+		r.ddlExecs++
+		if r.failNextDDL {
+			r.failNextDDL = false
+			return nil, errors.New("ddl failed")
+		}
+		return driver.RowsAffected(1), nil
+	}
+	r.upserts++
+	return driver.RowsAffected(1), nil
+}
+
+func (r *projectionSQLRecorder) counts() (int, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ddlExecs, r.upserts
 }

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -80,8 +80,14 @@ func (s *Store) GetSourceRuntime(ctx context.Context, runtimeID string) (*cerebr
 }
 
 func (s *Store) ensureSourceRuntimeTable(ctx context.Context) error {
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	if s.sourceRuntimeReady {
+		return nil
+	}
 	if _, err := s.db.ExecContext(ctx, ensureSourceRuntimeTableSQL); err != nil {
 		return fmt.Errorf("ensure source runtime table: %w", err)
 	}
+	s.sourceRuntimeReady = true
 	return nil
 }

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -72,11 +72,7 @@ func (s *Store) GetSourceRuntime(ctx context.Context, runtimeID string) (*cerebr
 		}
 		return nil, fmt.Errorf("query source runtime %q: %w", id, err)
 	}
-	runtime := &cerebrov1.SourceRuntime{}
-	if err := protojson.Unmarshal([]byte(payload), runtime); err != nil {
-		return nil, fmt.Errorf("decode source runtime %q: %w", id, err)
-	}
-	return runtime, nil
+	return decodeSourceRuntime(id, payload)
 }
 
 func (s *Store) ensureSourceRuntimeTable(ctx context.Context) error {
@@ -90,4 +86,12 @@ func (s *Store) ensureSourceRuntimeTable(ctx context.Context) error {
 	}
 	s.sourceRuntimeReady = true
 	return nil
+}
+
+func decodeSourceRuntime(id string, payload string) (*cerebrov1.SourceRuntime, error) {
+	runtime := &cerebrov1.SourceRuntime{}
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(payload), runtime); err != nil {
+		return nil, fmt.Errorf("decode source runtime %q: %w", id, err)
+	}
+	return runtime, nil
 }

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -1,0 +1,87 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const ensureSourceRuntimeTableSQL = `
+CREATE TABLE IF NOT EXISTS source_runtimes (
+  id TEXT PRIMARY KEY,
+  runtime_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`
+
+// PutSourceRuntime upserts one source runtime definition.
+func (s *Store) PutSourceRuntime(ctx context.Context, runtime *cerebrov1.SourceRuntime) error {
+	if runtime == nil {
+		return errors.New("source runtime is required")
+	}
+	id := strings.TrimSpace(runtime.GetId())
+	if id == "" {
+		return errors.New("source runtime id is required")
+	}
+	if strings.TrimSpace(runtime.GetSourceId()) == "" {
+		return errors.New("source id is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return err
+	}
+	payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(runtime)
+	if err != nil {
+		return fmt.Errorf("marshal source runtime: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO source_runtimes (id, runtime_json)
+VALUES ($1, $2::jsonb)
+ON CONFLICT (id)
+DO UPDATE SET runtime_json = EXCLUDED.runtime_json, updated_at = NOW()`, id, string(payload)); err != nil {
+		return fmt.Errorf("upsert source runtime %q: %w", id, err)
+	}
+	return nil
+}
+
+// GetSourceRuntime loads one persisted source runtime definition.
+func (s *Store) GetSourceRuntime(ctx context.Context, runtimeID string) (*cerebrov1.SourceRuntime, error) {
+	id := strings.TrimSpace(runtimeID)
+	if id == "" {
+		return nil, errors.New("source runtime id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return nil, err
+	}
+	var payload string
+	if err := s.db.QueryRowContext(ctx, `SELECT runtime_json::text FROM source_runtimes WHERE id = $1`, id).Scan(&payload); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrSourceRuntimeNotFound, id)
+		}
+		return nil, fmt.Errorf("query source runtime %q: %w", id, err)
+	}
+	runtime := &cerebrov1.SourceRuntime{}
+	if err := protojson.Unmarshal([]byte(payload), runtime); err != nil {
+		return nil, fmt.Errorf("decode source runtime %q: %w", id, err)
+	}
+	return runtime, nil
+}
+
+func (s *Store) ensureSourceRuntimeTable(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, ensureSourceRuntimeTableSQL); err != nil {
+		return fmt.Errorf("ensure source runtime table: %w", err)
+	}
+	return nil
+}

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -29,6 +29,19 @@ func TestPutSourceRuntimeRejectsMissingSourceID(t *testing.T) {
 	}
 }
 
+func TestDecodeSourceRuntimeDiscardsUnknownFields(t *testing.T) {
+	runtime, err := decodeSourceRuntime("runtime", `{"id":"runtime","source_id":"okta","future_field":"ignored"}`)
+	if err != nil {
+		t.Fatalf("decodeSourceRuntime() error = %v", err)
+	}
+	if runtime.GetId() != "runtime" {
+		t.Fatalf("decodeSourceRuntime().Id = %q, want runtime", runtime.GetId())
+	}
+	if runtime.GetSourceId() != "okta" {
+		t.Fatalf("decodeSourceRuntime().SourceId = %q, want okta", runtime.GetSourceId())
+	}
+}
+
 func TestPutSourceRuntimeEnsuresTableOnce(t *testing.T) {
 	recorder := &projectionSQLRecorder{}
 	store := newProjectionTestStore(t, recorder)

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -1,0 +1,30 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestPutSourceRuntimeRejectsNilRuntime(t *testing.T) {
+	store := &Store{}
+	if err := store.PutSourceRuntime(context.Background(), nil); err == nil {
+		t.Fatal("PutSourceRuntime() error = nil, want non-nil")
+	}
+}
+
+func TestGetSourceRuntimeRejectsMissingID(t *testing.T) {
+	store := &Store{}
+	if _, err := store.GetSourceRuntime(context.Background(), ""); err == nil {
+		t.Fatal("GetSourceRuntime() error = nil, want non-nil")
+	}
+}
+
+func TestPutSourceRuntimeRejectsMissingSourceID(t *testing.T) {
+	store := &Store{}
+	err := store.PutSourceRuntime(context.Background(), &cerebrov1.SourceRuntime{Id: "runtime"})
+	if err == nil {
+		t.Fatal("PutSourceRuntime() error = nil, want non-nil")
+	}
+}

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -28,3 +28,51 @@ func TestPutSourceRuntimeRejectsMissingSourceID(t *testing.T) {
 		t.Fatal("PutSourceRuntime() error = nil, want non-nil")
 	}
 }
+
+func TestPutSourceRuntimeEnsuresTableOnce(t *testing.T) {
+	recorder := &projectionSQLRecorder{}
+	store := newProjectionTestStore(t, recorder)
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "runtime",
+		SourceId: "okta",
+	}
+
+	if err := store.PutSourceRuntime(context.Background(), runtime); err != nil {
+		t.Fatalf("PutSourceRuntime(first) error = %v", err)
+	}
+	if err := store.PutSourceRuntime(context.Background(), runtime); err != nil {
+		t.Fatalf("PutSourceRuntime(second) error = %v", err)
+	}
+
+	ddlExecs, upserts := recorder.counts()
+	if ddlExecs != 1 {
+		t.Fatalf("source runtime DDL executions = %d, want 1", ddlExecs)
+	}
+	if upserts != 2 {
+		t.Fatalf("source runtime upserts = %d, want 2", upserts)
+	}
+}
+
+func TestPutSourceRuntimeRetriesEnsureAfterFailure(t *testing.T) {
+	recorder := &projectionSQLRecorder{failNextDDL: true}
+	store := newProjectionTestStore(t, recorder)
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "runtime",
+		SourceId: "okta",
+	}
+
+	if err := store.PutSourceRuntime(context.Background(), runtime); err == nil {
+		t.Fatal("PutSourceRuntime(first) error = nil, want non-nil")
+	}
+	if err := store.PutSourceRuntime(context.Background(), runtime); err != nil {
+		t.Fatalf("PutSourceRuntime(second) error = %v", err)
+	}
+
+	ddlExecs, upserts := recorder.counts()
+	if ddlExecs != 2 {
+		t.Fatalf("source runtime DDL executions = %d, want 2", ddlExecs)
+	}
+	if upserts != 1 {
+		t.Fatalf("source runtime upserts = %d, want 1", upserts)
+	}
+}

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -110,10 +110,11 @@ message ReadSourceResponse {
 message SourceRuntime {
   string id = 1;
   string source_id = 2;
-  map<string, string> config = 3;
-  SourceCheckpoint checkpoint = 4;
-  SourceCursor next_cursor = 5;
-  google.protobuf.Timestamp last_synced_at = 6;
+  string tenant_id = 3;
+  map<string, string> config = 4;
+  SourceCheckpoint checkpoint = 5;
+  SourceCursor next_cursor = 6;
+  google.protobuf.Timestamp last_synced_at = 7;
 }
 
 // PutSourceRuntimeRequest stores or updates one source runtime definition.
@@ -148,4 +149,6 @@ message SyncSourceRuntimeResponse {
   SourceSpec source = 2;
   uint32 pages_read = 3;
   uint32 events_appended = 4;
+  uint32 entities_projected = 5;
+  uint32 links_projected = 6;
 }

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -17,6 +17,9 @@ service BootstrapService {
   rpc CheckSource(CheckSourceRequest) returns (CheckSourceResponse);
   rpc DiscoverSource(DiscoverSourceRequest) returns (DiscoverSourceResponse);
   rpc ReadSource(ReadSourceRequest) returns (ReadSourceResponse);
+  rpc PutSourceRuntime(PutSourceRuntimeRequest) returns (PutSourceRuntimeResponse);
+  rpc GetSourceRuntime(GetSourceRuntimeRequest) returns (GetSourceRuntimeResponse);
+  rpc SyncSourceRuntime(SyncSourceRuntimeRequest) returns (SyncSourceRuntimeResponse);
 }
 
 // GetVersionRequest requests static build metadata from the running service.
@@ -101,4 +104,48 @@ message ReadSourceResponse {
   SourceCheckpoint checkpoint = 3;
   SourceCursor next_cursor = 4;
   repeated SourcePreviewEvent preview_events = 5;
+}
+
+// SourceRuntime stores source configuration plus the latest durable sync progress.
+message SourceRuntime {
+  string id = 1;
+  string source_id = 2;
+  map<string, string> config = 3;
+  SourceCheckpoint checkpoint = 4;
+  SourceCursor next_cursor = 5;
+  google.protobuf.Timestamp last_synced_at = 6;
+}
+
+// PutSourceRuntimeRequest stores or updates one source runtime definition.
+message PutSourceRuntimeRequest {
+  SourceRuntime runtime = 1;
+}
+
+// PutSourceRuntimeResponse returns the stored runtime view.
+message PutSourceRuntimeResponse {
+  SourceRuntime runtime = 1;
+}
+
+// GetSourceRuntimeRequest looks up one stored source runtime definition.
+message GetSourceRuntimeRequest {
+  string id = 1;
+}
+
+// GetSourceRuntimeResponse returns the stored runtime view.
+message GetSourceRuntimeResponse {
+  SourceRuntime runtime = 1;
+}
+
+// SyncSourceRuntimeRequest advances one stored source runtime.
+message SyncSourceRuntimeRequest {
+  string id = 1;
+  uint32 page_limit = 2;
+}
+
+// SyncSourceRuntimeResponse returns the updated runtime and sync totals.
+message SyncSourceRuntimeResponse {
+  SourceRuntime runtime = 1;
+  SourceSpec source = 2;
+  uint32 pages_read = 3;
+  uint32 events_appended = 4;
 }

--- a/sources/okta/catalog.yaml
+++ b/sources/okta/catalog.yaml
@@ -1,0 +1,6 @@
+id: okta
+name: Okta
+description: Okta audit log and user inventory source.
+emitted_kinds:
+  - okta.audit
+  - okta.user

--- a/sources/okta/fixture.go
+++ b/sources/okta/fixture.go
@@ -107,9 +107,12 @@ func (s *fixtureSource) Read(ctx context.Context, cfg sourcecdk.Config, cursor *
 	}
 	index := 0
 	if cursor != nil && strings.TrimSpace(cursor.Opaque) != "" {
-		parsed, err := strconv.Atoi(cursor.Opaque)
+		parsed, err := strconv.Atoi(strings.TrimSpace(cursor.Opaque))
 		if err != nil {
 			return sourcecdk.Pull{}, fmt.Errorf("parse cursor: %w", err)
+		}
+		if parsed < 0 {
+			return sourcecdk.Pull{}, fmt.Errorf("cursor index must be non-negative")
 		}
 		index = parsed
 	}

--- a/sources/okta/fixture.go
+++ b/sources/okta/fixture.go
@@ -1,0 +1,198 @@
+package okta
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+//go:embed testdata/*.json
+var fixtureFS embed.FS
+
+type fixtureEvent struct {
+	ID         string            `json:"id"`
+	TenantID   string            `json:"tenant_id"`
+	SourceID   string            `json:"source_id"`
+	Kind       string            `json:"kind"`
+	OccurredAt string            `json:"occurred_at"`
+	SchemaRef  string            `json:"schema_ref"`
+	Payload    json.RawMessage   `json:"payload"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+type fixtureSource struct {
+	spec        *cerebrov1.SourceSpec
+	auditURNs   []sourcecdk.URN
+	userURNs    []sourcecdk.URN
+	auditEvents []*primitives.Event
+	userEvents  []*primitives.Event
+}
+
+// NewFixture constructs the deterministic Okta source used by tests.
+func NewFixture() (sourcecdk.Source, error) {
+	spec, err := loadSpec()
+	if err != nil {
+		return nil, err
+	}
+	auditURNs, err := loadFixtureURNs("testdata/discover_audit.json")
+	if err != nil {
+		return nil, err
+	}
+	userURNs, err := loadFixtureURNs("testdata/discover_user.json")
+	if err != nil {
+		return nil, err
+	}
+	auditEvents, err := loadFixtureEvents("testdata/read_audit.json")
+	if err != nil {
+		return nil, err
+	}
+	userEvents, err := loadFixtureEvents("testdata/read_user.json")
+	if err != nil {
+		return nil, err
+	}
+	return &fixtureSource{
+		spec:        spec,
+		auditURNs:   auditURNs,
+		userURNs:    userURNs,
+		auditEvents: auditEvents,
+		userEvents:  userEvents,
+	}, nil
+}
+
+func (s *fixtureSource) Spec() *cerebrov1.SourceSpec {
+	return s.spec
+}
+
+func (s *fixtureSource) Check(_ context.Context, cfg sourcecdk.Config) error {
+	_, err := parseSettings(cfg)
+	return err
+}
+
+func (s *fixtureSource) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	settings, err := parseSettings(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.Check(ctx, cfg); err != nil {
+		return nil, err
+	}
+	switch settings.family {
+	case familyAudit:
+		return cloneURNs(s.auditURNs), nil
+	case familyUser:
+		return cloneURNs(s.userURNs), nil
+	default:
+		return nil, fmt.Errorf("unsupported okta family %q", settings.family)
+	}
+}
+
+func (s *fixtureSource) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	settings, err := parseSettings(cfg)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	if err := s.Check(ctx, cfg); err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	index := 0
+	if cursor != nil && strings.TrimSpace(cursor.Opaque) != "" {
+		parsed, err := strconv.Atoi(cursor.Opaque)
+		if err != nil {
+			return sourcecdk.Pull{}, fmt.Errorf("parse cursor: %w", err)
+		}
+		index = parsed
+	}
+	events := s.eventsForFamily(settings.family)
+	if index >= len(events) {
+		return sourcecdk.Pull{}, nil
+	}
+	event := proto.Clone(events[index]).(*cerebrov1.EventEnvelope)
+	pull := sourcecdk.Pull{
+		Events: []*primitives.Event{event},
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    event.OccurredAt,
+			CursorOpaque: strconv.Itoa(index + 1),
+		},
+	}
+	if index+1 < len(events) {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strconv.Itoa(index + 1)}
+	}
+	return pull, nil
+}
+
+func (s *fixtureSource) eventsForFamily(family string) []*primitives.Event {
+	switch family {
+	case familyAudit:
+		return s.auditEvents
+	case familyUser:
+		return s.userEvents
+	default:
+		return nil
+	}
+}
+
+func loadFixtureURNs(path string) ([]sourcecdk.URN, error) {
+	urnBytes, err := fixtureFS.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var rawURNs []string
+	if err := json.Unmarshal(urnBytes, &rawURNs); err != nil {
+		return nil, fmt.Errorf("unmarshal %s: %w", path, err)
+	}
+	urns := make([]sourcecdk.URN, 0, len(rawURNs))
+	for _, rawURN := range rawURNs {
+		urn, err := sourcecdk.ParseURN(rawURN)
+		if err != nil {
+			return nil, fmt.Errorf("parse urn %q from %s: %w", rawURN, path, err)
+		}
+		urns = append(urns, urn)
+	}
+	return urns, nil
+}
+
+func loadFixtureEvents(path string) ([]*primitives.Event, error) {
+	eventBytes, err := fixtureFS.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var rawEvents []fixtureEvent
+	if err := json.Unmarshal(eventBytes, &rawEvents); err != nil {
+		return nil, fmt.Errorf("unmarshal %s: %w", path, err)
+	}
+	events := make([]*primitives.Event, 0, len(rawEvents))
+	for _, raw := range rawEvents {
+		occurredAt, err := time.Parse(time.RFC3339, raw.OccurredAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse event occurred_at from %s: %w", path, err)
+		}
+		events = append(events, &primitives.Event{
+			Id:         raw.ID,
+			TenantId:   raw.TenantID,
+			SourceId:   raw.SourceID,
+			Kind:       raw.Kind,
+			OccurredAt: timestamppb.New(occurredAt),
+			SchemaRef:  raw.SchemaRef,
+			Payload:    append([]byte(nil), raw.Payload...),
+			Attributes: raw.Attributes,
+		})
+	}
+	return events, nil
+}
+
+func cloneURNs(values []sourcecdk.URN) []sourcecdk.URN {
+	cloned := make([]sourcecdk.URN, len(values))
+	copy(cloned, values)
+	return cloned
+}

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -492,6 +492,13 @@ func normalizeBaseURL(raw string, domain string) (string, error) {
 	if !strings.EqualFold(parsed.Hostname(), domain) || (parsed.Port() != "" && parsed.Port() != "443") {
 		return "", fmt.Errorf("okta base_url host must match okta domain")
 	}
+	// Reject non-root paths so a caller cannot pivot the okta client onto an attacker-controlled
+	// sub-path (e.g. https://writer.okta.com/evil/) which would leak the bearer token to a path
+	// the okta domain does not actually serve.
+	trimmedPath := strings.Trim(parsed.Path, "/")
+	if trimmedPath != "" {
+		return "", fmt.Errorf("okta base_url must point at the root path")
+	}
 	return strings.TrimRight(parsed.String(), "/"), nil
 }
 

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -27,6 +27,7 @@ var catalogFS embed.FS
 const (
 	defaultPageSize   = 10
 	maxPageSize       = 200
+	maxResponseBytes  = 5 << 20
 	defaultFamily     = familyAudit
 	defaultAuditOrder = "ASCENDING"
 	defaultUserOrder  = "asc"
@@ -183,6 +184,8 @@ type responseError struct {
 	statusCode int
 	message    string
 }
+
+var errResponseTooLarge = errors.New("response too large")
 
 func (e *responseError) Error() string {
 	return e.message
@@ -595,9 +598,12 @@ func (s *Source) getJSON(ctx context.Context, settings settings, requestPath str
 	}()
 	headers := resp.Header.Clone()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
 		return headers, fmt.Errorf("read %s response: %w", requestPath, err)
+	}
+	if len(body) > maxResponseBytes {
+		return headers, fmt.Errorf("read %s response: %w", requestPath, errResponseTooLarge)
 	}
 	if resp.StatusCode >= http.StatusMultipleChoices {
 		return headers, decodeResponseError(resp.StatusCode, body)

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -32,6 +33,13 @@ const (
 	familyAudit       = "audit"
 	familyUser        = "user"
 )
+
+var oktaDomainSuffixes = []string{
+	".okta.com",
+	".oktapreview.com",
+	".okta-emea.com",
+	".okta-gov.com",
+}
 
 // Source is the live Okta source preview used by the builtin registry.
 type Source struct {
@@ -423,7 +431,48 @@ func normalizeDomain(raw string) (string, error) {
 	if host == "" {
 		return "", fmt.Errorf("okta domain must be a valid host")
 	}
-	return strings.ToLower(host), nil
+	if strings.ToLower(strings.TrimSpace(parsed.Scheme)) != "https" {
+		return "", fmt.Errorf("okta domain must use https")
+	}
+	if parsed.User != nil || parsed.Port() != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("okta domain must be a bare hostname")
+	}
+	if path := strings.TrimSpace(parsed.EscapedPath()); path != "" && path != "/" {
+		return "", fmt.Errorf("okta domain must be a bare hostname")
+	}
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	if net.ParseIP(host) != nil || !validDNSHostname(host) || !allowedOktaDomain(host) {
+		return "", fmt.Errorf("okta domain must be an Okta tenant hostname")
+	}
+	return host, nil
+}
+
+func allowedOktaDomain(host string) bool {
+	for _, suffix := range oktaDomainSuffixes {
+		if strings.HasSuffix(host, suffix) && len(host) > len(suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func validDNSHostname(host string) bool {
+	labels := strings.Split(host, ".")
+	if len(labels) < 3 {
+		return false
+	}
+	for _, label := range labels {
+		if label == "" || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return false
+		}
+		for _, ch := range label {
+			if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' {
+				continue
+			}
+			return false
+		}
+	}
+	return true
 }
 
 func normalizeBaseURL(raw string, domain string) (string, error) {

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -1,0 +1,973 @@
+package okta
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+//go:embed catalog.yaml
+var catalogFS embed.FS
+
+const (
+	defaultPageSize   = 10
+	maxPageSize       = 200
+	defaultFamily     = familyAudit
+	defaultAuditOrder = "DESCENDING"
+	defaultUserOrder  = "asc"
+	familyAudit       = "audit"
+	familyUser        = "user"
+)
+
+// Source is the live Okta source preview used by the builtin registry.
+type Source struct {
+	spec   *cerebrov1.SourceSpec
+	client *http.Client
+}
+
+type settings struct {
+	family    string
+	domain    string
+	baseURL   string
+	token     string
+	filter    string
+	q         string
+	search    string
+	sortBy    string
+	sortOrder string
+	since     string
+	until     string
+	perPage   int
+}
+
+type auditRecord struct {
+	UUID           string           `json:"uuid"`
+	Published      time.Time        `json:"published"`
+	EventType      string           `json:"eventType"`
+	DisplayMessage string           `json:"displayMessage"`
+	Severity       string           `json:"severity"`
+	Actor          map[string]any   `json:"actor"`
+	Outcome        map[string]any   `json:"outcome"`
+	Client         map[string]any   `json:"client"`
+	Transaction    map[string]any   `json:"transaction"`
+	Target         []map[string]any `json:"target"`
+	raw            json.RawMessage
+}
+
+type userRecord struct {
+	ID              string         `json:"id"`
+	Status          string         `json:"status"`
+	Created         *time.Time     `json:"created"`
+	Activated       *time.Time     `json:"activated"`
+	LastLogin       *time.Time     `json:"lastLogin"`
+	LastUpdated     *time.Time     `json:"lastUpdated"`
+	PasswordChanged *time.Time     `json:"passwordChanged"`
+	StatusChanged   *time.Time     `json:"statusChanged"`
+	RealmID         string         `json:"realmId"`
+	Type            map[string]any `json:"type"`
+	Profile         map[string]any `json:"profile"`
+	raw             json.RawMessage
+}
+
+type auditPayload struct {
+	UUID           string            `json:"uuid"`
+	Domain         string            `json:"domain"`
+	Published      time.Time         `json:"published"`
+	EventType      string            `json:"event_type"`
+	DisplayMessage string            `json:"display_message,omitempty"`
+	Severity       string            `json:"severity,omitempty"`
+	Actor          identityPayload   `json:"actor,omitempty"`
+	Outcome        outcomePayload    `json:"outcome,omitempty"`
+	Client         clientPayload     `json:"client,omitempty"`
+	Transaction    eventPayload      `json:"transaction,omitempty"`
+	Targets        []identityPayload `json:"targets,omitempty"`
+	ResourceID     string            `json:"resource_id,omitempty"`
+	ResourceType   string            `json:"resource_type,omitempty"`
+	Raw            map[string]any    `json:"raw,omitempty"`
+}
+
+type userPayload struct {
+	ID         string                 `json:"id"`
+	Domain     string                 `json:"domain"`
+	Status     string                 `json:"status,omitempty"`
+	RealmID    string                 `json:"realm_id,omitempty"`
+	Timestamps *userTimestampsPayload `json:"timestamps,omitempty"`
+	Type       *userTypePayload       `json:"type,omitempty"`
+	Profile    *userProfilePayload    `json:"profile,omitempty"`
+	Employment *userEmploymentPayload `json:"employment,omitempty"`
+	Raw        map[string]any         `json:"raw,omitempty"`
+}
+
+type userTimestampsPayload struct {
+	CreatedAt         *time.Time `json:"created_at,omitempty"`
+	ActivatedAt       *time.Time `json:"activated_at,omitempty"`
+	LastLoginAt       *time.Time `json:"last_login_at,omitempty"`
+	LastUpdatedAt     *time.Time `json:"last_updated_at,omitempty"`
+	PasswordChangedAt *time.Time `json:"password_changed_at,omitempty"`
+	StatusChangedAt   *time.Time `json:"status_changed_at,omitempty"`
+}
+
+type userTypePayload struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type userProfilePayload struct {
+	Login       string `json:"login,omitempty"`
+	Email       string `json:"email,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	FirstName   string `json:"first_name,omitempty"`
+	LastName    string `json:"last_name,omitempty"`
+}
+
+type userEmploymentPayload struct {
+	Department     string `json:"department,omitempty"`
+	Title          string `json:"title,omitempty"`
+	Organization   string `json:"organization,omitempty"`
+	Manager        string `json:"manager,omitempty"`
+	ManagerID      string `json:"manager_id,omitempty"`
+	EmployeeNumber string `json:"employee_number,omitempty"`
+	UserType       string `json:"user_type,omitempty"`
+}
+
+type identityPayload struct {
+	ID          string `json:"id,omitempty"`
+	Type        string `json:"type,omitempty"`
+	AlternateID string `json:"alternate_id,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+}
+
+type outcomePayload struct {
+	Result string `json:"result,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type clientPayload struct {
+	IPAddress string `json:"ip_address,omitempty"`
+	UserAgent string `json:"user_agent,omitempty"`
+	Zone      string `json:"zone,omitempty"`
+}
+
+type eventPayload struct {
+	ID   string `json:"id,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
+type apiError struct {
+	ErrorSummary string `json:"errorSummary"`
+}
+
+type responseError struct {
+	statusCode int
+	message    string
+}
+
+func (e *responseError) Error() string {
+	return e.message
+}
+
+// New constructs the live Okta source.
+func New() (*Source, error) {
+	spec, err := loadSpec()
+	if err != nil {
+		return nil, err
+	}
+	return &Source{
+		spec: spec,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}, nil
+}
+
+// Spec returns static metadata for the Okta source.
+func (s *Source) Spec() *cerebrov1.SourceSpec {
+	return s.spec
+}
+
+// Check validates that the configured Okta family is reachable.
+func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
+	settings, err := parseSettings(cfg)
+	if err != nil {
+		return err
+	}
+	switch settings.family {
+	case familyAudit:
+		_, _, err = s.listAudit(ctx, settings, "", 1)
+		if err != nil {
+			return wrapLookupError(fmt.Sprintf("okta audit log for %s", settings.domain), err)
+		}
+	case familyUser:
+		_, _, err = s.listUsers(ctx, settings, "", 1)
+		if err != nil {
+			return wrapLookupError(fmt.Sprintf("okta users for %s", settings.domain), err)
+		}
+	}
+	return nil
+}
+
+// Discover returns live Okta URNs for the selected family.
+func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	settings, err := parseSettings(cfg)
+	if err != nil {
+		return nil, err
+	}
+	switch settings.family {
+	case familyAudit:
+		if err := s.Check(ctx, cfg); err != nil {
+			return nil, err
+		}
+		urn, err := sourcecdk.ParseURN(fmt.Sprintf("urn:cerebro:%s:org:%s", settings.domain, settings.domain))
+		if err != nil {
+			return nil, err
+		}
+		return []sourcecdk.URN{urn}, nil
+	case familyUser:
+		users, _, err := s.listUsers(ctx, settings, "", settings.perPage)
+		if err != nil {
+			return nil, wrapLookupError(fmt.Sprintf("okta users for %s", settings.domain), err)
+		}
+		urns := make([]sourcecdk.URN, 0, len(users))
+		for _, user := range users {
+			urn, err := userURN(settings.domain, user.ID)
+			if err != nil {
+				return nil, err
+			}
+			urns = append(urns, urn)
+		}
+		return urns, nil
+	default:
+		return nil, fmt.Errorf("unsupported okta family %q", settings.family)
+	}
+}
+
+// Read pages through the configured live Okta event family.
+func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	settings, err := parseSettings(cfg)
+	if err != nil {
+		return sourcecdk.Pull{}, err
+	}
+	after := strings.TrimSpace(cursor.GetOpaque())
+	switch settings.family {
+	case familyAudit:
+		entries, next, err := s.listAudit(ctx, settings, after, settings.perPage)
+		if err != nil {
+			return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("okta audit log for %s", settings.domain), err)
+		}
+		if len(entries) == 0 {
+			return sourcecdk.Pull{}, nil
+		}
+		events := make([]*primitives.Event, 0, len(entries))
+		for _, entry := range entries {
+			event, err := auditEvent(settings, entry)
+			if err != nil {
+				return sourcecdk.Pull{}, err
+			}
+			events = append(events, event)
+		}
+		pull := sourcecdk.Pull{
+			Events: events,
+			Checkpoint: &cerebrov1.SourceCheckpoint{
+				Watermark:    events[len(events)-1].OccurredAt,
+				CursorOpaque: checkpointCursor(next, entries[len(entries)-1].UUID, events[len(events)-1].OccurredAt.AsTime()),
+			},
+		}
+		if next != "" {
+			pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
+		}
+		return pull, nil
+	case familyUser:
+		users, next, err := s.listUsers(ctx, settings, after, settings.perPage)
+		if err != nil {
+			return sourcecdk.Pull{}, wrapLookupError(fmt.Sprintf("okta users for %s", settings.domain), err)
+		}
+		if len(users) == 0 {
+			return sourcecdk.Pull{}, nil
+		}
+		events := make([]*primitives.Event, 0, len(users))
+		for _, user := range users {
+			event, err := userEvent(settings, user)
+			if err != nil {
+				return sourcecdk.Pull{}, err
+			}
+			events = append(events, event)
+		}
+		pull := sourcecdk.Pull{
+			Events: events,
+			Checkpoint: &cerebrov1.SourceCheckpoint{
+				Watermark:    events[len(events)-1].OccurredAt,
+				CursorOpaque: checkpointCursor(next, users[len(users)-1].ID, events[len(events)-1].OccurredAt.AsTime()),
+			},
+		}
+		if next != "" {
+			pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
+		}
+		return pull, nil
+	default:
+		return sourcecdk.Pull{}, fmt.Errorf("unsupported okta family %q", settings.family)
+	}
+}
+
+func loadSpec() (*cerebrov1.SourceSpec, error) {
+	specBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read catalog: %w", err)
+	}
+	spec, err := sourcecdk.LoadCatalog(specBytes)
+	if err != nil {
+		return nil, fmt.Errorf("load catalog: %w", err)
+	}
+	return spec, nil
+}
+
+func parseSettings(cfg sourcecdk.Config) (settings, error) {
+	settings := settings{
+		family:    configValue(cfg, "family"),
+		domain:    configValue(cfg, "domain"),
+		baseURL:   configValue(cfg, "base_url"),
+		token:     configValue(cfg, "token"),
+		filter:    configValue(cfg, "filter"),
+		q:         configValue(cfg, "q"),
+		search:    configValue(cfg, "search"),
+		sortBy:    configValue(cfg, "sort_by"),
+		sortOrder: configValue(cfg, "sort_order"),
+		since:     configValue(cfg, "since"),
+		until:     configValue(cfg, "until"),
+		perPage:   defaultPageSize,
+	}
+	if settings.family == "" {
+		settings.family = defaultFamily
+	}
+	switch settings.family {
+	case familyAudit, familyUser:
+	default:
+		return settings, fmt.Errorf("okta family must be one of %s or %s", familyAudit, familyUser)
+	}
+	if settings.domain == "" {
+		return settings, fmt.Errorf("okta domain is required")
+	}
+	domain, err := normalizeDomain(settings.domain)
+	if err != nil {
+		return settings, err
+	}
+	settings.domain = domain
+	if settings.baseURL == "" {
+		settings.baseURL = "https://" + settings.domain
+	} else {
+		settings.baseURL, err = normalizeBaseURL(settings.baseURL)
+		if err != nil {
+			return settings, err
+		}
+	}
+	if settings.token == "" {
+		return settings, fmt.Errorf("okta token is required")
+	}
+	if rawPerPage, ok := cfg.Lookup("per_page"); ok && strings.TrimSpace(rawPerPage) != "" {
+		perPage, err := strconv.Atoi(strings.TrimSpace(rawPerPage))
+		if err != nil {
+			return settings, fmt.Errorf("parse okta per_page: %w", err)
+		}
+		if perPage < 1 || perPage > maxPageSize {
+			return settings, fmt.Errorf("okta per_page must be between 1 and %d", maxPageSize)
+		}
+		settings.perPage = perPage
+	}
+	switch settings.family {
+	case familyAudit:
+		if settings.search != "" || settings.sortBy != "" {
+			return settings, fmt.Errorf("okta search and sort_by are only supported when family=%q", familyUser)
+		}
+		settings.sortOrder, err = normalizeAuditSortOrder(settings.sortOrder)
+		if err != nil {
+			return settings, err
+		}
+	case familyUser:
+		if settings.since != "" || settings.until != "" {
+			return settings, fmt.Errorf("okta since and until are only supported when family=%q", familyAudit)
+		}
+		settings.sortOrder, err = normalizeUserSortOrder(settings.sortOrder)
+		if err != nil {
+			return settings, err
+		}
+	}
+	return settings, nil
+}
+
+func normalizeDomain(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", fmt.Errorf("okta domain is required")
+	}
+	if !strings.Contains(value, "://") {
+		value = "https://" + value
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("parse okta domain: %w", err)
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	if host == "" {
+		return "", fmt.Errorf("okta domain must be a valid host")
+	}
+	return strings.ToLower(host), nil
+}
+
+func normalizeBaseURL(raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse okta base_url: %w", err)
+	}
+	if strings.TrimSpace(parsed.Scheme) == "" || strings.TrimSpace(parsed.Host) == "" {
+		return "", fmt.Errorf("okta base_url must include scheme and host")
+	}
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func normalizeAuditSortOrder(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "desc", "descending":
+		return defaultAuditOrder, nil
+	case "asc", "ascending":
+		return "ASCENDING", nil
+	default:
+		return "", fmt.Errorf("okta sort_order must be one of asc, desc, ascending, or descending when family=%q", familyAudit)
+	}
+}
+
+func normalizeUserSortOrder(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "asc", "ascending":
+		return defaultUserOrder, nil
+	case "desc", "descending":
+		return "desc", nil
+	default:
+		return "", fmt.Errorf("okta sort_order must be one of asc, desc, ascending, or descending when family=%q", familyUser)
+	}
+}
+
+func (s *Source) listAudit(ctx context.Context, settings settings, after string, limit int) ([]auditRecord, string, error) {
+	query := url.Values{}
+	query.Set("limit", strconv.Itoa(limit))
+	addQuery(query, "after", after)
+	addQuery(query, "filter", settings.filter)
+	addQuery(query, "q", settings.q)
+	addQuery(query, "since", settings.since)
+	addQuery(query, "until", settings.until)
+	addQuery(query, "sortOrder", settings.sortOrder)
+
+	var rawRecords []json.RawMessage
+	headers, err := s.getJSON(ctx, settings, "/api/v1/logs", query, &rawRecords)
+	if err != nil {
+		return nil, "", err
+	}
+	records := make([]auditRecord, 0, len(rawRecords))
+	for _, rawRecord := range rawRecords {
+		var record auditRecord
+		if err := json.Unmarshal(rawRecord, &record); err != nil {
+			return nil, "", fmt.Errorf("decode okta audit event: %w", err)
+		}
+		record.raw = append(json.RawMessage(nil), rawRecord...)
+		records = append(records, record)
+	}
+	return records, nextAfter(headers), nil
+}
+
+func (s *Source) listUsers(ctx context.Context, settings settings, after string, limit int) ([]userRecord, string, error) {
+	query := url.Values{}
+	query.Set("limit", strconv.Itoa(limit))
+	addQuery(query, "after", after)
+	addQuery(query, "filter", settings.filter)
+	addQuery(query, "q", settings.q)
+	addQuery(query, "search", settings.search)
+	addQuery(query, "sortBy", settings.sortBy)
+	addQuery(query, "sortOrder", settings.sortOrder)
+
+	var rawRecords []json.RawMessage
+	headers, err := s.getJSON(ctx, settings, "/api/v1/users", query, &rawRecords)
+	if err != nil {
+		return nil, "", err
+	}
+	records := make([]userRecord, 0, len(rawRecords))
+	for _, rawRecord := range rawRecords {
+		var record userRecord
+		if err := json.Unmarshal(rawRecord, &record); err != nil {
+			return nil, "", fmt.Errorf("decode okta user: %w", err)
+		}
+		record.raw = append(json.RawMessage(nil), rawRecord...)
+		records = append(records, record)
+	}
+	return records, nextAfter(headers), nil
+}
+
+func (s *Source) getJSON(ctx context.Context, settings settings, requestPath string, query url.Values, target any) (http.Header, error) {
+	endpoint := settings.baseURL + requestPath
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request %s: %w", requestPath, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "SSWS "+settings.token)
+
+	client := s.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request %s: %w", requestPath, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	headers := resp.Header.Clone()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return headers, fmt.Errorf("read %s response: %w", requestPath, err)
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return headers, decodeResponseError(resp.StatusCode, body)
+	}
+	if target == nil || len(body) == 0 {
+		return headers, nil
+	}
+	if err := json.Unmarshal(body, target); err != nil {
+		return headers, fmt.Errorf("decode %s response: %w", requestPath, err)
+	}
+	return headers, nil
+}
+
+func decodeResponseError(statusCode int, body []byte) error {
+	message := http.StatusText(statusCode)
+	var apiErr apiError
+	if err := json.Unmarshal(body, &apiErr); err == nil && strings.TrimSpace(apiErr.ErrorSummary) != "" {
+		message = strings.TrimSpace(apiErr.ErrorSummary)
+	}
+	return &responseError{
+		statusCode: statusCode,
+		message:    fmt.Sprintf("okta API returned %d: %s", statusCode, message),
+	}
+}
+
+func auditEvent(settings settings, record auditRecord) (*primitives.Event, error) {
+	occurredAt := record.Published.UTC()
+	if occurredAt.IsZero() {
+		return nil, fmt.Errorf("okta audit event %q missing published timestamp", record.UUID)
+	}
+	raw, err := decodeRawPayload(record.raw, "okta audit")
+	if err != nil {
+		return nil, err
+	}
+	actor := identityFromMap(record.Actor)
+	targets := identitiesFromMaps(record.Target)
+	resourceID, resourceType := auditResource(record, actor, targets, settings.domain)
+	payload, err := json.Marshal(auditPayload{
+		UUID:           record.UUID,
+		Domain:         settings.domain,
+		Published:      occurredAt,
+		EventType:      record.EventType,
+		DisplayMessage: record.DisplayMessage,
+		Severity:       record.Severity,
+		Actor:          actor,
+		Outcome: outcomePayload{
+			Result: stringMap(record.Outcome, "result"),
+			Reason: stringMap(record.Outcome, "reason"),
+		},
+		Client: clientPayload{
+			IPAddress: stringMap(record.Client, "ipAddress"),
+			UserAgent: stringMap(nestedMap(record.Client, "userAgent"), "rawUserAgent"),
+			Zone:      stringMap(record.Client, "zone"),
+		},
+		Transaction: eventPayload{
+			ID:   stringMap(record.Transaction, "id"),
+			Type: stringMap(record.Transaction, "type"),
+		},
+		Targets:      targets,
+		ResourceID:   resourceID,
+		ResourceType: resourceType,
+		Raw:          raw,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal okta audit payload: %w", err)
+	}
+	eventID := strings.TrimSpace(record.UUID)
+	if eventID == "" {
+		eventID = fmt.Sprintf("%s-%d", strings.ReplaceAll(record.EventType, ".", "-"), occurredAt.UnixMilli())
+	}
+	return &primitives.Event{
+		Id:         "okta-audit-" + eventID,
+		TenantId:   settings.domain,
+		SourceId:   "okta",
+		Kind:       "okta.audit",
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  "okta/audit/v1",
+		Payload:    payload,
+		Attributes: auditAttributes(settings, record, actor, resourceID, resourceType),
+	}, nil
+}
+
+func userEvent(settings settings, record userRecord) (*primitives.Event, error) {
+	occurredAt := userOccurredAt(record)
+	if occurredAt.IsZero() {
+		return nil, fmt.Errorf("okta user %q missing timestamps", record.ID)
+	}
+	raw, err := decodeRawPayload(record.raw, "okta user")
+	if err != nil {
+		return nil, err
+	}
+	profile := record.Profile
+	payload, err := json.Marshal(userPayload{
+		ID:         record.ID,
+		Domain:     settings.domain,
+		Status:     record.Status,
+		RealmID:    record.RealmID,
+		Timestamps: userTimestamps(record),
+		Type:       userType(record.Type),
+		Profile:    userProfile(profile),
+		Employment: userEmployment(profile),
+		Raw:        raw,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal okta user payload: %w", err)
+	}
+	return &primitives.Event{
+		Id:         fmt.Sprintf("okta-user-%s-%d", record.ID, occurredAt.UnixMilli()),
+		TenantId:   settings.domain,
+		SourceId:   "okta",
+		Kind:       "okta.user",
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  "okta/user/v1",
+		Payload:    payload,
+		Attributes: userAttributes(settings, record),
+	}, nil
+}
+
+func auditAttributes(settings settings, record auditRecord, actor identityPayload, resourceID string, resourceType string) map[string]string {
+	attributes := map[string]string{
+		"domain":        settings.domain,
+		"event_type":    record.EventType,
+		"family":        familyAudit,
+		"resource_id":   resourceID,
+		"resource_type": resourceType,
+	}
+	addAttribute(attributes, "actor_id", actor.ID)
+	addAttribute(attributes, "actor_type", actor.Type)
+	addAttribute(attributes, "actor_alternate_id", actor.AlternateID)
+	addAttribute(attributes, "actor_display_name", actor.DisplayName)
+	addAttribute(attributes, "client_ip", stringMap(record.Client, "ipAddress"))
+	addAttribute(attributes, "outcome_reason", stringMap(record.Outcome, "reason"))
+	addAttribute(attributes, "outcome_result", stringMap(record.Outcome, "result"))
+	addAttribute(attributes, "severity", record.Severity)
+	addAttribute(attributes, "transaction_id", stringMap(record.Transaction, "id"))
+	return attributes
+}
+
+func userAttributes(settings settings, record userRecord) map[string]string {
+	attributes := map[string]string{
+		"domain":  settings.domain,
+		"family":  familyUser,
+		"user_id": record.ID,
+	}
+	addAttribute(attributes, "email", stringMap(record.Profile, "email"))
+	addAttribute(attributes, "login", stringMap(record.Profile, "login"))
+	addAttribute(attributes, "realm_id", record.RealmID)
+	addAttribute(attributes, "status", record.Status)
+	addAttribute(attributes, "type_id", stringMap(record.Type, "id"))
+	addAttribute(attributes, "type_name", stringMap(record.Type, "name"))
+	addAttribute(attributes, "user_type", stringMap(record.Profile, "userType"))
+	return attributes
+}
+
+func userTimestamps(record userRecord) *userTimestampsPayload {
+	payload := &userTimestampsPayload{
+		CreatedAt:         utcTime(record.Created),
+		ActivatedAt:       utcTime(record.Activated),
+		LastLoginAt:       utcTime(record.LastLogin),
+		LastUpdatedAt:     utcTime(record.LastUpdated),
+		PasswordChangedAt: utcTime(record.PasswordChanged),
+		StatusChangedAt:   utcTime(record.StatusChanged),
+	}
+	if payload.CreatedAt == nil &&
+		payload.ActivatedAt == nil &&
+		payload.LastLoginAt == nil &&
+		payload.LastUpdatedAt == nil &&
+		payload.PasswordChangedAt == nil &&
+		payload.StatusChangedAt == nil {
+		return nil
+	}
+	return payload
+}
+
+func userType(values map[string]any) *userTypePayload {
+	payload := &userTypePayload{
+		ID:   stringMap(values, "id"),
+		Name: stringMap(values, "name"),
+	}
+	if payload.ID == "" && payload.Name == "" {
+		return nil
+	}
+	return payload
+}
+
+func userProfile(values map[string]any) *userProfilePayload {
+	payload := &userProfilePayload{
+		Login:       stringMap(values, "login"),
+		Email:       stringMap(values, "email"),
+		DisplayName: firstNonEmpty(stringMap(values, "displayName"), strings.TrimSpace(strings.Join([]string{stringMap(values, "firstName"), stringMap(values, "lastName")}, " "))),
+		FirstName:   stringMap(values, "firstName"),
+		LastName:    stringMap(values, "lastName"),
+	}
+	if payload.Login == "" &&
+		payload.Email == "" &&
+		payload.DisplayName == "" &&
+		payload.FirstName == "" &&
+		payload.LastName == "" {
+		return nil
+	}
+	return payload
+}
+
+func userEmployment(values map[string]any) *userEmploymentPayload {
+	payload := &userEmploymentPayload{
+		Department:     stringMap(values, "department"),
+		Title:          stringMap(values, "title"),
+		Organization:   stringMap(values, "organization"),
+		Manager:        stringMap(values, "manager"),
+		ManagerID:      stringMap(values, "managerId"),
+		EmployeeNumber: stringMap(values, "employeeNumber"),
+		UserType:       stringMap(values, "userType"),
+	}
+	if payload.Department == "" &&
+		payload.Title == "" &&
+		payload.Organization == "" &&
+		payload.Manager == "" &&
+		payload.ManagerID == "" &&
+		payload.EmployeeNumber == "" &&
+		payload.UserType == "" {
+		return nil
+	}
+	return payload
+}
+
+func auditResource(record auditRecord, actor identityPayload, targets []identityPayload, domain string) (string, string) {
+	for _, target := range targets {
+		resourceID := firstNonEmpty(target.ID, target.AlternateID, target.DisplayName)
+		resourceType := strings.TrimSpace(target.Type)
+		if resourceID != "" || resourceType != "" {
+			return resourceID, firstNonEmpty(resourceType, auditEventResourceType(record.EventType))
+		}
+	}
+	if actor.AlternateID != "" || actor.ID != "" {
+		return firstNonEmpty(actor.AlternateID, actor.ID), firstNonEmpty(actor.Type, auditEventResourceType(record.EventType))
+	}
+	return domain, auditEventResourceType(record.EventType)
+}
+
+func auditEventResourceType(eventType string) string {
+	value := strings.TrimSpace(eventType)
+	if value == "" {
+		return "audit"
+	}
+	prefix, _, ok := strings.Cut(value, ".")
+	if !ok {
+		return value
+	}
+	return prefix
+}
+
+func identityFromMap(values map[string]any) identityPayload {
+	return identityPayload{
+		ID:          stringMap(values, "id"),
+		Type:        stringMap(values, "type"),
+		AlternateID: stringMap(values, "alternateId"),
+		DisplayName: stringMap(values, "displayName"),
+	}
+}
+
+func identitiesFromMaps(values []map[string]any) []identityPayload {
+	identities := make([]identityPayload, 0, len(values))
+	for _, value := range values {
+		identity := identityFromMap(value)
+		if identity != (identityPayload{}) {
+			identities = append(identities, identity)
+		}
+	}
+	return identities
+}
+
+func userOccurredAt(record userRecord) time.Time {
+	for _, stamp := range []*time.Time{
+		record.LastUpdated,
+		record.Created,
+		record.Activated,
+		record.StatusChanged,
+		record.LastLogin,
+		record.PasswordChanged,
+	} {
+		if stamp != nil && !stamp.IsZero() {
+			return stamp.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func decodeRawPayload(raw json.RawMessage, label string) (map[string]any, error) {
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, fmt.Errorf("decode %s raw payload: %w", label, err)
+	}
+	return decoded, nil
+}
+
+func userURN(domain string, userID string) (sourcecdk.URN, error) {
+	id := strings.TrimSpace(userID)
+	if id == "" {
+		return "", fmt.Errorf("okta user id is required")
+	}
+	return sourcecdk.ParseURN(fmt.Sprintf("urn:cerebro:%s:user:%s", domain, id))
+}
+
+func nextAfter(headers http.Header) string {
+	if headers == nil {
+		return ""
+	}
+	for _, header := range headers.Values("Link") {
+		for _, part := range strings.Split(header, ",") {
+			link, rel := parseLink(part)
+			if rel != "next" {
+				continue
+			}
+			parsed, err := url.Parse(link)
+			if err != nil {
+				continue
+			}
+			if after := strings.TrimSpace(parsed.Query().Get("after")); after != "" {
+				return after
+			}
+		}
+	}
+	return ""
+}
+
+func parseLink(value string) (string, string) {
+	trimmed := strings.TrimSpace(value)
+	if !strings.HasPrefix(trimmed, "<") {
+		return "", ""
+	}
+	end := strings.Index(trimmed, ">")
+	if end <= 1 {
+		return "", ""
+	}
+	link := trimmed[1:end]
+	params := strings.Split(trimmed[end+1:], ";")
+	for _, param := range params {
+		key, rawValue, ok := strings.Cut(strings.TrimSpace(param), "=")
+		if !ok || key != "rel" {
+			continue
+		}
+		return link, strings.Trim(rawValue, "\"")
+	}
+	return link, ""
+}
+
+func checkpointCursor(next string, fallback string, occurredAt time.Time) string {
+	if strings.TrimSpace(next) != "" {
+		return strings.TrimSpace(next)
+	}
+	if strings.TrimSpace(fallback) != "" {
+		return strings.TrimSpace(fallback)
+	}
+	if occurredAt.IsZero() {
+		return ""
+	}
+	return occurredAt.UTC().Format(time.RFC3339Nano)
+}
+
+func utcTime(value *time.Time) *time.Time {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	result := value.UTC()
+	return &result
+}
+
+func addQuery(query url.Values, key string, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	query.Set(key, value)
+}
+
+func addAttribute(attributes map[string]string, key string, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	attributes[key] = strings.TrimSpace(value)
+}
+
+func nestedMap(values map[string]any, key string) map[string]any {
+	value, ok := values[key]
+	if !ok {
+		return nil
+	}
+	child, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return child
+}
+
+func stringMap(values map[string]any, key string) string {
+	value, ok := values[key]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func configValue(cfg sourcecdk.Config, key string) string {
+	value, _ := cfg.Lookup(key)
+	return strings.TrimSpace(value)
+}
+
+func isNotFound(err error) bool {
+	var responseErr *responseError
+	return errors.As(err, &responseErr) && responseErr.statusCode == http.StatusNotFound
+}
+
+func wrapLookupError(subject string, err error) error {
+	if isNotFound(err) {
+		return fmt.Errorf("%s not found", subject)
+	}
+	return fmt.Errorf("%s: %w", subject, err)
+}

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -368,7 +368,7 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if settings.baseURL == "" {
 		settings.baseURL = "https://" + settings.domain
 	} else {
-		settings.baseURL, err = normalizeBaseURL(settings.baseURL)
+		settings.baseURL, err = normalizeBaseURL(settings.baseURL, settings.domain)
 		if err != nil {
 			return settings, err
 		}
@@ -426,13 +426,19 @@ func normalizeDomain(raw string) (string, error) {
 	return strings.ToLower(host), nil
 }
 
-func normalizeBaseURL(raw string) (string, error) {
+func normalizeBaseURL(raw string, domain string) (string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
 		return "", fmt.Errorf("parse okta base_url: %w", err)
 	}
-	if strings.TrimSpace(parsed.Scheme) == "" || strings.TrimSpace(parsed.Host) == "" {
-		return "", fmt.Errorf("okta base_url must include scheme and host")
+	if strings.ToLower(strings.TrimSpace(parsed.Scheme)) != "https" || strings.TrimSpace(parsed.Host) == "" {
+		return "", fmt.Errorf("okta base_url must use https and include a host")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("okta base_url must not include userinfo, query, or fragment")
+	}
+	if !strings.EqualFold(parsed.Hostname(), domain) || (parsed.Port() != "" && parsed.Port() != "443") {
+		return "", fmt.Errorf("okta base_url host must match okta domain")
 	}
 	return strings.TrimRight(parsed.String(), "/"), nil
 }

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -28,7 +28,7 @@ const (
 	defaultPageSize   = 10
 	maxPageSize       = 200
 	defaultFamily     = familyAudit
-	defaultAuditOrder = "DESCENDING"
+	defaultAuditOrder = "ASCENDING"
 	defaultUserOrder  = "asc"
 	familyAudit       = "audit"
 	familyUser        = "user"
@@ -494,8 +494,10 @@ func normalizeBaseURL(raw string, domain string) (string, error) {
 
 func normalizeAuditSortOrder(raw string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "", "desc", "descending":
+	case "":
 		return defaultAuditOrder, nil
+	case "desc", "descending":
+		return "DESCENDING", nil
 	case "asc", "ascending":
 		return "ASCENDING", nil
 	default:

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -115,6 +115,54 @@ func TestParseSettingsRejectsUnsafeBaseURL(t *testing.T) {
 	}
 }
 
+func TestParseSettingsRejectsUnsafeDomain(t *testing.T) {
+	for name, domain := range map[string]string{
+		"loopback-ipv4":    "127.0.0.1",
+		"link-local-ipv4":  "169.254.169.254",
+		"loopback-ipv6":    "[::1]",
+		"localhost":        "localhost",
+		"internal-host":    "metadata.google.internal",
+		"attacker-domain":  "attacker.example.com",
+		"lookalike-domain": "writer.okta.com.evil.com",
+		"userinfo":         "https://token@writer.okta.com",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+				"domain": domain,
+				"family": "audit",
+				"token":  "test-token",
+			}))
+			if err == nil {
+				t.Fatalf("parseSettings() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestParseSettingsAcceptsOktaDomains(t *testing.T) {
+	for name, domain := range map[string]string{
+		"okta":         "writer.okta.com",
+		"preview":      "writer.oktapreview.com",
+		"emea":         "writer.okta-emea.com",
+		"gov":          "writer.okta-gov.com",
+		"https-scheme": "https://writer.okta.com",
+	} {
+		t.Run(name, func(t *testing.T) {
+			settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+				"domain": domain,
+				"family": "audit",
+				"token":  "test-token",
+			}))
+			if err != nil {
+				t.Fatalf("parseSettings() error = %v", err)
+			}
+			if settings.baseURL != "https://"+settings.domain {
+				t.Fatalf("baseURL = %q, want https domain", settings.baseURL)
+			}
+		})
+	}
+}
+
 func TestNewFixtureReturnsFixtureURNs(t *testing.T) {
 	source, err := NewFixture()
 	if err != nil {

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -3,6 +3,7 @@ package okta
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -254,6 +255,30 @@ func TestNewFixtureRejectsNegativeCursor(t *testing.T) {
 	_, err = source.Read(context.Background(), cfg, &cerebrov1.SourceCursor{Opaque: "-1"})
 	if err == nil {
 		t.Fatal("Read() error = nil, want non-nil")
+	}
+}
+
+func TestGetJSONRejectsLargeResponse(t *testing.T) {
+	source, closeServer := newTestSource(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		payload := make([]byte, maxResponseBytes+1)
+		for i := range payload {
+			payload[i] = 'a'
+		}
+		_, _ = w.Write(payload)
+	}))
+	defer closeServer()
+
+	var raw []json.RawMessage
+	_, err := source.getJSON(context.Background(), settings{
+		baseURL: "https://writer.okta.com",
+		token:   "test-token",
+	}, "/api/v1/logs", nil, &raw)
+	if err == nil {
+		t.Fatal("getJSON() error = nil, want non-nil")
+	}
+	if !errors.Is(err, errResponseTooLarge) {
+		t.Fatalf("getJSON() error = %v, want response too large", err)
 	}
 }
 

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -175,6 +175,23 @@ func TestNewFixtureReplaysFixturePages(t *testing.T) {
 	}
 }
 
+func TestNewFixtureRejectsNegativeCursor(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"domain": "writer.okta.com",
+		"family": "audit",
+		"token":  "test-token",
+	})
+
+	_, err = source.Read(context.Background(), cfg, &cerebrov1.SourceCursor{Opaque: "-1"})
+	if err == nil {
+		t.Fatal("Read() error = nil, want non-nil")
+	}
+}
+
 func TestCheckDiscoverAndReadLiveOktaAuditPreview(t *testing.T) {
 	source, cleanup := newTestSource(t, newOktaAPIHandler(t))
 	defer cleanup()

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -57,6 +57,23 @@ func TestNewLoadsCatalog(t *testing.T) {
 	}
 }
 
+func TestNormalizeAuditSortOrderDefaultsAscending(t *testing.T) {
+	got, err := normalizeAuditSortOrder("")
+	if err != nil {
+		t.Fatalf("normalizeAuditSortOrder(default) error = %v", err)
+	}
+	if got != "ASCENDING" {
+		t.Fatalf("normalizeAuditSortOrder(default) = %q, want ASCENDING", got)
+	}
+	got, err = normalizeAuditSortOrder("desc")
+	if err != nil {
+		t.Fatalf("normalizeAuditSortOrder(desc) error = %v", err)
+	}
+	if got != "DESCENDING" {
+		t.Fatalf("normalizeAuditSortOrder(desc) = %q, want DESCENDING", got)
+	}
+}
+
 func TestCheckRequiresDomain(t *testing.T) {
 	source, err := New()
 	if err != nil {

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -1,0 +1,432 @@
+package okta
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+func TestNewLoadsCatalog(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if source.Spec().Id != "okta" {
+		t.Fatalf("Spec().Id = %q, want %q", source.Spec().Id, "okta")
+	}
+}
+
+func TestCheckRequiresDomain(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{"token": "test-token"})); err == nil {
+		t.Fatal("Check() error = nil, want non-nil")
+	}
+}
+
+func TestAuditRequiresToken(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"domain": "writer.okta.com",
+		"family": "audit",
+	})); err == nil {
+		t.Fatal("Check(audit) error = nil, want non-nil")
+	}
+}
+
+func TestUserRejectsSince(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"domain": "writer.okta.com",
+		"family": "user",
+		"since":  "2026-04-23T00:00:00Z",
+		"token":  "test-token",
+	}), nil)
+	if err == nil {
+		t.Fatal("Read(user) error = nil, want non-nil")
+	}
+}
+
+func TestNewFixtureReturnsFixtureURNs(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+	urns, err := source.Discover(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"domain": "writer.okta.com",
+		"family": "user",
+		"token":  "test-token",
+	}))
+	if err != nil {
+		t.Fatalf("Discover(user) error = %v", err)
+	}
+	if len(urns) != 2 {
+		t.Fatalf("len(Discover(user)) = %d, want 2", len(urns))
+	}
+}
+
+func TestNewFixtureReplaysFixturePages(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"domain": "writer.okta.com",
+		"family": "audit",
+		"token":  "test-token",
+	})
+
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
+	}
+	if first.NextCursor == nil {
+		t.Fatal("first.NextCursor = nil, want non-nil")
+	}
+
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if len(second.Events) != 1 {
+		t.Fatalf("len(second.Events) = %d, want 1", len(second.Events))
+	}
+	if second.NextCursor != nil {
+		t.Fatal("second.NextCursor != nil, want nil")
+	}
+
+	final, err := source.Read(context.Background(), cfg, &cerebrov1.SourceCursor{Opaque: "2"})
+	if err != nil {
+		t.Fatalf("Read(final) error = %v", err)
+	}
+	if len(final.Events) != 0 {
+		t.Fatalf("len(final.Events) = %d, want 0", len(final.Events))
+	}
+}
+
+func TestCheckDiscoverAndReadLiveOktaAuditPreview(t *testing.T) {
+	server := httptest.NewServer(newOktaAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"domain":   "writer.okta.com",
+		"family":   "audit",
+		"per_page": "1",
+		"token":    "test-token",
+	})
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check(audit) error = %v", err)
+	}
+
+	discover, err := source.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover(audit) error = %v", err)
+	}
+	if len(discover) != 1 {
+		t.Fatalf("len(Discover(audit)) = %d, want 1", len(discover))
+	}
+	if discover[0] != "urn:cerebro:writer.okta.com:org:writer.okta.com" {
+		t.Fatalf("Discover(audit)[0] = %q, want org urn", discover[0])
+	}
+
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(audit first) error = %v", err)
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(Read(audit first).Events) = %d, want 1", len(first.Events))
+	}
+	if first.NextCursor == nil || first.NextCursor.Opaque != "cursor-2" {
+		t.Fatalf("first.NextCursor = %#v, want cursor-2", first.NextCursor)
+	}
+	if got := first.Events[0].Kind; got != "okta.audit" {
+		t.Fatalf("first.Events[0].Kind = %q, want okta.audit", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(first.Events[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal audit payload: %v", err)
+	}
+	if got := payload["resource_type"]; got != "User" {
+		t.Fatalf("audit payload resource_type = %#v, want User", got)
+	}
+	if got := payload["resource_id"]; got != "00u1" {
+		t.Fatalf("audit payload resource_id = %#v, want 00u1", got)
+	}
+
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(audit second) error = %v", err)
+	}
+	if len(second.Events) != 1 {
+		t.Fatalf("len(Read(audit second).Events) = %d, want 1", len(second.Events))
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
+	}
+	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "evt-2" {
+		t.Fatalf("second.Checkpoint = %#v, want evt-2", second.Checkpoint)
+	}
+}
+
+func TestCheckDiscoverAndReadLiveOktaUserPreview(t *testing.T) {
+	server := httptest.NewServer(newOktaAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	discoverCfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"domain":   "writer.okta.com",
+		"family":   "user",
+		"per_page": "2",
+		"token":    "test-token",
+	})
+	if err := source.Check(context.Background(), discoverCfg); err != nil {
+		t.Fatalf("Check(user) error = %v", err)
+	}
+
+	discover, err := source.Discover(context.Background(), discoverCfg)
+	if err != nil {
+		t.Fatalf("Discover(user) error = %v", err)
+	}
+	if len(discover) != 2 {
+		t.Fatalf("len(Discover(user)) = %d, want 2", len(discover))
+	}
+	if discover[0] != "urn:cerebro:writer.okta.com:user:00u1" {
+		t.Fatalf("Discover(user)[0] = %q, want first user urn", discover[0])
+	}
+
+	readCfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"domain":   "writer.okta.com",
+		"family":   "user",
+		"per_page": "1",
+		"token":    "test-token",
+	})
+	first, err := source.Read(context.Background(), readCfg, nil)
+	if err != nil {
+		t.Fatalf("Read(user first) error = %v", err)
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(Read(user first).Events) = %d, want 1", len(first.Events))
+	}
+	if first.NextCursor == nil || first.NextCursor.Opaque != "cursor-user-2" {
+		t.Fatalf("first.NextCursor = %#v, want cursor-user-2", first.NextCursor)
+	}
+	if got := first.Events[0].Kind; got != "okta.user" {
+		t.Fatalf("first.Events[0].Kind = %q, want okta.user", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(first.Events[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal user payload: %v", err)
+	}
+	profile, ok := payload["profile"].(map[string]any)
+	if !ok {
+		t.Fatalf("user payload profile = %#v, want object", payload["profile"])
+	}
+	if got := profile["login"]; got != "alice@writer.com" {
+		t.Fatalf("user payload profile.login = %#v, want alice@writer.com", got)
+	}
+
+	second, err := source.Read(context.Background(), readCfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(user second) error = %v", err)
+	}
+	if len(second.Events) != 1 {
+		t.Fatalf("len(Read(user second).Events) = %d, want 1", len(second.Events))
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
+	}
+	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "00u2" {
+		t.Fatalf("second.Checkpoint = %#v, want 00u2", second.Checkpoint)
+	}
+}
+
+func newOktaAPIHandler(t *testing.T) http.Handler {
+	t.Helper()
+
+	auditRecords := []map[string]any{
+		{
+			"uuid":           "evt-1",
+			"published":      "2026-04-23T01:00:00Z",
+			"eventType":      "user.session.start",
+			"displayMessage": "User login to Okta",
+			"severity":       "INFO",
+			"actor": map[string]any{
+				"id":          "00u1",
+				"type":        "User",
+				"alternateId": "alice@writer.com",
+				"displayName": "Alice Example",
+			},
+			"client": map[string]any{
+				"ipAddress": "1.2.3.4",
+				"zone":      "null",
+				"userAgent": map[string]any{
+					"rawUserAgent": "Mozilla/5.0",
+				},
+			},
+			"outcome": map[string]any{
+				"result": "SUCCESS",
+			},
+			"transaction": map[string]any{
+				"id": "txn-1",
+			},
+			"target": []map[string]any{
+				{
+					"id":          "00u1",
+					"type":        "User",
+					"alternateId": "alice@writer.com",
+					"displayName": "Alice Example",
+				},
+			},
+		},
+		{
+			"uuid":           "evt-2",
+			"published":      "2026-04-23T00:00:00Z",
+			"eventType":      "policy.rule.update",
+			"displayMessage": "Policy updated",
+			"severity":       "WARN",
+			"actor": map[string]any{
+				"id":          "00u2",
+				"type":        "User",
+				"alternateId": "admin@writer.com",
+				"displayName": "Admin Example",
+			},
+			"outcome": map[string]any{
+				"result": "SUCCESS",
+			},
+			"target": []map[string]any{
+				{
+					"id":          "pol-1",
+					"type":        "PolicyRule",
+					"displayName": "Require MFA",
+				},
+			},
+		},
+	}
+	userRecords := []map[string]any{
+		{
+			"id":          "00u1",
+			"status":      "ACTIVE",
+			"created":     "2026-04-20T00:00:00Z",
+			"activated":   "2026-04-20T00:01:00Z",
+			"lastUpdated": "2026-04-23T01:00:00Z",
+			"lastLogin":   "2026-04-23T01:00:00Z",
+			"profile": map[string]any{
+				"login":        "alice@writer.com",
+				"email":        "alice@writer.com",
+				"displayName":  "Alice Example",
+				"firstName":    "Alice",
+				"lastName":     "Example",
+				"department":   "Security",
+				"title":        "Engineer",
+				"organization": "Writer",
+				"userType":     "employee",
+			},
+			"type": map[string]any{
+				"id":   "oty1",
+				"name": "default",
+			},
+		},
+		{
+			"id":            "00u2",
+			"status":        "SUSPENDED",
+			"created":       "2026-04-20T02:00:00Z",
+			"lastUpdated":   "2026-04-23T00:30:00Z",
+			"statusChanged": "2026-04-23T00:30:00Z",
+			"profile": map[string]any{
+				"login":       "admin@writer.com",
+				"email":       "admin@writer.com",
+				"displayName": "Admin Example",
+				"firstName":   "Admin",
+				"lastName":    "Example",
+			},
+			"type": map[string]any{
+				"id":   "oty1",
+				"name": "default",
+			},
+		},
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if got := r.Header.Get("Authorization"); got != "SSWS test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			if err := json.NewEncoder(w).Encode(map[string]any{"errorSummary": "invalid token"}); err != nil {
+				t.Fatalf("encode auth error: %v", err)
+			}
+			return
+		}
+		switch r.URL.Path {
+		case "/api/v1/logs":
+			after := r.URL.Query().Get("after")
+			if after == "" {
+				w.Header().Set("Link", "</api/v1/logs?after=cursor-2&limit=1>; rel=\"next\"")
+				if err := json.NewEncoder(w).Encode(auditRecords[:1]); err != nil {
+					t.Fatalf("encode audit page 1: %v", err)
+				}
+				return
+			}
+			if after == "cursor-2" {
+				if err := json.NewEncoder(w).Encode(auditRecords[1:2]); err != nil {
+					t.Fatalf("encode audit page 2: %v", err)
+				}
+				return
+			}
+			if err := json.NewEncoder(w).Encode([]map[string]any{}); err != nil {
+				t.Fatalf("encode empty audit page: %v", err)
+			}
+		case "/api/v1/users":
+			after := r.URL.Query().Get("after")
+			if after == "" {
+				limit := r.URL.Query().Get("limit")
+				if limit == "2" {
+					if err := json.NewEncoder(w).Encode(userRecords); err != nil {
+						t.Fatalf("encode user discover page: %v", err)
+					}
+					return
+				}
+				w.Header().Set("Link", "</api/v1/users?after=cursor-user-2&limit=1>; rel=\"next\"")
+				if err := json.NewEncoder(w).Encode(userRecords[:1]); err != nil {
+					t.Fatalf("encode users page 1: %v", err)
+				}
+				return
+			}
+			if after == "cursor-user-2" {
+				if err := json.NewEncoder(w).Encode(userRecords[1:2]); err != nil {
+					t.Fatalf("encode users page 2: %v", err)
+				}
+				return
+			}
+			if err := json.NewEncoder(w).Encode([]map[string]any{}); err != nil {
+				t.Fatalf("encode empty users page: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -5,11 +5,47 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
+
+type rewriteTransport struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.URL.Scheme = t.target.Scheme
+	cloned.URL.Host = t.target.Host
+	cloned.Host = t.target.Host
+	return t.base.RoundTrip(cloned)
+}
+
+func newTestSource(t *testing.T, handler http.Handler) (*Source, func()) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	target, err := url.Parse(server.URL)
+	if err != nil {
+		server.Close()
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	source, err := New()
+	if err != nil {
+		server.Close()
+		t.Fatalf("New() error = %v", err)
+	}
+	source.client = &http.Client{
+		Transport: rewriteTransport{
+			target: target,
+			base:   http.DefaultTransport,
+		},
+	}
+	return source, server.Close
+}
 
 func TestNewLoadsCatalog(t *testing.T) {
 	source, err := New()
@@ -57,6 +93,25 @@ func TestUserRejectsSince(t *testing.T) {
 	}), nil)
 	if err == nil {
 		t.Fatal("Read(user) error = nil, want non-nil")
+	}
+}
+
+func TestParseSettingsRejectsUnsafeBaseURL(t *testing.T) {
+	for name, baseURL := range map[string]string{
+		"http":       "http://writer.okta.com",
+		"other-host": "https://attacker.example.com",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+				"base_url": baseURL,
+				"domain":   "writer.okta.com",
+				"family":   "audit",
+				"token":    "test-token",
+			}))
+			if err == nil {
+				t.Fatalf("parseSettings() error = nil, want non-nil")
+			}
+		})
 	}
 }
 
@@ -121,15 +176,9 @@ func TestNewFixtureReplaysFixturePages(t *testing.T) {
 }
 
 func TestCheckDiscoverAndReadLiveOktaAuditPreview(t *testing.T) {
-	server := httptest.NewServer(newOktaAPIHandler(t))
-	defer server.Close()
-
-	source, err := New()
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
+	source, cleanup := newTestSource(t, newOktaAPIHandler(t))
+	defer cleanup()
 	cfg := sourcecdk.NewConfig(map[string]string{
-		"base_url": server.URL,
 		"domain":   "writer.okta.com",
 		"family":   "audit",
 		"per_page": "1",
@@ -190,15 +239,9 @@ func TestCheckDiscoverAndReadLiveOktaAuditPreview(t *testing.T) {
 }
 
 func TestCheckDiscoverAndReadLiveOktaUserPreview(t *testing.T) {
-	server := httptest.NewServer(newOktaAPIHandler(t))
-	defer server.Close()
-
-	source, err := New()
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
+	source, cleanup := newTestSource(t, newOktaAPIHandler(t))
+	defer cleanup()
 	discoverCfg := sourcecdk.NewConfig(map[string]string{
-		"base_url": server.URL,
 		"domain":   "writer.okta.com",
 		"family":   "user",
 		"per_page": "2",
@@ -220,7 +263,6 @@ func TestCheckDiscoverAndReadLiveOktaUserPreview(t *testing.T) {
 	}
 
 	readCfg := sourcecdk.NewConfig(map[string]string{
-		"base_url": server.URL,
 		"domain":   "writer.okta.com",
 		"family":   "user",
 		"per_page": "1",

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -579,3 +579,34 @@ func newOktaAPIHandler(t *testing.T) http.Handler {
 		}
 	})
 }
+
+func TestNormalizeBaseURLRejectsNonRootPaths(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"https://writer.okta.com/evil",
+		"https://writer.okta.com/api/v1",
+		"https://writer.okta.com/?q=1",
+	}
+	for _, raw := range cases {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if _, err := normalizeBaseURL(raw, "writer.okta.com"); err == nil {
+				t.Fatalf("normalizeBaseURL(%q) = nil, want error", raw)
+			}
+		})
+	}
+}
+
+func TestNormalizeBaseURLAllowsRoot(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{"https://writer.okta.com", "https://writer.okta.com/", "https://writer.okta.com:443"} {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if _, err := normalizeBaseURL(raw, "writer.okta.com"); err != nil {
+				t.Fatalf("normalizeBaseURL(%q) = %v, want nil", raw, err)
+			}
+		})
+	}
+}

--- a/sources/okta/testdata/discover_audit.json
+++ b/sources/okta/testdata/discover_audit.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:writer.okta.com:org:writer.okta.com"
+]

--- a/sources/okta/testdata/discover_user.json
+++ b/sources/okta/testdata/discover_user.json
@@ -1,0 +1,4 @@
+[
+  "urn:cerebro:writer.okta.com:user:00u1",
+  "urn:cerebro:writer.okta.com:user:00u2"
+]

--- a/sources/okta/testdata/read_audit.json
+++ b/sources/okta/testdata/read_audit.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "okta-audit-fixture-1",
+    "tenant_id": "writer.okta.com",
+    "source_id": "okta",
+    "kind": "okta.audit",
+    "occurred_at": "2026-04-23T01:00:00Z",
+    "schema_ref": "okta/audit/v1",
+    "payload": {
+      "uuid": "evt-1",
+      "domain": "writer.okta.com",
+      "published": "2026-04-23T01:00:00Z",
+      "event_type": "user.session.start",
+      "severity": "INFO",
+      "resource_id": "00u1",
+      "resource_type": "User",
+      "raw": {
+        "uuid": "evt-1",
+        "eventType": "user.session.start"
+      }
+    },
+    "attributes": {
+      "domain": "writer.okta.com",
+      "event_type": "user.session.start",
+      "family": "audit",
+      "resource_id": "00u1",
+      "resource_type": "User"
+    }
+  },
+  {
+    "id": "okta-audit-fixture-2",
+    "tenant_id": "writer.okta.com",
+    "source_id": "okta",
+    "kind": "okta.audit",
+    "occurred_at": "2026-04-23T00:00:00Z",
+    "schema_ref": "okta/audit/v1",
+    "payload": {
+      "uuid": "evt-2",
+      "domain": "writer.okta.com",
+      "published": "2026-04-23T00:00:00Z",
+      "event_type": "policy.rule.update",
+      "severity": "WARN",
+      "resource_id": "pol-1",
+      "resource_type": "PolicyRule",
+      "raw": {
+        "uuid": "evt-2",
+        "eventType": "policy.rule.update"
+      }
+    },
+    "attributes": {
+      "domain": "writer.okta.com",
+      "event_type": "policy.rule.update",
+      "family": "audit",
+      "resource_id": "pol-1",
+      "resource_type": "PolicyRule"
+    }
+  }
+]

--- a/sources/okta/testdata/read_user.json
+++ b/sources/okta/testdata/read_user.json
@@ -1,0 +1,60 @@
+[
+  {
+    "id": "okta-user-fixture-1",
+    "tenant_id": "writer.okta.com",
+    "source_id": "okta",
+    "kind": "okta.user",
+    "occurred_at": "2026-04-23T01:00:00Z",
+    "schema_ref": "okta/user/v1",
+    "payload": {
+      "id": "00u1",
+      "domain": "writer.okta.com",
+      "status": "ACTIVE",
+      "profile": {
+        "login": "alice@writer.com",
+        "email": "alice@writer.com",
+        "display_name": "Alice Example"
+      },
+      "raw": {
+        "id": "00u1",
+        "status": "ACTIVE"
+      }
+    },
+    "attributes": {
+      "domain": "writer.okta.com",
+      "family": "user",
+      "login": "alice@writer.com",
+      "status": "ACTIVE",
+      "user_id": "00u1"
+    }
+  },
+  {
+    "id": "okta-user-fixture-2",
+    "tenant_id": "writer.okta.com",
+    "source_id": "okta",
+    "kind": "okta.user",
+    "occurred_at": "2026-04-23T00:30:00Z",
+    "schema_ref": "okta/user/v1",
+    "payload": {
+      "id": "00u2",
+      "domain": "writer.okta.com",
+      "status": "SUSPENDED",
+      "profile": {
+        "login": "admin@writer.com",
+        "email": "admin@writer.com",
+        "display_name": "Admin Example"
+      },
+      "raw": {
+        "id": "00u2",
+        "status": "SUSPENDED"
+      }
+    },
+    "attributes": {
+      "domain": "writer.okta.com",
+      "family": "user",
+      "login": "admin@writer.com",
+      "status": "SUSPENDED",
+      "user_id": "00u2"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add an Okta source with audit and user preview families, cursor paging, and canonical payloads
- add a checkpointed source runtime surface that stores source config and sync progress, supports runtime tenant overrides, and appends synced events
- project synced GitHub and Okta events into normalized Postgres current-state entities/links and Kuzu graph edges, including shared identifier linking
- cover the source, runtime, projector, Postgres, Kuzu, CLI, and bootstrap flows with focused regressions

## Testing
- make verify
