### PR TITLE
feat(findings): graph rule architecture + deprovisioned Okta GitHub rule

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -41,6 +41,7 @@ type graphCountsStore interface {
 type graphQueryStore interface {
 	Ping(context.Context) error
 	GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error)
+	ExecuteReadCypher(context.Context, ports.CypherQueryRequest) ([]ports.CypherRow, error)
 }
 
 type graphPathStore interface {

--- a/cmd/cerebro/graph_test_store_test.go
+++ b/cmd/cerebro/graph_test_store_test.go
@@ -12,11 +12,14 @@ import (
 )
 
 type graphTestStore struct {
-	mu          sync.Mutex
-	entities    map[string]*ports.ProjectedEntity
-	links       map[string]*ports.ProjectedLink
-	checkpoints map[string]graphstore.IngestCheckpoint
-	runs        map[string]graphstore.IngestRun
+	mu                sync.Mutex
+	entities          map[string]*ports.ProjectedEntity
+	links             map[string]*ports.ProjectedLink
+	checkpoints       map[string]graphstore.IngestCheckpoint
+	runs              map[string]graphstore.IngestRun
+	cypherRows        []ports.CypherRow
+	cypherErr         error
+	lastCypherRequest ports.CypherQueryRequest
 }
 
 func newGraphTestStore() *graphTestStore {
@@ -192,6 +195,24 @@ func (s *graphTestStore) GetIngestRun(_ context.Context, id string) (graphstore.
 	defer s.mu.Unlock()
 	run, ok := s.runs[id]
 	return run, ok, nil
+}
+
+func (s *graphTestStore) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cypherErr != nil {
+		return nil, s.cypherErr
+	}
+	s.lastCypherRequest = request
+	rows := make([]ports.CypherRow, 0, len(s.cypherRows))
+	for _, row := range s.cypherRows {
+		clone := ports.CypherRow{Values: make(map[string]any, len(row.Values))}
+		for k, v := range row.Values {
+			clone.Values[k] = v
+		}
+		rows = append(rows, clone)
+	}
+	return rows, nil
 }
 
 func (s *graphTestStore) ListIngestRuns(_ context.Context, filter graphstore.IngestRunFilter) ([]graphstore.IngestRun, error) {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -426,7 +426,6 @@ func runOrchestratorIteration(
 		}
 		graphResult, err := graphService.RunRuntime(runtimeCtx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"})
 		runtimeSpanAttrs = applyGraphIngestCounters(runtimeResult, graphResult, runtimeSpanAttrs)
-		graphIngestSucceeded := false
 		if err != nil {
 			runtimeResult.GraphIngest = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
@@ -434,9 +433,12 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_error", err.Error())
 		} else {
 			runtimeResult.GraphIngest = "completed"
-			graphIngestSucceeded = true
 		}
-		if graphIngestSucceeded {
+		// Run graph rules whenever the projection has updated the graph for this runtime, even
+		// if a trailing PutIngestRun(completed) write failed. The graph is already fresh and the
+		// rules are read-only, so deferring them until the next iteration would needlessly delay
+		// detection and stale-finding auto-resolution.
+		if graphResult != nil && graphResult.Ingest != nil {
 			graphRulesResult, err := findingService.EvaluateSourceRuntimeGraphRules(runtimeCtx, findings.EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
 			runtimeSpanAttrs = applyGraphRuleCounters(runtimeResult, graphRulesResult, runtimeSpanAttrs)
 			if err != nil {

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -52,19 +52,23 @@ type orchestratorIterationResult struct {
 }
 
 type orchestratorRuntimeResult struct {
-	RuntimeID          string `json:"runtime_id"`
-	SourceID           string `json:"source_id,omitempty"`
-	TenantID           string `json:"tenant_id,omitempty"`
-	Sync               string `json:"sync"`
-	PagesRead          uint32 `json:"pages_read,omitempty"`
-	EventsAppended     uint32 `json:"events_appended,omitempty"`
-	FindingRules       string `json:"finding_rules"`
-	EventsEvaluated    uint32 `json:"events_evaluated,omitempty"`
-	FindingEvaluations int    `json:"finding_evaluations,omitempty"`
-	GraphIngest        string `json:"graph_ingest"`
-	EntitiesProjected  uint32 `json:"entities_projected,omitempty"`
-	LinksProjected     uint32 `json:"links_projected,omitempty"`
-	Error              string `json:"error,omitempty"`
+	RuntimeID            string `json:"runtime_id"`
+	SourceID             string `json:"source_id,omitempty"`
+	TenantID             string `json:"tenant_id,omitempty"`
+	Sync                 string `json:"sync"`
+	PagesRead            uint32 `json:"pages_read,omitempty"`
+	EventsAppended       uint32 `json:"events_appended,omitempty"`
+	FindingRules         string `json:"finding_rules"`
+	EventsEvaluated      uint32 `json:"events_evaluated,omitempty"`
+	FindingEvaluations   int    `json:"finding_evaluations,omitempty"`
+	GraphIngest          string `json:"graph_ingest"`
+	EntitiesProjected    uint32 `json:"entities_projected,omitempty"`
+	LinksProjected       uint32 `json:"links_projected,omitempty"`
+	GraphRules           string `json:"graph_rules"`
+	GraphRuleEvaluations int    `json:"graph_rule_evaluations,omitempty"`
+	GraphRuleFindings    int    `json:"graph_rule_findings,omitempty"`
+	GraphRuleRowsRead    uint32 `json:"graph_rule_rows_read,omitempty"`
+	Error                string `json:"error,omitempty"`
 }
 
 func runOrchestrator(args []string) error {
@@ -422,6 +426,7 @@ func runOrchestratorIteration(
 		}
 		graphResult, err := graphService.RunRuntime(runtimeCtx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"})
 		runtimeSpanAttrs = applyGraphIngestCounters(runtimeResult, graphResult, runtimeSpanAttrs)
+		graphIngestSucceeded := false
 		if err != nil {
 			runtimeResult.GraphIngest = "failed"
 			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
@@ -429,6 +434,26 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_error", err.Error())
 		} else {
 			runtimeResult.GraphIngest = "completed"
+			graphIngestSucceeded = true
+		}
+		if graphIngestSucceeded {
+			graphRulesResult, err := findingService.EvaluateSourceRuntimeGraphRules(runtimeCtx, findings.EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
+			runtimeSpanAttrs = applyGraphRuleCounters(runtimeResult, graphRulesResult, runtimeSpanAttrs)
+			if err != nil {
+				if errors.Is(err, findings.ErrGraphRuntimeUnavailable) || errors.Is(err, findings.ErrRuntimeUnavailable) {
+					runtimeResult.GraphRules = "skipped"
+					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_skip_reason", err.Error())
+				} else {
+					runtimeResult.GraphRules = "failed"
+					runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_rules", err)
+					runErr = err
+					runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_error", err.Error())
+				}
+			} else {
+				runtimeResult.GraphRules = "completed"
+			}
+		} else {
+			runtimeResult.GraphRules = "skipped"
 		}
 		cancelRuntime()
 		if err := stopLeaseRenewal(); err != nil {
@@ -468,6 +493,28 @@ func applyGraphIngestCounters(runtimeResult *orchestratorRuntimeResult, graphRes
 	runtimeResult.LinksProjected = graphResult.Ingest.LinksProjected
 	attrs = withTelemetryField(attrs, "entities_projected", runtimeResult.EntitiesProjected)
 	attrs = withTelemetryField(attrs, "links_projected", runtimeResult.LinksProjected)
+	return attrs
+}
+
+func applyGraphRuleCounters(runtimeResult *orchestratorRuntimeResult, graphRulesResult *findings.EvaluateGraphRulesResult, attrs telemetry.Attributes) telemetry.Attributes {
+	if runtimeResult == nil || graphRulesResult == nil {
+		return attrs
+	}
+	runtimeResult.GraphRuleEvaluations = len(graphRulesResult.Evaluations)
+	var totalFindings int
+	var totalRows uint32
+	for _, evaluation := range graphRulesResult.Evaluations {
+		if evaluation == nil {
+			continue
+		}
+		totalFindings += len(evaluation.Findings)
+		totalRows += evaluation.RowsRead
+	}
+	runtimeResult.GraphRuleFindings = totalFindings
+	runtimeResult.GraphRuleRowsRead = totalRows
+	attrs = withTelemetryField(attrs, "graph_rule_evaluations", runtimeResult.GraphRuleEvaluations)
+	attrs = withTelemetryField(attrs, "graph_rule_findings", runtimeResult.GraphRuleFindings)
+	attrs = withTelemetryField(attrs, "graph_rule_rows_read", runtimeResult.GraphRuleRowsRead)
 	return attrs
 }
 

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -146,6 +146,147 @@ func TestRunOrchestratorIterationPreservesGraphCountersOnPartialFailure(t *testi
 	}
 }
 
+func TestRunOrchestratorIterationRunsGraphRulesAfterIngest(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	graphRule := &orchestratorGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "orchestrator-graph-rule", Name: "Orchestrator graph rule"},
+		sourceID: "github",
+		query: ports.CypherQueryRequest{
+			Query:  "MATCH (n) RETURN n LIMIT 1",
+			Params: map[string]any{"tenant_id": "writer"},
+		},
+		emit: []*ports.FindingRecord{
+			{
+				ID:           "finding-graph-orchestrator-1",
+				Fingerprint:  "fp-graph-orchestrator-1",
+				TenantID:     "writer",
+				RuntimeID:    "runtime-1",
+				RuleID:       "orchestrator-graph-rule",
+				Title:        "Graph rule fired in orchestrator",
+				Severity:     "CRITICAL",
+				Status:       "open",
+				Summary:      "graph rule emitted via orchestrator",
+				ResourceURNs: []string{"urn:cerebro:writer:identity:email:alice@writer.com"},
+			},
+		},
+	}
+	ruleRegistry, err := findings.NewRegistry(graphRule)
+	if err != nil {
+		t.Fatalf("NewRegistry() finding rule error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{
+			Id:       "runtime-1",
+			SourceId: "github",
+			TenantId: "writer",
+		},
+		acquired: true,
+	}
+	eventLog := &orchestratorEventLog{}
+	findingStore := &orchestratorFindingStore{}
+	graphStore := newGraphTestStore()
+	graphStore.cypherRows = []ports.CypherRow{
+		{Values: map[string]any{"label": "alice@writer.com"}},
+	}
+	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithGraphQueryStore(graphStore)
+	graphService := graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore)
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(registry, store, eventLog, nil),
+		findingService,
+		graphService,
+		orchestratorOptions{},
+		1,
+	)
+	if err != nil {
+		t.Fatalf("runOrchestratorIteration() error = %v, want nil", err)
+	}
+	if got := len(result.Runtimes); got != 1 {
+		t.Fatalf("runtime result count = %d, want 1", got)
+	}
+	runtimeResult := result.Runtimes[0]
+	if runtimeResult.GraphIngest != "completed" {
+		t.Fatalf("graph ingest status = %q, want completed", runtimeResult.GraphIngest)
+	}
+	if runtimeResult.GraphRules != "completed" {
+		t.Fatalf("graph rules status = %q, want completed", runtimeResult.GraphRules)
+	}
+	if runtimeResult.GraphRuleEvaluations != 1 {
+		t.Fatalf("graph rule evaluations = %d, want 1", runtimeResult.GraphRuleEvaluations)
+	}
+	if runtimeResult.GraphRuleFindings != 1 {
+		t.Fatalf("graph rule findings = %d, want 1", runtimeResult.GraphRuleFindings)
+	}
+	if runtimeResult.GraphRuleRowsRead != 1 {
+		t.Fatalf("graph rule rows read = %d, want 1", runtimeResult.GraphRuleRowsRead)
+	}
+	if runtimeResult.Error != "" {
+		t.Fatalf("runtime error = %q, want empty", runtimeResult.Error)
+	}
+}
+
+func TestRunOrchestratorIterationSkipsGraphRulesWhenIngestFails(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	graphRule := &orchestratorGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "orchestrator-graph-rule"},
+		sourceID: "github",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"},
+	}
+	ruleRegistry, err := findings.NewRegistry(graphRule)
+	if err != nil {
+		t.Fatalf("NewRegistry() finding rule error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{
+			Id:       "runtime-1",
+			SourceId: "github",
+			TenantId: "writer",
+		},
+		acquired: true,
+	}
+	eventLog := &orchestratorEventLog{}
+	findingStore := &orchestratorFindingStore{}
+	graphStore := &failingCompletedIngestGraphStore{graphTestStore: newGraphTestStore()}
+	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithGraphQueryStore(graphStore)
+	graphService := graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore)
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(registry, store, eventLog, nil),
+		findingService,
+		graphService,
+		orchestratorOptions{},
+		1,
+	)
+	if err == nil {
+		t.Fatal("runOrchestratorIteration() error = nil, want graph ingest failure")
+	}
+	if got := len(result.Runtimes); got != 1 {
+		t.Fatalf("runtime result count = %d, want 1", got)
+	}
+	runtimeResult := result.Runtimes[0]
+	if runtimeResult.GraphIngest != "failed" {
+		t.Fatalf("graph ingest status = %q, want failed", runtimeResult.GraphIngest)
+	}
+	if runtimeResult.GraphRules != "skipped" {
+		t.Fatalf("graph rules status = %q, want skipped (ingest failed)", runtimeResult.GraphRules)
+	}
+	if graphRule.calls != 0 {
+		t.Fatalf("graph rule should not have been called, got %d calls", graphRule.calls)
+	}
+}
+
 func TestRunOrchestratorIterationSkipsUnavailableFindingRules(t *testing.T) {
 	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
 	if err != nil {
@@ -479,6 +620,35 @@ func (orchestratorNoopRule) SupportsRuntime(*cerebrov1.SourceRuntime) bool {
 
 func (orchestratorNoopRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
 	return nil, nil
+}
+
+type orchestratorGraphRule struct {
+	spec     *cerebrov1.RuleSpec
+	sourceID string
+	query    ports.CypherQueryRequest
+	emit     []*ports.FindingRecord
+	calls    int
+}
+
+func (r *orchestratorGraphRule) Spec() *cerebrov1.RuleSpec {
+	return r.spec
+}
+
+func (r *orchestratorGraphRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	return runtime != nil && runtime.GetSourceId() == r.sourceID
+}
+
+func (r *orchestratorGraphRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (r *orchestratorGraphRule) QueryFor(*cerebrov1.SourceRuntime) ports.CypherQueryRequest {
+	return r.query
+}
+
+func (r *orchestratorGraphRule) EvaluateRows(_ context.Context, _ *cerebrov1.SourceRuntime, _ []ports.CypherRow) ([]*ports.FindingRecord, error) {
+	r.calls++
+	return r.emit, nil
 }
 
 type orchestratorEventLog struct {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -92,7 +92,7 @@ func TestRunOrchestratorIterationStopsAfterSyncFailure(t *testing.T) {
 	if got := len(result.Runtimes); got != 1 {
 		t.Fatalf("runtime result count = %d, want 1", got)
 	}
-	if result.Runtimes[0].FindingRules != "" || result.Runtimes[0].GraphIngest != "" {
+	if result.Runtimes[0].FindingRules != "" || result.Runtimes[0].GraphIngest != "" || result.Runtimes[0].GraphRules != "" {
 		t.Fatalf("downstream stages ran after sync failure: %#v", result.Runtimes[0])
 	}
 	if store.leaseID != "runtime-1" || store.releaseID != "runtime-1" {
@@ -231,7 +231,10 @@ func TestRunOrchestratorIterationRunsGraphRulesAfterIngest(t *testing.T) {
 	}
 }
 
-func TestRunOrchestratorIterationSkipsGraphRulesWhenIngestFails(t *testing.T) {
+func TestRunOrchestratorIterationRunsGraphRulesWhenOnlyRunRecordWriteFails(t *testing.T) {
+	// The projection updates the graph BEFORE the trailing PutIngestRun(completed) write, so a
+	// transient run-record write failure leaves the graph fresh and graph rules MUST still run.
+	// Otherwise new detections and stale auto-resolutions are delayed until the next iteration.
 	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
@@ -239,7 +242,7 @@ func TestRunOrchestratorIterationSkipsGraphRulesWhenIngestFails(t *testing.T) {
 	graphRule := &orchestratorGraphRule{
 		spec:     &cerebrov1.RuleSpec{Id: "orchestrator-graph-rule"},
 		sourceID: "github",
-		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"},
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n LIMIT 1"},
 	}
 	ruleRegistry, err := findings.NewRegistry(graphRule)
 	if err != nil {
@@ -270,7 +273,7 @@ func TestRunOrchestratorIterationSkipsGraphRulesWhenIngestFails(t *testing.T) {
 		1,
 	)
 	if err == nil {
-		t.Fatal("runOrchestratorIteration() error = nil, want graph ingest failure")
+		t.Fatal("runOrchestratorIteration() error = nil, want graph ingest run-record write failure")
 	}
 	if got := len(result.Runtimes); got != 1 {
 		t.Fatalf("runtime result count = %d, want 1", got)
@@ -279,11 +282,14 @@ func TestRunOrchestratorIterationSkipsGraphRulesWhenIngestFails(t *testing.T) {
 	if runtimeResult.GraphIngest != "failed" {
 		t.Fatalf("graph ingest status = %q, want failed", runtimeResult.GraphIngest)
 	}
-	if runtimeResult.GraphRules != "skipped" {
-		t.Fatalf("graph rules status = %q, want skipped (ingest failed)", runtimeResult.GraphRules)
+	if runtimeResult.EntitiesProjected == 0 || runtimeResult.LinksProjected == 0 {
+		t.Fatalf("expected projection counters to be populated despite run-record failure, got %#v", runtimeResult)
 	}
-	if graphRule.calls != 0 {
-		t.Fatalf("graph rule should not have been called, got %d calls", graphRule.calls)
+	if runtimeResult.GraphRules != "completed" {
+		t.Fatalf("graph rules status = %q, want completed (graph is fresh)", runtimeResult.GraphRules)
+	}
+	if graphRule.calls != 1 {
+		t.Fatalf("graph rule should have been called once after fresh projection, got %d calls", graphRule.calls)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1023,6 +1023,13 @@ func (s *stubGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string
 	return cloneNeighborhood(s.neighborhood), nil
 }
 
+func (s *stubGraphStore) ExecuteReadCypher(_ context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return nil, nil
+}
+
 func (s *stubGraphStore) GetIngestCheckpoint(_ context.Context, id string) (graphstore.IngestCheckpoint, bool, error) {
 	if s.err != nil {
 		return graphstore.IngestCheckpoint{}, false, s.err

--- a/internal/findings/graph_rule.go
+++ b/internal/findings/graph_rule.go
@@ -2,25 +2,10 @@ package findings
 
 import (
 	"context"
-	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
-
-// GraphRuleRuntimePrefix labels the synthetic runtime_id stamped on graph-rule findings.
-// Graph rules are tenant-scoped: their fingerprints collapse the same offender across every
-// real runtime that could trigger them, so the persisted record cannot legitimately be tied
-// to one source runtime. The synthetic id pins the row to a stable (tenant, rule) identity
-// instead, which makes per-runtime list paths consistent across iterations.
-const GraphRuleRuntimePrefix = "graph-rule:"
-
-// graphRuleRuntimeID returns the synthetic runtime id that graph rules stamp on persisted
-// findings. The id is deterministic per rule so multiple triggering runtimes converge on
-// the same row instead of flipping it between source-specific runtime ids.
-func graphRuleRuntimeID(ruleID string) string {
-	return GraphRuleRuntimePrefix + strings.TrimSpace(ruleID)
-}
 
 // GraphRule evaluates the projected graph by issuing one bounded read-only Cypher query per
 // runtime invocation. Unlike event rules, graph rules do not see the append log directly;

--- a/internal/findings/graph_rule.go
+++ b/internal/findings/graph_rule.go
@@ -2,10 +2,25 @@ package findings
 
 import (
 	"context"
+	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
+
+// GraphRuleRuntimePrefix labels the synthetic runtime_id stamped on graph-rule findings.
+// Graph rules are tenant-scoped: their fingerprints collapse the same offender across every
+// real runtime that could trigger them, so the persisted record cannot legitimately be tied
+// to one source runtime. The synthetic id pins the row to a stable (tenant, rule) identity
+// instead, which makes per-runtime list paths consistent across iterations.
+const GraphRuleRuntimePrefix = "graph-rule:"
+
+// graphRuleRuntimeID returns the synthetic runtime id that graph rules stamp on persisted
+// findings. The id is deterministic per rule so multiple triggering runtimes converge on
+// the same row instead of flipping it between source-specific runtime ids.
+func graphRuleRuntimeID(ruleID string) string {
+	return GraphRuleRuntimePrefix + strings.TrimSpace(ruleID)
+}
 
 // GraphRule evaluates the projected graph by issuing one bounded read-only Cypher query per
 // runtime invocation. Unlike event rules, graph rules do not see the append log directly;

--- a/internal/findings/graph_rule.go
+++ b/internal/findings/graph_rule.go
@@ -1,0 +1,30 @@
+package findings
+
+import (
+	"context"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+// GraphRule evaluates the projected graph by issuing one bounded read-only Cypher query per
+// runtime invocation. Unlike event rules, graph rules do not see the append log directly;
+// they reason over the post-projection world model and emit findings from row sets.
+//
+// Implementations must keep queries deterministic and bounded: the store enforces a hard row
+// cap, but rules should also include LIMIT clauses to keep latency predictable and to avoid
+// surprising Neo4j cost profiles on large tenants.
+type GraphRule interface {
+	Rule
+	QueryFor(*cerebrov1.SourceRuntime) ports.CypherQueryRequest
+	EvaluateRows(context.Context, *cerebrov1.SourceRuntime, []ports.CypherRow) ([]*ports.FindingRecord, error)
+}
+
+// asGraphRule narrows a registered Rule into a GraphRule when supported.
+func asGraphRule(rule Rule) (GraphRule, bool) {
+	if rule == nil {
+		return nil, false
+	}
+	graphRule, ok := rule.(GraphRule)
+	return graphRule, ok
+}

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -1,0 +1,227 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+// EvaluateGraphRulesRequest scopes one graph-rule evaluation pass over one runtime.
+type EvaluateGraphRulesRequest struct {
+	RuntimeID string
+	RuleIDs   []string
+}
+
+// GraphRuleEvaluationResult reports one graph rule's outputs inside a multi-rule pass.
+type GraphRuleEvaluationResult struct {
+	Rule     *cerebrov1.RuleSpec
+	Findings []*ports.FindingRecord
+	Run      *cerebrov1.FindingEvaluationRun
+	Evidence []*cerebrov1.FindingEvidence
+	RowsRead uint32
+}
+
+// EvaluateGraphRulesResult reports one multi-rule graph evaluation over one runtime.
+type EvaluateGraphRulesResult struct {
+	Runtime     *cerebrov1.SourceRuntime
+	Evaluations []*GraphRuleEvaluationResult
+}
+
+// ErrGraphRuntimeUnavailable indicates that the graph query boundary is not configured.
+var ErrGraphRuntimeUnavailable = fmt.Errorf("%w: graph query boundary is not configured", ErrRuntimeUnavailable)
+
+// EvaluateSourceRuntimeGraphRules runs every registered GraphRule that supports one runtime.
+//
+// Each rule is evaluated in its own bounded read transaction; failures of one rule do not
+// abort the others. The orchestrator should call this after the graph projection has been
+// updated for the runtime so the rule sees the freshest world model.
+func (s *Service) EvaluateSourceRuntimeGraphRules(ctx context.Context, request EvaluateGraphRulesRequest) (*EvaluateGraphRulesResult, error) {
+	if s == nil || s.runtimeStore == nil || s.store == nil || s.runStore == nil || s.evidenceStore == nil || s.rules == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	if s.graphQuery == nil {
+		return nil, ErrGraphRuntimeUnavailable
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
+	}
+	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	candidates, err := s.selectGraphRules(runtime, request.RuleIDs)
+	if err != nil {
+		return nil, err
+	}
+	startedAt := time.Now().UTC()
+	result := &EvaluateGraphRulesResult{
+		Runtime:     runtime,
+		Evaluations: make([]*GraphRuleEvaluationResult, 0, len(candidates)),
+	}
+	for _, rule := range candidates {
+		evaluation, err := s.evaluateGraphRule(ctx, runtime, rule, startedAt)
+		if evaluation != nil {
+			result.Evaluations = append(result.Evaluations, evaluation)
+		}
+		if err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule GraphRule, startedAt time.Time) (*GraphRuleEvaluationResult, error) {
+	spec := rule.Spec()
+	run := newFindingEvaluationRun(strings.TrimSpace(runtime.GetId()), spec.GetId(), 0, startedAt)
+	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
+		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
+	}
+	result := &GraphRuleEvaluationResult{
+		Rule: spec,
+		Run:  run,
+	}
+	queryRequest := rule.QueryFor(runtime)
+	if strings.TrimSpace(queryRequest.Query) == "" {
+		if err := s.finishCompletedRun(ctx, run, 0, nil); err != nil {
+			return result, err
+		}
+		return result, nil
+	}
+	rows, err := s.graphQuery.ExecuteReadCypher(ctx, queryRequest)
+	if err != nil {
+		evaluationErr := fmt.Errorf("execute graph rule %q cypher: %w", spec.GetId(), err)
+		return result, s.finishFailedRun(ctx, run, 0, nil, evaluationErr)
+	}
+	result.RowsRead = uint32(len(rows))
+	emitted, err := rule.EvaluateRows(ctx, runtime, rows)
+	if err != nil {
+		evaluationErr := fmt.Errorf("evaluate graph rule %q rows: %w", spec.GetId(), err)
+		return result, s.finishFailedRun(ctx, run, result.RowsRead, nil, evaluationErr)
+	}
+	evidenceIDs := map[string]struct{}{}
+	emittedFindingIDs := map[string]struct{}{}
+	for _, record := range emitted {
+		if record == nil {
+			continue
+		}
+		record, err = s.reconcileLegacyFindingIdentity(ctx, record)
+		if err != nil {
+			evaluationErr := fmt.Errorf("reconcile finding identity for graph rule %q: %w", spec.GetId(), err)
+			return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+		}
+		stored, err := s.store.UpsertFinding(ctx, record)
+		if err != nil {
+			evaluationErr := fmt.Errorf("persist finding for graph rule %q: %w", spec.GetId(), err)
+			return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+		}
+		result.Findings = append(result.Findings, stored)
+		emittedFindingIDs[strings.TrimSpace(stored.ID)] = struct{}{}
+		evidence, err := s.buildFindingEvidence(ctx, stored, run)
+		if err != nil {
+			evaluationErr := fmt.Errorf("build evidence for graph rule %q finding %q: %w", spec.GetId(), stored.ID, err)
+			return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+		}
+		if _, seen := evidenceIDs[evidence.GetId()]; !seen {
+			if err := s.evidenceStore.PutFindingEvidence(ctx, evidence); err != nil {
+				evaluationErr := fmt.Errorf("persist evidence for graph rule %q finding %q: %w", spec.GetId(), stored.ID, err)
+				return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+			}
+			evidenceIDs[evidence.GetId()] = struct{}{}
+			result.Evidence = append(result.Evidence, evidence)
+		}
+		if err := s.projectFindingAnchor(ctx, stored); err != nil {
+			evaluationErr := fmt.Errorf("project graph rule %q finding %q anchor: %w", spec.GetId(), stored.ID, err)
+			return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+		}
+	}
+	if err := s.resolveStaleGraphFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), strings.TrimSpace(runtime.GetId()), spec.GetId(), emittedFindingIDs); err != nil {
+		evaluationErr := fmt.Errorf("resolve stale graph findings for rule %q: %w", spec.GetId(), err)
+		return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+	}
+	if err := s.finishCompletedRun(ctx, run, result.RowsRead, findingIDs(result.Findings)); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (s *Service) selectGraphRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string) ([]GraphRule, error) {
+	if len(ruleIDs) == 0 {
+		var graphRules []GraphRule
+		for _, rule := range s.rules.ForRuntime(runtime) {
+			if graphRule, ok := asGraphRule(rule); ok {
+				graphRules = append(graphRules, graphRule)
+			}
+		}
+		return graphRules, nil
+	}
+	graphRules := make([]GraphRule, 0, len(ruleIDs))
+	seen := make(map[string]struct{}, len(ruleIDs))
+	for _, rawID := range ruleIDs {
+		trimmedID := strings.TrimSpace(rawID)
+		if trimmedID == "" {
+			continue
+		}
+		if _, ok := seen[trimmedID]; ok {
+			continue
+		}
+		rule, ok := s.rules.Get(trimmedID)
+		if !ok {
+			return nil, fmt.Errorf("%w: %s", ErrRuleNotFound, trimmedID)
+		}
+		graphRule, ok := asGraphRule(rule)
+		if !ok {
+			return nil, fmt.Errorf("%w: %s is not a graph rule", ErrRuleUnsupported, trimmedID)
+		}
+		if !rule.SupportsRuntime(runtime) {
+			return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedID)
+		}
+		seen[trimmedID] = struct{}{}
+		graphRules = append(graphRules, graphRule)
+	}
+	if len(graphRules) == 0 {
+		return nil, fmt.Errorf("%w for runtime %q", ErrRuleSelectionRequired, strings.TrimSpace(runtime.GetId()))
+	}
+	return graphRules, nil
+}
+
+// resolveStaleGraphFindings closes any open finding emitted previously by one graph rule whose
+// source rows are no longer present in the latest evaluation. Without this, dormant findings
+// would never auto-resolve when an offending principal is finally deprovisioned in both
+// systems or the relationship is removed.
+func (s *Service) resolveStaleGraphFindings(ctx context.Context, tenantID string, runtimeID string, ruleID string, emittedFindingIDs map[string]struct{}) error {
+	findings, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
+		TenantID:  strings.TrimSpace(tenantID),
+		RuntimeID: strings.TrimSpace(runtimeID),
+		RuleID:    strings.TrimSpace(ruleID),
+		Status:    findingStatusOpen,
+	})
+	if err != nil {
+		return fmt.Errorf("list stale graph candidates for rule %q: %w", strings.TrimSpace(ruleID), err)
+	}
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		if _, emitted := emittedFindingIDs[strings.TrimSpace(finding.ID)]; emitted {
+			continue
+		}
+		updated, err := s.store.UpdateFindingStatus(ctx, ports.FindingStatusUpdate{
+			FindingID: strings.TrimSpace(finding.ID),
+			Status:    findingStatusResolved,
+			Reason:    "graph_rule_no_longer_matches",
+			UpdatedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			return fmt.Errorf("resolve stale graph finding %q: %w", strings.TrimSpace(finding.ID), err)
+		}
+		if err := s.recordFindingStatusWorkflow(ctx, updated, "graph_rule_evaluation"); err != nil {
+			return fmt.Errorf("project stale graph finding %q resolution: %w", strings.TrimSpace(finding.ID), err)
+		}
+	}
+	return nil
+}

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -211,12 +211,18 @@ func (s *Service) selectGraphRules(runtime *cerebrov1.SourceRuntime, ruleIDs []s
 // source rows are no longer present in the latest evaluation. Without this, dormant findings
 // would never auto-resolve when an offending principal is finally deprovisioned in both
 // systems or the relationship is removed.
-func (s *Service) resolveStaleGraphFindings(ctx context.Context, tenantID string, runtimeID string, ruleID string, emittedFindingIDs map[string]struct{}) error {
+//
+// The scope is intentionally (tenant, rule) rather than (tenant, runtime, rule). Graph rules
+// query a tenant-wide view (the projected graph upserts by tenant+entity, not by runtime),
+// so an emit set computed from any okta runtime in the tenant covers every offender that the
+// rule would report. Scoping by runtime here would close a finding that runtime A emitted as
+// soon as runtime B syncs and finishes its own evaluation (because runtime B's emit set
+// doesn't include runtime A's finding under the runtime-keyed query).
+func (s *Service) resolveStaleGraphFindings(ctx context.Context, tenantID string, _ string, ruleID string, emittedFindingIDs map[string]struct{}) error {
 	findings, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
-		TenantID:  strings.TrimSpace(tenantID),
-		RuntimeID: strings.TrimSpace(runtimeID),
-		RuleID:    strings.TrimSpace(ruleID),
-		Status:    findingStatusOpen,
+		TenantID: strings.TrimSpace(tenantID),
+		RuleID:   strings.TrimSpace(ruleID),
+		Status:   findingStatusOpen,
 	})
 	if err != nil {
 		return fmt.Errorf("list stale graph candidates for rule %q: %w", strings.TrimSpace(ruleID), err)

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -18,11 +18,12 @@ type EvaluateGraphRulesRequest struct {
 
 // GraphRuleEvaluationResult reports one graph rule's outputs inside a multi-rule pass.
 type GraphRuleEvaluationResult struct {
-	Rule     *cerebrov1.RuleSpec
-	Findings []*ports.FindingRecord
-	Run      *cerebrov1.FindingEvaluationRun
-	Evidence []*cerebrov1.FindingEvidence
-	RowsRead uint32
+	Rule      *cerebrov1.RuleSpec
+	Findings  []*ports.FindingRecord
+	Run       *cerebrov1.FindingEvaluationRun
+	Evidence  []*cerebrov1.FindingEvidence
+	RowsRead  uint32
+	Truncated bool
 }
 
 // EvaluateGraphRulesResult reports one multi-rule graph evaluation over one runtime.
@@ -99,10 +100,11 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		return result, s.finishFailedRun(ctx, run, 0, nil, evaluationErr)
 	}
 	result.RowsRead = uint32(len(rows))
+	result.Truncated = cypherRowsTruncated(queryRequest, len(rows))
 	emitted, err := rule.EvaluateRows(ctx, runtime, rows)
 	if err != nil {
 		evaluationErr := fmt.Errorf("evaluate graph rule %q rows: %w", spec.GetId(), err)
-		return result, s.finishFailedRun(ctx, run, result.RowsRead, nil, evaluationErr)
+		return result, s.finishFailedRun(ctx, run, 0, nil, evaluationErr)
 	}
 	evidenceIDs := map[string]struct{}{}
 	emittedFindingIDs := map[string]struct{}{}
@@ -113,41 +115,56 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		record, err = s.reconcileLegacyFindingIdentity(ctx, record)
 		if err != nil {
 			evaluationErr := fmt.Errorf("reconcile finding identity for graph rule %q: %w", spec.GetId(), err)
-			return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+			return result, s.finishFailedRun(ctx, run, 0, findingIDs(result.Findings), evaluationErr)
 		}
 		stored, err := s.store.UpsertFinding(ctx, record)
 		if err != nil {
 			evaluationErr := fmt.Errorf("persist finding for graph rule %q: %w", spec.GetId(), err)
-			return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+			return result, s.finishFailedRun(ctx, run, 0, findingIDs(result.Findings), evaluationErr)
 		}
 		result.Findings = append(result.Findings, stored)
 		emittedFindingIDs[strings.TrimSpace(stored.ID)] = struct{}{}
 		evidence, err := s.buildFindingEvidence(ctx, stored, run)
 		if err != nil {
 			evaluationErr := fmt.Errorf("build evidence for graph rule %q finding %q: %w", spec.GetId(), stored.ID, err)
-			return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+			return result, s.finishFailedRun(ctx, run, 0, findingIDs(result.Findings), evaluationErr)
 		}
 		if _, seen := evidenceIDs[evidence.GetId()]; !seen {
 			if err := s.evidenceStore.PutFindingEvidence(ctx, evidence); err != nil {
 				evaluationErr := fmt.Errorf("persist evidence for graph rule %q finding %q: %w", spec.GetId(), stored.ID, err)
-				return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+				return result, s.finishFailedRun(ctx, run, 0, findingIDs(result.Findings), evaluationErr)
 			}
 			evidenceIDs[evidence.GetId()] = struct{}{}
 			result.Evidence = append(result.Evidence, evidence)
 		}
 		if err := s.projectFindingAnchor(ctx, stored); err != nil {
 			evaluationErr := fmt.Errorf("project graph rule %q finding %q anchor: %w", spec.GetId(), stored.ID, err)
-			return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+			return result, s.finishFailedRun(ctx, run, 0, findingIDs(result.Findings), evaluationErr)
 		}
 	}
-	if err := s.resolveStaleGraphFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), strings.TrimSpace(runtime.GetId()), spec.GetId(), emittedFindingIDs); err != nil {
-		evaluationErr := fmt.Errorf("resolve stale graph findings for rule %q: %w", spec.GetId(), err)
-		return result, s.finishFailedRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+	if !result.Truncated {
+		if err := s.resolveStaleGraphFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), strings.TrimSpace(runtime.GetId()), spec.GetId(), emittedFindingIDs); err != nil {
+			evaluationErr := fmt.Errorf("resolve stale graph findings for rule %q: %w", spec.GetId(), err)
+			return result, s.finishFailedRun(ctx, run, 0, findingIDs(result.Findings), evaluationErr)
+		}
 	}
-	if err := s.finishCompletedRun(ctx, run, result.RowsRead, findingIDs(result.Findings)); err != nil {
+	if err := s.finishCompletedRun(ctx, run, 0, findingIDs(result.Findings)); err != nil {
 		return result, err
 	}
 	return result, nil
+}
+
+// cypherRowsTruncated reports whether the cypher result hit the effective row cap. When the
+// rule asks for at most N rows and we got back exactly N, we cannot tell the graph apart from
+// a graph that had N+1 matching rows, so the rule may have missed offenders. Stale-finding
+// auto-resolution must not run in that case or we would close findings whose still-matching
+// row simply fell past the cutoff.
+func cypherRowsTruncated(request ports.CypherQueryRequest, rowsReturned int) bool {
+	cap := request.RowLimit
+	if cap <= 0 || cap > ports.MaxCypherQueryRows {
+		cap = ports.MaxCypherQueryRows
+	}
+	return rowsReturned >= cap
 }
 
 func (s *Service) selectGraphRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string) ([]GraphRule, error) {

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -79,7 +79,7 @@ func (s *Service) EvaluateSourceRuntimeGraphRules(ctx context.Context, request E
 
 func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule GraphRule, startedAt time.Time) (*GraphRuleEvaluationResult, error) {
 	spec := rule.Spec()
-	run := newFindingEvaluationRun(strings.TrimSpace(runtime.GetId()), spec.GetId(), 0, startedAt)
+	run := newGraphFindingEvaluationRun(strings.TrimSpace(runtime.GetId()), spec.GetId(), startedAt)
 	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
 		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
 	}

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -63,16 +63,17 @@ func (s *Service) EvaluateSourceRuntimeGraphRules(ctx context.Context, request E
 		Runtime:     runtime,
 		Evaluations: make([]*GraphRuleEvaluationResult, 0, len(candidates)),
 	}
+	var firstErr error
 	for _, rule := range candidates {
 		evaluation, err := s.evaluateGraphRule(ctx, runtime, rule, startedAt)
 		if evaluation != nil {
 			result.Evaluations = append(result.Evaluations, evaluation)
 		}
-		if err != nil {
-			return result, err
+		if err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
-	return result, nil
+	return result, firstErr
 }
 
 func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule GraphRule, startedAt time.Time) (*GraphRuleEvaluationResult, error) {

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -1,0 +1,207 @@
+package findings
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type stubGraphRule struct {
+	spec     *cerebrov1.RuleSpec
+	sourceID string
+	query    ports.CypherQueryRequest
+	rows     []ports.CypherRow
+	emit     []*ports.FindingRecord
+	emitErr  error
+}
+
+func (r *stubGraphRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return r.spec
+}
+
+func (r *stubGraphRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	return runtime.GetSourceId() == r.sourceID
+}
+
+func (r *stubGraphRule) Evaluate(_ context.Context, _ *cerebrov1.SourceRuntime, _ *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (r *stubGraphRule) QueryFor(_ *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
+	if r == nil {
+		return ports.CypherQueryRequest{}
+	}
+	return r.query
+}
+
+func (r *stubGraphRule) EvaluateRows(_ context.Context, _ *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {
+	if r == nil {
+		return nil, nil
+	}
+	if r.emitErr != nil {
+		return nil, r.emitErr
+	}
+	r.rows = append(r.rows, rows...)
+	return r.emit, nil
+}
+
+func TestAsGraphRuleNarrows(t *testing.T) {
+	if _, ok := asGraphRule(nil); ok {
+		t.Fatalf("asGraphRule(nil) should be false")
+	}
+	regular := &stubRule{spec: &cerebrov1.RuleSpec{Id: "regular"}}
+	if _, ok := asGraphRule(regular); ok {
+		t.Fatalf("asGraphRule(regular) should be false")
+	}
+	graph := &stubGraphRule{spec: &cerebrov1.RuleSpec{Id: "graph"}}
+	if _, ok := asGraphRule(graph); !ok {
+		t.Fatalf("asGraphRule(graph) should be true")
+	}
+}
+
+func newGraphRuleStubRuntimeStore(runtime *cerebrov1.SourceRuntime) *stubRuntimeStore {
+	return &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{runtime.GetId(): runtime}}
+}
+
+func TestEvaluateSourceRuntimeGraphRulesEmitsAndPersistsFindings(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphStore := &stubGraphStore{
+		cypherRows: []ports.CypherRow{
+			{Values: map[string]any{"label": "alice@writer.com"}},
+		},
+	}
+	rule := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "test-graph-rule"},
+		sourceID: "okta",
+		query: ports.CypherQueryRequest{
+			Query:  "MATCH (n) RETURN n LIMIT 1",
+			Params: map[string]any{"tenant_id": "writer"},
+		},
+		emit: []*ports.FindingRecord{
+			{
+				ID:           "finding-graph-1",
+				Fingerprint:  "fp-graph-1",
+				TenantID:     "writer",
+				RuntimeID:    "runtime-okta",
+				RuleID:       "test-graph-rule",
+				Title:        "Test graph finding",
+				Severity:     "CRITICAL",
+				Status:       findingStatusOpen,
+				Summary:      "graph rule fired",
+				ResourceURNs: []string{"urn:cerebro:writer:identity:email:alice@writer.com"},
+			},
+		},
+	}
+	registry, err := NewRegistry(rule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if got := len(result.Evaluations); got != 1 {
+		t.Fatalf("len(Evaluations) = %d, want 1", got)
+	}
+	evaluation := result.Evaluations[0]
+	if got := evaluation.Rule.GetId(); got != "test-graph-rule" {
+		t.Fatalf("Rule.Id = %q, want %q", got, "test-graph-rule")
+	}
+	if got := evaluation.RowsRead; got != 1 {
+		t.Fatalf("RowsRead = %d, want 1", got)
+	}
+	if got := len(evaluation.Findings); got != 1 {
+		t.Fatalf("len(Findings) = %d, want 1", got)
+	}
+	if got := evaluation.Findings[0].ID; got != "finding-graph-1" {
+		t.Fatalf("Findings[0].ID = %q, want %q", got, "finding-graph-1")
+	}
+	if got := evaluation.Run.GetStatus(); got != "completed" {
+		t.Fatalf("Run.Status = %q, want completed", got)
+	}
+	if store.findings == nil || store.findings["finding-graph-1"] == nil {
+		t.Fatalf("finding store should contain persisted finding")
+	}
+}
+
+func TestEvaluateSourceRuntimeGraphRulesRequiresGraphQuery(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	registry, err := NewRegistry(&stubGraphRule{spec: &cerebrov1.RuleSpec{Id: "graph-rule"}, sourceID: "okta"})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry)
+	if _, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"}); !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v, want ErrRuntimeUnavailable", err)
+	}
+}
+
+func TestEvaluateSourceRuntimeGraphRulesPropagatesCypherFailure(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphStore := &stubGraphStore{cypherErr: errors.New("boom")}
+	rule := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "graph-rule"},
+		sourceID: "okta",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"},
+	}
+	registry, err := NewRegistry(rule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
+	if err == nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() expected error")
+	}
+	if result == nil || len(result.Evaluations) != 1 {
+		t.Fatalf("partial result expected with one evaluation, got %#v", result)
+	}
+	evaluation := result.Evaluations[0]
+	if got := evaluation.Run.GetStatus(); got != "failed" {
+		t.Fatalf("Run.Status = %q, want failed", got)
+	}
+}
+
+func TestEvaluateSourceRuntimeGraphRulesSelectsByRuleID(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphStore := &stubGraphStore{}
+	emitting := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "selected"},
+		sourceID: "okta",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"},
+	}
+	other := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "other"},
+		sourceID: "okta",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"},
+	}
+	registry, err := NewRegistry(emitting, other)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta", RuleIDs: []string{"selected"}})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if got := len(result.Evaluations); got != 1 {
+		t.Fatalf("len(Evaluations) = %d, want 1", got)
+	}
+	if got := result.Evaluations[0].Rule.GetId(); got != "selected" {
+		t.Fatalf("Rule.Id = %q, want selected", got)
+	}
+}

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -121,6 +121,9 @@ func TestEvaluateSourceRuntimeGraphRulesEmitsAndPersistsFindings(t *testing.T) {
 	if got := evaluation.RowsRead; got != 1 {
 		t.Fatalf("RowsRead = %d, want 1", got)
 	}
+	if evaluation.Truncated {
+		t.Fatalf("Truncated = true, want false (rows below cap)")
+	}
 	if got := len(evaluation.Findings); got != 1 {
 		t.Fatalf("len(Findings) = %d, want 1", got)
 	}
@@ -130,8 +133,66 @@ func TestEvaluateSourceRuntimeGraphRulesEmitsAndPersistsFindings(t *testing.T) {
 	if got := evaluation.Run.GetStatus(); got != "completed" {
 		t.Fatalf("Run.Status = %q, want completed", got)
 	}
+	if got := evaluation.Run.GetEventsEvaluated(); got != 0 {
+		t.Fatalf("Run.EventsEvaluated = %d, want 0 (graph rules read graph rows, not events)", got)
+	}
 	if store.findings == nil || store.findings["finding-graph-1"] == nil {
 		t.Fatalf("finding store should contain persisted finding")
+	}
+}
+
+func TestEvaluateSourceRuntimeGraphRulesTruncatedSkipsStaleResolution(t *testing.T) {
+	// When the cypher result hits the row cap we cannot tell a graph that has cap rows from a
+	// graph that has cap+1: an offender may have fallen past the cutoff. Auto-resolving open
+	// findings on that incomplete view would close still-active findings.
+	const rowLimit = 2
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	staleFinding := &ports.FindingRecord{
+		ID:          "finding-stale",
+		Fingerprint: "fp-stale",
+		TenantID:    "writer",
+		RuntimeID:   "runtime-okta",
+		RuleID:      "truncating-rule",
+		Status:      findingStatusOpen,
+	}
+	store := &stubFindingStore{findings: map[string]*ports.FindingRecord{staleFinding.ID: cloneFinding(staleFinding)}}
+	graphStore := &stubGraphStore{
+		cypherRows: []ports.CypherRow{
+			{Values: map[string]any{"label": "row-1"}},
+			{Values: map[string]any{"label": "row-2"}},
+		},
+	}
+	rule := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "truncating-rule"},
+		sourceID: "okta",
+		query: ports.CypherQueryRequest{
+			Query:    "MATCH (n) RETURN n LIMIT $row_limit",
+			Params:   map[string]any{"row_limit": int64(rowLimit)},
+			RowLimit: rowLimit,
+		},
+	}
+	registry, err := NewRegistry(rule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if got := len(result.Evaluations); got != 1 {
+		t.Fatalf("len(Evaluations) = %d, want 1", got)
+	}
+	evaluation := result.Evaluations[0]
+	if !evaluation.Truncated {
+		t.Fatalf("Truncated = false, want true (rows hit cap)")
+	}
+	persisted, ok := store.findings[staleFinding.ID]
+	if !ok {
+		t.Fatalf("stale finding %q missing after evaluation", staleFinding.ID)
+	}
+	if got := persisted.Status; got != findingStatusOpen {
+		t.Fatalf("stale finding status = %q, want still %q (truncated cypher view must not auto-resolve)", got, findingStatusOpen)
 	}
 }
 

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -507,3 +507,45 @@ func TestEvaluateSourceRuntimeGraphRulesPinsFindingButRecordsEvidencePerRuntime(
 		t.Fatalf("evidence ids collided across runtimes (%q); evidence id must be runtime-scoped so each runtime's listing is non-empty", oktaEvaluation.Evidence[0].GetId())
 	}
 }
+
+// Graph-rule runs evaluate cypher rows over the projected graph, not events from
+// the replay log, so the per-event `EventLimit` field is meaningless for them.
+// `newFindingEvaluationRun` normalizes 0 to the default replay cap (100), which
+// would make Get/ListFindingEvaluationRun advertise a fictional "100-event"
+// pass for every graph evaluation. We therefore use a dedicated constructor
+// that leaves EventLimit at the proto default (0), which the API surfaces as
+// "n/a for graph rule".
+func TestEvaluateSourceRuntimeGraphRulesPersistsRunWithoutEventLimit(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	runtimeStore := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		runtime.GetId(): runtime,
+	}}
+	store := &stubFindingStore{}
+	graphStore := &stubGraphStore{
+		cypherRows: []ports.CypherRow{{Values: map[string]any{"label": "alice@writer.com"}}},
+	}
+	rule := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "graph-rule-no-event-limit"},
+		sourceID: "okta",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n LIMIT 1"},
+	}
+	registry, err := NewRegistry(rule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(runtimeStore, &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
+	}
+	if got := len(result.Evaluations); got != 1 {
+		t.Fatalf("len(Evaluations) = %d, want 1", got)
+	}
+	run := result.Evaluations[0].Run
+	if run == nil {
+		t.Fatal("Run is nil")
+	}
+	if got := run.GetEventLimit(); got != 0 {
+		t.Fatalf("Run.EventLimit = %d, want 0; graph runs have no event-limit input and must not advertise the replay default", got)
+	}
+}

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -175,6 +175,57 @@ func TestEvaluateSourceRuntimeGraphRulesPropagatesCypherFailure(t *testing.T) {
 	}
 }
 
+func TestEvaluateSourceRuntimeGraphRulesContinuesAfterRuleFailure(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphStore := &stubGraphStore{
+		cypherRows: []ports.CypherRow{
+			{Values: map[string]any{"label": "alice@writer.com"}},
+		},
+	}
+	failing := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "failing-rule"},
+		sourceID: "okta",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"},
+		emitErr:  errors.New("evaluate failure"),
+	}
+	healthy := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "healthy-rule"},
+		sourceID: "okta",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"},
+	}
+	registry, err := NewRegistry(failing, healthy)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
+	if err == nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() expected error from failing rule")
+	}
+	if result == nil {
+		t.Fatalf("result = nil, want partial result with both rule evaluations")
+	}
+	if got := len(result.Evaluations); got != 2 {
+		t.Fatalf("len(Evaluations) = %d, want 2 (both rules should run)", got)
+	}
+	var failingRun, healthyRun *cerebrov1.FindingEvaluationRun
+	for _, evaluation := range result.Evaluations {
+		switch evaluation.Rule.GetId() {
+		case "failing-rule":
+			failingRun = evaluation.Run
+		case "healthy-rule":
+			healthyRun = evaluation.Run
+		}
+	}
+	if failingRun == nil || failingRun.GetStatus() != "failed" {
+		t.Fatalf("failing rule run status = %v, want failed", failingRun)
+	}
+	if healthyRun == nil || healthyRun.GetStatus() != "completed" {
+		t.Fatalf("healthy rule run status = %v, want completed (failures of one rule must not abort others)", healthyRun)
+	}
+}
+
 func TestEvaluateSourceRuntimeGraphRulesSelectsByRuleID(t *testing.T) {
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
 	store := &stubFindingStore{}

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -317,3 +317,45 @@ func TestEvaluateSourceRuntimeGraphRulesSelectsByRuleID(t *testing.T) {
 		t.Fatalf("Rule.Id = %q, want selected", got)
 	}
 }
