### PR TITLE
feat(findings): add runtime-scoped finding reads

### DIFF
--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -2280,11 +2280,12 @@ func (x *ListFindingsResponse) GetFindings() []*Finding {
 	return nil
 }
 
-// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through the first built-in finding evaluator.
+// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through one registered finding rule.
 type EvaluateSourceRuntimeFindingsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	EventLimit    uint32                 `protobuf:"varint,2,opt,name=event_limit,json=eventLimit,proto3" json:"event_limit,omitempty"`
+	RuleId        string                 `protobuf:"bytes,3,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2333,7 +2334,14 @@ func (x *EvaluateSourceRuntimeFindingsRequest) GetEventLimit() uint32 {
 	return 0
 }
 
-// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, fixed rule spec, and persisted findings.
+func (x *EvaluateSourceRuntimeFindingsRequest) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, selected rule spec, and persisted findings.
 type EvaluateSourceRuntimeFindingsResponse struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	Runtime          *SourceRuntime         `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
@@ -2851,11 +2859,12 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"G\n" +
 	"\x14ListFindingsResponse\x12/\n" +
-	"\bfindings\x18\x01 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\"W\n" +
+	"\bfindings\x18\x01 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\"p\n" +
 	"$EvaluateSourceRuntimeFindingsRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vevent_limit\x18\x02 \x01(\rR\n" +
