### PR TITLE
feat: add SentinelOne source with seven families and projectors

### DIFF
--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -99,6 +99,13 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"kubernetes.workload":                  kubernetesWorkloadProjections,
 	"kubernetes.workload_identity_binding": kubernetesWorkloadIdentityBindingProjections,
 	"runtime.evidence":                     runtimeEvidenceProjections,
+	"sentinelone.activity":                 sentinelOneActivityProjections,
+	"sentinelone.agent":                    sentinelOneAgentProjections,
+	"sentinelone.application_inventory":    sentinelOneApplicationInventoryProjections,
+	"sentinelone.exclusion":                sentinelOneExclusionProjections,
+	"sentinelone.group":                    sentinelOneGroupProjections,
+	"sentinelone.site":                     sentinelOneSiteProjections,
+	"sentinelone.threat":                   sentinelOneThreatProjections,
 	"sentinelone.vulnerability":            sentinelOneVulnerabilityProjections,
 }}
 

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -1,0 +1,434 @@
+package sourceprojection
+
+import (
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	sentinelOneEntityAgent     = "sentinelone.agent"
+	sentinelOneEntityThreat    = "sentinelone.threat"
+	sentinelOneEntitySite      = "sentinelone.site"
+	sentinelOneEntityGroup     = "sentinelone.group"
+	sentinelOneEntityActivity  = "sentinelone.activity"
+	sentinelOneEntityExclusion = "sentinelone.exclusion"
+	sentinelOneEntityAccount   = "sentinelone.account"
+	sentinelOneEntityApp       = "sentinelone.installed_application"
+)
+
+func sentinelOneAgentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenant, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	agentID := strings.TrimSpace(attrs["agent_id"])
+	if agentID == "" {
+		return nil, nil, nil
+	}
+	agentURN := sentinelOneAgentURN(tenant, agentID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        agentURN,
+		TenantID:   tenant,
+		SourceID:   event.GetSourceId(),
+		EntityType: sentinelOneEntityAgent,
+		Label:      firstNonEmpty(attrs["computer_name"], attrs["uuid"], agentID),
+		Attributes: map[string]string{
+			"agent_id":          agentID,
+			"agent_uuid":        strings.TrimSpace(attrs["uuid"]),
+			"computer_name":     strings.TrimSpace(attrs["computer_name"]),
+			"os_name":           strings.TrimSpace(attrs["os_name"]),
+			"os_type":           strings.TrimSpace(attrs["os_type"]),
+			"os_revision":       strings.TrimSpace(attrs["os_revision"]),
+			"agent_version":     strings.TrimSpace(attrs["agent_version"]),
+			"is_active":         strings.TrimSpace(attrs["is_active"]),
+			"is_decommissioned": strings.TrimSpace(attrs["is_decommissioned"]),
+			"is_uninstalled":    strings.TrimSpace(attrs["is_uninstalled"]),
+			"is_up_to_date":     strings.TrimSpace(attrs["is_up_to_date"]),
+			"is_infected":       strings.TrimSpace(attrs["infected"]),
+			"active_threats":    strings.TrimSpace(attrs["active_threats"]),
+			"last_active_date":  strings.TrimSpace(attrs["last_active_date"]),
+			"machine_type":      strings.TrimSpace(attrs["machine_type"]),
+			"model_name":        strings.TrimSpace(attrs["model_name"]),
+			"serial_number":     strings.TrimSpace(attrs["serial_number"]),
+			"external_ip":       strings.TrimSpace(attrs["external_ip"]),
+			"domain":            strings.TrimSpace(attrs["domain"]),
+			"network_status":    strings.TrimSpace(attrs["network_status"]),
+			"operational_state": strings.TrimSpace(attrs["operational_state"]),
+			"mitigation_mode":   strings.TrimSpace(attrs["mitigation_mode"]),
+			"site_id":           strings.TrimSpace(attrs["site_id"]),
+			"site_name":         strings.TrimSpace(attrs["site_name"]),
+			"group_id":          strings.TrimSpace(attrs["group_id"]),
+			"group_name":        strings.TrimSpace(attrs["group_name"]),
+			"account_id":        strings.TrimSpace(attrs["account_id"]),
+			"account_name":      strings.TrimSpace(attrs["account_name"]),
+			"tenant_host":       strings.TrimSpace(attrs["tenant_host"]),
+		},
+	})
+
+	addSentinelOneScopeLinks(entities, links, tenant, event, agentURN, attrs)
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func sentinelOneThreatProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenant, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	threatID := strings.TrimSpace(attrs["threat_id"])
+	if threatID == "" {
+		return nil, nil, nil
+	}
+	threatURN := sentinelOneThreatURN(tenant, threatID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        threatURN,
+		TenantID:   tenant,
+		SourceID:   event.GetSourceId(),
+		EntityType: sentinelOneEntityThreat,
+		Label:      firstNonEmpty(attrs["threat_name"], attrs["classification"], threatID),
+		Attributes: map[string]string{
+			"threat_id":             threatID,
+			"classification":        strings.TrimSpace(attrs["classification"]),
+			"classification_source": strings.TrimSpace(attrs["classification_source"]),
+			"analyst_verdict":       strings.TrimSpace(attrs["analyst_verdict"]),
+			"incident_status":       strings.TrimSpace(attrs["incident_status"]),
+			"confidence_level":      strings.TrimSpace(attrs["confidence_level"]),
+			"mitigation_status":     strings.TrimSpace(attrs["mitigation_status"]),
+			"detection_type":        strings.TrimSpace(attrs["detection_type"]),
+			"is_fileless":           strings.TrimSpace(attrs["is_fileless"]),
+			"file_path":             strings.TrimSpace(attrs["file_path"]),
+			"sha256":                strings.TrimSpace(attrs["sha256"]),
+			"mitre_tactics":         strings.TrimSpace(attrs["mitre_tactics"]),
+			"mitre_techniques":      strings.TrimSpace(attrs["mitre_techniques"]),
+			"indicator_categories":  strings.TrimSpace(attrs["indicator_categories"]),
+			"site_id":               strings.TrimSpace(attrs["site_id"]),
+			"group_id":              strings.TrimSpace(attrs["group_id"]),
+			"tenant_host":           strings.TrimSpace(attrs["tenant_host"]),
+		},
+	})
+
+	agentID := firstNonEmpty(strings.TrimSpace(attrs["agent_id"]), strings.TrimSpace(attrs["agent_uuid"]))
+	if agentID != "" {
+		agentURN := sentinelOneAgentURN(tenant, agentID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        agentURN,
+			TenantID:   tenant,
+			SourceID:   event.GetSourceId(),
+			EntityType: sentinelOneEntityAgent,
+			Label:      firstNonEmpty(attrs["computer_name"], attrs["agent_name"], agentID),
+			Attributes: map[string]string{
+				"agent_id":      agentID,
+				"computer_name": strings.TrimSpace(attrs["computer_name"]),
+				"os_name":       strings.TrimSpace(attrs["agent_os_name"]),
+				"os_type":       strings.TrimSpace(attrs["agent_os_type"]),
+				"is_active":     strings.TrimSpace(attrs["is_active"]),
+				"site_id":       strings.TrimSpace(attrs["site_id"]),
+				"group_id":      strings.TrimSpace(attrs["group_id"]),
+				"tenant_host":   strings.TrimSpace(attrs["tenant_host"]),
+			},
+		})
+		addLink(links, projectedLink(tenant, event.GetSourceId(), agentURN, threatURN, relationAffectedBy, map[string]string{
+			"event_id":          event.GetId(),
+			"classification":    strings.TrimSpace(attrs["classification"]),
+			"analyst_verdict":   strings.TrimSpace(attrs["analyst_verdict"]),
+			"incident_status":   strings.TrimSpace(attrs["incident_status"]),
+			"mitigation_status": strings.TrimSpace(attrs["mitigation_status"]),
+		}))
+	}
+
+	addSentinelOneScopeLinks(entities, links, tenant, event, threatURN, attrs)
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func sentinelOneSiteProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenant, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	siteID := strings.TrimSpace(attrs["site_id"])
+	if siteID == "" {
+		return nil, nil, nil
+	}
+	siteURN := sentinelOneSiteURN(tenant, siteID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        siteURN,
+		TenantID:   tenant,
+		SourceID:   event.GetSourceId(),
+		EntityType: sentinelOneEntitySite,
+		Label:      firstNonEmpty(attrs["site_name"], siteID),
+		Attributes: map[string]string{
+			"site_id":      siteID,
+			"site_name":    strings.TrimSpace(attrs["site_name"]),
+			"site_type":    strings.TrimSpace(attrs["site_type"]),
+			"state":        strings.TrimSpace(attrs["state"]),
+			"is_default":   strings.TrimSpace(attrs["is_default"]),
+			"account_id":   strings.TrimSpace(attrs["account_id"]),
+			"account_name": strings.TrimSpace(attrs["account_name"]),
+			"tenant_host":  strings.TrimSpace(attrs["tenant_host"]),
+		},
+	})
+
+	if accountID := strings.TrimSpace(attrs["account_id"]); accountID != "" {
+		accountURN := sentinelOneAccountURN(tenant, accountID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        accountURN,
+			TenantID:   tenant,
+			SourceID:   event.GetSourceId(),
+			EntityType: sentinelOneEntityAccount,
+			Label:      firstNonEmpty(attrs["account_name"], accountID),
+			Attributes: map[string]string{"account_id": accountID, "account_name": strings.TrimSpace(attrs["account_name"])},
+		})
+		addLink(links, projectedLink(tenant, event.GetSourceId(), siteURN, accountURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func sentinelOneGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenant, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	groupID := strings.TrimSpace(attrs["group_id"])
+	if groupID == "" {
+		return nil, nil, nil
+	}
+	groupURN := sentinelOneGroupURN(tenant, groupID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        groupURN,
+		TenantID:   tenant,
+		SourceID:   event.GetSourceId(),
+		EntityType: sentinelOneEntityGroup,
+		Label:      firstNonEmpty(attrs["group_name"], groupID),
+		Attributes: map[string]string{
+			"group_id":     groupID,
+			"group_name":   strings.TrimSpace(attrs["group_name"]),
+			"type":         strings.TrimSpace(attrs["type"]),
+			"is_default":   strings.TrimSpace(attrs["is_default"]),
+			"site_id":      strings.TrimSpace(attrs["site_id"]),
+			"total_agents": strings.TrimSpace(attrs["total_agents"]),
+			"tenant_host":  strings.TrimSpace(attrs["tenant_host"]),
+		},
+	})
+
+	if siteID := strings.TrimSpace(attrs["site_id"]); siteID != "" {
+		siteURN := sentinelOneSiteURN(tenant, siteID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        siteURN,
+			TenantID:   tenant,
+			SourceID:   event.GetSourceId(),
+			EntityType: sentinelOneEntitySite,
+			Label:      firstNonEmpty(attrs["site_name"], siteID),
+			Attributes: map[string]string{"site_id": siteID, "site_name": strings.TrimSpace(attrs["site_name"])},
+		})
+		addLink(links, projectedLink(tenant, event.GetSourceId(), groupURN, siteURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func sentinelOneActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenant, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	activityID := strings.TrimSpace(attrs["activity_id"])
+	if activityID == "" {
+		return nil, nil, nil
+	}
+	activityURN := projectionURN(tenant, "sentinelone_activity", activityID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        activityURN,
+		TenantID:   tenant,
+		SourceID:   event.GetSourceId(),
+		EntityType: sentinelOneEntityActivity,
+		Label:      firstNonEmpty(attrs["primary_description"], activityID),
+		Attributes: map[string]string{
+			"activity_id":         activityID,
+			"activity_type":       strings.TrimSpace(attrs["activity_type"]),
+			"activity_uuid":       strings.TrimSpace(attrs["activity_uuid"]),
+			"primary_description": strings.TrimSpace(attrs["primary_description"]),
+			"agent_id":            strings.TrimSpace(attrs["agent_id"]),
+			"site_id":             strings.TrimSpace(attrs["site_id"]),
+			"group_id":            strings.TrimSpace(attrs["group_id"]),
+			"threat_id":           strings.TrimSpace(attrs["threat_id"]),
+			"user_id":             strings.TrimSpace(attrs["user_id"]),
+			"os_family":           strings.TrimSpace(attrs["os_family"]),
+			"tenant_host":         strings.TrimSpace(attrs["tenant_host"]),
+		},
+	})
+
+	if agentID := strings.TrimSpace(attrs["agent_id"]); agentID != "" {
+		agentURN := sentinelOneAgentURN(tenant, agentID)
+		addLink(links, projectedLink(tenant, event.GetSourceId(), activityURN, agentURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
+	}
+	if threatID := strings.TrimSpace(attrs["threat_id"]); threatID != "" {
+		threatURN := sentinelOneThreatURN(tenant, threatID)
+		addLink(links, projectedLink(tenant, event.GetSourceId(), activityURN, threatURN, relationActedOn, map[string]string{"event_id": event.GetId()}))
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func sentinelOneExclusionProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenant, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	exclusionID := strings.TrimSpace(attrs["exclusion_id"])
+	if exclusionID == "" {
+		return nil, nil, nil
+	}
+	exclusionURN := projectionURN(tenant, "sentinelone_exclusion", exclusionID)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        exclusionURN,
+		TenantID:   tenant,
+		SourceID:   event.GetSourceId(),
+		EntityType: sentinelOneEntityExclusion,
+		Label:      firstNonEmpty(attrs["value"], exclusionID),
+		Attributes: map[string]string{
+			"exclusion_id":    exclusionID,
+			"exclusion_type":  strings.TrimSpace(attrs["exclusion_type"]),
+			"mode":            strings.TrimSpace(attrs["mode"]),
+			"os_type":         strings.TrimSpace(attrs["os_type"]),
+			"scope":           strings.TrimSpace(attrs["scope"]),
+			"scope_name":      strings.TrimSpace(attrs["scope_name"]),
+			"value":           strings.TrimSpace(attrs["value"]),
+			"not_recommended": strings.TrimSpace(attrs["not_recommended"]),
+			"tenant_host":     strings.TrimSpace(attrs["tenant_host"]),
+		},
+	})
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func sentinelOneApplicationInventoryProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenant, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	agentID := strings.TrimSpace(attrs["agent_id"])
+	name := strings.TrimSpace(attrs["application_name"])
+	publisher := strings.TrimSpace(attrs["publisher"])
+	version := strings.TrimSpace(attrs["version"])
+	if agentID == "" || name == "" {
+		return nil, nil, nil
+	}
+	parts := []string{publisher, name, version}
+	cleaned := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		cleaned = append(cleaned, normalizeIdentifier(p))
+	}
+	if len(cleaned) == 0 {
+		cleaned = []string{normalizeIdentifier(name)}
+	}
+	identity := strings.Join(cleaned, "|")
+	appURN := projectionURN(tenant, "sentinelone_installed_app", agentID, identity)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        appURN,
+		TenantID:   tenant,
+		SourceID:   event.GetSourceId(),
+		EntityType: sentinelOneEntityApp,
+		Label:      strings.TrimSpace(strings.Join([]string{publisher, name, version}, " ")),
+		Attributes: map[string]string{
+			"agent_id":       agentID,
+			"name":           name,
+			"publisher":      publisher,
+			"version":        version,
+			"installed_date": strings.TrimSpace(attrs["installed_date"]),
+			"tenant_host":    strings.TrimSpace(attrs["tenant_host"]),
+		},
+	})
+	agentURN := sentinelOneAgentURN(tenant, agentID)
+	addLink(links, projectedLink(tenant, event.GetSourceId(), agentURN, appURN, relationContains, map[string]string{"event_id": event.GetId()}))
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func addSentinelOneScopeLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenant string, event *cerebrov1.EventEnvelope, fromURN string, attrs map[string]string) {
+	if siteID := strings.TrimSpace(attrs["site_id"]); siteID != "" {
+		siteURN := sentinelOneSiteURN(tenant, siteID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        siteURN,
+			TenantID:   tenant,
+			SourceID:   event.GetSourceId(),
+			EntityType: sentinelOneEntitySite,
+			Label:      firstNonEmpty(attrs["site_name"], siteID),
+			Attributes: map[string]string{"site_id": siteID, "site_name": strings.TrimSpace(attrs["site_name"])},
+		})
+		addLink(links, projectedLink(tenant, event.GetSourceId(), fromURN, siteURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+	}
+	if groupID := strings.TrimSpace(attrs["group_id"]); groupID != "" {
+		groupURN := sentinelOneGroupURN(tenant, groupID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        groupURN,
+			TenantID:   tenant,
+			SourceID:   event.GetSourceId(),
+			EntityType: sentinelOneEntityGroup,
+			Label:      firstNonEmpty(attrs["group_name"], groupID),
+			Attributes: map[string]string{"group_id": groupID, "group_name": strings.TrimSpace(attrs["group_name"]), "site_id": strings.TrimSpace(attrs["site_id"])},
+		})
+		addLink(links, projectedLink(tenant, event.GetSourceId(), fromURN, groupURN, relationMemberOf, map[string]string{"event_id": event.GetId()}))
+	}
+}
+
+func sentinelOneAgentURN(tenant string, agentID string) string {
+	return projectionURN(tenant, "sentinelone_agent", agentID)
+}
+
+func sentinelOneThreatURN(tenant string, threatID string) string {
+	return projectionURN(tenant, "sentinelone_threat", threatID)
+}
+
+func sentinelOneSiteURN(tenant string, siteID string) string {
+	return projectionURN(tenant, "sentinelone_site", siteID)
+}
+
+func sentinelOneGroupURN(tenant string, groupID string) string {
+	return projectionURN(tenant, "sentinelone_group", groupID)
+}
+
+func sentinelOneAccountURN(tenant string, accountID string) string {
+	return projectionURN(tenant, "sentinelone_account", accountID)
+}

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -1,0 +1,271 @@
+package sourceprojection
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestProjectSentinelOneAgentBuildsAgentEntity(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "s1-agent-1",
+		TenantId: "writer",
+		SourceId: "sentinelone",
+		Kind:     "sentinelone.agent",
+		Attributes: map[string]string{
+			"agent_id":          "agent-1",
+			"computer_name":     "host-1",
+			"os_name":           "macOS",
+			"os_type":           "macos",
+			"is_active":         "true",
+			"is_decommissioned": "false",
+			"is_up_to_date":     "true",
+			"infected":          "false",
+			"active_threats":    "0",
+			"last_active_date":  "2026-04-23T01:00:00Z",
+			"site_id":           "site-1",
+			"site_name":         "Production",
+			"group_id":          "group-1",
+			"group_name":        "Default",
+			"tenant_host":       "writer.sentinelone.example",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesProjected != 3 {
+		t.Fatalf("EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 2 {
+		t.Fatalf("LinksProjected = %d, want 2", result.LinksProjected)
+	}
+
+	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
+	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
+	groupURN := "urn:cerebro:writer:sentinelone_group:group-1"
+	if state.entities[agentURN] == nil {
+		t.Fatalf("agent entity missing: %#v", state.entities)
+	}
+	if state.entities[agentURN].EntityType != "sentinelone.agent" {
+		t.Fatalf("agent entity type = %q, want sentinelone.agent", state.entities[agentURN].EntityType)
+	}
+	if state.entities[agentURN].Attributes["computer_name"] != "host-1" {
+		t.Fatalf("agent computer_name = %q, want host-1", state.entities[agentURN].Attributes["computer_name"])
+	}
+	assertProjectedLink(t, state, agentURN, relationBelongsTo, siteURN)
+	assertProjectedLink(t, state, agentURN, relationMemberOf, groupURN)
+}
+
+func TestProjectSentinelOneAgentSkipsWhenAgentIDMissing(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "s1-agent-empty",
+		TenantId:   "writer",
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.agent",
+		Attributes: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesProjected != 0 || result.LinksProjected != 0 {
+		t.Fatalf("expected empty projection, got entities=%d links=%d", result.EntitiesProjected, result.LinksProjected)
+	}
+}
+
+func TestProjectSentinelOneThreatLinksThreatToAgent(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "s1-threat-1",
+		TenantId: "writer",
+		SourceId: "sentinelone",
+		Kind:     "sentinelone.threat",
+		Attributes: map[string]string{
+			"threat_id":             "threat-1",
+			"agent_id":              "agent-1",
+			"agent_name":            "host-1",
+			"computer_name":         "host-1",
+			"classification":        "Malware",
+			"classification_source": "Engine",
+			"analyst_verdict":       "true_positive",
+			"incident_status":       "unresolved",
+			"mitigation_status":     "not_mitigated",
+			"confidence_level":      "malicious",
+			"site_id":               "site-1",
+			"group_id":              "group-1",
+			"mitre_tactics":         "Execution",
+			"mitre_techniques":      "Native API",
+			"is_active":             "true",
+			"is_fileless":           "false",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	threatURN := "urn:cerebro:writer:sentinelone_threat:threat-1"
+	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
+	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
+	groupURN := "urn:cerebro:writer:sentinelone_group:group-1"
+
+	if state.entities[threatURN] == nil {
+		t.Fatalf("threat entity missing")
+	}
+	if state.entities[agentURN] == nil {
+		t.Fatalf("agent entity missing")
+	}
+	assertProjectedLink(t, state, agentURN, relationAffectedBy, threatURN)
+	assertProjectedLink(t, state, threatURN, relationBelongsTo, siteURN)
+	assertProjectedLink(t, state, threatURN, relationMemberOf, groupURN)
+	if got := state.entities[threatURN].Attributes["classification"]; got != "Malware" {
+		t.Fatalf("threat classification = %q, want Malware", got)
+	}
+	if got := state.entities[threatURN].Attributes["mitre_tactics"]; got != "Execution" {
+		t.Fatalf("threat mitre_tactics = %q, want Execution", got)
+	}
+	_ = result
+}
+
+func TestProjectSentinelOneSiteAccountLink(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "s1-site-1",
+		TenantId: "writer",
+		SourceId: "sentinelone",
+		Kind:     "sentinelone.site",
+		Attributes: map[string]string{
+			"site_id":      "site-1",
+			"site_name":    "Production",
+			"account_id":   "account-1",
+			"account_name": "Writer",
+			"is_default":   "true",
+		},
+	}); err != nil {
+		t.Fatalf("Project(site) error = %v", err)
+	}
+	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
+	accountURN := "urn:cerebro:writer:sentinelone_account:account-1"
+	if state.entities[siteURN] == nil {
+		t.Fatal("site entity missing")
+	}
+	if state.entities[accountURN] == nil {
+		t.Fatal("account entity missing")
+	}
+	assertProjectedLink(t, state, siteURN, relationBelongsTo, accountURN)
+}
+
+func TestProjectSentinelOneGroupSiteLink(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "s1-group-1",
+		TenantId: "writer",
+		SourceId: "sentinelone",
+		Kind:     "sentinelone.group",
+		Attributes: map[string]string{
+			"group_id":     "group-1",
+			"group_name":   "Default",
+			"site_id":      "site-1",
+			"site_name":    "Production",
+			"total_agents": "5",
+		},
+	}); err != nil {
+		t.Fatalf("Project(group) error = %v", err)
+	}
+	groupURN := "urn:cerebro:writer:sentinelone_group:group-1"
+	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
+	if state.entities[groupURN] == nil {
+		t.Fatal("group entity missing")
+	}
+	assertProjectedLink(t, state, groupURN, relationBelongsTo, siteURN)
+}
+
+func TestProjectSentinelOneActivityLinksAgentAndThreat(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "s1-activity-1",
+		TenantId: "writer",
+		SourceId: "sentinelone",
+		Kind:     "sentinelone.activity",
+		Attributes: map[string]string{
+			"activity_id":         "activity-1",
+			"activity_type":       "27",
+			"primary_description": "User logged in",
+			"agent_id":            "agent-1",
+			"threat_id":           "threat-1",
+			"site_id":             "site-1",
+		},
+	}); err != nil {
+		t.Fatalf("Project(activity) error = %v", err)
+	}
+	activityURN := "urn:cerebro:writer:sentinelone_activity:activity-1"
+	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
+	threatURN := "urn:cerebro:writer:sentinelone_threat:threat-1"
+	if state.entities[activityURN] == nil {
+		t.Fatal("activity entity missing")
+	}
+	assertProjectedLink(t, state, activityURN, relationObservedOn, agentURN)
+	assertProjectedLink(t, state, activityURN, relationActedOn, threatURN)
+}
+
+func TestProjectSentinelOneApplicationInventoryContainedByAgent(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "s1-app-1",
+		TenantId: "writer",
+		SourceId: "sentinelone",
+		Kind:     "sentinelone.application_inventory",
+		Attributes: map[string]string{
+			"agent_id":         "agent-1",
+			"application_name": "Example App",
+			"publisher":        "Example Inc",
+			"version":          "1.0.0",
+			"installed_date":   "2026-04-20T00:00:00Z",
+		},
+	}); err != nil {
+		t.Fatalf("Project(app) error = %v", err)
+	}
+	appURN := "urn:cerebro:writer:sentinelone_installed_app:agent-1:example inc|example app|1.0.0"
+	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
+	if state.entities[appURN] == nil {
+		t.Fatalf("application entity missing; got entities=%v", state.entities)
+	}
+	assertProjectedLink(t, state, agentURN, relationContains, appURN)
+}
+
+func TestProjectSentinelOneExclusion(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	if _, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "s1-exclusion-1",
+		TenantId: "writer",
+		SourceId: "sentinelone",
+		Kind:     "sentinelone.exclusion",
+		Attributes: map[string]string{
+			"exclusion_id":   "exclusion-1",
+			"exclusion_type": "path",
+			"mode":           "suppress_alerts",
+			"os_type":        "macos",
+			"scope":          "site",
+			"value":          "/Applications/Approved.app",
+		},
+	}); err != nil {
+		t.Fatalf("Project(exclusion) error = %v", err)
+	}
+	exclusionURN := "urn:cerebro:writer:sentinelone_exclusion:exclusion-1"
+	if state.entities[exclusionURN] == nil {
+		t.Fatal("exclusion entity missing")
+	}
+	if got := state.entities[exclusionURN].Attributes["scope"]; got != "site" {
+		t.Fatalf("exclusion scope = %q, want site", got)
+	}
+}

