### PR TITLE
feat(source): add gh cli local github validation

### DIFF
--- a/cmd/cerebro/github_local.go
+++ b/cmd/cerebro/github_local.go
@@ -111,17 +111,29 @@ func prepareSourceRuntimeWithCLI(ctx context.Context, runtime *cerebrov1.SourceR
 }
 
 func hydrateGitHubLocalConfig(ctx context.Context, config map[string]string, cli githubLocalCLI, requireRepo bool, requireToken bool) (map[string]string, error) {
+	config = cloneConfig(config)
 	needsRepo := strings.TrimSpace(config["owner"]) == "" || (requireRepo && strings.TrimSpace(config["repo"]) == "")
 	if needsRepo {
 		repo, err := cli.Repo(ctx)
 		if err != nil {
 			return nil, err
 		}
+		ghOwner := strings.TrimSpace(repo.Owner.Login)
+		ghRepo := strings.TrimSpace(repo.Name)
+		if ghOwner == "" || ghRepo == "" {
+			return nil, fmt.Errorf("resolve github repo from gh cli: owner and repo are required")
+		}
+		if existing := strings.TrimSpace(config["owner"]); existing != "" && existing != ghOwner {
+			return nil, fmt.Errorf("resolve github repo from gh cli: owner mismatch (config=%q gh=%q)", existing, ghOwner)
+		}
+		if existing := strings.TrimSpace(config["repo"]); existing != "" && existing != ghRepo {
+			return nil, fmt.Errorf("resolve github repo from gh cli: repo mismatch (config=%q gh=%q)", existing, ghRepo)
+		}
 		if strings.TrimSpace(config["owner"]) == "" {
-			config["owner"] = strings.TrimSpace(repo.Owner.Login)
+			config["owner"] = ghOwner
 		}
 		if requireRepo && strings.TrimSpace(config["repo"]) == "" {
-			config["repo"] = strings.TrimSpace(repo.Name)
+			config["repo"] = ghRepo
 		}
 	}
 	if strings.TrimSpace(config["token"]) == "" && (requireToken || needsRepo) {

--- a/cmd/cerebro/github_local.go
+++ b/cmd/cerebro/github_local.go
@@ -96,15 +96,25 @@ func prepareSourceRuntimeWithCLI(ctx context.Context, runtime *cerebrov1.SourceR
 	if cli == nil {
 		return nil, fmt.Errorf("github local cli is required")
 	}
+	// gh CLI auth tokens must never land in a persisted SourceRuntime config: they would be
+	// written into the state store, possibly checkpointed, and shared across processes that have a
+	// different (or no) gh session. Hydrate only the owner/repo identity here and let the token
+	// flow per-call through prepareSourceConfigWithCLI for live read/discover/check requests.
+	originalConfig := cloned.GetConfig()
 	config, err := hydrateGitHubLocalConfig(
 		ctx,
-		cloned.GetConfig(),
+		originalConfig,
 		cli,
-		githubRuntimeRequiresRepo(cloned.GetConfig()),
-		githubRequiresToken(cloned.GetConfig()),
+		githubRuntimeRequiresRepo(originalConfig),
+		false,
 	)
 	if err != nil {
 		return nil, err
+	}
+	// Preserve a caller-supplied token (an explicit, persisted PAT) but never persist a token we
+	// just hydrated from the local gh CLI session.
+	if _, ok := originalConfig["token"]; !ok {
+		delete(config, "token")
 	}
 	cloned.Config = config
 	return cloned, nil

--- a/cmd/cerebro/github_local.go
+++ b/cmd/cerebro/github_local.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+const githubSourceID = "github"
+
+type githubLocalCLI interface {
+	AuthToken(context.Context) (string, error)
+	Repo(context.Context) (githubLocalRepo, error)
+}
+
+type execGitHubLocalCLI struct{}
+
+type githubLocalRepo struct {
+	Name  string               `json:"name"`
+	Owner githubLocalRepoOwner `json:"owner"`
+}
+
+type githubLocalRepoOwner struct {
+	Login string `json:"login"`
+}
+
+func (execGitHubLocalCLI) AuthToken(ctx context.Context) (string, error) {
+	output, err := exec.CommandContext(ctx, "gh", "auth", "token").Output()
+	if err != nil {
+		return "", fmt.Errorf("resolve github token from gh cli: %w", err)
+	}
+	token := strings.TrimSpace(string(output))
+	if token == "" {
+		return "", fmt.Errorf("resolve github token from gh cli: empty token")
+	}
+	return token, nil
+}
+
+func (execGitHubLocalCLI) Repo(ctx context.Context) (githubLocalRepo, error) {
+	output, err := exec.CommandContext(ctx, "gh", "repo", "view", "--json", "owner,name").Output()
+	if err != nil {
+		return githubLocalRepo{}, fmt.Errorf("resolve github repo from gh cli: %w", err)
+	}
+	var repo githubLocalRepo
+	if err := json.Unmarshal(output, &repo); err != nil {
+		return githubLocalRepo{}, fmt.Errorf("decode github repo from gh cli: %w", err)
+	}
+	if strings.TrimSpace(repo.Owner.Login) == "" {
+		return githubLocalRepo{}, fmt.Errorf("resolve github repo from gh cli: owner is required")
+	}
+	if strings.TrimSpace(repo.Name) == "" {
+		return githubLocalRepo{}, fmt.Errorf("resolve github repo from gh cli: repo is required")
+	}
+	return repo, nil
+}
+
+func prepareSourceConfig(ctx context.Context, sourceID string, command string, config map[string]string) (map[string]string, error) {
+	return prepareSourceConfigWithCLI(ctx, sourceID, command, config, execGitHubLocalCLI{})
+}
+
+func prepareSourceRuntime(ctx context.Context, runtime *cerebrov1.SourceRuntime) (*cerebrov1.SourceRuntime, error) {
+	return prepareSourceRuntimeWithCLI(ctx, runtime, execGitHubLocalCLI{})
+}
+
+func prepareSourceConfigWithCLI(ctx context.Context, sourceID string, command string, config map[string]string, cli githubLocalCLI) (map[string]string, error) {
+	cloned := cloneConfig(config)
+	if strings.TrimSpace(sourceID) != githubSourceID {
+		return cloned, nil
+	}
+	if cli == nil {
+		return cloned, fmt.Errorf("github local cli is required")
+	}
+	return hydrateGitHubLocalConfig(
+		ctx,
+		cloned,
+		cli,
+		githubReadRequiresRepo(command, cloned),
+		githubRequiresToken(cloned),
+	)
+}
+
+func prepareSourceRuntimeWithCLI(ctx context.Context, runtime *cerebrov1.SourceRuntime, cli githubLocalCLI) (*cerebrov1.SourceRuntime, error) {
+	if runtime == nil {
+		return nil, nil
+	}
+	cloned := proto.Clone(runtime).(*cerebrov1.SourceRuntime)
+	if strings.TrimSpace(cloned.GetSourceId()) != githubSourceID {
+		return cloned, nil
+	}
+	if cli == nil {
+		return nil, fmt.Errorf("github local cli is required")
+	}
+	config, err := hydrateGitHubLocalConfig(
+		ctx,
+		cloned.GetConfig(),
+		cli,
+		githubRuntimeRequiresRepo(cloned.GetConfig()),
+		githubRequiresToken(cloned.GetConfig()),
+	)
+	if err != nil {
+		return nil, err
+	}
+	cloned.Config = config
+	return cloned, nil
+}
+
+func hydrateGitHubLocalConfig(ctx context.Context, config map[string]string, cli githubLocalCLI, requireRepo bool, requireToken bool) (map[string]string, error) {
+	needsRepo := strings.TrimSpace(config["owner"]) == "" || (requireRepo && strings.TrimSpace(config["repo"]) == "")
+	if needsRepo {
+		repo, err := cli.Repo(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(config["owner"]) == "" {
+			config["owner"] = strings.TrimSpace(repo.Owner.Login)
+		}
+		if requireRepo && strings.TrimSpace(config["repo"]) == "" {
+			config["repo"] = strings.TrimSpace(repo.Name)
+		}
+	}
+	if strings.TrimSpace(config["token"]) == "" && (requireToken || needsRepo) {
+		token, err := cli.AuthToken(ctx)
+		if err != nil {
+			return nil, err
+		}
+		config["token"] = token
+	}
+	return config, nil
+}
+
+func githubReadRequiresRepo(command string, config map[string]string) bool {
+	if strings.TrimSpace(command) != "read" {
+		return false
+	}
+	return githubRuntimeRequiresRepo(config)
+}
+
+func githubRuntimeRequiresRepo(config map[string]string) bool {
+	return strings.TrimSpace(config["family"]) != "audit"
+}
+
+func githubRequiresToken(config map[string]string) bool {
+	return strings.TrimSpace(config["family"]) == "audit"
+}
+
+func cloneConfig(config map[string]string) map[string]string {
+	cloned := make(map[string]string, len(config))
+	for key, value := range config {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/cmd/cerebro/github_local.go
+++ b/cmd/cerebro/github_local.go
@@ -113,7 +113,7 @@ func prepareSourceRuntimeWithCLI(ctx context.Context, runtime *cerebrov1.SourceR
 	}
 	// Preserve a caller-supplied token (an explicit, persisted PAT) but never persist a token we
 	// just hydrated from the local gh CLI session.
-	if _, ok := originalConfig["token"]; !ok {
+	if strings.TrimSpace(originalConfig["token"]) == "" {
 		delete(config, "token")
 	}
 	cloned.Config = config

--- a/cmd/cerebro/github_local_e2e_test.go
+++ b/cmd/cerebro/github_local_e2e_test.go
@@ -51,14 +51,6 @@ func TestGitHubLocalEndToEndWithGHCLI(t *testing.T) {
 		t.Fatalf("prepareSourceConfigWithCLI() error = %v", err)
 	}
 
-	pulls, err := readGitHubPullsWithGHCLI(ctx, config["owner"], config["repo"], 5)
-	if err != nil {
-		t.Fatalf("readGitHubPullsWithGHCLI() error = %v", err)
-	}
-	if len(pulls) == 0 {
-		t.Fatal("readGitHubPullsWithGHCLI() returned zero pulls")
-	}
-
 	registry, err := sourceregistry.Builtin()
 	if err != nil {
 		t.Fatalf("Builtin() error = %v", err)
@@ -78,17 +70,24 @@ func TestGitHubLocalEndToEndWithGHCLI(t *testing.T) {
 	if err := json.Unmarshal(response.GetEvents()[0].GetPayload(), &payload); err != nil {
 		t.Fatalf("unmarshal source payload: %v", err)
 	}
-	if payload.Number != pulls[0].Number {
-		t.Fatalf("source payload number = %d, want %d", payload.Number, pulls[0].Number)
+	if payload.Number == 0 {
+		t.Fatal("source payload number = 0, want non-zero")
 	}
-	if payload.Title != pulls[0].Title {
-		t.Fatalf("source payload title = %q, want %q", payload.Title, pulls[0].Title)
+	pull, err := readGitHubPullWithGHCLI(ctx, config["owner"], config["repo"], payload.Number)
+	if err != nil {
+		t.Fatalf("readGitHubPullWithGHCLI(%d) error = %v", payload.Number, err)
 	}
-	if payload.URL != pulls[0].HTMLURL {
-		t.Fatalf("source payload url = %q, want %q", payload.URL, pulls[0].HTMLURL)
+	if payload.Number != pull.Number {
+		t.Fatalf("source payload number = %d, want %d", payload.Number, pull.Number)
 	}
-	if payload.Author != pulls[0].User.Login {
-		t.Fatalf("source payload author = %q, want %q", payload.Author, pulls[0].User.Login)
+	if payload.Title != pull.Title {
+		t.Fatalf("source payload title = %q, want %q", payload.Title, pull.Title)
+	}
+	if payload.URL != pull.HTMLURL {
+		t.Fatalf("source payload url = %q, want %q", payload.URL, pull.HTMLURL)
+	}
+	if payload.Author != pull.User.Login {
+		t.Fatalf("source payload author = %q, want %q", payload.Author, pull.User.Login)
 	}
 
 	graphPath := filepath.Join(t.TempDir(), "graph")
@@ -142,17 +141,17 @@ func TestGitHubLocalEndToEndWithGHCLI(t *testing.T) {
 	)
 }
 
-func readGitHubPullsWithGHCLI(ctx context.Context, owner string, repo string, perPage int) ([]ghAPIPull, error) {
-	path := fmt.Sprintf("/repos/%s/%s/pulls?state=all&sort=updated&direction=desc&per_page=%d", owner, repo, perPage)
+func readGitHubPullWithGHCLI(ctx context.Context, owner string, repo string, number int) (ghAPIPull, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
 	output, err := exec.CommandContext(ctx, "gh", "api", path).Output()
 	if err != nil {
-		return nil, fmt.Errorf("read github pulls with gh cli: %w", err)
+		return ghAPIPull{}, fmt.Errorf("read github pull with gh cli: %w", err)
 	}
-	var pulls []ghAPIPull
-	if err := json.Unmarshal(output, &pulls); err != nil {
-		return nil, fmt.Errorf("decode github pulls from gh cli: %w", err)
+	var pull ghAPIPull
+	if err := json.Unmarshal(output, &pull); err != nil {
+		return ghAPIPull{}, fmt.Errorf("decode github pull from gh cli: %w", err)
 	}
-	return pulls, nil
+	return pull, nil
 }
 
 func graphCount(t *testing.T, db *sql.DB, query string) int64 {

--- a/cmd/cerebro/github_local_e2e_test.go
+++ b/cmd/cerebro/github_local_e2e_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	kuzudb "github.com/kuzudb/go-kuzu"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	configpkg "github.com/writer/cerebro/internal/config"
+	graphstorekuzu "github.com/writer/cerebro/internal/graphstore/kuzu"
+	"github.com/writer/cerebro/internal/sourceops"
+	"github.com/writer/cerebro/internal/sourceprojection"
+	"github.com/writer/cerebro/internal/sourceregistry"
+)
+
+type ghAPIPull struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	HTMLURL string `json:"html_url"`
+	User    struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+type githubSourcePayload struct {
+	Number     int    `json:"number"`
+	Repository string `json:"repository"`
+	Title      string `json:"title"`
+	URL        string `json:"url"`
+	Author     string `json:"author"`
+}
+
+func TestGitHubLocalEndToEndWithGHCLI(t *testing.T) {
+	if os.Getenv("CEREBRO_RUN_GITHUB_LOCAL_E2E") != "1" {
+		t.Skip("set CEREBRO_RUN_GITHUB_LOCAL_E2E=1 to run the live GitHub local e2e flow")
+	}
+
+	ctx := context.Background()
+	config, err := prepareSourceConfigWithCLI(ctx, githubSourceID, "read", map[string]string{
+		"per_page": "5",
+		"state":    "all",
+	}, execGitHubLocalCLI{})
+	if err != nil {
+		t.Fatalf("prepareSourceConfigWithCLI() error = %v", err)
+	}
+
+	pulls, err := readGitHubPullsWithGHCLI(ctx, config["owner"], config["repo"], 5)
+	if err != nil {
+		t.Fatalf("readGitHubPullsWithGHCLI() error = %v", err)
+	}
+	if len(pulls) == 0 {
+		t.Fatal("readGitHubPullsWithGHCLI() returned zero pulls")
+	}
+
+	registry, err := sourceregistry.Builtin()
+	if err != nil {
+		t.Fatalf("Builtin() error = %v", err)
+	}
+	response, err := sourceops.New(registry).Read(ctx, &cerebrov1.ReadSourceRequest{
+		SourceId: githubSourceID,
+		Config:   config,
+	})
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(response.GetEvents()) == 0 {
+		t.Fatal("Read().Events = 0, want at least 1 live pull-request event")
+	}
+
+	var payload githubSourcePayload
+	if err := json.Unmarshal(response.GetEvents()[0].GetPayload(), &payload); err != nil {
+		t.Fatalf("unmarshal source payload: %v", err)
+	}
+	if payload.Number != pulls[0].Number {
+		t.Fatalf("source payload number = %d, want %d", payload.Number, pulls[0].Number)
+	}
+	if payload.Title != pulls[0].Title {
+		t.Fatalf("source payload title = %q, want %q", payload.Title, pulls[0].Title)
+	}
+	if payload.URL != pulls[0].HTMLURL {
+		t.Fatalf("source payload url = %q, want %q", payload.URL, pulls[0].HTMLURL)
+	}
+	if payload.Author != pulls[0].User.Login {
+		t.Fatalf("source payload author = %q, want %q", payload.Author, pulls[0].User.Login)
+	}
+
+	graphPath := filepath.Join(t.TempDir(), "graph")
+	store, err := graphstorekuzu.Open(configpkg.GraphStoreConfig{
+		Driver:   configpkg.GraphStoreDriverKuzu,
+		KuzuPath: graphPath,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() {
+		if closeErr := store.Close(); closeErr != nil {
+			t.Fatalf("Close() error = %v", closeErr)
+		}
+	}()
+
+	projector := sourceprojection.New(nil, store)
+	for _, event := range response.GetEvents() {
+		if _, err := projector.Project(ctx, event); err != nil {
+			t.Fatalf("Project(%q) error = %v", event.GetId(), err)
+		}
+	}
+
+	db, err := sql.Open(kuzudb.Name, "kuzu://"+filepath.ToSlash(graphPath))
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Fatalf("db.Close() error = %v", closeErr)
+		}
+	}()
+
+	nodeCount := graphCount(t, db, "MATCH (entity:entity) RETURN COUNT(entity)")
+	authoredCount := graphCount(t, db, "MATCH (:entity)-[r:relation]->(:entity) WHERE r.relation = 'authored' RETURN COUNT(r)")
+	if nodeCount == 0 {
+		t.Fatal("projected graph node count = 0, want non-zero")
+	}
+	if authoredCount == 0 {
+		t.Fatal("projected authored link count = 0, want non-zero")
+	}
+
+	t.Logf(
+		"validated live github flow owner=%s repo=%s first_pr=%d events=%d graph_nodes=%d authored_links=%d",
+		config["owner"],
+		config["repo"],
+		payload.Number,
+		len(response.GetEvents()),
+		nodeCount,
+		authoredCount,
+	)
+}
+
+func readGitHubPullsWithGHCLI(ctx context.Context, owner string, repo string, perPage int) ([]ghAPIPull, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls?state=all&sort=updated&direction=desc&per_page=%d", owner, repo, perPage)
+	output, err := exec.CommandContext(ctx, "gh", "api", path).Output()
+	if err != nil {
+		return nil, fmt.Errorf("read github pulls with gh cli: %w", err)
+	}
+	var pulls []ghAPIPull
+	if err := json.Unmarshal(output, &pulls); err != nil {
+		return nil, fmt.Errorf("decode github pulls from gh cli: %w", err)
+	}
+	return pulls, nil
+}
+
+func graphCount(t *testing.T, db *sql.DB, query string) int64 {
+	t.Helper()
+	var count int64
+	if err := db.QueryRowContext(context.Background(), query).Scan(&count); err != nil {
+		t.Fatalf("QueryRowContext(%q) error = %v", query, err)
+	}
+	return count
+}

--- a/cmd/cerebro/github_local_test.go
+++ b/cmd/cerebro/github_local_test.go
@@ -175,8 +175,32 @@ func TestPrepareSourceRuntimeWithCLIHydratesGitHubRuntime(t *testing.T) {
 	if got := runtime.GetConfig()["repo"]; got != "cerebro" {
 		t.Fatalf("runtime.Config[repo] = %q, want %q", got, "cerebro")
 	}
-	if got := runtime.GetConfig()["token"]; got != "gh-token" {
-		t.Fatalf("runtime.Config[token] = %q, want %q", got, "gh-token")
+	// gh CLI auth tokens must never land in the persisted SourceRuntime config: they expose the
+	// developer's personal credential to anyone with state-store access and are short-lived.
+	if got, ok := runtime.GetConfig()["token"]; ok {
+		t.Fatalf("runtime.Config[token] = %q, want absent", got)
+	}
+}
+
+func TestPrepareSourceRuntimeWithCLIPreservesCallerToken(t *testing.T) {
+	// Caller passes their own PAT explicitly; that's an opt-in persistent token and must round-trip.
+	cli := &fakeGitHubLocalCLI{
+		token: "gh-token",
+		repo: githubLocalRepo{
+			Name:  "cerebro",
+			Owner: githubLocalRepoOwner{Login: "writer"},
+		},
+	}
+	runtime, err := prepareSourceRuntimeWithCLI(context.Background(), &cerebrov1.SourceRuntime{
+		Id:       "writer-github",
+		SourceId: githubSourceID,
+		Config:   map[string]string{"state": "all", "token": "ghp_callerprovided"},
+	}, cli)
+	if err != nil {
+		t.Fatalf("prepareSourceRuntimeWithCLI() error = %v", err)
+	}
+	if got := runtime.GetConfig()["token"]; got != "ghp_callerprovided" {
+		t.Fatalf("runtime.Config[token] = %q, want caller-supplied PAT preserved", got)
 	}
 }
 

--- a/cmd/cerebro/github_local_test.go
+++ b/cmd/cerebro/github_local_test.go
@@ -204,6 +204,27 @@ func TestPrepareSourceRuntimeWithCLIPreservesCallerToken(t *testing.T) {
 	}
 }
 
+func TestPrepareSourceRuntimeWithCLIDropsWhitespaceCallerToken(t *testing.T) {
+	cli := &fakeGitHubLocalCLI{
+		token: "gh-token",
+		repo: githubLocalRepo{
+			Name:  "cerebro",
+			Owner: githubLocalRepoOwner{Login: "writer"},
+		},
+	}
+	runtime, err := prepareSourceRuntimeWithCLI(context.Background(), &cerebrov1.SourceRuntime{
+		Id:       "writer-github",
+		SourceId: githubSourceID,
+		Config:   map[string]string{"state": "all", "token": " \t "},
+	}, cli)
+	if err != nil {
+		t.Fatalf("prepareSourceRuntimeWithCLI() error = %v", err)
+	}
+	if got, ok := runtime.GetConfig()["token"]; ok {
+		t.Fatalf("runtime.Config[token] = %q, want absent", got)
+	}
+}
+
 func TestPrepareSourceConfigWithCLIReturnsGHError(t *testing.T) {
 	cli := &fakeGitHubLocalCLI{
 		tokenErr: errors.New("gh unavailable"),

--- a/cmd/cerebro/github_local_test.go
+++ b/cmd/cerebro/github_local_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+type fakeGitHubLocalCLI struct {
+	token          string
+	tokenErr       error
+	repo           githubLocalRepo
+	repoErr        error
+	authTokenCalls int
+	repoCalls      int
+}
+
+func (f *fakeGitHubLocalCLI) AuthToken(context.Context) (string, error) {
+	f.authTokenCalls++
+	if f.tokenErr != nil {
+		return "", f.tokenErr
+	}
+	return f.token, nil
+}
+
+func (f *fakeGitHubLocalCLI) Repo(context.Context) (githubLocalRepo, error) {
+	f.repoCalls++
+	if f.repoErr != nil {
+		return githubLocalRepo{}, f.repoErr
+	}
+	return f.repo, nil
+}
+
+func TestPrepareSourceConfigWithCLIHydratesGitHubRead(t *testing.T) {
+	cli := &fakeGitHubLocalCLI{
+		token: "gh-token",
+		repo: githubLocalRepo{
+			Name: "cerebro",
+			Owner: githubLocalRepoOwner{
+				Login: "writer",
+			},
+		},
+	}
+
+	config, err := prepareSourceConfigWithCLI(context.Background(), githubSourceID, "read", map[string]string{"state": "all"}, cli)
+	if err != nil {
+		t.Fatalf("prepareSourceConfigWithCLI() error = %v", err)
+	}
+	if got := config["token"]; got != "gh-token" {
+		t.Fatalf("config[token] = %q, want %q", got, "gh-token")
+	}
+	if got := config["owner"]; got != "writer" {
+		t.Fatalf("config[owner] = %q, want %q", got, "writer")
+	}
+	if got := config["repo"]; got != "cerebro" {
+		t.Fatalf("config[repo] = %q, want %q", got, "cerebro")
+	}
+	if cli.authTokenCalls != 1 {
+		t.Fatalf("authTokenCalls = %d, want 1", cli.authTokenCalls)
+	}
+	if cli.repoCalls != 1 {
+		t.Fatalf("repoCalls = %d, want 1", cli.repoCalls)
+	}
+}
+
+func TestPrepareSourceConfigWithCLIPreservesExplicitValues(t *testing.T) {
+	cli := &fakeGitHubLocalCLI{}
+
+	config, err := prepareSourceConfigWithCLI(context.Background(), githubSourceID, "read", map[string]string{
+		"owner": "writer",
+		"repo":  "cerebro",
+	}, cli)
+	if err != nil {
+		t.Fatalf("prepareSourceConfigWithCLI() error = %v", err)
+	}
+	if _, ok := config["token"]; ok {
+		t.Fatalf("config[token] = %q, want omitted", config["token"])
+	}
+	if cli.authTokenCalls != 0 {
+		t.Fatalf("authTokenCalls = %d, want 0", cli.authTokenCalls)
+	}
+	if cli.repoCalls != 0 {
+		t.Fatalf("repoCalls = %d, want 0", cli.repoCalls)
+	}
+}
+
+func TestPrepareSourceConfigWithCLIAuditHydratesOwnerAndToken(t *testing.T) {
+	cli := &fakeGitHubLocalCLI{
+		token: "gh-token",
+		repo: githubLocalRepo{
+			Name: "cerebro",
+			Owner: githubLocalRepoOwner{
+				Login: "writer",
+			},
+		},
+	}
+
+	config, err := prepareSourceConfigWithCLI(context.Background(), githubSourceID, "read", map[string]string{
+		"family": "audit",
+	}, cli)
+	if err != nil {
+		t.Fatalf("prepareSourceConfigWithCLI() error = %v", err)
+	}
+	if got := config["owner"]; got != "writer" {
+		t.Fatalf("config[owner] = %q, want %q", got, "writer")
+	}
+	if got := config["token"]; got != "gh-token" {
+		t.Fatalf("config[token] = %q, want %q", got, "gh-token")
+	}
+	if _, ok := config["repo"]; ok {
+		t.Fatalf("config[repo] = %q, want omitted", config["repo"])
+	}
+}
+
+func TestPrepareSourceRuntimeWithCLIHydratesGitHubRuntime(t *testing.T) {
+	cli := &fakeGitHubLocalCLI{
+		token: "gh-token",
+		repo: githubLocalRepo{
+			Name: "cerebro",
+			Owner: githubLocalRepoOwner{
+				Login: "writer",
+			},
+		},
+	}
+
+	runtime, err := prepareSourceRuntimeWithCLI(context.Background(), &cerebrov1.SourceRuntime{
+		Id:       "writer-github",
+		SourceId: githubSourceID,
+		Config:   map[string]string{"state": "all"},
+	}, cli)
+	if err != nil {
+		t.Fatalf("prepareSourceRuntimeWithCLI() error = %v", err)
+	}
+	if got := runtime.GetConfig()["owner"]; got != "writer" {
+		t.Fatalf("runtime.Config[owner] = %q, want %q", got, "writer")
+	}
+	if got := runtime.GetConfig()["repo"]; got != "cerebro" {
+		t.Fatalf("runtime.Config[repo] = %q, want %q", got, "cerebro")
+	}
+	if got := runtime.GetConfig()["token"]; got != "gh-token" {
+		t.Fatalf("runtime.Config[token] = %q, want %q", got, "gh-token")
+	}
+}
+
+func TestPrepareSourceConfigWithCLIReturnsGHError(t *testing.T) {
+	cli := &fakeGitHubLocalCLI{
+		tokenErr: errors.New("gh unavailable"),
+	}
+
+	_, err := prepareSourceConfigWithCLI(context.Background(), githubSourceID, "read", map[string]string{"state": "all"}, cli)
+	if err == nil {
+		t.Fatal("prepareSourceConfigWithCLI() error = nil, want non-nil")
+	}
+}

--- a/cmd/cerebro/github_local_test.go
+++ b/cmd/cerebro/github_local_test.go
@@ -114,6 +114,42 @@ func TestPrepareSourceConfigWithCLIAuditHydratesOwnerAndToken(t *testing.T) {
 	}
 }
 
+func TestPrepareSourceConfigWithCLIRejectsOwnerMismatch(t *testing.T) {
+	cli := &fakeGitHubLocalCLI{
+		repo: githubLocalRepo{
+			Name: "cerebro",
+			Owner: githubLocalRepoOwner{
+				Login: "writer",
+			},
+		},
+	}
+
+	_, err := prepareSourceConfigWithCLI(context.Background(), githubSourceID, "read", map[string]string{
+		"owner": "other",
+	}, cli)
+	if err == nil {
+		t.Fatal("prepareSourceConfigWithCLI() error = nil, want non-nil")
+	}
+}
+
+func TestPrepareSourceConfigWithCLIRejectsRepoMismatch(t *testing.T) {
+	cli := &fakeGitHubLocalCLI{
+		repo: githubLocalRepo{
+			Name: "cerebro",
+			Owner: githubLocalRepoOwner{
+				Login: "writer",
+			},
+		},
+	}
+
+	_, err := prepareSourceConfigWithCLI(context.Background(), githubSourceID, "read", map[string]string{
+		"repo": "other",
+	}, cli)
+	if err == nil {
+		t.Fatal("prepareSourceConfigWithCLI() error = nil, want non-nil")
+	}
+}
+
 func TestPrepareSourceRuntimeWithCLIHydratesGitHubRuntime(t *testing.T) {
 	cli := &fakeGitHubLocalCLI{
 		token: "gh-token",

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -113,6 +113,7 @@ func runSource(args []string) error {
 	if len(args) == 0 {
 		return usageError(fmt.Sprintf("usage: %s source [list|check|discover|read] ...", os.Args[0]))
 	}
+	ctx := context.Background()
 	registry, err := sourceregistry.Builtin()
 	if err != nil {
 		return fmt.Errorf("open source registry: %w", err)
@@ -127,7 +128,11 @@ func runSource(args []string) error {
 		if err != nil {
 			return err
 		}
-		response, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{
+		config, err = prepareSourceConfig(ctx, sourceID, "check", config)
+		if err != nil {
+			return err
+		}
+		response, err := service.Check(ctx, &cerebrov1.CheckSourceRequest{
 			SourceId: sourceID,
 			Config:   config,
 		})
@@ -140,7 +145,11 @@ func runSource(args []string) error {
 		if err != nil {
 			return err
 		}
-		response, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{
+		config, err = prepareSourceConfig(ctx, sourceID, "discover", config)
+		if err != nil {
+			return err
+		}
+		response, err := service.Discover(ctx, &cerebrov1.DiscoverSourceRequest{
 			SourceId: sourceID,
 			Config:   config,
 		})
@@ -153,7 +162,11 @@ func runSource(args []string) error {
 		if err != nil {
 			return err
 		}
-		response, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
+		config, err = prepareSourceConfig(ctx, sourceID, "read", config)
+		if err != nil {
+			return err
+		}
+		response, err := service.Read(ctx, &cerebrov1.ReadSourceRequest{
 			SourceId: sourceID,
 			Config:   config,
 			Cursor:   cursor,
@@ -175,7 +188,8 @@ func runSourceRuntime(args []string) error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
-	deps, closeDeps, err := bootstrap.OpenDependencies(context.Background(), cfg)
+	ctx := context.Background()
+	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("open dependencies: %w", err)
 	}
@@ -201,7 +215,11 @@ func runSourceRuntime(args []string) error {
 		if err != nil {
 			return err
 		}
-		response, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: runtime})
+		runtime, err = prepareSourceRuntime(ctx, runtime)
+		if err != nil {
+			return err
+		}
+		response, err := service.Put(ctx, &cerebrov1.PutSourceRuntimeRequest{Runtime: runtime})
 		if err != nil {
 			return err
 		}
@@ -210,7 +228,7 @@ func runSourceRuntime(args []string) error {
 		if len(args) < 2 || strings.TrimSpace(args[1]) == "" {
 			return usageError(fmt.Sprintf("usage: %s source-runtime get <runtime-id>", os.Args[0]))
 		}
-		response, err := service.Get(context.Background(), &cerebrov1.GetSourceRuntimeRequest{Id: strings.TrimSpace(args[1])})
+		response, err := service.Get(ctx, &cerebrov1.GetSourceRuntimeRequest{Id: strings.TrimSpace(args[1])})
 		if err != nil {
 			return err
 		}
@@ -220,7 +238,7 @@ func runSourceRuntime(args []string) error {
 		if err != nil {
 			return err
 		}
-		response, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
+		response, err := service.Sync(ctx, &cerebrov1.SyncSourceRuntimeRequest{
 			Id:        runtimeID,
 			PageLimit: pageLimit,
 		})


### PR DESCRIPTION
## Summary
- auto-resolve local GitHub source auth and repo config from the GH CLI when running the CLI without explicit token/owner/repo arguments
- add focused unit coverage for the GH CLI hydration path on source and source-runtime commands
- add a live opt-in end-to-end test that compares Cerebro GitHub source output against `gh api` and projects the result into local Kuzu

## Testing
- make verify
- `go run ./cmd/cerebro source read github per_page=1 state=all`
- `go run ./cmd/cerebro source read github family=audit per_page=1`
- `CEREBRO_RUN_GITHUB_LOCAL_E2E=1 go test ./cmd/cerebro -run TestGitHubLocalEndToEndWithGHCLI -v`
