### PR TITLE
feat(sourcedeploy): self-registering deploy manifests per source

### DIFF
--- a/cmd/sourcedeploy/main.go
+++ b/cmd/sourcedeploy/main.go
@@ -1,0 +1,61 @@
+// Command sourcedeploy renders the Pulumi config fragment that drives
+// cerebro source ingestion in a given environment.
+//
+// Each source under sources/<id>/ may declare a deploy.yaml manifest. This
+// tool walks the tree, applies environment overrides, and emits a YAML
+// fragment with three keys (cerebro:sourceSecretKeys, cerebro:sourceRuntimes,
+// cerebro:orchestratorSchedules) suitable for inclusion in
+// infra/aws/Pulumi.<env>.yaml in the WriterInternal/cerebro repository.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/writer/cerebro/tools/sourcedeploy"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	fs := flag.NewFlagSet("sourcedeploy", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	sourcesRoot := fs.String("sources", "sources", "directory containing per-source manifests")
+	env := fs.String("env", "", "environment to render (e.g. sec-dev, go-prod)")
+	tenant := fs.String("tenant", "writer", "tenant identifier embedded in qualified runtime ids")
+	out := fs.String("out", "-", "output path; '-' writes to stdout")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *env == "" {
+		fs.Usage()
+		return fmt.Errorf("-env is required")
+	}
+
+	manifests, err := sourcedeploy.Discover(*sourcesRoot)
+	if err != nil {
+		return err
+	}
+	fragment, err := sourcedeploy.Render(manifests, sourcedeploy.RenderOptions{
+		Environment: *env,
+		TenantID:    *tenant,
+	})
+	if err != nil {
+		return err
+	}
+	data, err := fragment.MarshalYAML()
+	if err != nil {
+		return err
+	}
+	if *out == "-" {
+		_, err = os.Stdout.Write(data)
+		return err
+	}
+	return os.WriteFile(*out, data, 0o644)
+}

--- a/sources/okta/deploy.yaml
+++ b/sources/okta/deploy.yaml
@@ -1,0 +1,111 @@
+sourceId: okta
+secretKeys:
+  - OKTA_API_TOKEN
+  - OKTA_DOMAIN
+runtimes:
+  - localId: audit
+    config:
+      domain: env:OKTA_DOMAIN
+      family: audit
+      per_page: "200"
+      since: "2026-05-01T00:00:00Z"
+      token: env:OKTA_API_TOKEN
+  - localId: user
+    config:
+      domain: env:OKTA_DOMAIN
+      family: user
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: group
+    config:
+      domain: env:OKTA_DOMAIN
+      family: group
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+  - localId: application
+    config:
+      domain: env:OKTA_DOMAIN
+      family: application
+      per_page: "200"
+      token: env:OKTA_API_TOKEN
+schedules:
+  - localName: audit-live
+    runtimeLocalId: audit
+    scheduleExpression: rate(10 minutes)
+    taskCount: 1
+    command:
+      - orchestrator
+      - run
+      - page_limit=20
+      - graph_page_limit=100
+      - event_limit=1000
+  - localName: user-inventory
+    runtimeLocalId: user
+    scheduleExpression: rate(30 minutes)
+    taskCount: 1
+    command:
+      - orchestrator
+      - run
+      - page_limit=100
+      - graph_page_limit=100
+      - event_limit=1000
+  - localName: group-inventory
+    runtimeLocalId: group
+    scheduleExpression: rate(30 minutes)
+    taskCount: 1
+    command:
+      - orchestrator
+      - run
+      - page_limit=100
+      - graph_page_limit=100
+      - event_limit=1000
+  - localName: application-inventory
+    runtimeLocalId: application
+    scheduleExpression: rate(30 minutes)
+    taskCount: 1
+    command:
+      - orchestrator
+      - run
+      - page_limit=100
+      - graph_page_limit=100
+      - event_limit=1000
+environments:
+  sec-dev:
+    extraRuntimes:
+      - localId: audit-2026-04
+        config:
+          domain: env:OKTA_DOMAIN
+          family: audit
+          per_page: "200"
+          since: "2026-04-01T00:00:00Z"
+          until: "2026-05-01T00:00:00Z"
+          token: env:OKTA_API_TOKEN
+      - localId: audit-2026-q1
+        config:
+          domain: env:OKTA_DOMAIN
+          family: audit
+          per_page: "200"
+          since: "2026-01-01T00:00:00Z"
+          until: "2026-04-01T00:00:00Z"
+          token: env:OKTA_API_TOKEN
+    extraSchedules:
+      - localName: audit-april-backfill
+        runtimeLocalId: audit-2026-04
+        scheduleExpression: rate(15 minutes)
+        taskCount: 1
+        command:
+          - orchestrator
+          - run
+          - page_limit=20
+          - graph_page_limit=100
+          - event_limit=1000
+      - localName: audit-q1-backfill
+        runtimeLocalId: audit-2026-q1
+        scheduleExpression: rate(15 minutes)
+        taskCount: 1
+        command:
+          - orchestrator
+          - run
+          - page_limit=20
+          - graph_page_limit=100
+          - event_limit=1000

--- a/sources/sentinelone/deploy.yaml
+++ b/sources/sentinelone/deploy.yaml
@@ -1,0 +1,17 @@
+sourceId: sentinelone
+secretKeys:
+  - SENTINELONE_API_TOKEN
+  - SENTINELONE_BASE_URL
+runtimes:
+  - localId: threat
+    config:
+      base_url: env:SENTINELONE_BASE_URL
+      family: threat
+      per_page: "200"
+      token: env:SENTINELONE_API_TOKEN
+  - localId: agent
+    config:
+      base_url: env:SENTINELONE_BASE_URL
+      family: agent
+      per_page: "200"
+      token: env:SENTINELONE_API_TOKEN

