### PR TITLE
fix(linters): close guardrail bypasses

### DIFF
--- a/tools/linters/nobackgroundctx/nobackgroundctx.go
+++ b/tools/linters/nobackgroundctx/nobackgroundctx.go
@@ -3,6 +3,7 @@ package nobackgroundctx
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"path/filepath"
 	"strings"
 
@@ -30,21 +31,36 @@ func run(pass *analysis.Pass) (any, error) {
 		if fileAllowed(pass, call.Pos()) {
 			return
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return
-		}
-		pkg, ok := sel.X.(*ast.Ident)
-		if !ok || pkg.Name != "context" {
-			return
-		}
-		switch sel.Sel.Name {
-		case "Background", "TODO":
+		report := func(name string) {
 			pass.Report(analysis.Diagnostic{
 				Pos:     call.Pos(),
 				End:     call.End(),
-				Message: "context." + sel.Sel.Name + " is forbidden outside cmd/ and tests; accept a context from the caller instead. (see PLAN.md §7 sin #12)",
+				Message: "context." + name + " is forbidden outside cmd/ and tests; accept a context from the caller instead. (see PLAN.md §7 sin #12)",
 			})
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			pkgIdent, ok := fun.X.(*ast.Ident)
+			if !ok {
+				return
+			}
+			pkgName, ok := pass.TypesInfo.Uses[pkgIdent].(*types.PkgName)
+			if !ok || pkgName.Imported() == nil || pkgName.Imported().Path() != "context" {
+				return
+			}
+			switch fun.Sel.Name {
+			case "Background", "TODO":
+				report(fun.Sel.Name)
+			}
+		case *ast.Ident:
+			fn, ok := pass.TypesInfo.Uses[fun].(*types.Func)
+			if !ok || fn.Pkg() == nil || fn.Pkg().Path() != "context" {
+				return
+			}
+			switch fn.Name() {
+			case "Background", "TODO":
+				report(fn.Name())
+			}
 		}
 	})
 	return nil, nil

--- a/tools/linters/nobackgroundctx/testdata/src/a/a.go
+++ b/tools/linters/nobackgroundctx/testdata/src/a/a.go
@@ -1,6 +1,10 @@
 package a
 
