### PR TITLE
feat(graph): add local rebuild dry-run

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/writer/cerebro/internal/bootstrap"
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphrebuild"
+	"github.com/writer/cerebro/internal/sourceregistry"
+)
+
+func runGraph(args []string) error {
+	if len(args) == 0 {
+		return usageError(fmt.Sprintf("usage: %s graph rebuild <runtime-id> [dry_run=true] [page_limit=N] [preview_limit=N]", os.Args[0]))
+	}
+	switch args[0] {
+	case "rebuild":
+		runtimeID, pageLimit, previewLimit, dryRun, err := parseGraphRebuildArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		if !dryRun {
+			return fmt.Errorf("graph rebuild currently only supports dry_run=true")
+		}
+		cfg, err := config.Load()
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		ctx := context.Background()
+		deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+		if err != nil {
+			return fmt.Errorf("open dependencies: %w", err)
+		}
+		defer func() {
+			if err := closeDeps(); err != nil {
+				log.Printf("close dependencies: %v", err)
+			}
+		}()
+		registry, err := sourceregistry.Builtin()
+		if err != nil {
+			return fmt.Errorf("open source registry: %w", err)
+		}
+		service := graphrebuild.New(registry, sourceRuntimeStore(deps.StateStore))
+		result, err := service.RebuildDryRun(ctx, graphrebuild.Request{
+			RuntimeID:    runtimeID,
+			PageLimit:    pageLimit,
+			PreviewLimit: previewLimit,
+		})
+		if err != nil {
+			return err
+		}
+		return printJSON(result)
+	default:
+		return usageError(fmt.Sprintf("usage: %s graph rebuild <runtime-id> [dry_run=true] [page_limit=N] [preview_limit=N]", os.Args[0]))
+	}
+}
+
+func parseGraphRebuildArgs(args []string) (string, uint32, int, bool, error) {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return "", 0, 0, false, usageError(fmt.Sprintf("usage: %s graph rebuild <runtime-id> [dry_run=true] [page_limit=N] [preview_limit=N]", os.Args[0]))
+	}
+	runtimeID := strings.TrimSpace(args[0])
+	dryRun := true
+	var (
+		pageLimit    uint32
+		previewLimit int
+	)
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return "", 0, 0, false, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		switch strings.TrimSpace(key) {
+		case "dry_run":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return "", 0, 0, false, fmt.Errorf("parse dry_run: %w", err)
+			}
+			dryRun = parsed
+		case "page_limit":
+			parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+			if err != nil {
+				return "", 0, 0, false, fmt.Errorf("parse page_limit: %w", err)
+			}
+			pageLimit = uint32(parsed)
+		case "preview_limit":
+			parsed, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil {
+				return "", 0, 0, false, fmt.Errorf("parse preview_limit: %w", err)
+			}
+			previewLimit = parsed
+		default:
+			return "", 0, 0, false, usageError(fmt.Sprintf("unsupported graph rebuild argument %q", key))
+		}
+	}
+	return runtimeID, pageLimit, previewLimit, dryRun, nil
+}
+
+func printJSON(value any) error {
+	payload, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal response: %w", err)
+	}
+	if _, err := os.Stdout.Write(append(payload, '\n')); err != nil {
+		return fmt.Errorf("write response: %w", err)
+	}
+	return nil
+}

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+func TestParseGraphRebuildArgs(t *testing.T) {
+	runtimeID, pageLimit, previewLimit, dryRun, err := parseGraphRebuildArgs([]string{
+		"writer-github",
+		"page_limit=3",
+		"preview_limit=7",
+		"dry_run=true",
+	})
+	if err != nil {
+		t.Fatalf("parseGraphRebuildArgs() error = %v", err)
+	}
+	if runtimeID != "writer-github" {
+		t.Fatalf("runtimeID = %q, want %q", runtimeID, "writer-github")
+	}
+	if pageLimit != 3 {
+		t.Fatalf("pageLimit = %d, want 3", pageLimit)
+	}
+	if previewLimit != 7 {
+		t.Fatalf("previewLimit = %d, want 7", previewLimit)
+	}
+	if !dryRun {
+		t.Fatalf("dryRun = %t, want true", dryRun)
+	}
+}
+
+func TestParseGraphRebuildArgsRejectsUnknownKey(t *testing.T) {
+	_, _, _, _, err := parseGraphRebuildArgs([]string{"writer-github", "bogus=1"})
+	if err == nil {
+		t.Fatal("parseGraphRebuildArgs() error = nil, want usage error")
+	}
+}

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -51,6 +51,8 @@ func run(args []string) error {
 	switch command {
 	case "serve":
 		return serve()
+	case "graph":
+		return runGraph(args[1:])
 	case "source":
 		return runSource(args[1:])
 	case "source-runtime":
@@ -59,7 +61,7 @@ func run(args []string) error {
 		fmt.Printf("%s %s\n", buildinfo.ServiceName, buildinfo.Version)
 		return nil
 	}
-	return usageError(fmt.Sprintf("usage: %s [serve|version|source|source-runtime]", os.Args[0]))
+	return usageError(fmt.Sprintf("usage: %s [serve|version|graph|source|source-runtime]", os.Args[0]))
 }
 
 func serve() error {

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -163,8 +163,11 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 		}
 		result.PagesRead++
 		result.EventsRead += uint32(len(pull.Events))
-		for _, event := range pull.Events {
+		for idx, event := range pull.Events {
 			materialized := materializeEvent(runtime, event)
+			if materialized == nil {
+				return nil, fmt.Errorf("read source page %d: nil event at index %d", page+1, idx)
+			}
 			previewer.addEvent(materialized)
 			projected, err := projector.Project(ctx, materialized)
 			if err != nil {

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -1,0 +1,351 @@
+package graphrebuild
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
+	graphstorekuzu "github.com/writer/cerebro/internal/graphstore/kuzu"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceops"
+	"github.com/writer/cerebro/internal/sourceprojection"
+)
+
+const (
+	defaultPageLimit    = 1
+	maxPageLimit        = 100
+	defaultPreviewLimit = 5
+	maxPreviewLimit     = 20
+)
+
+type graphStore interface {
+	ports.ProjectionGraphStore
+	Close() error
+	Counts(context.Context) (graphstorekuzu.Counts, error)
+}
+
+// Request configures one local graph rebuild dry-run.
+type Request struct {
+	RuntimeID    string
+	PageLimit    uint32
+	PreviewLimit int
+}
+
+// EventPreview captures one event consumed during the rebuild.
+type EventPreview struct {
+	ID   string `json:"id"`
+	Kind string `json:"kind"`
+}
+
+// EntityPreview captures one projected entity written to the local graph.
+type EntityPreview struct {
+	URN        string `json:"urn"`
+	EntityType string `json:"entity_type"`
+	Label      string `json:"label"`
+}
+
+// LinkPreview captures one projected graph edge written to the local graph.
+type LinkPreview struct {
+	FromURN  string `json:"from_urn"`
+	Relation string `json:"relation"`
+	ToURN    string `json:"to_urn"`
+}
+
+// Result summarizes a dry-run rebuild execution.
+type Result struct {
+	RuntimeID         string           `json:"runtime_id"`
+	SourceID          string           `json:"source_id"`
+	TenantID          string           `json:"tenant_id,omitempty"`
+	DryRun            bool             `json:"dry_run"`
+	PagesRead         uint32           `json:"pages_read"`
+	EventsRead        uint32           `json:"events_read"`
+	EntitiesProjected uint32           `json:"entities_projected"`
+	LinksProjected    uint32           `json:"links_projected"`
+	GraphNodes        int64            `json:"graph_nodes"`
+	GraphLinks        int64            `json:"graph_links"`
+	Events            []*EventPreview  `json:"events,omitempty"`
+	PreviewEntities   []*EntityPreview `json:"preview_entities,omitempty"`
+	PreviewLinks      []*LinkPreview   `json:"preview_links,omitempty"`
+}
+
+// Service rebuilds a local graph from stored source runtimes.
+type Service struct {
+	registry     *sourcecdk.Registry
+	runtimeStore ports.SourceRuntimeStore
+	openGraph    func(path string) (graphStore, error)
+	makeTempDir  func() (string, error)
+	removeAll    func(string) error
+}
+
+// New constructs a graph rebuild service.
+func New(registry *sourcecdk.Registry, runtimeStore ports.SourceRuntimeStore) *Service {
+	return &Service{
+		registry:     registry,
+		runtimeStore: runtimeStore,
+		openGraph: func(path string) (graphStore, error) {
+			return graphstorekuzu.Open(config.GraphStoreConfig{
+				Driver:   "kuzu",
+				KuzuPath: path,
+			})
+		},
+		makeTempDir: func() (string, error) {
+			return os.MkdirTemp("", "cerebro-graph-rebuild-")
+		},
+		removeAll: os.RemoveAll,
+	}
+}
+
+// RebuildDryRun projects a bounded number of source pages into a temporary local Kuzu graph.
+func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, err error) {
+	if s == nil || s.runtimeStore == nil {
+		return nil, fmt.Errorf("source runtime store is required")
+	}
+	runtimeID := strings.TrimSpace(req.RuntimeID)
+	if runtimeID == "" {
+		return nil, fmt.Errorf("runtime id is required")
+	}
+	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	source, err := s.lookupSource(strings.TrimSpace(runtime.GetSourceId()))
+	if err != nil {
+		return nil, err
+	}
+	tempDir, err := s.makeTempDir()
+	if err != nil {
+		return nil, fmt.Errorf("create temp graph directory: %w", err)
+	}
+	defer func() {
+		if removeErr := s.removeAll(tempDir); removeErr != nil && err == nil {
+			err = fmt.Errorf("remove temp graph directory: %w", removeErr)
+		}
+	}()
+	graph, err := s.openGraph(filepath.Join(tempDir, "graph"))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := graph.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close temp graph store: %w", closeErr)
+		}
+	}()
+	if err := graph.Ping(ctx); err != nil {
+		return nil, err
+	}
+
+	previewer := newPreviewGraphStore(graph, normalizePreviewLimit(req.PreviewLimit))
+	projector := sourceprojection.New(nil, previewer)
+	pageLimit := normalizePageLimit(req.PageLimit)
+
+	result := &Result{
+		RuntimeID: runtime.GetId(),
+		SourceID:  runtime.GetSourceId(),
+		TenantID:  strings.TrimSpace(runtime.GetTenantId()),
+		DryRun:    true,
+	}
+	var cursor *cerebrov1.SourceCursor
+	for page := uint32(0); page < pageLimit; page++ {
+		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtime.GetConfig()), cursor)
+		if err != nil {
+			return nil, fmt.Errorf("read source page %d: %w", page+1, err)
+		}
+		if len(pull.Events) == 0 {
+			break
+		}
+		result.PagesRead++
+		result.EventsRead += uint32(len(pull.Events))
+		for _, event := range pull.Events {
+			materialized := materializeEvent(runtime, event)
+			previewer.addEvent(materialized)
+			projected, err := projector.Project(ctx, materialized)
+			if err != nil {
+				return nil, fmt.Errorf("project event %q: %w", materialized.GetId(), err)
+			}
+			result.EntitiesProjected += projected.EntitiesProjected
+			result.LinksProjected += projected.LinksProjected
+		}
+		if pull.NextCursor == nil {
+			break
+		}
+		cursor = proto.Clone(pull.NextCursor).(*cerebrov1.SourceCursor)
+	}
+
+	counts, err := graph.Counts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result.GraphNodes = counts.Nodes
+	result.GraphLinks = counts.Relations
+	result.Events = previewer.events()
+	result.PreviewEntities = previewer.entities()
+	result.PreviewLinks = previewer.links()
+	return result, nil
+}
+
+func (s *Service) lookupSource(id string) (sourcecdk.Source, error) {
+	if s == nil || s.registry == nil {
+		return nil, fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, id)
+	}
+	source, ok := s.registry.Get(id)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", sourceops.ErrSourceNotFound, id)
+	}
+	return source, nil
+}
+
+func normalizePageLimit(pageLimit uint32) uint32 {
+	if pageLimit == 0 {
+		return defaultPageLimit
+	}
+	if pageLimit > maxPageLimit {
+		return maxPageLimit
+	}
+	return pageLimit
+}
+
+func normalizePreviewLimit(limit int) int {
+	if limit <= 0 {
+		return defaultPreviewLimit
+	}
+	if limit > maxPreviewLimit {
+		return maxPreviewLimit
+	}
+	return limit
+}
+
+func materializeEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) *cerebrov1.EventEnvelope {
+	if event == nil {
+		return nil
+	}
+	materialized := proto.Clone(event).(*cerebrov1.EventEnvelope)
+	if runtime == nil {
+		return materialized
+	}
+	if tenantID := strings.TrimSpace(runtime.GetTenantId()); tenantID != "" {
+		materialized.TenantId = tenantID
+	}
+	return materialized
+}
+
+type previewGraphStore struct {
+	store      graphStore
+	limit      int
+	eventItems []*EventPreview
+	entitiesBy map[string]*EntityPreview
+	linksBy    map[string]*LinkPreview
+}
+
+func newPreviewGraphStore(store graphStore, limit int) *previewGraphStore {
+	return &previewGraphStore{
+		store:      store,
+		limit:      limit,
+		entitiesBy: make(map[string]*EntityPreview),
+		linksBy:    make(map[string]*LinkPreview),
+	}
+}
+
+func (s *previewGraphStore) Ping(ctx context.Context) error {
+	return s.store.Ping(ctx)
+}
+
+func (s *previewGraphStore) UpsertProjectedEntity(ctx context.Context, entity *ports.ProjectedEntity) error {
+	if err := s.store.UpsertProjectedEntity(ctx, entity); err != nil {
+		return err
+	}
+	if entity == nil || len(s.entitiesBy) >= s.limit {
+		return nil
+	}
+	urn := strings.TrimSpace(entity.URN)
+	if urn == "" {
+		return nil
+	}
+	if _, exists := s.entitiesBy[urn]; exists {
+		return nil
+	}
+	s.entitiesBy[urn] = &EntityPreview{
+		URN:        urn,
+		EntityType: strings.TrimSpace(entity.EntityType),
+		Label:      strings.TrimSpace(entity.Label),
+	}
+	return nil
+}
+
+func (s *previewGraphStore) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLink) error {
+	if err := s.store.UpsertProjectedLink(ctx, link); err != nil {
+		return err
+	}
+	if link == nil || len(s.linksBy) >= s.limit {
+		return nil
+	}
+	key := strings.Join([]string{
+		strings.TrimSpace(link.FromURN),
+		strings.TrimSpace(link.Relation),
+		strings.TrimSpace(link.ToURN),
+	}, "|")
+	if key == "||" {
+		return nil
+	}
+	if _, exists := s.linksBy[key]; exists {
+		return nil
+	}
+	s.linksBy[key] = &LinkPreview{
+		FromURN:  strings.TrimSpace(link.FromURN),
+		Relation: strings.TrimSpace(link.Relation),
+		ToURN:    strings.TrimSpace(link.ToURN),
+	}
+	return nil
+}
+
+func (s *previewGraphStore) addEvent(event *cerebrov1.EventEnvelope) {
+	if event == nil || len(s.eventItems) >= s.limit {
+		return
+	}
+	s.eventItems = append(s.eventItems, &EventPreview{
+		ID:   strings.TrimSpace(event.GetId()),
+		Kind: strings.TrimSpace(event.GetKind()),
+	})
+}
+
+func (s *previewGraphStore) events() []*EventPreview {
+	events := append([]*EventPreview(nil), s.eventItems...)
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].ID == events[j].ID {
+			return events[i].Kind < events[j].Kind
+		}
+		return events[i].ID < events[j].ID
+	})
+	return events
+}
+
+func (s *previewGraphStore) entities() []*EntityPreview {
+	entities := make([]*EntityPreview, 0, len(s.entitiesBy))
+	for _, entity := range s.entitiesBy {
+		entities = append(entities, entity)
+	}
+	sort.Slice(entities, func(i, j int) bool {
+		return entities[i].URN < entities[j].URN
+	})
+	return entities
+}
+
+func (s *previewGraphStore) links() []*LinkPreview {
+	links := make([]*LinkPreview, 0, len(s.linksBy))
+	for _, link := range s.linksBy {
+		links = append(links, link)
+	}
+	sort.Slice(links, func(i, j int) bool {
+		left := strings.Join([]string{links[i].FromURN, links[i].Relation, links[i].ToURN}, "|")
+		right := strings.Join([]string{links[j].FromURN, links[j].Relation, links[j].ToURN}, "|")
+		return left < right
+	})
+	return links
+}

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -1,0 +1,253 @@
+package graphrebuild
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+type runtimeStore struct {
+	runtimes map[string]*cerebrov1.SourceRuntime
+}
+
+func (s *runtimeStore) Ping(context.Context) error {
+	return nil
+}
+
+func (s *runtimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {
+	if s.runtimes == nil {
+		s.runtimes = make(map[string]*cerebrov1.SourceRuntime)
+	}
+	s.runtimes[runtime.GetId()] = proto.Clone(runtime).(*cerebrov1.SourceRuntime)
+	return nil
+}
+
+func (s *runtimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov1.SourceRuntime, error) {
+	runtime, ok := s.runtimes[id]
+	if !ok {
+		return nil, ports.ErrSourceRuntimeNotFound
+	}
+	return proto.Clone(runtime).(*cerebrov1.SourceRuntime), nil
+}
+
+type testSource struct {
+	spec  *cerebrov1.SourceSpec
+	pages [][]*cerebrov1.EventEnvelope
+}
+
+func (s *testSource) Spec() *cerebrov1.SourceSpec {
+	return s.spec
+}
+
+func (s *testSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (s *testSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *testSource) Read(_ context.Context, _ sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	index := 0
+	if cursor != nil && cursor.GetOpaque() != "" {
+		parsed, err := strconv.Atoi(cursor.GetOpaque())
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		index = parsed
+	}
+	if index >= len(s.pages) {
+		return sourcecdk.Pull{}, nil
+	}
+	events := make([]*cerebrov1.EventEnvelope, 0, len(s.pages[index]))
+	for _, event := range s.pages[index] {
+		events = append(events, proto.Clone(event).(*cerebrov1.EventEnvelope))
+	}
+	pull := sourcecdk.Pull{
+		Events: events,
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    events[len(events)-1].GetOccurredAt(),
+			CursorOpaque: strconv.Itoa(index + 1),
+		},
+	}
+	if index+1 < len(s.pages) {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strconv.Itoa(index + 1)}
+	}
+	return pull, nil
+}
+
+func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(&testSource{
+		spec: &cerebrov1.SourceSpec{Id: "github", Name: "GitHub"},
+		pages: [][]*cerebrov1.EventEnvelope{
+			{
+				testEvent("github-audit-1", "github.audit", map[string]string{
+					"org":           "writer",
+					"repo":          "writer/cerebro",
+					"resource_id":   "writer/cerebro",
+					"resource_type": "repository",
+					"actor":         "octocat",
+					"action":        "repo.create",
+				}),
+			},
+			{
+				testEvent("github-pr-1", "github.pull_request", map[string]string{
+					"owner":       "writer",
+					"repository":  "writer/cerebro",
+					"pull_number": "418",
+					"author":      "octocat",
+					"state":       "open",
+					"html_url":    "https://github.com/writer/cerebro/pull/418",
+				}),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				TenantId: "writer-dogfood",
+				Config:   map[string]string{"token": "fixture-token"},
+			},
+		},
+	}
+	service := New(registry, store)
+
+	result, err := service.RebuildDryRun(context.Background(), Request{
+		RuntimeID:    "writer-github",
+		PageLimit:    2,
+		PreviewLimit: 10,
+	})
+	if err != nil {
+		t.Fatalf("RebuildDryRun() error = %v", err)
+	}
+	if result.PagesRead != 2 {
+		t.Fatalf("PagesRead = %d, want 2", result.PagesRead)
+	}
+	if result.EventsRead != 2 {
+		t.Fatalf("EventsRead = %d, want 2", result.EventsRead)
+	}
+	if result.EntitiesProjected != 9 {
+		t.Fatalf("EntitiesProjected = %d, want 9", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 7 {
+		t.Fatalf("LinksProjected = %d, want 7", result.LinksProjected)
+	}
+	if result.GraphNodes != 5 {
+		t.Fatalf("GraphNodes = %d, want 5", result.GraphNodes)
+	}
+	if result.GraphLinks != 5 {
+		t.Fatalf("GraphLinks = %d, want 5", result.GraphLinks)
+	}
+	if len(result.Events) != 2 {
+		t.Fatalf("len(Events) = %d, want 2", len(result.Events))
+	}
+	if !containsEntityURN(result.PreviewEntities, "urn:cerebro:writer-dogfood:github_pull_request:writer/cerebro#418") {
+		t.Fatalf("PreviewEntities missing projected pull request: %#v", result.PreviewEntities)
+	}
+	if !containsEntityURN(result.PreviewEntities, "urn:cerebro:writer-dogfood:identifier:login:octocat") {
+		t.Fatalf("PreviewEntities missing identifier node: %#v", result.PreviewEntities)
+	}
+	if !containsLink(result.PreviewLinks, "urn:cerebro:writer-dogfood:github_user:octocat", "authored", "urn:cerebro:writer-dogfood:github_pull_request:writer/cerebro#418") {
+		t.Fatalf("PreviewLinks missing authored relation: %#v", result.PreviewLinks)
+	}
+}
+
+func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(&testSource{
+		spec: &cerebrov1.SourceSpec{Id: "github", Name: "GitHub"},
+		pages: [][]*cerebrov1.EventEnvelope{
+			{
+				testEvent("github-audit-1", "github.audit", map[string]string{
+					"org":           "writer",
+					"repo":          "writer/cerebro",
+					"resource_id":   "writer/cerebro",
+					"resource_type": "repository",
+					"actor":         "octocat",
+					"action":        "repo.create",
+				}),
+			},
+			{
+				testEvent("github-pr-1", "github.pull_request", map[string]string{
+					"owner":       "writer",
+					"repository":  "writer/cerebro",
+					"pull_number": "418",
+					"author":      "octocat",
+				}),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := New(registry, &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				TenantId: "writer-dogfood",
+				Config:   map[string]string{"token": "fixture-token"},
+			},
+		},
+	})
+
+	result, err := service.RebuildDryRun(context.Background(), Request{RuntimeID: "writer-github"})
+	if err != nil {
+		t.Fatalf("RebuildDryRun() error = %v", err)
+	}
+	if result.PagesRead != 1 {
+		t.Fatalf("PagesRead = %d, want 1", result.PagesRead)
+	}
+	if result.EventsRead != 1 {
+		t.Fatalf("EventsRead = %d, want 1", result.EventsRead)
+	}
+	if result.GraphNodes != 4 {
+		t.Fatalf("GraphNodes = %d, want 4", result.GraphNodes)
+	}
+	if result.GraphLinks != 3 {
+		t.Fatalf("GraphLinks = %d, want 3", result.GraphLinks)
+	}
+}
+
+func testEvent(id string, kind string, attributes map[string]string) *cerebrov1.EventEnvelope {
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		SourceId:   "github",
+		TenantId:   "fixture-tenant",
+		Kind:       kind,
+		OccurredAt: timestamppb.Now(),
+		Attributes: attributes,
+	}
+}
+
+func containsEntityURN(entities []*EntityPreview, want string) bool {
+	for _, entity := range entities {
+		if entity != nil && entity.URN == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsLink(links []*LinkPreview, fromURN string, relation string, toURN string) bool {
+	for _, link := range links {
+		if link == nil {
+			continue
+		}
+		if link.FromURN == fromURN && link.Relation == relation && link.ToURN == toURN {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -2,7 +2,9 @@ package graphrebuild
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/proto"
@@ -68,6 +70,10 @@ func (s *testSource) Read(_ context.Context, _ sourcecdk.Config, cursor *cerebro
 	}
 	events := make([]*cerebrov1.EventEnvelope, 0, len(s.pages[index]))
 	for _, event := range s.pages[index] {
+		if event == nil {
+			events = append(events, nil)
+			continue
+		}
 		events = append(events, proto.Clone(event).(*cerebrov1.EventEnvelope))
 	}
 	pull := sourcecdk.Pull{
@@ -217,6 +223,31 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	}
 	if result.GraphLinks != 3 {
 		t.Fatalf("GraphLinks = %d, want 3", result.GraphLinks)
+	}
+}
+
+func TestRebuildDryRunRejectsNilEventWithPageContext(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(&testSource{
+		spec:  &cerebrov1.SourceSpec{Id: "github", Name: "GitHub"},
+		pages: [][]*cerebrov1.EventEnvelope{{nil}},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := New(registry, &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				TenantId: "writer-dogfood",
+				Config:   map[string]string{"token": "fixture-token"},
+			},
+		},
+	})
+
+	_, err = service.RebuildDryRun(context.Background(), Request{RuntimeID: "writer-github"})
+	if err == nil || !strings.Contains(fmt.Sprint(err), "read source page 1: nil event at index 0") {
+		t.Fatalf("RebuildDryRun() error = %v, want nil event page context", err)
 	}
 }
 

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -24,6 +24,12 @@ type Store struct {
 	schemaReady bool
 }
 
+// Counts summarizes the entity and relationship totals in the graph.
+type Counts struct {
+	Nodes     int64
+	Relations int64
+}
+
 // Open opens a Kuzu-backed graph projection store.
 func Open(cfg config.GraphStoreConfig) (*Store, error) {
 	rawPath := strings.TrimSpace(cfg.KuzuPath)
@@ -66,6 +72,31 @@ func (s *Store) Ping(ctx context.Context) error {
 		return fmt.Errorf("unexpected kuzu ping result %d", result)
 	}
 	return nil
+}
+
+// Counts returns the current number of projected nodes and relationships.
+func (s *Store) Counts(ctx context.Context) (Counts, error) {
+	if s == nil || s.db == nil {
+		return Counts{}, errors.New("kuzu is not configured")
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return Counts{}, err
+	}
+	if !tables["entity"] {
+		return Counts{}, nil
+	}
+	var counts Counts
+	if err := s.db.QueryRowContext(ctx, "MATCH (e:entity) RETURN COUNT(e) AS count").Scan(&counts.Nodes); err != nil {
+		return Counts{}, fmt.Errorf("count entity nodes: %w", err)
+	}
+	if !tables["relation"] {
+		return counts, nil
+	}
+	if err := s.db.QueryRowContext(ctx, "MATCH (src:entity)-[r:relation]->(dst:entity) RETURN COUNT(r) AS count").Scan(&counts.Relations); err != nil {
+		return Counts{}, fmt.Errorf("count relation edges: %w", err)
+	}
+	return counts, nil
 }
 
 // UpsertProjectedEntity upserts one normalized entity in the graph store.


### PR DESCRIPTION
## Summary
- add a  dry-run flow that replays a stored source runtime into a temporary local Kuzu graph
- return concrete rebuild output including page/event counts plus previewed nodes and edges
- cover the new service, parser, and graph counting path with tests

## Validation
- make verify