### PR TITLE
fix: address pruning release feedback

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -9,6 +9,7 @@ on:
         type: string
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:
@@ -33,6 +34,7 @@ jobs:
       - name: Create release tag
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
@@ -54,3 +56,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
           git push origin "refs/tags/${RELEASE_TAG}"
+          gh workflow run "Release" --ref main -f "release_tag=${RELEASE_TAG}"

--- a/internal/findings/github_audit_signal_rule_test.go
+++ b/internal/findings/github_audit_signal_rule_test.go
@@ -54,6 +54,20 @@ func TestGitHubRepositoryRulesetModifiedRequiresWeakeningSignal(t *testing.T) {
 		t.Fatalf("len(active update records) = %d, want 0", len(records))
 	}
 
+	event = githubAuditEvent("github-ruleset-check-removed", map[string]string{
+		"action":                        "repository_ruleset.update",
+		"enforcement":                   "active",
+		"required_status_check_removed": "true",
+		"repo":                          "writer/cerebro",
+	})
+	records, err = rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate(required status check removed) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(required status check removed records) = %d, want 1", len(records))
+	}
+
 	event = githubAuditEvent("github-ruleset-disabled", map[string]string{
 		"action":      "repository_ruleset.update",
 		"enforcement": "disabled",

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -102,7 +102,7 @@ func (s *Service) projectFindingTicket(ctx context.Context, finding *ports.Findi
 	return s.recordAndProjectWorkflowEvent(ctx, event)
 }
 
-func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *ports.FindingRecord) error {
+func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *ports.FindingRecord, statusSource string) error {
 	if s == nil || s.graph == nil || finding == nil {
 		return nil
 	}
@@ -116,7 +116,7 @@ func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *port
 	if status == findingStatusSuppressed {
 		decisionType = "finding-suppression"
 	}
-	pruneGraph := workflowevents.FindingStatusPrunesGraph(status, finding.StatusReason)
+	pruneGraph := workflowevents.FindingStatusPrunesGraph(status, statusSource)
 	decisionID := ""
 	outcomeID := ""
 	if !pruneGraph {
@@ -127,6 +127,7 @@ func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *port
 		Finding:     findingWorkflowSnapshot(finding, tenantID, sourceID),
 		Status:      status,
 		Reason:      strings.TrimSpace(finding.StatusReason),
+		Source:      strings.TrimSpace(statusSource),
 		UpdatedAt:   finding.StatusUpdatedAt.UTC().Format(time.RFC3339Nano),
 		DecisionID:  decisionID,
 		OutcomeID:   outcomeID,

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -309,10 +309,11 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 			}
 		}
 	}
-	if err := s.finishCompletedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings)); err != nil {
-		return nil, err
-	}
 	if err := s.resolveStaleOpenFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), runtimeID, rule.Spec().GetId(), evaluatedEventIDs, emittedFindingIDs); err != nil {
+		evaluationErr := fmt.Errorf("resolve stale findings for rule %q: %w", result.Rule.GetId(), err)
+		return nil, s.finishFailedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings), evaluationErr)
+	}
+	if err := s.finishCompletedRun(ctx, run, result.EventsEvaluated, findingIDs(result.Findings)); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -436,10 +437,11 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 		if state.failed {
 			continue
 		}
-		if err := s.finishCompletedRun(ctx, state.result.Run, state.eventsEvaluated, findingIDs(state.result.Findings)); err != nil {
-			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), err)
-		}
 		if err := s.resolveStaleOpenFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), runtimeID, state.result.Rule.GetId(), evaluatedEventIDs, state.emittedFindingIDs); err != nil {
+			evaluationErr := fmt.Errorf("resolve stale findings for rule %q: %w", state.result.Rule.GetId(), err)
+			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), evaluationErr)
+		}
+		if err := s.finishCompletedRun(ctx, state.result.Run, state.eventsEvaluated, findingIDs(state.result.Findings)); err != nil {
 			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), err)
 		}
 	}
