### PR TITLE
feat(sdk): add graph summary helpers

### DIFF
--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -330,6 +330,68 @@ class IntegrationClient:
                 }
         return layering
 
+    def graph_summary(self, layering: Dict[str, Any]) -> Dict[str, Any]:
+        roots = []
+        node_counts: Dict[str, int] = {}
+        relation_counts: Dict[str, int] = {}
+        neighborhood_sizes: Dict[str, Dict[str, int]] = {}
+        errors: Dict[str, str] = {}
+        seen_nodes = set()
+        seen_relations = set()
+        for root_urn, entry in layering.items():
+            if not isinstance(entry, dict):
+                continue
+            error = _optional_string(entry.get("error"))
+            if error is not None:
+                errors[_optional_string(entry.get("root_urn")) or root_urn] = error
+                continue
+            root = entry.get("root")
+            if not isinstance(root, dict):
+                continue
+            root_key = _optional_string(root.get("urn"))
+            if root_key is None:
+                continue
+            roots.append(
+                {
+                    "urn": root_key,
+                    "entity_type": _optional_string(root.get("entity_type")) or "unknown",
+                    "label": _optional_string(root.get("label")) or root_key,
+                }
+            )
+            neighborhood_sizes[root_key] = {
+                "neighbors": len(entry.get("neighbors", [])),
+                "relations": len(entry.get("relations", [])),
+            }
+            for node in [root] + list(entry.get("neighbors", [])):
+                if not isinstance(node, dict):
+                    continue
+                node_urn = _optional_string(node.get("urn"))
+                entity_type = _optional_string(node.get("entity_type")) or "unknown"
+                if node_urn is None or node_urn in seen_nodes:
+                    continue
+                seen_nodes.add(node_urn)
+                node_counts[entity_type] = node_counts.get(entity_type, 0) + 1
+            for relation in entry.get("relations", []):
+                if not isinstance(relation, dict):
+                    continue
+                from_urn = _optional_string(relation.get("from_urn"))
+                name = _optional_string(relation.get("relation"))
+                to_urn = _optional_string(relation.get("to_urn"))
+                if from_urn is None or name is None or to_urn is None:
+                    continue
+                key = (from_urn, name, to_urn)
+                if key in seen_relations:
+                    continue
+                seen_relations.add(key)
+                relation_counts[name] = relation_counts.get(name, 0) + 1
+        return {
+            "roots": roots,
+            "node_counts_by_type": node_counts,
+            "relation_counts_by_type": relation_counts,
+            "neighborhood_sizes": neighborhood_sizes,
+            "errors": errors,
+        }
+
     def ref(self, kind: str, external_id: str, label: str = "") -> Dict[str, str]:
         normalized_kind = kind.strip()
         normalized_external_id = external_id.strip()
@@ -383,7 +445,6 @@ class IntegrationClient:
     def _build_urn(self, kind: str, external_id: str) -> str:
         return ":".join(["urn", "cerebro", self.tenant_id, "runtime", self.runtime_id, kind, external_id])
 
-
 def normalize_root_urn(root: Any, name: str) -> str:
     if isinstance(root, dict):
         value = root.get("urn")
@@ -395,3 +456,9 @@ def normalize_root_urn(root: Any, name: str) -> str:
     if not root_urn:
         raise ValueError(f"{name} urn is required")
     return root_urn
