### PR TITLE
feat(graph): confirm rebuild stages locally

### DIFF
--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -187,28 +187,22 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 	})
 
 	previewLimit := normalizePreviewLimit(req.PreviewLimit)
-	readStart := time.Now()
-	readSummary, err := s.readEvents(ctx, source, runtime, normalizePageLimit(req.PageLimit))
+	readSummary, projectSummary, err := s.processEvents(ctx, source, runtime, graph, normalizePageLimit(req.PageLimit), previewLimit)
 	if err != nil {
 		return nil, err
 	}
 	result.PagesRead = readSummary.PagesRead
 	result.EventsRead = readSummary.EventsRead
 	result.EventKinds = countPreviews(readSummary.EventKinds)
-	result.Events = eventPreviews(readSummary.Events, previewLimit)
+	result.Events = readSummary.EventPreviews
 	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
 		Name:           "read_source",
 		Status:         stageStatusSuccess,
-		DurationMillis: durationMillis(readStart),
+		DurationMillis: readSummary.DurationMillis,
 		PagesRead:      readSummary.PagesRead,
 		EventsRead:     readSummary.EventsRead,
 	})
 
-	projectStart := time.Now()
-	projectSummary, err := s.projectEvents(ctx, graph, readSummary.Events, previewLimit)
-	if err != nil {
-		return nil, err
-	}
 	result.EntitiesProjected = projectSummary.EntitiesProjected
 	result.LinksProjected = projectSummary.LinksProjected
 	result.GraphEntityTypes = projectSummary.GraphEntityTypes
@@ -218,7 +212,7 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
 		Name:              "project_graph",
 		Status:            stageStatusSuccess,
-		DurationMillis:    durationMillis(projectStart),
+		DurationMillis:    projectSummary.DurationMillis,
 		EntitiesProjected: projectSummary.EntitiesProjected,
 		LinksProjected:    projectSummary.LinksProjected,
 	})
@@ -286,71 +280,73 @@ func materializeEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEn
 }
 
 type readSummary struct {
-	Events     []*cerebrov1.EventEnvelope
-	PagesRead  uint32
-	EventsRead uint32
-	EventKinds map[string]uint32
+	EventPreviews  []*EventPreview
+	PagesRead      uint32
+	EventsRead     uint32
+	EventKinds     map[string]uint32
+	DurationMillis int64
 }
 