-import "context"
+import (
+	"context"
+	. "context"
+	c "context"
+)
 
 func Bad() context.Context {
 	return context.Background() // want `context.Background is forbidden outside cmd/ and tests`
@@ -8,4 +12,12 @@ func Bad() context.Context {
 
 func AlsoBad() context.Context {
 	return context.TODO() // want `context.TODO is forbidden outside cmd/ and tests`
+}
+
+func AliasBad() context.Context {
+	return c.Background() // want `context.Background is forbidden outside cmd/ and tests`
+}
+
+func DotBad() context.Context {
+	return TODO() // want `context.TODO is forbidden outside cmd/ and tests`
 }

--- a/tools/linters/noenvoutsidecmd/noenvoutsidecmd.go
+++ b/tools/linters/noenvoutsidecmd/noenvoutsidecmd.go
@@ -3,6 +3,7 @@ package noenvoutsidecmd
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"path/filepath"
 	"strings"
 
@@ -30,21 +31,36 @@ func run(pass *analysis.Pass) (any, error) {
 		if fileAllowed(pass, call.Pos()) {
 			return
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return
-		}
-		pkg, ok := sel.X.(*ast.Ident)
-		if !ok || pkg.Name != "os" {
-			return
-		}
-		switch sel.Sel.Name {
-		case "Getenv", "LookupEnv":
+		report := func(name string) {
 			pass.Report(analysis.Diagnostic{
 				Pos:     call.Pos(),
 				End:     call.End(),
-				Message: "os." + sel.Sel.Name + " is forbidden outside cmd/ and config; thread configuration through typed inputs instead. (see PLAN.md §7 sin #11)",
+				Message: "os." + name + " is forbidden outside cmd/ and config; thread configuration through typed inputs instead. (see PLAN.md §7 sin #11)",
 			})
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			pkgIdent, ok := fun.X.(*ast.Ident)
+			if !ok {
+				return
+			}
+			pkgName, ok := pass.TypesInfo.Uses[pkgIdent].(*types.PkgName)
+			if !ok || pkgName.Imported() == nil || pkgName.Imported().Path() != "os" {
+				return
+			}
+			switch fun.Sel.Name {
+			case "Getenv", "LookupEnv":
+				report(fun.Sel.Name)
+			}
+		case *ast.Ident:
+			fn, ok := pass.TypesInfo.Uses[fun].(*types.Func)
+			if !ok || fn.Pkg() == nil || fn.Pkg().Path() != "os" {
+				return
+			}
+			switch fn.Name() {
+			case "Getenv", "LookupEnv":
+				report(fn.Name())
+			}
 		}
 	})
 	return nil, nil

--- a/tools/linters/noenvoutsidecmd/testdata/src/a/a.go
+++ b/tools/linters/noenvoutsidecmd/testdata/src/a/a.go
@@ -1,6 +1,10 @@
 package a
 
-import "os"
+import (
+	"os"
+	. "os"
+	o "os"
+)
 
 func Bad() string {
 	return os.Getenv("HOME") // want `os.Getenv is forbidden outside cmd/ and config`
@@ -9,4 +13,12 @@ func Bad() string {
 func AlsoBad() (string, bool) {
 	value, ok := os.LookupEnv("HOME") // want `os.LookupEnv is forbidden outside cmd/ and config`
 	return value, ok
+}
+
+func AliasBad() string {
+	return o.Getenv("HOME") // want `os.Getenv is forbidden outside cmd/ and config`
+}
+
+func DotBad() (string, bool) {
+	return LookupEnv("HOME") // want `os.LookupEnv is forbidden outside cmd/ and config`
 }

--- a/tools/linters/noinmemorydb/noinmemorydb.go
+++ b/tools/linters/noinmemorydb/noinmemorydb.go
@@ -3,6 +3,7 @@ package noinmemorydb
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"strconv"
 	"strings"
 
@@ -54,7 +55,7 @@ func run(pass *analysis.Pass) (any, error) {
 			if ident, ok := sel.X.(*ast.Ident); ok && strings.HasPrefix(strings.ToLower(ident.Name), "sqlite") {
 				report(pass, reported, call.Pos(), call.End())
 			}
-			if (sel.Sel.Name == "Open" || sel.Sel.Name == "OpenDB") && len(call.Args) > 0 && isSQLiteDriverLiteral(call.Args[0]) {
+			if (sel.Sel.Name == "Open" || sel.Sel.Name == "OpenDB") && len(call.Args) > 0 && isDatabaseSQLSelector(pass, sel) && isSQLiteDriverLiteral(call.Args[0]) {
 				report(pass, reported, call.Args[0].Pos(), call.Args[0].End())
 			}
 		}
@@ -65,6 +66,15 @@ func run(pass *analysis.Pass) (any, error) {
 		}
 	})
 	return nil, nil
+}
+
+func isDatabaseSQLSelector(pass *analysis.Pass, sel *ast.SelectorExpr) bool {
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	pkgName, ok := pass.TypesInfo.Uses[ident].(*types.PkgName)
+	return ok && pkgName.Imported() != nil && pkgName.Imported().Path() == "database/sql"
 }
 
 func report(pass *analysis.Pass, reported map[token.Pos]struct{}, pos, end token.Pos) {

--- a/tools/linters/noinmemorydb/testdata/src/a/a.go
+++ b/tools/linters/noinmemorydb/testdata/src/a/a.go
@@ -17,3 +17,11 @@ func AlsoBad() {
 func Good() {
 	_, _ = sql.Open("postgres", "postgres://db")
 }
+
+type opener struct{}
+
+func (opener) Open(driver string) {}
+
+func AlsoGood() {
+	opener{}.Open("sqlite")
+}

--- a/tools/linters/nopanicprod/nopanicprod.go
+++ b/tools/linters/nopanicprod/nopanicprod.go
@@ -43,7 +43,7 @@ func run(pass *analysis.Pass) (any, error) {
 			if !ok || ident.Name != "panic" {
 				return true
 			}
-			if enclosingFuncName(stack) == "init" {
+			if enclosingIsPackageInit(stack) {
 				return true
 			}
 			pass.Report(analysis.Diagnostic{
@@ -57,14 +57,14 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-func enclosingFuncName(stack []ast.Node) string {
+func enclosingIsPackageInit(stack []ast.Node) bool {
 	for i := len(stack) - 1; i >= 0; i-- {
 		decl, ok := stack[i].(*ast.FuncDecl)
 		if ok && decl.Name != nil {
-			return decl.Name.Name
+			return decl.Recv == nil && decl.Name.Name == "init"
 		}
 	}
-	return ""
+	return false
 }
 
 func packageAllowed(path string) bool {

--- a/tools/linters/nopanicprod/testdata/src/a/a.go
+++ b/tools/linters/nopanicprod/testdata/src/a/a.go
@@ -12,3 +12,9 @@ var _ = func() int {
 func init() {
 	panic("allowed during init")
 }
+
+type T struct{}
+
+func (T) init() {
+	panic("method init is not package init") // want `panic is forbidden outside tests, init, and panicsafe`
+}

--- a/tools/linters/sealedinterface/sealedinterface.go
+++ b/tools/linters/sealedinterface/sealedinterface.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"sort"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
@@ -25,11 +26,6 @@ var Analyzer = &analysis.Analyzer{
 	Doc:       doc,
 	FactTypes: []analysis.Fact{new(sealedFact)},
 	Run:       run,
-}
-
-type sealedInterface struct {
-	obj   *types.TypeName
-	iface *types.Interface
 }
 
 func run(pass *analysis.Pass) (any, error) {
@@ -83,6 +79,16 @@ func run(pass *analysis.Pass) (any, error) {
 		sealed[obj] = iface
 	}
 
+	sealedObjects := make([]*types.TypeName, 0, len(sealed))
+	for obj := range sealed {
+		sealedObjects = append(sealedObjects, obj)
+	}
+	sort.Slice(sealedObjects, func(i int, j int) bool {
+		left := qualifiedTypeName(sealedObjects[i])
+		right := qualifiedTypeName(sealedObjects[j])
+		return left < right
+	})
+
 	for _, file := range pass.Files {
 		if isTestFile(pass, file.Pos()) {
 			continue
@@ -108,10 +114,11 @@ func run(pass *analysis.Pass) (any, error) {
 				if !ok {
 					continue
 				}
-				for sealedObj, iface := range sealed {
+				for _, sealedObj := range sealedObjects {
 					if sealedObj == nil || sealedObj.Pkg() == nil || sealedObj.Pkg().Path() == pass.Pkg.Path() {
 						continue
 					}
+					iface := sealed[sealedObj]
 					if !implementsSealed(named, iface) {
 						continue
 					}
@@ -127,6 +134,13 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 
 	return nil, nil
+}
+
+func qualifiedTypeName(obj *types.TypeName) string {
+	if obj == nil || obj.Pkg() == nil {
+		return ""
+	}
+	return obj.Pkg().Path() + "." + obj.Name()
 }
 
 func namedInterface(t types.Type) *types.Interface {


### PR DESCRIPTION
## Summary
- land the current base `cerebro-next` branch into `main`
- close remaining guardrail bypasses in the linters

## Context
- `feat/cerebro-next-remove-legacy-cerebro-20260422` is already fully contained in `main`
- `feat/cerebro-next-guardrails-part-2-20260422` is the earliest `cerebro-next` branch that still diverges from `main`
