### PR TITLE
ci: configure release tag identity

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -50,5 +50,7 @@ jobs:
             exit 1
           fi
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
           git push origin "refs/tags/${RELEASE_TAG}"


### PR DESCRIPTION
## Summary
- Configure the Cut Release workflow's local git identity before creating annotated tags.
- Fixes the v2.1.1 tag workflow failure where git could not infer a committer identity.

## Validation
- actionlint -shellcheck= .github/workflows/cut-release.yml
- make verify
- git diff --check