### PR TITLE
fix(findings): reduce shadow github identity noise

### DIFF
--- a/internal/findings/identity_github_active_without_okta_link_rule.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule.go
@@ -2,6 +2,7 @@ package findings
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -226,14 +227,31 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 		if githubUserURN == "" {
 			continue
 		}
-		// Bot logins (dependabot[bot], github-actions[bot], renovate[bot], etc.)
-		// commit and act on resources but are not real human identities. They
-		// will never be in Okta by design, so emitting on them would flood
-		// the queue with non-actionable findings. The check is on the github
-		// user label (which the projector populates from the audit `actor`
-		// field) so it sees the raw login string the audit log carried.
+		// Suppress automation actors using the GitHub-stamped schema flags
+		// the source projector forwards onto every github.user node:
+		//
+		//   * actor_is_bot=true is GitHub's own classification for GitHub App
+		//     identities (the `<vendor>[bot]` accounts that surface in audit
+		//     `actor` fields — dependabot[bot], github-actions[bot],
+		//     renovate[bot], coderabbitai[bot], factory-droid[bot], etc.).
+		//   * actor_is_agent=true covers fine-grained PAT / installation-token
+		//     agent actions that GitHub categorises as automated.
+		//
+		// These accounts will never be in Okta by design; emitting on them
+		// would flood the queue with non-actionable findings. Trusting the
+		// schema avoids the maintenance burden of a hand-maintained vendor
+		// allowlist (every new GitHub App vendor would otherwise require a
+		// code change) and stays correct as the audit log API gains new
+		// classifications.
+		//
+		// The complementary org-as-actor pattern (audit events whose
+		// `actor_id == org_id`, e.g. `integration_installation.version_updated`
+		// system events) is filtered at the projector layer by routing the
+		// `acted_on` edge from the github.org node instead of minting a
+		// `github.user:<org>` shadow node, so this rule never sees those rows.
 		githubUserLabel := cypherRowString(row, "github_user_label")
