### PR TITLE
feat(claims): add runtime snapshot reconciliation

### DIFF
--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -1695,11 +1695,12 @@ func (x *SyncSourceRuntimeResponse) GetLinksProjected() uint32 {
 
 // WriteClaimsRequest persists one batch of runtime-scoped claims.
 type WriteClaimsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RuntimeId     string                 `protobuf:"bytes,1,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
-	Claims        []*Claim               `protobuf:"bytes,2,rep,name=claims,proto3" json:"claims,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	RuntimeId       string                 `protobuf:"bytes,1,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	Claims          []*Claim               `protobuf:"bytes,2,rep,name=claims,proto3" json:"claims,omitempty"`
+	ReplaceExisting bool                   `protobuf:"varint,3,opt,name=replace_existing,json=replaceExisting,proto3" json:"replace_existing,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *WriteClaimsRequest) Reset() {
@@ -1746,12 +1747,20 @@ func (x *WriteClaimsRequest) GetClaims() []*Claim {
 	return nil
 }
 
+func (x *WriteClaimsRequest) GetReplaceExisting() bool {
+	if x != nil {
+		return x.ReplaceExisting
+	}
+	return false
+}
+
 // WriteClaimsResponse reports the persisted and projected batch totals.
 type WriteClaimsResponse struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
 	ClaimsWritten          uint32                 `protobuf:"varint,1,opt,name=claims_written,json=claimsWritten,proto3" json:"claims_written,omitempty"`
 	EntitiesUpserted       uint32                 `protobuf:"varint,2,opt,name=entities_upserted,json=entitiesUpserted,proto3" json:"entities_upserted,omitempty"`
 	RelationLinksProjected uint32                 `protobuf:"varint,3,opt,name=relation_links_projected,json=relationLinksProjected,proto3" json:"relation_links_projected,omitempty"`
+	ClaimsRetracted        uint32                 `protobuf:"varint,4,opt,name=claims_retracted,json=claimsRetracted,proto3" json:"claims_retracted,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -1807,6 +1816,13 @@ func (x *WriteClaimsResponse) GetRelationLinksProjected() uint32 {
 	return 0
 }
 
