### PR TITLE
feat(graph): canonicalize Kandji and GCP CVEs

### DIFF
--- a/internal/api/handlers_providers.go
+++ b/internal/api/handlers_providers.go
@@ -163,7 +163,7 @@ func includeIncompleteProviders(r *http.Request) bool {
 
 func shouldApplyProviderGraphUpdate(name string) bool {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "sentinelone", "github":
+	case "sentinelone", "github", "kandji":
 		return true
 	default:
 		return false

--- a/internal/graph/builders/builder.go
+++ b/internal/graph/builders/builder.go
@@ -139,6 +139,7 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 	g.Go(func() error { working.buildK8sNodes(gctx); return nil })
 	g.Go(func() error { working.buildSentinelOneNodes(gctx); return nil })
 	g.Go(func() error { working.buildGitHubNodes(gctx); return nil })
+	g.Go(func() error { working.buildKandjiNodes(gctx); return nil })
 	_ = g.Wait()
 	if err := ctx.Err(); err != nil {
 		return nil, GraphMutationSummary{}, err
@@ -163,6 +164,7 @@ func (b *Builder) BuildCandidate(ctx context.Context) (*Graph, GraphMutationSumm
 	eg.Go(func() error { working.buildKubernetesEdges(ectx); return nil })
 	eg.Go(func() error { working.buildSentinelOneEdges(ectx); return nil })
 	eg.Go(func() error { working.buildGitHubEdges(ectx); return nil })
+	eg.Go(func() error { working.buildKandjiEdges(ectx); return nil })
 	eg.Go(func() error { working.buildRelationshipEdges(ectx); return nil })
 	_ = eg.Wait()
 	if err := ctx.Err(); err != nil {
@@ -365,6 +367,8 @@ func (b *Builder) buildRelationshipEdges(ctx context.Context) {
 			kind = EdgeKindCanWrite
 		case "HAS_PERMISSION":
 			kind = EdgeKindCanAdmin
+		case "HAS_VULNERABILITY":
+			kind = EdgeKindAffectedBy
 		case "EXPOSED_TO":
 			kind = EdgeKindExposedTo
 			if targetID == "internet" || targetType == "network:internet" {
@@ -556,6 +560,10 @@ func nodeKindForResourceType(resourceType string) NodeKind {
 		return NodeKindBucket
 	case "aws:ec2:instance", "gcp:compute:instance":
 		return NodeKindInstance
+	case "gcp:artifactregistry:image", "gcp:artifactregistry:package":
+		return NodeKindPackage
+	case "gcp:container:vulnerability":
+		return NodeKindVulnerability
 	case "azure:compute:virtual_machine":
 		return NodeKindInstance
 	case "aws:lambda:function", "gcp:cloudfunctions:function":

--- a/internal/graph/builders/builder_cdc.go
+++ b/internal/graph/builders/builder_cdc.go
@@ -1179,6 +1179,22 @@ func cdcEventToNode(table string, event cdcEvent) *Node {
 		}
 	case "github_dependabot_alerts":
 		return parseGitHubDependabotVulnerabilityNode(payload)
+	case "kandji_devices":
+		nodes := parseKandjiDeviceNodes([]map[string]any{payload})
+		if len(nodes) > 0 {
+			return nodes[0]
+		}
+	case "kandji_device_apps":
+		nodes := parseKandjiDeviceAppNodes([]map[string]any{payload})
+		if len(nodes) > 0 {
+			return nodes[0]
+		}
+	case "kandji_vulnerabilities":
+		return kandjiVulnerabilityNode(payload)
+	case "gcp_artifact_registry_images":
+		return gcpArtifactRegistryImageNode(payload)
+	case "gcp_container_vulnerabilities":
+		return gcpContainerVulnerabilityNode(payload)
 	case "k8s_core_pods",
 		"k8s_core_namespaces",
 		"k8s_core_service_accounts",
@@ -1217,6 +1233,10 @@ func cdcNodeID(table string, payload map[string]any, fallback string) string {
 			return id
 		}
 		return gcpFirewallNodeID(payload)
+	case "gcp_artifact_registry_images":
+		return firstNonEmpty(gcpArtifactRegistryImageNodeID(payload), fallback)
+	case "gcp_container_vulnerabilities":
+		return firstNonEmpty(gcpContainerVulnerabilityNodeIDForRow(payload), fallback)
 	case "gcp_compute_instances", "gcp_storage_buckets", "gcp_sql_instances", "gcp_cloudfunctions_functions", "gcp_cloudrun_services":
 		if id := strings.TrimSpace(fallback); id != "" {
 			return id
@@ -1276,6 +1296,12 @@ func cdcNodeID(table string, payload map[string]any, fallback string) string {
 		return githubRepositoryNodeID(firstNonEmpty(queryRowString(payload, "full_name"), queryRowString(payload, "repository"), fallback))
 	case "github_dependabot_alerts":
 		return firstNonEmpty(githubDependabotVulnerabilityNodeIDForRow(payload), fallback)
+	case "kandji_devices":
+		return kandjiDeviceNodeID(firstNonEmpty(queryRowString(payload, "device_id"), fallback))
+	case "kandji_device_apps":
+		return firstNonEmpty(kandjiPackageNodeID(queryRowString(payload, "device_id"), queryRowString(payload, "app_name"), queryRowString(payload, "version")), fallback)
+	case "kandji_vulnerabilities":
+		return firstNonEmpty(kandjiVulnerabilityNodeIDForRow(payload), fallback)
 	case "k8s_core_pods",
 		"k8s_core_namespaces",
 		"k8s_core_service_accounts",

--- a/internal/graph/builders/builder_gcp.go
+++ b/internal/graph/builders/builder_gcp.go
@@ -252,6 +252,16 @@ func (b *Builder) buildGCPNodes(ctx context.Context) {
 				return nodes
 			},
 		},
+		{
+			table: "gcp_artifact_registry_images",
+			query: `SELECT _cq_id, project_id, name, uri, tags, image_size, upload_time, media_type, build_time, update_time, repository, registry_type, scanned, scan_status, vulnerabilities, has_vulnerabilities, has_openssl_vulnerability FROM gcp_artifact_registry_images`,
+			parse: parseGCPArtifactRegistryImageNodes,
+		},
+		{
+			table: "gcp_container_vulnerabilities",
+			query: `SELECT _cq_id, project_id, name, resource_uri, note_name, kind, create_time, update_time, severity, cvss_score, cvss_v3_score, effective_severity, fix_available, long_description, short_description, cve_id, package_issue FROM gcp_container_vulnerabilities`,
+			parse: parseGCPContainerVulnerabilityNodes,
+		},
 	}
 
 	b.runNodeQueries(ctx, queries)
@@ -269,6 +279,7 @@ func (b *Builder) buildGCPEdges(ctx context.Context) {
 
 	b.buildGCPServiceAccountEdges(ctx)
 	b.buildGCPFirewallEdges(ctx)
+	b.buildGCPContainerVulnerabilityEdges(ctx)
 }
 
 func (b *Builder) buildGCPEdgesFromMembers(ctx context.Context, policyProjects map[string]struct{}) int {
@@ -886,4 +897,182 @@ func (b *Builder) buildGCPFirewallEdges(ctx context.Context) {
 		}
 	}
 	b.logger.Debug("added GCP firewall exposure edges", "count", count)
+}
+
+func parseGCPArtifactRegistryImageNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		node := gcpArtifactRegistryImageNode(row)
+		if node != nil {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}
+
+func gcpArtifactRegistryImageNode(row map[string]any) *Node {
+	id := gcpArtifactRegistryImageNodeID(row)
+	if id == "" {
+		return nil
+	}
+	name := firstNonEmpty(queryRowString(row, "uri"), queryRowString(row, "name"), id)
+	return &Node{
+		ID:       id,
+		Kind:     NodeKindPackage,
+		Name:     name,
+		Provider: "gcp",
+		Account:  queryRowString(row, "project_id"),
+		Risk:     gcpArtifactRegistryImageRisk(row),
+		Properties: map[string]any{
+			"source_table":                "gcp_artifact_registry_images",
+			"project_id":                  queryRow(row, "project_id"),
+			"name":                        queryRow(row, "name"),
+			"uri":                         queryRow(row, "uri"),
+			"tags":                        queryRow(row, "tags"),
+			"image_size":                  queryRow(row, "image_size"),
+			"upload_time":                 queryRow(row, "upload_time"),
+			"media_type":                  queryRow(row, "media_type"),
+			"build_time":                  queryRow(row, "build_time"),
+			"update_time":                 queryRow(row, "update_time"),
+			"repository":                  queryRow(row, "repository"),
+			"registry_type":               queryRow(row, "registry_type"),
+			"scanned":                     queryRow(row, "scanned"),
+			"scan_status":                 queryRow(row, "scan_status"),
+			"vulnerabilities":             queryRow(row, "vulnerabilities"),
+			"has_vulnerabilities":         queryRow(row, "has_vulnerabilities"),
+			"has_openssl_vulnerability":   queryRow(row, "has_openssl_vulnerability"),
+			"package_manager":             "gcp_artifact_registry",
+			"asset_support_entity_kind":   "container_image",
+			"artifact_registry_image_id":  id,
+			"artifact_registry_image_uri": queryRow(row, "uri"),
+		},
+	}
+}
+
+func parseGCPContainerVulnerabilityNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		node := gcpContainerVulnerabilityNode(row)
+		if node != nil {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}
+
+func gcpContainerVulnerabilityNode(row map[string]any) *Node {
+	nodeID := gcpContainerVulnerabilityNodeIDForRow(row)
+	if nodeID == "" {
+		return nil
+	}
+	cveID := normalizedVulnerabilityIdentifier(queryRowString(row, "cve_id"))
+	severity := firstNonEmpty(queryRowString(row, "effective_severity"), queryRowString(row, "severity"))
+	return &Node{
+		ID:       nodeID,
+		Kind:     NodeKindVulnerability,
+		Name:     firstNonEmpty(cveID, queryRowString(row, "name"), nodeID),
+		Provider: "gcp",
+		Account:  queryRowString(row, "project_id"),
+		Risk:     vulnerabilityRiskFromSeverity(severity),
+		Properties: map[string]any{
+			"source_table":               "gcp_container_vulnerabilities",
+			"occurrence_id":              queryRow(row, "_cq_id"),
+			"project_id":                 queryRow(row, "project_id"),
+			"name":                       queryRow(row, "name"),
+			"resource_uri":               queryRow(row, "resource_uri"),
+			"note_name":                  queryRow(row, "note_name"),
+			"kind":                       queryRow(row, "kind"),
+			"create_time":                queryRow(row, "create_time"),
+			"update_time":                queryRow(row, "update_time"),
+			"severity":                   queryRow(row, "severity"),
+			"effective_severity":         queryRow(row, "effective_severity"),
+			"cvss_score":                 queryRow(row, "cvss_score"),
+			"cvss_v3_score":              queryRow(row, "cvss_v3_score"),
+			"fix_available":              queryRow(row, "fix_available"),
+			"long_description":           queryRow(row, "long_description"),
+			"short_description":          queryRow(row, "short_description"),
+			"cve_id":                     cveID,
+			"package_issue":              queryRow(row, "package_issue"),
+			"asset_support_finding":      "gcp_container_vulnerability",
+			"canonical_vulnerability_id": nodeID,
+		},
+	}
+}
+
+func (b *Builder) buildGCPContainerVulnerabilityEdges(ctx context.Context) {
+	rows, err := b.queryIfExists(ctx, "gcp_container_vulnerabilities", `SELECT _cq_id, project_id, name, resource_uri, severity, cvss_score, cvss_v3_score, effective_severity, fix_available, cve_id, package_issue FROM gcp_container_vulnerabilities`)
+	if err != nil {
+		b.logger.Debug("gcp container vulnerability edge query failed", "error", err)
+		return
+	}
+	for _, row := range rows.Rows {
+		imageID := strings.TrimSpace(queryRowString(row, "resource_uri"))
+		vulnID := gcpContainerVulnerabilityNodeIDForRow(row)
+		if imageID == "" || vulnID == "" {
+			continue
+		}
+		if _, ok := b.graph.GetNode(imageID); !ok {
+			b.graph.AddNode(gcpArtifactRegistryImageFallbackNode(row))
+		}
+		severity := firstNonEmpty(queryRowString(row, "effective_severity"), queryRowString(row, "severity"))
+		b.addEdgeIfMissing(&Edge{
+			ID:     imageID + "->" + vulnID + ":affected_by",
+			Source: imageID,
+			Target: vulnID,
+			Kind:   EdgeKindAffectedBy,
+			Effect: EdgeEffectAllow,
+			Risk:   vulnerabilityRiskFromSeverity(severity),
+			Properties: map[string]any{
+				"source_table":         "gcp_container_vulnerabilities",
+				"occurrence_id":        queryRow(row, "_cq_id"),
+				"project_id":           queryRow(row, "project_id"),
+				"cve_id":               queryRow(row, "cve_id"),
+				"severity":             queryRow(row, "severity"),
+				"effective_severity":   queryRow(row, "effective_severity"),
+				"cvss_score":           queryRow(row, "cvss_score"),
+				"cvss_v3_score":        queryRow(row, "cvss_v3_score"),
+				"fix_available":        queryRow(row, "fix_available"),
+				"package_issue":        queryRow(row, "package_issue"),
+				"relationship_context": "container_image_vulnerability",
+			},
+		})
+	}
+}
+
+func gcpArtifactRegistryImageFallbackNode(row map[string]any) *Node {
+	uri := strings.TrimSpace(queryRowString(row, "resource_uri"))
+	return &Node{
+		ID:       uri,
+		Kind:     NodeKindPackage,
+		Name:     uri,
+		Provider: "gcp",
+		Account:  queryRowString(row, "project_id"),
+		Risk:     vulnerabilityRiskFromSeverity(firstNonEmpty(queryRowString(row, "effective_severity"), queryRowString(row, "severity"))),
+		Properties: map[string]any{
+			"source_table":               "gcp_container_vulnerabilities",
+			"project_id":                 queryRow(row, "project_id"),
+			"uri":                        uri,
+			"package_manager":            "gcp_artifact_registry",
+			"asset_support_entity_kind":  "container_image",
+			"artifact_registry_image_id": uri,
+		},
+	}
+}
+
+func gcpArtifactRegistryImageNodeID(row map[string]any) string {
+	return firstNonEmpty(queryRowString(row, "uri"), queryRowString(row, "_cq_id"), queryRowString(row, "name"))
+}
+
+func gcpContainerVulnerabilityNodeIDForRow(row map[string]any) string {
+	return vulnerabilityNodeIDWithFallback(queryRowString(row, "cve_id"), "gcp_container_vulnerability", queryRowString(row, "_cq_id"))
+}
+
+func gcpArtifactRegistryImageRisk(row map[string]any) RiskLevel {
+	if toBool(queryRow(row, "has_openssl_vulnerability")) {
+		return RiskHigh
+	}
+	if toBool(queryRow(row, "has_vulnerabilities")) {
+		return RiskMedium
+	}
+	return RiskNone
 }

--- a/internal/graph/builders/builder_gcp_vulnerability_test.go
+++ b/internal/graph/builders/builder_gcp_vulnerability_test.go
@@ -1,0 +1,117 @@
+package builders
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestBuilderBuildsGCPContainerVulnerabilityGraph(t *testing.T) {
+	ctx := context.Background()
+	source := newMockDataSource()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	imageURI := "us-central1-docker.pkg.dev/project-1/repo-1/team/app@sha256:abcd"
+	source.setResult(`SELECT _cq_id, project_id, name, uri, tags, image_size, upload_time, media_type, build_time, update_time, repository, registry_type, scanned, scan_status, vulnerabilities, has_vulnerabilities, has_openssl_vulnerability FROM gcp_artifact_registry_images`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"_cq_id":                    imageURI,
+			"project_id":                "project-1",
+			"name":                      "projects/project-1/locations/us-central1/repositories/repo-1/dockerImages/team/app@sha256:abcd",
+			"uri":                       imageURI,
+			"repository":                "projects/project-1/locations/us-central1/repositories/repo-1",
+			"registry_type":             "artifact_registry",
+			"scanned":                   true,
+			"scan_status":               "complete",
+			"has_vulnerabilities":       true,
+			"has_openssl_vulnerability": false,
+		}},
+	})
+	source.setResult(`SELECT _cq_id, project_id, name, resource_uri, note_name, kind, create_time, update_time, severity, cvss_score, cvss_v3_score, effective_severity, fix_available, long_description, short_description, cve_id, package_issue FROM gcp_container_vulnerabilities`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"_cq_id":             "occ-1",
+			"project_id":         "project-1",
+			"name":               "occ-1",
+			"resource_uri":       imageURI,
+			"note_name":          "projects/goog-vulnz/notes/CVE-2026-0001",
+			"kind":               "VULNERABILITY",
+			"severity":           "HIGH",
+			"effective_severity": "HIGH",
+			"cvss_score":         8.8,
+			"cvss_v3_score":      8.8,
+			"fix_available":      true,
+			"cve_id":             "CVE-2026-0001",
+			"package_issue":      "openssl",
+		}},
+	})
+	source.setResult(`SELECT _cq_id, project_id, name, resource_uri, severity, cvss_score, cvss_v3_score, effective_severity, fix_available, cve_id, package_issue FROM gcp_container_vulnerabilities`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"_cq_id":             "occ-1",
+			"project_id":         "project-1",
+			"name":               "occ-1",
+			"resource_uri":       imageURI,
+			"severity":           "HIGH",
+			"effective_severity": "HIGH",
+			"cvss_score":         8.8,
+			"cvss_v3_score":      8.8,
+			"fix_available":      true,
+			"cve_id":             "CVE-2026-0001",
+			"package_issue":      "openssl",
+		}},
+	})
+
+	builder := NewBuilder(source, logger)
+	if err := builder.Build(ctx); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	g := builder.Graph()
+
+	vulnID := "vulnerability:cve-2026-0001"
+	for _, expected := range []struct {
+		id   string
+		kind NodeKind
+	}{
+		{imageURI, NodeKindPackage},
+		{vulnID, NodeKindVulnerability},
+	} {
+		node, ok := g.GetNode(expected.id)
+		if !ok {
+			t.Fatalf("expected node %s", expected.id)
+		}
+		if node.Kind != expected.kind {
+			t.Fatalf("node %s kind = %s, want %s", expected.id, node.Kind, expected.kind)
+		}
+		if node.Provider != "gcp" {
+			t.Fatalf("node %s provider = %q, want gcp", expected.id, node.Provider)
+		}
+	}
+
+	assertEdgeExists(t, g, imageURI, vulnID, EdgeKindAffectedBy)
+}
+
+func TestGCPContainerVulnerabilityCDCEventToNode(t *testing.T) {
+	node := cdcEventToNode("gcp_container_vulnerabilities", cdcEvent{
+		TableName:  "gcp_container_vulnerabilities",
+		ResourceID: "occ-1",
+		Provider:   "gcp",
+		Payload: map[string]any{
+			"_cq_id":             "occ-1",
+			"project_id":         "project-1",
+			"resource_uri":       "us-central1-docker.pkg.dev/project-1/repo-1/team/app@sha256:abcd",
+			"effective_severity": "HIGH",
+			"cve_id":             "CVE-2026-0001",
+		},
+	})
+	if node == nil {
+		t.Fatal("expected GCP vulnerability CDC node")
+	}
+	if node.ID != "vulnerability:cve-2026-0001" {
+		t.Fatalf("node ID = %q", node.ID)
+	}
+	if node.Kind != NodeKindVulnerability {
+		t.Fatalf("node kind = %s, want vulnerability", node.Kind)
+	}
+	if node.Risk != RiskHigh {
+		t.Fatalf("node risk = %s, want high", node.Risk)
+	}
+}

