### PR TITLE
fix(findings): improve graph-backed finding evidence

### DIFF
--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -1056,7 +1056,169 @@ func (x *GetFindingEvaluationRunResponse) GetRun() *FindingEvaluationRun {
 	return nil
 }
 
-// FindingEvidence links one persisted finding and one evaluation run to its supporting claims, events, and graph roots.
+// GraphEvidencePath captures one supporting graph edge for a graph-backed finding.
+type GraphEvidencePath struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	FromUrn       string                 `protobuf:"bytes,1,opt,name=from_urn,json=fromUrn,proto3" json:"from_urn,omitempty"`
+	FromLabel     string                 `protobuf:"bytes,2,opt,name=from_label,json=fromLabel,proto3" json:"from_label,omitempty"`
+	FromType      string                 `protobuf:"bytes,3,opt,name=from_type,json=fromType,proto3" json:"from_type,omitempty"`
+	Relation      string                 `protobuf:"bytes,4,opt,name=relation,proto3" json:"relation,omitempty"`
+	ToUrn         string                 `protobuf:"bytes,5,opt,name=to_urn,json=toUrn,proto3" json:"to_urn,omitempty"`
+	ToLabel       string                 `protobuf:"bytes,6,opt,name=to_label,json=toLabel,proto3" json:"to_label,omitempty"`
+	ToType        string                 `protobuf:"bytes,7,opt,name=to_type,json=toType,proto3" json:"to_type,omitempty"`
+	Attributes    map[string]string      `protobuf:"bytes,8,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GraphEvidencePath) Reset() {
+	*x = GraphEvidencePath{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GraphEvidencePath) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GraphEvidencePath) ProtoMessage() {}
+
+func (x *GraphEvidencePath) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GraphEvidencePath.ProtoReflect.Descriptor instead.
+func (*GraphEvidencePath) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *GraphEvidencePath) GetFromUrn() string {
+	if x != nil {
+		return x.FromUrn
+	}
+	return ""
+}
+
+func (x *GraphEvidencePath) GetFromLabel() string {
+	if x != nil {
+		return x.FromLabel
+	}
+	return ""
+}
+
+func (x *GraphEvidencePath) GetFromType() string {
+	if x != nil {
+		return x.FromType
+	}
+	return ""
+}
+
+func (x *GraphEvidencePath) GetRelation() string {
+	if x != nil {
+		return x.Relation
+	}
+	return ""
+}
+
+func (x *GraphEvidencePath) GetToUrn() string {
+	if x != nil {
+		return x.ToUrn
+	}
+	return ""
+}
+
+func (x *GraphEvidencePath) GetToLabel() string {
+	if x != nil {
+		return x.ToLabel
+	}
+	return ""
+}
+
+func (x *GraphEvidencePath) GetToType() string {
+	if x != nil {
+		return x.ToType
+	}
+	return ""
+}
+
+func (x *GraphEvidencePath) GetAttributes() map[string]string {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
+}
+
+// GraphEvidenceRow captures one rule-specific graph row and its supporting paths.
+type GraphEvidenceRow struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Label         string                 `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"`
+	Attributes    map[string]string      `protobuf:"bytes,2,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Paths         []*GraphEvidencePath   `protobuf:"bytes,3,rep,name=paths,proto3" json:"paths,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GraphEvidenceRow) Reset() {
+	*x = GraphEvidenceRow{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GraphEvidenceRow) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GraphEvidenceRow) ProtoMessage() {}
+
+func (x *GraphEvidenceRow) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GraphEvidenceRow.ProtoReflect.Descriptor instead.
+func (*GraphEvidenceRow) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *GraphEvidenceRow) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+func (x *GraphEvidenceRow) GetAttributes() map[string]string {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
+}
+
+func (x *GraphEvidenceRow) GetPaths() []*GraphEvidencePath {
+	if x != nil {
+		return x.Paths
+	}
+	return nil
+}
+
+// FindingEvidence links one persisted finding and one evaluation run to its supporting claims, events, graph roots, and graph rows.
 type FindingEvidence struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -1068,13 +1230,14 @@ type FindingEvidence struct {
 	EventIds      []string               `protobuf:"bytes,7,rep,name=event_ids,json=eventIds,proto3" json:"event_ids,omitempty"`
 	GraphRootUrns []string               `protobuf:"bytes,8,rep,name=graph_root_urns,json=graphRootUrns,proto3" json:"graph_root_urns,omitempty"`
 	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	GraphRows     []*GraphEvidenceRow    `protobuf:"bytes,10,rep,name=graph_rows,json=graphRows,proto3" json:"graph_rows,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *FindingEvidence) Reset() {
 	*x = FindingEvidence{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1086,7 +1249,7 @@ func (x *FindingEvidence) String() string {
 func (*FindingEvidence) ProtoMessage() {}
 
 func (x *FindingEvidence) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[17]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1099,7 +1262,7 @@ func (x *FindingEvidence) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FindingEvidence.ProtoReflect.Descriptor instead.
 func (*FindingEvidence) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{17}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *FindingEvidence) GetId() string {
@@ -1165,6 +1328,13 @@ func (x *FindingEvidence) GetCreatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *FindingEvidence) GetGraphRows() []*GraphEvidenceRow {
+	if x != nil {
+		return x.GraphRows
+	}
+	return nil
+}
+
 // ListFindingEvidenceRequest queries persisted finding evidence for one stored runtime.
 type ListFindingEvidenceRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1182,7 +1352,7 @@ type ListFindingEvidenceRequest struct {
 
 func (x *ListFindingEvidenceRequest) Reset() {
 	*x = ListFindingEvidenceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1194,7 +1364,7 @@ func (x *ListFindingEvidenceRequest) String() string {
 func (*ListFindingEvidenceRequest) ProtoMessage() {}
 
 func (x *ListFindingEvidenceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[18]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1207,7 +1377,7 @@ func (x *ListFindingEvidenceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFindingEvidenceRequest.ProtoReflect.Descriptor instead.
 func (*ListFindingEvidenceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{18}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ListFindingEvidenceRequest) GetRuntimeId() string {
@@ -1276,7 +1446,7 @@ type ListFindingEvidenceResponse struct {
 
 func (x *ListFindingEvidenceResponse) Reset() {
 	*x = ListFindingEvidenceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1288,7 +1458,7 @@ func (x *ListFindingEvidenceResponse) String() string {
 func (*ListFindingEvidenceResponse) ProtoMessage() {}
 
 func (x *ListFindingEvidenceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[19]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1301,7 +1471,7 @@ func (x *ListFindingEvidenceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFindingEvidenceResponse.ProtoReflect.Descriptor instead.
 func (*ListFindingEvidenceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{19}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ListFindingEvidenceResponse) GetEvidence() []*FindingEvidence {
@@ -1321,7 +1491,7 @@ type GetFindingEvidenceRequest struct {
 
 func (x *GetFindingEvidenceRequest) Reset() {
 	*x = GetFindingEvidenceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1333,7 +1503,7 @@ func (x *GetFindingEvidenceRequest) String() string {
 func (*GetFindingEvidenceRequest) ProtoMessage() {}
 
 func (x *GetFindingEvidenceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[20]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1346,7 +1516,7 @@ func (x *GetFindingEvidenceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFindingEvidenceRequest.ProtoReflect.Descriptor instead.
 func (*GetFindingEvidenceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{20}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetFindingEvidenceRequest) GetId() string {
@@ -1366,7 +1536,7 @@ type GetFindingEvidenceResponse struct {
 
 func (x *GetFindingEvidenceResponse) Reset() {
 	*x = GetFindingEvidenceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1378,7 +1548,7 @@ func (x *GetFindingEvidenceResponse) String() string {
 func (*GetFindingEvidenceResponse) ProtoMessage() {}
 
 func (x *GetFindingEvidenceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[21]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1391,7 +1561,7 @@ func (x *GetFindingEvidenceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFindingEvidenceResponse.ProtoReflect.Descriptor instead.
 func (*GetFindingEvidenceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{21}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetFindingEvidenceResponse) GetEvidence() *FindingEvidence {
@@ -1412,7 +1582,7 @@ type RunReportRequest struct {
 
 func (x *RunReportRequest) Reset() {
 	*x = RunReportRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1424,7 +1594,7 @@ func (x *RunReportRequest) String() string {
 func (*RunReportRequest) ProtoMessage() {}
 
 func (x *RunReportRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[22]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1437,7 +1607,7 @@ func (x *RunReportRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunReportRequest.ProtoReflect.Descriptor instead.
 func (*RunReportRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{22}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *RunReportRequest) GetReportId() string {
@@ -1465,7 +1635,7 @@ type RunReportResponse struct {
 
 func (x *RunReportResponse) Reset() {
 	*x = RunReportResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1477,7 +1647,7 @@ func (x *RunReportResponse) String() string {
 func (*RunReportResponse) ProtoMessage() {}
 
 func (x *RunReportResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[23]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1490,7 +1660,7 @@ func (x *RunReportResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunReportResponse.ProtoReflect.Descriptor instead.
 func (*RunReportResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{23}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *RunReportResponse) GetReport() *ReportDefinition {
@@ -1517,7 +1687,7 @@ type GetReportRunRequest struct {
 
 func (x *GetReportRunRequest) Reset() {
 	*x = GetReportRunRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1529,7 +1699,7 @@ func (x *GetReportRunRequest) String() string {
 func (*GetReportRunRequest) ProtoMessage() {}
 
 func (x *GetReportRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[24]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1542,7 +1712,7 @@ func (x *GetReportRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReportRunRequest.ProtoReflect.Descriptor instead.
 func (*GetReportRunRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{24}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetReportRunRequest) GetId() string {
@@ -1562,7 +1732,7 @@ type GetReportRunResponse struct {
 
 func (x *GetReportRunResponse) Reset() {
 	*x = GetReportRunResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1574,7 +1744,7 @@ func (x *GetReportRunResponse) String() string {
 func (*GetReportRunResponse) ProtoMessage() {}
 
 func (x *GetReportRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[25]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1587,7 +1757,7 @@ func (x *GetReportRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReportRunResponse.ProtoReflect.Descriptor instead.
 func (*GetReportRunResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{25}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetReportRunResponse) GetRun() *ReportRun {
@@ -1606,7 +1776,7 @@ type ListSourcesRequest struct {
 
 func (x *ListSourcesRequest) Reset() {
 	*x = ListSourcesRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1618,7 +1788,7 @@ func (x *ListSourcesRequest) String() string {
 func (*ListSourcesRequest) ProtoMessage() {}
 
 func (x *ListSourcesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[26]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1631,7 +1801,7 @@ func (x *ListSourcesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSourcesRequest.ProtoReflect.Descriptor instead.
 func (*ListSourcesRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{26}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{28}
 }
 
 // ListSourcesResponse returns the registered in-process source specs.
@@ -1644,7 +1814,7 @@ type ListSourcesResponse struct {
 
 func (x *ListSourcesResponse) Reset() {
 	*x = ListSourcesResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1656,7 +1826,7 @@ func (x *ListSourcesResponse) String() string {
 func (*ListSourcesResponse) ProtoMessage() {}
 
 func (x *ListSourcesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[27]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1669,7 +1839,7 @@ func (x *ListSourcesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSourcesResponse.ProtoReflect.Descriptor instead.
 func (*ListSourcesResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{27}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListSourcesResponse) GetSources() []*SourceSpec {
@@ -1690,7 +1860,7 @@ type CheckSourceRequest struct {
 
 func (x *CheckSourceRequest) Reset() {
 	*x = CheckSourceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[28]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1702,7 +1872,7 @@ func (x *CheckSourceRequest) String() string {
 func (*CheckSourceRequest) ProtoMessage() {}
 
 func (x *CheckSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[28]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1715,7 +1885,7 @@ func (x *CheckSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckSourceRequest.ProtoReflect.Descriptor instead.
 func (*CheckSourceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{28}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *CheckSourceRequest) GetSourceId() string {
@@ -1743,7 +1913,7 @@ type CheckSourceResponse struct {
 
 func (x *CheckSourceResponse) Reset() {
 	*x = CheckSourceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[29]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1755,7 +1925,7 @@ func (x *CheckSourceResponse) String() string {
 func (*CheckSourceResponse) ProtoMessage() {}
 
 func (x *CheckSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[29]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1768,7 +1938,7 @@ func (x *CheckSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckSourceResponse.ProtoReflect.Descriptor instead.
 func (*CheckSourceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{29}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *CheckSourceResponse) GetSource() *SourceSpec {
@@ -1796,7 +1966,7 @@ type DiscoverSourceRequest struct {
 
 func (x *DiscoverSourceRequest) Reset() {
 	*x = DiscoverSourceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[30]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1808,7 +1978,7 @@ func (x *DiscoverSourceRequest) String() string {
 func (*DiscoverSourceRequest) ProtoMessage() {}
 
 func (x *DiscoverSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[30]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1821,7 +1991,7 @@ func (x *DiscoverSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoverSourceRequest.ProtoReflect.Descriptor instead.
 func (*DiscoverSourceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{30}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *DiscoverSourceRequest) GetSourceId() string {
@@ -1849,7 +2019,7 @@ type DiscoverSourceResponse struct {
 
 func (x *DiscoverSourceResponse) Reset() {
 	*x = DiscoverSourceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[31]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1861,7 +2031,7 @@ func (x *DiscoverSourceResponse) String() string {
 func (*DiscoverSourceResponse) ProtoMessage() {}
 
 func (x *DiscoverSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[31]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1874,7 +2044,7 @@ func (x *DiscoverSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoverSourceResponse.ProtoReflect.Descriptor instead.
 func (*DiscoverSourceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{31}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *DiscoverSourceResponse) GetSource() *SourceSpec {
@@ -1903,7 +2073,7 @@ type ReadSourceRequest struct {
 
 func (x *ReadSourceRequest) Reset() {
 	*x = ReadSourceRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1915,7 +2085,7 @@ func (x *ReadSourceRequest) String() string {
 func (*ReadSourceRequest) ProtoMessage() {}
 
 func (x *ReadSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[32]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1928,7 +2098,7 @@ func (x *ReadSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSourceRequest.ProtoReflect.Descriptor instead.
 func (*ReadSourceRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{32}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ReadSourceRequest) GetSourceId() string {
@@ -1965,7 +2135,7 @@ type SourcePreviewEvent struct {
 
 func (x *SourcePreviewEvent) Reset() {
 	*x = SourcePreviewEvent{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1977,7 +2147,7 @@ func (x *SourcePreviewEvent) String() string {
 func (*SourcePreviewEvent) ProtoMessage() {}
 
 func (x *SourcePreviewEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[33]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1990,7 +2160,7 @@ func (x *SourcePreviewEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SourcePreviewEvent.ProtoReflect.Descriptor instead.
 func (*SourcePreviewEvent) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{33}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *SourcePreviewEvent) GetEvent() *EventEnvelope {
@@ -2035,7 +2205,7 @@ type ReadSourceResponse struct {
 
 func (x *ReadSourceResponse) Reset() {
 	*x = ReadSourceResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2047,7 +2217,7 @@ func (x *ReadSourceResponse) String() string {
 func (*ReadSourceResponse) ProtoMessage() {}
 
 func (x *ReadSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[34]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2060,7 +2230,7 @@ func (x *ReadSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSourceResponse.ProtoReflect.Descriptor instead.
 func (*ReadSourceResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{34}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ReadSourceResponse) GetSource() *SourceSpec {
@@ -2114,7 +2284,7 @@ type SourceRuntime struct {
 
 func (x *SourceRuntime) Reset() {
 	*x = SourceRuntime{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2126,7 +2296,7 @@ func (x *SourceRuntime) String() string {
 func (*SourceRuntime) ProtoMessage() {}
 
 func (x *SourceRuntime) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[35]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2139,7 +2309,7 @@ func (x *SourceRuntime) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SourceRuntime.ProtoReflect.Descriptor instead.
 func (*SourceRuntime) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{35}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *SourceRuntime) GetId() string {
@@ -2201,7 +2371,7 @@ type PutSourceRuntimeRequest struct {
 
 func (x *PutSourceRuntimeRequest) Reset() {
 	*x = PutSourceRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2213,7 +2383,7 @@ func (x *PutSourceRuntimeRequest) String() string {
 func (*PutSourceRuntimeRequest) ProtoMessage() {}
 
 func (x *PutSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[36]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2226,7 +2396,7 @@ func (x *PutSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutSourceRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*PutSourceRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{36}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *PutSourceRuntimeRequest) GetRuntime() *SourceRuntime {
@@ -2246,7 +2416,7 @@ type PutSourceRuntimeResponse struct {
 
 func (x *PutSourceRuntimeResponse) Reset() {
 	*x = PutSourceRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2258,7 +2428,7 @@ func (x *PutSourceRuntimeResponse) String() string {
 func (*PutSourceRuntimeResponse) ProtoMessage() {}
 
 func (x *PutSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[37]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2271,7 +2441,7 @@ func (x *PutSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PutSourceRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*PutSourceRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{37}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *PutSourceRuntimeResponse) GetRuntime() *SourceRuntime {
@@ -2291,7 +2461,7 @@ type GetSourceRuntimeRequest struct {
 
 func (x *GetSourceRuntimeRequest) Reset() {
 	*x = GetSourceRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2303,7 +2473,7 @@ func (x *GetSourceRuntimeRequest) String() string {
 func (*GetSourceRuntimeRequest) ProtoMessage() {}
 
 func (x *GetSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[38]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2316,7 +2486,7 @@ func (x *GetSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSourceRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*GetSourceRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{38}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetSourceRuntimeRequest) GetId() string {
@@ -2336,7 +2506,7 @@ type GetSourceRuntimeResponse struct {
 
 func (x *GetSourceRuntimeResponse) Reset() {
 	*x = GetSourceRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2348,7 +2518,7 @@ func (x *GetSourceRuntimeResponse) String() string {
 func (*GetSourceRuntimeResponse) ProtoMessage() {}
 
 func (x *GetSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[39]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2361,7 +2531,7 @@ func (x *GetSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSourceRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*GetSourceRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{39}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *GetSourceRuntimeResponse) GetRuntime() *SourceRuntime {
@@ -2382,7 +2552,7 @@ type SyncSourceRuntimeRequest struct {
 
 func (x *SyncSourceRuntimeRequest) Reset() {
 	*x = SyncSourceRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2394,7 +2564,7 @@ func (x *SyncSourceRuntimeRequest) String() string {
 func (*SyncSourceRuntimeRequest) ProtoMessage() {}
 
 func (x *SyncSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[40]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2407,7 +2577,7 @@ func (x *SyncSourceRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncSourceRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*SyncSourceRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{40}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *SyncSourceRuntimeRequest) GetId() string {
@@ -2439,7 +2609,7 @@ type SyncSourceRuntimeResponse struct {
 
 func (x *SyncSourceRuntimeResponse) Reset() {
 	*x = SyncSourceRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2451,7 +2621,7 @@ func (x *SyncSourceRuntimeResponse) String() string {
 func (*SyncSourceRuntimeResponse) ProtoMessage() {}
 
 func (x *SyncSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[41]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2464,7 +2634,7 @@ func (x *SyncSourceRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncSourceRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*SyncSourceRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{41}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *SyncSourceRuntimeResponse) GetRuntime() *SourceRuntime {
@@ -2521,7 +2691,7 @@ type WriteClaimsRequest struct {
 
 func (x *WriteClaimsRequest) Reset() {
 	*x = WriteClaimsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2533,7 +2703,7 @@ func (x *WriteClaimsRequest) String() string {
 func (*WriteClaimsRequest) ProtoMessage() {}
 
 func (x *WriteClaimsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[42]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2546,7 +2716,7 @@ func (x *WriteClaimsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteClaimsRequest.ProtoReflect.Descriptor instead.
 func (*WriteClaimsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{42}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *WriteClaimsRequest) GetRuntimeId() string {
@@ -2583,7 +2753,7 @@ type WriteClaimsResponse struct {
 
 func (x *WriteClaimsResponse) Reset() {
 	*x = WriteClaimsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[43]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2595,7 +2765,7 @@ func (x *WriteClaimsResponse) String() string {
 func (*WriteClaimsResponse) ProtoMessage() {}
 
 func (x *WriteClaimsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[43]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2608,7 +2778,7 @@ func (x *WriteClaimsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteClaimsResponse.ProtoReflect.Descriptor instead.
 func (*WriteClaimsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{43}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *WriteClaimsResponse) GetClaimsWritten() uint32 {
@@ -2658,7 +2828,7 @@ type ListClaimsRequest struct {
 
 func (x *ListClaimsRequest) Reset() {
 	*x = ListClaimsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[44]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2670,7 +2840,7 @@ func (x *ListClaimsRequest) String() string {
 func (*ListClaimsRequest) ProtoMessage() {}
 
 func (x *ListClaimsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[44]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2683,7 +2853,7 @@ func (x *ListClaimsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListClaimsRequest.ProtoReflect.Descriptor instead.
 func (*ListClaimsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{44}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ListClaimsRequest) GetRuntimeId() string {
@@ -2766,7 +2936,7 @@ type ListClaimsResponse struct {
 
 func (x *ListClaimsResponse) Reset() {
 	*x = ListClaimsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[45]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2778,7 +2948,7 @@ func (x *ListClaimsResponse) String() string {
 func (*ListClaimsResponse) ProtoMessage() {}
 
 func (x *ListClaimsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[45]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2791,7 +2961,7 @@ func (x *ListClaimsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListClaimsResponse.ProtoReflect.Descriptor instead.
 func (*ListClaimsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{45}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *ListClaimsResponse) GetClaims() []*Claim {
@@ -2819,7 +2989,7 @@ type ListFindingsRequest struct {
 
 func (x *ListFindingsRequest) Reset() {
 	*x = ListFindingsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[46]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2831,7 +3001,7 @@ func (x *ListFindingsRequest) String() string {
 func (*ListFindingsRequest) ProtoMessage() {}
 
 func (x *ListFindingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[46]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2844,7 +3014,7 @@ func (x *ListFindingsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFindingsRequest.ProtoReflect.Descriptor instead.
 func (*ListFindingsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{46}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ListFindingsRequest) GetRuntimeId() string {
@@ -2921,7 +3091,7 @@ type FindingControlRef struct {
 
 func (x *FindingControlRef) Reset() {
 	*x = FindingControlRef{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[47]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2933,7 +3103,7 @@ func (x *FindingControlRef) String() string {
 func (*FindingControlRef) ProtoMessage() {}
 
 func (x *FindingControlRef) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[47]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2946,7 +3116,7 @@ func (x *FindingControlRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FindingControlRef.ProtoReflect.Descriptor instead.
 func (*FindingControlRef) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{47}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *FindingControlRef) GetFrameworkName() string {
@@ -2975,7 +3145,7 @@ type FindingNote struct {
 
 func (x *FindingNote) Reset() {
 	*x = FindingNote{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[48]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2987,7 +3157,7 @@ func (x *FindingNote) String() string {
 func (*FindingNote) ProtoMessage() {}
 
 func (x *FindingNote) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[48]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3000,7 +3170,7 @@ func (x *FindingNote) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FindingNote.ProtoReflect.Descriptor instead.
 func (*FindingNote) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{48}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *FindingNote) GetId() string {
@@ -3037,7 +3207,7 @@ type FindingTicket struct {
 
 func (x *FindingTicket) Reset() {
 	*x = FindingTicket{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[49]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3049,7 +3219,7 @@ func (x *FindingTicket) String() string {
 func (*FindingTicket) ProtoMessage() {}
 
 func (x *FindingTicket) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[49]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3062,7 +3232,7 @@ func (x *FindingTicket) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FindingTicket.ProtoReflect.Descriptor instead.
 func (*FindingTicket) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{49}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *FindingTicket) GetUrl() string {
@@ -3128,7 +3298,7 @@ type Finding struct {
 
 func (x *Finding) Reset() {
 	*x = Finding{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[50]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3140,7 +3310,7 @@ func (x *Finding) String() string {
 func (*Finding) ProtoMessage() {}
 
 func (x *Finding) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[50]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3153,7 +3323,7 @@ func (x *Finding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Finding.ProtoReflect.Descriptor instead.
 func (*Finding) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{50}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *Finding) GetId() string {
@@ -3348,7 +3518,7 @@ type GetFindingRequest struct {
 
 func (x *GetFindingRequest) Reset() {
 	*x = GetFindingRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[51]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3360,7 +3530,7 @@ func (x *GetFindingRequest) String() string {
 func (*GetFindingRequest) ProtoMessage() {}
 
 func (x *GetFindingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[51]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3373,7 +3543,7 @@ func (x *GetFindingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFindingRequest.ProtoReflect.Descriptor instead.
 func (*GetFindingRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{51}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *GetFindingRequest) GetId() string {
@@ -3393,7 +3563,7 @@ type GetFindingResponse struct {
 
 func (x *GetFindingResponse) Reset() {
 	*x = GetFindingResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[52]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3405,7 +3575,7 @@ func (x *GetFindingResponse) String() string {
 func (*GetFindingResponse) ProtoMessage() {}
 
 func (x *GetFindingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[52]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3418,7 +3588,7 @@ func (x *GetFindingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFindingResponse.ProtoReflect.Descriptor instead.
 func (*GetFindingResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{52}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *GetFindingResponse) GetFinding() *Finding {
@@ -3439,7 +3609,7 @@ type ResolveFindingRequest struct {
 
 func (x *ResolveFindingRequest) Reset() {
 	*x = ResolveFindingRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[53]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3451,7 +3621,7 @@ func (x *ResolveFindingRequest) String() string {
 func (*ResolveFindingRequest) ProtoMessage() {}
 
 func (x *ResolveFindingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[53]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3464,7 +3634,7 @@ func (x *ResolveFindingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveFindingRequest.ProtoReflect.Descriptor instead.
 func (*ResolveFindingRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{53}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ResolveFindingRequest) GetId() string {
@@ -3491,7 +3661,7 @@ type ResolveFindingResponse struct {
 
 func (x *ResolveFindingResponse) Reset() {
 	*x = ResolveFindingResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[54]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3503,7 +3673,7 @@ func (x *ResolveFindingResponse) String() string {
 func (*ResolveFindingResponse) ProtoMessage() {}
 
 func (x *ResolveFindingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[54]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3516,7 +3686,7 @@ func (x *ResolveFindingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveFindingResponse.ProtoReflect.Descriptor instead.
 func (*ResolveFindingResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{54}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ResolveFindingResponse) GetFinding() *Finding {
@@ -3537,7 +3707,7 @@ type SuppressFindingRequest struct {
 
 func (x *SuppressFindingRequest) Reset() {
 	*x = SuppressFindingRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[55]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3549,7 +3719,7 @@ func (x *SuppressFindingRequest) String() string {
 func (*SuppressFindingRequest) ProtoMessage() {}
 
 func (x *SuppressFindingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[55]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3562,7 +3732,7 @@ func (x *SuppressFindingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuppressFindingRequest.ProtoReflect.Descriptor instead.
 func (*SuppressFindingRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{55}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *SuppressFindingRequest) GetId() string {
@@ -3589,7 +3759,7 @@ type SuppressFindingResponse struct {
 
 func (x *SuppressFindingResponse) Reset() {
 	*x = SuppressFindingResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[56]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3601,7 +3771,7 @@ func (x *SuppressFindingResponse) String() string {
 func (*SuppressFindingResponse) ProtoMessage() {}
 
 func (x *SuppressFindingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[56]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3614,7 +3784,7 @@ func (x *SuppressFindingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SuppressFindingResponse.ProtoReflect.Descriptor instead.
 func (*SuppressFindingResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{56}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *SuppressFindingResponse) GetFinding() *Finding {
@@ -3635,7 +3805,7 @@ type AssignFindingRequest struct {
 
 func (x *AssignFindingRequest) Reset() {
 	*x = AssignFindingRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[57]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3647,7 +3817,7 @@ func (x *AssignFindingRequest) String() string {
 func (*AssignFindingRequest) ProtoMessage() {}
 
 func (x *AssignFindingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[57]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3660,7 +3830,7 @@ func (x *AssignFindingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssignFindingRequest.ProtoReflect.Descriptor instead.
 func (*AssignFindingRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{57}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *AssignFindingRequest) GetId() string {
@@ -3687,7 +3857,7 @@ type AssignFindingResponse struct {
 
 func (x *AssignFindingResponse) Reset() {
 	*x = AssignFindingResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[58]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3699,7 +3869,7 @@ func (x *AssignFindingResponse) String() string {
 func (*AssignFindingResponse) ProtoMessage() {}
 
 func (x *AssignFindingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[58]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3712,7 +3882,7 @@ func (x *AssignFindingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssignFindingResponse.ProtoReflect.Descriptor instead.
 func (*AssignFindingResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{58}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *AssignFindingResponse) GetFinding() *Finding {
@@ -3733,7 +3903,7 @@ type SetFindingDueDateRequest struct {
 
 func (x *SetFindingDueDateRequest) Reset() {
 	*x = SetFindingDueDateRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[59]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3745,7 +3915,7 @@ func (x *SetFindingDueDateRequest) String() string {
 func (*SetFindingDueDateRequest) ProtoMessage() {}
 
 func (x *SetFindingDueDateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[59]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3758,7 +3928,7 @@ func (x *SetFindingDueDateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetFindingDueDateRequest.ProtoReflect.Descriptor instead.
 func (*SetFindingDueDateRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{59}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *SetFindingDueDateRequest) GetId() string {
@@ -3785,7 +3955,7 @@ type SetFindingDueDateResponse struct {
 
 func (x *SetFindingDueDateResponse) Reset() {
 	*x = SetFindingDueDateResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[60]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3797,7 +3967,7 @@ func (x *SetFindingDueDateResponse) String() string {
 func (*SetFindingDueDateResponse) ProtoMessage() {}
 
 func (x *SetFindingDueDateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[60]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3810,7 +3980,7 @@ func (x *SetFindingDueDateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetFindingDueDateResponse.ProtoReflect.Descriptor instead.
 func (*SetFindingDueDateResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{60}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *SetFindingDueDateResponse) GetFinding() *Finding {
@@ -3831,7 +4001,7 @@ type AddFindingNoteRequest struct {
 
 func (x *AddFindingNoteRequest) Reset() {
 	*x = AddFindingNoteRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[61]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3843,7 +4013,7 @@ func (x *AddFindingNoteRequest) String() string {
 func (*AddFindingNoteRequest) ProtoMessage() {}
 
 func (x *AddFindingNoteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[61]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3856,7 +4026,7 @@ func (x *AddFindingNoteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddFindingNoteRequest.ProtoReflect.Descriptor instead.
 func (*AddFindingNoteRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{61}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *AddFindingNoteRequest) GetId() string {
@@ -3883,7 +4053,7 @@ type AddFindingNoteResponse struct {
 
 func (x *AddFindingNoteResponse) Reset() {
 	*x = AddFindingNoteResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[62]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3895,7 +4065,7 @@ func (x *AddFindingNoteResponse) String() string {
 func (*AddFindingNoteResponse) ProtoMessage() {}
 
 func (x *AddFindingNoteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[62]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3908,7 +4078,7 @@ func (x *AddFindingNoteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddFindingNoteResponse.ProtoReflect.Descriptor instead.
 func (*AddFindingNoteResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{62}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *AddFindingNoteResponse) GetFinding() *Finding {
@@ -3931,7 +4101,7 @@ type LinkFindingTicketRequest struct {
 
 func (x *LinkFindingTicketRequest) Reset() {
 	*x = LinkFindingTicketRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[63]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3943,7 +4113,7 @@ func (x *LinkFindingTicketRequest) String() string {
 func (*LinkFindingTicketRequest) ProtoMessage() {}
 
 func (x *LinkFindingTicketRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[63]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3956,7 +4126,7 @@ func (x *LinkFindingTicketRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinkFindingTicketRequest.ProtoReflect.Descriptor instead.
 func (*LinkFindingTicketRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{63}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *LinkFindingTicketRequest) GetId() string {
@@ -3997,7 +4167,7 @@ type LinkFindingTicketResponse struct {
 
 func (x *LinkFindingTicketResponse) Reset() {
 	*x = LinkFindingTicketResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[64]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4009,7 +4179,7 @@ func (x *LinkFindingTicketResponse) String() string {
 func (*LinkFindingTicketResponse) ProtoMessage() {}
 
 func (x *LinkFindingTicketResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[64]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4022,7 +4192,7 @@ func (x *LinkFindingTicketResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinkFindingTicketResponse.ProtoReflect.Descriptor instead.
 func (*LinkFindingTicketResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{64}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *LinkFindingTicketResponse) GetFinding() *Finding {
@@ -4042,7 +4212,7 @@ type ListFindingsResponse struct {
 
 func (x *ListFindingsResponse) Reset() {
 	*x = ListFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[65]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4054,7 +4224,7 @@ func (x *ListFindingsResponse) String() string {
 func (*ListFindingsResponse) ProtoMessage() {}
 
 func (x *ListFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[65]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4067,7 +4237,7 @@ func (x *ListFindingsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFindingsResponse.ProtoReflect.Descriptor instead.
 func (*ListFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{65}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *ListFindingsResponse) GetFindings() []*Finding {
@@ -4089,7 +4259,7 @@ type EvaluateSourceRuntimeFindingsRequest struct {
 
 func (x *EvaluateSourceRuntimeFindingsRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[66]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4101,7 +4271,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) String() string {
 func (*EvaluateSourceRuntimeFindingsRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[66]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4114,7 +4284,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{66}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *EvaluateSourceRuntimeFindingsRequest) GetId() string {
@@ -4150,7 +4320,7 @@ type EvaluateSourceRuntimeFindingRulesRequest struct {
 
 func (x *EvaluateSourceRuntimeFindingRulesRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingRulesRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[67]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4162,7 +4332,7 @@ func (x *EvaluateSourceRuntimeFindingRulesRequest) String() string {
 func (*EvaluateSourceRuntimeFindingRulesRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingRulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[67]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4175,7 +4345,7 @@ func (x *EvaluateSourceRuntimeFindingRulesRequest) ProtoReflect() protoreflect.M
 
 // Deprecated: Use EvaluateSourceRuntimeFindingRulesRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingRulesRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{67}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *EvaluateSourceRuntimeFindingRulesRequest) GetId() string {
@@ -4212,7 +4382,7 @@ type FindingRuleEvaluation struct {
 
 func (x *FindingRuleEvaluation) Reset() {
 	*x = FindingRuleEvaluation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[68]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4224,7 +4394,7 @@ func (x *FindingRuleEvaluation) String() string {
 func (*FindingRuleEvaluation) ProtoMessage() {}
 
 func (x *FindingRuleEvaluation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[68]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4237,7 +4407,7 @@ func (x *FindingRuleEvaluation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FindingRuleEvaluation.ProtoReflect.Descriptor instead.
 func (*FindingRuleEvaluation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{68}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *FindingRuleEvaluation) GetRule() *RuleSpec {
@@ -4280,7 +4450,7 @@ type EvaluateSourceRuntimeFindingRulesResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingRulesResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingRulesResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[69]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4292,7 +4462,7 @@ func (x *EvaluateSourceRuntimeFindingRulesResponse) String() string {
 func (*EvaluateSourceRuntimeFindingRulesResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingRulesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[69]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4305,7 +4475,7 @@ func (x *EvaluateSourceRuntimeFindingRulesResponse) ProtoReflect() protoreflect.
 
 // Deprecated: Use EvaluateSourceRuntimeFindingRulesResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingRulesResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{69}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *EvaluateSourceRuntimeFindingRulesResponse) GetRuntime() *SourceRuntime {
@@ -4345,7 +4515,7 @@ type EvaluateSourceRuntimeFindingsResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingsResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[70]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4357,7 +4527,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) String() string {
 func (*EvaluateSourceRuntimeFindingsResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[70]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4370,7 +4540,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{70}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *EvaluateSourceRuntimeFindingsResponse) GetRuntime() *SourceRuntime {
@@ -4446,7 +4616,7 @@ type WriteDecisionRequest struct {
 
 func (x *WriteDecisionRequest) Reset() {
 	*x = WriteDecisionRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[71]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4458,7 +4628,7 @@ func (x *WriteDecisionRequest) String() string {
 func (*WriteDecisionRequest) ProtoMessage() {}
 
 func (x *WriteDecisionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[71]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4471,7 +4641,7 @@ func (x *WriteDecisionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteDecisionRequest.ProtoReflect.Descriptor instead.
 func (*WriteDecisionRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{71}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *WriteDecisionRequest) GetId() string {
@@ -4590,7 +4760,7 @@ type WriteDecisionResponse struct {
 
 func (x *WriteDecisionResponse) Reset() {
 	*x = WriteDecisionResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[72]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4602,7 +4772,7 @@ func (x *WriteDecisionResponse) String() string {
 func (*WriteDecisionResponse) ProtoMessage() {}
 
 func (x *WriteDecisionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[72]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4615,7 +4785,7 @@ func (x *WriteDecisionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteDecisionResponse.ProtoReflect.Descriptor instead.
 func (*WriteDecisionResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{72}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *WriteDecisionResponse) GetDecisionId() string {
@@ -4656,7 +4826,7 @@ type WriteActionRequest struct {
 
 func (x *WriteActionRequest) Reset() {
 	*x = WriteActionRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[73]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4668,7 +4838,7 @@ func (x *WriteActionRequest) String() string {
 func (*WriteActionRequest) ProtoMessage() {}
 
 func (x *WriteActionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[73]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4681,7 +4851,7 @@ func (x *WriteActionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteActionRequest.ProtoReflect.Descriptor instead.
 func (*WriteActionRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{73}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *WriteActionRequest) GetId() string {
@@ -4801,7 +4971,7 @@ type WriteActionResponse struct {
 
 func (x *WriteActionResponse) Reset() {
 	*x = WriteActionResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[74]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4813,7 +4983,7 @@ func (x *WriteActionResponse) String() string {
 func (*WriteActionResponse) ProtoMessage() {}
 
 func (x *WriteActionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[74]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4826,7 +4996,7 @@ func (x *WriteActionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteActionResponse.ProtoReflect.Descriptor instead.
 func (*WriteActionResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{74}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *WriteActionResponse) GetActionId() string {
@@ -4872,7 +5042,7 @@ type WriteOutcomeRequest struct {
 
 func (x *WriteOutcomeRequest) Reset() {
 	*x = WriteOutcomeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[75]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4884,7 +5054,7 @@ func (x *WriteOutcomeRequest) String() string {
 func (*WriteOutcomeRequest) ProtoMessage() {}
 
 func (x *WriteOutcomeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[75]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4897,7 +5067,7 @@ func (x *WriteOutcomeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteOutcomeRequest.ProtoReflect.Descriptor instead.
 func (*WriteOutcomeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{75}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *WriteOutcomeRequest) GetId() string {
@@ -5003,7 +5173,7 @@ type WriteOutcomeResponse struct {
 
 func (x *WriteOutcomeResponse) Reset() {
 	*x = WriteOutcomeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[76]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5015,7 +5185,7 @@ func (x *WriteOutcomeResponse) String() string {
 func (*WriteOutcomeResponse) ProtoMessage() {}
 
 func (x *WriteOutcomeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[76]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5028,7 +5198,7 @@ func (x *WriteOutcomeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteOutcomeResponse.ProtoReflect.Descriptor instead.
 func (*WriteOutcomeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{76}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *WriteOutcomeResponse) GetOutcomeId() string {
@@ -5065,7 +5235,7 @@ type ReplayWorkflowEventsRequest struct {
 
 func (x *ReplayWorkflowEventsRequest) Reset() {
 	*x = ReplayWorkflowEventsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[77]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5077,7 +5247,7 @@ func (x *ReplayWorkflowEventsRequest) String() string {
 func (*ReplayWorkflowEventsRequest) ProtoMessage() {}
 
 func (x *ReplayWorkflowEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[77]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5090,7 +5260,7 @@ func (x *ReplayWorkflowEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayWorkflowEventsRequest.ProtoReflect.Descriptor instead.
 func (*ReplayWorkflowEventsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{77}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *ReplayWorkflowEventsRequest) GetKindPrefix() string {
@@ -5134,7 +5304,7 @@ type ReplayWorkflowEventsResponse struct {
 
 func (x *ReplayWorkflowEventsResponse) Reset() {
 	*x = ReplayWorkflowEventsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[78]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5146,7 +5316,7 @@ func (x *ReplayWorkflowEventsResponse) String() string {
 func (*ReplayWorkflowEventsResponse) ProtoMessage() {}
 
 func (x *ReplayWorkflowEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[78]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5159,7 +5329,7 @@ func (x *ReplayWorkflowEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayWorkflowEventsResponse.ProtoReflect.Descriptor instead.
 func (*ReplayWorkflowEventsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{78}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *ReplayWorkflowEventsResponse) GetEventsRead() uint32 {
@@ -5202,7 +5372,7 @@ type GraphEntity struct {
 
 func (x *GraphEntity) Reset() {
 	*x = GraphEntity{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[79]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5214,7 +5384,7 @@ func (x *GraphEntity) String() string {
 func (*GraphEntity) ProtoMessage() {}
 
 func (x *GraphEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[79]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5227,7 +5397,7 @@ func (x *GraphEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphEntity.ProtoReflect.Descriptor instead.
 func (*GraphEntity) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{79}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *GraphEntity) GetUrn() string {
@@ -5263,7 +5433,7 @@ type GraphRelation struct {
 
 func (x *GraphRelation) Reset() {
 	*x = GraphRelation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5275,7 +5445,7 @@ func (x *GraphRelation) String() string {
 func (*GraphRelation) ProtoMessage() {}
 
 func (x *GraphRelation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5288,7 +5458,7 @@ func (x *GraphRelation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphRelation.ProtoReflect.Descriptor instead.
 func (*GraphRelation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{80}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *GraphRelation) GetFromUrn() string {
@@ -5323,7 +5493,7 @@ type GetEntityNeighborhoodRequest struct {
 
 func (x *GetEntityNeighborhoodRequest) Reset() {
 	*x = GetEntityNeighborhoodRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5335,7 +5505,7 @@ func (x *GetEntityNeighborhoodRequest) String() string {
 func (*GetEntityNeighborhoodRequest) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5348,7 +5518,7 @@ func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodRequest.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{81}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *GetEntityNeighborhoodRequest) GetRootUrn() string {
@@ -5377,7 +5547,7 @@ type GetEntityNeighborhoodResponse struct {
 
 func (x *GetEntityNeighborhoodResponse) Reset() {
 	*x = GetEntityNeighborhoodResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5389,7 +5559,7 @@ func (x *GetEntityNeighborhoodResponse) String() string {
 func (*GetEntityNeighborhoodResponse) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5402,7 +5572,7 @@ func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodResponse.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{82}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *GetEntityNeighborhoodResponse) GetRoot() *GraphEntity {
@@ -5453,7 +5623,7 @@ type GraphIngestRun struct {
 
 func (x *GraphIngestRun) Reset() {
 	*x = GraphIngestRun{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5465,7 +5635,7 @@ func (x *GraphIngestRun) String() string {
 func (*GraphIngestRun) ProtoMessage() {}
 
 func (x *GraphIngestRun) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5478,7 +5648,7 @@ func (x *GraphIngestRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphIngestRun.ProtoReflect.Descriptor instead.
 func (*GraphIngestRun) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{83}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *GraphIngestRun) GetId() string {
@@ -5633,7 +5803,7 @@ type GraphIngestResult struct {
 
 func (x *GraphIngestResult) Reset() {
 	*x = GraphIngestResult{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5645,7 +5815,7 @@ func (x *GraphIngestResult) String() string {
 func (*GraphIngestResult) ProtoMessage() {}
 
 func (x *GraphIngestResult) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5658,7 +5828,7 @@ func (x *GraphIngestResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphIngestResult.ProtoReflect.Descriptor instead.
 func (*GraphIngestResult) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{84}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *GraphIngestResult) GetSourceId() string {
@@ -5791,7 +5961,7 @@ type GraphIngestRunResult struct {
 
 func (x *GraphIngestRunResult) Reset() {
 	*x = GraphIngestRunResult{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5803,7 +5973,7 @@ func (x *GraphIngestRunResult) String() string {
 func (*GraphIngestRunResult) ProtoMessage() {}
 
 func (x *GraphIngestRunResult) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5816,7 +5986,7 @@ func (x *GraphIngestRunResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphIngestRunResult.ProtoReflect.Descriptor instead.
 func (*GraphIngestRunResult) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{85}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *GraphIngestRunResult) GetRun() *GraphIngestRun {
@@ -5846,7 +6016,7 @@ type RunGraphIngestRuntimeRequest struct {
 
 func (x *RunGraphIngestRuntimeRequest) Reset() {
 	*x = RunGraphIngestRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5858,7 +6028,7 @@ func (x *RunGraphIngestRuntimeRequest) String() string {
 func (*RunGraphIngestRuntimeRequest) ProtoMessage() {}
 
 func (x *RunGraphIngestRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5871,7 +6041,7 @@ func (x *RunGraphIngestRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunGraphIngestRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*RunGraphIngestRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{86}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *RunGraphIngestRuntimeRequest) GetRuntimeId() string {
@@ -5912,7 +6082,7 @@ type RunGraphIngestRuntimeResponse struct {
 
 func (x *RunGraphIngestRuntimeResponse) Reset() {
 	*x = RunGraphIngestRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5924,7 +6094,7 @@ func (x *RunGraphIngestRuntimeResponse) String() string {
 func (*RunGraphIngestRuntimeResponse) ProtoMessage() {}
 
 func (x *RunGraphIngestRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5937,7 +6107,7 @@ func (x *RunGraphIngestRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunGraphIngestRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*RunGraphIngestRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{87}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *RunGraphIngestRuntimeResponse) GetResult() *GraphIngestRunResult {
@@ -5957,7 +6127,7 @@ type GetGraphIngestRunRequest struct {
 
 func (x *GetGraphIngestRunRequest) Reset() {
 	*x = GetGraphIngestRunRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5969,7 +6139,7 @@ func (x *GetGraphIngestRunRequest) String() string {
 func (*GetGraphIngestRunRequest) ProtoMessage() {}
 
 func (x *GetGraphIngestRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5982,7 +6152,7 @@ func (x *GetGraphIngestRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGraphIngestRunRequest.ProtoReflect.Descriptor instead.
 func (*GetGraphIngestRunRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{88}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *GetGraphIngestRunRequest) GetId() string {
@@ -6002,7 +6172,7 @@ type GetGraphIngestRunResponse struct {
 
 func (x *GetGraphIngestRunResponse) Reset() {
 	*x = GetGraphIngestRunResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6014,7 +6184,7 @@ func (x *GetGraphIngestRunResponse) String() string {
 func (*GetGraphIngestRunResponse) ProtoMessage() {}
 
 func (x *GetGraphIngestRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6027,7 +6197,7 @@ func (x *GetGraphIngestRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGraphIngestRunResponse.ProtoReflect.Descriptor instead.
 func (*GetGraphIngestRunResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{89}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *GetGraphIngestRunResponse) GetRun() *GraphIngestRun {
@@ -6049,7 +6219,7 @@ type ListGraphIngestRunsRequest struct {
 
 func (x *ListGraphIngestRunsRequest) Reset() {
 	*x = ListGraphIngestRunsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6061,7 +6231,7 @@ func (x *ListGraphIngestRunsRequest) String() string {
 func (*ListGraphIngestRunsRequest) ProtoMessage() {}
 
 func (x *ListGraphIngestRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6074,7 +6244,7 @@ func (x *ListGraphIngestRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGraphIngestRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListGraphIngestRunsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{90}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *ListGraphIngestRunsRequest) GetRuntimeId() string {
@@ -6109,7 +6279,7 @@ type ListGraphIngestRunsResponse struct {
 
 func (x *ListGraphIngestRunsResponse) Reset() {
 	*x = ListGraphIngestRunsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6121,7 +6291,7 @@ func (x *ListGraphIngestRunsResponse) String() string {
 func (*ListGraphIngestRunsResponse) ProtoMessage() {}
 
 func (x *ListGraphIngestRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6134,7 +6304,7 @@ func (x *ListGraphIngestRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGraphIngestRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListGraphIngestRunsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{91}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *ListGraphIngestRunsResponse) GetRuns() []*GraphIngestRun {
@@ -6161,7 +6331,7 @@ type CheckGraphIngestHealthRequest struct {
 
 func (x *CheckGraphIngestHealthRequest) Reset() {
 	*x = CheckGraphIngestHealthRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6173,7 +6343,7 @@ func (x *CheckGraphIngestHealthRequest) String() string {
 func (*CheckGraphIngestHealthRequest) ProtoMessage() {}
 
 func (x *CheckGraphIngestHealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6186,7 +6356,7 @@ func (x *CheckGraphIngestHealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckGraphIngestHealthRequest.ProtoReflect.Descriptor instead.
 func (*CheckGraphIngestHealthRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{92}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *CheckGraphIngestHealthRequest) GetLimit() uint32 {
@@ -6210,7 +6380,7 @@ type CheckGraphIngestHealthResponse struct {
 
 func (x *CheckGraphIngestHealthResponse) Reset() {
 	*x = CheckGraphIngestHealthResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6222,7 +6392,7 @@ func (x *CheckGraphIngestHealthResponse) String() string {
 func (*CheckGraphIngestHealthResponse) ProtoMessage() {}
 
 func (x *CheckGraphIngestHealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6235,7 +6405,7 @@ func (x *CheckGraphIngestHealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckGraphIngestHealthResponse.ProtoReflect.Descriptor instead.
 func (*CheckGraphIngestHealthResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{93}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *CheckGraphIngestHealthResponse) GetStatus() string {
@@ -6358,7 +6528,31 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x1eGetFindingEvaluationRunRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"U\n" +
 	"\x1fGetFindingEvaluationRunResponse\x122\n" +
-	"\x03run\x18\x01 \x01(\v2 .cerebro.v1.FindingEvaluationRunR\x03run\"\xac\x02\n" +
+	"\x03run\x18\x01 \x01(\v2 .cerebro.v1.FindingEvaluationRunR\x03run\"\xdf\x02\n" +
+	"\x11GraphEvidencePath\x12\x19\n" +
+	"\bfrom_urn\x18\x01 \x01(\tR\afromUrn\x12\x1d\n" +
+	"\n" +
+	"from_label\x18\x02 \x01(\tR\tfromLabel\x12\x1b\n" +
+	"\tfrom_type\x18\x03 \x01(\tR\bfromType\x12\x1a\n" +
+	"\brelation\x18\x04 \x01(\tR\brelation\x12\x15\n" +
+	"\x06to_urn\x18\x05 \x01(\tR\x05toUrn\x12\x19\n" +
+	"\bto_label\x18\x06 \x01(\tR\atoLabel\x12\x17\n" +
+	"\ato_type\x18\a \x01(\tR\x06toType\x12M\n" +
+	"\n" +
+	"attributes\x18\b \x03(\v2-.cerebro.v1.GraphEvidencePath.AttributesEntryR\n" +
+	"attributes\x1a=\n" +
+	"\x0fAttributesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xea\x01\n" +
+	"\x10GraphEvidenceRow\x12\x14\n" +
+	"\x05label\x18\x01 \x01(\tR\x05label\x12L\n" +
+	"\n" +
+	"attributes\x18\x02 \x03(\v2,.cerebro.v1.GraphEvidenceRow.AttributesEntryR\n" +
+	"attributes\x123\n" +
+	"\x05paths\x18\x03 \x03(\v2\x1d.cerebro.v1.GraphEvidencePathR\x05paths\x1a=\n" +
+	"\x0fAttributesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe9\x02\n" +
 	"\x0fFindingEvidence\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
@@ -6371,7 +6565,10 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\tevent_ids\x18\a \x03(\tR\beventIds\x12&\n" +
 	"\x0fgraph_root_urns\x18\b \x03(\tR\rgraphRootUrns\x129\n" +
 	"\n" +
-	"created_at\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\xfc\x01\n" +
+	"created_at\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12;\n" +
+	"\n" +
+	"graph_rows\x18\n" +
+	" \x03(\v2\x1c.cerebro.v1.GraphEvidenceRowR\tgraphRows\"\xfc\x01\n" +
 	"\x1aListFindingEvidenceRequest\x12\x1d\n" +
 	"\n" +
 	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12\x1d\n" +
@@ -6893,7 +7090,7 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 }
 
 var file_cerebro_v1_bootstrap_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 102)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 106)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(FindingStatus)(0),                                // 0: cerebro.v1.FindingStatus
 	(*GetVersionRequest)(nil),                         // 1: cerebro.v1.GetVersionRequest
@@ -6913,282 +7110,290 @@ var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*ListFindingEvaluationRunsResponse)(nil),         // 15: cerebro.v1.ListFindingEvaluationRunsResponse
 	(*GetFindingEvaluationRunRequest)(nil),            // 16: cerebro.v1.GetFindingEvaluationRunRequest
 	(*GetFindingEvaluationRunResponse)(nil),           // 17: cerebro.v1.GetFindingEvaluationRunResponse
-	(*FindingEvidence)(nil),                           // 18: cerebro.v1.FindingEvidence
-	(*ListFindingEvidenceRequest)(nil),                // 19: cerebro.v1.ListFindingEvidenceRequest
-	(*ListFindingEvidenceResponse)(nil),               // 20: cerebro.v1.ListFindingEvidenceResponse
-	(*GetFindingEvidenceRequest)(nil),                 // 21: cerebro.v1.GetFindingEvidenceRequest
-	(*GetFindingEvidenceResponse)(nil),                // 22: cerebro.v1.GetFindingEvidenceResponse
-	(*RunReportRequest)(nil),                          // 23: cerebro.v1.RunReportRequest
-	(*RunReportResponse)(nil),                         // 24: cerebro.v1.RunReportResponse
-	(*GetReportRunRequest)(nil),                       // 25: cerebro.v1.GetReportRunRequest
-	(*GetReportRunResponse)(nil),                      // 26: cerebro.v1.GetReportRunResponse
-	(*ListSourcesRequest)(nil),                        // 27: cerebro.v1.ListSourcesRequest
-	(*ListSourcesResponse)(nil),                       // 28: cerebro.v1.ListSourcesResponse
-	(*CheckSourceRequest)(nil),                        // 29: cerebro.v1.CheckSourceRequest
-	(*CheckSourceResponse)(nil),                       // 30: cerebro.v1.CheckSourceResponse
-	(*DiscoverSourceRequest)(nil),                     // 31: cerebro.v1.DiscoverSourceRequest
-	(*DiscoverSourceResponse)(nil),                    // 32: cerebro.v1.DiscoverSourceResponse
-	(*ReadSourceRequest)(nil),                         // 33: cerebro.v1.ReadSourceRequest
-	(*SourcePreviewEvent)(nil),                        // 34: cerebro.v1.SourcePreviewEvent
-	(*ReadSourceResponse)(nil),                        // 35: cerebro.v1.ReadSourceResponse
-	(*SourceRuntime)(nil),                             // 36: cerebro.v1.SourceRuntime
-	(*PutSourceRuntimeRequest)(nil),                   // 37: cerebro.v1.PutSourceRuntimeRequest
-	(*PutSourceRuntimeResponse)(nil),                  // 38: cerebro.v1.PutSourceRuntimeResponse
-	(*GetSourceRuntimeRequest)(nil),                   // 39: cerebro.v1.GetSourceRuntimeRequest
-	(*GetSourceRuntimeResponse)(nil),                  // 40: cerebro.v1.GetSourceRuntimeResponse
-	(*SyncSourceRuntimeRequest)(nil),                  // 41: cerebro.v1.SyncSourceRuntimeRequest
-	(*SyncSourceRuntimeResponse)(nil),                 // 42: cerebro.v1.SyncSourceRuntimeResponse
-	(*WriteClaimsRequest)(nil),                        // 43: cerebro.v1.WriteClaimsRequest
-	(*WriteClaimsResponse)(nil),                       // 44: cerebro.v1.WriteClaimsResponse
-	(*ListClaimsRequest)(nil),                         // 45: cerebro.v1.ListClaimsRequest
-	(*ListClaimsResponse)(nil),                        // 46: cerebro.v1.ListClaimsResponse
-	(*ListFindingsRequest)(nil),                       // 47: cerebro.v1.ListFindingsRequest
-	(*FindingControlRef)(nil),                         // 48: cerebro.v1.FindingControlRef
-	(*FindingNote)(nil),                               // 49: cerebro.v1.FindingNote
-	(*FindingTicket)(nil),                             // 50: cerebro.v1.FindingTicket
-	(*Finding)(nil),                                   // 51: cerebro.v1.Finding
-	(*GetFindingRequest)(nil),                         // 52: cerebro.v1.GetFindingRequest
-	(*GetFindingResponse)(nil),                        // 53: cerebro.v1.GetFindingResponse
-	(*ResolveFindingRequest)(nil),                     // 54: cerebro.v1.ResolveFindingRequest
-	(*ResolveFindingResponse)(nil),                    // 55: cerebro.v1.ResolveFindingResponse
-	(*SuppressFindingRequest)(nil),                    // 56: cerebro.v1.SuppressFindingRequest
-	(*SuppressFindingResponse)(nil),                   // 57: cerebro.v1.SuppressFindingResponse
-	(*AssignFindingRequest)(nil),                      // 58: cerebro.v1.AssignFindingRequest
-	(*AssignFindingResponse)(nil),                     // 59: cerebro.v1.AssignFindingResponse
-	(*SetFindingDueDateRequest)(nil),                  // 60: cerebro.v1.SetFindingDueDateRequest
-	(*SetFindingDueDateResponse)(nil),                 // 61: cerebro.v1.SetFindingDueDateResponse
-	(*AddFindingNoteRequest)(nil),                     // 62: cerebro.v1.AddFindingNoteRequest
-	(*AddFindingNoteResponse)(nil),                    // 63: cerebro.v1.AddFindingNoteResponse
-	(*LinkFindingTicketRequest)(nil),                  // 64: cerebro.v1.LinkFindingTicketRequest
-	(*LinkFindingTicketResponse)(nil),                 // 65: cerebro.v1.LinkFindingTicketResponse
-	(*ListFindingsResponse)(nil),                      // 66: cerebro.v1.ListFindingsResponse
-	(*EvaluateSourceRuntimeFindingsRequest)(nil),      // 67: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	(*EvaluateSourceRuntimeFindingRulesRequest)(nil),  // 68: cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
-	(*FindingRuleEvaluation)(nil),                     // 69: cerebro.v1.FindingRuleEvaluation
-	(*EvaluateSourceRuntimeFindingRulesResponse)(nil), // 70: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
-	(*EvaluateSourceRuntimeFindingsResponse)(nil),     // 71: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	(*WriteDecisionRequest)(nil),                      // 72: cerebro.v1.WriteDecisionRequest
-	(*WriteDecisionResponse)(nil),                     // 73: cerebro.v1.WriteDecisionResponse
-	(*WriteActionRequest)(nil),                        // 74: cerebro.v1.WriteActionRequest
-	(*WriteActionResponse)(nil),                       // 75: cerebro.v1.WriteActionResponse
-	(*WriteOutcomeRequest)(nil),                       // 76: cerebro.v1.WriteOutcomeRequest
-	(*WriteOutcomeResponse)(nil),                      // 77: cerebro.v1.WriteOutcomeResponse
-	(*ReplayWorkflowEventsRequest)(nil),               // 78: cerebro.v1.ReplayWorkflowEventsRequest
-	(*ReplayWorkflowEventsResponse)(nil),              // 79: cerebro.v1.ReplayWorkflowEventsResponse
-	(*GraphEntity)(nil),                               // 80: cerebro.v1.GraphEntity
-	(*GraphRelation)(nil),                             // 81: cerebro.v1.GraphRelation
-	(*GetEntityNeighborhoodRequest)(nil),              // 82: cerebro.v1.GetEntityNeighborhoodRequest
-	(*GetEntityNeighborhoodResponse)(nil),             // 83: cerebro.v1.GetEntityNeighborhoodResponse
-	(*GraphIngestRun)(nil),                            // 84: cerebro.v1.GraphIngestRun
-	(*GraphIngestResult)(nil),                         // 85: cerebro.v1.GraphIngestResult
-	(*GraphIngestRunResult)(nil),                      // 86: cerebro.v1.GraphIngestRunResult
-	(*RunGraphIngestRuntimeRequest)(nil),              // 87: cerebro.v1.RunGraphIngestRuntimeRequest
-	(*RunGraphIngestRuntimeResponse)(nil),             // 88: cerebro.v1.RunGraphIngestRuntimeResponse
-	(*GetGraphIngestRunRequest)(nil),                  // 89: cerebro.v1.GetGraphIngestRunRequest
-	(*GetGraphIngestRunResponse)(nil),                 // 90: cerebro.v1.GetGraphIngestRunResponse
-	(*ListGraphIngestRunsRequest)(nil),                // 91: cerebro.v1.ListGraphIngestRunsRequest
-	(*ListGraphIngestRunsResponse)(nil),               // 92: cerebro.v1.ListGraphIngestRunsResponse
-	(*CheckGraphIngestHealthRequest)(nil),             // 93: cerebro.v1.CheckGraphIngestHealthRequest
-	(*CheckGraphIngestHealthResponse)(nil),            // 94: cerebro.v1.CheckGraphIngestHealthResponse
-	nil,                                               // 95: cerebro.v1.ReportRun.ParametersEntry
-	nil,                                               // 96: cerebro.v1.RunReportRequest.ParametersEntry
-	nil,                                               // 97: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                                               // 98: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                                               // 99: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                                               // 100: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                                               // 101: cerebro.v1.Finding.AttributesEntry
-	nil,                                               // 102: cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
-	(*timestamppb.Timestamp)(nil),                     // 103: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                           // 104: google.protobuf.Struct
-	(*RuleSpec)(nil),                                  // 105: cerebro.v1.RuleSpec
-	(*SourceSpec)(nil),                                // 106: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),                              // 107: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                             // 108: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                            // 109: google.protobuf.Value
-	(*SourceCheckpoint)(nil),                          // 110: cerebro.v1.SourceCheckpoint
-	(*Claim)(nil),                                     // 111: cerebro.v1.Claim
+	(*GraphEvidencePath)(nil),                         // 18: cerebro.v1.GraphEvidencePath
+	(*GraphEvidenceRow)(nil),                          // 19: cerebro.v1.GraphEvidenceRow
+	(*FindingEvidence)(nil),                           // 20: cerebro.v1.FindingEvidence
+	(*ListFindingEvidenceRequest)(nil),                // 21: cerebro.v1.ListFindingEvidenceRequest
+	(*ListFindingEvidenceResponse)(nil),               // 22: cerebro.v1.ListFindingEvidenceResponse
+	(*GetFindingEvidenceRequest)(nil),                 // 23: cerebro.v1.GetFindingEvidenceRequest
+	(*GetFindingEvidenceResponse)(nil),                // 24: cerebro.v1.GetFindingEvidenceResponse
+	(*RunReportRequest)(nil),                          // 25: cerebro.v1.RunReportRequest
+	(*RunReportResponse)(nil),                         // 26: cerebro.v1.RunReportResponse
+	(*GetReportRunRequest)(nil),                       // 27: cerebro.v1.GetReportRunRequest
+	(*GetReportRunResponse)(nil),                      // 28: cerebro.v1.GetReportRunResponse
+	(*ListSourcesRequest)(nil),                        // 29: cerebro.v1.ListSourcesRequest
+	(*ListSourcesResponse)(nil),                       // 30: cerebro.v1.ListSourcesResponse
+	(*CheckSourceRequest)(nil),                        // 31: cerebro.v1.CheckSourceRequest
+	(*CheckSourceResponse)(nil),                       // 32: cerebro.v1.CheckSourceResponse
+	(*DiscoverSourceRequest)(nil),                     // 33: cerebro.v1.DiscoverSourceRequest
+	(*DiscoverSourceResponse)(nil),                    // 34: cerebro.v1.DiscoverSourceResponse
+	(*ReadSourceRequest)(nil),                         // 35: cerebro.v1.ReadSourceRequest
+	(*SourcePreviewEvent)(nil),                        // 36: cerebro.v1.SourcePreviewEvent
+	(*ReadSourceResponse)(nil),                        // 37: cerebro.v1.ReadSourceResponse
+	(*SourceRuntime)(nil),                             // 38: cerebro.v1.SourceRuntime
+	(*PutSourceRuntimeRequest)(nil),                   // 39: cerebro.v1.PutSourceRuntimeRequest
+	(*PutSourceRuntimeResponse)(nil),                  // 40: cerebro.v1.PutSourceRuntimeResponse
+	(*GetSourceRuntimeRequest)(nil),                   // 41: cerebro.v1.GetSourceRuntimeRequest
+	(*GetSourceRuntimeResponse)(nil),                  // 42: cerebro.v1.GetSourceRuntimeResponse
+	(*SyncSourceRuntimeRequest)(nil),                  // 43: cerebro.v1.SyncSourceRuntimeRequest
+	(*SyncSourceRuntimeResponse)(nil),                 // 44: cerebro.v1.SyncSourceRuntimeResponse
+	(*WriteClaimsRequest)(nil),                        // 45: cerebro.v1.WriteClaimsRequest
+	(*WriteClaimsResponse)(nil),                       // 46: cerebro.v1.WriteClaimsResponse
+	(*ListClaimsRequest)(nil),                         // 47: cerebro.v1.ListClaimsRequest
+	(*ListClaimsResponse)(nil),                        // 48: cerebro.v1.ListClaimsResponse
+	(*ListFindingsRequest)(nil),                       // 49: cerebro.v1.ListFindingsRequest
+	(*FindingControlRef)(nil),                         // 50: cerebro.v1.FindingControlRef
+	(*FindingNote)(nil),                               // 51: cerebro.v1.FindingNote
+	(*FindingTicket)(nil),                             // 52: cerebro.v1.FindingTicket
+	(*Finding)(nil),                                   // 53: cerebro.v1.Finding
+	(*GetFindingRequest)(nil),                         // 54: cerebro.v1.GetFindingRequest
+	(*GetFindingResponse)(nil),                        // 55: cerebro.v1.GetFindingResponse
+	(*ResolveFindingRequest)(nil),                     // 56: cerebro.v1.ResolveFindingRequest
+	(*ResolveFindingResponse)(nil),                    // 57: cerebro.v1.ResolveFindingResponse
+	(*SuppressFindingRequest)(nil),                    // 58: cerebro.v1.SuppressFindingRequest
+	(*SuppressFindingResponse)(nil),                   // 59: cerebro.v1.SuppressFindingResponse
+	(*AssignFindingRequest)(nil),                      // 60: cerebro.v1.AssignFindingRequest
+	(*AssignFindingResponse)(nil),                     // 61: cerebro.v1.AssignFindingResponse
+	(*SetFindingDueDateRequest)(nil),                  // 62: cerebro.v1.SetFindingDueDateRequest
+	(*SetFindingDueDateResponse)(nil),                 // 63: cerebro.v1.SetFindingDueDateResponse
+	(*AddFindingNoteRequest)(nil),                     // 64: cerebro.v1.AddFindingNoteRequest
+	(*AddFindingNoteResponse)(nil),                    // 65: cerebro.v1.AddFindingNoteResponse
+	(*LinkFindingTicketRequest)(nil),                  // 66: cerebro.v1.LinkFindingTicketRequest
+	(*LinkFindingTicketResponse)(nil),                 // 67: cerebro.v1.LinkFindingTicketResponse
+	(*ListFindingsResponse)(nil),                      // 68: cerebro.v1.ListFindingsResponse
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),      // 69: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingRulesRequest)(nil),  // 70: cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	(*FindingRuleEvaluation)(nil),                     // 71: cerebro.v1.FindingRuleEvaluation
+	(*EvaluateSourceRuntimeFindingRulesResponse)(nil), // 72: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	(*EvaluateSourceRuntimeFindingsResponse)(nil),     // 73: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	(*WriteDecisionRequest)(nil),                      // 74: cerebro.v1.WriteDecisionRequest
+	(*WriteDecisionResponse)(nil),                     // 75: cerebro.v1.WriteDecisionResponse
+	(*WriteActionRequest)(nil),                        // 76: cerebro.v1.WriteActionRequest
+	(*WriteActionResponse)(nil),                       // 77: cerebro.v1.WriteActionResponse
+	(*WriteOutcomeRequest)(nil),                       // 78: cerebro.v1.WriteOutcomeRequest
+	(*WriteOutcomeResponse)(nil),                      // 79: cerebro.v1.WriteOutcomeResponse
+	(*ReplayWorkflowEventsRequest)(nil),               // 80: cerebro.v1.ReplayWorkflowEventsRequest
+	(*ReplayWorkflowEventsResponse)(nil),              // 81: cerebro.v1.ReplayWorkflowEventsResponse
+	(*GraphEntity)(nil),                               // 82: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                             // 83: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),              // 84: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),             // 85: cerebro.v1.GetEntityNeighborhoodResponse
+	(*GraphIngestRun)(nil),                            // 86: cerebro.v1.GraphIngestRun
+	(*GraphIngestResult)(nil),                         // 87: cerebro.v1.GraphIngestResult
+	(*GraphIngestRunResult)(nil),                      // 88: cerebro.v1.GraphIngestRunResult
+	(*RunGraphIngestRuntimeRequest)(nil),              // 89: cerebro.v1.RunGraphIngestRuntimeRequest
+	(*RunGraphIngestRuntimeResponse)(nil),             // 90: cerebro.v1.RunGraphIngestRuntimeResponse
+	(*GetGraphIngestRunRequest)(nil),                  // 91: cerebro.v1.GetGraphIngestRunRequest
+	(*GetGraphIngestRunResponse)(nil),                 // 92: cerebro.v1.GetGraphIngestRunResponse
+	(*ListGraphIngestRunsRequest)(nil),                // 93: cerebro.v1.ListGraphIngestRunsRequest
+	(*ListGraphIngestRunsResponse)(nil),               // 94: cerebro.v1.ListGraphIngestRunsResponse
+	(*CheckGraphIngestHealthRequest)(nil),             // 95: cerebro.v1.CheckGraphIngestHealthRequest
+	(*CheckGraphIngestHealthResponse)(nil),            // 96: cerebro.v1.CheckGraphIngestHealthResponse
+	nil,                                               // 97: cerebro.v1.ReportRun.ParametersEntry
+	nil,                                               // 98: cerebro.v1.GraphEvidencePath.AttributesEntry
+	nil,                                               // 99: cerebro.v1.GraphEvidenceRow.AttributesEntry
+	nil,                                               // 100: cerebro.v1.RunReportRequest.ParametersEntry
+	nil,                                               // 101: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                               // 102: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                               // 103: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                               // 104: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                               // 105: cerebro.v1.Finding.AttributesEntry
+	nil,                                               // 106: cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
+	(*timestamppb.Timestamp)(nil),                     // 107: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                           // 108: google.protobuf.Struct
+	(*RuleSpec)(nil),                                  // 109: cerebro.v1.RuleSpec
+	(*SourceSpec)(nil),                                // 110: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                              // 111: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                             // 112: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                            // 113: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                          // 114: cerebro.v1.SourceCheckpoint
+	(*Claim)(nil),                                     // 115: cerebro.v1.Claim
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	103, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	107, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	4,   // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
 	6,   // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
-	95,  // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
-	103, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
-	104, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
+	97,  // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
+	107, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
+	108, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
 	7,   // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
-	105, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
-	103, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
-	103, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
+	109, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
+	107, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
+	107, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
 	13,  // 10: cerebro.v1.ListFindingEvaluationRunsResponse.runs:type_name -> cerebro.v1.FindingEvaluationRun
 	13,  // 11: cerebro.v1.GetFindingEvaluationRunResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	103, // 12: cerebro.v1.FindingEvidence.created_at:type_name -> google.protobuf.Timestamp
-	18,  // 13: cerebro.v1.ListFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	18,  // 14: cerebro.v1.GetFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	96,  // 15: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
-	7,   // 16: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
-	8,   // 17: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
-	8,   // 18: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
-	106, // 19: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	97,  // 20: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	106, // 21: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	98,  // 22: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	106, // 23: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	99,  // 24: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	107, // 25: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	108, // 26: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	109, // 27: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	106, // 28: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	108, // 29: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	110, // 30: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	107, // 31: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
-	34,  // 32: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	100, // 33: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	110, // 34: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	107, // 35: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	103, // 36: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
-	36,  // 37: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
-	36,  // 38: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	36,  // 39: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	36,  // 40: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	106, // 41: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	111, // 42: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	111, // 43: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
-	0,   // 44: cerebro.v1.ListFindingsRequest.status:type_name -> cerebro.v1.FindingStatus
-	103, // 45: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
-	103, // 46: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
-	0,   // 47: cerebro.v1.Finding.status:type_name -> cerebro.v1.FindingStatus
-	101, // 48: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	103, // 49: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	103, // 50: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	103, // 51: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
-	48,  // 52: cerebro.v1.Finding.control_refs:type_name -> cerebro.v1.FindingControlRef
-	103, // 53: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
-	49,  // 54: cerebro.v1.Finding.notes:type_name -> cerebro.v1.FindingNote
-	50,  // 55: cerebro.v1.Finding.tickets:type_name -> cerebro.v1.FindingTicket
-	51,  // 56: cerebro.v1.GetFindingResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 57: cerebro.v1.ResolveFindingResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 58: cerebro.v1.SuppressFindingResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 59: cerebro.v1.AssignFindingResponse.finding:type_name -> cerebro.v1.Finding
-	103, // 60: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
-	51,  // 61: cerebro.v1.SetFindingDueDateResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 62: cerebro.v1.AddFindingNoteResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 63: cerebro.v1.LinkFindingTicketResponse.finding:type_name -> cerebro.v1.Finding
-	51,  // 64: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	105, // 65: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
-	51,  // 66: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
-	13,  // 67: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
-	18,  // 68: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
-	36,  // 69: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	69,  // 70: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
-	36,  // 71: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	105, // 72: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	51,  // 73: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	13,  // 74: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	18,  // 75: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	103, // 76: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	103, // 77: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	103, // 78: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	104, // 79: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
-	103, // 80: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	103, // 81: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	103, // 82: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	104, // 83: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
-	103, // 84: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
-	103, // 85: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
-	103, // 86: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
-	104, // 87: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
-	102, // 88: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
-	80,  // 89: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	80,  // 90: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	81,  // 91: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	84,  // 92: cerebro.v1.GraphIngestRunResult.run:type_name -> cerebro.v1.GraphIngestRun
-	85,  // 93: cerebro.v1.GraphIngestRunResult.ingest:type_name -> cerebro.v1.GraphIngestResult
-	86,  // 94: cerebro.v1.RunGraphIngestRuntimeResponse.result:type_name -> cerebro.v1.GraphIngestRunResult
-	84,  // 95: cerebro.v1.GetGraphIngestRunResponse.run:type_name -> cerebro.v1.GraphIngestRun
-	84,  // 96: cerebro.v1.ListGraphIngestRunsResponse.runs:type_name -> cerebro.v1.GraphIngestRun
-	103, // 97: cerebro.v1.CheckGraphIngestHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
-	84,  // 98: cerebro.v1.CheckGraphIngestHealthResponse.failed_runs:type_name -> cerebro.v1.GraphIngestRun
-	1,   // 99: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	3,   // 100: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	9,   // 101: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	11,  // 102: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
-	23,  // 103: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	25,  // 104: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	27,  // 105: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	29,  // 106: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	31,  // 107: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	33,  // 108: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	37,  // 109: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	39,  // 110: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	41,  // 111: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	43,  // 112: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	45,  // 113: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
-	47,  // 114: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
-	52,  // 115: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
-	54,  // 116: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
-	56,  // 117: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
-	58,  // 118: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
-	60,  // 119: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
-	62,  // 120: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
-	64,  // 121: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
-	14,  // 122: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
-	16,  // 123: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
-	19,  // 124: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
-	21,  // 125: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
-	68,  // 126: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
-	67,  // 127: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	72,  // 128: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
-	74,  // 129: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
-	76,  // 130: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
-	78,  // 131: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
-	82,  // 132: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	87,  // 133: cerebro.v1.BootstrapService.RunGraphIngestRuntime:input_type -> cerebro.v1.RunGraphIngestRuntimeRequest
-	89,  // 134: cerebro.v1.BootstrapService.GetGraphIngestRun:input_type -> cerebro.v1.GetGraphIngestRunRequest
-	91,  // 135: cerebro.v1.BootstrapService.ListGraphIngestRuns:input_type -> cerebro.v1.ListGraphIngestRunsRequest
-	93,  // 136: cerebro.v1.BootstrapService.CheckGraphIngestHealth:input_type -> cerebro.v1.CheckGraphIngestHealthRequest
-	2,   // 137: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	5,   // 138: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	10,  // 139: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	12,  // 140: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
-	24,  // 141: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	26,  // 142: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	28,  // 143: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	30,  // 144: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	32,  // 145: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	35,  // 146: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	38,  // 147: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	40,  // 148: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	42,  // 149: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	44,  // 150: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	46,  // 151: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
-	66,  // 152: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
-	53,  // 153: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
-	55,  // 154: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
-	57,  // 155: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
-	59,  // 156: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
-	61,  // 157: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
-	63,  // 158: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
-	65,  // 159: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
-	15,  // 160: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
-	17,  // 161: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
-	20,  // 162: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
-	22,  // 163: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
-	70,  // 164: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
-	71,  // 165: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	73,  // 166: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
-	75,  // 167: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
-	77,  // 168: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
-	79,  // 169: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
-	83,  // 170: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	88,  // 171: cerebro.v1.BootstrapService.RunGraphIngestRuntime:output_type -> cerebro.v1.RunGraphIngestRuntimeResponse
-	90,  // 172: cerebro.v1.BootstrapService.GetGraphIngestRun:output_type -> cerebro.v1.GetGraphIngestRunResponse
-	92,  // 173: cerebro.v1.BootstrapService.ListGraphIngestRuns:output_type -> cerebro.v1.ListGraphIngestRunsResponse
-	94,  // 174: cerebro.v1.BootstrapService.CheckGraphIngestHealth:output_type -> cerebro.v1.CheckGraphIngestHealthResponse
-	137, // [137:175] is the sub-list for method output_type
-	99,  // [99:137] is the sub-list for method input_type
-	99,  // [99:99] is the sub-list for extension type_name
-	99,  // [99:99] is the sub-list for extension extendee
-	0,   // [0:99] is the sub-list for field type_name
+	98,  // 12: cerebro.v1.GraphEvidencePath.attributes:type_name -> cerebro.v1.GraphEvidencePath.AttributesEntry
+	99,  // 13: cerebro.v1.GraphEvidenceRow.attributes:type_name -> cerebro.v1.GraphEvidenceRow.AttributesEntry
+	18,  // 14: cerebro.v1.GraphEvidenceRow.paths:type_name -> cerebro.v1.GraphEvidencePath
+	107, // 15: cerebro.v1.FindingEvidence.created_at:type_name -> google.protobuf.Timestamp
+	19,  // 16: cerebro.v1.FindingEvidence.graph_rows:type_name -> cerebro.v1.GraphEvidenceRow
+	20,  // 17: cerebro.v1.ListFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	20,  // 18: cerebro.v1.GetFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	100, // 19: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
+	7,   // 20: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
+	8,   // 21: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
+	8,   // 22: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
+	110, // 23: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	101, // 24: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	110, // 25: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	102, // 26: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	110, // 27: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	103, // 28: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	111, // 29: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	112, // 30: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	113, // 31: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	110, // 32: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	112, // 33: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	114, // 34: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	111, // 35: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	36,  // 36: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
+	104, // 37: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	114, // 38: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	111, // 39: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	107, // 40: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	38,  // 41: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
+	38,  // 42: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	38,  // 43: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	38,  // 44: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	110, // 45: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	115, // 46: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	115, // 47: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	0,   // 48: cerebro.v1.ListFindingsRequest.status:type_name -> cerebro.v1.FindingStatus
+	107, // 49: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
+	107, // 50: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
+	0,   // 51: cerebro.v1.Finding.status:type_name -> cerebro.v1.FindingStatus
+	105, // 52: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	107, // 53: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	107, // 54: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	107, // 55: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
+	50,  // 56: cerebro.v1.Finding.control_refs:type_name -> cerebro.v1.FindingControlRef
+	107, // 57: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
+	51,  // 58: cerebro.v1.Finding.notes:type_name -> cerebro.v1.FindingNote
+	52,  // 59: cerebro.v1.Finding.tickets:type_name -> cerebro.v1.FindingTicket
+	53,  // 60: cerebro.v1.GetFindingResponse.finding:type_name -> cerebro.v1.Finding
+	53,  // 61: cerebro.v1.ResolveFindingResponse.finding:type_name -> cerebro.v1.Finding
+	53,  // 62: cerebro.v1.SuppressFindingResponse.finding:type_name -> cerebro.v1.Finding
+	53,  // 63: cerebro.v1.AssignFindingResponse.finding:type_name -> cerebro.v1.Finding
+	107, // 64: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
+	53,  // 65: cerebro.v1.SetFindingDueDateResponse.finding:type_name -> cerebro.v1.Finding
+	53,  // 66: cerebro.v1.AddFindingNoteResponse.finding:type_name -> cerebro.v1.Finding
+	53,  // 67: cerebro.v1.LinkFindingTicketResponse.finding:type_name -> cerebro.v1.Finding
+	53,  // 68: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	109, // 69: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
+	53,  // 70: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
+	13,  // 71: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
+	20,  // 72: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
+	38,  // 73: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	71,  // 74: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
+	38,  // 75: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	109, // 76: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	53,  // 77: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	13,  // 78: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
+	20,  // 79: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	107, // 80: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	107, // 81: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	107, // 82: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	108, // 83: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
+	107, // 84: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	107, // 85: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	107, // 86: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	108, // 87: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
+	107, // 88: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
+	107, // 89: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
+	107, // 90: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
+	108, // 91: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
+	106, // 92: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
+	82,  // 93: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	82,  // 94: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	83,  // 95: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	86,  // 96: cerebro.v1.GraphIngestRunResult.run:type_name -> cerebro.v1.GraphIngestRun
+	87,  // 97: cerebro.v1.GraphIngestRunResult.ingest:type_name -> cerebro.v1.GraphIngestResult
+	88,  // 98: cerebro.v1.RunGraphIngestRuntimeResponse.result:type_name -> cerebro.v1.GraphIngestRunResult
+	86,  // 99: cerebro.v1.GetGraphIngestRunResponse.run:type_name -> cerebro.v1.GraphIngestRun
+	86,  // 100: cerebro.v1.ListGraphIngestRunsResponse.runs:type_name -> cerebro.v1.GraphIngestRun
+	107, // 101: cerebro.v1.CheckGraphIngestHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	86,  // 102: cerebro.v1.CheckGraphIngestHealthResponse.failed_runs:type_name -> cerebro.v1.GraphIngestRun
+	1,   // 103: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	3,   // 104: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	9,   // 105: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	11,  // 106: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
+	25,  // 107: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	27,  // 108: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	29,  // 109: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	31,  // 110: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	33,  // 111: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	35,  // 112: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	39,  // 113: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	41,  // 114: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	43,  // 115: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	45,  // 116: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	47,  // 117: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	49,  // 118: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
+	54,  // 119: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
+	56,  // 120: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
+	58,  // 121: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
+	60,  // 122: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
+	62,  // 123: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
+	64,  // 124: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
+	66,  // 125: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
+	14,  // 126: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
+	16,  // 127: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
+	21,  // 128: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
+	23,  // 129: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
+	70,  // 130: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	69,  // 131: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	74,  // 132: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
+	76,  // 133: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
+	78,  // 134: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
+	80,  // 135: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
+	84,  // 136: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	89,  // 137: cerebro.v1.BootstrapService.RunGraphIngestRuntime:input_type -> cerebro.v1.RunGraphIngestRuntimeRequest
+	91,  // 138: cerebro.v1.BootstrapService.GetGraphIngestRun:input_type -> cerebro.v1.GetGraphIngestRunRequest
+	93,  // 139: cerebro.v1.BootstrapService.ListGraphIngestRuns:input_type -> cerebro.v1.ListGraphIngestRunsRequest
+	95,  // 140: cerebro.v1.BootstrapService.CheckGraphIngestHealth:input_type -> cerebro.v1.CheckGraphIngestHealthRequest
+	2,   // 141: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	5,   // 142: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	10,  // 143: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	12,  // 144: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
+	26,  // 145: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	28,  // 146: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	30,  // 147: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	32,  // 148: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	34,  // 149: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	37,  // 150: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	40,  // 151: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	42,  // 152: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	44,  // 153: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	46,  // 154: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	48,  // 155: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	68,  // 156: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
+	55,  // 157: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
+	57,  // 158: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
+	59,  // 159: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
+	61,  // 160: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
+	63,  // 161: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
+	65,  // 162: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
+	67,  // 163: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
+	15,  // 164: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
+	17,  // 165: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
+	22,  // 166: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
+	24,  // 167: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
+	72,  // 168: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	73,  // 169: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	75,  // 170: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
+	77,  // 171: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
+	79,  // 172: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
+	81,  // 173: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
+	85,  // 174: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	90,  // 175: cerebro.v1.BootstrapService.RunGraphIngestRuntime:output_type -> cerebro.v1.RunGraphIngestRuntimeResponse
+	92,  // 176: cerebro.v1.BootstrapService.GetGraphIngestRun:output_type -> cerebro.v1.GetGraphIngestRunResponse
+	94,  // 177: cerebro.v1.BootstrapService.ListGraphIngestRuns:output_type -> cerebro.v1.ListGraphIngestRunsResponse
+	96,  // 178: cerebro.v1.BootstrapService.CheckGraphIngestHealth:output_type -> cerebro.v1.CheckGraphIngestHealthResponse
+	141, // [141:179] is the sub-list for method output_type
+	103, // [103:141] is the sub-list for method input_type
+	103, // [103:103] is the sub-list for extension type_name
+	103, // [103:103] is the sub-list for extension extendee
+	0,   // [0:103] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -7204,7 +7409,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   102,
+			NumMessages:   106,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/findings/graph_evidence.go
+++ b/internal/findings/graph_evidence.go
@@ -1,0 +1,102 @@
+package findings
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func newGraphEvidenceRow(label string, attributes map[string]string, paths ...*cerebrov1.GraphEvidencePath) *cerebrov1.GraphEvidenceRow {
+	return &cerebrov1.GraphEvidenceRow{
+		Label:      strings.TrimSpace(label),
+		Attributes: compactStringMap(attributes),
+		Paths:      compactGraphEvidencePaths(paths),
+	}
+}
+
+func newGraphEvidencePath(fromURN, fromLabel, fromType, relation, toURN, toLabel, toType string, attributes map[string]string) *cerebrov1.GraphEvidencePath {
+	return &cerebrov1.GraphEvidencePath{
+		FromUrn:    strings.TrimSpace(fromURN),
+		FromLabel:  strings.TrimSpace(fromLabel),
+		FromType:   strings.TrimSpace(fromType),
+		Relation:   strings.TrimSpace(relation),
+		ToUrn:      strings.TrimSpace(toURN),
+		ToLabel:    strings.TrimSpace(toLabel),
+		ToType:     strings.TrimSpace(toType),
+		Attributes: compactStringMap(attributes),
+	}
+}
+
+func compactStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		trimmedKey := strings.TrimSpace(key)
+		trimmedValue := strings.TrimSpace(value)
+		if trimmedKey == "" || trimmedValue == "" {
+			continue
+		}
+		out[trimmedKey] = trimmedValue
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func compactGraphEvidencePaths(paths []*cerebrov1.GraphEvidencePath) []*cerebrov1.GraphEvidencePath {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make([]*cerebrov1.GraphEvidencePath, 0, len(paths))
+	for _, path := range paths {
+		if path == nil {
+			continue
+		}
+		if strings.TrimSpace(path.GetFromUrn()) == "" && strings.TrimSpace(path.GetToUrn()) == "" {
+			continue
+		}
+		out = append(out, path)
+	}
+	return out
+}
+
+func stringMapJSON(values []map[string]string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	cleaned := make([]map[string]string, 0, len(values))
+	for _, value := range values {
+		compact := compactStringMap(value)
+		if len(compact) == 0 {
+			continue
+		}
+		cleaned = append(cleaned, compact)
+	}
+	if len(cleaned) == 0 {
+		return ""
+	}
+	payload, err := json.Marshal(cleaned)
+	if err != nil {
+		return ""
+	}
+	return string(payload)
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if trimmed := strings.TrimSpace(key); trimmed != "" {
+			keys = append(keys, trimmed)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -112,6 +112,7 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		if record == nil {
 			continue
 		}
+		graphRows := cloneGraphEvidenceRows(record.GraphEvidenceRows)
 		record, err = s.reconcileLegacyFindingIdentity(ctx, record)
 		if err != nil {
 			evaluationErr := fmt.Errorf("reconcile finding identity for graph rule %q: %w", spec.GetId(), err)
@@ -124,7 +125,7 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		}
 		result.Findings = append(result.Findings, stored)
 		emittedFindingIDs[strings.TrimSpace(stored.ID)] = struct{}{}
-		evidence, err := s.buildFindingEvidence(ctx, stored, run)
+		evidence, err := s.buildFindingEvidence(ctx, stored, run, graphRows...)
 		if err != nil {
 			evaluationErr := fmt.Errorf("build evidence for graph rule %q finding %q: %w", spec.GetId(), stored.ID, err)
 			return result, s.finishFailedRun(ctx, run, 0, findingIDs(result.Findings), evaluationErr)

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -99,6 +99,18 @@ func TestEvaluateSourceRuntimeGraphRulesEmitsAndPersistsFindings(t *testing.T) {
 				Status:       findingStatusOpen,
 				Summary:      "graph rule fired",
 				ResourceURNs: []string{"urn:cerebro:writer:identity:email:alice@writer.com"},
+				GraphEvidenceRows: []*cerebrov1.GraphEvidenceRow{
+					newGraphEvidenceRow("identity_path", map[string]string{"label": "alice@writer.com"}, newGraphEvidencePath(
+						"urn:cerebro:writer:okta_user:alice",
+						"alice@writer.com",
+						"okta.user",
+						"represents_identity",
+						"urn:cerebro:writer:identity:email:alice@writer.com",
+						"alice@writer.com",
+						"identity.email",
+						map[string]string{"match_type": "exact_email"},
+					)),
+				},
 			},
 		},
 	}
@@ -138,6 +150,15 @@ func TestEvaluateSourceRuntimeGraphRulesEmitsAndPersistsFindings(t *testing.T) {
 	}
 	if store.findings == nil || store.findings["finding-graph-1"] == nil {
 		t.Fatalf("finding store should contain persisted finding")
+	}
+	if got := len(evaluation.Evidence); got != 1 {
+		t.Fatalf("len(Evidence) = %d, want 1", got)
+	}
+	if got := len(evaluation.Evidence[0].GetGraphRows()); got != 1 {
+		t.Fatalf("len(Evidence[0].GraphRows) = %d, want 1", got)
+	}
+	if got := evaluation.Evidence[0].GetGraphRows()[0].GetPaths()[0].GetRelation(); got != "represents_identity" {
+		t.Fatalf("graph evidence relation = %q, want represents_identity", got)
 	}
 }
 

--- a/internal/findings/identity_github_active_without_okta_link_rule.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule.go
@@ -212,11 +212,16 @@ WITH g, collect(DISTINCT {
        urn: target.urn,
        entity_type: coalesce(target.entity_type, ''),
        label: coalesce(target.label, ''),
+       attributes_json: coalesce(target.attributes_json, ''),
        acted_attributes_json: coalesce(acted.attributes_json, '')
      }) AS targets
-OPTIONAL MATCH (g)-[gi:RELATION {relation: 'represents_identity'}]->(:Entity)
-              <-[oi:RELATION {relation: 'represents_identity'}]-(:Entity {entity_type: 'okta.user', tenant_id: $tenant_id})
+OPTIONAL MATCH (g)-[gi:RELATION {relation: 'represents_identity'}]->(identity:Entity)
+              <-[oi:RELATION {relation: 'represents_identity'}]-(okta:Entity {entity_type: 'okta.user', tenant_id: $tenant_id})
 WITH g, targets, collect({
+       identity_urn: coalesce(identity.urn, ''),
+       identity_label: coalesce(identity.label, ''),
+       okta_urn: coalesce(okta.urn, ''),
+       okta_label: coalesce(okta.label, ''),
        github_identity_attributes_json: coalesce(gi.attributes_json, ''),
        okta_identity_attributes_json:   coalesce(oi.attributes_json, '')
      }) AS bridges
@@ -337,6 +342,7 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 				group.hasCurrentBridge = true
 				break
 			}
+			group.bridgeClues = append(group.bridgeClues, githubBridgeClueFromCypher(bridge, githubIdentityJSON, oktaIdentityJSON))
 		}
 		// `acted_on` edges projected before the at-stamp change have no
 		// `at`, and any edge whose latest action is older than the recency
@@ -360,10 +366,17 @@ func (r *githubActiveWithoutOktaLinkRule) EvaluateRows(_ context.Context, runtim
 			if _, exists := group.targets[targetURN]; exists {
 				continue
 			}
+			actedAttrs := edgeStringAttributes(actedAttributesJSON)
+			targetAttrs := edgeStringAttributes(cypherListMapString(target, "attributes_json"))
 			group.targets[targetURN] = githubActiveWithoutOktaTarget{
 				urn:        targetURN,
 				entityType: cypherListMapString(target, "entity_type"),
 				label:      cypherListMapString(target, "label"),
+				action:     actedAttrs["action"],
+				accessedAt: actedAttrs["at"],
+				eventID:    actedAttrs["event_id"],
+				attributes: targetAttrs,
+				edgeAttrs:  actedAttrs,
 			}
 		}
 	}
@@ -627,6 +640,7 @@ type githubActiveWithoutOktaGroup struct {
 	githubUserLabel      string
 	githubAttributesJSON string
 	targets              map[string]githubActiveWithoutOktaTarget
+	bridgeClues          []map[string]string
 	// hasCurrentBridge captures whether ANY row for this github user carried
 	// a represents_identity bridge proving the user is linked to an okta user,
 	// so the shadow-access premise no longer applies.
@@ -637,6 +651,11 @@ type githubActiveWithoutOktaTarget struct {
 	urn        string
 	entityType string
 	label      string
+	action     string
+	accessedAt string
+	eventID    string
+	attributes map[string]string
+	edgeAttrs  map[string]string
 }
 
 func (r *githubActiveWithoutOktaLinkRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, group *githubActiveWithoutOktaGroup, now time.Time) *ports.FindingRecord {
@@ -662,6 +681,12 @@ func (r *githubActiveWithoutOktaLinkRule) buildFinding(runtime *cerebrov1.Source
 	targetURNs := make([]string, 0, len(group.targets))
 	targetLabels := make([]string, 0, len(group.targets))
 	targetTypes := make(map[string]struct{}, len(group.targets))
+	accessActions := make(map[string]struct{}, len(group.targets))
+	accessEventIDs := make(map[string]struct{}, len(group.targets))
+	targetDetails := make([]map[string]string, 0, len(group.targets))
+	graphRows := make([]*cerebrov1.GraphEvidenceRow, 0, len(group.targets))
+	var latestAccessAt string
+	githubAttrs := edgeStringAttributes(group.githubAttributesJSON)
 	for urn, target := range group.targets {
 		targetURNs = append(targetURNs, urn)
 		if trimmed := strings.TrimSpace(target.label); trimmed != "" {
@@ -670,9 +695,38 @@ func (r *githubActiveWithoutOktaLinkRule) buildFinding(runtime *cerebrov1.Source
 		if trimmed := strings.TrimSpace(target.entityType); trimmed != "" {
 			targetTypes[trimmed] = struct{}{}
 		}
+		if action := strings.TrimSpace(target.action); action != "" {
+			accessActions[action] = struct{}{}
+		}
+		if eventID := strings.TrimSpace(target.eventID); eventID != "" {
+			accessEventIDs[eventID] = struct{}{}
+		}
+		latestAccessAt = maxRFC3339String(latestAccessAt, target.accessedAt)
+		targetDetails = append(targetDetails, map[string]string{
+			"urn":         target.urn,
+			"label":       target.label,
+			"entity_type": target.entityType,
+			"action":      target.action,
+			"at":          target.accessedAt,
+			"event_id":    target.eventID,
+			"repository":  target.attributes["repository"],
+			"visibility":  target.attributes["visibility"],
+		})
+		graphRows = append(graphRows, newGraphEvidenceRow("github_unlinked_access", map[string]string{
+			"github_user_urn":   group.githubUserURN,
+			"github_user_label": group.githubUserLabel,
+			"target_urn":        target.urn,
+			"target_label":      target.label,
+			"action":            target.action,
+			"at":                target.accessedAt,
+			"event_id":          target.eventID,
+		}, newGraphEvidencePath(group.githubUserURN, group.githubUserLabel, "github.user", "acted_on", target.urn, target.label, target.entityType, target.edgeAttrs)))
 	}
 	sort.Strings(targetURNs)
 	sort.Strings(targetLabels)
+	sort.Slice(targetDetails, func(i, j int) bool {
+		return targetDetails[i]["urn"] < targetDetails[j]["urn"]
+	})
 	resourceURNs = append(resourceURNs, targetURNs...)
 	primaryGitHubLabel := firstNonEmpty(group.githubUserLabel, group.githubUserURN)
 	summary := fmt.Sprintf(
@@ -681,36 +735,86 @@ func (r *githubActiveWithoutOktaLinkRule) buildFinding(runtime *cerebrov1.Source
 		len(targetURNs),
 	)
 	attributes := map[string]string{
-		"primary_resource_urn":  group.githubUserURN,
-		"github_user_urn":       group.githubUserURN,
-		"github_user_label":     group.githubUserLabel,
-		"target_count":          fmt.Sprintf("%d", len(targetURNs)),
-		"target_urns":           strings.Join(targetURNs, ","),
-		"target_labels":         strings.Join(targetLabels, ","),
-		"target_entity_types":   strings.Join(sortedKeys(targetTypes), ","),
-		"source_runtime_id":     triggeringRuntimeID,
-		"source_runtime_tenant": tenantID,
+		"primary_resource_urn":              group.githubUserURN,
+		"github_user_urn":                   group.githubUserURN,
+		"github_user_label":                 group.githubUserLabel,
+		"target_count":                      fmt.Sprintf("%d", len(targetURNs)),
+		"target_urns":                       strings.Join(targetURNs, ","),
+		"target_labels":                     strings.Join(targetLabels, ","),
+		"target_entity_types":               strings.Join(sortedKeys(targetTypes), ","),
+		"latest_access_at":                  latestAccessAt,
+		"access_actions":                    strings.Join(sortedStringSet(accessActions), ","),
+		"access_event_ids":                  strings.Join(sortedStringSet(accessEventIDs), ","),
+		"target_access_details":             stringMapJSON(targetDetails),
+		"bridge_clues":                      stringMapJSON(group.bridgeClues),
+		"github_actor_type":                 githubAttrs["actor_type"],
+		"github_actor_id":                   githubAttrs["actor_id"],
+		"github_external_identity_nameid":   githubAttrs["external_identity_nameid"],
+		"github_external_identity_username": githubAttrs["external_identity_username"],
+		"source_runtime_id":                 triggeringRuntimeID,
+		"source_runtime_tenant":             tenantID,
 	}
 	for key, value := range r.definition.AttributeMap() {
 		attributes["rule_"+key] = value
 	}
 	trimEmptyAttributes(attributes)
 	return &ports.FindingRecord{
-		ID:              fingerprint,
-		Fingerprint:     fingerprint,
-		TenantID:        tenantID,
-		RuntimeID:       triggeringRuntimeID,
-		RuleID:          r.definition.ID,
-		Title:           r.definition.Name,
-		Severity:        r.definition.Severity,
-		Status:          r.definition.Status,
-		Summary:         summary,
-		ResourceURNs:    deduplicateStrings(resourceURNs),
-		ControlRefs:     cloneFindingControlRefs(r.definition.ControlRefs),
-		Attributes:      attributes,
-		FirstObservedAt: now,
-		LastObservedAt:  now,
-		CheckID:         r.definition.ID,
-		CheckName:       r.definition.Name,
+		ID:                fingerprint,
+		Fingerprint:       fingerprint,
+		TenantID:          tenantID,
+		RuntimeID:         triggeringRuntimeID,
+		RuleID:            r.definition.ID,
+		Title:             r.definition.Name,
+		Severity:          r.definition.Severity,
+		Status:            r.definition.Status,
+		Summary:           summary,
+		ResourceURNs:      deduplicateStrings(resourceURNs),
+		EventIDs:          sortedStringSet(accessEventIDs),
+		ControlRefs:       cloneFindingControlRefs(r.definition.ControlRefs),
+		GraphEvidenceRows: graphRows,
+		Attributes:        attributes,
+		FirstObservedAt:   now,
+		LastObservedAt:    now,
+		CheckID:           r.definition.ID,
+		CheckName:         r.definition.Name,
 	}
+}
+
+func githubBridgeClueFromCypher(bridge any, githubIdentityJSON string, oktaIdentityJSON string) map[string]string {
+	githubAttrs := edgeStringAttributes(githubIdentityJSON)
+	oktaAttrs := edgeStringAttributes(oktaIdentityJSON)
+	return map[string]string{
+		"identity_urn":            cypherListMapString(bridge, "identity_urn"),
+		"identity_label":          cypherListMapString(bridge, "identity_label"),
+		"okta_urn":                cypherListMapString(bridge, "okta_urn"),
+		"okta_label":              cypherListMapString(bridge, "okta_label"),
+		"github_match_type":       githubAttrs["match_type"],
+		"github_identifier_type":  githubAttrs["identifier_type"],
+		"github_identifier_value": githubAttrs["identifier_value"],
+		"github_observed_at":      githubAttrs["at"],
+		"okta_match_type":         oktaAttrs["match_type"],
+		"okta_identifier_type":    oktaAttrs["identifier_type"],
+		"okta_identifier_value":   oktaAttrs["identifier_value"],
+		"okta_observed_at":        oktaAttrs["at"],
+	}
+}
+
+func maxRFC3339String(existing string, incoming string) string {
+	existing = strings.TrimSpace(existing)
+	incoming = strings.TrimSpace(incoming)
+	if existing == "" {
+		return incoming
+	}
+	if incoming == "" {
+		return existing
+	}
+	existingT, existingErr := time.Parse(time.RFC3339, existing)
+	incomingT, incomingErr := time.Parse(time.RFC3339, incoming)
+	if existingErr != nil || incomingErr != nil {
+		return incoming
+	}
+	if incomingT.After(existingT) {
+		return incoming
+	}
+	return existing
 }

--- a/internal/findings/rule_fixture_test.go
+++ b/internal/findings/rule_fixture_test.go
@@ -134,16 +134,8 @@ func TestGitHubPrivateRepositoryForkingEnabledFixture(t *testing.T) {
 	assertRuleFixture(t, newGitHubPrivateRepositoryForkingEnabledRule(), "testdata/rules/github-private-repository-forking-enabled.json")
 }
 
-func TestSentinelOneEndpointActiveInfectionFixture(t *testing.T) {
-	assertRuleFixture(t, newSentinelOneEndpointActiveInfectionRule(), "testdata/rules/sentinelone-endpoint-active-infection.json")
-}
-
 func TestSentinelOneMitigationFailedFixture(t *testing.T) {
 	assertRuleFixture(t, newSentinelOneMitigationFailedRule(), "testdata/rules/sentinelone-mitigation-failed.json")
-}
-
-func TestSentinelOneAgentStaleFixture(t *testing.T) {
-	assertRuleFixture(t, newSentinelOneAgentStaleRule(), "testdata/rules/sentinelone-agent-stale.json")
 }
 
 func TestSentinelOneAgentDetectOnlyModeFixture(t *testing.T) {
@@ -156,46 +148,6 @@ func TestSentinelOneProtectionControlTamperingFixture(t *testing.T) {
 
 func TestSentinelOneRiskyExclusionFixture(t *testing.T) {
 	assertRuleFixture(t, newSentinelOneRiskyExclusionRule(), "testdata/rules/sentinelone-risky-exclusion.json")
-}
-
-func TestSentinelOneFindingFingerprintIncludesRuntime(t *testing.T) {
-	rule := newSentinelOneEndpointActiveInfectionRule()
-	event := ruleFixtureEvent{
-		ID:         "s1-threat-same-agent",
-		TenantID:   "writer",
-		SourceID:   "sentinelone",
-		Kind:       "sentinelone.threat",
-		OccurredAt: "2026-05-09T06:20:00Z",
-		SchemaRef:  "sentinelone/threat/v1",
-		Attributes: map[string]string{
-			"threat_id":         "threat-1",
-			"threat_name":       "Malware Sample",
-			"incident_status":   "unresolved",
-			"mitigation_status": "not_mitigated",
-			"is_infected":       "true",
-			"agent_id":          "agent-shared",
-			"computer_name":     "mac-shared",
-		},
-	}.proto(t)
-	runtimeA := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-threat-a", SourceId: "sentinelone", TenantId: "writer"}
-	runtimeB := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-threat-b", SourceId: "sentinelone", TenantId: "writer"}
-	first, err := rule.Evaluate(context.Background(), runtimeA, event)
-	if err != nil {
-		t.Fatalf("Evaluate(runtimeA) error = %v", err)
-	}
-	second, err := rule.Evaluate(context.Background(), runtimeB, event)
-	if err != nil {
-		t.Fatalf("Evaluate(runtimeB) error = %v", err)
-	}
-	if len(first) != 1 || len(second) != 1 {
-		t.Fatalf("finding counts = %d/%d, want 1/1", len(first), len(second))
-	}
-	if first[0].PolicyID != second[0].PolicyID {
-		t.Fatalf("PolicyID mismatch = %q/%q, want same agent policy", first[0].PolicyID, second[0].PolicyID)
-	}
-	if first[0].ID == second[0].ID {
-		t.Fatalf("finding IDs matched across runtimes: %q", first[0].ID)
-	}
 }
 
 func TestRetiredSentinelOneRulesDoNotEmitFindings(t *testing.T) {

--- a/internal/findings/sentinelone_graph_rule.go
+++ b/internal/findings/sentinelone_graph_rule.go
@@ -1,0 +1,560 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	sentinelOneGraphQueryRowLimit      = 2000
+	sentinelOneGraphEvidenceAgentLimit = 100
+)
+
+type sentinelOneEndpointActiveInfectionGraphRule struct {
+	definition RuleDefinition
+}
+
+func (r *sentinelOneEndpointActiveInfectionGraphRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return proto.Clone(r.definition.RuleSpec()).(*cerebrov1.RuleSpec)
+}
+
+func (r *sentinelOneEndpointActiveInfectionGraphRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	return sentinelOneGraphRuleSupportsRuntime(runtime, "agent", "threat")
+}
+
+func (r *sentinelOneEndpointActiveInfectionGraphRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (r *sentinelOneEndpointActiveInfectionGraphRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
+	if runtime == nil || strings.TrimSpace(runtime.GetTenantId()) == "" {
+		return ports.CypherQueryRequest{}
+	}
+	return ports.CypherQueryRequest{
+		Query: `MATCH (agent:Entity {entity_type: 'sentinelone.agent', tenant_id: $tenant_id})
+OPTIONAL MATCH (agent)-[affected:RELATION {relation: 'affected_by'}]->(threat:Entity {entity_type: 'sentinelone.threat', tenant_id: $tenant_id})
+WITH agent, collect({
+       urn: threat.urn,
+       label: coalesce(threat.label, ''),
+       entity_type: coalesce(threat.entity_type, ''),
+       attributes_json: coalesce(threat.attributes_json, ''),
+       affected_attributes_json: coalesce(affected.attributes_json, '')
+     }) AS threats
+RETURN agent.urn AS agent_urn,
+       agent.label AS agent_label,
+       coalesce(agent.attributes_json, '') AS agent_attributes_json,
+       threats
+LIMIT $row_limit`,
+		Params: map[string]any{
+			"tenant_id": strings.TrimSpace(runtime.GetTenantId()),
+			"row_limit": int64(sentinelOneGraphQueryRowLimit),
+		},
+		RowLimit: sentinelOneGraphQueryRowLimit,
+	}
+}
+
+func (r *sentinelOneEndpointActiveInfectionGraphRule) EvaluateRows(_ context.Context, runtime *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {
+	if r == nil || runtime == nil {
+		return nil, nil
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return nil, nil
+	}
+	now := time.Now().UTC()
+	findings := make([]*ports.FindingRecord, 0, len(rows))
+	for _, row := range rows {
+		agentURN := cypherRowString(row, "agent_urn")
+		if agentURN == "" {
+			continue
+		}
+		agentAttrs := edgeStringAttributes(cypherRowString(row, "agent_attributes_json"))
+		activeThreats := sentinelOneActiveThreatsFromRow(row)
+		agentInfected := findingAttributeBool(agentAttrs, "is_infected", "infected") || sentinelOneIntAttribute(agentAttrs, "active_threats") > 0
+		if !agentInfected && !sentinelOneGraphThreatsHaveInfectionEvidence(activeThreats) {
+			continue
+		}
+		findings = append(findings, r.buildFinding(runtime, tenantID, agentURN, cypherRowString(row, "agent_label"), agentAttrs, activeThreats, now))
+	}
+	return findings, nil
+}
+
+func sentinelOneActiveThreatsFromRow(row ports.CypherRow) []sentinelOneGraphThreat {
+	threats := make([]sentinelOneGraphThreat, 0)
+	for _, item := range cypherRowList(row, "threats") {
+		threatURN := strings.TrimSpace(cypherListMapString(item, "urn"))
+		if threatURN == "" {
+			continue
+		}
+		threatAttrs := edgeStringAttributes(cypherListMapString(item, "attributes_json"))
+		edgeAttrs := edgeStringAttributes(cypherListMapString(item, "affected_attributes_json"))
+		merged := mergeFindingAttributeMaps(threatAttrs, edgeAttrs)
+		if sentinelOneFalsePositive(merged) || !sentinelOneThreatOpen(merged) {
+			continue
+		}
+		threats = append(threats, sentinelOneGraphThreat{
+			URN:        threatURN,
+			Label:      cypherListMapString(item, "label"),
+			EntityType: firstNonEmpty(cypherListMapString(item, "entity_type"), sentinelOneThreatEntityType),
+			Attributes: merged,
+		})
+	}
+	sort.Slice(threats, func(i, j int) bool {
+		return threats[i].URN < threats[j].URN
+	})
+	return threats
+}
+
+func (r *sentinelOneEndpointActiveInfectionGraphRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, agentURN string, agentLabel string, agentAttrs map[string]string, threats []sentinelOneGraphThreat, now time.Time) *ports.FindingRecord {
+	fingerprint := hashFindingFingerprint(r.definition.ID, tenantID, agentURN)
+	threatURNs := make([]string, 0, len(threats))
+	threatNames := make([]string, 0, len(threats))
+	threatIDs := make([]string, 0, len(threats))
+	incidentStatuses := map[string]struct{}{}
+	mitigationStatuses := map[string]struct{}{}
+	eventIDs := map[string]struct{}{}
+	resourceURNs := []string{agentURN}
+	graphRows := make([]*cerebrov1.GraphEvidenceRow, 0, len(threats)+1)
+	for _, threat := range threats {
+		threatURNs = append(threatURNs, threat.URN)
+		resourceURNs = append(resourceURNs, threat.URN)
+		if threat.Label != "" {
+			threatNames = append(threatNames, threat.Label)
+		}
+		if id := strings.TrimSpace(threat.Attributes["threat_id"]); id != "" {
+			threatIDs = append(threatIDs, id)
+		}
+		if status := strings.TrimSpace(threat.Attributes["incident_status"]); status != "" {
+			incidentStatuses[status] = struct{}{}
+		}
+		if status := strings.TrimSpace(threat.Attributes["mitigation_status"]); status != "" {
+			mitigationStatuses[status] = struct{}{}
+		}
+		if eventID := strings.TrimSpace(threat.Attributes["event_id"]); eventID != "" {
+			eventIDs[eventID] = struct{}{}
+		}
+		graphRows = append(graphRows, newGraphEvidenceRow("active_sentinelone_threat", map[string]string{
+			"agent_urn":         agentURN,
+			"agent_label":       agentLabel,
+			"threat_urn":        threat.URN,
+			"threat_label":      threat.Label,
+			"incident_status":   threat.Attributes["incident_status"],
+			"mitigation_status": threat.Attributes["mitigation_status"],
+			"classification":    threat.Attributes["classification"],
+			"event_id":          threat.Attributes["event_id"],
+		}, newGraphEvidencePath(agentURN, agentLabel, sentinelOneAgentEntityType, "affected_by", threat.URN, threat.Label, threat.EntityType, compactStringMap(threat.Attributes))))
+	}
+	if agentEventID := strings.TrimSpace(agentAttrs["event_id"]); agentEventID != "" {
+		eventIDs[agentEventID] = struct{}{}
+	}
+	if siteID := strings.TrimSpace(agentAttrs["site_id"]); siteID != "" {
+		resourceURNs = append(resourceURNs, sentinelOneProjectionURN(tenantID, "sentinelone_site", siteID))
+	}
+	if groupID := strings.TrimSpace(agentAttrs["group_id"]); groupID != "" {
+		resourceURNs = append(resourceURNs, sentinelOneProjectionURN(tenantID, "sentinelone_group", groupID))
+	}
+	if len(graphRows) == 0 {
+		graphRows = append(graphRows, newGraphEvidenceRow("infected_sentinelone_agent", map[string]string{
+			"agent_urn":      agentURN,
+			"agent_label":    agentLabel,
+			"is_infected":    agentAttrs["is_infected"],
+			"active_threats": agentAttrs["active_threats"],
+			"event_id":       agentAttrs["event_id"],
+		}))
+	}
+	sort.Strings(threatURNs)
+	sort.Strings(threatNames)
+	sort.Strings(threatIDs)
+	attributes := map[string]string{
+		"action":                 sentinelOneEndpointActiveInfectionAction,
+		"primary_resource_urn":   agentURN,
+		"resource_id":            firstNonEmpty(agentAttrs["agent_id"], lastURNSegment(agentURN)),
+		"resource_label":         firstNonEmpty(agentLabel, agentAttrs["computer_name"], agentAttrs["agent_id"]),
+		"resource_type":          sentinelOneAgentEntityType,
+		"agent_id":               agentAttrs["agent_id"],
+		"computer_name":          firstNonEmpty(agentAttrs["computer_name"], agentLabel),
+		"agent_os_name":          firstNonEmpty(agentAttrs["agent_os_name"], agentAttrs["os_name"]),
+		"agent_os_type":          firstNonEmpty(agentAttrs["agent_os_type"], agentAttrs["os_type"]),
+		"is_infected":            agentAttrs["is_infected"],
+		"active_threats":         firstNonEmpty(agentAttrs["active_threats"], fmt.Sprintf("%d", len(threats))),
+		"active_threat_count":    fmt.Sprintf("%d", len(threats)),
+		"active_threat_urns":     strings.Join(threatURNs, ","),
+		"active_threat_ids":      strings.Join(threatIDs, ","),
+		"active_threat_names":    strings.Join(threatNames, ","),
+		"incident_statuses":      strings.Join(sortedStringSet(incidentStatuses), ","),
+		"mitigation_statuses":    strings.Join(sortedStringSet(mitigationStatuses), ","),
+		"site_id":                agentAttrs["site_id"],
+		"site_name":              agentAttrs["site_name"],
+		"group_id":               agentAttrs["group_id"],
+		"group_name":             agentAttrs["group_name"],
+		"source_runtime_id":      strings.TrimSpace(runtime.GetId()),
+		"source_runtime_tenant":  tenantID,
+		"graph_evidence_summary": fmt.Sprintf("%d active threat(s) linked to current endpoint infection state", len(threats)),
+	}
+	for key, value := range r.definition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	label := firstNonEmpty(agentLabel, agentAttrs["computer_name"], agentAttrs["agent_id"], agentURN)
+	summaryThreat := firstNonEmpty(strings.Join(threatNames, ", "), fmt.Sprintf("%s active threat(s)", attributes["active_threats"]))
+	return &ports.FindingRecord{
+		ID:                fingerprint,
+		Fingerprint:       fingerprint,
+		TenantID:          tenantID,
+		RuntimeID:         strings.TrimSpace(runtime.GetId()),
+		RuleID:            r.definition.ID,
+		Title:             r.definition.Name,
+		Severity:          sentinelOneGraphInfectionSeverity(agentAttrs, threats),
+		Status:            r.definition.Status,
+		Summary:           fmt.Sprintf("SentinelOne endpoint %s has active infection evidence from %s", label, summaryThreat),
+		ResourceURNs:      deduplicateStrings(resourceURNs),
+		EventIDs:          sortedStringSet(eventIDs),
+		ObservedPolicyIDs: []string{firstNonEmpty(agentAttrs["agent_id"], agentURN)},
+		PolicyID:          firstNonEmpty(agentAttrs["agent_id"], agentURN),
+		PolicyName:        label,
+		CheckID:           r.definition.ID,
+		CheckName:         r.definition.Name,
+		ControlRefs:       cloneFindingControlRefs(r.definition.ControlRefs),
+		GraphEvidenceRows: graphRows,
+		Attributes:        attributes,
+		FirstObservedAt:   now,
+		LastObservedAt:    now,
+	}
+}
+
+type sentinelOneAgentStaleGraphRule struct {
+	definition RuleDefinition
+}
+
+func (r *sentinelOneAgentStaleGraphRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return proto.Clone(r.definition.RuleSpec()).(*cerebrov1.RuleSpec)
+}
+
+func (r *sentinelOneAgentStaleGraphRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	return sentinelOneGraphRuleSupportsRuntime(runtime, "agent")
+}
+
+func (r *sentinelOneAgentStaleGraphRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (r *sentinelOneAgentStaleGraphRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
+	if runtime == nil || strings.TrimSpace(runtime.GetTenantId()) == "" {
+		return ports.CypherQueryRequest{}
+	}
+	return ports.CypherQueryRequest{
+		Query: `MATCH (agent:Entity {entity_type: 'sentinelone.agent', tenant_id: $tenant_id})
+RETURN agent.urn AS agent_urn,
+       agent.label AS agent_label,
+       coalesce(agent.attributes_json, '') AS agent_attributes_json
+LIMIT $row_limit`,
+		Params: map[string]any{
+			"tenant_id": strings.TrimSpace(runtime.GetTenantId()),
+			"row_limit": int64(sentinelOneGraphQueryRowLimit),
+		},
+		RowLimit: sentinelOneGraphQueryRowLimit,
+	}
+}
+
+func (r *sentinelOneAgentStaleGraphRule) EvaluateRows(_ context.Context, runtime *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {
+	if r == nil || runtime == nil {
+		return nil, nil
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return nil, nil
+	}
+	now := time.Now().UTC()
+	groups := map[string]*sentinelOneStaleAgentGroup{}
+	keys := make([]string, 0)
+	for _, row := range rows {
+		agentURN := cypherRowString(row, "agent_urn")
+		if agentURN == "" {
+			continue
+		}
+		agentAttrs := edgeStringAttributes(cypherRowString(row, "agent_attributes_json"))
+		if sentinelOneAgentRetired(agentAttrs) {
+			continue
+		}
+		lastActive, ok := sentinelOneParseTimestamp(agentAttrs["last_active_date"])
+		if !ok {
+			continue
+		}
+		age := now.Sub(lastActive.UTC())
+		if age <= sentinelOneAgentStaleThreshold {
+			continue
+		}
+		bucket := sentinelOneStaleAgentBucket(age)
+		scopeURN, scopeLabel, scopeType := sentinelOneStaleAgentScope(tenantID, agentAttrs)
+		key := scopeURN + "|" + bucket.ID
+		group, ok := groups[key]
+		if !ok {
+			group = &sentinelOneStaleAgentGroup{
+				ScopeURN:   scopeURN,
+				ScopeLabel: scopeLabel,
+				ScopeType:  scopeType,
+				Bucket:     bucket,
+			}
+			groups[key] = group
+			keys = append(keys, key)
+		}
+		group.Agents = append(group.Agents, sentinelOneStaleAgent{
+			URN:        agentURN,
+			Label:      cypherRowString(row, "agent_label"),
+			LastActive: lastActive.UTC(),
+			Attributes: agentAttrs,
+		})
+	}
+	sort.Strings(keys)
+	findings := make([]*ports.FindingRecord, 0, len(keys))
+	for _, key := range keys {
+		group := groups[key]
+		if group == nil || len(group.Agents) == 0 {
+			continue
+		}
+		findings = append(findings, r.buildFinding(runtime, tenantID, group, now))
+	}
+	return findings, nil
+}
+
+func (r *sentinelOneAgentStaleGraphRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, group *sentinelOneStaleAgentGroup, now time.Time) *ports.FindingRecord {
+	sort.Slice(group.Agents, func(i, j int) bool {
+		return group.Agents[i].LastActive.Before(group.Agents[j].LastActive)
+	})
+	fingerprint := hashFindingFingerprint(r.definition.ID, tenantID, group.ScopeURN, group.Bucket.ID)
+	agentURNs := make([]string, 0, len(group.Agents))
+	agentLabels := make([]string, 0, len(group.Agents))
+	eventIDs := map[string]struct{}{}
+	graphRows := make([]*cerebrov1.GraphEvidenceRow, 0, minInt(len(group.Agents), sentinelOneGraphEvidenceAgentLimit))
+	for index, agent := range group.Agents {
+		agentURNs = append(agentURNs, agent.URN)
+		if agent.Label != "" {
+			agentLabels = append(agentLabels, agent.Label)
+		}
+		if eventID := strings.TrimSpace(agent.Attributes["event_id"]); eventID != "" {
+			eventIDs[eventID] = struct{}{}
+		}
+		if index < sentinelOneGraphEvidenceAgentLimit {
+			graphRows = append(graphRows, newGraphEvidenceRow("stale_sentinelone_agent", map[string]string{
+				"agent_urn":        agent.URN,
+				"agent_label":      agent.Label,
+				"scope_urn":        group.ScopeURN,
+				"scope_label":      group.ScopeLabel,
+				"staleness_bucket": group.Bucket.ID,
+				"last_active_date": agent.LastActive.Format(time.RFC3339),
+			}, newGraphEvidencePath(agent.URN, agent.Label, sentinelOneAgentEntityType, sentinelOneStaleScopeRelation(group.ScopeType), group.ScopeURN, group.ScopeLabel, group.ScopeType, map[string]string{
+				"last_active_date": agent.LastActive.Format(time.RFC3339),
+				"event_id":         agent.Attributes["event_id"],
+			})))
+		}
+	}
+	sort.Strings(agentURNs)
+	sort.Strings(agentLabels)
+	newest := group.Agents[len(group.Agents)-1].LastActive
+	oldest := group.Agents[0].LastActive
+	attributes := map[string]string{
+		"action":                  sentinelOneAgentStaleAction,
+		"primary_resource_urn":    group.ScopeURN,
+		"resource_label":          group.ScopeLabel,
+		"resource_type":           group.ScopeType,
+		"scope_urn":               group.ScopeURN,
+		"scope_label":             group.ScopeLabel,
+		"scope_type":              group.ScopeType,
+		"staleness_bucket":        group.Bucket.ID,
+		"staleness_bucket_label":  group.Bucket.Label,
+		"agent_count":             fmt.Sprintf("%d", len(group.Agents)),
+		"agent_urns":              strings.Join(agentURNs, ","),
+		"agent_labels":            strings.Join(limitStrings(agentLabels, 50), ","),
+		"oldest_last_active_date": oldest.Format(time.RFC3339),
+		"newest_last_active_date": newest.Format(time.RFC3339),
+		"evidence_rows_truncated": fmt.Sprintf("%t", len(group.Agents) > sentinelOneGraphEvidenceAgentLimit),
+		"source_runtime_id":       strings.TrimSpace(runtime.GetId()),
+		"source_runtime_tenant":   tenantID,
+		"graph_evidence_summary":  fmt.Sprintf("%d stale SentinelOne agent(s) grouped by %s and %s", len(group.Agents), group.ScopeLabel, group.Bucket.Label),
+	}
+	for key, value := range r.definition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	summary := fmt.Sprintf("SentinelOne %s has %d stale agent(s) last active %s", group.ScopeLabel, len(group.Agents), group.Bucket.Label)
+	return &ports.FindingRecord{
+		ID:                fingerprint,
+		Fingerprint:       fingerprint,
+		TenantID:          tenantID,
+		RuntimeID:         strings.TrimSpace(runtime.GetId()),
+		RuleID:            r.definition.ID,
+		Title:             r.definition.Name,
+		Severity:          group.Bucket.Severity,
+		Status:            r.definition.Status,
+		Summary:           summary,
+		ResourceURNs:      []string{group.ScopeURN},
+		EventIDs:          sortedStringSet(eventIDs),
+		ObservedPolicyIDs: []string{group.ScopeURN + ":" + group.Bucket.ID},
+		PolicyID:          group.ScopeURN + ":" + group.Bucket.ID,
+		PolicyName:        group.ScopeLabel + " " + group.Bucket.Label,
+		CheckID:           r.definition.ID,
+		CheckName:         r.definition.Name,
+		ControlRefs:       cloneFindingControlRefs(r.definition.ControlRefs),
+		GraphEvidenceRows: graphRows,
+		Attributes:        attributes,
+		FirstObservedAt:   now,
+		LastObservedAt:    now,
+	}
+}
+
+type sentinelOneGraphThreat struct {
+	URN        string
+	Label      string
+	EntityType string
+	Attributes map[string]string
+}
+
+type sentinelOneStaleAgent struct {
+	URN        string
+	Label      string
+	LastActive time.Time
+	Attributes map[string]string
+}
+
+type sentinelOneStaleAgentGroup struct {
+	ScopeURN   string
+	ScopeLabel string
+	ScopeType  string
+	Bucket     sentinelOneStaleBucket
+	Agents     []sentinelOneStaleAgent
+}
+
+type sentinelOneStaleBucket struct {
+	ID       string
+	Label    string
+	Severity string
+}
+
+func sentinelOneGraphRuleSupportsRuntime(runtime *cerebrov1.SourceRuntime, families ...string) bool {
+	if runtime == nil || !strings.EqualFold(strings.TrimSpace(runtime.GetSourceId()), "sentinelone") {
+		return false
+	}
+	family := strings.ToLower(strings.TrimSpace(runtime.GetConfig()["family"]))
+	if family == "" {
+		family = "threat"
+	}
+	for _, supported := range families {
+		if family == strings.ToLower(strings.TrimSpace(supported)) {
+			return true
+		}
+	}
+	return false
+}
+
+func sentinelOneGraphInfectionSeverity(agentAttrs map[string]string, threats []sentinelOneGraphThreat) string {
+	if sentinelOneIntAttribute(agentAttrs, "active_threats") > 1 || len(threats) > 1 {
+		return "CRITICAL"
+	}
+	for _, threat := range threats {
+		if findingAttributeBool(threat.Attributes, "is_fileless") {
+			return "CRITICAL"
+		}
+	}
+	return "HIGH"
+}
+
+func sentinelOneGraphThreatsHaveInfectionEvidence(threats []sentinelOneGraphThreat) bool {
+	for _, threat := range threats {
+		if findingAttributeBool(threat.Attributes, "is_infected", "infected") || sentinelOneIntAttribute(threat.Attributes, "active_threats") > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func sentinelOneStaleAgentBucket(age time.Duration) sentinelOneStaleBucket {
+	switch {
+	case age > 90*24*time.Hour:
+		return sentinelOneStaleBucket{ID: "stale_gt_90d", Label: "more than 90 days ago", Severity: "CRITICAL"}
+	case age > 30*24*time.Hour:
+		return sentinelOneStaleBucket{ID: "stale_31_90d", Label: "31-90 days ago", Severity: "HIGH"}
+	default:
+		return sentinelOneStaleBucket{ID: "stale_14_30d", Label: "14-30 days ago", Severity: "MEDIUM"}
+	}
+}
+
+func sentinelOneStaleAgentScope(tenantID string, attrs map[string]string) (string, string, string) {
+	if groupID := strings.TrimSpace(attrs["group_id"]); groupID != "" {
+		return sentinelOneProjectionURN(tenantID, "sentinelone_group", groupID), firstNonEmpty(attrs["group_name"], groupID), "sentinelone.group"
+	}
+	if siteID := strings.TrimSpace(attrs["site_id"]); siteID != "" {
+		return sentinelOneProjectionURN(tenantID, "sentinelone_site", siteID), firstNonEmpty(attrs["site_name"], siteID), "sentinelone.site"
+	}
+	return sentinelOneProjectionURN(tenantID, "sentinelone_scope", "tenant"), tenantID, "sentinelone.scope"
+}
+
+func sentinelOneStaleScopeRelation(scopeType string) string {
+	if scopeType == "sentinelone.site" {
+		return "belongs_to"
+	}
+	if scopeType == "sentinelone.group" {
+		return "member_of"
+	}
+	return "scoped_to"
+}
+
+func sentinelOneProjectionURN(tenantID string, kind string, parts ...string) string {
+	values := []string{"urn", "cerebro", strings.TrimSpace(tenantID), strings.TrimSpace(kind)}
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	return strings.Join(values, ":")
+}
+
+func mergeFindingAttributeMaps(primary map[string]string, secondary map[string]string) map[string]string {
+	merged := make(map[string]string, len(primary)+len(secondary))
+	for key, value := range secondary {
+		if strings.TrimSpace(value) != "" {
+			merged[key] = value
+		}
+	}
+	for key, value := range primary {
+		if strings.TrimSpace(value) != "" {
+			merged[key] = value
+		}
+	}
+	return merged
+}
+
+func limitStrings(values []string, limit int) []string {
+	if limit <= 0 || len(values) <= limit {
+		return values
+	}
+	return values[:limit]
+}
+
+func minInt(left int, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}
+
+func lastURNSegment(urn string) string {
+	parts := strings.Split(strings.TrimSpace(urn), ":")
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(parts[len(parts)-1])
+}

--- a/internal/findings/sentinelone_graph_rule_test.go
+++ b/internal/findings/sentinelone_graph_rule_test.go
@@ -1,0 +1,240 @@
+package findings
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestSentinelOneEndpointActiveInfectionGraphRuleAggregatesThreats(t *testing.T) {
+	rule := newSentinelOneEndpointActiveInfectionRule()
+	graphRule, ok := rule.(GraphRule)
+	if !ok {
+		t.Fatalf("newSentinelOneEndpointActiveInfectionRule() is not a GraphRule")
+	}
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-threat", SourceId: "sentinelone", TenantId: "writer", Config: map[string]string{"family": "threat"}}
+	rows := []ports.CypherRow{sentinelOneInfectionRow("agent-1", "mac-1", map[string]string{
+		"agent_id":       "agent-1",
+		"computer_name":  "mac-1",
+		"is_infected":    "true",
+		"active_threats": "2",
+		"site_id":        "site-1",
+		"site_name":      "Default site",
+		"group_id":       "group-1",
+		"group_name":     "Default Group",
+	}, []map[string]string{
+		{
+			"threat_id":         "threat-1",
+			"threat_name":       "malware-a",
+			"incident_status":   "unresolved",
+			"mitigation_status": "not_mitigated",
+			"classification":    "Malware",
+			"event_id":          "event-threat-1",
+		},
+		{
+			"threat_id":         "threat-2",
+			"threat_name":       "malware-b",
+			"incident_status":   "unresolved",
+			"mitigation_status": "not_mitigated",
+			"classification":    "General",
+			"event_id":          "event-threat-2",
+		},
+	})}
+	findings, err := graphRule.EvaluateRows(context.Background(), runtime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if got := len(findings); got != 1 {
+		t.Fatalf("len(findings) = %d, want 1", got)
+	}
+	finding := findings[0]
+	if finding.RuleID != sentinelOneEndpointActiveInfectionRuleID {
+		t.Fatalf("RuleID = %q", finding.RuleID)
+	}
+	if finding.Severity != "CRITICAL" {
+		t.Fatalf("Severity = %q, want CRITICAL", finding.Severity)
+	}
+	if got := finding.Attributes["active_threat_count"]; got != "2" {
+		t.Fatalf("active_threat_count = %q, want 2", got)
+	}
+	if got := len(finding.GraphEvidenceRows); got != 2 {
+		t.Fatalf("len(GraphEvidenceRows) = %d, want 2", got)
+	}
+	if !containsString(finding.EventIDs, "event-threat-1") || !containsString(finding.EventIDs, "event-threat-2") {
+		t.Fatalf("EventIDs = %#v, want both threat events", finding.EventIDs)
+	}
+}
+
+func TestSentinelOneEndpointActiveInfectionGraphRuleSkipsCleanMitigatedAgent(t *testing.T) {
+	graphRule := newSentinelOneEndpointActiveInfectionRule().(GraphRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-threat", SourceId: "sentinelone", TenantId: "writer", Config: map[string]string{"family": "threat"}}
+	rows := []ports.CypherRow{sentinelOneInfectionRow("agent-1", "mac-1", map[string]string{
+		"agent_id":       "agent-1",
+		"computer_name":  "mac-1",
+		"is_infected":    "false",
+		"active_threats": "0",
+	}, []map[string]string{
+		{
+			"threat_id":         "threat-1",
+			"threat_name":       "malware-a",
+			"incident_status":   "resolved",
+			"mitigation_status": "mitigated",
+			"classification":    "Malware",
+		},
+	})}
+	findings, err := graphRule.EvaluateRows(context.Background(), runtime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("len(findings) = %d, want 0", len(findings))
+	}
+}
+
+func TestSentinelOneEndpointActiveInfectionGraphRuleRequiresInfectionEvidence(t *testing.T) {
+	graphRule := newSentinelOneEndpointActiveInfectionRule().(GraphRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-threat", SourceId: "sentinelone", TenantId: "writer", Config: map[string]string{"family": "threat"}}
+	rows := []ports.CypherRow{sentinelOneInfectionRow("agent-1", "mac-1", map[string]string{
+		"agent_id":       "agent-1",
+		"computer_name":  "mac-1",
+		"is_infected":    "false",
+		"active_threats": "0",
+	}, []map[string]string{
+		{
+			"threat_id":         "threat-1",
+			"threat_name":       "suspicious-a",
+			"incident_status":   "unresolved",
+			"mitigation_status": "not_mitigated",
+			"classification":    "Suspicious",
+			"is_infected":       "false",
+			"active_threats":    "0",
+		},
+	})}
+	findings, err := graphRule.EvaluateRows(context.Background(), runtime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("len(findings) = %d, want 0", len(findings))
+	}
+}
+
+func TestSentinelOneEndpointActiveInfectionFingerprintIsStableAcrossRuntimes(t *testing.T) {
+	graphRule := newSentinelOneEndpointActiveInfectionRule().(GraphRule)
+	rows := []ports.CypherRow{sentinelOneInfectionRow("agent-1", "mac-1", map[string]string{
+		"agent_id":       "agent-1",
+		"computer_name":  "mac-1",
+		"is_infected":    "true",
+		"active_threats": "1",
+	}, []map[string]string{
+		{"threat_id": "threat-1", "threat_name": "malware-a", "incident_status": "unresolved", "mitigation_status": "not_mitigated"},
+	})}
+	threatRuntime := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-threat", SourceId: "sentinelone", TenantId: "writer", Config: map[string]string{"family": "threat"}}
+	agentRuntime := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-agent", SourceId: "sentinelone", TenantId: "writer", Config: map[string]string{"family": "agent"}}
+	first, err := graphRule.EvaluateRows(context.Background(), threatRuntime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows(threat) error = %v", err)
+	}
+	second, err := graphRule.EvaluateRows(context.Background(), agentRuntime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows(agent) error = %v", err)
+	}
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("finding counts = %d/%d, want 1/1", len(first), len(second))
+	}
+	if first[0].ID != second[0].ID {
+		t.Fatalf("finding IDs differ across runtimes: %q/%q", first[0].ID, second[0].ID)
+	}
+	if first[0].RuntimeID == second[0].RuntimeID {
+		t.Fatalf("RuntimeID should reflect triggering runtime before store pinning")
+	}
+}
+
+func TestSentinelOneAgentStaleGraphRuleGroupsByScopeAndBucket(t *testing.T) {
+	graphRule := newSentinelOneAgentStaleRule().(GraphRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-agent", SourceId: "sentinelone", TenantId: "writer", Config: map[string]string{"family": "agent"}}
+	now := time.Now().UTC()
+	rows := []ports.CypherRow{
+		sentinelOneStaleAgentRow("agent-1", "mac-1", now.Add(-45*24*time.Hour), map[string]string{"group_id": "group-1", "group_name": "Default Group"}),
+		sentinelOneStaleAgentRow("agent-2", "mac-2", now.Add(-60*24*time.Hour), map[string]string{"group_id": "group-1", "group_name": "Default Group"}),
+		sentinelOneStaleAgentRow("agent-recent", "mac-recent", now.Add(-2*24*time.Hour), map[string]string{"group_id": "group-1", "group_name": "Default Group"}),
+		sentinelOneStaleAgentRow("agent-retired", "mac-retired", now.Add(-80*24*time.Hour), map[string]string{"group_id": "group-1", "group_name": "Default Group", "is_decommissioned": "true"}),
+	}
+	findings, err := graphRule.EvaluateRows(context.Background(), runtime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if got := len(findings); got != 1 {
+		t.Fatalf("len(findings) = %d, want 1", got)
+	}
+	finding := findings[0]
+	if finding.Severity != "HIGH" {
+		t.Fatalf("Severity = %q, want HIGH", finding.Severity)
+	}
+	if got := finding.Attributes["agent_count"]; got != "2" {
+		t.Fatalf("agent_count = %q, want 2", got)
+	}
+	if got := finding.Attributes["staleness_bucket"]; got != "stale_31_90d" {
+		t.Fatalf("staleness_bucket = %q, want stale_31_90d", got)
+	}
+	if got := len(finding.ResourceURNs); got != 1 {
+		t.Fatalf("len(ResourceURNs) = %d, want grouped scope only", got)
+	}
+	if !strings.Contains(finding.ResourceURNs[0], "sentinelone_group:group-1") {
+		t.Fatalf("ResourceURNs = %#v, want group scope", finding.ResourceURNs)
+	}
+	if got := len(finding.GraphEvidenceRows); got != 2 {
+		t.Fatalf("len(GraphEvidenceRows) = %d, want 2", got)
+	}
+}
+
+func sentinelOneInfectionRow(agentID string, agentLabel string, agentAttrs map[string]string, threats []map[string]string) ports.CypherRow {
+	threatRows := make([]any, 0, len(threats))
+	for _, threat := range threats {
+		threatID := threat["threat_id"]
+		threatRows = append(threatRows, map[string]any{
+			"urn":                      "urn:cerebro:writer:sentinelone_threat:" + threatID,
+			"label":                    firstNonEmpty(threat["threat_name"], threatID),
+			"entity_type":              sentinelOneThreatEntityType,
+			"attributes_json":          sentinelOneTestJSON(threat),
+			"affected_attributes_json": sentinelOneTestJSON(threat),
+		})
+	}
+	return ports.CypherRow{Values: map[string]any{
+		"agent_urn":             "urn:cerebro:writer:sentinelone_agent:" + agentID,
+		"agent_label":           agentLabel,
+		"agent_attributes_json": sentinelOneTestJSON(agentAttrs),
+		"threats":               threatRows,
+	}}
+}
+
+func sentinelOneStaleAgentRow(agentID string, label string, lastActive time.Time, overrides map[string]string) ports.CypherRow {
+	attrs := map[string]string{
+		"agent_id":          agentID,
+		"computer_name":     label,
+		"last_active_date":  lastActive.UTC().Format(time.RFC3339),
+		"is_decommissioned": "false",
+		"is_uninstalled":    "false",
+	}
+	for key, value := range overrides {
+		attrs[key] = value
+	}
+	return ports.CypherRow{Values: map[string]any{
+		"agent_urn":             "urn:cerebro:writer:sentinelone_agent:" + agentID,
+		"agent_label":           label,
+		"agent_attributes_json": sentinelOneTestJSON(attrs),
+	}}
+}
+
+func sentinelOneTestJSON(values map[string]string) string {
+	payload, err := json.Marshal(values)
+	if err != nil {
+		panic(err)
+	}
+	return string(payload)
+}

--- a/internal/findings/sentinelone_signal_rule.go
+++ b/internal/findings/sentinelone_signal_rule.go
@@ -82,14 +82,7 @@ func newSentinelOneEndpointActiveInfectionRule() Rule {
 		[]string{"agent_id"},
 		sentinelOneThreatResponseControlRefs,
 	)
-	return newSentinelOneEventRule(definition, matchesSentinelOneEndpointActiveInfection, sentinelOneFindingOptions{
-		action:             sentinelOneEndpointActiveInfectionAction,
-		primaryEntityType:  sentinelOneAgentEntityType,
-		collectAllLinkURNs: true,
-		severity:           sentinelOneEndpointActiveInfectionSeverity,
-		summary:            sentinelOneEndpointActiveInfectionSummary,
-		policyID:           sentinelOneAgentPolicyID,
-	})
+	return &sentinelOneEndpointActiveInfectionGraphRule{definition: definition}
 }
 
 func newSentinelOneMitigationFailedRule() Rule {
@@ -128,13 +121,7 @@ func newSentinelOneAgentStaleRule() Rule {
 		[]string{"agent_id"},
 		sentinelOneEndpointCoverageControlRefs,
 	)
-	return newSentinelOneEventRule(definition, matchesSentinelOneAgentStale, sentinelOneFindingOptions{
-		action:             sentinelOneAgentStaleAction,
-		primaryEntityType:  sentinelOneAgentEntityType,
-		collectAllLinkURNs: true,
-		summary:            sentinelOneAgentStaleSummary,
-		policyID:           sentinelOneAgentPolicyID,
-	})
+	return &sentinelOneAgentStaleGraphRule{definition: definition}
 }
 
 func newSentinelOneAgentDetectOnlyModeRule() Rule {
@@ -352,34 +339,12 @@ func buildSentinelOneFinding(ctx context.Context, runtime *cerebrov1.SourceRunti
 	}, nil
 }
 
-func matchesSentinelOneEndpointActiveInfection(event *cerebrov1.EventEnvelope) bool {
-	if !eventKindMatcher(sentinelOneThreatEntityType)(event) || !hasRequiredAttributes(event, "agent_id") {
-		return false
-	}
-	attributes := eventAttributes(event)
-	return !sentinelOneFalsePositive(attributes) &&
-		sentinelOneThreatOpen(attributes) &&
-		(findingAttributeBool(attributes, "is_infected", "infected") || sentinelOneIntAttribute(attributes, "active_threats") > 0)
-}
-
 func matchesSentinelOneMitigationFailed(event *cerebrov1.EventEnvelope) bool {
 	if !eventKindMatcher(sentinelOneThreatEntityType)(event) || !hasRequiredAttributes(event, "agent_id", "mitigation_status") {
 		return false
 	}
 	attributes := eventAttributes(event)
 	return !sentinelOneFalsePositive(attributes) && sentinelOneMitigationNeedsAction(attributes["mitigation_status"])
-}
-
-func matchesSentinelOneAgentStale(event *cerebrov1.EventEnvelope) bool {
-	if !eventKindMatcher(sentinelOneAgentEntityType)(event) || !hasRequiredAttributes(event, "agent_id", "last_active_date") {
-		return false
-	}
-	attributes := eventAttributes(event)
-	if sentinelOneAgentRetired(attributes) {
-		return false
-	}
-	lastActive, ok := sentinelOneParseTimestamp(attributes["last_active_date"])
-	return ok && time.Since(lastActive.UTC()) > sentinelOneAgentStaleThreshold
 }
 
 func matchesSentinelOneAgentDetectOnlyMode(event *cerebrov1.EventEnvelope) bool {
@@ -492,13 +457,6 @@ func sentinelOneParseTimestamp(value string) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-func sentinelOneEndpointActiveInfectionSeverity(attributes map[string]string) string {
-	if findingAttributeBool(attributes, "is_fileless") || sentinelOneIntAttribute(attributes, "active_threats") > 1 {
-		return "CRITICAL"
-	}
-	return "HIGH"
-}
-
 func sentinelOneMitigationFailedSeverity(attributes map[string]string) string {
 	switch sentinelOneStatus(attributes["mitigation_status"]) {
 	case "failed", "failure", "action_required", "requires_action":
@@ -541,21 +499,10 @@ func sentinelOneActivityText(attributes map[string]string) string {
 	}, " "))
 }
 
-func sentinelOneEndpointActiveInfectionSummary(attributes map[string]string, context findingProjectionContext) string {
-	endpoint := firstNonEmpty(context.ResourceLabel, attributes["computer_name"], attributes["agent_name"], attributes["agent_id"], "unknown endpoint")
-	threat := firstNonEmpty(attributes["threat_name"], attributes["classification"], attributes["threat_id"], "active threat")
-	return fmt.Sprintf("SentinelOne endpoint %s has active infection evidence from %s", endpoint, threat)
-}
-
 func sentinelOneMitigationFailedSummary(attributes map[string]string, context findingProjectionContext) string {
 	endpoint := firstNonEmpty(context.ResourceLabel, attributes["computer_name"], attributes["agent_name"], attributes["agent_id"], "unknown endpoint")
 	threat := firstNonEmpty(attributes["threat_name"], attributes["classification"], attributes["threat_id"], "threat")
 	return fmt.Sprintf("SentinelOne mitigation %s for %s on %s", firstNonEmpty(attributes["mitigation_status"], "failed"), threat, endpoint)
-}
-
-func sentinelOneAgentStaleSummary(attributes map[string]string, context findingProjectionContext) string {
-	endpoint := firstNonEmpty(context.ResourceLabel, attributes["computer_name"], attributes["agent_id"], "unknown endpoint")
-	return fmt.Sprintf("SentinelOne agent %s has not checked in since %s", endpoint, attributes["last_active_date"])
 }
 
 func sentinelOneAgentDetectOnlyModeSummary(attributes map[string]string, context findingProjectionContext) string {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -15,6 +15,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/workflowevents"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1098,7 +1099,7 @@ func containsString(values []string, expected string) bool {
 	return false
 }
 
-func (s *Service) buildFindingEvidence(ctx context.Context, finding *ports.FindingRecord, run *cerebrov1.FindingEvaluationRun) (*cerebrov1.FindingEvidence, error) {
+func (s *Service) buildFindingEvidence(ctx context.Context, finding *ports.FindingRecord, run *cerebrov1.FindingEvaluationRun, graphRows ...*cerebrov1.GraphEvidenceRow) (*cerebrov1.FindingEvidence, error) {
 	if finding == nil {
 		return nil, errors.New("finding is required")
 	}
@@ -1111,6 +1112,9 @@ func (s *Service) buildFindingEvidence(ctx context.Context, finding *ports.Findi
 	}
 	graphRootURNs := uniqueSortedStrings(finding.ResourceURNs)
 	eventIDs := uniqueSortedStrings(finding.EventIDs)
+	if len(graphRows) == 0 {
+		graphRows = finding.GraphEvidenceRows
+	}
 	createdAt := time.Now().UTC()
 	// Evidence is keyed by the runtime that performed THIS evaluation, not by the runtime
 	// the finding happens to be pinned to. For event rules these are identical because the
@@ -1131,7 +1135,22 @@ func (s *Service) buildFindingEvidence(ctx context.Context, finding *ports.Findi
 		EventIds:      eventIDs,
 		GraphRootUrns: graphRootURNs,
 		CreatedAt:     timestamppb.New(createdAt),
+		GraphRows:     cloneGraphEvidenceRows(graphRows),
 	}, nil
+}
+
+func cloneGraphEvidenceRows(rows []*cerebrov1.GraphEvidenceRow) []*cerebrov1.GraphEvidenceRow {
+	if len(rows) == 0 {
+		return nil
+	}
+	cloned := make([]*cerebrov1.GraphEvidenceRow, 0, len(rows))
+	for _, row := range rows {
+		if row == nil {
+			continue
+		}
+		cloned = append(cloned, proto.Clone(row).(*cerebrov1.GraphEvidenceRow))
+	}
+	return cloned
 }
 
 func (s *Service) claimIDsForFinding(ctx context.Context, finding *ports.FindingRecord) ([]string, error) {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2771,6 +2771,7 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 	copy(observedPolicyIDs, finding.ObservedPolicyIDs)
 	controlRefs := make([]ports.FindingControlRef, len(finding.ControlRefs))
 	copy(controlRefs, finding.ControlRefs)
+	graphEvidenceRows := cloneGraphEvidenceRows(finding.GraphEvidenceRows)
 	notes := make([]ports.FindingNote, len(finding.Notes))
 	copy(notes, finding.Notes)
 	tickets := make([]ports.FindingTicket, len(finding.Tickets))
@@ -2797,6 +2798,7 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 		CheckID:           finding.CheckID,
 		CheckName:         finding.CheckName,
 		ControlRefs:       controlRefs,
+		GraphEvidenceRows: graphEvidenceRows,
 		FindingWorkflow: ports.FindingWorkflow{
 			Notes:           notes,
 			Tickets:         tickets,

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -501,6 +501,13 @@ func mergeStringMap(dst map[string]string, src map[string]string) map[string]str
 		dst = make(map[string]string, len(src))
 	}
 	incomingIsOlderObservation := projectedIncomingObservationIsOlder(dst, src)
+	if !incomingIsOlderObservation && projectedIncomingObservationIsNewer(dst, src) {
+		for key := range dst {
+			if projectedAttributeCoupledToObservationTime(key) {
+				delete(dst, key)
+			}
+		}
+	}
 	for key, value := range src {
 		if incomingIsOlderObservation && projectedAttributeCoupledToObservationTime(key) {
 			continue
@@ -527,9 +534,23 @@ func projectedIncomingObservationIsOlder(existing map[string]string, incoming ma
 	return incomingT.Before(existingT)
 }
 
+func projectedIncomingObservationIsNewer(existing map[string]string, incoming map[string]string) bool {
+	existingAt := strings.TrimSpace(existing["at"])
+	incomingAt := strings.TrimSpace(incoming["at"])
+	if existingAt == "" || incomingAt == "" {
+		return false
+	}
+	existingT, errExisting := time.Parse(time.RFC3339, existingAt)
+	incomingT, errIncoming := time.Parse(time.RFC3339, incomingAt)
+	if errExisting != nil || errIncoming != nil {
+		return false
+	}
+	return incomingT.After(existingT)
+}
+
 func projectedAttributeCoupledToObservationTime(key string) bool {
 	switch key {
-	case "action", "event_id", "programmatic_access_type", "source_event_id", "source_runtime_id", "transport_protocol_name":
+	case "action", "actor_type", "classification", "client_ip", "event_id", "event_type", "grant_type", "incident_status", "mitigation_status", "oauth_event_category", "outcome_reason", "outcome_result", "programmatic_access_type", "source_event_id", "source_runtime_id", "transaction_id", "transport_protocol_name":
 		return true
 	default:
 		return false

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -217,9 +217,10 @@ func TestProjectResponseCoalescedPreservesNewestObservationAttributes(t *testing
 				EntityType: "github.user",
 				Label:      "alice",
 				Attributes: map[string]string{
-					"at":       at,
-					"event_id": event.GetId(),
-					"login":    event.GetId(),
+					"at":             at,
+					"event_id":       event.GetId(),
+					"login":          event.GetId(),
+					"outcome_result": event.GetId(),
 				},
 			}},
 			[]*ports.ProjectedLink{{
@@ -230,10 +231,12 @@ func TestProjectResponseCoalescedPreservesNewestObservationAttributes(t *testing
 				Relation:  "acted_on",
 				ToURN:     "urn:cerebro:writer:github_repo:writer/cerebro",
 				Attributes: map[string]string{
-					"action":   "git.clone",
-					"at":       at,
-					"event_id": event.GetId(),
-					"target":   event.GetId(),
+					"action":         "git.clone",
+					"at":             at,
+					"event_id":       event.GetId(),
+					"event_type":     event.GetId(),
+					"outcome_result": event.GetId(),
+					"target":         event.GetId(),
 				},
 			}}, nil
 	})
@@ -258,6 +261,9 @@ func TestProjectResponseCoalescedPreservesNewestObservationAttributes(t *testing
 	if got := entity.Attributes["event_id"]; got != "newer-event" {
 		t.Fatalf("coalesced entity event_id = %q, want newer-event coupled to newest observation", got)
 	}
+	if got := entity.Attributes["outcome_result"]; got != "newer-event" {
+		t.Fatalf("coalesced entity outcome_result = %q, want newer-event coupled to newest observation", got)
+	}
 	if got := entity.Attributes["login"]; got != "older-event" {
 		t.Fatalf("coalesced entity non-observation attribute login = %q, want older-event latest write", got)
 	}
@@ -271,8 +277,44 @@ func TestProjectResponseCoalescedPreservesNewestObservationAttributes(t *testing
 	if got := link.Attributes["event_id"]; got != "newer-event" {
 		t.Fatalf("coalesced link event_id = %q, want newer-event coupled to newest observation", got)
 	}
+	if got := link.Attributes["event_type"]; got != "newer-event" {
+		t.Fatalf("coalesced link event_type = %q, want newer-event coupled to newest observation", got)
+	}
+	if got := link.Attributes["outcome_result"]; got != "newer-event" {
+		t.Fatalf("coalesced link outcome_result = %q, want newer-event coupled to newest observation", got)
+	}
 	if got := link.Attributes["target"]; got != "older-event" {
 		t.Fatalf("coalesced link non-observation attribute target = %q, want older-event latest write", got)
+	}
+}
+
+func TestMergeStringMapClearsOlderObservationMetadataMissingFromNewerAt(t *testing.T) {
+	merged := mergeStringMap(
+		map[string]string{
+			"at":             "2026-05-10T10:00:00Z",
+			"event_id":       "older-event",
+			"outcome_reason": "older reason",
+			"transaction_id": "older-txn",
+			"target":         "repo",
+		},
+		map[string]string{
+			"at":       "2026-05-11T10:00:00Z",
+			"event_id": "newer-event",
+		},
+	)
+	for key, want := range map[string]string{
+		"at":       "2026-05-11T10:00:00Z",
+		"event_id": "newer-event",
+		"target":   "repo",
+	} {
+		if got := merged[key]; got != want {
+			t.Fatalf("merged[%s] = %q, want %q", key, got, want)
+		}
+	}
+	for _, key := range []string{"outcome_reason", "transaction_id"} {
+		if got, exists := merged[key]; exists {
+			t.Fatalf("merged[%s] = %q, want missing because newer observation omitted it", key, got)
+		}
 	}
 }
 

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1131,6 +1131,13 @@ func mergeGraphAttributes(existing map[string]string, incoming map[string]string
 		merged[key] = value
 	}
 	incomingIsOlderObservation := graphIncomingObservationIsOlder(existing, incoming)
+	if !incomingIsOlderObservation && graphIncomingObservationIsNewer(existing, incoming) {
+		for key := range merged {
+			if graphAttributeCoupledToObservationTime(key) {
+				delete(merged, key)
+			}
+		}
+	}
 	for key, value := range incoming {
 		if incomingIsOlderObservation && graphAttributeCoupledToObservationTime(key) {
 			continue
@@ -1157,9 +1164,23 @@ func graphIncomingObservationIsOlder(existing map[string]string, incoming map[st
 	return incomingT.Before(existingT)
 }
 
+func graphIncomingObservationIsNewer(existing map[string]string, incoming map[string]string) bool {
+	existingAt := strings.TrimSpace(existing["at"])
+	incomingAt := strings.TrimSpace(incoming["at"])
+	if existingAt == "" || incomingAt == "" {
+		return false
+	}
+	existingT, errExisting := time.Parse(time.RFC3339, existingAt)
+	incomingT, errIncoming := time.Parse(time.RFC3339, incomingAt)
+	if errExisting != nil || errIncoming != nil {
+		return false
+	}
+	return incomingT.After(existingT)
+}
+
 func graphAttributeCoupledToObservationTime(key string) bool {
 	switch key {
-	case "action", "event_id", "programmatic_access_type", "source_event_id", "source_runtime_id", "transport_protocol_name":
+	case "action", "actor_type", "classification", "client_ip", "event_id", "event_type", "grant_type", "incident_status", "mitigation_status", "oauth_event_category", "outcome_reason", "outcome_result", "programmatic_access_type", "source_event_id", "source_runtime_id", "transaction_id", "transport_protocol_name":
 		return true
 	default:
 		return false

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -349,27 +349,68 @@ func TestMergeGraphAttributesKeepsObservationMetadataCoupledToLatestAt(t *testin
 		map[string]string{
 			"at":                       newer,
 			"action":                   "git.clone",
+			"event_type":               "user.lifecycle.update",
 			"event_id":                 "newer-event",
+			"outcome_result":           "SUCCESS",
 			"programmatic_access_type": "Fine-grained personal access token",
 			"source_runtime_id":        "writer-github-audit",
+			"transaction_id":           "newer-txn",
 		},
 		map[string]string{
 			"at":                       older,
 			"action":                   "workflows.completed_workflow_run",
+			"event_type":               "user.session.start",
 			"event_id":                 "older-event",
+			"outcome_result":           "FAILURE",
 			"programmatic_access_type": "GitHub App server-to-server token",
 			"source_runtime_id":        "writer-github-audit-writerinternal",
+			"transaction_id":           "older-txn",
 		},
 	)
 	for key, want := range map[string]string{
 		"at":                       newer,
 		"action":                   "git.clone",
+		"event_type":               "user.lifecycle.update",
 		"event_id":                 "newer-event",
+		"outcome_result":           "SUCCESS",
 		"programmatic_access_type": "Fine-grained personal access token",
 		"source_runtime_id":        "writer-github-audit",
+		"transaction_id":           "newer-txn",
 	} {
 		if got := merged[key]; got != want {
 			t.Fatalf("merged[%s] = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestMergeGraphAttributesClearsOlderObservationMetadataMissingFromNewerAt(t *testing.T) {
+	older := time.Date(2025, time.March, 1, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	newer := time.Date(2025, time.March, 5, 9, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	merged := mergeGraphAttributes(
+		map[string]string{
+			"at":             older,
+			"event_id":       "older-event",
+			"outcome_reason": "older reason",
+			"transaction_id": "older-txn",
+			"target":         "repo",
+		},
+		map[string]string{
+			"at":       newer,
+			"event_id": "newer-event",
+		},
+	)
+	for key, want := range map[string]string{
+		"at":       newer,
+		"event_id": "newer-event",
+		"target":   "repo",
+	} {
+		if got := merged[key]; got != want {
+			t.Fatalf("merged[%s] = %q, want %q", key, got, want)
+		}
+	}
+	for _, key := range []string{"outcome_reason", "transaction_id"} {
+		if got, exists := merged[key]; exists {
+			t.Fatalf("merged[%s] = %q, want missing because newer observation omitted it", key, got)
 		}
 	}
 }

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -58,6 +58,7 @@ type FindingRecord struct {
 	CheckID           string
 	CheckName         string
 	ControlRefs       []FindingControlRef
+	GraphEvidenceRows []*cerebrov1.GraphEvidenceRow
 	FindingWorkflow
 	Attributes      map[string]string
 	FirstObservedAt time.Time

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -840,12 +840,10 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), oauthClientURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
 		if resourceURN != "" {
-			addLink(links, projectedLink(tenantID, event.GetSourceId(), oauthClientURN, resourceURN, relationActedOn, map[string]string{
-				"event_id":             event.GetId(),
-				"event_type":           strings.TrimSpace(attributes["event_type"]),
-				"oauth_event_category": strings.TrimSpace(attributes["oauth_event_category"]),
-				"grant_type":           strings.TrimSpace(attributes["grant_type"]),
-			}))
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), oauthClientURN, resourceURN, relationActedOn, oktaAuditRelationAttributes(event, attributes, map[string]string{
+				"oauth_event_category": attributes["oauth_event_category"],
+				"grant_type":           attributes["grant_type"],
+			})))
 		}
 	}
 
@@ -866,17 +864,33 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
-		if resourceURN != "" {
-			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, map[string]string{
-				"event_id":   event.GetId(),
-				"event_type": strings.TrimSpace(attributes["event_type"]),
-			}))
+		if resourceURN != "" && resourceURN != actorURN {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, oktaAuditRelationAttributes(event, attributes, nil)))
 		}
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorAlternateID, event.GetOccurredAt())
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
+}
+
+func oktaAuditRelationAttributes(event *cerebrov1.EventEnvelope, attributes map[string]string, extra map[string]string) map[string]string {
+	relationAttrs := map[string]string{
+		"event_id":   event.GetId(),
+		"event_type": strings.TrimSpace(attributes["event_type"]),
+	}
+	addProjectedAttribute(relationAttrs, "outcome_result", strings.TrimSpace(attributes["outcome_result"]))
+	addProjectedAttribute(relationAttrs, "outcome_reason", strings.TrimSpace(attributes["outcome_reason"]))
+	addProjectedAttribute(relationAttrs, "transaction_id", strings.TrimSpace(attributes["transaction_id"]))
+	addProjectedAttribute(relationAttrs, "client_ip", strings.TrimSpace(attributes["client_ip"]))
+	addProjectedAttribute(relationAttrs, "source_runtime_id", strings.TrimSpace(attributes["source_runtime_id"]))
+	if occurredAt := event.GetOccurredAt(); occurredAt != nil && occurredAt.IsValid() {
+		relationAttrs["at"] = occurredAt.AsTime().UTC().Format(time.RFC3339)
+	}
+	for key, value := range extra {
+		addProjectedAttribute(relationAttrs, key, strings.TrimSpace(value))
+	}
+	return relationAttrs
 }
 
 func entitiesAndLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink) ([]*ports.ProjectedEntity, []*ports.ProjectedLink) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -288,6 +288,78 @@ func TestProjectOktaOAuthGrantAsApplicationTelemetry(t *testing.T) {
 	assertProjectedLink(t, state, clientURN, relationBelongsTo, "urn:cerebro:writer:okta_org:writer.okta.com")
 }
 
+func TestProjectOktaAuditSuppressesSelfActedOnEdge(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "okta-self",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.audit",
+		Attributes: map[string]string{
+			"domain":             "writer.okta.com",
+			"event_type":         "user.session.start",
+			"actor_id":           "00u-user",
+			"actor_type":         "User",
+			"actor_alternate_id": "alice@writer.com",
+			"resource_id":        "00u-user",
+			"resource_type":      "User",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	userURN := "urn:cerebro:writer:okta_user:00u-user"
+	assertProjectedLinkMissing(t, state, userURN, relationActedOn, userURN)
+}
+
+func TestProjectOktaAuditActedOnEdgesCarryTemporalContext(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	occurred := time.Date(2026, time.May, 12, 1, 2, 3, 0, time.UTC)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "okta-action",
+		TenantId:   "writer",
+		SourceId:   "okta",
+		Kind:       "okta.audit",
+		OccurredAt: timestamppb.New(occurred),
+		Attributes: map[string]string{
+			"domain":             "writer.okta.com",
+			"event_type":         "user.lifecycle.update",
+			"actor_id":           "00u-actor",
+			"actor_type":         "User",
+			"actor_alternate_id": "admin@writer.com",
+			"resource_id":        "00u-target",
+			"resource_type":      "User",
+			"outcome_result":     "SUCCESS",
+			"transaction_id":     "txn-1",
+			"client_ip":          "203.0.113.10",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	actorURN := "urn:cerebro:writer:okta_user:00u-actor"
+	targetURN := "urn:cerebro:writer:okta_user:00u-target"
+	link, ok := state.links[actorURN+"|"+relationActedOn+"|"+targetURN]
+	if !ok {
+		t.Fatalf("acted_on link missing for %s -> %s: %#v", actorURN, targetURN, state.links)
+	}
+	for key, want := range map[string]string{
+		"at":             occurred.Format(time.RFC3339),
+		"event_type":     "user.lifecycle.update",
+		"outcome_result": "SUCCESS",
+		"transaction_id": "txn-1",
+		"client_ip":      "203.0.113.10",
+	} {
+		if got := link.Attributes[key]; got != want {
+			t.Fatalf("link.Attributes[%q] = %q, want %q", key, got, want)
+		}
+	}
+}
+
 func TestProjectGitHubAuditSOTASignalsToGraph(t *testing.T) {
 	events := []struct {
 		id       string

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -2,6 +2,7 @@ package sourceprojection
 
 import (
 	"strings"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
@@ -68,6 +69,8 @@ func sentinelOneAgentProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 			"account_id":        strings.TrimSpace(attrs["account_id"]),
 			"account_name":      strings.TrimSpace(attrs["account_name"]),
 			"tenant_host":       strings.TrimSpace(attrs["tenant_host"]),
+			"event_id":          event.GetId(),
+			"at":                eventObservedAt(event),
 		},
 	})
 
@@ -115,6 +118,11 @@ func sentinelOneThreatProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 			"site_id":               strings.TrimSpace(attrs["site_id"]),
 			"group_id":              strings.TrimSpace(attrs["group_id"]),
 			"tenant_host":           strings.TrimSpace(attrs["tenant_host"]),
+			"threat_name":           strings.TrimSpace(attrs["threat_name"]),
+			"is_infected":           strings.TrimSpace(attrs["is_infected"]),
+			"active_threats":        strings.TrimSpace(attrs["active_threats"]),
+			"event_id":              event.GetId(),
+			"at":                    eventObservedAt(event),
 		},
 	})
 
@@ -128,18 +136,23 @@ func sentinelOneThreatProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 			EntityType: sentinelOneEntityAgent,
 			Label:      firstNonEmpty(attrs["computer_name"], attrs["agent_name"], agentID),
 			Attributes: map[string]string{
-				"agent_id":      agentID,
-				"computer_name": strings.TrimSpace(attrs["computer_name"]),
-				"os_name":       strings.TrimSpace(attrs["agent_os_name"]),
-				"os_type":       strings.TrimSpace(attrs["agent_os_type"]),
-				"is_active":     strings.TrimSpace(attrs["is_active"]),
-				"site_id":       strings.TrimSpace(attrs["site_id"]),
-				"group_id":      strings.TrimSpace(attrs["group_id"]),
-				"tenant_host":   strings.TrimSpace(attrs["tenant_host"]),
+				"agent_id":       agentID,
+				"computer_name":  strings.TrimSpace(attrs["computer_name"]),
+				"os_name":        strings.TrimSpace(attrs["agent_os_name"]),
+				"os_type":        strings.TrimSpace(attrs["agent_os_type"]),
+				"is_active":      strings.TrimSpace(attrs["is_active"]),
+				"is_infected":    strings.TrimSpace(attrs["is_infected"]),
+				"active_threats": strings.TrimSpace(attrs["active_threats"]),
+				"site_id":        strings.TrimSpace(attrs["site_id"]),
+				"group_id":       strings.TrimSpace(attrs["group_id"]),
+				"tenant_host":    strings.TrimSpace(attrs["tenant_host"]),
+				"event_id":       event.GetId(),
+				"at":             eventObservedAt(event),
 			},
 		})
 		addLink(links, projectedLink(tenant, event.GetSourceId(), agentURN, threatURN, relationAffectedBy, map[string]string{
 			"event_id":          event.GetId(),
+			"at":                eventObservedAt(event),
 			"classification":    strings.TrimSpace(attrs["classification"]),
 			"analyst_verdict":   strings.TrimSpace(attrs["analyst_verdict"]),
 			"incident_status":   strings.TrimSpace(attrs["incident_status"]),
@@ -282,16 +295,18 @@ func sentinelOneActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pr
 			"user_id":             strings.TrimSpace(attrs["user_id"]),
 			"os_family":           strings.TrimSpace(attrs["os_family"]),
 			"tenant_host":         strings.TrimSpace(attrs["tenant_host"]),
+			"event_id":            event.GetId(),
+			"at":                  eventObservedAt(event),
 		},
 	})
 
 	if agentID := strings.TrimSpace(attrs["agent_id"]); agentID != "" {
 		agentURN := sentinelOneAgentURN(tenant, agentID)
-		addLink(links, projectedLink(tenant, event.GetSourceId(), activityURN, agentURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
+		addLink(links, projectedLink(tenant, event.GetSourceId(), activityURN, agentURN, relationObservedOn, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
 	}
 	if threatID := strings.TrimSpace(attrs["threat_id"]); threatID != "" {
 		threatURN := sentinelOneThreatURN(tenant, threatID)
-		addLink(links, projectedLink(tenant, event.GetSourceId(), activityURN, threatURN, relationActedOn, map[string]string{"event_id": event.GetId()}))
+		addLink(links, projectedLink(tenant, event.GetSourceId(), activityURN, threatURN, relationActedOn, map[string]string{"event_id": event.GetId(), "at": eventObservedAt(event)}))
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -438,4 +453,11 @@ func sentinelOneGroupURN(tenant string, groupID string) string {
 
 func sentinelOneAccountURN(tenant string, accountID string) string {
 	return projectionURN(tenant, "sentinelone_account", accountID)
+}
+
+func eventObservedAt(event *cerebrov1.EventEnvelope) string {
+	if event == nil || event.GetOccurredAt() == nil || !event.GetOccurredAt().IsValid() {
+		return ""
+	}
+	return event.GetOccurredAt().AsTime().UTC().Format(time.RFC3339)
 }

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -159,7 +159,26 @@ message GetFindingEvaluationRunResponse {
   FindingEvaluationRun run = 1;
 }
 
-// FindingEvidence links one persisted finding and one evaluation run to its supporting claims, events, and graph roots.
+// GraphEvidencePath captures one supporting graph edge for a graph-backed finding.
+message GraphEvidencePath {
+  string from_urn = 1;
+  string from_label = 2;
+  string from_type = 3;
+  string relation = 4;
+  string to_urn = 5;
+  string to_label = 6;
+  string to_type = 7;
+  map<string, string> attributes = 8;
+}
+
+// GraphEvidenceRow captures one rule-specific graph row and its supporting paths.
+message GraphEvidenceRow {
+  string label = 1;
+  map<string, string> attributes = 2;
+  repeated GraphEvidencePath paths = 3;
+}
+
+// FindingEvidence links one persisted finding and one evaluation run to its supporting claims, events, graph roots, and graph rows.
 message FindingEvidence {
   string id = 1;
   string runtime_id = 2;
@@ -170,6 +189,7 @@ message FindingEvidence {
   repeated string event_ids = 7;
   repeated string graph_root_urns = 8;
   google.protobuf.Timestamp created_at = 9;
+  repeated GraphEvidenceRow graph_rows = 10;
 }
 
 // ListFindingEvidenceRequest queries persisted finding evidence for one stored runtime.


### PR DESCRIPTION
## Summary
- add persisted graph evidence rows/paths for graph-backed finding evidence
- convert SentinelOne active infection and stale-agent findings to current-state graph rules with grouped evidence
- enrich GitHub identity findings with access context and improve Okta/SentinelOne graph temporal hygiene

## Validation
- make verify
