### PR TITLE
feat(findings): graph rule for shadow GitHub identity (no Okta link)

### DIFF
--- a/internal/findings/identity_github_active_without_okta_link_rule.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule.go
@@ -135,11 +135,12 @@ func (r *githubActiveWithoutOktaLinkRule) Evaluate(_ context.Context, _ *cerebro
 // the answer to "is this GitHub identity bridged to any Okta user?" is the
 // same for any github runtime in the tenant.
 //
-// The cypher OPTIONAL MATCHes a candidate bridge to any okta.user in the
-// same tenant and returns the bridge edges' attributes alongside the github
-// user; EvaluateRows then applies the bridge-recency check in Go. The
-// match-type filter (email-only) used by the deprovisioned-okta-active rule
-// is intentionally NOT applied here: this rule asks "is there *any* fresh
+// The cypher returns ONE row per github user. Both the acted_on targets and
+// the candidate represents_identity bridges are collapsed into list-typed
+// columns via collect(). EvaluateRows then applies the bridge-recency check
+// and the acted_on recency filter on the per-row lists. The match-type
+// filter (email-only) used by the deprovisioned-okta-active rule is
+// intentionally NOT applied here: this rule asks "is there *any* fresh
 // identity bridge?" and surfacing a github user that only shares a username
 // with an okta user is safer to suppress than a coincidental username
 // collision is to report as HIGH. A tighter rule would risk flooding the
@@ -153,6 +154,15 @@ func (r *githubActiveWithoutOktaLinkRule) Evaluate(_ context.Context, _ *cerebro
 // projector therefore stamps every represents_identity edge with an `at`
 // attribute, and EvaluateRows rejects bridges whose `at` is outside the
 // recency window so a stale bridge cannot mask current shadow access.
+//
+// One-row-per-github-user is also a hard requirement for the row limit: a
+// naive (g, target) × candidate-bridge fan-out can consume the entire
+// $row_limit budget on a single prolific account or a user with multiple
+// historical email/login renames, pushing every other shadow github user
+// out of the result set so their findings silently never emit. The graph
+// store does not page truncated reads, only flags them, so collapsing the
+// fan-out at the cypher layer is the only safe way to keep the rule
+// scaling beyond the few-hundred-account regime.
 func (r *githubActiveWithoutOktaLinkRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
 	if runtime == nil {
 		return ports.CypherQueryRequest{}
@@ -162,26 +172,35 @@ func (r *githubActiveWithoutOktaLinkRule) QueryFor(runtime *cerebrov1.SourceRunt
 		return ports.CypherQueryRequest{}
 	}
 	return ports.CypherQueryRequest{
-		// The cypher returns one row per (github_user, target,
-		// optional candidate okta bridge). EvaluateRows applies the
-		// recency filter on both acted_on and the bridge edges, the
-		// bot-account filter, and the per-github-user grouping; we
-		// deliberately do not push the recency check into Cypher so
-		// the filter lives in one place that has unit-test coverage
-		// (the attributes_json fields are opaque on Neo4j).
+		// One row per github user. `targets` carries the collapsed
+		// list of acted_on targets (with the per-edge attributes
+		// JSON for the recency check), and `bridges` carries the
+		// collapsed list of candidate represents_identity bridges,
+		// each preserving the pairing between the github-side and
+		// okta-side edge attributes. EvaluateRows iterates both
+		// lists; we deliberately keep the recency check in Go so
+		// the at-attribute parser lives in one place with unit-test
+		// coverage (the attributes_json values are opaque on Neo4j
+		// pre-5.x without apoc).
 		Query: `MATCH (g:Entity {entity_type: 'github.user', tenant_id: $tenant_id})
-       -[acted:RELATION {relation: 'acted_on'}]->(target:Entity)
+      -[acted:RELATION {relation: 'acted_on'}]->(target:Entity)
+WITH g, collect(DISTINCT {
+       urn: target.urn,
+       entity_type: coalesce(target.entity_type, ''),
+       label: coalesce(target.label, ''),
+       acted_attributes_json: coalesce(acted.attributes_json, '')
+     }) AS targets
 OPTIONAL MATCH (g)-[gi:RELATION {relation: 'represents_identity'}]->(:Entity)
               <-[oi:RELATION {relation: 'represents_identity'}]-(:Entity {entity_type: 'okta.user', tenant_id: $tenant_id})
+WITH g, targets, collect({
+       github_identity_attributes_json: coalesce(gi.attributes_json, ''),
+       okta_identity_attributes_json:   coalesce(oi.attributes_json, '')
+     }) AS bridges
 RETURN g.urn AS github_user_urn,
        g.label AS github_user_label,
        coalesce(g.attributes_json, '') AS github_attributes_json,
-       target.urn AS target_urn,
-       target.entity_type AS target_entity_type,
-       target.label AS target_label,
-       coalesce(acted.attributes_json, '') AS acted_attributes_json,
-       coalesce(gi.attributes_json, '') AS github_identity_attributes_json,
-       coalesce(oi.attributes_json, '') AS okta_identity_attributes_json
+       targets,
+       bridges
 LIMIT $row_limit`,
 		Params: map[string]any{
 			"tenant_id": tenantID,
@@ -217,15 +236,12 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 		if isGitHubBotLogin(githubUserLabel) {
 			continue
 		}
-		// Each row may carry an OPTIONAL MATCH bridge that proves this
-		// github user IS linked to an okta user. We have to evaluate
-		// the bridge BEFORE deciding whether the row's target counts,
-		// because a fresh bridge on any row for this github user
-		// suppresses the entire group regardless of which target row
-		// happened to be observed first. Otherwise a row with no
-		// bridge and a fresh acted_on could create the group, the
-		// group would emit, and a later row carrying the actual fresh
-		// bridge would arrive too late to suppress.
+		// The cypher emits one row per github user; rows for the same
+		// user across multiple ExecuteReadCypher calls are an unusual
+		// case (it can happen if the Go-side caller composes more than
+		// one read), but we still merge defensively into the same
+		// group so the recency contract holds regardless of arrival
+		// shape.
 		group, ok := groups[githubUserURN]
 		if !ok {
 			group = &githubActiveWithoutOktaGroup{
@@ -245,37 +261,47 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 		// longer matches. The projector therefore stamps every
 		// represents_identity edge with an `at` attribute that the latest
 		// source event re-asserted (chronological max under the neo4j
-		// store's mergeAttribute rule); rows whose okta-side AND github-side
-		// identifier link have both been re-observed inside the recency
-		// window are evidence of a current bridge, and we suppress the
-		// group on them. A row with no bridge at all (OPTIONAL MATCH miss)
-		// has empty attributes JSON on both sides and the recency check
-		// returns false, so it cannot suppress.
-		githubIdentityJSON := cypherRowString(row, "github_identity_attributes_json")
-		oktaIdentityJSON := cypherRowString(row, "okta_identity_attributes_json")
-		if edgeIsRecent(githubIdentityJSON, now, identityGitHubActiveWithoutOktaRecencyWindow) &&
-			edgeIsRecent(oktaIdentityJSON, now, identityGitHubActiveWithoutOktaRecencyWindow) {
-			group.hasFreshBridge = true
+		// store's mergeAttribute rule); a bridge whose okta-side AND
+		// github-side identifier link have BOTH been re-observed inside
+		// the recency window is evidence of a current bridge, and we
+		// suppress the group on it.
+		//
+		// We must check the pairing on the SAME bridge candidate: a
+		// fresh github-side edge on bridge A combined with a fresh
+		// okta-side edge on bridge B (a different identity node) is two
+		// stale renamed bridges, not one current bridge.
+		for _, bridge := range cypherRowList(row, "bridges") {
+			githubIdentityJSON := cypherListMapString(bridge, "github_identity_attributes_json")
+			oktaIdentityJSON := cypherListMapString(bridge, "okta_identity_attributes_json")
+			if edgeIsRecent(githubIdentityJSON, now, identityGitHubActiveWithoutOktaRecencyWindow) &&
+				edgeIsRecent(oktaIdentityJSON, now, identityGitHubActiveWithoutOktaRecencyWindow) {
+				group.hasFreshBridge = true
+				break
+			}
 		}
 		// `acted_on` edges projected before the at-stamp change have no
 		// `at`, and any edge whose latest action is older than the recency
-		// window is stale history. Either way, this row is not evidence of
-		// current GitHub access for the unlinked identity, so do not record
-		// it as a target.
-		if !edgeIsRecent(cypherRowString(row, "acted_attributes_json"), now, identityGitHubActiveWithoutOktaRecencyWindow) {
-			continue
-		}
-		targetURN := cypherRowString(row, "target_urn")
-		if targetURN == "" {
-			continue
-		}
-		if _, exists := group.targets[targetURN]; exists {
-			continue
-		}
-		group.targets[targetURN] = githubActiveWithoutOktaTarget{
-			urn:        targetURN,
-			entityType: cypherRowString(row, "target_entity_type"),
-			label:      cypherRowString(row, "target_label"),
+		// window is stale history. Either way, that target is not evidence
+		// of current GitHub access for the unlinked identity, so we skip
+		// it. The targets list is collected from cypher; iterating it here
+		// gives one O(n) pass with the same semantics as the previous
+		// row-per-target form.
+		for _, target := range cypherRowList(row, "targets") {
+			if !edgeIsRecent(cypherListMapString(target, "acted_attributes_json"), now, identityGitHubActiveWithoutOktaRecencyWindow) {
+				continue
+			}
+			targetURN := strings.TrimSpace(cypherListMapString(target, "urn"))
+			if targetURN == "" {
+				continue
+			}
+			if _, exists := group.targets[targetURN]; exists {
+				continue
+			}
+			group.targets[targetURN] = githubActiveWithoutOktaTarget{
+				urn:        targetURN,
+				entityType: cypherListMapString(target, "entity_type"),
+				label:      cypherListMapString(target, "label"),
+			}
 		}
 	}
 	sort.Strings(keys)
@@ -296,6 +322,47 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 		findings = append(findings, r.buildFinding(runtime, tenantID, group, now))
 	}
 	return findings, nil
+}
+
+// cypherRowList extracts a list-typed cypher result column. The Neo4j Go
+// driver returns `collect(...)` results as `[]any` whose elements are
+// scalars, maps, or nested lists depending on the projected expression.
+// Returns nil for missing or non-list columns so callers can range over the
+// result safely without nil checks.
+func cypherRowList(row ports.CypherRow, key string) []any {
+	if row.Values == nil {
+		return nil
+	}
+	value, ok := row.Values[key]
+	if !ok || value == nil {
+		return nil
+	}
+	if list, ok := value.([]any); ok {
+		return list
+	}
+	return nil
+}
+
+// cypherListMapString reads a string field from a map literal element of a
+// collected cypher list. Map literal projections (`collect({a: ..., b: ...})`)
+// come back as `map[string]any` from the Neo4j Go driver. The trim mirrors
+// cypherRowString so empty / whitespace-only attributes_json values feed
+// edgeIsRecent the way the row-shaped path used to.
+func cypherListMapString(item any, key string) string {
+	m, ok := item.(map[string]any)
+	if !ok {
+		return ""
+	}
+	value, ok := m[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", typed))
+	}
 }
 
 // isGitHubBotLogin recognises the subset of GitHub login conventions that

--- a/internal/findings/identity_github_active_without_okta_link_rule.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule.go
@@ -1,0 +1,366 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var _ GraphRule = (*githubActiveWithoutOktaLinkRule)(nil)
+
+const (
+	identityGitHubActiveWithoutOktaLinkRuleID    = "identity-github-active-without-okta-link"
+	identityGitHubActiveWithoutOktaLinkKind      = "finding.identity_github_active_without_okta_link"
+	identityGitHubActiveWithoutOktaQueryRowLimit = 500
+	// identityGitHubActiveWithoutOktaRecencyWindow scopes "still active in
+	// GitHub" to recent activity. acted_on edges carry an `at` attribute
+	// stamped from the audit event's OccurredAt; rows whose latest `at` is
+	// older than this window, or that pre-date the at-stamping projector
+	// change and have no `at` at all, are treated as stale history rather
+	// than current access. Without this, a single historical commit would
+	// hold the finding open indefinitely.
+	identityGitHubActiveWithoutOktaRecencyWindow = 30 * 24 * time.Hour
+)
+
+// githubActiveWithoutOktaLinkRule fires when a GitHub identity is currently active
+// against repositories or organization resources but has no represents_identity
+// path back to an Okta user in the same tenant. Common offenders: personal
+// GitHub accounts that bypass corporate SAML/SSO, accounts created before SSO
+// enforcement that were never linked, or external collaborators whose
+// employment was never reflected in the corporate IdP. The rule runs against
+// the projected graph because no single source-event carries this information:
+// it requires verifying the absence of a cross-source identity bridge.
+type githubActiveWithoutOktaLinkRule struct {
+	definition RuleDefinition
+}
+
+func newGitHubActiveWithoutOktaLinkRule() Rule {
+	return &githubActiveWithoutOktaLinkRule{
+		definition: RuleDefinition{
+			ID:          identityGitHubActiveWithoutOktaLinkRuleID,
+			Name:        "Active GitHub Identity With No Linked Okta Identity",
+			Description: "Detect GitHub accounts acting on repositories or organization resources whose identifiers do not bridge to any Okta user in the same tenant, indicating shadow access that bypasses the corporate IdP.",
+			SourceID:    "github",
+			EventKinds:  []string{"github.audit", "okta.user"},
+			OutputKind:  identityGitHubActiveWithoutOktaLinkKind,
+			Severity:    "HIGH",
+			Status:      findingStatusOpen,
+			Maturity:    "test",
+			Tags: []string{
+				"identity",
+				"shadow-access",
+				"github",
+				"sso-bypass",
+				"graph-rule",
+				"attack.t1078.004",
+			},
+			References: []string{
+				"https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/iam-configuration-reference/saml-configuration-reference",
+				"https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-user-lifecycle.htm",
+			},
+			FalsePositives: []string{
+				"Service or automation account intentionally retained outside Okta with documented exception (e.g. break-glass, deploy bot).",
+				"Recently created GitHub user observed before the next Okta inventory sync; the gap should close inside one sync cycle.",
+				"External contributor not represented in the corporate IdP whose access is governed by repository-level controls.",
+			},
+			Runbook: "Confirm whether the GitHub account belongs to a current employee, link it to the corresponding Okta identity (or onboard the user into Okta), or remove the account's access if it is not authorized.",
+			// The fingerprint is keyed on github_user_urn only. The graph
+			// projector upserts github.user nodes by (tenant_id, login), so
+			// the same offender produces one stable URN regardless of which
+			// runtime ingested the audit event that produced the row. Adding
+			// runtime_id or target_urn would split a single shadow account
+			// into one finding per repo it touched.
+			FingerprintFields: []string{"github_user_urn"},
+			ControlRefs: []ports.FindingControlRef{
+				{FrameworkName: "SOC 2", ControlID: "CC6.2"},
+				{FrameworkName: "SOC 2", ControlID: "CC6.6"},
+				{FrameworkName: "ISO 27001:2022", ControlID: "A.5.16"},
+				{FrameworkName: "ISO 27001:2022", ControlID: "A.5.18"},
+			},
+		},
+	}
+}
+
+func (r *githubActiveWithoutOktaLinkRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return proto.Clone(r.definition.RuleSpec()).(*cerebrov1.RuleSpec)
+}
+
+// SupportsRuntime narrows graph-rule triggers to the runtime families whose
+// ingest can actually change the inputs of this rule's cypher: github
+// family=audit (acted_on edges from github.user) and okta family=user
+// (represents_identity edges from the okta side that determine whether a link
+// to github exists). Accepting unrelated github runtime families would let,
+// say, github.pull_request be the first observer and pin runtime_id onto the
+// persisted record, hiding the finding from `/source-runtimes/{github-audit}/findings`
+// even though the audit runtime is what produced the data.
+func (r *githubActiveWithoutOktaLinkRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	sourceID := strings.ToLower(strings.TrimSpace(runtime.GetSourceId()))
+	family := strings.ToLower(strings.TrimSpace(runtime.GetConfig()["family"]))
+	switch sourceID {
+	case "github":
+		return family == "audit"
+	case "okta":
+		return family == "user"
+	default:
+		return false
+	}
+}
+
+// Evaluate is the event-driven hook required by Rule. Graph rules emit no
+// findings during the per-event replay path; the graph-rule evaluator drives
+// them via EvaluateRows instead.
+func (r *githubActiveWithoutOktaLinkRule) Evaluate(_ context.Context, _ *cerebrov1.SourceRuntime, _ *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+// QueryFor scopes the cypher to the runtime's tenant only. The graph
+// deliberately upserts every github.user node by (tenant_id, login) so audit
+// runtimes share one node with merged attributes; runtime_id on github.user
+// is therefore not a stable partition (the latest event wins via
+// mergeGraphAttributes) and using it as a predicate would alias activity from
+// one audit runtime onto another. The rule is fundamentally tenant-scoped:
+// the answer to "is this GitHub identity bridged to any Okta user?" is the
+// same for any github runtime in the tenant.
+//
+// The NOT EXISTS subquery checks whether ANY okta.user in the same tenant
+// shares an identity node with the github.user. The match-type filter
+// (email-only) used by the deprovisioned-okta-active rule is intentionally
+// NOT applied here: this rule asks "is there *any* identity bridge?" and
+// surfacing a github user that only shares a username with an okta user is
+// safer to suppress than a coincidental username collision is to report. A
+// tighter rule would risk flooding the queue every time a brand new external
+// account showed up in the audit log.
+func (r *githubActiveWithoutOktaLinkRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
+	if runtime == nil {
+		return ports.CypherQueryRequest{}
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return ports.CypherQueryRequest{}
+	}
+	return ports.CypherQueryRequest{
+		// The cypher returns one row per (github_user, target). EvaluateRows
+		// applies the recency filter, the bot-account filter, and the
+		// per-github-user grouping; we deliberately do not push the recency
+		// check into Cypher so the filter lives in one place that has unit-
+		// test coverage (the acted_on attributes JSON is opaque on Neo4j).
+		Query: `MATCH (g:Entity {entity_type: 'github.user', tenant_id: $tenant_id})
+       -[acted:RELATION {relation: 'acted_on'}]->(target:Entity)
+WHERE NOT EXISTS {
+  MATCH (g)-[:RELATION {relation: 'represents_identity'}]->(:Entity)
+        <-[:RELATION {relation: 'represents_identity'}]-(o:Entity {entity_type: 'okta.user', tenant_id: $tenant_id})
+}
+RETURN g.urn AS github_user_urn,
+       g.label AS github_user_label,
+       coalesce(g.attributes_json, '') AS github_attributes_json,
+       target.urn AS target_urn,
+       target.entity_type AS target_entity_type,
+       target.label AS target_label,
+       coalesce(acted.attributes_json, '') AS acted_attributes_json
+LIMIT $row_limit`,
+		Params: map[string]any{
+			"tenant_id": tenantID,
+			"row_limit": int64(identityGitHubActiveWithoutOktaQueryRowLimit),
+		},
+		RowLimit: identityGitHubActiveWithoutOktaQueryRowLimit,
+	}
+}
+
+func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtime *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {
+	if r == nil || runtime == nil || len(rows) == 0 {
+		return nil, nil
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return nil, nil
+	}
+	now := time.Now().UTC()
+	groups := map[string]*githubActiveWithoutOktaGroup{}
+	keys := make([]string, 0)
+	for _, row := range rows {
+		githubUserURN := cypherRowString(row, "github_user_urn")
+		if githubUserURN == "" {
+			continue
+		}
+		targetURN := cypherRowString(row, "target_urn")
+		if targetURN == "" {
+			continue
+		}
+		// Bot logins (dependabot[bot], github-actions[bot], renovate[bot], etc.)
+		// commit and act on resources but are not real human identities. They
+		// will never be in Okta by design, so emitting on them would flood
+		// the queue with non-actionable findings. The check is on the github
+		// user label (which the projector populates from the audit `actor`
+		// field) so it sees the raw login string the audit log carried.
+		githubUserLabel := cypherRowString(row, "github_user_label")
+		if isGitHubBotLogin(githubUserLabel) {
+			continue
+		}
+		// `acted_on` edges projected before the at-stamp change have no `at`,
+		// and any edge whose latest action is older than the recency window
+		// is stale history. Either way, this row is not evidence of current
+		// GitHub access for the unlinked identity, so drop it before it can
+		// pin the group open.
+		if !edgeIsRecent(cypherRowString(row, "acted_attributes_json"), now, identityGitHubActiveWithoutOktaRecencyWindow) {
+			continue
+		}
+		group, ok := groups[githubUserURN]
+		if !ok {
+			group = &githubActiveWithoutOktaGroup{
+				githubUserURN:        githubUserURN,
+				githubUserLabel:      githubUserLabel,
+				githubAttributesJSON: cypherRowString(row, "github_attributes_json"),
+				targets:              map[string]githubActiveWithoutOktaTarget{},
+			}
+			groups[githubUserURN] = group
+			keys = append(keys, githubUserURN)
+		}
+		if _, exists := group.targets[targetURN]; exists {
+			continue
+		}
+		group.targets[targetURN] = githubActiveWithoutOktaTarget{
+			urn:        targetURN,
+			entityType: cypherRowString(row, "target_entity_type"),
+			label:      cypherRowString(row, "target_label"),
+		}
+	}
+	sort.Strings(keys)
+	findings := make([]*ports.FindingRecord, 0, len(keys))
+	for _, key := range keys {
+		group := groups[key]
+		if group == nil || len(group.targets) == 0 {
+			continue
+		}
+		findings = append(findings, r.buildFinding(runtime, tenantID, group, now))
+	}
+	return findings, nil
+}
+
+// isGitHubBotLogin recognises the subset of GitHub login conventions that
+// flag accounts as automation rather than employee identities. These never
+// belong in Okta and would otherwise emit a CRITICAL-volume of false
+// positives every time the audit log records a bot action.
+//
+// The patterns are intentionally narrow: the GitHub Apps convention reserves
+// the `[bot]` suffix for App-issued identities (which is why
+// `dependabot[bot]` and `github-actions[bot]` show up in audit `actor`
+// fields), and the prefix list covers the well-known third-party automation
+// vendors that mint GitHub-App-backed bots (Dependabot, GitHub Actions,
+// Renovate, Mergify, RenovateBot via repo-scoped tokens) without sweeping in
+// arbitrary user logins that happen to start with the same letters.
+func isGitHubBotLogin(login string) bool {
+	trimmed := strings.ToLower(strings.TrimSpace(login))
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasSuffix(trimmed, "[bot]") {
+		return true
+	}
+	switch trimmed {
+	case "dependabot", "github-actions", "renovate", "renovate-bot", "mergify", "mergify-bot":
+		return true
+	}
+	return false
+}
+
+type githubActiveWithoutOktaGroup struct {
+	githubUserURN        string
+	githubUserLabel      string
+	githubAttributesJSON string
+	targets              map[string]githubActiveWithoutOktaTarget
+}
+
+type githubActiveWithoutOktaTarget struct {
+	urn        string
+	entityType string
+	label      string
+}
+
+func (r *githubActiveWithoutOktaLinkRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, group *githubActiveWithoutOktaGroup, now time.Time) *ports.FindingRecord {
+	triggeringRuntimeID := strings.TrimSpace(runtime.GetId())
+	// The fingerprint is keyed on (rule, tenant, github_user) only.
+	//
+	//   * runtime_id is omitted because the graph projects github.user nodes
+	//     by (tenant_id, login), so two github runtimes touching the same
+	//     user share one node and would produce the same fingerprint anyway;
+	//     including runtime_id would split a single tenant-scoped finding
+	//     into duplicates the moment another github audit runtime synced.
+	//     Postgres' UpsertFinding ON CONFLICT pins runtime_id to the first
+	//     observer.
+	//   * target_urn is omitted because one shadow account typically touches
+	//     many resources; the full set of touched targets is preserved in the
+	//     finding attributes for telemetry and used to compose the summary.
+	fingerprint := hashFindingFingerprint(
+		r.definition.ID,
+		tenantID,
+		group.githubUserURN,
+	)
+	resourceURNs := []string{group.githubUserURN}
+	targetURNs := make([]string, 0, len(group.targets))
+	targetLabels := make([]string, 0, len(group.targets))
+	targetTypes := make(map[string]struct{}, len(group.targets))
+	for urn, target := range group.targets {
+		targetURNs = append(targetURNs, urn)
+		if trimmed := strings.TrimSpace(target.label); trimmed != "" {
+			targetLabels = append(targetLabels, trimmed)
+		}
+		if trimmed := strings.TrimSpace(target.entityType); trimmed != "" {
+			targetTypes[trimmed] = struct{}{}
+		}
+	}
+	sort.Strings(targetURNs)
+	sort.Strings(targetLabels)
+	resourceURNs = append(resourceURNs, targetURNs...)
+	primaryGitHubLabel := firstNonEmpty(group.githubUserLabel, group.githubUserURN)
+	summary := fmt.Sprintf(
+		"GitHub identity %s is active in %d resource(s) but is not linked to any Okta user in this tenant",
+		primaryGitHubLabel,
+		len(targetURNs),
+	)
+	attributes := map[string]string{
+		"primary_resource_urn":  group.githubUserURN,
+		"github_user_urn":       group.githubUserURN,
+		"github_user_label":     group.githubUserLabel,
+		"target_count":          fmt.Sprintf("%d", len(targetURNs)),
+		"target_urns":           strings.Join(targetURNs, ","),
+		"target_labels":         strings.Join(targetLabels, ","),
+		"target_entity_types":   strings.Join(sortedKeys(targetTypes), ","),
+		"source_runtime_id":     triggeringRuntimeID,
+		"source_runtime_tenant": tenantID,
+	}
+	for key, value := range r.definition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        tenantID,
+		RuntimeID:       triggeringRuntimeID,
+		RuleID:          r.definition.ID,
+		Title:           r.definition.Name,
+		Severity:        r.definition.Severity,
+		Status:          r.definition.Status,
+		Summary:         summary,
+		ResourceURNs:    deduplicateStrings(resourceURNs),
+		ControlRefs:     cloneFindingControlRefs(r.definition.ControlRefs),
+		Attributes:      attributes,
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+		CheckID:         r.definition.ID,
+		CheckName:       r.definition.Name,
+	}
+}

--- a/internal/findings/identity_github_active_without_okta_link_rule.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule.go
@@ -135,14 +135,24 @@ func (r *githubActiveWithoutOktaLinkRule) Evaluate(_ context.Context, _ *cerebro
 // the answer to "is this GitHub identity bridged to any Okta user?" is the
 // same for any github runtime in the tenant.
 //
-// The NOT EXISTS subquery checks whether ANY okta.user in the same tenant
-// shares an identity node with the github.user. The match-type filter
-// (email-only) used by the deprovisioned-okta-active rule is intentionally
-// NOT applied here: this rule asks "is there *any* identity bridge?" and
-// surfacing a github user that only shares a username with an okta user is
-// safer to suppress than a coincidental username collision is to report. A
-// tighter rule would risk flooding the queue every time a brand new external
-// account showed up in the audit log.
+// The cypher OPTIONAL MATCHes a candidate bridge to any okta.user in the
+// same tenant and returns the bridge edges' attributes alongside the github
+// user; EvaluateRows then applies the bridge-recency check in Go. The
+// match-type filter (email-only) used by the deprovisioned-okta-active rule
+// is intentionally NOT applied here: this rule asks "is there *any* fresh
+// identity bridge?" and surfacing a github user that only shares a username
+// with an okta user is safer to suppress than a coincidental username
+// collision is to report as HIGH. A tighter rule would risk flooding the
+// queue every time a brand new external account showed up in the audit log.
+//
+// We deliberately do NOT use a NOT EXISTS subquery to express the absence
+// check: represents_identity edges are upsert-only and never retracted when
+// an Okta login/email or GitHub external_identity_nameid is renamed, so a
+// stale historical bridge would satisfy NOT EXISTS forever and silently
+// suppress this finding even after the live identity link is gone. The
+// projector therefore stamps every represents_identity edge with an `at`
+// attribute, and EvaluateRows rejects bridges whose `at` is outside the
+// recency window so a stale bridge cannot mask current shadow access.
 func (r *githubActiveWithoutOktaLinkRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
 	if runtime == nil {
 		return ports.CypherQueryRequest{}
@@ -152,24 +162,26 @@ func (r *githubActiveWithoutOktaLinkRule) QueryFor(runtime *cerebrov1.SourceRunt
 		return ports.CypherQueryRequest{}
 	}
 	return ports.CypherQueryRequest{
-		// The cypher returns one row per (github_user, target). EvaluateRows
-		// applies the recency filter, the bot-account filter, and the
-		// per-github-user grouping; we deliberately do not push the recency
-		// check into Cypher so the filter lives in one place that has unit-
-		// test coverage (the acted_on attributes JSON is opaque on Neo4j).
+		// The cypher returns one row per (github_user, target,
+		// optional candidate okta bridge). EvaluateRows applies the
+		// recency filter on both acted_on and the bridge edges, the
+		// bot-account filter, and the per-github-user grouping; we
+		// deliberately do not push the recency check into Cypher so
+		// the filter lives in one place that has unit-test coverage
+		// (the attributes_json fields are opaque on Neo4j).
 		Query: `MATCH (g:Entity {entity_type: 'github.user', tenant_id: $tenant_id})
        -[acted:RELATION {relation: 'acted_on'}]->(target:Entity)
-WHERE NOT EXISTS {
-  MATCH (g)-[:RELATION {relation: 'represents_identity'}]->(:Entity)
-        <-[:RELATION {relation: 'represents_identity'}]-(o:Entity {entity_type: 'okta.user', tenant_id: $tenant_id})
-}
+OPTIONAL MATCH (g)-[gi:RELATION {relation: 'represents_identity'}]->(:Entity)
+              <-[oi:RELATION {relation: 'represents_identity'}]-(:Entity {entity_type: 'okta.user', tenant_id: $tenant_id})
 RETURN g.urn AS github_user_urn,
        g.label AS github_user_label,
        coalesce(g.attributes_json, '') AS github_attributes_json,
        target.urn AS target_urn,
        target.entity_type AS target_entity_type,
        target.label AS target_label,
-       coalesce(acted.attributes_json, '') AS acted_attributes_json
+       coalesce(acted.attributes_json, '') AS acted_attributes_json,
+       coalesce(gi.attributes_json, '') AS github_identity_attributes_json,
+       coalesce(oi.attributes_json, '') AS okta_identity_attributes_json
 LIMIT $row_limit`,
 		Params: map[string]any{
 			"tenant_id": tenantID,
@@ -195,10 +207,6 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 		if githubUserURN == "" {
 			continue
 		}
-		targetURN := cypherRowString(row, "target_urn")
-		if targetURN == "" {
-			continue
-		}
 		// Bot logins (dependabot[bot], github-actions[bot], renovate[bot], etc.)
 		// commit and act on resources but are not real human identities. They
 		// will never be in Okta by design, so emitting on them would flood
@@ -209,14 +217,15 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 		if isGitHubBotLogin(githubUserLabel) {
 			continue
 		}
-		// `acted_on` edges projected before the at-stamp change have no `at`,
-		// and any edge whose latest action is older than the recency window
-		// is stale history. Either way, this row is not evidence of current
-		// GitHub access for the unlinked identity, so drop it before it can
-		// pin the group open.
-		if !edgeIsRecent(cypherRowString(row, "acted_attributes_json"), now, identityGitHubActiveWithoutOktaRecencyWindow) {
-			continue
-		}
+		// Each row may carry an OPTIONAL MATCH bridge that proves this
+		// github user IS linked to an okta user. We have to evaluate
+		// the bridge BEFORE deciding whether the row's target counts,
+		// because a fresh bridge on any row for this github user
+		// suppresses the entire group regardless of which target row
+		// happened to be observed first. Otherwise a row with no
+		// bridge and a fresh acted_on could create the group, the
+		// group would emit, and a later row carrying the actual fresh
+		// bridge would arrive too late to suppress.
 		group, ok := groups[githubUserURN]
 		if !ok {
 			group = &githubActiveWithoutOktaGroup{
@@ -227,6 +236,38 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 			}
 			groups[githubUserURN] = group
 			keys = append(keys, githubUserURN)
+		}
+		// represents_identity edges are upsert-only — graph ingest never
+		// retracts them when an Okta email/login or GitHub
+		// external_identity_nameid is renamed. After a rename, both sides
+		// remain joined to the stale identity node and any join through it
+		// would suppress this finding even though the live identifier no
+		// longer matches. The projector therefore stamps every
+		// represents_identity edge with an `at` attribute that the latest
+		// source event re-asserted (chronological max under the neo4j
+		// store's mergeAttribute rule); rows whose okta-side AND github-side
+		// identifier link have both been re-observed inside the recency
+		// window are evidence of a current bridge, and we suppress the
+		// group on them. A row with no bridge at all (OPTIONAL MATCH miss)
+		// has empty attributes JSON on both sides and the recency check
+		// returns false, so it cannot suppress.
+		githubIdentityJSON := cypherRowString(row, "github_identity_attributes_json")
+		oktaIdentityJSON := cypherRowString(row, "okta_identity_attributes_json")
+		if edgeIsRecent(githubIdentityJSON, now, identityGitHubActiveWithoutOktaRecencyWindow) &&
+			edgeIsRecent(oktaIdentityJSON, now, identityGitHubActiveWithoutOktaRecencyWindow) {
+			group.hasFreshBridge = true
+		}
+		// `acted_on` edges projected before the at-stamp change have no
+		// `at`, and any edge whose latest action is older than the recency
+		// window is stale history. Either way, this row is not evidence of
+		// current GitHub access for the unlinked identity, so do not record
+		// it as a target.
+		if !edgeIsRecent(cypherRowString(row, "acted_attributes_json"), now, identityGitHubActiveWithoutOktaRecencyWindow) {
+			continue
+		}
+		targetURN := cypherRowString(row, "target_urn")
+		if targetURN == "" {
+			continue
 		}
 		if _, exists := group.targets[targetURN]; exists {
 			continue
@@ -242,6 +283,14 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 	for _, key := range keys {
 		group := groups[key]
 		if group == nil || len(group.targets) == 0 {
+			continue
+		}
+		// A current cross-source bridge proves the github user is
+		// linked to an okta user; the rule's premise (shadow access)
+		// no longer applies, so suppress the finding even if the
+		// group accumulated targets. Stale-only bridges leave
+		// hasFreshBridge=false and the group emits as expected.
+		if group.hasFreshBridge {
 			continue
 		}
 		findings = append(findings, r.buildFinding(runtime, tenantID, group, now))
@@ -281,6 +330,14 @@ type githubActiveWithoutOktaGroup struct {
 	githubUserLabel      string
 	githubAttributesJSON string
 	targets              map[string]githubActiveWithoutOktaTarget
+	// hasFreshBridge captures whether ANY row for this github user
+	// carried a represents_identity bridge to an okta.user whose okta-side
+	// AND github-side identifier edges were both re-asserted inside the
+	// recency window. A current bridge proves the github user is linked
+	// to an okta user, so the shadow-access premise no longer applies and
+	// the group is suppressed even if it accumulated targets. Stale-only
+	// bridges leave this false and the finding emits as expected.
+	hasFreshBridge bool
 }
 
 type githubActiveWithoutOktaTarget struct {

--- a/internal/findings/identity_github_active_without_okta_link_rule_test.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule_test.go
@@ -1,0 +1,512 @@
+package findings
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func githubActiveWithoutOktaRuleFixedNow() time.Time {
+	return time.Date(2025, time.March, 5, 12, 0, 0, 0, time.UTC)
+}
+
+func TestGitHubActiveWithoutOktaLinkRuleQueryScopesByTenant(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	request := rule.QueryFor(runtime)
+	if request.Query == "" {
+		t.Fatal("QueryFor() returned empty query for fully-populated runtime")
+	}
+	if got := request.Params["tenant_id"]; got != "writer" {
+		t.Fatalf("Params[tenant_id] = %v, want writer", got)
+	}
+	if !strings.Contains(request.Query, "NOT EXISTS") {
+		t.Fatalf("Query missing NOT EXISTS subquery; the rule must check for *absence* of an okta link, not its presence:\n%s", request.Query)
+	}
+	if !strings.Contains(request.Query, "github.user") {
+		t.Fatalf("Query missing github.user entity type predicate:\n%s", request.Query)
+	}
+	if !strings.Contains(request.Query, "okta.user") {
+		t.Fatalf("Query missing okta.user entity type predicate inside the NOT EXISTS subquery:\n%s", request.Query)
+	}
+	if request.RowLimit != identityGitHubActiveWithoutOktaQueryRowLimit {
+		t.Fatalf("RowLimit = %d, want %d", request.RowLimit, identityGitHubActiveWithoutOktaQueryRowLimit)
+	}
+}
+
+func TestGitHubActiveWithoutOktaLinkRuleQueryRequiresTenant(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	if request := rule.QueryFor(&cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github"}); request.Query != "" {
+		t.Fatalf("QueryFor() returned populated query without tenant id; rule must refuse to scan: %#v", request)
+	}
+}
+
+// The rule's cypher checks GitHub activity against Okta presence, so the
+// finding can change after a fresh ingest from EITHER side. SupportsRuntime
+// must accept both or detections lag until the next time the other source
+// happens to sync.
+func TestGitHubActiveWithoutOktaLinkRuleSupportsBothGitHubAndOkta(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	withFamily := func(sourceID, family string) *cerebrov1.SourceRuntime {
+		return &cerebrov1.SourceRuntime{SourceId: sourceID, Config: map[string]string{"family": family}}
+	}
+	cases := map[string]struct {
+		runtime *cerebrov1.SourceRuntime
+		want    bool
+	}{
+		"github audit runtime":          {withFamily("github", "audit"), true},
+		"okta user runtime":             {withFamily("okta", "user"), true},
+		"GITHUB audit upper case":       {withFamily("GITHUB", "AUDIT"), true},
+		"github pull-request runtime":   {withFamily("github", "pull_request"), false},
+		"github dependabot runtime":     {withFamily("github", "dependabot_alert"), false},
+		"okta audit runtime":            {withFamily("okta", "audit"), false},
+		"okta group runtime":            {withFamily("okta", "group_membership"), false},
+		"okta runtime missing family":   {&cerebrov1.SourceRuntime{SourceId: "okta"}, false},
+		"github runtime missing family": {&cerebrov1.SourceRuntime{SourceId: "github"}, false},
+		"unrelated source":              {withFamily("aws", "iam_user"), false},
+		"empty source":                  {&cerebrov1.SourceRuntime{}, false},
+		"nil runtime":                   {nil, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := rule.SupportsRuntime(tc.runtime); got != tc.want {
+				t.Fatalf("SupportsRuntime() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func githubActiveWithoutOktaRuleGroupWithTargets(targetURNs ...string) *githubActiveWithoutOktaGroup {
+	targets := map[string]githubActiveWithoutOktaTarget{}
+	for _, urn := range targetURNs {
+		targets[urn] = githubActiveWithoutOktaTarget{urn: urn, entityType: "github.repo", label: urn}
+	}
+	return &githubActiveWithoutOktaGroup{
+		githubUserURN:        "urn:cerebro:writer:github.user:alice",
+		githubUserLabel:      "alice",
+		githubAttributesJSON: `{"login":"alice"}`,
+		targets:              targets,
+	}
+}
+
+// The fingerprint is the persistence key for a finding row; if it drifts
+// across runs the same offender produces a fresh CRITICAL/HIGH alert every
+// evaluation cycle instead of reopening the existing one. This pins
+// fingerprint stability for the rule's identity-shaped inputs (rule + tenant
+// + github_user_urn) directly on buildFinding.
+func TestGitHubActiveWithoutOktaLinkRuleFingerprintIsStableAcrossRuns(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	group := githubActiveWithoutOktaRuleGroupWithTargets("urn:cerebro:writer:github_repo:writer/cerebro")
+	first := rule.buildFinding(runtime, "writer", group, githubActiveWithoutOktaRuleFixedNow())
+	second := rule.buildFinding(runtime, "writer", group, githubActiveWithoutOktaRuleFixedNow())
+	if first.ID != second.ID {
+		t.Fatalf("finding ID drifted across evaluations: %q vs %q (fingerprint must hash stable inputs only)", first.ID, second.ID)
+	}
+	if first.Fingerprint != second.Fingerprint {
+		t.Fatalf("finding fingerprint drifted: %q vs %q", first.Fingerprint, second.Fingerprint)
+	}
+}
+
+// The rule stamps the triggering runtime onto the persisted record so the
+// finding stays addressable through the real runtime-scoped read paths
+// (Service.ListFindings, ListEvidence, reports, GRC). The store pins
+// runtime_id on first insert via UpsertFinding's ON CONFLICT clause, so the
+// row does not flip when both GitHub and Okta triggers reevaluate the same
+// offender; that behavior is exercised in the postgres store tests. Here we
+// just assert the rule's contract: stamp the real triggering runtime, never
+// a synthetic value.
+func TestGitHubActiveWithoutOktaLinkRuleFindingStampsTriggeringRuntimeID(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	group := githubActiveWithoutOktaRuleGroupWithTargets("urn:cerebro:writer:github_repo:writer/cerebro")
+	githubTriggered := rule.buildFinding(&cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}, "writer", group, githubActiveWithoutOktaRuleFixedNow())
+	oktaTriggered := rule.buildFinding(&cerebrov1.SourceRuntime{Id: "writer-okta-user", SourceId: "okta", TenantId: "writer"}, "writer", group, githubActiveWithoutOktaRuleFixedNow())
+	if got := githubTriggered.RuntimeID; got != "writer-github-audit" {
+		t.Fatalf("github-triggered RuntimeID = %q, want real triggering runtime; synthetic ids would make the finding unreachable through runtime-scoped APIs", got)
+	}
+	if got := oktaTriggered.RuntimeID; got != "writer-okta-user" {
+		t.Fatalf("okta-triggered RuntimeID = %q, want real triggering runtime", got)
+	}
+	// Both triggers MUST share the same fingerprint; pinning to first-observed
+	// happens at the store layer so subsequent triggers keep the original
+	// runtime instead of flipping.
+	if githubTriggered.Fingerprint != oktaTriggered.Fingerprint {
+		t.Fatalf("fingerprints differ across triggering runtimes (github=%q okta=%q); same offender must produce same id so the store can pin runtime", githubTriggered.Fingerprint, oktaTriggered.Fingerprint)
+	}
+	if got := githubTriggered.Attributes["source_runtime_id"]; got != "writer-github-audit" {
+		t.Fatalf("attributes[source_runtime_id] = %q, want triggering runtime preserved for telemetry", got)
+	}
+}
+
+// Two GitHub audit runtimes (e.g. writer + writerinternal scoped to the same
+// tenant in dev) project to the same github.user node by (tenant_id, login),
+// so the same offender must collapse onto one tenant-scoped finding.
+// Including runtime_id in the fingerprint would split this into duplicates
+// the moment a second github runtime synced.
+func TestGitHubActiveWithoutOktaLinkRuleFingerprintCollapsesAcrossGitHubRuntimes(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtimeA := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	runtimeB := &cerebrov1.SourceRuntime{Id: "writer-github-audit-writerinternal", SourceId: "github", TenantId: "writer"}
+	group := githubActiveWithoutOktaRuleGroupWithTargets("urn:cerebro:writer:github_repo:writer/cerebro")
+	a := rule.buildFinding(runtimeA, "writer", group, githubActiveWithoutOktaRuleFixedNow())
+	b := rule.buildFinding(runtimeB, "writer", group, githubActiveWithoutOktaRuleFixedNow())
+	if a.ID != b.ID {
+		t.Fatalf("findings split across github runtimes for the same offender (a=%q b=%q); rule is tenant-scoped and must produce one finding per (tenant, github_user)", a.ID, b.ID)
+	}
+	if a.Fingerprint != b.Fingerprint {
+		t.Fatalf("fingerprints split across github runtimes: %q vs %q", a.Fingerprint, b.Fingerprint)
+	}
+}
+
+// One shadow GitHub account typically touches many resources. The full set
+// is preserved as telemetry on the finding, but the fingerprint must NOT
+// include target_urn or one shadow account would produce one finding per
+// repo it touched.
+func TestGitHubActiveWithoutOktaLinkRuleFingerprintIgnoresTargetSet(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	oneTarget := githubActiveWithoutOktaRuleGroupWithTargets("urn:cerebro:writer:github_repo:writer/cerebro")
+	threeTargets := githubActiveWithoutOktaRuleGroupWithTargets(
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+		"urn:cerebro:writer:github_repo:writer/palmyra",
+		"urn:cerebro:writer:github_repo:writer/some-other-repo",
+	)
+	first := rule.buildFinding(runtime, "writer", oneTarget, githubActiveWithoutOktaRuleFixedNow())
+	second := rule.buildFinding(runtime, "writer", threeTargets, githubActiveWithoutOktaRuleFixedNow())
+	if first.Fingerprint != second.Fingerprint {
+		t.Fatalf("fingerprint changes with the target set (%q vs %q); the set of touched repos is telemetry, not identity", first.Fingerprint, second.Fingerprint)
+	}
+}
+
+// Two distinct GitHub users must produce two distinct findings or the alert
+// queue would collapse different shadow accounts onto a single row.
+func TestGitHubActiveWithoutOktaLinkRuleFingerprintSeparatesGitHubUsers(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	groupAlice := &githubActiveWithoutOktaGroup{
+		githubUserURN:   "urn:cerebro:writer:github.user:alice",
+		githubUserLabel: "alice",
+		targets:         map[string]githubActiveWithoutOktaTarget{"urn:cerebro:writer:github_repo:writer/cerebro": {urn: "urn:cerebro:writer:github_repo:writer/cerebro"}},
+	}
+	groupBob := &githubActiveWithoutOktaGroup{
+		githubUserURN:   "urn:cerebro:writer:github.user:bob",
+		githubUserLabel: "bob",
+		targets:         map[string]githubActiveWithoutOktaTarget{"urn:cerebro:writer:github_repo:writer/cerebro": {urn: "urn:cerebro:writer:github_repo:writer/cerebro"}},
+	}
+	a := rule.buildFinding(runtime, "writer", groupAlice, githubActiveWithoutOktaRuleFixedNow())
+	b := rule.buildFinding(runtime, "writer", groupBob, githubActiveWithoutOktaRuleFixedNow())
+	if a.ID == b.ID {
+		t.Fatalf("two distinct shadow github users collapsed onto the same finding (id=%q); fingerprint must include github_user_urn", a.ID)
+	}
+}
+
+func githubActiveWithoutOktaRuleActedAttrs(at time.Time) string {
+	payload := map[string]string{
+		"action":   "git.clone",
+		"event_id": "github-audit-evt",
+	}
+	if !at.IsZero() {
+		payload["at"] = at.UTC().Format(time.RFC3339)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
+}
+
+func githubActiveWithoutOktaRuleRow(actedAttributesJSON, githubUserURN, githubUserLabel, targetURN string) ports.CypherRow {
+	return ports.CypherRow{Values: map[string]any{
+		"github_user_urn":        githubUserURN,
+		"github_user_label":      githubUserLabel,
+		"github_attributes_json": `{"login":"` + githubUserLabel + `"}`,
+		"target_urn":             targetURN,
+		"target_entity_type":     "github.repo",
+		"target_label":           "writer/cerebro",
+		"acted_attributes_json":  actedAttributesJSON,
+	}}
+}
+
+// Recent acted_on edges are the only source of truth that an unlinked GitHub
+// identity is "still active" right now. Without this, the rule could only
+// ever say "this user has touched github at some point in history", which
+// is true forever once a single edge exists and would keep findings open
+// indefinitely.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsEmitsForRecentActedOn(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	row := githubActiveWithoutOktaRuleRow(
+		githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-1*time.Hour)),
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1 (recent acted_on must trigger)", len(findings))
+	}
+	got := findings[0]
+	if got.Severity != "HIGH" {
+		t.Fatalf("Severity = %q, want HIGH", got.Severity)
+	}
+	if !strings.Contains(got.Summary, "alice") {
+		t.Fatalf("Summary missing GitHub login; got %q", got.Summary)
+	}
+}
+
+// An edge whose latest action is older than the recency window is stale
+// history, not current access. Without this filter, a single historical
+// commit from before the user offboarded would keep the finding open
+// indefinitely.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsRejectsStaleActedOn(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	row := githubActiveWithoutOktaRuleRow(
+		githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-90*24*time.Hour)),
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 0 (stale acted_on must not trigger)", len(findings))
+	}
+}
+
+// Edges projected before the at-stamp change have no `at` attribute. We
+// cannot prove recency on those rows, so the rule must refuse to fire on
+// them rather than treat absence of evidence as evidence of activity.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsRejectsActedOnWithoutAt(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	row := githubActiveWithoutOktaRuleRow(
+		`{"action":"git.clone","event_id":"github-audit-evt"}`,
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 0 (acted_on without `at` must not trigger; we cannot prove recency)", len(findings))
+	}
+}
+
+// Bot logins (dependabot[bot], github-actions[bot], renovate, etc.) are
+// automation accounts and will never be in Okta by design. Surfacing them as
+// shadow access would flood the queue with non-actionable findings; the rule
+// must filter them at evaluation time.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsSkipsBotLogins(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	rows := []ports.CypherRow{}
+	for _, login := range []string{
+		"dependabot[bot]",
+		"github-actions[bot]",
+		"renovate[bot]",
+		"dependabot",
+		"github-actions",
+		"renovate",
+		"renovate-bot",
+		"mergify[bot]",
+		"DEPENDABOT[BOT]",
+	} {
+		rows = append(rows, githubActiveWithoutOktaRuleRow(
+			githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-1*time.Hour)),
+			"urn:cerebro:writer:github.user:"+strings.ToLower(login),
+			login,
+			"urn:cerebro:writer:github_repo:writer/cerebro",
+		))
+	}
+	findings, err := rule.EvaluateRows(context.Background(), runtime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 0 (bot logins must be filtered)", len(findings))
+	}
+}
+
+// Many real GitHub usernames legitimately look like nothing in particular
+// even though they don't bridge to Okta yet (e.g. external collaborators on
+// a private repo, recent hires whose Okta inventory hasn't synced). The bot
+// filter must NOT swallow human-shaped logins that merely contain a vendor
+// name or look bot-adjacent.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsAcceptsHumanLoginsThatLookBotAdjacent(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	rows := []ports.CypherRow{}
+	humanLogins := []string{"renovate-team-lead", "dependable-alice", "github-actionsperson"}
+	for _, login := range humanLogins {
+		rows = append(rows, githubActiveWithoutOktaRuleRow(
+			githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-1*time.Hour)),
+			"urn:cerebro:writer:github.user:"+login,
+			login,
+			"urn:cerebro:writer:github_repo:writer/cerebro",
+		))
+	}
+	findings, err := rule.EvaluateRows(context.Background(), runtime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != len(humanLogins) {
+		t.Fatalf("EvaluateRows() returned %d findings, want %d (human-shaped logins must NOT be filtered as bots)", len(findings), len(humanLogins))
+	}
+}
+
+// The cypher returns one row per (github_user, target). The same shadow
+// account often touches many resources, so EvaluateRows must collapse them
+// into one finding (with the full target list as telemetry) instead of
+// emitting one finding per repo.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsCollapsesTargetsPerGitHubUser(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	at := time.Now().UTC().Add(-1 * time.Hour)
+	rowOne := githubActiveWithoutOktaRuleRow(
+		githubActiveWithoutOktaRuleActedAttrs(at),
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+	)
+	rowTwo := githubActiveWithoutOktaRuleRow(
+		githubActiveWithoutOktaRuleActedAttrs(at),
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/palmyra",
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{rowOne, rowTwo})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if got := len(findings); got != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1; same github user must collapse across targets", got)
+	}
+	finding := findings[0]
+	if got, want := finding.Attributes["target_count"], "2"; got != want {
+		t.Fatalf("target_count = %q, want %q", got, want)
+	}
+	if got, want := finding.Attributes["target_urns"], "urn:cerebro:writer:github_repo:writer/cerebro,urn:cerebro:writer:github_repo:writer/palmyra"; got != want {
+		t.Fatalf("target_urns = %q, want %q (full set must be retained as telemetry)", got, want)
+	}
+}
+
+// Two different shadow github users must produce two distinct findings,
+// sorted by the github user URN so the output is deterministic and
+// reproducible across runs.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsEmitsDeterministicOrder(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	at := time.Now().UTC().Add(-1 * time.Hour)
+	rowBob := githubActiveWithoutOktaRuleRow(
+		githubActiveWithoutOktaRuleActedAttrs(at),
+		"urn:cerebro:writer:github.user:bob",
+		"bob",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+	)
+	rowAlice := githubActiveWithoutOktaRuleRow(
+		githubActiveWithoutOktaRuleActedAttrs(at),
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{rowBob, rowAlice})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if got := len(findings); got != 2 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 2", got)
+	}
+	if got := findings[0].Attributes["github_user_label"]; got != "alice" {
+		t.Fatalf("findings[0] github_user_label = %q, want alice (output must be sorted by github_user_urn)", got)
+	}
+	if got := findings[1].Attributes["github_user_label"]; got != "bob" {
+		t.Fatalf("findings[1] github_user_label = %q, want bob", got)
+	}
+}
+
+// Empty / missing rows must not produce findings; the rule contract is to
+// emit only on real graph evidence.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsHandlesEmptyAndPartialRows(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	cases := map[string][]ports.CypherRow{
+		"nil rows":                nil,
+		"empty rows":              {},
+		"row missing github user": {{Values: map[string]any{"target_urn": "urn:cerebro:writer:github_repo:writer/cerebro"}}},
+		"row missing target":      {{Values: map[string]any{"github_user_urn": "urn:cerebro:writer:github.user:alice", "github_user_label": "alice"}}},
+	}
+	for name, rows := range cases {
+		t.Run(name, func(t *testing.T) {
+			findings, err := rule.EvaluateRows(context.Background(), runtime, rows)
+			if err != nil {
+				t.Fatalf("EvaluateRows() error = %v", err)
+			}
+			if len(findings) != 0 {
+				t.Fatalf("EvaluateRows() returned %d findings, want 0 for %s", len(findings), name)
+			}
+		})
+	}
+}
+
+// The rule emits no findings when there is no tenant id; the cypher would be
+// empty too, but EvaluateRows defends against being driven directly with
+// rows from a malformed runtime.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsRequiresTenant(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github"}
+	row := githubActiveWithoutOktaRuleRow(
+		githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-1*time.Hour)),
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 0 (no tenant id)", len(findings))
+	}
+}
+
+func TestIsGitHubBotLogin(t *testing.T) {
+	cases := map[string]bool{
+		"dependabot[bot]":      true,
+		"github-actions[bot]":  true,
+		"renovate[bot]":        true,
+		"renovate":             true,
+		"dependabot":           true,
+		"github-actions":       true,
+		"renovate-bot":         true,
+		"mergify":              true,
+		"mergify-bot":          true,
+		"MERGIFY[BOT]":         true,
+		"  dependabot[bot]  ":  true,
+		"":                     false,
+		"alice":                false,
+		"alice-bot-fan":        false,
+		"renovate-team-lead":   false,
+		"dependable-alice":     false,
+		"github-actionsperson": false,
+	}
+	for login, want := range cases {
+		t.Run(login, func(t *testing.T) {
+			if got := isGitHubBotLogin(login); got != want {
+				t.Fatalf("isGitHubBotLogin(%q) = %v, want %v", login, got, want)
+			}
+		})
+	}
+}

