### PR TITLE
feat: add source runtime flow telemetry

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -67,6 +67,10 @@ paths:
     get:
       summary: List source runtime configurations
       parameters:
+        - name: runtime_id
+          in: query
+          schema:
+            type: string
         - name: tenant_id
           in: query
           schema:

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -389,6 +389,8 @@ func parseSourceRuntimeListArgs(args []string) (ports.SourceRuntimeFilter, error
 			return ports.SourceRuntimeFilter{}, fmt.Errorf("invalid source runtime list argument %q; want key=value", arg)
 		}
 		switch key {
+		case "runtime_id":
+			filter.RuntimeID = strings.TrimSpace(value)
 		case "tenant_id":
 			filter.TenantID = strings.TrimSpace(value)
 		case "source_id":

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -169,7 +169,7 @@ func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
 	return options, nil
 }
 
-func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orchestratorResult, error) {
+func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (result *orchestratorResult, err error) {
 	ctx, span := telemetry.Start(ctx, "orchestrator.run", telemetry.Attrs(
 		telemetryField("runtime_id", options.Filter.RuntimeID),
 		telemetryField("tenant_id", options.Filter.TenantID),
@@ -184,6 +184,10 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 	status := "failed"
 	spanAttributes := telemetry.Attrs()
 	defer func() {
+		if err != nil {
+			status = "failed"
+			spanAttributes = withTelemetryField(spanAttributes, "error", err.Error())
+		}
 		telemetry.End(span, status, spanAttributes)
 	}()
 	cfg, err := config.Load()
@@ -232,7 +236,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 		sourceProjector(nil, deps.GraphStore),
 		deps.GraphStore,
 	).WithConfigPreparer(config.ResolveSourceRuntimeConfigSecretReferences)
-	result := &orchestratorResult{
+	result = &orchestratorResult{
 		Iterations: options.Iterations,
 		RunForever: options.RunForever,
 		Runs:       []*orchestratorIterationResult{},

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -410,6 +410,7 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_evaluations", runtimeResult.FindingEvaluations)
 		}
 		graphResult, err := graphService.RunRuntime(runtimeCtx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"})
+		runtimeSpanAttrs = applyGraphIngestCounters(runtimeResult, graphResult, runtimeSpanAttrs)
 		if err != nil {
 			runtimeResult.GraphIngest = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
@@ -417,12 +418,6 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_error", err.Error())
 		} else {
 			runtimeResult.GraphIngest = "completed"
-			if graphResult.Ingest != nil {
-				runtimeResult.EntitiesProjected = graphResult.Ingest.EntitiesProjected
-				runtimeResult.LinksProjected = graphResult.Ingest.LinksProjected
-				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "entities_projected", runtimeResult.EntitiesProjected)
-				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "links_projected", runtimeResult.LinksProjected)
-			}
 		}
 		cancelRuntime()
 		if err := stopLeaseRenewal(); err != nil {
@@ -452,6 +447,17 @@ func runOrchestratorIteration(
 	spanAttributes = withTelemetryField(spanAttributes, "runtimes_attempted", len(result.Runtimes))
 	spanAttributes = withTelemetryField(spanAttributes, "runtimes_acquired", acquiredCount)
 	return result, runErr
+}
+
+func applyGraphIngestCounters(runtimeResult *orchestratorRuntimeResult, graphResult *graphingest.RunResult, attrs telemetry.Attributes) telemetry.Attributes {
+	if runtimeResult == nil || graphResult == nil || graphResult.Ingest == nil {
+		return attrs
+	}
+	runtimeResult.EntitiesProjected = graphResult.Ingest.EntitiesProjected
+	runtimeResult.LinksProjected = graphResult.Ingest.LinksProjected
+	attrs = withTelemetryField(attrs, "entities_projected", runtimeResult.EntitiesProjected)
+	attrs = withTelemetryField(attrs, "links_projected", runtimeResult.LinksProjected)
+	return attrs
 }
 
 func orchestratorListFilter(filter ports.SourceRuntimeFilter) ports.SourceRuntimeFilter {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourceregistry"
 	"github.com/writer/cerebro/internal/sourceruntime"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 const defaultOrchestratorIterations = 1
@@ -50,18 +51,24 @@ type orchestratorIterationResult struct {
 }
 
 type orchestratorRuntimeResult struct {
-	RuntimeID    string `json:"runtime_id"`
-	SourceID     string `json:"source_id,omitempty"`
-	TenantID     string `json:"tenant_id,omitempty"`
-	Sync         string `json:"sync"`
-	FindingRules string `json:"finding_rules"`
-	GraphIngest  string `json:"graph_ingest"`
-	Error        string `json:"error,omitempty"`
+	RuntimeID          string `json:"runtime_id"`
+	SourceID           string `json:"source_id,omitempty"`
+	TenantID           string `json:"tenant_id,omitempty"`
+	Sync               string `json:"sync"`
+	PagesRead          uint32 `json:"pages_read,omitempty"`
+	EventsAppended     uint32 `json:"events_appended,omitempty"`
+	FindingRules       string `json:"finding_rules"`
+	EventsEvaluated    uint32 `json:"events_evaluated,omitempty"`
+	FindingEvaluations int    `json:"finding_evaluations,omitempty"`
+	GraphIngest        string `json:"graph_ingest"`
+	EntitiesProjected  uint32 `json:"entities_projected,omitempty"`
+	LinksProjected     uint32 `json:"links_projected,omitempty"`
+	Error              string `json:"error,omitempty"`
 }
 
 func runOrchestrator(args []string) error {
 	if len(args) == 0 || args[0] != "run" {
-		return usageError(fmt.Sprintf("usage: %s orchestrator run [tenant_id=<tenant-id>] [source_id=<source-id>] [limit=N] [page_limit=N] [event_limit=N] [graph_page_limit=N] [interval=30s] [iterations=N|forever]", os.Args[0]))
+		return usageError(fmt.Sprintf("usage: %s orchestrator run [runtime_id=<runtime-id>] [tenant_id=<tenant-id>] [source_id=<source-id>] [limit=N] [page_limit=N] [event_limit=N] [graph_page_limit=N] [interval=30s] [iterations=N|forever]", os.Args[0]))
 	}
 	options, err := parseOrchestratorOptions(args[1:])
 	if err != nil {
@@ -95,6 +102,8 @@ func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
 			return orchestratorOptions{}, fmt.Errorf("invalid orchestrator argument %q; want key=value", arg)
 		}
 		switch key {
+		case "runtime_id":
+			options.Filter.RuntimeID = strings.TrimSpace(value)
 		case "tenant_id":
 			options.Filter.TenantID = strings.TrimSpace(value)
 		case "source_id":
@@ -161,6 +170,22 @@ func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
 }
 
 func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orchestratorResult, error) {
+	ctx, span := telemetry.Start(ctx, "orchestrator.run", telemetry.Attrs(
+		telemetryField("runtime_id", options.Filter.RuntimeID),
+		telemetryField("tenant_id", options.Filter.TenantID),
+		telemetryField("source_id", options.Filter.SourceID),
+		telemetryField("limit", options.Filter.Limit),
+		telemetryField("page_limit", options.PageLimit),
+		telemetryField("event_limit", options.EventLimit),
+		telemetryField("graph_page_limit", options.GraphPageLimit),
+		telemetryField("iterations", options.Iterations),
+		telemetryField("run_forever", options.RunForever),
+	))
+	status := "failed"
+	spanAttributes := telemetry.Attrs()
+	defer func() {
+		telemetry.End(span, status, spanAttributes)
+	}()
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)
@@ -239,10 +264,17 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (*orc
 		}
 		select {
 		case <-ctx.Done():
+			spanAttributes = withTelemetryField(spanAttributes, "error", ctx.Err().Error())
 			return result, ctx.Err()
 		case <-ticker.C:
 		}
 	}
+	status = "completed"
+	if runErr != nil {
+		status = "failed"
+		spanAttributes = withTelemetryField(spanAttributes, "error", runErr.Error())
+	}
+	spanAttributes = withTelemetryField(spanAttributes, "iterations_completed", iteration)
 	return result, runErr
 }
 
@@ -264,12 +296,29 @@ func runOrchestratorIteration(
 	options orchestratorOptions,
 	iteration uint32,
 ) (*orchestratorIterationResult, error) {
+	ctx, span := telemetry.Start(ctx, "orchestrator.iteration", telemetry.Attrs(
+		telemetryField("iteration", iteration),
+		telemetryField("runtime_id", options.Filter.RuntimeID),
+		telemetryField("tenant_id", options.Filter.TenantID),
+		telemetryField("source_id", options.Filter.SourceID),
+		telemetryField("limit", options.Filter.Limit),
+	))
+	status := "failed"
+	spanAttributes := telemetry.Attrs()
+	defer func() {
+		telemetry.End(span, status, spanAttributes)
+	}()
 	targetLimit := options.Filter.Limit
 	runtimes, err := lister.ListSourceRuntimes(ctx, orchestratorListFilter(options.Filter))
 	result := &orchestratorIterationResult{Iteration: iteration, StartedAt: time.Now().UTC()}
 	if err != nil {
+		spanAttributes = withTelemetryField(spanAttributes, "error", err.Error())
 		return result, err
 	}
+	telemetry.Event(ctx, "orchestrator.runtimes_listed", telemetry.Attrs(
+		telemetryField("iteration", iteration),
+		telemetryField("runtime_count", len(runtimes)),
+	))
 	var runErr error
 	var acquiredCount uint32
 	for _, runtime := range runtimes {
@@ -278,9 +327,18 @@ func runOrchestratorIteration(
 		}
 		select {
 		case <-ctx.Done():
+			spanAttributes = withTelemetryField(spanAttributes, "error", ctx.Err().Error())
 			return result, ctx.Err()
 		default:
 		}
+		runtimeCtx, runtimeSpan := telemetry.Start(ctx, "orchestrator.runtime", telemetry.Attrs(
+			telemetryField("iteration", iteration),
+			telemetryField("runtime_id", runtime.GetId()),
+			telemetryField("source_id", runtime.GetSourceId()),
+			telemetryField("tenant_id", runtime.GetTenantId()),
+		))
+		runtimeStatus := "failed"
+		runtimeSpanAttrs := telemetry.Attrs()
 		runtimeResult := &orchestratorRuntimeResult{
 			RuntimeID: strings.TrimSpace(runtime.GetId()),
 			SourceID:  strings.TrimSpace(runtime.GetSourceId()),
@@ -292,59 +350,103 @@ func runOrchestratorIteration(
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "lease", err)
 			result.Runtimes = append(result.Runtimes, runtimeResult)
 			runErr = err
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error", err.Error())
+			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		}
 		if !acquired {
 			runtimeResult.Sync = "skipped"
 			result.Runtimes = append(result.Runtimes, runtimeResult)
+			runtimeStatus = "skipped"
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reason", "lease_not_acquired")
+			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		}
 		acquiredCount++
-		runtimeCtx, cancelRuntime := context.WithCancel(ctx)
+		runtimeCtx, cancelRuntime := context.WithCancel(runtimeCtx)
 		stopLeaseRenewal := startOrchestratorRuntimeLeaseRenewal(ctx, leaser, runtime, leaseOwner, cancelRuntime)
-		if _, err := runtimeService.Sync(runtimeCtx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit}); err != nil {
+		syncResult, err := runtimeService.Sync(runtimeCtx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit})
+		if err != nil {
 			runtimeResult.Sync = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "sync", err)
 			runErr = err
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error", err.Error())
 			cancelRuntime()
 			if renewalErr := stopLeaseRenewal(); renewalErr != nil {
 				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", renewalErr)
 				runErr = renewalErr
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error", renewalErr.Error())
 			}
 			if releaseErr := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); releaseErr != nil {
 				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", releaseErr)
 				runErr = releaseErr
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error", releaseErr.Error())
 			}
 			result.Runtimes = append(result.Runtimes, runtimeResult)
+			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 			continue
 		} else {
 			runtimeResult.Sync = "completed"
+			runtimeResult.PagesRead = syncResult.GetPagesRead()
+			runtimeResult.EventsAppended = syncResult.GetEventsAppended()
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "pages_read", runtimeResult.PagesRead)
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "events_appended", runtimeResult.EventsAppended)
 		}