-		if isGitHubBotLogin(githubUserLabel) {
+		githubAttributesJSON := cypherRowString(row, "github_attributes_json")
+		if githubActorIsAutomation(githubAttributesJSON) {
 			continue
 		}
 		// The cypher emits one row per github user; rows for the same
@@ -247,7 +265,7 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 			group = &githubActiveWithoutOktaGroup{
 				githubUserURN:        githubUserURN,
 				githubUserLabel:      githubUserLabel,
-				githubAttributesJSON: cypherRowString(row, "github_attributes_json"),
+				githubAttributesJSON: githubAttributesJSON,
 				targets:              map[string]githubActiveWithoutOktaTarget{},
 			}
 			groups[githubUserURN] = group
@@ -287,7 +305,11 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 		// gives one O(n) pass with the same semantics as the previous
 		// row-per-target form.
 		for _, target := range cypherRowList(row, "targets") {
-			if !edgeIsRecent(cypherListMapString(target, "acted_attributes_json"), now, identityGitHubActiveWithoutOktaRecencyWindow) {
+			actedAttributesJSON := cypherListMapString(target, "acted_attributes_json")
+			if !edgeIsRecent(actedAttributesJSON, now, identityGitHubActiveWithoutOktaRecencyWindow) {
+				continue
+			}
+			if !githubActedOnIsCurrentAccessEvidence(actedAttributesJSON) {
 				continue
 			}
 			targetURN := strings.TrimSpace(cypherListMapString(target, "urn"))
@@ -365,31 +387,76 @@ func cypherListMapString(item any, key string) string {
 	}
 }
 
-// isGitHubBotLogin recognises the subset of GitHub login conventions that
-// flag accounts as automation rather than employee identities. These never
-// belong in Okta and would otherwise emit a CRITICAL-volume of false
-// positives every time the audit log records a bot action.
+// githubActorIsAutomation returns true when a github.user node's
+// attributes_json carries an explicit GitHub-stamped automation flag. The
+// source projector forwards two booleans from the audit log API onto every
+// github.user node:
 //
-// The patterns are intentionally narrow: the GitHub Apps convention reserves
-// the `[bot]` suffix for App-issued identities (which is why
-// `dependabot[bot]` and `github-actions[bot]` show up in audit `actor`
-// fields), and the prefix list covers the well-known third-party automation
-// vendors that mint GitHub-App-backed bots (Dependabot, GitHub Actions,
-// Renovate, Mergify, RenovateBot via repo-scoped tokens) without sweeping in
-// arbitrary user logins that happen to start with the same letters.
-func isGitHubBotLogin(login string) bool {
-	trimmed := strings.ToLower(strings.TrimSpace(login))
+//   - actor_is_bot is GitHub's classification for GitHub App identities
+//     (`<vendor>[bot]` accounts: dependabot[bot], github-actions[bot],
+//     renovate[bot], coderabbitai[bot], factory-droid[bot], and any future
+//     App-issued bot the API decides to classify the same way).
+//   - actor_is_agent covers fine-grained PAT / installation-token agent
+//     actions GitHub categorises as automated.
+//
+// Comparing the schema flag instead of pattern-matching the login string
+// lets the rule stay correct without a hardcoded vendor allowlist and
+// without paying a per-vendor maintenance tax as new GitHub App
+// integrations come online.
+//
+// We accept the values verbatim from the audit log (strings, lower-cased
+// "true"/"false" in practice) and trim/compare case-insensitively so a
+// future API revision that returns "True" or "TRUE" still works. Empty or
+// malformed JSON is treated as "not classified as automation" — better to
+// surface a finding for review than to silently suppress a real shadow
+// account because the attributes blob was corrupt.
+func githubActorIsAutomation(attributesJSON string) bool {
+	trimmed := strings.TrimSpace(attributesJSON)
 	if trimmed == "" {
 		return false
 	}
-	if strings.HasSuffix(trimmed, "[bot]") {
+	var attrs map[string]string
+	if err := json.Unmarshal([]byte(trimmed), &attrs); err != nil {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(attrs["actor_is_bot"]), "true") {
 		return true
 	}
-	switch trimmed {
-	case "dependabot", "github-actions", "renovate", "renovate-bot", "mergify", "mergify-bot":
+	if strings.EqualFold(strings.TrimSpace(attrs["actor_is_agent"]), "true") {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(attrs["actor_type"]), "Bot") {
 		return true
 	}
 	return false
+}
+
+func githubActedOnIsCurrentAccessEvidence(attributesJSON string) bool {
+	trimmed := strings.TrimSpace(attributesJSON)
+	if trimmed == "" {
+		return false
+	}
+	var attrs map[string]string
+	if err := json.Unmarshal([]byte(trimmed), &attrs); err != nil {
+		return false
+	}
+	return githubAuditActionIndicatesCurrentAccess(attrs["action"])
+}
+
+func githubAuditActionIndicatesCurrentAccess(action string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(action))
+	if normalized == "" {
+		return false
+	}
+	switch normalized {
+	case "workflows.completed_workflow_run",
+		"workflows.created_workflow_run",
+		"workflows.prepared_workflow_job",
+		"org_credential_authorization.deauthorize":
+		return false
+	default:
+		return true
+	}
 }
 
 type githubActiveWithoutOktaGroup struct {

--- a/internal/findings/identity_github_active_without_okta_link_rule_test.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule_test.go
@@ -237,8 +237,12 @@ func TestGitHubActiveWithoutOktaLinkRuleFingerprintSeparatesGitHubUsers(t *testi
 }
 
 func githubActiveWithoutOktaRuleActedAttrs(at time.Time) string {
+	return githubActiveWithoutOktaRuleActedAttrsForAction("git.clone", at)
+}
+
+func githubActiveWithoutOktaRuleActedAttrsForAction(action string, at time.Time) string {
 	payload := map[string]string{
-		"action":   "git.clone",
+		"action":   action,
 		"event_id": "github-audit-evt",
 	}
 	if !at.IsZero() {
@@ -322,6 +326,22 @@ func githubActiveWithoutOktaRuleRowFull(githubUserURN, githubUserLabel string, t
 		"targets":                targetList,
 		"bridges":                bridgeList,
 	}}
+}
+
+// githubActiveWithoutOktaRuleRowWithGitHubAttrs lets bot/agent suppression
+// tests inject explicit attributes on the github.user node (e.g.
+// actor_is_bot=true) so the rule's schema-driven automation check is
+// exercised against the cypher row shape it sees in production. The
+// production projector serialises github.user attributes as a JSON map
+// keyed on attribute name; we emit the same string form here.
+func githubActiveWithoutOktaRuleRowWithGitHubAttrs(actedAttributesJSON, githubUserURN, githubUserLabel, targetURN string, githubAttrs map[string]string) ports.CypherRow {
+	row := githubActiveWithoutOktaRuleRow(actedAttributesJSON, githubUserURN, githubUserLabel, targetURN)
+	encoded, err := json.Marshal(githubAttrs)
+	if err != nil {
+		panic(err)
+	}
+	row.Values["github_attributes_json"] = string(encoded)
+	return row
 }
 
 // githubActiveWithoutOktaRuleBridgeAttrs builds a represents_identity edge's
@@ -412,11 +432,84 @@ func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsRejectsActedOnWithoutAt(t *t
 	}
 }
 
-// Bot logins (dependabot[bot], github-actions[bot], renovate, etc.) are
-// automation accounts and will never be in Okta by design. Surfacing them as
-// shadow access would flood the queue with non-actionable findings; the rule
-// must filter them at evaluation time.
-func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsSkipsBotLogins(t *testing.T) {
+// Not every recent audit edge proves current GitHub access. Workflow lifecycle
+// records like `workflows.created_workflow_run` / `completed_workflow_run` are
+// frequently emitted on behalf of the actor named on a commit, and live data
+// showed several otherwise-human accounts whose only recent evidence was these
+// passive workflow rows. Treating them as HIGH shadow access creates weak
+// findings. Revocation-only rows such as
+// `org_credential_authorization.deauthorize` are also not evidence that the
+// account currently retains access; they are evidence of access being removed.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsRejectsPassiveAndRevocationActions(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	now := time.Now().UTC()
+	for _, action := range []string{
+		"workflows.completed_workflow_run",
+		"workflows.created_workflow_run",
+		"workflows.prepared_workflow_job",
+		"org_credential_authorization.deauthorize",
+	} {
+		t.Run(action, func(t *testing.T) {
+			row := githubActiveWithoutOktaRuleRow(
+				githubActiveWithoutOktaRuleActedAttrsForAction(action, now.Add(-1*time.Hour)),
+				"urn:cerebro:writer:github.user:alice",
+				"alice",
+				"urn:cerebro:writer:github_repo:writer/cerebro",
+			)
+			findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+			if err != nil {
+				t.Fatalf("EvaluateRows() error = %v", err)
+			}
+			if len(findings) != 0 {
+				t.Fatalf("EvaluateRows() returned %d findings, want 0 for passive/revocation action %q", len(findings), action)
+			}
+		})
+	}
+}
+
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsAcceptsStrongAccessActions(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	now := time.Now().UTC()
+	for _, action := range []string{
+		"git.fetch",
+		"git.clone",
+		"git.push",
+		"org.sso_response",
+		"org_credential_authorization.grant",
+		"pull_request_review.submit",
+	} {
+		t.Run(action, func(t *testing.T) {
+			row := githubActiveWithoutOktaRuleRow(
+				githubActiveWithoutOktaRuleActedAttrsForAction(action, now.Add(-1*time.Hour)),
+				"urn:cerebro:writer:github.user:alice",
+				"alice",
+				"urn:cerebro:writer:github_repo:writer/cerebro",
+			)
+			findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+			if err != nil {
+				t.Fatalf("EvaluateRows() error = %v", err)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("EvaluateRows() returned %d findings, want 1 for strong access action %q", len(findings), action)
+			}
+		})
+	}
+}
+
+// GitHub stamps actor_is_bot=true on every audit event whose actor is a
+// GitHub App identity (the `<vendor>[bot]` accounts). The source projector
+// forwards that flag verbatim onto the github.user node attributes; rows
+// carrying it must be suppressed because App identities will never be in
+// Okta and would otherwise flood the queue with non-actionable findings.
+//
+// The suppression is keyed off the schema flag rather than the login string
+// so the rule stays correct without a hand-maintained vendor allowlist and
+// without paying a per-vendor maintenance tax as new GitHub App
+// integrations come online (dependabot[bot], github-actions[bot],
+// renovate[bot], coderabbitai[bot], factory-droid[bot], …).
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsSkipsActorIsBot(t *testing.T) {
 	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
 	rows := []ports.CypherRow{}
@@ -424,18 +517,16 @@ func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsSkipsBotLogins(t *testing.T)
 		"dependabot[bot]",
 		"github-actions[bot]",
 		"renovate[bot]",
-		"dependabot",
-		"github-actions",
-		"renovate",
-		"renovate-bot",
-		"mergify[bot]",
-		"DEPENDABOT[BOT]",
+		"coderabbitai[bot]",
+		"factory-droid[bot]",
+		"future-vendor-no-allowlist[bot]",
 	} {
-		rows = append(rows, githubActiveWithoutOktaRuleRow(
+		rows = append(rows, githubActiveWithoutOktaRuleRowWithGitHubAttrs(
 			githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-1*time.Hour)),
 			"urn:cerebro:writer:github.user:"+strings.ToLower(login),
 			login,
 			"urn:cerebro:writer:github_repo:writer/cerebro",
+			map[string]string{"login": login, "actor_is_bot": "true"},
 		))
 	}
 	findings, err := rule.EvaluateRows(context.Background(), runtime, rows)
@@ -443,34 +534,99 @@ func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsSkipsBotLogins(t *testing.T)
 		t.Fatalf("EvaluateRows() error = %v", err)
 	}
 	if len(findings) != 0 {
-		t.Fatalf("EvaluateRows() returned %d findings, want 0 (bot logins must be filtered)", len(findings))
+		t.Fatalf("EvaluateRows() returned %d findings, want 0 (actor_is_bot=true must be filtered)", len(findings))
 	}
 }
 
-// Many real GitHub usernames legitimately look like nothing in particular
-// even though they don't bridge to Okta yet (e.g. external collaborators on
-// a private repo, recent hires whose Okta inventory hasn't synced). The bot
-// filter must NOT swallow human-shaped logins that merely contain a vendor
-// name or look bot-adjacent.
-func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsAcceptsHumanLoginsThatLookBotAdjacent(t *testing.T) {
+// actor_is_agent=true is GitHub's classification for fine-grained PAT and
+// installation-token agent actions. The flag is stamped by the audit log API
+// itself; the rule suppresses on it for the same reason it suppresses
+// actor_is_bot: agents will never be in Okta and would otherwise flood the
+// queue with non-actionable findings.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsSkipsActorIsAgent(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	row := githubActiveWithoutOktaRuleRowWithGitHubAttrs(
+		githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-1*time.Hour)),
+		"urn:cerebro:writer:github.user:fine-grained-pat-agent",
+		"fine-grained-pat-agent",
+		"urn:cerebro:writer:github_repo:writer/cerebro",
+		map[string]string{"login": "fine-grained-pat-agent", "actor_is_agent": "true"},
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 0 (actor_is_agent=true must be filtered)", len(findings))
+	}
+}
+
+// A future API revision might emit "True" or "TRUE" instead of "true". The
+// suppression must stay case-insensitive so a casing change at GitHub's end
+// doesn't silently re-open every bot finding.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsSkipsActorIsAutomationCaseInsensitive(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	cases := []map[string]string{
+		{"login": "alice", "actor_is_bot": "True"},
+		{"login": "alice", "actor_is_bot": "TRUE"},
+		{"login": "alice", "actor_is_agent": "True"},
+		{"login": "alice", "actor_is_agent": "TRUE"},
+	}
+	for _, attrs := range cases {
+		row := githubActiveWithoutOktaRuleRowWithGitHubAttrs(
+			githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-1*time.Hour)),
+			"urn:cerebro:writer:github.user:alice",
+			"alice",
+			"urn:cerebro:writer:github_repo:writer/cerebro",
+			attrs,
+		)
+		findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+		if err != nil {
+			t.Fatalf("EvaluateRows() error = %v: attrs=%v", err, attrs)
+		}
+		if len(findings) != 0 {
+			t.Fatalf("EvaluateRows() returned %d findings, want 0 for attrs=%v (case-insensitive 'true' must suppress)", len(findings), attrs)
+		}
+	}
+}
+
+// Real GitHub usernames whose logins coincidentally look bot-adjacent (e.g.
+// `renovate-team-lead`, `dependable-alice`, `github-actionsperson`) must NOT
+// be suppressed. The schema flags are absent for these accounts, so the
+// rule trusts the GitHub-side classification and continues to emit shadow-
+// access findings. This also covers the failure mode where a real shadow
+// account happens to carry `actor_is_bot=false` / `actor_is_agent=false`
+// explicitly: those values must NOT suppress.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsAcceptsHumanLoginsWithoutAutomationFlags(t *testing.T) {
 	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
 	rows := []ports.CypherRow{}
