### PR TITLE
feat(source-runtime): add batch bootstrap command

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -202,7 +202,7 @@ func runSource(args []string) error {
 
 func runSourceRuntime(args []string) error {
 	if len(args) == 0 {
-		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|list|sync] ...", os.Args[0]))
+		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|list|sync|bootstrap] ...", os.Args[0]))
 	}
 	cfg, err := appconfig.Load()
 	if err != nil {
@@ -230,6 +230,27 @@ func runSourceRuntime(args []string) error {
 	))
 
 	switch args[0] {
+	case "bootstrap":
+		runtimes, err := parseSourceRuntimeBootstrapArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		for index, runtime := range runtimes {
+			runtime, err = prepareSourceRuntime(ctx, runtime)
+			if err != nil {
+				return fmt.Errorf("source runtime bootstrap runtimes[%d]: %w", index, err)
+			}
+			runtimes[index] = runtime
+		}
+		response, err := service.PutRuntimes(ctx, sourceruntime.PutRuntimesRequest{Runtimes: runtimes})
+		if err != nil {
+			return err
+		}
+		payload, err := sourceRuntimeListJSON(response.Runtimes)
+		if err != nil {
+			return err
+		}
+		return printJSON(payload)
 	case "put":
 		runtime, err := parseSourceRuntimePutArgs(args[1:])
 		if err != nil {
@@ -281,7 +302,7 @@ func runSourceRuntime(args []string) error {
 		}
 		return printProto(response)
 	default:
-		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|list|sync] ...", os.Args[0]))
+		return usageError(fmt.Sprintf("usage: %s source-runtime [put|get|list|sync|bootstrap] ...", os.Args[0]))
 	}
 }
 
@@ -341,6 +362,94 @@ func parseSourceRuntimePutArgs(args []string) (*cerebrov1.SourceRuntime, error) 
 		runtime.Config[key] = resolved
 	}
 	return runtime, nil