--- a/internal/graph/builders/builder_github.go
+++ b/internal/graph/builders/builder_github.go
@@ -261,10 +261,7 @@ func githubDependabotPackageNodeID(row map[string]any) string {
 
 func githubDependabotVulnerabilityNodeIDForRow(row map[string]any) string {
 	identifier := firstNonEmpty(strings.TrimSpace(queryRowString(row, "cve_id")), strings.TrimSpace(queryRowString(row, "ghsa_id")))
-	if identifier == "" {
-		return ""
-	}
-	return "vulnerability:" + slugifyKnowledgeKey(identifier)
+	return canonicalVulnerabilityNodeID(identifier)
 }
 
 func githubRepositoryRisk(row map[string]any) RiskLevel {
@@ -278,16 +275,5 @@ func githubRepositoryRisk(row map[string]any) RiskLevel {
 }
 
 func githubDependabotRisk(row map[string]any) RiskLevel {
-	switch strings.ToLower(strings.TrimSpace(queryRowString(row, "severity"))) {
-	case "critical":
-		return RiskCritical
-	case "high":
-		return RiskHigh
-	case "medium", "moderate":
-		return RiskMedium
-	case "low":
-		return RiskLow
-	default:
-		return RiskNone
-	}
+	return vulnerabilityRiskFromSeverity(queryRowString(row, "severity"))
 }

--- a/internal/graph/builders/builder_kandji.go
+++ b/internal/graph/builders/builder_kandji.go
@@ -1,0 +1,293 @@
+package builders
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func (b *Builder) buildKandjiNodes(ctx context.Context) {
+	queries := []nodeQuery{
+		{
+			table: "kandji_devices",
+			query: `SELECT device_id, device_name, serial_number, platform, os_version, last_check_in, user_name, user_email, asset_tag, blueprint_name, mdm_enabled, agent_installed, is_supervised, filevault_enabled, firewall_enabled, remote_desktop_enabled, screen_sharing_enabled, gatekeeper_enabled, sip_enabled FROM kandji_devices`,
+			parse: parseKandjiDeviceNodes,
+		},
+		{
+			table: "kandji_device_apps",
+			query: `SELECT device_id, app_name, bundle_id, version, path FROM kandji_device_apps`,
+			parse: parseKandjiDeviceAppNodes,
+		},
+		{
+			table: "kandji_vulnerabilities",
+			query: `SELECT cve_id, device_id, device_name, device_serial_number, software_name, software_version, cvss_score, cvss_severity, first_detection_date, latest_detection_date, cve_link FROM kandji_vulnerabilities`,
+			parse: parseKandjiVulnerabilityNodes,
+		},
+	}
+
+	b.runNodeQueries(ctx, queries)
+}
+
+func parseKandjiDeviceNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		deviceID := strings.TrimSpace(queryRowString(row, "device_id"))
+		if deviceID == "" {
+			continue
+		}
+		nodes = append(nodes, &Node{
+			ID:       kandjiDeviceNodeID(deviceID),
+			Kind:     NodeKindInstance,
+			Name:     firstNonEmpty(queryRowString(row, "device_name"), queryRowString(row, "serial_number"), deviceID),
+			Provider: "kandji",
+			Account:  firstNonEmpty(queryRowString(row, "blueprint_name"), queryRowString(row, "user_email")),
+			Risk:     kandjiDeviceRisk(row),
+			Properties: map[string]any{
+				"source_table":              "kandji_devices",
+				"device_id":                 deviceID,
+				"device_name":               queryRow(row, "device_name"),
+				"serial_number":             queryRow(row, "serial_number"),
+				"platform":                  queryRow(row, "platform"),
+				"os_version":                queryRow(row, "os_version"),
+				"last_check_in":             queryRow(row, "last_check_in"),
+				"user_name":                 queryRow(row, "user_name"),
+				"user_email":                queryRow(row, "user_email"),
+				"asset_tag":                 queryRow(row, "asset_tag"),
+				"blueprint_name":            queryRow(row, "blueprint_name"),
+				"mdm_enabled":               queryRow(row, "mdm_enabled"),
+				"agent_installed":           queryRow(row, "agent_installed"),
+				"is_supervised":             queryRow(row, "is_supervised"),
+				"filevault_enabled":         queryRow(row, "filevault_enabled"),
+				"firewall_enabled":          queryRow(row, "firewall_enabled"),
+				"remote_desktop_enabled":    queryRow(row, "remote_desktop_enabled"),
+				"screen_sharing_enabled":    queryRow(row, "screen_sharing_enabled"),
+				"gatekeeper_enabled":        queryRow(row, "gatekeeper_enabled"),
+				"sip_enabled":               queryRow(row, "sip_enabled"),
+				"asset_support_entity_kind": "endpoint",
+			},
+		})
+	}
+	return nodes
+}
+
+func parseKandjiDeviceAppNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows))
+	for _, row := range rows {
+		node := kandjiPackageNode(row, "kandji_device_apps")
+		if node != nil {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}
+
+func parseKandjiVulnerabilityNodes(rows []map[string]any) []*Node {
+	nodes := make([]*Node, 0, len(rows)*2)
+	for _, row := range rows {
+		if pkg := kandjiPackageNodeFromVulnerability(row); pkg != nil {
+			nodes = append(nodes, pkg)
+		}
+		node := kandjiVulnerabilityNode(row)
+		if node != nil {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
+}
+
+func kandjiPackageNode(row map[string]any, sourceTable string) *Node {
+	deviceID := strings.TrimSpace(queryRowString(row, "device_id"))
+	name := strings.TrimSpace(queryRowString(row, "app_name"))
+	if name == "" {
+		name = strings.TrimSpace(queryRowString(row, "software_name"))
+	}
+	if deviceID == "" || name == "" {
+		return nil
+	}
+	version := strings.TrimSpace(firstNonEmpty(queryRowString(row, "version"), queryRowString(row, "software_version")))
+	return &Node{
+		ID:       kandjiPackageNodeID(deviceID, name, version),
+		Kind:     NodeKindPackage,
+		Name:     firstNonEmpty(name, "unknown"),
+		Provider: "kandji",
+		Account:  deviceID,
+		Risk:     vulnerabilityRiskFromSeverity(queryRowString(row, "cvss_severity")),
+		Properties: map[string]any{
+			"source_table":              sourceTable,
+			"device_id":                 deviceID,
+			"package_name":              name,
+			"app_name":                  queryRow(row, "app_name"),
+			"software_name":             queryRow(row, "software_name"),
+			"bundle_id":                 queryRow(row, "bundle_id"),
+			"version":                   firstNonEmpty(version, "unknown"),
+			"path":                      queryRow(row, "path"),
+			"package_manager":           "kandji",
+			"asset_support_entity_kind": "package",
+		},
+	}
+}
+
+func kandjiPackageNodeFromVulnerability(row map[string]any) *Node {
+	return kandjiPackageNode(row, "kandji_vulnerabilities")
+}
+
+func kandjiVulnerabilityNode(row map[string]any) *Node {
+	cveID := normalizedVulnerabilityIdentifier(queryRowString(row, "cve_id"))
+	nodeID := kandjiVulnerabilityNodeIDForRow(row)
+	if nodeID == "" {
+		return nil
+	}
+	return &Node{
+		ID:       nodeID,
+		Kind:     NodeKindVulnerability,
+		Name:     firstNonEmpty(cveID, queryRowString(row, "software_name"), nodeID),
+		Provider: "kandji",
+		Account:  firstNonEmpty(queryRowString(row, "device_id"), queryRowString(row, "device_serial_number")),
+		Risk:     vulnerabilityRiskFromSeverity(queryRowString(row, "cvss_severity")),
+		Properties: map[string]any{
+			"source_table":                "kandji_vulnerabilities",
+			"cve_id":                      cveID,
+			"device_id":                   queryRow(row, "device_id"),
+			"device_name":                 queryRow(row, "device_name"),
+			"device_serial_number":        queryRow(row, "device_serial_number"),
+			"software_name":               queryRow(row, "software_name"),
+			"software_version":            queryRow(row, "software_version"),
+			"cvss_score":                  queryRow(row, "cvss_score"),
+			"cvss_severity":               queryRow(row, "cvss_severity"),
+			"first_detection_date":        queryRow(row, "first_detection_date"),
+			"latest_detection_date":       queryRow(row, "latest_detection_date"),
+			"cve_link":                    queryRow(row, "cve_link"),
+			"asset_support_finding":       "kandji_vulnerability",
+			"canonical_vulnerability_id":  nodeID,
+			"vulnerability_observed_from": "kandji",
+		},
+	}
+}
+
+func (b *Builder) buildKandjiEdges(ctx context.Context) {
+	b.buildKandjiDeviceAppEdges(ctx)
+	b.buildKandjiVulnerabilityEdges(ctx)
+}
+
+func (b *Builder) buildKandjiDeviceAppEdges(ctx context.Context) {
+	rows, err := b.queryIfExists(ctx, "kandji_device_apps", `SELECT device_id, app_name, bundle_id, version, path FROM kandji_device_apps`)
+	if err != nil {
+		b.logger.Debug("kandji device app edge query failed", "error", err)
+		return
+	}
+	for _, row := range rows.Rows {
+		deviceID := strings.TrimSpace(queryRowString(row, "device_id"))
+		name := strings.TrimSpace(queryRowString(row, "app_name"))
+		if deviceID == "" || name == "" {
+			continue
+		}
+		deviceNodeID := kandjiDeviceNodeID(deviceID)
+		packageNodeID := kandjiPackageNodeID(deviceID, name, queryRowString(row, "version"))
+		b.addEdgeIfMissing(&Edge{
+			ID:     deviceNodeID + "->" + packageNodeID + ":contains_package",
+			Source: deviceNodeID,
+			Target: packageNodeID,
+			Kind:   EdgeKindContainsPkg,
+			Effect: EdgeEffectAllow,
+			Risk:   RiskNone,
+			Properties: map[string]any{
+				"source_table": "kandji_device_apps",
+				"app_name":     queryRow(row, "app_name"),
+				"bundle_id":    queryRow(row, "bundle_id"),
+				"version":      queryRow(row, "version"),
+				"path":         queryRow(row, "path"),
+			},
+		})
+	}
+}
+
+func (b *Builder) buildKandjiVulnerabilityEdges(ctx context.Context) {
+	rows, err := b.queryIfExists(ctx, "kandji_vulnerabilities", `SELECT cve_id, device_id, device_name, device_serial_number, software_name, software_version, cvss_score, cvss_severity, first_detection_date, latest_detection_date, cve_link FROM kandji_vulnerabilities`)
+	if err != nil {
+		b.logger.Debug("kandji vulnerability edge query failed", "error", err)
+		return
+	}
+	for _, row := range rows.Rows {
+		deviceID := strings.TrimSpace(queryRowString(row, "device_id"))
+		vulnNodeID := kandjiVulnerabilityNodeIDForRow(row)
+		if deviceID == "" || vulnNodeID == "" {
+			continue
+		}
+		deviceNodeID := kandjiDeviceNodeID(deviceID)
+		risk := vulnerabilityRiskFromSeverity(queryRowString(row, "cvss_severity"))
+		b.addEdgeIfMissing(&Edge{
+			ID:         deviceNodeID + "->" + vulnNodeID + ":affected_by",
+			Source:     deviceNodeID,
+			Target:     vulnNodeID,
+			Kind:       EdgeKindAffectedBy,
+			Effect:     EdgeEffectAllow,
+			Risk:       risk,
+			Properties: kandjiVulnerabilityEdgeProperties(row, "endpoint_vulnerability"),
+		})
+		if packageName := strings.TrimSpace(queryRowString(row, "software_name")); packageName != "" {
+			packageNodeID := kandjiPackageNodeID(deviceID, packageName, queryRowString(row, "software_version"))
+			b.addEdgeIfMissing(&Edge{
+				ID:         packageNodeID + "->" + vulnNodeID + ":affected_by",
+				Source:     packageNodeID,
+				Target:     vulnNodeID,
+				Kind:       EdgeKindAffectedBy,
+				Effect:     EdgeEffectAllow,
+				Risk:       risk,
+				Properties: kandjiVulnerabilityEdgeProperties(row, "package_vulnerability"),
+			})
+		}
+	}
+}
+
+func kandjiVulnerabilityEdgeProperties(row map[string]any, context string) map[string]any {
+	return map[string]any{
+		"source_table":          "kandji_vulnerabilities",
+		"cve_id":                queryRow(row, "cve_id"),
+		"software_name":         queryRow(row, "software_name"),
+		"software_version":      queryRow(row, "software_version"),
+		"cvss_score":            queryRow(row, "cvss_score"),
+		"cvss_severity":         queryRow(row, "cvss_severity"),
+		"latest_detection_date": queryRow(row, "latest_detection_date"),
+		"relationship_context":  context,
+	}
+}
+
+func kandjiDeviceNodeID(deviceID string) string {
+	deviceID = strings.TrimSpace(deviceID)
+	if deviceID == "" {
+		return ""
+	}
+	return "kandji_device:" + deviceID
+}
+
+func kandjiPackageNodeID(deviceID, name, version string) string {
+	deviceID = strings.TrimSpace(deviceID)
+	name = strings.TrimSpace(name)
+	if deviceID == "" || name == "" {
+		return ""
+	}
+	return "kandji_package:" + slugifyKnowledgeKey(fmt.Sprintf("%s|%s|%s", deviceID, name, firstNonEmpty(version, "unknown")))
+}
+
+func kandjiVulnerabilityNodeIDForRow(row map[string]any) string {
+	deviceID := strings.TrimSpace(queryRowString(row, "device_id"))
+	cveID := strings.TrimSpace(queryRowString(row, "cve_id"))
+	fallback := ""
+	if deviceID != "" && cveID != "" {
+		fallback = deviceID + "|" + cveID
+	}
+	return vulnerabilityNodeIDWithFallback(queryRowString(row, "cve_id"), "kandji_vulnerability", fallback)
+}
+
+func kandjiDeviceRisk(row map[string]any) RiskLevel {
+	if toBool(queryRow(row, "remote_desktop_enabled")) || toBool(queryRow(row, "screen_sharing_enabled")) {
+		return RiskMedium
+	}
+	for _, key := range []string{"mdm_enabled", "agent_installed", "filevault_enabled", "firewall_enabled", "gatekeeper_enabled", "sip_enabled"} {
+		value, ok := queryRowValue(row, key)
+		if ok && !toBool(value) {
+			return RiskLow
+		}
+	}
+	return RiskNone
+}

--- a/internal/graph/builders/builder_kandji_test.go
+++ b/internal/graph/builders/builder_kandji_test.go
@@ -1,0 +1,113 @@
+package builders
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestBuilderBuildsKandjiVulnerabilityGraph(t *testing.T) {
+	ctx := context.Background()
+	source := newMockDataSource()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	source.setResult(`SELECT device_id, device_name, serial_number, platform, os_version, last_check_in, user_name, user_email, asset_tag, blueprint_name, mdm_enabled, agent_installed, is_supervised, filevault_enabled, firewall_enabled, remote_desktop_enabled, screen_sharing_enabled, gatekeeper_enabled, sip_enabled FROM kandji_devices`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"device_id":          "device-1",
+			"device_name":        "mac-1",
+			"serial_number":      "serial-1",
+			"platform":           "macOS",
+			"os_version":         "15.1",
+			"user_email":         "owner@example.com",
+			"mdm_enabled":        true,
+			"agent_installed":    true,
+			"filevault_enabled":  true,
+			"firewall_enabled":   true,
+			"gatekeeper_enabled": true,
+			"sip_enabled":        true,
+		}},
+	})
+	source.setResult(`SELECT device_id, app_name, bundle_id, version, path FROM kandji_device_apps`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"device_id": "device-1",
+			"app_name":  "Chrome",
+			"bundle_id": "com.google.Chrome",
+			"version":   "1.2.3",
+			"path":      "/Applications/Chrome.app",
+		}},
+	})
+	source.setResult(`SELECT cve_id, device_id, device_name, device_serial_number, software_name, software_version, cvss_score, cvss_severity, first_detection_date, latest_detection_date, cve_link FROM kandji_vulnerabilities`, &DataQueryResult{
+		Rows: []map[string]any{{
+			"cve_id":               "CVE-2026-0001",
+			"device_id":            "device-1",
+			"device_name":          "mac-1",
+			"device_serial_number": "serial-1",
+			"software_name":        "Chrome",
+			"software_version":     "1.2.3",
+			"cvss_score":           8.8,
+			"cvss_severity":        "HIGH",
+		}},
+	})
+
+	builder := NewBuilder(source, logger)
+	if err := builder.Build(ctx); err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	g := builder.Graph()
+
+	deviceID := kandjiDeviceNodeID("device-1")
+	packageID := kandjiPackageNodeID("device-1", "Chrome", "1.2.3")
+	vulnID := "vulnerability:cve-2026-0001"
+
+	for _, expected := range []struct {
+		id   string
+		kind NodeKind
+	}{
+		{deviceID, NodeKindInstance},
+		{packageID, NodeKindPackage},
+		{vulnID, NodeKindVulnerability},
+	} {
+		node, ok := g.GetNode(expected.id)
+		if !ok {
+			t.Fatalf("expected node %s", expected.id)
+		}
+		if node.Kind != expected.kind {
+			t.Fatalf("node %s kind = %s, want %s", expected.id, node.Kind, expected.kind)
+		}
+		if node.Provider != "kandji" {
+			t.Fatalf("node %s provider = %q, want kandji", expected.id, node.Provider)
+		}
+	}
+
+	assertEdgeExists(t, g, deviceID, packageID, EdgeKindContainsPkg)
+	assertEdgeExists(t, g, deviceID, vulnID, EdgeKindAffectedBy)
+	assertEdgeExists(t, g, packageID, vulnID, EdgeKindAffectedBy)
+}
+
+func TestKandjiCDCEventToNode(t *testing.T) {
+	node := cdcEventToNode("kandji_vulnerabilities", cdcEvent{
+		TableName:  "kandji_vulnerabilities",
+		ResourceID: "device-1|CVE-2026-0001",
+		Provider:   "kandji",
+		Payload: map[string]any{
+			"cve_id":           "CVE-2026-0001",
+			"device_id":        "device-1",
+			"software_name":    "Chrome",
+			"software_version": "1.2.3",
+			"cvss_severity":    "HIGH",
+		},
+	})
+	if node == nil {
+		t.Fatal("expected Kandji vulnerability CDC node")
+	}
+	if node.ID != "vulnerability:cve-2026-0001" {
+		t.Fatalf("node ID = %q", node.ID)
+	}
+	if node.Kind != NodeKindVulnerability {
+		t.Fatalf("node kind = %s, want vulnerability", node.Kind)
+	}
+	if node.Risk != RiskHigh {
+		t.Fatalf("node risk = %s, want high", node.Risk)
+	}
+}

