### PR TITLE
feat(graph): add bounded entity neighborhood query

### DIFF
--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -1479,6 +1479,242 @@ func (x *EvaluateSourceRuntimeFindingsResponse) GetFindings() []*Finding {
 	return nil
 }
 
+// GraphEntity is the normalized graph node view exposed by the first query surface.
+type GraphEntity struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Urn           string                 `protobuf:"bytes,1,opt,name=urn,proto3" json:"urn,omitempty"`
+	EntityType    string                 `protobuf:"bytes,2,opt,name=entity_type,json=entityType,proto3" json:"entity_type,omitempty"`
+	Label         string                 `protobuf:"bytes,3,opt,name=label,proto3" json:"label,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GraphEntity) Reset() {
+	*x = GraphEntity{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GraphEntity) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GraphEntity) ProtoMessage() {}
+
+func (x *GraphEntity) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GraphEntity.ProtoReflect.Descriptor instead.
+func (*GraphEntity) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *GraphEntity) GetUrn() string {
+	if x != nil {
+		return x.Urn
+	}
+	return ""
+}
+
+func (x *GraphEntity) GetEntityType() string {
+	if x != nil {
+		return x.EntityType
+	}
+	return ""
+}
+
+func (x *GraphEntity) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+// GraphRelation is the normalized graph edge view exposed by the first query surface.
+type GraphRelation struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	FromUrn       string                 `protobuf:"bytes,1,opt,name=from_urn,json=fromUrn,proto3" json:"from_urn,omitempty"`
+	Relation      string                 `protobuf:"bytes,2,opt,name=relation,proto3" json:"relation,omitempty"`
+	ToUrn         string                 `protobuf:"bytes,3,opt,name=to_urn,json=toUrn,proto3" json:"to_urn,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GraphRelation) Reset() {
+	*x = GraphRelation{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GraphRelation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GraphRelation) ProtoMessage() {}
+
+func (x *GraphRelation) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GraphRelation.ProtoReflect.Descriptor instead.
+func (*GraphRelation) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *GraphRelation) GetFromUrn() string {
+	if x != nil {
+		return x.FromUrn
+	}
+	return ""
+}
+
+func (x *GraphRelation) GetRelation() string {
+	if x != nil {
+		return x.Relation
+	}
+	return ""
+}
+
+func (x *GraphRelation) GetToUrn() string {
+	if x != nil {
+		return x.ToUrn
+	}
+	return ""
+}
+
+// GetEntityNeighborhoodRequest requests one bounded graph neighborhood around a root URN.
+type GetEntityNeighborhoodRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RootUrn       string                 `protobuf:"bytes,1,opt,name=root_urn,json=rootUrn,proto3" json:"root_urn,omitempty"`
+	Limit         uint32                 `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEntityNeighborhoodRequest) Reset() {
+	*x = GetEntityNeighborhoodRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEntityNeighborhoodRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEntityNeighborhoodRequest) ProtoMessage() {}
+
+func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEntityNeighborhoodRequest.ProtoReflect.Descriptor instead.
+func (*GetEntityNeighborhoodRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *GetEntityNeighborhoodRequest) GetRootUrn() string {
+	if x != nil {
+		return x.RootUrn
+	}
+	return ""
+}
+
+func (x *GetEntityNeighborhoodRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+// GetEntityNeighborhoodResponse returns the bounded neighbors and relations around one root URN.
+type GetEntityNeighborhoodResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Root          *GraphEntity           `protobuf:"bytes,1,opt,name=root,proto3" json:"root,omitempty"`
+	Neighbors     []*GraphEntity         `protobuf:"bytes,2,rep,name=neighbors,proto3" json:"neighbors,omitempty"`
+	Relations     []*GraphRelation       `protobuf:"bytes,3,rep,name=relations,proto3" json:"relations,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetEntityNeighborhoodResponse) Reset() {
+	*x = GetEntityNeighborhoodResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetEntityNeighborhoodResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetEntityNeighborhoodResponse) ProtoMessage() {}
+
+func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetEntityNeighborhoodResponse.ProtoReflect.Descriptor instead.
+func (*GetEntityNeighborhoodResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *GetEntityNeighborhoodResponse) GetRoot() *GraphEntity {
+	if x != nil {
+		return x.Root
+	}
+	return nil
+}
+
+func (x *GetEntityNeighborhoodResponse) GetNeighbors() []*GraphEntity {
+	if x != nil {
+		return x.Neighbors
+	}
+	return nil
+}
+
+func (x *GetEntityNeighborhoodResponse) GetRelations() []*GraphRelation {
+	if x != nil {
+		return x.Relations
+	}
+	return nil
+}
+
 var File_cerebro_v1_bootstrap_proto protoreflect.FileDescriptor
 
 const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
@@ -1612,7 +1848,23 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x04rule\x18\x02 \x01(\v2\x14.cerebro.v1.RuleSpecR\x04rule\x12)\n" +
 	"\x10events_evaluated\x18\x03 \x01(\rR\x0feventsEvaluated\x12+\n" +
 	"\x11findings_upserted\x18\x04 \x01(\rR\x10findingsUpserted\x12/\n" +
-	"\bfindings\x18\x05 \x03(\v2\x13.cerebro.v1.FindingR\bfindings2\x9c\a\n" +
+	"\bfindings\x18\x05 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\"V\n" +
+	"\vGraphEntity\x12\x10\n" +
+	"\x03urn\x18\x01 \x01(\tR\x03urn\x12\x1f\n" +
+	"\ventity_type\x18\x02 \x01(\tR\n" +
+	"entityType\x12\x14\n" +
+	"\x05label\x18\x03 \x01(\tR\x05label\"]\n" +
+	"\rGraphRelation\x12\x19\n" +
+	"\bfrom_urn\x18\x01 \x01(\tR\afromUrn\x12\x1a\n" +
+	"\brelation\x18\x02 \x01(\tR\brelation\x12\x15\n" +
+	"\x06to_urn\x18\x03 \x01(\tR\x05toUrn\"O\n" +
+	"\x1cGetEntityNeighborhoodRequest\x12\x19\n" +
+	"\broot_urn\x18\x01 \x01(\tR\arootUrn\x12\x14\n" +
+	"\x05limit\x18\x02 \x01(\rR\x05limit\"\xbc\x01\n" +
+	"\x1dGetEntityNeighborhoodResponse\x12+\n" +
+	"\x04root\x18\x01 \x01(\v2\x17.cerebro.v1.GraphEntityR\x04root\x125\n" +
+	"\tneighbors\x18\x02 \x03(\v2\x17.cerebro.v1.GraphEntityR\tneighbors\x127\n" +
+	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\x8a\b\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -1625,7 +1877,8 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x10PutSourceRuntime\x12#.cerebro.v1.PutSourceRuntimeRequest\x1a$.cerebro.v1.PutSourceRuntimeResponse\x12]\n" +
 	"\x10GetSourceRuntime\x12#.cerebro.v1.GetSourceRuntimeRequest\x1a$.cerebro.v1.GetSourceRuntimeResponse\x12`\n" +
 	"\x11SyncSourceRuntime\x12$.cerebro.v1.SyncSourceRuntimeRequest\x1a%.cerebro.v1.SyncSourceRuntimeResponse\x12\x84\x01\n" +
