### PR TITLE
feat(sourceruntime): lease cursor advances across API replicas

### DIFF
--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1052,7 +1052,9 @@ func (a *App) handleSyncSourceRuntime(w http.ResponseWriter, r *http.Request) {
 		writeSourceRuntimeError(w, err)
 		return
 	}
-	response, err := a.runtimeService().Sync(r.Context(), request)
+	response, err := a.runtimeService().SyncWithLease(r.Context(), request, sourceruntime.SyncWithLeaseOptions{
+		LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore),
+	})
 	if err != nil {
 		writeSourceRuntimeError(w, err)
 		return
@@ -1467,7 +1469,9 @@ func (s *bootstrapService) SyncSourceRuntime(ctx context.Context, req *connect.R
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetId(), false); err != nil {
 		return nil, sourceRuntimeConnectError(err)
 	}
-	response, err := newRuntimeService(s.deps, s.sources).Sync(ctx, req.Msg)
+	response, err := newRuntimeService(s.deps, s.sources).SyncWithLease(ctx, req.Msg, sourceruntime.SyncWithLeaseOptions{
+		LeaseStore: sourceRuntimeLeaseStore(s.deps.StateStore),
+	})
 	if err != nil {
 		return nil, sourceRuntimeConnectError(err)
 	}
@@ -2331,6 +2335,8 @@ func writeSourceRuntimeError(w http.ResponseWriter, err error) {
 		statusCode = http.StatusForbidden
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound), errors.Is(err, sourceops.ErrSourceNotFound):
 		statusCode = http.StatusNotFound
+	case errors.Is(err, sourceruntime.ErrSyncInProgress):
+		statusCode = http.StatusConflict
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable
 	case errors.Is(err, sourceruntime.ErrInvalidRequest), errors.Is(err, graphquery.ErrInvalidRequest), errors.Is(err, errInvalidHTTPRequest):
@@ -2343,6 +2349,8 @@ func sourceRuntimeConnectError(err error) error {
 	switch {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound), errors.Is(err, sourceops.ErrSourceNotFound):
 		return connect.NewError(connect.CodeNotFound, err)
+	case errors.Is(err, sourceruntime.ErrSyncInProgress):
+		return connect.NewError(connect.CodeAborted, err)
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable):
 		return connect.NewError(connect.CodeUnavailable, err)
 	case errors.Is(err, sourceruntime.ErrInvalidRequest):
@@ -2605,6 +2613,18 @@ func sourceRuntimeStore(store ports.StateStore) ports.SourceRuntimeStore {
 		return nil
 	}
 	return runtimeStore
+}
+
+// sourceRuntimeLeaseStore returns the StateStore's lease coordinator when
+// the underlying implementation supports it. The API's Sync handler uses
+// this to serialize cursor advances across replicas; CLI and single-task
+// callers receive nil and fall through to a plain Sync.
+func sourceRuntimeLeaseStore(store ports.StateStore) ports.SourceRuntimeLeaseStore {
+	leaseStore, ok := store.(ports.SourceRuntimeLeaseStore)
+	if !ok || isNilInterface(leaseStore) {
+		return nil
+	}
+	return leaseStore
 }
 
 func sourceProjectionStateStore(store ports.StateStore) ports.ProjectionStateStore {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -559,6 +560,43 @@ type stubRuntimeStore struct {
 	findingEvaluationRuns           map[string]*cerebrov1.FindingEvaluationRun
 	findingEvaluationRunListRequest ports.ListFindingEvaluationRunsRequest
 	reportRuns                      map[string]*cerebrov1.ReportRun
+}
+
+// leaseAwareRuntimeStore embeds stubRuntimeStore and additionally
+// implements ports.SourceRuntimeLeaseStore so the bootstrap layer's
+// SyncWithLease path can be exercised end-to-end. holdsAll=true makes
+// every Acquire fail; tests use this to drive the lease-held conflict
+// path.
+type leaseAwareRuntimeStore struct {
+	*stubRuntimeStore
+	mu       sync.Mutex
+	holder   string
+	holdsAll bool
+}
+
+func (s *leaseAwareRuntimeStore) AcquireSourceRuntimeLease(_ context.Context, _ string, owner string, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.holdsAll && s.holder != owner {
+		return false, nil
+	}
+	s.holder = owner
+	return true, nil
+}
+
+func (s *leaseAwareRuntimeStore) RenewSourceRuntimeLease(_ context.Context, _ string, owner string, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.holder == owner, nil
+}
+
+func (s *leaseAwareRuntimeStore) ReleaseSourceRuntimeLease(_ context.Context, _ string, owner string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.holder == owner {
+		s.holder = ""
+	}
+	return nil
 }
 
 func (s *stubRuntimeStore) Ping(context.Context) error { return s.err }
@@ -2661,6 +2699,69 @@ func TestConnectSourceRuntimeEndpointsResolveEnvReferences(t *testing.T) {
 	}
 	if source.readToken != "resolved-token" {
 		t.Fatalf("connect sync read token = %q, want resolved-token", source.readToken)
+	}
+}
+
+func TestSyncSourceRuntimeReturnsConflictWhenLeaseHeld(t *testing.T) {
+	source := &bootstrapTokenSource{id: "runtime_token"}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	runtimeStore := &leaseAwareRuntimeStore{
+		stubRuntimeStore: &stubRuntimeStore{
+			runtimes: map[string]*cerebrov1.SourceRuntime{
+				"writer-runtime-token": {
+					Id:       "writer-runtime-token",
+					SourceId: "runtime_token",
+					TenantId: "writer",
+				},
+			},
+		},
+		holder:   "other-task",
+		holdsAll: true,
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  &recordingAppendLog{},
+		StateStore: runtimeStore,
+	}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	t.Run("http", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-runtime-token/sync", nil)
+		if err != nil {
+			t.Fatalf("NewRequest() error = %v", err)
+		}
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			t.Fatalf("Do() error = %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("StatusCode = %d, want %d", resp.StatusCode, http.StatusConflict)
+		}
+	})
+
+	t.Run("connect", func(t *testing.T) {
+		client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+		_, err := client.SyncSourceRuntime(context.Background(), connect.NewRequest(&cerebrov1.SyncSourceRuntimeRequest{
+			Id: "writer-runtime-token",
+		}))
+		if err == nil {
+			t.Fatal("SyncSourceRuntime() error = nil, want non-nil")
+		}
+		var connectErr *connect.Error
+		if !errors.As(err, &connectErr) {
+			t.Fatalf("SyncSourceRuntime() error %v is not *connect.Error", err)
+		}
+		if connectErr.Code() != connect.CodeAborted {
+			t.Fatalf("SyncSourceRuntime() code = %v, want %v", connectErr.Code(), connect.CodeAborted)
+		}
+	})
+
+	if source.readToken != "" {
+		t.Fatalf("source.Read should not have been called while lease was held; readToken = %q", source.readToken)
 	}
 }
 