--- a/internal/sourceregistry/registry.go
+++ b/internal/sourceregistry/registry.go
@@ -11,6 +11,7 @@ import (
 	googleworkspacesource "github.com/writer/cerebro/sources/googleworkspace"
 	oktasource "github.com/writer/cerebro/sources/okta"
 	sdksource "github.com/writer/cerebro/sources/sdk"
+	sentineloneSource "github.com/writer/cerebro/sources/sentinelone"
 )
 
 type builtinSourceLoader struct {
@@ -59,6 +60,12 @@ var builtinSourceLoaders = []builtinSourceLoader{
 		name: "sdk",
 		load: func() (sourcecdk.Source, error) {
 			return sdksource.New()
+		},
+	},
+	{
+		name: "sentinelone",
+		load: func() (sourcecdk.Source, error) {
+			return sentineloneSource.New()
 		},
 	},
 }

--- a/internal/sourceregistry/registry_test.go
+++ b/internal/sourceregistry/registry_test.go
@@ -56,4 +56,11 @@ func TestBuiltin(t *testing.T) {
 	if sdk.Spec().Name != "SDK Push Source" {
 		t.Fatalf("sdk Spec().Name = %q, want %q", sdk.Spec().Name, "SDK Push Source")
 	}
+	sentinelone, ok := registry.Get("sentinelone")
+	if !ok {
+		t.Fatal("Get(sentinelone) = false, want true")
+	}
+	if sentinelone.Spec().Name != "SentinelOne" {
+		t.Fatalf("sentinelone Spec().Name = %q, want %q", sentinelone.Spec().Name, "SentinelOne")
+	}
 }

--- a/sources/sentinelone/catalog.yaml
+++ b/sources/sentinelone/catalog.yaml
@@ -1,0 +1,11 @@
+id: sentinelone
+name: SentinelOne
+description: SentinelOne EDR threat, agent, application, activity, site, group, and exclusion source.
+emitted_kinds:
+  - sentinelone.activity
+  - sentinelone.agent
+  - sentinelone.application_inventory
+  - sentinelone.exclusion
+  - sentinelone.group
+  - sentinelone.site
+  - sentinelone.threat