-func (s *Service) readEvents(ctx context.Context, source sourcecdk.Source, runtime *cerebrov1.SourceRuntime, pageLimit uint32) (*readSummary, error) {
-	summary := &readSummary{EventKinds: make(map[string]uint32)}
+func (s *Service) processEvents(ctx context.Context, source sourcecdk.Source, runtime *cerebrov1.SourceRuntime, graph graphStore, pageLimit uint32, previewLimit int) (*readSummary, *projectSummary, error) {
+	readSummary := &readSummary{EventKinds: make(map[string]uint32)}
+	previewer := newPreviewGraphStore(graph, previewLimit)
+	projector := sourceprojection.New(nil, previewer)
+	projectSummary := &projectSummary{}
 	var cursor *cerebrov1.SourceCursor
 	for page := uint32(0); page < pageLimit; page++ {
+		readStart := time.Now()
 		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtime.GetConfig()), cursor)
+		readSummary.DurationMillis += durationMillis(readStart)
 		if err != nil {
-			return nil, fmt.Errorf("read source page %d: %w", page+1, err)
+			return nil, nil, fmt.Errorf("read source page %d: %w", page+1, err)
 		}
 		if len(pull.Events) == 0 {
 			break
 		}
-		summary.PagesRead++
-		summary.EventsRead += uint32(len(pull.Events))
+		readSummary.PagesRead++
+		readSummary.EventsRead += uint32(len(pull.Events))
 		for idx, event := range pull.Events {
 			materialized := materializeEvent(runtime, event)
 			if materialized == nil {
-				return nil, fmt.Errorf("read source page %d: nil event at index %d", page+1, idx)
+				return nil, nil, fmt.Errorf("read source page %d: nil event at index %d", page+1, idx)
 			}
-			summary.Events = append(summary.Events, materialized)
+			if len(readSummary.EventPreviews) < previewLimit {
+				readSummary.EventPreviews = append(readSummary.EventPreviews, eventPreview(materialized))
+			}
 			kind := strings.TrimSpace(materialized.GetKind())
-			if kind == "" {
-				continue
+			if kind != "" {
+				readSummary.EventKinds[kind]++
 			}
-			summary.EventKinds[kind]++
+
+			projectStart := time.Now()
+			projected, err := projector.Project(ctx, materialized)
+			projectSummary.DurationMillis += durationMillis(projectStart)
+			if err != nil {
+				return nil, nil, fmt.Errorf("project event %q: %w", materialized.GetId(), err)
+			}
+			projectSummary.EntitiesProjected += projected.EntitiesProjected
+			projectSummary.LinksProjected += projected.LinksProjected
 		}
 		if pull.NextCursor == nil {
 			break
 		}
 		cursor = proto.Clone(pull.NextCursor).(*cerebrov1.SourceCursor)
 	}
-	return summary, nil
+	projectSummary.GraphEntityTypes = previewer.entityTypes()
+	projectSummary.GraphRelationTypes = previewer.relationTypes()
+	projectSummary.PreviewEntities = previewer.entities()
+	projectSummary.PreviewLinks = previewer.links()
+	return readSummary, projectSummary, nil
 }
 
 type projectSummary struct {
 	EntitiesProjected  uint32
 	LinksProjected     uint32
+	DurationMillis     int64
 	GraphEntityTypes   []*CountPreview
 	GraphRelationTypes []*CountPreview
 	PreviewEntities    []*EntityPreview
 	PreviewLinks       []*LinkPreview
-}
-
-func (s *Service) projectEvents(ctx context.Context, graph graphStore, events []*cerebrov1.EventEnvelope, previewLimit int) (*projectSummary, error) {
-	previewer := newPreviewGraphStore(graph, previewLimit)
-	projector := sourceprojection.New(nil, previewer)
-	summary := &projectSummary{}
-	for _, event := range events {
-		projected, err := projector.Project(ctx, event)
-		if err != nil {
-			return nil, fmt.Errorf("project event %q: %w", event.GetId(), err)
-		}
-		summary.EntitiesProjected += projected.EntitiesProjected
-		summary.LinksProjected += projected.LinksProjected
-	}
-	summary.GraphEntityTypes = previewer.entityTypes()
-	summary.GraphRelationTypes = previewer.relationTypes()
-	summary.PreviewEntities = previewer.entities()
-	summary.PreviewLinks = previewer.links()
-	return summary, nil
 }
 
 type previewGraphStore struct {
@@ -481,24 +477,11 @@ func (s *previewGraphStore) relationTypes() []*CountPreview {
 	return countPreviews(s.relationCounts)
 }
 
-func eventPreviews(events []*cerebrov1.EventEnvelope, limit int) []*EventPreview {
-	if len(events) == 0 || limit <= 0 {
-		return nil
+func eventPreview(event *cerebrov1.EventEnvelope) *EventPreview {
+	return &EventPreview{
+		ID:   strings.TrimSpace(event.GetId()),
+		Kind: strings.TrimSpace(event.GetKind()),
 	}
-	previews := make([]*EventPreview, 0, min(limit, len(events)))
-	for _, event := range events {
-		if len(previews) >= limit {
-			break
-		}
-		if event == nil {
-			continue
-		}
-		previews = append(previews, &EventPreview{
-			ID:   strings.TrimSpace(event.GetId()),
-			Kind: strings.TrimSpace(event.GetKind()),
-		})
-	}
-	return previews
 }
 
 func countPreviews(counts map[string]uint32) []*CountPreview {
@@ -523,11 +506,4 @@ func durationMillis(start time.Time) int64 {
 		return 0
 	}
 	return time.Since(start).Milliseconds()
-}
-
-func min(left int, right int) int {
-	if left < right {
-		return left
-	}
-	return right
 }

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 
@@ -24,6 +25,7 @@ const (
 	maxPageLimit        = 100
 	defaultPreviewLimit = 5
 	maxPreviewLimit     = 20
+	stageStatusSuccess  = "success"
 )
 
 type graphStore interface {
@@ -59,21 +61,44 @@ type LinkPreview struct {
 	ToURN    string `json:"to_urn"`
 }
 
+// CountPreview captures one grouped count in the rebuild output.
+type CountPreview struct {
+	Name  string `json:"name"`
+	Count uint32 `json:"count"`
+}
+
+// StageConfirmation captures local confirmation for one rebuild stage.
+type StageConfirmation struct {
+	Name              string `json:"name"`
+	Status            string `json:"status"`
+	DurationMillis    int64  `json:"duration_ms"`
+	PagesRead         uint32 `json:"pages_read,omitempty"`
+	EventsRead        uint32 `json:"events_read,omitempty"`
+	EntitiesProjected uint32 `json:"entities_projected,omitempty"`
+	LinksProjected    uint32 `json:"links_projected,omitempty"`
+	GraphNodes        int64  `json:"graph_nodes,omitempty"`
+	GraphLinks        int64  `json:"graph_links,omitempty"`
+}
+
 // Result summarizes a dry-run rebuild execution.
 type Result struct {
-	RuntimeID         string           `json:"runtime_id"`
-	SourceID          string           `json:"source_id"`
-	TenantID          string           `json:"tenant_id,omitempty"`
-	DryRun            bool             `json:"dry_run"`
-	PagesRead         uint32           `json:"pages_read"`
-	EventsRead        uint32           `json:"events_read"`
-	EntitiesProjected uint32           `json:"entities_projected"`
-	LinksProjected    uint32           `json:"links_projected"`
-	GraphNodes        int64            `json:"graph_nodes"`
-	GraphLinks        int64            `json:"graph_links"`
-	Events            []*EventPreview  `json:"events,omitempty"`
-	PreviewEntities   []*EntityPreview `json:"preview_entities,omitempty"`
-	PreviewLinks      []*LinkPreview   `json:"preview_links,omitempty"`
+	RuntimeID          string               `json:"runtime_id"`
+	SourceID           string               `json:"source_id"`
+	TenantID           string               `json:"tenant_id,omitempty"`
+	DryRun             bool                 `json:"dry_run"`
+	PagesRead          uint32               `json:"pages_read"`
+	EventsRead         uint32               `json:"events_read"`
+	EntitiesProjected  uint32               `json:"entities_projected"`
+	LinksProjected     uint32               `json:"links_projected"`
+	GraphNodes         int64                `json:"graph_nodes"`
+	GraphLinks         int64                `json:"graph_links"`
+	StageConfirmations []*StageConfirmation `json:"stage_confirmations,omitempty"`
+	EventKinds         []*CountPreview      `json:"event_kinds,omitempty"`
+	GraphEntityTypes   []*CountPreview      `json:"graph_entity_types,omitempty"`
+	GraphRelationTypes []*CountPreview      `json:"graph_relation_types,omitempty"`
+	Events             []*EventPreview      `json:"events,omitempty"`
+	PreviewEntities    []*EntityPreview     `json:"preview_entities,omitempty"`
+	PreviewLinks       []*LinkPreview       `json:"preview_links,omitempty"`
 }
 
 // Service rebuilds a local graph from stored source runtimes.
@@ -112,6 +137,7 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 	if runtimeID == "" {
 		return nil, fmt.Errorf("runtime id is required")
 	}
+	resolveStart := time.Now()
 	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
 	if err != nil {
 		return nil, err
@@ -120,6 +146,19 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 	if err != nil {
 		return nil, err
 	}
+	result := &Result{
+		RuntimeID: runtime.GetId(),
+		SourceID:  runtime.GetSourceId(),
+		TenantID:  strings.TrimSpace(runtime.GetTenantId()),
+		DryRun:    true,
+	}
+	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
+		Name:           "resolve_runtime",
+		Status:         stageStatusSuccess,
+		DurationMillis: durationMillis(resolveStart),
+	})
+
+	openStart := time.Now()
 	tempDir, err := s.makeTempDir()
 	if err != nil {
 		return nil, fmt.Errorf("create temp graph directory: %w", err)
@@ -141,53 +180,63 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 	if err := graph.Ping(ctx); err != nil {
 		return nil, err
 	}
+	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
+		Name:           "open_graph",
+		Status:         stageStatusSuccess,
+		DurationMillis: durationMillis(openStart),
+	})
 
-	previewer := newPreviewGraphStore(graph, normalizePreviewLimit(req.PreviewLimit))
-	projector := sourceprojection.New(nil, previewer)
-	pageLimit := normalizePageLimit(req.PageLimit)
-
-	result := &Result{
-		RuntimeID: runtime.GetId(),
-		SourceID:  runtime.GetSourceId(),
-		TenantID:  strings.TrimSpace(runtime.GetTenantId()),
-		DryRun:    true,
+	previewLimit := normalizePreviewLimit(req.PreviewLimit)
+	readStart := time.Now()
+	readSummary, err := s.readEvents(ctx, source, runtime, normalizePageLimit(req.PageLimit))
+	if err != nil {
+		return nil, err
 	}
-	var cursor *cerebrov1.SourceCursor
-	for page := uint32(0); page < pageLimit; page++ {
-		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtime.GetConfig()), cursor)
-		if err != nil {
-			return nil, fmt.Errorf("read source page %d: %w", page+1, err)
-		}
-		if len(pull.Events) == 0 {
-			break
-		}
-		result.PagesRead++
-		result.EventsRead += uint32(len(pull.Events))
-		for _, event := range pull.Events {
-			materialized := materializeEvent(runtime, event)
-			previewer.addEvent(materialized)
-			projected, err := projector.Project(ctx, materialized)
-			if err != nil {
-				return nil, fmt.Errorf("project event %q: %w", materialized.GetId(), err)
-			}
-			result.EntitiesProjected += projected.EntitiesProjected
-			result.LinksProjected += projected.LinksProjected
-		}
-		if pull.NextCursor == nil {
-			break
-		}
-		cursor = proto.Clone(pull.NextCursor).(*cerebrov1.SourceCursor)
-	}
+	result.PagesRead = readSummary.PagesRead
+	result.EventsRead = readSummary.EventsRead
+	result.EventKinds = countPreviews(readSummary.EventKinds)
+	result.Events = eventPreviews(readSummary.Events, previewLimit)
+	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
+		Name:           "read_source",
+		Status:         stageStatusSuccess,
+		DurationMillis: durationMillis(readStart),
+		PagesRead:      readSummary.PagesRead,
+		EventsRead:     readSummary.EventsRead,
+	})
 
