### PR TITLE
fix(graphingest): preserve recency while coalescing projections

### DIFF
--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -500,10 +500,61 @@ func mergeStringMap(dst map[string]string, src map[string]string) map[string]str
 	if dst == nil {
 		dst = make(map[string]string, len(src))
 	}
+	incomingIsOlderObservation := projectedIncomingObservationIsOlder(dst, src)
 	for key, value := range src {
-		dst[key] = value
+		if incomingIsOlderObservation && projectedAttributeCoupledToObservationTime(key) {
+			continue
+		}
+		dst[key] = mergeProjectedAttributeValue(key, dst[key], value)
 	}
 	return dst
+}
+
+func projectedIncomingObservationIsOlder(existing map[string]string, incoming map[string]string) bool {
+	existingAt := strings.TrimSpace(existing["at"])
+	incomingAt := strings.TrimSpace(incoming["at"])
+	if existingAt == "" {
+		return false
+	}
+	if incomingAt == "" {
+		return true
+	}
+	existingT, errExisting := time.Parse(time.RFC3339, existingAt)
+	incomingT, errIncoming := time.Parse(time.RFC3339, incomingAt)
+	if errExisting != nil || errIncoming != nil {
+		return false
+	}
+	return incomingT.Before(existingT)
+}
+
+func projectedAttributeCoupledToObservationTime(key string) bool {
+	switch key {
+	case "action", "event_id", "programmatic_access_type", "source_event_id", "source_runtime_id", "transport_protocol_name":
+		return true
+	default:
+		return false
+	}
+}
+
+func mergeProjectedAttributeValue(key string, existing string, incoming string) string {
+	if key != "at" {
+		return incoming
+	}
+	if strings.TrimSpace(existing) == "" {
+		return incoming
+	}
+	if strings.TrimSpace(incoming) == "" {
+		return existing
+	}
+	existingT, errExisting := time.Parse(time.RFC3339, existing)
+	incomingT, errIncoming := time.Parse(time.RFC3339, incoming)
+	if errExisting != nil || errIncoming != nil {
+		return incoming
+	}
+	if incomingT.Before(existingT) {
+		return existing
+	}
+	return incoming
 }
 
 func cloneProjectedEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity {

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -201,6 +201,81 @@ func TestProjectResponseCoalescedUpsertsUniqueRecords(t *testing.T) {
 	}
 }
 
+func TestProjectResponseCoalescedPreservesNewestObservationAttributes(t *testing.T) {
+	store := &recordingProjectionGraphStore{}
+	service := &Service{graphStore: store}
+	projector := recordProjectorFunc(func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		at := "2026-05-11T10:00:00Z"
+		if event.GetId() == "older-event" {
+			at = "2026-05-10T10:00:00Z"
+		}
+		return []*ports.ProjectedEntity{{
+				URN:        "urn:cerebro:writer:github_user:alice",
+				TenantID:   event.GetTenantId(),
+				SourceID:   event.GetSourceId(),
+				RuntimeID:  event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				EntityType: "github.user",
+				Label:      "alice",
+				Attributes: map[string]string{
+					"at":       at,
+					"event_id": event.GetId(),
+					"login":    event.GetId(),
+				},
+			}},
+			[]*ports.ProjectedLink{{
+				TenantID:  event.GetTenantId(),
+				SourceID:  event.GetSourceId(),
+				RuntimeID: event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				FromURN:   "urn:cerebro:writer:github_user:alice",
+				Relation:  "acted_on",
+				ToURN:     "urn:cerebro:writer:github_repo:writer/cerebro",
+				Attributes: map[string]string{
+					"action":   "git.clone",
+					"at":       at,
+					"event_id": event.GetId(),
+					"target":   event.GetId(),
+				},
+			}}, nil
+	})
+	_, err := service.projectResponseCoalesced(context.Background(), sourceRequest{
+		SourceID:  "github",
+		RuntimeID: "writer-github-audit",
+		TenantID:  "writer",
+	}, &cerebrov1.ReadSourceResponse{Events: []*cerebrov1.EventEnvelope{
+		{Id: "newer-event", SourceId: "github"},
+		{Id: "older-event", SourceId: "github"},
+	}}, projector)
+	if err != nil {
+		t.Fatalf("projectResponseCoalesced() error = %v", err)
+	}
+	entity := store.entities["urn:cerebro:writer:github_user:alice"]
+	if entity == nil {
+		t.Fatal("coalesced github.user entity missing")
+	}
+	if got := entity.Attributes["at"]; got != "2026-05-11T10:00:00Z" {
+		t.Fatalf("coalesced entity at = %q, want newest timestamp", got)
+	}
+	if got := entity.Attributes["event_id"]; got != "newer-event" {
+		t.Fatalf("coalesced entity event_id = %q, want newer-event coupled to newest observation", got)
+	}
+	if got := entity.Attributes["login"]; got != "older-event" {
+		t.Fatalf("coalesced entity non-observation attribute login = %q, want older-event latest write", got)
+	}
+	link := store.links["urn:cerebro:writer:github_user:alice|acted_on|urn:cerebro:writer:github_repo:writer/cerebro"]
+	if link == nil {
+		t.Fatal("coalesced acted_on link missing")
+	}
+	if got := link.Attributes["at"]; got != "2026-05-11T10:00:00Z" {
+		t.Fatalf("coalesced link at = %q, want newest timestamp", got)
+	}
+	if got := link.Attributes["event_id"]; got != "newer-event" {
+		t.Fatalf("coalesced link event_id = %q, want newer-event coupled to newest observation", got)
+	}
+	if got := link.Attributes["target"]; got != "older-event" {
+		t.Fatalf("coalesced link non-observation attribute target = %q, want older-event latest write", got)
+	}
+}
+
 func TestHealthFailedCountDoesNotDependOnPagingLimit(t *testing.T) {
 	store := &stubRunStore{
 		runs: []graphstore.IngestRun{

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -76,7 +76,6 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 	if err != nil {
 		return ports.ProjectionResult{}, err
 	}
-	stampProjectionRuntime(event, entities, links)
 	for _, entity := range entities {
 		if s.state != nil {
 			if err := s.state.UpsertProjectedEntity(ctx, entity); err != nil {


### PR DESCRIPTION
## Why

Droid-review correctly flagged that PR #543's page-local coalescing bypassed Neo4j's recency-aware attribute merge. GitHub audit pages can replay newest-first, so a later same-page older event could overwrite `at` and coupled evidence fields (`event_id`, `action`, etc.) before the coalesced record reached Neo4j, making recent activity look stale.

## What changed

- Reused the graph store merge semantics in the page coalescer:
  - `at` keeps the chronological max timestamp.
  - observation-coupled attributes are not overwritten by older observations.
  - non-observation attributes remain latest-write-wins.
- Added a regression test proving a same-page older event cannot pull `at`/`event_id` backward.
- Removed a redundant runtime stamp in `Project` now that `ProjectRecords` already stamps records.

## Validation

- `go test ./internal/graphingest ./internal/sourceprojection -count=1`
- `go test ./...`
- `go vet ./...`
- `make verify`
