### PR TITLE
fix(projection): keep github automation out of identity graph

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -550,7 +550,7 @@ func runOrchestratorPhase[R any](runtimeCtx context.Context, name string, iterat
 	if err != nil {
 		status = "failed"
 		endAttrs = withTelemetryField(endAttrs, "error", err.Error())
-		if errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(phaseCtx.Err(), context.DeadlineExceeded) {
 			endAttrs = withTelemetryField(endAttrs, "timeout_exceeded", true)
 		}
 	}

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -263,6 +263,7 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 	actorTypeIsOrg := strings.EqualFold(actorType, "Organization")
 	actorIsOrgSelf := actorID != "" && orgID != "" && actorID == orgID
 	actorIsUnresolvedPublicKey := strings.EqualFold(actorType, "Unresolved") && isGitHubPublicKeyCredential(programmaticAccessType)
+	actorIsAutomation := githubAuditActorIsAutomation(actor, actorType, actorIsBot, actorIsAgent)
 
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
@@ -398,6 +399,10 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 				addLink(links, projectedLink(tenantID, event.GetSourceId(), credentialURN, resourceURN, relationActedOn, actedAttrs))
 			}
 		}
+	} else if actorIsAutomation {
+		// Automation actors are GitHub Apps/agents, not human identities. Keep the
+		// audit event in the append log but do not project them into the identity
+		// graph or repeatedly rewrite hot bot->repo acted_on edges.
 	} else {
 		actorURN := githubUserURN(tenantID, actor)
 		if actorURN != "" {
@@ -454,24 +459,8 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 	// github.user actor, so this is purely for the user-actor case.
 	previousActorURN := githubUserURN(tenantID, actor)
 	targetURN := githubUserURN(tenantID, targetUser)
-	if targetURN != "" && targetURN != previousActorURN {
+	if targetURN != "" && targetURN != previousActorURN && githubSyntheticTargetActorType(targetUser) == "" {
 		targetAttrs := map[string]string{"login": targetUser}
-		// Target-context github.user nodes (e.g. `team.add_member`, where
-		// targetUser is the user being added) carry no actor resolution
-		// because the audit event's actor_* fields describe the issuer of
-		// the action, not the recipient. When the recipient login matches
-		// a structural automation pattern — GitHub's reserved `[bot]`
-		// suffix for App-issued identities, or synthetic placeholder
-		// logins like `deploy_key` for SSH-key activity — stamp the
-		// node's `actor_type` defensively so downstream identity rules
-		// can classify the entity as non-linkable without relying on
-		// later actor-context events to converge the blob via
-		// `mergeGraphAttributes`. Without this, target-only phantoms can
-		// linger indefinitely once the audit-log window scrolls past the
-		// last event that had them as the actor.
-		if classification := githubSyntheticTargetActorType(targetUser); classification != "" {
-			targetAttrs["actor_type"] = classification
-		}
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        targetURN,
 			TenantID:   tenantID,
@@ -495,35 +484,44 @@ func isGitHubPublicKeyCredential(programmaticAccessType string) bool {
 	return strings.Contains(normalized, "public key")
 }
 
-// githubSyntheticTargetActorType returns the `actor_type` value to stamp
-// onto a target-context github.user node when its login is structurally
-// synthetic (i.e. not a real user that could be linked to Okta). The
-// returned value is one of the automation classifications recognised by
-// `githubActorTypeClassifiesAutomation` in the findings package — keeping
-// the string set in sync with that helper is part of the suppression
-// contract.
+func githubAuditActorIsAutomation(actor string, actorType string, actorIsBot string, actorIsAgent string) bool {
+	if strings.EqualFold(strings.TrimSpace(actorIsBot), "true") {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(actorIsAgent), "true") {
+		return true
+	}
+	if githubActorTypeClassifiesAutomation(actorType) {
+		return true
+	}
+	return githubSyntheticTargetActorType(actor) != ""
+}
+
+func githubActorTypeClassifiesAutomation(actorType string) bool {
+	switch strings.ToLower(strings.TrimSpace(actorType)) {
+	case "bot", "organization", "unresolved":
+		return true
+	}
+	return false
+}
+
+// githubSyntheticTargetActorType returns the automation classification for a
+// structurally synthetic login (i.e. not a real user that could be linked to
+// Okta).
 //
 // Two synthetic shapes are recognised today:
 //
 //   - GitHub reserves the trailing `[bot]` suffix for App-issued
 //     identities (dependabot[bot], github-actions[bot], renovate[bot],
 //     coderabbitai[bot], factory-droid[bot], ...). The suffix is part of
-//     GitHub's public contract; vendor changes don't alter it. We stamp
-//     these as `Bot` so the identity rule treats them like any other
-//     App-issued account even when only target-context events ever
-//     surface them.
+//     GitHub's public contract; vendor changes don't alter it.
 //
 //   - The literal `deploy_key` login is GitHub's synthetic placeholder
 //     for SSH-key activity (no real /users/{login} resolution). The
 //     actor-side projector path routes these to `github.credential`
-//     via `actorIsUnresolvedPublicKey`, but target-context events
-//     (typically deploy-key lifecycle audit entries) still mint a
-//     `github.user:deploy_key` node. We stamp `Unresolved` so the same
-//     classifier short-circuits.
+//     via `actorIsUnresolvedPublicKey`.
 //
-// Returns "" when the login is a plain human-shaped GitHub username so
-// the existing target-context projection (`{login: <user>}` only) is
-// preserved.
+// Returns "" when the login is a plain human-shaped GitHub username.
 func githubSyntheticTargetActorType(login string) string {
 	trimmed := strings.TrimSpace(login)
 	if trimmed == "" {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -585,106 +585,86 @@ func TestProjectGitHubAuditOmitsAtWhenOccurredAtMissing(t *testing.T) {
 	}
 }
 
-// The audit log API stamps actor_is_bot/actor_is_agent on every event whose
-// actor is a GitHub App identity or an integration agent. Downstream graph
-// rules (e.g. identity-github-active-without-okta-link) use these flags to
-// suppress automation actors without resorting to a hardcoded vendor
-// allowlist. The projector must forward both flags onto the github.user
-// node attrs, alongside the numeric actor_id / org_id GitHub uses to detect
-// the org-as-actor pattern.
-func TestProjectGitHubAuditStampsActorClassificationOnGithubUser(t *testing.T) {
-	state := &projectionRecorder{}
-	graph := &projectionRecorder{}
-	_, err := New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
-		Id:         "github-audit-actor-flags",
-		TenantId:   "writer",
-		SourceId:   "github",
-		Kind:       "github.audit",
-		OccurredAt: timestamppb.New(time.Date(2025, time.March, 4, 10, 30, 0, 0, time.UTC)),
-		Attributes: map[string]string{
-			"actor":          "dependabot[bot]",
-			"actor_id":       "49699333",
-			"actor_is_bot":   "true",
-			"actor_is_agent": "false",
-			"action":         "repository_vulnerability_alert.create",
-			"org":            "writer",
-			"org_id":         "8090724",
-			"repo":           "writer/cerebro",
-			"resource_id":    "writer/cerebro",
-			"resource_type":  "repository",
-		},
-	})
-	if err != nil {
-		t.Fatalf("Project() error = %v", err)
-	}
-	actorURN := "urn:cerebro:writer:github_user:dependabot[bot]"
-	entity, ok := graph.entities[actorURN]
-	if !ok {
-		t.Fatalf("github.user entity %q missing in graph: %#v", actorURN, graph.entities)
-	}
-	for key, want := range map[string]string{
-		"actor_id":       "49699333",
-		"actor_is_bot":   "true",
-		"actor_is_agent": "false",
-		"org_id":         "8090724",
-		"login":          "dependabot[bot]",
-	} {
-		if got := entity.Attributes[key]; got != want {
-			t.Fatalf("github.user attributes[%s] = %q, want %q; rule depends on this signal to suppress automation actors", key, got, want)
-		}
-	}
-}
-
-// When an audit event names a TARGET user (`team_member.added`,
-// `org.add_member`, etc.) the projector mints a github.user node for the
-// target with only `{login: <user>}` because the audit event's actor_*
-// fields describe the issuer, not the recipient. For human targets this
-// is correct — converging actor_type via mergeGraphAttributes will happen
-// later when the target themselves act on something. But for structural
-// automation logins (`[bot]`-suffixed GitHub Apps, the synthetic
-// `deploy_key` placeholder) there is no convergence path: those logins
-// either never act (deploy_key activity is routed to github.credential
-// on the actor side) or only surface in target-context audit events. We
-// must therefore stamp `actor_type` defensively on the target-context
-// node so identity rules can short-circuit them on the very first
-// evaluation cycle.
-func TestProjectGitHubAuditStampsActorTypeOnSyntheticTargetUser(t *testing.T) {
+func TestProjectGitHubAuditSkipsAutomationActorsFromIdentityGraph(t *testing.T) {
 	cases := []struct {
-		name             string
-		targetLogin      string
-		wantActorType    string
-		wantSuppressedBy string
+		name  string
+		actor string
+		attrs map[string]string
 	}{
 		{
-			name:             "bot suffix is classified as Bot",
-			targetLogin:      "pullrequest[bot]",
-			wantActorType:    "Bot",
-			wantSuppressedBy: "githubActorTypeClassifiesAutomation(Bot)",
+			name:  "actor_is_bot true",
+			actor: "dependabot[bot]",
+			attrs: map[string]string{"actor_is_bot": "true", "actor_type": "Bot"},
 		},
 		{
-			name:             "uppercase Bot suffix is classified as Bot",
-			targetLogin:      "Renovate[Bot]",
-			wantActorType:    "Bot",
-			wantSuppressedBy: "githubActorTypeClassifiesAutomation(Bot)",
+			name:  "bot suffix defense in depth",
+			actor: "coderabbitai[bot]",
+			attrs: map[string]string{"actor_is_bot": "false"},
 		},
 		{
-			name:             "deploy_key is classified as Unresolved",
-			targetLogin:      "deploy_key",
-			wantActorType:    "Unresolved",
-			wantSuppressedBy: "githubActorTypeClassifiesAutomation(Unresolved)",
+			name:  "actor_type bot",
+			actor: "renovate",
+			attrs: map[string]string{"actor_type": "Bot"},
 		},
 		{
-			name:             "deploy-key is classified as Unresolved",
-			targetLogin:      "deploy-key",
-			wantActorType:    "Unresolved",
-			wantSuppressedBy: "githubActorTypeClassifiesAutomation(Unresolved)",
+			name:  "actor_is_agent true",
+			actor: "fine-grained-token-agent",
+			attrs: map[string]string{"actor_is_agent": "true"},
+		},
+		{
+			name:  "unresolved non public key",
+			actor: "pullrequest[bot]",
+			attrs: map[string]string{"actor_type": "Unresolved"},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			attrs := map[string]string{
+				"actor":         tc.actor,
+				"action":        "repository_vulnerability_alert.create",
+				"org":           "writer",
+				"org_id":        "8090724",
+				"repo":          "writer/cerebro",
+				"resource_id":   "writer/cerebro",
+				"resource_type": "repository",
+			}
+			for key, value := range tc.attrs {
+				attrs[key] = value
+			}
 			graph := &projectionRecorder{}
 			_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
-				Id:         "github-audit-target-" + tc.targetLogin,
+				Id:         "github-audit-automation-" + tc.actor,
+				TenantId:   "writer",
+				SourceId:   "github",
+				Kind:       "github.audit",
+				OccurredAt: timestamppb.New(time.Date(2025, time.March, 4, 10, 30, 0, 0, time.UTC)),
+				Attributes: attrs,
+			})
+			if err != nil {
+				t.Fatalf("Project() error = %v", err)
+			}
+			actorURN := "urn:cerebro:writer:github_user:" + tc.actor
+			if _, ok := graph.entities[actorURN]; ok {
+				t.Fatalf("automation actor %q should not be projected as github.user: %#v", actorURN, graph.entities[actorURN])
+			}
+			if _, ok := graph.links[actorURN+"|"+relationActedOn+"|urn:cerebro:writer:github_repo:writer/cerebro"]; ok {
+				t.Fatalf("automation actor %q should not emit acted_on repo links", actorURN)
+			}
+			for key := range graph.links {
+				if strings.HasPrefix(key, actorURN+"|") {
+					t.Fatalf("automation actor %q emitted identity graph link %q", actorURN, key)
+				}
+			}
+		})
+	}
+}
+
+func TestProjectGitHubAuditSkipsSyntheticTargetUsersFromIdentityGraph(t *testing.T) {
+	for _, targetLogin := range []string{"pullrequest[bot]", "Renovate[Bot]", "deploy_key", "deploy-key"} {
+		t.Run(targetLogin, func(t *testing.T) {
+			graph := &projectionRecorder{}
+			_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+				Id:         "github-audit-target-" + targetLogin,
 				TenantId:   "writer",
 				SourceId:   "github",
 				Kind:       "github.audit",
@@ -696,32 +676,29 @@ func TestProjectGitHubAuditStampsActorTypeOnSyntheticTargetUser(t *testing.T) {
 					"repo":          "writer/cerebro",
 					"resource_id":   "writer/cerebro",
 					"resource_type": "repository",
-					"user":          tc.targetLogin,
+					"user":          targetLogin,
 				},
 			})
 			if err != nil {
 				t.Fatalf("Project() error = %v", err)
 			}
-			targetURN := "urn:cerebro:writer:github_user:" + tc.targetLogin
-			entity, ok := graph.entities[targetURN]
-			if !ok {
-				t.Fatalf("github.user target entity %q missing in graph: %#v", targetURN, graph.entities)
+			targetURN := "urn:cerebro:writer:github_user:" + targetLogin
+			if _, ok := graph.entities[targetURN]; ok {
+				t.Fatalf("synthetic target %q should not be projected as github.user", targetURN)
 			}
-			if got := entity.Attributes["actor_type"]; got != tc.wantActorType {
-				t.Fatalf("target github.user attributes[actor_type] = %q, want %q so %s short-circuits the identity rule", got, tc.wantActorType, tc.wantSuppressedBy)
-			}
-			if got, want := entity.Attributes["login"], tc.targetLogin; got != want {
-				t.Fatalf("target github.user attributes[login] = %q, want %q (preserved)", got, want)
+			for key := range graph.links {
+				if strings.HasPrefix(key, targetURN+"|") {
+					t.Fatalf("synthetic target %q emitted identity graph link %q", targetURN, key)
+				}
 			}
 		})
 	}
 }
 
-// Plain human-shaped target logins must NOT receive a synthetic actor_type
-// stamp from the projector. They legitimately have no actor info in
-// target-context events, and will converge via mergeGraphAttributes the
-// next time they themselves act. Stamping a non-Bot value here would
-// short-circuit the identity rule against real shadow accounts.
+// Plain human-shaped target logins are still GitHub identities and must keep
+// projecting into the identity graph. Target-context events legitimately have
+// no actor_type because the audit event's actor_* fields describe the issuer,
+// not the recipient.
 func TestProjectGitHubAuditDoesNotStampActorTypeOnHumanTargetUser(t *testing.T) {
 	graph := &projectionRecorder{}
 	_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{


### PR DESCRIPTION
## Why

v2.1.16 proved the hang was not a generic orchestrator issue: writerinternal now emits phase spans and failed exactly at the 15m `orchestrator.graph_ingest` timeout while upserting a hot automation edge:

`github_user:coderabbitai[bot] -[:acted_on]-> github_repo:WriterInternal/k8s`

That means the graph model was still wrong. Bot/App/agent principals are not human GitHub identities that can link to Okta, and high-volume bot actors become shared hot source nodes across concurrent runtimes. Suppressing them in the finding rule is too late; ingest still pays the lock/write cost and keeps polluting the identity graph.

## What changed

- Treat GitHub audit automation actors as non-identity principals at projection time:
  - `actor_is_bot=true`
  - `actor_is_agent=true`
  - `actor_type in {Bot, Organization, Unresolved}`
  - structural `[bot]` suffix / `deploy_key` fallback
- Do not project those actors as `github.user`.
- Do not emit bot/agent `acted_on` repo edges or identifier links.
- Do not project synthetic target-context users (`[bot]`, `deploy_key`) as `github.user`.
- Keep public-key actors on the existing `github.credential` path.
- Preserve human GitHub actor/target behavior unchanged.
- Also marks `timeout_exceeded=true` when a wrapped downstream error does not preserve `context.DeadlineExceeded` but the phase context hit its deadline.

## Validation

- `go test ./internal/sourceprojection -count=1`
- `go test ./cmd/cerebro -run 'TestRunOrchestratorPhase' -count=1`
- `go test ./...`
- `go vet ./...`
- `make verify`

## Follow-up after merge

Cut v2.1.17, bump sec-dev, rerun writerinternal, and confirm graph_ingest no longer upserts the `coderabbitai[bot]` identity edge.
