### PR TITLE
feat(findings): add replay-backed Okta tampering evaluator

### DIFF
--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -1200,6 +1200,285 @@ func (x *SyncSourceRuntimeResponse) GetLinksProjected() uint32 {
 	return 0
 }
 
+// Finding is the normalized persisted finding view for the first runtime evaluator slice.
+type Finding struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Id              string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Fingerprint     string                 `protobuf:"bytes,2,opt,name=fingerprint,proto3" json:"fingerprint,omitempty"`
+	TenantId        string                 `protobuf:"bytes,3,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	RuntimeId       string                 `protobuf:"bytes,4,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	RuleId          string                 `protobuf:"bytes,5,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	Title           string                 `protobuf:"bytes,6,opt,name=title,proto3" json:"title,omitempty"`
+	Severity        string                 `protobuf:"bytes,7,opt,name=severity,proto3" json:"severity,omitempty"`
+	Status          string                 `protobuf:"bytes,8,opt,name=status,proto3" json:"status,omitempty"`
+	Summary         string                 `protobuf:"bytes,9,opt,name=summary,proto3" json:"summary,omitempty"`
+	ResourceUrns    []string               `protobuf:"bytes,10,rep,name=resource_urns,json=resourceUrns,proto3" json:"resource_urns,omitempty"`
+	EventIds        []string               `protobuf:"bytes,11,rep,name=event_ids,json=eventIds,proto3" json:"event_ids,omitempty"`
+	Attributes      map[string]string      `protobuf:"bytes,12,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	FirstObservedAt *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=first_observed_at,json=firstObservedAt,proto3" json:"first_observed_at,omitempty"`
+	LastObservedAt  *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=last_observed_at,json=lastObservedAt,proto3" json:"last_observed_at,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *Finding) Reset() {
+	*x = Finding{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Finding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Finding) ProtoMessage() {}
+
+func (x *Finding) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Finding.ProtoReflect.Descriptor instead.
+func (*Finding) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *Finding) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *Finding) GetFingerprint() string {
+	if x != nil {
+		return x.Fingerprint
+	}
+	return ""
+}
+
+func (x *Finding) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+func (x *Finding) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *Finding) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+func (x *Finding) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *Finding) GetSeverity() string {
+	if x != nil {
+		return x.Severity
+	}
+	return ""
+}
+
+func (x *Finding) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *Finding) GetSummary() string {
+	if x != nil {
+		return x.Summary
+	}
+	return ""
+}
+
+func (x *Finding) GetResourceUrns() []string {
+	if x != nil {
+		return x.ResourceUrns
+	}
+	return nil
+}
+
+func (x *Finding) GetEventIds() []string {
+	if x != nil {
+		return x.EventIds
+	}
+	return nil
+}
+
+func (x *Finding) GetAttributes() map[string]string {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
+}
+
+func (x *Finding) GetFirstObservedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.FirstObservedAt
+	}
+	return nil
+}
+
+func (x *Finding) GetLastObservedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastObservedAt
+	}
+	return nil
+}
+
+// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through the first built-in finding evaluator.
+type EvaluateSourceRuntimeFindingsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	EventLimit    uint32                 `protobuf:"varint,2,opt,name=event_limit,json=eventLimit,proto3" json:"event_limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EvaluateSourceRuntimeFindingsRequest) Reset() {
+	*x = EvaluateSourceRuntimeFindingsRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluateSourceRuntimeFindingsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluateSourceRuntimeFindingsRequest) ProtoMessage() {}
+
+func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluateSourceRuntimeFindingsRequest.ProtoReflect.Descriptor instead.
+func (*EvaluateSourceRuntimeFindingsRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *EvaluateSourceRuntimeFindingsRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *EvaluateSourceRuntimeFindingsRequest) GetEventLimit() uint32 {
+	if x != nil {
+		return x.EventLimit
+	}
+	return 0
+}
+
+// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, fixed rule spec, and persisted findings.
+type EvaluateSourceRuntimeFindingsResponse struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Runtime          *SourceRuntime         `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
+	Rule             *RuleSpec              `protobuf:"bytes,2,opt,name=rule,proto3" json:"rule,omitempty"`
+	EventsEvaluated  uint32                 `protobuf:"varint,3,opt,name=events_evaluated,json=eventsEvaluated,proto3" json:"events_evaluated,omitempty"`
+	FindingsUpserted uint32                 `protobuf:"varint,4,opt,name=findings_upserted,json=findingsUpserted,proto3" json:"findings_upserted,omitempty"`
+	Findings         []*Finding             `protobuf:"bytes,5,rep,name=findings,proto3" json:"findings,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *EvaluateSourceRuntimeFindingsResponse) Reset() {
+	*x = EvaluateSourceRuntimeFindingsResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluateSourceRuntimeFindingsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluateSourceRuntimeFindingsResponse) ProtoMessage() {}
+
+func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluateSourceRuntimeFindingsResponse.ProtoReflect.Descriptor instead.
+func (*EvaluateSourceRuntimeFindingsResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *EvaluateSourceRuntimeFindingsResponse) GetRuntime() *SourceRuntime {
+	if x != nil {
+		return x.Runtime
+	}
+	return nil
+}
+
+func (x *EvaluateSourceRuntimeFindingsResponse) GetRule() *RuleSpec {
+	if x != nil {
+		return x.Rule
+	}
+	return nil
+}
+
+func (x *EvaluateSourceRuntimeFindingsResponse) GetEventsEvaluated() uint32 {
+	if x != nil {
+		return x.EventsEvaluated
+	}
+	return 0
+}
+
+func (x *EvaluateSourceRuntimeFindingsResponse) GetFindingsUpserted() uint32 {
+	if x != nil {
+		return x.FindingsUpserted
+	}
+	return 0
+}
+
+func (x *EvaluateSourceRuntimeFindingsResponse) GetFindings() []*Finding {
+	if x != nil {
+		return x.Findings
+	}
+	return nil
+}
+
 var File_cerebro_v1_bootstrap_proto protoreflect.FileDescriptor
 
 const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
@@ -1301,7 +1580,39 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"pages_read\x18\x03 \x01(\rR\tpagesRead\x12'\n" +
 	"\x0fevents_appended\x18\x04 \x01(\rR\x0eeventsAppended\x12-\n" +
 	"\x12entities_projected\x18\x05 \x01(\rR\x11entitiesProjected\x12'\n" +
-	"\x0flinks_projected\x18\x06 \x01(\rR\x0elinksProjected2\x95\x06\n" +
+	"\x0flinks_projected\x18\x06 \x01(\rR\x0elinksProjected\"\xc8\x04\n" +
+	"\aFinding\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12 \n" +
+	"\vfingerprint\x18\x02 \x01(\tR\vfingerprint\x12\x1b\n" +
+	"\ttenant_id\x18\x03 \x01(\tR\btenantId\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x04 \x01(\tR\truntimeId\x12\x17\n" +
+	"\arule_id\x18\x05 \x01(\tR\x06ruleId\x12\x14\n" +
+	"\x05title\x18\x06 \x01(\tR\x05title\x12\x1a\n" +
+	"\bseverity\x18\a \x01(\tR\bseverity\x12\x16\n" +
+	"\x06status\x18\b \x01(\tR\x06status\x12\x18\n" +
+	"\asummary\x18\t \x01(\tR\asummary\x12#\n" +
+	"\rresource_urns\x18\n" +
+	" \x03(\tR\fresourceUrns\x12\x1b\n" +
+	"\tevent_ids\x18\v \x03(\tR\beventIds\x12C\n" +
+	"\n" +
+	"attributes\x18\f \x03(\v2#.cerebro.v1.Finding.AttributesEntryR\n" +
+	"attributes\x12F\n" +
+	"\x11first_observed_at\x18\r \x01(\v2\x1a.google.protobuf.TimestampR\x0ffirstObservedAt\x12D\n" +
+	"\x10last_observed_at\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\x0elastObservedAt\x1a=\n" +
+	"\x0fAttributesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"W\n" +
+	"$EvaluateSourceRuntimeFindingsRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
+	"\vevent_limit\x18\x02 \x01(\rR\n" +
+	"eventLimit\"\x8f\x02\n" +
+	"%EvaluateSourceRuntimeFindingsResponse\x123\n" +
+	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\x12(\n" +
+	"\x04rule\x18\x02 \x01(\v2\x14.cerebro.v1.RuleSpecR\x04rule\x12)\n" +
+	"\x10events_evaluated\x18\x03 \x01(\rR\x0feventsEvaluated\x12+\n" +
+	"\x11findings_upserted\x18\x04 \x01(\rR\x10findingsUpserted\x12/\n" +
+	"\bfindings\x18\x05 \x03(\v2\x13.cerebro.v1.FindingR\bfindings2\x9c\a\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -1313,7 +1624,8 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"ReadSource\x12\x1d.cerebro.v1.ReadSourceRequest\x1a\x1e.cerebro.v1.ReadSourceResponse\x12]\n" +
 	"\x10PutSourceRuntime\x12#.cerebro.v1.PutSourceRuntimeRequest\x1a$.cerebro.v1.PutSourceRuntimeResponse\x12]\n" +
 	"\x10GetSourceRuntime\x12#.cerebro.v1.GetSourceRuntimeRequest\x1a$.cerebro.v1.GetSourceRuntimeResponse\x12`\n" +
