### PR TITLE
chore(workflows): pin Droid Auto Review to gpt-5.4 models

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -29,3 +29,8 @@ jobs:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
           automatic_security_review: true
+          # Pin the review and security review models to the gpt-5.4 generation so PR scans
+          # benefit from the newer reasoning capabilities; previously the action defaulted to
+          # the gpt-5.2 generation. Update both knobs in lock-step.
+          review_model: gpt-5.4
+          security_model: gpt-5.4

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -31,6 +31,8 @@ jobs:
           automatic_security_review: true
           # Pin the review and security review models to the gpt-5.4 generation so PR scans
           # benefit from the newer reasoning capabilities; previously the action defaulted to
-          # the gpt-5.2 generation. Update both knobs in lock-step.
+          # the gpt-5.2 generation (`review_depth: deep`). Setting `review_model` explicitly
+          # bypasses the depth preset, so re-assert reasoning_effort=high to match `deep`.
           review_model: gpt-5.4
           security_model: gpt-5.4
+          reasoning_effort: high

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -36,3 +36,7 @@ jobs:
         uses: Factory-AI/droid-action@8ea31f351ee6636ebef918ccb64682f477af7184 # main
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          # Pin tag-triggered review/security runs (@droid review / @droid security) to the
+          # gpt-5.4 generation; the action's default `review_depth: deep` resolves to gpt-5.2.
+          review_model: gpt-5.4
+          security_model: gpt-5.4

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           # Pin tag-triggered review/security runs (@droid review / @droid security) to the
-          # gpt-5.4 generation; the action's default `review_depth: deep` resolves to gpt-5.2.
+          # gpt-5.4 generation with high reasoning effort. The action's default
+          # `review_depth: deep` resolves to gpt-5.2, and setting `review_model` explicitly
+          # bypasses the depth preset, so we also re-assert reasoning_effort=high.
           review_model: gpt-5.4
           security_model: gpt-5.4
+          reasoning_effort: high


### PR DESCRIPTION
Bump the Droid Auto Review and Droid Tag workflows from the implicit `gpt-5.2` default (`review_depth: deep`) to the `gpt-5.4` generation for both `review_model` and `security_model`.

This brings two workflow files into alignment with the existing `droid-create.yml` / `droid-autofix.yml` (which already use `--model gpt-5.4` for `droid exec`):

| File | Was | Now |
| --- | --- | --- |
| `.github/workflows/droid-review.yml` | implicit gpt-5.2 (`automatic_review: true` + default `review_depth: deep`) | `review_model: gpt-5.4`, `security_model: gpt-5.4` |
| `.github/workflows/droid.yml` | implicit gpt-5.2 for `@droid review` / `@droid security` | `review_model: gpt-5.4`, `security_model: gpt-5.4` |

Effects:
- New PR review runs (auto and tag-triggered) use the gpt-5.4 reasoning generation.
- No code paths are changed; only Action inputs.

Verification:
- `python3 -c "import yaml; yaml.safe_load(open(...))"` succeeds for both files.
- Diff is two small additive blocks; no logic changes.

Per request: "cut a new pr to make it scan with 5.4 rather than 5.2 if that is a workflow for droid".