### PR TITLE
feat(sdk): summarize jira posture graph layering

### DIFF
--- a/sdk/python/examples/jira_posture_onboarding.py
+++ b/sdk/python/examples/jira_posture_onboarding.py
@@ -291,11 +291,17 @@ def summarize_graph_layering(graph_layering: Dict[str, Any]) -> Dict[str, Any]:
                 "label": optional_string(root.get("label")) or root_key,
             }
         )
+        neighbors = entry.get("neighbors")
+        if not isinstance(neighbors, list):
+            neighbors = []
+        relations = entry.get("relations")
+        if not isinstance(relations, list):
+            relations = []
         neighborhood_sizes[root_key] = {
-            "neighbors": len(entry.get("neighbors", [])),
-            "relations": len(entry.get("relations", [])),
+            "neighbors": len(neighbors),
+            "relations": len(relations),
         }
-        for node in [root] + list(entry.get("neighbors", [])):
+        for node in [root] + neighbors:
             if not isinstance(node, dict):
                 continue
             node_urn = optional_string(node.get("urn"))
@@ -304,7 +310,7 @@ def summarize_graph_layering(graph_layering: Dict[str, Any]) -> Dict[str, Any]:
                 continue
             seen_nodes.add(node_urn)
             node_counts[entity_type] = node_counts.get(entity_type, 0) + 1
-        for relation in entry.get("relations", []):
+        for relation in relations:
             if not isinstance(relation, dict):
                 continue
             from_urn = optional_string(relation.get("from_urn"))

--- a/sdk/python/examples/jira_posture_onboarding.py
+++ b/sdk/python/examples/jira_posture_onboarding.py
@@ -161,6 +161,7 @@ def onboard_workspace_posture(
         "submitted_claims": claims,
         "persisted_claims": persisted.get("claims", []),
         "graph_layering": graph_layering,
+        "graph_summary": summarize_graph_layering(graph_layering),
     }
 
 
@@ -259,6 +260,69 @@ def load_graph_layering(integration: IntegrationClient, posture: Dict[str, Any])
     return {
         "workspace": workspace_graph.get(workspace_ref["urn"], {"root_urn": workspace_ref["urn"], "error": "missing graph response"}),
         "projects": project_graphs,
+    }
+
+
+def summarize_graph_layering(graph_layering: Dict[str, Any]) -> Dict[str, Any]:
+    roots = []
+    node_counts: Dict[str, int] = {}
+    relation_counts: Dict[str, int] = {}
+    neighborhood_sizes: Dict[str, Dict[str, int]] = {}
+    errors: Dict[str, str] = {}
+    seen_nodes = set()
+    seen_relations = set()
+    entries = [graph_layering.get("workspace")] + list(graph_layering.get("projects", {}).values())
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        error = optional_string(entry.get("error"))
+        root_urn = optional_string(entry.get("root_urn"))
+        if error and root_urn:
+            errors[root_urn] = error
+            continue
+        root = entry.get("root")
+        if not isinstance(root, dict):
+            continue
+        root_key = require_value(root.get("urn"), "graph root urn")
+        roots.append(
+            {
+                "urn": root_key,
+                "entity_type": optional_string(root.get("entity_type")) or "unknown",
+                "label": optional_string(root.get("label")) or root_key,
+            }
+        )
+        neighborhood_sizes[root_key] = {
+            "neighbors": len(entry.get("neighbors", [])),
+            "relations": len(entry.get("relations", [])),
+        }
+        for node in [root] + list(entry.get("neighbors", [])):
+            if not isinstance(node, dict):
+                continue
+            node_urn = optional_string(node.get("urn"))
+            entity_type = optional_string(node.get("entity_type")) or "unknown"
+            if node_urn is None or node_urn in seen_nodes:
+                continue
+            seen_nodes.add(node_urn)
+            node_counts[entity_type] = node_counts.get(entity_type, 0) + 1
+        for relation in entry.get("relations", []):
+            if not isinstance(relation, dict):
+                continue
+            from_urn = optional_string(relation.get("from_urn"))
+            name = optional_string(relation.get("relation"))
+            to_urn = optional_string(relation.get("to_urn"))
+            if from_urn is None or name is None or to_urn is None:
+                continue
+            key = (from_urn, name, to_urn)
+            if key in seen_relations:
+                continue
+            seen_relations.add(key)
+            relation_counts[name] = relation_counts.get(name, 0) + 1
+    return {
+        "roots": roots,
+        "node_counts_by_type": node_counts,
+        "relation_counts_by_type": relation_counts,
+        "neighborhood_sizes": neighborhood_sizes,
+        "errors": errors,
     }
 
 

