### PR TITLE
feat(claims): add runtime-scoped claim reads

### DIFF
--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -1807,6 +1807,160 @@ func (x *WriteClaimsResponse) GetRelationLinksProjected() uint32 {
 	return 0
 }
 
+// ListClaimsRequest queries persisted claims for one stored runtime.
+type ListClaimsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RuntimeId     string                 `protobuf:"bytes,1,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	ClaimId       string                 `protobuf:"bytes,2,opt,name=claim_id,json=claimId,proto3" json:"claim_id,omitempty"`
+	SubjectUrn    string                 `protobuf:"bytes,3,opt,name=subject_urn,json=subjectUrn,proto3" json:"subject_urn,omitempty"`
+	Predicate     string                 `protobuf:"bytes,4,opt,name=predicate,proto3" json:"predicate,omitempty"`
+	ObjectUrn     string                 `protobuf:"bytes,5,opt,name=object_urn,json=objectUrn,proto3" json:"object_urn,omitempty"`
+	ObjectValue   string                 `protobuf:"bytes,6,opt,name=object_value,json=objectValue,proto3" json:"object_value,omitempty"`
+	ClaimType     string                 `protobuf:"bytes,7,opt,name=claim_type,json=claimType,proto3" json:"claim_type,omitempty"`
+	Status        string                 `protobuf:"bytes,8,opt,name=status,proto3" json:"status,omitempty"`
+	Limit         uint32                 `protobuf:"varint,9,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListClaimsRequest) Reset() {
+	*x = ListClaimsRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListClaimsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListClaimsRequest) ProtoMessage() {}
+
+func (x *ListClaimsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListClaimsRequest.ProtoReflect.Descriptor instead.
+func (*ListClaimsRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *ListClaimsRequest) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *ListClaimsRequest) GetClaimId() string {
+	if x != nil {
+		return x.ClaimId
+	}
+	return ""
+}
+
+func (x *ListClaimsRequest) GetSubjectUrn() string {
+	if x != nil {
+		return x.SubjectUrn
+	}
+	return ""
+}
+
+func (x *ListClaimsRequest) GetPredicate() string {
+	if x != nil {
+		return x.Predicate
+	}
+	return ""
+}
+
+func (x *ListClaimsRequest) GetObjectUrn() string {
+	if x != nil {
+		return x.ObjectUrn
+	}
+	return ""
+}
+
+func (x *ListClaimsRequest) GetObjectValue() string {
+	if x != nil {
+		return x.ObjectValue
+	}
+	return ""
+}
+
+func (x *ListClaimsRequest) GetClaimType() string {
+	if x != nil {
+		return x.ClaimType
+	}
+	return ""
+}
+
+func (x *ListClaimsRequest) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ListClaimsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+// ListClaimsResponse returns the matched persisted claims.
+type ListClaimsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Claims        []*Claim               `protobuf:"bytes,1,rep,name=claims,proto3" json:"claims,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListClaimsResponse) Reset() {
+	*x = ListClaimsResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListClaimsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListClaimsResponse) ProtoMessage() {}
+
+func (x *ListClaimsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListClaimsResponse.ProtoReflect.Descriptor instead.
+func (*ListClaimsResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *ListClaimsResponse) GetClaims() []*Claim {
+	if x != nil {
+		return x.Claims
+	}
+	return nil
+}
+
 // Finding is the normalized persisted finding view for the first runtime evaluator slice.
 type Finding struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
@@ -1830,7 +1984,7 @@ type Finding struct {
 
 func (x *Finding) Reset() {
 	*x = Finding{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1842,7 +1996,7 @@ func (x *Finding) String() string {
 func (*Finding) ProtoMessage() {}
 
 func (x *Finding) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1855,7 +2009,7 @@ func (x *Finding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Finding.ProtoReflect.Descriptor instead.
 func (*Finding) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{32}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *Finding) GetId() string {
@@ -1967,7 +2121,7 @@ type EvaluateSourceRuntimeFindingsRequest struct {
 
 func (x *EvaluateSourceRuntimeFindingsRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1979,7 +2133,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) String() string {
 func (*EvaluateSourceRuntimeFindingsRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1992,7 +2146,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{33}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *EvaluateSourceRuntimeFindingsRequest) GetId() string {
@@ -2023,7 +2177,7 @@ type EvaluateSourceRuntimeFindingsResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingsResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2035,7 +2189,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) String() string {
 func (*EvaluateSourceRuntimeFindingsResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2048,7 +2202,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *EvaluateSourceRuntimeFindingsResponse) GetRuntime() *SourceRuntime {
@@ -2098,7 +2252,7 @@ type GraphEntity struct {
 
 func (x *GraphEntity) Reset() {
 	*x = GraphEntity{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2110,7 +2264,7 @@ func (x *GraphEntity) String() string {
 func (*GraphEntity) ProtoMessage() {}
 
 func (x *GraphEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2123,7 +2277,7 @@ func (x *GraphEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphEntity.ProtoReflect.Descriptor instead.
 func (*GraphEntity) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GraphEntity) GetUrn() string {
@@ -2159,7 +2313,7 @@ type GraphRelation struct {
 
 func (x *GraphRelation) Reset() {
 	*x = GraphRelation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2171,7 +2325,7 @@ func (x *GraphRelation) String() string {
 func (*GraphRelation) ProtoMessage() {}
 
 func (x *GraphRelation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2184,7 +2338,7 @@ func (x *GraphRelation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphRelation.ProtoReflect.Descriptor instead.
 func (*GraphRelation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GraphRelation) GetFromUrn() string {
@@ -2219,7 +2373,7 @@ type GetEntityNeighborhoodRequest struct {
 
 func (x *GetEntityNeighborhoodRequest) Reset() {
 	*x = GetEntityNeighborhoodRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2231,7 +2385,7 @@ func (x *GetEntityNeighborhoodRequest) String() string {
 func (*GetEntityNeighborhoodRequest) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2244,7 +2398,7 @@ func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodRequest.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{37}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetEntityNeighborhoodRequest) GetRootUrn() string {
@@ -2273,7 +2427,7 @@ type GetEntityNeighborhoodResponse struct {
 
 func (x *GetEntityNeighborhoodResponse) Reset() {
 	*x = GetEntityNeighborhoodResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2285,7 +2439,7 @@ func (x *GetEntityNeighborhoodResponse) String() string {
 func (*GetEntityNeighborhoodResponse) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2298,7 +2452,7 @@ func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodResponse.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{38}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetEntityNeighborhoodResponse) GetRoot() *GraphEntity {
@@ -2472,7 +2626,23 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x13WriteClaimsResponse\x12%\n" +
 	"\x0eclaims_written\x18\x01 \x01(\rR\rclaimsWritten\x12+\n" +
 	"\x11entities_upserted\x18\x02 \x01(\rR\x10entitiesUpserted\x128\n" +
-	"\x18relation_links_projected\x18\x03 \x01(\rR\x16relationLinksProjected\"\xc8\x04\n" +
+	"\x18relation_links_projected\x18\x03 \x01(\rR\x16relationLinksProjected\"\x9b\x02\n" +
+	"\x11ListClaimsRequest\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12\x19\n" +
+	"\bclaim_id\x18\x02 \x01(\tR\aclaimId\x12\x1f\n" +
+	"\vsubject_urn\x18\x03 \x01(\tR\n" +
+	"subjectUrn\x12\x1c\n" +
+	"\tpredicate\x18\x04 \x01(\tR\tpredicate\x12\x1d\n" +
+	"\n" +
+	"object_urn\x18\x05 \x01(\tR\tobjectUrn\x12!\n" +
+	"\fobject_value\x18\x06 \x01(\tR\vobjectValue\x12\x1d\n" +
+	"\n" +
+	"claim_type\x18\a \x01(\tR\tclaimType\x12\x16\n" +
+	"\x06status\x18\b \x01(\tR\x06status\x12\x14\n" +
+	"\x05limit\x18\t \x01(\rR\x05limit\"?\n" +
+	"\x12ListClaimsResponse\x12)\n" +
+	"\x06claims\x18\x01 \x03(\v2\x11.cerebro.v1.ClaimR\x06claims\"\xc8\x04\n" +
 	"\aFinding\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12 \n" +
 	"\vfingerprint\x18\x02 \x01(\tR\vfingerprint\x12\x1b\n" +
@@ -2520,8 +2690,7 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x1dGetEntityNeighborhoodResponse\x12+\n" +
 	"\x04root\x18\x01 \x01(\v2\x17.cerebro.v1.GraphEntityR\x04root\x125\n" +
 	"\tneighbors\x18\x02 \x03(\v2\x17.cerebro.v1.GraphEntityR\tneighbors\x127\n" +
-	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\xe5\n" +
-	"\n" +
+	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\xb2\v\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -2537,7 +2706,9 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x10PutSourceRuntime\x12#.cerebro.v1.PutSourceRuntimeRequest\x1a$.cerebro.v1.PutSourceRuntimeResponse\x12]\n" +
 	"\x10GetSourceRuntime\x12#.cerebro.v1.GetSourceRuntimeRequest\x1a$.cerebro.v1.GetSourceRuntimeResponse\x12`\n" +
 	"\x11SyncSourceRuntime\x12$.cerebro.v1.SyncSourceRuntimeRequest\x1a%.cerebro.v1.SyncSourceRuntimeResponse\x12N\n" +
