### PR TITLE
feat(graph): ingest live sources into Kuzu

### DIFF
--- a/cmd/cerebro/aws_github_kuzu_live_e2e_test.go
+++ b/cmd/cerebro/aws_github_kuzu_live_e2e_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	configpkg "github.com/writer/cerebro/internal/config"
+	graphstorekuzu "github.com/writer/cerebro/internal/graphstore/kuzu"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceops"
+	"github.com/writer/cerebro/internal/sourceprojection"
+	"github.com/writer/cerebro/internal/sourceregistry"
+)
+
+func TestAWSGitHubKuzuSharedIdentityLiveE2E(t *testing.T) {
+	if os.Getenv("CEREBRO_RUN_AWS_GITHUB_KUZU_E2E") != "1" {
+		t.Skip("set CEREBRO_RUN_AWS_GITHUB_KUZU_E2E=1 to run the live AWS/GitHub Kuzu e2e flow")
+	}
+	ctx := context.Background()
+	sharedEmail := requiredEnv(t, "CEREBRO_AWS_GITHUB_SHARED_EMAIL")
+	tenantID := envOrDefault("CEREBRO_AWS_GITHUB_TENANT_ID", "writer")
+	pageLimit := uint32EnvOrDefault(t, "CEREBRO_AWS_GITHUB_PAGE_LIMIT", 1)
+
+	registry, err := sourceregistry.Builtin()
+	if err != nil {
+		t.Fatalf("Builtin() error = %v", err)
+	}
+	graphPath := filepath.Join(t.TempDir(), "graph")
+	store, err := graphstorekuzu.Open(configpkg.GraphStoreConfig{
+		Driver:   configpkg.GraphStoreDriverKuzu,
+		KuzuPath: graphPath,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer func() {
+		if closeErr := store.Close(); closeErr != nil {
+			t.Fatalf("Close() error = %v", closeErr)
+		}
+	}()
+	projector := sourceprojection.New(nil, store)
+	sourceService := sourceops.New(registry)
+
+	githubConfig, err := prepareSourceConfigWithCLI(ctx, githubSourceID, "read", map[string]string{
+		"family":   "audit",
+		"include":  "all",
+		"order":    "desc",
+		"owner":    envOrDefault("CEREBRO_GITHUB_OWNER", "WriterInternal"),
+		"per_page": "5",
+		"phrase":   requiredEnv(t, "CEREBRO_GITHUB_AUDIT_PHRASE"),
+	}, execGitHubLocalCLI{})
+	if err != nil {
+		t.Fatalf("prepareSourceConfigWithCLI() error = %v", err)
+	}
+	githubResult, err := ingestGraph(ctx, sourceService, projector, store, graphIngestOptions{
+		SourceID:     githubSourceID,
+		SourceConfig: githubConfig,
+		TenantID:     tenantID,
+		PageLimit:    pageLimit,
+	})
+	if err != nil {
+		t.Fatalf("ingest github audit: %v", err)
+	}
+	if githubResult.EventsRead == 0 {
+		t.Fatal("github audit ingest read zero events")
+	}
+
+	awsResult, err := ingestGraph(ctx, sourceService, projector, store, graphIngestOptions{
+		SourceID: "aws",
+		SourceConfig: map[string]string{
+			"account_id":   requiredEnv(t, "CEREBRO_AWS_ACCOUNT_ID"),
+			"family":       "cloudtrail",
+			"lookup_key":   "Username",
+			"lookup_value": sharedEmail,
+			"per_page":     "5",
+			"profile":      envOrDefault("CEREBRO_AWS_PROFILE", ""),
+			"region":       envOrDefault("CEREBRO_AWS_REGION", "us-east-1"),
+		},
+		TenantID:  tenantID,
+		PageLimit: pageLimit,
+	})
+	if err != nil {
+		t.Fatalf("ingest aws cloudtrail: %v", err)
+	}
+	if awsResult.EventsRead == 0 {
+		t.Fatal("aws cloudtrail ingest read zero events")
+	}
+
+	assertIntegrityChecksPass(t, store)
+	counts, err := store.Counts(ctx)
+	if err != nil {
+		t.Fatalf("Counts() error = %v", err)
+	}
+	if counts.Nodes == 0 || counts.Relations == 0 {
+		t.Fatalf("graph counts = %#v, want non-zero nodes and relations", counts)
+	}
+	identityURN := "urn:cerebro:" + tenantID + ":identity:email:" + strings.ToLower(sharedEmail)
+	neighborhood, err := store.GetEntityNeighborhood(ctx, identityURN, 50)
+	if err != nil {
+		t.Fatalf("GetEntityNeighborhood(%q) error = %v", identityURN, err)
+	}
+	if !hasIdentityRelationFrom(neighborhood, identityURN, "github.user") {
+		t.Fatalf("identity neighborhood missing github.user relation: %#v", neighborhood.Relations)
+	}
+	if !hasIdentityRelationFrom(neighborhood, identityURN, "aws.user") {
+		t.Fatalf("identity neighborhood missing aws.user relation: %#v", neighborhood.Relations)
+	}
+	t.Logf("validated live AWS/GitHub Kuzu identity path email=%s nodes=%d relations=%d", sharedEmail, counts.Nodes, counts.Relations)
+}
+
+func hasIdentityRelationFrom(neighborhood *ports.EntityNeighborhood, identityURN string, entityType string) bool {
+	if neighborhood == nil {
+		return false
+	}
+	nodeTypes := map[string]string{}
+	if neighborhood.Root != nil {
+		nodeTypes[neighborhood.Root.URN] = neighborhood.Root.EntityType
+	}
+	for _, node := range neighborhood.Neighbors {
+		if node != nil {
+			nodeTypes[node.URN] = node.EntityType
+		}
+	}
+	for _, relation := range neighborhood.Relations {
+		if relation == nil || relation.ToURN != identityURN || relation.Relation != "represents_identity" {
+			continue
+		}
+		if nodeTypes[relation.FromURN] == entityType {
+			return true
+		}
+	}
+	return false
+}
+
+func assertIntegrityChecksPass(t *testing.T, store *graphstorekuzu.Store) {
+	t.Helper()
+	checks, err := store.IntegrityChecks(context.Background())
+	if err != nil {
+		t.Fatalf("IntegrityChecks() error = %v", err)
+	}
+	for _, check := range checks {
+		if !check.Passed {
+			t.Fatalf("integrity check %q failed: actual=%d expected=%d", check.Name, check.Actual, check.Expected)
+		}
+	}
+}
+
+func requiredEnv(t *testing.T, key string) string {
+	t.Helper()
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		t.Fatalf("%s is required", key)
+	}
+	return value
+}
+
+func envOrDefault(key string, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func uint32EnvOrDefault(t *testing.T, key string, fallback uint32) uint32 {
+	t.Helper()
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		t.Fatalf("parse %s: %v", key, err)
+	}
+	if parsed == 0 {
+		t.Fatalf("%s must be greater than zero", key)
+	}
+	return uint32(parsed)
+}

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -9,18 +9,84 @@ import (
 	"strconv"
 	"strings"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/bootstrap"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphrebuild"
+	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceregistry"
+	"google.golang.org/protobuf/proto"
 )
+
+const (
+	defaultGraphIngestPageLimit = 1
+	maxGraphIngestPageLimit     = 100
+)
+
+type graphCountsStore interface {
+	Counts(context.Context) (graphstore.Counts, error)
+}
+
+type graphIngestResult struct {
+	SourceID          string `json:"source_id"`
+	TenantID          string `json:"tenant_id,omitempty"`
+	PagesRead         uint32 `json:"pages_read"`
+	EventsRead        uint32 `json:"events_read"`
+	EntitiesProjected uint32 `json:"entities_projected"`
+	LinksProjected    uint32 `json:"links_projected"`
+	GraphNodesBefore  int64  `json:"graph_nodes_before,omitempty"`
+	GraphLinksBefore  int64  `json:"graph_links_before,omitempty"`
+	GraphNodesAfter   int64  `json:"graph_nodes_after,omitempty"`
+	GraphLinksAfter   int64  `json:"graph_links_after,omitempty"`
+	NextCursor        string `json:"next_cursor,omitempty"`
+}
 
 func runGraph(args []string) error {
 	if len(args) == 0 {
-		return usageError(fmt.Sprintf("usage: %s graph rebuild <runtime-id> [dry_run=true] [mode=source|replay] [page_limit=N] [event_limit=N] [preview_limit=N]", os.Args[0]))
+		return usageError(graphUsage())
 	}
 	switch args[0] {
+	case "ingest":
+		sourceID, sourceConfig, tenantID, pageLimit, cursor, err := parseGraphIngestArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		cfg, err := config.Load()
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		ctx := context.Background()
+		deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+		if err != nil {
+			return fmt.Errorf("open dependencies: %w", err)
+		}
+		defer func() {
+			if err := closeDeps(); err != nil {
+				log.Printf("close dependencies: %v", err)
+			}
+		}()
+		if deps.GraphStore == nil {
+			return fmt.Errorf("graph store is required")
+		}
+		sourceConfig, err = prepareSourceConfig(ctx, sourceID, "read", sourceConfig)
+		if err != nil {
+			return err
+		}
+		registry, err := sourceregistry.Builtin()
+		if err != nil {
+			return fmt.Errorf("open source registry: %w", err)
+		}
+		projector := sourceProjector(nil, deps.GraphStore)
+		if projector == nil {
+			return fmt.Errorf("projection graph store is required")
+		}
+		result, err := ingestGraph(ctx, sourceops.New(registry), projector, deps.GraphStore, sourceID, sourceConfig, tenantID, pageLimit, cursor)
+		if err != nil {
+			return err
+		}
+		return printJSON(result)
 	case "rebuild":
 		runtimeID, mode, pageLimit, eventLimit, previewLimit, dryRun, err := parseGraphRebuildArgs(args[1:])
 		if err != nil {
@@ -66,8 +132,128 @@ func runGraph(args []string) error {
 		}
 		return printJSON(result)
 	default:
-		return usageError(fmt.Sprintf("usage: %s graph rebuild <runtime-id> [dry_run=true] [mode=source|replay] [page_limit=N] [event_limit=N] [preview_limit=N]", os.Args[0]))
+		return usageError(graphUsage())
 	}
+}
+
+func graphUsage() string {
+	return fmt.Sprintf("usage: %s graph [ingest|rebuild] ...", os.Args[0])
+}
+
+func graphIngestUsage() string {
+	return fmt.Sprintf("usage: %s graph ingest <source-id> [tenant_id=<tenant-id>] [page_limit=N] [cursor=<cursor>] [key=value ...]", os.Args[0])
+}
+
+func parseGraphIngestArgs(args []string) (string, map[string]string, string, uint32, *cerebrov1.SourceCursor, error) {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return "", nil, "", 0, nil, usageError(graphIngestUsage())
+	}
+	sourceID := strings.TrimSpace(args[0])
+	sourceConfig := make(map[string]string)
+	pageLimit := uint32(defaultGraphIngestPageLimit)
+	var (
+		cursor   *cerebrov1.SourceCursor
+		tenantID string
+	)
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return "", nil, "", 0, nil, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		switch strings.TrimSpace(key) {
+		case "cursor":
+			if strings.TrimSpace(value) != "" {
+				cursor = &cerebrov1.SourceCursor{Opaque: strings.TrimSpace(value)}
+			}
+		case "page_limit":
+			parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+			if err != nil {
+				return "", nil, "", 0, nil, fmt.Errorf("parse page_limit: %w", err)
+			}
+			if parsed == 0 || parsed > maxGraphIngestPageLimit {
+				return "", nil, "", 0, nil, fmt.Errorf("page_limit must be between 1 and %d", maxGraphIngestPageLimit)
+			}
+			pageLimit = uint32(parsed)
+		case "tenant_id":
+			tenantID = strings.TrimSpace(value)
+		default:
+			sourceConfig[strings.TrimSpace(key)] = value
+		}
+	}
+	return sourceID, sourceConfig, tenantID, pageLimit, cursor, nil
+}
+
+func ingestGraph(
+	ctx context.Context,
+	sourceService *sourceops.Service,
+	projector ports.SourceProjector,
+	graphStore ports.GraphStore,
+	sourceID string,
+	sourceConfig map[string]string,
+	tenantID string,
+	pageLimit uint32,
+	cursor *cerebrov1.SourceCursor,
+) (*graphIngestResult, error) {
+	result := &graphIngestResult{
+		SourceID: strings.TrimSpace(sourceID),
+		TenantID: strings.TrimSpace(tenantID),
+	}
+	countsStore, hasCounts := graphStore.(graphCountsStore)
+	if hasCounts {
+		counts, err := countsStore.Counts(ctx)
+		if err != nil {
+			return nil, err
+		}
+		result.GraphNodesBefore = counts.Nodes
+		result.GraphLinksBefore = counts.Relations
+	}
+	for i := uint32(0); i < pageLimit; i++ {
+		response, err := sourceService.Read(ctx, &cerebrov1.ReadSourceRequest{
+			SourceId: sourceID,
+			Config:   sourceConfig,
+			Cursor:   cursor,
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.PagesRead++
+		for _, event := range response.GetEvents() {
+			projected, err := projector.Project(ctx, graphIngestEvent(event, tenantID))
+			if err != nil {
+				return nil, fmt.Errorf("project source event %q: %w", event.GetId(), err)
+			}
+			result.EventsRead++
+			result.EntitiesProjected += projected.EntitiesProjected
+			result.LinksProjected += projected.LinksProjected
+		}
+		cursor = response.GetNextCursor()
+		if cursor == nil {
+			break
+		}
+	}
+	if cursor != nil {
+		result.NextCursor = strings.TrimSpace(cursor.GetOpaque())
+	}
+	if hasCounts {
+		counts, err := countsStore.Counts(ctx)
+		if err != nil {
+			return nil, err
+		}
+		result.GraphNodesAfter = counts.Nodes
+		result.GraphLinksAfter = counts.Relations
+	}
+	return result, nil
+}
+
+func graphIngestEvent(event *cerebrov1.EventEnvelope, tenantID string) *cerebrov1.EventEnvelope {
+	if event == nil {
+		return nil
+	}
+	cloned := proto.Clone(event).(*cerebrov1.EventEnvelope)
+	if normalized := strings.TrimSpace(tenantID); normalized != "" {
+		cloned.TenantId = normalized
+	}
+	return cloned
 }
 
 func parseGraphRebuildArgs(args []string) (string, string, uint32, uint32, int, bool, error) {

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/bootstrap"
@@ -29,18 +33,66 @@ type graphCountsStore interface {
 	Counts(context.Context) (graphstore.Counts, error)
 }
 
+type graphQueryStore interface {
+	GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error)
+}
+
+type graphPathStore interface {
+	PathPatterns(context.Context, int) ([]graphstore.PathPattern, error)
+	SampleTraversals(context.Context, int) ([]graphstore.Traversal, error)
+	Topology(context.Context) (graphstore.Topology, error)
+}
+
+type graphIntegrityStore interface {
+	IntegrityChecks(context.Context) ([]graphstore.IntegrityCheck, error)
+}
+
+type graphIngestCheckpointStore interface {
+	GetIngestCheckpoint(context.Context, string) (graphstore.IngestCheckpoint, bool, error)
+	PutIngestCheckpoint(context.Context, graphstore.IngestCheckpoint) error
+}
+
+type graphIngestOptions struct {
+	SourceID          string
+	SourceConfig      map[string]string
+	TenantID          string
+	PageLimit         uint32
+	Cursor            *cerebrov1.SourceCursor
+	CheckpointEnabled bool
+	CheckpointID      string
+	ResetCheckpoint   bool
+}
+
 type graphIngestResult struct {
-	SourceID          string `json:"source_id"`
-	TenantID          string `json:"tenant_id,omitempty"`
-	PagesRead         uint32 `json:"pages_read"`
-	EventsRead        uint32 `json:"events_read"`
-	EntitiesProjected uint32 `json:"entities_projected"`
-	LinksProjected    uint32 `json:"links_projected"`
-	GraphNodesBefore  int64  `json:"graph_nodes_before,omitempty"`
-	GraphLinksBefore  int64  `json:"graph_links_before,omitempty"`
-	GraphNodesAfter   int64  `json:"graph_nodes_after,omitempty"`
-	GraphLinksAfter   int64  `json:"graph_links_after,omitempty"`
-	NextCursor        string `json:"next_cursor,omitempty"`
+	SourceID               string `json:"source_id"`
+	TenantID               string `json:"tenant_id,omitempty"`
+	PagesRead              uint32 `json:"pages_read"`
+	EventsRead             uint32 `json:"events_read"`
+	EntitiesProjected      uint32 `json:"entities_projected"`
+	LinksProjected         uint32 `json:"links_projected"`
+	GraphNodesBefore       int64  `json:"graph_nodes_before,omitempty"`
+	GraphLinksBefore       int64  `json:"graph_links_before,omitempty"`
+	GraphNodesAfter        int64  `json:"graph_nodes_after,omitempty"`
+	GraphLinksAfter        int64  `json:"graph_links_after,omitempty"`
+	NextCursor             string `json:"next_cursor,omitempty"`
+	CheckpointID           string `json:"checkpoint_id,omitempty"`
+	CheckpointCursor       string `json:"checkpoint_cursor,omitempty"`
+	CheckpointResumed      bool   `json:"checkpoint_resumed,omitempty"`
+	CheckpointPersisted    bool   `json:"checkpoint_persisted,omitempty"`
+	CheckpointComplete     bool   `json:"checkpoint_complete,omitempty"`
+	CheckpointAlreadyFresh bool   `json:"checkpoint_already_fresh,omitempty"`
+}
+
+type graphPathsResult struct {
+	Patterns   []graphstore.PathPattern `json:"patterns"`
+	Traversals []graphstore.Traversal   `json:"traversals"`
+	Topology   graphstore.Topology      `json:"topology"`
+}
+
+type graphIntegrityResult struct {
+	Checks []graphstore.IntegrityCheck `json:"checks"`
+	Passed uint32                      `json:"passed"`
+	Failed uint32                      `json:"failed"`
 }
 
 func runGraph(args []string) error {
@@ -49,28 +101,17 @@ func runGraph(args []string) error {
 	}
 	switch args[0] {
 	case "ingest":
-		sourceID, sourceConfig, tenantID, pageLimit, cursor, err := parseGraphIngestArgs(args[1:])
+		options, err := parseGraphIngestArgs(args[1:])
 		if err != nil {
 			return err
 		}
-		cfg, err := config.Load()
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
 		ctx := context.Background()
-		deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+		deps, closeDeps, err := openGraphDependencies(ctx)
 		if err != nil {
-			return fmt.Errorf("open dependencies: %w", err)
+			return err
 		}
-		defer func() {
-			if err := closeDeps(); err != nil {
-				log.Printf("close dependencies: %v", err)
-			}
-		}()
-		if deps.GraphStore == nil {
-			return fmt.Errorf("graph store is required")
-		}
-		sourceConfig, err = prepareSourceConfig(ctx, sourceID, "read", sourceConfig)
+		defer logClose(closeDeps)
+		options.SourceConfig, err = prepareSourceConfig(ctx, options.SourceID, "read", options.SourceConfig)
 		if err != nil {
 			return err
 		}
@@ -82,11 +123,18 @@ func runGraph(args []string) error {
 		if projector == nil {
 			return fmt.Errorf("projection graph store is required")
 		}
-		result, err := ingestGraph(ctx, sourceops.New(registry), projector, deps.GraphStore, sourceID, sourceConfig, tenantID, pageLimit, cursor)
+		result, err := ingestGraph(ctx, sourceops.New(registry), projector, deps.GraphStore, options)
 		if err != nil {
 			return err
 		}
 		return printJSON(result)
+	case "counts", "neighborhood", "paths", "integrity":
+		return runGraphInspect(args)
+	case "inspect":
+		if len(args) < 2 {
+			return usageError(graphInspectUsage())
+		}
+		return runGraphInspect(args[1:])
 	case "rebuild":
 		runtimeID, mode, pageLimit, eventLimit, previewLimit, dryRun, err := parseGraphRebuildArgs(args[1:])
 		if err != nil {
@@ -95,20 +143,16 @@ func runGraph(args []string) error {
 		if !dryRun {
 			return fmt.Errorf("graph rebuild currently only supports dry_run=true")
 		}
+		ctx := context.Background()
 		cfg, err := config.Load()
 		if err != nil {
 			return fmt.Errorf("load config: %w", err)
 		}
-		ctx := context.Background()
 		deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
 		if err != nil {
 			return fmt.Errorf("open dependencies: %w", err)
 		}
-		defer func() {
-			if err := closeDeps(); err != nil {
-				log.Printf("close dependencies: %v", err)
-			}
-		}()
+		defer logClose(closeDeps)
 		registry, err := sourceregistry.Builtin()
 		if err != nil {
 			return fmt.Errorf("open source registry: %w", err)
@@ -137,50 +181,217 @@ func runGraph(args []string) error {
 }
 
 func graphUsage() string {
-	return fmt.Sprintf("usage: %s graph [ingest|rebuild] ...", os.Args[0])
+	return fmt.Sprintf("usage: %s graph [counts|neighborhood|paths|integrity|ingest|rebuild|inspect] ...", os.Args[0])
 }
 
 func graphIngestUsage() string {
-	return fmt.Sprintf("usage: %s graph ingest <source-id> [tenant_id=<tenant-id>] [page_limit=N] [cursor=<cursor>] [key=value ...]", os.Args[0])
+	return fmt.Sprintf("usage: %s graph ingest <source-id> [tenant_id=<tenant-id>] [page_limit=N] [cursor=<cursor>] [checkpoint=true] [checkpoint_id=<id>] [reset_checkpoint=true] [key=value ...]", os.Args[0])
 }
 
-func parseGraphIngestArgs(args []string) (string, map[string]string, string, uint32, *cerebrov1.SourceCursor, error) {
-	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
-		return "", nil, "", 0, nil, usageError(graphIngestUsage())
+func graphInspectUsage() string {
+	return fmt.Sprintf("usage: %s graph [counts|neighborhood <urn>|paths|integrity] [limit=N]", os.Args[0])
+}
+
+func runGraphInspect(args []string) error {
+	ctx := context.Background()
+	deps, closeDeps, err := openGraphDependencies(ctx)
+	if err != nil {
+		return err
 	}
-	sourceID := strings.TrimSpace(args[0])
-	sourceConfig := make(map[string]string)
-	pageLimit := uint32(defaultGraphIngestPageLimit)
-	var (
-		cursor   *cerebrov1.SourceCursor
-		tenantID string
-	)
+	defer logClose(closeDeps)
+
+	switch args[0] {
+	case "counts":
+		store, ok := deps.GraphStore.(graphCountsStore)
+		if !ok {
+			return fmt.Errorf("graph store does not support counts")
+		}
+		counts, err := store.Counts(ctx)
+		if err != nil {
+			return err
+		}
+		return printJSON(counts)
+	case "neighborhood":
+		rootURN, limit, err := parseGraphNeighborhoodArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		store, ok := deps.GraphStore.(graphQueryStore)
+		if !ok {
+			return fmt.Errorf("graph store does not support neighborhoods")
+		}
+		neighborhood, err := store.GetEntityNeighborhood(ctx, rootURN, limit)
+		if err != nil {
+			return err
+		}
+		return printJSON(neighborhood)
+	case "paths":
+		limit, err := parseGraphLimitArgs(args[1:], 10, "paths")
+		if err != nil {
+			return err
+		}
+		store, ok := deps.GraphStore.(graphPathStore)
+		if !ok {
+			return fmt.Errorf("graph store does not support paths")
+		}
+		patterns, err := store.PathPatterns(ctx, limit)
+		if err != nil {
+			return err
+		}
+		traversals, err := store.SampleTraversals(ctx, limit)
+		if err != nil {
+			return err
+		}
+		topology, err := store.Topology(ctx)
+		if err != nil {
+			return err
+		}
+		return printJSON(graphPathsResult{Patterns: patterns, Traversals: traversals, Topology: topology})
+	case "integrity":
+		store, ok := deps.GraphStore.(graphIntegrityStore)
+		if !ok {
+			return fmt.Errorf("graph store does not support integrity checks")
+		}
+		checks, err := store.IntegrityChecks(ctx)
+		if err != nil {
+			return err
+		}
+		result := graphIntegrityResult{Checks: checks}
+		for _, check := range checks {
+			if check.Passed {
+				result.Passed++
+			} else {
+				result.Failed++
+			}
+		}
+		return printJSON(result)
+	default:
+		return usageError(graphInspectUsage())
+	}
+}
+
+func parseGraphNeighborhoodArgs(args []string) (string, int, error) {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return "", 0, usageError(graphInspectUsage())
+	}
+	rootURN := strings.TrimSpace(args[0])
+	remaining := args[1:]
+	if strings.Contains(rootURN, "=") {
+		key, value, _ := strings.Cut(rootURN, "=")
+		if strings.TrimSpace(key) != "root_urn" {
+			return "", 0, usageError(graphInspectUsage())
+		}
+		rootURN = strings.TrimSpace(value)
+		remaining = args[1:]
+	}
+	limit, err := parseGraphLimitArgs(remaining, 25, "neighborhood")
+	if err != nil {
+		return "", 0, err
+	}
+	return rootURN, limit, nil
+}
+
+func parseGraphLimitArgs(args []string, defaultLimit int, command string) (int, error) {
+	limit := defaultLimit
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return 0, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		switch strings.TrimSpace(key) {
+		case "limit":
+			parsed, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil {
+				return 0, fmt.Errorf("parse limit: %w", err)
+			}
+			if parsed < 1 || parsed > 500 {
+				return 0, fmt.Errorf("limit must be between 1 and 500")
+			}
+			limit = parsed
+		default:
+			return 0, usageError(fmt.Sprintf("unsupported graph %s argument %q", command, key))
+		}
+	}
+	return limit, nil
+}
+
+func openGraphDependencies(ctx context.Context) (bootstrap.Dependencies, func() error, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return bootstrap.Dependencies{}, nil, fmt.Errorf("load config: %w", err)
+	}
+	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+	if err != nil {
+		return bootstrap.Dependencies{}, nil, fmt.Errorf("open dependencies: %w", err)
+	}
+	if deps.GraphStore == nil {
+		_ = closeDeps()
+		return bootstrap.Dependencies{}, nil, fmt.Errorf("graph store is required")
+	}
+	return deps, closeDeps, nil
+}
+
+func logClose(closeFn func() error) {
+	if closeFn == nil {
+		return
+	}
+	if err := closeFn(); err != nil {
+		log.Printf("close dependencies: %v", err)
+	}
+}
+
+func parseGraphIngestArgs(args []string) (graphIngestOptions, error) {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return graphIngestOptions{}, usageError(graphIngestUsage())
+	}
+	options := graphIngestOptions{
+		SourceID:     strings.TrimSpace(args[0]),
+		SourceConfig: make(map[string]string),
+		PageLimit:    defaultGraphIngestPageLimit,
+	}
 	for _, arg := range args[1:] {
 		key, value, ok := strings.Cut(arg, "=")
 		if !ok {
-			return "", nil, "", 0, nil, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+			return graphIngestOptions{}, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
 		}
 		switch strings.TrimSpace(key) {
 		case "cursor":
 			if strings.TrimSpace(value) != "" {
-				cursor = &cerebrov1.SourceCursor{Opaque: strings.TrimSpace(value)}
+				options.Cursor = &cerebrov1.SourceCursor{Opaque: strings.TrimSpace(value)}
 			}
 		case "page_limit":
 			parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
 			if err != nil {
-				return "", nil, "", 0, nil, fmt.Errorf("parse page_limit: %w", err)
+				return graphIngestOptions{}, fmt.Errorf("parse page_limit: %w", err)
 			}
 			if parsed == 0 || parsed > maxGraphIngestPageLimit {
-				return "", nil, "", 0, nil, fmt.Errorf("page_limit must be between 1 and %d", maxGraphIngestPageLimit)
+				return graphIngestOptions{}, fmt.Errorf("page_limit must be between 1 and %d", maxGraphIngestPageLimit)
 			}
-			pageLimit = uint32(parsed)
+			options.PageLimit = uint32(parsed)
 		case "tenant_id":
-			tenantID = strings.TrimSpace(value)
+			options.TenantID = strings.TrimSpace(value)
+		case "checkpoint":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphIngestOptions{}, fmt.Errorf("parse checkpoint: %w", err)
+			}
+			options.CheckpointEnabled = parsed
+		case "checkpoint_id":
+			options.CheckpointID = strings.TrimSpace(value)
+			if options.CheckpointID != "" {
+				options.CheckpointEnabled = true
+			}
+		case "reset_checkpoint":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphIngestOptions{}, fmt.Errorf("parse reset_checkpoint: %w", err)
+			}
+			options.ResetCheckpoint = parsed
 		default:
-			sourceConfig[strings.TrimSpace(key)] = value
+			options.SourceConfig[strings.TrimSpace(key)] = value
 		}
 	}
-	return sourceID, sourceConfig, tenantID, pageLimit, cursor, nil
+	return options, nil
 }
 
 func ingestGraph(
@@ -188,15 +399,19 @@ func ingestGraph(
 	sourceService *sourceops.Service,
 	projector ports.SourceProjector,
 	graphStore ports.GraphStore,
-	sourceID string,
-	sourceConfig map[string]string,
-	tenantID string,
-	pageLimit uint32,
-	cursor *cerebrov1.SourceCursor,
+	options graphIngestOptions,
 ) (*graphIngestResult, error) {
 	result := &graphIngestResult{
-		SourceID: strings.TrimSpace(sourceID),
-		TenantID: strings.TrimSpace(tenantID),
+		SourceID: strings.TrimSpace(options.SourceID),
+		TenantID: strings.TrimSpace(options.TenantID),
+	}
+	cursor := options.Cursor
+	checkpointStore, err := prepareGraphIngestCheckpoint(ctx, graphStore, options, result, &cursor)
+	if err != nil {
+		return nil, err
+	}
+	if result.CheckpointAlreadyFresh {
+		return result, nil
 	}
 	countsStore, hasCounts := graphStore.(graphCountsStore)
 	if hasCounts {
@@ -207,10 +422,10 @@ func ingestGraph(
 		result.GraphNodesBefore = counts.Nodes
 		result.GraphLinksBefore = counts.Relations
 	}
-	for i := uint32(0); i < pageLimit; i++ {
+	for i := uint32(0); i < options.PageLimit; i++ {
 		response, err := sourceService.Read(ctx, &cerebrov1.ReadSourceRequest{
-			SourceId: sourceID,
-			Config:   sourceConfig,
+			SourceId: options.SourceID,
+			Config:   options.SourceConfig,
 			Cursor:   cursor,
 		})
 		if err != nil {
@@ -218,7 +433,7 @@ func ingestGraph(
 		}
 		result.PagesRead++
 		for _, event := range response.GetEvents() {
-			projected, err := projector.Project(ctx, graphIngestEvent(event, tenantID))
+			projected, err := projector.Project(ctx, graphIngestEvent(event, options.TenantID))
 			if err != nil {
 				return nil, fmt.Errorf("project source event %q: %w", event.GetId(), err)
 			}
@@ -227,6 +442,11 @@ func ingestGraph(
 			result.LinksProjected += projected.LinksProjected
 		}
 		cursor = response.GetNextCursor()
+		if checkpointStore != nil {
+			if err := persistGraphIngestCheckpoint(ctx, checkpointStore, options, result, response, cursor); err != nil {
+				return nil, err
+			}
+		}
 		if cursor == nil {
 			break
 		}
@@ -243,6 +463,125 @@ func ingestGraph(
 		result.GraphLinksAfter = counts.Relations
 	}
 	return result, nil
+}
+
+func prepareGraphIngestCheckpoint(
+	ctx context.Context,
+	graphStore ports.GraphStore,
+	options graphIngestOptions,
+	result *graphIngestResult,
+	cursor **cerebrov1.SourceCursor,
+) (graphIngestCheckpointStore, error) {
+	if !options.CheckpointEnabled {
+		return nil, nil
+	}
+	checkpointStore, ok := graphStore.(graphIngestCheckpointStore)
+	if !ok {
+		return nil, fmt.Errorf("graph store does not support ingest checkpoints")
+	}
+	checkpointID := graphIngestCheckpointID(options)
+	result.CheckpointID = checkpointID
+	if options.ResetCheckpoint || *cursor != nil {
+		return checkpointStore, nil
+	}
+	checkpoint, found, err := checkpointStore.GetIngestCheckpoint(ctx, checkpointID)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return checkpointStore, nil
+	}
+	result.CheckpointResumed = true
+	result.CheckpointCursor = strings.TrimSpace(checkpoint.CursorOpaque)
+	if checkpoint.Completed && checkpoint.CursorOpaque == "" {
+		result.CheckpointComplete = true
+		result.CheckpointAlreadyFresh = true
+		return checkpointStore, nil
+	}
+	if checkpoint.CursorOpaque != "" {
+		*cursor = &cerebrov1.SourceCursor{Opaque: checkpoint.CursorOpaque}
+	}
+	return checkpointStore, nil
+}
+
+func persistGraphIngestCheckpoint(
+	ctx context.Context,
+	checkpointStore graphIngestCheckpointStore,
+	options graphIngestOptions,
+	result *graphIngestResult,
+	response *cerebrov1.ReadSourceResponse,
+	nextCursor *cerebrov1.SourceCursor,
+) error {
+	cursorOpaque := ""
+	completed := true
+	if nextCursor != nil {
+		cursorOpaque = strings.TrimSpace(nextCursor.GetOpaque())
+		completed = cursorOpaque == ""
+	}
+	checkpointOpaque := strings.TrimSpace(response.GetCheckpoint().GetCursorOpaque())
+	checkpoint := graphstore.IngestCheckpoint{
+		ID:               graphIngestCheckpointID(options),
+		SourceID:         strings.TrimSpace(options.SourceID),
+		TenantID:         strings.TrimSpace(options.TenantID),
+		ConfigHash:       graphIngestConfigHash(options.SourceConfig),
+		CursorOpaque:     cursorOpaque,
+		CheckpointOpaque: checkpointOpaque,
+		Completed:        completed,
+		PagesRead:        int64(result.PagesRead),
+		EventsRead:       int64(result.EventsRead),
+		UpdatedAt:        time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if err := checkpointStore.PutIngestCheckpoint(ctx, checkpoint); err != nil {
+		return err
+	}
+	result.CheckpointID = checkpoint.ID
+	result.CheckpointCursor = cursorOpaque
+	result.CheckpointPersisted = true
+	result.CheckpointComplete = completed
+	return nil
+}
+
+func graphIngestCheckpointID(options graphIngestOptions) string {
+	if normalized := strings.TrimSpace(options.CheckpointID); normalized != "" {
+		return normalized
+	}
+	tenantID := strings.TrimSpace(options.TenantID)
+	if tenantID == "" {
+		tenantID = "default"
+	}
+	hash := graphIngestConfigHash(options.SourceConfig)
+	if len(hash) > 16 {
+		hash = hash[:16]
+	}
+	return strings.TrimSpace(options.SourceID) + ":" + tenantID + ":" + hash
+}
+
+func graphIngestConfigHash(config map[string]string) string {
+	keys := make([]string, 0, len(config))
+	for key := range config {
+		if !sensitiveGraphIngestConfigKey(key) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	hash := sha256.New()
+	for _, key := range keys {
+		hash.Write([]byte(strings.TrimSpace(key)))
+		hash.Write([]byte{0})
+		hash.Write([]byte(config[key]))
+		hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func sensitiveGraphIngestConfigKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	for _, marker := range []string{"token", "secret", "password", "access_key", "session"} {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func graphIngestEvent(event *cerebrov1.EventEnvelope, tenantID string) *cerebrov1.EventEnvelope {

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -1,6 +1,72 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestParseGraphIngestArgs(t *testing.T) {
+	sourceID, config, tenantID, pageLimit, cursor, err := parseGraphIngestArgs([]string{
+		"github",
+		"tenant_id=writer",
+		"page_limit=5",
+		"cursor=next-page",
+		"family=audit",
+		"owner=WriterInternal",
+	})
+	if err != nil {
+		t.Fatalf("parseGraphIngestArgs() error = %v", err)
+	}
+	if sourceID != "github" {
+		t.Fatalf("sourceID = %q, want github", sourceID)
+	}
+	if tenantID != "writer" {
+		t.Fatalf("tenantID = %q, want writer", tenantID)
+	}
+	if pageLimit != 5 {
+		t.Fatalf("pageLimit = %d, want 5", pageLimit)
+	}
+	if cursor == nil || cursor.GetOpaque() != "next-page" {
+		t.Fatalf("cursor = %#v, want next-page", cursor)
+	}
+	if config["family"] != "audit" || config["owner"] != "WriterInternal" {
+		t.Fatalf("config = %#v, want source config preserved", config)
+	}
+}
+
+func TestParseGraphIngestArgsDefaultsPageLimit(t *testing.T) {
+	_, _, _, pageLimit, _, err := parseGraphIngestArgs([]string{"aws", "family=cloudtrail"})
+	if err != nil {
+		t.Fatalf("parseGraphIngestArgs() error = %v", err)
+	}
+	if pageLimit != defaultGraphIngestPageLimit {
+		t.Fatalf("pageLimit = %d, want %d", pageLimit, defaultGraphIngestPageLimit)
+	}
+}
+
+func TestParseGraphIngestArgsRejectsInvalidPageLimit(t *testing.T) {
+	_, _, _, _, _, err := parseGraphIngestArgs([]string{"aws", "page_limit=0"})
+	if err == nil {
+		t.Fatal("parseGraphIngestArgs() error = nil, want non-nil")
+	}
+}
+
+func TestGraphIngestEventOverridesTenant(t *testing.T) {
+	original := &cerebrov1.EventEnvelope{
+		Id:       "evt-1",
+		TenantId: "aws-account",
+		SourceId: "aws",
+		Kind:     "aws.cloudtrail",
+	}
+	cloned := graphIngestEvent(original, "writer")
+	if cloned.GetTenantId() != "writer" {
+		t.Fatalf("cloned.TenantId = %q, want writer", cloned.GetTenantId())
+	}
+	if original.GetTenantId() != "aws-account" {
+		t.Fatalf("original.TenantId = %q, want unchanged aws-account", original.GetTenantId())
+	}
+}
 
 func TestParseGraphRebuildArgs(t *testing.T) {
 	runtimeID, mode, pageLimit, eventLimit, previewLimit, dryRun, err := parseGraphRebuildArgs([]string{

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -7,48 +7,83 @@ import (
 )
 
 func TestParseGraphIngestArgs(t *testing.T) {
-	sourceID, config, tenantID, pageLimit, cursor, err := parseGraphIngestArgs([]string{
+	options, err := parseGraphIngestArgs([]string{
 		"github",
 		"tenant_id=writer",
 		"page_limit=5",
 		"cursor=next-page",
+		"checkpoint=true",
+		"checkpoint_id=github-writer",
 		"family=audit",
 		"owner=WriterInternal",
 	})
 	if err != nil {
 		t.Fatalf("parseGraphIngestArgs() error = %v", err)
 	}
-	if sourceID != "github" {
-		t.Fatalf("sourceID = %q, want github", sourceID)
+	if options.SourceID != "github" {
+		t.Fatalf("SourceID = %q, want github", options.SourceID)
 	}
-	if tenantID != "writer" {
-		t.Fatalf("tenantID = %q, want writer", tenantID)
+	if options.TenantID != "writer" {
+		t.Fatalf("TenantID = %q, want writer", options.TenantID)
 	}
-	if pageLimit != 5 {
-		t.Fatalf("pageLimit = %d, want 5", pageLimit)
+	if options.PageLimit != 5 {
+		t.Fatalf("PageLimit = %d, want 5", options.PageLimit)
 	}
-	if cursor == nil || cursor.GetOpaque() != "next-page" {
-		t.Fatalf("cursor = %#v, want next-page", cursor)
+	if options.Cursor == nil || options.Cursor.GetOpaque() != "next-page" {
+		t.Fatalf("Cursor = %#v, want next-page", options.Cursor)
 	}
-	if config["family"] != "audit" || config["owner"] != "WriterInternal" {
-		t.Fatalf("config = %#v, want source config preserved", config)
+	if !options.CheckpointEnabled || options.CheckpointID != "github-writer" {
+		t.Fatalf("checkpoint options = enabled:%t id:%q, want enabled github-writer", options.CheckpointEnabled, options.CheckpointID)
+	}
+	if options.SourceConfig["family"] != "audit" || options.SourceConfig["owner"] != "WriterInternal" {
+		t.Fatalf("SourceConfig = %#v, want source config preserved", options.SourceConfig)
 	}
 }
 
 func TestParseGraphIngestArgsDefaultsPageLimit(t *testing.T) {
-	_, _, _, pageLimit, _, err := parseGraphIngestArgs([]string{"aws", "family=cloudtrail"})
+	options, err := parseGraphIngestArgs([]string{"aws", "family=cloudtrail"})
 	if err != nil {
 		t.Fatalf("parseGraphIngestArgs() error = %v", err)
 	}
-	if pageLimit != defaultGraphIngestPageLimit {
-		t.Fatalf("pageLimit = %d, want %d", pageLimit, defaultGraphIngestPageLimit)
+	if options.PageLimit != defaultGraphIngestPageLimit {
+		t.Fatalf("PageLimit = %d, want %d", options.PageLimit, defaultGraphIngestPageLimit)
 	}
 }
 
 func TestParseGraphIngestArgsRejectsInvalidPageLimit(t *testing.T) {
-	_, _, _, _, _, err := parseGraphIngestArgs([]string{"aws", "page_limit=0"})
+	_, err := parseGraphIngestArgs([]string{"aws", "page_limit=0"})
 	if err == nil {
 		t.Fatal("parseGraphIngestArgs() error = nil, want non-nil")
+	}
+}
+
+func TestGraphIngestCheckpointIDScrubsSensitiveConfig(t *testing.T) {
+	options := graphIngestOptions{
+		SourceID: "github",
+		TenantID: "writer",
+		SourceConfig: map[string]string{
+			"owner": "WriterInternal",
+			"token": "secret-token-a",
+		},
+	}
+	first := graphIngestCheckpointID(options)
+	options.SourceConfig["token"] = "secret-token-b"
+	second := graphIngestCheckpointID(options)
+	if first != second {
+		t.Fatalf("checkpoint id changed after token mutation: %q != %q", first, second)
+	}
+}
+
+func TestParseGraphNeighborhoodArgs(t *testing.T) {
+	rootURN, limit, err := parseGraphNeighborhoodArgs([]string{"root_urn=urn:cerebro:writer:github_user:alice", "limit=7"})
+	if err != nil {
+		t.Fatalf("parseGraphNeighborhoodArgs() error = %v", err)
+	}
+	if rootURN != "urn:cerebro:writer:github_user:alice" {
+		t.Fatalf("rootURN = %q, want alice urn", rootURN)
+	}
+	if limit != 7 {
+		t.Fatalf("limit = %d, want 7", limit)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2875,10 +2875,22 @@ func cloneNeighborhoodRelation(relation *ports.NeighborhoodRelation) *ports.Neig
 		return nil
 	}
 	return &ports.NeighborhoodRelation{
-		FromURN:  relation.FromURN,
-		Relation: relation.Relation,
-		ToURN:    relation.ToURN,
+		FromURN:    relation.FromURN,
+		Relation:   relation.Relation,
+		ToURN:      relation.ToURN,
+		Attributes: cloneStringMap(relation.Attributes),
 	}
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func findingTestEvent(id string, eventType string, outcome string) *cerebrov1.EventEnvelope {

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -14,9 +14,7 @@ import (
 
 const dependencyPingTimeout = 5 * time.Second
 
-type closer interface {
-	Close() error
-}
+type closer func(context.Context) error
 
 // OpenDependencies dials the configured append-log and current-state drivers.
 func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, func() error, error) {
@@ -26,8 +24,10 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 	)
 	closeAll := func() error {
 		var errs []error
+		closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), dependencyPingTimeout)
+		defer cancel()
 		for i := len(closers) - 1; i >= 0; i-- {
-			if err := closers[i].Close(); err != nil {
+			if err := closers[i](closeCtx); err != nil {
 				errs = append(errs, err)
 			}
 		}
@@ -44,7 +44,9 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 			return fail(fmt.Errorf("open append log: %w", err))
 		}
 		deps.AppendLog = appendLog
-		closers = append(closers, appendLog)
+		closers = append(closers, func(context.Context) error {
+			return appendLog.Close()
+		})
 	}
 	if cfg.StateStore.Driver == config.StateStoreDriverPostgres {
 		stateStore, err := statestorepostgres.Open(cfg.StateStore)
@@ -52,15 +54,23 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 			return fail(fmt.Errorf("open state store: %w", err))
 		}
 		deps.StateStore = stateStore
-		closers = append(closers, stateStore)
+		closers = append(closers, func(context.Context) error {
+			return stateStore.Close()
+		})
 	}
-	if cfg.GraphStore.Driver == config.GraphStoreDriverKuzu {
+	switch cfg.GraphStore.Driver {
+	case "":
+	case config.GraphStoreDriverKuzu:
 		graphStore, err := graphstorekuzu.Open(cfg.GraphStore)
 		if err != nil {
 			return fail(fmt.Errorf("open graph store: %w", err))
 		}
 		deps.GraphStore = graphStore
-		closers = append(closers, graphStore)
+		closers = append(closers, func(context.Context) error {
+			return graphStore.Close()
+		})
+	default:
+		return fail(fmt.Errorf("unsupported graph store driver %q", cfg.GraphStore.Driver))
 	}
 	pingCtx, cancel := context.WithTimeout(ctx, dependencyPingTimeout)
 	defer cancel()

--- a/internal/bootstrap/dependencies_test.go
+++ b/internal/bootstrap/dependencies_test.go
@@ -54,6 +54,15 @@ func TestOpenDependenciesRejectsIncompleteKuzuConfig(t *testing.T) {
 	}
 }
 
+func TestOpenDependenciesRejectsUnsupportedGraphStoreDriver(t *testing.T) {
+	_, _, err := OpenDependencies(context.Background(), config.Config{
+		GraphStore: config.GraphStoreConfig{Driver: "alternate"},
+	})
+	if err == nil {
+		t.Fatal("OpenDependencies() error = nil, want non-nil")
+	}
+}
+
 func TestOpenDependenciesConfiguresKuzu(t *testing.T) {
 	deps, closeAll, err := OpenDependencies(context.Background(), config.Config{
 		GraphStore: config.GraphStoreConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -129,3 +129,11 @@ func TestLoadRejectsMissingKuzuPath(t *testing.T) {
 		t.Fatal("Load() error = nil, want non-nil")
 	}
 }
+
+func TestLoadRejectsUnsupportedGraphStoreDriver(t *testing.T) {
+	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", "alternate")
+	t.Setenv("CEREBRO_KUZU_PATH", "/tmp/cerebro-kuzu")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
+}

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -13,6 +13,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphstore"
 	graphstorekuzu "github.com/writer/cerebro/internal/graphstore/kuzu"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -35,11 +36,11 @@ const (
 type graphStore interface {
 	ports.ProjectionGraphStore
 	Close() error
-	Counts(context.Context) (graphstorekuzu.Counts, error)
-	IntegrityChecks(context.Context) ([]graphstorekuzu.IntegrityCheck, error)
-	PathPatterns(context.Context, int) ([]graphstorekuzu.PathPattern, error)
-	Topology(context.Context) (graphstorekuzu.Topology, error)
-	SampleTraversals(context.Context, int) ([]graphstorekuzu.Traversal, error)
+	Counts(context.Context) (graphstore.Counts, error)
+	IntegrityChecks(context.Context) ([]graphstore.IntegrityCheck, error)
+	PathPatterns(context.Context, int) ([]graphstore.PathPattern, error)
+	Topology(context.Context) (graphstore.Topology, error)
+	SampleTraversals(context.Context, int) ([]graphstore.Traversal, error)
 }
 
 // Request configures one local graph rebuild dry-run.
@@ -197,7 +198,7 @@ func New(registry *sourcecdk.Registry, runtimeStore ports.SourceRuntimeStore, re
 		replayer:     replayer,
 		openGraph: func(path string) (graphStore, error) {
 			return graphstorekuzu.Open(config.GraphStoreConfig{
-				Driver:   "kuzu",
+				Driver:   config.GraphStoreDriverKuzu,
 				KuzuPath: path,
 			})
 		},
@@ -760,7 +761,7 @@ func countPreviews(counts map[string]uint32) []*CountPreview {
 	return previews
 }
 
-func assertionPreviews(checks []graphstorekuzu.IntegrityCheck) []*AssertionPreview {
+func assertionPreviews(checks []graphstore.IntegrityCheck) []*AssertionPreview {
 	previews := make([]*AssertionPreview, 0, len(checks))
 	for _, check := range checks {
 		previews = append(previews, &AssertionPreview{
@@ -789,7 +790,7 @@ func assertionCounts(assertions []*AssertionPreview) (uint32, uint32) {
 	return passed, failed
 }
 
-func pathPatternPreviews(patterns []graphstorekuzu.PathPattern) []*PathPatternPreview {
+func pathPatternPreviews(patterns []graphstore.PathPattern) []*PathPatternPreview {
 	previews := make([]*PathPatternPreview, 0, len(patterns))
 	for _, pattern := range patterns {
 		previews = append(previews, &PathPatternPreview{
@@ -805,7 +806,7 @@ func pathPatternPreviews(patterns []graphstorekuzu.PathPattern) []*PathPatternPr
 	return previews
 }
 
-func pathPatternLabel(pattern graphstorekuzu.PathPattern) string {
+func pathPatternLabel(pattern graphstore.PathPattern) string {
 	return strings.TrimSpace(pattern.FromType) +
 		" -[" + strings.TrimSpace(pattern.FirstRelation) + "]-> " +
 		strings.TrimSpace(pattern.ViaType) +
@@ -813,7 +814,7 @@ func pathPatternLabel(pattern graphstorekuzu.PathPattern) string {
 		strings.TrimSpace(pattern.ToType)
 }
 
-func topologyPreviews(topology graphstorekuzu.Topology) []*TopologyPreview {
+func topologyPreviews(topology graphstore.Topology) []*TopologyPreview {
 	previews := []*TopologyPreview{
 		{Name: "isolated", Count: topology.Isolated},
 		{Name: "sources_only", Count: topology.SourcesOnly},
@@ -823,7 +824,7 @@ func topologyPreviews(topology graphstorekuzu.Topology) []*TopologyPreview {
 	return previews
 }
 
-func traversalPreviews(traversals []graphstorekuzu.Traversal) []*TraversalPreview {
+func traversalPreviews(traversals []graphstore.Traversal) []*TraversalPreview {
 	previews := make([]*TraversalPreview, 0, len(traversals))
 	for _, traversal := range traversals {
 		previews = append(previews, &TraversalPreview{
@@ -838,7 +839,7 @@ func traversalPreviews(traversals []graphstorekuzu.Traversal) []*TraversalPrevie
 	return previews
 }
 
-func traversalPath(traversal graphstorekuzu.Traversal) string {
+func traversalPath(traversal graphstore.Traversal) string {
 	from := firstNonEmptyLabel(traversal.FromLabel, traversal.FromURN)
 	via := firstNonEmptyLabel(traversal.ViaLabel, traversal.ViaURN)
 	to := firstNonEmptyLabel(traversal.ToLabel, traversal.ToURN)

--- a/internal/graphstore/kuzu/checkpoint.go
+++ b/internal/graphstore/kuzu/checkpoint.go
@@ -1,0 +1,112 @@
+package kuzu
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// GetIngestCheckpoint returns one persisted graph ingest checkpoint.
+func (s *Store) GetIngestCheckpoint(ctx context.Context, id string) (IngestCheckpoint, bool, error) {
+	normalizedID := strings.TrimSpace(id)
+	if normalizedID == "" {
+		return IngestCheckpoint{}, false, errors.New("ingest checkpoint id is required")
+	}
+	if s == nil || s.db == nil {
+		return IngestCheckpoint{}, false, errors.New("kuzu is not configured")
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return IngestCheckpoint{}, false, err
+	}
+	if !tables["ingest_checkpoint"] {
+		return IngestCheckpoint{}, false, nil
+	}
+	var checkpoint IngestCheckpoint
+	var completed string
+	if err := s.db.QueryRowContext(ctx, fmt.Sprintf(
+		"MATCH (c:ingest_checkpoint {id: %s}) RETURN c.id, c.source_id, c.tenant_id, c.config_hash, c.cursor_opaque, c.checkpoint_opaque, c.completed, c.pages_read, c.events_read, c.updated_at",
+		cypherString(normalizedID),
+	)).Scan(
+		&checkpoint.ID,
+		&checkpoint.SourceID,
+		&checkpoint.TenantID,
+		&checkpoint.ConfigHash,
+		&checkpoint.CursorOpaque,
+		&checkpoint.CheckpointOpaque,
+		&completed,
+		&checkpoint.PagesRead,
+		&checkpoint.EventsRead,
+		&checkpoint.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return IngestCheckpoint{}, false, nil
+		}
+		return IngestCheckpoint{}, false, fmt.Errorf("query ingest checkpoint %q: %w", normalizedID, err)
+	}
+	checkpoint.Completed, err = strconv.ParseBool(completed)
+	if err != nil {
+		return IngestCheckpoint{}, false, fmt.Errorf("parse ingest checkpoint completion %q: %w", normalizedID, err)
+	}
+	return checkpoint, true, nil
+}
+
+// PutIngestCheckpoint upserts one durable graph ingest checkpoint.
+func (s *Store) PutIngestCheckpoint(ctx context.Context, checkpoint IngestCheckpoint) error {
+	checkpoint.ID = strings.TrimSpace(checkpoint.ID)
+	if checkpoint.ID == "" {
+		return errors.New("ingest checkpoint id is required")
+	}
+	checkpoint.SourceID = strings.TrimSpace(checkpoint.SourceID)
+	if checkpoint.SourceID == "" {
+		return errors.New("ingest checkpoint source id is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("kuzu is not configured")
+	}
+	if err := s.ensureIngestCheckpointSchema(ctx); err != nil {
+		return err
+	}
+	statement := fmt.Sprintf(
+		"MERGE (c:ingest_checkpoint {id: %s}) SET c.source_id = %s, c.tenant_id = %s, c.config_hash = %s, c.cursor_opaque = %s, c.checkpoint_opaque = %s, c.completed = %s, c.pages_read = %d, c.events_read = %d, c.updated_at = %s",
+		cypherString(checkpoint.ID),
+		cypherString(checkpoint.SourceID),
+		cypherString(strings.TrimSpace(checkpoint.TenantID)),
+		cypherString(strings.TrimSpace(checkpoint.ConfigHash)),
+		cypherString(strings.TrimSpace(checkpoint.CursorOpaque)),
+		cypherString(strings.TrimSpace(checkpoint.CheckpointOpaque)),
+		cypherString(strconv.FormatBool(checkpoint.Completed)),
+		checkpoint.PagesRead,
+		checkpoint.EventsRead,
+		cypherString(strings.TrimSpace(checkpoint.UpdatedAt)),
+	)
+	if _, err := s.db.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("upsert ingest checkpoint %q: %w", checkpoint.ID, err)
+	}
+	return nil
+}
+
+func (s *Store) ensureIngestCheckpointSchema(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return errors.New("kuzu is not configured")
+	}
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	if s.checkpointSchemaReady {
+		return nil
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return err
+	}
+	if !tables["ingest_checkpoint"] {
+		if _, err := s.db.ExecContext(ctx, "CREATE NODE TABLE ingest_checkpoint(id STRING, source_id STRING, tenant_id STRING, config_hash STRING, cursor_opaque STRING, checkpoint_opaque STRING, completed STRING, pages_read INT64, events_read INT64, updated_at STRING, PRIMARY KEY (id))"); err != nil {
+			return fmt.Errorf("create ingest checkpoint table: %w", err)
+		}
+	}
+	s.checkpointSchemaReady = true
+	return nil
+}

--- a/internal/graphstore/kuzu/checkpoint_test.go
+++ b/internal/graphstore/kuzu/checkpoint_test.go
@@ -1,0 +1,43 @@
+package kuzu
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIngestCheckpointRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if _, ok, err := store.GetIngestCheckpoint(ctx, "github-writer"); err != nil {
+		t.Fatalf("GetIngestCheckpoint() error = %v", err)
+	} else if ok {
+		t.Fatal("GetIngestCheckpoint() ok = true, want false")
+	}
+
+	want := IngestCheckpoint{
+		ID:               "github-writer",
+		SourceID:         "github",
+		TenantID:         "writer",
+		ConfigHash:       "hash",
+		CursorOpaque:     "next-cursor",
+		CheckpointOpaque: "checkpoint-cursor",
+		Completed:        false,
+		PagesRead:        3,
+		EventsRead:       15,
+		UpdatedAt:        "2026-04-28T00:00:00Z",
+	}
+	if err := store.PutIngestCheckpoint(ctx, want); err != nil {
+		t.Fatalf("PutIngestCheckpoint() error = %v", err)
+	}
+	got, ok, err := store.GetIngestCheckpoint(ctx, want.ID)
+	if err != nil {
+		t.Fatalf("GetIngestCheckpoint() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetIngestCheckpoint() ok = false, want true")
+	}
+	if got != want {
+		t.Fatalf("GetIngestCheckpoint() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -20,9 +20,10 @@ import (
 
 // Store is the Kuzu-backed graph projection store implementation.
 type Store struct {
-	db          *sql.DB
-	schemaMu    sync.Mutex
-	schemaReady bool
+	db                    *sql.DB
+	schemaMu              sync.Mutex
+	schemaReady           bool
+	checkpointSchemaReady bool
 }
 
 type Counts = graphstore.Counts
@@ -30,6 +31,7 @@ type Traversal = graphstore.Traversal
 type IntegrityCheck = graphstore.IntegrityCheck
 type PathPattern = graphstore.PathPattern
 type Topology = graphstore.Topology
+type IngestCheckpoint = graphstore.IngestCheckpoint
 
 // Open opens a Kuzu-backed graph projection store.
 func Open(cfg config.GraphStoreConfig) (*Store, error) {

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -14,6 +14,7 @@ import (
 	kuzudb "github.com/kuzudb/go-kuzu"
 
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -24,49 +25,11 @@ type Store struct {
 	schemaReady bool
 }
 
-// Counts summarizes the entity and relationship totals in the graph.
-type Counts struct {
-	Nodes     int64
-	Relations int64
-}
-
-// Traversal captures one sampled two-hop path from the local graph.
-type Traversal struct {
-	FromURN        string
-	FromLabel      string
-	FirstRelation  string
-	ViaURN         string
-	ViaLabel       string
-	SecondRelation string
-	ToURN          string
-	ToLabel        string
-}
-
-// IntegrityCheck captures one local graph invariant check result.
-type IntegrityCheck struct {
-	Name     string
-	Actual   int64
-	Expected int64
-	Passed   bool
-}
-
-// PathPattern captures one grouped two-hop graph pattern.
-type PathPattern struct {
-	FromType       string
-	FirstRelation  string
-	ViaType        string
-	SecondRelation string
-	ToType         string
-	Count          int64
-}
-
-// Topology summarizes node connectivity classes in the local graph.
-type Topology struct {
-	Isolated      int64
-	SourcesOnly   int64
-	SinksOnly     int64
-	Intermediates int64
-}
+type Counts = graphstore.Counts
+type Traversal = graphstore.Traversal
+type IntegrityCheck = graphstore.IntegrityCheck
+type PathPattern = graphstore.PathPattern
+type Topology = graphstore.Topology
 
 // Open opens a Kuzu-backed graph projection store.
 func Open(cfg config.GraphStoreConfig) (*Store, error) {

--- a/internal/graphstore/kuzu/query.go
+++ b/internal/graphstore/kuzu/query.go
@@ -3,6 +3,7 @@ package kuzu
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -43,7 +44,7 @@ func (s *Store) GetEntityNeighborhood(ctx context.Context, rootURN string, limit
 	relations := make(map[string]*ports.NeighborhoodRelation)
 	remaining, err := s.collectNeighborhoodRows(ctx, fmt.Sprintf(
 		"MATCH (root:entity {urn: %s})-[r:relation]->(neighbor:entity) "+
-			"RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label, root.urn AS from_urn, r.relation AS relation_type, neighbor.urn AS to_urn "+
+			"RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label, root.urn AS from_urn, r.relation AS relation_type, neighbor.urn AS to_urn, r.attributes_json AS attributes_json "+
 			"ORDER BY neighbor.urn, r.relation LIMIT %d",
 		cypherString(normalizedRootURN),
 		limit,
@@ -54,7 +55,7 @@ func (s *Store) GetEntityNeighborhood(ctx context.Context, rootURN string, limit
 	if remaining > 0 {
 		if _, err := s.collectNeighborhoodRows(ctx, fmt.Sprintf(
 			"MATCH (neighbor:entity)-[r:relation]->(root:entity {urn: %s}) "+
-				"RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label, neighbor.urn AS from_urn, r.relation AS relation_type, root.urn AS to_urn "+
+				"RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label, neighbor.urn AS from_urn, r.relation AS relation_type, root.urn AS to_urn, r.attributes_json AS attributes_json "+
 				"ORDER BY neighbor.urn, r.relation LIMIT %d",
 			cypherString(normalizedRootURN),
 			remaining,
@@ -94,6 +95,7 @@ func (s *Store) collectNeighborhoodRows(ctx context.Context, query string, remai
 	for rows.Next() {
 		var neighbor ports.NeighborhoodNode
 		var relation ports.NeighborhoodRelation
+		var attributesJSON string
 		if err := rows.Scan(
 			&neighbor.URN,
 			&neighbor.EntityType,
@@ -101,9 +103,15 @@ func (s *Store) collectNeighborhoodRows(ctx context.Context, query string, remai
 			&relation.FromURN,
 			&relation.Relation,
 			&relation.ToURN,
+			&attributesJSON,
 		); err != nil {
 			return remaining, fmt.Errorf("scan graph neighborhood row: %w", err)
 		}
+		attributes, err := decodeGraphAttributes(attributesJSON)
+		if err != nil {
+			return remaining, fmt.Errorf("decode graph neighborhood relation attributes: %w", err)
+		}
+		relation.Attributes = attributes
 		neighbors[neighbor.URN] = &neighbor
 		relations[relation.FromURN+"|"+relation.Relation+"|"+relation.ToURN] = &relation
 		remaining--
@@ -115,6 +123,18 @@ func (s *Store) collectNeighborhoodRows(ctx context.Context, query string, remai
 		return remaining, fmt.Errorf("iterate graph neighborhood rows: %w", err)
 	}
 	return remaining, nil
+}
+
+func decodeGraphAttributes(payload string) (map[string]string, error) {
+	trimmed := strings.TrimSpace(payload)
+	if trimmed == "" || trimmed == "{}" {
+		return nil, nil
+	}
+	attributes := map[string]string{}
+	if err := json.Unmarshal([]byte(trimmed), &attributes); err != nil {
+		return nil, err
+	}
+	return attributes, nil
 }
 
 func neighborhoodNodes(values map[string]*ports.NeighborhoodNode) []*ports.NeighborhoodNode {

--- a/internal/graphstore/kuzu/query_test.go
+++ b/internal/graphstore/kuzu/query_test.go
@@ -47,6 +47,9 @@ func TestGetEntityNeighborhoodReturnsRootNeighborsAndRelations(t *testing.T) {
 	if !containsNeighborhoodRelation(neighborhood.Relations, "urn:cerebro:writer:github_user:alice", "authored", "urn:cerebro:writer:github_pull_request:writer/cerebro#447") {
 		t.Fatalf("Relations missing authored edge: %#v", neighborhood.Relations)
 	}
+	if !containsNeighborhoodRelationAttribute(neighborhood.Relations, "urn:cerebro:writer:github_user:alice", "authored", "urn:cerebro:writer:github_pull_request:writer/cerebro#447", "event_id", "github-pr-447") {
+		t.Fatalf("Relations missing authored edge attributes: %#v", neighborhood.Relations)
+	}
 	if !containsNeighborhoodRelation(neighborhood.Relations, "urn:cerebro:writer:github_pull_request:writer/cerebro#447", "belongs_to", "urn:cerebro:writer:github_repo:writer/cerebro") {
 		t.Fatalf("Relations missing belongs_to edge: %#v", neighborhood.Relations)
 	}
@@ -72,6 +75,15 @@ func containsNeighborhoodNode(nodes []*ports.NeighborhoodNode, urn string, entit
 func containsNeighborhoodRelation(relations []*ports.NeighborhoodRelation, fromURN string, relation string, toURN string) bool {
 	for _, edge := range relations {
 		if edge != nil && edge.FromURN == fromURN && edge.Relation == relation && edge.ToURN == toURN {
+			return true
+		}
+	}
+	return false
+}
+
+func containsNeighborhoodRelationAttribute(relations []*ports.NeighborhoodRelation, fromURN string, relation string, toURN string, key string, value string) bool {
+	for _, edge := range relations {
+		if edge != nil && edge.FromURN == fromURN && edge.Relation == relation && edge.ToURN == toURN && edge.Attributes[key] == value {
 			return true
 		}
 	}

--- a/internal/graphstore/types.go
+++ b/internal/graphstore/types.go
@@ -1,0 +1,45 @@
+package graphstore
+
+// Counts summarizes entity and relationship totals in a graph store.
+type Counts struct {
+	Nodes     int64
+	Relations int64
+}
+
+// Traversal captures one sampled two-hop graph path.
+type Traversal struct {
+	FromURN        string
+	FromLabel      string
+	FirstRelation  string
+	ViaURN         string
+	ViaLabel       string
+	SecondRelation string
+	ToURN          string
+	ToLabel        string
+}
+
+// IntegrityCheck captures one graph invariant check result.
+type IntegrityCheck struct {
+	Name     string
+	Actual   int64
+	Expected int64
+	Passed   bool
+}
+
+// PathPattern captures one grouped two-hop graph pattern.
+type PathPattern struct {
+	FromType       string
+	FirstRelation  string
+	ViaType        string
+	SecondRelation string
+	ToType         string
+	Count          int64
+}
+
+// Topology summarizes node connectivity classes in a graph store.
+type Topology struct {
+	Isolated      int64
+	SourcesOnly   int64
+	SinksOnly     int64
+	Intermediates int64
+}

--- a/internal/graphstore/types.go
+++ b/internal/graphstore/types.go
@@ -2,44 +2,58 @@ package graphstore
 
 // Counts summarizes entity and relationship totals in a graph store.
 type Counts struct {
-	Nodes     int64
-	Relations int64
+	Nodes     int64 `json:"nodes"`
+	Relations int64 `json:"relations"`
 }
 
 // Traversal captures one sampled two-hop graph path.
 type Traversal struct {
-	FromURN        string
-	FromLabel      string
-	FirstRelation  string
-	ViaURN         string
-	ViaLabel       string
-	SecondRelation string
-	ToURN          string
-	ToLabel        string
+	FromURN        string `json:"from_urn"`
+	FromLabel      string `json:"from_label"`
+	FirstRelation  string `json:"first_relation"`
+	ViaURN         string `json:"via_urn"`
+	ViaLabel       string `json:"via_label"`
+	SecondRelation string `json:"second_relation"`
+	ToURN          string `json:"to_urn"`
+	ToLabel        string `json:"to_label"`
 }
 
 // IntegrityCheck captures one graph invariant check result.
 type IntegrityCheck struct {
-	Name     string
-	Actual   int64
-	Expected int64
-	Passed   bool
+	Name     string `json:"name"`
+	Actual   int64  `json:"actual"`
+	Expected int64  `json:"expected"`
+	Passed   bool   `json:"passed"`
 }
 
 // PathPattern captures one grouped two-hop graph pattern.
 type PathPattern struct {
-	FromType       string
-	FirstRelation  string
-	ViaType        string
-	SecondRelation string
-	ToType         string
-	Count          int64
+	FromType       string `json:"from_type"`
+	FirstRelation  string `json:"first_relation"`
+	ViaType        string `json:"via_type"`
+	SecondRelation string `json:"second_relation"`
+	ToType         string `json:"to_type"`
+	Count          int64  `json:"count"`
 }
 
 // Topology summarizes node connectivity classes in a graph store.
 type Topology struct {
-	Isolated      int64
-	SourcesOnly   int64
-	SinksOnly     int64
-	Intermediates int64
+	Isolated      int64 `json:"isolated"`
+	SourcesOnly   int64 `json:"sources_only"`
+	SinksOnly     int64 `json:"sinks_only"`
+	Intermediates int64 `json:"intermediates"`
+}
+
+// IngestCheckpoint records durable graph ingest progress in Kuzu.
+type IngestCheckpoint struct {
+	ID               string `json:"id"`
+	SourceID         string `json:"source_id"`
+	TenantID         string `json:"tenant_id,omitempty"`
+	ConfigHash       string `json:"config_hash"`
+	CursorOpaque     string `json:"cursor_opaque,omitempty"`
+	CheckpointOpaque string `json:"checkpoint_opaque,omitempty"`
+	Completed        bool   `json:"completed"`
+	PagesRead        int64  `json:"pages_read"`
+	EventsRead       int64  `json:"events_read"`
+	UpdatedAt        string `json:"updated_at,omitempty"`
 }

--- a/internal/ports/graphquery.go
+++ b/internal/ports/graphquery.go
@@ -10,23 +10,24 @@ var ErrGraphEntityNotFound = errors.New("graph entity not found")
 
 // NeighborhoodNode is the normalized graph node shape returned by bounded neighborhood queries.
 type NeighborhoodNode struct {
-	URN        string
-	EntityType string
-	Label      string
+	URN        string `json:"urn"`
+	EntityType string `json:"entity_type"`
+	Label      string `json:"label"`
 }
 
 // NeighborhoodRelation is the normalized graph edge shape returned by bounded neighborhood queries.
 type NeighborhoodRelation struct {
-	FromURN  string
-	Relation string
-	ToURN    string
+	FromURN    string            `json:"from_urn"`
+	Relation   string            `json:"relation"`
+	ToURN      string            `json:"to_urn"`
+	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
 // EntityNeighborhood is one bounded graph neighborhood centered on a root entity.
 type EntityNeighborhood struct {
-	Root      *NeighborhoodNode
-	Neighbors []*NeighborhoodNode
-	Relations []*NeighborhoodRelation
+	Root      *NeighborhoodNode       `json:"root,omitempty"`
+	Neighbors []*NeighborhoodNode     `json:"neighbors"`
+	Relations []*NeighborhoodRelation `json:"relations"`
 }
 
 // GraphQueryStore exposes bounded graph neighborhood reads.

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -556,11 +556,15 @@ func graphRelationsPayload(relations []*ports.NeighborhoodRelation) []any {
 		if relation == nil {
 			continue
 		}
-		payload = append(payload, map[string]any{
+		relationPayload := map[string]any{
 			"from_urn": relation.FromURN,
 			"relation": relation.Relation,
 			"to_urn":   relation.ToURN,
-		})
+		}
+		if len(relation.Attributes) > 0 {
+			relationPayload["attributes"] = relation.Attributes
+		}
+		payload = append(payload, relationPayload)
 	}
 	return payload
 }

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -487,9 +487,10 @@ func cloneNeighborhoodRelation(relation *ports.NeighborhoodRelation) *ports.Neig
 		return nil
 	}
 	return &ports.NeighborhoodRelation{
-		FromURN:  relation.FromURN,
-		Relation: relation.Relation,
-		ToURN:    relation.ToURN,
+		FromURN:    relation.FromURN,
+		Relation:   relation.Relation,
+		ToURN:      relation.ToURN,
+		Attributes: cloneAttributes(relation.Attributes),
 	}
 }
 

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -131,7 +131,7 @@ func cloudPrivilegePathProjections(event *cerebrov1.EventEnvelope, profile ident
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
 	}
 	if targetURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -142,7 +142,7 @@ func cloudPrivilegePathProjections(event *cerebrov1.EventEnvelope, profile ident
 			Label:      firstNonEmpty(attributes["target_name"], attributes["resource_name"], targetEmail, targetID),
 			Attributes: map[string]string{"target_id": targetID, "target_type": targetType},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), targetURN, targetEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), targetURN, targetEmail)
 	}
 	if subjectURN != "" && targetURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, targetURN, relation, map[string]string{
@@ -181,7 +181,7 @@ func cloudEffectivePermissionProjections(event *cerebrov1.EventEnvelope, profile
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
 	}
 	if resourceURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -214,9 +214,9 @@ func identityUserProjections(event *cerebrov1.EventEnvelope, profile identityPro
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), userURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), userURN, email)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, email)
 		if !sameIdentifier(email, login) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), userURN, login)
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, login)
 		}
 	}
 	return identityProjectionResult(entities, links)
@@ -259,7 +259,7 @@ func identityGroupProjections(event *cerebrov1.EventEnvelope, profile identityPr
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), groupURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), groupURN, groupEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), groupURN, groupEmail)
 	}
 	return identityProjectionResult(entities, links)
 }
@@ -307,7 +307,7 @@ func identityGroupMembershipProjections(event *cerebrov1.EventEnvelope, profile 
 				"status":      strings.TrimSpace(attributes["member_status"]),
 			},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), memberURN, memberEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), memberURN, memberEmail)
 		if groupURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), memberURN, groupURN, relationMemberOf, map[string]string{
 				"event_id": event.GetId(),
@@ -315,7 +315,7 @@ func identityGroupMembershipProjections(event *cerebrov1.EventEnvelope, profile 
 			}))
 		}
 	}
-	addIdentifierLink(entities, links, tenantID, event.GetSourceId(), groupURN, firstNonEmpty(attributes["group_email"], attributes["group_id"]))
+	addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), groupURN, firstNonEmpty(attributes["group_email"], attributes["group_id"]))
 	return identityProjectionResult(entities, links)
 }
 
@@ -370,7 +370,7 @@ func identityAppAssignmentProjections(event *cerebrov1.EventEnvelope, profile id
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), subjectURN, subjectEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, subjectEmail)
 	}
 	if appURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -423,7 +423,7 @@ func identityRoleAssignmentProjections(event *cerebrov1.EventEnvelope, profile i
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: subjectAttributes,
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
 	}
 	if roleURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -466,7 +466,7 @@ func identityCredentialProjections(event *cerebrov1.EventEnvelope, profile ident
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
 	}
 	if credentialURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -507,7 +507,7 @@ func identityAuditProjections(event *cerebrov1.EventEnvelope, profile identityPr
 			Label:      firstNonEmpty(attributes["actor_name"], actorEmail, attributes["actor_id"]),
 			Attributes: map[string]string{"email": actorEmail, "actor_id": strings.TrimSpace(attributes["actor_id"])},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), actorURN, actorEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorEmail)
 	}
 	if resourceURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -177,7 +177,7 @@ func githubPullRequestProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 		if prURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), authorURN, prURN, relationAuthored, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), authorURN, author)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), authorURN, author)
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -277,12 +277,12 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 				"event_id": event.GetId(),
 			}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), actorURN, actor)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actor)
 		if !sameIdentifier(actor, actorExternalNameID) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), actorURN, actorExternalNameID)
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalNameID)
 		}
 		if !sameIdentifier(actor, actorExternalUsername) && !sameIdentifier(actorExternalNameID, actorExternalUsername) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), actorURN, actorExternalUsername)
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalUsername)
 		}
 	}
 
@@ -299,7 +299,7 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 		if resourceURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, resourceURN, relationTargeted, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), targetURN, targetUser)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), targetURN, targetUser)
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -459,9 +459,9 @@ func oktaUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnti
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), userURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), userURN, email)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, email)
 		if !sameIdentifier(email, login) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), userURN, login)
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, login)
 		}
 	}
 
@@ -543,7 +543,7 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 				"event_type": strings.TrimSpace(attributes["event_type"]),
 			}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), actorURN, actorAlternateID)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorAlternateID)
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -585,11 +585,12 @@ func addLink(links map[string]*ports.ProjectedLink, link *ports.ProjectedLink) {
 	links[key] = link
 }
 