+
+// Graph rules satisfy Rule only to fit the registry contract; their Evaluate() is a no-op
+// because they need a cypher boundary the replay path doesn't supply. Letting the event
+// replay path pick them up creates empty completed evaluation runs and duplicates run
+// records per orchestrator iteration. The replay path must filter them out instead.
+func TestEvaluateSourceRuntimeRulesExcludesGraphRules(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphRule := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "okta-graph-only"},
+		sourceID: "okta",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"},
+	}
+	registry, err := NewRegistry(graphRule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry)
+	if _, err := service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "runtime-okta"}); !errors.Is(err, ErrRuleUnavailable) {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v, want ErrRuleUnavailable (graph rule should not be picked up by replay path)", err)
+	}
+}
+
+// When the caller asks for a graph rule by ID through the replay endpoint we must reject
+// rather than create a useless empty evaluation run.
+func TestEvaluateSourceRuntimeRulesRejectsExplicitGraphRuleID(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphRule := &stubGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "okta-graph-only"},
+		sourceID: "okta",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n"},
+	}
+	registry, err := NewRegistry(graphRule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry)
+	if _, err := service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "runtime-okta", RuleIDs: []string{"okta-graph-only"}}); !errors.Is(err, ErrRuleUnsupported) {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v, want ErrRuleUnsupported (explicit graph rule id must be rejected by replay path)", err)
+	}
+}

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -389,3 +389,121 @@ func TestEvaluateSourceRuntimeRulesRejectsExplicitGraphRuleID(t *testing.T) {
 		t.Fatalf("EvaluateSourceRuntimeRules() error = %v, want ErrRuleUnsupported (explicit graph rule id must be rejected by replay path)", err)
 	}
 }
