### PR TITLE
fix(providers): layer SentinelOne into compliance

### DIFF
--- a/internal/api/handlers_providers.go
+++ b/internal/api/handlers_providers.go
@@ -163,7 +163,7 @@ func includeIncompleteProviders(r *http.Request) bool {
 
 func shouldApplyProviderGraphUpdate(name string) bool {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "sentinelone":
+	case "sentinelone", "github":
 		return true
 	default:
 		return false

--- a/internal/api/handlers_providers.go
+++ b/internal/api/handlers_providers.go
@@ -113,6 +113,9 @@ func (s *Server) syncProvider(w http.ResponseWriter, r *http.Request) {
 		s.errorFromErr(w, err)
 		return
 	}
+	if result != nil && shouldApplyProviderGraphUpdate(name) {
+		result.GraphUpdate = serverSyncHandlerService{deps: s.app}.applySecurityGraphUpdateAfterSync(r.Context(), name, false)
+	}
 	s.json(w, http.StatusOK, result)
 }
 
@@ -156,4 +159,13 @@ func (s *Server) testProvider(w http.ResponseWriter, r *http.Request) {
 func includeIncompleteProviders(r *http.Request) bool {
 	include := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("include_incomplete")))
 	return include == "1" || include == "true" || include == "yes"
+}
+
+func shouldApplyProviderGraphUpdate(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "sentinelone":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/compliance/frameworks.go
+++ b/internal/compliance/frameworks.go
@@ -369,7 +369,7 @@ var PCIDSS40 = Framework{
 			ID:          "6.3.1",
 			Title:       "Security vulnerabilities are identified and addressed",
 			Description: "Vulnerabilities must be identified through scanning and patching.",
-			PolicyIDs:   []string{"aws-ecr-scan-on-push", "aws-lambda-runtime-supported"},
+			PolicyIDs:   []string{"aws-ecr-scan-on-push", "aws-lambda-runtime-supported", "sentinelone-vuln-medium"},
 		},
 
 		// Requirement 7: Restrict Access
@@ -417,7 +417,7 @@ var PCIDSS40 = Framework{
 			ID:          "10.4.1",
 			Title:       "Audit logs are reviewed at least daily",
 			Description: "Logs must be monitored for suspicious activity.",
-			PolicyIDs:   []string{"aws-guardduty-disabled", "aws-cloudwatch-alarm-missing"},
+			PolicyIDs:   []string{"aws-guardduty-disabled", "aws-cloudwatch-alarm-missing", "sentinelone-malware", "sentinelone-ransomware", "sentinelone-command-control"},
 		},
 
 		// Requirement 11: Test Security Regularly
@@ -425,7 +425,7 @@ var PCIDSS40 = Framework{
 			ID:          "11.3.1",
 			Title:       "Vulnerabilities are identified via scanning",
 			Description: "Regular vulnerability scans must be performed.",
-			PolicyIDs:   []string{"aws-ecr-scan-on-push"},
+			PolicyIDs:   []string{"aws-ecr-scan-on-push", "endpoint-sentinelone-active", "sentinelone-vuln-medium"},
 		},
 
 		// Requirement 12: Security Policies
@@ -453,7 +453,7 @@ var HIPAA = Framework{
 			ID:          "164.308(a)(1)",
 			Title:       "Security Management Process - Risk Analysis",
 			Description: "Conduct accurate and thorough assessment of risks to ePHI.",
-			PolicyIDs:   []string{"aws-config-enabled-all-regions", "aws-guardduty-disabled"},
+			PolicyIDs:   []string{"aws-config-enabled-all-regions", "aws-guardduty-disabled", "endpoint-sentinelone-active", "sentinelone-vuln-medium"},
 		},
 		{
 			ID:          "164.308(a)(3)",
@@ -491,7 +491,7 @@ var HIPAA = Framework{
 			ID:          "164.312(b)",
 			Title:       "Audit Controls",
 			Description: "Implement mechanisms to record and examine access to ePHI.",
-			PolicyIDs:   []string{"aws-cloudtrail-enabled", "aws-s3-bucket-logging-enabled", "aws-vpc-flow-logs-enabled"},
+			PolicyIDs:   []string{"aws-cloudtrail-enabled", "aws-s3-bucket-logging-enabled", "aws-vpc-flow-logs-enabled", "sentinelone-malware", "sentinelone-ransomware", "sentinelone-command-control"},
 		},
 		{
 			ID:          "164.312(c)(1)",
@@ -567,19 +567,19 @@ var SOC2 = Framework{
 			ID:          "CC7.1",
 			Title:       "Detection and Monitoring",
 			Description: "The entity detects and monitors security events to identify anomalies.",
-			PolicyIDs:   []string{"aws-cloudtrail-enabled", "aws-guardduty-disabled", "aws-config-enabled-all-regions"},
+			PolicyIDs:   []string{"aws-cloudtrail-enabled", "aws-guardduty-disabled", "aws-config-enabled-all-regions", "endpoint-sentinelone-active", "sentinelone-vuln-medium"},
 		},
 		{
 			ID:          "CC7.2",
 			Title:       "Security Event Analysis",
 			Description: "The entity evaluates potential security events and incidents.",
-			PolicyIDs:   []string{"aws-cloudwatch-alarm-missing", "aws-vpc-flow-logs-enabled"},
+			PolicyIDs:   []string{"aws-cloudwatch-alarm-missing", "aws-vpc-flow-logs-enabled", "sentinelone-malware", "sentinelone-ransomware", "sentinelone-command-control"},
 		},
 		{
 			ID:          "CC7.3",
 			Title:       "Response to Identified Security Incidents",
 			Description: "The entity responds to identified security incidents.",
-			PolicyIDs:   []string{"aws-s3-bucket-logging-enabled"},
+			PolicyIDs:   []string{"aws-s3-bucket-logging-enabled", "sentinelone-malware", "sentinelone-ransomware", "sentinelone-command-control"},
 		},
 
 		// CC8: Change Management

--- a/internal/compliance/frameworks_test.go
+++ b/internal/compliance/frameworks_test.go
@@ -243,6 +243,36 @@ func TestDSPMPolicyMappingsInFrameworks(t *testing.T) {
 	}
 }
 
+func TestSentinelOnePolicyMappingsInFrameworks(t *testing.T) {
+	tests := []struct {
+		policyID   string
+		frameworks []string
+	}{
+		{"endpoint-sentinelone-active", []string{"soc2-type2", "pci-dss-4.0", "hipaa-security"}},
+		{"sentinelone-vuln-medium", []string{"soc2-type2", "pci-dss-4.0", "hipaa-security"}},
+		{"sentinelone-malware", []string{"soc2-type2", "pci-dss-4.0", "hipaa-security"}},
+		{"sentinelone-ransomware", []string{"soc2-type2", "pci-dss-4.0", "hipaa-security"}},
+		{"sentinelone-command-control", []string{"soc2-type2", "pci-dss-4.0", "hipaa-security"}},
+	}
+
+	for _, tt := range tests {
+		controls := GetControlsForPolicy(tt.policyID)
+		if len(controls) == 0 {
+			t.Fatalf("expected %s to map to compliance controls", tt.policyID)
+		}
+
+		frameworks := make(map[string]bool, len(controls))
+		for _, control := range controls {
+			frameworks[control.Framework.ID] = true
+		}
+		for _, frameworkID := range tt.frameworks {
+			if !frameworks[frameworkID] {
+				t.Fatalf("expected %s to map to %s, got %+v", tt.policyID, frameworkID, frameworks)
+			}
+		}
+	}
+}
+
 func TestSeverityWeight(t *testing.T) {
 	tests := []struct {
 		severity ControlSeverity

--- a/internal/graph/builders/builder.go
+++ b/internal/graph/builders/builder.go
@@ -137,6 +137,7 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 	g.Go(func() error { working.buildOktaNodes(gctx); return nil })
 	g.Go(func() error { working.buildGoogleWorkspaceNodes(gctx); return nil })
 	g.Go(func() error { working.buildK8sNodes(gctx); return nil })
+	g.Go(func() error { working.buildSentinelOneNodes(gctx); return nil })
 	_ = g.Wait()
 	if err := ctx.Err(); err != nil {
 		return nil, GraphMutationSummary{}, err
@@ -159,6 +160,7 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 	eg.Go(func() error { working.buildGCPEdges(ectx); return nil })
 	eg.Go(func() error { working.buildAzureEdges(ectx); return nil })
 	eg.Go(func() error { working.buildKubernetesEdges(ectx); return nil })
+	eg.Go(func() error { working.buildSentinelOneEdges(ectx); return nil })
 	eg.Go(func() error { working.buildRelationshipEdges(ectx); return nil })
 	_ = eg.Wait()
 	if err := ctx.Err(); err != nil {

--- a/internal/graph/builders/builder.go
+++ b/internal/graph/builders/builder.go
@@ -138,6 +138,7 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 	g.Go(func() error { working.buildGoogleWorkspaceNodes(gctx); return nil })
 	g.Go(func() error { working.buildK8sNodes(gctx); return nil })
 	g.Go(func() error { working.buildSentinelOneNodes(gctx); return nil })
+	g.Go(func() error { working.buildGitHubNodes(gctx); return nil })
 	_ = g.Wait()
 	if err := ctx.Err(); err != nil {
 		return nil, GraphMutationSummary{}, err
@@ -161,6 +162,7 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 	eg.Go(func() error { working.buildAzureEdges(ectx); return nil })
 	eg.Go(func() error { working.buildKubernetesEdges(ectx); return nil })
 	eg.Go(func() error { working.buildSentinelOneEdges(ectx); return nil })
+	eg.Go(func() error { working.buildGitHubEdges(ectx); return nil })
 	eg.Go(func() error { working.buildRelationshipEdges(ectx); return nil })
 	_ = eg.Wait()
 	if err := ctx.Err(); err != nil {

--- a/internal/graph/builders/builder_cdc.go
+++ b/internal/graph/builders/builder_cdc.go
@@ -1172,6 +1172,13 @@ func cdcEventToNode(table string, event cdcEvent) *Node {
 		if len(nodes) > 0 {
 			return nodes[0]
 		}
+	case "github_repositories":
+		nodes := parseGitHubRepositoryNodes([]map[string]any{payload})
+		if len(nodes) > 0 {
+			return nodes[0]
+		}
+	case "github_dependabot_alerts":
+		return parseGitHubDependabotVulnerabilityNode(payload)
 	case "k8s_core_pods",
 		"k8s_core_namespaces",
 		"k8s_core_service_accounts",
@@ -1265,6 +1272,10 @@ func cdcNodeID(table string, payload map[string]any, fallback string) string {
 			return id
 		}
 		return sentinelOneVulnerabilityNodeID(firstNonEmpty(queryRowString(payload, "id"), fallback))
+	case "github_repositories":
+		return githubRepositoryNodeID(firstNonEmpty(queryRowString(payload, "full_name"), queryRowString(payload, "repository"), fallback))
+	case "github_dependabot_alerts":
+		return firstNonEmpty(githubDependabotVulnerabilityNodeIDForRow(payload), fallback)
 	case "k8s_core_pods",
 		"k8s_core_namespaces",
 		"k8s_core_service_accounts",

--- a/internal/graph/builders/builder_cdc.go
+++ b/internal/graph/builders/builder_cdc.go
@@ -1261,6 +1261,9 @@ func cdcNodeID(table string, payload map[string]any, fallback string) string {
 	case "sentinelone_applications":
 		return sentinelOneApplicationNodeID(firstNonEmpty(queryRowString(payload, "id"), fallback))
 	case "sentinelone_vulnerabilities":
+		if id := sentinelOneVulnerabilityNodeIDForRow(payload); id != "" {
+			return id
+		}
 		return sentinelOneVulnerabilityNodeID(firstNonEmpty(queryRowString(payload, "id"), fallback))
 	case "k8s_core_pods",
 		"k8s_core_namespaces",

--- a/internal/graph/builders/builder_cdc.go
+++ b/internal/graph/builders/builder_cdc.go
@@ -356,6 +356,7 @@ func (b *Builder) rebuildEdges(ctx context.Context) error {
 	eg.Go(func() error { b.buildGCPEdges(ectx); return nil })
 	eg.Go(func() error { b.buildAzureEdges(ectx); return nil })
 	eg.Go(func() error { b.buildKubernetesEdges(ectx); return nil })
+	eg.Go(func() error { b.buildSentinelOneEdges(ectx); return nil })
 	eg.Go(func() error { b.buildRelationshipEdges(ectx); return nil })
 	_ = eg.Wait()
 	if err := ctx.Err(); err != nil {
@@ -1141,6 +1142,36 @@ func cdcEventToNode(table string, event cdcEvent) *Node {
 				"role_type": roleType,
 			},
 		}
+	case "sentinelone_sites":
+		nodes := parseSentinelOneSiteNodes([]map[string]any{payload})
+		if len(nodes) > 0 {
+			return nodes[0]
+		}
+	case "sentinelone_agents":
+		nodes := parseSentinelOneAgentNodes([]map[string]any{payload})
+		if len(nodes) > 0 {
+			return nodes[0]
+		}
+	case "sentinelone_threats":
+		nodes := parseSentinelOneThreatNodes([]map[string]any{payload})
+		if len(nodes) > 0 {
+			return nodes[0]
+		}
+	case "sentinelone_activities":
+		nodes := parseSentinelOneActivityNodes([]map[string]any{payload})
+		if len(nodes) > 0 {
+			return nodes[0]
+		}
+	case "sentinelone_applications":
+		nodes := parseSentinelOneApplicationNodes([]map[string]any{payload})
+		if len(nodes) > 0 {
+			return nodes[0]
+		}
+	case "sentinelone_vulnerabilities":
+		nodes := parseSentinelOneVulnerabilityNodes([]map[string]any{payload})
+		if len(nodes) > 0 {
+			return nodes[0]
+		}
 	case "k8s_core_pods",
 		"k8s_core_namespaces",
 		"k8s_core_service_accounts",
@@ -1219,6 +1250,18 @@ func cdcNodeID(table string, payload map[string]any, fallback string) string {
 			return ""
 		}
 		return "okta_admin_role:" + strings.ToLower(roleType)
+	case "sentinelone_sites":
+		return sentinelOneSiteNodeID(firstNonEmpty(queryRowString(payload, "id"), fallback))
+	case "sentinelone_agents":
+		return sentinelOneAgentNodeID(firstNonEmpty(queryRowString(payload, "id"), fallback))
+	case "sentinelone_threats":
+		return sentinelOneThreatNodeID(firstNonEmpty(queryRowString(payload, "id"), fallback))
+	case "sentinelone_activities":
+		return sentinelOneActivityNodeID(firstNonEmpty(queryRowString(payload, "id"), fallback))
+	case "sentinelone_applications":
+		return sentinelOneApplicationNodeID(firstNonEmpty(queryRowString(payload, "id"), fallback))
+	case "sentinelone_vulnerabilities":
+		return sentinelOneVulnerabilityNodeID(firstNonEmpty(queryRowString(payload, "id"), fallback))
 	case "k8s_core_pods",
 		"k8s_core_namespaces",
 		"k8s_core_service_accounts",

--- a/internal/graph/builders/builder_github.go
+++ b/internal/graph/builders/builder_github.go
@@ -1,0 +1,293 @@
+package builders
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func (b *Builder) buildGitHubNodes(ctx context.Context) {
+	queries := []nodeQuery{
+		{
+			table: "github_repositories",
+			query: `SELECT id, name, full_name, private, visibility, default_branch, archived, disabled, fork, language, topics, created_at, updated_at, pushed_at FROM github_repositories`,
+			parse: parseGitHubRepositoryNodes,
+		},
+		{
+			table: "github_dependabot_alerts",
+			query: `SELECT number, repository, state, severity, package_name, package_ecosystem, vulnerable_version_range, patched_version, cve_id, ghsa_id, cvss_score, created_at, updated_at, fixed_at FROM github_dependabot_alerts`,
+			parse: parseGitHubDependabotNodes,
+		},
+	}
+
+	b.runNodeQueries(ctx, queries)
+}
+
+func parseGitHubRepositoryNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		fullName := strings.TrimSpace(queryRowString(row, "full_name"))
+		if fullName == "" {
+			fullName = strings.TrimSpace(queryRowString(row, "repository"))
+		}
+		if fullName == "" {
+			continue
+		}
+		nodes = append(nodes, &Node{
+			ID:       githubRepositoryNodeID(fullName),
+			Kind:     NodeKindRepository,
+			Name:     firstNonEmpty(queryRowString(row, "name"), fullName),
+			Provider: "github",
+			Account:  githubRepositoryOwner(fullName),
+			Risk:     githubRepositoryRisk(row),
+			Properties: map[string]any{
+				"source_table":   "github_repositories",
+				"repository":     fullName,
+				"html_url":       githubRepositoryNodeID(fullName),
+				"private":        queryRow(row, "private"),
+				"visibility":     queryRow(row, "visibility"),
+				"default_branch": queryRow(row, "default_branch"),
+				"archived":       queryRow(row, "archived"),
+				"disabled":       queryRow(row, "disabled"),
+				"fork":           queryRow(row, "fork"),
+				"language":       queryRow(row, "language"),
+				"topics":         queryRow(row, "topics"),
+				"created_at":     queryRow(row, "created_at"),
+				"updated_at":     queryRow(row, "updated_at"),
+				"pushed_at":      queryRow(row, "pushed_at"),
+			},
+		})
+	}
+	return nodes
+}
+
+func parseGitHubDependabotNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows)*2)
+	for _, row := range rows {
+		if pkg := parseGitHubDependabotPackageNode(row); pkg != nil {
+			nodes = append(nodes, pkg)
+		}
+		if vuln := parseGitHubDependabotVulnerabilityNode(row); vuln != nil {
+			nodes = append(nodes, vuln)
+		}
+	}
+	return nodes
+}
+
+func parseGitHubDependabotPackageNode(row map[string]any) *Node {
+	repository := strings.TrimSpace(queryRowString(row, "repository"))
+	packageName := strings.TrimSpace(queryRowString(row, "package_name"))
+	if repository == "" || packageName == "" {
+		return nil
+	}
+	ecosystem := firstNonEmpty(queryRowString(row, "package_ecosystem"), "unknown")
+	versionRange := strings.TrimSpace(queryRowString(row, "vulnerable_version_range"))
+	return &Node{
+		ID:       githubDependabotPackageNodeID(row),
+		Kind:     NodeKindPackage,
+		Name:     packageName,
+		Provider: "github",
+		Account:  githubRepositoryOwner(repository),
+		Risk:     githubDependabotRisk(row),
+		Properties: map[string]any{
+			"source_table":              "github_dependabot_alerts",
+			"repository":                repository,
+			"package_name":              packageName,
+			"ecosystem":                 ecosystem,
+			"version":                   firstNonEmpty(versionRange, "unknown"),
+			"vulnerable_version_range":  queryRow(row, "vulnerable_version_range"),
+			"patched_version":           queryRow(row, "patched_version"),
+			"package_manager":           "github_dependabot",
+			"asset_support_entity_kind": "package",
+		},
+	}
+}
+
+func parseGitHubDependabotVulnerabilityNode(row map[string]any) *Node {
+	nodeID := githubDependabotVulnerabilityNodeIDForRow(row)
+	if nodeID == "" {
+		return nil
+	}
+	cveID := strings.ToUpper(strings.TrimSpace(queryRowString(row, "cve_id")))
+	ghsaID := strings.ToUpper(strings.TrimSpace(queryRowString(row, "ghsa_id")))
+	name := firstNonEmpty(cveID, ghsaID, queryRowString(row, "package_name"), nodeID)
+	repository := strings.TrimSpace(queryRowString(row, "repository"))
+	return &Node{
+		ID:       nodeID,
+		Kind:     NodeKindVulnerability,
+		Name:     name,
+		Provider: "github",
+		Account:  githubRepositoryOwner(repository),
+		Risk:     githubDependabotRisk(row),
+		Properties: map[string]any{
+			"source_table":               "github_dependabot_alerts",
+			"repository":                 repository,
+			"state":                      queryRow(row, "state"),
+			"severity":                   queryRow(row, "severity"),
+			"package_name":               queryRow(row, "package_name"),
+			"package_ecosystem":          queryRow(row, "package_ecosystem"),
+			"vulnerable_version_range":   queryRow(row, "vulnerable_version_range"),
+			"patched_version":            queryRow(row, "patched_version"),
+			"cve_id":                     cveID,
+			"ghsa_id":                    ghsaID,
+			"cvss_score":                 queryRow(row, "cvss_score"),
+			"created_at":                 queryRow(row, "created_at"),
+			"updated_at":                 queryRow(row, "updated_at"),
+			"fixed_at":                   queryRow(row, "fixed_at"),
+			"asset_support_finding":      "github_dependabot_alert",
+			"canonical_vulnerability_id": nodeID,
+		},
+	}
+}
+
+func (b *Builder) buildGitHubEdges(ctx context.Context) {
+	b.buildGitHubRepositoryPackageEdges(ctx)
+	b.buildGitHubDependabotVulnerabilityEdges(ctx)
+}
+
+func (b *Builder) buildGitHubRepositoryPackageEdges(ctx context.Context) {
+	rows, err := b.queryIfExists(ctx, "github_dependabot_alerts", `SELECT number, repository, package_name, package_ecosystem, vulnerable_version_range, patched_version, state, severity, cve_id, ghsa_id FROM github_dependabot_alerts`)
+	if err != nil {
+		b.logger.Debug("github dependabot repository package edge query failed", "error", err)
+		return
+	}
+	for _, row := range rows.Rows {
+		repository := strings.TrimSpace(queryRowString(row, "repository"))
+		if repository == "" || strings.TrimSpace(queryRowString(row, "package_name")) == "" {
+			continue
+		}
+		repoNodeID := githubRepositoryNodeID(repository)
+		if _, ok := b.graph.GetNode(repoNodeID); !ok {
+			b.graph.AddNode(githubRepositoryFallbackNode(repository))
+		}
+		pkgNodeID := githubDependabotPackageNodeID(row)
+		b.addEdgeIfMissing(&Edge{
+			ID:     repoNodeID + "->" + pkgNodeID + ":contains_package",
+			Source: repoNodeID,
+			Target: pkgNodeID,
+			Kind:   EdgeKindContainsPkg,
+			Effect: EdgeEffectAllow,
+			Risk:   githubDependabotRisk(row),
+			Properties: map[string]any{
+				"source_table":             "github_dependabot_alerts",
+				"alert_number":             queryRow(row, "number"),
+				"package_name":             queryRow(row, "package_name"),
+				"package_ecosystem":        queryRow(row, "package_ecosystem"),
+				"vulnerable_version_range": queryRow(row, "vulnerable_version_range"),
+				"state":                    queryRow(row, "state"),
+			},
+		})
+	}
+}
+
+func (b *Builder) buildGitHubDependabotVulnerabilityEdges(ctx context.Context) {
+	rows, err := b.queryIfExists(ctx, "github_dependabot_alerts", `SELECT number, repository, state, severity, package_name, package_ecosystem, vulnerable_version_range, patched_version, cve_id, ghsa_id, cvss_score FROM github_dependabot_alerts`)
+	if err != nil {
+		b.logger.Debug("github dependabot vulnerability edge query failed", "error", err)
+		return
+	}
+	for _, row := range rows.Rows {
+		pkgNodeID := githubDependabotPackageNodeID(row)
+		vulnNodeID := githubDependabotVulnerabilityNodeIDForRow(row)
+		if pkgNodeID == "" || vulnNodeID == "" {
+			continue
+		}
+		b.addEdgeIfMissing(&Edge{
+			ID:     pkgNodeID + "->" + vulnNodeID + ":affected_by",
+			Source: pkgNodeID,
+			Target: vulnNodeID,
+			Kind:   EdgeKindAffectedBy,
+			Effect: EdgeEffectAllow,
+			Risk:   githubDependabotRisk(row),
+			Properties: map[string]any{
+				"source_table":             "github_dependabot_alerts",
+				"alert_number":             queryRow(row, "number"),
+				"repository":               queryRow(row, "repository"),
+				"state":                    queryRow(row, "state"),
+				"severity":                 queryRow(row, "severity"),
+				"cve_id":                   queryRow(row, "cve_id"),
+				"ghsa_id":                  queryRow(row, "ghsa_id"),
+				"cvss_score":               queryRow(row, "cvss_score"),
+				"patched_version":          queryRow(row, "patched_version"),
+				"relationship_context":     "package_vulnerability",
+				"vulnerable_version_range": queryRow(row, "vulnerable_version_range"),
+			},
+		})
+	}
+}
+
+func githubRepositoryNodeID(repository string) string {
+	repository = strings.TrimSpace(repository)
+	if strings.HasPrefix(repository, "http://") || strings.HasPrefix(repository, "https://") {
+		return repository
+	}
+	return "https://github.com/" + repository
+}
+
+func githubRepositoryFallbackNode(repository string) *Node {
+	return &Node{
+		ID:       githubRepositoryNodeID(repository),
+		Kind:     NodeKindRepository,
+		Name:     repository,
+		Provider: "github",
+		Account:  githubRepositoryOwner(repository),
+		Risk:     RiskNone,
+		Properties: map[string]any{
+			"source_table": "github_dependabot_alerts",
+			"repository":   repository,
+			"html_url":     githubRepositoryNodeID(repository),
+		},
+	}
+}
+
+func githubRepositoryOwner(repository string) string {
+	repository = strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(repository), "https://github.com/"), "http://github.com/")
+	parts := strings.Split(repository, "/")
+	if len(parts) > 0 {
+		return strings.TrimSpace(parts[0])
+	}
+	return ""
+}
+
+func githubDependabotPackageNodeID(row map[string]any) string {
+	repository := strings.TrimSpace(queryRowString(row, "repository"))
+	packageName := strings.TrimSpace(queryRowString(row, "package_name"))
+	if repository == "" || packageName == "" {
+		return ""
+	}
+	ecosystem := firstNonEmpty(queryRowString(row, "package_ecosystem"), "unknown")
+	return "github_package:" + slugifyKnowledgeKey(fmt.Sprintf("%s|%s|%s", repository, ecosystem, packageName))
+}
+
+func githubDependabotVulnerabilityNodeIDForRow(row map[string]any) string {
+	identifier := firstNonEmpty(strings.TrimSpace(queryRowString(row, "cve_id")), strings.TrimSpace(queryRowString(row, "ghsa_id")))
+	if identifier == "" {
+		return ""
+	}
+	return "vulnerability:" + slugifyKnowledgeKey(identifier)
+}
+
+func githubRepositoryRisk(row map[string]any) RiskLevel {
+	if toBool(queryRow(row, "disabled")) {
+		return RiskMedium
+	}
+	if toBool(queryRow(row, "archived")) {
+		return RiskLow
+	}
+	return RiskNone
+}
+
+func githubDependabotRisk(row map[string]any) RiskLevel {
+	switch strings.ToLower(strings.TrimSpace(queryRowString(row, "severity"))) {
+	case "critical":
+		return RiskCritical
+	case "high":
+		return RiskHigh
+	case "medium", "moderate":
+		return RiskMedium
+	case "low":
+		return RiskLow
+	default:
+		return RiskNone
+	}
+}

--- a/internal/graph/builders/builder_github_test.go
+++ b/internal/graph/builders/builder_github_test.go
@@ -1,0 +1,137 @@
+package builders
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestBuilderBuildsGitHubDependabotGraph(t *testing.T) {
+	ctx := context.Background()
+	source := newMockDataSource()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	source.setResult(`SELECT id, name, full_name, private, visibility, default_branch, archived, disabled, fork, language, topics, created_at, updated_at, pushed_at FROM github_repositories`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":             1,
+			"name":           "cerebro",
+			"full_name":      "writer/cerebro",
+			"private":        false,
+			"visibility":     "public",
+			"default_branch": "main",
+			"archived":       false,
+			"disabled":       false,
+		}},
+	})
+	source.setResult(`SELECT number, repository, state, severity, package_name, package_ecosystem, vulnerable_version_range, patched_version, cve_id, ghsa_id, cvss_score, created_at, updated_at, fixed_at FROM github_dependabot_alerts`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"number":                   7,
+			"repository":               "writer/cerebro",
+			"state":                    "open",
+			"severity":                 "critical",
+			"package_name":             "github.com/example/vuln",
+			"package_ecosystem":        "go",
+			"vulnerable_version_range": "< 1.2.3",
+			"patched_version":          "1.2.3",
+			"cve_id":                   "CVE-2026-0001",
+			"ghsa_id":                  "GHSA-2026-0001",
+			"cvss_score":               9.8,
+		}},
+	})
+	source.setResult(`SELECT number, repository, package_name, package_ecosystem, vulnerable_version_range, patched_version, state, severity, cve_id, ghsa_id FROM github_dependabot_alerts`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"number":                   7,
+			"repository":               "writer/cerebro",
+			"state":                    "open",
+			"severity":                 "critical",
+			"package_name":             "github.com/example/vuln",
+			"package_ecosystem":        "go",
+			"vulnerable_version_range": "< 1.2.3",
+			"patched_version":          "1.2.3",
+			"cve_id":                   "CVE-2026-0001",
+			"ghsa_id":                  "GHSA-2026-0001",
+		}},
+	})
+	source.setResult(`SELECT number, repository, state, severity, package_name, package_ecosystem, vulnerable_version_range, patched_version, cve_id, ghsa_id, cvss_score FROM github_dependabot_alerts`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"number":                   7,
+			"repository":               "writer/cerebro",
+			"state":                    "open",
+			"severity":                 "critical",
+			"package_name":             "github.com/example/vuln",
+			"package_ecosystem":        "go",
+			"vulnerable_version_range": "< 1.2.3",
+			"patched_version":          "1.2.3",
+			"cve_id":                   "CVE-2026-0001",
+			"ghsa_id":                  "GHSA-2026-0001",
+			"cvss_score":               9.8,
+		}},
+	})
+
+	builder := NewBuilder(source, logger)
+	if err := builder.Build(ctx); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	g := builder.Graph()
+
+	repoID := githubRepositoryNodeID("writer/cerebro")
+	pkgID := githubDependabotPackageNodeID(map[string]any{
+		"repository":        "writer/cerebro",
+		"package_name":      "github.com/example/vuln",
+		"package_ecosystem": "go",
+	})
+	vulnID := "vulnerability:cve-2026-0001"
+
+	for _, expected := range []struct {
+		id   string
+		kind NodeKind
+	}{
+		{repoID, NodeKindRepository},
+		{pkgID, NodeKindPackage},
+		{vulnID, NodeKindVulnerability},
+	} {
+		node, ok := g.GetNode(expected.id)
+		if !ok {
+			t.Fatalf("expected node %s", expected.id)
+		}
+		if node.Kind != expected.kind {
+			t.Fatalf("node %s kind = %s, want %s", expected.id, node.Kind, expected.kind)
+		}
+		if node.Provider != "github" {
+			t.Fatalf("node %s provider = %q, want github", expected.id, node.Provider)
+		}
+	}
+
+	assertEdgeExists(t, g, repoID, pkgID, EdgeKindContainsPkg)
+	assertEdgeExists(t, g, pkgID, vulnID, EdgeKindAffectedBy)
+}
+
+func TestGitHubDependabotCDCEventToNode(t *testing.T) {
+	node := cdcEventToNode("github_dependabot_alerts", cdcEvent{
+		TableName:  "github_dependabot_alerts",
+		ResourceID: "writer/cerebro|7",
+		Provider:   "github",
+		Payload: map[string]any{
+			"number":            7,
+			"repository":        "writer/cerebro",
+			"severity":          "high",
+			"package_name":      "github.com/example/vuln",
+			"package_ecosystem": "go",
+			"cve_id":            "CVE-2026-0001",
+			"ghsa_id":           "GHSA-2026-0001",
+		},
+	})
+	if node == nil {
+		t.Fatal("expected GitHub Dependabot CDC node")
+	}
+	if node.ID != "vulnerability:cve-2026-0001" {
+		t.Fatalf("node ID = %q", node.ID)
+	}
+	if node.Kind != NodeKindVulnerability {
+		t.Fatalf("node kind = %s, want vulnerability", node.Kind)
+	}
+	if node.Risk != RiskHigh {
+		t.Fatalf("node risk = %s, want high", node.Risk)
+	}
+}

