### PR TITLE
fix(orchestrator): bound post-sync phases + stamp synthetic target actor_type

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -28,6 +28,19 @@ const defaultSourceRuntimeLeaseTTL = 30 * time.Minute
 const sourceRuntimeLeaseReleaseTimeout = 5 * time.Second
 const sourceRuntimeLeaseOverscanLimit = 100
 
+// orchestratorPhaseTimeout bounds each post-sync runtime phase
+// (`finding_rules`, `graph_ingest`, `graph_rules`) independently so a
+// single blocked downstream call (e.g. a Neo4j tx waiting on a row lock,
+// or a source.Read() retrying against an exhausted GitHub rate-limit
+// budget) cannot stall the orchestrator iteration indefinitely. The
+// limit is conservative: writer-org runs in production observe ~2.5 min
+// for all three phases combined, so 15 min/step leaves ~4× headroom for
+// slower tenants and concurrent contention while still cutting off
+// pathologically stuck runs well within the lease TTL. On timeout the
+// phase fails fast, the runtime lease releases, and the next iteration
+// retries from a clean context.
+const orchestratorPhaseTimeout = 15 * time.Minute
+
 type orchestratorOptions struct {
 	Filter         ports.SourceRuntimeFilter `json:"filter"`
 	PageLimit      uint32                    `json:"page_limit,omitempty"`
@@ -406,7 +419,22 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "pages_read", runtimeResult.PagesRead)
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "events_appended", runtimeResult.EventsAppended)
 		}
-		findingResult, err := findingService.EvaluateSourceRuntimeRules(runtimeCtx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit})
+		// Each post-sync phase runs under its own telemetry span and a
+		// dedicated context timeout. Both are intentional: the span gives
+		// operators a span_end event per phase so a stall shows up as a
+		// missing span_end on the specific phase rather than an opaque
+		// silence between source_runtime.sync.span_end and
+		// orchestrator.runtime.span_end; the timeout lets a single
+		// pathologically blocked downstream (Neo4j row lock contention
+		// across concurrent runtimes writing the same tenant, or a
+		// source.Read() retry storm against an exhausted upstream rate
+		// limit) fail fast so the lease renews and the next iteration
+		// retries from a clean state. The phase contexts are derived
+		// from runtimeCtx (NOT ctx) so they inherit lease-renewal
+		// cancellation while still being independently bounded.
+		findingResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.finding_rules", iteration, runtime, orchestratorPhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateRulesResult, error) {
+			return findingService.EvaluateSourceRuntimeRules(phaseCtx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit})
+		})
 		if err != nil {
 			if errors.Is(err, findings.ErrRuleUnavailable) {
 				runtimeResult.FindingRules = "skipped"
@@ -424,7 +452,9 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "events_evaluated", runtimeResult.EventsEvaluated)
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_evaluations", runtimeResult.FindingEvaluations)
 		}