+
+// multiSourceStubGraphRule matches every runtime whose source_id is in supportedSources, so a
+// single graph rule can be triggered by an okta evaluation and then by a github evaluation
+// (mirroring the deprovisioned-Okta-active-in-GitHub topology).
+type multiSourceStubGraphRule struct {
+	stubGraphRule
+	supportedSources []string
+}
+
+func (r *multiSourceStubGraphRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	for _, source := range r.supportedSources {
+		if runtime.GetSourceId() == source {
+			return true
+		}
+	}
+	return false
+}
+
+// Cross-runtime graph-rule reevaluations must keep the finding pinned to the first triggering
+// runtime (so runtime_id stays addressable through the real source-runtime APIs) AND record
+// each subsequent evaluation's evidence under the runtime that performed it (so
+// `/source-runtimes/{runtime}/finding-evidence?run_id=<runtime-run>` actually returns rows
+// for the runtime that produced the run, instead of leaving the run listed in evaluation
+// listings without any matching evidence rows).
+func TestEvaluateSourceRuntimeGraphRulesPinsFindingButRecordsEvidencePerRuntime(t *testing.T) {
+	oktaRuntime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	githubRuntime := &cerebrov1.SourceRuntime{Id: "runtime-github", SourceId: "github", TenantId: "writer"}
+	runtimeStore := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		oktaRuntime.GetId():   oktaRuntime,
+		githubRuntime.GetId(): githubRuntime,
+	}}
+	store := &stubFindingStore{}
+	graphStore := &stubGraphStore{
+		cypherRows: []ports.CypherRow{{Values: map[string]any{"label": "alice@writer.com"}}},
+	}
+	// The same fingerprint is emitted from both okta and github triggers; that's the contract
+	// graph rules establish (tenant-scoped offender). UpsertFinding's ON CONFLICT clause
+	// pins runtime_id on first insert; evidence ownership is taken from the run.
+	emitFinding := func(triggeringRuntimeID string) []*ports.FindingRecord {
+		return []*ports.FindingRecord{{
+			ID:           "finding-cross-runtime",
+			Fingerprint:  "fp-cross-runtime",
+			TenantID:     "writer",
+			RuntimeID:    triggeringRuntimeID,
+			RuleID:       "cross-runtime-graph-rule",
+			Title:        "Cross runtime graph finding",
+			Severity:     "CRITICAL",
+			Status:       findingStatusOpen,
+			Summary:      "graph rule fired",
+			ResourceURNs: []string{"urn:cerebro:writer:identity:email:alice@writer.com"},
+		}}
+	}
+	rule := &multiSourceStubGraphRule{
+		stubGraphRule: stubGraphRule{
+			spec:  &cerebrov1.RuleSpec{Id: "cross-runtime-graph-rule"},
+			query: ports.CypherQueryRequest{Query: "MATCH (n) RETURN n LIMIT 1"},
+			emit:  emitFinding(oktaRuntime.GetId()),
+		},
+		supportedSources: []string{"okta", "github"},
+	}
+	registry, err := NewRegistry(rule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(runtimeStore, &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+
+	oktaResult, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: oktaRuntime.GetId()})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules(okta) error = %v", err)
+	}
+	if got := len(oktaResult.Evaluations); got != 1 {
+		t.Fatalf("len(okta.Evaluations) = %d, want 1", got)
+	}
+	oktaEvaluation := oktaResult.Evaluations[0]
+	if got := len(oktaEvaluation.Evidence); got != 1 {
+		t.Fatalf("len(okta.Evidence) = %d, want 1", got)
+	}
+	if got := oktaEvaluation.Evidence[0].GetRuntimeId(); got != oktaRuntime.GetId() {
+		t.Fatalf("okta evidence RuntimeId = %q, want %q", got, oktaRuntime.GetId())
+	}
+	if got := oktaEvaluation.Evidence[0].GetRunId(); got != oktaEvaluation.Run.GetId() {
+		t.Fatalf("okta evidence RunId = %q, want %q (the okta run)", got, oktaEvaluation.Run.GetId())
+	}
+
+	rule.emit = emitFinding(githubRuntime.GetId())
+	githubResult, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: githubRuntime.GetId()})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules(github) error = %v", err)
+	}
+	if got := len(githubResult.Evaluations); got != 1 {
+		t.Fatalf("len(github.Evaluations) = %d, want 1", got)
+	}
+	githubEvaluation := githubResult.Evaluations[0]
+	if got := len(githubEvaluation.Findings); got != 1 {
+		t.Fatalf("len(github.Findings) = %d, want 1", got)
+	}
+	if got := githubEvaluation.Findings[0].RuntimeID; got != oktaRuntime.GetId() {
+		t.Fatalf("github reevaluation finding RuntimeID = %q, want %q (pinned to first observer)", got, oktaRuntime.GetId())
+	}
+	if got := len(githubEvaluation.Evidence); got != 1 {
+		t.Fatalf("len(github.Evidence) = %d, want 1", got)
+	}
+	if got := githubEvaluation.Evidence[0].GetRuntimeId(); got != githubRuntime.GetId() {
+		t.Fatalf("github evidence RuntimeId = %q, want %q (evidence is owned by the evaluating runtime so /source-runtimes/{github}/finding-evidence stays consistent with the run)", got, githubRuntime.GetId())
+	}
+	if got := githubEvaluation.Evidence[0].GetRunId(); got != githubEvaluation.Run.GetId() {
+		t.Fatalf("github evidence RunId = %q, want %q", got, githubEvaluation.Run.GetId())
+	}
+	if got := githubEvaluation.Run.GetRuntimeId(); got != githubRuntime.GetId() {
+		t.Fatalf("github Run RuntimeId = %q, want %q (run is recorded under the evaluating runtime)", got, githubRuntime.GetId())
+	}
+	if oktaEvaluation.Evidence[0].GetId() == githubEvaluation.Evidence[0].GetId() {
+		t.Fatalf("evidence ids collided across runtimes (%q); evidence id must be runtime-scoped so each runtime's listing is non-empty", oktaEvaluation.Evidence[0].GetId())
+	}
+}

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -340,6 +340,36 @@ func TestEvaluateSourceRuntimeRulesExcludesGraphRules(t *testing.T) {
 	}
 }
 
