### PR TITLE
fix(grc): link vulnerabilities to targets

### DIFF
--- a/internal/graphrebuild/memory_graph.go
+++ b/internal/graphrebuild/memory_graph.go
@@ -74,8 +74,12 @@ func (s *memoryGraphStore) UpsertProjectedEntity(_ context.Context, entity *port
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	label := strings.TrimSpace(entity.Label)
+	fallbackLabel := label == ""
 	if label == "" {
 		label = urn
+	}
+	if existing, ok := s.entities[urn]; ok && fallbackLabel {
+		label = existing.Label
 	}
 	s.entities[urn] = memoryEntity{
 		URN:        urn,

--- a/internal/graphrebuild/memory_graph_test.go
+++ b/internal/graphrebuild/memory_graph_test.go
@@ -1,0 +1,39 @@
+package graphrebuild
+
+import (
+	"context"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestMemoryGraphStorePreservesExistingLabelsForFallbackLabels(t *testing.T) {
+	store, err := newMemoryGraphStore()
+	if err != nil {
+		t.Fatalf("newMemoryGraphStore() error = %v", err)
+	}
+	scratch := store.(*memoryGraphStore)
+	urn := "urn:cerebro:writer:source:vanta:integration:integration-1"
+
+	if err := scratch.UpsertProjectedEntity(context.Background(), &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   "writer",
+		SourceID:   "grc",
+		EntityType: "source",
+		Label:      "GitHub Dependabot",
+	}); err != nil {
+		t.Fatalf("UpsertProjectedEntity(named) error = %v", err)
+	}
+	if err := scratch.UpsertProjectedEntity(context.Background(), &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   "writer",
+		SourceID:   "grc",
+		EntityType: "source",
+	}); err != nil {
+		t.Fatalf("UpsertProjectedEntity(fallback) error = %v", err)
+	}
+
+	if got := scratch.entities[urn].Label; got != "GitHub Dependabot" {
+		t.Fatalf("memory graph label = %q, want GitHub Dependabot", got)
+	}
+}

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -20,6 +20,14 @@ import (
 const defaultIngestRunListLimit = 25
 const maxAttributeMergeRetries = 5
 const defaultProjectionCleanupLimit = 1000
+const mergeEntityAndLoadAttributesQuery = `MERGE (e:Entity {urn: $urn})
+ON CREATE SET e.attributes_json = '{}', e.attributes_version = 0
+SET e.tenant_id = $tenant_id,
+    e.source_id = $source_id,
+    e.runtime_id = CASE WHEN $runtime_id <> '' THEN $runtime_id ELSE coalesce(e.runtime_id, '') END,
+    e.entity_type = $entity_type,
+    e.label = CASE WHEN $label <> $urn THEN $label ELSE coalesce(e.label, $label) END
+RETURN coalesce(e.attributes_json, '{}'), coalesce(e.attributes_version, 0)`
 
 var errConcurrentAttributeMerge = errors.New("concurrent attribute merge")
 
@@ -973,14 +981,7 @@ func normalizeCleanupEntityTypes(values []string) []string {
 }
 
 func mergeEntityAndLoadAttributes(ctx context.Context, tx neo4jdriver.ManagedTransaction, params map[string]any) (string, int64, error) {
-	result, err := tx.Run(ctx, `MERGE (e:Entity {urn: $urn})
-ON CREATE SET e.attributes_json = '{}', e.attributes_version = 0
-SET e.tenant_id = $tenant_id,
-    e.source_id = $source_id,
-    e.runtime_id = CASE WHEN $runtime_id <> '' THEN $runtime_id ELSE coalesce(e.runtime_id, '') END,
-    e.entity_type = $entity_type,
-    e.label = $label
-RETURN coalesce(e.attributes_json, '{}'), coalesce(e.attributes_version, 0)`, params)
+	result, err := tx.Run(ctx, mergeEntityAndLoadAttributesQuery, params)
 	if err != nil {
 		return "", 0, err
 	}

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -30,6 +30,12 @@ func TestOpenRejectsIncompleteConfig(t *testing.T) {
 	}
 }
 
+func TestProjectedEntityMergePreservesExistingLabelsForFallbackLabels(t *testing.T) {
+	if !strings.Contains(mergeEntityAndLoadAttributesQuery, "e.label = CASE WHEN $label <> $urn THEN $label ELSE coalesce(e.label, $label) END") {
+		t.Fatalf("entity merge does not preserve existing labels for fallback labels:\n%s", mergeEntityAndLoadAttributesQuery)
+	}
+}
+
 func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	if os.Getenv("CEREBRO_RUN_NEO4J_DOCKER") != "1" {
 		t.Skip("set CEREBRO_RUN_NEO4J_DOCKER=1 to run Neo4j Docker integration test")

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -225,6 +225,9 @@ func grcVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	}
 	integrationID := firstAttribute(attrs, "integration_id")
 	integrationURN := grcIntegrationURN(tenantID, provider, integrationID)
+	if integrationURN != "" {
+		addEntity(entities, grcIntegrationReferenceEntity(tenantID, event.GetSourceId(), integrationURN, integrationID, provider))
+	}
 	targetID := firstAttribute(attrs, "target_id", "resource_id", "asset_id", "endpoint_id")
 	targetURN := grcTargetURN(tenantID, provider, targetID)
 	if targetURN != "" {
@@ -295,6 +298,20 @@ func grcIntegrationEntity(tenantID string, sourceID string, urn string, integrat
 		EntityType: "source",
 		Label:      firstAttribute(attrs, "display_name", "integration_name", "integration_id"),
 		Attributes: grcAttributes(attrs, map[string]string{
+			"canonical_name": integrationID,
+			"source_system":  provider,
+			"source_type":    "grc_integration",
+		}),
+	}
+}
+
+func grcIntegrationReferenceEntity(tenantID string, sourceID string, urn string, integrationID string, provider string) *ports.ProjectedEntity {
+	return &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "source",
+		Attributes: grcAttributes(nil, map[string]string{
 			"canonical_name": integrationID,
 			"source_system":  provider,
 			"source_type":    "grc_integration",

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -209,6 +209,7 @@ func grcVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 		return nil, nil, err
 	}
 	attrs := event.GetAttributes()
+	provider := grcProvider(attrs)
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 	vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), attrs)
@@ -219,13 +220,32 @@ func grcVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 			SourceID:   event.GetSourceId(),
 			EntityType: "vulnerability",
 			Label:      firstAttribute(attrs, "name", "vulnerability_id"),
-			Attributes: map[string]string{"source_system": grcProvider(attrs)},
+			Attributes: map[string]string{"source_system": provider},
 		})
