### PR TITLE
feat: add source runtime orchestration

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -63,6 +63,26 @@ paths:
       responses:
         '200':
           description: Source events and cursor.
+  /source-runtimes:
+    get:
+      summary: List source runtime configurations
+      parameters:
+        - name: tenant_id
+          in: query
+          schema:
+            type: string
+        - name: source_id
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Source runtime list.
   /source-runtimes/{runtimeID}:
     put:
       summary: Store source runtime configuration

--- a/cmd/cerebro/github_local.go
+++ b/cmd/cerebro/github_local.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	appconfig "github.com/writer/cerebro/internal/config"
 )
 
 const githubSourceID = "github"
@@ -73,6 +74,11 @@ func prepareSourceConfigWithCLI(ctx context.Context, sourceID string, command st
 	if strings.TrimSpace(sourceID) != githubSourceID {
 		return cloned, nil
 	}
+	resolved, err := appconfig.ResolveSourceConfigSecretReferences(ctx, sourceID, cloned)
+	if err != nil {
+		return nil, err
+	}
+	cloned = resolved
 	if cli == nil {
 		return cloned, fmt.Errorf("github local cli is required")
 	}
@@ -96,18 +102,32 @@ func prepareSourceRuntimeWithCLI(ctx context.Context, runtime *cerebrov1.SourceR
 	if cli == nil {
 		return nil, fmt.Errorf("github local cli is required")
 	}
+	resolvedConfig, err := appconfig.ResolveSourceRuntimeConfigSecretReferences(ctx, cloned.GetSourceId(), cloned.GetConfig())
+	if err != nil {
+		return nil, err
+	}
 	config, err := hydrateGitHubLocalConfig(
 		ctx,
-		cloned.GetConfig(),
+		resolvedConfig,
 		cli,
-		githubRuntimeRequiresRepo(cloned.GetConfig()),
-		githubRequiresToken(cloned.GetConfig()),
+		githubRuntimeRequiresRepo(resolvedConfig),
+		githubRequiresToken(resolvedConfig),
 	)
 	if err != nil {
 		return nil, err
 	}
-	cloned.Config = config
+	cloned.Config = mergeGitHubHydratedRuntimeConfig(cloned.GetConfig(), config)
 	return cloned, nil
+}
+
+func mergeGitHubHydratedRuntimeConfig(original map[string]string, hydrated map[string]string) map[string]string {
+	merged := cloneConfig(original)
+	for key, value := range hydrated {
+		if strings.TrimSpace(merged[key]) == "" {
+			merged[key] = value
+		}
+	}
+	return merged
 }
 
 func hydrateGitHubLocalConfig(ctx context.Context, config map[string]string, cli githubLocalCLI, requireRepo bool, requireToken bool) (map[string]string, error) {

--- a/cmd/cerebro/github_local_test.go
+++ b/cmd/cerebro/github_local_test.go
@@ -208,6 +208,64 @@ func TestPrepareSourceRuntimeWithCLIHydratesGitHubRuntime(t *testing.T) {
 	}
 }
 
+func TestPrepareSourceConfigWithCLIResolvesEnvOwnerBeforeHydration(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_GITHUB_OWNER", "writer")
+	cli := &fakeGitHubLocalCLI{
+		token: "gh-token",
+		repo: githubLocalRepo{
+			Name: "cerebro",
+			Owner: githubLocalRepoOwner{
+				Login: "writer",
+			},
+		},
+	}
+
+	config, err := prepareSourceConfigWithCLI(context.Background(), githubSourceID, "read", map[string]string{
+		"owner": "env:CEREBRO_SOURCE_GITHUB_OWNER",
+		"state": "all",
+	}, cli)
+	if err != nil {
+		t.Fatalf("prepareSourceConfigWithCLI() error = %v", err)
+	}
+	if got := config["owner"]; got != "writer" {
+		t.Fatalf("config[owner] = %q, want %q", got, "writer")
+	}
+	if got := config["repo"]; got != "cerebro" {
+		t.Fatalf("config[repo] = %q, want %q", got, "cerebro")
+	}
+}
+
+func TestPrepareSourceRuntimeWithCLIResolvesEnvOwnerBeforeHydration(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_GITHUB_OWNER", "writer")
+	cli := &fakeGitHubLocalCLI{
+		token: "gh-token",
+		repo: githubLocalRepo{
+			Name: "cerebro",
+			Owner: githubLocalRepoOwner{
+				Login: "writer",
+			},
+		},
+	}
+
+	runtime, err := prepareSourceRuntimeWithCLI(context.Background(), &cerebrov1.SourceRuntime{
+		Id:       "writer-github",
+		SourceId: githubSourceID,
+		Config: map[string]string{
+			"owner": "env:CEREBRO_SOURCE_GITHUB_OWNER",
+			"state": "all",
+		},
+	}, cli)
+	if err != nil {
+		t.Fatalf("prepareSourceRuntimeWithCLI() error = %v", err)
+	}
+	if got := runtime.GetConfig()["owner"]; got != "env:CEREBRO_SOURCE_GITHUB_OWNER" {
+		t.Fatalf("runtime.Config[owner] = %q, want env reference preserved", got)
+	}
+	if got := runtime.GetConfig()["repo"]; got != "cerebro" {
+		t.Fatalf("runtime.Config[repo] = %q, want %q", got, "cerebro")
+	}
+}
+
 func TestPrepareSourceConfigWithCLIReturnsGHError(t *testing.T) {
 	cli := &fakeGitHubLocalCLI{
 		tokenErr: errors.New("gh unavailable"),

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -220,7 +220,7 @@ func runGraph(args []string) error {
 				replayer = typed
 			}
 		}
-		service := graphrebuild.New(registry, sourceRuntimeStore(deps.StateStore), replayer)
+		service := graphrebuild.New(registry, sourceRuntimeStore(deps.StateStore), replayer).WithConfigPreparer(config.ResolveSourceConfigSecretReferences)
 		result, err := service.RebuildDryRun(ctx, graphrebuild.Request{
 			Mode:         mode,
 			RuntimeID:    runtimeID,

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -220,7 +220,7 @@ func runGraph(args []string) error {
 				replayer = typed
 			}
 		}
-		service := graphrebuild.New(registry, sourceRuntimeStore(deps.StateStore), replayer).WithConfigPreparer(config.ResolveSourceConfigSecretReferences)
+		service := graphrebuild.New(registry, sourceRuntimeStore(deps.StateStore), replayer).WithConfigPreparer(config.ResolveSourceRuntimeConfigSecretReferences)
 		result, err := service.RebuildDryRun(ctx, graphrebuild.Request{
 			Mode:         mode,
 			RuntimeID:    runtimeID,
@@ -915,7 +915,7 @@ func prepareGraphRuntimeSourceConfig(ctx context.Context, sourceID string, value
 	if err != nil {
 		return nil, err
 	}
-	return config.ResolveSourceConfigSecretReferences(ctx, sourceID, prepared)
+	return config.ResolveSourceRuntimeConfigSecretReferences(ctx, sourceID, prepared)
 }
 
 func graphIngestRuntimeResultCapacity(options graphIngestRuntimeOptions) int {

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -145,6 +145,10 @@ func runGraph(args []string) error {
 		if err != nil {
 			return err
 		}
+		options.SourceConfig, err = config.ResolveSourceConfigSecretReferences(ctx, options.SourceID, options.SourceConfig)
+		if err != nil {
+			return err
+		}
 		registry, err := sourceregistry.Builtin()
 		if err != nil {
 			return fmt.Errorf("open source registry: %w", err)

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -911,11 +911,7 @@ func graphIngestCheckpointID(options graphIngestOptions) string {
 }
 
 func prepareGraphRuntimeSourceConfig(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
-	prepared, err := prepareSourceConfig(ctx, sourceID, "read", values)
-	if err != nil {
-		return nil, err
-	}
-	return config.ResolveSourceRuntimeConfigSecretReferences(ctx, sourceID, prepared)
+	return config.ResolveSourceRuntimeConfigSecretReferences(ctx, sourceID, values)
 }
 
 func graphIngestRuntimeResultCapacity(options graphIngestRuntimeOptions) int {

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -145,7 +145,7 @@ func runGraph(args []string) error {
 		if err != nil {
 			return err
 		}
-		options.SourceConfig, err = config.ResolveSourceRuntimeConfigSecretReferences(ctx, options.SourceID, options.SourceConfig)
+		options.SourceConfig, err = config.ResolveSourceConfigSecretReferences(ctx, options.SourceID, options.SourceConfig)
 		if err != nil {
 			return err
 		}

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -771,9 +771,7 @@ func runGraphIngestRuntime(ctx context.Context, deps bootstrap.Dependencies, opt
 	if projector == nil {
 		return nil, fmt.Errorf("projection graph store is required")
 	}
-	service := graphingest.New(registry, runtimeStore, projector, deps.GraphStore).WithConfigPreparer(func(ctx context.Context, sourceID string, config map[string]string) (map[string]string, error) {
-		return prepareSourceConfig(ctx, sourceID, "read", config)
-	})
+	service := graphingest.New(registry, runtimeStore, projector, deps.GraphStore).WithConfigPreparer(prepareGraphRuntimeSourceConfig)
 	result := &graphIngestRuntimeRunnerResult{
 		RuntimeID:  strings.TrimSpace(options.RuntimeID),
 		Iterations: options.Iterations,
@@ -910,6 +908,14 @@ func graphIngestCheckpointID(options graphIngestOptions) string {
 		hash = hash[:16]
 	}
 	return strings.TrimSpace(options.SourceID) + ":" + tenantID + ":" + hash
+}
+
+func prepareGraphRuntimeSourceConfig(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
+	prepared, err := prepareSourceConfig(ctx, sourceID, "read", values)
+	if err != nil {
+		return nil, err
+	}
+	return config.ResolveSourceConfigSecretReferences(ctx, sourceID, prepared)
 }
 
 func graphIngestRuntimeResultCapacity(options graphIngestRuntimeOptions) int {

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -145,7 +145,7 @@ func runGraph(args []string) error {
 		if err != nil {
 			return err
 		}
-		options.SourceConfig, err = config.ResolveSourceConfigSecretReferences(ctx, options.SourceID, options.SourceConfig)
+		options.SourceConfig, err = config.ResolveSourceRuntimeConfigSecretReferences(ctx, options.SourceID, options.SourceConfig)
 		if err != nil {
 			return err
 		}

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -105,6 +105,25 @@ func TestPrepareGraphRuntimeSourceConfigResolvesEnvReferences(t *testing.T) {
 	}
 }
 
+func TestPrepareGraphRuntimeSourceConfigDoesNotHydrateGitHubFromLocalCLI(t *testing.T) {
+	config, err := prepareGraphRuntimeSourceConfig(context.Background(), githubSourceID, map[string]string{
+		"family": "pull_request",
+		"owner":  "writer",
+	})
+	if err != nil {
+		t.Fatalf("prepareGraphRuntimeSourceConfig() error = %v", err)
+	}
+	if got := config["owner"]; got != "writer" {
+		t.Fatalf("config[owner] = %q, want writer", got)
+	}
+	if _, ok := config["repo"]; ok {
+		t.Fatalf("config[repo] was hydrated from local gh state: %#v", config)
+	}
+	if _, ok := config["token"]; ok {
+		t.Fatalf("config[token] was hydrated from local gh auth: %#v", config)
+	}
+}
+
 func TestParseGraphIngestRunsArgs(t *testing.T) {
 	options, err := parseGraphIngestRunsArgs([]string{
 		"runtime_id=writer-github",

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -88,6 +89,19 @@ func TestParseGraphIngestRuntimeArgsRequiresIntervalForSchedule(t *testing.T) {
 	_, err := parseGraphIngestRuntimeArgs([]string{"writer-github", "iterations=2"})
 	if err == nil {
 		t.Fatal("parseGraphIngestRuntimeArgs() error = nil, want non-nil")
+	}
+}
+
+func TestPrepareGraphRuntimeSourceConfigResolvesEnvReferences(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_OKTA_TOKEN", "resolved-token")
+	config, err := prepareGraphRuntimeSourceConfig(context.Background(), "okta", map[string]string{
+		"token": "env:CEREBRO_SOURCE_OKTA_TOKEN",
+	})
+	if err != nil {
+		t.Fatalf("prepareGraphRuntimeSourceConfig() error = %v", err)
+	}
+	if got := config["token"]; got != "resolved-token" {
+		t.Fatalf("config[token] = %q, want resolved-token", got)
 	}
 }
 

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -393,6 +393,9 @@ func parseSourceRuntimeListArgs(args []string) (ports.SourceRuntimeFilter, error
 			if err != nil {
 				return ports.SourceRuntimeFilter{}, fmt.Errorf("parse limit: %w", err)
 			}
+			if parsed == 0 {
+				return ports.SourceRuntimeFilter{}, fmt.Errorf("limit must be at least 1")
+			}
 			filter.Limit = uint32(parsed)
 		default:
 			return ports.SourceRuntimeFilter{}, fmt.Errorf("unsupported source runtime list argument %q", key)

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -17,8 +17,9 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/bootstrap"
 	"github.com/writer/cerebro/internal/buildinfo"
-	"github.com/writer/cerebro/internal/config"
+	appconfig "github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceprojection"
 	"github.com/writer/cerebro/internal/sourceregistry"
@@ -53,6 +54,8 @@ func run(args []string) error {
 		return serve()
 	case "graph":
 		return runGraph(args[1:])
+	case "orchestrator":
+		return runOrchestrator(args[1:])
 	case "finding-rule":
 		return runFindingRule(args[1:])
 	case "source":
@@ -63,11 +66,11 @@ func run(args []string) error {
 		fmt.Printf("%s %s\n", buildinfo.ServiceName, buildinfo.Version)
 		return nil
 	}
-	return usageError(fmt.Sprintf("usage: %s [serve|version|graph|finding-rule|source|source-runtime]", os.Args[0]))
+	return usageError(fmt.Sprintf("usage: %s [serve|version|graph|orchestrator|finding-rule|source|source-runtime]", os.Args[0]))
 }
 
 func serve() error {
-	cfg, err := config.Load()
+	cfg, err := appconfig.Load()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
@@ -136,6 +139,10 @@ func runSource(args []string) error {
 		if err != nil {
 			return err
 		}
+		config, err = appconfig.ResolveSourceConfigSecretReferences(ctx, sourceID, config)
+		if err != nil {
+			return err
+		}
 		response, err := service.Check(ctx, &cerebrov1.CheckSourceRequest{
 			SourceId: sourceID,
 			Config:   config,
@@ -150,6 +157,10 @@ func runSource(args []string) error {
 			return err
 		}
 		config, err = prepareSourceConfig(ctx, sourceID, "discover", config)
+		if err != nil {
+			return err
+		}
+		config, err = appconfig.ResolveSourceConfigSecretReferences(ctx, sourceID, config)
 		if err != nil {
 			return err
 		}
@@ -170,6 +181,10 @@ func runSource(args []string) error {
 		if err != nil {
 			return err
 		}
+		config, err = appconfig.ResolveSourceConfigSecretReferences(ctx, sourceID, config)
+		if err != nil {
+			return err
+		}
 		response, err := service.Read(ctx, &cerebrov1.ReadSourceRequest{
 			SourceId: sourceID,
 			Config:   config,
@@ -186,9 +201,9 @@ func runSource(args []string) error {
 
 func runSourceRuntime(args []string) error {
 	if len(args) == 0 {
-		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|sync] ...", os.Args[0]))
+		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|list|sync] ...", os.Args[0]))
 	}
-	cfg, err := config.Load()
+	cfg, err := appconfig.Load()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
@@ -237,6 +252,16 @@ func runSourceRuntime(args []string) error {
 			return err
 		}
 		return printProto(response)
+	case "list":
+		filter, err := parseSourceRuntimeListArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		runtimes, err := service.List(ctx, filter)
+		if err != nil {
+			return err
+		}
+		return printJSON(map[string]any{"runtimes": runtimes})
 	case "sync":
 		runtimeID, pageLimit, err := parseSourceRuntimeSyncArgs(args[1:])
 		if err != nil {
@@ -251,7 +276,7 @@ func runSourceRuntime(args []string) error {
 		}
 		return printProto(response)
 	default:
-		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|sync] ...", os.Args[0]))
+		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|list|sync] ...", os.Args[0]))
 	}
 }
 
@@ -312,27 +337,12 @@ func parseSourceRuntimePutArgs(args []string) (*cerebrov1.SourceRuntime, error) 
 func sourceConfigValueFromArg(key string, value string) (string, error) {
 	sensitive := sensitiveCLIConfigKey(key)
 	if strings.HasPrefix(value, "env:") && !literalEnvPrefixCLIConfigKey(key) {
-		return sourceConfigValueFromEnv(key, value)
+		return value, nil
 	}
 	if sensitive && strings.TrimSpace(value) != "" {
 		return "", fmt.Errorf("source config %q is sensitive; pass env:VAR instead of a literal value", strings.TrimSpace(key))
 	}
 	return value, nil
-}
-
-func sourceConfigValueFromEnv(key string, value string) (string, error) {
-	envName := strings.TrimSpace(strings.TrimPrefix(value, "env:"))
-	if envName == "" {
-		return "", fmt.Errorf("source config %q env reference is missing a variable name", strings.TrimSpace(key))
-	}
-	resolved, ok := os.LookupEnv(envName)
-	if !ok {
-		return "", fmt.Errorf("source config %q references unset environment variable %q", strings.TrimSpace(key), envName)
-	}
-	if sensitiveCLIConfigKey(key) && strings.TrimSpace(resolved) == "" {
-		return "", fmt.Errorf("source config %q references empty environment variable %q", strings.TrimSpace(key), envName)
-	}
-	return resolved, nil
 }
 
 func literalEnvPrefixCLIConfigKey(key string) bool {
@@ -345,17 +355,7 @@ func literalEnvPrefixCLIConfigKey(key string) bool {
 }
 
 func sensitiveCLIConfigKey(key string) bool {
-	value := strings.ToLower(strings.TrimSpace(key))
-	if value == "" {
-		return false
-	}
-	if strings.Contains(value, "token") || strings.Contains(value, "secret") || strings.Contains(value, "password") {
-		return true
-	}
-	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(value)
-	return compact == "key" ||
-		strings.Contains(compact, "apikey") ||
-		strings.Contains(compact, "privatekey")
+	return sourceconfig.SensitiveKey(key)
 }
 
 func parseSourceRuntimeSyncArgs(args []string) (string, uint32, error) {
@@ -379,6 +379,31 @@ func parseSourceRuntimeSyncArgs(args []string) (string, uint32, error) {
 		pageLimit = uint32(parsed)
 	}
 	return runtimeID, pageLimit, nil
+}
+
+func parseSourceRuntimeListArgs(args []string) (ports.SourceRuntimeFilter, error) {
+	var filter ports.SourceRuntimeFilter
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return ports.SourceRuntimeFilter{}, fmt.Errorf("invalid source runtime list argument %q; want key=value", arg)
+		}
+		switch key {
+		case "tenant_id":
+			filter.TenantID = strings.TrimSpace(value)
+		case "source_id":
+			filter.SourceID = strings.TrimSpace(value)
+		case "limit":
+			parsed, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return ports.SourceRuntimeFilter{}, fmt.Errorf("parse limit: %w", err)
+			}
+			filter.Limit = uint32(parsed)
+		default:
+			return ports.SourceRuntimeFilter{}, fmt.Errorf("unsupported source runtime list argument %q", key)
+		}
+	}
+	return filter, nil
 }
 
 func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -261,7 +262,11 @@ func runSourceRuntime(args []string) error {
 		if err != nil {
 			return err
 		}
-		return printJSON(map[string]any{"runtimes": runtimes})
+		payload, err := sourceRuntimeListJSON(runtimes)
+		if err != nil {
+			return err
+		}
+		return printJSON(payload)
 	case "sync":
 		runtimeID, pageLimit, err := parseSourceRuntimeSyncArgs(args[1:])
 		if err != nil {
@@ -281,7 +286,7 @@ func runSourceRuntime(args []string) error {
 }
 
 func configureSourceRuntimeCommandService(service *sourceruntime.Service) *sourceruntime.Service {
-	return service.WithConfigResolver(appconfig.ResolveSourceConfigSecretReferences)
+	return service.WithConfigResolver(appconfig.ResolveSourceRuntimeConfigSecretReferences)
 }
 
 func parseSourceCommandArgs(args []string) (string, map[string]string, *cerebrov1.SourceCursor, error) {
@@ -402,6 +407,19 @@ func parseSourceRuntimeListArgs(args []string) (ports.SourceRuntimeFilter, error
 		}
 	}
 	return filter, nil
+}
+
+func sourceRuntimeListJSON(runtimes []*cerebrov1.SourceRuntime) (map[string][]json.RawMessage, error) {
+	items := make([]json.RawMessage, 0, len(runtimes))
+	marshaler := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
+	for _, runtime := range runtimes {
+		payload, err := marshaler.Marshal(runtime)
+		if err != nil {
+			return nil, fmt.Errorf("marshal source runtime: %w", err)
+		}
+		items = append(items, json.RawMessage(payload))
+	}
+	return map[string][]json.RawMessage{"runtimes": items}, nil
 }
 
 func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -336,22 +336,13 @@ func parseSourceRuntimePutArgs(args []string) (*cerebrov1.SourceRuntime, error) 
 
 func sourceConfigValueFromArg(key string, value string) (string, error) {
 	sensitive := sensitiveCLIConfigKey(key)
-	if strings.HasPrefix(value, "env:") && !literalEnvPrefixCLIConfigKey(key) {
+	if strings.HasPrefix(value, "env:") && !sourceconfig.LiteralEnvPrefixKey(key) {
 		return value, nil
 	}
 	if sensitive && strings.TrimSpace(value) != "" {
 		return "", fmt.Errorf("source config %q is sensitive; pass env:VAR instead of a literal value", strings.TrimSpace(key))
 	}
 	return value, nil
-}
-
-func literalEnvPrefixCLIConfigKey(key string) bool {
-	switch strings.ToLower(strings.TrimSpace(key)) {
-	case "filter", "phrase", "q", "search":
-		return true
-	default:
-		return false
-	}
 }
 
 func sensitiveCLIConfigKey(key string) bool {

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -221,12 +221,12 @@ func runSourceRuntime(args []string) error {
 	if err != nil {
 		return fmt.Errorf("open source registry: %w", err)
 	}
-	service := sourceruntime.New(
+	service := configureSourceRuntimeCommandService(sourceruntime.New(
 		registry,
 		sourceRuntimeStore(deps.StateStore),
 		deps.AppendLog,
 		sourceProjector(deps.StateStore, deps.GraphStore),
-	)
+	))
 
 	switch args[0] {
 	case "put":
@@ -278,6 +278,10 @@ func runSourceRuntime(args []string) error {
 	default:
 		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|list|sync] ...", os.Args[0]))
 	}
+}
+
+func configureSourceRuntimeCommandService(service *sourceruntime.Service) *sourceruntime.Service {
+	return service.WithConfigResolver(appconfig.ResolveSourceConfigSecretReferences)
 }
 
 func parseSourceCommandArgs(args []string) (string, map[string]string, *cerebrov1.SourceCursor, error) {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -75,7 +75,7 @@ func TestParseSourceArgsAllowNonSecretAccessKeyID(t *testing.T) {
 	}
 }
 
-func TestParseSourceCommandArgsResolvesEnvReferences(t *testing.T) {
+func TestParseSourceCommandArgsPreservesSensitiveEnvReferences(t *testing.T) {
 	t.Setenv("CEREBRO_TEST_TOKEN", "test-token")
 	sourceID, config, cursor, err := parseSourceCommandArgs([]string{
 		"github",
@@ -89,8 +89,8 @@ func TestParseSourceCommandArgsResolvesEnvReferences(t *testing.T) {
 	if sourceID != "github" {
 		t.Fatalf("sourceID = %q, want github", sourceID)
 	}
-	if got := config["token"]; got != "test-token" {
-		t.Fatalf("config[token] = %q, want env value", got)
+	if got := config["token"]; got != "env:CEREBRO_TEST_TOKEN" {
+		t.Fatalf("config[token] = %q, want env reference", got)
 	}
 	if got := config["lookup_key"]; got != "email" {
 		t.Fatalf("config[lookup_key] = %q, want email", got)
@@ -111,23 +111,40 @@ func TestParseSourceCommandArgsPreservesEnvPrefixForNonSensitiveValues(t *testin
 	}
 }
 
-func TestParseSourceCommandArgsResolvesEnvReferencesForNonSensitiveValues(t *testing.T) {
+func TestParseSourceCommandArgsPreservesEnvReferencesForNonSensitiveValues(t *testing.T) {
 	t.Setenv("CEREBRO_TEST_OKTA_DOMAIN", "writer.okta.com")
 	_, config, _, err := parseSourceCommandArgs([]string{"okta", "domain=env:CEREBRO_TEST_OKTA_DOMAIN"})
 	if err != nil {
 		t.Fatalf("parseSourceCommandArgs() error = %v", err)
 	}
-	if got := config["domain"]; got != "writer.okta.com" {
-		t.Fatalf("config[domain] = %q, want %q", got, "writer.okta.com")
+	if got := config["domain"]; got != "env:CEREBRO_TEST_OKTA_DOMAIN" {
+		t.Fatalf("config[domain] = %q, want env reference", got)
 	}
 }
 
-func TestParseSourceCommandArgsRejectsUnsetSensitiveEnvReference(t *testing.T) {
+func TestParseSourceCommandArgsAllowsUnsetSensitiveEnvReference(t *testing.T) {
 	_, _, _, err := parseSourceCommandArgs([]string{"github", "token=env:CEREBRO_MISSING_TOKEN"})
-	if err == nil {
-		t.Fatal("parseSourceCommandArgs() error = nil, want non-nil")
+	if err != nil {
+		t.Fatalf("parseSourceCommandArgs() error = %v", err)
 	}
-	if strings.Contains(fmt.Sprint(err), "token=env:") {
-		t.Fatalf("parseSourceCommandArgs() error leaked argument: %v", err)
+}
+
+func TestParseSourceRuntimeListArgs(t *testing.T) {
+	filter, err := parseSourceRuntimeListArgs([]string{"tenant_id=writer", "source_id=github", "limit=5"})
+	if err != nil {
+		t.Fatalf("parseSourceRuntimeListArgs() error = %v", err)
+	}
+	if filter.TenantID != "writer" || filter.SourceID != "github" || filter.Limit != 5 {
+		t.Fatalf("filter = %#v, want writer/github/5", filter)
+	}
+}
+
+func TestParseOrchestratorOptions(t *testing.T) {
+	options, err := parseOrchestratorOptions([]string{"tenant_id=writer", "source_id=github", "limit=2", "page_limit=3", "event_limit=4", "graph_page_limit=5"})
+	if err != nil {
+		t.Fatalf("parseOrchestratorOptions() error = %v", err)
+	}
+	if options.Filter.TenantID != "writer" || options.Filter.SourceID != "github" || options.Filter.Limit != 2 || options.PageLimit != 3 || options.EventLimit != 4 || options.GraphPageLimit != 5 {
+		t.Fatalf("options = %#v", options)
 	}
 }

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -231,3 +231,13 @@ func TestParseOrchestratorOptions(t *testing.T) {
 		t.Fatalf("options = %#v", options)
 	}
 }
+
+func TestParseOrchestratorOptionsNumericIterationsClearsForever(t *testing.T) {
+	options, err := parseOrchestratorOptions([]string{"iterations=forever", "iterations=1"})
+	if err != nil {
+		t.Fatalf("parseOrchestratorOptions() error = %v", err)
+	}
+	if options.RunForever || options.Iterations != 1 {
+		t.Fatalf("options = %#v, want finite single iteration", options)
+	}
+}

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -222,6 +222,12 @@ func TestParseSourceRuntimeListArgs(t *testing.T) {
 	}
 }
 
+func TestParseSourceRuntimeListArgsRejectsZeroLimit(t *testing.T) {
+	if _, err := parseSourceRuntimeListArgs([]string{"limit=0"}); err == nil {
+		t.Fatal("parseSourceRuntimeListArgs(limit=0) error = nil, want error")
+	}
+}
+
 func TestParseOrchestratorOptions(t *testing.T) {
 	options, err := parseOrchestratorOptions([]string{"tenant_id=writer", "source_id=github", "limit=2", "page_limit=3", "event_limit=4", "graph_page_limit=5"})
 	if err != nil {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceruntime"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestRunRejectsUnsupportedCommand(t *testing.T) {
@@ -225,6 +226,22 @@ func TestParseSourceRuntimeListArgs(t *testing.T) {
 func TestParseSourceRuntimeListArgsRejectsZeroLimit(t *testing.T) {
 	if _, err := parseSourceRuntimeListArgs([]string{"limit=0"}); err == nil {
 		t.Fatal("parseSourceRuntimeListArgs(limit=0) error = nil, want error")
+	}
+}
+
+func TestSourceRuntimeListJSONUsesProtoJSON(t *testing.T) {
+	payload, err := sourceRuntimeListJSON([]*cerebrov1.SourceRuntime{
+		{Id: "runtime-1", LastSyncedAt: timestamppb.Now()},
+	})
+	if err != nil {
+		t.Fatalf("sourceRuntimeListJSON() error = %v", err)
+	}
+	rendered := string(payload["runtimes"][0])
+	if !strings.Contains(rendered, `"last_synced_at":"`) {
+		t.Fatalf("runtime JSON = %s, want proto JSON timestamp string", rendered)
+	}
+	if strings.Contains(rendered, `"seconds"`) {
+		t.Fatalf("runtime JSON = %s, want no struct-style seconds field", rendered)
 	}
 }
 

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceruntime"
 )
 
 func TestRunRejectsUnsupportedCommand(t *testing.T) {
@@ -122,11 +129,87 @@ func TestParseSourceCommandArgsPreservesEnvReferencesForNonSensitiveValues(t *te
 	}
 }
 
+func TestConfigureSourceRuntimeCommandServiceResolvesEnvReferences(t *testing.T) {
+	source := &commandTokenSource{}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &commandRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-command-token": {
+			Id:       "writer-command-token",
+			SourceId: "command_token",
+			Config:   map[string]string{"token": "env:CEREBRO_SOURCE_COMMAND_TOKEN_TOKEN"},
+		},
+	}}
+	t.Setenv("CEREBRO_SOURCE_COMMAND_TOKEN_TOKEN", "resolved-token")
+
+	service := configureSourceRuntimeCommandService(sourceruntime.New(registry, store, &commandAppendLog{}, nil))
+	if _, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-command-token"}); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if source.readToken != "resolved-token" {
+		t.Fatalf("source read token = %q, want resolved-token", source.readToken)
+	}
+}
+
 func TestParseSourceCommandArgsAllowsUnsetSensitiveEnvReference(t *testing.T) {
 	_, _, _, err := parseSourceCommandArgs([]string{"github", "token=env:CEREBRO_MISSING_TOKEN"})
 	if err != nil {
 		t.Fatalf("parseSourceCommandArgs() error = %v", err)
 	}
+}
+
+type commandTokenSource struct {
+	readToken string
+}
+
+func (s *commandTokenSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "command_token", Name: "Command token"}
+}
+
+func (s *commandTokenSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (s *commandTokenSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *commandTokenSource) Read(_ context.Context, config sourcecdk.Config, _ *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	s.readToken, _ = config.Lookup("token")
+	return sourcecdk.Pull{Events: []*primitives.Event{}}, nil
+}
+
+type commandRuntimeStore struct {
+	runtimes map[string]*cerebrov1.SourceRuntime
+}
+
+func (s *commandRuntimeStore) Ping(context.Context) error {
+	return nil
+}
+
+func (s *commandRuntimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {
+	s.runtimes[runtime.GetId()] = runtime
+	return nil
+}
+
+func (s *commandRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov1.SourceRuntime, error) {
+	runtime, ok := s.runtimes[id]
+	if !ok {
+		return nil, ports.ErrSourceRuntimeNotFound
+	}
+	return runtime, nil
+}
+
+type commandAppendLog struct{}
+
+func (l *commandAppendLog) Ping(context.Context) error {
+	return nil
+}
+
+func (l *commandAppendLog) Append(context.Context, *cerebrov1.EventEnvelope) error {
+	return nil
 }
 
 func TestParseSourceRuntimeListArgs(t *testing.T) {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -66,10 +66,17 @@ func runOrchestrator(args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 	result, runErr := runOrchestratorLoop(ctx, options)
+	if !shouldPrintOrchestratorResult(result) {
+		return runErr
+	}
 	if err := printJSON(result); err != nil {
 		return err
 	}
 	return runErr
+}
+
+func shouldPrintOrchestratorResult(result *orchestratorResult) bool {
+	return result != nil
 }
 
 func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -206,7 +206,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 		if err != nil {
 			runErr = err
 		}
-		result.Runs = append(result.Runs, iterationResult)
+		result.Runs = appendOrchestratorRun(result.Runs, iterationResult, options.RunForever)
 		if !options.RunForever && iteration >= options.Iterations {
 			break
 		}
@@ -220,6 +220,13 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 		}
 	}
 	return result, runErr
+}
+
+func appendOrchestratorRun(runs []*orchestratorIterationResult, run *orchestratorIterationResult, runForever bool) []*orchestratorIterationResult {
+	if !runForever {
+		return append(runs, run)
+	}
+	return []*orchestratorIterationResult{run}
 }
 
 func runOrchestratorIteration(

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -349,6 +349,7 @@ func runOrchestratorIteration(
 
 func orchestratorListFilter(filter ports.SourceRuntimeFilter) ports.SourceRuntimeFilter {
 	if filter.Limit == 0 {
+		filter.Limit = ^uint32(0)
 		return filter
 	}
 	if ^uint32(0)-filter.Limit < sourceRuntimeLeaseOverscanLimit {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -174,6 +174,10 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 	if !ok {
 		return nil, sourceruntime.ErrRuntimeUnavailable
 	}
+	toucher, ok := lister.(ports.SourceRuntimeTouchStore)
+	if !ok {
+		return nil, sourceruntime.ErrRuntimeUnavailable
+	}
 	runtimeService := sourceruntime.New(
 		registry,
 		lister,
@@ -213,7 +217,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 	}
 	for {
 		iteration++
-		iterationResult, err := runOrchestratorIteration(ctx, lister, runtimeService, findingService, graphService, options, iteration)
+		iterationResult, err := runOrchestratorIteration(ctx, lister, toucher, runtimeService, findingService, graphService, options, iteration)
 		if err != nil {
 			runErr = err
 		}
@@ -243,6 +247,7 @@ func appendOrchestratorRun(runs []*orchestratorIterationResult, run *orchestrato
 func runOrchestratorIteration(
 	ctx context.Context,
 	lister ports.SourceRuntimeListStore,
+	toucher ports.SourceRuntimeTouchStore,
 	runtimeService *sourceruntime.Service,
 	findingService *findings.Service,
 	graphService *graphingest.Service,
@@ -261,7 +266,7 @@ func runOrchestratorIteration(
 			SourceID:  strings.TrimSpace(runtime.GetSourceId()),
 			TenantID:  strings.TrimSpace(runtime.GetTenantId()),
 		}
-		if err := touchOrchestratorRuntime(ctx, lister, runtime); err != nil {
+		if err := touchOrchestratorRuntime(ctx, toucher, runtime); err != nil {
 			runtimeResult.Sync = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "touch", err)
 			result.Runtimes = append(result.Runtimes, runtimeResult)
@@ -294,11 +299,11 @@ func runOrchestratorIteration(
 	return result, runErr
 }
 
-func touchOrchestratorRuntime(ctx context.Context, store ports.SourceRuntimeStore, runtime *cerebrov1.SourceRuntime) error {
+func touchOrchestratorRuntime(ctx context.Context, store ports.SourceRuntimeTouchStore, runtime *cerebrov1.SourceRuntime) error {
 	if store == nil || runtime == nil {
 		return nil
 	}
-	return store.PutSourceRuntime(ctx, runtime)
+	return store.TouchSourceRuntime(ctx, runtime.GetId())
 }
 
 func appendRuntimeError(existing string, stage string, err error) string {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -23,6 +23,7 @@ import (
 
 const defaultOrchestratorIterations = 1
 const defaultSourceRuntimeLeaseTTL = 30 * time.Minute
+const sourceRuntimeLeaseReleaseTimeout = 5 * time.Second
 const sourceRuntimeLeaseOverscanLimit = 100
 
 type orchestratorOptions struct {
@@ -429,7 +430,9 @@ func releaseOrchestratorRuntimeLease(ctx context.Context, store ports.SourceRunt
 	if store == nil || runtime == nil {
 		return nil
 	}
-	return store.ReleaseSourceRuntimeLease(context.WithoutCancel(ctx), runtime.GetId(), owner)
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sourceRuntimeLeaseReleaseTimeout)
+	defer cancel()
+	return store.ReleaseSourceRuntimeLease(releaseCtx, runtime.GetId(), owner)
 }
 
 func appendRuntimeError(existing string, stage string, err error) string {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -292,10 +292,15 @@ func runOrchestratorIteration(
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			continue
 		}
+		stopLeaseRenewal := startOrchestratorRuntimeLeaseRenewal(ctx, leaser, runtime, leaseOwner)
 		if _, err := runtimeService.Sync(ctx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit}); err != nil {
 			runtimeResult.Sync = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "sync", err)
 			runErr = err
+			if renewalErr := stopLeaseRenewal(); renewalErr != nil {
+				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", renewalErr)
+				runErr = renewalErr
+			}
 			if releaseErr := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); releaseErr != nil {
 				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", releaseErr)
 				runErr = releaseErr
@@ -319,6 +324,10 @@ func runOrchestratorIteration(
 		} else {
 			runtimeResult.GraphIngest = "completed"
 		}
+		if err := stopLeaseRenewal(); err != nil {
+			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", err)
+			runErr = err
+		}
 		if err := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); err != nil {
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", err)
 			runErr = err
@@ -341,6 +350,47 @@ func acquireOrchestratorRuntimeLease(ctx context.Context, store ports.SourceRunt
 		return true, nil
 	}
 	return store.AcquireSourceRuntimeLease(ctx, runtime.GetId(), owner, defaultSourceRuntimeLeaseTTL)
+}
+
+func startOrchestratorRuntimeLeaseRenewal(ctx context.Context, store ports.SourceRuntimeLeaseStore, runtime *cerebrov1.SourceRuntime, owner string) func() error {
+	if store == nil || runtime == nil {
+		return func() error { return nil }
+	}
+	renewCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() {
+		ticker := time.NewTicker(sourceRuntimeLeaseRenewalInterval(defaultSourceRuntimeLeaseTTL))
+		defer ticker.Stop()
+		for {
+			select {
+			case <-renewCtx.Done():
+				done <- nil
+				return
+			case <-ticker.C:
+				renewed, err := store.RenewSourceRuntimeLease(renewCtx, runtime.GetId(), owner, defaultSourceRuntimeLeaseTTL)
+				if err != nil {
+					done <- err
+					return
+				}
+				if !renewed {
+					done <- fmt.Errorf("source runtime lease lost: %s", runtime.GetId())
+					return
+				}
+			}
+		}
+	}()
+	return func() error {
+		cancel()
+		return <-done
+	}
+}
+
+func sourceRuntimeLeaseRenewalInterval(ttl time.Duration) time.Duration {
+	interval := ttl / 2
+	if interval <= 0 {
+		return ttl
+	}
+	return interval
 }
 
 func releaseOrchestratorRuntimeLease(ctx context.Context, store ports.SourceRuntimeLeaseStore, runtime *cerebrov1.SourceRuntime, owner string) error {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -63,7 +64,7 @@ func runOrchestrator(args []string) error {
 	if err != nil {
 		return err
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), orchestratorShutdownSignals()...)
 	defer stop()
 	result, runErr := runOrchestratorLoop(ctx, options)
 	if !shouldPrintOrchestratorResult(result) {
@@ -77,6 +78,10 @@ func runOrchestrator(args []string) error {
 
 func shouldPrintOrchestratorResult(result *orchestratorResult) bool {
 	return result != nil
+}
+
+func orchestratorShutdownSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
 }
 
 func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
@@ -183,7 +188,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 		lister,
 		deps.AppendLog,
 		sourceProjector(deps.StateStore, deps.GraphStore),
-	).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
+	).WithConfigResolver(config.ResolveSourceRuntimeConfigSecretReferences)
 	findingService := findings.New(
 		lister,
 		eventReplayer(deps.AppendLog),
@@ -197,7 +202,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 		lister,
 		sourceProjector(nil, deps.GraphStore),
 		deps.GraphStore,
-	).WithConfigPreparer(config.ResolveSourceConfigSecretReferences)
+	).WithConfigPreparer(config.ResolveSourceRuntimeConfigSecretReferences)
 	result := &orchestratorResult{
 		Iterations: options.Iterations,
 		RunForever: options.RunForever,

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -96,6 +96,9 @@ func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
 			if err != nil {
 				return orchestratorOptions{}, fmt.Errorf("parse limit: %w", err)
 			}
+			if parsed == 0 {
+				return orchestratorOptions{}, fmt.Errorf("limit must be at least 1")
+			}
 			options.Filter.Limit = uint32(parsed)
 		case "page_limit":
 			parsed, err := strconv.ParseUint(value, 10, 32)

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -258,6 +258,13 @@ func runOrchestratorIteration(
 			SourceID:  strings.TrimSpace(runtime.GetSourceId()),
 			TenantID:  strings.TrimSpace(runtime.GetTenantId()),
 		}
+		if err := touchOrchestratorRuntime(ctx, lister, runtime); err != nil {
+			runtimeResult.Sync = "failed"
+			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "touch", err)
+			result.Runtimes = append(result.Runtimes, runtimeResult)
+			runErr = err
+			continue
+		}
 		if _, err := runtimeService.Sync(ctx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit}); err != nil {
 			runtimeResult.Sync = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "sync", err)
@@ -282,6 +289,13 @@ func runOrchestratorIteration(
 		result.Runtimes = append(result.Runtimes, runtimeResult)
 	}
 	return result, runErr
+}
+
+func touchOrchestratorRuntime(ctx context.Context, store ports.SourceRuntimeStore, runtime *cerebrov1.SourceRuntime) error {
+	if store == nil || runtime == nil {
+		return nil
+	}
+	return store.PutSourceRuntime(ctx, runtime)
 }
 
 func appendRuntimeError(existing string, stage string, err error) string {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -22,6 +22,7 @@ import (
 )
 
 const defaultOrchestratorIterations = 1
+const defaultSourceRuntimeLeaseTTL = 30 * time.Minute
 
 type orchestratorOptions struct {
 	Filter         ports.SourceRuntimeFilter `json:"filter"`
@@ -179,10 +180,11 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 	if !ok {
 		return nil, sourceruntime.ErrRuntimeUnavailable
 	}
-	toucher, ok := lister.(ports.SourceRuntimeTouchStore)
+	leaser, ok := lister.(ports.SourceRuntimeLeaseStore)
 	if !ok {
 		return nil, sourceruntime.ErrRuntimeUnavailable
 	}
+	leaseOwner := orchestratorLeaseOwner()
 	runtimeService := sourceruntime.New(
 		registry,
 		lister,
@@ -222,7 +224,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 	}
 	for {
 		iteration++
-		iterationResult, err := runOrchestratorIteration(ctx, lister, toucher, runtimeService, findingService, graphService, options, iteration)
+		iterationResult, err := runOrchestratorIteration(ctx, lister, leaser, leaseOwner, runtimeService, findingService, graphService, options, iteration)
 		if err != nil {
 			runErr = err
 		}
@@ -252,7 +254,8 @@ func appendOrchestratorRun(runs []*orchestratorIterationResult, run *orchestrato
 func runOrchestratorIteration(
 	ctx context.Context,
 	lister ports.SourceRuntimeListStore,
-	toucher ports.SourceRuntimeTouchStore,
+	leaser ports.SourceRuntimeLeaseStore,
+	leaseOwner string,
 	runtimeService *sourceruntime.Service,
 	findingService *findings.Service,
 	graphService *graphingest.Service,
@@ -266,22 +269,37 @@ func runOrchestratorIteration(
 	}
 	var runErr error
 	for _, runtime := range runtimes {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
 		runtimeResult := &orchestratorRuntimeResult{
 			RuntimeID: strings.TrimSpace(runtime.GetId()),
 			SourceID:  strings.TrimSpace(runtime.GetSourceId()),
 			TenantID:  strings.TrimSpace(runtime.GetTenantId()),
 		}
-		if err := touchOrchestratorRuntime(ctx, toucher, runtime); err != nil {
+		acquired, err := acquireOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner)
+		if err != nil {
 			runtimeResult.Sync = "failed"
-			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "touch", err)
+			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "lease", err)
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			runErr = err
+			continue
+		}
+		if !acquired {
+			runtimeResult.Sync = "skipped"
+			result.Runtimes = append(result.Runtimes, runtimeResult)
 			continue
 		}
 		if _, err := runtimeService.Sync(ctx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit}); err != nil {
 			runtimeResult.Sync = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "sync", err)
 			runErr = err
+			if releaseErr := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); releaseErr != nil {
+				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", releaseErr)
+				runErr = releaseErr
+			}
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			continue
 		} else {
@@ -301,16 +319,35 @@ func runOrchestratorIteration(
 		} else {
 			runtimeResult.GraphIngest = "completed"
 		}
+		if err := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); err != nil {
+			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", err)
+			runErr = err
+		}
 		result.Runtimes = append(result.Runtimes, runtimeResult)
 	}
 	return result, runErr
 }
 
-func touchOrchestratorRuntime(ctx context.Context, store ports.SourceRuntimeTouchStore, runtime *cerebrov1.SourceRuntime) error {
+func orchestratorLeaseOwner() string {
+	hostname, err := os.Hostname()
+	if err != nil || strings.TrimSpace(hostname) == "" {
+		hostname = "unknown-host"
+	}
+	return fmt.Sprintf("%s:%d:%d", hostname, os.Getpid(), time.Now().UnixNano())
+}
+
+func acquireOrchestratorRuntimeLease(ctx context.Context, store ports.SourceRuntimeLeaseStore, runtime *cerebrov1.SourceRuntime, owner string) (bool, error) {
+	if store == nil || runtime == nil {
+		return true, nil
+	}
+	return store.AcquireSourceRuntimeLease(ctx, runtime.GetId(), owner, defaultSourceRuntimeLeaseTTL)
+}
+
+func releaseOrchestratorRuntimeLease(ctx context.Context, store ports.SourceRuntimeLeaseStore, runtime *cerebrov1.SourceRuntime, owner string) error {
 	if store == nil || runtime == nil {
 		return nil
 	}
-	return store.TouchSourceRuntime(ctx, runtime.GetId())
+	return store.ReleaseSourceRuntimeLease(ctx, runtime.GetId(), owner)
 }
 
 func appendRuntimeError(existing string, stage string, err error) string {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/bootstrap"
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphingest"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceregistry"
+	"github.com/writer/cerebro/internal/sourceruntime"
+)
+
+const defaultOrchestratorIterations = 1
+
+type orchestratorOptions struct {
+	Filter         ports.SourceRuntimeFilter `json:"filter"`
+	PageLimit      uint32                    `json:"page_limit,omitempty"`
+	EventLimit     uint32                    `json:"event_limit,omitempty"`
+	GraphPageLimit uint32                    `json:"graph_page_limit,omitempty"`
+	Interval       time.Duration             `json:"-"`
+	Iterations     uint32                    `json:"iterations"`
+	RunForever     bool                      `json:"run_forever,omitempty"`
+}
+
+type orchestratorResult struct {
+	Iterations uint32                         `json:"iterations"`
+	RunForever bool                           `json:"run_forever,omitempty"`
+	Interval   string                         `json:"interval,omitempty"`
+	Runs       []*orchestratorIterationResult `json:"runs"`
+}
+
+type orchestratorIterationResult struct {
+	Iteration uint32                       `json:"iteration"`
+	StartedAt time.Time                    `json:"started_at"`
+	Runtimes  []*orchestratorRuntimeResult `json:"runtimes"`
+}
+
+type orchestratorRuntimeResult struct {
+	RuntimeID    string `json:"runtime_id"`
+	SourceID     string `json:"source_id,omitempty"`
+	TenantID     string `json:"tenant_id,omitempty"`
+	Sync         string `json:"sync"`
+	FindingRules string `json:"finding_rules"`
+	GraphIngest  string `json:"graph_ingest"`
+	Error        string `json:"error,omitempty"`
+}
+
+func runOrchestrator(args []string) error {
+	if len(args) == 0 || args[0] != "run" {
+		return usageError(fmt.Sprintf("usage: %s orchestrator run [tenant_id=<tenant-id>] [source_id=<source-id>] [limit=N] [page_limit=N] [event_limit=N] [graph_page_limit=N] [interval=30s] [iterations=N|forever]", os.Args[0]))
+	}
+	options, err := parseOrchestratorOptions(args[1:])
+	if err != nil {
+		return err
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	result, runErr := runOrchestratorLoop(ctx, options)
+	if err := printJSON(result); err != nil {
+		return err
+	}
+	return runErr
+}
+
+func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
+	options := orchestratorOptions{Iterations: defaultOrchestratorIterations}
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return orchestratorOptions{}, fmt.Errorf("invalid orchestrator argument %q; want key=value", arg)
+		}
+		switch key {
+		case "tenant_id":
+			options.Filter.TenantID = strings.TrimSpace(value)
+		case "source_id":
+			options.Filter.SourceID = strings.TrimSpace(value)
+		case "limit":
+			parsed, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return orchestratorOptions{}, fmt.Errorf("parse limit: %w", err)
+			}
+			options.Filter.Limit = uint32(parsed)
+		case "page_limit":
+			parsed, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return orchestratorOptions{}, fmt.Errorf("parse page_limit: %w", err)
+			}
+			options.PageLimit = uint32(parsed)
+		case "event_limit":
+			parsed, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return orchestratorOptions{}, fmt.Errorf("parse event_limit: %w", err)
+			}
+			options.EventLimit = uint32(parsed)
+		case "graph_page_limit":
+			parsed, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return orchestratorOptions{}, fmt.Errorf("parse graph_page_limit: %w", err)
+			}
+			options.GraphPageLimit = uint32(parsed)
+		case "interval":
+			parsed, err := time.ParseDuration(strings.TrimSpace(value))
+			if err != nil {
+				return orchestratorOptions{}, fmt.Errorf("parse interval: %w", err)
+			}
+			if parsed <= 0 {
+				return orchestratorOptions{}, fmt.Errorf("interval must be positive")
+			}
+			options.Interval = parsed
+		case "iterations":
+			if strings.TrimSpace(value) == "forever" {
+				options.RunForever = true
+				options.Iterations = 0
+				continue
+			}
+			parsed, err := strconv.ParseUint(value, 10, 32)
+			if err != nil {
+				return orchestratorOptions{}, fmt.Errorf("parse iterations: %w", err)
+			}
+			if parsed == 0 {
+				return orchestratorOptions{}, fmt.Errorf("iterations must be at least 1 or forever")
+			}
+			options.Iterations = uint32(parsed)
+		default:
+			return orchestratorOptions{}, fmt.Errorf("unsupported orchestrator argument %q", key)
+		}
+	}
+	if (options.RunForever || options.Iterations > 1) && options.Interval <= 0 {
+		return orchestratorOptions{}, fmt.Errorf("interval is required when iterations is greater than 1 or forever")
+	}
+	return options, nil
+}
+
+func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orchestratorResult, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("open dependencies: %w", err)
+	}
+	defer func() {
+		if err := closeDeps(); err != nil {
+			log.Printf("close dependencies: %v", err)
+		}
+	}()
+	registry, err := sourceregistry.Builtin()
+	if err != nil {
+		return nil, fmt.Errorf("open source registry: %w", err)
+	}
+	lister, ok := sourceRuntimeStore(deps.StateStore).(ports.SourceRuntimeListStore)
+	if !ok {
+		return nil, sourceruntime.ErrRuntimeUnavailable
+	}
+	runtimeService := sourceruntime.New(
+		registry,
+		lister,
+		deps.AppendLog,
+		sourceProjector(deps.StateStore, deps.GraphStore),
+	).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
+	findingService := findings.New(
+		lister,
+		eventReplayer(deps.AppendLog),
+		findingStore(deps.StateStore),
+		findingEvaluationRunStore(deps.StateStore),
+		findingEvidenceStore(deps.StateStore),
+		claimStore(deps.StateStore),
+	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(findingGraphQueryStore(deps.GraphStore)).WithAppendLog(deps.AppendLog)
+	graphService := graphingest.New(
+		registry,
+		lister,
+		sourceProjector(nil, deps.GraphStore),
+		deps.GraphStore,
+	).WithConfigPreparer(config.ResolveSourceConfigSecretReferences)
+	result := &orchestratorResult{
+		Iterations: options.Iterations,
+		RunForever: options.RunForever,
+		Runs:       []*orchestratorIterationResult{},
+	}
+	if options.Interval > 0 {
+		result.Interval = options.Interval.String()
+	}
+	var (
+		ticker    *time.Ticker
+		iteration uint32
+		runErr    error
+	)
+	if options.RunForever || options.Iterations > 1 {
+		ticker = time.NewTicker(options.Interval)
+		defer ticker.Stop()
+	}
+	for {
+		iteration++
+		iterationResult, err := runOrchestratorIteration(ctx, lister, runtimeService, findingService, graphService, options, iteration)
+		if err != nil {
+			runErr = err
+		}
+		result.Runs = append(result.Runs, iterationResult)
+		if !options.RunForever && iteration >= options.Iterations {
+			break
+		}
+		if ticker == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+	return result, runErr
+}
+
+func runOrchestratorIteration(
+	ctx context.Context,
+	lister ports.SourceRuntimeListStore,
+	runtimeService *sourceruntime.Service,
+	findingService *findings.Service,
+	graphService *graphingest.Service,
+	options orchestratorOptions,
+	iteration uint32,
+) (*orchestratorIterationResult, error) {
+	runtimes, err := lister.ListSourceRuntimes(ctx, options.Filter)
+	result := &orchestratorIterationResult{Iteration: iteration, StartedAt: time.Now().UTC()}
+	if err != nil {
+		return result, err
+	}
+	var runErr error
+	for _, runtime := range runtimes {
+		runtimeResult := &orchestratorRuntimeResult{
+			RuntimeID: strings.TrimSpace(runtime.GetId()),
+			SourceID:  strings.TrimSpace(runtime.GetSourceId()),
+			TenantID:  strings.TrimSpace(runtime.GetTenantId()),
+		}
+		if _, err := runtimeService.Sync(ctx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit}); err != nil {
+			runtimeResult.Sync = "failed"
+			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "sync", err)
+			runErr = err
+		} else {
+			runtimeResult.Sync = "completed"
+		}
+		if _, err := findingService.EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit}); err != nil {
+			runtimeResult.FindingRules = "failed"
+			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "finding_rules", err)
+			runErr = err
+		} else {
+			runtimeResult.FindingRules = "completed"
+		}
+		if _, err := graphService.RunRuntime(ctx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"}); err != nil {
+			runtimeResult.GraphIngest = "failed"
+			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
+			runErr = err
+		} else {
+			runtimeResult.GraphIngest = "completed"
+		}
+		result.Runtimes = append(result.Runtimes, runtimeResult)
+	}
+	return result, runErr
+}
+
+func appendRuntimeError(existing string, stage string, err error) string {
+	message := fmt.Sprintf("%s: %v", stage, err)
+	if strings.TrimSpace(existing) == "" {
+		return message
+	}
+	return existing + "; " + message
+}
+
+func findingStore(store ports.StateStore) ports.FindingStore {
+	typed, _ := store.(ports.FindingStore)
+	return typed
+}
+
+func findingEvaluationRunStore(store ports.StateStore) ports.FindingEvaluationRunStore {
+	typed, _ := store.(ports.FindingEvaluationRunStore)
+	return typed
+}
+
+func findingEvidenceStore(store ports.StateStore) ports.FindingEvidenceStore {
+	typed, _ := store.(ports.FindingEvidenceStore)
+	return typed
+}
+
+func claimStore(store ports.StateStore) ports.ClaimStore {
+	typed, _ := store.(ports.ClaimStore)
+	return typed
+}
+
+func findingGraphQueryStore(store ports.GraphStore) ports.GraphQueryStore {
+	typed, _ := store.(ports.GraphQueryStore)
+	return typed
+}
+
+func eventReplayer(appendLog ports.AppendLog) ports.EventReplayer {
+	typed, _ := appendLog.(ports.EventReplayer)
+	return typed
+}

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -23,6 +23,7 @@ import (
 
 const defaultOrchestratorIterations = 1
 const defaultSourceRuntimeLeaseTTL = 30 * time.Minute
+const sourceRuntimeLeaseOverscanLimit = 100
 
 type orchestratorOptions struct {
 	Filter         ports.SourceRuntimeFilter `json:"filter"`
@@ -262,13 +263,18 @@ func runOrchestratorIteration(
 	options orchestratorOptions,
 	iteration uint32,
 ) (*orchestratorIterationResult, error) {
-	runtimes, err := lister.ListSourceRuntimes(ctx, options.Filter)
+	targetLimit := options.Filter.Limit
+	runtimes, err := lister.ListSourceRuntimes(ctx, orchestratorListFilter(options.Filter))
 	result := &orchestratorIterationResult{Iteration: iteration, StartedAt: time.Now().UTC()}
 	if err != nil {
 		return result, err
 	}
 	var runErr error
+	var acquiredCount uint32
 	for _, runtime := range runtimes {
+		if targetLimit > 0 && acquiredCount >= targetLimit {
+			break
+		}
 		select {
 		case <-ctx.Done():
 			return result, ctx.Err()
@@ -292,6 +298,7 @@ func runOrchestratorIteration(
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			continue
 		}
+		acquiredCount++
 		runtimeCtx, cancelRuntime := context.WithCancel(ctx)
 		stopLeaseRenewal := startOrchestratorRuntimeLeaseRenewal(ctx, leaser, runtime, leaseOwner, cancelRuntime)
 		if _, err := runtimeService.Sync(runtimeCtx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit}); err != nil {
@@ -338,6 +345,18 @@ func runOrchestratorIteration(
 		result.Runtimes = append(result.Runtimes, runtimeResult)
 	}
 	return result, runErr
+}
+
+func orchestratorListFilter(filter ports.SourceRuntimeFilter) ports.SourceRuntimeFilter {
+	if filter.Limit == 0 {
+		return filter
+	}
+	if ^uint32(0)-filter.Limit < sourceRuntimeLeaseOverscanLimit {
+		filter.Limit = ^uint32(0)
+		return filter
+	}
+	filter.Limit += sourceRuntimeLeaseOverscanLimit
+	return filter
 }
 
 func orchestratorLeaseOwner() string {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -347,7 +347,7 @@ func releaseOrchestratorRuntimeLease(ctx context.Context, store ports.SourceRunt
 	if store == nil || runtime == nil {
 		return nil
 	}
-	return store.ReleaseSourceRuntimeLease(ctx, runtime.GetId(), owner)
+	return store.ReleaseSourceRuntimeLease(context.WithoutCancel(ctx), runtime.GetId(), owner)
 }
 
 func appendRuntimeError(existing string, stage string, err error) string {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -282,6 +282,8 @@ func runOrchestratorIteration(
 			runtimeResult.Sync = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "sync", err)
 			runErr = err
+			result.Runtimes = append(result.Runtimes, runtimeResult)
+			continue
 		} else {
 			runtimeResult.Sync = "completed"
 		}

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -292,11 +292,13 @@ func runOrchestratorIteration(
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			continue
 		}
-		stopLeaseRenewal := startOrchestratorRuntimeLeaseRenewal(ctx, leaser, runtime, leaseOwner)
-		if _, err := runtimeService.Sync(ctx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit}); err != nil {
+		runtimeCtx, cancelRuntime := context.WithCancel(ctx)
+		stopLeaseRenewal := startOrchestratorRuntimeLeaseRenewal(ctx, leaser, runtime, leaseOwner, cancelRuntime)
+		if _, err := runtimeService.Sync(runtimeCtx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit}); err != nil {
 			runtimeResult.Sync = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "sync", err)
 			runErr = err
+			cancelRuntime()
 			if renewalErr := stopLeaseRenewal(); renewalErr != nil {
 				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", renewalErr)
 				runErr = renewalErr
@@ -310,20 +312,21 @@ func runOrchestratorIteration(
 		} else {
 			runtimeResult.Sync = "completed"
 		}
-		if _, err := findingService.EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit}); err != nil {
+		if _, err := findingService.EvaluateSourceRuntimeRules(runtimeCtx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit}); err != nil {
 			runtimeResult.FindingRules = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "finding_rules", err)
 			runErr = err
 		} else {
 			runtimeResult.FindingRules = "completed"
 		}
-		if _, err := graphService.RunRuntime(ctx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"}); err != nil {
+		if _, err := graphService.RunRuntime(runtimeCtx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"}); err != nil {
 			runtimeResult.GraphIngest = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
 			runErr = err
 		} else {
 			runtimeResult.GraphIngest = "completed"
 		}
+		cancelRuntime()
 		if err := stopLeaseRenewal(); err != nil {
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", err)
 			runErr = err
@@ -352,14 +355,21 @@ func acquireOrchestratorRuntimeLease(ctx context.Context, store ports.SourceRunt
 	return store.AcquireSourceRuntimeLease(ctx, runtime.GetId(), owner, defaultSourceRuntimeLeaseTTL)
 }
 
-func startOrchestratorRuntimeLeaseRenewal(ctx context.Context, store ports.SourceRuntimeLeaseStore, runtime *cerebrov1.SourceRuntime, owner string) func() error {
+func startOrchestratorRuntimeLeaseRenewal(ctx context.Context, store ports.SourceRuntimeLeaseStore, runtime *cerebrov1.SourceRuntime, owner string, cancelWork context.CancelFunc) func() error {
+	return startOrchestratorRuntimeLeaseRenewalWithTTL(ctx, store, runtime, owner, cancelWork, defaultSourceRuntimeLeaseTTL)
+}
+
+func startOrchestratorRuntimeLeaseRenewalWithTTL(ctx context.Context, store ports.SourceRuntimeLeaseStore, runtime *cerebrov1.SourceRuntime, owner string, cancelWork context.CancelFunc, ttl time.Duration) func() error {
 	if store == nil || runtime == nil {
 		return func() error { return nil }
+	}
+	if cancelWork == nil {
+		cancelWork = func() {}
 	}
 	renewCtx, cancel := context.WithCancel(ctx)
 	done := make(chan error, 1)
 	go func() {
-		ticker := time.NewTicker(sourceRuntimeLeaseRenewalInterval(defaultSourceRuntimeLeaseTTL))
+		ticker := time.NewTicker(sourceRuntimeLeaseRenewalInterval(ttl))
 		defer ticker.Stop()
 		for {
 			select {
@@ -367,12 +377,14 @@ func startOrchestratorRuntimeLeaseRenewal(ctx context.Context, store ports.Sourc
 				done <- nil
 				return
 			case <-ticker.C:
-				renewed, err := store.RenewSourceRuntimeLease(renewCtx, runtime.GetId(), owner, defaultSourceRuntimeLeaseTTL)
+				renewed, err := store.RenewSourceRuntimeLease(renewCtx, runtime.GetId(), owner, ttl)
 				if err != nil {
+					cancelWork()
 					done <- err
 					return
 				}
 				if !renewed {
+					cancelWork()
 					done <- fmt.Errorf("source runtime lease lost: %s", runtime.GetId())
 					return
 				}

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -137,6 +137,7 @@ func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
 			if parsed == 0 {
 				return orchestratorOptions{}, fmt.Errorf("iterations must be at least 1 or forever")
 			}
+			options.RunForever = false
 			options.Iterations = uint32(parsed)
 		default:
 			return orchestratorOptions{}, fmt.Errorf("unsupported orchestrator argument %q", key)

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -120,6 +120,22 @@ func TestSourceRuntimeLeaseRenewalIntervalUsesHalfTTL(t *testing.T) {
 	}
 }
 
+func TestLeaseRenewalFailureCancelsRuntimeWork(t *testing.T) {
+	store := &leaseRuntimeStore{renewed: false}
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1"}
+	workCtx, cancelWork := context.WithCancel(context.Background())
+	stopRenewal := startOrchestratorRuntimeLeaseRenewalWithTTL(context.Background(), store, runtime, "owner-1", cancelWork, time.Millisecond)
+
+	select {
+	case <-workCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("runtime work context was not canceled after lease renewal failed")
+	}
+	if err := stopRenewal(); err == nil {
+		t.Fatal("stopRenewal() error = nil, want lease lost error")
+	}
+}
+
 func TestRunOrchestratorIterationSkipsLockedRuntime(t *testing.T) {
 	store := &orchestratorRuntimeStore{
 		runtime:  &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "missing-source"},
@@ -177,6 +193,7 @@ type leaseRuntimeStore struct {
 	leaseTTL          time.Duration
 	releaseContextErr error
 	acquired          bool
+	renewed           bool
 }
 
 func (s *leaseRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtimeID string, owner string, ttl time.Duration) (bool, error) {
@@ -187,7 +204,7 @@ func (s *leaseRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtime
 }
 
 func (s *leaseRuntimeStore) RenewSourceRuntimeLease(context.Context, string, string, time.Duration) (bool, error) {
-	return true, nil
+	return s.renewed, nil
 }
 
 func (s *leaseRuntimeStore) ReleaseSourceRuntimeLease(ctx context.Context, _ string, _ string) error {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -49,16 +49,25 @@ func TestTouchOrchestratorRuntimePersistsRuntimeForScanRotation(t *testing.T) {
 	if err := touchOrchestratorRuntime(context.Background(), store, runtime); err != nil {
 		t.Fatalf("touchOrchestratorRuntime() error = %v", err)
 	}
-	if store.putID != "runtime-1" {
-		t.Fatalf("touched runtime id = %q, want runtime-1", store.putID)
+	if store.touchID != "runtime-1" {
+		t.Fatalf("touched runtime id = %q, want runtime-1", store.touchID)
+	}
+	if store.putID != "" {
+		t.Fatalf("PutSourceRuntime() touched stale runtime snapshot %q", store.putID)
 	}
 }
 
 type touchRuntimeStore struct {
-	putID string
+	touchID string
+	putID   string
 }
 
 func (s *touchRuntimeStore) Ping(context.Context) error { return nil }
+
+func (s *touchRuntimeStore) TouchSourceRuntime(_ context.Context, runtimeID string) error {
+	s.touchID = runtimeID
+	return nil
+}
 
 func (s *touchRuntimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {
 	s.putID = runtime.GetId()

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -21,3 +21,12 @@ func TestAppendOrchestratorRunPreservesFiniteHistory(t *testing.T) {
 		t.Fatalf("finite runs = %#v, want all iterations", runs)
 	}
 }
+
+func TestShouldPrintOrchestratorResultSkipsNilStartupFailure(t *testing.T) {
+	if shouldPrintOrchestratorResult(nil) {
+		t.Fatal("shouldPrintOrchestratorResult(nil) = true, want false")
+	}
+	if !shouldPrintOrchestratorResult(&orchestratorResult{}) {
+		t.Fatal("shouldPrintOrchestratorResult(non-nil) = false, want true")
+	}
+}

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -160,6 +160,45 @@ func TestRunOrchestratorIterationSkipsLockedRuntime(t *testing.T) {
 	}
 }
 
+func TestRunOrchestratorIterationContinuesPastLockedRuntimeWithLimit(t *testing.T) {
+	store := &orchestratorRuntimeStore{
+		runtimes: []*cerebrov1.SourceRuntime{
+			{Id: "locked-runtime", SourceId: "missing-source"},
+			{Id: "unlocked-runtime", SourceId: "missing-source"},
+		},
+		acquiredByID: map[string]bool{
+			"locked-runtime":   false,
+			"unlocked-runtime": true,
+		},
+	}
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(nil, store, nil, nil),
+		nil,
+		nil,
+		orchestratorOptions{Filter: ports.SourceRuntimeFilter{Limit: 1}},
+		1,
+	)
+	if err == nil {
+		t.Fatal("runOrchestratorIteration() error = nil, want unlocked runtime sync failure")
+	}
+	if store.listFilter.Limit != 1+sourceRuntimeLeaseOverscanLimit {
+		t.Fatalf("list limit = %d, want overscan limit", store.listFilter.Limit)
+	}
+	if got := len(result.Runtimes); got != 2 {
+		t.Fatalf("runtime result count = %d, want locked skip plus unlocked attempt", got)
+	}
+	if result.Runtimes[0].RuntimeID != "locked-runtime" || result.Runtimes[0].Sync != "skipped" {
+		t.Fatalf("first runtime result = %#v, want locked skip", result.Runtimes[0])
+	}
+	if result.Runtimes[1].RuntimeID != "unlocked-runtime" {
+		t.Fatalf("second runtime id = %q, want unlocked-runtime", result.Runtimes[1].RuntimeID)
+	}
+}
+
 func TestRunOrchestratorIterationStopsBeforeRuntimeWhenContextCanceled(t *testing.T) {
 	store := &orchestratorRuntimeStore{
 		runtime:  &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "missing-source"},
@@ -213,10 +252,13 @@ func (s *leaseRuntimeStore) ReleaseSourceRuntimeLease(ctx context.Context, _ str
 }
 
 type orchestratorRuntimeStore struct {
-	runtime   *cerebrov1.SourceRuntime
-	acquired  bool
-	leaseID   string
-	releaseID string
+	runtime      *cerebrov1.SourceRuntime
+	runtimes     []*cerebrov1.SourceRuntime
+	acquired     bool
+	acquiredByID map[string]bool
+	listFilter   ports.SourceRuntimeFilter
+	leaseID      string
+	releaseID    string
 }
 
 func (s *orchestratorRuntimeStore) Ping(context.Context) error { return nil }
@@ -225,16 +267,28 @@ func (s *orchestratorRuntimeStore) PutSourceRuntime(context.Context, *cerebrov1.
 	return nil
 }
 
-func (s *orchestratorRuntimeStore) GetSourceRuntime(context.Context, string) (*cerebrov1.SourceRuntime, error) {
+func (s *orchestratorRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov1.SourceRuntime, error) {
+	for _, runtime := range s.runtimes {
+		if runtime.GetId() == id {
+			return runtime, nil
+		}
+	}
 	return s.runtime, nil
 }
 
-func (s *orchestratorRuntimeStore) ListSourceRuntimes(context.Context, ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+func (s *orchestratorRuntimeStore) ListSourceRuntimes(_ context.Context, filter ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+	s.listFilter = filter
+	if len(s.runtimes) > 0 {
+		return s.runtimes, nil
+	}
 	return []*cerebrov1.SourceRuntime{s.runtime}, nil
 }
 
 func (s *orchestratorRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtimeID string, _ string, _ time.Duration) (bool, error) {
 	s.leaseID = runtimeID
+	if s.acquiredByID != nil {
+		return s.acquiredByID[runtimeID], nil
+	}
 	return s.acquired, nil
 }
 

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"syscall"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -39,6 +41,13 @@ func TestShouldPrintOrchestratorResultSkipsNilStartupFailure(t *testing.T) {
 func TestParseOrchestratorOptionsRejectsZeroLimit(t *testing.T) {
 	if _, err := parseOrchestratorOptions([]string{"limit=0"}); err == nil {
 		t.Fatal("parseOrchestratorOptions(limit=0) error = nil, want error")
+	}
+}
+
+func TestOrchestratorShutdownSignalsIncludeSIGTERM(t *testing.T) {
+	signals := orchestratorShutdownSignals()
+	if len(signals) != 2 || signals[0] != os.Interrupt || signals[1] != syscall.SIGTERM {
+		t.Fatalf("orchestratorShutdownSignals() = %#v, want interrupt and SIGTERM", signals)
 	}
 }
 

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
@@ -55,12 +56,14 @@ func TestOrchestratorShutdownSignalsIncludeSIGTERM(t *testing.T) {
 
 func TestRunOrchestratorIterationStopsAfterSyncFailure(t *testing.T) {
 	store := &orchestratorRuntimeStore{
-		runtime: &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "missing-source"},
+		runtime:  &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "missing-source"},
+		acquired: true,
 	}
 	result, err := runOrchestratorIteration(
 		context.Background(),
 		store,
 		store,
+		"test-owner",
 		sourceruntime.New(nil, store, nil, nil),
 		nil,
 		nil,
@@ -76,46 +79,101 @@ func TestRunOrchestratorIterationStopsAfterSyncFailure(t *testing.T) {
 	if result.Runtimes[0].FindingRules != "" || result.Runtimes[0].GraphIngest != "" {
 		t.Fatalf("downstream stages ran after sync failure: %#v", result.Runtimes[0])
 	}
+	if store.leaseID != "runtime-1" || store.releaseID != "runtime-1" {
+		t.Fatalf("lease/release = %q/%q, want runtime-1/runtime-1", store.leaseID, store.releaseID)
+	}
 }
 
-func TestTouchOrchestratorRuntimePersistsRuntimeForScanRotation(t *testing.T) {
-	store := &touchRuntimeStore{}
+func TestAcquireOrchestratorRuntimeLeaseClaimsRuntime(t *testing.T) {
+	store := &leaseRuntimeStore{acquired: true}
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1"}
 
-	if err := touchOrchestratorRuntime(context.Background(), store, runtime); err != nil {
-		t.Fatalf("touchOrchestratorRuntime() error = %v", err)
+	acquired, err := acquireOrchestratorRuntimeLease(context.Background(), store, runtime, "owner-1")
+	if err != nil {
+		t.Fatalf("acquireOrchestratorRuntimeLease() error = %v", err)
 	}
-	if store.touchID != "runtime-1" {
-		t.Fatalf("touched runtime id = %q, want runtime-1", store.touchID)
+	if !acquired {
+		t.Fatal("acquireOrchestratorRuntimeLease() = false, want true")
 	}
-	if store.putID != "" {
-		t.Fatalf("PutSourceRuntime() touched stale runtime snapshot %q", store.putID)
+	if store.leaseID != "runtime-1" || store.leaseOwner != "owner-1" || store.leaseTTL != defaultSourceRuntimeLeaseTTL {
+		t.Fatalf("lease = (%q, %q, %s), want runtime-1 owner-1 %s", store.leaseID, store.leaseOwner, store.leaseTTL, defaultSourceRuntimeLeaseTTL)
 	}
 }
 
-type touchRuntimeStore struct {
-	touchID string
-	putID   string
+func TestRunOrchestratorIterationSkipsLockedRuntime(t *testing.T) {
+	store := &orchestratorRuntimeStore{
+		runtime:  &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "missing-source"},
+		acquired: false,
+	}
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(nil, store, nil, nil),
+		nil,
+		nil,
+		orchestratorOptions{},
+		1,
+	)
+	if err != nil {
+		t.Fatalf("runOrchestratorIteration() error = %v", err)
+	}
+	if got := result.Runtimes[0].Sync; got != "skipped" {
+		t.Fatalf("runtime sync status = %q, want skipped", got)
+	}
 }
 
-func (s *touchRuntimeStore) Ping(context.Context) error { return nil }
+func TestRunOrchestratorIterationStopsBeforeRuntimeWhenContextCanceled(t *testing.T) {
+	store := &orchestratorRuntimeStore{
+		runtime:  &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "missing-source"},
+		acquired: true,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-func (s *touchRuntimeStore) TouchSourceRuntime(_ context.Context, runtimeID string) error {
-	s.touchID = runtimeID
+	result, err := runOrchestratorIteration(
+		ctx,
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(nil, store, nil, nil),
+		nil,
+		nil,
+		orchestratorOptions{},
+		1,
+	)
+	if err == nil {
+		t.Fatal("runOrchestratorIteration() error = nil, want context cancellation")
+	}
+	if got := len(result.Runtimes); got != 0 {
+		t.Fatalf("runtime result count = %d, want 0", got)
+	}
+}
+
+type leaseRuntimeStore struct {
+	leaseID    string
+	leaseOwner string
+	leaseTTL   time.Duration
+	acquired   bool
+}
+
+func (s *leaseRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtimeID string, owner string, ttl time.Duration) (bool, error) {
+	s.leaseID = runtimeID
+	s.leaseOwner = owner
+	s.leaseTTL = ttl
+	return s.acquired, nil
+}
+
+func (s *leaseRuntimeStore) ReleaseSourceRuntimeLease(context.Context, string, string) error {
 	return nil
-}
-
-func (s *touchRuntimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {
-	s.putID = runtime.GetId()
-	return nil
-}
-
-func (s *touchRuntimeStore) GetSourceRuntime(context.Context, string) (*cerebrov1.SourceRuntime, error) {
-	return nil, nil
 }
 
 type orchestratorRuntimeStore struct {
-	runtime *cerebrov1.SourceRuntime
+	runtime   *cerebrov1.SourceRuntime
+	acquired  bool
+	leaseID   string
+	releaseID string
 }
 
 func (s *orchestratorRuntimeStore) Ping(context.Context) error { return nil }
@@ -132,6 +190,12 @@ func (s *orchestratorRuntimeStore) ListSourceRuntimes(context.Context, ports.Sou
 	return []*cerebrov1.SourceRuntime{s.runtime}, nil
 }
 
-func (s *orchestratorRuntimeStore) TouchSourceRuntime(context.Context, string) error {
+func (s *orchestratorRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtimeID string, _ string, _ time.Duration) (bool, error) {
+	s.leaseID = runtimeID
+	return s.acquired, nil
+}
+
+func (s *orchestratorRuntimeStore) ReleaseSourceRuntimeLease(_ context.Context, runtimeID string, _ string) error {
+	s.releaseID = runtimeID
 	return nil
 }

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -36,6 +36,12 @@ func TestShouldPrintOrchestratorResultSkipsNilStartupFailure(t *testing.T) {
 	}
 }
 
+func TestParseOrchestratorOptionsRejectsZeroLimit(t *testing.T) {
+	if _, err := parseOrchestratorOptions([]string{"limit=0"}); err == nil {
+		t.Fatal("parseOrchestratorOptions(limit=0) error = nil, want error")
+	}
+}
+
 func TestTouchOrchestratorRuntimePersistsRuntimeForScanRotation(t *testing.T) {
 	store := &touchRuntimeStore{}
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1"}

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceruntime"
 )
 
 func TestAppendOrchestratorRunBoundsForeverHistory(t *testing.T) {
@@ -51,6 +53,31 @@ func TestOrchestratorShutdownSignalsIncludeSIGTERM(t *testing.T) {
 	}
 }
 
+func TestRunOrchestratorIterationStopsAfterSyncFailure(t *testing.T) {
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "missing-source"},
+	}
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		sourceruntime.New(nil, store, nil, nil),
+		nil,
+		nil,
+		orchestratorOptions{},
+		1,
+	)
+	if err == nil {
+		t.Fatal("runOrchestratorIteration() error = nil, want sync failure")
+	}
+	if got := len(result.Runtimes); got != 1 {
+		t.Fatalf("runtime result count = %d, want 1", got)
+	}
+	if result.Runtimes[0].FindingRules != "" || result.Runtimes[0].GraphIngest != "" {
+		t.Fatalf("downstream stages ran after sync failure: %#v", result.Runtimes[0])
+	}
+}
+
 func TestTouchOrchestratorRuntimePersistsRuntimeForScanRotation(t *testing.T) {
 	store := &touchRuntimeStore{}
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1"}
@@ -85,4 +112,26 @@ func (s *touchRuntimeStore) PutSourceRuntime(_ context.Context, runtime *cerebro
 
 func (s *touchRuntimeStore) GetSourceRuntime(context.Context, string) (*cerebrov1.SourceRuntime, error) {
 	return nil, nil
+}
+
+type orchestratorRuntimeStore struct {
+	runtime *cerebrov1.SourceRuntime
+}
+
+func (s *orchestratorRuntimeStore) Ping(context.Context) error { return nil }
+
+func (s *orchestratorRuntimeStore) PutSourceRuntime(context.Context, *cerebrov1.SourceRuntime) error {
+	return nil
+}
+
+func (s *orchestratorRuntimeStore) GetSourceRuntime(context.Context, string) (*cerebrov1.SourceRuntime, error) {
+	return s.runtime, nil
+}
+
+func (s *orchestratorRuntimeStore) ListSourceRuntimes(context.Context, ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+	return []*cerebrov1.SourceRuntime{s.runtime}, nil
+}
+
+func (s *orchestratorRuntimeStore) TouchSourceRuntime(context.Context, string) error {
+	return nil
 }

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestAppendOrchestratorRunBoundsForeverHistory(t *testing.T) {
+	var runs []*orchestratorIterationResult
+	for i := uint32(1); i <= 3; i++ {
+		runs = appendOrchestratorRun(runs, &orchestratorIterationResult{Iteration: i}, true)
+	}
+	if len(runs) != 1 || runs[0].Iteration != 3 {
+		t.Fatalf("forever runs = %#v, want only latest iteration", runs)
+	}
+}
+
+func TestAppendOrchestratorRunPreservesFiniteHistory(t *testing.T) {
+	var runs []*orchestratorIterationResult
+	for i := uint32(1); i <= 2; i++ {
+		runs = appendOrchestratorRun(runs, &orchestratorIterationResult{Iteration: i}, false)
+	}
+	if len(runs) != 2 || runs[0].Iteration != 1 || runs[1].Iteration != 2 {
+		t.Fatalf("finite runs = %#v, want all iterations", runs)
+	}
+}

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
 
 func TestAppendOrchestratorRunBoundsForeverHistory(t *testing.T) {
 	var runs []*orchestratorIterationResult
@@ -29,4 +34,31 @@ func TestShouldPrintOrchestratorResultSkipsNilStartupFailure(t *testing.T) {
 	if !shouldPrintOrchestratorResult(&orchestratorResult{}) {
 		t.Fatal("shouldPrintOrchestratorResult(non-nil) = false, want true")
 	}
+}
+
+func TestTouchOrchestratorRuntimePersistsRuntimeForScanRotation(t *testing.T) {
+	store := &touchRuntimeStore{}
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1"}
+
+	if err := touchOrchestratorRuntime(context.Background(), store, runtime); err != nil {
+		t.Fatalf("touchOrchestratorRuntime() error = %v", err)
+	}
+	if store.putID != "runtime-1" {
+		t.Fatalf("touched runtime id = %q, want runtime-1", store.putID)
+	}
+}
+
+type touchRuntimeStore struct {
+	putID string
+}
+
+func (s *touchRuntimeStore) Ping(context.Context) error { return nil }
+
+func (s *touchRuntimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {
+	s.putID = runtime.GetId()
+	return nil
+}
+
+func (s *touchRuntimeStore) GetSourceRuntime(context.Context, string) (*cerebrov1.SourceRuntime, error) {
+	return nil, nil
 }

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -100,6 +100,20 @@ func TestAcquireOrchestratorRuntimeLeaseClaimsRuntime(t *testing.T) {
 	}
 }
 
+func TestReleaseOrchestratorRuntimeLeaseIgnoresCancellation(t *testing.T) {
+	store := &leaseRuntimeStore{}
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1"}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := releaseOrchestratorRuntimeLease(ctx, store, runtime, "owner-1"); err != nil {
+		t.Fatalf("releaseOrchestratorRuntimeLease() error = %v", err)
+	}
+	if store.releaseContextErr != nil {
+		t.Fatalf("release context err = %v, want nil", store.releaseContextErr)
+	}
+}
+
 func TestRunOrchestratorIterationSkipsLockedRuntime(t *testing.T) {
 	store := &orchestratorRuntimeStore{
 		runtime:  &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "missing-source"},
@@ -152,10 +166,11 @@ func TestRunOrchestratorIterationStopsBeforeRuntimeWhenContextCanceled(t *testin
 }
 
 type leaseRuntimeStore struct {
-	leaseID    string
-	leaseOwner string
-	leaseTTL   time.Duration
-	acquired   bool
+	leaseID           string
+	leaseOwner        string
+	leaseTTL          time.Duration
+	releaseContextErr error
+	acquired          bool
 }
 
 func (s *leaseRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtimeID string, owner string, ttl time.Duration) (bool, error) {
@@ -165,7 +180,8 @@ func (s *leaseRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtime
 	return s.acquired, nil
 }
 
-func (s *leaseRuntimeStore) ReleaseSourceRuntimeLease(context.Context, string, string) error {
+func (s *leaseRuntimeStore) ReleaseSourceRuntimeLease(ctx context.Context, _ string, _ string) error {
+	s.releaseContextErr = ctx.Err()
 	return nil
 }
 

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -112,6 +112,12 @@ func TestReleaseOrchestratorRuntimeLeaseIgnoresCancellation(t *testing.T) {
 	if store.releaseContextErr != nil {
 		t.Fatalf("release context err = %v, want nil", store.releaseContextErr)
 	}
+	if !store.releaseHasDeadline {
+		t.Fatal("release context has no deadline")
+	}
+	if time.Until(store.releaseDeadline) > sourceRuntimeLeaseReleaseTimeout {
+		t.Fatalf("release deadline = %s, want within %s", store.releaseDeadline, sourceRuntimeLeaseReleaseTimeout)
+	}
 }
 
 func TestSourceRuntimeLeaseRenewalIntervalUsesHalfTTL(t *testing.T) {
@@ -233,12 +239,14 @@ func TestRunOrchestratorIterationStopsBeforeRuntimeWhenContextCanceled(t *testin
 }
 
 type leaseRuntimeStore struct {
-	leaseID           string
-	leaseOwner        string
-	leaseTTL          time.Duration
-	releaseContextErr error
-	acquired          bool
-	renewed           bool
+	leaseID            string
+	leaseOwner         string
+	leaseTTL           time.Duration
+	releaseContextErr  error
+	releaseHasDeadline bool
+	releaseDeadline    time.Time
+	acquired           bool
+	renewed            bool
 }
 
 func (s *leaseRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtimeID string, owner string, ttl time.Duration) (bool, error) {
@@ -254,6 +262,7 @@ func (s *leaseRuntimeStore) RenewSourceRuntimeLease(context.Context, string, str
 
 func (s *leaseRuntimeStore) ReleaseSourceRuntimeLease(ctx context.Context, _ string, _ string) error {
 	s.releaseContextErr = ctx.Err()
+	s.releaseDeadline, s.releaseHasDeadline = ctx.Deadline()
 	return nil
 }
 

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -114,6 +114,12 @@ func TestReleaseOrchestratorRuntimeLeaseIgnoresCancellation(t *testing.T) {
 	}
 }
 
+func TestSourceRuntimeLeaseRenewalIntervalUsesHalfTTL(t *testing.T) {
+	if got := sourceRuntimeLeaseRenewalInterval(30 * time.Minute); got != 15*time.Minute {
+		t.Fatalf("sourceRuntimeLeaseRenewalInterval() = %s, want 15m", got)
+	}
+}
+
 func TestRunOrchestratorIterationSkipsLockedRuntime(t *testing.T) {
 	store := &orchestratorRuntimeStore{
 		runtime:  &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "missing-source"},
@@ -180,6 +186,10 @@ func (s *leaseRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtime
 	return s.acquired, nil
 }
 
+func (s *leaseRuntimeStore) RenewSourceRuntimeLease(context.Context, string, string, time.Duration) (bool, error) {
+	return true, nil
+}
+
 func (s *leaseRuntimeStore) ReleaseSourceRuntimeLease(ctx context.Context, _ string, _ string) error {
 	s.releaseContextErr = ctx.Err()
 	return nil
@@ -209,6 +219,10 @@ func (s *orchestratorRuntimeStore) ListSourceRuntimes(context.Context, ports.Sou
 func (s *orchestratorRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, runtimeID string, _ string, _ time.Duration) (bool, error) {
 	s.leaseID = runtimeID
 	return s.acquired, nil
+}
+
+func (s *orchestratorRuntimeStore) RenewSourceRuntimeLease(context.Context, string, string, time.Duration) (bool, error) {
+	return true, nil
 }
 
 func (s *orchestratorRuntimeStore) ReleaseSourceRuntimeLease(_ context.Context, runtimeID string, _ string) error {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -120,6 +120,12 @@ func TestSourceRuntimeLeaseRenewalIntervalUsesHalfTTL(t *testing.T) {
 	}
 }
 
+func TestOrchestratorListFilterRequestsAllByDefault(t *testing.T) {
+	if got := orchestratorListFilter(ports.SourceRuntimeFilter{}).Limit; got != ^uint32(0) {
+		t.Fatalf("orchestratorListFilter(default).Limit = %d, want max uint32", got)
+	}
+}
+
 func TestLeaseRenewalFailureCancelsRuntimeWork(t *testing.T) {
 	store := &leaseRuntimeStore{renewed: false}
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1"}

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2098,7 +2098,7 @@ func newRuntimeService(deps Dependencies, sources *sourcecdk.Registry) *sourceru
 		sourceRuntimeStore(deps.StateStore),
 		deps.AppendLog,
 		sourceProjector(deps.StateStore, deps.GraphStore),
-	).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
+	).WithConfigResolver(config.ResolveSourceRuntimeConfigSecretReferences)
 }
 
 func (a *App) claimService() *claims.Service {
@@ -2149,7 +2149,7 @@ func newGraphIngestService(deps Dependencies, sources *sourcecdk.Registry) *grap
 		sourceRuntimeStore(deps.StateStore),
 		sourceProjector(nil, deps.GraphStore),
 		deps.GraphStore,
-	).WithConfigPreparer(config.ResolveSourceConfigSecretReferences)
+	).WithConfigPreparer(config.ResolveSourceRuntimeConfigSecretReferences)
 }
 
 func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -989,7 +989,7 @@ func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
 			filter.TenantID = strings.TrimSpace(auth.principal.TenantID)
 		}
 	}
-	if filter.TenantID == "" && hasAuthContext(r.Context()) {
+	if filter.TenantID == "" && requiresTenantFilter(r.Context()) {
 		writeSourceRuntimeError(w, errTenantForbidden)
 		return
 	}

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2110,6 +2110,9 @@ func resolveRuntimeSourceConfig(ctx context.Context, sourceID string, values map
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", sourceruntime.ErrInvalidRequest, err)
 	}
+	if err := authorizeSourceConfigTenant(ctx, resolved); err != nil {
+		return nil, err
+	}
 	return resolved, nil
 }
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2181,7 +2181,7 @@ func newGraphIngestService(deps Dependencies, sources *sourcecdk.Registry) *grap
 		sourceRuntimeStore(deps.StateStore),
 		sourceProjector(nil, deps.GraphStore),
 		deps.GraphStore,
-	).WithConfigPreparer(config.ResolveSourceRuntimeConfigSecretReferences)
+	).WithConfigPreparer(resolveRuntimeSourceConfig)
 }
 
 func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -61,8 +61,9 @@ type bootstrapService struct {
 }
 
 const (
-	maxProtoJSONBodyBytes = 1 << 20
-	healthCheckTimeout    = 2 * time.Second
+	maxProtoJSONBodyBytes              = 1 << 20
+	healthCheckTimeout                 = 2 * time.Second
+	sourceRuntimeProgressConfigHashKey = "__cerebro_resolved_progress_config_hash"
 )
 
 var (
@@ -2678,6 +2679,9 @@ func redactSourceRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRunt
 	redacted := proto.Clone(runtime).(*cerebrov1.SourceRuntime)
 	config := make(map[string]string, len(redacted.GetConfig()))
 	for key, value := range redacted.GetConfig() {
+		if key == sourceRuntimeProgressConfigHashKey {
+			continue
+		}
 		if sensitiveSourceConfigKey(key) {
 			config[key] = "[redacted]"
 			continue

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -119,6 +119,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("GET /graph/ingest-runs", deprecatedRoute(app.handleListGraphIngestRuns))
 	mux.HandleFunc("GET /platform/graph/ingest-runs/{runID}", app.handleGetGraphIngestRun)
 	mux.HandleFunc("GET /graph/ingest-runs/{runID}", deprecatedRoute(app.handleGetGraphIngestRun))
+	mux.HandleFunc("GET /source-runtimes", app.handleListSourceRuntimes)
 	mux.HandleFunc("PUT /source-runtimes/{runtimeID}", app.handlePutSourceRuntime)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}", app.handleGetSourceRuntime)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/sync", app.handleSyncSourceRuntime)
@@ -970,6 +971,34 @@ func (a *App) handleGetSourceRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, response)
+}
+
+func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
+	limit, err := uint32QueryParam(r, "limit")
+	if err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	filter := ports.SourceRuntimeFilter{
+		TenantID: strings.TrimSpace(r.URL.Query().Get("tenant_id")),
+		SourceID: strings.TrimSpace(r.URL.Query().Get("source_id")),
+		Limit:    limit,
+	}
+	if filter.TenantID == "" {
+		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok && strings.TrimSpace(auth.principal.TenantID) != "" {
+			filter.TenantID = strings.TrimSpace(auth.principal.TenantID)
+		}
+	}
+	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	runtimes, err := a.runtimeService().List(r.Context(), filter)
+	if err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	writeSourceRuntimeListJSON(w, http.StatusOK, runtimes)
 }
 
 func (a *App) handleSyncSourceRuntime(w http.ResponseWriter, r *http.Request) {
@@ -2026,6 +2055,19 @@ func writeJSON(w http.ResponseWriter, statusCode int, value any) {
 	_, _ = w.Write(payload)
 }
 
+func writeSourceRuntimeListJSON(w http.ResponseWriter, statusCode int, runtimes []*cerebrov1.SourceRuntime) {
+	items := make([]json.RawMessage, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(runtime)
+		if err != nil {
+			http.Error(w, "failed to encode response", http.StatusInternalServerError)
+			return
+		}
+		items = append(items, json.RawMessage(payload))
+	}
+	writeJSON(w, statusCode, map[string]any{"runtimes": items})
+}
+
 func uint32QueryParam(r *http.Request, key string) (uint32, error) {
 	value := strings.TrimSpace(r.URL.Query().Get(key))
 	if value == "" {
@@ -2059,7 +2101,7 @@ func (a *App) runtimeService() *sourceruntime.Service {
 		sourceRuntimeStore(a.deps.StateStore),
 		a.deps.AppendLog,
 		sourceProjector(a.deps.StateStore, a.deps.GraphStore),
-	)
+	).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
 }
 
 func (a *App) claimService() *claims.Service {
@@ -2110,7 +2152,7 @@ func newGraphIngestService(deps Dependencies, sources *sourcecdk.Registry) *grap
 		sourceRuntimeStore(deps.StateStore),
 		sourceProjector(nil, deps.GraphStore),
 		deps.GraphStore,
-	)
+	).WithConfigPreparer(config.ResolveSourceConfigSecretReferences)
 }
 
 func sourceConfigFromRequest(r *http.Request) (map[string]string, error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1381,11 +1381,11 @@ func (s *bootstrapService) GetReportRun(ctx context.Context, req *connect.Reques
 }
 
 func (s *bootstrapService) ListSources(_ context.Context, _ *connect.Request[cerebrov1.ListSourcesRequest]) (*connect.Response[cerebrov1.ListSourcesResponse], error) {
-	return connect.NewResponse(sourceops.New(s.sources).List()), nil
+	return connect.NewResponse(newSourceService(s.sources).List()), nil
 }
 
 func (s *bootstrapService) CheckSource(ctx context.Context, req *connect.Request[cerebrov1.CheckSourceRequest]) (*connect.Response[cerebrov1.CheckSourceResponse], error) {
-	response, err := sourceops.New(s.sources).Check(ctx, req.Msg)
+	response, err := newSourceService(s.sources).Check(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceConnectError(err)
 	}
@@ -1393,7 +1393,7 @@ func (s *bootstrapService) CheckSource(ctx context.Context, req *connect.Request
 }
 
 func (s *bootstrapService) DiscoverSource(ctx context.Context, req *connect.Request[cerebrov1.DiscoverSourceRequest]) (*connect.Response[cerebrov1.DiscoverSourceResponse], error) {
-	response, err := sourceops.New(s.sources).Discover(ctx, req.Msg)
+	response, err := newSourceService(s.sources).Discover(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceConnectError(err)
 	}
@@ -1401,7 +1401,7 @@ func (s *bootstrapService) DiscoverSource(ctx context.Context, req *connect.Requ
 }
 
 func (s *bootstrapService) ReadSource(ctx context.Context, req *connect.Request[cerebrov1.ReadSourceRequest]) (*connect.Response[cerebrov1.ReadSourceResponse], error) {
-	response, err := sourceops.New(s.sources).Read(ctx, req.Msg)
+	response, err := newSourceService(s.sources).Read(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceConnectError(err)
 	}
@@ -1412,12 +1412,7 @@ func (s *bootstrapService) PutSourceRuntime(ctx context.Context, req *connect.Re
 	if err := authorizePutSourceRuntimeTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetRuntime()); err != nil {
 		return nil, sourceRuntimeConnectError(err)
 	}
-	response, err := sourceruntime.New(
-		s.sources,
-		sourceRuntimeStore(s.deps.StateStore),
-		s.deps.AppendLog,
-		sourceProjector(s.deps.StateStore, s.deps.GraphStore),
-	).Put(ctx, req.Msg)
+	response, err := newRuntimeService(s.deps, s.sources).Put(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceRuntimeConnectError(err)
 	}
@@ -1428,12 +1423,7 @@ func (s *bootstrapService) GetSourceRuntime(ctx context.Context, req *connect.Re
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetId(), false); err != nil {
 		return nil, sourceRuntimeConnectError(err)
 	}
-	response, err := sourceruntime.New(
-		s.sources,
-		sourceRuntimeStore(s.deps.StateStore),
-		s.deps.AppendLog,
-		sourceProjector(s.deps.StateStore, s.deps.GraphStore),
-	).Get(ctx, req.Msg)
+	response, err := newRuntimeService(s.deps, s.sources).Get(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceRuntimeConnectError(err)
 	}
@@ -1444,12 +1434,7 @@ func (s *bootstrapService) SyncSourceRuntime(ctx context.Context, req *connect.R
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetId(), false); err != nil {
 		return nil, sourceRuntimeConnectError(err)
 	}
-	response, err := sourceruntime.New(
-		s.sources,
-		sourceRuntimeStore(s.deps.StateStore),
-		s.deps.AppendLog,
-		sourceProjector(s.deps.StateStore, s.deps.GraphStore),
-	).Sync(ctx, req.Msg)
+	response, err := newRuntimeService(s.deps, s.sources).Sync(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceRuntimeConnectError(err)
 	}
@@ -2088,7 +2073,7 @@ func uint32QueryParam(r *http.Request, key string) (uint32, error) {
 }
 
 func (a *App) sourceService() *sourceops.Service {
-	return sourceops.New(a.sources)
+	return newSourceService(a.sources)
 }
 
 func (a *App) reportService() *reports.Service {
@@ -2100,11 +2085,19 @@ func (a *App) reportService() *reports.Service {
 }
 
 func (a *App) runtimeService() *sourceruntime.Service {
+	return newRuntimeService(a.deps, a.sources)
+}
+
+func newSourceService(sources *sourcecdk.Registry) *sourceops.Service {
+	return sourceops.New(sources).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
+}
+
+func newRuntimeService(deps Dependencies, sources *sourcecdk.Registry) *sourceruntime.Service {
 	return sourceruntime.New(
-		a.sources,
-		sourceRuntimeStore(a.deps.StateStore),
-		a.deps.AppendLog,
-		sourceProjector(a.deps.StateStore, a.deps.GraphStore),
+		sources,
+		sourceRuntimeStore(deps.StateStore),
+		deps.AppendLog,
+		sourceProjector(deps.StateStore, deps.GraphStore),
 	).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
 }
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2107,7 +2107,7 @@ func newRuntimeService(deps Dependencies, sources *sourcecdk.Registry) *sourceru
 }
 
 func resolveRuntimeSourceConfig(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
-	if err := authorizeRuntimeConfigEnvReferences(ctx, values); err != nil {
+	if err := authorizeRuntimeConfigEnvReferences(ctx, sourceID, values); err != nil {
 		return nil, err
 	}
 	resolved, err := config.ResolveSourceRuntimeConfigSecretReferences(ctx, sourceID, values)
@@ -2120,12 +2120,16 @@ func resolveRuntimeSourceConfig(ctx context.Context, sourceID string, values map
 	return resolved, nil
 }
 
-func authorizeRuntimeConfigEnvReferences(ctx context.Context, values map[string]string) error {
+func authorizeRuntimeConfigEnvReferences(ctx context.Context, sourceID string, values map[string]string) error {
 	if !hasTenantScopedAuth(ctx) && !requiresTenantFilter(ctx) {
 		return nil
 	}
 	for key, value := range values {
-		if strings.TrimSpace(key) == "tenant_id" || !sourceconfig.IsSecretReference(value) {
+		envName, ok := sourceconfig.SecretReferenceName(value)
+		if strings.TrimSpace(key) == "tenant_id" || !ok {
+			continue
+		}
+		if sourceconfig.LiteralEnvPrefixKey(key) && !config.SourceConfigEnvReferenceAllowed(sourceID, key, envName) {
 			continue
 		}
 		return errTenantForbidden

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -32,6 +32,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/reports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceprojection"
 	"github.com/writer/cerebro/internal/sourceruntime"
@@ -2106,6 +2107,9 @@ func newRuntimeService(deps Dependencies, sources *sourcecdk.Registry) *sourceru
 }
 
 func resolveRuntimeSourceConfig(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
+	if err := authorizeRuntimeConfigEnvReferences(ctx, values); err != nil {
+		return nil, err
+	}
 	resolved, err := config.ResolveSourceRuntimeConfigSecretReferences(ctx, sourceID, values)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", sourceruntime.ErrInvalidRequest, err)
@@ -2114,6 +2118,19 @@ func resolveRuntimeSourceConfig(ctx context.Context, sourceID string, values map
 		return nil, err
 	}
 	return resolved, nil
+}
+
+func authorizeRuntimeConfigEnvReferences(ctx context.Context, values map[string]string) error {
+	if !hasTenantScopedAuth(ctx) && !requiresTenantFilter(ctx) {
+		return nil
+	}
+	for key, value := range values {
+		if strings.TrimSpace(key) == "tenant_id" || !sourceconfig.IsSecretReference(value) {
+			continue
+		}
+		return errTenantForbidden
+	}
+	return nil
 }
 
 func (a *App) claimService() *claims.Service {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2089,7 +2089,7 @@ func (a *App) runtimeService() *sourceruntime.Service {
 }
 
 func newSourceService(sources *sourcecdk.Registry) *sourceops.Service {
-	return sourceops.New(sources).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
+	return sourceops.New(sources)
 }
 
 func newRuntimeService(deps Dependencies, sources *sourcecdk.Registry) *sourceruntime.Service {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2276,7 +2276,7 @@ func writeSourceRuntimeError(w http.ResponseWriter, err error) {
 		statusCode = http.StatusNotFound
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable
-	case errors.Is(err, sourceruntime.ErrInvalidRequest), errors.Is(err, errInvalidHTTPRequest):
+	case errors.Is(err, sourceruntime.ErrInvalidRequest), errors.Is(err, graphquery.ErrInvalidRequest), errors.Is(err, errInvalidHTTPRequest):
 		statusCode = http.StatusBadRequest
 	}
 	http.Error(w, http.StatusText(statusCode), statusCode)

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2102,7 +2102,15 @@ func newRuntimeService(deps Dependencies, sources *sourcecdk.Registry) *sourceru
 		sourceRuntimeStore(deps.StateStore),
 		deps.AppendLog,
 		sourceProjector(deps.StateStore, deps.GraphStore),
-	).WithConfigResolver(config.ResolveSourceRuntimeConfigSecretReferences)
+	).WithConfigResolver(resolveRuntimeSourceConfig)
+}
+
+func resolveRuntimeSourceConfig(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
+	resolved, err := config.ResolveSourceRuntimeConfigSecretReferences(ctx, sourceID, values)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", sourceruntime.ErrInvalidRequest, err)
+	}
+	return resolved, nil
 }
 
 func (a *App) claimService() *claims.Service {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -989,6 +989,10 @@ func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
 			filter.TenantID = strings.TrimSpace(auth.principal.TenantID)
 		}
 	}
+	if filter.TenantID == "" && hasAuthContext(r.Context()) {
+		writeSourceRuntimeError(w, errTenantForbidden)
+		return
+	}
 	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
 		writeSourceRuntimeError(w, err)
 		return

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -989,6 +989,9 @@ func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
 			filter.TenantID = strings.TrimSpace(auth.principal.TenantID)
 		}
 	}
+	if filter.TenantID == "" {
+		filter.TenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
+	}
 	if filter.TenantID == "" && requiresTenantFilter(r.Context()) {
 		writeSourceRuntimeError(w, errTenantForbidden)
 		return

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/knowledge"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/reports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceops"
@@ -1255,6 +1256,44 @@ func TestBootstrapEndpoints(t *testing.T) {
 	}
 }
 
+func TestBootstrapSourcePreviewEndpointsResolveEnvReferences(t *testing.T) {
+	source := &bootstrapTokenSource{id: "bootstrap_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	t.Setenv("CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN", "resolved-token")
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := sourceGet(t, server, "/sources/bootstrap_token/read", map[string]string{
+		"token": "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN",
+	})
+	if err != nil {
+		t.Fatalf("GET /sources/bootstrap_token/read error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /sources/bootstrap_token/read status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if source.readToken != "resolved-token" {
+		t.Fatalf("HTTP read token = %q, want resolved-token", source.readToken)
+	}
+
+	source.readToken = ""
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	if _, err := client.ReadSource(context.Background(), connect.NewRequest(&cerebrov1.ReadSourceRequest{
+		SourceId: "bootstrap_token",
+		Config:   map[string]string{"token": "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN"},
+	})); err != nil {
+		t.Fatalf("ReadSource() error = %v", err)
+	}
+	if source.readToken != "resolved-token" {
+		t.Fatalf("Connect read token = %q, want resolved-token", source.readToken)
+	}
+}
+
 func TestAuthMiddlewareProtectsNonPublicRoutes(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
@@ -2202,6 +2241,48 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	}
 	if len(runtimeStore.entities) == 0 || len(graphStore.entities) == 0 {
 		t.Fatalf("projected entities = state:%d graph:%d, want non-zero", len(runtimeStore.entities), len(graphStore.entities))
+	}
+}
+
+func TestConnectSourceRuntimeEndpointsResolveEnvReferences(t *testing.T) {
+	source := &bootstrapTokenSource{id: "runtime_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	t.Setenv("CEREBRO_SOURCE_RUNTIME_TOKEN_TOKEN", "resolved-token")
+	runtimeStore := &stubRuntimeStore{}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  &recordingAppendLog{},
+		StateStore: runtimeStore,
+	}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	if _, err := client.PutSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-runtime-token",
+			SourceId: "runtime_token",
+			Config:   map[string]string{"token": "env:CEREBRO_SOURCE_RUNTIME_TOKEN_TOKEN"},
+		},
+	})); err != nil {
+		t.Fatalf("PutSourceRuntime() error = %v", err)
+	}
+	if source.checkToken != "resolved-token" {
+		t.Fatalf("connect put check token = %q, want resolved-token", source.checkToken)
+	}
+	if got := runtimeStore.runtimes["writer-runtime-token"].GetConfig()["token"]; got != "env:CEREBRO_SOURCE_RUNTIME_TOKEN_TOKEN" {
+		t.Fatalf("stored token = %q, want env reference", got)
+	}
+
+	if _, err := client.SyncSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.SyncSourceRuntimeRequest{
+		Id: "writer-runtime-token",
+	})); err != nil {
+		t.Fatalf("SyncSourceRuntime() error = %v", err)
+	}
+	if source.readToken != "resolved-token" {
+		t.Fatalf("connect sync read token = %q, want resolved-token", source.readToken)
 	}
 }
 
@@ -3988,6 +4069,30 @@ func newFixtureRegistry() (*sourcecdk.Registry, error) {
 		return nil, err
 	}
 	return sourcecdk.NewRegistry(source, okta, sdk)
+}
+
+type bootstrapTokenSource struct {
+	id         string
+	checkToken string
+	readToken  string
+}
+
+func (s *bootstrapTokenSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: s.id, Name: "Bootstrap token source"}
+}
+
+func (s *bootstrapTokenSource) Check(_ context.Context, config sourcecdk.Config) error {
+	s.checkToken, _ = config.Lookup("token")
+	return nil
+}
+
+func (s *bootstrapTokenSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *bootstrapTokenSource) Read(_ context.Context, config sourcecdk.Config, _ *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	s.readToken, _ = config.Lookup("token")
+	return sourcecdk.Pull{Events: []*primitives.Event{}}, nil
 }
 
 func cloneProjectedEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1476,6 +1476,21 @@ func TestListSourceRuntimesRequiresTenantFilterWithAllowedTenantAuth(t *testing.
 	}
 }
 
+func TestListSourceRuntimesInvalidLimitReturnsBadRequest(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/source-runtimes?limit=bogus")
+	if err != nil {
+		t.Fatalf("GET /source-runtimes invalid limit error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("GET /source-runtimes invalid limit status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
 func TestAuthMiddlewareRejectsBlankTenantSourceRuntimesForScopedKeys(t *testing.T) {
 	cfg := config.Config{
 		HTTPAddr:        "127.0.0.1:0",

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1416,6 +1416,66 @@ func TestAuthMiddlewareEnforcesTenantOnIDOnlyRoutes(t *testing.T) {
 	}
 }
 
+func TestListSourceRuntimesRequiresTenantFilterWithAllowedTenantAuth(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled:        true,
+			APIKeys:        []config.APIKey{{Key: "allowed-key"}},
+			AllowedTenants: []string{"writer"},
+		},
+	}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
+			"other-runtime":  {Id: "other-runtime", SourceId: "github", TenantId: "other"},
+		},
+	}
+	app := New(cfg, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes", nil)
+	if err != nil {
+		t.Fatalf("NewRequest without tenant: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer allowed-key")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes without tenant error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("GET /source-runtimes without tenant status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	scopedReq, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes?tenant_id=writer", nil)
+	if err != nil {
+		t.Fatalf("NewRequest with tenant: %v", err)
+	}
+	scopedReq.Header.Set("Authorization", "Bearer allowed-key")
+	scopedResp, err := server.Client().Do(scopedReq)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes with tenant error = %v", err)
+	}
+	defer func() {
+		if closeErr := scopedResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close scoped response body: %v", closeErr)
+		}
+	}()
+	if scopedResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /source-runtimes with tenant status = %d, want %d", scopedResp.StatusCode, http.StatusOK)
+	}
+	var payload map[string][]map[string]any
+	if err := json.NewDecoder(scopedResp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode source runtime list: %v", err)
+	}
+	if got := len(payload["runtimes"]); got != 1 {
+		t.Fatalf("listed runtime count = %d, want 1", got)
+	}
+}
+
 func TestAuthMiddlewareRejectsBlankTenantSourceRuntimesForScopedKeys(t *testing.T) {
 	cfg := config.Config{
 		HTTPAddr:        "127.0.0.1:0",

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -457,6 +457,29 @@ func (s *stubRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*cere
 	return proto.Clone(runtime).(*cerebrov1.SourceRuntime), nil
 }
 
+func (s *stubRuntimeStore) ListSourceRuntimes(_ context.Context, filter ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	var ids []string
+	for id := range s.runtimes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	var runtimes []*cerebrov1.SourceRuntime
+	for _, id := range ids {
+		runtime := s.runtimes[id]
+		if filter.TenantID != "" && runtime.GetTenantId() != filter.TenantID {
+			continue
+		}
+		if filter.SourceID != "" && runtime.GetSourceId() != filter.SourceID {
+			continue
+		}
+		runtimes = append(runtimes, proto.Clone(runtime).(*cerebrov1.SourceRuntime))
+	}
+	return runtimes, nil
+}
+
 func (s *stubRuntimeStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
 	if s.err != nil {
 		return s.err
@@ -1993,6 +2016,35 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	}
 	if got := getRuntimePayload["tenant_id"]; got != "writer" {
 		t.Fatalf("get runtime tenant_id = %#v, want writer", got)
+	}
+
+	listResp, err := server.Client().Get(server.URL + "/source-runtimes?tenant_id=writer")
+	if err != nil {
+		t.Fatalf("GET /source-runtimes error = %v", err)
+	}
+	defer func() {
+		if closeErr := listResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close list runtime response body: %v", closeErr)
+		}
+	}()
+	var listPayload map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&listPayload); err != nil {
+		t.Fatalf("decode list runtime response: %v", err)
+	}
+	listRuntimes, ok := listPayload["runtimes"].([]any)
+	if !ok || len(listRuntimes) != 1 {
+		t.Fatalf("list runtimes = %#v, want one runtime", listPayload["runtimes"])
+	}
+	listRuntimePayload, ok := listRuntimes[0].(map[string]any)
+	if !ok {
+		t.Fatalf("listed runtime = %#v, want object", listRuntimes[0])
+	}
+	listConfigPayload, ok := listRuntimePayload["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("listed runtime config = %#v, want object", listRuntimePayload["config"])
+	}
+	if got := listConfigPayload["token"]; got != "[redacted]" {
+		t.Fatalf("listed runtime token = %#v, want [redacted]", got)
 	}
 
 	syncReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-users/sync?page_limit=1", nil)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1515,6 +1515,53 @@ func TestListSourceRuntimesRequiresTenantFilterWithAllowedTenantAuth(t *testing.
 	}
 }
 
+func TestListSourceRuntimesUsesTenantHeaderWithAllowedTenantAuth(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled:        true,
+			APIKeys:        []config.APIKey{{Key: "allowed-key"}},
+			AllowedTenants: []string{"writer"},
+		},
+	}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
+			"other-runtime":  {Id: "other-runtime", SourceId: "github", TenantId: "other"},
+		},
+	}
+	app := New(cfg, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes", nil)
+	if err != nil {
+		t.Fatalf("NewRequest with tenant header: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer allowed-key")
+	req.Header.Set("X-Cerebro-Tenant", "writer")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes with tenant header error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response body: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /source-runtimes with tenant header status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload map[string][]map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode source runtime list: %v", err)
+	}
+	if got := len(payload["runtimes"]); got != 1 {
+		t.Fatalf("listed runtime count = %d, want 1", got)
+	}
+}
+
 func TestListSourceRuntimesAllowsUnscopedAdminKeyWithoutTenantFilter(t *testing.T) {
 	cfg := config.Config{
 		HTTPAddr:        "127.0.0.1:0",

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -250,6 +250,23 @@ func TestResolveRuntimeSourceConfigRejectsTenantScopedEnvSelectors(t *testing.T)
 	}
 }
 
+func TestResolveRuntimeSourceConfigAllowsTenantScopedLiteralEnvQuerySelectors(t *testing.T) {
+	ctx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		cfg:       config.AuthConfig{},
+		principal: authPrincipal{TenantID: "writer"},
+	})
+
+	resolved, err := resolveRuntimeSourceConfig(ctx, "github", map[string]string{
+		"phrase": "env:prod",
+	})
+	if err != nil {
+		t.Fatalf("resolveRuntimeSourceConfig() error = %v", err)
+	}
+	if got := resolved["phrase"]; got != "env:prod" {
+		t.Fatalf("resolved phrase = %q, want env:prod", got)
+	}
+}
+
 func TestResolveRuntimeSourceConfigAllowsAdminEnvSelectors(t *testing.T) {
 	t.Setenv("CEREBRO_SOURCE_GITHUB_OWNER", "writer")
 	ctx := context.WithValue(context.Background(), authContextKey{}, authContext{

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -268,6 +268,24 @@ func TestResolveRuntimeSourceConfigAllowsAdminEnvSelectors(t *testing.T) {
 	}
 }
 
+func TestAuthorizeHTTPRequestTenantSkipsEnvTenantPlaceholders(t *testing.T) {
+	ctx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		cfg:       config.AuthConfig{},
+		principal: authPrincipal{TenantID: "writer"},
+	})
+	err := authorizeHTTPRequestTenant(ctx, &cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			TenantId: "writer",
+			Config: map[string]string{
+				"tenant_id": "env:CEREBRO_SOURCE_AZURE_TENANT_ID",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("authorizeHTTPRequestTenant() error = %v, want nil", err)
+	}
+}
+
 func TestWriteKnowledgeErrorMapsInvalidRequestToBadRequest(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	writeKnowledgeError(recorder, knowledge.ErrInvalidRequest)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -286,6 +286,32 @@ func TestAuthorizeHTTPRequestTenantSkipsEnvTenantPlaceholders(t *testing.T) {
 	}
 }
 
+func TestGraphIngestRuntimeUsesRuntimeConfigAuthorization(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_GITHUB_OWNER", "writer")
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	ctx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		cfg:       config.AuthConfig{},
+		principal: authPrincipal{TenantID: "writer"},
+	})
+	store := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-github": {
+			Id:       "writer-github",
+			SourceId: "github",
+			TenantId: "writer",
+			Config:   map[string]string{"owner": "env:CEREBRO_SOURCE_GITHUB_OWNER"},
+		},
+	}}
+	service := newGraphIngestService(Dependencies{StateStore: store, GraphStore: &stubGraphStore{}}, registry)
+
+	_, err = service.RunRuntime(ctx, graphingest.RuntimeRequest{RuntimeID: "writer-github"})
+	if !errors.Is(err, errTenantForbidden) {
+		t.Fatalf("RunRuntime() error = %v, want tenant forbidden", err)
+	}
+}
+
 func TestWriteKnowledgeErrorMapsInvalidRequestToBadRequest(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	writeKnowledgeError(recorder, knowledge.ErrInvalidRequest)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -202,6 +202,24 @@ func TestWriteSourceRuntimeErrorDoesNotExposeInternalMessage(t *testing.T) {
 	}
 }
 
+func TestResolveRuntimeSourceConfigClassifiesEnvErrorsAsInvalidRequest(t *testing.T) {
+	_, err := resolveRuntimeSourceConfig(context.Background(), "github", map[string]string{
+		"token": "env:AWS_SECRET_ACCESS_KEY",
+	})
+	if !errors.Is(err, sourceruntime.ErrInvalidRequest) {
+		t.Fatalf("resolveRuntimeSourceConfig() error = %v, want invalid request", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	writeSourceRuntimeError(recorder, err)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("HTTP status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+	if got := connect.CodeOf(sourceRuntimeConnectError(err)); got != connect.CodeInvalidArgument {
+		t.Fatalf("connect code = %s, want %s", got, connect.CodeInvalidArgument)
+	}
+}
+
 func TestWriteKnowledgeErrorMapsInvalidRequestToBadRequest(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	writeKnowledgeError(recorder, knowledge.ErrInvalidRequest)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1256,7 +1256,7 @@ func TestBootstrapEndpoints(t *testing.T) {
 	}
 }
 
-func TestBootstrapSourcePreviewEndpointsResolveEnvReferences(t *testing.T) {
+func TestBootstrapSourcePreviewEndpointsDoNotResolveEnvReferences(t *testing.T) {
 	source := &bootstrapTokenSource{id: "bootstrap_token"}
 	registry, err := sourcecdk.NewRegistry(source)
 	if err != nil {
@@ -1277,8 +1277,8 @@ func TestBootstrapSourcePreviewEndpointsResolveEnvReferences(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("GET /sources/bootstrap_token/read status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
-	if source.readToken != "resolved-token" {
-		t.Fatalf("HTTP read token = %q, want resolved-token", source.readToken)
+	if source.readToken != "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN" {
+		t.Fatalf("HTTP read token = %q, want literal env reference", source.readToken)
 	}
 
 	source.readToken = ""
@@ -1289,8 +1289,8 @@ func TestBootstrapSourcePreviewEndpointsResolveEnvReferences(t *testing.T) {
 	})); err != nil {
 		t.Fatalf("ReadSource() error = %v", err)
 	}
-	if source.readToken != "resolved-token" {
-		t.Fatalf("Connect read token = %q, want resolved-token", source.readToken)
+	if source.readToken != "env:CEREBRO_SOURCE_BOOTSTRAP_TOKEN_TOKEN" {
+		t.Fatalf("Connect read token = %q, want literal env reference", source.readToken)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1622,6 +1622,26 @@ func TestListSourceRuntimesInvalidLimitReturnsBadRequest(t *testing.T) {
 	}
 }
 
+func TestRedactSourceRuntimeDropsInternalProgressHash(t *testing.T) {
+	runtime := redactSourceRuntime(&cerebrov1.SourceRuntime{
+		Id: "writer-github",
+		Config: map[string]string{
+			"token":                            "secret-token",
+			sourceRuntimeProgressConfigHashKey: "internal-hash",
+			"owner":                            "writer",
+		},
+	})
+	if _, ok := runtime.GetConfig()[sourceRuntimeProgressConfigHashKey]; ok {
+		t.Fatal("redacted runtime exposed internal progress hash")
+	}
+	if got := runtime.GetConfig()["token"]; got != "[redacted]" {
+		t.Fatalf("redacted token = %q, want [redacted]", got)
+	}
+	if got := runtime.GetConfig()["owner"]; got != "writer" {
+		t.Fatalf("redacted owner = %q, want writer", got)
+	}
+}
+
 func TestAuthMiddlewareRejectsBlankTenantSourceRuntimesForScopedKeys(t *testing.T) {
 	cfg := config.Config{
 		HTTPAddr:        "127.0.0.1:0",

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1515,6 +1515,51 @@ func TestListSourceRuntimesRequiresTenantFilterWithAllowedTenantAuth(t *testing.
 	}
 }
 
+func TestListSourceRuntimesAllowsUnscopedAdminKeyWithoutTenantFilter(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APIKeys: []config.APIKey{{Key: "admin-key"}},
+		},
+	}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
+			"other-runtime":  {Id: "other-runtime", SourceId: "github", TenantId: "other"},
+		},
+	}
+	app := New(cfg, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes", nil)
+	if err != nil {
+		t.Fatalf("NewRequest without tenant: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer admin-key")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes without tenant error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response body: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /source-runtimes without tenant status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload map[string][]map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode source runtime list: %v", err)
+	}
+	if got := len(payload["runtimes"]); got != 2 {
+		t.Fatalf("listed runtime count = %d, want 2", got)
+	}
+}
+
 func TestListSourceRuntimesInvalidLimitReturnsBadRequest(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, nil)
 	server := httptest.NewServer(app.Handler())

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -220,6 +220,21 @@ func TestResolveRuntimeSourceConfigClassifiesEnvErrorsAsInvalidRequest(t *testin
 	}
 }
 
+func TestResolveRuntimeSourceConfigAuthorizesResolvedTenantID(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_AZURE_TENANT_ID", "other")
+	ctx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		cfg:       config.AuthConfig{},
+		principal: authPrincipal{TenantID: "writer"},
+	})
+
+	_, err := resolveRuntimeSourceConfig(ctx, "azure", map[string]string{
+		"tenant_id": "env:CEREBRO_SOURCE_AZURE_TENANT_ID",
+	})
+	if !errors.Is(err, errTenantForbidden) {
+		t.Fatalf("resolveRuntimeSourceConfig() error = %v, want tenant forbidden", err)
+	}
+}
+
 func TestWriteKnowledgeErrorMapsInvalidRequestToBadRequest(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	writeKnowledgeError(recorder, knowledge.ErrInvalidRequest)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -235,6 +235,39 @@ func TestResolveRuntimeSourceConfigAuthorizesResolvedTenantID(t *testing.T) {
 	}
 }
 
+func TestResolveRuntimeSourceConfigRejectsTenantScopedEnvSelectors(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_GITHUB_OWNER", "writer")
+	ctx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		cfg:       config.AuthConfig{},
+		principal: authPrincipal{TenantID: "writer"},
+	})
+
+	_, err := resolveRuntimeSourceConfig(ctx, "github", map[string]string{
+		"owner": "env:CEREBRO_SOURCE_GITHUB_OWNER",
+	})
+	if !errors.Is(err, errTenantForbidden) {
+		t.Fatalf("resolveRuntimeSourceConfig() error = %v, want tenant forbidden", err)
+	}
+}
+
+func TestResolveRuntimeSourceConfigAllowsAdminEnvSelectors(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_GITHUB_OWNER", "writer")
+	ctx := context.WithValue(context.Background(), authContextKey{}, authContext{
+		cfg:       config.AuthConfig{},
+		principal: authPrincipal{},
+	})
+
+	resolved, err := resolveRuntimeSourceConfig(ctx, "github", map[string]string{
+		"owner": "env:CEREBRO_SOURCE_GITHUB_OWNER",
+	})
+	if err != nil {
+		t.Fatalf("resolveRuntimeSourceConfig() error = %v", err)
+	}
+	if got := resolved["owner"]; got != "writer" {
+		t.Fatalf("resolved owner = %q, want writer", got)
+	}
+}
+
 func TestWriteKnowledgeErrorMapsInvalidRequestToBadRequest(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	writeKnowledgeError(recorder, knowledge.ErrInvalidRequest)

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 var errTenantForbidden = errors.New("tenant forbidden")
@@ -315,6 +316,9 @@ func protoStringValue(message protoreflect.Message) string {
 func appendTenantID(rawTenantID string, seen map[string]struct{}, tenants *[]string) {
 	tenantID := strings.TrimSpace(rawTenantID)
 	if tenantID == "" {
+		return
+	}
+	if sourceconfig.IsSecretReference(tenantID) {
 		return
 	}
 	if _, ok := seen[tenantID]; ok {

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -209,6 +209,11 @@ func hasTenantScopedAuth(ctx context.Context) bool {
 	return ok && strings.TrimSpace(auth.principal.TenantID) != ""
 }
 
+func requiresTenantFilter(ctx context.Context) bool {
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	return ok && strings.TrimSpace(auth.principal.TenantID) == "" && len(auth.cfg.AllowedTenants) > 0
+}
+
 func tenantAllowed(cfg config.AuthConfig, principal authPrincipal, tenantID string) bool {
 	tenantID = strings.TrimSpace(tenantID)
 	if tenantID == "" {

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -28,13 +28,13 @@ func resolveSourceConfigSecretReferences(ctx context.Context, sourceID string, v
 		if !ok {
 			continue
 		}
-		if preserveLiteralQueryValues && sourceconfig.LiteralEnvPrefixKey(key) && !sourceConfigEnvReferenceAllowed(sourceID, key, envName) {
+		if preserveLiteralQueryValues && sourceconfig.LiteralEnvPrefixKey(key) && !SourceConfigEnvReferenceAllowed(sourceID, key, envName) {
 			continue
 		}
 		if envName == "" {
 			return nil, fmt.Errorf("source config %q has empty env reference", strings.TrimSpace(key))
 		}
-		if !sourceConfigEnvReferenceAllowed(sourceID, key, envName) {
+		if !SourceConfigEnvReferenceAllowed(sourceID, key, envName) {
 			return nil, fmt.Errorf("source config %q references disallowed environment variable %q; use %q or list it in %s", strings.TrimSpace(key), envName, sourceConfigEnvName(sourceID, key), sourceConfigEnvAllowlistEnv)
 		}
 		secret, ok := os.LookupEnv(envName)
@@ -49,7 +49,7 @@ func resolveSourceConfigSecretReferences(ctx context.Context, sourceID string, v
 	return resolved, nil
 }
 
-func sourceConfigEnvReferenceAllowed(sourceID string, key string, envName string) bool {
+func SourceConfigEnvReferenceAllowed(sourceID string, key string, envName string) bool {
 	trimmedEnvName := strings.TrimSpace(envName)
 	if trimmedEnvName == "" {
 		return false

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -24,11 +24,11 @@ func resolveSourceConfigSecretReferences(ctx context.Context, sourceID string, v
 	resolved := make(map[string]string, len(values))
 	for key, value := range values {
 		resolved[key] = value
-		if preserveLiteralQueryValues && sourceconfig.LiteralEnvPrefixKey(key) {
-			continue
-		}
 		envName, ok := sourceconfig.SecretReferenceName(value)
 		if !ok {
+			continue
+		}
+		if preserveLiteralQueryValues && sourceconfig.LiteralEnvPrefixKey(key) && !sourceConfigEnvReferenceAllowed(sourceID, key, envName) {
 			continue
 		}
 		if envName == "" {

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -12,11 +12,19 @@ import (
 const sourceConfigEnvAllowlistEnv = "CEREBRO_SOURCE_CONFIG_ENV_ALLOWLIST"
 
 func ResolveSourceConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
+	return resolveSourceConfigSecretReferences(ctx, sourceID, values, true)
+}
+
+func ResolveSourceRuntimeConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
+	return resolveSourceConfigSecretReferences(ctx, sourceID, values, false)
+}
+
+func resolveSourceConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string, preserveLiteralQueryValues bool) (map[string]string, error) {
 	_ = ctx
 	resolved := make(map[string]string, len(values))
 	for key, value := range values {
 		resolved[key] = value
-		if sourceconfig.LiteralEnvPrefixKey(key) {
+		if preserveLiteralQueryValues && sourceconfig.LiteralEnvPrefixKey(key) {
 			continue
 		}
 		envName, ok := sourceconfig.SecretReferenceName(value)

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -9,18 +9,25 @@ import (
 	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
+const sourceConfigEnvAllowlistEnv = "CEREBRO_SOURCE_CONFIG_ENV_ALLOWLIST"
+
 func ResolveSourceConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
 	_ = ctx
-	_ = sourceID
 	resolved := make(map[string]string, len(values))
 	for key, value := range values {
 		resolved[key] = value
-		if !sourceconfig.IsSecretReference(value) {
+		if sourceconfig.LiteralEnvPrefixKey(key) {
 			continue
 		}
-		envName := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(value), "env:"))
+		envName, ok := sourceconfig.SecretReferenceName(value)
+		if !ok {
+			continue
+		}
 		if envName == "" {
-			return nil, fmt.Errorf("source config %q has empty env secret reference", strings.TrimSpace(key))
+			return nil, fmt.Errorf("source config %q has empty env reference", strings.TrimSpace(key))
+		}
+		if !sourceConfigEnvReferenceAllowed(sourceID, key, envName) {
+			return nil, fmt.Errorf("source config %q references disallowed environment variable %q; use %q or list it in %s", strings.TrimSpace(key), envName, sourceConfigEnvName(sourceID, key), sourceConfigEnvAllowlistEnv)
 		}
 		secret, ok := os.LookupEnv(envName)
 		if !ok {
@@ -32,4 +39,45 @@ func ResolveSourceConfigSecretReferences(ctx context.Context, sourceID string, v
 		resolved[key] = secret
 	}
 	return resolved, nil
+}
+
+func sourceConfigEnvReferenceAllowed(sourceID string, key string, envName string) bool {
+	trimmedEnvName := strings.TrimSpace(envName)
+	if trimmedEnvName == "" {
+		return false
+	}
+	if trimmedEnvName == sourceConfigEnvName(sourceID, key) {
+		return true
+	}
+	for _, allowed := range strings.Split(os.Getenv(sourceConfigEnvAllowlistEnv), ",") {
+		if strings.TrimSpace(allowed) == trimmedEnvName {
+			return true
+		}
+	}
+	return false
+}
+
+func sourceConfigEnvName(sourceID string, key string) string {
+	return "CEREBRO_SOURCE_" + sourceConfigEnvComponent(sourceID) + "_" + sourceConfigEnvComponent(key)
+}
+
+func sourceConfigEnvComponent(value string) string {
+	var builder strings.Builder
+	for _, char := range strings.TrimSpace(value) {
+		switch {
+		case char >= 'a' && char <= 'z':
+			builder.WriteRune(char - 'a' + 'A')
+		case char >= 'A' && char <= 'Z':
+			builder.WriteRune(char)
+		case char >= '0' && char <= '9':
+			builder.WriteRune(char)
+		default:
+			builder.WriteByte('_')
+		}
+	}
+	component := strings.Trim(builder.String(), "_")
+	if component == "" {
+		return "CONFIG"
+	}
+	return component
 }

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -16,7 +16,7 @@ func ResolveSourceConfigSecretReferences(ctx context.Context, sourceID string, v
 }
 
 func ResolveSourceRuntimeConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
-	return resolveSourceConfigSecretReferences(ctx, sourceID, values, false)
+	return resolveSourceConfigSecretReferences(ctx, sourceID, values, true)
 }
 
 func resolveSourceConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string, preserveLiteralQueryValues bool) (map[string]string, error) {

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/writer/cerebro/internal/sourceconfig"
+)
+
+func ResolveSourceConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
+	_ = ctx
+	_ = sourceID
+	resolved := make(map[string]string, len(values))
+	for key, value := range values {
+		resolved[key] = value
+		if !sourceconfig.IsSecretReference(value) {
+			continue
+		}
+		envName := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(value), "env:"))
+		if envName == "" {
+			return nil, fmt.Errorf("source config %q has empty env secret reference", strings.TrimSpace(key))
+		}
+		secret, ok := os.LookupEnv(envName)
+		if !ok {
+			return nil, fmt.Errorf("source config %q references unset environment variable %q", strings.TrimSpace(key), envName)
+		}
+		if sourceconfig.SensitiveKey(key) && strings.TrimSpace(secret) == "" {
+			return nil, fmt.Errorf("source config %q references empty environment variable %q", strings.TrimSpace(key), envName)
+		}
+		resolved[key] = secret
+	}
+	return resolved, nil
+}

--- a/internal/config/source_config_test.go
+++ b/internal/config/source_config_test.go
@@ -95,3 +95,16 @@ func TestResolveSourceRuntimeConfigSecretReferencesResolvesQuerySelectors(t *tes
 		t.Fatalf("resolved phrase = %q, want archived:false", got)
 	}
 }
+
+func TestResolveSourceRuntimeConfigSecretReferencesPreservesLiteralEnvQueryValues(t *testing.T) {
+	t.Setenv("prod", "from-env")
+	resolved, err := ResolveSourceRuntimeConfigSecretReferences(context.Background(), "github", map[string]string{
+		"phrase": "env:prod",
+	})
+	if err != nil {
+		t.Fatalf("ResolveSourceRuntimeConfigSecretReferences() error = %v", err)
+	}
+	if got := resolved["phrase"]; got != "env:prod" {
+		t.Fatalf("resolved phrase = %q, want literal env:prod", got)
+	}
+}

--- a/internal/config/source_config_test.go
+++ b/internal/config/source_config_test.go
@@ -69,3 +69,16 @@ func TestResolveSourceConfigSecretReferencesPreservesLiteralEnvQueryValues(t *te
 		t.Fatalf("resolved phrase = %q, want literal env:prod", got)
 	}
 }
+
+func TestResolveSourceRuntimeConfigSecretReferencesResolvesQuerySelectors(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_GITHUB_PHRASE", "archived:false")
+	resolved, err := ResolveSourceRuntimeConfigSecretReferences(context.Background(), "github", map[string]string{
+		"phrase": "env:CEREBRO_SOURCE_GITHUB_PHRASE",
+	})
+	if err != nil {
+		t.Fatalf("ResolveSourceRuntimeConfigSecretReferences() error = %v", err)
+	}
+	if got := resolved["phrase"]; got != "archived:false" {
+		t.Fatalf("resolved phrase = %q, want archived:false", got)
+	}
+}

--- a/internal/config/source_config_test.go
+++ b/internal/config/source_config_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"context"
+	"testing"
+)
+
+func TestResolveSourceConfigSecretReferencesResolvesEnvValues(t *testing.T) {
+	t.Setenv("CEREBRO_TEST_TOKEN", "secret-token")
+	config := map[string]string{
+		"owner": "writer",
+		"token": "env:CEREBRO_TEST_TOKEN",
+	}
+
+	resolved, err := ResolveSourceConfigSecretReferences(context.Background(), "github", config)
+	if err != nil {
+		t.Fatalf("ResolveSourceConfigSecretReferences() error = %v", err)
+	}
+	if got := resolved["token"]; got != "secret-token" {
+		t.Fatalf("resolved token = %q, want secret-token", got)
+	}
+	if got := config["token"]; got != "env:CEREBRO_TEST_TOKEN" {
+		t.Fatalf("input token mutated to %q", got)
+	}
+}
+
+func TestResolveSourceConfigSecretReferencesRejectsUnsetEnv(t *testing.T) {
+	_, err := ResolveSourceConfigSecretReferences(context.Background(), "github", map[string]string{
+		"token": "env:CEREBRO_TEST_MISSING",
+	})
+	if err == nil {
+		t.Fatal("ResolveSourceConfigSecretReferences() error = nil, want error")
+	}
+}

--- a/internal/config/source_config_test.go
+++ b/internal/config/source_config_test.go
@@ -6,10 +6,10 @@ import (
 )
 
 func TestResolveSourceConfigSecretReferencesResolvesEnvValues(t *testing.T) {
-	t.Setenv("CEREBRO_TEST_TOKEN", "secret-token")
+	t.Setenv("CEREBRO_SOURCE_GITHUB_TOKEN", "secret-token")
 	config := map[string]string{
 		"owner": "writer",
-		"token": "env:CEREBRO_TEST_TOKEN",
+		"token": "env:CEREBRO_SOURCE_GITHUB_TOKEN",
 	}
 
 	resolved, err := ResolveSourceConfigSecretReferences(context.Background(), "github", config)
@@ -19,16 +19,53 @@ func TestResolveSourceConfigSecretReferencesResolvesEnvValues(t *testing.T) {
 	if got := resolved["token"]; got != "secret-token" {
 		t.Fatalf("resolved token = %q, want secret-token", got)
 	}
-	if got := config["token"]; got != "env:CEREBRO_TEST_TOKEN" {
+	if got := config["token"]; got != "env:CEREBRO_SOURCE_GITHUB_TOKEN" {
 		t.Fatalf("input token mutated to %q", got)
 	}
 }
 
 func TestResolveSourceConfigSecretReferencesRejectsUnsetEnv(t *testing.T) {
 	_, err := ResolveSourceConfigSecretReferences(context.Background(), "github", map[string]string{
-		"token": "env:CEREBRO_TEST_MISSING",
+		"token": "env:CEREBRO_SOURCE_GITHUB_TOKEN",
 	})
 	if err == nil {
 		t.Fatal("ResolveSourceConfigSecretReferences() error = nil, want error")
+	}
+}
+
+func TestResolveSourceConfigSecretReferencesRejectsDisallowedEnv(t *testing.T) {
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "deployment-secret")
+	_, err := ResolveSourceConfigSecretReferences(context.Background(), "github", map[string]string{
+		"token": "env:AWS_SECRET_ACCESS_KEY",
+	})
+	if err == nil {
+		t.Fatal("ResolveSourceConfigSecretReferences() error = nil, want error")
+	}
+}
+
+func TestResolveSourceConfigSecretReferencesAllowsExplicitEnvAllowlist(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_CONFIG_ENV_ALLOWLIST", "SHARED_GITHUB_TOKEN")
+	t.Setenv("SHARED_GITHUB_TOKEN", "secret-token")
+	resolved, err := ResolveSourceConfigSecretReferences(context.Background(), "github", map[string]string{
+		"token": "env:SHARED_GITHUB_TOKEN",
+	})
+	if err != nil {
+		t.Fatalf("ResolveSourceConfigSecretReferences() error = %v", err)
+	}
+	if got := resolved["token"]; got != "secret-token" {
+		t.Fatalf("resolved token = %q, want secret-token", got)
+	}
+}
+
+func TestResolveSourceConfigSecretReferencesPreservesLiteralEnvQueryValues(t *testing.T) {
+	t.Setenv("prod", "from-env")
+	resolved, err := ResolveSourceConfigSecretReferences(context.Background(), "github", map[string]string{
+		"phrase": "env:prod",
+	})
+	if err != nil {
+		t.Fatalf("ResolveSourceConfigSecretReferences() error = %v", err)
+	}
+	if got := resolved["phrase"]; got != "env:prod" {
+		t.Fatalf("resolved phrase = %q, want literal env:prod", got)
 	}
 }

--- a/internal/config/source_config_test.go
+++ b/internal/config/source_config_test.go
@@ -70,6 +70,19 @@ func TestResolveSourceConfigSecretReferencesPreservesLiteralEnvQueryValues(t *te
 	}
 }
 
+func TestResolveSourceConfigSecretReferencesResolvesAllowedQueryEnvValues(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_GITHUB_PHRASE", "archived:false")
+	resolved, err := ResolveSourceConfigSecretReferences(context.Background(), "github", map[string]string{
+		"phrase": "env:CEREBRO_SOURCE_GITHUB_PHRASE",
+	})
+	if err != nil {
+		t.Fatalf("ResolveSourceConfigSecretReferences() error = %v", err)
+	}
+	if got := resolved["phrase"]; got != "archived:false" {
+		t.Fatalf("resolved phrase = %q, want archived:false", got)
+	}
+}
+
 func TestResolveSourceRuntimeConfigSecretReferencesResolvesQuerySelectors(t *testing.T) {
 	t.Setenv("CEREBRO_SOURCE_GITHUB_PHRASE", "archived:false")
 	resolved, err := ResolveSourceRuntimeConfigSecretReferences(context.Background(), "github", map[string]string{

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceprojection"
 )
@@ -182,6 +183,7 @@ type Service struct {
 	runtimeStore ports.SourceRuntimeStore
 	replayer     ports.EventReplayer
 	openGraph    func() (graphStore, error)
+	preparer     sourceconfig.Resolver
 }
 
 // New constructs a graph rebuild service.
@@ -192,6 +194,15 @@ func New(registry *sourcecdk.Registry, runtimeStore ports.SourceRuntimeStore, re
 		replayer:     replayer,
 		openGraph:    newMemoryGraphStore,
 	}
+}
+
+// WithConfigPreparer configures runtime source config preparation.
+func (s *Service) WithConfigPreparer(preparer sourceconfig.Resolver) *Service {
+	if s == nil {
+		return nil
+	}
+	s.preparer = preparer
+	return s
 }
 
 // RebuildDryRun projects bounded source or append-log events into a scratch graph.
@@ -493,9 +504,13 @@ func (s *Service) replayEvents(ctx context.Context, runtime *cerebrov1.SourceRun
 
 func (s *Service) readEvents(ctx context.Context, source sourcecdk.Source, runtime *cerebrov1.SourceRuntime, pageLimit uint32, previewLimit int, process eventProcessor) (*readSummary, error) {
 	summary := &readSummary{EventKinds: make(map[string]uint32)}
+	config, err := s.prepareConfig(ctx, runtime)
+	if err != nil {
+		return nil, err
+	}
 	var cursor *cerebrov1.SourceCursor
 	for page := uint32(0); page < pageLimit; page++ {
-		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtime.GetConfig()), cursor)
+		pull, err := source.Read(ctx, sourcecdk.NewConfig(config), cursor)
 		if err != nil {
 			return nil, fmt.Errorf("read source page %d: %w", page+1, err)
 		}
@@ -545,6 +560,21 @@ func (s *Service) readEvents(ctx context.Context, source sourcecdk.Source, runti
 		cursor = proto.Clone(pull.NextCursor).(*cerebrov1.SourceCursor)
 	}
 	return summary, nil
+}
+
+func (s *Service) prepareConfig(ctx context.Context, runtime *cerebrov1.SourceRuntime) (map[string]string, error) {
+	if s == nil || s.preparer == nil {
+		return cloneConfig(runtime.GetConfig()), nil
+	}
+	return s.preparer(ctx, runtime.GetSourceId(), runtime.GetConfig())
+}
+
+func cloneConfig(config map[string]string) map[string]string {
+	cloned := make(map[string]string, len(config))
+	for key, value := range config {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 type projectSummary struct {

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -41,9 +41,10 @@ func (s *runtimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov
 }
 
 type testSource struct {
-	spec  *cerebrov1.SourceSpec
-	pages [][]*cerebrov1.EventEnvelope
-	delay time.Duration
+	spec      *cerebrov1.SourceSpec
+	pages     [][]*cerebrov1.EventEnvelope
+	delay     time.Duration
+	readToken string
 }
 
 func (s *testSource) Spec() *cerebrov1.SourceSpec {
@@ -58,10 +59,11 @@ func (s *testSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.UR
 	return nil, nil
 }
 
-func (s *testSource) Read(_ context.Context, _ sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+func (s *testSource) Read(_ context.Context, config sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	if s.delay > 0 {
 		time.Sleep(s.delay)
 	}
+	s.readToken, _ = config.Lookup("token")
 	index := 0
 	if cursor != nil && cursor.GetOpaque() != "" {
 		parsed, err := strconv.Atoi(cursor.GetOpaque())
@@ -279,6 +281,42 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	}
 	if !containsLink(result.PreviewLinks, "urn:cerebro:writer-dogfood:github_user:octocat", "authored", "urn:cerebro:writer-dogfood:github_pull_request:writer/cerebro#418") {
 		t.Fatalf("PreviewLinks missing authored relation: %#v", result.PreviewLinks)
+	}
+}
+
+func TestRebuildDryRunResolvesRuntimeConfigReferences(t *testing.T) {
+	source := &testSource{
+		spec:  &cerebrov1.SourceSpec{Id: "github", Name: "GitHub"},
+		pages: [][]*cerebrov1.EventEnvelope{{testEvent("github-audit-1", "github.audit", nil)}},
+	}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-github": {
+			Id:       "writer-github",
+			SourceId: "github",
+			Config:   map[string]string{"token": "env:TOKEN"},
+		},
+	}}
+	service := New(registry, store, nil).WithConfigPreparer(func(_ context.Context, _ string, values map[string]string) (map[string]string, error) {
+		resolved := make(map[string]string, len(values))
+		for key, value := range values {
+			if value == "env:TOKEN" {
+				resolved[key] = "resolved-token"
+				continue
+			}
+			resolved[key] = value
+		}
+		return resolved, nil
+	})
+
+	if _, err := service.RebuildDryRun(context.Background(), Request{RuntimeID: "writer-github"}); err != nil {
+		t.Fatalf("RebuildDryRun() error = %v", err)
+	}
+	if source.readToken != "resolved-token" {
+		t.Fatalf("source read token = %q, want resolved-token", source.readToken)
 	}
 }
 

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -34,5 +34,6 @@ type SourceRuntimeListStore interface {
 // SourceRuntimeLeaseStore leases source runtimes before orchestration work.
 type SourceRuntimeLeaseStore interface {
 	AcquireSourceRuntimeLease(context.Context, string, string, time.Duration) (bool, error)
+	RenewSourceRuntimeLease(context.Context, string, string, time.Duration) (bool, error)
 	ReleaseSourceRuntimeLease(context.Context, string, string) error
 }

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -16,3 +16,16 @@ type SourceRuntimeStore interface {
 	PutSourceRuntime(context.Context, *cerebrov1.SourceRuntime) error
 	GetSourceRuntime(context.Context, string) (*cerebrov1.SourceRuntime, error)
 }
+
+// SourceRuntimeFilter scopes persisted source runtime listing.
+type SourceRuntimeFilter struct {
+	TenantID string
+	SourceID string
+	Limit    uint32
+}
+
+// SourceRuntimeListStore lists persisted source runtime definitions.
+type SourceRuntimeListStore interface {
+	SourceRuntimeStore
+	ListSourceRuntimes(context.Context, SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error)
+}

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -3,6 +3,7 @@ package ports
 import (
 	"context"
 	"errors"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
@@ -30,7 +31,8 @@ type SourceRuntimeListStore interface {
 	ListSourceRuntimes(context.Context, SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error)
 }
 
-// SourceRuntimeTouchStore advances source runtime scheduling metadata without replacing runtime state.
-type SourceRuntimeTouchStore interface {
-	TouchSourceRuntime(context.Context, string) error
+// SourceRuntimeLeaseStore leases source runtimes before orchestration work.
+type SourceRuntimeLeaseStore interface {
+	AcquireSourceRuntimeLease(context.Context, string, string, time.Duration) (bool, error)
+	ReleaseSourceRuntimeLease(context.Context, string, string) error
 }

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -29,3 +29,8 @@ type SourceRuntimeListStore interface {
 	SourceRuntimeStore
 	ListSourceRuntimes(context.Context, SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error)
 }
+
+// SourceRuntimeTouchStore advances source runtime scheduling metadata without replacing runtime state.
+type SourceRuntimeTouchStore interface {
+	TouchSourceRuntime(context.Context, string) error
+}

--- a/internal/sourceconfig/secrets.go
+++ b/internal/sourceconfig/secrets.go
@@ -10,7 +10,25 @@ const envPrefix = "env:"
 type Resolver func(context.Context, string, map[string]string) (map[string]string, error)
 
 func IsSecretReference(value string) bool {
-	return strings.HasPrefix(strings.TrimSpace(value), envPrefix)
+	_, ok := SecretReferenceName(value)
+	return ok
+}
+
+func SecretReferenceName(value string) (string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if !strings.HasPrefix(trimmed, envPrefix) {
+		return "", false
+	}
+	return strings.TrimSpace(strings.TrimPrefix(trimmed, envPrefix)), true
+}
+
+func LiteralEnvPrefixKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "filter", "phrase", "q", "search":
+		return true
+	default:
+		return false
+	}
 }
 
 func SensitiveKey(key string) bool {

--- a/internal/sourceconfig/secrets.go
+++ b/internal/sourceconfig/secrets.go
@@ -1,0 +1,29 @@
+package sourceconfig
+
+import (
+	"context"
+	"strings"
+)
+
+const envPrefix = "env:"
+
+type Resolver func(context.Context, string, map[string]string) (map[string]string, error)
+
+func IsSecretReference(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), envPrefix)
+}
+
+func SensitiveKey(key string) bool {
+	value := strings.ToLower(strings.TrimSpace(key))
+	if value == "" {
+		return false
+	}
+	if strings.Contains(value, "token") || strings.Contains(value, "secret") || strings.Contains(value, "password") {
+		return true
+	}
+	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(value)
+	if strings.Contains(compact, "apikey") || strings.Contains(compact, "privatekey") {
+		return true
+	}
+	return value == "key" || compact == "key"
+}

--- a/internal/sourceconfig/secrets_test.go
+++ b/internal/sourceconfig/secrets_test.go
@@ -12,3 +12,14 @@ func TestSensitiveKeyDetectsCommonSecretNames(t *testing.T) {
 		t.Fatal("SensitiveKey(owner) = true, want false")
 	}
 }
+
+func TestLiteralEnvPrefixKeyDetectsQueryLikeKeys(t *testing.T) {
+	for _, key := range []string{"filter", "phrase", "q", "search"} {
+		if !LiteralEnvPrefixKey(key) {
+			t.Fatalf("LiteralEnvPrefixKey(%q) = false, want true", key)
+		}
+	}
+	if LiteralEnvPrefixKey("token") {
+		t.Fatal("LiteralEnvPrefixKey(token) = true, want false")
+	}
+}

--- a/internal/sourceconfig/secrets_test.go
+++ b/internal/sourceconfig/secrets_test.go
@@ -1,0 +1,14 @@
+package sourceconfig
+
+import "testing"
+
+func TestSensitiveKeyDetectsCommonSecretNames(t *testing.T) {
+	for _, key := range []string{"token", "api_key", "client-secret", "private.key", "password"} {
+		if !SensitiveKey(key) {
+			t.Fatalf("SensitiveKey(%q) = false, want true", key)
+		}
+	}
+	if SensitiveKey("owner") {
+		t.Fatal("SensitiveKey(owner) = true, want false")
+	}
+}

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -11,6 +11,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 var (
@@ -21,11 +22,21 @@ var (
 // Service exposes typed source preview operations over a registry.
 type Service struct {
 	registry *sourcecdk.Registry
+	resolver sourceconfig.Resolver
 }
 
 // New constructs a source operations service.
 func New(registry *sourcecdk.Registry) *Service {
 	return &Service{registry: registry}
+}
+
+// WithConfigResolver configures source config secret resolution.
+func (s *Service) WithConfigResolver(resolver sourceconfig.Resolver) *Service {
+	if s == nil {
+		return nil
+	}
+	s.resolver = resolver
+	return s
 }
 
 // List returns the registered source catalog.
@@ -44,7 +55,11 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 	if err != nil {
 		return nil, err
 	}
-	if err := source.Check(ctx, sourcecdk.NewConfig(req.GetConfig())); err != nil {
+	config, err := s.resolveConfig(ctx, req.GetSourceId(), req.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+	if err := source.Check(ctx, sourcecdk.NewConfig(config)); err != nil {
 		return nil, sourceOperationError(err)
 	}
 	return &cerebrov1.CheckSourceResponse{
@@ -59,7 +74,11 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 	if err != nil {
 		return nil, err
 	}
-	urns, err := source.Discover(ctx, sourcecdk.NewConfig(req.GetConfig()))
+	config, err := s.resolveConfig(ctx, req.GetSourceId(), req.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+	urns, err := source.Discover(ctx, sourcecdk.NewConfig(config))
 	if err != nil {
 		return nil, sourceOperationError(err)
 	}
@@ -79,7 +98,11 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	pull, err := source.Read(ctx, sourcecdk.NewConfig(req.GetConfig()), req.GetCursor())
+	config, err := s.resolveConfig(ctx, req.GetSourceId(), req.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+	pull, err := source.Read(ctx, sourcecdk.NewConfig(config), req.GetCursor())
 	if err != nil {
 		return nil, sourceOperationError(err)
 	}
@@ -96,11 +119,27 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*
 	}, nil
 }
 
+func (s *Service) resolveConfig(ctx context.Context, sourceID string, config map[string]string) (map[string]string, error) {
+	resolver := s.resolver
+	if resolver == nil {
+		return cloneConfig(config), nil
+	}
+	return resolver(ctx, sourceID, config)
+}
+
 func sourceOperationError(err error) error {
 	if errors.Is(err, sourcecdk.ErrInvalidConfig) {
 		return fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 	}
 	return err
+}
+
+func cloneConfig(config map[string]string) map[string]string {
+	cloned := make(map[string]string, len(config))
+	for key, value := range config {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func (s *Service) lookup(sourceID string) (sourcecdk.Source, error) {

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -11,7 +11,6 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
-	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 var (
@@ -22,21 +21,11 @@ var (
 // Service exposes typed source preview operations over a registry.
 type Service struct {
 	registry *sourcecdk.Registry
-	resolver sourceconfig.Resolver
 }
 
 // New constructs a source operations service.
 func New(registry *sourcecdk.Registry) *Service {
 	return &Service{registry: registry}
-}
-
-// WithConfigResolver configures source config secret resolution.
-func (s *Service) WithConfigResolver(resolver sourceconfig.Resolver) *Service {
-	if s == nil {
-		return nil
-	}
-	s.resolver = resolver
-	return s
 }
 
 // List returns the registered source catalog.
@@ -55,11 +44,7 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 	if err != nil {
 		return nil, err
 	}
-	config, err := s.resolveConfig(ctx, req.GetSourceId(), req.GetConfig())
-	if err != nil {
-		return nil, err
-	}
-	if err := source.Check(ctx, sourcecdk.NewConfig(config)); err != nil {
+	if err := source.Check(ctx, sourcecdk.NewConfig(req.GetConfig())); err != nil {
 		return nil, sourceOperationError(err)
 	}
 	return &cerebrov1.CheckSourceResponse{
@@ -74,11 +59,7 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 	if err != nil {
 		return nil, err
 	}
-	config, err := s.resolveConfig(ctx, req.GetSourceId(), req.GetConfig())
-	if err != nil {
-		return nil, err
-	}
-	urns, err := source.Discover(ctx, sourcecdk.NewConfig(config))
+	urns, err := source.Discover(ctx, sourcecdk.NewConfig(req.GetConfig()))
 	if err != nil {
 		return nil, sourceOperationError(err)
 	}
@@ -98,11 +79,7 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	config, err := s.resolveConfig(ctx, req.GetSourceId(), req.GetConfig())
-	if err != nil {
-		return nil, err
-	}
-	pull, err := source.Read(ctx, sourcecdk.NewConfig(config), req.GetCursor())
+	pull, err := source.Read(ctx, sourcecdk.NewConfig(req.GetConfig()), req.GetCursor())
 	if err != nil {
 		return nil, sourceOperationError(err)
 	}
@@ -119,27 +96,11 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*
 	}, nil
 }
 
-func (s *Service) resolveConfig(ctx context.Context, sourceID string, config map[string]string) (map[string]string, error) {
-	resolver := s.resolver
-	if resolver == nil {
-		return cloneConfig(config), nil
-	}
-	return resolver(ctx, sourceID, config)
-}
-
 func sourceOperationError(err error) error {
 	if errors.Is(err, sourcecdk.ErrInvalidConfig) {
 		return fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 	}
 	return err
-}
-
-func cloneConfig(config map[string]string) map[string]string {
-	cloned := make(map[string]string, len(config))
-	for key, value := range config {
-		cloned[key] = value
-	}
-	return cloned
 }
 
 func (s *Service) lookup(sourceID string) (sourcecdk.Source, error) {

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
-	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	githubsource "github.com/writer/cerebro/sources/github"
 	googleworkspacesource "github.com/writer/cerebro/sources/googleworkspace"
@@ -82,35 +81,6 @@ func TestCheckDiscoverAndRead(t *testing.T) {
 	}
 }
 
-func TestReadResolvesSourceConfigReferences(t *testing.T) {
-	source := &resolverSource{}
-	registry, err := sourcecdk.NewRegistry(source)
-	if err != nil {
-		t.Fatalf("NewRegistry() error = %v", err)
-	}
-	service := New(registry).WithConfigResolver(func(_ context.Context, _ string, values map[string]string) (map[string]string, error) {
-		resolved := make(map[string]string, len(values))
-		for key, value := range values {
-			if value == "env:TOKEN" {
-				resolved[key] = "resolved-token"
-				continue
-			}
-			resolved[key] = value
-		}
-		return resolved, nil
-	})
-
-	if _, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
-		SourceId: "resolver_source",
-		Config:   map[string]string{"token": "env:TOKEN"},
-	}); err != nil {
-		t.Fatalf("Read() error = %v", err)
-	}
-	if source.readToken != "resolved-token" {
-		t.Fatalf("source read token = %q, want resolved-token", source.readToken)
-	}
-}
-
 func TestCheckDiscoverAndReadOkta(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
@@ -163,27 +133,6 @@ func TestCheckDiscoverAndReadOkta(t *testing.T) {
 	if !readResp.PreviewEvents[0].PayloadDecoded {
 		t.Fatal("Read(okta).PreviewEvents[0].PayloadDecoded = false, want true")
 	}
-}
-
-type resolverSource struct {
-	readToken string
-}
-
-func (s *resolverSource) Spec() *cerebrov1.SourceSpec {
-	return &cerebrov1.SourceSpec{Id: "resolver_source", Name: "Resolver source"}
-}
-
-func (s *resolverSource) Check(context.Context, sourcecdk.Config) error {
-	return nil
-}
-
-func (s *resolverSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
-	return nil, nil
-}
-
-func (s *resolverSource) Read(_ context.Context, config sourcecdk.Config, _ *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-	s.readToken, _ = config.Lookup("token")
-	return sourcecdk.Pull{Events: []*primitives.Event{}}, nil
 }
 
 func TestCheckDiscoverAndReadGoogleWorkspace(t *testing.T) {

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	githubsource "github.com/writer/cerebro/sources/github"
 	googleworkspacesource "github.com/writer/cerebro/sources/googleworkspace"
@@ -81,6 +82,35 @@ func TestCheckDiscoverAndRead(t *testing.T) {
 	}
 }
 
+func TestReadResolvesSourceConfigReferences(t *testing.T) {
+	source := &resolverSource{}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := New(registry).WithConfigResolver(func(_ context.Context, _ string, values map[string]string) (map[string]string, error) {
+		resolved := make(map[string]string, len(values))
+		for key, value := range values {
+			if value == "env:TOKEN" {
+				resolved[key] = "resolved-token"
+				continue
+			}
+			resolved[key] = value
+		}
+		return resolved, nil
+	})
+
+	if _, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
+		SourceId: "resolver_source",
+		Config:   map[string]string{"token": "env:TOKEN"},
+	}); err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if source.readToken != "resolved-token" {
+		t.Fatalf("source read token = %q, want resolved-token", source.readToken)
+	}
+}
+
 func TestCheckDiscoverAndReadOkta(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
@@ -133,6 +163,27 @@ func TestCheckDiscoverAndReadOkta(t *testing.T) {
 	if !readResp.PreviewEvents[0].PayloadDecoded {
 		t.Fatal("Read(okta).PreviewEvents[0].PayloadDecoded = false, want true")
 	}
+}
+
+type resolverSource struct {
+	readToken string
+}
+
+func (s *resolverSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "resolver_source", Name: "Resolver source"}
+}
+
+func (s *resolverSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (s *resolverSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *resolverSource) Read(_ context.Context, config sourcecdk.Config, _ *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	s.readToken, _ = config.Lookup("token")
+	return sourcecdk.Pull{Events: []*primitives.Event{}}, nil
 }
 
 func TestCheckDiscoverAndReadGoogleWorkspace(t *testing.T) {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -411,7 +411,7 @@ func progressConfigHashForRuntime(rawConfig map[string]string, resolvedConfig ma
 
 func hasProgressConfigReferences(config map[string]string) bool {
 	for key, value := range config {
-		if key == runtimeProgressConfigHashKey || sensitiveConfigKey(key) {
+		if key == runtimeProgressConfigHashKey || sourceconfig.SensitiveKey(key) {
 			continue
 		}
 		if sourceconfig.IsSecretReference(value) {
@@ -432,7 +432,7 @@ func progressConfigHashChanged(existing map[string]string, incoming map[string]s
 func progressConfigHash(config map[string]string) string {
 	keys := make([]string, 0, len(config))
 	for key := range config {
-		if key == runtimeProgressConfigHashKey || sensitiveConfigKey(key) {
+		if key == runtimeProgressConfigHashKey || sourceconfig.SensitiveKey(key) {
 			continue
 		}
 		keys = append(keys, key)

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -481,7 +481,7 @@ func sensitiveConfigKey(key string) bool {
 		return true
 	}
 	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(strings.ToLower(strings.TrimSpace(key)))
-	return strings.Contains(compact, "accesskey")
+	return strings.Contains(compact, "accesskey") || strings.Contains(compact, "signingkey")
 }
 
 func cloneRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -2,8 +2,11 @@ package sourceruntime
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"google.golang.org/protobuf/proto"
@@ -22,6 +25,8 @@ const (
 	defaultListLimit = 100
 	maxListLimit     = 500
 	redactedValue    = "[redacted]"
+
+	runtimeProgressConfigHashKey = "__cerebro_resolved_progress_config_hash"
 )
 
 var (
@@ -91,6 +96,7 @@ func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeReques
 		}
 		return nil, err
 	}
+	runtime.Config = configWithProgressHash(runtime.GetConfig(), resolvedConfig)
 	if existing != nil {
 		if err := validateRuntimeTenantUnchanged(existing, runtime); err != nil {
 			return nil, err
@@ -152,6 +158,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	if err != nil {
 		return nil, err
 	}
+	refreshRuntimeProgressConfig(runtime, runtimeConfig)
 	pageLimit, err := normalizePageLimit(req.GetPageLimit())
 	if err != nil {
 		return nil, err
@@ -210,9 +217,13 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 func (s *Service) resolveConfig(ctx context.Context, sourceID string, config map[string]string) (map[string]string, error) {
 	resolver := s.resolver
 	if resolver == nil {
-		return cloneConfig(config), nil
+		return userConfig(config), nil
 	}
-	return resolver(ctx, sourceID, config)
+	resolved, err := resolver(ctx, sourceID, userConfig(config))
+	if err != nil {
+		return nil, err
+	}
+	return userConfig(resolved), nil
 }
 
 func (s *Service) lookupSource(sourceID string) (sourcecdk.Source, error) {
@@ -296,7 +307,8 @@ func mergeRuntime(existing *cerebrov1.SourceRuntime, incoming *cerebrov1.SourceR
 	}
 	resetProgress := existing.GetSourceId() != incoming.GetSourceId() ||
 		existing.GetTenantId() != incoming.GetTenantId() ||
-		!sameConfig(existing.GetConfig(), incoming.GetConfig())
+		!sameConfig(userConfig(existing.GetConfig()), userConfig(incoming.GetConfig())) ||
+		progressConfigHashChanged(existing.GetConfig(), incoming.GetConfig())
 	if !resetProgress {
 		incoming.Checkpoint = cloneCheckpoint(existing.GetCheckpoint())
 		incoming.NextCursor = cloneCursor(existing.GetNextCursor())
@@ -347,12 +359,93 @@ func sameConfig(left map[string]string, right map[string]string) bool {
 	return true
 }
 
-func cloneConfig(config map[string]string) map[string]string {
+func userConfig(config map[string]string) map[string]string {
 	cloned := make(map[string]string, len(config))
 	for key, value := range config {
+		if key == runtimeProgressConfigHashKey {
+			continue
+		}
 		cloned[key] = value
 	}
 	return cloned
+}
+
+func withProgressConfigHash(config map[string]string, hash string) map[string]string {
+	cloned := userConfig(config)
+	cloned[runtimeProgressConfigHashKey] = hash
+	return cloned
+}
+
+func configWithProgressHash(rawConfig map[string]string, resolvedConfig map[string]string) map[string]string {
+	hash, ok := progressConfigHashForRuntime(rawConfig, resolvedConfig)
+	if !ok {
+		return userConfig(rawConfig)
+	}
+	return withProgressConfigHash(rawConfig, hash)
+}
+
+func refreshRuntimeProgressConfig(runtime *cerebrov1.SourceRuntime, resolvedConfig map[string]string) {
+	if runtime == nil {
+		return
+	}
+	hash, ok := progressConfigHashForRuntime(runtime.GetConfig(), resolvedConfig)
+	if !ok {
+		runtime.Config = userConfig(runtime.GetConfig())
+		return
+	}
+	if runtime.GetConfig()[runtimeProgressConfigHashKey] == hash {
+		return
+	}
+	runtime.Checkpoint = nil
+	runtime.NextCursor = nil
+	runtime.LastSyncedAt = nil
+	runtime.Config = withProgressConfigHash(runtime.GetConfig(), hash)
+}
+
+func progressConfigHashForRuntime(rawConfig map[string]string, resolvedConfig map[string]string) (string, bool) {
+	if !hasProgressConfigReferences(rawConfig) {
+		return "", false
+	}
+	return progressConfigHash(resolvedConfig), true
+}
+
+func hasProgressConfigReferences(config map[string]string) bool {
+	for key, value := range config {
+		if key == runtimeProgressConfigHashKey || sensitiveConfigKey(key) {
+			continue
+		}
+		if sourceconfig.IsSecretReference(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func progressConfigHashChanged(existing map[string]string, incoming map[string]string) bool {
+	incomingHash := incoming[runtimeProgressConfigHashKey]
+	if incomingHash == "" {
+		return false
+	}
+	return existing[runtimeProgressConfigHashKey] != incomingHash
+}
+
+func progressConfigHash(config map[string]string) string {
+	keys := make([]string, 0, len(config))
+	for key := range config {
+		if key == runtimeProgressConfigHashKey || sensitiveConfigKey(key) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	hash := sha256.New()
+	for _, key := range keys {
+		hash.Write([]byte(strings.TrimSpace(key)))
+		hash.Write([]byte{0})
+		hash.Write([]byte(config[key]))
+		hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 func redactRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {
@@ -362,6 +455,9 @@ func redactRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {
 	}
 	redacted := make(map[string]string, len(cloned.GetConfig()))
 	for key, value := range cloned.GetConfig() {
+		if key == runtimeProgressConfigHashKey {
+			continue
+		}
 		if sensitiveConfigKey(key) {
 			redacted[key] = redactedValue
 			continue

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -411,7 +411,7 @@ func progressConfigHashForRuntime(rawConfig map[string]string, resolvedConfig ma
 
 func hasProgressConfigReferences(config map[string]string) bool {
 	for key, value := range config {
-		if key == runtimeProgressConfigHashKey || sourceconfig.SensitiveKey(key) {
+		if key == runtimeProgressConfigHashKey || progressHashSensitiveConfigKey(key) {
 			continue
 		}
 		if sourceconfig.IsSecretReference(value) {
@@ -432,7 +432,7 @@ func progressConfigHashChanged(existing map[string]string, incoming map[string]s
 func progressConfigHash(config map[string]string) string {
 	keys := make([]string, 0, len(config))
 	for key := range config {
-		if key == runtimeProgressConfigHashKey || sourceconfig.SensitiveKey(key) {
+		if key == runtimeProgressConfigHashKey || progressHashSensitiveConfigKey(key) {
 			continue
 		}
 		keys = append(keys, key)
@@ -446,6 +446,14 @@ func progressConfigHash(config map[string]string) string {
 		hash.Write([]byte{0})
 	}
 	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func progressHashSensitiveConfigKey(key string) bool {
+	if sourceconfig.SensitiveKey(key) {
+		return true
+	}
+	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(strings.ToLower(strings.TrimSpace(key)))
+	return compact == "accesskeyid"
 }
 
 func redactRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -403,15 +403,18 @@ func refreshRuntimeProgressConfig(runtime *cerebrov1.SourceRuntime, resolvedConf
 }
 
 func progressConfigHashForRuntime(rawConfig map[string]string, resolvedConfig map[string]string) (string, bool) {
-	if !hasProgressConfigReferences(rawConfig) {
+	if !hasProgressConfigReferences(rawConfig, resolvedConfig) {
 		return "", false
 	}
 	return progressConfigHash(resolvedConfig), true
 }
 
-func hasProgressConfigReferences(config map[string]string) bool {
+func hasProgressConfigReferences(config map[string]string, resolvedConfig map[string]string) bool {
 	for key, value := range config {
 		if key == runtimeProgressConfigHashKey || progressHashSensitiveConfigKey(key) {
+			continue
+		}
+		if sourceconfig.LiteralEnvPrefixKey(key) && resolvedConfig[key] == value {
 			continue
 		}
 		if sourceconfig.IsSecretReference(value) {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -477,18 +477,11 @@ func redactRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {
 }
 
 func sensitiveConfigKey(key string) bool {
-	value := strings.ToLower(strings.TrimSpace(key))
-	if value == "" {
-		return false
-	}
-	if strings.Contains(value, "token") || strings.Contains(value, "secret") || strings.Contains(value, "password") {
+	if sourceconfig.SensitiveKey(key) {
 		return true
 	}
-	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(value)
-	if strings.Contains(compact, "apikey") || strings.Contains(compact, "accesskey") || strings.Contains(compact, "privatekey") {
-		return true
-	}
-	return value == "key" || strings.HasSuffix(value, "_key")
+	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(strings.ToLower(strings.TrimSpace(key)))
+	return strings.Contains(compact, "accesskey")
 }
 
 func cloneRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -12,12 +12,15 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
 )
 
 const (
 	defaultPageLimit = 1
 	maxPageLimit     = 100
+	defaultListLimit = 100
+	maxListLimit     = 500
 	redactedValue    = "[redacted]"
 )
 
@@ -33,11 +36,21 @@ type Service struct {
 	store     ports.SourceRuntimeStore
 	appendLog ports.AppendLog
 	projector ports.SourceProjector
+	resolver  sourceconfig.Resolver
 }
 
 // New constructs a source runtime service.
 func New(registry *sourcecdk.Registry, store ports.SourceRuntimeStore, appendLog ports.AppendLog, projector ports.SourceProjector) *Service {
 	return &Service{registry: registry, store: store, appendLog: appendLog, projector: projector}
+}
+
+// WithConfigResolver configures runtime source config secret resolution.
+func (s *Service) WithConfigResolver(resolver sourceconfig.Resolver) *Service {
+	if s == nil {
+		return nil
+	}
+	s.resolver = resolver
+	return s
 }
 
 // Put validates and stores a source runtime definition.
@@ -68,7 +81,11 @@ func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeReques
 	default:
 		return nil, err
 	}
-	if err := source.Check(ctx, sourcecdk.NewConfig(runtime.GetConfig())); err != nil {
+	resolvedConfig, err := s.resolveConfig(ctx, runtime.GetSourceId(), runtime.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+	if err := source.Check(ctx, sourcecdk.NewConfig(resolvedConfig)); err != nil {
 		if errors.Is(err, sourcecdk.ErrInvalidConfig) {
 			return nil, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 		}
@@ -95,6 +112,29 @@ func (s *Service) Get(ctx context.Context, req *cerebrov1.GetSourceRuntimeReques
 	return &cerebrov1.GetSourceRuntimeResponse{Runtime: redactRuntime(runtime)}, nil
 }
 
+// List returns stored source runtime definitions.
+func (s *Service) List(ctx context.Context, filter ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	lister, ok := s.store.(ports.SourceRuntimeListStore)
+	if !ok {
+		return nil, ErrRuntimeUnavailable
+	}
+	normalized, err := normalizeListFilter(filter)
+	if err != nil {
+		return nil, err
+	}
+	runtimes, err := lister.ListSourceRuntimes(ctx, normalized)
+	if err != nil {
+		return nil, err
+	}
+	for i, runtime := range runtimes {
+		runtimes[i] = redactRuntime(runtime)
+	}
+	return runtimes, nil
+}
+
 // Sync advances one stored source runtime and appends emitted events.
 func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequest) (*cerebrov1.SyncSourceRuntimeResponse, error) {
 	if s == nil || s.store == nil || s.appendLog == nil {
@@ -105,6 +145,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		return nil, err
 	}
 	source, err := s.lookupSource(runtime.GetSourceId())
+	if err != nil {
+		return nil, err
+	}
+	runtimeConfig, err := s.resolveConfig(ctx, runtime.GetSourceId(), runtime.GetConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +164,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		linksProjected    uint32
 	)
 	for i := uint32(0); i < pageLimit; i++ {
-		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtime.GetConfig()), cursor)
+		pull, err := source.Read(ctx, sourcecdk.NewConfig(runtimeConfig), cursor)
 		if err != nil {
 			return nil, err
 		}
@@ -163,6 +207,14 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	}, nil
 }
 
+func (s *Service) resolveConfig(ctx context.Context, sourceID string, config map[string]string) (map[string]string, error) {
+	resolver := s.resolver
+	if resolver == nil {
+		return cloneConfig(config), nil
+	}
+	return resolver(ctx, sourceID, config)
+}
+
 func (s *Service) lookupSource(sourceID string) (sourcecdk.Source, error) {
 	id := strings.TrimSpace(sourceID)
 	if id == "" {
@@ -201,6 +253,21 @@ func normalizePageLimit(pageLimit uint32) (uint32, error) {
 		return 0, fmt.Errorf("%w: page_limit must be between 1 and %d", ErrInvalidRequest, maxPageLimit)
 	}
 	return pageLimit, nil
+}
+
+func normalizeListFilter(filter ports.SourceRuntimeFilter) (ports.SourceRuntimeFilter, error) {
+	normalized := ports.SourceRuntimeFilter{
+		TenantID: strings.TrimSpace(filter.TenantID),
+		SourceID: strings.TrimSpace(filter.SourceID),
+		Limit:    filter.Limit,
+	}
+	if normalized.Limit == 0 {
+		normalized.Limit = defaultListLimit
+	}
+	if normalized.Limit > maxListLimit {
+		return ports.SourceRuntimeFilter{}, fmt.Errorf("%w: limit must be between 1 and %d", ErrInvalidRequest, maxListLimit)
+	}
+	return normalized, nil
 }
 
 func restoreRedactedConfig(existing *cerebrov1.SourceRuntime, incoming *cerebrov1.SourceRuntime) {
@@ -278,6 +345,14 @@ func sameConfig(left map[string]string, right map[string]string) bool {
 		}
 	}
 	return true
+}
+
+func cloneConfig(config map[string]string) map[string]string {
+	cloned := make(map[string]string, len(config))
+	for key, value := range config {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func redactRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -382,6 +382,7 @@ func TestSensitiveConfigKeyCatchesCommonCamelCaseSecrets(t *testing.T) {
 		"accessKeyId",
 		"clientSecret",
 		"privateKey",
+		"signing_key",
 		"sessionToken",
 	} {
 		t.Run(key, func(t *testing.T) {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -235,13 +235,13 @@ func TestPutStoresSecretReferenceAfterResolvingForValidation(t *testing.T) {
 	}
 	store := &runtimeStore{}
 	service := New(registry, store, nil, nil).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
-	t.Setenv("CEREBRO_TEST_TOKEN", "resolved-token")
+	t.Setenv("CEREBRO_SOURCE_TOKEN_SOURCE_TOKEN", "resolved-token")
 
 	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
 		Runtime: &cerebrov1.SourceRuntime{
 			Id:       "writer-token",
 			SourceId: "token_source",
-			Config:   map[string]string{"token": "env:CEREBRO_TEST_TOKEN"},
+			Config:   map[string]string{"token": "env:CEREBRO_SOURCE_TOKEN_SOURCE_TOKEN"},
 		},
 	})
 	if err != nil {
@@ -250,7 +250,7 @@ func TestPutStoresSecretReferenceAfterResolvingForValidation(t *testing.T) {
 	if source.checked != "resolved-token" {
 		t.Fatalf("source checked token = %q, want resolved-token", source.checked)
 	}
-	if got := store.runtimes["writer-token"].GetConfig()["token"]; got != "env:CEREBRO_TEST_TOKEN" {
+	if got := store.runtimes["writer-token"].GetConfig()["token"]; got != "env:CEREBRO_SOURCE_TOKEN_SOURCE_TOKEN" {
 		t.Fatalf("stored token = %q, want env reference", got)
 	}
 }

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -3,6 +3,7 @@ package sourceruntime
 import (
 	"context"
 	"errors"
+	"sort"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	githubsource "github.com/writer/cerebro/sources/github"
@@ -47,6 +49,32 @@ func (s *runtimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov
 		return nil, ports.ErrSourceRuntimeNotFound
 	}
 	return proto.Clone(runtime).(*cerebrov1.SourceRuntime), nil
+}
+
+func (s *runtimeStore) ListSourceRuntimes(_ context.Context, filter ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	var ids []string
+	for id := range s.runtimes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	var runtimes []*cerebrov1.SourceRuntime
+	for _, id := range ids {
+		runtime := s.runtimes[id]
+		if filter.TenantID != "" && runtime.GetTenantId() != filter.TenantID {
+			continue
+		}
+		if filter.SourceID != "" && runtime.GetSourceId() != filter.SourceID {
+			continue
+		}
+		runtimes = append(runtimes, proto.Clone(runtime).(*cerebrov1.SourceRuntime))
+		if filter.Limit > 0 && uint32(len(runtimes)) >= filter.Limit {
+			break
+		}
+	}
+	return runtimes, nil
 }
 
 type appendLog struct {
@@ -129,13 +157,45 @@ func (s failingSource) Read(context.Context, sourcecdk.Config, *cerebrov1.Source
 	return sourcecdk.Pull{}, s.err
 }
 
+type tokenSource struct {
+	checked string
+	read    string
+}
+
+func (s *tokenSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "token_source"}
+}
+
+func (s *tokenSource) Check(_ context.Context, config sourcecdk.Config) error {
+	value, _ := config.Lookup("token")
+	s.checked = value
+	if value != "resolved-token" {
+		return sourcecdk.ErrInvalidConfig
+	}
+	return nil
+}
+
+func (s *tokenSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *tokenSource) Read(_ context.Context, config sourcecdk.Config, _ *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	value, _ := config.Lookup("token")
+	s.read = value
+	return sourcecdk.Pull{Events: []*cerebrov1.EventEnvelope{{
+		Id:       "token-event",
+		SourceId: "token_source",
+		Kind:     "token.event",
+	}}}, nil
+}
+
 func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
 		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
 	store := &runtimeStore{}
-	service := New(registry, store, nil, nil)
+	service := New(registry, store, nil, nil).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
 
 	putResp, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
 		Runtime: &cerebrov1.SourceRuntime{
@@ -164,6 +224,52 @@ func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 	}
 	if got := store.runtimes["writer-okta-users"].GetConfig()["token"]; got != "super-secret" {
 		t.Fatalf("stored runtime token = %q, want %q", got, "super-secret")
+	}
+}
+
+func TestPutStoresSecretReferenceAfterResolvingForValidation(t *testing.T) {
+	source := &tokenSource{}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{}
+	service := New(registry, store, nil, nil).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
+	t.Setenv("CEREBRO_TEST_TOKEN", "resolved-token")
+
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-token",
+			SourceId: "token_source",
+			Config:   map[string]string{"token": "env:CEREBRO_TEST_TOKEN"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if source.checked != "resolved-token" {
+		t.Fatalf("source checked token = %q, want resolved-token", source.checked)
+	}
+	if got := store.runtimes["writer-token"].GetConfig()["token"]; got != "env:CEREBRO_TEST_TOKEN" {
+		t.Fatalf("stored token = %q, want env reference", got)
+	}
+}
+
+func TestListRedactsSensitiveConfigAndFilters(t *testing.T) {
+	service := New(nil, &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-token": {Id: "writer-token", SourceId: "github", TenantId: "writer", Config: map[string]string{"token": "env:CEREBRO_TEST_TOKEN"}},
+		"other-token":  {Id: "other-token", SourceId: "okta", TenantId: "other", Config: map[string]string{"token": "env:OTHER"}},
+	}}, nil, nil)
+
+	runtimes, err := service.List(context.Background(), ports.SourceRuntimeFilter{TenantID: "writer"})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(runtimes) != 1 {
+		t.Fatalf("List() returned %d runtimes, want 1", len(runtimes))
+	}
+	if got := runtimes[0].GetConfig()["token"]; got != redactedValue {
+		t.Fatalf("listed token = %q, want %q", got, redactedValue)
 	}
 }
 

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -354,7 +354,7 @@ func TestProgressConfigHashIgnoresAccessKeyIDCredentials(t *testing.T) {
 
 func TestListRedactsSensitiveConfigAndFilters(t *testing.T) {
 	service := New(nil, &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
-		"writer-token": {Id: "writer-token", SourceId: "github", TenantId: "writer", Config: map[string]string{"token": "env:CEREBRO_TEST_TOKEN"}},
+		"writer-token": {Id: "writer-token", SourceId: "github", TenantId: "writer", Config: map[string]string{"token": "env:CEREBRO_TEST_TOKEN", "lookup_key": "prod", "group_key": "eng"}},
 		"other-token":  {Id: "other-token", SourceId: "okta", TenantId: "other", Config: map[string]string{"token": "env:OTHER"}},
 	}}, nil, nil)
 
@@ -367,6 +367,12 @@ func TestListRedactsSensitiveConfigAndFilters(t *testing.T) {
 	}
 	if got := runtimes[0].GetConfig()["token"]; got != redactedValue {
 		t.Fatalf("listed token = %q, want %q", got, redactedValue)
+	}
+	if got := runtimes[0].GetConfig()["lookup_key"]; got != "prod" {
+		t.Fatalf("listed lookup_key = %q, want prod", got)
+	}
+	if got := runtimes[0].GetConfig()["group_key"]; got != "eng" {
+		t.Fatalf("listed group_key = %q, want eng", got)
 	}
 }
 
@@ -381,6 +387,16 @@ func TestSensitiveConfigKeyCatchesCommonCamelCaseSecrets(t *testing.T) {
 		t.Run(key, func(t *testing.T) {
 			if !sensitiveConfigKey(key) {
 				t.Fatalf("sensitiveConfigKey(%q) = false, want true", key)
+			}
+		})
+	}
+}
+
+func TestSensitiveConfigKeyAllowsSelectorKeys(t *testing.T) {
+	for _, key := range []string{"lookup_key", "group_key"} {
+		t.Run(key, func(t *testing.T) {
+			if sensitiveConfigKey(key) {
+				t.Fatalf("sensitiveConfigKey(%q) = true, want false", key)
 			}
 		})
 	}

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -195,7 +195,7 @@ func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
 	store := &runtimeStore{}
-	service := New(registry, store, nil, nil).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
+	service := New(registry, store, nil, nil).WithConfigResolver(config.ResolveSourceRuntimeConfigSecretReferences)
 
 	putResp, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
 		Runtime: &cerebrov1.SourceRuntime{
@@ -234,7 +234,7 @@ func TestPutStoresSecretReferenceAfterResolvingForValidation(t *testing.T) {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 	store := &runtimeStore{}
-	service := New(registry, store, nil, nil).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
+	service := New(registry, store, nil, nil).WithConfigResolver(config.ResolveSourceRuntimeConfigSecretReferences)
 	t.Setenv("CEREBRO_SOURCE_TOKEN_SOURCE_TOKEN", "resolved-token")
 
 	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
@@ -284,7 +284,7 @@ func TestSyncResetsProgressWhenResolvedSelectorReferenceChanges(t *testing.T) {
 	}}
 	t.Setenv("CEREBRO_SOURCE_TOKEN_SOURCE_DOMAIN", "new.example.com")
 	t.Setenv("CEREBRO_SOURCE_TOKEN_SOURCE_TOKEN", "resolved-token")
-	service := New(registry, store, &appendLog{}, nil).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
+	service := New(registry, store, &appendLog{}, nil).WithConfigResolver(config.ResolveSourceRuntimeConfigSecretReferences)
 
 	if _, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-token"}); err != nil {
 		t.Fatalf("Sync() error = %v", err)

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -253,6 +253,55 @@ func TestPutStoresSecretReferenceAfterResolvingForValidation(t *testing.T) {
 	if got := store.runtimes["writer-token"].GetConfig()["token"]; got != "env:CEREBRO_SOURCE_TOKEN_SOURCE_TOKEN" {
 		t.Fatalf("stored token = %q, want env reference", got)
 	}
+	if _, ok := store.runtimes["writer-token"].GetConfig()[runtimeProgressConfigHashKey]; ok {
+		t.Fatal("stored sensitive-only env config wrote progress hash")
+	}
+}
+
+func TestSyncResetsProgressWhenResolvedSelectorReferenceChanges(t *testing.T) {
+	source := &tokenSource{}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	oldHash := progressConfigHash(map[string]string{
+		"domain": "old.example.com",
+		"token":  "resolved-token",
+	})
+	store := &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-token": {
+			Id:       "writer-token",
+			SourceId: "token_source",
+			Config: map[string]string{
+				"domain":                     "env:CEREBRO_SOURCE_TOKEN_SOURCE_DOMAIN",
+				"token":                      "env:CEREBRO_SOURCE_TOKEN_SOURCE_TOKEN",
+				runtimeProgressConfigHashKey: oldHash,
+			},
+			Checkpoint:   &cerebrov1.SourceCheckpoint{CursorOpaque: "old-cursor"},
+			NextCursor:   &cerebrov1.SourceCursor{Opaque: "old-cursor"},
+			LastSyncedAt: timestamppb.Now(),
+		},
+	}}
+	t.Setenv("CEREBRO_SOURCE_TOKEN_SOURCE_DOMAIN", "new.example.com")
+	t.Setenv("CEREBRO_SOURCE_TOKEN_SOURCE_TOKEN", "resolved-token")
+	service := New(registry, store, &appendLog{}, nil).WithConfigResolver(config.ResolveSourceConfigSecretReferences)
+
+	if _, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-token"}); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	stored := store.runtimes["writer-token"]
+	if stored.GetCheckpoint() != nil || stored.GetNextCursor() != nil {
+		t.Fatalf("stored cursor progress was preserved after selector change: checkpoint=%v cursor=%v", stored.GetCheckpoint(), stored.GetNextCursor())
+	}
+	if got := stored.GetConfig()[runtimeProgressConfigHashKey]; got == "" || got == oldHash {
+		t.Fatalf("stored progress hash = %q, want new non-empty hash", got)
+	}
+	if source.read != "resolved-token" {
+		t.Fatalf("source read token = %q, want resolved-token", source.read)
+	}
+	if _, ok := redactRuntime(stored).GetConfig()[runtimeProgressConfigHashKey]; ok {
+		t.Fatal("redacted runtime exposed internal progress hash")
+	}
 }
 
 func TestListRedactsSensitiveConfigAndFilters(t *testing.T) {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -328,6 +328,30 @@ func TestProgressConfigHashIncludesNonSecretKeySelectors(t *testing.T) {
 	}
 }
 
+func TestProgressConfigHashIgnoresAccessKeyIDCredentials(t *testing.T) {
+	rawConfig := map[string]string{
+		"access_key_id": "env:CEREBRO_SOURCE_AWS_ACCESS_KEY_ID",
+		"lookup_key":    "env:CEREBRO_SOURCE_AWS_LOOKUP_KEY",
+	}
+	hashA, ok := progressConfigHashForRuntime(rawConfig, map[string]string{
+		"access_key_id": "first",
+		"lookup_key":    "inventory",
+	})
+	if !ok {
+		t.Fatal("progressConfigHashForRuntime() did not include env-backed lookup_key selector")
+	}
+	hashB, ok := progressConfigHashForRuntime(rawConfig, map[string]string{
+		"access_key_id": "second",
+		"lookup_key":    "inventory",
+	})
+	if !ok {
+		t.Fatal("progressConfigHashForRuntime() did not include env-backed lookup_key selector after credential change")
+	}
+	if hashA != hashB {
+		t.Fatal("progress config hash changed when only access_key_id changed")
+	}
+}
+
 func TestListRedactsSensitiveConfigAndFilters(t *testing.T) {
 	service := New(nil, &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
 		"writer-token": {Id: "writer-token", SourceId: "github", TenantId: "writer", Config: map[string]string{"token": "env:CEREBRO_TEST_TOKEN"}},

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -304,6 +304,30 @@ func TestSyncResetsProgressWhenResolvedSelectorReferenceChanges(t *testing.T) {
 	}
 }
 
+func TestProgressConfigHashIncludesNonSecretKeySelectors(t *testing.T) {
+	rawConfig := map[string]string{
+		"lookup_key": "env:CEREBRO_SOURCE_TOKEN_SOURCE_LOOKUP_KEY",
+		"token":      "env:CEREBRO_SOURCE_TOKEN_SOURCE_TOKEN",
+	}
+	hashA, ok := progressConfigHashForRuntime(rawConfig, map[string]string{
+		"lookup_key": "team-a",
+		"token":      "resolved-token",
+	})
+	if !ok {
+		t.Fatal("progressConfigHashForRuntime() did not include env-backed lookup_key selector")
+	}
+	hashB, ok := progressConfigHashForRuntime(rawConfig, map[string]string{
+		"lookup_key": "team-b",
+		"token":      "resolved-token",
+	})
+	if !ok {
+		t.Fatal("progressConfigHashForRuntime() did not include changed env-backed lookup_key selector")
+	}
+	if hashA == hashB {
+		t.Fatal("progress config hash did not change when lookup_key changed")
+	}
+}
+
 func TestListRedactsSensitiveConfigAndFilters(t *testing.T) {
 	service := New(nil, &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
 		"writer-token": {Id: "writer-token", SourceId: "github", TenantId: "writer", Config: map[string]string{"token": "env:CEREBRO_TEST_TOKEN"}},

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -328,6 +328,32 @@ func TestProgressConfigHashIncludesNonSecretKeySelectors(t *testing.T) {
 	}
 }
 
+func TestProgressConfigHashIgnoresPreservedLiteralEnvQuerySelectors(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{
+		Id:           "writer-github",
+		SourceId:     "github",
+		Config:       map[string]string{"phrase": "env:prod"},
+		Checkpoint:   &cerebrov1.SourceCheckpoint{CursorOpaque: "old-cursor"},
+		NextCursor:   &cerebrov1.SourceCursor{Opaque: "next"},
+		LastSyncedAt: timestamppb.New(time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)),
+	}
+
+	refreshRuntimeProgressConfig(runtime, map[string]string{"phrase": "env:prod"})
+
+	if runtime.GetCheckpoint().GetCursorOpaque() != "old-cursor" {
+		t.Fatalf("checkpoint cursor = %q, want old-cursor", runtime.GetCheckpoint().GetCursorOpaque())
+	}
+	if runtime.GetNextCursor().GetOpaque() != "next" {
+		t.Fatalf("next cursor = %q, want next", runtime.GetNextCursor().GetOpaque())
+	}
+	if runtime.GetLastSyncedAt() == nil {
+		t.Fatal("last_synced_at = nil, want preserved timestamp")
+	}
+	if _, ok := runtime.GetConfig()[runtimeProgressConfigHashKey]; ok {
+		t.Fatal("literal env query selector wrote progress hash")
+	}
+}
+
 func TestProgressConfigHashIgnoresAccessKeyIDCredentials(t *testing.T) {
 	rawConfig := map[string]string{
 		"access_key_id": "env:CEREBRO_SOURCE_AWS_ACCESS_KEY_ID",

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -136,20 +136,11 @@ LIMIT $%d`, strings.Join(clauses, " AND "), sourceRuntimeListOrderClause(), len(
 // AcquireSourceRuntimeLease leases one source runtime without replacing runtime JSON.
 func (s *Store) AcquireSourceRuntimeLease(ctx context.Context, runtimeID string, owner string, ttl time.Duration) (bool, error) {
 	id := strings.TrimSpace(runtimeID)
-	if id == "" {
-		return false, errors.New("source runtime id is required")
+	leaseOwner, err := validateSourceRuntimeLeaseRequest(owner, ttl)
+	if err != nil {
+		return false, err
 	}
-	leaseOwner := strings.TrimSpace(owner)
-	if leaseOwner == "" {
-		return false, errors.New("source runtime lease owner is required")
-	}
-	if ttl <= 0 {
-		return false, errors.New("source runtime lease ttl must be positive")
-	}
-	if s == nil || s.db == nil {
-		return false, errors.New("postgres is not configured")
-	}
-	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+	if err := s.prepareSourceRuntimeLease(ctx, id); err != nil {
 		return false, err
 	}
 	result, err := s.db.ExecContext(ctx, `
@@ -165,6 +156,32 @@ WHERE id = $1
 	rows, err := result.RowsAffected()
 	if err != nil {
 		return false, fmt.Errorf("acquire source runtime lease %q rows affected: %w", id, err)
+	}
+	return rows > 0, nil
+}
+
+// RenewSourceRuntimeLease extends a source runtime lease held by owner.
+func (s *Store) RenewSourceRuntimeLease(ctx context.Context, runtimeID string, owner string, ttl time.Duration) (bool, error) {
+	id := strings.TrimSpace(runtimeID)
+	leaseOwner, err := validateSourceRuntimeLeaseRequest(owner, ttl)
+	if err != nil {
+		return false, err
+	}
+	if err := s.prepareSourceRuntimeLease(ctx, id); err != nil {
+		return false, err
+	}
+	result, err := s.db.ExecContext(ctx, `
+UPDATE source_runtimes
+SET lease_expires_at = NOW() + $3::interval
+WHERE id = $1
+  AND lease_owner = $2
+  AND lease_expires_at > NOW()`, id, leaseOwner, sourceRuntimeLeaseInterval(ttl))
+	if err != nil {
+		return false, fmt.Errorf("renew source runtime lease %q: %w", id, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("renew source runtime lease %q rows affected: %w", id, err)
 	}
 	return rows > 0, nil
 }
@@ -193,6 +210,27 @@ WHERE id = $1 AND lease_owner = $2`, id, leaseOwner); err != nil {
 		return fmt.Errorf("release source runtime lease %q: %w", id, err)
 	}
 	return nil
+}
+
+func validateSourceRuntimeLeaseRequest(owner string, ttl time.Duration) (string, error) {
+	leaseOwner := strings.TrimSpace(owner)
+	if leaseOwner == "" {
+		return "", errors.New("source runtime lease owner is required")
+	}
+	if ttl <= 0 {
+		return "", errors.New("source runtime lease ttl must be positive")
+	}
+	return leaseOwner, nil
+}
+
+func (s *Store) prepareSourceRuntimeLease(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("source runtime id is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	return s.ensureSourceRuntimeTable(ctx)
 }
 
 func sourceRuntimeLeaseInterval(ttl time.Duration) string {

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -78,6 +78,60 @@ func (s *Store) GetSourceRuntime(ctx context.Context, runtimeID string) (*cerebr
 	return runtime, nil
 }
 
+// ListSourceRuntimes loads persisted source runtime definitions.
+func (s *Store) ListSourceRuntimes(ctx context.Context, filter ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return nil, err
+	}
+	clauses := []string{"1=1"}
+	args := []any{}
+	if tenantID := strings.TrimSpace(filter.TenantID); tenantID != "" {
+		args = append(args, tenantID)
+		clauses = append(clauses, fmt.Sprintf("runtime_json->>'tenant_id' = $%d", len(args)))
+	}
+	if sourceID := strings.TrimSpace(filter.SourceID); sourceID != "" {
+		args = append(args, sourceID)
+		clauses = append(clauses, fmt.Sprintf("runtime_json->>'source_id' = $%d", len(args)))
+	}
+	limit := filter.Limit
+	if limit == 0 {
+		limit = 100
+	}
+	args = append(args, limit)
+	query := fmt.Sprintf(`
+SELECT runtime_json::text
+FROM source_runtimes
+WHERE %s
+ORDER BY updated_at DESC, id ASC
+LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list source runtimes: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+	var runtimes []*cerebrov1.SourceRuntime
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			return nil, fmt.Errorf("scan source runtime: %w", err)
+		}
+		runtime := &cerebrov1.SourceRuntime{}
+		if err := protojson.Unmarshal([]byte(payload), runtime); err != nil {
+			return nil, fmt.Errorf("decode source runtime: %w", err)
+		}
+		runtimes = append(runtimes, runtime)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate source runtimes: %w", err)
+	}
+	return runtimes, nil
+}
+
 func (s *Store) ensureSourceRuntimeTable(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.sourceRuntimeTableReady, "source runtime", ensureSourceRuntimeStatements)
 }

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -105,8 +105,8 @@ func (s *Store) ListSourceRuntimes(ctx context.Context, filter ports.SourceRunti
 SELECT runtime_json::text
 FROM source_runtimes
 WHERE %s
-ORDER BY updated_at DESC, id ASC
-LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
+ORDER BY %s
+LIMIT $%d`, strings.Join(clauses, " AND "), sourceRuntimeListOrderClause(), len(args))
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list source runtimes: %w", err)
@@ -130,6 +130,10 @@ LIMIT $%d`, strings.Join(clauses, " AND "), len(args))
 		return nil, fmt.Errorf("iterate source runtimes: %w", err)
 	}
 	return runtimes, nil
+}
+
+func sourceRuntimeListOrderClause() string {
+	return "updated_at ASC, id ASC"
 }
 
 func (s *Store) ensureSourceRuntimeTable(ctx context.Context) error {

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -132,6 +132,32 @@ LIMIT $%d`, strings.Join(clauses, " AND "), sourceRuntimeListOrderClause(), len(
 	return runtimes, nil
 }
 
+// TouchSourceRuntime advances source runtime scheduling metadata without replacing runtime JSON.
+func (s *Store) TouchSourceRuntime(ctx context.Context, runtimeID string) error {
+	id := strings.TrimSpace(runtimeID)
+	if id == "" {
+		return errors.New("source runtime id is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE source_runtimes SET updated_at = NOW() WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("touch source runtime %q: %w", id, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("touch source runtime %q rows affected: %w", id, err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("%w: %s", ports.ErrSourceRuntimeNotFound, id)
+	}
+	return nil
+}
+
 func sourceRuntimeListOrderClause() string {
 	return "updated_at ASC, id ASC"
 }

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -18,7 +19,7 @@ var ensureSourceRuntimeStatements = []string{`CREATE TABLE IF NOT EXISTS source_
   runtime_json JSONB NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-)`}
+)`, `ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_owner TEXT`, `ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ`}
 
 // PutSourceRuntime upserts one source runtime definition.
 func (s *Store) PutSourceRuntime(ctx context.Context, runtime *cerebrov1.SourceRuntime) error {
@@ -132,11 +133,51 @@ LIMIT $%d`, strings.Join(clauses, " AND "), sourceRuntimeListOrderClause(), len(
 	return runtimes, nil
 }
 
-// TouchSourceRuntime advances source runtime scheduling metadata without replacing runtime JSON.
-func (s *Store) TouchSourceRuntime(ctx context.Context, runtimeID string) error {
+// AcquireSourceRuntimeLease leases one source runtime without replacing runtime JSON.
+func (s *Store) AcquireSourceRuntimeLease(ctx context.Context, runtimeID string, owner string, ttl time.Duration) (bool, error) {
+	id := strings.TrimSpace(runtimeID)
+	if id == "" {
+		return false, errors.New("source runtime id is required")
+	}
+	leaseOwner := strings.TrimSpace(owner)
+	if leaseOwner == "" {
+		return false, errors.New("source runtime lease owner is required")
+	}
+	if ttl <= 0 {
+		return false, errors.New("source runtime lease ttl must be positive")
+	}
+	if s == nil || s.db == nil {
+		return false, errors.New("postgres is not configured")
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return false, err
+	}
+	result, err := s.db.ExecContext(ctx, `
+UPDATE source_runtimes
+SET lease_owner = $2,
+    lease_expires_at = NOW() + $3::interval,
+    updated_at = NOW()
+WHERE id = $1
+  AND (lease_expires_at IS NULL OR lease_expires_at <= NOW() OR lease_owner = $2)`, id, leaseOwner, sourceRuntimeLeaseInterval(ttl))
+	if err != nil {
+		return false, fmt.Errorf("acquire source runtime lease %q: %w", id, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("acquire source runtime lease %q rows affected: %w", id, err)
+	}
+	return rows > 0, nil
+}
+
+// ReleaseSourceRuntimeLease releases a source runtime lease held by owner.
+func (s *Store) ReleaseSourceRuntimeLease(ctx context.Context, runtimeID string, owner string) error {
 	id := strings.TrimSpace(runtimeID)
 	if id == "" {
 		return errors.New("source runtime id is required")
+	}
+	leaseOwner := strings.TrimSpace(owner)
+	if leaseOwner == "" {
+		return errors.New("source runtime lease owner is required")
 	}
 	if s == nil || s.db == nil {
 		return errors.New("postgres is not configured")
@@ -144,18 +185,22 @@ func (s *Store) TouchSourceRuntime(ctx context.Context, runtimeID string) error 
 	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
 		return err
 	}
-	result, err := s.db.ExecContext(ctx, `UPDATE source_runtimes SET updated_at = NOW() WHERE id = $1`, id)
-	if err != nil {
-		return fmt.Errorf("touch source runtime %q: %w", id, err)
-	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("touch source runtime %q rows affected: %w", id, err)
-	}
-	if rows == 0 {
-		return fmt.Errorf("%w: %s", ports.ErrSourceRuntimeNotFound, id)
+	if _, err := s.db.ExecContext(ctx, `
+UPDATE source_runtimes
+SET lease_owner = NULL,
+    lease_expires_at = NULL
+WHERE id = $1 AND lease_owner = $2`, id, leaseOwner); err != nil {
+		return fmt.Errorf("release source runtime lease %q: %w", id, err)
 	}
 	return nil
+}
+
+func sourceRuntimeLeaseInterval(ttl time.Duration) string {
+	milliseconds := ttl.Milliseconds()
+	if milliseconds < 1 {
+		milliseconds = 1
+	}
+	return fmt.Sprintf("%d milliseconds", milliseconds)
 }
 
 func sourceRuntimeListOrderClause() string {

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -43,6 +43,13 @@ func TestAcquireSourceRuntimeLeaseRejectsNonPositiveTTL(t *testing.T) {
 	}
 }
 
+func TestRenewSourceRuntimeLeaseRejectsMissingOwner(t *testing.T) {
+	store := &Store{}
+	if _, err := store.RenewSourceRuntimeLease(context.Background(), "runtime", " ", time.Minute); err == nil {
+		t.Fatal("RenewSourceRuntimeLease() error = nil, want non-nil")
+	}
+}
+
 func TestPutSourceRuntimeRejectsMissingSourceID(t *testing.T) {
 	store := &Store{}
 	err := store.PutSourceRuntime(context.Background(), &cerebrov1.SourceRuntime{Id: "runtime"})

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
@@ -21,10 +22,24 @@ func TestGetSourceRuntimeRejectsMissingID(t *testing.T) {
 	}
 }
 
-func TestTouchSourceRuntimeRejectsMissingID(t *testing.T) {
+func TestAcquireSourceRuntimeLeaseRejectsMissingID(t *testing.T) {
 	store := &Store{}
-	if err := store.TouchSourceRuntime(context.Background(), " "); err == nil {
-		t.Fatal("TouchSourceRuntime() error = nil, want non-nil")
+	if _, err := store.AcquireSourceRuntimeLease(context.Background(), " ", "owner", time.Minute); err == nil {
+		t.Fatal("AcquireSourceRuntimeLease() error = nil, want non-nil")
+	}
+}
+
+func TestAcquireSourceRuntimeLeaseRejectsMissingOwner(t *testing.T) {
+	store := &Store{}
+	if _, err := store.AcquireSourceRuntimeLease(context.Background(), "runtime", " ", time.Minute); err == nil {
+		t.Fatal("AcquireSourceRuntimeLease() error = nil, want non-nil")
+	}
+}
+
+func TestAcquireSourceRuntimeLeaseRejectsNonPositiveTTL(t *testing.T) {
+	store := &Store{}
+	if _, err := store.AcquireSourceRuntimeLease(context.Background(), "runtime", "owner", 0); err == nil {
+		t.Fatal("AcquireSourceRuntimeLease() error = nil, want non-nil")
 	}
 }
 

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -21,6 +21,13 @@ func TestGetSourceRuntimeRejectsMissingID(t *testing.T) {
 	}
 }
 
+func TestTouchSourceRuntimeRejectsMissingID(t *testing.T) {
+	store := &Store{}
+	if err := store.TouchSourceRuntime(context.Background(), " "); err == nil {
+		t.Fatal("TouchSourceRuntime() error = nil, want non-nil")
+	}
+}
+
 func TestPutSourceRuntimeRejectsMissingSourceID(t *testing.T) {
 	store := &Store{}
 	err := store.PutSourceRuntime(context.Background(), &cerebrov1.SourceRuntime{Id: "runtime"})

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -28,3 +28,9 @@ func TestPutSourceRuntimeRejectsMissingSourceID(t *testing.T) {
 		t.Fatal("PutSourceRuntime() error = nil, want non-nil")
 	}
 }
+
+func TestSourceRuntimeListOrderRotatesRecentlyUpdatedRows(t *testing.T) {
+	if got := sourceRuntimeListOrderClause(); got != "updated_at ASC, id ASC" {
+		t.Fatalf("sourceRuntimeListOrderClause() = %q, want least recently updated first", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add source runtime listing through CLI and HTTP
- add env-backed source config references resolved at runtime so infra can inject AWS Secrets Manager values
- add `cerebro orchestrator run` to sync runtimes, evaluate findings, and run graph ingest

## Validation
- `make verify`