### PR TITLE
feat(findings): persist evaluation run history

### DIFF
--- a/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
+++ b/docs/FINDINGS_PLATFORM_ARCHITECTURE.md
@@ -30,12 +30,13 @@ The rule registry fixes that.
 - Keep the service generic and deterministic.
 - Make rules discoverable to platform clients.
 - Keep persisted finding lineage explicit through `rule_id`.
+- Make each evaluation attempt durable and inspectable after the request returns.
 - Make adding a new detector a registration step, not a service fork.
 - Preserve the current storage model where findings remain current-state records in Postgres.
 
 ## Current Platform Model
 
-The current findings platform now has five layers.
+The current findings platform now has six layers.
 
 ### 1. Runtime Replay
 
@@ -78,7 +79,28 @@ Why the service selects exactly one rule per call:
 
 That is why the API now accepts `rule_id` for explicit rule selection.
 
-### 4. Persisted Finding Reads
+### 4. Durable Evaluation Runs
+
+Each evaluation now persists a `FindingEvaluationRun` record before replay starts and finishes that record with either completed or failed status.
+
+Why this layer exists:
+
+- evaluation is operational work, not just a transient HTTP response
+- platform clients need a durable audit trail for when a rule last ran
+- failures need to be inspectable without scraping logs
+- reports and future orchestration can anchor on a run identifier instead of guessing from timestamps
+
+The run captures:
+
+- which `runtime_id` and `rule_id` were evaluated
+- how many events were replayed
+- which finding IDs were upserted
+- whether the run completed or failed
+- when the run started and finished
+
+This keeps evaluation lineage separate from the findings themselves. Findings remain current-state security outcomes; runs explain how those outcomes were produced.
+
+### 5. Persisted Finding Reads
 
 Persisted findings remain the contract clients consume after evaluation:
 
@@ -87,7 +109,7 @@ Persisted findings remain the contract clients consume after evaluation:
 
 These reads stay generic and source-agnostic. Rules populate persisted findings; clients read findings, not source-specific detector internals.
 
-### 5. Reporting
+### 6. Reporting
 
 Reports such as `finding-summary` operate on persisted findings instead of on raw source logic.
 