+	}
+	integrationID := firstAttribute(attrs, "integration_id")
+	integrationURN := grcIntegrationURN(tenantID, provider, integrationID)
+	if integrationURN != "" {
+		addEntity(entities, grcIntegrationReferenceEntity(tenantID, event.GetSourceId(), integrationURN, integrationID, provider))
+	}
+	targetID := firstAttribute(attrs, "target_id", "resource_id", "asset_id", "endpoint_id")
+	targetURN := grcTargetURN(tenantID, provider, targetID)
+	if targetURN != "" {
+		addEntity(entities, grcTargetEntity(tenantID, event.GetSourceId(), targetURN, targetID, attrs, provider))
+		if vulnerabilityURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attrs)))
+		}
+		if integrationURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, integrationURN, relationBelongsTo, grcIntegrationLinkAttributes(event, integrationID)))
+		}
 	}
 	packageURN := vulnerabilityPackageURN(tenantID, attrs, "grc")
 	canonicalPackageURN := addCanonicalPackageEntity(entities, tenantID, event.GetSourceId(), attrs, "grc")
 	if packageURN != "" {
 		addVulnerablePackageEntity(entities, tenantID, event.GetSourceId(), packageURN, attrs, "grc")
+		if targetURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, packageURN, relationContains, grcPackageTargetAttributes(event, attrs)))
+		}
 		if vulnerabilityURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attrs)))
 		}