-	"\x11SyncSourceRuntime\x12$.cerebro.v1.SyncSourceRuntimeRequest\x1a%.cerebro.v1.SyncSourceRuntimeResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
+	"\x11SyncSourceRuntime\x12$.cerebro.v1.SyncSourceRuntimeRequest\x1a%.cerebro.v1.SyncSourceRuntimeResponse\x12\x84\x01\n" +
+	"\x1dEvaluateSourceRuntimeFindings\x120.cerebro.v1.EvaluateSourceRuntimeFindingsRequest\x1a1.cerebro.v1.EvaluateSourceRuntimeFindingsResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
 
 var (
 	file_cerebro_v1_bootstrap_proto_rawDescOnce sync.Once
@@ -1327,89 +1639,102 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
-	(*GetVersionRequest)(nil),         // 0: cerebro.v1.GetVersionRequest
-	(*GetVersionResponse)(nil),        // 1: cerebro.v1.GetVersionResponse
-	(*CheckHealthRequest)(nil),        // 2: cerebro.v1.CheckHealthRequest
-	(*ComponentStatus)(nil),           // 3: cerebro.v1.ComponentStatus
-	(*CheckHealthResponse)(nil),       // 4: cerebro.v1.CheckHealthResponse
-	(*ListSourcesRequest)(nil),        // 5: cerebro.v1.ListSourcesRequest
-	(*ListSourcesResponse)(nil),       // 6: cerebro.v1.ListSourcesResponse
-	(*CheckSourceRequest)(nil),        // 7: cerebro.v1.CheckSourceRequest
-	(*CheckSourceResponse)(nil),       // 8: cerebro.v1.CheckSourceResponse
-	(*DiscoverSourceRequest)(nil),     // 9: cerebro.v1.DiscoverSourceRequest
-	(*DiscoverSourceResponse)(nil),    // 10: cerebro.v1.DiscoverSourceResponse
-	(*ReadSourceRequest)(nil),         // 11: cerebro.v1.ReadSourceRequest
-	(*SourcePreviewEvent)(nil),        // 12: cerebro.v1.SourcePreviewEvent
-	(*ReadSourceResponse)(nil),        // 13: cerebro.v1.ReadSourceResponse
-	(*SourceRuntime)(nil),             // 14: cerebro.v1.SourceRuntime
-	(*PutSourceRuntimeRequest)(nil),   // 15: cerebro.v1.PutSourceRuntimeRequest
-	(*PutSourceRuntimeResponse)(nil),  // 16: cerebro.v1.PutSourceRuntimeResponse
-	(*GetSourceRuntimeRequest)(nil),   // 17: cerebro.v1.GetSourceRuntimeRequest
-	(*GetSourceRuntimeResponse)(nil),  // 18: cerebro.v1.GetSourceRuntimeResponse
-	(*SyncSourceRuntimeRequest)(nil),  // 19: cerebro.v1.SyncSourceRuntimeRequest
-	(*SyncSourceRuntimeResponse)(nil), // 20: cerebro.v1.SyncSourceRuntimeResponse
-	nil,                               // 21: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                               // 22: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                               // 23: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                               // 24: cerebro.v1.SourceRuntime.ConfigEntry
-	(*timestamppb.Timestamp)(nil),     // 25: google.protobuf.Timestamp
-	(*SourceSpec)(nil),                // 26: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),              // 27: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),             // 28: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),            // 29: google.protobuf.Value
-	(*SourceCheckpoint)(nil),          // 30: cerebro.v1.SourceCheckpoint
+	(*GetVersionRequest)(nil),                     // 0: cerebro.v1.GetVersionRequest
+	(*GetVersionResponse)(nil),                    // 1: cerebro.v1.GetVersionResponse
+	(*CheckHealthRequest)(nil),                    // 2: cerebro.v1.CheckHealthRequest
+	(*ComponentStatus)(nil),                       // 3: cerebro.v1.ComponentStatus
+	(*CheckHealthResponse)(nil),                   // 4: cerebro.v1.CheckHealthResponse
+	(*ListSourcesRequest)(nil),                    // 5: cerebro.v1.ListSourcesRequest
+	(*ListSourcesResponse)(nil),                   // 6: cerebro.v1.ListSourcesResponse
+	(*CheckSourceRequest)(nil),                    // 7: cerebro.v1.CheckSourceRequest
+	(*CheckSourceResponse)(nil),                   // 8: cerebro.v1.CheckSourceResponse
+	(*DiscoverSourceRequest)(nil),                 // 9: cerebro.v1.DiscoverSourceRequest
+	(*DiscoverSourceResponse)(nil),                // 10: cerebro.v1.DiscoverSourceResponse
+	(*ReadSourceRequest)(nil),                     // 11: cerebro.v1.ReadSourceRequest
+	(*SourcePreviewEvent)(nil),                    // 12: cerebro.v1.SourcePreviewEvent
+	(*ReadSourceResponse)(nil),                    // 13: cerebro.v1.ReadSourceResponse
+	(*SourceRuntime)(nil),                         // 14: cerebro.v1.SourceRuntime
+	(*PutSourceRuntimeRequest)(nil),               // 15: cerebro.v1.PutSourceRuntimeRequest
+	(*PutSourceRuntimeResponse)(nil),              // 16: cerebro.v1.PutSourceRuntimeResponse
+	(*GetSourceRuntimeRequest)(nil),               // 17: cerebro.v1.GetSourceRuntimeRequest
+	(*GetSourceRuntimeResponse)(nil),              // 18: cerebro.v1.GetSourceRuntimeResponse
+	(*SyncSourceRuntimeRequest)(nil),              // 19: cerebro.v1.SyncSourceRuntimeRequest
+	(*SyncSourceRuntimeResponse)(nil),             // 20: cerebro.v1.SyncSourceRuntimeResponse
+	(*Finding)(nil),                               // 21: cerebro.v1.Finding
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 22: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 23: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	nil,                           // 24: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                           // 25: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                           // 26: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                           // 27: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                           // 28: cerebro.v1.Finding.AttributesEntry
+	(*timestamppb.Timestamp)(nil), // 29: google.protobuf.Timestamp
+	(*SourceSpec)(nil),            // 30: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),          // 31: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),         // 32: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),        // 33: google.protobuf.Value
+	(*SourceCheckpoint)(nil),      // 34: cerebro.v1.SourceCheckpoint
+	(*RuleSpec)(nil),              // 35: cerebro.v1.RuleSpec
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	25, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	29, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
-	26, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	21, // 3: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	26, // 4: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	22, // 5: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	26, // 6: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	23, // 7: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	27, // 8: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	28, // 9: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	29, // 10: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	26, // 11: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	28, // 12: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	30, // 13: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	27, // 14: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	30, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	24, // 3: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	30, // 4: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	25, // 5: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	30, // 6: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	26, // 7: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	31, // 8: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	32, // 9: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	33, // 10: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	30, // 11: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	32, // 12: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	34, // 13: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	31, // 14: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
 	12, // 15: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	24, // 16: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	30, // 17: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	27, // 18: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	25, // 19: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	27, // 16: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	34, // 17: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	31, // 18: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	29, // 19: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
 	14, // 20: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
 	14, // 21: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	14, // 22: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	14, // 23: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	26, // 24: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	0,  // 25: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2,  // 26: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	5,  // 27: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	7,  // 28: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	9,  // 29: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	11, // 30: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	15, // 31: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	17, // 32: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	19, // 33: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	1,  // 34: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4,  // 35: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	6,  // 36: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	8,  // 37: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	10, // 38: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	13, // 39: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	16, // 40: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	18, // 41: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	20, // 42: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	34, // [34:43] is the sub-list for method output_type
-	25, // [25:34] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	30, // 24: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	28, // 25: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	29, // 26: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	29, // 27: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	14, // 28: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	35, // 29: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	21, // 30: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	0,  // 31: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 32: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	5,  // 33: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	7,  // 34: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	9,  // 35: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	11, // 36: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	15, // 37: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	17, // 38: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	19, // 39: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	22, // 40: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	1,  // 41: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 42: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	6,  // 43: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	8,  // 44: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	10, // 45: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	13, // 46: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	16, // 47: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	18, // 48: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	20, // 49: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	23, // 50: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	41, // [41:51] is the sub-list for method output_type
+	31, // [31:41] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -1425,7 +1750,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   25,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -60,6 +60,9 @@ const (
 	// BootstrapServiceSyncSourceRuntimeProcedure is the fully-qualified name of the BootstrapService's
 	// SyncSourceRuntime RPC.
 	BootstrapServiceSyncSourceRuntimeProcedure = "/cerebro.v1.BootstrapService/SyncSourceRuntime"
+	// BootstrapServiceEvaluateSourceRuntimeFindingsProcedure is the fully-qualified name of the
+	// BootstrapService's EvaluateSourceRuntimeFindings RPC.
+	BootstrapServiceEvaluateSourceRuntimeFindingsProcedure = "/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindings"
 )
 
 // BootstrapServiceClient is a client for the cerebro.v1.BootstrapService service.
