### PR TITLE
feat(report): add durable report run foundation

### DIFF
--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -296,6 +296,499 @@ func (x *CheckHealthResponse) GetComponents() []*ComponentStatus {
 	return nil
 }
 
+// ReportParameter describes one supported report input parameter.
+type ReportParameter struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	Required      bool                   `protobuf:"varint,3,opt,name=required,proto3" json:"required,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReportParameter) Reset() {
+	*x = ReportParameter{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportParameter) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportParameter) ProtoMessage() {}
+
+func (x *ReportParameter) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportParameter.ProtoReflect.Descriptor instead.
+func (*ReportParameter) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ReportParameter) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ReportParameter) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *ReportParameter) GetRequired() bool {
+	if x != nil {
+		return x.Required
+	}
+	return false
+}
+
+// ReportDefinition exposes one built-in durable report contract.
+type ReportDefinition struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Description   string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	Parameters    []*ReportParameter     `protobuf:"bytes,4,rep,name=parameters,proto3" json:"parameters,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReportDefinition) Reset() {
+	*x = ReportDefinition{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportDefinition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportDefinition) ProtoMessage() {}
+
+func (x *ReportDefinition) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportDefinition.ProtoReflect.Descriptor instead.
+func (*ReportDefinition) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ReportDefinition) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ReportDefinition) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ReportDefinition) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *ReportDefinition) GetParameters() []*ReportParameter {
+	if x != nil {
+		return x.Parameters
+	}
+	return nil
+}
+
+// ReportRun is the durable result envelope for one built-in report execution.
+type ReportRun struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	ReportId      string                 `protobuf:"bytes,2,opt,name=report_id,json=reportId,proto3" json:"report_id,omitempty"`
+	Parameters    map[string]string      `protobuf:"bytes,3,rep,name=parameters,proto3" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Status        string                 `protobuf:"bytes,4,opt,name=status,proto3" json:"status,omitempty"`
+	GeneratedAt   *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=generated_at,json=generatedAt,proto3" json:"generated_at,omitempty"`
+	Result        *structpb.Struct       `protobuf:"bytes,6,opt,name=result,proto3" json:"result,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReportRun) Reset() {
+	*x = ReportRun{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportRun) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportRun) ProtoMessage() {}
+
+func (x *ReportRun) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportRun.ProtoReflect.Descriptor instead.
+func (*ReportRun) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ReportRun) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ReportRun) GetReportId() string {
+	if x != nil {
+		return x.ReportId
+	}
+	return ""
+}
+
+func (x *ReportRun) GetParameters() map[string]string {
+	if x != nil {
+		return x.Parameters
+	}
+	return nil
+}
+
+func (x *ReportRun) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ReportRun) GetGeneratedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.GeneratedAt
+	}
+	return nil
+}
+
+func (x *ReportRun) GetResult() *structpb.Struct {
+	if x != nil {
+		return x.Result
+	}
+	return nil
+}
+
+// ListReportDefinitionsRequest requests the built-in report catalog.
+type ListReportDefinitionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListReportDefinitionsRequest) Reset() {
+	*x = ListReportDefinitionsRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListReportDefinitionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListReportDefinitionsRequest) ProtoMessage() {}
+
+func (x *ListReportDefinitionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListReportDefinitionsRequest.ProtoReflect.Descriptor instead.
+func (*ListReportDefinitionsRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{8}
+}
+
+// ListReportDefinitionsResponse returns the built-in report catalog.
+type ListReportDefinitionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Reports       []*ReportDefinition    `protobuf:"bytes,1,rep,name=reports,proto3" json:"reports,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListReportDefinitionsResponse) Reset() {
+	*x = ListReportDefinitionsResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListReportDefinitionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListReportDefinitionsResponse) ProtoMessage() {}
+
+func (x *ListReportDefinitionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListReportDefinitionsResponse.ProtoReflect.Descriptor instead.
+func (*ListReportDefinitionsResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *ListReportDefinitionsResponse) GetReports() []*ReportDefinition {
+	if x != nil {
+		return x.Reports
+	}
+	return nil
+}
+
+// RunReportRequest requests one durable report run.
+type RunReportRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ReportId      string                 `protobuf:"bytes,1,opt,name=report_id,json=reportId,proto3" json:"report_id,omitempty"`
+	Parameters    map[string]string      `protobuf:"bytes,2,rep,name=parameters,proto3" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunReportRequest) Reset() {
+	*x = RunReportRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunReportRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunReportRequest) ProtoMessage() {}
+
+func (x *RunReportRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunReportRequest.ProtoReflect.Descriptor instead.
+func (*RunReportRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *RunReportRequest) GetReportId() string {
+	if x != nil {
+		return x.ReportId
+	}
+	return ""
+}
+
+func (x *RunReportRequest) GetParameters() map[string]string {
+	if x != nil {
+		return x.Parameters
+	}
+	return nil
+}
+
+// RunReportResponse returns the resolved definition plus the persisted run.
+type RunReportResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Report        *ReportDefinition      `protobuf:"bytes,1,opt,name=report,proto3" json:"report,omitempty"`
+	Run           *ReportRun             `protobuf:"bytes,2,opt,name=run,proto3" json:"run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunReportResponse) Reset() {
+	*x = RunReportResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunReportResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunReportResponse) ProtoMessage() {}
+
+func (x *RunReportResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunReportResponse.ProtoReflect.Descriptor instead.
+func (*RunReportResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *RunReportResponse) GetReport() *ReportDefinition {
+	if x != nil {
+		return x.Report
+	}
+	return nil
+}
+
+func (x *RunReportResponse) GetRun() *ReportRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
+// GetReportRunRequest looks up one persisted report run.
+type GetReportRunRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetReportRunRequest) Reset() {
+	*x = GetReportRunRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetReportRunRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetReportRunRequest) ProtoMessage() {}
+
+func (x *GetReportRunRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetReportRunRequest.ProtoReflect.Descriptor instead.
+func (*GetReportRunRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *GetReportRunRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+// GetReportRunResponse returns one persisted report run.
+type GetReportRunResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Run           *ReportRun             `protobuf:"bytes,1,opt,name=run,proto3" json:"run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetReportRunResponse) Reset() {
+	*x = GetReportRunResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetReportRunResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetReportRunResponse) ProtoMessage() {}
+
+func (x *GetReportRunResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetReportRunResponse.ProtoReflect.Descriptor instead.
+func (*GetReportRunResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *GetReportRunResponse) GetRun() *ReportRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
 // ListSourcesRequest requests the currently registered source catalog.
 type ListSourcesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -305,7 +798,7 @@ type ListSourcesRequest struct {
 
 func (x *ListSourcesRequest) Reset() {
 	*x = ListSourcesRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[5]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -317,7 +810,7 @@ func (x *ListSourcesRequest) String() string {
 func (*ListSourcesRequest) ProtoMessage() {}
 
 func (x *ListSourcesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[5]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -330,7 +823,7 @@ func (x *ListSourcesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSourcesRequest.ProtoReflect.Descriptor instead.
 func (*ListSourcesRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{5}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{14}
 }
 
 // ListSourcesResponse returns the registered in-process source specs.
@@ -343,7 +836,7 @@ type ListSourcesResponse struct {
 
 func (x *ListSourcesResponse) Reset() {
 	*x = ListSourcesResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[6]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -355,7 +848,7 @@ func (x *ListSourcesResponse) String() string {
 func (*ListSourcesResponse) ProtoMessage() {}
 
 func (x *ListSourcesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[6]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -368,7 +861,7 @@ func (x *ListSourcesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSourcesResponse.ProtoReflect.Descriptor instead.
 func (*ListSourcesResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{6}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ListSourcesResponse) GetSources() []*SourceSpec {
@@ -389,7 +882,7 @@ type CheckSourceRequest struct {
 
 func (x *CheckSourceRequest) Reset() {
 	*x = CheckSourceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[7]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -401,7 +894,7 @@ func (x *CheckSourceRequest) String() string {
 func (*CheckSourceRequest) ProtoMessage() {}
 
 func (x *CheckSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[7]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -414,7 +907,7 @@ func (x *CheckSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckSourceRequest.ProtoReflect.Descriptor instead.
 func (*CheckSourceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{7}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CheckSourceRequest) GetSourceId() string {
@@ -442,7 +935,7 @@ type CheckSourceResponse struct {
 
 func (x *CheckSourceResponse) Reset() {
 	*x = CheckSourceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[8]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -454,7 +947,7 @@ func (x *CheckSourceResponse) String() string {
 func (*CheckSourceResponse) ProtoMessage() {}
 
 func (x *CheckSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[8]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -467,7 +960,7 @@ func (x *CheckSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckSourceResponse.ProtoReflect.Descriptor instead.
 func (*CheckSourceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{8}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *CheckSourceResponse) GetSource() *SourceSpec {
@@ -495,7 +988,7 @@ type DiscoverSourceRequest struct {
 
 func (x *DiscoverSourceRequest) Reset() {
 	*x = DiscoverSourceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[9]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -507,7 +1000,7 @@ func (x *DiscoverSourceRequest) String() string {
 func (*DiscoverSourceRequest) ProtoMessage() {}
 
 func (x *DiscoverSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[9]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -520,7 +1013,7 @@ func (x *DiscoverSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoverSourceRequest.ProtoReflect.Descriptor instead.
 func (*DiscoverSourceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{9}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *DiscoverSourceRequest) GetSourceId() string {
@@ -548,7 +1041,7 @@ type DiscoverSourceResponse struct {
 
 func (x *DiscoverSourceResponse) Reset() {
 	*x = DiscoverSourceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[10]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -560,7 +1053,7 @@ func (x *DiscoverSourceResponse) String() string {
 func (*DiscoverSourceResponse) ProtoMessage() {}
 
 func (x *DiscoverSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[10]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -573,7 +1066,7 @@ func (x *DiscoverSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoverSourceResponse.ProtoReflect.Descriptor instead.
 func (*DiscoverSourceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{10}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DiscoverSourceResponse) GetSource() *SourceSpec {
@@ -602,7 +1095,7 @@ type ReadSourceRequest struct {
 
 func (x *ReadSourceRequest) Reset() {
 	*x = ReadSourceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[11]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -614,7 +1107,7 @@ func (x *ReadSourceRequest) String() string {
 func (*ReadSourceRequest) ProtoMessage() {}
 
 func (x *ReadSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[11]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -627,7 +1120,7 @@ func (x *ReadSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSourceRequest.ProtoReflect.Descriptor instead.
 func (*ReadSourceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{11}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ReadSourceRequest) GetSourceId() string {
@@ -663,7 +1156,7 @@ type SourcePreviewEvent struct {
 
 func (x *SourcePreviewEvent) Reset() {
 	*x = SourcePreviewEvent{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -675,7 +1168,7 @@ func (x *SourcePreviewEvent) String() string {
 func (*SourcePreviewEvent) ProtoMessage() {}
 
 func (x *SourcePreviewEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -688,7 +1181,7 @@ func (x *SourcePreviewEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SourcePreviewEvent.ProtoReflect.Descriptor instead.
 func (*SourcePreviewEvent) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{12}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SourcePreviewEvent) GetEvent() *EventEnvelope {
@@ -726,7 +1219,7 @@ type ReadSourceResponse struct {
 
 func (x *ReadSourceResponse) Reset() {
 	*x = ReadSourceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[13]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -738,7 +1231,7 @@ func (x *ReadSourceResponse) String() string {
 func (*ReadSourceResponse) ProtoMessage() {}
 
 func (x *ReadSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[13]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -751,7 +1244,7 @@ func (x *ReadSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSourceResponse.ProtoReflect.Descriptor instead.
 func (*ReadSourceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{13}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ReadSourceResponse) GetSource() *SourceSpec {
@@ -805,7 +1298,7 @@ type SourceRuntime struct {
 
 func (x *SourceRuntime) Reset() {
 	*x = SourceRuntime{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[14]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -817,7 +1310,7 @@ func (x *SourceRuntime) String() string {
 func (*SourceRuntime) ProtoMessage() {}
 
 func (x *SourceRuntime) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[14]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -830,7 +1323,7 @@ func (x *SourceRuntime) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SourceRuntime.ProtoReflect.Descriptor instead.
 func (*SourceRuntime) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{14}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *SourceRuntime) GetId() string {
@@ -892,7 +1385,7 @@ type PutSourceRuntimeRequest struct {
 
 func (x *PutSourceRuntimeRequest) Reset() {
 	*x = PutSourceRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[15]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -904,7 +1397,7 @@ func (x *PutSourceRuntimeRequest) String() string {
 func (*PutSourceRuntimeRequest) ProtoMessage() {}
 
 func (x *PutSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[15]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -917,7 +1410,7 @@ func (x *PutSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutSourceRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*PutSourceRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{15}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *PutSourceRuntimeRequest) GetRuntime() *SourceRuntime {
@@ -937,7 +1430,7 @@ type PutSourceRuntimeResponse struct {
 
 func (x *PutSourceRuntimeResponse) Reset() {
 	*x = PutSourceRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[16]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -949,7 +1442,7 @@ func (x *PutSourceRuntimeResponse) String() string {
 func (*PutSourceRuntimeResponse) ProtoMessage() {}
 
 func (x *PutSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[16]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -962,7 +1455,7 @@ func (x *PutSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutSourceRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*PutSourceRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{16}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *PutSourceRuntimeResponse) GetRuntime() *SourceRuntime {
@@ -982,7 +1475,7 @@ type GetSourceRuntimeRequest struct {
 
 func (x *GetSourceRuntimeRequest) Reset() {
 	*x = GetSourceRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -994,7 +1487,7 @@ func (x *GetSourceRuntimeRequest) String() string {
 func (*GetSourceRuntimeRequest) ProtoMessage() {}
 
 func (x *GetSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1007,7 +1500,7 @@ func (x *GetSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSourceRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*GetSourceRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{17}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetSourceRuntimeRequest) GetId() string {
@@ -1027,7 +1520,7 @@ type GetSourceRuntimeResponse struct {
 
 func (x *GetSourceRuntimeResponse) Reset() {
 	*x = GetSourceRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1039,7 +1532,7 @@ func (x *GetSourceRuntimeResponse) String() string {
 func (*GetSourceRuntimeResponse) ProtoMessage() {}
 
 func (x *GetSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1052,7 +1545,7 @@ func (x *GetSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSourceRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*GetSourceRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{18}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetSourceRuntimeResponse) GetRuntime() *SourceRuntime {
@@ -1073,7 +1566,7 @@ type SyncSourceRuntimeRequest struct {
 
 func (x *SyncSourceRuntimeRequest) Reset() {
 	*x = SyncSourceRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1085,7 +1578,7 @@ func (x *SyncSourceRuntimeRequest) String() string {
 func (*SyncSourceRuntimeRequest) ProtoMessage() {}
 
 func (x *SyncSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1098,7 +1591,7 @@ func (x *SyncSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncSourceRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*SyncSourceRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{19}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SyncSourceRuntimeRequest) GetId() string {
@@ -1130,7 +1623,7 @@ type SyncSourceRuntimeResponse struct {
 
 func (x *SyncSourceRuntimeResponse) Reset() {
 	*x = SyncSourceRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1142,7 +1635,7 @@ func (x *SyncSourceRuntimeResponse) String() string {
 func (*SyncSourceRuntimeResponse) ProtoMessage() {}
 
 func (x *SyncSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1155,7 +1648,7 @@ func (x *SyncSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncSourceRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*SyncSourceRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{20}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *SyncSourceRuntimeResponse) GetRuntime() *SourceRuntime {
@@ -1223,7 +1716,7 @@ type Finding struct {
 
 func (x *Finding) Reset() {
 	*x = Finding{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1235,7 +1728,7 @@ func (x *Finding) String() string {
 func (*Finding) ProtoMessage() {}
 
 func (x *Finding) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1248,7 +1741,7 @@ func (x *Finding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Finding.ProtoReflect.Descriptor instead.
 func (*Finding) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{21}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *Finding) GetId() string {
@@ -1360,7 +1853,7 @@ type EvaluateSourceRuntimeFindingsRequest struct {
 
 func (x *EvaluateSourceRuntimeFindingsRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1372,7 +1865,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) String() string {
 func (*EvaluateSourceRuntimeFindingsRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1385,7 +1878,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{22}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *EvaluateSourceRuntimeFindingsRequest) GetId() string {
@@ -1416,7 +1909,7 @@ type EvaluateSourceRuntimeFindingsResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingsResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1428,7 +1921,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) String() string {
 func (*EvaluateSourceRuntimeFindingsResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1441,7 +1934,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{23}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *EvaluateSourceRuntimeFindingsResponse) GetRuntime() *SourceRuntime {
@@ -1491,7 +1984,7 @@ type GraphEntity struct {
 
 func (x *GraphEntity) Reset() {
 	*x = GraphEntity{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1503,7 +1996,7 @@ func (x *GraphEntity) String() string {
 func (*GraphEntity) ProtoMessage() {}
 
 func (x *GraphEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1516,7 +2009,7 @@ func (x *GraphEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphEntity.ProtoReflect.Descriptor instead.
 func (*GraphEntity) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{24}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GraphEntity) GetUrn() string {
@@ -1552,7 +2045,7 @@ type GraphRelation struct {
 
 func (x *GraphRelation) Reset() {
 	*x = GraphRelation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1564,7 +2057,7 @@ func (x *GraphRelation) String() string {
 func (*GraphRelation) ProtoMessage() {}
 
 func (x *GraphRelation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1577,7 +2070,7 @@ func (x *GraphRelation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphRelation.ProtoReflect.Descriptor instead.
 func (*GraphRelation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{25}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GraphRelation) GetFromUrn() string {
@@ -1612,7 +2105,7 @@ type GetEntityNeighborhoodRequest struct {
 
 func (x *GetEntityNeighborhoodRequest) Reset() {
 	*x = GetEntityNeighborhoodRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1624,7 +2117,7 @@ func (x *GetEntityNeighborhoodRequest) String() string {
 func (*GetEntityNeighborhoodRequest) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1637,7 +2130,7 @@ func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodRequest.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{26}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *GetEntityNeighborhoodRequest) GetRootUrn() string {
@@ -1666,7 +2159,7 @@ type GetEntityNeighborhoodResponse struct {
 
 func (x *GetEntityNeighborhoodResponse) Reset() {
 	*x = GetEntityNeighborhoodResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1678,7 +2171,7 @@ func (x *GetEntityNeighborhoodResponse) String() string {
 func (*GetEntityNeighborhoodResponse) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1691,7 +2184,7 @@ func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodResponse.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{27}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *GetEntityNeighborhoodResponse) GetRoot() *GraphEntity {
@@ -1741,7 +2234,48 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"checked_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcheckedAt\x12;\n" +
 	"\n" +
 	"components\x18\x03 \x03(\v2\x1b.cerebro.v1.ComponentStatusR\n" +
-	"components\"\x14\n" +
+	"components\"_\n" +
+	"\x0fReportParameter\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x1a\n" +
+	"\brequired\x18\x03 \x01(\bR\brequired\"\x95\x01\n" +
+	"\x10ReportDefinition\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
+	"\vdescription\x18\x03 \x01(\tR\vdescription\x12;\n" +
+	"\n" +
+	"parameters\x18\x04 \x03(\v2\x1b.cerebro.v1.ReportParameterR\n" +
+	"parameters\"\xc6\x02\n" +
+	"\tReportRun\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
+	"\treport_id\x18\x02 \x01(\tR\breportId\x12E\n" +
+	"\n" +
+	"parameters\x18\x03 \x03(\v2%.cerebro.v1.ReportRun.ParametersEntryR\n" +
+	"parameters\x12\x16\n" +
+	"\x06status\x18\x04 \x01(\tR\x06status\x12=\n" +
+	"\fgenerated_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\vgeneratedAt\x12/\n" +
+	"\x06result\x18\x06 \x01(\v2\x17.google.protobuf.StructR\x06result\x1a=\n" +
+	"\x0fParametersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x1e\n" +
+	"\x1cListReportDefinitionsRequest\"W\n" +
+	"\x1dListReportDefinitionsResponse\x126\n" +
+	"\areports\x18\x01 \x03(\v2\x1c.cerebro.v1.ReportDefinitionR\areports\"\xbc\x01\n" +
+	"\x10RunReportRequest\x12\x1b\n" +
+	"\treport_id\x18\x01 \x01(\tR\breportId\x12L\n" +
+	"\n" +
+	"parameters\x18\x02 \x03(\v2,.cerebro.v1.RunReportRequest.ParametersEntryR\n" +
+	"parameters\x1a=\n" +
+	"\x0fParametersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"r\n" +
+	"\x11RunReportResponse\x124\n" +
+	"\x06report\x18\x01 \x01(\v2\x1c.cerebro.v1.ReportDefinitionR\x06report\x12'\n" +
+	"\x03run\x18\x02 \x01(\v2\x15.cerebro.v1.ReportRunR\x03run\"%\n" +
+	"\x13GetReportRunRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"?\n" +
+	"\x14GetReportRunResponse\x12'\n" +
+	"\x03run\x18\x01 \x01(\v2\x15.cerebro.v1.ReportRunR\x03run\"\x14\n" +
 	"\x12ListSourcesRequest\"G\n" +
 	"\x13ListSourcesResponse\x120\n" +
 	"\asources\x18\x01 \x03(\v2\x16.cerebro.v1.SourceSpecR\asources\"\xb0\x01\n" +
@@ -1864,11 +2398,15 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x1dGetEntityNeighborhoodResponse\x12+\n" +
 	"\x04root\x18\x01 \x01(\v2\x17.cerebro.v1.GraphEntityR\x04root\x125\n" +
 	"\tneighbors\x18\x02 \x03(\v2\x17.cerebro.v1.GraphEntityR\tneighbors\x127\n" +
-	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\x8a\b\n" +
+	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\x95\n" +
+	"\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
-	"\vCheckHealth\x12\x1e.cerebro.v1.CheckHealthRequest\x1a\x1f.cerebro.v1.CheckHealthResponse\x12N\n" +
+	"\vCheckHealth\x12\x1e.cerebro.v1.CheckHealthRequest\x1a\x1f.cerebro.v1.CheckHealthResponse\x12l\n" +
+	"\x15ListReportDefinitions\x12(.cerebro.v1.ListReportDefinitionsRequest\x1a).cerebro.v1.ListReportDefinitionsResponse\x12H\n" +
+	"\tRunReport\x12\x1c.cerebro.v1.RunReportRequest\x1a\x1d.cerebro.v1.RunReportResponse\x12Q\n" +
+	"\fGetReportRun\x12\x1f.cerebro.v1.GetReportRunRequest\x1a .cerebro.v1.GetReportRunResponse\x12N\n" +
 	"\vListSources\x12\x1e.cerebro.v1.ListSourcesRequest\x1a\x1f.cerebro.v1.ListSourcesResponse\x12N\n" +
 	"\vCheckSource\x12\x1e.cerebro.v1.CheckSourceRequest\x1a\x1f.cerebro.v1.CheckSourceResponse\x12W\n" +
 	"\x0eDiscoverSource\x12!.cerebro.v1.DiscoverSourceRequest\x1a\".cerebro.v1.DiscoverSourceResponse\x12K\n" +
@@ -1892,111 +2430,138 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*GetVersionRequest)(nil),                     // 0: cerebro.v1.GetVersionRequest
 	(*GetVersionResponse)(nil),                    // 1: cerebro.v1.GetVersionResponse
 	(*CheckHealthRequest)(nil),                    // 2: cerebro.v1.CheckHealthRequest
 	(*ComponentStatus)(nil),                       // 3: cerebro.v1.ComponentStatus
 	(*CheckHealthResponse)(nil),                   // 4: cerebro.v1.CheckHealthResponse
-	(*ListSourcesRequest)(nil),                    // 5: cerebro.v1.ListSourcesRequest
-	(*ListSourcesResponse)(nil),                   // 6: cerebro.v1.ListSourcesResponse
-	(*CheckSourceRequest)(nil),                    // 7: cerebro.v1.CheckSourceRequest
-	(*CheckSourceResponse)(nil),                   // 8: cerebro.v1.CheckSourceResponse
-	(*DiscoverSourceRequest)(nil),                 // 9: cerebro.v1.DiscoverSourceRequest
-	(*DiscoverSourceResponse)(nil),                // 10: cerebro.v1.DiscoverSourceResponse
-	(*ReadSourceRequest)(nil),                     // 11: cerebro.v1.ReadSourceRequest
-	(*SourcePreviewEvent)(nil),                    // 12: cerebro.v1.SourcePreviewEvent
-	(*ReadSourceResponse)(nil),                    // 13: cerebro.v1.ReadSourceResponse
-	(*SourceRuntime)(nil),                         // 14: cerebro.v1.SourceRuntime
-	(*PutSourceRuntimeRequest)(nil),               // 15: cerebro.v1.PutSourceRuntimeRequest
-	(*PutSourceRuntimeResponse)(nil),              // 16: cerebro.v1.PutSourceRuntimeResponse
-	(*GetSourceRuntimeRequest)(nil),               // 17: cerebro.v1.GetSourceRuntimeRequest
-	(*GetSourceRuntimeResponse)(nil),              // 18: cerebro.v1.GetSourceRuntimeResponse
-	(*SyncSourceRuntimeRequest)(nil),              // 19: cerebro.v1.SyncSourceRuntimeRequest
-	(*SyncSourceRuntimeResponse)(nil),             // 20: cerebro.v1.SyncSourceRuntimeResponse
-	(*Finding)(nil),                               // 21: cerebro.v1.Finding
-	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 22: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 23: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	(*GraphEntity)(nil),                           // 24: cerebro.v1.GraphEntity
-	(*GraphRelation)(nil),                         // 25: cerebro.v1.GraphRelation
-	(*GetEntityNeighborhoodRequest)(nil),          // 26: cerebro.v1.GetEntityNeighborhoodRequest
-	(*GetEntityNeighborhoodResponse)(nil),         // 27: cerebro.v1.GetEntityNeighborhoodResponse
-	nil,                                           // 28: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                                           // 29: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                                           // 30: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                                           // 31: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                                           // 32: cerebro.v1.Finding.AttributesEntry
-	(*timestamppb.Timestamp)(nil),                 // 33: google.protobuf.Timestamp
-	(*SourceSpec)(nil),                            // 34: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),                          // 35: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                         // 36: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                        // 37: google.protobuf.Value
-	(*SourceCheckpoint)(nil),                      // 38: cerebro.v1.SourceCheckpoint
-	(*RuleSpec)(nil),                              // 39: cerebro.v1.RuleSpec
+	(*ReportParameter)(nil),                       // 5: cerebro.v1.ReportParameter
+	(*ReportDefinition)(nil),                      // 6: cerebro.v1.ReportDefinition
+	(*ReportRun)(nil),                             // 7: cerebro.v1.ReportRun
+	(*ListReportDefinitionsRequest)(nil),          // 8: cerebro.v1.ListReportDefinitionsRequest
+	(*ListReportDefinitionsResponse)(nil),         // 9: cerebro.v1.ListReportDefinitionsResponse
+	(*RunReportRequest)(nil),                      // 10: cerebro.v1.RunReportRequest
+	(*RunReportResponse)(nil),                     // 11: cerebro.v1.RunReportResponse
+	(*GetReportRunRequest)(nil),                   // 12: cerebro.v1.GetReportRunRequest
+	(*GetReportRunResponse)(nil),                  // 13: cerebro.v1.GetReportRunResponse
+	(*ListSourcesRequest)(nil),                    // 14: cerebro.v1.ListSourcesRequest
+	(*ListSourcesResponse)(nil),                   // 15: cerebro.v1.ListSourcesResponse
+	(*CheckSourceRequest)(nil),                    // 16: cerebro.v1.CheckSourceRequest
+	(*CheckSourceResponse)(nil),                   // 17: cerebro.v1.CheckSourceResponse
+	(*DiscoverSourceRequest)(nil),                 // 18: cerebro.v1.DiscoverSourceRequest
+	(*DiscoverSourceResponse)(nil),                // 19: cerebro.v1.DiscoverSourceResponse
+	(*ReadSourceRequest)(nil),                     // 20: cerebro.v1.ReadSourceRequest
+	(*SourcePreviewEvent)(nil),                    // 21: cerebro.v1.SourcePreviewEvent
+	(*ReadSourceResponse)(nil),                    // 22: cerebro.v1.ReadSourceResponse
+	(*SourceRuntime)(nil),                         // 23: cerebro.v1.SourceRuntime
+	(*PutSourceRuntimeRequest)(nil),               // 24: cerebro.v1.PutSourceRuntimeRequest
+	(*PutSourceRuntimeResponse)(nil),              // 25: cerebro.v1.PutSourceRuntimeResponse
+	(*GetSourceRuntimeRequest)(nil),               // 26: cerebro.v1.GetSourceRuntimeRequest
+	(*GetSourceRuntimeResponse)(nil),              // 27: cerebro.v1.GetSourceRuntimeResponse
+	(*SyncSourceRuntimeRequest)(nil),              // 28: cerebro.v1.SyncSourceRuntimeRequest
+	(*SyncSourceRuntimeResponse)(nil),             // 29: cerebro.v1.SyncSourceRuntimeResponse
+	(*Finding)(nil),                               // 30: cerebro.v1.Finding
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 31: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 32: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	(*GraphEntity)(nil),                           // 33: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                         // 34: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),          // 35: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),         // 36: cerebro.v1.GetEntityNeighborhoodResponse
+	nil,                                           // 37: cerebro.v1.ReportRun.ParametersEntry
+	nil,                                           // 38: cerebro.v1.RunReportRequest.ParametersEntry
+	nil,                                           // 39: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                           // 40: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                           // 41: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                           // 42: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                           // 43: cerebro.v1.Finding.AttributesEntry
+	(*timestamppb.Timestamp)(nil),                 // 44: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                       // 45: google.protobuf.Struct
+	(*SourceSpec)(nil),                            // 46: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                          // 47: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                         // 48: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                        // 49: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                      // 50: cerebro.v1.SourceCheckpoint
+	(*RuleSpec)(nil),                              // 51: cerebro.v1.RuleSpec
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	33, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	44, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
-	34, // 2: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	28, // 3: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	34, // 4: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	29, // 5: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	34, // 6: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	30, // 7: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	35, // 8: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	36, // 9: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	37, // 10: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	34, // 11: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	36, // 12: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	38, // 13: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	35, // 14: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
-	12, // 15: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	31, // 16: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	38, // 17: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	35, // 18: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	33, // 19: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
-	14, // 20: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
-	14, // 21: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	14, // 22: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	14, // 23: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	34, // 24: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	32, // 25: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	33, // 26: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	33, // 27: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	14, // 28: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	39, // 29: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	21, // 30: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	24, // 31: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	24, // 32: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	25, // 33: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	0,  // 34: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2,  // 35: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	5,  // 36: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	7,  // 37: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	9,  // 38: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	11, // 39: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	15, // 40: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	17, // 41: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	19, // 42: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	22, // 43: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	26, // 44: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	1,  // 45: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4,  // 46: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	6,  // 47: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	8,  // 48: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	10, // 49: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	13, // 50: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	16, // 51: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	18, // 52: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	20, // 53: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	23, // 54: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	27, // 55: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	45, // [45:56] is the sub-list for method output_type
-	34, // [34:45] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	5,  // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
+	37, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
+	44, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
+	45, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
+	6,  // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
+	38, // 7: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
+	6,  // 8: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
+	7,  // 9: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
+	7,  // 10: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
+	46, // 11: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	39, // 12: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	46, // 13: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	40, // 14: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	46, // 15: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	41, // 16: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	47, // 17: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	48, // 18: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	49, // 19: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	46, // 20: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	48, // 21: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	50, // 22: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	47, // 23: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	21, // 24: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
+	42, // 25: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	50, // 26: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	47, // 27: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	44, // 28: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	23, // 29: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
+	23, // 30: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	23, // 31: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	23, // 32: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	46, // 33: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	43, // 34: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	44, // 35: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	44, // 36: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	23, // 37: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	51, // 38: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	30, // 39: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	33, // 40: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	33, // 41: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	34, // 42: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	0,  // 43: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 44: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	8,  // 45: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	10, // 46: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	12, // 47: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	14, // 48: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	16, // 49: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	18, // 50: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	20, // 51: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	24, // 52: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	26, // 53: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	28, // 54: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	31, // 55: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	35, // 56: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	1,  // 57: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 58: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	9,  // 59: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	11, // 60: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	13, // 61: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	15, // 62: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	17, // 63: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	19, // 64: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	22, // 65: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	25, // 66: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	27, // 67: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	29, // 68: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	32, // 69: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	36, // 70: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	57, // [57:71] is the sub-list for method output_type
+	43, // [43:57] is the sub-list for method input_type
+	43, // [43:43] is the sub-list for extension type_name
+	43, // [43:43] is the sub-list for extension extendee
+	0,  // [0:43] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -2012,7 +2577,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   33,
+			NumMessages:   44,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -39,6 +39,15 @@ const (
 	// BootstrapServiceCheckHealthProcedure is the fully-qualified name of the BootstrapService's
 	// CheckHealth RPC.
 	BootstrapServiceCheckHealthProcedure = "/cerebro.v1.BootstrapService/CheckHealth"
+	// BootstrapServiceListReportDefinitionsProcedure is the fully-qualified name of the
+	// BootstrapService's ListReportDefinitions RPC.
+	BootstrapServiceListReportDefinitionsProcedure = "/cerebro.v1.BootstrapService/ListReportDefinitions"
+	// BootstrapServiceRunReportProcedure is the fully-qualified name of the BootstrapService's
+	// RunReport RPC.
+	BootstrapServiceRunReportProcedure = "/cerebro.v1.BootstrapService/RunReport"
+	// BootstrapServiceGetReportRunProcedure is the fully-qualified name of the BootstrapService's
+	// GetReportRun RPC.
+	BootstrapServiceGetReportRunProcedure = "/cerebro.v1.BootstrapService/GetReportRun"
 	// BootstrapServiceListSourcesProcedure is the fully-qualified name of the BootstrapService's
 	// ListSources RPC.
 	BootstrapServiceListSourcesProcedure = "/cerebro.v1.BootstrapService/ListSources"
@@ -72,6 +81,9 @@ const (
 type BootstrapServiceClient interface {
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
 	CheckHealth(context.Context, *connect.Request[v1.CheckHealthRequest]) (*connect.Response[v1.CheckHealthResponse], error)
+	ListReportDefinitions(context.Context, *connect.Request[v1.ListReportDefinitionsRequest]) (*connect.Response[v1.ListReportDefinitionsResponse], error)
+	RunReport(context.Context, *connect.Request[v1.RunReportRequest]) (*connect.Response[v1.RunReportResponse], error)
+	GetReportRun(context.Context, *connect.Request[v1.GetReportRunRequest]) (*connect.Response[v1.GetReportRunResponse], error)
 	ListSources(context.Context, *connect.Request[v1.ListSourcesRequest]) (*connect.Response[v1.ListSourcesResponse], error)
 	CheckSource(context.Context, *connect.Request[v1.CheckSourceRequest]) (*connect.Response[v1.CheckSourceResponse], error)
 	DiscoverSource(context.Context, *connect.Request[v1.DiscoverSourceRequest]) (*connect.Response[v1.DiscoverSourceResponse], error)
@@ -104,6 +116,24 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			httpClient,
 			baseURL+BootstrapServiceCheckHealthProcedure,
 			connect.WithSchema(bootstrapServiceMethods.ByName("CheckHealth")),
+			connect.WithClientOptions(opts...),
+		),
+		listReportDefinitions: connect.NewClient[v1.ListReportDefinitionsRequest, v1.ListReportDefinitionsResponse](
+			httpClient,
+			baseURL+BootstrapServiceListReportDefinitionsProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("ListReportDefinitions")),
+			connect.WithClientOptions(opts...),
+		),
+		runReport: connect.NewClient[v1.RunReportRequest, v1.RunReportResponse](
+			httpClient,
+			baseURL+BootstrapServiceRunReportProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("RunReport")),
+			connect.WithClientOptions(opts...),
+		),
+		getReportRun: connect.NewClient[v1.GetReportRunRequest, v1.GetReportRunResponse](
+			httpClient,
+			baseURL+BootstrapServiceGetReportRunProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("GetReportRun")),
 			connect.WithClientOptions(opts...),
 		),
 		listSources: connect.NewClient[v1.ListSourcesRequest, v1.ListSourcesResponse](
@@ -167,6 +197,9 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 type bootstrapServiceClient struct {
 	getVersion                    *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
 	checkHealth                   *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
+	listReportDefinitions         *connect.Client[v1.ListReportDefinitionsRequest, v1.ListReportDefinitionsResponse]
+	runReport                     *connect.Client[v1.RunReportRequest, v1.RunReportResponse]
+	getReportRun                  *connect.Client[v1.GetReportRunRequest, v1.GetReportRunResponse]
 	listSources                   *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
 	checkSource                   *connect.Client[v1.CheckSourceRequest, v1.CheckSourceResponse]
 	discoverSource                *connect.Client[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse]
@@ -186,6 +219,21 @@ func (c *bootstrapServiceClient) GetVersion(ctx context.Context, req *connect.Re
 // CheckHealth calls cerebro.v1.BootstrapService.CheckHealth.
 func (c *bootstrapServiceClient) CheckHealth(ctx context.Context, req *connect.Request[v1.CheckHealthRequest]) (*connect.Response[v1.CheckHealthResponse], error) {
 	return c.checkHealth.CallUnary(ctx, req)
+}
+
+// ListReportDefinitions calls cerebro.v1.BootstrapService.ListReportDefinitions.
+func (c *bootstrapServiceClient) ListReportDefinitions(ctx context.Context, req *connect.Request[v1.ListReportDefinitionsRequest]) (*connect.Response[v1.ListReportDefinitionsResponse], error) {
+	return c.listReportDefinitions.CallUnary(ctx, req)
+}
+
+// RunReport calls cerebro.v1.BootstrapService.RunReport.
+func (c *bootstrapServiceClient) RunReport(ctx context.Context, req *connect.Request[v1.RunReportRequest]) (*connect.Response[v1.RunReportResponse], error) {
+	return c.runReport.CallUnary(ctx, req)
+}
+
+// GetReportRun calls cerebro.v1.BootstrapService.GetReportRun.
+func (c *bootstrapServiceClient) GetReportRun(ctx context.Context, req *connect.Request[v1.GetReportRunRequest]) (*connect.Response[v1.GetReportRunResponse], error) {
+	return c.getReportRun.CallUnary(ctx, req)
 }
 
 // ListSources calls cerebro.v1.BootstrapService.ListSources.
@@ -237,6 +285,9 @@ func (c *bootstrapServiceClient) GetEntityNeighborhood(ctx context.Context, req 
 type BootstrapServiceHandler interface {
 	GetVersion(context.Context, *connect.Request[v1.GetVersionRequest]) (*connect.Response[v1.GetVersionResponse], error)
 	CheckHealth(context.Context, *connect.Request[v1.CheckHealthRequest]) (*connect.Response[v1.CheckHealthResponse], error)
+	ListReportDefinitions(context.Context, *connect.Request[v1.ListReportDefinitionsRequest]) (*connect.Response[v1.ListReportDefinitionsResponse], error)
+	RunReport(context.Context, *connect.Request[v1.RunReportRequest]) (*connect.Response[v1.RunReportResponse], error)
+	GetReportRun(context.Context, *connect.Request[v1.GetReportRunRequest]) (*connect.Response[v1.GetReportRunResponse], error)
 	ListSources(context.Context, *connect.Request[v1.ListSourcesRequest]) (*connect.Response[v1.ListSourcesResponse], error)
 	CheckSource(context.Context, *connect.Request[v1.CheckSourceRequest]) (*connect.Response[v1.CheckSourceResponse], error)
 	DiscoverSource(context.Context, *connect.Request[v1.DiscoverSourceRequest]) (*connect.Response[v1.DiscoverSourceResponse], error)
@@ -265,6 +316,24 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		BootstrapServiceCheckHealthProcedure,
 		svc.CheckHealth,
 		connect.WithSchema(bootstrapServiceMethods.ByName("CheckHealth")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceListReportDefinitionsHandler := connect.NewUnaryHandler(
+		BootstrapServiceListReportDefinitionsProcedure,
+		svc.ListReportDefinitions,
+		connect.WithSchema(bootstrapServiceMethods.ByName("ListReportDefinitions")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceRunReportHandler := connect.NewUnaryHandler(
+		BootstrapServiceRunReportProcedure,
+		svc.RunReport,
+		connect.WithSchema(bootstrapServiceMethods.ByName("RunReport")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceGetReportRunHandler := connect.NewUnaryHandler(
+		BootstrapServiceGetReportRunProcedure,
+		svc.GetReportRun,
+		connect.WithSchema(bootstrapServiceMethods.ByName("GetReportRun")),
 		connect.WithHandlerOptions(opts...),
 	)
 	bootstrapServiceListSourcesHandler := connect.NewUnaryHandler(
@@ -327,6 +396,12 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceGetVersionHandler.ServeHTTP(w, r)
 		case BootstrapServiceCheckHealthProcedure:
 			bootstrapServiceCheckHealthHandler.ServeHTTP(w, r)
+		case BootstrapServiceListReportDefinitionsProcedure:
+			bootstrapServiceListReportDefinitionsHandler.ServeHTTP(w, r)
+		case BootstrapServiceRunReportProcedure:
+			bootstrapServiceRunReportHandler.ServeHTTP(w, r)
+		case BootstrapServiceGetReportRunProcedure:
+			bootstrapServiceGetReportRunHandler.ServeHTTP(w, r)
 		case BootstrapServiceListSourcesProcedure:
 			bootstrapServiceListSourcesHandler.ServeHTTP(w, r)
 		case BootstrapServiceCheckSourceProcedure:
@@ -360,6 +435,18 @@ func (UnimplementedBootstrapServiceHandler) GetVersion(context.Context, *connect
 
 func (UnimplementedBootstrapServiceHandler) CheckHealth(context.Context, *connect.Request[v1.CheckHealthRequest]) (*connect.Response[v1.CheckHealthResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.CheckHealth is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) ListReportDefinitions(context.Context, *connect.Request[v1.ListReportDefinitionsRequest]) (*connect.Response[v1.ListReportDefinitionsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListReportDefinitions is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) RunReport(context.Context, *connect.Request[v1.RunReportRequest]) (*connect.Response[v1.RunReportResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.RunReport is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) GetReportRun(context.Context, *connect.Request[v1.GetReportRunRequest]) (*connect.Response[v1.GetReportRunResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.GetReportRun is not implemented"))
 }
 
 func (UnimplementedBootstrapServiceHandler) ListSources(context.Context, *connect.Request[v1.ListSourcesRequest]) (*connect.Response[v1.ListSourcesResponse], error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -567,7 +567,7 @@ func readProtoJSON(r *http.Request, message proto.Message) error {
 
 func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {
 	runtimeStore, ok := store.(ports.SourceRuntimeStore)
-	if !ok {
+	if !ok || isNilInterface(runtimeStore) {
 		return nil
 	}
 	return runtimeStore
@@ -575,7 +575,7 @@ func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {
 
 func sourceProjectionStateStore(store ports.StateStore) ports.ProjectionStateStore {
 	projectionStore, ok := store.(ports.ProjectionStateStore)
-	if !ok {
+	if !ok || isNilInterface(projectionStore) {
 		return nil
 	}
 	return projectionStore
@@ -583,7 +583,7 @@ func sourceProjectionStateStore(store ports.StateStore) ports.ProjectionStateSto
 
 func sourceProjectionGraphStore(store ports.GraphStore) ports.ProjectionGraphStore {
 	projectionStore, ok := store.(ports.ProjectionGraphStore)
-	if !ok {
+	if !ok || isNilInterface(projectionStore) {
 		return nil
 	}
 	return projectionStore
@@ -621,7 +621,7 @@ func isNilInterface(value any) bool {
 
 func findingStore(store ports.StateStore) ports.FindingStore {
 	findingStore, ok := store.(ports.FindingStore)
-	if !ok {
+	if !ok || isNilInterface(findingStore) {
 		return nil
 	}
 	return findingStore
@@ -629,7 +629,7 @@ func findingStore(store ports.StateStore) ports.FindingStore {
 
 func reportStore(store ports.StateStore) ports.ReportStore {
 	reportStore, ok := store.(ports.ReportStore)
-	if !ok {
+	if !ok || isNilInterface(reportStore) {
 		return nil
 	}
 	return reportStore
@@ -637,7 +637,7 @@ func reportStore(store ports.StateStore) ports.ReportStore {
 
 func eventReplayer(appendLog ports.AppendLog) ports.EventReplayer {
 	replayer, ok := appendLog.(ports.EventReplayer)
-	if !ok {
+	if !ok || isNilInterface(replayer) {
 		return nil
 	}
 	return replayer

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -298,7 +298,7 @@ func (s *bootstrapService) RunReport(ctx context.Context, req *connect.Request[c
 		reportStore(s.deps.StateStore),
 	).Run(ctx, req.Msg)
 	if err != nil {
-		return nil, err
+		return nil, reportConnectError(err)
 	}
 	return connect.NewResponse(response), nil
 }
@@ -309,7 +309,7 @@ func (s *bootstrapService) GetReportRun(ctx context.Context, req *connect.Reques
 		reportStore(s.deps.StateStore),
 	).Get(ctx, req.Msg)
 	if err != nil {
-		return nil, err
+		return nil, reportConnectError(err)
 	}
 	return connect.NewResponse(response), nil
 }
@@ -500,6 +500,17 @@ func writeReportError(w http.ResponseWriter, err error) {
 		statusCode = http.StatusServiceUnavailable
 	}
 	http.Error(w, err.Error(), statusCode)
+}
+
+func reportConnectError(err error) error {
+	switch {
+	case errors.Is(err, reports.ErrReportNotFound), errors.Is(err, ports.ErrReportRunNotFound):
+		return connect.NewError(connect.CodeNotFound, err)
+	case errors.Is(err, reports.ErrRuntimeUnavailable):
+		return connect.NewError(connect.CodeUnavailable, err)
+	default:
+		return err
+	}
 }
 
 func writeSourceRuntimeError(w http.ResponseWriter, err error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/reports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceprojection"
@@ -58,6 +59,9 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	app := &App{cfg: cfg, deps: deps, sources: sources, mux: mux}
 	mux.HandleFunc("/health", app.handleHealth)
 	mux.HandleFunc("/healthz", app.handleHealth)
+	mux.HandleFunc("GET /reports", app.handleListReportDefinitions)
+	mux.HandleFunc("POST /reports/{reportID}/runs", app.handleRunReport)
+	mux.HandleFunc("GET /report-runs/{runID}", app.handleGetReportRun)
 	mux.HandleFunc("/sources", app.handleSources)
 	mux.HandleFunc("GET /sources/{sourceID}/check", app.handleCheckSource)
 	mux.HandleFunc("GET /sources/{sourceID}/discover", app.handleDiscoverSource)
@@ -100,6 +104,42 @@ func (a *App) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleSources(w http.ResponseWriter, r *http.Request) {
 	writeProtoJSON(w, http.StatusOK, a.sourceService().List())
+}
+
+func (a *App) handleListReportDefinitions(w http.ResponseWriter, r *http.Request) {
+	writeProtoJSON(w, http.StatusOK, a.reportService().List())
+}
+
+func (a *App) handleRunReport(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.RunReportRequest{}
+	if err := readProtoJSON(r, request); err != nil {
+		writeReportError(w, err)
+		return
+	}
+	request.ReportId = r.PathValue("reportID")
+	if request.Parameters == nil {
+		request.Parameters = map[string]string{}
+	}
+	for key, value := range sourceConfigFromQuery(r) {
+		request.Parameters[key] = value
+	}
+	response, err := a.reportService().Run(r.Context(), request)
+	if err != nil {
+		writeReportError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleGetReportRun(w http.ResponseWriter, r *http.Request) {
+	response, err := a.reportService().Get(r.Context(), &cerebrov1.GetReportRunRequest{
+		Id: r.PathValue("runID"),
+	})
+	if err != nil {
+		writeReportError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, response)
 }
 
 func (a *App) handleCheckSource(w http.ResponseWriter, r *http.Request) {
@@ -245,6 +285,35 @@ func (s *bootstrapService) CheckHealth(ctx context.Context, _ *connect.Request[c
 	return connect.NewResponse(healthResponse(ctx, s.deps)), nil
 }
 
+func (s *bootstrapService) ListReportDefinitions(_ context.Context, _ *connect.Request[cerebrov1.ListReportDefinitionsRequest]) (*connect.Response[cerebrov1.ListReportDefinitionsResponse], error) {
+	return connect.NewResponse(reports.New(
+		findingStore(s.deps.StateStore),
+		reportStore(s.deps.StateStore),
+	).List()), nil
+}
+
+func (s *bootstrapService) RunReport(ctx context.Context, req *connect.Request[cerebrov1.RunReportRequest]) (*connect.Response[cerebrov1.RunReportResponse], error) {
+	response, err := reports.New(
+		findingStore(s.deps.StateStore),
+		reportStore(s.deps.StateStore),
+	).Run(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
+func (s *bootstrapService) GetReportRun(ctx context.Context, req *connect.Request[cerebrov1.GetReportRunRequest]) (*connect.Response[cerebrov1.GetReportRunResponse], error) {
+	response, err := reports.New(
+		findingStore(s.deps.StateStore),
+		reportStore(s.deps.StateStore),
+	).Get(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(response), nil
+}
+
 func (s *bootstrapService) ListSources(_ context.Context, _ *connect.Request[cerebrov1.ListSourcesRequest]) (*connect.Response[cerebrov1.ListSourcesResponse], error) {
 	return connect.NewResponse(sourceops.New(s.sources).List()), nil
 }
@@ -375,6 +444,13 @@ func (a *App) sourceService() *sourceops.Service {
 	return sourceops.New(a.sources)
 }
 
+func (a *App) reportService() *reports.Service {
+	return reports.New(
+		findingStore(a.deps.StateStore),
+		reportStore(a.deps.StateStore),
+	)
+}
+
 func (a *App) runtimeService() *sourceruntime.Service {
 	return sourceruntime.New(
 		a.sources,
@@ -411,6 +487,17 @@ func writeSourceError(w http.ResponseWriter, err error) {
 	statusCode := http.StatusBadRequest
 	if errors.Is(err, sourceops.ErrSourceNotFound) {
 		statusCode = http.StatusNotFound
+	}
+	http.Error(w, err.Error(), statusCode)
+}
+
+func writeReportError(w http.ResponseWriter, err error) {
+	statusCode := http.StatusBadRequest
+	switch {
+	case errors.Is(err, reports.ErrReportNotFound), errors.Is(err, ports.ErrReportRunNotFound):
+		statusCode = http.StatusNotFound
+	case errors.Is(err, reports.ErrRuntimeUnavailable):
+		statusCode = http.StatusServiceUnavailable
 	}
 	http.Error(w, err.Error(), statusCode)
 }
@@ -525,6 +612,14 @@ func findingStore(store ports.StateStore) ports.FindingStore {
 		return nil
 	}
 	return findingStore
+}
+
+func reportStore(store ports.StateStore) ports.ReportStore {
+	reportStore, ok := store.(ports.ReportStore)
+	if !ok {
+		return nil
+	}
+	return reportStore
 }
 
 func eventReplayer(appendLog ports.AppendLog) ports.EventReplayer {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -504,6 +504,8 @@ func writeReportError(w http.ResponseWriter, err error) {
 
 func reportConnectError(err error) error {
 	switch {
+	case errors.Is(err, reports.ErrInvalidReportRequest):
+		return connect.NewError(connect.CodeInvalidArgument, err)
 	case errors.Is(err, reports.ErrReportNotFound), errors.Is(err, ports.ErrReportRunNotFound):
 		return connect.NewError(connect.CodeNotFound, err)
 	case errors.Is(err, reports.ErrRuntimeUnavailable):

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -79,11 +79,12 @@ func (s *recordingAppendLog) Replay(_ context.Context, request ports.ReplayReque
 }
 
 type stubRuntimeStore struct {
-	err      error
-	runtimes map[string]*cerebrov1.SourceRuntime
-	entities map[string]*ports.ProjectedEntity
-	links    map[string]*ports.ProjectedLink
-	findings map[string]*ports.FindingRecord
+	err        error
+	runtimes   map[string]*cerebrov1.SourceRuntime
+	entities   map[string]*ports.ProjectedEntity
+	links      map[string]*ports.ProjectedLink
+	findings   map[string]*ports.FindingRecord
+	reportRuns map[string]*cerebrov1.ReportRun
 }
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
@@ -150,6 +151,45 @@ func (s *stubRuntimeStore) UpsertFinding(_ context.Context, finding *ports.Findi
 	}
 	s.findings[finding.ID] = cloneFinding(finding)
 	return cloneFinding(finding), nil
+}
+
+func (s *stubRuntimeStore) ListFindings(_ context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	findings := []*ports.FindingRecord{}
+	for _, finding := range s.findings {
+		if finding == nil || finding.RuntimeID != request.RuntimeID {
+			continue
+		}
+		findings = append(findings, cloneFinding(finding))
+	}
+	return findings, nil
+}
+
+func (s *stubRuntimeStore) PutReportRun(_ context.Context, run *cerebrov1.ReportRun) error {
+	if s.err != nil {
+		return s.err
+	}
+	if run == nil {
+		return nil
+	}
+	if s.reportRuns == nil {
+		s.reportRuns = make(map[string]*cerebrov1.ReportRun)
+	}
+	s.reportRuns[run.GetId()] = cloneReportRun(run)
+	return nil
+}
+
+func (s *stubRuntimeStore) GetReportRun(_ context.Context, id string) (*cerebrov1.ReportRun, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	run, ok := s.reportRuns[id]
+	if !ok {
+		return nil, ports.ErrReportRunNotFound
+	}
+	return cloneReportRun(run), nil
 }
 
 type stubGraphStore struct {
@@ -863,6 +903,146 @@ func TestGraphQueryStoreRejectsTypedNilStore(t *testing.T) {
 	}
 }
 
+func TestReportEndpoints(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	runtimeStore := &stubRuntimeStore{
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:        "finding-1",
+				RuntimeID: "writer-okta-audit",
+				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
+				Severity:  "HIGH",
+				Status:    "open",
+			},
+			"finding-2": {
+				ID:        "finding-2",
+				RuntimeID: "writer-okta-audit",
+				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
+				Severity:  "HIGH",
+				Status:    "resolved",
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  &recordingAppendLog{},
+		StateStore: runtimeStore,
+		GraphStore: &stubGraphStore{},
+	}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	listResp, err := server.Client().Get(server.URL + "/reports")
+	if err != nil {
+		t.Fatalf("GET /reports error = %v", err)
+	}
+	defer func() {
+		if closeErr := listResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /reports response body: %v", closeErr)
+		}
+	}()
+	var listPayload map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&listPayload); err != nil {
+		t.Fatalf("decode /reports response: %v", err)
+	}
+	reportsPayload, ok := listPayload["reports"].([]any)
+	if !ok || len(reportsPayload) != 1 {
+		t.Fatalf("/reports payload = %#v, want 1 entry", listPayload["reports"])
+	}
+
+	runReq, err := http.NewRequest(http.MethodPost, server.URL+"/reports/finding-summary/runs?runtime_id=writer-okta-audit", nil)
+	if err != nil {
+		t.Fatalf("new run report request: %v", err)
+	}
+	runResp, err := server.Client().Do(runReq)
+	if err != nil {
+		t.Fatalf("POST /reports/{id}/runs error = %v", err)
+	}
+	defer func() {
+		if closeErr := runResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /reports/{id}/runs response body: %v", closeErr)
+		}
+	}()
+	var runPayload map[string]any
+	if err := json.NewDecoder(runResp.Body).Decode(&runPayload); err != nil {
+		t.Fatalf("decode /reports/{id}/runs response: %v", err)
+	}
+	runBody, ok := runPayload["run"].(map[string]any)
+	if !ok {
+		t.Fatalf("run payload = %#v, want object", runPayload["run"])
+	}
+	if got := runBody["report_id"]; got != "finding-summary" {
+		t.Fatalf("run report_id = %#v, want finding-summary", got)
+	}
+	resultBody, ok := runBody["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("run result payload = %#v, want object", runBody["result"])
+	}
+	if got := resultBody["total_findings"]; got != float64(2) {
+		t.Fatalf("run total_findings = %#v, want 2", got)
+	}
+	runID, ok := runBody["id"].(string)
+	if !ok || runID == "" {
+		t.Fatalf("run id = %#v, want non-empty string", runBody["id"])
+	}
+	if len(runtimeStore.reportRuns) != 1 {
+		t.Fatalf("len(runtimeStore.reportRuns) = %d, want 1", len(runtimeStore.reportRuns))
+	}
+
+	getResp, err := server.Client().Get(server.URL + "/report-runs/" + runID)
+	if err != nil {
+		t.Fatalf("GET /report-runs/{id} error = %v", err)
+	}
+	defer func() {
+		if closeErr := getResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close /report-runs/{id} response body: %v", closeErr)
+		}
+	}()
+	var getPayload map[string]any
+	if err := json.NewDecoder(getResp.Body).Decode(&getPayload); err != nil {
+		t.Fatalf("decode /report-runs/{id} response: %v", err)
+	}
+	getRunPayload, ok := getPayload["run"].(map[string]any)
+	if !ok {
+		t.Fatalf("get run payload = %#v, want object", getPayload["run"])
+	}
+	if got := getRunPayload["id"]; got != runID {
+		t.Fatalf("get run id = %#v, want %q", got, runID)
+	}
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	listReportsResp, err := client.ListReportDefinitions(context.Background(), connect.NewRequest(&cerebrov1.ListReportDefinitionsRequest{}))
+	if err != nil {
+		t.Fatalf("ListReportDefinitions() error = %v", err)
+	}
+	if len(listReportsResp.Msg.GetReports()) != 1 {
+		t.Fatalf("len(ListReportDefinitions.Reports) = %d, want 1", len(listReportsResp.Msg.GetReports()))
+	}
+	runReportResp, err := client.RunReport(context.Background(), connect.NewRequest(&cerebrov1.RunReportRequest{
+		ReportId: "finding-summary",
+		Parameters: map[string]string{
+			"runtime_id": "writer-okta-audit",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("RunReport() error = %v", err)
+	}
+	if got := runReportResp.Msg.GetRun().GetReportId(); got != "finding-summary" {
+		t.Fatalf("RunReport report id = %q, want finding-summary", got)
+	}
+	getRunResp, err := client.GetReportRun(context.Background(), connect.NewRequest(&cerebrov1.GetReportRunRequest{
+		Id: runReportResp.Msg.GetRun().GetId(),
+	}))
+	if err != nil {
+		t.Fatalf("GetReportRun() error = %v", err)
+	}
+	if got := getRunResp.Msg.GetRun().GetId(); got != runReportResp.Msg.GetRun().GetId() {
+		t.Fatalf("GetReportRun id = %q, want %q", got, runReportResp.Msg.GetRun().GetId())
+	}
+}
+
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.NewFixture()
 	if err != nil {
@@ -939,6 +1119,13 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 		FirstObservedAt: finding.FirstObservedAt,
 		LastObservedAt:  finding.LastObservedAt,
 	}
+}
+
+func cloneReportRun(run *cerebrov1.ReportRun) *cerebrov1.ReportRun {
+	if run == nil {
+		return nil
+	}
+	return proto.Clone(run).(*cerebrov1.ReportRun)
 }
 
 func cloneNeighborhood(neighborhood *ports.EntityNeighborhood) *ports.EntityNeighborhood {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/reports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	githubsource "github.com/writer/cerebro/sources/github"
 	oktasource "github.com/writer/cerebro/sources/okta"
@@ -1046,6 +1047,12 @@ func TestReportEndpoints(t *testing.T) {
 	}
 }
 
+func TestReportConnectErrorMapsInvalidRequestsToInvalidArgument(t *testing.T) {
+	err := reportConnectError(reports.ErrInvalidReportRequest)
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Fatalf("connect.CodeOf(reportConnectError()) = %v, want %v", got, connect.CodeInvalidArgument)
+	}
+}
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.NewFixture()
 	if err != nil {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -159,7 +159,7 @@ func (s *stubRuntimeStore) ListFindings(_ context.Context, request ports.ListFin
 	}
 	findings := []*ports.FindingRecord{}
 	for _, finding := range s.findings {
-		if finding == nil || finding.RuntimeID != request.RuntimeID {
+		if finding == nil || finding.TenantID != request.TenantID || finding.RuntimeID != request.RuntimeID {
 			continue
 		}
 		findings = append(findings, cloneFinding(finding))
@@ -912,6 +912,7 @@ func TestReportEndpoints(t *testing.T) {
 		findings: map[string]*ports.FindingRecord{
 			"finding-1": {
 				ID:        "finding-1",
+				TenantID:  "writer",
 				RuntimeID: "writer-okta-audit",
 				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
 				Severity:  "HIGH",
@@ -919,6 +920,7 @@ func TestReportEndpoints(t *testing.T) {
 			},
 			"finding-2": {
 				ID:        "finding-2",
+				TenantID:  "writer",
 				RuntimeID: "writer-okta-audit",
 				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
 				Severity:  "HIGH",
@@ -952,7 +954,7 @@ func TestReportEndpoints(t *testing.T) {
 		t.Fatalf("/reports payload = %#v, want 1 entry", listPayload["reports"])
 	}
 
-	runReq, err := http.NewRequest(http.MethodPost, server.URL+"/reports/finding-summary/runs?runtime_id=writer-okta-audit", nil)
+	runReq, err := http.NewRequest(http.MethodPost, server.URL+"/reports/finding-summary/runs?tenant_id=writer&runtime_id=writer-okta-audit", nil)
 	if err != nil {
 		t.Fatalf("new run report request: %v", err)
 	}
@@ -1023,6 +1025,7 @@ func TestReportEndpoints(t *testing.T) {
 	runReportResp, err := client.RunReport(context.Background(), connect.NewRequest(&cerebrov1.RunReportRequest{
 		ReportId: "finding-summary",
 		Parameters: map[string]string{
+			"tenant_id":  "writer",
 			"runtime_id": "writer-okta-audit",
 		},
 	}))

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1204,3 +1204,48 @@ func findingTestEvent(id string, eventType string, outcome string) *cerebrov1.Ev
 func projectedLinkKey(link *ports.ProjectedLink) string {
 	return link.FromURN + "|" + link.Relation + "|" + link.ToURN
 }
+
+// nilFindingStateStore is a concrete *struct that satisfies ports.FindingStore via pointer
+// receivers, so a typed-nil pointer value implements the interface without panicking on a
+// plain `if x == nil` check. The findingStore/reportStore/eventReplayer guards must catch this.
+type nilFindingStateStore struct{}
+
+func (*nilFindingStateStore) Ping(context.Context) error { return nil }
+func (*nilFindingStateStore) UpsertFinding(context.Context, *ports.FindingRecord) (*ports.FindingRecord, error) {
+	return nil, nil
+}
+func (*nilFindingStateStore) ListFindings(context.Context, ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+type nilReportStateStore struct{}
+
+func (*nilReportStateStore) Ping(context.Context) error                               { return nil }
+func (*nilReportStateStore) PutReportRun(context.Context, *cerebrov1.ReportRun) error { return nil }
+func (*nilReportStateStore) GetReportRun(context.Context, string) (*cerebrov1.ReportRun, error) {
+	return nil, nil
+}
+
+type nilEventReplayer struct{}
+
+func (*nilEventReplayer) Ping(context.Context) error                             { return nil }
+func (*nilEventReplayer) Append(context.Context, *cerebrov1.EventEnvelope) error { return nil }
+func (*nilEventReplayer) Replay(context.Context, ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
+	return nil, nil
+}
+
+func TestStoreCastsHandleTypedNilInterface(t *testing.T) {
+	t.Parallel()
+	var fs *nilFindingStateStore
+	var rs *nilReportStateStore
+	var er *nilEventReplayer
+	if got := findingStore(fs); got != nil {
+		t.Fatalf("findingStore(typed-nil) = %v, want nil", got)
+	}
+	if got := reportStore(rs); got != nil {
+		t.Fatalf("reportStore(typed-nil) = %v, want nil", got)
+	}
+	if got := eventReplayer(er); got != nil {
+		t.Fatalf("eventReplayer(typed-nil) = %v, want nil", got)
+	}
+}

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -63,6 +63,17 @@ func (s *stubFindingStore) UpsertFinding(_ context.Context, finding *ports.Findi
 	return cloneFinding(cloned), nil
 }
 
+func (s *stubFindingStore) ListFindings(_ context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	findings := []*ports.FindingRecord{}
+	for _, finding := range s.findings {
+		if finding == nil || finding.RuntimeID != request.RuntimeID {
+			continue
+		}
+		findings = append(findings, cloneFinding(finding))
+	}
+	return findings, nil
+}
+
 func TestEvaluateSourceRuntimeFindingsReplaysOktaPolicyRuleLifecycleTampering(t *testing.T) {
 	replayer := &stubReplayer{
 		events: []*cerebrov1.EventEnvelope{

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -25,6 +25,7 @@ type FindingRecord struct {
 
 // ListFindingsRequest scopes one finding query.
 type ListFindingsRequest struct {
+	TenantID  string
 	RuntimeID string
 }
 

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -23,8 +23,14 @@ type FindingRecord struct {
 	LastObservedAt  time.Time
 }
 
+// ListFindingsRequest scopes one finding query.
+type ListFindingsRequest struct {
+	RuntimeID string
+}
+
 // FindingStore persists normalized findings in the state store.
 type FindingStore interface {
 	StateStore
 	UpsertFinding(context.Context, *FindingRecord) (*FindingRecord, error)
+	ListFindings(context.Context, ListFindingsRequest) ([]*FindingRecord, error)
 }

--- a/internal/ports/reports.go
+++ b/internal/ports/reports.go
@@ -1,0 +1,18 @@
+package ports
+
+import (
+	"context"
+	"errors"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+// ErrReportRunNotFound indicates that a persisted report run does not exist.
+var ErrReportRunNotFound = errors.New("report run not found")
+
+// ReportStore persists durable report runs in the state store.
+type ReportStore interface {
+	StateStore
+	PutReportRun(context.Context, *cerebrov1.ReportRun) error
+	GetReportRun(context.Context, string) (*cerebrov1.ReportRun, error)
+}

--- a/internal/reports/errors.go
+++ b/internal/reports/errors.go
@@ -1,0 +1,19 @@
+package reports
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrInvalidReportRequest indicates that the request payload or parameters are invalid.
+	ErrInvalidReportRequest = errors.New("invalid report request")
+)
+
+func invalidReportRequest(message string) error {
+	return fmt.Errorf("%w: %s", ErrInvalidReportRequest, message)
+}
+
+func invalidReportRequestf(format string, args ...any) error {
+	return invalidReportRequest(fmt.Sprintf(format, args...))
+}

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -1,0 +1,239 @@
+package reports
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	findingSummaryReportID     = "finding-summary"
+	findingSummaryReportName   = "Finding Summary"
+	findingSummaryReportStatus = "completed"
+	reportParameterRuntimeID   = "runtime_id"
+)
+
+var (
+	// ErrRuntimeUnavailable indicates that the report-run dependencies are unavailable.
+	ErrRuntimeUnavailable = errors.New("report runtime is unavailable")
+
+	// ErrReportNotFound indicates that a requested built-in report definition does not exist.
+	ErrReportNotFound = errors.New("report definition not found")
+)
+
+// Service exposes the first durable report-run foundation.
+type Service struct {
+	findingStore ports.FindingStore
+	reportStore  ports.ReportStore
+}
+
+// New constructs the report service.
+func New(findingStore ports.FindingStore, reportStore ports.ReportStore) *Service {
+	return &Service{
+		findingStore: findingStore,
+		reportStore:  reportStore,
+	}
+}
+
+// List returns the built-in report definition catalog.
+func (s *Service) List() *cerebrov1.ListReportDefinitionsResponse {
+	return &cerebrov1.ListReportDefinitionsResponse{
+		Reports: []*cerebrov1.ReportDefinition{
+			findingSummaryDefinition(),
+		},
+	}
+}
+
+// Run evaluates one built-in report and persists the resulting run.
+func (s *Service) Run(ctx context.Context, request *cerebrov1.RunReportRequest) (*cerebrov1.RunReportResponse, error) {
+	if s == nil || s.findingStore == nil || s.reportStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	if request == nil {
+		return nil, errors.New("report request is required")
+	}
+	reportID := strings.TrimSpace(request.GetReportId())
+	if reportID == "" {
+		return nil, errors.New("report id is required")
+	}
+	definition, err := reportDefinition(reportID)
+	if err != nil {
+		return nil, err
+	}
+	parameters := normalizeParameters(request.GetParameters())
+	generatedAt := time.Now().UTC()
+
+	var result *structpb.Struct
+	switch reportID {
+	case findingSummaryReportID:
+		result, err = s.runFindingSummary(ctx, parameters)
+	default:
+		err = fmt.Errorf("%w: %s", ErrReportNotFound, reportID)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	run := &cerebrov1.ReportRun{
+		Id:          reportRunID(reportID, generatedAt),
+		ReportId:    reportID,
+		Parameters:  parameters,
+		Status:      findingSummaryReportStatus,
+		GeneratedAt: timestamppb.New(generatedAt),
+		Result:      result,
+	}
+	if err := s.reportStore.PutReportRun(ctx, run); err != nil {
+		return nil, fmt.Errorf("persist report run %q: %w", run.GetId(), err)
+	}
+	return &cerebrov1.RunReportResponse{
+		Report: definition,
+		Run:    run,
+	}, nil
+}
+
+// Get loads one persisted report run.
+func (s *Service) Get(ctx context.Context, request *cerebrov1.GetReportRunRequest) (*cerebrov1.GetReportRunResponse, error) {
+	if s == nil || s.reportStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	if request == nil {
+		return nil, errors.New("get report run request is required")
+	}
+	reportRunID := strings.TrimSpace(request.GetId())
+	if reportRunID == "" {
+		return nil, errors.New("report run id is required")
+	}
+	run, err := s.reportStore.GetReportRun(ctx, reportRunID)
+	if err != nil {
+		return nil, err
+	}
+	return &cerebrov1.GetReportRunResponse{Run: run}, nil
+}
+
+func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]string) (*structpb.Struct, error) {
+	runtimeID := strings.TrimSpace(parameters[reportParameterRuntimeID])
+	if runtimeID == "" {
+		return nil, fmt.Errorf("report parameter %q is required", reportParameterRuntimeID)
+	}
+	findings, err := s.findingStore.ListFindings(ctx, ports.ListFindingsRequest{RuntimeID: runtimeID})
+	if err != nil {
+		return nil, fmt.Errorf("list findings for runtime %q: %w", runtimeID, err)
+	}
+	severityCounts := make(map[string]int, len(findings))
+	statusCounts := make(map[string]int, len(findings))
+	ruleCounts := make(map[string]int, len(findings))
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		severity := strings.TrimSpace(finding.Severity)
+		if severity != "" {
+			severityCounts[severity]++
+		}
+		status := strings.TrimSpace(finding.Status)
+		if status != "" {
+			statusCounts[status]++
+		}
+		ruleID := strings.TrimSpace(finding.RuleID)
+		if ruleID != "" {
+			ruleCounts[ruleID]++
+		}
+	}
+	result, err := structpb.NewStruct(map[string]any{
+		reportParameterRuntimeID: runtimeID,
+		"total_findings":         len(findings),
+		"severity_counts":        countEntries(severityCounts, "severity"),
+		"status_counts":          countEntries(statusCounts, "status"),
+		"rule_counts":            countEntries(ruleCounts, "rule_id"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build finding summary report result: %w", err)
+	}
+	return result, nil
+}
+
+func findingSummaryDefinition() *cerebrov1.ReportDefinition {
+	return &cerebrov1.ReportDefinition{
+		Id:          findingSummaryReportID,
+		Name:        findingSummaryReportName,
+		Description: "Materialize one runtime-scoped summary of persisted findings, grouped by severity, status, and rule.",
+		Parameters: []*cerebrov1.ReportParameter{
+			{
+				Id:          reportParameterRuntimeID,
+				Description: "Stored source runtime identifier whose persisted findings should be summarized.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func reportDefinition(reportID string) (*cerebrov1.ReportDefinition, error) {
+	switch strings.TrimSpace(reportID) {
+	case findingSummaryReportID:
+		return findingSummaryDefinition(), nil
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrReportNotFound, reportID)
+	}
+}
+
+func normalizeParameters(parameters map[string]string) map[string]string {
+	if len(parameters) == 0 {
+		return map[string]string{}
+	}
+	normalized := make(map[string]string, len(parameters))
+	for key, value := range parameters {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			continue
+		}
+		normalized[trimmedKey] = strings.TrimSpace(value)
+	}
+	return normalized
+}
+
+func reportRunID(reportID string, generatedAt time.Time) string {
+	replacer := strings.NewReplacer(" ", "-", "_", "-", "/", "-")
+	return replacer.Replace(strings.TrimSpace(reportID)) + "-" + fmt.Sprintf("%d", generatedAt.UnixNano())
+}
+
+func countEntries(counts map[string]int, keyName string) []any {
+	type countEntry struct {
+		Key   string
+		Count int
+	}
+	entries := make([]countEntry, 0, len(counts))
+	for key, count := range counts {
+		entries = append(entries, countEntry{Key: key, Count: count})
+	}
+	slices.SortFunc(entries, func(left countEntry, right countEntry) int {
+		switch {
+		case left.Count > right.Count:
+			return -1
+		case left.Count < right.Count:
+			return 1
+		case left.Key < right.Key:
+			return -1
+		case left.Key > right.Key:
+			return 1
+		default:
+			return 0
+		}
+	})
+	values := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		values = append(values, map[string]any{
+			keyName: entry.Key,
+			"count": entry.Count,
+		})
+	}
+	return values
+}

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -2,6 +2,8 @@ package reports
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"slices"
@@ -19,6 +21,7 @@ const (
 	findingSummaryReportID     = "finding-summary"
 	findingSummaryReportName   = "Finding Summary"
 	findingSummaryReportStatus = "completed"
+	reportParameterTenantID    = "tenant_id"
 	reportParameterRuntimeID   = "runtime_id"
 )
 
@@ -83,8 +86,12 @@ func (s *Service) Run(ctx context.Context, request *cerebrov1.RunReportRequest) 
 		return nil, err
 	}
 
+	runID, err := reportRunID(reportID, generatedAt)
+	if err != nil {
+		return nil, err
+	}
 	run := &cerebrov1.ReportRun{
-		Id:          reportRunID(reportID, generatedAt),
+		Id:          runID,
 		ReportId:    reportID,
 		Parameters:  parameters,
 		Status:      findingSummaryReportStatus,
@@ -120,13 +127,17 @@ func (s *Service) Get(ctx context.Context, request *cerebrov1.GetReportRunReques
 }
 
 func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]string) (*structpb.Struct, error) {
+	tenantID := strings.TrimSpace(parameters[reportParameterTenantID])
+	if tenantID == "" {
+		return nil, fmt.Errorf("report parameter %q is required", reportParameterTenantID)
+	}
 	runtimeID := strings.TrimSpace(parameters[reportParameterRuntimeID])
 	if runtimeID == "" {
 		return nil, fmt.Errorf("report parameter %q is required", reportParameterRuntimeID)
 	}
-	findings, err := s.findingStore.ListFindings(ctx, ports.ListFindingsRequest{RuntimeID: runtimeID})
+	findings, err := s.findingStore.ListFindings(ctx, ports.ListFindingsRequest{TenantID: tenantID, RuntimeID: runtimeID})
 	if err != nil {
-		return nil, fmt.Errorf("list findings for runtime %q: %w", runtimeID, err)
+		return nil, fmt.Errorf("list findings for tenant %q runtime %q: %w", tenantID, runtimeID, err)
 	}
 	severityCounts := make(map[string]int, len(findings))
 	statusCounts := make(map[string]int, len(findings))
@@ -149,6 +160,7 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 		}
 	}
 	result, err := structpb.NewStruct(map[string]any{
+		reportParameterTenantID:  tenantID,
 		reportParameterRuntimeID: runtimeID,
 		"total_findings":         len(findings),
 		"severity_counts":        countEntries(severityCounts, "severity"),
@@ -165,8 +177,13 @@ func findingSummaryDefinition() *cerebrov1.ReportDefinition {
 	return &cerebrov1.ReportDefinition{
 		Id:          findingSummaryReportID,
 		Name:        findingSummaryReportName,
-		Description: "Materialize one runtime-scoped summary of persisted findings, grouped by severity, status, and rule.",
+		Description: "Materialize one tenant/runtime-scoped summary of persisted findings, grouped by severity, status, and rule.",
 		Parameters: []*cerebrov1.ReportParameter{
+			{
+				Id:          reportParameterTenantID,
+				Description: "Tenant identifier whose persisted findings should be summarized.",
+				Required:    true,
+			},
 			{
 				Id:          reportParameterRuntimeID,
 				Description: "Stored source runtime identifier whose persisted findings should be summarized.",
@@ -200,9 +217,13 @@ func normalizeParameters(parameters map[string]string) map[string]string {
 	return normalized
 }
 
-func reportRunID(reportID string, generatedAt time.Time) string {
+func reportRunID(reportID string, generatedAt time.Time) (string, error) {
 	replacer := strings.NewReplacer(" ", "-", "_", "-", "/", "-")
-	return replacer.Replace(strings.TrimSpace(reportID)) + "-" + fmt.Sprintf("%d", generatedAt.UnixNano())
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate report run id entropy: %w", err)
+	}
+	return replacer.Replace(strings.TrimSpace(reportID)) + "-" + fmt.Sprintf("%d", generatedAt.UnixNano()) + "-" + hex.EncodeToString(random), nil
 }
 
 func countEntries(counts map[string]int, keyName string) []any {

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -62,11 +62,11 @@ func (s *Service) Run(ctx context.Context, request *cerebrov1.RunReportRequest) 
 		return nil, ErrRuntimeUnavailable
 	}
 	if request == nil {
-		return nil, errors.New("report request is required")
+		return nil, invalidReportRequest("report request is required")
 	}
 	reportID := strings.TrimSpace(request.GetReportId())
 	if reportID == "" {
-		return nil, errors.New("report id is required")
+		return nil, invalidReportRequest("report id is required")
 	}
 	definition, err := reportDefinition(reportID)
 	if err != nil {
@@ -113,11 +113,11 @@ func (s *Service) Get(ctx context.Context, request *cerebrov1.GetReportRunReques
 		return nil, ErrRuntimeUnavailable
 	}
 	if request == nil {
-		return nil, errors.New("get report run request is required")
+		return nil, invalidReportRequest("get report run request is required")
 	}
 	reportRunID := strings.TrimSpace(request.GetId())
 	if reportRunID == "" {
-		return nil, errors.New("report run id is required")
+		return nil, invalidReportRequest("report run id is required")
 	}
 	run, err := s.reportStore.GetReportRun(ctx, reportRunID)
 	if err != nil {
@@ -129,11 +129,11 @@ func (s *Service) Get(ctx context.Context, request *cerebrov1.GetReportRunReques
 func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]string) (*structpb.Struct, error) {
 	tenantID := strings.TrimSpace(parameters[reportParameterTenantID])
 	if tenantID == "" {
-		return nil, fmt.Errorf("report parameter %q is required", reportParameterTenantID)
+		return nil, invalidReportRequestf("report parameter %q is required", reportParameterTenantID)
 	}
 	runtimeID := strings.TrimSpace(parameters[reportParameterRuntimeID])
 	if runtimeID == "" {
-		return nil, fmt.Errorf("report parameter %q is required", reportParameterRuntimeID)
+		return nil, invalidReportRequestf("report parameter %q is required", reportParameterRuntimeID)
 	}
 	findings, err := s.findingStore.ListFindings(ctx, ports.ListFindingsRequest{TenantID: tenantID, RuntimeID: runtimeID})
 	if err != nil {

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -123,6 +123,19 @@ func TestGetReportRunRequiresAvailableStore(t *testing.T) {
 	}
 }
 
+func TestRunFindingSummaryReportWrapsValidationErrors(t *testing.T) {
+	service := New(&stubFindingStore{}, &stubReportStore{})
+	_, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: findingSummaryReportID,
+		Parameters: map[string]string{
+			reportParameterTenantID: "writer",
+		},
+	})
+	if !errors.Is(err, ErrInvalidReportRequest) {
+		t.Fatalf("Run() error = %v, want %v", err, ErrInvalidReportRequest)
+	}
+}
+
 func TestListReportDefinitionsIncludesFindingSummary(t *testing.T) {
 	response := New(nil, nil).List()
 	if len(response.GetReports()) != 1 {

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -1,0 +1,174 @@
+package reports
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type stubFindingStore struct {
+	findings []*ports.FindingRecord
+	request  ports.ListFindingsRequest
+}
+
+func (s *stubFindingStore) Ping(context.Context) error { return nil }
+
+func (s *stubFindingStore) UpsertFinding(context.Context, *ports.FindingRecord) (*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (s *stubFindingStore) ListFindings(_ context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	s.request = request
+	findings := make([]*ports.FindingRecord, 0, len(s.findings))
+	for _, finding := range s.findings {
+		findings = append(findings, cloneFinding(finding))
+	}
+	return findings, nil
+}
+
+type stubReportStore struct {
+	run *cerebrov1.ReportRun
+}
+
+func (s *stubReportStore) Ping(context.Context) error { return nil }
+
+func (s *stubReportStore) PutReportRun(_ context.Context, run *cerebrov1.ReportRun) error {
+	s.run = cloneReportRun(run)
+	return nil
+}
+
+func (s *stubReportStore) GetReportRun(_ context.Context, id string) (*cerebrov1.ReportRun, error) {
+	if s.run == nil || s.run.GetId() != id {
+		return nil, ports.ErrReportRunNotFound
+	}
+	return cloneReportRun(s.run), nil
+}
+
+func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
+	findingStore := &stubFindingStore{
+		findings: []*ports.FindingRecord{
+			{
+				ID:        "finding-1",
+				RuntimeID: "writer-okta-audit",
+				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
+				Severity:  "HIGH",
+				Status:    "open",
+			},
+			{
+				ID:        "finding-2",
+				RuntimeID: "writer-okta-audit",
+				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
+				Severity:  "HIGH",
+				Status:    "resolved",
+			},
+		},
+	}
+	reportStore := &stubReportStore{}
+	service := New(findingStore, reportStore)
+
+	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: findingSummaryReportID,
+		Parameters: map[string]string{
+			reportParameterRuntimeID: "writer-okta-audit",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if response.GetReport().GetId() != findingSummaryReportID {
+		t.Fatalf("Run().Report.ID = %q, want %q", response.GetReport().GetId(), findingSummaryReportID)
+	}
+	if response.GetRun().GetReportId() != findingSummaryReportID {
+		t.Fatalf("Run().Run.ReportId = %q, want %q", response.GetRun().GetReportId(), findingSummaryReportID)
+	}
+	if response.GetRun().GetStatus() != findingSummaryReportStatus {
+		t.Fatalf("Run().Run.Status = %q, want %q", response.GetRun().GetStatus(), findingSummaryReportStatus)
+	}
+	if findingStore.request.RuntimeID != "writer-okta-audit" {
+		t.Fatalf("ListFindings().RuntimeID = %q, want writer-okta-audit", findingStore.request.RuntimeID)
+	}
+	result := response.GetRun().GetResult().AsMap()
+	if got := result[reportParameterRuntimeID]; got != "writer-okta-audit" {
+		t.Fatalf("Run().Run.Result[runtime_id] = %#v, want writer-okta-audit", got)
+	}
+	if got := result["total_findings"]; got != float64(2) {
+		t.Fatalf("Run().Run.Result[total_findings] = %#v, want 2", got)
+	}
+	severityCounts, ok := result["severity_counts"].([]any)
+	if !ok || len(severityCounts) != 1 {
+		t.Fatalf("Run().Run.Result[severity_counts] = %#v, want 1 entry", result["severity_counts"])
+	}
+	if reportStore.run == nil {
+		t.Fatal("PutReportRun() not called")
+	}
+}
+
+func TestGetReportRunRequiresAvailableStore(t *testing.T) {
+	service := New(nil, nil)
+	if _, err := service.Get(context.Background(), &cerebrov1.GetReportRunRequest{Id: "report-run-1"}); !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("Get() error = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}
+
+func TestListReportDefinitionsIncludesFindingSummary(t *testing.T) {
+	response := New(nil, nil).List()
+	if len(response.GetReports()) != 1 {
+		t.Fatalf("len(List().Reports) = %d, want 1", len(response.GetReports()))
+	}
+	if response.GetReports()[0].GetId() != findingSummaryReportID {
+		t.Fatalf("List().Reports[0].ID = %q, want %q", response.GetReports()[0].GetId(), findingSummaryReportID)
+	}
+}
+
+func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
+	if finding == nil {
+		return nil
+	}
+	return &ports.FindingRecord{
+		ID:              finding.ID,
+		Fingerprint:     finding.Fingerprint,
+		TenantID:        finding.TenantID,
+		RuntimeID:       finding.RuntimeID,
+		RuleID:          finding.RuleID,
+		Title:           finding.Title,
+		Severity:        finding.Severity,
+		Status:          finding.Status,
+		Summary:         finding.Summary,
+		ResourceURNs:    append([]string(nil), finding.ResourceURNs...),
+		EventIDs:        append([]string(nil), finding.EventIDs...),
+		Attributes:      cloneAttributes(finding.Attributes),
+		FirstObservedAt: finding.FirstObservedAt,
+		LastObservedAt:  finding.LastObservedAt,
+	}
+}
+
+func cloneReportRun(run *cerebrov1.ReportRun) *cerebrov1.ReportRun {
+	if run == nil {
+		return nil
+	}
+	cloned := &cerebrov1.ReportRun{
+		Id:          run.GetId(),
+		ReportId:    run.GetReportId(),
+		Parameters:  cloneAttributes(run.GetParameters()),
+		Status:      run.GetStatus(),
+		GeneratedAt: run.GetGeneratedAt(),
+	}
+	if run.GetResult() != nil {
+		cloned.Result = run.GetResult()
+	}
+	return cloned
+}
+
+func cloneAttributes(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return map[string]string{}
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
@@ -52,6 +53,7 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 		findings: []*ports.FindingRecord{
 			{
 				ID:        "finding-1",
+				TenantID:  "writer",
 				RuntimeID: "writer-okta-audit",
 				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
 				Severity:  "HIGH",
@@ -59,6 +61,7 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 			},
 			{
 				ID:        "finding-2",
+				TenantID:  "writer",
 				RuntimeID: "writer-okta-audit",
 				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
 				Severity:  "HIGH",
@@ -72,6 +75,7 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
 		ReportId: findingSummaryReportID,
 		Parameters: map[string]string{
+			reportParameterTenantID:  "writer",
 			reportParameterRuntimeID: "writer-okta-audit",
 		},
 	})
@@ -87,10 +91,16 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 	if response.GetRun().GetStatus() != findingSummaryReportStatus {
 		t.Fatalf("Run().Run.Status = %q, want %q", response.GetRun().GetStatus(), findingSummaryReportStatus)
 	}
+	if findingStore.request.TenantID != "writer" {
+		t.Fatalf("ListFindings().TenantID = %q, want writer", findingStore.request.TenantID)
+	}
 	if findingStore.request.RuntimeID != "writer-okta-audit" {
 		t.Fatalf("ListFindings().RuntimeID = %q, want writer-okta-audit", findingStore.request.RuntimeID)
 	}
 	result := response.GetRun().GetResult().AsMap()
+	if got := result[reportParameterTenantID]; got != "writer" {
+		t.Fatalf("Run().Run.Result[tenant_id] = %#v, want writer", got)
+	}
 	if got := result[reportParameterRuntimeID]; got != "writer-okta-audit" {
 		t.Fatalf("Run().Run.Result[runtime_id] = %#v, want writer-okta-audit", got)
 	}
@@ -120,6 +130,21 @@ func TestListReportDefinitionsIncludesFindingSummary(t *testing.T) {
 	}
 	if response.GetReports()[0].GetId() != findingSummaryReportID {
 		t.Fatalf("List().Reports[0].ID = %q, want %q", response.GetReports()[0].GetId(), findingSummaryReportID)
+	}
+}
+
+func TestReportRunIDIncludesEntropy(t *testing.T) {
+	generatedAt := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	first, err := reportRunID(findingSummaryReportID, generatedAt)
+	if err != nil {
+		t.Fatalf("reportRunID(first) error = %v", err)
+	}
+	second, err := reportRunID(findingSummaryReportID, generatedAt)
+	if err != nil {
+		t.Fatalf("reportRunID(second) error = %v", err)
+	}
+	if first == second {
+		t.Fatalf("reportRunID() returned duplicate id %q", first)
 	}
 }
 

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -163,8 +163,12 @@ RETURNING
 	return stored.record()
 }
 
-// ListFindings loads persisted findings for one runtime.
+// ListFindings loads persisted findings for one tenant/runtime scope.
 func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequest) (_ []*ports.FindingRecord, err error) {
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return nil, errors.New("finding tenant id is required")
+	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
 	if runtimeID == "" {
 		return nil, errors.New("finding runtime id is required")
@@ -180,10 +184,10 @@ SELECT
   id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
   resource_urns_json::text, event_ids_json::text, attributes_json::text, first_observed_at, last_observed_at
 FROM findings
-WHERE runtime_id = $1
-ORDER BY last_observed_at DESC, id`, runtimeID)
+WHERE tenant_id = $1 AND runtime_id = $2
+ORDER BY last_observed_at DESC, id`, tenantID, runtimeID)
 	if err != nil {
-		return nil, fmt.Errorf("query findings for runtime %q: %w", runtimeID, err)
+		return nil, fmt.Errorf("query findings for tenant %q runtime %q: %w", tenantID, runtimeID, err)
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil && err == nil {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -163,6 +163,67 @@ RETURNING
 	return stored.record()
 }
 
+// ListFindings loads persisted findings for one runtime.
+func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequest) (_ []*ports.FindingRecord, err error) {
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, errors.New("finding runtime id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT
+  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
+  resource_urns_json::text, event_ids_json::text, attributes_json::text, first_observed_at, last_observed_at
+FROM findings
+WHERE runtime_id = $1
+ORDER BY last_observed_at DESC, id`, runtimeID)
+	if err != nil {
+		return nil, fmt.Errorf("query findings for runtime %q: %w", runtimeID, err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close findings rows: %w", closeErr)
+		}
+	}()
+
+	findings := []*ports.FindingRecord{}
+	for rows.Next() {
+		var row findingRow
+		if err := rows.Scan(
+			&row.ID,
+			&row.Fingerprint,
+			&row.TenantID,
+			&row.RuntimeID,
+			&row.RuleID,
+			&row.Title,
+			&row.Severity,
+			&row.Status,
+			&row.Summary,
+			&row.ResourceURNsJSON,
+			&row.EventIDsJSON,
+			&row.AttributesJSON,
+			&row.FirstObservedAt,
+			&row.LastObservedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan finding row: %w", err)
+		}
+		record, err := row.record()
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate findings rows: %w", err)
+	}
+	return findings, nil
+}
+
 func (s *Store) ensureFindingTables(ctx context.Context) error {
 	for _, statement := range ensureFindingStatements {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -54,16 +54,23 @@ func TestUpsertFindingRejectsUnconfiguredStore(t *testing.T) {
 	}
 }
 
-func TestListFindingsRejectsMissingRuntimeID(t *testing.T) {
+func TestListFindingsRejectsMissingTenantID(t *testing.T) {
 	store := &Store{}
 	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{}); err == nil {
 		t.Fatal("ListFindings() error = nil, want non-nil")
 	}
 }
 
+func TestListFindingsRejectsMissingRuntimeID(t *testing.T) {
+	store := &Store{}
+	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{TenantID: "writer"}); err == nil {
+		t.Fatal("ListFindings() error = nil, want non-nil")
+	}
+}
+
 func TestListFindingsRejectsUnconfiguredStore(t *testing.T) {
 	store := &Store{}
-	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{RuntimeID: "writer-okta-audit"}); err == nil {
+	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{TenantID: "writer", RuntimeID: "writer-okta-audit"}); err == nil {
 		t.Fatal("ListFindings() error = nil, want non-nil")
 	}
 }

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -53,3 +53,17 @@ func TestUpsertFindingRejectsUnconfiguredStore(t *testing.T) {
 		t.Fatal("UpsertFinding() error = nil, want non-nil")
 	}
 }