--- a/internal/graph/builders/builder_sentinelone.go
+++ b/internal/graph/builders/builder_sentinelone.go
@@ -1,0 +1,559 @@
+package builders
+
+import (
+	"context"
+	"strings"
+)
+
+func (b *Builder) buildSentinelOneNodes(ctx context.Context) {
+	queries := []nodeQuery{
+		{
+			table: "sentinelone_sites",
+			query: `SELECT id, name, state, account_id, account_name, license_type, total_licenses, active_licenses, created_at FROM sentinelone_sites`,
+			parse: parseSentinelOneSiteNodes,
+		},
+		{
+			table: "sentinelone_agents",
+			query: `SELECT id, uuid, computer_name, external_ip, internal_ip, os_name, os_type, os_version, agent_version, is_active, is_infected, is_up_to_date, network_status, scan_status, threat_reboot_required, last_active_date, registered_at, site_id, site_name, group_id, group_name, machine_type, domain, encrypted_applications, firewall_enabled FROM sentinelone_agents`,
+			parse: parseSentinelOneAgentNodes,
+		},
+		{
+			table: "sentinelone_threats",
+			query: `SELECT id, agent_id, agent_computer_name, threat_name, classification, classification_source, confidence_level, analyst_verdict, incident_status, mitigation_status, initiated_by, file_path, file_sha256, file_sha1, file_md5, mitre_tactics, mitre_techniques, created_at, updated_at FROM sentinelone_threats`,
+			parse: parseSentinelOneThreatNodes,
+		},
+		{
+			table: "sentinelone_activities",
+			query: `SELECT id, activity_type, activity_description, primary_description, secondary_description, user_id, agent_id, site_id, threat_id, created_at FROM sentinelone_activities`,
+			parse: parseSentinelOneActivityNodes,
+		},
+		{
+			table: "sentinelone_applications",
+			query: `SELECT id, agent_id, name, version, publisher, size, installed_date, type, risk_level FROM sentinelone_applications`,
+			parse: parseSentinelOneApplicationNodes,
+		},
+		{
+			table: "sentinelone_vulnerabilities",
+			query: `SELECT id, cve_id, agent_id, site_id, endpoint_name, application_name, application_version, severity, status, cvss_score, exploited_in_wild, days_since_detection, remediation_action, detected_at FROM sentinelone_vulnerabilities`,
+			parse: parseSentinelOneVulnerabilityNodes,
+		},
+	}
+
+	b.runNodeQueries(ctx, queries)
+}
+
+func parseSentinelOneSiteNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		id := strings.TrimSpace(queryRowString(row, "id"))
+		if id == "" {
+			continue
+		}
+		name := firstNonEmpty(queryRowString(row, "name"), id)
+		nodes = append(nodes, &Node{
+			ID:       sentinelOneSiteNodeID(id),
+			Kind:     NodeKindOrganization,
+			Name:     name,
+			Provider: "sentinelone",
+			Account:  firstNonEmpty(queryRowString(row, "account_id"), id),
+			Risk:     RiskNone,
+			Properties: map[string]any{
+				"source_table":     "sentinelone_sites",
+				"site_id":          id,
+				"state":            queryRow(row, "state"),
+				"account_id":       queryRow(row, "account_id"),
+				"account_name":     queryRow(row, "account_name"),
+				"license_type":     queryRow(row, "license_type"),
+				"total_licenses":   queryRow(row, "total_licenses"),
+				"active_licenses":  queryRow(row, "active_licenses"),
+				"provider_created": queryRow(row, "created_at"),
+			},
+		})
+	}
+	return nodes
+}
+
+func parseSentinelOneAgentNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		id := strings.TrimSpace(queryRowString(row, "id"))
+		if id == "" {
+			continue
+		}
+		name := firstNonEmpty(queryRowString(row, "computer_name"), queryRowString(row, "uuid"), id)
+		nodes = append(nodes, &Node{
+			ID:       sentinelOneAgentNodeID(id),
+			Kind:     NodeKindInstance,
+			Name:     name,
+			Provider: "sentinelone",
+			Account:  firstNonEmpty(queryRowString(row, "site_id"), queryRowString(row, "group_id")),
+			Risk:     sentinelOneAgentRisk(row),
+			Properties: map[string]any{
+				"source_table":              "sentinelone_agents",
+				"agent_id":                  id,
+				"uuid":                      queryRow(row, "uuid"),
+				"computer_name":             queryRow(row, "computer_name"),
+				"external_ip":               queryRow(row, "external_ip"),
+				"internal_ip":               queryRow(row, "internal_ip"),
+				"os_name":                   queryRow(row, "os_name"),
+				"os_type":                   queryRow(row, "os_type"),
+				"os_version":                queryRow(row, "os_version"),
+				"agent_version":             queryRow(row, "agent_version"),
+				"is_active":                 queryRow(row, "is_active"),
+				"is_infected":               queryRow(row, "is_infected"),
+				"is_up_to_date":             queryRow(row, "is_up_to_date"),
+				"network_status":            queryRow(row, "network_status"),
+				"scan_status":               queryRow(row, "scan_status"),
+				"threat_reboot_required":    queryRow(row, "threat_reboot_required"),
+				"last_active_date":          queryRow(row, "last_active_date"),
+				"registered_at":             queryRow(row, "registered_at"),
+				"site_id":                   queryRow(row, "site_id"),
+				"site_name":                 queryRow(row, "site_name"),
+				"group_id":                  queryRow(row, "group_id"),
+				"group_name":                queryRow(row, "group_name"),
+				"machine_type":              queryRow(row, "machine_type"),
+				"domain":                    queryRow(row, "domain"),
+				"encrypted_applications":    queryRow(row, "encrypted_applications"),
+				"firewall_enabled":          queryRow(row, "firewall_enabled"),
+				"asset_support_entity_kind": "endpoint",
+			},
+		})
+	}
+	return nodes
+}
+
+func parseSentinelOneThreatNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		id := strings.TrimSpace(queryRowString(row, "id"))
+		if id == "" {
+			continue
+		}
+		name := firstNonEmpty(queryRowString(row, "threat_name"), queryRowString(row, "classification"), id)
+		nodes = append(nodes, &Node{
+			ID:       sentinelOneThreatNodeID(id),
+			Kind:     NodeKindIncident,
+			Name:     name,
+			Provider: "sentinelone",
+			Account:  queryRowString(row, "agent_id"),
+			Risk:     sentinelOneThreatRisk(row),
+			Properties: map[string]any{
+				"source_table":          "sentinelone_threats",
+				"threat_id":             id,
+				"agent_id":              queryRow(row, "agent_id"),
+				"agent_computer_name":   queryRow(row, "agent_computer_name"),
+				"classification":        queryRow(row, "classification"),
+				"classification_source": queryRow(row, "classification_source"),
+				"confidence_level":      queryRow(row, "confidence_level"),
+				"analyst_verdict":       queryRow(row, "analyst_verdict"),
+				"incident_status":       queryRow(row, "incident_status"),
+				"mitigation_status":     queryRow(row, "mitigation_status"),
+				"initiated_by":          queryRow(row, "initiated_by"),
+				"file_path":             queryRow(row, "file_path"),
+				"file_sha256":           queryRow(row, "file_sha256"),
+				"file_sha1":             queryRow(row, "file_sha1"),
+				"file_md5":              queryRow(row, "file_md5"),
+				"mitre_tactics":         queryRow(row, "mitre_tactics"),
+				"mitre_techniques":      queryRow(row, "mitre_techniques"),
+				"created_at":            queryRow(row, "created_at"),
+				"updated_at":            queryRow(row, "updated_at"),
+			},
+		})
+	}
+	return nodes
+}
+
+func parseSentinelOneActivityNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		id := strings.TrimSpace(queryRowString(row, "id"))
+		if id == "" {
+			continue
+		}
+		name := firstNonEmpty(queryRowString(row, "primary_description"), queryRowString(row, "activity_description"), id)
+		nodes = append(nodes, &Node{
+			ID:       sentinelOneActivityNodeID(id),
+			Kind:     NodeKindObservation,
+			Name:     name,
+			Provider: "sentinelone",
+			Account:  firstNonEmpty(queryRowString(row, "site_id"), queryRowString(row, "agent_id")),
+			Risk:     RiskNone,
+			Properties: map[string]any{
+				"source_table":           "sentinelone_activities",
+				"activity_id":            id,
+				"activity_type":          queryRow(row, "activity_type"),
+				"activity_description":   queryRow(row, "activity_description"),
+				"primary_description":    queryRow(row, "primary_description"),
+				"secondary_description":  queryRow(row, "secondary_description"),
+				"user_id":                queryRow(row, "user_id"),
+				"agent_id":               queryRow(row, "agent_id"),
+				"site_id":                queryRow(row, "site_id"),
+				"threat_id":              queryRow(row, "threat_id"),
+				"created_at":             queryRow(row, "created_at"),
+				"asset_support_evidence": "sentinelone_activity",
+			},
+		})
+	}
+	return nodes
+}
+
+func parseSentinelOneApplicationNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		id := strings.TrimSpace(queryRowString(row, "id"))
+		if id == "" {
+			continue
+		}
+		name := firstNonEmpty(queryRowString(row, "name"), id)
+		version := strings.TrimSpace(queryRowString(row, "version"))
+		if version != "" {
+			name += " " + version
+		}
+		nodes = append(nodes, &Node{
+			ID:       sentinelOneApplicationNodeID(id),
+			Kind:     NodeKindPackage,
+			Name:     name,
+			Provider: "sentinelone",
+			Account:  queryRowString(row, "agent_id"),
+			Risk:     sentinelOneApplicationRisk(row),
+			Properties: map[string]any{
+				"source_table":    "sentinelone_applications",
+				"application_id":  id,
+				"agent_id":        queryRow(row, "agent_id"),
+				"name":            queryRow(row, "name"),
+				"version":         queryRow(row, "version"),
+				"publisher":       queryRow(row, "publisher"),
+				"size":            queryRow(row, "size"),
+				"installed_date":  queryRow(row, "installed_date"),
+				"type":            queryRow(row, "type"),
+				"risk_level":      queryRow(row, "risk_level"),
+				"package_manager": "sentinelone",
+			},
+		})
+	}
+	return nodes
+}
+
+func parseSentinelOneVulnerabilityNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		id := strings.TrimSpace(queryRowString(row, "id"))
+		if id == "" {
+			continue
+		}
+		cveID := strings.ToUpper(strings.TrimSpace(queryRowString(row, "cve_id")))
+		name := firstNonEmpty(cveID, queryRowString(row, "application_name"), id)
+		nodes = append(nodes, &Node{
+			ID:       sentinelOneVulnerabilityNodeID(id),
+			Kind:     NodeKindVulnerability,
+			Name:     name,
+			Provider: "sentinelone",
+			Account:  firstNonEmpty(queryRowString(row, "site_id"), queryRowString(row, "agent_id")),
+			Risk:     sentinelOneSeverityRisk(queryRowString(row, "severity")),
+			Properties: map[string]any{
+				"source_table":          "sentinelone_vulnerabilities",
+				"vulnerability_id":      id,
+				"cve_id":                cveID,
+				"agent_id":              queryRow(row, "agent_id"),
+				"site_id":               queryRow(row, "site_id"),
+				"endpoint_name":         queryRow(row, "endpoint_name"),
+				"application_name":      queryRow(row, "application_name"),
+				"application_version":   queryRow(row, "application_version"),
+				"severity":              queryRow(row, "severity"),
+				"status":                queryRow(row, "status"),
+				"cvss_score":            queryRow(row, "cvss_score"),
+				"exploited_in_wild":     queryRow(row, "exploited_in_wild"),
+				"days_since_detection":  queryRow(row, "days_since_detection"),
+				"remediation_action":    queryRow(row, "remediation_action"),
+				"detected_at":           queryRow(row, "detected_at"),
+				"asset_support_finding": "sentinelone_vulnerability",
+			},
+		})
+	}
+	return nodes
+}
+
+func (b *Builder) buildSentinelOneEdges(ctx context.Context) {
+	b.buildSentinelOneSiteAgentEdges(ctx)
+	b.buildSentinelOneAgentApplicationEdges(ctx)
+	b.buildSentinelOneAgentVulnerabilityEdges(ctx)
+	b.buildSentinelOneThreatEdges(ctx)
+	b.buildSentinelOneActivityEdges(ctx)
+}
+
+func (b *Builder) buildSentinelOneSiteAgentEdges(ctx context.Context) {
+	rows, err := b.queryIfExists(ctx, "sentinelone_agents", `SELECT id, site_id, site_name FROM sentinelone_agents`)
+	if err != nil {
+		b.logger.Debug("sentinelone agent/site edge query failed", "error", err)
+		return
+	}
+	for _, row := range rows.Rows {
+		agentID := strings.TrimSpace(queryRowString(row, "id"))
+		siteID := strings.TrimSpace(queryRowString(row, "site_id"))
+		if agentID == "" || siteID == "" {
+			continue
+		}
+		siteNodeID := sentinelOneSiteNodeID(siteID)
+		if _, ok := b.graph.GetNode(siteNodeID); !ok {
+			b.graph.AddNode(&Node{
+				ID:       siteNodeID,
+				Kind:     NodeKindOrganization,
+				Name:     firstNonEmpty(queryRowString(row, "site_name"), siteID),
+				Provider: "sentinelone",
+				Account:  siteID,
+				Risk:     RiskNone,
+				Properties: map[string]any{
+					"source_table": "sentinelone_sites",
+					"site_id":      siteID,
+				},
+			})
+		}
+		agentNodeID := sentinelOneAgentNodeID(agentID)
+		b.addEdgeIfMissing(&Edge{
+			ID:     siteNodeID + "->" + agentNodeID + ":contains",
+			Source: siteNodeID,
+			Target: agentNodeID,
+			Kind:   EdgeKindContains,
+			Effect: EdgeEffectAllow,
+			Risk:   RiskNone,
+			Properties: map[string]any{
+				"source_table": "sentinelone_agents",
+			},
+		})
+	}
+}
+
+func (b *Builder) buildSentinelOneAgentApplicationEdges(ctx context.Context) {
+	rows, err := b.queryIfExists(ctx, "sentinelone_applications", `SELECT id, agent_id, name, version FROM sentinelone_applications`)
+	if err != nil {
+		b.logger.Debug("sentinelone application edge query failed", "error", err)
+		return
+	}
+	for _, row := range rows.Rows {
+		agentID := strings.TrimSpace(queryRowString(row, "agent_id"))
+		appID := strings.TrimSpace(queryRowString(row, "id"))
+		if agentID == "" || appID == "" {
+			continue
+		}
+		agentNodeID := sentinelOneAgentNodeID(agentID)
+		appNodeID := sentinelOneApplicationNodeID(appID)
+		b.addEdgeIfMissing(&Edge{
+			ID:     agentNodeID + "->" + appNodeID + ":contains_package",
+			Source: agentNodeID,
+			Target: appNodeID,
+			Kind:   EdgeKindContainsPkg,
+			Effect: EdgeEffectAllow,
+			Risk:   RiskNone,
+			Properties: map[string]any{
+				"source_table": "sentinelone_applications",
+				"name":         queryRow(row, "name"),
+				"version":      queryRow(row, "version"),
+			},
+		})
+	}
+}
+
+func (b *Builder) buildSentinelOneAgentVulnerabilityEdges(ctx context.Context) {
+	rows, err := b.queryIfExists(ctx, "sentinelone_vulnerabilities", `SELECT id, cve_id, agent_id, application_name, application_version, severity, status FROM sentinelone_vulnerabilities`)
+	if err != nil {
+		b.logger.Debug("sentinelone vulnerability edge query failed", "error", err)
+		return
+	}
+	for _, row := range rows.Rows {
+		agentID := strings.TrimSpace(queryRowString(row, "agent_id"))
+		vulnID := strings.TrimSpace(queryRowString(row, "id"))
+		if agentID == "" || vulnID == "" {
+			continue
+		}
+		agentNodeID := sentinelOneAgentNodeID(agentID)
+		vulnNodeID := sentinelOneVulnerabilityNodeID(vulnID)
+		risk := sentinelOneSeverityRisk(queryRowString(row, "severity"))
+		b.addEdgeIfMissing(&Edge{
+			ID:     agentNodeID + "->" + vulnNodeID + ":affected_by",
+			Source: agentNodeID,
+			Target: vulnNodeID,
+			Kind:   EdgeKindAffectedBy,
+			Effect: EdgeEffectAllow,
+			Risk:   risk,
+			Properties: map[string]any{
+				"source_table":         "sentinelone_vulnerabilities",
+				"cve_id":               queryRow(row, "cve_id"),
+				"application_name":     queryRow(row, "application_name"),
+				"application_version":  queryRow(row, "application_version"),
+				"severity":             queryRow(row, "severity"),
+				"status":               queryRow(row, "status"),
+				"relationship_context": "endpoint_vulnerability",
+			},
+		})
+	}
+}
+
+func (b *Builder) buildSentinelOneThreatEdges(ctx context.Context) {
+	rows, err := b.queryIfExists(ctx, "sentinelone_threats", `SELECT id, agent_id, threat_name, classification, mitigation_status, incident_status FROM sentinelone_threats`)
+	if err != nil {
+		b.logger.Debug("sentinelone threat edge query failed", "error", err)
+		return
+	}
+	for _, row := range rows.Rows {
+		agentID := strings.TrimSpace(queryRowString(row, "agent_id"))
+		threatID := strings.TrimSpace(queryRowString(row, "id"))
+		if agentID == "" || threatID == "" {
+			continue
+		}
+		agentNodeID := sentinelOneAgentNodeID(agentID)
+		threatNodeID := sentinelOneThreatNodeID(threatID)
+		risk := sentinelOneThreatRisk(row)
+		b.addEdgeIfMissing(&Edge{
+			ID:     threatNodeID + "->" + agentNodeID + ":targets",
+			Source: threatNodeID,
+			Target: agentNodeID,
+			Kind:   EdgeKindTargets,
+			Effect: EdgeEffectAllow,
+			Risk:   risk,
+			Properties: map[string]any{
+				"source_table":      "sentinelone_threats",
+				"threat_name":       queryRow(row, "threat_name"),
+				"classification":    queryRow(row, "classification"),
+				"mitigation_status": queryRow(row, "mitigation_status"),
+				"incident_status":   queryRow(row, "incident_status"),
+			},
+		})
+		b.addEdgeIfMissing(&Edge{
+			ID:     agentNodeID + "->" + threatNodeID + ":affected_by",
+			Source: agentNodeID,
+			Target: threatNodeID,
+			Kind:   EdgeKindAffectedBy,
+			Effect: EdgeEffectAllow,
+			Risk:   risk,
+			Properties: map[string]any{
+				"source_table": "sentinelone_threats",
+			},
+		})
+	}
+}
+
+func (b *Builder) buildSentinelOneActivityEdges(ctx context.Context) {
+	rows, err := b.queryIfExists(ctx, "sentinelone_activities", `SELECT id, agent_id, threat_id, site_id, activity_type, created_at FROM sentinelone_activities`)
+	if err != nil {
+		b.logger.Debug("sentinelone activity edge query failed", "error", err)
+		return
+	}
+	for _, row := range rows.Rows {
+		activityID := strings.TrimSpace(queryRowString(row, "id"))
+		if activityID == "" {
+			continue
+		}
+		activityNodeID := sentinelOneActivityNodeID(activityID)
+		if agentID := strings.TrimSpace(queryRowString(row, "agent_id")); agentID != "" {
+			agentNodeID := sentinelOneAgentNodeID(agentID)
+			b.addEdgeIfMissing(&Edge{
+				ID:     activityNodeID + "->" + agentNodeID + ":targets",
+				Source: activityNodeID,
+				Target: agentNodeID,
+				Kind:   EdgeKindTargets,
+				Effect: EdgeEffectAllow,
+				Risk:   RiskNone,
+				Properties: map[string]any{
+					"source_table":  "sentinelone_activities",
+					"activity_type": queryRow(row, "activity_type"),
+					"created_at":    queryRow(row, "created_at"),
+				},
+			})
+		}
+		if threatID := strings.TrimSpace(queryRowString(row, "threat_id")); threatID != "" {
+			threatNodeID := sentinelOneThreatNodeID(threatID)
+			if _, ok := b.graph.GetNode(threatNodeID); ok {
+				b.addEdgeIfMissing(&Edge{
+					ID:     activityNodeID + "->" + threatNodeID + ":targets",
+					Source: activityNodeID,
+					Target: threatNodeID,
+					Kind:   EdgeKindTargets,
+					Effect: EdgeEffectAllow,
+					Risk:   RiskNone,
+					Properties: map[string]any{
+						"source_table": "sentinelone_activities",
+					},
+				})
+			}
+		}
+	}
+}
+
+func sentinelOneSiteNodeID(id string) string {
+	return "sentinelone_site:" + strings.TrimSpace(id)
+}
+
+func sentinelOneAgentNodeID(id string) string {
+	return "sentinelone_agent:" + strings.TrimSpace(id)
+}
+
+func sentinelOneThreatNodeID(id string) string {
+	return "sentinelone_threat:" + strings.TrimSpace(id)
+}
+
+func sentinelOneActivityNodeID(id string) string {
+	return "sentinelone_activity:" + strings.TrimSpace(id)
+}
+
+func sentinelOneApplicationNodeID(id string) string {
+	return "sentinelone_application:" + strings.TrimSpace(id)
+}
+
+func sentinelOneVulnerabilityNodeID(id string) string {
+	return "sentinelone_vulnerability:" + strings.TrimSpace(id)
+}
+
+func sentinelOneAgentRisk(row map[string]any) RiskLevel {
+	if toBool(queryRow(row, "is_infected")) || toBool(queryRow(row, "threat_reboot_required")) {
+		return RiskHigh
+	}
+	if !toBool(queryRow(row, "is_active")) {
+		return RiskMedium
+	}
+	if !toBool(queryRow(row, "is_up_to_date")) {
+		return RiskLow
+	}
+	return RiskNone
+}
+
+func sentinelOneApplicationRisk(row map[string]any) RiskLevel {
+	switch strings.ToLower(strings.TrimSpace(queryRowString(row, "risk_level"))) {
+	case "critical":
+		return RiskCritical
+	case "high":
+		return RiskHigh
+	case "medium":
+		return RiskMedium
+	case "low":
+		return RiskLow
+	default:
+		return RiskNone
+	}
+}
+
+func sentinelOneThreatRisk(row map[string]any) RiskLevel {
+	classification := strings.ToLower(queryRowString(row, "classification"))
+	mitigationStatus := strings.ToLower(queryRowString(row, "mitigation_status"))
+	if strings.Contains(classification, "ransom") {
+		return RiskCritical
+	}
+	if mitigationStatus != "" && mitigationStatus != "mitigated" && mitigationStatus != "remediated" {
+		return RiskHigh
+	}
+	return RiskMedium
+}
+
+func sentinelOneSeverityRisk(severity string) RiskLevel {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical":
+		return RiskCritical
+	case "high":
+		return RiskHigh
+	case "medium":
+		return RiskMedium
+	case "low":
+		return RiskLow
+	default:
+		return RiskNone
+	}
+}