+}
+
+func parseSourceRuntimeBootstrapArgs(args []string) ([]*cerebrov1.SourceRuntime, error) {
+	if len(args) != 1 {
+		return nil, usageError(fmt.Sprintf("usage: %s source-runtime bootstrap env=<env-var>", os.Args[0]))
+	}
+	key, value, ok := strings.Cut(args[0], "=")
+	envName := strings.TrimSpace(value)
+	if !ok || key != "env" || envName == "" {
+		return nil, usageError(fmt.Sprintf("usage: %s source-runtime bootstrap env=<env-var>", os.Args[0]))
+	}
+	payload, ok := os.LookupEnv(envName)
+	if !ok {
+		return nil, fmt.Errorf("source runtime bootstrap env %q is unset", envName)
+	}
+	return parseSourceRuntimeBootstrapJSON(payload)
+}
+
+func parseSourceRuntimeBootstrapJSON(payload string) ([]*cerebrov1.SourceRuntime, error) {
+	payload = strings.TrimSpace(payload)
+	if payload == "" {
+		return nil, fmt.Errorf("source runtime bootstrap payload is empty")
+	}
+	rawRuntimes, err := sourceRuntimeBootstrapRawMessages(payload)
+	if err != nil {
+		return nil, err
+	}
+	if len(rawRuntimes) == 0 {
+		return nil, fmt.Errorf("source runtime bootstrap payload must include at least one runtime")
+	}
+	runtimes := make([]*cerebrov1.SourceRuntime, 0, len(rawRuntimes))
+	seenRuntimeIDs := make(map[string]struct{}, len(rawRuntimes))
+	unmarshaler := protojson.UnmarshalOptions{DiscardUnknown: false}
+	for index, raw := range rawRuntimes {
+		var runtime cerebrov1.SourceRuntime
+		if err := unmarshaler.Unmarshal(raw, &runtime); err != nil {
+			return nil, fmt.Errorf("parse source runtime bootstrap runtimes[%d]: %w", index, err)
+		}
+		if err := normalizeBootstrapSourceRuntime(&runtime); err != nil {
+			return nil, fmt.Errorf("source runtime bootstrap runtimes[%d]: %w", index, err)
+		}
+		if _, ok := seenRuntimeIDs[runtime.GetId()]; ok {
+			return nil, fmt.Errorf("source runtime bootstrap runtimes[%d]: duplicate runtime id %q", index, runtime.GetId())
+		}
+		seenRuntimeIDs[runtime.GetId()] = struct{}{}
+		runtimes = append(runtimes, &runtime)
+	}
+	return runtimes, nil
+}
+
+func sourceRuntimeBootstrapRawMessages(payload string) ([]json.RawMessage, error) {
+	if strings.HasPrefix(payload, "[") {
+		var runtimes []json.RawMessage
+		if err := json.Unmarshal([]byte(payload), &runtimes); err != nil {
+			return nil, fmt.Errorf("parse source runtime bootstrap payload: %w", err)
+		}
+		return runtimes, nil
+	}
+	var document struct {
+		Runtimes []json.RawMessage `json:"runtimes"`
+	}
+	if err := json.Unmarshal([]byte(payload), &document); err != nil {
+		return nil, fmt.Errorf("parse source runtime bootstrap payload: %w", err)
+	}
+	return document.Runtimes, nil
+}
+
+func normalizeBootstrapSourceRuntime(runtime *cerebrov1.SourceRuntime) error {
+	runtime.Id = strings.TrimSpace(runtime.GetId())
+	runtime.SourceId = strings.TrimSpace(runtime.GetSourceId())
+	runtime.TenantId = strings.TrimSpace(runtime.GetTenantId())
+	runtime.Checkpoint = nil
+	runtime.NextCursor = nil
+	runtime.LastSyncedAt = nil
+	if runtime.GetId() == "" || runtime.GetSourceId() == "" {
+		return usageError(fmt.Sprintf("usage: %s source-runtime bootstrap env=<env-var>", os.Args[0]))
+	}
+	if runtime.Config == nil {
+		runtime.Config = make(map[string]string)
+	}
+	for key, value := range runtime.GetConfig() {
+		normalized, err := sourceConfigValueFromArg(key, value)
+		if err != nil {
+			return err
+		}
+		runtime.Config[key] = normalized
+	}
+	return nil
 }
 
 func sourceConfigValueFromArg(key string, value string) (string, error) {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -161,6 +161,71 @@ func TestParseSourceCommandArgsAllowsUnsetSensitiveEnvReference(t *testing.T) {
 	}
 }
 
