### PR TITLE
feat(sdk): show jira posture layering on the graph

### DIFF
--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -310,20 +310,14 @@ class IntegrationClient:
         return self.client.list_claims(self.runtime_id, filters)
 
     def graph_neighborhood(self, root: Any, limit: int = 0) -> Any:
-        if isinstance(root, dict):
-            root_urn = str(root["urn"]).strip()
-        else:
-            root_urn = str(root).strip()
+        root_urn = normalize_root_urn(root, "root")
         return self.client.get_entity_neighborhood(root_urn, limit)
 
     def graph_layering(self, roots: list[Any], limit: int = 0) -> Dict[str, Any]:
         layering: Dict[str, Any] = {}
         seen = set()
         for root in roots:
-            if isinstance(root, dict):
-                root_urn = str(root["urn"]).strip()
-            else:
-                root_urn = str(root).strip()
+            root_urn = normalize_root_urn(root, "root")
             if not root_urn or root_urn in seen:
                 continue
             seen.add(root_urn)
@@ -388,3 +382,16 @@ class IntegrationClient:
 
     def _build_urn(self, kind: str, external_id: str) -> str:
         return ":".join(["urn", "cerebro", self.tenant_id, "runtime", self.runtime_id, kind, external_id])
+
+
+def normalize_root_urn(root: Any, name: str) -> str:
+    if isinstance(root, dict):
+        value = root.get("urn")
+        if value is None:
+            raise ValueError(f"{name}['urn'] is required")
+    else:
+        value = root
+    root_urn = str(value).strip() if value is not None else ""
+    if not root_urn:
+        raise ValueError(f"{name} urn is required")
+    return root_urn

--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -59,6 +59,16 @@ class Client:
         result, _ = self._request_json("GET", path)
         return result
 
+    def get_entity_neighborhood(self, root_urn: str, limit: int = 0) -> Any:
+        normalized_root_urn = root_urn.strip()
+        if not normalized_root_urn:
+            raise ValueError("root_urn is required")
+        query = {"root_urn": normalized_root_urn}
+        if limit > 0:
+            query["limit"] = str(limit)
+        result, _ = self._request_json("GET", f"/graph/neighborhood?{parse.urlencode(query)}")
+        return result
+
     def integration(self, runtime_id: str, tenant_id: str, integration: str) -> "IntegrationClient":
         return IntegrationClient(self, runtime_id=runtime_id, tenant_id=tenant_id, integration=integration)
 
@@ -298,6 +308,13 @@ class IntegrationClient:
 
     def list_claims(self, filters: Optional[Dict[str, Any]] = None) -> Any:
         return self.client.list_claims(self.runtime_id, filters)
+
+    def graph_neighborhood(self, root: Any, limit: int = 0) -> Any:
+        if isinstance(root, dict):
+            root_urn = str(root["urn"]).strip()
+        else:
+            root_urn = str(root).strip()
+        return self.client.get_entity_neighborhood(root_urn, limit)
 
     def ref(self, kind: str, external_id: str, label: str = "") -> Dict[str, str]:
         normalized_kind = kind.strip()

--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -318,7 +318,7 @@ class IntegrationClient:
         seen = set()
         for root in roots:
             root_urn = normalize_root_urn(root, "root")
-            if not root_urn or root_urn in seen:
+            if root_urn in seen:
                 continue
             seen.add(root_urn)
             try:

--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -316,6 +316,26 @@ class IntegrationClient:
             root_urn = str(root).strip()
         return self.client.get_entity_neighborhood(root_urn, limit)
 
