### PR TITLE
fix(grc): refresh Vanta tokens on unauthorized

### DIFF
--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -7,6 +7,7 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -289,24 +290,16 @@ func (s *Source) list(ctx context.Context, settings settings, path string, curso
 	if err != nil {
 		return nil, "", err
 	}
-	query := url.Values{}
-	query.Set("pageSize", strconv.Itoa(pageSize))
-	if strings.TrimSpace(cursor) != "" {
-		query.Set("pageCursor", strings.TrimSpace(cursor))
+	response, err := s.listPage(ctx, settings, path, cursor, pageSize, token)
+	if err != nil && isUnauthorizedResponse(err) {
+		s.invalidateToken(settings)
+		token, tokenErr := s.token(ctx, settings)
+		if tokenErr != nil {
+			return nil, "", tokenErr
+		}
+		response, err = s.listPage(ctx, settings, path, cursor, pageSize, token)
 	}
-	endpoint := settings.baseURL + path
-	if encoded := query.Encode(); encoded != "" {
-		endpoint += "?" + encoded
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return nil, "", fmt.Errorf("build request %s: %w", path, err)
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	var response pageResponse
-	if err := s.doJSON(req, &response); err != nil {
 		return nil, "", err
 	}
 	records := make([]grcRecord, 0, len(response.Results.Data))
@@ -321,6 +314,30 @@ func (s *Source) list(ctx context.Context, settings settings, path string, curso
 		return records, strings.TrimSpace(response.Results.PageInfo.EndCursor), nil
 	}
 	return records, "", nil
+}
+
+func (s *Source) listPage(ctx context.Context, settings settings, path string, cursor string, pageSize int, token string) (pageResponse, error) {
+	query := url.Values{}
+	query.Set("pageSize", strconv.Itoa(pageSize))
+	if strings.TrimSpace(cursor) != "" {
+		query.Set("pageCursor", strings.TrimSpace(cursor))
+	}
+	endpoint := settings.baseURL + path
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return pageResponse{}, fmt.Errorf("build request %s: %w", path, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	var response pageResponse
+	if err := s.doJSON(req, &response); err != nil {
+		return pageResponse{}, err
+	}
+	return response, nil
 }
 
 func (s *Source) token(ctx context.Context, settings settings) (string, error) {
@@ -368,6 +385,25 @@ func (s *Source) token(ctx context.Context, settings settings) (string, error) {
 	s.tokenExpiresAt = time.Now().Add(time.Duration(expiresIn) * time.Second)
 	s.mu.Unlock()
 	return response.AccessToken, nil
+}
+
+func (s *Source) invalidateToken(settings settings) {
+	if s == nil {
+		return
+	}
+	cacheKey := tokenCacheKey(settings)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.tokenKey != cacheKey {
+		return
+	}
+	s.accessToken = ""
+	s.tokenExpiresAt = time.Time{}
+}
+
+func isUnauthorizedResponse(err error) bool {
+	var responseErr *responseError
+	return errors.As(err, &responseErr) && responseErr.statusCode == http.StatusUnauthorized
 }
 
 func (s *Source) doJSON(req *http.Request, target any) error {

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -411,6 +411,72 @@ func TestTokenCacheReusesTokenAcrossFamilies(t *testing.T) {
 	}
 }
 
+func TestReadRefreshesTokenAfterUnauthorizedPage(t *testing.T) {
+	tokenRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			tokenRequests++
+			token := "token-1"
+			if tokenRequests == 2 {
+				token = "token-2"
+			}
+			writeJSON(t, w, map[string]any{
+				"access_token": token,
+				"expires_in":   3599,
+				"token_type":   "Bearer",
+			})
+		case "/v1/vendors":
+			cursor := r.URL.Query().Get("pageCursor")
+			switch cursor {
+			case "":
+				if got := r.Header.Get("Authorization"); got != "Bearer token-1" {
+					t.Fatalf("first page Authorization = %q, want token-1", got)
+				}
+				writePage(t, w, true, "cursor-2", []map[string]any{{"id": "vendor-1", "name": "Acme SaaS"}})
+			case "cursor-2":
+				switch got := r.Header.Get("Authorization"); got {
+				case "Bearer token-1":
+					http.Error(w, `{"error":"Unauthorized"}`, http.StatusUnauthorized)
+				case "Bearer token-2":
+					writePage(t, w, false, "", []map[string]any{{"id": "vendor-2", "name": "Beta SaaS"}})
+				default:
+					t.Fatalf("second page Authorization = %q, want token-1 retry then token-2", got)
+				}
+			default:
+				t.Fatalf("unexpected pageCursor = %q", cursor)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := testConfig(server.URL, familyVendor)
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first page) error = %v", err)
+	}
+	if first.NextCursor == nil {
+		t.Fatalf("Read(first page).NextCursor is nil")
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second page) error = %v", err)
+	}
+	if len(second.Events) != 1 {
+		t.Fatalf("len(Read(second page).Events) = %d, want 1", len(second.Events))
+	}
+	if tokenRequests != 2 {
+		t.Fatalf("token requests = %d, want 2", tokenRequests)
+	}
+}
+
 func testConfig(baseURL string, family string) sourcecdk.Config {
 	return sourcecdk.NewConfig(map[string]string{
 		"base_url":      baseURL,


### PR DESCRIPTION
## Summary
- retry GRC page reads once with a fresh Vanta token after a 401 Unauthorized response
- keep token cache reuse across GRC families while invalidating only the matching cached token
- add coverage for stale-token pagination retry

## Validation
- go test ./sources/grc -count=10 -shuffle=on
- make verify