### PR TITLE
fix(orchestrator): skip unavailable finding rules

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -398,10 +399,15 @@ func runOrchestratorIteration(
 		}
 		findingResult, err := findingService.EvaluateSourceRuntimeRules(runtimeCtx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit})
 		if err != nil {
-			runtimeResult.FindingRules = "failed"
-			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "finding_rules", err)
-			runErr = err
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_rules_error", err.Error())
+			if errors.Is(err, findings.ErrRuleUnavailable) {
+				runtimeResult.FindingRules = "skipped"
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_rules_skip_reason", err.Error())
+			} else {
+				runtimeResult.FindingRules = "failed"
+				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "finding_rules", err)
+				runErr = err
+				runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_rules_error", err.Error())
+			}
 		} else {
 			runtimeResult.FindingRules = "completed"
 			runtimeResult.EventsEvaluated = findingResult.EventsEvaluated

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -146,6 +146,58 @@ func TestRunOrchestratorIterationPreservesGraphCountersOnPartialFailure(t *testi
 	}
 }
 
+func TestRunOrchestratorIterationSkipsUnavailableFindingRules(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	ruleRegistry, err := findings.NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() finding rule error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{
+			Id:       "runtime-1",
+			SourceId: "github",
+			TenantId: "writer",
+		},
+		acquired: true,
+	}
+	eventLog := &orchestratorEventLog{}
+	findingStore := &orchestratorFindingStore{}
+	graphStore := newGraphTestStore()
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(registry, store, eventLog, nil),
+		findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry),
+		graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore),
+		orchestratorOptions{},
+		1,
+	)
+	if err != nil {
+		t.Fatalf("runOrchestratorIteration() error = %v, want nil", err)
+	}
+	if got := len(result.Runtimes); got != 1 {
+		t.Fatalf("runtime result count = %d, want 1", got)
+	}
+	runtimeResult := result.Runtimes[0]
+	if runtimeResult.Sync != "completed" {
+		t.Fatalf("sync status = %q, want completed", runtimeResult.Sync)
+	}
+	if runtimeResult.FindingRules != "skipped" {
+		t.Fatalf("finding rules status = %q, want skipped", runtimeResult.FindingRules)
+	}
+	if runtimeResult.GraphIngest != "completed" {
+		t.Fatalf("graph ingest status = %q, want completed", runtimeResult.GraphIngest)
+	}
+	if runtimeResult.Error != "" {
+		t.Fatalf("runtime error = %q, want empty", runtimeResult.Error)
+	}
+}
+
 func TestAcquireOrchestratorRuntimeLeaseClaimsRuntime(t *testing.T) {
 	store := &leaseRuntimeStore{acquired: true}
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1"}


### PR DESCRIPTION
## Summary

SentinelOne sec-dev proved that a new source can ingest and graph successfully before we have source-specific finding rules. The current orchestrator treats `findings.ErrRuleUnavailable` as fatal, causing a one-off S1 run to exit 1 after successfully reading and committing 200 events and projecting 600 entities / 400 links.

This changes `ErrRuleUnavailable` handling to mark the findings stage as `skipped`, continue graph ingest, and return success if no other stage fails.

## AWS diagnosis

- sec-dev health 503 was caused by ECS rolling back from task def 28 because `cerebro-sec-dev/SENTINELONE_API_TOKEN` was missing in Secrets Manager.
- Created the missing secret from 1Password (without printing value), redeployed `cerebro-sec-dev-api` to task def 28, and health now returns 200.
- S1 bootstrap containers now register `writer-sentinelone-threat` and `writer-sentinelone-agent` successfully.
- One-off ECS task for `runtime_id=writer-sentinelone-agent` read 200 events, appended 200 events, projected 600 entities / 400 links, then failed only because no finding rules support SentinelOne yet.

## Validation

- `go test ./cmd/cerebro -run 'TestRunOrchestratorIteration(SkipsUnavailableFindingRules|PreservesGraphCountersOnPartialFailure)'`
- `make verify`