+	projectStart := time.Now()
+	projectSummary, err := s.projectEvents(ctx, graph, readSummary.Events, previewLimit)
+	if err != nil {
+		return nil, err
+	}
+	result.EntitiesProjected = projectSummary.EntitiesProjected
+	result.LinksProjected = projectSummary.LinksProjected
+	result.GraphEntityTypes = projectSummary.GraphEntityTypes
+	result.GraphRelationTypes = projectSummary.GraphRelationTypes
+	result.PreviewEntities = projectSummary.PreviewEntities
+	result.PreviewLinks = projectSummary.PreviewLinks
+	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
+		Name:              "project_graph",
+		Status:            stageStatusSuccess,
+		DurationMillis:    durationMillis(projectStart),
+		EntitiesProjected: projectSummary.EntitiesProjected,
+		LinksProjected:    projectSummary.LinksProjected,
+	})
+
+	countStart := time.Now()
 	counts, err := graph.Counts(ctx)
 	if err != nil {
 		return nil, err
 	}
 	result.GraphNodes = counts.Nodes
 	result.GraphLinks = counts.Relations
-	result.Events = previewer.events()
-	result.PreviewEntities = previewer.entities()
-	result.PreviewLinks = previewer.links()
+	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
+		Name:           "count_graph",
+		Status:         stageStatusSuccess,
+		DurationMillis: durationMillis(countStart),
+		GraphNodes:     counts.Nodes,
+		GraphLinks:     counts.Relations,
+	})
 	return result, nil
 }
 
@@ -236,20 +285,95 @@ func materializeEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEn
 	return materialized
 }
 
+type readSummary struct {
+	Events     []*cerebrov1.EventEnvelope
+	PagesRead  uint32
+	EventsRead uint32
+	EventKinds map[string]uint32
+}
+
+func (s *Service) readEvents(ctx context.Context, source sourcecdk.Source, runtime *cerebrov1.SourceRuntime, pageLimit uint32) (*readSummary, error) {
+	summary := &readSummary{EventKinds: make(map[string]uint32)}
+	var cursor *cerebrov1.SourceCursor
+	for page := uint32(0); page < pageLimit; page++ {
+		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtime.GetConfig()), cursor)
+		if err != nil {
+			return nil, fmt.Errorf("read source page %d: %w", page+1, err)
+		}
+		if len(pull.Events) == 0 {
+			break
+		}
+		summary.PagesRead++
+		summary.EventsRead += uint32(len(pull.Events))
+		for _, event := range pull.Events {
+			materialized := materializeEvent(runtime, event)
+			if materialized == nil {
+				continue
+			}
+			summary.Events = append(summary.Events, materialized)
+			kind := strings.TrimSpace(materialized.GetKind())
+			if kind == "" {
+				continue
+			}
+			summary.EventKinds[kind]++
+		}
+		if pull.NextCursor == nil {
+			break
+		}
+		cursor = proto.Clone(pull.NextCursor).(*cerebrov1.SourceCursor)
+	}
+	return summary, nil
+}
+
+type projectSummary struct {
+	EntitiesProjected  uint32
+	LinksProjected     uint32
+	GraphEntityTypes   []*CountPreview
+	GraphRelationTypes []*CountPreview
+	PreviewEntities    []*EntityPreview
+	PreviewLinks       []*LinkPreview
+}
+
+func (s *Service) projectEvents(ctx context.Context, graph graphStore, events []*cerebrov1.EventEnvelope, previewLimit int) (*projectSummary, error) {
+	previewer := newPreviewGraphStore(graph, previewLimit)
+	projector := sourceprojection.New(nil, previewer)
+	summary := &projectSummary{}
+	for _, event := range events {
+		projected, err := projector.Project(ctx, event)
+		if err != nil {
+			return nil, fmt.Errorf("project event %q: %w", event.GetId(), err)
+		}
+		summary.EntitiesProjected += projected.EntitiesProjected
+		summary.LinksProjected += projected.LinksProjected
+	}
+	summary.GraphEntityTypes = previewer.entityTypes()
+	summary.GraphRelationTypes = previewer.relationTypes()
+	summary.PreviewEntities = previewer.entities()
+	summary.PreviewLinks = previewer.links()
+	return summary, nil
+}
+
 type previewGraphStore struct {
-	store      graphStore
-	limit      int
-	eventItems []*EventPreview
-	entitiesBy map[string]*EntityPreview
-	linksBy    map[string]*LinkPreview
+	store            graphStore
+	limit            int
+	entitiesBy       map[string]*EntityPreview
+	linksBy          map[string]*LinkPreview
+	seenEntities     map[string]struct{}
+	seenLinks        map[string]struct{}
+	entityTypeCounts map[string]uint32
+	relationCounts   map[string]uint32
 }
 
 func newPreviewGraphStore(store graphStore, limit int) *previewGraphStore {
 	return &previewGraphStore{
-		store:      store,
-		limit:      limit,
-		entitiesBy: make(map[string]*EntityPreview),
-		linksBy:    make(map[string]*LinkPreview),
+		store:            store,
+		limit:            limit,
+		entitiesBy:       make(map[string]*EntityPreview),
+		linksBy:          make(map[string]*LinkPreview),
+		seenEntities:     make(map[string]struct{}),
+		seenLinks:        make(map[string]struct{}),
+		entityTypeCounts: make(map[string]uint32),
+		relationCounts:   make(map[string]uint32),
 	}
 }
 