@@ -73,6 +76,7 @@ type BootstrapServiceClient interface {
 	PutSourceRuntime(context.Context, *connect.Request[v1.PutSourceRuntimeRequest]) (*connect.Response[v1.PutSourceRuntimeResponse], error)
 	GetSourceRuntime(context.Context, *connect.Request[v1.GetSourceRuntimeRequest]) (*connect.Response[v1.GetSourceRuntimeResponse], error)
 	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
+	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 }
 
 // NewBootstrapServiceClient constructs a client for the cerebro.v1.BootstrapService service. By
@@ -140,20 +144,27 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("SyncSourceRuntime")),
 			connect.WithClientOptions(opts...),
 		),
+		evaluateSourceRuntimeFindings: connect.NewClient[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse](
+			httpClient,
+			baseURL+BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("EvaluateSourceRuntimeFindings")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // bootstrapServiceClient implements BootstrapServiceClient.
 type bootstrapServiceClient struct {
-	getVersion        *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
-	checkHealth       *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
-	listSources       *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
-	checkSource       *connect.Client[v1.CheckSourceRequest, v1.CheckSourceResponse]
-	discoverSource    *connect.Client[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse]
-	readSource        *connect.Client[v1.ReadSourceRequest, v1.ReadSourceResponse]
-	putSourceRuntime  *connect.Client[v1.PutSourceRuntimeRequest, v1.PutSourceRuntimeResponse]
-	getSourceRuntime  *connect.Client[v1.GetSourceRuntimeRequest, v1.GetSourceRuntimeResponse]
-	syncSourceRuntime *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
+	getVersion                    *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
+	checkHealth                   *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
+	listSources                   *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
+	checkSource                   *connect.Client[v1.CheckSourceRequest, v1.CheckSourceResponse]
+	discoverSource                *connect.Client[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse]
+	readSource                    *connect.Client[v1.ReadSourceRequest, v1.ReadSourceResponse]
+	putSourceRuntime              *connect.Client[v1.PutSourceRuntimeRequest, v1.PutSourceRuntimeResponse]
+	getSourceRuntime              *connect.Client[v1.GetSourceRuntimeRequest, v1.GetSourceRuntimeResponse]
+	syncSourceRuntime             *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
+	evaluateSourceRuntimeFindings *connect.Client[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse]
 }
 
 // GetVersion calls cerebro.v1.BootstrapService.GetVersion.
@@ -201,6 +212,11 @@ func (c *bootstrapServiceClient) SyncSourceRuntime(ctx context.Context, req *con
 	return c.syncSourceRuntime.CallUnary(ctx, req)
 }
 
+// EvaluateSourceRuntimeFindings calls cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings.
+func (c *bootstrapServiceClient) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {
+	return c.evaluateSourceRuntimeFindings.CallUnary(ctx, req)
+}
+
 // BootstrapServiceHandler is an implementation of the cerebro.v1.BootstrapService service.
 type BootstrapServiceHandler interface {
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
@@ -212,6 +228,7 @@ type BootstrapServiceHandler interface {
 	PutSourceRuntime(context.Context, *connect.Request[v1.PutSourceRuntimeRequest]) (*connect.Response[v1.PutSourceRuntimeResponse], error)
 	GetSourceRuntime(context.Context, *connect.Request[v1.GetSourceRuntimeRequest]) (*connect.Response[v1.GetSourceRuntimeResponse], error)
 	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
+	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 }
 
 // NewBootstrapServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -275,6 +292,12 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		connect.WithSchema(bootstrapServiceMethods.ByName("SyncSourceRuntime")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bootstrapServiceEvaluateSourceRuntimeFindingsHandler := connect.NewUnaryHandler(
+		BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
+		svc.EvaluateSourceRuntimeFindings,
+		connect.WithSchema(bootstrapServiceMethods.ByName("EvaluateSourceRuntimeFindings")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/cerebro.v1.BootstrapService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case BootstrapServiceGetVersionProcedure:
@@ -295,6 +318,8 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceGetSourceRuntimeHandler.ServeHTTP(w, r)
 		case BootstrapServiceSyncSourceRuntimeProcedure:
 			bootstrapServiceSyncSourceRuntimeHandler.ServeHTTP(w, r)
+		case BootstrapServiceEvaluateSourceRuntimeFindingsProcedure:
+			bootstrapServiceEvaluateSourceRuntimeFindingsHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -338,4 +363,8 @@ func (UnimplementedBootstrapServiceHandler) GetSourceRuntime(context.Context, *c
 
 func (UnimplementedBootstrapServiceHandler) SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.SyncSourceRuntime is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings is not implemented"))
 }

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -465,7 +465,6 @@ func findingResponse(result *findings.EvaluateResult) *cerebrov1.EvaluateSourceR
 		return &cerebrov1.EvaluateSourceRuntimeFindingsResponse{}
 	}
 	response := &cerebrov1.EvaluateSourceRuntimeFindingsResponse{
-		Runtime:          result.Runtime,
 		Rule:             result.Rule,
 		EventsEvaluated:  result.EventsEvaluated,
 		FindingsUpserted: uint32(len(result.Findings)),

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceops"
@@ -62,6 +63,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("PUT /source-runtimes/{runtimeID}", app.handlePutSourceRuntime)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}", app.handleGetSourceRuntime)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/sync", app.handleSyncSourceRuntime)
+	mux.HandleFunc("POST /source-runtimes/{runtimeID}/findings/evaluate", app.handleEvaluateSourceRuntimeFindings)
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           mux,
@@ -184,6 +186,27 @@ func (a *App) handleSyncSourceRuntime(w http.ResponseWriter, r *http.Request) {
 	writeProtoJSON(w, http.StatusOK, response)
 }
 
+func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.EvaluateSourceRuntimeFindingsRequest{}
+	if eventLimit := r.URL.Query().Get("event_limit"); eventLimit != "" {
+		body := []byte(`{"event_limit":` + eventLimit + `}`)
+		if err := protojson.Unmarshal(body, request); err != nil {
+			writeFindingError(w, err)
+			return
+		}
+	}
+	request.Id = r.PathValue("runtimeID")
+	response, err := a.findingService().EvaluateSourceRuntime(r.Context(), findings.EvaluateRequest{
+		RuntimeID:  request.GetId(),
+		EventLimit: request.GetEventLimit(),
+	})
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, findingResponse(response))
+}
+
 func (s *bootstrapService) GetVersion(_ context.Context, _ *connect.Request[cerebrov1.GetVersionRequest]) (*connect.Response[cerebrov1.GetVersionResponse], error) {
 	return connect.NewResponse(&cerebrov1.GetVersionResponse{
 		ServiceName: buildinfo.ServiceName,
@@ -265,6 +288,21 @@ func (s *bootstrapService) SyncSourceRuntime(ctx context.Context, req *connect.R
 	return connect.NewResponse(response), nil
 }
 
+func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingsResponse], error) {
+	response, err := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+	).EvaluateSourceRuntime(ctx, findings.EvaluateRequest{
+		RuntimeID:  req.Msg.GetId(),
+		EventLimit: req.Msg.GetEventLimit(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(findingResponse(response)), nil
+}
+
 func healthResponse(ctx context.Context, deps Dependencies) *cerebrov1.CheckHealthResponse {
 	components := []*cerebrov1.ComponentStatus{
 		componentStatus(ctx, "append_log", deps.AppendLog),
@@ -309,6 +347,14 @@ func (a *App) runtimeService() *sourceruntime.Service {
 	)
 }
 
+func (a *App) findingService() *findings.Service {
+	return findings.New(
+		sourceRuntimeStore(a.deps.StateStore),
+		eventReplayer(a.deps.AppendLog),
+		findingStore(a.deps.StateStore),
+	)
+}
+
 func sourceConfigFromQuery(r *http.Request) map[string]string {
 	values := make(map[string]string)
 	for key, rawValues := range r.URL.Query() {
@@ -334,6 +380,17 @@ func writeSourceRuntimeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound), errors.Is(err, sourceops.ErrSourceNotFound):
 		statusCode = http.StatusNotFound
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable):
+		statusCode = http.StatusServiceUnavailable
+	}
+	http.Error(w, err.Error(), statusCode)
+}
+
+func writeFindingError(w http.ResponseWriter, err error) {
+	statusCode := http.StatusBadRequest
+	switch {
+	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
+		statusCode = http.StatusNotFound
+	case errors.Is(err, findings.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable
 	}
 	http.Error(w, err.Error(), statusCode)
@@ -381,6 +438,69 @@ func sourceProjector(stateStore ports.StateStore, graphStore ports.GraphStore) p
 		return nil
 	}
 	return sourceprojection.New(state, graph)
+}
+
+func findingStore(store ports.StateStore) ports.FindingStore {
+	findingStore, ok := store.(ports.FindingStore)
+	if !ok {
+		return nil
+	}
+	return findingStore
+}
+
+func eventReplayer(appendLog ports.AppendLog) ports.EventReplayer {
+	replayer, ok := appendLog.(ports.EventReplayer)
+	if !ok {
+		return nil
+	}
+	return replayer
+}
+
+func findingResponse(result *findings.EvaluateResult) *cerebrov1.EvaluateSourceRuntimeFindingsResponse {
+	if result == nil {
+		return &cerebrov1.EvaluateSourceRuntimeFindingsResponse{}
+	}
+	response := &cerebrov1.EvaluateSourceRuntimeFindingsResponse{
+		Runtime:          result.Runtime,
+		Rule:             result.Rule,
+		EventsEvaluated:  result.EventsEvaluated,
+		FindingsUpserted: uint32(len(result.Findings)),
+		Findings:         make([]*cerebrov1.Finding, 0, len(result.Findings)),
+	}
+	for _, finding := range result.Findings {
+		response.Findings = append(response.Findings, findingMessage(finding))
+	}
+	return response
+}
+
+func findingMessage(finding *ports.FindingRecord) *cerebrov1.Finding {
+	if finding == nil {
+		return nil
+	}
+	message := &cerebrov1.Finding{
+		Id:           finding.ID,
+		Fingerprint:  finding.Fingerprint,
+		TenantId:     finding.TenantID,
+		RuntimeId:    finding.RuntimeID,
+		RuleId:       finding.RuleID,
+		Title:        finding.Title,
+		Severity:     finding.Severity,
+		Status:       finding.Status,
+		Summary:      finding.Summary,
+		ResourceUrns: append([]string(nil), finding.ResourceURNs...),
+		EventIds:     append([]string(nil), finding.EventIDs...),
+		Attributes:   make(map[string]string, len(finding.Attributes)),
+	}
+	for key, value := range finding.Attributes {
+		message.Attributes[key] = value
+	}
+	if !finding.FirstObservedAt.IsZero() {
+		message.FirstObservedAt = timestamppb.New(finding.FirstObservedAt)
+	}
+	if !finding.LastObservedAt.IsZero() {
+		message.LastObservedAt = timestamppb.New(finding.LastObservedAt)
+	}
+	return message
 }
 
 type pinger interface {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -397,9 +397,13 @@ func writeFindingError(w http.ResponseWriter, err error) {
 }
 
 func readProtoJSON(r *http.Request, message proto.Message) error {
-	body, err := io.ReadAll(r.Body)
+	const maxBodyBytes int64 = 1 << 20
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes+1))
 	if err != nil {
 		return err
+	}
+	if int64(len(body)) > maxBodyBytes {
+		return errors.New("request body too large")
 	}
 	if len(bytes.TrimSpace(body)) == 0 {
 		return nil

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -13,6 +13,7 @@ import (
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
@@ -38,8 +39,9 @@ type stubStore struct {
 func (s stubStore) Ping(context.Context) error { return s.err }
 
 type recordingAppendLog struct {
-	err    error
-	events []*cerebrov1.EventEnvelope
+	err          error
+	events       []*cerebrov1.EventEnvelope
+	replayEvents []*cerebrov1.EventEnvelope
 }
 
 func (s *recordingAppendLog) Ping(context.Context) error { return s.err }
@@ -52,11 +54,36 @@ func (s *recordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnv
 	return nil
 }
 
+func (s *recordingAppendLog) Replay(_ context.Context, request ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	source := s.events
+	if len(s.replayEvents) != 0 {
+		source = s.replayEvents
+	}
+	events := make([]*cerebrov1.EventEnvelope, 0, len(source))
+	for _, event := range source {
+		if event == nil {
+			continue
+		}
+		if event.GetAttributes()[ports.EventAttributeSourceRuntimeID] != request.RuntimeID {
+			continue
+		}
+		events = append(events, proto.Clone(event).(*cerebrov1.EventEnvelope))
+		if request.Limit != 0 && uint32(len(events)) >= request.Limit {
+			break
+		}
+	}
+	return events, nil
+}
+
 type stubRuntimeStore struct {
 	err      error
 	runtimes map[string]*cerebrov1.SourceRuntime
 	entities map[string]*ports.ProjectedEntity
 	links    map[string]*ports.ProjectedLink
+	findings map[string]*ports.FindingRecord
 }
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
@@ -109,6 +136,20 @@ func (s *stubRuntimeStore) UpsertProjectedLink(_ context.Context, link *ports.Pr
 	}
 	s.links[projectedLinkKey(link)] = cloneProjectedLink(link)
 	return nil
+}
+
+func (s *stubRuntimeStore) UpsertFinding(_ context.Context, finding *ports.FindingRecord) (*ports.FindingRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if finding == nil {
+		return nil, nil
+	}
+	if s.findings == nil {
+		s.findings = make(map[string]*ports.FindingRecord)
+	}
+	s.findings[finding.ID] = cloneFinding(finding)
+	return cloneFinding(finding), nil
 }
 
 type stubGraphStore struct {
@@ -600,6 +641,97 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	}
 }
 
+func TestFindingEndpoints(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	appendLog := &recordingAppendLog{
+		replayEvents: []*cerebrov1.EventEnvelope{
+			findingTestEvent("okta-audit-1", "user.session.start", "SUCCESS"),
+			findingTestEvent("okta-audit-2", "policy.rule.update", "SUCCESS"),
+		},
+	}
+	runtimeStore := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {
+				Id:       "writer-okta-audit",
+				SourceId: "okta",
+				TenantId: "writer",
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  appendLog,
+		StateStore: runtimeStore,
+		GraphStore: &stubGraphStore{},
+	}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	evaluateReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?event_limit=2", nil)
+	if err != nil {
+		t.Fatalf("new evaluate findings request: %v", err)
+	}
+	evaluateResp, err := server.Client().Do(evaluateReq)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/findings/evaluate error = %v", err)
+	}
+	defer func() {
+		if closeErr := evaluateResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close evaluate findings response body: %v", closeErr)
+		}
+	}()
+	var evaluatePayload map[string]any
+	if err := json.NewDecoder(evaluateResp.Body).Decode(&evaluatePayload); err != nil {
+		t.Fatalf("decode evaluate findings response: %v", err)
+	}
+	if got := evaluatePayload["events_evaluated"]; got != float64(2) {
+		t.Fatalf("evaluate findings events_evaluated = %#v, want 2", got)
+	}
+	if got := evaluatePayload["findings_upserted"]; got != float64(1) {
+		t.Fatalf("evaluate findings findings_upserted = %#v, want 1", got)
+	}
+	findingsPayload, ok := evaluatePayload["findings"].([]any)
+	if !ok || len(findingsPayload) != 1 {
+		t.Fatalf("evaluate findings payload = %#v, want 1 entry", evaluatePayload["findings"])
+	}
+	findingPayload, ok := findingsPayload[0].(map[string]any)
+	if !ok {
+		t.Fatalf("evaluate finding payload = %#v, want object", findingsPayload[0])
+	}
+	if got := findingPayload["rule_id"]; got != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("evaluate finding rule_id = %#v, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	if got := findingPayload["summary"]; got != "admin@writer.com performed policy.rule.update on pol-1" {
+		t.Fatalf("evaluate finding summary = %#v, want admin summary", got)
+	}
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	evaluateFindingsResp, err := client.EvaluateSourceRuntimeFindings(context.Background(), connect.NewRequest(&cerebrov1.EvaluateSourceRuntimeFindingsRequest{
+		Id:         "writer-okta-audit",
+		EventLimit: 5,
+	}))
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeFindings() error = %v", err)
+	}
+	if got := evaluateFindingsResp.Msg.GetEventsEvaluated(); got != 2 {
+		t.Fatalf("EvaluateSourceRuntimeFindings events_evaluated = %d, want 2", got)
+	}
+	if got := evaluateFindingsResp.Msg.GetFindingsUpserted(); got != 1 {
+		t.Fatalf("EvaluateSourceRuntimeFindings findings_upserted = %d, want 1", got)
+	}
+	if len(evaluateFindingsResp.Msg.GetFindings()) != 1 {
+		t.Fatalf("len(EvaluateSourceRuntimeFindings.Findings) = %d, want 1", len(evaluateFindingsResp.Msg.GetFindings()))
+	}
+	if got := evaluateFindingsResp.Msg.GetRule().GetId(); got != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("EvaluateSourceRuntimeFindings rule id = %q, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	if len(runtimeStore.findings) != 1 {
+		t.Fatalf("len(runtimeStore.findings) = %d, want 1", len(runtimeStore.findings))
+	}
+}
+
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.NewFixture()
 	if err != nil {
@@ -645,6 +777,59 @@ func cloneProjectedLink(link *ports.ProjectedLink) *ports.ProjectedLink {
 		ToURN:      link.ToURN,
 		Relation:   link.Relation,
 		Attributes: attributes,
+	}
+}
+
+func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
+	if finding == nil {
+		return nil
+	}
+	resourceURNs := make([]string, len(finding.ResourceURNs))
+	copy(resourceURNs, finding.ResourceURNs)
+	eventIDs := make([]string, len(finding.EventIDs))
+	copy(eventIDs, finding.EventIDs)
+	attributes := make(map[string]string, len(finding.Attributes))
+	for key, value := range finding.Attributes {
+		attributes[key] = value
+	}
+	return &ports.FindingRecord{
+		ID:              finding.ID,
+		Fingerprint:     finding.Fingerprint,
+		TenantID:        finding.TenantID,
+		RuntimeID:       finding.RuntimeID,
+		RuleID:          finding.RuleID,
+		Title:           finding.Title,
+		Severity:        finding.Severity,
+		Status:          finding.Status,
+		Summary:         finding.Summary,
+		ResourceURNs:    resourceURNs,
+		EventIDs:        eventIDs,
+		Attributes:      attributes,
+		FirstObservedAt: finding.FirstObservedAt,
+		LastObservedAt:  finding.LastObservedAt,
+	}
+}
+
+func findingTestEvent(id string, eventType string, outcome string) *cerebrov1.EventEnvelope {
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   "okta",
+		Kind:       "okta.audit",
+		OccurredAt: timestamppb.New(time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)),
+		SchemaRef:  "okta/audit/v1",
+		Attributes: map[string]string{
+			"domain":                            "writer.okta.com",
+			"event_type":                        eventType,
+			"resource_id":                       "pol-1",
+			"resource_type":                     "PolicyRule",
+			"actor_id":                          "00u2",
+			"actor_type":                        "User",
+			"actor_alternate_id":                "admin@writer.com",
+			"actor_display_name":                "Admin Example",
+			"outcome_result":                    outcome,
+			ports.EventAttributeSourceRuntimeID: "writer-okta-audit",
+		},
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -658,6 +658,9 @@ func TestFindingEndpoints(t *testing.T) {
 				Id:       "writer-okta-audit",
 				SourceId: "okta",
 				TenantId: "writer",
+				Config: map[string]string{
+					"token": "super-secret",
+				},
 			},
 		},
 	}
