### PR TITLE
feat(findings): add finding rule registry

### DIFF
--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -2280,11 +2280,12 @@ func (x *ListFindingsResponse) GetFindings() []*Finding {
 	return nil
 }
 
-// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through the first built-in finding evaluator.
+// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through one registered finding rule.
 type EvaluateSourceRuntimeFindingsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	EventLimit    uint32                 `protobuf:"varint,2,opt,name=event_limit,json=eventLimit,proto3" json:"event_limit,omitempty"`
+	RuleId        string                 `protobuf:"bytes,3,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2333,7 +2334,14 @@ func (x *EvaluateSourceRuntimeFindingsRequest) GetEventLimit() uint32 {
 	return 0
 }
 
-// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, fixed rule spec, and persisted findings.
+func (x *EvaluateSourceRuntimeFindingsRequest) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, selected rule spec, and persisted findings.
 type EvaluateSourceRuntimeFindingsResponse struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	Runtime          *SourceRuntime         `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
@@ -2851,11 +2859,12 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"G\n" +
 	"\x14ListFindingsResponse\x12/\n" +
-	"\bfindings\x18\x01 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\"W\n" +
+	"\bfindings\x18\x01 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\"p\n" +
 	"$EvaluateSourceRuntimeFindingsRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vevent_limit\x18\x02 \x01(\rR\n" +