+
+def _optional_string(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None

--- a/sdk/python/examples/jira_posture_onboarding.py
+++ b/sdk/python/examples/jira_posture_onboarding.py
@@ -161,7 +161,7 @@ def onboard_workspace_posture(
         "submitted_claims": claims,
         "persisted_claims": persisted.get("claims", []),
         "graph_layering": graph_layering,
-        "graph_summary": summarize_graph_layering(graph_layering),
+        "graph_summary": graph_layering.get("summary", {}),
     }
 
 
@@ -254,81 +254,15 @@ def load_graph_layering(integration: IntegrationClient, posture: Dict[str, Any])
         project_keys.append(project_key)
     workspace_graph = integration.graph_layering([workspace_ref], limit=50)
     project_layering = integration.graph_layering(project_refs, limit=12)
+    combined_layering = dict(workspace_graph)
+    combined_layering.update(project_layering)
     project_graphs = {}
     for project_key, project_ref in zip(project_keys, project_refs):
         project_graphs[project_key] = project_layering.get(project_ref["urn"], {"root_urn": project_ref["urn"], "error": "missing graph response"})
     return {
         "workspace": workspace_graph.get(workspace_ref["urn"], {"root_urn": workspace_ref["urn"], "error": "missing graph response"}),
         "projects": project_graphs,
-    }
-
-
-def summarize_graph_layering(graph_layering: Dict[str, Any]) -> Dict[str, Any]:
-    roots = []
-    node_counts: Dict[str, int] = {}
-    relation_counts: Dict[str, int] = {}
-    neighborhood_sizes: Dict[str, Dict[str, int]] = {}
-    errors: Dict[str, str] = {}
-    seen_nodes = set()
-    seen_relations = set()
-    entries = [graph_layering.get("workspace")] + list(graph_layering.get("projects", {}).values())
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        error = optional_string(entry.get("error"))
-        root_urn = optional_string(entry.get("root_urn"))
-        if error and root_urn:
-            errors[root_urn] = error
-            continue
-        root = entry.get("root")
-        if not isinstance(root, dict):
-            continue
-        root_key = require_value(root.get("urn"), "graph root urn")
-        roots.append(
-            {
-                "urn": root_key,
-                "entity_type": optional_string(root.get("entity_type")) or "unknown",
-                "label": optional_string(root.get("label")) or root_key,
-            }
-        )
-        neighbors = entry.get("neighbors")
-        if not isinstance(neighbors, list):
-            neighbors = []
-        relations = entry.get("relations")
-        if not isinstance(relations, list):
-            relations = []
-        neighborhood_sizes[root_key] = {
-            "neighbors": len(neighbors),
-            "relations": len(relations),
-        }
-        for node in [root] + neighbors:
-            if not isinstance(node, dict):
-                continue
-            node_urn = optional_string(node.get("urn"))
-            entity_type = optional_string(node.get("entity_type")) or "unknown"
-            if node_urn is None or node_urn in seen_nodes:
-                continue
-            seen_nodes.add(node_urn)
-            node_counts[entity_type] = node_counts.get(entity_type, 0) + 1
-        for relation in relations:
-            if not isinstance(relation, dict):
-                continue
-            from_urn = optional_string(relation.get("from_urn"))
-            name = optional_string(relation.get("relation"))
-            to_urn = optional_string(relation.get("to_urn"))
-            if from_urn is None or name is None or to_urn is None:
-                continue
-            key = (from_urn, name, to_urn)
-            if key in seen_relations:
-                continue
-            seen_relations.add(key)
-            relation_counts[name] = relation_counts.get(name, 0) + 1
-    return {
-        "roots": roots,
-        "node_counts_by_type": node_counts,
-        "relation_counts_by_type": relation_counts,
-        "neighborhood_sizes": neighborhood_sizes,
-        "errors": errors,
+        "summary": integration.graph_summary(combined_layering),
     }
 
 

--- a/sdk/typescript/examples/jira_posture_onboarding.ts
+++ b/sdk/typescript/examples/jira_posture_onboarding.ts
@@ -204,7 +204,7 @@ export async function onboardWorkspacePosture(options: OnboardWorkspacePostureOp
     submitted_claims: claims,
     persisted_claims: Array.isArray(persisted["claims"]) ? persisted["claims"] : [],
     graph_layering: graphLayering,
-    graph_summary: summarizeGraphLayering(graphLayering),
+    graph_summary: graphLayering["summary"] ?? {},
   };
 }
 
@@ -311,6 +311,10 @@ async function loadGraphLayering(
     projectEntries.map(([, projectRef]) => projectRef),
     12,
   );
+  const combinedLayering = {
+    ...workspaceLayering,
+    ...projectLayering,
+  };
   return {
     workspace: workspaceLayering[workspaceRef.urn] ?? {
       root_urn: workspaceRef.urn,
@@ -325,75 +329,7 @@ async function loadGraphLayering(
         },
       ]),
     ),