-	"eventLimit\"\x8f\x02\n" +
+	"eventLimit\x12\x17\n" +
+	"\arule_id\x18\x03 \x01(\tR\x06ruleId\"\x8f\x02\n" +
 	"%EvaluateSourceRuntimeFindingsResponse\x123\n" +
 	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\x12(\n" +
 	"\x04rule\x18\x02 \x01(\v2\x14.cerebro.v1.RuleSpecR\x04rule\x12)\n" +

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -1985,6 +1985,107 @@ func (x *ListClaimsResponse) GetClaims() []*Claim {
 	return nil
 }
 
+// ListFindingsRequest queries persisted findings for one stored runtime.
+type ListFindingsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RuntimeId     string                 `protobuf:"bytes,1,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	FindingId     string                 `protobuf:"bytes,2,opt,name=finding_id,json=findingId,proto3" json:"finding_id,omitempty"`
+	RuleId        string                 `protobuf:"bytes,3,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	Severity      string                 `protobuf:"bytes,4,opt,name=severity,proto3" json:"severity,omitempty"`
+	Status        string                 `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
+	ResourceUrn   string                 `protobuf:"bytes,6,opt,name=resource_urn,json=resourceUrn,proto3" json:"resource_urn,omitempty"`
+	EventId       string                 `protobuf:"bytes,7,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Limit         uint32                 `protobuf:"varint,8,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFindingsRequest) Reset() {
+	*x = ListFindingsRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFindingsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFindingsRequest) ProtoMessage() {}
+
+func (x *ListFindingsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFindingsRequest.ProtoReflect.Descriptor instead.
+func (*ListFindingsRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *ListFindingsRequest) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetFindingId() string {
+	if x != nil {
+		return x.FindingId
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetSeverity() string {
+	if x != nil {
+		return x.Severity
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetResourceUrn() string {
+	if x != nil {
+		return x.ResourceUrn
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *ListFindingsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
 // Finding is the normalized persisted finding view for the first runtime evaluator slice.
 type Finding struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
@@ -2008,7 +2109,7 @@ type Finding struct {
 
 func (x *Finding) Reset() {
 	*x = Finding{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2020,7 +2121,7 @@ func (x *Finding) String() string {
 func (*Finding) ProtoMessage() {}
 
 func (x *Finding) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2033,7 +2134,7 @@ func (x *Finding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Finding.ProtoReflect.Descriptor instead.
 func (*Finding) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *Finding) GetId() string {
@@ -2134,6 +2235,51 @@ func (x *Finding) GetLastObservedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+// ListFindingsResponse returns the matched persisted findings.
+type ListFindingsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Findings      []*Finding             `protobuf:"bytes,1,rep,name=findings,proto3" json:"findings,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFindingsResponse) Reset() {
+	*x = ListFindingsResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFindingsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFindingsResponse) ProtoMessage() {}
+
+func (x *ListFindingsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFindingsResponse.ProtoReflect.Descriptor instead.
+func (*ListFindingsResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *ListFindingsResponse) GetFindings() []*Finding {
+	if x != nil {
+		return x.Findings
+	}
+	return nil
+}
+
 // EvaluateSourceRuntimeFindingsRequest replays one stored runtime through the first built-in finding evaluator.
 type EvaluateSourceRuntimeFindingsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2145,7 +2291,7 @@ type EvaluateSourceRuntimeFindingsRequest struct {
 
 func (x *EvaluateSourceRuntimeFindingsRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2157,7 +2303,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) String() string {
 func (*EvaluateSourceRuntimeFindingsRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2170,7 +2316,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *EvaluateSourceRuntimeFindingsRequest) GetId() string {
@@ -2201,7 +2347,7 @@ type EvaluateSourceRuntimeFindingsResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingsResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2213,7 +2359,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) String() string {
 func (*EvaluateSourceRuntimeFindingsResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2226,7 +2372,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *EvaluateSourceRuntimeFindingsResponse) GetRuntime() *SourceRuntime {
@@ -2276,7 +2422,7 @@ type GraphEntity struct {
 
 func (x *GraphEntity) Reset() {
 	*x = GraphEntity{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2288,7 +2434,7 @@ func (x *GraphEntity) String() string {
 func (*GraphEntity) ProtoMessage() {}
 
 func (x *GraphEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2301,7 +2447,7 @@ func (x *GraphEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphEntity.ProtoReflect.Descriptor instead.
 func (*GraphEntity) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{37}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GraphEntity) GetUrn() string {
@@ -2337,7 +2483,7 @@ type GraphRelation struct {
 
 func (x *GraphRelation) Reset() {
 	*x = GraphRelation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2349,7 +2495,7 @@ func (x *GraphRelation) String() string {
 func (*GraphRelation) ProtoMessage() {}
 
 func (x *GraphRelation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2362,7 +2508,7 @@ func (x *GraphRelation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphRelation.ProtoReflect.Descriptor instead.
 func (*GraphRelation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{38}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GraphRelation) GetFromUrn() string {
@@ -2397,7 +2543,7 @@ type GetEntityNeighborhoodRequest struct {
 
 func (x *GetEntityNeighborhoodRequest) Reset() {
 	*x = GetEntityNeighborhoodRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2409,7 +2555,7 @@ func (x *GetEntityNeighborhoodRequest) String() string {
 func (*GetEntityNeighborhoodRequest) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2422,7 +2568,7 @@ func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodRequest.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{39}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetEntityNeighborhoodRequest) GetRootUrn() string {
@@ -2451,7 +2597,7 @@ type GetEntityNeighborhoodResponse struct {
 
 func (x *GetEntityNeighborhoodResponse) Reset() {
 	*x = GetEntityNeighborhoodResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2463,7 +2609,7 @@ func (x *GetEntityNeighborhoodResponse) String() string {
 func (*GetEntityNeighborhoodResponse) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2476,7 +2622,7 @@ func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodResponse.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{40}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *GetEntityNeighborhoodResponse) GetRoot() *GraphEntity {
@@ -2670,7 +2816,18 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x0fsource_event_id\x18\n" +
 	" \x01(\tR\rsourceEventId\"?\n" +
 	"\x12ListClaimsResponse\x12)\n" +
-	"\x06claims\x18\x01 \x03(\v2\x11.cerebro.v1.ClaimR\x06claims\"\xc8\x04\n" +
+	"\x06claims\x18\x01 \x03(\v2\x11.cerebro.v1.ClaimR\x06claims\"\xf4\x01\n" +
+	"\x13ListFindingsRequest\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12\x1d\n" +
+	"\n" +
+	"finding_id\x18\x02 \x01(\tR\tfindingId\x12\x17\n" +
+	"\arule_id\x18\x03 \x01(\tR\x06ruleId\x12\x1a\n" +
+	"\bseverity\x18\x04 \x01(\tR\bseverity\x12\x16\n" +
+	"\x06status\x18\x05 \x01(\tR\x06status\x12!\n" +
+	"\fresource_urn\x18\x06 \x01(\tR\vresourceUrn\x12\x19\n" +
+	"\bevent_id\x18\a \x01(\tR\aeventId\x12\x14\n" +
+	"\x05limit\x18\b \x01(\rR\x05limit\"\xc8\x04\n" +
 	"\aFinding\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12 \n" +
 	"\vfingerprint\x18\x02 \x01(\tR\vfingerprint\x12\x1b\n" +
@@ -2692,7 +2849,9 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x10last_observed_at\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\x0elastObservedAt\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"W\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"G\n" +
+	"\x14ListFindingsResponse\x12/\n" +
+	"\bfindings\x18\x01 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\"W\n" +
 	"$EvaluateSourceRuntimeFindingsRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vevent_limit\x18\x02 \x01(\rR\n" +
@@ -2718,7 +2877,7 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x1dGetEntityNeighborhoodResponse\x12+\n" +
 	"\x04root\x18\x01 \x01(\v2\x17.cerebro.v1.GraphEntityR\x04root\x125\n" +
 	"\tneighbors\x18\x02 \x03(\v2\x17.cerebro.v1.GraphEntityR\tneighbors\x127\n" +
-	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\xb2\v\n" +
+	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\x85\f\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -2736,7 +2895,8 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x11SyncSourceRuntime\x12$.cerebro.v1.SyncSourceRuntimeRequest\x1a%.cerebro.v1.SyncSourceRuntimeResponse\x12N\n" +
 	"\vWriteClaims\x12\x1e.cerebro.v1.WriteClaimsRequest\x1a\x1f.cerebro.v1.WriteClaimsResponse\x12K\n" +
 	"\n" +
-	"ListClaims\x12\x1d.cerebro.v1.ListClaimsRequest\x1a\x1e.cerebro.v1.ListClaimsResponse\x12\x84\x01\n" +
+	"ListClaims\x12\x1d.cerebro.v1.ListClaimsRequest\x1a\x1e.cerebro.v1.ListClaimsResponse\x12Q\n" +
+	"\fListFindings\x12\x1f.cerebro.v1.ListFindingsRequest\x1a .cerebro.v1.ListFindingsResponse\x12\x84\x01\n" +
 	"\x1dEvaluateSourceRuntimeFindings\x120.cerebro.v1.EvaluateSourceRuntimeFindingsRequest\x1a1.cerebro.v1.EvaluateSourceRuntimeFindingsResponse\x12l\n" +
 	"\x15GetEntityNeighborhood\x12(.cerebro.v1.GetEntityNeighborhoodRequest\x1a).cerebro.v1.GetEntityNeighborhoodResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
 
@@ -2752,7 +2912,7 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 50)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*GetVersionRequest)(nil),                     // 0: cerebro.v1.GetVersionRequest
 	(*GetVersionResponse)(nil),                    // 1: cerebro.v1.GetVersionResponse
@@ -2788,113 +2948,118 @@ var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*WriteClaimsResponse)(nil),                   // 31: cerebro.v1.WriteClaimsResponse
 	(*ListClaimsRequest)(nil),                     // 32: cerebro.v1.ListClaimsRequest
 	(*ListClaimsResponse)(nil),                    // 33: cerebro.v1.ListClaimsResponse
-	(*Finding)(nil),                               // 34: cerebro.v1.Finding
-	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 35: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 36: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	(*GraphEntity)(nil),                           // 37: cerebro.v1.GraphEntity
-	(*GraphRelation)(nil),                         // 38: cerebro.v1.GraphRelation
-	(*GetEntityNeighborhoodRequest)(nil),          // 39: cerebro.v1.GetEntityNeighborhoodRequest
-	(*GetEntityNeighborhoodResponse)(nil),         // 40: cerebro.v1.GetEntityNeighborhoodResponse
-	nil,                                           // 41: cerebro.v1.ReportRun.ParametersEntry
-	nil,                                           // 42: cerebro.v1.RunReportRequest.ParametersEntry
-	nil,                                           // 43: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                                           // 44: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                                           // 45: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                                           // 46: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                                           // 47: cerebro.v1.Finding.AttributesEntry
-	(*timestamppb.Timestamp)(nil),                 // 48: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                       // 49: google.protobuf.Struct
-	(*SourceSpec)(nil),                            // 50: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),                          // 51: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                         // 52: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                        // 53: google.protobuf.Value
-	(*SourceCheckpoint)(nil),                      // 54: cerebro.v1.SourceCheckpoint
-	(*Claim)(nil),                                 // 55: cerebro.v1.Claim
-	(*RuleSpec)(nil),                              // 56: cerebro.v1.RuleSpec
+	(*ListFindingsRequest)(nil),                   // 34: cerebro.v1.ListFindingsRequest
+	(*Finding)(nil),                               // 35: cerebro.v1.Finding
+	(*ListFindingsResponse)(nil),                  // 36: cerebro.v1.ListFindingsResponse
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 37: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 38: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	(*GraphEntity)(nil),                           // 39: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                         // 40: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),          // 41: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),         // 42: cerebro.v1.GetEntityNeighborhoodResponse
+	nil,                                           // 43: cerebro.v1.ReportRun.ParametersEntry
+	nil,                                           // 44: cerebro.v1.RunReportRequest.ParametersEntry
+	nil,                                           // 45: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                           // 46: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                           // 47: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                           // 48: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                           // 49: cerebro.v1.Finding.AttributesEntry
+	(*timestamppb.Timestamp)(nil),                 // 50: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                       // 51: google.protobuf.Struct
+	(*SourceSpec)(nil),                            // 52: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                          // 53: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                         // 54: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                        // 55: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                      // 56: cerebro.v1.SourceCheckpoint
+	(*Claim)(nil),                                 // 57: cerebro.v1.Claim
+	(*RuleSpec)(nil),                              // 58: cerebro.v1.RuleSpec
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	48, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	50, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
 	5,  // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
-	41, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
-	48, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
-	49, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
+	43, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
+	50, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
+	51, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
 	6,  // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
-	42, // 7: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
+	44, // 7: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
 	6,  // 8: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
 	7,  // 9: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
 	7,  // 10: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
-	50, // 11: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	43, // 12: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	50, // 13: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	44, // 14: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	50, // 15: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	45, // 16: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	51, // 17: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	52, // 18: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	53, // 19: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	50, // 20: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	52, // 21: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	54, // 22: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	51, // 23: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	52, // 11: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	45, // 12: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	52, // 13: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	46, // 14: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	52, // 15: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	47, // 16: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	53, // 17: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	54, // 18: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	55, // 19: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	52, // 20: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	54, // 21: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	56, // 22: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	53, // 23: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
 	21, // 24: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	46, // 25: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	54, // 26: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	51, // 27: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	48, // 28: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	48, // 25: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	56, // 26: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	53, // 27: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	50, // 28: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
 	23, // 29: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
 	23, // 30: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	23, // 31: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	23, // 32: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	50, // 33: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	55, // 34: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	55, // 35: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
-	47, // 36: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	48, // 37: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	48, // 38: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	23, // 39: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	56, // 40: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	34, // 41: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	37, // 42: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	37, // 43: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	38, // 44: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	0,  // 45: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2,  // 46: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	8,  // 47: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	10, // 48: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	12, // 49: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	14, // 50: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	16, // 51: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	18, // 52: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	20, // 53: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	24, // 54: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	26, // 55: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	28, // 56: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	30, // 57: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	32, // 58: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
-	35, // 59: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	39, // 60: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	1,  // 61: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4,  // 62: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	9,  // 63: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	11, // 64: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	13, // 65: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	15, // 66: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	17, // 67: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	19, // 68: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	22, // 69: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	25, // 70: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	27, // 71: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	29, // 72: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	31, // 73: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	33, // 74: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
-	36, // 75: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	40, // 76: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	61, // [61:77] is the sub-list for method output_type
-	45, // [45:61] is the sub-list for method input_type
-	45, // [45:45] is the sub-list for extension type_name
-	45, // [45:45] is the sub-list for extension extendee
-	0,  // [0:45] is the sub-list for field type_name
+	52, // 33: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	57, // 34: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	57, // 35: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	49, // 36: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	50, // 37: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	50, // 38: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	35, // 39: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	23, // 40: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	58, // 41: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	35, // 42: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	39, // 43: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	39, // 44: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	40, // 45: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	0,  // 46: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 47: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	8,  // 48: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	10, // 49: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	12, // 50: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	14, // 51: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	16, // 52: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	18, // 53: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	20, // 54: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	24, // 55: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	26, // 56: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	28, // 57: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	30, // 58: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	32, // 59: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	34, // 60: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
+	37, // 61: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	41, // 62: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	1,  // 63: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 64: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	9,  // 65: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	11, // 66: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	13, // 67: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	15, // 68: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	17, // 69: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	19, // 70: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	22, // 71: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	25, // 72: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	27, // 73: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	29, // 74: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	31, // 75: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	33, // 76: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	36, // 77: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
+	38, // 78: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	42, // 79: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	63, // [63:80] is the sub-list for method output_type
+	46, // [46:63] is the sub-list for method input_type
+	46, // [46:46] is the sub-list for extension type_name
+	46, // [46:46] is the sub-list for extension extendee
+	0,  // [0:46] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -2910,7 +3075,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   48,
+			NumMessages:   50,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -75,6 +75,9 @@ const (
 	// BootstrapServiceListClaimsProcedure is the fully-qualified name of the BootstrapService's
 	// ListClaims RPC.
 	BootstrapServiceListClaimsProcedure = "/cerebro.v1.BootstrapService/ListClaims"
+	// BootstrapServiceListFindingsProcedure is the fully-qualified name of the BootstrapService's
+	// ListFindings RPC.
+	BootstrapServiceListFindingsProcedure = "/cerebro.v1.BootstrapService/ListFindings"
 	// BootstrapServiceEvaluateSourceRuntimeFindingsProcedure is the fully-qualified name of the
 	// BootstrapService's EvaluateSourceRuntimeFindings RPC.
 	BootstrapServiceEvaluateSourceRuntimeFindingsProcedure = "/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindings"
@@ -99,6 +102,7 @@ type BootstrapServiceClient interface {
 	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
 	WriteClaims(context.Context, *connect.Request[v1.WriteClaimsRequest]) (*connect.Response[v1.WriteClaimsResponse], error)
 	ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error)
+	ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
@@ -198,6 +202,12 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("ListClaims")),
 			connect.WithClientOptions(opts...),
 		),
+		listFindings: connect.NewClient[v1.ListFindingsRequest, v1.ListFindingsResponse](
+			httpClient,
+			baseURL+BootstrapServiceListFindingsProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("ListFindings")),
+			connect.WithClientOptions(opts...),
+		),
 		evaluateSourceRuntimeFindings: connect.NewClient[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse](
 			httpClient,
 			baseURL+BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
@@ -229,6 +239,7 @@ type bootstrapServiceClient struct {
 	syncSourceRuntime             *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
 	writeClaims                   *connect.Client[v1.WriteClaimsRequest, v1.WriteClaimsResponse]
 	listClaims                    *connect.Client[v1.ListClaimsRequest, v1.ListClaimsResponse]
+	listFindings                  *connect.Client[v1.ListFindingsRequest, v1.ListFindingsResponse]
 	evaluateSourceRuntimeFindings *connect.Client[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse]
 	getEntityNeighborhood         *connect.Client[v1.GetEntityNeighborhoodRequest, v1.GetEntityNeighborhoodResponse]
 }
@@ -303,6 +314,11 @@ func (c *bootstrapServiceClient) ListClaims(ctx context.Context, req *connect.Re
 	return c.listClaims.CallUnary(ctx, req)
 }
 
+// ListFindings calls cerebro.v1.BootstrapService.ListFindings.
+func (c *bootstrapServiceClient) ListFindings(ctx context.Context, req *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error) {
+	return c.listFindings.CallUnary(ctx, req)
+}
+
 // EvaluateSourceRuntimeFindings calls cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings.
 func (c *bootstrapServiceClient) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {
 	return c.evaluateSourceRuntimeFindings.CallUnary(ctx, req)
@@ -329,6 +345,7 @@ type BootstrapServiceHandler interface {
 	SyncSourceRuntime(context.Context, *connect.Request[v1.SyncSourceRuntimeRequest]) (*connect.Response[v1.SyncSourceRuntimeResponse], error)
 	WriteClaims(context.Context, *connect.Request[v1.WriteClaimsRequest]) (*connect.Response[v1.WriteClaimsResponse], error)
 	ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error)
+	ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
@@ -424,6 +441,12 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		connect.WithSchema(bootstrapServiceMethods.ByName("ListClaims")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bootstrapServiceListFindingsHandler := connect.NewUnaryHandler(
+		BootstrapServiceListFindingsProcedure,
+		svc.ListFindings,
+		connect.WithSchema(bootstrapServiceMethods.ByName("ListFindings")),
+		connect.WithHandlerOptions(opts...),
+	)
 	bootstrapServiceEvaluateSourceRuntimeFindingsHandler := connect.NewUnaryHandler(
 		BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
 		svc.EvaluateSourceRuntimeFindings,
@@ -466,6 +489,8 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceWriteClaimsHandler.ServeHTTP(w, r)
 		case BootstrapServiceListClaimsProcedure:
 			bootstrapServiceListClaimsHandler.ServeHTTP(w, r)
+		case BootstrapServiceListFindingsProcedure:
+			bootstrapServiceListFindingsHandler.ServeHTTP(w, r)
 		case BootstrapServiceEvaluateSourceRuntimeFindingsProcedure:
 			bootstrapServiceEvaluateSourceRuntimeFindingsHandler.ServeHTTP(w, r)
 		case BootstrapServiceGetEntityNeighborhoodProcedure:
@@ -533,6 +558,10 @@ func (UnimplementedBootstrapServiceHandler) WriteClaims(context.Context, *connec
 
 func (UnimplementedBootstrapServiceHandler) ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListClaims is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListFindings is not implemented"))
 }
 
 func (UnimplementedBootstrapServiceHandler) EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -72,6 +72,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/sync", app.handleSyncSourceRuntime)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/claims", app.handleListClaims)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/claims", app.handleWriteClaims)
+	mux.HandleFunc("GET /source-runtimes/{runtimeID}/findings", app.handleListFindings)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/findings/evaluate", app.handleEvaluateSourceRuntimeFindings)
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
@@ -346,6 +347,47 @@ func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http
 	writeProtoJSON(w, http.StatusOK, findingResponse(response))
 }
 
+func (a *App) handleListFindings(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.ListFindingsRequest{
+		RuntimeId:   r.PathValue("runtimeID"),
+		FindingId:   r.URL.Query().Get("finding_id"),
+		RuleId:      r.URL.Query().Get("rule_id"),
+		Severity:    r.URL.Query().Get("severity"),
+		Status:      r.URL.Query().Get("status"),
+		ResourceUrn: r.URL.Query().Get("resource_urn"),
+		EventId:     r.URL.Query().Get("event_id"),
+	}
+	if limit := r.URL.Query().Get("limit"); limit != "" {
+		body := []byte(`{"limit":` + limit + `}`)
+		if err := protojson.Unmarshal(body, request); err != nil {
+			writeFindingError(w, err)
+			return
+		}
+		request.RuntimeId = r.PathValue("runtimeID")
+		request.FindingId = r.URL.Query().Get("finding_id")
+		request.RuleId = r.URL.Query().Get("rule_id")
+		request.Severity = r.URL.Query().Get("severity")
+		request.Status = r.URL.Query().Get("status")
+		request.ResourceUrn = r.URL.Query().Get("resource_urn")
+		request.EventId = r.URL.Query().Get("event_id")
+	}
+	response, err := a.findingService().ListFindings(r.Context(), findings.ListRequest{
+		RuntimeID:   request.GetRuntimeId(),
+		FindingID:   request.GetFindingId(),
+		RuleID:      request.GetRuleId(),
+		Severity:    request.GetSeverity(),
+		Status:      request.GetStatus(),
+		ResourceURN: request.GetResourceUrn(),
+		EventID:     request.GetEventId(),
+		Limit:       request.GetLimit(),
+	})
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, listFindingsResponse(response))
+}
+
 func (s *bootstrapService) GetVersion(_ context.Context, _ *connect.Request[cerebrov1.GetVersionRequest]) (*connect.Response[cerebrov1.GetVersionResponse], error) {
 	return connect.NewResponse(&cerebrov1.GetVersionResponse{
 		ServiceName: buildinfo.ServiceName,
@@ -505,6 +547,27 @@ func (s *bootstrapService) ListClaims(ctx context.Context, req *connect.Request[
 	return connect.NewResponse(&cerebrov1.ListClaimsResponse{
 		Claims: response.Claims,
 	}), nil
+}
+
+func (s *bootstrapService) ListFindings(ctx context.Context, req *connect.Request[cerebrov1.ListFindingsRequest]) (*connect.Response[cerebrov1.ListFindingsResponse], error) {
+	response, err := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+	).ListFindings(ctx, findings.ListRequest{
+		RuntimeID:   req.Msg.GetRuntimeId(),
+		FindingID:   req.Msg.GetFindingId(),
+		RuleID:      req.Msg.GetRuleId(),
+		Severity:    req.Msg.GetSeverity(),
+		Status:      req.Msg.GetStatus(),
+		ResourceURN: req.Msg.GetResourceUrn(),
+		EventID:     req.Msg.GetEventId(),
+		Limit:       req.Msg.GetLimit(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(listFindingsResponse(response)), nil
 }
 
 func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingsResponse], error) {
@@ -775,12 +838,26 @@ func findingResponse(result *findings.EvaluateResult) *cerebrov1.EvaluateSourceR
 		Rule:             result.Rule,
 		EventsEvaluated:  result.EventsEvaluated,
 		FindingsUpserted: uint32(len(result.Findings)),
-		Findings:         make([]*cerebrov1.Finding, 0, len(result.Findings)),
-	}
-	for _, finding := range result.Findings {
-		response.Findings = append(response.Findings, findingMessage(finding))
+		Findings:         findingMessages(result.Findings),
 	}
 	return response
+}
+
+func listFindingsResponse(result *findings.ListResult) *cerebrov1.ListFindingsResponse {
+	if result == nil {
+		return &cerebrov1.ListFindingsResponse{}
+	}
+	return &cerebrov1.ListFindingsResponse{
+		Findings: findingMessages(result.Findings),
+	}
+}
+
+func findingMessages(findings []*ports.FindingRecord) []*cerebrov1.Finding {
+	messages := make([]*cerebrov1.Finding, 0, len(findings))
+	for _, finding := range findings {
+		messages = append(messages, findingMessage(finding))
+	}
+	return messages
 }
 
 func findingMessage(finding *ports.FindingRecord) *cerebrov1.Finding {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -328,6 +328,7 @@ func (a *App) handleWriteClaims(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http.Request) {
 	request := &cerebrov1.EvaluateSourceRuntimeFindingsRequest{}
+	request.RuleId = r.URL.Query().Get("rule_id")
 	if eventLimit := r.URL.Query().Get("event_limit"); eventLimit != "" {
 		body := []byte(`{"event_limit":` + eventLimit + `}`)
 		if err := protojson.Unmarshal(body, request); err != nil {
@@ -336,8 +337,10 @@ func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http
 		}
 	}
 	request.Id = r.PathValue("runtimeID")
+	request.RuleId = r.URL.Query().Get("rule_id")
 	response, err := a.findingService().EvaluateSourceRuntime(r.Context(), findings.EvaluateRequest{
 		RuntimeID:  request.GetId(),
+		RuleID:     request.GetRuleId(),
 		EventLimit: request.GetEventLimit(),
 	})
 	if err != nil {
@@ -577,6 +580,7 @@ func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, re
 		findingStore(s.deps.StateStore),
 	).EvaluateSourceRuntime(ctx, findings.EvaluateRequest{
 		RuntimeID:  req.Msg.GetId(),
+		RuleID:     req.Msg.GetRuleId(),
 		EventLimit: req.Msg.GetEventLimit(),
 	})
 	if err != nil {
@@ -727,6 +731,8 @@ func writeFindingError(w http.ResponseWriter, err error) {
 	statusCode := http.StatusBadRequest
 	switch {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
+		statusCode = http.StatusNotFound
+	case errors.Is(err, findings.ErrRuleNotFound):
 		statusCode = http.StatusNotFound
 	case errors.Is(err, findings.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -82,14 +82,15 @@ func (s *recordingAppendLog) Replay(_ context.Context, request ports.ReplayReque
 }
 
 type stubRuntimeStore struct {
-	err              error
-	runtimes         map[string]*cerebrov1.SourceRuntime
-	entities         map[string]*ports.ProjectedEntity
-	links            map[string]*ports.ProjectedLink
-	claims           map[string]*ports.ClaimRecord
-	claimListRequest ports.ListClaimsRequest
-	findings         map[string]*ports.FindingRecord
-	reportRuns       map[string]*cerebrov1.ReportRun
+	err                error
+	runtimes           map[string]*cerebrov1.SourceRuntime
+	entities           map[string]*ports.ProjectedEntity
+	links              map[string]*ports.ProjectedLink
+	claims             map[string]*ports.ClaimRecord
+	claimListRequest   ports.ListClaimsRequest
+	findings           map[string]*ports.FindingRecord
+	findingListRequest ports.ListFindingsRequest
+	reportRuns         map[string]*cerebrov1.ReportRun
 }
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
@@ -208,12 +209,30 @@ func (s *stubRuntimeStore) ListFindings(_ context.Context, request ports.ListFin
 	if s.err != nil {
 		return nil, s.err
 	}
+	s.findingListRequest = request
 	findings := []*ports.FindingRecord{}
 	for _, finding := range s.findings {
-		if finding == nil || finding.RuntimeID != request.RuntimeID {
+		if !findingMatches(request, finding) {
 			continue
 		}
 		findings = append(findings, cloneFinding(finding))
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		left := findings[i]
+		right := findings[j]
+		switch {
+		case left.LastObservedAt.Equal(right.LastObservedAt):
+			return left.ID < right.ID
+		case left.LastObservedAt.IsZero():
+			return false
+		case right.LastObservedAt.IsZero():
+			return true
+		default:
+			return left.LastObservedAt.After(right.LastObservedAt)
+		}
+	})
+	if request.Limit != 0 && len(findings) > int(request.Limit) {
+		findings = findings[:int(request.Limit)]
 	}
 	return findings, nil
 }
@@ -812,6 +831,30 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := findingPayload["summary"]; got != "admin@writer.com performed policy.rule.update on pol-1" {
 		t.Fatalf("evaluate finding summary = %#v, want admin summary", got)
 	}
+	listResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-okta-audit/findings?rule_id=identity-okta-policy-rule-lifecycle-tampering&status=open&event_id=okta-audit-2&limit=1")
+	if err != nil {
+		t.Fatalf("GET /source-runtimes/{id}/findings error = %v", err)
+	}
+	defer func() {
+		if closeErr := listResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close list findings response body: %v", closeErr)
+		}
+	}()
+	var listPayload map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&listPayload); err != nil {
+		t.Fatalf("decode list findings response: %v", err)
+	}
+	listedFindings, ok := listPayload["findings"].([]any)
+	if !ok || len(listedFindings) != 1 {
+		t.Fatalf("list findings payload = %#v, want 1 entry", listPayload["findings"])
+	}
+	listedFinding, ok := listedFindings[0].(map[string]any)
+	if !ok {
+		t.Fatalf("list findings entry = %#v, want object", listedFindings[0])
+	}
+	if got := listedFinding["rule_id"]; got != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("list finding rule_id = %#v, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	evaluateFindingsResp, err := client.EvaluateSourceRuntimeFindings(context.Background(), connect.NewRequest(&cerebrov1.EvaluateSourceRuntimeFindingsRequest{
@@ -832,6 +875,33 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := evaluateFindingsResp.Msg.GetRule().GetId(); got != "identity-okta-policy-rule-lifecycle-tampering" {
 		t.Fatalf("EvaluateSourceRuntimeFindings rule id = %q, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	listFindingsResp, err := client.ListFindings(context.Background(), connect.NewRequest(&cerebrov1.ListFindingsRequest{
+		RuntimeId:   "writer-okta-audit",
+		RuleId:      "identity-okta-policy-rule-lifecycle-tampering",
+		Severity:    "HIGH",
+		Status:      "open",
+		ResourceUrn: "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+		EventId:     "okta-audit-2",
+		Limit:       1,
+	}))
+	if err != nil {
+		t.Fatalf("ListFindings() error = %v", err)
+	}
+	if got := len(listFindingsResp.Msg.GetFindings()); got != 1 {
+		t.Fatalf("len(ListFindings().Findings) = %d, want 1", got)
+	}
+	if got := listFindingsResp.Msg.GetFindings()[0].GetId(); got == "" {
+		t.Fatal("ListFindings().Findings[0].ID = empty, want non-empty")
+	}
+	if got := runtimeStore.findingListRequest.RuleID; got != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("runtimeStore.findingListRequest.RuleID = %q, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	if got := runtimeStore.findingListRequest.ResourceURN; got != "urn:cerebro:writer:okta_resource:policyrule:pol-1" {
+		t.Fatalf("runtimeStore.findingListRequest.ResourceURN = %q, want policy rule urn", got)
+	}
+	if got := runtimeStore.findingListRequest.EventID; got != "okta-audit-2" {
+		t.Fatalf("runtimeStore.findingListRequest.EventID = %q, want okta-audit-2", got)
 	}
 	if len(runtimeStore.findings) != 1 {
 		t.Fatalf("len(runtimeStore.findings) = %d, want 1", len(runtimeStore.findings))
@@ -1447,6 +1517,34 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 	}
 }
 
+func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRecord) bool {
+	if finding == nil {
+		return false
+	}
+	if strings.TrimSpace(finding.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+		return false
+	}
+	if request.FindingID != "" && strings.TrimSpace(finding.ID) != strings.TrimSpace(request.FindingID) {
+		return false
+	}
+	if request.RuleID != "" && strings.TrimSpace(finding.RuleID) != strings.TrimSpace(request.RuleID) {
+		return false
+	}
+	if request.Severity != "" && strings.TrimSpace(finding.Severity) != strings.TrimSpace(request.Severity) {
+		return false
+	}
+	if request.Status != "" && strings.TrimSpace(finding.Status) != strings.TrimSpace(request.Status) {
+		return false
+	}
+	if request.ResourceURN != "" && !containsTrimmed(finding.ResourceURNs, request.ResourceURN) {
+		return false
+	}
+	if request.EventID != "" && !containsTrimmed(finding.EventIDs, request.EventID) {
+		return false
+	}
+	return true
+}
+
 func cloneClaim(claim *ports.ClaimRecord) *ports.ClaimRecord {
 	if claim == nil {
 		return nil
@@ -1507,6 +1605,16 @@ func claimMatches(request ports.ListClaimsRequest, claim *ports.ClaimRecord) boo
 		return false
 	}
 	return true
+}
+
+func containsTrimmed(values []string, expected string) bool {
+	trimmedExpected := strings.TrimSpace(expected)
+	for _, value := range values {
+		if strings.TrimSpace(value) == trimmedExpected {
+			return true
+		}
+	}
+	return false
 }
 
 func cloneReportRun(run *cerebrov1.ReportRun) *cerebrov1.ReportRun {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -794,7 +794,7 @@ func TestFindingEndpoints(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	evaluateReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?event_limit=2", nil)
+	evaluateReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?event_limit=2&rule_id=identity-okta-policy-rule-lifecycle-tampering", nil)
 	if err != nil {
 		t.Fatalf("new evaluate findings request: %v", err)
 	}
@@ -855,10 +855,23 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := listedFinding["rule_id"]; got != "identity-okta-policy-rule-lifecycle-tampering" {
 		t.Fatalf("list finding rule_id = %#v, want identity-okta-policy-rule-lifecycle-tampering", got)
 	}
+	missingRuleResp, err := server.Client().Post(server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?rule_id=does-not-exist", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/findings/evaluate unknown rule error = %v", err)
+	}
+	defer func() {
+		if closeErr := missingRuleResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close unknown rule response body: %v", closeErr)
+		}
+	}()
+	if got := missingRuleResp.StatusCode; got != http.StatusNotFound {
+		t.Fatalf("unknown rule status = %d, want %d", got, http.StatusNotFound)
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	evaluateFindingsResp, err := client.EvaluateSourceRuntimeFindings(context.Background(), connect.NewRequest(&cerebrov1.EvaluateSourceRuntimeFindingsRequest{
 		Id:         "writer-okta-audit",
+		RuleId:     "identity-okta-policy-rule-lifecycle-tampering",
 		EventLimit: 5,
 	}))
 	if err != nil {

--- a/internal/findings/okta_policy_rule_lifecycle_tampering_rule.go
+++ b/internal/findings/okta_policy_rule_lifecycle_tampering_rule.go
@@ -66,7 +66,7 @@ func (*oktaPolicyRuleLifecycleTamperingRule) Evaluate(ctx context.Context, runti
 	if !matchesOktaPolicyRuleLifecycleTampering(event) {
 		return nil, nil
 	}
-	record, err := oktaPolicyRuleLifecycleTamperingFinding(ctx, event, runtime.GetId())
+	record, err := oktaPolicyRuleLifecycleTamperingFinding(ctx, event, runtime)
 	if err != nil {
 		return nil, err
 	}
@@ -90,16 +90,22 @@ func matchesOktaPolicyRuleLifecycleTampering(event *cerebrov1.EventEnvelope) boo
 	return ok
 }
 
-func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
+func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebrov1.EventEnvelope, runtime *cerebrov1.SourceRuntime) (*ports.FindingRecord, error) {
 	resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, err := projectedEntityContext(ctx, event)
 	if err != nil {
 		return nil, fmt.Errorf("project finding context for event %q: %w", event.GetId(), err)
 	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		tenantID = strings.TrimSpace(event.GetTenantId())
+	}
+	runtimeID := strings.TrimSpace(runtime.GetId())
+	eventID := strings.TrimSpace(event.GetId())
 	attributes := map[string]string{
-		"event_id":             strings.TrimSpace(event.GetId()),
+		"event_id":             eventID,
 		"event_type":           strings.TrimSpace(event.GetAttributes()["event_type"]),
 		"outcome_result":       strings.TrimSpace(event.GetAttributes()["outcome_result"]),
-		"source_runtime_id":    strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID]),
+		"source_runtime_id":    runtimeID,
 		"primary_actor_urn":    actorURN,
 		"primary_resource_urn": resourceURN,
 	}
@@ -108,19 +114,24 @@ func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebro
 	if timestamp := event.GetOccurredAt(); timestamp != nil {
 		observedAt = timestamp.AsTime().UTC()
 	}
-	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, event.GetId())
+	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, tenantID, runtimeID, eventID)
+	if eventID != "" {
+		legacy := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, eventID)
+		attributes["legacy_finding_id"] = legacy
+		attributes["legacy_fingerprint"] = legacy
+	}
 	return &ports.FindingRecord{
 		ID:              fingerprint,
 		Fingerprint:     fingerprint,
-		TenantID:        strings.TrimSpace(event.GetTenantId()),
-		RuntimeID:       strings.TrimSpace(runtimeID),
+		TenantID:        tenantID,
+		RuntimeID:       runtimeID,
 		RuleID:          oktaPolicyRuleLifecycleTamperingRuleID,
 		Title:           oktaPolicyRuleLifecycleTamperingTitle,
 		Severity:        oktaPolicyRuleLifecycleTamperingSeverity,
 		Status:          oktaPolicyRuleLifecycleTamperingStatus,
 		Summary:         findingSummary(event, actorLabel, resourceLabel),
 		ResourceURNs:    resourceURNs,
-		EventIDs:        []string{strings.TrimSpace(event.GetId())},
+		EventIDs:        []string{eventID},
 		Attributes:      attributes,
 		FirstObservedAt: observedAt,
 		LastObservedAt:  observedAt,

--- a/internal/findings/okta_policy_rule_lifecycle_tampering_rule.go
+++ b/internal/findings/okta_policy_rule_lifecycle_tampering_rule.go
@@ -1,0 +1,279 @@
+package findings
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceprojection"
+)
+
+const (
+	oktaPolicyRuleLifecycleTamperingRuleID   = "identity-okta-policy-rule-lifecycle-tampering"
+	oktaPolicyRuleLifecycleTamperingTitle    = "Okta Policy Rule Lifecycle Tampering"
+	oktaPolicyRuleLifecycleTamperingSeverity = "HIGH"
+	oktaPolicyRuleLifecycleTamperingStatus   = "open"
+)
+
+var (
+	oktaPolicyRuleLifecycleTamperingEventTypes = map[string]struct{}{
+		"policy.rule.update":     {},
+		"policy.rule.deactivate": {},
+		"policy.rule.delete":     {},
+	}
+	oktaPolicyRuleLifecycleTamperingOutcomes = map[string]struct{}{
+		"success": {},
+		"allow":   {},
+		"allowed": {},
+	}
+)
+
+type oktaPolicyRuleLifecycleTamperingRule struct{}
+
+func newOktaPolicyRuleLifecycleTamperingRule() Rule {
+	return &oktaPolicyRuleLifecycleTamperingRule{}
+}
+
+func (*oktaPolicyRuleLifecycleTamperingRule) Spec() *cerebrov1.RuleSpec {
+	return &cerebrov1.RuleSpec{
+		Id:          oktaPolicyRuleLifecycleTamperingRuleID,
+		Name:        oktaPolicyRuleLifecycleTamperingTitle,
+		Description: "Detect successful Okta policy rule update, deactivate, or delete events replayed from one source runtime.",
+		InputStreamIds: []string{
+			"source-runtime-replay",
+		},
+		OutputKinds: []string{
+			"finding.okta_policy_rule_lifecycle_tampering",
+		},
+	}
+}
+
+func (*oktaPolicyRuleLifecycleTamperingRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	return runtime != nil && strings.EqualFold(strings.TrimSpace(runtime.GetSourceId()), "okta")
+}
+
+func (*oktaPolicyRuleLifecycleTamperingRule) Evaluate(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	if runtime == nil {
+		return nil, errors.New("source runtime is required")
+	}
+	if !matchesOktaPolicyRuleLifecycleTampering(event) {
+		return nil, nil
+	}
+	record, err := oktaPolicyRuleLifecycleTamperingFinding(ctx, event, runtime.GetId())
+	if err != nil {
+		return nil, err
+	}
+	return []*ports.FindingRecord{record}, nil
+}
+
+func matchesOktaPolicyRuleLifecycleTampering(event *cerebrov1.EventEnvelope) bool {
+	if event == nil || !strings.EqualFold(strings.TrimSpace(event.GetKind()), "okta.audit") {
+		return false
+	}
+	attributes := event.GetAttributes()
+	eventType := strings.ToLower(strings.TrimSpace(attributes["event_type"]))
+	if _, ok := oktaPolicyRuleLifecycleTamperingEventTypes[eventType]; !ok {
+		return false
+	}
+	outcome := strings.ToLower(strings.TrimSpace(attributes["outcome_result"]))
+	if outcome == "" {
+		outcome = "success"
+	}
+	_, ok := oktaPolicyRuleLifecycleTamperingOutcomes[outcome]
+	return ok
+}
+
+func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
+	resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, err := projectedEntityContext(ctx, event)
+	if err != nil {
+		return nil, fmt.Errorf("project finding context for event %q: %w", event.GetId(), err)
+	}
+	attributes := map[string]string{
+		"event_id":             strings.TrimSpace(event.GetId()),
+		"event_type":           strings.TrimSpace(event.GetAttributes()["event_type"]),
+		"outcome_result":       strings.TrimSpace(event.GetAttributes()["outcome_result"]),
+		"source_runtime_id":    strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID]),
+		"primary_actor_urn":    actorURN,
+		"primary_resource_urn": resourceURN,
+	}
+	trimEmptyAttributes(attributes)
+	observedAt := time.Time{}
+	if timestamp := event.GetOccurredAt(); timestamp != nil {
+		observedAt = timestamp.AsTime().UTC()
+	}
+	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, event.GetId())
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        strings.TrimSpace(event.GetTenantId()),
+		RuntimeID:       strings.TrimSpace(runtimeID),
+		RuleID:          oktaPolicyRuleLifecycleTamperingRuleID,
+		Title:           oktaPolicyRuleLifecycleTamperingTitle,
+		Severity:        oktaPolicyRuleLifecycleTamperingSeverity,
+		Status:          oktaPolicyRuleLifecycleTamperingStatus,
+		Summary:         findingSummary(event, actorLabel, resourceLabel),
+		ResourceURNs:    resourceURNs,
+		EventIDs:        []string{strings.TrimSpace(event.GetId())},
+		Attributes:      attributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}
+
+func projectedEntityContext(ctx context.Context, event *cerebrov1.EventEnvelope) ([]string, string, string, string, string, error) {
+	recorder := &projectionRecorder{
+		entities: make(map[string]*ports.ProjectedEntity),
+		links:    make(map[string]*ports.ProjectedLink),
+	}
+	if ctx == nil {
+		return nil, "", "", "", "", errors.New("context is required")
+	}
+	if _, err := sourceprojection.New(nil, recorder).Project(ctx, event); err != nil {
+		return nil, "", "", "", "", err
+	}
+	resourceURNs := make([]string, 0, len(recorder.entities))
+	seenURNs := make(map[string]struct{}, len(recorder.entities))
+	var actorURN string
+	var resourceURN string
+	for _, link := range recorder.links {
+		if !strings.EqualFold(strings.TrimSpace(link.Relation), "acted_on") {
+			continue
+		}
+		if actorURN == "" {
+			actorURN = strings.TrimSpace(link.FromURN)
+		}
+		if resourceURN == "" {
+			resourceURN = strings.TrimSpace(link.ToURN)
+		}
+		if candidate := strings.TrimSpace(link.FromURN); candidate != "" {
+			if _, ok := seenURNs[candidate]; !ok {
+				seenURNs[candidate] = struct{}{}
+				resourceURNs = append(resourceURNs, candidate)
+			}
+		}
+		if candidate := strings.TrimSpace(link.ToURN); candidate != "" {
+			if _, ok := seenURNs[candidate]; !ok {
+				seenURNs[candidate] = struct{}{}
+				resourceURNs = append(resourceURNs, candidate)
+			}
+		}
+	}
+	slices.Sort(resourceURNs)
+	actorLabel := entityLabel(recorder.entities[actorURN], event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"])
+	resourceLabel := entityLabel(recorder.entities[resourceURN], event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"])
+	return resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, nil
+}
+
+func entityLabel(entity *ports.ProjectedEntity, fallbacks ...string) string {
+	if entity != nil && strings.TrimSpace(entity.Label) != "" {
+		return strings.TrimSpace(entity.Label)
+	}
+	for _, fallback := range fallbacks {
+		if strings.TrimSpace(fallback) != "" {
+			return strings.TrimSpace(fallback)
+		}
+	}
+	return ""
+}
+
+func findingSummary(event *cerebrov1.EventEnvelope, actorLabel string, resourceLabel string) string {
+	eventType := strings.TrimSpace(event.GetAttributes()["event_type"])
+	actor := firstNonEmpty(actorLabel, event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"], "unknown actor")
+	resource := firstNonEmpty(resourceLabel, event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"], "unknown resource")
+	return fmt.Sprintf("%s performed %s on %s", actor, eventType, resource)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func trimEmptyAttributes(attributes map[string]string) {
+	for key, value := range attributes {
+		if strings.TrimSpace(value) == "" {
+			delete(attributes, key)
+		}
+	}
+}
+
+func hashFindingFingerprint(parts ...string) string {
+	hash := sha256.New()
+	for _, part := range parts {
+		_, _ = hash.Write([]byte(strings.TrimSpace(part)))
+		_, _ = hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+type projectionRecorder struct {
+	entities map[string]*ports.ProjectedEntity
+	links    map[string]*ports.ProjectedLink
+}
+
+func (r *projectionRecorder) Ping(context.Context) error {
+	return nil
+}
+
+func (r *projectionRecorder) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if entity == nil {
+		return nil
+	}
+	r.entities[entity.URN] = cloneEntity(entity)
+	return nil
+}
+
+func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	key := strings.TrimSpace(link.FromURN) + "|" + strings.TrimSpace(link.Relation) + "|" + strings.TrimSpace(link.ToURN)
+	r.links[key] = cloneLink(link)
+	return nil
+}
+
+func cloneEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
+	if entity == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(entity.Attributes))
+	for key, value := range entity.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedEntity{
+		URN:        entity.URN,
+		TenantID:   entity.TenantID,
+		SourceID:   entity.SourceID,
+		EntityType: entity.EntityType,
+		Label:      entity.Label,
+		Attributes: attributes,
+	}
+}
+
+func cloneLink(link *ports.ProjectedLink) *ports.ProjectedLink {
+	if link == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(link.Attributes))
+	for key, value := range link.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedLink{
+		TenantID:   link.TenantID,
+		SourceID:   link.SourceID,
+		FromURN:    link.FromURN,
+		ToURN:      link.ToURN,
+		Relation:   link.Relation,
+		Attributes: attributes,
+	}
+}

--- a/internal/findings/registry.go
+++ b/internal/findings/registry.go
@@ -1,0 +1,99 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/primitives"
+)
+
+// Rule evaluates replayed runtime events and emits persisted findings.
+type Rule interface {
+	primitives.Rule
+	SupportsRuntime(*cerebrov1.SourceRuntime) bool
+	Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error)
+}
+
+// Registry indexes finding rules by their stable identifier.
+type Registry struct {
+	rules map[string]Rule
+}
+
+// NewRegistry constructs a finding rule registry and rejects duplicate or invalid specs.
+func NewRegistry(rules ...Rule) (*Registry, error) {
+	indexed := make(map[string]Rule, len(rules))
+	for _, rule := range rules {
+		if rule == nil {
+			return nil, fmt.Errorf("finding rule is required")
+		}
+		spec := rule.Spec()
+		if spec == nil {
+			return nil, fmt.Errorf("finding rule spec is required")
+		}
+		id := strings.TrimSpace(spec.GetId())
+		if id == "" {
+			return nil, fmt.Errorf("finding rule id is required")
+		}
+		if _, exists := indexed[id]; exists {
+			return nil, fmt.Errorf("duplicate finding rule id %q", id)
+		}
+		indexed[id] = rule
+	}
+	return &Registry{rules: indexed}, nil
+}
+
+// Builtin returns the in-process finding rule registry for the rewrite skeleton.
+func Builtin() *Registry {
+	return &Registry{
+		rules: map[string]Rule{
+			oktaPolicyRuleLifecycleTamperingRuleID: newOktaPolicyRuleLifecycleTamperingRule(),
+		},
+	}
+}
+
+// Get returns a registered finding rule by ID.
+func (r *Registry) Get(id string) (Rule, bool) {
+	if r == nil {
+		return nil, false
+	}
+	rule, ok := r.rules[strings.TrimSpace(id)]
+	return rule, ok
+}
+
+// List returns all registered rule specs sorted by ID.
+func (r *Registry) List() []*cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(r.rules))
+	for id := range r.rules {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	specs := make([]*cerebrov1.RuleSpec, 0, len(ids))
+	for _, id := range ids {
+		specs = append(specs, r.rules[id].Spec())
+	}
+	return specs
+}
+
+// ForRuntime returns the registered rules that support one runtime, sorted by rule ID.
+func (r *Registry) ForRuntime(runtime *cerebrov1.SourceRuntime) []Rule {
+	if r == nil || runtime == nil {
+		return nil
+	}
+	specs := r.List()
+	rules := make([]Rule, 0, len(specs))
+	for _, spec := range specs {
+		rule, ok := r.rules[strings.TrimSpace(spec.GetId())]
+		if !ok || !rule.SupportsRuntime(runtime) {
+			continue
+		}
+		rules = append(rules, rule)
+	}
+	return rules
+}

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -1,0 +1,87 @@
+package findings
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type stubRule struct {
+	spec               *cerebrov1.RuleSpec
+	supportedSourceIDs map[string]struct{}
+}
+
+func (r *stubRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return r.spec
+}
+
+func (r *stubRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	_, ok := r.supportedSourceIDs[runtime.GetSourceId()]
+	return ok
+}
+
+func (r *stubRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func TestNewRegistryRejectsDuplicateRuleIDs(t *testing.T) {
+	_, err := NewRegistry(
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-1"}},
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-1"}},
+	)
+	if err == nil {
+		t.Fatal("NewRegistry() error = nil, want non-nil")
+	}
+}
+
+func TestRegistryGetAndListSortByRuleID(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-b"}},
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-a"}},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	rule, ok := registry.Get("rule-a")
+	if !ok || rule == nil {
+		t.Fatal("Get(rule-a) = nil, want rule")
+	}
+	specs := registry.List()
+	if got := len(specs); got != 2 {
+		t.Fatalf("len(List()) = %d, want 2", got)
+	}
+	if specs[0].GetId() != "rule-a" || specs[1].GetId() != "rule-b" {
+		t.Fatalf("List() ids = [%q %q], want [rule-a rule-b]", specs[0].GetId(), specs[1].GetId())
+	}
+}
+
+func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b"},
+			supportedSourceIDs: map[string]struct{}{"github": {}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	rules := registry.ForRuntime(&cerebrov1.SourceRuntime{SourceId: "okta"})
+	if got := len(rules); got != 1 {
+		t.Fatalf("len(ForRuntime()) = %d, want 1", got)
+	}
+	if got := rules[0].Spec().GetId(); got != "rule-a" {
+		t.Fatalf("ForRuntime()[0].Spec().Id = %q, want rule-a", got)
+	}
+}

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -2,55 +2,48 @@ package findings
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
-	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
-	"github.com/writer/cerebro/internal/sourceprojection"
 )
 
 const (
 	defaultEventLimit = 100
 	maxEventLimit     = 1000
-
-	oktaPolicyRuleLifecycleTamperingRuleID   = "identity-okta-policy-rule-lifecycle-tampering"
-	oktaPolicyRuleLifecycleTamperingTitle    = "Okta Policy Rule Lifecycle Tampering"
-	oktaPolicyRuleLifecycleTamperingSeverity = "HIGH"
-	oktaPolicyRuleLifecycleTamperingStatus   = "open"
 )
 
 var (
 	// ErrRuntimeUnavailable indicates that the runtime, replay, or finding store boundary is unavailable.
 	ErrRuntimeUnavailable = errors.New("finding runtime is unavailable")
 
-	oktaPolicyRuleLifecycleTamperingEventTypes = map[string]struct{}{
-		"policy.rule.update":     {},
-		"policy.rule.deactivate": {},
-		"policy.rule.delete":     {},
-	}
-	oktaPolicyRuleLifecycleTamperingOutcomes = map[string]struct{}{
-		"success": {},
-		"allow":   {},
-		"allowed": {},
-	}
+	// ErrRuleNotFound indicates that one requested finding rule is not registered.
+	ErrRuleNotFound = errors.New("finding rule not found")
+
+	// ErrRuleSelectionRequired indicates that one finding rule must be selected explicitly.
+	ErrRuleSelectionRequired = errors.New("finding rule id is required")
+
+	// ErrRuleUnsupported indicates that one finding rule does not support the requested runtime.
+	ErrRuleUnsupported = errors.New("finding rule is not supported for source runtime")
+
+	// ErrRuleUnavailable indicates that no registered finding rule supports the requested runtime.
+	ErrRuleUnavailable = errors.New("finding rule is unavailable for source runtime")
 )
 
-// Service replays runtime events through a fixed finding evaluator and persists emitted findings.
+// Service replays runtime events through one selected finding rule and persists emitted findings.
 type Service struct {
 	runtimeStore ports.SourceRuntimeStore
 	replayer     ports.EventReplayer
 	store        ports.FindingStore
+	rules        *Registry
 }
 
 // EvaluateRequest scopes one replay-backed finding evaluation.
 type EvaluateRequest struct {
 	RuntimeID  string
+	RuleID     string
 	EventLimit uint32
 }
 
@@ -79,18 +72,24 @@ type ListResult struct {
 	Findings []*ports.FindingRecord
 }
 
-// New constructs a replay-backed finding service.
+// New constructs a replay-backed finding service with the built-in rule registry.
 func New(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore) *Service {
+	return NewWithRegistry(runtimeStore, replayer, store, Builtin())
+}
+
+// NewWithRegistry constructs a replay-backed finding service with one explicit rule registry.
+func NewWithRegistry(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore, rules *Registry) *Service {
 	return &Service{
 		runtimeStore: runtimeStore,
 		replayer:     replayer,
 		store:        store,
+		rules:        rules,
 	}
 }
 
-// EvaluateSourceRuntime replays one runtime and persists findings for matching Okta audit events.
+// EvaluateSourceRuntime replays one runtime and persists findings for one selected registered rule.
 func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateRequest) (*EvaluateResult, error) {
-	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.store == nil {
+	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.store == nil || s.rules == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
@@ -98,6 +97,10 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 		return nil, errors.New("source runtime id is required")
 	}
 	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	rule, err := s.selectRule(runtime, request.RuleID)
 	if err != nil {
 		return nil, err
 	}
@@ -110,22 +113,24 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	}
 	result := &EvaluateResult{
 		Runtime:         runtime,
-		Rule:            oktaPolicyRuleLifecycleTamperingRuleSpec(),
+		Rule:            rule.Spec(),
 		EventsEvaluated: uint32(len(events)),
 	}
 	for _, event := range events {
-		if !matchesOktaPolicyRuleLifecycleTampering(event) {
-			continue
-		}
-		record, err := oktaPolicyRuleLifecycleTamperingFinding(ctx, event, runtimeID)
+		emitted, err := rule.Evaluate(ctx, runtime, event)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("evaluate finding rule %q for event %q: %w", result.Rule.GetId(), event.GetId(), err)
 		}
-		stored, err := s.store.UpsertFinding(ctx, record)
-		if err != nil {
-			return nil, fmt.Errorf("persist finding for event %q: %w", event.GetId(), err)
+		for _, record := range emitted {
+			if record == nil {
+				continue
+			}
+			stored, err := s.store.UpsertFinding(ctx, record)
+			if err != nil {
+				return nil, fmt.Errorf("persist finding for rule %q event %q: %w", result.Rule.GetId(), event.GetId(), err)
+			}
+			result.Findings = append(result.Findings, stored)
 		}
-		result.Findings = append(result.Findings, stored)
 	}
 	return result, nil
 }
@@ -158,6 +163,29 @@ func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListR
 	return &ListResult{Findings: findings}, nil
 }
 
+func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (Rule, error) {
+	trimmedRuleID := strings.TrimSpace(ruleID)
+	if trimmedRuleID != "" {
+		rule, ok := s.rules.Get(trimmedRuleID)
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", ErrRuleNotFound, trimmedRuleID)
+		}
+		if !rule.SupportsRuntime(runtime) {
+			return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedRuleID)
+		}
+		return rule, nil
+	}
+	applicable := s.rules.ForRuntime(runtime)
+	switch len(applicable) {
+	case 0:
+		return nil, fmt.Errorf("%w: %s", ErrRuleUnavailable, strings.TrimSpace(runtime.GetId()))
+	case 1:
+		return applicable[0], nil
+	default:
+		return nil, fmt.Errorf("%w for runtime %q", ErrRuleSelectionRequired, strings.TrimSpace(runtime.GetId()))
+	}
+}
+
 func normalizeEventLimit(limit uint32) uint32 {
 	switch {
 	case limit == 0:
@@ -166,224 +194,5 @@ func normalizeEventLimit(limit uint32) uint32 {
 		return maxEventLimit
 	default:
 		return limit
-	}
-}
-
-func oktaPolicyRuleLifecycleTamperingRuleSpec() *cerebrov1.RuleSpec {
-	return &cerebrov1.RuleSpec{
-		Id:          oktaPolicyRuleLifecycleTamperingRuleID,
-		Name:        oktaPolicyRuleLifecycleTamperingTitle,
-		Description: "Detect successful Okta policy rule update, deactivate, or delete events replayed from one source runtime.",
-		InputStreamIds: []string{
-			"source-runtime-replay",
-		},
-		OutputKinds: []string{
-			"finding.okta_policy_rule_lifecycle_tampering",
-		},
-	}
-}
-
-func matchesOktaPolicyRuleLifecycleTampering(event *cerebrov1.EventEnvelope) bool {
-	if event == nil || !strings.EqualFold(strings.TrimSpace(event.GetKind()), "okta.audit") {
-		return false
-	}
-	attributes := event.GetAttributes()
-	eventType := strings.ToLower(strings.TrimSpace(attributes["event_type"]))
-	if _, ok := oktaPolicyRuleLifecycleTamperingEventTypes[eventType]; !ok {
-		return false
-	}
-	outcome := strings.ToLower(strings.TrimSpace(attributes["outcome_result"]))
-	if outcome == "" {
-		outcome = "success"
-	}
-	_, ok := oktaPolicyRuleLifecycleTamperingOutcomes[outcome]
-	return ok
-}
-
-func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
-	resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, err := projectedEntityContext(ctx, event)
-	if err != nil {
-		return nil, fmt.Errorf("project finding context for event %q: %w", event.GetId(), err)
-	}
-	attributes := map[string]string{
-		"event_id":             strings.TrimSpace(event.GetId()),
-		"event_type":           strings.TrimSpace(event.GetAttributes()["event_type"]),
-		"outcome_result":       strings.TrimSpace(event.GetAttributes()["outcome_result"]),
-		"source_runtime_id":    strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID]),
-		"primary_actor_urn":    actorURN,
-		"primary_resource_urn": resourceURN,
-	}
-	trimEmptyAttributes(attributes)
-	observedAt := time.Time{}
-	if timestamp := event.GetOccurredAt(); timestamp != nil {
-		observedAt = timestamp.AsTime().UTC()
-	}
-	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, event.GetId())
-	return &ports.FindingRecord{
-		ID:              fingerprint,
-		Fingerprint:     fingerprint,
-		TenantID:        strings.TrimSpace(event.GetTenantId()),
-		RuntimeID:       strings.TrimSpace(runtimeID),
-		RuleID:          oktaPolicyRuleLifecycleTamperingRuleID,
-		Title:           oktaPolicyRuleLifecycleTamperingTitle,
-		Severity:        oktaPolicyRuleLifecycleTamperingSeverity,
-		Status:          oktaPolicyRuleLifecycleTamperingStatus,
-		Summary:         findingSummary(event, actorLabel, resourceLabel),
-		ResourceURNs:    resourceURNs,
-		EventIDs:        []string{strings.TrimSpace(event.GetId())},
-		Attributes:      attributes,
-		FirstObservedAt: observedAt,
-		LastObservedAt:  observedAt,
-	}, nil
-}
-
-func projectedEntityContext(ctx context.Context, event *cerebrov1.EventEnvelope) ([]string, string, string, string, string, error) {
-	recorder := &projectionRecorder{
-		entities: make(map[string]*ports.ProjectedEntity),
-		links:    make(map[string]*ports.ProjectedLink),
-	}
-	if ctx == nil {
-		return nil, "", "", "", "", errors.New("context is required")
-	}
-	if _, err := sourceprojection.New(nil, recorder).Project(ctx, event); err != nil {
-		return nil, "", "", "", "", err
-	}
-	resourceURNs := make([]string, 0, len(recorder.entities))
-	seenURNs := make(map[string]struct{}, len(recorder.entities))
-	var actorURN string
-	var resourceURN string
-	for _, link := range recorder.links {
-		if !strings.EqualFold(strings.TrimSpace(link.Relation), "acted_on") {
-			continue
-		}
-		if actorURN == "" {
-			actorURN = strings.TrimSpace(link.FromURN)
-		}
-		if resourceURN == "" {
-			resourceURN = strings.TrimSpace(link.ToURN)
-		}
-		if candidate := strings.TrimSpace(link.FromURN); candidate != "" {
-			if _, ok := seenURNs[candidate]; !ok {
-				seenURNs[candidate] = struct{}{}
-				resourceURNs = append(resourceURNs, candidate)
-			}
-		}
-		if candidate := strings.TrimSpace(link.ToURN); candidate != "" {
-			if _, ok := seenURNs[candidate]; !ok {
-				seenURNs[candidate] = struct{}{}
-				resourceURNs = append(resourceURNs, candidate)
-			}
-		}
-	}
-	slices.Sort(resourceURNs)
-	actorLabel := entityLabel(recorder.entities[actorURN], event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"])
-	resourceLabel := entityLabel(recorder.entities[resourceURN], event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"])
-	return resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, nil
-}
-
-func entityLabel(entity *ports.ProjectedEntity, fallbacks ...string) string {
-	if entity != nil && strings.TrimSpace(entity.Label) != "" {
-		return strings.TrimSpace(entity.Label)
-	}
-	for _, fallback := range fallbacks {
-		if strings.TrimSpace(fallback) != "" {
-			return strings.TrimSpace(fallback)
-		}
-	}
-	return ""
-}
-
-func findingSummary(event *cerebrov1.EventEnvelope, actorLabel string, resourceLabel string) string {
-	eventType := strings.TrimSpace(event.GetAttributes()["event_type"])
-	actor := firstNonEmpty(actorLabel, event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"], "unknown actor")
-	resource := firstNonEmpty(resourceLabel, event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"], "unknown resource")
-	return fmt.Sprintf("%s performed %s on %s", actor, eventType, resource)
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
-}
-
-func trimEmptyAttributes(attributes map[string]string) {
-	for key, value := range attributes {
-		if strings.TrimSpace(value) == "" {
-			delete(attributes, key)
-		}
-	}
-}
-
-func hashFindingFingerprint(parts ...string) string {
-	hash := sha256.New()
-	for _, part := range parts {
-		_, _ = hash.Write([]byte(strings.TrimSpace(part)))
-		_, _ = hash.Write([]byte{0})
-	}
-	return hex.EncodeToString(hash.Sum(nil))
-}
-
-type projectionRecorder struct {
-	entities map[string]*ports.ProjectedEntity
-	links    map[string]*ports.ProjectedLink
-}
-
-func (r *projectionRecorder) Ping(context.Context) error {
-	return nil
-}
-
-func (r *projectionRecorder) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
-	if entity == nil {
-		return nil
-	}
-	r.entities[entity.URN] = cloneEntity(entity)
-	return nil
-}
-
-func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
-	if link == nil {
-		return nil
-	}
-	key := strings.TrimSpace(link.FromURN) + "|" + strings.TrimSpace(link.Relation) + "|" + strings.TrimSpace(link.ToURN)
-	r.links[key] = cloneLink(link)
-	return nil
-}
-
-func cloneEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
-	if entity == nil {
-		return nil
-	}
-	attributes := make(map[string]string, len(entity.Attributes))
-	for key, value := range entity.Attributes {
-		attributes[key] = value
-	}
-	return &ports.ProjectedEntity{
-		URN:        entity.URN,
-		TenantID:   entity.TenantID,
-		SourceID:   entity.SourceID,
-		EntityType: entity.EntityType,
-		Label:      entity.Label,
-		Attributes: attributes,
-	}
-}
-
-func cloneLink(link *ports.ProjectedLink) *ports.ProjectedLink {
-	if link == nil {
-		return nil
-	}
-	attributes := make(map[string]string, len(link.Attributes))
-	for key, value := range link.Attributes {
-		attributes[key] = value
-	}
-	return &ports.ProjectedLink{
-		TenantID:   link.TenantID,
-		SourceID:   link.SourceID,
-		FromURN:    link.FromURN,
-		ToURN:      link.ToURN,
-		Relation:   link.Relation,
-		Attributes: attributes,
 	}
 }

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -54,12 +54,29 @@ type EvaluateRequest struct {
 	EventLimit uint32
 }
 
+// ListRequest scopes one persisted finding query.
+type ListRequest struct {
+	RuntimeID   string
+	FindingID   string
+	RuleID      string
+	Severity    string
+	Status      string
+	ResourceURN string
+	EventID     string
+	Limit       uint32
+}
+
 // EvaluateResult reports the persisted findings emitted for one runtime evaluation.
 type EvaluateResult struct {
 	Runtime         *cerebrov1.SourceRuntime
 	Rule            *cerebrov1.RuleSpec
 	EventsEvaluated uint32
 	Findings        []*ports.FindingRecord
+}
+
+// ListResult reports one persisted finding query.
+type ListResult struct {
+	Findings []*ports.FindingRecord
 }
 
 // New constructs a replay-backed finding service.
@@ -111,6 +128,34 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 		result.Findings = append(result.Findings, stored)
 	}
 	return result, nil
+}
+
+// ListFindings loads persisted findings for one runtime.
+func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListResult, error) {
+	if s == nil || s.runtimeStore == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, errors.New("source runtime id is required")
+	}
+	if _, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID); err != nil {
+		return nil, err
+	}
+	findings, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
+		RuntimeID:   runtimeID,
+		FindingID:   strings.TrimSpace(request.FindingID),
+		RuleID:      strings.TrimSpace(request.RuleID),
+		Severity:    strings.TrimSpace(request.Severity),
+		Status:      strings.TrimSpace(request.Status),
+		ResourceURN: strings.TrimSpace(request.ResourceURN),
+		EventID:     strings.TrimSpace(request.EventID),
+		Limit:       request.Limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list findings for runtime %q: %w", runtimeID, err)
+	}
+	return &ListResult{Findings: findings}, nil
 }
 
 func normalizeEventLimit(limit uint32) uint32 {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -3,6 +3,8 @@ package findings
 import (
 	"context"
 	"errors"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,6 +49,7 @@ func (s *stubReplayer) Replay(_ context.Context, request ports.ReplayRequest) ([
 
 type stubFindingStore struct {
 	findings map[string]*ports.FindingRecord
+	request  ports.ListFindingsRequest
 }
 
 func (s *stubFindingStore) Ping(context.Context) error { return nil }
@@ -64,12 +67,30 @@ func (s *stubFindingStore) UpsertFinding(_ context.Context, finding *ports.Findi
 }
 
 func (s *stubFindingStore) ListFindings(_ context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	s.request = request
 	findings := []*ports.FindingRecord{}
 	for _, finding := range s.findings {
-		if finding == nil || finding.RuntimeID != request.RuntimeID {
+		if !findingMatches(request, finding) {
 			continue
 		}
 		findings = append(findings, cloneFinding(finding))
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		left := findings[i]
+		right := findings[j]
+		switch {
+		case left.LastObservedAt.Equal(right.LastObservedAt):
+			return left.ID < right.ID
+		case left.LastObservedAt.IsZero():
+			return false
+		case right.LastObservedAt.IsZero():
+			return true
+		default:
+			return left.LastObservedAt.After(right.LastObservedAt)
+		}
+	})
+	if request.Limit != 0 && len(findings) > int(request.Limit) {
+		findings = findings[:int(request.Limit)]
 	}
 	return findings, nil
 }
@@ -157,6 +178,93 @@ func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T
 	}
 }
 
+func TestListFindingsReturnsFilteredPersistedFindings(t *testing.T) {
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				RuntimeID:      "writer-okta-audit",
+				RuleID:         oktaPolicyRuleLifecycleTamperingRuleID,
+				Severity:       "HIGH",
+				Status:         "open",
+				ResourceURNs:   []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+				EventIDs:       []string{"okta-audit-2"},
+				LastObservedAt: time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC),
+			},
+			"finding-2": {
+				ID:             "finding-2",
+				RuntimeID:      "writer-okta-audit",
+				RuleID:         oktaPolicyRuleLifecycleTamperingRuleID,
+				Severity:       "MEDIUM",
+				Status:         "resolved",
+				ResourceURNs:   []string{"urn:cerebro:writer:okta_resource:policyrule:pol-2"},
+				EventIDs:       []string{"okta-audit-3"},
+				LastObservedAt: time.Date(2026, 4, 23, 11, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		store,
+	)
+
+	result, err := service.ListFindings(context.Background(), ListRequest{
+		RuntimeID:   "writer-okta-audit",
+		RuleID:      oktaPolicyRuleLifecycleTamperingRuleID,
+		Severity:    "HIGH",
+		Status:      "open",
+		ResourceURN: "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+		EventID:     "okta-audit-2",
+		Limit:       1,
+	})
+	if err != nil {
+		t.Fatalf("ListFindings() error = %v", err)
+	}
+	if got := len(result.Findings); got != 1 {
+		t.Fatalf("len(ListFindings().Findings) = %d, want 1", got)
+	}
+	if got := result.Findings[0].ID; got != "finding-1" {
+		t.Fatalf("ListFindings().Findings[0].ID = %q, want finding-1", got)
+	}
+	if got := store.request.RuntimeID; got != "writer-okta-audit" {
+		t.Fatalf("ListFindings().RuntimeID = %q, want writer-okta-audit", got)
+	}
+	if got := store.request.RuleID; got != oktaPolicyRuleLifecycleTamperingRuleID {
+		t.Fatalf("ListFindings().RuleID = %q, want %q", got, oktaPolicyRuleLifecycleTamperingRuleID)
+	}
+	if got := store.request.Severity; got != "HIGH" {
+		t.Fatalf("ListFindings().Severity = %q, want HIGH", got)
+	}
+	if got := store.request.Status; got != "open" {
+		t.Fatalf("ListFindings().Status = %q, want open", got)
+	}
+	if got := store.request.ResourceURN; got != "urn:cerebro:writer:okta_resource:policyrule:pol-1" {
+		t.Fatalf("ListFindings().ResourceURN = %q, want policy rule urn", got)
+	}
+	if got := store.request.EventID; got != "okta-audit-2" {
+		t.Fatalf("ListFindings().EventID = %q, want okta-audit-2", got)
+	}
+	if got := store.request.Limit; got != 1 {
+		t.Fatalf("ListFindings().Limit = %d, want 1", got)
+	}
+}
+
+func TestListFindingsRequiresAvailableDependencies(t *testing.T) {
+	service := New(nil, nil, nil)
+	if _, err := service.ListFindings(context.Background(), ListRequest{RuntimeID: "writer-okta-audit"}); !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("ListFindings() error = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}
+
 func newAuditEvent(id string, eventType string, outcome string) *cerebrov1.EventEnvelope {
 	return &cerebrov1.EventEnvelope{
 		Id:         id,
@@ -208,4 +316,42 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 		FirstObservedAt: finding.FirstObservedAt,
 		LastObservedAt:  finding.LastObservedAt,
 	}
+}
+
+func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRecord) bool {
+	if finding == nil {
+		return false
+	}
+	if strings.TrimSpace(finding.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+		return false
+	}
+	if request.FindingID != "" && strings.TrimSpace(finding.ID) != strings.TrimSpace(request.FindingID) {
+		return false
+	}
+	if request.RuleID != "" && strings.TrimSpace(finding.RuleID) != strings.TrimSpace(request.RuleID) {
+		return false
+	}
+	if request.Severity != "" && strings.TrimSpace(finding.Severity) != strings.TrimSpace(request.Severity) {
+		return false
+	}
+	if request.Status != "" && strings.TrimSpace(finding.Status) != strings.TrimSpace(request.Status) {
+		return false
+	}
+	if request.ResourceURN != "" && !containsTrimmed(finding.ResourceURNs, request.ResourceURN) {
+		return false
+	}
+	if request.EventID != "" && !containsTrimmed(finding.EventIDs, request.EventID) {
+		return false
+	}
+	return true
+}
+
+func containsTrimmed(values []string, expected string) bool {
+	trimmedExpected := strings.TrimSpace(expected)
+	for _, value := range values {
+		if strings.TrimSpace(value) == trimmedExpected {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -178,6 +178,121 @@ func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T
 	}
 }
 
+func TestEvaluateSourceRuntimeFindingsSelectsRequestedRule(t *testing.T) {
+	replayer := &stubReplayer{
+		events: []*cerebrov1.EventEnvelope{
+			newAuditEvent("okta-audit-2", "policy.rule.update", "SUCCESS"),
+		},
+	}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		replayer,
+		&stubFindingStore{},
+	)
+
+	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID:  "writer-okta-audit",
+		RuleID:     oktaPolicyRuleLifecycleTamperingRuleID,
+		EventLimit: 10,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntime() error = %v", err)
+	}
+	if got := result.Rule.GetId(); got != oktaPolicyRuleLifecycleTamperingRuleID {
+		t.Fatalf("EvaluateSourceRuntime().Rule.ID = %q, want %q", got, oktaPolicyRuleLifecycleTamperingRuleID)
+	}
+	if got := len(result.Findings); got != 1 {
+		t.Fatalf("len(EvaluateSourceRuntime().Findings) = %d, want 1", got)
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsRejectsUnknownRule(t *testing.T) {
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		&stubFindingStore{},
+	)
+	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-okta-audit",
+		RuleID:    "rule-does-not-exist",
+	}); !errors.Is(err, ErrRuleNotFound) {
+		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuleNotFound)
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsRequiresRuleIDWhenMultipleRulesSupportRuntime(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		&stubFindingStore{},
+		registry,
+	)
+	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-okta-audit",
+	}); !errors.Is(err, ErrRuleSelectionRequired) {
+		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuleSelectionRequired)
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsRejectsUnsupportedRule(t *testing.T) {
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-github-audit": {
+					Id:       "writer-github-audit",
+					SourceId: "github",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		&stubFindingStore{},
+	)
+	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-github-audit",
+		RuleID:    oktaPolicyRuleLifecycleTamperingRuleID,
+	}); !errors.Is(err, ErrRuleUnsupported) {
+		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuleUnsupported)
+	}
+}
+
 func TestListFindingsReturnsFilteredPersistedFindings(t *testing.T) {
 	store := &stubFindingStore{
 		findings: map[string]*ports.FindingRecord{

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -25,7 +25,14 @@ type FindingRecord struct {
 
 // ListFindingsRequest scopes one finding query.
 type ListFindingsRequest struct {
-	RuntimeID string
+	RuntimeID   string
+	FindingID   string
+	RuleID      string
+	Severity    string
+	Status      string
+	ResourceURN string
+	EventID     string
+	Limit       uint32
 }
 
 // FindingStore persists normalized findings in the state store.

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -31,6 +31,10 @@ var ensureFindingStatements = []string{
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_rule_idx ON findings (runtime_id, rule_id)`,
+	`CREATE INDEX IF NOT EXISTS findings_runtime_status_idx ON findings (runtime_id, status)`,
+	`CREATE INDEX IF NOT EXISTS findings_runtime_severity_idx ON findings (runtime_id, severity)`,
+	`CREATE INDEX IF NOT EXISTS findings_resource_urns_gin_idx ON findings USING GIN (resource_urns_json)`,
+	`CREATE INDEX IF NOT EXISTS findings_event_ids_gin_idx ON findings USING GIN (event_ids_json)`,
 }
 
 // UpsertFinding persists one normalized finding in the current-state store.
@@ -163,25 +167,19 @@ RETURNING
 
 // ListFindings loads persisted findings for one runtime.
 func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequest) (_ []*ports.FindingRecord, err error) {
-	runtimeID := strings.TrimSpace(request.RuntimeID)
-	if runtimeID == "" {
-		return nil, errors.New("finding runtime id is required")
-	}
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
 	}
 	if err := s.ensureFindingTables(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := s.db.QueryContext(ctx, `
-SELECT
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, attributes_json::text, first_observed_at, last_observed_at
-FROM findings
-WHERE runtime_id = $1
-ORDER BY last_observed_at DESC, id`, runtimeID)
+	query, args, err := findingListQuery(request)
 	if err != nil {
-		return nil, fmt.Errorf("query findings for runtime %q: %w", runtimeID, err)
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query findings for runtime %q: %w", strings.TrimSpace(request.RuntimeID), err)
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil && err == nil {
@@ -222,6 +220,37 @@ ORDER BY last_observed_at DESC, id`, runtimeID)
 	return findings, nil
 }
 
+func findingListQuery(request ports.ListFindingsRequest) (string, []any, error) {
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return "", nil, errors.New("finding runtime id is required")
+	}
+	clauses := []string{"runtime_id = $1"}
+	args := []any{runtimeID}
+	addFindingFilter(&clauses, &args, "id", request.FindingID)
+	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
+	addFindingFilter(&clauses, &args, "severity", request.Severity)
+	addFindingFilter(&clauses, &args, "status", request.Status)
+	if err := addFindingArrayContainsFilter(&clauses, &args, "resource_urns_json", request.ResourceURN); err != nil {
+		return "", nil, err
+	}
+	if err := addFindingArrayContainsFilter(&clauses, &args, "event_ids_json", request.EventID); err != nil {
+		return "", nil, err
+	}
+	query := `
+SELECT
+  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
+  resource_urns_json::text, event_ids_json::text, attributes_json::text, first_observed_at, last_observed_at
+FROM findings
+WHERE ` + strings.Join(clauses, " AND ") + `
+ORDER BY last_observed_at DESC, id`
+	if request.Limit != 0 {
+		args = append(args, int64(request.Limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	return query, args, nil
+}
+
 func (s *Store) ensureFindingTables(ctx context.Context) error {
 	for _, statement := range ensureFindingStatements {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {
@@ -257,6 +286,29 @@ func findingAttributesJSON(attributes map[string]string) (string, error) {
 		return "", err
 	}
 	return string(payload), nil
+}
+
+func addFindingFilter(clauses *[]string, args *[]any, column string, value string) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return
+	}
+	*args = append(*args, trimmed)
+	*clauses = append(*clauses, fmt.Sprintf("%s = $%d", column, len(*args)))
+}
+
+func addFindingArrayContainsFilter(clauses *[]string, args *[]any, column string, value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	payload, err := findingStringsJSON([]string{trimmed})
+	if err != nil {
+		return fmt.Errorf("marshal %s filter: %w", column, err)
+	}
+	*args = append(*args, payload)
+	*clauses = append(*clauses, fmt.Sprintf("%s @> $%d::jsonb", column, len(*args)))
+	return nil
 }
 
 type findingRow struct {

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,5 +66,50 @@ func TestListFindingsRejectsUnconfiguredStore(t *testing.T) {
 	store := &Store{}
 	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{RuntimeID: "writer-okta-audit"}); err == nil {
 		t.Fatal("ListFindings() error = nil, want non-nil")
+	}
+}
+
+func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
+	query, args, err := findingListQuery(ports.ListFindingsRequest{
+		RuntimeID:   "writer-okta-audit",
+		FindingID:   "finding-1",
+		RuleID:      "identity-okta-policy-rule-lifecycle-tampering",
+		Severity:    "HIGH",
+		Status:      "open",
+		ResourceURN: "urn:cerebro:writer:okta_resource:policyrule:pol-1",
+		EventID:     "okta-audit-2",
+		Limit:       25,
+	})
+	if err != nil {
+		t.Fatalf("findingListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"runtime_id = $1",
+		"id = $2",
+		"rule_id = $3",
+		"severity = $4",
+		"status = $5",
+		"resource_urns_json @> $6::jsonb",
+		"event_ids_json @> $7::jsonb",
+		"LIMIT $8",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if got := len(args); got != 8 {
+		t.Fatalf("len(findingListQuery().args) = %d, want 8", got)
+	}
+	if got := args[0]; got != "writer-okta-audit" {
+		t.Fatalf("findingListQuery().args[0] = %#v, want writer-okta-audit", got)
+	}
+	if got := args[5]; got != `["urn:cerebro:writer:okta_resource:policyrule:pol-1"]` {
+		t.Fatalf("findingListQuery().args[5] = %#v, want resource urn array json", got)
+	}
+	if got := args[6]; got != `["okta-audit-2"]` {
+		t.Fatalf("findingListQuery().args[6] = %#v, want event id array json", got)
+	}
+	if got := args[7]; got != int64(25) {
+		t.Fatalf("findingListQuery().args[7] = %#v, want 25", got)
 	}
 }

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -25,6 +25,7 @@ service BootstrapService {
   rpc SyncSourceRuntime(SyncSourceRuntimeRequest) returns (SyncSourceRuntimeResponse);
   rpc WriteClaims(WriteClaimsRequest) returns (WriteClaimsResponse);
   rpc ListClaims(ListClaimsRequest) returns (ListClaimsResponse);
+  rpc ListFindings(ListFindingsRequest) returns (ListFindingsResponse);
   rpc EvaluateSourceRuntimeFindings(EvaluateSourceRuntimeFindingsRequest) returns (EvaluateSourceRuntimeFindingsResponse);
   rpc GetEntityNeighborhood(GetEntityNeighborhoodRequest) returns (GetEntityNeighborhoodResponse);
 }
@@ -249,6 +250,18 @@ message ListClaimsResponse {
   repeated Claim claims = 1;
 }
 
+// ListFindingsRequest queries persisted findings for one stored runtime.
+message ListFindingsRequest {
+  string runtime_id = 1;
+  string finding_id = 2;
+  string rule_id = 3;
+  string severity = 4;
+  string status = 5;
+  string resource_urn = 6;
+  string event_id = 7;
+  uint32 limit = 8;
+}
+
 // Finding is the normalized persisted finding view for the first runtime evaluator slice.
 message Finding {
   string id = 1;
@@ -265,6 +278,11 @@ message Finding {
   map<string, string> attributes = 12;
   google.protobuf.Timestamp first_observed_at = 13;
   google.protobuf.Timestamp last_observed_at = 14;
+}
+
+// ListFindingsResponse returns the matched persisted findings.
+message ListFindingsResponse {
+  repeated Finding findings = 1;
 }
 
 // EvaluateSourceRuntimeFindingsRequest replays one stored runtime through the first built-in finding evaluator.

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -285,13 +285,14 @@ message ListFindingsResponse {
   repeated Finding findings = 1;
 }
 
-// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through the first built-in finding evaluator.
+// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through one registered finding rule.
 message EvaluateSourceRuntimeFindingsRequest {
   string id = 1;
   uint32 event_limit = 2;
+  string rule_id = 3;
 }
 
-// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, fixed rule spec, and persisted findings.
+// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, selected rule spec, and persisted findings.
 message EvaluateSourceRuntimeFindingsResponse {
   SourceRuntime runtime = 1;
   RuleSpec rule = 2;


### PR DESCRIPTION
## Summary
- add first-class runtime-scoped finding read surfaces over HTTP and ConnectRPC
- extend finding store filtering so persisted findings can be queried by id, rule, severity, status, resource, and event
- add store/query tests plus bootstrap and service coverage for the new finding read path

## Validation
- go -C /Users/jonathan/Documents/cerebro-worktrees/cerebro-next-okta-source-20260423 test ./internal/findings ./internal/bootstrap ./internal/statestore/postgres ./internal/reports
- make verify