+// ListRules powers `GET /finding-rules` and the rule selection UI. Because all public
+// evaluation endpoints reject graph rules, advertising them in the catalog would surface
+// rule ids that no client can run. Graph rules execute exclusively from the orchestrator
+// hook and must be hidden from the public list.
+func TestListRulesHidesGraphRulesFromCatalog(t *testing.T) {
+	store := &stubFindingStore{}
+	eventRule := &stubRule{spec: &cerebrov1.RuleSpec{Id: "event-only-rule"}}
+	graphRule := &stubGraphRule{spec: &cerebrov1.RuleSpec{Id: "graph-only-rule"}, sourceID: "okta"}
+	registry, err := NewRegistry(eventRule, graphRule)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	service := NewWithRegistry(&stubRuntimeStore{}, &stubReplayer{}, store, store, store, store, registry)
+	listed := service.ListRules().GetRules()
+	for _, spec := range listed {
+		if spec.GetId() == "graph-only-rule" {
+			t.Fatalf("ListRules() advertised graph-only-rule via public catalog; clients have no way to execute it")
+		}
+	}
+	var foundEvent bool
+	for _, spec := range listed {
+		if spec.GetId() == "event-only-rule" {
+			foundEvent = true
+		}
+	}
+	if !foundEvent {
+		t.Fatalf("ListRules() dropped event-only-rule along with graph rules; got %v", listed)
+	}
+}
+
 // When the caller asks for a graph rule by ID through the replay endpoint we must reject
 // rather than create a useless empty evaluation run.
 func TestEvaluateSourceRuntimeRulesRejectsExplicitGraphRuleID(t *testing.T) {

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule.go
@@ -75,11 +75,21 @@ func (r *deprovisionedOktaActiveGitHubRule) Spec() *cerebrov1.RuleSpec {
 	return proto.Clone(r.definition.RuleSpec()).(*cerebrov1.RuleSpec)
 }
 
+// SupportsRuntime accepts either an okta or a github source runtime: the rule's cypher join
+// reads okta.user lifecycle status AND github.user `acted_on` edges, so a fresh ingest from
+// either side could surface a new offender or invalidate an existing finding. Restricting the
+// rule to one source would leave detections delayed until the next pass on the other.
 func (r *deprovisionedOktaActiveGitHubRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
 	if r == nil || runtime == nil {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(runtime.GetSourceId()), r.definition.SourceID)
+	sourceID := strings.ToLower(strings.TrimSpace(runtime.GetSourceId()))
+	switch sourceID {
+	case "okta", "github":
+		return true
+	default:
+		return false
+	}
 }
 
 // Evaluate is the event-driven hook required by Rule. Graph rules emit no findings during the

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule.go
@@ -89,18 +89,29 @@ func (r *deprovisionedOktaActiveGitHubRule) Spec() *cerebrov1.RuleSpec {
 	return proto.Clone(r.definition.RuleSpec()).(*cerebrov1.RuleSpec)
 }
 
-// SupportsRuntime accepts either an okta or a github source runtime: the rule's cypher join
-// reads okta.user lifecycle status AND github.user `acted_on` edges, so a fresh ingest from
-// either side could surface a new offender or invalidate an existing finding. Restricting the
-// rule to one source would leave detections delayed until the next pass on the other.
+// SupportsRuntime narrows graph-rule triggers to the runtime families whose ingest can
+// actually change the inputs of this rule's cypher: okta family=user (lifecycle status
+// on okta.user nodes) and github family=audit (acted_on edges from github.user).
+//
+// Source runtimes within a single source_id are family-scoped (e.g. github.audit,
+// github.pull_request, github.dependabot_alert; okta.user, okta.audit, okta.group_membership)
+// and only the families above touch the data this rule reads. Accepting every runtime
+// in the family would let, say, a github.pull_request ingest be the first trigger that
+// observes an existing offender — buildFinding would then stamp that pull-request runtime
+// onto the persisted record and Postgres' UpsertFinding ON CONFLICT would pin it there,
+// hiding the finding from `/source-runtimes/{github-audit}/findings` even though the audit
+// runtime is what produced the data and is what an investigator would inspect.
 func (r *deprovisionedOktaActiveGitHubRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
 	if r == nil || runtime == nil {
 		return false
 	}
 	sourceID := strings.ToLower(strings.TrimSpace(runtime.GetSourceId()))
+	family := strings.ToLower(strings.TrimSpace(runtime.GetConfig()["family"]))
 	switch sourceID {
-	case "okta", "github":
-		return true
+	case "okta":
+		return family == "user"
+	case "github":
+		return family == "audit"
 	default:
 		return false
 	}
@@ -128,6 +139,11 @@ func (r *deprovisionedOktaActiveGitHubRule) QueryFor(runtime *cerebrov1.SourceRu
 		return ports.CypherQueryRequest{}
 	}
 	return ports.CypherQueryRequest{
+		// The cypher returns one row per (okta_user, identity, github_user, target);
+		// EvaluateRows applies the recency filter and grouping. We deliberately do
+		// not push the recency check into Cypher so we can keep the filter in one
+		// place and have unit-test coverage on it (the represents_identity attrs
+		// JSON is opaque on the Neo4j side).
 		Query: `MATCH (o:Entity {entity_type: 'okta.user', tenant_id: $tenant_id})
        -[oi:RELATION {relation: 'represents_identity'}]->(id:Entity)
        <-[gi:RELATION {relation: 'represents_identity'}]-(g:Entity {entity_type: 'github.user', tenant_id: $tenant_id})
@@ -145,7 +161,9 @@ RETURN o.urn AS okta_user_urn,
        target.urn AS target_urn,
        target.entity_type AS target_entity_type,
        target.label AS target_label,
-       coalesce(acted.attributes_json, '') AS acted_attributes_json
+       coalesce(acted.attributes_json, '') AS acted_attributes_json,
+       coalesce(oi.attributes_json, '') AS okta_identity_attributes_json,
+       coalesce(gi.attributes_json, '') AS github_identity_attributes_json
 LIMIT $row_limit`,
 		Params: map[string]any{
 			"tenant_id": tenantID,
@@ -182,7 +200,24 @@ func (r *deprovisionedOktaActiveGitHubRule) EvaluateRows(_ context.Context, runt
 		// stale history. Either way, this row is not evidence of current GitHub
 		// access for the deprovisioned identity, so drop it before it can pin
 		// the group open.
-		if !actedOnEdgeIsRecent(cypherRowString(row, "acted_attributes_json"), now, identityDeprovisionedOktaRecencyWindow) {
+		if !edgeIsRecent(cypherRowString(row, "acted_attributes_json"), now, identityDeprovisionedOktaRecencyWindow) {
+			continue
+		}
+		// represents_identity edges are upsert-only — graph ingest never retracts
+		// them when an Okta email/login or GitHub external_identity_nameid is
+		// renamed. After a rename, both the okta.user and the github.user remain
+		// linked to the stale identity node, and a join through that node would
+		// keep emitting (or reopening) findings even though the current Okta and
+		// GitHub identifiers no longer match. Each represents_identity edge
+		// therefore carries an `at` attribute that the latest source event
+		// re-asserted (chronological max under the neo4j store's mergeAttribute
+		// rule); rows whose okta-side OR github-side identifier link has not
+		// been re-observed inside the recency window are treated as stale and
+		// dropped, mirroring the acted_on check.
+		if !edgeIsRecent(cypherRowString(row, "okta_identity_attributes_json"), now, identityDeprovisionedOktaRecencyWindow) {
+			continue
+		}
+		if !edgeIsRecent(cypherRowString(row, "github_identity_attributes_json"), now, identityDeprovisionedOktaRecencyWindow) {
 			continue
 		}
 		// Group on the Okta/GitHub account pair only. The cypher join can walk
@@ -233,13 +268,19 @@ func (r *deprovisionedOktaActiveGitHubRule) EvaluateRows(_ context.Context, runt
 	return findings, nil
 }
 
-// actedOnEdgeIsRecent decides whether a github acted_on edge represents activity
-// inside the recency window. The edge attributes are JSON-encoded by the projector
-// (see githubAuditProjections); when the latest action was at least `window` ago
-// the user has not exercised access recently and the edge should not, on its own,
-// keep a deprovisioned-Okta finding open. Edges projected before the at-stamp
-// change have no `at` at all and are treated identically to stale history.
-func actedOnEdgeIsRecent(attributesJSON string, now time.Time, window time.Duration) bool {
+// edgeIsRecent decides whether a graph edge has been re-observed inside the
+// recency window. Edge attributes are JSON-encoded by the projector and carry
+// an `at` attribute (RFC3339 UTC) populated from each source event's OccurredAt;
+// the neo4j store's mergeAttributeValue keeps the chronological max so the field
+// reflects the latest re-assertion of the edge regardless of ingestion order.
+//
+// Edges projected before the at-stamping change have no `at` at all and are
+// treated identically to stale: we cannot prove recency, so we refuse to fire
+// on them. The same helper is used for both `acted_on` (current GitHub access)
+// and `represents_identity` (current identifier link); the rule must require
+// all three relations along the path to be recent so a pre-rename identifier
+// graph cannot keep emitting findings indefinitely.
+func edgeIsRecent(attributesJSON string, now time.Time, window time.Duration) bool {
 	trimmed := strings.TrimSpace(attributesJSON)
 	if trimmed == "" {
 		return false

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule.go
@@ -214,10 +214,24 @@ func (r *deprovisionedOktaActiveGitHubRule) EvaluateRows(_ context.Context, runt
 		// rule); rows whose okta-side OR github-side identifier link has not
 		// been re-observed inside the recency window are treated as stale and
 		// dropped, mirroring the acted_on check.
-		if !edgeIsRecent(cypherRowString(row, "okta_identity_attributes_json"), now, identityDeprovisionedOktaRecencyWindow) {
+		oktaIdentityJSON := cypherRowString(row, "okta_identity_attributes_json")
+		githubIdentityJSON := cypherRowString(row, "github_identity_attributes_json")
+		if !edgeIsRecent(oktaIdentityJSON, now, identityDeprovisionedOktaRecencyWindow) {
 			continue
 		}
-		if !edgeIsRecent(cypherRowString(row, "github_identity_attributes_json"), now, identityDeprovisionedOktaRecencyWindow) {
+		if !edgeIsRecent(githubIdentityJSON, now, identityDeprovisionedOktaRecencyWindow) {
+			continue
+		}
+		// Reject login-only identity matches on either side. The projector
+		// emits a represents_identity edge for every identifier value, including
+		// raw GitHub usernames where identifierEvidenceAttributes assigns
+		// match_type=login at confidence=0.60. Two unrelated people who happen
+		// to share a username (e.g. okta login "alice" vs github login "alice")
+		// would otherwise satisfy the join through the shared identity:login
+		// node and produce a CRITICAL false positive. Require the match on both
+		// sides to be email-based (exact_email or extracted_email, both 0.85+),
+		// which is what guarantees the accounts belong to the same person.
+		if !identifierMatchIsEmail(oktaIdentityJSON) || !identifierMatchIsEmail(githubIdentityJSON) {
 			continue
 		}
 		// Group on the Okta/GitHub account pair only. The cypher join can walk
@@ -266,6 +280,41 @@ func (r *deprovisionedOktaActiveGitHubRule) EvaluateRows(_ context.Context, runt
 		findings = append(findings, r.buildFinding(runtime, tenantID, group, now))
 	}
 	return findings, nil
+}
+
+// identifierMatchIsEmail decides whether a represents_identity edge proves
+// account ownership rather than just a coincidental identifier overlap.
+//
+// The projector (see identifierEvidenceAttributes) emits a represents_identity
+// edge for every identifier value it observes, including raw GitHub usernames
+// where match_type=login is stamped at confidence=0.60. That signal is enough
+// to surface the link in the graph, but it is not enough to fuse two accounts:
+// two unrelated people can both pick the username "alice", and a login-walked
+// join `(okta.user)-[oi]->(identity:login:alice)<-[gi]-(github.user)` would
+// then satisfy this rule's cypher and emit a CRITICAL finding against an
+// unrelated GitHub account.
+//
+// Email-based matches (exact_email at 0.95, extracted_email at 0.85) are the
+// only identifier signals we accept here: they require the projector to have
+// observed a real email address on each side, which in practice does not
+// collide across people the way usernames do. Empty/malformed JSON, missing
+// match_type, and any non-email value (including login) all return false so
+// the rule refuses to fire on weak identity evidence.
+func identifierMatchIsEmail(attributesJSON string) bool {
+	trimmed := strings.TrimSpace(attributesJSON)
+	if trimmed == "" {
+		return false
+	}
+	var attrs map[string]string
+	if err := json.Unmarshal([]byte(trimmed), &attrs); err != nil {
+		return false
+	}
+	switch strings.TrimSpace(attrs["match_type"]) {
+	case "exact_email", "extracted_email":
+		return true
+	default:
+		return false
+	}
 }
 
 // edgeIsRecent decides whether a graph edge has been re-observed inside the

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule.go
@@ -223,6 +223,10 @@ func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.Sour
 	// (tenant_id, user_id), so two okta runtimes touching the same user share one node and
 	// would produce the same fingerprint anyway; tracking runtime_id here would split a
 	// single tenant-scoped finding into duplicates the moment another okta runtime synced.
+	// The same fingerprint can also be emitted by either an okta or a github ingest, so the
+	// store must not rebind runtime_id on conflict; that pinning is enforced by Postgres'
+	// UpsertFinding (`runtime_id = findings.runtime_id`) so the row stays addressable through
+	// real source-runtime APIs even when both sides trigger the rule.
 	fingerprint := hashFindingFingerprint(
 		r.definition.ID,
 		tenantID,
@@ -230,13 +234,6 @@ func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.Sour
 		group.identityURN,
 		group.githubUserURN,
 	)
-	// The persisted runtime_id is a stable synthetic id per (tenant, rule), not the runtime
-	// that happened to trigger this evaluation. The rule's identity is tenant-scoped, so
-	// stamping the triggering runtime would cause UpsertFinding to flip the row between okta
-	// and github runtimes every iteration and make per-runtime list paths swap the finding
-	// in and out under each side. The triggering runtime is preserved in attributes for
-	// telemetry only.
-	persistedRuntimeID := graphRuleRuntimeID(r.definition.ID)
 	resourceURNs := []string{group.identityURN, group.oktaUserURN, group.githubUserURN}
 	targetURNs := make([]string, 0, len(group.targets))
 	targetLabels := make([]string, 0, len(group.targets))
@@ -284,7 +281,7 @@ func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.Sour
 		ID:              fingerprint,
 		Fingerprint:     fingerprint,
 		TenantID:        tenantID,
-		RuntimeID:       persistedRuntimeID,
+		RuntimeID:       triggeringRuntimeID,
 		RuleID:          r.definition.ID,
 		Title:           r.definition.Name,
 		Severity:        r.definition.Severity,

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule.go
@@ -65,8 +65,14 @@ func newDeprovisionedOktaActiveGitHubRule() Rule {
 				"Service or break-glass account intentionally retained in GitHub during an off-boarding grace window with documented exception.",
 				"Delayed Okta lifecycle propagation immediately after a status change; window typically closes within one sync cycle.",
 			},
-			Runbook:           "Confirm the Okta identity is truly off-boarded, revoke or suspend the linked GitHub account, rotate any tokens it created, and document the gap that allowed continued access.",
-			FingerprintFields: []string{"okta_user_urn", "identity_urn", "github_user_urn"},
+			Runbook: "Confirm the Okta identity is truly off-boarded, revoke or suspend the linked GitHub account, rotate any tokens it created, and document the gap that allowed continued access.",
+			// The fingerprint is (okta_user, github_user) only. The graph projector attaches the same
+			// account pair to multiple `identity` nodes when okta.user has distinct email and login,
+			// or when github.audit links both `actor` and `external_identity_nameid`; including
+			// identity_urn in the fingerprint would split one offboarding gap into two CRITICAL
+			// findings that differ only by which identity node the join walked through. The full
+			// list of matched identity URNs is preserved in the finding attributes for telemetry.
+			FingerprintFields: []string{"okta_user_urn", "github_user_urn"},
 			ControlRefs: []ports.FindingControlRef{
 				{FrameworkName: "SOC 2", ControlID: "CC6.2"},
 				{FrameworkName: "ISO 27001:2022", ControlID: "A.5.18"},
@@ -179,21 +185,32 @@ func (r *deprovisionedOktaActiveGitHubRule) EvaluateRows(_ context.Context, runt
 		if !actedOnEdgeIsRecent(cypherRowString(row, "acted_attributes_json"), now, identityDeprovisionedOktaRecencyWindow) {
 			continue
 		}
-		key := oktaUserURN + "\x00" + identityURN + "\x00" + githubUserURN
+		// Group on the Okta/GitHub account pair only. The cypher join can walk
+		// through multiple `identity` nodes for the same pair (okta.user links
+		// both email and login when they differ; github.audit links both `actor`
+		// and `external_identity_nameid`), so keying on identityURN here would
+		// split one offboarding gap into duplicate findings. The full set of
+		// identity URNs matched for this pair is preserved on the group so we
+		// can surface it as telemetry on the finding.
+		key := oktaUserURN + "\x00" + githubUserURN
 		group, ok := groups[key]
 		if !ok {
 			group = &deprovisionedOktaGroup{
 				oktaUserURN:        oktaUserURN,
 				oktaUserLabel:      cypherRowString(row, "okta_user_label"),
 				oktaAttributesJSON: cypherRowString(row, "okta_attributes_json"),
-				identityURN:        identityURN,
-				identityLabel:      cypherRowString(row, "identity_label"),
 				githubUserURN:      githubUserURN,
 				githubUserLabel:    cypherRowString(row, "github_user_label"),
+				identityURNs:       map[string]struct{}{},
+				identityLabels:     map[string]struct{}{},
 				targets:            map[string]deprovisionedOktaTarget{},
 			}
 			groups[key] = group
 			keys = append(keys, key)
+		}
+		group.identityURNs[identityURN] = struct{}{}
+		if label := cypherRowString(row, "identity_label"); label != "" {
+			group.identityLabels[label] = struct{}{}
 		}
 		if _, exists := group.targets[targetURN]; exists {
 			continue
@@ -246,10 +263,10 @@ type deprovisionedOktaGroup struct {
 	oktaUserURN        string
 	oktaUserLabel      string
 	oktaAttributesJSON string
-	identityURN        string
-	identityLabel      string
 	githubUserURN      string
 	githubUserLabel    string
+	identityURNs       map[string]struct{}
+	identityLabels     map[string]struct{}
 	targets            map[string]deprovisionedOktaTarget
 }
 
@@ -261,22 +278,31 @@ type deprovisionedOktaTarget struct {
 
 func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, group *deprovisionedOktaGroup, now time.Time) *ports.FindingRecord {
 	triggeringRuntimeID := strings.TrimSpace(runtime.GetId())
-	// The fingerprint deliberately omits runtime_id. The graph projects okta.user nodes by
-	// (tenant_id, user_id), so two okta runtimes touching the same user share one node and
-	// would produce the same fingerprint anyway; tracking runtime_id here would split a
-	// single tenant-scoped finding into duplicates the moment another okta runtime synced.
-	// The same fingerprint can also be emitted by either an okta or a github ingest, so the
-	// store must not rebind runtime_id on conflict; that pinning is enforced by Postgres'
-	// UpsertFinding (`runtime_id = findings.runtime_id`) so the row stays addressable through
-	// real source-runtime APIs even when both sides trigger the rule.
+	// The fingerprint is keyed on (rule, tenant, okta_user, github_user) only.
+	//
+	//   * runtime_id is omitted because the graph projects okta.user nodes by
+	//     (tenant_id, user_id), so two okta runtimes touching the same user share
+	//     one node and would produce the same fingerprint anyway; including
+	//     runtime_id would split a single tenant-scoped finding into duplicates
+	//     the moment another okta runtime synced. The same fingerprint can be
+	//     emitted by either an okta or a github trigger, so Postgres'
+	//     UpsertFinding (`runtime_id = findings.runtime_id`) pins runtime_id to
+	//     the first observer and keeps the row addressable through runtime APIs.
+	//   * identity_urn is omitted because the projector links the same Okta/GitHub
+	//     account pair to multiple `identity` nodes (email + login when they
+	//     differ on okta.user, actor + external_identity_nameid on github.audit).
+	//     Including identity_urn would split one offboarding gap into two
+	//     CRITICAL findings for the same account pair.
 	fingerprint := hashFindingFingerprint(
 		r.definition.ID,
 		tenantID,
 		group.oktaUserURN,
-		group.identityURN,
 		group.githubUserURN,
 	)
-	resourceURNs := []string{group.identityURN, group.oktaUserURN, group.githubUserURN}
+	identityURNs := sortedKeys(group.identityURNs)
+	identityLabels := sortedKeys(group.identityLabels)
+	resourceURNs := []string{group.oktaUserURN, group.githubUserURN}
+	resourceURNs = append(resourceURNs, identityURNs...)
 	targetURNs := make([]string, 0, len(group.targets))
 	targetLabels := make([]string, 0, len(group.targets))
 	targetTypes := make(map[string]struct{}, len(group.targets))
@@ -292,17 +318,17 @@ func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.Sour
 	sort.Strings(targetURNs)
 	sort.Strings(targetLabels)
 	resourceURNs = append(resourceURNs, targetURNs...)
-	identityLabel := firstNonEmpty(group.identityLabel, group.oktaUserLabel, group.githubUserLabel, "identity")
+	primaryIdentityLabel := firstNonEmpty(append(append([]string{}, identityLabels...), group.oktaUserLabel, group.githubUserLabel, "identity")...)
 	summary := fmt.Sprintf(
 		"Deprovisioned Okta identity %s remains active in GitHub as %s and has acted on %d resource(s)",
-		identityLabel,
+		primaryIdentityLabel,
 		firstNonEmpty(group.githubUserLabel, group.githubUserURN),
 		len(targetURNs),
 	)
 	attributes := map[string]string{
-		"primary_resource_urn":  group.identityURN,
-		"identity_urn":          group.identityURN,
-		"identity_label":        group.identityLabel,
+		"primary_resource_urn":  group.oktaUserURN,
+		"identity_urns":         strings.Join(identityURNs, ","),
+		"identity_labels":       strings.Join(identityLabels, ","),
 		"okta_user_urn":         group.oktaUserURN,
 		"okta_user_label":       group.oktaUserLabel,
 		"okta_status":           extractOktaStatus(group.oktaAttributesJSON),

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule.go
@@ -218,7 +218,7 @@ type deprovisionedOktaTarget struct {
 }
 
 func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, group *deprovisionedOktaGroup, now time.Time) *ports.FindingRecord {
-	runtimeID := strings.TrimSpace(runtime.GetId())
+	triggeringRuntimeID := strings.TrimSpace(runtime.GetId())
 	// The fingerprint deliberately omits runtime_id. The graph projects okta.user nodes by
 	// (tenant_id, user_id), so two okta runtimes touching the same user share one node and
 	// would produce the same fingerprint anyway; tracking runtime_id here would split a
@@ -230,6 +230,13 @@ func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.Sour
 		group.identityURN,
 		group.githubUserURN,
 	)
+	// The persisted runtime_id is a stable synthetic id per (tenant, rule), not the runtime
+	// that happened to trigger this evaluation. The rule's identity is tenant-scoped, so
+	// stamping the triggering runtime would cause UpsertFinding to flip the row between okta
+	// and github runtimes every iteration and make per-runtime list paths swap the finding
+	// in and out under each side. The triggering runtime is preserved in attributes for
+	// telemetry only.
+	persistedRuntimeID := graphRuleRuntimeID(r.definition.ID)
 	resourceURNs := []string{group.identityURN, group.oktaUserURN, group.githubUserURN}
 	targetURNs := make([]string, 0, len(group.targets))
 	targetLabels := make([]string, 0, len(group.targets))
@@ -266,7 +273,7 @@ func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.Sour
 		"target_urns":           strings.Join(targetURNs, ","),
 		"target_labels":         strings.Join(targetLabels, ","),
 		"target_entity_types":   strings.Join(sortedKeys(targetTypes), ","),
-		"source_runtime_id":     runtimeID,
+		"source_runtime_id":     triggeringRuntimeID,
 		"source_runtime_tenant": tenantID,
 	}
 	for key, value := range r.definition.AttributeMap() {
@@ -277,7 +284,7 @@ func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.Sour
 		ID:              fingerprint,
 		Fingerprint:     fingerprint,
 		TenantID:        tenantID,
-		RuntimeID:       runtimeID,
+		RuntimeID:       persistedRuntimeID,
 		RuleID:          r.definition.ID,
 		Title:           r.definition.Name,
 		Severity:        r.definition.Severity,

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule.go
@@ -1,0 +1,322 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var _ GraphRule = (*deprovisionedOktaActiveGitHubRule)(nil)
+
+const (
+	identityDeprovisionedOktaActiveGitHubRuleID = "identity-okta-deprovisioned-active-in-github"
+	identityDeprovisionedOktaActiveGitHubKind   = "finding.identity_okta_deprovisioned_active_in_github"
+	identityDeprovisionedOktaQueryRowLimit      = 500
+)
+
+// deprovisionedOktaActiveGitHubRule fires when an Okta user whose lifecycle status is
+// deprovisioned, suspended, or otherwise inactive still resolves to an active GitHub
+// account that has acted on a repository or other GitHub resource. The rule runs
+// against the projected graph because no single source-event can answer this question:
+// it requires joining Okta lifecycle state with GitHub audit-derived identity edges.
+type deprovisionedOktaActiveGitHubRule struct {
+	definition RuleDefinition
+}
+
+func newDeprovisionedOktaActiveGitHubRule() Rule {
+	return &deprovisionedOktaActiveGitHubRule{
+		definition: RuleDefinition{
+			ID:          identityDeprovisionedOktaActiveGitHubRuleID,
+			Name:        "Deprovisioned Okta Identity Still Active In GitHub",
+			Description: "Detect Okta identities marked deprovisioned, suspended, or inactive whose linked GitHub account is still acting on repositories or organization resources.",
+			SourceID:    "okta",
+			EventKinds:  []string{"okta.user", "github.audit"},
+			OutputKind:  identityDeprovisionedOktaActiveGitHubKind,
+			Severity:    "CRITICAL",
+			Status:      findingStatusOpen,
+			Maturity:    "test",
+			Tags: []string{
+				"identity",
+				"offboarding",
+				"github",
+				"graph-rule",
+				"attack.t1078",
+			},
+			References: []string{
+				"https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-user-lifecycle.htm",
+				"https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/iam-configuration-reference/audit-log-events-for-your-enterprise",
+			},
+			FalsePositives: []string{
+				"Service or break-glass account intentionally retained in GitHub during an off-boarding grace window with documented exception.",
+				"Delayed Okta lifecycle propagation immediately after a status change; window typically closes within one sync cycle.",
+			},
+			Runbook:           "Confirm the Okta identity is truly off-boarded, revoke or suspend the linked GitHub account, rotate any tokens it created, and document the gap that allowed continued access.",
+			FingerprintFields: []string{"identity_urn", "github_user_urn"},
+			ControlRefs: []ports.FindingControlRef{
+				{FrameworkName: "SOC 2", ControlID: "CC6.2"},
+				{FrameworkName: "ISO 27001:2022", ControlID: "A.5.18"},
+				{FrameworkName: "HIPAA", ControlID: "164.308(a)(3)(ii)(C)"},
+			},
+		},
+	}
+}
+
+func (r *deprovisionedOktaActiveGitHubRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return proto.Clone(r.definition.RuleSpec()).(*cerebrov1.RuleSpec)
+}
+
+func (r *deprovisionedOktaActiveGitHubRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(runtime.GetSourceId()), r.definition.SourceID)
+}
+
+// Evaluate is the event-driven hook required by Rule. Graph rules emit no findings during the
+// per-event replay path; the graph-rule evaluator drives them via EvaluateRows instead.
+func (r *deprovisionedOktaActiveGitHubRule) Evaluate(_ context.Context, _ *cerebrov1.SourceRuntime, _ *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (r *deprovisionedOktaActiveGitHubRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
+	if runtime == nil {
+		return ports.CypherQueryRequest{}
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return ports.CypherQueryRequest{}
+	}
+	return ports.CypherQueryRequest{
+		Query: `MATCH (o:Entity {entity_type: 'okta.user', tenant_id: $tenant_id})
+       -[oi:RELATION {relation: 'represents_identity'}]->(id:Entity)
+       <-[gi:RELATION {relation: 'represents_identity'}]-(g:Entity {entity_type: 'github.user', tenant_id: $tenant_id})
+       -[acted:RELATION {relation: 'acted_on'}]->(target:Entity)
+WHERE toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"DEPROVISIONED"'
+   OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"SUSPENDED"'
+   OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"INACTIVE"'
+RETURN o.urn AS okta_user_urn,
+       o.label AS okta_user_label,
+       coalesce(o.attributes_json, '') AS okta_attributes_json,
+       id.urn AS identity_urn,
+       id.label AS identity_label,
+       g.urn AS github_user_urn,
+       g.label AS github_user_label,
+       target.urn AS target_urn,
+       target.entity_type AS target_entity_type,
+       target.label AS target_label,
+       coalesce(acted.attributes_json, '') AS acted_attributes_json
+LIMIT $row_limit`,
+		Params: map[string]any{
+			"tenant_id": tenantID,
+			"row_limit": int64(identityDeprovisionedOktaQueryRowLimit),
+		},
+		RowLimit: identityDeprovisionedOktaQueryRowLimit,
+	}
+}
+
+func (r *deprovisionedOktaActiveGitHubRule) EvaluateRows(_ context.Context, runtime *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {
+	if r == nil || runtime == nil || len(rows) == 0 {
+		return nil, nil
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return nil, nil
+	}
+	now := time.Now().UTC()
+	groups := map[string]*deprovisionedOktaGroup{}
+	keys := make([]string, 0)
+	for _, row := range rows {
+		oktaUserURN := cypherRowString(row, "okta_user_urn")
+		identityURN := cypherRowString(row, "identity_urn")
+		githubUserURN := cypherRowString(row, "github_user_urn")
+		if oktaUserURN == "" || identityURN == "" || githubUserURN == "" {
+			continue
+		}
+		key := oktaUserURN + "\x00" + identityURN + "\x00" + githubUserURN
+		group, ok := groups[key]
+		if !ok {
+			group = &deprovisionedOktaGroup{
+				oktaUserURN:        oktaUserURN,
+				oktaUserLabel:      cypherRowString(row, "okta_user_label"),
+				oktaAttributesJSON: cypherRowString(row, "okta_attributes_json"),
+				identityURN:        identityURN,
+				identityLabel:      cypherRowString(row, "identity_label"),
+				githubUserURN:      githubUserURN,
+				githubUserLabel:    cypherRowString(row, "github_user_label"),
+				targets:            map[string]deprovisionedOktaTarget{},
+			}
+			groups[key] = group
+			keys = append(keys, key)
+		}
+		targetURN := cypherRowString(row, "target_urn")
+		if targetURN == "" {
+			continue
+		}
+		if _, exists := group.targets[targetURN]; exists {
+			continue
+		}
+		group.targets[targetURN] = deprovisionedOktaTarget{
+			urn:        targetURN,
+			entityType: cypherRowString(row, "target_entity_type"),
+			label:      cypherRowString(row, "target_label"),
+		}
+	}
+	sort.Strings(keys)
+	findings := make([]*ports.FindingRecord, 0, len(keys))
+	for _, key := range keys {
+		group := groups[key]
+		if group == nil {
+			continue
+		}
+		findings = append(findings, r.buildFinding(runtime, tenantID, group, now))
+	}
+	return findings, nil
+}
+
+type deprovisionedOktaGroup struct {
+	oktaUserURN        string
+	oktaUserLabel      string
+	oktaAttributesJSON string
+	identityURN        string
+	identityLabel      string
+	githubUserURN      string
+	githubUserLabel    string
+	targets            map[string]deprovisionedOktaTarget
+}
+
+type deprovisionedOktaTarget struct {
+	urn        string
+	entityType string
+	label      string
+}
+
+func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, group *deprovisionedOktaGroup, now time.Time) *ports.FindingRecord {
+	fingerprint := hashFindingFingerprint(
+		r.definition.ID,
+		tenantID,
+		group.identityURN,
+		group.githubUserURN,
+	)
+	resourceURNs := []string{group.identityURN, group.oktaUserURN, group.githubUserURN}
+	targetURNs := make([]string, 0, len(group.targets))
+	targetLabels := make([]string, 0, len(group.targets))
+	targetTypes := make(map[string]struct{}, len(group.targets))
+	for urn, target := range group.targets {
+		targetURNs = append(targetURNs, urn)
+		if trimmed := strings.TrimSpace(target.label); trimmed != "" {
+			targetLabels = append(targetLabels, trimmed)
+		}
+		if trimmed := strings.TrimSpace(target.entityType); trimmed != "" {
+			targetTypes[trimmed] = struct{}{}
+		}
+	}
+	sort.Strings(targetURNs)
+	sort.Strings(targetLabels)
+	resourceURNs = append(resourceURNs, targetURNs...)
+	identityLabel := firstNonEmpty(group.identityLabel, group.oktaUserLabel, group.githubUserLabel, "identity")
+	summary := fmt.Sprintf(
+		"Deprovisioned Okta identity %s remains active in GitHub as %s and has acted on %d resource(s)",
+		identityLabel,
+		firstNonEmpty(group.githubUserLabel, group.githubUserURN),
+		len(targetURNs),
+	)
+	attributes := map[string]string{
+		"primary_resource_urn":  group.identityURN,
+		"identity_urn":          group.identityURN,
+		"identity_label":        group.identityLabel,
+		"okta_user_urn":         group.oktaUserURN,
+		"okta_user_label":       group.oktaUserLabel,
+		"okta_status":           extractOktaStatus(group.oktaAttributesJSON),
+		"github_user_urn":       group.githubUserURN,
+		"github_user_label":     group.githubUserLabel,
+		"target_count":          fmt.Sprintf("%d", len(targetURNs)),
+		"target_urns":           strings.Join(targetURNs, ","),
+		"target_labels":         strings.Join(targetLabels, ","),
+		"target_entity_types":   strings.Join(sortedKeys(targetTypes), ","),
+		"source_runtime_id":     strings.TrimSpace(runtime.GetId()),
+		"source_runtime_tenant": tenantID,
+	}
+	for key, value := range r.definition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       strings.TrimSpace(runtime.GetId()),
+		RuleID:          r.definition.ID,
+		Title:           r.definition.Name,
+		Severity:        r.definition.Severity,
+		Status:          r.definition.Status,
+		Summary:         summary,
+		ResourceURNs:    deduplicateStrings(resourceURNs),
+		ControlRefs:     cloneFindingControlRefs(r.definition.ControlRefs),
+		Attributes:      attributes,
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+		CheckID:         r.definition.ID,
+		CheckName:       r.definition.Name,
+	}
+}
+
+func extractOktaStatus(attributesJSON string) string {
+	if attributesJSON == "" {
+		return ""
+	}
+	upper := strings.ToUpper(attributesJSON)
+	for _, status := range []string{"DEPROVISIONED", "SUSPENDED", "INACTIVE"} {
+		if strings.Contains(upper, "\"STATUS\":\""+status+"\"") {
+			return status
+		}
+	}
+	return ""
+}
+
+func cypherRowString(row ports.CypherRow, key string) string {
+	if row.Values == nil {
+		return ""
+	}
+	value, ok := row.Values[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", typed))
+	}
+}
+
+func deduplicateStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule.go
@@ -2,6 +2,7 @@ package findings
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -19,6 +20,13 @@ const (
 	identityDeprovisionedOktaActiveGitHubRuleID = "identity-okta-deprovisioned-active-in-github"
 	identityDeprovisionedOktaActiveGitHubKind   = "finding.identity_okta_deprovisioned_active_in_github"
 	identityDeprovisionedOktaQueryRowLimit      = 500
+	// identityDeprovisionedOktaRecencyWindow scopes "still active in GitHub" to
+	// recent activity. acted_on edges carry an `at` attribute populated from the
+	// audit event's OccurredAt; rows whose latest `at` is older than this window,
+	// or that pre-date the at-stamping projector change and have no `at` at all,
+	// are treated as stale history rather than current access. This prevents a
+	// single pre-offboarding action from holding the finding open indefinitely.
+	identityDeprovisionedOktaRecencyWindow = 30 * 24 * time.Hour
 )
 
 // deprovisionedOktaActiveGitHubRule fires when an Okta user whose lifecycle status is
@@ -159,6 +167,18 @@ func (r *deprovisionedOktaActiveGitHubRule) EvaluateRows(_ context.Context, runt
 		if oktaUserURN == "" || identityURN == "" || githubUserURN == "" {
 			continue
 		}
+		targetURN := cypherRowString(row, "target_urn")
+		if targetURN == "" {
+			continue
+		}
+		// `acted_on` edges projected before the at-stamp change have no `at`,
+		// and any edge whose latest action is older than the recency window is
+		// stale history. Either way, this row is not evidence of current GitHub
+		// access for the deprovisioned identity, so drop it before it can pin
+		// the group open.
+		if !actedOnEdgeIsRecent(cypherRowString(row, "acted_attributes_json"), now, identityDeprovisionedOktaRecencyWindow) {
+			continue
+		}
 		key := oktaUserURN + "\x00" + identityURN + "\x00" + githubUserURN
 		group, ok := groups[key]
 		if !ok {
@@ -175,10 +195,6 @@ func (r *deprovisionedOktaActiveGitHubRule) EvaluateRows(_ context.Context, runt
 			groups[key] = group
 			keys = append(keys, key)
 		}
-		targetURN := cypherRowString(row, "target_urn")
-		if targetURN == "" {
-			continue
-		}
 		if _, exists := group.targets[targetURN]; exists {
 			continue
 		}
@@ -192,12 +208,38 @@ func (r *deprovisionedOktaActiveGitHubRule) EvaluateRows(_ context.Context, runt
 	findings := make([]*ports.FindingRecord, 0, len(keys))
 	for _, key := range keys {
 		group := groups[key]
-		if group == nil {
+		if group == nil || len(group.targets) == 0 {
 			continue
 		}
 		findings = append(findings, r.buildFinding(runtime, tenantID, group, now))
 	}
 	return findings, nil
+}
+
+// actedOnEdgeIsRecent decides whether a github acted_on edge represents activity
+// inside the recency window. The edge attributes are JSON-encoded by the projector
+// (see githubAuditProjections); when the latest action was at least `window` ago
+// the user has not exercised access recently and the edge should not, on its own,
+// keep a deprovisioned-Okta finding open. Edges projected before the at-stamp
+// change have no `at` at all and are treated identically to stale history.
+func actedOnEdgeIsRecent(attributesJSON string, now time.Time, window time.Duration) bool {
+	trimmed := strings.TrimSpace(attributesJSON)
+	if trimmed == "" {
+		return false
+	}
+	var attrs map[string]string
+	if err := json.Unmarshal([]byte(trimmed), &attrs); err != nil {
+		return false
+	}
+	raw := strings.TrimSpace(attrs["at"])
+	if raw == "" {
+		return false
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return false
+	}
+	return now.UTC().Sub(parsed.UTC()) <= window
 }
 
 type deprovisionedOktaGroup struct {

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule.go
@@ -58,7 +58,7 @@ func newDeprovisionedOktaActiveGitHubRule() Rule {
 				"Delayed Okta lifecycle propagation immediately after a status change; window typically closes within one sync cycle.",
 			},
 			Runbook:           "Confirm the Okta identity is truly off-boarded, revoke or suspend the linked GitHub account, rotate any tokens it created, and document the gap that allowed continued access.",
-			FingerprintFields: []string{"identity_urn", "github_user_urn"},
+			FingerprintFields: []string{"runtime_id", "okta_user_urn", "identity_urn", "github_user_urn"},
 			ControlRefs: []ports.FindingControlRef{
 				{FrameworkName: "SOC 2", ControlID: "CC6.2"},
 				{FrameworkName: "ISO 27001:2022", ControlID: "A.5.18"},
@@ -93,7 +93,8 @@ func (r *deprovisionedOktaActiveGitHubRule) QueryFor(runtime *cerebrov1.SourceRu
 		return ports.CypherQueryRequest{}
 	}
 	tenantID := strings.TrimSpace(runtime.GetTenantId())
-	if tenantID == "" {
+	runtimeID := strings.TrimSpace(runtime.GetId())
+	if tenantID == "" || runtimeID == "" {
 		return ports.CypherQueryRequest{}
 	}
 	return ports.CypherQueryRequest{
@@ -101,9 +102,10 @@ func (r *deprovisionedOktaActiveGitHubRule) QueryFor(runtime *cerebrov1.SourceRu
        -[oi:RELATION {relation: 'represents_identity'}]->(id:Entity)
        <-[gi:RELATION {relation: 'represents_identity'}]-(g:Entity {entity_type: 'github.user', tenant_id: $tenant_id})
        -[acted:RELATION {relation: 'acted_on'}]->(target:Entity)
-WHERE toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"DEPROVISIONED"'
-   OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"SUSPENDED"'
-   OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"INACTIVE"'
+WHERE coalesce(o.attributes_json, '') CONTAINS $okta_runtime_marker
+  AND (toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"DEPROVISIONED"'
+       OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"SUSPENDED"'
+       OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"INACTIVE"')
 RETURN o.urn AS okta_user_urn,
        o.label AS okta_user_label,
        coalesce(o.attributes_json, '') AS okta_attributes_json,
@@ -117,8 +119,9 @@ RETURN o.urn AS okta_user_urn,
        coalesce(acted.attributes_json, '') AS acted_attributes_json
 LIMIT $row_limit`,
 		Params: map[string]any{
-			"tenant_id": tenantID,
-			"row_limit": int64(identityDeprovisionedOktaQueryRowLimit),
+			"tenant_id":           tenantID,
+			"okta_runtime_marker": fmt.Sprintf("%q:%q", "source_runtime_id", runtimeID),
+			"row_limit":           int64(identityDeprovisionedOktaQueryRowLimit),
 		},
 		RowLimit: identityDeprovisionedOktaQueryRowLimit,
 	}
@@ -201,9 +204,12 @@ type deprovisionedOktaTarget struct {
 }
 
 func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, group *deprovisionedOktaGroup, now time.Time) *ports.FindingRecord {
+	runtimeID := strings.TrimSpace(runtime.GetId())
 	fingerprint := hashFindingFingerprint(
 		r.definition.ID,
 		tenantID,
+		runtimeID,
+		group.oktaUserURN,
 		group.identityURN,
 		group.githubUserURN,
 	)
@@ -243,7 +249,7 @@ func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.Sour
 		"target_urns":           strings.Join(targetURNs, ","),
 		"target_labels":         strings.Join(targetLabels, ","),
 		"target_entity_types":   strings.Join(sortedKeys(targetTypes), ","),
-		"source_runtime_id":     strings.TrimSpace(runtime.GetId()),
+		"source_runtime_id":     runtimeID,
 		"source_runtime_tenant": tenantID,
 	}
 	for key, value := range r.definition.AttributeMap() {
@@ -254,7 +260,7 @@ func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.Sour
 		ID:              fingerprint,
 		Fingerprint:     fingerprint,
 		TenantID:        tenantID,
-		RuntimeID:       strings.TrimSpace(runtime.GetId()),
+		RuntimeID:       runtimeID,
 		RuleID:          r.definition.ID,
 		Title:           r.definition.Name,
 		Severity:        r.definition.Severity,

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule.go
@@ -58,7 +58,7 @@ func newDeprovisionedOktaActiveGitHubRule() Rule {
 				"Delayed Okta lifecycle propagation immediately after a status change; window typically closes within one sync cycle.",
 			},
 			Runbook:           "Confirm the Okta identity is truly off-boarded, revoke or suspend the linked GitHub account, rotate any tokens it created, and document the gap that allowed continued access.",
-			FingerprintFields: []string{"runtime_id", "okta_user_urn", "identity_urn", "github_user_urn"},
+			FingerprintFields: []string{"okta_user_urn", "identity_urn", "github_user_urn"},
 			ControlRefs: []ports.FindingControlRef{
 				{FrameworkName: "SOC 2", ControlID: "CC6.2"},
 				{FrameworkName: "ISO 27001:2022", ControlID: "A.5.18"},
@@ -88,13 +88,19 @@ func (r *deprovisionedOktaActiveGitHubRule) Evaluate(_ context.Context, _ *cereb
 	return nil, nil
 }
 
+// QueryFor scopes the cypher to the runtime's tenant only. The graph deliberately upserts
+// every okta.user node by `(tenant_id, user_id)` so inventory and audit runtimes share one
+// node with merged attributes; runtime_id on okta.user is therefore not a stable partition
+// (the latest event wins via mergeGraphAttributes) and using it as a predicate would alias
+// inventory-derived `status` onto the audit runtime that touched the node last. The rule is
+// fundamentally tenant-scoped: the answer to "is this deprovisioned okta identity still
+// active in github?" is the same for any okta runtime in the tenant.
 func (r *deprovisionedOktaActiveGitHubRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
 	if runtime == nil {
 		return ports.CypherQueryRequest{}
 	}
 	tenantID := strings.TrimSpace(runtime.GetTenantId())
-	runtimeID := strings.TrimSpace(runtime.GetId())
-	if tenantID == "" || runtimeID == "" {
+	if tenantID == "" {
 		return ports.CypherQueryRequest{}
 	}
 	return ports.CypherQueryRequest{
@@ -102,10 +108,9 @@ func (r *deprovisionedOktaActiveGitHubRule) QueryFor(runtime *cerebrov1.SourceRu
        -[oi:RELATION {relation: 'represents_identity'}]->(id:Entity)
        <-[gi:RELATION {relation: 'represents_identity'}]-(g:Entity {entity_type: 'github.user', tenant_id: $tenant_id})
        -[acted:RELATION {relation: 'acted_on'}]->(target:Entity)
-WHERE coalesce(o.attributes_json, '') CONTAINS $okta_runtime_marker
-  AND (toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"DEPROVISIONED"'
-       OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"SUSPENDED"'
-       OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"INACTIVE"')
+WHERE toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"DEPROVISIONED"'
+   OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"SUSPENDED"'
+   OR toUpper(coalesce(o.attributes_json, '')) CONTAINS '"STATUS":"INACTIVE"'
 RETURN o.urn AS okta_user_urn,
        o.label AS okta_user_label,
        coalesce(o.attributes_json, '') AS okta_attributes_json,
@@ -119,9 +124,8 @@ RETURN o.urn AS okta_user_urn,
        coalesce(acted.attributes_json, '') AS acted_attributes_json
 LIMIT $row_limit`,
 		Params: map[string]any{
-			"tenant_id":           tenantID,
-			"okta_runtime_marker": fmt.Sprintf("%q:%q", "source_runtime_id", runtimeID),
-			"row_limit":           int64(identityDeprovisionedOktaQueryRowLimit),
+			"tenant_id": tenantID,
+			"row_limit": int64(identityDeprovisionedOktaQueryRowLimit),
 		},
 		RowLimit: identityDeprovisionedOktaQueryRowLimit,
 	}
@@ -205,10 +209,13 @@ type deprovisionedOktaTarget struct {
 
 func (r *deprovisionedOktaActiveGitHubRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, group *deprovisionedOktaGroup, now time.Time) *ports.FindingRecord {
 	runtimeID := strings.TrimSpace(runtime.GetId())
+	// The fingerprint deliberately omits runtime_id. The graph projects okta.user nodes by
+	// (tenant_id, user_id), so two okta runtimes touching the same user share one node and
+	// would produce the same fingerprint anyway; tracking runtime_id here would split a
+	// single tenant-scoped finding into duplicates the moment another okta runtime synced.
 	fingerprint := hashFindingFingerprint(
 		r.definition.ID,
 		tenantID,
-		runtimeID,
 		group.oktaUserURN,
 		group.identityURN,
 		group.githubUserURN,

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
@@ -43,6 +43,31 @@ func TestDeprovisionedOktaActiveGitHubRuleQueryRequiresTenant(t *testing.T) {
 	}
 }
 
+// The rule's cypher joins okta.user lifecycle state with github.user acted_on edges, so the
+// finding can change after a fresh ingest from EITHER side. SupportsRuntime must accept both
+// or detections lag until the next time the other source happens to sync.
+func TestDeprovisionedOktaActiveGitHubRuleSupportsBothOktaAndGitHub(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	cases := map[string]struct {
+		runtime *cerebrov1.SourceRuntime
+		want    bool
+	}{
+		"okta runtime":     {&cerebrov1.SourceRuntime{SourceId: "okta"}, true},
+		"github runtime":   {&cerebrov1.SourceRuntime{SourceId: "github"}, true},
+		"OKTA upper case":  {&cerebrov1.SourceRuntime{SourceId: "OKTA"}, true},
+		"unrelated source": {&cerebrov1.SourceRuntime{SourceId: "aws"}, false},
+		"empty source":     {&cerebrov1.SourceRuntime{}, false},
+		"nil runtime":      {nil, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := rule.SupportsRuntime(tc.runtime); got != tc.want {
+				t.Fatalf("SupportsRuntime() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDeprovisionedOktaActiveGitHubRuleFingerprintIsStableAcrossRuns(t *testing.T) {
 	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
@@ -1,0 +1,93 @@
+package findings
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func deprovisionedOktaRuleFixedNow() time.Time {
+	return time.Date(2025, time.March, 5, 12, 0, 0, 0, time.UTC)
+}
+
+func TestDeprovisionedOktaActiveGitHubRuleQueryScopesByRuntime(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	request := rule.QueryFor(runtime)
+	if request.Query == "" {
+		t.Fatal("QueryFor() returned empty query for fully-populated runtime")
+	}
+	if got := request.Params["tenant_id"]; got != "writer" {
+		t.Fatalf("Params[tenant_id] = %v, want writer", got)
+	}
+	marker, ok := request.Params["okta_runtime_marker"].(string)
+	if !ok {
+		t.Fatalf("Params[okta_runtime_marker] type = %T, want string", request.Params["okta_runtime_marker"])
+	}
+	if !strings.Contains(marker, "writer-okta-prod") {
+		t.Fatalf("Params[okta_runtime_marker] = %q, want to contain runtime id %q", marker, "writer-okta-prod")
+	}
+	if !strings.Contains(marker, "source_runtime_id") {
+		t.Fatalf("Params[okta_runtime_marker] = %q, want to contain attribute key %q", marker, "source_runtime_id")
+	}
+	if !strings.Contains(request.Query, "$okta_runtime_marker") {
+		t.Fatalf("Query missing $okta_runtime_marker predicate; without it findings cross runtimes:\n%s", request.Query)
+	}
+	if request.RowLimit != identityDeprovisionedOktaQueryRowLimit {
+		t.Fatalf("RowLimit = %d, want %d", request.RowLimit, identityDeprovisionedOktaQueryRowLimit)
+	}
+}
+
+func TestDeprovisionedOktaActiveGitHubRuleQueryRequiresRuntimeIdentity(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	cases := map[string]*cerebrov1.SourceRuntime{
+		"missing tenant":  {Id: "writer-okta-prod", SourceId: "okta"},
+		"missing runtime": {SourceId: "okta", TenantId: "writer"},
+	}
+	for name, runtime := range cases {
+		t.Run(name, func(t *testing.T) {
+			if request := rule.QueryFor(runtime); request.Query != "" {
+				t.Fatalf("QueryFor(%s) returned populated query; rule must refuse to scan without tenant+runtime: %#v", name, request)
+			}
+		})
+	}
+}
+
+func TestDeprovisionedOktaActiveGitHubRuleFingerprintIsStableAcrossRuns(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	group := &deprovisionedOktaGroup{
+		oktaUserURN:   "urn:cerebro:writer:okta.user:alice@writer.com",
+		identityURN:   "urn:cerebro:writer:identity:email:alice@writer.com",
+		githubUserURN: "urn:cerebro:writer:github.user:alice",
+	}
+	first := rule.buildFinding(runtime, "writer", group, deprovisionedOktaRuleFixedNow())
+	second := rule.buildFinding(runtime, "writer", group, deprovisionedOktaRuleFixedNow())
+	if first.ID != second.ID {
+		t.Fatalf("finding ID drifted across evaluations: %q vs %q (fingerprint must hash stable inputs only)", first.ID, second.ID)
+	}
+	if first.Fingerprint != second.Fingerprint {
+		t.Fatalf("finding fingerprint drifted: %q vs %q", first.Fingerprint, second.Fingerprint)
+	}
+}
+
+func TestDeprovisionedOktaActiveGitHubRuleFingerprintSeparatesRuntimes(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtimeA := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	runtimeB := &cerebrov1.SourceRuntime{Id: "writer-okta-sandbox", SourceId: "okta", TenantId: "writer"}
+	group := &deprovisionedOktaGroup{
+		oktaUserURN:   "urn:cerebro:writer:okta.user:alice@writer.com",
+		identityURN:   "urn:cerebro:writer:identity:email:alice@writer.com",
+		githubUserURN: "urn:cerebro:writer:github.user:alice",
+	}
+	a := rule.buildFinding(runtimeA, "writer", group, deprovisionedOktaRuleFixedNow())
+	b := rule.buildFinding(runtimeB, "writer", group, deprovisionedOktaRuleFixedNow())
+	if a.ID == b.ID {
+		t.Fatalf("findings collide across runtimes (id=%q); two okta runtimes touching the same identity must produce distinct finding IDs", a.ID)
+	}
+	if a.Fingerprint == b.Fingerprint {
+		t.Fatalf("fingerprint identical across runtimes: %q", a.Fingerprint)
+	}
+}

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
@@ -51,16 +51,25 @@ func TestDeprovisionedOktaActiveGitHubRuleQueryRequiresTenant(t *testing.T) {
 // or detections lag until the next time the other source happens to sync.
 func TestDeprovisionedOktaActiveGitHubRuleSupportsBothOktaAndGitHub(t *testing.T) {
 	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	withFamily := func(sourceID, family string) *cerebrov1.SourceRuntime {
+		return &cerebrov1.SourceRuntime{SourceId: sourceID, Config: map[string]string{"family": family}}
+	}
 	cases := map[string]struct {
 		runtime *cerebrov1.SourceRuntime
 		want    bool
 	}{
-		"okta runtime":     {&cerebrov1.SourceRuntime{SourceId: "okta"}, true},
-		"github runtime":   {&cerebrov1.SourceRuntime{SourceId: "github"}, true},
-		"OKTA upper case":  {&cerebrov1.SourceRuntime{SourceId: "OKTA"}, true},
-		"unrelated source": {&cerebrov1.SourceRuntime{SourceId: "aws"}, false},
-		"empty source":     {&cerebrov1.SourceRuntime{}, false},
-		"nil runtime":      {nil, false},
+		"okta user runtime":             {withFamily("okta", "user"), true},
+		"github audit runtime":          {withFamily("github", "audit"), true},
+		"OKTA user upper case":          {withFamily("OKTA", "USER"), true},
+		"okta audit runtime":            {withFamily("okta", "audit"), false},
+		"okta group runtime":            {withFamily("okta", "group_membership"), false},
+		"github pull-request runtime":   {withFamily("github", "pull_request"), false},
+		"github dependabot runtime":     {withFamily("github", "dependabot_alert"), false},
+		"okta runtime missing family":   {&cerebrov1.SourceRuntime{SourceId: "okta"}, false},
+		"github runtime missing family": {&cerebrov1.SourceRuntime{SourceId: "github"}, false},
+		"unrelated source":              {withFamily("aws", "iam_user"), false},
+		"empty source":                  {&cerebrov1.SourceRuntime{}, false},
+		"nil runtime":                   {nil, false},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -234,18 +243,21 @@ func deprovisionedOktaRuleActedAttrs(at time.Time) string {
 }
 
 func deprovisionedOktaRuleRow(actedAttributesJSON string) ports.CypherRow {
+	recent := deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour))
 	return ports.CypherRow{Values: map[string]any{
-		"okta_user_urn":         "urn:cerebro:writer:okta.user:alice@writer.com",
-		"okta_user_label":       "Alice",
-		"okta_attributes_json":  `{"status":"DEPROVISIONED"}`,
-		"identity_urn":          "urn:cerebro:writer:identity:email:alice@writer.com",
-		"identity_label":        "alice@writer.com",
-		"github_user_urn":       "urn:cerebro:writer:github.user:alice",
-		"github_user_label":     "alice",
-		"target_urn":            "urn:cerebro:writer:github_repo:writer/cerebro",
-		"target_entity_type":    "github_repo",
-		"target_label":          "writer/cerebro",
-		"acted_attributes_json": actedAttributesJSON,
+		"okta_user_urn":                   "urn:cerebro:writer:okta.user:alice@writer.com",
+		"okta_user_label":                 "Alice",
+		"okta_attributes_json":            `{"status":"DEPROVISIONED"}`,
+		"identity_urn":                    "urn:cerebro:writer:identity:email:alice@writer.com",
+		"identity_label":                  "alice@writer.com",
+		"github_user_urn":                 "urn:cerebro:writer:github.user:alice",
+		"github_user_label":               "alice",
+		"target_urn":                      "urn:cerebro:writer:github_repo:writer/cerebro",
+		"target_entity_type":              "github_repo",
+		"target_label":                    "writer/cerebro",
+		"acted_attributes_json":           actedAttributesJSON,
+		"okta_identity_attributes_json":   recent,
+		"github_identity_attributes_json": recent,
 	}}
 }
 
@@ -344,5 +356,63 @@ func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsSkipsMalformedAt(t *testin
 	}
 	if len(findings) != 0 {
 		t.Fatalf("EvaluateRows() returned %d findings with unparseable `at`, want 0", len(findings))
+	}
+}
+
+// represents_identity edges are upsert-only: when an Okta email/login (or a
+// GitHub external_identity_nameid) is renamed, the old identity node stays
+// linked to both accounts in the graph. The cypher `(o)-[oi]->(id)<-[gi]-(g)`
+// would otherwise keep matching through the stale identity node forever and
+// the rule would emit (or fail to auto-resolve) findings for accounts whose
+// current identifiers no longer overlap. We require BOTH the okta-side and
+// github-side identifier links to have been re-asserted within the recency
+// window before treating the join as evidence.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsSkipsStaleOktaIdentifierEdge(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	staleAt := time.Now().UTC().Add(-(identityDeprovisionedOktaRecencyWindow + 24*time.Hour))
+	row := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour)))
+	row.Values["okta_identity_attributes_json"] = deprovisionedOktaRuleActedAttrs(staleAt)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings with stale okta represents_identity edge, want 0; rename-stale joins must not keep findings open", len(findings))
+	}
+}
+
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsSkipsStaleGitHubIdentifierEdge(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	staleAt := time.Now().UTC().Add(-(identityDeprovisionedOktaRecencyWindow + 24*time.Hour))
+	row := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour)))
+	row.Values["github_identity_attributes_json"] = deprovisionedOktaRuleActedAttrs(staleAt)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings with stale github represents_identity edge, want 0", len(findings))
+	}
+}
+
+// represents_identity edges projected before the at-stamp change have no `at`
+// at all. We refuse to fire on those for the same reason as missing-at acted_on
+// edges: we cannot prove the identifier link is current, so we cannot honestly
+// claim the deprovisioned account is "still active". Once the projector
+// backfills, these rows reappear with `at` and the rule re-emits naturally.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsSkipsUnstampedIdentifierEdges(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	row := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour)))
+	row.Values["okta_identity_attributes_json"] = `{"identifier_type":"email","identifier_value":"alice@writer.com"}`
+	row.Values["github_identity_attributes_json"] = `{"identifier_type":"login","identifier_value":"alice"}`
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings for legacy identifier edges without `at`, want 0", len(findings))
 	}
 }

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
@@ -71,14 +71,23 @@ func TestDeprovisionedOktaActiveGitHubRuleSupportsBothOktaAndGitHub(t *testing.T
 	}
 }
 
+func deprovisionedOktaRuleGroupWithIdentities(identityURNs ...string) *deprovisionedOktaGroup {
+	identities := map[string]struct{}{}
+	for _, urn := range identityURNs {
+		identities[urn] = struct{}{}
+	}
+	return &deprovisionedOktaGroup{
+		oktaUserURN:    "urn:cerebro:writer:okta.user:alice@writer.com",
+		githubUserURN:  "urn:cerebro:writer:github.user:alice",
+		identityURNs:   identities,
+		identityLabels: map[string]struct{}{},
+	}
+}
+
 func TestDeprovisionedOktaActiveGitHubRuleFingerprintIsStableAcrossRuns(t *testing.T) {
 	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
-	group := &deprovisionedOktaGroup{
-		oktaUserURN:   "urn:cerebro:writer:okta.user:alice@writer.com",
-		identityURN:   "urn:cerebro:writer:identity:email:alice@writer.com",
-		githubUserURN: "urn:cerebro:writer:github.user:alice",
-	}
+	group := deprovisionedOktaRuleGroupWithIdentities("urn:cerebro:writer:identity:email:alice@writer.com")
 	first := rule.buildFinding(runtime, "writer", group, deprovisionedOktaRuleFixedNow())
 	second := rule.buildFinding(runtime, "writer", group, deprovisionedOktaRuleFixedNow())
 	if first.ID != second.ID {
@@ -97,11 +106,7 @@ func TestDeprovisionedOktaActiveGitHubRuleFingerprintIsStableAcrossRuns(t *testi
 // the rule's contract: stamp the real triggering runtime, never a synthetic value.
 func TestDeprovisionedOktaActiveGitHubRuleFindingStampsTriggeringRuntimeID(t *testing.T) {
 	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
-	group := &deprovisionedOktaGroup{
-		oktaUserURN:   "urn:cerebro:writer:okta.user:alice@writer.com",
-		identityURN:   "urn:cerebro:writer:identity:email:alice@writer.com",
-		githubUserURN: "urn:cerebro:writer:github.user:alice",
-	}
+	group := deprovisionedOktaRuleGroupWithIdentities("urn:cerebro:writer:identity:email:alice@writer.com")
 	oktaTriggered := rule.buildFinding(&cerebrov1.SourceRuntime{Id: "writer-okta-inventory", SourceId: "okta", TenantId: "writer"}, "writer", group, deprovisionedOktaRuleFixedNow())
 	githubTriggered := rule.buildFinding(&cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}, "writer", group, deprovisionedOktaRuleFixedNow())
 	if got := oktaTriggered.RuntimeID; got != "writer-okta-inventory" {
@@ -128,15 +133,11 @@ func TestDeprovisionedOktaActiveGitHubRuleFingerprintCollapsesAcrossOktaRuntimes
 	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
 	runtimeA := &cerebrov1.SourceRuntime{Id: "writer-okta-inventory", SourceId: "okta", TenantId: "writer"}
 	runtimeB := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"}
-	group := &deprovisionedOktaGroup{
-		oktaUserURN:   "urn:cerebro:writer:okta.user:alice@writer.com",
-		identityURN:   "urn:cerebro:writer:identity:email:alice@writer.com",
-		githubUserURN: "urn:cerebro:writer:github.user:alice",
-	}
+	group := deprovisionedOktaRuleGroupWithIdentities("urn:cerebro:writer:identity:email:alice@writer.com")
 	a := rule.buildFinding(runtimeA, "writer", group, deprovisionedOktaRuleFixedNow())
 	b := rule.buildFinding(runtimeB, "writer", group, deprovisionedOktaRuleFixedNow())
 	if a.ID != b.ID {
-		t.Fatalf("findings split across okta runtimes for the same offender (a=%q b=%q); rule is tenant-scoped and must produce one finding per (tenant, okta_user, identity, github_user)", a.ID, b.ID)
+		t.Fatalf("findings split across okta runtimes for the same offender (a=%q b=%q); rule is tenant-scoped and must produce one finding per (tenant, okta_user, github_user)", a.ID, b.ID)
 	}
 	if a.Fingerprint != b.Fingerprint {
 		t.Fatalf("fingerprints split across okta runtimes: %q vs %q", a.Fingerprint, b.Fingerprint)
@@ -149,19 +150,71 @@ func TestDeprovisionedOktaActiveGitHubRuleFingerprintSeparatesOktaUsers(t *testi
 	identityURN := "urn:cerebro:writer:identity:email:shared@writer.com"
 	githubURN := "urn:cerebro:writer:github.user:shared"
 	groupOne := &deprovisionedOktaGroup{
-		oktaUserURN:   "urn:cerebro:writer:okta.user:alice@writer.com",
-		identityURN:   identityURN,
-		githubUserURN: githubURN,
+		oktaUserURN:    "urn:cerebro:writer:okta.user:alice@writer.com",
+		githubUserURN:  githubURN,
+		identityURNs:   map[string]struct{}{identityURN: {}},
+		identityLabels: map[string]struct{}{},
 	}
 	groupTwo := &deprovisionedOktaGroup{
-		oktaUserURN:   "urn:cerebro:writer:okta.user:bob@writer.com",
-		identityURN:   identityURN,
-		githubUserURN: githubURN,
+		oktaUserURN:    "urn:cerebro:writer:okta.user:bob@writer.com",
+		githubUserURN:  githubURN,
+		identityURNs:   map[string]struct{}{identityURN: {}},
+		identityLabels: map[string]struct{}{},
 	}
 	a := rule.buildFinding(runtime, "writer", groupOne, deprovisionedOktaRuleFixedNow())
 	b := rule.buildFinding(runtime, "writer", groupTwo, deprovisionedOktaRuleFixedNow())
 	if a.ID == b.ID {
 		t.Fatalf("two distinct deprovisioned okta users collapsed onto the same finding (id=%q); fingerprint must include okta_user_urn", a.ID)
+	}
+}
+
+// The graph projector links the same Okta/GitHub account pair to multiple `identity`
+// nodes when okta.user has distinct email and login attributes, or when github.audit
+// links both `actor` and `external_identity_nameid`. The rule's cypher join then
+// emits one row per identity node, but those rows describe the same offboarding gap.
+// This test pins that the rule collapses them onto a single CRITICAL finding rather
+// than emitting one per identity node.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsCollapsesDuplicateIdentitiesPerAccountPair(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	emailRow := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour)))
+	loginRow := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour)))
+	loginRow.Values["identity_urn"] = "urn:cerebro:writer:identity:login:alice"
+	loginRow.Values["identity_label"] = "alice"
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{emailRow, loginRow})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if got := len(findings); got != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1; same Okta/GitHub pair must collapse across identity nodes (got: %#v)", got, findings)
+	}
+	finding := findings[0]
+	if got, want := finding.Attributes["identity_urns"], "urn:cerebro:writer:identity:email:alice@writer.com,urn:cerebro:writer:identity:login:alice"; got != want {
+		t.Fatalf("identity_urns = %q, want %q (full set must be retained as telemetry)", got, want)
+	}
+}
+
+// The fingerprint must be invariant to which identity node the cypher walked
+// through, otherwise reprocessing the same offboarding gap from a different
+// identity ordering would create a fresh CRITICAL finding instead of
+// reopening the existing one. This pins the contract on buildFinding directly.
+func TestDeprovisionedOktaActiveGitHubRuleFingerprintIgnoresIdentityNode(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	emailGroup := deprovisionedOktaRuleGroupWithIdentities("urn:cerebro:writer:identity:email:alice@writer.com")
+	loginGroup := deprovisionedOktaRuleGroupWithIdentities("urn:cerebro:writer:identity:login:alice")
+	bothGroup := deprovisionedOktaRuleGroupWithIdentities(
+		"urn:cerebro:writer:identity:email:alice@writer.com",
+		"urn:cerebro:writer:identity:login:alice",
+	)
+	emailFinding := rule.buildFinding(runtime, "writer", emailGroup, deprovisionedOktaRuleFixedNow())
+	loginFinding := rule.buildFinding(runtime, "writer", loginGroup, deprovisionedOktaRuleFixedNow())
+	bothFinding := rule.buildFinding(runtime, "writer", bothGroup, deprovisionedOktaRuleFixedNow())
+	if emailFinding.Fingerprint != loginFinding.Fingerprint {
+		t.Fatalf("fingerprint changes with identity node (email=%q login=%q); same Okta/GitHub pair must produce one fingerprint regardless of which identity node was traversed", emailFinding.Fingerprint, loginFinding.Fingerprint)
+	}
+	if emailFinding.Fingerprint != bothFinding.Fingerprint {
+		t.Fatalf("fingerprint changes when both identity nodes match (single=%q both=%q); the set of matched identities is telemetry, not identity", emailFinding.Fingerprint, bothFinding.Fingerprint)
 	}
 }
 

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
@@ -242,8 +242,44 @@ func deprovisionedOktaRuleActedAttrs(at time.Time) string {
 	return string(encoded)
 }
 
+// deprovisionedOktaRuleEmailIdentityAttrs mirrors the represents_identity edge
+// payload that identifierEvidenceAttributes emits when the projector resolves
+// an identifier as an email (match_type=exact_email at confidence=0.95). The
+// rule rejects any other match_type, so test rows must use this shape to land
+// in the email-only acceptance branch.
+func deprovisionedOktaRuleEmailIdentityAttrs(at time.Time) string {
+	return deprovisionedOktaRuleIdentityAttrs("email", "alice@writer.com", "exact_email", "0.95", at)
+}
+
+// deprovisionedOktaRuleLoginIdentityAttrs mirrors the represents_identity edge
+// payload that identifierEvidenceAttributes emits for raw GitHub usernames
+// (match_type=login at confidence=0.60). A username collision must not produce
+// a CRITICAL finding even when both `at` stamps are recent, so this fixture
+// exists specifically to drive the login-rejection regression tests.
+func deprovisionedOktaRuleLoginIdentityAttrs(at time.Time) string {
+	return deprovisionedOktaRuleIdentityAttrs("login", "alice", "login", "0.60", at)
+}
+
+func deprovisionedOktaRuleIdentityAttrs(identifierType, identifierValue, matchType, confidence string, at time.Time) string {
+	payload := map[string]string{
+		"confidence":       confidence,
+		"evidence_type":    "shared_identifier",
+		"identifier_type":  identifierType,
+		"identifier_value": identifierValue,
+		"match_type":       matchType,
+	}
+	if !at.IsZero() {
+		payload["at"] = at.UTC().Format(time.RFC3339)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}
+
 func deprovisionedOktaRuleRow(actedAttributesJSON string) ports.CypherRow {
-	recent := deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour))
+	recentEmail := deprovisionedOktaRuleEmailIdentityAttrs(time.Now().UTC().Add(-1 * time.Hour))
 	return ports.CypherRow{Values: map[string]any{
 		"okta_user_urn":                   "urn:cerebro:writer:okta.user:alice@writer.com",
 		"okta_user_label":                 "Alice",
@@ -256,8 +292,8 @@ func deprovisionedOktaRuleRow(actedAttributesJSON string) ports.CypherRow {
 		"target_entity_type":              "github_repo",
 		"target_label":                    "writer/cerebro",
 		"acted_attributes_json":           actedAttributesJSON,
-		"okta_identity_attributes_json":   recent,
-		"github_identity_attributes_json": recent,
+		"okta_identity_attributes_json":   recentEmail,
+		"github_identity_attributes_json": recentEmail,
 	}}
 }
 
@@ -414,5 +450,82 @@ func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsSkipsUnstampedIdentifierEd
 	}
 	if len(findings) != 0 {
 		t.Fatalf("EvaluateRows() returned %d findings for legacy identifier edges without `at`, want 0", len(findings))
+	}
+}
+
+// The projector emits a represents_identity edge for every identifier value,
+// including raw GitHub usernames where match_type=login is stamped at
+// confidence=0.60. Two unrelated people who happen to share a username
+// (e.g. okta login "alice" vs github login "alice") would otherwise satisfy
+// the rule's cypher join through the shared identity:login node and produce
+// a CRITICAL false positive against an unrelated GitHub account. The rule
+// must require the identifier match on BOTH sides to be email-based
+// (exact_email/extracted_email), even when both edges are recent.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsRejectsLoginOnlyMatch(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	loginAttrs := deprovisionedOktaRuleLoginIdentityAttrs(time.Now().UTC().Add(-1 * time.Hour))
+	row := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour)))
+	row.Values["identity_urn"] = "urn:cerebro:writer:identity:login:alice"
+	row.Values["identity_label"] = "alice"
+	row.Values["okta_identity_attributes_json"] = loginAttrs
+	row.Values["github_identity_attributes_json"] = loginAttrs
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings for login-only identifier match, want 0; username collision must not produce a CRITICAL finding", len(findings))
+	}
+}
+
+// Asymmetric variant: one side is a high-confidence email match, the other a
+// login. That is still not enough — the join only proves account ownership
+// when both endpoints anchor on a shared email, so a single login leg breaks
+// the proof and the rule must refuse to fire.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsRejectsLoginOnOktaSide(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	row := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour)))
+	row.Values["okta_identity_attributes_json"] = deprovisionedOktaRuleLoginIdentityAttrs(time.Now().UTC().Add(-1 * time.Hour))
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings when okta-side identifier match is login-only, want 0; both sides must anchor on an email", len(findings))
+	}
+}
+
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsRejectsLoginOnGitHubSide(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	row := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour)))
+	row.Values["github_identity_attributes_json"] = deprovisionedOktaRuleLoginIdentityAttrs(time.Now().UTC().Add(-1 * time.Hour))
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings when github-side identifier match is login-only, want 0; both sides must anchor on an email", len(findings))
+	}
+}
+
+// A GitHub-side extracted_email match (e.g. derived from a noreply email) is a
+// 0.85-confidence email signal — strong enough that the rule should treat it
+// like exact_email and emit. This pins the contract that the email gate covers
+// both email match types, not just exact_email, so the projector's existing
+// extracted_email path does not silently lose findings.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsAcceptsExtractedEmailMatch(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	row := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour)))
+	row.Values["github_identity_attributes_json"] = deprovisionedOktaRuleIdentityAttrs("email", "alice@writer.com", "extracted_email", "0.85", time.Now().UTC().Add(-1*time.Hour))
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings for extracted_email match, want 1; extracted_email is a high-confidence email signal", len(findings))
 	}
 }

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
@@ -1,11 +1,14 @@
 package findings
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func deprovisionedOktaRuleFixedNow() time.Time {
@@ -159,5 +162,134 @@ func TestDeprovisionedOktaActiveGitHubRuleFingerprintSeparatesOktaUsers(t *testi
 	b := rule.buildFinding(runtime, "writer", groupTwo, deprovisionedOktaRuleFixedNow())
 	if a.ID == b.ID {
 		t.Fatalf("two distinct deprovisioned okta users collapsed onto the same finding (id=%q); fingerprint must include okta_user_urn", a.ID)
+	}
+}
+
+func deprovisionedOktaRuleActedAttrs(at time.Time) string {
+	payload := map[string]string{
+		"action":   "git.clone",
+		"event_id": "github-audit-evt",
+	}
+	if !at.IsZero() {
+		payload["at"] = at.UTC().Format(time.RFC3339)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}
+
+func deprovisionedOktaRuleRow(actedAttributesJSON string) ports.CypherRow {
+	return ports.CypherRow{Values: map[string]any{
+		"okta_user_urn":         "urn:cerebro:writer:okta.user:alice@writer.com",
+		"okta_user_label":       "Alice",
+		"okta_attributes_json":  `{"status":"DEPROVISIONED"}`,
+		"identity_urn":          "urn:cerebro:writer:identity:email:alice@writer.com",
+		"identity_label":        "alice@writer.com",
+		"github_user_urn":       "urn:cerebro:writer:github.user:alice",
+		"github_user_label":     "alice",
+		"target_urn":            "urn:cerebro:writer:github_repo:writer/cerebro",
+		"target_entity_type":    "github_repo",
+		"target_label":          "writer/cerebro",
+		"acted_attributes_json": actedAttributesJSON,
+	}}
+}
+
+// Recent acted_on edges are the only source of truth that a deprovisioned identity is
+// "still active" right now. Without this, the rule could only ever say "this user has
+// touched github at some point in history", which is true forever once a single edge
+// exists and would keep findings open indefinitely.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsEmitsForRecentActedOn(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	row := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-1 * time.Hour)))
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1 (recent acted_on must trigger)", len(findings))
+	}
+}
+
+// An edge whose latest action is older than the recency window is stale history,
+// not current access. The previous behavior treated it as proof of activity and
+// kept the finding open even after the GitHub account was suspended; this regression
+// test pins the new contract: stale-only groups produce no finding so the
+// deprovisioning surface auto-resolves once activity stops.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsSkipsStaleActedOn(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	staleAt := time.Now().UTC().Add(-(identityDeprovisionedOktaRecencyWindow + 24*time.Hour))
+	row := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(staleAt))
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings for stale acted_on edge, want 0; rule must require recent activity", len(findings))
+	}
+}
+
+// Acted_on edges projected before the at-stamp change have no `at` attribute at all.
+// We refuse to fire on those rather than papering over them with a synthetic timestamp:
+// the rule cannot prove the activity is recent, so it must not claim "still active".
+// Once the projector backfills, rows reappear with `at` and the rule re-emits naturally.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsSkipsUnstampedActedOn(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	row := deprovisionedOktaRuleRow(`{"action":"git.clone","event_id":"legacy"}`)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings for legacy acted_on edge without `at`, want 0", len(findings))
+	}
+}
+
+// A user can have many acted_on edges where some are recent and some are stale (e.g.
+// touched repo A last week, repo B two years ago). We must still emit the finding,
+// but only attribute it to the recent target(s); reporting the stale target would
+// mislead the responder into thinking the user is still pulling from a repo they
+// haven't touched in years.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsKeepsRecentDropsStaleWithinSameGroup(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	recentRow := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(time.Now().UTC().Add(-2 * time.Hour)))
+	staleAt := time.Now().UTC().Add(-(identityDeprovisionedOktaRecencyWindow + 7*24*time.Hour))
+	staleRow := deprovisionedOktaRuleRow(deprovisionedOktaRuleActedAttrs(staleAt))
+	staleRow.Values["target_urn"] = "urn:cerebro:writer:github_repo:writer/legacy"
+	staleRow.Values["target_label"] = "writer/legacy"
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{recentRow, staleRow})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1 (group has at least one recent target)", len(findings))
+	}
+	finding := findings[0]
+	if got := finding.Attributes["target_count"]; got != "1" {
+		t.Fatalf("target_count = %q, want 1; stale-only target must not be reported", got)
+	}
+	if got := finding.Attributes["target_urns"]; got != "urn:cerebro:writer:github_repo:writer/cerebro" {
+		t.Fatalf("target_urns = %q, want only the recent target", got)
+	}
+}
+
+// A malformed `at` (not RFC3339) is treated the same as a missing one: we cannot
+// prove recency, so we do not fire. This guards against future projector bugs that
+// might write a non-conforming string and silently keep a finding open.
+func TestDeprovisionedOktaActiveGitHubRuleEvaluateRowsSkipsMalformedAt(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
+	row := deprovisionedOktaRuleRow(`{"action":"git.clone","event_id":"weird","at":"yesterday"}`)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings with unparseable `at`, want 0", len(findings))
 	}
 }

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
@@ -86,11 +86,13 @@ func TestDeprovisionedOktaActiveGitHubRuleFingerprintIsStableAcrossRuns(t *testi
 	}
 }
 