@@ -238,6 +258,79 @@ func grcVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	}
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
+}
+
+func grcTargetURN(tenantID string, provider string, targetID string) string {
+	return projectionURN(tenantID, "grc_target", provider, targetID)
+}
+
+func grcTargetEntity(tenantID string, sourceID string, urn string, targetID string, attrs map[string]string, provider string) *ports.ProjectedEntity {
+	return &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "grc.target",
+		Label:      firstAttribute(attrs, "target_name", "resource_name", "hostname", "target_id", "resource_id"),
+		Attributes: grcAttributes(nil, map[string]string{
+			"integration_id": firstAttribute(attrs, "integration_id"),
+			"source_system":  provider,
+			"target_id":      targetID,
+			"target_type":    firstAttribute(attrs, "target_type", "resource_type", "asset_type"),
+		}),
+	}
+}
+
+func grcIntegrationURN(tenantID string, provider string, integrationID string) string {
+	return projectionURN(tenantID, "source", provider, "integration", integrationID)
+}
+
+func grcIntegrationEntity(tenantID string, sourceID string, urn string, integrationID string, attrs map[string]string, provider string) *ports.ProjectedEntity {
+	return &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "source",
+		Label:      firstAttribute(attrs, "display_name", "integration_name", "integration_id"),
+		Attributes: grcAttributes(attrs, map[string]string{
+			"canonical_name": integrationID,
+			"source_system":  provider,
+			"source_type":    "grc_integration",
+		}),
+	}
+}
+
+func grcIntegrationReferenceEntity(tenantID string, sourceID string, urn string, integrationID string, provider string) *ports.ProjectedEntity {
+	return &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "source",
+		Label:      integrationID,
+		Attributes: grcAttributes(nil, map[string]string{
+			"canonical_name": integrationID,
+			"source_system":  provider,
+			"source_type":    "grc_integration",
+		}),
+	}
+}
+
+func grcIntegrationLinkAttributes(event *cerebrov1.EventEnvelope, integrationID string) map[string]string {
+	return map[string]string{
+		"event_id":        event.GetId(),
+		"integration_id":  integrationID,
+		"relationship":    relationBelongsTo,
+		"relationship_by": "grc_vulnerability",
+	}
+}
+
+func grcPackageTargetAttributes(event *cerebrov1.EventEnvelope, attrs map[string]string) map[string]string {
+	return map[string]string{
+		"event_id":      event.GetId(),
+		"package":       vulnerablePackageName(attrs),
+		"target_id":     firstAttribute(attrs, "target_id", "resource_id", "asset_id", "endpoint_id"),
+		"version":       firstAttribute(attrs, "version", "package_version", "application_version", "installed_version"),
+		"source_system": firstAttribute(attrs, "source_system", "provider", "source_provider"),
+	}
 }
 
 func grcRiskScenarioProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -343,19 +436,8 @@ func grcIntegrationProjections(event *cerebrov1.EventEnvelope) ([]*ports.Project
 	}
 	provider := grcProvider(attrs)
 	entities := map[string]*ports.ProjectedEntity{}
-	sourceURN := projectionURN(tenantID, "source", provider, "integration", integrationID)
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        sourceURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "source",
-		Label:      firstAttribute(attrs, "display_name", "integration_id"),
-		Attributes: grcAttributes(attrs, map[string]string{
-			"canonical_name": integrationID,
-			"source_system":  provider,
-			"source_type":    "grc_integration",
-		}),
-	})
+	sourceURN := grcIntegrationURN(tenantID, provider, integrationID)
+	addEntity(entities, grcIntegrationEntity(tenantID, event.GetSourceId(), sourceURN, integrationID, attrs, provider))
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, nil)
 	return projectedEntities, projectedLinks, nil
 }

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -225,9 +225,6 @@ func grcVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	}
 	integrationID := firstAttribute(attrs, "integration_id")
 	integrationURN := grcIntegrationURN(tenantID, provider, integrationID)
