### PR TITLE
fix: address merged PR feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           cache: true
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+        run: make lint-bootstrap
 
       - name: Verify
         run: make verify

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -20,11 +20,11 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@8ea31f351ee6636ebef918ccb64682f477af7184 # main
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -29,10 +29,10 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@8ea31f351ee6636ebef918ccb64682f477af7184 # main
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
+GOLANGCI_LINT_VERSION ?= v2.11.4
 BUF := GOTOOLCHAIN=go1.26.2 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
 APP_PACKAGES := ./api/... ./cmd/... ./internal/... ./sources/...
 LINTER_MODULE := ./tools/linters
@@ -81,7 +82,7 @@ lint: lint-bootstrap
 	$(GOLANGCI_LINT) run --timeout 5m $(APP_PACKAGES)
 
 lint-bootstrap:
-	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOTOOLCHAIN=go1.26.2 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest; 	fi
+	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOTOOLCHAIN=go1.26.2 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
 
 proto-lint:
 	$(BUF) lint
@@ -104,10 +105,10 @@ check-structural: check-structural-build
 	@$(LINTER_BIN) $(APP_PACKAGES)
 
 check-structural-build:
-	@GOFLAGS= cd $(LINTER_MODULE) && go build -o $(LINTER_BIN) ./cerebrolint
+	@cd $(LINTER_MODULE) && GOFLAGS= go build -o $(LINTER_BIN) ./cerebrolint
 
 check-structural-test:
-	@GOFLAGS= cd $(LINTER_MODULE) && go test ./...
+	@cd $(LINTER_MODULE) && GOFLAGS= go test ./...
 
 check-arch:
 	go test ./tools/archtests/...

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -129,11 +130,8 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 		return errors.New("event is required")
 	}
 	kind := strings.TrimSpace(event.Kind)
-	if kind == "" {
-		return errors.New("event kind is required")
-	}
-	if strings.ContainsRune(kind, ' ') {
-		return fmt.Errorf("event kind %q is not a valid NATS subject token", kind)
+	if err := validateEventKind(kind); err != nil {
+		return err
 	}
 	payload, err := proto.Marshal(event)
 	if err != nil {
@@ -196,6 +194,23 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		}
 	}
 	return events, nil
+}
+
+func validateEventKind(kind string) error {
+	if kind == "" {
+		return errors.New("event kind is required")
+	}
+	for _, token := range strings.Split(kind, ".") {
+		if token == "" {
+			return fmt.Errorf("event kind %q is not a valid NATS subject", kind)
+		}
+		for _, r := range token {
+			if unicode.IsSpace(r) || unicode.IsControl(r) || r == '*' || r == '>' {
+				return fmt.Errorf("event kind %q is not a valid NATS subject", kind)
+			}
+		}
+	}
+	return nil
 }
 
 func normalizeReplayLimit(limit uint32) uint32 {

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -98,6 +98,25 @@ func TestAppendRejectsMissingKind(t *testing.T) {
 	}
 }
 