@@ -261,11 +385,21 @@ func (s *previewGraphStore) UpsertProjectedEntity(ctx context.Context, entity *p
 	if err := s.store.UpsertProjectedEntity(ctx, entity); err != nil {
 		return err
 	}
-	if entity == nil || len(s.entitiesBy) >= s.limit {
+	if entity == nil {
 		return nil
 	}
 	urn := strings.TrimSpace(entity.URN)
 	if urn == "" {
+		return nil
+	}
+	if _, exists := s.seenEntities[urn]; !exists {
+		s.seenEntities[urn] = struct{}{}
+		entityType := strings.TrimSpace(entity.EntityType)
+		if entityType != "" {
+			s.entityTypeCounts[entityType]++
+		}
+	}
+	if len(s.entitiesBy) >= s.limit {
 		return nil
 	}
 	if _, exists := s.entitiesBy[urn]; exists {
@@ -283,7 +417,7 @@ func (s *previewGraphStore) UpsertProjectedLink(ctx context.Context, link *ports
 	if err := s.store.UpsertProjectedLink(ctx, link); err != nil {
 		return err
 	}
-	if link == nil || len(s.linksBy) >= s.limit {
+	if link == nil {
 		return nil
 	}
 	key := strings.Join([]string{
@@ -292,6 +426,16 @@ func (s *previewGraphStore) UpsertProjectedLink(ctx context.Context, link *ports
 		strings.TrimSpace(link.ToURN),
 	}, "|")
 	if key == "||" {
+		return nil
+	}
+	if _, exists := s.seenLinks[key]; !exists {
+		s.seenLinks[key] = struct{}{}
+		relation := strings.TrimSpace(link.Relation)
+		if relation != "" {
+			s.relationCounts[relation]++
+		}
+	}
+	if len(s.linksBy) >= s.limit {
 		return nil
 	}
 	if _, exists := s.linksBy[key]; exists {
@@ -303,27 +447,6 @@ func (s *previewGraphStore) UpsertProjectedLink(ctx context.Context, link *ports
 		ToURN:    strings.TrimSpace(link.ToURN),
 	}
 	return nil
-}
-
-func (s *previewGraphStore) addEvent(event *cerebrov1.EventEnvelope) {
-	if event == nil || len(s.eventItems) >= s.limit {
-		return
-	}
-	s.eventItems = append(s.eventItems, &EventPreview{
-		ID:   strings.TrimSpace(event.GetId()),
-		Kind: strings.TrimSpace(event.GetKind()),
-	})
-}
-
-func (s *previewGraphStore) events() []*EventPreview {
-	events := append([]*EventPreview(nil), s.eventItems...)
-	sort.Slice(events, func(i, j int) bool {
-		if events[i].ID == events[j].ID {
-			return events[i].Kind < events[j].Kind
-		}
-		return events[i].ID < events[j].ID
-	})
-	return events
 }
 
 func (s *previewGraphStore) entities() []*EntityPreview {
@@ -348,4 +471,63 @@ func (s *previewGraphStore) links() []*LinkPreview {
 		return left < right
 	})
 	return links
+}
+
+func (s *previewGraphStore) entityTypes() []*CountPreview {
+	return countPreviews(s.entityTypeCounts)
+}
+
+func (s *previewGraphStore) relationTypes() []*CountPreview {
+	return countPreviews(s.relationCounts)
+}
+
+func eventPreviews(events []*cerebrov1.EventEnvelope, limit int) []*EventPreview {
+	if len(events) == 0 || limit <= 0 {
+		return nil
+	}
+	previews := make([]*EventPreview, 0, min(limit, len(events)))
+	for _, event := range events {
+		if len(previews) >= limit {
+			break
+		}
+		if event == nil {
+			continue
+		}
+		previews = append(previews, &EventPreview{
+			ID:   strings.TrimSpace(event.GetId()),
+			Kind: strings.TrimSpace(event.GetKind()),
+		})
+	}
+	return previews
+}
+
+func countPreviews(counts map[string]uint32) []*CountPreview {
+	previews := make([]*CountPreview, 0, len(counts))
+	for name, count := range counts {
+		if strings.TrimSpace(name) == "" || count == 0 {
+			continue
+		}
+		previews = append(previews, &CountPreview{Name: name, Count: count})
+	}
+	sort.Slice(previews, func(i, j int) bool {
+		if previews[i].Count == previews[j].Count {
+			return previews[i].Name < previews[j].Name
+		}
+		return previews[i].Count > previews[j].Count
+	})
+	return previews
+}
+
+func durationMillis(start time.Time) int64 {
+	if start.IsZero() {
+		return 0
+	}
+	return time.Since(start).Milliseconds()
+}
+
+func min(left int, right int) int {
+	if left < right {
+		return left
+	}
+	return right
 }

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -32,6 +32,7 @@ type graphStore interface {
 	ports.ProjectionGraphStore
 	Close() error
 	Counts(context.Context) (graphstorekuzu.Counts, error)
+	IntegrityChecks(context.Context) ([]graphstorekuzu.IntegrityCheck, error)
 	SampleTraversals(context.Context, int) ([]graphstorekuzu.Traversal, error)
 }
 
@@ -77,6 +78,8 @@ type StageConfirmation struct {
 	EventsRead         uint32 `json:"events_read,omitempty"`
 	EntitiesProjected  uint32 `json:"entities_projected,omitempty"`
 	LinksProjected     uint32 `json:"links_projected,omitempty"`
+	AssertionsPassed   uint32 `json:"assertions_passed,omitempty"`
+	AssertionsFailed   uint32 `json:"assertions_failed,omitempty"`
 	TraversalsVerified uint32 `json:"traversals_verified,omitempty"`
 	GraphNodes         int64  `json:"graph_nodes,omitempty"`
 	GraphLinks         int64  `json:"graph_links,omitempty"`
@@ -90,6 +93,14 @@ type TraversalPreview struct {
 	ViaURN         string `json:"via_urn"`
 	SecondRelation string `json:"second_relation"`
 	ToURN          string `json:"to_urn"`
+}
+
+// AssertionPreview captures one local graph integrity assertion.
+type AssertionPreview struct {
+	Name     string `json:"name"`
+	Actual   int64  `json:"actual"`
+	Expected int64  `json:"expected"`
+	Passed   bool   `json:"passed"`
 }
 
 // Result summarizes a dry-run rebuild execution.
@@ -108,6 +119,7 @@ type Result struct {
 	EventKinds         []*CountPreview      `json:"event_kinds,omitempty"`
 	GraphEntityTypes   []*CountPreview      `json:"graph_entity_types,omitempty"`
 	GraphRelationTypes []*CountPreview      `json:"graph_relation_types,omitempty"`
+	GraphAssertions    []*AssertionPreview  `json:"graph_assertions,omitempty"`
 	GraphTraversals    []*TraversalPreview  `json:"graph_traversals,omitempty"`
 	Events             []*EventPreview      `json:"events,omitempty"`
 	PreviewEntities    []*EntityPreview     `json:"preview_entities,omitempty"`
@@ -249,6 +261,21 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 		DurationMillis: durationMillis(countStart),
 		GraphNodes:     counts.Nodes,
 		GraphLinks:     counts.Relations,
+	})
+
+	integrityStart := time.Now()
+	checks, err := graph.IntegrityChecks(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result.GraphAssertions = assertionPreviews(checks)
+	assertionsPassed, assertionsFailed := assertionCounts(result.GraphAssertions)
+	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
+		Name:             "verify_integrity",
+		Status:           stageStatusSuccess,
+		DurationMillis:   durationMillis(integrityStart),
+		AssertionsPassed: assertionsPassed,
+		AssertionsFailed: assertionsFailed,
 	})
 
 	traversalStart := time.Now()
@@ -542,6 +569,35 @@ func countPreviews(counts map[string]uint32) []*CountPreview {
 		return previews[i].Count > previews[j].Count
 	})
 	return previews
+}
+
+func assertionPreviews(checks []graphstorekuzu.IntegrityCheck) []*AssertionPreview {
+	previews := make([]*AssertionPreview, 0, len(checks))
+	for _, check := range checks {
+		previews = append(previews, &AssertionPreview{
+			Name:     check.Name,
+			Actual:   check.Actual,
+			Expected: check.Expected,
+			Passed:   check.Passed,
+		})
+	}
+	return previews
+}
+
+func assertionCounts(assertions []*AssertionPreview) (uint32, uint32) {
+	var passed uint32
+	var failed uint32
+	for _, assertion := range assertions {
+		if assertion == nil {
+			continue
+		}
+		if assertion.Passed {
+			passed++
+			continue
+		}
+		failed++
+	}
+	return passed, failed
 }
 
 func traversalPreviews(traversals []graphstorekuzu.Traversal) []*TraversalPreview {

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -32,6 +32,7 @@ type graphStore interface {
 	ports.ProjectionGraphStore
 	Close() error
 	Counts(context.Context) (graphstorekuzu.Counts, error)
+	SampleTraversals(context.Context, int) ([]graphstorekuzu.Traversal, error)
 }
 
 // Request configures one local graph rebuild dry-run.
@@ -69,15 +70,26 @@ type CountPreview struct {
 
 // StageConfirmation captures local confirmation for one rebuild stage.
 type StageConfirmation struct {
-	Name              string `json:"name"`
-	Status            string `json:"status"`
-	DurationMillis    int64  `json:"duration_ms"`
-	PagesRead         uint32 `json:"pages_read,omitempty"`
-	EventsRead        uint32 `json:"events_read,omitempty"`
-	EntitiesProjected uint32 `json:"entities_projected,omitempty"`
-	LinksProjected    uint32 `json:"links_projected,omitempty"`
-	GraphNodes        int64  `json:"graph_nodes,omitempty"`
-	GraphLinks        int64  `json:"graph_links,omitempty"`
+	Name               string `json:"name"`
+	Status             string `json:"status"`
+	DurationMillis     int64  `json:"duration_ms"`
+	PagesRead          uint32 `json:"pages_read,omitempty"`
+	EventsRead         uint32 `json:"events_read,omitempty"`
+	EntitiesProjected  uint32 `json:"entities_projected,omitempty"`
+	LinksProjected     uint32 `json:"links_projected,omitempty"`
+	TraversalsVerified uint32 `json:"traversals_verified,omitempty"`
+	GraphNodes         int64  `json:"graph_nodes,omitempty"`
+	GraphLinks         int64  `json:"graph_links,omitempty"`
+}
+
+// TraversalPreview captures one sampled two-hop path returned from the local graph.
+type TraversalPreview struct {
+	Path           string `json:"path"`
+	FromURN        string `json:"from_urn"`
+	FirstRelation  string `json:"first_relation"`
+	ViaURN         string `json:"via_urn"`
+	SecondRelation string `json:"second_relation"`
+	ToURN          string `json:"to_urn"`
 }
 
 // Result summarizes a dry-run rebuild execution.
@@ -96,6 +108,7 @@ type Result struct {
 	EventKinds         []*CountPreview      `json:"event_kinds,omitempty"`
 	GraphEntityTypes   []*CountPreview      `json:"graph_entity_types,omitempty"`
 	GraphRelationTypes []*CountPreview      `json:"graph_relation_types,omitempty"`
+	GraphTraversals    []*TraversalPreview  `json:"graph_traversals,omitempty"`
 	Events             []*EventPreview      `json:"events,omitempty"`
 	PreviewEntities    []*EntityPreview     `json:"preview_entities,omitempty"`
 	PreviewLinks       []*LinkPreview       `json:"preview_links,omitempty"`
@@ -236,6 +249,19 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 		DurationMillis: durationMillis(countStart),
 		GraphNodes:     counts.Nodes,
 		GraphLinks:     counts.Relations,
+	})
+
+	traversalStart := time.Now()
+	traversals, err := graph.SampleTraversals(ctx, previewLimit)
+	if err != nil {
+		return nil, err
+	}
+	result.GraphTraversals = traversalPreviews(traversals)
+	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
+		Name:               "verify_traversals",
+		Status:             stageStatusSuccess,
+		DurationMillis:     durationMillis(traversalStart),
+		TraversalsVerified: uint32(len(result.GraphTraversals)),
 	})
 	return result, nil
 }
