### PR TITLE
fix(findings): retire noisy SentinelOne rules

### DIFF
--- a/internal/findings/rule_fixture_test.go
+++ b/internal/findings/rule_fixture_test.go
@@ -198,6 +198,40 @@ func TestSentinelOneFindingFingerprintIncludesRuntime(t *testing.T) {
 	}
 }
 
+func TestRetiredSentinelOneRulesDoNotEmitFindings(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-threat", SourceId: "sentinelone", TenantId: "writer"}
+	event := ruleFixtureEvent{
+		ID:         "s1-threat-retired",
+		TenantID:   "writer",
+		SourceID:   "sentinelone",
+		Kind:       "sentinelone.threat",
+		OccurredAt: "2026-05-09T06:20:00Z",
+		SchemaRef:  "sentinelone/threat/v1",
+		Attributes: map[string]string{
+			"threat_id":         "threat-retired",
+			"threat_name":       "Malware Sample",
+			"incident_status":   "unresolved",
+			"mitigation_status": "not_mitigated",
+			"is_infected":       "true",
+			"agent_id":          "agent-retired",
+		},
+	}.proto(t)
+	rules := []Rule{
+		newRetiredSentinelOneRule(sentinelOneRetiredUnresolvedThreatRuleID, "Retired SentinelOne Unresolved Threat", "finding.sentinelone_unresolved_threat"),
+		newRetiredSentinelOneRule(sentinelOneRetiredMaliciousOrFilelessRuleID, "Retired SentinelOne Malicious Or Fileless Threat", "finding.sentinelone_malicious_or_fileless_threat"),
+		newRetiredSentinelOneRule(sentinelOneRetiredInfectedEndpointRuleID, "Retired SentinelOne Infected Endpoint", "finding.sentinelone_infected_endpoint"),
+	}
+	for _, rule := range rules {
+		records, err := rule.Evaluate(context.Background(), runtime, event)
+		if err != nil {
+			t.Fatalf("Evaluate(%q) error = %v", rule.Spec().GetId(), err)
+		}
+		if len(records) != 0 {
+			t.Fatalf("Evaluate(%q) returned %d findings, want none", rule.Spec().GetId(), len(records))
+		}
+	}
+}
+
 func assertRuleFixture(t *testing.T, rule Rule, path string) {
 	t.Helper()
 	payload, err := os.ReadFile(path)

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -67,6 +67,9 @@ func builtinRulePacks() []RulePack {
 				newSentinelOneAgentDetectOnlyModeRule(),
 				newSentinelOneProtectionControlTamperingRule(),
 				newSentinelOneRiskyExclusionRule(),
+				newRetiredSentinelOneRule(sentinelOneRetiredUnresolvedThreatRuleID, "Retired SentinelOne Unresolved Threat", "finding.sentinelone_unresolved_threat"),
+				newRetiredSentinelOneRule(sentinelOneRetiredMaliciousOrFilelessRuleID, "Retired SentinelOne Malicious Or Fileless Threat", "finding.sentinelone_malicious_or_fileless_threat"),
+				newRetiredSentinelOneRule(sentinelOneRetiredInfectedEndpointRuleID, "Retired SentinelOne Infected Endpoint", "finding.sentinelone_infected_endpoint"),
 			},
 		},
 		{

--- a/internal/findings/sentinelone_signal_rule.go
+++ b/internal/findings/sentinelone_signal_rule.go
@@ -12,6 +12,9 @@ import (
 )
 
 const (
+	sentinelOneRetiredUnresolvedThreatRuleID    = "sentinelone-unresolved-threat"
+	sentinelOneRetiredMaliciousOrFilelessRuleID = "sentinelone-malicious-or-fileless-threat"
+	sentinelOneRetiredInfectedEndpointRuleID    = "sentinelone-infected-endpoint"
 	sentinelOneEndpointActiveInfectionRuleID    = "sentinelone-endpoint-active-infection"
 	sentinelOneMitigationFailedRuleID           = "sentinelone-mitigation-failed"
 	sentinelOneAgentStaleRuleID                 = "sentinelone-agent-stale"
@@ -202,6 +205,29 @@ func newSentinelOneRiskyExclusionRule() Rule {
 		summary:            sentinelOneRiskyExclusionSummary,
 		policyID: func(attributes map[string]string) string {
 			return firstNonEmpty(attributes["exclusion_id"], attributes["value"])
+		},
+	})
+}
+
+func newRetiredSentinelOneRule(id string, name string, outputKind string) Rule {
+	definition := sentinelOneRuleDefinition(
+		id,
+		name,
+		"Retired SentinelOne threat-mirror rule retained temporarily so stale open findings are resolved after rule redesign.",
+		[]string{sentinelOneThreatEntityType},
+		outputKind,
+		"INFO",
+		[]string{"sentinelone", "retired", "cleanup"},
+		nil,
+		nil,
+		nil,
+	)
+	return newEventRule(eventRuleConfig{
+		definition: definition,
+		sourceID:   "sentinelone",
+		match:      func(*cerebrov1.EventEnvelope) bool { return false },
+		build: func(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+			return nil, nil
 		},
 	})
 }


### PR DESCRIPTION
## Summary
- keep retired no-op SentinelOne threat-mirror rule IDs registered so stale open findings from v2.1.9 and earlier are resolved
- ensure retired SentinelOne unresolved/malicious/infected rules emit no new findings

## Validation
- go test ./internal/findings -run 'TestRetiredSentinelOneRulesDoNotEmitFindings|TestSentinelOne|TestBuiltinRulePacksFlattenIntoCatalog' -count=1
- make verify