-	"\x1dEvaluateSourceRuntimeFindings\x120.cerebro.v1.EvaluateSourceRuntimeFindingsRequest\x1a1.cerebro.v1.EvaluateSourceRuntimeFindingsResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
+	"\x1dEvaluateSourceRuntimeFindings\x120.cerebro.v1.EvaluateSourceRuntimeFindingsRequest\x1a1.cerebro.v1.EvaluateSourceRuntimeFindingsResponse\x12l\n" +
+	"\x15GetEntityNeighborhood\x12(.cerebro.v1.GetEntityNeighborhoodRequest\x1a).cerebro.v1.GetEntityNeighborhoodResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
 
 var (
 	file_cerebro_v1_bootstrap_proto_rawDescOnce sync.Once
@@ -1639,7 +1892,7 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*GetVersionRequest)(nil),                     // 0: cerebro.v1.GetVersionRequest
 	(*GetVersionResponse)(nil),                    // 1: cerebro.v1.GetVersionResponse
@@ -1665,76 +1918,85 @@ var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*Finding)(nil),                               // 21: cerebro.v1.Finding
 	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 22: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
 	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 23: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	nil,                           // 24: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                           // 25: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                           // 26: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                           // 27: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                           // 28: cerebro.v1.Finding.AttributesEntry
-	(*timestamppb.Timestamp)(nil), // 29: google.protobuf.Timestamp
-	(*SourceSpec)(nil),            // 30: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),          // 31: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),         // 32: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),        // 33: google.protobuf.Value
-	(*SourceCheckpoint)(nil),      // 34: cerebro.v1.SourceCheckpoint
-	(*RuleSpec)(nil),              // 35: cerebro.v1.RuleSpec
+	(*GraphEntity)(nil),                           // 24: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                         // 25: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),          // 26: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),         // 27: cerebro.v1.GetEntityNeighborhoodResponse
+	nil,                                           // 28: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                           // 29: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                           // 30: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                           // 31: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                           // 32: cerebro.v1.Finding.AttributesEntry
+	(*timestamppb.Timestamp)(nil),                 // 33: google.protobuf.Timestamp
+	(*SourceSpec)(nil),                            // 34: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                          // 35: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                         // 36: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                        // 37: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                      // 38: cerebro.v1.SourceCheckpoint
+	(*RuleSpec)(nil),                              // 39: cerebro.v1.RuleSpec
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	29, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	33, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
-	30, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	24, // 3: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	30, // 4: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	25, // 5: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	30, // 6: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	26, // 7: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	31, // 8: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	32, // 9: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	33, // 10: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	30, // 11: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	32, // 12: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	34, // 13: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	31, // 14: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	34, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	28, // 3: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	34, // 4: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	29, // 5: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	34, // 6: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	30, // 7: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	35, // 8: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	36, // 9: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	37, // 10: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	34, // 11: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	36, // 12: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	38, // 13: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	35, // 14: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
 	12, // 15: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	27, // 16: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	34, // 17: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	31, // 18: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	29, // 19: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	31, // 16: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	38, // 17: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	35, // 18: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	33, // 19: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
 	14, // 20: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
 	14, // 21: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	14, // 22: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	14, // 23: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	30, // 24: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	28, // 25: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	29, // 26: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	29, // 27: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	34, // 24: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	32, // 25: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	33, // 26: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	33, // 27: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
 	14, // 28: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	35, // 29: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	39, // 29: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
 	21, // 30: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	0,  // 31: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2,  // 32: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	5,  // 33: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	7,  // 34: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	9,  // 35: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	11, // 36: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	15, // 37: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	17, // 38: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	19, // 39: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	22, // 40: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	1,  // 41: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4,  // 42: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	6,  // 43: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	8,  // 44: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	10, // 45: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	13, // 46: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	16, // 47: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	18, // 48: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	20, // 49: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	23, // 50: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	41, // [41:51] is the sub-list for method output_type
-	31, // [31:41] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	24, // 31: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	24, // 32: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	25, // 33: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	0,  // 34: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 35: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	5,  // 36: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	7,  // 37: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	9,  // 38: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	11, // 39: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	15, // 40: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	17, // 41: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	19, // 42: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	22, // 43: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	26, // 44: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	1,  // 45: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 46: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	6,  // 47: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	8,  // 48: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	10, // 49: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	13, // 50: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	16, // 51: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	18, // 52: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	20, // 53: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	23, // 54: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	27, // 55: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	45, // [45:56] is the sub-list for method output_type
+	34, // [34:45] is the sub-list for method input_type
+	34, // [34:34] is the sub-list for extension type_name
+	34, // [34:34] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -1750,7 +2012,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   29,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -63,6 +63,9 @@ const (
 	// BootstrapServiceEvaluateSourceRuntimeFindingsProcedure is the fully-qualified name of the
 	// BootstrapService's EvaluateSourceRuntimeFindings RPC.
 	BootstrapServiceEvaluateSourceRuntimeFindingsProcedure = "/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindings"
+	// BootstrapServiceGetEntityNeighborhoodProcedure is the fully-qualified name of the
+	// BootstrapService's GetEntityNeighborhood RPC.
+	BootstrapServiceGetEntityNeighborhoodProcedure = "/cerebro.v1.BootstrapService/GetEntityNeighborhood"
 )
 
 // BootstrapServiceClient is a client for the cerebro.v1.BootstrapService service.
@@ -77,6 +80,7 @@ type BootstrapServiceClient interface {
 	GetSourceRuntime(context.Context, *connect.Request[v1.GetSourceRuntimeRequest]) (*connect.Response[v1.GetSourceRuntimeResponse], error)
 	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
+	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
 
 // NewBootstrapServiceClient constructs a client for the cerebro.v1.BootstrapService service. By
@@ -150,6 +154,12 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("EvaluateSourceRuntimeFindings")),
 			connect.WithClientOptions(opts...),
 		),
