### PR TITLE
fix(ci): cover main-cut review gaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
 BUF := GOTOOLCHAIN=go1.26.2 go run github.com/bufbuild/buf/cmd/buf@latest
-APP_PACKAGES := ./cmd/... ./internal/... ./sources/...
+APP_PACKAGES := ./api/... ./cmd/... ./internal/... ./sources/...
 LINTER_MODULE := ./tools/linters
 LINTER_BIN := $(GO_BIN)/cerebrolint
 WORKFLOW_E2E_PACKAGES := ./internal/workflowevents ./internal/workflowprojection ./internal/knowledge ./internal/findings ./internal/bootstrap

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -1,6 +1,17 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
+
+func TestRunRejectsUnsupportedCommand(t *testing.T) {
+	err := run([]string{"unsupported"})
+	var usage usageError
+	if !errors.As(err, &usage) {
+		t.Fatalf("run(unsupported) error = %v, want usageError", err)
+	}
+}
 
 func TestParseSourceRuntimePutArgsSeparatesTenantID(t *testing.T) {
 	runtime, err := parseSourceRuntimePutArgs([]string{


### PR DESCRIPTION
Main-based follow-up for PR #436.\n\n- Include the remaining api package in the lint package set.\n- Add a regression test that unsupported CLI commands return a usage error instead of silently succeeding.\n\nValidation: make verify