### PR TITLE
fix(findings): serialize evidence history upserts

### DIFF
--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -88,6 +88,10 @@ DO UPDATE SET
   updated_at = NOW()`
 }
 
+func findingEvidenceAdvisoryLockSQL() string {
+	return `SELECT pg_advisory_xact_lock(hashtext('finding_evidence'), hashtext($1))`
+}
+
 // PutFindingEvidence upserts one durable finding evidence record.
 func (s *Store) PutFindingEvidence(ctx context.Context, evidence *cerebrov1.FindingEvidence) error {
 	if evidence == nil {
@@ -136,6 +140,10 @@ func (s *Store) PutFindingEvidence(ctx context.Context, evidence *cerebrov1.Find
 			_ = tx.Rollback()
 		}
 	}()
+	// Serialize same-ID first writes before the preflight read so history merges cannot race.
+	if _, err := tx.ExecContext(ctx, findingEvidenceAdvisoryLockSQL(), id); err != nil {
+		return fmt.Errorf("lock finding evidence %q: %w", id, err)
+	}
 	var existingPayload string
 	if err := tx.QueryRowContext(ctx, `SELECT finding_evidence_json::text FROM finding_evidence WHERE id = $1 FOR UPDATE`, id).Scan(&existingPayload); err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -112,6 +112,19 @@ func TestFindingEvidenceUpsertPreservesCreatedAtOnConflict(t *testing.T) {
 	}
 }
 
+func TestFindingEvidenceAdvisoryLockSerializesHistoryMerges(t *testing.T) {
+	query := findingEvidenceAdvisoryLockSQL()
+	for _, fragment := range []string{
+		"pg_advisory_xact_lock",
+		"hashtext('finding_evidence')",
+		"hashtext($1)",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("finding evidence advisory lock query missing %q:\n%s", fragment, query)
+		}
+	}
+}
+
 func TestFindingEvidenceSchemaPersistsEnrichedEvidence(t *testing.T) {
 	joined := strings.Join(ensureFindingEvidenceStatements, "\n")
 	for _, fragment := range []string{


### PR DESCRIPTION
## Summary
- address Droid review feedback from #555 about concurrent first inserts losing evidence history
- take a Postgres transaction-scoped advisory lock per evidence ID before the preflight merge read
- add coverage for the advisory lock query

## Validation
- make verify