### PR TITLE
feat(report): include graph evidence in finding summaries

### DIFF
--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -288,6 +288,7 @@ func (s *bootstrapService) CheckHealth(ctx context.Context, _ *connect.Request[c
 func (s *bootstrapService) ListReportDefinitions(_ context.Context, _ *connect.Request[cerebrov1.ListReportDefinitionsRequest]) (*connect.Response[cerebrov1.ListReportDefinitionsResponse], error) {
 	return connect.NewResponse(reports.New(
 		findingStore(s.deps.StateStore),
+		graphQueryStore(s.deps.GraphStore),
 		reportStore(s.deps.StateStore),
 	).List()), nil
 }
@@ -295,6 +296,7 @@ func (s *bootstrapService) ListReportDefinitions(_ context.Context, _ *connect.R
 func (s *bootstrapService) RunReport(ctx context.Context, req *connect.Request[cerebrov1.RunReportRequest]) (*connect.Response[cerebrov1.RunReportResponse], error) {
 	response, err := reports.New(
 		findingStore(s.deps.StateStore),
+		graphQueryStore(s.deps.GraphStore),
 		reportStore(s.deps.StateStore),
 	).Run(ctx, req.Msg)
 	if err != nil {
@@ -306,6 +308,7 @@ func (s *bootstrapService) RunReport(ctx context.Context, req *connect.Request[c
 func (s *bootstrapService) GetReportRun(ctx context.Context, req *connect.Request[cerebrov1.GetReportRunRequest]) (*connect.Response[cerebrov1.GetReportRunResponse], error) {
 	response, err := reports.New(
 		findingStore(s.deps.StateStore),
+		graphQueryStore(s.deps.GraphStore),
 		reportStore(s.deps.StateStore),
 	).Get(ctx, req.Msg)
 	if err != nil {
@@ -447,6 +450,7 @@ func (a *App) sourceService() *sourceops.Service {
 func (a *App) reportService() *reports.Service {
 	return reports.New(
 		findingStore(a.deps.StateStore),
+		graphQueryStore(a.deps.GraphStore),
 		reportStore(a.deps.StateStore),
 	)
 }

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -912,27 +912,50 @@ func TestReportEndpoints(t *testing.T) {
 	runtimeStore := &stubRuntimeStore{
 		findings: map[string]*ports.FindingRecord{
 			"finding-1": {
-				ID:        "finding-1",
-				TenantID:  "writer",
-				RuntimeID: "writer-okta-audit",
-				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
-				Severity:  "HIGH",
-				Status:    "open",
+				ID:           "finding-1",
+				TenantID:     "writer",
+				RuntimeID:    "writer-okta-audit",
+				RuleID:       "identity-okta-policy-rule-lifecycle-tampering",
+				Severity:     "HIGH",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+				Attributes: map[string]string{
+					"primary_resource_urn": "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+				},
 			},
 			"finding-2": {
-				ID:        "finding-2",
-				TenantID:  "writer",
-				RuntimeID: "writer-okta-audit",
-				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
-				Severity:  "HIGH",
-				Status:    "resolved",
+				ID:           "finding-2",
+				TenantID:     "writer",
+				RuntimeID:    "writer-okta-audit",
+				RuleID:       "identity-okta-policy-rule-lifecycle-tampering",
+				Severity:     "HIGH",
+				Status:       "resolved",
+				ResourceURNs: []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+				Attributes: map[string]string{
+					"primary_resource_urn": "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+				},
+			},
+		},
+	}
+	graphStore := &stubGraphStore{
+		neighborhood: &ports.EntityNeighborhood{
+			Root: &ports.NeighborhoodNode{
+				URN:        "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+				EntityType: "okta.resource",
+				Label:      "Require MFA",
+			},
+			Neighbors: []*ports.NeighborhoodNode{
+				{URN: "urn:cerebro:writer:okta_user:00u2", EntityType: "okta.user", Label: "admin@writer.com"},
+			},
+			Relations: []*ports.NeighborhoodRelation{
+				{FromURN: "urn:cerebro:writer:okta_user:00u2", Relation: "acted_on", ToURN: "urn:cerebro:writer:okta_resource:policyrule:pol-1"},
 			},
 		},
 	}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
 		AppendLog:  &recordingAppendLog{},
 		StateStore: runtimeStore,
-		GraphStore: &stubGraphStore{},
+		GraphStore: graphStore,
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -955,7 +978,7 @@ func TestReportEndpoints(t *testing.T) {
 		t.Fatalf("/reports payload = %#v, want 1 entry", listPayload["reports"])
 	}
 
-	runReq, err := http.NewRequest(http.MethodPost, server.URL+"/reports/finding-summary/runs?tenant_id=writer&runtime_id=writer-okta-audit", nil)
+	runReq, err := http.NewRequest(http.MethodPost, server.URL+"/reports/finding-summary/runs?tenant_id=writer&runtime_id=writer-okta-audit&graph_limit=2", nil)
 	if err != nil {
 		t.Fatalf("new run report request: %v", err)
 	}
@@ -986,12 +1009,32 @@ func TestReportEndpoints(t *testing.T) {
 	if got := resultBody["total_findings"]; got != float64(2) {
 		t.Fatalf("run total_findings = %#v, want 2", got)
 	}
+	if got := resultBody["graph_evidence_status"]; got != "included" {
+		t.Fatalf("run graph_evidence_status = %#v, want included", got)
+	}
+	graphEvidencePayload, ok := resultBody["graph_evidence"].([]any)
+	if !ok || len(graphEvidencePayload) != 1 {
+		t.Fatalf("run graph_evidence = %#v, want 1 entry", resultBody["graph_evidence"])
+	}
+	graphEvidenceEntry, ok := graphEvidencePayload[0].(map[string]any)
+	if !ok {
+		t.Fatalf("run graph evidence entry = %#v, want object", graphEvidencePayload[0])
+	}
+	if got := graphEvidenceEntry["resource_urn"]; got != "urn:cerebro:writer:okta_resource:policyrule:pol-1" {
+		t.Fatalf("run graph evidence resource_urn = %#v, want policy rule urn", got)
+	}
 	runID, ok := runBody["id"].(string)
 	if !ok || runID == "" {
 		t.Fatalf("run id = %#v, want non-empty string", runBody["id"])
 	}
 	if len(runtimeStore.reportRuns) != 1 {
 		t.Fatalf("len(runtimeStore.reportRuns) = %d, want 1", len(runtimeStore.reportRuns))
+	}
+	if graphStore.neighborhoodRootURN != "urn:cerebro:writer:okta_resource:policyrule:pol-1" {
+		t.Fatalf("graph evidence root urn = %q, want policy rule urn", graphStore.neighborhoodRootURN)
+	}
+	if graphStore.neighborhoodLimit != 2 {
+		t.Fatalf("graph evidence limit = %d, want 2", graphStore.neighborhoodLimit)
 	}
 
 	getResp, err := server.Client().Get(server.URL + "/report-runs/" + runID)
@@ -1053,6 +1096,7 @@ func TestReportConnectErrorMapsInvalidRequestsToInvalidArgument(t *testing.T) {
 		t.Fatalf("connect.CodeOf(reportConnectError()) = %v, want %v", got, connect.CodeInvalidArgument)
 	}
 }
+
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	source, err := githubsource.NewFixture()
 	if err != nil {

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,11 +19,21 @@ import (
 )
 
 const (
-	findingSummaryReportID     = "finding-summary"
-	findingSummaryReportName   = "Finding Summary"
-	findingSummaryReportStatus = "completed"
-	reportParameterTenantID    = "tenant_id"
-	reportParameterRuntimeID   = "runtime_id"
+	findingSummaryReportID           = "finding-summary"
+	findingSummaryReportName         = "Finding Summary"
+	findingSummaryReportStatus       = "completed"
+	reportParameterTenantID          = "tenant_id"
+	reportParameterRuntimeID         = "runtime_id"
+	reportParameterResourceLimit     = "resource_limit"
+	reportParameterGraphLimit        = "graph_limit"
+	defaultResourceEvidenceLimit     = 3
+	maxResourceEvidenceLimit         = 10
+	defaultNeighborhoodEvidenceLimit = 3
+	maxNeighborhoodEvidenceLimit     = 10
+	graphEvidenceStatusIncluded      = "included"
+	graphEvidenceStatusUnconfigured  = "unconfigured"
+	graphEvidenceEntryStatusIncluded = "included"
+	graphEvidenceEntryStatusNotFound = "not_found"
 )
 
 var (
@@ -36,13 +47,15 @@ var (
 // Service exposes the first durable report-run foundation.
 type Service struct {
 	findingStore ports.FindingStore
+	graphStore   ports.GraphQueryStore
 	reportStore  ports.ReportStore
 }
 
 // New constructs the report service.
-func New(findingStore ports.FindingStore, reportStore ports.ReportStore) *Service {
+func New(findingStore ports.FindingStore, graphStore ports.GraphQueryStore, reportStore ports.ReportStore) *Service {
 	return &Service{
 		findingStore: findingStore,
+		graphStore:   graphStore,
 		reportStore:  reportStore,
 	}
 }
@@ -135,6 +148,16 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 	if runtimeID == "" {
 		return nil, invalidReportRequestf("report parameter %q is required", reportParameterRuntimeID)
 	}
+	resourceLimit, err := normalizePositiveLimit(parameters[reportParameterResourceLimit], defaultResourceEvidenceLimit, maxResourceEvidenceLimit, reportParameterResourceLimit)
+	if err != nil {
+		return nil, err
+	}
+	graphLimit, err := normalizePositiveLimit(parameters[reportParameterGraphLimit], defaultNeighborhoodEvidenceLimit, maxNeighborhoodEvidenceLimit, reportParameterGraphLimit)
+	if err != nil {
+		return nil, err
+	}
+	persistNormalizedLimit(parameters, reportParameterResourceLimit, resourceLimit)
+	persistNormalizedLimit(parameters, reportParameterGraphLimit, graphLimit)
 	findings, err := s.findingStore.ListFindings(ctx, ports.ListFindingsRequest{TenantID: tenantID, RuntimeID: runtimeID})
 	if err != nil {
 		return nil, fmt.Errorf("list findings for tenant %q runtime %q: %w", tenantID, runtimeID, err)
@@ -142,6 +165,7 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 	severityCounts := make(map[string]int, len(findings))
 	statusCounts := make(map[string]int, len(findings))
 	ruleCounts := make(map[string]int, len(findings))
+	resourceCounts := make(map[string]int, len(findings))
 	for _, finding := range findings {
 		if finding == nil {
 			continue
@@ -158,6 +182,18 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 		if ruleID != "" {
 			ruleCounts[ruleID]++
 		}
+		if resourceURN := primaryResourceURN(finding); resourceURN != "" {
+			resourceCounts[resourceURN]++
+		}
+	}
+	graphEvidenceStatus := graphEvidenceStatusUnconfigured
+	graphEvidence := []any{}
+	if s.graphStore != nil {
+		graphEvidenceStatus = graphEvidenceStatusIncluded
+		graphEvidence, err = s.graphEvidence(ctx, resourceCounts, resourceLimit, graphLimit)
+		if err != nil {
+			return nil, err
+		}
 	}
 	result, err := structpb.NewStruct(map[string]any{
 		reportParameterTenantID:  tenantID,
@@ -166,6 +202,9 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 		"severity_counts":        countEntries(severityCounts, "severity"),
 		"status_counts":          countEntries(statusCounts, "status"),
 		"rule_counts":            countEntries(ruleCounts, "rule_id"),
+		"resource_counts":        countEntries(resourceCounts, "resource_urn"),
+		"graph_evidence_status":  graphEvidenceStatus,
+		"graph_evidence":         graphEvidence,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build finding summary report result: %w", err)
@@ -173,11 +212,45 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 	return result, nil
 }
 
+func (s *Service) graphEvidence(ctx context.Context, resourceCounts map[string]int, resourceLimit int, graphLimit int) ([]any, error) {
+	entries := sortedCountEntries(resourceCounts)
+	if len(entries) > resourceLimit {
+		entries = entries[:resourceLimit]
+	}
+	evidence := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		neighborhood, err := s.graphStore.GetEntityNeighborhood(ctx, entry.Key, graphLimit)
+		switch {
+		case err == nil:
+			if neighborhood == nil {
+				neighborhood = &ports.EntityNeighborhood{}
+			}
+			evidence = append(evidence, map[string]any{
+				"resource_urn":  entry.Key,
+				"finding_count": entry.Count,
+				"status":        graphEvidenceEntryStatusIncluded,
+				"root":          graphNodePayload(neighborhood.Root),
+				"neighbors":     graphNodesPayload(neighborhood.Neighbors),
+				"relations":     graphRelationsPayload(neighborhood.Relations),
+			})
+		case errors.Is(err, ports.ErrGraphEntityNotFound):
+			evidence = append(evidence, map[string]any{
+				"resource_urn":  entry.Key,
+				"finding_count": entry.Count,
+				"status":        graphEvidenceEntryStatusNotFound,
+			})
+		default:
+			return nil, fmt.Errorf("load graph evidence for %q: %w", entry.Key, err)
+		}
+	}
+	return evidence, nil
+}
+
 func findingSummaryDefinition() *cerebrov1.ReportDefinition {
 	return &cerebrov1.ReportDefinition{
 		Id:          findingSummaryReportID,
 		Name:        findingSummaryReportName,
-		Description: "Materialize one tenant/runtime-scoped summary of persisted findings, grouped by severity, status, and rule.",
+		Description: "Materialize one tenant/runtime-scoped summary of persisted findings, grouped by severity, status, rule, and bounded graph evidence for top resources when the graph is configured.",
 		Parameters: []*cerebrov1.ReportParameter{
 			{
 				Id:          reportParameterTenantID,
@@ -188,6 +261,16 @@ func findingSummaryDefinition() *cerebrov1.ReportDefinition {
 				Id:          reportParameterRuntimeID,
 				Description: "Stored source runtime identifier whose persisted findings should be summarized.",
 				Required:    true,
+			},
+			{
+				Id:          reportParameterResourceLimit,
+				Description: "Optional maximum number of resource roots to include in the graph evidence section.",
+				Required:    false,
+			},
+			{
+				Id:          reportParameterGraphLimit,
+				Description: "Optional maximum neighborhood size to read for each graph evidence root.",
+				Required:    false,
 			},
 		},
 	}
@@ -217,6 +300,16 @@ func normalizeParameters(parameters map[string]string) map[string]string {
 	return normalized
 }
 
+func persistNormalizedLimit(parameters map[string]string, parameterID string, value int) {
+	if parameters == nil {
+		return
+	}
+	if _, ok := parameters[parameterID]; !ok {
+		return
+	}
+	parameters[parameterID] = strconv.Itoa(value)
+}
+
 func reportRunID(reportID string, generatedAt time.Time) (string, error) {
 	replacer := strings.NewReplacer(" ", "-", "_", "-", "/", "-")
 	random := make([]byte, 8)
@@ -226,11 +319,24 @@ func reportRunID(reportID string, generatedAt time.Time) (string, error) {
 	return replacer.Replace(strings.TrimSpace(reportID)) + "-" + fmt.Sprintf("%d", generatedAt.UnixNano()) + "-" + hex.EncodeToString(random), nil
 }
 
+type countEntry struct {
+	Key   string
+	Count int
+}
+
 func countEntries(counts map[string]int, keyName string) []any {
-	type countEntry struct {
-		Key   string
-		Count int
+	entries := sortedCountEntries(counts)
+	values := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		values = append(values, map[string]any{
+			keyName: entry.Key,
+			"count": entry.Count,
+		})
 	}
+	return values
+}
+
+func sortedCountEntries(counts map[string]int) []countEntry {
 	entries := make([]countEntry, 0, len(counts))
 	for key, count := range counts {
 		entries = append(entries, countEntry{Key: key, Count: count})
@@ -249,12 +355,76 @@ func countEntries(counts map[string]int, keyName string) []any {
 			return 0
 		}
 	})
-	values := make([]any, 0, len(entries))
-	for _, entry := range entries {
-		values = append(values, map[string]any{
-			keyName: entry.Key,
-			"count": entry.Count,
+	return entries
+}
+
+func primaryResourceURN(finding *ports.FindingRecord) string {
+	if finding == nil {
+		return ""
+	}
+	if value := strings.TrimSpace(finding.Attributes["primary_resource_urn"]); value != "" {
+		return value
+	}
+	primaryActorURN := strings.TrimSpace(finding.Attributes["primary_actor_urn"])
+	for _, resourceURN := range finding.ResourceURNs {
+		trimmed := strings.TrimSpace(resourceURN)
+		if trimmed == "" || trimmed == primaryActorURN {
+			continue
+		}
+		return trimmed
+	}
+	return ""
+}
+
+func normalizePositiveLimit(raw string, defaultValue int, maxValue int, parameterID string) (int, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return defaultValue, nil
+	}
+	parsed, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, invalidReportRequestf("report parameter %q must be a positive integer: %v", parameterID, err)
+	}
+	switch {
+	case parsed <= 0:
+		return 0, invalidReportRequestf("report parameter %q must be greater than zero", parameterID)
+	case parsed > maxValue:
+		return maxValue, nil
+	default:
+		return parsed, nil
+	}
+}
+
+func graphNodePayload(node *ports.NeighborhoodNode) map[string]any {
+	if node == nil {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"urn":         node.URN,
+		"entity_type": node.EntityType,
+		"label":       node.Label,
+	}
+}
+
+func graphNodesPayload(nodes []*ports.NeighborhoodNode) []any {
+	payload := make([]any, 0, len(nodes))
+	for _, node := range nodes {
+		payload = append(payload, graphNodePayload(node))
+	}
+	return payload
+}
+
+func graphRelationsPayload(relations []*ports.NeighborhoodRelation) []any {
+	payload := make([]any, 0, len(relations))
+	for _, relation := range relations {
+		if relation == nil {
+			continue
+		}
+		payload = append(payload, map[string]any{
+			"from_urn": relation.FromURN,
+			"relation": relation.Relation,
+			"to_urn":   relation.ToURN,
 		})
 	}
-	return values
+	return payload
 }

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -30,6 +30,24 @@ func (s *stubFindingStore) ListFindings(_ context.Context, request ports.ListFin
 	return findings, nil
 }
 
+type stubGraphStore struct {
+	rootURN       string
+	limit         int
+	neighborhoods map[string]*ports.EntityNeighborhood
+}
+
+func (s *stubGraphStore) Ping(context.Context) error { return nil }
+
+func (s *stubGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
+	s.rootURN = rootURN
+	s.limit = limit
+	neighborhood, ok := s.neighborhoods[rootURN]
+	if !ok {
+		return nil, ports.ErrGraphEntityNotFound
+	}
+	return cloneNeighborhood(neighborhood), nil
+}
+
 type stubReportStore struct {
 	run *cerebrov1.ReportRun
 }
@@ -52,31 +70,65 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 	findingStore := &stubFindingStore{
 		findings: []*ports.FindingRecord{
 			{
-				ID:        "finding-1",
-				TenantID:  "writer",
-				RuntimeID: "writer-okta-audit",
-				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
-				Severity:  "HIGH",
-				Status:    "open",
+				ID:           "finding-1",
+				TenantID:     "writer",
+				RuntimeID:    "writer-okta-audit",
+				RuleID:       "identity-okta-policy-rule-lifecycle-tampering",
+				Severity:     "HIGH",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+				Attributes: map[string]string{
+					"primary_resource_urn": "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+				},
 			},
 			{
-				ID:        "finding-2",
-				TenantID:  "writer",
-				RuntimeID: "writer-okta-audit",
-				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
-				Severity:  "HIGH",
-				Status:    "resolved",
+				ID:           "finding-2",
+				TenantID:     "writer",
+				RuntimeID:    "writer-okta-audit",
+				RuleID:       "identity-okta-policy-rule-lifecycle-tampering",
+				Severity:     "HIGH",
+				Status:       "resolved",
+				ResourceURNs: []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+				Attributes: map[string]string{
+					"primary_resource_urn": "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+				},
+			},
+		},
+	}
+	graphStore := &stubGraphStore{
+		neighborhoods: map[string]*ports.EntityNeighborhood{
+			"urn:cerebro:writer:okta_resource:policyrule:pol-1": {
+				Root: &ports.NeighborhoodNode{
+					URN:        "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+					EntityType: "okta.resource",
+					Label:      "Require MFA",
+				},
+				Neighbors: []*ports.NeighborhoodNode{
+					{
+						URN:        "urn:cerebro:writer:okta_user:00u2",
+						EntityType: "okta.user",
+						Label:      "admin@writer.com",
+					},
+				},
+				Relations: []*ports.NeighborhoodRelation{
+					{
+						FromURN:  "urn:cerebro:writer:okta_user:00u2",
+						Relation: "acted_on",
+						ToURN:    "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+					},
+				},
 			},
 		},
 	}
 	reportStore := &stubReportStore{}
-	service := New(findingStore, reportStore)
+	service := New(findingStore, graphStore, reportStore)
 
 	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
 		ReportId: findingSummaryReportID,
 		Parameters: map[string]string{
-			reportParameterTenantID:  "writer",
-			reportParameterRuntimeID: "writer-okta-audit",
+			reportParameterTenantID:   "writer",
+			reportParameterRuntimeID:  "writer-okta-audit",
+			reportParameterGraphLimit: "2",
 		},
 	})
 	if err != nil {
@@ -111,20 +163,95 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 	if !ok || len(severityCounts) != 1 {
 		t.Fatalf("Run().Run.Result[severity_counts] = %#v, want 1 entry", result["severity_counts"])
 	}
+	resourceCounts, ok := result["resource_counts"].([]any)
+	if !ok || len(resourceCounts) != 1 {
+		t.Fatalf("Run().Run.Result[resource_counts] = %#v, want 1 entry", result["resource_counts"])
+	}
+	graphEvidence, ok := result["graph_evidence"].([]any)
+	if !ok || len(graphEvidence) != 1 {
+		t.Fatalf("Run().Run.Result[graph_evidence] = %#v, want 1 entry", result["graph_evidence"])
+	}
+	graphEvidenceEntry, ok := graphEvidence[0].(map[string]any)
+	if !ok {
+		t.Fatalf("graph evidence entry = %#v, want object", graphEvidence[0])
+	}
+	if got := graphEvidenceEntry["status"]; got != graphEvidenceEntryStatusIncluded {
+		t.Fatalf("graph evidence status = %#v, want %q", got, graphEvidenceEntryStatusIncluded)
+	}
+	if graphStore.rootURN != "urn:cerebro:writer:okta_resource:policyrule:pol-1" {
+		t.Fatalf("GetEntityNeighborhood().rootURN = %q, want policy rule urn", graphStore.rootURN)
+	}
+	if graphStore.limit != 2 {
+		t.Fatalf("GetEntityNeighborhood().limit = %d, want 2", graphStore.limit)
+	}
 	if reportStore.run == nil {
 		t.Fatal("PutReportRun() not called")
 	}
 }
 
+func TestRunFindingSummaryReportPersistsNormalizedLimitParameters(t *testing.T) {
+	findingStore := &stubFindingStore{
+		findings: []*ports.FindingRecord{
+			{
+				ID:           "finding-1",
+				TenantID:     "writer",
+				RuntimeID:    "writer-okta-audit",
+				RuleID:       "identity-okta-policy-rule-lifecycle-tampering",
+				Severity:     "HIGH",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+				Attributes: map[string]string{
+					"primary_resource_urn": "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+				},
+			},
+		},
+	}
+	graphStore := &stubGraphStore{
+		neighborhoods: map[string]*ports.EntityNeighborhood{
+			"urn:cerebro:writer:okta_resource:policyrule:pol-1": {},
+		},
+	}
+	reportStore := &stubReportStore{}
+	service := New(findingStore, graphStore, reportStore)
+
+	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: findingSummaryReportID,
+		Parameters: map[string]string{
+			reportParameterTenantID:      "writer",
+			reportParameterRuntimeID:     "writer-okta-audit",
+			reportParameterResourceLimit: "999",
+			reportParameterGraphLimit:    "999",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := response.GetRun().GetParameters()[reportParameterResourceLimit]; got != "10" {
+		t.Fatalf("Run().Run.Parameters[resource_limit] = %q, want 10", got)
+	}
+	if got := response.GetRun().GetParameters()[reportParameterGraphLimit]; got != "10" {
+		t.Fatalf("Run().Run.Parameters[graph_limit] = %q, want 10", got)
+	}
+	if got := reportStore.run.GetParameters()[reportParameterResourceLimit]; got != "10" {
+		t.Fatalf("stored Run.Parameters[resource_limit] = %q, want 10", got)
+	}
+	if got := reportStore.run.GetParameters()[reportParameterGraphLimit]; got != "10" {
+		t.Fatalf("stored Run.Parameters[graph_limit] = %q, want 10", got)
+	}
+	if graphStore.limit != 10 {
+		t.Fatalf("GetEntityNeighborhood().limit = %d, want 10", graphStore.limit)
+	}
+}
+
 func TestGetReportRunRequiresAvailableStore(t *testing.T) {
-	service := New(nil, nil)
+	service := New(nil, nil, nil)
 	if _, err := service.Get(context.Background(), &cerebrov1.GetReportRunRequest{Id: "report-run-1"}); !errors.Is(err, ErrRuntimeUnavailable) {
 		t.Fatalf("Get() error = %v, want %v", err, ErrRuntimeUnavailable)
 	}
 }
 
 func TestRunFindingSummaryReportWrapsValidationErrors(t *testing.T) {
-	service := New(&stubFindingStore{}, &stubReportStore{})
+	service := New(&stubFindingStore{}, nil, &stubReportStore{})
 	_, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
 		ReportId: findingSummaryReportID,
 		Parameters: map[string]string{
@@ -137,12 +264,42 @@ func TestRunFindingSummaryReportWrapsValidationErrors(t *testing.T) {
 }
 
 func TestListReportDefinitionsIncludesFindingSummary(t *testing.T) {
-	response := New(nil, nil).List()
+	response := New(nil, nil, nil).List()
 	if len(response.GetReports()) != 1 {
 		t.Fatalf("len(List().Reports) = %d, want 1", len(response.GetReports()))
 	}
 	if response.GetReports()[0].GetId() != findingSummaryReportID {
 		t.Fatalf("List().Reports[0].ID = %q, want %q", response.GetReports()[0].GetId(), findingSummaryReportID)
+	}
+}
+
+func TestRunFindingSummaryReportWithoutGraphStoreMarksEvidenceUnconfigured(t *testing.T) {
+	findingStore := &stubFindingStore{
+		findings: []*ports.FindingRecord{
+			{
+				ID:        "finding-1",
+				TenantID:  "writer",
+				RuntimeID: "writer-okta-audit",
+				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
+				Severity:  "HIGH",
+				Status:    "open",
+			},
+		},
+	}
+	service := New(findingStore, nil, &stubReportStore{})
+
+	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: findingSummaryReportID,
+		Parameters: map[string]string{
+			reportParameterTenantID:  "writer",
+			reportParameterRuntimeID: "writer-okta-audit",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := response.GetRun().GetResult().AsMap()["graph_evidence_status"]; got != graphEvidenceStatusUnconfigured {
+		t.Fatalf("graph_evidence_status = %#v, want %q", got, graphEvidenceStatusUnconfigured)
 	}
 }
 
@@ -198,6 +355,46 @@ func cloneReportRun(run *cerebrov1.ReportRun) *cerebrov1.ReportRun {
 		cloned.Result = run.GetResult()
 	}
 	return cloned
+}
+
+func cloneNeighborhood(neighborhood *ports.EntityNeighborhood) *ports.EntityNeighborhood {
+	if neighborhood == nil {
+		return nil
+	}
+	cloned := &ports.EntityNeighborhood{
+		Root:      cloneNeighborhoodNode(neighborhood.Root),
+		Neighbors: make([]*ports.NeighborhoodNode, 0, len(neighborhood.Neighbors)),
+		Relations: make([]*ports.NeighborhoodRelation, 0, len(neighborhood.Relations)),
+	}
+	for _, neighbor := range neighborhood.Neighbors {
+		cloned.Neighbors = append(cloned.Neighbors, cloneNeighborhoodNode(neighbor))
+	}
+	for _, relation := range neighborhood.Relations {
+		cloned.Relations = append(cloned.Relations, cloneNeighborhoodRelation(relation))
+	}
+	return cloned
+}
+
+func cloneNeighborhoodNode(node *ports.NeighborhoodNode) *ports.NeighborhoodNode {
+	if node == nil {
+		return nil
+	}
+	return &ports.NeighborhoodNode{
+		URN:        node.URN,
+		EntityType: node.EntityType,
+		Label:      node.Label,
+	}
+}
+
+func cloneNeighborhoodRelation(relation *ports.NeighborhoodRelation) *ports.NeighborhoodRelation {
+	if relation == nil {
+		return nil
+	}
+	return &ports.NeighborhoodRelation{
+		FromURN:  relation.FromURN,
+		Relation: relation.Relation,
+		ToURN:    relation.ToURN,
+	}
 }
 
 func cloneAttributes(values map[string]string) map[string]string {


### PR DESCRIPTION
## Summary
- enrich the built-in `finding-summary` report with bounded graph evidence for top finding resources
- plumb the graph query store through the bootstrap report service so report runs can compose persisted findings with local graph neighborhoods
- add focused report and bootstrap coverage for resource-root selection, bounded graph reads, and unconfigured-graph fallback

## Testing
- make verify
- go test ./internal/reports ./internal/bootstrap
- local graph-backed finding-summary report demo