-	if integrationURN != "" {
-		addEntity(entities, grcIntegrationReferenceEntity(tenantID, event.GetSourceId(), integrationURN, integrationID, provider))
-	}
 	targetID := firstAttribute(attrs, "target_id", "resource_id", "asset_id", "endpoint_id")
 	targetURN := grcTargetURN(tenantID, provider, targetID)
 	if targetURN != "" {
@@ -298,21 +295,6 @@ func grcIntegrationEntity(tenantID string, sourceID string, urn string, integrat
 		EntityType: "source",
 		Label:      firstAttribute(attrs, "display_name", "integration_name", "integration_id"),
 		Attributes: grcAttributes(attrs, map[string]string{
-			"canonical_name": integrationID,
-			"source_system":  provider,
-			"source_type":    "grc_integration",
-		}),
-	}
-}
-
-func grcIntegrationReferenceEntity(tenantID string, sourceID string, urn string, integrationID string, provider string) *ports.ProjectedEntity {
-	return &ports.ProjectedEntity{
-		URN:        urn,
-		TenantID:   tenantID,
-		SourceID:   sourceID,
-		EntityType: "source",
-		Label:      integrationID,
-		Attributes: grcAttributes(nil, map[string]string{
 			"canonical_name": integrationID,
 			"source_system":  provider,
 			"source_type":    "grc_integration",

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -261,6 +261,9 @@ func grcVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 }
 
 func grcTargetURN(tenantID string, provider string, targetID string) string {
+	if strings.TrimSpace(targetID) == "" {
+		return ""
+	}
 	return projectionURN(tenantID, "grc_target", provider, targetID)
 }
 
@@ -281,6 +284,9 @@ func grcTargetEntity(tenantID string, sourceID string, urn string, targetID stri
 }
 
 func grcIntegrationURN(tenantID string, provider string, integrationID string) string {
+	if strings.TrimSpace(integrationID) == "" {
+		return ""
+	}
 	return projectionURN(tenantID, "source", provider, "integration", integrationID)
 }
 

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -362,35 +362,18 @@ func TestProjectGRCVulnerabilityLinksTargetPackageAndIntegration(t *testing.T) {
 	if got := state.entities[targetURN].Attributes["integration_id"]; got != "integration-1" {
 		t.Fatalf("target integration_id = %q, want integration-1", got)
 	}
+	if entity := state.entities[integrationURN]; entity == nil || entity.EntityType != "source" {
+		t.Fatalf("GRC integration source reference missing: %#v", entity)
+	}
 	assertProjectedLink(t, state, targetURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, targetURN, relationContains, packageURN)
 	assertProjectedLink(t, state, targetURN, relationBelongsTo, integrationURN)
 }
 
 func TestProjectGRCVulnerabilityDoesNotRegressIntegrationLabel(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-
 	integrationURN := "urn:cerebro:writer:source:vanta:integration:integration-1"
-	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
-		Id:       "grc-integration-integration-1",
-		TenantId: "writer",
-		SourceId: "grc",
-		Kind:     "grc.integration",
-		Attributes: map[string]string{
-			"provider":       "vanta",
-			"integration_id": "integration-1",
-			"display_name":   "GitHub Dependabot",
-		},
-	})
-	if err != nil {
-		t.Fatalf("Project(integration) error = %v", err)
-	}
-	if got := state.entities[integrationURN].Label; got != "GitHub Dependabot" {
-		t.Fatalf("integration label before vulnerability = %q, want GitHub Dependabot", got)
-	}
-
-	_, err = service.Project(context.Background(), &cerebrov1.EventEnvelope{
+	targetURN := "urn:cerebro:writer:grc_target:vanta:target-1"
+	entities, links, err := grcVulnerabilityProjections(&cerebrov1.EventEnvelope{
 		Id:       "grc-vulnerability-vuln-1",
 		TenantId: "writer",
 		SourceId: "grc",
@@ -405,11 +388,28 @@ func TestProjectGRCVulnerabilityDoesNotRegressIntegrationLabel(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Project(vulnerability) error = %v", err)
+		t.Fatalf("grcVulnerabilityProjections() error = %v", err)
 	}
 
-	if got := state.entities[integrationURN].Label; got != "GitHub Dependabot" {
-		t.Fatalf("integration label after vulnerability = %q, want GitHub Dependabot", got)
+	var integrationLabel string
+	integrationFound := false
+	for _, entity := range entities {
+		if entity.URN == integrationURN {
+			integrationFound = true
+			integrationLabel = entity.Label
+			break
+		}
 	}
-	assertProjectedLink(t, state, "urn:cerebro:writer:grc_target:vanta:target-1", relationBelongsTo, integrationURN)
+	if !integrationFound {
+		t.Fatalf("integration reference entity missing: %#v", entities)
+	}
+	if integrationLabel != "" {
+		t.Fatalf("integration reference label = %q, want empty fallback-preserving label", integrationLabel)
+	}
+	for _, link := range links {
+		if link.FromURN == targetURN && link.Relation == relationBelongsTo && link.ToURN == integrationURN {
+			return
+		}
+	}
+	t.Fatalf("target belongs_to integration link missing: %#v", links)
 }

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -362,10 +362,54 @@ func TestProjectGRCVulnerabilityLinksTargetPackageAndIntegration(t *testing.T) {
 	if got := state.entities[targetURN].Attributes["integration_id"]; got != "integration-1" {
 		t.Fatalf("target integration_id = %q, want integration-1", got)
 	}
-	if entity := state.entities[integrationURN]; entity == nil || entity.EntityType != "source" {
-		t.Fatalf("GRC integration source entity missing: %#v", entity)
-	}
 	assertProjectedLink(t, state, targetURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, targetURN, relationContains, packageURN)
 	assertProjectedLink(t, state, targetURN, relationBelongsTo, integrationURN)
+}
+
+func TestProjectGRCVulnerabilityDoesNotRegressIntegrationLabel(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	integrationURN := "urn:cerebro:writer:source:vanta:integration:integration-1"
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-integration-integration-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.integration",
+		Attributes: map[string]string{
+			"provider":       "vanta",
+			"integration_id": "integration-1",
+			"display_name":   "GitHub Dependabot",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project(integration) error = %v", err)
+	}
+	if got := state.entities[integrationURN].Label; got != "GitHub Dependabot" {
+		t.Fatalf("integration label before vulnerability = %q, want GitHub Dependabot", got)
+	}
+
+	_, err = service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerability-vuln-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerability",
+		Attributes: map[string]string{
+			"provider":         "vanta",
+			"vulnerability_id": "vuln-1",
+			"name":             "CVE-2026-4242",
+			"package":          "example/module",
+			"target_id":        "target-1",
+			"integration_id":   "integration-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project(vulnerability) error = %v", err)
+	}
+
+	if got := state.entities[integrationURN].Label; got != "GitHub Dependabot" {
+		t.Fatalf("integration label after vulnerability = %q, want GitHub Dependabot", got)
+	}
+	assertProjectedLink(t, state, "urn:cerebro:writer:grc_target:vanta:target-1", relationBelongsTo, integrationURN)
 }

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -290,6 +290,42 @@ func TestProjectGRCVulnerabilityUsesCanonicalVulnerability(t *testing.T) {
 	}
 }
 
+func TestProjectGRCVulnerabilitySkipsMissingTargetAndIntegrationIDs(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerability-vuln-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerability",
+		Attributes: map[string]string{
+			"provider":         "vanta",
+			"vulnerability_id": "vuln-1",
+			"name":             "CVE-2026-4242",
+			"package":          "example/module",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	targetURN := "urn:cerebro:writer:grc_target:vanta"
+	integrationURN := "urn:cerebro:writer:source:vanta:integration"
+	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+	packageURN := "urn:cerebro:writer:package:grc:example/module"
+
+	if entity := state.entities[targetURN]; entity != nil {
+		t.Fatalf("phantom GRC target entity = %#v, want nil", entity)
+	}
+	if entity := state.entities[integrationURN]; entity != nil {
+		t.Fatalf("phantom GRC integration entity = %#v, want nil", entity)
+	}
+	assertProjectedLinkMissing(t, state, targetURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLinkMissing(t, state, targetURN, relationContains, packageURN)
+	assertProjectedLinkMissing(t, state, targetURN, relationBelongsTo, integrationURN)
+}
+
 func TestProjectGRCVulnerabilityLinksTargetPackageAndIntegration(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -289,3 +289,47 @@ func TestProjectGRCVulnerabilityUsesCanonicalVulnerability(t *testing.T) {
 		t.Fatalf("affected_by remediate_by_date = %q, want deadline", got)
 	}
 }
+
+func TestProjectGRCVulnerabilityLinksTargetPackageAndIntegration(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerability-vuln-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerability",
+		Attributes: map[string]string{
+			"provider":           "vanta",
+			"vulnerability_id":   "vuln-1",
+			"name":               "CVE-2026-4242",
+			"package":            "example/module",
+			"package_purl":       "pkg:golang/example/module@1.2.3",
+			"severity":           "HIGH",
+			"target_id":          "target-1",
+			"integration_id":     "integration-1",
+			"vulnerability_type": "package",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	targetURN := "urn:cerebro:writer:grc_target:vanta:target-1"
+	integrationURN := "urn:cerebro:writer:source:vanta:integration:integration-1"
+	packageURN := "urn:cerebro:writer:package:grc:example/module"
+	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+
+	if entity := state.entities[targetURN]; entity == nil || entity.EntityType != "grc.target" {
+		t.Fatalf("GRC target entity missing: %#v", entity)
+	}
+	if got := state.entities[targetURN].Attributes["integration_id"]; got != "integration-1" {
+		t.Fatalf("target integration_id = %q, want integration-1", got)
+	}
+	if entity := state.entities[integrationURN]; entity == nil || entity.EntityType != "source" {
+		t.Fatalf("GRC integration source entity missing: %#v", entity)
+	}
+	assertProjectedLink(t, state, targetURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, targetURN, relationContains, packageURN)
+	assertProjectedLink(t, state, targetURN, relationBelongsTo, integrationURN)
+}

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -50,7 +50,7 @@ DO UPDATE SET
   source_id = EXCLUDED.source_id,
   runtime_id = CASE WHEN EXCLUDED.runtime_id <> '' THEN EXCLUDED.runtime_id ELSE entities.runtime_id END,
   entity_type = EXCLUDED.entity_type,
-  label = EXCLUDED.label,
+  label = CASE WHEN EXCLUDED.label = EXCLUDED.urn THEN entities.label ELSE EXCLUDED.label END,
   attributes_json = entities.attributes_json || EXCLUDED.attributes_json,
   updated_at = NOW()`
 }

--- a/internal/statestore/postgres/projection_test.go
+++ b/internal/statestore/postgres/projection_test.go
@@ -52,6 +52,13 @@ func TestProjectionUpsertsMergeAttributes(t *testing.T) {
 	}
 }
 
+func TestProjectionUpsertsPreserveExistingLabelsForFallbackLabels(t *testing.T) {
+	entitySQL := projectedEntityUpsertSQL()
+	if !strings.Contains(entitySQL, "label = CASE WHEN EXCLUDED.label = EXCLUDED.urn THEN entities.label ELSE EXCLUDED.label END") {
+		t.Fatalf("entity upsert does not preserve existing labels for fallback labels:\n%s", entitySQL)
+	}
+}
+
 func TestProjectedLinkDeleteUsesPrimaryKey(t *testing.T) {
 	linkSQL := projectedLinkDeleteSQL()
 	if !strings.Contains(linkSQL, "WHERE from_urn = $1 AND relation = $2 AND to_urn = $3") {

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -316,6 +316,12 @@ func TestReadVantaVulnerabilityNormalizesFields(t *testing.T) {
 	if got := attrs["remediate_by_date"]; got != "2026-05-30T00:00:00Z" {
 		t.Fatalf("remediate_by_date = %q, want deadline", got)
 	}
+	if got := attrs["target_id"]; got != "target-1" {
+		t.Fatalf("target_id = %q, want target-1", got)
+	}
+	if got := attrs["integration_id"]; got != "integration-1" {
+		t.Fatalf("integration_id = %q, want integration-1", got)
+	}
 }
 
 func TestTokenCacheScopesRuntimeSecretsAndBaseURL(t *testing.T) {
@@ -598,6 +604,8 @@ func newTestAPIHandler(t *testing.T) http.Handler {
 				"packageIdentifier": "pkg:golang/example/module@1.2.3",
 				"severity":          "HIGH",
 				"cvssSeverityScore": 8.7,
+				"targetId":          "target-1",
+				"integrationId":     "integration-1",
 				"isFixable":         true,
 				"remediateByDate":   "2026-05-30T00:00:00Z",
 				"lastDetectedDate":  "2026-05-10T00:00:00Z",


### PR DESCRIPTION
## Summary
- Add GRC target entities for vulnerability target IDs.
- Link GRC vulnerability targets to vulnerabilities, affected packages, and source integrations.
- Reuse GRC integration source projection helpers and assert target/integration field normalization.

## Tests
- go test ./internal/sourceprojection ./sources/grc
- make verify
