### PR TITLE
feat(graph): add operational Kuzu ingest runner

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -5,9 +5,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"sort"
 	"strconv"
 	"strings"
@@ -25,8 +27,11 @@ import (
 )
 
 const (
-	defaultGraphIngestPageLimit = 1
-	maxGraphIngestPageLimit     = 100
+	defaultGraphIngestPageLimit       = 1
+	maxGraphIngestPageLimit           = 100
+	maxGraphIngestRuntimeIterations   = 10000
+	defaultGraphIngestRunStatusLimit  = 25
+	maxGraphIngestRunStatusQueryLimit = 500
 )
 
 type graphCountsStore interface {
@@ -52,6 +57,12 @@ type graphIngestCheckpointStore interface {
 	PutIngestCheckpoint(context.Context, graphstore.IngestCheckpoint) error
 }
 
+type graphIngestRunStore interface {
+	PutIngestRun(context.Context, graphstore.IngestRun) error
+	GetIngestRun(context.Context, string) (graphstore.IngestRun, bool, error)
+	ListIngestRuns(context.Context, graphstore.IngestRunFilter) ([]graphstore.IngestRun, error)
+}
+
 type graphIngestOptions struct {
 	SourceID          string
 	SourceConfig      map[string]string
@@ -61,6 +72,16 @@ type graphIngestOptions struct {
 	CheckpointEnabled bool
 	CheckpointID      string
 	ResetCheckpoint   bool
+}
+
+type graphIngestRuntimeOptions struct {
+	RuntimeID       string
+	PageLimit       uint32
+	CheckpointID    string
+	ResetCheckpoint bool
+	Interval        time.Duration
+	Iterations      uint32
+	RunForever      bool
 }
 
 type graphIngestResult struct {
@@ -81,6 +102,25 @@ type graphIngestResult struct {
 	CheckpointPersisted    bool   `json:"checkpoint_persisted,omitempty"`
 	CheckpointComplete     bool   `json:"checkpoint_complete,omitempty"`
 	CheckpointAlreadyFresh bool   `json:"checkpoint_already_fresh,omitempty"`
+}
+
+type graphIngestRuntimeResult struct {
+	Run    graphstore.IngestRun `json:"run"`
+	Ingest *graphIngestResult   `json:"ingest,omitempty"`
+}
+
+type graphIngestRuntimeRunnerResult struct {
+	RuntimeID  string                      `json:"runtime_id"`
+	Iterations uint32                      `json:"iterations"`
+	RunForever bool                        `json:"run_forever,omitempty"`
+	Interval   string                      `json:"interval,omitempty"`
+	Runs       []*graphIngestRuntimeResult `json:"runs"`
+}
+
+type graphIngestRunsOptions struct {
+	RuntimeID string
+	Status    string
+	Limit     int
 }
 
 type graphPathsResult struct {
@@ -128,6 +168,39 @@ func runGraph(args []string) error {
 			return err
 		}
 		return printJSON(result)
+	case "ingest-runtime":
+		options, err := parseGraphIngestRuntimeArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+		defer stop()
+		deps, closeDeps, err := openGraphDependencies(ctx)
+		if err != nil {
+			return err
+		}
+		defer logClose(closeDeps)
+		runtimeStore := sourceRuntimeStore(deps.StateStore)
+		if runtimeStore == nil {
+			return fmt.Errorf("source runtime store is required")
+		}
+		registry, err := sourceregistry.Builtin()
+		if err != nil {
+			return fmt.Errorf("open source registry: %w", err)
+		}
+		projector := sourceProjector(nil, deps.GraphStore)
+		if projector == nil {
+			return fmt.Errorf("projection graph store is required")
+		}
+		result, runErr := ingestRuntimeGraph(ctx, runtimeStore, sourceops.New(registry), projector, deps.GraphStore, options)
+		if err := printJSON(result); err != nil {
+			return err
+		}
+		return runErr
+	case "ingest-run":
+		return runGraphIngestRun(args[1:])
+	case "ingest-runs":
+		return runGraphIngestRuns(args[1:])
 	case "counts", "neighborhood", "paths", "integrity":
 		return runGraphInspect(args)
 	case "inspect":
@@ -181,11 +254,19 @@ func runGraph(args []string) error {
 }
 
 func graphUsage() string {
-	return fmt.Sprintf("usage: %s graph [counts|neighborhood|paths|integrity|ingest|rebuild|inspect] ...", os.Args[0])
+	return fmt.Sprintf("usage: %s graph [counts|neighborhood|paths|integrity|ingest|ingest-runtime|ingest-run|ingest-runs|rebuild|inspect] ...", os.Args[0])
 }
 
 func graphIngestUsage() string {
 	return fmt.Sprintf("usage: %s graph ingest <source-id> [tenant_id=<tenant-id>] [page_limit=N] [cursor=<cursor>] [checkpoint=true] [checkpoint_id=<id>] [reset_checkpoint=true] [key=value ...]", os.Args[0])
+}
+
+func graphIngestRuntimeUsage() string {
+	return fmt.Sprintf("usage: %s graph ingest-runtime <runtime-id> [page_limit=N] [checkpoint_id=<id>] [reset_checkpoint=true] [interval=30s] [iterations=N|forever]", os.Args[0])
+}
+
+func graphIngestRunUsage() string {
+	return fmt.Sprintf("usage: %s graph ingest-run <run-id>", os.Args[0])
 }
 
 func graphInspectUsage() string {
@@ -268,6 +349,56 @@ func runGraphInspect(args []string) error {
 	default:
 		return usageError(graphInspectUsage())
 	}
+}
+
+func runGraphIngestRun(args []string) error {
+	if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
+		return usageError(graphIngestRunUsage())
+	}
+	ctx := context.Background()
+	deps, closeDeps, err := openGraphDependencies(ctx)
+	if err != nil {
+		return err
+	}
+	defer logClose(closeDeps)
+	store, ok := deps.GraphStore.(graphIngestRunStore)
+	if !ok {
+		return fmt.Errorf("graph store does not support ingest run status")
+	}
+	run, found, err := store.GetIngestRun(ctx, strings.TrimSpace(args[0]))
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("ingest run %q not found", strings.TrimSpace(args[0]))
+	}
+	return printJSON(run)
+}
+
+func runGraphIngestRuns(args []string) error {
+	options, err := parseGraphIngestRunsArgs(args)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	deps, closeDeps, err := openGraphDependencies(ctx)
+	if err != nil {
+		return err
+	}
+	defer logClose(closeDeps)
+	store, ok := deps.GraphStore.(graphIngestRunStore)
+	if !ok {
+		return fmt.Errorf("graph store does not support ingest run status")
+	}
+	runs, err := store.ListIngestRuns(ctx, graphstore.IngestRunFilter{
+		RuntimeID: options.RuntimeID,
+		Status:    options.Status,
+		Limit:     options.Limit,
+	})
+	if err != nil {
+		return err
+	}
+	return printJSON(runs)
 }
 
 func parseGraphNeighborhoodArgs(args []string) (string, int, error) {
@@ -394,6 +525,109 @@ func parseGraphIngestArgs(args []string) (graphIngestOptions, error) {
 	return options, nil
 }
 
+func parseGraphIngestRuntimeArgs(args []string) (graphIngestRuntimeOptions, error) {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return graphIngestRuntimeOptions{}, usageError(graphIngestRuntimeUsage())
+	}
+	options := graphIngestRuntimeOptions{
+		RuntimeID:  strings.TrimSpace(args[0]),
+		PageLimit:  defaultGraphIngestPageLimit,
+		Iterations: 1,
+	}
+	for _, arg := range args[1:] {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return graphIngestRuntimeOptions{}, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		switch strings.TrimSpace(key) {
+		case "page_limit":
+			parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+			if err != nil {
+				return graphIngestRuntimeOptions{}, fmt.Errorf("parse page_limit: %w", err)
+			}
+			if parsed == 0 || parsed > maxGraphIngestPageLimit {
+				return graphIngestRuntimeOptions{}, fmt.Errorf("page_limit must be between 1 and %d", maxGraphIngestPageLimit)
+			}
+			options.PageLimit = uint32(parsed)
+		case "checkpoint_id":
+			options.CheckpointID = strings.TrimSpace(value)
+		case "reset_checkpoint":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphIngestRuntimeOptions{}, fmt.Errorf("parse reset_checkpoint: %w", err)
+			}
+			options.ResetCheckpoint = parsed
+		case "interval":
+			parsed, err := time.ParseDuration(strings.TrimSpace(value))
+			if err != nil {
+				return graphIngestRuntimeOptions{}, fmt.Errorf("parse interval: %w", err)
+			}
+			if parsed <= 0 {
+				return graphIngestRuntimeOptions{}, fmt.Errorf("interval must be positive")
+			}
+			options.Interval = parsed
+		case "iterations":
+			normalized := strings.TrimSpace(value)
+			if normalized == "forever" {
+				options.Iterations = 0
+				options.RunForever = true
+				continue
+			}
+			parsed, err := strconv.ParseUint(normalized, 10, 32)
+			if err != nil {
+				return graphIngestRuntimeOptions{}, fmt.Errorf("parse iterations: %w", err)
+			}
+			if parsed == 0 {
+				options.Iterations = 0
+				options.RunForever = true
+				continue
+			}
+			if parsed > maxGraphIngestRuntimeIterations {
+				return graphIngestRuntimeOptions{}, fmt.Errorf("iterations must be between 1 and %d or forever", maxGraphIngestRuntimeIterations)
+			}
+			options.Iterations = uint32(parsed)
+			options.RunForever = false
+		default:
+			return graphIngestRuntimeOptions{}, usageError(fmt.Sprintf("unsupported graph ingest-runtime argument %q", key))
+		}
+	}
+	if (options.RunForever || options.Iterations > 1) && options.Interval <= 0 {
+		return graphIngestRuntimeOptions{}, fmt.Errorf("interval is required when iterations is greater than 1 or forever")
+	}
+	return options, nil
+}
+
+func parseGraphIngestRunsArgs(args []string) (graphIngestRunsOptions, error) {
+	options := graphIngestRunsOptions{Limit: defaultGraphIngestRunStatusLimit}
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return graphIngestRunsOptions{}, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		switch strings.TrimSpace(key) {
+		case "runtime_id":
+			options.RuntimeID = strings.TrimSpace(value)
+		case "status":
+			options.Status = strings.TrimSpace(value)
+			if !validGraphIngestRunStatus(options.Status) {
+				return graphIngestRunsOptions{}, fmt.Errorf("unsupported ingest run status %q", options.Status)
+			}
+		case "limit":
+			parsed, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil {
+				return graphIngestRunsOptions{}, fmt.Errorf("parse limit: %w", err)
+			}
+			if parsed < 1 || parsed > maxGraphIngestRunStatusQueryLimit {
+				return graphIngestRunsOptions{}, fmt.Errorf("limit must be between 1 and %d", maxGraphIngestRunStatusQueryLimit)
+			}
+			options.Limit = parsed
+		default:
+			return graphIngestRunsOptions{}, usageError(fmt.Sprintf("unsupported graph ingest-runs argument %q", key))
+		}
+	}
+	return options, nil
+}
+
 func ingestGraph(
 	ctx context.Context,
 	sourceService *sourceops.Service,
@@ -463,6 +697,126 @@ func ingestGraph(
 		result.GraphLinksAfter = counts.Relations
 	}
 	return result, nil
+}
+
+func ingestRuntimeGraph(
+	ctx context.Context,
+	runtimeStore ports.SourceRuntimeStore,
+	sourceService *sourceops.Service,
+	projector ports.SourceProjector,
+	graphStore ports.GraphStore,
+	options graphIngestRuntimeOptions,
+) (*graphIngestRuntimeRunnerResult, error) {
+	runStore, ok := graphStore.(graphIngestRunStore)
+	if !ok {
+		return nil, fmt.Errorf("graph store does not support ingest run status")
+	}
+	result := &graphIngestRuntimeRunnerResult{
+		RuntimeID:  strings.TrimSpace(options.RuntimeID),
+		Iterations: options.Iterations,
+		RunForever: options.RunForever,
+		Runs:       make([]*graphIngestRuntimeResult, 0, graphIngestRuntimeResultCapacity(options)),
+	}
+	if options.Interval > 0 {
+		result.Interval = options.Interval.String()
+	}
+	var (
+		ticker    *time.Ticker
+		joined    error
+		iteration uint32
+	)
+	if options.RunForever || options.Iterations > 1 {
+		ticker = time.NewTicker(options.Interval)
+		defer ticker.Stop()
+	}
+	for {
+		runResult, err := ingestRuntimeGraphOnce(ctx, runtimeStore, sourceService, projector, graphStore, runStore, options, iteration)
+		if runResult != nil {
+			result.Runs = append(result.Runs, runResult)
+		}
+		joined = errors.Join(joined, err)
+		iteration++
+		if !options.RunForever && iteration >= options.Iterations {
+			break
+		}
+		if ticker == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			joined = errors.Join(joined, ctx.Err())
+			return result, joined
+		case <-ticker.C:
+		}
+	}
+	return result, joined
+}
+
+func ingestRuntimeGraphOnce(
+	ctx context.Context,
+	runtimeStore ports.SourceRuntimeStore,
+	sourceService *sourceops.Service,
+	projector ports.SourceProjector,
+	graphStore ports.GraphStore,
+	runStore graphIngestRunStore,
+	options graphIngestRuntimeOptions,
+	iteration uint32,
+) (*graphIngestRuntimeResult, error) {
+	startedAt := time.Now().UTC()
+	run := graphstore.IngestRun{
+		ID:        graphIngestRunID(options.RuntimeID, startedAt, iteration),
+		RuntimeID: strings.TrimSpace(options.RuntimeID),
+		Status:    graphstore.IngestRunStatusRunning,
+		Trigger:   graphIngestTrigger(options),
+		StartedAt: startedAt.Format(time.RFC3339Nano),
+	}
+	runResult := &graphIngestRuntimeResult{Run: run}
+	if err := runStore.PutIngestRun(ctx, run); err != nil {
+		return runResult, err
+	}
+	runtime, err := runtimeStore.GetSourceRuntime(ctx, run.RuntimeID)
+	if err != nil {
+		failed := finishGraphIngestRun(run, nil, graphstore.IngestRunStatusFailed, err)
+		runResult.Run = failed
+		return runResult, errors.Join(err, runStore.PutIngestRun(ctx, failed))
+	}
+	runtimeConfig, err := prepareSourceConfig(ctx, runtime.GetSourceId(), "read", runtime.GetConfig())
+	if err != nil {
+		run.SourceID = strings.TrimSpace(runtime.GetSourceId())
+		run.TenantID = strings.TrimSpace(runtime.GetTenantId())
+		failed := finishGraphIngestRun(run, nil, graphstore.IngestRunStatusFailed, err)
+		runResult.Run = failed
+		return runResult, errors.Join(err, runStore.PutIngestRun(ctx, failed))
+	}
+	ingestOptions := graphIngestOptions{
+		SourceID:          strings.TrimSpace(runtime.GetSourceId()),
+		SourceConfig:      runtimeConfig,
+		TenantID:          strings.TrimSpace(runtime.GetTenantId()),
+		PageLimit:         options.PageLimit,
+		CheckpointEnabled: true,
+		CheckpointID:      graphRuntimeCheckpointID(options, runtime, runtimeConfig),
+		ResetCheckpoint:   options.ResetCheckpoint,
+	}
+	run.SourceID = ingestOptions.SourceID
+	run.TenantID = ingestOptions.TenantID
+	run.CheckpointID = ingestOptions.CheckpointID
+	runResult.Run = run
+	if err := runStore.PutIngestRun(ctx, run); err != nil {
+		return runResult, err
+	}
+	ingestResult, err := ingestGraph(ctx, sourceService, projector, graphStore, ingestOptions)
+	runResult.Ingest = ingestResult
+	if err != nil {
+		failed := finishGraphIngestRun(run, ingestResult, graphstore.IngestRunStatusFailed, err)
+		runResult.Run = failed
+		return runResult, errors.Join(err, runStore.PutIngestRun(ctx, failed))
+	}
+	completed := finishGraphIngestRun(run, ingestResult, graphstore.IngestRunStatusCompleted, nil)
+	runResult.Run = completed
+	if err := runStore.PutIngestRun(ctx, completed); err != nil {
+		return runResult, err
+	}
+	return runResult, nil
 }
 
 func prepareGraphIngestCheckpoint(
@@ -554,6 +908,94 @@ func graphIngestCheckpointID(options graphIngestOptions) string {
 		hash = hash[:16]
 	}
 	return strings.TrimSpace(options.SourceID) + ":" + tenantID + ":" + hash
+}
+
+func graphRuntimeCheckpointID(options graphIngestRuntimeOptions, runtime *cerebrov1.SourceRuntime, config map[string]string) string {
+	if normalized := strings.TrimSpace(options.CheckpointID); normalized != "" {
+		return normalized
+	}
+	hash := graphIngestConfigHash(config)
+	if len(hash) > 16 {
+		hash = hash[:16]
+	}
+	return "runtime:" + sanitizeGraphIngestIDPart(runtime.GetId()) + ":" + hash
+}
+
+func graphIngestRunID(runtimeID string, startedAt time.Time, iteration uint32) string {
+	return fmt.Sprintf("graph-ingest:%s:%s:%d", sanitizeGraphIngestIDPart(runtimeID), startedAt.UTC().Format("20060102T150405.000000000Z"), iteration+1)
+}
+
+func sanitizeGraphIngestIDPart(value string) string {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return "unknown"
+	}
+	var builder strings.Builder
+	lastDash := false
+	for _, char := range normalized {
+		switch {
+		case char >= 'a' && char <= 'z', char >= 'A' && char <= 'Z', char >= '0' && char <= '9':
+			builder.WriteRune(char)
+			lastDash = false
+		default:
+			if !lastDash {
+				builder.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	sanitized := strings.Trim(builder.String(), "-")
+	if sanitized == "" {
+		return "unknown"
+	}
+	return sanitized
+}
+
+func graphIngestRuntimeResultCapacity(options graphIngestRuntimeOptions) int {
+	if options.RunForever {
+		return 1
+	}
+	if options.Iterations == 0 {
+		return 1
+	}
+	return int(options.Iterations)
+}
+
+func graphIngestTrigger(options graphIngestRuntimeOptions) string {
+	if options.RunForever || options.Iterations > 1 {
+		return "scheduled"
+	}
+	return "manual"
+}
+
+func finishGraphIngestRun(run graphstore.IngestRun, result *graphIngestResult, status string, runErr error) graphstore.IngestRun {
+	finished := run
+	finished.Status = status
+	finished.FinishedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	if result != nil {
+		finished.CheckpointID = result.CheckpointID
+		finished.PagesRead = int64(result.PagesRead)
+		finished.EventsRead = int64(result.EventsRead)
+		finished.EntitiesProjected = int64(result.EntitiesProjected)
+		finished.LinksProjected = int64(result.LinksProjected)
+		finished.GraphNodesBefore = result.GraphNodesBefore
+		finished.GraphLinksBefore = result.GraphLinksBefore
+		finished.GraphNodesAfter = result.GraphNodesAfter
+		finished.GraphLinksAfter = result.GraphLinksAfter
+	}
+	if runErr != nil {
+		finished.Error = runErr.Error()
+	}
+	return finished
+}
+
+func validGraphIngestRunStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case graphstore.IngestRunStatusRunning, graphstore.IngestRunStatusCompleted, graphstore.IngestRunStatusFailed:
+		return true
+	default:
+		return false
+	}
 }
 
 func graphIngestConfigHash(config map[string]string) string {

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
@@ -54,6 +55,53 @@ func TestParseGraphIngestArgsRejectsInvalidPageLimit(t *testing.T) {
 	_, err := parseGraphIngestArgs([]string{"aws", "page_limit=0"})
 	if err == nil {
 		t.Fatal("parseGraphIngestArgs() error = nil, want non-nil")
+	}
+}
+
+func TestParseGraphIngestRuntimeArgs(t *testing.T) {
+	options, err := parseGraphIngestRuntimeArgs([]string{
+		"writer-github",
+		"page_limit=3",
+		"checkpoint_id=runtime-writer-github",
+		"reset_checkpoint=true",
+		"interval=30s",
+		"iterations=2",
+	})
+	if err != nil {
+		t.Fatalf("parseGraphIngestRuntimeArgs() error = %v", err)
+	}
+	if options.RuntimeID != "writer-github" {
+		t.Fatalf("RuntimeID = %q, want writer-github", options.RuntimeID)
+	}
+	if options.PageLimit != 3 {
+		t.Fatalf("PageLimit = %d, want 3", options.PageLimit)
+	}
+	if options.CheckpointID != "runtime-writer-github" || !options.ResetCheckpoint {
+		t.Fatalf("checkpoint options = id:%q reset:%t", options.CheckpointID, options.ResetCheckpoint)
+	}
+	if options.Interval != 30*time.Second || options.Iterations != 2 || options.RunForever {
+		t.Fatalf("schedule options = interval:%s iterations:%d forever:%t", options.Interval, options.Iterations, options.RunForever)
+	}
+}
+
+func TestParseGraphIngestRuntimeArgsRequiresIntervalForSchedule(t *testing.T) {
+	_, err := parseGraphIngestRuntimeArgs([]string{"writer-github", "iterations=2"})
+	if err == nil {
+		t.Fatal("parseGraphIngestRuntimeArgs() error = nil, want non-nil")
+	}
+}
+
+func TestParseGraphIngestRunsArgs(t *testing.T) {
+	options, err := parseGraphIngestRunsArgs([]string{
+		"runtime_id=writer-github",
+		"status=failed",
+		"limit=7",
+	})
+	if err != nil {
+		t.Fatalf("parseGraphIngestRunsArgs() error = %v", err)
+	}
+	if options.RuntimeID != "writer-github" || options.Status != "failed" || options.Limit != 7 {
+		t.Fatalf("options = %#v, want runtime/status/limit", options)
 	}
 }
 

--- a/cmd/cerebro/graph_validation_test.go
+++ b/cmd/cerebro/graph_validation_test.go
@@ -103,13 +103,85 @@ func TestGraphKuzuCLIValidationFlow(t *testing.T) {
 	}
 }
 