--- a/internal/graph/builders/builder_sentinelone.go
+++ b/internal/graph/builders/builder_sentinelone.go
@@ -560,14 +560,7 @@ func sentinelOneVulnerabilityNodeID(id string) string {
 }
 
 func sentinelOneVulnerabilityNodeIDForRow(row map[string]any) string {
-	if cveID := strings.TrimSpace(queryRowString(row, "cve_id")); cveID != "" {
-		return "vulnerability:" + slugifyKnowledgeKey(cveID)
-	}
-	id := strings.TrimSpace(queryRowString(row, "id"))
-	if id == "" {
-		return ""
-	}
-	return sentinelOneVulnerabilityNodeID(id)
+	return vulnerabilityNodeIDWithFallback(queryRowString(row, "cve_id"), "sentinelone_vulnerability", queryRowString(row, "id"))
 }
 
 func sentinelOneApplicationMatchKey(agentID, name, version string) string {
@@ -594,18 +587,7 @@ func sentinelOneAgentRisk(row map[string]any) RiskLevel {
 }
 
 func sentinelOneApplicationRisk(row map[string]any) RiskLevel {
-	switch strings.ToLower(strings.TrimSpace(queryRowString(row, "risk_level"))) {
-	case "critical":
-		return RiskCritical
-	case "high":
-		return RiskHigh
-	case "medium":
-		return RiskMedium
-	case "low":
-		return RiskLow
-	default:
-		return RiskNone
-	}
+	return vulnerabilityRiskFromSeverity(queryRowString(row, "risk_level"))
 }
 
 func sentinelOneThreatRisk(row map[string]any) RiskLevel {
@@ -621,16 +603,5 @@ func sentinelOneThreatRisk(row map[string]any) RiskLevel {
 }
 
 func sentinelOneSeverityRisk(severity string) RiskLevel {
-	switch strings.ToLower(strings.TrimSpace(severity)) {
-	case "critical":
-		return RiskCritical
-	case "high":
-		return RiskHigh
-	case "medium":
-		return RiskMedium
-	case "low":
-		return RiskLow
-	default:
-		return RiskNone
-	}
+	return vulnerabilityRiskFromSeverity(severity)
 }

--- a/internal/graph/builders/builder_vulnerability.go
+++ b/internal/graph/builders/builder_vulnerability.go
@@ -1,0 +1,42 @@
+package builders
+
+import "strings"
+
+func canonicalVulnerabilityNodeID(identifier string) string {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return ""
+	}
+	return "vulnerability:" + slugifyKnowledgeKey(identifier)
+}
+
+func vulnerabilityNodeIDWithFallback(identifier, fallbackPrefix, fallbackID string) string {
+	if id := canonicalVulnerabilityNodeID(identifier); id != "" {
+		return id
+	}
+	fallbackPrefix = strings.TrimSuffix(strings.TrimSpace(fallbackPrefix), ":")
+	fallbackID = strings.TrimSpace(fallbackID)
+	if fallbackPrefix == "" || fallbackID == "" {
+		return ""
+	}
+	return fallbackPrefix + ":" + fallbackID
+}
+
+func normalizedVulnerabilityIdentifier(identifier string) string {
+	return strings.ToUpper(strings.TrimSpace(identifier))
+}
+
+func vulnerabilityRiskFromSeverity(severity string) RiskLevel {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical":
+		return RiskCritical
+	case "high":
+		return RiskHigh
+	case "medium", "moderate":
+		return RiskMedium
+	case "low":
+		return RiskLow
+	default:
+		return RiskNone
+	}
+}

