### PR TITLE
feat(graph): confirm local rebuild path patterns

### DIFF
--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -33,6 +33,7 @@ type graphStore interface {
 	Close() error
 	Counts(context.Context) (graphstorekuzu.Counts, error)
 	IntegrityChecks(context.Context) ([]graphstorekuzu.IntegrityCheck, error)
+	PathPatterns(context.Context, int) ([]graphstorekuzu.PathPattern, error)
 	SampleTraversals(context.Context, int) ([]graphstorekuzu.Traversal, error)
 }
 
@@ -80,6 +81,7 @@ type StageConfirmation struct {
 	LinksProjected     uint32 `json:"links_projected,omitempty"`
 	AssertionsPassed   uint32 `json:"assertions_passed,omitempty"`
 	AssertionsFailed   uint32 `json:"assertions_failed,omitempty"`
+	PatternsVerified   uint32 `json:"patterns_verified,omitempty"`
 	TraversalsVerified uint32 `json:"traversals_verified,omitempty"`
 	GraphNodes         int64  `json:"graph_nodes,omitempty"`
 	GraphLinks         int64  `json:"graph_links,omitempty"`
@@ -103,27 +105,39 @@ type AssertionPreview struct {
 	Passed   bool   `json:"passed"`
 }
 
+// PathPatternPreview captures one grouped two-hop graph pattern from the local graph.
+type PathPatternPreview struct {
+	Pattern        string `json:"pattern"`
+	FromType       string `json:"from_type"`
+	FirstRelation  string `json:"first_relation"`
+	ViaType        string `json:"via_type"`
+	SecondRelation string `json:"second_relation"`
+	ToType         string `json:"to_type"`
+	Count          int64  `json:"count"`
+}
+
 // Result summarizes a dry-run rebuild execution.
 type Result struct {
-	RuntimeID          string               `json:"runtime_id"`
-	SourceID           string               `json:"source_id"`
-	TenantID           string               `json:"tenant_id,omitempty"`
-	DryRun             bool                 `json:"dry_run"`
-	PagesRead          uint32               `json:"pages_read"`
-	EventsRead         uint32               `json:"events_read"`
-	EntitiesProjected  uint32               `json:"entities_projected"`
-	LinksProjected     uint32               `json:"links_projected"`
-	GraphNodes         int64                `json:"graph_nodes"`
-	GraphLinks         int64                `json:"graph_links"`
-	StageConfirmations []*StageConfirmation `json:"stage_confirmations,omitempty"`
-	EventKinds         []*CountPreview      `json:"event_kinds,omitempty"`
-	GraphEntityTypes   []*CountPreview      `json:"graph_entity_types,omitempty"`
-	GraphRelationTypes []*CountPreview      `json:"graph_relation_types,omitempty"`
-	GraphAssertions    []*AssertionPreview  `json:"graph_assertions,omitempty"`
-	GraphTraversals    []*TraversalPreview  `json:"graph_traversals,omitempty"`
-	Events             []*EventPreview      `json:"events,omitempty"`
-	PreviewEntities    []*EntityPreview     `json:"preview_entities,omitempty"`
-	PreviewLinks       []*LinkPreview       `json:"preview_links,omitempty"`
+	RuntimeID          string                `json:"runtime_id"`
+	SourceID           string                `json:"source_id"`
+	TenantID           string                `json:"tenant_id,omitempty"`
+	DryRun             bool                  `json:"dry_run"`
+	PagesRead          uint32                `json:"pages_read"`
+	EventsRead         uint32                `json:"events_read"`
+	EntitiesProjected  uint32                `json:"entities_projected"`
+	LinksProjected     uint32                `json:"links_projected"`
+	GraphNodes         int64                 `json:"graph_nodes"`
+	GraphLinks         int64                 `json:"graph_links"`
+	StageConfirmations []*StageConfirmation  `json:"stage_confirmations,omitempty"`
+	EventKinds         []*CountPreview       `json:"event_kinds,omitempty"`
+	GraphEntityTypes   []*CountPreview       `json:"graph_entity_types,omitempty"`
+	GraphRelationTypes []*CountPreview       `json:"graph_relation_types,omitempty"`
+	GraphAssertions    []*AssertionPreview   `json:"graph_assertions,omitempty"`
+	GraphPathPatterns  []*PathPatternPreview `json:"graph_path_patterns,omitempty"`
+	GraphTraversals    []*TraversalPreview   `json:"graph_traversals,omitempty"`
+	Events             []*EventPreview       `json:"events,omitempty"`
+	PreviewEntities    []*EntityPreview      `json:"preview_entities,omitempty"`
+	PreviewLinks       []*LinkPreview        `json:"preview_links,omitempty"`
 }
 
 // Service rebuilds a local graph from stored source runtimes.
@@ -276,6 +290,19 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 		DurationMillis:   durationMillis(integrityStart),
 		AssertionsPassed: assertionsPassed,
 		AssertionsFailed: assertionsFailed,
+	})
+
+	patternStart := time.Now()
+	patterns, err := graph.PathPatterns(ctx, previewLimit)
+	if err != nil {
+		return nil, err
+	}
+	result.GraphPathPatterns = pathPatternPreviews(patterns)
+	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
+		Name:             "verify_path_patterns",
+		Status:           stageStatusSuccess,
+		DurationMillis:   durationMillis(patternStart),
+		PatternsVerified: uint32(len(result.GraphPathPatterns)),
 	})
 
 	traversalStart := time.Now()
