### PR TITLE
fix(findings): always resolve github audit actor type

### DIFF
--- a/internal/findings/identity_github_active_without_okta_link_rule.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule.go
@@ -388,21 +388,32 @@ func cypherListMapString(item any, key string) string {
 }
 
 // githubActorIsAutomation returns true when a github.user node's
-// attributes_json carries an explicit GitHub-stamped automation flag. The
-// source projector forwards two booleans from the audit log API onto every
+// attributes_json carries an explicit GitHub-stamped automation flag or
+// is otherwise structurally not a person that could be linked to Okta.
+// The source projector forwards three boolean/enumerated classifications
+// from the audit log API and the GitHub /users resolution onto every
 // github.user node:
 //
-//   - actor_is_bot is GitHub's classification for GitHub App identities
-//     (`<vendor>[bot]` accounts: dependabot[bot], github-actions[bot],
-//     renovate[bot], coderabbitai[bot], factory-droid[bot], and any future
-//     App-issued bot the API decides to classify the same way).
+//   - actor_is_bot is the audit-log boolean GitHub stamps on
+//     first-party App identities (dependabot[bot], github-actions[bot],
+//     coderabbitai[bot], etc.). It is NOT set for many third-party Apps,
+//     so the rule must not depend on it alone.
 //   - actor_is_agent covers fine-grained PAT / installation-token agent
 //     actions GitHub categorises as automated.
+//   - actor_type comes from the /users/{login} resolution and is the
+//     authoritative classifier across all GitHub App accounts. Type=Bot
+//     covers every App-issued identity uniformly; Type=Organization
+//     means the audit row was emitted by the org acting on itself (a
+//     stale phantom github.user node from before the org-self projector
+//     fix) and is never a real person to link; Type=Unresolved means
+//     GitHub returned 404 for the login, which happens for deleted or
+//     retired App accounts (pullrequest[bot] after uninstall, etc.) and
+//     for placeholder logins like deploy_key. None of these are
+//     linkable to a human Okta identity, so all three suppress the
+//     finding.
 //
-// Comparing the schema flag instead of pattern-matching the login string
-// lets the rule stay correct without a hardcoded vendor allowlist and
-// without paying a per-vendor maintenance tax as new GitHub App
-// integrations come online.
+// Comparing GitHub-native classifications avoids a hardcoded vendor
+// allowlist and stays correct as new App integrations come online.
 //
 // We accept the values verbatim from the audit log (strings, lower-cased
 // "true"/"false" in practice) and trim/compare case-insensitively so a
@@ -425,7 +436,8 @@ func githubActorIsAutomation(attributesJSON string) bool {
 	if strings.EqualFold(strings.TrimSpace(attrs["actor_is_agent"]), "true") {
 		return true
 	}
-	if strings.EqualFold(strings.TrimSpace(attrs["actor_type"]), "Bot") {
+	switch strings.ToLower(strings.TrimSpace(attrs["actor_type"])) {
+	case "bot", "organization", "unresolved":
 		return true
 	}
 	return false

--- a/internal/findings/identity_github_active_without_okta_link_rule_test.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule_test.go
@@ -538,6 +538,49 @@ func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsSkipsActorIsBot(t *testing.T
 	}
 }
 
+// actor_type=Organization on a github.user node means the audit row
+// surfaced the org acting on itself (org-self events such as
+// integration_installation.version_updated). New events with org-self
+// actors route through the github.org projection path; stale github.user
+// nodes from the pre-fix projection still carry edges but the resolved
+// actor_type lets the rule suppress them rather than asking a human to
+// "link the writer organisation to Okta".
+//
+// actor_type=Unresolved means GitHub returned 404 for /users/{login} when
+// the source resolver tried to classify it. That happens for retired
+// GitHub Apps (pullrequest[bot] after uninstall) and for the deploy_key
+// placeholder login: in both cases the account no longer exists as a
+// linkable identity so the finding is non-actionable.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsSkipsOrganizationAndUnresolvedActorTypes(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	cases := []struct {
+		login string
+		attrs map[string]string
+	}{
+		{login: "writer", attrs: map[string]string{"login": "writer", "actor_type": "Organization"}},
+		{login: "writer", attrs: map[string]string{"login": "writer", "actor_type": "organization"}},
+		{login: "deploy_key", attrs: map[string]string{"login": "deploy_key", "actor_type": "Unresolved"}},
+		{login: "pullrequest[bot]", attrs: map[string]string{"login": "pullrequest[bot]", "actor_type": "unresolved"}},
+	}
+	for _, tc := range cases {
+		row := githubActiveWithoutOktaRuleRowWithGitHubAttrs(
+			githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-1*time.Hour)),
+			"urn:cerebro:writer:github.user:"+tc.login,
+			tc.login,
+			"urn:cerebro:writer:github_repo:writer/cerebro",
+			tc.attrs,
+		)
+		findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+		if err != nil {
+			t.Fatalf("EvaluateRows() error = %v: attrs=%v", err, tc.attrs)
+		}
+		if len(findings) != 0 {
+			t.Fatalf("EvaluateRows() returned %d findings for actor_type=%q, want 0 (non-user actor_types must be filtered)", len(findings), tc.attrs["actor_type"])
+		}
+	}
+}
+
 // actor_is_agent=true is GitHub's classification for fine-grained PAT and
 // installation-token agent actions. The flag is stamped by the audit log API
 // itself; the rule suppresses on it for the same reason it suppresses