+func TestGraphRuntimeIngestRecordsStatus(t *testing.T) {
+	ctx := context.Background()
+	store, err := graphstorekuzu.Open(configpkg.GraphStoreConfig{
+		Driver:   configpkg.GraphStoreDriverKuzu,
+		KuzuPath: filepath.Join(t.TempDir(), "graph"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := store.Close(); closeErr != nil {
+			t.Fatalf("Close() error = %v", closeErr)
+		}
+	})
+	source, err := validationFixtureSourceWithID("validation")
+	if err != nil {
+		t.Fatalf("validationFixtureSourceWithID() error = %v", err)
+	}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	runtimeStore := &validationRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-validation": {
+			Id:       "writer-validation",
+			SourceId: "validation",
+			TenantId: "writer",
+			Config:   map[string]string{"family": "audit"},
+		},
+		"writer-validation-failing": {
+			Id:       "writer-validation-failing",
+			SourceId: "validation",
+			TenantId: "writer",
+			Config:   map[string]string{"family": "missing"},
+		},
+	}}
+	projector := sourceprojection.New(nil, store)
+	result, err := ingestRuntimeGraph(ctx, runtimeStore, sourceops.New(registry), projector, store, graphIngestRuntimeOptions{
+		RuntimeID:    "writer-validation",
+		PageLimit:    2,
+		CheckpointID: "runtime-validation",
+	})
+	if err != nil {
+		t.Fatalf("ingestRuntimeGraph() error = %v", err)
+	}
+	if len(result.Runs) != 1 || result.Runs[0].Run.Status != "completed" || result.Runs[0].Ingest.EventsRead != 2 {
+		t.Fatalf("ingestRuntimeGraph() = %#v, want one completed two-event run", result)
+	}
+	completed, err := store.ListIngestRuns(ctx, graphstorekuzu.IngestRunFilter{RuntimeID: "writer-validation", Status: "completed", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListIngestRuns(completed) error = %v", err)
+	}
+	if len(completed) != 1 || completed[0].CheckpointID != "runtime-validation" {
+		t.Fatalf("completed runs = %#v, want runtime-validation checkpoint", completed)
+	}
+
+	failedResult, err := ingestRuntimeGraph(ctx, runtimeStore, sourceops.New(registry), projector, store, graphIngestRuntimeOptions{
+		RuntimeID: "writer-validation-failing",
+		PageLimit: defaultGraphIngestPageLimit,
+	})
+	if err == nil {
+		t.Fatal("ingestRuntimeGraph(failing) error = nil, want non-nil")
+	}
+	if len(failedResult.Runs) != 1 || failedResult.Runs[0].Run.Status != "failed" || failedResult.Runs[0].Run.Error == "" {
+		t.Fatalf("failed ingest result = %#v, want failed run with error", failedResult)
+	}
+}
+
 func validationFixtureSource() (sourcecdk.Source, error) {
+	return validationFixtureSourceWithID("github")
+}
+
+func validationFixtureSourceWithID(sourceID string) (sourcecdk.Source, error) {
 	events := []*primitives.Event{
 		validationGitHubAuditEvent("github-audit-validation-1"),
 		validationGitHubAuditEvent("github-audit-validation-2"),
 	}
 	return sourcecdk.NewFixtureSource(sourcecdk.FixtureSourceOptions{
-		Spec:          &cerebrov1.SourceSpec{Id: "github", Name: "GitHub validation fixture"},
+		Spec:          &cerebrov1.SourceSpec{Id: sourceID, Name: "Graph validation fixture"},
 		DefaultFamily: "audit",
 		Families: []sourcecdk.FixtureFamily{{
 			Name:   "audit",
@@ -145,4 +217,25 @@ func neighborhoodHasEvidence(relations []*ports.NeighborhoodRelation, key string
 		}
 	}
 	return false
+}
+
+type validationRuntimeStore struct {
+	runtimes map[string]*cerebrov1.SourceRuntime
+}
+
+func (s *validationRuntimeStore) Ping(context.Context) error {
+	return nil
+}
+
+func (s *validationRuntimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {
+	s.runtimes[runtime.GetId()] = runtime
+	return nil
+}
+
+func (s *validationRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov1.SourceRuntime, error) {
+	runtime, ok := s.runtimes[id]
+	if !ok {
+		return nil, ports.ErrSourceRuntimeNotFound
+	}
+	return runtime, nil
 }

--- a/internal/graphstore/kuzu/ingest_run.go
+++ b/internal/graphstore/kuzu/ingest_run.go
@@ -1,0 +1,224 @@
+package kuzu
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/graphstore"
+)
+
+const defaultIngestRunListLimit = 25
+
+// PutIngestRun upserts one operational graph ingest run.
+func (s *Store) PutIngestRun(ctx context.Context, run IngestRun) error {
+	run.ID = strings.TrimSpace(run.ID)
+	if run.ID == "" {
+		return errors.New("ingest run id is required")
+	}
+	run.Status = strings.TrimSpace(run.Status)
+	if run.Status == "" {
+		return errors.New("ingest run status is required")
+	}
+	if !validIngestRunStatus(run.Status) {
+		return fmt.Errorf("unsupported ingest run status %q", run.Status)
+	}
+	if s == nil || s.db == nil {
+		return errors.New("kuzu is not configured")
+	}
+	if err := s.ensureIngestRunSchema(ctx); err != nil {
+		return err
+	}
+	statement := fmt.Sprintf(
+		"MERGE (r:ingest_run {id: %s}) SET r.runtime_id = %s, r.source_id = %s, r.tenant_id = %s, r.checkpoint_id = %s, r.status = %s, r.trigger = %s, r.pages_read = %d, r.events_read = %d, r.entities_projected = %d, r.links_projected = %d, r.graph_nodes_before = %d, r.graph_links_before = %d, r.graph_nodes_after = %d, r.graph_links_after = %d, r.started_at = %s, r.finished_at = %s, r.error_message = %s",
+		cypherString(run.ID),
+		cypherString(strings.TrimSpace(run.RuntimeID)),
+		cypherString(strings.TrimSpace(run.SourceID)),
+		cypherString(strings.TrimSpace(run.TenantID)),
+		cypherString(strings.TrimSpace(run.CheckpointID)),
+		cypherString(run.Status),
+		cypherString(strings.TrimSpace(run.Trigger)),
+		run.PagesRead,
+		run.EventsRead,
+		run.EntitiesProjected,
+		run.LinksProjected,
+		run.GraphNodesBefore,
+		run.GraphLinksBefore,
+		run.GraphNodesAfter,
+		run.GraphLinksAfter,
+		cypherString(strings.TrimSpace(run.StartedAt)),
+		cypherString(strings.TrimSpace(run.FinishedAt)),
+		cypherString(strings.TrimSpace(run.Error)),
+	)
+	if _, err := s.db.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("upsert ingest run %q: %w", run.ID, err)
+	}
+	return nil
+}
+
+// GetIngestRun returns one operational graph ingest run.
+func (s *Store) GetIngestRun(ctx context.Context, id string) (IngestRun, bool, error) {
+	normalizedID := strings.TrimSpace(id)
+	if normalizedID == "" {
+		return IngestRun{}, false, errors.New("ingest run id is required")
+	}
+	if s == nil || s.db == nil {
+		return IngestRun{}, false, errors.New("kuzu is not configured")
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return IngestRun{}, false, err
+	}
+	if !tables["ingest_run"] {
+		return IngestRun{}, false, nil
+	}
+	var run IngestRun
+	if err := s.db.QueryRowContext(ctx, fmt.Sprintf(
+		"MATCH (r:ingest_run {id: %s}) RETURN r.id, r.runtime_id, r.source_id, r.tenant_id, r.checkpoint_id, r.status, r.trigger, r.pages_read, r.events_read, r.entities_projected, r.links_projected, r.graph_nodes_before, r.graph_links_before, r.graph_nodes_after, r.graph_links_after, r.started_at, r.finished_at, r.error_message",
+		cypherString(normalizedID),
+	)).Scan(
+		&run.ID,
+		&run.RuntimeID,
+		&run.SourceID,
+		&run.TenantID,
+		&run.CheckpointID,
+		&run.Status,
+		&run.Trigger,
+		&run.PagesRead,
+		&run.EventsRead,
+		&run.EntitiesProjected,
+		&run.LinksProjected,
+		&run.GraphNodesBefore,
+		&run.GraphLinksBefore,
+		&run.GraphNodesAfter,
+		&run.GraphLinksAfter,
+		&run.StartedAt,
+		&run.FinishedAt,
+		&run.Error,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return IngestRun{}, false, nil
+		}
+		return IngestRun{}, false, fmt.Errorf("query ingest run %q: %w", normalizedID, err)
+	}
+	return run, true, nil
+}
+
+// ListIngestRuns returns recent operational graph ingest runs.
+func (s *Store) ListIngestRuns(ctx context.Context, filter IngestRunFilter) (_ []IngestRun, err error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("kuzu is not configured")
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !tables["ingest_run"] {
+		return nil, nil
+	}
+	limit := filter.Limit
+	if limit == 0 {
+		limit = defaultIngestRunListLimit
+	}
+	if limit < 0 || limit > 500 {
+		return nil, fmt.Errorf("ingest run limit must be between 1 and 500")
+	}
+	where := make([]string, 0, 2)
+	if runtimeID := strings.TrimSpace(filter.RuntimeID); runtimeID != "" {
+		where = append(where, "r.runtime_id = "+cypherString(runtimeID))
+	}
+	if status := strings.TrimSpace(filter.Status); status != "" {
+		if !validIngestRunStatus(status) {
+			return nil, fmt.Errorf("unsupported ingest run status %q", status)
+		}
+		where = append(where, "r.status = "+cypherString(status))
+	}
+	query := "MATCH (r:ingest_run)"
+	if len(where) > 0 {
+		query += " WHERE " + strings.Join(where, " AND ")
+	}
+	query += fmt.Sprintf(" RETURN r.id, r.runtime_id, r.source_id, r.tenant_id, r.checkpoint_id, r.status, r.trigger, r.pages_read, r.events_read, r.entities_projected, r.links_projected, r.graph_nodes_before, r.graph_links_before, r.graph_nodes_after, r.graph_links_after, r.started_at, r.finished_at, r.error_message ORDER BY r.started_at DESC, r.id DESC LIMIT %d", limit)
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list ingest runs: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close ingest runs: %w", closeErr)
+		}
+	}()
+	runs := make([]IngestRun, 0, limit)
+	for rows.Next() {
+		run, err := scanIngestRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate ingest runs: %w", err)
+	}
+	return runs, nil
+}
+
+func (s *Store) ensureIngestRunSchema(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return errors.New("kuzu is not configured")
+	}
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	if s.ingestRunSchemaReady {
+		return nil
+	}
+	tables, err := s.graphTables(ctx)
+	if err != nil {
+		return err
+	}
+	if !tables["ingest_run"] {
+		if _, err := s.db.ExecContext(ctx, "CREATE NODE TABLE ingest_run(id STRING, runtime_id STRING, source_id STRING, tenant_id STRING, checkpoint_id STRING, status STRING, trigger STRING, pages_read INT64, events_read INT64, entities_projected INT64, links_projected INT64, graph_nodes_before INT64, graph_links_before INT64, graph_nodes_after INT64, graph_links_after INT64, started_at STRING, finished_at STRING, error_message STRING, PRIMARY KEY (id))"); err != nil {
+			return fmt.Errorf("create ingest run table: %w", err)
+		}
+	}
+	s.ingestRunSchemaReady = true
+	return nil
+}
+
+func scanIngestRun(scanner interface {
+	Scan(dest ...any) error
+}) (IngestRun, error) {
+	var run IngestRun
+	if err := scanner.Scan(
+		&run.ID,
+		&run.RuntimeID,
+		&run.SourceID,
+		&run.TenantID,
+		&run.CheckpointID,
+		&run.Status,
+		&run.Trigger,
+		&run.PagesRead,
+		&run.EventsRead,
+		&run.EntitiesProjected,
+		&run.LinksProjected,
+		&run.GraphNodesBefore,
+		&run.GraphLinksBefore,
+		&run.GraphNodesAfter,
+		&run.GraphLinksAfter,
+		&run.StartedAt,
+		&run.FinishedAt,
+		&run.Error,
+	); err != nil {
+		return IngestRun{}, fmt.Errorf("scan ingest run: %w", err)
+	}
+	return run, nil
+}
+
+func validIngestRunStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case graphstore.IngestRunStatusRunning, graphstore.IngestRunStatusCompleted, graphstore.IngestRunStatusFailed:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/graphstore/kuzu/ingest_run_test.go
+++ b/internal/graphstore/kuzu/ingest_run_test.go
@@ -1,0 +1,78 @@
+package kuzu
+
+import (
+	"context"
+	"testing"
+
+	"github.com/writer/cerebro/internal/graphstore"
+)
+
+func TestIngestRunRoundTripAndList(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	if _, ok, err := store.GetIngestRun(ctx, "run-1"); err != nil {
+		t.Fatalf("GetIngestRun() error = %v", err)
+	} else if ok {
+		t.Fatal("GetIngestRun() ok = true, want false")
+	}
+
+	first := IngestRun{
+		ID:                "run-1",
+		RuntimeID:         "writer-github",
+		SourceID:          "github",
+		TenantID:          "writer",
+		CheckpointID:      "runtime:writer-github:hash",
+		Status:            graphstore.IngestRunStatusCompleted,
+		Trigger:           "manual",
+		PagesRead:         2,
+		EventsRead:        3,
+		EntitiesProjected: 4,
+		LinksProjected:    5,
+		GraphNodesBefore:  6,
+		GraphLinksBefore:  7,
+		GraphNodesAfter:   8,
+		GraphLinksAfter:   9,
+		StartedAt:         "2026-04-29T00:00:00Z",
+		FinishedAt:        "2026-04-29T00:00:01Z",
+	}
+	second := first
+	second.ID = "run-2"
+	second.RuntimeID = "writer-aws"
+	second.SourceID = "aws"
+	second.Status = graphstore.IngestRunStatusFailed
+	second.Error = "read failed"
+	second.StartedAt = "2026-04-29T00:00:02Z"
+	if err := store.PutIngestRun(ctx, first); err != nil {
+		t.Fatalf("PutIngestRun(first) error = %v", err)
+	}
+	if err := store.PutIngestRun(ctx, second); err != nil {
+		t.Fatalf("PutIngestRun(second) error = %v", err)
+	}
+
+	got, ok, err := store.GetIngestRun(ctx, second.ID)
+	if err != nil {
+		t.Fatalf("GetIngestRun() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetIngestRun() ok = false, want true")
+	}
+	if got != second {
+		t.Fatalf("GetIngestRun() = %#v, want %#v", got, second)
+	}
+
+	failed, err := store.ListIngestRuns(ctx, IngestRunFilter{Status: graphstore.IngestRunStatusFailed, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListIngestRuns(failed) error = %v", err)
+	}
+	if len(failed) != 1 || failed[0].ID != second.ID {
+		t.Fatalf("ListIngestRuns(failed) = %#v, want run-2", failed)
+	}
+	writerGitHub, err := store.ListIngestRuns(ctx, IngestRunFilter{RuntimeID: "writer-github", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListIngestRuns(runtime) error = %v", err)
+	}
+	if len(writerGitHub) != 1 || writerGitHub[0].ID != first.ID {
+		t.Fatalf("ListIngestRuns(runtime) = %#v, want run-1", writerGitHub)
+	}
+}

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -24,6 +24,7 @@ type Store struct {
 	schemaMu              sync.Mutex
 	schemaReady           bool
 	checkpointSchemaReady bool
+	ingestRunSchemaReady  bool
 }
 
 type Counts = graphstore.Counts
@@ -32,6 +33,8 @@ type IntegrityCheck = graphstore.IntegrityCheck
 type PathPattern = graphstore.PathPattern
 type Topology = graphstore.Topology
 type IngestCheckpoint = graphstore.IngestCheckpoint
+type IngestRun = graphstore.IngestRun
+type IngestRunFilter = graphstore.IngestRunFilter
 
 // Open opens a Kuzu-backed graph projection store.
 func Open(cfg config.GraphStoreConfig) (*Store, error) {

--- a/internal/graphstore/types.go
+++ b/internal/graphstore/types.go
@@ -57,3 +57,38 @@ type IngestCheckpoint struct {
 	EventsRead       int64  `json:"events_read"`
 	UpdatedAt        string `json:"updated_at,omitempty"`
 }
+
+const (
+	IngestRunStatusRunning   = "running"
+	IngestRunStatusCompleted = "completed"
+	IngestRunStatusFailed    = "failed"
+)
+
+// IngestRun records one operational graph ingest attempt.
+type IngestRun struct {
+	ID                string `json:"id"`
+	RuntimeID         string `json:"runtime_id,omitempty"`
+	SourceID          string `json:"source_id,omitempty"`
+	TenantID          string `json:"tenant_id,omitempty"`
+	CheckpointID      string `json:"checkpoint_id,omitempty"`
+	Status            string `json:"status"`
+	Trigger           string `json:"trigger,omitempty"`
+	PagesRead         int64  `json:"pages_read"`
+	EventsRead        int64  `json:"events_read"`
+	EntitiesProjected int64  `json:"entities_projected"`
+	LinksProjected    int64  `json:"links_projected"`
+	GraphNodesBefore  int64  `json:"graph_nodes_before,omitempty"`
+	GraphLinksBefore  int64  `json:"graph_links_before,omitempty"`
+	GraphNodesAfter   int64  `json:"graph_nodes_after,omitempty"`
+	GraphLinksAfter   int64  `json:"graph_links_after,omitempty"`
+	StartedAt         string `json:"started_at,omitempty"`
+	FinishedAt        string `json:"finished_at,omitempty"`
+	Error             string `json:"error,omitempty"`
+}
+
+// IngestRunFilter scopes ingest run listing.
+type IngestRunFilter struct {
+	RuntimeID string
+	Status    string
+	Limit     int
+}


### PR DESCRIPTION
## Summary
- add `graph ingest-runtime` for source-runtime driven Kuzu ingest with checkpoint reuse and optional scheduled iterations
- persist Kuzu ingest run records with running/completed/failed status, counts, timestamps, checkpoint IDs, and error messages
- add `graph ingest-run` and `graph ingest-runs` status inspection commands

## Validation
- `make verify`
- `make finding-rule-test`
- `git diff --check`
- `go test ./cmd/cerebro -run TestGraphRuntimeIngestRecordsStatus -count=1 -v`
- `CEREBRO_RUN_AWS_GITHUB_KUZU_E2E=1 ... go test ./cmd/cerebro -run TestAWSGitHubKuzuSharedIdentityLiveE2E -count=1 -v`