-		if _, err := findingService.EvaluateSourceRuntimeRules(runtimeCtx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit}); err != nil {
+		findingResult, err := findingService.EvaluateSourceRuntimeRules(runtimeCtx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit})
+		if err != nil {
 			runtimeResult.FindingRules = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "finding_rules", err)
 			runErr = err
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_rules_error", err.Error())
 		} else {
 			runtimeResult.FindingRules = "completed"
+			runtimeResult.EventsEvaluated = findingResult.EventsEvaluated
+			runtimeResult.FindingEvaluations = len(findingResult.Evaluations)
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "events_evaluated", runtimeResult.EventsEvaluated)
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_evaluations", runtimeResult.FindingEvaluations)
 		}
-		if _, err := graphService.RunRuntime(runtimeCtx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"}); err != nil {
+		graphResult, err := graphService.RunRuntime(runtimeCtx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"})
+		if err != nil {
 			runtimeResult.GraphIngest = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
 			runErr = err
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_error", err.Error())
 		} else {
 			runtimeResult.GraphIngest = "completed"
+			if graphResult.Ingest != nil {
+				runtimeResult.EntitiesProjected = graphResult.Ingest.EntitiesProjected
+				runtimeResult.LinksProjected = graphResult.Ingest.LinksProjected
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "entities_projected", runtimeResult.EntitiesProjected)
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "links_projected", runtimeResult.LinksProjected)
+			}
 		}
 		cancelRuntime()
 		if err := stopLeaseRenewal(); err != nil {
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "renew_lease", err)
 			runErr = err
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "renew_lease_error", err.Error())
 		}
 		if err := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); err != nil {
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", err)
 			runErr = err
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "release_lease_error", err.Error())
 		}
 		result.Runtimes = append(result.Runtimes, runtimeResult)