-  };
-}
-
-export function summarizeGraphLayering(graphLayering: Record<string, unknown>): Record<string, unknown> {
-  const roots: Array<Record<string, string>> = [];
-  const nodeCounts = new Map<string, number>();
-  const relationCounts = new Map<string, number>();
-  const neighborhoodSizes: Record<string, { neighbors: number; relations: number }> = {};
-  const errors: Record<string, string> = {};
-  const seenNodes = new Set<string>();
-  const seenRelations = new Set<string>();
-  const workspace = asRecord(graphLayering["workspace"]);
-  const projects = asRecord(graphLayering["projects"]);
-  const entries = [workspace, ...Object.values(projects).map(asRecord)];
-
-  for (const entry of entries) {
-    const error = optionalRecordValue(entry, "error");
-    const rootUrn = optionalRecordValue(entry, "root_urn");
-    if (error && rootUrn) {
-      errors[rootUrn] = error;
-      continue;
-    }
-    const root = asRecord(entry["root"]);
-    const rootKey = optionalRecordValue(root, "urn");
-    if (!rootKey) {
-      continue;
-    }
-    roots.push({
-      urn: rootKey,
-      entity_type: optionalRecordValue(root, "entity_type") || "unknown",
-      label: optionalRecordValue(root, "label") || rootKey,
-    });
-    const neighbors = asRecordArray(entry["neighbors"]);
-    const relations = asRecordArray(entry["relations"]);
-    neighborhoodSizes[rootKey] = {
-      neighbors: neighbors.length,
-      relations: relations.length,
-    };
-    for (const node of [root, ...neighbors]) {
-      const nodeUrn = optionalRecordValue(node, "urn");
-      const entityType = optionalRecordValue(node, "entity_type") || "unknown";
-      if (!nodeUrn || seenNodes.has(nodeUrn)) {
-        continue;
-      }
-      seenNodes.add(nodeUrn);
-      nodeCounts.set(entityType, (nodeCounts.get(entityType) ?? 0) + 1);
-    }
-    for (const relation of relations) {
-      const fromUrn = optionalRecordValue(relation, "from_urn");
-      const name = optionalRecordValue(relation, "relation");
-      const toUrn = optionalRecordValue(relation, "to_urn");
-      if (!fromUrn || !name || !toUrn) {
-        continue;
-      }
-      const relationKey = `${fromUrn}\u0000${name}\u0000${toUrn}`;
-      if (seenRelations.has(relationKey)) {
-        continue;
-      }
-      seenRelations.add(relationKey);
-      relationCounts.set(name, (relationCounts.get(name) ?? 0) + 1);
-    }
-  }
-
-  return {
-    roots,
-    node_counts_by_type: Object.fromEntries(nodeCounts),
-    relation_counts_by_type: Object.fromEntries(relationCounts),
-    neighborhood_sizes: neighborhoodSizes,
-    errors,
+    summary: integration.graphSummary(combinedLayering),
   };
 }
 
@@ -403,23 +339,4 @@ function requireValue(value: string, name: string): string {
     throw new Error(`${name} is required`);
   }
   return normalized;