--- a/internal/sync/relationships.go
+++ b/internal/sync/relationships.go
@@ -969,6 +969,38 @@ func gcpArtifactPackageIDFromImage(imageName string) string {
 	return fmt.Sprintf("%s/packages/%s", repoID, imageRef)
 }
 
+func canonicalVulnerabilityRelationshipID(identifier, fallback string) string {
+	identifier = strings.TrimSpace(identifier)
+	if identifier != "" {
+		return "vulnerability:" + slugifyRelationshipIdentifier(identifier)
+	}
+	return normalizeRelationshipID(fallback)
+}
+
+func slugifyRelationshipIdentifier(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastDash = false
+		case !lastDash:
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "unknown"
+	}
+	return out
+}
+
 func gcpSCCFindingID(cqID, name string) string {
 	if id := normalizeRelationshipID(cqID); id != "" {
 		return id

--- a/internal/sync/relationships_gcp.go
+++ b/internal/sync/relationships_gcp.go
@@ -1077,7 +1077,10 @@ func (r *RelationshipExtractor) extractGCPRelationships(ctx context.Context) (in
 	} else if ok {
 		for _, row := range result.Rows {
 			imageID := gcpArtifactImageID(toString(queryRow(row, "resource_uri")), "", "")
-			vulnID := normalizeRelationshipID(toString(queryRow(row, "_cq_id")))
+			vulnID := canonicalVulnerabilityRelationshipID(
+				toString(queryRow(row, "cve_id")),
+				toString(queryRow(row, "_cq_id")),
+			)
 			if imageID == "" || vulnID == "" {
 				continue
 			}

--- a/internal/sync/relationships_test.go
+++ b/internal/sync/relationships_test.go
@@ -729,6 +729,15 @@ func TestGCPArtifactImageRelationshipHelpers(t *testing.T) {
 	}
 }
 
+func TestCanonicalVulnerabilityRelationshipID(t *testing.T) {
+	if got := canonicalVulnerabilityRelationshipID("CVE-2026-0001", "occ-1"); got != "vulnerability:cve-2026-0001" {
+		t.Fatalf("unexpected canonical vulnerability id: %s", got)
+	}
+	if got := canonicalVulnerabilityRelationshipID("", "occ-1"); got != "occ-1" {
+		t.Fatalf("unexpected fallback vulnerability id: %s", got)
+	}
+}
+
 func TestPersistRelationships_UsesRunSyncTimeForFreshWrites(t *testing.T) {
 	originalSchema := relationshipSchemaName
 	originalBatch := relationshipQueryBatch


### PR DESCRIPTION
## Summary
- add shared canonical vulnerability graph helpers
- materialize Kandji devices/packages/CVEs with endpoint/package affected_by links
- materialize GCP Artifact Registry image CVEs with canonical vulnerability nodes and affected_by links
- canonicalize GCP vulnerability relationship targets for resource_relationships

## Validation
- GOFLAGS=-mod=mod go test ./internal/graph/builders ./internal/sync
- GOFLAGS=-mod=mod go test ./...
- commit hooks: go vet, staged package tests, golangci-lint fast checks, contract compatibility, graph guardrails