@@ -509,7 +511,7 @@ func (s *Service) resolveStaleOpenFindings(ctx context.Context, tenantID string,
 		if err != nil {
 			return fmt.Errorf("resolve stale finding %q: %w", strings.TrimSpace(finding.ID), err)
 		}
-		if err := s.recordFindingStatusWorkflow(ctx, updated); err != nil {
+		if err := s.recordFindingStatusWorkflow(ctx, updated, workflowevents.FindingStatusSourceStaleEvaluation); err != nil {
 			return fmt.Errorf("project stale finding %q resolution: %w", strings.TrimSpace(finding.ID), err)
 		}
 	}
@@ -842,7 +844,7 @@ func (s *Service) updateFindingStatus(ctx context.Context, id string, status str
 	if err != nil {
 		return nil, fmt.Errorf("update finding %q status to %q: %w", findingID, status, err)
 	}
-	if err := s.recordFindingStatusWorkflow(ctx, finding); err != nil {
+	if err := s.recordFindingStatusWorkflow(ctx, finding, ""); err != nil {
 		return nil, fmt.Errorf("record finding %q status workflow: %w", findingID, err)
 	}
 	return finding, nil

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -63,6 +63,7 @@ func (s *recordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnv
 type stubFindingStore struct {
 	findings         map[string]*ports.FindingRecord
 	request          ports.ListFindingsRequest
+	listFindingsErr  error
 	claims           map[string]*ports.ClaimRecord
 	claimListRequest ports.ListClaimsRequest
 	runs             map[string]*cerebrov1.FindingEvaluationRun
@@ -102,6 +103,9 @@ func (s *stubFindingStore) GetFinding(_ context.Context, id string) (*ports.Find
 
 func (s *stubFindingStore) ListFindings(_ context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
 	s.request = request
+	if s.listFindingsErr != nil {
+		return nil, s.listFindingsErr
+	}
 	findings := []*ports.FindingRecord{}
 	for _, finding := range s.findings {
 		if !findingMatches(request, finding) {
@@ -927,6 +931,53 @@ func TestEvaluateSourceRuntimeResolvesAndPrunesStaleFindings(t *testing.T) {
 	}
 }
 
+func TestEvaluateSourceRuntimeMarksRunFailedWhenStaleCleanupFails(t *testing.T) {
+	registry, err := NewRegistry(&emittingRule{
+		spec:               &cerebrov1.RuleSpec{Id: "routine-oauth-rule", Name: "Routine OAuth Rule"},
+		supportedSourceIDs: map[string]struct{}{"okta": {}},
+		triggerEventID:     "different-event",
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{listFindingsErr: errors.New("list stale candidates failed")}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		&stubReplayer{events: []*cerebrov1.EventEnvelope{{
+			Id:         "okta-oauth-grant",
+			TenantId:   "writer",
+			SourceId:   "okta",
+			Kind:       "okta.audit",
+			OccurredAt: timestamppb.New(time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC)),
+		}}},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	_, err = service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
+		RuntimeID: "writer-okta-audit",
+		RuleID:    "routine-oauth-rule",
+	})
+	if err == nil {
+		t.Fatal("EvaluateSourceRuntime() error = nil, want stale cleanup error")
+	}
+	run, ok := runForRule(store.runs, "routine-oauth-rule")
+	if !ok {
+		t.Fatal("routine-oauth-rule run missing")
+	}
+	if got := run.GetStatus(); got != "failed" {
+		t.Fatalf("run status = %q, want failed", got)
+	}
+	if got := run.GetError(); !strings.Contains(got, "list stale candidates failed") {
+		t.Fatalf("run error = %q, want stale cleanup error", got)
+	}
+}
+
 func TestEvaluateSourceRuntimeFindingsRequiresAvailableDependencies(t *testing.T) {
 	service := New(nil, nil, nil, nil, nil, nil)
 	if _, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{RuntimeID: "writer-okta-audit"}); !errors.Is(err, ErrRuntimeUnavailable) {
@@ -1523,6 +1574,57 @@ func TestEvaluateSourceRuntimeRulesMarksUnfinishedRunsFailedWhenCompletionFails(
 	}
 }
 
+func TestEvaluateSourceRuntimeRulesMarksUnfinishedRunsFailedWhenStaleCleanupFails(t *testing.T) {
+	registry, err := NewRegistry(
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-a", Name: "Rule A"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "rule-b", Name: "Rule B"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{listFindingsErr: errors.New("stale cleanup unavailable")}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		&stubReplayer{events: []*cerebrov1.EventEnvelope{{
+			Id:         "okta-audit-1",
+			TenantId:   "writer",
+			SourceId:   "okta",
+			Kind:       "okta.audit",
+			OccurredAt: timestamppb.New(time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC)),
+		}}},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	_, err = service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "writer-okta-audit"})
+	if err == nil {
+		t.Fatal("EvaluateSourceRuntimeRules() error = nil, want stale cleanup error")
+	}
+	for _, ruleID := range []string{"rule-a", "rule-b"} {
+		run, ok := runForRule(store.runs, ruleID)
+		if !ok {
+			t.Fatalf("%s run missing", ruleID)
+		}
+		if got := run.GetStatus(); got != "failed" {
+			t.Fatalf("%s run status = %q, want failed", ruleID, got)
+		}
+		if got := run.GetError(); !strings.Contains(got, "stale cleanup unavailable") {
+			t.Fatalf("%s run error = %q, want stale cleanup unavailable", ruleID, got)
+		}
+	}
+}
+
 func TestEvaluateSourceRuntimeRulesPreservesEarlierFailureWhenCompletionCleanupRuns(t *testing.T) {
 	registry, err := NewRegistry(
 		&emittingRule{
@@ -2088,7 +2190,7 @@ func TestResolveFindingBridgesDecisionAndOutcomeWhenGraphConfigured(t *testing.T
 	}
 	appendLog := &recordingAppendLog{}
 	service := New(nil, nil, store, store, store, store).WithGraphStore(graphStore).WithGraphQueryStore(graphStore).WithAppendLog(appendLog)
-	finding, err := service.ResolveFinding(context.Background(), "finding-1", "verified remediation")
+	finding, err := service.ResolveFinding(context.Background(), "finding-1", workflowevents.FindingStatusReasonNoLongerEmitted)
 	if err != nil {
 		t.Fatalf("ResolveFinding() error = %v", err)
 	}

--- a/internal/workflowevents/events.go
+++ b/internal/workflowevents/events.go
@@ -30,9 +30,13 @@ const (
 	EventAttributeOutcomeID    = "outcome_id"
 	EventAttributeFindingID    = "finding_id"
 	EventAttributeSourceEvent  = "source_event_id"
+	EventAttributeStatusSource = "status_source"
 )
 
-const FindingStatusReasonNoLongerEmitted = "No longer emitted by latest rule evaluation."
+const (
+	FindingStatusReasonNoLongerEmitted = "No longer emitted by latest rule evaluation."
+	FindingStatusSourceStaleEvaluation = "stale_rule_evaluation"
+)
 
 const (
 	SchemaKnowledgeDecisionRecorded = "urn:cerebro:events/workflow.knowledge.decision_recorded/v1"
@@ -65,9 +69,9 @@ type DecisionRecorded struct {
 }
 
 // FindingStatusPrunesGraph reports whether one status transition should remove ephemeral finding graph anchors.
-func FindingStatusPrunesGraph(status string, reason string) bool {
+func FindingStatusPrunesGraph(status string, source string) bool {
 	return strings.EqualFold(strings.TrimSpace(status), "resolved") &&
-		strings.EqualFold(strings.TrimSpace(reason), FindingStatusReasonNoLongerEmitted)
+		strings.EqualFold(strings.TrimSpace(source), FindingStatusSourceStaleEvaluation)
 }
 
 // ActionRecorded captures one durable workflow action event payload.
@@ -171,6 +175,7 @@ type FindingStatusChanged struct {
 	Finding     FindingSnapshot `json:"finding"`
 	Status      string          `json:"status"`
 	Reason      string          `json:"reason,omitempty"`
+	Source      string          `json:"source,omitempty"`
 	UpdatedAt   string          `json:"updated_at"`
 	DecisionID  string          `json:"decision_id,omitempty"`
 	OutcomeID   string          `json:"outcome_id,omitempty"`
@@ -237,6 +242,7 @@ func NewFindingStatusChangedEvent(payload FindingStatusChanged) (*cerebrov1.Even
 		EventAttributeFindingID:    payload.Finding.FindingID,
 		EventAttributeDecisionID:   payload.DecisionID,
 		EventAttributeOutcomeID:    payload.OutcomeID,
+		EventAttributeStatusSource: payload.Source,
 	})
 }
 

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -350,7 +350,7 @@ func (s *Service) projectFindingStatus(ctx context.Context, event *cerebrov1.Eve
 		return ports.ProjectionResult{}, err
 	}
 	result := ports.ProjectionResult{}
-	if workflowevents.FindingStatusPrunesGraph(payload.Finding.Status, payload.Reason) {
+	if workflowevents.FindingStatusPrunesGraph(payload.Finding.Status, payload.Source) {
 		return s.deleteFindingAnchor(ctx, payload.Finding)
 	}
 	if err := s.ensureFindingEntity(ctx, payload.Finding, &result); err != nil {

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -281,7 +281,7 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	manualStatusEvent, err := workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{
 		Finding:     finding,
 		Status:      "resolved",
-		Reason:      "verified remediation",
+		Reason:      workflowevents.FindingStatusReasonNoLongerEmitted,
 		UpdatedAt:   "2026-04-27T12:45:00Z",
 		OutcomeType: "finding-resolution",
 	})
@@ -303,6 +303,7 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 		Finding:     finding,
 		Status:      "resolved",
 		Reason:      workflowevents.FindingStatusReasonNoLongerEmitted,
+		Source:      workflowevents.FindingStatusSourceStaleEvaluation,
 		UpdatedAt:   "2026-04-27T13:00:00Z",
 		OutcomeType: "finding-resolution",
 	})

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -250,13 +250,22 @@ func auditAttributes(entry *gogithub.AuditEntry, raw map[string]any, settings se
 
 var auditAdditionalAttributeKeys = []string{
 	"branch",
+	"bypass_actor_added",
+	"change_type",
+	"changes",
+	"deletions_allowed",
+	"enforcement",
+	"force_pushes_allowed",
 	"hook_id",
 	"integration",
 	"name",
+	"new_enforcement",
 	"number",
 	"permission",
 	"previous_visibility",
 	"repository_public",
+	"required_review_removed",
+	"required_status_check_removed",
 	"ruleset_enforcement",
 	"ruleset_id",
 	"ruleset_name",
@@ -329,6 +338,12 @@ func rawScalarString(raw map[string]any, key string) string {
 		return strconv.Itoa(typed)
 	case int64:
 		return strconv.FormatInt(typed, 10)
+	case map[string]any, []any:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return ""
+		}
+		return string(encoded)
 	default:
 		return ""
 	}

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -335,6 +335,30 @@ func TestAuditScopeKeepsOwnerBackedEntriesAtOrganizationScope(t *testing.T) {
 	}
 }
 
+func TestAuditAttributesForwardRulesetWeakeningMetadata(t *testing.T) {
+	attributes := auditAttributes(&gogithub.AuditEntry{
+		Action: gogithub.String("repository_ruleset.update"),
+	}, map[string]any{
+		"repo":                          "writer/cerebro",
+		"ruleset_enforcement":           "active",
+		"required_status_check_removed": true,
+		"bypass_actor_added":            true,
+		"changes": map[string]any{
+			"required_status_checks": "removed",
+		},
+	}, settings{owner: "writer"})
+
+	if got := attributes["required_status_check_removed"]; got != "true" {
+		t.Fatalf("required_status_check_removed = %q, want true", got)
+	}
+	if got := attributes["bypass_actor_added"]; got != "true" {
+		t.Fatalf("bypass_actor_added = %q, want true", got)
+	}
+	if got := attributes["changes"]; !strings.Contains(got, "required_status_checks") {
+		t.Fatalf("changes = %q, want encoded ruleset changes", got)
+	}
+}
+
 func TestCheckDiscoverAndReadLiveGitHubDependabotAlertPreview(t *testing.T) {
 	server := httptest.NewServer(newGitHubAPIHandler(t))
 	defer server.Close()


### PR DESCRIPTION
## Summary
- Dispatch the Release workflow explicitly after Cut Release creates a tag, since GITHUB_TOKEN tag pushes do not trigger push workflows.
- Forward GitHub ruleset weakening audit metadata into event attributes and cover required-check removal detection.
- Mark finding evaluation runs failed when stale cleanup fails, before recording completion.
- Replace reason-string pruning control with a structured stale-evaluation status source so manual resolves keep workflow history.

## Validation
- actionlint -shellcheck= .github/workflows/cut-release.yml
- go test ./internal/findings -run 'Test(GitHubRepositoryRulesetModifiedRequiresWeakeningSignal|EvaluateSourceRuntimeMarksRunFailedWhenStaleCleanupFails|EvaluateSourceRuntimeRulesMarksUnfinishedRunsFailedWhenStaleCleanupFails|ResolveFindingBridgesDecisionAndOutcomeWhenGraphConfigured|EvaluateSourceRuntimeResolvesAndPrunesStaleFindings)$' -count=1
- go test ./sources/github -run 'TestAuditAttributesForwardRulesetWeakeningMetadata' -count=1
- go test ./internal/workflowprojection -run 'TestProjectFindingWorkflowEvents' -count=1
- make verify
- git diff --check

Addresses feedback from #516.