### PR TITLE
fix: update Cerebro release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,15 +128,13 @@ jobs:
           IMAGE_BASE: ghcr.io/${{ github.repository }}
         run: |
           set -euo pipefail
-          docker manifest create "${IMAGE_BASE}:${RELEASE_TAG}" \
+          docker buildx imagetools create -t "${IMAGE_BASE}:${RELEASE_TAG}" \
             "${IMAGE_BASE}:${RELEASE_TAG}-amd64" \
             "${IMAGE_BASE}:${RELEASE_TAG}-arm64"
-          docker manifest push "${IMAGE_BASE}:${RELEASE_TAG}"
 
-          docker manifest create "${IMAGE_BASE}:latest" \
+          docker buildx imagetools create -t "${IMAGE_BASE}:latest" \
             "${IMAGE_BASE}:${RELEASE_TAG}-amd64" \
             "${IMAGE_BASE}:${RELEASE_TAG}-arm64"
-          docker manifest push "${IMAGE_BASE}:latest"
 
       - name: Keyless sign release images
         shell: bash

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,31 +23,12 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -s -w -X github.com/writer/cerebro/internal/cli.Version={{.Version}} -X github.com/writer/cerebro/internal/cli.Commit={{.Commit}} -X github.com/writer/cerebro/internal/cli.BuildDate={{.Date}}
-
-  - id: policy-enhancer
-    main: ./cmd/policy-enhancer
-    binary: policy-enhancer
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
-      - windows
-    goarch:
-      - amd64
-      - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
-    ldflags:
-      - -s -w
+      - -s -w -X github.com/writer/cerebro/internal/buildinfo.Version={{.Version}} -X github.com/writer/cerebro/internal/buildinfo.Commit={{.Commit}} -X github.com/writer/cerebro/internal/buildinfo.BuildDate={{.Date}}
 
 archives:
   - id: binaries
     builds:
       - cerebro
-      - policy-enhancer
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows


### PR DESCRIPTION
## Summary
- remove obsolete policy-enhancer release artifacts
- publish multi-arch GHCR manifests with buildx imagetools

## Validation
- go run github.com/goreleaser/goreleaser/v2@v2.15.4 release --snapshot --clean --skip=publish
- make verify
- v2.0.2 release workflow completed successfully