-		graphResult, err := graphService.RunRuntime(runtimeCtx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"})
+		graphResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_ingest", iteration, runtime, orchestratorPhaseTimeout, func(phaseCtx context.Context) (*graphingest.RunResult, error) {
+			return graphService.RunRuntime(phaseCtx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"})
+		})
 		runtimeSpanAttrs = applyGraphIngestCounters(runtimeResult, graphResult, runtimeSpanAttrs)
 		if err != nil {
 			runtimeResult.GraphIngest = "failed"
@@ -439,7 +469,9 @@ func runOrchestratorIteration(
 		// rules are read-only, so deferring them until the next iteration would needlessly delay
 		// detection and stale-finding auto-resolution.
 		if graphResult != nil && graphResult.Ingest != nil {
-			graphRulesResult, err := findingService.EvaluateSourceRuntimeGraphRules(runtimeCtx, findings.EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
+			graphRulesResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_rules", iteration, runtime, orchestratorPhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateGraphRulesResult, error) {
+				return findingService.EvaluateSourceRuntimeGraphRules(phaseCtx, findings.EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
+			})
 			runtimeSpanAttrs = applyGraphRuleCounters(runtimeResult, graphRulesResult, runtimeSpanAttrs)
 			if err != nil {
 				if errors.Is(err, findings.ErrGraphRuntimeUnavailable) || errors.Is(err, findings.ErrRuntimeUnavailable) {
@@ -485,6 +517,45 @@ func runOrchestratorIteration(
 	spanAttributes = withTelemetryField(spanAttributes, "runtimes_attempted", len(result.Runtimes))
 	spanAttributes = withTelemetryField(spanAttributes, "runtimes_acquired", acquiredCount)
 	return result, runErr
+}
+
+// runOrchestratorPhase wraps a single post-sync orchestrator step
+// (`finding_rules`, `graph_ingest`, `graph_rules`) with a named telemetry
+// span and a dedicated context timeout. The span surfaces a span_end
+// event per phase — without it, a stall between source_runtime.sync and
+// orchestrator.runtime is opaque: there's no way to tell which step is
+// blocked from logs alone. The timeout decouples per-phase liveness from
+// the runtime-level lease TTL, so a single Neo4j tx waiting on a row
+// lock or a source.Read() retry storm can't park the iteration
+// indefinitely. On context deadline the phase returns
+// context.DeadlineExceeded, which the caller treats like any other
+// failure (lease releases, next iteration retries).
+//
+// The phase context is derived from runtimeCtx so it still receives
+// lease-renewal cancellation. The generic R parameter lets each phase
+// return its own result type without an interface boxing dance.
+func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iteration uint32, runtime *cerebrov1.SourceRuntime, timeout time.Duration, fn func(context.Context) (R, error)) (R, error) {
+	phaseCtx, cancel := context.WithTimeout(runtimeCtx, timeout)
+	defer cancel()
+	phaseCtx, span := telemetry.Start(phaseCtx, name, telemetry.Attrs(
+		telemetryField("iteration", iteration),
+		telemetryField("runtime_id", runtime.GetId()),
+		telemetryField("source_id", runtime.GetSourceId()),
+		telemetryField("tenant_id", runtime.GetTenantId()),
+		telemetryField("timeout_ms", timeout.Milliseconds()),
+	))
+	result, err := fn(phaseCtx)
+	status := "completed"
+	endAttrs := telemetry.Attrs()
+	if err != nil {
+		status = "failed"
+		endAttrs = withTelemetryField(endAttrs, "error", err.Error())
+		if errors.Is(err, context.DeadlineExceeded) {
+			endAttrs = withTelemetryField(endAttrs, "timeout_exceeded", true)
+		}
+	}
+	telemetry.End(span, status, endAttrs)
+	return result, err
 }
 
 func applyGraphIngestCounters(runtimeResult *orchestratorRuntimeResult, graphResult *graphingest.RunResult, attrs telemetry.Attributes) telemetry.Attributes {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -70,6 +70,76 @@ func TestOrchestratorShutdownSignalsIncludeSIGTERM(t *testing.T) {
 	}
 }
 
+// A blocked downstream call (e.g. a Neo4j tx waiting on a row lock held
+// by a concurrent runtime, or a source.Read() retry storm against an
+// exhausted upstream rate limit) must not park an orchestrator iteration
+// indefinitely. runOrchestratorPhase wraps each post-sync step in a
+// dedicated context.WithTimeout that fires independently of the
+// runtime-level lease TTL, so a phase that exceeds its budget returns
+// context.DeadlineExceeded and the caller can mark the phase failed,
+// release the lease, and let the next iteration retry from a clean
+// context. Without this, the only path out of a stuck phase is to kill
+// the Fargate task — exactly the symptom that motivated this fix.
+func TestRunOrchestratorPhaseFailsFastOnTimeout(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "github", TenantId: "writer"}
+	start := time.Now()
+	_, err := runOrchestratorPhase[*struct{}](context.Background(), "orchestrator.test_phase", 1, runtime, 5*time.Millisecond, func(phaseCtx context.Context) (*struct{}, error) {
+		<-phaseCtx.Done()
+		return nil, phaseCtx.Err()
+	})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("runOrchestratorPhase() error = nil, want context.DeadlineExceeded")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runOrchestratorPhase() error = %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed >= 2*time.Second {
+		t.Fatalf("runOrchestratorPhase elapsed = %v, want fail-fast under per-phase budget; without the timeout the phase would block until lease expiry", elapsed)
+	}
+}
+
+// runOrchestratorPhase must propagate the result returned by the wrapped
+// function on success and not paper over the underlying error type when
+// the function fails for non-timeout reasons. This keeps caller error
+// branches (e.g. ErrRuleUnavailable / ErrGraphRuntimeUnavailable
+// short-circuits) working through the phase wrapper.
+func TestRunOrchestratorPhasePassesThroughErrors(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "github", TenantId: "writer"}
+	wantErr := errors.New("downstream failure")
+	result, err := runOrchestratorPhase[int](context.Background(), "orchestrator.test_phase", 1, runtime, time.Second, func(_ context.Context) (int, error) {
+		return 42, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runOrchestratorPhase() error = %v, want %v", err, wantErr)
+	}
+	if result != 42 {
+		t.Fatalf("runOrchestratorPhase() result = %d, want 42 (passed through even on error so callers can apply counters)", result)
+	}
+}
+
+// runOrchestratorPhase must inherit cancellation from the parent runtime
+// context. The orchestrator's lease-renewal goroutine cancels the
+// runtime context when lease renewal fails, and that cancellation must
+// reach the phase function so it doesn't keep working with a stale
+// lease.
+func TestRunOrchestratorPhaseInheritsParentCancellation(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "github", TenantId: "writer"}
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := runOrchestratorPhase[*struct{}](parent, "orchestrator.test_phase", 1, runtime, time.Minute, func(phaseCtx context.Context) (*struct{}, error) {
+		select {
+		case <-phaseCtx.Done():
+			return nil, phaseCtx.Err()
+		case <-time.After(time.Second):
+			return nil, errors.New("phase did not observe parent cancellation")
+		}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runOrchestratorPhase() error = %v, want context.Canceled (inherited from parent)", err)
+	}
+}
+
 func TestRunOrchestratorIterationStopsAfterSyncFailure(t *testing.T) {
 	store := &orchestratorRuntimeStore{
 		runtime:  &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "missing-source"},

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -455,13 +455,30 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 	previousActorURN := githubUserURN(tenantID, actor)
 	targetURN := githubUserURN(tenantID, targetUser)
 	if targetURN != "" && targetURN != previousActorURN {
+		targetAttrs := map[string]string{"login": targetUser}
+		// Target-context github.user nodes (e.g. `team.add_member`, where
+		// targetUser is the user being added) carry no actor resolution
+		// because the audit event's actor_* fields describe the issuer of
+		// the action, not the recipient. When the recipient login matches
+		// a structural automation pattern — GitHub's reserved `[bot]`
+		// suffix for App-issued identities, or synthetic placeholder
+		// logins like `deploy_key` for SSH-key activity — stamp the
+		// node's `actor_type` defensively so downstream identity rules
+		// can classify the entity as non-linkable without relying on
+		// later actor-context events to converge the blob via
+		// `mergeGraphAttributes`. Without this, target-only phantoms can
+		// linger indefinitely once the audit-log window scrolls past the
+		// last event that had them as the actor.
+		if classification := githubSyntheticTargetActorType(targetUser); classification != "" {
+			targetAttrs["actor_type"] = classification
+		}
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        targetURN,
 			TenantID:   tenantID,
 			SourceID:   event.GetSourceId(),
 			EntityType: "github.user",
 			Label:      targetUser,
-			Attributes: map[string]string{"login": targetUser},
+			Attributes: targetAttrs,
 		})
 		if resourceURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, resourceURN, relationTargeted, map[string]string{"event_id": event.GetId()}))
@@ -476,6 +493,51 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 func isGitHubPublicKeyCredential(programmaticAccessType string) bool {
 	normalized := strings.ToLower(strings.TrimSpace(programmaticAccessType))
 	return strings.Contains(normalized, "public key")
+}
+
+// githubSyntheticTargetActorType returns the `actor_type` value to stamp
+// onto a target-context github.user node when its login is structurally
+// synthetic (i.e. not a real user that could be linked to Okta). The
+// returned value is one of the automation classifications recognised by
+// `githubActorTypeClassifiesAutomation` in the findings package — keeping
+// the string set in sync with that helper is part of the suppression
+// contract.
+//
+// Two synthetic shapes are recognised today:
+//
+//   - GitHub reserves the trailing `[bot]` suffix for App-issued
+//     identities (dependabot[bot], github-actions[bot], renovate[bot],
+//     coderabbitai[bot], factory-droid[bot], ...). The suffix is part of
+//     GitHub's public contract; vendor changes don't alter it. We stamp
+//     these as `Bot` so the identity rule treats them like any other
+//     App-issued account even when only target-context events ever
+//     surface them.
+//
+//   - The literal `deploy_key` login is GitHub's synthetic placeholder
+//     for SSH-key activity (no real /users/{login} resolution). The
+//     actor-side projector path routes these to `github.credential`
+//     via `actorIsUnresolvedPublicKey`, but target-context events
+//     (typically deploy-key lifecycle audit entries) still mint a
+//     `github.user:deploy_key` node. We stamp `Unresolved` so the same
+//     classifier short-circuits.
+//
+// Returns "" when the login is a plain human-shaped GitHub username so
+// the existing target-context projection (`{login: <user>}` only) is
+// preserved.
+func githubSyntheticTargetActorType(login string) string {
+	trimmed := strings.TrimSpace(login)
+	if trimmed == "" {
+		return ""
+	}
+	lower := strings.ToLower(trimmed)
+	if strings.HasSuffix(lower, "[bot]") {
+		return "Bot"
+	}
+	switch lower {
+	case "deploy_key", "deploy-key":
+		return "Unresolved"
+	}
+	return ""
 }
 
 func githubPublicKeyCredentialID(tokenID string, actor string, repo string, resourceID string, org string) string {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -635,6 +635,124 @@ func TestProjectGitHubAuditStampsActorClassificationOnGithubUser(t *testing.T) {
 	}
 }
 
+// When an audit event names a TARGET user (`team_member.added`,
+// `org.add_member`, etc.) the projector mints a github.user node for the
+// target with only `{login: <user>}` because the audit event's actor_*
+// fields describe the issuer, not the recipient. For human targets this
+// is correct — converging actor_type via mergeGraphAttributes will happen
+// later when the target themselves act on something. But for structural
+// automation logins (`[bot]`-suffixed GitHub Apps, the synthetic
+// `deploy_key` placeholder) there is no convergence path: those logins
+// either never act (deploy_key activity is routed to github.credential
+// on the actor side) or only surface in target-context audit events. We
+// must therefore stamp `actor_type` defensively on the target-context
+// node so identity rules can short-circuit them on the very first
+// evaluation cycle.
+func TestProjectGitHubAuditStampsActorTypeOnSyntheticTargetUser(t *testing.T) {
+	cases := []struct {
+		name             string
+		targetLogin      string
+		wantActorType    string
+		wantSuppressedBy string
+	}{
+		{
+			name:             "bot suffix is classified as Bot",
+			targetLogin:      "pullrequest[bot]",
+			wantActorType:    "Bot",
+			wantSuppressedBy: "githubActorTypeClassifiesAutomation(Bot)",
+		},
+		{
+			name:             "uppercase Bot suffix is classified as Bot",
+			targetLogin:      "Renovate[Bot]",
+			wantActorType:    "Bot",
+			wantSuppressedBy: "githubActorTypeClassifiesAutomation(Bot)",
+		},
+		{
+			name:             "deploy_key is classified as Unresolved",
+			targetLogin:      "deploy_key",
+			wantActorType:    "Unresolved",
+			wantSuppressedBy: "githubActorTypeClassifiesAutomation(Unresolved)",
+		},
+		{
+			name:             "deploy-key is classified as Unresolved",
+			targetLogin:      "deploy-key",
+			wantActorType:    "Unresolved",
+			wantSuppressedBy: "githubActorTypeClassifiesAutomation(Unresolved)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			graph := &projectionRecorder{}
+			_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+				Id:         "github-audit-target-" + tc.targetLogin,
+				TenantId:   "writer",
+				SourceId:   "github",
+				Kind:       "github.audit",
+				OccurredAt: timestamppb.New(time.Date(2025, time.March, 4, 10, 30, 0, 0, time.UTC)),
+				Attributes: map[string]string{
+					"actor":         "alice",
+					"action":        "team.add_member",
+					"org":           "writer",
+					"repo":          "writer/cerebro",
+					"resource_id":   "writer/cerebro",
+					"resource_type": "repository",
+					"user":          tc.targetLogin,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Project() error = %v", err)
+			}
+			targetURN := "urn:cerebro:writer:github_user:" + tc.targetLogin
+			entity, ok := graph.entities[targetURN]
+			if !ok {
+				t.Fatalf("github.user target entity %q missing in graph: %#v", targetURN, graph.entities)
+			}
+			if got := entity.Attributes["actor_type"]; got != tc.wantActorType {
+				t.Fatalf("target github.user attributes[actor_type] = %q, want %q so %s short-circuits the identity rule", got, tc.wantActorType, tc.wantSuppressedBy)
+			}
+			if got, want := entity.Attributes["login"], tc.targetLogin; got != want {
+				t.Fatalf("target github.user attributes[login] = %q, want %q (preserved)", got, want)
+			}
+		})
+	}
+}
+
+// Plain human-shaped target logins must NOT receive a synthetic actor_type
+// stamp from the projector. They legitimately have no actor info in
+// target-context events, and will converge via mergeGraphAttributes the
+// next time they themselves act. Stamping a non-Bot value here would
+// short-circuit the identity rule against real shadow accounts.
+func TestProjectGitHubAuditDoesNotStampActorTypeOnHumanTargetUser(t *testing.T) {
+	graph := &projectionRecorder{}
+	_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "github-audit-target-human",
+		TenantId:   "writer",
+		SourceId:   "github",
+		Kind:       "github.audit",
+		OccurredAt: timestamppb.New(time.Date(2025, time.March, 4, 10, 30, 0, 0, time.UTC)),
+		Attributes: map[string]string{
+			"actor":         "alice",
+			"action":        "team.add_member",
+			"org":           "writer",
+			"repo":          "writer/cerebro",
+			"resource_id":   "writer/cerebro",
+			"resource_type": "repository",
+			"user":          "joechu-writer",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	targetURN := "urn:cerebro:writer:github_user:joechu-writer"
+	entity, ok := graph.entities[targetURN]
+	if !ok {
+		t.Fatalf("github.user target entity %q missing in graph: %#v", targetURN, graph.entities)
+	}
+	if got, exists := entity.Attributes["actor_type"]; exists {
+		t.Fatalf("target github.user attributes[actor_type] = %q present for human-shaped login; rule would silently suppress real shadow accounts", got)
+	}
+}
+
 // `org_id` is a small but important field on the github.org node: it pins
 // the numeric ID GitHub stamps on every audit event for the org. The rule
 // uses it to disambiguate the org-as-actor pattern (where actor_id ==


### PR DESCRIPTION
## Why

Two complementary changes addressing observations on sec-dev after v2.1.15 (PR #539):

### 1. Orchestrator post-sync phases hang silently

The `writer-github-audit-writerinternal` task was observed to hang for 28+ minutes after `source_runtime.sync.span_end` with **zero log output** between sync completion and orchestrator-level span_end. The 3 post-sync phases (`finding_rules`, `graph_ingest`, `graph_rules`) ran with:

- **no per-phase telemetry** — operators cannot tell from logs which step is stuck.
- **no independent timeout** — a single blocked downstream (Neo4j row-lock contention across concurrent runtimes writing the same tenant, or a `source.Read()` retry storm against an exhausted GitHub rate-limit budget) parks the iteration indefinitely. Lease-renewal cancellation does not unblock a stuck Neo4j transaction.

This PR wraps each phase in:
- A named telemetry span (`orchestrator.finding_rules`, `orchestrator.graph_ingest`, `orchestrator.graph_rules`) so a stall now surfaces as a missing `span_end` on the specific phase.
- A 15 min `context.WithTimeout` derived from `runtimeCtx` (preserves lease-renewal cancellation while bounding the phase). Production writer-org runs complete all 3 phases in ~2.5 min — 15 min leaves ~4x headroom while still cutting off pathological runs well within lease TTL. On deadline the phase fails fast, lease releases, next iteration retries.

The generic `runOrchestratorPhase[R]` helper avoids interface-boxing each phase's distinct result type.

### 2. Target-context phantoms regenerate after Neo4j cleanup

`projector.go:githubAuditProjections` mints `github.user` nodes from target-context audit events (e.g. `team.add_member`, where `targetUser` is the recipient) with only `{login: <user>}` — no `actor_type`. The actor-context path correctly classifies `[bot]`-suffix Apps and `deploy_key` synthetic logins, but **target-only** phantoms linger indefinitely once the audit-log window scrolls past the last event that had them as the actor: the identity rule's node-side and edge-side automation checks both rely on `actor_type` that simply never gets stamped.

This PR adds `githubSyntheticTargetActorType` which stamps:
- `actor_type=Bot` for `[bot]`-suffix (GitHub's reserved suffix for App identities; case-insensitive).
- `actor_type=Unresolved` for `deploy_key` / `deploy-key` (synthetic placeholder for SSH-key activity).
- `""` for plain human logins (preserves existing `{login}`-only behavior).

Symmetric with the actor-context path; matches the suppression contract in `githubActorTypeClassifiesAutomation`.

## Why the two ship together

Unrelated in scope but both surfaced from the same triage round (sec-dev 26→10 open HIGH on identity-github-active-without-okta-link). Shipping in one PR captures both the diagnostic improvement and the projector hardening as v2.1.16.

## Tests

- `TestRunOrchestratorPhaseFailsFastOnTimeout` — 5 ms timeout returns `context.DeadlineExceeded` under 2 s.
- `TestRunOrchestratorPhasePassesThroughErrors` — error pass-through with result preservation.
- `TestRunOrchestratorPhaseInheritsParentCancellation` — parent `context.Cancel` propagates as `context.Canceled`.
- `TestProjectGitHubAuditStampsActorTypeOnSyntheticTargetUser` — table-driven: pullrequest[bot]→Bot, Renovate[Bot]→Bot (case-insensitive), deploy_key→Unresolved, deploy-key→Unresolved.
- `TestProjectGitHubAuditDoesNotStampActorTypeOnHumanTargetUser` — joechu-writer must NOT carry actor_type.

`make verify` SUCCESS (gofmt clean, go vet clean, golangci-lint 0 issues, buf lint ok, arch tests ok, all packages green).

## Follow-up

Cut v2.1.16; bump WriterInternal Pulumi.sec-dev.yaml; deploy to sec-dev; tail logs to confirm new `orchestrator.*` spans materialize on the next run.