-	"\vWriteClaims\x12\x1e.cerebro.v1.WriteClaimsRequest\x1a\x1f.cerebro.v1.WriteClaimsResponse\x12\x84\x01\n" +
+	"\vWriteClaims\x12\x1e.cerebro.v1.WriteClaimsRequest\x1a\x1f.cerebro.v1.WriteClaimsResponse\x12K\n" +
+	"\n" +
+	"ListClaims\x12\x1d.cerebro.v1.ListClaimsRequest\x1a\x1e.cerebro.v1.ListClaimsResponse\x12\x84\x01\n" +
 	"\x1dEvaluateSourceRuntimeFindings\x120.cerebro.v1.EvaluateSourceRuntimeFindingsRequest\x1a1.cerebro.v1.EvaluateSourceRuntimeFindingsResponse\x12l\n" +
 	"\x15GetEntityNeighborhood\x12(.cerebro.v1.GetEntityNeighborhoodRequest\x1a).cerebro.v1.GetEntityNeighborhoodResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
 
@@ -2553,7 +2724,7 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*GetVersionRequest)(nil),                     // 0: cerebro.v1.GetVersionRequest
 	(*GetVersionResponse)(nil),                    // 1: cerebro.v1.GetVersionResponse
@@ -2587,110 +2758,115 @@ var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*SyncSourceRuntimeResponse)(nil),             // 29: cerebro.v1.SyncSourceRuntimeResponse
 	(*WriteClaimsRequest)(nil),                    // 30: cerebro.v1.WriteClaimsRequest
 	(*WriteClaimsResponse)(nil),                   // 31: cerebro.v1.WriteClaimsResponse
-	(*Finding)(nil),                               // 32: cerebro.v1.Finding
-	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 33: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 34: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	(*GraphEntity)(nil),                           // 35: cerebro.v1.GraphEntity
-	(*GraphRelation)(nil),                         // 36: cerebro.v1.GraphRelation
-	(*GetEntityNeighborhoodRequest)(nil),          // 37: cerebro.v1.GetEntityNeighborhoodRequest
-	(*GetEntityNeighborhoodResponse)(nil),         // 38: cerebro.v1.GetEntityNeighborhoodResponse
-	nil,                                           // 39: cerebro.v1.ReportRun.ParametersEntry
-	nil,                                           // 40: cerebro.v1.RunReportRequest.ParametersEntry
-	nil,                                           // 41: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                                           // 42: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                                           // 43: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                                           // 44: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                                           // 45: cerebro.v1.Finding.AttributesEntry
-	(*timestamppb.Timestamp)(nil),                 // 46: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                       // 47: google.protobuf.Struct
-	(*SourceSpec)(nil),                            // 48: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),                          // 49: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                         // 50: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                        // 51: google.protobuf.Value
-	(*SourceCheckpoint)(nil),                      // 52: cerebro.v1.SourceCheckpoint
-	(*Claim)(nil),                                 // 53: cerebro.v1.Claim
-	(*RuleSpec)(nil),                              // 54: cerebro.v1.RuleSpec
+	(*ListClaimsRequest)(nil),                     // 32: cerebro.v1.ListClaimsRequest
+	(*ListClaimsResponse)(nil),                    // 33: cerebro.v1.ListClaimsResponse
+	(*Finding)(nil),                               // 34: cerebro.v1.Finding
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 35: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 36: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	(*GraphEntity)(nil),                           // 37: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                         // 38: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),          // 39: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),         // 40: cerebro.v1.GetEntityNeighborhoodResponse
+	nil,                                           // 41: cerebro.v1.ReportRun.ParametersEntry
+	nil,                                           // 42: cerebro.v1.RunReportRequest.ParametersEntry
+	nil,                                           // 43: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                           // 44: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                           // 45: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                           // 46: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                           // 47: cerebro.v1.Finding.AttributesEntry
+	(*timestamppb.Timestamp)(nil),                 // 48: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                       // 49: google.protobuf.Struct
+	(*SourceSpec)(nil),                            // 50: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                          // 51: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                         // 52: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                        // 53: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                      // 54: cerebro.v1.SourceCheckpoint
+	(*Claim)(nil),                                 // 55: cerebro.v1.Claim
+	(*RuleSpec)(nil),                              // 56: cerebro.v1.RuleSpec
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	46, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	48, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
 	5,  // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
-	39, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
-	46, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
-	47, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
+	41, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
+	48, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
+	49, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
 	6,  // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
-	40, // 7: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
+	42, // 7: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
 	6,  // 8: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
 	7,  // 9: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
 	7,  // 10: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
-	48, // 11: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	41, // 12: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	48, // 13: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	42, // 14: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	48, // 15: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	43, // 16: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	49, // 17: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	50, // 18: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	51, // 19: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	48, // 20: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	50, // 21: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	52, // 22: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	49, // 23: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	50, // 11: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	43, // 12: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	50, // 13: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	44, // 14: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	50, // 15: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	45, // 16: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	51, // 17: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	52, // 18: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	53, // 19: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	50, // 20: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	52, // 21: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	54, // 22: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	51, // 23: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
 	21, // 24: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	44, // 25: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	52, // 26: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	49, // 27: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	46, // 28: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	46, // 25: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	54, // 26: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	51, // 27: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	48, // 28: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
 	23, // 29: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
 	23, // 30: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	23, // 31: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	23, // 32: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	48, // 33: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	53, // 34: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	45, // 35: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	46, // 36: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	46, // 37: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	23, // 38: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	54, // 39: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	32, // 40: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	35, // 41: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	35, // 42: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	36, // 43: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	0,  // 44: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2,  // 45: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	8,  // 46: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	10, // 47: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	12, // 48: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	14, // 49: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	16, // 50: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	18, // 51: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	20, // 52: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	24, // 53: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	26, // 54: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	28, // 55: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	30, // 56: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	33, // 57: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	37, // 58: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	1,  // 59: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4,  // 60: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	9,  // 61: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	11, // 62: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	13, // 63: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	15, // 64: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	17, // 65: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	19, // 66: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	22, // 67: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	25, // 68: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	27, // 69: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	29, // 70: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	31, // 71: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	34, // 72: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	38, // 73: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	59, // [59:74] is the sub-list for method output_type
-	44, // [44:59] is the sub-list for method input_type
-	44, // [44:44] is the sub-list for extension type_name
-	44, // [44:44] is the sub-list for extension extendee
-	0,  // [0:44] is the sub-list for field type_name
+	50, // 33: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	55, // 34: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	55, // 35: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	47, // 36: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	48, // 37: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	48, // 38: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	23, // 39: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	56, // 40: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	34, // 41: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	37, // 42: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	37, // 43: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	38, // 44: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	0,  // 45: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 46: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	8,  // 47: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	10, // 48: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	12, // 49: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	14, // 50: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	16, // 51: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	18, // 52: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	20, // 53: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	24, // 54: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	26, // 55: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	28, // 56: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	30, // 57: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	32, // 58: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	35, // 59: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	39, // 60: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	1,  // 61: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 62: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	9,  // 63: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	11, // 64: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	13, // 65: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	15, // 66: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	17, // 67: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	19, // 68: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	22, // 69: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	25, // 70: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	27, // 71: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	29, // 72: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	31, // 73: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	33, // 74: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	36, // 75: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	40, // 76: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	61, // [61:77] is the sub-list for method output_type
+	45, // [45:61] is the sub-list for method input_type
+	45, // [45:45] is the sub-list for extension type_name
+	45, // [45:45] is the sub-list for extension extendee
+	0,  // [0:45] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -2706,7 +2882,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   46,
+			NumMessages:   48,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -72,6 +72,9 @@ const (
 	// BootstrapServiceWriteClaimsProcedure is the fully-qualified name of the BootstrapService's
 	// WriteClaims RPC.
 	BootstrapServiceWriteClaimsProcedure = "/cerebro.v1.BootstrapService/WriteClaims"
+	// BootstrapServiceListClaimsProcedure is the fully-qualified name of the BootstrapService's
+	// ListClaims RPC.
+	BootstrapServiceListClaimsProcedure = "/cerebro.v1.BootstrapService/ListClaims"
 	// BootstrapServiceEvaluateSourceRuntimeFindingsProcedure is the fully-qualified name of the
 	// BootstrapService's EvaluateSourceRuntimeFindings RPC.
 	BootstrapServiceEvaluateSourceRuntimeFindingsProcedure = "/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindings"
@@ -95,6 +98,7 @@ type BootstrapServiceClient interface {
 	GetSourceRuntime(context.Context, *connect.Request[v1.GetSourceRuntimeRequest]) (*connect.Response[v1.GetSourceRuntimeResponse], error)
 	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
 	WriteClaims(context.Context, *connect.Request[v1.WriteClaimsRequest]) (*connect.Response[v1.WriteClaimsResponse], error)
+	ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
@@ -188,6 +192,12 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("WriteClaims")),
 			connect.WithClientOptions(opts...),
 		),