--- a/internal/sourceruntime/lease.go
+++ b/internal/sourceruntime/lease.go
@@ -85,10 +85,15 @@ func (s *Service) SyncWithLease(ctx context.Context, req *cerebrov1.SyncSourceRu
 		return nil, fmt.Errorf("acquire source runtime lease %q: %w", runtimeID, err)
 	}
 	if !acquired {
+		if s.store != nil {
+			if _, lookupErr := s.lookupRuntime(ctx, runtimeID); lookupErr != nil {
+				return nil, lookupErr
+			}
+		}
 		return nil, fmt.Errorf("%w: %s", ErrSyncInProgress, runtimeID)
 	}
 	syncCtx, cancelSync := context.WithCancel(ctx)
-	stopRenewal := startLeaseRenewal(ctx, opts.LeaseStore, runtimeID, owner, ttl, cancelSync)
+	stopRenewal := startLeaseRenewal(syncCtx, opts.LeaseStore, runtimeID, owner, ttl, cancelSync)
 	response, syncErr := s.Sync(syncCtx, req)
 	cancelSync()
 	renewalErr := stopRenewal()

--- a/internal/sourceruntime/lease.go
+++ b/internal/sourceruntime/lease.go
@@ -1,0 +1,163 @@
+package sourceruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	// DefaultLeaseTTL bounds how long a single Sync call may hold a runtime
+	// lease before the lease is considered abandoned and another caller
+	// can acquire it. The orchestrator uses the same value when it leases
+	// runtimes for its iteration; matching it here keeps cross-task
+	// coordination behavior predictable when the API and the orchestrator
+	// race for the same runtime.
+	DefaultLeaseTTL = 30 * time.Minute
+
+	// LeaseReleaseTimeout bounds the best-effort lease release on shutdown
+	// paths so a slow database cannot block the caller indefinitely.
+	LeaseReleaseTimeout = 5 * time.Second
+)
+
+// ErrSyncInProgress is returned by SyncWithLease when the runtime is
+// already leased by another worker (API task, orchestrator, or other API
+// task). Callers should treat it as a soft conflict and retry after the
+// holder finishes; HTTP and connect adapters map it to a 409/Aborted.
+var ErrSyncInProgress = errors.New("source runtime sync is in progress")
+
+// SyncWithLeaseOptions configures cross-task locking around Sync.
+//
+// LeaseStore is the durable lease coordinator. When nil, SyncWithLease
+// falls back to plain Sync so callers that are statically single-task
+// (CLI, single-replica deployments) keep working without changes.
+type SyncWithLeaseOptions struct {
+	LeaseStore ports.SourceRuntimeLeaseStore
+	LeaseOwner string
+	LeaseTTL   time.Duration
+}
+
+// SyncWithLease wraps Sync with a durable, renewable runtime lease so the
+// cursor advance is safe when several API replicas (or the API and the
+// orchestrator) try to sync the same runtime concurrently.
+//
+// Behavior:
+//
+//   - Acquire fails fast with ErrSyncInProgress when another holder has a
+//     valid lease; the caller decides whether to retry.
+//   - A background goroutine renews the lease every TTL/2 so a long pull
+//     (paginated GitHub backfill, slow projection) does not lose the
+//     lease mid-stream. Renewal failure cancels the Sync context so the
+//     work stops promptly and the cursor is not advanced after another
+//     task has taken over.
+//   - Release runs on a detached timeout-bounded context so it still
+//     happens when the parent context is already cancelled.
+func (s *Service) SyncWithLease(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequest, opts SyncWithLeaseOptions) (*cerebrov1.SyncSourceRuntimeResponse, error) {
+	if s == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	if opts.LeaseStore == nil {
+		return s.Sync(ctx, req)
+	}
+	runtimeID := ""
+	if req != nil {
+		runtimeID = strings.TrimSpace(req.GetId())
+	}
+	if runtimeID == "" {
+		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
+	}
+	owner := strings.TrimSpace(opts.LeaseOwner)
+	if owner == "" {
+		owner = DefaultAPILeaseOwner()
+	}
+	ttl := opts.LeaseTTL
+	if ttl <= 0 {
+		ttl = DefaultLeaseTTL
+	}
+	acquired, err := opts.LeaseStore.AcquireSourceRuntimeLease(ctx, runtimeID, owner, ttl)
+	if err != nil {
+		return nil, fmt.Errorf("acquire source runtime lease %q: %w", runtimeID, err)
+	}
+	if !acquired {
+		return nil, fmt.Errorf("%w: %s", ErrSyncInProgress, runtimeID)
+	}
+	syncCtx, cancelSync := context.WithCancel(ctx)
+	stopRenewal := startLeaseRenewal(ctx, opts.LeaseStore, runtimeID, owner, ttl, cancelSync)
+	response, syncErr := s.Sync(syncCtx, req)
+	cancelSync()
+	renewalErr := stopRenewal()
+	releaseErr := releaseLease(ctx, opts.LeaseStore, runtimeID, owner)
+	if syncErr != nil {
+		return nil, syncErr
+	}
+	if renewalErr != nil {
+		return nil, fmt.Errorf("renew source runtime lease %q: %w", runtimeID, renewalErr)
+	}
+	if releaseErr != nil {
+		return nil, fmt.Errorf("release source runtime lease %q: %w", runtimeID, releaseErr)
+	}
+	return response, nil
+}
+
+// DefaultAPILeaseOwner returns an owner identifier suitable for the API
+// service. The pid+nanos suffix keeps owners unique across both replicas
+// on the same host (rare in ECS, common in local dev) and across rapid
+// restarts.
+func DefaultAPILeaseOwner() string {
+	hostname, err := os.Hostname()
+	if err != nil || strings.TrimSpace(hostname) == "" {
+		hostname = "unknown-host"
+	}
+	return fmt.Sprintf("cerebro-api:%s:%d:%d", hostname, os.Getpid(), time.Now().UnixNano())
+}
+
+func startLeaseRenewal(ctx context.Context, store ports.SourceRuntimeLeaseStore, runtimeID string, owner string, ttl time.Duration, cancelWork context.CancelFunc) func() error {
+	if cancelWork == nil {
+		cancelWork = func() {}
+	}
+	renewCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	interval := ttl / 2
+	if interval <= 0 {
+		interval = ttl
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-renewCtx.Done():
+				done <- nil
+				return
+			case <-ticker.C:
+				renewed, err := store.RenewSourceRuntimeLease(renewCtx, runtimeID, owner, ttl)
+				if err != nil {
+					cancelWork()
+					done <- err
+					return
+				}
+				if !renewed {
+					cancelWork()
+					done <- fmt.Errorf("source runtime lease lost: %s", runtimeID)
+					return
+				}
+			}
+		}
+	}()
+	return func() error {
+		cancel()
+		return <-done
+	}
+}
+
+func releaseLease(parent context.Context, store ports.SourceRuntimeLeaseStore, runtimeID string, owner string) error {
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(parent), LeaseReleaseTimeout)
+	defer cancel()
+	return store.ReleaseSourceRuntimeLease(releaseCtx, runtimeID, owner)
+}