-	humanLogins := []string{"renovate-team-lead", "dependable-alice", "github-actionsperson"}
-	for _, login := range humanLogins {
-		rows = append(rows, githubActiveWithoutOktaRuleRow(
+	cases := []struct {
+		login string
+		attrs map[string]string
+	}{
+		{login: "renovate-team-lead", attrs: map[string]string{"login": "renovate-team-lead"}},
+		{login: "dependable-alice", attrs: map[string]string{"login": "dependable-alice", "actor_is_bot": "false"}},
+		{login: "github-actionsperson", attrs: map[string]string{"login": "github-actionsperson", "actor_is_agent": "false"}},
+		{login: "explicit-false-both", attrs: map[string]string{"login": "explicit-false-both", "actor_is_bot": "false", "actor_is_agent": "false"}},
+	}
+	for _, tc := range cases {
+		rows = append(rows, githubActiveWithoutOktaRuleRowWithGitHubAttrs(
 			githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-1*time.Hour)),
-			"urn:cerebro:writer:github.user:"+login,
-			login,
+			"urn:cerebro:writer:github.user:"+tc.login,
+			tc.login,
 			"urn:cerebro:writer:github_repo:writer/cerebro",
+			tc.attrs,
 		))
 	}
 	findings, err := rule.EvaluateRows(context.Background(), runtime, rows)
 	if err != nil {
 		t.Fatalf("EvaluateRows() error = %v", err)
 	}
-	if len(findings) != len(humanLogins) {
-		t.Fatalf("EvaluateRows() returned %d findings, want %d (human-shaped logins must NOT be filtered as bots)", len(findings), len(humanLogins))
+	if len(findings) != len(cases) {
+		t.Fatalf("EvaluateRows() returned %d findings, want %d (real users without automation flags must NOT be suppressed)", len(findings), len(cases))
 	}
 }
 
@@ -896,30 +1052,51 @@ func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsBridgesListPairing(t *testin
 	}
 }
 
-func TestIsGitHubBotLogin(t *testing.T) {
-	cases := map[string]bool{
-		"dependabot[bot]":      true,
-		"github-actions[bot]":  true,
-		"renovate[bot]":        true,
-		"renovate":             true,
-		"dependabot":           true,
-		"github-actions":       true,
-		"renovate-bot":         true,
-		"mergify":              true,
-		"mergify-bot":          true,
-		"MERGIFY[BOT]":         true,
-		"  dependabot[bot]  ":  true,
-		"":                     false,
-		"alice":                false,
-		"alice-bot-fan":        false,
-		"renovate-team-lead":   false,
-		"dependable-alice":     false,
-		"github-actionsperson": false,
+// githubActorIsAutomation reads the github-stamped automation flags off the
+// node's attributes_json blob; the rule depends on these signals to suppress
+// bot/agent rows without resorting to a hardcoded vendor allowlist. The
+// table here pins:
+//
+//   - both true-shaped flags suppress (bot and agent)
+//   - case variations of "true" are honoured (a future API revision returning
+//     "True"/"TRUE" must not silently re-open every bot finding)
+//   - false / absent / unrelated values do NOT suppress (we surface the
+//     finding for review rather than swallow a real shadow account because
+//     the attribute was malformed or missing)
+//   - malformed JSON / empty input is treated as "not classified as
+//     automation", same fail-open posture
+func TestGitHubActorIsAutomation(t *testing.T) {
+	cases := map[string]struct {
+		attributesJSON string
+		want           bool
+	}{
+		"actor_is_bot true":             {`{"actor_is_bot":"true"}`, true},
+		"actor_is_bot TRUE upper":       {`{"actor_is_bot":"TRUE"}`, true},
+		"actor_is_bot True mixed":       {`{"actor_is_bot":"True"}`, true},
+		"actor_is_bot true with spaces": {`{"actor_is_bot":"  true  "}`, true},
+		"actor_is_agent true":           {`{"actor_is_agent":"true"}`, true},
+		"actor_is_agent TRUE upper":     {`{"actor_is_agent":"TRUE"}`, true},
+		"actor_type bot":                {`{"actor_type":"Bot"}`, true},
+		"actor_type bot lowercase":      {`{"actor_type":"bot"}`, true},
+		"both flags true":               {`{"actor_is_bot":"true","actor_is_agent":"true"}`, true},
+		"only bot true, agent false":    {`{"actor_is_bot":"true","actor_is_agent":"false"}`, true},
+		"only agent true, bot false":    {`{"actor_is_bot":"false","actor_is_agent":"true"}`, true},
+		"both flags false":              {`{"actor_is_bot":"false","actor_is_agent":"false"}`, false},
+		"bot flag absent":               {`{"login":"alice"}`, false},
+		"actor_type user":               {`{"actor_type":"User"}`, false},
+		"actor_type unresolved":         {`{"actor_type":"Unresolved"}`, false},
+		"bot flag empty string":         {`{"actor_is_bot":""}`, false},
+		"bot flag arbitrary value":      {`{"actor_is_bot":"maybe"}`, false},
+		"empty JSON object":             {`{}`, false},
+		"empty string":                  {``, false},
+		"whitespace string":             {`   `, false},
+		"malformed JSON":                {`{not valid json`, false},
+		"non-object JSON":               {`"string"`, false},
 	}
-	for login, want := range cases {
-		t.Run(login, func(t *testing.T) {
-			if got := isGitHubBotLogin(login); got != want {
-				t.Fatalf("isGitHubBotLogin(%q) = %v, want %v", login, got, want)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := githubActorIsAutomation(tc.attributesJSON); got != tc.want {
+				t.Fatalf("githubActorIsAutomation(%q) = %v, want %v", tc.attributesJSON, got, tc.want)
 			}
 		})
 	}

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1130,10 +1130,40 @@ func mergeGraphAttributes(existing map[string]string, incoming map[string]string
 	for key, value := range existing {
 		merged[key] = value
 	}
+	incomingIsOlderObservation := graphIncomingObservationIsOlder(existing, incoming)
 	for key, value := range incoming {
+		if incomingIsOlderObservation && graphAttributeCoupledToObservationTime(key) {
+			continue
+		}
 		merged[key] = mergeAttributeValue(key, merged[key], value)
 	}
 	return merged
+}
+
+func graphIncomingObservationIsOlder(existing map[string]string, incoming map[string]string) bool {
+	existingAt := strings.TrimSpace(existing["at"])
+	incomingAt := strings.TrimSpace(incoming["at"])
+	if existingAt == "" {
+		return false
+	}
+	if incomingAt == "" {
+		return true
+	}
+	existingT, errExisting := time.Parse(time.RFC3339, existingAt)
+	incomingT, errIncoming := time.Parse(time.RFC3339, incomingAt)
+	if errExisting != nil || errIncoming != nil {
+		return false
+	}
+	return incomingT.Before(existingT)
+}
+
+func graphAttributeCoupledToObservationTime(key string) bool {
+	switch key {
+	case "action", "event_id", "programmatic_access_type", "source_event_id", "source_runtime_id", "transport_protocol_name":
+		return true
+	default:
+		return false
+	}
 }
 
 // mergeAttributeValue lets specific attribute keys override the default

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -294,34 +294,39 @@ func TestMergeGraphAttributesKeepsLatestAtAcrossOutOfOrderUpserts(t *testing.T) 
 	newer := time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)
 
 	cases := []struct {
-		name     string
-		existing map[string]string
-		incoming map[string]string
-		wantAt   string
+		name       string
+		existing   map[string]string
+		incoming   map[string]string
+		wantAt     string
+		wantAction string
 	}{
 		{
-			name:     "older incoming after newer existing keeps newer",
-			existing: map[string]string{"at": newer, "action": "git.clone"},
-			incoming: map[string]string{"at": older, "action": "git.fetch"},
-			wantAt:   newer,
+			name:       "older incoming after newer existing keeps newer observation",
+			existing:   map[string]string{"at": newer, "action": "git.clone"},
+			incoming:   map[string]string{"at": older, "action": "workflows.completed_workflow_run"},
+			wantAt:     newer,
+			wantAction: "git.clone",
 		},
 		{
-			name:     "newer incoming after older existing wins",
-			existing: map[string]string{"at": older, "action": "git.clone"},
-			incoming: map[string]string{"at": newer, "action": "git.push"},
-			wantAt:   newer,
+			name:       "newer incoming after older existing wins",
+			existing:   map[string]string{"at": older, "action": "git.clone"},
+			incoming:   map[string]string{"at": newer, "action": "git.push"},
+			wantAt:     newer,
+			wantAction: "git.push",
 		},
 		{
-			name:     "missing existing at takes incoming",
-			existing: map[string]string{"action": "git.clone"},
-			incoming: map[string]string{"at": newer, "action": "git.push"},
-			wantAt:   newer,
+			name:       "missing existing at takes incoming",
+			existing:   map[string]string{"action": "git.clone"},
+			incoming:   map[string]string{"at": newer, "action": "git.push"},
+			wantAt:     newer,
+			wantAction: "git.push",
 		},
 		{
-			name:     "missing incoming at preserves existing",
-			existing: map[string]string{"at": newer, "action": "git.clone"},
-			incoming: map[string]string{"action": "git.push"},
-			wantAt:   newer,
+			name:       "missing incoming at preserves existing observation",
+			existing:   map[string]string{"at": newer, "action": "git.clone"},
+			incoming:   map[string]string{"action": "git.push"},
+			wantAt:     newer,
+			wantAction: "git.clone",
 		},
 	}
 	for _, tc := range cases {
@@ -330,12 +335,47 @@ func TestMergeGraphAttributesKeepsLatestAtAcrossOutOfOrderUpserts(t *testing.T) 
 			if got := merged["at"]; got != tc.wantAt {
 				t.Fatalf("merged at = %q, want %q (rule recency check depends on chronological max)", got, tc.wantAt)
 			}
+			if got := merged["action"]; got != tc.wantAction {
+				t.Fatalf("merged action = %q, want %q (action must stay coupled to the winning at timestamp)", got, tc.wantAction)
+			}
 		})
 	}
 }
 