@@ -598,6 +625,30 @@ func assertionCounts(assertions []*AssertionPreview) (uint32, uint32) {
 		failed++
 	}
 	return passed, failed
+}
+
+func pathPatternPreviews(patterns []graphstorekuzu.PathPattern) []*PathPatternPreview {
+	previews := make([]*PathPatternPreview, 0, len(patterns))
+	for _, pattern := range patterns {
+		previews = append(previews, &PathPatternPreview{
+			Pattern:        pathPatternLabel(pattern),
+			FromType:       pattern.FromType,
+			FirstRelation:  pattern.FirstRelation,
+			ViaType:        pattern.ViaType,
+			SecondRelation: pattern.SecondRelation,
+			ToType:         pattern.ToType,
+			Count:          pattern.Count,
+		})
+	}
+	return previews
+}
+
+func pathPatternLabel(pattern graphstorekuzu.PathPattern) string {
+	return strings.TrimSpace(pattern.FromType) +
+		" -[" + strings.TrimSpace(pattern.FirstRelation) + "]-> " +
+		strings.TrimSpace(pattern.ViaType) +
+		" -[" + strings.TrimSpace(pattern.SecondRelation) + "]-> " +
+		strings.TrimSpace(pattern.ToType)
 }
 
 func traversalPreviews(traversals []graphstorekuzu.Traversal) []*TraversalPreview {

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -51,6 +51,17 @@ type EventPreview struct {
 	Kind string `json:"kind"`
 }
 
+// ReadPagePreview captures one source page consumed during the rebuild.
+type ReadPagePreview struct {
+	Page             uint32 `json:"page"`
+	Events           uint32 `json:"events"`
+	CheckpointCursor string `json:"checkpoint_cursor,omitempty"`
+	NextCursor       string `json:"next_cursor,omitempty"`
+	Watermark        string `json:"watermark,omitempty"`
+	FirstEventID     string `json:"first_event_id,omitempty"`
+	LastEventID      string `json:"last_event_id,omitempty"`
+}
+
 // EntityPreview captures one projected entity written to the local graph.
 type EntityPreview struct {
 	URN        string `json:"urn"`
@@ -137,6 +148,7 @@ type Result struct {
 	GraphNodes         int64                 `json:"graph_nodes"`
 	GraphLinks         int64                 `json:"graph_links"`
 	StageConfirmations []*StageConfirmation  `json:"stage_confirmations,omitempty"`
+	ReadPages          []*ReadPagePreview    `json:"read_pages,omitempty"`
 	EventKinds         []*CountPreview       `json:"event_kinds,omitempty"`
 	GraphEntityTypes   []*CountPreview       `json:"graph_entity_types,omitempty"`
 	GraphRelationTypes []*CountPreview       `json:"graph_relation_types,omitempty"`
@@ -242,6 +254,7 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 	}
 	result.PagesRead = readSummary.PagesRead
 	result.EventsRead = readSummary.EventsRead
+	result.ReadPages = readSummary.Pages
 	result.EventKinds = countPreviews(readSummary.EventKinds)
 	result.Events = eventPreviews(readSummary.Events, previewLimit)
 	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
@@ -389,6 +402,7 @@ func materializeEvent(runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEn
 
 type readSummary struct {
 	Events     []*cerebrov1.EventEnvelope
+	Pages      []*ReadPagePreview
 	PagesRead  uint32
 	EventsRead uint32
 	EventKinds map[string]uint32
@@ -407,18 +421,30 @@ func (s *Service) readEvents(ctx context.Context, source sourcecdk.Source, runti
 		}
 		summary.PagesRead++
 		summary.EventsRead += uint32(len(pull.Events))
+		pageSummary := &ReadPagePreview{
+			Page:             page + 1,
+			Events:           uint32(len(pull.Events)),
+			CheckpointCursor: checkpointCursor(pull.Checkpoint),
+			NextCursor:       nextCursor(pull.NextCursor),
+			Watermark:        formatWatermark(pull.Checkpoint),
+		}
 		for _, event := range pull.Events {
 			materialized := materializeEvent(runtime, event)
 			if materialized == nil {
 				continue
 			}
 			summary.Events = append(summary.Events, materialized)
+			if pageSummary.FirstEventID == "" {
+				pageSummary.FirstEventID = strings.TrimSpace(materialized.GetId())
+			}
+			pageSummary.LastEventID = strings.TrimSpace(materialized.GetId())
 			kind := strings.TrimSpace(materialized.GetKind())
 			if kind == "" {
 				continue
 			}
 			summary.EventKinds[kind]++
 		}
+		summary.Pages = append(summary.Pages, pageSummary)
 		if pull.NextCursor == nil {
 			break
 		}
@@ -717,6 +743,27 @@ func durationMillis(start time.Time) int64 {
 		return 0
 	}
 	return time.Since(start).Milliseconds()
+}
+
+func formatWatermark(checkpoint *cerebrov1.SourceCheckpoint) string {
+	if checkpoint == nil || checkpoint.GetWatermark() == nil || checkpoint.GetWatermark().AsTime().IsZero() {
+		return ""
+	}
+	return checkpoint.GetWatermark().AsTime().UTC().Format(time.RFC3339Nano)
+}
+
+func checkpointCursor(checkpoint *cerebrov1.SourceCheckpoint) string {
+	if checkpoint == nil {
+		return ""
+	}
+	return strings.TrimSpace(checkpoint.GetCursorOpaque())
+}
+
+func nextCursor(cursor *cerebrov1.SourceCursor) string {
+	if cursor == nil {
+		return ""
+	}
+	return strings.TrimSpace(cursor.GetOpaque())
 }
 
 func min(left int, right int) int {

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -34,6 +34,7 @@ type graphStore interface {
 	Counts(context.Context) (graphstorekuzu.Counts, error)
 	IntegrityChecks(context.Context) ([]graphstorekuzu.IntegrityCheck, error)
 	PathPatterns(context.Context, int) ([]graphstorekuzu.PathPattern, error)
+	Topology(context.Context) (graphstorekuzu.Topology, error)
 	SampleTraversals(context.Context, int) ([]graphstorekuzu.Traversal, error)
 }
 
@@ -82,6 +83,7 @@ type StageConfirmation struct {
 	AssertionsPassed   uint32 `json:"assertions_passed,omitempty"`
 	AssertionsFailed   uint32 `json:"assertions_failed,omitempty"`
 	PatternsVerified   uint32 `json:"patterns_verified,omitempty"`
+	TopologyBuckets    uint32 `json:"topology_buckets,omitempty"`
 	TraversalsVerified uint32 `json:"traversals_verified,omitempty"`
 	GraphNodes         int64  `json:"graph_nodes,omitempty"`
 	GraphLinks         int64  `json:"graph_links,omitempty"`
@@ -116,6 +118,12 @@ type PathPatternPreview struct {
 	Count          int64  `json:"count"`
 }
 
+// TopologyPreview captures one connectivity bucket in the local graph.
+type TopologyPreview struct {
+	Name  string `json:"name"`
+	Count int64  `json:"count"`
+}
+
 // Result summarizes a dry-run rebuild execution.
 type Result struct {
 	RuntimeID          string                `json:"runtime_id"`
@@ -134,6 +142,7 @@ type Result struct {
 	GraphRelationTypes []*CountPreview       `json:"graph_relation_types,omitempty"`
 	GraphAssertions    []*AssertionPreview   `json:"graph_assertions,omitempty"`
 	GraphPathPatterns  []*PathPatternPreview `json:"graph_path_patterns,omitempty"`
+	GraphTopology      []*TopologyPreview    `json:"graph_topology,omitempty"`
 	GraphTraversals    []*TraversalPreview   `json:"graph_traversals,omitempty"`
 	Events             []*EventPreview       `json:"events,omitempty"`
 	PreviewEntities    []*EntityPreview      `json:"preview_entities,omitempty"`
@@ -303,6 +312,19 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 		Status:           stageStatusSuccess,
 		DurationMillis:   durationMillis(patternStart),
 		PatternsVerified: uint32(len(result.GraphPathPatterns)),
+	})
+
+	topologyStart := time.Now()
+	topology, err := graph.Topology(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result.GraphTopology = topologyPreviews(topology)
+	result.StageConfirmations = append(result.StageConfirmations, &StageConfirmation{
+		Name:            "verify_topology",
+		Status:          stageStatusSuccess,
+		DurationMillis:  durationMillis(topologyStart),
+		TopologyBuckets: uint32(len(result.GraphTopology)),
 	})
 
 	traversalStart := time.Now()
@@ -649,6 +671,16 @@ func pathPatternLabel(pattern graphstorekuzu.PathPattern) string {
 		strings.TrimSpace(pattern.ViaType) +
 		" -[" + strings.TrimSpace(pattern.SecondRelation) + "]-> " +
 		strings.TrimSpace(pattern.ToType)
+}
+
+func topologyPreviews(topology graphstorekuzu.Topology) []*TopologyPreview {
+	previews := []*TopologyPreview{
+		{Name: "isolated", Count: topology.Isolated},
+		{Name: "sources_only", Count: topology.SourcesOnly},
+		{Name: "sinks_only", Count: topology.SinksOnly},
+		{Name: "intermediates", Count: topology.Intermediates},
+	}
+	return previews
 }
 
 func traversalPreviews(traversals []graphstorekuzu.Traversal) []*TraversalPreview {

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -150,10 +150,10 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if result.GraphLinks != 5 {
 		t.Fatalf("GraphLinks = %d, want 5", result.GraphLinks)
 	}
-	if len(result.StageConfirmations) != 8 {
-		t.Fatalf("len(StageConfirmations) = %d, want 8", len(result.StageConfirmations))
+	if len(result.StageConfirmations) != 9 {
+		t.Fatalf("len(StageConfirmations) = %d, want 9", len(result.StageConfirmations))
 	}
-	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph", "verify_integrity", "verify_path_patterns", "verify_traversals")
+	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph", "verify_integrity", "verify_path_patterns", "verify_topology", "verify_traversals")
 	if got := result.StageConfirmations[5].AssertionsPassed; got != 5 {
 		t.Fatalf("verify_integrity assertions_passed = %d, want 5", got)
 	}
@@ -163,7 +163,10 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if got := result.StageConfirmations[6].PatternsVerified; got != 3 {
 		t.Fatalf("verify_path_patterns patterns_verified = %d, want 3", got)
 	}
-	if got := result.StageConfirmations[7].TraversalsVerified; got != 3 {
+	if got := result.StageConfirmations[7].TopologyBuckets; got != 4 {
+		t.Fatalf("verify_topology topology_buckets = %d, want 4", got)
+	}
+	if got := result.StageConfirmations[8].TraversalsVerified; got != 3 {
 		t.Fatalf("verify_traversals traversals_verified = %d, want 3", got)
 	}
 	if got := countValue(result.EventKinds, "github.audit"); got != 1 {
@@ -198,6 +201,21 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	}
 	if !containsPathPatternPreview(result.GraphPathPatterns, "github.user -[authored]-> github.pull_request -[belongs_to]-> github.repo", 1) {
 		t.Fatalf("GraphPathPatterns missing authored pattern: %#v", result.GraphPathPatterns)
+	}
+	if len(result.GraphTopology) != 4 {
+		t.Fatalf("len(GraphTopology) = %d, want 4", len(result.GraphTopology))
+	}
+	if !containsTopologyPreview(result.GraphTopology, "isolated", 0) {
+		t.Fatalf("GraphTopology missing isolated bucket: %#v", result.GraphTopology)
+	}
+	if !containsTopologyPreview(result.GraphTopology, "sources_only", 1) {
+		t.Fatalf("GraphTopology missing sources_only bucket: %#v", result.GraphTopology)
+	}
+	if !containsTopologyPreview(result.GraphTopology, "sinks_only", 2) {
+		t.Fatalf("GraphTopology missing sinks_only bucket: %#v", result.GraphTopology)
+	}
+	if !containsTopologyPreview(result.GraphTopology, "intermediates", 2) {
+		t.Fatalf("GraphTopology missing intermediates bucket: %#v", result.GraphTopology)
 	}
 	if len(result.GraphTraversals) != 3 {
 		t.Fatalf("len(GraphTraversals) = %d, want 3", len(result.GraphTraversals))
@@ -288,7 +306,10 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if got := result.StageConfirmations[6].PatternsVerified; got != 1 {
 		t.Fatalf("verify_path_patterns patterns_verified = %d, want 1", got)
 	}
-	if got := result.StageConfirmations[7].TraversalsVerified; got != 1 {
+	if got := result.StageConfirmations[7].TopologyBuckets; got != 4 {
+		t.Fatalf("verify_topology topology_buckets = %d, want 4", got)
+	}
+	if got := result.StageConfirmations[8].TraversalsVerified; got != 1 {
 		t.Fatalf("verify_traversals traversals_verified = %d, want 1", got)
 	}
 	if len(result.GraphPathPatterns) != 1 {
@@ -296,6 +317,9 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	}
 	if !containsPathPatternPreview(result.GraphPathPatterns, "github.user -[acted_on]-> github.repo -[belongs_to]-> github.org", 1) {
 		t.Fatalf("GraphPathPatterns missing acted_on pattern: %#v", result.GraphPathPatterns)
+	}
+	if !containsTopologyPreview(result.GraphTopology, "isolated", 0) || !containsTopologyPreview(result.GraphTopology, "sources_only", 1) || !containsTopologyPreview(result.GraphTopology, "sinks_only", 2) || !containsTopologyPreview(result.GraphTopology, "intermediates", 1) {
+		t.Fatalf("GraphTopology unexpected values: %#v", result.GraphTopology)
 	}
 	if !containsTraversalPath(result.GraphTraversals, "octocat -[acted_on]-> writer/cerebro -[belongs_to]-> writer") {
 		t.Fatalf("GraphTraversals missing acted_on path: %#v", result.GraphTraversals)
@@ -385,6 +409,15 @@ func containsAssertion(assertions []*AssertionPreview, name string, actual int64
 func containsPathPatternPreview(patterns []*PathPatternPreview, label string, count int64) bool {
 	for _, pattern := range patterns {
 		if pattern != nil && pattern.Pattern == label && pattern.Count == count {
+			return true
+		}
+	}
+	return false
+}
+
+func containsTopologyPreview(topology []*TopologyPreview, name string, count int64) bool {
+	for _, bucket := range topology {
+		if bucket != nil && bucket.Name == name && bucket.Count == count {
 			return true
 		}
 	}

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -169,6 +169,11 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if got := result.StageConfirmations[8].TraversalsVerified; got != 3 {
 		t.Fatalf("verify_traversals traversals_verified = %d, want 3", got)
 	}
+	if len(result.ReadPages) != 2 {
+		t.Fatalf("len(ReadPages) = %d, want 2", len(result.ReadPages))
+	}
+	assertReadPage(t, result.ReadPages[0], 1, 1, "1", "1", "github-audit-1", "github-audit-1")
+	assertReadPage(t, result.ReadPages[1], 2, 1, "2", "", "github-pr-1", "github-pr-1")
 	if got := countValue(result.EventKinds, "github.audit"); got != 1 {
 		t.Fatalf("event kind github.audit = %d, want 1", got)
 	}
@@ -312,6 +317,10 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if got := result.StageConfirmations[8].TraversalsVerified; got != 1 {
 		t.Fatalf("verify_traversals traversals_verified = %d, want 1", got)
 	}
+	if len(result.ReadPages) != 1 {
+		t.Fatalf("len(ReadPages) = %d, want 1", len(result.ReadPages))
+	}
+	assertReadPage(t, result.ReadPages[0], 1, 1, "1", "1", "github-audit-1", "github-audit-1")
 	if len(result.GraphPathPatterns) != 1 {
 		t.Fatalf("len(GraphPathPatterns) = %d, want 1", len(result.GraphPathPatterns))
 	}
@@ -422,4 +431,32 @@ func containsTopologyPreview(topology []*TopologyPreview, name string, count int
 		}
 	}
 	return false
+}
+
+func assertReadPage(t *testing.T, page *ReadPagePreview, wantPage uint32, wantEvents uint32, wantCheckpoint string, wantNext string, wantFirstEventID string, wantLastEventID string) {
+	t.Helper()
+	if page == nil {
+		t.Fatal("read page = nil")
+	}
+	if page.Page != wantPage {
+		t.Fatalf("page.Page = %d, want %d", page.Page, wantPage)
+	}
+	if page.Events != wantEvents {
+		t.Fatalf("page.Events = %d, want %d", page.Events, wantEvents)
+	}
+	if page.CheckpointCursor != wantCheckpoint {
+		t.Fatalf("page.CheckpointCursor = %q, want %q", page.CheckpointCursor, wantCheckpoint)
+	}
+	if page.NextCursor != wantNext {
+		t.Fatalf("page.NextCursor = %q, want %q", page.NextCursor, wantNext)
+	}
+	if page.FirstEventID != wantFirstEventID {
+		t.Fatalf("page.FirstEventID = %q, want %q", page.FirstEventID, wantFirstEventID)
+	}
+	if page.LastEventID != wantLastEventID {
+		t.Fatalf("page.LastEventID = %q, want %q", page.LastEventID, wantLastEventID)
+	}
+	if page.Watermark == "" {
+		t.Fatal("page.Watermark = empty, want non-empty")
+	}
 }

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -150,17 +150,20 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if result.GraphLinks != 5 {
 		t.Fatalf("GraphLinks = %d, want 5", result.GraphLinks)
 	}
-	if len(result.StageConfirmations) != 7 {
-		t.Fatalf("len(StageConfirmations) = %d, want 7", len(result.StageConfirmations))
+	if len(result.StageConfirmations) != 8 {
+		t.Fatalf("len(StageConfirmations) = %d, want 8", len(result.StageConfirmations))
 	}
-	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph", "verify_integrity", "verify_traversals")
+	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph", "verify_integrity", "verify_path_patterns", "verify_traversals")
 	if got := result.StageConfirmations[5].AssertionsPassed; got != 5 {
 		t.Fatalf("verify_integrity assertions_passed = %d, want 5", got)
 	}
 	if got := result.StageConfirmations[5].AssertionsFailed; got != 0 {
 		t.Fatalf("verify_integrity assertions_failed = %d, want 0", got)
 	}
-	if got := result.StageConfirmations[6].TraversalsVerified; got != 3 {
+	if got := result.StageConfirmations[6].PatternsVerified; got != 3 {
+		t.Fatalf("verify_path_patterns patterns_verified = %d, want 3", got)
+	}
+	if got := result.StageConfirmations[7].TraversalsVerified; got != 3 {
 		t.Fatalf("verify_traversals traversals_verified = %d, want 3", got)
 	}
 	if got := countValue(result.EventKinds, "github.audit"); got != 1 {
@@ -189,6 +192,12 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	}
 	if !containsAssertion(result.GraphAssertions, "self_referential_relations", 0, 0, true) {
 		t.Fatalf("GraphAssertions missing self_referential_relations: %#v", result.GraphAssertions)
+	}
+	if len(result.GraphPathPatterns) != 3 {
+		t.Fatalf("len(GraphPathPatterns) = %d, want 3", len(result.GraphPathPatterns))
+	}
+	if !containsPathPatternPreview(result.GraphPathPatterns, "github.user -[authored]-> github.pull_request -[belongs_to]-> github.repo", 1) {
+		t.Fatalf("GraphPathPatterns missing authored pattern: %#v", result.GraphPathPatterns)
 	}
 	if len(result.GraphTraversals) != 3 {
 		t.Fatalf("len(GraphTraversals) = %d, want 3", len(result.GraphTraversals))
@@ -276,8 +285,17 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if got := result.StageConfirmations[5].AssertionsPassed; got != 5 {
 		t.Fatalf("verify_integrity assertions_passed = %d, want 5", got)
 	}
-	if got := result.StageConfirmations[6].TraversalsVerified; got != 1 {
+	if got := result.StageConfirmations[6].PatternsVerified; got != 1 {
+		t.Fatalf("verify_path_patterns patterns_verified = %d, want 1", got)
+	}
+	if got := result.StageConfirmations[7].TraversalsVerified; got != 1 {
 		t.Fatalf("verify_traversals traversals_verified = %d, want 1", got)
+	}
+	if len(result.GraphPathPatterns) != 1 {
+		t.Fatalf("len(GraphPathPatterns) = %d, want 1", len(result.GraphPathPatterns))
+	}
+	if !containsPathPatternPreview(result.GraphPathPatterns, "github.user -[acted_on]-> github.repo -[belongs_to]-> github.org", 1) {
+		t.Fatalf("GraphPathPatterns missing acted_on pattern: %#v", result.GraphPathPatterns)
 	}
 	if !containsTraversalPath(result.GraphTraversals, "octocat -[acted_on]-> writer/cerebro -[belongs_to]-> writer") {
 		t.Fatalf("GraphTraversals missing acted_on path: %#v", result.GraphTraversals)
@@ -358,6 +376,15 @@ func containsAssertion(assertions []*AssertionPreview, name string, actual int64
 			continue
 		}
 		if assertion.Name == name && assertion.Actual == actual && assertion.Expected == expected && assertion.Passed == passed {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPathPatternPreview(patterns []*PathPatternPreview, label string, count int64) bool {
+	for _, pattern := range patterns {
+		if pattern != nil && pattern.Pattern == label && pattern.Count == count {
 			return true
 		}
 	}

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -60,6 +60,14 @@ type PathPattern struct {
 	Count          int64
 }
 
+// Topology summarizes node connectivity classes in the local graph.
+type Topology struct {
+	Isolated      int64
+	SourcesOnly   int64
+	SinksOnly     int64
+	Intermediates int64
+}
+
 // Open opens a Kuzu-backed graph projection store.
 func Open(cfg config.GraphStoreConfig) (*Store, error) {
 	rawPath := strings.TrimSpace(cfg.KuzuPath)
@@ -231,6 +239,58 @@ func (s *Store) PathPatterns(ctx context.Context, limit int) (_ []PathPattern, e
 		return nil, fmt.Errorf("iterate graph path patterns: %w", err)
 	}
 	return patterns, nil
+}
+
+// Topology returns connectivity-class counts for nodes in the local graph.
+func (s *Store) Topology(ctx context.Context) (Topology, error) {
+	if s == nil || s.db == nil {
+		return Topology{}, errors.New("kuzu is not configured")
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return Topology{}, err
+	}
+	if !tables["entity"] {
+		return Topology{}, nil
+	}
+	urns, err := s.entityURNs(ctx)
+	if err != nil {
+		return Topology{}, err
+	}
+	edges, err := s.graphEdges(ctx, tables["relation"])
+	if err != nil {
+		return Topology{}, err
+	}
+	inDegree := make(map[string]int64, len(urns))
+	outDegree := make(map[string]int64, len(urns))
+	for _, urn := range urns {
+		inDegree[urn] = 0
+		outDegree[urn] = 0
+	}
+	for _, edge := range edges {
+		if strings.TrimSpace(edge.FromURN) != "" {
+			outDegree[edge.FromURN]++
+		}
+		if strings.TrimSpace(edge.ToURN) != "" {
+			inDegree[edge.ToURN]++
+		}
+	}
+	var topology Topology
+	for _, urn := range urns {
+		incoming := inDegree[urn]
+		outgoing := outDegree[urn]
+		switch {
+		case incoming == 0 && outgoing == 0:
+			topology.Isolated++
+		case incoming == 0:
+			topology.SourcesOnly++
+		case outgoing == 0:
+			topology.SinksOnly++
+		default:
+			topology.Intermediates++
+		}
+	}
+	return topology, nil
 }
 
 // IntegrityChecks returns a fixed set of local graph invariant checks.
@@ -458,6 +518,62 @@ func (s *Store) countQuery(ctx context.Context, query string) (int64, error) {
 		return 0, fmt.Errorf("count query: %w", err)
 	}
 	return count, nil
+}
+
+type graphEdge struct {
+	FromURN string
+	ToURN   string
+}
+
+func (s *Store) entityURNs(ctx context.Context) (_ []string, err error) {
+	rows, err := s.db.QueryContext(ctx, "MATCH (e:entity) RETURN e.urn ORDER BY e.urn")
+	if err != nil {
+		return nil, fmt.Errorf("query entity urns: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close entity urns: %w", closeErr)
+		}
+	}()
+	var urns []string
+	for rows.Next() {
+		var urn string
+		if err := rows.Scan(&urn); err != nil {
+			return nil, fmt.Errorf("scan entity urn: %w", err)
+		}
+		urns = append(urns, urn)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate entity urns: %w", err)
+	}
+	return urns, nil
+}
+
+func (s *Store) graphEdges(ctx context.Context, relationsReady bool) (_ []graphEdge, err error) {
+	if !relationsReady {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, "MATCH (src:entity)-[r:relation]->(dst:entity) RETURN src.urn, dst.urn")
+	if err != nil {
+		return nil, fmt.Errorf("query graph edges: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close graph edges: %w", closeErr)
+		}
+	}()
+	var edges []graphEdge
+	for rows.Next() {
+		var edge graphEdge
+		if err := rows.Scan(&edge.FromURN, &edge.ToURN); err != nil {
+			return nil, fmt.Errorf("scan graph edge: %w", err)
+		}
+		edges = append(edges, edge)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate graph edges: %w", err)
+	}
+	return edges, nil
 }
 
 func stringColumn(value any) string {

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -50,6 +50,16 @@ type IntegrityCheck struct {
 	Passed   bool
 }
 
+// PathPattern captures one grouped two-hop graph pattern.
+type PathPattern struct {
+	FromType       string
+	FirstRelation  string
+	ViaType        string
+	SecondRelation string
+	ToType         string
+	Count          int64
+}
+
 // Open opens a Kuzu-backed graph projection store.
 func Open(cfg config.GraphStoreConfig) (*Store, error) {
 	rawPath := strings.TrimSpace(cfg.KuzuPath)
@@ -170,6 +180,57 @@ func (s *Store) SampleTraversals(ctx context.Context, limit int) (_ []Traversal,
 		return nil, fmt.Errorf("iterate graph traversals: %w", err)
 	}
 	return traversals, nil
+}
+
+// PathPatterns returns bounded grouped two-hop path patterns from the local graph.
+func (s *Store) PathPatterns(ctx context.Context, limit int) (_ []PathPattern, err error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("kuzu is not configured")
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !tables["entity"] || !tables["relation"] {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(
+		"MATCH (src:entity)-[left:relation]->(mid:entity)-[right:relation]->(dst:entity) "+
+			"RETURN src.entity_type, left.relation, mid.entity_type, right.relation, dst.entity_type, COUNT(*) "+
+			"ORDER BY COUNT(*) DESC, src.entity_type, left.relation, mid.entity_type, right.relation, dst.entity_type LIMIT %d",
+		limit,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("query graph path patterns: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close graph path patterns: %w", closeErr)
+		}
+	}()
+
+	patterns := make([]PathPattern, 0, limit)
+	for rows.Next() {
+		var pattern PathPattern
+		if err := rows.Scan(
+			&pattern.FromType,
+			&pattern.FirstRelation,
+			&pattern.ViaType,
+			&pattern.SecondRelation,
+			&pattern.ToType,
+			&pattern.Count,
+		); err != nil {
+			return nil, fmt.Errorf("scan graph path pattern: %w", err)
+		}
+		patterns = append(patterns, pattern)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate graph path patterns: %w", err)
+	}
+	return patterns, nil
 }
 
 // IntegrityChecks returns a fixed set of local graph invariant checks.

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -141,6 +141,14 @@ func TestProjectorBuildsTraversableLocalGraph(t *testing.T) {
 	if !containsPathPattern(patterns, "github.user", "authored", "github.pull_request", "belongs_to", "github.repo", 1) {
 		t.Fatalf("PathPatterns() missing authored pattern: %#v", patterns)
 	}
+
+	topology, err := store.Topology(context.Background())
+	if err != nil {
+		t.Fatalf("Topology() error = %v", err)
+	}
+	if topology.Isolated != 0 || topology.SourcesOnly != 1 || topology.SinksOnly != 2 || topology.Intermediates != 2 {
+		t.Fatalf("Topology() = %#v, want isolated=0 sources=1 sinks=2 intermediates=2", topology)
+	}
 }
 
 func TestProjectorKeepsLocalGraphIdentityLinksTenantScoped(t *testing.T) {

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -133,6 +133,14 @@ func TestProjectorBuildsTraversableLocalGraph(t *testing.T) {
 	if failedIntegrityChecks(checks) != 0 {
 		t.Fatalf("IntegrityChecks() failed = %d, want 0: %#v", failedIntegrityChecks(checks), checks)
 	}
+
+	patterns, err := store.PathPatterns(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("PathPatterns() error = %v", err)
+	}
+	if !containsPathPattern(patterns, "github.user", "authored", "github.pull_request", "belongs_to", "github.repo", 1) {
+		t.Fatalf("PathPatterns() missing authored pattern: %#v", patterns)
+	}
 }
 
 func TestProjectorKeepsLocalGraphIdentityLinksTenantScoped(t *testing.T) {
@@ -336,4 +344,18 @@ func integrityCheckActual(checks []IntegrityCheck, name string) int64 {
 		}
 	}
 	return -1
+}
+
+func containsPathPattern(patterns []PathPattern, fromType string, firstRelation string, viaType string, secondRelation string, toType string, count int64) bool {
+	for _, pattern := range patterns {
+		if pattern.FromType == fromType &&
+			pattern.FirstRelation == firstRelation &&
+			pattern.ViaType == viaType &&
+			pattern.SecondRelation == secondRelation &&
+			pattern.ToType == toType &&
+			pattern.Count == count {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- add grouped two-hop path pattern sampling to local graph rebuild dry-runs
- expose graph_path_patterns in rebuild JSON and add a verify_path_patterns stage with a confirmed pattern count
- cover both the Kuzu path pattern query and rebuild output with focused tests

## Validation
- go test ./internal/graphstore/kuzu ./internal/graphrebuild ./cmd/cerebro
- make verify
- local fixture demo via go run ./graph_rebuild_local_demo.go