-// The persisted runtime_id on graph-rule findings must be a stable synthetic value, not
-// the runtime that happened to trigger this evaluation, because the same fingerprint can
-// be emitted by either an okta or a github runtime and UpsertFinding would otherwise flip
-// the row between them every iteration.
-func TestDeprovisionedOktaActiveGitHubRuleFindingPinsRuntimeID(t *testing.T) {
+// The rule stamps the triggering runtime onto the persisted record so the finding stays
+// addressable through the real runtime-scoped read paths (Service.ListFindings, ListEvidence,
+// reports, GRC). The store pins runtime_id on first insert via UpsertFinding's ON CONFLICT
+// clause, so the row does not flip when both Okta and GitHub triggers reevaluate the same
+// offender; that behavior is exercised in the postgres store tests. Here we just assert
+// the rule's contract: stamp the real triggering runtime, never a synthetic value.
+func TestDeprovisionedOktaActiveGitHubRuleFindingStampsTriggeringRuntimeID(t *testing.T) {
 	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
 	group := &deprovisionedOktaGroup{
 		oktaUserURN:   "urn:cerebro:writer:okta.user:alice@writer.com",
@@ -99,11 +101,16 @@ func TestDeprovisionedOktaActiveGitHubRuleFindingPinsRuntimeID(t *testing.T) {
 	}
 	oktaTriggered := rule.buildFinding(&cerebrov1.SourceRuntime{Id: "writer-okta-inventory", SourceId: "okta", TenantId: "writer"}, "writer", group, deprovisionedOktaRuleFixedNow())
 	githubTriggered := rule.buildFinding(&cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}, "writer", group, deprovisionedOktaRuleFixedNow())
-	if got := oktaTriggered.RuntimeID; !strings.HasPrefix(got, GraphRuleRuntimePrefix) {
-		t.Fatalf("RuntimeID = %q, want prefix %q (synthetic graph-rule runtime keeps the row stable across triggering runtimes)", got, GraphRuleRuntimePrefix)
+	if got := oktaTriggered.RuntimeID; got != "writer-okta-inventory" {
+		t.Fatalf("okta-triggered RuntimeID = %q, want real triggering runtime; synthetic ids would make the finding unreachable through runtime-scoped APIs", got)
 	}
-	if oktaTriggered.RuntimeID != githubTriggered.RuntimeID {
-		t.Fatalf("RuntimeID flipped across triggering runtimes (okta=%q github=%q); UpsertFinding would rebind the row each iteration", oktaTriggered.RuntimeID, githubTriggered.RuntimeID)
+	if got := githubTriggered.RuntimeID; got != "writer-github-audit" {
+		t.Fatalf("github-triggered RuntimeID = %q, want real triggering runtime", got)
+	}
+	// Both triggers MUST share the same fingerprint; pinning to first-observed happens at
+	// the store layer so subsequent triggers keep the original runtime instead of flipping.
+	if oktaTriggered.Fingerprint != githubTriggered.Fingerprint {
+		t.Fatalf("fingerprints differ across triggering runtimes (okta=%q github=%q); same offender must produce same id so the store can pin runtime", oktaTriggered.Fingerprint, githubTriggered.Fingerprint)
 	}
 	if got := oktaTriggered.Attributes["source_runtime_id"]; got != "writer-okta-inventory" {
 		t.Fatalf("attributes[source_runtime_id] = %q, want triggering runtime preserved for telemetry", got)

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
@@ -12,7 +12,7 @@ func deprovisionedOktaRuleFixedNow() time.Time {
 	return time.Date(2025, time.March, 5, 12, 0, 0, 0, time.UTC)
 }
 
-func TestDeprovisionedOktaActiveGitHubRuleQueryScopesByRuntime(t *testing.T) {
+func TestDeprovisionedOktaActiveGitHubRuleQueryScopesByTenant(t *testing.T) {
 	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
 	request := rule.QueryFor(runtime)
@@ -22,36 +22,24 @@ func TestDeprovisionedOktaActiveGitHubRuleQueryScopesByRuntime(t *testing.T) {
 	if got := request.Params["tenant_id"]; got != "writer" {
 		t.Fatalf("Params[tenant_id] = %v, want writer", got)
 	}
-	marker, ok := request.Params["okta_runtime_marker"].(string)
-	if !ok {
-		t.Fatalf("Params[okta_runtime_marker] type = %T, want string", request.Params["okta_runtime_marker"])
+	if _, hasMarker := request.Params["okta_runtime_marker"]; hasMarker {
+		t.Fatalf("Params unexpectedly contained okta_runtime_marker; the okta.user node merges runtime ids across syncs so a marker filter would alias inventory status onto whichever runtime touched the node last")
 	}
-	if !strings.Contains(marker, "writer-okta-prod") {
-		t.Fatalf("Params[okta_runtime_marker] = %q, want to contain runtime id %q", marker, "writer-okta-prod")
+	if strings.Contains(request.Query, "okta_runtime_marker") {
+		t.Fatalf("Query references okta_runtime_marker; rule must be tenant-scoped only:\n%s", request.Query)
 	}
-	if !strings.Contains(marker, "source_runtime_id") {
-		t.Fatalf("Params[okta_runtime_marker] = %q, want to contain attribute key %q", marker, "source_runtime_id")
-	}
-	if !strings.Contains(request.Query, "$okta_runtime_marker") {
-		t.Fatalf("Query missing $okta_runtime_marker predicate; without it findings cross runtimes:\n%s", request.Query)
+	if !strings.Contains(strings.ToUpper(request.Query), `"STATUS":"DEPROVISIONED"`) {
+		t.Fatalf("Query missing deprovisioned status predicate:\n%s", request.Query)
 	}
 	if request.RowLimit != identityDeprovisionedOktaQueryRowLimit {
 		t.Fatalf("RowLimit = %d, want %d", request.RowLimit, identityDeprovisionedOktaQueryRowLimit)
 	}
 }
 
-func TestDeprovisionedOktaActiveGitHubRuleQueryRequiresRuntimeIdentity(t *testing.T) {
+func TestDeprovisionedOktaActiveGitHubRuleQueryRequiresTenant(t *testing.T) {
 	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
-	cases := map[string]*cerebrov1.SourceRuntime{
-		"missing tenant":  {Id: "writer-okta-prod", SourceId: "okta"},
-		"missing runtime": {SourceId: "okta", TenantId: "writer"},
-	}
-	for name, runtime := range cases {
-		t.Run(name, func(t *testing.T) {
-			if request := rule.QueryFor(runtime); request.Query != "" {
-				t.Fatalf("QueryFor(%s) returned populated query; rule must refuse to scan without tenant+runtime: %#v", name, request)
-			}
-		})
+	if request := rule.QueryFor(&cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta"}); request.Query != "" {
+		t.Fatalf("QueryFor() returned populated query without tenant id; rule must refuse to scan: %#v", request)
 	}
 }
 
@@ -73,10 +61,14 @@ func TestDeprovisionedOktaActiveGitHubRuleFingerprintIsStableAcrossRuns(t *testi
 	}
 }
 
-func TestDeprovisionedOktaActiveGitHubRuleFingerprintSeparatesRuntimes(t *testing.T) {
+// Two okta runtimes (e.g. inventory + audit) project to the same okta.user node by
+// (tenant_id, user_id), so the same offender must collapse onto one tenant-scoped finding.
+// Including runtime_id in the fingerprint would split this into duplicates the moment a
+// second okta runtime synced.
+func TestDeprovisionedOktaActiveGitHubRuleFingerprintCollapsesAcrossOktaRuntimes(t *testing.T) {
 	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
-	runtimeA := &cerebrov1.SourceRuntime{Id: "writer-okta-prod", SourceId: "okta", TenantId: "writer"}
-	runtimeB := &cerebrov1.SourceRuntime{Id: "writer-okta-sandbox", SourceId: "okta", TenantId: "writer"}
+	runtimeA := &cerebrov1.SourceRuntime{Id: "writer-okta-inventory", SourceId: "okta", TenantId: "writer"}
+	runtimeB := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"}
 	group := &deprovisionedOktaGroup{
 		oktaUserURN:   "urn:cerebro:writer:okta.user:alice@writer.com",
 		identityURN:   "urn:cerebro:writer:identity:email:alice@writer.com",
@@ -84,10 +76,32 @@ func TestDeprovisionedOktaActiveGitHubRuleFingerprintSeparatesRuntimes(t *testin
 	}
 	a := rule.buildFinding(runtimeA, "writer", group, deprovisionedOktaRuleFixedNow())
 	b := rule.buildFinding(runtimeB, "writer", group, deprovisionedOktaRuleFixedNow())
-	if a.ID == b.ID {
-		t.Fatalf("findings collide across runtimes (id=%q); two okta runtimes touching the same identity must produce distinct finding IDs", a.ID)
+	if a.ID != b.ID {
+		t.Fatalf("findings split across okta runtimes for the same offender (a=%q b=%q); rule is tenant-scoped and must produce one finding per (tenant, okta_user, identity, github_user)", a.ID, b.ID)
 	}
-	if a.Fingerprint == b.Fingerprint {
-		t.Fatalf("fingerprint identical across runtimes: %q", a.Fingerprint)
+	if a.Fingerprint != b.Fingerprint {
+		t.Fatalf("fingerprints split across okta runtimes: %q vs %q", a.Fingerprint, b.Fingerprint)
+	}
+}
+
+func TestDeprovisionedOktaActiveGitHubRuleFingerprintSeparatesOktaUsers(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-inventory", SourceId: "okta", TenantId: "writer"}
+	identityURN := "urn:cerebro:writer:identity:email:shared@writer.com"
+	githubURN := "urn:cerebro:writer:github.user:shared"
+	groupOne := &deprovisionedOktaGroup{
+		oktaUserURN:   "urn:cerebro:writer:okta.user:alice@writer.com",
+		identityURN:   identityURN,
+		githubUserURN: githubURN,
+	}
+	groupTwo := &deprovisionedOktaGroup{
+		oktaUserURN:   "urn:cerebro:writer:okta.user:bob@writer.com",
+		identityURN:   identityURN,
+		githubUserURN: githubURN,
+	}
+	a := rule.buildFinding(runtime, "writer", groupOne, deprovisionedOktaRuleFixedNow())
+	b := rule.buildFinding(runtime, "writer", groupTwo, deprovisionedOktaRuleFixedNow())
+	if a.ID == b.ID {
+		t.Fatalf("two distinct deprovisioned okta users collapsed onto the same finding (id=%q); fingerprint must include okta_user_urn", a.ID)
 	}
 }

--- a/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
+++ b/internal/findings/identity_deprovisioned_okta_active_github_rule_test.go
@@ -86,6 +86,30 @@ func TestDeprovisionedOktaActiveGitHubRuleFingerprintIsStableAcrossRuns(t *testi
 	}
 }
 
+// The persisted runtime_id on graph-rule findings must be a stable synthetic value, not
+// the runtime that happened to trigger this evaluation, because the same fingerprint can
+// be emitted by either an okta or a github runtime and UpsertFinding would otherwise flip
+// the row between them every iteration.
+func TestDeprovisionedOktaActiveGitHubRuleFindingPinsRuntimeID(t *testing.T) {
+	rule := newDeprovisionedOktaActiveGitHubRule().(*deprovisionedOktaActiveGitHubRule)
+	group := &deprovisionedOktaGroup{
+		oktaUserURN:   "urn:cerebro:writer:okta.user:alice@writer.com",
+		identityURN:   "urn:cerebro:writer:identity:email:alice@writer.com",
+		githubUserURN: "urn:cerebro:writer:github.user:alice",
+	}
+	oktaTriggered := rule.buildFinding(&cerebrov1.SourceRuntime{Id: "writer-okta-inventory", SourceId: "okta", TenantId: "writer"}, "writer", group, deprovisionedOktaRuleFixedNow())
+	githubTriggered := rule.buildFinding(&cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}, "writer", group, deprovisionedOktaRuleFixedNow())
+	if got := oktaTriggered.RuntimeID; !strings.HasPrefix(got, GraphRuleRuntimePrefix) {
+		t.Fatalf("RuntimeID = %q, want prefix %q (synthetic graph-rule runtime keeps the row stable across triggering runtimes)", got, GraphRuleRuntimePrefix)
+	}
+	if oktaTriggered.RuntimeID != githubTriggered.RuntimeID {
+		t.Fatalf("RuntimeID flipped across triggering runtimes (okta=%q github=%q); UpsertFinding would rebind the row each iteration", oktaTriggered.RuntimeID, githubTriggered.RuntimeID)
+	}
+	if got := oktaTriggered.Attributes["source_runtime_id"]; got != "writer-okta-inventory" {
+		t.Fatalf("attributes[source_runtime_id] = %q, want triggering runtime preserved for telemetry", got)
+	}
+}
+
 // Two okta runtimes (e.g. inventory + audit) project to the same okta.user node by
 // (tenant_id, user_id), so the same offender must collapse onto one tenant-scoped finding.
 // Including runtime_id in the fingerprint would split this into duplicates the moment a

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -42,6 +42,7 @@ func builtinRulePacks() []RulePack {
 			Description: "Identity platform control-plane findings.",
 			Rules: append([]Rule{
 				newOktaPolicyRuleLifecycleTamperingRule(),
+				newDeprovisionedOktaActiveGitHubRule(),
 			}, newIdentitySignalRules()...),
 		},
 		{

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -769,9 +769,12 @@ func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (R
 		if !rule.SupportsRuntime(runtime) {
 			return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedRuleID)
 		}
+		if _, isGraph := asGraphRule(rule); isGraph {
+			return nil, fmt.Errorf("%w: %s is a graph rule and cannot be evaluated via event replay", ErrRuleUnsupported, trimmedRuleID)
+		}
 		return rule, nil
 	}
-	applicable := s.rules.ForRuntime(runtime)
+	applicable := filterEventDrivenRules(s.rules.ForRuntime(runtime))
 	switch len(applicable) {
 	case 0:
 		return nil, fmt.Errorf("%w: %s", ErrRuleUnavailable, strings.TrimSpace(runtime.GetId()))
@@ -784,7 +787,7 @@ func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (R
 
 func (s *Service) selectRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string) ([]Rule, error) {
 	if len(ruleIDs) == 0 {
-		applicable := s.rules.ForRuntime(runtime)
+		applicable := filterEventDrivenRules(s.rules.ForRuntime(runtime))
 		if len(applicable) == 0 {
 			return nil, fmt.Errorf("%w: %s", ErrRuleUnavailable, strings.TrimSpace(runtime.GetId()))
 		}
@@ -807,6 +810,9 @@ func (s *Service) selectRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string
 		if !rule.SupportsRuntime(runtime) {
 			return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedID)
 		}
+		if _, isGraph := asGraphRule(rule); isGraph {
+			return nil, fmt.Errorf("%w: %s is a graph rule and cannot be evaluated via event replay", ErrRuleUnsupported, trimmedID)
+		}
 		seen[trimmedID] = struct{}{}
 		selected = append(selected, rule)
 	}
@@ -814,6 +820,24 @@ func (s *Service) selectRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string
 		return nil, fmt.Errorf("%w for runtime %q", ErrRuleSelectionRequired, strings.TrimSpace(runtime.GetId()))
 	}
 	return selected, nil
+}
+
+// filterEventDrivenRules excludes graph rules from a rule slice. Graph rules implement Rule
+// only to satisfy the registry contract; their Evaluate() is a no-op because they need a
+// graph cypher query that the event-replay path cannot supply. Including them in the replay
+// pass produces empty completed evaluation runs and duplicates the run record per rule.
+func filterEventDrivenRules(rules []Rule) []Rule {
+	if len(rules) == 0 {
+		return rules
+	}
+	out := make([]Rule, 0, len(rules))
+	for _, rule := range rules {
+		if _, isGraph := asGraphRule(rule); isGraph {
+			continue
+		}
+		out = append(out, rule)
+	}
+	return out
 }
 
 func normalizeEventLimit(limit uint32) uint32 {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -1095,9 +1095,18 @@ func (s *Service) buildFindingEvidence(ctx context.Context, finding *ports.Findi
 	graphRootURNs := uniqueSortedStrings(finding.ResourceURNs)
 	eventIDs := uniqueSortedStrings(finding.EventIDs)
 	createdAt := time.Now().UTC()
+	// Evidence is keyed by the runtime that performed THIS evaluation, not by the runtime
+	// the finding happens to be pinned to. For event rules these are identical because the
+	// fingerprint includes runtime_id. For graph rules the finding's runtime_id is pinned to
+	// the first triggering runtime by UpsertFinding's ON CONFLICT clause, but every
+	// triggering runtime should still record its own evidence so that
+	// `/source-runtimes/{runtime}/finding-evidence?run_id=<runtime-run>` returns rows for
+	// the runtime that produced the run, otherwise the run shows up in evaluation listings
+	// without any matching evidence.
+	evidenceRuntimeID := strings.TrimSpace(run.GetRuntimeId())
 	return &cerebrov1.FindingEvidence{
-		Id:            findingEvidenceID(finding.RuntimeID, finding.ID, run.GetId(), eventIDs),
-		RuntimeId:     strings.TrimSpace(finding.RuntimeID),
+		Id:            findingEvidenceID(evidenceRuntimeID, finding.ID, run.GetId(), eventIDs),
+		RuntimeId:     evidenceRuntimeID,
 		RuleId:        strings.TrimSpace(finding.RuleID),
 		FindingId:     strings.TrimSpace(finding.ID),
 		RunId:         strings.TrimSpace(run.GetId()),

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -215,13 +215,28 @@ func (s *Service) WithAppendLog(appendLog ports.AppendLog) *Service {
 	return s
 }
 
-// ListRules returns the discoverable registered finding rule catalog.
+// ListRules returns the discoverable registered finding rule catalog. Graph rules are hidden
+// from the public catalog: every public evaluation handler (`EvaluateSourceRuntimeRules`,
+// `EvaluateSourceRuntime`) rejects them, so advertising their ids would let clients discover
+// rules they cannot run. Graph rules execute exclusively from the orchestrator hook.
 func (s *Service) ListRules() *cerebrov1.ListFindingRulesResponse {
 	if s == nil || s.rules == nil {
 		return &cerebrov1.ListFindingRulesResponse{}
 	}
+	specs := s.rules.List()
+	publicSpecs := make([]*cerebrov1.RuleSpec, 0, len(specs))
+	for _, spec := range specs {
+		rule, ok := s.rules.Get(spec.GetId())
+		if !ok {
+			continue
+		}
+		if _, isGraph := asGraphRule(rule); isGraph {
+			continue
+		}
+		publicSpecs = append(publicSpecs, spec)
+	}
 	return &cerebrov1.ListFindingRulesResponse{
-		Rules: s.rules.List(),
+		Rules: publicSpecs,
 	}
 }
 

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -901,6 +901,23 @@ func newFindingEvaluationRun(runtimeID string, ruleID string, eventLimit uint32,
 	}
 }
 
+// newGraphFindingEvaluationRun mints a run row for a graph-rule pass. Graph rules
+// evaluate cypher rows over the projected graph and never replay events, so the
+// per-event `EventLimit` does not apply. Persisting the default replay cap of 100
+// here would make Get/ListFindingEvaluationRun advertise misleading metadata for
+// graph runs (as if they were event replays capped at 100), so we leave EventLimit
+// at zero — the proto-default — for callers to interpret as "n/a for graph rule".
+func newGraphFindingEvaluationRun(runtimeID string, ruleID string, startedAt time.Time) *cerebrov1.FindingEvaluationRun {
+	normalizedStartedAt := startedAt.UTC()
+	return &cerebrov1.FindingEvaluationRun{
+		Id:        findingEvaluationRunID(runtimeID, ruleID, normalizedStartedAt),
+		RuntimeId: strings.TrimSpace(runtimeID),
+		RuleId:    strings.TrimSpace(ruleID),
+		Status:    "running",
+		StartedAt: timestamppb.New(normalizedStartedAt),
+	}
+}
+
 var findingEvaluationRunIDReplacer = strings.NewReplacer(" ", "-", "_", "-", "/", "-", ":", "-", ".", "-")
 
 func findingEvaluationRunID(runtimeID string, ruleID string, startedAt time.Time) string {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -200,8 +200,10 @@ func (s *stubFindingStore) LinkFindingTicket(_ context.Context, request ports.Fi
 }
 
 type stubGraphStore struct {
-	entities map[string]*ports.ProjectedEntity
-	links    map[string]*ports.ProjectedLink
+	entities   map[string]*ports.ProjectedEntity
+	links      map[string]*ports.ProjectedLink
+	cypherRows []ports.CypherRow
+	cypherErr  error
 }
 
 func (s *stubGraphStore) Ping(context.Context) error { return nil }
@@ -218,6 +220,13 @@ func (s *stubGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string
 			Label:      entity.Label,
 		},
 	}, nil
+}
+
+func (s *stubGraphStore) ExecuteReadCypher(_ context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	if s.cypherErr != nil {
+		return nil, s.cypherErr
+	}
+	return s.cypherRows, nil
 }
 
 func (s *stubGraphStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -88,6 +88,12 @@ func (s *stubFindingStore) UpsertFinding(_ context.Context, finding *ports.Findi
 	cloned := cloneFinding(finding)
 	if existing, ok := s.findings[cloned.ID]; ok {
 		cloned = preserveFindingWorkflow(existing, cloned)
+		// Mirror the postgres ON CONFLICT clause (`runtime_id = findings.runtime_id`) so
+		// stub-store tests catch regressions in the runtime-pinning contract; without this
+		// the stub would silently let graph-rule findings flip between triggering runtimes.
+		if existingRuntimeID := strings.TrimSpace(existing.RuntimeID); existingRuntimeID != "" {
+			cloned.RuntimeID = existingRuntimeID
+		}
 	}
 	s.findings[cloned.ID] = cloned
 	return cloneFinding(cloned), nil

--- a/internal/graphquery/impact_test.go
+++ b/internal/graphquery/impact_test.go
@@ -24,6 +24,10 @@ func (s *impactStubStore) GetEntityNeighborhood(_ context.Context, rootURN strin
 	return neighborhood, nil
 }
 
+func (s *impactStubStore) ExecuteReadCypher(_ context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	return nil, nil
+}
+
 func TestGetImpactVulnerabilityGroupsCanonicalPackageAssetsAndEvidence(t *testing.T) {
 	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
 	canonicalPackageURN := "urn:cerebro:writer:package:canonical:golang.org/x/crypto"

--- a/internal/graphquery/service_test.go
+++ b/internal/graphquery/service_test.go
@@ -22,6 +22,10 @@ func (s *stubStore) GetEntityNeighborhood(_ context.Context, rootURN string, lim
 	return s.neighborhood, nil
 }
 
+func (s *stubStore) ExecuteReadCypher(_ context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	return nil, nil
+}
+
 func TestGetEntityNeighborhoodNormalizesLimit(t *testing.T) {
 	store := &stubStore{
 		neighborhood: &ports.EntityNeighborhood{

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -548,6 +548,55 @@ ORDER BY neighbor.urn, r.relation LIMIT $limit`, map[string]any{"root_urn": norm
 	return neighborhood, nil
 }
 
+// ExecuteReadCypher runs one bounded read-only Cypher query and returns its rows.
+//
+// The store enforces a row cap to keep graph rules from accidentally pulling unbounded result
+// sets that would stall the orchestrator; callers may request a smaller cap via RowLimit but
+// the absolute upper bound is ports.MaxCypherQueryRows.
+func (s *Store) ExecuteReadCypher(ctx context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	query := strings.TrimSpace(request.Query)
+	if query == "" {
+		return nil, errors.New("cypher query is required")
+	}
+	if err := s.requireConfigured(); err != nil {
+		return nil, err
+	}
+	rowLimit := request.RowLimit
+	if rowLimit <= 0 || rowLimit > ports.MaxCypherQueryRows {
+		rowLimit = ports.MaxCypherQueryRows
+	}
+	var rows []ports.CypherRow
+	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		rows = nil
+		result, err := tx.Run(ctx, query, request.Params)
+		if err != nil {
+			return nil, err
+		}
+		keys, err := result.Keys()
+		if err != nil {
+			return nil, err
+		}
+		for result.Next(ctx) {
+			if len(rows) >= rowLimit {
+				break
+			}
+			record := result.Record()
+			values := make(map[string]any, len(keys))
+			for i, key := range keys {
+				if i >= len(record.Values) {
+					break
+				}
+				values[key] = record.Values[i]
+			}
+			rows = append(rows, ports.CypherRow{Values: values})
+		}
+		return nil, result.Err()
+	}); err != nil {
+		return nil, fmt.Errorf("execute read cypher: %w", err)
+	}
+	return rows, nil
+}
+
 // GetIngestCheckpoint returns one persisted graph ingest checkpoint.
 func (s *Store) GetIngestCheckpoint(ctx context.Context, id string) (IngestCheckpoint, bool, error) {
 	normalizedID := strings.TrimSpace(id)

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	neo4jdriver "github.com/neo4j/neo4j-go-driver/v5/neo4j"
 
@@ -1130,9 +1131,40 @@ func mergeGraphAttributes(existing map[string]string, incoming map[string]string
 		merged[key] = value
 	}
 	for key, value := range incoming {
-		merged[key] = value
+		merged[key] = mergeAttributeValue(key, merged[key], value)
 	}
 	return merged
+}
+
+// mergeAttributeValue lets specific attribute keys override the default
+// last-write-wins merge. The `at` key carries the "most recent observed
+// action" timestamp (RFC3339 UTC) for relations like `acted_on`. Some sources
+// — notably GitHub audit logs — paginate newest-first, so a later batch may
+// replay older pages after newer ones have already landed. Last-write-wins
+// would let that older page silently overwrite the newer timestamp, which
+// would in turn cause the deprovisioned-Okta-active-in-GitHub rule to read
+// the edge as stale and auto-resolve a finding that should still be open.
+// We take chronological max instead so once the edge has seen a recent
+// action, no subsequent older event can pull the timestamp backward.
+func mergeAttributeValue(key, existing, incoming string) string {
+	if key != "at" {
+		return incoming
+	}
+	if strings.TrimSpace(existing) == "" {
+		return incoming
+	}
+	if strings.TrimSpace(incoming) == "" {
+		return existing
+	}
+	existingT, errExisting := time.Parse(time.RFC3339, existing)
+	incomingT, errIncoming := time.Parse(time.RFC3339, incoming)
+	if errExisting != nil || errIncoming != nil {
+		return incoming
+	}
+	if incomingT.Before(existingT) {
+		return existing
+	}
+	return incoming
 }
 
 func decodeGraphAttributes(payload string) (map[string]string, error) {

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -283,6 +283,92 @@ func freePort(t *testing.T) int {
 	return listener.Addr().(*net.TCPAddr).Port
 }
 
+// Some sources (notably GitHub audit) page newest-first and replay each batch
+// sequentially, so an older batch can be merged after a newer one. Last-write-wins
+// would let that older batch overwrite the newer `at` timestamp on a relation,
+// and the deprovisioned-Okta-active-in-GitHub rule's recency check would then read
+// an actively-used edge as stale. mergeGraphAttributes must therefore keep the
+// chronological max for `at`.
+func TestMergeGraphAttributesKeepsLatestAtAcrossOutOfOrderUpserts(t *testing.T) {
+	older := time.Date(2025, time.March, 1, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	newer := time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	cases := []struct {
+		name     string
+		existing map[string]string
+		incoming map[string]string
+		wantAt   string
+	}{
+		{
+			name:     "older incoming after newer existing keeps newer",
+			existing: map[string]string{"at": newer, "action": "git.clone"},
+			incoming: map[string]string{"at": older, "action": "git.fetch"},
+			wantAt:   newer,
+		},
+		{
+			name:     "newer incoming after older existing wins",
+			existing: map[string]string{"at": older, "action": "git.clone"},
+			incoming: map[string]string{"at": newer, "action": "git.push"},
+			wantAt:   newer,
+		},
+		{
+			name:     "missing existing at takes incoming",
+			existing: map[string]string{"action": "git.clone"},
+			incoming: map[string]string{"at": newer, "action": "git.push"},
+			wantAt:   newer,
+		},
+		{
+			name:     "missing incoming at preserves existing",
+			existing: map[string]string{"at": newer, "action": "git.clone"},
+			incoming: map[string]string{"action": "git.push"},
+			wantAt:   newer,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			merged := mergeGraphAttributes(tc.existing, tc.incoming)
+			if got := merged["at"]; got != tc.wantAt {
+				t.Fatalf("merged at = %q, want %q (rule recency check depends on chronological max)", got, tc.wantAt)
+			}
+		})
+	}
+}
+
+// Non-`at` keys must keep the default last-write-wins semantics so the special-
+// case in mergeAttributeValue does not silently change merge behavior elsewhere.
+func TestMergeGraphAttributesKeepsLastWriteWinsForOtherKeys(t *testing.T) {
+	merged := mergeGraphAttributes(
+		map[string]string{"action": "git.clone", "actor": "alice"},
+		map[string]string{"action": "git.push"},
+	)
+	if got, want := merged["action"], "git.push"; got != want {
+		t.Fatalf("merged action = %q, want %q (non-`at` keys must remain last-write-wins)", got, want)
+	}
+	if got, want := merged["actor"], "alice"; got != want {
+		t.Fatalf("merged actor = %q, want %q (existing keys not in incoming must survive)", got, want)
+	}
+}
+
+// If either side carries an unparseable `at` (e.g. a future projector bug or a
+// downgrade from a different format), fall back to last-write-wins so we never
+// crash or silently freeze the timestamp at a malformed value.
+func TestMergeGraphAttributesFallsBackToLastWriteWinsWhenAtUnparseable(t *testing.T) {
+	merged := mergeGraphAttributes(
+		map[string]string{"at": "yesterday"},
+		map[string]string{"at": "2025-03-05T09:00:00Z"},
+	)
+	if got, want := merged["at"], "2025-03-05T09:00:00Z"; got != want {
+		t.Fatalf("merged at = %q, want %q (unparseable existing falls back to incoming)", got, want)
+	}
+	merged = mergeGraphAttributes(
+		map[string]string{"at": "2025-03-05T09:00:00Z"},
+		map[string]string{"at": "tomorrow"},
+	)
+	if got, want := merged["at"], "tomorrow"; got != want {
+		t.Fatalf("merged at = %q, want %q (unparseable incoming wins to avoid freezing)", got, want)
+	}
+}
+
 func waitForStore(t *testing.T, ctx context.Context, cfg config.GraphStoreConfig) *Store {
 	t.Helper()
 	deadline := time.Now().Add(90 * time.Second)

--- a/internal/knowledge/service_test.go
+++ b/internal/knowledge/service_test.go
@@ -32,6 +32,10 @@ func (s *stubGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string
 	return nil, ports.ErrGraphEntityNotFound
 }
 
+func (s *stubGraphStore) ExecuteReadCypher(_ context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	return nil, nil
+}
+
 func (s *stubGraphStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
 	if s.upsertErr != nil {
 		return s.upsertErr

--- a/internal/ports/graphquery.go
+++ b/internal/ports/graphquery.go
@@ -30,8 +30,24 @@ type EntityNeighborhood struct {
 	Relations []*NeighborhoodRelation `json:"relations"`
 }
 
-// GraphQueryStore exposes bounded graph neighborhood reads.
+// CypherRow is one row returned by a read-only Cypher query.
+type CypherRow struct {
+	Values map[string]any
+}
+
+// CypherQueryRequest scopes one read-only graph query call.
+type CypherQueryRequest struct {
+	Query    string
+	Params   map[string]any
+	RowLimit int
+}
+
+// MaxCypherQueryRows caps the number of rows the graph store will return for one read query.
+const MaxCypherQueryRows = 3000
+
+// GraphQueryStore exposes bounded graph neighborhood reads and read-only Cypher.
 type GraphQueryStore interface {
 	GraphStore
 	GetEntityNeighborhood(context.Context, string, int) (*EntityNeighborhood, error)
+	ExecuteReadCypher(context.Context, CypherQueryRequest) ([]CypherRow, error)
 }

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -129,6 +129,10 @@ func (s *stubGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string
 	return cloneNeighborhood(neighborhood), nil
 }
 
+func (s *stubGraphStore) ExecuteReadCypher(_ context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	return nil, nil
+}
+
 type stubReportStore struct {
 	run *cerebrov1.ReportRun
 }

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -131,7 +131,7 @@ func cloudPrivilegePathProjections(event *cerebrov1.EventEnvelope, profile ident
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID), event.GetOccurredAt())
 	}
 	if targetURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -142,7 +142,7 @@ func cloudPrivilegePathProjections(event *cerebrov1.EventEnvelope, profile ident
 			Label:      firstNonEmpty(attributes["target_name"], attributes["resource_name"], targetEmail, targetID),
 			Attributes: map[string]string{"target_id": targetID, "target_type": targetType},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), targetURN, targetEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), targetURN, targetEmail, event.GetOccurredAt())
 	}
 	if subjectURN != "" && targetURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, targetURN, relation, map[string]string{
@@ -181,7 +181,7 @@ func cloudEffectivePermissionProjections(event *cerebrov1.EventEnvelope, profile
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID), event.GetOccurredAt())
 	}
 	if resourceURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -214,9 +214,9 @@ func identityUserProjections(event *cerebrov1.EventEnvelope, profile identityPro
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), userURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, email)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, email, event.GetOccurredAt())
 		if !sameIdentifier(email, login) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, login)
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, login, event.GetOccurredAt())
 		}
 	}
 	return identityProjectionResult(entities, links)
@@ -259,7 +259,7 @@ func identityGroupProjections(event *cerebrov1.EventEnvelope, profile identityPr
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), groupURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), groupURN, groupEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), groupURN, groupEmail, event.GetOccurredAt())
 	}
 	return identityProjectionResult(entities, links)
 }
@@ -307,7 +307,7 @@ func identityGroupMembershipProjections(event *cerebrov1.EventEnvelope, profile 
 				"status":      strings.TrimSpace(attributes["member_status"]),
 			},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), memberURN, memberEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), memberURN, memberEmail, event.GetOccurredAt())
 		if groupURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), memberURN, groupURN, relationMemberOf, map[string]string{
 				"event_id": event.GetId(),
@@ -315,7 +315,7 @@ func identityGroupMembershipProjections(event *cerebrov1.EventEnvelope, profile 
 			}))
 		}
 	}
-	addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), groupURN, firstNonEmpty(attributes["group_email"], attributes["group_id"]))
+	addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), groupURN, firstNonEmpty(attributes["group_email"], attributes["group_id"]), event.GetOccurredAt())
 	return identityProjectionResult(entities, links)
 }
 
@@ -370,7 +370,7 @@ func identityAppAssignmentProjections(event *cerebrov1.EventEnvelope, profile id
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, subjectEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, subjectEmail, event.GetOccurredAt())
 	}
 	if appURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -423,7 +423,7 @@ func identityRoleAssignmentProjections(event *cerebrov1.EventEnvelope, profile i
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: subjectAttributes,
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID), event.GetOccurredAt())
 	}
 	if roleURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -466,7 +466,7 @@ func identityCredentialProjections(event *cerebrov1.EventEnvelope, profile ident
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID))
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID), event.GetOccurredAt())
 	}
 	if credentialURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -507,7 +507,7 @@ func identityAuditProjections(event *cerebrov1.EventEnvelope, profile identityPr
 			Label:      firstNonEmpty(attributes["actor_name"], actorEmail, attributes["actor_id"]),
 			Attributes: map[string]string{"email": actorEmail, "actor_id": strings.TrimSpace(attributes["actor_id"])},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorEmail, event.GetOccurredAt())
 	}
 	if resourceURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
@@ -315,10 +316,20 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 			},
 		})
 		if resourceURN != "" {
-			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, map[string]string{
+			// `at` carries the audit event's OccurredAt timestamp so graph rules can tell
+			// recent GitHub activity from stale historical edges. mergeGraphAttributes is
+			// latest-wins, so under the normal in-order ingestion path this field always
+			// reflects the most recent action that touched the edge. The
+			// deprovisioned-Okta-active-in-GitHub rule uses this to avoid reporting users as
+			// "still active" purely from pre-offboarding history.
+			actedAttrs := map[string]string{
 				"action":   strings.TrimSpace(attributes["action"]),
 				"event_id": event.GetId(),
-			}))
+			}
+			if occurredAt := event.GetOccurredAt(); occurredAt != nil && occurredAt.IsValid() {
+				actedAttrs["at"] = occurredAt.AsTime().UTC().Format(time.RFC3339)
+			}
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, actedAttrs))
 		}
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actor)
 		if !sameIdentifier(actor, actorExternalNameID) {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -221,7 +223,7 @@ func githubPullRequestProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 		if prURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), authorURN, prURN, relationAuthored, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), authorURN, author)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), authorURN, author, event.GetOccurredAt())
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -331,12 +333,12 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 			}
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, actedAttrs))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actor)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actor, event.GetOccurredAt())
 		if !sameIdentifier(actor, actorExternalNameID) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalNameID)
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalNameID, event.GetOccurredAt())
 		}
 		if !sameIdentifier(actor, actorExternalUsername) && !sameIdentifier(actorExternalNameID, actorExternalUsername) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalUsername)
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalUsername, event.GetOccurredAt())
 		}
 	}
 
@@ -353,7 +355,7 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 		if resourceURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, resourceURN, relationTargeted, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), targetURN, targetUser)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), targetURN, targetUser, event.GetOccurredAt())
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -532,9 +534,9 @@ func oktaUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnti
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), userURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, email)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, email, event.GetOccurredAt())
 		if !sameIdentifier(email, login) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, login)
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, login, event.GetOccurredAt())
 		}
 	}
 
@@ -647,7 +649,7 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 				"event_type": strings.TrimSpace(attributes["event_type"]),
 			}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorAlternateID)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorAlternateID, event.GetOccurredAt())
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -712,12 +714,12 @@ func addLink(links map[string]*ports.ProjectedLink, link *ports.ProjectedLink) {
 	links[key] = link
 }
 
-func addIdentifierLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, eventID string, fromURN string, value string) {
+func addIdentifierLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, eventID string, fromURN string, value string, occurredAt *timestamppb.Timestamp) {
 	identifierURN, identifierType, label := identifierURN(tenantID, value)
 	if identifierURN == "" {
 		return
 	}
-	evidenceAttributes := identifierEvidenceAttributes(value, identifierType, label, eventID)
+	evidenceAttributes := identifierEvidenceAttributes(value, identifierType, label, eventID, occurredAt)
 	canonicalIdentityURN, canonicalIdentityType := canonicalIdentityURN(tenantID, value)
 	if canonicalIdentityURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -744,7 +746,7 @@ func addIdentifierLink(entities map[string]*ports.ProjectedEntity, links map[str
 	}
 }
 
-func identifierEvidenceAttributes(rawValue string, identifierType string, normalizedValue string, eventID string) map[string]string {
+func identifierEvidenceAttributes(rawValue string, identifierType string, normalizedValue string, eventID string, occurredAt *timestamppb.Timestamp) map[string]string {
 	matchType := "login"
 	confidence := "0.60"
 	value := strings.TrimSpace(rawValue)
@@ -766,6 +768,17 @@ func identifierEvidenceAttributes(rawValue string, identifierType string, normal
 	}
 	if normalizedEventID := strings.TrimSpace(eventID); normalizedEventID != "" {
 		attributes["source_event_id"] = normalizedEventID
+	}
+	// `at` carries the most recent OccurredAt that re-asserted this identifier
+	// link. Source projection is upsert-only and never retracts old edges, so an
+	// Okta email/login or GitHub external_identity_nameid that has been renamed
+	// would otherwise leave the stale represents_identity edge intact forever
+	// and let identity-aware graph rules keep matching through it. The
+	// chronological-max merge for `at` (see neo4j store mergeAttributeValue)
+	// means rules can scope joins to recently re-observed links and the stale
+	// edge naturally ages out of the window once it stops being refreshed.
+	if occurredAt != nil && occurredAt.IsValid() {
+		attributes["at"] = occurredAt.AsTime().UTC().Format(time.RFC3339)
 	}
 	return attributes
 }

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -534,9 +534,24 @@ func oktaUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnti
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), userURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, email, event.GetOccurredAt())
+		// observedAt is the time this projection ran, not the event's
+		// OccurredAt. okta.user events derive OccurredAt from profile-history
+		// fields (LastUpdated/Created/Activated/StatusChanged/LastLogin/
+		// PasswordChanged) in sources/okta/source.go's userOccurredAt, so any
+		// user whose profile has been static for longer than the graph-rule
+		// recency window would have its represents_identity edges restamped
+		// with an already-stale `at` on every fresh sync. Identity-aware rules
+		// (e.g. the deprovisioned-Okta-active-in-GitHub graph rule) treat
+		// stale-`at` rows as evidence the identifier link is no longer
+		// asserted and drop them, which silently swallows offboarding gaps for
+		// long-static accounts. Stamping with the projection's own clock
+		// instead means any current inventory link is always recent, while
+		// edges that stop being re-asserted (e.g. a renamed email) still age
+		// out naturally because subsequent syncs no longer refresh them.
+		observedAt := timestamppb.New(time.Now().UTC())
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, email, observedAt)
 		if !sameIdentifier(email, login) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, login, event.GetOccurredAt())
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, login, observedAt)
 		}
 	}
 

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -459,6 +459,43 @@ func TestProjectGitHubAuditStampsAtOnActedOn(t *testing.T) {
 	}
 }
 
+// represents_identity edges must also carry the OccurredAt as `at` so identity-
+// aware rules can age out stale identifier links left behind by upsert-only
+// graph ingest. The deprovisioned-Okta-active-in-GitHub rule joins through both
+// the okta-side and github-side represents_identity edges; if either lacks `at`,
+// the rule cannot prove the identifier link is current and refuses to fire.
+func TestProjectGitHubAuditStampsAtOnRepresentsIdentity(t *testing.T) {
+	graph := &projectionRecorder{}
+	occurred := time.Date(2025, time.March, 4, 11, 15, 0, 0, time.UTC)
+	_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "github-audit-represents-identity-at",
+		TenantId:   "writer",
+		SourceId:   "github",
+		Kind:       "github.audit",
+		OccurredAt: timestamppb.New(occurred),
+		Attributes: map[string]string{
+			"actor":         "alice",
+			"action":        "git.clone",
+			"org":           "writer",
+			"repo":          "writer/cerebro",
+			"resource_id":   "writer/cerebro",
+			"resource_type": "repository",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	actorURN := "urn:cerebro:writer:github_user:alice"
+	identityURN := "urn:cerebro:writer:identity:login:alice"
+	link, ok := graph.links[actorURN+"|"+relationRepresentsIdentity+"|"+identityURN]
+	if !ok {
+		t.Fatalf("represents_identity link missing for %s -> %s: %#v", actorURN, identityURN, graph.links)
+	}
+	if got, want := link.Attributes["at"], occurred.Format(time.RFC3339); got != want {
+		t.Fatalf("represents_identity attributes[at] = %q, want %q (rename-stale join filter depends on this)", got, want)
+	}
+}
+
 // TestProjectGitHubAuditOmitsAtWhenOccurredAtMissing covers the legacy contract:
 // historical events backfilled without OccurredAt must not pollute the edge with
 // a placeholder timestamp. The rule reads a missing `at` as "I cannot prove this

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -496,6 +496,61 @@ func TestProjectGitHubAuditStampsAtOnRepresentsIdentity(t *testing.T) {
 	}
 }
 
+// okta.user inventory events derive OccurredAt from profile-history fields
+// (LastUpdated/Created/Activated/StatusChanged/LastLogin/PasswordChanged), so
+// for any user whose profile has been static for longer than the graph-rule
+// recency window the event arrives with an OccurredAt that is already older
+// than that window. Stamping the represents_identity edge with that history
+// timestamp makes a fresh inventory sync look stale to identity-aware rules
+// and silently drops unchanged-but-deprovisioned offenders. The projector
+// therefore stamps okta.user represents_identity edges with the projection's
+// own clock, so any current inventory link is always recent regardless of
+// when the user's profile was last edited.
+func TestProjectOktaUserStampsObservationTimeOnRepresentsIdentity(t *testing.T) {
+	graph := &projectionRecorder{}
+	historicalProfileEdit := time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Now().UTC()
+	_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "okta-user-stale-profile",
+		TenantId:   "writer",
+		SourceId:   "okta",
+		Kind:       "okta.user",
+		OccurredAt: timestamppb.New(historicalProfileEdit),
+		Attributes: map[string]string{
+			"domain":  "writer.okta.com",
+			"email":   "alice@writer.com",
+			"login":   "alice@writer.com",
+			"status":  "DEPROVISIONED",
+			"user_id": "00u1",
+		},
+	})
+	after := time.Now().UTC()
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	userURN := "urn:cerebro:writer:okta_user:00u1"
+	identityURN := "urn:cerebro:writer:identity:email:alice@writer.com"
+	link, ok := graph.links[userURN+"|"+relationRepresentsIdentity+"|"+identityURN]
+	if !ok {
+		t.Fatalf("represents_identity link missing for %s -> %s: %#v", userURN, identityURN, graph.links)
+	}
+	raw, present := link.Attributes["at"]
+	if !present || raw == "" {
+		t.Fatalf("represents_identity attributes[at] missing; rule needs observation time to age out renamed identifier links")
+	}
+	stamped, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		t.Fatalf("represents_identity attributes[at] = %q is not RFC3339: %v", raw, err)
+	}
+	if stamped.Equal(historicalProfileEdit) {
+		t.Fatalf("represents_identity attributes[at] = %q matches the historical profile timestamp; sources/okta sets event.OccurredAt from profile fields, so the projector must stamp observation time instead to keep unchanged-but-deprovisioned users in the recency window", raw)
+	}
+	// Allow a small clock-skew margin around the projection call.
+	if stamped.Before(before.Add(-time.Second)) || stamped.After(after.Add(time.Second)) {
+		t.Fatalf("represents_identity attributes[at] = %v not within projection window [%v, %v]; expected observation-time stamp", stamped, before, after)
+	}
+}
+
 // TestProjectGitHubAuditOmitsAtWhenOccurredAtMissing covers the legacy contract:
 // historical events backfilled without OccurredAt must not pollute the edge with
 // a placeholder timestamp. The rule reads a missing `at` as "I cannot prove this

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
@@ -412,6 +415,81 @@ func TestProjectGitHubAuditSOTASignalsToGraph(t *testing.T) {
 				t.Fatalf("graph acted_on link missing for %s -> %s: %#v", actorURN, tt.resource, graph.links)
 			}
 		})
+	}
+}
+
+// TestProjectGitHubAuditStampsAtOnActedOn pins the contract that the projector
+// writes the audit event's OccurredAt onto the github acted_on edge. The
+// deprovisioned-Okta-active-in-GitHub rule treats the absence of `at` as
+// "stale or pre-fix history" and refuses to fire on it, so dropping this stamp
+// would cause real, current GitHub activity to look indistinguishable from
+// pre-offboarding history and the rule would silently stop emitting findings.
+func TestProjectGitHubAuditStampsAtOnActedOn(t *testing.T) {
+	graph := &projectionRecorder{}
+	occurred := time.Date(2025, time.March, 4, 10, 30, 0, 0, time.UTC)
+	_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "github-audit-acted-on-at",
+		TenantId:   "writer",
+		SourceId:   "github",
+		Kind:       "github.audit",
+		OccurredAt: timestamppb.New(occurred),
+		Attributes: map[string]string{
+			"actor":         "alice",
+			"action":        "git.clone",
+			"org":           "writer",
+			"repo":          "writer/cerebro",
+			"resource_id":   "writer/cerebro",
+			"resource_type": "repository",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	actorURN := "urn:cerebro:writer:github_user:alice"
+	resourceURN := "urn:cerebro:writer:github_repo:writer/cerebro"
+	link, ok := graph.links[actorURN+"|"+relationActedOn+"|"+resourceURN]
+	if !ok {
+		t.Fatalf("acted_on link missing for %s -> %s: %#v", actorURN, resourceURN, graph.links)
+	}
+	if got, want := link.Attributes["at"], occurred.Format(time.RFC3339); got != want {
+		t.Fatalf("acted_on attributes[at] = %q, want %q (recency window in deprovisioned-okta rule depends on this stamp)", got, want)
+	}
+	if got, want := link.Attributes["action"], "git.clone"; got != want {
+		t.Fatalf("acted_on attributes[action] = %q, want %q (preserving existing payload alongside `at`)", got, want)
+	}
+}
+
+// TestProjectGitHubAuditOmitsAtWhenOccurredAtMissing covers the legacy contract:
+// historical events backfilled without OccurredAt must not pollute the edge with
+// a placeholder timestamp. The rule reads a missing `at` as "I cannot prove this
+// is recent" and skips it; emitting a synthetic `at` would defeat that.
+func TestProjectGitHubAuditOmitsAtWhenOccurredAtMissing(t *testing.T) {
+	graph := &projectionRecorder{}
+	_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-audit-acted-on-no-at",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"actor":         "alice",
+			"action":        "git.clone",
+			"org":           "writer",
+			"repo":          "writer/cerebro",
+			"resource_id":   "writer/cerebro",
+			"resource_type": "repository",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	actorURN := "urn:cerebro:writer:github_user:alice"
+	resourceURN := "urn:cerebro:writer:github_repo:writer/cerebro"
+	link, ok := graph.links[actorURN+"|"+relationActedOn+"|"+resourceURN]
+	if !ok {
+		t.Fatalf("acted_on link missing for %s -> %s: %#v", actorURN, resourceURN, graph.links)
+	}
+	if got, exists := link.Attributes["at"]; exists {
+		t.Fatalf("acted_on attributes[at] = %q present without event OccurredAt; rule must be able to distinguish recent vs unstamped edges", got)
 	}
 }
 

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -70,6 +70,76 @@ var ensureFindingStatements = []string{
 	`CREATE INDEX IF NOT EXISTS findings_tickets_gin_idx ON findings USING GIN (tickets_json)`,
 }
 
+// upsertFindingStatement persists one finding row, preserving runtime_id on conflict.
+//
+// runtime_id is intentionally pinned on first insert. Event-rule fingerprints already include
+// runtime_id, so the same id can never collide across runtimes for them and this clause is a
+// no-op. Graph-rule fingerprints are deliberately tenant-scoped (they omit runtime_id) so the
+// same offender can be emitted by multiple triggering runtimes (e.g. okta inventory and
+// github audit for the deprovisioned-Okta-active-in-GitHub rule); preserving the original
+// runtime keeps the row addressable through the real runtime-scoped read paths
+// (Service.ListFindings, ListEvidence, reports, GRC) instead of flipping it between sources
+// every iteration.
+const upsertFindingStatement = `
+INSERT INTO findings (
+  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
+  resource_urns_json, event_ids_json, observed_policy_ids_json, control_refs_json, notes_json, tickets_json, attributes_json,
+  policy_id, policy_name, check_id, check_name, assignee, due_at, status_reason,
+  status_updated_at, first_observed_at, last_observed_at
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12::jsonb, $13::jsonb, $14::jsonb, $15::jsonb, $16::jsonb, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
+ON CONFLICT (id)
+DO UPDATE SET
+  fingerprint = EXCLUDED.fingerprint,
+  tenant_id = EXCLUDED.tenant_id,
+  runtime_id = findings.runtime_id,
+  rule_id = EXCLUDED.rule_id,
+  title = EXCLUDED.title,
+  severity = EXCLUDED.severity,
+  status = CASE
+    WHEN findings.status IN ('resolved', 'suppressed') AND EXCLUDED.status = 'open' THEN findings.status
+    ELSE EXCLUDED.status
+  END,
+  summary = EXCLUDED.summary,
+  resource_urns_json = EXCLUDED.resource_urns_json,
+  event_ids_json = EXCLUDED.event_ids_json,
+  observed_policy_ids_json = EXCLUDED.observed_policy_ids_json,
+  control_refs_json = EXCLUDED.control_refs_json,
+  notes_json = CASE
+    WHEN jsonb_array_length(EXCLUDED.notes_json) = 0 THEN findings.notes_json
+    ELSE EXCLUDED.notes_json
+  END,
+  tickets_json = CASE
+    WHEN jsonb_array_length(EXCLUDED.tickets_json) = 0 THEN findings.tickets_json
+    ELSE EXCLUDED.tickets_json
+  END,
+  attributes_json = EXCLUDED.attributes_json,
+  policy_id = EXCLUDED.policy_id,
+  policy_name = EXCLUDED.policy_name,
+  check_id = EXCLUDED.check_id,
+  check_name = EXCLUDED.check_name,
+  assignee = CASE
+    WHEN findings.assignee <> '' AND EXCLUDED.assignee = '' THEN findings.assignee
+    ELSE EXCLUDED.assignee
+  END,
+  due_at = COALESCE(EXCLUDED.due_at, findings.due_at),
+  status_reason = CASE
+    WHEN findings.status IN ('resolved', 'suppressed') AND EXCLUDED.status = 'open' THEN findings.status_reason
+    ELSE EXCLUDED.status_reason
+  END,
+  status_updated_at = CASE
+    WHEN findings.status IN ('resolved', 'suppressed') AND EXCLUDED.status = 'open' THEN findings.status_updated_at
+    ELSE EXCLUDED.status_updated_at
+  END,
+  first_observed_at = LEAST(findings.first_observed_at, EXCLUDED.first_observed_at),
+  last_observed_at = GREATEST(findings.last_observed_at, EXCLUDED.last_observed_at),
+  updated_at = NOW()
+RETURNING
+  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
+  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
+  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
+  status_updated_at, first_observed_at, last_observed_at`
+
 // UpsertFinding persists one normalized finding in the current-state store.
 func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord) (*ports.FindingRecord, error) {
 	if finding == nil {
@@ -161,65 +231,7 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord)
 	}
 	firstObservedAt, lastObservedAt := normalizeFindingObservationWindow(finding.FirstObservedAt, finding.LastObservedAt, time.Now().UTC())
 	var stored findingRow
-	if err := s.db.QueryRowContext(ctx, `
-INSERT INTO findings (
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json, event_ids_json, observed_policy_ids_json, control_refs_json, notes_json, tickets_json, attributes_json,
-  policy_id, policy_name, check_id, check_name, assignee, due_at, status_reason,
-  status_updated_at, first_observed_at, last_observed_at
-)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12::jsonb, $13::jsonb, $14::jsonb, $15::jsonb, $16::jsonb, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
-ON CONFLICT (id)
-DO UPDATE SET
-  fingerprint = EXCLUDED.fingerprint,
-  tenant_id = EXCLUDED.tenant_id,
-  runtime_id = EXCLUDED.runtime_id,
-  rule_id = EXCLUDED.rule_id,
-  title = EXCLUDED.title,
-  severity = EXCLUDED.severity,
-  status = CASE
-    WHEN findings.status IN ('resolved', 'suppressed') AND EXCLUDED.status = 'open' THEN findings.status
-    ELSE EXCLUDED.status
-  END,
-  summary = EXCLUDED.summary,
-  resource_urns_json = EXCLUDED.resource_urns_json,
-  event_ids_json = EXCLUDED.event_ids_json,
-  observed_policy_ids_json = EXCLUDED.observed_policy_ids_json,
-  control_refs_json = EXCLUDED.control_refs_json,
-  notes_json = CASE
-    WHEN jsonb_array_length(EXCLUDED.notes_json) = 0 THEN findings.notes_json
-    ELSE EXCLUDED.notes_json
-  END,
-  tickets_json = CASE
-    WHEN jsonb_array_length(EXCLUDED.tickets_json) = 0 THEN findings.tickets_json
-    ELSE EXCLUDED.tickets_json
-  END,
-  attributes_json = EXCLUDED.attributes_json,
-  policy_id = EXCLUDED.policy_id,
-  policy_name = EXCLUDED.policy_name,
-  check_id = EXCLUDED.check_id,
-  check_name = EXCLUDED.check_name,
-  assignee = CASE
-    WHEN findings.assignee <> '' AND EXCLUDED.assignee = '' THEN findings.assignee
-    ELSE EXCLUDED.assignee
-  END,
-  due_at = COALESCE(EXCLUDED.due_at, findings.due_at),
-  status_reason = CASE
-    WHEN findings.status IN ('resolved', 'suppressed') AND EXCLUDED.status = 'open' THEN findings.status_reason
-    ELSE EXCLUDED.status_reason
-  END,
-  status_updated_at = CASE
-    WHEN findings.status IN ('resolved', 'suppressed') AND EXCLUDED.status = 'open' THEN findings.status_updated_at
-    ELSE EXCLUDED.status_updated_at
-  END,
-  first_observed_at = LEAST(findings.first_observed_at, EXCLUDED.first_observed_at),
-  last_observed_at = GREATEST(findings.last_observed_at, EXCLUDED.last_observed_at),
-  updated_at = NOW()
-RETURNING
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
-  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
-  status_updated_at, first_observed_at, last_observed_at`,
+	if err := s.db.QueryRowContext(ctx, upsertFindingStatement,
 		id,
 		fingerprint,
 		tenantID,

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -56,6 +56,7 @@ var ensureFindingStatements = []string{
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS status_reason TEXT NOT NULL DEFAULT ''`,
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS status_updated_at TIMESTAMPTZ`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_rule_idx ON findings (runtime_id, rule_id)`,
+	`CREATE INDEX IF NOT EXISTS findings_tenant_rule_idx ON findings (tenant_id, rule_id)`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_policy_idx ON findings (runtime_id, policy_id)`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_check_idx ON findings (runtime_id, check_id)`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_due_at_idx ON findings (runtime_id, due_at)`,
@@ -295,15 +296,20 @@ func normalizeFindingObservationWindow(firstObservedAt time.Time, lastObservedAt
 	return firstObservedAt, lastObservedAt
 }
 
-// ListFindings loads persisted findings for one tenant/runtime scope.
+// ListFindings loads persisted findings filtered by tenant plus at least one of runtime_id
+// or rule_id. Graph rules need a tenant+rule scope (the projected graph has no per-runtime
+// partition for shared entities like okta.user), while replay-driven callers stay on the
+// indexed (runtime_id, ...) path. Requiring at least one of the two prevents a caller from
+// accidentally issuing a tenant-wide table scan.
 func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequest) (_ []*ports.FindingRecord, err error) {
 	tenantID := strings.TrimSpace(request.TenantID)
 	if tenantID == "" {
 		return nil, errors.New("finding tenant id is required")
 	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
-	if runtimeID == "" {
-		return nil, errors.New("finding runtime id is required")
+	ruleID := strings.TrimSpace(request.RuleID)
+	if runtimeID == "" && ruleID == "" {
+		return nil, errors.New("finding runtime id or rule id is required")
 	}
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
@@ -317,7 +323,7 @@ func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequ
 	}
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("query findings for tenant %q runtime %q: %w", tenantID, runtimeID, err)
+		return nil, fmt.Errorf("query findings for tenant %q runtime %q rule %q: %w", tenantID, runtimeID, ruleID, err)
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil && err == nil {
@@ -772,11 +778,16 @@ func findingListQuery(request ports.ListFindingsRequest) (string, []any, error) 
 		return "", nil, errors.New("finding tenant id is required")
 	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
-	if runtimeID == "" {
-		return "", nil, errors.New("finding runtime id is required")
+	ruleID := strings.TrimSpace(request.RuleID)
+	if runtimeID == "" && ruleID == "" {
+		return "", nil, errors.New("finding runtime id or rule id is required")
 	}
-	clauses := []string{"tenant_id = $1", "runtime_id = $2"}
-	args := []any{tenantID, runtimeID}
+	clauses := []string{"tenant_id = $1"}
+	args := []any{tenantID}
+	if runtimeID != "" {
+		args = append(args, runtimeID)
+		clauses = append(clauses, fmt.Sprintf("runtime_id = $%d", len(args)))
+	}
 	addFindingFilter(&clauses, &args, "id", request.FindingID)
 	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
 	addFindingFilter(&clauses, &args, "severity", request.Severity)

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -82,7 +82,10 @@ func TestListFindingsRejectsMissingTenantID(t *testing.T) {
 	}
 }
 
-func TestListFindingsRejectsMissingRuntimeID(t *testing.T) {
+// ListFindings now requires either runtime_id or rule_id (graph rules query the tenant by
+// rule because the projected graph has no per-runtime partition for shared entities like
+// okta.user). Sending tenant alone would scan the table.
+func TestListFindingsRejectsMissingRuntimeAndRule(t *testing.T) {
 	store := &Store{}
 	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{TenantID: "writer"}); err == nil {
 		t.Fatal("ListFindings() error = nil, want non-nil")
@@ -93,6 +96,22 @@ func TestListFindingsRejectsUnconfiguredStore(t *testing.T) {
 	store := &Store{}
 	if _, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{TenantID: "writer", RuntimeID: "writer-okta-audit"}); err == nil {
 		t.Fatal("ListFindings() error = nil, want non-nil")
+	}
+}
+
+// Graph rules call ListFindings with tenant + rule (no runtime) so the contract must accept
+// that combination; only an unconfigured Store should fail at this point.
+func TestListFindingsAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
+	store := &Store{}
+	_, err := store.ListFindings(context.Background(), ports.ListFindingsRequest{
+		TenantID: "writer",
+		RuleID:   "identity-okta-deprovisioned-active-in-github",
+	})
+	if err == nil {
+		t.Fatal("ListFindings() error = nil, want unconfigured store error")
+	}
+	if got := err.Error(); strings.Contains(got, "runtime id") || strings.Contains(got, "rule id is required") {
+		t.Fatalf("ListFindings() rejected tenant+rule combination: %v", err)
 	}
 }
 
@@ -114,6 +133,35 @@ func TestLinkFindingTicketRejectsEmptyURL(t *testing.T) {
 	store := &Store{}
 	if _, err := store.LinkFindingTicket(context.Background(), ports.FindingTicketLink{FindingID: "finding-1"}); err == nil {
 		t.Fatal("LinkFindingTicket() error = nil, want non-nil")
+	}
+}
+
+func TestFindingListQueryAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
+	query, args, err := findingListQuery(ports.ListFindingsRequest{
+		TenantID: "writer",
+		RuleID:   "identity-okta-deprovisioned-active-in-github",
+		Status:   "open",
+	})
+	if err != nil {
+		t.Fatalf("findingListQuery() error = %v", err)
+	}
+	if !strings.Contains(query, "tenant_id = $1") {
+		t.Fatalf("findingListQuery() missing tenant clause: %s", query)
+	}
+	if strings.Contains(query, "runtime_id = ") {
+		t.Fatalf("findingListQuery() injected runtime_id clause for tenant+rule scope: %s", query)
+	}
+	if !strings.Contains(query, "rule_id = $2") {
+		t.Fatalf("findingListQuery() did not slot rule_id at $2 when runtime is omitted: %s", query)
+	}
+	if !strings.Contains(query, "status = $3") {
+		t.Fatalf("findingListQuery() did not slot status at $3 when runtime is omitted: %s", query)
+	}
+	if got := len(args); got != 3 {
+		t.Fatalf("len(findingListQuery().args) = %d, want 3", got)
+	}
+	if got := args[1]; got != "identity-okta-deprovisioned-active-in-github" {
+		t.Fatalf("findingListQuery().args[1] = %#v, want rule id", got)
 	}
 }
 

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -136,6 +136,22 @@ func TestLinkFindingTicketRejectsEmptyURL(t *testing.T) {
 	}
 }
 
+// runtime_id must be pinned on conflict so the same fingerprint stays addressable on the
+// originally-observed runtime instead of flipping. Event-rule fingerprints already include
+// runtime_id (so the clause is a no-op for them); graph-rule fingerprints are tenant-scoped
+// and the same offender can be emitted by multiple triggering runtimes (okta inventory or
+// github audit for the deprovisioned-Okta-active-in-GitHub rule), so without this pin every
+// reevaluation would rebind runtime_id and per-runtime list/evidence/report/GRC paths would
+// swap the finding in and out under each side.
+func TestUpsertFindingStatementPreservesRuntimeIDOnConflict(t *testing.T) {
+	if !strings.Contains(upsertFindingStatement, "runtime_id = findings.runtime_id") {
+		t.Fatalf("upsertFindingStatement does not preserve runtime_id on conflict; graph-rule findings would flip between triggering runtimes:\n%s", upsertFindingStatement)
+	}
+	if strings.Contains(upsertFindingStatement, "runtime_id = EXCLUDED.runtime_id") {
+		t.Fatalf("upsertFindingStatement still rebinds runtime_id from EXCLUDED on conflict; this would break graph-rule pinning:\n%s", upsertFindingStatement)
+	}
+}
+
 func TestFindingListQueryAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
 	query, args, err := findingListQuery(ports.ListFindingsRequest{
 		TenantID: "writer",


### PR DESCRIPTION
## Summary
Add a graph-rule path so findings can reason over the projected world model rather than only the per-event append log. The orchestrator runs graph rules after each successful graph ingest, so any rule that needs to join state across two source systems (e.g. Okta lifecycle vs GitHub activity) can finally see both sides.

Ship the first rule on this path: **`identity-okta-deprovisioned-active-in-github`** (CRITICAL) fires when an Okta user marked DEPROVISIONED, SUSPENDED, or INACTIVE still has a represents_identity link to a GitHub account that has acted on resources. Stale findings auto-resolve when the row no longer matches in a later evaluation pass.

## What's in here
- **Port**: `ports.CypherRow`, `ports.CypherQueryRequest`, `ports.MaxCypherQueryRows` (3000), `GraphQueryStore.ExecuteReadCypher`.
- **Neo4j store**: bounded read-only Cypher executor (`Store.ExecuteReadCypher`) wrapped in the existing read transaction helper, with hard row cap.
- **Findings service**: `GraphRule` interface (extends `Rule`) plus `Service.EvaluateSourceRuntimeGraphRules` that runs each registered graph rule against one runtime, persists findings + evidence + run, and resolves stale findings whose Cypher rows are gone.
- **Orchestrator**: per-runtime hook after `graphService.RunRuntime` succeeds, with new `graph_rules`, `graph_rule_evaluations`, `graph_rule_findings`, `graph_rule_rows_read` result fields and matching telemetry attrs.
- **Rule #1**: `identity_deprovisioned_okta_active_github_rule.go` (~315 LOC) groups by (oktaURN, identityURN, githubURN), emits one finding per group with target list, fingerprint scoped to `rule_id|tenant|identity_urn|github_user_urn`, control refs SOC2 CC6.2 / ISO 27001 A.5.18 / HIPAA 164.308(a)(3)(ii)(C).

## Tests
- `internal/findings/graph_rule_test.go`: emits/persists, requires graph store, propagates Cypher failure with partial result, selects by RuleID.
- `cmd/cerebro/orchestrator_test.go`: runs graph rules after ingest, skips when ingest fails.
- Stub updates for `GraphQueryStore` consumers across bootstrap, findings, graphquery, knowledge, reports.
- `go test ./...`, `go vet ./...`, `gofmt -l .` all clean.

## Notes for reviewers
- This is the first graph rule on the new pattern; the four other top-priority rules (GitHub SSO bypass, MFA-to-PAT chain, S1 infection on privileged endpoint, fresh Okta admin -> GitHub change) will follow on top of this same scaffolding.
- The Cypher query in Rule #1 is parameterized with `tenant_id` and `runtime_id` and uses an explicit `LIMIT $row_limit`; row cap defends against runaway result sets even if a future tenant graph grows unexpectedly large.
