### PR TITLE
fix(findings): suppress phantom github.user:<org> rows at cypher layer

### DIFF
--- a/internal/findings/identity_github_active_without_okta_link_rule.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule.go
@@ -183,8 +183,31 @@ func (r *githubActiveWithoutOktaLinkRule) QueryFor(runtime *cerebrov1.SourceRunt
 		// the at-attribute parser lives in one place with unit-test
 		// coverage (the attributes_json values are opaque on Neo4j
 		// pre-5.x without apoc).
+		//
+		// The leading `WHERE NOT EXISTS { ... github.org ... }` clause
+		// suppresses pre-fix phantom `github.user:<org>` nodes that
+		// were minted before the projector started routing
+		// `actor_type=Organization` / `actor_id == org_id` events
+		// through `github.org`. Those phantoms carry no `actor_type`
+		// on their `attributes_json` (the audit-actor resolver did
+		// not run on actor_id-stamped rows on the pre-fix code path)
+		// and would never re-stamp after the projector fix because
+		// every new org-self event now lands on the `github.org` node
+		// instead. Filtering by label-overlap with the tenant's
+		// `github.org` set excludes them at the cypher layer so they
+		// cannot reach EvaluateRows. The match is case-insensitive
+		// to defend against the GitHub username/org-slug case-folding
+		// rule (`writer` vs `Writer` vs `WriterInternal` all surface
+		// in audit logs in their original casing). We keep the
+		// node-side `actor_type=Organization` branch in
+		// `githubActorIsAutomation` as defense in depth in case a
+		// future projector change ever re-stamps the phantom node.
 		Query: `MATCH (g:Entity {entity_type: 'github.user', tenant_id: $tenant_id})
-      -[acted:RELATION {relation: 'acted_on'}]->(target:Entity)
+WHERE NOT EXISTS {
+  MATCH (org:Entity {entity_type: 'github.org', tenant_id: $tenant_id})
+  WHERE toLower(coalesce(org.label, '')) = toLower(coalesce(g.label, ''))
+}
+MATCH (g)-[acted:RELATION {relation: 'acted_on'}]->(target:Entity)
 WITH g, collect(DISTINCT {
        urn: target.urn,
        entity_type: coalesce(target.entity_type, ''),
@@ -252,6 +275,27 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 		githubUserLabel := cypherRowString(row, "github_user_label")
 		githubAttributesJSON := cypherRowString(row, "github_attributes_json")
 		if githubActorIsAutomation(githubAttributesJSON) {
+			continue
+		}
+		// Defense in depth for phantom github.user nodes whose
+		// `attributes_json` was projected before audit.go always
+		// resolved the actor (so the node carries no `actor_type`),
+		// but whose `acted_on` edges have since been re-stamped by
+		// the v2.1.14+ projector. The projector writes `actor_type`
+		// onto every `acted_on` edge it merges, so a recent
+		// edge-side automation classification is a reliable signal
+		// that the user is non-linkable even when the node-side
+		// blob has not yet caught up (mergeGraphAttributes is
+		// latest-wins per-key, so the node IS supposed to converge
+		// on the same value — but a single early evaluation cycle
+		// after a fresh audit ingest can run before the per-key
+		// merge has rotated the node blob, especially when the
+		// graph rule eval immediately follows source ingest in the
+		// same orchestrator iteration). We keep this check after
+		// the node-level check so that the cheaper, single-blob
+		// classification still short-circuits before we touch the
+		// per-target list.
+		if githubRecentEdgeMarksAutomation(cypherRowList(row, "targets"), now, identityGitHubActiveWithoutOktaRecencyWindow) {
 			continue
 		}
 		// The cypher emits one row per github user; rows for the same
@@ -436,11 +480,62 @@ func githubActorIsAutomation(attributesJSON string) bool {
 	if strings.EqualFold(strings.TrimSpace(attrs["actor_is_agent"]), "true") {
 		return true
 	}
-	switch strings.ToLower(strings.TrimSpace(attrs["actor_type"])) {
+	return githubActorTypeClassifiesAutomation(attrs["actor_type"])
+}
+
+// githubActorTypeClassifiesAutomation centralises the actor_type → automation
+// mapping so the node-side (`attributes_json` on github.user) and the
+// edge-side (`attributes_json` on acted_on) checks agree on the same set
+// of non-linkable types: Bot (GitHub App), Organization (org acting on
+// itself — stale phantom github.user pre-fix path), and Unresolved (GitHub
+// returned 404 for /users/{login}, e.g. retired GitHub Apps or synthetic
+// placeholder logins like deploy_key). The compare is case-insensitive to
+// defend against future API casing changes.
+func githubActorTypeClassifiesAutomation(actorType string) bool {
+	switch strings.ToLower(strings.TrimSpace(actorType)) {
 	case "bot", "organization", "unresolved":
 		return true
 	}
 	return false
+}
+
+// githubRecentEdgeMarksAutomation returns true when any acted_on edge
+// within the recency window classifies its actor as automation. The
+// projector stamps `actor_type` onto every acted_on edge it merges, so a
+// recent edge with `actor_type=Bot/Organization/Unresolved` is a reliable
+// signal that the user is non-linkable even when the github.user node's
+// `attributes_json` has not yet caught up with the per-key merge.
+func githubRecentEdgeMarksAutomation(targets []any, now time.Time, window time.Duration) bool {
+	for _, target := range targets {
+		attrs := cypherListMapString(target, "acted_attributes_json")
+		if !edgeIsRecent(attrs, now, window) {
+			continue
+		}
+		if githubEdgeActorTypeIsAutomation(attrs) {
+			return true
+		}
+	}
+	return false
+}
+
+// githubEdgeActorTypeIsAutomation parses the acted_on edge's
+// `attributes_json` and reports whether its `actor_type` field classifies
+// the actor as automation. The edge schema does not currently carry
+// `actor_is_bot` or `actor_is_agent` (those are stamped only on the
+// github.user node), so this check focuses on the resolver-stamped
+// `actor_type` field exclusively. Returns false for malformed / empty
+// JSON: the rule defaults to surfacing for review rather than silently
+// suppressing a real shadow account whose edge blob is corrupt.
+func githubEdgeActorTypeIsAutomation(attributesJSON string) bool {
+	trimmed := strings.TrimSpace(attributesJSON)
+	if trimmed == "" {
+		return false
+	}
+	var attrs map[string]string
+	if err := json.Unmarshal([]byte(trimmed), &attrs); err != nil {
+		return false
+	}
+	return githubActorTypeClassifiesAutomation(attrs["actor_type"])
 }
 
 func githubActedOnIsCurrentAccessEvidence(attributesJSON string) bool {

--- a/internal/findings/identity_github_active_without_okta_link_rule_test.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule_test.go
@@ -30,9 +30,13 @@ func TestGitHubActiveWithoutOktaLinkRuleQueryScopesByTenant(t *testing.T) {
 	// edges as evidence of a current link and silently suppress the
 	// finding after a rename. The cypher must OPTIONAL MATCH the
 	// bridge and surface the edge attributes so EvaluateRows can apply
-	// the recency check.
-	if strings.Contains(request.Query, "NOT EXISTS") {
-		t.Fatalf("Query uses NOT EXISTS for bridge check; stale represents_identity edges would mask shadow access. Must OPTIONAL MATCH and check `at` recency in EvaluateRows:\n%s", request.Query)
+	// the recency check. (NOT EXISTS is still used for the
+	// github.org overlap filter on github.user phantoms — that is a
+	// different node-set entirely and is asserted separately below.)
+	for _, line := range strings.Split(request.Query, "\n") {
+		if strings.Contains(line, "represents_identity") && strings.Contains(line, "NOT EXISTS") {
+			t.Fatalf("Query uses NOT EXISTS for the represents_identity bridge; stale upsert-only edges would mask shadow access after a rename. Must OPTIONAL MATCH and check `at` recency in EvaluateRows. Offending line:\n%s\nFull query:\n%s", line, request.Query)
+		}
 	}
 	if !strings.Contains(request.Query, "OPTIONAL MATCH") {
 		t.Fatalf("Query missing OPTIONAL MATCH for the represents_identity bridge:\n%s", request.Query)
@@ -48,6 +52,27 @@ func TestGitHubActiveWithoutOktaLinkRuleQueryScopesByTenant(t *testing.T) {
 	}
 	if !strings.Contains(request.Query, "okta.user") {
 		t.Fatalf("Query missing okta.user entity type predicate in the bridge OPTIONAL MATCH:\n%s", request.Query)
+	}
+	// Phantom `github.user:<org>` nodes minted before the projector
+	// started routing org-self actor events through `github.org`
+	// stay in the graph forever: they carry no `actor_type` on
+	// `attributes_json` (the audit-actor resolver did not run on
+	// actor_id-stamped rows pre-fix) and every new org-self event
+	// re-routes through `github.org` instead of re-stamping the
+	// phantom. The rule must suppress them at the cypher layer or
+	// they would keep producing false positives until graph
+	// cleanup. The label-overlap filter excludes any github.user
+	// whose label matches an existing github.org label in the same
+	// tenant; this is the only signal that survives a stale
+	// `attributes_json` blob.
+	if !strings.Contains(request.Query, "github.org") {
+		t.Fatalf("Query missing github.org overlap filter; phantom github.user:<org> rows would keep producing false positives until manual graph cleanup. Query:\n%s", request.Query)
+	}
+	if !strings.Contains(request.Query, "NOT EXISTS") {
+		t.Fatalf("Query missing `NOT EXISTS { ... github.org ... }` suppression clause; the rule must reject phantom github.user nodes whose label matches a github.org in the same tenant. Query:\n%s", request.Query)
+	}
+	if !strings.Contains(request.Query, "toLower(") {
+		t.Fatalf("Query missing case-insensitive label comparison; GitHub usernames and org slugs round-trip with original casing (e.g. `writer` vs `WriterInternal`), so the overlap predicate must lower-case both sides. Query:\n%s", request.Query)
 	}
 	// Both target and bridge fan-outs MUST be collapsed via collect()
 	// before LIMIT $row_limit clamps the result set. Without the
@@ -1090,6 +1115,183 @@ func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsBridgesListPairing(t *testin
 			}
 			if gotN != wantN {
 				t.Fatalf("EvaluateRows() returned %d findings, want %d for %q", gotN, wantN, name)
+			}
+		})
+	}
+}
+
+// Phantom github.user nodes that survived from before audit.go always
+// resolved actors do not carry `actor_type` on their `attributes_json`,
+// but new audit events under the v2.1.14+ projector stamp `actor_type`
+// onto every acted_on edge they merge. A recent edge that classifies
+// the actor as automation (Bot / Organization / Unresolved) is therefore
+// a reliable signal that the user is non-linkable, even when the node's
+// blob has not yet caught up via mergeGraphAttributes. EvaluateRows
+// must honour the edge-side classification or the rule keeps emitting
+// findings for accounts that have already been classified out by the
+// resolver. The test exercises the canonical phantom logins from live
+// data (deploy_key, pullrequest[bot], socket-security[bot], the writer
+// org acting on itself before the org-self routing fix).
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsEdgeActorTypeSuppressesPhantom(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	now := time.Now().UTC()
+	freshAt := now.Add(-1 * time.Hour)
+	cases := []struct {
+		name        string
+		login       string
+		edgeAttrs   string
+		nodeAttrs   map[string]string
+		wantEmit    bool
+		description string
+	}{
+		{
+			name:      "phantom node stale, fresh edge Bot",
+			login:     "socket-security[bot]",
+			edgeAttrs: `{"action":"git.clone","actor_type":"Bot","at":"` + freshAt.Format(time.RFC3339) + `"}`,
+			nodeAttrs: map[string]string{"login": "socket-security[bot]"},
+			wantEmit:  false,
+		},
+		{
+			name:      "phantom node stale, fresh edge Unresolved",
+			login:     "deploy_key",
+			edgeAttrs: `{"action":"git.clone","actor_type":"Unresolved","at":"` + freshAt.Format(time.RFC3339) + `"}`,
+			nodeAttrs: map[string]string{"login": "deploy_key"},
+			wantEmit:  false,
+		},
+		{
+			name:      "phantom node stale, fresh edge Organization",
+			login:     "writer",
+			edgeAttrs: `{"action":"git.clone","actor_type":"Organization","at":"` + freshAt.Format(time.RFC3339) + `"}`,
+			nodeAttrs: map[string]string{"login": "writer"},
+			wantEmit:  false,
+		},
+		{
+			name:      "phantom node stale, fresh edge lower-case bot",
+			login:     "pullrequest[bot]",
+			edgeAttrs: `{"action":"git.clone","actor_type":"bot","at":"` + freshAt.Format(time.RFC3339) + `"}`,
+			nodeAttrs: map[string]string{"login": "pullrequest[bot]"},
+			wantEmit:  false,
+		},
+		{
+			name:        "real user, fresh edge User must NOT suppress",
+			login:       "samjulien",
+			edgeAttrs:   `{"action":"git.clone","actor_type":"User","at":"` + freshAt.Format(time.RFC3339) + `"}`,
+			nodeAttrs:   map[string]string{"login": "samjulien", "actor_type": "User"},
+			wantEmit:    true,
+			description: "actor_type=User means a real human actor, finding must emit",
+		},
+		{
+			name:        "phantom node stale, edge actor_type empty must NOT suppress",
+			login:       "alice",
+			edgeAttrs:   `{"action":"git.clone","at":"` + freshAt.Format(time.RFC3339) + `"}`,
+			nodeAttrs:   map[string]string{"login": "alice"},
+			wantEmit:    true,
+			description: "no actor_type classification on either side; rule defaults to surfacing",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			row := githubActiveWithoutOktaRuleRowWithGitHubAttrs(
+				tc.edgeAttrs,
+				"urn:cerebro:writer:github.user:"+tc.login,
+				tc.login,
+				"urn:cerebro:writer:github_repo:writer/cerebro",
+				tc.nodeAttrs,
+			)
+			findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+			if err != nil {
+				t.Fatalf("EvaluateRows() error = %v", err)
+			}
+			gotN := len(findings)
+			wantN := 0
+			if tc.wantEmit {
+				wantN = 1
+			}
+			if gotN != wantN {
+				t.Fatalf("EvaluateRows() returned %d findings, want %d for %s (%s)", gotN, wantN, tc.name, tc.description)
+			}
+		})
+	}
+}
+
+// Edge-side automation classifications must respect the recency window.
+// A stale edge with actor_type=Bot from years ago is not evidence that
+// the user is currently automation — the audit log API could have
+// re-classified the login as a human user since then. We only suppress
+// on automation markers that survived the recency cutoff.
+func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsStaleEdgeAutomationDoesNotSuppress(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	now := time.Now().UTC()
+	staleAt := now.Add(-90 * 24 * time.Hour)
+	freshAt := now.Add(-1 * time.Hour)
+	row := githubActiveWithoutOktaRuleRowFull(
+		"urn:cerebro:writer:github.user:alice",
+		"alice",
+		[]githubActiveWithoutOktaTestTarget{
+			{
+				urn:                 "urn:cerebro:writer:github_repo:writer/cerebro",
+				entityType:          "github.repo",
+				label:               "writer/cerebro",
+				actedAttributesJSON: `{"action":"git.clone","actor_type":"Bot","at":"` + staleAt.Format(time.RFC3339) + `"}`,
+			},
+			{
+				urn:                 "urn:cerebro:writer:github_repo:writer/palmyra",
+				entityType:          "github.repo",
+				label:               "writer/palmyra",
+				actedAttributesJSON: `{"action":"git.clone","at":"` + freshAt.Format(time.RFC3339) + `"}`,
+			},
+		},
+		nil,
+	)
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("EvaluateRows() returned %d findings, want 1; stale Bot edge must NOT suppress when a fresh non-bot edge exists for the same user", len(findings))
+	}
+	finding := findings[0]
+	if got, want := finding.Attributes["target_count"], "1"; got != want {
+		t.Fatalf("target_count = %q, want %q (only the fresh non-bot edge should remain)", got, want)
+	}
+}
+
+// githubEdgeActorTypeIsAutomation parses the acted_on edge's
+// `attributes_json` and reports whether its `actor_type` field classifies
+// the actor as automation. The helper is shared with the node-side check
+// via githubActorTypeClassifiesAutomation; this table pins:
+//
+//   - the canonical Bot/Organization/Unresolved classifications suppress
+//   - case variations are honoured
+//   - User and other types do NOT suppress
+//   - empty, malformed, or non-actor_type JSON falls open
+func TestGitHubEdgeActorTypeIsAutomation(t *testing.T) {
+	cases := map[string]struct {
+		attributesJSON string
+		want           bool
+	}{
+		"edge actor_type Bot":              {`{"actor_type":"Bot"}`, true},
+		"edge actor_type bot lowercase":    {`{"actor_type":"bot"}`, true},
+		"edge actor_type Organization":     {`{"actor_type":"Organization"}`, true},
+		"edge actor_type org lower":        {`{"actor_type":"organization"}`, true},
+		"edge actor_type Unresolved":       {`{"actor_type":"Unresolved"}`, true},
+		"edge actor_type unresolved lower": {`{"actor_type":"unresolved"}`, true},
+		"edge actor_type whitespace bot":   {`{"actor_type":"  Bot  "}`, true},
+		"edge actor_type User":             {`{"actor_type":"User"}`, false},
+		"edge actor_type empty":            {`{"actor_type":""}`, false},
+		"edge no actor_type":               {`{"action":"git.clone"}`, false},
+		"empty JSON object":                {`{}`, false},
+		"empty string":                     {``, false},
+		"whitespace string":                {`   `, false},
+		"malformed JSON":                   {`{not valid`, false},
+		"non-object JSON":                  {`"string"`, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := githubEdgeActorTypeIsAutomation(tc.attributesJSON); got != tc.want {
+				t.Fatalf("githubEdgeActorTypeIsAutomation(%q) = %v, want %v", tc.attributesJSON, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Follow-up to PR #538: address droid-review feedback

PR #538's `actor_type=Organization` branch in `githubActorIsAutomation` is
unreachable for fresh ingest because the projector routes org-self actor
events (`actor_type=Organization` or `actor_id == org_id`) through
`github.org` instead of minting a `github.user` node. Pre-fix phantom
`github.user:<org>` rows (e.g. `writer` in the `writer` tenant) keep
their original `attributes_json` with no `actor_type` and would never
re-stamp under v2.1.14, so the rule kept emitting false positives for
them after that fix landed.

### What this changes

1. **Cypher-layer suppression for org-self phantoms.** The `QueryFor`
   cypher now starts with a `NOT EXISTS { MATCH (org:Entity {entity_type:
   'github.org', tenant_id: $tenant_id}) WHERE toLower(org.label) =
   toLower(g.label) }` clause. Any `github.user` whose label matches an
   existing `github.org` label in the same tenant is excluded from the
   result set entirely; the rule can no longer fire on stale phantoms
   even when the node blob lacks `actor_type`. The case-insensitive
   compare defends against GitHub's casing round-trip (`writer` vs
   `WriterInternal` are both real org slugs in this tenant).

2. **Edge-side `actor_type` defense in depth.** The v2.1.14+ projector
   stamps `actor_type` onto every `acted_on` edge it merges, so a
   recent edge with `actor_type=Bot/Organization/Unresolved` is a
   reliable signal that the user is non-linkable even when the node
   blob has not yet converged. `EvaluateRows` now suppresses on any
   recent edge's automation classification via
   `githubRecentEdgeMarksAutomation`. The check runs after the
   single-blob node check so the cheap path still short-circuits.

3. **Shared `actor_type` classifier.** Node-side and edge-side checks
   now share `githubActorTypeClassifiesAutomation` so they cannot
   disagree on what counts as non-linkable.

### Live data this fixes

| Login | Why it was leaking | Now suppressed by |
| --- | --- | --- |
| `writer` | Phantom `github.user:writer` (label matches `github.org:writer`); pre-v2.1.14 `attributes_json` has no `actor_type`. | Cypher `NOT EXISTS` overlap filter on `github.org`. |
| `WriterInternal` (if surfaced) | Same as above for `github.org:WriterInternal`. | Same filter; case-insensitive compare. |
| `socket-security[bot]`, `writer-cross-repo[bot]`, etc. | New audit events under v2.1.14+ stamp `actor_type=Bot` on the `acted_on` edge before mergeGraphAttributes rotates the node blob. | Edge-side `actor_type=Bot` short-circuit, plus existing node-side check once merge catches up. |
| `deploy_key`, `pullrequest[bot]` | Resolver returns 404 → `actor_type=Unresolved`; same projector race. | Edge-side `actor_type=Unresolved` short-circuit, plus existing node-side check once merge catches up. |

### Tests

- `TestGitHubActiveWithoutOktaLinkRuleQueryScopesByTenant` extended
  to assert the new cypher clauses: presence of `github.org`,
  `NOT EXISTS`, and `toLower(`. The existing `NOT EXISTS` guard
  against `represents_identity` was rewritten to only forbid that
  pairing (not all `NOT EXISTS` usage in the query).
- `TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsEdgeActorTypeSuppressesPhantom`:
  phantom logins (`socket-security[bot]`, `deploy_key`, `writer`,
  `pullrequest[bot]`) with stale node attrs but recent edge
  `actor_type=Bot/Organization/Unresolved` are suppressed; real
  users with `actor_type=User` and empty `actor_type` are NOT
  suppressed.
- `TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsStaleEdgeAutomationDoesNotSuppress`:
  a stale `actor_type=Bot` edge does NOT suppress when a fresh
  non-bot edge exists for the same user; the recency window guards
  the classification.
- `TestGitHubEdgeActorTypeIsAutomation`: table-driven coverage of the
  edge-side classifier covering case variation, malformed JSON, and
  unrelated types.

### Verification

- `go test ./... -count=1`: all packages pass.
- `make verify`: golangci-lint, buf lint, archtests all green.
- No new dependencies; no public API changes.
