### PR TITLE
fix: address missed release feedback

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -56,4 +56,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
           git push origin "refs/tags/${RELEASE_TAG}"
-          gh workflow run "Release" --ref main -f "release_tag=${RELEASE_TAG}"
+          gh workflow run "Release" --ref "${RELEASE_TAG}" -f "release_tag=${RELEASE_TAG}"

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -844,7 +844,7 @@ func (s *Service) updateFindingStatus(ctx context.Context, id string, status str
 	if err != nil {
 		return nil, fmt.Errorf("update finding %q status to %q: %w", findingID, status, err)
 	}
-	if err := s.recordFindingStatusWorkflow(ctx, finding, ""); err != nil {
+	if err := s.recordFindingStatusWorkflow(ctx, finding, workflowevents.FindingStatusSourceManual); err != nil {
 		return nil, fmt.Errorf("record finding %q status workflow: %w", findingID, err)
 	}
 	return finding, nil

--- a/internal/workflowevents/events.go
+++ b/internal/workflowevents/events.go
@@ -35,6 +35,7 @@ const (
 
 const (
 	FindingStatusReasonNoLongerEmitted = "No longer emitted by latest rule evaluation."
+	FindingStatusSourceManual          = "manual"
 	FindingStatusSourceStaleEvaluation = "stale_rule_evaluation"
 )
 
@@ -72,6 +73,13 @@ type DecisionRecorded struct {
 func FindingStatusPrunesGraph(status string, source string) bool {
 	return strings.EqualFold(strings.TrimSpace(status), "resolved") &&
 		strings.EqualFold(strings.TrimSpace(source), FindingStatusSourceStaleEvaluation)
+}
+
+// LegacyFindingStatusPrunesGraph preserves replay behavior for stale-resolution events emitted before status source existed.
+func LegacyFindingStatusPrunesGraph(status string, source string, reason string) bool {
+	return strings.TrimSpace(source) == "" &&
+		strings.EqualFold(strings.TrimSpace(status), "resolved") &&
+		strings.EqualFold(strings.TrimSpace(reason), FindingStatusReasonNoLongerEmitted)
 }
 
 // ActionRecorded captures one durable workflow action event payload.

--- a/internal/workflowevents/events.go
+++ b/internal/workflowevents/events.go
@@ -76,8 +76,10 @@ func FindingStatusPrunesGraph(status string, source string) bool {
 }
 
 // LegacyFindingStatusPrunesGraph preserves replay behavior for stale-resolution events emitted before status source existed.
-func LegacyFindingStatusPrunesGraph(status string, source string, reason string) bool {
+func LegacyFindingStatusPrunesGraph(status string, source string, reason string, decisionID string, outcomeID string) bool {
 	return strings.TrimSpace(source) == "" &&
+		strings.TrimSpace(decisionID) == "" &&
+		strings.TrimSpace(outcomeID) == "" &&
 		strings.EqualFold(strings.TrimSpace(status), "resolved") &&
 		strings.EqualFold(strings.TrimSpace(reason), FindingStatusReasonNoLongerEmitted)
 }

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -351,7 +351,7 @@ func (s *Service) projectFindingStatus(ctx context.Context, event *cerebrov1.Eve
 	}
 	result := ports.ProjectionResult{}
 	if workflowevents.FindingStatusPrunesGraph(payload.Finding.Status, payload.Source) ||
-		workflowevents.LegacyFindingStatusPrunesGraph(payload.Finding.Status, payload.Source, payload.Reason) {
+		workflowevents.LegacyFindingStatusPrunesGraph(payload.Finding.Status, payload.Source, payload.Reason, payload.DecisionID, payload.OutcomeID) {
 		return s.deleteFindingAnchor(ctx, payload.Finding)
 	}
 	if err := s.ensureFindingEntity(ctx, payload.Finding, &result); err != nil {

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -350,7 +350,8 @@ func (s *Service) projectFindingStatus(ctx context.Context, event *cerebrov1.Eve
 		return ports.ProjectionResult{}, err
 	}
 	result := ports.ProjectionResult{}
-	if workflowevents.FindingStatusPrunesGraph(payload.Finding.Status, payload.Source) {
+	if workflowevents.FindingStatusPrunesGraph(payload.Finding.Status, payload.Source) ||
+		workflowevents.LegacyFindingStatusPrunesGraph(payload.Finding.Status, payload.Source, payload.Reason) {
 		return s.deleteFindingAnchor(ctx, payload.Finding)
 	}
 	if err := s.ensureFindingEntity(ctx, payload.Finding, &result); err != nil {

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -300,6 +300,28 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	}
 
 	if _, err := service.Project(context.Background(), recordedEvent); err != nil {
+		t.Fatalf("Project(recorded legacy manual reset) error = %v", err)
+	}
+	legacyManualStatusEvent, err := workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{
+		Finding:     finding,
+		Status:      "resolved",
+		Reason:      workflowevents.FindingStatusReasonNoLongerEmitted,
+		DecisionID:  "urn:cerebro:writer:decision:finding-resolution",
+		OutcomeID:   "urn:cerebro:writer:outcome:finding-resolution",
+		UpdatedAt:   "2026-04-27T12:48:00Z",
+		OutcomeType: "finding-resolution",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingStatusChangedEvent(legacy manual) error = %v", err)
+	}
+	if _, err := service.Project(context.Background(), legacyManualStatusEvent); err != nil {
+		t.Fatalf("Project(legacy manual status) error = %v", err)
+	}
+	if _, ok := graph.entities["urn:cerebro:writer:finding:finding-1"]; !ok {
+		t.Fatal("legacy manual finding status with workflow IDs should keep finding anchor")
+	}
+
+	if _, err := service.Project(context.Background(), recordedEvent); err != nil {
 		t.Fatalf("Project(recorded legacy reset) error = %v", err)
 	}
 	legacyStatusEvent, err := workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -282,6 +282,7 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 		Finding:     finding,
 		Status:      "resolved",
 		Reason:      workflowevents.FindingStatusReasonNoLongerEmitted,
+		Source:      workflowevents.FindingStatusSourceManual,
 		UpdatedAt:   "2026-04-27T12:45:00Z",
 		OutcomeType: "finding-resolution",
 	})
@@ -298,6 +299,29 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 		t.Fatal("manually resolved finding should not keep active has_finding link")
 	}
 
+	if _, err := service.Project(context.Background(), recordedEvent); err != nil {
+		t.Fatalf("Project(recorded legacy reset) error = %v", err)
+	}
+	legacyStatusEvent, err := workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{
+		Finding:     finding,
+		Status:      "resolved",
+		Reason:      workflowevents.FindingStatusReasonNoLongerEmitted,
+		UpdatedAt:   "2026-04-27T12:50:00Z",
+		OutcomeType: "finding-resolution",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingStatusChangedEvent(legacy) error = %v", err)
+	}
+	if _, err := service.Project(context.Background(), legacyStatusEvent); err != nil {
+		t.Fatalf("Project(legacy status) error = %v", err)
+	}
+	if _, ok := graph.entities["urn:cerebro:writer:finding:finding-1"]; ok {
+		t.Fatal("legacy stale finding status should prune finding anchor")
+	}
+
+	if _, err := service.Project(context.Background(), recordedEvent); err != nil {
+		t.Fatalf("Project(recorded stale reset) error = %v", err)
+	}
 	finding.Status = "resolved"
 	statusEvent, err := workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{
 		Finding:     finding,


### PR DESCRIPTION
## Summary
- Dispatch Release from the freshly created tag ref instead of main.
- Preserve legacy stale-resolution replay pruning for status events emitted before status_source existed, while requiring missing workflow IDs so historical manual resolves keep workflow history.
- Mark manual finding status changes with a structured manual source.

## Validation
- actionlint -shellcheck= .github/workflows/cut-release.yml
- go test ./internal/workflowprojection -run 'TestProjectFindingWorkflowEvents' -count=1
- go test ./internal/findings -run 'TestResolveFindingBridgesDecisionAndOutcomeWhenGraphConfigured' -count=1
- make verify
- git diff --check

Addresses missed feedback from #518.