@@ -1078,13 +1121,18 @@ func TestGitHubActorIsAutomation(t *testing.T) {
 		"actor_is_agent TRUE upper":     {`{"actor_is_agent":"TRUE"}`, true},
 		"actor_type bot":                {`{"actor_type":"Bot"}`, true},
 		"actor_type bot lowercase":      {`{"actor_type":"bot"}`, true},
+		"actor_type bot mixed case":     {`{"actor_type":"  Bot  "}`, true},
+		"actor_type organization":       {`{"actor_type":"Organization"}`, true},
+		"actor_type org lowercase":      {`{"actor_type":"organization"}`, true},
+		"actor_type unresolved":         {`{"actor_type":"Unresolved"}`, true},
+		"actor_type unresolved lower":   {`{"actor_type":"unresolved"}`, true},
 		"both flags true":               {`{"actor_is_bot":"true","actor_is_agent":"true"}`, true},
 		"only bot true, agent false":    {`{"actor_is_bot":"true","actor_is_agent":"false"}`, true},
 		"only agent true, bot false":    {`{"actor_is_bot":"false","actor_is_agent":"true"}`, true},
 		"both flags false":              {`{"actor_is_bot":"false","actor_is_agent":"false"}`, false},
 		"bot flag absent":               {`{"login":"alice"}`, false},
 		"actor_type user":               {`{"actor_type":"User"}`, false},
-		"actor_type unresolved":         {`{"actor_type":"Unresolved"}`, false},
+		"actor_type user with id":       {`{"actor_type":"User","actor_id":"42"}`, false},
 		"bot flag empty string":         {`{"actor_is_bot":""}`, false},
 		"bot flag arbitrary value":      {`{"actor_is_bot":"maybe"}`, false},
 		"empty JSON object":             {`{}`, false},

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -78,8 +78,19 @@ func (s *Source) readAudit(ctx context.Context, client *gogithub.Client, setting
 	events := make([]*primitives.Event, 0, len(entries))
 	actorResolutionCache := map[string]auditActorResolution{}
 	for _, entry := range entries {
+		// Resolve every non-empty actor login. The audit log raw payload
+		// does NOT include an actor_type field; without resolution the
+		// projector sees only entry.ActorID (which GitHub stamps even on
+		// GitHub-App / Bot / Organization-self actors) and therefore
+		// can't tell a bot apart from a user. Resolution returns
+		// Type=Bot for GitHub Apps, Type=Organization for org-self
+		// events, Type=Unresolved for deleted/placeholder logins
+		// (deploy_key, retired bot apps), and Type=User otherwise. The
+		// shared cache keeps the per-pull cost at one /users/{login}
+		// call per unique actor, which is well within the 5000/hour
+		// authenticated rate limit for any realistic audit volume.
 		actorResolution := auditActorResolution{}
-		if strings.TrimSpace(entry.GetActor()) != "" && entry.GetActorID() <= 0 {
+		if strings.TrimSpace(entry.GetActor()) != "" {
 			actorResolution = resolveAuditActor(ctx, client, entry.GetActor(), actorResolutionCache)
 		}
 		event, err := auditEvent(settings, entry, actorResolution)

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -280,6 +280,14 @@ func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
 	if got := first.Events[0].Attributes["external_identity_nameid"]; got != "dependabot@writer.com" {
 		t.Fatalf("first.Events[0].Attributes[external_identity_nameid] = %q, want dependabot@writer.com", got)
 	}
+	// Audit Read must resolve every actor login (not just those without
+	// actor_id) so that GitHub-App identities — which always carry an
+	// actor_id — still get actor_type=Bot stamped. Without resolution
+	// the github.user node attributes_json would never reach the rule's
+	// automation check for these accounts.
+	if got := first.Events[0].Attributes["actor_type"]; got != "Bot" {
+		t.Fatalf("first.Events[0].Attributes[actor_type] = %q, want Bot", got)
+	}
 	var payload map[string]any
 	if err := json.Unmarshal(first.Events[0].Payload, &payload); err != nil {
 		t.Fatalf("unmarshal audit payload: %v", err)
@@ -799,6 +807,23 @@ func newGitHubAPIHandler(t *testing.T) http.Handler {
 			}
 			if err := json.NewEncoder(w).Encode([]map[string]any{}); err != nil {
 				t.Fatalf("encode empty pulls page: %v", err)
+			}
+		case "/api/v3/users/dependabot%5Bbot%5D",
+			"/api/v3/users/dependabot[bot]":
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"login": "dependabot[bot]",
+				"id":    49699333,
+				"type":  "Bot",
+			}); err != nil {
+				t.Fatalf("encode users response: %v", err)
+			}
+		case "/api/v3/users/octocat":
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"login": "octocat",
+				"id":    1,
+				"type":  "User",
+			}); err != nil {
+				t.Fatalf("encode users response: %v", err)
 			}
 		case "/api/v3/orgs/writer/audit-log":
 			after := r.URL.Query().Get("after")


### PR DESCRIPTION
## Summary

Live sec-dev had 20 OPEN HIGH `identity-github-active-without-okta-link` findings on top of the v2.1.13 deploy. After querying Neo4j directly, I confirmed several GitHub App / placeholder logins were leaking through the rule because they carry an `actor_id` (so the previous `actorID <= 0` guard skipped resolution) and the audit log's `actor_is_bot` boolean is **not** set for many third-party Apps:

| Login | GitHub /users API | Previous classification | New classification |
|---|---|---|---|
| pullrequest[bot] | 404 | github.user (empty actor_type) | github.user (Unresolved) → filtered |
| socket-security[bot] | type=Bot | github.user (empty actor_type) | github.user (Bot) → filtered |
| stainless-app[bot] | type=Bot | github.user (empty actor_type) | github.user (Bot) → filtered |
| writer-renovate-app[bot] | type=Bot | github.user (empty actor_type) | github.user (Bot) → filtered |
| writer-cross-repo[bot] | type=Bot | github.user (empty actor_type) | github.user (Bot) → filtered |
| writer-vulnview-k8s-sync[bot] | type=Bot | github.user (empty actor_type) | github.user (Bot) → filtered |
| writer | type=Organization | github.user (empty actor_type) | github.org (org-self routing) |
| deploy_key | 404 | github.user (empty actor_type) | github.user (Unresolved) → filtered |

## Change

1. `sources/github/audit.go` - Always resolve the actor login (cached per pull). The audit-log raw payload has no `actor_type` field, so without resolution there is no GitHub-native classifier on the github.user node. The resolution cache keeps the cost at one `/users/{login}` call per unique actor per orchestrator iteration.
2. `internal/findings/identity_github_active_without_okta_link_rule.go` - Extend the automation check to treat `actor_type=Organization` and `actor_type=Unresolved` as automation. Organization is the org acting on itself (`integration_installation.version_updated`, etc.); Unresolved is GitHub returning 404 for the login (deleted/retired Apps, placeholder logins like `deploy_key`). Neither is a linkable Okta identity.

## Validation

- `go test -count=1 -mod=mod ./...` passes.
- `go vet ./...` passes.
- `make verify` (golangci-lint + buf lint + archtests) passes.

## Live data verification

Queried Neo4j Aura directly for github.user nodes in tenant=writer; confirmed:
- `bulldozer-writer[bot]` already has `actor_is_bot=true` from the v2.1.13 deploy and is NOT in the current 20 findings.
- Bots showing up in findings (pullrequest[bot], socket-security[bot], stainless-app[bot], writer-renovate-app[bot]) lack `actor_is_bot=true` because GitHub's audit-log boolean is only set for first-party Apps; `/users/{login}` resolution returns `type=Bot` for all of them.
- `writer` resolves to `type=Organization` (id 8090724); `deploy_key` and `pullrequest[bot]` return 404.

## Follow-up

Stale `github.user:writer`, `github.user:deploy_key`, and any unstamped bot nodes from before the deploy will need to be cleaned up after this lands (their acted_on edges are inside the 30-day recency window). I will run targeted Neo4j deletes after deploy to sec-dev.

## Risk

Low. The change is additive: more actors get resolved, more rows get suppressed. The rule's fail-open posture on malformed/missing attributes is preserved.