+func TestParseSourceRuntimeBootstrapArgsReadsEnvDocument(t *testing.T) {
+	t.Setenv("CEREBRO_SOURCE_RUNTIME_BOOTSTRAP_JSON", `{
+		"runtimes": [
+			{
+				"id": " writer-okta-users ",
+				"source_id": " okta ",
+				"tenant_id": " writer ",
+				"config": {
+					"domain": "env:OKTA_DOMAIN",
+					"family": "user",
+					"token": "env:OKTA_API_TOKEN"
+				},
+				"next_cursor": {"opaque": "ignored"}
+			}
+		]
+	}`)
+	runtimes, err := parseSourceRuntimeBootstrapArgs([]string{"env=CEREBRO_SOURCE_RUNTIME_BOOTSTRAP_JSON"})
+	if err != nil {
+		t.Fatalf("parseSourceRuntimeBootstrapArgs() error = %v", err)
+	}
+	if len(runtimes) != 1 {
+		t.Fatalf("len(runtimes) = %d, want 1", len(runtimes))
+	}
+	runtime := runtimes[0]
+	if runtime.GetId() != "writer-okta-users" || runtime.GetSourceId() != "okta" || runtime.GetTenantId() != "writer" {
+		t.Fatalf("runtime identity = (%q, %q, %q)", runtime.GetId(), runtime.GetSourceId(), runtime.GetTenantId())
+	}
+	if got := runtime.GetConfig()["token"]; got != "env:OKTA_API_TOKEN" {
+		t.Fatalf("runtime.Config[token] = %q, want env ref", got)
+	}
+	if runtime.GetNextCursor() != nil {
+		t.Fatal("runtime.NextCursor present, want ignored bootstrap progress")
+	}
+}
+
+func TestParseSourceRuntimeBootstrapJSONAcceptsArray(t *testing.T) {
+	runtimes, err := parseSourceRuntimeBootstrapJSON(`[{"id":"runtime-1","sourceId":"github","config":{"owner":"writer","repo":"cerebro"}}]`)
+	if err != nil {
+		t.Fatalf("parseSourceRuntimeBootstrapJSON() error = %v", err)
+	}
+	if len(runtimes) != 1 || runtimes[0].GetSourceId() != "github" {
+		t.Fatalf("runtimes = %#v", runtimes)
+	}
+}
+
+func TestParseSourceRuntimeBootstrapRejectsLiteralSensitiveValues(t *testing.T) {
+	_, err := parseSourceRuntimeBootstrapJSON(`{"runtimes":[{"id":"runtime-1","source_id":"github","config":{"token":"test-token"}}]}`)
+	if err == nil {
+		t.Fatal("parseSourceRuntimeBootstrapJSON() error = nil, want non-nil")
+	}
+	if strings.Contains(fmt.Sprint(err), "test-token") {
+		t.Fatalf("parseSourceRuntimeBootstrapJSON() error leaked literal value: %v", err)
+	}
+}
+
+func TestParseSourceRuntimeBootstrapRejectsDuplicateRuntimeIDs(t *testing.T) {
+	_, err := parseSourceRuntimeBootstrapJSON(`{"runtimes":[{"id":"runtime-1","source_id":"github"},{"id":"runtime-1","source_id":"okta"}]}`)
+	if err == nil {
+		t.Fatal("parseSourceRuntimeBootstrapJSON() error = nil, want non-nil")
+	}
+	if !strings.Contains(fmt.Sprint(err), "duplicate runtime id") {
+		t.Fatalf("parseSourceRuntimeBootstrapJSON() error = %v, want duplicate runtime id", err)
+	}
+}
+
 type commandTokenSource struct {
 	readToken string
 }

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -18,6 +18,12 @@ type SourceRuntimeStore interface {
 	GetSourceRuntime(context.Context, string) (*cerebrov1.SourceRuntime, error)
 }
 