+		getEntityNeighborhood: connect.NewClient[v1.GetEntityNeighborhoodRequest, v1.GetEntityNeighborhoodResponse](
+			httpClient,
+			baseURL+BootstrapServiceGetEntityNeighborhoodProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("GetEntityNeighborhood")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -165,6 +175,7 @@ type bootstrapServiceClient struct {
 	getSourceRuntime              *connect.Client[v1.GetSourceRuntimeRequest, v1.GetSourceRuntimeResponse]
 	syncSourceRuntime             *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
 	evaluateSourceRuntimeFindings *connect.Client[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse]
+	getEntityNeighborhood         *connect.Client[v1.GetEntityNeighborhoodRequest, v1.GetEntityNeighborhoodResponse]
 }
 
 // GetVersion calls cerebro.v1.BootstrapService.GetVersion.
@@ -217,6 +228,11 @@ func (c *bootstrapServiceClient) EvaluateSourceRuntimeFindings(ctx context.Conte
 	return c.evaluateSourceRuntimeFindings.CallUnary(ctx, req)
 }
 
+// GetEntityNeighborhood calls cerebro.v1.BootstrapService.GetEntityNeighborhood.
+func (c *bootstrapServiceClient) GetEntityNeighborhood(ctx context.Context, req *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error) {
+	return c.getEntityNeighborhood.CallUnary(ctx, req)
+}
+
 // BootstrapServiceHandler is an implementation of the cerebro.v1.BootstrapService service.
 type BootstrapServiceHandler interface {
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
@@ -229,6 +245,7 @@ type BootstrapServiceHandler interface {
 	GetSourceRuntime(context.Context, *connect.Request[v1.GetSourceRuntimeRequest]) (*connect.Response[v1.GetSourceRuntimeResponse], error)
 	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
+	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
 
 // NewBootstrapServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -298,6 +315,12 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		connect.WithSchema(bootstrapServiceMethods.ByName("EvaluateSourceRuntimeFindings")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bootstrapServiceGetEntityNeighborhoodHandler := connect.NewUnaryHandler(
+		BootstrapServiceGetEntityNeighborhoodProcedure,
+		svc.GetEntityNeighborhood,
+		connect.WithSchema(bootstrapServiceMethods.ByName("GetEntityNeighborhood")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/cerebro.v1.BootstrapService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case BootstrapServiceGetVersionProcedure:
@@ -320,6 +343,8 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceSyncSourceRuntimeHandler.ServeHTTP(w, r)
 		case BootstrapServiceEvaluateSourceRuntimeFindingsProcedure:
 			bootstrapServiceEvaluateSourceRuntimeFindingsHandler.ServeHTTP(w, r)
+		case BootstrapServiceGetEntityNeighborhoodProcedure:
+			bootstrapServiceGetEntityNeighborhoodHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -367,4 +392,8 @@ func (UnimplementedBootstrapServiceHandler) SyncSourceRuntime(context.Context, *
 
 func (UnimplementedBootstrapServiceHandler) EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.GetEntityNeighborhood is not implemented"))
 }

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -147,7 +147,7 @@ func (a *App) handleGetEntityNeighborhood(w http.ResponseWriter, r *http.Request
 	if limit := r.URL.Query().Get("limit"); limit != "" {
 		body := []byte(`{"limit":` + limit + `}`)
 		if err := protojson.Unmarshal(body, request); err != nil {
-			writeGraphQueryError(w, err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"reflect"
 	"time"
 
 	"connectrpc.com/connect"
@@ -437,8 +438,10 @@ func writeFindingError(w http.ResponseWriter, err error) {
 }
 
 func writeGraphQueryError(w http.ResponseWriter, err error) {
-	statusCode := http.StatusBadRequest
+	statusCode := http.StatusInternalServerError
 	switch {
+	case errors.Is(err, graphquery.ErrInvalidArgument):
+		statusCode = http.StatusBadRequest
 	case errors.Is(err, ports.ErrGraphEntityNotFound):
 		statusCode = http.StatusNotFound
 	case errors.Is(err, graphquery.ErrRuntimeUnavailable):
@@ -497,10 +500,23 @@ func sourceProjector(stateStore ports.StateStore, graphStore ports.GraphStore) p
 
 func graphQueryStore(store ports.GraphStore) ports.GraphQueryStore {
 	queryStore, ok := store.(ports.GraphQueryStore)
-	if !ok {
+	if !ok || isNilInterface(queryStore) {
 		return nil
 	}
 	return queryStore
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
 }
 
 func findingStore(store ports.StateStore) ports.FindingStore {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -335,9 +335,26 @@ func (s *bootstrapService) GetEntityNeighborhood(ctx context.Context, req *conne
 		Limit:   req.Msg.GetLimit(),
 	})
 	if err != nil {
-		return nil, err
+		return nil, graphQueryConnectError(err)
 	}
 	return connect.NewResponse(graphNeighborhoodResponse(response)), nil
+}
+
+func graphQueryConnectError(err error) error {
+	switch {
+	case errors.Is(err, ports.ErrGraphEntityNotFound):
+		return connect.NewError(connect.CodeNotFound, err)
+	case errors.Is(err, graphquery.ErrInvalidArgument):
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	case errors.Is(err, graphquery.ErrRuntimeUnavailable):
+		return connect.NewError(connect.CodeUnavailable, err)
+	case errors.Is(err, context.Canceled):
+		return connect.NewError(connect.CodeCanceled, err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return connect.NewError(connect.CodeDeadlineExceeded, err)
+	default:
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
+	}
 }
 
 func healthResponse(ctx context.Context, deps Dependencies) *cerebrov1.CheckHealthResponse {
@@ -467,7 +484,7 @@ func readProtoJSON(r *http.Request, message proto.Message) error {
 
 func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {
 	runtimeStore, ok := store.(ports.SourceRuntimeStore)
-	if !ok {
+	if !ok || isNilInterface(runtimeStore) {
 		return nil
 	}
 	return runtimeStore
@@ -475,7 +492,7 @@ func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {
 
 func sourceProjectionStateStore(store ports.StateStore) ports.ProjectionStateStore {
 	projectionStore, ok := store.(ports.ProjectionStateStore)
-	if !ok {
+	if !ok || isNilInterface(projectionStore) {
 		return nil
 	}
 	return projectionStore
@@ -483,7 +500,7 @@ func sourceProjectionStateStore(store ports.StateStore) ports.ProjectionStateSto
 
 func sourceProjectionGraphStore(store ports.GraphStore) ports.ProjectionGraphStore {
 	projectionStore, ok := store.(ports.ProjectionGraphStore)
-	if !ok {
+	if !ok || isNilInterface(projectionStore) {
 		return nil
 	}
 	return projectionStore
@@ -521,7 +538,7 @@ func isNilInterface(value any) bool {
 
 func findingStore(store ports.StateStore) ports.FindingStore {
 	findingStore, ok := store.(ports.FindingStore)
-	if !ok {
+	if !ok || isNilInterface(findingStore) {
 		return nil
 	}
 	return findingStore
@@ -529,7 +546,7 @@ func findingStore(store ports.StateStore) ports.FindingStore {
 
 func eventReplayer(appendLog ports.AppendLog) ports.EventReplayer {
 	replayer, ok := appendLog.(ports.EventReplayer)
-	if !ok {
+	if !ok || isNilInterface(replayer) {
 		return nil
 	}
 	return replayer

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -644,7 +644,7 @@ type pinger interface {
 
 func componentStatus(ctx context.Context, name string, dependency pinger) *cerebrov1.ComponentStatus {
 	status := &cerebrov1.ComponentStatus{Name: name, Status: "unconfigured"}
-	if dependency == nil {
+	if dependency == nil || isNilInterface(dependency) {
 		return status
 	}
 	if err := dependency.Ping(ctx); err != nil {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceops"
@@ -60,6 +61,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("GET /sources/{sourceID}/check", app.handleCheckSource)
 	mux.HandleFunc("GET /sources/{sourceID}/discover", app.handleDiscoverSource)
 	mux.HandleFunc("GET /sources/{sourceID}/read", app.handleReadSource)
+	mux.HandleFunc("GET /graph/neighborhood", app.handleGetEntityNeighborhood)
 	mux.HandleFunc("PUT /source-runtimes/{runtimeID}", app.handlePutSourceRuntime)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}", app.handleGetSourceRuntime)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/sync", app.handleSyncSourceRuntime)
@@ -137,6 +139,27 @@ func (a *App) handleReadSource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleGetEntityNeighborhood(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.GetEntityNeighborhoodRequest{}
+	if limit := r.URL.Query().Get("limit"); limit != "" {
+		body := []byte(`{"limit":` + limit + `}`)
+		if err := protojson.Unmarshal(body, request); err != nil {
+			writeGraphQueryError(w, err)
+			return
+		}
+	}
+	request.RootUrn = r.URL.Query().Get("root_urn")
+	response, err := a.graphQueryService().GetEntityNeighborhood(r.Context(), graphquery.NeighborhoodRequest{
+		RootURN: request.GetRootUrn(),
+		Limit:   request.GetLimit(),
+	})
+	if err != nil {
+		writeGraphQueryError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, graphNeighborhoodResponse(response))
 }
 
 func (a *App) handlePutSourceRuntime(w http.ResponseWriter, r *http.Request) {
@@ -303,6 +326,19 @@ func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, re
 	return connect.NewResponse(findingResponse(response)), nil
 }
 
+func (s *bootstrapService) GetEntityNeighborhood(ctx context.Context, req *connect.Request[cerebrov1.GetEntityNeighborhoodRequest]) (*connect.Response[cerebrov1.GetEntityNeighborhoodResponse], error) {
+	response, err := graphquery.New(
+		graphQueryStore(s.deps.GraphStore),
+	).GetEntityNeighborhood(ctx, graphquery.NeighborhoodRequest{
+		RootURN: req.Msg.GetRootUrn(),
+		Limit:   req.Msg.GetLimit(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(graphNeighborhoodResponse(response)), nil
+}
+
 func healthResponse(ctx context.Context, deps Dependencies) *cerebrov1.CheckHealthResponse {
 	components := []*cerebrov1.ComponentStatus{
 		componentStatus(ctx, "append_log", deps.AppendLog),
@@ -355,6 +391,10 @@ func (a *App) findingService() *findings.Service {
 	)
 }
 
+func (a *App) graphQueryService() *graphquery.Service {
+	return graphquery.New(graphQueryStore(a.deps.GraphStore))
+}
+
 func sourceConfigFromQuery(r *http.Request) map[string]string {
 	values := make(map[string]string)
 	for key, rawValues := range r.URL.Query() {
@@ -391,6 +431,17 @@ func writeFindingError(w http.ResponseWriter, err error) {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
 		statusCode = http.StatusNotFound
 	case errors.Is(err, findings.ErrRuntimeUnavailable):
+		statusCode = http.StatusServiceUnavailable
+	}
+	http.Error(w, err.Error(), statusCode)
+}
+
+func writeGraphQueryError(w http.ResponseWriter, err error) {
+	statusCode := http.StatusBadRequest
+	switch {
+	case errors.Is(err, ports.ErrGraphEntityNotFound):
+		statusCode = http.StatusNotFound
+	case errors.Is(err, graphquery.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable
 	}
 	http.Error(w, err.Error(), statusCode)
@@ -442,6 +493,14 @@ func sourceProjector(stateStore ports.StateStore, graphStore ports.GraphStore) p
 		return nil
 	}
 	return sourceprojection.New(state, graph)
+}
+
+func graphQueryStore(store ports.GraphStore) ports.GraphQueryStore {
+	queryStore, ok := store.(ports.GraphQueryStore)
+	if !ok {
+		return nil
+	}
+	return queryStore
 }
 
 func findingStore(store ports.StateStore) ports.FindingStore {
@@ -504,6 +563,46 @@ func findingMessage(finding *ports.FindingRecord) *cerebrov1.Finding {
 		message.LastObservedAt = timestamppb.New(finding.LastObservedAt)
 	}
 	return message
+}
+
+func graphNeighborhoodResponse(neighborhood *ports.EntityNeighborhood) *cerebrov1.GetEntityNeighborhoodResponse {
+	if neighborhood == nil {
+		return &cerebrov1.GetEntityNeighborhoodResponse{}
+	}
+	response := &cerebrov1.GetEntityNeighborhoodResponse{
+		Root:      graphEntityMessage(neighborhood.Root),
+		Neighbors: make([]*cerebrov1.GraphEntity, 0, len(neighborhood.Neighbors)),
+		Relations: make([]*cerebrov1.GraphRelation, 0, len(neighborhood.Relations)),
+	}
+	for _, neighbor := range neighborhood.Neighbors {
+		response.Neighbors = append(response.Neighbors, graphEntityMessage(neighbor))
+	}
+	for _, relation := range neighborhood.Relations {
+		response.Relations = append(response.Relations, graphRelationMessage(relation))
+	}
+	return response
+}
+
+func graphEntityMessage(node *ports.NeighborhoodNode) *cerebrov1.GraphEntity {
+	if node == nil {
+		return nil
+	}
+	return &cerebrov1.GraphEntity{
+		Urn:        node.URN,
+		EntityType: node.EntityType,
+		Label:      node.Label,
+	}
+}
+
+func graphRelationMessage(relation *ports.NeighborhoodRelation) *cerebrov1.GraphRelation {
+	if relation == nil {
+		return nil
+	}
+	return &cerebrov1.GraphRelation{
+		FromUrn:  relation.FromURN,
+		Relation: relation.Relation,
+		ToUrn:    relation.ToURN,
+	}
 }
 
 type pinger interface {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -153,9 +153,12 @@ func (s *stubRuntimeStore) UpsertFinding(_ context.Context, finding *ports.Findi
 }
 
 type stubGraphStore struct {
-	err      error
-	entities map[string]*ports.ProjectedEntity
-	links    map[string]*ports.ProjectedLink
+	err                 error
+	entities            map[string]*ports.ProjectedEntity
+	links               map[string]*ports.ProjectedLink
+	neighborhood        *ports.EntityNeighborhood
+	neighborhoodRootURN string
+	neighborhoodLimit   int
 }
 
 func (s *stubGraphStore) Ping(context.Context) error {
@@ -188,6 +191,18 @@ func (s *stubGraphStore) UpsertProjectedLink(_ context.Context, link *ports.Proj
 	}
 	s.links[projectedLinkKey(link)] = cloneProjectedLink(link)
 	return nil
+}
+
+func (s *stubGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	s.neighborhoodRootURN = rootURN
+	s.neighborhoodLimit = limit
+	if s.neighborhood == nil {
+		return nil, ports.ErrGraphEntityNotFound
+	}
+	return cloneNeighborhood(s.neighborhood), nil
 }
 
 func TestBootstrapEndpoints(t *testing.T) {
@@ -741,6 +756,86 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 }
 
+func TestGraphNeighborhoodEndpoints(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	graphStore := &stubGraphStore{
+		neighborhood: &ports.EntityNeighborhood{
+			Root: &ports.NeighborhoodNode{
+				URN:        "urn:cerebro:writer:github_pull_request:writer/cerebro#447",
+				EntityType: "github.pull_request",
+				Label:      "writer/cerebro#447",
+			},
+			Neighbors: []*ports.NeighborhoodNode{
+				{URN: "urn:cerebro:writer:github_repo:writer/cerebro", EntityType: "github.repo", Label: "writer/cerebro"},
+				{URN: "urn:cerebro:writer:github_user:alice", EntityType: "github.user", Label: "Alice"},
+			},
+			Relations: []*ports.NeighborhoodRelation{
+				{FromURN: "urn:cerebro:writer:github_user:alice", Relation: "authored", ToURN: "urn:cerebro:writer:github_pull_request:writer/cerebro#447"},
+				{FromURN: "urn:cerebro:writer:github_pull_request:writer/cerebro#447", Relation: "belongs_to", ToURN: "urn:cerebro:writer:github_repo:writer/cerebro"},
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  &recordingAppendLog{},
+		StateStore: &stubRuntimeStore{},
+		GraphStore: graphStore,
+	}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/graph/neighborhood?root_urn=urn:cerebro:writer:github_pull_request:writer/cerebro%23447&limit=5")
+	if err != nil {
+		t.Fatalf("GET /graph/neighborhood error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /graph/neighborhood response body: %v", closeErr)
+		}
+	}()
+	var payload map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /graph/neighborhood response: %v", err)
+	}
+	rootPayload, ok := payload["root"].(map[string]any)
+	if !ok {
+		t.Fatalf("graph root payload = %#v, want object", payload["root"])
+	}
+	if got := rootPayload["entity_type"]; got != "github.pull_request" {
+		t.Fatalf("graph root entity_type = %#v, want github.pull_request", got)
+	}
+	neighborsPayload, ok := payload["neighbors"].([]any)
+	if !ok || len(neighborsPayload) != 2 {
+		t.Fatalf("graph neighbors payload = %#v, want 2 entries", payload["neighbors"])
+	}
+	if graphStore.neighborhoodRootURN != "urn:cerebro:writer:github_pull_request:writer/cerebro#447" {
+		t.Fatalf("graph neighborhood root urn = %q, want pull request urn", graphStore.neighborhoodRootURN)
+	}
+	if graphStore.neighborhoodLimit != 5 {
+		t.Fatalf("graph neighborhood limit = %d, want 5", graphStore.neighborhoodLimit)
+	}
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	neighborhoodResp, err := client.GetEntityNeighborhood(context.Background(), connect.NewRequest(&cerebrov1.GetEntityNeighborhoodRequest{
+		RootUrn: "urn:cerebro:writer:github_pull_request:writer/cerebro#447",
+		Limit:   2,
+	}))
+	if err != nil {
+		t.Fatalf("GetEntityNeighborhood() error = %v", err)
+	}
+	if got := neighborhoodResp.Msg.GetRoot().GetUrn(); got != "urn:cerebro:writer:github_pull_request:writer/cerebro#447" {
+		t.Fatalf("GetEntityNeighborhood root urn = %q, want pull request urn", got)
+	}
+	if len(neighborhoodResp.Msg.GetNeighbors()) != 2 {
+		t.Fatalf("len(GetEntityNeighborhood.Neighbors) = %d, want 2", len(neighborhoodResp.Msg.GetNeighbors()))
+	}
+	if len(neighborhoodResp.Msg.GetRelations()) != 2 {
+		t.Fatalf("len(GetEntityNeighborhood.Relations) = %d, want 2", len(neighborhoodResp.Msg.GetRelations()))
+	}
+}
+
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.NewFixture()
 	if err != nil {
@@ -816,6 +911,46 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 		Attributes:      attributes,
 		FirstObservedAt: finding.FirstObservedAt,
 		LastObservedAt:  finding.LastObservedAt,
+	}
+}
+
+func cloneNeighborhood(neighborhood *ports.EntityNeighborhood) *ports.EntityNeighborhood {
+	if neighborhood == nil {
+		return nil
+	}
+	cloned := &ports.EntityNeighborhood{
+		Root:      cloneNeighborhoodNode(neighborhood.Root),
+		Neighbors: make([]*ports.NeighborhoodNode, 0, len(neighborhood.Neighbors)),
+		Relations: make([]*ports.NeighborhoodRelation, 0, len(neighborhood.Relations)),
+	}
+	for _, neighbor := range neighborhood.Neighbors {
+		cloned.Neighbors = append(cloned.Neighbors, cloneNeighborhoodNode(neighbor))
+	}
+	for _, relation := range neighborhood.Relations {
+		cloned.Relations = append(cloned.Relations, cloneNeighborhoodRelation(relation))
+	}
+	return cloned
+}
+
+func cloneNeighborhoodNode(node *ports.NeighborhoodNode) *ports.NeighborhoodNode {
+	if node == nil {
+		return nil
+	}
+	return &ports.NeighborhoodNode{
+		URN:        node.URN,
+		EntityType: node.EntityType,
+		Label:      node.Label,
+	}
+}
+
+func cloneNeighborhoodRelation(relation *ports.NeighborhoodRelation) *ports.NeighborhoodRelation {
+	if relation == nil {
+		return nil
+	}
+	return &ports.NeighborhoodRelation{
+		FromURN:  relation.FromURN,
+		Relation: relation.Relation,
+		ToURN:    relation.ToURN,
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -836,6 +836,21 @@ func TestGraphNeighborhoodEndpoints(t *testing.T) {
 	}
 }
 
+func TestWriteGraphQueryErrorMapsInternalFailuresToServerError(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writeGraphQueryError(recorder, errors.New("kuzu query failed"))
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("graph query error status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestGraphQueryStoreRejectsTypedNilStore(t *testing.T) {
+	var store *stubGraphStore
+	if got := graphQueryStore(store); got != nil {
+		t.Fatalf("graphQueryStore(typed nil) = %#v, want nil", got)
+	}
+}
+
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.NewFixture()
 	if err != nil {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -816,6 +816,18 @@ func TestGraphNeighborhoodEndpoints(t *testing.T) {
 	if graphStore.neighborhoodLimit != 5 {
 		t.Fatalf("graph neighborhood limit = %d, want 5", graphStore.neighborhoodLimit)
 	}
+	invalidLimitResp, err := server.Client().Get(server.URL + "/graph/neighborhood?root_urn=urn:cerebro:writer:github_pull_request:writer/cerebro%23447&limit=abc")
+	if err != nil {
+		t.Fatalf("GET /graph/neighborhood invalid limit error = %v", err)
+	}
+	defer func() {
+		if closeErr := invalidLimitResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /graph/neighborhood invalid limit response body: %v", closeErr)
+		}
+	}()
+	if got := invalidLimitResp.StatusCode; got != http.StatusBadRequest {
+		t.Fatalf("invalid limit status = %d, want %d", got, http.StatusBadRequest)
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	neighborhoodResp, err := client.GetEntityNeighborhood(context.Background(), connect.NewRequest(&cerebrov1.GetEntityNeighborhoodRequest{

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -464,6 +464,30 @@ func TestBootstrapEndpoints(t *testing.T) {
 	}
 }
 
+func TestBootstrapHealthHandlesTypedNilDependencies(t *testing.T) {
+	var typedNilStateStore *stubRuntimeStore
+	var typedNilGraphStore *stubGraphStore
+	var typedNilAppendLog *recordingAppendLog
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  typedNilAppendLog,
+		StateStore: typedNilStateStore,
+		GraphStore: typedNilGraphStore,
+	}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	healthResp, err := client.CheckHealth(context.Background(), connect.NewRequest(&cerebrov1.CheckHealthRequest{}))
+	if err != nil {
+		t.Fatalf("CheckHealth() error = %v", err)
+	}
+	for _, component := range healthResp.Msg.Components {
+		if got := component.Status; got != "unconfigured" {
+			t.Fatalf("CheckHealth component %q status = %q, want %q", component.Name, got, "unconfigured")
+		}
+	}
+}
+
 func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
 		AppendLog:  stubAppendLog{},

--- a/internal/graphquery/service.go
+++ b/internal/graphquery/service.go
@@ -3,6 +3,7 @@ package graphquery
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -15,6 +16,9 @@ const (
 
 // ErrRuntimeUnavailable indicates that the graph query boundary is unavailable.
 var ErrRuntimeUnavailable = errors.New("graph query runtime is unavailable")
+
+// ErrInvalidArgument indicates that the graph query request is invalid.
+var ErrInvalidArgument = errors.New("graph query invalid argument")
 
 // Service exposes the first bounded graph neighborhood query.
 type Service struct {
@@ -39,7 +43,7 @@ func (s *Service) GetEntityNeighborhood(ctx context.Context, request Neighborhoo
 	}
 	rootURN := strings.TrimSpace(request.RootURN)
 	if rootURN == "" {
-		return nil, errors.New("root urn is required")
+		return nil, fmt.Errorf("%w: root urn is required", ErrInvalidArgument)
 	}
 	return s.store.GetEntityNeighborhood(ctx, rootURN, normalizeNeighborhoodLimit(request.Limit))
 }

--- a/internal/graphquery/service.go
+++ b/internal/graphquery/service.go
@@ -1,0 +1,56 @@
+package graphquery
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	defaultNeighborhoodLimit = 10
+	maxNeighborhoodLimit     = 50
+)
+
+// ErrRuntimeUnavailable indicates that the graph query boundary is unavailable.
+var ErrRuntimeUnavailable = errors.New("graph query runtime is unavailable")
+
+// Service exposes the first bounded graph neighborhood query.
+type Service struct {
+	store ports.GraphQueryStore
+}
+
+// NeighborhoodRequest scopes one bounded root-centered graph query.
+type NeighborhoodRequest struct {
+	RootURN string
+	Limit   uint32
+}
+
+// New constructs a bounded graph neighborhood service.
+func New(store ports.GraphQueryStore) *Service {
+	return &Service{store: store}
+}
+
+// GetEntityNeighborhood loads one bounded root-centered graph neighborhood.
+func (s *Service) GetEntityNeighborhood(ctx context.Context, request NeighborhoodRequest) (*ports.EntityNeighborhood, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	rootURN := strings.TrimSpace(request.RootURN)
+	if rootURN == "" {
+		return nil, errors.New("root urn is required")
+	}
+	return s.store.GetEntityNeighborhood(ctx, rootURN, normalizeNeighborhoodLimit(request.Limit))
+}
+
+func normalizeNeighborhoodLimit(limit uint32) int {
+	switch {
+	case limit == 0:
+		return defaultNeighborhoodLimit
+	case limit > maxNeighborhoodLimit:
+		return maxNeighborhoodLimit
+	default:
+		return int(limit)
+	}
+}

--- a/internal/graphquery/service_test.go
+++ b/internal/graphquery/service_test.go
@@ -1,0 +1,56 @@
+package graphquery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type stubStore struct {
+	rootURN      string
+	limit        int
+	neighborhood *ports.EntityNeighborhood
+}
+
+func (s *stubStore) Ping(context.Context) error { return nil }
+
+func (s *stubStore) GetEntityNeighborhood(_ context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
+	s.rootURN = rootURN
+	s.limit = limit
+	return s.neighborhood, nil
+}
+
+func TestGetEntityNeighborhoodNormalizesLimit(t *testing.T) {
+	store := &stubStore{
+		neighborhood: &ports.EntityNeighborhood{
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:github_user:alice", EntityType: "github.user", Label: "Alice"},
+		},
+	}
+	service := New(store)
+
+	result, err := service.GetEntityNeighborhood(context.Background(), NeighborhoodRequest{
+		RootURN: "urn:cerebro:writer:github_user:alice",
+		Limit:   99,
+	})
+	if err != nil {
+		t.Fatalf("GetEntityNeighborhood() error = %v", err)
+	}
+	if result.Root == nil || result.Root.URN != "urn:cerebro:writer:github_user:alice" {
+		t.Fatalf("Root = %#v, want alice root", result.Root)
+	}
+	if store.rootURN != "urn:cerebro:writer:github_user:alice" {
+		t.Fatalf("store root urn = %q, want alice urn", store.rootURN)
+	}
+	if store.limit != maxNeighborhoodLimit {
+		t.Fatalf("store limit = %d, want %d", store.limit, maxNeighborhoodLimit)
+	}
+}
+
+func TestGetEntityNeighborhoodRequiresAvailableStore(t *testing.T) {
+	service := New(nil)
+	if _, err := service.GetEntityNeighborhood(context.Background(), NeighborhoodRequest{RootURN: "urn:cerebro:writer:github_user:alice"}); !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("GetEntityNeighborhood() error = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}

--- a/internal/graphstore/kuzu/query.go
+++ b/internal/graphstore/kuzu/query.go
@@ -92,8 +92,8 @@ func (s *Store) collectNeighborhoodRows(ctx context.Context, query string, remai
 		}
 	}()
 	for rows.Next() {
-		var neighbor ports.NeighborhoodNode
-		var relation ports.NeighborhoodRelation
+		neighbor := &ports.NeighborhoodNode{}
+		relation := &ports.NeighborhoodRelation{}
 		if err := rows.Scan(
 			&neighbor.URN,
 			&neighbor.EntityType,
@@ -104,8 +104,8 @@ func (s *Store) collectNeighborhoodRows(ctx context.Context, query string, remai
 		); err != nil {
 			return remaining, fmt.Errorf("scan graph neighborhood row: %w", err)
 		}
-		neighbors[neighbor.URN] = &neighbor
-		relations[relation.FromURN+"|"+relation.Relation+"|"+relation.ToURN] = &relation
+		neighbors[neighbor.URN] = neighbor
+		relations[relation.FromURN+"|"+relation.Relation+"|"+relation.ToURN] = relation
 		remaining--
 		if remaining == 0 {
 			break

--- a/internal/graphstore/kuzu/query.go
+++ b/internal/graphstore/kuzu/query.go
@@ -1,0 +1,156 @@
+package kuzu
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+// GetEntityNeighborhood returns one bounded root-centered graph neighborhood.
+func (s *Store) GetEntityNeighborhood(ctx context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
+	normalizedRootURN := strings.TrimSpace(rootURN)
+	if normalizedRootURN == "" {
+		return nil, errors.New("root urn is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("kuzu is not configured")
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !tables["entity"] {
+		return nil, fmt.Errorf("%w: %s", ports.ErrGraphEntityNotFound, normalizedRootURN)
+	}
+	root, err := s.lookupNeighborhoodNode(ctx, normalizedRootURN)
+	if err != nil {
+		return nil, err
+	}
+	neighborhood := &ports.EntityNeighborhood{
+		Root:      root,
+		Neighbors: []*ports.NeighborhoodNode{},
+		Relations: []*ports.NeighborhoodRelation{},
+	}
+	if !tables["relation"] || limit <= 0 {
+		return neighborhood, nil
+	}
+	neighbors := make(map[string]*ports.NeighborhoodNode)
+	relations := make(map[string]*ports.NeighborhoodRelation)
+	remaining, err := s.collectNeighborhoodRows(ctx, fmt.Sprintf(
+		"MATCH (root:entity {urn: %s})-[r:relation]->(neighbor:entity) "+
+			"RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label, root.urn AS from_urn, r.relation AS relation_type, neighbor.urn AS to_urn "+
+			"ORDER BY neighbor.urn, r.relation LIMIT %d",
+		cypherString(normalizedRootURN),
+		limit,
+	), limit, neighbors, relations)
+	if err != nil {
+		return nil, err
+	}
+	if remaining > 0 {
+		if _, err := s.collectNeighborhoodRows(ctx, fmt.Sprintf(
+			"MATCH (neighbor:entity)-[r:relation]->(root:entity {urn: %s}) "+
+				"RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label, neighbor.urn AS from_urn, r.relation AS relation_type, root.urn AS to_urn "+
+				"ORDER BY neighbor.urn, r.relation LIMIT %d",
+			cypherString(normalizedRootURN),
+			remaining,
+		), remaining, neighbors, relations); err != nil {
+			return nil, err
+		}
+	}
+	neighborhood.Neighbors = neighborhoodNodes(neighbors)
+	neighborhood.Relations = neighborhoodRelations(relations)
+	return neighborhood, nil
+}
+
+func (s *Store) lookupNeighborhoodNode(ctx context.Context, rootURN string) (*ports.NeighborhoodNode, error) {
+	node := &ports.NeighborhoodNode{}
+	if err := s.db.QueryRowContext(ctx, fmt.Sprintf(
+		"MATCH (e:entity {urn: %s}) RETURN e.urn, e.entity_type, e.label",
+		cypherString(rootURN),
+	)).Scan(&node.URN, &node.EntityType, &node.Label); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrGraphEntityNotFound, rootURN)
+		}
+		return nil, fmt.Errorf("query graph root %q: %w", rootURN, err)
+	}
+	return node, nil
+}
+
+func (s *Store) collectNeighborhoodRows(ctx context.Context, query string, remaining int, neighbors map[string]*ports.NeighborhoodNode, relations map[string]*ports.NeighborhoodRelation) (_ int, err error) {
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return remaining, fmt.Errorf("query graph neighborhood: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close graph neighborhood rows: %w", closeErr)
+		}
+	}()
+	for rows.Next() {
+		var neighbor ports.NeighborhoodNode
+		var relation ports.NeighborhoodRelation
+		if err := rows.Scan(
+			&neighbor.URN,
+			&neighbor.EntityType,
+			&neighbor.Label,
+			&relation.FromURN,
+			&relation.Relation,
+			&relation.ToURN,
+		); err != nil {
+			return remaining, fmt.Errorf("scan graph neighborhood row: %w", err)
+		}
+		neighbors[neighbor.URN] = &neighbor
+		relations[relation.FromURN+"|"+relation.Relation+"|"+relation.ToURN] = &relation
+		remaining--
+		if remaining == 0 {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return remaining, fmt.Errorf("iterate graph neighborhood rows: %w", err)
+	}
+	return remaining, nil
+}
+
+func neighborhoodNodes(values map[string]*ports.NeighborhoodNode) []*ports.NeighborhoodNode {
+	nodes := make([]*ports.NeighborhoodNode, 0, len(values))
+	for _, node := range values {
+		nodes = append(nodes, node)
+	}
+	slices.SortFunc(nodes, func(left *ports.NeighborhoodNode, right *ports.NeighborhoodNode) int {
+		switch {
+		case left.URN < right.URN:
+			return -1
+		case left.URN > right.URN:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return nodes
+}
+
+func neighborhoodRelations(values map[string]*ports.NeighborhoodRelation) []*ports.NeighborhoodRelation {
+	relations := make([]*ports.NeighborhoodRelation, 0, len(values))
+	for _, relation := range values {
+		relations = append(relations, relation)
+	}
+	slices.SortFunc(relations, func(left *ports.NeighborhoodRelation, right *ports.NeighborhoodRelation) int {
+		leftKey := left.FromURN + "|" + left.Relation + "|" + left.ToURN
+		rightKey := right.FromURN + "|" + right.Relation + "|" + right.ToURN
+		switch {
+		case leftKey < rightKey:
+			return -1
+		case leftKey > rightKey:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return relations
+}

--- a/internal/graphstore/kuzu/query_test.go
+++ b/internal/graphstore/kuzu/query_test.go
@@ -1,0 +1,79 @@
+package kuzu
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestGetEntityNeighborhoodReturnsRootNeighborsAndRelations(t *testing.T) {
+	store := newTestStore(t)
+	projectEvents(t, store, &cerebrov1.EventEnvelope{
+		Id:       "github-pr-447",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.pull_request",
+		Attributes: map[string]string{
+			"author":      "alice",
+			"owner":       "writer",
+			"pull_number": "447",
+			"repository":  "writer/cerebro",
+			"state":       "open",
+		},
+	})
+
+	neighborhood, err := store.GetEntityNeighborhood(context.Background(), "urn:cerebro:writer:github_pull_request:writer/cerebro#447", 2)
+	if err != nil {
+		t.Fatalf("GetEntityNeighborhood() error = %v", err)
+	}
+	if neighborhood.Root == nil || neighborhood.Root.URN != "urn:cerebro:writer:github_pull_request:writer/cerebro#447" {
+		t.Fatalf("Root = %#v, want pull request root", neighborhood.Root)
+	}
+	if len(neighborhood.Neighbors) != 2 {
+		t.Fatalf("len(Neighbors) = %d, want 2", len(neighborhood.Neighbors))
+	}
+	if len(neighborhood.Relations) != 2 {
+		t.Fatalf("len(Relations) = %d, want 2", len(neighborhood.Relations))
+	}
+	if !containsNeighborhoodNode(neighborhood.Neighbors, "urn:cerebro:writer:github_repo:writer/cerebro", "github.repo") {
+		t.Fatalf("Neighbors missing repo: %#v", neighborhood.Neighbors)
+	}
+	if !containsNeighborhoodNode(neighborhood.Neighbors, "urn:cerebro:writer:github_user:alice", "github.user") {
+		t.Fatalf("Neighbors missing author: %#v", neighborhood.Neighbors)
+	}
+	if !containsNeighborhoodRelation(neighborhood.Relations, "urn:cerebro:writer:github_user:alice", "authored", "urn:cerebro:writer:github_pull_request:writer/cerebro#447") {
+		t.Fatalf("Relations missing authored edge: %#v", neighborhood.Relations)
+	}
+	if !containsNeighborhoodRelation(neighborhood.Relations, "urn:cerebro:writer:github_pull_request:writer/cerebro#447", "belongs_to", "urn:cerebro:writer:github_repo:writer/cerebro") {
+		t.Fatalf("Relations missing belongs_to edge: %#v", neighborhood.Relations)
+	}
+}
+
+func TestGetEntityNeighborhoodReturnsNotFoundForMissingRoot(t *testing.T) {
+	store := newTestStore(t)
+	_, err := store.GetEntityNeighborhood(context.Background(), "urn:cerebro:writer:github_user:missing", 5)
+	if !errors.Is(err, ports.ErrGraphEntityNotFound) {
+		t.Fatalf("GetEntityNeighborhood() error = %v, want %v", err, ports.ErrGraphEntityNotFound)
+	}
+}
+
+func containsNeighborhoodNode(nodes []*ports.NeighborhoodNode, urn string, entityType string) bool {
+	for _, node := range nodes {
+		if node != nil && node.URN == urn && node.EntityType == entityType {
+			return true
+		}
+	}
+	return false
+}
+
+func containsNeighborhoodRelation(relations []*ports.NeighborhoodRelation, fromURN string, relation string, toURN string) bool {
+	for _, edge := range relations {
+		if edge != nil && edge.FromURN == fromURN && edge.Relation == relation && edge.ToURN == toURN {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ports/graphquery.go
+++ b/internal/ports/graphquery.go
@@ -1,0 +1,36 @@
+package ports
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrGraphEntityNotFound indicates that the requested graph root entity does not exist.
+var ErrGraphEntityNotFound = errors.New("graph entity not found")
+
+// NeighborhoodNode is the normalized graph node shape returned by bounded neighborhood queries.
+type NeighborhoodNode struct {
+	URN        string
+	EntityType string
+	Label      string
+}
+
+// NeighborhoodRelation is the normalized graph edge shape returned by bounded neighborhood queries.
+type NeighborhoodRelation struct {
+	FromURN  string
+	Relation string
+	ToURN    string
+}
+
+// EntityNeighborhood is one bounded graph neighborhood centered on a root entity.
+type EntityNeighborhood struct {
+	Root      *NeighborhoodNode
+	Neighbors []*NeighborhoodNode
+	Relations []*NeighborhoodRelation
+}
+
+// GraphQueryStore exposes bounded graph neighborhood reads.
+type GraphQueryStore interface {
+	GraphStore
+	GetEntityNeighborhood(context.Context, string, int) (*EntityNeighborhood, error)
+}

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -21,6 +21,7 @@ service BootstrapService {
   rpc GetSourceRuntime(GetSourceRuntimeRequest) returns (GetSourceRuntimeResponse);
   rpc SyncSourceRuntime(SyncSourceRuntimeRequest) returns (SyncSourceRuntimeResponse);
   rpc EvaluateSourceRuntimeFindings(EvaluateSourceRuntimeFindingsRequest) returns (EvaluateSourceRuntimeFindingsResponse);
+  rpc GetEntityNeighborhood(GetEntityNeighborhoodRequest) returns (GetEntityNeighborhoodResponse);
 }
 
 // GetVersionRequest requests static build metadata from the running service.
@@ -185,4 +186,31 @@ message EvaluateSourceRuntimeFindingsResponse {
   uint32 events_evaluated = 3;
   uint32 findings_upserted = 4;
   repeated Finding findings = 5;
+}
+
+// GraphEntity is the normalized graph node view exposed by the first query surface.
+message GraphEntity {
+  string urn = 1;
+  string entity_type = 2;
+  string label = 3;
+}
+
+// GraphRelation is the normalized graph edge view exposed by the first query surface.
+message GraphRelation {
+  string from_urn = 1;
+  string relation = 2;
+  string to_urn = 3;
+}
+
+// GetEntityNeighborhoodRequest requests one bounded graph neighborhood around a root URN.
+message GetEntityNeighborhoodRequest {
+  string root_urn = 1;
+  uint32 limit = 2;
+}
+
+// GetEntityNeighborhoodResponse returns the bounded neighbors and relations around one root URN.
+message GetEntityNeighborhoodResponse {
+  GraphEntity root = 1;
+  repeated GraphEntity neighbors = 2;
+  repeated GraphRelation relations = 3;
 }


### PR DESCRIPTION
## Summary
- add a bounded graph neighborhood query boundary and Kuzu implementation for one root URN
- expose REST and Connect bootstrap endpoints that return normalized graph nodes and relations
- cover the slice with graph query service, Kuzu, and bootstrap tests plus a local neighborhood demo

## Testing
- make verify
- go test ./internal/graphquery ./internal/graphstore/kuzu ./internal/bootstrap
- local Kuzu neighborhood demo for a projected GitHub pull request