--- a/internal/sourceruntime/lease_test.go
+++ b/internal/sourceruntime/lease_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 type leaseEvent struct {
@@ -122,6 +123,15 @@ func TestSyncWithLeaseReturnsErrSyncInProgressWhenNotAcquired(t *testing.T) {
 	}
 }
 
+func TestSyncWithLeasePreservesNotFoundWhenAcquireRejectsMissingRuntime(t *testing.T) {
+	service := New(nil, &runtimeStore{}, nil, nil)
+	store := &stubLeaseStore{rejectNext: true}
+	_, err := service.SyncWithLease(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "missing-runtime"}, SyncWithLeaseOptions{LeaseStore: store})
+	if !errors.Is(err, ports.ErrSourceRuntimeNotFound) {
+		t.Fatalf("SyncWithLease() err = %v, want %v", err, ports.ErrSourceRuntimeNotFound)
+	}
+}
+
 func TestSyncWithLeaseAcquiresAndReleasesAroundSync(t *testing.T) {
 	service := New(nil, nil, nil, nil)
 	store := &stubLeaseStore{}
@@ -163,6 +173,18 @@ func TestSyncWithLeaseRefusesSecondHolderWhileLeased(t *testing.T) {
 		if ev.verb == "release" {
 			t.Fatalf("SyncWithLease() released a lease it never acquired: %#v", events)
 		}
+	}
+}
+
+func TestStartLeaseRenewalStopsWhenSyncContextCancels(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	store := &stubLeaseStore{renewErr: errors.New("renew should not run after sync stops")}
+	stopRenewal := startLeaseRenewal(parent, store, "runtime-a", "owner-a", time.Hour, func() {})
+
+	cancel()
+
+	if err := stopRenewal(); err != nil {
+		t.Fatalf("stopRenewal() err = %v, want nil", err)
 	}
 }
 