+		if runtimeResult.Error == "" {
+			runtimeStatus = "completed"
+		}
+		if runtimeResult.Error != "" {
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error", runtimeResult.Error)
+		}
+		telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
 	}
+	status = "completed"
+	if runErr != nil {
+		status = "failed"
+		spanAttributes = withTelemetryField(spanAttributes, "error", runErr.Error())
+	}
+	spanAttributes = withTelemetryField(spanAttributes, "runtimes_attempted", len(result.Runtimes))
+	spanAttributes = withTelemetryField(spanAttributes, "runtimes_acquired", acquiredCount)
 	return result, runErr
 }
 
@@ -441,6 +543,14 @@ func appendRuntimeError(existing string, stage string, err error) string {
 		return message
 	}
 	return existing + "; " + message
+}
+
+func telemetryField(key string, value any) telemetry.Field {
+	return telemetry.Field{Key: key, Value: value}
+}
+
+func withTelemetryField(attributes telemetry.Attributes, key string, value any) telemetry.Attributes {
+	return attributes.WithField(telemetryField(key, value))
 }
 
 func findingStore(store ports.StateStore) ports.FindingStore {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -47,6 +47,16 @@ func TestParseOrchestratorOptionsRejectsZeroLimit(t *testing.T) {
 	}
 }
 
+func TestParseOrchestratorOptionsAcceptsRuntimeID(t *testing.T) {
+	options, err := parseOrchestratorOptions([]string{"runtime_id=writer-okta-audit"})
+	if err != nil {
+		t.Fatalf("parseOrchestratorOptions(runtime_id) error = %v", err)
+	}
+	if got := options.Filter.RuntimeID; got != "writer-okta-audit" {
+		t.Fatalf("runtime filter = %q, want writer-okta-audit", got)
+	}
+}
+
 func TestOrchestratorShutdownSignalsIncludeSIGTERM(t *testing.T) {
 	signals := orchestratorShutdownSignals()
 	if len(signals) != 2 || signals[0] != os.Interrupt || signals[1] != syscall.SIGTERM {
@@ -129,6 +139,13 @@ func TestSourceRuntimeLeaseRenewalIntervalUsesHalfTTL(t *testing.T) {
 func TestOrchestratorListFilterRequestsAllByDefault(t *testing.T) {
 	if got := orchestratorListFilter(ports.SourceRuntimeFilter{}).Limit; got != ^uint32(0) {
 		t.Fatalf("orchestratorListFilter(default).Limit = %d, want max uint32", got)
+	}
+}
+
+func TestOrchestratorListFilterPreservesRuntimeID(t *testing.T) {
+	filter := orchestratorListFilter(ports.SourceRuntimeFilter{RuntimeID: "writer-okta-audit", Limit: 1})
+	if got := filter.RuntimeID; got != "writer-okta-audit" {
+		t.Fatalf("orchestratorListFilter().RuntimeID = %q, want writer-okta-audit", got)
 	}
 }
 

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -2,13 +2,19 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"syscall"
 	"testing"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphingest"
+	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceprojection"
 	"github.com/writer/cerebro/internal/sourceruntime"
 )
 
@@ -91,6 +97,52 @@ func TestRunOrchestratorIterationStopsAfterSyncFailure(t *testing.T) {
 	}
 	if store.leaseID != "runtime-1" || store.releaseID != "runtime-1" {
 		t.Fatalf("lease/release = %q/%q, want runtime-1/runtime-1", store.leaseID, store.releaseID)
+	}
+}
+
+func TestRunOrchestratorIterationPreservesGraphCountersOnPartialFailure(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	ruleRegistry, err := findings.NewRegistry(orchestratorNoopRule{})
+	if err != nil {
+		t.Fatalf("NewRegistry() finding rule error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{
+			Id:       "runtime-1",
+			SourceId: "github",
+			TenantId: "writer",
+		},
+		acquired: true,
+	}
+	eventLog := &orchestratorEventLog{}
+	findingStore := &orchestratorFindingStore{}
+	graphStore := &failingCompletedIngestGraphStore{graphTestStore: newGraphTestStore()}
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(registry, store, eventLog, nil),
+		findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry),
+		graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore),
+		orchestratorOptions{},
+		1,
+	)
+	if err == nil {
+		t.Fatal("runOrchestratorIteration() error = nil, want graph ingest completion failure")
+	}
+	if got := len(result.Runtimes); got != 1 {
+		t.Fatalf("runtime result count = %d, want 1", got)
+	}
+	runtimeResult := result.Runtimes[0]
+	if runtimeResult.GraphIngest != "failed" {
+		t.Fatalf("graph ingest status = %q, want failed", runtimeResult.GraphIngest)
+	}
+	if runtimeResult.EntitiesProjected != 6 || runtimeResult.LinksProjected != 6 {
+		t.Fatalf("graph counters = %d/%d, want 6/6", runtimeResult.EntitiesProjected, runtimeResult.LinksProjected)
 	}
 }
 
