### PR TITLE
feat(sdk): add jira posture helper modules

### DIFF
--- a/sdk/python/cerebro_sdk/__init__.py
+++ b/sdk/python/cerebro_sdk/__init__.py
@@ -1,7 +1,31 @@
 from .client import APIError, Client, IntegrationClient
+from .jira import (
+    JiraAdminPosture,
+    JiraMarketplaceAppPosture,
+    JiraPostureFinding,
+    JiraProjectPosture,
+    JiraWorkspaceGraphLayering,
+    JiraWorkspacePosture,
+    OnboardJiraWorkspacePostureResult,
+    build_jira_posture_findings,
+    build_jira_workspace_claims,
+    load_jira_workspace_graph_layering,
+    onboard_jira_workspace_posture,
+)
 
 __all__ = [
     "APIError",
     "Client",
     "IntegrationClient",
+    "JiraAdminPosture",
+    "JiraMarketplaceAppPosture",
+    "JiraPostureFinding",
+    "JiraProjectPosture",
+    "JiraWorkspaceGraphLayering",
+    "JiraWorkspacePosture",
+    "OnboardJiraWorkspacePostureResult",
+    "build_jira_posture_findings",
+    "build_jira_workspace_claims",
+    "load_jira_workspace_graph_layering",
+    "onboard_jira_workspace_posture",
 ]

--- a/sdk/python/cerebro_sdk/jira.py
+++ b/sdk/python/cerebro_sdk/jira.py
@@ -411,6 +411,16 @@ def bool_value(value: Any) -> str:
 def default_bool(value: Any, default: bool) -> bool:
     if value is None:
         return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "":
+            return default
+        if normalized in {"1", "true", "t", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "f", "no", "n", "off"}:
+            return False
     return bool(value)
 
 

--- a/sdk/python/cerebro_sdk/jira.py
+++ b/sdk/python/cerebro_sdk/jira.py
@@ -76,9 +76,9 @@ def build_jira_workspace_claims(
     workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
     source_event_id = optional_string(posture.get("event_id"))
     shared_options: Dict[str, Any] = {"source_event_id": source_event_id} if source_event_id else {}
-    admins = list(posture.get("admins", []))
-    projects = list(posture.get("projects", []))
-    apps = list(posture.get("apps", []))
+    admins = list(posture.get("admins") or [])
+    projects = list(posture.get("projects") or [])
+    apps = list(posture.get("apps") or [])
 
     claims = [
         integration.exists(workspace_ref, **shared_options),
@@ -194,7 +194,7 @@ def build_jira_workspace_claims(
                 **shared_options,
             )
         )
-        scopes = [optional_string(scope) for scope in app.get("scopes", [])]
+        scopes = [optional_string(scope) for scope in (app.get("scopes") or [])]
         normalized_scopes = [scope for scope in scopes if scope]
         if normalized_scopes:
             claims.append(integration.attr(app_ref, "scopes", ",".join(normalized_scopes), **shared_options))
@@ -211,7 +211,7 @@ def load_jira_workspace_graph_layering(
     workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
     project_refs = []
     project_keys = []
-    for project in posture.get("projects", []):
+    for project in posture.get("projects") or []:
         project_key = require_value(project.get("key"), "projects[].key")
         project_name = optional_string(project.get("name")) or project_key
         project_refs.append(integration.ref("project", project_key, project_name))
@@ -293,7 +293,7 @@ def build_jira_posture_findings(
             )
         )
 
-    for project in posture.get("projects", []):
+    for project in posture.get("projects") or []:
         project_key = require_value(project.get("key"), "projects[].key")
         project_name = optional_string(project.get("name")) or project_key
         project_ref = integration.ref("project", project_key, project_name)
@@ -329,7 +329,7 @@ def build_jira_posture_findings(
                 )
             )
 
-    for app in posture.get("apps", []):
+    for app in posture.get("apps") or []:
         if app.get("approved_by_security", True):
             continue
         app_key = require_value(app.get("key"), "apps[].key")

