### PR TITLE
fix(cli): preserve env-prefixed source config literals

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -310,7 +310,7 @@ func parseSourceRuntimePutArgs(args []string) (*cerebrov1.SourceRuntime, error) 
 }
 
 func sourceConfigValueFromArg(key string, value string) (string, error) {
-	if strings.HasPrefix(value, "env:") {
+	if strings.HasPrefix(value, "env:") && sensitiveCLIConfigKey(key) {
 		return sourceConfigValueFromEnv(key, value)
 	}
 	if sensitiveCLIConfigKey(key) && strings.TrimSpace(value) != "" {

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -310,10 +310,17 @@ func parseSourceRuntimePutArgs(args []string) (*cerebrov1.SourceRuntime, error) 
 }
 
 func sourceConfigValueFromArg(key string, value string) (string, error) {
-	if strings.HasPrefix(value, "env:") && sensitiveCLIConfigKey(key) {
-		return sourceConfigValueFromEnv(key, value)
+	sensitive := sensitiveCLIConfigKey(key)
+	if strings.HasPrefix(value, "env:") {
+		resolved, err := sourceConfigValueFromEnv(key, value)
+		if err == nil {
+			return resolved, nil
+		}
+		if sensitive {
+			return "", err
+		}
 	}
-	if sensitiveCLIConfigKey(key) && strings.TrimSpace(value) != "" {
+	if sensitive && strings.TrimSpace(value) != "" {
 		return "", fmt.Errorf("source config %q is sensitive; pass env:VAR instead of a literal value", strings.TrimSpace(key))
 	}
 	return value, nil

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -311,14 +311,8 @@ func parseSourceRuntimePutArgs(args []string) (*cerebrov1.SourceRuntime, error) 
 
 func sourceConfigValueFromArg(key string, value string) (string, error) {
 	sensitive := sensitiveCLIConfigKey(key)
-	if strings.HasPrefix(value, "env:") {
-		resolved, err := sourceConfigValueFromEnv(key, value)
-		if err == nil {
-			return resolved, nil
-		}
-		if sensitive {
-			return "", err
-		}
+	if strings.HasPrefix(value, "env:") && !literalEnvPrefixCLIConfigKey(key) {
+		return sourceConfigValueFromEnv(key, value)
 	}
 	if sensitive && strings.TrimSpace(value) != "" {
 		return "", fmt.Errorf("source config %q is sensitive; pass env:VAR instead of a literal value", strings.TrimSpace(key))
@@ -339,6 +333,15 @@ func sourceConfigValueFromEnv(key string, value string) (string, error) {
 		return "", fmt.Errorf("source config %q references empty environment variable %q", strings.TrimSpace(key), envName)
 	}
 	return resolved, nil
+}
+
+func literalEnvPrefixCLIConfigKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "filter", "phrase", "q", "search":
+		return true
+	default:
+		return false
+	}
 }
 
 func sensitiveCLIConfigKey(key string) bool {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -101,6 +101,7 @@ func TestParseSourceCommandArgsResolvesEnvReferences(t *testing.T) {
 }
 
 func TestParseSourceCommandArgsPreservesEnvPrefixForNonSensitiveValues(t *testing.T) {
+	t.Setenv("prod", "from-env")
 	_, config, _, err := parseSourceCommandArgs([]string{"github", "phrase=env:prod"})
 	if err != nil {
 		t.Fatalf("parseSourceCommandArgs() error = %v", err)

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -100,6 +100,16 @@ func TestParseSourceCommandArgsResolvesEnvReferences(t *testing.T) {
 	}
 }
 
+func TestParseSourceCommandArgsPreservesEnvPrefixForNonSensitiveValues(t *testing.T) {
+	_, config, _, err := parseSourceCommandArgs([]string{"github", "phrase=env:prod"})
+	if err != nil {
+		t.Fatalf("parseSourceCommandArgs() error = %v", err)
+	}
+	if got := config["phrase"]; got != "env:prod" {
+		t.Fatalf("config[phrase] = %q, want literal env:prod", got)
+	}
+}
+
 func TestParseSourceCommandArgsRejectsUnsetSensitiveEnvReference(t *testing.T) {
 	_, _, _, err := parseSourceCommandArgs([]string{"github", "token=env:CEREBRO_MISSING_TOKEN"})
 	if err == nil {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -110,6 +110,17 @@ func TestParseSourceCommandArgsPreservesEnvPrefixForNonSensitiveValues(t *testin
 	}
 }
 
+func TestParseSourceCommandArgsResolvesEnvReferencesForNonSensitiveValues(t *testing.T) {
+	t.Setenv("CEREBRO_TEST_OKTA_DOMAIN", "writer.okta.com")
+	_, config, _, err := parseSourceCommandArgs([]string{"okta", "domain=env:CEREBRO_TEST_OKTA_DOMAIN"})
+	if err != nil {
+		t.Fatalf("parseSourceCommandArgs() error = %v", err)
+	}
+	if got := config["domain"]; got != "writer.okta.com" {
+		t.Fatalf("config[domain] = %q, want %q", got, "writer.okta.com")
+	}
+}
+
 func TestParseSourceCommandArgsRejectsUnsetSensitiveEnvReference(t *testing.T) {
 	_, _, _, err := parseSourceCommandArgs([]string{"github", "token=env:CEREBRO_MISSING_TOKEN"})
 	if err == nil {


### PR DESCRIPTION
Follow-up to #494.\n\nThis keeps literal non-sensitive source config values such as `phrase=env:prod` intact while still resolving `env:VAR` for sensitive keys like tokens.\n\nValidation: `make verify`.