@@ -331,4 +383,144 @@ func (s *orchestratorRuntimeStore) RenewSourceRuntimeLease(context.Context, stri
 func (s *orchestratorRuntimeStore) ReleaseSourceRuntimeLease(_ context.Context, runtimeID string, _ string) error {
 	s.releaseID = runtimeID
 	return nil
+}
+
+type orchestratorTestSource struct{}
+
+func (orchestratorTestSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "github", Name: "GitHub"}
+}
+
+func (orchestratorTestSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (orchestratorTestSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (orchestratorTestSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{Events: []*cerebrov1.EventEnvelope{{
+		Id:       "github-pr-515",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.pull_request",
+		Attributes: map[string]string{
+			"author":      "alice",
+			"owner":       "writer",
+			"pull_number": "515",
+			"repository":  "writer/cerebro",
+			"state":       "open",
+		},
+	}}}, nil
+}
+
+type orchestratorNoopRule struct{}
+
+func (orchestratorNoopRule) Spec() *cerebrov1.RuleSpec {
+	return &cerebrov1.RuleSpec{Id: "noop-rule", Name: "Noop rule"}
+}
+
+func (orchestratorNoopRule) SupportsRuntime(*cerebrov1.SourceRuntime) bool {
+	return true
+}
+
+func (orchestratorNoopRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+type orchestratorEventLog struct {
+	events []*cerebrov1.EventEnvelope
+}
+
+func (l *orchestratorEventLog) Ping(context.Context) error {
+	return nil
+}
+
+func (l *orchestratorEventLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) error {
+	l.events = append(l.events, event)
+	return nil
+}
+
+func (l *orchestratorEventLog) Replay(context.Context, ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
+	return nil, nil
+}
+
+type orchestratorFindingStore struct{}
+
+func (s *orchestratorFindingStore) Ping(context.Context) error { return nil }
+
+func (s *orchestratorFindingStore) UpsertFinding(_ context.Context, finding *ports.FindingRecord) (*ports.FindingRecord, error) {
+	return finding, nil
+}
+
+func (s *orchestratorFindingStore) GetFinding(context.Context, string) (*ports.FindingRecord, error) {
+	return nil, ports.ErrFindingNotFound
+}
+
+func (s *orchestratorFindingStore) ListFindings(context.Context, ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (s *orchestratorFindingStore) UpdateFindingStatus(context.Context, ports.FindingStatusUpdate) (*ports.FindingRecord, error) {
+	return nil, ports.ErrFindingNotFound
+}
+
+func (s *orchestratorFindingStore) UpdateFindingAssignee(context.Context, ports.FindingAssigneeUpdate) (*ports.FindingRecord, error) {
+	return nil, ports.ErrFindingNotFound
+}
+
+func (s *orchestratorFindingStore) UpdateFindingDueDate(context.Context, ports.FindingDueDateUpdate) (*ports.FindingRecord, error) {
+	return nil, ports.ErrFindingNotFound
+}
+
+func (s *orchestratorFindingStore) AddFindingNote(context.Context, ports.FindingNoteCreate) (*ports.FindingRecord, error) {
+	return nil, ports.ErrFindingNotFound
+}
+
+func (s *orchestratorFindingStore) LinkFindingTicket(context.Context, ports.FindingTicketLink) (*ports.FindingRecord, error) {
+	return nil, ports.ErrFindingNotFound
+}
+
+func (s *orchestratorFindingStore) PutFindingEvaluationRun(context.Context, *cerebrov1.FindingEvaluationRun) error {
+	return nil
+}
+
+func (s *orchestratorFindingStore) GetFindingEvaluationRun(context.Context, string) (*cerebrov1.FindingEvaluationRun, error) {
+	return nil, ports.ErrFindingEvaluationRunNotFound
+}
+
+func (s *orchestratorFindingStore) ListFindingEvaluationRuns(context.Context, ports.ListFindingEvaluationRunsRequest) ([]*cerebrov1.FindingEvaluationRun, error) {
+	return nil, nil
+}
+
+func (s *orchestratorFindingStore) PutFindingEvidence(context.Context, *cerebrov1.FindingEvidence) error {
+	return nil
+}
+
+func (s *orchestratorFindingStore) GetFindingEvidence(context.Context, string) (*cerebrov1.FindingEvidence, error) {
+	return nil, ports.ErrFindingEvidenceNotFound
+}
+
+func (s *orchestratorFindingStore) ListFindingEvidence(context.Context, ports.ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error) {
+	return nil, nil
+}
+
+func (s *orchestratorFindingStore) UpsertClaim(_ context.Context, claim *ports.ClaimRecord) (*ports.ClaimRecord, error) {
+	return claim, nil
+}
+
+func (s *orchestratorFindingStore) ListClaims(context.Context, ports.ListClaimsRequest) ([]*ports.ClaimRecord, error) {
+	return nil, nil
+}
+
+type failingCompletedIngestGraphStore struct {
+	*graphTestStore
+}
+
+func (s *failingCompletedIngestGraphStore) PutIngestRun(ctx context.Context, run graphstore.IngestRun) error {
+	if run.Status == graphstore.IngestRunStatusCompleted {
+		return errors.New("run completion failed")
+	}
+	return s.graphTestStore.PutIngestRun(ctx, run)
 }

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -995,7 +995,12 @@ func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
 	if filter.TenantID == "" {
 		filter.TenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
 	}
-	if filter.TenantID == "" && requiresTenantFilter(r.Context()) {
+	if filter.RuntimeID != "" {
+		if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), filter.RuntimeID, true); err != nil {
+			writeSourceRuntimeError(w, err)
+			return
+		}
+	} else if filter.TenantID == "" && requiresTenantFilter(r.Context()) {
 		writeSourceRuntimeError(w, errTenantForbidden)
 		return
 	}

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -982,9 +982,10 @@ func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	filter := ports.SourceRuntimeFilter{
-		TenantID: strings.TrimSpace(r.URL.Query().Get("tenant_id")),
-		SourceID: strings.TrimSpace(r.URL.Query().Get("source_id")),
-		Limit:    limit,
+		RuntimeID: strings.TrimSpace(r.URL.Query().Get("runtime_id")),
+		TenantID:  strings.TrimSpace(r.URL.Query().Get("tenant_id")),
+		SourceID:  strings.TrimSpace(r.URL.Query().Get("source_id")),
+		Limit:     limit,
 	}
 	if filter.TenantID == "" {
 		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok && strings.TrimSpace(auth.principal.TenantID) != "" {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -995,12 +995,28 @@ func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
 	if filter.TenantID == "" {
 		filter.TenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
 	}
-	if filter.RuntimeID != "" {
-		if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), filter.RuntimeID, true); err != nil {
+	if filter.TenantID == "" && filter.RuntimeID != "" && requiresTenantFilter(r.Context()) {
+		store := sourceRuntimeStore(a.deps.StateStore)
+		if store == nil {
+			writeSourceRuntimeError(w, sourceruntime.ErrRuntimeUnavailable)
+			return
+		}
+		runtime, err := store.GetSourceRuntime(r.Context(), filter.RuntimeID)
+		if errors.Is(err, ports.ErrSourceRuntimeNotFound) {
+			writeSourceRuntimeListJSON(w, http.StatusOK, nil)
+			return
+		}
+		if err != nil {
 			writeSourceRuntimeError(w, err)
 			return
 		}
-	} else if filter.TenantID == "" && requiresTenantFilter(r.Context()) {
+		if err := authorizeTenantID(r.Context(), runtime.GetTenantId()); err != nil {
+			writeSourceRuntimeListJSON(w, http.StatusOK, nil)
+			return
+		}
+		filter.TenantID = strings.TrimSpace(runtime.GetTenantId())
+	}
+	if filter.TenantID == "" && requiresTenantFilter(r.Context()) {
 		writeSourceRuntimeError(w, errTenantForbidden)
 		return
 	}

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1016,7 +1016,7 @@ func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
 		}
 		filter.TenantID = strings.TrimSpace(runtime.GetTenantId())
 	}
-	if filter.TenantID == "" && requiresTenantFilter(r.Context()) {
+	if filter.TenantID == "" && filter.RuntimeID == "" && requiresTenantFilter(r.Context()) {
 		writeSourceRuntimeError(w, errTenantForbidden)
 		return
 	}

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -597,6 +597,9 @@ func (s *stubRuntimeStore) ListSourceRuntimes(_ context.Context, filter ports.So
 	var runtimes []*cerebrov1.SourceRuntime
 	for _, id := range ids {
 		runtime := s.runtimes[id]
+		if filter.RuntimeID != "" && runtime.GetId() != filter.RuntimeID {
+			continue
+		}
 		if filter.TenantID != "" && runtime.GetTenantId() != filter.TenantID {
 			continue
 		}
@@ -1639,6 +1642,69 @@ func TestListSourceRuntimesRequiresTenantFilterWithAllowedTenantAuth(t *testing.
 	}
 	if got := len(payload["runtimes"]); got != 1 {
 		t.Fatalf("listed runtime count = %d, want 1", got)
+	}
+}
+
+func TestListSourceRuntimesAuthorizesRuntimeIDWithAllowedTenantAuth(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled:        true,
+			APIKeys:        []config.APIKey{{Key: "allowed-key"}},
+			AllowedTenants: []string{"writer"},
+		},
+	}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
+			"other-runtime":  {Id: "other-runtime", SourceId: "github", TenantId: "other"},
+		},
+	}
+	app := New(cfg, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes?runtime_id=writer-runtime", nil)
+	if err != nil {
+		t.Fatalf("NewRequest with runtime_id: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer allowed-key")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes with runtime_id error = %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Fatalf("close response body: %v", closeErr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /source-runtimes with runtime_id status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload map[string][]map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode source runtime list: %v", err)
+	}
+	if got := len(payload["runtimes"]); got != 1 {
+		t.Fatalf("listed runtime count = %d, want 1", got)
+	}
+	if got := payload["runtimes"][0]["id"]; got != "writer-runtime" {
+		t.Fatalf("listed runtime id = %v, want writer-runtime", got)
+	}
+
+	forbiddenReq, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes?runtime_id=other-runtime", nil)
+	if err != nil {
+		t.Fatalf("NewRequest with forbidden runtime_id: %v", err)
+	}
+	forbiddenReq.Header.Set("Authorization", "Bearer allowed-key")
+	forbiddenResp, err := server.Client().Do(forbiddenReq)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes with forbidden runtime_id error = %v", err)
+	}
+	_ = forbiddenResp.Body.Close()
+	if forbiddenResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("GET /source-runtimes with forbidden runtime_id status = %d, want %d", forbiddenResp.StatusCode, http.StatusForbidden)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1599,6 +1599,7 @@ func TestListSourceRuntimesRequiresTenantFilterWithAllowedTenantAuth(t *testing.
 		runtimes: map[string]*cerebrov1.SourceRuntime{
 			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
 			"other-runtime":  {Id: "other-runtime", SourceId: "github", TenantId: "other"},
+			"blank-runtime":  {Id: "blank-runtime", SourceId: "github"},
 		},
 	}
 	app := New(cfg, Dependencies{StateStore: store}, nil)
@@ -1659,6 +1660,7 @@ func TestListSourceRuntimesAuthorizesRuntimeIDWithAllowedTenantAuth(t *testing.T
 		runtimes: map[string]*cerebrov1.SourceRuntime{
 			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
 			"other-runtime":  {Id: "other-runtime", SourceId: "github", TenantId: "other"},
+			"blank-runtime":  {Id: "blank-runtime", SourceId: "github"},
 		},
 	}
 	app := New(cfg, Dependencies{StateStore: store}, nil)
@@ -1691,6 +1693,34 @@ func TestListSourceRuntimesAuthorizesRuntimeIDWithAllowedTenantAuth(t *testing.T
 	}
 	if got := payload["runtimes"][0]["id"]; got != "writer-runtime" {
 		t.Fatalf("listed runtime id = %v, want writer-runtime", got)
+	}
+
+	blankReq, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes?runtime_id=blank-runtime", nil)
+	if err != nil {
+		t.Fatalf("NewRequest with blank runtime_id: %v", err)
+	}
+	blankReq.Header.Set("Authorization", "Bearer allowed-key")
+	blankResp, err := server.Client().Do(blankReq)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes with blank runtime_id error = %v", err)
+	}
+	defer func() {
+		if closeErr := blankResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close blank response body: %v", closeErr)
+		}
+	}()
+	if blankResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /source-runtimes with blank runtime_id status = %d, want %d", blankResp.StatusCode, http.StatusOK)
+	}
+	var blankPayload map[string][]map[string]any
+	if err := json.NewDecoder(blankResp.Body).Decode(&blankPayload); err != nil {
+		t.Fatalf("decode blank source runtime list: %v", err)
+	}
+	if got := len(blankPayload["runtimes"]); got != 1 {
+		t.Fatalf("blank runtime count = %d, want 1", got)
+	}
+	if got := blankPayload["runtimes"][0]["id"]; got != "blank-runtime" {
+		t.Fatalf("blank runtime id = %v, want blank-runtime", got)
 	}
 
 	forbiddenReq, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes?runtime_id=other-runtime", nil)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1702,9 +1702,45 @@ func TestListSourceRuntimesAuthorizesRuntimeIDWithAllowedTenantAuth(t *testing.T
 	if err != nil {
 		t.Fatalf("GET /source-runtimes with forbidden runtime_id error = %v", err)
 	}