--- a/internal/graph/builders/builder_sentinelone.go
+++ b/internal/graph/builders/builder_sentinelone.go
@@ -242,9 +242,10 @@ func parseSentinelOneVulnerabilityNodes(rows []map[string]any) []*Node {
 			continue
 		}
 		cveID := strings.ToUpper(strings.TrimSpace(queryRowString(row, "cve_id")))
+		nodeID := sentinelOneVulnerabilityNodeIDForRow(row)
 		name := firstNonEmpty(cveID, queryRowString(row, "application_name"), id)
 		nodes = append(nodes, &Node{
-			ID:       sentinelOneVulnerabilityNodeID(id),
+			ID:       nodeID,
 			Kind:     NodeKindVulnerability,
 			Name:     name,
 			Provider: "sentinelone",
@@ -277,6 +278,7 @@ func (b *Builder) buildSentinelOneEdges(ctx context.Context) {
 	b.buildSentinelOneSiteAgentEdges(ctx)
 	b.buildSentinelOneAgentApplicationEdges(ctx)
 	b.buildSentinelOneAgentVulnerabilityEdges(ctx)
+	b.buildSentinelOneApplicationVulnerabilityEdges(ctx)
 	b.buildSentinelOneThreatEdges(ctx)
 	b.buildSentinelOneActivityEdges(ctx)
 }
@@ -366,7 +368,7 @@ func (b *Builder) buildSentinelOneAgentVulnerabilityEdges(ctx context.Context) {
 			continue
 		}
 		agentNodeID := sentinelOneAgentNodeID(agentID)
-		vulnNodeID := sentinelOneVulnerabilityNodeID(vulnID)
+		vulnNodeID := sentinelOneVulnerabilityNodeIDForRow(row)
 		risk := sentinelOneSeverityRisk(queryRowString(row, "severity"))
 		b.addEdgeIfMissing(&Edge{
 			ID:     agentNodeID + "->" + vulnNodeID + ":affected_by",
@@ -383,6 +385,60 @@ func (b *Builder) buildSentinelOneAgentVulnerabilityEdges(ctx context.Context) {
 				"severity":             queryRow(row, "severity"),
 				"status":               queryRow(row, "status"),
 				"relationship_context": "endpoint_vulnerability",
+			},
+		})
+	}
+}
+
+func (b *Builder) buildSentinelOneApplicationVulnerabilityEdges(ctx context.Context) {
+	appRows, err := b.queryIfExists(ctx, "sentinelone_applications", `SELECT id, agent_id, name, version FROM sentinelone_applications`)
+	if err != nil {
+		b.logger.Debug("sentinelone application vulnerability application query failed", "error", err)
+		return
+	}
+	vulnRows, err := b.queryIfExists(ctx, "sentinelone_vulnerabilities", `SELECT id, cve_id, agent_id, application_name, application_version, severity, status FROM sentinelone_vulnerabilities`)
+	if err != nil {
+		b.logger.Debug("sentinelone application vulnerability query failed", "error", err)
+		return
+	}
+	appIndex := make(map[string]string, len(appRows.Rows))
+	for _, row := range appRows.Rows {
+		appID := strings.TrimSpace(queryRowString(row, "id"))
+		if appID == "" {
+			continue
+		}
+		key := sentinelOneApplicationMatchKey(queryRowString(row, "agent_id"), queryRowString(row, "name"), queryRowString(row, "version"))
+		if key != "" {
+			appIndex[key] = appID
+		}
+	}
+	for _, row := range vulnRows.Rows {
+		key := sentinelOneApplicationMatchKey(queryRowString(row, "agent_id"), queryRowString(row, "application_name"), queryRowString(row, "application_version"))
+		appID := appIndex[key]
+		if appID == "" {
+			continue
+		}
+		appNodeID := sentinelOneApplicationNodeID(appID)
+		vulnNodeID := sentinelOneVulnerabilityNodeIDForRow(row)
+		if vulnNodeID == "" {
+			continue
+		}
+		risk := sentinelOneSeverityRisk(queryRowString(row, "severity"))
+		b.addEdgeIfMissing(&Edge{
+			ID:     appNodeID + "->" + vulnNodeID + ":affected_by",
+			Source: appNodeID,
+			Target: vulnNodeID,
+			Kind:   EdgeKindAffectedBy,
+			Effect: EdgeEffectAllow,
+			Risk:   risk,
+			Properties: map[string]any{
+				"source_table":         "sentinelone_vulnerabilities",
+				"cve_id":               queryRow(row, "cve_id"),
+				"application_name":     queryRow(row, "application_name"),
+				"application_version":  queryRow(row, "application_version"),
+				"severity":             queryRow(row, "severity"),
+				"status":               queryRow(row, "status"),
+				"relationship_context": "package_vulnerability",
 			},
 		})
 	}
@@ -501,6 +557,27 @@ func sentinelOneApplicationNodeID(id string) string {
 
 func sentinelOneVulnerabilityNodeID(id string) string {
 	return "sentinelone_vulnerability:" + strings.TrimSpace(id)
+}
+
+func sentinelOneVulnerabilityNodeIDForRow(row map[string]any) string {
+	if cveID := strings.TrimSpace(queryRowString(row, "cve_id")); cveID != "" {
+		return "vulnerability:" + slugifyKnowledgeKey(cveID)
+	}
+	id := strings.TrimSpace(queryRowString(row, "id"))
+	if id == "" {
+		return ""
+	}
+	return sentinelOneVulnerabilityNodeID(id)
+}
+
+func sentinelOneApplicationMatchKey(agentID, name, version string) string {
+	agentID = strings.ToLower(strings.TrimSpace(agentID))
+	name = strings.ToLower(strings.TrimSpace(name))
+	version = strings.ToLower(strings.TrimSpace(version))
+	if agentID == "" || name == "" || version == "" {
+		return ""
+	}
+	return agentID + "|" + name + "|" + version
 }
 
 func sentinelOneAgentRisk(row map[string]any) RiskLevel {

--- a/internal/graph/builders/builder_sentinelone_test.go
+++ b/internal/graph/builders/builder_sentinelone_test.go
@@ -94,7 +94,7 @@ func TestBuilderBuildsSentinelOneGraph(t *testing.T) {
 	siteID := sentinelOneSiteNodeID("site-1")
 	agentID := sentinelOneAgentNodeID("agent-1")
 	appID := sentinelOneApplicationNodeID("agent-1|Chrome|1.2.3|Google")
-	vulnID := sentinelOneVulnerabilityNodeID("agent-1|CVE-2026-0001|Chrome|1.2.3")
+	vulnID := "vulnerability:cve-2026-0001"
 	threatID := sentinelOneThreatNodeID("threat-1")
 	activityID := sentinelOneActivityNodeID("activity-1")
 
@@ -124,6 +124,7 @@ func TestBuilderBuildsSentinelOneGraph(t *testing.T) {
 	assertEdgeExists(t, g, siteID, agentID, EdgeKindContains)
 	assertEdgeExists(t, g, agentID, appID, EdgeKindContainsPkg)
 	assertEdgeExists(t, g, agentID, vulnID, EdgeKindAffectedBy)
+	assertEdgeExists(t, g, appID, vulnID, EdgeKindAffectedBy)
 	assertEdgeExists(t, g, threatID, agentID, EdgeKindTargets)
 	assertEdgeExists(t, g, agentID, threatID, EdgeKindAffectedBy)
 	assertEdgeExists(t, g, activityID, agentID, EdgeKindTargets)
@@ -148,7 +149,7 @@ func TestSentinelOneCDCEventToNode(t *testing.T) {
 	if node == nil {
 		t.Fatal("expected SentinelOne vulnerability CDC node")
 	}
-	if node.ID != sentinelOneVulnerabilityNodeID("agent-1|CVE-2026-0001|Chrome|1.2.3") {
+	if node.ID != "vulnerability:cve-2026-0001" {
 		t.Fatalf("node ID = %q", node.ID)
 	}
 	if node.Kind != NodeKindVulnerability {

--- a/internal/graph/builders/builder_sentinelone_test.go
+++ b/internal/graph/builders/builder_sentinelone_test.go
@@ -1,0 +1,160 @@
+package builders
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestBuilderBuildsSentinelOneGraph(t *testing.T) {
+	ctx := context.Background()
+	source := newMockDataSource()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	source.setResult(`SELECT id, name, state, account_id, account_name, license_type, total_licenses, active_licenses, created_at FROM sentinelone_sites`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":           "site-1",
+			"name":         "Default site",
+			"state":        "active",
+			"account_id":   "acct-1",
+			"account_name": "Acme",
+		}},
+	})
+	source.setResult(`SELECT id, uuid, computer_name, external_ip, internal_ip, os_name, os_type, os_version, agent_version, is_active, is_infected, is_up_to_date, network_status, scan_status, threat_reboot_required, last_active_date, registered_at, site_id, site_name, group_id, group_name, machine_type, domain, encrypted_applications, firewall_enabled FROM sentinelone_agents`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":            "agent-1",
+			"uuid":          "uuid-1",
+			"computer_name": "host-1",
+			"os_name":       "macOS",
+			"os_type":       "macos",
+			"agent_version": "25.3.1",
+			"is_active":     true,
+			"is_infected":   false,
+			"is_up_to_date": true,
+			"site_id":       "site-1",
+			"site_name":     "Default site",
+		}},
+	})
+	source.setResult(`SELECT id, agent_id, agent_computer_name, threat_name, classification, classification_source, confidence_level, analyst_verdict, incident_status, mitigation_status, initiated_by, file_path, file_sha256, file_sha1, file_md5, mitre_tactics, mitre_techniques, created_at, updated_at FROM sentinelone_threats`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":                "threat-1",
+			"agent_id":          "agent-1",
+			"threat_name":       "EICAR",
+			"classification":    "Malware",
+			"mitigation_status": "not_mitigated",
+		}},
+	})
+	source.setResult(`SELECT id, activity_type, activity_description, primary_description, secondary_description, user_id, agent_id, site_id, threat_id, created_at FROM sentinelone_activities`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":                  "activity-1",
+			"activity_type":       2004,
+			"primary_description": "Agent quarantined threat",
+			"agent_id":            "agent-1",
+			"site_id":             "site-1",
+			"threat_id":           "threat-1",
+		}},
+	})
+	source.setResult(`SELECT id, agent_id, name, version, publisher, size, installed_date, type, risk_level FROM sentinelone_applications`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":         "agent-1|Chrome|1.2.3|Google",
+			"agent_id":   "agent-1",
+			"name":       "Chrome",
+			"version":    "1.2.3",
+			"publisher":  "Google",
+			"risk_level": "low",
+		}},
+	})
+	source.setResult(`SELECT id, cve_id, agent_id, site_id, endpoint_name, application_name, application_version, severity, status, cvss_score, exploited_in_wild, days_since_detection, remediation_action, detected_at FROM sentinelone_vulnerabilities`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"id":                   "agent-1|CVE-2026-0001|Chrome|1.2.3",
+			"cve_id":               "CVE-2026-0001",
+			"agent_id":             "agent-1",
+			"site_id":              "site-1",
+			"application_name":     "Chrome",
+			"application_version":  "1.2.3",
+			"severity":             "HIGH",
+			"status":               "Detected",
+			"cvss_score":           "7.8",
+			"days_since_detection": 31,
+		}},
+	})
+	source.setResult(`SELECT id, site_id, site_name FROM sentinelone_agents`, &DataQueryResult{Rows: []map[string]any{{"id": "agent-1", "site_id": "site-1", "site_name": "Default site"}}})
+	source.setResult(`SELECT id, agent_id, name, version FROM sentinelone_applications`, &DataQueryResult{Rows: []map[string]any{{"id": "agent-1|Chrome|1.2.3|Google", "agent_id": "agent-1", "name": "Chrome", "version": "1.2.3"}}})
+	source.setResult(`SELECT id, cve_id, agent_id, application_name, application_version, severity, status FROM sentinelone_vulnerabilities`, &DataQueryResult{Rows: []map[string]any{{"id": "agent-1|CVE-2026-0001|Chrome|1.2.3", "cve_id": "CVE-2026-0001", "agent_id": "agent-1", "application_name": "Chrome", "application_version": "1.2.3", "severity": "HIGH", "status": "Detected"}}})
+	source.setResult(`SELECT id, agent_id, threat_name, classification, mitigation_status, incident_status FROM sentinelone_threats`, &DataQueryResult{Rows: []map[string]any{{"id": "threat-1", "agent_id": "agent-1", "threat_name": "EICAR", "classification": "Malware", "mitigation_status": "not_mitigated"}}})
+	source.setResult(`SELECT id, agent_id, threat_id, site_id, activity_type, created_at FROM sentinelone_activities`, &DataQueryResult{Rows: []map[string]any{{"id": "activity-1", "agent_id": "agent-1", "threat_id": "threat-1", "site_id": "site-1", "activity_type": 2004}}})
+
+	builder := NewBuilder(source, logger)
+	if err := builder.Build(ctx); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	g := builder.Graph()
+
+	siteID := sentinelOneSiteNodeID("site-1")
+	agentID := sentinelOneAgentNodeID("agent-1")
+	appID := sentinelOneApplicationNodeID("agent-1|Chrome|1.2.3|Google")
+	vulnID := sentinelOneVulnerabilityNodeID("agent-1|CVE-2026-0001|Chrome|1.2.3")
+	threatID := sentinelOneThreatNodeID("threat-1")
+	activityID := sentinelOneActivityNodeID("activity-1")
+
+	for _, expected := range []struct {
+		id   string
+		kind NodeKind
+	}{
+		{siteID, NodeKindOrganization},
+		{agentID, NodeKindInstance},
+		{appID, NodeKindPackage},
+		{vulnID, NodeKindVulnerability},
+		{threatID, NodeKindIncident},
+		{activityID, NodeKindObservation},
+	} {
+		node, ok := g.GetNode(expected.id)
+		if !ok {
+			t.Fatalf("expected node %s", expected.id)
+		}
+		if node.Kind != expected.kind {
+			t.Fatalf("node %s kind = %s, want %s", expected.id, node.Kind, expected.kind)
+		}
+		if node.Provider != "sentinelone" {
+			t.Fatalf("node %s provider = %q, want sentinelone", expected.id, node.Provider)
+		}
+	}
+
+	assertEdgeExists(t, g, siteID, agentID, EdgeKindContains)
+	assertEdgeExists(t, g, agentID, appID, EdgeKindContainsPkg)
+	assertEdgeExists(t, g, agentID, vulnID, EdgeKindAffectedBy)
+	assertEdgeExists(t, g, threatID, agentID, EdgeKindTargets)
+	assertEdgeExists(t, g, agentID, threatID, EdgeKindAffectedBy)
+	assertEdgeExists(t, g, activityID, agentID, EdgeKindTargets)
+	assertEdgeExists(t, g, activityID, threatID, EdgeKindTargets)
+}
+
+func TestSentinelOneCDCEventToNode(t *testing.T) {
+	node := cdcEventToNode("sentinelone_vulnerabilities", cdcEvent{
+		TableName:  "sentinelone_vulnerabilities",
+		ResourceID: "agent-1|CVE-2026-0001|Chrome|1.2.3",
+		Provider:   "sentinelone",
+		Payload: map[string]any{
+			"id":                   "agent-1|CVE-2026-0001|Chrome|1.2.3",
+			"cve_id":               "CVE-2026-0001",
+			"agent_id":             "agent-1",
+			"application_name":     "Chrome",
+			"application_version":  "1.2.3",
+			"severity":             "HIGH",
+			"days_since_detection": 31,
+		},
+	})
+	if node == nil {
+		t.Fatal("expected SentinelOne vulnerability CDC node")
+	}
+	if node.ID != sentinelOneVulnerabilityNodeID("agent-1|CVE-2026-0001|Chrome|1.2.3") {
+		t.Fatalf("node ID = %q", node.ID)
+	}
+	if node.Kind != NodeKindVulnerability {
+		t.Fatalf("node kind = %s, want vulnerability", node.Kind)
+	}
+	if node.Risk != RiskHigh {
+		t.Fatalf("node risk = %s, want high", node.Risk)
+	}
+}