--- a/internal/findings/identity_github_active_without_okta_link_rule_test.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule_test.go
@@ -25,14 +25,29 @@ func TestGitHubActiveWithoutOktaLinkRuleQueryScopesByTenant(t *testing.T) {
 	if got := request.Params["tenant_id"]; got != "writer" {
 		t.Fatalf("Params[tenant_id] = %v, want writer", got)
 	}
-	if !strings.Contains(request.Query, "NOT EXISTS") {
-		t.Fatalf("Query missing NOT EXISTS subquery; the rule must check for *absence* of an okta link, not its presence:\n%s", request.Query)
+	// The rule deliberately does NOT use a NOT EXISTS subquery for the
+	// represents_identity bridge: that would treat upsert-only stale
+	// edges as evidence of a current link and silently suppress the
+	// finding after a rename. The cypher must OPTIONAL MATCH the
+	// bridge and surface the edge attributes so EvaluateRows can apply
+	// the recency check.
+	if strings.Contains(request.Query, "NOT EXISTS") {
+		t.Fatalf("Query uses NOT EXISTS for bridge check; stale represents_identity edges would mask shadow access. Must OPTIONAL MATCH and check `at` recency in EvaluateRows:\n%s", request.Query)
+	}
+	if !strings.Contains(request.Query, "OPTIONAL MATCH") {
+		t.Fatalf("Query missing OPTIONAL MATCH for the represents_identity bridge:\n%s", request.Query)
+	}
+	if !strings.Contains(request.Query, "github_identity_attributes_json") {
+		t.Fatalf("Query missing github-side bridge attributes_json projection; EvaluateRows needs it to apply the bridge recency filter:\n%s", request.Query)
+	}
+	if !strings.Contains(request.Query, "okta_identity_attributes_json") {
+		t.Fatalf("Query missing okta-side bridge attributes_json projection; EvaluateRows needs both sides to confirm a fresh bridge:\n%s", request.Query)
 	}
 	if !strings.Contains(request.Query, "github.user") {
 		t.Fatalf("Query missing github.user entity type predicate:\n%s", request.Query)
 	}
 	if !strings.Contains(request.Query, "okta.user") {
-		t.Fatalf("Query missing okta.user entity type predicate inside the NOT EXISTS subquery:\n%s", request.Query)
+		t.Fatalf("Query missing okta.user entity type predicate in the bridge OPTIONAL MATCH:\n%s", request.Query)
 	}
 	if request.RowLimit != identityGitHubActiveWithoutOktaQueryRowLimit {
 		t.Fatalf("RowLimit = %d, want %d", request.RowLimit, identityGitHubActiveWithoutOktaQueryRowLimit)
@@ -221,15 +236,42 @@ func githubActiveWithoutOktaRuleActedAttrs(at time.Time) string {
 }
 
 func githubActiveWithoutOktaRuleRow(actedAttributesJSON, githubUserURN, githubUserLabel, targetURN string) ports.CypherRow {
+	return githubActiveWithoutOktaRuleRowWithBridge(actedAttributesJSON, githubUserURN, githubUserLabel, targetURN, "", "")
+}
+
+// githubActiveWithoutOktaRuleRowWithBridge is the full row builder; tests
+// that exercise the bridge-recency contract use it to inject the
+// represents_identity edge attributes_json on each side. The default
+// helper above passes empty strings on both sides which is exactly what
+// the cypher's OPTIONAL MATCH miss surfaces in production via coalesce(),
+// so existing "no bridge" tests still hit the production code path.
+func githubActiveWithoutOktaRuleRowWithBridge(actedAttributesJSON, githubUserURN, githubUserLabel, targetURN, githubIdentityJSON, oktaIdentityJSON string) ports.CypherRow {
 	return ports.CypherRow{Values: map[string]any{
-		"github_user_urn":        githubUserURN,
-		"github_user_label":      githubUserLabel,
-		"github_attributes_json": `{"login":"` + githubUserLabel + `"}`,
-		"target_urn":             targetURN,
-		"target_entity_type":     "github.repo",
-		"target_label":           "writer/cerebro",
-		"acted_attributes_json":  actedAttributesJSON,
+		"github_user_urn":                 githubUserURN,
+		"github_user_label":               githubUserLabel,
+		"github_attributes_json":          `{"login":"` + githubUserLabel + `"}`,
+		"target_urn":                      targetURN,
+		"target_entity_type":              "github.repo",
+		"target_label":                    "writer/cerebro",
+		"acted_attributes_json":           actedAttributesJSON,
+		"github_identity_attributes_json": githubIdentityJSON,
+		"okta_identity_attributes_json":   oktaIdentityJSON,
 	}}
+}
+
+// githubActiveWithoutOktaRuleBridgeAttrs builds a represents_identity edge's
+// attributes_json with an optional `at` timestamp, matching what the
+// neo4j store persists.
+func githubActiveWithoutOktaRuleBridgeAttrs(at time.Time) string {
+	payload := map[string]string{}
+	if !at.IsZero() {
+		payload["at"] = at.UTC().Format(time.RFC3339)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return string(encoded)
 }
 
 // Recent acted_on edges are the only source of truth that an unlinked GitHub
@@ -479,6 +521,164 @@ func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsRequiresTenant(t *testing.T)
 	}
 	if len(findings) != 0 {
 		t.Fatalf("EvaluateRows() returned %d findings, want 0 (no tenant id)", len(findings))
+	}
+}
+
+// represents_identity edges are upsert-only: the projector never retracts
+// them when an Okta login/email or GitHub external_identity_nameid is
+// renamed. After a rename, both sides remain joined to the obsolete
+// identity node forever. A NOT EXISTS subquery would treat that stale
+// bridge as evidence of a current link and suppress this finding
+// indefinitely. The rule must therefore reject bridges whose `at` is
+// outside the recency window: stale-only bridges leave hasFreshBridge
+// false and the group emits as expected.
+func TestGitHubActiveWithoutOktaLinkRuleStaleBridgeDoesNotSuppress(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	now := time.Now().UTC()
+	staleAt := now.Add(-90 * 24 * time.Hour)
+	row := githubActiveWithoutOktaRuleRowWithBridge(
+		githubActiveWithoutOktaRuleActedAttrs(now.Add(-1*time.Hour)),
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+		githubActiveWithoutOktaRuleBridgeAttrs(staleAt),
+		githubActiveWithoutOktaRuleBridgeAttrs(staleAt),
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1; stale bridge edges must NOT suppress shadow access (otherwise renames would silently mask findings forever)", len(findings))
+	}
+}
+
+// A bridge whose okta-side AND github-side identifier edges have BOTH been
+// re-asserted inside the recency window proves the github user is currently
+// linked to an okta user via fresh identifiers. Shadow-access premise no
+// longer applies, so the group must be suppressed.
+func TestGitHubActiveWithoutOktaLinkRuleFreshBridgeOnBothSidesSuppresses(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	now := time.Now().UTC()
+	freshAt := now.Add(-1 * time.Hour)
+	row := githubActiveWithoutOktaRuleRowWithBridge(
+		githubActiveWithoutOktaRuleActedAttrs(freshAt),
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+		githubActiveWithoutOktaRuleBridgeAttrs(freshAt),
+		githubActiveWithoutOktaRuleBridgeAttrs(freshAt),
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 0; a fresh bridge on both sides proves the github user is linked to an okta user, the rule must suppress", len(findings))
+	}
+}
+
+// One-sided fresh bridges (only the github→identity OR only the okta→identity
+// edge has been re-asserted recently) are NOT proof of a current link: the
+// missing side is exactly the kind of stale upsert this rule defends against.
+// Without requiring both sides, a renamed Okta login that left the okta-side
+// edge frozen would be enough to suppress the finding the moment a fresh
+// github.audit event re-asserted the github-side edge.
+func TestGitHubActiveWithoutOktaLinkRuleOneSidedBridgeDoesNotSuppress(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	now := time.Now().UTC()
+	freshAt := now.Add(-1 * time.Hour)
+	staleAt := now.Add(-90 * 24 * time.Hour)
+	cases := map[string]struct {
+		githubBridgeJSON string
+		oktaBridgeJSON   string
+	}{
+		"only github side fresh": {
+			githubBridgeJSON: githubActiveWithoutOktaRuleBridgeAttrs(freshAt),
+			oktaBridgeJSON:   githubActiveWithoutOktaRuleBridgeAttrs(staleAt),
+		},
+		"only okta side fresh": {
+			githubBridgeJSON: githubActiveWithoutOktaRuleBridgeAttrs(staleAt),
+			oktaBridgeJSON:   githubActiveWithoutOktaRuleBridgeAttrs(freshAt),
+		},
+		"github side fresh, okta side missing at": {
+			githubBridgeJSON: githubActiveWithoutOktaRuleBridgeAttrs(freshAt),
+			oktaBridgeJSON:   `{}`,
+		},
+		"okta side fresh, github side missing at": {
+			githubBridgeJSON: `{}`,
+			oktaBridgeJSON:   githubActiveWithoutOktaRuleBridgeAttrs(freshAt),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			row := githubActiveWithoutOktaRuleRowWithBridge(
+				githubActiveWithoutOktaRuleActedAttrs(freshAt),
+				"urn:cerebro:writer:github.user:alice",
+				"alice",
+				"urn:cerebro:writer:github_repo:writer/cerebro",
+				tc.githubBridgeJSON,
+				tc.oktaBridgeJSON,
+			)
+			findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+			if err != nil {
+				t.Fatalf("EvaluateRows() error = %v", err)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("EvaluateRows() returned %d findings, want 1 for %q; one-sided fresh bridge is not proof of a current link", len(findings), name)
+			}
+		})
+	}
+}
+
+// The cypher returns one row per (github_user, target, candidate okta
+// bridge). A given github user can therefore arrive across multiple rows
+// where some have a bridge and some don't (e.g. the OPTIONAL MATCH miss
+// row + a row that hit the bridge). The order rows are processed in is
+// not stable across runs because Neo4j does not guarantee row order.
+//
+// EvaluateRows must therefore set hasFreshBridge=true if ANY row for the
+// github user carries a fresh bridge, regardless of whether the bridge
+// row arrived first or last. Otherwise, suppression would depend on
+// ordering luck and the same offender would oscillate between "suppressed"
+// and "open" across evaluation cycles.
+func TestGitHubActiveWithoutOktaLinkRuleFreshBridgeArrivesAfterNoBridgeRow(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	now := time.Now().UTC()
+	freshAt := now.Add(-1 * time.Hour)
+	rowNoBridge := githubActiveWithoutOktaRuleRowWithBridge(
+		githubActiveWithoutOktaRuleActedAttrs(freshAt),
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+		"",
+		"",
+	)
+	rowFreshBridge := githubActiveWithoutOktaRuleRowWithBridge(
+		githubActiveWithoutOktaRuleActedAttrs(freshAt),
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		"urn:cerebro:writer:github_repo:writer/palmyra",
+		githubActiveWithoutOktaRuleBridgeAttrs(freshAt),
+		githubActiveWithoutOktaRuleBridgeAttrs(freshAt),
+	)
+	for name, rows := range map[string][]ports.CypherRow{
+		"no-bridge row first":    {rowNoBridge, rowFreshBridge},
+		"fresh-bridge row first": {rowFreshBridge, rowNoBridge},
+	} {
+		t.Run(name, func(t *testing.T) {
+			findings, err := rule.EvaluateRows(context.Background(), runtime, rows)
+			if err != nil {
+				t.Fatalf("EvaluateRows() error = %v", err)
+			}
+			if len(findings) != 0 {
+				t.Fatalf("EvaluateRows() returned %d findings, want 0 for %q; ANY fresh bridge across rows for the same github user must suppress regardless of arrival order", len(findings), name)
+			}
+		})
 	}
 }
 

--- a/internal/findings/identity_github_active_without_okta_link_rule_test.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule_test.go
@@ -49,6 +49,22 @@ func TestGitHubActiveWithoutOktaLinkRuleQueryScopesByTenant(t *testing.T) {
 	if !strings.Contains(request.Query, "okta.user") {
 		t.Fatalf("Query missing okta.user entity type predicate in the bridge OPTIONAL MATCH:\n%s", request.Query)
 	}
+	// Both target and bridge fan-outs MUST be collapsed via collect()
+	// before LIMIT $row_limit clamps the result set. Without the
+	// collapse, a single prolific shadow account or a user with several
+	// renamed identity bridges can consume the entire row budget and
+	// push every other shadow github user out of the result set; the
+	// graph store does not page truncated reads, so the dropped users
+	// would silently never produce findings.
+	if !strings.Contains(request.Query, "collect(") {
+		t.Fatalf("Query missing collect() aggregation; targets and bridges must be collapsed before LIMIT or one prolific user can starve the rest. Query:\n%s", request.Query)
+	}
+	if !strings.Contains(request.Query, "AS targets") {
+		t.Fatalf("Query missing `AS targets` projection (collapsed target list); EvaluateRows iterates the per-row targets list:\n%s", request.Query)
+	}
+	if !strings.Contains(request.Query, "AS bridges") {
+		t.Fatalf("Query missing `AS bridges` projection (collapsed bridge list); EvaluateRows iterates the per-row bridges list:\n%s", request.Query)
+	}
 	if request.RowLimit != identityGitHubActiveWithoutOktaQueryRowLimit {
 		t.Fatalf("RowLimit = %d, want %d", request.RowLimit, identityGitHubActiveWithoutOktaQueryRowLimit)
 	}
@@ -235,27 +251,76 @@ func githubActiveWithoutOktaRuleActedAttrs(at time.Time) string {
 	return string(encoded)
 }
 
+// githubActiveWithoutOktaRuleRow builds the simple single-target single-bridge
+// row used by most tests. The cypher returns one row per github user with
+// `targets` and `bridges` as collected lists; this helper wraps the single
+// scalar values into one-element lists so existing test scenarios (single
+// target, no/single bridge) still exercise the production decode path.
 func githubActiveWithoutOktaRuleRow(actedAttributesJSON, githubUserURN, githubUserLabel, targetURN string) ports.CypherRow {
 	return githubActiveWithoutOktaRuleRowWithBridge(actedAttributesJSON, githubUserURN, githubUserLabel, targetURN, "", "")
 }
 
 // githubActiveWithoutOktaRuleRowWithBridge is the full row builder; tests
 // that exercise the bridge-recency contract use it to inject the
-// represents_identity edge attributes_json on each side. The default
-// helper above passes empty strings on both sides which is exactly what
-// the cypher's OPTIONAL MATCH miss surfaces in production via coalesce(),
-// so existing "no bridge" tests still hit the production code path.
+// represents_identity edge attributes_json on each side. Empty bridge JSON
+// on both sides reproduces the single-element list cypher emits when the
+// OPTIONAL MATCH misses (every coalesce(...) returns ”).
 func githubActiveWithoutOktaRuleRowWithBridge(actedAttributesJSON, githubUserURN, githubUserLabel, targetURN, githubIdentityJSON, oktaIdentityJSON string) ports.CypherRow {
+	return githubActiveWithoutOktaRuleRowFull(
+		githubUserURN,
+		githubUserLabel,
+		[]githubActiveWithoutOktaTestTarget{{
+			urn:                 targetURN,
+			entityType:          "github.repo",
+			label:               "writer/cerebro",
+			actedAttributesJSON: actedAttributesJSON,
+		}},
+		[]githubActiveWithoutOktaTestBridge{{
+			githubIdentityAttributesJSON: githubIdentityJSON,
+			oktaIdentityAttributesJSON:   oktaIdentityJSON,
+		}},
+	)
+}
+
+type githubActiveWithoutOktaTestTarget struct {
+	urn                 string
+	entityType          string
+	label               string
+	actedAttributesJSON string
+}
+
+type githubActiveWithoutOktaTestBridge struct {
+	githubIdentityAttributesJSON string
+	oktaIdentityAttributesJSON   string
+}
+
+// githubActiveWithoutOktaRuleRowFull mirrors what the production cypher
+// returns: one row per github user, with `targets` and `bridges` as
+// `[]any` whose elements are `map[string]any` (the Neo4j Go driver shape
+// for collected map literals).
+func githubActiveWithoutOktaRuleRowFull(githubUserURN, githubUserLabel string, targets []githubActiveWithoutOktaTestTarget, bridges []githubActiveWithoutOktaTestBridge) ports.CypherRow {
+	targetList := make([]any, 0, len(targets))
+	for _, target := range targets {
+		targetList = append(targetList, map[string]any{
+			"urn":                   target.urn,
+			"entity_type":           target.entityType,
+			"label":                 target.label,
+			"acted_attributes_json": target.actedAttributesJSON,
+		})
+	}
+	bridgeList := make([]any, 0, len(bridges))
+	for _, bridge := range bridges {
+		bridgeList = append(bridgeList, map[string]any{
+			"github_identity_attributes_json": bridge.githubIdentityAttributesJSON,
+			"okta_identity_attributes_json":   bridge.oktaIdentityAttributesJSON,
+		})
+	}
 	return ports.CypherRow{Values: map[string]any{
-		"github_user_urn":                 githubUserURN,
-		"github_user_label":               githubUserLabel,
-		"github_attributes_json":          `{"login":"` + githubUserLabel + `"}`,
-		"target_urn":                      targetURN,
-		"target_entity_type":              "github.repo",
-		"target_label":                    "writer/cerebro",
-		"acted_attributes_json":           actedAttributesJSON,
-		"github_identity_attributes_json": githubIdentityJSON,
-		"okta_identity_attributes_json":   oktaIdentityJSON,
+		"github_user_urn":        githubUserURN,
+		"github_user_label":      githubUserLabel,
+		"github_attributes_json": `{"login":"` + githubUserLabel + `"}`,
+		"targets":                targetList,
+		"bridges":                bridgeList,
 	}}
 }
 
@@ -677,6 +742,155 @@ func TestGitHubActiveWithoutOktaLinkRuleFreshBridgeArrivesAfterNoBridgeRow(t *te
 			}
 			if len(findings) != 0 {
 				t.Fatalf("EvaluateRows() returned %d findings, want 0 for %q; ANY fresh bridge across rows for the same github user must suppress regardless of arrival order", len(findings), name)
+			}
+		})
+	}
+}
+
+// The cypher emits ONE row per github user with the targets list collected
+// inside it. EvaluateRows must scan the per-row targets list so a single
+// shadow account that has touched many resources still produces ONE finding
+// with the full target list as telemetry. The list-shaped fan-out is what
+// makes the 500-row LIMIT scale to 500 distinct shadow users instead of
+// being consumed by one prolific account's targets and bridges.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsConsumesTargetsList(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	freshAt := time.Now().UTC().Add(-1 * time.Hour)
+	row := githubActiveWithoutOktaRuleRowFull(
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		[]githubActiveWithoutOktaTestTarget{
+			{urn: "urn:cerebro:writer:github_repo:writer/cerebro", entityType: "github.repo", label: "writer/cerebro", actedAttributesJSON: githubActiveWithoutOktaRuleActedAttrs(freshAt)},
+			{urn: "urn:cerebro:writer:github_repo:writer/palmyra", entityType: "github.repo", label: "writer/palmyra", actedAttributesJSON: githubActiveWithoutOktaRuleActedAttrs(freshAt)},
+			{urn: "urn:cerebro:writer:github_repo:writer/some-other-repo", entityType: "github.repo", label: "writer/some-other-repo", actedAttributesJSON: githubActiveWithoutOktaRuleActedAttrs(freshAt)},
+		},
+		nil,
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if got := len(findings); got != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1; one row per github user with N targets must collapse to ONE finding", got)
+	}
+	finding := findings[0]
+	if got, want := finding.Attributes["target_count"], "3"; got != want {
+		t.Fatalf("target_count = %q, want %q", got, want)
+	}
+	if got, want := finding.Attributes["target_urns"], "urn:cerebro:writer:github_repo:writer/cerebro,urn:cerebro:writer:github_repo:writer/palmyra,urn:cerebro:writer:github_repo:writer/some-other-repo"; got != want {
+		t.Fatalf("target_urns = %q, want %q (full target list must be retained as telemetry)", got, want)
+	}
+}
+
+// Per-target acted_on recency is enforced inside the targets list scan: a
+// row whose targets list mixes fresh and stale entries must only retain
+// the fresh ones. Stale targets are not evidence of current access and
+// must not pin the finding open.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsFiltersStaleTargetsInList(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	now := time.Now().UTC()
+	row := githubActiveWithoutOktaRuleRowFull(
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		[]githubActiveWithoutOktaTestTarget{
+			{urn: "urn:cerebro:writer:github_repo:writer/fresh", entityType: "github.repo", label: "writer/fresh", actedAttributesJSON: githubActiveWithoutOktaRuleActedAttrs(now.Add(-1 * time.Hour))},
+			{urn: "urn:cerebro:writer:github_repo:writer/stale", entityType: "github.repo", label: "writer/stale", actedAttributesJSON: githubActiveWithoutOktaRuleActedAttrs(now.Add(-90 * 24 * time.Hour))},
+			{urn: "urn:cerebro:writer:github_repo:writer/missing-at", entityType: "github.repo", label: "writer/missing-at", actedAttributesJSON: `{"action":"git.clone"}`},
+		},
+		nil,
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if got := len(findings); got != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1", got)
+	}
+	finding := findings[0]
+	if got, want := finding.Attributes["target_count"], "1"; got != want {
+		t.Fatalf("target_count = %q, want %q (only the fresh target should remain)", got, want)
+	}
+	if got, want := finding.Attributes["target_urns"], "urn:cerebro:writer:github_repo:writer/fresh"; got != want {
+		t.Fatalf("target_urns = %q, want %q", got, want)
+	}
+}
+
+// The bridges list can carry multiple candidate bridges (e.g. one per
+// historical email/login). Suppression must trip on ANY bridge whose
+// github-side AND okta-side identifier edges have BOTH been re-asserted
+// inside the recency window; stale bridges in the list must not contribute
+// proof, and a fresh github-side edge on bridge A combined with a fresh
+// okta-side edge on bridge B (different identity nodes) is two stale
+// renamed bridges, NOT one current bridge.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsBridgesListPairing(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	now := time.Now().UTC()
+	freshAt := now.Add(-1 * time.Hour)
+	staleAt := now.Add(-90 * 24 * time.Hour)
+	cases := map[string]struct {
+		bridges      []githubActiveWithoutOktaTestBridge
+		wantSuppress bool
+	}{
+		"only stale bridges in list": {
+			bridges: []githubActiveWithoutOktaTestBridge{
+				{githubActiveWithoutOktaRuleBridgeAttrs(staleAt), githubActiveWithoutOktaRuleBridgeAttrs(staleAt)},
+				{githubActiveWithoutOktaRuleBridgeAttrs(staleAt), githubActiveWithoutOktaRuleBridgeAttrs(staleAt)},
+			},
+			wantSuppress: false,
+		},
+		"one fresh-both-sides bridge among stale": {
+			bridges: []githubActiveWithoutOktaTestBridge{
+				{githubActiveWithoutOktaRuleBridgeAttrs(staleAt), githubActiveWithoutOktaRuleBridgeAttrs(staleAt)},
+				{githubActiveWithoutOktaRuleBridgeAttrs(freshAt), githubActiveWithoutOktaRuleBridgeAttrs(freshAt)},
+				{githubActiveWithoutOktaRuleBridgeAttrs(staleAt), githubActiveWithoutOktaRuleBridgeAttrs(staleAt)},
+			},
+			wantSuppress: true,
+		},
+		"only one-sided fresh bridges in list": {
+			bridges: []githubActiveWithoutOktaTestBridge{
+				{githubActiveWithoutOktaRuleBridgeAttrs(freshAt), githubActiveWithoutOktaRuleBridgeAttrs(staleAt)},
+				{githubActiveWithoutOktaRuleBridgeAttrs(staleAt), githubActiveWithoutOktaRuleBridgeAttrs(freshAt)},
+			},
+			wantSuppress: false,
+		},
+		"empty bridges list (OPTIONAL MATCH miss)": {
+			bridges:      nil,
+			wantSuppress: false,
+		},
+		"single OPTIONAL MATCH miss element (cypher coalesce)": {
+			bridges: []githubActiveWithoutOktaTestBridge{
+				{"", ""},
+			},
+			wantSuppress: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			row := githubActiveWithoutOktaRuleRowFull(
+				"urn:cerebro:writer:github.user:alice",
+				"alice",
+				[]githubActiveWithoutOktaTestTarget{{
+					urn:                 "urn:cerebro:writer:github_repo:writer/cerebro",
+					entityType:          "github.repo",
+					label:               "writer/cerebro",
+					actedAttributesJSON: githubActiveWithoutOktaRuleActedAttrs(freshAt),
+				}},
+				tc.bridges,
+			)
+			findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+			if err != nil {
+				t.Fatalf("EvaluateRows() error = %v", err)
+			}
+			gotN := len(findings)
+			wantN := 1
+			if tc.wantSuppress {
+				wantN = 0
+			}
+			if gotN != wantN {
+				t.Fatalf("EvaluateRows() returned %d findings, want %d for %q", gotN, wantN, name)
 			}
 		})
 	}

