### PR TITLE
fix: improve finding efficacy and graph pruning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,54 @@
+name: Cut Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to create from main, e.g. v2.1.1'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cut-release-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  cut-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Create release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "ERROR: release_tag '${RELEASE_TAG}' must match vMAJOR.MINOR.PATCH[-PRERELEASE]"
+            exit 1
+          fi
+
+          git fetch origin main --tags
+          git checkout --detach origin/main
+          make verify
+
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null; then
+            echo "ERROR: tag '${RELEASE_TAG}' already exists"
+            exit 1
+          fi
+
+          git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
+          git push origin "refs/tags/${RELEASE_TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ permissions:
   packages: write
   id-token: write
 
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   resolve-tag:
     runs-on: ubuntu-latest
@@ -31,8 +35,8 @@ jobs:
           else
             tag="${{ inputs.release_tag }}"
           fi
-          if [[ ! "${tag}" =~ ^v ]]; then
-            echo "ERROR: tag '${tag}' must start with 'v'"
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "ERROR: tag '${tag}' must match vMAJOR.MINOR.PATCH[-PRERELEASE]"
             exit 1
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
@@ -52,8 +56,10 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run tests
-        run: go test ./...
+      - name: Run verify
+        run: |
+          make lint-bootstrap
+          make verify
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
@@ -98,8 +104,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .dist
+          VERSION="${RELEASE_TAG#v}"
+          COMMIT="$(git rev-parse HEAD)"
+          BUILD_DATE="$(date -u +%FT%TZ)"
+          LDFLAGS="-s -w -X github.com/writer/cerebro/internal/buildinfo.Version=${VERSION} -X github.com/writer/cerebro/internal/buildinfo.Commit=${COMMIT} -X github.com/writer/cerebro/internal/buildinfo.BuildDate=${BUILD_DATE}"
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-            go build -buildvcs=false -trimpath -ldflags="-s -w" -o .dist/cerebro ./cmd/cerebro
+            go build -buildvcs=false -trimpath -ldflags="${LDFLAGS}" -o .dist/cerebro ./cmd/cerebro
           docker buildx build --platform linux/amd64 \
             -f Dockerfile.runtime \
             -t "${IMAGE_BASE}:${RELEASE_TAG}-amd64" \
@@ -113,8 +123,12 @@ jobs:
           IMAGE_BASE: ghcr.io/${{ github.repository }}
         run: |
           set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          COMMIT="$(git rev-parse HEAD)"
+          BUILD_DATE="$(date -u +%FT%TZ)"
+          LDFLAGS="-s -w -X github.com/writer/cerebro/internal/buildinfo.Version=${VERSION} -X github.com/writer/cerebro/internal/buildinfo.Commit=${COMMIT} -X github.com/writer/cerebro/internal/buildinfo.BuildDate=${BUILD_DATE}"
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
-            go build -buildvcs=false -trimpath -ldflags="-s -w" -o .dist/cerebro ./cmd/cerebro
+            go build -buildvcs=false -trimpath -ldflags="${LDFLAGS}" -o .dist/cerebro ./cmd/cerebro
           docker buildx build --platform linux/arm64 \
             -f Dockerfile.runtime \
             -t "${IMAGE_BASE}:${RELEASE_TAG}-arm64" \

--- a/internal/findings/cloud_signal_rule.go
+++ b/internal/findings/cloud_signal_rule.go
@@ -224,11 +224,28 @@ func cloudFindingSummary(attributes map[string]string, context findingProjection
 }
 
 func matchesCloudPublicExposure(_ *cerebrov1.EventEnvelope, attributes map[string]string) bool {
-	return findingAttributeBool(attributes, "internet_exposed", "external_exposure", "public") || strings.Contains(identityAction(attributes), "public_network_ingress")
+	if findingAttributeBool(attributes, "internet_exposed", "external_exposure") {
+		return true
+	}
+	if containsAny(strings.ToLower(firstNonEmpty(attributes["exposure_type"], attributes["relationship"], attributes["event_type"])), "public_network_ingress", "public_ip", "internet_facing") {
+		return true
+	}
+	if containsAny(strings.ToLower(firstNonEmpty(attributes["exposed_to"], attributes["principal"], attributes["member"], attributes["source"])), "public_internet", "allusers", "all_users", "allauthenticatedusers", "all_authenticated_users", "internet") {
+		return true
+	}
+	return cloudCIDRIsPublicInternet(attributes["source_cidr"]) || cloudCIDRIsPublicInternet(attributes["cidr"])
 }
 
 func matchesCloudPrivilegePath(_ *cerebrov1.EventEnvelope, attributes map[string]string) bool {
-	return strings.TrimSpace(attributes["path_type"]) != "" || strings.TrimSpace(attributes["relationship"]) != "" || strings.TrimSpace(attributes["target_id"]) != ""
+	pathType := strings.ToLower(strings.TrimSpace(attributes["path_type"]))
+	relationship := strings.ToLower(strings.TrimSpace(attributes["relationship"]))
+	if containsAny(pathType, "assume_role", "impersonation", "workload_identity", "app_role", "federated_identity") {
+		return true
+	}
+	return relationship == "can_assume" ||
+		relationship == "can_impersonate" ||
+		relationship == "can_admin" ||
+		relationship == "assigned_to"
 }
 
 func matchesCloudEffectiveAdminPermission(_ *cerebrov1.EventEnvelope, attributes map[string]string) bool {
@@ -239,17 +256,45 @@ func matchesCloudEffectiveAdminPermission(_ *cerebrov1.EventEnvelope, attributes
 		return true
 	}
 	value := strings.ToLower(firstNonEmpty(attributes["permission"], attributes["actions"], attributes["role_name"], attributes["role_id"], attributes["privilege_level"]))
-	return containsAny(value,
-		"*",
+	return cloudPermissionGrantsAdmin(value)
+}
+
+func cloudCIDRIsPublicInternet(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	return normalized == "0.0.0.0/0" || normalized == "::/0" || normalized == "internet"
+}
+
+func cloudPermissionGrantsAdmin(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		return false
+	}
+	if normalized == "*" || normalized == "*:*" || normalized == "*/*" {
+		return true
+	}
+	if containsAny(normalized,
 		"administratoraccess",
 		"owner",
 		"contributor",
-		"iam.serviceaccounts.actas",
-		"iam.serviceaccounts.getaccesstoken",
 		"iam.serviceaccounttokencreator",
 		"microsoft.authorization/roleassignments/write",
-		"secretsmanager",
-		"keyvault",
-		"kms",
-	)
+	) {
+		return true
+	}
+	for _, token := range strings.FieldsFunc(normalized, cloudPermissionTokenSeparator) {
+		switch token {
+		case "*", "*:*", "*/*", "iam.serviceaccounts.actas", "iam.serviceaccounts.getaccesstoken", "secretsmanager:*", "kms:*", "keyvault:*", "keyvault/*":
+			return true
+		}
+	}
+	return false
+}
+
+func cloudPermissionTokenSeparator(r rune) bool {
+	switch r {
+	case ',', ';', '\n', '\t', ' ':
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/findings/cloud_signal_rule_test.go
+++ b/internal/findings/cloud_signal_rule_test.go
@@ -158,6 +158,49 @@ func TestCloudSignalRulesDetectPrivilegePaths(t *testing.T) {
 	}
 }
 
+func TestCloudSignalRulesIgnoreLowContextCloudSignals(t *testing.T) {
+	rules := cloudRulesByID(t)
+	runtime := &cerebrov1.SourceRuntime{Id: "aws-runtime", SourceId: "aws", TenantId: "writer"}
+
+	publicTagOnly := &cerebrov1.EventEnvelope{
+		Id:       "aws-public-tag-only",
+		TenantId: "writer",
+		SourceId: "aws",
+		Kind:     "aws.resource_exposure",
+		Attributes: map[string]string{
+			"family":        "resource_exposure",
+			"public":        "true",
+			"resource_id":   "arn:aws:s3:::docs",
+			"resource_type": "bucket",
+		},
+	}
+	records, err := rules[cloudPublicResourceExposureRuleID].Evaluate(context.Background(), runtime, publicTagOnly)
+	if err != nil {
+		t.Fatalf("Evaluate(publicTagOnly) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(publicTagOnly records) = %d, want 0", len(records))
+	}
+
+	targetOnly := &cerebrov1.EventEnvelope{
+		Id:       "aws-target-only",
+		TenantId: "writer",
+		SourceId: "aws",
+		Kind:     "aws.iam_role_trust",
+		Attributes: map[string]string{
+			"family":    "iam_role_trust",
+			"target_id": "arn:aws:iam::123456789012:role/ReadOnlyRole",
+		},
+	}
+	records, err = rules[cloudPrivilegePathGrantedRuleID].Evaluate(context.Background(), runtime, targetOnly)
+	if err != nil {
+		t.Fatalf("Evaluate(targetOnly) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(targetOnly records) = %d, want 0", len(records))
+	}
+}
+
 func TestCloudSignalRulesDetectEffectiveAdminPermissions(t *testing.T) {
 	rules := cloudRulesByID(t)
 	runtime := &cerebrov1.SourceRuntime{Id: "aws-runtime", SourceId: "aws", TenantId: "writer"}
@@ -207,6 +250,29 @@ func TestCloudSignalRulesDetectEffectiveAdminPermissions(t *testing.T) {
 	}
 	if len(records) != 0 {
 		t.Fatalf("len(viewer records) = %d, want 0", len(records))
+	}
+
+	wildcardRead := &cerebrov1.EventEnvelope{
+		Id:       "aws-effective-wildcard-read",
+		TenantId: "writer",
+		SourceId: "aws",
+		Kind:     "aws.effective_permission",
+		Attributes: map[string]string{
+			"actions":       "s3:GetObject*",
+			"domain":        "123456789012",
+			"effect":        "allow",
+			"resource_id":   "arn:aws:s3:::reports",
+			"resource_type": "bucket",
+			"subject_id":    "reader@writer.com",
+			"subject_type":  "user",
+		},
+	}
+	records, err = rules[cloudEffectiveAdminPermissionRuleID].Evaluate(context.Background(), runtime, wildcardRead)
+	if err != nil {
+		t.Fatalf("Evaluate(wildcardRead) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(wildcardRead records) = %d, want 0", len(records))
 	}
 }
 

--- a/internal/findings/data_signal_rule.go
+++ b/internal/findings/data_signal_rule.go
@@ -77,9 +77,28 @@ func buildDataSensitiveAssetFinding(ctx context.Context, runtime *cerebrov1.Sour
 }
 
 func matchesDataSensitiveAssetRisk(attributes map[string]string) bool {
-	sensitive := findingAttributeBool(attributes, "crown_jewel", "contains_secrets", "contains_pii", "contains_phi") || containsAny(strings.ToLower(firstNonEmpty(attributes["data_classification"], attributes["data_sensitivity"], attributes["sensitivity"])), "secret", "sensitive", "confidential", "restricted")
+	sensitive := findingAttributeBool(attributes, "crown_jewel", "contains_secrets", "contains_pii", "contains_phi") || dataClassificationSensitive(firstNonEmpty(attributes["data_classification"], attributes["data_sensitivity"], attributes["sensitivity"]))
 	if !sensitive {
 		return false
 	}
 	return findingAttributeBool(attributes, "public", "internet_exposed", "external_exposure", "privileged_access", "is_admin")
+}
+
+func dataClassificationSensitive(value string) bool {
+	tokens := strings.FieldsFunc(strings.ToLower(strings.TrimSpace(value)), dataClassificationSeparator)
+	switch strings.Join(tokens, "_") {
+	case "", "public", "unrestricted", "not_sensitive", "non_sensitive", "no_sensitive_data":
+		return false
+	}
+	for _, token := range tokens {
+		switch token {
+		case "secret", "secrets", "sensitive", "confidential", "restricted":
+			return true
+		}
+	}
+	return false
+}
+
+func dataClassificationSeparator(r rune) bool {
+	return (r < 'a' || r > 'z') && (r < '0' || r > '9')
 }

--- a/internal/findings/data_signal_rule_test.go
+++ b/internal/findings/data_signal_rule_test.go
@@ -43,4 +43,22 @@ func TestDataSensitiveAssetRiskRule(t *testing.T) {
 	if len(records) != 0 {
 		t.Fatalf("len(internal records) = %d, want 0", len(records))
 	}
+
+	unrestricted := &cerebrov1.EventEnvelope{Id: "asset-unrestricted", TenantId: "writer", SourceId: "asset", Kind: "asset.data_sensitivity", Attributes: map[string]string{"data_classification": "unrestricted", "internet_exposed": "true", "resource_id": "public-docs", "resource_type": "bucket", "source_provider": "aws"}}
+	records, err = rule.Evaluate(context.Background(), runtime, unrestricted)
+	if err != nil {
+		t.Fatalf("Evaluate(unrestricted) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(unrestricted records) = %d, want 0", len(records))
+	}
+
+	notSensitive := &cerebrov1.EventEnvelope{Id: "asset-not-sensitive", TenantId: "writer", SourceId: "asset", Kind: "asset.data_sensitivity", Attributes: map[string]string{"data_classification": "not_sensitive", "public": "true", "resource_id": "public-docs", "resource_type": "bucket", "source_provider": "aws"}}
+	records, err = rule.Evaluate(context.Background(), runtime, notSensitive)
+	if err != nil {
+		t.Fatalf("Evaluate(notSensitive) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(notSensitive records) = %d, want 0", len(records))
+	}
 }

--- a/internal/findings/github_audit_signal_rule.go
+++ b/internal/findings/github_audit_signal_rule.go
@@ -537,6 +537,14 @@ var githubOrgAuthControlModifiedConfig = githubAuditSignalConfig{
 		"org.saml_enabled",
 		"org.update_saml_provider_settings",
 	),
+	predicate: githubOrgAuthControlWeakening,
+	severity: func(attributes map[string]string) string {
+		action := strings.TrimSpace(attributes["action"])
+		if action == "org.update_saml_provider_settings" {
+			return "HIGH"
+		}
+		return "CRITICAL"
+	},
 	summary: func(attributes map[string]string) string {
 		return fmt.Sprintf("%s modified GitHub organization authentication control %s for %s", githubAuditActor(attributes), strings.TrimSpace(attributes["action"]), githubAuditTarget(attributes))
 	},
@@ -553,6 +561,7 @@ var githubOrgIPAllowListModifiedConfig = githubAuditSignalConfig{
 		"ip_allow_list_entry.destroy",
 		"ip_allow_list_entry.update",
 	),
+	predicate: githubIPAllowListWeakeningOrExpansion,
 	severity: func(attributes map[string]string) string {
 		if strings.Contains(strings.TrimSpace(attributes["action"]), "disable") || strings.Contains(strings.TrimSpace(attributes["action"]), "destroy") {
 			return "HIGH"
@@ -601,6 +610,7 @@ var githubProtectedBranchPolicyOverrideConfig = githubAuditSignalConfig{
 var githubRepositoryRulesetModifiedConfig = githubAuditSignalConfig{
 	definition: githubRepositoryRulesetModifiedDefinition,
 	actions:    githubAuditActionSet("repository_ruleset.destroy", "repository_ruleset.update"),
+	predicate:  githubRepositoryRulesetWeakening,
 	summary: func(attributes map[string]string) string {
 		return fmt.Sprintf("%s modified GitHub repository ruleset %s for %s", githubAuditActor(attributes), firstNonEmpty(attributes["ruleset_name"], attributes["ruleset_id"], "unknown ruleset"), githubAuditTarget(attributes))
 	},
@@ -608,7 +618,13 @@ var githubRepositoryRulesetModifiedConfig = githubAuditSignalConfig{
 
 var githubCriticalResourceDeletedConfig = githubAuditSignalConfig{
 	definition: githubCriticalResourceDeletedDefinition,
-	actions:    githubAuditActionSet("codespaces.delete", "environment.delete", "project.delete", "repo.destroy"),
+	actions:    githubAuditActionSet("environment.delete", "repo.destroy"),
+	severity: func(attributes map[string]string) string {
+		if strings.TrimSpace(attributes["action"]) == "environment.delete" {
+			return "MEDIUM"
+		}
+		return "HIGH"
+	},
 	summary: func(attributes map[string]string) string {
 		return fmt.Sprintf("%s deleted GitHub resource %s for %s", githubAuditActor(attributes), strings.TrimSpace(attributes["action"]), githubAuditTarget(attributes))
 	},
@@ -865,6 +881,41 @@ func githubAuditActionSet(actions ...string) map[string]struct{} {
 		}
 	}
 	return set
+}
+
+func githubOrgAuthControlWeakening(attributes map[string]string) bool {
+	switch strings.TrimSpace(attributes["action"]) {
+	case "org.disable_oauth_app_restrictions", "org.disable_two_factor_requirement", "org.saml_disabled", "org.update_saml_provider_settings":
+		return true
+	default:
+		return false
+	}
+}
+
+func githubIPAllowListWeakeningOrExpansion(attributes map[string]string) bool {
+	action := strings.TrimSpace(attributes["action"])
+	return strings.Contains(action, "disable") ||
+		strings.Contains(action, "destroy") ||
+		strings.Contains(action, "update") ||
+		action == "ip_allow_list_entry.create"
+}
+
+func githubRepositoryRulesetWeakening(attributes map[string]string) bool {
+	action := strings.TrimSpace(attributes["action"])
+	if action == "repository_ruleset.destroy" {
+		return true
+	}
+	if action != "repository_ruleset.update" {
+		return false
+	}
+	if containsAny(strings.ToLower(firstNonEmpty(attributes["operation_type"], attributes["change_type"], attributes["changes"])), "disable", "remove", "delete", "downgrade", "bypass") {
+		return true
+	}
+	enforcement := strings.ToLower(firstNonEmpty(attributes["new_enforcement"], attributes["enforcement"], attributes["ruleset_enforcement"]))
+	if enforcement == "disabled" || enforcement == "evaluate" {
+		return true
+	}
+	return findingAttributeBool(attributes, "bypass_actor_added", "required_review_removed", "required_status_check_removed", "force_pushes_allowed", "deletions_allowed")
 }
 
 func keysOfStringMap(values map[string]string) []string {

--- a/internal/findings/github_audit_signal_rule_test.go
+++ b/internal/findings/github_audit_signal_rule_test.go
@@ -1,0 +1,161 @@
+package findings
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestGitHubOrgAuthControlModifiedIgnoresHardening(t *testing.T) {
+	rule := newGitHubOrgAuthControlModifiedRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "github-runtime", SourceId: "github", TenantId: "writer"}
+	event := githubAuditEvent("github-auth-enable", map[string]string{
+		"action": "org.enable_two_factor_requirement",
+		"org":    "writer",
+	})
+	records, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(enable) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(enable records) = %d, want 0", len(records))
+	}
+
+	event = githubAuditEvent("github-auth-disable", map[string]string{
+		"action": "org.disable_two_factor_requirement",
+		"org":    "writer",
+	})
+	records, err = rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(disable) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(disable records) = %d, want 1", len(records))
+	}
+	if got := records[0].Severity; got != "CRITICAL" {
+		t.Fatalf("Severity = %q, want CRITICAL", got)
+	}
+}
+
+func TestGitHubRepositoryRulesetModifiedRequiresWeakeningSignal(t *testing.T) {
+	rule := newGitHubRepositoryRulesetModifiedRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "github-runtime", SourceId: "github", TenantId: "writer"}
+	event := githubAuditEvent("github-ruleset-active", map[string]string{
+		"action":      "repository_ruleset.update",
+		"enforcement": "active",
+		"repo":        "writer/cerebro",
+	})
+	records, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(active update) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(active update records) = %d, want 0", len(records))
+	}
+
+	event = githubAuditEvent("github-ruleset-disabled", map[string]string{
+		"action":      "repository_ruleset.update",
+		"enforcement": "disabled",
+		"repo":        "writer/cerebro",
+	})
+	records, err = rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(disabled update) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(disabled update records) = %d, want 1", len(records))
+	}
+}
+
+func TestGitHubIPAllowListModifiedIgnoresEnableOnly(t *testing.T) {
+	rule := newGitHubOrgIPAllowListModifiedRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "github-runtime", SourceId: "github", TenantId: "writer"}
+	event := githubAuditEvent("github-ip-enable", map[string]string{
+		"action": "ip_allow_list.enable",
+		"org":    "writer",
+	})
+	records, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(enable) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(enable records) = %d, want 0", len(records))
+	}
+
+	event = githubAuditEvent("github-ip-disable", map[string]string{
+		"action": "ip_allow_list.disable",
+		"org":    "writer",
+	})
+	records, err = rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(disable) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(disable records) = %d, want 1", len(records))
+	}
+	if got := records[0].Severity; got != "HIGH" {
+		t.Fatalf("Severity = %q, want HIGH", got)
+	}
+}
+
+func TestGitHubCriticalResourceDeletedSuppressesLowValueDeletes(t *testing.T) {
+	rule := newGitHubCriticalResourceDeletedRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "github-runtime", SourceId: "github", TenantId: "writer"}
+	for _, action := range []string{"codespaces.delete", "project.delete"} {
+		event := githubAuditEvent("github-"+action, map[string]string{
+			"action": action,
+			"repo":   "writer/cerebro",
+		})
+		records, err := rule.Evaluate(context.Background(), runtime, event)
+		if err != nil {
+			t.Fatalf("Evaluate(%s) error = %v", action, err)
+		}
+		if len(records) != 0 {
+			t.Fatalf("len(%s records) = %d, want 0", action, len(records))
+		}
+	}
+
+	event := githubAuditEvent("github-repo-destroy", map[string]string{
+		"action": "repo.destroy",
+		"repo":   "writer/cerebro",
+	})
+	records, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(repo.destroy) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(repo.destroy records) = %d, want 1", len(records))
+	}
+	if got := records[0].Severity; got != "HIGH" {
+		t.Fatalf("repo.destroy Severity = %q, want HIGH", got)
+	}
+
+	event = githubAuditEvent("github-environment-delete", map[string]string{
+		"action": "environment.delete",
+		"repo":   "writer/cerebro",
+	})
+	records, err = rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(environment.delete) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(environment.delete records) = %d, want 1", len(records))
+	}
+	if got := records[0].Severity; got != "MEDIUM" {
+		t.Fatalf("environment.delete Severity = %q, want MEDIUM", got)
+	}
+}
+
+func githubAuditEvent(id string, attributes map[string]string) *cerebrov1.EventEnvelope {
+	if attributes["actor"] == "" {
+		attributes["actor"] = "admin"
+	}
+	return &cerebrov1.EventEnvelope{
+		Id:         id,
+		TenantId:   "writer",
+		SourceId:   "github",
+		Kind:       "github.audit",
+		Attributes: attributes,
+	}
+}