--- a/tools/archtests/source_deploy_test.go
+++ b/tools/archtests/source_deploy_test.go
@@ -1,0 +1,69 @@
+package archtests
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/writer/cerebro/tools/sourcedeploy"
+)
+
+// requireDeployManifest holds sources that must declare a deploy.yaml so the
+// sourcedeploy synthesizer can render their Pulumi config. Sources that do
+// not own runtimes (e.g. push-only SDK adapters, infrastructure scanners
+// driven by the orchestrator default command) are exempt by being absent.
+var requireDeployManifest = map[string]struct{}{
+	"okta":        {},
+	"sentinelone": {},
+}
+
+func TestSourceDeployManifestsAreValid(t *testing.T) {
+	root := filepath.Join("..", "..", "sources")
+	manifests, err := sourcedeploy.Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	have := make(map[string]struct{}, len(manifests))
+	for _, manifest := range manifests {
+		have[manifest.SourceID] = struct{}{}
+	}
+
+	missing := make([]string, 0)
+	for id := range requireDeployManifest {
+		if _, ok := have[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("sources missing deploy.yaml: %v", missing)
+	}
+
+	for _, manifest := range manifests {
+		if err := manifest.Validate(); err != nil {
+			t.Fatalf("source %s: %v", manifest.SourceID, err)
+		}
+	}
+}
+
+func TestSourceDeployManifestsRenderForKnownEnvironments(t *testing.T) {
+	root := filepath.Join("..", "..", "sources")
+	manifests, err := sourcedeploy.Discover(root)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(manifests) == 0 {
+		t.Skip("no manifests to render")
+	}
+	for _, env := range []string{"sec-dev", "go-prod", "gcp-prod"} {
+		if _, err := sourcedeploy.Render(manifests, sourcedeploy.RenderOptions{
+			Environment: env,
+			TenantID:    "writer",
+		}); err != nil {
+			t.Fatalf("Render(%s): %v", env, err)
+		}
+	}
+}

--- a/tools/sourcedeploy/manifest.go
+++ b/tools/sourcedeploy/manifest.go
@@ -1,0 +1,308 @@
+// Package sourcedeploy declares the deploy manifest contract that lives next
+// to each source's catalog and the loader/renderer that turns those manifests
+// into infrastructure-ready Pulumi config blocks.
+//
+// Each source under sources/<id>/ may provide a deploy.yaml describing the
+// secret keys it expects, the runtimes it ships, and the schedules it would
+// like the orchestrator to run. The synth tool walks every manifest, applies
+// per-environment overrides, and renders a single YAML fragment matching the
+// Pulumi config schema consumed by infra/aws/__main__.py in WriterInternal.
+//
+// Keeping the manifest source-resident has two benefits: (1) the team that
+// adds a new source owns its deployment story instead of pinging SRE, and
+// (2) the public OSS code base stays the source of truth — internal infra
+// merely renders, never re-invents.
+package sourcedeploy
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ErrSourceIDMismatch is returned by Discover when a deploy manifest declares
+// a sourceId that does not match the directory name it lives under.
+var ErrSourceIDMismatch = errors.New("deploy manifest sourceId does not match sources directory")
+
+// Manifest is the declarative deploy contract that lives next to each
+// source's catalog. All fields are optional except SourceID.
+type Manifest struct {
+	SourceID     string                          `yaml:"sourceId"`
+	SecretKeys   []string                        `yaml:"secretKeys,omitempty"`
+	Runtimes     []RuntimeManifest               `yaml:"runtimes,omitempty"`
+	Schedules    []ScheduleManifest              `yaml:"schedules,omitempty"`
+	Environments map[string]EnvironmentOverrides `yaml:"environments,omitempty"`
+}
+
+// EnvironmentOverrides layer environment-specific tweaks on top of the base
+// manifest. Disabling lists are matched by localId / localName; additional
+// runtimes and schedules are appended verbatim and validated identically.
+type EnvironmentOverrides struct {
+	DisabledRuntimes  []string           `yaml:"disabledRuntimes,omitempty"`
+	DisabledSchedules []string           `yaml:"disabledSchedules,omitempty"`
+	ExtraRuntimes     []RuntimeManifest  `yaml:"extraRuntimes,omitempty"`
+	ExtraSchedules    []ScheduleManifest `yaml:"extraSchedules,omitempty"`
+	ExtraSecretKeys   []string           `yaml:"extraSecretKeys,omitempty"`
+}
+
+// RuntimeManifest describes a logical runtime configuration. The fully
+// qualified runtime ID is composed at render time as
+// `<tenant>-<sourceId>-<localId>`.
+type RuntimeManifest struct {
+	LocalID string            `yaml:"localId"`
+	Family  string            `yaml:"family,omitempty"`
+	Config  map[string]string `yaml:"config"`
+}
+
+// ScheduleManifest describes a recurring orchestrator invocation that
+// targets a runtime defined in the same manifest. The fully qualified
+// schedule name is `<sourceId>-<localName>`; the rendered command is
+// the shared base plus a `runtime_id=` argument so the orchestrator
+// runs only that runtime.
+type ScheduleManifest struct {
+	LocalName          string   `yaml:"localName"`
+	RuntimeLocalID     string   `yaml:"runtimeLocalId"`
+	ScheduleExpression string   `yaml:"scheduleExpression"`
+	TaskCount          int      `yaml:"taskCount,omitempty"`
+	Command            []string `yaml:"command,omitempty"`
+}
+
+var (
+	idPattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
+	envRefRegex = regexp.MustCompile(`^env:[A-Z][A-Z0-9_]*$`)
+)
+
+// Load reads a single manifest file from disk.
+func Load(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read deploy manifest %s: %w", path, err)
+	}
+	return Parse(data, path)
+}
+
+// Parse decodes a manifest from raw bytes and runs validation.
+func Parse(data []byte, label string) (*Manifest, error) {
+	var manifest Manifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("decode deploy manifest %s: %w", label, err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return nil, fmt.Errorf("validate deploy manifest %s: %w", label, err)
+	}
+	return &manifest, nil
+}
+
+// Discover walks the sources/ directory tree and returns one manifest per
+// source that ships a deploy.yaml. Sources without a manifest are skipped
+// silently; archtests enforce coverage separately.
+func Discover(sourcesRoot string) ([]Manifest, error) {
+	entries, err := os.ReadDir(sourcesRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read sources root %s: %w", sourcesRoot, err)
+	}
+	manifests := make([]Manifest, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(sourcesRoot, entry.Name(), "deploy.yaml")
+		if _, statErr := os.Stat(path); statErr != nil {
+			continue
+		}
+		manifest, err := Load(path)
+		if err != nil {
+			return nil, err
+		}
+		if manifest.SourceID != entry.Name() {
+			return nil, fmt.Errorf(
+				"%w: %s declares sourceId %q but lives under sources/%s",
+				ErrSourceIDMismatch, path, manifest.SourceID, entry.Name(),
+			)
+		}
+		manifests = append(manifests, *manifest)
+	}
+	sort.Slice(manifests, func(i, j int) bool {
+		return manifests[i].SourceID < manifests[j].SourceID
+	})
+	return manifests, nil
+}
+
+// Validate enforces structural rules the renderer relies on.
+func (m *Manifest) Validate() error {
+	if !idPattern.MatchString(m.SourceID) {
+		return fmt.Errorf("sourceId %q must be lowercase kebab-case", m.SourceID)
+	}
+	if err := validateSecretKeys(m.SecretKeys); err != nil {
+		return err
+	}
+	runtimes, err := validateRuntimes(m.Runtimes)
+	if err != nil {
+		return err
+	}
+	if err := validateSchedules(m.Schedules, runtimes); err != nil {
+		return err
+	}
+	for envName, overlay := range m.Environments {
+		if strings.TrimSpace(envName) == "" {
+			return fmt.Errorf("environments key must be non-empty")
+		}
+		if err := validateOverlay(envName, overlay, runtimes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRuntimes(list []RuntimeManifest) (map[string]struct{}, error) {
+	runtimes := map[string]struct{}{}
+	for _, runtime := range list {
+		if !idPattern.MatchString(runtime.LocalID) {
+			return nil, fmt.Errorf("runtime localId %q must be lowercase kebab-case", runtime.LocalID)
+		}
+		if _, dup := runtimes[runtime.LocalID]; dup {
+			return nil, fmt.Errorf("runtime localId %q declared twice", runtime.LocalID)
+		}
+		runtimes[runtime.LocalID] = struct{}{}
+		if len(runtime.Config) == 0 {
+			return nil, fmt.Errorf("runtime %q must declare at least one config entry", runtime.LocalID)
+		}
+		if err := validateRuntimeConfig(runtime); err != nil {
+			return nil, err
+		}
+	}
+	return runtimes, nil
+}
+
+func validateSchedules(list []ScheduleManifest, runtimes map[string]struct{}) error {
+	scheduleNames := map[string]struct{}{}
+	for _, schedule := range list {
+		if !idPattern.MatchString(schedule.LocalName) {
+			return fmt.Errorf("schedule localName %q must be lowercase kebab-case", schedule.LocalName)
+		}
+		if _, dup := scheduleNames[schedule.LocalName]; dup {
+			return fmt.Errorf("schedule localName %q declared twice", schedule.LocalName)
+		}
+		scheduleNames[schedule.LocalName] = struct{}{}
+		if _, ok := runtimes[schedule.RuntimeLocalID]; !ok {
+			return fmt.Errorf(
+				"schedule %q references runtime localId %q that is not declared",
+				schedule.LocalName, schedule.RuntimeLocalID,
+			)
+		}
+		if strings.TrimSpace(schedule.ScheduleExpression) == "" {
+			return fmt.Errorf("schedule %q must set scheduleExpression", schedule.LocalName)
+		}
+		if schedule.TaskCount < 0 {
+			return fmt.Errorf("schedule %q taskCount must be >= 0", schedule.LocalName)
+		}
+		if err := validateScheduleCommand(schedule); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateOverlay(env string, overlay EnvironmentOverrides, baseRuntimes map[string]struct{}) error {
+	for _, id := range overlay.DisabledRuntimes {
+		if _, ok := baseRuntimes[id]; !ok {
+			return fmt.Errorf("environment %q disables runtime %q which is not declared", env, id)
+		}
+	}
+	combined := make(map[string]struct{}, len(baseRuntimes)+len(overlay.ExtraRuntimes))
+	for id := range baseRuntimes {
+		combined[id] = struct{}{}
+	}
+	extraRuntimes, err := validateRuntimes(overlay.ExtraRuntimes)
+	if err != nil {
+		return fmt.Errorf("environment %q: %w", env, err)
+	}
+	for id := range extraRuntimes {
+		if _, dup := combined[id]; dup {
+			return fmt.Errorf("environment %q extra runtime %q collides with base runtime", env, id)
+		}
+		combined[id] = struct{}{}
+	}
+	if err := validateSchedules(overlay.ExtraSchedules, combined); err != nil {
+		return fmt.Errorf("environment %q: %w", env, err)
+	}
+	if err := validateSecretKeys(overlay.ExtraSecretKeys); err != nil {
+		return fmt.Errorf("environment %q: %w", env, err)
+	}
+	return nil
+}
+
+func validateSecretKeys(keys []string) error {
+	seen := map[string]struct{}{}
+	for _, key := range keys {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			return fmt.Errorf("secretKeys entries must be non-empty")
+		}
+		if trimmed != strings.ToUpper(trimmed) {
+			return fmt.Errorf("secretKeys entry %q must be SCREAMING_SNAKE_CASE", key)
+		}
+		if _, dup := seen[trimmed]; dup {
+			return fmt.Errorf("secretKeys entry %q declared twice", key)
+		}
+		seen[trimmed] = struct{}{}
+	}
+	return nil
+}
+
+func validateRuntimeConfig(runtime RuntimeManifest) error {
+	for k, v := range runtime.Config {
+		if strings.TrimSpace(k) == "" {
+			return fmt.Errorf("runtime %q config has an empty key", runtime.LocalID)
+		}
+		if isSensitiveConfigKey(k) {
+			if !envRefRegex.MatchString(strings.TrimSpace(v)) {
+				return fmt.Errorf(
+					"runtime %q config %q is sensitive and must use env:VAR (got %q)",
+					runtime.LocalID, k, v,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func validateScheduleCommand(schedule ScheduleManifest) error {
+	if len(schedule.Command) == 0 {
+		return nil
+	}
+	for _, part := range schedule.Command {
+		if strings.HasPrefix(part, "runtime_id=") {
+			return fmt.Errorf(
+				"schedule %q must not pre-declare runtime_id; it is composed at render time",
+				schedule.LocalName,
+			)
+		}
+	}
+	return nil
+}
+
+// isSensitiveConfigKey mirrors infra/aws/compute.py:_sensitive_source_config_key
+// so the manifest fails fast in CI if a developer leaves a literal token in
+// a runtime config.
+func isSensitiveConfigKey(key string) bool {
+	value := strings.ToLower(strings.TrimSpace(key))
+	compact := strings.NewReplacer("_", "", "-", "", ".", "").Replace(value)
+	switch {
+	case strings.Contains(value, "token"),
+		strings.Contains(value, "secret"),
+		strings.Contains(value, "password"),
+		strings.Contains(compact, "apikey"),
+		strings.Contains(compact, "privatekey"),
+		value == "key",
+		compact == "key":
+		return true
+	}
+	return false
+}

--- a/tools/sourcedeploy/manifest_test.go
+++ b/tools/sourcedeploy/manifest_test.go
@@ -1,0 +1,206 @@
+package sourcedeploy
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseValidManifest(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+sourceId: example
+secretKeys:
+  - EXAMPLE_API_TOKEN
+  - EXAMPLE_DOMAIN
+runtimes:
+  - localId: live
+    config:
+      domain: env:EXAMPLE_DOMAIN
+      family: live
+      token: env:EXAMPLE_API_TOKEN
+schedules:
+  - localName: live
+    runtimeLocalId: live
+    scheduleExpression: rate(10 minutes)
+    taskCount: 1
+    command:
+      - orchestrator
+      - run
+environments:
+  sec-dev:
+    extraSecretKeys:
+      - EXAMPLE_BACKFILL_KEY
+    extraRuntimes:
+      - localId: backfill
+        config:
+          domain: env:EXAMPLE_DOMAIN
+          family: live
+          since: "2026-01-01T00:00:00Z"
+          token: env:EXAMPLE_API_TOKEN
+    extraSchedules:
+      - localName: backfill
+        runtimeLocalId: backfill
+        scheduleExpression: rate(15 minutes)
+    disabledSchedules:
+      - live
+`)
+	manifest, err := Parse(data, "example.yaml")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if manifest.SourceID != "example" {
+		t.Fatalf("sourceId mismatch: %q", manifest.SourceID)
+	}
+	if len(manifest.Environments) != 1 {
+		t.Fatalf("expected 1 environment override, got %d", len(manifest.Environments))
+	}
+}
+
+func TestValidateRejectsInvalidManifests(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"non-kebab sourceId": `
+sourceId: Example
+runtimes:
+  - localId: a
+    config: {family: a}
+`,
+		"sensitive literal token": `
+sourceId: example
+runtimes:
+  - localId: live
+    config:
+      family: a
+      token: literal-secret
+`,
+		"sensitive literal apikey": `
+sourceId: example
+runtimes:
+  - localId: live
+    config:
+      family: a
+      apiKey: literal
+`,
+		"non-screaming secret key": `
+sourceId: example
+secretKeys:
+  - lowercase_secret
+runtimes:
+  - localId: live
+    config: {family: a}
+`,
+		"runtime config empty": `
+sourceId: example
+runtimes:
+  - localId: live
+    config: {}
+`,
+		"duplicate runtime": `
+sourceId: example
+runtimes:
+  - localId: live
+    config: {family: a}
+  - localId: live
+    config: {family: a}
+`,
+		"schedule unknown runtime": `
+sourceId: example
+schedules:
+  - localName: live
+    runtimeLocalId: ghost
+    scheduleExpression: rate(1 hour)
+`,
+		"schedule pre-declares runtime_id": `
+sourceId: example
+runtimes:
+  - localId: live
+    config: {family: a}
+schedules:
+  - localName: live
+    runtimeLocalId: live
+    scheduleExpression: rate(1 hour)
+    command:
+      - orchestrator
+      - run
+      - runtime_id=writer-example-live
+`,
+		"overlay disables unknown runtime": `
+sourceId: example
+runtimes:
+  - localId: live
+    config: {family: a}
+environments:
+  sec-dev:
+    disabledRuntimes:
+      - phantom
+`,
+		"overlay extra collides": `
+sourceId: example
+runtimes:
+  - localId: live
+    config: {family: a}
+environments:
+  sec-dev:
+    extraRuntimes:
+      - localId: live
+        config: {family: a}
+`,
+	}
+	for name, body := range cases {
+		body := body
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := Parse([]byte(body), name); err == nil {
+				t.Fatalf("expected validation error for %s", name)
+			}
+		})
+	}
+}
+
+func TestDiscoverWalksSourcesRoot(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkSource := func(id, body string) {
+		dir := filepath.Join(root, id)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte(body), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+	mkSource("alpha", "sourceId: alpha\nsecretKeys: [ALPHA_TOKEN]\n")
+	mkSource("beta", "sourceId: beta\n")
+	if err := os.MkdirAll(filepath.Join(root, "gamma"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	manifests, err := Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(manifests) != 2 {
+		t.Fatalf("expected 2 manifests, got %d", len(manifests))
+	}
+	if manifests[0].SourceID != "alpha" || manifests[1].SourceID != "beta" {
+		t.Fatalf("Discover returned unsorted: %#v", manifests)
+	}
+}
+
+func TestDiscoverRejectsMisplacedSource(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dir := filepath.Join(root, "alpha")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte("sourceId: beta\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := Discover(root)
+	if !errors.Is(err, ErrSourceIDMismatch) {
+		t.Fatalf("expected ErrSourceIDMismatch, got %v", err)
+	}
+}

--- a/tools/sourcedeploy/render.go
+++ b/tools/sourcedeploy/render.go
@@ -1,0 +1,299 @@
+package sourcedeploy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RenderOptions controls how manifests are projected onto an environment.
+type RenderOptions struct {
+	Environment string
+	TenantID    string
+}
+
+// Fragment is the Pulumi-shaped subset this tool owns. Marshalling it as YAML
+// produces keys identical to the ones consumed by infra/aws/__main__.py:
+// cerebro:sourceSecretKeys, cerebro:sourceRuntimes, cerebro:orchestratorSchedules.
+type Fragment struct {
+	SourceSecretKeys      []string           `yaml:"cerebro:sourceSecretKeys,omitempty"`
+	SourceRuntimes        []RenderedRuntime  `yaml:"cerebro:sourceRuntimes,omitempty"`
+	OrchestratorSchedules []RenderedSchedule `yaml:"cerebro:orchestratorSchedules,omitempty"`
+}
+
+// RenderedRuntime is the shape Pulumi expects in `sourceRuntimes`.
+type RenderedRuntime struct {
+	ID       string            `yaml:"id"`
+	SourceID string            `yaml:"sourceId"`
+	TenantID string            `yaml:"tenantId,omitempty"`
+	Config   map[string]string `yaml:"config"`
+}
+
+// RenderedSchedule is the shape Pulumi expects in `orchestratorSchedules`.
+type RenderedSchedule struct {
+	Name               string   `yaml:"name"`
+	ScheduleExpression string   `yaml:"scheduleExpression"`
+	TaskCount          int      `yaml:"taskCount,omitempty"`
+	Command            []string `yaml:"command"`
+}
+
+// Render projects a list of manifests onto an environment, applying overlays
+// declared under the manifest's `environments.<env>` block. The result is a
+// deterministic, alphabetically sorted Fragment that can be merged into a
+// Pulumi.<env>.yaml `config:` block.
+func Render(manifests []Manifest, opts RenderOptions) (Fragment, error) {
+	if strings.TrimSpace(opts.TenantID) == "" {
+		return Fragment{}, fmt.Errorf("RenderOptions.TenantID is required")
+	}
+	if !idPattern.MatchString(opts.TenantID) {
+		return Fragment{}, fmt.Errorf("tenantId %q must be lowercase kebab-case", opts.TenantID)
+	}
+	if strings.TrimSpace(opts.Environment) == "" {
+		return Fragment{}, fmt.Errorf("RenderOptions.Environment is required")
+	}
+
+	secretKeys := map[string]struct{}{}
+	runtimes := make([]RenderedRuntime, 0)
+	schedules := make([]RenderedSchedule, 0)
+
+	sortedManifests := append([]Manifest(nil), manifests...)
+	sort.Slice(sortedManifests, func(i, j int) bool {
+		return sortedManifests[i].SourceID < sortedManifests[j].SourceID
+	})
+
+	for _, manifest := range sortedManifests {
+		overlay := manifest.Environments[opts.Environment]
+		disabledRuntimes := stringSet(overlay.DisabledRuntimes)
+		disabledSchedules := stringSet(overlay.DisabledSchedules)
+
+		for _, key := range manifest.SecretKeys {
+			secretKeys[strings.TrimSpace(key)] = struct{}{}
+		}
+		for _, key := range overlay.ExtraSecretKeys {
+			secretKeys[strings.TrimSpace(key)] = struct{}{}
+		}
+
+		emit := func(list []RuntimeManifest, disabled map[string]struct{}) {
+			for _, runtime := range list {
+				if _, dropped := disabled[runtime.LocalID]; dropped {
+					continue
+				}
+				runtimes = append(runtimes, RenderedRuntime{
+					ID:       qualifiedRuntimeID(opts.TenantID, manifest.SourceID, runtime.LocalID),
+					SourceID: manifest.SourceID,
+					TenantID: opts.TenantID,
+					Config:   copyConfig(runtime.Config),
+				})
+			}
+		}
+		emit(manifest.Runtimes, disabledRuntimes)
+		emit(overlay.ExtraRuntimes, nil)
+
+		emitSchedules := func(list []ScheduleManifest, disabled map[string]struct{}) {
+			for _, schedule := range list {
+				if _, dropped := disabled[schedule.LocalName]; dropped {
+					continue
+				}
+				schedules = append(schedules, RenderedSchedule{
+					Name:               qualifiedScheduleName(manifest.SourceID, schedule.LocalName),
+					ScheduleExpression: schedule.ScheduleExpression,
+					TaskCount:          schedule.TaskCount,
+					Command: composeScheduleCommand(
+						schedule.Command,
+						qualifiedRuntimeID(opts.TenantID, manifest.SourceID, schedule.RuntimeLocalID),
+					),
+				})
+			}
+		}
+		emitSchedules(manifest.Schedules, disabledSchedules)
+		emitSchedules(overlay.ExtraSchedules, nil)
+	}
+
+	keys := make([]string, 0, len(secretKeys))
+	for key := range secretKeys {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	sort.Slice(runtimes, func(i, j int) bool { return runtimes[i].ID < runtimes[j].ID })
+	sort.Slice(schedules, func(i, j int) bool { return schedules[i].Name < schedules[j].Name })
+
+	return Fragment{
+		SourceSecretKeys:      keys,
+		SourceRuntimes:        runtimes,
+		OrchestratorSchedules: schedules,
+	}, nil
+}
+
+// MarshalYAML emits the Fragment as a deterministic YAML document with
+// 2-space indentation matching the hand-authored Pulumi config files. Map
+// keys inside `config` are sorted, and config values are emitted as quoted
+// strings because the Pulumi consumer always coerces them via str().
+func (f Fragment) MarshalYAML() ([]byte, error) {
+	doc := &yaml.Node{Kind: yaml.MappingNode}
+	if len(f.SourceSecretKeys) > 0 {
+		doc.Content = append(doc.Content, scalar("cerebro:sourceSecretKeys"), seqOfScalars(f.SourceSecretKeys))
+	}
+	if len(f.OrchestratorSchedules) > 0 {
+		seq := &yaml.Node{Kind: yaml.SequenceNode}
+		for _, schedule := range f.OrchestratorSchedules {
+			node := &yaml.Node{Kind: yaml.MappingNode}
+			node.Content = append(node.Content,
+				scalar("name"), scalar(schedule.Name),
+				scalar("scheduleExpression"), scalar(schedule.ScheduleExpression),
+				scalar("taskCount"), intScalar(schedule.TaskCount),
+				scalar("command"), seqOfScalars(schedule.Command),
+			)
+			seq.Content = append(seq.Content, node)
+		}
+		doc.Content = append(doc.Content, scalar("cerebro:orchestratorSchedules"), seq)
+	}
+	if len(f.SourceRuntimes) > 0 {
+		seq := &yaml.Node{Kind: yaml.SequenceNode}
+		for _, runtime := range f.SourceRuntimes {
+			node := &yaml.Node{Kind: yaml.MappingNode}
+			node.Content = append(node.Content,
+				scalar("id"), scalar(runtime.ID),
+				scalar("sourceId"), scalar(runtime.SourceID),
+				scalar("tenantId"), scalar(runtime.TenantID),
+				scalar("config"), sortedQuotedMap(runtime.Config),
+			)
+			seq.Content = append(seq.Content, node)
+		}
+		doc.Content = append(doc.Content, scalar("cerebro:sourceRuntimes"), seq)
+	}
+	var buf strings.Builder
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(doc); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return []byte(buf.String()), nil
+}
+
+func qualifiedRuntimeID(tenant, source, local string) string {
+	return fmt.Sprintf("%s-%s-%s", tenant, source, local)
+}
+
+func qualifiedScheduleName(source, local string) string {
+	return fmt.Sprintf("%s-%s", source, local)
+}
+
+// composeScheduleCommand inserts the runtime_id key=value argument immediately
+// after the verb tokens (the leading run of arguments without '=') so the
+// rendered command matches the existing hand-authored Pulumi schedules:
+//
+//	[orchestrator, run, runtime_id=..., page_limit=20, ...]
+func composeScheduleCommand(base []string, runtimeID string) []string {
+	if len(base) == 0 {
+		return []string{"orchestrator", "run", fmt.Sprintf("runtime_id=%s", runtimeID)}
+	}
+	insertAt := 0
+	for ; insertAt < len(base); insertAt++ {
+		if strings.Contains(base[insertAt], "=") {
+			break
+		}
+	}
+	out := make([]string, 0, len(base)+1)
+	out = append(out, base[:insertAt]...)
+	out = append(out, fmt.Sprintf("runtime_id=%s", runtimeID))
+	out = append(out, base[insertAt:]...)
+	return out
+}
+
+func stringSet(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+func copyConfig(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func scalar(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Value: value}
+}
+
+func intScalar(value int) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: fmt.Sprintf("%d", value)}
+}
+
+func seqOfScalars(values []string) *yaml.Node {
+	seq := &yaml.Node{Kind: yaml.SequenceNode}
+	for _, value := range values {
+		seq.Content = append(seq.Content, scalar(value))
+	}
+	return seq
+}
+
+func sortedQuotedMap(in map[string]string) *yaml.Node {
+	keys := make([]string, 0, len(in))
+	for key := range in {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	node := &yaml.Node{Kind: yaml.MappingNode}
+	for _, key := range keys {
+		valueNode := &yaml.Node{Kind: yaml.ScalarNode, Value: in[key]}
+		if shouldQuoteConfigValue(in[key]) {
+			valueNode.Style = yaml.DoubleQuotedStyle
+		}
+		node.Content = append(node.Content, scalar(key), valueNode)
+	}
+	return node
+}
+
+// shouldQuoteConfigValue decides whether a runtime config value should be
+// emitted as a quoted YAML scalar. We quote any value that yaml.v3 would
+// otherwise tag as a non-string (e.g. "200", "2026-01-01T00:00:00Z") so the
+// rendered file matches the hand-authored Pulumi config style.
+func shouldQuoteConfigValue(value string) bool {
+	if value == "" {
+		return true
+	}
+	if strings.HasPrefix(value, "env:") {
+		return false
+	}
+	for _, r := range value {
+		if (r < '0' || r > '9') && r != '-' && r != '_' && r != '.' && (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
+			continue
+		}
+	}
+	if isDigitsOnly(value) {
+		return true
+	}
+	if strings.Contains(value, ":") || strings.Contains(value, "T") && strings.Contains(value, "-") {
+		return true
+	}
+	return false
+}
+
+func isDigitsOnly(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/tools/sourcedeploy/render_test.go
+++ b/tools/sourcedeploy/render_test.go
@@ -1,0 +1,190 @@
+package sourcedeploy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderProjectsSecretsRuntimesAndSchedules(t *testing.T) {
+	t.Parallel()
+	manifests := []Manifest{
+		{
+			SourceID:   "okta",
+			SecretKeys: []string{"OKTA_API_TOKEN", "OKTA_DOMAIN"},
+			Runtimes: []RuntimeManifest{{
+				LocalID: "audit",
+				Config: map[string]string{
+					"domain":   "env:OKTA_DOMAIN",
+					"family":   "audit",
+					"per_page": "200",
+					"since":    "2026-05-01T00:00:00Z",
+					"token":    "env:OKTA_API_TOKEN",
+				},
+			}},
+			Schedules: []ScheduleManifest{{
+				LocalName:          "audit-live",
+				RuntimeLocalID:     "audit",
+				ScheduleExpression: "rate(10 minutes)",
+				TaskCount:          1,
+				Command: []string{
+					"orchestrator", "run",
+					"page_limit=20", "graph_page_limit=100", "event_limit=1000",
+				},
+			}},
+		},
+		{
+			SourceID:   "sentinelone",
+			SecretKeys: []string{"SENTINELONE_API_TOKEN", "SENTINELONE_BASE_URL"},
+			Runtimes: []RuntimeManifest{{
+				LocalID: "threat",
+				Config: map[string]string{
+					"base_url": "env:SENTINELONE_BASE_URL",
+					"family":   "threat",
+					"per_page": "200",
+					"token":    "env:SENTINELONE_API_TOKEN",
+				},
+			}},
+		},
+	}
+
+	frag, err := Render(manifests, RenderOptions{Environment: "sec-dev", TenantID: "writer"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	wantSecrets := []string{"OKTA_API_TOKEN", "OKTA_DOMAIN", "SENTINELONE_API_TOKEN", "SENTINELONE_BASE_URL"}
+	if !equalStrings(frag.SourceSecretKeys, wantSecrets) {
+		t.Fatalf("secret keys = %v, want %v", frag.SourceSecretKeys, wantSecrets)
+	}
+	if len(frag.SourceRuntimes) != 2 {
+		t.Fatalf("expected 2 rendered runtimes, got %d", len(frag.SourceRuntimes))
+	}
+	if frag.SourceRuntimes[0].ID != "writer-okta-audit" {
+		t.Fatalf("runtime[0].id = %q", frag.SourceRuntimes[0].ID)
+	}
+	if frag.SourceRuntimes[1].ID != "writer-sentinelone-threat" {
+		t.Fatalf("runtime[1].id = %q", frag.SourceRuntimes[1].ID)
+	}
+	if len(frag.OrchestratorSchedules) != 1 {
+		t.Fatalf("expected 1 schedule, got %d", len(frag.OrchestratorSchedules))
+	}
+	got := frag.OrchestratorSchedules[0]
+	if got.Name != "okta-audit-live" {
+		t.Fatalf("schedule.name = %q", got.Name)
+	}
+	wantCmd := []string{
+		"orchestrator", "run", "runtime_id=writer-okta-audit",
+		"page_limit=20", "graph_page_limit=100", "event_limit=1000",
+	}
+	if !equalStrings(got.Command, wantCmd) {
+		t.Fatalf("command = %v, want %v", got.Command, wantCmd)
+	}
+}
+
+func TestRenderAppliesEnvironmentOverlay(t *testing.T) {
+	t.Parallel()
+	manifests := []Manifest{{
+		SourceID: "okta",
+		Runtimes: []RuntimeManifest{{
+			LocalID: "audit",
+			Config:  map[string]string{"family": "audit"},
+		}},
+		Schedules: []ScheduleManifest{{
+			LocalName:          "live",
+			RuntimeLocalID:     "audit",
+			ScheduleExpression: "rate(10 minutes)",
+			Command:            []string{"orchestrator", "run"},
+		}},
+		Environments: map[string]EnvironmentOverrides{
+			"sec-dev": {
+				DisabledSchedules: []string{"live"},
+				ExtraRuntimes: []RuntimeManifest{{
+					LocalID: "audit-2026-04",
+					Config:  map[string]string{"family": "audit", "since": "2026-04-01T00:00:00Z"},
+				}},
+				ExtraSchedules: []ScheduleManifest{{
+					LocalName:          "audit-2026-04",
+					RuntimeLocalID:     "audit-2026-04",
+					ScheduleExpression: "rate(15 minutes)",
+					Command:            []string{"orchestrator", "run"},
+				}},
+				ExtraSecretKeys: []string{"BACKFILL_KEY"},
+			},
+		},
+	}}
+
+	frag, err := Render(manifests, RenderOptions{Environment: "sec-dev", TenantID: "writer"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !equalStrings(frag.SourceSecretKeys, []string{"BACKFILL_KEY"}) {
+		t.Fatalf("secret keys = %v", frag.SourceSecretKeys)
+	}
+	if len(frag.SourceRuntimes) != 2 {
+		t.Fatalf("expected base+extra runtime, got %d", len(frag.SourceRuntimes))
+	}
+	if len(frag.OrchestratorSchedules) != 1 {
+		t.Fatalf("expected only the extra schedule, got %d", len(frag.OrchestratorSchedules))
+	}
+	if frag.OrchestratorSchedules[0].Name != "okta-audit-2026-04" {
+		t.Fatalf("schedule.name = %q", frag.OrchestratorSchedules[0].Name)
+	}
+}
+
+func TestRenderRejectsBadOptions(t *testing.T) {
+	t.Parallel()
+	cases := []RenderOptions{
+		{Environment: "sec-dev"},
+		{Environment: "sec-dev", TenantID: "Writer"},
+		{TenantID: "writer"},
+	}
+	for _, opt := range cases {
+		if _, err := Render(nil, opt); err == nil {
+			t.Fatalf("expected error for opts %#v", opt)
+		}
+	}
+}
+
+func TestFragmentMarshalsPulumiKeys(t *testing.T) {
+	t.Parallel()
+	frag := Fragment{
+		SourceSecretKeys: []string{"AAA"},
+		SourceRuntimes: []RenderedRuntime{{
+			ID: "writer-example-live", SourceID: "example", TenantID: "writer",
+			Config: map[string]string{"family": "live"},
+		}},
+		OrchestratorSchedules: []RenderedSchedule{{
+			Name: "example-live", ScheduleExpression: "rate(1 hour)", TaskCount: 1,
+			Command: []string{"orchestrator", "run", "runtime_id=writer-example-live"},
+		}},
+	}
+	data, err := frag.MarshalYAML()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		"cerebro:sourceSecretKeys",
+		"cerebro:sourceRuntimes",
+		"cerebro:orchestratorSchedules",
+		"writer-example-live",
+		"family: live",
+		"runtime_id=writer-example-live",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected output to contain %q\n%s", want, got)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Each source under `sources/<id>/` may now declare a `deploy.yaml` describing the secret keys, runtimes, and orchestrator schedules it owns. The new `tools/sourcedeploy` package walks the tree, validates each manifest, and renders a deterministic Pulumi-shaped YAML fragment (`cerebro:sourceSecretKeys`, `cerebro:sourceRuntimes`, `cerebro:orchestratorSchedules`) so adding a new source no longer requires hand-editing infra config in WriterInternal/cerebro.

## Highlights

- `tools/sourcedeploy/manifest.go` defines `Manifest` with optional per-environment overlays (`disabledRuntimes`, `extraRuntimes`, `extraSchedules`, `extraSecretKeys`).
- Validation mirrors `infra/aws/compute.py:_sensitive_source_config_key` so literal tokens fail fast in CI; sensitive values must use `env:VAR`.
- `tools/sourcedeploy/render.go` produces a deterministic fragment with stable ordering, 2-space indents, and quoted string scalars matching the hand-authored Pulumi files.
- New `cmd/sourcedeploy` CLI: `go run ./cmd/sourcedeploy -env sec-dev -tenant writer`.
- `tools/archtests/source_deploy_test.go` enforces presence + validity for sources that own runtimes (initially `okta`, `sentinelone`) and exercises rendering across known environments.
- `sources/okta/deploy.yaml` and `sources/sentinelone/deploy.yaml` are authored to reproduce the current `Pulumi.sec-dev.yaml` fragment exactly. Verified by extracting the existing fragment and comparing as a multiset (4 secret keys, 6 schedules, 8 runtimes match).

## Why

Adding the next source today requires opening a private PR against WriterInternal/cerebro to hand-edit a Pulumi YAML file. With this change, the public source repo is the source of truth and the internal repo can simply consume the rendered fragment, keeping the secure boundary intact.

## Validation

- `make verify` passes (build, full `go test ./...`, golangci-lint, buf, cerebrolint, archtests).
- Rendered fragment for `sec-dev` is set-equal to the current `Pulumi.sec-dev.yaml` config (verified locally).

## Follow-ups (not in this PR)

- Wire WriterInternal/cerebro to consume the rendered fragment via a generated overlay file.
- Run a SentinelOne scan via `aws ecs run-task` against `cerebro-sec-dev-orchestrator`.
- Document the OSS-to-Internal promotion strategy (image signing, ECR mirroring via OIDC, secret provenance through Infisical).