-}
-
-function asRecord(value: unknown): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return {};
-  }
-  return value as Record<string, unknown>;
-}
-
-function asRecordArray(value: unknown): Array<Record<string, unknown>> {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return value.map(asRecord);
-}
-
-function optionalRecordValue(record: Record<string, unknown>, key: string): string {
-  const value = record[key];
-  return typeof value === "string" ? value : "";
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -122,6 +122,14 @@ export interface GraphNeighborhoodError {
 
 export type GraphLayering = Record<string, GraphNeighborhood | GraphNeighborhoodError>;
 
+export interface GraphSummary {
+  roots: GraphEntity[];
+  node_counts_by_type: Record<string, number>;
+  relation_counts_by_type: Record<string, number>;
+  neighborhood_sizes: Record<string, { neighbors: number; relations: number }>;
+  errors: Record<string, string>;
+}
+
 export interface IntegrationOptions {
   runtimeId: string;
   tenantId: string;
@@ -548,6 +556,10 @@ export class IntegrationClient {
     return layering;
   }
 
+  graphSummary(layering: GraphLayering): GraphSummary {
+    return summarizeGraphLayering(layering);
+  }
+
   ref(kind: string, externalId: string, label = ""): EntityRef {
     const normalizedKind = kind.trim();
     const normalizedExternalId = externalId.trim();
@@ -621,4 +633,57 @@ export class IntegrationClient {
   private buildURN(kind: string, externalId: string): string {
     return ["urn", "cerebro", this.tenantId, "runtime", this.runtimeId, kind, externalId].join(":");
   }
+}
+
+export function summarizeGraphLayering(layering: GraphLayering): GraphSummary {
+  const roots: GraphEntity[] = [];
+  const nodeCounts = new Map<string, number>();
+  const relationCounts = new Map<string, number>();
+  const neighborhoodSizes: Record<string, { neighbors: number; relations: number }> = {};
+  const errors: Record<string, string> = {};
+  const seenNodes = new Set<string>();
+  const seenRelations = new Set<string>();
+
+  for (const [rootUrn, entry] of Object.entries(layering)) {
+    if ("error" in entry) {
+      errors[entry.root_urn || rootUrn] = entry.error;
+      continue;
+    }
+    const root = entry.root;
+    if (!root?.urn) {
+      continue;
+    }
+    roots.push(root);
+    neighborhoodSizes[root.urn] = {
+      neighbors: entry.neighbors?.length ?? 0,
+      relations: entry.relations?.length ?? 0,
+    };
+    for (const node of [root, ...(entry.neighbors ?? [])]) {
+      if (!node?.urn || seenNodes.has(node.urn)) {
+        continue;
+      }
+      seenNodes.add(node.urn);
+      const entityType = node.entity_type || "unknown";
+      nodeCounts.set(entityType, (nodeCounts.get(entityType) ?? 0) + 1);
+    }
+    for (const relation of entry.relations ?? []) {
+      if (!relation?.from_urn || !relation?.relation || !relation?.to_urn) {
+        continue;
+      }
+      const key = `${relation.from_urn}\u0000${relation.relation}\u0000${relation.to_urn}`;
+      if (seenRelations.has(key)) {
+        continue;
+      }
+      seenRelations.add(key);
+      relationCounts.set(relation.relation, (relationCounts.get(relation.relation) ?? 0) + 1);
+    }
+  }
+
+  return {
+    roots,
+    node_counts_by_type: Object.fromEntries(nodeCounts),
+    relation_counts_by_type: Object.fromEntries(relationCounts),
+    neighborhood_sizes: neighborhoodSizes,
+    errors,
+  };
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -653,7 +653,11 @@ export function summarizeGraphLayering(layering: GraphLayering): GraphSummary {
     if (!root?.urn) {
       continue;
     }
-    roots.push(root);
+    roots.push({
+      urn: root.urn,
+      entity_type: root.entity_type || "unknown",
+      label: root.label || root.urn,
+    });
     neighborhoodSizes[root.urn] = {
       neighbors: entry.neighbors?.length ?? 0,
       relations: entry.relations?.length ?? 0,


### PR DESCRIPTION
## Summary
- move graph-summary logic into reusable Python and TypeScript SDK helpers instead of keeping it duplicated inside the Jira posture examples
- expose SDK-level graph summary APIs on top of graph layering so onboarding flows can summarize roots, node counts, relation counts, neighborhood sizes, and errors uniformly
- simplify the Jira posture examples to consume those shared helpers

## Testing
- make verify
- python3 -m py_compile sdk/python/cerebro_sdk/client.py sdk/python/examples/jira_posture_onboarding.py
- PYTHONPATH=sdk/python python3 smoke test for graph_summary
- cd sdk/typescript && npx -y -p typescript tsc -p tsconfig.json
- cd sdk/typescript && npx -y -p tsx tsx smoke test for summarizeGraphLayering and graphSummary