--- a/internal/findings/github_dependabot_alert_rule.go
+++ b/internal/findings/github_dependabot_alert_rule.go
@@ -144,9 +144,18 @@ func githubDependabotAlertSummary(attributes map[string]string, primaryResourceL
 }
 
 func normalizeFindingSeverity(value string) string {
-	severity := strings.ToUpper(strings.TrimSpace(value))
-	if severity == "" {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "critical":
+		return "CRITICAL"
+	case "high":
+		return "HIGH"
+	case "medium", "moderate":
+		return "MEDIUM"
+	case "low":
+		return "LOW"
+	case "info", "informational":
+		return "INFO"
+	default:
 		return "MEDIUM"
 	}
-	return severity
 }

--- a/internal/findings/github_dependabot_alert_rule_test.go
+++ b/internal/findings/github_dependabot_alert_rule_test.go
@@ -1,0 +1,49 @@
+package findings
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestGitHubDependabotAlertSeverityNormalization(t *testing.T) {
+	rule := newGitHubDependabotOpenAlertRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "github-runtime", SourceId: "github", TenantId: "writer"}
+	for _, tt := range []struct {
+		name     string
+		severity string
+		want     string
+	}{
+		{name: "critical", severity: "critical", want: "CRITICAL"},
+		{name: "high", severity: "high", want: "HIGH"},
+		{name: "moderate", severity: "moderate", want: "MEDIUM"},
+		{name: "empty", severity: "", want: "MEDIUM"},
+		{name: "unknown", severity: "urgent", want: "MEDIUM"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &cerebrov1.EventEnvelope{
+				Id:       "dependabot-" + tt.name,
+				TenantId: "writer",
+				SourceId: "github",
+				Kind:     "github.dependabot_alert",
+				Attributes: map[string]string{
+					"alert_number": "7",
+					"repository":   "writer/cerebro",
+					"severity":     tt.severity,
+					"state":        "open",
+				},
+			}
+			records, err := rule.Evaluate(context.Background(), runtime, event)
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			if len(records) != 1 {
+				t.Fatalf("len(records) = %d, want 1", len(records))
+			}
+			if got := records[0].Severity; got != tt.want {
+				t.Fatalf("Severity = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -116,8 +116,13 @@ func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *port
 	if status == findingStatusSuppressed {
 		decisionType = "finding-suppression"
 	}
-	decisionID := workflowevents.CanonicalWorkflowID(tenantID, "decision", findingStatusDecisionID(finding), decisionType, targetURNs, finding.StatusUpdatedAt)
-	outcomeID := workflowevents.CanonicalWorkflowID(tenantID, "outcome", findingStatusOutcomeID(finding), decisionType, append([]string{decisionID}, targetURNs...), finding.StatusUpdatedAt)
+	pruneGraph := workflowevents.FindingStatusPrunesGraph(status, finding.StatusReason)
+	decisionID := ""
+	outcomeID := ""
+	if !pruneGraph {
+		decisionID = workflowevents.CanonicalWorkflowID(tenantID, "decision", findingStatusDecisionID(finding), decisionType, targetURNs, finding.StatusUpdatedAt)
+		outcomeID = workflowevents.CanonicalWorkflowID(tenantID, "outcome", findingStatusOutcomeID(finding), decisionType, append([]string{decisionID}, targetURNs...), finding.StatusUpdatedAt)
+	}
 	statusEvent, err := workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{
 		Finding:     findingWorkflowSnapshot(finding, tenantID, sourceID),
 		Status:      status,
@@ -132,6 +137,9 @@ func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *port
 	}
 	if err := s.recordAndProjectWorkflowEvent(ctx, statusEvent); err != nil {
 		return err
+	}
+	if pruneGraph {
+		return nil
 	}
 	if s.graphQuery == nil {
 		return nil

--- a/internal/findings/identity_signal_rule.go
+++ b/internal/findings/identity_signal_rule.go
@@ -331,6 +331,9 @@ func identityAction(attributes map[string]string) string {
 }
 
 func matchesIdentityAuthControlTampering(_ *cerebrov1.EventEnvelope, attributes map[string]string) bool {
+	if !identityOutcomeSuccessfulOrUnknown(attributes) {
+		return false
+	}
 	action := identityAction(attributes)
 	resourceType := strings.ToLower(firstNonEmpty(attributes["resource_type"], attributes["target_type"]))
 	return containsAny(action, "policy", "rule", "network_zone", "zone", "idp", "two_step", "2sv", "saml", "security_setting", "change_two_step") &&
@@ -344,27 +347,52 @@ func matchesIdentityAdminPrivilegeGranted(event *cerebrov1.EventEnvelope, attrib
 	if builtinIdentityCapabilities.KindHasCapability(event.GetKind(), identityCapabilityRoleAssignment) {
 		return identityPrivileged(attributes)
 	}
+	if !identityOutcomeSuccessfulOrUnknown(attributes) {
+		return false
+	}
 	action := identityAction(attributes)
 	return containsAny(action, "privilege.grant", "role.assignment", "assign_role", "grant_admin", "delegated_admin", "super_admin")
 }
 
 func matchesIdentityMFAFactorResetOrDisabled(_ *cerebrov1.EventEnvelope, attributes map[string]string) bool {
+	if !identityOutcomeSuccessfulOrUnknown(attributes) {
+		return false
+	}
 	action := identityAction(attributes)
 	return containsAny(action, "mfa", "factor", "two_step", "2sv", "verification") &&
 		containsAny(action, "reset", "disable", "deactivate", "unenroll", "change")
 }
 
 func matchesIdentityAPITokenOrOAuthCreated(_ *cerebrov1.EventEnvelope, attributes map[string]string) bool {
+	if !identityOutcomeSuccessfulOrUnknown(attributes) {
+		return false
+	}
 	action := identityAction(attributes)
 	if strings.TrimSpace(attributes["credential_id"]) != "" || strings.TrimSpace(attributes["credential_type"]) != "" {
+		return identityCredentialActiveOrUnknown(attributes)
+	}
+	if routineOAuthRuntimeGrant(action) {
+		return false
+	}
+	if containsAny(action, "api_token", "client_secret", "client.secret", "domain_wide", "domain-wide") {
+		return containsAny(action, "create", "authorize", "grant", "add", "rotate", "generate")
+	}
+	return containsAny(action, "oauth", "api_client", "client_access", "application") &&
+		containsAny(action, "create", "add")
+}
+
+func routineOAuthRuntimeGrant(action string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(action))
+	switch normalized {
+	case "app.oauth2.authorize.code", "app.oauth2.as.authorize.code":
 		return true
 	}
-	return containsAny(action, "api_token", "oauth", "api_client", "domain_wide", "client_access", "application") &&
-		containsAny(action, "create", "authorize", "grant", "add")
+	return strings.HasPrefix(normalized, "app.oauth2.token.grant.") ||
+		strings.HasPrefix(normalized, "app.oauth2.as.token.grant.")
 }
 
 func matchesIdentityPrivilegedWithoutMFA(_ *cerebrov1.EventEnvelope, attributes map[string]string) bool {
-	return identityPrivileged(attributes) && !identityMFAEnabled(attributes)
+	return identityPrivileged(attributes) && identityMFAExplicitlyDisabled(attributes)
 }
 
 func matchesIdentityStalePrivilegedAccount(_ *cerebrov1.EventEnvelope, attributes map[string]string) bool {
@@ -388,6 +416,9 @@ func matchesIdentityExternalGroupMember(_ *cerebrov1.EventEnvelope, attributes m
 }
 
 func matchesIdentityControlTamperOrCredentialChange(event *cerebrov1.EventEnvelope, attributes map[string]string) bool {
+	if !identityOutcomeSuccessfulOrUnknown(attributes) {
+		return false
+	}
 	return matchesIdentityAuthControlTampering(event, attributes) ||
 		matchesIdentityMFAFactorResetOrDisabled(event, attributes) ||
 		matchesIdentityAPITokenOrOAuthCreated(event, attributes) ||
@@ -415,4 +446,38 @@ func identityPrivileged(attributes map[string]string) bool {
 
 func identityMFAEnabled(attributes map[string]string) bool {
 	return findingAttributeBool(attributes, "mfa_enrolled", "mfa_enforced", "is_enrolled_in_2sv", "is_enforced_in_2sv")
+}
+
+func identityMFAExplicitlyDisabled(attributes map[string]string) bool {
+	if identityMFAEnabled(attributes) {
+		return false
+	}
+	for _, key := range []string{"mfa_enrolled", "mfa_enforced", "is_enrolled_in_2sv", "is_enforced_in_2sv"} {
+		value := strings.ToLower(strings.TrimSpace(attributes[key]))
+		switch value {
+		case "0", "f", "false", "no", "n", "disabled", "unenrolled", "not_enrolled", "not enrolled":
+			return true
+		}
+	}
+	return false
+}
+
+func identityCredentialActiveOrUnknown(attributes map[string]string) bool {
+	status := strings.ToLower(firstNonEmpty(attributes["credential_status"], attributes["status"], attributes["state"], attributes["lifecycle_status"]))
+	switch status {
+	case "inactive", "disabled", "deleted", "revoked", "expired", "deactivated", "suspended":
+		return false
+	default:
+		return true
+	}
+}
+
+func identityOutcomeSuccessfulOrUnknown(attributes map[string]string) bool {
+	outcome := strings.ToLower(firstNonEmpty(attributes["outcome_result"], attributes["result"], attributes["outcome"]))
+	switch outcome {
+	case "", "success", "succeeded", "allow", "allowed":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/findings/identity_signal_rule_test.go
+++ b/internal/findings/identity_signal_rule_test.go
@@ -3,6 +3,7 @@ package findings
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -91,6 +92,49 @@ func TestIdentitySignalRulesDetectPrivilegedNoMFAUser(t *testing.T) {
 	}
 	assertFindingResourceURN(t, records[0].ResourceURNs, "urn:cerebro:writer:google_workspace_user:1001")
 	assertFindingResourceURN(t, records[0].ResourceURNs, "urn:cerebro:writer:identifier:email:admin@writer.com")
+
+	unknownMFA := &cerebrov1.EventEnvelope{
+		Id:       "google-user-admin-unknown-mfa",
+		TenantId: "writer",
+		SourceId: "google_workspace",
+		Kind:     "google_workspace.user",
+		Attributes: map[string]string{
+			"domain":        "writer.com",
+			"email":         "admin@writer.com",
+			"is_admin":      "true",
+			"primary_email": "admin@writer.com",
+			"user_id":       "1001",
+		},
+	}
+	records, err = rules[identityPrivilegedAccountWithoutMFARuleID].Evaluate(context.Background(), runtime, unknownMFA)
+	if err != nil {
+		t.Fatalf("Evaluate(unknownMFA) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(unknownMFA records) = %d, want 0", len(records))
+	}
+
+	withMFA := &cerebrov1.EventEnvelope{
+		Id:       "google-user-admin-with-mfa",
+		TenantId: "writer",
+		SourceId: "google_workspace",
+		Kind:     "google_workspace.user",
+		Attributes: map[string]string{
+			"domain":        "writer.com",
+			"email":         "admin@writer.com",
+			"is_admin":      "true",
+			"mfa_enrolled":  "true",
+			"primary_email": "admin@writer.com",
+			"user_id":       "1001",
+		},
+	}
+	records, err = rules[identityPrivilegedAccountWithoutMFARuleID].Evaluate(context.Background(), runtime, withMFA)
+	if err != nil {
+		t.Fatalf("Evaluate(withMFA) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(withMFA records) = %d, want 0", len(records))
+	}
 }
 
 func TestIdentitySignalRulesDetectCloudRoleAssignments(t *testing.T) {
@@ -288,6 +332,141 @@ func TestIdentitySignalRulesDetectCloudCredentials(t *testing.T) {
 				t.Fatalf("len(records) = %d, want 1", len(records))
 			}
 			assertFindingResourceURN(t, records[0].ResourceURNs, tt.resourceURN)
+		})
+	}
+}
+
+func TestIdentitySignalRulesIgnoreInactiveCloudCredentials(t *testing.T) {
+	rules := identityRulesByID(t)
+	runtime := &cerebrov1.SourceRuntime{Id: "aws-runtime", SourceId: "aws", TenantId: "writer"}
+	event := &cerebrov1.EventEnvelope{
+		Id:       "aws-access-key-disabled",
+		TenantId: "writer",
+		SourceId: "aws",
+		Kind:     "aws.access_key",
+		Attributes: map[string]string{
+			"credential_id":   "AKIAEXAMPLE",
+			"credential_type": "aws_access_key",
+			"domain":          "123456789012",
+			"status":          "DISABLED",
+			"subject_id":      "admin@writer.com",
+			"subject_type":    "user",
+		},
+	}
+	records, err := rules[identityAPIOrOAuthCredentialCreatedRuleID].Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(disabled) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(disabled records) = %d, want 0", len(records))
+	}
+
+	event.Attributes["status"] = "ACTIVE"
+	records, err = rules[identityAPIOrOAuthCredentialCreatedRuleID].Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(active) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(active records) = %d, want 1", len(records))
+	}
+}
+
+func TestIdentitySignalRulesTreatRoutineOAuthGrantsAsTelemetry(t *testing.T) {
+	rules := identityRulesByID(t)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"}
+	for _, ruleID := range []string{
+		identityAPIOrOAuthCredentialCreatedRuleID,
+		identityControlTamperCredentialChangeRuleID,
+	} {
+		t.Run(ruleID, func(t *testing.T) {
+			for _, action := range []string{
+				"app.oauth2.authorize.code",
+				"app.oauth2.as.authorize.code",
+				"app.oauth2.token.grant.access_token",
+				"app.oauth2.as.token.grant.id_token",
+			} {
+				event := &cerebrov1.EventEnvelope{
+					Id:       strings.ReplaceAll(action, ".", "-"),
+					TenantId: "writer",
+					SourceId: "okta",
+					Kind:     "okta.audit",
+					Attributes: map[string]string{
+						"domain":               "writer.okta.com",
+						"event_type":           action,
+						"actor_id":             "0oa-client",
+						"actor_type":           "PublicClientApp",
+						"resource_id":          "00u-user",
+						"resource_type":        "User",
+						"outcome_result":       "SUCCESS",
+						"oauth_event_category": "runtime_grant",
+					},
+				}
+				records, err := rules[ruleID].Evaluate(context.Background(), runtime, event)
+				if err != nil {
+					t.Fatalf("Evaluate(%s) error = %v", action, err)
+				}
+				if len(records) != 0 {
+					t.Fatalf("Evaluate(%s) returned %d findings, want telemetry-only", action, len(records))
+				}
+			}
+		})
+	}
+}
+
+func TestIdentitySignalRulesStillDetectOAuthCredentialCreation(t *testing.T) {
+	rules := identityRulesByID(t)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"}
+	event := &cerebrov1.EventEnvelope{
+		Id:       "okta-api-token-create",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.audit",
+		Attributes: map[string]string{
+			"domain":        "writer.okta.com",
+			"event_type":    "system.api_token.create",
+			"actor_id":      "00u-admin",
+			"actor_type":    "User",
+			"resource_id":   "token-1",
+			"resource_type": "ApiToken",
+		},
+	}
+	records, err := rules[identityAPIOrOAuthCredentialCreatedRuleID].Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(records))
+	}
+}
+
+func TestIdentitySignalRulesIgnoreFailedSensitiveAuditEvents(t *testing.T) {
+	rules := identityRulesByID(t)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"}
+	for _, ruleID := range []string{
+		identityMFAFactorResetOrDisabledRuleID,
+		identityControlTamperCredentialChangeRuleID,
+	} {
+		t.Run(ruleID, func(t *testing.T) {
+			event := &cerebrov1.EventEnvelope{
+				Id:       "okta-failed-mfa-reset-" + ruleID,
+				TenantId: "writer",
+				SourceId: "okta",
+				Kind:     "okta.audit",
+				Attributes: map[string]string{
+					"domain":         "writer.okta.com",
+					"event_type":     "user.mfa.factor.reset",
+					"outcome_result": "FAILURE",
+					"resource_id":    "00u-user",
+					"resource_type":  "User",
+				},
+			}
+			records, err := rules[ruleID].Evaluate(context.Background(), runtime, event)
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			if len(records) != 0 {
+				t.Fatalf("len(records) = %d, want 0", len(records))
+			}
 		})
 	}
 }

--- a/internal/findings/runtime_signal_rule.go
+++ b/internal/findings/runtime_signal_rule.go
@@ -78,13 +78,41 @@ func buildRuntimeActiveThreatFinding(ctx context.Context, runtime *cerebrov1.Sou
 
 func matchesRuntimeActiveThreat(attributes map[string]string) bool {
 	verdict := strings.ToLower(strings.TrimSpace(attributes["verdict"]))
-	if containsAny(verdict, "malicious", "exploited", "confirmed", "active") {
+	evidenceType := strings.ToLower(strings.TrimSpace(attributes["evidence_type"]))
+	if runtimeThreatVerdictConfirmed(verdict) {
 		return true
 	}
-	evidenceType := strings.ToLower(strings.TrimSpace(attributes["evidence_type"]))
-	if !containsAny(evidenceType, "exploit", "secret_access", "credential_use", "token_exchange", "suspicious_process") {
+	if !runtimeRiskyEvidenceType(evidenceType) {
 		return false
+	}
+	if runtimeThreatVerdictActive(verdict) {
+		return true
 	}
 	confidence, err := strconv.ParseFloat(strings.TrimSpace(attributes["confidence"]), 64)
 	return err == nil && confidence >= 0.7
+}
+
+func runtimeThreatVerdictConfirmed(verdict string) bool {
+	return runtimeVerdictHasToken(verdict, "malicious", "exploited", "confirmed")
+}
+
+func runtimeThreatVerdictActive(verdict string) bool {
+	return runtimeVerdictHasToken(verdict, "active")
+}
+
+func runtimeVerdictHasToken(verdict string, tokens ...string) bool {
+	for _, token := range strings.FieldsFunc(verdict, func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	}) {
+		for _, candidate := range tokens {
+			if token == candidate {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func runtimeRiskyEvidenceType(evidenceType string) bool {
+	return containsAny(evidenceType, "exploit", "secret_access", "credential_use", "token_exchange", "suspicious_process")
 }

--- a/internal/findings/runtime_signal_rule_test.go
+++ b/internal/findings/runtime_signal_rule_test.go
@@ -40,4 +40,22 @@ func TestRuntimeActiveThreatEvidenceRule(t *testing.T) {
 	if len(records) != 0 {
 		t.Fatalf("len(benign records) = %d, want 0", len(records))
 	}
+
+	inactive := &cerebrov1.EventEnvelope{Id: "runtime-evidence-inactive", TenantId: "writer", SourceId: "runtime", Kind: "runtime.evidence", Attributes: map[string]string{"confidence": "0.2", "evidence_type": "credential_use", "verdict": "inactive"}}
+	records, err = rule.Evaluate(context.Background(), runtime, inactive)
+	if err != nil {
+		t.Fatalf("Evaluate(inactive) error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("len(inactive records) = %d, want 0", len(records))
+	}
+
+	activeRisky := &cerebrov1.EventEnvelope{Id: "runtime-evidence-active", TenantId: "writer", SourceId: "runtime", Kind: "runtime.evidence", Attributes: map[string]string{"confidence": "0.2", "evidence_type": "credential_use", "verdict": "active"}}
+	records, err = rule.Evaluate(context.Background(), runtime, activeRisky)
+	if err != nil {
+		t.Fatalf("Evaluate(active) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(active records) = %d, want 1", len(records))
+	}
 }

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -261,7 +261,12 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 		Run:     run,
 	}
 	evidenceIDs := map[string]struct{}{}
+	evaluatedEventIDs := map[string]struct{}{}
+	emittedFindingIDs := map[string]struct{}{}
 	for _, event := range events {
+		if eventID := strings.TrimSpace(event.GetId()); eventID != "" {
+			evaluatedEventIDs[eventID] = struct{}{}
+		}
 		emitted, err := rule.Evaluate(ctx, runtime, event)
 		if err != nil {
 			evaluationErr := fmt.Errorf("evaluate finding rule %q for event %q: %w", result.Rule.GetId(), event.GetId(), err)
@@ -283,6 +288,7 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 				return nil, s.finishFailedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings), evaluationErr)
 			}
 			result.Findings = append(result.Findings, stored)
+			emittedFindingIDs[strings.TrimSpace(stored.ID)] = struct{}{}
 			evidence, err := s.buildFindingEvidence(ctx, stored, run)
 			if err != nil {
 				evaluationErr := fmt.Errorf("build evidence for finding %q: %w", stored.ID, err)
@@ -303,6 +309,9 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 		}
 	}
 	if err := s.finishCompletedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings)); err != nil {
+		return nil, err
+	}
+	if err := s.resolveStaleOpenFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), runtimeID, rule.Spec().GetId(), evaluatedEventIDs, emittedFindingIDs); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -339,8 +348,9 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 			return nil, s.markRuleEvaluationsFailed(ctx, states, evaluationErr)
 		}
 		state := &ruleEvaluationState{
-			rule:        rule,
-			evidenceIDs: map[string]struct{}{},
+			rule:              rule,
+			evidenceIDs:       map[string]struct{}{},
+			emittedFindingIDs: map[string]struct{}{},
 			result: &RuleEvaluationResult{
 				Rule: rule.Spec(),
 				Run:  run,
@@ -358,7 +368,11 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 		return nil, s.markRuleEvaluationsFailed(ctx, states, evaluationErr)
 	}
 	result.EventsEvaluated = uint32(len(events))
+	evaluatedEventIDs := map[string]struct{}{}
 	for _, event := range events {
+		if eventID := strings.TrimSpace(event.GetId()); eventID != "" {
+			evaluatedEventIDs[eventID] = struct{}{}
+		}
 		for _, state := range states {
 			if state.failed {
 				continue
@@ -390,6 +404,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 					break
 				}
 				state.result.Findings = append(state.result.Findings, stored)
+				state.emittedFindingIDs[strings.TrimSpace(stored.ID)] = struct{}{}
 				evidence, err := s.buildFindingEvidence(ctx, stored, state.result.Run)
 				if err != nil {
 					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("build evidence for finding %q: %w", stored.ID, err)); failErr != nil {
@@ -421,6 +436,9 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 			continue
 		}
 		if err := s.finishCompletedRun(ctx, state.result.Run, state.eventsEvaluated, findingIDs(state.result.Findings)); err != nil {
+			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), err)
+		}
+		if err := s.resolveStaleOpenFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), runtimeID, state.result.Rule.GetId(), evaluatedEventIDs, state.emittedFindingIDs); err != nil {
 			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), err)
 		}
 	}