--- a/sources/sentinelone/fixture.go
+++ b/sources/sentinelone/fixture.go
@@ -1,0 +1,54 @@
+package sentinelone
+
+import (
+	"context"
+	"embed"
+	"fmt"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+//go:embed testdata/*.json
+var fixtureFS embed.FS
+
+// NewFixture constructs the deterministic SentinelOne source used by tests.
+func NewFixture() (sourcecdk.Source, error) {
+	spec, err := loadSpec()
+	if err != nil {
+		return nil, err
+	}
+	families := []sourcecdk.FixtureFamily{}
+	for _, name := range []string{
+		familyActivity, familyAgent, familyApplication, familyExclusion, familyGroup, familySite, familyThreat,
+	} {
+		urns, err := sourcecdk.LoadFixtureURNs(fixtureFS, "testdata/discover_"+name+".json")
+		if err != nil {
+			return nil, err
+		}
+		events, err := sourcecdk.LoadFixtureEvents(fixtureFS, "testdata/read_"+name+".json")
+		if err != nil {
+			return nil, err
+		}
+		families = append(families, sourcecdk.FixtureFamily{Name: name, URNs: urns, Events: events})
+	}
+	return sourcecdk.NewFixtureSource(sourcecdk.FixtureSourceOptions{
+		Spec:          spec,
+		DefaultFamily: defaultFamily,
+		Check:         checkFixtureConfig,
+		ResolveFamily: resolveFixtureFamily,
+		Families:      families,
+	})
+}
+
+func checkFixtureConfig(_ context.Context, cfg sourcecdk.Config) error {
+	_, err := parseSettings(cfg, false)
+	return err
+}
+
+func resolveFixtureFamily(cfg sourcecdk.Config) (string, error) {
+	settings, err := parseSettings(cfg, false)
+	if err != nil {
+		return "", fmt.Errorf("parse sentinelone fixture settings: %w", err)
+	}
+	return settings.family, nil
+}

--- a/sources/sentinelone/records.go
+++ b/sources/sentinelone/records.go
@@ -1,0 +1,1254 @@
+package sentinelone
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/primitives"
+)
+
+// raw types are used to capture the raw response body alongside the decoded fields so that
+// downstream projection can read details that we did not statically model.
+
+type rawCarrier interface {
+	setRaw(json.RawMessage)
+	rawBytes() json.RawMessage
+}
+
+// threatRecord captures the high-value fields returned by /web/api/v2.1/threats.
+type threatRecord struct {
+	ID                 string                   `json:"id"`
+	ThreatInfo         threatInfoRecord         `json:"threatInfo"`
+	AgentDetectionInfo agentDetectionInfoRecord `json:"agentDetectionInfo"`
+	AgentRealtimeInfo  agentRealtimeInfoRecord  `json:"agentRealtimeInfo"`
+	Indicators         []threatIndicatorRecord  `json:"indicators"`
+	MitigationStatus   []mitigationStatusRecord `json:"mitigationStatus"`
+	WhiteningOptions   []string                 `json:"whiteningOptions"`
+	raw                json.RawMessage
+}
+
+func (r *threatRecord) setRaw(raw json.RawMessage) { r.raw = raw }
+func (r *threatRecord) rawBytes() json.RawMessage  { return r.raw }
+
+type threatInfoRecord struct {
+	threatClassificationRecord
+	threatLifecycleRecord
+	threatFileRecord
+}
+
+type threatClassificationRecord struct {
+	AnalystVerdict        string `json:"analystVerdict"`
+	Classification        string `json:"classification"`
+	ClassificationSource  string `json:"classificationSource"`
+	ConfidenceLevel       string `json:"confidenceLevel"`
+	IncidentStatus        string `json:"incidentStatus"`
+	MitigationStatus      string `json:"mitigationStatus"`
+	IsFileless            bool   `json:"isFileless"`
+	ThreatName            string `json:"threatName"`
+	DetectionType         string `json:"detectionType"`
+	AutomaticallyResolved bool   `json:"automaticallyResolved"`
+}
+
+type threatLifecycleRecord struct {
+	CreatedAt              string `json:"createdAt"`
+	IdentifiedAt           string `json:"identifiedAt"`
+	UpdatedAt              string `json:"updatedAt"`
+	InitiatedBy            string `json:"initiatedBy"`
+	InitiatedByDescription string `json:"initiatedByDescription"`
+	InitiatingUserID       string `json:"initiatingUserId"`
+	InitiatingUsername     string `json:"initiatingUsername"`
+	OriginatorProcess      string `json:"originatorProcess"`
+	StorylineID            string `json:"storyline"`
+	ExternalTicketID       string `json:"externalTicketId"`
+}
+
+type threatFileRecord struct {
+	FilePath          string `json:"filePath"`
+	FileSize          int64  `json:"fileSize"`
+	FileExtension     string `json:"fileExtension"`
+	FileExtensionType string `json:"fileExtensionType"`
+	Sha1              string `json:"sha1"`
+	Sha256            string `json:"sha256"`
+	Md5               string `json:"md5"`
+}
+
+type agentDetectionInfoRecord struct {
+	AccountID                 string `json:"accountId"`
+	AccountName               string `json:"accountName"`
+	AgentDetectionState       string `json:"agentDetectionState"`
+	AgentDomain               string `json:"agentDomain"`
+	AgentIPV4                 string `json:"agentIpV4"`
+	AgentIPV6                 string `json:"agentIpV6"`
+	AgentLastLoggedInUserMail string `json:"agentLastLoggedInUserMail"`
+	AgentLastLoggedInUserName string `json:"agentLastLoggedInUserName"`
+	AgentMitigationMode       string `json:"agentMitigationMode"`
+	AgentOSName               string `json:"agentOsName"`
+	AgentOSRevision           string `json:"agentOsRevision"`
+	AgentRegisteredAt         string `json:"agentRegisteredAt"`
+	AgentUUID                 string `json:"agentUuid"`
+	AgentVersion              string `json:"agentVersion"`
+	ExternalIP                string `json:"externalIp"`
+	GroupID                   string `json:"groupId"`
+	GroupName                 string `json:"groupName"`
+	SiteID                    string `json:"siteId"`
+	SiteName                  string `json:"siteName"`
+}
+
+type agentRealtimeInfoRecord struct {
+	agentRealtimeIdentity
+	agentRealtimeStatus
+}
+
+type agentRealtimeIdentity struct {
+	AccountID         string `json:"accountId"`
+	AccountName       string `json:"accountName"`
+	AgentComputerName string `json:"agentComputerName"`
+	AgentDomain       string `json:"agentDomain"`
+	AgentID           string `json:"agentId"`
+	AgentMachineType  string `json:"agentMachineType"`
+	AgentUUID         string `json:"agentUuid"`
+	AgentVersion      string `json:"agentVersion"`
+	GroupID           string `json:"groupId"`
+	GroupName         string `json:"groupName"`
+	SiteID            string `json:"siteId"`
+	SiteName          string `json:"siteName"`
+	StorageName       string `json:"storageName"`
+}
+
+type agentRealtimeStatus struct {
+	ActiveThreats         int    `json:"activeThreats"`
+	AgentInfected         bool   `json:"agentInfected"`
+	AgentIsActive         bool   `json:"agentIsActive"`
+	AgentIsDecommissioned bool   `json:"agentIsDecommissioned"`
+	AgentMitigationMode   string `json:"agentMitigationMode"`
+	AgentNetworkStatus    string `json:"agentNetworkStatus"`
+	AgentOSName           string `json:"agentOsName"`
+	AgentOSRevision       string `json:"agentOsRevision"`
+	AgentOSType           string `json:"agentOsType"`
+	OperationalState      string `json:"operationalState"`
+	RebootRequired        bool   `json:"rebootRequired"`
+	ScanStatus            string `json:"scanStatus"`
+}
+
+type threatIndicatorRecord struct {
+	Category    string            `json:"category"`
+	IDs         []int             `json:"ids"`
+	Tactics     []indicatorTactic `json:"tactics"`
+	Description string            `json:"description"`
+	Categories  []string          `json:"categories"`
+}
+
+type indicatorTactic struct {
+	Name       string             `json:"name"`
+	Source     string             `json:"source"`
+	Techniques []indicatorTactic2 `json:"techniques"`
+}
+
+type indicatorTactic2 struct {
+	Link string `json:"link"`
+	Name string `json:"name"`
+}
+
+type mitigationStatusRecord struct {
+	Action              string         `json:"action"`
+	ActionsCounters     map[string]int `json:"actionsCounters"`
+	LastUpdate          string         `json:"lastUpdate"`
+	MitigationStartedAt string         `json:"mitigationStartedAt"`
+	MitigationEndedAt   string         `json:"mitigationEndedAt"`
+	Status              string         `json:"status"`
+	ReportID            string         `json:"reportId"`
+}
+
+// agentRecord captures fields returned by /web/api/v2.1/agents.
+type agentRecord struct {
+	agentIdentityRecord
+	agentLifecycleRecord
+	agentStatusRecord
+	agentHardwareRecord
+	agentLocationRecord
+	agentTagsRecord
+	raw json.RawMessage
+}
+
+type agentIdentityRecord struct {
+	ID           string `json:"id"`
+	AccountID    string `json:"accountId"`
+	AccountName  string `json:"accountName"`
+	ComputerName string `json:"computerName"`
+	UUID         string `json:"uuid"`
+	ExternalID   string `json:"externalId"`
+	ModelName    string `json:"modelName"`
+	SerialNumber string `json:"serialNumber"`
+}
+
+type agentLifecycleRecord struct {
+	CreatedAt              string `json:"createdAt"`
+	UpdatedAt              string `json:"updatedAt"`
+	RegisteredAt           string `json:"registeredAt"`
+	LastActiveDate         string `json:"lastActiveDate"`
+	LastSuccessfulScanDate string `json:"lastSuccessfulScanDate"`
+	AgentVersion           string `json:"agentVersion"`
+	IsUpToDate             bool   `json:"isUpToDate"`
+	InstallerType          string `json:"installerType"`
+}
+
+type agentStatusRecord struct {
+	IsActive                 bool   `json:"isActive"`
+	IsDecommissioned         bool   `json:"isDecommissioned"`
+	IsPendingUninstall       bool   `json:"isPendingUninstall"`
+	IsUninstalled            bool   `json:"isUninstalled"`
+	Infected                 bool   `json:"infected"`
+	ActiveThreats            int    `json:"activeThreats"`
+	FirewallEnabled          bool   `json:"firewallEnabled"`
+	NetworkStatus            string `json:"networkStatus"`
+	OperationalState         string `json:"operationalState"`
+	ScanStatus               string `json:"scanStatus"`
+	MitigationMode           string `json:"mitigationMode"`
+	MitigationModeSuspicious string `json:"mitigationModeSuspicious"`
+	DetectionState           string `json:"detectionState"`
+	AppsVulnerabilityStatus  string `json:"appsVulnerabilityStatus"`
+	ShowAlertIcon            bool   `json:"showAlertIcon"`
+	InRemoteShellSession     bool   `json:"inRemoteShellSession"`
+}
+
+type agentHardwareRecord struct {
+	CoreCount   int    `json:"coreCount"`
+	CPUCount    int    `json:"cpuCount"`
+	MachineType string `json:"machineType"`
+	OSArch      string `json:"osArch"`
+	OSName      string `json:"osName"`
+	OSRevision  string `json:"osRevision"`
+	OSType      string `json:"osType"`
+	OSUsername  string `json:"osUsername"`
+	TotalMemory int    `json:"totalMemory"`
+	LicenseKey  string `json:"licenseKey"`
+}
+
+type agentLocationRecord struct {
+	Domain               string `json:"domain"`
+	ExternalIP           string `json:"externalIp"`
+	GroupID              string `json:"groupId"`
+	GroupName            string `json:"groupName"`
+	GroupIP              string `json:"groupIp"`
+	LastIPToMgmt         string `json:"lastIpToMgmt"`
+	LastLoggedInUserName string `json:"lastLoggedInUserName"`
+	SiteID               string `json:"siteId"`
+	SiteName             string `json:"siteName"`
+	StorageName          string `json:"storageName"`
+	StorageType          string `json:"storageType"`
+	RebootRequired       bool   `json:"rebootRequired"`
+}
+
+type agentTagsRecord struct {
+	Tags              map[string]any `json:"tags"`
+	UserActionsNeeded []string       `json:"userActionsNeeded"`
+}
+
+func (r *agentRecord) setRaw(raw json.RawMessage) { r.raw = raw }
+func (r *agentRecord) rawBytes() json.RawMessage  { return r.raw }
+
+// siteRecord captures fields from /web/api/v2.1/sites.
+type siteRecord struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	AccountID     string `json:"accountId"`
+	AccountName   string `json:"accountName"`
+	State         string `json:"state"`
+	IsDefault     bool   `json:"isDefault"`
+	CreatedAt     string `json:"createdAt"`
+	UpdatedAt     string `json:"updatedAt"`
+	Description   string `json:"description"`
+	Expiration    string `json:"expiration"`
+	HealthStatus  bool   `json:"healthStatus"`
+	SiteType      string `json:"siteType"`
+	TotalLicenses int    `json:"totalLicenses"`
+	UsedLicenses  int    `json:"activeLicenses"`
+	raw           json.RawMessage
+}
+
+func (r *siteRecord) setRaw(raw json.RawMessage) { r.raw = raw }
+func (r *siteRecord) rawBytes() json.RawMessage  { return r.raw }
+
+// groupRecord captures fields from /web/api/v2.1/groups.
+type groupRecord struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	Description       string `json:"description"`
+	Type              string `json:"type"`
+	IsDefault         bool   `json:"isDefault"`
+	Inherits          bool   `json:"inherits"`
+	Rank              int    `json:"rank"`
+	SiteID            string `json:"siteId"`
+	TotalAgents       int    `json:"totalAgents"`
+	FilterID          string `json:"filterId"`
+	FilterName        string `json:"filterName"`
+	CreatedAt         string `json:"createdAt"`
+	UpdatedAt         string `json:"updatedAt"`
+	Creator           string `json:"creator"`
+	CreatorID         string `json:"creatorId"`
+	RegistrationToken string `json:"registrationToken"`
+	raw               json.RawMessage
+}
+
+func (r *groupRecord) setRaw(raw json.RawMessage) { r.raw = raw }
+func (r *groupRecord) rawBytes() json.RawMessage  { return r.raw }
+
+// exclusionRecord captures fields from /web/api/v2.1/exclusions.
+type exclusionRecord struct {
+	ID                string   `json:"id"`
+	Type              string   `json:"type"`
+	Mode              string   `json:"mode"`
+	Source            string   `json:"source"`
+	OSType            string   `json:"osType"`
+	PathExclusionType string   `json:"pathExclusionType"`
+	IncludeChildren   bool     `json:"includeChildren"`
+	IncludeParents    bool     `json:"includeParents"`
+	Imported          bool     `json:"imported"`
+	NotRecommended    bool     `json:"notRecommended"`
+	Description       string   `json:"description"`
+	ApplicationName   string   `json:"applicationName"`
+	UserID            string   `json:"userId"`
+	UserName          string   `json:"userName"`
+	Scope             string   `json:"scope"`
+	ScopeName         string   `json:"scopeName"`
+	ScopePath         string   `json:"scopePath"`
+	Value             string   `json:"value"`
+	Actions           []string `json:"actions"`
+	CreatedAt         string   `json:"createdAt"`
+	UpdatedAt         string   `json:"updatedAt"`
+	raw               json.RawMessage
+}
+
+func (r *exclusionRecord) setRaw(raw json.RawMessage) { r.raw = raw }
+func (r *exclusionRecord) rawBytes() json.RawMessage  { return r.raw }
+
+// activityRecord captures fields from /web/api/v2.1/activities.
+type activityRecord struct {
+	ID                   string         `json:"id"`
+	AccountID            string         `json:"accountId"`
+	AccountName          string         `json:"accountName"`
+	ActivityType         int            `json:"activityType"`
+	ActivityUUID         string         `json:"activityUuid"`
+	AgentID              string         `json:"agentId"`
+	AgentUpdatedVersion  string         `json:"agentUpdatedVersion"`
+	Comments             string         `json:"comments"`
+	CreatedAt            string         `json:"createdAt"`
+	Data                 map[string]any `json:"data"`
+	Description          string         `json:"description"`
+	GroupID              string         `json:"groupId"`
+	GroupName            string         `json:"groupName"`
+	Hash                 string         `json:"hash"`
+	OSFamily             string         `json:"osFamily"`
+	PrimaryDescription   string         `json:"primaryDescription"`
+	SecondaryDescription string         `json:"secondaryDescription"`
+	SiteID               string         `json:"siteId"`
+	SiteName             string         `json:"siteName"`
+	ThreatID             string         `json:"threatId"`
+	UpdatedAt            string         `json:"updatedAt"`
+	UserID               string         `json:"userId"`
+	raw                  json.RawMessage
+}
+
+func (r *activityRecord) setRaw(raw json.RawMessage) { r.raw = raw }
+func (r *activityRecord) rawBytes() json.RawMessage  { return r.raw }
+
+// applicationRecord is the per-agent installed application inventory entry.
+type applicationRecord struct {
+	Name          string `json:"name"`
+	Publisher     string `json:"publisher"`
+	Version       string `json:"version"`
+	InstalledDate string `json:"installedDate"`
+	Size          int64  `json:"size"`
+	raw           json.RawMessage
+}
+
+func (r *applicationRecord) setRaw(raw json.RawMessage) { r.raw = raw }
+func (r *applicationRecord) rawBytes() json.RawMessage  { return r.raw }
+
+func applicationID(_ settings, app applicationRecord) string {
+	parts := []string{app.Publisher, app.Name, app.Version}
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		v := strings.TrimSpace(p)
+		if v == "" {
+			continue
+		}
+		out = append(out, strings.ReplaceAll(v, " ", "_"))
+	}
+	if len(out) == 0 {
+		return "unknown"
+	}
+	return strings.Join(out, "::")
+}
+
+// payloads -- emitted JSON shapes.
+
+type threatPayload struct {
+	ID                string                    `json:"id"`
+	TenantHost        string                    `json:"tenant_host"`
+	ThreatInfo        threatInfoPayload         `json:"threat_info"`
+	AgentDetection    agentDetectionPayload     `json:"agent_detection"`
+	AgentRealtime     agentRealtimePayload      `json:"agent_realtime"`
+	Indicators        indicatorPayload          `json:"indicators"`
+	MitigationActions []mitigationActionPayload `json:"mitigation_actions,omitempty"`
+	WhiteningOptions  []string                  `json:"whitening_options,omitempty"`
+	Raw               map[string]any            `json:"raw,omitempty"`
+}
+
+type threatInfoPayload struct {
+	threatClassificationPayload
+	threatLifecyclePayload
+	threatFilePayload
+}
+
+type threatClassificationPayload struct {
+	AnalystVerdict        string `json:"analyst_verdict"`
+	Classification        string `json:"classification"`
+	ClassificationSource  string `json:"classification_source"`
+	ConfidenceLevel       string `json:"confidence_level"`
+	IncidentStatus        string `json:"incident_status"`
+	MitigationStatus      string `json:"mitigation_status"`
+	IsFileless            bool   `json:"is_fileless,omitempty"`
+	ThreatName            string `json:"threat_name,omitempty"`
+	DetectionType         string `json:"detection_type,omitempty"`
+	AutomaticallyResolved bool   `json:"automatically_resolved,omitempty"`
+}
+
+type threatLifecyclePayload struct {
+	CreatedAt              string `json:"created_at,omitempty"`
+	IdentifiedAt           string `json:"identified_at,omitempty"`
+	UpdatedAt              string `json:"updated_at,omitempty"`
+	InitiatedBy            string `json:"initiated_by,omitempty"`
+	InitiatedByDescription string `json:"initiated_by_description,omitempty"`
+	InitiatingUserID       string `json:"initiating_user_id,omitempty"`
+	InitiatingUsername     string `json:"initiating_username,omitempty"`
+	OriginatorProcess      string `json:"originator_process,omitempty"`
+	StorylineID            string `json:"storyline_id,omitempty"`
+	ExternalTicketID       string `json:"external_ticket_id,omitempty"`
+}
+
+type threatFilePayload struct {
+	FilePath          string `json:"file_path,omitempty"`
+	FileSize          int64  `json:"file_size,omitempty"`
+	FileExtension     string `json:"file_extension,omitempty"`
+	FileExtensionType string `json:"file_extension_type,omitempty"`
+	Sha1              string `json:"sha1,omitempty"`
+	Sha256            string `json:"sha256,omitempty"`
+	Md5               string `json:"md5,omitempty"`
+}
+
+type agentDetectionPayload struct {
+	AccountID    string `json:"account_id,omitempty"`
+	AccountName  string `json:"account_name,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+	IPV4         string `json:"ip_v4,omitempty"`
+	IPV6         string `json:"ip_v6,omitempty"`
+	OSName       string `json:"os_name,omitempty"`
+	OSRevision   string `json:"os_revision,omitempty"`
+	RegisteredAt string `json:"registered_at,omitempty"`
+	UUID         string `json:"uuid,omitempty"`
+	Version      string `json:"version,omitempty"`
+	ExternalIP   string `json:"external_ip,omitempty"`
+	GroupID      string `json:"group_id,omitempty"`
+	GroupName    string `json:"group_name,omitempty"`
+	SiteID       string `json:"site_id,omitempty"`
+	SiteName     string `json:"site_name,omitempty"`
+	UserMail     string `json:"user_mail,omitempty"`
+	UserName     string `json:"user_name,omitempty"`
+}
+
+type agentRealtimePayload struct {
+	AgentID          string `json:"agent_id,omitempty"`
+	ComputerName     string `json:"computer_name,omitempty"`
+	OSName           string `json:"os_name,omitempty"`
+	OSType           string `json:"os_type,omitempty"`
+	OSRevision       string `json:"os_revision,omitempty"`
+	IsActive         bool   `json:"is_active"`
+	IsDecommissioned bool   `json:"is_decommissioned"`
+	Infected         bool   `json:"is_infected"`
+	ActiveThreats    int    `json:"active_threats"`
+	NetworkStatus    string `json:"network_status,omitempty"`
+	OperationalState string `json:"operational_state,omitempty"`
+	RebootRequired   bool   `json:"reboot_required,omitempty"`
+	ScanStatus       string `json:"scan_status,omitempty"`
+	MitigationMode   string `json:"mitigation_mode,omitempty"`
+	UUID             string `json:"uuid,omitempty"`
+	Version          string `json:"version,omitempty"`
+	GroupID          string `json:"group_id,omitempty"`
+	GroupName        string `json:"group_name,omitempty"`
+	SiteID           string `json:"site_id,omitempty"`
+	SiteName         string `json:"site_name,omitempty"`
+}
+
+type indicatorPayload struct {
+	Categories      []string `json:"categories,omitempty"`
+	MitreTactics    []string `json:"mitre_tactics,omitempty"`
+	MitreTechniques []string `json:"mitre_techniques,omitempty"`
+	Descriptions    []string `json:"descriptions,omitempty"`
+}
+
+type mitigationActionPayload struct {
+	Action     string `json:"action"`
+	Status     string `json:"status,omitempty"`
+	StartedAt  string `json:"started_at,omitempty"`
+	EndedAt    string `json:"ended_at,omitempty"`
+	LastUpdate string `json:"last_update,omitempty"`
+	ReportID   string `json:"report_id,omitempty"`
+}
+
+type agentPayload struct {
+	agentIdentityPayload
+	agentLifecyclePayloadFields
+	agentStatusPayload
+	agentLocationPayload
+	TenantHost string         `json:"tenant_host"`
+	Tags       map[string]any `json:"tags,omitempty"`
+	Raw        map[string]any `json:"raw,omitempty"`
+}
+
+type agentIdentityPayload struct {
+	ID           string `json:"id"`
+	ComputerName string `json:"computer_name"`
+	UUID         string `json:"uuid,omitempty"`
+	AccountID    string `json:"account_id,omitempty"`
+	AccountName  string `json:"account_name,omitempty"`
+	ModelName    string `json:"model_name,omitempty"`
+	SerialNumber string `json:"serial_number,omitempty"`
+	MachineType  string `json:"machine_type,omitempty"`
+	OSName       string `json:"os_name,omitempty"`
+	OSType       string `json:"os_type,omitempty"`
+	OSArch       string `json:"os_arch,omitempty"`
+	OSRevision   string `json:"os_revision,omitempty"`
+}
+
+type agentLifecyclePayloadFields struct {
+	AgentVersion       string `json:"agent_version,omitempty"`
+	LastActiveDate     string `json:"last_active_date,omitempty"`
+	LastSuccessfulScan string `json:"last_successful_scan_at,omitempty"`
+	RegisteredAt       string `json:"registered_at,omitempty"`
+	CreatedAt          string `json:"created_at,omitempty"`
+	UpdatedAt          string `json:"updated_at,omitempty"`
+}
+
+type agentStatusPayload struct {
+	IsActive           bool     `json:"is_active"`
+	IsDecommissioned   bool     `json:"is_decommissioned"`
+	IsUpToDate         bool     `json:"is_up_to_date"`
+	IsUninstalled      bool     `json:"is_uninstalled"`
+	IsPendingUninstall bool     `json:"is_pending_uninstall"`
+	Infected           bool     `json:"is_infected"`
+	ActiveThreats      int      `json:"active_threats"`
+	NetworkStatus      string   `json:"network_status,omitempty"`
+	OperationalState   string   `json:"operational_state,omitempty"`
+	MitigationMode     string   `json:"mitigation_mode,omitempty"`
+	UserActionsNeeded  []string `json:"user_actions_needed,omitempty"`
+}
+
+type agentLocationPayload struct {
+	Domain     string `json:"domain,omitempty"`
+	ExternalIP string `json:"external_ip,omitempty"`
+	GroupID    string `json:"group_id,omitempty"`
+	GroupName  string `json:"group_name,omitempty"`
+	SiteID     string `json:"site_id,omitempty"`
+	SiteName   string `json:"site_name,omitempty"`
+}
+
+type sitePayload struct {
+	ID            string         `json:"id"`
+	TenantHost    string         `json:"tenant_host"`
+	Name          string         `json:"name,omitempty"`
+	State         string         `json:"state,omitempty"`
+	SiteType      string         `json:"site_type,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	Expiration    string         `json:"expiration,omitempty"`
+	IsDefault     bool           `json:"is_default,omitempty"`
+	HealthStatus  bool           `json:"health_status,omitempty"`
+	TotalLicenses int            `json:"total_licenses,omitempty"`
+	UsedLicenses  int            `json:"used_licenses,omitempty"`
+	AccountID     string         `json:"account_id,omitempty"`
+	AccountName   string         `json:"account_name,omitempty"`
+	CreatedAt     string         `json:"created_at,omitempty"`
+	UpdatedAt     string         `json:"updated_at,omitempty"`
+	Raw           map[string]any `json:"raw,omitempty"`
+}
+
+type groupPayload struct {
+	ID              string         `json:"id"`
+	TenantHost      string         `json:"tenant_host"`
+	Name            string         `json:"name,omitempty"`
+	Type            string         `json:"type,omitempty"`
+	Description     string         `json:"description,omitempty"`
+	IsDefault       bool           `json:"is_default,omitempty"`
+	Inherits        bool           `json:"inherits,omitempty"`
+	Rank            int            `json:"rank,omitempty"`
+	SiteID          string         `json:"site_id,omitempty"`
+	TotalAgents     int            `json:"total_agents,omitempty"`
+	FilterID        string         `json:"filter_id,omitempty"`
+	FilterName      string         `json:"filter_name,omitempty"`
+	Creator         string         `json:"creator,omitempty"`
+	CreatorID       string         `json:"creator_id,omitempty"`
+	HasRegistration bool           `json:"has_registration_token,omitempty"`
+	CreatedAt       string         `json:"created_at,omitempty"`
+	UpdatedAt       string         `json:"updated_at,omitempty"`
+	Raw             map[string]any `json:"raw,omitempty"`
+}
+
+type exclusionPayload struct {
+	ID                string         `json:"id"`
+	TenantHost        string         `json:"tenant_host"`
+	Type              string         `json:"type,omitempty"`
+	Mode              string         `json:"mode,omitempty"`
+	Source            string         `json:"source,omitempty"`
+	OSType            string         `json:"os_type,omitempty"`
+	PathExclusionType string         `json:"path_exclusion_type,omitempty"`
+	IncludeChildren   bool           `json:"include_children,omitempty"`
+	IncludeParents    bool           `json:"include_parents,omitempty"`
+	Imported          bool           `json:"imported,omitempty"`
+	NotRecommended    bool           `json:"not_recommended,omitempty"`
+	Description       string         `json:"description,omitempty"`
+	ApplicationName   string         `json:"application_name,omitempty"`
+	UserID            string         `json:"user_id,omitempty"`
+	UserName          string         `json:"user_name,omitempty"`
+	Scope             string         `json:"scope,omitempty"`
+	ScopeName         string         `json:"scope_name,omitempty"`
+	ScopePath         string         `json:"scope_path,omitempty"`
+	Value             string         `json:"value,omitempty"`
+	Actions           []string       `json:"actions,omitempty"`
+	CreatedAt         string         `json:"created_at,omitempty"`
+	UpdatedAt         string         `json:"updated_at,omitempty"`
+	Raw               map[string]any `json:"raw,omitempty"`
+}
+
+type activityPayload struct {
+	ID                   string         `json:"id"`
+	TenantHost           string         `json:"tenant_host"`
+	ActivityType         int            `json:"activity_type,omitempty"`
+	ActivityUUID         string         `json:"activity_uuid,omitempty"`
+	AgentID              string         `json:"agent_id,omitempty"`
+	AgentUpdatedVersion  string         `json:"agent_updated_version,omitempty"`
+	CreatedAt            string         `json:"created_at,omitempty"`
+	UpdatedAt            string         `json:"updated_at,omitempty"`
+	Description          string         `json:"description,omitempty"`
+	PrimaryDescription   string         `json:"primary_description,omitempty"`
+	SecondaryDescription string         `json:"secondary_description,omitempty"`
+	Comments             string         `json:"comments,omitempty"`
+	GroupID              string         `json:"group_id,omitempty"`
+	GroupName            string         `json:"group_name,omitempty"`
+	OSFamily             string         `json:"os_family,omitempty"`
+	SiteID               string         `json:"site_id,omitempty"`
+	SiteName             string         `json:"site_name,omitempty"`
+	AccountID            string         `json:"account_id,omitempty"`
+	AccountName          string         `json:"account_name,omitempty"`
+	ThreatID             string         `json:"threat_id,omitempty"`
+	UserID               string         `json:"user_id,omitempty"`
+	Hash                 string         `json:"hash,omitempty"`
+	Data                 map[string]any `json:"data,omitempty"`
+	Raw                  map[string]any `json:"raw,omitempty"`
+}
+
+type applicationPayload struct {
+	AgentID       string         `json:"agent_id"`
+	TenantHost    string         `json:"tenant_host"`
+	Name          string         `json:"name,omitempty"`
+	Publisher     string         `json:"publisher,omitempty"`
+	Version       string         `json:"version,omitempty"`
+	InstalledDate string         `json:"installed_date,omitempty"`
+	SizeBytes     int64          `json:"size_bytes,omitempty"`
+	Raw           map[string]any `json:"raw,omitempty"`
+}
+
+// event builders
+
+func threatEvent(s settings, record threatRecord) (*primitives.Event, error) {
+	occurredAt := eventOccurredAt(
+		parseTimestamp(record.ThreatInfo.UpdatedAt),
+		parseTimestamp(record.ThreatInfo.IdentifiedAt),
+		parseTimestamp(record.ThreatInfo.CreatedAt),
+	)
+	raw, err := decodeRaw(record.raw, "sentinelone threat")
+	if err != nil {
+		return nil, err
+	}
+	indicators := buildIndicatorPayload(record.Indicators)
+	mitigations := buildMitigationActions(record.MitigationStatus)
+	payload, err := json.Marshal(threatPayload{
+		ID:                record.ID,
+		TenantHost:        s.host,
+		ThreatInfo:        toThreatInfoPayload(record.ThreatInfo),
+		AgentDetection:    toAgentDetectionPayload(record.AgentDetectionInfo),
+		AgentRealtime:     toAgentRealtimePayload(record.AgentRealtimeInfo),
+		Indicators:        indicators,
+		MitigationActions: mitigations,
+		WhiteningOptions:  record.WhiteningOptions,
+		Raw:               raw,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal sentinelone threat payload: %w", err)
+	}
+	return &primitives.Event{
+		Id:         eventID("sentinelone-threat", s, record.ID),
+		TenantId:   s.host,
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.threat",
+		OccurredAt: toTimestamp(occurredAt),
+		SchemaRef:  "sentinelone/threat/v1",
+		Payload:    payload,
+		Attributes: threatAttributes(s, record, indicators),
+	}, nil
+}
+
+func agentEvent(s settings, record agentRecord) (*primitives.Event, error) {
+	occurredAt := eventOccurredAt(
+		parseTimestamp(record.UpdatedAt),
+		parseTimestamp(record.LastActiveDate),
+		parseTimestamp(record.CreatedAt),
+		parseTimestamp(record.RegisteredAt),
+	)
+	raw, err := decodeRaw(record.raw, "sentinelone agent")
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(agentPayload{
+		agentIdentityPayload: agentIdentityPayload{
+			ID:           record.ID,
+			ComputerName: record.ComputerName,
+			UUID:         record.UUID,
+			AccountID:    record.AccountID,
+			AccountName:  record.AccountName,
+			ModelName:    record.ModelName,
+			SerialNumber: record.SerialNumber,
+			MachineType:  record.MachineType,
+			OSName:       record.OSName,
+			OSType:       record.OSType,
+			OSArch:       record.OSArch,
+			OSRevision:   record.OSRevision,
+		},
+		agentLifecyclePayloadFields: agentLifecyclePayloadFields{
+			AgentVersion:       record.AgentVersion,
+			LastActiveDate:     record.LastActiveDate,
+			LastSuccessfulScan: record.LastSuccessfulScanDate,
+			RegisteredAt:       record.RegisteredAt,
+			CreatedAt:          record.CreatedAt,
+			UpdatedAt:          record.UpdatedAt,
+		},
+		agentStatusPayload: agentStatusPayload{
+			IsActive:           record.IsActive,
+			IsDecommissioned:   record.IsDecommissioned,
+			IsUpToDate:         record.IsUpToDate,
+			IsUninstalled:      record.IsUninstalled,
+			IsPendingUninstall: record.IsPendingUninstall,
+			Infected:           record.Infected,
+			ActiveThreats:      record.ActiveThreats,
+			NetworkStatus:      record.NetworkStatus,
+			OperationalState:   record.OperationalState,
+			MitigationMode:     record.MitigationMode,
+			UserActionsNeeded:  record.UserActionsNeeded,
+		},
+		agentLocationPayload: agentLocationPayload{
+			Domain:     record.Domain,
+			ExternalIP: record.ExternalIP,
+			GroupID:    record.GroupID,
+			GroupName:  record.GroupName,
+			SiteID:     record.SiteID,
+			SiteName:   record.SiteName,
+		},
+		TenantHost: s.host,
+		Tags:       record.Tags,
+		Raw:        raw,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal sentinelone agent payload: %w", err)
+	}
+	return &primitives.Event{
+		Id:         eventID("sentinelone-agent", s, record.ID),
+		TenantId:   s.host,
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.agent",
+		OccurredAt: toTimestamp(occurredAt),
+		SchemaRef:  "sentinelone/agent/v1",
+		Payload:    payload,
+		Attributes: agentAttributes(s, record),
+	}, nil
+}
+
+func siteEvent(s settings, record siteRecord) (*primitives.Event, error) {
+	occurredAt := eventOccurredAt(
+		parseTimestamp(record.UpdatedAt),
+		parseTimestamp(record.CreatedAt),
+	)
+	raw, err := decodeRaw(record.raw, "sentinelone site")
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(sitePayload{
+		ID:            record.ID,
+		TenantHost:    s.host,
+		Name:          record.Name,
+		State:         record.State,
+		SiteType:      record.SiteType,
+		Description:   record.Description,
+		Expiration:    record.Expiration,
+		IsDefault:     record.IsDefault,
+		HealthStatus:  record.HealthStatus,
+		TotalLicenses: record.TotalLicenses,
+		UsedLicenses:  record.UsedLicenses,
+		AccountID:     record.AccountID,
+		AccountName:   record.AccountName,
+		CreatedAt:     record.CreatedAt,
+		UpdatedAt:     record.UpdatedAt,
+		Raw:           raw,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal sentinelone site payload: %w", err)
+	}
+	attrs := map[string]string{
+		"family":      familySite,
+		"site_id":     record.ID,
+		"tenant_host": s.host,
+	}
+	addAttribute(attrs, "site_name", record.Name)
+	addAttribute(attrs, "state", record.State)
+	addAttribute(attrs, "site_type", record.SiteType)
+	addAttribute(attrs, "account_id", record.AccountID)
+	addAttribute(attrs, "account_name", record.AccountName)
+	addAttribute(attrs, "is_default", boolString(record.IsDefault))
+	return &primitives.Event{
+		Id:         eventID("sentinelone-site", s, record.ID),
+		TenantId:   s.host,
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.site",
+		OccurredAt: toTimestamp(occurredAt),
+		SchemaRef:  "sentinelone/site/v1",
+		Payload:    payload,
+		Attributes: attrs,
+	}, nil
+}
+
+func groupEvent(s settings, record groupRecord) (*primitives.Event, error) {
+	occurredAt := eventOccurredAt(
+		parseTimestamp(record.UpdatedAt),
+		parseTimestamp(record.CreatedAt),
+	)
+	raw, err := decodeRaw(record.raw, "sentinelone group")
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(groupPayload{
+		ID:              record.ID,
+		TenantHost:      s.host,
+		Name:            record.Name,
+		Type:            record.Type,
+		Description:     record.Description,
+		IsDefault:       record.IsDefault,
+		Inherits:        record.Inherits,
+		Rank:            record.Rank,
+		SiteID:          record.SiteID,
+		TotalAgents:     record.TotalAgents,
+		FilterID:        record.FilterID,
+		FilterName:      record.FilterName,
+		Creator:         record.Creator,
+		CreatorID:       record.CreatorID,
+		HasRegistration: strings.TrimSpace(record.RegistrationToken) != "",
+		CreatedAt:       record.CreatedAt,
+		UpdatedAt:       record.UpdatedAt,
+		Raw:             raw,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal sentinelone group payload: %w", err)
+	}
+	attrs := map[string]string{
+		"family":      familyGroup,
+		"group_id":    record.ID,
+		"tenant_host": s.host,
+	}
+	addAttribute(attrs, "group_name", record.Name)
+	addAttribute(attrs, "site_id", record.SiteID)
+	addAttribute(attrs, "type", record.Type)
+	addAttribute(attrs, "is_default", boolString(record.IsDefault))
+	addAttribute(attrs, "total_agents", intToString(record.TotalAgents))
+	return &primitives.Event{
+		Id:         eventID("sentinelone-group", s, record.ID),
+		TenantId:   s.host,
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.group",
+		OccurredAt: toTimestamp(occurredAt),
+		SchemaRef:  "sentinelone/group/v1",
+		Payload:    payload,
+		Attributes: attrs,
+	}, nil
+}
+
+func exclusionEvent(s settings, record exclusionRecord) (*primitives.Event, error) {
+	occurredAt := eventOccurredAt(
+		parseTimestamp(record.UpdatedAt),
+		parseTimestamp(record.CreatedAt),
+	)
+	raw, err := decodeRaw(record.raw, "sentinelone exclusion")
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(exclusionPayload{
+		ID:                record.ID,
+		TenantHost:        s.host,
+		Type:              record.Type,
+		Mode:              record.Mode,
+		Source:            record.Source,
+		OSType:            record.OSType,
+		PathExclusionType: record.PathExclusionType,
+		IncludeChildren:   record.IncludeChildren,
+		IncludeParents:    record.IncludeParents,
+		Imported:          record.Imported,
+		NotRecommended:    record.NotRecommended,
+		Description:       record.Description,
+		ApplicationName:   record.ApplicationName,
+		UserID:            record.UserID,
+		UserName:          record.UserName,
+		Scope:             record.Scope,
+		ScopeName:         record.ScopeName,
+		ScopePath:         record.ScopePath,
+		Value:             record.Value,
+		Actions:           record.Actions,
+		CreatedAt:         record.CreatedAt,
+		UpdatedAt:         record.UpdatedAt,
+		Raw:               raw,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal sentinelone exclusion payload: %w", err)
+	}
+	attrs := map[string]string{
+		"family":       familyExclusion,
+		"exclusion_id": record.ID,
+		"tenant_host":  s.host,
+	}
+	addAttribute(attrs, "exclusion_type", record.Type)
+	addAttribute(attrs, "mode", record.Mode)
+	addAttribute(attrs, "os_type", record.OSType)
+	addAttribute(attrs, "scope", record.Scope)
+	addAttribute(attrs, "scope_name", record.ScopeName)
+	addAttribute(attrs, "value", record.Value)
+	addAttribute(attrs, "not_recommended", boolString(record.NotRecommended))
+	return &primitives.Event{
+		Id:         eventID("sentinelone-exclusion", s, record.ID),
+		TenantId:   s.host,
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.exclusion",
+		OccurredAt: toTimestamp(occurredAt),
+		SchemaRef:  "sentinelone/exclusion/v1",
+		Payload:    payload,
+		Attributes: attrs,
+	}, nil
+}
+
+func activityEvent(s settings, record activityRecord) (*primitives.Event, error) {
+	occurredAt := eventOccurredAt(
+		parseTimestamp(record.CreatedAt),
+		parseTimestamp(record.UpdatedAt),
+	)
+	raw, err := decodeRaw(record.raw, "sentinelone activity")
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(activityPayload{
+		ID:                   record.ID,
+		TenantHost:           s.host,
+		ActivityType:         record.ActivityType,
+		ActivityUUID:         record.ActivityUUID,
+		AgentID:              record.AgentID,
+		AgentUpdatedVersion:  record.AgentUpdatedVersion,
+		CreatedAt:            record.CreatedAt,
+		UpdatedAt:            record.UpdatedAt,
+		Description:          record.Description,
+		PrimaryDescription:   record.PrimaryDescription,
+		SecondaryDescription: record.SecondaryDescription,
+		Comments:             record.Comments,
+		GroupID:              record.GroupID,
+		GroupName:            record.GroupName,
+		OSFamily:             record.OSFamily,
+		SiteID:               record.SiteID,
+		SiteName:             record.SiteName,
+		AccountID:            record.AccountID,
+		AccountName:          record.AccountName,
+		ThreatID:             record.ThreatID,
+		UserID:               record.UserID,
+		Hash:                 record.Hash,
+		Data:                 record.Data,
+		Raw:                  raw,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal sentinelone activity payload: %w", err)
+	}
+	attrs := map[string]string{
+		"family":        familyActivity,
+		"activity_id":   record.ID,
+		"tenant_host":   s.host,
+		"activity_type": intToString(record.ActivityType),
+	}
+	addAttribute(attrs, "activity_uuid", record.ActivityUUID)
+	addAttribute(attrs, "agent_id", record.AgentID)
+	addAttribute(attrs, "site_id", record.SiteID)
+	addAttribute(attrs, "group_id", record.GroupID)
+	addAttribute(attrs, "threat_id", record.ThreatID)
+	addAttribute(attrs, "user_id", record.UserID)
+	addAttribute(attrs, "primary_description", record.PrimaryDescription)
+	addAttribute(attrs, "os_family", record.OSFamily)
+	return &primitives.Event{
+		Id:         eventID("sentinelone-activity", s, record.ID),
+		TenantId:   s.host,
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.activity",
+		OccurredAt: toTimestamp(occurredAt),
+		SchemaRef:  "sentinelone/activity/v1",
+		Payload:    payload,
+		Attributes: attrs,
+	}, nil
+}
+
+func applicationEvent(s settings, record applicationRecord) (*primitives.Event, error) {
+	occurredAt := eventOccurredAt(parseTimestamp(record.InstalledDate))
+	raw, err := decodeRaw(record.raw, "sentinelone application")
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(applicationPayload{
+		AgentID:       s.agentID,
+		TenantHost:    s.host,
+		Name:          record.Name,
+		Publisher:     record.Publisher,
+		Version:       record.Version,
+		InstalledDate: record.InstalledDate,
+		SizeBytes:     record.Size,
+		Raw:           raw,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal sentinelone application payload: %w", err)
+	}
+	attrs := map[string]string{
+		"family":      familyApplication,
+		"agent_id":    s.agentID,
+		"tenant_host": s.host,
+	}
+	addAttribute(attrs, "application_name", record.Name)
+	addAttribute(attrs, "publisher", record.Publisher)
+	addAttribute(attrs, "version", record.Version)
+	addAttribute(attrs, "installed_date", record.InstalledDate)
+	return &primitives.Event{
+		Id:         eventID("sentinelone-application", s, s.agentID, applicationID(s, record)),
+		TenantId:   s.host,
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.application_inventory",
+		OccurredAt: toTimestamp(occurredAt),
+		SchemaRef:  "sentinelone/application_inventory/v1",
+		Payload:    payload,
+		Attributes: attrs,
+	}, nil
+}
+
+func toThreatInfoPayload(info threatInfoRecord) threatInfoPayload {
+	return threatInfoPayload{
+		threatClassificationPayload: threatClassificationPayload(info.threatClassificationRecord),
+		threatLifecyclePayload:      threatLifecyclePayload(info.threatLifecycleRecord),
+		threatFilePayload:           threatFilePayload(info.threatFileRecord),
+	}
+}
+
+func toAgentDetectionPayload(info agentDetectionInfoRecord) agentDetectionPayload {
+	return agentDetectionPayload{
+		AccountID:    info.AccountID,
+		AccountName:  info.AccountName,
+		Domain:       info.AgentDomain,
+		IPV4:         info.AgentIPV4,
+		IPV6:         info.AgentIPV6,
+		OSName:       info.AgentOSName,
+		OSRevision:   info.AgentOSRevision,
+		RegisteredAt: info.AgentRegisteredAt,
+		UUID:         info.AgentUUID,
+		Version:      info.AgentVersion,
+		ExternalIP:   info.ExternalIP,
+		GroupID:      info.GroupID,
+		GroupName:    info.GroupName,
+		SiteID:       info.SiteID,
+		SiteName:     info.SiteName,
+		UserMail:     info.AgentLastLoggedInUserMail,
+		UserName:     info.AgentLastLoggedInUserName,
+	}
+}
+
+func toAgentRealtimePayload(info agentRealtimeInfoRecord) agentRealtimePayload {
+	return agentRealtimePayload{
+		AgentID:          info.AgentID,
+		ComputerName:     info.AgentComputerName,
+		OSName:           info.AgentOSName,
+		OSType:           info.AgentOSType,
+		OSRevision:       info.AgentOSRevision,
+		IsActive:         info.AgentIsActive,
+		IsDecommissioned: info.AgentIsDecommissioned,
+		Infected:         info.AgentInfected,
+		ActiveThreats:    info.ActiveThreats,
+		NetworkStatus:    info.AgentNetworkStatus,
+		OperationalState: info.OperationalState,
+		RebootRequired:   info.RebootRequired,
+		ScanStatus:       info.ScanStatus,
+		MitigationMode:   info.AgentMitigationMode,
+		UUID:             info.AgentUUID,
+		Version:          info.AgentVersion,
+		GroupID:          info.GroupID,
+		GroupName:        info.GroupName,
+		SiteID:           info.SiteID,
+		SiteName:         info.SiteName,
+	}
+}
+
+func buildIndicatorPayload(records []threatIndicatorRecord) indicatorPayload {
+	categories := map[string]struct{}{}
+	tactics := map[string]struct{}{}
+	techniques := map[string]struct{}{}
+	descs := map[string]struct{}{}
+	for _, ind := range records {
+		if cat := strings.TrimSpace(ind.Category); cat != "" {
+			categories[cat] = struct{}{}
+		}
+		for _, c := range ind.Categories {
+			if c = strings.TrimSpace(c); c != "" {
+				categories[c] = struct{}{}
+			}
+		}
+		if d := strings.TrimSpace(ind.Description); d != "" {
+			descs[d] = struct{}{}
+		}
+		for _, tac := range ind.Tactics {
+			if name := strings.TrimSpace(tac.Name); name != "" {
+				tactics[name] = struct{}{}
+			}
+			for _, technique := range tac.Techniques {
+				if name := strings.TrimSpace(technique.Name); name != "" {
+					techniques[name] = struct{}{}
+				}
+			}
+		}
+	}
+	return indicatorPayload{
+		Categories:      sortedStrings(mapKeys(categories)),
+		MitreTactics:    sortedStrings(mapKeys(tactics)),
+		MitreTechniques: sortedStrings(mapKeys(techniques)),
+		Descriptions:    sortedStrings(mapKeys(descs)),
+	}
+}
+
+func buildMitigationActions(records []mitigationStatusRecord) []mitigationActionPayload {
+	actions := make([]mitigationActionPayload, 0, len(records))
+	for _, m := range records {
+		actions = append(actions, mitigationActionPayload{
+			Action:     m.Action,
+			Status:     m.Status,
+			StartedAt:  m.MitigationStartedAt,
+			EndedAt:    m.MitigationEndedAt,
+			LastUpdate: m.LastUpdate,
+			ReportID:   m.ReportID,
+		})
+	}
+	return actions
+}
+
+func mapKeys(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for k := range values {
+		out = append(out, k)
+	}
+	return out
+}
+
+func threatAttributes(s settings, record threatRecord, indicators indicatorPayload) map[string]string {
+	attrs := map[string]string{
+		"family":            familyThreat,
+		"threat_id":         record.ID,
+		"tenant_host":       s.host,
+		"is_active":         boolString(record.AgentRealtimeInfo.AgentIsActive),
+		"is_decommissioned": boolString(record.AgentRealtimeInfo.AgentIsDecommissioned),
+		"is_infected":       boolString(record.AgentRealtimeInfo.AgentInfected),
+		"is_fileless":       boolString(record.ThreatInfo.IsFileless),
+	}
+	addAttribute(attrs, "classification", record.ThreatInfo.Classification)
+	addAttribute(attrs, "classification_source", record.ThreatInfo.ClassificationSource)
+	addAttribute(attrs, "analyst_verdict", record.ThreatInfo.AnalystVerdict)
+	addAttribute(attrs, "incident_status", record.ThreatInfo.IncidentStatus)
+	addAttribute(attrs, "confidence_level", record.ThreatInfo.ConfidenceLevel)
+	addAttribute(attrs, "mitigation_status", record.ThreatInfo.MitigationStatus)
+	addAttribute(attrs, "detection_type", record.ThreatInfo.DetectionType)
+	addAttribute(attrs, "threat_name", record.ThreatInfo.ThreatName)
+	addAttribute(attrs, "file_path", record.ThreatInfo.FilePath)
+	addAttribute(attrs, "sha256", record.ThreatInfo.Sha256)
+	addAttribute(attrs, "agent_id", firstNonEmpty(record.AgentRealtimeInfo.AgentID, record.AgentDetectionInfo.AgentUUID))
+	addAttribute(attrs, "agent_uuid", record.AgentDetectionInfo.AgentUUID)
+	addAttribute(attrs, "agent_name", record.AgentRealtimeInfo.AgentComputerName)
+	addAttribute(attrs, "computer_name", record.AgentRealtimeInfo.AgentComputerName)
+	addAttribute(attrs, "site_id", firstNonEmpty(record.AgentDetectionInfo.SiteID, record.AgentRealtimeInfo.SiteID))
+	addAttribute(attrs, "group_id", firstNonEmpty(record.AgentDetectionInfo.GroupID, record.AgentRealtimeInfo.GroupID))
+	addAttribute(attrs, "site_name", firstNonEmpty(record.AgentDetectionInfo.SiteName, record.AgentRealtimeInfo.SiteName))
+	addAttribute(attrs, "group_name", firstNonEmpty(record.AgentDetectionInfo.GroupName, record.AgentRealtimeInfo.GroupName))
+	addAttribute(attrs, "account_id", firstNonEmpty(record.AgentDetectionInfo.AccountID, record.AgentRealtimeInfo.AccountID))
+	addAttribute(attrs, "account_name", firstNonEmpty(record.AgentDetectionInfo.AccountName, record.AgentRealtimeInfo.AccountName))
+	addAttribute(attrs, "agent_os_name", firstNonEmpty(record.AgentDetectionInfo.AgentOSName, record.AgentRealtimeInfo.AgentOSName))
+	addAttribute(attrs, "agent_os_type", record.AgentRealtimeInfo.AgentOSType)
+	addAttribute(attrs, "agent_ip_v4", record.AgentDetectionInfo.AgentIPV4)
+	addAttribute(attrs, "external_ip", record.AgentDetectionInfo.ExternalIP)
+	addAttribute(attrs, "user_mail", record.AgentDetectionInfo.AgentLastLoggedInUserMail)
+	addAttribute(attrs, "user_name", record.AgentDetectionInfo.AgentLastLoggedInUserName)
+	if len(indicators.MitreTactics) != 0 {
+		attrs["mitre_tactics"] = strings.Join(indicators.MitreTactics, ",")
+	}
+	if len(indicators.MitreTechniques) != 0 {
+		attrs["mitre_techniques"] = strings.Join(indicators.MitreTechniques, ",")
+	}
+	if len(indicators.Categories) != 0 {
+		attrs["indicator_categories"] = strings.Join(indicators.Categories, ",")
+	}
+	return attrs
+}
+
+func agentAttributes(s settings, record agentRecord) map[string]string {
+	attrs := map[string]string{
+		"family":               familyAgent,
+		"agent_id":             record.ID,
+		"tenant_host":          s.host,
+		"is_active":            boolString(record.IsActive),
+		"is_decommissioned":    boolString(record.IsDecommissioned),
+		"is_uninstalled":       boolString(record.IsUninstalled),
+		"is_pending_uninstall": boolString(record.IsPendingUninstall),
+		"is_up_to_date":        boolString(record.IsUpToDate),
+		"infected":             boolString(record.Infected),
+		"firewall_enabled":     boolString(record.FirewallEnabled),
+		"active_threats":       intToString(record.ActiveThreats),
+	}
+	addAttribute(attrs, "computer_name", record.ComputerName)
+	addAttribute(attrs, "uuid", record.UUID)
+	addAttribute(attrs, "os_name", record.OSName)
+	addAttribute(attrs, "os_type", record.OSType)
+	addAttribute(attrs, "os_arch", record.OSArch)
+	addAttribute(attrs, "os_revision", record.OSRevision)
+	addAttribute(attrs, "agent_version", record.AgentVersion)
+	addAttribute(attrs, "last_active_date", record.LastActiveDate)
+	addAttribute(attrs, "registered_at", record.RegisteredAt)
+	addAttribute(attrs, "domain", record.Domain)
+	addAttribute(attrs, "external_ip", record.ExternalIP)
+	addAttribute(attrs, "site_id", record.SiteID)
+	addAttribute(attrs, "site_name", record.SiteName)
+	addAttribute(attrs, "group_id", record.GroupID)
+	addAttribute(attrs, "group_name", record.GroupName)
+	addAttribute(attrs, "account_id", record.AccountID)
+	addAttribute(attrs, "account_name", record.AccountName)
+	addAttribute(attrs, "machine_type", record.MachineType)
+	addAttribute(attrs, "model_name", record.ModelName)
+	addAttribute(attrs, "serial_number", record.SerialNumber)
+	addAttribute(attrs, "operational_state", record.OperationalState)
+	addAttribute(attrs, "network_status", record.NetworkStatus)
+	addAttribute(attrs, "mitigation_mode", record.MitigationMode)
+	if len(record.UserActionsNeeded) != 0 {
+		attrs["user_actions_needed"] = strings.Join(record.UserActionsNeeded, ",")
+	}
+	return attrs
+}
+
+// timeFormatter helper kept to avoid removing time import if not used elsewhere.
+var _ = time.RFC3339

--- a/sources/sentinelone/source.go
+++ b/sources/sentinelone/source.go
@@ -1,0 +1,893 @@
+package sentinelone
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+//go:embed catalog.yaml
+var catalogFS embed.FS
+
+const (
+	defaultPageSize = 10
+	maxPageSize     = 200
+	httpTimeout     = 30 * time.Second
+	maxBodyBytes    = 8 << 20
+	defaultFamily   = familyThreat
+
+	familyActivity    = "activity"
+	familyAgent       = "agent"
+	familyApplication = "application"
+	familyExclusion   = "exclusion"
+	familyGroup       = "group"
+	familySite        = "site"
+	familyThreat      = "threat"
+)
+
+// Source is the live SentinelOne source preview used by the builtin registry.
+type Source struct {
+	spec                 *cerebrov1.SourceSpec
+	client               *http.Client
+	families             *sourcecdk.FamilyEngine[settings]
+	allowLoopbackBaseURL bool
+	lookupIPAddrs        func(context.Context, string) ([]net.IPAddr, error)
+}
+
+type settings struct {
+	family   string
+	baseURL  string
+	host     string
+	token    string
+	siteID   string
+	groupID  string
+	agentID  string
+	since    string
+	until    string
+	activity string
+	perPage  int
+}
+
+type listResponse struct {
+	Data       []json.RawMessage `json:"data"`
+	Pagination paginationInfo    `json:"pagination"`
+}
+
+type paginationInfo struct {
+	NextCursor string `json:"nextCursor"`
+	TotalItems int    `json:"totalItems"`
+}
+
+type apiError struct {
+	Errors []apiErrorDetail `json:"errors"`
+}
+
+type apiErrorDetail struct {
+	Code   int    `json:"code"`
+	Detail string `json:"detail"`
+	Title  string `json:"title"`
+}
+
+type responseError struct {
+	statusCode int
+	message    string
+}
+
+func (e *responseError) Error() string {
+	return e.message
+}
+
+func (e *responseError) StatusCode() int {
+	return e.statusCode
+}
+
+// New constructs the live SentinelOne source.
+func New() (*Source, error) {
+	spec, err := loadSpec()
+	if err != nil {
+		return nil, err
+	}
+	source := &Source{
+		spec:          spec,
+		lookupIPAddrs: net.DefaultResolver.LookupIPAddr,
+	}
+	source.families, err = source.newFamilyEngine()
+	if err != nil {
+		return nil, err
+	}
+	return source, nil
+}
+
+// Spec returns the static metadata for the SentinelOne source.
+func (s *Source) Spec() *cerebrov1.SourceSpec {
+	return s.spec
+}
+
+// Check validates that the configured SentinelOne family is reachable.
+func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
+	return s.families.Check(ctx, cfg)
+}
+
+// Discover returns SentinelOne URNs for the configured family.
+func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return s.families.Discover(ctx, cfg)
+}
+
+// Read pages through the configured SentinelOne family.
+func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return s.families.Read(ctx, cfg, cursor)
+}
+
+func loadSpec() (*cerebrov1.SourceSpec, error) {
+	specBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read catalog: %w", err)
+	}
+	spec, err := sourcecdk.LoadCatalog(specBytes)
+	if err != nil {
+		return nil, fmt.Errorf("load catalog: %w", err)
+	}
+	return spec, nil
+}
+
+func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
+	return parseSettings(cfg, s != nil && s.allowLoopbackBaseURL)
+}
+
+func parseSettings(cfg sourcecdk.Config, allowLoopbackBaseURL bool) (settings, error) {
+	resolved := settings{
+		family:   configValue(cfg, "family"),
+		baseURL:  configValue(cfg, "base_url"),
+		token:    configValue(cfg, "token"),
+		siteID:   configValue(cfg, "site_id"),
+		groupID:  configValue(cfg, "group_id"),
+		agentID:  configValue(cfg, "agent_id"),
+		since:    configValue(cfg, "since"),
+		until:    configValue(cfg, "until"),
+		activity: configValue(cfg, "activity_type"),
+		perPage:  defaultPageSize,
+	}
+	if resolved.family == "" {
+		resolved.family = defaultFamily
+	}
+	switch resolved.family {
+	case familyActivity, familyAgent, familyApplication, familyExclusion, familyGroup, familySite, familyThreat:
+	default:
+		return resolved, fmt.Errorf("sentinelone family must be one of activity, agent, application, exclusion, group, site, or threat")
+	}
+	if resolved.baseURL == "" {
+		return resolved, fmt.Errorf("sentinelone base_url is required")
+	}
+	normalizedBase, host, err := normalizeBaseURL(resolved.baseURL, allowLoopbackBaseURL)
+	if err != nil {
+		return resolved, err
+	}
+	resolved.baseURL = normalizedBase
+	resolved.host = host
+	if resolved.token == "" {
+		return resolved, fmt.Errorf("sentinelone token is required")
+	}
+	if rawPerPage, ok := cfg.Lookup("per_page"); ok && strings.TrimSpace(rawPerPage) != "" {
+		perPage, err := strconv.Atoi(strings.TrimSpace(rawPerPage))
+		if err != nil {
+			return resolved, fmt.Errorf("parse sentinelone per_page: %w", err)
+		}
+		if perPage < 1 || perPage > maxPageSize {
+			return resolved, fmt.Errorf("sentinelone per_page must be between 1 and %d", maxPageSize)
+		}
+		resolved.perPage = perPage
+	}
+	if resolved.family == familyApplication && resolved.agentID == "" {
+		return resolved, fmt.Errorf("sentinelone agent_id is required when family=%q", familyApplication)
+	}
+	switch resolved.family {
+	case familyActivity, familyThreat:
+	default:
+		if resolved.since != "" || resolved.until != "" {
+			return resolved, fmt.Errorf("sentinelone since/until are only supported when family is %q or %q", familyActivity, familyThreat)
+		}
+	}
+	return resolved, nil
+}
+
+func normalizeBaseURL(raw string, allowLoopback bool) (string, string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", "", fmt.Errorf("parse sentinelone base_url: %w", err)
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	allowInsecureLoopback := allowLoopback && parsed.Scheme == "http" && isLoopbackHost(host)
+	if parsed.Scheme != "https" && !allowInsecureLoopback {
+		return "", "", fmt.Errorf("sentinelone base_url must use https")
+	}
+	if host == "" {
+		return "", "", fmt.Errorf("sentinelone base_url must include a host")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", "", fmt.Errorf("sentinelone base_url must not include user info, query, or fragment")
+	}
+	if (parsed.Path != "" && parsed.Path != "/") || parsed.RawPath != "" {
+		return "", "", fmt.Errorf("sentinelone base_url must be an origin URL")
+	}
+	allowCustomPort := allowLoopback && isLoopbackHost(host)
+	if strings.TrimSpace(parsed.Port()) != "" && parsed.Port() != "443" && !allowCustomPort {
+		return "", "", fmt.Errorf("sentinelone base_url must not include a custom port")
+	}
+	allowLoopbackHost := allowLoopback && isLoopbackHost(host)
+	if isUnsafeHost(host) && !allowLoopbackHost {
+		return "", "", fmt.Errorf("sentinelone base_url must not target loopback, private, or link-local hosts")
+	}
+	parsed.Path = ""
+	return strings.TrimRight(parsed.String(), "/"), host, nil
+}
+
+func isUnsafeHost(host string) bool {
+	value := normalizedIPHost(host)
+	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(value)
+	if ip == nil {
+		ip = parseNumericIPv4Host(value)
+	}
+	if ip == nil {
+		return false
+	}
+	return isUnsafeIP(ip)
+}
+
+func isUnsafeIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast()
+}
+
+func isLoopbackHost(host string) bool {
+	value := normalizedIPHost(host)
+	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(value)
+	if ip == nil {
+		ip = parseNumericIPv4Host(value)
+	}
+	return ip != nil && ip.IsLoopback()
+}
+
+func normalizedIPHost(host string) string {
+	value := strings.TrimRight(strings.ToLower(strings.TrimSpace(host)), ".")
+	value = strings.Trim(value, "[]")
+	if address, _, ok := strings.Cut(value, "%"); ok {
+		value = address
+	}
+	return value
+}
+
+func parseNumericIPv4Host(host string) net.IP {
+	if strings.Contains(host, ":") {
+		return nil
+	}
+	parts := strings.Split(host, ".")
+	if len(parts) == 0 || len(parts) > 4 {
+		return nil
+	}
+	values := make([]uint64, len(parts))
+	for i, part := range parts {
+		if part == "" {
+			return nil
+		}
+		value, err := strconv.ParseUint(part, 0, 32)
+		if err != nil {
+			return nil
+		}
+		values[i] = value
+	}
+	var ipv4 uint32
+	switch len(values) {
+	case 1:
+		ipv4 = uint32(values[0])
+	case 2:
+		if values[0] > 0xff || values[1] > 0xffffff {
+			return nil
+		}
+		ipv4 = uint32(values[0]<<24 | values[1])
+	case 3:
+		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xffff {
+			return nil
+		}
+		ipv4 = uint32(values[0]<<24 | values[1]<<16 | values[2])
+	case 4:
+		if values[0] > 0xff || values[1] > 0xff || values[2] > 0xff || values[3] > 0xff {
+			return nil
+		}
+		ipv4 = uint32(values[0]<<24 | values[1]<<16 | values[2]<<8 | values[3])
+	}
+	return net.IPv4(byte(ipv4>>24), byte(ipv4>>16), byte(ipv4>>8), byte(ipv4))
+}
+
+type listFunc[T any] func(context.Context, settings, string, int) ([]T, string, error)
+
+type familyOptions[T any] struct {
+	Name           string
+	Label          string
+	List           listFunc[T]
+	Event          func(settings, T) (*primitives.Event, error)
+	URN            func(settings, T) (string, error)
+	Discover       func(context.Context, settings) ([]sourcecdk.URN, error)
+	CursorFallback func(T) string
+}
+
+func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
+	return sourcecdk.NewFamilyEngine(s.parseSettings, func(settings settings) string {
+		return settings.family
+	},
+		family(familyOptions[threatRecord]{
+			Name:  familyThreat,
+			Label: "sentinelone threat",
+			List:  s.listThreats,
+			Event: threatEvent,
+			URN: func(settings settings, threat threatRecord) (string, error) {
+				return fmt.Sprintf("urn:cerebro:%s:threat:%s", settings.host, threat.ID), nil
+			},
+			CursorFallback: func(t threatRecord) string { return t.ID },
+		}),
+		family(familyOptions[agentRecord]{
+			Name:  familyAgent,
+			Label: "sentinelone agent",
+			List:  s.listAgents,
+			Event: agentEvent,
+			URN: func(settings settings, agent agentRecord) (string, error) {
+				return fmt.Sprintf("urn:cerebro:%s:agent:%s", settings.host, agent.ID), nil
+			},
+			CursorFallback: func(a agentRecord) string { return a.ID },
+		}),
+		family(familyOptions[siteRecord]{
+			Name:  familySite,
+			Label: "sentinelone site",
+			List:  s.listSites,
+			Event: siteEvent,
+			URN: func(settings settings, site siteRecord) (string, error) {
+				return fmt.Sprintf("urn:cerebro:%s:site:%s", settings.host, site.ID), nil
+			},
+			CursorFallback: func(r siteRecord) string { return r.ID },
+		}),
+		family(familyOptions[groupRecord]{
+			Name:  familyGroup,
+			Label: "sentinelone group",
+			List:  s.listGroups,
+			Event: groupEvent,
+			URN: func(settings settings, group groupRecord) (string, error) {
+				return fmt.Sprintf("urn:cerebro:%s:group:%s", settings.host, group.ID), nil
+			},
+			CursorFallback: func(r groupRecord) string { return r.ID },
+		}),
+		family(familyOptions[exclusionRecord]{
+			Name:  familyExclusion,
+			Label: "sentinelone exclusion",
+			List:  s.listExclusions,
+			Event: exclusionEvent,
+			URN: func(settings settings, exclusion exclusionRecord) (string, error) {
+				return fmt.Sprintf("urn:cerebro:%s:exclusion:%s", settings.host, exclusion.ID), nil
+			},
+			CursorFallback: func(r exclusionRecord) string { return r.ID },
+		}),
+		family(familyOptions[activityRecord]{
+			Name:  familyActivity,
+			Label: "sentinelone activity",
+			List:  s.listActivities,
+			Event: activityEvent,
+			URN: func(settings settings, activity activityRecord) (string, error) {
+				return fmt.Sprintf("urn:cerebro:%s:activity:%s", settings.host, activity.ID), nil
+			},
+			CursorFallback: func(r activityRecord) string { return r.ID },
+		}),
+		family(familyOptions[applicationRecord]{
+			Name:  familyApplication,
+			Label: "sentinelone application inventory",
+			List:  s.listApplications,
+			Event: applicationEvent,
+			Discover: func(ctx context.Context, settings settings) ([]sourcecdk.URN, error) {
+				if err := agentApplicationCheck(ctx, s, settings); err != nil {
+					return nil, err
+				}
+				urn, err := sourcecdk.ParseURN(fmt.Sprintf("urn:cerebro:%s:agent:%s", settings.host, settings.agentID))
+				if err != nil {
+					return nil, err
+				}
+				return []sourcecdk.URN{urn}, nil
+			},
+			URN: func(settings settings, app applicationRecord) (string, error) {
+				return fmt.Sprintf("urn:cerebro:%s:application_inventory:%s:%s", settings.host, settings.agentID, applicationID(settings, app)), nil
+			},
+			CursorFallback: func(app applicationRecord) string { return applicationID(settings{}, app) },
+		}),
+	)
+}
+
+func family[T any](options familyOptions[T]) sourcecdk.Family[settings] {
+	return sourcecdk.Family[settings]{
+		Name: options.Name,
+		Check: func(ctx context.Context, settings settings) error {
+			_, _, err := options.List(ctx, settings, "", 1)
+			if err != nil {
+				return wrapLookupError(label(options.Label, settings), err)
+			}
+			return nil
+		},
+		Discover: func(ctx context.Context, settings settings) ([]sourcecdk.URN, error) {
+			if options.Discover != nil {
+				return options.Discover(ctx, settings)
+			}
+			records, _, err := options.List(ctx, settings, "", settings.perPage)
+			if err != nil {
+				return nil, wrapLookupError(label(options.Label, settings), err)
+			}
+			return urnsFor(settings, records, options.URN)
+		},
+		Read: func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+			records, next, err := options.List(ctx, settings, strings.TrimSpace(cursor.GetOpaque()), settings.perPage)
+			if err != nil {
+				return sourcecdk.Pull{}, wrapLookupError(label(options.Label, settings), err)
+			}
+			build := func(record T) (*primitives.Event, error) {
+				return options.Event(settings, record)
+			}
+			return pullFromRecords(records, next, build, options.CursorFallback)
+		},
+	}
+}
+
+func label(prefix string, settings settings) string {
+	return fmt.Sprintf("%s for %s", prefix, settings.host)
+}
+
+func urnsFor[T any](settings settings, records []T, render func(settings, T) (string, error)) ([]sourcecdk.URN, error) {
+	urns := make([]sourcecdk.URN, 0, len(records))
+	for _, record := range records {
+		rawURN, err := render(settings, record)
+		if err != nil {
+			return nil, err
+		}
+		urn, err := sourcecdk.ParseURN(rawURN)
+		if err != nil {
+			return nil, err
+		}
+		urns = append(urns, urn)
+	}
+	return urns, nil
+}
+
+func pullFromRecords[T any](records []T, next string, build func(T) (*primitives.Event, error), cursorFallback func(T) string) (sourcecdk.Pull, error) {
+	if len(records) == 0 {
+		return sourcecdk.Pull{}, nil
+	}
+	events := make([]*primitives.Event, 0, len(records))
+	for _, record := range records {
+		event, err := build(record)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		events = append(events, event)
+	}
+	fallback := events[len(events)-1].GetId()
+	if cursorFallback != nil {
+		fallback = cursorFallback(records[len(records)-1])
+	}
+	pull := sourcecdk.Pull{
+		Events: events,
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    events[len(events)-1].OccurredAt,
+			CursorOpaque: checkpointCursor(next, fallback, events[len(events)-1].OccurredAt.AsTime()),
+		},
+	}
+	if next != "" {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
+	}
+	return pull, nil
+}
+
+func agentApplicationCheck(ctx context.Context, source *Source, settings settings) error {
+	_, _, err := source.listApplications(ctx, settings, "", 1)
+	if err != nil {
+		return wrapLookupError(label("sentinelone application inventory", settings), err)
+	}
+	return nil
+}
+
+func (s *Source) getJSON(ctx context.Context, settings settings, requestPath string, query url.Values, target any) error {
+	endpoint := settings.baseURL + requestPath
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("build request %s: %w", requestPath, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "ApiToken "+settings.token)
+
+	client := s.client
+	if client == nil {
+		client = httpClientNoRedirect(nil, s != nil && s.allowLoopbackBaseURL, lookupIPAddrs(s))
+	} else {
+		client = httpClientNoRedirect(client, s != nil && s.allowLoopbackBaseURL, lookupIPAddrs(s))
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", requestPath, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := readLimitedBody(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read %s response: %w", requestPath, err)
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return decodeResponseError(resp.StatusCode, body)
+	}
+	if target == nil || len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, target); err != nil {
+		return fmt.Errorf("decode %s response: %w", requestPath, err)
+	}
+	return nil
+}
+
+func httpClientNoRedirect(client *http.Client, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
+	if client == nil {
+		client = &http.Client{Timeout: httpTimeout}
+	}
+	cloned := *client
+	if cloned.CheckRedirect == nil {
+		cloned.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+	transport := cloned.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	cloned.Transport = safeRoundTripper{base: transport, allowLoopback: allowLoopback, lookupIPAddrs: lookupIPAddrs}
+	return &cloned
+}
+
+func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {
+	if source != nil && source.lookupIPAddrs != nil {
+		return source.lookupIPAddrs
+	}
+	return net.DefaultResolver.LookupIPAddr
+}
+
+type safeRoundTripper struct {
+	base          http.RoundTripper
+	allowLoopback bool
+	lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)
+}
+
+func (rt safeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req != nil && req.URL != nil {
+		if err := rejectResolvedUnsafeHost(req.Context(), req.URL.Hostname(), rt.allowLoopback, rt.lookupIPAddrs); err != nil {
+			return nil, err
+		}
+	}
+	return rt.base.RoundTrip(req)
+}
+
+func rejectResolvedUnsafeHost(ctx context.Context, host string, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) error {
+	normalized := normalizedIPHost(host)
+	if normalized == "" {
+		return nil
+	}
+	if isUnsafeHost(normalized) {
+		if allowLoopback && isLoopbackHost(normalized) {
+			return nil
+		}
+		return fmt.Errorf("sentinelone base_url must not target loopback, private, or link-local hosts")
+	}
+	if lookupIPAddrs == nil {
+		lookupIPAddrs = net.DefaultResolver.LookupIPAddr
+	}
+	addrs, err := lookupIPAddrs(ctx, normalized)
+	if err != nil {
+		return fmt.Errorf("resolve sentinelone base_url host %q: %w", normalized, err)
+	}
+	for _, addr := range addrs {
+		if isUnsafeIP(addr.IP) {
+			if allowLoopback && addr.IP != nil && addr.IP.IsLoopback() {
+				continue
+			}
+			return fmt.Errorf("sentinelone base_url must not target loopback, private, or link-local hosts")
+		}
+	}
+	return nil
+}
+
+func readLimitedBody(body io.Reader) ([]byte, error) {
+	limited := io.LimitReader(body, maxBodyBytes+1)
+	payload, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if len(payload) > maxBodyBytes {
+		return nil, fmt.Errorf("sentinelone response body exceeds %d bytes", maxBodyBytes)
+	}
+	return payload, nil
+}
+
+func decodeResponseError(statusCode int, body []byte) error {
+	message := http.StatusText(statusCode)
+	var apiErr apiError
+	if err := json.Unmarshal(body, &apiErr); err == nil && len(apiErr.Errors) > 0 {
+		first := apiErr.Errors[0]
+		title := strings.TrimSpace(first.Title)
+		detail := strings.TrimSpace(first.Detail)
+		switch {
+		case title != "" && detail != "":
+			message = fmt.Sprintf("%s: %s", title, detail)
+		case detail != "":
+			message = detail
+		case title != "":
+			message = title
+		}
+	}
+	return &responseError{
+		statusCode: statusCode,
+		message:    fmt.Sprintf("sentinelone API returned %d: %s", statusCode, message),
+	}
+}
+
+func listJSONRecords[T any, P interface {
+	*T
+	rawCarrier
+}](ctx context.Context, source *Source, settings settings, requestPath string, query url.Values) ([]T, string, error) {
+	var resp listResponse
+	if err := source.getJSON(ctx, settings, requestPath, query, &resp); err != nil {
+		return nil, "", err
+	}
+	records := make([]T, 0, len(resp.Data))
+	for _, item := range resp.Data {
+		var record T
+		if err := json.Unmarshal(item, &record); err != nil {
+			return nil, "", fmt.Errorf("decode %s record: %w", requestPath, err)
+		}
+		P(&record).setRaw(cloneRaw(item))
+		records = append(records, record)
+	}
+	return records, strings.TrimSpace(resp.Pagination.NextCursor), nil
+}
+
+func (s *Source) listThreats(ctx context.Context, settings settings, cursor string, limit int) ([]threatRecord, string, error) {
+	query := buildPagedQuery(cursor, limit)
+	addQuery(query, "createdAt__gte", settings.since)
+	addQuery(query, "createdAt__lte", settings.until)
+	addQuery(query, "siteIds", settings.siteID)
+	return listJSONRecords[threatRecord, *threatRecord](ctx, s, settings, "/web/api/v2.1/threats", query)
+}
+
+func (s *Source) listAgents(ctx context.Context, settings settings, cursor string, limit int) ([]agentRecord, string, error) {
+	query := buildPagedQuery(cursor, limit)
+	addQuery(query, "siteIds", settings.siteID)
+	addQuery(query, "groupIds", settings.groupID)
+	return listJSONRecords[agentRecord, *agentRecord](ctx, s, settings, "/web/api/v2.1/agents", query)
+}
+
+func (s *Source) listSites(ctx context.Context, settings settings, cursor string, limit int) ([]siteRecord, string, error) {
+	query := buildPagedQuery(cursor, limit)
+	return listJSONRecords[siteRecord, *siteRecord](ctx, s, settings, "/web/api/v2.1/sites", query)
+}
+
+func (s *Source) listGroups(ctx context.Context, settings settings, cursor string, limit int) ([]groupRecord, string, error) {
+	query := buildPagedQuery(cursor, limit)
+	addQuery(query, "siteIds", settings.siteID)
+	return listJSONRecords[groupRecord, *groupRecord](ctx, s, settings, "/web/api/v2.1/groups", query)
+}
+
+func (s *Source) listExclusions(ctx context.Context, settings settings, cursor string, limit int) ([]exclusionRecord, string, error) {
+	query := buildPagedQuery(cursor, limit)
+	addQuery(query, "siteIds", settings.siteID)
+	return listJSONRecords[exclusionRecord, *exclusionRecord](ctx, s, settings, "/web/api/v2.1/exclusions", query)
+}
+
+func (s *Source) listActivities(ctx context.Context, settings settings, cursor string, limit int) ([]activityRecord, string, error) {
+	query := buildPagedQuery(cursor, limit)
+	addQuery(query, "createdAt__gte", settings.since)
+	addQuery(query, "createdAt__lte", settings.until)
+	addQuery(query, "activityTypes", settings.activity)
+	addQuery(query, "siteIds", settings.siteID)
+	addQuery(query, "groupIds", settings.groupID)
+	return listJSONRecords[activityRecord, *activityRecord](ctx, s, settings, "/web/api/v2.1/activities", query)
+}
+
+func (s *Source) listApplications(ctx context.Context, settings settings, cursor string, _ int) ([]applicationRecord, string, error) {
+	if cursor != "" {
+		return nil, "", nil
+	}
+	query := url.Values{}
+	addQuery(query, "ids", settings.agentID)
+	var resp struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	if err := s.getJSON(ctx, settings, "/web/api/v2.1/agents/applications", query, &resp); err != nil {
+		return nil, "", err
+	}
+	records := make([]applicationRecord, 0, len(resp.Data))
+	for _, item := range resp.Data {
+		var record applicationRecord
+		if err := json.Unmarshal(item, &record); err != nil {
+			return nil, "", fmt.Errorf("decode sentinelone application record: %w", err)
+		}
+		record.setRaw(cloneRaw(item))
+		records = append(records, record)
+	}
+	return records, "", nil
+}
+
+func buildPagedQuery(cursor string, limit int) url.Values {
+	query := url.Values{}
+	if limit > 0 {
+		query.Set("limit", strconv.Itoa(limit))
+	}
+	if strings.TrimSpace(cursor) != "" {
+		query.Set("cursor", strings.TrimSpace(cursor))
+	}
+	return query
+}
+
+func addQuery(query url.Values, key string, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	query.Set(key, value)
+}
+
+func configValue(cfg sourcecdk.Config, key string) string {
+	value, _ := cfg.Lookup(key)
+	return strings.TrimSpace(value)
+}
+
+func isNotFound(err error) bool {
+	var responseErr *responseError
+	return errors.As(err, &responseErr) && responseErr.statusCode == http.StatusNotFound
+}
+
+func wrapLookupError(subject string, err error) error {
+	if isNotFound(err) {
+		return fmt.Errorf("%s not found", subject)
+	}
+	return fmt.Errorf("%s: %w", subject, err)
+}
+
+func checkpointCursor(next string, fallback string, occurredAt time.Time) string {
+	if strings.TrimSpace(next) != "" {
+		return strings.TrimSpace(next)
+	}
+	if strings.TrimSpace(fallback) != "" {
+		return strings.TrimSpace(fallback)
+	}
+	if occurredAt.IsZero() {
+		return ""
+	}
+	return occurredAt.UTC().Format(time.RFC3339Nano)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func addAttribute(attributes map[string]string, key string, value string) {
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	attributes[key] = strings.TrimSpace(value)
+}
+
+func boolString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func sortedStrings(values []string) []string {
+	cleaned := make([]string, 0, len(values))
+	for _, value := range values {
+		v := strings.TrimSpace(value)
+		if v == "" {
+			continue
+		}
+		cleaned = append(cleaned, v)
+	}
+	sort.Strings(cleaned)
+	return cleaned
+}
+
+func intToString(value int) string {
+	return strconv.Itoa(value)
+}
+
+func parseTimestamp(value string) time.Time {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05.000000Z"} {
+		if parsed, err := time.Parse(layout, v); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func decodeRaw(raw json.RawMessage, label string) (map[string]any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, fmt.Errorf("decode %s raw payload: %w", label, err)
+	}
+	return decoded, nil
+}
+
+func cloneRaw(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(json.RawMessage, len(raw))
+	copy(out, raw)
+	return out
+}
+
+// Records and event builders live in records.go.
+
+func eventID(prefix string, settings settings, parts ...string) string {
+	values := make([]string, 0, len(parts)+2)
+	values = append(values, prefix, settings.host)
+	for _, part := range parts {
+		values = append(values, strings.TrimSpace(part))
+	}
+	return strings.Join(values, "-")
+}
+
+func eventOccurredAt(values ...time.Time) time.Time {
+	for _, t := range values {
+		if !t.IsZero() {
+			return t.UTC()
+		}
+	}
+	return time.Now().UTC()
+}
+
+func toTimestamp(t time.Time) *timestamppb.Timestamp {
+	return timestamppb.New(t)
+}

--- a/sources/sentinelone/source_test.go
+++ b/sources/sentinelone/source_test.go
@@ -1,0 +1,691 @@
+package sentinelone
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+const (
+	fixtureBaseURL = "https://sentinelone.example.test"
+	fixtureToken   = "test-token"
+)
+
+func newFixtureConfig(family string, extra map[string]string) map[string]string {
+	cfg := map[string]string{
+		"base_url": fixtureBaseURL,
+		"family":   family,
+		"token":    fixtureToken,
+	}
+	for k, v := range extra {
+		cfg[k] = v
+	}
+	return cfg
+}
+
+func TestNewLoadsCatalog(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if source.Spec().Id != "sentinelone" {
+		t.Fatalf("Spec().Id = %q, want sentinelone", source.Spec().Id)
+	}
+	if source.Spec().Name != "SentinelOne" {
+		t.Fatalf("Spec().Name = %q, want SentinelOne", source.Spec().Name)
+	}
+}
+
+func TestParseSettingsRequiresBaseURL(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	err = source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"family": "threat",
+		"token":  fixtureToken,
+	}))
+	if err == nil {
+		t.Fatal("Check() error = nil, want non-nil")
+	}
+}
+
+func TestParseSettingsRequiresToken(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	err = source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"family":   "threat",
+		"base_url": fixtureBaseURL,
+	}))
+	if err == nil {
+		t.Fatal("Check() error = nil, want non-nil")
+	}
+}
+
+func TestParseSettingsRejectsUnknownFamily(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	err = source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"family":   "unknown",
+		"base_url": fixtureBaseURL,
+		"token":    fixtureToken,
+	}))
+	if err == nil {
+		t.Fatal("Check(unknown) error = nil, want non-nil")
+	}
+}
+
+func TestApplicationFamilyRequiresAgentID(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	err = source.Check(context.Background(), sourcecdk.NewConfig(newFixtureConfig("application", nil)))
+	if err == nil {
+		t.Fatal("Check(application) error = nil, want non-nil")
+	}
+}
+
+func TestSinceRejectedForNonTimeFamilies(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	err = source.Check(context.Background(), sourcecdk.NewConfig(newFixtureConfig("agent", map[string]string{
+		"since": "2026-04-23T00:00:00Z",
+	})))
+	if err == nil {
+		t.Fatal("Check(agent, since) error = nil, want non-nil")
+	}
+}
+
+func TestNewFixtureDiscoversAndReadsAllFamilies(t *testing.T) {
+	source, err := NewFixture()
+	if err != nil {
+		t.Fatalf("NewFixture() error = %v", err)
+	}
+	for _, family := range []string{
+		familyActivity, familyAgent, familyApplication, familyExclusion, familyGroup, familySite, familyThreat,
+	} {
+		t.Run(family, func(t *testing.T) {
+			cfg := newFixtureConfig(family, nil)
+			if family == familyApplication {
+				cfg["agent_id"] = "agent-fixture-1"
+			}
+			urns, err := source.Discover(context.Background(), sourcecdk.NewConfig(cfg))
+			if err != nil {
+				t.Fatalf("Discover(%s) error = %v", family, err)
+			}
+			if len(urns) != 1 {
+				t.Fatalf("len(Discover(%s)) = %d, want 1", family, len(urns))
+			}
+			pull, err := source.Read(context.Background(), sourcecdk.NewConfig(cfg), nil)
+			if err != nil {
+				t.Fatalf("Read(%s) error = %v", family, err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("len(Read(%s).Events) = %d, want 1", family, len(pull.Events))
+			}
+		})
+	}
+}
+
+func TestCheckDiscoverAndReadLiveThreats(t *testing.T) {
+	server := httptest.NewServer(newTestAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   "threat",
+		"per_page": "1",
+		"token":    fixtureToken,
+	})
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check(threat) error = %v", err)
+	}
+	discover, err := source.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover(threat) error = %v", err)
+	}
+	if len(discover) != 1 {
+		t.Fatalf("len(Discover(threat)) = %d, want 1", len(discover))
+	}
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(threat first) error = %v", err)
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(Read(threat first).Events) = %d, want 1", len(first.Events))
+	}
+	if first.NextCursor == nil || first.NextCursor.Opaque != "cursor-2" {
+		t.Fatalf("first.NextCursor = %#v, want cursor-2", first.NextCursor)
+	}
+	if got := first.Events[0].Kind; got != "sentinelone.threat" {
+		t.Fatalf("first.Events[0].Kind = %q, want sentinelone.threat", got)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(first.Events[0].Payload, &payload); err != nil {
+		t.Fatalf("unmarshal threat payload: %v", err)
+	}
+	threatInfo, ok := payload["threat_info"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload threat_info = %#v, want object", payload["threat_info"])
+	}
+	if got := threatInfo["classification"]; got != "Malware" {
+		t.Fatalf("threat_info.classification = %#v, want Malware", got)
+	}
+	if got := first.Events[0].Attributes["mitre_tactics"]; got != "Execution" {
+		t.Fatalf("threat attribute mitre_tactics = %q, want Execution", got)
+	}
+
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(threat second) error = %v", err)
+	}
+	if len(second.Events) != 1 {
+		t.Fatalf("len(Read(threat second).Events) = %d, want 1", len(second.Events))
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
+	}
+	if second.Checkpoint == nil || second.Checkpoint.CursorOpaque != "T-2" {
+		t.Fatalf("second.Checkpoint = %#v, want cursor T-2", second.Checkpoint)
+	}
+}
+
+func TestCheckDiscoverAndReadLiveAgents(t *testing.T) {
+	server := httptest.NewServer(newTestAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   "agent",
+		"per_page": "1",
+		"token":    fixtureToken,
+	})
+	if err := source.Check(context.Background(), cfg); err != nil {
+		t.Fatalf("Check(agent) error = %v", err)
+	}
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(agent) error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Read(agent).Events) = %d, want 1", len(pull.Events))
+	}
+	if got := pull.Events[0].Kind; got != "sentinelone.agent" {
+		t.Fatalf("agent event kind = %q, want sentinelone.agent", got)
+	}
+	attrs := pull.Events[0].Attributes
+	for k, want := range map[string]string{
+		"agent_id":      "A-1",
+		"computer_name": "host-A-1",
+		"is_active":     "true",
+		"family":        "agent",
+	} {
+		if got := attrs[k]; got != want {
+			t.Fatalf("agent attribute %s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestReadLiveJoinFamilies(t *testing.T) {
+	server := httptest.NewServer(newTestAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	for _, tt := range []struct {
+		family string
+		extra  map[string]string
+		kind   string
+		attr   string
+		want   string
+	}{
+		{family: "site", kind: "sentinelone.site", attr: "site_id", want: "S-1"},
+		{family: "group", kind: "sentinelone.group", attr: "group_id", want: "G-1"},
+		{family: "exclusion", kind: "sentinelone.exclusion", attr: "exclusion_id", want: "X-1"},
+		{family: "activity", kind: "sentinelone.activity", attr: "activity_id", want: "Y-1"},
+		{family: "application", extra: map[string]string{"agent_id": "A-1"}, kind: "sentinelone.application_inventory", attr: "application_name", want: "Example App"},
+	} {
+		t.Run(tt.family, func(t *testing.T) {
+			config := map[string]string{
+				"base_url": server.URL,
+				"family":   tt.family,
+				"per_page": "1",
+				"token":    fixtureToken,
+			}
+			for k, v := range tt.extra {
+				config[k] = v
+			}
+			if err := source.Check(context.Background(), sourcecdk.NewConfig(config)); err != nil {
+				t.Fatalf("Check(%s) error = %v", tt.family, err)
+			}
+			pull, err := source.Read(context.Background(), sourcecdk.NewConfig(config), nil)
+			if err != nil {
+				t.Fatalf("Read(%s) error = %v", tt.family, err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("len(Read(%s).Events) = %d, want 1", tt.family, len(pull.Events))
+			}
+			if got := pull.Events[0].Kind; got != tt.kind {
+				t.Fatalf("Read(%s).Events[0].Kind = %q, want %q", tt.family, got, tt.kind)
+			}
+			if got := pull.Events[0].Attributes[tt.attr]; got != tt.want {
+				t.Fatalf("Read(%s).Events[0].Attributes[%q] = %q, want %q", tt.family, tt.attr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRejectsUnsafeBaseURL(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	for _, baseURL := range []string{
+		"http://sentinelone.example.test",
+		"https://sentinelone.example.test:8443",
+		"https://sentinelone.example.test/path",
+		"https://user@sentinelone.example.test",
+		"https://localhost.",
+		"https://127.1",
+		"https://10.0.0.1",
+		"https://172.16.0.1",
+		"https://192.168.1.10",
+		"https://169.254.169.254",
+		"https://[fe80::1]",
+		"https://0.0.0.0",
+		"https://2130706433",
+		"https://0177.0.0.1",
+		"https://0x7f000001",
+	} {
+		t.Run(baseURL, func(t *testing.T) {
+			err := source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{
+				"base_url": baseURL,
+				"family":   "threat",
+				"token":    fixtureToken,
+			}))
+			if err == nil {
+				t.Fatal("Check() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestGetJSONRejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[" + strings.Repeat(" ", maxBodyBytes) + "]"))
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	var target []map[string]any
+	err = source.getJSON(context.Background(), settings{
+		baseURL: server.URL,
+		token:   fixtureToken,
+	}, "/web/api/v2.1/threats", nil, &target)
+	if err == nil {
+		t.Fatal("getJSON() error = nil, want non-nil")
+	}
+}
+
+func TestGetJSONDoesNotFollowRedirects(t *testing.T) {
+	redirectHit := false
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectHit = true
+	}))
+	defer redirectTarget.Close()
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	var target []map[string]any
+	err = source.getJSON(context.Background(), settings{
+		baseURL: redirector.URL,
+		token:   fixtureToken,
+	}, "/web/api/v2.1/threats", nil, &target)
+	if err == nil {
+		t.Fatal("getJSON() error = nil, want non-nil redirect response")
+	}
+	if redirectHit {
+		t.Fatal("getJSON() followed redirect target")
+	}
+}
+
+func TestHTTPClientRejectsHostsResolvingToPrivateIPs(t *testing.T) {
+	called := false
+	client := httpClientNoRedirect(&http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return nil, errors.New("unexpected round trip")
+		}),
+	}, false, func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("169.254.169.254")}}, nil
+	})
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://attacker.example/web/api/v2.1/threats", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+	resp, err := client.Do(req)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("Do() error = nil, want non-nil")
+	}
+	if called {
+		t.Fatal("Do() reached wrapped transport for unsafe resolved host")
+	}
+}
+
+func TestHTTPClientFailsClosedWhenHostResolutionFails(t *testing.T) {
+	called := false
+	client := httpClientNoRedirect(&http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			called = true
+			return nil, errors.New("unexpected round trip")
+		}),
+	}, false, func(context.Context, string) ([]net.IPAddr, error) {
+		return nil, errors.New("dns failed")
+	})
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://attacker.example/web/api/v2.1/threats", nil)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+	resp, err := client.Do(req)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("Do() error = nil, want non-nil")
+	}
+	if called {
+		t.Fatal("Do() reached wrapped transport after DNS failure")
+	}
+}
+
+func TestUnauthorizedReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"errors":[{"code":4000040,"detail":"invalid token","title":"Authentication Failed"}]}`))
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   "threat",
+		"token":    fixtureToken,
+	})
+	err = source.Check(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("Check() error = nil, want non-nil")
+	}
+	var respErr *responseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("Check() error = %v, want *responseError", err)
+	}
+	if respErr.StatusCode() != http.StatusUnauthorized {
+		t.Fatalf("Check() status = %d, want %d", respErr.StatusCode(), http.StatusUnauthorized)
+	}
+}
+
+func TestThreatEventComputesMitreTactics(t *testing.T) {
+	event, err := threatEvent(settings{host: "sentinelone.example.test"}, threatRecord{
+		ID: "T-7",
+		ThreatInfo: threatInfoRecord{
+			threatClassificationRecord: threatClassificationRecord{
+				Classification:       "Trojan",
+				ClassificationSource: "Engine",
+				AnalystVerdict:       "true_positive",
+				IncidentStatus:       "unresolved",
+				MitigationStatus:     "not_mitigated",
+				ConfidenceLevel:      "malicious",
+			},
+			threatLifecycleRecord: threatLifecycleRecord{
+				IdentifiedAt: "2026-04-23T01:00:00Z",
+			},
+		},
+		AgentRealtimeInfo: agentRealtimeInfoRecord{
+			agentRealtimeIdentity: agentRealtimeIdentity{AgentID: "A-1", AgentComputerName: "host-A-1"},
+			agentRealtimeStatus:   agentRealtimeStatus{AgentIsActive: true},
+		},
+		Indicators: []threatIndicatorRecord{
+			{Category: "Exploitation", Tactics: []indicatorTactic{
+				{Name: "Execution", Techniques: []indicatorTactic2{{Name: "Native API"}, {Name: "Native API"}}},
+				{Name: "Defense Evasion"},
+			}},
+		},
+		raw: json.RawMessage(`{"id":"T-7"}`),
+	})
+	if err != nil {
+		t.Fatalf("threatEvent() error = %v", err)
+	}
+	tactics := event.Attributes["mitre_tactics"]
+	if tactics != "Defense Evasion,Execution" {
+		t.Fatalf("mitre_tactics = %q, want sorted [Defense Evasion,Execution]", tactics)
+	}
+	if got := event.Attributes["mitre_techniques"]; got != "Native API" {
+		t.Fatalf("mitre_techniques = %q, want Native API", got)
+	}
+	if got := event.Attributes["indicator_categories"]; got != "Exploitation" {
+		t.Fatalf("indicator_categories = %q, want Exploitation", got)
+	}
+}
+
+func TestNextCursorPreservedFromBody(t *testing.T) {
+	server := httptest.NewServer(newTestAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   "agent",
+		"per_page": "1",
+		"token":    fixtureToken,
+	})
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(agent first) error = %v", err)
+	}
+	if first.NextCursor == nil || first.NextCursor.Opaque != "cursor-A-2" {
+		t.Fatalf("first.NextCursor = %#v, want cursor-A-2", first.NextCursor)
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(agent second) error = %v", err)
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
+	}
+}
+
+// Test API handler.
+
+func newTestAPIHandler(t *testing.T) http.Handler {
+	t.Helper()
+	threats := []map[string]any{
+		{
+			"id": "T-1",
+			"threatInfo": map[string]any{
+				"analystVerdict":       "true_positive",
+				"classification":       "Malware",
+				"classificationSource": "Engine",
+				"confidenceLevel":      "malicious",
+				"incidentStatus":       "unresolved",
+				"mitigationStatus":     "not_mitigated",
+				"identifiedAt":         "2026-04-23T01:00:00Z",
+				"sha256":               "feedfacecafebeef",
+			},
+			"agentRealtimeInfo": map[string]any{
+				"agentId":           "A-1",
+				"agentComputerName": "host-A-1",
+				"agentIsActive":     true,
+				"agentInfected":     true,
+			},
+			"agentDetectionInfo": map[string]any{
+				"siteId":  "S-1",
+				"groupId": "G-1",
+			},
+			"indicators": []map[string]any{
+				{"category": "Malware", "tactics": []map[string]any{{"name": "Execution"}}},
+			},
+		},
+		{
+			"id": "T-2",
+			"threatInfo": map[string]any{
+				"classification":   "Trojan",
+				"incidentStatus":   "resolved",
+				"mitigationStatus": "mitigated",
+				"identifiedAt":     "2026-04-23T00:00:00Z",
+			},
+			"agentRealtimeInfo": map[string]any{
+				"agentId": "A-2",
+			},
+		},
+	}
+	agents := []map[string]any{
+		{
+			"id":             "A-1",
+			"computerName":   "host-A-1",
+			"osName":         "macOS",
+			"osType":         "macos",
+			"isActive":       true,
+			"isUpToDate":     true,
+			"siteId":         "S-1",
+			"groupId":        "G-1",
+			"lastActiveDate": "2026-04-23T01:00:00Z",
+			"updatedAt":      "2026-04-23T01:00:00Z",
+		},
+		{
+			"id":             "A-2",
+			"computerName":   "host-A-2",
+			"osName":         "Windows",
+			"osType":         "windows",
+			"isActive":       false,
+			"siteId":         "S-1",
+			"groupId":        "G-1",
+			"lastActiveDate": "2026-03-23T01:00:00Z",
+			"updatedAt":      "2026-04-23T00:00:00Z",
+		},
+	}
+	sites := []map[string]any{{"id": "S-1", "name": "Production", "state": "active", "isDefault": true}}
+	groups := []map[string]any{{"id": "G-1", "name": "Default Group", "type": "static", "isDefault": true, "siteId": "S-1", "totalAgents": 2}}
+	exclusions := []map[string]any{{"id": "X-1", "type": "path", "mode": "suppress_alerts", "osType": "macos", "scope": "site", "scopeName": "Production", "value": "/Applications/Approved.app"}}
+	activities := []map[string]any{{"id": "Y-1", "activityType": 27, "primaryDescription": "User user@example.test logged in", "agentId": "A-1", "siteId": "S-1", "groupId": "G-1", "createdAt": "2026-04-23T00:30:00Z"}}
+	apps := []map[string]any{
+		{"name": "Example App", "publisher": "Example Inc", "version": "1.0.0", "installedDate": "2026-04-20T00:00:00Z", "size": 12345},
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if got := r.Header.Get("Authorization"); got != "ApiToken "+fixtureToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"errors": []map[string]any{{"detail": "invalid token", "title": "Auth Failed"}}})
+			return
+		}
+		switch r.URL.Path {
+		case "/web/api/v2.1/threats":
+			cursor := r.URL.Query().Get("cursor")
+			if cursor == "" {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data":       threats[:1],
+					"pagination": map[string]any{"nextCursor": "cursor-2", "totalItems": 2},
+				})
+				return
+			}
+			if cursor == "cursor-2" {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data":       threats[1:2],
+					"pagination": map[string]any{"nextCursor": nil, "totalItems": 2},
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{}, "pagination": map[string]any{}})
+		case "/web/api/v2.1/agents":
+			cursor := r.URL.Query().Get("cursor")
+			if cursor == "" {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data":       agents[:1],
+					"pagination": map[string]any{"nextCursor": "cursor-A-2"},
+				})
+				return
+			}
+			if cursor == "cursor-A-2" {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data":       agents[1:2],
+					"pagination": map[string]any{},
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{}, "pagination": map[string]any{}})
+		case "/web/api/v2.1/sites":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": sites, "pagination": map[string]any{}})
+		case "/web/api/v2.1/groups":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": groups, "pagination": map[string]any{}})
+		case "/web/api/v2.1/exclusions":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": exclusions, "pagination": map[string]any{}})
+		case "/web/api/v2.1/activities":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": activities, "pagination": map[string]any{}})
+		case "/web/api/v2.1/agents/applications":
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": apps})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+}
+
+// avoid unused error in TestNextCursor; refer to cerebrov1 to keep import alive when partial test runs.
+var _ = cerebrov1.SourceCursor{}

--- a/sources/sentinelone/testdata/discover_activity.json
+++ b/sources/sentinelone/testdata/discover_activity.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:sentinelone.example.test:activity:activity-fixture-1"
+]

--- a/sources/sentinelone/testdata/discover_agent.json
+++ b/sources/sentinelone/testdata/discover_agent.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:sentinelone.example.test:agent:agent-fixture-1"
+]

--- a/sources/sentinelone/testdata/discover_application.json
+++ b/sources/sentinelone/testdata/discover_application.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:sentinelone.example.test:agent:agent-fixture-1"
+]

--- a/sources/sentinelone/testdata/discover_exclusion.json
+++ b/sources/sentinelone/testdata/discover_exclusion.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:sentinelone.example.test:exclusion:exclusion-fixture-1"
+]

--- a/sources/sentinelone/testdata/discover_group.json
+++ b/sources/sentinelone/testdata/discover_group.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:sentinelone.example.test:group:group-fixture-1"
+]

--- a/sources/sentinelone/testdata/discover_site.json
+++ b/sources/sentinelone/testdata/discover_site.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:sentinelone.example.test:site:site-fixture-1"
+]

--- a/sources/sentinelone/testdata/discover_threat.json
+++ b/sources/sentinelone/testdata/discover_threat.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:sentinelone.example.test:threat:threat-fixture-1"
+]

--- a/sources/sentinelone/testdata/read_activity.json
+++ b/sources/sentinelone/testdata/read_activity.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "sentinelone-activity-sentinelone.example.test-activity-fixture-1",
+    "tenant_id": "sentinelone.example.test",
+    "source_id": "sentinelone",
+    "kind": "sentinelone.activity",
+    "occurred_at": "2026-04-23T00:30:00Z",
+    "schema_ref": "sentinelone/activity/v1",
+    "payload": {
+      "id": "activity-fixture-1",
+      "tenant_host": "sentinelone.example.test",
+      "activity_type": 27,
+      "primary_description": "User user@example.test logged into the management console",
+      "agent_id": "agent-fixture-1",
+      "site_id": "site-fixture-1",
+      "group_id": "group-fixture-1",
+      "raw": {}
+    },
+    "attributes": {
+      "activity_id": "activity-fixture-1",
+      "activity_type": "27",
+      "agent_id": "agent-fixture-1",
+      "family": "activity",
+      "group_id": "group-fixture-1",
+      "primary_description": "User user@example.test logged into the management console",
+      "site_id": "site-fixture-1",
+      "tenant_host": "sentinelone.example.test"
+    }
+  }
+]

--- a/sources/sentinelone/testdata/read_agent.json
+++ b/sources/sentinelone/testdata/read_agent.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "sentinelone-agent-sentinelone.example.test-agent-fixture-1",
+    "tenant_id": "sentinelone.example.test",
+    "source_id": "sentinelone",
+    "kind": "sentinelone.agent",
+    "occurred_at": "2026-04-23T01:00:00Z",
+    "schema_ref": "sentinelone/agent/v1",
+    "payload": {
+      "id": "agent-fixture-1",
+      "tenant_host": "sentinelone.example.test",
+      "computer_name": "host-fixture-1",
+      "os_name": "macOS",
+      "os_type": "macos",
+      "is_active": true,
+      "is_decommissioned": false,
+      "is_up_to_date": true,
+      "is_uninstalled": false,
+      "is_pending_uninstall": false,
+      "is_infected": false,
+      "active_threats": 0,
+      "last_active_date": "2026-04-23T01:00:00Z",
+      "site_id": "site-fixture-1",
+      "group_id": "group-fixture-1",
+      "raw": {}
+    },
+    "attributes": {
+      "agent_id": "agent-fixture-1",
+      "active_threats": "0",
+      "computer_name": "host-fixture-1",
+      "family": "agent",
+      "firewall_enabled": "false",
+      "infected": "false",
+      "is_active": "true",
+      "is_decommissioned": "false",
+      "is_pending_uninstall": "false",
+      "is_uninstalled": "false",
+      "is_up_to_date": "true",
+      "last_active_date": "2026-04-23T01:00:00Z",
+      "os_name": "macOS",
+      "os_type": "macos",
+      "site_id": "site-fixture-1",
+      "group_id": "group-fixture-1",
+      "tenant_host": "sentinelone.example.test"
+    }
+  }
+]

--- a/sources/sentinelone/testdata/read_application.json
+++ b/sources/sentinelone/testdata/read_application.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "sentinelone-application-sentinelone.example.test-agent-fixture-1-Example_Inc::Example_App",
+    "tenant_id": "sentinelone.example.test",
+    "source_id": "sentinelone",
+    "kind": "sentinelone.application_inventory",
+    "occurred_at": "2026-04-20T00:00:00Z",
+    "schema_ref": "sentinelone/application_inventory/v1",
+    "payload": {
+      "agent_id": "agent-fixture-1",
+      "tenant_host": "sentinelone.example.test",
+      "name": "Example App",
+      "publisher": "Example Inc",
+      "version": "1.0.0",
+      "installed_date": "2026-04-20T00:00:00Z",
+      "size_bytes": 12345,
+      "raw": {}
+    },
+    "attributes": {
+      "agent_id": "agent-fixture-1",
+      "application_name": "Example App",
+      "family": "application",
+      "installed_date": "2026-04-20T00:00:00Z",
+      "publisher": "Example Inc",
+      "tenant_host": "sentinelone.example.test",
+      "version": "1.0.0"
+    }
+  }
+]

--- a/sources/sentinelone/testdata/read_exclusion.json
+++ b/sources/sentinelone/testdata/read_exclusion.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "sentinelone-exclusion-sentinelone.example.test-exclusion-fixture-1",
+    "tenant_id": "sentinelone.example.test",
+    "source_id": "sentinelone",
+    "kind": "sentinelone.exclusion",
+    "occurred_at": "2026-04-22T00:00:00Z",
+    "schema_ref": "sentinelone/exclusion/v1",
+    "payload": {
+      "id": "exclusion-fixture-1",
+      "tenant_host": "sentinelone.example.test",
+      "type": "path",
+      "mode": "suppress_alerts",
+      "os_type": "macos",
+      "scope": "site",
+      "scope_name": "Production",
+      "value": "/Applications/Approved.app",
+      "raw": {}
+    },
+    "attributes": {
+      "exclusion_id": "exclusion-fixture-1",
+      "exclusion_type": "path",
+      "family": "exclusion",
+      "mode": "suppress_alerts",
+      "not_recommended": "false",
+      "os_type": "macos",
+      "scope": "site",
+      "scope_name": "Production",
+      "tenant_host": "sentinelone.example.test",
+      "value": "/Applications/Approved.app"
+    }
+  }
+]

--- a/sources/sentinelone/testdata/read_group.json
+++ b/sources/sentinelone/testdata/read_group.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "sentinelone-group-sentinelone.example.test-group-fixture-1",
+    "tenant_id": "sentinelone.example.test",
+    "source_id": "sentinelone",
+    "kind": "sentinelone.group",
+    "occurred_at": "2026-04-22T00:00:00Z",
+    "schema_ref": "sentinelone/group/v1",
+    "payload": {
+      "id": "group-fixture-1",
+      "tenant_host": "sentinelone.example.test",
+      "name": "Default Group",
+      "type": "static",
+      "is_default": true,
+      "site_id": "site-fixture-1",
+      "total_agents": 1,
+      "raw": {}
+    },
+    "attributes": {
+      "family": "group",
+      "group_id": "group-fixture-1",
+      "group_name": "Default Group",
+      "is_default": "true",
+      "site_id": "site-fixture-1",
+      "tenant_host": "sentinelone.example.test",
+      "total_agents": "1",
+      "type": "static"
+    }
+  }
+]

--- a/sources/sentinelone/testdata/read_site.json
+++ b/sources/sentinelone/testdata/read_site.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "sentinelone-site-sentinelone.example.test-site-fixture-1",
+    "tenant_id": "sentinelone.example.test",
+    "source_id": "sentinelone",
+    "kind": "sentinelone.site",
+    "occurred_at": "2026-04-22T00:00:00Z",
+    "schema_ref": "sentinelone/site/v1",
+    "payload": {
+      "id": "site-fixture-1",
+      "tenant_host": "sentinelone.example.test",
+      "name": "Production",
+      "state": "active",
+      "site_type": "Paid",
+      "is_default": true,
+      "raw": {}
+    },
+    "attributes": {
+      "family": "site",
+      "is_default": "true",
+      "site_id": "site-fixture-1",
+      "site_name": "Production",
+      "site_type": "Paid",
+      "state": "active",
+      "tenant_host": "sentinelone.example.test"
+    }
+  }
+]

--- a/sources/sentinelone/testdata/read_threat.json
+++ b/sources/sentinelone/testdata/read_threat.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "sentinelone-threat-sentinelone.example.test-threat-fixture-1",
+    "tenant_id": "sentinelone.example.test",
+    "source_id": "sentinelone",
+    "kind": "sentinelone.threat",
+    "occurred_at": "2026-04-23T01:00:00Z",
+    "schema_ref": "sentinelone/threat/v1",
+    "payload": {
+      "id": "threat-fixture-1",
+      "tenant_host": "sentinelone.example.test",
+      "threat_info": {
+        "analyst_verdict": "true_positive",
+        "classification": "Malware",
+        "classification_source": "Engine",
+        "confidence_level": "malicious",
+        "incident_status": "unresolved",
+        "mitigation_status": "not_mitigated"
+      },
+      "agent_detection": {
+        "uuid": "agent-uuid-1",
+        "site_id": "site-fixture-1",
+        "group_id": "group-fixture-1"
+      },
+      "agent_realtime": {
+        "agent_id": "agent-fixture-1",
+        "computer_name": "host-fixture-1",
+        "is_active": true,
+        "is_decommissioned": false,
+        "is_infected": true,
+        "active_threats": 1
+      },
+      "indicators": {
+        "categories": ["Malware"],
+        "mitre_tactics": ["Execution"]
+      },
+      "raw": {}
+    },
+    "attributes": {
+      "agent_id": "agent-fixture-1",
+      "agent_uuid": "agent-uuid-1",
+      "analyst_verdict": "true_positive",
+      "classification": "Malware",
+      "classification_source": "Engine",
+      "computer_name": "host-fixture-1",
+      "confidence_level": "malicious",
+      "family": "threat",
+      "indicator_categories": "Malware",
+      "incident_status": "unresolved",
+      "is_active": "true",
+      "is_decommissioned": "false",
+      "is_infected": "true",
+      "is_fileless": "false",
+      "mitigation_status": "not_mitigated",
+      "mitre_tactics": "Execution",
+      "site_id": "site-fixture-1",
+      "tenant_host": "sentinelone.example.test",
+      "threat_id": "threat-fixture-1"
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Adds a SentinelOne ingest source covering seven families using the existing `FamilyEngine` pattern, plus matching projectors and registry wiring. Mirrors the depth and hardening of the Okta source.

## Scope

### `sources/sentinelone/`
- `catalog.yaml`: emits `sentinelone.{threat,agent,site,group,exclusion,activity,application_inventory}`.
- `source.go`: settings parsing with SSRF/DNS guards (rejects unsafe hosts and IPs at dial time), generic `listJSONRecords` helper that preserves raw response bytes, `ApiToken` auth header, no-redirect transport, oversized body protection, structured `{errors:[...]}` decoder surfaced as a typed `*responseError` with `StatusCode()`.
- `records.go`: API record types decomposed into cohesive embedded sub-structs (identity / lifecycle / status / hardware / location / classification / file) so they satisfy `maxfields`; matching payload types and seven event builders, with MITRE tactic/technique aggregation across indicators.
- `fixture.go` + `testdata/`: 14 synthetic fixtures (`sentinelone.example.test` tenant, invented IDs only).
- `source_test.go`: 16 tests including catalog load, settings rejections, fixture replay across all families, live `httptest` cursor pagination for threats and agents, MITRE tactic sorting, oversize body, redirect rejection, unsafe URL rejection, DNS unsafe-IP rejection, DNS resolution failure, and 401 status surfaced via `errors.As(*responseError)`.

### `internal/sourceprojection/`
- `sentinelone.go`: seven projectors with URN helpers and an `addSentinelOneScopeLinks` helper for `belongs_to` (site) and `member_of` (group). Threat → agent `affected_by`, site → account `belongs_to`, group → site `belongs_to`, activity → agent `observed_on` / activity → threat `acted_on`, application_inventory → agent `contains`.
- `sentinelone_test.go`: eight projector tests covering entities, attributes, and link directions.
- `registry.go`: registers all seven `sentinelone.*` kinds.

### `internal/sourceregistry/`
- `registry.go`: registers the `sentinelone` source loader.
- `registry_test.go`: asserts the new loader is reachable.

## Verification

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./... -count=1 -timeout=300s` green (full repo).
- `golangci-lint run --timeout 5m ./...` clean.
- `cerebrolint` (in-repo: `maxfields`, `maxmutex`, `noerrstringmatch`, etc.) clean.
- Pre-commit hook ran `build + test + lint + proto-lint + check-structural + check-arch` successfully.

## Notes

- No real tenant IDs, hostnames, or secrets are committed; fixtures use `sentinelone.example.test`.
- The `ApiToken` string in source/test is the SentinelOne API auth scheme literal, not a credential.