@@ -118,7 +140,18 @@ curl -X POST \
   "http://localhost:8080/source-runtimes/writer-okta-audit/findings/evaluate?rule_id=identity-okta-policy-rule-lifecycle-tampering&event_limit=100"
 ```
 
-This replays one runtime and persists findings emitted by the selected rule.
+This replays one runtime, persists findings emitted by the selected rule, and returns the durable evaluation run metadata.
+
+### Inspect evaluation runs
+
+```bash
+curl \
+  "http://localhost:8080/source-runtimes/writer-okta-audit/finding-evaluation-runs?rule_id=identity-okta-policy-rule-lifecycle-tampering&status=completed&limit=20"
+
+curl http://localhost:8080/finding-evaluation-runs/<run-id>
+```
+
+These endpoints answer operational questions like "when did this rule last run?", "did it fail?", and "which findings came from that pass?"
 
 ### Read persisted findings
 
@@ -146,10 +179,11 @@ Why it was extracted into its own file:
 ## Code Map
 
 - `internal/findings/registry.go` — rule interface and rule catalog
-- `internal/findings/service.go` — replay orchestration and explicit rule selection
+- `internal/findings/service.go` — replay orchestration, explicit rule selection, and durable evaluation run lifecycle
 - `internal/findings/okta_policy_rule_lifecycle_tampering_rule.go` — first built-in finding rule
+- `internal/statestore/postgres/findingevaluationruns.go` — persisted evaluation run storage and query filters
 - `internal/bootstrap/app.go` — HTTP and ConnectRPC exposure
-- `proto/cerebro/v1/bootstrap.proto` — transport contract for rule listing and rule-scoped evaluation
+- `proto/cerebro/v1/bootstrap.proto` — transport contract for rule listing, rule-scoped evaluation, and run inspection
 
 ## How To Add A New Finding Rule
 
@@ -172,6 +206,7 @@ Still intentionally out of scope:
 - cross-runtime or tenant-wide rule orchestration
 - control/check mapping
 - evidence bundles beyond current finding attributes and graph/report joins
+- retries, leases, or scheduler-owned evaluation execution
 - suppression, assignment, and lifecycle workflows in the bootstrap surface
 
 ## Why This Is The Right Intermediate Step
@@ -180,6 +215,7 @@ This change is intentionally small but architectural:
 
 - it makes findings extensible without pretending the full policy/control system already exists
 - it gives clients a discoverable rule catalog now
+- it gives the platform a durable execution history instead of burying evaluation inside request logs
 - it preserves replay as the authoritative evaluation substrate
 - it keeps rule logic, finding persistence, and reporting as separate layers
 

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -32,6 +32,11 @@ curl http://localhost:8080/finding-rules
 curl -X POST \
   "http://localhost:8080/source-runtimes/writer-okta-audit/findings/evaluate?rule_id=identity-okta-policy-rule-lifecycle-tampering&event_limit=100"
 
+# Inspect persisted finding evaluation runs
+curl \
+  "http://localhost:8080/source-runtimes/writer-okta-audit/finding-evaluation-runs?rule_id=identity-okta-policy-rule-lifecycle-tampering&status=completed&limit=20"
+curl http://localhost:8080/finding-evaluation-runs/<run-id>
+
 # Read persisted findings for one runtime
 curl \
   "http://localhost:8080/source-runtimes/writer-okta-audit/findings?rule_id=identity-okta-policy-rule-lifecycle-tampering&status=open"

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -675,6 +675,335 @@ func (x *ListFindingRulesResponse) GetRules() []*RuleSpec {
 	return nil
 }
 
+// FindingEvaluationRun is the durable audit envelope for one rule evaluation over one source runtime.
+type FindingEvaluationRun struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Id               string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	RuntimeId        string                 `protobuf:"bytes,2,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	RuleId           string                 `protobuf:"bytes,3,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	Status           string                 `protobuf:"bytes,4,opt,name=status,proto3" json:"status,omitempty"`
+	EventLimit       uint32                 `protobuf:"varint,5,opt,name=event_limit,json=eventLimit,proto3" json:"event_limit,omitempty"`
+	EventsEvaluated  uint32                 `protobuf:"varint,6,opt,name=events_evaluated,json=eventsEvaluated,proto3" json:"events_evaluated,omitempty"`
+	FindingsUpserted uint32                 `protobuf:"varint,7,opt,name=findings_upserted,json=findingsUpserted,proto3" json:"findings_upserted,omitempty"`
+	FindingIds       []string               `protobuf:"bytes,8,rep,name=finding_ids,json=findingIds,proto3" json:"finding_ids,omitempty"`
+	StartedAt        *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	FinishedAt       *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=finished_at,json=finishedAt,proto3" json:"finished_at,omitempty"`
+	Error            string                 `protobuf:"bytes,11,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *FindingEvaluationRun) Reset() {
+	*x = FindingEvaluationRun{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FindingEvaluationRun) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FindingEvaluationRun) ProtoMessage() {}
+
+func (x *FindingEvaluationRun) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FindingEvaluationRun.ProtoReflect.Descriptor instead.
+func (*FindingEvaluationRun) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *FindingEvaluationRun) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *FindingEvaluationRun) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *FindingEvaluationRun) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+func (x *FindingEvaluationRun) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *FindingEvaluationRun) GetEventLimit() uint32 {
+	if x != nil {
+		return x.EventLimit
+	}
+	return 0
+}
+
+func (x *FindingEvaluationRun) GetEventsEvaluated() uint32 {
+	if x != nil {
+		return x.EventsEvaluated
+	}
+	return 0
+}
+
+func (x *FindingEvaluationRun) GetFindingsUpserted() uint32 {
+	if x != nil {
+		return x.FindingsUpserted
+	}
+	return 0
+}
+
+func (x *FindingEvaluationRun) GetFindingIds() []string {
+	if x != nil {
+		return x.FindingIds
+	}
+	return nil
+}
+
+func (x *FindingEvaluationRun) GetStartedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartedAt
+	}
+	return nil
+}
+
+func (x *FindingEvaluationRun) GetFinishedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.FinishedAt
+	}
+	return nil
+}
+
+func (x *FindingEvaluationRun) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+// ListFindingEvaluationRunsRequest requests persisted finding evaluation runs for one stored runtime.
+type ListFindingEvaluationRunsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RuntimeId     string                 `protobuf:"bytes,1,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	RuleId        string                 `protobuf:"bytes,2,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	Status        string                 `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	Limit         uint32                 `protobuf:"varint,4,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFindingEvaluationRunsRequest) Reset() {
+	*x = ListFindingEvaluationRunsRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFindingEvaluationRunsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFindingEvaluationRunsRequest) ProtoMessage() {}
+
+func (x *ListFindingEvaluationRunsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFindingEvaluationRunsRequest.ProtoReflect.Descriptor instead.
+func (*ListFindingEvaluationRunsRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *ListFindingEvaluationRunsRequest) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *ListFindingEvaluationRunsRequest) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+func (x *ListFindingEvaluationRunsRequest) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ListFindingEvaluationRunsRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+// ListFindingEvaluationRunsResponse returns the matched persisted finding evaluation runs.
+type ListFindingEvaluationRunsResponse struct {
+	state         protoimpl.MessageState  `protogen:"open.v1"`
+	Runs          []*FindingEvaluationRun `protobuf:"bytes,1,rep,name=runs,proto3" json:"runs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFindingEvaluationRunsResponse) Reset() {
+	*x = ListFindingEvaluationRunsResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFindingEvaluationRunsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFindingEvaluationRunsResponse) ProtoMessage() {}
+
+func (x *ListFindingEvaluationRunsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFindingEvaluationRunsResponse.ProtoReflect.Descriptor instead.
+func (*ListFindingEvaluationRunsResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *ListFindingEvaluationRunsResponse) GetRuns() []*FindingEvaluationRun {
+	if x != nil {
+		return x.Runs
+	}
+	return nil
+}
+
+// GetFindingEvaluationRunRequest looks up one persisted finding evaluation run.
+type GetFindingEvaluationRunRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetFindingEvaluationRunRequest) Reset() {
+	*x = GetFindingEvaluationRunRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetFindingEvaluationRunRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetFindingEvaluationRunRequest) ProtoMessage() {}
+
+func (x *GetFindingEvaluationRunRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetFindingEvaluationRunRequest.ProtoReflect.Descriptor instead.
+func (*GetFindingEvaluationRunRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *GetFindingEvaluationRunRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+// GetFindingEvaluationRunResponse returns one persisted finding evaluation run.
+type GetFindingEvaluationRunResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Run           *FindingEvaluationRun  `protobuf:"bytes,1,opt,name=run,proto3" json:"run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetFindingEvaluationRunResponse) Reset() {
+	*x = GetFindingEvaluationRunResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetFindingEvaluationRunResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetFindingEvaluationRunResponse) ProtoMessage() {}
+
+func (x *GetFindingEvaluationRunResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetFindingEvaluationRunResponse.ProtoReflect.Descriptor instead.
+func (*GetFindingEvaluationRunResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *GetFindingEvaluationRunResponse) GetRun() *FindingEvaluationRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
 // RunReportRequest requests one durable report run.
 type RunReportRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -686,7 +1015,7 @@ type RunReportRequest struct {
 
 func (x *RunReportRequest) Reset() {
 	*x = RunReportRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -698,7 +1027,7 @@ func (x *RunReportRequest) String() string {
 func (*RunReportRequest) ProtoMessage() {}
 
 func (x *RunReportRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[12]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -711,7 +1040,7 @@ func (x *RunReportRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunReportRequest.ProtoReflect.Descriptor instead.
 func (*RunReportRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{12}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *RunReportRequest) GetReportId() string {
@@ -739,7 +1068,7 @@ type RunReportResponse struct {
 
 func (x *RunReportResponse) Reset() {
 	*x = RunReportResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[13]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -751,7 +1080,7 @@ func (x *RunReportResponse) String() string {
 func (*RunReportResponse) ProtoMessage() {}
 
 func (x *RunReportResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[13]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -764,7 +1093,7 @@ func (x *RunReportResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunReportResponse.ProtoReflect.Descriptor instead.
 func (*RunReportResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{13}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *RunReportResponse) GetReport() *ReportDefinition {
@@ -791,7 +1120,7 @@ type GetReportRunRequest struct {
 
 func (x *GetReportRunRequest) Reset() {
 	*x = GetReportRunRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[14]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -803,7 +1132,7 @@ func (x *GetReportRunRequest) String() string {
 func (*GetReportRunRequest) ProtoMessage() {}
 
 func (x *GetReportRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[14]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -816,7 +1145,7 @@ func (x *GetReportRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReportRunRequest.ProtoReflect.Descriptor instead.
 func (*GetReportRunRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{14}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetReportRunRequest) GetId() string {
@@ -836,7 +1165,7 @@ type GetReportRunResponse struct {
 
 func (x *GetReportRunResponse) Reset() {
 	*x = GetReportRunResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[15]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -848,7 +1177,7 @@ func (x *GetReportRunResponse) String() string {
 func (*GetReportRunResponse) ProtoMessage() {}
 
 func (x *GetReportRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[15]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -861,7 +1190,7 @@ func (x *GetReportRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReportRunResponse.ProtoReflect.Descriptor instead.
 func (*GetReportRunResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{15}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetReportRunResponse) GetRun() *ReportRun {
@@ -880,7 +1209,7 @@ type ListSourcesRequest struct {
 
 func (x *ListSourcesRequest) Reset() {
 	*x = ListSourcesRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[16]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -892,7 +1221,7 @@ func (x *ListSourcesRequest) String() string {
 func (*ListSourcesRequest) ProtoMessage() {}
 
 func (x *ListSourcesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[16]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -905,7 +1234,7 @@ func (x *ListSourcesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSourcesRequest.ProtoReflect.Descriptor instead.
 func (*ListSourcesRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{16}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{21}
 }
 
 // ListSourcesResponse returns the registered in-process source specs.
@@ -918,7 +1247,7 @@ type ListSourcesResponse struct {
 
 func (x *ListSourcesResponse) Reset() {
 	*x = ListSourcesResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -930,7 +1259,7 @@ func (x *ListSourcesResponse) String() string {
 func (*ListSourcesResponse) ProtoMessage() {}
 
 func (x *ListSourcesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -943,7 +1272,7 @@ func (x *ListSourcesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSourcesResponse.ProtoReflect.Descriptor instead.
 func (*ListSourcesResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{17}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListSourcesResponse) GetSources() []*SourceSpec {
@@ -964,7 +1293,7 @@ type CheckSourceRequest struct {
 
 func (x *CheckSourceRequest) Reset() {
 	*x = CheckSourceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -976,7 +1305,7 @@ func (x *CheckSourceRequest) String() string {
 func (*CheckSourceRequest) ProtoMessage() {}
 
 func (x *CheckSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -989,7 +1318,7 @@ func (x *CheckSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckSourceRequest.ProtoReflect.Descriptor instead.
 func (*CheckSourceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{18}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CheckSourceRequest) GetSourceId() string {
@@ -1017,7 +1346,7 @@ type CheckSourceResponse struct {
 
 func (x *CheckSourceResponse) Reset() {
 	*x = CheckSourceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1029,7 +1358,7 @@ func (x *CheckSourceResponse) String() string {
 func (*CheckSourceResponse) ProtoMessage() {}
 
 func (x *CheckSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1042,7 +1371,7 @@ func (x *CheckSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckSourceResponse.ProtoReflect.Descriptor instead.
 func (*CheckSourceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{19}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *CheckSourceResponse) GetSource() *SourceSpec {
@@ -1070,7 +1399,7 @@ type DiscoverSourceRequest struct {
 
 func (x *DiscoverSourceRequest) Reset() {
 	*x = DiscoverSourceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1082,7 +1411,7 @@ func (x *DiscoverSourceRequest) String() string {
 func (*DiscoverSourceRequest) ProtoMessage() {}
 
 func (x *DiscoverSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1095,7 +1424,7 @@ func (x *DiscoverSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoverSourceRequest.ProtoReflect.Descriptor instead.
 func (*DiscoverSourceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{20}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *DiscoverSourceRequest) GetSourceId() string {
@@ -1123,7 +1452,7 @@ type DiscoverSourceResponse struct {
 
 func (x *DiscoverSourceResponse) Reset() {
 	*x = DiscoverSourceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1135,7 +1464,7 @@ func (x *DiscoverSourceResponse) String() string {
 func (*DiscoverSourceResponse) ProtoMessage() {}
 
 func (x *DiscoverSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1148,7 +1477,7 @@ func (x *DiscoverSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoverSourceResponse.ProtoReflect.Descriptor instead.
 func (*DiscoverSourceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{21}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *DiscoverSourceResponse) GetSource() *SourceSpec {
@@ -1177,7 +1506,7 @@ type ReadSourceRequest struct {
 
 func (x *ReadSourceRequest) Reset() {
 	*x = ReadSourceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1189,7 +1518,7 @@ func (x *ReadSourceRequest) String() string {
 func (*ReadSourceRequest) ProtoMessage() {}
 
 func (x *ReadSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1202,7 +1531,7 @@ func (x *ReadSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSourceRequest.ProtoReflect.Descriptor instead.
 func (*ReadSourceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{22}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ReadSourceRequest) GetSourceId() string {
@@ -1238,7 +1567,7 @@ type SourcePreviewEvent struct {
 
 func (x *SourcePreviewEvent) Reset() {
 	*x = SourcePreviewEvent{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1250,7 +1579,7 @@ func (x *SourcePreviewEvent) String() string {
 func (*SourcePreviewEvent) ProtoMessage() {}
 
 func (x *SourcePreviewEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1263,7 +1592,7 @@ func (x *SourcePreviewEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SourcePreviewEvent.ProtoReflect.Descriptor instead.
 func (*SourcePreviewEvent) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{23}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SourcePreviewEvent) GetEvent() *EventEnvelope {
@@ -1301,7 +1630,7 @@ type ReadSourceResponse struct {
 
 func (x *ReadSourceResponse) Reset() {
 	*x = ReadSourceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1313,7 +1642,7 @@ func (x *ReadSourceResponse) String() string {
 func (*ReadSourceResponse) ProtoMessage() {}
 
 func (x *ReadSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1326,7 +1655,7 @@ func (x *ReadSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSourceResponse.ProtoReflect.Descriptor instead.
 func (*ReadSourceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{24}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ReadSourceResponse) GetSource() *SourceSpec {
@@ -1380,7 +1709,7 @@ type SourceRuntime struct {
 
 func (x *SourceRuntime) Reset() {
 	*x = SourceRuntime{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1392,7 +1721,7 @@ func (x *SourceRuntime) String() string {
 func (*SourceRuntime) ProtoMessage() {}
 
 func (x *SourceRuntime) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1405,7 +1734,7 @@ func (x *SourceRuntime) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SourceRuntime.ProtoReflect.Descriptor instead.
 func (*SourceRuntime) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{25}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SourceRuntime) GetId() string {
@@ -1467,7 +1796,7 @@ type PutSourceRuntimeRequest struct {
 
 func (x *PutSourceRuntimeRequest) Reset() {
 	*x = PutSourceRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1479,7 +1808,7 @@ func (x *PutSourceRuntimeRequest) String() string {
 func (*PutSourceRuntimeRequest) ProtoMessage() {}
 
 func (x *PutSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1492,7 +1821,7 @@ func (x *PutSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutSourceRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*PutSourceRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{26}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *PutSourceRuntimeRequest) GetRuntime() *SourceRuntime {
@@ -1512,7 +1841,7 @@ type PutSourceRuntimeResponse struct {
 
 func (x *PutSourceRuntimeResponse) Reset() {
 	*x = PutSourceRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1524,7 +1853,7 @@ func (x *PutSourceRuntimeResponse) String() string {
 func (*PutSourceRuntimeResponse) ProtoMessage() {}
 
 func (x *PutSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1537,7 +1866,7 @@ func (x *PutSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutSourceRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*PutSourceRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{27}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *PutSourceRuntimeResponse) GetRuntime() *SourceRuntime {
@@ -1557,7 +1886,7 @@ type GetSourceRuntimeRequest struct {
 
 func (x *GetSourceRuntimeRequest) Reset() {
 	*x = GetSourceRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[28]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1569,7 +1898,7 @@ func (x *GetSourceRuntimeRequest) String() string {
 func (*GetSourceRuntimeRequest) ProtoMessage() {}
 
 func (x *GetSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[28]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1582,7 +1911,7 @@ func (x *GetSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSourceRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*GetSourceRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{28}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetSourceRuntimeRequest) GetId() string {
@@ -1602,7 +1931,7 @@ type GetSourceRuntimeResponse struct {
 
 func (x *GetSourceRuntimeResponse) Reset() {
 	*x = GetSourceRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[29]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1614,7 +1943,7 @@ func (x *GetSourceRuntimeResponse) String() string {
 func (*GetSourceRuntimeResponse) ProtoMessage() {}
 
 func (x *GetSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[29]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1627,7 +1956,7 @@ func (x *GetSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSourceRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*GetSourceRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{29}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *GetSourceRuntimeResponse) GetRuntime() *SourceRuntime {
@@ -1648,7 +1977,7 @@ type SyncSourceRuntimeRequest struct {
 
 func (x *SyncSourceRuntimeRequest) Reset() {
 	*x = SyncSourceRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[30]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1660,7 +1989,7 @@ func (x *SyncSourceRuntimeRequest) String() string {
 func (*SyncSourceRuntimeRequest) ProtoMessage() {}
 
 func (x *SyncSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[30]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1673,7 +2002,7 @@ func (x *SyncSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncSourceRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*SyncSourceRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{30}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *SyncSourceRuntimeRequest) GetId() string {
@@ -1705,7 +2034,7 @@ type SyncSourceRuntimeResponse struct {
 
 func (x *SyncSourceRuntimeResponse) Reset() {
 	*x = SyncSourceRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[31]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1717,7 +2046,7 @@ func (x *SyncSourceRuntimeResponse) String() string {
 func (*SyncSourceRuntimeResponse) ProtoMessage() {}
 
 func (x *SyncSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[31]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1730,7 +2059,7 @@ func (x *SyncSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncSourceRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*SyncSourceRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{31}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *SyncSourceRuntimeResponse) GetRuntime() *SourceRuntime {
@@ -1787,7 +2116,7 @@ type WriteClaimsRequest struct {
 
 func (x *WriteClaimsRequest) Reset() {
 	*x = WriteClaimsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1799,7 +2128,7 @@ func (x *WriteClaimsRequest) String() string {
 func (*WriteClaimsRequest) ProtoMessage() {}
 
 func (x *WriteClaimsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1812,7 +2141,7 @@ func (x *WriteClaimsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteClaimsRequest.ProtoReflect.Descriptor instead.
 func (*WriteClaimsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{32}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *WriteClaimsRequest) GetRuntimeId() string {
@@ -1849,7 +2178,7 @@ type WriteClaimsResponse struct {
 
 func (x *WriteClaimsResponse) Reset() {
 	*x = WriteClaimsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1861,7 +2190,7 @@ func (x *WriteClaimsResponse) String() string {
 func (*WriteClaimsResponse) ProtoMessage() {}
 
 func (x *WriteClaimsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1874,7 +2203,7 @@ func (x *WriteClaimsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteClaimsResponse.ProtoReflect.Descriptor instead.
 func (*WriteClaimsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{33}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *WriteClaimsResponse) GetClaimsWritten() uint32 {
@@ -1924,7 +2253,7 @@ type ListClaimsRequest struct {
 
 func (x *ListClaimsRequest) Reset() {
 	*x = ListClaimsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1936,7 +2265,7 @@ func (x *ListClaimsRequest) String() string {
 func (*ListClaimsRequest) ProtoMessage() {}
 
 func (x *ListClaimsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1949,7 +2278,7 @@ func (x *ListClaimsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListClaimsRequest.ProtoReflect.Descriptor instead.
 func (*ListClaimsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ListClaimsRequest) GetRuntimeId() string {
@@ -2032,7 +2361,7 @@ type ListClaimsResponse struct {
 
 func (x *ListClaimsResponse) Reset() {
 	*x = ListClaimsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2044,7 +2373,7 @@ func (x *ListClaimsResponse) String() string {
 func (*ListClaimsResponse) ProtoMessage() {}
 
 func (x *ListClaimsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2057,7 +2386,7 @@ func (x *ListClaimsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListClaimsResponse.ProtoReflect.Descriptor instead.
 func (*ListClaimsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ListClaimsResponse) GetClaims() []*Claim {
@@ -2084,7 +2413,7 @@ type ListFindingsRequest struct {
 
 func (x *ListFindingsRequest) Reset() {
 	*x = ListFindingsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2096,7 +2425,7 @@ func (x *ListFindingsRequest) String() string {
 func (*ListFindingsRequest) ProtoMessage() {}
 
 func (x *ListFindingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2109,7 +2438,7 @@ func (x *ListFindingsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFindingsRequest.ProtoReflect.Descriptor instead.
 func (*ListFindingsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ListFindingsRequest) GetRuntimeId() string {
@@ -2191,7 +2520,7 @@ type Finding struct {
 
 func (x *Finding) Reset() {
 	*x = Finding{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2203,7 +2532,7 @@ func (x *Finding) String() string {
 func (*Finding) ProtoMessage() {}
 
 func (x *Finding) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2216,7 +2545,7 @@ func (x *Finding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Finding.ProtoReflect.Descriptor instead.
 func (*Finding) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{37}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *Finding) GetId() string {
@@ -2327,7 +2656,7 @@ type ListFindingsResponse struct {
 
 func (x *ListFindingsResponse) Reset() {
 	*x = ListFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2339,7 +2668,7 @@ func (x *ListFindingsResponse) String() string {
 func (*ListFindingsResponse) ProtoMessage() {}
 
 func (x *ListFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2352,7 +2681,7 @@ func (x *ListFindingsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFindingsResponse.ProtoReflect.Descriptor instead.
 func (*ListFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{38}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ListFindingsResponse) GetFindings() []*Finding {
@@ -2374,7 +2703,7 @@ type EvaluateSourceRuntimeFindingsRequest struct {
 
 func (x *EvaluateSourceRuntimeFindingsRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2386,7 +2715,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) String() string {
 func (*EvaluateSourceRuntimeFindingsRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2399,7 +2728,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{39}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *EvaluateSourceRuntimeFindingsRequest) GetId() string {
@@ -2431,13 +2760,14 @@ type EvaluateSourceRuntimeFindingsResponse struct {
 	EventsEvaluated  uint32                 `protobuf:"varint,3,opt,name=events_evaluated,json=eventsEvaluated,proto3" json:"events_evaluated,omitempty"`
 	FindingsUpserted uint32                 `protobuf:"varint,4,opt,name=findings_upserted,json=findingsUpserted,proto3" json:"findings_upserted,omitempty"`
 	Findings         []*Finding             `protobuf:"bytes,5,rep,name=findings,proto3" json:"findings,omitempty"`
+	Run              *FindingEvaluationRun  `protobuf:"bytes,6,opt,name=run,proto3" json:"run,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
 
 func (x *EvaluateSourceRuntimeFindingsResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2449,7 +2779,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) String() string {
 func (*EvaluateSourceRuntimeFindingsResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2462,7 +2792,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{40}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *EvaluateSourceRuntimeFindingsResponse) GetRuntime() *SourceRuntime {
@@ -2500,6 +2830,13 @@ func (x *EvaluateSourceRuntimeFindingsResponse) GetFindings() []*Finding {
 	return nil
 }
 
+func (x *EvaluateSourceRuntimeFindingsResponse) GetRun() *FindingEvaluationRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
 // GraphEntity is the normalized graph node view exposed by the first query surface.
 type GraphEntity struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2512,7 +2849,7 @@ type GraphEntity struct {
 
 func (x *GraphEntity) Reset() {
 	*x = GraphEntity{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2524,7 +2861,7 @@ func (x *GraphEntity) String() string {
 func (*GraphEntity) ProtoMessage() {}
 
 func (x *GraphEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2537,7 +2874,7 @@ func (x *GraphEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphEntity.ProtoReflect.Descriptor instead.
 func (*GraphEntity) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{41}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *GraphEntity) GetUrn() string {
@@ -2573,7 +2910,7 @@ type GraphRelation struct {
 
 func (x *GraphRelation) Reset() {
 	*x = GraphRelation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2585,7 +2922,7 @@ func (x *GraphRelation) String() string {
 func (*GraphRelation) ProtoMessage() {}
 
 func (x *GraphRelation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2598,7 +2935,7 @@ func (x *GraphRelation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphRelation.ProtoReflect.Descriptor instead.
 func (*GraphRelation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{42}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GraphRelation) GetFromUrn() string {
@@ -2633,7 +2970,7 @@ type GetEntityNeighborhoodRequest struct {
 
 func (x *GetEntityNeighborhoodRequest) Reset() {
 	*x = GetEntityNeighborhoodRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[43]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2645,7 +2982,7 @@ func (x *GetEntityNeighborhoodRequest) String() string {
 func (*GetEntityNeighborhoodRequest) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[43]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2658,7 +2995,7 @@ func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodRequest.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{43}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetEntityNeighborhoodRequest) GetRootUrn() string {
@@ -2687,7 +3024,7 @@ type GetEntityNeighborhoodResponse struct {
 
 func (x *GetEntityNeighborhoodResponse) Reset() {
 	*x = GetEntityNeighborhoodResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[44]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2699,7 +3036,7 @@ func (x *GetEntityNeighborhoodResponse) String() string {
 func (*GetEntityNeighborhoodResponse) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[44]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2712,7 +3049,7 @@ func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodResponse.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{44}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetEntityNeighborhoodResponse) GetRoot() *GraphEntity {
@@ -2791,7 +3128,37 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\areports\x18\x01 \x03(\v2\x1c.cerebro.v1.ReportDefinitionR\areports\"\x19\n" +
 	"\x17ListFindingRulesRequest\"F\n" +
 	"\x18ListFindingRulesResponse\x12*\n" +
-	"\x05rules\x18\x01 \x03(\v2\x14.cerebro.v1.RuleSpecR\x05rules\"\xbc\x01\n" +
+	"\x05rules\x18\x01 \x03(\v2\x14.cerebro.v1.RuleSpecR\x05rules\"\x9e\x03\n" +
+	"\x14FindingEvaluationRun\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x02 \x01(\tR\truntimeId\x12\x17\n" +
+	"\arule_id\x18\x03 \x01(\tR\x06ruleId\x12\x16\n" +
+	"\x06status\x18\x04 \x01(\tR\x06status\x12\x1f\n" +
+	"\vevent_limit\x18\x05 \x01(\rR\n" +
+	"eventLimit\x12)\n" +
+	"\x10events_evaluated\x18\x06 \x01(\rR\x0feventsEvaluated\x12+\n" +
+	"\x11findings_upserted\x18\a \x01(\rR\x10findingsUpserted\x12\x1f\n" +
+	"\vfinding_ids\x18\b \x03(\tR\n" +
+	"findingIds\x129\n" +
+	"\n" +
+	"started_at\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12;\n" +
+	"\vfinished_at\x18\n" +
+	" \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"finishedAt\x12\x14\n" +
+	"\x05error\x18\v \x01(\tR\x05error\"\x88\x01\n" +
+	" ListFindingEvaluationRunsRequest\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12\x17\n" +
+	"\arule_id\x18\x02 \x01(\tR\x06ruleId\x12\x16\n" +
+	"\x06status\x18\x03 \x01(\tR\x06status\x12\x14\n" +
+	"\x05limit\x18\x04 \x01(\rR\x05limit\"Y\n" +
+	"!ListFindingEvaluationRunsResponse\x124\n" +
+	"\x04runs\x18\x01 \x03(\v2 .cerebro.v1.FindingEvaluationRunR\x04runs\"0\n" +
+	"\x1eGetFindingEvaluationRunRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"U\n" +
+	"\x1fGetFindingEvaluationRunResponse\x122\n" +
+	"\x03run\x18\x01 \x01(\v2 .cerebro.v1.FindingEvaluationRunR\x03run\"\xbc\x01\n" +
 	"\x10RunReportRequest\x12\x1b\n" +
 	"\treport_id\x18\x01 \x01(\tR\breportId\x12L\n" +
 	"\n" +
@@ -2949,13 +3316,14 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vevent_limit\x18\x02 \x01(\rR\n" +
 	"eventLimit\x12\x17\n" +
-	"\arule_id\x18\x03 \x01(\tR\x06ruleId\"\x8f\x02\n" +
+	"\arule_id\x18\x03 \x01(\tR\x06ruleId\"\xc3\x02\n" +
 	"%EvaluateSourceRuntimeFindingsResponse\x123\n" +
 	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\x12(\n" +
 	"\x04rule\x18\x02 \x01(\v2\x14.cerebro.v1.RuleSpecR\x04rule\x12)\n" +
 	"\x10events_evaluated\x18\x03 \x01(\rR\x0feventsEvaluated\x12+\n" +
 	"\x11findings_upserted\x18\x04 \x01(\rR\x10findingsUpserted\x12/\n" +
-	"\bfindings\x18\x05 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\"V\n" +
+	"\bfindings\x18\x05 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\x122\n" +
+	"\x03run\x18\x06 \x01(\v2 .cerebro.v1.FindingEvaluationRunR\x03run\"V\n" +
 	"\vGraphEntity\x12\x10\n" +
 	"\x03urn\x18\x01 \x01(\tR\x03urn\x12\x1f\n" +
 	"\ventity_type\x18\x02 \x01(\tR\n" +
@@ -2971,7 +3339,7 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x1dGetEntityNeighborhoodResponse\x12+\n" +
 	"\x04root\x18\x01 \x01(\v2\x17.cerebro.v1.GraphEntityR\x04root\x125\n" +
 	"\tneighbors\x18\x02 \x03(\v2\x17.cerebro.v1.GraphEntityR\tneighbors\x127\n" +
-	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\xe4\f\n" +
+	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\xd2\x0e\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -2991,7 +3359,9 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\vWriteClaims\x12\x1e.cerebro.v1.WriteClaimsRequest\x1a\x1f.cerebro.v1.WriteClaimsResponse\x12K\n" +
 	"\n" +
 	"ListClaims\x12\x1d.cerebro.v1.ListClaimsRequest\x1a\x1e.cerebro.v1.ListClaimsResponse\x12Q\n" +
-	"\fListFindings\x12\x1f.cerebro.v1.ListFindingsRequest\x1a .cerebro.v1.ListFindingsResponse\x12\x84\x01\n" +
+	"\fListFindings\x12\x1f.cerebro.v1.ListFindingsRequest\x1a .cerebro.v1.ListFindingsResponse\x12x\n" +
+	"\x19ListFindingEvaluationRuns\x12,.cerebro.v1.ListFindingEvaluationRunsRequest\x1a-.cerebro.v1.ListFindingEvaluationRunsResponse\x12r\n" +
+	"\x17GetFindingEvaluationRun\x12*.cerebro.v1.GetFindingEvaluationRunRequest\x1a+.cerebro.v1.GetFindingEvaluationRunResponse\x12\x84\x01\n" +
 	"\x1dEvaluateSourceRuntimeFindings\x120.cerebro.v1.EvaluateSourceRuntimeFindingsRequest\x1a1.cerebro.v1.EvaluateSourceRuntimeFindingsResponse\x12l\n" +
 	"\x15GetEntityNeighborhood\x12(.cerebro.v1.GetEntityNeighborhoodRequest\x1a).cerebro.v1.GetEntityNeighborhoodResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
 
@@ -3007,7 +3377,7 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 57)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*GetVersionRequest)(nil),                     // 0: cerebro.v1.GetVersionRequest
 	(*GetVersionResponse)(nil),                    // 1: cerebro.v1.GetVersionResponse
@@ -3021,145 +3391,159 @@ var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*ListReportDefinitionsResponse)(nil),         // 9: cerebro.v1.ListReportDefinitionsResponse
 	(*ListFindingRulesRequest)(nil),               // 10: cerebro.v1.ListFindingRulesRequest
 	(*ListFindingRulesResponse)(nil),              // 11: cerebro.v1.ListFindingRulesResponse
-	(*RunReportRequest)(nil),                      // 12: cerebro.v1.RunReportRequest
-	(*RunReportResponse)(nil),                     // 13: cerebro.v1.RunReportResponse
-	(*GetReportRunRequest)(nil),                   // 14: cerebro.v1.GetReportRunRequest
-	(*GetReportRunResponse)(nil),                  // 15: cerebro.v1.GetReportRunResponse
-	(*ListSourcesRequest)(nil),                    // 16: cerebro.v1.ListSourcesRequest
-	(*ListSourcesResponse)(nil),                   // 17: cerebro.v1.ListSourcesResponse
-	(*CheckSourceRequest)(nil),                    // 18: cerebro.v1.CheckSourceRequest
-	(*CheckSourceResponse)(nil),                   // 19: cerebro.v1.CheckSourceResponse
-	(*DiscoverSourceRequest)(nil),                 // 20: cerebro.v1.DiscoverSourceRequest
-	(*DiscoverSourceResponse)(nil),                // 21: cerebro.v1.DiscoverSourceResponse
-	(*ReadSourceRequest)(nil),                     // 22: cerebro.v1.ReadSourceRequest
-	(*SourcePreviewEvent)(nil),                    // 23: cerebro.v1.SourcePreviewEvent
-	(*ReadSourceResponse)(nil),                    // 24: cerebro.v1.ReadSourceResponse
-	(*SourceRuntime)(nil),                         // 25: cerebro.v1.SourceRuntime
-	(*PutSourceRuntimeRequest)(nil),               // 26: cerebro.v1.PutSourceRuntimeRequest
-	(*PutSourceRuntimeResponse)(nil),              // 27: cerebro.v1.PutSourceRuntimeResponse
-	(*GetSourceRuntimeRequest)(nil),               // 28: cerebro.v1.GetSourceRuntimeRequest
-	(*GetSourceRuntimeResponse)(nil),              // 29: cerebro.v1.GetSourceRuntimeResponse
-	(*SyncSourceRuntimeRequest)(nil),              // 30: cerebro.v1.SyncSourceRuntimeRequest
-	(*SyncSourceRuntimeResponse)(nil),             // 31: cerebro.v1.SyncSourceRuntimeResponse
-	(*WriteClaimsRequest)(nil),                    // 32: cerebro.v1.WriteClaimsRequest
-	(*WriteClaimsResponse)(nil),                   // 33: cerebro.v1.WriteClaimsResponse
-	(*ListClaimsRequest)(nil),                     // 34: cerebro.v1.ListClaimsRequest
-	(*ListClaimsResponse)(nil),                    // 35: cerebro.v1.ListClaimsResponse
-	(*ListFindingsRequest)(nil),                   // 36: cerebro.v1.ListFindingsRequest
-	(*Finding)(nil),                               // 37: cerebro.v1.Finding
-	(*ListFindingsResponse)(nil),                  // 38: cerebro.v1.ListFindingsResponse
-	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 39: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 40: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	(*GraphEntity)(nil),                           // 41: cerebro.v1.GraphEntity
-	(*GraphRelation)(nil),                         // 42: cerebro.v1.GraphRelation
-	(*GetEntityNeighborhoodRequest)(nil),          // 43: cerebro.v1.GetEntityNeighborhoodRequest
-	(*GetEntityNeighborhoodResponse)(nil),         // 44: cerebro.v1.GetEntityNeighborhoodResponse
-	nil,                                           // 45: cerebro.v1.ReportRun.ParametersEntry
-	nil,                                           // 46: cerebro.v1.RunReportRequest.ParametersEntry
-	nil,                                           // 47: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                                           // 48: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                                           // 49: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                                           // 50: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                                           // 51: cerebro.v1.Finding.AttributesEntry
-	(*timestamppb.Timestamp)(nil),                 // 52: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                       // 53: google.protobuf.Struct
-	(*RuleSpec)(nil),                              // 54: cerebro.v1.RuleSpec
-	(*SourceSpec)(nil),                            // 55: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),                          // 56: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                         // 57: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                        // 58: google.protobuf.Value
-	(*SourceCheckpoint)(nil),                      // 59: cerebro.v1.SourceCheckpoint
-	(*Claim)(nil),                                 // 60: cerebro.v1.Claim
+	(*FindingEvaluationRun)(nil),                  // 12: cerebro.v1.FindingEvaluationRun
+	(*ListFindingEvaluationRunsRequest)(nil),      // 13: cerebro.v1.ListFindingEvaluationRunsRequest
+	(*ListFindingEvaluationRunsResponse)(nil),     // 14: cerebro.v1.ListFindingEvaluationRunsResponse
+	(*GetFindingEvaluationRunRequest)(nil),        // 15: cerebro.v1.GetFindingEvaluationRunRequest
+	(*GetFindingEvaluationRunResponse)(nil),       // 16: cerebro.v1.GetFindingEvaluationRunResponse
+	(*RunReportRequest)(nil),                      // 17: cerebro.v1.RunReportRequest
+	(*RunReportResponse)(nil),                     // 18: cerebro.v1.RunReportResponse
+	(*GetReportRunRequest)(nil),                   // 19: cerebro.v1.GetReportRunRequest
+	(*GetReportRunResponse)(nil),                  // 20: cerebro.v1.GetReportRunResponse
+	(*ListSourcesRequest)(nil),                    // 21: cerebro.v1.ListSourcesRequest
+	(*ListSourcesResponse)(nil),                   // 22: cerebro.v1.ListSourcesResponse
+	(*CheckSourceRequest)(nil),                    // 23: cerebro.v1.CheckSourceRequest
+	(*CheckSourceResponse)(nil),                   // 24: cerebro.v1.CheckSourceResponse
+	(*DiscoverSourceRequest)(nil),                 // 25: cerebro.v1.DiscoverSourceRequest
+	(*DiscoverSourceResponse)(nil),                // 26: cerebro.v1.DiscoverSourceResponse
+	(*ReadSourceRequest)(nil),                     // 27: cerebro.v1.ReadSourceRequest
+	(*SourcePreviewEvent)(nil),                    // 28: cerebro.v1.SourcePreviewEvent
+	(*ReadSourceResponse)(nil),                    // 29: cerebro.v1.ReadSourceResponse
+	(*SourceRuntime)(nil),                         // 30: cerebro.v1.SourceRuntime
+	(*PutSourceRuntimeRequest)(nil),               // 31: cerebro.v1.PutSourceRuntimeRequest
+	(*PutSourceRuntimeResponse)(nil),              // 32: cerebro.v1.PutSourceRuntimeResponse
+	(*GetSourceRuntimeRequest)(nil),               // 33: cerebro.v1.GetSourceRuntimeRequest
+	(*GetSourceRuntimeResponse)(nil),              // 34: cerebro.v1.GetSourceRuntimeResponse
+	(*SyncSourceRuntimeRequest)(nil),              // 35: cerebro.v1.SyncSourceRuntimeRequest
+	(*SyncSourceRuntimeResponse)(nil),             // 36: cerebro.v1.SyncSourceRuntimeResponse
+	(*WriteClaimsRequest)(nil),                    // 37: cerebro.v1.WriteClaimsRequest
+	(*WriteClaimsResponse)(nil),                   // 38: cerebro.v1.WriteClaimsResponse
+	(*ListClaimsRequest)(nil),                     // 39: cerebro.v1.ListClaimsRequest
+	(*ListClaimsResponse)(nil),                    // 40: cerebro.v1.ListClaimsResponse
+	(*ListFindingsRequest)(nil),                   // 41: cerebro.v1.ListFindingsRequest
+	(*Finding)(nil),                               // 42: cerebro.v1.Finding
+	(*ListFindingsResponse)(nil),                  // 43: cerebro.v1.ListFindingsResponse
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 44: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 45: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	(*GraphEntity)(nil),                           // 46: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                         // 47: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),          // 48: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),         // 49: cerebro.v1.GetEntityNeighborhoodResponse
+	nil,                                           // 50: cerebro.v1.ReportRun.ParametersEntry
+	nil,                                           // 51: cerebro.v1.RunReportRequest.ParametersEntry
+	nil,                                           // 52: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                           // 53: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                           // 54: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                           // 55: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                           // 56: cerebro.v1.Finding.AttributesEntry
+	(*timestamppb.Timestamp)(nil),                 // 57: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                       // 58: google.protobuf.Struct
+	(*RuleSpec)(nil),                              // 59: cerebro.v1.RuleSpec
+	(*SourceSpec)(nil),                            // 60: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                          // 61: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                         // 62: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                        // 63: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                      // 64: cerebro.v1.SourceCheckpoint
+	(*Claim)(nil),                                 // 65: cerebro.v1.Claim
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	52, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	57, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
 	5,  // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
-	45, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
-	52, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
-	53, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
+	50, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
+	57, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
+	58, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
 	6,  // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
-	54, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
-	46, // 8: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
-	6,  // 9: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
-	7,  // 10: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
-	7,  // 11: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
-	55, // 12: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	47, // 13: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	55, // 14: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	48, // 15: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	55, // 16: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	49, // 17: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	56, // 18: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	57, // 19: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	58, // 20: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	55, // 21: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	57, // 22: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	59, // 23: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	56, // 24: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
-	23, // 25: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	50, // 26: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	59, // 27: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	56, // 28: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	52, // 29: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
-	25, // 30: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
-	25, // 31: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	25, // 32: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	25, // 33: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	55, // 34: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	60, // 35: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	60, // 36: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
-	51, // 37: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	52, // 38: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	52, // 39: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	37, // 40: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	25, // 41: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	54, // 42: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	37, // 43: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	41, // 44: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	41, // 45: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	42, // 46: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	0,  // 47: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2,  // 48: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	8,  // 49: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	10, // 50: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
-	12, // 51: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	14, // 52: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	16, // 53: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	18, // 54: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	20, // 55: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	22, // 56: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	26, // 57: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	28, // 58: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	30, // 59: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	32, // 60: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	34, // 61: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
-	36, // 62: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
-	39, // 63: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	43, // 64: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	1,  // 65: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4,  // 66: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	9,  // 67: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	11, // 68: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
-	13, // 69: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	15, // 70: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	17, // 71: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	19, // 72: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	21, // 73: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	24, // 74: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	27, // 75: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	29, // 76: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	31, // 77: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	33, // 78: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	35, // 79: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
-	38, // 80: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
-	40, // 81: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	44, // 82: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	65, // [65:83] is the sub-list for method output_type
-	47, // [47:65] is the sub-list for method input_type
-	47, // [47:47] is the sub-list for extension type_name
-	47, // [47:47] is the sub-list for extension extendee
-	0,  // [0:47] is the sub-list for field type_name
+	59, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
+	57, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
+	57, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
+	12, // 10: cerebro.v1.ListFindingEvaluationRunsResponse.runs:type_name -> cerebro.v1.FindingEvaluationRun
+	12, // 11: cerebro.v1.GetFindingEvaluationRunResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
+	51, // 12: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
+	6,  // 13: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
+	7,  // 14: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
+	7,  // 15: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
+	60, // 16: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	52, // 17: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	60, // 18: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	53, // 19: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	60, // 20: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	54, // 21: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	61, // 22: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	62, // 23: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	63, // 24: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	60, // 25: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	62, // 26: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	64, // 27: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	61, // 28: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	28, // 29: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
+	55, // 30: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	64, // 31: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	61, // 32: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	57, // 33: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	30, // 34: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
+	30, // 35: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	30, // 36: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	30, // 37: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	60, // 38: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	65, // 39: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	65, // 40: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	56, // 41: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	57, // 42: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	57, // 43: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	42, // 44: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	30, // 45: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	59, // 46: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	42, // 47: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	12, // 48: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
+	46, // 49: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	46, // 50: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	47, // 51: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	0,  // 52: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 53: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	8,  // 54: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	10, // 55: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
+	17, // 56: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	19, // 57: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	21, // 58: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	23, // 59: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	25, // 60: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	27, // 61: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	31, // 62: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	33, // 63: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	35, // 64: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	37, // 65: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	39, // 66: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	41, // 67: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
+	13, // 68: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
+	15, // 69: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
+	44, // 70: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	48, // 71: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	1,  // 72: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 73: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	9,  // 74: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	11, // 75: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
+	18, // 76: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	20, // 77: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	22, // 78: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	24, // 79: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	26, // 80: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	29, // 81: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	32, // 82: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	34, // 83: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	36, // 84: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	38, // 85: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	40, // 86: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	43, // 87: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
+	14, // 88: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
+	16, // 89: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
+	45, // 90: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	49, // 91: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	72, // [72:92] is the sub-list for method output_type
+	52, // [52:72] is the sub-list for method input_type
+	52, // [52:52] is the sub-list for extension type_name
+	52, // [52:52] is the sub-list for extension extendee
+	0,  // [0:52] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -3175,7 +3559,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   52,
+			NumMessages:   57,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -81,6 +81,12 @@ const (
 	// BootstrapServiceListFindingsProcedure is the fully-qualified name of the BootstrapService's
 	// ListFindings RPC.
 	BootstrapServiceListFindingsProcedure = "/cerebro.v1.BootstrapService/ListFindings"
+	// BootstrapServiceListFindingEvaluationRunsProcedure is the fully-qualified name of the
+	// BootstrapService's ListFindingEvaluationRuns RPC.
+	BootstrapServiceListFindingEvaluationRunsProcedure = "/cerebro.v1.BootstrapService/ListFindingEvaluationRuns"
+	// BootstrapServiceGetFindingEvaluationRunProcedure is the fully-qualified name of the
+	// BootstrapService's GetFindingEvaluationRun RPC.
+	BootstrapServiceGetFindingEvaluationRunProcedure = "/cerebro.v1.BootstrapService/GetFindingEvaluationRun"
 	// BootstrapServiceEvaluateSourceRuntimeFindingsProcedure is the fully-qualified name of the
 	// BootstrapService's EvaluateSourceRuntimeFindings RPC.
 	BootstrapServiceEvaluateSourceRuntimeFindingsProcedure = "/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindings"
@@ -107,6 +113,8 @@ type BootstrapServiceClient interface {
 	WriteClaims(context.Context, *connect.Request[v1.WriteClaimsRequest]) (*connect.Response[v1.WriteClaimsResponse], error)
 	ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error)
 	ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error)
+	ListFindingEvaluationRuns(context.Context, *connect.Request[v1.ListFindingEvaluationRunsRequest]) (*connect.Response[v1.ListFindingEvaluationRunsResponse], error)
+	GetFindingEvaluationRun(context.Context, *connect.Request[v1.GetFindingEvaluationRunRequest]) (*connect.Response[v1.GetFindingEvaluationRunResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
@@ -218,6 +226,18 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("ListFindings")),
 			connect.WithClientOptions(opts...),
 		),
+		listFindingEvaluationRuns: connect.NewClient[v1.ListFindingEvaluationRunsRequest, v1.ListFindingEvaluationRunsResponse](
+			httpClient,
+			baseURL+BootstrapServiceListFindingEvaluationRunsProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("ListFindingEvaluationRuns")),
+			connect.WithClientOptions(opts...),
+		),
+		getFindingEvaluationRun: connect.NewClient[v1.GetFindingEvaluationRunRequest, v1.GetFindingEvaluationRunResponse](
+			httpClient,
+			baseURL+BootstrapServiceGetFindingEvaluationRunProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("GetFindingEvaluationRun")),
+			connect.WithClientOptions(opts...),
+		),
 		evaluateSourceRuntimeFindings: connect.NewClient[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse](
 			httpClient,
 			baseURL+BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
@@ -251,6 +271,8 @@ type bootstrapServiceClient struct {
 	writeClaims                   *connect.Client[v1.WriteClaimsRequest, v1.WriteClaimsResponse]
 	listClaims                    *connect.Client[v1.ListClaimsRequest, v1.ListClaimsResponse]
 	listFindings                  *connect.Client[v1.ListFindingsRequest, v1.ListFindingsResponse]
+	listFindingEvaluationRuns     *connect.Client[v1.ListFindingEvaluationRunsRequest, v1.ListFindingEvaluationRunsResponse]
+	getFindingEvaluationRun       *connect.Client[v1.GetFindingEvaluationRunRequest, v1.GetFindingEvaluationRunResponse]
 	evaluateSourceRuntimeFindings *connect.Client[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse]
 	getEntityNeighborhood         *connect.Client[v1.GetEntityNeighborhoodRequest, v1.GetEntityNeighborhoodResponse]
 }
@@ -335,6 +357,16 @@ func (c *bootstrapServiceClient) ListFindings(ctx context.Context, req *connect.
 	return c.listFindings.CallUnary(ctx, req)
 }
 
+// ListFindingEvaluationRuns calls cerebro.v1.BootstrapService.ListFindingEvaluationRuns.
+func (c *bootstrapServiceClient) ListFindingEvaluationRuns(ctx context.Context, req *connect.Request[v1.ListFindingEvaluationRunsRequest]) (*connect.Response[v1.ListFindingEvaluationRunsResponse], error) {
+	return c.listFindingEvaluationRuns.CallUnary(ctx, req)
+}
+
+// GetFindingEvaluationRun calls cerebro.v1.BootstrapService.GetFindingEvaluationRun.
+func (c *bootstrapServiceClient) GetFindingEvaluationRun(ctx context.Context, req *connect.Request[v1.GetFindingEvaluationRunRequest]) (*connect.Response[v1.GetFindingEvaluationRunResponse], error) {
+	return c.getFindingEvaluationRun.CallUnary(ctx, req)
+}
+
 // EvaluateSourceRuntimeFindings calls cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings.
 func (c *bootstrapServiceClient) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {
 	return c.evaluateSourceRuntimeFindings.CallUnary(ctx, req)
@@ -363,6 +395,8 @@ type BootstrapServiceHandler interface {
 	WriteClaims(context.Context, *connect.Request[v1.WriteClaimsRequest]) (*connect.Response[v1.WriteClaimsResponse], error)
 	ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error)
 	ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error)
+	ListFindingEvaluationRuns(context.Context, *connect.Request[v1.ListFindingEvaluationRunsRequest]) (*connect.Response[v1.ListFindingEvaluationRunsResponse], error)
+	GetFindingEvaluationRun(context.Context, *connect.Request[v1.GetFindingEvaluationRunRequest]) (*connect.Response[v1.GetFindingEvaluationRunResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
@@ -470,6 +504,18 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		connect.WithSchema(bootstrapServiceMethods.ByName("ListFindings")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bootstrapServiceListFindingEvaluationRunsHandler := connect.NewUnaryHandler(
+		BootstrapServiceListFindingEvaluationRunsProcedure,
+		svc.ListFindingEvaluationRuns,
+		connect.WithSchema(bootstrapServiceMethods.ByName("ListFindingEvaluationRuns")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceGetFindingEvaluationRunHandler := connect.NewUnaryHandler(
+		BootstrapServiceGetFindingEvaluationRunProcedure,
+		svc.GetFindingEvaluationRun,
+		connect.WithSchema(bootstrapServiceMethods.ByName("GetFindingEvaluationRun")),
+		connect.WithHandlerOptions(opts...),
+	)
 	bootstrapServiceEvaluateSourceRuntimeFindingsHandler := connect.NewUnaryHandler(
 		BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
 		svc.EvaluateSourceRuntimeFindings,
@@ -516,6 +562,10 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceListClaimsHandler.ServeHTTP(w, r)
 		case BootstrapServiceListFindingsProcedure:
 			bootstrapServiceListFindingsHandler.ServeHTTP(w, r)
+		case BootstrapServiceListFindingEvaluationRunsProcedure:
+			bootstrapServiceListFindingEvaluationRunsHandler.ServeHTTP(w, r)
+		case BootstrapServiceGetFindingEvaluationRunProcedure:
+			bootstrapServiceGetFindingEvaluationRunHandler.ServeHTTP(w, r)
 		case BootstrapServiceEvaluateSourceRuntimeFindingsProcedure:
 			bootstrapServiceEvaluateSourceRuntimeFindingsHandler.ServeHTTP(w, r)
 		case BootstrapServiceGetEntityNeighborhoodProcedure:
@@ -591,6 +641,14 @@ func (UnimplementedBootstrapServiceHandler) ListClaims(context.Context, *connect
 
 func (UnimplementedBootstrapServiceHandler) ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListFindings is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) ListFindingEvaluationRuns(context.Context, *connect.Request[v1.ListFindingEvaluationRunsRequest]) (*connect.Response[v1.ListFindingEvaluationRunsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListFindingEvaluationRuns is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) GetFindingEvaluationRun(context.Context, *connect.Request[v1.GetFindingEvaluationRunRequest]) (*connect.Response[v1.GetFindingEvaluationRunResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.GetFindingEvaluationRun is not implemented"))
 }
 
 func (UnimplementedBootstrapServiceHandler) EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -63,6 +63,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("GET /finding-rules", app.handleListFindingRules)
 	mux.HandleFunc("POST /reports/{reportID}/runs", app.handleRunReport)
 	mux.HandleFunc("GET /report-runs/{runID}", app.handleGetReportRun)
+	mux.HandleFunc("GET /finding-evaluation-runs/{runID}", app.handleGetFindingEvaluationRun)
 	mux.HandleFunc("/sources", app.handleSources)
 	mux.HandleFunc("GET /sources/{sourceID}/check", app.handleCheckSource)
 	mux.HandleFunc("GET /sources/{sourceID}/discover", app.handleDiscoverSource)
@@ -74,6 +75,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/claims", app.handleListClaims)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/claims", app.handleWriteClaims)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/findings", app.handleListFindings)
+	mux.HandleFunc("GET /source-runtimes/{runtimeID}/finding-evaluation-runs", app.handleListFindingEvaluationRuns)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/findings/evaluate", app.handleEvaluateSourceRuntimeFindings)
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
@@ -116,6 +118,17 @@ func (a *App) handleListReportDefinitions(w http.ResponseWriter, r *http.Request
 
 func (a *App) handleListFindingRules(w http.ResponseWriter, r *http.Request) {
 	writeProtoJSON(w, http.StatusOK, a.findingService().ListRules())
+}
+
+func (a *App) handleGetFindingEvaluationRun(w http.ResponseWriter, r *http.Request) {
+	response, err := a.findingService().GetEvaluationRun(r.Context(), r.PathValue("runID"))
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, &cerebrov1.GetFindingEvaluationRunResponse{
+		Run: response,
+	})
 }
 
 func (a *App) handleRunReport(w http.ResponseWriter, r *http.Request) {
@@ -396,6 +409,37 @@ func (a *App) handleListFindings(w http.ResponseWriter, r *http.Request) {
 	writeProtoJSON(w, http.StatusOK, listFindingsResponse(response))
 }
 
+func (a *App) handleListFindingEvaluationRuns(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.ListFindingEvaluationRunsRequest{
+		RuntimeId: r.PathValue("runtimeID"),
+		RuleId:    r.URL.Query().Get("rule_id"),
+		Status:    r.URL.Query().Get("status"),
+	}
+	if limit := r.URL.Query().Get("limit"); limit != "" {
+		body := []byte(`{"limit":` + limit + `}`)
+		if err := protojson.Unmarshal(body, request); err != nil {
+			writeFindingError(w, err)
+			return
+		}
+		request.RuntimeId = r.PathValue("runtimeID")
+		request.RuleId = r.URL.Query().Get("rule_id")
+		request.Status = r.URL.Query().Get("status")
+	}
+	response, err := a.findingService().ListEvaluationRuns(r.Context(), findings.ListEvaluationRunsRequest{
+		RuntimeID: request.GetRuntimeId(),
+		RuleID:    request.GetRuleId(),
+		Status:    request.GetStatus(),
+		Limit:     request.GetLimit(),
+	})
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, &cerebrov1.ListFindingEvaluationRunsResponse{
+		Runs: response.Runs,
+	})
+}
+
 func (s *bootstrapService) GetVersion(_ context.Context, _ *connect.Request[cerebrov1.GetVersionRequest]) (*connect.Response[cerebrov1.GetVersionResponse], error) {
 	return connect.NewResponse(&cerebrov1.GetVersionResponse{
 		ServiceName: buildinfo.ServiceName,
@@ -423,6 +467,7 @@ func (s *bootstrapService) ListFindingRules(_ context.Context, _ *connect.Reques
 		sourceRuntimeStore(s.deps.StateStore),
 		eventReplayer(s.deps.AppendLog),
 		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
 	).ListRules()), nil
 }
 
@@ -570,6 +615,7 @@ func (s *bootstrapService) ListFindings(ctx context.Context, req *connect.Reques
 		sourceRuntimeStore(s.deps.StateStore),
 		eventReplayer(s.deps.AppendLog),
 		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
 	).ListFindings(ctx, findings.ListRequest{
 		RuntimeID:   req.Msg.GetRuntimeId(),
 		FindingID:   req.Msg.GetFindingId(),
@@ -586,11 +632,45 @@ func (s *bootstrapService) ListFindings(ctx context.Context, req *connect.Reques
 	return connect.NewResponse(listFindingsResponse(response)), nil
 }
 
+func (s *bootstrapService) ListFindingEvaluationRuns(ctx context.Context, req *connect.Request[cerebrov1.ListFindingEvaluationRunsRequest]) (*connect.Response[cerebrov1.ListFindingEvaluationRunsResponse], error) {
+	response, err := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
+	).ListEvaluationRuns(ctx, findings.ListEvaluationRunsRequest{
+		RuntimeID: req.Msg.GetRuntimeId(),
+		RuleID:    req.Msg.GetRuleId(),
+		Status:    req.Msg.GetStatus(),
+		Limit:     req.Msg.GetLimit(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&cerebrov1.ListFindingEvaluationRunsResponse{
+		Runs: response.Runs,
+	}), nil
+}
+
+func (s *bootstrapService) GetFindingEvaluationRun(ctx context.Context, req *connect.Request[cerebrov1.GetFindingEvaluationRunRequest]) (*connect.Response[cerebrov1.GetFindingEvaluationRunResponse], error) {
+	run, err := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
+	).GetEvaluationRun(ctx, req.Msg.GetId())
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&cerebrov1.GetFindingEvaluationRunResponse{Run: run}), nil
+}
+
 func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingsResponse], error) {
 	response, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
 		eventReplayer(s.deps.AppendLog),
 		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
 	).EvaluateSourceRuntime(ctx, findings.EvaluateRequest{
 		RuntimeID:  req.Msg.GetId(),
 		RuleID:     req.Msg.GetRuleId(),
@@ -681,6 +761,7 @@ func (a *App) findingService() *findings.Service {
 		sourceRuntimeStore(a.deps.StateStore),
 		eventReplayer(a.deps.AppendLog),
 		findingStore(a.deps.StateStore),
+		findingEvaluationRunStore(a.deps.StateStore),
 	)
 }
 
@@ -746,6 +827,8 @@ func writeFindingError(w http.ResponseWriter, err error) {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
 		statusCode = http.StatusNotFound
 	case errors.Is(err, findings.ErrRuleNotFound):
+		statusCode = http.StatusNotFound
+	case errors.Is(err, ports.ErrFindingEvaluationRunNotFound):
 		statusCode = http.StatusNotFound
 	case errors.Is(err, findings.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable
@@ -824,6 +907,14 @@ func findingStore(store ports.StateStore) ports.FindingStore {
 	return findingStore
 }
 
+func findingEvaluationRunStore(store ports.StateStore) ports.FindingEvaluationRunStore {
+	runStore, ok := store.(ports.FindingEvaluationRunStore)
+	if !ok {
+		return nil
+	}
+	return runStore
+}
+
 func claimStore(store ports.StateStore) ports.ClaimStore {
 	claimStore, ok := store.(ports.ClaimStore)
 	if !ok {
@@ -858,6 +949,7 @@ func findingResponse(result *findings.EvaluateResult) *cerebrov1.EvaluateSourceR
 		EventsEvaluated:  result.EventsEvaluated,
 		FindingsUpserted: uint32(len(result.Findings)),
 		Findings:         findingMessages(result.Findings),
+		Run:              result.Run,
 	}
 	return response
 }

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -82,15 +82,17 @@ func (s *recordingAppendLog) Replay(_ context.Context, request ports.ReplayReque
 }
 
 type stubRuntimeStore struct {
-	err                error
-	runtimes           map[string]*cerebrov1.SourceRuntime
-	entities           map[string]*ports.ProjectedEntity
-	links              map[string]*ports.ProjectedLink
-	claims             map[string]*ports.ClaimRecord
-	claimListRequest   ports.ListClaimsRequest
-	findings           map[string]*ports.FindingRecord
-	findingListRequest ports.ListFindingsRequest
-	reportRuns         map[string]*cerebrov1.ReportRun
+	err                             error
+	runtimes                        map[string]*cerebrov1.SourceRuntime
+	entities                        map[string]*ports.ProjectedEntity
+	links                           map[string]*ports.ProjectedLink
+	claims                          map[string]*ports.ClaimRecord
+	claimListRequest                ports.ListClaimsRequest
+	findings                        map[string]*ports.FindingRecord
+	findingListRequest              ports.ListFindingsRequest
+	findingEvaluationRuns           map[string]*cerebrov1.FindingEvaluationRun
+	findingEvaluationRunListRequest ports.ListFindingEvaluationRunsRequest
+	reportRuns                      map[string]*cerebrov1.ReportRun
 }
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
@@ -235,6 +237,59 @@ func (s *stubRuntimeStore) ListFindings(_ context.Context, request ports.ListFin
 		findings = findings[:int(request.Limit)]
 	}
 	return findings, nil
+}
+
+func (s *stubRuntimeStore) PutFindingEvaluationRun(_ context.Context, run *cerebrov1.FindingEvaluationRun) error {
+	if s.err != nil {
+		return s.err
+	}
+	if run == nil {
+		return nil
+	}
+	if s.findingEvaluationRuns == nil {
+		s.findingEvaluationRuns = make(map[string]*cerebrov1.FindingEvaluationRun)
+	}
+	s.findingEvaluationRuns[run.GetId()] = cloneFindingEvaluationRun(run)
+	return nil
+}
+
+func (s *stubRuntimeStore) GetFindingEvaluationRun(_ context.Context, id string) (*cerebrov1.FindingEvaluationRun, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	run, ok := s.findingEvaluationRuns[id]
+	if !ok {
+		return nil, ports.ErrFindingEvaluationRunNotFound
+	}
+	return cloneFindingEvaluationRun(run), nil
+}
+
+func (s *stubRuntimeStore) ListFindingEvaluationRuns(_ context.Context, request ports.ListFindingEvaluationRunsRequest) ([]*cerebrov1.FindingEvaluationRun, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	s.findingEvaluationRunListRequest = request
+	runs := []*cerebrov1.FindingEvaluationRun{}
+	for _, run := range s.findingEvaluationRuns {
+		if !findingEvaluationRunMatches(request, run) {
+			continue
+		}
+		runs = append(runs, cloneFindingEvaluationRun(run))
+	}
+	sort.Slice(runs, func(i, j int) bool {
+		left := runs[i]
+		right := runs[j]
+		switch {
+		case left.GetStartedAt().AsTime().Equal(right.GetStartedAt().AsTime()):
+			return left.GetId() < right.GetId()
+		default:
+			return left.GetStartedAt().AsTime().After(right.GetStartedAt().AsTime())
+		}
+	})
+	if request.Limit != 0 && len(runs) > int(request.Limit) {
+		runs = runs[:int(request.Limit)]
+	}
+	return runs, nil
 }
 
 func (s *stubRuntimeStore) PutReportRun(_ context.Context, run *cerebrov1.ReportRun) error {
@@ -878,6 +933,20 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := findingPayload["summary"]; got != "admin@writer.com performed policy.rule.update on pol-1" {
 		t.Fatalf("evaluate finding summary = %#v, want admin summary", got)
 	}
+	runPayload, ok := evaluatePayload["run"].(map[string]any)
+	if !ok {
+		t.Fatalf("evaluate run payload = %#v, want object", evaluatePayload["run"])
+	}
+	runID, ok := runPayload["id"].(string)
+	if !ok || runID == "" {
+		t.Fatalf("evaluate run id = %#v, want non-empty string", runPayload["id"])
+	}
+	if got := runPayload["status"]; got != "completed" {
+		t.Fatalf("evaluate run status = %#v, want completed", got)
+	}
+	if got := runPayload["rule_id"]; got != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("evaluate run rule_id = %#v, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
 	listResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-okta-audit/findings?rule_id=identity-okta-policy-rule-lifecycle-tampering&status=open&event_id=okta-audit-2&limit=1")
 	if err != nil {
 		t.Fatalf("GET /source-runtimes/{id}/findings error = %v", err)
@@ -901,6 +970,50 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := listedFinding["rule_id"]; got != "identity-okta-policy-rule-lifecycle-tampering" {
 		t.Fatalf("list finding rule_id = %#v, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	runListResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-okta-audit/finding-evaluation-runs?rule_id=identity-okta-policy-rule-lifecycle-tampering&status=completed&limit=1")
+	if err != nil {
+		t.Fatalf("GET /source-runtimes/{id}/finding-evaluation-runs error = %v", err)
+	}
+	defer func() {
+		if closeErr := runListResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close list evaluation runs response body: %v", closeErr)
+		}
+	}()
+	var runListPayload map[string]any
+	if err := json.NewDecoder(runListResp.Body).Decode(&runListPayload); err != nil {
+		t.Fatalf("decode list evaluation runs response: %v", err)
+	}
+	runEntries, ok := runListPayload["runs"].([]any)
+	if !ok || len(runEntries) != 1 {
+		t.Fatalf("list evaluation runs payload = %#v, want 1 entry", runListPayload["runs"])
+	}
+	runEntry, ok := runEntries[0].(map[string]any)
+	if !ok {
+		t.Fatalf("list evaluation run entry = %#v, want object", runEntries[0])
+	}
+	if got := runEntry["id"]; got != runID {
+		t.Fatalf("list evaluation run id = %#v, want %q", got, runID)
+	}
+	getRunResp, err := server.Client().Get(server.URL + "/finding-evaluation-runs/" + runID)
+	if err != nil {
+		t.Fatalf("GET /finding-evaluation-runs/{id} error = %v", err)
+	}
+	defer func() {
+		if closeErr := getRunResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close get evaluation run response body: %v", closeErr)
+		}
+	}()
+	var getRunPayload map[string]any
+	if err := json.NewDecoder(getRunResp.Body).Decode(&getRunPayload); err != nil {
+		t.Fatalf("decode get evaluation run response: %v", err)
+	}
+	getRunBody, ok := getRunPayload["run"].(map[string]any)
+	if !ok {
+		t.Fatalf("get evaluation run payload = %#v, want object", getRunPayload["run"])
+	}
+	if got := getRunBody["id"]; got != runID {
+		t.Fatalf("get evaluation run id = %#v, want %q", got, runID)
 	}
 	missingRuleResp, err := server.Client().Post(server.URL+"/source-runtimes/writer-okta-audit/findings/evaluate?rule_id=does-not-exist", "application/json", nil)
 	if err != nil {
@@ -936,6 +1049,9 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := evaluateFindingsResp.Msg.GetRule().GetId(); got != "identity-okta-policy-rule-lifecycle-tampering" {
 		t.Fatalf("EvaluateSourceRuntimeFindings rule id = %q, want identity-okta-policy-rule-lifecycle-tampering", got)
 	}
+	if got := evaluateFindingsResp.Msg.GetRun().GetId(); got == "" {
+		t.Fatal("EvaluateSourceRuntimeFindings run id = empty, want non-empty")
+	}
 	listFindingsResp, err := client.ListFindings(context.Background(), connect.NewRequest(&cerebrov1.ListFindingsRequest{
 		RuntimeId:   "writer-okta-audit",
 		RuleId:      "identity-okta-policy-rule-lifecycle-tampering",
@@ -962,6 +1078,36 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := runtimeStore.findingListRequest.EventID; got != "okta-audit-2" {
 		t.Fatalf("runtimeStore.findingListRequest.EventID = %q, want okta-audit-2", got)
+	}
+	listRunsResp, err := client.ListFindingEvaluationRuns(context.Background(), connect.NewRequest(&cerebrov1.ListFindingEvaluationRunsRequest{
+		RuntimeId: "writer-okta-audit",
+		RuleId:    "identity-okta-policy-rule-lifecycle-tampering",
+		Status:    "completed",
+		Limit:     1,
+	}))
+	if err != nil {
+		t.Fatalf("ListFindingEvaluationRuns() error = %v", err)
+	}
+	if got := len(listRunsResp.Msg.GetRuns()); got != 1 {
+		t.Fatalf("len(ListFindingEvaluationRuns().Runs) = %d, want 1", got)
+	}
+	getEvaluationRunResp, err := client.GetFindingEvaluationRun(context.Background(), connect.NewRequest(&cerebrov1.GetFindingEvaluationRunRequest{
+		Id: evaluateFindingsResp.Msg.GetRun().GetId(),
+	}))
+	if err != nil {
+		t.Fatalf("GetFindingEvaluationRun() error = %v", err)
+	}
+	if got := getEvaluationRunResp.Msg.GetRun().GetId(); got != evaluateFindingsResp.Msg.GetRun().GetId() {
+		t.Fatalf("GetFindingEvaluationRun().Run.Id = %q, want %q", got, evaluateFindingsResp.Msg.GetRun().GetId())
+	}
+	if got := runtimeStore.findingEvaluationRunListRequest.RuleID; got != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("runtimeStore.findingEvaluationRunListRequest.RuleID = %q, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	if got := runtimeStore.findingEvaluationRunListRequest.Status; got != "completed" {
+		t.Fatalf("runtimeStore.findingEvaluationRunListRequest.Status = %q, want completed", got)
+	}
+	if len(runtimeStore.findingEvaluationRuns) != 2 {
+		t.Fatalf("len(runtimeStore.findingEvaluationRuns) = %d, want 2", len(runtimeStore.findingEvaluationRuns))
 	}
 	if len(runtimeStore.findings) != 1 {
 		t.Fatalf("len(runtimeStore.findings) = %d, want 1", len(runtimeStore.findings))
@@ -1677,11 +1823,34 @@ func containsTrimmed(values []string, expected string) bool {
 	return false
 }
 
+func findingEvaluationRunMatches(request ports.ListFindingEvaluationRunsRequest, run *cerebrov1.FindingEvaluationRun) bool {
+	if run == nil {
+		return false
+	}
+	if strings.TrimSpace(run.GetRuntimeId()) != strings.TrimSpace(request.RuntimeID) {
+		return false
+	}
+	if request.RuleID != "" && strings.TrimSpace(run.GetRuleId()) != strings.TrimSpace(request.RuleID) {
+		return false
+	}
+	if request.Status != "" && strings.TrimSpace(run.GetStatus()) != strings.TrimSpace(request.Status) {
+		return false
+	}
+	return true
+}
+
 func cloneReportRun(run *cerebrov1.ReportRun) *cerebrov1.ReportRun {
 	if run == nil {
 		return nil
 	}
 	return proto.Clone(run).(*cerebrov1.ReportRun)
+}
+
+func cloneFindingEvaluationRun(run *cerebrov1.FindingEvaluationRun) *cerebrov1.FindingEvaluationRun {
+	if run == nil {
+		return nil
+	}
+	return proto.Clone(run).(*cerebrov1.FindingEvaluationRun)
 }
 
 func cloneNeighborhood(neighborhood *ports.EntityNeighborhood) *ports.EntityNeighborhood {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -151,16 +151,16 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 		return nil, s.finishFailedRun(ctx, run, 0, nil, evaluationErr)
 	}
 	result := &EvaluateResult{
-		Runtime:         runtime,
-		Rule:            rule.Spec(),
-		EventsEvaluated: uint32(len(events)),
-		Run:             run,
+		Runtime: runtime,
+		Rule:    rule.Spec(),
+		Run:     run,
 	}
+	var eventsEvaluated uint32
 	for _, event := range events {
 		emitted, err := rule.Evaluate(ctx, runtime, event)
 		if err != nil {
 			evaluationErr := fmt.Errorf("evaluate finding rule %q for event %q: %w", result.Rule.GetId(), event.GetId(), err)
-			return nil, s.finishFailedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings), evaluationErr)
+			return nil, s.finishFailedRun(ctx, run, eventsEvaluated, findingIDs(result.Findings), evaluationErr)
 		}
 		for _, record := range emitted {
 			if record == nil {
@@ -169,12 +169,14 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 			stored, err := s.store.UpsertFinding(ctx, record)
 			if err != nil {
 				evaluationErr := fmt.Errorf("persist finding for rule %q event %q: %w", result.Rule.GetId(), event.GetId(), err)
-				return nil, s.finishFailedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings), evaluationErr)
+				return nil, s.finishFailedRun(ctx, run, eventsEvaluated, findingIDs(result.Findings), evaluationErr)
 			}
 			result.Findings = append(result.Findings, stored)
 		}
+		eventsEvaluated++
+		result.EventsEvaluated = eventsEvaluated
 	}
-	if err := s.finishCompletedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings)); err != nil {
+	if err := s.finishCompletedRun(ctx, run, eventsEvaluated, findingIDs(result.Findings)); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -41,6 +43,7 @@ type Service struct {
 	runtimeStore ports.SourceRuntimeStore
 	replayer     ports.EventReplayer
 	store        ports.FindingStore
+	runStore     ports.FindingEvaluationRunStore
 	rules        *Registry
 }
 
@@ -69,6 +72,7 @@ type EvaluateResult struct {
 	Rule            *cerebrov1.RuleSpec
 	EventsEvaluated uint32
 	Findings        []*ports.FindingRecord
+	Run             *cerebrov1.FindingEvaluationRun
 }
 
 // ListResult reports one persisted finding query.
@@ -76,17 +80,31 @@ type ListResult struct {
 	Findings []*ports.FindingRecord
 }
 
+// ListEvaluationRunsRequest scopes one persisted finding evaluation run query.
+type ListEvaluationRunsRequest struct {
+	RuntimeID string
+	RuleID    string
+	Status    string
+	Limit     uint32
+}
+
+// ListEvaluationRunsResult reports one persisted finding evaluation run query.
+type ListEvaluationRunsResult struct {
+	Runs []*cerebrov1.FindingEvaluationRun
+}
+
 // New constructs a replay-backed finding service with the built-in rule registry.
-func New(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore) *Service {
-	return NewWithRegistry(runtimeStore, replayer, store, Builtin())
+func New(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore, runStore ports.FindingEvaluationRunStore) *Service {
+	return NewWithRegistry(runtimeStore, replayer, store, runStore, Builtin())
 }
 
 // NewWithRegistry constructs a replay-backed finding service with one explicit rule registry.
-func NewWithRegistry(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore, rules *Registry) *Service {
+func NewWithRegistry(runtimeStore ports.SourceRuntimeStore, replayer ports.EventReplayer, store ports.FindingStore, runStore ports.FindingEvaluationRunStore, rules *Registry) *Service {
 	return &Service{
 		runtimeStore: runtimeStore,
 		replayer:     replayer,
 		store:        store,
+		runStore:     runStore,
 		rules:        rules,
 	}
 }
@@ -103,7 +121,7 @@ func (s *Service) ListRules() *cerebrov1.ListFindingRulesResponse {
 
 // EvaluateSourceRuntime replays one runtime and persists findings for one selected registered rule.
 func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateRequest) (*EvaluateResult, error) {
-	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.store == nil || s.rules == nil {
+	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.store == nil || s.runStore == nil || s.rules == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
@@ -118,22 +136,30 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	if err != nil {
 		return nil, err
 	}
+	startedAt := time.Now().UTC()
+	run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), request.EventLimit, startedAt)
+	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
+		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
+	}
 	events, err := s.replayer.Replay(ctx, ports.ReplayRequest{
 		RuntimeID: runtimeID,
 		Limit:     normalizeEventLimit(request.EventLimit),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
+		evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
+		return nil, s.finishFailedRun(ctx, run, 0, nil, evaluationErr)
 	}
 	result := &EvaluateResult{
 		Runtime:         runtime,
 		Rule:            rule.Spec(),
 		EventsEvaluated: uint32(len(events)),
+		Run:             run,
 	}
 	for _, event := range events {
 		emitted, err := rule.Evaluate(ctx, runtime, event)
 		if err != nil {
-			return nil, fmt.Errorf("evaluate finding rule %q for event %q: %w", result.Rule.GetId(), event.GetId(), err)
+			evaluationErr := fmt.Errorf("evaluate finding rule %q for event %q: %w", result.Rule.GetId(), event.GetId(), err)
+			return nil, s.finishFailedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings), evaluationErr)
 		}
 		for _, record := range emitted {
 			if record == nil {
@@ -141,10 +167,14 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 			}
 			stored, err := s.store.UpsertFinding(ctx, record)
 			if err != nil {
-				return nil, fmt.Errorf("persist finding for rule %q event %q: %w", result.Rule.GetId(), event.GetId(), err)
+				evaluationErr := fmt.Errorf("persist finding for rule %q event %q: %w", result.Rule.GetId(), event.GetId(), err)
+				return nil, s.finishFailedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings), evaluationErr)
 			}
 			result.Findings = append(result.Findings, stored)
 		}
+	}
+	if err := s.finishCompletedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings)); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
@@ -175,6 +205,46 @@ func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListR
 		return nil, fmt.Errorf("list findings for runtime %q: %w", runtimeID, err)
 	}
 	return &ListResult{Findings: findings}, nil
+}
+
+// ListEvaluationRuns loads persisted finding evaluation runs for one runtime.
+func (s *Service) ListEvaluationRuns(ctx context.Context, request ListEvaluationRunsRequest) (*ListEvaluationRunsResult, error) {
+	if s == nil || s.runtimeStore == nil || s.runStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, errors.New("source runtime id is required")
+	}
+	if _, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID); err != nil {
+		return nil, err
+	}
+	runs, err := s.runStore.ListFindingEvaluationRuns(ctx, ports.ListFindingEvaluationRunsRequest{
+		RuntimeID: runtimeID,
+		RuleID:    strings.TrimSpace(request.RuleID),
+		Status:    strings.TrimSpace(request.Status),
+		Limit:     request.Limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list finding evaluation runs for runtime %q: %w", runtimeID, err)
+	}
+	return &ListEvaluationRunsResult{Runs: runs}, nil
+}
+
+// GetEvaluationRun loads one persisted finding evaluation run.
+func (s *Service) GetEvaluationRun(ctx context.Context, id string) (*cerebrov1.FindingEvaluationRun, error) {
+	if s == nil || s.runStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	trimmedID := strings.TrimSpace(id)
+	if trimmedID == "" {
+		return nil, errors.New("finding evaluation run id is required")
+	}
+	run, err := s.runStore.GetFindingEvaluationRun(ctx, trimmedID)
+	if err != nil {
+		return nil, err
+	}
+	return run, nil
 }
 
 func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (Rule, error) {
@@ -209,4 +279,70 @@ func normalizeEventLimit(limit uint32) uint32 {
 	default:
 		return limit
 	}
+}
+
+func newFindingEvaluationRun(runtimeID string, ruleID string, eventLimit uint32, startedAt time.Time) *cerebrov1.FindingEvaluationRun {
+	normalizedStartedAt := startedAt.UTC()
+	return &cerebrov1.FindingEvaluationRun{
+		Id:         findingEvaluationRunID(runtimeID, ruleID, normalizedStartedAt),
+		RuntimeId:  strings.TrimSpace(runtimeID),
+		RuleId:     strings.TrimSpace(ruleID),
+		Status:     "running",
+		EventLimit: eventLimit,
+		StartedAt:  timestamppb.New(normalizedStartedAt),
+	}
+}
+
+func findingEvaluationRunID(runtimeID string, ruleID string, startedAt time.Time) string {
+	replacer := strings.NewReplacer(" ", "-", "_", "-", "/", "-", ":", "-", ".", "-")
+	prefix := replacer.Replace(strings.TrimSpace(runtimeID) + "-" + strings.TrimSpace(ruleID))
+	return "finding-evaluation-run-" + prefix + "-" + fmt.Sprintf("%d", startedAt.UnixNano())
+}
+
+func (s *Service) finishCompletedRun(ctx context.Context, run *cerebrov1.FindingEvaluationRun, eventsEvaluated uint32, findingIDs []string) error {
+	if run == nil {
+		return nil
+	}
+	run.Status = "completed"
+	run.EventsEvaluated = eventsEvaluated
+	run.FindingsUpserted = uint32(len(findingIDs))
+	run.FindingIds = append([]string(nil), findingIDs...)
+	run.Error = ""
+	run.FinishedAt = timestamppb.New(time.Now().UTC())
+	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
+		return fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
+	}
+	return nil
+}
+
+func (s *Service) finishFailedRun(ctx context.Context, run *cerebrov1.FindingEvaluationRun, eventsEvaluated uint32, findingIDs []string, evaluationErr error) error {
+	if run == nil {
+		return evaluationErr
+	}
+	run.Status = "failed"
+	run.EventsEvaluated = eventsEvaluated
+	run.FindingsUpserted = uint32(len(findingIDs))
+	run.FindingIds = append([]string(nil), findingIDs...)
+	run.Error = strings.TrimSpace(evaluationErr.Error())
+	run.FinishedAt = timestamppb.New(time.Now().UTC())
+	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
+		return errors.Join(
+			evaluationErr,
+			fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err),
+		)
+	}
+	return evaluationErr
+}
+
+func findingIDs(findings []*ports.FindingRecord) []string {
+	ids := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		if id := strings.TrimSpace(finding.ID); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -136,14 +136,15 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	if err != nil {
 		return nil, err
 	}
+	normalizedLimit := normalizeEventLimit(request.EventLimit)
 	startedAt := time.Now().UTC()
-	run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), request.EventLimit, startedAt)
+	run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), normalizedLimit, startedAt)
 	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
 		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
 	}
 	events, err := s.replayer.Replay(ctx, ports.ReplayRequest{
 		RuntimeID: runtimeID,
-		Limit:     normalizeEventLimit(request.EventLimit),
+		Limit:     normalizedLimit,
 	})
 	if err != nil {
 		evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -50,6 +50,8 @@ func (s *stubReplayer) Replay(_ context.Context, request ports.ReplayRequest) ([
 type stubFindingStore struct {
 	findings map[string]*ports.FindingRecord
 	request  ports.ListFindingsRequest
+	runs     map[string]*cerebrov1.FindingEvaluationRun
+	runList  ports.ListFindingEvaluationRunsRequest
 }
 
 func (s *stubFindingStore) Ping(context.Context) error { return nil }
@@ -95,6 +97,50 @@ func (s *stubFindingStore) ListFindings(_ context.Context, request ports.ListFin
 	return findings, nil
 }
 
+func (s *stubFindingStore) PutFindingEvaluationRun(_ context.Context, run *cerebrov1.FindingEvaluationRun) error {
+	if run == nil {
+		return errors.New("finding evaluation run is required")
+	}
+	if s.runs == nil {
+		s.runs = make(map[string]*cerebrov1.FindingEvaluationRun)
+	}
+	s.runs[run.GetId()] = cloneFindingEvaluationRun(run)
+	return nil
+}
+
+func (s *stubFindingStore) GetFindingEvaluationRun(_ context.Context, id string) (*cerebrov1.FindingEvaluationRun, error) {
+	run, ok := s.runs[id]
+	if !ok {
+		return nil, ports.ErrFindingEvaluationRunNotFound
+	}
+	return cloneFindingEvaluationRun(run), nil
+}
+
+func (s *stubFindingStore) ListFindingEvaluationRuns(_ context.Context, request ports.ListFindingEvaluationRunsRequest) ([]*cerebrov1.FindingEvaluationRun, error) {
+	s.runList = request
+	runs := make([]*cerebrov1.FindingEvaluationRun, 0, len(s.runs))
+	for _, run := range s.runs {
+		if !findingEvaluationRunMatches(request, run) {
+			continue
+		}
+		runs = append(runs, cloneFindingEvaluationRun(run))
+	}
+	sort.Slice(runs, func(i, j int) bool {
+		left := runs[i]
+		right := runs[j]
+		switch {
+		case left.GetStartedAt().AsTime().Equal(right.GetStartedAt().AsTime()):
+			return left.GetId() < right.GetId()
+		default:
+			return left.GetStartedAt().AsTime().After(right.GetStartedAt().AsTime())
+		}
+	})
+	if request.Limit != 0 && len(runs) > int(request.Limit) {
+		runs = runs[:int(request.Limit)]
+	}
+	return runs, nil
+}
+
 func TestEvaluateSourceRuntimeFindingsReplaysOktaPolicyRuleLifecycleTampering(t *testing.T) {
 	replayer := &stubReplayer{
 		events: []*cerebrov1.EventEnvelope{
@@ -111,7 +157,7 @@ func TestEvaluateSourceRuntimeFindingsReplaysOktaPolicyRuleLifecycleTampering(t 
 				TenantId: "writer",
 			},
 		},
-	}, replayer, store)
+	}, replayer, store, store)
 
 	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
 		RuntimeID:  "writer-okta-audit",
@@ -169,17 +215,26 @@ func TestEvaluateSourceRuntimeFindingsReplaysOktaPolicyRuleLifecycleTampering(t 
 	if len(store.findings) != 1 {
 		t.Fatalf("len(store.findings) = %d, want 1", len(store.findings))
 	}
+	if got := result.Run.GetStatus(); got != "completed" {
+		t.Fatalf("Run.Status = %q, want completed", got)
+	}
+	if got := result.Run.GetRuleId(); got != oktaPolicyRuleLifecycleTamperingRuleID {
+		t.Fatalf("Run.RuleId = %q, want %q", got, oktaPolicyRuleLifecycleTamperingRuleID)
+	}
+	if got := result.Run.GetFindingsUpserted(); got != 1 {
+		t.Fatalf("Run.FindingsUpserted = %d, want 1", got)
+	}
 }
 
 func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T) {
-	service := New(nil, nil, nil)
+	service := New(nil, nil, nil, nil)
 	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{RuntimeID: "writer-okta-audit"}); !errors.Is(err, ErrRuntimeUnavailable) {
 		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuntimeUnavailable)
 	}
 }
 
 func TestListRulesReturnsBuiltinCatalog(t *testing.T) {
-	service := New(nil, nil, nil)
+	service := New(nil, nil, nil, nil)
 	response := service.ListRules()
 	if got := len(response.GetRules()); got != 1 {
 		t.Fatalf("len(ListRules().Rules) = %d, want 1", got)
@@ -206,6 +261,7 @@ func TestEvaluateSourceRuntimeFindingsSelectsRequestedRule(t *testing.T) {
 			},
 		},
 		replayer,
+		&stubFindingStore{},
 		&stubFindingStore{},
 	)
 
@@ -237,6 +293,7 @@ func TestEvaluateSourceRuntimeFindingsRejectsUnknownRule(t *testing.T) {
 			},
 		},
 		&stubReplayer{},
+		&stubFindingStore{},
 		&stubFindingStore{},
 	)
 	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
@@ -273,6 +330,7 @@ func TestEvaluateSourceRuntimeFindingsRequiresRuleIDWhenMultipleRulesSupportRunt
 		},
 		&stubReplayer{},
 		&stubFindingStore{},
+		&stubFindingStore{},
 		registry,
 	)
 	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
@@ -294,6 +352,7 @@ func TestEvaluateSourceRuntimeFindingsRejectsUnsupportedRule(t *testing.T) {
 			},
 		},
 		&stubReplayer{},
+		&stubFindingStore{},
 		&stubFindingStore{},
 	)
 	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
@@ -341,6 +400,7 @@ func TestListFindingsReturnsFilteredPersistedFindings(t *testing.T) {
 		},
 		&stubReplayer{},
 		store,
+		store,
 	)
 
 	result, err := service.ListFindings(context.Background(), ListRequest{
@@ -385,9 +445,106 @@ func TestListFindingsReturnsFilteredPersistedFindings(t *testing.T) {
 }
 
 func TestListFindingsRequiresAvailableDependencies(t *testing.T) {
-	service := New(nil, nil, nil)
+	service := New(nil, nil, nil, nil)
 	if _, err := service.ListFindings(context.Background(), ListRequest{RuntimeID: "writer-okta-audit"}); !errors.Is(err, ErrRuntimeUnavailable) {
 		t.Fatalf("ListFindings() error = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}
+
+func TestListEvaluationRunsReturnsFilteredRuns(t *testing.T) {
+	store := &stubFindingStore{
+		runs: map[string]*cerebrov1.FindingEvaluationRun{
+			"run-1": {
+				Id:         "run-1",
+				RuntimeId:  "writer-okta-audit",
+				RuleId:     oktaPolicyRuleLifecycleTamperingRuleID,
+				Status:     "completed",
+				StartedAt:  timestamppb.New(time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)),
+				FinishedAt: timestamppb.New(time.Date(2026, 4, 24, 12, 1, 0, 0, time.UTC)),
+			},
+			"run-2": {
+				Id:         "run-2",
+				RuntimeId:  "writer-okta-audit",
+				RuleId:     oktaPolicyRuleLifecycleTamperingRuleID,
+				Status:     "failed",
+				StartedAt:  timestamppb.New(time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)),
+				FinishedAt: timestamppb.New(time.Date(2026, 4, 24, 11, 1, 0, 0, time.UTC)),
+			},
+		},
+	}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		store,
+		store,
+	)
+	result, err := service.ListEvaluationRuns(context.Background(), ListEvaluationRunsRequest{
+		RuntimeID: "writer-okta-audit",
+		RuleID:    oktaPolicyRuleLifecycleTamperingRuleID,
+		Status:    "completed",
+		Limit:     1,
+	})
+	if err != nil {
+		t.Fatalf("ListEvaluationRuns() error = %v", err)
+	}
+	if got := len(result.Runs); got != 1 {
+		t.Fatalf("len(ListEvaluationRuns().Runs) = %d, want 1", got)
+	}
+	if got := result.Runs[0].GetId(); got != "run-1" {
+		t.Fatalf("ListEvaluationRuns().Runs[0].Id = %q, want run-1", got)
+	}
+	if got := store.runList.RuntimeID; got != "writer-okta-audit" {
+		t.Fatalf("ListEvaluationRuns().RuntimeID = %q, want writer-okta-audit", got)
+	}
+	if got := store.runList.RuleID; got != oktaPolicyRuleLifecycleTamperingRuleID {
+		t.Fatalf("ListEvaluationRuns().RuleID = %q, want %q", got, oktaPolicyRuleLifecycleTamperingRuleID)
+	}
+	if got := store.runList.Status; got != "completed" {
+		t.Fatalf("ListEvaluationRuns().Status = %q, want completed", got)
+	}
+}
+
+func TestGetEvaluationRunReturnsPersistedRun(t *testing.T) {
+	store := &stubFindingStore{
+		runs: map[string]*cerebrov1.FindingEvaluationRun{
+			"run-1": {
+				Id:        "run-1",
+				RuntimeId: "writer-okta-audit",
+				RuleId:    oktaPolicyRuleLifecycleTamperingRuleID,
+				Status:    "completed",
+				StartedAt: timestamppb.New(time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)),
+			},
+		},
+	}
+	service := New(nil, nil, store, store)
+	run, err := service.GetEvaluationRun(context.Background(), "run-1")
+	if err != nil {
+		t.Fatalf("GetEvaluationRun() error = %v", err)
+	}
+	if got := run.GetRuleId(); got != oktaPolicyRuleLifecycleTamperingRuleID {
+		t.Fatalf("GetEvaluationRun().RuleId = %q, want %q", got, oktaPolicyRuleLifecycleTamperingRuleID)
+	}
+}
+
+func TestListEvaluationRunsRequiresAvailableDependencies(t *testing.T) {
+	service := New(nil, nil, nil, nil)
+	if _, err := service.ListEvaluationRuns(context.Background(), ListEvaluationRunsRequest{RuntimeID: "writer-okta-audit"}); !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("ListEvaluationRuns() error = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}
+
+func TestGetEvaluationRunRequiresAvailableDependencies(t *testing.T) {
+	service := New(nil, nil, nil, nil)
+	if _, err := service.GetEvaluationRun(context.Background(), "run-1"); !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("GetEvaluationRun() error = %v, want %v", err, ErrRuntimeUnavailable)
 	}
 }
 
@@ -444,6 +601,13 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 	}
 }
 
+func cloneFindingEvaluationRun(run *cerebrov1.FindingEvaluationRun) *cerebrov1.FindingEvaluationRun {
+	if run == nil {
+		return nil
+	}
+	return proto.Clone(run).(*cerebrov1.FindingEvaluationRun)
+}
+
 func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRecord) bool {
 	if finding == nil {
 		return false
@@ -480,4 +644,20 @@ func containsTrimmed(values []string, expected string) bool {
 		}
 	}
 	return false
+}
+
+func findingEvaluationRunMatches(request ports.ListFindingEvaluationRunsRequest, run *cerebrov1.FindingEvaluationRun) bool {
+	if run == nil {
+		return false
+	}
+	if strings.TrimSpace(run.GetRuntimeId()) != strings.TrimSpace(request.RuntimeID) {
+		return false
+	}
+	if request.RuleID != "" && strings.TrimSpace(run.GetRuleId()) != strings.TrimSpace(request.RuleID) {
+		return false
+	}
+	if request.Status != "" && strings.TrimSpace(run.GetStatus()) != strings.TrimSpace(request.Status) {
+		return false
+	}
+	return true
 }

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -233,6 +233,33 @@ func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T
 	}
 }
 
+func TestEvaluateSourceRuntimeFindingsStoresNormalizedEventLimit(t *testing.T) {
+	replayer := &stubReplayer{}
+	store := &stubFindingStore{}
+	service := New(&stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {
+				Id:       "writer-okta-audit",
+				SourceId: "okta",
+				TenantId: "writer",
+			},
+		},
+	}, replayer, store, store)
+
+	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-okta-audit",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntime() error = %v", err)
+	}
+	if got := replayer.request.Limit; got != defaultEventLimit {
+		t.Fatalf("Replay().Limit = %d, want %d", got, defaultEventLimit)
+	}
+	if got := result.Run.GetEventLimit(); got != defaultEventLimit {
+		t.Fatalf("Run.EventLimit = %d, want %d", got, defaultEventLimit)
+	}
+}
+
 func TestListRulesReturnsBuiltinCatalog(t *testing.T) {
 	service := New(nil, nil, nil, nil)
 	response := service.ListRules()

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -2,7 +2,10 @@ package ports
 
 import (
 	"context"
+	"errors"
 	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
 // FindingRecord is the normalized persisted finding shape.
@@ -35,9 +38,28 @@ type ListFindingsRequest struct {
 	Limit       uint32
 }
 
+// ErrFindingEvaluationRunNotFound indicates that a persisted finding evaluation run does not exist.
+var ErrFindingEvaluationRunNotFound = errors.New("finding evaluation run not found")
+
+// ListFindingEvaluationRunsRequest scopes one finding evaluation run query.
+type ListFindingEvaluationRunsRequest struct {
+	RuntimeID string
+	RuleID    string
+	Status    string
+	Limit     uint32
+}
+
 // FindingStore persists normalized findings in the state store.
 type FindingStore interface {
 	StateStore
 	UpsertFinding(context.Context, *FindingRecord) (*FindingRecord, error)
 	ListFindings(context.Context, ListFindingsRequest) ([]*FindingRecord, error)
+}
+
+// FindingEvaluationRunStore persists durable finding evaluation runs in the state store.
+type FindingEvaluationRunStore interface {
+	StateStore
+	PutFindingEvaluationRun(context.Context, *cerebrov1.FindingEvaluationRun) error
+	GetFindingEvaluationRun(context.Context, string) (*cerebrov1.FindingEvaluationRun, error)
+	ListFindingEvaluationRuns(context.Context, ListFindingEvaluationRunsRequest) ([]*cerebrov1.FindingEvaluationRun, error)
 }

--- a/internal/statestore/postgres/findingevaluationruns.go
+++ b/internal/statestore/postgres/findingevaluationruns.go
@@ -1,0 +1,210 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureFindingEvaluationRunStatements = []string{
+	`CREATE TABLE IF NOT EXISTS finding_evaluation_runs (
+  id TEXT PRIMARY KEY,
+  runtime_id TEXT NOT NULL,
+  rule_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  started_at TIMESTAMPTZ NOT NULL,
+  finished_at TIMESTAMPTZ,
+  finding_evaluation_run_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS finding_evaluation_runs_runtime_idx ON finding_evaluation_runs (runtime_id, started_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS finding_evaluation_runs_rule_idx ON finding_evaluation_runs (rule_id, started_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS finding_evaluation_runs_status_idx ON finding_evaluation_runs (status, started_at DESC)`,
+}
+
+// PutFindingEvaluationRun upserts one durable finding evaluation run.
+func (s *Store) PutFindingEvaluationRun(ctx context.Context, run *cerebrov1.FindingEvaluationRun) error {
+	if run == nil {
+		return errors.New("finding evaluation run is required")
+	}
+	id := strings.TrimSpace(run.GetId())
+	if id == "" {
+		return errors.New("finding evaluation run id is required")
+	}
+	runtimeID := strings.TrimSpace(run.GetRuntimeId())
+	if runtimeID == "" {
+		return errors.New("finding evaluation runtime id is required")
+	}
+	ruleID := strings.TrimSpace(run.GetRuleId())
+	if ruleID == "" {
+		return errors.New("finding evaluation rule id is required")
+	}
+	status := strings.TrimSpace(run.GetStatus())
+	if status == "" {
+		return errors.New("finding evaluation status is required")
+	}
+	startedAt := run.GetStartedAt()
+	if startedAt == nil || startedAt.AsTime().IsZero() {
+		return errors.New("finding evaluation started_at is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingEvaluationRunTables(ctx); err != nil {
+		return err
+	}
+	payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(run)
+	if err != nil {
+		return fmt.Errorf("marshal finding evaluation run: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO finding_evaluation_runs (
+  id, runtime_id, rule_id, status, started_at, finished_at, finding_evaluation_run_json
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+ON CONFLICT (id)
+DO UPDATE SET
+  runtime_id = EXCLUDED.runtime_id,
+  rule_id = EXCLUDED.rule_id,
+  status = EXCLUDED.status,
+  started_at = EXCLUDED.started_at,
+  finished_at = EXCLUDED.finished_at,
+  finding_evaluation_run_json = EXCLUDED.finding_evaluation_run_json,
+  updated_at = NOW()`,
+		id,
+		runtimeID,
+		ruleID,
+		status,
+		run.GetStartedAt().AsTime().UTC(),
+		nullableTime(findingEvaluationRunTime(run.GetFinishedAt())),
+		string(payload),
+	); err != nil {
+		return fmt.Errorf("upsert finding evaluation run %q: %w", id, err)
+	}
+	return nil
+}
+
+// GetFindingEvaluationRun loads one persisted finding evaluation run.
+func (s *Store) GetFindingEvaluationRun(ctx context.Context, runID string) (*cerebrov1.FindingEvaluationRun, error) {
+	id := strings.TrimSpace(runID)
+	if id == "" {
+		return nil, errors.New("finding evaluation run id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingEvaluationRunTables(ctx); err != nil {
+		return nil, err
+	}
+	var payload string
+	if err := s.db.QueryRowContext(ctx, `SELECT finding_evaluation_run_json::text FROM finding_evaluation_runs WHERE id = $1`, id).Scan(&payload); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrFindingEvaluationRunNotFound, id)
+		}
+		return nil, fmt.Errorf("query finding evaluation run %q: %w", id, err)
+	}
+	run := &cerebrov1.FindingEvaluationRun{}
+	if err := protojson.Unmarshal([]byte(payload), run); err != nil {
+		return nil, fmt.Errorf("decode finding evaluation run %q: %w", id, err)
+	}
+	return run, nil
+}
+
+// ListFindingEvaluationRuns loads persisted finding evaluation runs for one runtime.
+func (s *Store) ListFindingEvaluationRuns(ctx context.Context, request ports.ListFindingEvaluationRunsRequest) (_ []*cerebrov1.FindingEvaluationRun, err error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingEvaluationRunTables(ctx); err != nil {
+		return nil, err
+	}
+	query, args, err := findingEvaluationRunListQuery(request)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query finding evaluation runs for runtime %q: %w", strings.TrimSpace(request.RuntimeID), err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close finding evaluation run rows: %w", closeErr)
+		}
+	}()
+
+	runs := []*cerebrov1.FindingEvaluationRun{}
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			return nil, fmt.Errorf("scan finding evaluation run row: %w", err)
+		}
+		run := &cerebrov1.FindingEvaluationRun{}
+		if err := protojson.Unmarshal([]byte(payload), run); err != nil {
+			return nil, fmt.Errorf("decode finding evaluation run: %w", err)
+		}
+		runs = append(runs, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate finding evaluation run rows: %w", err)
+	}
+	return runs, nil
+}
+
+func ensureFindingEvaluationRunTable(ctx context.Context, db *sql.DB) error {
+	for _, statement := range ensureFindingEvaluationRunStatements {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("ensure finding evaluation run tables: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) ensureFindingEvaluationRunTables(ctx context.Context) error {
+	return ensureFindingEvaluationRunTable(ctx, s.db)
+}
+
+func findingEvaluationRunListQuery(request ports.ListFindingEvaluationRunsRequest) (string, []any, error) {
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return "", nil, errors.New("finding evaluation runtime id is required")
+	}
+	clauses := []string{"runtime_id = $1"}
+	args := []any{runtimeID}
+	addFindingEvaluationRunFilter(&clauses, &args, "rule_id", request.RuleID)
+	addFindingEvaluationRunFilter(&clauses, &args, "status", request.Status)
+	query := `
+SELECT finding_evaluation_run_json::text
+FROM finding_evaluation_runs
+WHERE ` + strings.Join(clauses, " AND ") + `
+ORDER BY started_at DESC, id`
+	if request.Limit != 0 {
+		args = append(args, int64(request.Limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	return query, args, nil
+}
+
+func addFindingEvaluationRunFilter(clauses *[]string, args *[]any, column string, value string) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return
+	}
+	*args = append(*args, trimmed)
+	*clauses = append(*clauses, fmt.Sprintf("%s = $%d", column, len(*args)))
+}
+
+func findingEvaluationRunTime(value interface{ AsTime() time.Time }) time.Time {
+	if value == nil {
+		return time.Time{}
+	}
+	return value.AsTime().UTC()
+}

--- a/internal/statestore/postgres/findingevaluationruns_test.go
+++ b/internal/statestore/postgres/findingevaluationruns_test.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestPutFindingEvaluationRunRejectsNilRun(t *testing.T) {
+	store := &Store{}
+	if err := store.PutFindingEvaluationRun(context.Background(), nil); err == nil {
+		t.Fatal("PutFindingEvaluationRun() error = nil, want non-nil")
+	}
+}
+
+func TestPutFindingEvaluationRunRejectsMissingRuleID(t *testing.T) {
+	store := &Store{}
+	err := store.PutFindingEvaluationRun(context.Background(), &cerebrov1.FindingEvaluationRun{
+		Id:        "finding-eval-run-1",
+		RuntimeId: "writer-okta-audit",
+		Status:    "completed",
+		StartedAt: timestamppb.New(time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)),
+	})
+	if err == nil {
+		t.Fatal("PutFindingEvaluationRun() error = nil, want non-nil")
+	}
+}
+
+func TestGetFindingEvaluationRunRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	if _, err := store.GetFindingEvaluationRun(context.Background(), "finding-eval-run-1"); err == nil {
+		t.Fatal("GetFindingEvaluationRun() error = nil, want non-nil")
+	}
+}
+
+func TestListFindingEvaluationRunsRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	if _, err := store.ListFindingEvaluationRuns(context.Background(), ports.ListFindingEvaluationRunsRequest{RuntimeID: "writer-okta-audit"}); err == nil {
+		t.Fatal("ListFindingEvaluationRuns() error = nil, want non-nil")
+	}
+}
+
+func TestFindingEvaluationRunListQueryIncludesOptionalFilters(t *testing.T) {
+	query, args, err := findingEvaluationRunListQuery(ports.ListFindingEvaluationRunsRequest{
+		RuntimeID: "writer-okta-audit",
+		RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
+		Status:    "completed",
+		Limit:     25,
+	})
+	if err != nil {
+		t.Fatalf("findingEvaluationRunListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"runtime_id = $1",
+		"rule_id = $2",
+		"status = $3",
+		"LIMIT $4",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingEvaluationRunListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if got := len(args); got != 4 {
+		t.Fatalf("len(findingEvaluationRunListQuery().args) = %d, want 4", got)
+	}
+	if got := args[0]; got != "writer-okta-audit" {
+		t.Fatalf("findingEvaluationRunListQuery().args[0] = %#v, want writer-okta-audit", got)
+	}
+	if got := args[1]; got != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("findingEvaluationRunListQuery().args[1] = %#v, want rule id", got)
+	}
+	if got := args[2]; got != "completed" {
+		t.Fatalf("findingEvaluationRunListQuery().args[2] = %#v, want completed", got)
+	}
+	if got := args[3]; got != int64(25) {
+		t.Fatalf("findingEvaluationRunListQuery().args[3] = %#v, want 25", got)
+	}
+}

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -27,6 +27,8 @@ service BootstrapService {
   rpc WriteClaims(WriteClaimsRequest) returns (WriteClaimsResponse);
   rpc ListClaims(ListClaimsRequest) returns (ListClaimsResponse);
   rpc ListFindings(ListFindingsRequest) returns (ListFindingsResponse);
+  rpc ListFindingEvaluationRuns(ListFindingEvaluationRunsRequest) returns (ListFindingEvaluationRunsResponse);
+  rpc GetFindingEvaluationRun(GetFindingEvaluationRunRequest) returns (GetFindingEvaluationRunResponse);
   rpc EvaluateSourceRuntimeFindings(EvaluateSourceRuntimeFindingsRequest) returns (EvaluateSourceRuntimeFindingsResponse);
   rpc GetEntityNeighborhood(GetEntityNeighborhoodRequest) returns (GetEntityNeighborhoodResponse);
 }
@@ -99,6 +101,44 @@ message ListFindingRulesRequest {}
 // ListFindingRulesResponse returns the discoverable finding rule catalog for explicit rule selection.
 message ListFindingRulesResponse {
   repeated RuleSpec rules = 1;
+}
+
+// FindingEvaluationRun is the durable audit envelope for one rule evaluation over one source runtime.
+message FindingEvaluationRun {
+  string id = 1;
+  string runtime_id = 2;
+  string rule_id = 3;
+  string status = 4;
+  uint32 event_limit = 5;
+  uint32 events_evaluated = 6;
+  uint32 findings_upserted = 7;
+  repeated string finding_ids = 8;
+  google.protobuf.Timestamp started_at = 9;
+  google.protobuf.Timestamp finished_at = 10;
+  string error = 11;
+}
+
+// ListFindingEvaluationRunsRequest requests persisted finding evaluation runs for one stored runtime.
+message ListFindingEvaluationRunsRequest {
+  string runtime_id = 1;
+  string rule_id = 2;
+  string status = 3;
+  uint32 limit = 4;
+}
+
+// ListFindingEvaluationRunsResponse returns the matched persisted finding evaluation runs.
+message ListFindingEvaluationRunsResponse {
+  repeated FindingEvaluationRun runs = 1;
+}
+
+// GetFindingEvaluationRunRequest looks up one persisted finding evaluation run.
+message GetFindingEvaluationRunRequest {
+  string id = 1;
+}
+
+// GetFindingEvaluationRunResponse returns one persisted finding evaluation run.
+message GetFindingEvaluationRunResponse {
+  FindingEvaluationRun run = 1;
 }
 
 // RunReportRequest requests one durable report run.
@@ -308,6 +348,7 @@ message EvaluateSourceRuntimeFindingsResponse {
   uint32 events_evaluated = 3;
   uint32 findings_upserted = 4;
   repeated Finding findings = 5;
+  FindingEvaluationRun run = 6;
 }
 
 // GraphEntity is the normalized graph node view exposed by the first query surface.


### PR DESCRIPTION
## Summary
- persist durable finding evaluation runs alongside rule-scoped finding evaluation
- add bootstrap HTTP and ConnectRPC reads for listing and fetching evaluation runs
- document why evaluation runs are a platform primitive and how to inspect them

## Testing
- make verify