-// Non-`at` keys must keep the default last-write-wins semantics so the special-
-// case in mergeAttributeValue does not silently change merge behavior elsewhere.
+func TestMergeGraphAttributesKeepsObservationMetadataCoupledToLatestAt(t *testing.T) {
+	older := time.Date(2025, time.March, 1, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	newer := time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	merged := mergeGraphAttributes(
+		map[string]string{
+			"at":                       newer,
+			"action":                   "git.clone",
+			"event_id":                 "newer-event",
+			"programmatic_access_type": "Fine-grained personal access token",
+			"source_runtime_id":        "writer-github-audit",
+		},
+		map[string]string{
+			"at":                       older,
+			"action":                   "workflows.completed_workflow_run",
+			"event_id":                 "older-event",
+			"programmatic_access_type": "GitHub App server-to-server token",
+			"source_runtime_id":        "writer-github-audit-writerinternal",
+		},
+	)
+	for key, want := range map[string]string{
+		"at":                       newer,
+		"action":                   "git.clone",
+		"event_id":                 "newer-event",
+		"programmatic_access_type": "Fine-grained personal access token",
+		"source_runtime_id":        "writer-github-audit",
+	} {
+		if got := merged[key]; got != want {
+			t.Fatalf("merged[%s] = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// Non-observation keys must keep the default last-write-wins semantics so the
+// special-case for event metadata does not silently change merge behavior elsewhere.
 func TestMergeGraphAttributesKeepsLastWriteWinsForOtherKeys(t *testing.T) {
 	merged := mergeGraphAttributes(
 		map[string]string{"action": "git.clone", "actor": "alice"},

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -241,23 +241,66 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 	resourceID := strings.TrimSpace(attributes["resource_id"])
 	resourceType := strings.TrimSpace(attributes["resource_type"])
 	actor := strings.TrimSpace(attributes["actor"])
+	actorID := strings.TrimSpace(attributes["actor_id"])
+	actorIsBot := strings.TrimSpace(attributes["actor_is_bot"])
+	actorIsAgent := strings.TrimSpace(attributes["actor_is_agent"])
+	actorType := strings.TrimSpace(attributes["actor_type"])
 	actorExternalNameID := strings.TrimSpace(attributes["external_identity_nameid"])
 	actorExternalUsername := strings.TrimSpace(attributes["external_identity_username"])
+	orgID := strings.TrimSpace(attributes["org_id"])
+	programmaticAccessType := strings.TrimSpace(attributes["programmatic_access_type"])
 	targetUser := strings.TrimSpace(attributes["user"])
+	tokenID := strings.TrimSpace(attributes["token_id"])
+
+	// actorIsOrgSelf is true when GitHub stamps the audit event with the org
+	// as its own actor — a pattern that shows up on system-level events such
+	// as `integration_installation.version_updated` where no specific user
+	// triggered the action. We detect it by comparing the audit log's
+	// actor_id against org_id (both numeric and stamped by GitHub itself).
+	// When this is true we route the acted_on edge from the github.org node
+	// rather than minting a phantom `github.user:<org>` node, mirroring
+	// cartography's separation of GitHubOrganization and GitHubUser.
+	actorTypeIsOrg := strings.EqualFold(actorType, "Organization")
+	actorIsOrgSelf := actorID != "" && orgID != "" && actorID == orgID
+	actorIsUnresolvedPublicKey := strings.EqualFold(actorType, "Unresolved") && isGitHubPublicKeyCredential(programmaticAccessType)
 
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 
 	orgURN := projectionURN(tenantID, "github_org", org)
 	if org != "" {
+		orgAttrs := map[string]string{"org": org}
+		// Stamp the numeric org_id onto the github.org node so it stays
+		// available when consumers need to reason about the org as a
+		// first-class actor (e.g. distinguishing org-self events from
+		// user actions in downstream rules).
+		if orgID != "" {
+			orgAttrs["org_id"] = orgID
+		}
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        orgURN,
 			TenantID:   tenantID,
 			SourceID:   event.GetSourceId(),
 			EntityType: "github.org",
 			Label:      org,
-			Attributes: map[string]string{"org": org},
+			Attributes: orgAttrs,
 		})
+	}
+	actorOrgURN := orgURN
+	if actorTypeIsOrg {
+		actorOrgURN = projectionURN(tenantID, "github_org", firstNonEmpty(actor, org))
+		if actorOrgURN != "" && actor != "" && !strings.EqualFold(actor, org) {
+			actorOrgAttrs := map[string]string{"org": actor}
+			addProjectedAttribute(actorOrgAttrs, "org_id", actorID)
+			addEntity(entities, &ports.ProjectedEntity{
+				URN:        actorOrgURN,
+				TenantID:   tenantID,
+				SourceID:   event.GetSourceId(),
+				EntityType: "github.org",
+				Label:      actor,
+				Attributes: actorOrgAttrs,
+			})
+		}
 	}
 
 	repoURN := projectionURN(tenantID, "github_repo", firstNonEmpty(repo, resourceID))
@@ -303,47 +346,115 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 		}
 	}
 
-	actorURN := githubUserURN(tenantID, actor)
-	if actorURN != "" {
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        actorURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: "github.user",
-			Label:      actor,
-			Attributes: map[string]string{
+	// `at` carries the audit event's OccurredAt timestamp so graph rules can tell
+	// recent GitHub activity from stale historical edges. mergeGraphAttributes is
+	// latest-wins, so under the normal in-order ingestion path this field always
+	// reflects the most recent action that touched the edge. The
+	// deprovisioned-Okta-active-in-GitHub rule uses this to avoid reporting users as
+	// "still active" purely from pre-offboarding history.
+	actedAttrs := map[string]string{
+		"action":   strings.TrimSpace(attributes["action"]),
+		"event_id": event.GetId(),
+	}
+	addProjectedAttribute(actedAttrs, "actor_type", actorType)
+	addProjectedAttribute(actedAttrs, "programmatic_access_type", programmaticAccessType)
+	addProjectedAttribute(actedAttrs, "source_runtime_id", strings.TrimSpace(attributes["source_runtime_id"]))
+	addProjectedAttribute(actedAttrs, "transport_protocol_name", strings.TrimSpace(attributes["transport_protocol_name"]))
+	if occurredAt := event.GetOccurredAt(); occurredAt != nil && occurredAt.IsValid() {
+		actedAttrs["at"] = occurredAt.AsTime().UTC().Format(time.RFC3339)
+	}
+
+	// When the audit event's actor is the org itself (system-level events),
+	// route the acted_on edge from the github.org node rather than minting a
+	// `github.user:<org>` shadow node. This matches GitHub's data model
+	// (orgs are not users) and prevents identity rules from chasing the org
+	// as if it were a person that should have an Okta link.
+	if (actorIsOrgSelf || actorTypeIsOrg) && actorOrgURN != "" {
+		if resourceURN != "" && resourceURN != actorOrgURN {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorOrgURN, resourceURN, relationActedOn, actedAttrs))
+		}
+	} else if actorIsUnresolvedPublicKey {
+		credentialURN := githubCredentialURN(tenantID, githubPublicKeyCredentialID(tokenID, actor, repo, resourceID, org))
+		if credentialURN != "" {
+			credentialAttrs := map[string]string{
+				"actor":                    actor,
+				"credential_type":          "public_key",
+				"programmatic_access_type": programmaticAccessType,
+			}
+			addProjectedAttribute(credentialAttrs, "org", org)
+			addProjectedAttribute(credentialAttrs, "org_id", orgID)
+			addProjectedAttribute(credentialAttrs, "repository", firstNonEmpty(repo, resourceID))
+			addProjectedAttribute(credentialAttrs, "token_id", tokenID)
+			addProjectedAttribute(credentialAttrs, "transport_protocol_name", strings.TrimSpace(attributes["transport_protocol_name"]))
+			addEntity(entities, &ports.ProjectedEntity{
+				URN:        credentialURN,
+				TenantID:   tenantID,
+				SourceID:   event.GetSourceId(),
+				EntityType: "github.credential",
+				Label:      actor,
+				Attributes: credentialAttrs,
+			})
+			if resourceURN != "" {
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), credentialURN, resourceURN, relationActedOn, actedAttrs))
+			}
+		}
+	} else {
+		actorURN := githubUserURN(tenantID, actor)
+		if actorURN != "" {
+			actorAttrs := map[string]string{
 				"external_identity_nameid":   actorExternalNameID,
 				"external_identity_username": actorExternalUsername,
 				"login":                      actor,
-			},
-		})
-		if resourceURN != "" {
-			// `at` carries the audit event's OccurredAt timestamp so graph rules can tell
-			// recent GitHub activity from stale historical edges. mergeGraphAttributes is
-			// latest-wins, so under the normal in-order ingestion path this field always
-			// reflects the most recent action that touched the edge. The
-			// deprovisioned-Okta-active-in-GitHub rule uses this to avoid reporting users as
-			// "still active" purely from pre-offboarding history.
-			actedAttrs := map[string]string{
-				"action":   strings.TrimSpace(attributes["action"]),
-				"event_id": event.GetId(),
 			}
-			if occurredAt := event.GetOccurredAt(); occurredAt != nil && occurredAt.IsValid() {
-				actedAttrs["at"] = occurredAt.AsTime().UTC().Format(time.RFC3339)
+			// Stamp the GitHub-native actor classification signals onto
+			// the github.user node so downstream rules can distinguish
+			// real users from bots and integration agents structurally,
+			// without resorting to login-string heuristics. These fields
+			// are stamped by GitHub itself on every audit event; values
+			// are kept verbatim ("true" / "false") and merged latest-wins.
+			if actorID != "" {
+				actorAttrs["actor_id"] = actorID
 			}
-			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, actedAttrs))
-		}
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actor, event.GetOccurredAt())
-		if !sameIdentifier(actor, actorExternalNameID) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalNameID, event.GetOccurredAt())
-		}
-		if !sameIdentifier(actor, actorExternalUsername) && !sameIdentifier(actorExternalNameID, actorExternalUsername) {
-			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalUsername, event.GetOccurredAt())
+			if actorType != "" {
+				actorAttrs["actor_type"] = actorType
+			}
+			if actorIsBot != "" {
+				actorAttrs["actor_is_bot"] = actorIsBot
+			}
+			if actorIsAgent != "" {
+				actorAttrs["actor_is_agent"] = actorIsAgent
+			}
+			if orgID != "" {
+				actorAttrs["org_id"] = orgID
+			}
+			addEntity(entities, &ports.ProjectedEntity{
+				URN:        actorURN,
+				TenantID:   tenantID,
+				SourceID:   event.GetSourceId(),
+				EntityType: "github.user",
+				Label:      actor,
+				Attributes: actorAttrs,
+			})
+			if resourceURN != "" {
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, actedAttrs))
+			}
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actor, event.GetOccurredAt())
+			if !sameIdentifier(actor, actorExternalNameID) {
+				addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalNameID, event.GetOccurredAt())
+			}
+			if !sameIdentifier(actor, actorExternalUsername) && !sameIdentifier(actorExternalNameID, actorExternalUsername) {
+				addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalUsername, event.GetOccurredAt())
+			}
 		}
 	}
 