+// SourceRuntimeBatchStore persists multiple source runtimes atomically.
+type SourceRuntimeBatchStore interface {
+	SourceRuntimeStore
+	PutSourceRuntimes(context.Context, []*cerebrov1.SourceRuntime) error
+}
+
 // SourceRuntimeFilter scopes persisted source runtime listing.
 type SourceRuntimeFilter struct {
 	RuntimeID string

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -45,6 +45,16 @@ type Service struct {
 	resolver  sourceconfig.Resolver
 }
 
+// PutRuntimesRequest contains source runtime definitions to validate and store together.
+type PutRuntimesRequest struct {
+	Runtimes []*cerebrov1.SourceRuntime
+}
+
+// PutRuntimesResponse contains stored source runtime definitions with sensitive config redacted.
+type PutRuntimesResponse struct {
+	Runtimes []*cerebrov1.SourceRuntime
+}
+
 // New constructs a source runtime service.
 func New(registry *sourcecdk.Registry, store ports.SourceRuntimeStore, appendLog ports.AppendLog, projector ports.SourceProjector) *Service {
 	return &Service{registry: registry, store: store, appendLog: appendLog, projector: projector}
@@ -67,7 +77,62 @@ func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeReques
 	if req == nil || req.GetRuntime() == nil {
 		return nil, fmt.Errorf("%w: source runtime is required", ErrInvalidRequest)
 	}
-	runtime := cloneRuntime(req.GetRuntime())
+	runtime, err := s.preparePutRuntime(ctx, req.GetRuntime())
+	if err != nil {
+		return nil, err
+	}
+	if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
+		return nil, err
+	}
+	return &cerebrov1.PutSourceRuntimeResponse{Runtime: redactRuntime(runtime)}, nil
+}
+
+// PutRuntimes validates all runtimes, then stores them atomically when more than one runtime is provided.
+func (s *Service) PutRuntimes(ctx context.Context, req PutRuntimesRequest) (*PutRuntimesResponse, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	if len(req.Runtimes) == 0 {
+		return nil, fmt.Errorf("%w: at least one source runtime is required", ErrInvalidRequest)
+	}
+	seenRuntimeIDs := make(map[string]struct{}, len(req.Runtimes))
+	runtimes := make([]*cerebrov1.SourceRuntime, 0, len(req.Runtimes))
+	for index, runtime := range req.Runtimes {
+		prepared, err := s.preparePutRuntime(ctx, runtime)
+		if err != nil {
+			return nil, fmt.Errorf("source runtime %d: %w", index, err)
+		}
+		if _, ok := seenRuntimeIDs[prepared.GetId()]; ok {
+			return nil, fmt.Errorf("%w: duplicate source runtime id %q", ErrInvalidRequest, prepared.GetId())
+		}
+		seenRuntimeIDs[prepared.GetId()] = struct{}{}
+		runtimes = append(runtimes, prepared)
+	}
+	if len(runtimes) == 1 {
+		if err := s.store.PutSourceRuntime(ctx, runtimes[0]); err != nil {
+			return nil, err
+		}
+	} else {
+		batchStore, ok := s.store.(ports.SourceRuntimeBatchStore)
+		if !ok {
+			return nil, fmt.Errorf("%w: atomic source runtime batch store is unavailable", ErrRuntimeUnavailable)
+		}
+		if err := batchStore.PutSourceRuntimes(ctx, runtimes); err != nil {
+			return nil, err
+		}
+	}
+	redacted := make([]*cerebrov1.SourceRuntime, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		redacted = append(redacted, redactRuntime(runtime))
+	}
+	return &PutRuntimesResponse{Runtimes: redacted}, nil
+}
+
+func (s *Service) preparePutRuntime(ctx context.Context, input *cerebrov1.SourceRuntime) (*cerebrov1.SourceRuntime, error) {
+	if input == nil {
+		return nil, fmt.Errorf("%w: source runtime is required", ErrInvalidRequest)
+	}
+	runtime := cloneRuntime(input)
 	runtime.Id = strings.TrimSpace(runtime.GetId())
 	runtime.SourceId = strings.TrimSpace(runtime.GetSourceId())
 	runtime.TenantId = strings.TrimSpace(runtime.GetTenantId())
@@ -104,10 +169,7 @@ func (s *Service) Put(ctx context.Context, req *cerebrov1.PutSourceRuntimeReques
 		}
 		runtime = mergeRuntime(existing, runtime)
 	}
-	if err := s.store.PutSourceRuntime(ctx, runtime); err != nil {
-		return nil, err
-	}
-	return &cerebrov1.PutSourceRuntimeResponse{Runtime: redactRuntime(runtime)}, nil
+	return runtime, nil
 }
 
 // Get returns one stored source runtime definition.

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -40,6 +40,22 @@ func (s *runtimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.So
 	return nil
 }
 