@@ -516,6 +542,35 @@ func countPreviews(counts map[string]uint32) []*CountPreview {
 		return previews[i].Count > previews[j].Count
 	})
 	return previews
+}
+
+func traversalPreviews(traversals []graphstorekuzu.Traversal) []*TraversalPreview {
+	previews := make([]*TraversalPreview, 0, len(traversals))
+	for _, traversal := range traversals {
+		previews = append(previews, &TraversalPreview{
+			Path:           traversalPath(traversal),
+			FromURN:        traversal.FromURN,
+			FirstRelation:  traversal.FirstRelation,
+			ViaURN:         traversal.ViaURN,
+			SecondRelation: traversal.SecondRelation,
+			ToURN:          traversal.ToURN,
+		})
+	}
+	return previews
+}
+
+func traversalPath(traversal graphstorekuzu.Traversal) string {
+	from := firstNonEmptyLabel(traversal.FromLabel, traversal.FromURN)
+	via := firstNonEmptyLabel(traversal.ViaLabel, traversal.ViaURN)
+	to := firstNonEmptyLabel(traversal.ToLabel, traversal.ToURN)
+	return from + " -[" + traversal.FirstRelation + "]-> " + via + " -[" + traversal.SecondRelation + "]-> " + to
+}
+
+func firstNonEmptyLabel(label string, fallback string) string {
+	if strings.TrimSpace(label) != "" {
+		return strings.TrimSpace(label)
+	}
+	return strings.TrimSpace(fallback)
 }
 
 func durationMillis(start time.Time) int64 {

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -150,6 +150,28 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if result.GraphLinks != 5 {
 		t.Fatalf("GraphLinks = %d, want 5", result.GraphLinks)
 	}
+	if len(result.StageConfirmations) != 5 {
+		t.Fatalf("len(StageConfirmations) = %d, want 5", len(result.StageConfirmations))
+	}
+	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph")
+	if got := countValue(result.EventKinds, "github.audit"); got != 1 {
+		t.Fatalf("event kind github.audit = %d, want 1", got)
+	}
+	if got := countValue(result.EventKinds, "github.pull_request"); got != 1 {
+		t.Fatalf("event kind github.pull_request = %d, want 1", got)
+	}
+	if got := countValue(result.GraphEntityTypes, "github.pull_request"); got != 1 {
+		t.Fatalf("graph entity type github.pull_request = %d, want 1", got)
+	}
+	if got := countValue(result.GraphEntityTypes, "identifier.login"); got != 1 {
+		t.Fatalf("graph entity type identifier.login = %d, want 1", got)
+	}
+	if got := countValue(result.GraphRelationTypes, "belongs_to"); got != 2 {
+		t.Fatalf("graph relation type belongs_to = %d, want 2", got)
+	}
+	if got := countValue(result.GraphRelationTypes, "authored"); got != 1 {
+		t.Fatalf("graph relation type authored = %d, want 1", got)
+	}
 	if len(result.Events) != 2 {
 		t.Fatalf("len(Events) = %d, want 2", len(result.Events))
 	}
@@ -218,6 +240,12 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if result.GraphLinks != 3 {
 		t.Fatalf("GraphLinks = %d, want 3", result.GraphLinks)
 	}
+	if got := countValue(result.EventKinds, "github.audit"); got != 1 {
+		t.Fatalf("event kind github.audit = %d, want 1", got)
+	}
+	if got := countValue(result.GraphEntityTypes, "github.repo"); got != 1 {
+		t.Fatalf("graph entity type github.repo = %d, want 1", got)
+	}
 }
 
 func testEvent(id string, kind string, attributes map[string]string) *cerebrov1.EventEnvelope {
@@ -250,4 +278,31 @@ func containsLink(links []*LinkPreview, fromURN string, relation string, toURN s
 		}
 	}
 	return false