-	_ = forbiddenResp.Body.Close()
-	if forbiddenResp.StatusCode != http.StatusForbidden {
-		t.Fatalf("GET /source-runtimes with forbidden runtime_id status = %d, want %d", forbiddenResp.StatusCode, http.StatusForbidden)
+	defer func() {
+		if closeErr := forbiddenResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close forbidden response body: %v", closeErr)
+		}
+	}()
+	if forbiddenResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /source-runtimes with forbidden runtime_id status = %d, want %d", forbiddenResp.StatusCode, http.StatusOK)
+	}
+	var forbiddenPayload map[string][]map[string]any
+	if err := json.NewDecoder(forbiddenResp.Body).Decode(&forbiddenPayload); err != nil {
+		t.Fatalf("decode forbidden source runtime list: %v", err)
+	}
+	if got := len(forbiddenPayload["runtimes"]); got != 0 {
+		t.Fatalf("forbidden runtime count = %d, want 0", got)
+	}
+
+	missingReq, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes?runtime_id=missing-runtime", nil)
+	if err != nil {
+		t.Fatalf("NewRequest with missing runtime_id: %v", err)
+	}
+	missingReq.Header.Set("Authorization", "Bearer allowed-key")
+	missingResp, err := server.Client().Do(missingReq)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes with missing runtime_id error = %v", err)
+	}
+	defer func() {
+		if closeErr := missingResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close missing response body: %v", closeErr)
+		}
+	}()
+	if missingResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /source-runtimes with missing runtime_id status = %d, want %d", missingResp.StatusCode, http.StatusOK)
+	}
+	var missingPayload map[string][]map[string]any
+	if err := json.NewDecoder(missingResp.Body).Decode(&missingPayload); err != nil {
+		t.Fatalf("decode missing source runtime list: %v", err)
+	}
+	if got := len(missingPayload["runtimes"]); got != 0 {
+		t.Fatalf("missing runtime count = %d, want 0", got)
 	}
 }
 

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -20,9 +20,10 @@ type SourceRuntimeStore interface {
 
 // SourceRuntimeFilter scopes persisted source runtime listing.
 type SourceRuntimeFilter struct {
-	TenantID string
-	SourceID string
-	Limit    uint32
+	RuntimeID string
+	TenantID  string
+	SourceID  string
+	Limit     uint32
 }
 
 // SourceRuntimeListStore lists persisted source runtime definitions.

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 const (
@@ -143,6 +144,19 @@ func (s *Service) List(ctx context.Context, filter ports.SourceRuntimeFilter) ([
 
 // Sync advances one stored source runtime and appends emitted events.
 func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequest) (*cerebrov1.SyncSourceRuntimeResponse, error) {
+	runtimeID := ""
+	if req != nil {
+		runtimeID = strings.TrimSpace(req.GetId())
+	}
+	ctx, span := telemetry.Start(ctx, "source_runtime.sync", telemetry.Attrs(
+		telemetry.Field{Key: "runtime_id", Value: runtimeID},
+		telemetry.Field{Key: "page_limit", Value: req.GetPageLimit()},
+	))
+	status := "failed"
+	spanAttributes := telemetry.Attrs()
+	defer func() {
+		telemetry.End(span, status, spanAttributes)
+	}()
 	if s == nil || s.store == nil || s.appendLog == nil {
 		return nil, ErrRuntimeUnavailable
 	}
@@ -158,6 +172,8 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	if err != nil {
 		return nil, err
 	}
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()})
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()})
 	refreshRuntimeProgressConfig(runtime, runtimeConfig)
 	pageLimit, err := normalizePageLimit(req.GetPageLimit())
 	if err != nil {
@@ -175,6 +191,16 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		if err != nil {
 			return nil, err
 		}
+		pageNumber := i + 1
+		eventsRead := uint32(len(pull.Events))
+		telemetry.Event(ctx, "source_runtime.page_read", telemetry.Attrs(
+			telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
+			telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()},
+			telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()},
+			telemetry.Field{Key: "page", Value: pageNumber},
+			telemetry.Field{Key: "events_read", Value: eventsRead},
+			telemetry.Field{Key: "has_next_cursor", Value: pull.NextCursor != nil},
+		))
 		if pull.Checkpoint != nil {
 			runtime.Checkpoint = cloneCheckpoint(pull.Checkpoint)
 		}
