### PR TITLE
feat(findings): add multi-rule evaluation

### DIFF
--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -3097,6 +3097,197 @@ func (x *EvaluateSourceRuntimeFindingsRequest) GetRuleId() string {
 	return ""
 }
 
+// EvaluateSourceRuntimeFindingRulesRequest replays one stored runtime through one or more registered finding rules.
+type EvaluateSourceRuntimeFindingRulesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	RuleIds       []string               `protobuf:"bytes,2,rep,name=rule_ids,json=ruleIds,proto3" json:"rule_ids,omitempty"`
+	EventLimit    uint32                 `protobuf:"varint,3,opt,name=event_limit,json=eventLimit,proto3" json:"event_limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EvaluateSourceRuntimeFindingRulesRequest) Reset() {
+	*x = EvaluateSourceRuntimeFindingRulesRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluateSourceRuntimeFindingRulesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluateSourceRuntimeFindingRulesRequest) ProtoMessage() {}
+
+func (x *EvaluateSourceRuntimeFindingRulesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluateSourceRuntimeFindingRulesRequest.ProtoReflect.Descriptor instead.
+func (*EvaluateSourceRuntimeFindingRulesRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *EvaluateSourceRuntimeFindingRulesRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *EvaluateSourceRuntimeFindingRulesRequest) GetRuleIds() []string {
+	if x != nil {
+		return x.RuleIds
+	}
+	return nil
+}
+
+func (x *EvaluateSourceRuntimeFindingRulesRequest) GetEventLimit() uint32 {
+	if x != nil {
+		return x.EventLimit
+	}
+	return 0
+}
+
+// FindingRuleEvaluation returns the persisted outputs for one rule within a multi-rule evaluation pass.
+type FindingRuleEvaluation struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Rule          *RuleSpec              `protobuf:"bytes,1,opt,name=rule,proto3" json:"rule,omitempty"`
+	Findings      []*Finding             `protobuf:"bytes,2,rep,name=findings,proto3" json:"findings,omitempty"`
+	Run           *FindingEvaluationRun  `protobuf:"bytes,3,opt,name=run,proto3" json:"run,omitempty"`
+	Evidence      []*FindingEvidence     `protobuf:"bytes,4,rep,name=evidence,proto3" json:"evidence,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FindingRuleEvaluation) Reset() {
+	*x = FindingRuleEvaluation{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FindingRuleEvaluation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FindingRuleEvaluation) ProtoMessage() {}
+
+func (x *FindingRuleEvaluation) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FindingRuleEvaluation.ProtoReflect.Descriptor instead.
+func (*FindingRuleEvaluation) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *FindingRuleEvaluation) GetRule() *RuleSpec {
+	if x != nil {
+		return x.Rule
+	}
+	return nil
+}
+
+func (x *FindingRuleEvaluation) GetFindings() []*Finding {
+	if x != nil {
+		return x.Findings
+	}
+	return nil
+}
+
+func (x *FindingRuleEvaluation) GetRun() *FindingEvaluationRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
+func (x *FindingRuleEvaluation) GetEvidence() []*FindingEvidence {
+	if x != nil {
+		return x.Evidence
+	}
+	return nil
+}
+
+// EvaluateSourceRuntimeFindingRulesResponse returns one replay pass over a runtime with one result per evaluated rule.
+type EvaluateSourceRuntimeFindingRulesResponse struct {
+	state           protoimpl.MessageState   `protogen:"open.v1"`
+	Runtime         *SourceRuntime           `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
+	EventsEvaluated uint32                   `protobuf:"varint,2,opt,name=events_evaluated,json=eventsEvaluated,proto3" json:"events_evaluated,omitempty"`
+	Evaluations     []*FindingRuleEvaluation `protobuf:"bytes,3,rep,name=evaluations,proto3" json:"evaluations,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *EvaluateSourceRuntimeFindingRulesResponse) Reset() {
+	*x = EvaluateSourceRuntimeFindingRulesResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluateSourceRuntimeFindingRulesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluateSourceRuntimeFindingRulesResponse) ProtoMessage() {}
+
+func (x *EvaluateSourceRuntimeFindingRulesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluateSourceRuntimeFindingRulesResponse.ProtoReflect.Descriptor instead.
+func (*EvaluateSourceRuntimeFindingRulesResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *EvaluateSourceRuntimeFindingRulesResponse) GetRuntime() *SourceRuntime {
+	if x != nil {
+		return x.Runtime
+	}
+	return nil
+}
+
+func (x *EvaluateSourceRuntimeFindingRulesResponse) GetEventsEvaluated() uint32 {
+	if x != nil {
+		return x.EventsEvaluated
+	}
+	return 0
+}
+
+func (x *EvaluateSourceRuntimeFindingRulesResponse) GetEvaluations() []*FindingRuleEvaluation {
+	if x != nil {
+		return x.Evaluations
+	}
+	return nil
+}
+
 // EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, selected rule spec, and persisted findings.
 type EvaluateSourceRuntimeFindingsResponse struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
@@ -3113,7 +3304,7 @@ type EvaluateSourceRuntimeFindingsResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingsResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[50]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3125,7 +3316,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) String() string {
 func (*EvaluateSourceRuntimeFindingsResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[50]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3138,7 +3329,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{50}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *EvaluateSourceRuntimeFindingsResponse) GetRuntime() *SourceRuntime {
@@ -3202,7 +3393,7 @@ type GraphEntity struct {
 
 func (x *GraphEntity) Reset() {
 	*x = GraphEntity{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[51]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3214,7 +3405,7 @@ func (x *GraphEntity) String() string {
 func (*GraphEntity) ProtoMessage() {}
 
 func (x *GraphEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[51]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3227,7 +3418,7 @@ func (x *GraphEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphEntity.ProtoReflect.Descriptor instead.
 func (*GraphEntity) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{51}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *GraphEntity) GetUrn() string {
@@ -3263,7 +3454,7 @@ type GraphRelation struct {
 
 func (x *GraphRelation) Reset() {
 	*x = GraphRelation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[52]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3275,7 +3466,7 @@ func (x *GraphRelation) String() string {
 func (*GraphRelation) ProtoMessage() {}
 
 func (x *GraphRelation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[52]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3288,7 +3479,7 @@ func (x *GraphRelation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphRelation.ProtoReflect.Descriptor instead.
 func (*GraphRelation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{52}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *GraphRelation) GetFromUrn() string {
@@ -3323,7 +3514,7 @@ type GetEntityNeighborhoodRequest struct {
 
 func (x *GetEntityNeighborhoodRequest) Reset() {
 	*x = GetEntityNeighborhoodRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[53]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3335,7 +3526,7 @@ func (x *GetEntityNeighborhoodRequest) String() string {
 func (*GetEntityNeighborhoodRequest) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[53]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3348,7 +3539,7 @@ func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodRequest.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{53}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *GetEntityNeighborhoodRequest) GetRootUrn() string {
@@ -3377,7 +3568,7 @@ type GetEntityNeighborhoodResponse struct {
 
 func (x *GetEntityNeighborhoodResponse) Reset() {
 	*x = GetEntityNeighborhoodResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[54]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3389,7 +3580,7 @@ func (x *GetEntityNeighborhoodResponse) String() string {
 func (*GetEntityNeighborhoodResponse) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[54]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3402,7 +3593,7 @@ func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodResponse.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{54}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *GetEntityNeighborhoodResponse) GetRoot() *GraphEntity {
@@ -3699,7 +3890,21 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vevent_limit\x18\x02 \x01(\rR\n" +
 	"eventLimit\x12\x17\n" +
-	"\arule_id\x18\x03 \x01(\tR\x06ruleId\"\xfc\x02\n" +
+	"\arule_id\x18\x03 \x01(\tR\x06ruleId\"v\n" +
+	"(EvaluateSourceRuntimeFindingRulesRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x19\n" +
+	"\brule_ids\x18\x02 \x03(\tR\aruleIds\x12\x1f\n" +
+	"\vevent_limit\x18\x03 \x01(\rR\n" +
+	"eventLimit\"\xdf\x01\n" +
+	"\x15FindingRuleEvaluation\x12(\n" +
+	"\x04rule\x18\x01 \x01(\v2\x14.cerebro.v1.RuleSpecR\x04rule\x12/\n" +
+	"\bfindings\x18\x02 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\x122\n" +
+	"\x03run\x18\x03 \x01(\v2 .cerebro.v1.FindingEvaluationRunR\x03run\x127\n" +
+	"\bevidence\x18\x04 \x03(\v2\x1b.cerebro.v1.FindingEvidenceR\bevidence\"\xd0\x01\n" +
+	")EvaluateSourceRuntimeFindingRulesResponse\x123\n" +
+	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\x12)\n" +
+	"\x10events_evaluated\x18\x02 \x01(\rR\x0feventsEvaluated\x12C\n" +
+	"\vevaluations\x18\x03 \x03(\v2!.cerebro.v1.FindingRuleEvaluationR\vevaluations\"\xfc\x02\n" +
 	"%EvaluateSourceRuntimeFindingsResponse\x123\n" +
 	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\x12(\n" +
 	"\x04rule\x18\x02 \x01(\v2\x14.cerebro.v1.RuleSpecR\x04rule\x12)\n" +
@@ -3723,7 +3928,7 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x1dGetEntityNeighborhoodResponse\x12+\n" +
 	"\x04root\x18\x01 \x01(\v2\x17.cerebro.v1.GraphEntityR\x04root\x125\n" +
 	"\tneighbors\x18\x02 \x03(\v2\x17.cerebro.v1.GraphEntityR\tneighbors\x127\n" +
-	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\x9f\x10\n" +
+	"\trelations\x18\x03 \x03(\v2\x19.cerebro.v1.GraphRelationR\trelations2\xb2\x11\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -3747,7 +3952,8 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x19ListFindingEvaluationRuns\x12,.cerebro.v1.ListFindingEvaluationRunsRequest\x1a-.cerebro.v1.ListFindingEvaluationRunsResponse\x12r\n" +
 	"\x17GetFindingEvaluationRun\x12*.cerebro.v1.GetFindingEvaluationRunRequest\x1a+.cerebro.v1.GetFindingEvaluationRunResponse\x12f\n" +
 	"\x13ListFindingEvidence\x12&.cerebro.v1.ListFindingEvidenceRequest\x1a'.cerebro.v1.ListFindingEvidenceResponse\x12c\n" +
-	"\x12GetFindingEvidence\x12%.cerebro.v1.GetFindingEvidenceRequest\x1a&.cerebro.v1.GetFindingEvidenceResponse\x12\x84\x01\n" +
+	"\x12GetFindingEvidence\x12%.cerebro.v1.GetFindingEvidenceRequest\x1a&.cerebro.v1.GetFindingEvidenceResponse\x12\x90\x01\n" +
+	"!EvaluateSourceRuntimeFindingRules\x124.cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest\x1a5.cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse\x12\x84\x01\n" +
 	"\x1dEvaluateSourceRuntimeFindings\x120.cerebro.v1.EvaluateSourceRuntimeFindingsRequest\x1a1.cerebro.v1.EvaluateSourceRuntimeFindingsResponse\x12l\n" +
 	"\x15GetEntityNeighborhood\x12(.cerebro.v1.GetEntityNeighborhoodRequest\x1a).cerebro.v1.GetEntityNeighborhoodResponseB4Z2github.com/writer/cerebro/gen/cerebro/v1;cerebrov1b\x06proto3"
 
@@ -3763,186 +3969,197 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 62)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 65)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
-	(*GetVersionRequest)(nil),                     // 0: cerebro.v1.GetVersionRequest
-	(*GetVersionResponse)(nil),                    // 1: cerebro.v1.GetVersionResponse
-	(*CheckHealthRequest)(nil),                    // 2: cerebro.v1.CheckHealthRequest
-	(*ComponentStatus)(nil),                       // 3: cerebro.v1.ComponentStatus
-	(*CheckHealthResponse)(nil),                   // 4: cerebro.v1.CheckHealthResponse
-	(*ReportParameter)(nil),                       // 5: cerebro.v1.ReportParameter
-	(*ReportDefinition)(nil),                      // 6: cerebro.v1.ReportDefinition
-	(*ReportRun)(nil),                             // 7: cerebro.v1.ReportRun
-	(*ListReportDefinitionsRequest)(nil),          // 8: cerebro.v1.ListReportDefinitionsRequest
-	(*ListReportDefinitionsResponse)(nil),         // 9: cerebro.v1.ListReportDefinitionsResponse
-	(*ListFindingRulesRequest)(nil),               // 10: cerebro.v1.ListFindingRulesRequest
-	(*ListFindingRulesResponse)(nil),              // 11: cerebro.v1.ListFindingRulesResponse
-	(*FindingEvaluationRun)(nil),                  // 12: cerebro.v1.FindingEvaluationRun
-	(*ListFindingEvaluationRunsRequest)(nil),      // 13: cerebro.v1.ListFindingEvaluationRunsRequest
-	(*ListFindingEvaluationRunsResponse)(nil),     // 14: cerebro.v1.ListFindingEvaluationRunsResponse
-	(*GetFindingEvaluationRunRequest)(nil),        // 15: cerebro.v1.GetFindingEvaluationRunRequest
-	(*GetFindingEvaluationRunResponse)(nil),       // 16: cerebro.v1.GetFindingEvaluationRunResponse
-	(*FindingEvidence)(nil),                       // 17: cerebro.v1.FindingEvidence
-	(*ListFindingEvidenceRequest)(nil),            // 18: cerebro.v1.ListFindingEvidenceRequest
-	(*ListFindingEvidenceResponse)(nil),           // 19: cerebro.v1.ListFindingEvidenceResponse
-	(*GetFindingEvidenceRequest)(nil),             // 20: cerebro.v1.GetFindingEvidenceRequest
-	(*GetFindingEvidenceResponse)(nil),            // 21: cerebro.v1.GetFindingEvidenceResponse
-	(*RunReportRequest)(nil),                      // 22: cerebro.v1.RunReportRequest
-	(*RunReportResponse)(nil),                     // 23: cerebro.v1.RunReportResponse
-	(*GetReportRunRequest)(nil),                   // 24: cerebro.v1.GetReportRunRequest
-	(*GetReportRunResponse)(nil),                  // 25: cerebro.v1.GetReportRunResponse
-	(*ListSourcesRequest)(nil),                    // 26: cerebro.v1.ListSourcesRequest
-	(*ListSourcesResponse)(nil),                   // 27: cerebro.v1.ListSourcesResponse
-	(*CheckSourceRequest)(nil),                    // 28: cerebro.v1.CheckSourceRequest
-	(*CheckSourceResponse)(nil),                   // 29: cerebro.v1.CheckSourceResponse
-	(*DiscoverSourceRequest)(nil),                 // 30: cerebro.v1.DiscoverSourceRequest
-	(*DiscoverSourceResponse)(nil),                // 31: cerebro.v1.DiscoverSourceResponse
-	(*ReadSourceRequest)(nil),                     // 32: cerebro.v1.ReadSourceRequest
-	(*SourcePreviewEvent)(nil),                    // 33: cerebro.v1.SourcePreviewEvent
-	(*ReadSourceResponse)(nil),                    // 34: cerebro.v1.ReadSourceResponse
-	(*SourceRuntime)(nil),                         // 35: cerebro.v1.SourceRuntime
-	(*PutSourceRuntimeRequest)(nil),               // 36: cerebro.v1.PutSourceRuntimeRequest
-	(*PutSourceRuntimeResponse)(nil),              // 37: cerebro.v1.PutSourceRuntimeResponse
-	(*GetSourceRuntimeRequest)(nil),               // 38: cerebro.v1.GetSourceRuntimeRequest
-	(*GetSourceRuntimeResponse)(nil),              // 39: cerebro.v1.GetSourceRuntimeResponse
-	(*SyncSourceRuntimeRequest)(nil),              // 40: cerebro.v1.SyncSourceRuntimeRequest
-	(*SyncSourceRuntimeResponse)(nil),             // 41: cerebro.v1.SyncSourceRuntimeResponse
-	(*WriteClaimsRequest)(nil),                    // 42: cerebro.v1.WriteClaimsRequest
-	(*WriteClaimsResponse)(nil),                   // 43: cerebro.v1.WriteClaimsResponse
-	(*ListClaimsRequest)(nil),                     // 44: cerebro.v1.ListClaimsRequest
-	(*ListClaimsResponse)(nil),                    // 45: cerebro.v1.ListClaimsResponse
-	(*ListFindingsRequest)(nil),                   // 46: cerebro.v1.ListFindingsRequest
-	(*Finding)(nil),                               // 47: cerebro.v1.Finding
-	(*ListFindingsResponse)(nil),                  // 48: cerebro.v1.ListFindingsResponse
-	(*EvaluateSourceRuntimeFindingsRequest)(nil),  // 49: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	(*EvaluateSourceRuntimeFindingsResponse)(nil), // 50: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	(*GraphEntity)(nil),                           // 51: cerebro.v1.GraphEntity
-	(*GraphRelation)(nil),                         // 52: cerebro.v1.GraphRelation
-	(*GetEntityNeighborhoodRequest)(nil),          // 53: cerebro.v1.GetEntityNeighborhoodRequest
-	(*GetEntityNeighborhoodResponse)(nil),         // 54: cerebro.v1.GetEntityNeighborhoodResponse
-	nil,                                           // 55: cerebro.v1.ReportRun.ParametersEntry
-	nil,                                           // 56: cerebro.v1.RunReportRequest.ParametersEntry
-	nil,                                           // 57: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                                           // 58: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                                           // 59: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                                           // 60: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                                           // 61: cerebro.v1.Finding.AttributesEntry
-	(*timestamppb.Timestamp)(nil),                 // 62: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                       // 63: google.protobuf.Struct
-	(*RuleSpec)(nil),                              // 64: cerebro.v1.RuleSpec
-	(*SourceSpec)(nil),                            // 65: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),                          // 66: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                         // 67: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                        // 68: google.protobuf.Value
-	(*SourceCheckpoint)(nil),                      // 69: cerebro.v1.SourceCheckpoint
-	(*Claim)(nil),                                 // 70: cerebro.v1.Claim
+	(*GetVersionRequest)(nil),                         // 0: cerebro.v1.GetVersionRequest
+	(*GetVersionResponse)(nil),                        // 1: cerebro.v1.GetVersionResponse
+	(*CheckHealthRequest)(nil),                        // 2: cerebro.v1.CheckHealthRequest
+	(*ComponentStatus)(nil),                           // 3: cerebro.v1.ComponentStatus
+	(*CheckHealthResponse)(nil),                       // 4: cerebro.v1.CheckHealthResponse
+	(*ReportParameter)(nil),                           // 5: cerebro.v1.ReportParameter
+	(*ReportDefinition)(nil),                          // 6: cerebro.v1.ReportDefinition
+	(*ReportRun)(nil),                                 // 7: cerebro.v1.ReportRun
+	(*ListReportDefinitionsRequest)(nil),              // 8: cerebro.v1.ListReportDefinitionsRequest
+	(*ListReportDefinitionsResponse)(nil),             // 9: cerebro.v1.ListReportDefinitionsResponse
+	(*ListFindingRulesRequest)(nil),                   // 10: cerebro.v1.ListFindingRulesRequest
+	(*ListFindingRulesResponse)(nil),                  // 11: cerebro.v1.ListFindingRulesResponse
+	(*FindingEvaluationRun)(nil),                      // 12: cerebro.v1.FindingEvaluationRun
+	(*ListFindingEvaluationRunsRequest)(nil),          // 13: cerebro.v1.ListFindingEvaluationRunsRequest
+	(*ListFindingEvaluationRunsResponse)(nil),         // 14: cerebro.v1.ListFindingEvaluationRunsResponse
+	(*GetFindingEvaluationRunRequest)(nil),            // 15: cerebro.v1.GetFindingEvaluationRunRequest
+	(*GetFindingEvaluationRunResponse)(nil),           // 16: cerebro.v1.GetFindingEvaluationRunResponse
+	(*FindingEvidence)(nil),                           // 17: cerebro.v1.FindingEvidence
+	(*ListFindingEvidenceRequest)(nil),                // 18: cerebro.v1.ListFindingEvidenceRequest
+	(*ListFindingEvidenceResponse)(nil),               // 19: cerebro.v1.ListFindingEvidenceResponse
+	(*GetFindingEvidenceRequest)(nil),                 // 20: cerebro.v1.GetFindingEvidenceRequest
+	(*GetFindingEvidenceResponse)(nil),                // 21: cerebro.v1.GetFindingEvidenceResponse
+	(*RunReportRequest)(nil),                          // 22: cerebro.v1.RunReportRequest
+	(*RunReportResponse)(nil),                         // 23: cerebro.v1.RunReportResponse
+	(*GetReportRunRequest)(nil),                       // 24: cerebro.v1.GetReportRunRequest
+	(*GetReportRunResponse)(nil),                      // 25: cerebro.v1.GetReportRunResponse
+	(*ListSourcesRequest)(nil),                        // 26: cerebro.v1.ListSourcesRequest
+	(*ListSourcesResponse)(nil),                       // 27: cerebro.v1.ListSourcesResponse
+	(*CheckSourceRequest)(nil),                        // 28: cerebro.v1.CheckSourceRequest
+	(*CheckSourceResponse)(nil),                       // 29: cerebro.v1.CheckSourceResponse
+	(*DiscoverSourceRequest)(nil),                     // 30: cerebro.v1.DiscoverSourceRequest
+	(*DiscoverSourceResponse)(nil),                    // 31: cerebro.v1.DiscoverSourceResponse
+	(*ReadSourceRequest)(nil),                         // 32: cerebro.v1.ReadSourceRequest
+	(*SourcePreviewEvent)(nil),                        // 33: cerebro.v1.SourcePreviewEvent
+	(*ReadSourceResponse)(nil),                        // 34: cerebro.v1.ReadSourceResponse
+	(*SourceRuntime)(nil),                             // 35: cerebro.v1.SourceRuntime
+	(*PutSourceRuntimeRequest)(nil),                   // 36: cerebro.v1.PutSourceRuntimeRequest
+	(*PutSourceRuntimeResponse)(nil),                  // 37: cerebro.v1.PutSourceRuntimeResponse
+	(*GetSourceRuntimeRequest)(nil),                   // 38: cerebro.v1.GetSourceRuntimeRequest
+	(*GetSourceRuntimeResponse)(nil),                  // 39: cerebro.v1.GetSourceRuntimeResponse
+	(*SyncSourceRuntimeRequest)(nil),                  // 40: cerebro.v1.SyncSourceRuntimeRequest
+	(*SyncSourceRuntimeResponse)(nil),                 // 41: cerebro.v1.SyncSourceRuntimeResponse
+	(*WriteClaimsRequest)(nil),                        // 42: cerebro.v1.WriteClaimsRequest
+	(*WriteClaimsResponse)(nil),                       // 43: cerebro.v1.WriteClaimsResponse
+	(*ListClaimsRequest)(nil),                         // 44: cerebro.v1.ListClaimsRequest
+	(*ListClaimsResponse)(nil),                        // 45: cerebro.v1.ListClaimsResponse
+	(*ListFindingsRequest)(nil),                       // 46: cerebro.v1.ListFindingsRequest
+	(*Finding)(nil),                                   // 47: cerebro.v1.Finding
+	(*ListFindingsResponse)(nil),                      // 48: cerebro.v1.ListFindingsResponse
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),      // 49: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingRulesRequest)(nil),  // 50: cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	(*FindingRuleEvaluation)(nil),                     // 51: cerebro.v1.FindingRuleEvaluation
+	(*EvaluateSourceRuntimeFindingRulesResponse)(nil), // 52: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	(*EvaluateSourceRuntimeFindingsResponse)(nil),     // 53: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	(*GraphEntity)(nil),                               // 54: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                             // 55: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),              // 56: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),             // 57: cerebro.v1.GetEntityNeighborhoodResponse
+	nil,                                               // 58: cerebro.v1.ReportRun.ParametersEntry
+	nil,                                               // 59: cerebro.v1.RunReportRequest.ParametersEntry
+	nil,                                               // 60: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                               // 61: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                               // 62: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                               // 63: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                               // 64: cerebro.v1.Finding.AttributesEntry
+	(*timestamppb.Timestamp)(nil),                     // 65: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                           // 66: google.protobuf.Struct
+	(*RuleSpec)(nil),                                  // 67: cerebro.v1.RuleSpec
+	(*SourceSpec)(nil),                                // 68: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                              // 69: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                             // 70: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                            // 71: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                          // 72: cerebro.v1.SourceCheckpoint
+	(*Claim)(nil),                                     // 73: cerebro.v1.Claim
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	62, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	65, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	3,  // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
 	5,  // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
-	55, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
-	62, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
-	63, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
+	58, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
+	65, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
+	66, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
 	6,  // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
-	64, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
-	62, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
-	62, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
+	67, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
+	65, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
+	65, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
 	12, // 10: cerebro.v1.ListFindingEvaluationRunsResponse.runs:type_name -> cerebro.v1.FindingEvaluationRun
 	12, // 11: cerebro.v1.GetFindingEvaluationRunResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	62, // 12: cerebro.v1.FindingEvidence.created_at:type_name -> google.protobuf.Timestamp
+	65, // 12: cerebro.v1.FindingEvidence.created_at:type_name -> google.protobuf.Timestamp
 	17, // 13: cerebro.v1.ListFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
 	17, // 14: cerebro.v1.GetFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	56, // 15: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
+	59, // 15: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
 	6,  // 16: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
 	7,  // 17: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
 	7,  // 18: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
-	65, // 19: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	57, // 20: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	65, // 21: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	58, // 22: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	65, // 23: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	59, // 24: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	66, // 25: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	67, // 26: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	68, // 27: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	65, // 28: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	67, // 29: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	69, // 30: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	66, // 31: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	68, // 19: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	60, // 20: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	68, // 21: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	61, // 22: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	68, // 23: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	62, // 24: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	69, // 25: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	70, // 26: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	71, // 27: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	68, // 28: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	70, // 29: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	72, // 30: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	69, // 31: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
 	33, // 32: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	60, // 33: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	69, // 34: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	66, // 35: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	62, // 36: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	63, // 33: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	72, // 34: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	69, // 35: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	65, // 36: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
 	35, // 37: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
 	35, // 38: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	35, // 39: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	35, // 40: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	65, // 41: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	70, // 42: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	70, // 43: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
-	61, // 44: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	62, // 45: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	62, // 46: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	68, // 41: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	73, // 42: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	73, // 43: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	64, // 44: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	65, // 45: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	65, // 46: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
 	47, // 47: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	35, // 48: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	64, // 49: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	47, // 50: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	12, // 51: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	17, // 52: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	51, // 53: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	51, // 54: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	52, // 55: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	0,  // 56: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	2,  // 57: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	8,  // 58: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	10, // 59: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
-	22, // 60: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	24, // 61: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	26, // 62: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	28, // 63: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	30, // 64: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	32, // 65: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	36, // 66: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	38, // 67: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	40, // 68: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	42, // 69: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	44, // 70: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
-	46, // 71: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
-	13, // 72: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
-	15, // 73: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
-	18, // 74: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
-	20, // 75: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
-	49, // 76: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	53, // 77: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	1,  // 78: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	4,  // 79: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	9,  // 80: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	11, // 81: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
-	23, // 82: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	25, // 83: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	27, // 84: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	29, // 85: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	31, // 86: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	34, // 87: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	37, // 88: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	39, // 89: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	41, // 90: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	43, // 91: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	45, // 92: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
-	48, // 93: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
-	14, // 94: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
-	16, // 95: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
-	19, // 96: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
-	21, // 97: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
-	50, // 98: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	54, // 99: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	78, // [78:100] is the sub-list for method output_type
-	56, // [56:78] is the sub-list for method input_type
-	56, // [56:56] is the sub-list for extension type_name
-	56, // [56:56] is the sub-list for extension extendee
-	0,  // [0:56] is the sub-list for field type_name
+	67, // 48: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
+	47, // 49: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
+	12, // 50: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
+	17, // 51: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
+	35, // 52: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	51, // 53: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
+	35, // 54: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	67, // 55: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	47, // 56: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	12, // 57: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
+	17, // 58: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	54, // 59: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	54, // 60: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	55, // 61: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	0,  // 62: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	2,  // 63: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	8,  // 64: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	10, // 65: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
+	22, // 66: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	24, // 67: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	26, // 68: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	28, // 69: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	30, // 70: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	32, // 71: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	36, // 72: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	38, // 73: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	40, // 74: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	42, // 75: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	44, // 76: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	46, // 77: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
+	13, // 78: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
+	15, // 79: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
+	18, // 80: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
+	20, // 81: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
+	50, // 82: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	49, // 83: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	56, // 84: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	1,  // 85: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	4,  // 86: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	9,  // 87: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	11, // 88: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
+	23, // 89: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	25, // 90: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	27, // 91: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	29, // 92: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	31, // 93: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	34, // 94: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	37, // 95: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	39, // 96: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	41, // 97: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	43, // 98: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	45, // 99: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	48, // 100: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
+	14, // 101: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
+	16, // 102: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
+	19, // 103: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
+	21, // 104: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
+	52, // 105: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	53, // 106: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	57, // 107: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	85, // [85:108] is the sub-list for method output_type
+	62, // [62:85] is the sub-list for method input_type
+	62, // [62:62] is the sub-list for extension type_name
+	62, // [62:62] is the sub-list for extension extendee
+	0,  // [0:62] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -3958,7 +4175,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   62,
+			NumMessages:   65,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -93,6 +93,9 @@ const (
 	// BootstrapServiceGetFindingEvidenceProcedure is the fully-qualified name of the BootstrapService's
 	// GetFindingEvidence RPC.
 	BootstrapServiceGetFindingEvidenceProcedure = "/cerebro.v1.BootstrapService/GetFindingEvidence"
+	// BootstrapServiceEvaluateSourceRuntimeFindingRulesProcedure is the fully-qualified name of the
+	// BootstrapService's EvaluateSourceRuntimeFindingRules RPC.
+	BootstrapServiceEvaluateSourceRuntimeFindingRulesProcedure = "/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindingRules"
 	// BootstrapServiceEvaluateSourceRuntimeFindingsProcedure is the fully-qualified name of the
 	// BootstrapService's EvaluateSourceRuntimeFindings RPC.
 	BootstrapServiceEvaluateSourceRuntimeFindingsProcedure = "/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindings"
@@ -123,6 +126,7 @@ type BootstrapServiceClient interface {
 	GetFindingEvaluationRun(context.Context, *connect.Request[v1.GetFindingEvaluationRunRequest]) (*connect.Response[v1.GetFindingEvaluationRunResponse], error)
 	ListFindingEvidence(context.Context, *connect.Request[v1.ListFindingEvidenceRequest]) (*connect.Response[v1.ListFindingEvidenceResponse], error)
 	GetFindingEvidence(context.Context, *connect.Request[v1.GetFindingEvidenceRequest]) (*connect.Response[v1.GetFindingEvidenceResponse], error)
+	EvaluateSourceRuntimeFindingRules(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingRulesRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingRulesResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
@@ -258,6 +262,12 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("GetFindingEvidence")),
 			connect.WithClientOptions(opts...),
 		),
+		evaluateSourceRuntimeFindingRules: connect.NewClient[v1.EvaluateSourceRuntimeFindingRulesRequest, v1.EvaluateSourceRuntimeFindingRulesResponse](
+			httpClient,
+			baseURL+BootstrapServiceEvaluateSourceRuntimeFindingRulesProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("EvaluateSourceRuntimeFindingRules")),
+			connect.WithClientOptions(opts...),
+		),
 		evaluateSourceRuntimeFindings: connect.NewClient[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse](
 			httpClient,
 			baseURL+BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
@@ -275,28 +285,29 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 
 // bootstrapServiceClient implements BootstrapServiceClient.
 type bootstrapServiceClient struct {
-	getVersion                    *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
-	checkHealth                   *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
-	listReportDefinitions         *connect.Client[v1.ListReportDefinitionsRequest, v1.ListReportDefinitionsResponse]
-	listFindingRules              *connect.Client[v1.ListFindingRulesRequest, v1.ListFindingRulesResponse]
-	runReport                     *connect.Client[v1.RunReportRequest, v1.RunReportResponse]
-	getReportRun                  *connect.Client[v1.GetReportRunRequest, v1.GetReportRunResponse]
-	listSources                   *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
-	checkSource                   *connect.Client[v1.CheckSourceRequest, v1.CheckSourceResponse]
-	discoverSource                *connect.Client[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse]
-	readSource                    *connect.Client[v1.ReadSourceRequest, v1.ReadSourceResponse]
-	putSourceRuntime              *connect.Client[v1.PutSourceRuntimeRequest, v1.PutSourceRuntimeResponse]
-	getSourceRuntime              *connect.Client[v1.GetSourceRuntimeRequest, v1.GetSourceRuntimeResponse]
-	syncSourceRuntime             *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
-	writeClaims                   *connect.Client[v1.WriteClaimsRequest, v1.WriteClaimsResponse]
-	listClaims                    *connect.Client[v1.ListClaimsRequest, v1.ListClaimsResponse]
-	listFindings                  *connect.Client[v1.ListFindingsRequest, v1.ListFindingsResponse]
-	listFindingEvaluationRuns     *connect.Client[v1.ListFindingEvaluationRunsRequest, v1.ListFindingEvaluationRunsResponse]
-	getFindingEvaluationRun       *connect.Client[v1.GetFindingEvaluationRunRequest, v1.GetFindingEvaluationRunResponse]
-	listFindingEvidence           *connect.Client[v1.ListFindingEvidenceRequest, v1.ListFindingEvidenceResponse]
-	getFindingEvidence            *connect.Client[v1.GetFindingEvidenceRequest, v1.GetFindingEvidenceResponse]
-	evaluateSourceRuntimeFindings *connect.Client[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse]
-	getEntityNeighborhood         *connect.Client[v1.GetEntityNeighborhoodRequest, v1.GetEntityNeighborhoodResponse]
+	getVersion                        *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
+	checkHealth                       *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
+	listReportDefinitions             *connect.Client[v1.ListReportDefinitionsRequest, v1.ListReportDefinitionsResponse]
+	listFindingRules                  *connect.Client[v1.ListFindingRulesRequest, v1.ListFindingRulesResponse]
+	runReport                         *connect.Client[v1.RunReportRequest, v1.RunReportResponse]
+	getReportRun                      *connect.Client[v1.GetReportRunRequest, v1.GetReportRunResponse]
+	listSources                       *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
+	checkSource                       *connect.Client[v1.CheckSourceRequest, v1.CheckSourceResponse]
+	discoverSource                    *connect.Client[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse]
+	readSource                        *connect.Client[v1.ReadSourceRequest, v1.ReadSourceResponse]
+	putSourceRuntime                  *connect.Client[v1.PutSourceRuntimeRequest, v1.PutSourceRuntimeResponse]
+	getSourceRuntime                  *connect.Client[v1.GetSourceRuntimeRequest, v1.GetSourceRuntimeResponse]
+	syncSourceRuntime                 *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
+	writeClaims                       *connect.Client[v1.WriteClaimsRequest, v1.WriteClaimsResponse]
+	listClaims                        *connect.Client[v1.ListClaimsRequest, v1.ListClaimsResponse]
+	listFindings                      *connect.Client[v1.ListFindingsRequest, v1.ListFindingsResponse]
+	listFindingEvaluationRuns         *connect.Client[v1.ListFindingEvaluationRunsRequest, v1.ListFindingEvaluationRunsResponse]
+	getFindingEvaluationRun           *connect.Client[v1.GetFindingEvaluationRunRequest, v1.GetFindingEvaluationRunResponse]
+	listFindingEvidence               *connect.Client[v1.ListFindingEvidenceRequest, v1.ListFindingEvidenceResponse]
+	getFindingEvidence                *connect.Client[v1.GetFindingEvidenceRequest, v1.GetFindingEvidenceResponse]
+	evaluateSourceRuntimeFindingRules *connect.Client[v1.EvaluateSourceRuntimeFindingRulesRequest, v1.EvaluateSourceRuntimeFindingRulesResponse]
+	evaluateSourceRuntimeFindings     *connect.Client[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse]
+	getEntityNeighborhood             *connect.Client[v1.GetEntityNeighborhoodRequest, v1.GetEntityNeighborhoodResponse]
 }
 
 // GetVersion calls cerebro.v1.BootstrapService.GetVersion.
@@ -399,6 +410,12 @@ func (c *bootstrapServiceClient) GetFindingEvidence(ctx context.Context, req *co
 	return c.getFindingEvidence.CallUnary(ctx, req)
 }
 
+// EvaluateSourceRuntimeFindingRules calls
+// cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules.
+func (c *bootstrapServiceClient) EvaluateSourceRuntimeFindingRules(ctx context.Context, req *connect.Request[v1.EvaluateSourceRuntimeFindingRulesRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingRulesResponse], error) {
+	return c.evaluateSourceRuntimeFindingRules.CallUnary(ctx, req)
+}
+
 // EvaluateSourceRuntimeFindings calls cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings.
 func (c *bootstrapServiceClient) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {
 	return c.evaluateSourceRuntimeFindings.CallUnary(ctx, req)
@@ -431,6 +448,7 @@ type BootstrapServiceHandler interface {
 	GetFindingEvaluationRun(context.Context, *connect.Request[v1.GetFindingEvaluationRunRequest]) (*connect.Response[v1.GetFindingEvaluationRunResponse], error)
 	ListFindingEvidence(context.Context, *connect.Request[v1.ListFindingEvidenceRequest]) (*connect.Response[v1.ListFindingEvidenceResponse], error)
 	GetFindingEvidence(context.Context, *connect.Request[v1.GetFindingEvidenceRequest]) (*connect.Response[v1.GetFindingEvidenceResponse], error)
+	EvaluateSourceRuntimeFindingRules(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingRulesRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingRulesResponse], error)
 	EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error)
 	GetEntityNeighborhood(context.Context, *connect.Request[v1.GetEntityNeighborhoodRequest]) (*connect.Response[v1.GetEntityNeighborhoodResponse], error)
 }
@@ -562,6 +580,12 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		connect.WithSchema(bootstrapServiceMethods.ByName("GetFindingEvidence")),
 		connect.WithHandlerOptions(opts...),
 	)
+	bootstrapServiceEvaluateSourceRuntimeFindingRulesHandler := connect.NewUnaryHandler(
+		BootstrapServiceEvaluateSourceRuntimeFindingRulesProcedure,
+		svc.EvaluateSourceRuntimeFindingRules,
+		connect.WithSchema(bootstrapServiceMethods.ByName("EvaluateSourceRuntimeFindingRules")),
+		connect.WithHandlerOptions(opts...),
+	)
 	bootstrapServiceEvaluateSourceRuntimeFindingsHandler := connect.NewUnaryHandler(
 		BootstrapServiceEvaluateSourceRuntimeFindingsProcedure,
 		svc.EvaluateSourceRuntimeFindings,
@@ -616,6 +640,8 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceListFindingEvidenceHandler.ServeHTTP(w, r)
 		case BootstrapServiceGetFindingEvidenceProcedure:
 			bootstrapServiceGetFindingEvidenceHandler.ServeHTTP(w, r)
+		case BootstrapServiceEvaluateSourceRuntimeFindingRulesProcedure:
+			bootstrapServiceEvaluateSourceRuntimeFindingRulesHandler.ServeHTTP(w, r)
 		case BootstrapServiceEvaluateSourceRuntimeFindingsProcedure:
 			bootstrapServiceEvaluateSourceRuntimeFindingsHandler.ServeHTTP(w, r)
 		case BootstrapServiceGetEntityNeighborhoodProcedure:
@@ -707,6 +733,10 @@ func (UnimplementedBootstrapServiceHandler) ListFindingEvidence(context.Context,
 
 func (UnimplementedBootstrapServiceHandler) GetFindingEvidence(context.Context, *connect.Request[v1.GetFindingEvidenceRequest]) (*connect.Response[v1.GetFindingEvidenceResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.GetFindingEvidence is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) EvaluateSourceRuntimeFindingRules(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingRulesRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingRulesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules is not implemented"))
 }
 
 func (UnimplementedBootstrapServiceHandler) EvaluateSourceRuntimeFindings(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingsResponse], error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -78,6 +78,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/findings", app.handleListFindings)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/finding-evidence", app.handleListFindingEvidence)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/finding-evaluation-runs", app.handleListFindingEvaluationRuns)
+	mux.HandleFunc("POST /source-runtimes/{runtimeID}/finding-rules/evaluate", app.handleEvaluateSourceRuntimeFindingRules)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/findings/evaluate", app.handleEvaluateSourceRuntimeFindings)
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
@@ -379,6 +380,35 @@ func (a *App) handleEvaluateSourceRuntimeFindings(w http.ResponseWriter, r *http
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, findingResponse(response))
+}
+
+func (a *App) handleEvaluateSourceRuntimeFindingRules(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.EvaluateSourceRuntimeFindingRulesRequest{}
+	if err := readProtoJSON(r, request); err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	if eventLimit := r.URL.Query().Get("event_limit"); eventLimit != "" {
+		body := []byte(`{"event_limit":` + eventLimit + `}`)
+		if err := protojson.Unmarshal(body, request); err != nil {
+			writeFindingError(w, err)
+			return
+		}
+	}
+	request.Id = r.PathValue("runtimeID")
+	if ruleIDs := r.URL.Query()["rule_id"]; len(ruleIDs) != 0 {
+		request.RuleIds = ruleIDs
+	}
+	response, err := a.findingService().EvaluateSourceRuntimeRules(r.Context(), findings.EvaluateRulesRequest{
+		RuntimeID:  request.GetId(),
+		RuleIDs:    request.GetRuleIds(),
+		EventLimit: request.GetEventLimit(),
+	})
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, findingRulesResponse(response))
 }
 
 func (a *App) handleListFindings(w http.ResponseWriter, r *http.Request) {
@@ -770,6 +800,25 @@ func (s *bootstrapService) GetFindingEvidence(ctx context.Context, req *connect.
 	return connect.NewResponse(&cerebrov1.GetFindingEvidenceResponse{Evidence: evidence}), nil
 }
 
+func (s *bootstrapService) EvaluateSourceRuntimeFindingRules(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingRulesRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingRulesResponse], error) {
+	response, err := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
+		findingEvidenceStore(s.deps.StateStore),
+		claimStore(s.deps.StateStore),
+	).EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
+		RuntimeID:  req.Msg.GetId(),
+		RuleIDs:    req.Msg.GetRuleIds(),
+		EventLimit: req.Msg.GetEventLimit(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(findingRulesResponse(response)), nil
+}
+
 func (s *bootstrapService) EvaluateSourceRuntimeFindings(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingsRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingsResponse], error) {
 	response, err := findings.New(
 		sourceRuntimeStore(s.deps.StateStore),
@@ -1072,6 +1121,33 @@ func findingResponse(result *findings.EvaluateResult) *cerebrov1.EvaluateSourceR
 		Evidence:         result.Evidence,
 	}
 	return response
+}
+
+func findingRulesResponse(result *findings.EvaluateRulesResult) *cerebrov1.EvaluateSourceRuntimeFindingRulesResponse {
+	if result == nil {
+		return &cerebrov1.EvaluateSourceRuntimeFindingRulesResponse{}
+	}
+	evaluations := make([]*cerebrov1.FindingRuleEvaluation, 0, len(result.Evaluations))
+	for _, evaluation := range result.Evaluations {
+		evaluations = append(evaluations, findingRuleEvaluationMessage(evaluation))
+	}
+	return &cerebrov1.EvaluateSourceRuntimeFindingRulesResponse{
+		Runtime:         result.Runtime,
+		EventsEvaluated: result.EventsEvaluated,
+		Evaluations:     evaluations,
+	}
+}
+
+func findingRuleEvaluationMessage(result *findings.RuleEvaluationResult) *cerebrov1.FindingRuleEvaluation {
+	if result == nil {
+		return &cerebrov1.FindingRuleEvaluation{}
+	}
+	return &cerebrov1.FindingRuleEvaluation{
+		Rule:     result.Rule,
+		Findings: findingMessages(result.Findings),
+		Run:      result.Run,
+		Evidence: result.Evidence,
+	}
 }
 
 func listFindingsResponse(result *findings.ListResult) *cerebrov1.ListFindingsResponse {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"connectrpc.com/connect"
@@ -389,11 +390,12 @@ func (a *App) handleEvaluateSourceRuntimeFindingRules(w http.ResponseWriter, r *
 		return
 	}
 	if eventLimit := r.URL.Query().Get("event_limit"); eventLimit != "" {
-		body := []byte(`{"event_limit":` + eventLimit + `}`)
-		if err := protojson.Unmarshal(body, request); err != nil {
+		parsedLimit, err := strconv.ParseUint(eventLimit, 10, 32)
+		if err != nil {
 			writeFindingError(w, err)
 			return
 		}
+		request.EventLimit = uint32(parsedLimit)
 	}
 	request.Id = r.PathValue("runtimeID")
 	if ruleIDs := r.URL.Query()["rule_id"]; len(ruleIDs) != 0 {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1159,6 +1159,26 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := missingRuleResp.StatusCode; got != http.StatusNotFound {
 		t.Fatalf("unknown rule status = %d, want %d", got, http.StatusNotFound)
 	}
+	batchMissingRuleReq, err := http.NewRequest(
+		http.MethodPost,
+		server.URL+"/source-runtimes/writer-okta-audit/finding-rules/evaluate?event_limit=2",
+		strings.NewReader(`{"rule_ids":["does-not-exist"]}`),
+	)
+	if err != nil {
+		t.Fatalf("new batch unknown rule request: %v", err)
+	}
+	batchMissingRuleResp, err := server.Client().Do(batchMissingRuleReq)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/finding-rules/evaluate unknown rule error = %v", err)
+	}
+	defer func() {
+		if closeErr := batchMissingRuleResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close batch unknown rule response body: %v", closeErr)
+		}
+	}()
+	if got := batchMissingRuleResp.StatusCode; got != http.StatusNotFound {
+		t.Fatalf("batch unknown rule status = %d, want %d", got, http.StatusNotFound)
+	}
 	batchEvaluateReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-audit/finding-rules/evaluate?event_limit=2", nil)
 	if err != nil {
 		t.Fatalf("new batch evaluate request: %v", err)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1159,6 +1159,42 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := missingRuleResp.StatusCode; got != http.StatusNotFound {
 		t.Fatalf("unknown rule status = %d, want %d", got, http.StatusNotFound)
 	}
+	batchEvaluateReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-audit/finding-rules/evaluate?event_limit=2", nil)
+	if err != nil {
+		t.Fatalf("new batch evaluate request: %v", err)
+	}
+	batchEvaluateResp, err := server.Client().Do(batchEvaluateReq)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/finding-rules/evaluate error = %v", err)
+	}
+	defer func() {
+		if closeErr := batchEvaluateResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close batch evaluate response body: %v", closeErr)
+		}
+	}()
+	var batchEvaluatePayload map[string]any
+	if err := json.NewDecoder(batchEvaluateResp.Body).Decode(&batchEvaluatePayload); err != nil {
+		t.Fatalf("decode batch evaluate response: %v", err)
+	}
+	if got := batchEvaluatePayload["events_evaluated"]; got != float64(2) {
+		t.Fatalf("batch evaluate events_evaluated = %#v, want 2", got)
+	}
+	batchEvaluations, ok := batchEvaluatePayload["evaluations"].([]any)
+	if !ok || len(batchEvaluations) != 1 {
+		t.Fatalf("batch evaluate payload = %#v, want 1 evaluation", batchEvaluatePayload["evaluations"])
+	}
+	batchEvaluation, ok := batchEvaluations[0].(map[string]any)
+	if !ok {
+		t.Fatalf("batch evaluation entry = %#v, want object", batchEvaluations[0])
+	}
+	batchRule, ok := batchEvaluation["rule"].(map[string]any)
+	if !ok || batchRule["id"] != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("batch evaluation rule = %#v, want builtin rule", batchEvaluation["rule"])
+	}
+	batchEvidence, ok := batchEvaluation["evidence"].([]any)
+	if !ok || len(batchEvidence) != 1 {
+		t.Fatalf("batch evaluation evidence = %#v, want 1 entry", batchEvaluation["evidence"])
+	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	evaluateFindingsResp, err := client.EvaluateSourceRuntimeFindings(context.Background(), connect.NewRequest(&cerebrov1.EvaluateSourceRuntimeFindingsRequest{
@@ -1229,6 +1265,25 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := len(listRunsResp.Msg.GetRuns()); got != 1 {
 		t.Fatalf("len(ListFindingEvaluationRuns().Runs) = %d, want 1", got)
 	}
+	evaluateFindingRulesResp, err := client.EvaluateSourceRuntimeFindingRules(context.Background(), connect.NewRequest(&cerebrov1.EvaluateSourceRuntimeFindingRulesRequest{
+		Id:         "writer-okta-audit",
+		EventLimit: 2,
+	}))
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeFindingRules() error = %v", err)
+	}
+	if got := evaluateFindingRulesResp.Msg.GetEventsEvaluated(); got != 2 {
+		t.Fatalf("EvaluateSourceRuntimeFindingRules events_evaluated = %d, want 2", got)
+	}
+	if got := len(evaluateFindingRulesResp.Msg.GetEvaluations()); got != 1 {
+		t.Fatalf("len(EvaluateSourceRuntimeFindingRules().Evaluations) = %d, want 1", got)
+	}
+	if got := evaluateFindingRulesResp.Msg.GetEvaluations()[0].GetRule().GetId(); got != "identity-okta-policy-rule-lifecycle-tampering" {
+		t.Fatalf("EvaluateSourceRuntimeFindingRules rule id = %q, want identity-okta-policy-rule-lifecycle-tampering", got)
+	}
+	if got := len(evaluateFindingRulesResp.Msg.GetEvaluations()[0].GetEvidence()); got != 1 {
+		t.Fatalf("len(EvaluateSourceRuntimeFindingRules().Evaluations[0].Evidence) = %d, want 1", got)
+	}
 	listEvidenceResp, err := client.ListFindingEvidence(context.Background(), connect.NewRequest(&cerebrov1.ListFindingEvidenceRequest{
 		RuntimeId:    "writer-okta-audit",
 		FindingId:    evaluateFindingsResp.Msg.GetFindings()[0].GetId(),
@@ -1275,14 +1330,14 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := runtimeStore.findingEvidenceListRequest.EventID; got != "okta-audit-2" {
 		t.Fatalf("runtimeStore.findingEvidenceListRequest.EventID = %q, want okta-audit-2", got)
 	}
-	if len(runtimeStore.findingEvaluationRuns) != 2 {
-		t.Fatalf("len(runtimeStore.findingEvaluationRuns) = %d, want 2", len(runtimeStore.findingEvaluationRuns))
+	if len(runtimeStore.findingEvaluationRuns) != 4 {
+		t.Fatalf("len(runtimeStore.findingEvaluationRuns) = %d, want 4", len(runtimeStore.findingEvaluationRuns))
 	}
 	if len(runtimeStore.findings) != 1 {
 		t.Fatalf("len(runtimeStore.findings) = %d, want 1", len(runtimeStore.findings))
 	}
-	if len(runtimeStore.findingEvidence) != 2 {
-		t.Fatalf("len(runtimeStore.findingEvidence) = %d, want 2", len(runtimeStore.findingEvidence))
+	if len(runtimeStore.findingEvidence) != 4 {
+		t.Fatalf("len(runtimeStore.findingEvidence) = %d, want 4", len(runtimeStore.findingEvidence))
 	}
 }
 

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -199,7 +199,7 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	}
 	normalizedLimit := normalizeEventLimit(request.EventLimit)
 	startedAt := time.Now().UTC()
-	run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), request.EventLimit, startedAt)
+	run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), normalizedLimit, startedAt)
 	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
 		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
 	}

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -58,6 +58,13 @@ type EvaluateRequest struct {
 	EventLimit uint32
 }
 
+// EvaluateRulesRequest scopes one replay-backed multi-rule evaluation.
+type EvaluateRulesRequest struct {
+	RuntimeID  string
+	RuleIDs    []string
+	EventLimit uint32
+}
+
 // ListRequest scopes one persisted finding query.
 type ListRequest struct {
 	RuntimeID   string
@@ -78,6 +85,21 @@ type EvaluateResult struct {
 	Findings        []*ports.FindingRecord
 	Run             *cerebrov1.FindingEvaluationRun
 	Evidence        []*cerebrov1.FindingEvidence
+}
+
+// RuleEvaluationResult reports one rule's outputs inside a multi-rule evaluation pass.
+type RuleEvaluationResult struct {
+	Rule     *cerebrov1.RuleSpec
+	Findings []*ports.FindingRecord
+	Run      *cerebrov1.FindingEvaluationRun
+	Evidence []*cerebrov1.FindingEvidence
+}
+
+// EvaluateRulesResult reports one multi-rule evaluation over one runtime replay.
+type EvaluateRulesResult struct {
+	Runtime         *cerebrov1.SourceRuntime
+	EventsEvaluated uint32
+	Evaluations     []*RuleEvaluationResult
 }
 
 // ListResult reports one persisted finding query.
@@ -228,6 +250,111 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	return result, nil
 }
 
+// EvaluateSourceRuntimeRules replays one runtime once and evaluates one or more registered rules over that shared pass.
+func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request EvaluateRulesRequest) (*EvaluateRulesResult, error) {
+	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.store == nil || s.runStore == nil || s.evidenceStore == nil || s.claimStore == nil || s.rules == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, errors.New("source runtime id is required")
+	}
+	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	rules, err := s.selectRules(runtime, request.RuleIDs)
+	if err != nil {
+		return nil, err
+	}
+	startedAt := time.Now().UTC()
+	states := make([]*ruleEvaluationState, 0, len(rules))
+	result := &EvaluateRulesResult{
+		Runtime:     runtime,
+		Evaluations: make([]*RuleEvaluationResult, 0, len(rules)),
+	}
+	for _, rule := range rules {
+		run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), request.EventLimit, startedAt)
+		if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
+			return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
+		}
+		state := &ruleEvaluationState{
+			rule: rule,
+			result: &RuleEvaluationResult{
+				Rule: rule.Spec(),
+				Run:  run,
+			},
+		}
+		states = append(states, state)
+		result.Evaluations = append(result.Evaluations, state.result)
+	}
+	events, err := s.replayer.Replay(ctx, ports.ReplayRequest{
+		RuntimeID: runtimeID,
+		Limit:     normalizeEventLimit(request.EventLimit),
+	})
+	if err != nil {
+		evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
+		for _, state := range states {
+			if failErr := s.markRuleEvaluationFailed(ctx, state, evaluationErr); failErr != nil {
+				return nil, failErr
+			}
+		}
+		return nil, evaluationErr
+	}
+	result.EventsEvaluated = uint32(len(events))
+	for _, event := range events {
+		for _, state := range states {
+			if state.failed {
+				continue
+			}
+			state.eventsEvaluated++
+			emitted, err := state.rule.Evaluate(ctx, runtime, event)
+			if err != nil {
+				if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("evaluate finding rule %q for event %q: %w", state.result.Rule.GetId(), event.GetId(), err)); failErr != nil {
+					return nil, failErr
+				}
+				continue
+			}
+			for _, record := range emitted {
+				if record == nil {
+					continue
+				}
+				stored, err := s.store.UpsertFinding(ctx, record)
+				if err != nil {
+					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("persist finding for rule %q event %q: %w", state.result.Rule.GetId(), event.GetId(), err)); failErr != nil {
+						return nil, failErr
+					}
+					break
+				}
+				state.result.Findings = append(state.result.Findings, stored)
+				evidence, err := s.buildFindingEvidence(ctx, stored, state.result.Run)
+				if err != nil {
+					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("build evidence for finding %q: %w", stored.ID, err)); failErr != nil {
+						return nil, failErr
+					}
+					break
+				}
+				if err := s.evidenceStore.PutFindingEvidence(ctx, evidence); err != nil {
+					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("persist evidence for finding %q: %w", stored.ID, err)); failErr != nil {
+						return nil, failErr
+					}
+					break
+				}
+				state.result.Evidence = append(state.result.Evidence, evidence)
+			}
+		}
+	}
+	for _, state := range states {
+		if state.failed {
+			continue
+		}
+		if err := s.finishCompletedRun(ctx, state.result.Run, state.eventsEvaluated, findingIDs(state.result.Findings)); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
 // ListFindings loads persisted findings for one runtime.
 func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListResult, error) {
 	if s == nil || s.runtimeStore == nil || s.store == nil {
@@ -340,6 +467,13 @@ func (s *Service) GetEvidence(ctx context.Context, id string) (*cerebrov1.Findin
 	return evidence, nil
 }
 
+type ruleEvaluationState struct {
+	rule            Rule
+	result          *RuleEvaluationResult
+	eventsEvaluated uint32
+	failed          bool
+}
+
 func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (Rule, error) {
 	trimmedRuleID := strings.TrimSpace(ruleID)
 	if trimmedRuleID != "" {
@@ -361,6 +495,40 @@ func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (R
 	default:
 		return nil, fmt.Errorf("%w for runtime %q", ErrRuleSelectionRequired, strings.TrimSpace(runtime.GetId()))
 	}
+}
+
+func (s *Service) selectRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string) ([]Rule, error) {
+	if len(ruleIDs) == 0 {
+		applicable := s.rules.ForRuntime(runtime)
+		if len(applicable) == 0 {
+			return nil, fmt.Errorf("%w: %s", ErrRuleUnavailable, strings.TrimSpace(runtime.GetId()))
+		}
+		return applicable, nil
+	}
+	selected := make([]Rule, 0, len(ruleIDs))
+	seen := make(map[string]struct{}, len(ruleIDs))
+	for _, rawID := range ruleIDs {
+		trimmedID := strings.TrimSpace(rawID)
+		if trimmedID == "" {
+			continue
+		}
+		if _, ok := seen[trimmedID]; ok {
+			continue
+		}
+		rule, ok := s.rules.Get(trimmedID)
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", ErrRuleNotFound, trimmedID)
+		}
+		if !rule.SupportsRuntime(runtime) {
+			return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedID)
+		}
+		seen[trimmedID] = struct{}{}
+		selected = append(selected, rule)
+	}
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("%w for runtime %q", ErrRuleSelectionRequired, strings.TrimSpace(runtime.GetId()))
+	}
+	return selected, nil
 }
 
 func normalizeEventLimit(limit uint32) uint32 {
@@ -425,6 +593,24 @@ func (s *Service) finishFailedRun(ctx context.Context, run *cerebrov1.FindingEva
 		)
 	}
 	return evaluationErr
+}
+
+func (s *Service) markRuleEvaluationFailed(ctx context.Context, state *ruleEvaluationState, evaluationErr error) error {
+	if state == nil || state.result == nil || state.result.Run == nil {
+		return evaluationErr
+	}
+	state.failed = true
+	run := state.result.Run
+	run.Status = "failed"
+	run.EventsEvaluated = state.eventsEvaluated
+	run.FindingsUpserted = uint32(len(state.result.Findings))
+	run.FindingIds = append([]string(nil), findingIDs(state.result.Findings)...)
+	run.Error = strings.TrimSpace(evaluationErr.Error())
+	run.FinishedAt = timestamppb.New(time.Now().UTC())
+	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
+		return fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
+	}
+	return nil
 }
 
 func findingIDs(findings []*ports.FindingRecord) []string {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -197,6 +197,7 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	if err != nil {
 		return nil, err
 	}
+	normalizedLimit := normalizeEventLimit(request.EventLimit)
 	startedAt := time.Now().UTC()
 	run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), request.EventLimit, startedAt)
 	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
@@ -204,7 +205,7 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	}
 	events, err := s.replayer.Replay(ctx, ports.ReplayRequest{
 		RuntimeID: runtimeID,
-		Limit:     normalizeEventLimit(request.EventLimit),
+		Limit:     normalizedLimit,
 	})
 	if err != nil {
 		evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
@@ -267,6 +268,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 	if err != nil {
 		return nil, err
 	}
+	normalizedLimit := normalizeEventLimit(request.EventLimit)
 	startedAt := time.Now().UTC()
 	states := make([]*ruleEvaluationState, 0, len(rules))
 	result := &EvaluateRulesResult{
@@ -274,9 +276,15 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 		Evaluations: make([]*RuleEvaluationResult, 0, len(rules)),
 	}
 	for _, rule := range rules {
-		run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), request.EventLimit, startedAt)
+		run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), normalizedLimit, startedAt)
 		if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
-			return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
+			evaluationErr := fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
+			for _, state := range states {
+				if failErr := s.markRuleEvaluationFailed(ctx, state, evaluationErr); failErr != nil {
+					return nil, failErr
+				}
+			}
+			return nil, evaluationErr
 		}
 		state := &ruleEvaluationState{
 			rule: rule,
@@ -290,7 +298,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 	}
 	events, err := s.replayer.Replay(ctx, ports.ReplayRequest{
 		RuntimeID: runtimeID,
-		Limit:     normalizeEventLimit(request.EventLimit),
+		Limit:     normalizedLimit,
 	})
 	if err != nil {
 		evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -230,6 +230,52 @@ func (s *stubFindingStore) ListFindingEvidence(_ context.Context, request ports.
 	return evidence, nil
 }
 
+type emittingRule struct {
+	spec               *cerebrov1.RuleSpec
+	supportedSourceIDs map[string]struct{}
+	triggerEventID     string
+}
+
+func (r *emittingRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return r.spec
+}
+
+func (r *emittingRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	_, ok := r.supportedSourceIDs[runtime.GetSourceId()]
+	return ok
+}
+
+func (r *emittingRule) Evaluate(_ context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	if r == nil || runtime == nil || event == nil || strings.TrimSpace(event.GetId()) != strings.TrimSpace(r.triggerEventID) {
+		return nil, nil
+	}
+	observedAt := event.GetOccurredAt().AsTime().UTC()
+	id := strings.TrimSpace(r.spec.GetId()) + "-" + strings.TrimSpace(event.GetId())
+	return []*ports.FindingRecord{
+		{
+			ID:              id,
+			Fingerprint:     id,
+			TenantID:        strings.TrimSpace(event.GetTenantId()),
+			RuntimeID:       strings.TrimSpace(runtime.GetId()),
+			RuleID:          strings.TrimSpace(r.spec.GetId()),
+			Title:           firstNonEmpty(r.spec.GetName(), strings.TrimSpace(r.spec.GetId())),
+			Severity:        "MEDIUM",
+			Status:          "open",
+			Summary:         strings.TrimSpace(r.spec.GetId()) + " summary",
+			ResourceURNs:    []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+			EventIDs:        []string{strings.TrimSpace(event.GetId())},
+			FirstObservedAt: observedAt,
+			LastObservedAt:  observedAt,
+		},
+	}, nil
+}
+
 func TestEvaluateSourceRuntimeFindingsReplaysOktaPolicyRuleLifecycleTampering(t *testing.T) {
 	replayer := &stubReplayer{
 		events: []*cerebrov1.EventEnvelope{
@@ -487,6 +533,184 @@ func TestEvaluateSourceRuntimeFindingsRejectsUnsupportedRule(t *testing.T) {
 		RuleID:    oktaPolicyRuleLifecycleTamperingRuleID,
 	}); !errors.Is(err, ErrRuleUnsupported) {
 		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuleUnsupported)
+	}
+}
+
+func TestEvaluateSourceRuntimeRulesReplaysOnceAcrossMultipleRules(t *testing.T) {
+	registry, err := NewRegistry(
+		&emittingRule{
+			spec: &cerebrov1.RuleSpec{
+				Id:   "rule-a",
+				Name: "Rule A",
+			},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			triggerEventID:     "okta-audit-2",
+		},
+		&emittingRule{
+			spec: &cerebrov1.RuleSpec{
+				Id:   "rule-b",
+				Name: "Rule B",
+			},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			triggerEventID:     "okta-audit-3",
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	replayer := &stubReplayer{
+		events: []*cerebrov1.EventEnvelope{
+			newAuditEvent("okta-audit-2", "policy.rule.update", "SUCCESS"),
+			newAuditEvent("okta-audit-3", "policy.rule.delete", "SUCCESS"),
+		},
+	}
+	store := &stubFindingStore{
+		claims: map[string]*ports.ClaimRecord{
+			"claim-1": {
+				ID:            "claim-1",
+				RuntimeID:     "writer-okta-audit",
+				TenantID:      "writer",
+				SourceEventID: "okta-audit-2",
+				ObservedAt:    time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC),
+			},
+			"claim-2": {
+				ID:            "claim-2",
+				RuntimeID:     "writer-okta-audit",
+				TenantID:      "writer",
+				SourceEventID: "okta-audit-3",
+				ObservedAt:    time.Date(2026, 4, 23, 12, 1, 0, 0, time.UTC),
+			},
+		},
+	}
+	service := NewWithRegistry(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		replayer,
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+	result, err := service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{
+		RuntimeID:  "writer-okta-audit",
+		EventLimit: 2,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v", err)
+	}
+	if got := result.EventsEvaluated; got != 2 {
+		t.Fatalf("EvaluateSourceRuntimeRules().EventsEvaluated = %d, want 2", got)
+	}
+	if got := replayer.request.Limit; got != 2 {
+		t.Fatalf("Replay().Limit = %d, want 2", got)
+	}
+	if got := len(result.Evaluations); got != 2 {
+		t.Fatalf("len(EvaluateSourceRuntimeRules().Evaluations) = %d, want 2", got)
+	}
+	if got := result.Evaluations[0].Rule.GetId(); got != "rule-a" {
+		t.Fatalf("EvaluateSourceRuntimeRules().Evaluations[0].Rule.Id = %q, want rule-a", got)
+	}
+	if got := result.Evaluations[1].Rule.GetId(); got != "rule-b" {
+		t.Fatalf("EvaluateSourceRuntimeRules().Evaluations[1].Rule.Id = %q, want rule-b", got)
+	}
+	if got := len(result.Evaluations[0].Findings); got != 1 {
+		t.Fatalf("len(EvaluateSourceRuntimeRules().Evaluations[0].Findings) = %d, want 1", got)
+	}
+	if got := len(result.Evaluations[1].Findings); got != 1 {
+		t.Fatalf("len(EvaluateSourceRuntimeRules().Evaluations[1].Findings) = %d, want 1", got)
+	}
+	if got := result.Evaluations[0].Run.GetStatus(); got != "completed" {
+		t.Fatalf("EvaluateSourceRuntimeRules().Evaluations[0].Run.Status = %q, want completed", got)
+	}
+	if got := result.Evaluations[1].Run.GetStatus(); got != "completed" {
+		t.Fatalf("EvaluateSourceRuntimeRules().Evaluations[1].Run.Status = %q, want completed", got)
+	}
+	if got := len(result.Evaluations[0].Evidence); got != 1 {
+		t.Fatalf("len(EvaluateSourceRuntimeRules().Evaluations[0].Evidence) = %d, want 1", got)
+	}
+	if got := len(result.Evaluations[1].Evidence); got != 1 {
+		t.Fatalf("len(EvaluateSourceRuntimeRules().Evaluations[1].Evidence) = %d, want 1", got)
+	}
+	if got := result.Evaluations[0].Evidence[0].GetClaimIds()[0]; got != "claim-1" {
+		t.Fatalf("EvaluateSourceRuntimeRules().Evaluations[0].Evidence[0].ClaimIds[0] = %q, want claim-1", got)
+	}
+	if got := result.Evaluations[1].Evidence[0].GetClaimIds()[0]; got != "claim-2" {
+		t.Fatalf("EvaluateSourceRuntimeRules().Evaluations[1].Evidence[0].ClaimIds[0] = %q, want claim-2", got)
+	}
+	if got := len(store.evidence); got != 2 {
+		t.Fatalf("len(store.evidence) = %d, want 2", got)
+	}
+}
+
+func TestEvaluateSourceRuntimeRulesSelectsExplicitRules(t *testing.T) {
+	registry, err := NewRegistry(
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			triggerEventID:     "okta-audit-2",
+		},
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			triggerEventID:     "okta-audit-3",
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{
+		claims: map[string]*ports.ClaimRecord{
+			"claim-2": {
+				ID:            "claim-2",
+				RuntimeID:     "writer-okta-audit",
+				TenantID:      "writer",
+				SourceEventID: "okta-audit-3",
+				ObservedAt:    time.Date(2026, 4, 23, 12, 1, 0, 0, time.UTC),
+			},
+		},
+	}
+	service := NewWithRegistry(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{
+			events: []*cerebrov1.EventEnvelope{
+				newAuditEvent("okta-audit-2", "policy.rule.update", "SUCCESS"),
+				newAuditEvent("okta-audit-3", "policy.rule.delete", "SUCCESS"),
+			},
+		},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+	result, err := service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{
+		RuntimeID: "writer-okta-audit",
+		RuleIDs:   []string{"rule-b"},
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v", err)
+	}
+	if got := len(result.Evaluations); got != 1 {
+		t.Fatalf("len(EvaluateSourceRuntimeRules().Evaluations) = %d, want 1", got)
+	}
+	if got := result.Evaluations[0].Rule.GetId(); got != "rule-b" {
+		t.Fatalf("EvaluateSourceRuntimeRules().Evaluations[0].Rule.Id = %q, want rule-b", got)
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -53,6 +53,9 @@ type stubFindingStore struct {
 	claims           map[string]*ports.ClaimRecord
 	claimListRequest ports.ListClaimsRequest
 	runs             map[string]*cerebrov1.FindingEvaluationRun
+	putRunCalls      int
+	putRunErr        error
+	putRunErrOnCall  int
 	runList          ports.ListFindingEvaluationRunsRequest
 	evidence         map[string]*cerebrov1.FindingEvidence
 	evidenceList     ports.ListFindingEvidenceRequest
@@ -145,6 +148,10 @@ func (s *stubFindingStore) ListClaims(_ context.Context, request ports.ListClaim
 func (s *stubFindingStore) PutFindingEvaluationRun(_ context.Context, run *cerebrov1.FindingEvaluationRun) error {
 	if run == nil {
 		return errors.New("finding evaluation run is required")
+	}
+	s.putRunCalls++
+	if s.putRunErr != nil && s.putRunCalls == s.putRunErrOnCall {
+		return s.putRunErr
 	}
 	if s.runs == nil {
 		s.runs = make(map[string]*cerebrov1.FindingEvaluationRun)
@@ -398,6 +405,33 @@ func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T
 	}
 }
 
+func TestEvaluateSourceRuntimeFindingsStoresNormalizedEventLimit(t *testing.T) {
+	replayer := &stubReplayer{}
+	store := &stubFindingStore{}
+	service := New(&stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {
+				Id:       "writer-okta-audit",
+				SourceId: "okta",
+				TenantId: "writer",
+			},
+		},
+	}, replayer, store, store, store, store)
+
+	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-okta-audit",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntime() error = %v", err)
+	}
+	if got := replayer.request.Limit; got != defaultEventLimit {
+		t.Fatalf("Replay().Limit = %d, want %d", got, defaultEventLimit)
+	}
+	if got := result.Run.GetEventLimit(); got != defaultEventLimit {
+		t.Fatalf("Run.EventLimit = %d, want %d", got, defaultEventLimit)
+	}
+}
+
 func TestListRulesReturnsBuiltinCatalog(t *testing.T) {
 	service := New(nil, nil, nil, nil, nil, nil)
 	response := service.ListRules()
@@ -647,6 +681,64 @@ func TestEvaluateSourceRuntimeRulesReplaysOnceAcrossMultipleRules(t *testing.T) 
 	}
 	if got := len(store.evidence); got != 2 {
 		t.Fatalf("len(store.evidence) = %d, want 2", got)
+	}
+}
+
+func TestEvaluateSourceRuntimeRulesMarksStartedRunsFailedWhenLaterRunPersistFails(t *testing.T) {
+	persistErr := errors.New("persist run failed")
+	registry, err := NewRegistry(
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{
+		putRunErr:       persistErr,
+		putRunErrOnCall: 2,
+	}
+	service := NewWithRegistry(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubReplayer{},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	if _, err := service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{
+		RuntimeID: "writer-okta-audit",
+	}); !errors.Is(err, persistErr) {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v, want %v", err, persistErr)
+	}
+	if len(store.runs) != 1 {
+		t.Fatalf("len(store.runs) = %d, want 1", len(store.runs))
+	}
+	for _, run := range store.runs {
+		if got := run.GetStatus(); got != "failed" {
+			t.Fatalf("Run.Status = %q, want failed", got)
+		}
+		if run.GetFinishedAt() == nil {
+			t.Fatal("Run.FinishedAt = nil, want timestamp")
+		}
+		if run.GetError() == "" {
+			t.Fatal("Run.Error = empty, want failure detail")
+		}
 	}
 }
 

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -31,6 +31,7 @@ service BootstrapService {
   rpc GetFindingEvaluationRun(GetFindingEvaluationRunRequest) returns (GetFindingEvaluationRunResponse);
   rpc ListFindingEvidence(ListFindingEvidenceRequest) returns (ListFindingEvidenceResponse);
   rpc GetFindingEvidence(GetFindingEvidenceRequest) returns (GetFindingEvidenceResponse);
+  rpc EvaluateSourceRuntimeFindingRules(EvaluateSourceRuntimeFindingRulesRequest) returns (EvaluateSourceRuntimeFindingRulesResponse);
   rpc EvaluateSourceRuntimeFindings(EvaluateSourceRuntimeFindingsRequest) returns (EvaluateSourceRuntimeFindingsResponse);
   rpc GetEntityNeighborhood(GetEntityNeighborhoodRequest) returns (GetEntityNeighborhoodResponse);
 }
@@ -381,6 +382,28 @@ message EvaluateSourceRuntimeFindingsRequest {
   string id = 1;
   uint32 event_limit = 2;
   string rule_id = 3;
+}
+
+// EvaluateSourceRuntimeFindingRulesRequest replays one stored runtime through one or more registered finding rules.
+message EvaluateSourceRuntimeFindingRulesRequest {
+  string id = 1;
+  repeated string rule_ids = 2;
+  uint32 event_limit = 3;
+}
+
+// FindingRuleEvaluation returns the persisted outputs for one rule within a multi-rule evaluation pass.
+message FindingRuleEvaluation {
+  RuleSpec rule = 1;
+  repeated Finding findings = 2;
+  FindingEvaluationRun run = 3;
+  repeated FindingEvidence evidence = 4;
+}
+
+// EvaluateSourceRuntimeFindingRulesResponse returns one replay pass over a runtime with one result per evaluated rule.
+message EvaluateSourceRuntimeFindingRulesResponse {
+  SourceRuntime runtime = 1;
+  uint32 events_evaluated = 2;
+  repeated FindingRuleEvaluation evaluations = 3;
 }
 
 // EvaluateSourceRuntimeFindingsResponse returns the evaluated runtime, selected rule spec, and persisted findings.


### PR DESCRIPTION
## Summary
- add a batch runtime evaluation API that replays source events once and evaluates multiple finding rules in one pass
- persist per-rule evaluation runs, findings, and evidence for the shared replay
- cover HTTP and ConnectRPC surfaces plus replay-once semantics in tests

## Testing
- make verify