### PR TITLE
Canonicalize CVE projections

### DIFF
--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -465,30 +465,30 @@ func TestRebuildDryRunProjectsDependabotAlertGraph(t *testing.T) {
 	if result.EventsRead != 1 {
 		t.Fatalf("EventsRead = %d, want 1", result.EventsRead)
 	}
-	if result.EntitiesProjected != 6 {
-		t.Fatalf("EntitiesProjected = %d, want 6", result.EntitiesProjected)
+	if result.EntitiesProjected != 7 {
+		t.Fatalf("EntitiesProjected = %d, want 7", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 6 {
-		t.Fatalf("LinksProjected = %d, want 6", result.LinksProjected)
+	if result.LinksProjected != 8 {
+		t.Fatalf("LinksProjected = %d, want 8", result.LinksProjected)
 	}
-	if result.GraphNodes != 6 {
-		t.Fatalf("GraphNodes = %d, want 6", result.GraphNodes)
+	if result.GraphNodes != 7 {
+		t.Fatalf("GraphNodes = %d, want 7", result.GraphNodes)
 	}
-	if result.GraphLinks != 6 {
-		t.Fatalf("GraphLinks = %d, want 6", result.GraphLinks)
+	if result.GraphLinks != 8 {
+		t.Fatalf("GraphLinks = %d, want 8", result.GraphLinks)
 	}
 	if len(result.EventProjections) != 1 {
 		t.Fatalf("len(EventProjections) = %d, want 1", len(result.EventProjections))
 	}
-	assertEventProjection(t, result.EventProjections[0], "github-dependabot-alert-1", "github.dependabot_alert", 6, 6, 6, 6)
+	assertEventProjection(t, result.EventProjections[0], "github-dependabot-alert-1", "github.dependabot_alert", 7, 8, 7, 8)
 	if got := countValue(result.GraphEntityTypes, "github.dependabot_alert"); got != 1 {
 		t.Fatalf("graph entity type github.dependabot_alert = %d, want 1", got)
 	}
 	if got := countValue(result.GraphEntityTypes, "github.security_advisory"); got != 1 {
 		t.Fatalf("graph entity type github.security_advisory = %d, want 1", got)
 	}
-	if got := countValue(result.GraphEntityTypes, "package"); got != 1 {
-		t.Fatalf("graph entity type package = %d, want 1", got)
+	if got := countValue(result.GraphEntityTypes, "package"); got != 2 {
+		t.Fatalf("graph entity type package = %d, want 2", got)
 	}
 	if got := countValue(result.GraphEntityTypes, "vulnerability"); got != 1 {
 		t.Fatalf("graph entity type vulnerability = %d, want 1", got)
@@ -496,15 +496,19 @@ func TestRebuildDryRunProjectsDependabotAlertGraph(t *testing.T) {
 	if got := countValue(result.GraphRelationTypes, "belongs_to"); got != 2 {
 		t.Fatalf("graph relation type belongs_to = %d, want 2", got)
 	}
-	if got := countValue(result.GraphRelationTypes, "affected_by"); got != 3 {
-		t.Fatalf("graph relation type affected_by = %d, want 3", got)
+	if got := countValue(result.GraphRelationTypes, "affected_by"); got != 4 {
+		t.Fatalf("graph relation type affected_by = %d, want 4", got)
 	}
 	if got := countValue(result.GraphRelationTypes, "affects"); got != 1 {
 		t.Fatalf("graph relation type affects = %d, want 1", got)
 	}
+	if got := countValue(result.GraphRelationTypes, "represents"); got != 1 {
+		t.Fatalf("graph relation type represents = %d, want 1", got)
+	}
 	alertURN := "urn:cerebro:writer-dogfood:github_dependabot_alert:writer/cerebro:5"
 	advisoryURN := "urn:cerebro:writer-dogfood:github_advisory:GHSA-1234-5678-90ab"
 	packageURN := "urn:cerebro:writer-dogfood:package:gomod:golang.org/x/net"
+	canonicalPackageURN := "urn:cerebro:writer-dogfood:package:canonical:golang.org/x/net"
 	vulnerabilityURN := "urn:cerebro:writer-dogfood:vulnerability:ghsa-1234-5678-90ab"
 	if !containsEntityURN(result.PreviewEntities, alertURN) {
 		t.Fatalf("PreviewEntities missing Dependabot alert: %#v", result.PreviewEntities)
@@ -518,6 +522,9 @@ func TestRebuildDryRunProjectsDependabotAlertGraph(t *testing.T) {
 	if !containsEntityURN(result.PreviewEntities, vulnerabilityURN) {
 		t.Fatalf("PreviewEntities missing canonical vulnerability: %#v", result.PreviewEntities)
 	}
+	if !containsEntityURN(result.PreviewEntities, canonicalPackageURN) {
+		t.Fatalf("PreviewEntities missing canonical package: %#v", result.PreviewEntities)
+	}
 	if !containsLink(result.PreviewLinks, alertURN, "affected_by", advisoryURN) {
 		t.Fatalf("PreviewLinks missing advisory relation: %#v", result.PreviewLinks)
 	}
@@ -529,6 +536,12 @@ func TestRebuildDryRunProjectsDependabotAlertGraph(t *testing.T) {
 	}
 	if !containsLink(result.PreviewLinks, packageURN, "affected_by", vulnerabilityURN) {
 		t.Fatalf("PreviewLinks missing package vulnerability relation: %#v", result.PreviewLinks)
+	}
+	if !containsLink(result.PreviewLinks, packageURN, "represents", canonicalPackageURN) {
+		t.Fatalf("PreviewLinks missing package identity relation: %#v", result.PreviewLinks)
+	}
+	if !containsLink(result.PreviewLinks, canonicalPackageURN, "affected_by", vulnerabilityURN) {
+		t.Fatalf("PreviewLinks missing canonical package vulnerability relation: %#v", result.PreviewLinks)
 	}
 }
 

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -465,22 +465,22 @@ func TestRebuildDryRunProjectsDependabotAlertGraph(t *testing.T) {
 	if result.EventsRead != 1 {
 		t.Fatalf("EventsRead = %d, want 1", result.EventsRead)
 	}
-	if result.EntitiesProjected != 5 {
-		t.Fatalf("EntitiesProjected = %d, want 5", result.EntitiesProjected)
+	if result.EntitiesProjected != 6 {
+		t.Fatalf("EntitiesProjected = %d, want 6", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 4 {
-		t.Fatalf("LinksProjected = %d, want 4", result.LinksProjected)
+	if result.LinksProjected != 6 {
+		t.Fatalf("LinksProjected = %d, want 6", result.LinksProjected)
 	}
-	if result.GraphNodes != 5 {
-		t.Fatalf("GraphNodes = %d, want 5", result.GraphNodes)
+	if result.GraphNodes != 6 {
+		t.Fatalf("GraphNodes = %d, want 6", result.GraphNodes)
 	}
-	if result.GraphLinks != 4 {
-		t.Fatalf("GraphLinks = %d, want 4", result.GraphLinks)
+	if result.GraphLinks != 6 {
+		t.Fatalf("GraphLinks = %d, want 6", result.GraphLinks)
 	}
 	if len(result.EventProjections) != 1 {
 		t.Fatalf("len(EventProjections) = %d, want 1", len(result.EventProjections))
 	}
-	assertEventProjection(t, result.EventProjections[0], "github-dependabot-alert-1", "github.dependabot_alert", 5, 4, 5, 4)
+	assertEventProjection(t, result.EventProjections[0], "github-dependabot-alert-1", "github.dependabot_alert", 6, 6, 6, 6)
 	if got := countValue(result.GraphEntityTypes, "github.dependabot_alert"); got != 1 {
 		t.Fatalf("graph entity type github.dependabot_alert = %d, want 1", got)
 	}
@@ -490,11 +490,14 @@ func TestRebuildDryRunProjectsDependabotAlertGraph(t *testing.T) {
 	if got := countValue(result.GraphEntityTypes, "package"); got != 1 {
 		t.Fatalf("graph entity type package = %d, want 1", got)
 	}
+	if got := countValue(result.GraphEntityTypes, "vulnerability"); got != 1 {
+		t.Fatalf("graph entity type vulnerability = %d, want 1", got)
+	}
 	if got := countValue(result.GraphRelationTypes, "belongs_to"); got != 2 {
 		t.Fatalf("graph relation type belongs_to = %d, want 2", got)
 	}
-	if got := countValue(result.GraphRelationTypes, "affected_by"); got != 1 {
-		t.Fatalf("graph relation type affected_by = %d, want 1", got)
+	if got := countValue(result.GraphRelationTypes, "affected_by"); got != 3 {
+		t.Fatalf("graph relation type affected_by = %d, want 3", got)
 	}
 	if got := countValue(result.GraphRelationTypes, "affects"); got != 1 {
 		t.Fatalf("graph relation type affects = %d, want 1", got)
@@ -502,6 +505,7 @@ func TestRebuildDryRunProjectsDependabotAlertGraph(t *testing.T) {
 	alertURN := "urn:cerebro:writer-dogfood:github_dependabot_alert:writer/cerebro:5"
 	advisoryURN := "urn:cerebro:writer-dogfood:github_advisory:GHSA-1234-5678-90ab"
 	packageURN := "urn:cerebro:writer-dogfood:package:gomod:golang.org/x/net"
+	vulnerabilityURN := "urn:cerebro:writer-dogfood:vulnerability:ghsa-1234-5678-90ab"
 	if !containsEntityURN(result.PreviewEntities, alertURN) {
 		t.Fatalf("PreviewEntities missing Dependabot alert: %#v", result.PreviewEntities)
 	}
@@ -511,11 +515,20 @@ func TestRebuildDryRunProjectsDependabotAlertGraph(t *testing.T) {
 	if !containsEntityURN(result.PreviewEntities, packageURN) {
 		t.Fatalf("PreviewEntities missing package: %#v", result.PreviewEntities)
 	}
+	if !containsEntityURN(result.PreviewEntities, vulnerabilityURN) {
+		t.Fatalf("PreviewEntities missing canonical vulnerability: %#v", result.PreviewEntities)
+	}
 	if !containsLink(result.PreviewLinks, alertURN, "affected_by", advisoryURN) {
 		t.Fatalf("PreviewLinks missing advisory relation: %#v", result.PreviewLinks)
 	}
 	if !containsLink(result.PreviewLinks, alertURN, "affects", packageURN) {
 		t.Fatalf("PreviewLinks missing package relation: %#v", result.PreviewLinks)
+	}
+	if !containsLink(result.PreviewLinks, alertURN, "affected_by", vulnerabilityURN) {
+		t.Fatalf("PreviewLinks missing canonical vulnerability relation: %#v", result.PreviewLinks)
+	}
+	if !containsLink(result.PreviewLinks, packageURN, "affected_by", vulnerabilityURN) {
+		t.Fatalf("PreviewLinks missing package vulnerability relation: %#v", result.PreviewLinks)
 	}
 }
 

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -27,6 +27,7 @@ const (
 	relationCanAdmin           = "can_admin"
 	relationCanImpersonate     = "can_impersonate"
 	relationCanReach           = "can_reach"
+	relationContains           = "contains"
 	relationHasClassification  = "has_classification"
 	relationHasEvidence        = "has_evidence"
 	relationMemberOf           = "member_of"
@@ -320,6 +321,7 @@ func githubDependabotAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 	packageName := strings.TrimSpace(attributes["package"])
 	ecosystem := strings.TrimSpace(attributes["ecosystem"])
 	advisoryID := firstNonEmpty(attributes["advisory_ghsa_id"], attributes["advisory_cve_id"])
+	vulnerabilityID := firstNonEmpty(canonicalVulnerabilityIdentifier(attributes), advisoryID)
 
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
@@ -368,7 +370,7 @@ func githubDependabotAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 				"repository":         repository,
 				"severity":           strings.TrimSpace(attributes["severity"]),
 				"state":              strings.TrimSpace(attributes["state"]),
-				"vulnerability_id":   advisoryID,
+				"vulnerability_id":   vulnerabilityID,
 				"vulnerability_type": "dependabot",
 			},
 		})
@@ -411,6 +413,17 @@ func githubDependabotAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 		})
 		if alertURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, packageURN, relationAffects, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+
+	vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), attributes)
+	if vulnerabilityURN != "" {
+		evidenceAttributes := vulnerabilityEvidenceAttributes(event, attributes)
+		if alertURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, vulnerabilityURN, relationAffectedBy, evidenceAttributes))
+		}
+		if packageURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, vulnerabilityURN, relationAffectedBy, evidenceAttributes))
 		}
 	}
 

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -33,6 +33,7 @@ const (
 	relationMemberOf           = "member_of"
 	relationObservedOn         = "observed_on"
 	relationOwnedBy            = "owned_by"
+	relationRepresents         = "represents"
 	relationRepresentsIdentity = "represents_identity"
 	relationRunsAs             = "runs_as"
 	relationSupports           = "supports"
@@ -417,6 +418,7 @@ func githubDependabotAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 	}
 
 	vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), attributes)
+	canonicalPackageURN := addCanonicalPackageEntity(entities, tenantID, event.GetSourceId(), attributes, ecosystem)
 	if vulnerabilityURN != "" {
 		evidenceAttributes := vulnerabilityEvidenceAttributes(event, attributes)
 		if alertURN != "" {
@@ -425,6 +427,12 @@ func githubDependabotAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 		if packageURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, vulnerabilityURN, relationAffectedBy, evidenceAttributes))
 		}
+		if canonicalPackageURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), canonicalPackageURN, vulnerabilityURN, relationAffectedBy, evidenceAttributes))
+		}
+	}
+	if packageURN != "" && canonicalPackageURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, canonicalPackageURN, relationRepresents, packageIdentityAttributes(event, attributes, ecosystem)))
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -164,17 +164,18 @@ func TestProjectGitHubDependabotAlert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 6 {
-		t.Fatalf("Project().EntitiesProjected = %d, want 6", result.EntitiesProjected)
+	if result.EntitiesProjected != 7 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 7", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 6 {
-		t.Fatalf("Project().LinksProjected = %d, want 6", result.LinksProjected)
+	if result.LinksProjected != 8 {
+		t.Fatalf("Project().LinksProjected = %d, want 8", result.LinksProjected)
 	}
 
 	alertURN := "urn:cerebro:writer:github_dependabot_alert:writer/cerebro:7"
 	repoURN := "urn:cerebro:writer:github_repo:writer/cerebro"
 	advisoryURN := "urn:cerebro:writer:github_advisory:GHSA-xxxx-yyyy-zzzz"
 	packageURN := "urn:cerebro:writer:package:go:golang.org/x/crypto"
+	canonicalPackageURN := "urn:cerebro:writer:package:canonical:golang.org/x/crypto"
 	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2025-12345"
 	if _, ok := state.entities[alertURN]; !ok {
 		t.Fatalf("state entity %q missing", alertURN)
@@ -196,6 +197,12 @@ func TestProjectGitHubDependabotAlert(t *testing.T) {
 	}
 	if _, ok := state.links[packageURN+"|"+relationAffectedBy+"|"+vulnerabilityURN]; !ok {
 		t.Fatal("package canonical vulnerability link missing")
+	}
+	if _, ok := state.links[packageURN+"|"+relationRepresents+"|"+canonicalPackageURN]; !ok {
+		t.Fatal("package canonical identity link missing")
+	}
+	if _, ok := state.links[canonicalPackageURN+"|"+relationAffectedBy+"|"+vulnerabilityURN]; !ok {
+		t.Fatal("canonical package vulnerability link missing")
 	}
 }
 

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -148,6 +148,7 @@ func TestProjectGitHubDependabotAlert(t *testing.T) {
 		SourceId: "github",
 		Kind:     "github.dependabot_alert",
 		Attributes: map[string]string{
+			"advisory_cve_id":    "CVE-2025-12345",
 			"advisory_ghsa_id":   "GHSA-xxxx-yyyy-zzzz",
 			"alert_number":       "7",
 			"ecosystem":          "go",
@@ -163,17 +164,18 @@ func TestProjectGitHubDependabotAlert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 5 {
-		t.Fatalf("Project().EntitiesProjected = %d, want 5", result.EntitiesProjected)
+	if result.EntitiesProjected != 6 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 6", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 4 {
-		t.Fatalf("Project().LinksProjected = %d, want 4", result.LinksProjected)
+	if result.LinksProjected != 6 {
+		t.Fatalf("Project().LinksProjected = %d, want 6", result.LinksProjected)
 	}
 
 	alertURN := "urn:cerebro:writer:github_dependabot_alert:writer/cerebro:7"
 	repoURN := "urn:cerebro:writer:github_repo:writer/cerebro"
 	advisoryURN := "urn:cerebro:writer:github_advisory:GHSA-xxxx-yyyy-zzzz"
 	packageURN := "urn:cerebro:writer:package:go:golang.org/x/crypto"
+	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2025-12345"
 	if _, ok := state.entities[alertURN]; !ok {
 		t.Fatalf("state entity %q missing", alertURN)
 	}
@@ -188,6 +190,12 @@ func TestProjectGitHubDependabotAlert(t *testing.T) {
 	}
 	if _, ok := state.links[alertURN+"|"+relationAffects+"|"+packageURN]; !ok {
 		t.Fatal("alert package link missing")
+	}
+	if _, ok := state.links[alertURN+"|"+relationAffectedBy+"|"+vulnerabilityURN]; !ok {
+		t.Fatal("alert canonical vulnerability link missing")
+	}
+	if _, ok := state.links[packageURN+"|"+relationAffectedBy+"|"+vulnerabilityURN]; !ok {
+		t.Fatal("package canonical vulnerability link missing")
 	}
 }
 

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -80,6 +80,9 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"gcp.service_account":                  gcpServiceAccountProjections,
 	"gcp.service_account_impersonation":    gcpServiceAccountImpersonationProjections,
 	"gcp.service_account_key":              gcpServiceAccountKeyProjections,
+	"gcp.container_analysis_vulnerability": gcpContainerVulnerabilityProjections,
+	"gcp.container_vulnerability":          gcpContainerVulnerabilityProjections,
+	"kandji.vulnerability":                 kandjiVulnerabilityProjections,
 	"okta.user":                            oktaUserProjections,
 	"okta.group":                           oktaGroupProjections,
 	"okta.group_membership":                oktaGroupMembershipProjections,
@@ -96,6 +99,7 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"kubernetes.workload":                  kubernetesWorkloadProjections,
 	"kubernetes.workload_identity_binding": kubernetesWorkloadIdentityBindingProjections,
 	"runtime.evidence":                     runtimeEvidenceProjections,
+	"sentinelone.vulnerability":            sentinelOneVulnerabilityProjections,
 }}
 
 // BuiltinRegistry returns the default source event projector registry.

--- a/internal/sourceprojection/vulnerability.go
+++ b/internal/sourceprojection/vulnerability.go
@@ -1,0 +1,269 @@
+package sourceprojection
+
+import (
+	"regexp"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var (
+	cveIdentifierPattern  = regexp.MustCompile(`(?i)\bCVE-\d{4}-\d{4,}\b`)
+	ghsaIdentifierPattern = regexp.MustCompile(`(?i)\bGHSA-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}\b`)
+)
+
+func sentinelOneVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return endpointSoftwareVulnerabilityProjections(event, endpointVulnerabilityProfile{
+		Provider:          "sentinelone",
+		EndpointKind:      "sentinelone_agent",
+		EndpointType:      "sentinelone.agent",
+		EndpointIDKeys:    []string{"agent_id", "agent_uuid", "endpoint_id", "device_id"},
+		EndpointLabelKeys: []string{"agent_name", "endpoint_name", "device_name", "hostname"},
+		PackageScope:      "sentinelone",
+	})
+}
+
+func kandjiVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return endpointSoftwareVulnerabilityProjections(event, endpointVulnerabilityProfile{
+		Provider:          "kandji",
+		EndpointKind:      "kandji_device",
+		EndpointType:      "kandji.device",
+		EndpointIDKeys:    []string{"device_id", "device_uuid", "serial_number", "asset_id"},
+		EndpointLabelKeys: []string{"device_name", "hostname", "computer_name", "serial_number"},
+		PackageScope:      "macos",
+	})
+}
+
+func gcpContainerVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), attributes)
+	imageID := firstAttribute(attributes, "image_uri", "image", "resource_uri", "resource_id", "artifact_uri")
+	imageURN := projectionURN(tenantID, "gcp_artifact_registry_image", imageID)
+	if imageURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        imageURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "gcp.artifact_registry_image",
+			Label:      firstAttribute(attributes, "image_name", "resource_name", "image_uri", "image"),
+			Attributes: map[string]string{
+				"digest":        strings.TrimSpace(attributes["digest"]),
+				"image_uri":     imageID,
+				"project_id":    strings.TrimSpace(attributes["project_id"]),
+				"registry":      strings.TrimSpace(attributes["registry"]),
+				"repository":    strings.TrimSpace(attributes["repository"]),
+				"resource_id":   strings.TrimSpace(attributes["resource_id"]),
+				"resource_type": strings.TrimSpace(attributes["resource_type"]),
+			},
+		})
+		if vulnerabilityURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), imageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attributes)))
+		}
+	}
+
+	packageURN := vulnerabilityPackageURN(tenantID, attributes, "container")
+	if packageURN != "" {
+		addVulnerablePackageEntity(entities, tenantID, event.GetSourceId(), packageURN, attributes, "container")
+		if imageURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), imageURN, packageURN, relationContains, map[string]string{"event_id": event.GetId()}))
+		}
+		if vulnerabilityURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attributes)))
+		}
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+type endpointVulnerabilityProfile struct {
+	Provider          string
+	EndpointKind      string
+	EndpointType      string
+	EndpointIDKeys    []string
+	EndpointLabelKeys []string
+	PackageScope      string
+}
+
+func endpointSoftwareVulnerabilityProjections(event *cerebrov1.EventEnvelope, profile endpointVulnerabilityProfile) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), attributes)
+	endpointID := firstAttribute(attributes, profile.EndpointIDKeys...)
+	endpointURN := projectionURN(tenantID, profile.EndpointKind, endpointID)
+	if endpointURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        endpointURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: profile.EndpointType,
+			Label:      firstNonEmpty(firstAttribute(attributes, profile.EndpointLabelKeys...), endpointID),
+			Attributes: map[string]string{
+				"device_id":      endpointID,
+				"hostname":       strings.TrimSpace(attributes["hostname"]),
+				"serial_number":  strings.TrimSpace(attributes["serial_number"]),
+				"source_product": profile.Provider,
+			},
+		})
+		if vulnerabilityURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), endpointURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attributes)))
+		}
+	}
+
+	packageURN := vulnerabilityPackageURN(tenantID, attributes, profile.PackageScope)
+	if packageURN != "" {
+		addVulnerablePackageEntity(entities, tenantID, event.GetSourceId(), packageURN, attributes, profile.PackageScope)
+		if endpointURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), endpointURN, packageURN, relationContains, map[string]string{"event_id": event.GetId()}))
+		}
+		if vulnerabilityURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attributes)))
+		}
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func addCanonicalVulnerabilityEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, attributes map[string]string) string {
+	identifier := canonicalVulnerabilityIdentifier(attributes)
+	if identifier == "" {
+		return ""
+	}
+	normalized := normalizeIdentifier(identifier)
+	vulnerabilityURN := projectionURN(tenantID, "vulnerability", normalized)
+	if vulnerabilityURN == "" {
+		return ""
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        vulnerabilityURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "vulnerability",
+		Label:      strings.ToUpper(normalized),
+		Attributes: map[string]string{
+			"cve_id":             firstCVEIdentifier(attributes),
+			"ghsa_id":            firstGHSAIdentifier(attributes),
+			"identifier":         strings.ToUpper(normalized),
+			"severity":           firstAttribute(attributes, "severity", "advisory_severity", "vulnerability_severity", "cvss_severity"),
+			"source_provider":    strings.TrimSpace(attributes["source_provider"]),
+			"vulnerability_type": firstAttribute(attributes, "vulnerability_type", "type"),
+		},
+	})
+	return vulnerabilityURN
+}
+
+func canonicalVulnerabilityIdentifier(attributes map[string]string) string {
+	if cve := firstCVEIdentifier(attributes); cve != "" {
+		return cve
+	}
+	return firstGHSAIdentifier(attributes)
+}
+
+func firstCVEIdentifier(attributes map[string]string) string {
+	return firstMatchingIdentifier(cveIdentifierPattern, attributes,
+		"cve_id",
+		"advisory_cve_id",
+		"cve",
+		"vulnerability_id",
+		"identifier",
+		"name",
+		"title",
+	)
+}
+
+func firstGHSAIdentifier(attributes map[string]string) string {
+	return firstMatchingIdentifier(ghsaIdentifierPattern, attributes,
+		"ghsa_id",
+		"advisory_ghsa_id",
+		"advisory_id",
+		"vulnerability_id",
+		"identifier",
+		"name",
+		"title",
+	)
+}
+
+func firstMatchingIdentifier(pattern *regexp.Regexp, attributes map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if match := pattern.FindString(strings.TrimSpace(attributes[key])); match != "" {
+			return strings.ToUpper(match)
+		}
+	}
+	for _, value := range attributes {
+		if match := pattern.FindString(strings.TrimSpace(value)); match != "" {
+			return strings.ToUpper(match)
+		}
+	}
+	return ""
+}
+
+func vulnerabilityPackageURN(tenantID string, attributes map[string]string, defaultScope string) string {
+	packageName := firstAttribute(attributes, "package", "package_name", "application_name", "app_name", "software_name", "component_name")
+	if packageName == "" {
+		return ""
+	}
+	scope := firstAttribute(attributes, "ecosystem", "package_ecosystem", "platform", "os")
+	if scope == "" {
+		scope = defaultScope
+	}
+	return projectionURN(tenantID, "package", normalizeIdentifier(scope), packageName)
+}
+
+func addVulnerablePackageEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, packageURN string, attributes map[string]string, defaultScope string) {
+	packageName := firstAttribute(attributes, "package", "package_name", "application_name", "app_name", "software_name", "component_name")
+	scope := firstAttribute(attributes, "ecosystem", "package_ecosystem", "platform", "os")
+	if scope == "" {
+		scope = defaultScope
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        packageURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "package",
+		Label:      packageName,
+		Attributes: map[string]string{
+			"ecosystem": scope,
+			"name":      packageName,
+			"version":   firstAttribute(attributes, "version", "package_version", "application_version", "installed_version"),
+		},
+	})
+}
+
+func vulnerabilityEvidenceAttributes(event *cerebrov1.EventEnvelope, attributes map[string]string) map[string]string {
+	return map[string]string{
+		"confidence":                 firstAttribute(attributes, "confidence"),
+		"event_id":                   event.GetId(),
+		"first_detected_at":          firstAttribute(attributes, "first_detected_at", "created_at"),
+		"fixed_version":              firstAttribute(attributes, "fixed_version", "first_patched_version", "patched_version"),
+		"severity":                   firstAttribute(attributes, "severity", "advisory_severity", "vulnerability_severity", "cvss_severity"),
+		"status":                     firstAttribute(attributes, "status", "state"),
+		"vulnerable_version_range":   strings.TrimSpace(attributes["vulnerable_version_range"]),
+		"vulnerable_version":         firstAttribute(attributes, "version", "package_version", "application_version", "installed_version"),
+		"vulnerability_identifier":   canonicalVulnerabilityIdentifier(attributes),
+		"vulnerability_source_label": firstAttribute(attributes, "vulnerability_id", "advisory_id", "name", "title"),
+	}
+}
+
+func firstAttribute(attributes map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(attributes[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/sourceprojection/vulnerability.go
+++ b/internal/sourceprojection/vulnerability.go
@@ -298,7 +298,25 @@ func vulnerablePackageName(attributes map[string]string) string {
 }
 
 func canonicalPackageIdentity(attributes map[string]string) string {
-	return firstAttribute(attributes, "purl", "package_url", "package_purl", "package", "package_name", "application_name", "app_name", "software_name", "component_name")
+	if purl := firstAttribute(attributes, "purl", "package_url", "package_purl"); purl != "" {
+		return canonicalPackagePURLIdentity(purl)
+	}
+	return vulnerablePackageName(attributes)
+}
+
+func canonicalPackagePURLIdentity(value string) string {
+	identity := strings.TrimSpace(value)
+	if identity == "" {
+		return ""
+	}
+	if index := strings.IndexAny(identity, "?#"); index >= 0 {
+		identity = identity[:index]
+	}
+	lastSlash := strings.LastIndex(identity, "/")
+	if versionIndex := strings.LastIndex(identity, "@"); versionIndex > lastSlash {
+		identity = identity[:versionIndex]
+	}
+	return strings.TrimSpace(identity)
 }
 
 func canonicalPackageIdentityType(attributes map[string]string) string {

--- a/internal/sourceprojection/vulnerability.go
+++ b/internal/sourceprojection/vulnerability.go
@@ -70,6 +70,7 @@ func gcpContainerVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*po
 	}
 
 	packageURN := vulnerabilityPackageURN(tenantID, attributes, "container")
+	canonicalPackageURN := addCanonicalPackageEntity(entities, tenantID, event.GetSourceId(), attributes, "container")
 	if packageURN != "" {
 		addVulnerablePackageEntity(entities, tenantID, event.GetSourceId(), packageURN, attributes, "container")
 		if imageURN != "" {
@@ -78,6 +79,12 @@ func gcpContainerVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*po
 		if vulnerabilityURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attributes)))
 		}
+	}
+	if packageURN != "" && canonicalPackageURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, canonicalPackageURN, relationRepresents, packageIdentityAttributes(event, attributes, "container")))
+	}
+	if canonicalPackageURN != "" && vulnerabilityURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), canonicalPackageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attributes)))
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -125,6 +132,7 @@ func endpointSoftwareVulnerabilityProjections(event *cerebrov1.EventEnvelope, pr
 	}
 
 	packageURN := vulnerabilityPackageURN(tenantID, attributes, profile.PackageScope)
