### PR TITLE
feat(github): add deploy manifest for github audit runtime

### DIFF
--- a/sources/github/deploy.yaml
+++ b/sources/github/deploy.yaml
@@ -1,0 +1,10 @@
+sourceId: github
+secretKeys:
+  - GITHUB_TOKEN
+runtimes:
+  - localId: audit
+    config:
+      family: audit
+      owner: writer
+      per_page: "100"
+      token: env:GITHUB_TOKEN

--- a/tools/archtests/source_deploy_test.go
+++ b/tools/archtests/source_deploy_test.go
@@ -15,6 +15,7 @@ import (
 // not own runtimes (e.g. push-only SDK adapters, infrastructure scanners
 // driven by the orchestrator default command) are exempt by being absent.
 var requireDeployManifest = map[string]struct{}{
+	"github":      {},
 	"okta":        {},
 	"sentinelone": {},
 }


### PR DESCRIPTION
Declares the canonical writer-org github audit runtime so the `sourcedeploy` synth can render `cerebro:sourceSecretKeys` + `cerebro:sourceRuntimes` for the private infra repo. Adds `github` to the archtest required-manifest set.

The OSS contract only declares the canonical writer-tenant baseline (org `writer`, audit family). Per-org backfill or additional org runtimes (writercolab, WriterInternal) are private-infra cadence and live in WriterInternal/cerebro.