@@ -691,6 +694,9 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := evaluatePayload["findings_upserted"]; got != float64(1) {
 		t.Fatalf("evaluate findings findings_upserted = %#v, want 1", got)
+	}
+	if _, ok := evaluatePayload["runtime"]; ok {
+		t.Fatalf("evaluate findings runtime = %#v, want omitted", evaluatePayload["runtime"])
 	}
 	findingsPayload, ok := evaluatePayload["findings"].([]any)
 	if !ok || len(findingsPayload) != 1 {
@@ -726,6 +732,9 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := evaluateFindingsResp.Msg.GetRule().GetId(); got != "identity-okta-policy-rule-lifecycle-tampering" {
 		t.Fatalf("EvaluateSourceRuntimeFindings rule id = %q, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	if evaluateFindingsResp.Msg.GetRuntime() != nil {
+		t.Fatalf("EvaluateSourceRuntimeFindings runtime = %#v, want nil", evaluateFindingsResp.Msg.GetRuntime())
 	}
 	if len(runtimeStore.findings) != 1 {
 		t.Fatalf("len(runtimeStore.findings) = %d, want 1", len(runtimeStore.findings))

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -173,12 +173,14 @@ func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebro
 	if timestamp := event.GetOccurredAt(); timestamp != nil {
 		observedAt = timestamp.AsTime().UTC()
 	}
-	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, event.GetId())
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	normalizedRuntimeID := strings.TrimSpace(runtimeID)
+	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, tenantID, normalizedRuntimeID, event.GetId())
 	return &ports.FindingRecord{
 		ID:              fingerprint,
 		Fingerprint:     fingerprint,
-		TenantID:        strings.TrimSpace(event.GetTenantId()),
-		RuntimeID:       strings.TrimSpace(runtimeID),
+		TenantID:        tenantID,
+		RuntimeID:       normalizedRuntimeID,
 		RuleID:          oktaPolicyRuleLifecycleTamperingRuleID,
 		Title:           oktaPolicyRuleLifecycleTamperingTitle,
 		Severity:        oktaPolicyRuleLifecycleTamperingSeverity,

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -1,0 +1,344 @@
+package findings
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceprojection"
+)
+
+const (
+	defaultEventLimit = 100
+	maxEventLimit     = 1000
+
+	oktaPolicyRuleLifecycleTamperingRuleID   = "identity-okta-policy-rule-lifecycle-tampering"
+	oktaPolicyRuleLifecycleTamperingTitle    = "Okta Policy Rule Lifecycle Tampering"
+	oktaPolicyRuleLifecycleTamperingSeverity = "HIGH"
+	oktaPolicyRuleLifecycleTamperingStatus   = "open"
+)
+
+var (
+	// ErrRuntimeUnavailable indicates that the runtime, replay, or finding store boundary is unavailable.
+	ErrRuntimeUnavailable = errors.New("finding runtime is unavailable")
+
+	oktaPolicyRuleLifecycleTamperingEventTypes = map[string]struct{}{
+		"policy.rule.update":     {},
+		"policy.rule.deactivate": {},
+		"policy.rule.delete":     {},
+	}
+	oktaPolicyRuleLifecycleTamperingOutcomes = map[string]struct{}{
+		"success": {},
+		"allow":   {},
+		"allowed": {},
+	}
+)
+
+// Service replays runtime events through a fixed finding evaluator and persists emitted findings.
+type Service struct {
+	runtimeStore ports.SourceRuntimeStore
+	replayer     ports.EventReplayer
+	store        ports.FindingStore
+}
+
+// EvaluateRequest scopes one replay-backed finding evaluation.
+type EvaluateRequest struct {
+	RuntimeID  string
+	EventLimit uint32
+}
+
+// EvaluateResult reports the persisted findings emitted for one runtime evaluation.
+type EvaluateResult struct {
+	Runtime         *cerebrov1.SourceRuntime
+	Rule            *cerebrov1.RuleSpec
+	EventsEvaluated uint32
+	Findings        []*ports.FindingRecord
+}
+
+// New constructs a replay-backed finding service.
+func New(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore) *Service {
+	return &Service{
+		runtimeStore: runtimeStore,
+		replayer:     replayer,
+		store:        store,
+	}
+}
+
+// EvaluateSourceRuntime replays one runtime and persists findings for matching Okta audit events.
+func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateRequest) (*EvaluateResult, error) {
+	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, errors.New("source runtime id is required")
+	}
+	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	events, err := s.replayer.Replay(ctx, ports.ReplayRequest{
+		RuntimeID: runtimeID,
+		Limit:     normalizeEventLimit(request.EventLimit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
+	}
+	result := &EvaluateResult{
+		Runtime:         runtime,
+		Rule:            oktaPolicyRuleLifecycleTamperingRuleSpec(),
+		EventsEvaluated: uint32(len(events)),
+	}
+	for _, event := range events {
+		if !matchesOktaPolicyRuleLifecycleTampering(event) {
+			continue
+		}
+		record, err := oktaPolicyRuleLifecycleTamperingFinding(ctx, event, runtimeID)
+		if err != nil {
+			return nil, err
+		}
+		stored, err := s.store.UpsertFinding(ctx, record)
+		if err != nil {
+			return nil, fmt.Errorf("persist finding for event %q: %w", event.GetId(), err)
+		}
+		result.Findings = append(result.Findings, stored)
+	}
+	return result, nil
+}
+
+func normalizeEventLimit(limit uint32) uint32 {
+	switch {
+	case limit == 0:
+		return defaultEventLimit
+	case limit > maxEventLimit:
+		return maxEventLimit
+	default:
+		return limit
+	}
+}
+
+func oktaPolicyRuleLifecycleTamperingRuleSpec() *cerebrov1.RuleSpec {
+	return &cerebrov1.RuleSpec{
+		Id:          oktaPolicyRuleLifecycleTamperingRuleID,
+		Name:        oktaPolicyRuleLifecycleTamperingTitle,
+		Description: "Detect successful Okta policy rule update, deactivate, or delete events replayed from one source runtime.",
+		InputStreamIds: []string{
+			"source-runtime-replay",
+		},
+		OutputKinds: []string{
+			"finding.okta_policy_rule_lifecycle_tampering",
+		},
+	}
+}
+
+func matchesOktaPolicyRuleLifecycleTampering(event *cerebrov1.EventEnvelope) bool {
+	if event == nil || !strings.EqualFold(strings.TrimSpace(event.GetKind()), "okta.audit") {
+		return false
+	}
+	attributes := event.GetAttributes()
+	eventType := strings.ToLower(strings.TrimSpace(attributes["event_type"]))
+	if _, ok := oktaPolicyRuleLifecycleTamperingEventTypes[eventType]; !ok {
+		return false
+	}
+	outcome := strings.ToLower(strings.TrimSpace(attributes["outcome_result"]))
+	if outcome == "" {
+		outcome = "success"
+	}
+	_, ok := oktaPolicyRuleLifecycleTamperingOutcomes[outcome]
+	return ok
+}
+
+func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
+	resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, err := projectedEntityContext(ctx, event)
+	if err != nil {
+		return nil, fmt.Errorf("project finding context for event %q: %w", event.GetId(), err)
+	}
+	attributes := map[string]string{
+		"event_id":             strings.TrimSpace(event.GetId()),
+		"event_type":           strings.TrimSpace(event.GetAttributes()["event_type"]),
+		"outcome_result":       strings.TrimSpace(event.GetAttributes()["outcome_result"]),
+		"source_runtime_id":    strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID]),
+		"primary_actor_urn":    actorURN,
+		"primary_resource_urn": resourceURN,
+	}
+	trimEmptyAttributes(attributes)
+	observedAt := time.Time{}
+	if timestamp := event.GetOccurredAt(); timestamp != nil {
+		observedAt = timestamp.AsTime().UTC()
+	}
+	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, event.GetId())
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        strings.TrimSpace(event.GetTenantId()),
+		RuntimeID:       strings.TrimSpace(runtimeID),
+		RuleID:          oktaPolicyRuleLifecycleTamperingRuleID,
+		Title:           oktaPolicyRuleLifecycleTamperingTitle,
+		Severity:        oktaPolicyRuleLifecycleTamperingSeverity,
+		Status:          oktaPolicyRuleLifecycleTamperingStatus,
+		Summary:         findingSummary(event, actorLabel, resourceLabel),
+		ResourceURNs:    resourceURNs,
+		EventIDs:        []string{strings.TrimSpace(event.GetId())},
+		Attributes:      attributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}
+
+func projectedEntityContext(ctx context.Context, event *cerebrov1.EventEnvelope) ([]string, string, string, string, string, error) {
+	recorder := &projectionRecorder{
+		entities: make(map[string]*ports.ProjectedEntity),
+		links:    make(map[string]*ports.ProjectedLink),
+	}
+	if ctx == nil {
+		return nil, "", "", "", "", errors.New("context is required")
+	}
+	if _, err := sourceprojection.New(nil, recorder).Project(ctx, event); err != nil {
+		return nil, "", "", "", "", err
+	}
+	resourceURNs := make([]string, 0, len(recorder.entities))
+	seenURNs := make(map[string]struct{}, len(recorder.entities))
+	var actorURN string
+	var resourceURN string
+	for _, link := range recorder.links {
+		if !strings.EqualFold(strings.TrimSpace(link.Relation), "acted_on") {
+			continue
+		}
+		if actorURN == "" {
+			actorURN = strings.TrimSpace(link.FromURN)
+		}
+		if resourceURN == "" {
+			resourceURN = strings.TrimSpace(link.ToURN)
+		}
+		if candidate := strings.TrimSpace(link.FromURN); candidate != "" {
+			if _, ok := seenURNs[candidate]; !ok {
+				seenURNs[candidate] = struct{}{}
+				resourceURNs = append(resourceURNs, candidate)
+			}
+		}
+		if candidate := strings.TrimSpace(link.ToURN); candidate != "" {
+			if _, ok := seenURNs[candidate]; !ok {
+				seenURNs[candidate] = struct{}{}
+				resourceURNs = append(resourceURNs, candidate)
+			}
+		}
+	}
+	slices.Sort(resourceURNs)
+	actorLabel := entityLabel(recorder.entities[actorURN], event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"])
+	resourceLabel := entityLabel(recorder.entities[resourceURN], event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"])
+	return resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, nil
+}
+
+func entityLabel(entity *ports.ProjectedEntity, fallbacks ...string) string {
+	if entity != nil && strings.TrimSpace(entity.Label) != "" {
+		return strings.TrimSpace(entity.Label)
+	}
+	for _, fallback := range fallbacks {
+		if strings.TrimSpace(fallback) != "" {
+			return strings.TrimSpace(fallback)
+		}
+	}
+	return ""
+}
+
+func findingSummary(event *cerebrov1.EventEnvelope, actorLabel string, resourceLabel string) string {
+	eventType := strings.TrimSpace(event.GetAttributes()["event_type"])
+	actor := firstNonEmpty(actorLabel, event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"], "unknown actor")
+	resource := firstNonEmpty(resourceLabel, event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"], "unknown resource")
+	return fmt.Sprintf("%s performed %s on %s", actor, eventType, resource)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func trimEmptyAttributes(attributes map[string]string) {
+	for key, value := range attributes {
+		if strings.TrimSpace(value) == "" {
+			delete(attributes, key)
+		}
+	}
+}
+
+func hashFindingFingerprint(parts ...string) string {
+	hash := sha256.New()
+	for _, part := range parts {
+		_, _ = hash.Write([]byte(strings.TrimSpace(part)))
+		_, _ = hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+type projectionRecorder struct {
+	entities map[string]*ports.ProjectedEntity
+	links    map[string]*ports.ProjectedLink
+}
+
+func (r *projectionRecorder) Ping(context.Context) error {
+	return nil
+}
+
+func (r *projectionRecorder) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if entity == nil {
+		return nil
+	}
+	r.entities[entity.URN] = cloneEntity(entity)
+	return nil
+}
+
+func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	key := strings.TrimSpace(link.FromURN) + "|" + strings.TrimSpace(link.Relation) + "|" + strings.TrimSpace(link.ToURN)
+	r.links[key] = cloneLink(link)
+	return nil
+}
+
+func cloneEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
+	if entity == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(entity.Attributes))
+	for key, value := range entity.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedEntity{
+		URN:        entity.URN,
+		TenantID:   entity.TenantID,
+		SourceID:   entity.SourceID,
+		EntityType: entity.EntityType,
+		Label:      entity.Label,
+		Attributes: attributes,
+	}
+}
+
+func cloneLink(link *ports.ProjectedLink) *ports.ProjectedLink {
+	if link == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(link.Attributes))
+	for key, value := range link.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedLink{
+		TenantID:   link.TenantID,
+		SourceID:   link.SourceID,
+		FromURN:    link.FromURN,
+		ToURN:      link.ToURN,
+		Relation:   link.Relation,
+		Attributes: attributes,
+	}
+}

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -149,7 +149,7 @@ func matchesOktaPolicyRuleLifecycleTampering(event *cerebrov1.EventEnvelope) boo
 	}
 	outcome := strings.ToLower(strings.TrimSpace(attributes["outcome_result"]))
 	if outcome == "" {
-		outcome = "success"
+		return false
 	}
 	_, ok := oktaPolicyRuleLifecycleTamperingOutcomes[outcome]
 	return ok

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -146,6 +146,24 @@ func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T
 	}
 }
 