+	canonicalPackageURN := addCanonicalPackageEntity(entities, tenantID, event.GetSourceId(), attributes, profile.PackageScope)
 	if packageURN != "" {
 		addVulnerablePackageEntity(entities, tenantID, event.GetSourceId(), packageURN, attributes, profile.PackageScope)
 		if endpointURN != "" {
@@ -133,6 +141,12 @@ func endpointSoftwareVulnerabilityProjections(event *cerebrov1.EventEnvelope, pr
 		if vulnerabilityURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attributes)))
 		}
+	}
+	if packageURN != "" && canonicalPackageURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, canonicalPackageURN, relationRepresents, packageIdentityAttributes(event, attributes, profile.PackageScope)))
+	}
+	if canonicalPackageURN != "" && vulnerabilityURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), canonicalPackageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attributes)))
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -213,7 +227,7 @@ func firstMatchingIdentifier(pattern *regexp.Regexp, attributes map[string]strin
 }
 
 func vulnerabilityPackageURN(tenantID string, attributes map[string]string, defaultScope string) string {
-	packageName := firstAttribute(attributes, "package", "package_name", "application_name", "app_name", "software_name", "component_name")
+	packageName := vulnerablePackageName(attributes)
 	if packageName == "" {
 		return ""
 	}
@@ -225,7 +239,7 @@ func vulnerabilityPackageURN(tenantID string, attributes map[string]string, defa
 }
 
 func addVulnerablePackageEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, packageURN string, attributes map[string]string, defaultScope string) {
-	packageName := firstAttribute(attributes, "package", "package_name", "application_name", "app_name", "software_name", "component_name")
+	packageName := vulnerablePackageName(attributes)
 	scope := firstAttribute(attributes, "ecosystem", "package_ecosystem", "platform", "os")
 	if scope == "" {
 		scope = defaultScope
@@ -242,6 +256,71 @@ func addVulnerablePackageEntity(entities map[string]*ports.ProjectedEntity, tena
 			"version":   firstAttribute(attributes, "version", "package_version", "application_version", "installed_version"),
 		},
 	})
