### PR TITLE
fix(cerebro-next): roll up remaining fixes into main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
-BUF := GOTOOLCHAIN=go1.26.2 go run github.com/bufbuild/buf/cmd/buf@latest
+BUF := GOTOOLCHAIN=go1.26.2 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
 APP_PACKAGES := ./cmd/... ./internal/... ./sources/...
 LINTER_MODULE := ./tools/linters
 LINTER_BIN := $(GO_BIN)/cerebrolint

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,10 +1,10 @@
 version: v2
 plugins:
-  - remote: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go:v1.36.11
     out: gen
     opt:
       - paths=source_relative
-  - remote: buf.build/connectrpc/go
+  - remote: buf.build/connectrpc/go:v1.19.2
     out: gen
     opt:
       - paths=source_relative

--- a/cmd/cerebro/aws_github_kuzu_live_e2e_test.go
+++ b/cmd/cerebro/aws_github_kuzu_live_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/cerebro/github_findings_live_e2e_test.go
+++ b/cmd/cerebro/github_findings_live_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/cerebro/github_local.go
+++ b/cmd/cerebro/github_local.go
@@ -111,17 +111,29 @@ func prepareSourceRuntimeWithCLI(ctx context.Context, runtime *cerebrov1.SourceR
 }
 
 func hydrateGitHubLocalConfig(ctx context.Context, config map[string]string, cli githubLocalCLI, requireRepo bool, requireToken bool) (map[string]string, error) {
+	config = cloneConfig(config)
 	needsRepo := strings.TrimSpace(config["owner"]) == "" || (requireRepo && strings.TrimSpace(config["repo"]) == "")
 	if needsRepo {
 		repo, err := cli.Repo(ctx)
 		if err != nil {
 			return nil, err
 		}
+		ghOwner := strings.TrimSpace(repo.Owner.Login)
+		ghRepo := strings.TrimSpace(repo.Name)
+		if ghOwner == "" || ghRepo == "" {
+			return nil, fmt.Errorf("resolve github repo from gh cli: owner and repo are required")
+		}
+		if existing := strings.TrimSpace(config["owner"]); existing != "" && existing != ghOwner {
+			return nil, fmt.Errorf("resolve github repo from gh cli: owner mismatch (config=%q gh=%q)", existing, ghOwner)
+		}
+		if existing := strings.TrimSpace(config["repo"]); existing != "" && existing != ghRepo {
+			return nil, fmt.Errorf("resolve github repo from gh cli: repo mismatch (config=%q gh=%q)", existing, ghRepo)
+		}
 		if strings.TrimSpace(config["owner"]) == "" {
-			config["owner"] = strings.TrimSpace(repo.Owner.Login)
+			config["owner"] = ghOwner
 		}
 		if requireRepo && strings.TrimSpace(config["repo"]) == "" {
-			config["repo"] = strings.TrimSpace(repo.Name)
+			config["repo"] = ghRepo
 		}
 	}
 	if strings.TrimSpace(config["token"]) == "" && (requireToken || needsRepo) {

--- a/cmd/cerebro/github_local_e2e_test.go
+++ b/cmd/cerebro/github_local_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/cerebro/github_local_e2e_test.go
+++ b/cmd/cerebro/github_local_e2e_test.go
@@ -51,14 +51,6 @@ func TestGitHubLocalEndToEndWithGHCLI(t *testing.T) {
 		t.Fatalf("prepareSourceConfigWithCLI() error = %v", err)
 	}
 
-	pulls, err := readGitHubPullsWithGHCLI(ctx, config["owner"], config["repo"], 5)
-	if err != nil {
-		t.Fatalf("readGitHubPullsWithGHCLI() error = %v", err)
-	}
-	if len(pulls) == 0 {
-		t.Fatal("readGitHubPullsWithGHCLI() returned zero pulls")
-	}
-
 	registry, err := sourceregistry.Builtin()
 	if err != nil {
 		t.Fatalf("Builtin() error = %v", err)
@@ -78,17 +70,24 @@ func TestGitHubLocalEndToEndWithGHCLI(t *testing.T) {
 	if err := json.Unmarshal(response.GetEvents()[0].GetPayload(), &payload); err != nil {
 		t.Fatalf("unmarshal source payload: %v", err)
 	}
-	if payload.Number != pulls[0].Number {
-		t.Fatalf("source payload number = %d, want %d", payload.Number, pulls[0].Number)
+	if payload.Number == 0 {
+		t.Fatal("source payload number = 0, want non-zero")
 	}
-	if payload.Title != pulls[0].Title {
-		t.Fatalf("source payload title = %q, want %q", payload.Title, pulls[0].Title)
+	pull, err := readGitHubPullWithGHCLI(ctx, config["owner"], config["repo"], payload.Number)
+	if err != nil {
+		t.Fatalf("readGitHubPullWithGHCLI(%d) error = %v", payload.Number, err)
 	}
-	if payload.URL != pulls[0].HTMLURL {
-		t.Fatalf("source payload url = %q, want %q", payload.URL, pulls[0].HTMLURL)
+	if payload.Number != pull.Number {
+		t.Fatalf("source payload number = %d, want %d", payload.Number, pull.Number)
 	}
-	if payload.Author != pulls[0].User.Login {
-		t.Fatalf("source payload author = %q, want %q", payload.Author, pulls[0].User.Login)
+	if payload.Title != pull.Title {
+		t.Fatalf("source payload title = %q, want %q", payload.Title, pull.Title)
+	}
+	if payload.URL != pull.HTMLURL {
+		t.Fatalf("source payload url = %q, want %q", payload.URL, pull.HTMLURL)
+	}
+	if payload.Author != pull.User.Login {
+		t.Fatalf("source payload author = %q, want %q", payload.Author, pull.User.Login)
 	}
 
 	graphPath := filepath.Join(t.TempDir(), "graph")
@@ -142,17 +141,17 @@ func TestGitHubLocalEndToEndWithGHCLI(t *testing.T) {
 	)
 }
 
-func readGitHubPullsWithGHCLI(ctx context.Context, owner string, repo string, perPage int) ([]ghAPIPull, error) {
-	path := fmt.Sprintf("/repos/%s/%s/pulls?state=all&sort=updated&direction=desc&per_page=%d", owner, repo, perPage)
+func readGitHubPullWithGHCLI(ctx context.Context, owner string, repo string, number int) (ghAPIPull, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
 	output, err := exec.CommandContext(ctx, "gh", "api", path).Output()
 	if err != nil {
-		return nil, fmt.Errorf("read github pulls with gh cli: %w", err)
+		return ghAPIPull{}, fmt.Errorf("read github pull with gh cli: %w", err)
 	}
-	var pulls []ghAPIPull
-	if err := json.Unmarshal(output, &pulls); err != nil {
-		return nil, fmt.Errorf("decode github pulls from gh cli: %w", err)
+	var pull ghAPIPull
+	if err := json.Unmarshal(output, &pull); err != nil {
+		return ghAPIPull{}, fmt.Errorf("decode github pull from gh cli: %w", err)
 	}
-	return pulls, nil
+	return pull, nil
 }
 
 func graphCount(t *testing.T, db *sql.DB, query string) int64 {

--- a/cmd/cerebro/github_local_test.go
+++ b/cmd/cerebro/github_local_test.go
@@ -114,6 +114,42 @@ func TestPrepareSourceConfigWithCLIAuditHydratesOwnerAndToken(t *testing.T) {
 	}
 }
 
+func TestPrepareSourceConfigWithCLIRejectsOwnerMismatch(t *testing.T) {
+	cli := &fakeGitHubLocalCLI{
+		repo: githubLocalRepo{
+			Name: "cerebro",
+			Owner: githubLocalRepoOwner{
+				Login: "writer",
+			},
+		},
+	}
+
+	_, err := prepareSourceConfigWithCLI(context.Background(), githubSourceID, "read", map[string]string{
+		"owner": "other",
+	}, cli)
+	if err == nil {
+		t.Fatal("prepareSourceConfigWithCLI() error = nil, want non-nil")
+	}
+}
+
+func TestPrepareSourceConfigWithCLIRejectsRepoMismatch(t *testing.T) {
+	cli := &fakeGitHubLocalCLI{
+		repo: githubLocalRepo{
+			Name: "cerebro",
+			Owner: githubLocalRepoOwner{
+				Login: "writer",
+			},
+		},
+	}
+
+	_, err := prepareSourceConfigWithCLI(context.Background(), githubSourceID, "read", map[string]string{
+		"repo": "other",
+	}, cli)
+	if err == nil {
+		t.Fatal("prepareSourceConfigWithCLI() error = nil, want non-nil")
+	}
+}
+
 func TestPrepareSourceConfigWithCLIDependabotHydratesRepoAndToken(t *testing.T) {
 	cli := &fakeGitHubLocalCLI{
 		token: "gh-token",

--- a/cmd/cerebro/graph_validation_test.go
+++ b/cmd/cerebro/graph_validation_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -1955,7 +1955,7 @@ func (x *ReadSourceRequest) GetCursor() *SourceCursor {
 // SourcePreviewEvent exposes a decoded payload view for preview consumers.
 type SourcePreviewEvent struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
-	Event          *EventEnvelope         `protobuf:"bytes,1,opt,name=event,proto3" json:"event,omitempty"`
+	EventId        string                 `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
 	Payload        *structpb.Value        `protobuf:"bytes,2,opt,name=payload,proto3" json:"payload,omitempty"`
 	PayloadDecoded bool                   `protobuf:"varint,3,opt,name=payload_decoded,json=payloadDecoded,proto3" json:"payload_decoded,omitempty"`
 	unknownFields  protoimpl.UnknownFields
@@ -1992,11 +1992,11 @@ func (*SourcePreviewEvent) Descriptor() ([]byte, []int) {
 	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{33}
 }
 
-func (x *SourcePreviewEvent) GetEvent() *EventEnvelope {
+func (x *SourcePreviewEvent) GetEventId() string {
 	if x != nil {
-		return x.Event
+		return x.EventId
 	}
-	return nil
+	return ""
 }
 
 func (x *SourcePreviewEvent) GetPayload() *structpb.Value {
@@ -5576,9 +5576,9 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x06cursor\x18\x03 \x01(\v2\x18.cerebro.v1.SourceCursorR\x06cursor\x1a9\n" +
 	"\vConfigEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xa0\x01\n" +
-	"\x12SourcePreviewEvent\x12/\n" +
-	"\x05event\x18\x01 \x01(\v2\x19.cerebro.v1.EventEnvelopeR\x05event\x120\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8a\x01\n" +
+	"\x12SourcePreviewEvent\x12\x19\n" +
+	"\bevent_id\x18\x01 \x01(\tR\aeventId\x120\n" +
 	"\apayload\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\apayload\x12'\n" +
 	"\x0fpayload_decoded\x18\x03 \x01(\bR\x0epayloadDecoded\"\xb7\x02\n" +
 	"\x12ReadSourceResponse\x12.\n" +
@@ -6051,8 +6051,8 @@ var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*RuleSpec)(nil),                                  // 94: cerebro.v1.RuleSpec
 	(*SourceSpec)(nil),                                // 95: cerebro.v1.SourceSpec
 	(*SourceCursor)(nil),                              // 96: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                             // 97: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                            // 98: google.protobuf.Value
+	(*structpb.Value)(nil),                            // 97: google.protobuf.Value
+	(*EventEnvelope)(nil),                             // 98: cerebro.v1.EventEnvelope
 	(*SourceCheckpoint)(nil),                          // 99: cerebro.v1.SourceCheckpoint
 	(*Claim)(nil),                                     // 100: cerebro.v1.Claim
 }
@@ -6083,145 +6083,144 @@ var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
 	95,  // 23: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
 	88,  // 24: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
 	96,  // 25: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	97,  // 26: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	98,  // 27: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	95,  // 28: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	97,  // 29: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	99,  // 30: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	96,  // 31: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
-	34,  // 32: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	89,  // 33: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	99,  // 34: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	96,  // 35: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	92,  // 36: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
-	36,  // 37: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
-	36,  // 38: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	36,  // 39: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	36,  // 40: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	95,  // 41: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	100, // 42: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	100, // 43: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
-	0,   // 44: cerebro.v1.ListFindingsRequest.status:type_name -> cerebro.v1.FindingStatus
-	92,  // 45: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
-	92,  // 46: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
-	0,   // 47: cerebro.v1.Finding.status:type_name -> cerebro.v1.FindingStatus
-	90,  // 48: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	92,  // 49: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	92,  // 50: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	92,  // 51: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
-	48,  // 52: cerebro.v1.Finding.control_refs:type_name -> cerebro.v1.FindingControlRef
-	92,  // 53: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
-	49,  // 54: cerebro.v1.Finding.notes:type_name -> cerebro.v1.FindingNote
-	50,  // 55: cerebro.v1.Finding.tickets:type_name -> cerebro.v1.FindingTicket
-	51,  // 56: cerebro.v1.GetFindingResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 57: cerebro.v1.ResolveFindingResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 58: cerebro.v1.SuppressFindingResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 59: cerebro.v1.AssignFindingResponse.finding:type_name -> cerebro.v1.Finding
-	92,  // 60: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
-	51,  // 61: cerebro.v1.SetFindingDueDateResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 62: cerebro.v1.AddFindingNoteResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 63: cerebro.v1.LinkFindingTicketResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 64: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	94,  // 65: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
-	51,  // 66: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
-	13,  // 67: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
-	18,  // 68: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
-	36,  // 69: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	69,  // 70: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
-	36,  // 71: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	94,  // 72: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	51,  // 73: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	13,  // 74: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	18,  // 75: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	92,  // 76: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	92,  // 77: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	92,  // 78: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	93,  // 79: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
-	92,  // 80: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	92,  // 81: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	92,  // 82: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	93,  // 83: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
-	92,  // 84: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
-	92,  // 85: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
-	92,  // 86: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
-	93,  // 87: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
-	91,  // 88: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
-	80,  // 89: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	80,  // 90: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	81,  // 91: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	1,   // 92: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	3,   // 93: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	9,   // 94: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	11,  // 95: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
-	23,  // 96: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	25,  // 97: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	27,  // 98: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	29,  // 99: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	31,  // 100: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	33,  // 101: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	37,  // 102: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	39,  // 103: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	41,  // 104: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	43,  // 105: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	45,  // 106: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
-	47,  // 107: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
-	52,  // 108: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
-	54,  // 109: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
-	56,  // 110: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
-	58,  // 111: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
-	60,  // 112: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
-	62,  // 113: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
-	64,  // 114: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
-	14,  // 115: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
-	16,  // 116: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
-	19,  // 117: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
-	21,  // 118: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
-	68,  // 119: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
-	67,  // 120: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	72,  // 121: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
-	74,  // 122: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
-	76,  // 123: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
-	78,  // 124: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
-	82,  // 125: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	2,   // 126: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	5,   // 127: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	10,  // 128: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	12,  // 129: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
-	24,  // 130: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	26,  // 131: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	28,  // 132: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	30,  // 133: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	32,  // 134: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	35,  // 135: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	38,  // 136: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	40,  // 137: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	42,  // 138: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	44,  // 139: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	46,  // 140: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
-	66,  // 141: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
-	53,  // 142: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
-	55,  // 143: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
-	57,  // 144: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
-	59,  // 145: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
-	61,  // 146: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
-	63,  // 147: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
-	65,  // 148: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
-	15,  // 149: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
-	17,  // 150: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
-	20,  // 151: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
-	22,  // 152: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
-	70,  // 153: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
-	71,  // 154: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	73,  // 155: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
-	75,  // 156: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
-	77,  // 157: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
-	79,  // 158: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
-	83,  // 159: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	126, // [126:160] is the sub-list for method output_type
-	92,  // [92:126] is the sub-list for method input_type
-	92,  // [92:92] is the sub-list for extension type_name
-	92,  // [92:92] is the sub-list for extension extendee
-	0,   // [0:92] is the sub-list for field type_name
+	97,  // 26: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	95,  // 27: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	98,  // 28: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	99,  // 29: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	96,  // 30: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	34,  // 31: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
+	89,  // 32: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	99,  // 33: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	96,  // 34: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	92,  // 35: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	36,  // 36: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
+	36,  // 37: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	36,  // 38: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	36,  // 39: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	95,  // 40: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	100, // 41: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	100, // 42: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	0,   // 43: cerebro.v1.ListFindingsRequest.status:type_name -> cerebro.v1.FindingStatus
+	92,  // 44: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
+	92,  // 45: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
+	0,   // 46: cerebro.v1.Finding.status:type_name -> cerebro.v1.FindingStatus
+	90,  // 47: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	92,  // 48: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	92,  // 49: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	92,  // 50: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
+	48,  // 51: cerebro.v1.Finding.control_refs:type_name -> cerebro.v1.FindingControlRef
+	92,  // 52: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
+	49,  // 53: cerebro.v1.Finding.notes:type_name -> cerebro.v1.FindingNote
+	50,  // 54: cerebro.v1.Finding.tickets:type_name -> cerebro.v1.FindingTicket
+	51,  // 55: cerebro.v1.GetFindingResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 56: cerebro.v1.ResolveFindingResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 57: cerebro.v1.SuppressFindingResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 58: cerebro.v1.AssignFindingResponse.finding:type_name -> cerebro.v1.Finding
+	92,  // 59: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
+	51,  // 60: cerebro.v1.SetFindingDueDateResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 61: cerebro.v1.AddFindingNoteResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 62: cerebro.v1.LinkFindingTicketResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 63: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	94,  // 64: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
+	51,  // 65: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
+	13,  // 66: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
+	18,  // 67: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
+	36,  // 68: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	69,  // 69: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
+	36,  // 70: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	94,  // 71: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	51,  // 72: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	13,  // 73: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
+	18,  // 74: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	92,  // 75: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	92,  // 76: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	92,  // 77: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	93,  // 78: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
+	92,  // 79: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	92,  // 80: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	92,  // 81: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	93,  // 82: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
+	92,  // 83: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
+	92,  // 84: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
+	92,  // 85: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
+	93,  // 86: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
+	91,  // 87: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
+	80,  // 88: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	80,  // 89: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	81,  // 90: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	1,   // 91: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	3,   // 92: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	9,   // 93: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	11,  // 94: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
+	23,  // 95: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	25,  // 96: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	27,  // 97: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	29,  // 98: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	31,  // 99: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	33,  // 100: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	37,  // 101: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	39,  // 102: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	41,  // 103: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	43,  // 104: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	45,  // 105: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	47,  // 106: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
+	52,  // 107: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
+	54,  // 108: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
+	56,  // 109: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
+	58,  // 110: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
+	60,  // 111: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
+	62,  // 112: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
+	64,  // 113: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
+	14,  // 114: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
+	16,  // 115: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
+	19,  // 116: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
+	21,  // 117: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
+	68,  // 118: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	67,  // 119: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	72,  // 120: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
+	74,  // 121: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
+	76,  // 122: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
+	78,  // 123: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
+	82,  // 124: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	2,   // 125: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	5,   // 126: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	10,  // 127: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	12,  // 128: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
+	24,  // 129: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	26,  // 130: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	28,  // 131: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	30,  // 132: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	32,  // 133: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	35,  // 134: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	38,  // 135: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	40,  // 136: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	42,  // 137: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	44,  // 138: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	46,  // 139: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	66,  // 140: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
+	53,  // 141: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
+	55,  // 142: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
+	57,  // 143: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
+	59,  // 144: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
+	61,  // 145: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
+	63,  // 146: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
+	65,  // 147: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
+	15,  // 148: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
+	17,  // 149: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
+	20,  // 150: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
+	22,  // 151: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
+	70,  // 152: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	71,  // 153: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	73,  // 154: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
+	75,  // 155: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
+	77,  // 156: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
+	79,  // 157: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
+	83,  // 158: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	125, // [125:159] is the sub-list for method output_type
+	91,  // [91:125] is the sub-list for method input_type
+	91,  // [91:91] is the sub-list for extension type_name
+	91,  // [91:91] is the sub-list for extension extendee
+	0,   // [0:91] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -1955,9 +1955,10 @@ func (x *ReadSourceRequest) GetCursor() *SourceCursor {
 // SourcePreviewEvent exposes a decoded payload view for preview consumers.
 type SourcePreviewEvent struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
-	EventId        string                 `protobuf:"bytes,1,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	Event          *EventEnvelope         `protobuf:"bytes,1,opt,name=event,proto3" json:"event,omitempty"`
 	Payload        *structpb.Value        `protobuf:"bytes,2,opt,name=payload,proto3" json:"payload,omitempty"`
 	PayloadDecoded bool                   `protobuf:"varint,3,opt,name=payload_decoded,json=payloadDecoded,proto3" json:"payload_decoded,omitempty"`
+	EventId        string                 `protobuf:"bytes,4,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -1992,11 +1993,11 @@ func (*SourcePreviewEvent) Descriptor() ([]byte, []int) {
 	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{33}
 }
 
-func (x *SourcePreviewEvent) GetEventId() string {
+func (x *SourcePreviewEvent) GetEvent() *EventEnvelope {
 	if x != nil {
-		return x.EventId
+		return x.Event
 	}
-	return ""
+	return nil
 }
 
 func (x *SourcePreviewEvent) GetPayload() *structpb.Value {
@@ -2011,6 +2012,13 @@ func (x *SourcePreviewEvent) GetPayloadDecoded() bool {
 		return x.PayloadDecoded
 	}
 	return false
+}
+
+func (x *SourcePreviewEvent) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
 }
 
 // ReadSourceResponse returns one page of source events plus replay cursors.
@@ -5576,11 +5584,12 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x06cursor\x18\x03 \x01(\v2\x18.cerebro.v1.SourceCursorR\x06cursor\x1a9\n" +
 	"\vConfigEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8a\x01\n" +
-	"\x12SourcePreviewEvent\x12\x19\n" +
-	"\bevent_id\x18\x01 \x01(\tR\aeventId\x120\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xbb\x01\n" +
+	"\x12SourcePreviewEvent\x12/\n" +
+	"\x05event\x18\x01 \x01(\v2\x19.cerebro.v1.EventEnvelopeR\x05event\x120\n" +
 	"\apayload\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\apayload\x12'\n" +
-	"\x0fpayload_decoded\x18\x03 \x01(\bR\x0epayloadDecoded\"\xb7\x02\n" +
+	"\x0fpayload_decoded\x18\x03 \x01(\bR\x0epayloadDecoded\x12\x19\n" +
+	"\bevent_id\x18\x04 \x01(\tR\aeventId\"\xb7\x02\n" +
 	"\x12ReadSourceResponse\x12.\n" +
 	"\x06source\x18\x01 \x01(\v2\x16.cerebro.v1.SourceSpecR\x06source\x121\n" +
 	"\x06events\x18\x02 \x03(\v2\x19.cerebro.v1.EventEnvelopeR\x06events\x12<\n" +
@@ -6051,8 +6060,8 @@ var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*RuleSpec)(nil),                                  // 94: cerebro.v1.RuleSpec
 	(*SourceSpec)(nil),                                // 95: cerebro.v1.SourceSpec
 	(*SourceCursor)(nil),                              // 96: cerebro.v1.SourceCursor
-	(*structpb.Value)(nil),                            // 97: google.protobuf.Value
-	(*EventEnvelope)(nil),                             // 98: cerebro.v1.EventEnvelope
+	(*EventEnvelope)(nil),                             // 97: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                            // 98: google.protobuf.Value
 	(*SourceCheckpoint)(nil),                          // 99: cerebro.v1.SourceCheckpoint
 	(*Claim)(nil),                                     // 100: cerebro.v1.Claim
 }
@@ -6083,144 +6092,145 @@ var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
 	95,  // 23: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
 	88,  // 24: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
 	96,  // 25: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	97,  // 26: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	95,  // 27: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	98,  // 28: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	99,  // 29: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	96,  // 30: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
-	34,  // 31: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	89,  // 32: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	99,  // 33: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	96,  // 34: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	92,  // 35: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
-	36,  // 36: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
-	36,  // 37: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	36,  // 38: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	36,  // 39: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	95,  // 40: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	100, // 41: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	100, // 42: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
-	0,   // 43: cerebro.v1.ListFindingsRequest.status:type_name -> cerebro.v1.FindingStatus
-	92,  // 44: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
-	92,  // 45: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
-	0,   // 46: cerebro.v1.Finding.status:type_name -> cerebro.v1.FindingStatus
-	90,  // 47: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	92,  // 48: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	92,  // 49: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	92,  // 50: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
-	48,  // 51: cerebro.v1.Finding.control_refs:type_name -> cerebro.v1.FindingControlRef
-	92,  // 52: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
-	49,  // 53: cerebro.v1.Finding.notes:type_name -> cerebro.v1.FindingNote
-	50,  // 54: cerebro.v1.Finding.tickets:type_name -> cerebro.v1.FindingTicket
-	51,  // 55: cerebro.v1.GetFindingResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 56: cerebro.v1.ResolveFindingResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 57: cerebro.v1.SuppressFindingResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 58: cerebro.v1.AssignFindingResponse.finding:type_name -> cerebro.v1.Finding
-	92,  // 59: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
-	51,  // 60: cerebro.v1.SetFindingDueDateResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 61: cerebro.v1.AddFindingNoteResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 62: cerebro.v1.LinkFindingTicketResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 63: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	94,  // 64: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
-	51,  // 65: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
-	13,  // 66: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
-	18,  // 67: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
-	36,  // 68: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	69,  // 69: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
-	36,  // 70: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	94,  // 71: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	51,  // 72: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	13,  // 73: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	18,  // 74: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	92,  // 75: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	92,  // 76: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	92,  // 77: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	93,  // 78: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
-	92,  // 79: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	92,  // 80: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	92,  // 81: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	93,  // 82: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
-	92,  // 83: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
-	92,  // 84: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
-	92,  // 85: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
-	93,  // 86: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
-	91,  // 87: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
-	80,  // 88: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	80,  // 89: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	81,  // 90: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	1,   // 91: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	3,   // 92: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	9,   // 93: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	11,  // 94: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
-	23,  // 95: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	25,  // 96: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	27,  // 97: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	29,  // 98: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	31,  // 99: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	33,  // 100: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	37,  // 101: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	39,  // 102: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	41,  // 103: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	43,  // 104: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	45,  // 105: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
-	47,  // 106: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
-	52,  // 107: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
-	54,  // 108: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
-	56,  // 109: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
-	58,  // 110: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
-	60,  // 111: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
-	62,  // 112: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
-	64,  // 113: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
-	14,  // 114: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
-	16,  // 115: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
-	19,  // 116: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
-	21,  // 117: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
-	68,  // 118: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
-	67,  // 119: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	72,  // 120: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
-	74,  // 121: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
-	76,  // 122: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
-	78,  // 123: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
-	82,  // 124: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	2,   // 125: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	5,   // 126: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	10,  // 127: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	12,  // 128: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
-	24,  // 129: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	26,  // 130: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	28,  // 131: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	30,  // 132: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	32,  // 133: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	35,  // 134: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	38,  // 135: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	40,  // 136: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	42,  // 137: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	44,  // 138: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	46,  // 139: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
-	66,  // 140: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
-	53,  // 141: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
-	55,  // 142: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
-	57,  // 143: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
-	59,  // 144: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
-	61,  // 145: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
-	63,  // 146: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
-	65,  // 147: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
-	15,  // 148: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
-	17,  // 149: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
-	20,  // 150: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
-	22,  // 151: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
-	70,  // 152: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
-	71,  // 153: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	73,  // 154: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
-	75,  // 155: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
-	77,  // 156: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
-	79,  // 157: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
-	83,  // 158: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	125, // [125:159] is the sub-list for method output_type
-	91,  // [91:125] is the sub-list for method input_type
-	91,  // [91:91] is the sub-list for extension type_name
-	91,  // [91:91] is the sub-list for extension extendee
-	0,   // [0:91] is the sub-list for field type_name
+	97,  // 26: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	98,  // 27: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	95,  // 28: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	97,  // 29: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	99,  // 30: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	96,  // 31: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	34,  // 32: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
+	89,  // 33: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	99,  // 34: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	96,  // 35: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	92,  // 36: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	36,  // 37: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
+	36,  // 38: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	36,  // 39: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	36,  // 40: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	95,  // 41: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	100, // 42: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	100, // 43: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	0,   // 44: cerebro.v1.ListFindingsRequest.status:type_name -> cerebro.v1.FindingStatus
+	92,  // 45: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
+	92,  // 46: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
+	0,   // 47: cerebro.v1.Finding.status:type_name -> cerebro.v1.FindingStatus
+	90,  // 48: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	92,  // 49: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	92,  // 50: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	92,  // 51: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
+	48,  // 52: cerebro.v1.Finding.control_refs:type_name -> cerebro.v1.FindingControlRef
+	92,  // 53: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
+	49,  // 54: cerebro.v1.Finding.notes:type_name -> cerebro.v1.FindingNote
+	50,  // 55: cerebro.v1.Finding.tickets:type_name -> cerebro.v1.FindingTicket
+	51,  // 56: cerebro.v1.GetFindingResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 57: cerebro.v1.ResolveFindingResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 58: cerebro.v1.SuppressFindingResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 59: cerebro.v1.AssignFindingResponse.finding:type_name -> cerebro.v1.Finding
+	92,  // 60: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
+	51,  // 61: cerebro.v1.SetFindingDueDateResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 62: cerebro.v1.AddFindingNoteResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 63: cerebro.v1.LinkFindingTicketResponse.finding:type_name -> cerebro.v1.Finding
+	51,  // 64: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	94,  // 65: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
+	51,  // 66: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
+	13,  // 67: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
+	18,  // 68: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
+	36,  // 69: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	69,  // 70: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
+	36,  // 71: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	94,  // 72: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	51,  // 73: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	13,  // 74: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
+	18,  // 75: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	92,  // 76: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	92,  // 77: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	92,  // 78: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	93,  // 79: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
+	92,  // 80: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	92,  // 81: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	92,  // 82: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	93,  // 83: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
+	92,  // 84: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
+	92,  // 85: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
+	92,  // 86: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
+	93,  // 87: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
+	91,  // 88: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
+	80,  // 89: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	80,  // 90: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	81,  // 91: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	1,   // 92: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	3,   // 93: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	9,   // 94: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	11,  // 95: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
+	23,  // 96: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	25,  // 97: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	27,  // 98: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	29,  // 99: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	31,  // 100: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	33,  // 101: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	37,  // 102: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	39,  // 103: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	41,  // 104: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	43,  // 105: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	45,  // 106: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	47,  // 107: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
+	52,  // 108: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
+	54,  // 109: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
+	56,  // 110: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
+	58,  // 111: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
+	60,  // 112: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
+	62,  // 113: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
+	64,  // 114: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
+	14,  // 115: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
+	16,  // 116: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
+	19,  // 117: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
+	21,  // 118: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
+	68,  // 119: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	67,  // 120: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	72,  // 121: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
+	74,  // 122: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
+	76,  // 123: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
+	78,  // 124: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
+	82,  // 125: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	2,   // 126: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	5,   // 127: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	10,  // 128: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	12,  // 129: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
+	24,  // 130: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	26,  // 131: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	28,  // 132: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	30,  // 133: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	32,  // 134: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	35,  // 135: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	38,  // 136: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	40,  // 137: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	42,  // 138: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	44,  // 139: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	46,  // 140: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	66,  // 141: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
+	53,  // 142: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
+	55,  // 143: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
+	57,  // 144: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
+	59,  // 145: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
+	61,  // 146: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
+	63,  // 147: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
+	65,  // 148: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
+	15,  // 149: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
+	17,  // 150: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
+	20,  // 151: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
+	22,  // 152: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
+	70,  // 153: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	71,  // 154: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	73,  // 155: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
+	75,  // 156: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
+	77,  // 157: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
+	79,  // 158: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
+	83,  // 159: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	126, // [126:160] is the sub-list for method output_type
+	92,  // [92:126] is the sub-list for method input_type
+	92,  // [92:92] is the sub-list for extension type_name
+	92,  // [92:92] is the sub-list for extension extendee
+	0,   // [0:92] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -16,7 +16,11 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
-const connectTimeout = 5 * time.Second
+const (
+	connectTimeout     = 5 * time.Second
+	defaultReplayLimit = 100
+	maxReplayLimit     = 1000
+)
 
 type publisher interface {
 	AccountInfo(context.Context) (*jetstream.AccountInfo, error)
@@ -25,7 +29,11 @@ type publisher interface {
 
 type replayManager interface {
 	Streams(context.Context) ([]*jetstream.StreamInfo, error)
-	GetMsg(context.Context, string, uint64) (*jetstream.RawStreamMsg, error)
+	Stream(context.Context, string) (replayStream, error)
+}
+
+type replayStream interface {
+	GetMsg(context.Context, uint64, ...jetstream.GetMsgOpt) (*jetstream.RawStreamMsg, error)
 }
 
 type jetStreamReplayManager struct {
@@ -44,12 +52,12 @@ func (m *jetStreamReplayManager) Streams(ctx context.Context) ([]*jetstream.Stre
 	return streams, nil
 }
 
-func (m *jetStreamReplayManager) GetMsg(ctx context.Context, stream string, seq uint64) (*jetstream.RawStreamMsg, error) {
+func (m *jetStreamReplayManager) Stream(ctx context.Context, stream string) (replayStream, error) {
 	streamRef, err := m.js.Stream(ctx, stream)
 	if err != nil {
 		return nil, err
 	}
-	return streamRef.GetMsg(ctx, seq)
+	return streamRef, nil
 }
 
 // Log is the JetStream-backed append-log implementation.
@@ -155,12 +163,17 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	if err != nil {
 		return nil, err
 	}
-	events := make([]*cerebrov1.EventEnvelope, 0)
+	limit := normalizeReplayLimit(request.Limit)
+	streamRef, err := l.replay.Stream(ctx, stream.Config.Name)
+	if err != nil {
+		return nil, fmt.Errorf("open replay stream %q: %w", stream.Config.Name, err)
+	}
+	events := make([]*cerebrov1.EventEnvelope, 0, limit)
 	if stream.State.LastSeq == 0 || stream.State.LastSeq < stream.State.FirstSeq {
 		return events, nil
 	}
 	for seq := stream.State.FirstSeq; seq <= stream.State.LastSeq; seq++ {
-		raw, err := l.replay.GetMsg(ctx, stream.Config.Name, seq)
+		raw, err := streamRef.GetMsg(ctx, seq)
 		if err != nil {
 			if errors.Is(err, jetstream.ErrMsgNotFound) {
 				continue
@@ -178,11 +191,21 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 			continue
 		}
 		events = append(events, event)
-		if req.Limit > 0 && uint32(len(events)) >= req.Limit {
+		if uint32(len(events)) >= limit {
 			break
 		}
 	}
 	return events, nil
+}
+
+func normalizeReplayLimit(limit uint32) uint32 {
+	if limit == 0 {
+		return defaultReplayLimit
+	}
+	if limit > maxReplayLimit {
+		return maxReplayLimit
+	}
+	return limit
 }
 
 func normalizeReplayRequest(req ports.ReplayRequest) ports.ReplayRequest {

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -3,6 +3,7 @@ package jetstream
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/nats-io/nats.go"
@@ -29,20 +30,30 @@ func (f *fakePublisher) PublishMsg(_ context.Context, msg *nats.Msg, _ ...natsje
 }
 
 type fakeReplayManager struct {
-	streams []*natsjetstream.StreamInfo
-	msgs    map[string]map[uint64]*natsjetstream.RawStreamMsg
-	err     error
+	streams     []*natsjetstream.StreamInfo
+	msgs        map[string]map[uint64]*natsjetstream.RawStreamMsg
+	err         error
+	streamCalls int
 }
 
 func (f *fakeReplayManager) Streams(context.Context) ([]*natsjetstream.StreamInfo, error) {
 	return f.streams, f.err
 }
 
-func (f *fakeReplayManager) GetMsg(_ context.Context, stream string, seq uint64) (*natsjetstream.RawStreamMsg, error) {
+func (f *fakeReplayManager) Stream(_ context.Context, stream string) (replayStream, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
-	raw := f.msgs[stream][seq]
+	f.streamCalls++
+	return &fakeReplayStream{msgs: f.msgs[stream]}, nil
+}
+
+type fakeReplayStream struct {
+	msgs map[uint64]*natsjetstream.RawStreamMsg
+}
+
+func (f *fakeReplayStream) GetMsg(_ context.Context, seq uint64, _ ...natsjetstream.GetMsgOpt) (*natsjetstream.RawStreamMsg, error) {
+	raw := f.msgs[seq]
 	if raw == nil {
 		return nil, natsjetstream.ErrMsgNotFound
 	}
@@ -128,6 +139,37 @@ func TestReplayFiltersEventsByRuntime(t *testing.T) {
 	}
 	if events[0].GetId() != "evt-1" || events[1].GetId() != "evt-3" {
 		t.Fatalf("replayed ids = [%q, %q], want [evt-1, evt-3]", events[0].GetId(), events[1].GetId())
+	}
+	if replay.streamCalls != 1 {
+		t.Fatalf("streamCalls = %d, want 1", replay.streamCalls)
+	}
+}
+
+func TestReplayAppliesDefaultLimit(t *testing.T) {
+	msgs := make(map[uint64]*natsjetstream.RawStreamMsg)
+	for seq := uint64(1); seq <= defaultReplayLimit+5; seq++ {
+		msgs[seq] = rawReplayMsg(t, "events.github.audit", replayEvent("evt-"+strconv.FormatUint(seq, 10), "github.audit", "writer-github"))
+	}
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{
+					Name:     "CEREBRO_EVENTS",
+					Subjects: []string{"events.>"},
+				},
+				State: natsjetstream.StreamState{FirstSeq: 1, LastSeq: defaultReplayLimit + 5},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{"CEREBRO_EVENTS": msgs},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github"})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(events) != defaultReplayLimit {
+		t.Fatalf("len(events) = %d, want %d", len(events), defaultReplayLimit)
 	}
 }
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1523,7 +1523,13 @@ func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {
 
 func sensitiveSourceConfigKey(key string) bool {
 	value := strings.ToLower(strings.TrimSpace(key))
-	return strings.Contains(value, "token") || strings.Contains(value, "secret") || strings.Contains(value, "password")
+	if value == "" {
+		return false
+	}
+	if strings.Contains(value, "token") || strings.Contains(value, "secret") || strings.Contains(value, "password") {
+		return true
+	}
+	return value == "key" || strings.HasSuffix(value, "_key")
 }
 
 func writeSourceError(w http.ResponseWriter, err error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -303,7 +304,12 @@ func (a *App) handleRunReport(w http.ResponseWriter, r *http.Request) {
 	if request.Parameters == nil {
 		request.Parameters = map[string]string{}
 	}
-	for key, value := range sourceConfigFromQuery(r) {
+	config, err := sourceConfigFromRequest(r)
+	if err != nil {
+		writeReportError(w, err)
+		return
+	}
+	for key, value := range config {
 		request.Parameters[key] = value
 	}
 	response, err := a.reportService().Run(r.Context(), request)
@@ -326,9 +332,14 @@ func (a *App) handleGetReportRun(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleCheckSource(w http.ResponseWriter, r *http.Request) {
+	config, err := sourceConfigFromRequest(r)
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
 	response, err := a.sourceService().Check(r.Context(), &cerebrov1.CheckSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   sourceConfigFromQuery(r),
+		Config:   config,
 	})
 	if err != nil {
 		writeSourceError(w, err)
@@ -338,9 +349,14 @@ func (a *App) handleCheckSource(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleDiscoverSource(w http.ResponseWriter, r *http.Request) {
+	config, err := sourceConfigFromRequest(r)
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
 	response, err := a.sourceService().Discover(r.Context(), &cerebrov1.DiscoverSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   sourceConfigFromQuery(r),
+		Config:   config,
 	})
 	if err != nil {
 		writeSourceError(w, err)
@@ -350,9 +366,14 @@ func (a *App) handleDiscoverSource(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleReadSource(w http.ResponseWriter, r *http.Request) {
+	config, err := sourceConfigFromRequest(r)
+	if err != nil {
+		writeSourceError(w, err)
+		return
+	}
 	request := &cerebrov1.ReadSourceRequest{
 		SourceId: r.PathValue("sourceID"),
-		Config:   sourceConfigFromQuery(r),
+		Config:   config,
 	}
 	rawCursors := r.URL.Query()["cursor"]
 	if len(rawCursors) > 0 {
@@ -1474,15 +1495,35 @@ func (a *App) workflowReplayService() *workflowprojection.Replayer {
 	)
 }
 
-func sourceConfigFromQuery(r *http.Request) map[string]string {
+func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {
 	values := make(map[string]string)
 	for key, rawValues := range r.URL.Query() {
 		if key == "cursor" || len(rawValues) == 0 {
 			continue
 		}
+		if sensitiveSourceConfigKey(key) {
+			return nil, fmt.Errorf("source config key %q must not be supplied in query parameters", key)
+		}
 		values[key] = rawValues[len(rawValues)-1]
 	}
-	return values
+	if rawConfig := strings.TrimSpace(r.Header.Get("X-Cerebro-Source-Config")); rawConfig != "" {
+		headerValues := map[string]string{}
+		if err := json.Unmarshal([]byte(rawConfig), &headerValues); err != nil {
+			return nil, fmt.Errorf("decode source config header: %w", err)
+		}
+		for key, value := range headerValues {
+			trimmedKey := strings.TrimSpace(key)
+			if trimmedKey != "" {
+				values[trimmedKey] = value
+			}
+		}
+	}
+	return values, nil
+}
+
+func sensitiveSourceConfigKey(key string) bool {
+	value := strings.ToLower(strings.TrimSpace(key))
+	return strings.Contains(value, "token") || strings.Contains(value, "secret") || strings.Contains(value, "password")
 }
 
 func writeSourceError(w http.ResponseWriter, err error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -354,8 +354,12 @@ func (a *App) handleReadSource(w http.ResponseWriter, r *http.Request) {
 		SourceId: r.PathValue("sourceID"),
 		Config:   sourceConfigFromQuery(r),
 	}
-	if cursor := r.URL.Query().Get("cursor"); cursor != "" {
-		request.Cursor = &cerebrov1.SourceCursor{Opaque: cursor}
+	rawCursors := r.URL.Query()["cursor"]
+	if len(rawCursors) > 0 {
+		cursor := rawCursors[len(rawCursors)-1]
+		if cursor != "" {
+			request.Cursor = &cerebrov1.SourceCursor{Opaque: cursor}
+		}
 	}
 	response, err := a.sourceService().Read(r.Context(), request)
 	if err != nil {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -304,7 +304,9 @@ func (a *App) handleRunReport(w http.ResponseWriter, r *http.Request) {
 	if request.Parameters == nil {
 		request.Parameters = map[string]string{}
 	}
-	config, err := sourceConfigFromRequest(r)
+	configReq := r.Clone(r.Context())
+	configReq.Header.Del("X-Cerebro-Source-Config")
+	config, err := sourceConfigFromRequest(configReq)
 	if err != nil {
 		writeReportError(w, err)
 		return

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1949,7 +1949,7 @@ func componentStatus(ctx context.Context, name string, dependency pinger) *cereb
 	}
 	if err := dependency.Ping(ctx); err != nil {
 		status.Status = "error"
-		status.Detail = err.Error()
+		status.Detail = "unhealthy"
 		return status
 	}
 	status.Status = "ready"

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2511,6 +2511,7 @@ func TestReportEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new run report request: %v", err)
 	}
+	runReq.Header.Set("X-Cerebro-Source-Config", `{"token":"secret","api_key":"secret"}`)
 	runResp, err := server.Client().Do(runReq)
 	if err != nil {
 		t.Fatalf("POST /reports/{id}/runs error = %v", err)
@@ -2558,6 +2559,13 @@ func TestReportEndpoints(t *testing.T) {
 	}
 	if len(runtimeStore.reportRuns) != 1 {
 		t.Fatalf("len(runtimeStore.reportRuns) = %d, want 1", len(runtimeStore.reportRuns))
+	}
+	storedRun := runtimeStore.reportRuns[runID]
+	if _, ok := storedRun.GetParameters()["token"]; ok {
+		t.Fatalf("stored report parameters include token")
+	}
+	if _, ok := storedRun.GetParameters()["api_key"]; ok {
+		t.Fatalf("stored report parameters include api_key")
 	}
 	if graphStore.neighborhoodRootURN != "urn:cerebro:writer:okta_resource:policyrule:pol-1" {
 		t.Fatalf("graph evidence root urn = %q, want policy rule urn", graphStore.neighborhoodRootURN)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -29,6 +29,22 @@ import (
 	sdksource "github.com/writer/cerebro/sources/sdk"
 )
 
+func sourceGet(t *testing.T, server *httptest.Server, path string, config map[string]string) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(config) > 0 {
+		payload, err := json.Marshal(config)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("X-Cerebro-Source-Config", string(payload))
+	}
+	return server.Client().Do(req)
+}
+
 type stubAppendLog struct {
 	err error
 }
@@ -596,7 +612,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if !ok || len(entries) != 3 {
 		t.Fatalf("/sources entries = %#v, want 3 entries", sourcesPayload["sources"])
 	}
-	checkResp, err := server.Client().Get(server.URL + "/sources/github/check?token=test")
+	checkResp, err := sourceGet(t, server, "/sources/github/check", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/github/check error = %v", err)
 	}
@@ -612,7 +628,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if checkPayload["status"] != "ok" {
 		t.Fatalf("check status = %#v, want %q", checkPayload["status"], "ok")
 	}
-	discoverResp, err := server.Client().Get(server.URL + "/sources/github/discover?token=test")
+	discoverResp, err := sourceGet(t, server, "/sources/github/discover", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/github/discover error = %v", err)
 	}
@@ -628,7 +644,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if urns, ok := discoverPayload["urns"].([]any); !ok || len(urns) != 2 {
 		t.Fatalf("discover urns = %#v, want 2 entries", discoverPayload["urns"])
 	}
-	readResp, err := server.Client().Get(server.URL + "/sources/github/read?token=test")
+	readResp, err := sourceGet(t, server, "/sources/github/read", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/github/read error = %v", err)
 	}
@@ -644,7 +660,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if events, ok := readPayload["events"].([]any); !ok || len(events) != 1 {
 		t.Fatalf("read events = %#v, want 1 entry", readPayload["events"])
 	}
-	repeatedCursorResp, err := server.Client().Get(server.URL + "/sources/github/read?token=test&cursor=0&cursor=1")
+	repeatedCursorResp, err := sourceGet(t, server, "/sources/github/read?cursor=0&cursor=1", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/github/read repeated cursor error = %v", err)
 	}
@@ -673,7 +689,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if !ok || previewEvent["event_id"] != "github-audit-1" {
 		t.Fatalf("read preview_event = %#v, want event_id github-audit-1", previewEvents[0])
 	}
-	oktaCheckResp, err := server.Client().Get(server.URL + "/sources/okta/check?domain=writer.okta.com&family=user&token=test")
+	oktaCheckResp, err := sourceGet(t, server, "/sources/okta/check?domain=writer.okta.com&family=user", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/okta/check error = %v", err)
 	}
@@ -689,7 +705,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if oktaCheckPayload["status"] != "ok" {
 		t.Fatalf("okta check status = %#v, want %q", oktaCheckPayload["status"], "ok")
 	}
-	oktaDiscoverResp, err := server.Client().Get(server.URL + "/sources/okta/discover?domain=writer.okta.com&family=user&token=test")
+	oktaDiscoverResp, err := sourceGet(t, server, "/sources/okta/discover?domain=writer.okta.com&family=user", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/okta/discover error = %v", err)
 	}
@@ -705,7 +721,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if urns, ok := oktaDiscoverPayload["urns"].([]any); !ok || len(urns) != 2 {
 		t.Fatalf("okta discover urns = %#v, want 2 entries", oktaDiscoverPayload["urns"])
 	}
-	oktaReadResp, err := server.Client().Get(server.URL + "/sources/okta/read?domain=writer.okta.com&family=user&token=test")
+	oktaReadResp, err := sourceGet(t, server, "/sources/okta/read?domain=writer.okta.com&family=user", map[string]string{"token": "test"})
 	if err != nil {
 		t.Fatalf("GET /sources/okta/read error = %v", err)
 	}
@@ -724,6 +740,18 @@ func TestBootstrapEndpoints(t *testing.T) {
 	oktaPreviewEvents, ok := oktaReadPayload["preview_events"].([]any)
 	if !ok || len(oktaPreviewEvents) != 1 {
 		t.Fatalf("okta read preview_events = %#v, want 1 entry", oktaReadPayload["preview_events"])
+	}
+	leakyQueryResp, err := server.Client().Get(server.URL + "/sources/github/check?token=secret")
+	if err != nil {
+		t.Fatalf("GET /sources/github/check leaky query error = %v", err)
+	}
+	defer func() {
+		if closeErr := leakyQueryResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close leaky query response body: %v", closeErr)
+		}
+	}()
+	if leakyQueryResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("leaky query status = %d, want %d", leakyQueryResp.StatusCode, http.StatusBadRequest)
 	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -644,6 +644,27 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if events, ok := readPayload["events"].([]any); !ok || len(events) != 1 {
 		t.Fatalf("read events = %#v, want 1 entry", readPayload["events"])
 	}
+	repeatedCursorResp, err := server.Client().Get(server.URL + "/sources/github/read?token=test&cursor=0&cursor=1")
+	if err != nil {
+		t.Fatalf("GET /sources/github/read repeated cursor error = %v", err)
+	}
+	defer func() {
+		if closeErr := repeatedCursorResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close repeated cursor response body: %v", closeErr)
+		}
+	}()
+	var repeatedCursorPayload map[string]any
+	if err := json.NewDecoder(repeatedCursorResp.Body).Decode(&repeatedCursorPayload); err != nil {
+		t.Fatalf("decode repeated cursor response: %v", err)
+	}
+	repeatedCursorEvents, ok := repeatedCursorPayload["events"].([]any)
+	if !ok || len(repeatedCursorEvents) != 1 {
+		t.Fatalf("repeated cursor events = %#v, want 1 entry", repeatedCursorPayload["events"])
+	}
+	repeatedCursorEvent, ok := repeatedCursorEvents[0].(map[string]any)
+	if !ok || repeatedCursorEvent["id"] != "github-pr-1" {
+		t.Fatalf("repeated cursor event = %#v, want github-pr-1", repeatedCursorEvents[0])
+	}
 	previewEvents, ok := readPayload["preview_events"].([]any)
 	if !ok || len(previewEvents) != 1 {
 		t.Fatalf("read preview_events = %#v, want 1 entry", readPayload["preview_events"])

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -669,6 +669,10 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if !ok || len(previewEvents) != 1 {
 		t.Fatalf("read preview_events = %#v, want 1 entry", readPayload["preview_events"])
 	}
+	previewEvent, ok := previewEvents[0].(map[string]any)
+	if !ok || previewEvent["event_id"] != "github-audit-1" {
+		t.Fatalf("read preview_event = %#v, want event_id github-audit-1", previewEvents[0])
+	}
 	oktaCheckResp, err := server.Client().Get(server.URL + "/sources/okta/check?domain=writer.okta.com&family=user&token=test")
 	if err != nil {
 		t.Fatalf("GET /sources/okta/check error = %v", err)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -811,9 +811,10 @@ func TestBootstrapEndpoints(t *testing.T) {
 }
 
 func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
+	const rawDependencyError = "state store unavailable at postgres://user:pass@internal-db:5432/cerebro"
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
 		AppendLog:  stubAppendLog{},
-		StateStore: stubStore{err: errors.New("state store unavailable")},
+		StateStore: stubStore{err: errors.New(rawDependencyError)},
 		GraphStore: stubStore{},
 	}, nil)
 	server := httptest.NewServer(app.Handler())
@@ -829,6 +830,12 @@ func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
 	}
 	if got := healthResp.Msg.Components[1].Status; got != "error" {
 		t.Fatalf("state_store status = %q, want %q", got, "error")
+	}
+	if got := healthResp.Msg.Components[1].Detail; got != "unhealthy" {
+		t.Fatalf("state_store detail = %q, want sanitized detail", got)
+	}
+	if got := healthResp.Msg.Components[1].Detail; got == rawDependencyError {
+		t.Fatalf("state_store detail leaked raw dependency error")
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -45,6 +45,17 @@ func sourceGet(t *testing.T, server *httptest.Server, path string, config map[st
 	return server.Client().Do(req)
 }
 
+func TestSourceConfigFromRequestRejectsSensitiveQueryKeys(t *testing.T) {
+	for _, key := range []string{"token", "api_key", "private_key", "key"} {
+		t.Run(key, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/sources/okta/check?"+key+"=secret", nil)
+			if _, err := sourceConfigFromRequest(req); err == nil {
+				t.Fatalf("sourceConfigFromRequest() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
 type stubAppendLog struct {
 	err error
 }

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1480,6 +1480,9 @@ func TestFindingEndpoints(t *testing.T) {
 	if got := len(listFindingsResp.Msg.GetFindings()[0].GetControlRefs()); got != 2 {
 		t.Fatalf("len(ListFindings().Findings[0].ControlRefs) = %d, want 2", got)
 	}
+	if got := runtimeStore.findingListRequest.TenantID; got != "writer" {
+		t.Fatalf("runtimeStore.findingListRequest.TenantID = %q, want writer", got)
+	}
 	if got := runtimeStore.findingListRequest.RuleID; got != "identity-okta-policy-rule-lifecycle-tampering" {
 		t.Fatalf("runtimeStore.findingListRequest.RuleID = %q, want identity-okta-policy-rule-lifecycle-tampering", got)
 	}
@@ -2428,6 +2431,7 @@ func TestReportEndpoints(t *testing.T) {
 		findings: map[string]*ports.FindingRecord{
 			"finding-1": {
 				ID:           "finding-1",
+				TenantID:     "writer",
 				RuntimeID:    "writer-okta-audit",
 				RuleID:       "identity-okta-policy-rule-lifecycle-tampering",
 				Severity:     "HIGH",
@@ -2439,6 +2443,7 @@ func TestReportEndpoints(t *testing.T) {
 			},
 			"finding-2": {
 				ID:           "finding-2",
+				TenantID:     "writer",
 				RuntimeID:    "writer-okta-audit",
 				RuleID:       "identity-okta-policy-rule-lifecycle-tampering",
 				Severity:     "HIGH",
@@ -2491,7 +2496,7 @@ func TestReportEndpoints(t *testing.T) {
 		t.Fatalf("/reports payload = %#v, want 1 entry", listPayload["reports"])
 	}
 
-	runReq, err := http.NewRequest(http.MethodPost, server.URL+"/reports/finding-summary/runs?runtime_id=writer-okta-audit&graph_limit=2", nil)
+	runReq, err := http.NewRequest(http.MethodPost, server.URL+"/reports/finding-summary/runs?tenant_id=writer&runtime_id=writer-okta-audit&graph_limit=2", nil)
 	if err != nil {
 		t.Fatalf("new run report request: %v", err)
 	}
@@ -2582,6 +2587,7 @@ func TestReportEndpoints(t *testing.T) {
 	runReportResp, err := client.RunReport(context.Background(), connect.NewRequest(&cerebrov1.RunReportRequest{
 		ReportId: "finding-summary",
 		Parameters: map[string]string{
+			"tenant_id":  "writer",
 			"runtime_id": "writer-okta-audit",
 		},
 	}))
@@ -2735,6 +2741,9 @@ func preserveFindingWorkflow(existing *ports.FindingRecord, incoming *ports.Find
 
 func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRecord) bool {
 	if finding == nil {
+		return false
+	}
+	if request.TenantID != "" && strings.TrimSpace(finding.TenantID) != strings.TrimSpace(request.TenantID) {
 		return false
 	}
 	if strings.TrimSpace(finding.RuntimeID) != strings.TrimSpace(request.RuntimeID) {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2318,11 +2318,11 @@ func TestWriteClaimsReplaceExistingReportsRetractedClaims(t *testing.T) {
 	if got := resp.Msg.GetClaimsWritten(); got != 1 {
 		t.Fatalf("replace claims_written = %d, want 1", got)
 	}
-	if got := resp.Msg.GetClaimsRetracted(); got != 1 {
-		t.Fatalf("replace claims_retracted = %d, want 1", got)
+	if got := resp.Msg.GetClaimsRetracted(); got != 2 {
+		t.Fatalf("replace claims_retracted = %d, want 2", got)
 	}
-	if len(runtimeStore.claims) != 2 {
-		t.Fatalf("len(runtimeStore.claims) = %d, want 2", len(runtimeStore.claims))
+	if len(runtimeStore.claims) != 3 {
+		t.Fatalf("len(runtimeStore.claims) = %d, want 3", len(runtimeStore.claims))
 	}
 	var retracted *ports.ClaimRecord
 	for _, claim := range runtimeStore.claims {

--- a/internal/bootstrap/dependencies_cgo_test.go
+++ b/internal/bootstrap/dependencies_cgo_test.go
@@ -1,0 +1,29 @@
+//go:build cgo
+
+package bootstrap
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+func TestOpenDependenciesConfiguresKuzu(t *testing.T) {
+	deps, closeAll, err := OpenDependencies(context.Background(), config.Config{
+		GraphStore: config.GraphStoreConfig{
+			Driver:   config.GraphStoreDriverKuzu,
+			KuzuPath: filepath.Join(t.TempDir(), "graph"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("OpenDependencies() error = %v", err)
+	}
+	if deps.GraphStore == nil {
+		t.Fatal("GraphStore = nil, want non-nil")
+	}
+	if err := closeAll(); err != nil {
+		t.Fatalf("closeAll() error = %v", err)
+	}
+}

--- a/internal/bootstrap/dependencies_nocgo_test.go
+++ b/internal/bootstrap/dependencies_nocgo_test.go
@@ -1,0 +1,24 @@
+//go:build !cgo
+
+package bootstrap
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+func TestOpenDependenciesRejectsKuzuWithoutCGO(t *testing.T) {
+	_, _, err := OpenDependencies(context.Background(), config.Config{
+		GraphStore: config.GraphStoreConfig{
+			Driver:   config.GraphStoreDriverKuzu,
+			KuzuPath: filepath.Join(t.TempDir(), "graph"),
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires CGO") {
+		t.Fatalf("OpenDependencies() error = %v, want requires CGO", err)
+	}
+}

--- a/internal/bootstrap/dependencies_test.go
+++ b/internal/bootstrap/dependencies_test.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/writer/cerebro/internal/config"
@@ -60,23 +59,5 @@ func TestOpenDependenciesRejectsUnsupportedGraphStoreDriver(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("OpenDependencies() error = nil, want non-nil")
-	}
-}
-
-func TestOpenDependenciesConfiguresKuzu(t *testing.T) {
-	deps, closeAll, err := OpenDependencies(context.Background(), config.Config{
-		GraphStore: config.GraphStoreConfig{
-			Driver:   config.GraphStoreDriverKuzu,
-			KuzuPath: filepath.Join(t.TempDir(), "graph"),
-		},
-	})
-	if err != nil {
-		t.Fatalf("OpenDependencies() error = %v", err)
-	}
-	if deps.GraphStore == nil {
-		t.Fatal("GraphStore = nil, want non-nil")
-	}
-	if err := closeAll(); err != nil {
-		t.Fatalf("closeAll() error = %v", err)
 	}
 }

--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -105,6 +105,10 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 		normalizedClaims = append(normalizedClaims, claim)
 	}
 	for _, claim := range normalizedClaims {
+		if _, err := s.store.UpsertClaim(ctx, claimRecord(runtime, claim)); err != nil {
+			return nil, fmt.Errorf("persist claim %q: %w", claim.GetId(), err)
+		}
+		result.ClaimsWritten++
 		if entity := projectedEntity(runtime, claim.GetSubjectRef(), claim.GetSubjectUrn()); entity != nil {
 			wrote, err := s.upsertEntity(ctx, entity, upsertedEntities)
 			if err != nil {
@@ -132,10 +136,6 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 				result.RelationLinksProjected++
 			}
 		}
-		if _, err := s.store.UpsertClaim(ctx, claimRecord(runtime, claim)); err != nil {
-			return nil, fmt.Errorf("persist claim %q: %w", claim.GetId(), err)
-		}
-		result.ClaimsWritten++
 	}
 	if request.ReplaceExisting {
 		retracted, err := s.retractMissingClaims(ctx, runtimeID, normalizedClaims)
@@ -381,7 +381,7 @@ func normalizeClaim(claim *cerebrov1.Claim, runtime *cerebrov1.SourceRuntime) (*
 		return nil, fmt.Errorf("unsupported claim type %q", normalized.GetClaimType())
 	}
 	if normalized.GetId() == "" {
-		normalized.Id = hashClaimID(strings.TrimSpace(runtime.GetId()), normalized.GetClaimType(), normalized.GetSubjectUrn(), normalized.GetPredicate())
+		normalized.Id = hashClaimID(strings.TrimSpace(runtime.GetId()), normalized.GetClaimType(), normalized.GetSubjectUrn(), normalized.GetPredicate(), claimIdentityObject(normalized))
 	}
 	normalized.Attributes = trimAttributes(normalized.GetAttributes())
 	return normalized, nil
@@ -415,12 +415,24 @@ func inferClaimType(claim *cerebrov1.Claim) string {
 	}
 }
 
-func hashClaimID(runtimeID string, claimType string, subjectURN string, predicate string) string {
+func claimIdentityObject(claim *cerebrov1.Claim) string {
+	switch claim.GetClaimType() {
+	case claimTypeRelation:
+		return claim.GetObjectUrn()
+	case claimTypeAttribute, claimTypeClassification:
+		return claim.GetObjectValue()
+	default:
+		return ""
+	}
+}
+
+func hashClaimID(runtimeID string, claimType string, subjectURN string, predicate string, objectIdentity string) string {
 	sum := sha256.Sum256([]byte(strings.Join([]string{
 		strings.TrimSpace(runtimeID),
 		strings.TrimSpace(claimType),
 		strings.TrimSpace(subjectURN),
 		strings.TrimSpace(predicate),
+		strings.TrimSpace(objectIdentity),
 	}, "\x00")))
 	return "claim_" + hex.EncodeToString(sum[:])
 }

--- a/internal/claims/service_test.go
+++ b/internal/claims/service_test.go
@@ -36,11 +36,15 @@ func (s *stubRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*cere
 type stubClaimStore struct {
 	claims      map[string]*ports.ClaimRecord
 	listRequest ports.ListClaimsRequest
+	err         error
 }
 
 func (s *stubClaimStore) Ping(context.Context) error { return nil }
 
 func (s *stubClaimStore) UpsertClaim(_ context.Context, claim *ports.ClaimRecord) (*ports.ClaimRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
 	if s.claims == nil {
 		s.claims = make(map[string]*ports.ClaimRecord)
 	}
@@ -220,8 +224,8 @@ func TestWriteClaimsReplaceExistingRetractsOmittedClaims(t *testing.T) {
 	issueURN := "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123"
 	assigneeURN := "urn:cerebro:writer:runtime:writer-jira:user:acct:42"
 	observedAt := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
-	statusID := hashClaimID("writer-jira", claimTypeAttribute, issueURN, "status")
-	assigneeID := hashClaimID("writer-jira", claimTypeRelation, issueURN, "assigned_to")
+	statusID := hashClaimID("writer-jira", claimTypeAttribute, issueURN, "status", "in_progress")
+	assigneeID := hashClaimID("writer-jira", claimTypeRelation, issueURN, "assigned_to", assigneeURN)
 	store := &stubClaimStore{
 		claims: map[string]*ports.ClaimRecord{
 			statusID: {
@@ -290,8 +294,8 @@ func TestWriteClaimsReplaceExistingRetractsOmittedClaims(t *testing.T) {
 	if got := result.ClaimsWritten; got != 1 {
 		t.Fatalf("WriteClaims().ClaimsWritten = %d, want 1", got)
 	}
-	if got := result.ClaimsRetracted; got != 1 {
-		t.Fatalf("WriteClaims().ClaimsRetracted = %d, want 1", got)
+	if got := result.ClaimsRetracted; got != 2 {
+		t.Fatalf("WriteClaims().ClaimsRetracted = %d, want 2", got)
 	}
 	if got := store.listRequest.RuntimeID; got != "writer-jira" {
 		t.Fatalf("retract list runtime_id = %q, want writer-jira", got)
@@ -435,6 +439,95 @@ func TestWriteClaimsRejectsRelationWithoutObjectURN(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("WriteClaims() error = nil, want non-nil")
+	}
+}
+
+func TestWriteClaimsDoesNotProjectWhenPersistenceFails(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-jira": {
+					Id:       "writer-jira",
+					SourceId: "sdk",
+					TenantId: "writer",
+				},
+			},
+		},
+		&stubClaimStore{err: errors.New("persist failed")},
+		state,
+		nil,
+	)
+
+	_, err := service.WriteClaims(context.Background(), WriteRequest{
+		RuntimeID: "writer-jira",
+		Claims: []*cerebrov1.Claim{
+			{
+				SubjectRef: &cerebrov1.EntityRef{
+					Urn:        "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+					EntityType: "ticket",
+				},
+				Predicate:   "status",
+				ObjectValue: "in_progress",
+				ClaimType:   claimTypeAttribute,
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("WriteClaims() error = nil, want non-nil")
+	}
+	if len(state.entities) != 0 {
+		t.Fatalf("len(state.entities) = %d, want 0", len(state.entities))
+	}
+	if len(state.links) != 0 {
+		t.Fatalf("len(state.links) = %d, want 0", len(state.links))
+	}
+}
+
+func TestNormalizeClaimIDIncludesObjectIdentity(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-jira"}
+	first, err := normalizeClaim(&cerebrov1.Claim{
+		SubjectUrn: "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+		Predicate:  "assigned_to",
+		ObjectUrn:  "urn:cerebro:writer:runtime:writer-jira:user:alice",
+		ClaimType:  claimTypeRelation,
+	}, runtime)
+	if err != nil {
+		t.Fatalf("normalizeClaim(first) error = %v", err)
+	}
+	second, err := normalizeClaim(&cerebrov1.Claim{
+		SubjectUrn: "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+		Predicate:  "assigned_to",
+		ObjectUrn:  "urn:cerebro:writer:runtime:writer-jira:user:bob",
+		ClaimType:  claimTypeRelation,
+	}, runtime)
+	if err != nil {
+		t.Fatalf("normalizeClaim(second) error = %v", err)
+	}
+	if first.GetId() == second.GetId() {
+		t.Fatalf("relation claim ids collided: %q", first.GetId())
+	}
+
+	attrFirst, err := normalizeClaim(&cerebrov1.Claim{
+		SubjectUrn:  "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+		Predicate:   "status",
+		ObjectValue: "open",
+		ClaimType:   claimTypeAttribute,
+	}, runtime)
+	if err != nil {
+		t.Fatalf("normalizeClaim(attrFirst) error = %v", err)
+	}
+	attrSecond, err := normalizeClaim(&cerebrov1.Claim{
+		SubjectUrn:  "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123",
+		Predicate:   "status",
+		ObjectValue: "closed",
+		ClaimType:   claimTypeAttribute,
+	}, runtime)
+	if err != nil {
+		t.Fatalf("normalizeClaim(attrSecond) error = %v", err)
+	}
+	if attrFirst.GetId() == attrSecond.GetId() {
+		t.Fatalf("attribute claim ids collided: %q", attrFirst.GetId())
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -124,6 +124,7 @@ func TestLoadRejectsMissingPostgresDSN(t *testing.T) {
 }
 
 func TestLoadRejectsMissingKuzuPath(t *testing.T) {
+	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", GraphStoreDriverKuzu)
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want non-nil")

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -409,10 +409,12 @@ func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListR
 	if runtimeID == "" {
 		return nil, errors.New("source runtime id is required")
 	}
-	if _, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID); err != nil {
+	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
 		return nil, err
 	}
 	findings, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
+		TenantID:    strings.TrimSpace(runtime.GetTenantId()),
 		RuntimeID:   runtimeID,
 		FindingID:   strings.TrimSpace(request.FindingID),
 		RuleID:      strings.TrimSpace(request.RuleID),
@@ -424,7 +426,7 @@ func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListR
 		Limit:       request.Limit,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("list findings for runtime %q: %w", runtimeID, err)
+		return nil, fmt.Errorf("list findings for tenant %q runtime %q: %w", strings.TrimSpace(runtime.GetTenantId()), runtimeID, err)
 	}
 	return &ListResult{Findings: findings}, nil
 }

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -1121,6 +1121,7 @@ func TestListFindingsReturnsFilteredPersistedFindings(t *testing.T) {
 		findings: map[string]*ports.FindingRecord{
 			"finding-1": {
 				ID:             "finding-1",
+				TenantID:       "writer",
 				RuntimeID:      "writer-okta-audit",
 				RuleID:         oktaPolicyRuleLifecycleTamperingRuleID,
 				Severity:       "HIGH",
@@ -1132,6 +1133,7 @@ func TestListFindingsReturnsFilteredPersistedFindings(t *testing.T) {
 			},
 			"finding-2": {
 				ID:             "finding-2",
+				TenantID:       "writer",
 				RuntimeID:      "writer-okta-audit",
 				RuleID:         oktaPolicyRuleLifecycleTamperingRuleID,
 				Severity:       "MEDIUM",
@@ -1180,6 +1182,9 @@ func TestListFindingsReturnsFilteredPersistedFindings(t *testing.T) {
 	}
 	if got := store.request.RuntimeID; got != "writer-okta-audit" {
 		t.Fatalf("ListFindings().RuntimeID = %q, want writer-okta-audit", got)
+	}
+	if got := store.request.TenantID; got != "writer" {
+		t.Fatalf("ListFindings().TenantID = %q, want writer", got)
 	}
 	if got := store.request.RuleID; got != oktaPolicyRuleLifecycleTamperingRuleID {
 		t.Fatalf("ListFindings().RuleID = %q, want %q", got, oktaPolicyRuleLifecycleTamperingRuleID)
@@ -1963,6 +1968,9 @@ func cloneFindingEvidence(evidence *cerebrov1.FindingEvidence) *cerebrov1.Findin
 
 func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRecord) bool {
 	if finding == nil {
+		return false
+	}
+	if request.TenantID != "" && strings.TrimSpace(finding.TenantID) != strings.TrimSpace(request.TenantID) {
 		return false
 	}
 	if strings.TrimSpace(finding.RuntimeID) != strings.TrimSpace(request.RuntimeID) {

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -528,10 +528,10 @@ func (s *Service) readEvents(ctx context.Context, source sourcecdk.Source, runti
 			NextCursor:       nextCursor(pull.NextCursor),
 			Watermark:        formatWatermark(pull.Checkpoint),
 		}
-		for _, event := range pull.Events {
+		for idx, event := range pull.Events {
 			materialized := materializeEvent(runtime, event)
 			if materialized == nil {
-				continue
+				return nil, fmt.Errorf("read source page %d: nil event at index %d", page+1, idx)
 			}
 			summary.Events = append(summary.Events, materialized)
 			if pageSummary.FirstEventID == "" {

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -2,7 +2,9 @@ package graphrebuild
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/proto"
@@ -68,6 +70,10 @@ func (s *testSource) Read(_ context.Context, _ sourcecdk.Config, cursor *cerebro
 	}
 	events := make([]*cerebrov1.EventEnvelope, 0, len(s.pages[index]))
 	for _, event := range s.pages[index] {
+		if event == nil {
+			events = append(events, nil)
+			continue
+		}
 		events = append(events, proto.Clone(event).(*cerebrov1.EventEnvelope))
 	}
 	pull := sourcecdk.Pull{
@@ -546,6 +552,31 @@ func TestRebuildDryRunReplaysRuntimeIntoTemporaryGraph(t *testing.T) {
 	}
 	if !containsTraversalPath(result.GraphTraversals, "octocat -[authored]-> writer/cerebro#418 -[belongs_to]-> writer/cerebro") {
 		t.Fatalf("GraphTraversals missing authored path: %#v", result.GraphTraversals)
+	}
+}
+
+func TestRebuildDryRunRejectsNilEventWithPageContext(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(&testSource{
+		spec:  &cerebrov1.SourceSpec{Id: "github", Name: "GitHub"},
+		pages: [][]*cerebrov1.EventEnvelope{{nil}},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := New(registry, &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				TenantId: "writer-dogfood",
+				Config:   map[string]string{"token": "fixture-token"},
+			},
+		},
+	}, nil)
+
+	_, err = service.RebuildDryRun(context.Background(), Request{RuntimeID: "writer-github"})
+	if err == nil || !strings.Contains(fmt.Sprint(err), "read source page 1: nil event at index 0") {
+		t.Fatalf("RebuildDryRun() error = %v, want nil event page context", err)
 	}
 }
 

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package graphrebuild
 
 import (

--- a/internal/graphstore/kuzu/checkpoint.go
+++ b/internal/graphstore/kuzu/checkpoint.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package kuzu
 
 import (

--- a/internal/graphstore/kuzu/checkpoint_test.go
+++ b/internal/graphstore/kuzu/checkpoint_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package kuzu
 
 import (

--- a/internal/graphstore/kuzu/ingest_run.go
+++ b/internal/graphstore/kuzu/ingest_run.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package kuzu
 
 import (

--- a/internal/graphstore/kuzu/ingest_run_test.go
+++ b/internal/graphstore/kuzu/ingest_run_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package kuzu
 
 import (

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package kuzu
 
 import (

--- a/internal/graphstore/kuzu/kuzu.go
+++ b/internal/graphstore/kuzu/kuzu.go
@@ -279,26 +279,35 @@ func (s *Store) IntegrityChecks(ctx context.Context) ([]IntegrityCheck, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !tables["entity"] || !tables["relation"] {
-		for index := range checks {
+	hasEntity := tables["entity"]
+	hasRelation := tables["relation"]
+	run := func(index int, enabled bool, query string) error {
+		if !enabled {
 			checks[index].Passed = true
+			return nil
 		}
-		return checks, nil
-	}
-	queries := []string{
-		"MATCH (src:entity)-[r:relation]->(dst:entity) WHERE src.tenant_id <> dst.tenant_id OR src.tenant_id <> r.tenant_id OR dst.tenant_id <> r.tenant_id RETURN COUNT(r)",
-		"MATCH (e:entity) WHERE e.label = '' RETURN COUNT(e)",
-		"MATCH (e:entity) WHERE e.entity_type = '' RETURN COUNT(e)",
-		"MATCH (src:entity)-[r:relation]->(dst:entity) WHERE r.relation = '' RETURN COUNT(r)",
-		"MATCH (src:entity)-[r:relation]->(dst:entity) WHERE src.urn = dst.urn RETURN COUNT(r)",
-	}
-	for index, query := range queries {
 		actual, err := s.countQuery(ctx, query)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		checks[index].Actual = actual
 		checks[index].Passed = actual == checks[index].Expected
+		return nil
+	}
+	if err := run(0, hasEntity && hasRelation, "MATCH (src:entity)-[r:relation]->(dst:entity) WHERE src.tenant_id <> dst.tenant_id OR src.tenant_id <> r.tenant_id OR dst.tenant_id <> r.tenant_id RETURN COUNT(r)"); err != nil {
+		return nil, err
+	}
+	if err := run(1, hasEntity, "MATCH (e:entity) WHERE e.label = '' RETURN COUNT(e)"); err != nil {
+		return nil, err
+	}
+	if err := run(2, hasEntity, "MATCH (e:entity) WHERE e.entity_type = '' RETURN COUNT(e)"); err != nil {
+		return nil, err
+	}
+	if err := run(3, hasEntity && hasRelation, "MATCH (src:entity)-[r:relation]->(dst:entity) WHERE r.relation = '' RETURN COUNT(r)"); err != nil {
+		return nil, err
+	}
+	if err := run(4, hasEntity && hasRelation, "MATCH (src:entity)-[r:relation]->(dst:entity) WHERE src.urn = dst.urn RETURN COUNT(r)"); err != nil {
+		return nil, err
 	}
 	return checks, nil
 }

--- a/internal/graphstore/kuzu/kuzu_nocgo.go
+++ b/internal/graphstore/kuzu/kuzu_nocgo.go
@@ -1,0 +1,34 @@
+//go:build !cgo
+
+package kuzu
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+var errCGORequired = errors.New("kuzu graph store requires CGO; rebuild with CGO_ENABLED=1")
+
+// Store is a non-CGO placeholder for the Kuzu-backed graph store.
+type Store struct{}
+
+// Open returns a clear error in non-CGO builds because go-kuzu requires CGO.
+func Open(cfg config.GraphStoreConfig) (*Store, error) {
+	if strings.TrimSpace(cfg.KuzuPath) == "" {
+		return nil, errors.New("kuzu path is required")
+	}
+	return nil, errCGORequired
+}
+
+// Close is a no-op for the non-CGO placeholder.
+func (s *Store) Close() error {
+	return nil
+}
+
+// Ping returns a clear error in non-CGO builds because go-kuzu requires CGO.
+func (s *Store) Ping(context.Context) error {
+	return errCGORequired
+}

--- a/internal/graphstore/kuzu/kuzu_nocgo.go
+++ b/internal/graphstore/kuzu/kuzu_nocgo.go
@@ -7,13 +7,25 @@ import (
 	"errors"
 	"strings"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 var errCGORequired = errors.New("kuzu graph store requires CGO; rebuild with CGO_ENABLED=1")
 
 // Store is a non-CGO placeholder for the Kuzu-backed graph store.
 type Store struct{}
+
+type Counts = graphstore.Counts
+type Traversal = graphstore.Traversal
+type IntegrityCheck = graphstore.IntegrityCheck
+type PathPattern = graphstore.PathPattern
+type Topology = graphstore.Topology
+type IngestCheckpoint = graphstore.IngestCheckpoint
+type IngestRun = graphstore.IngestRun
+type IngestRunFilter = graphstore.IngestRunFilter
 
 // Open returns a clear error in non-CGO builds because go-kuzu requires CGO.
 func Open(cfg config.GraphStoreConfig) (*Store, error) {
@@ -31,4 +43,60 @@ func (s *Store) Close() error {
 // Ping returns a clear error in non-CGO builds because go-kuzu requires CGO.
 func (s *Store) Ping(context.Context) error {
 	return errCGORequired
+}
+
+func (s *Store) Project(context.Context, *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
+	return ports.ProjectionResult{}, errCGORequired
+}
+
+func (s *Store) UpsertProjectedEntity(context.Context, *ports.ProjectedEntity) error {
+	return errCGORequired
+}
+
+func (s *Store) UpsertProjectedLink(context.Context, *ports.ProjectedLink) error {
+	return errCGORequired
+}
+
+func (s *Store) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
+	return nil, errCGORequired
+}
+
+func (s *Store) Counts(context.Context) (Counts, error) {
+	return Counts{}, errCGORequired
+}
+
+func (s *Store) IntegrityChecks(context.Context) ([]IntegrityCheck, error) {
+	return nil, errCGORequired
+}
+
+func (s *Store) PathPatterns(context.Context, int) ([]PathPattern, error) {
+	return nil, errCGORequired
+}
+
+func (s *Store) Topology(context.Context) (Topology, error) {
+	return Topology{}, errCGORequired
+}
+
+func (s *Store) SampleTraversals(context.Context, int) ([]Traversal, error) {
+	return nil, errCGORequired
+}
+
+func (s *Store) GetIngestCheckpoint(context.Context, string) (IngestCheckpoint, bool, error) {
+	return IngestCheckpoint{}, false, errCGORequired
+}
+
+func (s *Store) PutIngestCheckpoint(context.Context, IngestCheckpoint) error {
+	return errCGORequired
+}
+
+func (s *Store) PutIngestRun(context.Context, IngestRun) error {
+	return errCGORequired
+}
+
+func (s *Store) GetIngestRun(context.Context, string) (IngestRun, bool, error) {
+	return IngestRun{}, false, errCGORequired
+}
+
+func (s *Store) ListIngestRuns(context.Context, IngestRunFilter) ([]IngestRun, error) {
+	return nil, errCGORequired
 }

--- a/internal/graphstore/kuzu/kuzu_nocgo_test.go
+++ b/internal/graphstore/kuzu/kuzu_nocgo_test.go
@@ -1,0 +1,21 @@
+//go:build !cgo
+
+package kuzu
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+func TestOpenWithoutCGOReturnsClearError(t *testing.T) {
+	_, err := Open(config.GraphStoreConfig{
+		Driver:   config.GraphStoreDriverKuzu,
+		KuzuPath: filepath.Join(t.TempDir(), "graph"),
+	})
+	if !errors.Is(err, errCGORequired) {
+		t.Fatalf("Open() error = %v, want %v", err, errCGORequired)
+	}
+}

--- a/internal/graphstore/kuzu/kuzu_test.go
+++ b/internal/graphstore/kuzu/kuzu_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package kuzu
 
 import (

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package kuzu
 
 import (

--- a/internal/graphstore/kuzu/projection_test.go
+++ b/internal/graphstore/kuzu/projection_test.go
@@ -259,6 +259,39 @@ func TestIntegrityChecksDetectTenantMismatch(t *testing.T) {
 	}
 }
 
+func TestIntegrityChecksRunEntityOnlyChecksWithoutRelationTable(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	if _, err := store.db.ExecContext(ctx, "CREATE NODE TABLE entity(urn STRING, tenant_id STRING, source_id STRING, entity_type STRING, label STRING, attributes_json STRING, PRIMARY KEY (urn))"); err != nil {
+		t.Fatalf("create entity table: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE (:entity {urn: %s, tenant_id: %s, source_id: %s, entity_type: %s, label: %s, attributes_json: %s})",
+		cypherString("urn:cerebro:writer:github_repo:writer/cerebro"),
+		cypherString("writer"),
+		cypherString("github"),
+		cypherString("github.repo"),
+		cypherString(""),
+		cypherString("{}"),
+	)); err != nil {
+		t.Fatalf("insert entity: %v", err)
+	}
+
+	checks, err := store.IntegrityChecks(ctx)
+	if err != nil {
+		t.Fatalf("IntegrityChecks() error = %v", err)
+	}
+	if actual := integrityCheckActual(checks, "blank_entity_labels"); actual != 1 {
+		t.Fatalf("blank_entity_labels = %d, want 1", actual)
+	}
+	if passed := integrityCheckPassed(checks, "blank_entity_labels"); passed {
+		t.Fatal("blank_entity_labels passed = true, want false")
+	}
+	if passed := integrityCheckPassed(checks, "blank_relation_types"); !passed {
+		t.Fatal("blank_relation_types passed = false, want true when relation table is absent")
+	}
+}
+
 func TestUpsertProjectedEntityRejectsNilEntity(t *testing.T) {
 	store := &Store{}
 	if err := store.UpsertProjectedEntity(context.Background(), nil); err == nil {
@@ -363,6 +396,15 @@ func integrityCheckActual(checks []IntegrityCheck, name string) int64 {
 		}
 	}
 	return -1
+}
+
+func integrityCheckPassed(checks []IntegrityCheck, name string) bool {
+	for _, check := range checks {
+		if check.Name == name {
+			return check.Passed
+		}
+	}
+	return false
 }
 
 func containsPathPattern(patterns []PathPattern, fromType string, firstRelation string, viaType string, secondRelation string, toType string, count int64) bool {

--- a/internal/graphstore/kuzu/query.go
+++ b/internal/graphstore/kuzu/query.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package kuzu
 
 import (

--- a/internal/graphstore/kuzu/query_test.go
+++ b/internal/graphstore/kuzu/query_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package kuzu
 
 import (

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -66,6 +66,7 @@ type FindingRecord struct {
 
 // ListFindingsRequest scopes one finding query.
 type ListFindingsRequest struct {
+	TenantID    string
 	RuntimeID   string
 	FindingID   string
 	RuleID      string

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -2,6 +2,8 @@ package reports
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"slices"
@@ -20,6 +22,7 @@ const (
 	findingSummaryReportID           = "finding-summary"
 	findingSummaryReportName         = "Finding Summary"
 	findingSummaryReportStatus       = "completed"
+	reportParameterTenantID          = "tenant_id"
 	reportParameterRuntimeID         = "runtime_id"
 	reportParameterResourceLimit     = "resource_limit"
 	reportParameterGraphLimit        = "graph_limit"
@@ -96,8 +99,12 @@ func (s *Service) Run(ctx context.Context, request *cerebrov1.RunReportRequest) 
 		return nil, err
 	}
 
+	runID, err := reportRunID(reportID, generatedAt)
+	if err != nil {
+		return nil, err
+	}
 	run := &cerebrov1.ReportRun{
-		Id:          reportRunID(reportID, generatedAt),
+		Id:          runID,
 		ReportId:    reportID,
 		Parameters:  parameters,
 		Status:      findingSummaryReportStatus,
@@ -133,6 +140,10 @@ func (s *Service) Get(ctx context.Context, request *cerebrov1.GetReportRunReques
 }
 
 func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]string) (*structpb.Struct, error) {
+	tenantID := strings.TrimSpace(parameters[reportParameterTenantID])
+	if tenantID == "" {
+		return nil, fmt.Errorf("report parameter %q is required", reportParameterTenantID)
+	}
 	runtimeID := strings.TrimSpace(parameters[reportParameterRuntimeID])
 	if runtimeID == "" {
 		return nil, fmt.Errorf("report parameter %q is required", reportParameterRuntimeID)
@@ -145,9 +156,9 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 	if err != nil {
 		return nil, err
 	}
-	findings, err := s.findingStore.ListFindings(ctx, ports.ListFindingsRequest{RuntimeID: runtimeID})
+	findings, err := s.findingStore.ListFindings(ctx, ports.ListFindingsRequest{TenantID: tenantID, RuntimeID: runtimeID})
 	if err != nil {
-		return nil, fmt.Errorf("list findings for runtime %q: %w", runtimeID, err)
+		return nil, fmt.Errorf("list findings for tenant %q runtime %q: %w", tenantID, runtimeID, err)
 	}
 	severityCounts := make(map[string]int, len(findings))
 	statusCounts := make(map[string]int, len(findings))
@@ -237,6 +248,7 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 		}
 	}
 	result, err := structpb.NewStruct(map[string]any{
+		reportParameterTenantID:  tenantID,
 		reportParameterRuntimeID: runtimeID,
 		"total_findings":         len(findings),
 		"severity_counts":        countEntries(severityCounts, "severity"),
@@ -298,8 +310,13 @@ func findingSummaryDefinition() *cerebrov1.ReportDefinition {
 	return &cerebrov1.ReportDefinition{
 		Id:          findingSummaryReportID,
 		Name:        findingSummaryReportName,
-		Description: "Materialize one runtime-scoped summary of persisted findings, grouped by severity, status, due-date posture, rule, policy, check, and control, with note and ticket activity plus bounded graph evidence for top resources when the graph is configured.",
+		Description: "Materialize one tenant/runtime-scoped summary of persisted findings, grouped by severity, status, due-date posture, rule, policy, check, and control, with note and ticket activity plus bounded graph evidence for top resources when the graph is configured.",
 		Parameters: []*cerebrov1.ReportParameter{
+			{
+				Id:          reportParameterTenantID,
+				Description: "Tenant identifier whose persisted findings should be summarized.",
+				Required:    true,
+			},
 			{
 				Id:          reportParameterRuntimeID,
 				Description: "Stored source runtime identifier whose persisted findings should be summarized.",
@@ -343,9 +360,13 @@ func normalizeParameters(parameters map[string]string) map[string]string {
 	return normalized
 }
 
-func reportRunID(reportID string, generatedAt time.Time) string {
+func reportRunID(reportID string, generatedAt time.Time) (string, error) {
 	replacer := strings.NewReplacer(" ", "-", "_", "-", "/", "-")
-	return replacer.Replace(strings.TrimSpace(reportID)) + "-" + fmt.Sprintf("%d", generatedAt.UnixNano())
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate report run id entropy: %w", err)
+	}
+	return replacer.Replace(strings.TrimSpace(reportID)) + "-" + fmt.Sprintf("%d", generatedAt.UnixNano()) + "-" + hex.EncodeToString(random), nil
 }
 
 type countEntry struct {

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -3,6 +3,7 @@ package reports
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +35,15 @@ func (s *stubFindingStore) ListFindings(_ context.Context, request ports.ListFin
 	s.request = request
 	findings := make([]*ports.FindingRecord, 0, len(s.findings))
 	for _, finding := range s.findings {
+		if finding == nil {
+			continue
+		}
+		if request.TenantID != "" && strings.TrimSpace(finding.TenantID) != strings.TrimSpace(request.TenantID) {
+			continue
+		}
+		if request.RuntimeID != "" && strings.TrimSpace(finding.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+			continue
+		}
 		findings = append(findings, cloneFinding(finding))
 	}
 	return findings, nil
@@ -144,6 +154,7 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 		findings: []*ports.FindingRecord{
 			{
 				ID:        "finding-1",
+				TenantID:  "writer",
 				RuntimeID: "writer-okta-audit",
 				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
 				PolicyID:  "pol-1",
@@ -173,6 +184,7 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 			},
 			{
 				ID:        "finding-2",
+				TenantID:  "writer",
 				RuntimeID: "writer-okta-audit",
 				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
 				PolicyID:  "pol-1",
@@ -225,6 +237,7 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
 		ReportId: findingSummaryReportID,
 		Parameters: map[string]string{
+			reportParameterTenantID:   "writer",
 			reportParameterRuntimeID:  "writer-okta-audit",
 			reportParameterGraphLimit: "2",
 		},
@@ -241,10 +254,16 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 	if response.GetRun().GetStatus() != findingSummaryReportStatus {
 		t.Fatalf("Run().Run.Status = %q, want %q", response.GetRun().GetStatus(), findingSummaryReportStatus)
 	}
+	if findingStore.request.TenantID != "writer" {
+		t.Fatalf("ListFindings().TenantID = %q, want writer", findingStore.request.TenantID)
+	}
 	if findingStore.request.RuntimeID != "writer-okta-audit" {
 		t.Fatalf("ListFindings().RuntimeID = %q, want writer-okta-audit", findingStore.request.RuntimeID)
 	}
 	result := response.GetRun().GetResult().AsMap()
+	if got := result[reportParameterTenantID]; got != "writer" {
+		t.Fatalf("Run().Run.Result[tenant_id] = %#v, want writer", got)
+	}
 	if got := result[reportParameterRuntimeID]; got != "writer-okta-audit" {
 		t.Fatalf("Run().Run.Result[runtime_id] = %#v, want writer-okta-audit", got)
 	}
@@ -372,11 +391,27 @@ func TestListReportDefinitionsIncludesFindingSummary(t *testing.T) {
 	}
 }
 
+func TestReportRunIDIncludesEntropy(t *testing.T) {
+	generatedAt := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	first, err := reportRunID(findingSummaryReportID, generatedAt)
+	if err != nil {
+		t.Fatalf("reportRunID(first) error = %v", err)
+	}
+	second, err := reportRunID(findingSummaryReportID, generatedAt)
+	if err != nil {
+		t.Fatalf("reportRunID(second) error = %v", err)
+	}
+	if first == second {
+		t.Fatalf("reportRunID() returned duplicate id %q", first)
+	}
+}
+
 func TestRunFindingSummaryReportWithoutGraphStoreMarksEvidenceUnconfigured(t *testing.T) {
 	findingStore := &stubFindingStore{
 		findings: []*ports.FindingRecord{
 			{
 				ID:        "finding-1",
+				TenantID:  "writer",
 				RuntimeID: "writer-okta-audit",
 				RuleID:    "identity-okta-policy-rule-lifecycle-tampering",
 				Severity:  "HIGH",
@@ -389,6 +424,7 @@ func TestRunFindingSummaryReportWithoutGraphStoreMarksEvidenceUnconfigured(t *te
 	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
 		ReportId: findingSummaryReportID,
 		Parameters: map[string]string{
+			reportParameterTenantID:  "writer",
 			reportParameterRuntimeID: "writer-okta-audit",
 		},
 	})

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -86,9 +86,13 @@ func NewRegistry(sources ...Source) (*Registry, error) {
 		if spec == nil {
 			return nil, fmt.Errorf("source spec is required")
 		}
-		id := strings.TrimSpace(spec.Id)
+		rawID := spec.Id
+		id := strings.TrimSpace(rawID)
 		if id == "" {
 			return nil, fmt.Errorf("source id is required")
+		}
+		if id != rawID {
+			return nil, fmt.Errorf("source id %q must not have leading/trailing whitespace", rawID)
 		}
 		if _, exists := indexed[id]; exists {
 			return nil, fmt.Errorf("duplicate source id %q", id)

--- a/internal/sourcecdk/source_test.go
+++ b/internal/sourcecdk/source_test.go
@@ -78,3 +78,10 @@ func TestRegistryRejectsDuplicateIDs(t *testing.T) {
 		t.Fatal("NewRegistry() error = nil, want non-nil")
 	}
 }
+
+func TestRegistryRejectsNonCanonicalIDs(t *testing.T) {
+	_, err := NewRegistry(stubSource{spec: &cerebrov1.SourceSpec{Id: " github "}})
+	if err == nil {
+		t.Fatal("NewRegistry() error = nil, want non-nil")
+	}
+}

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -111,7 +111,7 @@ func (s *Service) lookup(sourceID string) (sourcecdk.Source, error) {
 func previewEvents(events []*cerebrov1.EventEnvelope) ([]*cerebrov1.SourcePreviewEvent, error) {
 	previews := make([]*cerebrov1.SourcePreviewEvent, 0, len(events))
 	for _, event := range events {
-		preview := &cerebrov1.SourcePreviewEvent{EventId: event.GetId()}
+		preview := &cerebrov1.SourcePreviewEvent{Event: event, EventId: event.GetId()}
 		if len(event.GetPayload()) == 0 {
 			previews = append(previews, preview)
 			continue

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -111,7 +111,7 @@ func (s *Service) lookup(sourceID string) (sourcecdk.Source, error) {
 func previewEvents(events []*cerebrov1.EventEnvelope) ([]*cerebrov1.SourcePreviewEvent, error) {
 	previews := make([]*cerebrov1.SourcePreviewEvent, 0, len(events))
 	for _, event := range events {
-		preview := &cerebrov1.SourcePreviewEvent{Event: event}
+		preview := &cerebrov1.SourcePreviewEvent{EventId: event.GetId()}
 		if len(event.GetPayload()) == 0 {
 			previews = append(previews, preview)
 			continue

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -70,6 +70,9 @@ func TestCheckDiscoverAndRead(t *testing.T) {
 	if len(readResp.PreviewEvents) != 1 {
 		t.Fatalf("len(Read().PreviewEvents) = %d, want 1", len(readResp.PreviewEvents))
 	}
+	if readResp.PreviewEvents[0].EventId != readResp.Events[0].Id {
+		t.Fatalf("Read().PreviewEvents[0].EventId = %q, want %q", readResp.PreviewEvents[0].EventId, readResp.Events[0].Id)
+	}
 	if !readResp.PreviewEvents[0].PayloadDecoded {
 		t.Fatal("Read().PreviewEvents[0].PayloadDecoded = false, want true")
 	}

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -73,6 +73,9 @@ func TestCheckDiscoverAndRead(t *testing.T) {
 	if readResp.PreviewEvents[0].EventId != readResp.Events[0].Id {
 		t.Fatalf("Read().PreviewEvents[0].EventId = %q, want %q", readResp.PreviewEvents[0].EventId, readResp.Events[0].Id)
 	}
+	if readResp.PreviewEvents[0].GetEvent().GetId() != readResp.Events[0].Id {
+		t.Fatalf("Read().PreviewEvents[0].Event.Id = %q, want %q", readResp.PreviewEvents[0].GetEvent().GetId(), readResp.Events[0].Id)
+	}
 	if !readResp.PreviewEvents[0].PayloadDecoded {
 		t.Fatal("Read().PreviewEvents[0].PayloadDecoded = false, want true")
 	}

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -116,8 +116,9 @@ func githubPullRequestProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 
-	orgURN := projectionURN(tenantID, "github_org", owner)
+	orgURN := ""
 	if owner != "" {
+		orgURN = projectionURN(tenantID, "github_org", owner)
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        orgURN,
 			TenantID:   tenantID,

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -3,6 +3,7 @@ package sourceprojection
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -81,6 +82,34 @@ func TestProjectGitHubPullRequest(t *testing.T) {
 	}
 	if _, ok := state.links["urn:cerebro:writer:github_user:alice|"+relationHasIdentifier+"|"+identifierURN]; !ok {
 		t.Fatalf("state identifier link missing for %q", identifierURN)
+	}
+}
+
+func TestProjectGitHubPullRequestWithoutOwnerDoesNotLinkEmptyOrg(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-pr-447",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.pull_request",
+		Attributes: map[string]string{
+			"pull_number": "447",
+			"repository":  "writer/cerebro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	emptyOrgURN := "urn:cerebro:writer:github_org:"
+	if _, ok := state.entities[emptyOrgURN]; ok {
+		t.Fatalf("empty org entity %q should not be projected", emptyOrgURN)
+	}
+	for key := range state.links {
+		if strings.Contains(key, emptyOrgURN) {
+			t.Fatalf("empty org link %q should not be projected", key)
+		}
 	}
 }
 

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -239,7 +239,8 @@ func sameConfig(left map[string]string, right map[string]string) bool {
 		return false
 	}
 	for key, value := range left {
-		if right[key] != value {
+		other, ok := right[key]
+		if !ok || other != value {
 			return false
 		}
 	}

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -379,6 +379,12 @@ func TestSyncRuntimeRequiresDependencies(t *testing.T) {
 	}
 }
 
+func TestSameConfigComparesKeyPresence(t *testing.T) {
+	if sameConfig(map[string]string{"a": ""}, map[string]string{"b": ""}) {
+		t.Fatal("sameConfig() = true, want false for different key sets")
+	}
+}
+
 func newFixtureRegistry() (*sourcecdk.Registry, error) {
 	github, err := githubsource.NewFixture()
 	if err != nil {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -285,8 +285,16 @@ RETURNING
 	return stored.record()
 }
 
-// ListFindings loads persisted findings for one runtime.
+// ListFindings loads persisted findings for one tenant/runtime scope.
 func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequest) (_ []*ports.FindingRecord, err error) {
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return nil, errors.New("finding tenant id is required")
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, errors.New("finding runtime id is required")
+	}
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
 	}
@@ -299,7 +307,7 @@ func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequ
 	}
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("query findings for runtime %q: %w", strings.TrimSpace(request.RuntimeID), err)
+		return nil, fmt.Errorf("query findings for tenant %q runtime %q: %w", tenantID, runtimeID, err)
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil && err == nil {
@@ -749,12 +757,16 @@ RETURNING
 }
 
 func findingListQuery(request ports.ListFindingsRequest) (string, []any, error) {
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return "", nil, errors.New("finding tenant id is required")
+	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
 	if runtimeID == "" {
 		return "", nil, errors.New("finding runtime id is required")
 	}
-	clauses := []string{"runtime_id = $1"}
-	args := []any{runtimeID}
+	clauses := []string{"tenant_id = $1", "runtime_id = $2"}
+	args := []any{tenantID, runtimeID}
 	addFindingFilter(&clauses, &args, "id", request.FindingID)
 	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
 	addFindingFilter(&clauses, &args, "severity", request.Severity)

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -56,16 +56,23 @@ func TestUpsertFindingRejectsUnconfiguredStore(t *testing.T) {
 	}
 }
 
-func TestListFindingsRejectsMissingRuntimeID(t *testing.T) {
+func TestListFindingsRejectsMissingTenantID(t *testing.T) {
 	store := &Store{}
 	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{}); err == nil {
 		t.Fatal("ListFindings() error = nil, want non-nil")
 	}
 }
 
+func TestListFindingsRejectsMissingRuntimeID(t *testing.T) {
+	store := &Store{}
+	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{TenantID: "writer"}); err == nil {
+		t.Fatal("ListFindings() error = nil, want non-nil")
+	}
+}
+
 func TestListFindingsRejectsUnconfiguredStore(t *testing.T) {
 	store := &Store{}
-	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{RuntimeID: "writer-okta-audit"}); err == nil {
+	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{TenantID: "writer", RuntimeID: "writer-okta-audit"}); err == nil {
 		t.Fatal("ListFindings() error = nil, want non-nil")
 	}
 }
@@ -93,6 +100,7 @@ func TestLinkFindingTicketRejectsEmptyURL(t *testing.T) {
 
 func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
 	query, args, err := findingListQuery(ports.ListFindingsRequest{
+		TenantID:    "writer",
 		RuntimeID:   "writer-okta-audit",
 		FindingID:   "finding-1",
 		RuleID:      "identity-okta-policy-rule-lifecycle-tampering",
@@ -107,37 +115,41 @@ func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
 		t.Fatalf("findingListQuery() error = %v", err)
 	}
 	for _, fragment := range []string{
-		"runtime_id = $1",
-		"id = $2",
-		"rule_id = $3",
-		"severity = $4",
-		"status = $5",
-		"policy_id = $6",
-		"resource_urns_json @> $7::jsonb",
-		"event_ids_json @> $8::jsonb",
-		"LIMIT $9",
+		"tenant_id = $1",
+		"runtime_id = $2",
+		"id = $3",
+		"rule_id = $4",
+		"severity = $5",
+		"status = $6",
+		"policy_id = $7",
+		"resource_urns_json @> $8::jsonb",
+		"event_ids_json @> $9::jsonb",
+		"LIMIT $10",
 	} {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("findingListQuery() query missing %q: %s", fragment, query)
 		}
 	}
-	if got := len(args); got != 9 {
-		t.Fatalf("len(findingListQuery().args) = %d, want 9", got)
+	if got := len(args); got != 10 {
+		t.Fatalf("len(findingListQuery().args) = %d, want 10", got)
 	}
-	if got := args[0]; got != "writer-okta-audit" {
-		t.Fatalf("findingListQuery().args[0] = %#v, want writer-okta-audit", got)
+	if got := args[0]; got != "writer" {
+		t.Fatalf("findingListQuery().args[0] = %#v, want writer", got)
 	}
-	if got := args[5]; got != "pol-1" {
-		t.Fatalf("findingListQuery().args[5] = %#v, want pol-1", got)
+	if got := args[1]; got != "writer-okta-audit" {
+		t.Fatalf("findingListQuery().args[1] = %#v, want writer-okta-audit", got)
 	}
-	if got := args[6]; got != `["urn:cerebro:writer:okta_resource:policyrule:pol-1"]` {
-		t.Fatalf("findingListQuery().args[6] = %#v, want resource urn array json", got)
+	if got := args[6]; got != "pol-1" {
+		t.Fatalf("findingListQuery().args[6] = %#v, want pol-1", got)
 	}
-	if got := args[7]; got != `["okta-audit-2"]` {
-		t.Fatalf("findingListQuery().args[7] = %#v, want event id array json", got)
+	if got := args[7]; got != `["urn:cerebro:writer:okta_resource:policyrule:pol-1"]` {
+		t.Fatalf("findingListQuery().args[7] = %#v, want resource urn array json", got)
 	}
-	if got := args[8]; got != int64(25) {
-		t.Fatalf("findingListQuery().args[8] = %#v, want 25", got)
+	if got := args[8]; got != `["okta-audit-2"]` {
+		t.Fatalf("findingListQuery().args[8] = %#v, want event id array json", got)
+	}
+	if got := args[9]; got != int64(25) {
+		t.Fatalf("findingListQuery().args[9] = %#v, want 25", got)
 	}
 }
 

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -258,7 +258,7 @@ message ReadSourceRequest {
 
 // SourcePreviewEvent exposes a decoded payload view for preview consumers.
 message SourcePreviewEvent {
-  EventEnvelope event = 1;
+  string event_id = 1;
   google.protobuf.Value payload = 2;
   bool payload_decoded = 3;
 }

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -258,9 +258,10 @@ message ReadSourceRequest {
 
 // SourcePreviewEvent exposes a decoded payload view for preview consumers.
 message SourcePreviewEvent {
-  string event_id = 1;
+  EventEnvelope event = 1;
   google.protobuf.Value payload = 2;
   bool payload_decoded = 3;
+  string event_id = 4;
 }
 
 // ReadSourceResponse returns one page of source events plus replay cursors.

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -206,8 +206,6 @@ func nextAuditCursor(resp *gogithub.Response) string {
 		return strings.TrimSpace(resp.After)
 	case strings.TrimSpace(resp.Cursor) != "":
 		return strings.TrimSpace(resp.Cursor)
-	case strings.TrimSpace(resp.Before) != "":
-		return strings.TrimSpace(resp.Before)
 	case strings.TrimSpace(resp.NextPageToken) != "":
 		return strings.TrimSpace(resp.NextPageToken)
 	case resp.NextPage > 0:

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	gogithub "github.com/google/go-github/v66/github"
+
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
@@ -301,6 +303,12 @@ func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
 	}
 	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "audit-doc-2" {
 		t.Fatalf("second.Checkpoint = %#v, want audit-doc-2", second.Checkpoint)
+	}
+}
+
+func TestNextAuditCursorIgnoresBefore(t *testing.T) {
+	if got := nextAuditCursor(&gogithub.Response{Before: "cursor-1"}); got != "" {
+		t.Fatalf("nextAuditCursor() = %q, want empty cursor", got)
 	}
 }
 

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -107,6 +107,43 @@ func TestNewFixtureReplaysFixturePages(t *testing.T) {
 	}
 }
 
+func TestReadRejectsNegativeCursor(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	cfg := sourcecdk.NewConfig(map[string]string{"owner": "writer", "repo": "cerebro"})
+
+	if _, err := source.Read(context.Background(), cfg, &cerebrov1.SourceCursor{Opaque: "-1"}); err == nil {
+		t.Fatal("Read() error = nil, want non-nil")
+	}
+}
+
+func TestReadTrimsCursor(t *testing.T) {
+	server := httptest.NewServer(newGitHubAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"owner":    "writer",
+		"per_page": "1",
+		"repo":     "cerebro",
+		"state":    "all",
+	})
+
+	pull, err := source.Read(context.Background(), cfg, &cerebrov1.SourceCursor{Opaque: " 1 "})
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+}
+
 func TestCheckDiscoverAndReadLiveGitHubPullRequestPreview(t *testing.T) {
 	server := httptest.NewServer(newGitHubAPIHandler(t))
 	defer server.Close()

--- a/tools/linters/nobackgroundctx/nobackgroundctx.go
+++ b/tools/linters/nobackgroundctx/nobackgroundctx.go
@@ -3,6 +3,7 @@ package nobackgroundctx
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"path/filepath"
 	"strings"
 
@@ -30,21 +31,36 @@ func run(pass *analysis.Pass) (any, error) {
 		if fileAllowed(pass, call.Pos()) {
 			return
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return
-		}
-		pkg, ok := sel.X.(*ast.Ident)
-		if !ok || pkg.Name != "context" {
-			return
-		}
-		switch sel.Sel.Name {
-		case "Background", "TODO":
+		report := func(name string) {
 			pass.Report(analysis.Diagnostic{
 				Pos:     call.Pos(),
 				End:     call.End(),
-				Message: "context." + sel.Sel.Name + " is forbidden outside cmd/ and tests; accept a context from the caller instead. (see PLAN.md §7 sin #12)",
+				Message: "context." + name + " is forbidden outside cmd/ and tests; accept a context from the caller instead. (see PLAN.md §7 sin #12)",
 			})
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			pkgIdent, ok := fun.X.(*ast.Ident)
+			if !ok {
+				return
+			}
+			pkgName, ok := pass.TypesInfo.Uses[pkgIdent].(*types.PkgName)
+			if !ok || pkgName.Imported() == nil || pkgName.Imported().Path() != "context" {
+				return
+			}
+			switch fun.Sel.Name {
+			case "Background", "TODO":
+				report(fun.Sel.Name)
+			}
+		case *ast.Ident:
+			fn, ok := pass.TypesInfo.Uses[fun].(*types.Func)
+			if !ok || fn.Pkg() == nil || fn.Pkg().Path() != "context" {
+				return
+			}
+			switch fn.Name() {
+			case "Background", "TODO":
+				report(fn.Name())
+			}
 		}
 	})
 	return nil, nil

--- a/tools/linters/nobackgroundctx/testdata/src/a/a.go
+++ b/tools/linters/nobackgroundctx/testdata/src/a/a.go
@@ -1,6 +1,10 @@
 package a
 
-import "context"
+import (
+	"context"
+	. "context"
+	c "context"
+)
 
 func Bad() context.Context {
 	return context.Background() // want `context.Background is forbidden outside cmd/ and tests`
@@ -8,4 +12,12 @@ func Bad() context.Context {
 
 func AlsoBad() context.Context {
 	return context.TODO() // want `context.TODO is forbidden outside cmd/ and tests`
+}
+
+func AliasBad() context.Context {
+	return c.Background() // want `context.Background is forbidden outside cmd/ and tests`
+}
+
+func DotBad() context.Context {
+	return TODO() // want `context.TODO is forbidden outside cmd/ and tests`
 }

--- a/tools/linters/noenvoutsidecmd/noenvoutsidecmd.go
+++ b/tools/linters/noenvoutsidecmd/noenvoutsidecmd.go
@@ -3,6 +3,7 @@ package noenvoutsidecmd
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"path/filepath"
 	"strings"
 
@@ -30,21 +31,36 @@ func run(pass *analysis.Pass) (any, error) {
 		if fileAllowed(pass, call.Pos()) {
 			return
 		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return
-		}
-		pkg, ok := sel.X.(*ast.Ident)
-		if !ok || pkg.Name != "os" {
-			return
-		}
-		switch sel.Sel.Name {
-		case "Getenv", "LookupEnv":
+		report := func(name string) {
 			pass.Report(analysis.Diagnostic{
 				Pos:     call.Pos(),
 				End:     call.End(),
-				Message: "os." + sel.Sel.Name + " is forbidden outside cmd/ and config; thread configuration through typed inputs instead. (see PLAN.md §7 sin #11)",
+				Message: "os." + name + " is forbidden outside cmd/ and config; thread configuration through typed inputs instead. (see PLAN.md §7 sin #11)",
 			})
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			pkgIdent, ok := fun.X.(*ast.Ident)
+			if !ok {
+				return
+			}
+			pkgName, ok := pass.TypesInfo.Uses[pkgIdent].(*types.PkgName)
+			if !ok || pkgName.Imported() == nil || pkgName.Imported().Path() != "os" {
+				return
+			}
+			switch fun.Sel.Name {
+			case "Getenv", "LookupEnv":
+				report(fun.Sel.Name)
+			}
+		case *ast.Ident:
+			fn, ok := pass.TypesInfo.Uses[fun].(*types.Func)
+			if !ok || fn.Pkg() == nil || fn.Pkg().Path() != "os" {
+				return
+			}
+			switch fn.Name() {
+			case "Getenv", "LookupEnv":
+				report(fn.Name())
+			}
 		}
 	})
 	return nil, nil

--- a/tools/linters/noenvoutsidecmd/testdata/src/a/a.go
+++ b/tools/linters/noenvoutsidecmd/testdata/src/a/a.go
@@ -1,6 +1,10 @@
 package a
 
-import "os"
+import (
+	"os"
+	. "os"
+	o "os"
+)
 
 func Bad() string {
 	return os.Getenv("HOME") // want `os.Getenv is forbidden outside cmd/ and config`
@@ -9,4 +13,12 @@ func Bad() string {
 func AlsoBad() (string, bool) {
 	value, ok := os.LookupEnv("HOME") // want `os.LookupEnv is forbidden outside cmd/ and config`
 	return value, ok
+}
+
+func AliasBad() string {
+	return o.Getenv("HOME") // want `os.Getenv is forbidden outside cmd/ and config`
+}
+
+func DotBad() (string, bool) {
+	return LookupEnv("HOME") // want `os.LookupEnv is forbidden outside cmd/ and config`
 }

--- a/tools/linters/noinmemorydb/noinmemorydb.go
+++ b/tools/linters/noinmemorydb/noinmemorydb.go
@@ -3,6 +3,7 @@ package noinmemorydb
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"strconv"
 	"strings"
 
@@ -54,7 +55,7 @@ func run(pass *analysis.Pass) (any, error) {
 			if ident, ok := sel.X.(*ast.Ident); ok && strings.HasPrefix(strings.ToLower(ident.Name), "sqlite") {
 				report(pass, reported, call.Pos(), call.End())
 			}
-			if (sel.Sel.Name == "Open" || sel.Sel.Name == "OpenDB") && len(call.Args) > 0 && isSQLiteDriverLiteral(call.Args[0]) {
+			if (sel.Sel.Name == "Open" || sel.Sel.Name == "OpenDB") && len(call.Args) > 0 && isDatabaseSQLSelector(pass, sel) && isSQLiteDriverLiteral(call.Args[0]) {
 				report(pass, reported, call.Args[0].Pos(), call.Args[0].End())
 			}
 		}
@@ -65,6 +66,15 @@ func run(pass *analysis.Pass) (any, error) {
 		}
 	})
 	return nil, nil
+}
+
+func isDatabaseSQLSelector(pass *analysis.Pass, sel *ast.SelectorExpr) bool {
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	pkgName, ok := pass.TypesInfo.Uses[ident].(*types.PkgName)
+	return ok && pkgName.Imported() != nil && pkgName.Imported().Path() == "database/sql"
 }
 
 func report(pass *analysis.Pass, reported map[token.Pos]struct{}, pos, end token.Pos) {

--- a/tools/linters/noinmemorydb/testdata/src/a/a.go
+++ b/tools/linters/noinmemorydb/testdata/src/a/a.go
@@ -17,3 +17,11 @@ func AlsoBad() {
 func Good() {
 	_, _ = sql.Open("postgres", "postgres://db")
 }
+
+type opener struct{}
+
+func (opener) Open(driver string) {}
+
+func AlsoGood() {
+	opener{}.Open("sqlite")
+}

--- a/tools/linters/nopanicprod/nopanicprod.go
+++ b/tools/linters/nopanicprod/nopanicprod.go
@@ -43,7 +43,7 @@ func run(pass *analysis.Pass) (any, error) {
 			if !ok || ident.Name != "panic" {
 				return true
 			}
-			if enclosingFuncName(stack) == "init" {
+			if enclosingIsPackageInit(stack) {
 				return true
 			}
 			pass.Report(analysis.Diagnostic{
@@ -57,14 +57,14 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-func enclosingFuncName(stack []ast.Node) string {
+func enclosingIsPackageInit(stack []ast.Node) bool {
 	for i := len(stack) - 1; i >= 0; i-- {
 		decl, ok := stack[i].(*ast.FuncDecl)
 		if ok && decl.Name != nil {
-			return decl.Name.Name
+			return decl.Recv == nil && decl.Name.Name == "init"
 		}
 	}
-	return ""
+	return false
 }
 
 func packageAllowed(path string) bool {

--- a/tools/linters/nopanicprod/testdata/src/a/a.go
+++ b/tools/linters/nopanicprod/testdata/src/a/a.go
@@ -12,3 +12,9 @@ var _ = func() int {
 func init() {
 	panic("allowed during init")
 }
+
+type T struct{}
+
+func (T) init() {
+	panic("method init is not package init") // want `panic is forbidden outside tests, init, and panicsafe`
+}


### PR DESCRIPTION
## Summary
- roll up the remaining `cerebro-next` fixes that are still missing from `main`
- include the 14 non-obsolete commits from the stacked branch chain
- supersede #488, which only carried the standalone linter fix into `main`

## Included fixes
- linter guardrail hardening
- bootstrap health and proto tooling hardening
- Kuzu CGO/non-CGO graph fixes plus integrity-check coverage
- source runtime, cursor, preview, and GitHub audit fixes
- JetStream replay bounding
- tenant-scoped finding summary reports with unique run IDs
- claim identity preservation and ordering fixes

## Notes
- the final `fix(sdk): validate optional jira fields` cherry-pick was intentionally skipped because it only touched `sdk/typescript/examples/jira_onboarding.ts`, which is already deleted on `main`

## Validation
- `go build -o bin/cerebro ./cmd/cerebro`
- `go test ./...`
- `/Users/jonathan/go/bin/golangci-lint run --timeout 5m ./cmd/... ./internal/... ./sources/...`
- `GOTOOLCHAIN=go1.26.2 go run github.com/bufbuild/buf/cmd/buf@v1.59.0 lint`
- `go test ./tools/archtests/...`
