### PR TITLE
fix(sentinelone): tolerate object exclusion scopes

### DIFF
--- a/sources/sentinelone/records.go
+++ b/sources/sentinelone/records.go
@@ -1,6 +1,7 @@
 package sentinelone
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -44,6 +45,42 @@ func (b *flexibleBool) UnmarshalJSON(raw []byte) error {
 		}
 	}
 	return fmt.Errorf("invalid bool value %s", string(raw))
+}
+
+type flexibleString string
+
+func (s *flexibleString) UnmarshalJSON(raw []byte) error {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "null" {
+		*s = ""
+		return nil
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		*s = flexibleString(text)
+		return nil
+	}
+	var value any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return err
+	}
+	switch typed := value.(type) {
+	case nil:
+		*s = ""
+	case bool:
+		*s = flexibleString(fmt.Sprint(typed))
+	case json.Number:
+		*s = flexibleString(typed.String())
+	default:
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, raw); err != nil {
+			return err
+		}
+		*s = flexibleString(compact.String())
+	}
+	return nil
 }
 
 // threatRecord captures the high-value fields returned by /web/api/v2.1/threats.
@@ -326,27 +363,27 @@ func (r *groupRecord) rawBytes() json.RawMessage  { return r.raw }
 
 // exclusionRecord captures fields from /web/api/v2.1/exclusions.
 type exclusionRecord struct {
-	ID                string       `json:"id"`
-	Type              string       `json:"type"`
-	Mode              string       `json:"mode"`
-	Source            string       `json:"source"`
-	OSType            string       `json:"osType"`
-	PathExclusionType string       `json:"pathExclusionType"`
-	IncludeChildren   flexibleBool `json:"includeChildren"`
-	IncludeParents    flexibleBool `json:"includeParents"`
-	Imported          flexibleBool `json:"imported"`
-	NotRecommended    flexibleBool `json:"notRecommended"`
-	Description       string       `json:"description"`
-	ApplicationName   string       `json:"applicationName"`
-	UserID            string       `json:"userId"`
-	UserName          string       `json:"userName"`
-	Scope             string       `json:"scope"`
-	ScopeName         string       `json:"scopeName"`
-	ScopePath         string       `json:"scopePath"`
-	Value             string       `json:"value"`
-	Actions           []string     `json:"actions"`
-	CreatedAt         string       `json:"createdAt"`
-	UpdatedAt         string       `json:"updatedAt"`
+	ID                string         `json:"id"`
+	Type              string         `json:"type"`
+	Mode              string         `json:"mode"`
+	Source            string         `json:"source"`
+	OSType            string         `json:"osType"`
+	PathExclusionType string         `json:"pathExclusionType"`
+	IncludeChildren   flexibleBool   `json:"includeChildren"`
+	IncludeParents    flexibleBool   `json:"includeParents"`
+	Imported          flexibleBool   `json:"imported"`
+	NotRecommended    flexibleBool   `json:"notRecommended"`
+	Description       string         `json:"description"`
+	ApplicationName   string         `json:"applicationName"`
+	UserID            string         `json:"userId"`
+	UserName          string         `json:"userName"`
+	Scope             flexibleString `json:"scope"`
+	ScopeName         flexibleString `json:"scopeName"`
+	ScopePath         flexibleString `json:"scopePath"`
+	Value             flexibleString `json:"value"`
+	Actions           []string       `json:"actions"`
+	CreatedAt         string         `json:"createdAt"`
+	UpdatedAt         string         `json:"updatedAt"`
 	raw               json.RawMessage
 }
 
@@ -934,10 +971,10 @@ func exclusionEvent(s settings, record exclusionRecord) (*primitives.Event, erro
 		ApplicationName:   record.ApplicationName,
 		UserID:            record.UserID,
 		UserName:          record.UserName,
-		Scope:             record.Scope,
-		ScopeName:         record.ScopeName,
-		ScopePath:         record.ScopePath,
-		Value:             record.Value,
+		Scope:             string(record.Scope),
+		ScopeName:         string(record.ScopeName),
+		ScopePath:         string(record.ScopePath),
+		Value:             string(record.Value),
 		Actions:           record.Actions,
 		CreatedAt:         record.CreatedAt,
 		UpdatedAt:         record.UpdatedAt,
@@ -956,10 +993,10 @@ func exclusionEvent(s settings, record exclusionRecord) (*primitives.Event, erro
 	addAttribute(attrs, "source", record.Source)
 	addAttribute(attrs, "os_type", record.OSType)
 	addAttribute(attrs, "path_exclusion_type", record.PathExclusionType)
-	addAttribute(attrs, "scope", record.Scope)
-	addAttribute(attrs, "scope_name", record.ScopeName)
-	addAttribute(attrs, "scope_path", record.ScopePath)
-	addAttribute(attrs, "value", record.Value)
+	addAttribute(attrs, "scope", string(record.Scope))
+	addAttribute(attrs, "scope_name", string(record.ScopeName))
+	addAttribute(attrs, "scope_path", string(record.ScopePath))
+	addAttribute(attrs, "value", string(record.Value))
 	addAttribute(attrs, "not_recommended", boolString(bool(record.NotRecommended)))
 	addAttribute(attrs, "include_children", boolString(bool(record.IncludeChildren)))
 	addAttribute(attrs, "include_parents", boolString(bool(record.IncludeParents)))

--- a/sources/sentinelone/source_test.go
+++ b/sources/sentinelone/source_test.go
@@ -623,7 +623,7 @@ func newTestAPIHandler(t *testing.T) http.Handler {
 	}
 	sites := []map[string]any{{"id": "S-1", "name": "Production", "state": "active", "isDefault": true}}
 	groups := []map[string]any{{"id": "G-1", "name": "Default Group", "type": "static", "isDefault": true, "siteId": "S-1", "totalAgents": 2}}
-	exclusions := []map[string]any{{"id": "X-1", "type": "path", "mode": "suppress_alerts", "osType": "macos", "scope": "site", "scopeName": "Production", "value": "/Applications/Approved.app", "notRecommended": "NONE", "includeChildren": "true"}}
+	exclusions := []map[string]any{{"id": "X-1", "type": "path", "mode": "suppress_alerts", "osType": "macos", "scope": map[string]any{"name": "Production", "type": "site"}, "scopeName": "Production", "value": "/Applications/Approved.app", "notRecommended": "NONE", "includeChildren": "true"}}
 	activities := []map[string]any{{"id": "Y-1", "activityType": 27, "primaryDescription": "User user@example.test logged in", "agentId": "A-1", "siteId": "S-1", "groupId": "G-1", "createdAt": "2026-04-23T00:30:00Z"}}
 	apps := []map[string]any{
 		{"name": "Example App", "publisher": "Example Inc", "version": "1.0.0", "installedDate": "2026-04-20T00:00:00Z", "size": 12345},


### PR DESCRIPTION
## Summary
- Decode SentinelOne exclusion scope fields from strings or structured JSON values.
- Preserve structured scope values as compact JSON strings in event payload/attributes.
- Add regression coverage using an object-shaped exclusion scope fixture.

## Validation
- go test -C /Users/jonathan/cerebro-grc-worktrees/cerebro ./sources/sentinelone -run 'TestReadLiveJoinFamilies|TestReadAgentFamily' -count=1 -v
- make -C /Users/jonathan/cerebro-grc-worktrees/cerebro verify