### PR TITLE
feat(graph): confirm rebuild event projections locally

### DIFF
--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -76,6 +76,16 @@ type LinkPreview struct {
 	ToURN    string `json:"to_urn"`
 }
 
+// EventProjectionPreview captures the graph projection impact of one event.
+type EventProjectionPreview struct {
+	EventID           string `json:"event_id"`
+	Kind              string `json:"kind"`
+	EntitiesProjected uint32 `json:"entities_projected"`
+	LinksProjected    uint32 `json:"links_projected"`
+	GraphNodesAfter   int64  `json:"graph_nodes_after"`
+	GraphLinksAfter   int64  `json:"graph_links_after"`
+}
+
 // CountPreview captures one grouped count in the rebuild output.
 type CountPreview struct {
 	Name  string `json:"name"`
@@ -137,28 +147,29 @@ type TopologyPreview struct {
 
 // Result summarizes a dry-run rebuild execution.
 type Result struct {
-	RuntimeID          string                `json:"runtime_id"`
-	SourceID           string                `json:"source_id"`
-	TenantID           string                `json:"tenant_id,omitempty"`
-	DryRun             bool                  `json:"dry_run"`
-	PagesRead          uint32                `json:"pages_read"`
-	EventsRead         uint32                `json:"events_read"`
-	EntitiesProjected  uint32                `json:"entities_projected"`
-	LinksProjected     uint32                `json:"links_projected"`
-	GraphNodes         int64                 `json:"graph_nodes"`
-	GraphLinks         int64                 `json:"graph_links"`
-	StageConfirmations []*StageConfirmation  `json:"stage_confirmations,omitempty"`
-	ReadPages          []*ReadPagePreview    `json:"read_pages,omitempty"`
-	EventKinds         []*CountPreview       `json:"event_kinds,omitempty"`
-	GraphEntityTypes   []*CountPreview       `json:"graph_entity_types,omitempty"`
-	GraphRelationTypes []*CountPreview       `json:"graph_relation_types,omitempty"`
-	GraphAssertions    []*AssertionPreview   `json:"graph_assertions,omitempty"`
-	GraphPathPatterns  []*PathPatternPreview `json:"graph_path_patterns,omitempty"`
-	GraphTopology      []*TopologyPreview    `json:"graph_topology,omitempty"`
-	GraphTraversals    []*TraversalPreview   `json:"graph_traversals,omitempty"`
-	Events             []*EventPreview       `json:"events,omitempty"`
-	PreviewEntities    []*EntityPreview      `json:"preview_entities,omitempty"`
-	PreviewLinks       []*LinkPreview        `json:"preview_links,omitempty"`
+	RuntimeID          string                    `json:"runtime_id"`
+	SourceID           string                    `json:"source_id"`
+	TenantID           string                    `json:"tenant_id,omitempty"`
+	DryRun             bool                      `json:"dry_run"`
+	PagesRead          uint32                    `json:"pages_read"`
+	EventsRead         uint32                    `json:"events_read"`
+	EntitiesProjected  uint32                    `json:"entities_projected"`
+	LinksProjected     uint32                    `json:"links_projected"`
+	GraphNodes         int64                     `json:"graph_nodes"`
+	GraphLinks         int64                     `json:"graph_links"`
+	StageConfirmations []*StageConfirmation      `json:"stage_confirmations,omitempty"`
+	ReadPages          []*ReadPagePreview        `json:"read_pages,omitempty"`
+	EventProjections   []*EventProjectionPreview `json:"event_projections,omitempty"`
+	EventKinds         []*CountPreview           `json:"event_kinds,omitempty"`
+	GraphEntityTypes   []*CountPreview           `json:"graph_entity_types,omitempty"`
+	GraphRelationTypes []*CountPreview           `json:"graph_relation_types,omitempty"`
+	GraphAssertions    []*AssertionPreview       `json:"graph_assertions,omitempty"`
+	GraphPathPatterns  []*PathPatternPreview     `json:"graph_path_patterns,omitempty"`
+	GraphTopology      []*TopologyPreview        `json:"graph_topology,omitempty"`
+	GraphTraversals    []*TraversalPreview       `json:"graph_traversals,omitempty"`
+	Events             []*EventPreview           `json:"events,omitempty"`
+	PreviewEntities    []*EntityPreview          `json:"preview_entities,omitempty"`
+	PreviewLinks       []*LinkPreview            `json:"preview_links,omitempty"`
 }
 
 // Service rebuilds a local graph from stored source runtimes.
@@ -272,6 +283,7 @@ func (s *Service) RebuildDryRun(ctx context.Context, req Request) (_ *Result, er
 	}
 	result.EntitiesProjected = projectSummary.EntitiesProjected
 	result.LinksProjected = projectSummary.LinksProjected
+	result.EventProjections = projectSummary.EventProjections
 	result.GraphEntityTypes = projectSummary.GraphEntityTypes
 	result.GraphRelationTypes = projectSummary.GraphRelationTypes
 	result.PreviewEntities = projectSummary.PreviewEntities
@@ -456,6 +468,7 @@ func (s *Service) readEvents(ctx context.Context, source sourcecdk.Source, runti
 type projectSummary struct {
 	EntitiesProjected  uint32
 	LinksProjected     uint32
+	EventProjections   []*EventProjectionPreview
 	GraphEntityTypes   []*CountPreview
 	GraphRelationTypes []*CountPreview
 	PreviewEntities    []*EntityPreview
@@ -473,6 +486,20 @@ func (s *Service) projectEvents(ctx context.Context, graph graphStore, events []
 		}
 		summary.EntitiesProjected += projected.EntitiesProjected
 		summary.LinksProjected += projected.LinksProjected
+		if len(summary.EventProjections) < previewLimit {
+			counts, err := graph.Counts(ctx)
+			if err != nil {
+				return nil, err
+			}
+			summary.EventProjections = append(summary.EventProjections, &EventProjectionPreview{
+				EventID:           strings.TrimSpace(event.GetId()),
+				Kind:              strings.TrimSpace(event.GetKind()),
+				EntitiesProjected: projected.EntitiesProjected,
+				LinksProjected:    projected.LinksProjected,
+				GraphNodesAfter:   counts.Nodes,
+				GraphLinksAfter:   counts.Relations,
+			})
+		}
 	}
 	summary.GraphEntityTypes = previewer.entityTypes()
 	summary.GraphRelationTypes = previewer.relationTypes()

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -174,6 +174,11 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	}
 	assertReadPage(t, result.ReadPages[0], 1, 1, "1", "1", "github-audit-1", "github-audit-1")
 	assertReadPage(t, result.ReadPages[1], 2, 1, "2", "", "github-pr-1", "github-pr-1")
+	if len(result.EventProjections) != 2 {
+		t.Fatalf("len(EventProjections) = %d, want 2", len(result.EventProjections))
+	}
+	assertEventProjection(t, result.EventProjections[0], "github-audit-1", "github.audit", 4, 3, 4, 3)
+	assertEventProjection(t, result.EventProjections[1], "github-pr-1", "github.pull_request", 5, 4, 5, 5)
 	if got := countValue(result.EventKinds, "github.audit"); got != 1 {
 		t.Fatalf("event kind github.audit = %d, want 1", got)
 	}
@@ -321,6 +326,10 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 		t.Fatalf("len(ReadPages) = %d, want 1", len(result.ReadPages))
 	}
 	assertReadPage(t, result.ReadPages[0], 1, 1, "1", "1", "github-audit-1", "github-audit-1")
+	if len(result.EventProjections) != 1 {
+		t.Fatalf("len(EventProjections) = %d, want 1", len(result.EventProjections))
+	}
+	assertEventProjection(t, result.EventProjections[0], "github-audit-1", "github.audit", 4, 3, 4, 3)
 	if len(result.GraphPathPatterns) != 1 {
 		t.Fatalf("len(GraphPathPatterns) = %d, want 1", len(result.GraphPathPatterns))
 	}
@@ -458,5 +467,30 @@ func assertReadPage(t *testing.T, page *ReadPagePreview, wantPage uint32, wantEv
 	}
 	if page.Watermark == "" {
 		t.Fatal("page.Watermark = empty, want non-empty")
+	}
+}
+
+func assertEventProjection(t *testing.T, projection *EventProjectionPreview, wantEventID string, wantKind string, wantEntities uint32, wantLinks uint32, wantGraphNodes int64, wantGraphLinks int64) {
+	t.Helper()
+	if projection == nil {
+		t.Fatal("event projection = nil")
+	}
+	if projection.EventID != wantEventID {
+		t.Fatalf("projection.EventID = %q, want %q", projection.EventID, wantEventID)
+	}
+	if projection.Kind != wantKind {
+		t.Fatalf("projection.Kind = %q, want %q", projection.Kind, wantKind)
+	}
+	if projection.EntitiesProjected != wantEntities {
+		t.Fatalf("projection.EntitiesProjected = %d, want %d", projection.EntitiesProjected, wantEntities)
+	}
+	if projection.LinksProjected != wantLinks {
+		t.Fatalf("projection.LinksProjected = %d, want %d", projection.LinksProjected, wantLinks)
+	}
+	if projection.GraphNodesAfter != wantGraphNodes {
+		t.Fatalf("projection.GraphNodesAfter = %d, want %d", projection.GraphNodesAfter, wantGraphNodes)
+	}
+	if projection.GraphLinksAfter != wantGraphLinks {
+		t.Fatalf("projection.GraphLinksAfter = %d, want %d", projection.GraphLinksAfter, wantGraphLinks)
 	}
 }


### PR DESCRIPTION
## Summary
- add event_projections to graph rebuild dry-run output with per-event projected counts and post-event graph totals
- strengthen local project-stage confirmation by showing how each source event changes the temporary Kuzu graph
- cover the new event-level projection previews in graph rebuild tests

## Validation
- go test ./internal/graphrebuild ./internal/graphstore/kuzu ./cmd/cerebro
- make verify
- local fixture demo via go run ./graph_rebuild_local_demo.go