+func TestAppendRejectsInvalidKindSubjects(t *testing.T) {
+	log := &Log{js: &fakePublisher{}, subjectPrefix: "events"}
+	for _, kind := range []string{
+		"entity update",
+		"entity\tupdate",
+		"entity..update",
+		".entity",
+		"entity.",
+		"entity.*",
+		"entity.>",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			if err := log.Append(context.Background(), &cerebrov1.EventEnvelope{Kind: kind}); err == nil {
+				t.Fatal("Append() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
 func TestPingSurfacesPublisherError(t *testing.T) {
 	log := &Log{js: &fakePublisher{accountErr: errors.New("down")}, subjectPrefix: "events"}
 	if err := log.Ping(context.Background()); err == nil {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -56,6 +56,13 @@ type bootstrapService struct {
 	sources *sourcecdk.Registry
 }
 
+const (
+	maxProtoJSONBodyBytes = 1 << 20
+	healthCheckTimeout    = 2 * time.Second
+)
+
+var errProtoJSONBodyTooLarge = errors.New("request JSON body exceeds maximum size")
+
 // New constructs the minimal bootstrap app and registers the Connect handlers.
 func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App {
 	mux := http.NewServeMux()
@@ -1807,9 +1814,15 @@ func timestampValue(value *timestamppb.Timestamp) time.Time {
 	return value.AsTime()
 }
 func readProtoJSON(r *http.Request, message proto.Message) error {
-	body, err := io.ReadAll(r.Body)
+	if r.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxProtoJSONBodyBytes+1))
 	if err != nil {
 		return err
+	}
+	if len(body) > maxProtoJSONBodyBytes {
+		return fmt.Errorf("%w: %d bytes", errProtoJSONBodyTooLarge, maxProtoJSONBodyBytes)
 	}
 	if len(bytes.TrimSpace(body)) == 0 {
 		return nil
@@ -2265,7 +2278,9 @@ func componentStatus(ctx context.Context, name string, dependency pinger) *cereb
 	if dependency == nil {
 		return status
 	}
-	if err := dependency.Ping(ctx); err != nil {
+	checkCtx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+	defer cancel()
+	if err := dependency.Ping(checkCtx); err != nil {
 		status.Status = "error"
 		status.Detail = "unhealthy"
 		return status

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -70,6 +70,18 @@ type stubStore struct {
 
 func (s stubStore) Ping(context.Context) error { return s.err }
 
+type deadlineAwareStore struct {
+	sawDeadline bool
+}
+
+func (s *deadlineAwareStore) Ping(ctx context.Context) error {
+	if _, ok := ctx.Deadline(); !ok {
+		return errors.New("health check deadline is required")
+	}
+	s.sawDeadline = true
+	return nil
+}
+
 type recordingAppendLog struct {
 	err            error
 	events         []*cerebrov1.EventEnvelope
@@ -971,6 +983,28 @@ func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
 	}
 	if got := healthResp.Msg.Components[1].Detail; got == rawDependencyError {
 		t.Fatalf("state_store detail leaked raw dependency error")
+	}
+}
+
+func TestBootstrapHealthPingsUseTimeoutContext(t *testing.T) {
+	stateStore := &deadlineAwareStore{}
+	response := healthResponse(context.Background(), Dependencies{StateStore: stateStore})
+	if response.GetStatus() != "ready" {
+		t.Fatalf("health status = %q, want ready", response.GetStatus())
+	}
+	if !stateStore.sawDeadline {
+		t.Fatal("state store ping did not receive a deadline")
+	}
+}
+
+func TestReadProtoJSONRejectsOversizedBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/reports/finding-summary/runs", strings.NewReader(strings.Repeat("x", maxProtoJSONBodyBytes+1)))
+	err := readProtoJSON(req, &cerebrov1.RunReportRequest{})
+	if err == nil {
+		t.Fatal("readProtoJSON() error = nil, want non-nil")
+	}
+	if !errors.Is(err, errProtoJSONBodyTooLarge) {
+		t.Fatalf("readProtoJSON() error = %v, want size error", err)
 	}
 }
 

--- a/internal/findings/okta_policy_rule_lifecycle_tampering_rule.go
+++ b/internal/findings/okta_policy_rule_lifecycle_tampering_rule.go
@@ -85,9 +85,6 @@ func matchesOktaPolicyRuleLifecycleTampering(event *cerebrov1.EventEnvelope) boo
 		return false
 	}
 	outcome := strings.ToLower(strings.TrimSpace(attributes["outcome_result"]))
-	if outcome == "" {
-		outcome = "success"
-	}
 	_, ok := oktaPolicyRuleLifecycleTamperingOutcomes[outcome]
 	return ok
 }

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -246,12 +246,12 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 		return nil, s.finishFailedRun(ctx, run, 0, nil, evaluationErr)
 	}
 	result := &EvaluateResult{
-		Runtime:         runtime,
-		Rule:            rule.Spec(),
-		EventsEvaluated: uint32(len(events)),
-		Run:             run,
+		Runtime: runtime,
+		Rule:    rule.Spec(),
+		Run:     run,
 	}
 	for _, event := range events {
+		result.EventsEvaluated++
 		emitted, err := rule.Evaluate(ctx, runtime, event)
 		if err != nil {
 			evaluationErr := fmt.Errorf("evaluate finding rule %q for event %q: %w", result.Rule.GetId(), event.GetId(), err)
@@ -756,7 +756,7 @@ func newFindingEvaluationRun(runtimeID string, ruleID string, eventLimit uint32,
 		RuntimeId:  strings.TrimSpace(runtimeID),
 		RuleId:     strings.TrimSpace(ruleID),
 		Status:     "running",
-		EventLimit: eventLimit,
+		EventLimit: normalizeEventLimit(eventLimit),
 		StartedAt:  timestamppb.New(normalizedStartedAt),
 	}
 }

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -432,6 +432,31 @@ func (r *emittingRule) Evaluate(_ context.Context, runtime *cerebrov1.SourceRunt
 	}, nil
 }
 
+type failingRule struct {
+	spec               *cerebrov1.RuleSpec
+	supportedSourceIDs map[string]struct{}
+	err                error
+}
+
+func (r *failingRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return r.spec
+}
+
+func (r *failingRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	_, ok := r.supportedSourceIDs[runtime.GetSourceId()]
+	return ok
+}
+
+func (r *failingRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, r.err
+}
+
 func TestEvaluateSourceRuntimeFindingsReplaysOktaPolicyRuleLifecycleTampering(t *testing.T) {
 	replayer := &stubReplayer{
 		events: []*cerebrov1.EventEnvelope{
@@ -572,6 +597,22 @@ func TestEvaluateSourceRuntimeFindingsReplaysOktaPolicyRuleLifecycleTampering(t 
 	}
 }
 
+func TestOktaPolicyRuleLifecycleTamperingRequiresSuccessfulOutcome(t *testing.T) {
+	missingOutcome := newAuditEvent("okta-audit-2", "policy.rule.update", "")
+	delete(missingOutcome.Attributes, "outcome_result")
+	if matchesOktaPolicyRuleLifecycleTampering(missingOutcome) {
+		t.Fatal("matchesOktaPolicyRuleLifecycleTampering() = true for missing outcome, want false")
+	}
+	failedOutcome := newAuditEvent("okta-audit-3", "policy.rule.update", "FAILURE")
+	if matchesOktaPolicyRuleLifecycleTampering(failedOutcome) {
+		t.Fatal("matchesOktaPolicyRuleLifecycleTampering() = true for failed outcome, want false")
+	}
+	successOutcome := newAuditEvent("okta-audit-4", "policy.rule.update", "SUCCESS")
+	if !matchesOktaPolicyRuleLifecycleTampering(successOutcome) {
+		t.Fatal("matchesOktaPolicyRuleLifecycleTampering() = false for success outcome, want true")
+	}
+}
+
 func TestEvaluateSourceRuntimeFindingsReplaysGitHubDependabotAlert(t *testing.T) {
 	replayer := &stubReplayer{
 		events: []*cerebrov1.EventEnvelope{
@@ -695,6 +736,70 @@ func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T
 	service := New(nil, nil, nil, nil, nil, nil)
 	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{RuntimeID: "writer-okta-audit"}); !errors.Is(err, ErrRuntimeUnavailable) {
 		t.Fatalf("EvaluateSourceRuntime() error = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}
+
+func TestEvaluateSourceRuntimeFindingsPersistsNormalizedFailedRun(t *testing.T) {
+	registry, err := NewRegistry(&failingRule{
+		spec: &cerebrov1.RuleSpec{
+			Id:   "failing-rule",
+			Name: "Failing Rule",
+		},
+		supportedSourceIDs: map[string]struct{}{"okta": {}},
+		err:                errors.New("rule failed"),
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	replayer := &stubReplayer{
+		events: []*cerebrov1.EventEnvelope{
+			newAuditEvent("okta-audit-1", "policy.rule.update", "SUCCESS"),
+			newAuditEvent("okta-audit-2", "policy.rule.update", "SUCCESS"),
+		},
+	}
+	store := &stubFindingStore{}
+	service := NewWithRegistry(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {
+					Id:       "writer-okta-audit",
+					SourceId: "okta",
+					TenantId: "writer",
+				},
+			},
+		},
+		replayer,
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	_, err = service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID:  "writer-okta-audit",
+		RuleID:     "failing-rule",
+		EventLimit: maxEventLimit + 1,
+	})
+	if err == nil {
+		t.Fatal("EvaluateSourceRuntime() error = nil, want non-nil")
+	}
+	if got := replayer.request.Limit; got != maxEventLimit {
+		t.Fatalf("Replay().Limit = %d, want %d", got, maxEventLimit)
+	}
+	if got := len(store.runs); got != 1 {
+		t.Fatalf("len(store.runs) = %d, want 1", got)
+	}
+	for _, run := range store.runs {
+		if got := run.GetStatus(); got != "failed" {
+			t.Fatalf("Run.Status = %q, want failed", got)
+		}
+		if got := run.GetEventLimit(); got != maxEventLimit {
+			t.Fatalf("Run.EventLimit = %d, want %d", got, maxEventLimit)
+		}
+		if got := run.GetEventsEvaluated(); got != 1 {
+			t.Fatalf("Run.EventsEvaluated = %d, want 1", got)
+		}
 	}
 }
 

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -156,6 +156,8 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 	if err != nil {
 		return nil, err
 	}
+	parameters[reportParameterResourceLimit] = strconv.Itoa(resourceLimit)
+	parameters[reportParameterGraphLimit] = strconv.Itoa(graphLimit)
 	findings, err := s.findingStore.ListFindings(ctx, ports.ListFindingsRequest{TenantID: tenantID, RuntimeID: runtimeID})
 	if err != nil {
 		return nil, fmt.Errorf("list findings for tenant %q runtime %q: %w", tenantID, runtimeID, err)

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -372,6 +372,12 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 	if reportStore.run == nil {
 		t.Fatal("PutReportRun() not called")
 	}
+	if got := reportStore.run.GetParameters()[reportParameterResourceLimit]; got != "3" {
+		t.Fatalf("stored resource_limit = %q, want default 3", got)
+	}
+	if got := reportStore.run.GetParameters()[reportParameterGraphLimit]; got != "2" {
+		t.Fatalf("stored graph_limit = %q, want 2", got)
+	}
 }
 
 func TestGetReportRunRequiresAvailableStore(t *testing.T) {

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -22,6 +22,15 @@ func ParseURN(raw string) (URN, error) {
 	if !strings.HasPrefix(value, "urn:cerebro:") {
 		return "", fmt.Errorf("invalid cerebro urn %q", value)
 	}
+	parts := strings.Split(value, ":")
+	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
+		return "", fmt.Errorf("invalid cerebro urn %q", value)
+	}
+	for _, part := range parts[2:] {
+		if strings.TrimSpace(part) == "" || strings.TrimSpace(part) != part {
+			return "", fmt.Errorf("invalid cerebro urn %q", value)
+		}
+	}
 	return URN(value), nil
 }
 

--- a/internal/sourcecdk/source_test.go
+++ b/internal/sourcecdk/source_test.go
@@ -34,8 +34,21 @@ func TestParseURN(t *testing.T) {
 }
 
 func TestParseURNRejectsInvalidValue(t *testing.T) {
-	if _, err := ParseURN("user:123"); err == nil {
-		t.Fatal("ParseURN() error = nil, want non-nil")
+	for _, raw := range []string{
+		"user:123",
+		"urn:cerebro:",
+		"urn:cerebro:tenant",
+		"urn:cerebro:tenant:user",
+		"urn:cerebro::user:123",
+		"urn:cerebro:tenant::123",
+		"urn:cerebro:tenant:user:",
+		"urn:cerebro: tenant:user:123",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := ParseURN(raw); err == nil {
+				t.Fatal("ParseURN() error = nil, want non-nil")
+			}
+		})
 	}
 }
 

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -56,16 +56,20 @@ func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeReques
 	if err != nil {
 		return nil, err
 	}
-	if err := source.Check(ctx, sourcecdk.NewConfig(runtime.GetConfig())); err != nil {
-		return nil, err
-	}
 	existing, err := s.lookupRuntime(ctx, runtime.GetId())
 	switch {
 	case err == nil:
-		runtime = mergeRuntime(existing, runtime)
+		restoreRedactedConfig(existing, runtime)
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
+		existing = nil
 	default:
 		return nil, err
+	}
+	if err := source.Check(ctx, sourcecdk.NewConfig(runtime.GetConfig())); err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		runtime = mergeRuntime(existing, runtime)
 	}
 	if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
 		return nil, err
@@ -188,6 +192,23 @@ func normalizePageLimit(pageLimit uint32) (uint32, error) {
 		return 0, fmt.Errorf("page_limit must be between 1 and %d", maxPageLimit)
 	}
 	return pageLimit, nil
+}
+
+func restoreRedactedConfig(existing *cerebrov1.SourceRuntime, incoming *cerebrov1.SourceRuntime) {
+	if existing == nil || incoming == nil || len(incoming.GetConfig()) == 0 {
+		return
+	}
+	if strings.TrimSpace(existing.GetSourceId()) != strings.TrimSpace(incoming.GetSourceId()) {
+		return
+	}
+	for key, value := range incoming.GetConfig() {
+		if strings.TrimSpace(value) != redactedValue || !sensitiveConfigKey(key) {
+			continue
+		}
+		if preserved, ok := existing.GetConfig()[key]; ok {
+			incoming.Config[key] = preserved
+		}
+	}
 }
 
 func mergeRuntime(existing *cerebrov1.SourceRuntime, incoming *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -184,6 +184,49 @@ func TestPutPreservesProgressWhenConfigIsUnchanged(t *testing.T) {
 	}
 }
 
+func TestPutRestoresRedactedSensitiveConfigBeforeMerge(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-github": {
+				Id:       "writer-github",
+				SourceId: "github",
+				TenantId: "writer",
+				Config:   map[string]string{"token": "preserved-value"},
+				Checkpoint: &cerebrov1.SourceCheckpoint{
+					CursorOpaque: "1",
+				},
+				NextCursor:   &cerebrov1.SourceCursor{Opaque: "1"},
+				LastSyncedAt: timestamppb.Now(),
+			},
+		},
+	}
+	service := New(registry, store, nil, nil)
+
+	resp, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-github",
+			SourceId: "github",
+			Config:   map[string]string{"token": redactedValue},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if got := store.runtimes["writer-github"].GetConfig()["token"]; got != "preserved-value" {
+		t.Fatalf("stored token = %q, want preserved secret", got)
+	}
+	if got := resp.GetRuntime().GetConfig()["token"]; got != redactedValue {
+		t.Fatalf("response token = %q, want redacted", got)
+	}
+	if got := store.runtimes["writer-github"].GetNextCursor().GetOpaque(); got != "1" {
+		t.Fatalf("stored next cursor = %q, want preserved cursor", got)
+	}
+}
+
 func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -158,14 +158,7 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord)
 	if !finding.StatusUpdatedAt.IsZero() {
 		statusUpdatedAt = finding.StatusUpdatedAt.UTC()
 	}
-	firstObservedAt := finding.FirstObservedAt.UTC()
-	lastObservedAt := finding.LastObservedAt.UTC()
-	if firstObservedAt.IsZero() {
-		firstObservedAt = lastObservedAt
-	}
-	if lastObservedAt.IsZero() {
-		lastObservedAt = firstObservedAt
-	}
+	firstObservedAt, lastObservedAt := normalizeFindingObservationWindow(finding.FirstObservedAt, finding.LastObservedAt, time.Now().UTC())
 	var stored findingRow
 	if err := s.db.QueryRowContext(ctx, `
 INSERT INTO findings (
@@ -283,6 +276,23 @@ RETURNING
 		return nil, fmt.Errorf("upsert finding %q: %w", id, err)
 	}
 	return stored.record()
+}
+
+func normalizeFindingObservationWindow(firstObservedAt time.Time, lastObservedAt time.Time, now time.Time) (time.Time, time.Time) {
+	firstObservedAt = firstObservedAt.UTC()
+	lastObservedAt = lastObservedAt.UTC()
+	if firstObservedAt.IsZero() {
+		firstObservedAt = lastObservedAt
+	}
+	if lastObservedAt.IsZero() {
+		lastObservedAt = firstObservedAt
+	}
+	if firstObservedAt.IsZero() {
+		now = now.UTC()
+		firstObservedAt = now
+		lastObservedAt = now
+	}
+	return firstObservedAt, lastObservedAt
 }
 
 // ListFindings loads persisted findings for one tenant/runtime scope.

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -56,6 +56,25 @@ func TestUpsertFindingRejectsUnconfiguredStore(t *testing.T) {
 	}
 }
 
+func TestNormalizeFindingObservationWindowDefaultsBothZero(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	first, last := normalizeFindingObservationWindow(time.Time{}, time.Time{}, now)
+	if !first.Equal(now) {
+		t.Fatalf("first observed at = %v, want %v", first, now)
+	}
+	if !last.Equal(now) {
+		t.Fatalf("last observed at = %v, want %v", last, now)
+	}
+}
+
+func TestNormalizeFindingObservationWindowFillsMissingBound(t *testing.T) {
+	observedAt := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	first, last := normalizeFindingObservationWindow(time.Time{}, observedAt, observedAt.Add(time.Hour))
+	if !first.Equal(observedAt) || !last.Equal(observedAt) {
+		t.Fatalf("window = (%v, %v), want both %v", first, last, observedAt)
+	}
+}
+
 func TestListFindingsRejectsMissingTenantID(t *testing.T) {
 	store := &Store{}
 	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{}); err == nil {

--- a/tools/linters/noinmemorydb/noinmemorydb.go
+++ b/tools/linters/noinmemorydb/noinmemorydb.go
@@ -52,9 +52,6 @@ func run(pass *analysis.Pass) (any, error) {
 			return
 		}
 		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
-			if ident, ok := sel.X.(*ast.Ident); ok && strings.HasPrefix(strings.ToLower(ident.Name), "sqlite") {
-				report(pass, reported, call.Pos(), call.End())
-			}
 			if (sel.Sel.Name == "Open" || sel.Sel.Name == "OpenDB") && len(call.Args) > 0 && isDatabaseSQLSelector(pass, sel) && isSQLiteDriverLiteral(call.Args[0]) {
 				report(pass, reported, call.Args[0].Pos(), call.Args[0].End())
 			}

--- a/tools/linters/noinmemorydb/testdata/src/a/a.go
+++ b/tools/linters/noinmemorydb/testdata/src/a/a.go
@@ -22,6 +22,9 @@ type opener struct{}
 
 func (opener) Open(driver string) {}
 
+var sqliteConnector opener
+
 func AlsoGood() {
 	opener{}.Open("sqlite")
+	sqliteConnector.Open("sqlite")
 }


### PR DESCRIPTION
## Summary
- Bound JSON request bodies and health dependency pings.
- Tighten event kind/URN validation, preserve redacted source runtime secrets, normalize report/finding run metadata, and avoid zero finding timestamps.
- Reduce false positives in the in-memory DB linter and pin CI/Droid workflow dependencies.

## Validation
- make verify