### PR TITLE
fix: address remaining rewrite review feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Binaries
 bin/
-cerebro
+/cerebro
 !cmd/cerebro/
 !cmd/cerebro/**
 !proto/cerebro/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.11.4
-BUF := GOTOOLCHAIN=go1.26.2 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
+BUF := GOFLAGS= GOTOOLCHAIN=go1.26.2 go run github.com/bufbuild/buf/cmd/buf@v1.59.0
 APP_PACKAGES := ./api/... ./cmd/... ./internal/... ./sources/...
 LINTER_MODULE := ./tools/linters
 LINTER_BIN := $(GO_BIN)/cerebrolint
@@ -82,7 +82,7 @@ lint: lint-bootstrap
 	$(GOLANGCI_LINT) run --timeout 5m $(APP_PACKAGES)
 
 lint-bootstrap:
-	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOTOOLCHAIN=go1.26.2 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
+	@if [ ! -x "$(GOLANGCI_LINT)" ]; then 		GOFLAGS= GOTOOLCHAIN=go1.26.2 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); 	fi
 
 proto-lint:
 	$(BUF) lint

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -71,7 +71,8 @@ type Log struct {
 
 // Open dials JetStream and returns an append-log implementation.
 func Open(cfg config.AppendLogConfig) (*Log, error) {
-	if strings.TrimSpace(cfg.JetStreamURL) == "" {
+	url := strings.TrimSpace(cfg.JetStreamURL)
+	if url == "" {
 		return nil, errors.New("jetstream url is required")
 	}
 	prefix, err := normalizeSubjectPrefix(cfg.JetStreamSubjectPrefix)
@@ -79,7 +80,7 @@ func Open(cfg config.AppendLogConfig) (*Log, error) {
 		return nil, err
 	}
 	nc, err := nats.Connect(
-		cfg.JetStreamURL,
+		url,
 		nats.Name("cerebro"),
 		nats.Timeout(connectTimeout),
 		nats.RetryOnFailedConnect(false),

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1710,10 +1710,13 @@ func sensitiveSourceConfigKey(key string) bool {
 		return true
 	}
 	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(value)
-	if strings.Contains(compact, "apikey") || strings.Contains(compact, "accesskey") || strings.Contains(compact, "privatekey") {
+	if strings.Contains(compact, "apikey") ||
+		strings.Contains(compact, "accesskey") ||
+		strings.Contains(compact, "privatekey") ||
+		strings.Contains(compact, "signingkey") {
 		return true
 	}
-	return value == "key" || strings.HasSuffix(value, "_key")
+	return value == "key"
 }
 
 func writeSourceError(w http.ResponseWriter, err error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1681,7 +1681,7 @@ func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {
 		if key == "cursor" || len(rawValues) == 0 {
 			continue
 		}
-		if sensitiveSourceConfigKey(key) {
+		if headerOnlySourceConfigKey(key) {
 			return nil, fmt.Errorf("%w: source config key %q must not be supplied in query parameters", sourceops.ErrInvalidRequest, key)
 		}
 		values[key] = rawValues[len(rawValues)-1]
@@ -1699,6 +1699,18 @@ func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {
 		}
 	}
 	return values, nil
+}
+
+func headerOnlySourceConfigKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	if normalized == "" {
+		return false
+	}
+	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(normalized)
+	if compact == "accesskeyid" {
+		return false
+	}
+	return sensitiveSourceConfigKey(normalized)
 }
 
 func sensitiveSourceConfigKey(key string) bool {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -809,11 +809,15 @@ func (a *App) handleEvaluateSourceRuntimeFindingRules(w http.ResponseWriter, r *
 		return
 	}
 	if eventLimit := r.URL.Query().Get("event_limit"); eventLimit != "" {
+		// Unmarshal the override into a separate message so we do not reset
+		// rule_ids (or any future field) provided in the request body.
+		overrides := &cerebrov1.EvaluateSourceRuntimeFindingRulesRequest{}
 		body := []byte(`{"event_limit":` + eventLimit + `}`)
-		if err := unmarshalHTTPProtoJSON(body, request); err != nil {
+		if err := unmarshalHTTPProtoJSON(body, overrides); err != nil {
 			writeFindingError(w, err)
 			return
 		}
+		request.EventLimit = overrides.GetEventLimit()
 	}
 	request.Id = r.PathValue("runtimeID")
 	if ruleIDs := r.URL.Query()["rule_id"]; len(ruleIDs) != 0 {
@@ -1706,10 +1710,10 @@ func sensitiveSourceConfigKey(key string) bool {
 		return true
 	}
 	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(value)
-	if strings.Contains(compact, "apikey") || strings.Contains(compact, "privatekey") {
+	if strings.Contains(compact, "apikey") || strings.Contains(compact, "accesskey") || strings.Contains(compact, "privatekey") {
 		return true
 	}
-	return value == "key"
+	return value == "key" || strings.HasSuffix(value, "_key")
 }
 
 func writeSourceError(w http.ResponseWriter, err error) {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -56,7 +56,7 @@ func sourceGet(t *testing.T, server *httptest.Server, path string, config map[st
 }
 
 func TestSourceConfigFromRequestRejectsSensitiveQueryKeys(t *testing.T) {
-	for _, key := range []string{"token", "api_key", "apiKey", "private_key", "privateKey", "key"} {
+	for _, key := range []string{"token", "api_key", "apiKey", "access_key_id", "private_key", "privateKey", "signing_key", "key"} {
 		t.Run(key, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/sources/okta/check?"+key+"=secret", nil)
 			if _, err := sourceConfigFromRequest(req); !errors.Is(err, sourceops.ErrInvalidRequest) {
@@ -67,12 +67,12 @@ func TestSourceConfigFromRequestRejectsSensitiveQueryKeys(t *testing.T) {
 }
 
 func TestSourceConfigFromRequestAllowsNonSecretKeyQueryFields(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/sources/aws/check?access_key_id=access-key-id&lookup_key=inventory&group_key=eng", nil)
+	req := httptest.NewRequest(http.MethodGet, "/sources/aws/check?region=us-east-1&lookup=inventory&group=eng", nil)
 	config, err := sourceConfigFromRequest(req)
 	if err != nil {
 		t.Fatalf("sourceConfigFromRequest() error = %v", err)
 	}
-	for _, key := range []string{"access_key_id", "lookup_key", "group_key"} {
+	for _, key := range []string{"region", "lookup", "group"} {
 		if got := config[key]; got == "" {
 			t.Fatalf("config[%q] = %q, want value", key, got)
 		}
@@ -2004,6 +2004,35 @@ func TestFindingEndpoints(t *testing.T) {
 	batchEvidence, ok := batchEvaluation["evidence"].([]any)
 	if !ok || len(batchEvidence) != 1 {
 		t.Fatalf("batch evaluation evidence = %#v, want 1 entry", batchEvaluation["evidence"])
+	}
+
+	batchBody, err := protojson.Marshal(&cerebrov1.EvaluateSourceRuntimeFindingRulesRequest{
+		RuleIds: []string{"identity-okta-policy-rule-lifecycle-tampering"},
+	})
+	if err != nil {
+		t.Fatalf("marshal batch evaluate body: %v", err)
+	}
+	batchBodyReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-audit/finding-rules/evaluate?event_limit=2", bytes.NewReader(batchBody))
+	if err != nil {
+		t.Fatalf("new body batch evaluate request: %v", err)
+	}
+	batchBodyReq.Header.Set("Content-Type", "application/json")
+	batchBodyResp, err := server.Client().Do(batchBodyReq)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/finding-rules/evaluate body error = %v", err)
+	}
+	defer func() {
+		if closeErr := batchBodyResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close body batch evaluate response body: %v", closeErr)
+		}
+	}()
+	var batchBodyPayload map[string]any
+	if err := json.NewDecoder(batchBodyResp.Body).Decode(&batchBodyPayload); err != nil {
+		t.Fatalf("decode body batch evaluate response: %v", err)
+	}
+	batchBodyEvaluations, ok := batchBodyPayload["evaluations"].([]any)
+	if !ok || len(batchBodyEvaluations) != 1 {
+		t.Fatalf("body batch evaluations = %#v, want exactly one selected rule", batchBodyPayload["evaluations"])
 	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -67,12 +67,12 @@ func TestSourceConfigFromRequestRejectsSensitiveQueryKeys(t *testing.T) {
 }
 
 func TestSourceConfigFromRequestAllowsNonSecretKeyQueryFields(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/sources/aws/check?region=us-east-1&lookup=inventory&group=eng", nil)
+	req := httptest.NewRequest(http.MethodGet, "/sources/aws/check?region=us-east-1&lookup_key=inventory&group_key=security@example.com", nil)
 	config, err := sourceConfigFromRequest(req)
 	if err != nil {
 		t.Fatalf("sourceConfigFromRequest() error = %v", err)
 	}
-	for _, key := range []string{"region", "lookup", "group"} {
+	for _, key := range []string{"region", "lookup_key", "group_key"} {
 		if got := config[key]; got == "" {
 			t.Fatalf("config[%q] = %q, want value", key, got)
 		}

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -56,13 +56,27 @@ func sourceGet(t *testing.T, server *httptest.Server, path string, config map[st
 }
 
 func TestSourceConfigFromRequestRejectsSensitiveQueryKeys(t *testing.T) {
-	for _, key := range []string{"token", "api_key", "apiKey", "access_key_id", "private_key", "privateKey", "signing_key", "key"} {
+	for _, key := range []string{"token", "api_key", "apiKey", "secret_access_key", "private_key", "privateKey", "signing_key", "key"} {
 		t.Run(key, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/sources/okta/check?"+key+"=secret", nil)
 			if _, err := sourceConfigFromRequest(req); !errors.Is(err, sourceops.ErrInvalidRequest) {
 				t.Fatalf("sourceConfigFromRequest() error = %v, want ErrInvalidRequest", err)
 			}
 		})
+	}
+}
+
+func TestSourceConfigFromRequestAllowsAWSAccessKeyIDQueryField(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/sources/aws/check?account_id=123456789012&access_key_id=AKIAEXAMPLE", nil)
+	config, err := sourceConfigFromRequest(req)
+	if err != nil {
+		t.Fatalf("sourceConfigFromRequest() error = %v", err)
+	}
+	if got := config["account_id"]; got != "123456789012" {
+		t.Fatalf("config[account_id] = %q, want 123456789012", got)
+	}
+	if got := config["access_key_id"]; got != "AKIAEXAMPLE" {
+		t.Fatalf("config[access_key_id] = %q, want AKIAEXAMPLE", got)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -81,12 +81,12 @@ func TestSourceConfigFromRequestAllowsAWSAccessKeyIDQueryField(t *testing.T) {
 }
 
 func TestSourceConfigFromRequestAllowsNonSecretKeyQueryFields(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/sources/aws/check?region=us-east-1&lookup_key=inventory&group_key=security@example.com", nil)
+	req := httptest.NewRequest(http.MethodGet, "/sources/aws/check?region=us-east-1&lookup_key=inventory&group_key=security@example.com&access_key_id=AKIAEXAMPLE", nil)
 	config, err := sourceConfigFromRequest(req)
 	if err != nil {
 		t.Fatalf("sourceConfigFromRequest() error = %v", err)
 	}
-	for _, key := range []string{"region", "lookup_key", "group_key"} {
+	for _, key := range []string{"region", "lookup_key", "group_key", "access_key_id"} {
 		if got := config[key]; got == "" {
 			t.Fatalf("config[%q] = %q, want value", key, got)
 		}

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -72,22 +72,29 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 	default:
 		return fail(fmt.Errorf("unsupported graph store driver %q", cfg.GraphStore.Driver))
 	}
-	pingCtx, cancel := context.WithTimeout(ctx, dependencyPingTimeout)
-	defer cancel()
-	if deps.AppendLog != nil {
-		if err := deps.AppendLog.Ping(pingCtx); err != nil {
-			return fail(fmt.Errorf("ping append log: %w", err))
-		}
+	if err := pingDependency(ctx, "append log", deps.AppendLog); err != nil {
+		return fail(err)
 	}
-	if deps.StateStore != nil {
-		if err := deps.StateStore.Ping(pingCtx); err != nil {
-			return fail(fmt.Errorf("ping state store: %w", err))
-		}
+	if err := pingDependency(ctx, "state store", deps.StateStore); err != nil {
+		return fail(err)
 	}
-	if deps.GraphStore != nil {
-		if err := deps.GraphStore.Ping(pingCtx); err != nil {
-			return fail(fmt.Errorf("ping graph store: %w", err))
-		}
+	if err := pingDependency(ctx, "graph store", deps.GraphStore); err != nil {
+		return fail(err)
 	}
 	return deps, closeAll, nil
+}
+
+// pingDependency runs Ping with its own dependencyPingTimeout-bounded context so
+// the second/third dependency check still gets the full configured budget even
+// if an earlier ping consumed most of the original deadline.
+func pingDependency(ctx context.Context, label string, dep interface{ Ping(context.Context) error }) error {
+	if dep == nil {
+		return nil
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, dependencyPingTimeout)
+	defer cancel()
+	if err := dep.Ping(pingCtx); err != nil {
+		return fmt.Errorf("ping %s: %w", label, err)
+	}
+	return nil
 }

--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -34,20 +34,36 @@ var (
 	ErrInvalidRequest     = errors.New("invalid claim request")
 )
 
+// runtimeWriteLocks serializes WriteClaims requests per runtime so that a
+// replace_existing snapshot cannot interleave with another write batch for
+// the same runtime and retract its freshly asserted rows. The locks live at
+// package scope so two concurrent requests that build separate
+// claims.Service instances (App.claimService and bootstrapService.WriteClaims
+// each call claims.New) still share the same mutex per runtime ID. This
+// protects in-process concurrency only; cross-process callers must rely on a
+// shared advisory lock when one is available.
+var (
+	runtimeWriteLocksGuard sync.Mutex
+	runtimeWriteLocks      = map[string]*sync.Mutex{}
+)
+
+func runtimeWriteLockFor(runtimeID string) *sync.Mutex {
+	runtimeWriteLocksGuard.Lock()
+	defer runtimeWriteLocksGuard.Unlock()
+	lock, ok := runtimeWriteLocks[runtimeID]
+	if !ok {
+		lock = &sync.Mutex{}
+		runtimeWriteLocks[runtimeID] = lock
+	}
+	return lock
+}
+
 // Service reads and writes runtime-scoped claims into the state store and optional projections.
 type Service struct {
 	runtimeStore ports.SourceRuntimeStore
 	store        ports.ClaimStore
 	state        ports.ProjectionStateStore
 	graph        ports.ProjectionGraphStore
-
-	// runtimeWriteLocks serializes WriteClaims requests per runtime so that a
-	// replace_existing snapshot cannot interleave with another write batch for
-	// the same runtime and retract its freshly asserted rows. This protects
-	// in-process concurrency only; cross-process callers should rely on a
-	// shared advisory lock when one is available.
-	runtimeWriteLocksGuard sync.Mutex
-	runtimeWriteLocks      map[string]*sync.Mutex
 }
 
 // WriteRequest scopes one runtime-scoped claim batch.
@@ -87,29 +103,11 @@ type ListResult struct {
 // New constructs a claim write service.
 func New(runtimeStore ports.SourceRuntimeStore, store ports.ClaimStore, state ports.ProjectionStateStore, graph ports.ProjectionGraphStore) *Service {
 	return &Service{
-		runtimeStore:      runtimeStore,
-		store:             store,
-		state:             state,
-		graph:             graph,
-		runtimeWriteLocks: make(map[string]*sync.Mutex),
+		runtimeStore: runtimeStore,
+		store:        store,
+		state:        state,
+		graph:        graph,
 	}
-}
-
-// runtimeWriteLock returns a per-runtime mutex used to serialize concurrent
-// WriteClaims executions for the same runtime so the per-claim upserts and the
-// final retractMissingClaims pass cannot interleave for two snapshots.
-func (s *Service) runtimeWriteLock(runtimeID string) *sync.Mutex {
-	s.runtimeWriteLocksGuard.Lock()
-	defer s.runtimeWriteLocksGuard.Unlock()
-	if s.runtimeWriteLocks == nil {
-		s.runtimeWriteLocks = make(map[string]*sync.Mutex)
-	}
-	lock, ok := s.runtimeWriteLocks[runtimeID]
-	if !ok {
-		lock = &sync.Mutex{}
-		s.runtimeWriteLocks[runtimeID] = lock
-	}
-	return lock
 }
 
 // WriteClaims persists one runtime-scoped claim batch.
@@ -121,7 +119,7 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 	if runtimeID == "" {
 		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
 	}
-	lock := s.runtimeWriteLock(runtimeID)
+	lock := runtimeWriteLockFor(runtimeID)
 	lock.Lock()
 	defer lock.Unlock()
 	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)

--- a/internal/claims/service.go
+++ b/internal/claims/service.go
@@ -119,13 +119,13 @@ func (s *Service) WriteClaims(ctx context.Context, request WriteRequest) (*Write
 	if runtimeID == "" {
 		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
 	}
-	lock := runtimeWriteLockFor(runtimeID)
-	lock.Lock()
-	defer lock.Unlock()
 	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
 	if err != nil {
 		return nil, err
 	}
+	lock := runtimeWriteLockFor(runtimeID)
+	lock.Lock()
+	defer lock.Unlock()
 	result := &WriteResult{}
 	upsertedEntities := make(map[string]struct{})
 	upsertedLinks := make(map[string]struct{})

--- a/internal/claims/service_test.go
+++ b/internal/claims/service_test.go
@@ -1015,21 +1015,20 @@ func TestWriteClaimsSerializesPerRuntime(t *testing.T) {
 		concurrent:  &concurrent,
 		maxObserved: &maxObserved,
 	}
-	service := New(
-		&stubRuntimeStore{
-			runtimes: map[string]*cerebrov1.SourceRuntime{
-				"writer-jira": {Id: "writer-jira", SourceId: "sdk", TenantId: "writer"},
-			},
+	runtimeStore := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-jira": {Id: "writer-jira", SourceId: "sdk", TenantId: "writer"},
 		},
-		store,
-		nil,
-		nil,
-	)
+	}
 	var wg sync.WaitGroup
 	for g := 0; g < goroutines; g++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			// Build a fresh Service per goroutine so the test enforces that the
+			// serialization lock is shared across Service instances (matching the
+			// production wiring where every request creates a new claims.Service).
+			service := New(runtimeStore, store, nil, nil)
 			for i := 0; i < calls; i++ {
 				_, err := service.WriteClaims(context.Background(), WriteRequest{
 					RuntimeID: "writer-jira",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -80,8 +80,13 @@ func TestLoadRejectsInvalidDuration(t *testing.T) {
 }
 
 func TestLoadInfersDriversFromURLs(t *testing.T) {
+	t.Setenv("CEREBRO_SHUTDOWN_TIMEOUT", "")
+	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", "")
 	t.Setenv("CEREBRO_JETSTREAM_URL", "nats://127.0.0.1:4222")
+	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
+	t.Setenv("CEREBRO_STATE_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_POSTGRES_DSN", "postgres://127.0.0.1:5432/cerebro?sslmode=disable")
+	t.Setenv("CEREBRO_GRAPH_STORE_DRIVER", "")
 	t.Setenv("CEREBRO_KUZU_PATH", "/tmp/cerebro-kuzu")
 
 	cfg, err := Load()
@@ -111,6 +116,7 @@ func TestLoadRejectsUnknownAppendLogDriver(t *testing.T) {
 
 func TestLoadRejectsMissingJetStreamURL(t *testing.T) {
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", AppendLogDriverJetStream)
+	t.Setenv("CEREBRO_JETSTREAM_URL", "")
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want non-nil")
 	}
@@ -118,6 +124,7 @@ func TestLoadRejectsMissingJetStreamURL(t *testing.T) {
 
 func TestLoadRejectsMissingPostgresDSN(t *testing.T) {
 	t.Setenv("CEREBRO_STATE_STORE_DRIVER", StateStoreDriverPostgres)
+	t.Setenv("CEREBRO_POSTGRES_DSN", "")
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want non-nil")
 	}

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -335,7 +335,15 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 	for _, rule := range rules {
 		run := newFindingEvaluationRun(runtimeID, rule.Spec().GetId(), normalizedLimit, startedAt)
 		if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
-			return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
+			persistErr := fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
+			// Mark every previously persisted run failed so the durable run history
+			// does not leave them stuck in `running` when later persistence fails.
+			for _, prior := range states {
+				if failErr := s.markRuleEvaluationFailed(ctx, prior, persistErr); failErr != nil {
+					return nil, failErr
+				}
+			}
+			return nil, persistErr
 		}
 		state := &ruleEvaluationState{
 			rule:        rule,

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -69,6 +69,8 @@ type stubFindingStore struct {
 	runList          ports.ListFindingEvaluationRunsRequest
 	evidence         map[string]*cerebrov1.FindingEvidence
 	evidenceList     ports.ListFindingEvidenceRequest
+	runPutCalls      int
+	runPutErrOnCall  int
 }
 
 func (s *stubFindingStore) Ping(context.Context) error { return nil }
@@ -301,6 +303,10 @@ func (s *stubFindingStore) ListClaims(_ context.Context, request ports.ListClaim
 func (s *stubFindingStore) PutFindingEvaluationRun(_ context.Context, run *cerebrov1.FindingEvaluationRun) error {
 	if run == nil {
 		return errors.New("finding evaluation run is required")
+	}
+	s.runPutCalls++
+	if s.runPutErrOnCall > 0 && s.runPutCalls == s.runPutErrOnCall {
+		return errors.New("persist run failed")
 	}
 	if s.runs == nil {
 		s.runs = make(map[string]*cerebrov1.FindingEvaluationRun)
@@ -1176,6 +1182,52 @@ func TestEvaluateSourceRuntimeRulesReplaysOnceAcrossMultipleRules(t *testing.T) 
 	}
 	if got := len(store.evidence); got != 2 {
 		t.Fatalf("len(store.evidence) = %d, want 2", got)
+	}
+}
+
+func TestEvaluateSourceRuntimeRulesMarksPersistedRunsFailedWhenLaterRunPersistenceFails(t *testing.T) {
+	registry, err := NewRegistry(
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a", Name: "Rule A"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b", Name: "Rule B"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{runPutErrOnCall: 2}
+	service := NewWithRegistry(
+		&stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+			},
+		},
+		&stubReplayer{},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	_, err = service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "writer-okta-audit"})
+	if err == nil {
+		t.Fatal("EvaluateSourceRuntimeRules() error = nil, want non-nil")
+	}
+	if got := len(store.runs); got != 1 {
+		t.Fatalf("len(store.runs) = %d, want 1", got)
+	}
+	for _, run := range store.runs {
+		if got := run.GetStatus(); got != "failed" {
+			t.Fatalf("Run.Status = %q, want failed", got)
+		}
+		if run.GetFinishedAt() == nil {
+			t.Fatal("Run.FinishedAt = nil, want populated")
+		}
 	}
 }
 

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -563,10 +563,13 @@ func sensitiveConfigKey(key string) bool {
 		}
 	}
 	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(normalized)
-	if strings.Contains(compact, "apikey") || strings.Contains(compact, "accesskey") || strings.Contains(compact, "privatekey") {
+	if strings.Contains(compact, "apikey") ||
+		strings.Contains(compact, "accesskey") ||
+		strings.Contains(compact, "privatekey") ||
+		strings.Contains(compact, "signingkey") {
 		return true
 	}
-	return normalized == "key" || strings.HasSuffix(normalized, "_key")
+	return normalized == "key"
 }
 
 func ingestEvent(event *cerebrov1.EventEnvelope, tenantID string) *cerebrov1.EventEnvelope {

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -563,10 +563,10 @@ func sensitiveConfigKey(key string) bool {
 		}
 	}
 	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(normalized)
-	if strings.Contains(compact, "apikey") || strings.Contains(compact, "privatekey") {
+	if strings.Contains(compact, "apikey") || strings.Contains(compact, "accesskey") || strings.Contains(compact, "privatekey") {
 		return true
 	}
-	return normalized == "key"
+	return normalized == "key" || strings.HasSuffix(normalized, "_key")
 }
 
 func ingestEvent(event *cerebrov1.EventEnvelope, tenantID string) *cerebrov1.EventEnvelope {

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -65,7 +65,7 @@ func TestConfigHashIgnoresSensitiveKeyValues(t *testing.T) {
 }
 
 func TestConfigHashIncludesNonSecretSelectorKeys(t *testing.T) {
-	for _, key := range []string{"region", "lookup", "group"} {
+	for _, key := range []string{"region", "lookup_key", "group_key"} {
 		left := configHash(map[string]string{key: "first", "domain": "writer.example.com"})
 		right := configHash(map[string]string{key: "second", "domain": "writer.example.com"})
 		if left == right {

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -41,7 +41,7 @@ func (s *stubRunStore) ListIngestRuns(_ context.Context, filter graphstore.Inges
 }
 
 func TestSensitiveConfigKeyTreatsSecretMarkersAsSensitive(t *testing.T) {
-	for _, key := range []string{"key", "api_key", "apiKey", "secret_access_key", "private_key", "privateKey"} {
+	for _, key := range []string{"key", "api_key", "apiKey", "access_key_id", "secret_access_key", "private_key", "privateKey", "signing_key"} {
 		if !sensitiveConfigKey(key) {
 			t.Fatalf("sensitiveConfigKey(%q) = false, want true", key)
 		}
@@ -65,7 +65,7 @@ func TestConfigHashIgnoresSensitiveKeyValues(t *testing.T) {
 }
 
 func TestConfigHashIncludesNonSecretSelectorKeys(t *testing.T) {
-	for _, key := range []string{"access_key_id", "lookup_key", "group_key"} {
+	for _, key := range []string{"region", "lookup", "group"} {
 		left := configHash(map[string]string{key: "first", "domain": "writer.example.com"})
 		right := configHash(map[string]string{key: "second", "domain": "writer.example.com"})
 		if left == right {

--- a/internal/graphquery/service.go
+++ b/internal/graphquery/service.go
@@ -55,14 +55,14 @@ func (s *Service) GetEntityNeighborhood(ctx context.Context, request Neighborhoo
 
 // validateCerebroURN rejects malformed root URN inputs so the API can surface
 // 400 InvalidArgument instead of 404 NotFound for caller mistakes. It mirrors
-// the canonical sourcecdk.ParseURN expectations: required scheme prefix,
-// non-empty segments, and no whitespace-padded segments.
+// the canonical root shape: required scheme prefix, non-empty tenant/entity/id
+// segments, and no whitespace-padded required segments.
 func validateCerebroURN(urn string) error {
 	parts := strings.Split(urn, ":")
 	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
 		return fmt.Errorf("%w: root urn must be of the form urn:cerebro:<tenant>:<entity_type>:<id>", ErrInvalidRequest)
 	}
-	for i := 2; i < len(parts); i++ {
+	for i := 2; i < 5; i++ {
 		segment := parts[i]
 		if segment == "" || strings.TrimSpace(segment) != segment {
 			return fmt.Errorf("%w: root urn must be of the form urn:cerebro:<tenant>:<entity_type>:<id>", ErrInvalidRequest)

--- a/internal/graphquery/service.go
+++ b/internal/graphquery/service.go
@@ -54,14 +54,17 @@ func (s *Service) GetEntityNeighborhood(ctx context.Context, request Neighborhoo
 }
 
 // validateCerebroURN rejects malformed root URN inputs so the API can surface
-// 400 InvalidArgument instead of 404 NotFound for caller mistakes.
+// 400 InvalidArgument instead of 404 NotFound for caller mistakes. It mirrors
+// the canonical sourcecdk.ParseURN expectations: required scheme prefix,
+// non-empty segments, and no whitespace-padded segments.
 func validateCerebroURN(urn string) error {
 	parts := strings.Split(urn, ":")
 	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
 		return fmt.Errorf("%w: root urn must be of the form urn:cerebro:<tenant>:<entity_type>:<id>", ErrInvalidRequest)
 	}
-	for i := 2; i < 5; i++ {
-		if strings.TrimSpace(parts[i]) == "" {
+	for i := 2; i < len(parts); i++ {
+		segment := parts[i]
+		if segment == "" || strings.TrimSpace(segment) != segment {
 			return fmt.Errorf("%w: root urn must be of the form urn:cerebro:<tenant>:<entity_type>:<id>", ErrInvalidRequest)
 		}
 	}

--- a/internal/graphquery/service_test.go
+++ b/internal/graphquery/service_test.go
@@ -64,6 +64,9 @@ func TestGetEntityNeighborhoodRejectsMalformedRootURN(t *testing.T) {
 		"urn:cerebro:writer:user",
 		"urn:cerebro::user:alice",
 		"   ",
+		"urn:cerebro: writer:user:alice",
+		"urn:cerebro:writer: user:alice",
+		"urn:cerebro:writer:user: alice",
 	}
 	for _, raw := range cases {
 		_, err := service.GetEntityNeighborhood(context.Background(), NeighborhoodRequest{RootURN: raw})

--- a/internal/graphquery/service_test.go
+++ b/internal/graphquery/service_test.go
@@ -55,6 +55,19 @@ func TestGetEntityNeighborhoodRequiresAvailableStore(t *testing.T) {
 	}
 }
 
+func TestGetEntityNeighborhoodAllowsColonDelimitedRootIDs(t *testing.T) {
+	const arnRoot = "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/AdminRole"
+	store := &stubStore{neighborhood: &ports.EntityNeighborhood{Root: &ports.NeighborhoodNode{URN: arnRoot}}}
+	service := New(store)
+
+	if _, err := service.GetEntityNeighborhood(context.Background(), NeighborhoodRequest{RootURN: arnRoot}); err != nil {
+		t.Fatalf("GetEntityNeighborhood() error = %v", err)
+	}
+	if store.rootURN != arnRoot {
+		t.Fatalf("store root urn = %q, want %q", store.rootURN, arnRoot)
+	}
+}
+
 func TestGetEntityNeighborhoodRejectsMalformedRootURN(t *testing.T) {
 	store := &stubStore{}
 	service := New(store)

--- a/internal/sourcecdk/source.go
+++ b/internal/sourcecdk/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -91,7 +92,7 @@ type Registry struct {
 func NewRegistry(sources ...Source) (*Registry, error) {
 	indexed := make(map[string]Source, len(sources))
 	for _, source := range sources {
-		if source == nil {
+		if isNilSource(source) {
 			return nil, fmt.Errorf("source is required")
 		}
 		spec := source.Spec()
@@ -112,6 +113,19 @@ func NewRegistry(sources ...Source) (*Registry, error) {
 		indexed[id] = source
 	}
 	return &Registry{sources: indexed}, nil
+}
+
+func isNilSource(source Source) bool {
+	if source == nil {
+		return true
+	}
+	value := reflect.ValueOf(source)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // Get returns a registered source by ID.

--- a/internal/sourcecdk/source_test.go
+++ b/internal/sourcecdk/source_test.go
@@ -98,3 +98,22 @@ func TestRegistryRejectsNonCanonicalIDs(t *testing.T) {
 		t.Fatal("NewRegistry() error = nil, want non-nil")
 	}
 }
+
+type typedNilSource struct{}
+
+func (*typedNilSource) Spec() *cerebrov1.SourceSpec { panic("Spec called for typed-nil source") }
+
+func (*typedNilSource) Check(context.Context, Config) error { return nil }
+
+func (*typedNilSource) Discover(context.Context, Config) ([]URN, error) { return nil, nil }
+
+func (*typedNilSource) Read(context.Context, Config, *cerebrov1.SourceCursor) (Pull, error) {
+	return Pull{}, nil
+}
+
+func TestRegistryRejectsTypedNilSources(t *testing.T) {
+	var source *typedNilSource
+	if _, err := NewRegistry(source); err == nil {
+		t.Fatal("NewRegistry() error = nil, want non-nil")
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -26,10 +26,11 @@ type Store struct {
 
 // Open opens a Postgres-backed current-state store.
 func Open(cfg config.StateStoreConfig) (*Store, error) {
-	if strings.TrimSpace(cfg.PostgresDSN) == "" {
+	dsn := strings.TrimSpace(cfg.PostgresDSN)
+	if dsn == "" {
 		return nil, errors.New("postgres dsn is required")
 	}
-	db, err := sql.Open("pgx", cfg.PostgresDSN)
+	db, err := sql.Open("pgx", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open postgres: %w", err)
 	}


### PR DESCRIPTION
Pulls forward the remaining applicable factory-droid findings from the merged rewrite PRs that were not fully covered by #497/#499/#500.

Fixes include:

- Share per-runtime claim write locks across per-request claims.Service instances (#499).
- Reject whitespace-padded graph root URN segments (#499).
- Preserve body-provided finding rule_ids when applying event_limit query overrides (#480).
- Mark already-persisted multi-rule finding evaluation runs failed when later run persistence fails (#480).
- Align source config / graph ingest sensitive key handling with sourceruntime redaction, including access_key and *_key forms (#489/#486).
- Trim JetStream/Postgres connection strings before dialing (#439).
- Give dependency pings independent startup timeout budgets (#438).
- Reject typed-nil source registry entries (#440).
- Clear GOFLAGS for pinned Buf and golangci bootstrap invocations, anchor /cerebro in .gitignore, and make config tests hermetic (#438/#439).

Validation:

- make verify

@droid review