--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -123,4 +123,15 @@ func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	if _, ok := registry.Get(dataSensitiveAssetRiskRuleID); !ok {
 		t.Fatalf("registry missing %q", dataSensitiveAssetRiskRuleID)
 	}
+	// Graph rules must be in the catalog so the orchestrator's
+	// graph-rule evaluator picks them up when okta-user / github-audit
+	// runtimes complete a sync. A rule that ships in code but never
+	// registers is a silent regression: the cypher never runs and no
+	// finding is emitted, with no observable error.
+	if _, ok := registry.Get(identityDeprovisionedOktaActiveGitHubRuleID); !ok {
+		t.Fatalf("registry missing %q", identityDeprovisionedOktaActiveGitHubRuleID)
+	}
+	if _, ok := registry.Get(identityGitHubActiveWithoutOktaLinkRuleID); !ok {
+		t.Fatalf("registry missing %q", identityGitHubActiveWithoutOktaLinkRuleID)
+	}
 }

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -43,6 +43,7 @@ func builtinRulePacks() []RulePack {
 			Rules: append([]Rule{
 				newOktaPolicyRuleLifecycleTamperingRule(),
 				newDeprovisionedOktaActiveGitHubRule(),
+				newGitHubActiveWithoutOktaLinkRule(),
 			}, newIdentitySignalRules()...),
 		},
 		{


### PR DESCRIPTION
## Summary

Adds the second built-in graph rule: `identity-github-active-without-okta-link`. Fires when a `github.user` has recent `acted_on` edges but no `represents_identity` bridge to any `okta.user` in the same tenant — shadow access bypassing corporate IdP.

## Why

After shipping #535 (deprovisioned-Okta-still-active-in-GitHub), the next gap is the inverse cross-source check: GitHub identities that were never on-boarded into Okta at all. Two real-world cases this catches:

1. Personal/legacy GitHub accounts that pre-date SAML enforcement and were never bridged.
2. External collaborators whose access lives entirely outside the corporate IdP.

Panther's event-based github_rules cannot express this because the answer requires the *absence* of a cross-source identity edge — which only the projected graph holds.

## Cypher

```cypher
MATCH (g:Entity {entity_type: 'github.user', tenant_id: $tenant_id})
       -[acted:RELATION {relation: 'acted_on'}]->(target:Entity)
WHERE NOT EXISTS {
  MATCH (g)-[:RELATION {relation: 'represents_identity'}]->(:Entity)
        <-[:RELATION {relation: 'represents_identity'}]-(o:Entity {entity_type: 'okta.user', tenant_id: $tenant_id})
}
RETURN ...
```

## Design choices

| Knob | Choice | Rationale |
|---|---|---|
| Severity | HIGH (vs CRITICAL on the deprovisioned rule) | Control-gap hygiene, not active misuse |
| Match-type filter | Accept any identity match | Asymmetric to the deprovisioned rule: false-negatives (missed shadow on a coincidental username collision) are safer than false-positives (CRITICAL on a name twin) |
| Bot filter | `*[bot]` suffix + narrow vendor list (`dependabot`, `github-actions`, `renovate`, `mergify`) | GitHub Apps reserve `[bot]` for app identities; vendor list does not over-match human logins |
| Recency window | 30d on `acted_on` | Same as deprovisioned rule; keeps stale history from pinning findings open |
| Fingerprint | (rule, tenant, github_user_urn) | One shadow account → one finding regardless of how many repos it touched or which runtime triggered |
| SupportsRuntime | github.audit + okta.user | Either side's ingest can flip the answer |

## Tests

- `TestGitHubActiveWithoutOktaLinkRuleQueryScopesByTenant` — cypher includes NOT EXISTS, github.user, okta.user predicates
- `TestGitHubActiveWithoutOktaLinkRuleQueryRequiresTenant` — refuses to scan with no tenant
- `TestGitHubActiveWithoutOktaLinkRuleSupportsBothGitHubAndOkta` — runtime family table
- `TestGitHubActiveWithoutOktaLinkRuleFingerprint{IsStableAcrossRuns,CollapsesAcrossGitHubRuntimes,IgnoresTargetSet,SeparatesGitHubUsers}` — fingerprint identity contract
- `TestGitHubActiveWithoutOktaLinkRuleFindingStampsTriggeringRuntimeID` — runtime-stamp contract
- `TestGitHubActiveWithoutOktaLinkRuleEvaluateRows{EmitsForRecentActedOn,RejectsStaleActedOn,RejectsActedOnWithoutAt,SkipsBotLogins,AcceptsHumanLoginsThatLookBotAdjacent,CollapsesTargetsPerGitHubUser,EmitsDeterministicOrder,HandlesEmptyAndPartialRows,RequiresTenant}` — semantic contract
- `TestIsGitHubBotLogin` — bot pattern table
- Extended `TestBuiltinRulePacksFlattenIntoCatalog` to assert both graph rules are catalogued (silent registry gaps would let a rule ship without ever running)