+	// The previous-version actor URN computed against the github.user
+	// URN scheme is used here only to suppress redundant targeted edges
+	// when actor==targetUser. The org-self path above doesn't create a
+	// github.user actor, so this is purely for the user-actor case.
+	previousActorURN := githubUserURN(tenantID, actor)
 	targetURN := githubUserURN(tenantID, targetUser)
-	if targetURN != "" && targetURN != actorURN {
+	if targetURN != "" && targetURN != previousActorURN {
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        targetURN,
 			TenantID:   tenantID,
@@ -360,6 +471,26 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
+}
+
+func isGitHubPublicKeyCredential(programmaticAccessType string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(programmaticAccessType))
+	return strings.Contains(normalized, "public key")
+}
+
+func githubPublicKeyCredentialID(tokenID string, actor string, repo string, resourceID string, org string) string {
+	if strings.TrimSpace(tokenID) != "" {
+		return strings.TrimSpace(tokenID)
+	}
+	scope := firstNonEmpty(repo, resourceID, org)
+	if strings.TrimSpace(actor) != "" && scope != "" {
+		return strings.TrimSpace(actor) + "@" + scope
+	}
+	return firstNonEmpty(actor, scope)
+}
+
+func githubCredentialURN(tenantID string, credentialID string) string {
+	return projectionURN(tenantID, "github_credential", credentialID)
 }
 
 func githubDependabotAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -727,6 +858,16 @@ func addLink(links map[string]*ports.ProjectedLink, link *ports.ProjectedLink) {
 	}
 	key := link.FromURN + "|" + link.Relation + "|" + link.ToURN
 	links[key] = link
+}
+
+func addProjectedAttribute(attributes map[string]string, key string, value string) {
+	if attributes == nil {
+		return
+	}
+	if strings.TrimSpace(value) == "" {
+		return
+	}
+	attributes[key] = strings.TrimSpace(value)
 }
 
 func addIdentifierLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, eventID string, fromURN string, value string, occurredAt *timestamppb.Timestamp) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -585,6 +585,347 @@ func TestProjectGitHubAuditOmitsAtWhenOccurredAtMissing(t *testing.T) {
 	}
 }
 