+		listClaims: connect.NewClient[v1.ListClaimsRequest, v1.ListClaimsResponse](
+			httpClient,
+			baseURL+BootstrapServiceListClaimsProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("ListClaims")),
+			connect.WithClientOptions(opts...),
+		),
 		evaluateSourceRuntimeFindings: connect.NewClient[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse](
 			httpClient,
 			baseURL+BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
@@ -218,6 +228,7 @@ type bootstrapServiceClient struct {
 	getSourceRuntime              *connect.Client[v1.GetSourceRuntimeRequest, v1.GetSourceRuntimeResponse]
 	syncSourceRuntime             *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
 	writeClaims                   *connect.Client[v1.WriteClaimsRequest, v1.WriteClaimsResponse]
+	listClaims                    *connect.Client[v1.ListClaimsRequest, v1.ListClaimsResponse]
 	evaluateSourceRuntimeFindings *connect.Client[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse]
 	getEntityNeighborhood         *connect.Client[v1.GetEntityNeighborhoodRequest, v1.GetEntityNeighborhoodResponse]
 }
@@ -287,6 +298,11 @@ func (c *bootstrapServiceClient) WriteClaims(ctx context.Context, req *connect.R
 	return c.writeClaims.CallUnary(ctx, req)
 }
 
+// ListClaims calls cerebro.v1.BootstrapService.ListClaims.
+func (c *bootstrapServiceClient) ListClaims(ctx context.Context, req *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error) {
+	return c.listClaims.CallUnary(ctx, req)
+}
+
 // EvaluateSourceRuntimeFindings calls cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings.
 func (c *bootstrapServiceClient) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {
 	return c.evaluateSourceRuntimeFindings.CallUnary(ctx, req)
@@ -312,6 +328,7 @@ type BootstrapServiceHandler interface {
 	GetSourceRuntime(context.Context, *connect.Request[v1.GetSourceRuntimeRequest]) (*connect.Response[v1.GetSourceRuntimeResponse], error)
 	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
 	WriteClaims(context.Context, *connect.Request[v1.WriteClaimsRequest]) (*connect.Response[v1.WriteClaimsResponse], error)
+	ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
@@ -401,6 +418,12 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		connect.WithSchema(bootstrapServiceMethods.ByName("WriteClaims")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bootstrapServiceListClaimsHandler := connect.NewUnaryHandler(
+		BootstrapServiceListClaimsProcedure,
+		svc.ListClaims,
+		connect.WithSchema(bootstrapServiceMethods.ByName("ListClaims")),
+		connect.WithHandlerOptions(opts...),
+	)
 	bootstrapServiceEvaluateSourceRuntimeFindingsHandler := connect.NewUnaryHandler(
 		BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
 		svc.EvaluateSourceRuntimeFindings,
@@ -441,6 +464,8 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceSyncSourceRuntimeHandler.ServeHTTP(w, r)
 		case BootstrapServiceWriteClaimsProcedure:
 			bootstrapServiceWriteClaimsHandler.ServeHTTP(w, r)
+		case BootstrapServiceListClaimsProcedure:
+			bootstrapServiceListClaimsHandler.ServeHTTP(w, r)
 		case BootstrapServiceEvaluateSourceRuntimeFindingsProcedure:
 			bootstrapServiceEvaluateSourceRuntimeFindingsHandler.ServeHTTP(w, r)
 		case BootstrapServiceGetEntityNeighborhoodProcedure:
@@ -504,6 +529,10 @@ func (UnimplementedBootstrapServiceHandler) SyncSourceRuntime(context.Context, *
 
 func (UnimplementedBootstrapServiceHandler) WriteClaims(context.Context, *connect.Request[v1.WriteClaimsRequest]) (*connect.Response[v1.WriteClaimsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.WriteClaims is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListClaims is not implemented"))
 }
 
 func (UnimplementedBootstrapServiceHandler) EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -71,6 +71,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("PUT /source-runtimes/{runtimeID}", app.handlePutSourceRuntime)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}", app.handleGetSourceRuntime)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/sync", app.handleSyncSourceRuntime)
+	mux.HandleFunc("GET /source-runtimes/{runtimeID}/claims", app.handleListClaims)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/claims", app.handleWriteClaims)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/findings/evaluate", app.handleEvaluateSourceRuntimeFindings)
 	app.server = &http.Server{
@@ -252,6 +253,52 @@ func (a *App) handleSyncSourceRuntime(w http.ResponseWriter, r *http.Request) {
 	writeProtoJSON(w, http.StatusOK, response)
 }
 
+func (a *App) handleListClaims(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.ListClaimsRequest{
+		RuntimeId:   r.PathValue("runtimeID"),
+		ClaimId:     r.URL.Query().Get("claim_id"),
+		SubjectUrn:  r.URL.Query().Get("subject_urn"),
+		Predicate:   r.URL.Query().Get("predicate"),
+		ObjectUrn:   r.URL.Query().Get("object_urn"),
+		ObjectValue: r.URL.Query().Get("object_value"),
+		ClaimType:   r.URL.Query().Get("claim_type"),
+		Status:      r.URL.Query().Get("status"),
+	}
+	if limit := r.URL.Query().Get("limit"); limit != "" {
+		body := []byte(`{"limit":` + limit + `}`)
+		if err := protojson.Unmarshal(body, request); err != nil {
+			writeClaimError(w, err)
+			return
+		}
+		request.RuntimeId = r.PathValue("runtimeID")
+		request.ClaimId = r.URL.Query().Get("claim_id")
+		request.SubjectUrn = r.URL.Query().Get("subject_urn")
+		request.Predicate = r.URL.Query().Get("predicate")
+		request.ObjectUrn = r.URL.Query().Get("object_urn")
+		request.ObjectValue = r.URL.Query().Get("object_value")
+		request.ClaimType = r.URL.Query().Get("claim_type")
+		request.Status = r.URL.Query().Get("status")
+	}
+	response, err := a.claimService().ListClaims(r.Context(), claims.ListRequest{
+		RuntimeID:   request.GetRuntimeId(),
+		ClaimID:     request.GetClaimId(),
+		SubjectURN:  request.GetSubjectUrn(),
+		Predicate:   request.GetPredicate(),
+		ObjectURN:   request.GetObjectUrn(),
+		ObjectValue: request.GetObjectValue(),
+		ClaimType:   request.GetClaimType(),
+		Status:      request.GetStatus(),
+		Limit:       request.GetLimit(),
+	})
+	if err != nil {
+		writeClaimError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, &cerebrov1.ListClaimsResponse{
+		Claims: response.Claims,
+	})
+}
+
 func (a *App) handleWriteClaims(w http.ResponseWriter, r *http.Request) {
 	request := &cerebrov1.WriteClaimsRequest{}
 	if err := readProtoJSON(r, request); err != nil {
@@ -425,6 +472,31 @@ func (s *bootstrapService) WriteClaims(ctx context.Context, req *connect.Request
 		ClaimsWritten:          response.ClaimsWritten,
 		EntitiesUpserted:       response.EntitiesUpserted,
 		RelationLinksProjected: response.RelationLinksProjected,
+	}), nil
+}
+
+func (s *bootstrapService) ListClaims(ctx context.Context, req *connect.Request[cerebrov1.ListClaimsRequest]) (*connect.Response[cerebrov1.ListClaimsResponse], error) {
+	response, err := claims.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		claimStore(s.deps.StateStore),
+		sourceProjectionStateStore(s.deps.StateStore),
+		sourceProjectionGraphStore(s.deps.GraphStore),
+	).ListClaims(ctx, claims.ListRequest{
+		RuntimeID:   req.Msg.GetRuntimeId(),
+		ClaimID:     req.Msg.GetClaimId(),
+		SubjectURN:  req.Msg.GetSubjectUrn(),
+		Predicate:   req.Msg.GetPredicate(),
+		ObjectURN:   req.Msg.GetObjectUrn(),
+		ObjectValue: req.Msg.GetObjectValue(),
+		ClaimType:   req.Msg.GetClaimType(),
+		Status:      req.Msg.GetStatus(),
+		Limit:       req.Msg.GetLimit(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&cerebrov1.ListClaimsResponse{
+		Claims: response.Claims,
 	}), nil
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -81,13 +83,14 @@ func (s *recordingAppendLog) Replay(_ context.Context, request ports.ReplayReque
 }
 
 type stubRuntimeStore struct {
-	err        error
-	runtimes   map[string]*cerebrov1.SourceRuntime
-	entities   map[string]*ports.ProjectedEntity
-	links      map[string]*ports.ProjectedLink
-	claims     map[string]*ports.ClaimRecord
-	findings   map[string]*ports.FindingRecord
-	reportRuns map[string]*cerebrov1.ReportRun
+	err              error
+	runtimes         map[string]*cerebrov1.SourceRuntime
+	entities         map[string]*ports.ProjectedEntity
+	links            map[string]*ports.ProjectedLink
+	claims           map[string]*ports.ClaimRecord
+	claimListRequest ports.ListClaimsRequest
+	findings         map[string]*ports.FindingRecord
+	reportRuns       map[string]*cerebrov1.ReportRun
 }
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
@@ -168,6 +171,38 @@ func (s *stubRuntimeStore) UpsertClaim(_ context.Context, claim *ports.ClaimReco
 	}
 	s.claims[claim.ID] = cloneClaim(claim)
 	return cloneClaim(claim), nil
+}
+
+func (s *stubRuntimeStore) ListClaims(_ context.Context, request ports.ListClaimsRequest) ([]*ports.ClaimRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	s.claimListRequest = request
+	claims := []*ports.ClaimRecord{}
+	for _, claim := range s.claims {
+		if !claimMatches(request, claim) {
+			continue
+		}
+		claims = append(claims, cloneClaim(claim))
+	}
+	sort.Slice(claims, func(i, j int) bool {
+		left := claims[i]
+		right := claims[j]
+		switch {
+		case left.ObservedAt.Equal(right.ObservedAt):
+			return left.ID < right.ID
+		case left.ObservedAt.IsZero():
+			return false
+		case right.ObservedAt.IsZero():
+			return true
+		default:
+			return left.ObservedAt.After(right.ObservedAt)
+		}
+	})
+	if request.Limit != 0 && len(claims) > int(request.Limit) {
+		claims = claims[:int(request.Limit)]
+	}
+	return claims, nil
 }
 
 func (s *stubRuntimeStore) ListFindings(_ context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
@@ -933,6 +968,53 @@ func TestClaimEndpoints(t *testing.T) {
 	if len(graphStore.links) != 1 {
 		t.Fatalf("len(graphStore.links) = %d, want 1", len(graphStore.links))
 	}
+
+	listResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-jira/claims?predicate=assigned_to&limit=1")
+	if err != nil {
+		t.Fatalf("GET /source-runtimes/{id}/claims error = %v", err)
+	}
+	defer func() {
+		if closeErr := listResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close list claims response body: %v", closeErr)
+		}
+	}()
+	var listPayload map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&listPayload); err != nil {
+		t.Fatalf("decode list claims response: %v", err)
+	}
+	listedClaims, ok := listPayload["claims"].([]any)
+	if !ok || len(listedClaims) != 1 {
+		t.Fatalf("list claims payload = %#v, want 1 claim", listPayload["claims"])
+	}
+	listedClaim, ok := listedClaims[0].(map[string]any)
+	if !ok {
+		t.Fatalf("list claims entry = %#v, want object", listedClaims[0])
+	}
+	if got := listedClaim["predicate"]; got != "assigned_to" {
+		t.Fatalf("list claims predicate = %#v, want assigned_to", got)
+	}
+
+	listClaimsResp, err := client.ListClaims(context.Background(), connect.NewRequest(&cerebrov1.ListClaimsRequest{
+		RuntimeId:   "writer-jira",
+		Predicate:   "status",
+		ObjectValue: "in_progress",
+		Limit:       1,
+	}))
+	if err != nil {
+		t.Fatalf("ListClaims() error = %v", err)
+	}
+	if got := len(listClaimsResp.Msg.GetClaims()); got != 1 {
+		t.Fatalf("len(ListClaims().Claims) = %d, want 1", got)
+	}
+	if got := listClaimsResp.Msg.GetClaims()[0].GetObjectValue(); got != "in_progress" {
+		t.Fatalf("ListClaims().Claims[0].ObjectValue = %q, want in_progress", got)
+	}
+	if got := runtimeStore.claimListRequest.Predicate; got != "status" {
+		t.Fatalf("runtimeStore.claimListRequest.Predicate = %q, want status", got)
+	}
+	if got := runtimeStore.claimListRequest.ObjectValue; got != "in_progress" {
+		t.Fatalf("runtimeStore.claimListRequest.ObjectValue = %q, want in_progress", got)
+	}
 }
 
 func TestGraphNeighborhoodEndpoints(t *testing.T) {
@@ -1343,6 +1425,37 @@ func cloneClaim(claim *ports.ClaimRecord) *ports.ClaimRecord {
 		ValidTo:       claim.ValidTo,
 		Attributes:    attributes,
 	}
+}
+
+func claimMatches(request ports.ListClaimsRequest, claim *ports.ClaimRecord) bool {
+	if claim == nil {
+		return false
+	}
+	if strings.TrimSpace(claim.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+		return false
+	}
+	if request.ClaimID != "" && strings.TrimSpace(claim.ID) != strings.TrimSpace(request.ClaimID) {
+		return false
+	}
+	if request.SubjectURN != "" && strings.TrimSpace(claim.SubjectURN) != strings.TrimSpace(request.SubjectURN) {
+		return false
+	}
+	if request.Predicate != "" && strings.TrimSpace(claim.Predicate) != strings.TrimSpace(request.Predicate) {
+		return false
+	}
+	if request.ObjectURN != "" && strings.TrimSpace(claim.ObjectURN) != strings.TrimSpace(request.ObjectURN) {
+		return false
+	}
+	if request.ObjectValue != "" && strings.TrimSpace(claim.ObjectValue) != strings.TrimSpace(request.ObjectValue) {
+		return false
+	}
+	if request.ClaimType != "" && strings.TrimSpace(claim.ClaimType) != strings.TrimSpace(request.ClaimType) {
+		return false
+	}
+	if request.Status != "" && strings.TrimSpace(claim.Status) != strings.TrimSpace(request.Status) {
+		return false
+	}
+	return true
 }
 
 func cloneReportRun(run *cerebrov1.ReportRun) *cerebrov1.ReportRun {

--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -458,7 +458,7 @@ func cloneEntityRef(ref *cerebrov1.EntityRef) *cerebrov1.EntityRef {
 	return proto.Clone(ref).(*cerebrov1.EntityRef)
 }
 
-func claimTime(value interface{ AsTime() time.Time }) time.Time {
+func claimTime(value *timestamppb.Timestamp) time.Time {
 	if value == nil {
 		return time.Time{}
 	}

--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
@@ -26,7 +27,7 @@ const (
 // ErrRuntimeUnavailable indicates that the runtime or claim store boundary is unavailable.
 var ErrRuntimeUnavailable = errors.New("claim runtime is unavailable")
 
-// Service writes runtime-scoped claims into the state store and optional projections.
+// Service reads and writes runtime-scoped claims into the state store and optional projections.
 type Service struct {
 	runtimeStore ports.SourceRuntimeStore
 	store        ports.ClaimStore
@@ -45,6 +46,24 @@ type WriteResult struct {
 	ClaimsWritten          uint32
 	EntitiesUpserted       uint32
 	RelationLinksProjected uint32
+}
+
+// ListRequest scopes one runtime-scoped claim query.
+type ListRequest struct {
+	RuntimeID   string
+	ClaimID     string
+	SubjectURN  string
+	Predicate   string
+	ObjectURN   string
+	ObjectValue string
+	ClaimType   string
+	Status      string
+	Limit       uint32
+}
+
+// ListResult reports one runtime-scoped claim query.
+type ListResult struct {
+	Claims []*cerebrov1.Claim
 }
 
 // New constructs a claim write service.
@@ -111,6 +130,42 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 		}
 	}
 	return result, nil
+}
+
+// ListClaims loads persisted claims for one runtime.
+func (s *Service) ListClaims(ctx context.Context, request ListRequest) (*ListResult, error) {
+	if s == nil || s.runtimeStore == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, errors.New("source runtime id is required")
+	}
+	if _, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID); err != nil {
+		return nil, err
+	}
+	records, err := s.store.ListClaims(ctx, ports.ListClaimsRequest{
+		RuntimeID:   runtimeID,
+		ClaimID:     strings.TrimSpace(request.ClaimID),
+		SubjectURN:  strings.TrimSpace(request.SubjectURN),
+		Predicate:   strings.TrimSpace(request.Predicate),
+		ObjectURN:   strings.TrimSpace(request.ObjectURN),
+		ObjectValue: strings.TrimSpace(request.ObjectValue),
+		ClaimType:   strings.TrimSpace(request.ClaimType),
+		Status:      strings.TrimSpace(request.Status),
+		Limit:       request.Limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list claims for runtime %q: %w", runtimeID, err)
+	}
+	response := &ListResult{Claims: make([]*cerebrov1.Claim, 0, len(records))}
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		response.Claims = append(response.Claims, protoClaim(record))
+	}
+	return response, nil
 }
 
 func (s *Service) upsertEntity(ctx context.Context, entity *ports.ProjectedEntity, seen map[string]struct{}) (bool, error) {
@@ -365,6 +420,35 @@ func claimRecord(runtime *cerebrov1.SourceRuntime, claim *cerebrov1.Claim) *port
 		ValidTo:       claimTime(claim.GetValidTo()),
 		Attributes:    trimAttributes(claim.GetAttributes()),
 	}
+}
+
+func protoClaim(record *ports.ClaimRecord) *cerebrov1.Claim {
+	if record == nil {
+		return nil
+	}
+	claim := &cerebrov1.Claim{
+		Id:            strings.TrimSpace(record.ID),
+		SubjectUrn:    strings.TrimSpace(record.SubjectURN),
+		SubjectRef:    cloneEntityRef(record.SubjectRef),
+		Predicate:     strings.TrimSpace(record.Predicate),
+		ObjectUrn:     strings.TrimSpace(record.ObjectURN),
+		ObjectRef:     cloneEntityRef(record.ObjectRef),
+		ObjectValue:   strings.TrimSpace(record.ObjectValue),
+		ClaimType:     strings.TrimSpace(record.ClaimType),
+		Status:        strings.TrimSpace(record.Status),
+		SourceEventId: strings.TrimSpace(record.SourceEventID),
+		Attributes:    trimAttributes(record.Attributes),
+	}
+	if !record.ObservedAt.IsZero() {
+		claim.ObservedAt = timestamppb.New(record.ObservedAt.UTC())
+	}
+	if !record.ValidFrom.IsZero() {
+		claim.ValidFrom = timestamppb.New(record.ValidFrom.UTC())
+	}
+	if !record.ValidTo.IsZero() {
+		claim.ValidTo = timestamppb.New(record.ValidTo.UTC())
+	}
+	return claim
 }
 
 func cloneEntityRef(ref *cerebrov1.EntityRef) *cerebrov1.EntityRef {

--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -22,6 +22,8 @@ const (
 	claimTypeRelation       = "relation"
 	claimTypeClassification = "classification"
 	claimStatusAsserted     = "asserted"
+	defaultClaimListLimit   = 100
+	maxClaimListLimit       = 1000
 )
 
 // ErrRuntimeUnavailable indicates that the runtime or claim store boundary is unavailable.
@@ -153,7 +155,7 @@ func (s *Service) ListClaims(ctx context.Context, request ListRequest) (*ListRes
 		ObjectValue: strings.TrimSpace(request.ObjectValue),
 		ClaimType:   strings.TrimSpace(request.ClaimType),
 		Status:      strings.TrimSpace(request.Status),
-		Limit:       request.Limit,
+		Limit:       normalizeClaimListLimit(request.Limit),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list claims for runtime %q: %w", runtimeID, err)
@@ -166,6 +168,17 @@ func (s *Service) ListClaims(ctx context.Context, request ListRequest) (*ListRes
 		response.Claims = append(response.Claims, protoClaim(record))
 	}
 	return response, nil
+}
+
+func normalizeClaimListLimit(limit uint32) uint32 {
+	switch {
+	case limit == 0:
+		return defaultClaimListLimit
+	case limit > maxClaimListLimit:
+		return maxClaimListLimit
+	default:
+		return limit
+	}
 }
 
 func (s *Service) upsertEntity(ctx context.Context, entity *ports.ProjectedEntity, seen map[string]struct{}) (bool, error) {

--- a/internal/claims/service_test.go
+++ b/internal/claims/service_test.go
@@ -3,7 +3,10 @@ package claims
 import (
 	"context"
 	"errors"
+	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -31,8 +34,9 @@ func (s *stubRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*cere
 }
 
 type stubClaimStore struct {
-	claims map[string]*ports.ClaimRecord
-	err    error
+	claims      map[string]*ports.ClaimRecord
+	listRequest ports.ListClaimsRequest
+	err         error
 }
 
 func (s *stubClaimStore) Ping(context.Context) error { return nil }
@@ -46,6 +50,35 @@ func (s *stubClaimStore) UpsertClaim(_ context.Context, claim *ports.ClaimRecord
 	}
 	s.claims[claim.ID] = cloneClaimRecord(claim)
 	return cloneClaimRecord(claim), nil
+}
+
+func (s *stubClaimStore) ListClaims(_ context.Context, request ports.ListClaimsRequest) ([]*ports.ClaimRecord, error) {
+	s.listRequest = request
+	claims := make([]*ports.ClaimRecord, 0, len(s.claims))
+	for _, claim := range s.claims {
+		if !claimMatches(request, claim) {
+			continue
+		}
+		claims = append(claims, cloneClaimRecord(claim))
+	}
+	sort.Slice(claims, func(i, j int) bool {
+		left := claims[i]
+		right := claims[j]
+		switch {
+		case left.ObservedAt.Equal(right.ObservedAt):
+			return left.ID < right.ID
+		case left.ObservedAt.IsZero():
+			return false
+		case right.ObservedAt.IsZero():
+			return true
+		default:
+			return left.ObservedAt.After(right.ObservedAt)
+		}
+	})
+	if request.Limit != 0 && len(claims) > int(request.Limit) {
+		claims = claims[:int(request.Limit)]
+	}
+	return claims, nil
 }
 
 type projectionRecorder struct {
@@ -191,6 +224,87 @@ func TestWriteClaimsRequiresAvailableDependencies(t *testing.T) {
 	service := New(nil, nil, nil, nil)
 	if _, err := service.WriteClaims(context.Background(), WriteRequest{RuntimeID: "writer-jira"}); !errors.Is(err, ErrRuntimeUnavailable) {
 		t.Fatalf("WriteClaims() error = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}
+
+func TestListClaimsReturnsFilteredProtoClaims(t *testing.T) {
+	store := &stubClaimStore{
+		claims: map[string]*ports.ClaimRecord{
+			"claim-status": {
+				ID:          "claim-status",
+				RuntimeID:   "writer-jira",
+				TenantID:    "writer",
+				SubjectURN:  "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+				Predicate:   "status",
+				ObjectValue: "in_progress",
+				ClaimType:   claimTypeAttribute,
+				Status:      claimStatusAsserted,
+				ObservedAt:  timeFromProto(timestamppb.New(timestamppb.Now().AsTime().Add(-time.Minute))),
+			},
+			"claim-assignee": {
+				ID:         "claim-assignee",
+				RuntimeID:  "writer-jira",
+				TenantID:   "writer",
+				SubjectURN: "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+				Predicate:  "assigned_to",
+				ObjectURN:  "urn:cerebro:writer:runtime:writer-jira:user:acct:42",
+				ClaimType:  claimTypeRelation,
+				Status:     claimStatusAsserted,
+				ObservedAt: timeFromProto(timestamppb.Now()),
+			},
+		},
+	}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-jira": {
+					Id:       "writer-jira",
+					SourceId: "sdk",
+					TenantId: "writer",
+				},
+			},
+		},
+		store,
+		nil,
+		nil,
+	)
+
+	response, err := service.ListClaims(context.Background(), ListRequest{
+		RuntimeID:   "writer-jira",
+		Predicate:   "status",
+		ObjectValue: "in_progress",
+		Limit:       1,
+	})
+	if err != nil {
+		t.Fatalf("ListClaims() error = %v", err)
+	}
+	if got := len(response.Claims); got != 1 {
+		t.Fatalf("len(ListClaims().Claims) = %d, want 1", got)
+	}
+	if got := response.Claims[0].GetPredicate(); got != "status" {
+		t.Fatalf("ListClaims().Claims[0].Predicate = %q, want status", got)
+	}
+	if got := response.Claims[0].GetObjectValue(); got != "in_progress" {
+		t.Fatalf("ListClaims().Claims[0].ObjectValue = %q, want in_progress", got)
+	}
+	if got := store.listRequest.RuntimeID; got != "writer-jira" {
+		t.Fatalf("ListClaims().RuntimeID = %q, want writer-jira", got)
+	}
+	if got := store.listRequest.Predicate; got != "status" {
+		t.Fatalf("ListClaims().Predicate = %q, want status", got)
+	}
+	if got := store.listRequest.ObjectValue; got != "in_progress" {
+		t.Fatalf("ListClaims().ObjectValue = %q, want in_progress", got)
+	}
+	if got := store.listRequest.Limit; got != 1 {
+		t.Fatalf("ListClaims().Limit = %d, want 1", got)
+	}
+}
+
+func TestListClaimsRequiresAvailableDependencies(t *testing.T) {
+	service := New(nil, nil, nil, nil)
+	if _, err := service.ListClaims(context.Background(), ListRequest{RuntimeID: "writer-jira"}); !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("ListClaims() error = %v, want %v", err, ErrRuntimeUnavailable)
 	}
 }
 
@@ -370,4 +484,42 @@ func cloneProjectedLink(link *ports.ProjectedLink) *ports.ProjectedLink {
 		ToURN:      link.ToURN,
 		Attributes: attributes,
 	}
+}
+
+func claimMatches(request ports.ListClaimsRequest, claim *ports.ClaimRecord) bool {
+	if claim == nil {
+		return false
+	}
+	if strings.TrimSpace(claim.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+		return false
+	}
+	if request.ClaimID != "" && strings.TrimSpace(claim.ID) != strings.TrimSpace(request.ClaimID) {
+		return false
+	}
+	if request.SubjectURN != "" && strings.TrimSpace(claim.SubjectURN) != strings.TrimSpace(request.SubjectURN) {
+		return false
+	}
+	if request.Predicate != "" && strings.TrimSpace(claim.Predicate) != strings.TrimSpace(request.Predicate) {
+		return false
+	}
+	if request.ObjectURN != "" && strings.TrimSpace(claim.ObjectURN) != strings.TrimSpace(request.ObjectURN) {
+		return false
+	}
+	if request.ObjectValue != "" && strings.TrimSpace(claim.ObjectValue) != strings.TrimSpace(request.ObjectValue) {
+		return false
+	}
+	if request.ClaimType != "" && strings.TrimSpace(claim.ClaimType) != strings.TrimSpace(request.ClaimType) {
+		return false
+	}
+	if request.Status != "" && strings.TrimSpace(claim.Status) != strings.TrimSpace(request.Status) {
+		return false
+	}
+	return true
+}
+
+func timeFromProto(value *timestamppb.Timestamp) time.Time {
+	if value == nil {
+		return time.Time{}
+	}
+	return value.AsTime().UTC()
 }

--- a/internal/claims/service_test.go
+++ b/internal/claims/service_test.go
@@ -346,6 +346,40 @@ func TestListClaimsReturnsFilteredProtoClaims(t *testing.T) {
 	}
 }
 
+func TestListClaimsAppliesDefaultLimit(t *testing.T) {
+	store := &stubClaimStore{
+		claims: map[string]*ports.ClaimRecord{
+			"claim-1": {
+				ID:        "claim-1",
+				RuntimeID: "writer-jira",
+				Status:    claimStatusAsserted,
+			},
+		},
+	}
+	service := New(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-jira": {Id: "writer-jira"},
+		}},
+		store,
+		nil,
+		nil,
+	)
+
+	if _, err := service.ListClaims(context.Background(), ListRequest{RuntimeID: "writer-jira"}); err != nil {
+		t.Fatalf("ListClaims() error = %v", err)
+	}
+	if got := store.listRequest.Limit; got != defaultClaimListLimit {
+		t.Fatalf("ListClaims().Limit = %d, want default %d", got, defaultClaimListLimit)
+	}
+
+	if _, err := service.ListClaims(context.Background(), ListRequest{RuntimeID: "writer-jira", Limit: maxClaimListLimit + 1}); err != nil {
+		t.Fatalf("ListClaims(over max) error = %v", err)
+	}
+	if got := store.listRequest.Limit; got != maxClaimListLimit {
+		t.Fatalf("ListClaims(over max).Limit = %d, want max %d", got, maxClaimListLimit)
+	}
+}
+
 func TestListClaimsRequiresAvailableDependencies(t *testing.T) {
 	service := New(nil, nil, nil, nil)
 	if _, err := service.ListClaims(context.Background(), ListRequest{RuntimeID: "writer-jira"}); !errors.Is(err, ErrRuntimeUnavailable) {

--- a/internal/claims/service_test.go
+++ b/internal/claims/service_test.go
@@ -227,6 +227,51 @@ func TestWriteClaimsRequiresAvailableDependencies(t *testing.T) {
 	}
 }
 
+func TestWriteClaimsPreservesMissingTimestamps(t *testing.T) {
+	store := &stubClaimStore{}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-jira": {
+					Id:       "writer-jira",
+					SourceId: "sdk",
+					TenantId: "writer",
+				},
+			},
+		},
+		store,
+		nil,
+		nil,
+	)
+
+	_, err := service.WriteClaims(context.Background(), WriteRequest{
+		RuntimeID: "writer-jira",
+		Claims: []*cerebrov1.Claim{
+			{
+				SubjectUrn: "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+				Predicate:  "exists",
+				ClaimType:  claimTypeExistence,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteClaims() error = %v", err)
+	}
+	for _, claim := range store.claims {
+		if !claim.ObservedAt.IsZero() {
+			t.Fatalf("stored claim observed_at = %v, want zero", claim.ObservedAt)
+		}
+		if !claim.ValidFrom.IsZero() {
+			t.Fatalf("stored claim valid_from = %v, want zero", claim.ValidFrom)
+		}
+		if !claim.ValidTo.IsZero() {
+			t.Fatalf("stored claim valid_to = %v, want zero", claim.ValidTo)
+		}
+		return
+	}
+	t.Fatal("stored claims = empty, want one claim")
+}
+
 func TestListClaimsReturnsFilteredProtoClaims(t *testing.T) {
 	store := &stubClaimStore{
 		claims: map[string]*ports.ClaimRecord{

--- a/internal/ports/claims.go
+++ b/internal/ports/claims.go
@@ -27,8 +27,22 @@ type ClaimRecord struct {
 	Attributes    map[string]string
 }
 
+// ListClaimsRequest scopes one claim query.
+type ListClaimsRequest struct {
+	RuntimeID   string
+	ClaimID     string
+	SubjectURN  string
+	Predicate   string
+	ObjectURN   string
+	ObjectValue string
+	ClaimType   string
+	Status      string
+	Limit       uint32
+}
+
 // ClaimStore persists normalized claims in the state store.
 type ClaimStore interface {
 	StateStore
 	UpsertClaim(context.Context, *ClaimRecord) (*ClaimRecord, error)
+	ListClaims(context.Context, ListClaimsRequest) ([]*ClaimRecord, error)
 }

--- a/internal/statestore/postgres/claims.go
+++ b/internal/statestore/postgres/claims.go
@@ -39,6 +39,8 @@ var ensureClaimStatements = []string{
 	`CREATE INDEX IF NOT EXISTS claims_runtime_subject_idx ON claims (runtime_id, subject_urn)`,
 	`CREATE INDEX IF NOT EXISTS claims_runtime_predicate_idx ON claims (runtime_id, predicate)`,
 	`CREATE INDEX IF NOT EXISTS claims_runtime_object_idx ON claims (runtime_id, object_urn)`,
+	`CREATE INDEX IF NOT EXISTS claims_runtime_type_status_idx ON claims (runtime_id, claim_type, status)`,
+	`CREATE INDEX IF NOT EXISTS claims_runtime_object_value_idx ON claims (runtime_id, object_value)`,
 }
 
 // UpsertClaim persists one normalized claim in the current-state store.
@@ -130,6 +132,75 @@ DO UPDATE SET
 	return cloneClaimRecord(claim), nil
 }
 
+// ListClaims loads persisted claims for one runtime.
+func (s *Store) ListClaims(ctx context.Context, request ports.ListClaimsRequest) (_ []*ports.ClaimRecord, err error) {
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, errors.New("claim runtime id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureClaimTables(ctx); err != nil {
+		return nil, err
+	}
+	clauses := []string{"runtime_id = $1"}
+	args := []any{runtimeID}
+	addFilter := func(column string, value string) {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return
+		}
+		args = append(args, trimmed)
+		clauses = append(clauses, fmt.Sprintf("%s = $%d", column, len(args)))
+	}
+	addFilter("id", request.ClaimID)
+	addFilter("subject_urn", request.SubjectURN)
+	addFilter("predicate", request.Predicate)
+	addFilter("object_urn", request.ObjectURN)
+	addFilter("object_value", request.ObjectValue)
+	addFilter("claim_type", request.ClaimType)
+	addFilter("status", request.Status)
+
+	query := `
+SELECT runtime_id, tenant_id, claim_json::text
+FROM claims
+WHERE ` + strings.Join(clauses, " AND ") + `
+ORDER BY observed_at DESC NULLS LAST, updated_at DESC, id`
+	if request.Limit != 0 {
+		args = append(args, int64(request.Limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query claims for runtime %q: %w", runtimeID, err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close claims rows: %w", closeErr)
+		}
+	}()
+
+	claims := []*ports.ClaimRecord{}
+	for rows.Next() {
+		var storedRuntimeID string
+		var tenantID string
+		var claimJSON string
+		if err := rows.Scan(&storedRuntimeID, &tenantID, &claimJSON); err != nil {
+			return nil, fmt.Errorf("scan claim row: %w", err)
+		}
+		record, err := claimRecordFromJSON(storedRuntimeID, tenantID, claimJSON)
+		if err != nil {
+			return nil, err
+		}
+		claims = append(claims, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate claims rows: %w", err)
+	}
+	return claims, nil
+}
+
 func (s *Store) ensureClaimTables(ctx context.Context) error {
 	for _, statement := range ensureClaimStatements {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {
@@ -217,6 +288,52 @@ func cloneClaimEntityRef(ref *cerebrov1.EntityRef) *cerebrov1.EntityRef {
 		EntityType: ref.GetEntityType(),
 		Label:      ref.GetLabel(),
 	}
+}
+
+func claimRecordFromJSON(runtimeID string, tenantID string, payload string) (*ports.ClaimRecord, error) {
+	if strings.TrimSpace(payload) == "" {
+		return nil, errors.New("claim json is required")
+	}
+	claim := &cerebrov1.Claim{}
+	if err := protojson.Unmarshal([]byte(payload), claim); err != nil {
+		return nil, fmt.Errorf("unmarshal claim json: %w", err)
+	}
+	return &ports.ClaimRecord{
+		ID:            strings.TrimSpace(claim.GetId()),
+		RuntimeID:     strings.TrimSpace(runtimeID),
+		TenantID:      strings.TrimSpace(tenantID),
+		SubjectURN:    strings.TrimSpace(claim.GetSubjectUrn()),
+		SubjectRef:    cloneClaimEntityRef(claim.GetSubjectRef()),
+		Predicate:     strings.TrimSpace(claim.GetPredicate()),
+		ObjectURN:     strings.TrimSpace(claim.GetObjectUrn()),
+		ObjectRef:     cloneClaimEntityRef(claim.GetObjectRef()),
+		ObjectValue:   strings.TrimSpace(claim.GetObjectValue()),
+		ClaimType:     strings.TrimSpace(claim.GetClaimType()),
+		Status:        strings.TrimSpace(claim.GetStatus()),
+		SourceEventID: strings.TrimSpace(claim.GetSourceEventId()),
+		ObservedAt:    claimMessageTime(claim.GetObservedAt()),
+		ValidFrom:     claimMessageTime(claim.GetValidFrom()),
+		ValidTo:       claimMessageTime(claim.GetValidTo()),
+		Attributes:    cloneClaimAttributes(claim.GetAttributes()),
+	}, nil
+}
+
+func cloneClaimAttributes(attributes map[string]string) map[string]string {
+	if len(attributes) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(attributes))
+	for key, value := range attributes {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func claimMessageTime(value interface{ AsTime() time.Time }) time.Time {
+	if value == nil {
+		return time.Time{}
+	}
+	return value.AsTime().UTC()
 }
 
 func nullableTime(value time.Time) any {

--- a/internal/statestore/postgres/claims.go
+++ b/internal/statestore/postgres/claims.go
@@ -295,7 +295,7 @@ func claimRecordFromJSON(runtimeID string, tenantID string, payload string) (*po
 		return nil, errors.New("claim json is required")
 	}
 	claim := &cerebrov1.Claim{}
-	if err := protojson.Unmarshal([]byte(payload), claim); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(payload), claim); err != nil {
 		return nil, fmt.Errorf("unmarshal claim json: %w", err)
 	}
 	return &ports.ClaimRecord{

--- a/internal/statestore/postgres/claims.go
+++ b/internal/statestore/postgres/claims.go
@@ -329,7 +329,7 @@ func cloneClaimAttributes(attributes map[string]string) map[string]string {
 	return cloned
 }
 
-func claimMessageTime(value interface{ AsTime() time.Time }) time.Time {
+func claimMessageTime(value *timestamppb.Timestamp) time.Time {
 	if value == nil {
 		return time.Time{}
 	}

--- a/internal/statestore/postgres/claims_test.go
+++ b/internal/statestore/postgres/claims_test.go
@@ -87,6 +87,23 @@ func TestClaimRecordFromJSONRestoresRefsAndTimes(t *testing.T) {
 	}
 }
 
+func TestClaimRecordFromJSONPreservesMissingTimestamps(t *testing.T) {
+	payload := `{"id":"claim_1","subject_urn":"urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123","predicate":"status","object_value":"in_progress","claim_type":"attribute","status":"asserted"}`
+	record, err := claimRecordFromJSON("writer-jira", "writer", payload)
+	if err != nil {
+		t.Fatalf("claimRecordFromJSON() error = %v", err)
+	}
+	if !record.ObservedAt.IsZero() {
+		t.Fatalf("record.ObservedAt = %v, want zero time", record.ObservedAt)
+	}
+	if !record.ValidFrom.IsZero() {
+		t.Fatalf("record.ValidFrom = %v, want zero time", record.ValidFrom)
+	}
+	if !record.ValidTo.IsZero() {
+		t.Fatalf("record.ValidTo = %v, want zero time", record.ValidTo)
+	}
+}
+
 func TestClaimJSONIncludesTimestampsForRoundTrip(t *testing.T) {
 	payload, err := claimJSON(&ports.ClaimRecord{
 		ID:          "claim_1",

--- a/internal/statestore/postgres/claims_test.go
+++ b/internal/statestore/postgres/claims_test.go
@@ -104,6 +104,13 @@ func TestClaimRecordFromJSONPreservesMissingTimestamps(t *testing.T) {
 	}
 }
 
+func TestClaimRecordFromJSONDiscardsUnknownFields(t *testing.T) {
+	payload := `{"id":"claim_1","subject_urn":"urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123","predicate":"status","object_value":"in_progress","claim_type":"attribute","status":"asserted","future_field":"ignored"}`
+	if _, err := claimRecordFromJSON("writer-jira", "writer", payload); err != nil {
+		t.Fatalf("claimRecordFromJSON() error = %v, want nil", err)
+	}
+}
+
 func TestClaimJSONIncludesTimestampsForRoundTrip(t *testing.T) {
 	payload, err := claimJSON(&ports.ClaimRecord{
 		ID:          "claim_1",

--- a/internal/statestore/postgres/claims_test.go
+++ b/internal/statestore/postgres/claims_test.go
@@ -3,7 +3,11 @@ package postgres
 import (
 	"context"
 	"testing"
+	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -43,5 +47,70 @@ func TestUpsertClaimRejectsUnconfiguredStore(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("UpsertClaim() error = nil, want non-nil")
+	}
+}
+
+func TestListClaimsRejectsMissingRuntimeID(t *testing.T) {
+	store := &Store{}
+	if _, err := store.ListClaims(context.Background(), ports.ListClaimsRequest{}); err == nil {
+		t.Fatal("ListClaims() error = nil, want non-nil")
+	}
+}
+
+func TestListClaimsRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	if _, err := store.ListClaims(context.Background(), ports.ListClaimsRequest{RuntimeID: "writer-jira"}); err == nil {
+		t.Fatal("ListClaims() error = nil, want non-nil")
+	}
+}
+
+func TestClaimRecordFromJSONRestoresRefsAndTimes(t *testing.T) {
+	payload := `{"id":"claim_1","subject_urn":"urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123","subject_ref":{"urn":"urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123","entity_type":"ticket","label":"ENG-123"},"predicate":"assigned_to","object_urn":"urn:cerebro:writer:runtime:writer-jira:user:acct:42","object_ref":{"urn":"urn:cerebro:writer:runtime:writer-jira:user:acct:42","entity_type":"user","label":"Alice"},"claim_type":"relation","status":"asserted","observed_at":"2026-04-23T12:00:00Z","attributes":{"source":"jira"}}`
+	record, err := claimRecordFromJSON("writer-jira", "writer", payload)
+	if err != nil {
+		t.Fatalf("claimRecordFromJSON() error = %v", err)
+	}
+	if got := record.RuntimeID; got != "writer-jira" {
+		t.Fatalf("record.RuntimeID = %q, want writer-jira", got)
+	}
+	if got := record.SubjectRef.GetEntityType(); got != "ticket" {
+		t.Fatalf("record.SubjectRef.EntityType = %q, want ticket", got)
+	}
+	if got := record.ObjectRef.GetLabel(); got != "Alice" {
+		t.Fatalf("record.ObjectRef.Label = %q, want Alice", got)
+	}
+	if got := record.ObservedAt; !got.Equal(time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("record.ObservedAt = %v, want 2026-04-23T12:00:00Z", got)
+	}
+	if got := record.Attributes["source"]; got != "jira" {
+		t.Fatalf("record.Attributes[source] = %q, want jira", got)
+	}
+}
+
+func TestClaimJSONIncludesTimestampsForRoundTrip(t *testing.T) {
+	payload, err := claimJSON(&ports.ClaimRecord{
+		ID:          "claim_1",
+		RuntimeID:   "writer-jira",
+		TenantID:    "writer",
+		SubjectURN:  "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+		SubjectRef:  &cerebrov1.EntityRef{Urn: "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123", EntityType: "ticket", Label: "ENG-123"},
+		Predicate:   "status",
+		ObjectValue: "in_progress",
+		ClaimType:   "attribute",
+		Status:      "asserted",
+		ObservedAt:  timestamppb.New(time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)).AsTime(),
+	})
+	if err != nil {
+		t.Fatalf("claimJSON() error = %v", err)
+	}
+	record, err := claimRecordFromJSON("writer-jira", "writer", payload)
+	if err != nil {
+		t.Fatalf("claimRecordFromJSON() error = %v", err)
+	}
+	if got := record.ObjectValue; got != "in_progress" {
+		t.Fatalf("record.ObjectValue = %q, want in_progress", got)
+	}
+	if got := record.ObservedAt; !got.Equal(time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)) {
+		t.Fatalf("record.ObservedAt = %v, want 2026-04-23T12:00:00Z", got)
 	}
 }

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -24,6 +24,7 @@ service BootstrapService {
   rpc GetSourceRuntime(GetSourceRuntimeRequest) returns (GetSourceRuntimeResponse);
   rpc SyncSourceRuntime(SyncSourceRuntimeRequest) returns (SyncSourceRuntimeResponse);
   rpc WriteClaims(WriteClaimsRequest) returns (WriteClaimsResponse);
+  rpc ListClaims(ListClaimsRequest) returns (ListClaimsResponse);
   rpc EvaluateSourceRuntimeFindings(EvaluateSourceRuntimeFindingsRequest) returns (EvaluateSourceRuntimeFindingsResponse);
   rpc GetEntityNeighborhood(GetEntityNeighborhoodRequest) returns (GetEntityNeighborhoodResponse);
 }
@@ -225,6 +226,24 @@ message WriteClaimsResponse {
   uint32 claims_written = 1;
   uint32 entities_upserted = 2;
   uint32 relation_links_projected = 3;
+}
+
+// ListClaimsRequest queries persisted claims for one stored runtime.
+message ListClaimsRequest {
+  string runtime_id = 1;
+  string claim_id = 2;
+  string subject_urn = 3;
+  string predicate = 4;
+  string object_urn = 5;
+  string object_value = 6;
+  string claim_type = 7;
+  string status = 8;
+  uint32 limit = 9;
+}
+
+// ListClaimsResponse returns the matched persisted claims.
+message ListClaimsResponse {
+  repeated Claim claims = 1;
 }
 
 // Finding is the normalized persisted finding view for the first runtime evaluator slice.

--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -53,7 +53,7 @@ class Client:
             if value in (None, ""):
                 continue
             query[key] = str(value)
-        path = f"/source-runtimes/{parse.quote(runtime_id)}/claims"
+        path = f"/source-runtimes/{parse.quote(runtime_id, safe='')}/claims"
         if query:
             path = f"{path}?{parse.urlencode(query)}"
         result, _ = self._request_json("GET", path)

--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -47,6 +47,18 @@ class Client:
         result, _ = self._request_json("POST", f"/source-runtimes/{parse.quote(runtime_id, safe='')}/claims", {"claims": claims})
         return result
 
+    def list_claims(self, runtime_id: str, filters: Optional[Dict[str, Any]] = None) -> Any:
+        query: Dict[str, str] = {}
+        for key, value in (filters or {}).items():
+            if value in (None, ""):
+                continue
+            query[key] = str(value)
+        path = f"/source-runtimes/{parse.quote(runtime_id)}/claims"
+        if query:
+            path = f"{path}?{parse.urlencode(query)}"
+        result, _ = self._request_json("GET", path)
+        return result
+
     def integration(self, runtime_id: str, tenant_id: str, integration: str) -> "IntegrationClient":
         return IntegrationClient(self, runtime_id=runtime_id, tenant_id=tenant_id, integration=integration)
 
@@ -283,6 +295,9 @@ class IntegrationClient:
 
     def write_claims(self, claims: list[Dict[str, Any]]) -> Any:
         return self.client.write_claims(self.runtime_id, claims)
+
+    def list_claims(self, filters: Optional[Dict[str, Any]] = None) -> Any:
+        return self.client.list_claims(self.runtime_id, filters)
 
     def ref(self, kind: str, external_id: str, label: str = "") -> Dict[str, str]:
         normalized_kind = kind.strip()

--- a/sdk/python/examples/jira_onboarding.py
+++ b/sdk/python/examples/jira_onboarding.py
@@ -1,0 +1,113 @@
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+# Make the example runnable directly from a repo checkout without an extra `pip install -e .`
+# step by adding the parent `sdk/python` directory to sys.path before importing cerebro_sdk.
+_SDK_PYTHON_ROOT = Path(__file__).resolve().parent.parent
+if str(_SDK_PYTHON_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SDK_PYTHON_ROOT))
+
+from cerebro_sdk import Client, IntegrationClient  # noqa: E402
+
+
+def build_issue_claims(integration: IntegrationClient, issue: Dict[str, Any]) -> list[Dict[str, Any]]:
+    issue_key = str(issue["key"]).strip()
+    issue_ref = integration.ref("ticket", issue_key, issue_key)
+    claims = [
+        integration.exists(
+            issue_ref,
+            source_event_id=str(issue.get("event_id", "")).strip() or None,
+        ),
+        integration.attr(issue_ref, "summary", str(issue["summary"]).strip()),
+        integration.attr(issue_ref, "status", str(issue["status"]).strip()),
+    ]
+
+    project_key = str(issue.get("project_key", "")).strip()
+    if project_key:
+        claims.append(
+            integration.rel(
+                issue_ref,
+                "belongs_to",
+                integration.ref("project", project_key, project_key),
+            )
+        )
+
+    assignee_email = str(issue.get("assignee_email", "")).strip()
+    if assignee_email:
+        claims.append(
+            integration.rel(
+                issue_ref,
+                "assigned_to",
+                integration.ref("user", assignee_email, assignee_email),
+            )
+        )
+
+    reporter_email = str(issue.get("reporter_email", "")).strip()
+    if reporter_email:
+        claims.append(
+            integration.rel(
+                issue_ref,
+                "reported_by",
+                integration.ref("user", reporter_email, reporter_email),
+            )
+        )
+
+    priority = str(issue.get("priority", "")).strip()
+    if priority:
+        claims.append(integration.attr(issue_ref, "priority", priority))
+
+    return claims
+
+
+def onboard_issue(base_url: str, api_key: str, tenant_id: str, runtime_id: str, issue: Dict[str, Any]) -> Dict[str, Any]:
+    client = Client(base_url=base_url, api_key=api_key or None)
+    integration = client.integration(runtime_id=runtime_id, tenant_id=tenant_id, integration="jira")
+    runtime_config = {}
+    workspace = str(issue.get("workspace", "")).strip()
+    if workspace:
+        runtime_config["workspace"] = workspace
+    integration.ensure_runtime(runtime_config)
+    claims = build_issue_claims(integration, issue)
+    write_result = integration.write_claims(claims)
+    claim_result = integration.list_claims(
+        {
+            "subject_urn": claims[0]["subject_urn"],
+            "limit": 20,
+        }
+    )
+    return {
+        "write_result": write_result,
+        "claims": claim_result.get("claims", []),
+    }
+
+
+def main() -> None:
+    base_url = os.environ.get("CEREBRO_BASE_URL", "").strip()
+    if not base_url:
+        raise RuntimeError("CEREBRO_BASE_URL is required")
+
+    result = onboard_issue(
+        base_url=base_url,
+        api_key=os.environ.get("CEREBRO_API_KEY", "").strip(),
+        tenant_id=os.environ.get("CEREBRO_TENANT_ID", "writer").strip(),
+        runtime_id=os.environ.get("CEREBRO_RUNTIME_ID", "writer-jira").strip(),
+        issue={
+            "workspace": os.environ.get("JIRA_WORKSPACE", "writer").strip(),
+            "event_id": os.environ.get("JIRA_EVENT_ID", "jira-event-1").strip(),
+            "project_key": os.environ.get("JIRA_PROJECT_KEY", "ENG").strip(),
+            "key": os.environ.get("JIRA_ISSUE_KEY", "ENG-123").strip(),
+            "summary": os.environ.get("JIRA_ISSUE_SUMMARY", "Claim-first Jira onboarding example").strip(),
+            "status": os.environ.get("JIRA_ISSUE_STATUS", "in_progress").strip(),
+            "priority": os.environ.get("JIRA_ISSUE_PRIORITY", "high").strip(),
+            "assignee_email": os.environ.get("JIRA_ASSIGNEE_EMAIL", "alice@writer.com").strip(),
+            "reporter_email": os.environ.get("JIRA_REPORTER_EMAIL", "bob@writer.com").strip(),
+        },
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -86,6 +86,17 @@ export interface ClaimOptions {
   claim_type?: string;
 }
 
+export interface ListClaimsOptions {
+  claim_id?: string;
+  subject_urn?: string;
+  predicate?: string;
+  object_urn?: string;
+  object_value?: string;
+  claim_type?: string;
+  status?: string;
+  limit?: number;
+}
+
 export interface IntegrationOptions {
   runtimeId: string;
   tenantId: string;
@@ -145,6 +156,18 @@ export class Client {
 
   async writeClaims(runtimeId: string, claims: Claim[]): Promise<Record<string, unknown>> {
     return this.requestJson<Record<string, unknown>>("POST", `/source-runtimes/${encodeURIComponent(runtimeId)}/claims`, { claims });
+  }
+
+  async listClaims(runtimeId: string, options: ListClaimsOptions = {}): Promise<Record<string, unknown>> {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(options)) {
+      if (value === undefined || value === null || value === "") {
+        continue;
+      }
+      query.set(key, String(value));
+    }
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    return this.requestJson<Record<string, unknown>>("GET", `/source-runtimes/${encodeURIComponent(runtimeId)}/claims${suffix}`);
   }
 
   integration(options: IntegrationOptions): IntegrationClient {
@@ -452,6 +475,10 @@ export class IntegrationClient {
 
   async writeClaims(claims: Claim[]): Promise<Record<string, unknown>> {
     return this.client.writeClaims(this.runtimeId, claims);
+  }
+
+  async listClaims(options: ListClaimsOptions = {}): Promise<Record<string, unknown>> {
+    return this.client.listClaims(this.runtimeId, options);
   }
 
   ref(kind: string, externalId: string, label = ""): EntityRef {


### PR DESCRIPTION
## Summary
- add runtime-scoped claim listing to BootstrapService plus the mirrored HTTP surface
- extend claim storage and services with filtered reads over persisted claim batches
- add SDK helpers for reading claims from TypeScript and Python integrations

## Testing
- make verify
- python3 -m py_compile sdk/python/cerebro_sdk/client.py sdk/python/cerebro_sdk/__init__.py
- cd sdk/typescript && npx -y -p typescript tsc -p tsconfig.json