+func TestOktaPolicyRuleLifecycleTamperingFindingIsRuntimeScoped(t *testing.T) {
+	event := newAuditEvent("okta-audit-1", "policy.rule.update", "SUCCESS")
+	first, err := oktaPolicyRuleLifecycleTamperingFinding(context.Background(), event, "runtime-a")
+	if err != nil {
+		t.Fatalf("oktaPolicyRuleLifecycleTamperingFinding(first) error = %v", err)
+	}
+	second, err := oktaPolicyRuleLifecycleTamperingFinding(context.Background(), event, "runtime-b")
+	if err != nil {
+		t.Fatalf("oktaPolicyRuleLifecycleTamperingFinding(second) error = %v", err)
+	}
+	if first.ID == second.ID {
+		t.Fatalf("finding IDs collided across runtimes: %q", first.ID)
+	}
+	if first.RuntimeID != "runtime-a" || second.RuntimeID != "runtime-b" {
+		t.Fatalf("RuntimeID = %q, %q; want runtime-a, runtime-b", first.RuntimeID, second.RuntimeID)
+	}
+}
+
 func newAuditEvent(id string, eventType string, outcome string) *cerebrov1.EventEnvelope {
 	return &cerebrov1.EventEnvelope{
 		Id:         id,

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -1,0 +1,200 @@
+package findings
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type stubRuntimeStore struct {
+	runtimes map[string]*cerebrov1.SourceRuntime
+}
+
+func (s *stubRuntimeStore) Ping(context.Context) error { return nil }
+
+func (s *stubRuntimeStore) PutSourceRuntime(context.Context, *cerebrov1.SourceRuntime) error {
+	return nil
+}
+
+func (s *stubRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov1.SourceRuntime, error) {
+	runtime, ok := s.runtimes[id]
+	if !ok {
+		return nil, ports.ErrSourceRuntimeNotFound
+	}
+	return proto.Clone(runtime).(*cerebrov1.SourceRuntime), nil
+}
+
+type stubReplayer struct {
+	request ports.ReplayRequest
+	events  []*cerebrov1.EventEnvelope
+}
+
+func (s *stubReplayer) Replay(_ context.Context, request ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
+	s.request = request
+	events := make([]*cerebrov1.EventEnvelope, 0, len(s.events))
+	for _, event := range s.events {
+		events = append(events, proto.Clone(event).(*cerebrov1.EventEnvelope))
+	}
+	return events, nil
+}
+
+type stubFindingStore struct {
+	findings map[string]*ports.FindingRecord
+}
+
+func (s *stubFindingStore) Ping(context.Context) error { return nil }
+
+func (s *stubFindingStore) UpsertFinding(_ context.Context, finding *ports.FindingRecord) (*ports.FindingRecord, error) {
+	if finding == nil {
+		return nil, errors.New("finding is required")
+	}
+	if s.findings == nil {
+		s.findings = make(map[string]*ports.FindingRecord)
+	}
+	cloned := cloneFinding(finding)
+	s.findings[cloned.ID] = cloned
+	return cloneFinding(cloned), nil
+}
+
+func TestEvaluateSourceRuntimeFindingsReplaysOktaPolicyRuleLifecycleTampering(t *testing.T) {
+	replayer := &stubReplayer{
+		events: []*cerebrov1.EventEnvelope{
+			newAuditEvent("okta-audit-1", "user.session.start", "SUCCESS"),
+			newAuditEvent("okta-audit-2", "policy.rule.update", "SUCCESS"),
+		},
+	}
+	store := &stubFindingStore{}
+	service := New(&stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {
+				Id:       "writer-okta-audit",
+				SourceId: "okta",
+				TenantId: "writer",
+			},
+		},
+	}, replayer, store)
+
+	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID:  "writer-okta-audit",
+		EventLimit: 25,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntime() error = %v", err)
+	}
+	if result.Runtime.GetId() != "writer-okta-audit" {
+		t.Fatalf("Runtime.ID = %q, want writer-okta-audit", result.Runtime.GetId())
+	}
+	if result.Rule.GetId() != oktaPolicyRuleLifecycleTamperingRuleID {
+		t.Fatalf("Rule.ID = %q, want %q", result.Rule.GetId(), oktaPolicyRuleLifecycleTamperingRuleID)
+	}
+	if result.EventsEvaluated != 2 {
+		t.Fatalf("EventsEvaluated = %d, want 2", result.EventsEvaluated)
+	}
+	if got := replayer.request.RuntimeID; got != "writer-okta-audit" {
+		t.Fatalf("Replay().RuntimeID = %q, want writer-okta-audit", got)
+	}
+	if got := replayer.request.Limit; got != 25 {
+		t.Fatalf("Replay().Limit = %d, want 25", got)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("len(Findings) = %d, want 1", len(result.Findings))
+	}
+	finding := result.Findings[0]
+	if finding.RuleID != oktaPolicyRuleLifecycleTamperingRuleID {
+		t.Fatalf("Finding.RuleID = %q, want %q", finding.RuleID, oktaPolicyRuleLifecycleTamperingRuleID)
+	}
+	if finding.Severity != "HIGH" {
+		t.Fatalf("Finding.Severity = %q, want HIGH", finding.Severity)
+	}
+	if finding.Status != "open" {
+		t.Fatalf("Finding.Status = %q, want open", finding.Status)
+	}
+	if finding.Summary != "admin@writer.com performed policy.rule.update on pol-1" {
+		t.Fatalf("Finding.Summary = %q, want admin@writer.com performed policy.rule.update on pol-1", finding.Summary)
+	}
+	if len(finding.ResourceURNs) != 2 {
+		t.Fatalf("len(Finding.ResourceURNs) = %d, want 2", len(finding.ResourceURNs))
+	}
+	if finding.ResourceURNs[0] != "urn:cerebro:writer:okta_resource:policyrule:pol-1" {
+		t.Fatalf("Finding.ResourceURNs[0] = %q, want policy rule urn", finding.ResourceURNs[0])
+	}
+	if finding.ResourceURNs[1] != "urn:cerebro:writer:okta_user:00u2" {
+		t.Fatalf("Finding.ResourceURNs[1] = %q, want actor urn", finding.ResourceURNs[1])
+	}
+	if finding.Attributes["primary_actor_urn"] != "urn:cerebro:writer:okta_user:00u2" {
+		t.Fatalf("Finding.Attributes[primary_actor_urn] = %q, want actor urn", finding.Attributes["primary_actor_urn"])
+	}
+	if finding.Attributes["primary_resource_urn"] != "urn:cerebro:writer:okta_resource:policyrule:pol-1" {
+		t.Fatalf("Finding.Attributes[primary_resource_urn] = %q, want resource urn", finding.Attributes["primary_resource_urn"])
+	}
+	if len(store.findings) != 1 {
+		t.Fatalf("len(store.findings) = %d, want 1", len(store.findings))
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T) {
+	service := New(nil, nil, nil)
+	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{RuntimeID: "writer-okta-audit"}); !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}
+
+func newAuditEvent(id string, eventType string, outcome string) *cerebrov1.EventEnvelope {
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   "okta",
+		Kind:       "okta.audit",
+		OccurredAt: timestamppb.New(time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)),
+		SchemaRef:  "okta/audit/v1",
+		Attributes: map[string]string{
+			"domain":                            "writer.okta.com",
+			"event_type":                        eventType,
+			"resource_id":                       "pol-1",
+			"resource_type":                     "PolicyRule",
+			"actor_id":                          "00u2",
+			"actor_type":                        "User",
+			"actor_alternate_id":                "admin@writer.com",
+			"actor_display_name":                "Admin Example",
+			"outcome_result":                    outcome,
+			ports.EventAttributeSourceRuntimeID: "writer-okta-audit",
+		},
+	}
+}
+
+func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
+	if finding == nil {
+		return nil
+	}
+	resourceURNs := make([]string, len(finding.ResourceURNs))
+	copy(resourceURNs, finding.ResourceURNs)
+	eventIDs := make([]string, len(finding.EventIDs))
+	copy(eventIDs, finding.EventIDs)
+	attributes := make(map[string]string, len(finding.Attributes))
+	for key, value := range finding.Attributes {
+		attributes[key] = value
+	}
+	return &ports.FindingRecord{
+		ID:              finding.ID,
+		Fingerprint:     finding.Fingerprint,
+		TenantID:        finding.TenantID,
+		RuntimeID:       finding.RuntimeID,
+		RuleID:          finding.RuleID,
+		Title:           finding.Title,
+		Severity:        finding.Severity,
+		Status:          finding.Status,
+		Summary:         finding.Summary,
+		ResourceURNs:    resourceURNs,
+		EventIDs:        eventIDs,
+		Attributes:      attributes,
+		FirstObservedAt: finding.FirstObservedAt,
+		LastObservedAt:  finding.LastObservedAt,
+	}
+}

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -1,0 +1,30 @@
+package ports
+
+import (
+	"context"
+	"time"
+)
+
+// FindingRecord is the normalized persisted finding shape.
+type FindingRecord struct {
+	ID              string
+	Fingerprint     string
+	TenantID        string
+	RuntimeID       string
+	RuleID          string
+	Title           string
+	Severity        string
+	Status          string
+	Summary         string
+	ResourceURNs    []string
+	EventIDs        []string
+	Attributes      map[string]string
+	FirstObservedAt time.Time
+	LastObservedAt  time.Time
+}
+
+// FindingStore persists normalized findings in the state store.
+type FindingStore interface {
+	StateStore
+	UpsertFinding(context.Context, *FindingRecord) (*FindingRecord, error)
+}

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -94,10 +94,12 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord)
 	}
 	firstObservedAt := finding.FirstObservedAt.UTC()
 	lastObservedAt := finding.LastObservedAt.UTC()