--- a/sdk/python/cerebro_sdk/jira.py
+++ b/sdk/python/cerebro_sdk/jira.py
@@ -1,0 +1,437 @@
+from typing import Any, Dict, Optional, TypedDict
+
+from .client import Client, IntegrationClient
+
+
+class JiraAdminPosture(TypedDict, total=False):
+    email: str
+    display_name: str
+    role: str
+
+
+class JiraProjectPosture(TypedDict, total=False):
+    key: str
+    name: str
+    classification: str
+    issue_level_security_enabled: bool
+    anonymous_browse_enabled: bool
+    service_desk_public_portal_enabled: bool
+
+
+class JiraMarketplaceAppPosture(TypedDict, total=False):
+    key: str
+    name: str
+    approved_by_security: bool
+    scopes: list[str]
+
+
+class JiraWorkspacePosture(TypedDict, total=False):
+    workspace_key: str
+    workspace_name: str
+    event_id: str
+    sso_enforced: bool
+    mfa_required_for_admins: bool
+    atlassian_guard_enabled: bool
+    audit_log_export_enabled: bool
+    api_token_expiration_enforced: bool
+    public_signup_enabled: bool
+    anonymous_access_enabled: bool
+    approved_marketplace_apps_only: bool
+    admins: list[JiraAdminPosture]
+    projects: list[JiraProjectPosture]
+    apps: list[JiraMarketplaceAppPosture]
+
+
+class JiraWorkspaceGraphLayering(TypedDict):
+    workspace: Dict[str, Any]
+    projects: Dict[str, Dict[str, Any]]
+    summary: Dict[str, Any]
+
+
+class JiraPostureFinding(TypedDict, total=False):
+    id: str
+    severity: str
+    title: str
+    summary: str
+    resource_urns: list[str]
+    attributes: Dict[str, str]
+
+
+class OnboardJiraWorkspacePostureResult(TypedDict):
+    workspace_urn: str
+    write_result: Dict[str, Any]
+    submitted_claims: list[Dict[str, Any]]
+    persisted_claims: list[Dict[str, Any]]
+    graph_layering: JiraWorkspaceGraphLayering
+    graph_summary: Dict[str, Any]
+    posture_findings: list[JiraPostureFinding]
+
+
+def build_jira_workspace_claims(
+    integration: IntegrationClient,
+    posture: JiraWorkspacePosture,
+) -> list[Dict[str, Any]]:
+    workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
+    workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
+    workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
+    source_event_id = optional_string(posture.get("event_id"))
+    shared_options: Dict[str, Any] = {"source_event_id": source_event_id} if source_event_id else {}
+    admins = list(posture.get("admins", []))
+    projects = list(posture.get("projects", []))
+    apps = list(posture.get("apps", []))
+
+    claims = [
+        integration.exists(workspace_ref, **shared_options),
+        integration.attr(workspace_ref, "platform", "jira", **shared_options),
+        integration.attr(workspace_ref, "vendor", "atlassian", **shared_options),
+        integration.attr(workspace_ref, "sso_enforced", bool_value(posture.get("sso_enforced", True)), **shared_options),
+        integration.attr(
+            workspace_ref,
+            "mfa_required_for_admins",
+            bool_value(posture.get("mfa_required_for_admins", True)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "atlassian_guard_enabled",
+            bool_value(posture.get("atlassian_guard_enabled", True)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "audit_log_export_enabled",
+            bool_value(posture.get("audit_log_export_enabled", True)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "api_token_expiration_enforced",
+            bool_value(posture.get("api_token_expiration_enforced", True)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "public_signup_enabled",
+            bool_value(posture.get("public_signup_enabled", False)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "anonymous_access_enabled",
+            bool_value(posture.get("anonymous_access_enabled", False)),
+            **shared_options,
+        ),
+        integration.attr(
+            workspace_ref,
+            "approved_marketplace_apps_only",
+            bool_value(posture.get("approved_marketplace_apps_only", True)),
+            **shared_options,
+        ),
+        integration.attr(workspace_ref, "admin_count", str(len(admins)), **shared_options),
+        integration.attr(workspace_ref, "project_count", str(len(projects)), **shared_options),
+        integration.attr(workspace_ref, "installed_app_count", str(len(apps)), **shared_options),
+    ]
+
+    for admin in admins:
+        email = require_value(admin.get("email"), "admins[].email")
+        label = optional_string(admin.get("display_name")) or email
+        role = optional_string(admin.get("role")) or "site_admin"
+        admin_ref = integration.ref("user", email, label)
+        claims.append(integration.exists(admin_ref, **shared_options))
+        claims.append(integration.rel(admin_ref, "administers", workspace_ref, **shared_options))
+        claims.append(integration.attr(admin_ref, "role", role, **shared_options))
+
+    for project in projects:
+        key = require_value(project.get("key"), "projects[].key")
+        name = optional_string(project.get("name")) or key
+        project_ref = integration.ref("project", key, name)
+        claims.append(integration.exists(project_ref, **shared_options))
+        claims.append(integration.rel(project_ref, "belongs_to", workspace_ref, **shared_options))
+        claims.append(
+            integration.attr(
+                project_ref,
+                "classification",
+                optional_string(project.get("classification")) or "internal",
+                **shared_options,
+            )
+        )
+        claims.append(
+            integration.attr(
+                project_ref,
+                "issue_level_security_enabled",
+                bool_value(project.get("issue_level_security_enabled", True)),
+                **shared_options,
+            )
+        )
+        claims.append(
+            integration.attr(
+                project_ref,
+                "anonymous_browse_enabled",
+                bool_value(project.get("anonymous_browse_enabled", False)),
+                **shared_options,
+            )
+        )
+        claims.append(
+            integration.attr(
+                project_ref,
+                "service_desk_public_portal_enabled",
+                bool_value(project.get("service_desk_public_portal_enabled", False)),
+                **shared_options,
+            )
+        )
+
+    for app in apps:
+        key = require_value(app.get("key"), "apps[].key")
+        name = optional_string(app.get("name")) or key
+        app_ref = integration.ref("app", key, name)
+        claims.append(integration.exists(app_ref, **shared_options))
+        claims.append(integration.rel(app_ref, "installed_on", workspace_ref, **shared_options))
+        claims.append(
+            integration.attr(
+                app_ref,
+                "approved_by_security",
+                bool_value(app.get("approved_by_security", True)),
+                **shared_options,
+            )
+        )
+        scopes = [optional_string(scope) for scope in app.get("scopes", [])]
+        normalized_scopes = [scope for scope in scopes if scope]
+        if normalized_scopes:
+            claims.append(integration.attr(app_ref, "scopes", ",".join(normalized_scopes), **shared_options))
+
+    return claims
+
+
+def load_jira_workspace_graph_layering(
+    integration: IntegrationClient,
+    posture: JiraWorkspacePosture,
+) -> JiraWorkspaceGraphLayering:
+    workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
+    workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
+    workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
+    project_refs = []
+    project_keys = []
+    for project in posture.get("projects", []):
+        project_key = require_value(project.get("key"), "projects[].key")
+        project_name = optional_string(project.get("name")) or project_key
+        project_refs.append(integration.ref("project", project_key, project_name))
+        project_keys.append(project_key)
+    workspace_graph = integration.graph_layering([workspace_ref], limit=50)
+    project_layering = integration.graph_layering(project_refs, limit=12)
+    combined_layering = dict(workspace_graph)
+    combined_layering.update(project_layering)
+    project_graphs: Dict[str, Dict[str, Any]] = {}
+    for project_key, project_ref in zip(project_keys, project_refs):
+        project_graphs[project_key] = project_layering.get(
+            project_ref["urn"],
+            {"root_urn": project_ref["urn"], "error": "missing graph response"},
+        )
+    return {
+        "workspace": workspace_graph.get(
+            workspace_ref["urn"],
+            {"root_urn": workspace_ref["urn"], "error": "missing graph response"},
+        ),
+        "projects": project_graphs,
+        "summary": integration.graph_summary(combined_layering),
+    }
+
+
+def build_jira_posture_findings(
+    integration: IntegrationClient,
+    posture: JiraWorkspacePosture,
+    graph_summary: Dict[str, Any],
+) -> list[JiraPostureFinding]:
+    findings: list[JiraPostureFinding] = []
+    workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
+    workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
+    workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
+
+    if posture.get("public_signup_enabled", False):
+        findings.append(
+            finding(
+                "jira_workspace_public_signup_enabled",
+                "HIGH",
+                "Jira workspace allows self-service signup",
+                f"{workspace_name} allows self-service signup, which increases exposure to unmanaged identities.",
+                [workspace_ref["urn"]],
+            )
+        )
+    if posture.get("anonymous_access_enabled", False):
+        findings.append(
+            finding(
+                "jira_workspace_anonymous_access_enabled",
+                "HIGH",
+                "Jira workspace permits anonymous access",
+                f"{workspace_name} exposes content to unauthenticated users.",
+                [workspace_ref["urn"]],
+            )
+        )
+    if not posture.get("approved_marketplace_apps_only", True):
+        findings.append(
+            finding(
+                "jira_workspace_marketplace_policy_open",
+                "MEDIUM",
+                "Jira workspace does not restrict marketplace apps",
+                f"{workspace_name} allows marketplace apps outside the approved set.",
+                [workspace_ref["urn"]],
+            )
+        )
+
+    relation_counts = graph_summary.get("relation_counts_by_type", {})
+    if not isinstance(relation_counts, dict):
+        relation_counts = {}
+    admin_count = int(relation_counts.get("administers", 0))
+    if admin_count > 5:
+        findings.append(
+            finding(
+                "jira_workspace_admin_sprawl",
+                "MEDIUM",
+                "Jira workspace has elevated admin sprawl",
+                f"{workspace_name} has {admin_count} admin relationships in the graph neighborhood.",
+                [workspace_ref["urn"]],
+                {"admin_count": str(admin_count)},
+            )
+        )
+
+    for project in posture.get("projects", []):
+        project_key = require_value(project.get("key"), "projects[].key")
+        project_name = optional_string(project.get("name")) or project_key
+        project_ref = integration.ref("project", project_key, project_name)
+        classification = optional_string(project.get("classification")) or "internal"
+        if classification == "restricted" and not project.get("issue_level_security_enabled", True):
+            findings.append(
+                finding(
+                    f"jira_project_{project_key.lower()}_restricted_issue_security_disabled",
+                    "HIGH",
+                    "Restricted Jira project lacks issue-level security",
+                    f"{project_name} is marked restricted but issue-level security is disabled.",
+                    [project_ref["urn"], workspace_ref["urn"]],
+                )
+            )
+        if project.get("anonymous_browse_enabled", False):
+            findings.append(
+                finding(
+                    f"jira_project_{project_key.lower()}_anonymous_browse_enabled",
+                    "HIGH",
+                    "Jira project allows anonymous browsing",
+                    f"{project_name} allows anonymous issue browsing.",
+                    [project_ref["urn"], workspace_ref["urn"]],
+                )
+            )
+        if project.get("service_desk_public_portal_enabled", False):
+            findings.append(
+                finding(
+                    f"jira_project_{project_key.lower()}_public_portal_enabled",
+                    "HIGH" if classification == "restricted" else "MEDIUM",
+                    "Jira project exposes a public service desk portal",
+                    f"{project_name} exposes a public portal for {classification} data.",
+                    [project_ref["urn"], workspace_ref["urn"]],
+                )
+            )
+
+    for app in posture.get("apps", []):
+        if app.get("approved_by_security", True):
+            continue
+        app_key = require_value(app.get("key"), "apps[].key")
+        app_name = optional_string(app.get("name")) or app_key
+        app_ref = integration.ref("app", app_key, app_name)
+        findings.append(
+            finding(
+                f"jira_app_{app_key.lower()}_unapproved",
+                "MEDIUM",
+                "Unapproved Jira marketplace app is installed",
+                f"{app_name} is installed on {workspace_name} without security approval.",
+                [app_ref["urn"], workspace_ref["urn"]],
+            )
+        )
+
+    return findings
+
+
+def onboard_jira_workspace_posture(
+    base_url: str,
+    tenant_id: str,
+    runtime_id: str,
+    posture: JiraWorkspacePosture,
+    api_key: Optional[str] = None,
+) -> OnboardJiraWorkspacePostureResult:
+    client = Client(base_url=base_url, api_key=api_key or None)
+    integration = client.integration(runtime_id=runtime_id, tenant_id=tenant_id, integration="jira")
+    runtime_config: Dict[str, str] = {}
+    workspace_key = optional_string(posture.get("workspace_key"))
+    if workspace_key:
+        runtime_config["workspace"] = workspace_key
+    integration.ensure_runtime(runtime_config)
+    claims = build_jira_workspace_claims(integration, posture)
+    write_result = integration.write_claims(claims)
+    persisted = integration.list_claims({"limit": 100})
+    persisted_claims = persisted.get("claims", [])
+    if not isinstance(persisted_claims, list):
+        persisted_claims = []
+    graph_layering = load_jira_workspace_graph_layering(integration, posture)
+    return {
+        "workspace_urn": claims[0]["subject_urn"],
+        "write_result": write_result,
+        "submitted_claims": claims,
+        "persisted_claims": persisted_claims,
+        "graph_layering": graph_layering,
+        "graph_summary": graph_layering.get("summary", {}),
+        "posture_findings": build_jira_posture_findings(
+            integration,
+            posture,
+            graph_layering.get("summary", {}),
+        ),
+    }
+
+
+def finding(
+    finding_id: str,
+    severity: str,
+    title: str,
+    summary: str,
+    resource_urns: list[str],
+    attributes: Optional[Dict[str, str]] = None,
+) -> JiraPostureFinding:
+    payload: JiraPostureFinding = {
+        "id": finding_id,
+        "severity": severity,
+        "title": title,
+        "summary": summary,
+        "resource_urns": resource_urns,
+    }
+    if attributes:
+        payload["attributes"] = attributes
+    return payload
+
+
+def bool_value(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def optional_string(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def require_value(value: Any, name: str) -> str:
+    normalized = optional_string(value)
+    if normalized is None:
+        raise ValueError(f"{name} is required")
+    return normalized
+
+
+__all__ = [
+    "JiraAdminPosture",
+    "JiraProjectPosture",
+    "JiraMarketplaceAppPosture",
+    "JiraWorkspacePosture",
+    "JiraWorkspaceGraphLayering",
+    "JiraPostureFinding",
+    "OnboardJiraWorkspacePostureResult",
+    "build_jira_workspace_claims",
+    "load_jira_workspace_graph_layering",
+    "build_jira_posture_findings",
+    "onboard_jira_workspace_posture",
+]

--- a/sdk/python/cerebro_sdk/jira.py
+++ b/sdk/python/cerebro_sdk/jira.py
@@ -76,9 +76,9 @@ def build_jira_workspace_claims(
     workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
     source_event_id = optional_string(posture.get("event_id"))
     shared_options: Dict[str, Any] = {"source_event_id": source_event_id} if source_event_id else {}
-    admins = list(posture.get("admins") or [])
-    projects = list(posture.get("projects") or [])
-    apps = list(posture.get("apps") or [])
+    admins = dict_items(posture.get("admins"))
+    projects = dict_items(posture.get("projects"))
+    apps = dict_items(posture.get("apps"))
 
     claims = [
         integration.exists(workspace_ref, **shared_options),
@@ -211,7 +211,7 @@ def load_jira_workspace_graph_layering(
     workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
     project_refs = []
     project_keys = []
-    for project in posture.get("projects") or []:
+    for project in dict_items(posture.get("projects")):
         project_key = require_value(project.get("key"), "projects[].key")
         project_name = optional_string(project.get("name")) or project_key
         project_refs.append(integration.ref("project", project_key, project_name))
@@ -293,7 +293,7 @@ def build_jira_posture_findings(
             )
         )
 
-    for project in posture.get("projects") or []:
+    for project in dict_items(posture.get("projects")):
         project_key = require_value(project.get("key"), "projects[].key")
         project_name = optional_string(project.get("name")) or project_key
         project_ref = integration.ref("project", project_key, project_name)
@@ -329,7 +329,7 @@ def build_jira_posture_findings(
                 )
             )
 
-    for app in posture.get("apps") or []:
+    for app in dict_items(posture.get("apps")):
         if default_bool(app.get("approved_by_security"), True):
             continue
         app_key = require_value(app.get("key"), "apps[].key")
@@ -422,6 +422,12 @@ def default_bool(value: Any, default: bool) -> bool:
         if normalized in {"0", "false", "f", "no", "n", "off"}:
             return False
     return bool(value)
+
+
+def dict_items(value: Any) -> list[Dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
 
 
 def optional_string(value: Any) -> Optional[str]:

--- a/sdk/python/cerebro_sdk/jira.py
+++ b/sdk/python/cerebro_sdk/jira.py
@@ -84,47 +84,47 @@ def build_jira_workspace_claims(
         integration.exists(workspace_ref, **shared_options),
         integration.attr(workspace_ref, "platform", "jira", **shared_options),
         integration.attr(workspace_ref, "vendor", "atlassian", **shared_options),
-        integration.attr(workspace_ref, "sso_enforced", bool_value(posture.get("sso_enforced", True)), **shared_options),
+        integration.attr(workspace_ref, "sso_enforced", bool_value(default_bool(posture.get("sso_enforced"), True)), **shared_options),
         integration.attr(
             workspace_ref,
             "mfa_required_for_admins",
-            bool_value(posture.get("mfa_required_for_admins", True)),
+            bool_value(default_bool(posture.get("mfa_required_for_admins"), True)),
             **shared_options,
         ),
         integration.attr(
             workspace_ref,
             "atlassian_guard_enabled",
-            bool_value(posture.get("atlassian_guard_enabled", True)),
+            bool_value(default_bool(posture.get("atlassian_guard_enabled"), True)),
             **shared_options,
         ),
         integration.attr(
             workspace_ref,
             "audit_log_export_enabled",
-            bool_value(posture.get("audit_log_export_enabled", True)),
+            bool_value(default_bool(posture.get("audit_log_export_enabled"), True)),
             **shared_options,
         ),
         integration.attr(
             workspace_ref,
             "api_token_expiration_enforced",
-            bool_value(posture.get("api_token_expiration_enforced", True)),
+            bool_value(default_bool(posture.get("api_token_expiration_enforced"), True)),
             **shared_options,
         ),
         integration.attr(
             workspace_ref,
             "public_signup_enabled",
-            bool_value(posture.get("public_signup_enabled", False)),
+            bool_value(default_bool(posture.get("public_signup_enabled"), False)),
             **shared_options,
         ),
         integration.attr(
             workspace_ref,
             "anonymous_access_enabled",
-            bool_value(posture.get("anonymous_access_enabled", False)),
+            bool_value(default_bool(posture.get("anonymous_access_enabled"), False)),
             **shared_options,
         ),
         integration.attr(
             workspace_ref,
             "approved_marketplace_apps_only",
-            bool_value(posture.get("approved_marketplace_apps_only", True)),
+            bool_value(default_bool(posture.get("approved_marketplace_apps_only"), True)),
             **shared_options,
         ),
         integration.attr(workspace_ref, "admin_count", str(len(admins)), **shared_options),
@@ -159,7 +159,7 @@ def build_jira_workspace_claims(
             integration.attr(
                 project_ref,
                 "issue_level_security_enabled",
-                bool_value(project.get("issue_level_security_enabled", True)),
+                bool_value(default_bool(project.get("issue_level_security_enabled"), True)),
                 **shared_options,
             )
         )
@@ -167,7 +167,7 @@ def build_jira_workspace_claims(
             integration.attr(
                 project_ref,
                 "anonymous_browse_enabled",
-                bool_value(project.get("anonymous_browse_enabled", False)),
+                bool_value(default_bool(project.get("anonymous_browse_enabled"), False)),
                 **shared_options,
             )
         )
@@ -175,7 +175,7 @@ def build_jira_workspace_claims(
             integration.attr(
                 project_ref,
                 "service_desk_public_portal_enabled",
-                bool_value(project.get("service_desk_public_portal_enabled", False)),
+                bool_value(default_bool(project.get("service_desk_public_portal_enabled"), False)),
                 **shared_options,
             )
         )
@@ -190,7 +190,7 @@ def build_jira_workspace_claims(
             integration.attr(
                 app_ref,
                 "approved_by_security",
-                bool_value(app.get("approved_by_security", True)),
+                bool_value(default_bool(app.get("approved_by_security"), True)),
                 **shared_options,
             )
         )
@@ -246,7 +246,7 @@ def build_jira_posture_findings(
     workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
     workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
 
-    if posture.get("public_signup_enabled", False):
+    if default_bool(posture.get("public_signup_enabled"), False):
         findings.append(
             finding(
                 "jira_workspace_public_signup_enabled",
@@ -256,7 +256,7 @@ def build_jira_posture_findings(
                 [workspace_ref["urn"]],
             )
         )
-    if posture.get("anonymous_access_enabled", False):
+    if default_bool(posture.get("anonymous_access_enabled"), False):
         findings.append(
             finding(
                 "jira_workspace_anonymous_access_enabled",
@@ -266,7 +266,7 @@ def build_jira_posture_findings(
                 [workspace_ref["urn"]],
             )
         )
-    if not posture.get("approved_marketplace_apps_only", True):
+    if not default_bool(posture.get("approved_marketplace_apps_only"), True):
         findings.append(
             finding(
                 "jira_workspace_marketplace_policy_open",
@@ -298,7 +298,7 @@ def build_jira_posture_findings(
         project_name = optional_string(project.get("name")) or project_key
         project_ref = integration.ref("project", project_key, project_name)
         classification = optional_string(project.get("classification")) or "internal"
-        if classification == "restricted" and not project.get("issue_level_security_enabled", True):
+        if classification == "restricted" and not default_bool(project.get("issue_level_security_enabled"), True):
             findings.append(
                 finding(
                     f"jira_project_{project_key.lower()}_restricted_issue_security_disabled",
@@ -308,7 +308,7 @@ def build_jira_posture_findings(
                     [project_ref["urn"], workspace_ref["urn"]],
                 )
             )
-        if project.get("anonymous_browse_enabled", False):
+        if default_bool(project.get("anonymous_browse_enabled"), False):
             findings.append(
                 finding(
                     f"jira_project_{project_key.lower()}_anonymous_browse_enabled",
@@ -318,7 +318,7 @@ def build_jira_posture_findings(
                     [project_ref["urn"], workspace_ref["urn"]],
                 )
             )
-        if project.get("service_desk_public_portal_enabled", False):
+        if default_bool(project.get("service_desk_public_portal_enabled"), False):
             findings.append(
                 finding(
                     f"jira_project_{project_key.lower()}_public_portal_enabled",
@@ -330,7 +330,7 @@ def build_jira_posture_findings(
             )
 
     for app in posture.get("apps") or []:
-        if app.get("approved_by_security", True):
+        if default_bool(app.get("approved_by_security"), True):
             continue
         app_key = require_value(app.get("key"), "apps[].key")
         app_name = optional_string(app.get("name")) or app_key
@@ -406,6 +406,12 @@ def finding(
 
 def bool_value(value: Any) -> str:
     return "true" if bool(value) else "false"
+
+
+def default_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    return bool(value)
 
 
 def optional_string(value: Any) -> Optional[str]:

--- a/sdk/python/examples/jira_posture_onboarding.py
+++ b/sdk/python/examples/jira_posture_onboarding.py
@@ -1,238 +1,77 @@
 import json
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
-from cerebro_sdk import Client, IntegrationClient
-
-
-def build_workspace_claims(integration: IntegrationClient, posture: Dict[str, Any]) -> list[Dict[str, Any]]:
-    workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
-    workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
-    workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
-    source_event_id = optional_string(posture.get("event_id"))
-    shared_options = {"source_event_id": source_event_id} if source_event_id else {}
-    admins = list(posture.get("admins", []))
-    projects = list(posture.get("projects", []))
-    apps = list(posture.get("apps", []))
-
-    claims = [
-        integration.exists(workspace_ref, **shared_options),
-        integration.attr(workspace_ref, "platform", "jira", **shared_options),
-        integration.attr(workspace_ref, "vendor", "atlassian", **shared_options),
-        integration.attr(workspace_ref, "sso_enforced", bool_value(posture.get("sso_enforced", True)), **shared_options),
-        integration.attr(
-            workspace_ref,
-            "mfa_required_for_admins",
-            bool_value(posture.get("mfa_required_for_admins", True)),
-            **shared_options,
-        ),
-        integration.attr(
-            workspace_ref,
-            "atlassian_guard_enabled",
-            bool_value(posture.get("atlassian_guard_enabled", True)),
-            **shared_options,
-        ),
-        integration.attr(
-            workspace_ref,
-            "audit_log_export_enabled",
-            bool_value(posture.get("audit_log_export_enabled", True)),
-            **shared_options,
-        ),
-        integration.attr(
-            workspace_ref,
-            "api_token_expiration_enforced",
-            bool_value(posture.get("api_token_expiration_enforced", True)),
-            **shared_options,
-        ),
-        integration.attr(
-            workspace_ref,
-            "public_signup_enabled",
-            bool_value(posture.get("public_signup_enabled", False)),
-            **shared_options,
-        ),
-        integration.attr(
-            workspace_ref,
-            "anonymous_access_enabled",
-            bool_value(posture.get("anonymous_access_enabled", False)),
-            **shared_options,
-        ),
-        integration.attr(
-            workspace_ref,
-            "approved_marketplace_apps_only",
-            bool_value(posture.get("approved_marketplace_apps_only", True)),
-            **shared_options,
-        ),
-        integration.attr(workspace_ref, "admin_count", str(len(admins)), **shared_options),
-        integration.attr(workspace_ref, "project_count", str(len(projects)), **shared_options),
-        integration.attr(workspace_ref, "installed_app_count", str(len(apps)), **shared_options),
-    ]
-
-    for admin in admins:
-        email = require_value(admin.get("email"), "admins[].email")
-        label = optional_string(admin.get("display_name")) or email
-        role = optional_string(admin.get("role")) or "site_admin"
-        admin_ref = integration.ref("user", email, label)
-        claims.append(integration.exists(admin_ref, **shared_options))
-        claims.append(integration.rel(admin_ref, "administers", workspace_ref, **shared_options))
-        claims.append(integration.attr(admin_ref, "role", role, **shared_options))
-
-    for project in projects:
-        key = require_value(project.get("key"), "projects[].key")
-        name = optional_string(project.get("name")) or key
-        project_ref = integration.ref("project", key, name)
-        claims.append(integration.exists(project_ref, **shared_options))
-        claims.append(integration.rel(project_ref, "belongs_to", workspace_ref, **shared_options))
-        claims.append(
-            integration.attr(
-                project_ref,
-                "classification",
-                optional_string(project.get("classification")) or "internal",
-                **shared_options,
-            )
-        )
-        claims.append(
-            integration.attr(
-                project_ref,
-                "issue_level_security_enabled",
-                bool_value(project.get("issue_level_security_enabled", True)),
-                **shared_options,
-            )
-        )
-        claims.append(
-            integration.attr(
-                project_ref,
-                "anonymous_browse_enabled",
-                bool_value(project.get("anonymous_browse_enabled", False)),
-                **shared_options,
-            )
-        )
-        claims.append(
-            integration.attr(
-                project_ref,
-                "service_desk_public_portal_enabled",
-                bool_value(project.get("service_desk_public_portal_enabled", False)),
-                **shared_options,
-            )
-        )
-
-    for app in apps:
-        key = require_value(app.get("key"), "apps[].key")
-        name = optional_string(app.get("name")) or key
-        app_ref = integration.ref("app", key, name)
-        claims.append(integration.exists(app_ref, **shared_options))
-        claims.append(integration.rel(app_ref, "installed_on", workspace_ref, **shared_options))
-        claims.append(
-            integration.attr(
-                app_ref,
-                "approved_by_security",
-                bool_value(app.get("approved_by_security", True)),
-                **shared_options,
-            )
-        )
-        scopes = [optional_string(scope) for scope in app.get("scopes", [])]
-        normalized_scopes = [scope for scope in scopes if scope]
-        if normalized_scopes:
-            claims.append(integration.attr(app_ref, "scopes", ",".join(normalized_scopes), **shared_options))
-
-    return claims
-
-
-def onboard_workspace_posture(
-    base_url: str,
-    api_key: str,
-    tenant_id: str,
-    runtime_id: str,
-    posture: Dict[str, Any],
-) -> Dict[str, Any]:
-    client = Client(base_url=base_url, api_key=api_key or None)
-    integration = client.integration(runtime_id=runtime_id, tenant_id=tenant_id, integration="jira")
-    runtime_config = {}
-    workspace_key = optional_string(posture.get("workspace_key"))
-    if workspace_key:
-        runtime_config["workspace"] = workspace_key
-    integration.ensure_runtime(runtime_config)
-    claims = build_workspace_claims(integration, posture)
-    write_result = integration.write_claims(claims)
-    persisted = integration.list_claims({"limit": 100})
-    graph_layering = load_graph_layering(integration, posture)
-    return {
-        "workspace_urn": claims[0]["subject_urn"],
-        "write_result": write_result,
-        "submitted_claims": claims,
-        "persisted_claims": persisted.get("claims", []),
-        "graph_layering": graph_layering,
-        "graph_summary": graph_layering.get("summary", {}),
-        "posture_findings": build_posture_findings(
-            integration,
-            posture,
-            graph_layering.get("summary", {}),
-        ),
-    }
+from cerebro_sdk import JiraWorkspacePosture, onboard_jira_workspace_posture
 
 
 def main() -> None:
     base_url = require_value(os.environ.get("CEREBRO_BASE_URL"), "CEREBRO_BASE_URL")
-    result = onboard_workspace_posture(
+    result = onboard_jira_workspace_posture(
         base_url=base_url,
-        api_key=optional_string(os.environ.get("CEREBRO_API_KEY")) or "",
+        api_key=optional_string(os.environ.get("CEREBRO_API_KEY")),
         tenant_id=optional_string(os.environ.get("CEREBRO_TENANT_ID")) or "writer",
         runtime_id=optional_string(os.environ.get("CEREBRO_RUNTIME_ID")) or "writer-jira-posture",
-        posture={
-            "workspace_key": optional_string(os.environ.get("JIRA_WORKSPACE")) or "writer",
-            "workspace_name": optional_string(os.environ.get("JIRA_WORKSPACE_NAME")) or "Writer Jira",
-            "event_id": optional_string(os.environ.get("JIRA_EVENT_ID")) or "jira-posture-snapshot-1",
-            "sso_enforced": env_bool("JIRA_SSO_ENFORCED", True),
-            "mfa_required_for_admins": env_bool("JIRA_MFA_REQUIRED_FOR_ADMINS", True),
-            "atlassian_guard_enabled": env_bool("JIRA_ATLASSIAN_GUARD_ENABLED", True),
-            "audit_log_export_enabled": env_bool("JIRA_AUDIT_LOG_EXPORT_ENABLED", True),
-            "api_token_expiration_enforced": env_bool("JIRA_API_TOKEN_EXPIRATION_ENFORCED", True),
-            "public_signup_enabled": env_bool("JIRA_PUBLIC_SIGNUP_ENABLED", False),
-            "anonymous_access_enabled": env_bool("JIRA_ANONYMOUS_ACCESS_ENABLED", False),
-            "approved_marketplace_apps_only": env_bool("JIRA_APPROVED_MARKETPLACE_APPS_ONLY", True),
-            "admins": [
-                {
-                    "email": optional_string(os.environ.get("JIRA_ADMIN_1_EMAIL")) or "alice@writer.com",
-                    "display_name": optional_string(os.environ.get("JIRA_ADMIN_1_NAME")) or "Alice",
-                    "role": optional_string(os.environ.get("JIRA_ADMIN_1_ROLE")) or "site_admin",
-                },
-                {
-                    "email": optional_string(os.environ.get("JIRA_ADMIN_2_EMAIL")) or "bob@writer.com",
-                    "display_name": optional_string(os.environ.get("JIRA_ADMIN_2_NAME")) or "Bob",
-                    "role": optional_string(os.environ.get("JIRA_ADMIN_2_ROLE")) or "org_admin",
-                },
-            ],
-            "projects": [
-                {
-                    "key": optional_string(os.environ.get("JIRA_PROJECT_1_KEY")) or "ENG",
-                    "name": optional_string(os.environ.get("JIRA_PROJECT_1_NAME")) or "Engineering",
-                    "classification": optional_string(os.environ.get("JIRA_PROJECT_1_CLASSIFICATION")) or "internal",
-                    "issue_level_security_enabled": env_bool("JIRA_PROJECT_1_ISSUE_SECURITY_ENABLED", True),
-                    "anonymous_browse_enabled": env_bool("JIRA_PROJECT_1_ANONYMOUS_BROWSE_ENABLED", False),
-                    "service_desk_public_portal_enabled": env_bool("JIRA_PROJECT_1_PUBLIC_PORTAL_ENABLED", False),
-                },
-                {
-                    "key": optional_string(os.environ.get("JIRA_PROJECT_2_KEY")) or "SEC",
-                    "name": optional_string(os.environ.get("JIRA_PROJECT_2_NAME")) or "Security",
-                    "classification": optional_string(os.environ.get("JIRA_PROJECT_2_CLASSIFICATION")) or "restricted",
-                    "issue_level_security_enabled": env_bool("JIRA_PROJECT_2_ISSUE_SECURITY_ENABLED", True),
-                    "anonymous_browse_enabled": env_bool("JIRA_PROJECT_2_ANONYMOUS_BROWSE_ENABLED", False),
-                    "service_desk_public_portal_enabled": env_bool("JIRA_PROJECT_2_PUBLIC_PORTAL_ENABLED", False),
-                },
-            ],
-            "apps": [
-                {
-                    "key": optional_string(os.environ.get("JIRA_APP_1_KEY")) or "slack",
-                    "name": optional_string(os.environ.get("JIRA_APP_1_NAME")) or "Slack for Jira",
-                    "approved_by_security": env_bool("JIRA_APP_1_APPROVED_BY_SECURITY", True),
-                    "scopes": [
-                        optional_string(os.environ.get("JIRA_APP_1_SCOPE_1")) or "read:project:jira",
-                        optional_string(os.environ.get("JIRA_APP_1_SCOPE_2")) or "write:comment:jira",
-                    ],
-                }
-            ],
-        },
+        posture=build_workspace_posture_from_env(),
     )
     print(json.dumps(result, indent=2, sort_keys=True))
+
+
+def build_workspace_posture_from_env() -> JiraWorkspacePosture:
+    return {
+        "workspace_key": optional_string(os.environ.get("JIRA_WORKSPACE")) or "writer",
+        "workspace_name": optional_string(os.environ.get("JIRA_WORKSPACE_NAME")) or "Writer Jira",
+        "event_id": optional_string(os.environ.get("JIRA_EVENT_ID")) or "jira-posture-snapshot-1",
+        "sso_enforced": env_bool("JIRA_SSO_ENFORCED", True),
+        "mfa_required_for_admins": env_bool("JIRA_MFA_REQUIRED_FOR_ADMINS", True),
+        "atlassian_guard_enabled": env_bool("JIRA_ATLASSIAN_GUARD_ENABLED", True),
+        "audit_log_export_enabled": env_bool("JIRA_AUDIT_LOG_EXPORT_ENABLED", True),
+        "api_token_expiration_enforced": env_bool("JIRA_API_TOKEN_EXPIRATION_ENFORCED", True),
+        "public_signup_enabled": env_bool("JIRA_PUBLIC_SIGNUP_ENABLED", False),
+        "anonymous_access_enabled": env_bool("JIRA_ANONYMOUS_ACCESS_ENABLED", False),
+        "approved_marketplace_apps_only": env_bool("JIRA_APPROVED_MARKETPLACE_APPS_ONLY", True),
+        "admins": [
+            {
+                "email": optional_string(os.environ.get("JIRA_ADMIN_1_EMAIL")) or "alice@writer.com",
+                "display_name": optional_string(os.environ.get("JIRA_ADMIN_1_NAME")) or "Alice",
+                "role": optional_string(os.environ.get("JIRA_ADMIN_1_ROLE")) or "site_admin",
+            },
+            {
+                "email": optional_string(os.environ.get("JIRA_ADMIN_2_EMAIL")) or "bob@writer.com",
+                "display_name": optional_string(os.environ.get("JIRA_ADMIN_2_NAME")) or "Bob",
+                "role": optional_string(os.environ.get("JIRA_ADMIN_2_ROLE")) or "org_admin",
+            },
+        ],
+        "projects": [
+            {
+                "key": optional_string(os.environ.get("JIRA_PROJECT_1_KEY")) or "ENG",
+                "name": optional_string(os.environ.get("JIRA_PROJECT_1_NAME")) or "Engineering",
+                "classification": optional_string(os.environ.get("JIRA_PROJECT_1_CLASSIFICATION")) or "internal",
+                "issue_level_security_enabled": env_bool("JIRA_PROJECT_1_ISSUE_SECURITY_ENABLED", True),
+                "anonymous_browse_enabled": env_bool("JIRA_PROJECT_1_ANONYMOUS_BROWSE_ENABLED", False),
+                "service_desk_public_portal_enabled": env_bool("JIRA_PROJECT_1_PUBLIC_PORTAL_ENABLED", False),
+            },
+            {
+                "key": optional_string(os.environ.get("JIRA_PROJECT_2_KEY")) or "SEC",
+                "name": optional_string(os.environ.get("JIRA_PROJECT_2_NAME")) or "Security",
+                "classification": optional_string(os.environ.get("JIRA_PROJECT_2_CLASSIFICATION")) or "restricted",
+                "issue_level_security_enabled": env_bool("JIRA_PROJECT_2_ISSUE_SECURITY_ENABLED", True),
+                "anonymous_browse_enabled": env_bool("JIRA_PROJECT_2_ANONYMOUS_BROWSE_ENABLED", False),
+                "service_desk_public_portal_enabled": env_bool("JIRA_PROJECT_2_PUBLIC_PORTAL_ENABLED", False),
+            },
+        ],
+        "apps": [
+            {
+                "key": optional_string(os.environ.get("JIRA_APP_1_KEY")) or "slack",
+                "name": optional_string(os.environ.get("JIRA_APP_1_NAME")) or "Slack for Jira",
+                "approved_by_security": env_bool("JIRA_APP_1_APPROVED_BY_SECURITY", True),
+                "scopes": [
+                    optional_string(os.environ.get("JIRA_APP_1_SCOPE_1")) or "read:project:jira",
+                    optional_string(os.environ.get("JIRA_APP_1_SCOPE_2")) or "write:comment:jira",
+                ],
+            }
+        ],
+    }
 
 
 def env_bool(name: str, default: bool) -> bool:
@@ -240,164 +79,6 @@ def env_bool(name: str, default: bool) -> bool:
     if raw is None:
         return default
     return raw.lower() in {"1", "true", "yes", "on"}
-
-
-def bool_value(value: Any) -> str:
-    return "true" if bool(value) else "false"
-
-
-def load_graph_layering(integration: IntegrationClient, posture: Dict[str, Any]) -> Dict[str, Any]:
-    workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
-    workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
-    workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
-    project_refs = []
-    project_keys = []
-    for project in posture.get("projects", []):
-        project_key = require_value(project.get("key"), "projects[].key")
-        project_name = optional_string(project.get("name")) or project_key
-        project_refs.append(integration.ref("project", project_key, project_name))
-        project_keys.append(project_key)
-    workspace_graph = integration.graph_layering([workspace_ref], limit=50)
-    project_layering = integration.graph_layering(project_refs, limit=12)
-    combined_layering = dict(workspace_graph)
-    combined_layering.update(project_layering)
-    project_graphs = {}
-    for project_key, project_ref in zip(project_keys, project_refs):
-        project_graphs[project_key] = project_layering.get(project_ref["urn"], {"root_urn": project_ref["urn"], "error": "missing graph response"})
-    return {
-        "workspace": workspace_graph.get(workspace_ref["urn"], {"root_urn": workspace_ref["urn"], "error": "missing graph response"}),
-        "projects": project_graphs,
-        "summary": integration.graph_summary(combined_layering),
-    }
-
-
-def build_posture_findings(
-    integration: IntegrationClient,
-    posture: Dict[str, Any],
-    graph_summary: Dict[str, Any],
-) -> list[Dict[str, Any]]:
-    findings = []
-    workspace_key = require_value(posture.get("workspace_key"), "workspace_key")
-    workspace_name = optional_string(posture.get("workspace_name")) or workspace_key
-    workspace_ref = integration.ref("workspace", workspace_key, workspace_name)
-
-    if posture.get("public_signup_enabled", False):
-        findings.append(
-            finding(
-                "jira_workspace_public_signup_enabled",
-                "HIGH",
-                "Jira workspace allows self-service signup",
-                f"{workspace_name} allows self-service signup, which increases exposure to unmanaged identities.",
-                [workspace_ref["urn"]],
-            )
-        )
-    if posture.get("anonymous_access_enabled", False):
-        findings.append(
-            finding(
-                "jira_workspace_anonymous_access_enabled",
-                "HIGH",
-                "Jira workspace permits anonymous access",
-                f"{workspace_name} exposes content to unauthenticated users.",
-                [workspace_ref["urn"]],
-            )
-        )
-    if not posture.get("approved_marketplace_apps_only", True):
-        findings.append(
-            finding(
-                "jira_workspace_marketplace_policy_open",
-                "MEDIUM",
-                "Jira workspace does not restrict marketplace apps",
-                f"{workspace_name} allows marketplace apps outside the approved set.",
-                [workspace_ref["urn"]],
-            )
-        )
-
-    admin_count = int(graph_summary.get("relation_counts_by_type", {}).get("administers", 0))
-    if admin_count > 5:
-        findings.append(
-            finding(
-                "jira_workspace_admin_sprawl",
-                "MEDIUM",
-                "Jira workspace has elevated admin sprawl",
-                f"{workspace_name} has {admin_count} admin relationships in the graph neighborhood.",
-                [workspace_ref["urn"]],
-                {"admin_count": str(admin_count)},
-            )
-        )
-
-    for project in posture.get("projects", []):
-        project_key = require_value(project.get("key"), "projects[].key")
-        project_name = optional_string(project.get("name")) or project_key
-        project_ref = integration.ref("project", project_key, project_name)
-        classification = optional_string(project.get("classification")) or "internal"
-        if classification == "restricted" and not project.get("issue_level_security_enabled", True):
-            findings.append(
-                finding(
-                    f"jira_project_{project_key.lower()}_restricted_issue_security_disabled",
-                    "HIGH",
-                    "Restricted Jira project lacks issue-level security",
-                    f"{project_name} is marked restricted but issue-level security is disabled.",
-                    [project_ref["urn"], workspace_ref["urn"]],
-                )
-            )
-        if project.get("anonymous_browse_enabled", False):
-            findings.append(
-                finding(
-                    f"jira_project_{project_key.lower()}_anonymous_browse_enabled",
-                    "HIGH",
-                    "Jira project allows anonymous browsing",
-                    f"{project_name} allows anonymous issue browsing.",
-                    [project_ref["urn"], workspace_ref["urn"]],
-                )
-            )
-        if project.get("service_desk_public_portal_enabled", False):
-            findings.append(
-                finding(
-                    f"jira_project_{project_key.lower()}_public_portal_enabled",
-                    "HIGH" if classification == "restricted" else "MEDIUM",
-                    "Jira project exposes a public service desk portal",
-                    f"{project_name} exposes a public portal for {classification} data.",
-                    [project_ref["urn"], workspace_ref["urn"]],
-                )
-            )
-
-    for app in posture.get("apps", []):
-        if app.get("approved_by_security", True):
-            continue
-        app_key = require_value(app.get("key"), "apps[].key")
-        app_name = optional_string(app.get("name")) or app_key
-        app_ref = integration.ref("app", app_key, app_name)
-        findings.append(
-            finding(
-                f"jira_app_{app_key.lower()}_unapproved",
-                "MEDIUM",
-                "Unapproved Jira marketplace app is installed",
-                f"{app_name} is installed on {workspace_name} without security approval.",
-                [app_ref["urn"], workspace_ref["urn"]],
-            )
-        )
-
-    return findings
-
-
-def finding(
-    finding_id: str,
-    severity: str,
-    title: str,
-    summary: str,
-    resource_urns: list[str],
-    attributes: Optional[Dict[str, str]] = None,
-) -> Dict[str, Any]:
-    payload = {
-        "id": finding_id,
-        "severity": severity,
-        "title": title,
-        "summary": summary,
-        "resource_urns": resource_urns,
-    }
-    if attributes:
-        payload["attributes"] = attributes
-    return payload
 
 
 def optional_string(value: Any) -> Optional[str]:

--- a/sdk/typescript/examples/jira_posture_onboarding.ts
+++ b/sdk/typescript/examples/jira_posture_onboarding.ts
@@ -1,284 +1,83 @@
-import { Client, type Claim, type IntegrationClient } from "../src/index.js";
+import {
+  type JiraWorkspacePosture,
+  onboardJiraWorkspacePosture,
+} from "../src/jira.js";
 
 declare const process: {
   env: Record<string, string | undefined>;
   argv?: string[];
 };
 
-export interface JiraAdminPosture {
-  email: string;
-  displayName?: string;
-  role?: string;
-}
-
-export interface JiraProjectPosture {
-  key: string;
-  name?: string;
-  classification?: string;
-  issueLevelSecurityEnabled?: boolean;
-  anonymousBrowseEnabled?: boolean;
-  serviceDeskPublicPortalEnabled?: boolean;
-}
-
-export interface JiraMarketplaceAppPosture {
-  key: string;
-  name?: string;
-  approvedBySecurity?: boolean;
-  scopes?: string[];
-}
-
-export interface JiraWorkspacePosture {
-  workspaceKey: string;
-  workspaceName?: string;
-  eventId?: string;
-  ssoEnforced?: boolean;
-  mfaRequiredForAdmins?: boolean;
-  atlassianGuardEnabled?: boolean;
-  auditLogExportEnabled?: boolean;
-  apiTokenExpirationEnforced?: boolean;
-  publicSignupEnabled?: boolean;
-  anonymousAccessEnabled?: boolean;
-  approvedMarketplaceAppsOnly?: boolean;
-  admins?: JiraAdminPosture[];
-  projects?: JiraProjectPosture[];
-  apps?: JiraMarketplaceAppPosture[];
-}
-
-export interface OnboardWorkspacePostureOptions {
-  baseUrl: string;
-  apiKey?: string;
-  tenantId: string;
-  runtimeId: string;
-  posture: JiraWorkspacePosture;
-}
-
-export function buildWorkspaceClaims(integration: IntegrationClient, posture: JiraWorkspacePosture): Claim[] {
-  const workspaceKey = requireValue(posture.workspaceKey, "posture.workspaceKey");
-  const workspaceName = posture.workspaceName?.trim() || workspaceKey;
-  const workspaceRef = integration.ref("workspace", workspaceKey, workspaceName);
-  const sourceEventId = posture.eventId?.trim();
-  const sharedOptions = sourceEventId ? { source_event_id: sourceEventId } : {};
-  const admins = posture.admins ?? [];
-  const projects = posture.projects ?? [];
-  const apps = posture.apps ?? [];
-
-  const claims: Claim[] = [
-    integration.exists(workspaceRef, sharedOptions),
-    integration.attr(workspaceRef, "platform", "jira", sharedOptions),
-    integration.attr(workspaceRef, "vendor", "atlassian", sharedOptions),
-    integration.attr(workspaceRef, "sso_enforced", boolValue(posture.ssoEnforced ?? true), sharedOptions),
-    integration.attr(
-      workspaceRef,
-      "mfa_required_for_admins",
-      boolValue(posture.mfaRequiredForAdmins ?? true),
-      sharedOptions,
-    ),
-    integration.attr(
-      workspaceRef,
-      "atlassian_guard_enabled",
-      boolValue(posture.atlassianGuardEnabled ?? true),
-      sharedOptions,
-    ),
-    integration.attr(
-      workspaceRef,
-      "audit_log_export_enabled",
-      boolValue(posture.auditLogExportEnabled ?? true),
-      sharedOptions,
-    ),
-    integration.attr(
-      workspaceRef,
-      "api_token_expiration_enforced",
-      boolValue(posture.apiTokenExpirationEnforced ?? true),
-      sharedOptions,
-    ),
-    integration.attr(
-      workspaceRef,
-      "public_signup_enabled",
-      boolValue(posture.publicSignupEnabled ?? false),
-      sharedOptions,
-    ),
-    integration.attr(
-      workspaceRef,
-      "anonymous_access_enabled",
-      boolValue(posture.anonymousAccessEnabled ?? false),
-      sharedOptions,
-    ),
-    integration.attr(
-      workspaceRef,
-      "approved_marketplace_apps_only",
-      boolValue(posture.approvedMarketplaceAppsOnly ?? true),
-      sharedOptions,
-    ),
-    integration.attr(workspaceRef, "admin_count", String(admins.length), sharedOptions),
-    integration.attr(workspaceRef, "project_count", String(projects.length), sharedOptions),
-    integration.attr(workspaceRef, "installed_app_count", String(apps.length), sharedOptions),
-  ];
-
-  for (const admin of admins) {
-    const email = requireValue(admin.email, "posture.admins[].email");
-    const adminRef = integration.ref("user", email, admin.displayName?.trim() || email);
-    claims.push(integration.exists(adminRef, sharedOptions));
-    claims.push(integration.rel(adminRef, "administers", workspaceRef, sharedOptions));
-    claims.push(integration.attr(adminRef, "role", admin.role?.trim() || "site_admin", sharedOptions));
-  }
-
-  for (const project of projects) {
-    const key = requireValue(project.key, "posture.projects[].key");
-    const projectRef = integration.ref("project", key, project.name?.trim() || key);
-    claims.push(integration.exists(projectRef, sharedOptions));
-    claims.push(integration.rel(projectRef, "belongs_to", workspaceRef, sharedOptions));
-    claims.push(
-      integration.attr(projectRef, "classification", project.classification?.trim() || "internal", sharedOptions),
-    );
-    claims.push(
-      integration.attr(
-        projectRef,
-        "issue_level_security_enabled",
-        boolValue(project.issueLevelSecurityEnabled ?? true),
-        sharedOptions,
-      ),
-    );
-    claims.push(
-      integration.attr(
-        projectRef,
-        "anonymous_browse_enabled",
-        boolValue(project.anonymousBrowseEnabled ?? false),
-        sharedOptions,
-      ),
-    );
-    claims.push(
-      integration.attr(
-        projectRef,
-        "service_desk_public_portal_enabled",
-        boolValue(project.serviceDeskPublicPortalEnabled ?? false),
-        sharedOptions,
-      ),
-    );
-  }
-
-  for (const app of apps) {
-    const key = requireValue(app.key, "posture.apps[].key");
-    const appRef = integration.ref("app", key, app.name?.trim() || key);
-    claims.push(integration.exists(appRef, sharedOptions));
-    claims.push(integration.rel(appRef, "installed_on", workspaceRef, sharedOptions));
-    claims.push(
-      integration.attr(
-        appRef,
-        "approved_by_security",
-        boolValue(app.approvedBySecurity ?? true),
-        sharedOptions,
-      ),
-    );
-    const scopes = (app.scopes ?? []).map((scope) => scope.trim()).filter(Boolean);
-    if (scopes.length > 0) {
-      claims.push(integration.attr(appRef, "scopes", scopes.join(","), sharedOptions));
-    }
-  }
-
-  return claims;
-}
-
-export async function onboardWorkspacePosture(options: OnboardWorkspacePostureOptions): Promise<Record<string, unknown>> {
-  const client = new Client({
-    baseUrl: options.baseUrl,
-    apiKey: options.apiKey?.trim() || undefined,
-  });
-  const integration = client.integration({
-    runtimeId: options.runtimeId.trim(),
-    tenantId: options.tenantId.trim(),
-    integration: "jira",
-  });
-  const runtimeConfig: Record<string, string> = {};
-  const workspaceKey = options.posture.workspaceKey.trim();
-  if (workspaceKey) {
-    runtimeConfig.workspace = workspaceKey;
-  }
-  await integration.ensureRuntime(runtimeConfig);
-  const claims = buildWorkspaceClaims(integration, options.posture);
-  const writeResult = await integration.writeClaims(claims);
-  const persisted = await integration.listClaims({ limit: 100 });
-  const graphLayering = await loadGraphLayering(integration, options.posture);
-  return {
-    workspace_urn: claims[0]?.subject_urn ?? "",
-    write_result: writeResult,
-    submitted_claims: claims,
-    persisted_claims: Array.isArray(persisted["claims"]) ? persisted["claims"] : [],
-    graph_layering: graphLayering,
-    graph_summary: graphLayering["summary"] ?? {},
-    posture_findings: buildPostureFindings(
-      integration,
-      options.posture,
-      graphLayering["summary"] as Record<string, unknown>,
-    ),
-  };
-}
-
 async function main(): Promise<void> {
   const baseUrl = process.env.CEREBRO_BASE_URL?.trim() ?? "";
   if (!baseUrl) {
     throw new Error("CEREBRO_BASE_URL is required");
   }
-  const result = await onboardWorkspacePosture({
+  const result = await onboardJiraWorkspacePosture({
     baseUrl,
     apiKey: process.env.CEREBRO_API_KEY?.trim(),
     tenantId: process.env.CEREBRO_TENANT_ID?.trim() || "writer",
     runtimeId: process.env.CEREBRO_RUNTIME_ID?.trim() || "writer-jira-posture",
-    posture: {
-      workspaceKey: process.env.JIRA_WORKSPACE?.trim() || "writer",
-      workspaceName: process.env.JIRA_WORKSPACE_NAME?.trim() || "Writer Jira",
-      eventId: process.env.JIRA_EVENT_ID?.trim() || "jira-posture-snapshot-1",
-      ssoEnforced: envBool("JIRA_SSO_ENFORCED", true),
-      mfaRequiredForAdmins: envBool("JIRA_MFA_REQUIRED_FOR_ADMINS", true),
-      atlassianGuardEnabled: envBool("JIRA_ATLASSIAN_GUARD_ENABLED", true),
-      auditLogExportEnabled: envBool("JIRA_AUDIT_LOG_EXPORT_ENABLED", true),
-      apiTokenExpirationEnforced: envBool("JIRA_API_TOKEN_EXPIRATION_ENFORCED", true),
-      publicSignupEnabled: envBool("JIRA_PUBLIC_SIGNUP_ENABLED", false),
-      anonymousAccessEnabled: envBool("JIRA_ANONYMOUS_ACCESS_ENABLED", false),
-      approvedMarketplaceAppsOnly: envBool("JIRA_APPROVED_MARKETPLACE_APPS_ONLY", true),
-      admins: [
-        {
-          email: process.env.JIRA_ADMIN_1_EMAIL?.trim() || "alice@writer.com",
-          displayName: process.env.JIRA_ADMIN_1_NAME?.trim() || "Alice",
-          role: process.env.JIRA_ADMIN_1_ROLE?.trim() || "site_admin",
-        },
-        {
-          email: process.env.JIRA_ADMIN_2_EMAIL?.trim() || "bob@writer.com",
-          displayName: process.env.JIRA_ADMIN_2_NAME?.trim() || "Bob",
-          role: process.env.JIRA_ADMIN_2_ROLE?.trim() || "org_admin",
-        },
-      ],
-      projects: [
-        {
-          key: process.env.JIRA_PROJECT_1_KEY?.trim() || "ENG",
-          name: process.env.JIRA_PROJECT_1_NAME?.trim() || "Engineering",
-          classification: process.env.JIRA_PROJECT_1_CLASSIFICATION?.trim() || "internal",
-          issueLevelSecurityEnabled: envBool("JIRA_PROJECT_1_ISSUE_SECURITY_ENABLED", true),
-          anonymousBrowseEnabled: envBool("JIRA_PROJECT_1_ANONYMOUS_BROWSE_ENABLED", false),
-          serviceDeskPublicPortalEnabled: envBool("JIRA_PROJECT_1_PUBLIC_PORTAL_ENABLED", false),
-        },
-        {
-          key: process.env.JIRA_PROJECT_2_KEY?.trim() || "SEC",
-          name: process.env.JIRA_PROJECT_2_NAME?.trim() || "Security",
-          classification: process.env.JIRA_PROJECT_2_CLASSIFICATION?.trim() || "restricted",
-          issueLevelSecurityEnabled: envBool("JIRA_PROJECT_2_ISSUE_SECURITY_ENABLED", true),
-          anonymousBrowseEnabled: envBool("JIRA_PROJECT_2_ANONYMOUS_BROWSE_ENABLED", false),
-          serviceDeskPublicPortalEnabled: envBool("JIRA_PROJECT_2_PUBLIC_PORTAL_ENABLED", false),
-        },
-      ],
-      apps: [
-        {
-          key: process.env.JIRA_APP_1_KEY?.trim() || "slack",
-          name: process.env.JIRA_APP_1_NAME?.trim() || "Slack for Jira",
-          approvedBySecurity: envBool("JIRA_APP_1_APPROVED_BY_SECURITY", true),
-          scopes: [
-            process.env.JIRA_APP_1_SCOPE_1?.trim() || "read:project:jira",
-            process.env.JIRA_APP_1_SCOPE_2?.trim() || "write:comment:jira",
-          ],
-        },
-      ],
-    },
+    posture: buildWorkspacePostureFromEnv(),
   });
   console.log(JSON.stringify(result, null, 2));
+}
+
+function buildWorkspacePostureFromEnv(): JiraWorkspacePosture {
+  return {
+    workspaceKey: process.env.JIRA_WORKSPACE?.trim() || "writer",
+    workspaceName: process.env.JIRA_WORKSPACE_NAME?.trim() || "Writer Jira",
+    eventId: process.env.JIRA_EVENT_ID?.trim() || "jira-posture-snapshot-1",
+    ssoEnforced: envBool("JIRA_SSO_ENFORCED", true),
+    mfaRequiredForAdmins: envBool("JIRA_MFA_REQUIRED_FOR_ADMINS", true),
+    atlassianGuardEnabled: envBool("JIRA_ATLASSIAN_GUARD_ENABLED", true),
+    auditLogExportEnabled: envBool("JIRA_AUDIT_LOG_EXPORT_ENABLED", true),
+    apiTokenExpirationEnforced: envBool("JIRA_API_TOKEN_EXPIRATION_ENFORCED", true),
+    publicSignupEnabled: envBool("JIRA_PUBLIC_SIGNUP_ENABLED", false),
+    anonymousAccessEnabled: envBool("JIRA_ANONYMOUS_ACCESS_ENABLED", false),
+    approvedMarketplaceAppsOnly: envBool("JIRA_APPROVED_MARKETPLACE_APPS_ONLY", true),
+    admins: [
+      {
+        email: process.env.JIRA_ADMIN_1_EMAIL?.trim() || "alice@writer.com",
+        displayName: process.env.JIRA_ADMIN_1_NAME?.trim() || "Alice",
+        role: process.env.JIRA_ADMIN_1_ROLE?.trim() || "site_admin",
+      },
+      {
+        email: process.env.JIRA_ADMIN_2_EMAIL?.trim() || "bob@writer.com",
+        displayName: process.env.JIRA_ADMIN_2_NAME?.trim() || "Bob",
+        role: process.env.JIRA_ADMIN_2_ROLE?.trim() || "org_admin",
+      },
+    ],
+    projects: [
+      {
+        key: process.env.JIRA_PROJECT_1_KEY?.trim() || "ENG",
+        name: process.env.JIRA_PROJECT_1_NAME?.trim() || "Engineering",
+        classification: process.env.JIRA_PROJECT_1_CLASSIFICATION?.trim() || "internal",
+        issueLevelSecurityEnabled: envBool("JIRA_PROJECT_1_ISSUE_SECURITY_ENABLED", true),
+        anonymousBrowseEnabled: envBool("JIRA_PROJECT_1_ANONYMOUS_BROWSE_ENABLED", false),
+        serviceDeskPublicPortalEnabled: envBool("JIRA_PROJECT_1_PUBLIC_PORTAL_ENABLED", false),
+      },
+      {
+        key: process.env.JIRA_PROJECT_2_KEY?.trim() || "SEC",
+        name: process.env.JIRA_PROJECT_2_NAME?.trim() || "Security",
+        classification: process.env.JIRA_PROJECT_2_CLASSIFICATION?.trim() || "restricted",
+        issueLevelSecurityEnabled: envBool("JIRA_PROJECT_2_ISSUE_SECURITY_ENABLED", true),
+        anonymousBrowseEnabled: envBool("JIRA_PROJECT_2_ANONYMOUS_BROWSE_ENABLED", false),
+        serviceDeskPublicPortalEnabled: envBool("JIRA_PROJECT_2_PUBLIC_PORTAL_ENABLED", false),
+      },
+    ],
+    apps: [
+      {
+        key: process.env.JIRA_APP_1_KEY?.trim() || "slack",
+        name: process.env.JIRA_APP_1_NAME?.trim() || "Slack for Jira",
+        approvedBySecurity: envBool("JIRA_APP_1_APPROVED_BY_SECURITY", true),
+        scopes: [
+          process.env.JIRA_APP_1_SCOPE_1?.trim() || "read:project:jira",
+          process.env.JIRA_APP_1_SCOPE_2?.trim() || "write:comment:jira",
+        ],
+      },
+    ],
+  };
 }
 
 if (typeof process !== "undefined" && process.env) {
@@ -294,205 +93,4 @@ function envBool(name: string, defaultValue: boolean): boolean {
     return defaultValue;
   }
   return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
-}
-
-function boolValue(value: boolean): string {
-  return value ? "true" : "false";
-}
-
-async function loadGraphLayering(
-  integration: IntegrationClient,
-  posture: JiraWorkspacePosture,
-): Promise<Record<string, unknown>> {
-  const workspaceKey = requireValue(posture.workspaceKey, "posture.workspaceKey");
-  const workspaceRef = integration.ref("workspace", workspaceKey, posture.workspaceName?.trim() || workspaceKey);
-  const projectEntries = (posture.projects ?? []).map((project) => {
-    const projectKey = requireValue(project.key, "posture.projects[].key");
-    const projectRef = integration.ref("project", projectKey, project.name?.trim() || projectKey);
-    return [projectKey, projectRef] as const;
-  });
-  const workspaceLayering = await integration.graphLayering([workspaceRef], 50);
-  const projectLayering = await integration.graphLayering(
-    projectEntries.map(([, projectRef]) => projectRef),
-    12,
-  );
-  const combinedLayering = {
-    ...workspaceLayering,
-    ...projectLayering,
-  };
-  return {
-    workspace: workspaceLayering[workspaceRef.urn] ?? {
-      root_urn: workspaceRef.urn,
-      error: "missing graph response",
-    },
-    projects: Object.fromEntries(
-      projectEntries.map(([projectKey, projectRef]) => [
-        projectKey,
-        projectLayering[projectRef.urn] ?? {
-          root_urn: projectRef.urn,
-          error: "missing graph response",
-        },
-      ]),
-    ),
-    summary: integration.graphSummary(combinedLayering),
-  };
-}
-
-export function buildPostureFindings(
-  integration: IntegrationClient,
-  posture: JiraWorkspacePosture,
-  graphSummary: Record<string, unknown>,
-): Array<Record<string, unknown>> {
-  const findings: Array<Record<string, unknown>> = [];
-  const workspaceKey = requireValue(posture.workspaceKey, "posture.workspaceKey");
-  const workspaceName = posture.workspaceName?.trim() || workspaceKey;
-  const workspaceRef = integration.ref("workspace", workspaceKey, workspaceName);
-
-  if (posture.publicSignupEnabled ?? false) {
-    findings.push(
-      finding(
-        "jira_workspace_public_signup_enabled",
-        "HIGH",
-        "Jira workspace allows self-service signup",
-        `${workspaceName} allows self-service signup, which increases exposure to unmanaged identities.`,
-        [workspaceRef.urn],
-      ),
-    );
-  }
-  if (posture.anonymousAccessEnabled ?? false) {
-    findings.push(
-      finding(
-        "jira_workspace_anonymous_access_enabled",
-        "HIGH",
-        "Jira workspace permits anonymous access",
-        `${workspaceName} exposes content to unauthenticated users.`,
-        [workspaceRef.urn],
-      ),
-    );
-  }
-  if (!(posture.approvedMarketplaceAppsOnly ?? true)) {
-    findings.push(
-      finding(
-        "jira_workspace_marketplace_policy_open",
-        "MEDIUM",
-        "Jira workspace does not restrict marketplace apps",
-        `${workspaceName} allows marketplace apps outside the approved set.`,
-        [workspaceRef.urn],
-      ),
-    );
-  }
-
-  const relationCounts = asNumberRecord(graphSummary["relation_counts_by_type"]);
-  const adminCount = relationCounts.administers ?? 0;
-  if (adminCount > 5) {
-    findings.push(
-      finding(
-        "jira_workspace_admin_sprawl",
-        "MEDIUM",
-        "Jira workspace has elevated admin sprawl",
-        `${workspaceName} has ${adminCount} admin relationships in the graph neighborhood.`,
-        [workspaceRef.urn],
-        { admin_count: String(adminCount) },
-      ),
-    );
-  }
-
-  for (const project of posture.projects ?? []) {
-    const projectKey = requireValue(project.key, "posture.projects[].key");
-    const projectName = project.name?.trim() || projectKey;
-    const projectRef = integration.ref("project", projectKey, projectName);
-    const classification = project.classification?.trim() || "internal";
-    if (classification === "restricted" && !(project.issueLevelSecurityEnabled ?? true)) {
-      findings.push(
-        finding(
-          `jira_project_${projectKey.toLowerCase()}_restricted_issue_security_disabled`,
-          "HIGH",
-          "Restricted Jira project lacks issue-level security",
-          `${projectName} is marked restricted but issue-level security is disabled.`,
-          [projectRef.urn, workspaceRef.urn],
-        ),
-      );
-    }
-    if (project.anonymousBrowseEnabled ?? false) {
-      findings.push(
-        finding(
-          `jira_project_${projectKey.toLowerCase()}_anonymous_browse_enabled`,
-          "HIGH",
-          "Jira project allows anonymous browsing",
-          `${projectName} allows anonymous issue browsing.`,
-          [projectRef.urn, workspaceRef.urn],
-        ),
-      );
-    }
-    if (project.serviceDeskPublicPortalEnabled ?? false) {
-      findings.push(
-        finding(
-          `jira_project_${projectKey.toLowerCase()}_public_portal_enabled`,
-          classification === "restricted" ? "HIGH" : "MEDIUM",
-          "Jira project exposes a public service desk portal",
-          `${projectName} exposes a public portal for ${classification} data.`,
-          [projectRef.urn, workspaceRef.urn],
-        ),
-      );
-    }
-  }
-
-  for (const app of posture.apps ?? []) {
-    if (app.approvedBySecurity ?? true) {
-      continue;
-    }
-    const appKey = requireValue(app.key, "posture.apps[].key");
-    const appName = app.name?.trim() || appKey;
-    const appRef = integration.ref("app", appKey, appName);
-    findings.push(
-      finding(
-        `jira_app_${appKey.toLowerCase()}_unapproved`,
-        "MEDIUM",
-        "Unapproved Jira marketplace app is installed",
-        `${appName} is installed on ${workspaceName} without security approval.`,
-        [appRef.urn, workspaceRef.urn],
-      ),
-    );
-  }
-
-  return findings;
-}
-
-function requireValue(value: string, name: string): string {
-  const normalized = value.trim();
-  if (!normalized) {
-    throw new Error(`${name} is required`);
-  }
-  return normalized;
-}
-
-function finding(
-  id: string,
-  severity: string,
-  title: string,
-  summary: string,
-  resourceUrns: string[],
-  attributes?: Record<string, string>,
-): Record<string, unknown> {
-  return {
-    id,
-    severity,
-    title,
-    summary,
-    resource_urns: resourceUrns,
-    ...(attributes ? { attributes } : {}),
-  };
-}
-
-function asNumberRecord(value: unknown): Record<string, number> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return {};
-  }
-  const result: Record<string, number> = {};
-  for (const [key, raw] of Object.entries(value)) {
-    if (typeof raw === "number") {
-      result[key] = raw;
-    }
-  }
-  return result;
 }

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./jira": "./src/jira.ts"
   }
 }

--- a/sdk/typescript/src/jira.ts
+++ b/sdk/typescript/src/jira.ts
@@ -376,7 +376,7 @@ export async function onboardJiraWorkspacePosture(
     integration: "jira",
   });
   const runtimeConfig: Record<string, string> = {};
-  const workspaceKey = options.posture.workspaceKey.trim();
+  const workspaceKey = requireValue(options.posture.workspaceKey, "posture.workspaceKey");
   if (workspaceKey) {
     runtimeConfig.workspace = workspaceKey;
   }
@@ -396,7 +396,10 @@ export async function onboardJiraWorkspacePosture(
   };
 }
 
-function requireValue(value: string, name: string): string {
+function requireValue(value: unknown, name: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${name} is required`);
+  }
   const normalized = value.trim();
   if (!normalized) {
     throw new Error(`${name} is required`);

--- a/sdk/typescript/src/jira.ts
+++ b/sdk/typescript/src/jira.ts
@@ -1,0 +1,440 @@
+import {
+  Client,
+  type Claim,
+  type GraphNeighborhood,
+  type GraphNeighborhoodError,
+  type GraphSummary,
+  type IntegrationClient,
+} from "./index.js";
+
+export interface JiraAdminPosture {
+  email: string;
+  displayName?: string;
+  role?: string;
+}
+
+export interface JiraProjectPosture {
+  key: string;
+  name?: string;
+  classification?: string;
+  issueLevelSecurityEnabled?: boolean;
+  anonymousBrowseEnabled?: boolean;
+  serviceDeskPublicPortalEnabled?: boolean;
+}
+
+export interface JiraMarketplaceAppPosture {
+  key: string;
+  name?: string;
+  approvedBySecurity?: boolean;
+  scopes?: string[];
+}
+
+export interface JiraWorkspacePosture {
+  workspaceKey: string;
+  workspaceName?: string;
+  eventId?: string;
+  ssoEnforced?: boolean;
+  mfaRequiredForAdmins?: boolean;
+  atlassianGuardEnabled?: boolean;
+  auditLogExportEnabled?: boolean;
+  apiTokenExpirationEnforced?: boolean;
+  publicSignupEnabled?: boolean;
+  anonymousAccessEnabled?: boolean;
+  approvedMarketplaceAppsOnly?: boolean;
+  admins?: JiraAdminPosture[];
+  projects?: JiraProjectPosture[];
+  apps?: JiraMarketplaceAppPosture[];
+}
+
+export interface JiraWorkspaceGraphLayering {
+  workspace: GraphNeighborhood | GraphNeighborhoodError;
+  projects: Record<string, GraphNeighborhood | GraphNeighborhoodError>;
+  summary: GraphSummary;
+}
+
+export interface JiraPostureFinding {
+  id: string;
+  severity: string;
+  title: string;
+  summary: string;
+  resource_urns: string[];
+  attributes?: Record<string, string>;
+}
+
+export interface OnboardJiraWorkspacePostureOptions {
+  baseUrl: string;
+  apiKey?: string;
+  tenantId: string;
+  runtimeId: string;
+  posture: JiraWorkspacePosture;
+}
+
+export interface OnboardJiraWorkspacePostureResult {
+  workspace_urn: string;
+  write_result: Record<string, unknown>;
+  submitted_claims: Claim[];
+  persisted_claims: Claim[];
+  graph_layering: JiraWorkspaceGraphLayering;
+  graph_summary: GraphSummary;
+  posture_findings: JiraPostureFinding[];
+}
+
+export function buildJiraWorkspaceClaims(integration: IntegrationClient, posture: JiraWorkspacePosture): Claim[] {
+  const workspaceKey = requireValue(posture.workspaceKey, "posture.workspaceKey");
+  const workspaceName = posture.workspaceName?.trim() || workspaceKey;
+  const workspaceRef = integration.ref("workspace", workspaceKey, workspaceName);
+  const sourceEventId = posture.eventId?.trim();
+  const sharedOptions = sourceEventId ? { source_event_id: sourceEventId } : {};
+  const admins = posture.admins ?? [];
+  const projects = posture.projects ?? [];
+  const apps = posture.apps ?? [];
+
+  const claims: Claim[] = [
+    integration.exists(workspaceRef, sharedOptions),
+    integration.attr(workspaceRef, "platform", "jira", sharedOptions),
+    integration.attr(workspaceRef, "vendor", "atlassian", sharedOptions),
+    integration.attr(workspaceRef, "sso_enforced", boolValue(posture.ssoEnforced ?? true), sharedOptions),
+    integration.attr(
+      workspaceRef,
+      "mfa_required_for_admins",
+      boolValue(posture.mfaRequiredForAdmins ?? true),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "atlassian_guard_enabled",
+      boolValue(posture.atlassianGuardEnabled ?? true),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "audit_log_export_enabled",
+      boolValue(posture.auditLogExportEnabled ?? true),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "api_token_expiration_enforced",
+      boolValue(posture.apiTokenExpirationEnforced ?? true),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "public_signup_enabled",
+      boolValue(posture.publicSignupEnabled ?? false),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "anonymous_access_enabled",
+      boolValue(posture.anonymousAccessEnabled ?? false),
+      sharedOptions,
+    ),
+    integration.attr(
+      workspaceRef,
+      "approved_marketplace_apps_only",
+      boolValue(posture.approvedMarketplaceAppsOnly ?? true),
+      sharedOptions,
+    ),
+    integration.attr(workspaceRef, "admin_count", String(admins.length), sharedOptions),
+    integration.attr(workspaceRef, "project_count", String(projects.length), sharedOptions),
+    integration.attr(workspaceRef, "installed_app_count", String(apps.length), sharedOptions),
+  ];
+
+  for (const admin of admins) {
+    const email = requireValue(admin.email, "posture.admins[].email");
+    const adminRef = integration.ref("user", email, admin.displayName?.trim() || email);
+    claims.push(integration.exists(adminRef, sharedOptions));
+    claims.push(integration.rel(adminRef, "administers", workspaceRef, sharedOptions));
+    claims.push(integration.attr(adminRef, "role", admin.role?.trim() || "site_admin", sharedOptions));
+  }
+
+  for (const project of projects) {
+    const key = requireValue(project.key, "posture.projects[].key");
+    const projectRef = integration.ref("project", key, project.name?.trim() || key);
+    claims.push(integration.exists(projectRef, sharedOptions));
+    claims.push(integration.rel(projectRef, "belongs_to", workspaceRef, sharedOptions));
+    claims.push(
+      integration.attr(projectRef, "classification", project.classification?.trim() || "internal", sharedOptions),
+    );
+    claims.push(
+      integration.attr(
+        projectRef,
+        "issue_level_security_enabled",
+        boolValue(project.issueLevelSecurityEnabled ?? true),
+        sharedOptions,
+      ),
+    );
+    claims.push(
+      integration.attr(
+        projectRef,
+        "anonymous_browse_enabled",
+        boolValue(project.anonymousBrowseEnabled ?? false),
+        sharedOptions,
+      ),
+    );
+    claims.push(
+      integration.attr(
+        projectRef,
+        "service_desk_public_portal_enabled",
+        boolValue(project.serviceDeskPublicPortalEnabled ?? false),
+        sharedOptions,
+      ),
+    );
+  }
+
+  for (const app of apps) {
+    const key = requireValue(app.key, "posture.apps[].key");
+    const appRef = integration.ref("app", key, app.name?.trim() || key);
+    claims.push(integration.exists(appRef, sharedOptions));
+    claims.push(integration.rel(appRef, "installed_on", workspaceRef, sharedOptions));
+    claims.push(
+      integration.attr(
+        appRef,
+        "approved_by_security",
+        boolValue(app.approvedBySecurity ?? true),
+        sharedOptions,
+      ),
+    );
+    const scopes = (app.scopes ?? []).map((scope) => scope.trim()).filter(Boolean);
+    if (scopes.length > 0) {
+      claims.push(integration.attr(appRef, "scopes", scopes.join(","), sharedOptions));
+    }
+  }
+
+  return claims;
+}
+
+export async function loadJiraWorkspaceGraphLayering(
+  integration: IntegrationClient,
+  posture: JiraWorkspacePosture,
+): Promise<JiraWorkspaceGraphLayering> {
+  const workspaceKey = requireValue(posture.workspaceKey, "posture.workspaceKey");
+  const workspaceRef = integration.ref("workspace", workspaceKey, posture.workspaceName?.trim() || workspaceKey);
+  const projectEntries = (posture.projects ?? []).map((project) => {
+    const projectKey = requireValue(project.key, "posture.projects[].key");
+    const projectRef = integration.ref("project", projectKey, project.name?.trim() || projectKey);
+    return [projectKey, projectRef] as const;
+  });
+  const workspaceLayering = await integration.graphLayering([workspaceRef], 50);
+  const projectLayering = await integration.graphLayering(
+    projectEntries.map(([, projectRef]) => projectRef),
+    12,
+  );
+  const combinedLayering = {
+    ...workspaceLayering,
+    ...projectLayering,
+  };
+  return {
+    workspace: workspaceLayering[workspaceRef.urn] ?? {
+      root_urn: workspaceRef.urn,
+      error: "missing graph response",
+    },
+    projects: Object.fromEntries(
+      projectEntries.map(([projectKey, projectRef]) => [
+        projectKey,
+        projectLayering[projectRef.urn] ?? {
+          root_urn: projectRef.urn,
+          error: "missing graph response",
+        },
+      ]),
+    ),
+    summary: integration.graphSummary(combinedLayering),
+  };
+}
+
+export function buildJiraPostureFindings(
+  integration: IntegrationClient,
+  posture: JiraWorkspacePosture,
+  graphSummary: GraphSummary | Record<string, unknown>,
+): JiraPostureFinding[] {
+  const findings: JiraPostureFinding[] = [];
+  const workspaceKey = requireValue(posture.workspaceKey, "posture.workspaceKey");
+  const workspaceName = posture.workspaceName?.trim() || workspaceKey;
+  const workspaceRef = integration.ref("workspace", workspaceKey, workspaceName);
+
+  if (posture.publicSignupEnabled ?? false) {
+    findings.push(
+      finding(
+        "jira_workspace_public_signup_enabled",
+        "HIGH",
+        "Jira workspace allows self-service signup",
+        `${workspaceName} allows self-service signup, which increases exposure to unmanaged identities.`,
+        [workspaceRef.urn],
+      ),
+    );
+  }
+  if (posture.anonymousAccessEnabled ?? false) {
+    findings.push(
+      finding(
+        "jira_workspace_anonymous_access_enabled",
+        "HIGH",
+        "Jira workspace permits anonymous access",
+        `${workspaceName} exposes content to unauthenticated users.`,
+        [workspaceRef.urn],
+      ),
+    );
+  }
+  if (!(posture.approvedMarketplaceAppsOnly ?? true)) {
+    findings.push(
+      finding(
+        "jira_workspace_marketplace_policy_open",
+        "MEDIUM",
+        "Jira workspace does not restrict marketplace apps",
+        `${workspaceName} allows marketplace apps outside the approved set.`,
+        [workspaceRef.urn],
+      ),
+    );
+  }
+
+  const relationCounts = asNumberRecord(graphSummary["relation_counts_by_type"]);
+  const adminCount = relationCounts.administers ?? 0;
+  if (adminCount > 5) {
+    findings.push(
+      finding(
+        "jira_workspace_admin_sprawl",
+        "MEDIUM",
+        "Jira workspace has elevated admin sprawl",
+        `${workspaceName} has ${adminCount} admin relationships in the graph neighborhood.`,
+        [workspaceRef.urn],
+        { admin_count: String(adminCount) },
+      ),
+    );
+  }
+
+  for (const project of posture.projects ?? []) {
+    const projectKey = requireValue(project.key, "posture.projects[].key");
+    const projectName = project.name?.trim() || projectKey;
+    const projectRef = integration.ref("project", projectKey, projectName);
+    const classification = project.classification?.trim() || "internal";
+    if (classification === "restricted" && !(project.issueLevelSecurityEnabled ?? true)) {
+      findings.push(
+        finding(
+          `jira_project_${projectKey.toLowerCase()}_restricted_issue_security_disabled`,
+          "HIGH",
+          "Restricted Jira project lacks issue-level security",
+          `${projectName} is marked restricted but issue-level security is disabled.`,
+          [projectRef.urn, workspaceRef.urn],
+        ),
+      );
+    }
+    if (project.anonymousBrowseEnabled ?? false) {
+      findings.push(
+        finding(
+          `jira_project_${projectKey.toLowerCase()}_anonymous_browse_enabled`,
+          "HIGH",
+          "Jira project allows anonymous browsing",
+          `${projectName} allows anonymous issue browsing.`,
+          [projectRef.urn, workspaceRef.urn],
+        ),
+      );
+    }
+    if (project.serviceDeskPublicPortalEnabled ?? false) {
+      findings.push(
+        finding(
+          `jira_project_${projectKey.toLowerCase()}_public_portal_enabled`,
+          classification === "restricted" ? "HIGH" : "MEDIUM",
+          "Jira project exposes a public service desk portal",
+          `${projectName} exposes a public portal for ${classification} data.`,
+          [projectRef.urn, workspaceRef.urn],
+        ),
+      );
+    }
+  }
+
+  for (const app of posture.apps ?? []) {
+    if (app.approvedBySecurity ?? true) {
+      continue;
+    }
+    const appKey = requireValue(app.key, "posture.apps[].key");
+    const appName = app.name?.trim() || appKey;
+    const appRef = integration.ref("app", appKey, appName);
+    findings.push(
+      finding(
+        `jira_app_${appKey.toLowerCase()}_unapproved`,
+        "MEDIUM",
+        "Unapproved Jira marketplace app is installed",
+        `${appName} is installed on ${workspaceName} without security approval.`,
+        [appRef.urn, workspaceRef.urn],
+      ),
+    );
+  }
+
+  return findings;
+}
+
+export async function onboardJiraWorkspacePosture(
+  options: OnboardJiraWorkspacePostureOptions,
+): Promise<OnboardJiraWorkspacePostureResult> {
+  const client = new Client({
+    baseUrl: options.baseUrl,
+    apiKey: options.apiKey?.trim() || undefined,
+  });
+  const integration = client.integration({
+    runtimeId: options.runtimeId.trim(),
+    tenantId: options.tenantId.trim(),
+    integration: "jira",
+  });
+  const runtimeConfig: Record<string, string> = {};
+  const workspaceKey = options.posture.workspaceKey.trim();
+  if (workspaceKey) {
+    runtimeConfig.workspace = workspaceKey;
+  }
+  await integration.ensureRuntime(runtimeConfig);
+  const claims = buildJiraWorkspaceClaims(integration, options.posture);
+  const writeResult = await integration.writeClaims(claims);
+  const persisted = await integration.listClaims({ limit: 100 });
+  const graphLayering = await loadJiraWorkspaceGraphLayering(integration, options.posture);
+  return {
+    workspace_urn: claims[0]?.subject_urn ?? "",
+    write_result: writeResult,
+    submitted_claims: claims,
+    persisted_claims: Array.isArray(persisted["claims"]) ? (persisted["claims"] as Claim[]) : [],
+    graph_layering: graphLayering,
+    graph_summary: graphLayering.summary,
+    posture_findings: buildJiraPostureFindings(integration, options.posture, graphLayering.summary),
+  };
+}
+
+function requireValue(value: string, name: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${name} is required`);
+  }
+  return normalized;
+}
+
+function finding(
+  id: string,
+  severity: string,
+  title: string,
+  summary: string,
+  resourceUrns: string[],
+  attributes?: Record<string, string>,
+): JiraPostureFinding {
+  return {
+    id,
+    severity,
+    title,
+    summary,
+    resource_urns: resourceUrns,
+    ...(attributes ? { attributes } : {}),
+  };
+}
+
+function boolValue(value: boolean): string {
+  return value ? "true" : "false";
+}
+
+function asNumberRecord(value: unknown): Record<string, number> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  const result: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "number") {
+      result[key] = raw;
+    }
+  }
+  return result;
+}

--- a/sdk/typescript/src/jira.ts
+++ b/sdk/typescript/src/jira.ts
@@ -93,47 +93,47 @@ export function buildJiraWorkspaceClaims(integration: IntegrationClient, posture
     integration.exists(workspaceRef, sharedOptions),
     integration.attr(workspaceRef, "platform", "jira", sharedOptions),
     integration.attr(workspaceRef, "vendor", "atlassian", sharedOptions),
-    integration.attr(workspaceRef, "sso_enforced", boolValue(posture.ssoEnforced ?? true), sharedOptions),
+    integration.attr(workspaceRef, "sso_enforced", boolValue(defaultBool(posture.ssoEnforced, true)), sharedOptions),
     integration.attr(
       workspaceRef,
       "mfa_required_for_admins",
-      boolValue(posture.mfaRequiredForAdmins ?? true),
+      boolValue(defaultBool(posture.mfaRequiredForAdmins, true)),
       sharedOptions,
     ),
     integration.attr(
       workspaceRef,
       "atlassian_guard_enabled",
-      boolValue(posture.atlassianGuardEnabled ?? true),
+      boolValue(defaultBool(posture.atlassianGuardEnabled, true)),
       sharedOptions,
     ),
     integration.attr(
       workspaceRef,
       "audit_log_export_enabled",
-      boolValue(posture.auditLogExportEnabled ?? true),
+      boolValue(defaultBool(posture.auditLogExportEnabled, true)),
       sharedOptions,
     ),
     integration.attr(
       workspaceRef,
       "api_token_expiration_enforced",
-      boolValue(posture.apiTokenExpirationEnforced ?? true),
+      boolValue(defaultBool(posture.apiTokenExpirationEnforced, true)),
       sharedOptions,
     ),
     integration.attr(
       workspaceRef,
       "public_signup_enabled",
-      boolValue(posture.publicSignupEnabled ?? false),
+      boolValue(defaultBool(posture.publicSignupEnabled, false)),
       sharedOptions,
     ),
     integration.attr(
       workspaceRef,
       "anonymous_access_enabled",
-      boolValue(posture.anonymousAccessEnabled ?? false),
+      boolValue(defaultBool(posture.anonymousAccessEnabled, false)),
       sharedOptions,
     ),
     integration.attr(
       workspaceRef,
       "approved_marketplace_apps_only",
-      boolValue(posture.approvedMarketplaceAppsOnly ?? true),
+      boolValue(defaultBool(posture.approvedMarketplaceAppsOnly, true)),
       sharedOptions,
     ),
     integration.attr(workspaceRef, "admin_count", String(admins.length), sharedOptions),
@@ -161,7 +161,7 @@ export function buildJiraWorkspaceClaims(integration: IntegrationClient, posture
       integration.attr(
         projectRef,
         "issue_level_security_enabled",
-        boolValue(project.issueLevelSecurityEnabled ?? true),
+        boolValue(defaultBool(project.issueLevelSecurityEnabled, true)),
         sharedOptions,
       ),
     );
@@ -169,7 +169,7 @@ export function buildJiraWorkspaceClaims(integration: IntegrationClient, posture
       integration.attr(
         projectRef,
         "anonymous_browse_enabled",
-        boolValue(project.anonymousBrowseEnabled ?? false),
+        boolValue(defaultBool(project.anonymousBrowseEnabled, false)),
         sharedOptions,
       ),
     );
@@ -177,7 +177,7 @@ export function buildJiraWorkspaceClaims(integration: IntegrationClient, posture
       integration.attr(
         projectRef,
         "service_desk_public_portal_enabled",
-        boolValue(project.serviceDeskPublicPortalEnabled ?? false),
+        boolValue(defaultBool(project.serviceDeskPublicPortalEnabled, false)),
         sharedOptions,
       ),
     );
@@ -192,7 +192,7 @@ export function buildJiraWorkspaceClaims(integration: IntegrationClient, posture
       integration.attr(
         appRef,
         "approved_by_security",
-        boolValue(app.approvedBySecurity ?? true),
+        boolValue(defaultBool(app.approvedBySecurity, true)),
         sharedOptions,
       ),
     );
@@ -253,7 +253,7 @@ export function buildJiraPostureFindings(
   const workspaceName = posture.workspaceName?.trim() || workspaceKey;
   const workspaceRef = integration.ref("workspace", workspaceKey, workspaceName);
 
-  if (posture.publicSignupEnabled ?? false) {
+  if (defaultBool(posture.publicSignupEnabled, false)) {
     findings.push(
       finding(
         "jira_workspace_public_signup_enabled",
@@ -264,7 +264,7 @@ export function buildJiraPostureFindings(
       ),
     );
   }
-  if (posture.anonymousAccessEnabled ?? false) {
+  if (defaultBool(posture.anonymousAccessEnabled, false)) {
     findings.push(
       finding(
         "jira_workspace_anonymous_access_enabled",
@@ -275,7 +275,7 @@ export function buildJiraPostureFindings(
       ),
     );
   }
-  if (!(posture.approvedMarketplaceAppsOnly ?? true)) {
+  if (!defaultBool(posture.approvedMarketplaceAppsOnly, true)) {
     findings.push(
       finding(
         "jira_workspace_marketplace_policy_open",
@@ -307,7 +307,7 @@ export function buildJiraPostureFindings(
     const projectName = project.name?.trim() || projectKey;
     const projectRef = integration.ref("project", projectKey, projectName);
     const classification = project.classification?.trim() || "internal";
-    if (classification === "restricted" && !(project.issueLevelSecurityEnabled ?? true)) {
+    if (classification === "restricted" && !defaultBool(project.issueLevelSecurityEnabled, true)) {
       findings.push(
         finding(
           `jira_project_${projectKey.toLowerCase()}_restricted_issue_security_disabled`,
@@ -318,7 +318,7 @@ export function buildJiraPostureFindings(
         ),
       );
     }
-    if (project.anonymousBrowseEnabled ?? false) {
+    if (defaultBool(project.anonymousBrowseEnabled, false)) {
       findings.push(
         finding(
           `jira_project_${projectKey.toLowerCase()}_anonymous_browse_enabled`,
@@ -329,7 +329,7 @@ export function buildJiraPostureFindings(
         ),
       );
     }
-    if (project.serviceDeskPublicPortalEnabled ?? false) {
+    if (defaultBool(project.serviceDeskPublicPortalEnabled, false)) {
       findings.push(
         finding(
           `jira_project_${projectKey.toLowerCase()}_public_portal_enabled`,
@@ -343,7 +343,7 @@ export function buildJiraPostureFindings(
   }
 
   for (const app of posture.apps ?? []) {
-    if (app.approvedBySecurity ?? true) {
+    if (defaultBool(app.approvedBySecurity, true)) {
       continue;
     }
     const appKey = requireValue(app.key, "posture.apps[].key");
@@ -427,6 +427,28 @@ function finding(
 
 function boolValue(value: boolean): string {
   return value ? "true" : "false";
+}
+
+function defaultBool(value: unknown, defaultValue: boolean): boolean {
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return defaultValue;
+    }
+    if (["1", "true", "t", "yes", "y", "on"].includes(normalized)) {
+      return true;
+    }
+    if (["0", "false", "f", "no", "n", "off"].includes(normalized)) {
+      return false;
+    }
+  }
+  return Boolean(value);
 }
 
 function asNumberRecord(value: unknown): Record<string, number> {


### PR DESCRIPTION
## Summary
- extract reusable Jira posture claim, graph layering, finding, and onboarding helpers into the Python SDK
- add matching TypeScript Jira posture helpers and expose them via a package subpath
- slim the Python and TypeScript posture examples down to environment wiring around the shared helpers

## Validation
- python3 -m py_compile sdk/python/cerebro_sdk/client.py sdk/python/cerebro_sdk/jira.py sdk/python/examples/jira_posture_onboarding.py
- python smoke for build_jira_workspace_claims and build_jira_posture_findings
- npx -y -p typescript tsc -p tsconfig.json
- typescript smoke for buildJiraWorkspaceClaims and buildJiraPostureFindings
- make verify