+func (s *runtimeStore) PutSourceRuntimes(_ context.Context, runtimes []*cerebrov1.SourceRuntime) error {
+	if s.err != nil {
+		return s.err
+	}
+	cloned := make(map[string]*cerebrov1.SourceRuntime, len(s.runtimes)+len(runtimes))
+	for id, runtime := range s.runtimes {
+		cloned[id] = proto.Clone(runtime).(*cerebrov1.SourceRuntime)
+	}
+	for _, runtime := range runtimes {
+		cloned[runtime.GetId()] = proto.Clone(runtime).(*cerebrov1.SourceRuntime)
+	}
+	s.putCount += len(runtimes)
+	s.runtimes = cloned
+	return nil
+}
+
 func (s *runtimeStore) GetSourceRuntime(_ context.Context, id string) (*cerebrov1.SourceRuntime, error) {
 	if s.err != nil {
 		return nil, s.err
@@ -253,6 +269,49 @@ func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 	}
 	if got := store.runtimes["writer-okta-users"].GetConfig()["token"]; got != "super-secret" {
 		t.Fatalf("stored runtime token = %q, want %q", got, "super-secret")
+	}
+}
+
+func TestPutRuntimesValidatesBatchBeforeWriting(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(emptyPageSource{}, failingSource{err: sourcecdk.ErrInvalidConfig})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{}
+	service := New(registry, store, nil, nil)
+
+	_, err = service.PutRuntimes(context.Background(), PutRuntimesRequest{Runtimes: []*cerebrov1.SourceRuntime{
+		{Id: "runtime-1", SourceId: "empty_page"},
+		{Id: "runtime-2", SourceId: "failing"},
+	}})
+	if err == nil {
+		t.Fatal("PutRuntimes() error = nil, want non-nil")
+	}
+	if store.putCount != 0 {
+		t.Fatalf("store.putCount = %d, want 0", store.putCount)
+	}
+	if len(store.runtimes) != 0 {
+		t.Fatalf("store.runtimes len = %d, want 0", len(store.runtimes))
+	}
+}
+
+func TestPutRuntimesRejectsDuplicateRuntimeIDs(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(emptyPageSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{}
+	service := New(registry, store, nil, nil)
+
+	_, err = service.PutRuntimes(context.Background(), PutRuntimesRequest{Runtimes: []*cerebrov1.SourceRuntime{
+		{Id: "runtime-1", SourceId: "empty_page"},
+		{Id: " runtime-1 ", SourceId: "empty_page"},
+	}})
+	if err == nil {
+		t.Fatal("PutRuntimes() error = nil, want non-nil")
+	}
+	if store.putCount != 0 {
+		t.Fatalf("store.putCount = %d, want 0", store.putCount)
 	}
 }
 

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -23,6 +23,49 @@ var ensureSourceRuntimeStatements = []string{`CREATE TABLE IF NOT EXISTS source_
 
 // PutSourceRuntime upserts one source runtime definition.
 func (s *Store) PutSourceRuntime(ctx context.Context, runtime *cerebrov1.SourceRuntime) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return err
+	}
+	return putSourceRuntime(ctx, s.db, runtime)
+}
+
+// PutSourceRuntimes upserts source runtime definitions atomically.
+func (s *Store) PutSourceRuntimes(ctx context.Context, runtimes []*cerebrov1.SourceRuntime) error {
+	if len(runtimes) == 0 {
+		return errors.New("at least one source runtime is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin source runtime batch: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	for _, runtime := range runtimes {
+		if err := putSourceRuntime(ctx, tx, runtime); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit source runtime batch: %w", err)
+	}
+	return nil
+}
+
+type sourceRuntimeExecutor interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func putSourceRuntime(ctx context.Context, executor sourceRuntimeExecutor, runtime *cerebrov1.SourceRuntime) error {
 	if runtime == nil {
 		return errors.New("source runtime is required")
 	}
@@ -33,17 +76,11 @@ func (s *Store) PutSourceRuntime(ctx context.Context, runtime *cerebrov1.SourceR
 	if strings.TrimSpace(runtime.GetSourceId()) == "" {
 		return errors.New("source id is required")
 	}
-	if s == nil || s.db == nil {
-		return errors.New("postgres is not configured")
-	}
-	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
-		return err
-	}
 	payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(runtime)
 	if err != nil {
 		return fmt.Errorf("marshal source runtime: %w", err)
 	}
-	if _, err := s.db.ExecContext(ctx, `
+	if _, err := executor.ExecContext(ctx, `
 INSERT INTO source_runtimes (id, runtime_json)
 VALUES ($1, $2::jsonb)
 ON CONFLICT (id)


### PR DESCRIPTION
## Summary
- add a source-runtime bootstrap command that loads multiple runtime definitions from JSON in an env var
- reject literal sensitive config values and clear progress fields from bootstrap payloads

## Validation
- make verify