-	"eventLimit\"\x8f\x02\n" +
+	"eventLimit\x12\x17\n" +
+	"\arule_id\x18\x03 \x01(\tR\x06ruleId\"\x8f\x02\n" +
 	"%EvaluateSourceRuntimeFindingsResponse\x123\n" +
 	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\x12(\n" +
 	"\x04rule\x18\x02 \x01(\v2\x14.cerebro.v1.RuleSpecR\x04rule\x12)\n" +

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -328,6 +328,7 @@ func (a *App) handleWriteClaims(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http.Request) {
 	request := &cerebrov1.EvaluateSourceRuntimeFindingsRequest{}
+	request.RuleId = r.URL.Query().Get("rule_id")
 	if eventLimit := r.URL.Query().Get("event_limit"); eventLimit != "" {
 		body := []byte(`{"event_limit":` + eventLimit + `}`)
 		if err := protojson.Unmarshal(body, request); err != nil {
@@ -336,8 +337,10 @@ func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http
 		}
 	}
 	request.Id = r.PathValue("runtimeID")
+	request.RuleId = r.URL.Query().Get("rule_id")
 	response, err := a.findingService().EvaluateSourceRuntime(r.Context(), findings.EvaluateRequest{
 		RuntimeID:  request.GetId(),
+		RuleID:     request.GetRuleId(),
 		EventLimit: request.GetEventLimit(),
 	})
 	if err != nil {
@@ -577,6 +580,7 @@ func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, re
 		findingStore(s.deps.StateStore),
 	).EvaluateSourceRuntime(ctx, findings.EvaluateRequest{
 		RuntimeID:  req.Msg.GetId(),
+		RuleID:     req.Msg.GetRuleId(),
 		EventLimit: req.Msg.GetEventLimit(),
 	})
 	if err != nil {
@@ -727,6 +731,8 @@ func writeFindingError(w http.ResponseWriter, err error) {
 	statusCode := http.StatusBadRequest
 	switch {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
+		statusCode = http.StatusNotFound
+	case errors.Is(err, findings.ErrRuleNotFound):
 		statusCode = http.StatusNotFound
 	case errors.Is(err, findings.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -794,7 +794,7 @@ func TestFindingEndpoints(t *testing.T) {
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	evaluateReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?event_limit=2", nil)
+	evaluateReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?event_limit=2&rule_id=identity-okta-policy-rule-lifecycle-tampering", nil)
 	if err != nil {
 		t.Fatalf("new evaluate findings request: %v", err)
 	}
@@ -855,10 +855,23 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := listedFinding["rule_id"]; got != "identity-okta-policy-rule-lifecycle-tampering" {
 		t.Fatalf("list finding rule_id = %#v, want identity-okta-policy-rule-lifecycle-tampering", got)
 	}
+	missingRuleResp, err := server.Client().Post(server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?rule_id=does-not-exist", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/findings/evaluate unknown rule error = %v", err)
+	}
+	defer func() {
+		if closeErr := missingRuleResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close unknown rule response body: %v", closeErr)
+		}
+	}()
+	if got := missingRuleResp.StatusCode; got != http.StatusNotFound {
+		t.Fatalf("unknown rule status = %d, want %d", got, http.StatusNotFound)
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	evaluateFindingsResp, err := client.EvaluateSourceRuntimeFindings(context.Background(), connect.NewRequest(&cerebrov1.EvaluateSourceRuntimeFindingsRequest{
 		Id:         "writer-okta-audit",
+		RuleId:     "identity-okta-policy-rule-lifecycle-tampering",
 		EventLimit: 5,
 	}))
 	if err != nil {

--- a/internal/findings/okta_policy_rule_lifecycle_tampering_rule.go
+++ b/internal/findings/okta_policy_rule_lifecycle_tampering_rule.go
@@ -1,0 +1,279 @@
+package findings
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceprojection"
+)
+
+const (
+	oktaPolicyRuleLifecycleTamperingRuleID   = "identity-okta-policy-rule-lifecycle-tampering"
+	oktaPolicyRuleLifecycleTamperingTitle    = "Okta Policy Rule Lifecycle Tampering"
+	oktaPolicyRuleLifecycleTamperingSeverity = "HIGH"
+	oktaPolicyRuleLifecycleTamperingStatus   = "open"
+)
+
+var (
+	oktaPolicyRuleLifecycleTamperingEventTypes = map[string]struct{}{
+		"policy.rule.update":     {},
+		"policy.rule.deactivate": {},
+		"policy.rule.delete":     {},
+	}
+	oktaPolicyRuleLifecycleTamperingOutcomes = map[string]struct{}{
+		"success": {},
+		"allow":   {},
+		"allowed": {},
+	}
+)
+
+type oktaPolicyRuleLifecycleTamperingRule struct{}
+
+func newOktaPolicyRuleLifecycleTamperingRule() Rule {
+	return &oktaPolicyRuleLifecycleTamperingRule{}
+}
+
+func (*oktaPolicyRuleLifecycleTamperingRule) Spec() *cerebrov1.RuleSpec {
+	return &cerebrov1.RuleSpec{
+		Id:          oktaPolicyRuleLifecycleTamperingRuleID,
+		Name:        oktaPolicyRuleLifecycleTamperingTitle,
+		Description: "Detect successful Okta policy rule update, deactivate, or delete events replayed from one source runtime.",
+		InputStreamIds: []string{
+			"source-runtime-replay",
+		},
+		OutputKinds: []string{
+			"finding.okta_policy_rule_lifecycle_tampering",
+		},
+	}
+}
+
+func (*oktaPolicyRuleLifecycleTamperingRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	return runtime != nil && strings.EqualFold(strings.TrimSpace(runtime.GetSourceId()), "okta")
+}
+
+func (*oktaPolicyRuleLifecycleTamperingRule) Evaluate(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	if runtime == nil {
+		return nil, errors.New("source runtime is required")
+	}
+	if !matchesOktaPolicyRuleLifecycleTampering(event) {
+		return nil, nil
+	}
+	record, err := oktaPolicyRuleLifecycleTamperingFinding(ctx, event, runtime.GetId())
+	if err != nil {
+		return nil, err
+	}
+	return []*ports.FindingRecord{record}, nil
+}
+
+func matchesOktaPolicyRuleLifecycleTampering(event *cerebrov1.EventEnvelope) bool {
+	if event == nil || !strings.EqualFold(strings.TrimSpace(event.GetKind()), "okta.audit") {
+		return false
+	}
+	attributes := event.GetAttributes()
+	eventType := strings.ToLower(strings.TrimSpace(attributes["event_type"]))
+	if _, ok := oktaPolicyRuleLifecycleTamperingEventTypes[eventType]; !ok {
+		return false
+	}
+	outcome := strings.ToLower(strings.TrimSpace(attributes["outcome_result"]))
+	if outcome == "" {
+		outcome = "success"
+	}
+	_, ok := oktaPolicyRuleLifecycleTamperingOutcomes[outcome]
+	return ok
+}
+
+func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
+	resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, err := projectedEntityContext(ctx, event)
+	if err != nil {
+		return nil, fmt.Errorf("project finding context for event %q: %w", event.GetId(), err)
+	}
+	attributes := map[string]string{
+		"event_id":             strings.TrimSpace(event.GetId()),
+		"event_type":           strings.TrimSpace(event.GetAttributes()["event_type"]),
+		"outcome_result":       strings.TrimSpace(event.GetAttributes()["outcome_result"]),
+		"source_runtime_id":    strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID]),
+		"primary_actor_urn":    actorURN,
+		"primary_resource_urn": resourceURN,
+	}
+	trimEmptyAttributes(attributes)
+	observedAt := time.Time{}
+	if timestamp := event.GetOccurredAt(); timestamp != nil {
+		observedAt = timestamp.AsTime().UTC()
+	}
+	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, event.GetId())
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        strings.TrimSpace(event.GetTenantId()),
+		RuntimeID:       strings.TrimSpace(runtimeID),
+		RuleID:          oktaPolicyRuleLifecycleTamperingRuleID,
+		Title:           oktaPolicyRuleLifecycleTamperingTitle,
+		Severity:        oktaPolicyRuleLifecycleTamperingSeverity,
+		Status:          oktaPolicyRuleLifecycleTamperingStatus,
+		Summary:         findingSummary(event, actorLabel, resourceLabel),
+		ResourceURNs:    resourceURNs,
+		EventIDs:        []string{strings.TrimSpace(event.GetId())},
+		Attributes:      attributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}
+
+func projectedEntityContext(ctx context.Context, event *cerebrov1.EventEnvelope) ([]string, string, string, string, string, error) {
+	recorder := &projectionRecorder{
+		entities: make(map[string]*ports.ProjectedEntity),
+		links:    make(map[string]*ports.ProjectedLink),
+	}
+	if ctx == nil {
+		return nil, "", "", "", "", errors.New("context is required")
+	}
+	if _, err := sourceprojection.New(nil, recorder).Project(ctx, event); err != nil {
+		return nil, "", "", "", "", err
+	}
+	resourceURNs := make([]string, 0, len(recorder.entities))
+	seenURNs := make(map[string]struct{}, len(recorder.entities))
+	var actorURN string
+	var resourceURN string
+	for _, link := range recorder.links {
+		if !strings.EqualFold(strings.TrimSpace(link.Relation), "acted_on") {
+			continue
+		}
+		if actorURN == "" {
+			actorURN = strings.TrimSpace(link.FromURN)
+		}
+		if resourceURN == "" {
+			resourceURN = strings.TrimSpace(link.ToURN)
+		}
+		if candidate := strings.TrimSpace(link.FromURN); candidate != "" {
+			if _, ok := seenURNs[candidate]; !ok {
+				seenURNs[candidate] = struct{}{}
+				resourceURNs = append(resourceURNs, candidate)
+			}
+		}
+		if candidate := strings.TrimSpace(link.ToURN); candidate != "" {
+			if _, ok := seenURNs[candidate]; !ok {
+				seenURNs[candidate] = struct{}{}
+				resourceURNs = append(resourceURNs, candidate)
+			}
+		}
+	}
+	slices.Sort(resourceURNs)
+	actorLabel := entityLabel(recorder.entities[actorURN], event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"])
+	resourceLabel := entityLabel(recorder.entities[resourceURN], event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"])
+	return resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, nil
+}
+
+func entityLabel(entity *ports.ProjectedEntity, fallbacks ...string) string {
+	if entity != nil && strings.TrimSpace(entity.Label) != "" {
+		return strings.TrimSpace(entity.Label)
+	}
+	for _, fallback := range fallbacks {
+		if strings.TrimSpace(fallback) != "" {
+			return strings.TrimSpace(fallback)
+		}
+	}
+	return ""
+}
+
+func findingSummary(event *cerebrov1.EventEnvelope, actorLabel string, resourceLabel string) string {
+	eventType := strings.TrimSpace(event.GetAttributes()["event_type"])
+	actor := firstNonEmpty(actorLabel, event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"], "unknown actor")
+	resource := firstNonEmpty(resourceLabel, event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"], "unknown resource")
+	return fmt.Sprintf("%s performed %s on %s", actor, eventType, resource)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func trimEmptyAttributes(attributes map[string]string) {
+	for key, value := range attributes {
+		if strings.TrimSpace(value) == "" {
+			delete(attributes, key)
+		}
+	}
+}
+
+func hashFindingFingerprint(parts ...string) string {
+	hash := sha256.New()
+	for _, part := range parts {
+		_, _ = hash.Write([]byte(strings.TrimSpace(part)))
+		_, _ = hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+type projectionRecorder struct {
+	entities map[string]*ports.ProjectedEntity
+	links    map[string]*ports.ProjectedLink
+}
+
+func (r *projectionRecorder) Ping(context.Context) error {
+	return nil
+}
+
+func (r *projectionRecorder) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if entity == nil {
+		return nil
+	}
+	r.entities[entity.URN] = cloneEntity(entity)
+	return nil
+}
+
+func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	key := strings.TrimSpace(link.FromURN) + "|" + strings.TrimSpace(link.Relation) + "|" + strings.TrimSpace(link.ToURN)
+	r.links[key] = cloneLink(link)
+	return nil
+}
+
+func cloneEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
+	if entity == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(entity.Attributes))
+	for key, value := range entity.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedEntity{
+		URN:        entity.URN,
+		TenantID:   entity.TenantID,
+		SourceID:   entity.SourceID,
+		EntityType: entity.EntityType,
+		Label:      entity.Label,
+		Attributes: attributes,
+	}
+}
+
+func cloneLink(link *ports.ProjectedLink) *ports.ProjectedLink {
+	if link == nil {
+		return nil
+	}
+	attributes := make(map[string]string, len(link.Attributes))
+	for key, value := range link.Attributes {
+		attributes[key] = value
+	}
+	return &ports.ProjectedLink{
+		TenantID:   link.TenantID,
+		SourceID:   link.SourceID,
+		FromURN:    link.FromURN,
+		ToURN:      link.ToURN,
+		Relation:   link.Relation,
+		Attributes: attributes,
+	}
+}

--- a/internal/findings/registry.go
+++ b/internal/findings/registry.go
@@ -1,0 +1,99 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/primitives"
+)
+
+// Rule evaluates replayed runtime events and emits persisted findings.
+type Rule interface {
+	primitives.Rule
+	SupportsRuntime(*cerebrov1.SourceRuntime) bool
+	Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error)
+}
+
+// Registry indexes finding rules by their stable identifier.
+type Registry struct {
+	rules map[string]Rule
+}
+
+// NewRegistry constructs a finding rule registry and rejects duplicate or invalid specs.
+func NewRegistry(rules ...Rule) (*Registry, error) {
+	indexed := make(map[string]Rule, len(rules))
+	for _, rule := range rules {
+		if rule == nil {
+			return nil, fmt.Errorf("finding rule is required")
+		}
+		spec := rule.Spec()
+		if spec == nil {
+			return nil, fmt.Errorf("finding rule spec is required")
+		}
+		id := strings.TrimSpace(spec.GetId())
+		if id == "" {
+			return nil, fmt.Errorf("finding rule id is required")
+		}
+		if _, exists := indexed[id]; exists {
+			return nil, fmt.Errorf("duplicate finding rule id %q", id)
+		}
+		indexed[id] = rule
+	}
+	return &Registry{rules: indexed}, nil
+}
+
+// Builtin returns the in-process finding rule registry for the rewrite skeleton.
+func Builtin() *Registry {
+	return &Registry{
+		rules: map[string]Rule{
+			oktaPolicyRuleLifecycleTamperingRuleID: newOktaPolicyRuleLifecycleTamperingRule(),
+		},
+	}
+}
+
+// Get returns a registered finding rule by ID.
+func (r *Registry) Get(id string) (Rule, bool) {
+	if r == nil {
+		return nil, false
+	}
+	rule, ok := r.rules[strings.TrimSpace(id)]
+	return rule, ok
+}
+
+// List returns all registered rule specs sorted by ID.
+func (r *Registry) List() []*cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(r.rules))
+	for id := range r.rules {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	specs := make([]*cerebrov1.RuleSpec, 0, len(ids))
+	for _, id := range ids {
+		specs = append(specs, r.rules[id].Spec())
+	}
+	return specs
+}
+
+// ForRuntime returns the registered rules that support one runtime, sorted by rule ID.
+func (r *Registry) ForRuntime(runtime *cerebrov1.SourceRuntime) []Rule {
+	if r == nil || runtime == nil {
+		return nil
+	}
+	specs := r.List()
+	rules := make([]Rule, 0, len(specs))
+	for _, spec := range specs {
+		rule, ok := r.rules[strings.TrimSpace(spec.GetId())]
+		if !ok || !rule.SupportsRuntime(runtime) {
+			continue
+		}
+		rules = append(rules, rule)
+	}
+	return rules
+}

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -1,0 +1,87 @@
+package findings
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type stubRule struct {
+	spec               *cerebrov1.RuleSpec
+	supportedSourceIDs map[string]struct{}
+}
+
+func (r *stubRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return r.spec
+}
+
+func (r *stubRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	_, ok := r.supportedSourceIDs[runtime.GetSourceId()]
+	return ok
+}
+
+func (r *stubRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func TestNewRegistryRejectsDuplicateRuleIDs(t *testing.T) {
+	_, err := NewRegistry(
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-1"}},
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-1"}},
+	)
+	if err == nil {
+		t.Fatal("NewRegistry() error = nil, want non-nil")
+	}
+}
+
+func TestRegistryGetAndListSortByRuleID(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-b"}},
+		&stubRule{spec: &cerebrov1.RuleSpec{Id: "rule-a"}},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	rule, ok := registry.Get("rule-a")
+	if !ok || rule == nil {
+		t.Fatal("Get(rule-a) = nil, want rule")
+	}
+	specs := registry.List()
+	if got := len(specs); got != 2 {
+		t.Fatalf("len(List()) = %d, want 2", got)
+	}
+	if specs[0].GetId() != "rule-a" || specs[1].GetId() != "rule-b" {
+		t.Fatalf("List() ids = [%q %q], want [rule-a rule-b]", specs[0].GetId(), specs[1].GetId())
+	}
+}
+
+func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b"},
+			supportedSourceIDs: map[string]struct{}{"github": {}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	rules := registry.ForRuntime(&cerebrov1.SourceRuntime{SourceId: "okta"})
+	if got := len(rules); got != 1 {
+		t.Fatalf("len(ForRuntime()) = %d, want 1", got)
+	}
+	if got := rules[0].Spec().GetId(); got != "rule-a" {
+		t.Fatalf("ForRuntime()[0].Spec().Id = %q, want rule-a", got)
+	}
+}

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -2,55 +2,48 @@ package findings
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
-	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
-	"github.com/writer/cerebro/internal/sourceprojection"
 )
 
 const (
 	defaultEventLimit = 100
 	maxEventLimit     = 1000
-
-	oktaPolicyRuleLifecycleTamperingRuleID   = "identity-okta-policy-rule-lifecycle-tampering"
-	oktaPolicyRuleLifecycleTamperingTitle    = "Okta Policy Rule Lifecycle Tampering"
-	oktaPolicyRuleLifecycleTamperingSeverity = "HIGH"
-	oktaPolicyRuleLifecycleTamperingStatus   = "open"
 )
 
 var (
 	// ErrRuntimeUnavailable indicates that the runtime, replay, or finding store boundary is unavailable.
 	ErrRuntimeUnavailable = errors.New("finding runtime is unavailable")
 
-	oktaPolicyRuleLifecycleTamperingEventTypes = map[string]struct{}{
-		"policy.rule.update":     {},
-		"policy.rule.deactivate": {},
-		"policy.rule.delete":     {},
-	}
-	oktaPolicyRuleLifecycleTamperingOutcomes = map[string]struct{}{
-		"success": {},
-		"allow":   {},
-		"allowed": {},
-	}
+	// ErrRuleNotFound indicates that one requested finding rule is not registered.
+	ErrRuleNotFound = errors.New("finding rule not found")
+
+	// ErrRuleSelectionRequired indicates that one finding rule must be selected explicitly.
+	ErrRuleSelectionRequired = errors.New("finding rule id is required")
+
+	// ErrRuleUnsupported indicates that one finding rule does not support the requested runtime.
+	ErrRuleUnsupported = errors.New("finding rule is not supported for source runtime")
+
+	// ErrRuleUnavailable indicates that no registered finding rule supports the requested runtime.
+	ErrRuleUnavailable = errors.New("finding rule is unavailable for source runtime")
 )
 
-// Service replays runtime events through a fixed finding evaluator and persists emitted findings.
+// Service replays runtime events through one selected finding rule and persists emitted findings.
 type Service struct {
 	runtimeStore ports.SourceRuntimeStore
 	replayer     ports.EventReplayer
 	store        ports.FindingStore
+	rules        *Registry
 }
 
 // EvaluateRequest scopes one replay-backed finding evaluation.
 type EvaluateRequest struct {
 	RuntimeID  string
+	RuleID     string
 	EventLimit uint32
 }
 
@@ -79,18 +72,24 @@ type ListResult struct {
 	Findings []*ports.FindingRecord
 }
 
-// New constructs a replay-backed finding service.
+// New constructs a replay-backed finding service with the built-in rule registry.
 func New(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore) *Service {
+	return NewWithRegistry(runtimeStore, replayer, store, Builtin())
+}
+
+// NewWithRegistry constructs a replay-backed finding service with one explicit rule registry.
+func NewWithRegistry(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore, rules *Registry) *Service {
 	return &Service{
 		runtimeStore: runtimeStore,
 		replayer:     replayer,
 		store:        store,
+		rules:        rules,
 	}
 }
 
-// EvaluateSourceRuntime replays one runtime and persists findings for matching Okta audit events.
+// EvaluateSourceRuntime replays one runtime and persists findings for one selected registered rule.
 func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateRequest) (*EvaluateResult, error) {
-	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.store == nil {
+	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.store == nil || s.rules == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
@@ -98,6 +97,10 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 		return nil, errors.New("source runtime id is required")
 	}
 	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	rule, err := s.selectRule(runtime, request.RuleID)
 	if err != nil {
 		return nil, err
 	}
@@ -110,22 +113,24 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	}
 	result := &EvaluateResult{
 		Runtime:         runtime,
-		Rule:            oktaPolicyRuleLifecycleTamperingRuleSpec(),
+		Rule:            rule.Spec(),
 		EventsEvaluated: uint32(len(events)),
 	}
 	for _, event := range events {
-		if !matchesOktaPolicyRuleLifecycleTampering(event) {
-			continue
-		}
-		record, err := oktaPolicyRuleLifecycleTamperingFinding(ctx, event, runtimeID)
+		emitted, err := rule.Evaluate(ctx, runtime, event)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("evaluate finding rule %q for event %q: %w", result.Rule.GetId(), event.GetId(), err)
 		}
-		stored, err := s.store.UpsertFinding(ctx, record)
-		if err != nil {
-			return nil, fmt.Errorf("persist finding for event %q: %w", event.GetId(), err)
+		for _, record := range emitted {
+			if record == nil {
+				continue
+			}
+			stored, err := s.store.UpsertFinding(ctx, record)
+			if err != nil {
+				return nil, fmt.Errorf("persist finding for rule %q event %q: %w", result.Rule.GetId(), event.GetId(), err)
+			}
+			result.Findings = append(result.Findings, stored)
 		}
-		result.Findings = append(result.Findings, stored)
 	}
 	return result, nil
 }
