### PR TITLE
fix(findings): persist normalized event limit and disambiguate run/evidence ids

### DIFF
--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -2,6 +2,9 @@ package findings
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/url"
@@ -239,13 +242,14 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 		return nil, err
 	}
 	startedAt := time.Now().UTC()
-	run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), request.EventLimit, startedAt)
+	normalizedLimit := normalizeEventLimit(request.EventLimit)
+	run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), normalizedLimit, startedAt)
 	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
 		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
 	}
 	events, err := s.replayer.Replay(ctx, ports.ReplayRequest{
 		RuntimeID: runtimeID,
-		Limit:     normalizeEventLimit(request.EventLimit),
+		Limit:     normalizedLimit,
 	})
 	if err != nil {
 		evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
@@ -327,8 +331,9 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 		Runtime:     runtime,
 		Evaluations: make([]*RuleEvaluationResult, 0, len(rules)),
 	}
+	normalizedLimit := normalizeEventLimit(request.EventLimit)
 	for _, rule := range rules {
-		run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), request.EventLimit, startedAt)
+		run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), normalizedLimit, startedAt)
 		if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
 			return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
 		}
@@ -345,7 +350,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 	}
 	events, err := s.replayer.Replay(ctx, ports.ReplayRequest{
 		RuntimeID: runtimeID,
-		Limit:     normalizeEventLimit(request.EventLimit),
+		Limit:     normalizedLimit,
 	})
 	if err != nil {
 		evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
@@ -788,10 +793,23 @@ func newFindingEvaluationRun(runtimeID string, ruleID string, eventLimit uint32,
 	}
 }
 
+var findingEvaluationRunIDReplacer = strings.NewReplacer(" ", "-", "_", "-", "/", "-", ":", "-", ".", "-")
+
 func findingEvaluationRunID(runtimeID string, ruleID string, startedAt time.Time) string {
-	replacer := strings.NewReplacer(" ", "-", "_", "-", "/", "-", ":", "-", ".", "-")
-	prefix := replacer.Replace(strings.TrimSpace(runtimeID) + "-" + strings.TrimSpace(ruleID))
-	return "finding-evaluation-run-" + prefix + "-" + fmt.Sprintf("%d", startedAt.UnixNano())
+	rawRuntime := strings.TrimSpace(runtimeID)
+	rawRule := strings.TrimSpace(ruleID)
+	prefix := findingEvaluationRunIDReplacer.Replace(rawRuntime + "-" + rawRule)
+	digest := sha256.Sum256([]byte(rawRuntime + "\x00" + rawRule))
+	hashSuffix := hex.EncodeToString(digest[:4])
+	return "finding-evaluation-run-" + prefix + "-" + hashSuffix + "-" + fmt.Sprintf("%d", startedAt.UnixNano()) + "-" + randomFindingRunSuffix()
+}
+
+func randomFindingRunSuffix() string {
+	var buf [4]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "0000"
+	}
+	return hex.EncodeToString(buf[:])
 }
 
 func findingNoteID(findingID string, createdAt time.Time) string {
@@ -1005,5 +1023,6 @@ func findingEvidenceID(runtimeID string, findingID string, runID string, eventID
 	parts := []string{strings.TrimSpace(runtimeID), strings.TrimSpace(findingID), strings.TrimSpace(runID)}
 	parts = append(parts, uniqueSortedStrings(eventIDs)...)
 	prefix := replacer.Replace(strings.Join(parts, "-"))
-	return "finding-evidence-" + prefix
+	digest := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return "finding-evidence-" + prefix + "-" + hex.EncodeToString(digest[:8])
 }

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2458,3 +2458,34 @@ func cloneEntityRef(ref *cerebrov1.EntityRef) *cerebrov1.EntityRef {
 	}
 	return proto.Clone(ref).(*cerebrov1.EntityRef)
 }
+
+func TestFindingEvaluationRunIDIsUniqueAcrossSameNanosecond(t *testing.T) {
+	t.Parallel()
+	startedAt := time.Unix(0, 1700000000000000000).UTC()
+	first := findingEvaluationRunID("writer-jira", "rule-a", startedAt)
+	second := findingEvaluationRunID("writer-jira", "rule-a", startedAt)
+	if first == second {
+		t.Fatalf("findingEvaluationRunID() = %q, want unique random suffix between calls", first)
+	}
+	collidingFirst := findingEvaluationRunID("writer-jira", "rule_a", startedAt)
+	collidingNormalized := findingEvaluationRunID("writer-jira", "rule-a", startedAt)
+	if strings.HasPrefix(collidingFirst, "finding-evaluation-run-writer-jira-rule-a-") &&
+		strings.HasPrefix(collidingNormalized, "finding-evaluation-run-writer-jira-rule-a-") {
+		// Strip the random suffix and ensure the deterministic hash differs so callers
+		// distinguishing by raw rule id do not collide on normalization alone.
+		firstHash := strings.Split(collidingFirst, "-")[7]
+		secondHash := strings.Split(collidingNormalized, "-")[7]
+		if firstHash == secondHash {
+			t.Fatalf("findingEvaluationRunID() hash suffix collides for normalized rule ids: %s vs %s", collidingFirst, collidingNormalized)
+		}
+	}
+}
+
+func TestFindingEvidenceIDDistinguishesNormalizationCollisions(t *testing.T) {
+	t.Parallel()
+	first := findingEvidenceID("rt:a", "finding_x", "run-1", []string{"event-1"})
+	second := findingEvidenceID("rt-a", "finding-x", "run-1", []string{"event-1"})
+	if first == second {
+		t.Fatalf("findingEvidenceID() = %q, want distinct ids for raw inputs that normalize alike", first)
+	}
+}


### PR DESCRIPTION
Pulls forward the unresolved factory-droid findings from PRs #477 and #479 whose feature work already landed on main but whose follow-up fixes did not.

**Findings addressed:**

- **PR #477** `internal/findings/service.go`: persist the same normalized event limit on FindingEvaluationRun records that we use for replay so the persisted limit no longer drifts from the actual replay request.
- **PR #479** `internal/findings/service.go`: append a deterministic raw-id hash + crypto/rand suffix to `findingEvaluationRunID` so multi-rule evaluations dispatched in the same nanosecond never collide on (runtime, rule, startedAt), and so rule ids that differ only by normalized characters still produce distinct ids.
- **PR #479** `internal/findings/service.go`: append a sha256 suffix derived from the raw runtime/finding/run/event ids to `findingEvidenceID` so lossy normalization no longer overwrites distinct evidence rows.

Regression coverage added in `internal/findings/service_test.go`.

@droid review