### PR TITLE
fix(sentinelone): tolerate non-boolean exclusion flags

### DIFF
--- a/sources/sentinelone/records.go
+++ b/sources/sentinelone/records.go
@@ -20,6 +20,10 @@ type rawCarrier interface {
 type flexibleBool bool
 
 func (b *flexibleBool) UnmarshalJSON(raw []byte) error {
+	if strings.TrimSpace(string(raw)) == "null" {
+		*b = false
+		return nil
+	}
 	var value bool
 	if err := json.Unmarshal(raw, &value); err == nil {
 		*b = flexibleBool(value)
@@ -28,14 +32,15 @@ func (b *flexibleBool) UnmarshalJSON(raw []byte) error {
 	var text string
 	if err := json.Unmarshal(raw, &text); err == nil {
 		switch strings.ToLower(strings.TrimSpace(text)) {
-		case "", "0", "false", "n", "no":
+		case "", "0", "false", "n", "no", "none", "null":
 			*b = false
 			return nil
 		case "1", "true", "y", "yes":
 			*b = true
 			return nil
 		default:
-			return fmt.Errorf("invalid bool string %q", text)
+			*b = false
+			return nil
 		}
 	}
 	return fmt.Errorf("invalid bool value %s", string(raw))

--- a/sources/sentinelone/source_test.go
+++ b/sources/sentinelone/source_test.go
@@ -623,7 +623,7 @@ func newTestAPIHandler(t *testing.T) http.Handler {
 	}
 	sites := []map[string]any{{"id": "S-1", "name": "Production", "state": "active", "isDefault": true}}
 	groups := []map[string]any{{"id": "G-1", "name": "Default Group", "type": "static", "isDefault": true, "siteId": "S-1", "totalAgents": 2}}
-	exclusions := []map[string]any{{"id": "X-1", "type": "path", "mode": "suppress_alerts", "osType": "macos", "scope": "site", "scopeName": "Production", "value": "/Applications/Approved.app", "notRecommended": "true"}}
+	exclusions := []map[string]any{{"id": "X-1", "type": "path", "mode": "suppress_alerts", "osType": "macos", "scope": "site", "scopeName": "Production", "value": "/Applications/Approved.app", "notRecommended": "NONE", "includeChildren": "true"}}
 	activities := []map[string]any{{"id": "Y-1", "activityType": 27, "primaryDescription": "User user@example.test logged in", "agentId": "A-1", "siteId": "S-1", "groupId": "G-1", "createdAt": "2026-04-23T00:30:00Z"}}
 	apps := []map[string]any{
 		{"name": "Example App", "publisher": "Example Inc", "version": "1.0.0", "installedDate": "2026-04-20T00:00:00Z", "size": 12345},


### PR DESCRIPTION
## Summary
- treat SentinelOne exclusion bool-like enum strings such as NONE as false
- keep ingestion from failing on unknown string flags while preserving raw payloads

## Validation
- make verify