+}
+
+func countValue(counts []*CountPreview, name string) uint32 {
+	for _, count := range counts {
+		if count != nil && count.Name == name {
+			return count.Count
+		}
+	}
+	return 0
+}
+
+func assertStageNames(t *testing.T, stages []*StageConfirmation, want ...string) {
+	t.Helper()
+	if len(stages) != len(want) {
+		t.Fatalf("len(stages) = %d, want %d", len(stages), len(want))
+	}
+	for index, stage := range stages {
+		if stage == nil {
+			t.Fatalf("stage %d = nil", index)
+		}
+		if stage.Name != want[index] {
+			t.Fatalf("stage %d name = %q, want %q", index, stage.Name, want[index])
+		}
+		if stage.Status != stageStatusSuccess {
+			t.Fatalf("stage %d status = %q, want %q", index, stage.Status, stageStatusSuccess)
+		}
+	}
 }

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -150,10 +150,13 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if result.GraphLinks != 5 {
 		t.Fatalf("GraphLinks = %d, want 5", result.GraphLinks)
 	}
-	if len(result.StageConfirmations) != 5 {
-		t.Fatalf("len(StageConfirmations) = %d, want 5", len(result.StageConfirmations))
+	if len(result.StageConfirmations) != 6 {
+		t.Fatalf("len(StageConfirmations) = %d, want 6", len(result.StageConfirmations))
 	}
-	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph")
+	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph", "verify_traversals")
+	if got := result.StageConfirmations[5].TraversalsVerified; got != 3 {
+		t.Fatalf("verify_traversals traversals_verified = %d, want 3", got)
+	}
 	if got := countValue(result.EventKinds, "github.audit"); got != 1 {
 		t.Fatalf("event kind github.audit = %d, want 1", got)
 	}
@@ -171,6 +174,12 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	}
 	if got := countValue(result.GraphRelationTypes, "authored"); got != 1 {
 		t.Fatalf("graph relation type authored = %d, want 1", got)
+	}
+	if len(result.GraphTraversals) != 3 {
+		t.Fatalf("len(GraphTraversals) = %d, want 3", len(result.GraphTraversals))
+	}
+	if !containsTraversalPath(result.GraphTraversals, "octocat -[authored]-> writer/cerebro#418 -[belongs_to]-> writer/cerebro") {
+		t.Fatalf("GraphTraversals missing authored path: %#v", result.GraphTraversals)
 	}
 	if len(result.Events) != 2 {
 		t.Fatalf("len(Events) = %d, want 2", len(result.Events))
@@ -246,6 +255,15 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if got := countValue(result.GraphEntityTypes, "github.repo"); got != 1 {
 		t.Fatalf("graph entity type github.repo = %d, want 1", got)
 	}
+	if len(result.GraphTraversals) != 1 {
+		t.Fatalf("len(GraphTraversals) = %d, want 1", len(result.GraphTraversals))
+	}
+	if got := result.StageConfirmations[5].TraversalsVerified; got != 1 {
+		t.Fatalf("verify_traversals traversals_verified = %d, want 1", got)
+	}
+	if !containsTraversalPath(result.GraphTraversals, "octocat -[acted_on]-> writer/cerebro -[belongs_to]-> writer") {
+		t.Fatalf("GraphTraversals missing acted_on path: %#v", result.GraphTraversals)
+	}
 }
 
 func testEvent(id string, kind string, attributes map[string]string) *cerebrov1.EventEnvelope {
@@ -305,4 +323,13 @@ func assertStageNames(t *testing.T, stages []*StageConfirmation, want ...string)
 			t.Fatalf("stage %d status = %q, want %q", index, stage.Status, stageStatusSuccess)
 		}
 	}