@@ -182,6 +208,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		pagesRead++
 		for _, event := range pull.Events {
 			syncedEvent := materializeEvent(runtime, event)
+			if syncedEvent.Attributes == nil {
+				syncedEvent.Attributes = make(map[string]string)
+			}
+			telemetry.InjectEventAttributes(ctx, syncedEvent.Attributes)
 			if err := s.appendLog.Append(ctx, syncedEvent); err != nil {
 				return nil, fmt.Errorf("append source event %q: %w", syncedEvent.GetId(), err)
 			}
@@ -199,11 +229,27 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
 			return nil, err
 		}
+		telemetry.Event(ctx, "source_runtime.page_committed", telemetry.Attrs(
+			telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
+			telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()},
+			telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()},
+			telemetry.Field{Key: "page", Value: pageNumber},
+			telemetry.Field{Key: "events_appended", Value: eventsAppended},
+			telemetry.Field{Key: "entities_projected", Value: entitiesProjected},
+			telemetry.Field{Key: "links_projected", Value: linksProjected},
+			telemetry.Field{Key: "has_next_cursor", Value: pull.NextCursor != nil},
+		))
 		if pull.NextCursor == nil {
 			break
 		}
 		cursor = cloneCursor(pull.NextCursor)
 	}
+	status = "completed"
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "pages_read", Value: pagesRead})
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "events_appended", Value: eventsAppended})
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "entities_projected", Value: entitiesProjected})
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "links_projected", Value: linksProjected})
+	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "has_next_cursor", Value: runtime.GetNextCursor() != nil})
 	return &cerebrov1.SyncSourceRuntimeResponse{
 		Runtime:           redactRuntime(runtime),
 		Source:            source.Spec(),
@@ -268,9 +314,10 @@ func normalizePageLimit(pageLimit uint32) (uint32, error) {
 
 func normalizeListFilter(filter ports.SourceRuntimeFilter) (ports.SourceRuntimeFilter, error) {
 	normalized := ports.SourceRuntimeFilter{
-		TenantID: strings.TrimSpace(filter.TenantID),
-		SourceID: strings.TrimSpace(filter.SourceID),
-		Limit:    filter.Limit,
+		RuntimeID: strings.TrimSpace(filter.RuntimeID),
+		TenantID:  strings.TrimSpace(filter.TenantID),
+		SourceID:  strings.TrimSpace(filter.SourceID),
+		Limit:     filter.Limit,
 	}
 	if normalized.Limit == 0 {
 		normalized.Limit = defaultListLimit

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -143,7 +143,7 @@ func (s *Service) List(ctx context.Context, filter ports.SourceRuntimeFilter) ([
 }
 
 // Sync advances one stored source runtime and appends emitted events.
-func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequest) (*cerebrov1.SyncSourceRuntimeResponse, error) {
+func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequest) (response *cerebrov1.SyncSourceRuntimeResponse, err error) {
 	runtimeID := ""
 	if req != nil {
 		runtimeID = strings.TrimSpace(req.GetId())
@@ -155,6 +155,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	status := "failed"
 	spanAttributes := telemetry.Attrs()
 	defer func() {
+		if err != nil {
+			status = "failed"
+			spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "error", Value: err.Error()})
+		}
 		telemetry.End(span, status, spanAttributes)
 	}()
 	if s == nil || s.store == nil || s.appendLog == nil {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -212,6 +212,9 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		pagesRead++
 		for _, event := range pull.Events {
 			syncedEvent := materializeEvent(runtime, event)
+			if syncedEvent == nil {
+				continue
+			}
 			if syncedEvent.Attributes == nil {
 				syncedEvent.Attributes = make(map[string]string)
 			}

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -63,6 +63,9 @@ func (s *runtimeStore) ListSourceRuntimes(_ context.Context, filter ports.Source
 	var runtimes []*cerebrov1.SourceRuntime
 	for _, id := range ids {
 		runtime := s.runtimes[id]
+		if filter.RuntimeID != "" && runtime.GetId() != filter.RuntimeID {
+			continue
+		}
 		if filter.TenantID != "" && runtime.GetTenantId() != filter.TenantID {
 			continue
 		}
@@ -400,6 +403,14 @@ func TestListRedactsSensitiveConfigAndFilters(t *testing.T) {
 	if got := runtimes[0].GetConfig()["group_key"]; got != "eng" {
 		t.Fatalf("listed group_key = %q, want eng", got)
 	}
+
+	runtimes, err = service.List(context.Background(), ports.SourceRuntimeFilter{RuntimeID: "other-token"})
+	if err != nil {
+		t.Fatalf("List(runtime_id) error = %v", err)
+	}
+	if len(runtimes) != 1 || runtimes[0].GetId() != "other-token" {
+		t.Fatalf("List(runtime_id) returned %#v, want other-token", runtimes)
+	}
 }
 
 func TestSensitiveConfigKeyCatchesCommonCamelCaseSecrets(t *testing.T) {
@@ -663,6 +674,12 @@ func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 	}
 	if got := log.events[0].GetAttributes()[ports.EventAttributeSourceRuntimeID]; got != "writer-github" {
 		t.Fatalf("appended event source_runtime_id = %q, want %q", got, "writer-github")
+	}
+	if got := log.events[0].GetAttributes()["trace_id"]; got == "" {
+		t.Fatal("appended event trace_id is empty")
+	}
+	if got := log.events[0].GetAttributes()["span_id"]; got == "" {
+		t.Fatal("appended event span_id is empty")
 	}
 	runtime := store.runtimes["writer-github"]
 	if runtime.GetCheckpoint().GetCursorOpaque() != "2" {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -140,6 +140,32 @@ func (emptyPageSource) Read(_ context.Context, _ sourcecdk.Config, cursor *cereb
 	}, nil
 }
 
+type nilEventSource struct{}
+
+func (nilEventSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "nil_event"}
+}
+
+func (nilEventSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (nilEventSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (nilEventSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{Events: []*cerebrov1.EventEnvelope{
+		nil,
+		{
+			Id:       "event-after-nil",
+			TenantId: "writer",
+			SourceId: "nil_event",
+			Kind:     "nil_event.event",
+		},
+	}}, nil
+}
+
 type failingSource struct {
 	err error
 }
@@ -734,6 +760,41 @@ func TestSyncRuntimeContinuesPastEmptyPagesWithCursor(t *testing.T) {
 	}
 	if got := store.runtimes["writer-empty-page"].GetNextCursor(); got != nil {
 		t.Fatalf("stored next cursor = %#v, want nil", got)
+	}
+}
+
+func TestSyncRuntimeSkipsNilEvents(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(nilEventSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-nil-event": {
+				Id:       "writer-nil-event",
+				SourceId: "nil_event",
+				TenantId: "writer",
+			},
+		},
+	}
+	log := &appendLog{}
+	service := New(registry, store, log, nil)
+
+	resp, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-nil-event"})
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if resp.GetEventsAppended() != 1 {
+		t.Fatalf("Sync().EventsAppended = %d, want 1", resp.GetEventsAppended())
+	}
+	if len(log.events) != 1 {
+		t.Fatalf("len(appendLog.events) = %d, want 1", len(log.events))
+	}
+	if got := log.events[0].GetId(); got != "event-after-nil" {
+		t.Fatalf("appended event id = %q, want event-after-nil", got)
+	}
+	if got := log.events[0].GetAttributes()[ports.EventAttributeSourceRuntimeID]; got != "writer-nil-event" {
+		t.Fatalf("appended event source_runtime_id = %q, want writer-nil-event", got)
 	}
 }
 

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -89,6 +89,10 @@ func (s *Store) ListSourceRuntimes(ctx context.Context, filter ports.SourceRunti
 	}
 	clauses := []string{"1=1"}
 	args := []any{}
+	if runtimeID := strings.TrimSpace(filter.RuntimeID); runtimeID != "" {
+		args = append(args, runtimeID)
+		clauses = append(clauses, fmt.Sprintf("id = $%d", len(args)))
+	}
 	if tenantID := strings.TrimSpace(filter.TenantID); tenantID != "" {
 		args = append(args, tenantID)
 		clauses = append(clauses, fmt.Sprintf("runtime_json->>'tenant_id' = $%d", len(args)))

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -134,7 +134,7 @@ func emit(kind string, span *Span, attributes Attributes) {
 		return
 	}
 	encoded = append(encoded, '\n')
-	if _, err := os.Stdout.Write(encoded); err != nil {
+	if _, err := os.Stderr.Write(encoded); err != nil {
 		log.Printf("telemetry write: %v", err)
 	}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"log"
+	"os"
 	"time"
 )
 
@@ -132,7 +133,10 @@ func emit(kind string, span *Span, attributes Attributes) {
 		log.Printf("telemetry encode: %v", err)
 		return
 	}
-	log.Print(string(encoded))
+	encoded = append(encoded, '\n')
+	if _, err := os.Stdout.Write(encoded); err != nil {
+		log.Printf("telemetry write: %v", err)
+	}
 }
 
 func randomHex(bytes int) string {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,144 @@
+package telemetry
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"log"
+	"time"
+)
+
+type spanContextKey struct{}
+
+type spanContext struct {
+	TraceID string
+	SpanID  string
+}
+
+type Span struct {
+	name     string
+	traceID  string
+	spanID   string
+	parentID string
+	started  time.Time
+}
+
+type Attributes struct {
+	values map[string]any
+}
+
+type Field struct {
+	Key   string
+	Value any
+}
+
+func Attrs(fields ...Field) Attributes {
+	attributes := Attributes{values: map[string]any{}}
+	for _, field := range fields {
+		if field.Key == "" {
+			continue
+		}
+		attributes.values[field.Key] = field.Value
+	}
+	return attributes
+}
+
+func (a Attributes) WithField(field Field) Attributes {
+	return a.with(field.Key, field.Value)
+}
+
+func (a Attributes) with(key string, value any) Attributes {
+	if a.values == nil {
+		a.values = map[string]any{}
+	}
+	if key != "" {
+		a.values[key] = value
+	}
+	return a
+}
+
+func Start(ctx context.Context, name string, attributes Attributes) (context.Context, *Span) {
+	parent, _ := ctx.Value(spanContextKey{}).(spanContext)
+	traceID := parent.TraceID
+	if traceID == "" {
+		traceID = randomHex(16)
+	}
+	span := &Span{
+		name:     name,
+		traceID:  traceID,
+		spanID:   randomHex(8),
+		parentID: parent.SpanID,
+		started:  time.Now().UTC(),
+	}
+	next := context.WithValue(ctx, spanContextKey{}, spanContext{TraceID: span.traceID, SpanID: span.spanID})
+	emit("span_start", span, attributes)
+	return next, span
+}
+
+func Event(ctx context.Context, name string, attributes Attributes) {
+	current, _ := ctx.Value(spanContextKey{}).(spanContext)
+	emit("event", &Span{name: name, traceID: current.TraceID, spanID: current.SpanID}, attributes)
+}
+
+func End(span *Span, status string, attributes Attributes) {
+	if span == nil {
+		return
+	}
+	if status != "" {
+		attributes = attributes.with("status", status)
+	}
+	attributes = attributes.with("duration_ms", time.Since(span.started).Milliseconds())
+	emit("span_end", span, attributes)
+}
+
+func InjectEventAttributes(ctx context.Context, attributes map[string]string) {
+	if attributes == nil {
+		return
+	}
+	current, _ := ctx.Value(spanContextKey{}).(spanContext)
+	if current.TraceID != "" {
+		attributes["trace_id"] = current.TraceID
+	}
+	if current.SpanID != "" {
+		attributes["span_id"] = current.SpanID
+	}
+}
+
+func emit(kind string, span *Span, attributes Attributes) {
+	payload := map[string]any{
+		"kind": kind,
+		"ts":   time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if span != nil {
+		if span.name != "" {
+			payload["name"] = span.name
+		}
+		if span.traceID != "" {
+			payload["trace_id"] = span.traceID
+		}
+		if span.spanID != "" {
+			payload["span_id"] = span.spanID
+		}
+		if span.parentID != "" {
+			payload["parent_span_id"] = span.parentID
+		}
+	}
+	for key, value := range attributes.values {
+		payload[key] = value
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("telemetry encode: %v", err)
+		return
+	}
+	log.Print(string(encoded))
+}
+
+func randomHex(bytes int) string {
+	buf := make([]byte, bytes)
+	if _, err := rand.Read(buf); err != nil {
+		return hex.EncodeToString([]byte(time.Now().UTC().Format(time.RFC3339Nano)))
+	}
+	return hex.EncodeToString(buf)
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -9,11 +9,14 @@ import (
 	"testing"
 )
 
-func TestEventEmitsParseableJSONLine(t *testing.T) {
-	output := captureStdout(t, func() {
+func TestEventEmitsParseableJSONLineOnStderr(t *testing.T) {
+	stdout, stderr := captureOutput(t, func() {
 		Event(context.Background(), "test.event", Attrs(Field{Key: "value", Value: 42}))
 	})
-	line := strings.TrimSpace(output)
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	line := strings.TrimSpace(stderr)
 	if !strings.HasPrefix(line, "{") {
 		t.Fatalf("telemetry line = %q, want JSON object without log prefix", line)
 	}
@@ -29,25 +32,39 @@ func TestEventEmitsParseableJSONLine(t *testing.T) {
 	}
 }
 
-func captureStdout(t *testing.T, fn func()) string {
+func captureOutput(t *testing.T, fn func()) (string, string) {
 	t.Helper()
 	oldStdout := os.Stdout
-	reader, writer, err := os.Pipe()
+	oldStderr := os.Stderr
+	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
+		t.Fatalf("os.Pipe stdout: %v", err)
 	}
-	os.Stdout = writer
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stderr: %v", err)
+	}
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
 	defer func() {
 		os.Stdout = oldStdout
+		os.Stderr = oldStderr
 	}()
 
 	fn()
-	if err := writer.Close(); err != nil {
-		t.Fatalf("close writer: %v", err)
+	if err := stdoutWriter.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
 	}
-	output, err := io.ReadAll(reader)
+	if err := stderrWriter.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	stdout, err := io.ReadAll(stdoutReader)
 	if err != nil {
 		t.Fatalf("read stdout: %v", err)
 	}
-	return string(output)
+	stderr, err := io.ReadAll(stderrReader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	return string(stdout), string(stderr)
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,53 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestEventEmitsParseableJSONLine(t *testing.T) {
+	output := captureStdout(t, func() {
+		Event(context.Background(), "test.event", Attrs(Field{Key: "value", Value: 42}))
+	})
+	line := strings.TrimSpace(output)
+	if !strings.HasPrefix(line, "{") {
+		t.Fatalf("telemetry line = %q, want JSON object without log prefix", line)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(line), &payload); err != nil {
+		t.Fatalf("telemetry line is not JSON: %v", err)
+	}
+	if got := payload["kind"]; got != "event" {
+		t.Fatalf("kind = %v, want event", got)
+	}
+	if got := payload["name"]; got != "test.event" {
+		t.Fatalf("name = %v, want test.event", got)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return string(output)
+}


### PR DESCRIPTION
## Summary
- add runtime_id filtering for source-runtime listing and orchestrator runs
- emit structured JSON telemetry spans/events for orchestrator iterations, per-runtime work, sync pages, and commits
- propagate trace_id/span_id onto emitted source events and include runtime result counters

## Validation
- go test ./cmd/cerebro ./internal/sourceruntime ./internal/statestore/postgres ./internal/bootstrap ./internal/telemetry -count=1
- make verify