+func (x *WriteClaimsResponse) GetClaimsRetracted() uint32 {
+	if x != nil {
+		return x.ClaimsRetracted
+	}
+	return 0
+}
+
 // ListClaimsRequest queries persisted claims for one stored runtime.
 type ListClaimsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1819,6 +1835,7 @@ type ListClaimsRequest struct {
 	ClaimType     string                 `protobuf:"bytes,7,opt,name=claim_type,json=claimType,proto3" json:"claim_type,omitempty"`
 	Status        string                 `protobuf:"bytes,8,opt,name=status,proto3" json:"status,omitempty"`
 	Limit         uint32                 `protobuf:"varint,9,opt,name=limit,proto3" json:"limit,omitempty"`
+	SourceEventId string                 `protobuf:"bytes,10,opt,name=source_event_id,json=sourceEventId,proto3" json:"source_event_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1914,6 +1931,13 @@ func (x *ListClaimsRequest) GetLimit() uint32 {
 		return x.Limit
 	}
 	return 0
+}
+
+func (x *ListClaimsRequest) GetSourceEventId() string {
+	if x != nil {
+		return x.SourceEventId
+	}
+	return ""
 }
 
 // ListClaimsResponse returns the matched persisted claims.
@@ -2618,15 +2642,17 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"pages_read\x18\x03 \x01(\rR\tpagesRead\x12'\n" +
 	"\x0fevents_appended\x18\x04 \x01(\rR\x0eeventsAppended\x12-\n" +
 	"\x12entities_projected\x18\x05 \x01(\rR\x11entitiesProjected\x12'\n" +
-	"\x0flinks_projected\x18\x06 \x01(\rR\x0elinksProjected\"^\n" +
+	"\x0flinks_projected\x18\x06 \x01(\rR\x0elinksProjected\"\x89\x01\n" +
 	"\x12WriteClaimsRequest\x12\x1d\n" +
 	"\n" +
 	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12)\n" +
-	"\x06claims\x18\x02 \x03(\v2\x11.cerebro.v1.ClaimR\x06claims\"\xa3\x01\n" +
+	"\x06claims\x18\x02 \x03(\v2\x11.cerebro.v1.ClaimR\x06claims\x12)\n" +
+	"\x10replace_existing\x18\x03 \x01(\bR\x0freplaceExisting\"\xce\x01\n" +
 	"\x13WriteClaimsResponse\x12%\n" +
 	"\x0eclaims_written\x18\x01 \x01(\rR\rclaimsWritten\x12+\n" +
 	"\x11entities_upserted\x18\x02 \x01(\rR\x10entitiesUpserted\x128\n" +
-	"\x18relation_links_projected\x18\x03 \x01(\rR\x16relationLinksProjected\"\x9b\x02\n" +
+	"\x18relation_links_projected\x18\x03 \x01(\rR\x16relationLinksProjected\x12)\n" +
+	"\x10claims_retracted\x18\x04 \x01(\rR\x0fclaimsRetracted\"\xc3\x02\n" +
 	"\x11ListClaimsRequest\x12\x1d\n" +
 	"\n" +
 	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12\x19\n" +
@@ -2640,7 +2666,9 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\n" +
 	"claim_type\x18\a \x01(\tR\tclaimType\x12\x16\n" +
 	"\x06status\x18\b \x01(\tR\x06status\x12\x14\n" +
-	"\x05limit\x18\t \x01(\rR\x05limit\"?\n" +
+	"\x05limit\x18\t \x01(\rR\x05limit\x12&\n" +
+	"\x0fsource_event_id\x18\n" +
+	" \x01(\tR\rsourceEventId\"?\n" +
 	"\x12ListClaimsResponse\x12)\n" +
 	"\x06claims\x18\x01 \x03(\v2\x11.cerebro.v1.ClaimR\x06claims\"\xc8\x04\n" +
 	"\aFinding\x12\x0e\n" +

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -1985,6 +1985,107 @@ func (x *ListClaimsResponse) GetClaims() []*Claim {
 	return nil
 }
 
+// ListFindingsRequest queries persisted findings for one stored runtime.
+type ListFindingsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RuntimeId     string                 `protobuf:"bytes,1,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	FindingId     string                 `protobuf:"bytes,2,opt,name=finding_id,json=findingId,proto3" json:"finding_id,omitempty"`
+	RuleId        string                 `protobuf:"bytes,3,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	Severity      string                 `protobuf:"bytes,4,opt,name=severity,proto3" json:"severity,omitempty"`
+	Status        string                 `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
+	ResourceUrn   string                 `protobuf:"bytes,6,opt,name=resource_urn,json=resourceUrn,proto3" json:"resource_urn,omitempty"`
+	EventId       string                 `protobuf:"bytes,7,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Limit         uint32                 `protobuf:"varint,8,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFindingsRequest) Reset() {
+	*x = ListFindingsRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFindingsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFindingsRequest) ProtoMessage() {}
+
+func (x *ListFindingsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFindingsRequest.ProtoReflect.Descriptor instead.
+func (*ListFindingsRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *ListFindingsRequest) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetFindingId() string {
+	if x != nil {
+		return x.FindingId
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetSeverity() string {
+	if x != nil {
+		return x.Severity
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetResourceUrn() string {
+	if x != nil {
+		return x.ResourceUrn
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
 // Finding is the normalized persisted finding view for the first runtime evaluator slice.
 type Finding struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
@@ -2008,7 +2109,7 @@ type Finding struct {
 
 func (x *Finding) Reset() {
 	*x = Finding{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2020,7 +2121,7 @@ func (x *Finding) String() string {
 func (*Finding) ProtoMessage() {}
 
 func (x *Finding) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2033,7 +2134,7 @@ func (x *Finding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Finding.ProtoReflect.Descriptor instead.
 func (*Finding) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *Finding) GetId() string {
@@ -2134,18 +2235,64 @@ func (x *Finding) GetLastObservedAt() *timestamppb.Timestamp {
 	return nil
 }
 
-// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through the first built-in finding evaluator.
+// ListFindingsResponse returns the matched persisted findings.
+type ListFindingsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Findings      []*Finding             `protobuf:"bytes,1,rep,name=findings,proto3" json:"findings,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFindingsResponse) Reset() {
+	*x = ListFindingsResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFindingsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFindingsResponse) ProtoMessage() {}
+
+func (x *ListFindingsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFindingsResponse.ProtoReflect.Descriptor instead.
+func (*ListFindingsResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *ListFindingsResponse) GetFindings() []*Finding {
+	if x != nil {
+		return x.Findings
+	}
+	return nil
+}
+
+// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through one registered finding rule.
 type EvaluateSourceRuntimeFindingsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	EventLimit    uint32                 `protobuf:"varint,2,opt,name=event_limit,json=eventLimit,proto3" json:"event_limit,omitempty"`
+	RuleId        string                 `protobuf:"bytes,3,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EvaluateSourceRuntimeFindingsRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2157,7 +2304,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) String() string {
 func (*EvaluateSourceRuntimeFindingsRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2170,7 +2317,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *EvaluateSourceRuntimeFindingsRequest) GetId() string {
@@ -2187,7 +2334,14 @@ func (x *EvaluateSourceRuntimeFindingsRequest) GetEventLimit() uint32 {
 	return 0
 }
 
-// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, fixed rule spec, and persisted findings.
+func (x *EvaluateSourceRuntimeFindingsRequest) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, selected rule spec, and persisted findings.
 type EvaluateSourceRuntimeFindingsResponse struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	Runtime          *SourceRuntime         `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
@@ -2201,7 +2355,7 @@ type EvaluateSourceRuntimeFindingsResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingsResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2213,7 +2367,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) String() string {
 func (*EvaluateSourceRuntimeFindingsResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2226,7 +2380,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *EvaluateSourceRuntimeFindingsResponse) GetRuntime() *SourceRuntime {
@@ -2276,7 +2430,7 @@ type GraphEntity struct {
 
 func (x *GraphEntity) Reset() {
 	*x = GraphEntity{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2288,7 +2442,7 @@ func (x *GraphEntity) String() string {
 func (*GraphEntity) ProtoMessage() {}
 
 func (x *GraphEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2301,7 +2455,7 @@ func (x *GraphEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphEntity.ProtoReflect.Descriptor instead.
 func (*GraphEntity) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{37}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GraphEntity) GetUrn() string {
@@ -2337,7 +2491,7 @@ type GraphRelation struct {
 
 func (x *GraphRelation) Reset() {
 	*x = GraphRelation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2349,7 +2503,7 @@ func (x *GraphRelation) String() string {
 func (*GraphRelation) ProtoMessage() {}
 
 func (x *GraphRelation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2362,7 +2516,7 @@ func (x *GraphRelation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphRelation.ProtoReflect.Descriptor instead.
 func (*GraphRelation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{38}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GraphRelation) GetFromUrn() string {
@@ -2397,7 +2551,7 @@ type GetEntityNeighborhoodRequest struct {
 
 func (x *GetEntityNeighborhoodRequest) Reset() {
 	*x = GetEntityNeighborhoodRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2409,7 +2563,7 @@ func (x *GetEntityNeighborhoodRequest) String() string {
 func (*GetEntityNeighborhoodRequest) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2422,7 +2576,7 @@ func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodRequest.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{39}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetEntityNeighborhoodRequest) GetRootUrn() string {
@@ -2451,7 +2605,7 @@ type GetEntityNeighborhoodResponse struct {
 
 func (x *GetEntityNeighborhoodResponse) Reset() {
 	*x = GetEntityNeighborhoodResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2463,7 +2617,7 @@ func (x *GetEntityNeighborhoodResponse) String() string {
 func (*GetEntityNeighborhoodResponse) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2476,7 +2630,7 @@ func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodResponse.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{40}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *GetEntityNeighborhoodResponse) GetRoot() *GraphEntity {
@@ -2670,7 +2824,18 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x0fsource_event_id\x18\n" +
 	" \x01(\tR\rsourceEventId\"?\n" +
 	"\x12ListClaimsResponse\x12)\n" +
-	"\x06claims\x18\x01 \x03(\v2\x11.cerebro.v1.ClaimR\x06claims\"\xc8\x04\n" +
+	"\x06claims\x18\x01 \x03(\v2\x11.cerebro.v1.ClaimR\x06claims\"\xf4\x01\n" +
+	"\x13ListFindingsRequest\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12\x1d\n" +
+	"\n" +
+	"finding_id\x18\x02 \x01(\tR\tfindingId\x12\x17\n" +
+	"\arule_id\x18\x03 \x01(\tR\x06ruleId\x12\x1a\n" +
+	"\bseverity\x18\x04 \x01(\tR\bseverity\x12\x16\n" +
+	"\x06status\x18\x05 \x01(\tR\x06status\x12!\n" +
+	"\fresource_urn\x18\x06 \x01(\tR\vresourceUrn\x12\x19\n" +
+	"\bevent_id\x18\a \x01(\tR\aeventId\x12\x14\n" +
+	"\x05limit\x18\b \x01(\rR\x05limit\"\xc8\x04\n" +
 	"\aFinding\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12 \n" +
 	"\vfingerprint\x18\x02 \x01(\tR\vfingerprint\x12\x1b\n" +
@@ -2692,11 +2857,14 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x10last_observed_at\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\x0elastObservedAt\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"W\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"G\n" +
+	"\x14ListFindingsResponse\x12/\n" +
+	"\bfindings\x18\x01 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\"p\n" +
 	"$EvaluateSourceRuntimeFindingsRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vevent_limit\x18\x02 \x01(\rR\n" +
-	"eventLimit\"\x8f\x02\n" +
+	"eventLimit\x12\x17\n" +
+	"\arule_id\x18\x03 \x01(\tR\x06ruleId\"\x8f\x02\n" +
 	"%EvaluateSourceRuntimeFindingsResponse\x123\n" +
 	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\x12(\n" +
 	"\x04rule\x18\x02 \x01(\v2\x14.cerebro.v1.RuleSpecR\x04rule\x12)\n" +
@@ -2718,7 +2886,7 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x1dGetEntityNeighborhoodResponse\x12+\n" +
 	"\x04root\x18\x01 \x01(\v2\x17.cerebro.v1.GraphEntityR\x04root\x125\n" +
 	"\tneighbors\x18\x02 \x03(\v2\x17.cerebro.v1.GraphEntityR\tneighbors\x127\n" +
-	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\xb2\v\n" +
+	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\x85\f\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -2736,7 +2904,8 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x11SyncSourceRuntime\x12$.cerebro.v1.SyncSourceRuntimeRequest\x1a%.cerebro.v1.SyncSourceRuntimeResponse\x12N\n" +
 	"\vWriteClaims\x12\x1e.cerebro.v1.WriteClaimsRequest\x1a\x1f.cerebro.v1.WriteClaimsResponse\x12K\n" +
 	"\n" +
-	"ListClaims\x12\x1d.cerebro.v1.ListClaimsRequest\x1a\x1e.cerebro.v1.ListClaimsResponse\x12\x84\x01\n" +
+	"ListClaims\x12\x1d.cerebro.v1.ListClaimsRequest\x1a\x1e.cerebro.v1.ListClaimsResponse\x12Q\n" +
+	"\fListFindings\x12\x1f.cerebro.v1.ListFindingsRequest\x1a .cerebro.v1.ListFindingsResponse\x12\x84\x01\n" +
 	"\x1dEvaluateSourceRuntimeFindings\x120.cerebro.v1.EvaluateSourceRuntimeFindingsRequest\x1a1.cerebro.v1.EvaluateSourceRuntimeFindingsResponse\x12l\n" +
 	"\x15GetEntityNeighborhood\x12(.cerebro.v1.GetEntityNeighborhoodRequest\x1a).cerebro.v1.GetEntityNeighborhoodResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
 
@@ -2752,7 +2921,7 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 50)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*GetVersionRequest)(nil),                     // 0: cerebro.v1.GetVersionRequest
 	(*GetVersionResponse)(nil),                    // 1: cerebro.v1.GetVersionResponse
@@ -2788,113 +2957,118 @@ var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*WriteClaimsResponse)(nil),                   // 31: cerebro.v1.WriteClaimsResponse
 	(*ListClaimsRequest)(nil),                     // 32: cerebro.v1.ListClaimsRequest
 	(*ListClaimsResponse)(nil),                    // 33: cerebro.v1.ListClaimsResponse
-	(*Finding)(nil),                               // 34: cerebro.v1.Finding
-	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 35: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 36: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	(*GraphEntity)(nil),                           // 37: cerebro.v1.GraphEntity
-	(*GraphRelation)(nil),                         // 38: cerebro.v1.GraphRelation
-	(*GetEntityNeighborhoodRequest)(nil),          // 39: cerebro.v1.GetEntityNeighborhoodRequest
-	(*GetEntityNeighborhoodResponse)(nil),         // 40: cerebro.v1.GetEntityNeighborhoodResponse
-	nil,                                           // 41: cerebro.v1.ReportRun.ParametersEntry
-	nil,                                           // 42: cerebro.v1.RunReportRequest.ParametersEntry
-	nil,                                           // 43: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                                           // 44: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                                           // 45: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                                           // 46: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                                           // 47: cerebro.v1.Finding.AttributesEntry
-	(*timestamppb.Timestamp)(nil),                 // 48: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                       // 49: google.protobuf.Struct
-	(*SourceSpec)(nil),                            // 50: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),                          // 51: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                         // 52: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                        // 53: google.protobuf.Value
-	(*SourceCheckpoint)(nil),                      // 54: cerebro.v1.SourceCheckpoint
-	(*Claim)(nil),                                 // 55: cerebro.v1.Claim
-	(*RuleSpec)(nil),                              // 56: cerebro.v1.RuleSpec
+	(*ListFindingsRequest)(nil),                   // 34: cerebro.v1.ListFindingsRequest
+	(*Finding)(nil),                               // 35: cerebro.v1.Finding
+	(*ListFindingsResponse)(nil),                  // 36: cerebro.v1.ListFindingsResponse
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 37: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 38: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	(*GraphEntity)(nil),                           // 39: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                         // 40: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),          // 41: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),         // 42: cerebro.v1.GetEntityNeighborhoodResponse
+	nil,                                           // 43: cerebro.v1.ReportRun.ParametersEntry
+	nil,                                           // 44: cerebro.v1.RunReportRequest.ParametersEntry
+	nil,                                           // 45: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                           // 46: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                           // 47: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                           // 48: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                           // 49: cerebro.v1.Finding.AttributesEntry
+	(*timestamppb.Timestamp)(nil),                 // 50: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                       // 51: google.protobuf.Struct
+	(*SourceSpec)(nil),                            // 52: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                          // 53: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                         // 54: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                        // 55: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                      // 56: cerebro.v1.SourceCheckpoint
+	(*Claim)(nil),                                 // 57: cerebro.v1.Claim
+	(*RuleSpec)(nil),                              // 58: cerebro.v1.RuleSpec
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	48, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	50, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
 	5,  // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
-	41, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
-	48, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
-	49, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
+	43, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
+	50, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
+	51, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
 	6,  // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
-	42, // 7: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
+	44, // 7: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
 	6,  // 8: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
 	7,  // 9: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
 	7,  // 10: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
-	50, // 11: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	43, // 12: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	50, // 13: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	44, // 14: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	50, // 15: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	45, // 16: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	51, // 17: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	52, // 18: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	53, // 19: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	50, // 20: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	52, // 21: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	54, // 22: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	51, // 23: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	52, // 11: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	45, // 12: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	52, // 13: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	46, // 14: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	52, // 15: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	47, // 16: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	53, // 17: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	54, // 18: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	55, // 19: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	52, // 20: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	54, // 21: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	56, // 22: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	53, // 23: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
 	21, // 24: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	46, // 25: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	54, // 26: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	51, // 27: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	48, // 28: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	48, // 25: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	56, // 26: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	53, // 27: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	50, // 28: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
 	23, // 29: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
 	23, // 30: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	23, // 31: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	23, // 32: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	50, // 33: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	55, // 34: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	55, // 35: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
-	47, // 36: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	48, // 37: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	48, // 38: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	23, // 39: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	56, // 40: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	34, // 41: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	37, // 42: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	37, // 43: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	38, // 44: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	0,  // 45: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2,  // 46: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	8,  // 47: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	10, // 48: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	12, // 49: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	14, // 50: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	16, // 51: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	18, // 52: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	20, // 53: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	24, // 54: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	26, // 55: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	28, // 56: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	30, // 57: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	32, // 58: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
-	35, // 59: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	39, // 60: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	1,  // 61: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4,  // 62: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	9,  // 63: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	11, // 64: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	13, // 65: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	15, // 66: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	17, // 67: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	19, // 68: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	22, // 69: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	25, // 70: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	27, // 71: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	29, // 72: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	31, // 73: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	33, // 74: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
-	36, // 75: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	40, // 76: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	61, // [61:77] is the sub-list for method output_type
-	45, // [45:61] is the sub-list for method input_type
-	45, // [45:45] is the sub-list for extension type_name
-	45, // [45:45] is the sub-list for extension extendee
-	0,  // [0:45] is the sub-list for field type_name
+	52, // 33: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	57, // 34: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	57, // 35: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	49, // 36: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	50, // 37: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	50, // 38: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	35, // 39: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	23, // 40: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	58, // 41: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	35, // 42: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	39, // 43: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	39, // 44: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	40, // 45: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	0,  // 46: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 47: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	8,  // 48: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	10, // 49: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	12, // 50: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	14, // 51: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	16, // 52: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	18, // 53: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	20, // 54: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	24, // 55: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	26, // 56: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	28, // 57: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	30, // 58: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	32, // 59: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	34, // 60: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
+	37, // 61: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	41, // 62: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	1,  // 63: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 64: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	9,  // 65: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	11, // 66: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	13, // 67: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	15, // 68: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	17, // 69: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	19, // 70: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	22, // 71: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	25, // 72: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	27, // 73: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	29, // 74: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	31, // 75: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	33, // 76: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	36, // 77: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
+	38, // 78: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	42, // 79: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	63, // [63:80] is the sub-list for method output_type
+	46, // [46:63] is the sub-list for method input_type
+	46, // [46:46] is the sub-list for extension type_name
+	46, // [46:46] is the sub-list for extension extendee
+	0,  // [0:46] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -2910,7 +3084,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   48,
+			NumMessages:   50,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -75,6 +75,9 @@ const (
 	// BootstrapServiceListClaimsProcedure is the fully-qualified name of the BootstrapService's
 	// ListClaims RPC.
 	BootstrapServiceListClaimsProcedure = "/cerebro.v1.BootstrapService/ListClaims"
+	// BootstrapServiceListFindingsProcedure is the fully-qualified name of the BootstrapService's
+	// ListFindings RPC.
+	BootstrapServiceListFindingsProcedure = "/cerebro.v1.BootstrapService/ListFindings"
 	// BootstrapServiceEvaluateSourceRuntimeFindingsProcedure is the fully-qualified name of the
 	// BootstrapService's EvaluateSourceRuntimeFindings RPC.
 	BootstrapServiceEvaluateSourceRuntimeFindingsProcedure = "/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindings"
@@ -99,6 +102,7 @@ type BootstrapServiceClient interface {
 	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
 	WriteClaims(context.Context, *connect.Request[v1.WriteClaimsRequest]) (*connect.Response[v1.WriteClaimsResponse], error)
 	ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error)
+	ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
@@ -198,6 +202,12 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("ListClaims")),
 			connect.WithClientOptions(opts...),
 		),
+		listFindings: connect.NewClient[v1.ListFindingsRequest, v1.ListFindingsResponse](
+			httpClient,
+			baseURL+BootstrapServiceListFindingsProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("ListFindings")),
+			connect.WithClientOptions(opts...),
+		),
 		evaluateSourceRuntimeFindings: connect.NewClient[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse](
 			httpClient,
 			baseURL+BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
@@ -229,6 +239,7 @@ type bootstrapServiceClient struct {
 	syncSourceRuntime             *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
 	writeClaims                   *connect.Client[v1.WriteClaimsRequest, v1.WriteClaimsResponse]
 	listClaims                    *connect.Client[v1.ListClaimsRequest, v1.ListClaimsResponse]
+	listFindings                  *connect.Client[v1.ListFindingsRequest, v1.ListFindingsResponse]
 	evaluateSourceRuntimeFindings *connect.Client[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse]
 	getEntityNeighborhood         *connect.Client[v1.GetEntityNeighborhoodRequest, v1.GetEntityNeighborhoodResponse]
 }
@@ -303,6 +314,11 @@ func (c *bootstrapServiceClient) ListClaims(ctx context.Context, req *connect.Re
 	return c.listClaims.CallUnary(ctx, req)
 }
 
+// ListFindings calls cerebro.v1.BootstrapService.ListFindings.
+func (c *bootstrapServiceClient) ListFindings(ctx context.Context, req *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error) {
+	return c.listFindings.CallUnary(ctx, req)
+}
+
 // EvaluateSourceRuntimeFindings calls cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings.
 func (c *bootstrapServiceClient) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {
 	return c.evaluateSourceRuntimeFindings.CallUnary(ctx, req)
@@ -329,6 +345,7 @@ type BootstrapServiceHandler interface {
 	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
 	WriteClaims(context.Context, *connect.Request[v1.WriteClaimsRequest]) (*connect.Response[v1.WriteClaimsResponse], error)
 	ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error)
+	ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
@@ -424,6 +441,12 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		connect.WithSchema(bootstrapServiceMethods.ByName("ListClaims")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bootstrapServiceListFindingsHandler := connect.NewUnaryHandler(
+		BootstrapServiceListFindingsProcedure,
+		svc.ListFindings,
+		connect.WithSchema(bootstrapServiceMethods.ByName("ListFindings")),
+		connect.WithHandlerOptions(opts...),
+	)
 	bootstrapServiceEvaluateSourceRuntimeFindingsHandler := connect.NewUnaryHandler(
 		BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
 		svc.EvaluateSourceRuntimeFindings,
@@ -466,6 +489,8 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceWriteClaimsHandler.ServeHTTP(w, r)
 		case BootstrapServiceListClaimsProcedure:
 			bootstrapServiceListClaimsHandler.ServeHTTP(w, r)
+		case BootstrapServiceListFindingsProcedure:
+			bootstrapServiceListFindingsHandler.ServeHTTP(w, r)
 		case BootstrapServiceEvaluateSourceRuntimeFindingsProcedure:
 			bootstrapServiceEvaluateSourceRuntimeFindingsHandler.ServeHTTP(w, r)
 		case BootstrapServiceGetEntityNeighborhoodProcedure:
@@ -533,6 +558,10 @@ func (UnimplementedBootstrapServiceHandler) WriteClaims(context.Context, *connec
 
 func (UnimplementedBootstrapServiceHandler) ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListClaims is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListFindings is not implemented"))
 }
 
 func (UnimplementedBootstrapServiceHandler) EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -72,6 +72,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/sync", app.handleSyncSourceRuntime)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/claims", app.handleListClaims)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/claims", app.handleWriteClaims)
+	mux.HandleFunc("GET /source-runtimes/{runtimeID}/findings", app.handleListFindings)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/findings/evaluate", app.handleEvaluateSourceRuntimeFindings)
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
@@ -327,6 +328,7 @@ func (a *App) handleWriteClaims(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http.Request) {
 	request := &cerebrov1.EvaluateSourceRuntimeFindingsRequest{}
+	request.RuleId = r.URL.Query().Get("rule_id")
 	if eventLimit := r.URL.Query().Get("event_limit"); eventLimit != "" {
 		body := []byte(`{"event_limit":` + eventLimit + `}`)
 		if err := protojson.Unmarshal(body, request); err != nil {
@@ -335,8 +337,10 @@ func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http
 		}
 	}
 	request.Id = r.PathValue("runtimeID")
+	request.RuleId = r.URL.Query().Get("rule_id")
 	response, err := a.findingService().EvaluateSourceRuntime(r.Context(), findings.EvaluateRequest{
 		RuntimeID:  request.GetId(),
+		RuleID:     request.GetRuleId(),
 		EventLimit: request.GetEventLimit(),
 	})
 	if err != nil {
@@ -344,6 +348,47 @@ func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, findingResponse(response))
+}
+
+func (a *App) handleListFindings(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.ListFindingsRequest{
+		RuntimeId:   r.PathValue("runtimeID"),
+		FindingId:   r.URL.Query().Get("finding_id"),
+		RuleId:      r.URL.Query().Get("rule_id"),
+		Severity:    r.URL.Query().Get("severity"),
+		Status:      r.URL.Query().Get("status"),
+		ResourceUrn: r.URL.Query().Get("resource_urn"),
+		EventId:     r.URL.Query().Get("event_id"),
+	}
+	if limit := r.URL.Query().Get("limit"); limit != "" {
+		body := []byte(`{"limit":` + limit + `}`)
+		if err := protojson.Unmarshal(body, request); err != nil {
+			writeFindingError(w, err)
+			return
+		}
+		request.RuntimeId = r.PathValue("runtimeID")
+		request.FindingId = r.URL.Query().Get("finding_id")
+		request.RuleId = r.URL.Query().Get("rule_id")
+		request.Severity = r.URL.Query().Get("severity")
+		request.Status = r.URL.Query().Get("status")
+		request.ResourceUrn = r.URL.Query().Get("resource_urn")
+		request.EventId = r.URL.Query().Get("event_id")
+	}
+	response, err := a.findingService().ListFindings(r.Context(), findings.ListRequest{
+		RuntimeID:   request.GetRuntimeId(),
+		FindingID:   request.GetFindingId(),
+		RuleID:      request.GetRuleId(),
+		Severity:    request.GetSeverity(),
+		Status:      request.GetStatus(),
+		ResourceURN: request.GetResourceUrn(),
+		EventID:     request.GetEventId(),
+		Limit:       request.GetLimit(),
+	})
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, listFindingsResponse(response))
 }
 
 func (s *bootstrapService) GetVersion(_ context.Context, _ *connect.Request[cerebrov1.GetVersionRequest]) (*connect.Response[cerebrov1.GetVersionResponse], error) {
@@ -507,6 +552,27 @@ func (s *bootstrapService) ListClaims(ctx context.Context, req *connect.Request[
 	}), nil
 }
 
+func (s *bootstrapService) ListFindings(ctx context.Context, req *connect.Request[cerebrov1.ListFindingsRequest]) (*connect.Response[cerebrov1.ListFindingsResponse], error) {
+	response, err := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+	).ListFindings(ctx, findings.ListRequest{
+		RuntimeID:   req.Msg.GetRuntimeId(),
+		FindingID:   req.Msg.GetFindingId(),
+		RuleID:      req.Msg.GetRuleId(),
+		Severity:    req.Msg.GetSeverity(),
+		Status:      req.Msg.GetStatus(),
+		ResourceURN: req.Msg.GetResourceUrn(),
+		EventID:     req.Msg.GetEventId(),
+		Limit:       req.Msg.GetLimit(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(listFindingsResponse(response)), nil
+}
+
 func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingsResponse], error) {
 	response, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -514,6 +580,7 @@ func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, re
 		findingStore(s.deps.StateStore),
 	).EvaluateSourceRuntime(ctx, findings.EvaluateRequest{
 		RuntimeID:  req.Msg.GetId(),
+		RuleID:     req.Msg.GetRuleId(),
 		EventLimit: req.Msg.GetEventLimit(),
 	})
 	if err != nil {
@@ -665,6 +732,8 @@ func writeFindingError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
 		statusCode = http.StatusNotFound
+	case errors.Is(err, findings.ErrRuleNotFound):
+		statusCode = http.StatusNotFound
 	case errors.Is(err, findings.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable
 	}
@@ -775,12 +844,26 @@ func findingResponse(result *findings.EvaluateResult) *cerebrov1.EvaluateSourceR
 		Rule:             result.Rule,
 		EventsEvaluated:  result.EventsEvaluated,
 		FindingsUpserted: uint32(len(result.Findings)),
-		Findings:         make([]*cerebrov1.Finding, 0, len(result.Findings)),
-	}
-	for _, finding := range result.Findings {
-		response.Findings = append(response.Findings, findingMessage(finding))
+		Findings:         findingMessages(result.Findings),
 	}
 	return response
+}
+
+func listFindingsResponse(result *findings.ListResult) *cerebrov1.ListFindingsResponse {
+	if result == nil {
+		return &cerebrov1.ListFindingsResponse{}
+	}
+	return &cerebrov1.ListFindingsResponse{
+		Findings: findingMessages(result.Findings),
+	}
+}
+
+func findingMessages(findings []*ports.FindingRecord) []*cerebrov1.Finding {
+	messages := make([]*cerebrov1.Finding, 0, len(findings))
+	for _, finding := range findings {
+		messages = append(messages, findingMessage(finding))
+	}
+	return messages
 }
 
 func findingMessage(finding *ports.FindingRecord) *cerebrov1.Finding {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -254,14 +254,15 @@ func (a *App) handleSyncSourceRuntime(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleListClaims(w http.ResponseWriter, r *http.Request) {
 	request := &cerebrov1.ListClaimsRequest{
-		RuntimeId:   r.PathValue("runtimeID"),
-		ClaimId:     r.URL.Query().Get("claim_id"),
-		SubjectUrn:  r.URL.Query().Get("subject_urn"),
-		Predicate:   r.URL.Query().Get("predicate"),
-		ObjectUrn:   r.URL.Query().Get("object_urn"),
-		ObjectValue: r.URL.Query().Get("object_value"),
-		ClaimType:   r.URL.Query().Get("claim_type"),
-		Status:      r.URL.Query().Get("status"),
+		RuntimeId:     r.PathValue("runtimeID"),
+		ClaimId:       r.URL.Query().Get("claim_id"),
+		SubjectUrn:    r.URL.Query().Get("subject_urn"),
+		Predicate:     r.URL.Query().Get("predicate"),
+		ObjectUrn:     r.URL.Query().Get("object_urn"),
+		ObjectValue:   r.URL.Query().Get("object_value"),
+		ClaimType:     r.URL.Query().Get("claim_type"),
+		Status:        r.URL.Query().Get("status"),
+		SourceEventId: r.URL.Query().Get("source_event_id"),
 	}
 	if limit := r.URL.Query().Get("limit"); limit != "" {
 		body := []byte(`{"limit":` + limit + `}`)
@@ -277,17 +278,19 @@ func (a *App) handleListClaims(w http.ResponseWriter, r *http.Request) {
 		request.ObjectValue = r.URL.Query().Get("object_value")
 		request.ClaimType = r.URL.Query().Get("claim_type")
 		request.Status = r.URL.Query().Get("status")
+		request.SourceEventId = r.URL.Query().Get("source_event_id")
 	}
 	response, err := a.claimService().ListClaims(r.Context(), claims.ListRequest{
-		RuntimeID:   request.GetRuntimeId(),
-		ClaimID:     request.GetClaimId(),
-		SubjectURN:  request.GetSubjectUrn(),
-		Predicate:   request.GetPredicate(),
-		ObjectURN:   request.GetObjectUrn(),
-		ObjectValue: request.GetObjectValue(),
-		ClaimType:   request.GetClaimType(),
-		Status:      request.GetStatus(),
-		Limit:       request.GetLimit(),
+		RuntimeID:     request.GetRuntimeId(),
+		ClaimID:       request.GetClaimId(),
+		SubjectURN:    request.GetSubjectUrn(),
+		Predicate:     request.GetPredicate(),
+		ObjectURN:     request.GetObjectUrn(),
+		ObjectValue:   request.GetObjectValue(),
+		ClaimType:     request.GetClaimType(),
+		Status:        request.GetStatus(),
+		SourceEventID: request.GetSourceEventId(),
+		Limit:         request.GetLimit(),
 	})
 	if err != nil {
 		writeClaimError(w, err)
@@ -306,8 +309,9 @@ func (a *App) handleWriteClaims(w http.ResponseWriter, r *http.Request) {
 	}
 	request.RuntimeId = r.PathValue("runtimeID")
 	response, err := a.claimService().WriteClaims(r.Context(), claims.WriteRequest{
-		RuntimeID: request.GetRuntimeId(),
-		Claims:    request.GetClaims(),
+		RuntimeID:       request.GetRuntimeId(),
+		Claims:          request.GetClaims(),
+		ReplaceExisting: request.GetReplaceExisting(),
 	})
 	if err != nil {
 		writeClaimError(w, err)
@@ -317,6 +321,7 @@ func (a *App) handleWriteClaims(w http.ResponseWriter, r *http.Request) {
 		ClaimsWritten:          response.ClaimsWritten,
 		EntitiesUpserted:       response.EntitiesUpserted,
 		RelationLinksProjected: response.RelationLinksProjected,
+		ClaimsRetracted:        response.ClaimsRetracted,
 	})
 }
 
@@ -461,8 +466,9 @@ func (s *bootstrapService) WriteClaims(ctx context.Context, req *connect.Request
 		sourceProjectionStateStore(s.deps.StateStore),
 		sourceProjectionGraphStore(s.deps.GraphStore),
 	).WriteClaims(ctx, claims.WriteRequest{
-		RuntimeID: req.Msg.GetRuntimeId(),
-		Claims:    req.Msg.GetClaims(),
+		RuntimeID:       req.Msg.GetRuntimeId(),
+		Claims:          req.Msg.GetClaims(),
+		ReplaceExisting: req.Msg.GetReplaceExisting(),
 	})
 	if err != nil {
 		return nil, err
@@ -471,6 +477,7 @@ func (s *bootstrapService) WriteClaims(ctx context.Context, req *connect.Request
 		ClaimsWritten:          response.ClaimsWritten,
 		EntitiesUpserted:       response.EntitiesUpserted,
 		RelationLinksProjected: response.RelationLinksProjected,
+		ClaimsRetracted:        response.ClaimsRetracted,
 	}), nil
 }
 
@@ -481,15 +488,16 @@ func (s *bootstrapService) ListClaims(ctx context.Context, req *connect.Request[
 		sourceProjectionStateStore(s.deps.StateStore),
 		sourceProjectionGraphStore(s.deps.GraphStore),
 	).ListClaims(ctx, claims.ListRequest{
-		RuntimeID:   req.Msg.GetRuntimeId(),
-		ClaimID:     req.Msg.GetClaimId(),
-		SubjectURN:  req.Msg.GetSubjectUrn(),
-		Predicate:   req.Msg.GetPredicate(),
-		ObjectURN:   req.Msg.GetObjectUrn(),
-		ObjectValue: req.Msg.GetObjectValue(),
-		ClaimType:   req.Msg.GetClaimType(),
-		Status:      req.Msg.GetStatus(),
-		Limit:       req.Msg.GetLimit(),
+		RuntimeID:     req.Msg.GetRuntimeId(),
+		ClaimID:       req.Msg.GetClaimId(),
+		SubjectURN:    req.Msg.GetSubjectUrn(),
+		Predicate:     req.Msg.GetPredicate(),
+		ObjectURN:     req.Msg.GetObjectUrn(),
+		ObjectValue:   req.Msg.GetObjectValue(),
+		ClaimType:     req.Msg.GetClaimType(),
+		Status:        req.Msg.GetStatus(),
+		SourceEventID: req.Msg.GetSourceEventId(),
+		Limit:         req.Msg.GetLimit(),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -959,7 +959,7 @@ func TestClaimEndpoints(t *testing.T) {
 		t.Fatalf("len(graphStore.links) = %d, want 1", len(graphStore.links))
 	}
 
-	listResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-jira/claims?predicate=assigned_to&limit=1")
+	listResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-jira/claims?predicate=assigned_to&source_event_id=jira-event-1&limit=1")
 	if err != nil {
 		t.Fatalf("GET /source-runtimes/{id}/claims error = %v", err)
 	}
@@ -985,10 +985,11 @@ func TestClaimEndpoints(t *testing.T) {
 	}
 
 	listClaimsResp, err := client.ListClaims(context.Background(), connect.NewRequest(&cerebrov1.ListClaimsRequest{
-		RuntimeId:   "writer-jira",
-		Predicate:   "status",
-		ObjectValue: "in_progress",
-		Limit:       1,
+		RuntimeId:     "writer-jira",
+		Predicate:     "status",
+		ObjectValue:   "in_progress",
+		SourceEventId: "jira-event-1",
+		Limit:         1,
 	}))
 	if err != nil {
 		t.Fatalf("ListClaims() error = %v", err)
@@ -1004,6 +1005,100 @@ func TestClaimEndpoints(t *testing.T) {
 	}
 	if got := runtimeStore.claimListRequest.ObjectValue; got != "in_progress" {
 		t.Fatalf("runtimeStore.claimListRequest.ObjectValue = %q, want in_progress", got)
+	}
+	if got := runtimeStore.claimListRequest.SourceEventID; got != "jira-event-1" {
+		t.Fatalf("runtimeStore.claimListRequest.SourceEventID = %q, want jira-event-1", got)
+	}
+}
+
+func TestWriteClaimsReplaceExistingReportsRetractedClaims(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	runtimeStore := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-jira": {
+				Id:       "writer-jira",
+				SourceId: "sdk",
+				TenantId: "writer",
+				Config:   map[string]string{"integration": "jira"},
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  &recordingAppendLog{},
+		StateStore: runtimeStore,
+	}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	issueURN := "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123"
+	userURN := "urn:cerebro:writer:runtime:writer-jira:user:acct:42"
+	if _, err := client.WriteClaims(context.Background(), connect.NewRequest(&cerebrov1.WriteClaimsRequest{
+		RuntimeId: "writer-jira",
+		Claims: []*cerebrov1.Claim{
+			{
+				SubjectRef:    &cerebrov1.EntityRef{Urn: issueURN, EntityType: "ticket", Label: "ENG-123"},
+				Predicate:     "status",
+				ObjectValue:   "in_progress",
+				ClaimType:     "attribute",
+				SourceEventId: "jira-event-1",
+			},
+			{
+				SubjectRef:    &cerebrov1.EntityRef{Urn: issueURN, EntityType: "ticket", Label: "ENG-123"},
+				Predicate:     "assigned_to",
+				ObjectRef:     &cerebrov1.EntityRef{Urn: userURN, EntityType: "user", Label: "Alice"},
+				ClaimType:     "relation",
+				SourceEventId: "jira-event-1",
+			},
+		},
+	})); err != nil {
+		t.Fatalf("seed WriteClaims() error = %v", err)
+	}
+
+	resp, err := client.WriteClaims(context.Background(), connect.NewRequest(&cerebrov1.WriteClaimsRequest{
+		RuntimeId:       "writer-jira",
+		ReplaceExisting: true,
+		Claims: []*cerebrov1.Claim{
+			{
+				SubjectRef:    &cerebrov1.EntityRef{Urn: issueURN, EntityType: "ticket", Label: "ENG-123"},
+				Predicate:     "status",
+				ObjectValue:   "done",
+				ClaimType:     "attribute",
+				SourceEventId: "jira-event-2",
+				ObservedAt:    timestamppb.New(time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)),
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("replace WriteClaims() error = %v", err)
+	}
+	if got := resp.Msg.GetClaimsWritten(); got != 1 {
+		t.Fatalf("replace claims_written = %d, want 1", got)
+	}
+	if got := resp.Msg.GetClaimsRetracted(); got != 1 {
+		t.Fatalf("replace claims_retracted = %d, want 1", got)
+	}
+	if len(runtimeStore.claims) != 2 {
+		t.Fatalf("len(runtimeStore.claims) = %d, want 2", len(runtimeStore.claims))
+	}
+	var retracted *ports.ClaimRecord
+	for _, claim := range runtimeStore.claims {
+		if claim != nil && claim.Predicate == "assigned_to" {
+			retracted = claim
+			break
+		}
+	}
+	if retracted == nil {
+		t.Fatal("retracted assigned_to claim = nil, want non-nil")
+	}
+	if got := retracted.Status; got != "retracted" {
+		t.Fatalf("retracted claim status = %q, want retracted", got)
+	}
+	if got := retracted.SourceEventID; got != "jira-event-2" {
+		t.Fatalf("retracted claim source_event_id = %q, want jira-event-2", got)
 	}
 }
 
@@ -1406,6 +1501,9 @@ func claimMatches(request ports.ListClaimsRequest, claim *ports.ClaimRecord) boo
 		return false
 	}
 	if request.Status != "" && strings.TrimSpace(claim.Status) != strings.TrimSpace(request.Status) {
+		return false
+	}
+	if request.SourceEventID != "" && strings.TrimSpace(claim.SourceEventID) != strings.TrimSpace(request.SourceEventID) {
 		return false
 	}
 	return true

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -82,14 +82,15 @@ func (s *recordingAppendLog) Replay(_ context.Context, request ports.ReplayReque
 }
 
 type stubRuntimeStore struct {
-	err              error
-	runtimes         map[string]*cerebrov1.SourceRuntime
-	entities         map[string]*ports.ProjectedEntity
-	links            map[string]*ports.ProjectedLink
-	claims           map[string]*ports.ClaimRecord
-	claimListRequest ports.ListClaimsRequest
-	findings         map[string]*ports.FindingRecord
-	reportRuns       map[string]*cerebrov1.ReportRun
+	err                error
+	runtimes           map[string]*cerebrov1.SourceRuntime
+	entities           map[string]*ports.ProjectedEntity
+	links              map[string]*ports.ProjectedLink
+	claims             map[string]*ports.ClaimRecord
+	claimListRequest   ports.ListClaimsRequest
+	findings           map[string]*ports.FindingRecord
+	findingListRequest ports.ListFindingsRequest
+	reportRuns         map[string]*cerebrov1.ReportRun
 }
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
@@ -208,12 +209,30 @@ func (s *stubRuntimeStore) ListFindings(_ context.Context, request ports.ListFin
 	if s.err != nil {
 		return nil, s.err
 	}
+	s.findingListRequest = request
 	findings := []*ports.FindingRecord{}
 	for _, finding := range s.findings {
-		if finding == nil || finding.RuntimeID != request.RuntimeID {
+		if !findingMatches(request, finding) {
 			continue
 		}
 		findings = append(findings, cloneFinding(finding))
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		left := findings[i]
+		right := findings[j]
+		switch {
+		case left.LastObservedAt.Equal(right.LastObservedAt):
+			return left.ID < right.ID
+		case left.LastObservedAt.IsZero():
+			return false
+		case right.LastObservedAt.IsZero():
+			return true
+		default:
+			return left.LastObservedAt.After(right.LastObservedAt)
+		}
+	})
+	if request.Limit != 0 && len(findings) > int(request.Limit) {
+		findings = findings[:int(request.Limit)]
 	}
 	return findings, nil
 }
@@ -775,7 +794,7 @@ func TestFindingEndpoints(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	evaluateReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?event_limit=2", nil)
+	evaluateReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?event_limit=2&rule_id=identity-okta-policy-rule-lifecycle-tampering", nil)
 	if err != nil {
 		t.Fatalf("new evaluate findings request: %v", err)
 	}
@@ -812,10 +831,47 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := findingPayload["summary"]; got != "admin@writer.com performed policy.rule.update on pol-1" {
 		t.Fatalf("evaluate finding summary = %#v, want admin summary", got)
 	}
+	listResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-okta-audit/findings?rule_id=identity-okta-policy-rule-lifecycle-tampering&status=open&event_id=okta-audit-2&limit=1")
+	if err != nil {
+		t.Fatalf("GET /source-runtimes/{id}/findings error = %v", err)
+	}
+	defer func() {
+		if closeErr := listResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close list findings response body: %v", closeErr)
+		}
+	}()
+	var listPayload map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&listPayload); err != nil {
+		t.Fatalf("decode list findings response: %v", err)
+	}
+	listedFindings, ok := listPayload["findings"].([]any)
+	if !ok || len(listedFindings) != 1 {
+		t.Fatalf("list findings payload = %#v, want 1 entry", listPayload["findings"])
+	}
+	listedFinding, ok := listedFindings[0].(map[string]any)
+	if !ok {
+		t.Fatalf("list findings entry = %#v, want object", listedFindings[0])
+	}
+	if got := listedFinding["rule_id"]; got != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("list finding rule_id = %#v, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	missingRuleResp, err := server.Client().Post(server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?rule_id=does-not-exist", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/findings/evaluate unknown rule error = %v", err)
+	}
+	defer func() {
+		if closeErr := missingRuleResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close unknown rule response body: %v", closeErr)
+		}
+	}()
+	if got := missingRuleResp.StatusCode; got != http.StatusNotFound {
+		t.Fatalf("unknown rule status = %d, want %d", got, http.StatusNotFound)
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	evaluateFindingsResp, err := client.EvaluateSourceRuntimeFindings(context.Background(), connect.NewRequest(&cerebrov1.EvaluateSourceRuntimeFindingsRequest{
 		Id:         "writer-okta-audit",
+		RuleId:     "identity-okta-policy-rule-lifecycle-tampering",
 		EventLimit: 5,
 	}))
 	if err != nil {
@@ -832,6 +888,33 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := evaluateFindingsResp.Msg.GetRule().GetId(); got != "identity-okta-policy-rule-lifecycle-tampering" {
 		t.Fatalf("EvaluateSourceRuntimeFindings rule id = %q, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	listFindingsResp, err := client.ListFindings(context.Background(), connect.NewRequest(&cerebrov1.ListFindingsRequest{
+		RuntimeId:   "writer-okta-audit",
+		RuleId:      "identity-okta-policy-rule-lifecycle-tampering",
+		Severity:    "HIGH",
+		Status:      "open",
+		ResourceUrn: "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+		EventId:     "okta-audit-2",
+		Limit:       1,
+	}))
+	if err != nil {
+		t.Fatalf("ListFindings() error = %v", err)
+	}
+	if got := len(listFindingsResp.Msg.GetFindings()); got != 1 {
+		t.Fatalf("len(ListFindings().Findings) = %d, want 1", got)
+	}
+	if got := listFindingsResp.Msg.GetFindings()[0].GetId(); got == "" {
+		t.Fatal("ListFindings().Findings[0].ID = empty, want non-empty")
+	}
+	if got := runtimeStore.findingListRequest.RuleID; got != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("runtimeStore.findingListRequest.RuleID = %q, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	if got := runtimeStore.findingListRequest.ResourceURN; got != "urn:cerebro:writer:okta_resource:policyrule:pol-1" {
+		t.Fatalf("runtimeStore.findingListRequest.ResourceURN = %q, want policy rule urn", got)
+	}
+	if got := runtimeStore.findingListRequest.EventID; got != "okta-audit-2" {
+		t.Fatalf("runtimeStore.findingListRequest.EventID = %q, want okta-audit-2", got)
 	}
 	if len(runtimeStore.findings) != 1 {
 		t.Fatalf("len(runtimeStore.findings) = %d, want 1", len(runtimeStore.findings))
@@ -1447,6 +1530,34 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 	}
 }
 
+func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRecord) bool {
+	if finding == nil {
+		return false
+	}
+	if strings.TrimSpace(finding.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+		return false
+	}
+	if request.FindingID != "" && strings.TrimSpace(finding.ID) != strings.TrimSpace(request.FindingID) {
+		return false
+	}
+	if request.RuleID != "" && strings.TrimSpace(finding.RuleID) != strings.TrimSpace(request.RuleID) {
+		return false
+	}
+	if request.Severity != "" && strings.TrimSpace(finding.Severity) != strings.TrimSpace(request.Severity) {
+		return false
+	}
+	if request.Status != "" && strings.TrimSpace(finding.Status) != strings.TrimSpace(request.Status) {
+		return false
+	}
+	if request.ResourceURN != "" && !containsTrimmed(finding.ResourceURNs, request.ResourceURN) {
+		return false
+	}
+	if request.EventID != "" && !containsTrimmed(finding.EventIDs, request.EventID) {
+		return false
+	}
+	return true
+}
+
 func cloneClaim(claim *ports.ClaimRecord) *ports.ClaimRecord {
 	if claim == nil {
 		return nil
@@ -1507,6 +1618,16 @@ func claimMatches(request ports.ListClaimsRequest, claim *ports.ClaimRecord) boo
 		return false
 	}
 	return true
+}
+
+func containsTrimmed(values []string, expected string) bool {
+	trimmedExpected := strings.TrimSpace(expected)
+	for _, value := range values {
+		if strings.TrimSpace(value) == trimmedExpected {
+			return true
+		}
+	}
+	return false
 }
 
 func cloneReportRun(run *cerebrov1.ReportRun) *cerebrov1.ReportRun {

--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -22,6 +22,7 @@ const (
 	claimTypeRelation       = "relation"
 	claimTypeClassification = "classification"
 	claimStatusAsserted     = "asserted"
+	claimStatusRetracted    = "retracted"
 )
 
 // ErrRuntimeUnavailable indicates that the runtime or claim store boundary is unavailable.
@@ -37,8 +38,9 @@ type Service struct {
 
 // WriteRequest scopes one runtime-scoped claim batch.
 type WriteRequest struct {
-	RuntimeID string
-	Claims    []*cerebrov1.Claim
+	RuntimeID       string
+	Claims          []*cerebrov1.Claim
+	ReplaceExisting bool
 }
 
 // WriteResult reports one claim batch write.
@@ -46,19 +48,21 @@ type WriteResult struct {
 	ClaimsWritten          uint32
 	EntitiesUpserted       uint32
 	RelationLinksProjected uint32
+	ClaimsRetracted        uint32
 }
 
 // ListRequest scopes one runtime-scoped claim query.
 type ListRequest struct {
-	RuntimeID   string
-	ClaimID     string
-	SubjectURN  string
-	Predicate   string
-	ObjectURN   string
-	ObjectValue string
-	ClaimType   string
-	Status      string
-	Limit       uint32
+	RuntimeID     string
+	ClaimID       string
+	SubjectURN    string
+	Predicate     string
+	ObjectURN     string
+	ObjectValue   string
+	ClaimType     string
+	Status        string
+	SourceEventID string
+	Limit         uint32
 }
 
 // ListResult reports one runtime-scoped claim query.
@@ -92,11 +96,15 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 	result := &WriteResult{}
 	upsertedEntities := make(map[string]struct{})
 	upsertedLinks := make(map[string]struct{})
+	normalizedClaims := make([]*cerebrov1.Claim, 0, len(request.Claims))
 	for index, raw := range request.Claims {
 		claim, err := normalizeClaim(raw, runtime)
 		if err != nil {
 			return nil, fmt.Errorf("normalize claim %d: %w", index, err)
 		}
+		normalizedClaims = append(normalizedClaims, claim)
+	}
+	for _, claim := range normalizedClaims {
 		if entity := projectedEntity(runtime, claim.GetSubjectRef(), claim.GetSubjectUrn()); entity != nil {
 			wrote, err := s.upsertEntity(ctx, entity, upsertedEntities)
 			if err != nil {
@@ -129,6 +137,13 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 		}
 		result.ClaimsWritten++
 	}
+	if request.ReplaceExisting {
+		retracted, err := s.retractMissingClaims(ctx, runtimeID, normalizedClaims)
+		if err != nil {
+			return nil, err
+		}
+		result.ClaimsRetracted = retracted
+	}
 	return result, nil
 }
 
@@ -145,15 +160,16 @@ func (s *Service) ListClaims(ctx context.Context, request ListRequest) (*ListRes
 		return nil, err
 	}
 	records, err := s.store.ListClaims(ctx, ports.ListClaimsRequest{
-		RuntimeID:   runtimeID,
-		ClaimID:     strings.TrimSpace(request.ClaimID),
-		SubjectURN:  strings.TrimSpace(request.SubjectURN),
-		Predicate:   strings.TrimSpace(request.Predicate),
-		ObjectURN:   strings.TrimSpace(request.ObjectURN),
-		ObjectValue: strings.TrimSpace(request.ObjectValue),
-		ClaimType:   strings.TrimSpace(request.ClaimType),
-		Status:      strings.TrimSpace(request.Status),
-		Limit:       request.Limit,
+		RuntimeID:     runtimeID,
+		ClaimID:       strings.TrimSpace(request.ClaimID),
+		SubjectURN:    strings.TrimSpace(request.SubjectURN),
+		Predicate:     strings.TrimSpace(request.Predicate),
+		ObjectURN:     strings.TrimSpace(request.ObjectURN),
+		ObjectValue:   strings.TrimSpace(request.ObjectValue),
+		ClaimType:     strings.TrimSpace(request.ClaimType),
+		Status:        strings.TrimSpace(request.Status),
+		SourceEventID: strings.TrimSpace(request.SourceEventID),
+		Limit:         request.Limit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list claims for runtime %q: %w", runtimeID, err)
@@ -166,6 +182,105 @@ func (s *Service) ListClaims(ctx context.Context, request ListRequest) (*ListRes
 		response.Claims = append(response.Claims, protoClaim(record))
 	}
 	return response, nil
+}
+
+func (s *Service) retractMissingClaims(ctx context.Context, runtimeID string, claims []*cerebrov1.Claim) (uint32, error) {
+	incomingIDs := make(map[string]struct{}, len(claims))
+	for _, claim := range claims {
+		if claim == nil {
+			continue
+		}
+		if claimID := strings.TrimSpace(claim.GetId()); claimID != "" {
+			incomingIDs[claimID] = struct{}{}
+		}
+	}
+	existing, err := s.store.ListClaims(ctx, ports.ListClaimsRequest{
+		RuntimeID: runtimeID,
+		Status:    claimStatusAsserted,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("list existing claims for runtime %q: %w", runtimeID, err)
+	}
+	retractAt := snapshotObservedAt(claims)
+	snapshotEventID := snapshotSourceEventID(claims)
+	var retracted uint32
+	for _, existingClaim := range existing {
+		if existingClaim == nil {
+			continue
+		}
+		if _, ok := incomingIDs[strings.TrimSpace(existingClaim.ID)]; ok {
+			continue
+		}
+		if _, err := s.store.UpsertClaim(ctx, retractedClaim(existingClaim, retractAt, snapshotEventID)); err != nil {
+			return retracted, fmt.Errorf("retract claim %q: %w", existingClaim.ID, err)
+		}
+		retracted++
+	}
+	return retracted, nil
+}
+
+func snapshotObservedAt(claims []*cerebrov1.Claim) time.Time {
+	latest := time.Time{}
+	for _, claim := range claims {
+		if claim == nil || claim.GetObservedAt() == nil {
+			continue
+		}
+		observedAt := claim.GetObservedAt().AsTime().UTC()
+		if observedAt.IsZero() {
+			continue
+		}
+		if latest.IsZero() || observedAt.After(latest) {
+			latest = observedAt
+		}
+	}
+	if latest.IsZero() {
+		return time.Now().UTC()
+	}
+	return latest
+}
+
+func snapshotSourceEventID(claims []*cerebrov1.Claim) string {
+	for _, claim := range claims {
+		if claim == nil {
+			continue
+		}
+		if sourceEventID := strings.TrimSpace(claim.GetSourceEventId()); sourceEventID != "" {
+			return sourceEventID
+		}
+	}
+	return ""
+}
+
+func retractedClaim(claim *ports.ClaimRecord, retractAt time.Time, sourceEventID string) *ports.ClaimRecord {
+	if claim == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(claim.Attributes))
+	for key, value := range claim.Attributes {
+		attributes[key] = value
+	}
+	retracted := &ports.ClaimRecord{
+		ID:            strings.TrimSpace(claim.ID),
+		RuntimeID:     strings.TrimSpace(claim.RuntimeID),
+		TenantID:      strings.TrimSpace(claim.TenantID),
+		SubjectURN:    strings.TrimSpace(claim.SubjectURN),
+		SubjectRef:    cloneEntityRef(claim.SubjectRef),
+		Predicate:     strings.TrimSpace(claim.Predicate),
+		ObjectURN:     strings.TrimSpace(claim.ObjectURN),
+		ObjectRef:     cloneEntityRef(claim.ObjectRef),
+		ObjectValue:   strings.TrimSpace(claim.ObjectValue),
+		ClaimType:     strings.TrimSpace(claim.ClaimType),
+		Status:        claimStatusRetracted,
+		SourceEventID: strings.TrimSpace(claim.SourceEventID),
+		ObservedAt:    retractAt.UTC(),
+		ValidFrom:     claim.ValidFrom.UTC(),
+		ValidTo:       retractAt.UTC(),
+		Attributes:    attributes,
+	}
+	if sourceEventID != "" {
+		retracted.SourceEventID = sourceEventID
+	}
+	return retracted
 }
 
 func (s *Service) upsertEntity(ctx context.Context, entity *ports.ProjectedEntity, seen map[string]struct{}) (bool, error) {

--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -138,7 +138,7 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 		result.ClaimsWritten++
 	}
 	if request.ReplaceExisting {
-		retracted, err := s.retractMissingClaims(ctx, runtimeID, normalizedClaims)
+		retracted, err := s.retractMissingClaims(ctx, runtime, normalizedClaims)
 		if err != nil {
 			return nil, err
 		}
@@ -184,7 +184,8 @@ func (s *Service) ListClaims(ctx context.Context, request ListRequest) (*ListRes
 	return response, nil
 }
 
-func (s *Service) retractMissingClaims(ctx context.Context, runtimeID string, claims []*cerebrov1.Claim) (uint32, error) {
+func (s *Service) retractMissingClaims(ctx context.Context, runtime *cerebrov1.SourceRuntime, claims []*cerebrov1.Claim) (uint32, error) {
+	runtimeID := strings.TrimSpace(runtime.GetId())
 	incomingIDs := make(map[string]struct{}, len(claims))
 	for _, claim := range claims {
 		if claim == nil {
@@ -211,12 +212,32 @@ func (s *Service) retractMissingClaims(ctx context.Context, runtimeID string, cl
 		if _, ok := incomingIDs[strings.TrimSpace(existingClaim.ID)]; ok {
 			continue
 		}
+		if err := s.deleteLink(ctx, projectedRelation(runtime, protoClaim(existingClaim))); err != nil {
+			return retracted, err
+		}
 		if _, err := s.store.UpsertClaim(ctx, retractedClaim(existingClaim, retractAt, snapshotEventID)); err != nil {
 			return retracted, fmt.Errorf("retract claim %q: %w", existingClaim.ID, err)
 		}
 		retracted++
 	}
 	return retracted, nil
+}
+
+func (s *Service) deleteLink(ctx context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	if deleter, ok := s.state.(ports.ProjectionLinkDeleter); ok {
+		if err := deleter.DeleteProjectedLink(ctx, link); err != nil {
+			return fmt.Errorf("delete projected link %q: %w", projectedLinkKey(link), err)
+		}
+	}
+	if deleter, ok := s.graph.(ports.ProjectionLinkDeleter); ok {
+		if err := deleter.DeleteProjectedLink(ctx, link); err != nil {
+			return fmt.Errorf("delete graph link %q: %w", projectedLinkKey(link), err)
+		}
+	}
+	return nil
 }
 
 func snapshotObservedAt(claims []*cerebrov1.Claim) time.Time {
@@ -311,7 +332,7 @@ func (s *Service) upsertLink(ctx context.Context, link *ports.ProjectedLink, see
 	if link == nil {
 		return false, nil
 	}
-	key := link.FromURN + "|" + link.Relation + "|" + link.ToURN
+	key := projectedLinkKey(link)
 	if _, ok := seen[key]; ok {
 		return false, nil
 	}
@@ -330,6 +351,13 @@ func (s *Service) upsertLink(ctx context.Context, link *ports.ProjectedLink, see
 	}
 	seen[key] = struct{}{}
 	return true, nil
+}
+
+func projectedLinkKey(link *ports.ProjectedLink) string {
+	if link == nil {
+		return ""
+	}
+	return link.FromURN + "|" + link.Relation + "|" + link.ToURN
 }
 
 func normalizeClaim(claim *cerebrov1.Claim, runtime *cerebrov1.SourceRuntime) (*cerebrov1.Claim, error) {

--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -124,6 +124,9 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 			}
 		}
 		if projected := projectedRelation(runtime, claim); projected != nil {
+			if err := s.retractStalePriorLink(ctx, runtime, claim, projected); err != nil {
+				return nil, err
+			}
 			wrote, err := s.upsertLink(ctx, projected, upsertedLinks)
 			if err != nil {
 				return nil, err
@@ -131,6 +134,11 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 			if wrote {
 				result.RelationLinksProjected++
 			}
+		} else if err := s.retractStalePriorLink(ctx, runtime, claim, nil); err != nil {
+			// Claim previously projected a relation but the new claim no longer does (e.g. predicate
+			// changed from "belongs_to" to "labeled" with the same claim id). Make sure the old edge
+			// is removed.
+			return nil, err
 		}
 		if _, err := s.store.UpsertClaim(ctx, claimRecord(runtime, claim)); err != nil {
 			return nil, fmt.Errorf("persist claim %q: %w", claim.GetId(), err)
@@ -235,6 +243,44 @@ func (s *Service) deleteLink(ctx context.Context, link *ports.ProjectedLink) err
 	if deleter, ok := s.graph.(ports.ProjectionLinkDeleter); ok {
 		if err := deleter.DeleteProjectedLink(ctx, link); err != nil {
 			return fmt.Errorf("delete graph link %q: %w", projectedLinkKey(link), err)
+		}
+	}
+	return nil
+}
+
+// retractStalePriorLink deletes the projected link emitted by a previous version of the same
+// claim_id when the new claim's projection differs (for example because the relation's object_urn
+// changed). The new (possibly nil) projection is supplied so we only retract links that are
+// actually stale -- if the new projection matches the previous one, upsertLink is a no-op.
+func (s *Service) retractStalePriorLink(ctx context.Context, runtime *cerebrov1.SourceRuntime, claim *cerebrov1.Claim, next *ports.ProjectedLink) error {
+	if claim == nil {
+		return nil
+	}
+	claimID := strings.TrimSpace(claim.GetId())
+	if claimID == "" {
+		return nil
+	}
+	existing, err := s.store.ListClaims(ctx, ports.ListClaimsRequest{
+		RuntimeID: strings.TrimSpace(runtime.GetId()),
+		ClaimID:   claimID,
+		Status:    claimStatusAsserted,
+	})
+	if err != nil {
+		return fmt.Errorf("load existing claim %q: %w", claimID, err)
+	}
+	for _, prior := range existing {
+		if prior == nil {
+			continue
+		}
+		stale := projectedRelation(runtime, protoClaim(prior))
+		if stale == nil {
+			continue
+		}
+		if next != nil && projectedLinkKey(stale) == projectedLinkKey(next) {
+			continue
+		}
+		if err := s.deleteLink(ctx, stale); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/claims/service_test.go
+++ b/internal/claims/service_test.go
@@ -78,8 +78,9 @@ func (s *stubClaimStore) ListClaims(_ context.Context, request ports.ListClaimsR
 }
 
 type projectionRecorder struct {
-	entities map[string]*ports.ProjectedEntity
-	links    map[string]*ports.ProjectedLink
+	entities     map[string]*ports.ProjectedEntity
+	links        map[string]*ports.ProjectedLink
+	deletedLinks map[string]*ports.ProjectedLink
 }
 
 func (r *projectionRecorder) Ping(context.Context) error { return nil }
@@ -97,6 +98,14 @@ func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.
 		r.links = make(map[string]*ports.ProjectedLink)
 	}
 	r.links[link.FromURN+"|"+link.Relation+"|"+link.ToURN] = cloneProjectedLink(link)
+	return nil
+}
+
+func (r *projectionRecorder) DeleteProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if r.deletedLinks == nil {
+		r.deletedLinks = make(map[string]*ports.ProjectedLink)
+	}
+	r.deletedLinks[link.FromURN+"|"+link.Relation+"|"+link.ToURN] = cloneProjectedLink(link)
 	return nil
 }
 
@@ -251,6 +260,7 @@ func TestWriteClaimsReplaceExistingRetractsOmittedClaims(t *testing.T) {
 			},
 		},
 	}
+	projection := &projectionRecorder{}
 	service := New(
 		&stubRuntimeStore{
 			runtimes: map[string]*cerebrov1.SourceRuntime{
@@ -262,8 +272,8 @@ func TestWriteClaimsReplaceExistingRetractsOmittedClaims(t *testing.T) {
 			},
 		},
 		store,
-		nil,
-		nil,
+		projection,
+		projection,
 	)
 
 	result, err := service.WriteClaims(context.Background(), WriteRequest{
@@ -311,6 +321,9 @@ func TestWriteClaimsReplaceExistingRetractsOmittedClaims(t *testing.T) {
 	}
 	if !retracted.ValidTo.Equal(observedAt) {
 		t.Fatalf("retracted claim valid_to = %v, want %v", retracted.ValidTo, observedAt)
+	}
+	if _, ok := projection.deletedLinks[issueURN+"|assigned_to|"+assigneeURN]; !ok {
+		t.Fatalf("deleted projected link missing for retracted relation")
 	}
 }
 

--- a/internal/claims/service_test.go
+++ b/internal/claims/service_test.go
@@ -216,6 +216,104 @@ func TestWriteClaimsPersistsClaimsAndProjectsRelations(t *testing.T) {
 	}
 }
 
+func TestWriteClaimsReplaceExistingRetractsOmittedClaims(t *testing.T) {
+	issueURN := "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123"
+	assigneeURN := "urn:cerebro:writer:runtime:writer-jira:user:acct:42"
+	observedAt := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	statusID := hashClaimID("writer-jira", claimTypeAttribute, issueURN, "status")
+	assigneeID := hashClaimID("writer-jira", claimTypeRelation, issueURN, "assigned_to")
+	store := &stubClaimStore{
+		claims: map[string]*ports.ClaimRecord{
+			statusID: {
+				ID:            statusID,
+				RuntimeID:     "writer-jira",
+				TenantID:      "writer",
+				SubjectURN:    issueURN,
+				Predicate:     "status",
+				ObjectValue:   "in_progress",
+				ClaimType:     claimTypeAttribute,
+				Status:        claimStatusAsserted,
+				SourceEventID: "jira-event-1",
+				ObservedAt:    observedAt.Add(-time.Hour),
+			},
+			assigneeID: {
+				ID:            assigneeID,
+				RuntimeID:     "writer-jira",
+				TenantID:      "writer",
+				SubjectURN:    issueURN,
+				Predicate:     "assigned_to",
+				ObjectURN:     assigneeURN,
+				ObjectRef:     &cerebrov1.EntityRef{Urn: assigneeURN, EntityType: "user", Label: "Alice"},
+				ClaimType:     claimTypeRelation,
+				Status:        claimStatusAsserted,
+				SourceEventID: "jira-event-1",
+				ObservedAt:    observedAt.Add(-time.Hour),
+			},
+		},
+	}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-jira": {
+					Id:       "writer-jira",
+					SourceId: "sdk",
+					TenantId: "writer",
+				},
+			},
+		},
+		store,
+		nil,
+		nil,
+	)
+
+	result, err := service.WriteClaims(context.Background(), WriteRequest{
+		RuntimeID:       "writer-jira",
+		ReplaceExisting: true,
+		Claims: []*cerebrov1.Claim{
+			{
+				SubjectRef: &cerebrov1.EntityRef{
+					Urn:        issueURN,
+					EntityType: "ticket",
+					Label:      "ENG-123",
+				},
+				Predicate:     "status",
+				ObjectValue:   "done",
+				ClaimType:     claimTypeAttribute,
+				ObservedAt:    timestamppb.New(observedAt),
+				SourceEventId: "jira-event-2",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteClaims() error = %v", err)
+	}
+	if got := result.ClaimsWritten; got != 1 {
+		t.Fatalf("WriteClaims().ClaimsWritten = %d, want 1", got)
+	}
+	if got := result.ClaimsRetracted; got != 1 {
+		t.Fatalf("WriteClaims().ClaimsRetracted = %d, want 1", got)
+	}
+	if got := store.listRequest.RuntimeID; got != "writer-jira" {
+		t.Fatalf("retract list runtime_id = %q, want writer-jira", got)
+	}
+	if got := store.listRequest.Status; got != claimStatusAsserted {
+		t.Fatalf("retract list status = %q, want %q", got, claimStatusAsserted)
+	}
+	retracted := store.claims[assigneeID]
+	if retracted == nil {
+		t.Fatal("retracted claim = nil, want non-nil")
+	}
+	if got := retracted.Status; got != claimStatusRetracted {
+		t.Fatalf("retracted claim status = %q, want %q", got, claimStatusRetracted)
+	}
+	if got := retracted.SourceEventID; got != "jira-event-2" {
+		t.Fatalf("retracted claim source_event_id = %q, want jira-event-2", got)
+	}
+	if !retracted.ValidTo.Equal(observedAt) {
+		t.Fatalf("retracted claim valid_to = %v, want %v", retracted.ValidTo, observedAt)
+	}
+}
+
 func TestWriteClaimsRequiresAvailableDependencies(t *testing.T) {
 	service := New(nil, nil, nil, nil)
 	if _, err := service.WriteClaims(context.Background(), WriteRequest{RuntimeID: "writer-jira"}); !errors.Is(err, ErrRuntimeUnavailable) {
@@ -227,26 +325,28 @@ func TestListClaimsReturnsFilteredProtoClaims(t *testing.T) {
 	store := &stubClaimStore{
 		claims: map[string]*ports.ClaimRecord{
 			"claim-status": {
-				ID:          "claim-status",
-				RuntimeID:   "writer-jira",
-				TenantID:    "writer",
-				SubjectURN:  "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
-				Predicate:   "status",
-				ObjectValue: "in_progress",
-				ClaimType:   claimTypeAttribute,
-				Status:      claimStatusAsserted,
-				ObservedAt:  timeFromProto(timestamppb.New(timestamppb.Now().AsTime().Add(-time.Minute))),
+				ID:            "claim-status",
+				RuntimeID:     "writer-jira",
+				TenantID:      "writer",
+				SubjectURN:    "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+				Predicate:     "status",
+				ObjectValue:   "in_progress",
+				ClaimType:     claimTypeAttribute,
+				Status:        claimStatusAsserted,
+				SourceEventID: "jira-event-1",
+				ObservedAt:    timeFromProto(timestamppb.New(timestamppb.Now().AsTime().Add(-time.Minute))),
 			},
 			"claim-assignee": {
-				ID:         "claim-assignee",
-				RuntimeID:  "writer-jira",
-				TenantID:   "writer",
-				SubjectURN: "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
-				Predicate:  "assigned_to",
-				ObjectURN:  "urn:cerebro:writer:runtime:writer-jira:user:acct:42",
-				ClaimType:  claimTypeRelation,
-				Status:     claimStatusAsserted,
-				ObservedAt: timeFromProto(timestamppb.Now()),
+				ID:            "claim-assignee",
+				RuntimeID:     "writer-jira",
+				TenantID:      "writer",
+				SubjectURN:    "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+				Predicate:     "assigned_to",
+				ObjectURN:     "urn:cerebro:writer:runtime:writer-jira:user:acct:42",
+				ClaimType:     claimTypeRelation,
+				Status:        claimStatusAsserted,
+				SourceEventID: "jira-event-2",
+				ObservedAt:    timeFromProto(timestamppb.Now()),
 			},
 		},
 	}
@@ -266,10 +366,11 @@ func TestListClaimsReturnsFilteredProtoClaims(t *testing.T) {
 	)
 
 	response, err := service.ListClaims(context.Background(), ListRequest{
-		RuntimeID:   "writer-jira",
-		Predicate:   "status",
-		ObjectValue: "in_progress",
-		Limit:       1,
+		RuntimeID:     "writer-jira",
+		Predicate:     "status",
+		ObjectValue:   "in_progress",
+		SourceEventID: "jira-event-1",
+		Limit:         1,
 	})
 	if err != nil {
 		t.Fatalf("ListClaims() error = %v", err)
@@ -291,6 +392,9 @@ func TestListClaimsReturnsFilteredProtoClaims(t *testing.T) {
 	}
 	if got := store.listRequest.ObjectValue; got != "in_progress" {
 		t.Fatalf("ListClaims().ObjectValue = %q, want in_progress", got)
+	}
+	if got := store.listRequest.SourceEventID; got != "jira-event-1" {
+		t.Fatalf("ListClaims().SourceEventID = %q, want jira-event-1", got)
 	}
 	if got := store.listRequest.Limit; got != 1 {
 		t.Fatalf("ListClaims().Limit = %d, want 1", got)
@@ -419,6 +523,9 @@ func claimMatches(request ports.ListClaimsRequest, claim *ports.ClaimRecord) boo
 		return false
 	}
 	if request.Status != "" && strings.TrimSpace(claim.Status) != strings.TrimSpace(request.Status) {
+		return false
+	}
+	if request.SourceEventID != "" && strings.TrimSpace(claim.SourceEventID) != strings.TrimSpace(request.SourceEventID) {
 		return false
 	}
 	return true

--- a/internal/claims/service_test.go
+++ b/internal/claims/service_test.go
@@ -327,6 +327,92 @@ func TestWriteClaimsReplaceExistingRetractsOmittedClaims(t *testing.T) {
 	}
 }
 
+func TestWriteClaimsRetractsStaleProjectedLinkWhenRelationObjectChanges(t *testing.T) {
+	issueURN := "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123"
+	originalAssignee := "urn:cerebro:writer:runtime:writer-jira:user:acct:42"
+	newAssignee := "urn:cerebro:writer:runtime:writer-jira:user:acct:99"
+	observedAt := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	assigneeID := hashClaimID("writer-jira", claimTypeRelation, issueURN, "assigned_to")
+	store := &stubClaimStore{
+		claims: map[string]*ports.ClaimRecord{
+			assigneeID: {
+				ID:            assigneeID,
+				RuntimeID:     "writer-jira",
+				TenantID:      "writer",
+				SubjectURN:    issueURN,
+				Predicate:     "assigned_to",
+				ObjectURN:     originalAssignee,
+				ObjectRef:     &cerebrov1.EntityRef{Urn: originalAssignee, EntityType: "user", Label: "Alice"},
+				ClaimType:     claimTypeRelation,
+				Status:        claimStatusAsserted,
+				SourceEventID: "jira-event-1",
+				ObservedAt:    observedAt.Add(-time.Hour),
+			},
+		},
+	}
+	projection := &projectionRecorder{
+		links: map[string]*ports.ProjectedLink{
+			issueURN + "|assigned_to|" + originalAssignee: {
+				FromURN:  issueURN,
+				Relation: "assigned_to",
+				ToURN:    originalAssignee,
+			},
+		},
+	}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-jira": {Id: "writer-jira", SourceId: "sdk", TenantId: "writer"},
+			},
+		},
+		store,
+		projection,
+		projection,
+	)
+
+	result, err := service.WriteClaims(context.Background(), WriteRequest{
+		RuntimeID: "writer-jira",
+		Claims: []*cerebrov1.Claim{
+			{
+				SubjectRef: &cerebrov1.EntityRef{
+					Urn:        issueURN,
+					EntityType: "ticket",
+					Label:      "ENG-123",
+				},
+				Predicate:     "assigned_to",
+				ObjectRef:     &cerebrov1.EntityRef{Urn: newAssignee, EntityType: "user", Label: "Bob"},
+				ObjectUrn:     newAssignee,
+				ClaimType:     claimTypeRelation,
+				ObservedAt:    timestamppb.New(observedAt),
+				SourceEventId: "jira-event-2",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteClaims() error = %v", err)
+	}
+	if got := result.RelationLinksProjected; got != 1 {
+		t.Fatalf("WriteClaims().RelationLinksProjected = %d, want 1", got)
+	}
+	staleKey := issueURN + "|assigned_to|" + originalAssignee
+	if _, ok := projection.deletedLinks[staleKey]; !ok {
+		t.Fatalf("expected stale projected link %q to be deleted, got %v", staleKey, keysOf(projection.deletedLinks))
+	}
+	freshKey := issueURN + "|assigned_to|" + newAssignee
+	if _, ok := projection.links[freshKey]; !ok {
+		t.Fatalf("expected fresh projected link %q to be present, got %v", freshKey, keysOf(projection.links))
+	}
+}
+
+func keysOf[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func TestWriteClaimsRequiresAvailableDependencies(t *testing.T) {
 	service := New(nil, nil, nil, nil)
 	if _, err := service.WriteClaims(context.Background(), WriteRequest{RuntimeID: "writer-jira"}); !errors.Is(err, ErrRuntimeUnavailable) {

--- a/internal/findings/okta_policy_rule_lifecycle_tampering_rule.go
+++ b/internal/findings/okta_policy_rule_lifecycle_tampering_rule.go
@@ -1,0 +1,290 @@
+package findings
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceprojection"
+)
+
+const (
+	oktaPolicyRuleLifecycleTamperingRuleID   = "identity-okta-policy-rule-lifecycle-tampering"
+	oktaPolicyRuleLifecycleTamperingTitle    = "Okta Policy Rule Lifecycle Tampering"
+	oktaPolicyRuleLifecycleTamperingSeverity = "HIGH"
+	oktaPolicyRuleLifecycleTamperingStatus   = "open"
+)
+
+var (
+	oktaPolicyRuleLifecycleTamperingEventTypes = map[string]struct{}{
+		"policy.rule.update":     {},
+		"policy.rule.deactivate": {},
+		"policy.rule.delete":     {},
+	}
+	oktaPolicyRuleLifecycleTamperingOutcomes = map[string]struct{}{
+		"success": {},
+		"allow":   {},
+		"allowed": {},
+	}
+)
+
+type oktaPolicyRuleLifecycleTamperingRule struct{}
+
+func newOktaPolicyRuleLifecycleTamperingRule() Rule {
+	return &oktaPolicyRuleLifecycleTamperingRule{}
+}
+
+func (*oktaPolicyRuleLifecycleTamperingRule) Spec() *cerebrov1.RuleSpec {
+	return &cerebrov1.RuleSpec{
+		Id:          oktaPolicyRuleLifecycleTamperingRuleID,
+		Name:        oktaPolicyRuleLifecycleTamperingTitle,
+		Description: "Detect successful Okta policy rule update, deactivate, or delete events replayed from one source runtime.",
+		InputStreamIds: []string{
+			"source-runtime-replay",
+		},
+		OutputKinds: []string{
+			"finding.okta_policy_rule_lifecycle_tampering",
+		},
+	}
+}
+
+func (*oktaPolicyRuleLifecycleTamperingRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	return runtime != nil && strings.EqualFold(strings.TrimSpace(runtime.GetSourceId()), "okta")
+}
+
+func (*oktaPolicyRuleLifecycleTamperingRule) Evaluate(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	if runtime == nil {
+		return nil, errors.New("source runtime is required")
+	}
+	if !matchesOktaPolicyRuleLifecycleTampering(event) {
+		return nil, nil
+	}
+	record, err := oktaPolicyRuleLifecycleTamperingFinding(ctx, event, runtime)
+	if err != nil {
+		return nil, err
+	}
+	return []*ports.FindingRecord{record}, nil
+}
+
+func matchesOktaPolicyRuleLifecycleTampering(event *cerebrov1.EventEnvelope) bool {
+	if event == nil || !strings.EqualFold(strings.TrimSpace(event.GetKind()), "okta.audit") {
+		return false
+	}
+	attributes := event.GetAttributes()
+	eventType := strings.ToLower(strings.TrimSpace(attributes["event_type"]))
+	if _, ok := oktaPolicyRuleLifecycleTamperingEventTypes[eventType]; !ok {
+		return false
+	}
+	outcome := strings.ToLower(strings.TrimSpace(attributes["outcome_result"]))
+	if outcome == "" {
+		outcome = "success"
+	}
+	_, ok := oktaPolicyRuleLifecycleTamperingOutcomes[outcome]
+	return ok
+}
+
+func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebrov1.EventEnvelope, runtime *cerebrov1.SourceRuntime) (*ports.FindingRecord, error) {
+	resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, err := projectedEntityContext(ctx, event)
+	if err != nil {
+		return nil, fmt.Errorf("project finding context for event %q: %w", event.GetId(), err)
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		tenantID = strings.TrimSpace(event.GetTenantId())
+	}
+	runtimeID := strings.TrimSpace(runtime.GetId())
+	eventID := strings.TrimSpace(event.GetId())
+	attributes := map[string]string{
+		"event_id":             eventID,
+		"event_type":           strings.TrimSpace(event.GetAttributes()["event_type"]),
+		"outcome_result":       strings.TrimSpace(event.GetAttributes()["outcome_result"]),
+		"source_runtime_id":    runtimeID,
+		"primary_actor_urn":    actorURN,
+		"primary_resource_urn": resourceURN,
+	}
+	trimEmptyAttributes(attributes)
+	observedAt := time.Time{}
+	if timestamp := event.GetOccurredAt(); timestamp != nil {
+		observedAt = timestamp.AsTime().UTC()
+	}
+	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, tenantID, runtimeID, eventID)
+	if eventID != "" {
+		legacy := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, eventID)
+		attributes["legacy_finding_id"] = legacy
+		attributes["legacy_fingerprint"] = legacy
+	}
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       runtimeID,
+		RuleID:          oktaPolicyRuleLifecycleTamperingRuleID,
+		Title:           oktaPolicyRuleLifecycleTamperingTitle,
+		Severity:        oktaPolicyRuleLifecycleTamperingSeverity,
+		Status:          oktaPolicyRuleLifecycleTamperingStatus,
+		Summary:         findingSummary(event, actorLabel, resourceLabel),
+		ResourceURNs:    resourceURNs,
+		EventIDs:        []string{eventID},
+		Attributes:      attributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}
+
+func projectedEntityContext(ctx context.Context, event *cerebrov1.EventEnvelope) ([]string, string, string, string, string, error) {
+	recorder := &projectionRecorder{
+		entities: make(map[string]*ports.ProjectedEntity),
+		links:    make(map[string]*ports.ProjectedLink),
+	}
+	if ctx == nil {
+		return nil, "", "", "", "", errors.New("context is required")
+	}
+	if _, err := sourceprojection.New(nil, recorder).Project(ctx, event); err != nil {
+		return nil, "", "", "", "", err
+	}
+	resourceURNs := make([]string, 0, len(recorder.entities))
+	seenURNs := make(map[string]struct{}, len(recorder.entities))
+	var actorURN string
+	var resourceURN string
+	for _, link := range recorder.links {
+		if !strings.EqualFold(strings.TrimSpace(link.Relation), "acted_on") {
+			continue
+		}
+		if actorURN == "" {
+			actorURN = strings.TrimSpace(link.FromURN)
+		}
+		if resourceURN == "" {
+			resourceURN = strings.TrimSpace(link.ToURN)
+		}
+		if candidate := strings.TrimSpace(link.FromURN); candidate != "" {
+			if _, ok := seenURNs[candidate]; !ok {
+				seenURNs[candidate] = struct{}{}
+				resourceURNs = append(resourceURNs, candidate)
+			}
+		}
+		if candidate := strings.TrimSpace(link.ToURN); candidate != "" {
+			if _, ok := seenURNs[candidate]; !ok {
+				seenURNs[candidate] = struct{}{}
+				resourceURNs = append(resourceURNs, candidate)
+			}
+		}
+	}
+	slices.Sort(resourceURNs)
+	actorLabel := entityLabel(recorder.entities[actorURN], event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"])
+	resourceLabel := entityLabel(recorder.entities[resourceURN], event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"])
+	return resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, nil
+}
+
+func entityLabel(entity *ports.ProjectedEntity, fallbacks ...string) string {
+	if entity != nil && strings.TrimSpace(entity.Label) != "" {
+		return strings.TrimSpace(entity.Label)
+	}
+	for _, fallback := range fallbacks {
+		if strings.TrimSpace(fallback) != "" {
+			return strings.TrimSpace(fallback)
+		}
+	}
+	return ""
+}
+
+func findingSummary(event *cerebrov1.EventEnvelope, actorLabel string, resourceLabel string) string {
+	eventType := strings.TrimSpace(event.GetAttributes()["event_type"])
+	actor := firstNonEmpty(actorLabel, event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"], "unknown actor")
+	resource := firstNonEmpty(resourceLabel, event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"], "unknown resource")
+	return fmt.Sprintf("%s performed %s on %s", actor, eventType, resource)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func trimEmptyAttributes(attributes map[string]string) {
+	for key, value := range attributes {
+		if strings.TrimSpace(value) == "" {
+			delete(attributes, key)
+		}
+	}
+}
+
+func hashFindingFingerprint(parts ...string) string {
+	hash := sha256.New()
+	for _, part := range parts {
+		_, _ = hash.Write([]byte(strings.TrimSpace(part)))
+		_, _ = hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+type projectionRecorder struct {
+	entities map[string]*ports.ProjectedEntity
+	links    map[string]*ports.ProjectedLink
+}
+
+func (r *projectionRecorder) Ping(context.Context) error {
+	return nil
+}
+
+func (r *projectionRecorder) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if entity == nil {
+		return nil
+	}
+	r.entities[entity.URN] = cloneEntity(entity)
+	return nil
+}
+
+func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	key := strings.TrimSpace(link.FromURN) + "|" + strings.TrimSpace(link.Relation) + "|" + strings.TrimSpace(link.ToURN)
+	r.links[key] = cloneLink(link)
+	return nil
+}
+
+func cloneEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
+	if entity == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(entity.Attributes))
+	for key, value := range entity.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedEntity{
+		URN:        entity.URN,
+		TenantID:   entity.TenantID,
+		SourceID:   entity.SourceID,
+		EntityType: entity.EntityType,
+		Label:      entity.Label,
+		Attributes: attributes,
+	}
+}
+
+func cloneLink(link *ports.ProjectedLink) *ports.ProjectedLink {
+	if link == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(link.Attributes))
+	for key, value := range link.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedLink{
+		TenantID:   link.TenantID,
+		SourceID:   link.SourceID,
+		FromURN:    link.FromURN,
+		ToURN:      link.ToURN,
+		Relation:   link.Relation,
+		Attributes: attributes,
+	}
+}

--- a/internal/findings/registry.go
+++ b/internal/findings/registry.go
@@ -1,0 +1,99 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/primitives"
+)
+
+// Rule evaluates replayed runtime events and emits persisted findings.
+type Rule interface {
+	primitives.Rule
+	SupportsRuntime(*cerebrov1.SourceRuntime) bool
+	Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error)
+}
+
+// Registry indexes finding rules by their stable identifier.
+type Registry struct {
+	rules map[string]Rule
+}
+
+// NewRegistry constructs a finding rule registry and rejects duplicate or invalid specs.
+func NewRegistry(rules ...Rule) (*Registry, error) {
+	indexed := make(map[string]Rule, len(rules))
+	for _, rule := range rules {
+		if rule == nil {
+			return nil, fmt.Errorf("finding rule is required")
+		}
+		spec := rule.Spec()
+		if spec == nil {
+			return nil, fmt.Errorf("finding rule spec is required")
+		}
+		id := strings.TrimSpace(spec.GetId())
+		if id == "" {
+			return nil, fmt.Errorf("finding rule id is required")
+		}
+		if _, exists := indexed[id]; exists {
+			return nil, fmt.Errorf("duplicate finding rule id %q", id)
+		}
+		indexed[id] = rule
+	}
+	return &Registry{rules: indexed}, nil
+}
+
+// Builtin returns the in-process finding rule registry for the rewrite skeleton.
+func Builtin() *Registry {
+	return &Registry{
+		rules: map[string]Rule{
+			oktaPolicyRuleLifecycleTamperingRuleID: newOktaPolicyRuleLifecycleTamperingRule(),
+		},
+	}
+}
+
+// Get returns a registered finding rule by ID.
+func (r *Registry) Get(id string) (Rule, bool) {
+	if r == nil {
+		return nil, false
+	}
+	rule, ok := r.rules[strings.TrimSpace(id)]
+	return rule, ok
+}
+
+// List returns all registered rule specs sorted by ID.
+func (r *Registry) List() []*cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(r.rules))
+	for id := range r.rules {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	specs := make([]*cerebrov1.RuleSpec, 0, len(ids))
+	for _, id := range ids {
+		specs = append(specs, r.rules[id].Spec())
+	}
+	return specs
+}
+
+// ForRuntime returns the registered rules that support one runtime, sorted by rule ID.
+func (r *Registry) ForRuntime(runtime *cerebrov1.SourceRuntime) []Rule {
+	if r == nil || runtime == nil {
+		return nil
+	}
+	specs := r.List()
+	rules := make([]Rule, 0, len(specs))
+	for _, spec := range specs {
+		rule, ok := r.rules[strings.TrimSpace(spec.GetId())]
+		if !ok || !rule.SupportsRuntime(runtime) {
+			continue
+		}
+		rules = append(rules, rule)
+	}
+	return rules
+}

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -1,0 +1,87 @@
+package findings
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type stubRule struct {
+	spec               *cerebrov1.RuleSpec
+	supportedSourceIDs map[string]struct{}
+}
+
+func (r *stubRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return r.spec
+}
+
+func (r *stubRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	_, ok := r.supportedSourceIDs[runtime.GetSourceId()]
+	return ok
+}
+
+func (r *stubRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func TestNewRegistryRejectsDuplicateRuleIDs(t *testing.T) {
+	_, err := NewRegistry(
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-1"}},
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-1"}},
+	)
+	if err == nil {
+		t.Fatal("NewRegistry() error = nil, want non-nil")
+	}
+}
+
+func TestRegistryGetAndListSortByRuleID(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-b"}},
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-a"}},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	rule, ok := registry.Get("rule-a")
+	if !ok || rule == nil {
+		t.Fatal("Get(rule-a) = nil, want rule")
+	}
+	specs := registry.List()
+	if got := len(specs); got != 2 {
+		t.Fatalf("len(List()) = %d, want 2", got)
+	}
+	if specs[0].GetId() != "rule-a" || specs[1].GetId() != "rule-b" {
+		t.Fatalf("List() ids = [%q %q], want [rule-a rule-b]", specs[0].GetId(), specs[1].GetId())
+	}
+}
+
+func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b"},
+			supportedSourceIDs: map[string]struct{}{"github": {}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	rules := registry.ForRuntime(&cerebrov1.SourceRuntime{SourceId: "okta"})
+	if got := len(rules); got != 1 {
+		t.Fatalf("len(ForRuntime()) = %d, want 1", got)
+	}
+	if got := rules[0].Spec().GetId(); got != "rule-a" {
+		t.Fatalf("ForRuntime()[0].Spec().Id = %q, want rule-a", got)
+	}
+}

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -2,56 +2,61 @@ package findings
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
-	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
-	"github.com/writer/cerebro/internal/sourceprojection"
 )
 
 const (
 	defaultEventLimit = 100
 	maxEventLimit     = 1000
-
-	oktaPolicyRuleLifecycleTamperingRuleID   = "identity-okta-policy-rule-lifecycle-tampering"
-	oktaPolicyRuleLifecycleTamperingTitle    = "Okta Policy Rule Lifecycle Tampering"
-	oktaPolicyRuleLifecycleTamperingSeverity = "HIGH"
-	oktaPolicyRuleLifecycleTamperingStatus   = "open"
 )
 
 var (
 	// ErrRuntimeUnavailable indicates that the runtime, replay, or finding store boundary is unavailable.
 	ErrRuntimeUnavailable = errors.New("finding runtime is unavailable")
 
-	oktaPolicyRuleLifecycleTamperingEventTypes = map[string]struct{}{
-		"policy.rule.update":     {},
-		"policy.rule.deactivate": {},
-		"policy.rule.delete":     {},
-	}
-	oktaPolicyRuleLifecycleTamperingOutcomes = map[string]struct{}{
-		"success": {},
-		"allow":   {},
-		"allowed": {},
-	}
+	// ErrRuleNotFound indicates that one requested finding rule is not registered.
+	ErrRuleNotFound = errors.New("finding rule not found")
+
+	// ErrRuleSelectionRequired indicates that one finding rule must be selected explicitly.
+	ErrRuleSelectionRequired = errors.New("finding rule id is required")
+
+	// ErrRuleUnsupported indicates that one finding rule does not support the requested runtime.
+	ErrRuleUnsupported = errors.New("finding rule is not supported for source runtime")
+
+	// ErrRuleUnavailable indicates that no registered finding rule supports the requested runtime.
+	ErrRuleUnavailable = errors.New("finding rule is unavailable for source runtime")
 )
 
-// Service replays runtime events through a fixed finding evaluator and persists emitted findings.
+// Service replays runtime events through one selected finding rule and persists emitted findings.
 type Service struct {
 	runtimeStore ports.SourceRuntimeStore
 	replayer     ports.EventReplayer
 	store        ports.FindingStore
+	rules        *Registry
 }
 
 // EvaluateRequest scopes one replay-backed finding evaluation.
 type EvaluateRequest struct {
 	RuntimeID  string
+	RuleID     string
 	EventLimit uint32
+}
+
+// ListRequest scopes one persisted finding query.
+type ListRequest struct {
+	RuntimeID   string
+	FindingID   string
+	RuleID      string
+	Severity    string
+	Status      string
+	ResourceURN string
+	EventID     string
+	Limit       uint32
 }
 
 // EvaluateResult reports the persisted findings emitted for one runtime evaluation.
@@ -62,18 +67,29 @@ type EvaluateResult struct {
 	Findings        []*ports.FindingRecord
 }
 
-// New constructs a replay-backed finding service.
+// ListResult reports one persisted finding query.
+type ListResult struct {
+	Findings []*ports.FindingRecord
+}
+
+// New constructs a replay-backed finding service with the built-in rule registry.
 func New(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore) *Service {
+	return NewWithRegistry(runtimeStore, replayer, store, Builtin())
+}
+
+// NewWithRegistry constructs a replay-backed finding service with one explicit rule registry.
+func NewWithRegistry(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore, rules *Registry) *Service {
 	return &Service{
 		runtimeStore: runtimeStore,
 		replayer:     replayer,
 		store:        store,
+		rules:        rules,
 	}
 }
 
-// EvaluateSourceRuntime replays one runtime and persists findings for matching Okta audit events.
+// EvaluateSourceRuntime replays one runtime and persists findings for one selected registered rule.
 func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateRequest) (*EvaluateResult, error) {
-	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.store == nil {
+	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.store == nil || s.rules == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
@@ -81,6 +97,10 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 		return nil, errors.New("source runtime id is required")
 	}
 	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	rule, err := s.selectRule(runtime, request.RuleID)
 	if err != nil {
 		return nil, err
 	}
@@ -93,24 +113,77 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	}
 	result := &EvaluateResult{
 		Runtime:         runtime,
-		Rule:            oktaPolicyRuleLifecycleTamperingRuleSpec(),
+		Rule:            rule.Spec(),
 		EventsEvaluated: uint32(len(events)),
 	}
 	for _, event := range events {
-		if !matchesOktaPolicyRuleLifecycleTampering(event) {
-			continue
-		}
-		record, err := oktaPolicyRuleLifecycleTamperingFinding(ctx, event, runtimeID)
+		emitted, err := rule.Evaluate(ctx, runtime, event)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("evaluate finding rule %q for event %q: %w", result.Rule.GetId(), event.GetId(), err)
 		}
-		stored, err := s.store.UpsertFinding(ctx, record)
-		if err != nil {
-			return nil, fmt.Errorf("persist finding for event %q: %w", event.GetId(), err)
+		for _, record := range emitted {
+			if record == nil {
+				continue
+			}
+			stored, err := s.store.UpsertFinding(ctx, record)
+			if err != nil {
+				return nil, fmt.Errorf("persist finding for rule %q event %q: %w", result.Rule.GetId(), event.GetId(), err)
+			}
+			result.Findings = append(result.Findings, stored)
 		}
-		result.Findings = append(result.Findings, stored)
 	}
 	return result, nil
+}
+
+// ListFindings loads persisted findings for one runtime.
+func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListResult, error) {
+	if s == nil || s.runtimeStore == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, errors.New("source runtime id is required")
+	}
+	if _, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID); err != nil {
+		return nil, err
+	}
+	findings, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
+		RuntimeID:   runtimeID,
+		FindingID:   strings.TrimSpace(request.FindingID),
+		RuleID:      strings.TrimSpace(request.RuleID),
+		Severity:    strings.TrimSpace(request.Severity),
+		Status:      strings.TrimSpace(request.Status),
+		ResourceURN: strings.TrimSpace(request.ResourceURN),
+		EventID:     strings.TrimSpace(request.EventID),
+		Limit:       request.Limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list findings for runtime %q: %w", runtimeID, err)
+	}
+	return &ListResult{Findings: findings}, nil
+}
+
+func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (Rule, error) {
+	trimmedRuleID := strings.TrimSpace(ruleID)
+	if trimmedRuleID != "" {
+		rule, ok := s.rules.Get(trimmedRuleID)
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", ErrRuleNotFound, trimmedRuleID)
+		}
+		if !rule.SupportsRuntime(runtime) {
+			return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedRuleID)
+		}
+		return rule, nil
+	}
+	applicable := s.rules.ForRuntime(runtime)
+	switch len(applicable) {
+	case 0:
+		return nil, fmt.Errorf("%w: %s", ErrRuleUnavailable, strings.TrimSpace(runtime.GetId()))
+	case 1:
+		return applicable[0], nil
+	default:
+		return nil, fmt.Errorf("%w for runtime %q", ErrRuleSelectionRequired, strings.TrimSpace(runtime.GetId()))
+	}
 }
 
 func normalizeEventLimit(limit uint32) uint32 {
@@ -121,224 +194,5 @@ func normalizeEventLimit(limit uint32) uint32 {
 		return maxEventLimit
 	default:
 		return limit
-	}
-}
-
-func oktaPolicyRuleLifecycleTamperingRuleSpec() *cerebrov1.RuleSpec {
-	return &cerebrov1.RuleSpec{
-		Id:          oktaPolicyRuleLifecycleTamperingRuleID,
-		Name:        oktaPolicyRuleLifecycleTamperingTitle,
-		Description: "Detect successful Okta policy rule update, deactivate, or delete events replayed from one source runtime.",
-		InputStreamIds: []string{
-			"source-runtime-replay",
-		},
-		OutputKinds: []string{
-			"finding.okta_policy_rule_lifecycle_tampering",
-		},
-	}
-}
-
-func matchesOktaPolicyRuleLifecycleTampering(event *cerebrov1.EventEnvelope) bool {
-	if event == nil || !strings.EqualFold(strings.TrimSpace(event.GetKind()), "okta.audit") {
-		return false
-	}
-	attributes := event.GetAttributes()
-	eventType := strings.ToLower(strings.TrimSpace(attributes["event_type"]))
-	if _, ok := oktaPolicyRuleLifecycleTamperingEventTypes[eventType]; !ok {
-		return false
-	}
-	outcome := strings.ToLower(strings.TrimSpace(attributes["outcome_result"]))
-	if outcome == "" {
-		outcome = "success"
-	}
-	_, ok := oktaPolicyRuleLifecycleTamperingOutcomes[outcome]
-	return ok
-}
-
-func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
-	resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, err := projectedEntityContext(ctx, event)
-	if err != nil {
-		return nil, fmt.Errorf("project finding context for event %q: %w", event.GetId(), err)
-	}
-	attributes := map[string]string{
-		"event_id":             strings.TrimSpace(event.GetId()),
-		"event_type":           strings.TrimSpace(event.GetAttributes()["event_type"]),
-		"outcome_result":       strings.TrimSpace(event.GetAttributes()["outcome_result"]),
-		"source_runtime_id":    strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID]),
-		"primary_actor_urn":    actorURN,
-		"primary_resource_urn": resourceURN,
-	}
-	trimEmptyAttributes(attributes)
-	observedAt := time.Time{}
-	if timestamp := event.GetOccurredAt(); timestamp != nil {
-		observedAt = timestamp.AsTime().UTC()
-	}
-	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, event.GetId())
-	return &ports.FindingRecord{
-		ID:              fingerprint,
-		Fingerprint:     fingerprint,
-		TenantID:        strings.TrimSpace(event.GetTenantId()),
-		RuntimeID:       strings.TrimSpace(runtimeID),
-		RuleID:          oktaPolicyRuleLifecycleTamperingRuleID,
-		Title:           oktaPolicyRuleLifecycleTamperingTitle,
-		Severity:        oktaPolicyRuleLifecycleTamperingSeverity,
-		Status:          oktaPolicyRuleLifecycleTamperingStatus,
-		Summary:         findingSummary(event, actorLabel, resourceLabel),
-		ResourceURNs:    resourceURNs,
-		EventIDs:        []string{strings.TrimSpace(event.GetId())},
-		Attributes:      attributes,
-		FirstObservedAt: observedAt,
-		LastObservedAt:  observedAt,
-	}, nil
-}
-
-func projectedEntityContext(ctx context.Context, event *cerebrov1.EventEnvelope) ([]string, string, string, string, string, error) {
-	recorder := &projectionRecorder{
-		entities: make(map[string]*ports.ProjectedEntity),
-		links:    make(map[string]*ports.ProjectedLink),
-	}
-	if ctx == nil {
-		return nil, "", "", "", "", errors.New("context is required")
-	}
-	if _, err := sourceprojection.New(nil, recorder).Project(ctx, event); err != nil {
-		return nil, "", "", "", "", err
-	}
-	resourceURNs := make([]string, 0, len(recorder.entities))
-	seenURNs := make(map[string]struct{}, len(recorder.entities))
-	var actorURN string
-	var resourceURN string
-	for _, link := range recorder.links {
-		if !strings.EqualFold(strings.TrimSpace(link.Relation), "acted_on") {
-			continue
-		}
-		if actorURN == "" {
-			actorURN = strings.TrimSpace(link.FromURN)
-		}
-		if resourceURN == "" {
-			resourceURN = strings.TrimSpace(link.ToURN)
-		}
-		if candidate := strings.TrimSpace(link.FromURN); candidate != "" {
-			if _, ok := seenURNs[candidate]; !ok {
-				seenURNs[candidate] = struct{}{}
-				resourceURNs = append(resourceURNs, candidate)
-			}
-		}
-		if candidate := strings.TrimSpace(link.ToURN); candidate != "" {
-			if _, ok := seenURNs[candidate]; !ok {
-				seenURNs[candidate] = struct{}{}
-				resourceURNs = append(resourceURNs, candidate)
-			}
-		}
-	}
-	slices.Sort(resourceURNs)
-	actorLabel := entityLabel(recorder.entities[actorURN], event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"])
-	resourceLabel := entityLabel(recorder.entities[resourceURN], event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"])
-	return resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, nil
-}
-
-func entityLabel(entity *ports.ProjectedEntity, fallbacks ...string) string {
-	if entity != nil && strings.TrimSpace(entity.Label) != "" {
-		return strings.TrimSpace(entity.Label)
-	}
-	for _, fallback := range fallbacks {
-		if strings.TrimSpace(fallback) != "" {
-			return strings.TrimSpace(fallback)
-		}
-	}
-	return ""
-}
-
-func findingSummary(event *cerebrov1.EventEnvelope, actorLabel string, resourceLabel string) string {
-	eventType := strings.TrimSpace(event.GetAttributes()["event_type"])
-	actor := firstNonEmpty(actorLabel, event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"], "unknown actor")
-	resource := firstNonEmpty(resourceLabel, event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"], "unknown resource")
-	return fmt.Sprintf("%s performed %s on %s", actor, eventType, resource)
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
-}
-
-func trimEmptyAttributes(attributes map[string]string) {
-	for key, value := range attributes {
-		if strings.TrimSpace(value) == "" {
-			delete(attributes, key)
-		}
-	}
-}
-
-func hashFindingFingerprint(parts ...string) string {
-	hash := sha256.New()
-	for _, part := range parts {
-		_, _ = hash.Write([]byte(strings.TrimSpace(part)))
-		_, _ = hash.Write([]byte{0})
-	}
-	return hex.EncodeToString(hash.Sum(nil))
-}
-
-type projectionRecorder struct {
-	entities map[string]*ports.ProjectedEntity
-	links    map[string]*ports.ProjectedLink
-}
-
-func (r *projectionRecorder) Ping(context.Context) error {
-	return nil
-}
-
-func (r *projectionRecorder) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
-	if entity == nil {
-		return nil
-	}
-	r.entities[entity.URN] = cloneEntity(entity)
-	return nil
-}
-
-func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
-	if link == nil {
-		return nil
-	}
-	key := strings.TrimSpace(link.FromURN) + "|" + strings.TrimSpace(link.Relation) + "|" + strings.TrimSpace(link.ToURN)
-	r.links[key] = cloneLink(link)
-	return nil
-}
-
-func cloneEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
-	if entity == nil {
-		return nil
-	}
-	attributes := make(map[string]string, len(entity.Attributes))
-	for key, value := range entity.Attributes {
-		attributes[key] = value
-	}
-	return &ports.ProjectedEntity{
-		URN:        entity.URN,
-		TenantID:   entity.TenantID,
-		SourceID:   entity.SourceID,
-		EntityType: entity.EntityType,
-		Label:      entity.Label,
-		Attributes: attributes,
-	}
-}
-
-func cloneLink(link *ports.ProjectedLink) *ports.ProjectedLink {
-	if link == nil {
-		return nil
-	}
-	attributes := make(map[string]string, len(link.Attributes))
-	for key, value := range link.Attributes {
-		attributes[key] = value
-	}
-	return &ports.ProjectedLink{
-		TenantID:   link.TenantID,
-		SourceID:   link.SourceID,
-		FromURN:    link.FromURN,
-		ToURN:      link.ToURN,
-		Relation:   link.Relation,
-		Attributes: attributes,
 	}
 }

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -3,6 +3,8 @@ package findings
 import (
 	"context"
 	"errors"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,6 +49,7 @@ func (s *stubReplayer) Replay(_ context.Context, request ports.ReplayRequest) ([
 
 type stubFindingStore struct {
 	findings map[string]*ports.FindingRecord
+	request  ports.ListFindingsRequest
 }
 
 func (s *stubFindingStore) Ping(context.Context) error { return nil }
@@ -64,12 +67,30 @@ func (s *stubFindingStore) UpsertFinding(_ context.Context, finding *ports.Findi
 }
 
 func (s *stubFindingStore) ListFindings(_ context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	s.request = request
 	findings := []*ports.FindingRecord{}
 	for _, finding := range s.findings {
-		if finding == nil || finding.RuntimeID != request.RuntimeID {
+		if !findingMatches(request, finding) {
 			continue
 		}
 		findings = append(findings, cloneFinding(finding))
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		left := findings[i]
+		right := findings[j]
+		switch {
+		case left.LastObservedAt.Equal(right.LastObservedAt):
+			return left.ID < right.ID
+		case left.LastObservedAt.IsZero():
+			return false
+		case right.LastObservedAt.IsZero():
+			return true
+		default:
+			return left.LastObservedAt.After(right.LastObservedAt)
+		}
+	})
+	if request.Limit != 0 && len(findings) > int(request.Limit) {
+		findings = findings[:int(request.Limit)]
 	}
 	return findings, nil
 }
@@ -157,6 +178,208 @@ func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T
 	}
 }
 
+func TestEvaluateSourceRuntimeFindingsSelectsRequestedRule(t *testing.T) {
+	replayer := &stubReplayer{
+		events: []*cerebrov1.EventEnvelope{
+			newAuditEvent("okta-audit-2", "policy.rule.update", "SUCCESS"),
+		},
+	}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		replayer,
+		&stubFindingStore{},
+	)
+
+	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID:  "writer-okta-audit",
+		RuleID:     oktaPolicyRuleLifecycleTamperingRuleID,
+		EventLimit: 10,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntime() error = %v", err)
+	}
+	if got := result.Rule.GetId(); got != oktaPolicyRuleLifecycleTamperingRuleID {
+		t.Fatalf("EvaluateSourceRuntime().Rule.ID = %q, want %q", got, oktaPolicyRuleLifecycleTamperingRuleID)
+	}
+	if got := len(result.Findings); got != 1 {
+		t.Fatalf("len(EvaluateSourceRuntime().Findings) = %d, want 1", got)
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsRejectsUnknownRule(t *testing.T) {
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		&stubFindingStore{},
+	)
+	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-okta-audit",
+		RuleID:    "rule-does-not-exist",
+	}); !errors.Is(err, ErrRuleNotFound) {
+		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuleNotFound)
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsRequiresRuleIDWhenMultipleRulesSupportRuntime(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		&stubFindingStore{},
+		registry,
+	)
+	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-okta-audit",
+	}); !errors.Is(err, ErrRuleSelectionRequired) {
+		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuleSelectionRequired)
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsRejectsUnsupportedRule(t *testing.T) {
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-github-audit": {
+					Id:       "writer-github-audit",
+					SourceId: "github",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		&stubFindingStore{},
+	)
+	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-github-audit",
+		RuleID:    oktaPolicyRuleLifecycleTamperingRuleID,
+	}); !errors.Is(err, ErrRuleUnsupported) {
+		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuleUnsupported)
+	}
+}
+
+func TestListFindingsReturnsFilteredPersistedFindings(t *testing.T) {
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				RuntimeID:      "writer-okta-audit",
+				RuleID:         oktaPolicyRuleLifecycleTamperingRuleID,
+				Severity:       "HIGH",
+				Status:         "open",
+				ResourceURNs:   []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+				EventIDs:       []string{"okta-audit-2"},
+				LastObservedAt: time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC),
+			},
+			"finding-2": {
+				ID:             "finding-2",
+				RuntimeID:      "writer-okta-audit",
+				RuleID:         oktaPolicyRuleLifecycleTamperingRuleID,
+				Severity:       "MEDIUM",
+				Status:         "resolved",
+				ResourceURNs:   []string{"urn:cerebro:writer:okta_resource:policyrule:pol-2"},
+				EventIDs:       []string{"okta-audit-3"},
+				LastObservedAt: time.Date(2026, 4, 23, 11, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		store,
+	)
+
+	result, err := service.ListFindings(context.Background(), ListRequest{
+		RuntimeID:   "writer-okta-audit",
+		RuleID:      oktaPolicyRuleLifecycleTamperingRuleID,
+		Severity:    "HIGH",
+		Status:      "open",
+		ResourceURN: "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+		EventID:     "okta-audit-2",
+		Limit:       1,
+	})
+	if err != nil {
+		t.Fatalf("ListFindings() error = %v", err)
+	}
+	if got := len(result.Findings); got != 1 {
+		t.Fatalf("len(ListFindings().Findings) = %d, want 1", got)
+	}
+	if got := result.Findings[0].ID; got != "finding-1" {
+		t.Fatalf("ListFindings().Findings[0].ID = %q, want finding-1", got)
+	}
+	if got := store.request.RuntimeID; got != "writer-okta-audit" {
+		t.Fatalf("ListFindings().RuntimeID = %q, want writer-okta-audit", got)
+	}
+	if got := store.request.RuleID; got != oktaPolicyRuleLifecycleTamperingRuleID {
+		t.Fatalf("ListFindings().RuleID = %q, want %q", got, oktaPolicyRuleLifecycleTamperingRuleID)
+	}
+	if got := store.request.Severity; got != "HIGH" {
+		t.Fatalf("ListFindings().Severity = %q, want HIGH", got)
+	}
+	if got := store.request.Status; got != "open" {
+		t.Fatalf("ListFindings().Status = %q, want open", got)
+	}
+	if got := store.request.ResourceURN; got != "urn:cerebro:writer:okta_resource:policyrule:pol-1" {
+		t.Fatalf("ListFindings().ResourceURN = %q, want policy rule urn", got)
+	}
+	if got := store.request.EventID; got != "okta-audit-2" {
+		t.Fatalf("ListFindings().EventID = %q, want okta-audit-2", got)
+	}
+	if got := store.request.Limit; got != 1 {
+		t.Fatalf("ListFindings().Limit = %d, want 1", got)
+	}
+}
+
+func TestListFindingsRequiresAvailableDependencies(t *testing.T) {
+	service := New(nil, nil, nil)
+	if _, err := service.ListFindings(context.Background(), ListRequest{RuntimeID: "writer-okta-audit"}); !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("ListFindings() error = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}
+
 func newAuditEvent(id string, eventType string, outcome string) *cerebrov1.EventEnvelope {
 	return &cerebrov1.EventEnvelope{
 		Id:         id,
@@ -208,4 +431,42 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 		FirstObservedAt: finding.FirstObservedAt,
 		LastObservedAt:  finding.LastObservedAt,
 	}
+}
+
+func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRecord) bool {
+	if finding == nil {
+		return false
+	}
+	if strings.TrimSpace(finding.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+		return false
+	}
+	if request.FindingID != "" && strings.TrimSpace(finding.ID) != strings.TrimSpace(request.FindingID) {
+		return false
+	}
+	if request.RuleID != "" && strings.TrimSpace(finding.RuleID) != strings.TrimSpace(request.RuleID) {
+		return false
+	}
+	if request.Severity != "" && strings.TrimSpace(finding.Severity) != strings.TrimSpace(request.Severity) {
+		return false
+	}
+	if request.Status != "" && strings.TrimSpace(finding.Status) != strings.TrimSpace(request.Status) {
+		return false
+	}
+	if request.ResourceURN != "" && !containsTrimmed(finding.ResourceURNs, request.ResourceURN) {
+		return false
+	}
+	if request.EventID != "" && !containsTrimmed(finding.EventIDs, request.EventID) {
+		return false
+	}
+	return true
+}
+
+func containsTrimmed(values []string, expected string) bool {
+	trimmedExpected := strings.TrimSpace(expected)
+	for _, value := range values {
+		if strings.TrimSpace(value) == trimmedExpected {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -450,14 +450,6 @@ func (s *Store) DeleteProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	if relation == "" {
 		return errors.New("projected link relation is required")
 	}
-	tenantID := strings.TrimSpace(link.TenantID)
-	if tenantID == "" {
-		return errors.New("projected link tenant id is required")
-	}
-	sourceID := strings.TrimSpace(link.SourceID)
-	if sourceID == "" {
-		return errors.New("projected link source id is required")
-	}
 	if s == nil || s.db == nil {
 		return errors.New("kuzu is not configured")
 	}
@@ -465,11 +457,9 @@ func (s *Store) DeleteProjectedLink(ctx context.Context, link *ports.ProjectedLi
 		return err
 	}
 	statement := fmt.Sprintf(
-		"MATCH (src:entity {urn: %s})-[r:relation {relation: %s, tenant_id: %s, source_id: %s}]->(dst:entity {urn: %s}) DELETE r",
+		"MATCH (src:entity {urn: %s})-[r:relation {relation: %s}]->(dst:entity {urn: %s}) DELETE r",
 		cypherString(fromURN),
 		cypherString(relation),
-		cypherString(tenantID),
-		cypherString(sourceID),
 		cypherString(toURN),
 	)
 	if _, err := s.db.ExecContext(ctx, statement); err != nil {

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -433,6 +433,51 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	return nil
 }
 
+// DeleteProjectedLink removes one normalized link from the graph store.
+func (s *Store) DeleteProjectedLink(ctx context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return errors.New("projected link is required")
+	}
+	fromURN := strings.TrimSpace(link.FromURN)
+	if fromURN == "" {
+		return errors.New("projected link from urn is required")
+	}
+	toURN := strings.TrimSpace(link.ToURN)
+	if toURN == "" {
+		return errors.New("projected link to urn is required")
+	}
+	relation := strings.TrimSpace(link.Relation)
+	if relation == "" {
+		return errors.New("projected link relation is required")
+	}
+	tenantID := strings.TrimSpace(link.TenantID)
+	if tenantID == "" {
+		return errors.New("projected link tenant id is required")
+	}
+	sourceID := strings.TrimSpace(link.SourceID)
+	if sourceID == "" {
+		return errors.New("projected link source id is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("kuzu is not configured")
+	}
+	if err := s.ensureProjectionSchema(ctx); err != nil {
+		return err
+	}
+	statement := fmt.Sprintf(
+		"MATCH (src:entity {urn: %s})-[r:relation {relation: %s, tenant_id: %s, source_id: %s}]->(dst:entity {urn: %s}) DELETE r",
+		cypherString(fromURN),
+		cypherString(relation),
+		cypherString(tenantID),
+		cypherString(sourceID),
+		cypherString(toURN),
+	)
+	if _, err := s.db.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("delete projected link %q %q %q: %w", fromURN, relation, toURN, err)
+	}
+	return nil
+}
+
 func (s *Store) ensureProjectionSchema(ctx context.Context) error {
 	if s == nil || s.db == nil {
 		return errors.New("kuzu is not configured")

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -66,6 +66,17 @@ func TestUpsertProjectedEntityAndLink(t *testing.T) {
 	if linkCount != 1 {
 		t.Fatalf("projected link count = %d, want 1", linkCount)
 	}
+
+	deleteLink := *link
+	deleteLink.TenantID = "updated-tenant"
+	deleteLink.SourceID = "updated-source"
+	if err := store.DeleteProjectedLink(ctx, &deleteLink); err != nil {
+		t.Fatalf("DeleteProjectedLink(changed tenant/source) error = %v", err)
+	}
+	linkCount = queryGraphCount(t, store, "MATCH (:entity)-[r:relation]->(:entity) RETURN COUNT(r)")
+	if linkCount != 0 {
+		t.Fatalf("projected link count after delete = %d, want 0", linkCount)
+	}
 }
 
 func TestProjectorBuildsTraversableLocalGraph(t *testing.T) {

--- a/internal/ports/claims.go
+++ b/internal/ports/claims.go
@@ -29,15 +29,16 @@ type ClaimRecord struct {
 
 // ListClaimsRequest scopes one claim query.
 type ListClaimsRequest struct {
-	RuntimeID   string
-	ClaimID     string
-	SubjectURN  string
-	Predicate   string
-	ObjectURN   string
-	ObjectValue string
-	ClaimType   string
-	Status      string
-	Limit       uint32
+	RuntimeID     string
+	ClaimID       string
+	SubjectURN    string
+	Predicate     string
+	ObjectURN     string
+	ObjectValue   string
+	ClaimType     string
+	Status        string
+	SourceEventID string
+	Limit         uint32
 }
 
 // ClaimStore persists normalized claims in the state store.

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -25,7 +25,14 @@ type FindingRecord struct {
 
 // ListFindingsRequest scopes one finding query.
 type ListFindingsRequest struct {
-	RuntimeID string
+	RuntimeID   string
+	FindingID   string
+	RuleID      string
+	Severity    string
+	Status      string
+	ResourceURN string
+	EventID     string
+	Limit       uint32
 }
 
 // FindingStore persists normalized findings in the state store.

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -46,6 +46,11 @@ type ProjectionGraphStore interface {
 	UpsertProjectedLink(context.Context, *ProjectedLink) error
 }
 
+// ProjectionLinkDeleter removes normalized links from projection stores that support deletion.
+type ProjectionLinkDeleter interface {
+	DeleteProjectedLink(context.Context, *ProjectedLink) error
+}
+
 // SourceProjector materializes source events into current-state and graph stores.
 type SourceProjector interface {
 	Project(context.Context, *cerebrov1.EventEnvelope) (ProjectionResult, error)

--- a/internal/statestore/postgres/claims.go
+++ b/internal/statestore/postgres/claims.go
@@ -40,6 +40,7 @@ var ensureClaimStatements = []string{
 	`CREATE INDEX IF NOT EXISTS claims_runtime_object_idx ON claims (runtime_id, object_urn)`,
 	`CREATE INDEX IF NOT EXISTS claims_runtime_type_status_idx ON claims (runtime_id, claim_type, status)`,
 	`CREATE INDEX IF NOT EXISTS claims_runtime_object_value_idx ON claims (runtime_id, object_value)`,
+	`CREATE INDEX IF NOT EXISTS claims_runtime_source_event_idx ON claims (runtime_id, source_event_id)`,
 }
 
 // UpsertClaim persists one normalized claim in the current-state store.
@@ -162,6 +163,7 @@ func (s *Store) ListClaims(ctx context.Context, request ports.ListClaimsRequest)
 	addFilter("object_value", request.ObjectValue)
 	addFilter("claim_type", request.ClaimType)
 	addFilter("status", request.Status)
+	addFilter("source_event_id", request.SourceEventID)
 
 	query := `
 SELECT runtime_id, tenant_id, claim_json::text

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -31,6 +31,10 @@ var ensureFindingStatements = []string{
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_rule_idx ON findings (runtime_id, rule_id)`,
+	`CREATE INDEX IF NOT EXISTS findings_runtime_status_idx ON findings (runtime_id, status)`,
+	`CREATE INDEX IF NOT EXISTS findings_runtime_severity_idx ON findings (runtime_id, severity)`,
+	`CREATE INDEX IF NOT EXISTS findings_resource_urns_gin_idx ON findings USING GIN (resource_urns_json)`,
+	`CREATE INDEX IF NOT EXISTS findings_event_ids_gin_idx ON findings USING GIN (event_ids_json)`,
 }
 
 // UpsertFinding persists one normalized finding in the current-state store.
@@ -163,25 +167,19 @@ RETURNING
 
 // ListFindings loads persisted findings for one runtime.
 func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequest) (_ []*ports.FindingRecord, err error) {
-	runtimeID := strings.TrimSpace(request.RuntimeID)
-	if runtimeID == "" {
-		return nil, errors.New("finding runtime id is required")
-	}
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
 	}
 	if err := s.ensureFindingTables(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := s.db.QueryContext(ctx, `
-SELECT
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, attributes_json::text, first_observed_at, last_observed_at
-FROM findings
-WHERE runtime_id = $1
-ORDER BY last_observed_at DESC, id`, runtimeID)
+	query, args, err := findingListQuery(request)
 	if err != nil {
-		return nil, fmt.Errorf("query findings for runtime %q: %w", runtimeID, err)
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query findings for runtime %q: %w", strings.TrimSpace(request.RuntimeID), err)
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil && err == nil {
@@ -222,6 +220,37 @@ ORDER BY last_observed_at DESC, id`, runtimeID)
 	return findings, nil
 }
 
+func findingListQuery(request ports.ListFindingsRequest) (string, []any, error) {
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return "", nil, errors.New("finding runtime id is required")
+	}
+	clauses := []string{"runtime_id = $1"}
+	args := []any{runtimeID}
+	addFindingFilter(&clauses, &args, "id", request.FindingID)
+	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
+	addFindingFilter(&clauses, &args, "severity", request.Severity)
+	addFindingFilter(&clauses, &args, "status", request.Status)
+	if err := addFindingArrayContainsFilter(&clauses, &args, "resource_urns_json", request.ResourceURN); err != nil {
+		return "", nil, err
+	}
+	if err := addFindingArrayContainsFilter(&clauses, &args, "event_ids_json", request.EventID); err != nil {
+		return "", nil, err
+	}
+	query := `
+SELECT
+  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
+  resource_urns_json::text, event_ids_json::text, attributes_json::text, first_observed_at, last_observed_at
+FROM findings
+WHERE ` + strings.Join(clauses, " AND ") + `
+ORDER BY last_observed_at DESC, id`
+	if request.Limit != 0 {
+		args = append(args, int64(request.Limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	return query, args, nil
+}
+
 func (s *Store) ensureFindingTables(ctx context.Context) error {
 	for _, statement := range ensureFindingStatements {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {
@@ -257,6 +286,29 @@ func findingAttributesJSON(attributes map[string]string) (string, error) {
 		return "", err
 	}
 	return string(payload), nil
+}
+
+func addFindingFilter(clauses *[]string, args *[]any, column string, value string) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return
+	}
+	*args = append(*args, trimmed)
+	*clauses = append(*clauses, fmt.Sprintf("%s = $%d", column, len(*args)))
+}
+
+func addFindingArrayContainsFilter(clauses *[]string, args *[]any, column string, value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	payload, err := findingStringsJSON([]string{trimmed})
+	if err != nil {
+		return fmt.Errorf("marshal %s filter: %w", column, err)
+	}
+	*args = append(*args, payload)
+	*clauses = append(*clauses, fmt.Sprintf("%s @> $%d::jsonb", column, len(*args)))
+	return nil
 }
 
 type findingRow struct {

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,5 +66,50 @@ func TestListFindingsRejectsUnconfiguredStore(t *testing.T) {
 	store := &Store{}
 	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{RuntimeID: "writer-okta-audit"}); err == nil {
 		t.Fatal("ListFindings() error = nil, want non-nil")
+	}
+}
+
+func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
+	query, args, err := findingListQuery(ports.ListFindingsRequest{
+		RuntimeID:   "writer-okta-audit",
+		FindingID:   "finding-1",
+		RuleID:      "identity-okta-policy-rule-lifecycle-tampering",
+		Severity:    "HIGH",
+		Status:      "open",
+		ResourceURN: "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+		EventID:     "okta-audit-2",
+		Limit:       25,
+	})
+	if err != nil {
+		t.Fatalf("findingListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"runtime_id = $1",
+		"id = $2",
+		"rule_id = $3",
+		"severity = $4",
+		"status = $5",
+		"resource_urns_json @> $6::jsonb",
+		"event_ids_json @> $7::jsonb",
+		"LIMIT $8",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if got := len(args); got != 8 {
+		t.Fatalf("len(findingListQuery().args) = %d, want 8", got)
+	}
+	if got := args[0]; got != "writer-okta-audit" {
+		t.Fatalf("findingListQuery().args[0] = %#v, want writer-okta-audit", got)
+	}
+	if got := args[5]; got != `["urn:cerebro:writer:okta_resource:policyrule:pol-1"]` {
+		t.Fatalf("findingListQuery().args[5] = %#v, want resource urn array json", got)
+	}
+	if got := args[6]; got != `["okta-audit-2"]` {
+		t.Fatalf("findingListQuery().args[6] = %#v, want event id array json", got)
+	}
+	if got := args[7]; got != int64(25) {
+		t.Fatalf("findingListQuery().args[7] = %#v, want 25", got)
 	}
 }

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -151,14 +151,6 @@ func (s *Store) DeleteProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	if relation == "" {
 		return errors.New("projected link relation is required")
 	}
-	tenantID := strings.TrimSpace(link.TenantID)
-	if tenantID == "" {
-		return errors.New("projected link tenant id is required")
-	}
-	sourceID := strings.TrimSpace(link.SourceID)
-	if sourceID == "" {
-		return errors.New("projected link source id is required")
-	}
 	if s == nil || s.db == nil {
 		return errors.New("postgres is not configured")
 	}
@@ -167,8 +159,8 @@ func (s *Store) DeleteProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	}
 	if _, err := s.db.ExecContext(ctx, `
 DELETE FROM entity_links
-WHERE from_urn = $1 AND relation = $2 AND to_urn = $3 AND tenant_id = $4 AND source_id = $5`,
-		fromURN, relation, toURN, tenantID, sourceID); err != nil {
+WHERE from_urn = $1 AND relation = $2 AND to_urn = $3`,
+		fromURN, relation, toURN); err != nil {
 		return fmt.Errorf("delete projected link %q %q %q: %w", fromURN, relation, toURN, err)
 	}
 	return nil

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -134,6 +134,46 @@ DO UPDATE SET
 	return nil
 }
 
+// DeleteProjectedLink removes one normalized link from the current-state store.
+func (s *Store) DeleteProjectedLink(ctx context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return errors.New("projected link is required")
+	}
+	fromURN := strings.TrimSpace(link.FromURN)
+	if fromURN == "" {
+		return errors.New("projected link from urn is required")
+	}
+	toURN := strings.TrimSpace(link.ToURN)
+	if toURN == "" {
+		return errors.New("projected link to urn is required")
+	}
+	relation := strings.TrimSpace(link.Relation)
+	if relation == "" {
+		return errors.New("projected link relation is required")
+	}
+	tenantID := strings.TrimSpace(link.TenantID)
+	if tenantID == "" {
+		return errors.New("projected link tenant id is required")
+	}
+	sourceID := strings.TrimSpace(link.SourceID)
+	if sourceID == "" {
+		return errors.New("projected link source id is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureProjectionTables(ctx); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `
+DELETE FROM entity_links
+WHERE from_urn = $1 AND relation = $2 AND to_urn = $3 AND tenant_id = $4 AND source_id = $5`,
+		fromURN, relation, toURN, tenantID, sourceID); err != nil {
+		return fmt.Errorf("delete projected link %q %q %q: %w", fromURN, relation, toURN, err)
+	}
+	return nil
+}
+
 func (s *Store) ensureProjectionTables(ctx context.Context) error {
 	for _, statement := range ensureProjectionStatements {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -219,6 +219,7 @@ message SyncSourceRuntimeResponse {
 message WriteClaimsRequest {
   string runtime_id = 1;
   repeated Claim claims = 2;
+  bool replace_existing = 3;
 }
 
 // WriteClaimsResponse reports the persisted and projected batch totals.
@@ -226,6 +227,7 @@ message WriteClaimsResponse {
   uint32 claims_written = 1;
   uint32 entities_upserted = 2;
   uint32 relation_links_projected = 3;
+  uint32 claims_retracted = 4;
 }
 
 // ListClaimsRequest queries persisted claims for one stored runtime.
@@ -239,6 +241,7 @@ message ListClaimsRequest {
   string claim_type = 7;
   string status = 8;
   uint32 limit = 9;
+  string source_event_id = 10;
 }
 
 // ListClaimsResponse returns the matched persisted claims.

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -25,6 +25,7 @@ service BootstrapService {
   rpc SyncSourceRuntime(SyncSourceRuntimeRequest) returns (SyncSourceRuntimeResponse);
   rpc WriteClaims(WriteClaimsRequest) returns (WriteClaimsResponse);
   rpc ListClaims(ListClaimsRequest) returns (ListClaimsResponse);
+  rpc ListFindings(ListFindingsRequest) returns (ListFindingsResponse);
   rpc EvaluateSourceRuntimeFindings(EvaluateSourceRuntimeFindingsRequest) returns (EvaluateSourceRuntimeFindingsResponse);
   rpc GetEntityNeighborhood(GetEntityNeighborhoodRequest) returns (GetEntityNeighborhoodResponse);
 }
@@ -249,6 +250,18 @@ message ListClaimsResponse {
   repeated Claim claims = 1;
 }
 
+// ListFindingsRequest queries persisted findings for one stored runtime.
+message ListFindingsRequest {
+  string runtime_id = 1;
+  string finding_id = 2;
+  string rule_id = 3;
+  string severity = 4;
+  string status = 5;
+  string resource_urn = 6;
+  string event_id = 7;
+  uint32 limit = 8;
+}
+
 // Finding is the normalized persisted finding view for the first runtime evaluator slice.
 message Finding {
   string id = 1;
@@ -267,13 +280,19 @@ message Finding {
   google.protobuf.Timestamp last_observed_at = 14;
 }
 
-// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through the first built-in finding evaluator.
+// ListFindingsResponse returns the matched persisted findings.
+message ListFindingsResponse {
+  repeated Finding findings = 1;
+}
+
+// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through one registered finding rule.
 message EvaluateSourceRuntimeFindingsRequest {
   string id = 1;
   uint32 event_limit = 2;
+  string rule_id = 3;
 }
 
-// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, fixed rule spec, and persisted findings.
+// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, selected rule spec, and persisted findings.
 message EvaluateSourceRuntimeFindingsResponse {
   SourceRuntime runtime = 1;
   RuleSpec rule = 2;

--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -51,6 +51,8 @@ class Client:
     ) -> Any:
         payload: Dict[str, Any] = {"claims": claims}
         if options:
+            if "claims" in options:
+                raise ValueError("options must not include 'claims'")
             payload.update(options)
         result, _ = self._request_json("POST", f"/source-runtimes/{parse.quote(runtime_id)}/claims", payload)
         return result

--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -43,8 +43,16 @@ class Client:
         result, _ = self._request_json("GET", f"/source-runtimes/{parse.quote(runtime_id)}")
         return result
 
-    def write_claims(self, runtime_id: str, claims: list[Dict[str, Any]]) -> Any:
-        result, _ = self._request_json("POST", f"/source-runtimes/{parse.quote(runtime_id)}/claims", {"claims": claims})
+    def write_claims(
+        self,
+        runtime_id: str,
+        claims: list[Dict[str, Any]],
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        payload: Dict[str, Any] = {"claims": claims}
+        if options:
+            payload.update(options)
+        result, _ = self._request_json("POST", f"/source-runtimes/{parse.quote(runtime_id)}/claims", payload)
         return result
 
     def list_claims(self, runtime_id: str, filters: Optional[Dict[str, Any]] = None) -> Any:
@@ -303,8 +311,8 @@ class IntegrationClient:
         }
         return self.client.put_source_runtime(self.runtime_id, runtime)
 
-    def write_claims(self, claims: list[Dict[str, Any]]) -> Any:
-        return self.client.write_claims(self.runtime_id, claims)
+    def write_claims(self, claims: list[Dict[str, Any]], options: Optional[Dict[str, Any]] = None) -> Any:
+        return self.client.write_claims(self.runtime_id, claims, options)
 
     def list_claims(self, filters: Optional[Dict[str, Any]] = None) -> Any:
         return self.client.list_claims(self.runtime_id, filters)

--- a/sdk/python/cerebro_sdk/jira.py
+++ b/sdk/python/cerebro_sdk/jira.py
@@ -359,12 +359,16 @@ def onboard_jira_workspace_posture(
     integration = client.integration(runtime_id=runtime_id, tenant_id=tenant_id, integration="jira")
     runtime_config: Dict[str, str] = {}
     workspace_key = optional_string(posture.get("workspace_key"))
+    source_event_id = optional_string(posture.get("event_id"))
     if workspace_key:
         runtime_config["workspace"] = workspace_key
     integration.ensure_runtime(runtime_config)
     claims = build_jira_workspace_claims(integration, posture)
-    write_result = integration.write_claims(claims)
-    persisted = integration.list_claims({"limit": 100})
+    write_result = integration.write_claims(claims, {"replace_existing": True})
+    filters: Dict[str, Any] = {"limit": 100, "status": "asserted"}
+    if source_event_id:
+        filters["source_event_id"] = source_event_id
+    persisted = integration.list_claims(filters)
     persisted_claims = persisted.get("claims", [])
     if not isinstance(persisted_claims, list):
         persisted_claims = []

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -194,8 +194,8 @@ export class Client {
 
   async writeClaims(runtimeId: string, claims: Claim[], options: WriteClaimsOptions = {}): Promise<Record<string, unknown>> {
     return this.requestJson<Record<string, unknown>>("POST", `/source-runtimes/${encodeURIComponent(runtimeId)}/claims`, {
-      claims,
       ...options,
+      claims,
     });
   }
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -86,6 +86,10 @@ export interface ClaimOptions {
   claim_type?: string;
 }
 
+export interface WriteClaimsOptions {
+  replace_existing?: boolean;
+}
+
 export interface ListClaimsOptions {
   claim_id?: string;
   subject_urn?: string;
@@ -94,6 +98,7 @@ export interface ListClaimsOptions {
   object_value?: string;
   claim_type?: string;
   status?: string;
+  source_event_id?: string;
   limit?: number;
 }
 
@@ -187,8 +192,11 @@ export class Client {
     return this.requestJson<Record<string, unknown>>("GET", `/source-runtimes/${encodeURIComponent(runtimeId)}`);
   }
 
-  async writeClaims(runtimeId: string, claims: Claim[]): Promise<Record<string, unknown>> {
-    return this.requestJson<Record<string, unknown>>("POST", `/source-runtimes/${encodeURIComponent(runtimeId)}/claims`, { claims });
+  async writeClaims(runtimeId: string, claims: Claim[], options: WriteClaimsOptions = {}): Promise<Record<string, unknown>> {
+    return this.requestJson<Record<string, unknown>>("POST", `/source-runtimes/${encodeURIComponent(runtimeId)}/claims`, {
+      claims,
+      ...options,
+    });
   }
 
   async listClaims(runtimeId: string, options: ListClaimsOptions = {}): Promise<Record<string, unknown>> {
@@ -518,8 +526,8 @@ export class IntegrationClient {
     });
   }
 
-  async writeClaims(claims: Claim[]): Promise<Record<string, unknown>> {
-    return this.client.writeClaims(this.runtimeId, claims);
+  async writeClaims(claims: Claim[], options: WriteClaimsOptions = {}): Promise<Record<string, unknown>> {
+    return this.client.writeClaims(this.runtimeId, claims, options);
   }
 
   async listClaims(options: ListClaimsOptions = {}): Promise<Record<string, unknown>> {

--- a/sdk/typescript/src/jira.ts
+++ b/sdk/typescript/src/jira.ts
@@ -377,13 +377,18 @@ export async function onboardJiraWorkspacePosture(
   });
   const runtimeConfig: Record<string, string> = {};
   const workspaceKey = requireValue(options.posture.workspaceKey, "posture.workspaceKey");
+  const sourceEventId = options.posture.eventId?.trim();
   if (workspaceKey) {
     runtimeConfig.workspace = workspaceKey;
   }
   await integration.ensureRuntime(runtimeConfig);
   const claims = buildJiraWorkspaceClaims(integration, options.posture);
-  const writeResult = await integration.writeClaims(claims);
-  const persisted = await integration.listClaims({ limit: 100 });
+  const writeResult = await integration.writeClaims(claims, { replace_existing: true });
+  const persisted = await integration.listClaims({
+    limit: 100,
+    status: "asserted",
+    ...(sourceEventId ? { source_event_id: sourceEventId } : {}),
+  });
   const graphLayering = await loadJiraWorkspaceGraphLayering(integration, options.posture);
   return {
     workspace_urn: claims[0]?.subject_urn ?? "",


### PR DESCRIPTION
## Summary
- add replace-existing claim writes that retract omitted asserted claims for a runtime snapshot
- add source-event claim filtering through bootstrap and both SDKs so snapshot readback can stay scoped
- update the Jira posture helpers to write reconciled snapshots and read back only asserted claims from the current snapshot

## Validation
- python3 -m py_compile sdk/python/cerebro_sdk/client.py sdk/python/cerebro_sdk/jira.py sdk/python/examples/jira_posture_onboarding.py
- python smoke for Jira posture claim and finding helpers
- npx -y -p typescript tsc -p sdk/typescript/tsconfig.json
- typescript smoke for Jira posture claim and finding helpers
- make verify