--- a/internal/graph/builders/core_exports.go
+++ b/internal/graph/builders/core_exports.go
@@ -41,6 +41,9 @@ const (
 	EdgeKindResolvesTo     = graph.EdgeKindResolvesTo
 	EdgeKindServes         = graph.EdgeKindServes
 	EdgeKindTargets        = graph.EdgeKindTargets
+	EdgeKindContains       = graph.EdgeKindContains
+	EdgeKindContainsPkg    = graph.EdgeKindContainsPkg
+	EdgeKindAffectedBy     = graph.EdgeKindAffectedBy
 
 	NodeKindAPIEndpoint        = graph.NodeKindAPIEndpoint
 	NodeKindApplication        = graph.NodeKindApplication
@@ -71,6 +74,9 @@ const (
 	NodeKindSecret             = graph.NodeKindSecret
 	NodeKindService            = graph.NodeKindService
 	NodeKindServiceAccount     = graph.NodeKindServiceAccount
+	NodeKindPackage            = graph.NodeKindPackage
+	NodeKindVulnerability      = graph.NodeKindVulnerability
+	NodeKindIncident           = graph.NodeKindIncident
 	NodeKindUser               = graph.NodeKindUser
 	NodeKindFolder             = graph.NodeKindFolder
 	NodeKindVendor             = graph.NodeKindVendor

--- a/internal/policy/tables.go
+++ b/internal/policy/tables.go
@@ -373,7 +373,8 @@ var ResourceToTableMapping = map[string][]string{
 	"okta::system_log":       {"okta_system_logs"},
 
 	// SentinelOne
-	"sentinelone::threat": {"sentinelone_threats"},
+	"sentinelone::threat":        {"sentinelone_threats"},
+	"sentinelone::vulnerability": {"sentinelone_vulnerabilities"},
 
 	// GitLab
 	"gitlab::runner": {"gitlab_runners"},

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -42,13 +42,14 @@ type SyncOptions struct {
 }
 
 type SyncResult struct {
-	Provider    string        `json:"provider"`
-	StartedAt   time.Time     `json:"started_at"`
-	CompletedAt time.Time     `json:"completed_at"`
-	Duration    time.Duration `json:"duration"`
-	Tables      []TableResult `json:"tables"`
-	TotalRows   int64         `json:"total_rows"`
-	Errors      []string      `json:"errors,omitempty"`
+	Provider    string         `json:"provider"`
+	StartedAt   time.Time      `json:"started_at"`
+	CompletedAt time.Time      `json:"completed_at"`
+	Duration    time.Duration  `json:"duration"`
+	Tables      []TableResult  `json:"tables"`
+	TotalRows   int64          `json:"total_rows"`
+	Errors      []string       `json:"errors,omitempty"`
+	GraphUpdate map[string]any `json:"graph_update,omitempty"`
 }
 
 type TableResult struct {

--- a/internal/providers/sentinelone.go
+++ b/internal/providers/sentinelone.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -30,8 +31,24 @@ func (s *SentinelOneProvider) Configure(ctx context.Context, config map[string]i
 		return err
 	}
 
-	s.apiToken = s.GetConfigString("api_token")
-	s.baseURL = s.GetConfigString("base_url") // e.g., https://usea1-partners.sentinelone.net
+	s.apiToken = strings.TrimSpace(s.GetConfigString("api_token"))
+	if s.apiToken == "" {
+		return fmt.Errorf("sentinelone api_token is required")
+	}
+
+	s.baseURL = strings.TrimRight(strings.TrimSpace(s.GetConfigString("base_url")), "/")
+	if s.baseURL == "" {
+		return fmt.Errorf("sentinelone base_url is required")
+	}
+	parsed, err := url.Parse(s.baseURL)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "https" && parsed.Scheme != "http") {
+		return fmt.Errorf("sentinelone base_url must be an http(s) URL")
+	}
+
+	s.client = newProviderHTTPClientWithOptions(ProviderHTTPClientOptions{
+		Provider: "sentinelone",
+		Timeout:  30 * time.Second,
+	})
 
 	return nil
 }
@@ -80,6 +97,10 @@ func (s *SentinelOneProvider) Schema() []TableSchema {
 			Description: "SentinelOne threat detections",
 			Columns: []ColumnSchema{
 				{Name: "id", Type: "string", Required: true},
+				{Name: "threat_info", Type: "object"},
+				{Name: "agent_realtime_info", Type: "object"},
+				{Name: "agent_detection_info", Type: "object"},
+				{Name: "indicators", Type: "object"},
 				{Name: "agent_id", Type: "string"},
 				{Name: "agent_computer_name", Type: "string"},
 				{Name: "threat_name", Type: "string"},
@@ -157,9 +178,12 @@ func (s *SentinelOneProvider) Schema() []TableSchema {
 				{Name: "id", Type: "string", Required: true},
 				{Name: "cve_id", Type: "string"},
 				{Name: "agent_id", Type: "string"},
+				{Name: "site_id", Type: "string"},
+				{Name: "endpoint_name", Type: "string"},
 				{Name: "application_name", Type: "string"},
 				{Name: "application_version", Type: "string"},
 				{Name: "severity", Type: "string"},
+				{Name: "status", Type: "string"},
 				{Name: "cvss_score", Type: "float"},
 				{Name: "exploited_in_wild", Type: "boolean"},
 				{Name: "days_since_detection", Type: "integer"},
@@ -178,6 +202,36 @@ func (s *SentinelOneProvider) Sync(ctx context.Context, opts SyncOptions) (*Sync
 		StartedAt: start,
 	}
 
+	type syncPlan struct {
+		name string
+		fn   func(context.Context) (*TableResult, error)
+	}
+	plans := []syncPlan{
+		{name: "sentinelone_sites", fn: s.syncSites},
+		{name: "sentinelone_agents", fn: s.syncAgents},
+		{name: "sentinelone_threats", fn: func(ctx context.Context) (*TableResult, error) {
+			return s.syncThreats(ctx, opts.Since)
+		}},
+		{name: "sentinelone_activities", fn: func(ctx context.Context) (*TableResult, error) {
+			return s.syncActivities(ctx, opts.Since)
+		}},
+		{name: "sentinelone_applications", fn: s.syncApplications},
+		{name: "sentinelone_vulnerabilities", fn: s.syncVulnerabilities},
+	}
+
+	if len(opts.Tables) > 0 {
+		anySelected := false
+		for _, plan := range plans {
+			if tableRequested(opts.Tables, plan.name) {
+				anySelected = true
+				break
+			}
+		}
+		if !anySelected {
+			return result, fmt.Errorf("no matching SentinelOne tables in filter: %s", strings.Join(opts.Tables, ", "))
+		}
+	}
+
 	syncTable := func(name string, fn func(context.Context) (*TableResult, error)) {
 		table, err := fn(ctx)
 		if err != nil {
@@ -188,12 +242,12 @@ func (s *SentinelOneProvider) Sync(ctx context.Context, opts SyncOptions) (*Sync
 		result.TotalRows += table.Rows
 	}
 
-	syncTable("sites", s.syncSites)
-	syncTable("agents", s.syncAgents)
-	syncTable("threats", s.syncThreats)
-	syncTable("activities", s.syncActivities)
-	syncTable("applications", s.syncApplications)
-	syncTable("vulnerabilities", s.syncVulnerabilities)
+	for _, plan := range plans {
+		if !tableRequested(opts.Tables, plan.name) {
+			continue
+		}
+		syncTable(plan.name, plan.fn)
+	}
 
 	result.CompletedAt = time.Now()
 	result.Duration = result.CompletedAt.Sub(start)
@@ -277,16 +331,15 @@ func (s *SentinelOneProvider) syncAgents(ctx context.Context) (*TableResult, err
 	return s.syncTable(ctx, schema, rows)
 }
 
-func (s *SentinelOneProvider) syncThreats(ctx context.Context) (*TableResult, error) {
+func (s *SentinelOneProvider) syncThreats(ctx context.Context, since *time.Time) (*TableResult, error) {
 	schema, err := s.schemaFor("sentinelone_threats")
 	result := &TableResult{Name: "sentinelone_threats"}
 	if err != nil {
 		return result, err
 	}
 
-	// Get threats from last 30 days
-	createdAfter := time.Now().AddDate(0, 0, -30).Format(time.RFC3339)
-	path := fmt.Sprintf("/web/api/v2.1/threats?limit=1000&createdAt__gt=%s", createdAfter)
+	createdAfter := sentinelOneSince(since, 30).Format(time.RFC3339)
+	path := addQueryParams("/web/api/v2.1/threats?limit=1000", map[string]string{"createdAt__gt": createdAfter})
 
 	threats, err := s.listCollection(ctx, path, "")
 	if err != nil {
@@ -295,7 +348,7 @@ func (s *SentinelOneProvider) syncThreats(ctx context.Context) (*TableResult, er
 
 	rows := make([]map[string]interface{}, 0, len(threats))
 	for _, threat := range threats {
-		row := normalizeSentinelOneRow(threat)
+		row := normalizeSentinelOneThreat(threat)
 		ensureSentinelOneRowID(row, "agent_id", "file_sha256", "threat_name")
 		rows = append(rows, row)
 	}
@@ -303,16 +356,15 @@ func (s *SentinelOneProvider) syncThreats(ctx context.Context) (*TableResult, er
 	return s.syncTable(ctx, schema, rows)
 }
 
-func (s *SentinelOneProvider) syncActivities(ctx context.Context) (*TableResult, error) {
+func (s *SentinelOneProvider) syncActivities(ctx context.Context, since *time.Time) (*TableResult, error) {
 	schema, err := s.schemaFor("sentinelone_activities")
 	result := &TableResult{Name: "sentinelone_activities"}
 	if err != nil {
 		return result, err
 	}
 
-	// Get activities from last 7 days
-	createdAfter := time.Now().AddDate(0, 0, -7).Format(time.RFC3339)
-	path := fmt.Sprintf("/web/api/v2.1/activities?limit=1000&createdAt__gt=%s", createdAfter)
+	createdAfter := sentinelOneSince(since, 7).Format(time.RFC3339)
+	path := addQueryParams("/web/api/v2.1/activities?limit=1000", map[string]string{"createdAt__gt": createdAfter})
 
 	activities, err := s.listCollection(ctx, path, "")
 	if err != nil {
@@ -364,22 +416,29 @@ func (s *SentinelOneProvider) syncVulnerabilities(ctx context.Context) (*TableRe
 		return result, err
 	}
 
-	vulnerabilities, err := s.listCollection(ctx, "/web/api/v2.1/vulnerabilities?limit=1000", "")
+	sites, err := s.listCollection(ctx, "/web/api/v2.1/sites?limit=200", "sites")
 	if err != nil {
 		return result, err
 	}
 
-	rows := make([]map[string]interface{}, 0, len(vulnerabilities))
-	for _, vulnerability := range vulnerabilities {
-		row := normalizeSentinelOneRow(vulnerability)
-		if row["application_name"] == nil {
-			row["application_name"] = firstSentinelOneValue(row, "name", "app_name")
+	rows := make([]map[string]interface{}, 0)
+	for _, site := range sites {
+		siteID := strings.TrimSpace(providerStringValue(site["id"]))
+		if siteID == "" {
+			continue
 		}
-		if row["application_version"] == nil {
-			row["application_version"] = firstSentinelOneValue(row, "version", "app_version")
+
+		path := addQueryParams("/web/api/v2.1/application-management/risks?limit=1000", map[string]string{"siteIds": siteID})
+		vulnerabilities, err := s.listCollection(ctx, path, "")
+		if err != nil {
+			return result, err
 		}
-		ensureSentinelOneRowID(row, "agent_id", "cve_id", "application_name", "application_version")
-		rows = append(rows, row)
+
+		for _, vulnerability := range vulnerabilities {
+			row := normalizeSentinelOneVulnerability(vulnerability, siteID)
+			ensureSentinelOneRowID(row, "agent_id", "cve_id", "application_name", "application_version")
+			rows = append(rows, row)
+		}
 	}
 
 	return s.syncTable(ctx, schema, rows)
@@ -487,6 +546,99 @@ func normalizeSentinelOneRow(row map[string]interface{}) map[string]interface{} 
 		return map[string]interface{}{}
 	}
 	return normalized
+}
+
+func normalizeSentinelOneThreat(threat map[string]interface{}) map[string]interface{} {
+	row := normalizeSentinelOneRow(threat)
+	threatInfo := sentinelOneMapValue(row, "threat_info")
+	agentRealtime := sentinelOneMapValue(row, "agent_realtime_info")
+	agentDetection := sentinelOneMapValue(row, "agent_detection_info")
+	indicators := sentinelOneMapValue(row, "indicators")
+
+	fillSentinelOneValue(row, "id", threatInfo, "threat_id", "id")
+	fillSentinelOneValue(row, "agent_id", agentRealtime, "agent_id", "id")
+	fillSentinelOneValue(row, "agent_id", agentDetection, "agent_id", "id")
+	fillSentinelOneValue(row, "agent_computer_name", agentRealtime, "agent_computer_name", "computer_name")
+	fillSentinelOneValue(row, "agent_computer_name", agentDetection, "agent_computer_name", "computer_name")
+	fillSentinelOneValue(row, "threat_name", threatInfo, "threat_name", "name")
+	fillSentinelOneValue(row, "classification", threatInfo, "classification")
+	fillSentinelOneValue(row, "classification_source", threatInfo, "classification_source")
+	fillSentinelOneValue(row, "confidence_level", threatInfo, "confidence_level")
+	fillSentinelOneValue(row, "analyst_verdict", threatInfo, "analyst_verdict")
+	fillSentinelOneValue(row, "incident_status", threatInfo, "incident_status")
+	fillSentinelOneValue(row, "mitigation_status", threatInfo, "mitigation_status")
+	fillSentinelOneValue(row, "initiated_by", threatInfo, "initiated_by")
+	fillSentinelOneValue(row, "file_path", threatInfo, "file_path")
+	fillSentinelOneValue(row, "file_sha256", threatInfo, "sha256", "file_sha256")
+	fillSentinelOneValue(row, "file_sha1", threatInfo, "sha1", "file_sha1")
+	fillSentinelOneValue(row, "file_md5", threatInfo, "md5", "file_md5")
+	fillSentinelOneValue(row, "mitre_tactics", indicators, "mitre_tactics")
+	fillSentinelOneValue(row, "mitre_techniques", indicators, "mitre_techniques")
+	fillSentinelOneValue(row, "created_at", threatInfo, "created_at")
+	fillSentinelOneValue(row, "updated_at", threatInfo, "updated_at")
+
+	return row
+}
+
+func normalizeSentinelOneVulnerability(vulnerability map[string]interface{}, siteID string) map[string]interface{} {
+	row := normalizeSentinelOneRow(vulnerability)
+	if strings.TrimSpace(providerStringValue(row["site_id"])) == "" {
+		row["site_id"] = siteID
+	}
+	if row["agent_id"] == nil {
+		row["agent_id"] = firstSentinelOneValue(row, "endpoint_id")
+	}
+	if row["application_name"] == nil {
+		row["application_name"] = firstSentinelOneValue(row, "application", "name", "app_name")
+	}
+	if row["application_version"] == nil {
+		row["application_version"] = firstSentinelOneValue(row, "version", "app_version")
+	}
+	if row["cvss_score"] == nil {
+		row["cvss_score"] = firstSentinelOneValue(row, "base_score")
+	}
+	if row["days_since_detection"] == nil {
+		row["days_since_detection"] = firstSentinelOneValue(row, "days_detected")
+	}
+	if row["detected_at"] == nil {
+		row["detected_at"] = firstSentinelOneValue(row, "detection_date")
+	}
+	if row["remediation_action"] == nil {
+		row["remediation_action"] = firstSentinelOneValue(row, "reason", "last_scan_result")
+	}
+	return row
+}
+
+func sentinelOneSince(since *time.Time, defaultDays int) time.Time {
+	if since != nil && !since.IsZero() {
+		return since.UTC()
+	}
+	return time.Now().AddDate(0, 0, -defaultDays).UTC()
+}
+
+func sentinelOneMapValue(row map[string]interface{}, key string) map[string]interface{} {
+	value, ok := row[key]
+	if !ok || value == nil {
+		return nil
+	}
+	asMap, ok := value.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return asMap
+}
+
+func fillSentinelOneValue(row map[string]interface{}, target string, source map[string]interface{}, keys ...string) {
+	if row == nil || source == nil {
+		return
+	}
+	if value, ok := row[target]; ok && value != nil && strings.TrimSpace(providerStringValue(value)) != "" {
+		return
+	}
+	value := firstSentinelOneValue(source, keys...)
+	if value != nil {
+		row[target] = value
+	}
 }
 
 func ensureSentinelOneRowID(row map[string]interface{}, fallbackKeys ...string) {

--- a/internal/providers/sentinelone_test.go
+++ b/internal/providers/sentinelone_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -47,10 +48,25 @@ func TestSentinelOneProviderSync_IncludesApplicationsAndVulnerabilities(t *testi
 					{"agentId": "agent-1", "name": "Chrome", "version": "1.2.3", "publisher": "Google"},
 				},
 			})
-		case "/web/api/v2.1/vulnerabilities":
+		case "/web/api/v2.1/application-management/risks":
+			if got := r.URL.Query().Get("siteIds"); got != "site-1" {
+				t.Fatalf("risk siteIds = %q, want site-1", got)
+			}
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"data": []map[string]interface{}{
-					{"agentId": "agent-1", "cveId": "CVE-2026-0001", "applicationName": "Chrome", "applicationVersion": "1.2.3", "severity": "high"},
+					{
+						"endpointId":         "agent-1",
+						"endpointName":       "host-1",
+						"cveId":              "CVE-2026-0001",
+						"applicationName":    "Chrome",
+						"applicationVersion": "1.2.3",
+						"severity":           "Medium",
+						"status":             "open",
+						"baseScore":          "6.5",
+						"daysDetected":       31,
+						"detectionDate":      "2026-01-01T00:00:00Z",
+						"lastScanResult":     "patch available",
+					},
 				},
 			})
 		default:
@@ -145,5 +161,152 @@ func TestSentinelOneProviderSyncAgents_PaginationLoopStops(t *testing.T) {
 	}
 	if requestCount != 2 {
 		t.Fatalf("syncAgents request count = %d, want 2", requestCount)
+	}
+}
+
+func TestSentinelOneProviderConfigure_ValidatesRequiredConfig(t *testing.T) {
+	t.Parallel()
+
+	provider := NewSentinelOneProvider()
+	if err := provider.Configure(context.Background(), map[string]interface{}{
+		"base_url": "https://example.sentinelone.net",
+	}); err == nil || !strings.Contains(err.Error(), "api_token") {
+		t.Fatalf("configure missing token error = %v, want api_token error", err)
+	}
+
+	if err := provider.Configure(context.Background(), map[string]interface{}{
+		"api_token": "token",
+		"base_url":  "not-a-url",
+	}); err == nil || !strings.Contains(err.Error(), "base_url") {
+		t.Fatalf("configure invalid base_url error = %v, want base_url error", err)
+	}
+}
+
+func TestSentinelOneProviderSync_HonorsTableFilter(t *testing.T) {
+	t.Parallel()
+
+	requestedPaths := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/web/api/v2.1/agents":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": []map[string]interface{}{{"id": "agent-1"}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewSentinelOneProvider()
+	if err := provider.Configure(context.Background(), map[string]interface{}{
+		"api_token": "token",
+		"base_url":  server.URL + "/",
+	}); err != nil {
+		t.Fatalf("configure failed: %v", err)
+	}
+
+	result, err := provider.Sync(context.Background(), SyncOptions{Tables: []string{"sentinelone_agents"}})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("unexpected sync errors: %v", result.Errors)
+	}
+	if len(result.Tables) != 1 || result.Tables[0].Name != "sentinelone_agents" {
+		t.Fatalf("synced tables = %+v, want only sentinelone_agents", result.Tables)
+	}
+	if len(requestedPaths) != 1 || requestedPaths[0] != "/web/api/v2.1/agents" {
+		t.Fatalf("requested paths = %v, want only agents", requestedPaths)
+	}
+
+	_, err = provider.Sync(context.Background(), SyncOptions{Tables: []string{"sentinelone_unknown"}})
+	if err == nil || !strings.Contains(err.Error(), "no matching SentinelOne tables") {
+		t.Fatalf("unknown table sync error = %v, want no matching tables error", err)
+	}
+}
+
+func TestNormalizeSentinelOneThreat_LiveNestedShape(t *testing.T) {
+	t.Parallel()
+
+	row := normalizeSentinelOneThreat(map[string]interface{}{
+		"threatInfo": map[string]interface{}{
+			"threatId":             "threat-1",
+			"threatName":           "EICAR",
+			"classification":       "Malware",
+			"classificationSource": "Cloud",
+			"analystVerdict":       "true_positive",
+			"mitigationStatus":     "not_mitigated",
+			"sha256":               "abc123",
+			"createdAt":            "2026-01-01T00:00:00Z",
+		},
+		"agentRealtimeInfo": map[string]interface{}{
+			"agentId":           "agent-1",
+			"agentComputerName": "host-1",
+		},
+		"indicators": map[string]interface{}{
+			"mitreTactics": []interface{}{"TA0011"},
+			"categories":   []interface{}{"Ransomware"},
+		},
+	})
+
+	if got := row["id"]; got != "threat-1" {
+		t.Fatalf("id = %v, want threat-1", got)
+	}
+	if got := row["agent_id"]; got != "agent-1" {
+		t.Fatalf("agent_id = %v, want agent-1", got)
+	}
+	if got := row["agent_computer_name"]; got != "host-1" {
+		t.Fatalf("agent_computer_name = %v, want host-1", got)
+	}
+	if got := row["threat_name"]; got != "EICAR" {
+		t.Fatalf("threat_name = %v, want EICAR", got)
+	}
+	if _, ok := row["threat_info"].(map[string]interface{}); !ok {
+		t.Fatalf("threat_info missing or wrong type: %T", row["threat_info"])
+	}
+	if _, ok := row["indicators"].(map[string]interface{}); !ok {
+		t.Fatalf("indicators missing or wrong type: %T", row["indicators"])
+	}
+}
+
+func TestNormalizeSentinelOneVulnerability_ApplicationRiskShape(t *testing.T) {
+	t.Parallel()
+
+	row := normalizeSentinelOneVulnerability(map[string]interface{}{
+		"endpointId":         "agent-1",
+		"endpointName":       "host-1",
+		"cveId":              "CVE-2026-0001",
+		"applicationName":    "Chrome",
+		"applicationVersion": "1.2.3",
+		"severity":           "Medium",
+		"status":             "open",
+		"baseScore":          "6.5",
+		"daysDetected":       31,
+		"detectionDate":      "2026-01-01T00:00:00Z",
+		"lastScanResult":     "patch available",
+	}, "site-1")
+
+	want := map[string]interface{}{
+		"agent_id":             "agent-1",
+		"site_id":              "site-1",
+		"cve_id":               "CVE-2026-0001",
+		"application_name":     "Chrome",
+		"application_version":  "1.2.3",
+		"severity":             "Medium",
+		"status":               "open",
+		"cvss_score":           "6.5",
+		"days_since_detection": 31,
+		"detected_at":          "2026-01-01T00:00:00Z",
+		"remediation_action":   "patch available",
+	}
+
+	for key, wantValue := range want {
+		if got := row[key]; got != wantValue {
+			t.Fatalf("%s = %v, want %v", key, got, wantValue)
+		}
 	}
 }

--- a/internal/providers/storage.go
+++ b/internal/providers/storage.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/writer/cerebro/internal/snowflake"
 	"github.com/writer/cerebro/internal/snowflake/tableops"
@@ -52,26 +53,30 @@ func (b *BaseProvider) syncTable(ctx context.Context, schema TableSchema, rows [
 		result.Rows = int64(len(prepared))
 	}
 
-	existingIDs, err := listProviderExistingIDs(ctx, sf, schema.Name)
+	existingRows, err := listProviderExistingRows(ctx, sf, schema.Name)
 	if err != nil {
 		return result, err
 	}
 
 	newIDs := providerRowIDSet(prepared)
+	cdcEvents := buildProviderCDCEvents(schema.Name, b.Name(), prepared, existingRows, newIDs)
 
 	// Atomic upsert via MERGE - no delete-before-insert window.
 	if err := mergeProviderRows(ctx, sf, schema.Name, prepared); err != nil {
 		return result, err
 	}
 
-	removedIDs := make(map[string]struct{}, len(existingIDs))
-	for id := range existingIDs {
+	removedIDs := make(map[string]struct{}, len(existingRows))
+	for id := range existingRows {
 		if _, exists := newIDs[id]; !exists {
 			removedIDs[id] = struct{}{}
 		}
 	}
 	if err := deleteProviderRowsByID(ctx, sf, schema.Name, removedIDs); err != nil {
 		return result, err
+	}
+	if err := sf.InsertCDCEvents(ctx, cdcEvents); err != nil {
+		return result, fmt.Errorf("insert provider cdc events: %w", err)
 	}
 
 	result.Rows = int64(len(prepared))
@@ -101,27 +106,34 @@ func ensureProviderTable(ctx context.Context, sf providerSnowflakeClient, table 
 	return err
 }
 
-func listProviderExistingIDs(ctx context.Context, sf providerSnowflakeClient, table string) (map[string]struct{}, error) {
+type providerExistingRow struct {
+	Hash string
+}
+
+func listProviderExistingRows(ctx context.Context, sf providerSnowflakeClient, table string) (map[string]providerExistingRow, error) {
 	if err := snowflake.ValidateTableName(table); err != nil {
 		return nil, fmt.Errorf("invalid table name %s: %w", table, err)
 	}
 
-	query := fmt.Sprintf("SELECT _CQ_ID FROM %s", table)
+	query := fmt.Sprintf("SELECT _CQ_ID, _CQ_HASH FROM %s", table)
 	result, err := sf.Query(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("list existing provider rows: %w", err)
 	}
 
-	ids := make(map[string]struct{}, len(result.Rows))
+	rows := make(map[string]providerExistingRow, len(result.Rows))
 	for _, row := range result.Rows {
 		value, _ := lookupProviderValue(row, "_cq_id")
 		id := strings.TrimSpace(providerStringValue(value))
 		if id == "" {
 			continue
 		}
-		ids[id] = struct{}{}
+		hashValue, _ := lookupProviderValue(row, "_cq_hash")
+		rows[id] = providerExistingRow{
+			Hash: strings.TrimSpace(providerStringValue(hashValue)),
+		}
 	}
-	return ids, nil
+	return rows, nil
 }
 
 func providerRowIDSet(rows []map[string]interface{}) map[string]struct{} {
@@ -199,6 +211,66 @@ func prepareProviderRows(schema TableSchema, rows []map[string]interface{}) ([]m
 		prepared = append(prepared, projected)
 	}
 	return prepared, skipped
+}
+
+func buildProviderCDCEvents(table, provider string, prepared []map[string]interface{}, existingRows map[string]providerExistingRow, newIDs map[string]struct{}) []snowflake.CDCEvent {
+	now := time.Now().UTC()
+	events := make([]snowflake.CDCEvent, 0, len(prepared))
+
+	for _, row := range prepared {
+		id := strings.TrimSpace(providerStringValue(row["_cq_id"]))
+		if id == "" {
+			continue
+		}
+		hash := strings.TrimSpace(providerStringValue(row["_cq_hash"]))
+		existing, existed := existingRows[id]
+		changeType := "added"
+		if existed {
+			if existing.Hash == hash {
+				continue
+			}
+			changeType = "modified"
+		}
+		events = append(events, snowflake.CDCEvent{
+			TableName:   table,
+			ResourceID:  id,
+			ChangeType:  changeType,
+			Provider:    provider,
+			AccountID:   firstProviderCDCValue(row, "account_id", "site_id", "tenant_id"),
+			Payload:     row,
+			PayloadHash: hash,
+			EventTime:   now,
+		})
+	}
+
+	for id, existing := range existingRows {
+		if _, exists := newIDs[id]; exists {
+			continue
+		}
+		events = append(events, snowflake.CDCEvent{
+			TableName:   table,
+			ResourceID:  id,
+			ChangeType:  "removed",
+			Provider:    provider,
+			PayloadHash: existing.Hash,
+			EventTime:   now,
+		})
+	}
+
+	return events
+}
+
+func firstProviderCDCValue(row map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		value, ok := lookupProviderValue(row, key)
+		if !ok {
+			continue
+		}
+		if text := strings.TrimSpace(providerStringValue(value)); text != "" {
+			return text
+		}
+	}
+	return ""
 }
 
 func projectProviderRow(row map[string]interface{}, columns []ColumnSchema) map[string]interface{} {

--- a/internal/providers/storage_test.go
+++ b/internal/providers/storage_test.go
@@ -131,3 +131,46 @@ func TestEnsureProviderTable_SkipsExistingColumnsCaseInsensitive(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildProviderCDCEvents(t *testing.T) {
+	prepared := []map[string]interface{}{
+		{"_cq_id": "new-row", "_cq_hash": "hash-new", "site_id": "site-1", "id": "new-row"},
+		{"_cq_id": "changed-row", "_cq_hash": "hash-changed", "site_id": "site-1", "id": "changed-row"},
+		{"_cq_id": "same-row", "_cq_hash": "hash-same", "site_id": "site-1", "id": "same-row"},
+	}
+	existing := map[string]providerExistingRow{
+		"changed-row": {Hash: "hash-old"},
+		"same-row":    {Hash: "hash-same"},
+		"removed-row": {Hash: "hash-removed"},
+	}
+	newIDs := providerRowIDSet(prepared)
+
+	events := buildProviderCDCEvents("sentinelone_agents", "sentinelone", prepared, existing, newIDs)
+	if len(events) != 3 {
+		t.Fatalf("events = %d, want 3: %#v", len(events), events)
+	}
+
+	byResource := make(map[string]string, len(events))
+	for _, event := range events {
+		if event.Provider != "sentinelone" {
+			t.Fatalf("provider = %q, want sentinelone", event.Provider)
+		}
+		if event.TableName != "sentinelone_agents" {
+			t.Fatalf("table = %q, want sentinelone_agents", event.TableName)
+		}
+		byResource[event.ResourceID] = event.ChangeType
+	}
+
+	if byResource["new-row"] != "added" {
+		t.Fatalf("new-row change = %q, want added", byResource["new-row"])
+	}
+	if byResource["changed-row"] != "modified" {
+		t.Fatalf("changed-row change = %q, want modified", byResource["changed-row"])
+	}
+	if byResource["removed-row"] != "removed" {
+		t.Fatalf("removed-row change = %q, want removed", byResource["removed-row"])
+	}
+	if _, ok := byResource["same-row"]; ok {
+		t.Fatal("same-row should not emit a CDC event")
+	}
+}

--- a/policies/endpoint/endpoint-sentinelone-active.json
+++ b/policies/endpoint/endpoint-sentinelone-active.json
@@ -9,19 +9,19 @@
     {
       "name": "SOC 2",
       "controls": [
-        "CC1.1"
+        "CC7.1"
       ]
     },
     {
       "name": "ISO 27001:2022",
       "controls": [
-        "A.5.1"
+        "A.8.7"
       ]
     },
     {
       "name": "PCI DSS v4.0",
       "controls": [
-        "1.1"
+        "11.3.1"
       ]
     }
   ],

--- a/policies/sentinelone/sentinelone-command-control.json
+++ b/policies/sentinelone/sentinelone-command-control.json
@@ -20,5 +20,33 @@
     "threat-detection",
     "mitre-ta0011"
   ],
-  "remediation": "Immediately isolate endpoint from network. Block C2 domains/IPs at perimeter. Conduct forensic investigation. Engage incident response procedures. Hunt for lateral movement."
+  "remediation": "Immediately isolate endpoint from network. Block C2 domains/IPs at perimeter. Conduct forensic investigation. Engage incident response procedures. Hunt for lateral movement.",
+  "frameworks": [
+    {
+      "name": "SOC 2",
+      "controls": [
+        "CC7.2",
+        "CC7.3"
+      ]
+    },
+    {
+      "name": "PCI DSS v4.0",
+      "controls": [
+        "10.4.1"
+      ]
+    },
+    {
+      "name": "HIPAA Security Rule",
+      "controls": [
+        "164.312(b)"
+      ]
+    },
+    {
+      "name": "NIST 800-53 r5",
+      "controls": [
+        "SI-4",
+        "IR-4"
+      ]
+    }
+  ]
 }

--- a/policies/sentinelone/sentinelone-malware.json
+++ b/policies/sentinelone/sentinelone-malware.json
@@ -22,5 +22,33 @@
     "threat-detection",
     "mitre-ta0002"
   ],
-  "remediation": "Investigate threat in SentinelOne console. Execute mitigation actions (kill, quarantine, remediate). Consider reimaging endpoint if infection is severe. Collect IOCs for threat hunting."
+  "remediation": "Investigate threat in SentinelOne console. Execute mitigation actions (kill, quarantine, remediate). Consider reimaging endpoint if infection is severe. Collect IOCs for threat hunting.",
+  "frameworks": [
+    {
+      "name": "SOC 2",
+      "controls": [
+        "CC7.2",
+        "CC7.3"
+      ]
+    },
+    {
+      "name": "PCI DSS v4.0",
+      "controls": [
+        "10.4.1"
+      ]
+    },
+    {
+      "name": "HIPAA Security Rule",
+      "controls": [
+        "164.312(b)"
+      ]
+    },
+    {
+      "name": "NIST 800-53 r5",
+      "controls": [
+        "SI-4",
+        "IR-4"
+      ]
+    }
+  ]
 }

--- a/policies/sentinelone/sentinelone-ransomware.json
+++ b/policies/sentinelone/sentinelone-ransomware.json
@@ -25,6 +25,19 @@
   ],
   "frameworks": [
     {
+      "name": "SOC 2",
+      "controls": [
+        "CC7.2",
+        "CC7.3"
+      ]
+    },
+    {
+      "name": "HIPAA Security Rule",
+      "controls": [
+        "164.312(b)"
+      ]
+    },
+    {
       "name": "NIST 800-53 r5",
       "controls": [
         "SC-12",
@@ -33,8 +46,9 @@
       ]
     },
     {
-      "name": "PCI DSS v4.0.1",
+      "name": "PCI DSS v4.0",
       "controls": [
+        "10.4.1",
         "3.5",
         "4.2"
       ]


### PR DESCRIPTION
## Summary
- validate and normalize SentinelOne provider config/API responses
- switch vulnerability sync to application-management risks scoped by site
- map SentinelOne endpoint/threat/vulnerability policies into compliance frameworks

## Validation
- Live SentinelOne smoke test against system info, sites, agents, threats, activities, installed applications, and application risks endpoints
- GOFLAGS=-mod=mod go test ./...
- commit hooks: go vet, staged package tests, golangci-lint fast checks, contract compatibility, graph guardrails