+}
+
+func addCanonicalPackageEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, attributes map[string]string, defaultScope string) string {
+	packageName := vulnerablePackageName(attributes)
+	if packageName == "" {
+		return ""
+	}
+	identity := canonicalPackageIdentity(attributes)
+	if identity == "" {
+		identity = packageName
+	}
+	canonicalPackageURN := projectionURN(tenantID, "package", "canonical", identity)
+	if canonicalPackageURN == "" {
+		return ""
+	}
+	scope := firstAttribute(attributes, "ecosystem", "package_ecosystem", "platform", "os")
+	if scope == "" {
+		scope = defaultScope
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        canonicalPackageURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "package",
+		Label:      packageName,
+		Attributes: map[string]string{
+			"canonical":     "true",
+			"ecosystem":     scope,
+			"identity":      identity,
+			"identity_type": canonicalPackageIdentityType(attributes),
+			"name":          packageName,
+			"purl":          firstAttribute(attributes, "purl", "package_url", "package_purl"),
+		},
+	})
+	return canonicalPackageURN
+}
+
+func vulnerablePackageName(attributes map[string]string) string {
+	return firstAttribute(attributes, "package", "package_name", "application_name", "app_name", "software_name", "component_name")
+}
+
+func canonicalPackageIdentity(attributes map[string]string) string {
+	return firstAttribute(attributes, "purl", "package_url", "package_purl", "package", "package_name", "application_name", "app_name", "software_name", "component_name")
+}
+
+func canonicalPackageIdentityType(attributes map[string]string) string {
+	if firstAttribute(attributes, "purl", "package_url", "package_purl") != "" {
+		return "purl"
+	}
+	return "name"
+}
+
+func packageIdentityAttributes(event *cerebrov1.EventEnvelope, attributes map[string]string, defaultScope string) map[string]string {
+	scope := firstAttribute(attributes, "ecosystem", "package_ecosystem", "platform", "os")
+	if scope == "" {
+		scope = defaultScope
+	}
+	return map[string]string{
+		"event_id":       event.GetId(),
+		"identity":       canonicalPackageIdentity(attributes),
+		"identity_type":  canonicalPackageIdentityType(attributes),
+		"package":        vulnerablePackageName(attributes),
+		"package_scope":  scope,
+		"package_source": firstAttribute(attributes, "source_provider", "vulnerability_type"),
+	}
 }
 
 func vulnerabilityEvidenceAttributes(event *cerebrov1.EventEnvelope, attributes map[string]string) map[string]string {

--- a/internal/sourceprojection/vulnerability_test.go
+++ b/internal/sourceprojection/vulnerability_test.go
@@ -28,15 +28,16 @@ func TestProjectSentinelOneVulnerabilityUsesCanonicalCVE(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 3 {
-		t.Fatalf("Project().EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	if result.EntitiesProjected != 4 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 4", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 3 {
-		t.Fatalf("Project().LinksProjected = %d, want 3", result.LinksProjected)
+	if result.LinksProjected != 5 {
+		t.Fatalf("Project().LinksProjected = %d, want 5", result.LinksProjected)
 	}
 
 	endpointURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
 	packageURN := "urn:cerebro:writer:package:sentinelone:openssl"
+	canonicalPackageURN := "urn:cerebro:writer:package:canonical:openssl"
 	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2025-23456"
 	if entity := state.entities[vulnerabilityURN]; entity == nil || entity.EntityType != "vulnerability" {
 		t.Fatalf("canonical vulnerability entity missing: %#v", entity)
@@ -44,6 +45,8 @@ func TestProjectSentinelOneVulnerabilityUsesCanonicalCVE(t *testing.T) {
 	assertProjectedLink(t, state, endpointURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, packageURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, endpointURN, relationContains, packageURN)
+	assertProjectedLink(t, state, packageURN, relationRepresents, canonicalPackageURN)
+	assertProjectedLink(t, state, canonicalPackageURN, relationAffectedBy, vulnerabilityURN)
 }
 
 func TestProjectKandjiVulnerabilityUsesCanonicalCVE(t *testing.T) {
@@ -67,19 +70,22 @@ func TestProjectKandjiVulnerabilityUsesCanonicalCVE(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 3 {
-		t.Fatalf("Project().EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	if result.EntitiesProjected != 4 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 4", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 3 {
-		t.Fatalf("Project().LinksProjected = %d, want 3", result.LinksProjected)
+	if result.LinksProjected != 5 {
+		t.Fatalf("Project().LinksProjected = %d, want 5", result.LinksProjected)
 	}
 
 	deviceURN := "urn:cerebro:writer:kandji_device:device-1"
 	packageURN := "urn:cerebro:writer:package:macos:Safari"
+	canonicalPackageURN := "urn:cerebro:writer:package:canonical:Safari"
 	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2025-34567"
 	assertProjectedLink(t, state, deviceURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, packageURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, deviceURN, relationContains, packageURN)
+	assertProjectedLink(t, state, packageURN, relationRepresents, canonicalPackageURN)
+	assertProjectedLink(t, state, canonicalPackageURN, relationAffectedBy, vulnerabilityURN)
 }
 
 func TestProjectGCPContainerVulnerabilityUsesCanonicalCVE(t *testing.T) {
@@ -103,19 +109,75 @@ func TestProjectGCPContainerVulnerabilityUsesCanonicalCVE(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 3 {
-		t.Fatalf("Project().EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	if result.EntitiesProjected != 4 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 4", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 3 {
-		t.Fatalf("Project().LinksProjected = %d, want 3", result.LinksProjected)
+	if result.LinksProjected != 5 {
+		t.Fatalf("Project().LinksProjected = %d, want 5", result.LinksProjected)
 	}
 
 	imageURN := "urn:cerebro:writer:gcp_artifact_registry_image:us-docker.pkg.dev/writer/prod/api@sha256:abc"
 	packageURN := "urn:cerebro:writer:package:container:openssl"
+	canonicalPackageURN := "urn:cerebro:writer:package:canonical:openssl"
 	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2025-45678"
 	assertProjectedLink(t, state, imageURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, packageURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, imageURN, relationContains, packageURN)
+	assertProjectedLink(t, state, packageURN, relationRepresents, canonicalPackageURN)
+	assertProjectedLink(t, state, canonicalPackageURN, relationAffectedBy, vulnerabilityURN)
+}
+
+func TestGitHubAndSentinelOneConvergeThroughCanonicalPackageAndCVE(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	events := []*cerebrov1.EventEnvelope{
+		{
+			Id:       "github-dependabot-alert-demo",
+			TenantId: "writer",
+			SourceId: "github",
+			Kind:     "github.dependabot_alert",
+			Attributes: map[string]string{
+				"advisory_cve_id":  "CVE-2026-4242",
+				"advisory_ghsa_id": "GHSA-abcd-efgh-ijkl",
+				"alert_number":     "42",
+				"ecosystem":        "go",
+				"owner":            "writer",
+				"package":          "golang.org/x/crypto",
+				"repository":       "writer/cerebro",
+				"severity":         "high",
+				"state":            "open",
+			},
+		},
+		{
+			Id:       "sentinelone-vulnerability-demo",
+			TenantId: "writer",
+			SourceId: "sentinelone",
+			Kind:     "sentinelone.vulnerability",
+			Attributes: map[string]string{
+				"agent_id":         "agent-42",
+				"agent_name":       "macbook-42",
+				"application_name": "golang.org/x/crypto",
+				"cve_id":           "CVE-2026-4242",
+				"severity":         "critical",
+				"version":          "0.0.1",
+			},
+		},
+	}
+	for _, event := range events {
+		if _, err := service.Project(context.Background(), event); err != nil {
+			t.Fatalf("Project(%s) error = %v", event.GetKind(), err)
+		}
+	}
+
+	githubPackageURN := "urn:cerebro:writer:package:go:golang.org/x/crypto"
+	sentinelOnePackageURN := "urn:cerebro:writer:package:sentinelone:golang.org/x/crypto"
+	canonicalPackageURN := "urn:cerebro:writer:package:canonical:golang.org/x/crypto"
+	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+
+	assertProjectedLink(t, state, githubPackageURN, relationRepresents, canonicalPackageURN)
+	assertProjectedLink(t, state, sentinelOnePackageURN, relationRepresents, canonicalPackageURN)
+	assertProjectedLink(t, state, canonicalPackageURN, relationAffectedBy, vulnerabilityURN)
 }
 
 func TestCanonicalVulnerabilityIdentifierPrefersCVEOverGHSA(t *testing.T) {

--- a/internal/sourceprojection/vulnerability_test.go
+++ b/internal/sourceprojection/vulnerability_test.go
@@ -1,0 +1,129 @@
+package sourceprojection
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestProjectSentinelOneVulnerabilityUsesCanonicalCVE(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "s1-vuln-1",
+		TenantId: "writer",
+		SourceId: "sentinelone",
+		Kind:     "sentinelone.vulnerability",
+		Attributes: map[string]string{
+			"agent_id":         "agent-1",
+			"agent_name":       "macbook-1",
+			"application_name": "openssl",
+			"cve_id":           "CVE-2025-23456",
+			"severity":         "critical",
+			"version":          "3.0.0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesProjected != 3 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 3 {
+		t.Fatalf("Project().LinksProjected = %d, want 3", result.LinksProjected)
+	}
+
+	endpointURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
+	packageURN := "urn:cerebro:writer:package:sentinelone:openssl"
+	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2025-23456"
+	if entity := state.entities[vulnerabilityURN]; entity == nil || entity.EntityType != "vulnerability" {
+		t.Fatalf("canonical vulnerability entity missing: %#v", entity)
+	}
+	assertProjectedLink(t, state, endpointURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, packageURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, endpointURN, relationContains, packageURN)
+}
+
+func TestProjectKandjiVulnerabilityUsesCanonicalCVE(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "kandji-vuln-1",
+		TenantId: "writer",
+		SourceId: "kandji",
+		Kind:     "kandji.vulnerability",
+		Attributes: map[string]string{
+			"application_name": "Safari",
+			"cve_id":           "CVE-2025-34567",
+			"device_id":        "device-1",
+			"device_name":      "mba-1",
+			"severity":         "high",
+			"version":          "18.0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesProjected != 3 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 3 {
+		t.Fatalf("Project().LinksProjected = %d, want 3", result.LinksProjected)
+	}
+
+	deviceURN := "urn:cerebro:writer:kandji_device:device-1"
+	packageURN := "urn:cerebro:writer:package:macos:Safari"
+	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2025-34567"
+	assertProjectedLink(t, state, deviceURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, packageURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, deviceURN, relationContains, packageURN)
+}
+
+func TestProjectGCPContainerVulnerabilityUsesCanonicalCVE(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "gcp-vuln-1",
+		TenantId: "writer",
+		SourceId: "gcp",
+		Kind:     "gcp.container_vulnerability",
+		Attributes: map[string]string{
+			"cve_id":     "CVE-2025-45678",
+			"image_uri":  "us-docker.pkg.dev/writer/prod/api@sha256:abc",
+			"package":    "openssl",
+			"project_id": "writer-prod",
+			"severity":   "medium",
+			"version":    "3.0.0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesProjected != 3 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 3 {
+		t.Fatalf("Project().LinksProjected = %d, want 3", result.LinksProjected)
+	}
+
+	imageURN := "urn:cerebro:writer:gcp_artifact_registry_image:us-docker.pkg.dev/writer/prod/api@sha256:abc"
+	packageURN := "urn:cerebro:writer:package:container:openssl"
+	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2025-45678"
+	assertProjectedLink(t, state, imageURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, packageURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, imageURN, relationContains, packageURN)
+}
+
+func TestCanonicalVulnerabilityIdentifierPrefersCVEOverGHSA(t *testing.T) {
+	identifier := canonicalVulnerabilityIdentifier(map[string]string{
+		"advisory_cve_id":  "CVE-2025-56789",
+		"advisory_ghsa_id": "GHSA-abcd-efgh-ijkl",
+	})
+	if identifier != "CVE-2025-56789" {
+		t.Fatalf("canonicalVulnerabilityIdentifier() = %q, want CVE-2025-56789", identifier)
+	}
+}

--- a/internal/sourceprojection/vulnerability_test.go
+++ b/internal/sourceprojection/vulnerability_test.go
@@ -189,3 +189,20 @@ func TestCanonicalVulnerabilityIdentifierPrefersCVEOverGHSA(t *testing.T) {
 		t.Fatalf("canonicalVulnerabilityIdentifier() = %q, want CVE-2025-56789", identifier)
 	}
 }
+
+func TestCanonicalPackageIdentityStripsPURLVersion(t *testing.T) {
+	left := canonicalPackageIdentity(map[string]string{
+		"package": "foo",
+		"purl":    "pkg:npm/foo@1.2.3?repository_url=https://registry.npmjs.org#dist",
+	})
+	right := canonicalPackageIdentity(map[string]string{
+		"package": "foo",
+		"purl":    "pkg:npm/foo@1.2.4",
+	})
+	if left != "pkg:npm/foo" {
+		t.Fatalf("canonicalPackageIdentity(versioned purl) = %q, want pkg:npm/foo", left)
+	}
+	if right != left {
+		t.Fatalf("canonicalPackageIdentity() fragmented by version: left=%q right=%q", left, right)
+	}
+}

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -42,7 +42,7 @@ func TestSourceCDKOwnsExternalHTTPClients(t *testing.T) {
 		}
 		if entry.IsDir() {
 			switch entry.Name() {
-			case ".git", "vendor", "gen":
+			case ".git", "vendor", "gen", "sdk":
 				return filepath.SkipDir
 			default:
 				return nil


### PR DESCRIPTION
## Summary
- add canonical vulnerability projection helpers for CVE/GHSA identifiers
- link GitHub Dependabot packages and alerts to canonical vulnerability entities
- add SentinelOne, Kandji, and GCP vulnerability event projectors for the sourceprojection runtime

## Validation
- GOFLAGS=-mod=mod go test ./internal/sourceprojection ./internal/graphrebuild
- GOFLAGS=-mod=mod go test ./...
- make lint
- commit hooks: build, tests, lint, buf lint, tool linters