### PR TITLE
fix: address post-merge feedback across pending stacks

### DIFF
--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -23,6 +24,8 @@ const (
 	claimTypeClassification = "classification"
 	claimStatusAsserted     = "asserted"
 	claimStatusRetracted    = "retracted"
+	claimStatusRefuted      = "refuted"
+	claimStatusSuperseded   = "superseded"
 )
 
 var (
@@ -37,6 +40,14 @@ type Service struct {
 	store        ports.ClaimStore
 	state        ports.ProjectionStateStore
 	graph        ports.ProjectionGraphStore
+
+	// runtimeWriteLocks serializes WriteClaims requests per runtime so that a
+	// replace_existing snapshot cannot interleave with another write batch for
+	// the same runtime and retract its freshly asserted rows. This protects
+	// in-process concurrency only; cross-process callers should rely on a
+	// shared advisory lock when one is available.
+	runtimeWriteLocksGuard sync.Mutex
+	runtimeWriteLocks      map[string]*sync.Mutex
 }
 
 // WriteRequest scopes one runtime-scoped claim batch.
@@ -76,11 +87,29 @@ type ListResult struct {
 // New constructs a claim write service.
 func New(runtimeStore ports.SourceRuntimeStore, store ports.ClaimStore, state ports.ProjectionStateStore, graph ports.ProjectionGraphStore) *Service {
 	return &Service{
-		runtimeStore: runtimeStore,
-		store:        store,
-		state:        state,
-		graph:        graph,
+		runtimeStore:      runtimeStore,
+		store:             store,
+		state:             state,
+		graph:             graph,
+		runtimeWriteLocks: make(map[string]*sync.Mutex),
 	}
+}
+
+// runtimeWriteLock returns a per-runtime mutex used to serialize concurrent
+// WriteClaims executions for the same runtime so the per-claim upserts and the
+// final retractMissingClaims pass cannot interleave for two snapshots.
+func (s *Service) runtimeWriteLock(runtimeID string) *sync.Mutex {
+	s.runtimeWriteLocksGuard.Lock()
+	defer s.runtimeWriteLocksGuard.Unlock()
+	if s.runtimeWriteLocks == nil {
+		s.runtimeWriteLocks = make(map[string]*sync.Mutex)
+	}
+	lock, ok := s.runtimeWriteLocks[runtimeID]
+	if !ok {
+		lock = &sync.Mutex{}
+		s.runtimeWriteLocks[runtimeID] = lock
+	}
+	return lock
 }
 
 // WriteClaims persists one runtime-scoped claim batch.
@@ -92,6 +121,9 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 	if runtimeID == "" {
 		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
 	}
+	lock := s.runtimeWriteLock(runtimeID)
+	lock.Lock()
+	defer lock.Unlock()
 	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
 	if err != nil {
 		return nil, err
@@ -165,11 +197,13 @@ func (s *Service) ListClaims(ctx context.Context, request ListRequest) (*ListRes
 	if runtimeID == "" {
 		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
 	}
-	if _, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID); err != nil {
+	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
 		return nil, err
 	}
 	records, err := s.store.ListClaims(ctx, ports.ListClaimsRequest{
 		RuntimeID:     runtimeID,
+		TenantID:      strings.TrimSpace(runtime.GetTenantId()),
 		ClaimID:       strings.TrimSpace(request.ClaimID),
 		SubjectURN:    strings.TrimSpace(request.SubjectURN),
 		Predicate:     strings.TrimSpace(request.Predicate),
@@ -206,6 +240,7 @@ func (s *Service) retractMissingClaims(ctx context.Context, runtime *cerebrov1.S
 	}
 	existing, err := s.store.ListClaims(ctx, ports.ListClaimsRequest{
 		RuntimeID: runtimeID,
+		TenantID:  strings.TrimSpace(runtime.GetTenantId()),
 		Status:    claimStatusAsserted,
 	})
 	if err != nil {
@@ -542,7 +577,9 @@ func projectedRelation(runtime *cerebrov1.SourceRuntime, claim *cerebrov1.Claim)
 }
 
 func retractedRelation(runtime *cerebrov1.SourceRuntime, claim *cerebrov1.Claim) *ports.ProjectedLink {
-	if !strings.EqualFold(strings.TrimSpace(claim.GetStatus()), claimStatusRetracted) {
+	switch strings.ToLower(strings.TrimSpace(claim.GetStatus())) {
+	case claimStatusRetracted, claimStatusRefuted, claimStatusSuperseded:
+	default:
 		return nil
 	}
 	return relationLink(runtime, claim)

--- a/internal/claims/service_test.go
+++ b/internal/claims/service_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -394,6 +396,55 @@ func TestWriteClaimsRetractedRelationDeletesProjectedLink(t *testing.T) {
 	}
 	if _, ok := projection.deletedLinks[issueURN+"|assigned_to|"+assigneeURN]; !ok {
 		t.Fatal("deleted projected link missing for explicitly retracted relation")
+	}
+}
+
+func TestWriteClaimsRefutedAndSupersededRelationsDeleteProjectedLink(t *testing.T) {
+	issueURN := "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-123"
+	assigneeURN := "urn:cerebro:writer:runtime:writer-jira:user:acct:42"
+	for _, status := range []string{claimStatusRefuted, claimStatusSuperseded} {
+		t.Run(status, func(t *testing.T) {
+			projection := &projectionRecorder{}
+			service := New(
+				&stubRuntimeStore{
+					runtimes: map[string]*cerebrov1.SourceRuntime{
+						"writer-jira": {
+							Id:       "writer-jira",
+							SourceId: "sdk",
+							TenantId: "writer",
+						},
+					},
+				},
+				&stubClaimStore{},
+				projection,
+				projection,
+			)
+			result, err := service.WriteClaims(context.Background(), WriteRequest{
+				RuntimeID: "writer-jira",
+				Claims: []*cerebrov1.Claim{
+					{
+						SubjectUrn:    issueURN,
+						Predicate:     "assigned_to",
+						ObjectUrn:     assigneeURN,
+						ClaimType:     claimTypeRelation,
+						Status:        status,
+						SourceEventId: "jira-event-" + status,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("WriteClaims() error = %v", err)
+			}
+			if got := result.RelationLinksProjected; got != 0 {
+				t.Fatalf("WriteClaims().RelationLinksProjected = %d, want 0", got)
+			}
+			if _, ok := projection.links[issueURN+"|assigned_to|"+assigneeURN]; ok {
+				t.Fatalf("projected link was upserted for %q relation", status)
+			}
+			if _, ok := projection.deletedLinks[issueURN+"|assigned_to|"+assigneeURN]; !ok {
+				t.Fatalf("deleted projected link missing for %q relation", status)
+			}
+		})
 	}
 }
 
@@ -951,4 +1002,85 @@ func timeFromProto(value *timestamppb.Timestamp) time.Time {
 		return time.Time{}
 	}
 	return value.AsTime().UTC()
+}
+
+func TestWriteClaimsSerializesPerRuntime(t *testing.T) {
+	const goroutines = 4
+	const calls = 6
+	var (
+		concurrent  int32
+		maxObserved int32
+	)
+	store := &concurrencyClaimStore{
+		concurrent:  &concurrent,
+		maxObserved: &maxObserved,
+	}
+	service := New(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-jira": {Id: "writer-jira", SourceId: "sdk", TenantId: "writer"},
+			},
+		},
+		store,
+		nil,
+		nil,
+	)
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < calls; i++ {
+				_, err := service.WriteClaims(context.Background(), WriteRequest{
+					RuntimeID: "writer-jira",
+					Claims: []*cerebrov1.Claim{{
+						SubjectUrn:  "urn:cerebro:writer:runtime:writer-jira:ticket:ENG-1",
+						Predicate:   "status",
+						ObjectValue: "open",
+						ClaimType:   claimTypeAttribute,
+					}},
+				})
+				if err != nil {
+					t.Errorf("WriteClaims() error = %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if got := atomic.LoadInt32(&maxObserved); got != 1 {
+		t.Fatalf("max concurrent claim writers = %d, want 1 per runtime", got)
+	}
+}
+
+type concurrencyClaimStore struct {
+	concurrent  *int32
+	maxObserved *int32
+	mu          sync.Mutex
+	claims      map[string]*ports.ClaimRecord
+}
+
+func (c *concurrencyClaimStore) Ping(context.Context) error { return nil }
+
+func (c *concurrencyClaimStore) UpsertClaim(_ context.Context, claim *ports.ClaimRecord) (*ports.ClaimRecord, error) {
+	current := atomic.AddInt32(c.concurrent, 1)
+	defer atomic.AddInt32(c.concurrent, -1)
+	for {
+		prev := atomic.LoadInt32(c.maxObserved)
+		if current <= prev || atomic.CompareAndSwapInt32(c.maxObserved, prev, current) {
+			break
+		}
+	}
+	time.Sleep(2 * time.Millisecond)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.claims == nil {
+		c.claims = make(map[string]*ports.ClaimRecord)
+	}
+	c.claims[claim.ID] = cloneClaimRecord(claim)
+	return cloneClaimRecord(claim), nil
+}
+
+func (c *concurrencyClaimStore) ListClaims(context.Context, ports.ListClaimsRequest) ([]*ports.ClaimRecord, error) {
+	return nil, nil
 }

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -962,6 +962,7 @@ func (s *Service) claimIDsForFinding(ctx context.Context, finding *ports.Finding
 	for _, eventID := range uniqueSortedStrings(finding.EventIDs) {
 		claims, err := s.claimStore.ListClaims(ctx, ports.ListClaimsRequest{
 			RuntimeID:     strings.TrimSpace(finding.RuntimeID),
+			TenantID:      strings.TrimSpace(finding.TenantID),
 			SourceEventID: eventID,
 			Limit:         defaultEvidenceClaimCap,
 		})

--- a/internal/graphquery/service.go
+++ b/internal/graphquery/service.go
@@ -47,7 +47,25 @@ func (s *Service) GetEntityNeighborhood(ctx context.Context, request Neighborhoo
 	if rootURN == "" {
 		return nil, fmt.Errorf("%w: root urn is required", ErrInvalidRequest)
 	}
+	if err := validateCerebroURN(rootURN); err != nil {
+		return nil, err
+	}
 	return s.store.GetEntityNeighborhood(ctx, rootURN, normalizeNeighborhoodLimit(request.Limit))
+}
+
+// validateCerebroURN rejects malformed root URN inputs so the API can surface
+// 400 InvalidArgument instead of 404 NotFound for caller mistakes.
+func validateCerebroURN(urn string) error {
+	parts := strings.Split(urn, ":")
+	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
+		return fmt.Errorf("%w: root urn must be of the form urn:cerebro:<tenant>:<entity_type>:<id>", ErrInvalidRequest)
+	}
+	for i := 2; i < 5; i++ {
+		if strings.TrimSpace(parts[i]) == "" {
+			return fmt.Errorf("%w: root urn must be of the form urn:cerebro:<tenant>:<entity_type>:<id>", ErrInvalidRequest)
+		}
+	}
+	return nil
 }
 
 func normalizeNeighborhoodLimit(limit uint32) int {

--- a/internal/graphquery/service_test.go
+++ b/internal/graphquery/service_test.go
@@ -54,3 +54,24 @@ func TestGetEntityNeighborhoodRequiresAvailableStore(t *testing.T) {
 		t.Fatalf("GetEntityNeighborhood() error = %v, want %v", err, ErrRuntimeUnavailable)
 	}
 }
+
+func TestGetEntityNeighborhoodRejectsMalformedRootURN(t *testing.T) {
+	store := &stubStore{}
+	service := New(store)
+	cases := []string{
+		"user:123",
+		"urn:other:writer:user:alice",
+		"urn:cerebro:writer:user",
+		"urn:cerebro::user:alice",
+		"   ",
+	}
+	for _, raw := range cases {
+		_, err := service.GetEntityNeighborhood(context.Background(), NeighborhoodRequest{RootURN: raw})
+		if !errors.Is(err, ErrInvalidRequest) {
+			t.Fatalf("GetEntityNeighborhood(%q) error = %v, want %v", raw, err, ErrInvalidRequest)
+		}
+	}
+	if store.rootURN != "" {
+		t.Fatalf("store should never see malformed urns; got %q", store.rootURN)
+	}
+}

--- a/internal/ports/claims.go
+++ b/internal/ports/claims.go
@@ -30,6 +30,7 @@ type ClaimRecord struct {
 // ListClaimsRequest scopes one claim query.
 type ListClaimsRequest struct {
 	RuntimeID     string
+	TenantID      string
 	ClaimID       string
 	SubjectURN    string
 	Predicate     string

--- a/internal/statestore/postgres/claims.go
+++ b/internal/statestore/postgres/claims.go
@@ -191,6 +191,7 @@ func (s *Store) ListClaims(ctx context.Context, request ports.ListClaimsRequest)
 		args = append(args, trimmed)
 		clauses = append(clauses, fmt.Sprintf("%s = $%d", column, len(args)))
 	}
+	addFilter("tenant_id", request.TenantID)
 	addFilter("id", request.ClaimID)
 	addFilter("subject_urn", request.SubjectURN)
 	addFilter("predicate", request.Predicate)

--- a/sdk/python/cerebro_sdk/client.py
+++ b/sdk/python/cerebro_sdk/client.py
@@ -371,11 +371,17 @@ class IntegrationClient:
                     "label": _optional_string(root.get("label")) or root_key,
                 }
             )
+            neighbors = entry.get("neighbors")
+            if not isinstance(neighbors, list):
+                neighbors = []
+            relations = entry.get("relations")
+            if not isinstance(relations, list):
+                relations = []
             neighborhood_sizes[root_key] = {
-                "neighbors": len(entry.get("neighbors", [])),
-                "relations": len(entry.get("relations", [])),
+                "neighbors": len(neighbors),
+                "relations": len(relations),
             }
-            for node in [root] + list(entry.get("neighbors", [])):
+            for node in [root] + neighbors:
                 if not isinstance(node, dict):
                     continue
                 node_urn = _optional_string(node.get("urn"))
@@ -384,7 +390,7 @@ class IntegrationClient:
                     continue
                 seen_nodes.add(node_urn)
                 node_counts[entity_type] = node_counts.get(entity_type, 0) + 1
-            for relation in entry.get("relations", []):
+            for relation in relations:
                 if not isinstance(relation, dict):
                     continue
                 from_urn = _optional_string(relation.get("from_urn"))

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -544,7 +544,10 @@ export class IntegrationClient {
     const seen = new Set<string>();
     for (const root of roots) {
       const rootUrn = typeof root === "string" ? root.trim() : root.urn.trim();
-      if (!rootUrn || seen.has(rootUrn)) {
+      if (!rootUrn) {
+        throw new Error("graphLayering: root urn must be a non-empty string");
+      }
+      if (seen.has(rootUrn)) {
         continue;
       }
       seen.add(rootUrn);


### PR DESCRIPTION
Addresses unresolved factory-droid findings posted after the recent stack merges. The PR-time fixes either never reached main (because the diverged branch chains stayed off the rollup) or refer to behavior the rolled-up code still exhibits, so they have to land on main directly.

**Findings addressed:**

- **PR #460** `internal/graphquery/service.go`: reject malformed root URNs as InvalidArgument instead of returning NotFound from the store. Adds `validateCerebroURN` and a regression test.
- **PR #463** `internal/claims/service.go`: extend retracted-relation projection cleanup to cover `refuted` and `superseded` statuses so graph queries do not continue to surface inactive edges. Adds a regression test for both statuses.
- **PR #464** `internal/claims` + `internal/ports` + `internal/statestore/postgres` + `internal/findings`: scope `ListClaims` by `tenant_id` as well as `runtime_id` so a runtime that moves tenants no longer leaks the old tenant's history.
- **PR #474** `internal/claims/service.go`: serialize `WriteClaims` per runtime via a per-key mutex so concurrent `replace_existing` snapshots cannot retract each other's freshly asserted rows. Adds a serialization regression test.
- **PR #470** `sdk/python/cerebro_sdk/client.py`: restore null-array normalization in `graph_summary` so Jira graph responses with `null` neighbors or relations no longer raise `TypeError`.
- **PR #468** `sdk/typescript/src/index.ts`: surface blank-root validation errors from `graphLayering` instead of silently dropping the entry.

@droid review