@@ -158,6 +163,29 @@ func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListR
 	return &ListResult{Findings: findings}, nil
 }
 
+func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (Rule, error) {
+	trimmedRuleID := strings.TrimSpace(ruleID)
+	if trimmedRuleID != "" {
+		rule, ok := s.rules.Get(trimmedRuleID)
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", ErrRuleNotFound, trimmedRuleID)
+		}
+		if !rule.SupportsRuntime(runtime) {
+			return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedRuleID)
+		}
+		return rule, nil
+	}
+	applicable := s.rules.ForRuntime(runtime)
+	switch len(applicable) {
+	case 0:
+		return nil, fmt.Errorf("%w: %s", ErrRuleUnavailable, strings.TrimSpace(runtime.GetId()))
+	case 1:
+		return applicable[0], nil
+	default:
+		return nil, fmt.Errorf("%w for runtime %q", ErrRuleSelectionRequired, strings.TrimSpace(runtime.GetId()))
+	}
+}
+
 func normalizeEventLimit(limit uint32) uint32 {
 	switch {
 	case limit == 0:
@@ -166,224 +194,5 @@ func normalizeEventLimit(limit uint32) uint32 {
 		return maxEventLimit
 	default:
 		return limit
-	}
-}
-
-func oktaPolicyRuleLifecycleTamperingRuleSpec() *cerebrov1.RuleSpec {
-	return &cerebrov1.RuleSpec{
-		Id:          oktaPolicyRuleLifecycleTamperingRuleID,
-		Name:        oktaPolicyRuleLifecycleTamperingTitle,
-		Description: "Detect successful Okta policy rule update, deactivate, or delete events replayed from one source runtime.",
-		InputStreamIds: []string{
-			"source-runtime-replay",
-		},
-		OutputKinds: []string{
-			"finding.okta_policy_rule_lifecycle_tampering",
-		},
-	}
-}
-
-func matchesOktaPolicyRuleLifecycleTampering(event *cerebrov1.EventEnvelope) bool {
-	if event == nil || !strings.EqualFold(strings.TrimSpace(event.GetKind()), "okta.audit") {
-		return false
-	}
-	attributes := event.GetAttributes()
-	eventType := strings.ToLower(strings.TrimSpace(attributes["event_type"]))
-	if _, ok := oktaPolicyRuleLifecycleTamperingEventTypes[eventType]; !ok {
-		return false
-	}
-	outcome := strings.ToLower(strings.TrimSpace(attributes["outcome_result"]))
-	if outcome == "" {
-		outcome = "success"
-	}
-	_, ok := oktaPolicyRuleLifecycleTamperingOutcomes[outcome]
-	return ok
-}
-
-func oktaPolicyRuleLifecycleTamperingFinding(ctx context.Context, event *cerebrov1.EventEnvelope, runtimeID string) (*ports.FindingRecord, error) {
-	resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, err := projectedEntityContext(ctx, event)
-	if err != nil {
-		return nil, fmt.Errorf("project finding context for event %q: %w", event.GetId(), err)
-	}
-	attributes := map[string]string{
-		"event_id":             strings.TrimSpace(event.GetId()),
-		"event_type":           strings.TrimSpace(event.GetAttributes()["event_type"]),
-		"outcome_result":       strings.TrimSpace(event.GetAttributes()["outcome_result"]),
-		"source_runtime_id":    strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID]),
-		"primary_actor_urn":    actorURN,
-		"primary_resource_urn": resourceURN,
-	}
-	trimEmptyAttributes(attributes)
-	observedAt := time.Time{}
-	if timestamp := event.GetOccurredAt(); timestamp != nil {
-		observedAt = timestamp.AsTime().UTC()
-	}
-	fingerprint := hashFindingFingerprint(oktaPolicyRuleLifecycleTamperingRuleID, event.GetId())
-	return &ports.FindingRecord{
-		ID:              fingerprint,
-		Fingerprint:     fingerprint,
-		TenantID:        strings.TrimSpace(event.GetTenantId()),
-		RuntimeID:       strings.TrimSpace(runtimeID),
-		RuleID:          oktaPolicyRuleLifecycleTamperingRuleID,
-		Title:           oktaPolicyRuleLifecycleTamperingTitle,
-		Severity:        oktaPolicyRuleLifecycleTamperingSeverity,
-		Status:          oktaPolicyRuleLifecycleTamperingStatus,
-		Summary:         findingSummary(event, actorLabel, resourceLabel),
-		ResourceURNs:    resourceURNs,
-		EventIDs:        []string{strings.TrimSpace(event.GetId())},
-		Attributes:      attributes,
-		FirstObservedAt: observedAt,
-		LastObservedAt:  observedAt,
-	}, nil
-}
-
-func projectedEntityContext(ctx context.Context, event *cerebrov1.EventEnvelope) ([]string, string, string, string, string, error) {
-	recorder := &projectionRecorder{
-		entities: make(map[string]*ports.ProjectedEntity),
-		links:    make(map[string]*ports.ProjectedLink),
-	}
-	if ctx == nil {
-		return nil, "", "", "", "", errors.New("context is required")
-	}
-	if _, err := sourceprojection.New(nil, recorder).Project(ctx, event); err != nil {
-		return nil, "", "", "", "", err
-	}
-	resourceURNs := make([]string, 0, len(recorder.entities))
-	seenURNs := make(map[string]struct{}, len(recorder.entities))
-	var actorURN string
-	var resourceURN string
-	for _, link := range recorder.links {
-		if !strings.EqualFold(strings.TrimSpace(link.Relation), "acted_on") {
-			continue
-		}
-		if actorURN == "" {
-			actorURN = strings.TrimSpace(link.FromURN)
-		}
-		if resourceURN == "" {
-			resourceURN = strings.TrimSpace(link.ToURN)
-		}
-		if candidate := strings.TrimSpace(link.FromURN); candidate != "" {
-			if _, ok := seenURNs[candidate]; !ok {
-				seenURNs[candidate] = struct{}{}
-				resourceURNs = append(resourceURNs, candidate)
-			}
-		}
-		if candidate := strings.TrimSpace(link.ToURN); candidate != "" {
-			if _, ok := seenURNs[candidate]; !ok {
-				seenURNs[candidate] = struct{}{}
-				resourceURNs = append(resourceURNs, candidate)
-			}
-		}
-	}
-	slices.Sort(resourceURNs)
-	actorLabel := entityLabel(recorder.entities[actorURN], event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"])
-	resourceLabel := entityLabel(recorder.entities[resourceURN], event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"])
-	return resourceURNs, actorURN, resourceURN, actorLabel, resourceLabel, nil
-}
-
-func entityLabel(entity *ports.ProjectedEntity, fallbacks ...string) string {
-	if entity != nil && strings.TrimSpace(entity.Label) != "" {
-		return strings.TrimSpace(entity.Label)
-	}
-	for _, fallback := range fallbacks {
-		if strings.TrimSpace(fallback) != "" {
-			return strings.TrimSpace(fallback)
-		}
-	}
-	return ""
-}
-
-func findingSummary(event *cerebrov1.EventEnvelope, actorLabel string, resourceLabel string) string {
-	eventType := strings.TrimSpace(event.GetAttributes()["event_type"])
-	actor := firstNonEmpty(actorLabel, event.GetAttributes()["actor_alternate_id"], event.GetAttributes()["actor_display_name"], event.GetAttributes()["actor_id"], "unknown actor")
-	resource := firstNonEmpty(resourceLabel, event.GetAttributes()["resource_id"], event.GetAttributes()["resource_type"], "unknown resource")
-	return fmt.Sprintf("%s performed %s on %s", actor, eventType, resource)
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
-}
-
-func trimEmptyAttributes(attributes map[string]string) {
-	for key, value := range attributes {
-		if strings.TrimSpace(value) == "" {
-			delete(attributes, key)
-		}
-	}
-}
-
-func hashFindingFingerprint(parts ...string) string {
-	hash := sha256.New()
-	for _, part := range parts {
-		_, _ = hash.Write([]byte(strings.TrimSpace(part)))
-		_, _ = hash.Write([]byte{0})
-	}
-	return hex.EncodeToString(hash.Sum(nil))
-}
-
-type projectionRecorder struct {
-	entities map[string]*ports.ProjectedEntity
-	links    map[string]*ports.ProjectedLink
-}
-
-func (r *projectionRecorder) Ping(context.Context) error {
-	return nil
-}
-
-func (r *projectionRecorder) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
-	if entity == nil {
-		return nil
-	}
-	r.entities[entity.URN] = cloneEntity(entity)
-	return nil
-}
-
-func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
-	if link == nil {
-		return nil
-	}
-	key := strings.TrimSpace(link.FromURN) + "|" + strings.TrimSpace(link.Relation) + "|" + strings.TrimSpace(link.ToURN)
-	r.links[key] = cloneLink(link)
-	return nil
-}
-
-func cloneEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
-	if entity == nil {
-		return nil
-	}
-	attributes := make(map[string]string, len(entity.Attributes))
-	for key, value := range entity.Attributes {
-		attributes[key] = value
-	}
-	return &ports.ProjectedEntity{
-		URN:        entity.URN,
-		TenantID:   entity.TenantID,
-		SourceID:   entity.SourceID,
-		EntityType: entity.EntityType,
-		Label:      entity.Label,
-		Attributes: attributes,
-	}
-}
-
-func cloneLink(link *ports.ProjectedLink) *ports.ProjectedLink {
-	if link == nil {
-		return nil
-	}
-	attributes := make(map[string]string, len(link.Attributes))
-	for key, value := range link.Attributes {
-		attributes[key] = value
-	}
-	return &ports.ProjectedLink{
-		TenantID:   link.TenantID,
-		SourceID:   link.SourceID,
-		FromURN:    link.FromURN,
-		ToURN:      link.ToURN,
-		Relation:   link.Relation,
-		Attributes: attributes,
 	}
 }

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -178,6 +178,121 @@ func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T
 	}
 }
 