--- a/internal/sourceruntime/lease_test.go
+++ b/internal/sourceruntime/lease_test.go
@@ -1,0 +1,232 @@
+package sourceruntime
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+type leaseEvent struct {
+	verb     string
+	owner    string
+	acquired bool
+}
+
+type stubLeaseStore struct {
+	mu sync.Mutex
+
+	heldBy     string
+	holdUntil  time.Time
+	rejectNext bool
+
+	acquireErr error
+	renewErr   error
+	releaseErr error
+
+	events []leaseEvent
+}
+
+func (s *stubLeaseStore) AcquireSourceRuntimeLease(_ context.Context, runtimeID string, owner string, ttl time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.acquireErr != nil {
+		return false, s.acquireErr
+	}
+	if s.rejectNext {
+		s.rejectNext = false
+		s.events = append(s.events, leaseEvent{verb: "acquire", owner: owner, acquired: false})
+		return false, nil
+	}
+	now := time.Now()
+	if s.heldBy != "" && s.heldBy != owner && s.holdUntil.After(now) {
+		s.events = append(s.events, leaseEvent{verb: "acquire", owner: owner, acquired: false})
+		return false, nil
+	}
+	s.heldBy = owner
+	s.holdUntil = now.Add(ttl)
+	_ = runtimeID
+	s.events = append(s.events, leaseEvent{verb: "acquire", owner: owner, acquired: true})
+	return true, nil
+}
+
+func (s *stubLeaseStore) RenewSourceRuntimeLease(_ context.Context, runtimeID string, owner string, ttl time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.renewErr != nil {
+		return false, s.renewErr
+	}
+	if s.heldBy != owner {
+		s.events = append(s.events, leaseEvent{verb: "renew", owner: owner, acquired: false})
+		return false, nil
+	}
+	s.holdUntil = time.Now().Add(ttl)
+	_ = runtimeID
+	s.events = append(s.events, leaseEvent{verb: "renew", owner: owner, acquired: true})
+	return true, nil
+}
+
+func (s *stubLeaseStore) ReleaseSourceRuntimeLease(_ context.Context, runtimeID string, owner string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.releaseErr != nil {
+		return s.releaseErr
+	}
+	if s.heldBy == owner {
+		s.heldBy = ""
+	}
+	_ = runtimeID
+	s.events = append(s.events, leaseEvent{verb: "release", owner: owner, acquired: true})
+	return nil
+}
+
+func (s *stubLeaseStore) snapshotEvents() []leaseEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]leaseEvent, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+func TestSyncWithLeaseFallsThroughWhenLeaseStoreIsNil(t *testing.T) {
+	service := New(nil, nil, nil, nil)
+	_, err := service.SyncWithLease(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-a"}, SyncWithLeaseOptions{})
+	if !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("SyncWithLease() err = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}
+
+func TestSyncWithLeaseRejectsMissingRuntimeID(t *testing.T) {
+	service := New(nil, nil, nil, nil)
+	store := &stubLeaseStore{}
+	_, err := service.SyncWithLease(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{}, SyncWithLeaseOptions{LeaseStore: store})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("SyncWithLease() err = %v, want %v", err, ErrInvalidRequest)
+	}
+}
+
+func TestSyncWithLeaseReturnsErrSyncInProgressWhenNotAcquired(t *testing.T) {
+	service := New(nil, nil, nil, nil)
+	store := &stubLeaseStore{rejectNext: true}
+	_, err := service.SyncWithLease(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-a"}, SyncWithLeaseOptions{LeaseStore: store})
+	if !errors.Is(err, ErrSyncInProgress) {
+		t.Fatalf("SyncWithLease() err = %v, want %v", err, ErrSyncInProgress)
+	}
+	events := store.snapshotEvents()
+	if len(events) != 1 || events[0].verb != "acquire" || events[0].acquired {
+		t.Fatalf("SyncWithLease() events = %#v, want one rejected acquire", events)
+	}
+}
+
+func TestSyncWithLeaseAcquiresAndReleasesAroundSync(t *testing.T) {
+	service := New(nil, nil, nil, nil)
+	store := &stubLeaseStore{}
+	_, err := service.SyncWithLease(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-a"}, SyncWithLeaseOptions{LeaseStore: store})
+	// The inner Sync should fail with ErrRuntimeUnavailable because the
+	// service has no store/appendlog, but the lease must still be acquired
+	// and released around it; that is what this test asserts.
+	if !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("SyncWithLease() err = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+	events := store.snapshotEvents()
+	if len(events) < 2 {
+		t.Fatalf("SyncWithLease() events = %#v, want at least acquire and release", events)
+	}
+	if events[0].verb != "acquire" || !events[0].acquired {
+		t.Fatalf("first event = %#v, want successful acquire", events[0])
+	}
+	last := events[len(events)-1]
+	if last.verb != "release" {
+		t.Fatalf("last event = %#v, want release", last)
+	}
+}
+
+func TestSyncWithLeaseRefusesSecondHolderWhileLeased(t *testing.T) {
+	service := New(nil, nil, nil, nil)
+	store := &stubLeaseStore{
+		heldBy:    "holder-a",
+		holdUntil: time.Now().Add(time.Minute),
+	}
+	_, err := service.SyncWithLease(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-a"}, SyncWithLeaseOptions{
+		LeaseStore: store,
+		LeaseOwner: "holder-b",
+	})
+	if !errors.Is(err, ErrSyncInProgress) {
+		t.Fatalf("SyncWithLease() err = %v, want ErrSyncInProgress", err)
+	}
+	events := store.snapshotEvents()
+	for _, ev := range events {
+		if ev.verb == "release" {
+			t.Fatalf("SyncWithLease() released a lease it never acquired: %#v", events)
+		}
+	}
+}
+
+func TestSyncWithLeaseSerializesConcurrentCallers(t *testing.T) {
+	store := &stubLeaseStore{}
+	service := New(nil, nil, nil, nil)
+	var (
+		successCount  atomic.Int64
+		conflictCount atomic.Int64
+		wg            sync.WaitGroup
+	)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := service.SyncWithLease(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-shared"}, SyncWithLeaseOptions{
+				LeaseStore: store,
+				LeaseOwner: defaultOwnerFromIndex(i),
+				LeaseTTL:   time.Second,
+			})
+			switch {
+			case errors.Is(err, ErrSyncInProgress):
+				conflictCount.Add(1)
+			case errors.Is(err, ErrRuntimeUnavailable):
+				// inner Sync stub is unavailable; success path from the lease
+				// perspective.
+				successCount.Add(1)
+			default:
+				t.Errorf("unexpected SyncWithLease err = %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if successCount.Load()+conflictCount.Load() != 8 {
+		t.Fatalf("success=%d conflict=%d, want sum=8", successCount.Load(), conflictCount.Load())
+	}
+	if successCount.Load() == 0 {
+		t.Fatalf("no caller acquired the lease in 8 concurrent attempts; events=%#v", store.snapshotEvents())
+	}
+}
+
+func defaultOwnerFromIndex(i int) string {
+	return "owner-" + time.Now().Format("150405.000000") + ":" + itoa(i)
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	negative := false
+	if i < 0 {
+		negative = true
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if negative {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}


### PR DESCRIPTION
## Why

Before this PR the orchestrator was the only caller that serialized its work behind the postgres `source_runtimes.lease_owner` / `lease_expires_at` columns. The API `/source-runtimes/{id}/sync` HTTP handler and `SyncSourceRuntime` connect RPC went straight to `Service.Sync` without acquiring the lease.

That meant two API replicas calling `Sync` against the same runtime would each load the same `next_cursor` snapshot, pull the same upstream page, append duplicate events to the append log, and race the cursor advance (last-write-wins). The Pulumi guardrail `cerebro:apiMaxInstances=1` in WriterInternal/cerebro was the only thing keeping that from happening in production.

## What

- New `internal/sourceruntime/lease.go`:
  - `Service.SyncWithLease(ctx, req, opts)` wraps `Sync` with acquire / renew / release of the existing lease primitive.
  - `ErrSyncInProgress` is returned when another holder has a valid lease so callers can retry.
  - Renewal runs every TTL/2 in a goroutine; renewal failure cancels the Sync context so the work stops promptly and does not advance the cursor after another worker has taken over.
  - Release uses a detached timeout-bounded context so it fires even when the parent ctx is cancelled.
  - `DefaultLeaseTTL = 30 min`, matching the orchestrator.
- `SyncWithLease` falls through to plain `Sync` when the StateStore does not satisfy `ports.SourceRuntimeLeaseStore` so CLI / single-task callers see no behavior change.
- `internal/bootstrap/app.go` routes both the HTTP handler and the connect handler through `SyncWithLease`; a new `sourceRuntimeLeaseStore` helper type-asserts the lease coordinator off the existing `StateStore`.
- Error mapping: `ErrSyncInProgress` -> 409 Conflict on HTTP, `connect.CodeAborted` on RPC.

## Tests

- `internal/sourceruntime/lease_test.go` (6 cases):
  - Lease-store-nil fallthrough.
  - Missing runtime id rejected.
  - `ErrSyncInProgress` when `AcquireSourceRuntimeLease` returns false.
  - Acquire-then-release ordering on the happy path.
  - No release attempted when acquire fails.
  - 8-way concurrent acquire exercises the serialization contract.
- `internal/bootstrap/app_test.go`:
  - `TestSyncSourceRuntimeReturnsConflictWhenLeaseHeld` with both `/http` and `/connect` subtests + a new `leaseAwareRuntimeStore` test stub.

`make verify` is fully green (tests + golangci-lint + buf lint + custom linters + archtests).

## Sequencing for cross-task scale-up

1. Merge this PR
2. Tag `v2.1.25` from `writer/cerebro` main via the existing Cut Release workflow
3. Open a paired WriterInternal/cerebro PR that bumps `cerebro:apiMaxInstances` (sec-dev first, then go-prod) and pins to `v2.1.25`

The orchestrator already uses the same lease primitive, so this PR is a no-op for the scheduled task path.

## Risk

- Single-task / CLI callers see no behavior change (the lease branch is opt-in through the StateStore type assertion).
- Multi-task API callers now see a 409/Aborted on a true conflict; clients can retry. Existing single-task deployments will never see this because no second holder exists.
- The renewal goroutine derives its context from the request ctx; cancellation, renewal loss, or release errors are all reported through the existing error path.