+    def graph_layering(self, roots: list[Any], limit: int = 0) -> Dict[str, Any]:
+        layering: Dict[str, Any] = {}
+        seen = set()
+        for root in roots:
+            if isinstance(root, dict):
+                root_urn = str(root["urn"]).strip()
+            else:
+                root_urn = str(root).strip()
+            if not root_urn or root_urn in seen:
+                continue
+            seen.add(root_urn)
+            try:
+                layering[root_urn] = self.graph_neighborhood(root_urn, limit)
+            except APIError as err:
+                layering[root_urn] = {
+                    "root_urn": root_urn,
+                    "error": str(err),
+                }
+        return layering
+
     def ref(self, kind: str, external_id: str, label: str = "") -> Dict[str, str]:
         normalized_kind = kind.strip()
         normalized_external_id = external_id.strip()

--- a/sdk/python/examples/jira_posture_onboarding.py
+++ b/sdk/python/examples/jira_posture_onboarding.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import Any, Dict, Optional
 
-from cerebro_sdk import APIError, Client, IntegrationClient
+from cerebro_sdk import Client, IntegrationClient
 
 
 def build_workspace_claims(integration: IntegrationClient, posture: Dict[str, Any]) -> list[Dict[str, Any]]:
@@ -244,26 +244,22 @@ def load_graph_layering(integration: IntegrationClient, posture: Dict[str, Any])
     workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
     workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
     workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
-    project_graphs: Dict[str, Any] = {}
+    project_refs = []
+    project_keys = []
     for project in posture.get("projects", []):
         project_key = require_value(project.get("key"), "projects[].key")
         project_name = optional_string(project.get("name")) or project_key
-        project_ref = integration.ref("project", project_key, project_name)
-        project_graphs[project_key] = safe_graph_neighborhood(integration, project_ref, limit=12)
+        project_refs.append(integration.ref("project", project_key, project_name))
+        project_keys.append(project_key)
+    workspace_graph = integration.graph_layering([workspace_ref], limit=50)
+    project_layering = integration.graph_layering(project_refs, limit=12)
+    project_graphs = {}
+    for project_key, project_ref in zip(project_keys, project_refs):
+        project_graphs[project_key] = project_layering.get(project_ref["urn"], {"root_urn": project_ref["urn"], "error": "missing graph response"})
     return {
-        "workspace": safe_graph_neighborhood(integration, workspace_ref, limit=50),
+        "workspace": workspace_graph.get(workspace_ref["urn"], {"root_urn": workspace_ref["urn"], "error": "missing graph response"}),
         "projects": project_graphs,
     }
-
-
-def safe_graph_neighborhood(integration: IntegrationClient, root: Dict[str, str], limit: int) -> Dict[str, Any]:
-    try:
-        return integration.graph_neighborhood(root, limit)
-    except APIError as err:
-        return {
-            "root_urn": root["urn"],
-            "error": str(err),
-        }
 
 
 def optional_string(value: Any) -> Optional[str]:

--- a/sdk/python/examples/jira_posture_onboarding.py
+++ b/sdk/python/examples/jira_posture_onboarding.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import Any, Dict, Optional
 
-from cerebro_sdk import Client, IntegrationClient
+from cerebro_sdk import APIError, Client, IntegrationClient
 
 
 def build_workspace_claims(integration: IntegrationClient, posture: Dict[str, Any]) -> list[Dict[str, Any]]:
@@ -154,11 +154,13 @@ def onboard_workspace_posture(
     claims = build_workspace_claims(integration, posture)
     write_result = integration.write_claims(claims)
     persisted = integration.list_claims({"limit": 100})
+    graph_layering = load_graph_layering(integration, posture)
     return {
         "workspace_urn": claims[0]["subject_urn"],
         "write_result": write_result,
         "submitted_claims": claims,
         "persisted_claims": persisted.get("claims", []),
+        "graph_layering": graph_layering,
     }
 
 
@@ -236,6 +238,32 @@ def env_bool(name: str, default: bool) -> bool:
 
 def bool_value(value: Any) -> str:
     return "true" if bool(value) else "false"
+
+
+def load_graph_layering(integration: IntegrationClient, posture: Dict[str, Any]) -> Dict[str, Any]:
+    workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
+    workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
+    workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
+    project_graphs: Dict[str, Any] = {}
+    for project in posture.get("projects", []):
+        project_key = require_value(project.get("key"), "projects[].key")
+        project_name = optional_string(project.get("name")) or project_key
+        project_ref = integration.ref("project", project_key, project_name)
+        project_graphs[project_key] = safe_graph_neighborhood(integration, project_ref, limit=12)
+    return {
+        "workspace": safe_graph_neighborhood(integration, workspace_ref, limit=50),
+        "projects": project_graphs,
+    }
+
+
+def safe_graph_neighborhood(integration: IntegrationClient, root: Dict[str, str], limit: int) -> Dict[str, Any]:
+    try:
+        return integration.graph_neighborhood(root, limit)
+    except APIError as err:
+        return {
+            "root_urn": root["urn"],
+            "error": str(err),
+        }
 
 
 def optional_string(value: Any) -> Optional[str]:

--- a/sdk/python/examples/jira_posture_onboarding.py
+++ b/sdk/python/examples/jira_posture_onboarding.py
@@ -7,7 +7,7 @@ from cerebro_sdk import Client, IntegrationClient
 
 def build_workspace_claims(integration: IntegrationClient, posture: Dict[str, Any]) -> list[Dict[str, Any]]:
     workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
-    workspace_name = str(posture.get("workspace_name", workspace_key)).strip() or workspace_key
+    workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
     workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
     source_event_id = optional_string(posture.get("event_id"))
     shared_options = {"source_event_id": source_event_id} if source_event_id else {}

--- a/sdk/typescript/examples/jira_posture_onboarding.ts
+++ b/sdk/typescript/examples/jira_posture_onboarding.ts
@@ -1,4 +1,4 @@
-import { APIError, Client, type Claim, type IntegrationClient } from "../src/index.js";
+import { Client, type Claim, type IntegrationClient } from "../src/index.js";
 
 declare const process: {
   env: Record<string, string | undefined>;
@@ -300,35 +300,31 @@ async function loadGraphLayering(
 ): Promise<Record<string, unknown>> {
   const workspaceKey = requireValue(posture.workspaceKey, "posture.workspaceKey");
   const workspaceRef = integration.ref("workspace", workspaceKey, posture.workspaceName?.trim() || workspaceKey);
-  const projectEntries = await Promise.all(
-    (posture.projects ?? []).map(async (project) => {
-      const projectKey = requireValue(project.key, "posture.projects[].key");
-      const projectRef = integration.ref("project", projectKey, project.name?.trim() || projectKey);
-      return [projectKey, await safeGraphNeighborhood(integration, projectRef, 12)] as const;
-    }),
+  const projectEntries = (posture.projects ?? []).map((project) => {
+    const projectKey = requireValue(project.key, "posture.projects[].key");
+    const projectRef = integration.ref("project", projectKey, project.name?.trim() || projectKey);
+    return [projectKey, projectRef] as const;
+  });
+  const workspaceLayering = await integration.graphLayering([workspaceRef], 50);
+  const projectLayering = await integration.graphLayering(
+    projectEntries.map(([, projectRef]) => projectRef),
+    12,
   );
   return {
-    workspace: await safeGraphNeighborhood(integration, workspaceRef, 50),
-    projects: Object.fromEntries(projectEntries),
+    workspace: workspaceLayering[workspaceRef.urn] ?? {
+      root_urn: workspaceRef.urn,
+      error: "missing graph response",
+    },
+    projects: Object.fromEntries(
+      projectEntries.map(([projectKey, projectRef]) => [
+        projectKey,
+        projectLayering[projectRef.urn] ?? {
+          root_urn: projectRef.urn,
+          error: "missing graph response",
+        },
+      ]),
+    ),
   };
-}
-
-async function safeGraphNeighborhood(
-  integration: IntegrationClient,
-  root: { urn: string },
-  limit: number,
-): Promise<unknown> {
-  try {
-    return await integration.graphNeighborhood(root.urn, limit);
-  } catch (error) {
-    if (error instanceof APIError) {
-      return {
-        root_urn: root.urn,
-        error: error.message,
-      };
-    }
-    throw error;
-  }
 }
 
 function requireValue(value: string, name: string): string {

--- a/sdk/typescript/examples/jira_posture_onboarding.ts
+++ b/sdk/typescript/examples/jira_posture_onboarding.ts
@@ -1,4 +1,4 @@
-import { Client, type Claim, type IntegrationClient } from "../src/index.js";
+import { APIError, Client, type Claim, type IntegrationClient } from "../src/index.js";
 
 declare const process: {
   env: Record<string, string | undefined>;
@@ -197,11 +197,13 @@ export async function onboardWorkspacePosture(options: OnboardWorkspacePostureOp
   const claims = buildWorkspaceClaims(integration, options.posture);
   const writeResult = await integration.writeClaims(claims);
   const persisted = await integration.listClaims({ limit: 100 });
+  const graphLayering = await loadGraphLayering(integration, options.posture);
   return {
     workspace_urn: claims[0]?.subject_urn ?? "",
     write_result: writeResult,
     submitted_claims: claims,
     persisted_claims: Array.isArray(persisted["claims"]) ? persisted["claims"] : [],
+    graph_layering: graphLayering,
   };
 }
 
@@ -290,6 +292,43 @@ function envBool(name: string, defaultValue: boolean): boolean {
 
 function boolValue(value: boolean): string {
   return value ? "true" : "false";
+}
+
+async function loadGraphLayering(
+  integration: IntegrationClient,
+  posture: JiraWorkspacePosture,
+): Promise<Record<string, unknown>> {
+  const workspaceKey = requireValue(posture.workspaceKey, "posture.workspaceKey");
+  const workspaceRef = integration.ref("workspace", workspaceKey, posture.workspaceName?.trim() || workspaceKey);
+  const projectEntries = await Promise.all(
+    (posture.projects ?? []).map(async (project) => {
+      const projectKey = requireValue(project.key, "posture.projects[].key");
+      const projectRef = integration.ref("project", projectKey, project.name?.trim() || projectKey);
+      return [projectKey, await safeGraphNeighborhood(integration, projectRef, 12)] as const;
+    }),
+  );
+  return {
+    workspace: await safeGraphNeighborhood(integration, workspaceRef, 50),
+    projects: Object.fromEntries(projectEntries),
+  };
+}
+
+async function safeGraphNeighborhood(
+  integration: IntegrationClient,
+  root: { urn: string },
+  limit: number,
+): Promise<unknown> {
+  try {
+    return await integration.graphNeighborhood(root.urn, limit);
+  } catch (error) {
+    if (error instanceof APIError) {
+      return {
+        root_urn: root.urn,
+        error: error.message,
+      };
+    }
+    throw error;
+  }
 }
 
 function requireValue(value: string, name: string): string {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -115,6 +115,13 @@ export interface GraphNeighborhood {
   relations?: GraphRelation[];
 }
 
+export interface GraphNeighborhoodError {
+  root_urn: string;
+  error: string;
+}
+
+export type GraphLayering = Record<string, GraphNeighborhood | GraphNeighborhoodError>;
+
 export interface IntegrationOptions {
   runtimeId: string;
   tenantId: string;
@@ -514,6 +521,31 @@ export class IntegrationClient {
   async graphNeighborhood(root: EntityRef | string, limit = 0): Promise<GraphNeighborhood> {
     const rootUrn = typeof root === "string" ? root.trim() : root.urn.trim();
     return this.client.getEntityNeighborhood(rootUrn, limit);
+  }
+
+  async graphLayering(roots: Array<EntityRef | string>, limit = 0): Promise<GraphLayering> {
+    const layering: GraphLayering = {};
+    const seen = new Set<string>();
+    for (const root of roots) {
+      const rootUrn = typeof root === "string" ? root.trim() : root.urn.trim();
+      if (!rootUrn || seen.has(rootUrn)) {
+        continue;
+      }
+      seen.add(rootUrn);
+      try {
+        layering[rootUrn] = await this.graphNeighborhood(rootUrn, limit);
+      } catch (error) {
+        if (error instanceof APIError) {
+          layering[rootUrn] = {
+            root_urn: rootUrn,
+            error: error.message,
+          };
+          continue;
+        }
+        throw error;
+      }
+    }
+    return layering;
   }
 
   ref(kind: string, externalId: string, label = ""): EntityRef {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -524,7 +524,7 @@ export class IntegrationClient {
   }
 
   async graphLayering(roots: Array<EntityRef | string>, limit = 0): Promise<GraphLayering> {
-    const layering: GraphLayering = {};
+    const layering = Object.create(null) as GraphLayering;
     const seen = new Set<string>();
     for (const root of roots) {
       const rootUrn = typeof root === "string" ? root.trim() : root.urn.trim();

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -100,7 +100,7 @@ export interface ListClaimsOptions {
 export interface GraphEntity {
   urn: string;
   entity_type: string;
-  label: string;
+  label?: string;
 }
 
 export interface GraphRelation {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -97,6 +97,24 @@ export interface ListClaimsOptions {
   limit?: number;
 }
 
+export interface GraphEntity {
+  urn: string;
+  entity_type: string;
+  label: string;
+}
+
+export interface GraphRelation {
+  from_urn: string;
+  relation: string;
+  to_urn: string;
+}
+
+export interface GraphNeighborhood {
+  root?: GraphEntity;
+  neighbors?: GraphEntity[];
+  relations?: GraphRelation[];
+}
+
 export interface IntegrationOptions {
   runtimeId: string;
   tenantId: string;
@@ -168,6 +186,18 @@ export class Client {
     }
     const suffix = query.toString() ? `?${query.toString()}` : "";
     return this.requestJson<Record<string, unknown>>("GET", `/source-runtimes/${encodeURIComponent(runtimeId)}/claims${suffix}`);
+  }
+
+  async getEntityNeighborhood(rootUrn: string, limit = 0): Promise<GraphNeighborhood> {
+    const normalizedRootUrn = rootUrn.trim();
+    if (!normalizedRootUrn) {
+      throw new Error("rootUrn is required");
+    }
+    const query = new URLSearchParams({ root_urn: normalizedRootUrn });
+    if (limit > 0) {
+      query.set("limit", String(limit));
+    }
+    return this.requestJson<GraphNeighborhood>("GET", `/graph/neighborhood?${query.toString()}`);
   }
 
   integration(options: IntegrationOptions): IntegrationClient {
@@ -479,6 +509,11 @@ export class IntegrationClient {
 
   async listClaims(options: ListClaimsOptions = {}): Promise<Record<string, unknown>> {
     return this.client.listClaims(this.runtimeId, options);
+  }
+
+  async graphNeighborhood(root: EntityRef | string, limit = 0): Promise<GraphNeighborhood> {
+    const rootUrn = typeof root === "string" ? root.trim() : root.urn.trim();
+    return this.client.getEntityNeighborhood(rootUrn, limit);
   }
 
   ref(kind: string, externalId: string, label = ""): EntityRef {


### PR DESCRIPTION
## Summary
- add SDK helpers for bounded graph neighborhood reads in both Python and TypeScript
- extend the Jira posture onboarding examples to fetch graph neighborhoods after claim writes so the layered workspace/project topology is visible immediately
- return graph-layering output alongside submitted and persisted claims, with graceful API error payloads when the graph surface is unavailable

## Testing
- make verify
- python3 -m py_compile sdk/python/cerebro_sdk/client.py sdk/python/examples/jira_posture_onboarding.py
- PYTHONPATH=sdk/python python3 smoke test for graph helpers and build_workspace_claims
- cd sdk/typescript && npx -y -p typescript tsc -p tsconfig.json
- cd sdk/typescript && npx -y -p tsx tsx smoke test for graph helpers and buildWorkspaceClaims