+func TestEvaluateSourceRuntimeFindingsSelectsRequestedRule(t *testing.T) {
+	replayer := &stubReplayer{
+		events: []*cerebrov1.EventEnvelope{
+			newAuditEvent("okta-audit-2", "policy.rule.update", "SUCCESS"),
+		},
+	}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		replayer,
+		&stubFindingStore{},
+	)
+
+	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID:  "writer-okta-audit",
+		RuleID:     oktaPolicyRuleLifecycleTamperingRuleID,
+		EventLimit: 10,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntime() error = %v", err)
+	}
+	if got := result.Rule.GetId(); got != oktaPolicyRuleLifecycleTamperingRuleID {
+		t.Fatalf("EvaluateSourceRuntime().Rule.ID = %q, want %q", got, oktaPolicyRuleLifecycleTamperingRuleID)
+	}
+	if got := len(result.Findings); got != 1 {
+		t.Fatalf("len(EvaluateSourceRuntime().Findings) = %d, want 1", got)
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsRejectsUnknownRule(t *testing.T) {
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		&stubFindingStore{},
+	)
+	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-okta-audit",
+		RuleID:    "rule-does-not-exist",
+	}); !errors.Is(err, ErrRuleNotFound) {
+		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuleNotFound)
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsRequiresRuleIDWhenMultipleRulesSupportRuntime(t *testing.T) {
+	registry, err := NewRegistry(
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		&stubRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		&stubFindingStore{},
+		registry,
+	)
+	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-okta-audit",
+	}); !errors.Is(err, ErrRuleSelectionRequired) {
+		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuleSelectionRequired)
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsRejectsUnsupportedRule(t *testing.T) {
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-github-audit": {
+					Id:       "writer-github-audit",
+					SourceId: "github",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		&stubFindingStore{},
+	)
+	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-github-audit",
+		RuleID:    oktaPolicyRuleLifecycleTamperingRuleID,
+	}); !errors.Is(err, ErrRuleUnsupported) {
+		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuleUnsupported)
+	}
+}
+
 func TestListFindingsReturnsFilteredPersistedFindings(t *testing.T) {
 	store := &stubFindingStore{
 		findings: map[string]*ports.FindingRecord{

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -285,13 +285,14 @@ message ListFindingsResponse {
   repeated Finding findings = 1;
 }
 
-// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through the first built-in finding evaluator.
+// EvaluateSourceRuntimeFindingsRequest replays one stored runtime through one registered finding rule.
 message EvaluateSourceRuntimeFindingsRequest {
   string id = 1;
   uint32 event_limit = 2;
+  string rule_id = 3;
 }
 
-// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, fixed rule spec, and persisted findings.
+// EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, selected rule spec, and persisted findings.
 message EvaluateSourceRuntimeFindingsResponse {
   SourceRuntime runtime = 1;
   RuleSpec rule = 2;


### PR DESCRIPTION
## Summary
- extract the Okta lifecycle detector into a registered finding rule and route evaluation through a reusable findings registry
- add optional `rule_id` selection to runtime finding evaluation so the API stays generic while still returning one selected rule per call
- cover registry selection, unsupported or unknown rule handling, and bootstrap forwarding for the new evaluation path

## Validation
- go -C /Users/jonathan/Documents/cerebro-worktrees/cerebro-next-okta-source-20260423 test ./internal/findings ./internal/bootstrap ./internal/statestore/postgres ./internal/reports
- make verify