+}
+
+func containsTraversalPath(traversals []*TraversalPreview, want string) bool {
+	for _, traversal := range traversals {
+		if traversal != nil && traversal.Path == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -150,11 +150,17 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if result.GraphLinks != 5 {
 		t.Fatalf("GraphLinks = %d, want 5", result.GraphLinks)
 	}
-	if len(result.StageConfirmations) != 6 {
-		t.Fatalf("len(StageConfirmations) = %d, want 6", len(result.StageConfirmations))
+	if len(result.StageConfirmations) != 7 {
+		t.Fatalf("len(StageConfirmations) = %d, want 7", len(result.StageConfirmations))
 	}
-	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph", "verify_traversals")
-	if got := result.StageConfirmations[5].TraversalsVerified; got != 3 {
+	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph", "verify_integrity", "verify_traversals")
+	if got := result.StageConfirmations[5].AssertionsPassed; got != 5 {
+		t.Fatalf("verify_integrity assertions_passed = %d, want 5", got)
+	}
+	if got := result.StageConfirmations[5].AssertionsFailed; got != 0 {
+		t.Fatalf("verify_integrity assertions_failed = %d, want 0", got)
+	}
+	if got := result.StageConfirmations[6].TraversalsVerified; got != 3 {
 		t.Fatalf("verify_traversals traversals_verified = %d, want 3", got)
 	}
 	if got := countValue(result.EventKinds, "github.audit"); got != 1 {
@@ -174,6 +180,15 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	}
 	if got := countValue(result.GraphRelationTypes, "authored"); got != 1 {
 		t.Fatalf("graph relation type authored = %d, want 1", got)
+	}
+	if len(result.GraphAssertions) != 5 {
+		t.Fatalf("len(GraphAssertions) = %d, want 5", len(result.GraphAssertions))
+	}
+	if !containsAssertion(result.GraphAssertions, "tenant_mismatched_relations", 0, 0, true) {
+		t.Fatalf("GraphAssertions missing tenant_mismatched_relations: %#v", result.GraphAssertions)
+	}
+	if !containsAssertion(result.GraphAssertions, "self_referential_relations", 0, 0, true) {
+		t.Fatalf("GraphAssertions missing self_referential_relations: %#v", result.GraphAssertions)
 	}
 	if len(result.GraphTraversals) != 3 {
 		t.Fatalf("len(GraphTraversals) = %d, want 3", len(result.GraphTraversals))
@@ -258,7 +273,10 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if len(result.GraphTraversals) != 1 {
 		t.Fatalf("len(GraphTraversals) = %d, want 1", len(result.GraphTraversals))
 	}
-	if got := result.StageConfirmations[5].TraversalsVerified; got != 1 {
+	if got := result.StageConfirmations[5].AssertionsPassed; got != 5 {
+		t.Fatalf("verify_integrity assertions_passed = %d, want 5", got)
+	}
+	if got := result.StageConfirmations[6].TraversalsVerified; got != 1 {
 		t.Fatalf("verify_traversals traversals_verified = %d, want 1", got)
 	}
 	if !containsTraversalPath(result.GraphTraversals, "octocat -[acted_on]-> writer/cerebro -[belongs_to]-> writer") {
@@ -328,6 +346,18 @@ func assertStageNames(t *testing.T, stages []*StageConfirmation, want ...string)
 func containsTraversalPath(traversals []*TraversalPreview, want string) bool {
 	for _, traversal := range traversals {
 		if traversal != nil && traversal.Path == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAssertion(assertions []*AssertionPreview, name string, actual int64, expected int64, passed bool) bool {
+	for _, assertion := range assertions {
+		if assertion == nil {
+			continue
+		}
+		if assertion.Name == name && assertion.Actual == actual && assertion.Expected == expected && assertion.Passed == passed {
 			return true
 		}
 	}

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -30,6 +30,18 @@ type Counts struct {
 	Relations int64
 }
 
+// Traversal captures one sampled two-hop path from the local graph.
+type Traversal struct {
+	FromURN        string
+	FromLabel      string
+	FirstRelation  string
+	ViaURN         string
+	ViaLabel       string
+	SecondRelation string
+	ToURN          string
+	ToLabel        string
+}
+
 // Open opens a Kuzu-backed graph projection store.
 func Open(cfg config.GraphStoreConfig) (*Store, error) {
 	rawPath := strings.TrimSpace(cfg.KuzuPath)
@@ -97,6 +109,59 @@ func (s *Store) Counts(ctx context.Context) (Counts, error) {
 		return Counts{}, fmt.Errorf("count relation edges: %w", err)
 	}
 	return counts, nil
+}
+
+// SampleTraversals returns a bounded set of traversable two-hop paths from the local graph.
+func (s *Store) SampleTraversals(ctx context.Context, limit int) (_ []Traversal, err error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("kuzu is not configured")
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !tables["entity"] || !tables["relation"] {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(
+		"MATCH (src:entity)-[left:relation]->(mid:entity)-[right:relation]->(dst:entity) "+
+			"RETURN src.urn, src.label, left.relation, mid.urn, mid.label, right.relation, dst.urn, dst.label "+
+			"ORDER BY src.urn, left.relation, mid.urn, right.relation, dst.urn LIMIT %d",
+		limit,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("sample graph traversals: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close graph traversals: %w", closeErr)
+		}
+	}()
+
+	traversals := make([]Traversal, 0, limit)
+	for rows.Next() {
+		var traversal Traversal
+		if err := rows.Scan(
+			&traversal.FromURN,
+			&traversal.FromLabel,
+			&traversal.FirstRelation,
+			&traversal.ViaURN,
+			&traversal.ViaLabel,
+			&traversal.SecondRelation,
+			&traversal.ToURN,
+			&traversal.ToLabel,
+		); err != nil {
+			return nil, fmt.Errorf("scan graph traversal: %w", err)
+		}
+		traversals = append(traversals, traversal)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate graph traversals: %w", err)
+	}
+	return traversals, nil
 }
 
 // UpsertProjectedEntity upserts one normalized entity in the graph store.

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -42,6 +42,14 @@ type Traversal struct {
 	ToLabel        string
 }
 
+// IntegrityCheck captures one local graph invariant check result.
+type IntegrityCheck struct {
+	Name     string
+	Actual   int64
+	Expected int64
+	Passed   bool
+}
+
 // Open opens a Kuzu-backed graph projection store.
 func Open(cfg config.GraphStoreConfig) (*Store, error) {
 	rawPath := strings.TrimSpace(cfg.KuzuPath)
@@ -162,6 +170,46 @@ func (s *Store) SampleTraversals(ctx context.Context, limit int) (_ []Traversal,
 		return nil, fmt.Errorf("iterate graph traversals: %w", err)
 	}
 	return traversals, nil
+}
+
+// IntegrityChecks returns a fixed set of local graph invariant checks.
+func (s *Store) IntegrityChecks(ctx context.Context) ([]IntegrityCheck, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("kuzu is not configured")
+	}
+	checks := []IntegrityCheck{
+		{Name: "tenant_mismatched_relations", Expected: 0},
+		{Name: "blank_entity_labels", Expected: 0},
+		{Name: "blank_entity_types", Expected: 0},
+		{Name: "blank_relation_types", Expected: 0},
+		{Name: "self_referential_relations", Expected: 0},
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !tables["entity"] || !tables["relation"] {
+		for index := range checks {
+			checks[index].Passed = true
+		}
+		return checks, nil
+	}
+	queries := []string{
+		"MATCH (src:entity)-[r:relation]->(dst:entity) WHERE src.tenant_id <> dst.tenant_id OR src.tenant_id <> r.tenant_id OR dst.tenant_id <> r.tenant_id RETURN COUNT(r)",
+		"MATCH (e:entity) WHERE e.label = '' RETURN COUNT(e)",
+		"MATCH (e:entity) WHERE e.entity_type = '' RETURN COUNT(e)",
+		"MATCH (src:entity)-[r:relation]->(dst:entity) WHERE r.relation = '' RETURN COUNT(r)",
+		"MATCH (src:entity)-[r:relation]->(dst:entity) WHERE src.urn = dst.urn RETURN COUNT(r)",
+	}
+	for index, query := range queries {
+		actual, err := s.countQuery(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+		checks[index].Actual = actual
+		checks[index].Passed = actual == checks[index].Expected
+	}
+	return checks, nil
 }
 
 // UpsertProjectedEntity upserts one normalized entity in the graph store.
@@ -341,6 +389,14 @@ func graphAttributesJSON(attributes map[string]string) (string, error) {
 		return "", err
 	}
 	return string(payload), nil
+}
+
+func (s *Store) countQuery(ctx context.Context, query string) (int64, error) {
+	var count int64
+	if err := s.db.QueryRowContext(ctx, query).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count query: %w", err)
+	}
+	return count, nil
 }
 
 func stringColumn(value any) string {

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -188,26 +188,35 @@ func (s *Store) IntegrityChecks(ctx context.Context) ([]IntegrityCheck, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !tables["entity"] || !tables["relation"] {
-		for index := range checks {
+	hasEntity := tables["entity"]
+	hasRelation := tables["relation"]
+	run := func(index int, enabled bool, query string) error {
+		if !enabled {
 			checks[index].Passed = true
+			return nil
 		}
-		return checks, nil
-	}
-	queries := []string{
-		"MATCH (src:entity)-[r:relation]->(dst:entity) WHERE src.tenant_id <> dst.tenant_id OR src.tenant_id <> r.tenant_id OR dst.tenant_id <> r.tenant_id RETURN COUNT(r)",
-		"MATCH (e:entity) WHERE e.label = '' RETURN COUNT(e)",
-		"MATCH (e:entity) WHERE e.entity_type = '' RETURN COUNT(e)",
-		"MATCH (src:entity)-[r:relation]->(dst:entity) WHERE r.relation = '' RETURN COUNT(r)",
-		"MATCH (src:entity)-[r:relation]->(dst:entity) WHERE src.urn = dst.urn RETURN COUNT(r)",
-	}
-	for index, query := range queries {
 		actual, err := s.countQuery(ctx, query)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		checks[index].Actual = actual
 		checks[index].Passed = actual == checks[index].Expected
+		return nil
+	}
+	if err := run(0, hasEntity && hasRelation, "MATCH (src:entity)-[r:relation]->(dst:entity) WHERE src.tenant_id <> dst.tenant_id OR src.tenant_id <> r.tenant_id OR dst.tenant_id <> r.tenant_id RETURN COUNT(r)"); err != nil {
+		return nil, err
+	}
+	if err := run(1, hasEntity, "MATCH (e:entity) WHERE e.label = '' RETURN COUNT(e)"); err != nil {
+		return nil, err
+	}
+	if err := run(2, hasEntity, "MATCH (e:entity) WHERE e.entity_type = '' RETURN COUNT(e)"); err != nil {
+		return nil, err
+	}
+	if err := run(3, hasEntity && hasRelation, "MATCH (src:entity)-[r:relation]->(dst:entity) WHERE r.relation = '' RETURN COUNT(r)"); err != nil {
+		return nil, err
+	}
+	if err := run(4, hasEntity && hasRelation, "MATCH (src:entity)-[r:relation]->(dst:entity) WHERE src.urn = dst.urn RETURN COUNT(r)"); err != nil {
+		return nil, err
 	}
 	return checks, nil
 }

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -232,6 +232,39 @@ func TestIntegrityChecksDetectTenantMismatch(t *testing.T) {
 	}
 }
 
+func TestIntegrityChecksRunEntityOnlyChecksWithoutRelationTable(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	if _, err := store.db.ExecContext(ctx, "CREATE NODE TABLE entity(urn STRING, tenant_id STRING, source_id STRING, entity_type STRING, label STRING, attributes_json STRING, PRIMARY KEY (urn))"); err != nil {
+		t.Fatalf("create entity table: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE (:entity {urn: %s, tenant_id: %s, source_id: %s, entity_type: %s, label: %s, attributes_json: %s})",
+		cypherString("urn:cerebro:writer:github_repo:writer/cerebro"),
+		cypherString("writer"),
+		cypherString("github"),
+		cypherString("github.repo"),
+		cypherString(""),
+		cypherString("{}"),
+	)); err != nil {
+		t.Fatalf("insert entity: %v", err)
+	}
+
+	checks, err := store.IntegrityChecks(ctx)
+	if err != nil {
+		t.Fatalf("IntegrityChecks() error = %v", err)
+	}
+	if actual := integrityCheckActual(checks, "blank_entity_labels"); actual != 1 {
+		t.Fatalf("blank_entity_labels = %d, want 1", actual)
+	}
+	if passed := integrityCheckPassed(checks, "blank_entity_labels"); passed {
+		t.Fatal("blank_entity_labels passed = true, want false")
+	}
+	if passed := integrityCheckPassed(checks, "blank_relation_types"); !passed {
+		t.Fatal("blank_relation_types passed = false, want true when relation table is absent")
+	}
+}
+
 func TestUpsertProjectedEntityRejectsNilEntity(t *testing.T) {
 	store := &Store{}
 	if err := store.UpsertProjectedEntity(context.Background(), nil); err == nil {
@@ -336,4 +369,13 @@ func integrityCheckActual(checks []IntegrityCheck, name string) int64 {
 		}
 	}
 	return -1
+}
+
+func integrityCheckPassed(checks []IntegrityCheck, name string) bool {
+	for _, check := range checks {
+		if check.Name == name {
+			return check.Passed
+		}
+	}
+	return false
 }

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -125,6 +125,14 @@ func TestProjectorBuildsTraversableLocalGraph(t *testing.T) {
 	) {
 		t.Fatalf("SampleTraversals() missing authored path: %#v", traversals)
 	}
+
+	checks, err := store.IntegrityChecks(context.Background())
+	if err != nil {
+		t.Fatalf("IntegrityChecks() error = %v", err)
+	}
+	if failedIntegrityChecks(checks) != 0 {
+		t.Fatalf("IntegrityChecks() failed = %d, want 0: %#v", failedIntegrityChecks(checks), checks)
+	}
 }
 
 func TestProjectorKeepsLocalGraphIdentityLinksTenantScoped(t *testing.T) {
@@ -187,6 +195,40 @@ func TestProjectorKeepsLocalGraphIdentityLinksTenantScoped(t *testing.T) {
 	)
 	if identifierCount != 2 {
 		t.Fatalf("identifier count = %d, want 2", identifierCount)
+	}
+}
+
+func TestIntegrityChecksDetectTenantMismatch(t *testing.T) {
+	store := newTestStore(t)
+	projectEvents(t, store,
+		&cerebrov1.EventEnvelope{
+			Id:       "github-pr-447",
+			TenantId: "writer",
+			SourceId: "github",
+			Kind:     "github.pull_request",
+			Attributes: map[string]string{
+				"author":      "alice",
+				"owner":       "writer",
+				"pull_number": "447",
+				"repository":  "writer/cerebro",
+			},
+		},
+	)
+
+	if _, err := store.db.ExecContext(context.Background(), fmt.Sprintf(
+		"MATCH (e:entity {urn: %s}) SET e.tenant_id = %s",
+		cypherString("urn:cerebro:writer:github_repo:writer/cerebro"),
+		cypherString("writer-mismatch"),
+	)); err != nil {
+		t.Fatalf("ExecContext() error = %v", err)
+	}
+
+	checks, err := store.IntegrityChecks(context.Background())
+	if err != nil {
+		t.Fatalf("IntegrityChecks() error = %v", err)
+	}
+	if actual := integrityCheckActual(checks, "tenant_mismatched_relations"); actual != 2 {
+		t.Fatalf("tenant_mismatched_relations = %d, want 2", actual)
 	}
 }
 
@@ -275,4 +317,23 @@ func containsTraversal(traversals []Traversal, fromURN string, firstRelation str
 		}
 	}
 	return false
+}
+
+func failedIntegrityChecks(checks []IntegrityCheck) int {
+	failed := 0
+	for _, check := range checks {
+		if !check.Passed {
+			failed++
+		}
+	}
+	return failed
+}
+
+func integrityCheckActual(checks []IntegrityCheck, name string) int64 {
+	for _, check := range checks {
+		if check.Name == name {
+			return check.Actual
+		}
+	}
+	return -1
 }

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -111,6 +111,20 @@ func TestProjectorBuildsTraversableLocalGraph(t *testing.T) {
 	if pathCount != 1 {
 		t.Fatalf("authored pull-request path count = %d, want 1", pathCount)
 	}
+
+	traversals, err := store.SampleTraversals(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("SampleTraversals() error = %v", err)
+	}
+	if !containsTraversal(traversals,
+		"urn:cerebro:writer:github_user:alice",
+		"authored",
+		"urn:cerebro:writer:github_pull_request:writer/cerebro#447",
+		"belongs_to",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+	) {
+		t.Fatalf("SampleTraversals() missing authored path: %#v", traversals)
+	}
 }
 
 func TestProjectorKeepsLocalGraphIdentityLinksTenantScoped(t *testing.T) {
@@ -248,4 +262,17 @@ func mustJSON(t *testing.T, value any) []byte {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
 	return payload
+}
+
+func containsTraversal(traversals []Traversal, fromURN string, firstRelation string, viaURN string, secondRelation string, toURN string) bool {
+	for _, traversal := range traversals {
+		if traversal.FromURN == fromURN &&
+			traversal.FirstRelation == firstRelation &&
+			traversal.ViaURN == viaURN &&
+			traversal.SecondRelation == secondRelation &&
+			traversal.ToURN == toURN {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- add explicit stage confirmations to graph rebuild dry-runs for runtime resolution, local graph open, source reads, projection, and final graph counting
- include local grouped output for event kinds plus unique graph entity and relation types
- extend rebuild tests to assert the new confirmation data

## Validation
- go test ./internal/graphrebuild ./cmd/cerebro ./internal/graphstore/kuzu
- make verify
- local fixture demo via go run ./graph_rebuild_local_demo.go