### PR TITLE
feat(sdk): add typescript jira onboarding example

### DIFF
--- a/sdk/python/examples/jira_posture_onboarding.py
+++ b/sdk/python/examples/jira_posture_onboarding.py
@@ -7,13 +7,13 @@ from cerebro_sdk import Client, IntegrationClient
 
 def build_workspace_claims(integration: IntegrationClient, posture: Dict[str, Any]) -> list[Dict[str, Any]]:
     workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
-    workspace_name = str(posture.get("workspace_name", workspace_key)).strip() or workspace_key
+    workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
     workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
     source_event_id = optional_string(posture.get("event_id"))
     shared_options = {"source_event_id": source_event_id} if source_event_id else {}
-    admins = list(posture.get("admins", []))
-    projects = list(posture.get("projects", []))
-    apps = list(posture.get("apps", []))
+    admins = list(posture.get("admins") or [])
+    projects = list(posture.get("projects") or [])
+    apps = list(posture.get("apps") or [])
 
     claims = [
         integration.exists(workspace_ref, **shared_options),
@@ -129,7 +129,7 @@ def build_workspace_claims(integration: IntegrationClient, posture: Dict[str, An
                 **shared_options,
             )
         )
-        scopes = [optional_string(scope) for scope in app.get("scopes", [])]
+        scopes = [optional_string(scope) for scope in (app.get("scopes") or [])]
         normalized_scopes = [scope for scope in scopes if scope]
         if normalized_scopes:
             claims.append(integration.attr(app_ref, "scopes", ",".join(normalized_scopes), **shared_options))

--- a/sdk/python/examples/jira_posture_onboarding.py
+++ b/sdk/python/examples/jira_posture_onboarding.py
@@ -1,0 +1,256 @@
+import json
+import os
+from typing import Any, Dict, Optional
+
+from cerebro_sdk import Client, IntegrationClient
+
+
+def build_workspace_claims(integration: IntegrationClient, posture: Dict[str, Any]) -> list[Dict[str, Any]]:
+    workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
+    workspace_name = str(posture.get("workspace_name", workspace_key)).strip() or workspace_key
+    workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
+    source_event_id = optional_string(posture.get("event_id"))
+    shared_options = {"source_event_id": source_event_id} if source_event_id else {}
+    admins = list(posture.get("admins", []))
+    projects = list(posture.get("projects", []))
+    apps = list(posture.get("apps", []))
+
+    claims = [
+        integration.exists(workspace_ref, **shared_options),
+        integration.attr(workspace_ref, "platform", "jira", **shared_options),
+        integration.attr(workspace_ref, "vendor", "atlassian", **shared_options),
+        integration.attr(workspace_ref, "sso_enforced", bool_value(posture.get("sso_enforced", True)), **shared_options),
+        integration.attr(
+            workspace_ref,
+            "mfa_required_for_admins",
+            bool_value(posture.get("mfa_required_for_admins", True)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "atlassian_guard_enabled",
+            bool_value(posture.get("atlassian_guard_enabled", True)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "audit_log_export_enabled",
+            bool_value(posture.get("audit_log_export_enabled", True)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "api_token_expiration_enforced",
+            bool_value(posture.get("api_token_expiration_enforced", True)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "public_signup_enabled",
+            bool_value(posture.get("public_signup_enabled", False)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "anonymous_access_enabled",
+            bool_value(posture.get("anonymous_access_enabled", False)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "approved_marketplace_apps_only",
+            bool_value(posture.get("approved_marketplace_apps_only", True)),
+            **shared_options,
+        ),
+        integration.attr(workspace_ref, "admin_count", str(len(admins)), **shared_options),
+        integration.attr(workspace_ref, "project_count", str(len(projects)), **shared_options),
+        integration.attr(workspace_ref, "installed_app_count", str(len(apps)), **shared_options),
+    ]
+
+    for admin in admins:
+        email = require_value(admin.get("email"), "admins[].email")
+        label = optional_string(admin.get("display_name")) or email
+        role = optional_string(admin.get("role")) or "site_admin"
+        admin_ref = integration.ref("user", email, label)
+        claims.append(integration.exists(admin_ref, **shared_options))
+        claims.append(integration.rel(admin_ref, "administers", workspace_ref, **shared_options))
+        claims.append(integration.attr(admin_ref, "role", role, **shared_options))
+
+    for project in projects:
+        key = require_value(project.get("key"), "projects[].key")
+        name = optional_string(project.get("name")) or key
+        project_ref = integration.ref("project", key, name)
+        claims.append(integration.exists(project_ref, **shared_options))
+        claims.append(integration.rel(project_ref, "belongs_to", workspace_ref, **shared_options))
+        claims.append(
+            integration.attr(
+                project_ref,
+                "classification",
+                optional_string(project.get("classification")) or "internal",
+                **shared_options,
+            )
+        )
+        claims.append(
+            integration.attr(
+                project_ref,
+                "issue_level_security_enabled",
+                bool_value(project.get("issue_level_security_enabled", True)),
+                **shared_options,
+            )
+        )
+        claims.append(
+            integration.attr(
+                project_ref,
+                "anonymous_browse_enabled",
+                bool_value(project.get("anonymous_browse_enabled", False)),
+                **shared_options,
+            )
+        )
+        claims.append(
+            integration.attr(
+                project_ref,
+                "service_desk_public_portal_enabled",
+                bool_value(project.get("service_desk_public_portal_enabled", False)),
+                **shared_options,
+            )
+        )
+
+    for app in apps:
+        key = require_value(app.get("key"), "apps[].key")
+        name = optional_string(app.get("name")) or key
+        app_ref = integration.ref("app", key, name)
+        claims.append(integration.exists(app_ref, **shared_options))
+        claims.append(integration.rel(app_ref, "installed_on", workspace_ref, **shared_options))
+        claims.append(
+            integration.attr(
+                app_ref,
+                "approved_by_security",
+                bool_value(app.get("approved_by_security", True)),
+                **shared_options,
+            )
+        )
+        scopes = [optional_string(scope) for scope in app.get("scopes", [])]
+        normalized_scopes = [scope for scope in scopes if scope]
+        if normalized_scopes:
+            claims.append(integration.attr(app_ref, "scopes", ",".join(normalized_scopes), **shared_options))
+
+    return claims
+
+
+def onboard_workspace_posture(
+    base_url: str,
+    api_key: str,
+    tenant_id: str,
+    runtime_id: str,
+    posture: Dict[str, Any],
+) -> Dict[str, Any]:
+    client = Client(base_url=base_url, api_key=api_key or None)
+    integration = client.integration(runtime_id=runtime_id, tenant_id=tenant_id, integration="jira")
+    runtime_config = {}
+    workspace_key = optional_string(posture.get("workspace_key"))
+    if workspace_key:
+        runtime_config["workspace"] = workspace_key
+    integration.ensure_runtime(runtime_config)
+    claims = build_workspace_claims(integration, posture)
+    write_result = integration.write_claims(claims)
+    persisted = integration.list_claims({"limit": 100})
+    return {
+        "workspace_urn": claims[0]["subject_urn"],
+        "write_result": write_result,
+        "submitted_claims": claims,
+        "persisted_claims": persisted.get("claims", []),
+    }
+
+
+def main() -> None:
+    base_url = require_value(os.environ.get("CEREBRO_BASE_URL"), "CEREBRO_BASE_URL")
+    result = onboard_workspace_posture(
+        base_url=base_url,
+        api_key=optional_string(os.environ.get("CEREBRO_API_KEY")) or "",
+        tenant_id=optional_string(os.environ.get("CEREBRO_TENANT_ID")) or "writer",
+        runtime_id=optional_string(os.environ.get("CEREBRO_RUNTIME_ID")) or "writer-jira-posture",
+        posture={
+            "workspace_key": optional_string(os.environ.get("JIRA_WORKSPACE")) or "writer",
+            "workspace_name": optional_string(os.environ.get("JIRA_WORKSPACE_NAME")) or "Writer Jira",
+            "event_id": optional_string(os.environ.get("JIRA_EVENT_ID")) or "jira-posture-snapshot-1",
+            "sso_enforced": env_bool("JIRA_SSO_ENFORCED", True),
+            "mfa_required_for_admins": env_bool("JIRA_MFA_REQUIRED_FOR_ADMINS", True),
+            "atlassian_guard_enabled": env_bool("JIRA_ATLASSIAN_GUARD_ENABLED", True),
+            "audit_log_export_enabled": env_bool("JIRA_AUDIT_LOG_EXPORT_ENABLED", True),
+            "api_token_expiration_enforced": env_bool("JIRA_API_TOKEN_EXPIRATION_ENFORCED", True),
+            "public_signup_enabled": env_bool("JIRA_PUBLIC_SIGNUP_ENABLED", False),
+            "anonymous_access_enabled": env_bool("JIRA_ANONYMOUS_ACCESS_ENABLED", False),
+            "approved_marketplace_apps_only": env_bool("JIRA_APPROVED_MARKETPLACE_APPS_ONLY", True),
+            "admins": [
+                {
+                    "email": optional_string(os.environ.get("JIRA_ADMIN_1_EMAIL")) or "alice@writer.com",
+                    "display_name": optional_string(os.environ.get("JIRA_ADMIN_1_NAME")) or "Alice",
+                    "role": optional_string(os.environ.get("JIRA_ADMIN_1_ROLE")) or "site_admin",
+                },
+                {
+                    "email": optional_string(os.environ.get("JIRA_ADMIN_2_EMAIL")) or "bob@writer.com",
+                    "display_name": optional_string(os.environ.get("JIRA_ADMIN_2_NAME")) or "Bob",
+                    "role": optional_string(os.environ.get("JIRA_ADMIN_2_ROLE")) or "org_admin",
+                },
+            ],
+            "projects": [
+                {
+                    "key": optional_string(os.environ.get("JIRA_PROJECT_1_KEY")) or "ENG",
+                    "name": optional_string(os.environ.get("JIRA_PROJECT_1_NAME")) or "Engineering",
+                    "classification": optional_string(os.environ.get("JIRA_PROJECT_1_CLASSIFICATION")) or "internal",
+                    "issue_level_security_enabled": env_bool("JIRA_PROJECT_1_ISSUE_SECURITY_ENABLED", True),
+                    "anonymous_browse_enabled": env_bool("JIRA_PROJECT_1_ANONYMOUS_BROWSE_ENABLED", False),
+                    "service_desk_public_portal_enabled": env_bool("JIRA_PROJECT_1_PUBLIC_PORTAL_ENABLED", False),
+                },
+                {
+                    "key": optional_string(os.environ.get("JIRA_PROJECT_2_KEY")) or "SEC",
+                    "name": optional_string(os.environ.get("JIRA_PROJECT_2_NAME")) or "Security",
+                    "classification": optional_string(os.environ.get("JIRA_PROJECT_2_CLASSIFICATION")) or "restricted",
+                    "issue_level_security_enabled": env_bool("JIRA_PROJECT_2_ISSUE_SECURITY_ENABLED", True),
+                    "anonymous_browse_enabled": env_bool("JIRA_PROJECT_2_ANONYMOUS_BROWSE_ENABLED", False),
+                    "service_desk_public_portal_enabled": env_bool("JIRA_PROJECT_2_PUBLIC_PORTAL_ENABLED", False),
+                },
+            ],
+            "apps": [
+                {
+                    "key": optional_string(os.environ.get("JIRA_APP_1_KEY")) or "slack",
+                    "name": optional_string(os.environ.get("JIRA_APP_1_NAME")) or "Slack for Jira",
+                    "approved_by_security": env_bool("JIRA_APP_1_APPROVED_BY_SECURITY", True),
+                    "scopes": [
+                        optional_string(os.environ.get("JIRA_APP_1_SCOPE_1")) or "read:project:jira",
+                        optional_string(os.environ.get("JIRA_APP_1_SCOPE_2")) or "write:comment:jira",
+                    ],
+                }
+            ],
+        },
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+def env_bool(name: str, default: bool) -> bool:
+    raw = optional_string(os.environ.get(name))
+    if raw is None:
+        return default
+    return raw.lower() in {"1", "true", "yes", "on"}
+
+
+def bool_value(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def optional_string(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def require_value(value: Any, name: str) -> str:
+    normalized = optional_string(value)
+    if normalized is None:
+        raise ValueError(f"{name} is required")
+    return normalized
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/typescript/examples/jira_onboarding.ts
+++ b/sdk/typescript/examples/jira_onboarding.ts
@@ -9,9 +9,9 @@ export interface JiraIssuePayload {
   workspace?: string;
   eventId?: string;
   projectKey?: string;
-  key: string;
-  summary: string;
-  status: string;
+  key?: string | null;
+  summary?: string | null;
+  status?: string | null;
   priority?: string;
   assigneeEmail?: string;
   reporterEmail?: string;
@@ -141,7 +141,10 @@ if (typeof process !== "undefined" && process.env) {
   }
 }
 
-function requireValue(value: string, name: string): string {
+function requireValue(value: string | undefined | null, name: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${name} is required`);
+  }
   const normalized = value.trim();
   if (!normalized) {
     throw new Error(`${name} is required`);

--- a/sdk/typescript/examples/jira_onboarding.ts
+++ b/sdk/typescript/examples/jira_onboarding.ts
@@ -1,0 +1,150 @@
+import { Client, type Claim, type IntegrationClient } from "../src/index.js";
+
+declare const process: {
+  env: Record<string, string | undefined>;
+  argv?: string[];
+};
+
+export interface JiraIssuePayload {
+  workspace?: string;
+  eventId?: string;
+  projectKey?: string;
+  key: string;
+  summary: string;
+  status: string;
+  priority?: string;
+  assigneeEmail?: string;
+  reporterEmail?: string;
+}
+
+export interface OnboardIssueOptions {
+  baseUrl: string;
+  apiKey?: string;
+  tenantId: string;
+  runtimeId: string;
+  issue: JiraIssuePayload;
+}
+
+export function buildIssueClaims(integration: IntegrationClient, issue: JiraIssuePayload): Claim[] {
+  const issueKey = requireValue(issue.key, "issue.key");
+  const summary = requireValue(issue.summary, "issue.summary");
+  const status = requireValue(issue.status, "issue.status");
+
+  const issueRef = integration.ref("ticket", issueKey, issueKey);
+  const sourceEventId = issue.eventId?.trim();
+  const sharedOptions = sourceEventId ? { source_event_id: sourceEventId } : {};
+  const claims: Claim[] = [
+    integration.exists(issueRef, sharedOptions),
+    integration.attr(issueRef, "summary", summary, sharedOptions),
+    integration.attr(issueRef, "status", status, sharedOptions),
+  ];
+
+  const projectKey = issue.projectKey?.trim();
+  if (projectKey) {
+    claims.push(
+      integration.rel(
+        issueRef,
+        "belongs_to",
+        integration.ref("project", projectKey, projectKey),
+        sharedOptions,
+      ),
+    );
+  }
+
+  const assigneeEmail = issue.assigneeEmail?.trim();
+  if (assigneeEmail) {
+    claims.push(
+      integration.rel(
+        issueRef,
+        "assigned_to",
+        integration.ref("user", assigneeEmail, assigneeEmail),
+        sharedOptions,
+      ),
+    );
+  }
+
+  const reporterEmail = issue.reporterEmail?.trim();
+  if (reporterEmail) {
+    claims.push(
+      integration.rel(
+        issueRef,
+        "reported_by",
+        integration.ref("user", reporterEmail, reporterEmail),
+        sharedOptions,
+      ),
+    );
+  }
+
+  const priority = issue.priority?.trim();
+  if (priority) {
+    claims.push(integration.attr(issueRef, "priority", priority, sharedOptions));
+  }
+
+  return claims;
+}
+
+export async function onboardIssue(options: OnboardIssueOptions): Promise<Record<string, unknown>> {
+  const client = new Client({
+    baseUrl: options.baseUrl,
+    apiKey: options.apiKey?.trim() || undefined,
+  });
+  const integration = client.integration({
+    runtimeId: options.runtimeId.trim(),
+    tenantId: options.tenantId.trim(),
+    integration: "jira",
+  });
+  const runtimeConfig: Record<string, string> = {};
+  const workspace = options.issue.workspace?.trim();
+  if (workspace) {
+    runtimeConfig.workspace = workspace;
+  }
+  await integration.ensureRuntime(runtimeConfig);
+  const claims = buildIssueClaims(integration, options.issue);
+  const writeResult = await integration.writeClaims(claims);
+  const subjectUrn = claims[0]?.subject_urn ?? "";
+  const claimResult = await integration.listClaims(subjectUrn ? { subject_urn: subjectUrn, limit: 20 } : { limit: 20 });
+  return {
+    writeResult,
+    claims: Array.isArray(claimResult["claims"]) ? claimResult["claims"] : [],
+  };
+}
+
+async function main(): Promise<void> {
+  const baseUrl = process.env.CEREBRO_BASE_URL?.trim() ?? "";
+  if (!baseUrl) {
+    throw new Error("CEREBRO_BASE_URL is required");
+  }
+  const result = await onboardIssue({
+    baseUrl,
+    apiKey: process.env.CEREBRO_API_KEY?.trim(),
+    tenantId: process.env.CEREBRO_TENANT_ID?.trim() || "writer",
+    runtimeId: process.env.CEREBRO_RUNTIME_ID?.trim() || "writer-jira",
+    issue: {
+      workspace: process.env.JIRA_WORKSPACE?.trim() || "writer",
+      eventId: process.env.JIRA_EVENT_ID?.trim() || "jira-event-1",
+      projectKey: process.env.JIRA_PROJECT_KEY?.trim() || "ENG",
+      key: process.env.JIRA_ISSUE_KEY?.trim() || "ENG-123",
+      summary: process.env.JIRA_ISSUE_SUMMARY?.trim() || "Claim-first Jira onboarding example",
+      status: process.env.JIRA_ISSUE_STATUS?.trim() || "in_progress",
+      priority: process.env.JIRA_ISSUE_PRIORITY?.trim() || "high",
+      assigneeEmail: process.env.JIRA_ASSIGNEE_EMAIL?.trim() || "alice@writer.com",
+      reporterEmail: process.env.JIRA_REPORTER_EMAIL?.trim() || "bob@writer.com",
+    },
+  });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (typeof process !== "undefined" && process.env) {
+  const entrypoint = process.argv?.[1] ?? "";
+  if (entrypoint.endsWith("jira_onboarding.ts") || entrypoint.endsWith("jira_onboarding.js")) {
+    void main();
+  }
+}
+
+function requireValue(value: string, name: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${name} is required`);
+  }
+  return normalized;
+}

--- a/sdk/typescript/examples/jira_posture_onboarding.ts
+++ b/sdk/typescript/examples/jira_posture_onboarding.ts
@@ -281,7 +281,7 @@ if (typeof process !== "undefined" && process.env) {
 }
 
 function envBool(name: string, defaultValue: boolean): boolean {
-  const raw = process.env[name]?.trim().toLowerCase();
+  const raw = process.env[name]?.trim()?.toLowerCase();
   if (!raw) {
     return defaultValue;
   }

--- a/sdk/typescript/examples/jira_posture_onboarding.ts
+++ b/sdk/typescript/examples/jira_posture_onboarding.ts
@@ -1,0 +1,301 @@
+import { Client, type Claim, type IntegrationClient } from "../src/index.js";
+
+declare const process: {
+  env: Record<string, string | undefined>;
+  argv?: string[];
+};
+
+export interface JiraAdminPosture {
+  email: string;
+  displayName?: string;
+  role?: string;
+}
+
+export interface JiraProjectPosture {
+  key: string;
+  name?: string;
+  classification?: string;
+  issueLevelSecurityEnabled?: boolean;
+  anonymousBrowseEnabled?: boolean;
+  serviceDeskPublicPortalEnabled?: boolean;
+}
+
+export interface JiraMarketplaceAppPosture {
+  key: string;
+  name?: string;
+  approvedBySecurity?: boolean;
+  scopes?: string[];
+}
+
+export interface JiraWorkspacePosture {
+  workspaceKey: string;
+  workspaceName?: string;
+  eventId?: string;
+  ssoEnforced?: boolean;
+  mfaRequiredForAdmins?: boolean;
+  atlassianGuardEnabled?: boolean;
+  auditLogExportEnabled?: boolean;
+  apiTokenExpirationEnforced?: boolean;
+  publicSignupEnabled?: boolean;
+  anonymousAccessEnabled?: boolean;
+  approvedMarketplaceAppsOnly?: boolean;
+  admins?: JiraAdminPosture[];
+  projects?: JiraProjectPosture[];
+  apps?: JiraMarketplaceAppPosture[];
+}
+
+export interface OnboardWorkspacePostureOptions {
+  baseUrl: string;
+  apiKey?: string;
+  tenantId: string;
+  runtimeId: string;
+  posture: JiraWorkspacePosture;
+}
+
+export function buildWorkspaceClaims(integration: IntegrationClient, posture: JiraWorkspacePosture): Claim[] {
+  const workspaceKey = requireValue(posture.workspaceKey, "posture.workspaceKey");
+  const workspaceName = posture.workspaceName?.trim() || workspaceKey;
+  const workspaceRef = integration.ref("workspace", workspaceKey, workspaceName);
+  const sourceEventId = posture.eventId?.trim();
+  const sharedOptions = sourceEventId ? { source_event_id: sourceEventId } : {};
+  const admins = posture.admins ?? [];
+  const projects = posture.projects ?? [];
+  const apps = posture.apps ?? [];
+
+  const claims: Claim[] = [
+    integration.exists(workspaceRef, sharedOptions),
+    integration.attr(workspaceRef, "platform", "jira", sharedOptions),
+    integration.attr(workspaceRef, "vendor", "atlassian", sharedOptions),
+    integration.attr(workspaceRef, "sso_enforced", boolValue(posture.ssoEnforced ?? true), sharedOptions),
+    integration.attr(
+      workspaceRef,
+      "mfa_required_for_admins",
+      boolValue(posture.mfaRequiredForAdmins ?? true),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "atlassian_guard_enabled",
+      boolValue(posture.atlassianGuardEnabled ?? true),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "audit_log_export_enabled",
+      boolValue(posture.auditLogExportEnabled ?? true),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "api_token_expiration_enforced",
+      boolValue(posture.apiTokenExpirationEnforced ?? true),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "public_signup_enabled",
+      boolValue(posture.publicSignupEnabled ?? false),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "anonymous_access_enabled",
+      boolValue(posture.anonymousAccessEnabled ?? false),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "approved_marketplace_apps_only",
+      boolValue(posture.approvedMarketplaceAppsOnly ?? true),
+      sharedOptions,
+    ),
+    integration.attr(workspaceRef, "admin_count", String(admins.length), sharedOptions),
+    integration.attr(workspaceRef, "project_count", String(projects.length), sharedOptions),
+    integration.attr(workspaceRef, "installed_app_count", String(apps.length), sharedOptions),
+  ];
+
+  for (const admin of admins) {
+    const email = requireValue(admin.email, "posture.admins[].email");
+    const adminRef = integration.ref("user", email, admin.displayName?.trim() || email);
+    claims.push(integration.exists(adminRef, sharedOptions));
+    claims.push(integration.rel(adminRef, "administers", workspaceRef, sharedOptions));
+    claims.push(integration.attr(adminRef, "role", admin.role?.trim() || "site_admin", sharedOptions));
+  }
+
+  for (const project of projects) {
+    const key = requireValue(project.key, "posture.projects[].key");
+    const projectRef = integration.ref("project", key, project.name?.trim() || key);
+    claims.push(integration.exists(projectRef, sharedOptions));
+    claims.push(integration.rel(projectRef, "belongs_to", workspaceRef, sharedOptions));
+    claims.push(
+      integration.attr(projectRef, "classification", project.classification?.trim() || "internal", sharedOptions),
+    );
+    claims.push(
+      integration.attr(
+        projectRef,
+        "issue_level_security_enabled",
+        boolValue(project.issueLevelSecurityEnabled ?? true),
+        sharedOptions,
+      ),
+    );
+    claims.push(
+      integration.attr(
+        projectRef,
+        "anonymous_browse_enabled",
+        boolValue(project.anonymousBrowseEnabled ?? false),
+        sharedOptions,
+      ),
+    );
+    claims.push(
+      integration.attr(
+        projectRef,
+        "service_desk_public_portal_enabled",
+        boolValue(project.serviceDeskPublicPortalEnabled ?? false),
+        sharedOptions,
+      ),
+    );
+  }
+
+  for (const app of apps) {
+    const key = requireValue(app.key, "posture.apps[].key");
+    const appRef = integration.ref("app", key, app.name?.trim() || key);
+    claims.push(integration.exists(appRef, sharedOptions));
+    claims.push(integration.rel(appRef, "installed_on", workspaceRef, sharedOptions));
+    claims.push(
+      integration.attr(
+        appRef,
+        "approved_by_security",
+        boolValue(app.approvedBySecurity ?? true),
+        sharedOptions,
+      ),
+    );
+    const scopes = (app.scopes ?? []).map((scope) => scope.trim()).filter(Boolean);
+    if (scopes.length > 0) {
+      claims.push(integration.attr(appRef, "scopes", scopes.join(","), sharedOptions));
+    }
+  }
+
+  return claims;
+}
+
+export async function onboardWorkspacePosture(options: OnboardWorkspacePostureOptions): Promise<Record<string, unknown>> {
+  const client = new Client({
+    baseUrl: options.baseUrl,
+    apiKey: options.apiKey?.trim() || undefined,
+  });
+  const integration = client.integration({
+    runtimeId: options.runtimeId.trim(),
+    tenantId: options.tenantId.trim(),
+    integration: "jira",
+  });
+  const runtimeConfig: Record<string, string> = {};
+  const workspaceKey = options.posture.workspaceKey.trim();
+  if (workspaceKey) {
+    runtimeConfig.workspace = workspaceKey;
+  }
+  await integration.ensureRuntime(runtimeConfig);
+  const claims = buildWorkspaceClaims(integration, options.posture);
+  const writeResult = await integration.writeClaims(claims);
+  const persisted = await integration.listClaims({ limit: 100 });
+  return {
+    workspace_urn: claims[0]?.subject_urn ?? "",
+    write_result: writeResult,
+    submitted_claims: claims,
+    persisted_claims: Array.isArray(persisted["claims"]) ? persisted["claims"] : [],
+  };
+}
+
+async function main(): Promise<void> {
+  const baseUrl = process.env.CEREBRO_BASE_URL?.trim() ?? "";
+  if (!baseUrl) {
+    throw new Error("CEREBRO_BASE_URL is required");
+  }
+  const result = await onboardWorkspacePosture({
+    baseUrl,
+    apiKey: process.env.CEREBRO_API_KEY?.trim(),
+    tenantId: process.env.CEREBRO_TENANT_ID?.trim() || "writer",
+    runtimeId: process.env.CEREBRO_RUNTIME_ID?.trim() || "writer-jira-posture",
+    posture: {
+      workspaceKey: process.env.JIRA_WORKSPACE?.trim() || "writer",
+      workspaceName: process.env.JIRA_WORKSPACE_NAME?.trim() || "Writer Jira",
+      eventId: process.env.JIRA_EVENT_ID?.trim() || "jira-posture-snapshot-1",
+      ssoEnforced: envBool("JIRA_SSO_ENFORCED", true),
+      mfaRequiredForAdmins: envBool("JIRA_MFA_REQUIRED_FOR_ADMINS", true),
+      atlassianGuardEnabled: envBool("JIRA_ATLASSIAN_GUARD_ENABLED", true),
+      auditLogExportEnabled: envBool("JIRA_AUDIT_LOG_EXPORT_ENABLED", true),
+      apiTokenExpirationEnforced: envBool("JIRA_API_TOKEN_EXPIRATION_ENFORCED", true),
+      publicSignupEnabled: envBool("JIRA_PUBLIC_SIGNUP_ENABLED", false),
+      anonymousAccessEnabled: envBool("JIRA_ANONYMOUS_ACCESS_ENABLED", false),
+      approvedMarketplaceAppsOnly: envBool("JIRA_APPROVED_MARKETPLACE_APPS_ONLY", true),
+      admins: [
+        {
+          email: process.env.JIRA_ADMIN_1_EMAIL?.trim() || "alice@writer.com",
+          displayName: process.env.JIRA_ADMIN_1_NAME?.trim() || "Alice",
+          role: process.env.JIRA_ADMIN_1_ROLE?.trim() || "site_admin",
+        },
+        {
+          email: process.env.JIRA_ADMIN_2_EMAIL?.trim() || "bob@writer.com",
+          displayName: process.env.JIRA_ADMIN_2_NAME?.trim() || "Bob",
+          role: process.env.JIRA_ADMIN_2_ROLE?.trim() || "org_admin",
+        },
+      ],
+      projects: [
+        {
+          key: process.env.JIRA_PROJECT_1_KEY?.trim() || "ENG",
+          name: process.env.JIRA_PROJECT_1_NAME?.trim() || "Engineering",
+          classification: process.env.JIRA_PROJECT_1_CLASSIFICATION?.trim() || "internal",
+          issueLevelSecurityEnabled: envBool("JIRA_PROJECT_1_ISSUE_SECURITY_ENABLED", true),
+          anonymousBrowseEnabled: envBool("JIRA_PROJECT_1_ANONYMOUS_BROWSE_ENABLED", false),
+          serviceDeskPublicPortalEnabled: envBool("JIRA_PROJECT_1_PUBLIC_PORTAL_ENABLED", false),
+        },
+        {
+          key: process.env.JIRA_PROJECT_2_KEY?.trim() || "SEC",
+          name: process.env.JIRA_PROJECT_2_NAME?.trim() || "Security",
+          classification: process.env.JIRA_PROJECT_2_CLASSIFICATION?.trim() || "restricted",
+          issueLevelSecurityEnabled: envBool("JIRA_PROJECT_2_ISSUE_SECURITY_ENABLED", true),
+          anonymousBrowseEnabled: envBool("JIRA_PROJECT_2_ANONYMOUS_BROWSE_ENABLED", false),
+          serviceDeskPublicPortalEnabled: envBool("JIRA_PROJECT_2_PUBLIC_PORTAL_ENABLED", false),
+        },
+      ],
+      apps: [
+        {
+          key: process.env.JIRA_APP_1_KEY?.trim() || "slack",
+          name: process.env.JIRA_APP_1_NAME?.trim() || "Slack for Jira",
+          approvedBySecurity: envBool("JIRA_APP_1_APPROVED_BY_SECURITY", true),
+          scopes: [
+            process.env.JIRA_APP_1_SCOPE_1?.trim() || "read:project:jira",
+            process.env.JIRA_APP_1_SCOPE_2?.trim() || "write:comment:jira",
+          ],
+        },
+      ],
+    },
+  });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+if (typeof process !== "undefined" && process.env) {
+  const entrypoint = process.argv?.[1] ?? "";
+  if (entrypoint.endsWith("jira_posture_onboarding.ts") || entrypoint.endsWith("jira_posture_onboarding.js")) {
+    void main();
+  }
+}
+
+function envBool(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name]?.trim().toLowerCase();
+  if (!raw) {
+    return defaultValue;
+  }
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+function boolValue(value: boolean): string {
+  return value ? "true" : "false";
+}
+
+function requireValue(value: string, name: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${name} is required`);
+  }
+  return normalized;
+}

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -7,5 +7,5 @@
     "noEmit": true,
     "lib": ["ES2022", "DOM"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "examples/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add a TypeScript Jira onboarding example that provisions the sdk runtime, writes claim batches, and reads the claims back
- mirror the Python onboarding flow so app integrators have a concrete example in both supported SDK languages
- type-check the new example by including `sdk/typescript/examples` in the package tsconfig

## Testing
- make verify
- cd sdk/typescript && npx -y -p typescript tsc -p tsconfig.json
- cd sdk/typescript && npx -y -p tsx tsx smoke-test for buildIssueClaims
