### PR TITLE
fix(graphingest): coalesce projected records per page

### DIFF
--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -58,6 +58,16 @@ type Service struct {
 	prepareConfig ConfigPreparer
 }
 
+type projectionRecordProjector interface {
+	ProjectRecords(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error)
+}
+
+type pageProjectionResult struct {
+	EventsRead        uint32
+	EntitiesProjected uint32
+	LinksProjected    uint32
+}
+
 type RuntimeRequest struct {
 	RuntimeID       string
 	PageLimit       uint32
@@ -342,14 +352,24 @@ func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*Ing
 			return nil, err
 		}
 		result.PagesRead++
-		for _, event := range response.GetEvents() {
-			projected, err := s.projector.Project(ctx, ingestEvent(event, request.TenantID, request.RuntimeID))
+		if recordProjector, ok := s.projector.(projectionRecordProjector); ok {
+			projected, err := s.projectResponseCoalesced(ctx, request, response, recordProjector)
 			if err != nil {
-				return nil, fmt.Errorf("project source event %q: %w", event.GetId(), err)
+				return nil, err
 			}
-			result.EventsRead++
+			result.EventsRead += projected.EventsRead
 			result.EntitiesProjected += projected.EntitiesProjected
 			result.LinksProjected += projected.LinksProjected
+		} else {
+			for _, event := range response.GetEvents() {
+				projected, err := s.projector.Project(ctx, ingestEvent(event, request.TenantID, request.RuntimeID))
+				if err != nil {
+					return nil, fmt.Errorf("project source event %q: %w", event.GetId(), err)
+				}
+				result.EventsRead++
+				result.EntitiesProjected += projected.EntitiesProjected
+				result.LinksProjected += projected.LinksProjected
+			}
 		}
 		cursor = response.GetNextCursor()
 		if checkpointStore != nil {
@@ -373,6 +393,155 @@ func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*Ing
 		result.GraphLinksAfter = counts.Relations
 	}
 	return result, nil
+}
+
+func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRequest, response *cerebrov1.ReadSourceResponse, projector projectionRecordProjector) (pageProjectionResult, error) {
+	graphStore, ok := s.graphStore.(ports.ProjectionGraphStore)
+	if !ok {
+		return pageProjectionResult{}, ErrRuntimeUnavailable
+	}
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	result := pageProjectionResult{}
+	for _, event := range response.GetEvents() {
+		ingested := ingestEvent(event, request.TenantID, request.RuntimeID)
+		projectedEntities, projectedLinks, err := projector.ProjectRecords(ingested)
+		if err != nil {
+			return result, fmt.Errorf("project source event %q: %w", event.GetId(), err)
+		}
+		for _, entity := range projectedEntities {
+			mergeProjectedEntity(entities, entity)
+		}
+		for _, link := range projectedLinks {
+			mergeProjectedLink(links, link)
+		}
+		result.EventsRead++
+	}
+	entityKeys := sortedMapKeys(entities)
+	for _, key := range entityKeys {
+		if err := graphStore.UpsertProjectedEntity(ctx, entities[key]); err != nil {
+			return result, fmt.Errorf("upsert coalesced projected entity %q: %w", key, err)
+		}
+		result.EntitiesProjected++
+	}
+	linkKeys := sortedMapKeys(links)
+	for _, key := range linkKeys {
+		if err := graphStore.UpsertProjectedLink(ctx, links[key]); err != nil {
+			return result, fmt.Errorf("upsert coalesced projected link %q: %w", key, err)
+		}
+		result.LinksProjected++
+	}
+	return result, nil
+}
+
+func mergeProjectedEntity(entities map[string]*ports.ProjectedEntity, entity *ports.ProjectedEntity) {
+	if entity == nil {
+		return
+	}
+	urn := strings.TrimSpace(entity.URN)
+	if urn == "" {
+		return
+	}
+	existing, ok := entities[urn]
+	if !ok {
+		entities[urn] = cloneProjectedEntity(entity)
+		return
+	}
+	if value := strings.TrimSpace(entity.TenantID); value != "" {
+		existing.TenantID = value
+	}
+	if value := strings.TrimSpace(entity.SourceID); value != "" {
+		existing.SourceID = value
+	}
+	if value := strings.TrimSpace(entity.RuntimeID); value != "" {
+		existing.RuntimeID = value
+	}
+	if value := strings.TrimSpace(entity.EntityType); value != "" {
+		existing.EntityType = value
+	}
+	if value := strings.TrimSpace(entity.Label); value != "" {
+		existing.Label = value
+	}
+	existing.Attributes = mergeStringMap(existing.Attributes, entity.Attributes)
+}
+
+func mergeProjectedLink(links map[string]*ports.ProjectedLink, link *ports.ProjectedLink) {
+	if link == nil {
+		return
+	}
+	fromURN := strings.TrimSpace(link.FromURN)
+	relation := strings.TrimSpace(link.Relation)
+	toURN := strings.TrimSpace(link.ToURN)
+	if fromURN == "" || relation == "" || toURN == "" {
+		return
+	}
+	key := fromURN + "|" + relation + "|" + toURN
+	existing, ok := links[key]
+	if !ok {
+		links[key] = cloneProjectedLink(link)
+		return
+	}
+	if value := strings.TrimSpace(link.TenantID); value != "" {
+		existing.TenantID = value
+	}
+	if value := strings.TrimSpace(link.SourceID); value != "" {
+		existing.SourceID = value
+	}
+	if value := strings.TrimSpace(link.RuntimeID); value != "" {
+		existing.RuntimeID = value
+	}
+	existing.Attributes = mergeStringMap(existing.Attributes, link.Attributes)
+}
+
+func mergeStringMap(dst map[string]string, src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = make(map[string]string, len(src))
+	}
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
+
+func cloneProjectedEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {
+	if entity == nil {
+		return nil
+	}
+	clone := *entity
+	clone.Attributes = cloneStringMap(entity.Attributes)
+	return &clone
+}
+
+func cloneProjectedLink(link *ports.ProjectedLink) *ports.ProjectedLink {
+	if link == nil {
+		return nil
+	}
+	clone := *link
+	clone.Attributes = cloneStringMap(link.Attributes)
+	return &clone
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	clone := make(map[string]string, len(values))
+	for key, value := range values {
+		clone[key] = value
+	}
+	return clone
+}
+
+func sortedMapKeys[T any](values map[string]T) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (s *Service) prepareCheckpoint(ctx context.Context, request sourceRequest, result *IngestResult, cursor **cerebrov1.SourceCursor) (CheckpointStore, error) {

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -41,6 +41,35 @@ func (s *stubRunStore) ListIngestRuns(_ context.Context, filter graphstore.Inges
 	return runs, nil
 }
 
+type recordProjectorFunc func(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error)
+
+func (f recordProjectorFunc) ProjectRecords(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return f(event)
+}
+
+type recordingProjectionGraphStore struct {
+	entities map[string]*ports.ProjectedEntity
+	links    map[string]*ports.ProjectedLink
+}
+
+func (s *recordingProjectionGraphStore) Ping(context.Context) error { return nil }
+
+func (s *recordingProjectionGraphStore) UpsertProjectedEntity(_ context.Context, entity *ports.ProjectedEntity) error {
+	if s.entities == nil {
+		s.entities = map[string]*ports.ProjectedEntity{}
+	}
+	s.entities[entity.URN] = entity
+	return nil
+}
+
+func (s *recordingProjectionGraphStore) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if s.links == nil {
+		s.links = map[string]*ports.ProjectedLink{}
+	}
+	s.links[link.FromURN+"|"+link.Relation+"|"+link.ToURN] = link
+	return nil
+}
+
 func TestSensitiveConfigKeyTreatsSecretMarkersAsSensitive(t *testing.T) {
 	for _, key := range []string{"key", "api_key", "apiKey", "access_key_id", "secret_access_key", "private_key", "privateKey", "signing_key"} {
 		if !sensitiveConfigKey(key) {
@@ -102,6 +131,73 @@ func TestIngestEventStampsTenantAndRuntime(t *testing.T) {
 	}
 	if got := event.GetAttributes()["existing"]; got != "value" {
 		t.Fatalf("existing attribute = %q, want value", got)
+	}
+}
+
+func TestProjectResponseCoalescedUpsertsUniqueRecords(t *testing.T) {
+	store := &recordingProjectionGraphStore{}
+	service := &Service{graphStore: store}
+	projector := recordProjectorFunc(func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		if event.GetTenantId() != "writer" {
+			t.Fatalf("event tenant = %q, want writer", event.GetTenantId())
+		}
+		if got := event.GetAttributes()[ports.EventAttributeSourceRuntimeID]; got != "writer-github-audit" {
+			t.Fatalf("source_runtime_id = %q, want writer-github-audit", got)
+		}
+		return []*ports.ProjectedEntity{{
+				URN:        "urn:cerebro:writer:github_org:WriterInternal",
+				TenantID:   event.GetTenantId(),
+				SourceID:   event.GetSourceId(),
+				RuntimeID:  event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				EntityType: "github.org",
+				Label:      "WriterInternal",
+				Attributes: map[string]string{"event_id": event.GetId()},
+			}},
+			[]*ports.ProjectedLink{{
+				TenantID:  event.GetTenantId(),
+				SourceID:  event.GetSourceId(),
+				RuntimeID: event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				FromURN:   "urn:cerebro:writer:github_repo:WriterInternal/k8s",
+				Relation:  "belongs_to",
+				ToURN:     "urn:cerebro:writer:github_org:WriterInternal",
+				Attributes: map[string]string{
+					"event_id": event.GetId(),
+				},
+			}}, nil
+	})
+	result, err := service.projectResponseCoalesced(context.Background(), sourceRequest{
+		SourceID:  "github",
+		RuntimeID: "writer-github-audit",
+		TenantID:  "writer",
+	}, &cerebrov1.ReadSourceResponse{Events: []*cerebrov1.EventEnvelope{
+		{Id: "event-1", SourceId: "github"},
+		{Id: "event-2", SourceId: "github"},
+	}}, projector)
+	if err != nil {
+		t.Fatalf("projectResponseCoalesced() error = %v", err)
+	}
+	if result.EventsRead != 2 {
+		t.Fatalf("EventsRead = %d, want 2", result.EventsRead)
+	}
+	if result.EntitiesProjected != 1 {
+		t.Fatalf("EntitiesProjected = %d, want 1 coalesced org upsert", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 1 {
+		t.Fatalf("LinksProjected = %d, want 1 coalesced repo->org link upsert", result.LinksProjected)
+	}
+	entity := store.entities["urn:cerebro:writer:github_org:WriterInternal"]
+	if entity == nil {
+		t.Fatal("coalesced org entity missing")
+	}
+	if got := entity.Attributes["event_id"]; got != "event-2" {
+		t.Fatalf("coalesced entity event_id = %q, want latest event-2", got)
+	}
+	link := store.links["urn:cerebro:writer:github_repo:WriterInternal/k8s|belongs_to|urn:cerebro:writer:github_org:WriterInternal"]
+	if link == nil {
+		t.Fatal("coalesced repo->org link missing")
+	}
+	if got := link.Attributes["event_id"]; got != "event-2" {
+		t.Fatalf("coalesced link event_id = %q, want latest event-2", got)
 	}
 }
 

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -72,7 +72,7 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 	if s == nil || (s.state == nil && s.graph == nil) {
 		return ports.ProjectionResult{}, nil
 	}
-	entities, links, err := s.registry.Project(event)
+	entities, links, err := s.ProjectRecords(event)
 	if err != nil {
 		return ports.ProjectionResult{}, err
 	}
@@ -105,6 +105,24 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 		EntitiesProjected: uint32(len(entities)),
 		LinksProjected:    uint32(len(links)),
 	}, nil
+}
+
+// ProjectRecords converts one event into normalized projection records without
+// writing them. Graph ingest uses this to coalesce repeated records before
+// touching Neo4j.
+func (s *Service) ProjectRecords(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	if event == nil {
+		return nil, nil, fmt.Errorf("event is required")
+	}
+	if s == nil || s.registry == nil {
+		return nil, nil, nil
+	}
+	entities, links, err := s.registry.Project(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	stampProjectionRuntime(event, entities, links)
+	return entities, links, nil
 }
 
 func stampProjectionRuntime(event *cerebrov1.EventEnvelope, entities []*ports.ProjectedEntity, links []*ports.ProjectedLink) {


### PR DESCRIPTION
## Why

v2.1.17 fixed the first model issue (GitHub automation actors no longer become `github.user` identities), but the next sec-dev validation run exposed the broader ingest flaw: graph_ingest still timed out while upserting the same stable org node (`github_org:WriterInternal`) repeatedly.

The root problem is that graph ingest projected and upserted every event one-by-one. Audit pages contain many repeated current-state records (same org, same repo, same repo→org link, same identity link), so Neo4j gets hammered with redundant writes and hot-node locks even when the final graph state only needs one latest-wins record per page.

## What changed

- Added `ProjectRecords` to sourceprojection so graph ingest can get normalized projection records without writing immediately.
- Graph ingest now coalesces projected entities and links per source page before writing to Neo4j.
- Duplicate entity/link records merge latest-wins attributes in the same event order, preserving the existing `at`/latest evidence semantics.
- Writes are sorted for deterministic behavior.
- Falls back to the old per-event `Project` path for any projector that does not expose records.

## Validation

- `go test ./internal/graphingest ./internal/sourceprojection -count=1`
- `go test ./...`
- `go vet ./...`
- `make verify`

## Expected sec-dev effect

For GitHub audit, a page with 100 events now writes one coalesced `github_org:WriterInternal` entity (and one latest repo/org edge per unique target) instead of rewriting the same hot records for every event.