-func addIdentifierLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, fromURN string, value string) {
+func addIdentifierLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, eventID string, fromURN string, value string) {
 	identifierURN, identifierType, label := identifierURN(tenantID, value)
 	if identifierURN == "" {
 		return
 	}
+	evidenceAttributes := identifierEvidenceAttributes(value, identifierType, label, eventID)
 	canonicalIdentityURN, canonicalIdentityType := canonicalIdentityURN(tenantID, value)
 	if canonicalIdentityURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -600,7 +601,7 @@ func addIdentifierLink(entities map[string]*ports.ProjectedEntity, links map[str
 			Label:      label,
 			Attributes: map[string]string{"value": label},
 		})
-		addLink(links, projectedLink(tenantID, sourceID, fromURN, canonicalIdentityURN, relationRepresentsIdentity, nil))
+		addLink(links, projectedLink(tenantID, sourceID, fromURN, canonicalIdentityURN, relationRepresentsIdentity, evidenceAttributes))
 	}
 	addEntity(entities, &ports.ProjectedEntity{
 		URN:        identifierURN,
@@ -610,10 +611,36 @@ func addIdentifierLink(entities map[string]*ports.ProjectedEntity, links map[str
 		Label:      label,
 		Attributes: map[string]string{"value": label},
 	})
-	addLink(links, projectedLink(tenantID, sourceID, fromURN, identifierURN, relationHasIdentifier, nil))
+	addLink(links, projectedLink(tenantID, sourceID, fromURN, identifierURN, relationHasIdentifier, evidenceAttributes))
 	if canonicalIdentityURN != "" {
-		addLink(links, projectedLink(tenantID, sourceID, canonicalIdentityURN, identifierURN, relationHasIdentifier, nil))
+		addLink(links, projectedLink(tenantID, sourceID, canonicalIdentityURN, identifierURN, relationHasIdentifier, evidenceAttributes))
 	}
+}
+
+func identifierEvidenceAttributes(rawValue string, identifierType string, normalizedValue string, eventID string) map[string]string {
+	matchType := "login"
+	confidence := "0.60"
+	value := strings.TrimSpace(rawValue)
+	if identifierType == "identifier.email" {
+		if strings.EqualFold(normalizeIdentifier(value), normalizedValue) {
+			matchType = "exact_email"
+			confidence = "0.95"
+		} else {
+			matchType = "extracted_email"
+			confidence = "0.85"
+		}
+	}
+	attributes := map[string]string{
+		"confidence":       confidence,
+		"evidence_type":    "shared_identifier",
+		"identifier_type":  strings.TrimPrefix(identifierType, "identifier."),
+		"identifier_value": normalizedValue,
+		"match_type":       matchType,
+	}
+	if normalizedEventID := strings.TrimSpace(eventID); normalizedEventID != "" {
+		attributes["source_event_id"] = normalizedEventID
+	}
+	return attributes
 }
 
 func projectedLink(tenantID string, sourceID string, fromURN string, toURN string, relation string, attributes map[string]string) *ports.ProjectedLink {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -195,6 +195,8 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 	resourceID := strings.TrimSpace(attributes["resource_id"])
 	resourceType := strings.TrimSpace(attributes["resource_type"])
 	actor := strings.TrimSpace(attributes["actor"])
+	actorExternalNameID := strings.TrimSpace(attributes["external_identity_nameid"])
+	actorExternalUsername := strings.TrimSpace(attributes["external_identity_username"])
 	targetUser := strings.TrimSpace(attributes["user"])
 
 	entities := map[string]*ports.ProjectedEntity{}
@@ -263,7 +265,11 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 			SourceID:   event.GetSourceId(),
 			EntityType: "github.user",
 			Label:      actor,
-			Attributes: map[string]string{"login": actor},
+			Attributes: map[string]string{
+				"external_identity_nameid":   actorExternalNameID,
+				"external_identity_username": actorExternalUsername,
+				"login":                      actor,
+			},
 		})
 		if resourceURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, map[string]string{
@@ -272,6 +278,12 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 			}))
 		}
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), actorURN, actor)
+		if !sameIdentifier(actor, actorExternalNameID) {
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), actorURN, actorExternalNameID)
+		}
+		if !sameIdentifier(actor, actorExternalUsername) && !sameIdentifier(actorExternalNameID, actorExternalUsername) {
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), actorURN, actorExternalUsername)
+		}
 	}
 
 	targetURN := githubUserURN(tenantID, targetUser)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -341,6 +341,23 @@ func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
 	if _, ok := state.links[awsActorURN+"|"+relationRepresentsIdentity+"|"+canonicalIdentityURN]; !ok {
 		t.Fatalf("aws canonical identity link missing for %q", canonicalIdentityURN)
 	}
