### PR TITLE
fix(github): address post-merge audit cursor feedback from PR #446

### DIFF
--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -215,21 +215,12 @@ func nextAuditCursor(resp *gogithub.Response) string {
 	}
 }
 
-func checkpointAuditCursor(entries []*gogithub.AuditEntry, cursor string) string {
-	if cursor != "" {
-		return cursor
-	}
-	if len(entries) == 0 {
-		return ""
-	}
-	if documentID := strings.TrimSpace(entries[len(entries)-1].GetDocumentID()); documentID != "" {
-		return documentID
-	}
-	occurredAt := auditOccurredAt(entries[len(entries)-1])
-	if occurredAt.IsZero() {
-		return ""
-	}
-	return occurredAt.Format(time.RFC3339Nano)
+func checkpointAuditCursor(_ []*gogithub.AuditEntry, cursor string) string {
+	// Only persist genuine GitHub pagination cursors; document IDs and
+	// occurrence timestamps are not valid `After` tokens for the audit log
+	// API, so a caller that resumes from a stored opaque must never receive
+	// one of those terminal-page fallbacks.
+	return strings.TrimSpace(cursor)
 }
 
 func auditAttributes(entry *gogithub.AuditEntry, raw map[string]any, settings settings) map[string]string {

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -308,8 +308,11 @@ func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
 	if second.NextCursor != nil {
 		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
 	}
-	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "audit-doc-2" {
-		t.Fatalf("second.Checkpoint = %#v, want audit-doc-2", second.Checkpoint)
+	if second.Checkpoint == nil {
+		t.Fatalf("second.Checkpoint = nil, want non-nil with empty CursorOpaque")
+	}
+	if second.Checkpoint.CursorOpaque != "" {
+		t.Fatalf("second.Checkpoint.CursorOpaque = %q, want empty cursor on terminal audit page", second.Checkpoint.CursorOpaque)
 	}
 }
 


### PR DESCRIPTION
Addresses an unresolved factory-droid finding on the merged source-preview chain (PR #446):

- **[P1] Keep audit checkpoint cursors reusable** (`sources/github/audit.go` line 218): the audit Read path returned the last entry's `_document_id` or an RFC3339 timestamp as `Checkpoint.CursorOpaque` whenever `nextCursor` was empty. GitHub's audit log API only accepts genuine pagination cursors via `After`, so a caller persisting that opaque and resuming from it would send a non-cursor token to GitHub and fail. The watermark already records the last-seen event time, so this commit drops the non-cursor fallback and only persists real GitHub cursors.

Updates `TestCheckDiscoverAndReadLiveGitHubAuditPreview` to assert the empty terminal cursor.

@droid review