@@ -456,6 +474,57 @@ func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListR
 		return nil, fmt.Errorf("list findings for tenant %q runtime %q: %w", strings.TrimSpace(runtime.GetTenantId()), runtimeID, err)
 	}
 	return &ListResult{Findings: findings}, nil
+}
+
+func (s *Service) resolveStaleOpenFindings(ctx context.Context, tenantID string, runtimeID string, ruleID string, evaluatedEventIDs map[string]struct{}, emittedFindingIDs map[string]struct{}) error {
+	if len(evaluatedEventIDs) == 0 {
+		return nil
+	}
+	findings, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
+		TenantID:  strings.TrimSpace(tenantID),
+		RuntimeID: strings.TrimSpace(runtimeID),
+		RuleID:    strings.TrimSpace(ruleID),
+		Status:    findingStatusOpen,
+	})
+	if err != nil {
+		return fmt.Errorf("list stale candidates for rule %q: %w", strings.TrimSpace(ruleID), err)
+	}
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		if _, emitted := emittedFindingIDs[strings.TrimSpace(finding.ID)]; emitted {
+			continue
+		}
+		if !findingReferencesEvaluatedEvent(finding, evaluatedEventIDs) {
+			continue
+		}
+		updated, err := s.store.UpdateFindingStatus(ctx, ports.FindingStatusUpdate{
+			FindingID: strings.TrimSpace(finding.ID),
+			Status:    findingStatusResolved,
+			Reason:    "No longer emitted by latest rule evaluation.",
+			UpdatedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			return fmt.Errorf("resolve stale finding %q: %w", strings.TrimSpace(finding.ID), err)
+		}
+		if err := s.recordFindingStatusWorkflow(ctx, updated); err != nil {
+			return fmt.Errorf("project stale finding %q resolution: %w", strings.TrimSpace(finding.ID), err)
+		}
+	}
+	return nil
+}
+
+func findingReferencesEvaluatedEvent(finding *ports.FindingRecord, evaluatedEventIDs map[string]struct{}) bool {
+	if finding == nil {
+		return false
+	}
+	for _, eventID := range finding.EventIDs {
+		if _, ok := evaluatedEventIDs[strings.TrimSpace(eventID)]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // GetFinding loads one persisted finding by durable identifier.
@@ -679,11 +748,12 @@ func (s *Service) GetEvidence(ctx context.Context, id string) (*cerebrov1.Findin
 }
 
 type ruleEvaluationState struct {
-	rule            Rule
-	result          *RuleEvaluationResult
-	eventsEvaluated uint32
-	evidenceIDs     map[string]struct{}
-	failed          bool
+	rule              Rule
+	result            *RuleEvaluationResult
+	eventsEvaluated   uint32
+	evidenceIDs       map[string]struct{}
+	emittedFindingIDs map[string]struct{}
+	failed            bool
 }
 
 func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (Rule, error) {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -14,6 +14,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -502,7 +503,7 @@ func (s *Service) resolveStaleOpenFindings(ctx context.Context, tenantID string,
 		updated, err := s.store.UpdateFindingStatus(ctx, ports.FindingStatusUpdate{
 			FindingID: strings.TrimSpace(finding.ID),
 			Status:    findingStatusResolved,
-			Reason:    "No longer emitted by latest rule evaluation.",
+			Reason:    workflowevents.FindingStatusReasonNoLongerEmitted,
 			UpdatedAt: time.Now().UTC(),
 		})
 		if err != nil {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -261,6 +261,16 @@ func (s *stubGraphStore) UpsertProjectedLink(_ context.Context, link *ports.Proj
 	return nil
 }
 
+func (s *stubGraphStore) DeleteProjectedEntity(_ context.Context, urn string) error {
+	delete(s.entities, urn)
+	for key, link := range s.links {
+		if link.FromURN == urn || link.ToURN == urn {
+			delete(s.links, key)
+		}
+	}
+	return nil
+}
+
 func (s *stubFindingStore) UpsertClaim(_ context.Context, claim *ports.ClaimRecord) (*ports.ClaimRecord, error) {
 	if claim == nil {
 		return nil, errors.New("claim is required")
@@ -818,6 +828,97 @@ func TestEvaluateSourceRuntimeFindingsProjectsRecordedFindingToGraph(t *testing.
 	}
 	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindFindingRecorded {
 		t.Fatalf("appendLog.events[0].Kind = %q, want %q", got, workflowevents.EventKindFindingRecorded)
+	}
+}
+
+func TestEvaluateSourceRuntimeResolvesAndPrunesStaleFindings(t *testing.T) {
+	registry, err := NewRegistry(&emittingRule{
+		spec: &cerebrov1.RuleSpec{
+			Id:   "routine-oauth-rule",
+			Name: "Routine OAuth Rule",
+		},
+		supportedSourceIDs: map[string]struct{}{"okta": {}},
+		triggerEventID:     "different-event",
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	staleFinding := &ports.FindingRecord{
+		ID:              "stale-oauth-finding",
+		Fingerprint:     "stale-oauth-finding",
+		TenantID:        "writer",
+		RuntimeID:       "writer-okta-audit",
+		RuleID:          "routine-oauth-rule",
+		Title:           "Routine OAuth Rule",
+		Severity:        "HIGH",
+		Status:          "open",
+		Summary:         "routine OAuth grant was previously emitted",
+		ResourceURNs:    []string{"urn:cerebro:writer:okta_application:0oa-client"},
+		EventIDs:        []string{"okta-oauth-grant"},
+		FirstObservedAt: time.Date(2026, 5, 7, 19, 54, 0, 0, time.UTC),
+		LastObservedAt:  time.Date(2026, 5, 7, 19, 54, 0, 0, time.UTC),
+	}
+	store := &stubFindingStore{findings: map[string]*ports.FindingRecord{staleFinding.ID: staleFinding}}
+	graph := &stubGraphStore{
+		entities: map[string]*ports.ProjectedEntity{
+			"urn:cerebro:writer:finding:stale-oauth-finding": {
+				URN:        "urn:cerebro:writer:finding:stale-oauth-finding",
+				TenantID:   "writer",
+				SourceID:   "writer-okta-audit",
+				EntityType: "finding",
+				Label:      "Routine OAuth Rule",
+			},
+		},
+		links: map[string]*ports.ProjectedLink{
+			"urn:cerebro:writer:okta_application:0oa-client|has_finding|urn:cerebro:writer:finding:stale-oauth-finding": {
+				TenantID: "writer",
+				SourceID: "writer-okta-audit",
+				FromURN:  "urn:cerebro:writer:okta_application:0oa-client",
+				ToURN:    "urn:cerebro:writer:finding:stale-oauth-finding",
+				Relation: "has_finding",
+			},
+		},
+	}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		&stubReplayer{events: []*cerebrov1.EventEnvelope{{
+			Id:       "okta-oauth-grant",
+			TenantId: "writer",
+			SourceId: "okta",
+			Kind:     "okta.audit",
+			Attributes: map[string]string{
+				"event_type": "app.oauth2.token.grant.access_token",
+			},
+			OccurredAt: timestamppb.New(time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC)),
+		}}},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	).WithGraphStore(graph)
+
+	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-okta-audit",
+		RuleID:    "routine-oauth-rule",
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntime() error = %v", err)
+	}
+	if got := len(result.Findings); got != 0 {
+		t.Fatalf("len(Findings) = %d, want 0", got)
+	}
+	resolved := store.findings["stale-oauth-finding"]
+	if got := resolved.Status; got != "resolved" {
+		t.Fatalf("stale finding status = %q, want resolved", got)
+	}
+	if _, ok := graph.entities["urn:cerebro:writer:finding:stale-oauth-finding"]; ok {
+		t.Fatal("stale finding graph entity should be pruned")
+	}
+	if len(graph.links) != 0 {
+		t.Fatalf("graph links = %#v, want stale links pruned", graph.links)
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -898,7 +898,7 @@ func TestEvaluateSourceRuntimeResolvesAndPrunesStaleFindings(t *testing.T) {
 		store,
 		store,
 		registry,
-	).WithGraphStore(graph)
+	).WithGraphStore(graph).WithGraphQueryStore(graph)
 
 	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
 		RuntimeID: "writer-okta-audit",
@@ -919,6 +919,11 @@ func TestEvaluateSourceRuntimeResolvesAndPrunesStaleFindings(t *testing.T) {
 	}
 	if len(graph.links) != 0 {
 		t.Fatalf("graph links = %#v, want stale links pruned", graph.links)
+	}
+	for urn, entity := range graph.entities {
+		if entity.EntityType == "decision" || entity.EntityType == "outcome" {
+			t.Fatalf("auto-pruned finding should not leave workflow entity %q: %#v", urn, entity)
+		}
 	}
 }
 

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -161,6 +161,7 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (*RunR
 	}
 	ingestRequest := sourceRequest{
 		SourceID:          strings.TrimSpace(runtime.GetSourceId()),
+		RuntimeID:         runtimeID,
 		SourceConfig:      runtimeConfig,
 		TenantID:          strings.TrimSpace(runtime.GetTenantId()),
 		PageLimit:         pageLimit,
@@ -299,6 +300,7 @@ func (s *Service) preparedConfig(ctx context.Context, runtime *cerebrov1.SourceR
 
 type sourceRequest struct {
 	SourceID          string
+	RuntimeID         string
 	SourceConfig      map[string]string
 	TenantID          string
 	PageLimit         uint32
@@ -341,7 +343,7 @@ func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*Ing
 		}
 		result.PagesRead++
 		for _, event := range response.GetEvents() {
-			projected, err := s.projector.Project(ctx, ingestEvent(event, request.TenantID))
+			projected, err := s.projector.Project(ctx, ingestEvent(event, request.TenantID, request.RuntimeID))
 			if err != nil {
 				return nil, fmt.Errorf("project source event %q: %w", event.GetId(), err)
 			}
@@ -572,13 +574,19 @@ func sensitiveConfigKey(key string) bool {
 	return normalized == "key"
 }
 
-func ingestEvent(event *cerebrov1.EventEnvelope, tenantID string) *cerebrov1.EventEnvelope {
+func ingestEvent(event *cerebrov1.EventEnvelope, tenantID string, runtimeID string) *cerebrov1.EventEnvelope {
 	if event == nil {
 		return nil
 	}
 	cloned := proto.Clone(event).(*cerebrov1.EventEnvelope)
 	if normalized := strings.TrimSpace(tenantID); normalized != "" {
 		cloned.TenantId = normalized
+	}
+	if normalized := strings.TrimSpace(runtimeID); normalized != "" {
+		if cloned.Attributes == nil {
+			cloned.Attributes = map[string]string{}
+		}
+		cloned.Attributes[ports.EventAttributeSourceRuntimeID] = normalized
 	}
 	return cloned
 }

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/graphstore"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 type stubRunStore struct {
@@ -82,6 +83,25 @@ func TestRuntimeCheckpointIDDistinguishesOriginalRuntimeIDs(t *testing.T) {
 	}
 	if !strings.HasPrefix(first, "runtime:") || !strings.HasPrefix(second, "runtime:") {
 		t.Fatalf("runtimeCheckpointID() = %q, %q; want runtime prefix", first, second)
+	}
+}
+
+func TestIngestEventStampsTenantAndRuntime(t *testing.T) {
+	event := ingestEvent(&cerebrov1.EventEnvelope{
+		Id:       "event-1",
+		TenantId: "old-tenant",
+		Attributes: map[string]string{
+			"existing": "value",
+		},
+	}, "writer", "writer-github")
+	if got := event.GetTenantId(); got != "writer" {
+		t.Fatalf("TenantId = %q, want writer", got)
+	}
+	if got := event.GetAttributes()[ports.EventAttributeSourceRuntimeID]; got != "writer-github" {
+		t.Fatalf("source_runtime_id = %q, want writer-github", got)
+	}
+	if got := event.GetAttributes()["existing"]; got != "value" {
+		t.Fatalf("existing attribute = %q, want value", got)
 	}
 }
 

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -405,6 +405,27 @@ func (s *Store) DeleteProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	return nil
 }
 
+// DeleteProjectedEntity removes one normalized entity and its graph relationships.
+func (s *Store) DeleteProjectedEntity(ctx context.Context, urn string) error {
+	normalizedURN := strings.TrimSpace(urn)
+	if normalizedURN == "" {
+		return errors.New("projected entity urn is required")
+	}
+	if err := s.requireConfigured(); err != nil {
+		return err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return err
+	}
+	_, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		return consume(ctx, tx, `MATCH (e:Entity {urn: $urn}) DETACH DELETE e`, map[string]any{"urn": normalizedURN})
+	})
+	if err != nil {
+		return fmt.Errorf("delete projected entity %q: %w", normalizedURN, err)
+	}
+	return nil
+}
+
 // GetEntityNeighborhood returns one bounded root-centered graph neighborhood.
 func (s *Store) GetEntityNeighborhood(ctx context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
 	normalizedRootURN := strings.TrimSpace(rootURN)

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -18,6 +18,7 @@ import (
 
 const defaultIngestRunListLimit = 25
 const maxAttributeMergeRetries = 5
+const defaultProjectionCleanupLimit = 1000
 
 var errConcurrentAttributeMerge = errors.New("concurrent attribute merge")
 
@@ -287,6 +288,7 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 		"urn":         urn,
 		"tenant_id":   tenantID,
 		"source_id":   sourceID,
+		"runtime_id":  strings.TrimSpace(entity.RuntimeID),
 		"entity_type": entityType,
 		"label":       label,
 	}
@@ -338,11 +340,12 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	params := map[string]any{
-		"from_urn":  fromURN,
-		"to_urn":    toURN,
-		"relation":  relation,
-		"tenant_id": tenantID,
-		"source_id": sourceID,
+		"from_urn":   fromURN,
+		"to_urn":     toURN,
+		"relation":   relation,
+		"tenant_id":  tenantID,
+		"source_id":  sourceID,
+		"runtime_id": strings.TrimSpace(link.RuntimeID),
 	}
 	for attempt := 0; attempt < maxAttributeMergeRetries; attempt++ {
 		_, err = s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
@@ -424,6 +427,73 @@ func (s *Store) DeleteProjectedEntity(ctx context.Context, urn string) error {
 		return fmt.Errorf("delete projected entity %q: %w", normalizedURN, err)
 	}
 	return nil
+}
+
+// CleanupProjectedEntities deletes scoped isolated projection entities.
+func (s *Store) CleanupProjectedEntities(ctx context.Context, request ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
+	if err := s.requireConfigured(); err != nil {
+		return ports.ProjectionCleanupResult{}, err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return ports.ProjectionCleanupResult{}, err
+	}
+	limit := int64(request.Limit)
+	if limit <= 0 {
+		limit = defaultProjectionCleanupLimit
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	sourceID := strings.TrimSpace(request.SourceID)
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	findingID := strings.TrimSpace(request.FindingID)
+	entityTypes := normalizeCleanupEntityTypes(request.EntityTypes)
+	if tenantID == "" && sourceID == "" && runtimeID == "" && findingID == "" && len(entityTypes) == 0 {
+		return ports.ProjectionCleanupResult{}, errors.New("projection cleanup scope is required")
+	}
+	conditions := []string{}
+	params := map[string]any{
+		"limit":        limit,
+		"entity_types": entityTypes,
+	}
+	if tenantID != "" {
+		conditions = append(conditions, "e.tenant_id = $tenant_id")
+		params["tenant_id"] = tenantID
+	}
+	if sourceID != "" {
+		conditions = append(conditions, "e.source_id = $source_id")
+		params["source_id"] = sourceID
+	}
+	if runtimeID != "" {
+		conditions = append(conditions, "coalesce(e.runtime_id, '') = $runtime_id")
+		params["runtime_id"] = runtimeID
+	}
+	if findingID != "" {
+		conditions = append(conditions, "coalesce(e.attributes_json, '') CONTAINS $finding_id_fragment")
+		params["finding_id_fragment"] = fmt.Sprintf("%q:%q", "finding_id", findingID)
+	}
+	if len(entityTypes) != 0 {
+		conditions = append(conditions, "e.entity_type IN $entity_types")
+	}
+	if request.OnlyIsolated && findingID == "" {
+		conditions = append(conditions, "NOT (e)-[:RELATION]-()")
+	}
+	query := `MATCH (e:Entity)
+WHERE ` + strings.Join(conditions, " AND ") + `
+WITH e LIMIT $limit
+WITH collect(e) AS entities
+FOREACH (entity IN entities | DETACH DELETE entity)
+RETURN size(entities)`
+	var deleted int64
+	if _, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		value, err := queryOneValue(ctx, tx, query, params)
+		if err != nil {
+			return nil, err
+		}
+		deleted = toInt64(value)
+		return nil, nil
+	}); err != nil {
+		return ports.ProjectionCleanupResult{}, fmt.Errorf("cleanup projected entities: %w", err)
+	}
+	return ports.ProjectionCleanupResult{EntitiesDeleted: uint32(deleted)}, nil
 }
 
 // GetEntityNeighborhood returns one bounded root-centered graph neighborhood.
@@ -736,6 +806,8 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 		"CREATE CONSTRAINT cerebro_entity_urn IF NOT EXISTS FOR (e:Entity) REQUIRE e.urn IS UNIQUE",
 		"CREATE CONSTRAINT cerebro_checkpoint_id IF NOT EXISTS FOR (c:IngestCheckpoint) REQUIRE c.id IS UNIQUE",
 		"CREATE CONSTRAINT cerebro_ingest_run_id IF NOT EXISTS FOR (r:IngestRun) REQUIRE r.id IS UNIQUE",
+		"CREATE INDEX cerebro_entity_tenant_runtime IF NOT EXISTS FOR (e:Entity) ON (e.tenant_id, e.runtime_id)",
+		"CREATE INDEX cerebro_relation_tenant_runtime IF NOT EXISTS FOR ()-[r:RELATION]-() ON (r.tenant_id, r.runtime_id)",
 	}
 	if _, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
 		for _, statement := range statements {
@@ -833,11 +905,29 @@ func validateProjectedLinkIdentity(link *ports.ProjectedLink) (fromURN string, t
 	return fromURN, toURN, relation, strings.TrimSpace(link.TenantID), strings.TrimSpace(link.SourceID), nil
 }
 
+func normalizeCleanupEntityTypes(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
+}
+
 func mergeEntityAndLoadAttributes(ctx context.Context, tx neo4jdriver.ManagedTransaction, params map[string]any) (string, int64, error) {
 	result, err := tx.Run(ctx, `MERGE (e:Entity {urn: $urn})
 ON CREATE SET e.attributes_json = '{}', e.attributes_version = 0
 SET e.tenant_id = $tenant_id,
     e.source_id = $source_id,
+    e.runtime_id = CASE WHEN $runtime_id <> '' THEN $runtime_id ELSE coalesce(e.runtime_id, '') END,
     e.entity_type = $entity_type,
     e.label = $label
 RETURN coalesce(e.attributes_json, '{}'), coalesce(e.attributes_version, 0)`, params)
@@ -877,7 +967,8 @@ SET src.relation_lock = coalesce(src.relation_lock, 0) + 1
 MERGE (src)-[r:RELATION {relation: $relation}]->(dst)
 ON CREATE SET r.attributes_json = '{}', r.attributes_version = 0
 SET r.tenant_id = $tenant_id,
-    r.source_id = $source_id
+    r.source_id = $source_id,
+    r.runtime_id = CASE WHEN $runtime_id <> '' THEN $runtime_id ELSE coalesce(r.runtime_id, '') END
 RETURN coalesce(r.attributes_json, '{}'), coalesce(r.attributes_version, 0)`, params)
 	if err != nil {
 		return "", 0, false, err

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -51,6 +51,11 @@ type ProjectionLinkDeleter interface {
 	DeleteProjectedLink(context.Context, *ProjectedLink) error
 }
 
+// ProjectionEntityDeleter removes normalized entities from projection stores that support deletion.
+type ProjectionEntityDeleter interface {
+	DeleteProjectedEntity(context.Context, string) error
+}
+
 // SourceProjector materializes source events into current-state and graph stores.
 type SourceProjector interface {
 	Project(context.Context, *cerebrov1.EventEnvelope) (ProjectionResult, error)

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -11,6 +11,7 @@ type ProjectedEntity struct {
 	URN        string
 	TenantID   string
 	SourceID   string
+	RuntimeID  string
 	EntityType string
 	Label      string
 	Attributes map[string]string
@@ -20,6 +21,7 @@ type ProjectedEntity struct {
 type ProjectedLink struct {
 	TenantID   string
 	SourceID   string
+	RuntimeID  string
 	FromURN    string
 	ToURN      string
 	Relation   string
@@ -30,6 +32,25 @@ type ProjectedLink struct {
 type ProjectionResult struct {
 	EntitiesProjected uint32
 	LinksProjected    uint32
+	EntitiesDeleted   uint32
+	LinksDeleted      uint32
+}
+
+// ProjectionCleanupRequest scopes opportunistic graph cleanup to one tenant/source/runtime boundary.
+type ProjectionCleanupRequest struct {
+	TenantID     string
+	SourceID     string
+	RuntimeID    string
+	FindingID    string
+	EntityTypes  []string
+	OnlyIsolated bool
+	Limit        uint32
+}
+
+// ProjectionCleanupResult reports graph objects removed by one cleanup pass.
+type ProjectionCleanupResult struct {
+	EntitiesDeleted uint32
+	LinksDeleted    uint32
 }
 
 // ProjectionStateStore persists normalized current-state entities and links.
@@ -54,6 +75,11 @@ type ProjectionLinkDeleter interface {
 // ProjectionEntityDeleter removes normalized entities from projection stores that support deletion.
 type ProjectionEntityDeleter interface {
 	DeleteProjectedEntity(context.Context, string) error
+}
+
+// ProjectionCleaner removes stale or orphaned projection artifacts in scoped batches.
+type ProjectionCleaner interface {
+	CleanupProjectedEntities(context.Context, ProjectionCleanupRequest) (ProjectionCleanupResult, error)
 }
 
 // SourceProjector materializes source events into current-state and graph stores.

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -73,6 +73,7 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 	if err != nil {
 		return ports.ProjectionResult{}, err
 	}
+	stampProjectionRuntime(event, entities, links)
 	for _, entity := range entities {
 		if s.state != nil {
 			if err := s.state.UpsertProjectedEntity(ctx, entity); err != nil {
@@ -101,6 +102,44 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 		EntitiesProjected: uint32(len(entities)),
 		LinksProjected:    uint32(len(links)),
 	}, nil
+}
+
+func stampProjectionRuntime(event *cerebrov1.EventEnvelope, entities []*ports.ProjectedEntity, links []*ports.ProjectedLink) {
+	if event == nil {
+		return
+	}
+	runtimeID := strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID])
+	if runtimeID == "" {
+		return
+	}
+	for _, entity := range entities {
+		if entity == nil {
+			continue
+		}
+		if strings.TrimSpace(entity.RuntimeID) == "" {
+			entity.RuntimeID = runtimeID
+		}
+		if entity.Attributes == nil {
+			entity.Attributes = map[string]string{}
+		}
+		if strings.TrimSpace(entity.Attributes[ports.EventAttributeSourceRuntimeID]) == "" {
+			entity.Attributes[ports.EventAttributeSourceRuntimeID] = runtimeID
+		}
+	}
+	for _, link := range links {
+		if link == nil {
+			continue
+		}
+		if strings.TrimSpace(link.RuntimeID) == "" {
+			link.RuntimeID = runtimeID
+		}
+		if link.Attributes == nil {
+			link.Attributes = map[string]string{}
+		}
+		if strings.TrimSpace(link.Attributes[ports.EventAttributeSourceRuntimeID]) == "" {
+			link.Attributes[ports.EventAttributeSourceRuntimeID] = runtimeID
+		}
+	}
 }
 
 func githubPullRequestProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -505,6 +505,8 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 	actorDisplayName := strings.TrimSpace(attributes["actor_display_name"])
 	resourceID := strings.TrimSpace(attributes["resource_id"])
 	resourceType := strings.TrimSpace(attributes["resource_type"])
+	oauthClientID := firstNonEmpty(attributes["oauth_client_id"], attributes["client_id"])
+	oauthClientLabel := firstNonEmpty(attributes["oauth_client_label"], attributes["actor_display_name"], oauthClientID)
 
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
@@ -540,6 +542,35 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		})
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+
+	oauthClientURN := oktaApplicationURN(tenantID, oauthClientID)
+	if oauthClientURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        oauthClientURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "okta.application",
+			Label:      oauthClientLabel,
+			Attributes: map[string]string{
+				"app_id":               oauthClientID,
+				"client_id":            oauthClientID,
+				"oauth_client_type":    strings.TrimSpace(attributes["oauth_client_type"]),
+				"oauth_event_category": strings.TrimSpace(attributes["oauth_event_category"]),
+				"grant_type":           strings.TrimSpace(attributes["grant_type"]),
+			},
+		})
+		if orgURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), oauthClientURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+		if resourceURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), oauthClientURN, resourceURN, relationActedOn, map[string]string{
+				"event_id":             event.GetId(),
+				"event_type":           strings.TrimSpace(attributes["event_type"]),
+				"oauth_event_category": strings.TrimSpace(attributes["oauth_event_category"]),
+				"grant_type":           strings.TrimSpace(attributes["grant_type"]),
+			}))
 		}
 	}
 
@@ -714,6 +745,14 @@ func oktaUserURN(tenantID string, userID string) string {
 		return ""
 	}
 	return projectionURN(tenantID, "okta_user", value)
+}
+
+func oktaApplicationURN(tenantID string, appID string) string {
+	value := strings.TrimSpace(appID)
+	if value == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "okta_application", value)
 }
 
 func oktaActorURN(tenantID string, actorType string, actorID string) string {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -85,6 +85,45 @@ func TestProjectGitHubPullRequest(t *testing.T) {
 	}
 }
 
+func TestProjectStampsRuntimeIDOnEntitiesAndLinks(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	service := New(state, graph)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-pr-447",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.pull_request",
+		Attributes: map[string]string{
+			"author":                            "alice",
+			"owner":                             "writer",
+			"pull_number":                       "447",
+			"repository":                        "writer/cerebro",
+			ports.EventAttributeSourceRuntimeID: "writer-github",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	for urn, entity := range state.entities {
+		if got := entity.RuntimeID; got != "writer-github" {
+			t.Fatalf("state entity %q RuntimeID = %q, want writer-github", urn, got)
+		}
+		if got := entity.Attributes[ports.EventAttributeSourceRuntimeID]; got != "writer-github" {
+			t.Fatalf("state entity %q source_runtime_id = %q, want writer-github", urn, got)
+		}
+	}
+	for key, link := range graph.links {
+		if got := link.RuntimeID; got != "writer-github" {
+			t.Fatalf("graph link %q RuntimeID = %q, want writer-github", key, got)
+		}
+		if got := link.Attributes[ports.EventAttributeSourceRuntimeID]; got != "writer-github" {
+			t.Fatalf("graph link %q source_runtime_id = %q, want writer-github", key, got)
+		}
+	}
+}
+
 func TestProjectGitHubPullRequestWithoutOwnerDoesNotLinkEmptyOrg(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
@@ -1149,6 +1188,7 @@ func cloneProjectedEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity 
 		URN:        entity.URN,
 		TenantID:   entity.TenantID,
 		SourceID:   entity.SourceID,
+		RuntimeID:  entity.RuntimeID,
 		EntityType: entity.EntityType,
 		Label:      entity.Label,
 		Attributes: attributes,
@@ -1166,6 +1206,7 @@ func cloneProjectedLink(link *ports.ProjectedLink) *ports.ProjectedLink {
 	return &ports.ProjectedLink{
 		TenantID:   link.TenantID,
 		SourceID:   link.SourceID,
+		RuntimeID:  link.RuntimeID,
 		FromURN:    link.FromURN,
 		ToURN:      link.ToURN,
 		Relation:   link.Relation,

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -206,6 +206,46 @@ func TestProjectGitHubDependabotAlert(t *testing.T) {
 	}
 }
 
+func TestProjectOktaOAuthGrantAsApplicationTelemetry(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "okta-oauth-grant",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.audit",
+		Attributes: map[string]string{
+			"domain":               "writer.okta.com",
+			"event_type":           "app.oauth2.token.grant.access_token",
+			"actor_id":             "0oa-client",
+			"actor_type":           "PublicClientApp",
+			"actor_display_name":   "Production Client",
+			"resource_id":          "00u-user",
+			"resource_type":        "User",
+			"oauth_client_id":      "0oa-client",
+			"oauth_client_label":   "Production Client",
+			"oauth_client_type":    "PublicClientApp",
+			"oauth_event_category": "runtime_grant",
+			"grant_type":           "access_token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	clientURN := "urn:cerebro:writer:okta_application:0oa-client"
+	userURN := "urn:cerebro:writer:okta_user:00u-user"
+	entity, ok := state.entities[clientURN]
+	if !ok {
+		t.Fatalf("OAuth client entity %q missing", clientURN)
+	}
+	if got := entity.Attributes["oauth_event_category"]; got != "runtime_grant" {
+		t.Fatalf("oauth_event_category = %q, want runtime_grant", got)
+	}
+	assertProjectedLink(t, state, clientURN, relationActedOn, userURN)
+	assertProjectedLink(t, state, clientURN, relationBelongsTo, "urn:cerebro:writer:okta_org:writer.okta.com")
+}
+
 func TestProjectGitHubAuditSOTASignalsToGraph(t *testing.T) {
 	events := []struct {
 		id       string

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -15,33 +15,40 @@ var ensureProjectionStatements = []string{
   urn TEXT PRIMARY KEY,
   tenant_id TEXT NOT NULL,
   source_id TEXT NOT NULL,
+  runtime_id TEXT NOT NULL DEFAULT '',
   entity_type TEXT NOT NULL,
   label TEXT NOT NULL,
   attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
 	`CREATE INDEX IF NOT EXISTS entities_tenant_type_idx ON entities (tenant_id, entity_type)`,
+	`ALTER TABLE entities ADD COLUMN IF NOT EXISTS runtime_id TEXT NOT NULL DEFAULT ''`,
+	`CREATE INDEX IF NOT EXISTS entities_tenant_runtime_idx ON entities (tenant_id, runtime_id)`,
 	`CREATE TABLE IF NOT EXISTS entity_links (
   from_urn TEXT NOT NULL,
   relation TEXT NOT NULL,
   to_urn TEXT NOT NULL,
   tenant_id TEXT NOT NULL,
   source_id TEXT NOT NULL,
+  runtime_id TEXT NOT NULL DEFAULT '',
   attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (from_urn, relation, to_urn)
 )`,
 	`CREATE INDEX IF NOT EXISTS entity_links_tenant_relation_idx ON entity_links (tenant_id, relation)`,
+	`ALTER TABLE entity_links ADD COLUMN IF NOT EXISTS runtime_id TEXT NOT NULL DEFAULT ''`,
+	`CREATE INDEX IF NOT EXISTS entity_links_tenant_runtime_idx ON entity_links (tenant_id, runtime_id)`,
 }
 
 func projectedEntityUpsertSQL() string {
 	return `
-INSERT INTO entities (urn, tenant_id, source_id, entity_type, label, attributes_json)
-VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+INSERT INTO entities (urn, tenant_id, source_id, runtime_id, entity_type, label, attributes_json)
+VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
 ON CONFLICT (urn)
 DO UPDATE SET
   tenant_id = EXCLUDED.tenant_id,
   source_id = EXCLUDED.source_id,
+  runtime_id = CASE WHEN EXCLUDED.runtime_id <> '' THEN EXCLUDED.runtime_id ELSE entities.runtime_id END,
   entity_type = EXCLUDED.entity_type,
   label = EXCLUDED.label,
   attributes_json = entities.attributes_json || EXCLUDED.attributes_json,
@@ -50,12 +57,13 @@ DO UPDATE SET
 
 func projectedLinkUpsertSQL() string {
 	return `
-INSERT INTO entity_links (from_urn, relation, to_urn, tenant_id, source_id, attributes_json)
-VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+INSERT INTO entity_links (from_urn, relation, to_urn, tenant_id, source_id, runtime_id, attributes_json)
+VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
 ON CONFLICT (from_urn, relation, to_urn)
 DO UPDATE SET
   tenant_id = EXCLUDED.tenant_id,
   source_id = EXCLUDED.source_id,
+  runtime_id = CASE WHEN EXCLUDED.runtime_id <> '' THEN EXCLUDED.runtime_id ELSE entity_links.runtime_id END,
   attributes_json = entity_links.attributes_json || EXCLUDED.attributes_json,
   updated_at = NOW()`
 }
@@ -101,7 +109,7 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 	if label == "" {
 		label = urn
 	}
-	if _, err := s.db.ExecContext(ctx, projectedEntityUpsertSQL(), urn, tenantID, sourceID, entityType, label, attributesJSON); err != nil {
+	if _, err := s.db.ExecContext(ctx, projectedEntityUpsertSQL(), urn, tenantID, sourceID, strings.TrimSpace(entity.RuntimeID), entityType, label, attributesJSON); err != nil {
 		return fmt.Errorf("upsert projected entity %q: %w", urn, err)
 	}
 	return nil
@@ -142,7 +150,7 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	if err != nil {
 		return fmt.Errorf("marshal projected link attributes: %w", err)
 	}
-	if _, err := s.db.ExecContext(ctx, projectedLinkUpsertSQL(), fromURN, relation, toURN, tenantID, sourceID, attributesJSON); err != nil {
+	if _, err := s.db.ExecContext(ctx, projectedLinkUpsertSQL(), fromURN, relation, toURN, tenantID, sourceID, strings.TrimSpace(link.RuntimeID), attributesJSON); err != nil {
 		return fmt.Errorf("upsert projected link %q %q %q: %w", fromURN, relation, toURN, err)
 	}
 	return nil

--- a/internal/workflowevents/events.go
+++ b/internal/workflowevents/events.go
@@ -32,6 +32,8 @@ const (
 	EventAttributeSourceEvent  = "source_event_id"
 )
 
+const FindingStatusReasonNoLongerEmitted = "No longer emitted by latest rule evaluation."
+
 const (
 	SchemaKnowledgeDecisionRecorded = "urn:cerebro:events/workflow.knowledge.decision_recorded/v1"
 	SchemaKnowledgeActionRecorded   = "urn:cerebro:events/workflow.knowledge.action_recorded/v1"
@@ -60,6 +62,12 @@ type DecisionRecorded struct {
 	ValidTo       string         `json:"valid_to,omitempty"`
 	Confidence    float64        `json:"confidence,omitempty"`
 	Metadata      map[string]any `json:"metadata,omitempty"`
+}
+
+// FindingStatusPrunesGraph reports whether one status transition should remove ephemeral finding graph anchors.
+func FindingStatusPrunesGraph(status string, reason string) bool {
+	return strings.EqualFold(strings.TrimSpace(status), "resolved") &&
+		strings.EqualFold(strings.TrimSpace(reason), FindingStatusReasonNoLongerEmitted)
 }
 
 // ActionRecorded captures one durable workflow action event payload.

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -254,7 +254,7 @@ func (s *Service) projectFindingNote(ctx context.Context, event *cerebrov1.Event
 		return ports.ProjectionResult{}, err
 	}
 	result := ports.ProjectionResult{}
-	targetURNs, err := s.ensureFindingAnchor(ctx, payload.Finding, &result)
+	targetURNs, err := s.ensureFindingForWorkflow(ctx, payload.Finding, &result)
 	if err != nil {
 		return ports.ProjectionResult{}, err
 	}
@@ -301,7 +301,7 @@ func (s *Service) projectFindingTicket(ctx context.Context, event *cerebrov1.Eve
 		return ports.ProjectionResult{}, err
 	}
 	result := ports.ProjectionResult{}
-	targetURNs, err := s.ensureFindingAnchor(ctx, payload.Finding, &result)
+	targetURNs, err := s.ensureFindingForWorkflow(ctx, payload.Finding, &result)
 	if err != nil {
 		return ports.ProjectionResult{}, err
 	}
@@ -350,12 +350,23 @@ func (s *Service) projectFindingStatus(ctx context.Context, event *cerebrov1.Eve
 		return ports.ProjectionResult{}, err
 	}
 	result := ports.ProjectionResult{}
-	if !findingStatusProjectsToGraph(payload.Finding.Status) && findingStatusPrunesGraph(payload.Reason) {
+	if workflowevents.FindingStatusPrunesGraph(payload.Finding.Status, payload.Reason) {
 		return s.deleteFindingAnchor(ctx, payload.Finding)
 	}
-	if _, err := s.ensureFindingAnchor(ctx, payload.Finding, &result); err != nil {
+	if err := s.ensureFindingEntity(ctx, payload.Finding, &result); err != nil {
 		return ports.ProjectionResult{}, err
 	}
+	if findingStatusProjectsToGraph(payload.Finding.Status) {
+		if err := s.ensureFindingActiveLinks(ctx, payload.Finding, &result); err != nil {
+			return ports.ProjectionResult{}, err
+		}
+		return result, nil
+	}
+	deleted, err := s.deleteFindingActiveLinks(ctx, payload.Finding)
+	if err != nil {
+		return ports.ProjectionResult{}, err
+	}
+	result.LinksDeleted += deleted
 	return result, nil
 }
 
@@ -367,7 +378,23 @@ func (s *Service) deleteFindingAnchor(ctx context.Context, finding workflowevent
 	if err := deleter.DeleteProjectedEntity(ctx, findingURN(strings.TrimSpace(finding.TenantID), strings.TrimSpace(finding.FindingID))); err != nil {
 		return ports.ProjectionResult{}, err
 	}
-	return ports.ProjectionResult{}, nil
+	result := ports.ProjectionResult{EntitiesDeleted: 1}
+	if cleaner, ok := s.graph.(ports.ProjectionCleaner); ok {
+		cleanup, err := cleaner.CleanupProjectedEntities(ctx, ports.ProjectionCleanupRequest{
+			TenantID:     strings.TrimSpace(finding.TenantID),
+			SourceID:     strings.TrimSpace(finding.SourceSystem),
+			FindingID:    strings.TrimSpace(finding.FindingID),
+			EntityTypes:  []string{annotationEntityType, ticketEntityType, evidenceEntityType, decisionEntityType, actionEntityType, outcomeEntityType},
+			OnlyIsolated: true,
+			Limit:        1000,
+		})
+		if err != nil {
+			return ports.ProjectionResult{}, err
+		}
+		result.EntitiesDeleted += cleanup.EntitiesDeleted
+		result.LinksDeleted += cleanup.LinksDeleted
+	}
+	return result, nil
 }
 
 func findingStatusProjectsToGraph(status string) bool {
@@ -375,11 +402,29 @@ func findingStatusProjectsToGraph(status string) bool {
 	return normalized == "" || normalized == "open"
 }
 
-func findingStatusPrunesGraph(reason string) bool {
-	return strings.Contains(strings.ToLower(strings.TrimSpace(reason)), "no longer emitted")
+func (s *Service) ensureFindingAnchor(ctx context.Context, finding workflowevents.FindingSnapshot, result *ports.ProjectionResult) ([]string, error) {
+	if err := s.ensureFindingEntity(ctx, finding, result); err != nil {
+		return nil, err
+	}
+	if err := s.ensureFindingActiveLinks(ctx, finding, result); err != nil {
+		return nil, err
+	}
+	return findingTargetURNs(finding), nil
 }
 
-func (s *Service) ensureFindingAnchor(ctx context.Context, finding workflowevents.FindingSnapshot, result *ports.ProjectionResult) ([]string, error) {
+func (s *Service) ensureFindingForWorkflow(ctx context.Context, finding workflowevents.FindingSnapshot, result *ports.ProjectionResult) ([]string, error) {
+	if err := s.ensureFindingEntity(ctx, finding, result); err != nil {
+		return nil, err
+	}
+	if findingStatusProjectsToGraph(finding.Status) {
+		if err := s.ensureFindingActiveLinks(ctx, finding, result); err != nil {
+			return nil, err
+		}
+	}
+	return findingTargetURNs(finding), nil
+}
+
+func (s *Service) ensureFindingEntity(ctx context.Context, finding workflowevents.FindingSnapshot, result *ports.ProjectionResult) error {
 	tenantID := strings.TrimSpace(finding.TenantID)
 	sourceID := strings.TrimSpace(finding.SourceSystem)
 	anchorURN := findingURN(tenantID, finding.FindingID)
@@ -391,8 +436,15 @@ func (s *Service) ensureFindingAnchor(ctx context.Context, finding workflowevent
 		Label:      graphEntityLabel(finding.Title),
 		Attributes: findingAnchorAttributes(finding),
 	}, result); err != nil {
-		return nil, err
+		return err
 	}
+	return nil
+}
+
+func (s *Service) ensureFindingActiveLinks(ctx context.Context, finding workflowevents.FindingSnapshot, result *ports.ProjectionResult) error {
+	tenantID := strings.TrimSpace(finding.TenantID)
+	sourceID := strings.TrimSpace(finding.SourceSystem)
+	anchorURN := findingURN(tenantID, finding.FindingID)
 	resourceURNs := normalizeIDs(finding.ResourceURNs)
 	for _, resourceURN := range resourceURNs {
 		if err := s.upsertLink(ctx, &ports.ProjectedLink{
@@ -403,10 +455,38 @@ func (s *Service) ensureFindingAnchor(ctx context.Context, finding workflowevent
 			Relation:   relationHasFinding,
 			Attributes: findingAnchorLinkAttributes(finding),
 		}, result); err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return normalizeIDs(append(resourceURNs, anchorURN)), nil
+	return nil
+}
+
+func (s *Service) deleteFindingActiveLinks(ctx context.Context, finding workflowevents.FindingSnapshot) (uint32, error) {
+	deleter, ok := s.graph.(ports.ProjectionLinkDeleter)
+	if !ok {
+		return 0, nil
+	}
+	tenantID := strings.TrimSpace(finding.TenantID)
+	sourceID := strings.TrimSpace(finding.SourceSystem)
+	anchorURN := findingURN(tenantID, finding.FindingID)
+	var deleted uint32
+	for _, resourceURN := range normalizeIDs(finding.ResourceURNs) {
+		if err := deleter.DeleteProjectedLink(ctx, &ports.ProjectedLink{
+			TenantID: tenantID,
+			SourceID: sourceID,
+			FromURN:  resourceURN,
+			ToURN:    anchorURN,
+			Relation: relationHasFinding,
+		}); err != nil {
+			return deleted, err
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
+func findingTargetURNs(finding workflowevents.FindingSnapshot) []string {
+	return normalizeIDs(append(normalizeIDs(finding.ResourceURNs), findingURN(strings.TrimSpace(finding.TenantID), finding.FindingID)))
 }
 
 func (s *Service) upsertEntity(ctx context.Context, entity *ports.ProjectedEntity, result *ports.ProjectionResult) error {

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -239,6 +239,9 @@ func (s *Service) projectFindingRecorded(ctx context.Context, event *cerebrov1.E
 		return ports.ProjectionResult{}, err
 	}
 	result := ports.ProjectionResult{}
+	if !findingStatusProjectsToGraph(payload.Finding.Status) {
+		return result, nil
+	}
 	if _, err := s.ensureFindingAnchor(ctx, payload.Finding, &result); err != nil {
 		return ports.ProjectionResult{}, err
 	}
@@ -347,10 +350,33 @@ func (s *Service) projectFindingStatus(ctx context.Context, event *cerebrov1.Eve
 		return ports.ProjectionResult{}, err
 	}
 	result := ports.ProjectionResult{}
+	if !findingStatusProjectsToGraph(payload.Finding.Status) && findingStatusPrunesGraph(payload.Reason) {
+		return s.deleteFindingAnchor(ctx, payload.Finding)
+	}
 	if _, err := s.ensureFindingAnchor(ctx, payload.Finding, &result); err != nil {
 		return ports.ProjectionResult{}, err
 	}
 	return result, nil
+}
+
+func (s *Service) deleteFindingAnchor(ctx context.Context, finding workflowevents.FindingSnapshot) (ports.ProjectionResult, error) {
+	deleter, ok := s.graph.(ports.ProjectionEntityDeleter)
+	if !ok {
+		return ports.ProjectionResult{}, nil
+	}
+	if err := deleter.DeleteProjectedEntity(ctx, findingURN(strings.TrimSpace(finding.TenantID), strings.TrimSpace(finding.FindingID))); err != nil {
+		return ports.ProjectionResult{}, err
+	}
+	return ports.ProjectionResult{}, nil
+}
+
+func findingStatusProjectsToGraph(status string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	return normalized == "" || normalized == "open"
+}
+
+func findingStatusPrunesGraph(reason string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(reason)), "no longer emitted")
 }
 
 func (s *Service) ensureFindingAnchor(ctx context.Context, finding workflowevents.FindingSnapshot, result *ports.ProjectionResult) ([]string, error) {

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -41,6 +41,61 @@ func (r *projectionRecorder) DeleteProjectedEntity(_ context.Context, urn string
 	return nil
 }
 
+func (r *projectionRecorder) DeleteProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	delete(r.links, link.FromURN+"|"+link.Relation+"|"+link.ToURN)
+	return nil
+}
+
+func (r *projectionRecorder) CleanupProjectedEntities(_ context.Context, request ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
+	allowed := map[string]struct{}{}
+	for _, entityType := range request.EntityTypes {
+		allowed[entityType] = struct{}{}
+	}
+	result := ports.ProjectionCleanupResult{}
+	for urn, entity := range r.entities {
+		if entity == nil {
+			continue
+		}
+		if request.TenantID != "" && entity.TenantID != request.TenantID {
+			continue
+		}
+		if request.SourceID != "" && entity.SourceID != request.SourceID {
+			continue
+		}
+		if request.FindingID != "" && entity.Attributes["finding_id"] != request.FindingID {
+			continue
+		}
+		if len(allowed) != 0 {
+			if _, ok := allowed[entity.EntityType]; !ok {
+				continue
+			}
+		}
+		if request.OnlyIsolated && request.FindingID == "" && projectionEntityHasLinks(r.links, urn) {
+			continue
+		}
+		delete(r.entities, urn)
+		for key, link := range r.links {
+			if link.FromURN == urn || link.ToURN == urn {
+				delete(r.links, key)
+			}
+		}
+		result.EntitiesDeleted++
+	}
+	return result, nil
+}
+
+func projectionEntityHasLinks(links map[string]*ports.ProjectedLink, urn string) bool {
+	for _, link := range links {
+		if link.FromURN == urn || link.ToURN == urn {
+			return true
+		}
+	}
+	return false
+}
+
 func TestProjectKnowledgeWorkflowEvents(t *testing.T) {
 	graph := &projectionRecorder{}
 	service := New(graph)
@@ -223,10 +278,31 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	}
 
 	finding.Status = "resolved"
+	manualStatusEvent, err := workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{
+		Finding:     finding,
+		Status:      "resolved",
+		Reason:      "verified remediation",
+		UpdatedAt:   "2026-04-27T12:45:00Z",
+		OutcomeType: "finding-resolution",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingStatusChangedEvent(manual) error = %v", err)
+	}
+	if _, err := service.Project(context.Background(), manualStatusEvent); err != nil {
+		t.Fatalf("Project(manual status) error = %v", err)
+	}
+	if _, ok := graph.entities["urn:cerebro:writer:finding:finding-1"]; !ok {
+		t.Fatal("manually resolved finding anchor should remain for workflow history")
+	}
+	if _, ok := graph.links["urn:cerebro:writer:okta_resource:policyrule:pol-1|has_finding|urn:cerebro:writer:finding:finding-1"]; ok {
+		t.Fatal("manually resolved finding should not keep active has_finding link")
+	}
+
+	finding.Status = "resolved"
 	statusEvent, err := workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{
 		Finding:     finding,
 		Status:      "resolved",
-		Reason:      "No longer emitted by latest rule evaluation.",
+		Reason:      workflowevents.FindingStatusReasonNoLongerEmitted,
 		UpdatedAt:   "2026-04-27T13:00:00Z",
 		OutcomeType: "finding-resolution",
 	})
@@ -242,6 +318,9 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	if _, ok := graph.links["urn:cerebro:writer:okta_resource:policyrule:pol-1|has_finding|urn:cerebro:writer:finding:finding-1"]; ok {
 		t.Fatal("resolved finding has_finding link should be pruned from graph")
 	}
+	if _, ok := graph.entities[annotationURN]; ok {
+		t.Fatal("isolated finding note annotation should be pruned from graph")
+	}
 }
 
 func cloneProjectedEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
@@ -253,6 +332,7 @@ func cloneProjectedEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity 
 		URN:        entity.URN,
 		TenantID:   entity.TenantID,
 		SourceID:   entity.SourceID,
+		RuntimeID:  entity.RuntimeID,
 		EntityType: entity.EntityType,
 		Label:      entity.Label,
 		Attributes: attributes,
@@ -267,6 +347,7 @@ func cloneProjectedLink(link *ports.ProjectedLink) *ports.ProjectedLink {
 	return &ports.ProjectedLink{
 		TenantID:   link.TenantID,
 		SourceID:   link.SourceID,
+		RuntimeID:  link.RuntimeID,
 		FromURN:    link.FromURN,
 		ToURN:      link.ToURN,
 		Relation:   link.Relation,

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -31,6 +31,16 @@ func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.
 	return nil
 }
 
+func (r *projectionRecorder) DeleteProjectedEntity(_ context.Context, urn string) error {
+	delete(r.entities, urn)
+	for key, link := range r.links {
+		if link.FromURN == urn || link.ToURN == urn {
+			delete(r.links, key)
+		}
+	}
+	return nil
+}
+
 func TestProjectKnowledgeWorkflowEvents(t *testing.T) {
 	graph := &projectionRecorder{}
 	service := New(graph)
@@ -210,6 +220,27 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	}
 	if _, ok := graph.links["urn:cerebro:writer:okta_resource:policyrule:pol-1|has_finding|urn:cerebro:writer:finding:finding-1"]; !ok {
 		t.Fatal("resource finding link missing")
+	}
+
+	finding.Status = "resolved"
+	statusEvent, err := workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{
+		Finding:     finding,
+		Status:      "resolved",
+		Reason:      "No longer emitted by latest rule evaluation.",
+		UpdatedAt:   "2026-04-27T13:00:00Z",
+		OutcomeType: "finding-resolution",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingStatusChangedEvent() error = %v", err)
+	}
+	if _, err := service.Project(context.Background(), statusEvent); err != nil {
+		t.Fatalf("Project(status) error = %v", err)
+	}
+	if _, ok := graph.entities["urn:cerebro:writer:finding:finding-1"]; ok {
+		t.Fatal("resolved finding anchor should be pruned from graph")
+	}
+	if _, ok := graph.links["urn:cerebro:writer:okta_resource:policyrule:pol-1|has_finding|urn:cerebro:writer:finding:finding-1"]; ok {
+		t.Fatal("resolved finding has_finding link should be pruned from graph")
 	}
 }
 

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -1013,7 +1013,7 @@ func auditEvent(settings settings, record auditRecord) (*primitives.Event, error
 		OccurredAt: timestamppb.New(occurredAt),
 		SchemaRef:  "okta/audit/v1",
 		Payload:    payload,
-		Attributes: auditAttributes(settings, record, actor, resourceID, resourceType),
+		Attributes: auditAttributes(settings, record, actor, targets, resourceID, resourceType),
 	}, nil
 }
 
@@ -1235,7 +1235,7 @@ func oktaPullFromRecordsWithCursor[T any](records []T, next string, build func(T
 	return pull, nil
 }
 
-func auditAttributes(settings settings, record auditRecord, actor identityPayload, resourceID string, resourceType string) map[string]string {
+func auditAttributes(settings settings, record auditRecord, actor identityPayload, targets []identityPayload, resourceID string, resourceType string) map[string]string {
 	attributes := map[string]string{
 		"domain":        settings.domain,
 		"event_type":    record.EventType,
@@ -1248,10 +1248,29 @@ func auditAttributes(settings settings, record auditRecord, actor identityPayloa
 	addAttribute(attributes, "actor_alternate_id", actor.AlternateID)
 	addAttribute(attributes, "actor_display_name", actor.DisplayName)
 	addAttribute(attributes, "client_ip", stringMap(record.Client, "ipAddress"))
+	addAttribute(attributes, "client_user_agent", stringMap(nestedMap(record.Client, "userAgent"), "rawUserAgent"))
+	addAttribute(attributes, "client_zone", stringMap(record.Client, "zone"))
 	addAttribute(attributes, "outcome_reason", stringMap(record.Outcome, "reason"))
 	addAttribute(attributes, "outcome_result", stringMap(record.Outcome, "result"))
 	addAttribute(attributes, "severity", record.Severity)
 	addAttribute(attributes, "transaction_id", stringMap(record.Transaction, "id"))
+	if len(targets) != 0 {
+		target := targets[0]
+		addAttribute(attributes, "target_id", target.ID)
+		addAttribute(attributes, "target_type", target.Type)
+		addAttribute(attributes, "target_alternate_id", target.AlternateID)
+		addAttribute(attributes, "target_display_name", target.DisplayName)
+	}
+	if category := oktaOAuthEventCategory(record.EventType); category != "" {
+		attributes["oauth_event_category"] = category
+		addAttribute(attributes, "grant_type", oktaOAuthGrantType(record.EventType))
+		if client := oktaOAuthClientIdentity(actor, targets); client != (identityPayload{}) {
+			addAttribute(attributes, "oauth_client_id", client.ID)
+			addAttribute(attributes, "oauth_client_type", client.Type)
+			addAttribute(attributes, "oauth_client_label", firstNonEmpty(client.DisplayName, client.AlternateID, client.ID))
+			addAttribute(attributes, "client_id", client.ID)
+		}
+	}
 	return attributes
 }
 
@@ -1363,6 +1382,68 @@ func adminRoleAttributes(settings settings, record adminRoleRecord) map[string]s
 	addAttribute(attributes, "status", record.Status)
 	addAttribute(attributes, "assignment_type", record.AssignmentType)
 	return attributes
+}
+
+func oktaOAuthEventCategory(eventType string) string {
+	action := strings.ToLower(strings.TrimSpace(eventType))
+	switch action {
+	case "app.oauth2.authorize.code", "app.oauth2.as.authorize.code":
+		return "runtime_grant"
+	}
+	if strings.HasPrefix(action, "app.oauth2.token.grant.") ||
+		strings.HasPrefix(action, "app.oauth2.as.token.grant.") {
+		return "runtime_grant"
+	}
+	if containsAny(action, "api_token", "client_secret", "client.secret", "domain_wide", "domain-wide") &&
+		containsAny(action, "create", "authorize", "grant", "add", "rotate", "generate") {
+		return "credential_change"
+	}
+	if containsAny(action, "oauth", "api_client", "client_access", "application") &&
+		containsAny(action, "create", "add") {
+		return "credential_change"
+	}
+	return ""
+}
+
+func oktaOAuthGrantType(eventType string) string {
+	action := strings.ToLower(strings.TrimSpace(eventType))
+	switch {
+	case strings.Contains(action, "authorize.code"):
+		return "authorization_code"
+	case strings.HasSuffix(action, ".access_token"):
+		return "access_token"
+	case strings.HasSuffix(action, ".id_token"):
+		return "id_token"
+	default:
+		return ""
+	}
+}
+
+func oktaOAuthClientIdentity(actor identityPayload, targets []identityPayload) identityPayload {
+	if oktaOAuthClientLike(actor) {
+		return actor
+	}
+	for _, target := range targets {
+		if oktaOAuthClientLike(target) {
+			return target
+		}
+	}
+	return identityPayload{}
+}
+
+func oktaOAuthClientLike(identity identityPayload) bool {
+	id := strings.TrimSpace(identity.ID)
+	kind := strings.ToLower(strings.TrimSpace(identity.Type))
+	return id != "" && (strings.Contains(kind, "clientapp") || strings.Contains(kind, "application") || strings.HasSuffix(kind, "app") || strings.HasPrefix(id, "0oa"))
+}
+
+func containsAny(value string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 func userTimestamps(record userRecord) *userTimestampsPayload {

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -243,6 +244,56 @@ func TestCheckDiscoverAndReadLiveOktaAuditPreview(t *testing.T) {
 	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "evt-2" {
 		t.Fatalf("second.Checkpoint = %#v, want evt-2", second.Checkpoint)
 	}
+}
+
+func TestAuditEventNormalizesOAuthRuntimeGrantTelemetry(t *testing.T) {
+	published := mustParseTime(t, "2026-05-07T19:54:46Z")
+	event, err := auditEvent(settings{domain: "writer.okta.com"}, auditRecord{
+		UUID:      "evt-oauth",
+		Published: published,
+		EventType: "app.oauth2.token.grant.access_token",
+		Actor: map[string]any{
+			"id":          "0oa-client",
+			"type":        "PublicClientApp",
+			"displayName": "Production Client",
+		},
+		Client: map[string]any{
+			"ipAddress": "203.0.113.10",
+			"userAgent": map[string]any{"rawUserAgent": "OktaAuth/1.0"},
+		},
+		Outcome: map[string]any{"result": "SUCCESS"},
+		Target: []map[string]any{{
+			"id":          "00u-user",
+			"type":        "User",
+			"alternateId": "user@writer.com",
+		}},
+		raw: json.RawMessage(`{"uuid":"evt-oauth"}`),
+	})
+	if err != nil {
+		t.Fatalf("auditEvent() error = %v", err)
+	}
+	attrs := event.Attributes
+	for key, want := range map[string]string{
+		"oauth_event_category": "runtime_grant",
+		"grant_type":           "access_token",
+		"oauth_client_id":      "0oa-client",
+		"client_id":            "0oa-client",
+		"target_id":            "00u-user",
+		"client_user_agent":    "OktaAuth/1.0",
+	} {
+		if got := attrs[key]; got != want {
+			t.Fatalf("attribute %s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", value, err)
+	}
+	return parsed
 }
 
 func TestCheckDiscoverAndReadLiveOktaUserPreview(t *testing.T) {


### PR DESCRIPTION
## Summary
- Tighten finding rules to reduce noisy false positives across runtime, cloud, GitHub, identity, data, Dependabot, and Okta signals.
- Add runtime-scoped graph projection ownership and cleanup boundaries for stale finding artifacts.
- Add release automation safeguards: main-push CI, strict release tag workflow, stronger release validation, and stamped runtime images.
- Add tests for pruning behavior, rule matching, projection runtime ownership, Neo4j cleanup, and Okta outcomes.

## Validation
- actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/cut-release.yml
- make verify
- go test ./...
- make lint
- make proto-lint
- go build ./...
- git diff --check