+	githubIdentityLink := state.links["urn:cerebro:writer:github_user:alice|"+relationRepresentsIdentity+"|"+canonicalIdentityURN]
+	if got := githubIdentityLink.Attributes["evidence_type"]; got != "shared_identifier" {
+		t.Fatalf("github identity evidence_type = %q, want shared_identifier", got)
+	}
+	if got := githubIdentityLink.Attributes["confidence"]; got != "0.95" {
+		t.Fatalf("github identity confidence = %q, want 0.95", got)
+	}
+	if got := githubIdentityLink.Attributes["source_event_id"]; got != "github-audit-1" {
+		t.Fatalf("github identity source_event_id = %q, want github-audit-1", got)
+	}
+	awsIdentityLink := state.links[awsActorURN+"|"+relationRepresentsIdentity+"|"+canonicalIdentityURN]
+	if got := awsIdentityLink.Attributes["match_type"]; got != "extracted_email" {
+		t.Fatalf("aws identity match_type = %q, want extracted_email", got)
+	}
+	if got := awsIdentityLink.Attributes["confidence"]; got != "0.85" {
+		t.Fatalf("aws identity confidence = %q, want 0.85", got)
+	}
 }
 
 func TestProjectIdentityProviderJoinEdges(t *testing.T) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -273,11 +273,12 @@ func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
 			SourceId: "github",
 			Kind:     "github.audit",
 			Attributes: map[string]string{
-				"actor":         "alice@writer.com",
-				"org":           "writer",
-				"repo":          "writer/cerebro",
-				"resource_id":   "writer/cerebro",
-				"resource_type": "repository",
+				"actor":                    "alice",
+				"external_identity_nameid": "alice@writer.com",
+				"org":                      "writer",
+				"repo":                     "writer/cerebro",
+				"resource_id":              "writer/cerebro",
+				"resource_type":            "repository",
 			},
 		},
 		{
@@ -324,13 +325,13 @@ func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
 	if _, ok := state.entities[canonicalIdentityURN]; !ok {
 		t.Fatalf("canonical identity entity %q missing", canonicalIdentityURN)
 	}
-	if _, ok := state.links["urn:cerebro:writer:github_user:alice@writer.com|"+relationHasIdentifier+"|"+identifierURN]; !ok {
+	if _, ok := state.links["urn:cerebro:writer:github_user:alice|"+relationHasIdentifier+"|"+identifierURN]; !ok {
 		t.Fatalf("github identifier link missing for %q", identifierURN)
 	}
 	if _, ok := state.links["urn:cerebro:writer:okta_user:00u1|"+relationHasIdentifier+"|"+identifierURN]; !ok {
 		t.Fatalf("okta identifier link missing for %q", identifierURN)
 	}
-	if _, ok := state.links["urn:cerebro:writer:github_user:alice@writer.com|"+relationRepresentsIdentity+"|"+canonicalIdentityURN]; !ok {
+	if _, ok := state.links["urn:cerebro:writer:github_user:alice|"+relationRepresentsIdentity+"|"+canonicalIdentityURN]; !ok {
 		t.Fatalf("github canonical identity link missing for %q", canonicalIdentityURN)
 	}
 	if _, ok := state.links["urn:cerebro:writer:okta_user:00u1|"+relationRepresentsIdentity+"|"+canonicalIdentityURN]; !ok {

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -247,6 +247,8 @@ func auditAttributes(entry *gogithub.AuditEntry, raw map[string]any, settings se
 	addAttribute(attributes, "actor", entry.GetActor())
 	addAttribute(attributes, "actor_is_agent", boolString(raw, "actor_is_agent"))
 	addAttribute(attributes, "actor_is_bot", boolString(raw, "actor_is_bot"))
+	addAttribute(attributes, "external_identity_nameid", entry.GetExternalIdentityNameID())
+	addAttribute(attributes, "external_identity_username", entry.GetExternalIdentityUsername())
 	addAttribute(attributes, "programmatic_access_type", rawString(raw, "programmatic_access_type"))
 	addAttribute(attributes, "repo", rawString(raw, "repo"))
 	addAttribute(attributes, "user", entry.GetUser())

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -231,6 +231,9 @@ func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
 	if got := first.Events[0].Attributes["previous_visibility"]; got != "private" {
 		t.Fatalf("first.Events[0].Attributes[previous_visibility] = %q, want private", got)
 	}
+	if got := first.Events[0].Attributes["external_identity_nameid"]; got != "dependabot@writer.com" {
+		t.Fatalf("first.Events[0].Attributes[external_identity_nameid] = %q, want dependabot@writer.com", got)
+	}
 	var payload map[string]any
 	if err := json.Unmarshal(first.Events[0].Payload, &payload); err != nil {
 		t.Fatalf("unmarshal audit payload: %v", err)
@@ -390,6 +393,7 @@ func newGitHubAPIHandler(t *testing.T) http.Handler {
 			"business":                    "writer",
 			"business_id":                 10550,
 			"created_at":                  1776916397852,
+			"external_identity_nameid":    "dependabot@writer.com",
 			"operation_type":              "create",
 			"org":                         "writer",
 			"org_id":                      1,

--- a/tools/archtests/graph_store_guardrails_test.go
+++ b/tools/archtests/graph_store_guardrails_test.go
@@ -1,6 +1,7 @@
 package archtests
 
 import (
+	"bytes"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -9,6 +10,27 @@ import (
 	"strings"
 	"testing"
 )
+
+var forbiddenGraphBackendMarkers = []string{
+	"arango",
+	"cayley",
+	"dgraph",
+	"gremlin",
+	"janusgraph",
+	"memgraph",
+	"nebula",
+	"neo4j",
+}
+
+var forbiddenGraphBackendEnvMarkers = []string{
+	"CEREBRO_GRAPH_BACKEND",
+	"CEREBRO_NEO4J_",
+	"CEREBRO_DGRAPH_",
+	"CEREBRO_ARANGO_",
+	"CEREBRO_GREMLIN_",
+	"CEREBRO_MEMGRAPH_",
+	"CEREBRO_NEBULA_",
+}
 
 func TestGraphStoreImplementationIsKuzuOnly(t *testing.T) {
 	root := repoRoot(t)
@@ -58,6 +80,79 @@ func TestGraphStoreImportsUseKuzuImplementationOnly(t *testing.T) {
 		return nil
 	}); err != nil {
 		t.Fatalf("scan graph store imports: %v", err)
+	}
+}
+
+func TestGraphStoreDependenciesAreKuzuOnly(t *testing.T) {
+	root := repoRoot(t)
+	for _, name := range []string{"go.mod", "go.sum"} {
+		body, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		lower := bytes.ToLower(body)
+		for _, marker := range forbiddenGraphBackendMarkers {
+			if bytes.Contains(lower, []byte(marker)) {
+				t.Fatalf("%s contains forbidden graph backend dependency marker %q", name, marker)
+			}
+		}
+	}
+}
+
+func TestGraphStoreProductionEnvVarsAreKuzuOnly(t *testing.T) {
+	root := repoRoot(t)
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "vendor", "docs":
+				return filepath.SkipDir
+			default:
+				return nil
+			}
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") || strings.Contains(path, string(filepath.Separator)+"tools"+string(filepath.Separator)+"archtests"+string(filepath.Separator)) {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, marker := range forbiddenGraphBackendEnvMarkers {
+			if bytes.Contains(body, []byte(marker)) {
+				t.Fatalf("%s contains forbidden graph backend env var marker %q", shortPath(root, path), marker)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("scan graph store env vars: %v", err)
+	}
+}
+
+func TestGraphStoreDriverConstantsAreKuzuOnly(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, "internal", "config", "config.go")
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse config.go: %v", err)
+	}
+	var graphDrivers []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		valueSpec, ok := node.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+		for _, name := range valueSpec.Names {
+			if strings.HasPrefix(name.Name, "GraphStoreDriver") {
+				graphDrivers = append(graphDrivers, name.Name)
+			}
+		}
+		return true
+	})
+	if strings.Join(graphDrivers, ",") != "GraphStoreDriverKuzu" {
+		t.Fatalf("graph store drivers = %v, want only GraphStoreDriverKuzu", graphDrivers)
 	}
 }
 

--- a/tools/archtests/graph_store_guardrails_test.go
+++ b/tools/archtests/graph_store_guardrails_test.go
@@ -1,0 +1,100 @@
+package archtests
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGraphStoreImplementationIsKuzuOnly(t *testing.T) {
+	root := repoRoot(t)
+	graphStoreDir := filepath.Join(root, "internal", "graphstore")
+	entries, err := os.ReadDir(graphStoreDir)
+	if err != nil {
+		t.Fatalf("ReadDir(internal/graphstore): %v", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if entry.Name() != "kuzu" {
+			t.Fatalf("unexpected graph store implementation package %q; Kuzu is the only supported graph backend", entry.Name())
+		}
+	}
+}
+
+func TestGraphStoreImportsUseKuzuImplementationOnly(t *testing.T) {
+	root := repoRoot(t)
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "vendor":
+				return filepath.SkipDir
+			default:
+				return nil
+			}
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		for _, importSpec := range file.Imports {
+			importPath := strings.Trim(importSpec.Path.Value, `"`)
+			if strings.HasPrefix(importPath, "github.com/writer/cerebro/internal/graphstore/") &&
+				importPath != "github.com/writer/cerebro/internal/graphstore/kuzu" {
+				t.Fatalf("%s imports unsupported graph store implementation %q", shortPath(root, path), importPath)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("scan graph store imports: %v", err)
+	}
+}
+
+func TestGraphStoreConfigExposesOnlyKuzuFields(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, "internal", "config", "config.go")
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse config.go: %v", err)
+	}
+	var fields []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		typeSpec, ok := node.(*ast.TypeSpec)
+		if !ok || typeSpec.Name.Name != "GraphStoreConfig" {
+			return true
+		}
+		structType, ok := typeSpec.Type.(*ast.StructType)
+		if !ok {
+			t.Fatalf("GraphStoreConfig is not a struct")
+		}
+		for _, field := range structType.Fields.List {
+			for _, name := range field.Names {
+				fields = append(fields, name.Name)
+			}
+		}
+		return false
+	})
+	want := []string{"Driver", "KuzuPath"}
+	if strings.Join(fields, ",") != strings.Join(want, ",") {
+		t.Fatalf("GraphStoreConfig fields = %v, want exactly %v", fields, want)
+	}
+}
+
+func shortPath(root string, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return path
+	}
+	return rel
+}


### PR DESCRIPTION
## Summary
- add Kuzu graph ingest CLI support for projecting live source reads directly into the configured Kuzu graph store
- add Kuzu graph inspection commands for counts, neighborhoods, path patterns/traversals, and integrity checks
- persist graph ingest checkpoints in Kuzu for resumable page-limited ingests without storing sensitive config values
- link GitHub audit external identities into the canonical identifier graph and add shared-identifier evidence/confidence attributes to identity edges
- strengthen Kuzu-only guardrails at config/bootstrap/import/package/dependency/env-var boundaries and add gated live AWS+GitHub Kuzu E2E coverage

## Validation
- make verify
- make finding-rule-test
- git diff --check
- CEREBRO_RUN_AWS_GITHUB_KUZU_E2E=1 ... go test ./cmd/cerebro -run TestAWSGitHubKuzuSharedIdentityLiveE2E -count=1 -v
- live graph ingest checkpoint + neighborhood CLI smoke into temporary Kuzu