--- a/sdk/typescript/examples/jira_posture_onboarding.ts
+++ b/sdk/typescript/examples/jira_posture_onboarding.ts
@@ -204,6 +204,7 @@ export async function onboardWorkspacePosture(options: OnboardWorkspacePostureOp
     submitted_claims: claims,
     persisted_claims: Array.isArray(persisted["claims"]) ? persisted["claims"] : [],
     graph_layering: graphLayering,
+    graph_summary: summarizeGraphLayering(graphLayering),
   };
 }
 
@@ -327,10 +328,98 @@ async function loadGraphLayering(
   };
 }
 
+export function summarizeGraphLayering(graphLayering: Record<string, unknown>): Record<string, unknown> {
+  const roots: Array<Record<string, string>> = [];
+  const nodeCounts = new Map<string, number>();
+  const relationCounts = new Map<string, number>();
+  const neighborhoodSizes: Record<string, { neighbors: number; relations: number }> = {};
+  const errors: Record<string, string> = {};
+  const seenNodes = new Set<string>();
+  const seenRelations = new Set<string>();
+  const workspace = asRecord(graphLayering["workspace"]);
+  const projects = asRecord(graphLayering["projects"]);
+  const entries = [workspace, ...Object.values(projects).map(asRecord)];
+
+  for (const entry of entries) {
+    const error = optionalRecordValue(entry, "error");
+    const rootUrn = optionalRecordValue(entry, "root_urn");
+    if (error && rootUrn) {
+      errors[rootUrn] = error;
+      continue;
+    }
+    const root = asRecord(entry["root"]);
+    const rootKey = optionalRecordValue(root, "urn");
+    if (!rootKey) {
+      continue;
+    }
+    roots.push({
+      urn: rootKey,
+      entity_type: optionalRecordValue(root, "entity_type") || "unknown",
+      label: optionalRecordValue(root, "label") || rootKey,
+    });
+    const neighbors = asRecordArray(entry["neighbors"]);
+    const relations = asRecordArray(entry["relations"]);
+    neighborhoodSizes[rootKey] = {
+      neighbors: neighbors.length,
+      relations: relations.length,
+    };
+    for (const node of [root, ...neighbors]) {
+      const nodeUrn = optionalRecordValue(node, "urn");
+      const entityType = optionalRecordValue(node, "entity_type") || "unknown";
+      if (!nodeUrn || seenNodes.has(nodeUrn)) {
+        continue;
+      }
+      seenNodes.add(nodeUrn);
+      nodeCounts.set(entityType, (nodeCounts.get(entityType) ?? 0) + 1);
+    }
+    for (const relation of relations) {
+      const fromUrn = optionalRecordValue(relation, "from_urn");
+      const name = optionalRecordValue(relation, "relation");
+      const toUrn = optionalRecordValue(relation, "to_urn");
+      if (!fromUrn || !name || !toUrn) {
+        continue;
+      }
+      const relationKey = `${fromUrn}\u0000${name}\u0000${toUrn}`;
+      if (seenRelations.has(relationKey)) {
+        continue;
+      }
+      seenRelations.add(relationKey);
+      relationCounts.set(name, (relationCounts.get(name) ?? 0) + 1);
+    }
+  }
+
+  return {
+    roots,
+    node_counts_by_type: Object.fromEntries(nodeCounts),
+    relation_counts_by_type: Object.fromEntries(relationCounts),
+    neighborhood_sizes: neighborhoodSizes,
+    errors,
+  };
+}
+
 function requireValue(value: string, name: string): string {
   const normalized = value.trim();
   if (!normalized) {
     throw new Error(`${name} is required`);
   }
   return normalized;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function asRecordArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map(asRecord);
+}
+
+function optionalRecordValue(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" ? value : "";
 }


### PR DESCRIPTION
## Summary
- add graph summaries on top of the raw Jira posture neighborhood output in both SDK examples
- count unique node types and relation types, track per-root neighborhood sizes, and preserve any graph fetch errors in the summary
- make the posture examples return both the raw graph layering and a concise graph-summary view that is easier to inspect during onboarding

## Testing
- make verify
- python3 -m py_compile sdk/python/examples/jira_posture_onboarding.py
- PYTHONPATH=sdk/python python3 smoke test for summarize_graph_layering
- cd sdk/typescript && npx -y -p typescript tsc -p tsconfig.json
- cd sdk/typescript && npx -y -p tsx tsx smoke test for summarizeGraphLayering