+// The audit log API stamps actor_is_bot/actor_is_agent on every event whose
+// actor is a GitHub App identity or an integration agent. Downstream graph
+// rules (e.g. identity-github-active-without-okta-link) use these flags to
+// suppress automation actors without resorting to a hardcoded vendor
+// allowlist. The projector must forward both flags onto the github.user
+// node attrs, alongside the numeric actor_id / org_id GitHub uses to detect
+// the org-as-actor pattern.
+func TestProjectGitHubAuditStampsActorClassificationOnGithubUser(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	_, err := New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "github-audit-actor-flags",
+		TenantId:   "writer",
+		SourceId:   "github",
+		Kind:       "github.audit",
+		OccurredAt: timestamppb.New(time.Date(2025, time.March, 4, 10, 30, 0, 0, time.UTC)),
+		Attributes: map[string]string{
+			"actor":          "dependabot[bot]",
+			"actor_id":       "49699333",
+			"actor_is_bot":   "true",
+			"actor_is_agent": "false",
+			"action":         "repository_vulnerability_alert.create",
+			"org":            "writer",
+			"org_id":         "8090724",
+			"repo":           "writer/cerebro",
+			"resource_id":    "writer/cerebro",
+			"resource_type":  "repository",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	actorURN := "urn:cerebro:writer:github_user:dependabot[bot]"
+	entity, ok := graph.entities[actorURN]
+	if !ok {
+		t.Fatalf("github.user entity %q missing in graph: %#v", actorURN, graph.entities)
+	}
+	for key, want := range map[string]string{
+		"actor_id":       "49699333",
+		"actor_is_bot":   "true",
+		"actor_is_agent": "false",
+		"org_id":         "8090724",
+		"login":          "dependabot[bot]",
+	} {
+		if got := entity.Attributes[key]; got != want {
+			t.Fatalf("github.user attributes[%s] = %q, want %q; rule depends on this signal to suppress automation actors", key, got, want)
+		}
+	}
+}
+
+// `org_id` is a small but important field on the github.org node: it pins
+// the numeric ID GitHub stamps on every audit event for the org. The rule
+// uses it to disambiguate the org-as-actor pattern (where actor_id ==
+// org_id and the event represents a system-level action with no human
+// actor) from real user activity.
+func TestProjectGitHubAuditStampsOrgIDOnGithubOrg(t *testing.T) {
+	graph := &projectionRecorder{}
+	_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-audit-org-id",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"actor":         "alice",
+			"action":        "git.clone",
+			"org":           "writer",
+			"org_id":        "8090724",
+			"repo":          "writer/cerebro",
+			"resource_id":   "writer/cerebro",
+			"resource_type": "repository",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	orgURN := "urn:cerebro:writer:github_org:writer"
+	entity, ok := graph.entities[orgURN]
+	if !ok {
+		t.Fatalf("github.org entity %q missing", orgURN)
+	}
+	if got, want := entity.Attributes["org_id"], "8090724"; got != want {
+		t.Fatalf("github.org attributes[org_id] = %q, want %q", got, want)
+	}
+}
+
+// GitHub's audit log API names the org itself as the audit actor on
+// system-level events (e.g. `integration_installation.version_updated`).
+// The actor_id on those events equals the org_id, and there is no human
+// user behind the action. Minting a `github.user:<org>` node would create
+// a phantom identity that no rule could ever bridge back to Okta — the org
+// is not a user. The projector must therefore route the acted_on edge
+// from the github.org node and skip the github.user mint entirely,
+// mirroring cartography's GitHubUser vs GitHubOrganization separation.
+func TestProjectGitHubAuditRoutesActedOnFromOrgWhenActorIsOrgSelf(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	_, err := New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "github-audit-org-self",
+		TenantId:   "writer",
+		SourceId:   "github",
+		Kind:       "github.audit",
+		OccurredAt: timestamppb.New(time.Date(2025, time.March, 4, 10, 30, 0, 0, time.UTC)),
+		Attributes: map[string]string{
+			"actor":         "writer",
+			"actor_id":      "8090724",
+			"action":        "integration_installation.version_updated",
+			"org":           "writer",
+			"org_id":        "8090724",
+			"resource_id":   "writer",
+			"resource_type": "integration_installation",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	orgURN := "urn:cerebro:writer:github_org:writer"
+	resourceURN := "urn:cerebro:writer:github_resource:integration_installation:writer"
+	phantomUserURN := "urn:cerebro:writer:github_user:writer"
+	if _, ok := graph.entities[phantomUserURN]; ok {
+		t.Fatalf("phantom github.user %q minted for org-as-actor event; projector must route through github.org instead", phantomUserURN)
+	}
+	if _, ok := graph.entities[orgURN]; !ok {
+		t.Fatalf("github.org entity %q missing", orgURN)
+	}
+	if _, ok := graph.entities[resourceURN]; !ok {
+		t.Fatalf("resource entity %q missing", resourceURN)
+	}
+	link, ok := graph.links[orgURN+"|"+relationActedOn+"|"+resourceURN]
+	if !ok {
+		t.Fatalf("acted_on link missing for %s -> %s (org-as-actor must route the edge from github.org): %#v", orgURN, resourceURN, graph.links)
+	}
+	if got, want := link.Attributes["action"], "integration_installation.version_updated"; got != want {
+		t.Fatalf("acted_on attributes[action] = %q, want %q", got, want)
+	}
+	if link.Attributes["at"] == "" {
+		t.Fatalf("acted_on attributes[at] empty; rule needs the recency stamp on org-as-actor edges too")
+	}
+}
+
+// When actor_id != org_id, the projector must continue to mint a github.user
+// for the actor — this is the normal user-action path. A regression in the
+// org-self detection (e.g. mis-comparing strings or treating empty IDs as
+// equal) would silently drop every real user from the graph; this test
+// pins the correct branch.
+func TestProjectGitHubAuditMintsGithubUserWhenActorIsNotOrgSelf(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	_, err := New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-audit-user-actor",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"actor":         "alice",
+			"actor_id":      "111",
+			"action":        "git.clone",
+			"org":           "writer",
+			"org_id":        "8090724",
+			"repo":          "writer/cerebro",
+			"resource_id":   "writer/cerebro",
+			"resource_type": "repository",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	actorURN := "urn:cerebro:writer:github_user:alice"
+	resourceURN := "urn:cerebro:writer:github_repo:writer/cerebro"
+	if _, ok := graph.entities[actorURN]; !ok {
+		t.Fatalf("github.user entity %q missing for user actor; org-self detection must not trip when IDs differ", actorURN)
+	}
+	if _, ok := graph.links[actorURN+"|"+relationActedOn+"|"+resourceURN]; !ok {
+		t.Fatalf("acted_on link missing for %s -> %s; user actor path must still mint the edge", actorURN, resourceURN)
+	}
+}
+
+// Events arriving with no actor_id at all (e.g. backfilled legacy rows) must
+// fall through to the user-actor mint, not the org-self routing. We
+// explicitly require BOTH actor_id and org_id to be non-empty and equal
+// before suppressing the github.user — equality of two empty strings would
+// otherwise silently route every legacy event from github.org.
+func TestProjectGitHubAuditDoesNotTreatMissingActorIDsAsOrgSelf(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	_, err := New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-audit-no-actor-id",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"actor":         "alice",
+			"action":        "git.clone",
+			"org":           "writer",
+			"repo":          "writer/cerebro",
+			"resource_id":   "writer/cerebro",
+			"resource_type": "repository",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	actorURN := "urn:cerebro:writer:github_user:alice"
+	if _, ok := graph.entities[actorURN]; !ok {
+		t.Fatalf("github.user entity %q missing; legacy events without actor_id must NOT be treated as org-as-actor", actorURN)
+	}
+}
+
+// Git audit rows can name non-user credentials as the actor. Live data shows
+// deploy-key access as actor=deploy_key, actor_id missing, user_id=0, and
+// programmatic_access_type="Public Key (User/Deploy)"; /users/deploy_key
+// returns 404, so the source stamps actor_type=Unresolved. The projector must
+// preserve that access evidence as a github.credential, not as a
+// github.user, otherwise identity rules will chase a non-user credential that
+// can never have an Okta bridge.
+func TestProjectGitHubAuditProjectsUnresolvedPublicKeyAsCredential(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	occurred := time.Date(2026, time.May, 9, 14, 56, 28, 0, time.UTC)
+	_, err := New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "github-audit-deploy-key",
+		TenantId:   "writer",
+		SourceId:   "github",
+		Kind:       "github.audit",
+		OccurredAt: timestamppb.New(occurred),
+		Attributes: map[string]string{
+			"actor":                    "deploy_key",
+			"actor_type":               "Unresolved",
+			"action":                   "git.clone",
+			"org":                      "WriterInternal",
+			"org_id":                   "112636266",
+			"programmatic_access_type": "Public Key (User/Deploy)",
+			"repo":                     "WriterInternal/k8s",
+			"resource_id":              "WriterInternal/k8s",
+			"resource_type":            "repository",
+			"transport_protocol_name":  "ssh",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	userURN := "urn:cerebro:writer:github_user:deploy_key"
+	if _, ok := graph.entities[userURN]; ok {
+		t.Fatalf("github.user %q minted for unresolved public-key credential; deploy keys must be modeled as credentials", userURN)
+	}
+	credentialURN := "urn:cerebro:writer:github_credential:deploy_key@WriterInternal/k8s"
+	credential, ok := graph.entities[credentialURN]
+	if !ok {
+		t.Fatalf("github.credential entity %q missing: %#v", credentialURN, graph.entities)
+	}
+	if got, want := credential.EntityType, "github.credential"; got != want {
+		t.Fatalf("credential entity_type = %q, want %q", got, want)
+	}
+	for key, want := range map[string]string{
+		"actor":                    "deploy_key",
+		"credential_type":          "public_key",
+		"programmatic_access_type": "Public Key (User/Deploy)",
+		"repository":               "WriterInternal/k8s",
+		"transport_protocol_name":  "ssh",
+	} {
+		if got := credential.Attributes[key]; got != want {
+			t.Fatalf("credential attributes[%s] = %q, want %q", key, got, want)
+		}
+	}
+	resourceURN := "urn:cerebro:writer:github_repo:WriterInternal/k8s"
+	link, ok := graph.links[credentialURN+"|"+relationActedOn+"|"+resourceURN]
+	if !ok {
+		t.Fatalf("acted_on link missing for credential %s -> %s: %#v", credentialURN, resourceURN, graph.links)
+	}
+	if got, want := link.Attributes["programmatic_access_type"], "Public Key (User/Deploy)"; got != want {
+		t.Fatalf("acted_on attributes[programmatic_access_type] = %q, want %q", got, want)
+	}
+	if got, want := link.Attributes["at"], occurred.Format(time.RFC3339); got != want {
+		t.Fatalf("acted_on attributes[at] = %q, want %q", got, want)
+	}
+
+	_, err = New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "github-audit-deploy-key-other-repo",
+		TenantId:   "writer",
+		SourceId:   "github",
+		Kind:       "github.audit",
+		OccurredAt: timestamppb.New(occurred.Add(time.Minute)),
+		Attributes: map[string]string{
+			"actor":                    "deploy_key",
+			"actor_type":               "Unresolved",
+			"action":                   "git.clone",
+			"org":                      "WriterInternal",
+			"programmatic_access_type": "Public Key (User/Deploy)",
+			"repo":                     "WriterInternal/other",
+			"resource_id":              "WriterInternal/other",
+			"resource_type":            "repository",
+			"transport_protocol_name":  "ssh",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() second repo error = %v", err)
+	}
+	otherCredentialURN := "urn:cerebro:writer:github_credential:deploy_key@WriterInternal/other"
+	if _, ok := graph.entities[otherCredentialURN]; !ok {
+		t.Fatalf("github.credential entity %q missing for same deploy_key actor on another repo", otherCredentialURN)
+	}
+}
+
+// Missing actor_id alone is not enough to call an audit actor a credential:
+// GitHub git audit rows for real users can also omit actor_id. The source
+// resolves those actors through /users/{login} and stamps actor_type=User, and
+// the projector must keep the normal github.user path so real user access is
+// still evaluated by identity rules.
+func TestProjectGitHubAuditKeepsResolvedUserPublicKeyAsGithubUser(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	_, err := New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-audit-user-public-key",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"actor":                    "brandon-writer",
+			"actor_type":               "User",
+			"action":                   "git.push",
+			"org":                      "WriterInternal",
+			"org_id":                   "112636266",
+			"programmatic_access_type": "Public Key (User/Deploy)",
+			"repo":                     "WriterInternal/be.llm-gateway",
+			"resource_id":              "WriterInternal/be.llm-gateway",
+			"resource_type":            "repository",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	userURN := "urn:cerebro:writer:github_user:brandon-writer"
+	if _, ok := graph.entities[userURN]; !ok {
+		t.Fatalf("github.user %q missing for resolved User public-key actor", userURN)
+	}
+	for urn := range graph.entities {
+		if strings.Contains(urn, "github_credential:brandon-writer") {
+			t.Fatalf("github.credential %q minted for resolved User actor; public-key users must stay github.user identities", urn)
+		}
+	}
+}
+
 func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -3,7 +3,9 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -23,6 +25,7 @@ type auditPayload struct {
 	ActorIP                  string         `json:"actor_ip,omitempty"`
 	ActorIsAgent             bool           `json:"actor_is_agent,omitempty"`
 	ActorIsBot               bool           `json:"actor_is_bot,omitempty"`
+	ActorType                string         `json:"actor_type,omitempty"`
 	Business                 string         `json:"business,omitempty"`
 	BusinessID               int64          `json:"business_id,omitempty"`
 	ExternalIdentityNameID   string         `json:"external_identity_nameid,omitempty"`
@@ -73,8 +76,13 @@ func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, setting
 		return sourcecdk.Pull{}, nil
 	}
 	events := make([]*primitives.Event, 0, len(entries))
+	actorResolutionCache := map[string]auditActorResolution{}
 	for _, entry := range entries {
-		event, err := auditEvent(settings, entry)
+		actorResolution := auditActorResolution{}
+		if strings.TrimSpace(entry.GetActor()) != "" && entry.GetActorID() <= 0 {
+			actorResolution = resolveAuditActor(ctx, client, entry.GetActor(), actorResolutionCache)
+		}
+		event, err := auditEvent(settings, entry, actorResolution)
 		if err != nil {
 			return sourcecdk.Pull{}, err
 		}
@@ -116,7 +124,42 @@ func readAuditCursor(cursor *cerebrov1.SourceCursor) (string, error) {
 	return strings.TrimSpace(cursor.GetOpaque()), nil
 }
 
-func auditEvent(settings settings, entry *gogithub.AuditEntry) (*primitives.Event, error) {
+type auditActorResolution struct {
+	Login string
+	Type  string
+	ID    int64
+}
+
+func resolveAuditActor(ctx context.Context, client *gogithub.Client, actor string, cache map[string]auditActorResolution) auditActorResolution {
+	normalized := strings.TrimSpace(actor)
+	if normalized == "" || client == nil {
+		return auditActorResolution{}
+	}
+	if cached, ok := cache[normalized]; ok {
+		return cached
+	}
+	resolution := auditActorResolution{Login: normalized}
+	user, resp, err := client.Users.Get(ctx, normalized)
+	if err != nil {
+		var errResponse *gogithub.ErrorResponse
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			resolution.Type = "Unresolved"
+		} else if errors.As(err, &errResponse) && errResponse.Response != nil && errResponse.Response.StatusCode == http.StatusNotFound {
+			resolution.Type = "Unresolved"
+		}
+		cache[normalized] = resolution
+		return resolution
+	}
+	resolution.Type = strings.TrimSpace(user.GetType())
+	resolution.ID = user.GetID()
+	if login := strings.TrimSpace(user.GetLogin()); login != "" {
+		resolution.Login = login
+	}
+	cache[normalized] = resolution
+	return resolution
+}
+
+func auditEvent(settings settings, entry *gogithub.AuditEntry, actorResolution auditActorResolution) (*primitives.Event, error) {
 	occurredAt := auditOccurredAt(entry)
 	if occurredAt.IsZero() {
 		return nil, fmt.Errorf("github audit event %q missing timestamps", entry.GetDocumentID())
@@ -125,13 +168,15 @@ func auditEvent(settings settings, entry *gogithub.AuditEntry) (*primitives.Even
 	if err != nil {
 		return nil, err
 	}
+	actorID := firstPositiveInt64(entry.GetActorID(), actorResolution.ID)
 	payload, err := json.Marshal(auditPayload{
 		Action:                   entry.GetAction(),
 		Actor:                    entry.GetActor(),
-		ActorID:                  entry.GetActorID(),
+		ActorID:                  actorID,
 		ActorIP:                  rawString(raw, "actor_ip"),
 		ActorIsAgent:             rawBool(raw, "actor_is_agent"),
 		ActorIsBot:               rawBool(raw, "actor_is_bot"),
+		ActorType:                actorResolution.Type,
 		Business:                 entry.GetBusiness(),
 		BusinessID:               entry.GetBusinessID(),
 		ExternalIdentityNameID:   entry.GetExternalIdentityNameID(),
@@ -160,7 +205,7 @@ func auditEvent(settings settings, entry *gogithub.AuditEntry) (*primitives.Even
 		OccurredAt: timestamppb.New(occurredAt.UTC()),
 		SchemaRef:  "github/audit/v1",
 		Payload:    payload,
-		Attributes: auditAttributes(entry, raw, settings),
+		Attributes: auditAttributes(entry, raw, settings, actorResolution),
 	}, nil
 }
 
@@ -223,7 +268,7 @@ func checkpointAuditCursor(_ []*gogithub.AuditEntry, cursor string) string {
 	return strings.TrimSpace(cursor)
 }
 
-func auditAttributes(entry *gogithub.AuditEntry, raw map[string]any, settings settings) map[string]string {
+func auditAttributes(entry *gogithub.AuditEntry, raw map[string]any, settings settings, actorResolution auditActorResolution) map[string]string {
 	attributes := map[string]string{
 		"action":         entry.GetAction(),
 		"family":         familyAudit,
@@ -234,18 +279,37 @@ func auditAttributes(entry *gogithub.AuditEntry, raw map[string]any, settings se
 		"scope":          auditScope(entry, raw, settings),
 	}
 	addAttribute(attributes, "actor", entry.GetActor())
+	addAttribute(attributes, "actor_id", positiveInt64String(firstPositiveInt64(entry.GetActorID(), actorResolution.ID)))
 	addAttribute(attributes, "actor_is_agent", boolString(raw, "actor_is_agent"))
 	addAttribute(attributes, "actor_is_bot", boolString(raw, "actor_is_bot"))
+	addAttribute(attributes, "actor_type", actorResolution.Type)
 	addAttribute(attributes, "external_identity_nameid", entry.GetExternalIdentityNameID())
 	addAttribute(attributes, "external_identity_username", entry.GetExternalIdentityUsername())
+	// org_id is the numeric ID GitHub stamps on every audit event for the org
+	// the action belongs to. We surface it on the event so the projector can
+	// detect the org-as-actor pattern (actor_id == org_id), which occurs on
+	// system-level events like integration_installation.version_updated where
+	// GitHub names the org itself as the audit actor rather than a user.
+	addAttribute(attributes, "org_id", positiveInt64String(rawInt64(raw, "org_id")))
 	addAttribute(attributes, "programmatic_access_type", rawString(raw, "programmatic_access_type"))
 	addAttribute(attributes, "repo", rawString(raw, "repo"))
+	addAttribute(attributes, "token_id", positiveInt64String(rawInt64(raw, "token_id")))
 	addAttribute(attributes, "user", entry.GetUser())
+	addAttribute(attributes, "user_id", positiveInt64String(entry.GetUserID()))
 	addAttribute(attributes, "visibility", rawString(raw, "visibility"))
 	for _, key := range auditAdditionalAttributeKeys {
 		addAttribute(attributes, key, rawScalarString(raw, key))
 	}
 	return attributes
+}
+
+func firstPositiveInt64(values ...int64) int64 {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
 }
 
 var auditAdditionalAttributeKeys = []string{
@@ -371,6 +435,41 @@ func boolString(raw map[string]any, key string) string {
 		return ""
 	}
 	return strconv.FormatBool(boolValue)
+}
+
+// rawInt64 reads a numeric field from the raw audit log payload. The GitHub
+// audit log API returns IDs as JSON numbers, which json.Unmarshal turns into
+// float64 inside map[string]any; encoding/json never falls back to int64 for
+// untyped maps. We round to int64 here so the projector sees stable integer
+// IDs and the actor_id == org_id comparison in the rule is exact.
+func rawInt64(raw map[string]any, key string) int64 {
+	value, ok := raw[key]
+	if !ok || value == nil {
+		return 0
+	}
+	switch typed := value.(type) {
+	case float64:
+		return int64(typed)
+	case int:
+		return int64(typed)
+	case int64:
+		return typed
+	default:
+		return 0
+	}
+}
+
+// positiveInt64String returns the decimal form of a positive int64 or empty
+// when the value is non-positive. We use empty rather than "0" so the
+// downstream addAttribute helper drops the key; "0" is not a valid GitHub
+// numeric ID and is what GitHub returns when no real actor is associated
+// (deploy keys, anonymous webhook events). Suppressing the attribute keeps
+// the projected node free of placeholder zeros that a rule could trip on.
+func positiveInt64String(value int64) string {
+	if value <= 0 {
+		return ""
+	}
+	return strconv.FormatInt(value, 10)
 }
 
 func addAttribute(attributes map[string]string, key string, value string) {

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -346,7 +346,7 @@ func TestAuditAttributesForwardRulesetWeakeningMetadata(t *testing.T) {
 		"changes": map[string]any{
 			"required_status_checks": "removed",
 		},
-	}, settings{owner: "writer"})
+	}, settings{owner: "writer"}, auditActorResolution{})
 
 	if got := attributes["required_status_check_removed"]; got != "true" {
 		t.Fatalf("required_status_check_removed = %q, want true", got)
@@ -356,6 +356,36 @@ func TestAuditAttributesForwardRulesetWeakeningMetadata(t *testing.T) {
 	}
 	if got := attributes["changes"]; !strings.Contains(got, "required_status_checks") {
 		t.Fatalf("changes = %q, want encoded ruleset changes", got)
+	}
+}
+
+func TestAuditAttributesForwardResolvedActorTypeForGitEvents(t *testing.T) {
+	attributes := auditAttributes(&gogithub.AuditEntry{
+		Action: gogithub.String("git.clone"),
+		Actor:  gogithub.String("deploy_key"),
+	}, map[string]any{
+		"org":                      "WriterInternal",
+		"org_id":                   112636266,
+		"programmatic_access_type": "Public Key (User/Deploy)",
+		"repo":                     "WriterInternal/k8s",
+		"transport_protocol_name":  "ssh",
+		"user_id":                  0,
+	}, settings{owner: "WriterInternal"}, auditActorResolution{Login: "deploy_key", Type: "Unresolved"})
+
+	if got := attributes["actor_type"]; got != "Unresolved" {
+		t.Fatalf("actor_type = %q, want Unresolved", got)
+	}
+	if got := attributes["programmatic_access_type"]; got != "Public Key (User/Deploy)" {
+		t.Fatalf("programmatic_access_type = %q, want Public Key (User/Deploy)", got)
+	}
+	if got := attributes["org_id"]; got != "112636266" {
+		t.Fatalf("org_id = %q, want 112636266", got)
+	}
+	if got := attributes["actor_id"]; got != "" {
+		t.Fatalf("actor_id = %q, want empty for unresolved deploy-key actor", got)
+	}
+	if got := attributes["transport_protocol_name"]; got != "ssh" {
+		t.Fatalf("transport_protocol_name = %q, want ssh", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- enrich GitHub audit actors with org/bot/agent/credential metadata
- route org-as-actor and unresolved deploy-key access away from github.user identities
- filter weak workflow/revocation evidence from the shadow GitHub identity rule
- preserve latest acted_on metadata atomically in Neo4j merges

## Validation
- go test -count=1 -mod=mod ./...
- go vet -mod=mod ./...
- git diff --check
- git diff --cached --check