+
+func TestListFindingsRejectsMissingRuntimeID(t *testing.T) {
+	store := &Store{}
+	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{}); err == nil {
+		t.Fatal("ListFindings() error = nil, want non-nil")
+	}
+}
+
+func TestListFindingsRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{RuntimeID: "writer-okta-audit"}); err == nil {
+		t.Fatal("ListFindings() error = nil, want non-nil")
+	}
+}

--- a/internal/statestore/postgres/reports.go
+++ b/internal/statestore/postgres/reports.go
@@ -1,0 +1,92 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const ensureReportRunTableSQL = `
+CREATE TABLE IF NOT EXISTS report_runs (
+  id TEXT PRIMARY KEY,
+  report_run_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`
+
+// PutReportRun upserts one durable report run.
+func (s *Store) PutReportRun(ctx context.Context, run *cerebrov1.ReportRun) error {
+	if run == nil {
+		return errors.New("report run is required")
+	}
+	id := strings.TrimSpace(run.GetId())
+	if id == "" {
+		return errors.New("report run id is required")
+	}
+	reportID := strings.TrimSpace(run.GetReportId())
+	if reportID == "" {
+		return errors.New("report id is required")
+	}
+	status := strings.TrimSpace(run.GetStatus())
+	if status == "" {
+		return errors.New("report run status is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureReportRunTable(ctx); err != nil {
+		return err
+	}
+	payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(run)
+	if err != nil {
+		return fmt.Errorf("marshal report run: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO report_runs (id, report_run_json)
+VALUES ($1, $2::jsonb)
+ON CONFLICT (id)
+DO UPDATE SET report_run_json = EXCLUDED.report_run_json, updated_at = NOW()`, id, string(payload)); err != nil {
+		return fmt.Errorf("upsert report run %q: %w", id, err)
+	}
+	return nil
+}
+
+// GetReportRun loads one persisted report run.
+func (s *Store) GetReportRun(ctx context.Context, reportRunID string) (*cerebrov1.ReportRun, error) {
+	id := strings.TrimSpace(reportRunID)
+	if id == "" {
+		return nil, errors.New("report run id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureReportRunTable(ctx); err != nil {
+		return nil, err
+	}
+	var payload string
+	if err := s.db.QueryRowContext(ctx, `SELECT report_run_json::text FROM report_runs WHERE id = $1`, id).Scan(&payload); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrReportRunNotFound, id)
+		}
+		return nil, fmt.Errorf("query report run %q: %w", id, err)
+	}
+	run := &cerebrov1.ReportRun{}
+	if err := protojson.Unmarshal([]byte(payload), run); err != nil {
+		return nil, fmt.Errorf("decode report run %q: %w", id, err)
+	}
+	return run, nil
+}
+
+func (s *Store) ensureReportRunTable(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, ensureReportRunTableSQL); err != nil {
+		return fmt.Errorf("ensure report run table: %w", err)
+	}
+	return nil
+}

--- a/internal/statestore/postgres/reports_test.go
+++ b/internal/statestore/postgres/reports_test.go
@@ -1,0 +1,59 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestPutReportRunRejectsNilRun(t *testing.T) {
+	store := &Store{}
+	if err := store.PutReportRun(context.Background(), nil); err == nil {
+		t.Fatal("PutReportRun() error = nil, want non-nil")
+	}
+}
+
+func TestPutReportRunRejectsMissingReportID(t *testing.T) {
+	store := &Store{}
+	err := store.PutReportRun(context.Background(), &cerebrov1.ReportRun{
+		Id:     "report-run-1",
+		Status: "completed",
+	})
+	if err == nil {
+		t.Fatal("PutReportRun() error = nil, want non-nil")
+	}
+}
+
+func TestGetReportRunRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	if _, err := store.GetReportRun(context.Background(), "report-run-1"); err == nil {
+		t.Fatal("GetReportRun() error = nil, want non-nil")
+	}
+}
+
+func TestGetReportRunRejectsMissingID(t *testing.T) {
+	store := &Store{}
+	if _, err := store.GetReportRun(context.Background(), ""); err == nil {
+		t.Fatal("GetReportRun() error = nil, want non-nil")
+	}
+}
+
+func TestPutReportRunRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	result, err := structpb.NewStruct(map[string]any{"total_findings": 1})
+	if err != nil {
+		t.Fatalf("NewStruct() error = %v", err)
+	}
+	err = store.PutReportRun(context.Background(), &cerebrov1.ReportRun{
+		Id:       "report-run-1",
+		ReportId: "finding-summary",
+		Status:   "completed",
+		Result:   result,
+	})
+	if err == nil {
+		t.Fatal("PutReportRun() error = nil, want non-nil")
+	}
+}

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -13,6 +13,9 @@ import "google/protobuf/timestamp.proto";
 service BootstrapService {
   rpc GetVersion(GetVersionRequest) returns (GetVersionResponse);
   rpc CheckHealth(CheckHealthRequest) returns (CheckHealthResponse);
+  rpc ListReportDefinitions(ListReportDefinitionsRequest) returns (ListReportDefinitionsResponse);
+  rpc RunReport(RunReportRequest) returns (RunReportResponse);
+  rpc GetReportRun(GetReportRunRequest) returns (GetReportRunResponse);
   rpc ListSources(ListSourcesRequest) returns (ListSourcesResponse);
   rpc CheckSource(CheckSourceRequest) returns (CheckSourceResponse);
   rpc DiscoverSource(DiscoverSourceRequest) returns (DiscoverSourceResponse);
@@ -51,6 +54,61 @@ message CheckHealthResponse {
   string status = 1;
   google.protobuf.Timestamp checked_at = 2;
   repeated ComponentStatus components = 3;
+}
+
+// ReportParameter describes one supported report input parameter.
+message ReportParameter {
+  string id = 1;
+  string description = 2;
+  bool required = 3;
+}
+
+// ReportDefinition exposes one built-in durable report contract.
+message ReportDefinition {
+  string id = 1;
+  string name = 2;
+  string description = 3;
+  repeated ReportParameter parameters = 4;
+}
+
+// ReportRun is the durable result envelope for one built-in report execution.
+message ReportRun {
+  string id = 1;
+  string report_id = 2;
+  map<string, string> parameters = 3;
+  string status = 4;
+  google.protobuf.Timestamp generated_at = 5;
+  google.protobuf.Struct result = 6;
+}
+
+// ListReportDefinitionsRequest requests the built-in report catalog.
+message ListReportDefinitionsRequest {}
+
+// ListReportDefinitionsResponse returns the built-in report catalog.
+message ListReportDefinitionsResponse {
+  repeated ReportDefinition reports = 1;
+}
+
+// RunReportRequest requests one durable report run.
+message RunReportRequest {
+  string report_id = 1;
+  map<string, string> parameters = 2;
+}
+
+// RunReportResponse returns the resolved definition plus the persisted run.
+message RunReportResponse {
+  ReportDefinition report = 1;
+  ReportRun run = 2;
+}
+
+// GetReportRunRequest looks up one persisted report run.
+message GetReportRunRequest {
+  string id = 1;
+}
+
+// GetReportRunResponse returns one persisted report run.
+message GetReportRunResponse {
+  ReportRun run = 1;
 }
 
 // ListSourcesRequest requests the currently registered source catalog.


### PR DESCRIPTION
## Summary
- add a durable report-run foundation with built-in report definitions, persisted report runs, and bootstrap REST/Connect endpoints
- add the first built-in `finding-summary` report that materializes one runtime-scoped summary of persisted findings by severity, status, and rule
- extend the Postgres finding store with runtime-scoped finding reads so reports can compose over persisted findings instead of introducing a separate compliance module

## Testing
- make verify
- go test ./internal/reports ./internal/bootstrap ./internal/statestore/postgres ./internal/findings
- local finding-summary report demo