-	if firstObservedAt.IsZero() {
+	switch {
+	case firstObservedAt.IsZero() && lastObservedAt.IsZero():
+		return nil, errors.New("finding observed at is required")
+	case firstObservedAt.IsZero():
 		firstObservedAt = lastObservedAt
-	}
-	if lastObservedAt.IsZero() {
+	case lastObservedAt.IsZero():
 		lastObservedAt = firstObservedAt
 	}
 	var stored findingRow

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -1,0 +1,247 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureFindingStatements = []string{
+	`CREATE TABLE IF NOT EXISTS findings (
+  id TEXT PRIMARY KEY,
+  fingerprint TEXT NOT NULL UNIQUE,
+  tenant_id TEXT NOT NULL,
+  runtime_id TEXT NOT NULL,
+  rule_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  severity TEXT NOT NULL,
+  status TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  resource_urns_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  event_ids_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  first_observed_at TIMESTAMPTZ NOT NULL,
+  last_observed_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS findings_runtime_rule_idx ON findings (runtime_id, rule_id)`,
+}
+
+// UpsertFinding persists one normalized finding in the current-state store.
+func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord) (*ports.FindingRecord, error) {
+	if finding == nil {
+		return nil, errors.New("finding is required")
+	}
+	id := strings.TrimSpace(finding.ID)
+	if id == "" {
+		return nil, errors.New("finding id is required")
+	}
+	fingerprint := strings.TrimSpace(finding.Fingerprint)
+	if fingerprint == "" {
+		return nil, errors.New("finding fingerprint is required")
+	}
+	tenantID := strings.TrimSpace(finding.TenantID)
+	if tenantID == "" {
+		return nil, errors.New("finding tenant id is required")
+	}
+	runtimeID := strings.TrimSpace(finding.RuntimeID)
+	if runtimeID == "" {
+		return nil, errors.New("finding runtime id is required")
+	}
+	ruleID := strings.TrimSpace(finding.RuleID)
+	if ruleID == "" {
+		return nil, errors.New("finding rule id is required")
+	}
+	title := strings.TrimSpace(finding.Title)
+	if title == "" {
+		return nil, errors.New("finding title is required")
+	}
+	severity := strings.TrimSpace(finding.Severity)
+	if severity == "" {
+		return nil, errors.New("finding severity is required")
+	}
+	status := strings.TrimSpace(finding.Status)
+	if status == "" {
+		return nil, errors.New("finding status is required")
+	}
+	summary := strings.TrimSpace(finding.Summary)
+	if summary == "" {
+		return nil, errors.New("finding summary is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return nil, err
+	}
+	resourceURNsJSON, err := findingStringsJSON(finding.ResourceURNs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal finding resource urns: %w", err)
+	}
+	eventIDsJSON, err := findingStringsJSON(finding.EventIDs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal finding event ids: %w", err)
+	}
+	attributesJSON, err := findingAttributesJSON(finding.Attributes)
+	if err != nil {
+		return nil, fmt.Errorf("marshal finding attributes: %w", err)
+	}
+	firstObservedAt := finding.FirstObservedAt.UTC()
+	lastObservedAt := finding.LastObservedAt.UTC()
+	if firstObservedAt.IsZero() {
+		firstObservedAt = lastObservedAt
+	}
+	if lastObservedAt.IsZero() {
+		lastObservedAt = firstObservedAt
+	}
+	var stored findingRow
+	if err := s.db.QueryRowContext(ctx, `
+INSERT INTO findings (
+  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
+  resource_urns_json, event_ids_json, attributes_json, first_observed_at, last_observed_at
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12::jsonb, $13, $14)
+ON CONFLICT (id)
+DO UPDATE SET
+  fingerprint = EXCLUDED.fingerprint,
+  tenant_id = EXCLUDED.tenant_id,
+  runtime_id = EXCLUDED.runtime_id,
+  rule_id = EXCLUDED.rule_id,
+  title = EXCLUDED.title,
+  severity = EXCLUDED.severity,
+  status = EXCLUDED.status,
+  summary = EXCLUDED.summary,
+  resource_urns_json = EXCLUDED.resource_urns_json,
+  event_ids_json = EXCLUDED.event_ids_json,
+  attributes_json = EXCLUDED.attributes_json,
+  first_observed_at = LEAST(findings.first_observed_at, EXCLUDED.first_observed_at),
+  last_observed_at = GREATEST(findings.last_observed_at, EXCLUDED.last_observed_at),
+  updated_at = NOW()
+RETURNING
+  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
+  resource_urns_json::text, event_ids_json::text, attributes_json::text, first_observed_at, last_observed_at`,
+		id,
+		fingerprint,
+		tenantID,
+		runtimeID,
+		ruleID,
+		title,
+		severity,
+		status,
+		summary,
+		resourceURNsJSON,
+		eventIDsJSON,
+		attributesJSON,
+		firstObservedAt,
+		lastObservedAt,
+	).Scan(
+		&stored.ID,
+		&stored.Fingerprint,
+		&stored.TenantID,
+		&stored.RuntimeID,
+		&stored.RuleID,
+		&stored.Title,
+		&stored.Severity,
+		&stored.Status,
+		&stored.Summary,
+		&stored.ResourceURNsJSON,
+		&stored.EventIDsJSON,
+		&stored.AttributesJSON,
+		&stored.FirstObservedAt,
+		&stored.LastObservedAt,
+	); err != nil {
+		return nil, fmt.Errorf("upsert finding %q: %w", id, err)
+	}
+	return stored.record()
+}
+
+func (s *Store) ensureFindingTables(ctx context.Context) error {
+	for _, statement := range ensureFindingStatements {
+		if _, err := s.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("ensure findings tables: %w", err)
+		}
+	}
+	return nil
+}
+
+func findingStringsJSON(values []string) (string, error) {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	if len(normalized) == 0 {
+		return `[]`, nil
+	}
+	payload, err := json.Marshal(normalized)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func findingAttributesJSON(attributes map[string]string) (string, error) {
+	if len(attributes) == 0 {
+		return `{}`, nil
+	}
+	payload, err := json.Marshal(attributes)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+type findingRow struct {
+	ID               string
+	Fingerprint      string
+	TenantID         string
+	RuntimeID        string
+	RuleID           string
+	Title            string
+	Severity         string
+	Status           string
+	Summary          string
+	ResourceURNsJSON string
+	EventIDsJSON     string
+	AttributesJSON   string
+	FirstObservedAt  time.Time
+	LastObservedAt   time.Time
+}
+
+func (r findingRow) record() (*ports.FindingRecord, error) {
+	resourceURNs := []string{}
+	if err := json.Unmarshal([]byte(r.ResourceURNsJSON), &resourceURNs); err != nil {
+		return nil, fmt.Errorf("decode finding resource urns: %w", err)
+	}
+	eventIDs := []string{}
+	if err := json.Unmarshal([]byte(r.EventIDsJSON), &eventIDs); err != nil {
+		return nil, fmt.Errorf("decode finding event ids: %w", err)
+	}
+	attributes := map[string]string{}
+	if err := json.Unmarshal([]byte(r.AttributesJSON), &attributes); err != nil {
+		return nil, fmt.Errorf("decode finding attributes: %w", err)
+	}
+	return &ports.FindingRecord{
+		ID:              r.ID,
+		Fingerprint:     r.Fingerprint,
+		TenantID:        r.TenantID,
+		RuntimeID:       r.RuntimeID,
+		RuleID:          r.RuleID,
+		Title:           r.Title,
+		Severity:        r.Severity,
+		Status:          r.Status,
+		Summary:         r.Summary,
+		ResourceURNs:    resourceURNs,
+		EventIDs:        eventIDs,
+		Attributes:      attributes,
+		FirstObservedAt: r.FirstObservedAt.UTC(),
+		LastObservedAt:  r.LastObservedAt.UTC(),
+	}, nil
+}

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -109,9 +109,8 @@ INSERT INTO findings (
   resource_urns_json, event_ids_json, attributes_json, first_observed_at, last_observed_at
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12::jsonb, $13, $14)
-ON CONFLICT (id)
+ON CONFLICT (fingerprint)
 DO UPDATE SET
-  fingerprint = EXCLUDED.fingerprint,
   tenant_id = EXCLUDED.tenant_id,
   runtime_id = EXCLUDED.runtime_id,
   rule_id = EXCLUDED.rule_id,

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -1,0 +1,55 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestUpsertFindingRejectsNilFinding(t *testing.T) {
+	store := &Store{}
+	if _, err := store.UpsertFinding(context.Background(), nil); err == nil {
+		t.Fatal("UpsertFinding() error = nil, want non-nil")
+	}
+}
+
+func TestUpsertFindingRejectsMissingRuleID(t *testing.T) {
+	store := &Store{}
+	_, err := store.UpsertFinding(context.Background(), &ports.FindingRecord{
+		ID:              "finding-1",
+		Fingerprint:     "fingerprint-1",
+		TenantID:        "writer",
+		RuntimeID:       "writer-okta-audit",
+		Title:           "Okta Policy Rule Lifecycle Tampering",
+		Severity:        "HIGH",
+		Status:          "open",
+		Summary:         "admin@writer.com performed policy.rule.update on pol-1",
+		FirstObservedAt: time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC),
+		LastObservedAt:  time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("UpsertFinding() error = nil, want non-nil")
+	}
+}
+
+func TestUpsertFindingRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	_, err := store.UpsertFinding(context.Background(), &ports.FindingRecord{
+		ID:              "finding-1",
+		Fingerprint:     "fingerprint-1",
+		TenantID:        "writer",
+		RuntimeID:       "writer-okta-audit",
+		RuleID:          "identity-okta-policy-rule-lifecycle-tampering",
+		Title:           "Okta Policy Rule Lifecycle Tampering",
+		Severity:        "HIGH",
+		Status:          "open",
+		Summary:         "admin@writer.com performed policy.rule.update on pol-1",
+		FirstObservedAt: time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC),
+		LastObservedAt:  time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("UpsertFinding() error = nil, want non-nil")
+	}
+}

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -20,6 +20,7 @@ service BootstrapService {
   rpc PutSourceRuntime(PutSourceRuntimeRequest) returns (PutSourceRuntimeResponse);
   rpc GetSourceRuntime(GetSourceRuntimeRequest) returns (GetSourceRuntimeResponse);
   rpc SyncSourceRuntime(SyncSourceRuntimeRequest) returns (SyncSourceRuntimeResponse);
+  rpc EvaluateSourceRuntimeFindings(EvaluateSourceRuntimeFindingsRequest) returns (EvaluateSourceRuntimeFindingsResponse);
 }
 
 // GetVersionRequest requests static build metadata from the running service.
@@ -151,4 +152,37 @@ message SyncSourceRuntimeResponse {
   uint32 events_appended = 4;
   uint32 entities_projected = 5;
   uint32 links_projected = 6;
+}
+
+// Finding is the normalized persisted finding view for the first runtime evaluator slice.
+message Finding {
+  string id = 1;
+  string fingerprint = 2;
+  string tenant_id = 3;
+  string runtime_id = 4;
+  string rule_id = 5;
+  string title = 6;
+  string severity = 7;
+  string status = 8;
+  string summary = 9;
+  repeated string resource_urns = 10;
+  repeated string event_ids = 11;
+  map<string, string> attributes = 12;
+  google.protobuf.Timestamp first_observed_at = 13;
+  google.protobuf.Timestamp last_observed_at = 14;
+}
+
+// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through the first built-in finding evaluator.
+message EvaluateSourceRuntimeFindingsRequest {
+  string id = 1;
+  uint32 event_limit = 2;
+}
+
+// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, fixed rule spec, and persisted findings.
+message EvaluateSourceRuntimeFindingsResponse {
+  SourceRuntime runtime = 1;
+  RuleSpec rule = 2;
+  uint32 events_evaluated = 3;
+  uint32 findings_upserted = 4;
+  repeated Finding findings = 5;
 }


### PR DESCRIPTION
## Summary
- add a replay-backed Okta policy rule lifecycle tampering evaluator that persists normalized findings in Postgres
- expose REST and Connect bootstrap endpoints to evaluate one source runtime and return the persisted findings with the fixed rule spec
- cover the slice with finding service, bootstrap, and Postgres tests plus a local replay demo

## Testing
- make verify
- go test ./internal/findings ./internal/bootstrap ./internal/statestore/postgres
- local replay demo for a policy.rule.update event
