### PR TITLE
test(grc): verify vulnerability graph links

### DIFF
--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -88,8 +88,8 @@ func TestRegistryForRuntimeFiltersSupportedRules(t *testing.T) {
 
 func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	packs := builtinRulePacks()
-	if got := len(packs); got != 7 {
-		t.Fatalf("len(builtinRulePacks()) = %d, want 7", got)
+	if got := len(packs); got != 8 {
+		t.Fatalf("len(builtinRulePacks()) = %d, want 8", got)
 	}
 	rules := flattenRulePacks(packs)
 	if got := len(rules); got < 10 {
@@ -140,6 +140,9 @@ func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	}
 	if _, ok := registry.Get(sentinelOneEndpointActiveInfectionRuleID); !ok {
 		t.Fatalf("registry missing %q", sentinelOneEndpointActiveInfectionRuleID)
+	}
+	if _, ok := registry.Get(vulnViewActionableExternalFindingRuleID); !ok {
+		t.Fatalf("registry missing %q", vulnViewActionableExternalFindingRuleID)
 	}
 	if _, ok := registry.Get(dataSensitiveAssetRiskRuleID); !ok {
 		t.Fatalf("registry missing %q", dataSensitiveAssetRiskRuleID)

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -89,6 +89,12 @@ func builtinRulePacks() []RulePack {
 			},
 		},
 		{
+			ID:          "vulnview",
+			Name:        "VulnView",
+			Description: "VulnView external attack-surface findings.",
+			Rules:       []Rule{newVulnViewActionableExternalFindingRule()},
+		},
+		{
 			ID:          "data",
 			Name:        "Data",
 			Description: "Sensitive data and crown-jewel findings.",

--- a/internal/findings/vulnview_signal_rule.go
+++ b/internal/findings/vulnview_signal_rule.go
@@ -1,0 +1,101 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const vulnViewActionableExternalFindingRuleID = "vulnview-actionable-external-finding"
+
+func newVulnViewActionableExternalFindingRule() Rule {
+	definition := RuleDefinition{
+		ID:                 vulnViewActionableExternalFindingRuleID,
+		Name:               "VulnView Actionable External Finding",
+		Description:        "Detect VulnView external attack-surface findings that require AppSec triage.",
+		SourceID:           "vulnview",
+		EventKinds:         []string{"vulnview.vulnerability", "vulnview.dns_alert"},
+		OutputKind:         "finding.vulnview_actionable_external_finding",
+		Severity:           "dynamic",
+		Status:             findingStatusOpen,
+		Maturity:           "test",
+		Tags:               []string{"vulnview", "appsec", "attack-surface"},
+		RequiredAttributes: []string{"severity"},
+		FingerprintFields:  []string{"template_id", "alert", "target_id", "matched_at"},
+	}
+	return newEventRule(eventRuleConfig{definition: definition, sourceID: "vulnview", match: matchesVulnViewActionableExternalFinding, build: buildVulnViewActionableExternalFinding})
+}
+
+func matchesVulnViewActionableExternalFinding(event *cerebrov1.EventEnvelope) bool {
+	if !eventKindMatcher("vulnview.vulnerability")(event) && !eventKindMatcher("vulnview.dns_alert")(event) {
+		return false
+	}
+	severity := strings.ToLower(strings.TrimSpace(event.GetAttributes()["severity"]))
+	return severity == "critical" || severity == "high" || severity == "medium"
+}
+
+func buildVulnViewActionableExternalFinding(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+	attrs := eventAttributes(event)
+	projectedContext, err := buildFindingProjectionContext(ctx, event, findingProjectionContextOptions{
+		PrimaryRelations:   []string{"has_evidence", "observed_on", "affected_by"},
+		CollectAllEntities: true,
+		ResourceFallbacks:  []string{attrs["target_name"], attrs["target_id"], attrs["host"], attrs["matched_at"], attrs["asset_id"]},
+	})
+	if err != nil {
+		return nil, err
+	}
+	observedAt := time.Time{}
+	if event.GetOccurredAt() != nil {
+		observedAt = event.GetOccurredAt().AsTime().UTC()
+	}
+	action := firstNonEmpty(attrs["name"], attrs["alert"], attrs["template_id"], attrs["external_id"], "VulnView finding")
+	target := firstNonEmpty(projectedContext.ResourceLabel, attrs["target_name"], attrs["target_id"], attrs["host"], attrs["matched_at"], "unknown target")
+	findingAttributes := map[string]string{
+		"action":               action,
+		"event_id":             strings.TrimSpace(event.GetId()),
+		"event_kind":           strings.TrimSpace(event.GetKind()),
+		"primary_resource_urn": projectedContext.PrimaryResourceURN,
+		"source_runtime_id":    strings.TrimSpace(runtime.GetId()),
+		"target":               target,
+	}
+	for key, value := range attrs {
+		if _, exists := findingAttributes[key]; !exists {
+			findingAttributes[key] = strings.TrimSpace(value)
+		}
+	}
+	definition := RuleDefinition{ID: vulnViewActionableExternalFindingRuleID, Name: "VulnView Actionable External Finding", SourceID: "vulnview", OutputKind: "finding.vulnview_actionable_external_finding", Severity: "dynamic", Status: findingStatusOpen}
+	for key, value := range definition.AttributeMap() {
+		findingAttributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(findingAttributes)
+	fingerprint := hashFindingFingerprint(
+		vulnViewActionableExternalFindingRuleID,
+		strings.TrimSpace(event.GetTenantId()),
+		firstNonEmpty(attrs["template_id"], attrs["alert"], attrs["external_id"]),
+		firstNonEmpty(attrs["target_id"], attrs["host"], attrs["asset_id"], attrs["matched_at"], projectedContext.PrimaryResourceURN),
+	)
+	return &ports.FindingRecord{
+		ID:              fingerprint,
+		Fingerprint:     fingerprint,
+		TenantID:        strings.TrimSpace(event.GetTenantId()),
+		RuntimeID:       strings.TrimSpace(runtime.GetId()),
+		RuleID:          vulnViewActionableExternalFindingRuleID,
+		Title:           "VulnView Actionable External Finding",
+		Severity:        normalizeFindingSeverity(attrs["severity"]),
+		Status:          findingStatusOpen,
+		Summary:         fmt.Sprintf("VulnView reported %s on %s", action, target),
+		ResourceURNs:    projectedContext.ResourceURNs,
+		EventIDs:        []string{strings.TrimSpace(event.GetId())},
+		PolicyID:        firstNonEmpty(attrs["template_id"], attrs["alert"], attrs["external_id"]),
+		PolicyName:      action,
+		CheckID:         vulnViewActionableExternalFindingRuleID,
+		CheckName:       "VulnView Actionable External Finding",
+		Attributes:      findingAttributes,
+		FirstObservedAt: observedAt,
+		LastObservedAt:  observedAt,
+	}, nil
+}

--- a/internal/findings/vulnview_signal_rule.go
+++ b/internal/findings/vulnview_signal_rule.go
@@ -42,6 +42,7 @@ func buildVulnViewActionableExternalFinding(ctx context.Context, runtime *cerebr
 	attrs := eventAttributes(event)
 	projectedContext, err := buildFindingProjectionContext(ctx, event, findingProjectionContextOptions{
 		PrimaryRelations:   []string{"has_evidence", "observed_on", "affected_by"},
+		PrimaryEntityType:  "external.asset",
 		CollectAllEntities: true,
 		ResourceFallbacks:  []string{attrs["target_name"], attrs["target_id"], attrs["host"], attrs["matched_at"], attrs["asset_id"]},
 	})
@@ -76,7 +77,8 @@ func buildVulnViewActionableExternalFinding(ctx context.Context, runtime *cerebr
 		vulnViewActionableExternalFindingRuleID,
 		strings.TrimSpace(event.GetTenantId()),
 		firstNonEmpty(attrs["template_id"], attrs["alert"], attrs["external_id"]),
-		firstNonEmpty(attrs["target_id"], attrs["host"], attrs["asset_id"], attrs["matched_at"], projectedContext.PrimaryResourceURN),
+		firstNonEmpty(attrs["target_id"], attrs["host"], attrs["asset_id"], projectedContext.PrimaryResourceURN),
+		attrs["matched_at"],
 	)
 	return &ports.FindingRecord{
 		ID:              fingerprint,

--- a/internal/findings/vulnview_signal_rule_test.go
+++ b/internal/findings/vulnview_signal_rule_test.go
@@ -1,0 +1,65 @@
+package findings
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestVulnViewActionableExternalFindingRule(t *testing.T) {
+	rule := newVulnViewActionableExternalFindingRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-vulnview-vulnerability", SourceId: "vulnview", TenantId: "writer"}
+	event := &cerebrov1.EventEnvelope{
+		Id:       "vulnview-vuln-1",
+		TenantId: "writer",
+		SourceId: "vulnview",
+		Kind:     "vulnview.vulnerability",
+		Attributes: map[string]string{
+			"external_id": "scan-1:exposed-panel:admin.writer.com",
+			"host":        "admin.writer.com",
+			"matched_at":  "https://admin.writer.com",
+			"name":        "Exposed Admin Panel",
+			"severity":    "high",
+			"target_id":   "admin.writer.com",
+			"template_id": "exposed-panel",
+		},
+	}
+	findings, err := rule.Evaluate(context.Background(), runtime, event)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("len(Evaluate()) = %d, want 1", len(findings))
+	}
+	finding := findings[0]
+	if finding.RuleID != vulnViewActionableExternalFindingRuleID {
+		t.Fatalf("RuleID = %q, want %q", finding.RuleID, vulnViewActionableExternalFindingRuleID)
+	}
+	if finding.Severity != "HIGH" {
+		t.Fatalf("Severity = %q, want HIGH", finding.Severity)
+	}
+	if finding.PolicyID != "exposed-panel" {
+		t.Fatalf("PolicyID = %q, want exposed-panel", finding.PolicyID)
+	}
+}
+
+func TestVulnViewActionableExternalFindingRuleIgnoresInfo(t *testing.T) {
+	rule := newVulnViewActionableExternalFindingRule()
+	findings, err := rule.Evaluate(context.Background(), &cerebrov1.SourceRuntime{Id: "writer-vulnview", SourceId: "vulnview", TenantId: "writer"}, &cerebrov1.EventEnvelope{
+		Id:       "vulnview-info-1",
+		TenantId: "writer",
+		SourceId: "vulnview",
+		Kind:     "vulnview.vulnerability",
+		Attributes: map[string]string{
+			"name":     "Technology Detection",
+			"severity": "info",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("len(Evaluate()) = %d, want 0", len(findings))
+	}
+}

--- a/internal/findings/vulnview_signal_rule_test.go
+++ b/internal/findings/vulnview_signal_rule_test.go
@@ -42,6 +42,12 @@ func TestVulnViewActionableExternalFindingRule(t *testing.T) {
 	if finding.PolicyID != "exposed-panel" {
 		t.Fatalf("PolicyID = %q, want exposed-panel", finding.PolicyID)
 	}
+	if finding.Attributes["target"] != "admin.writer.com" {
+		t.Fatalf("target = %q, want admin.writer.com", finding.Attributes["target"])
+	}
+	if finding.Attributes["primary_resource_urn"] != "urn:cerebro:writer:external_asset:admin.writer.com" {
+		t.Fatalf("primary_resource_urn = %q, want external asset", finding.Attributes["primary_resource_urn"])
+	}
 }
 
 func TestVulnViewActionableExternalFindingRuleIgnoresInfo(t *testing.T) {
@@ -61,5 +67,37 @@ func TestVulnViewActionableExternalFindingRuleIgnoresInfo(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Fatalf("len(Evaluate()) = %d, want 0", len(findings))
+	}
+}
+
+func TestVulnViewActionableExternalFindingRuleSplitsMatchedLocations(t *testing.T) {
+	rule := newVulnViewActionableExternalFindingRule()
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-vulnview-vulnerability", SourceId: "vulnview", TenantId: "writer"}
+	base := &cerebrov1.EventEnvelope{
+		Id:       "vulnview-vuln-1",
+		TenantId: "writer",
+		SourceId: "vulnview",
+		Kind:     "vulnview.vulnerability",
+		Attributes: map[string]string{
+			"host":        "app.writer.com",
+			"matched_at":  "https://app.writer.com/login",
+			"name":        "Test CVE",
+			"severity":    "high",
+			"target_id":   "app.writer.com",
+			"template_id": "cve-2026-1234",
+		},
+	}
+	first, err := rule.Evaluate(context.Background(), runtime, base)
+	if err != nil {
+		t.Fatalf("Evaluate(first) error = %v", err)
+	}
+	base.Id = "vulnview-vuln-2"
+	base.Attributes["matched_at"] = "https://app.writer.com/admin"
+	second, err := rule.Evaluate(context.Background(), runtime, base)
+	if err != nil {
+		t.Fatalf("Evaluate(second) error = %v", err)
+	}
+	if first[0].ID == second[0].ID {
+		t.Fatalf("finding IDs matched for distinct matched_at values: %q", first[0].ID)
 	}
 }

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -765,6 +765,64 @@ func TestRebuildDryRunReplaysRuntimeIntoTemporaryGraph(t *testing.T) {
 	}
 }
 
+func TestRebuildDryRunReplaysGRCVulnerabilityTargetIntegrationGraph(t *testing.T) {
+	replayer := &eventReplayer{
+		events: []*cerebrov1.EventEnvelope{
+			testRuntimeEvent("grc-integration-1", "grc.integration", "writer-grc", map[string]string{
+				"provider":       "vanta",
+				"integration_id": "integration-1",
+				"display_name":   "GitHub Dependabot",
+			}),
+			testRuntimeEvent("grc-vulnerability-1", "grc.vulnerability", "writer-grc", map[string]string{
+				"provider":         "vanta",
+				"vulnerability_id": "vuln-1",
+				"name":             "CVE-2026-4242",
+				"package":          "example/module",
+				"target_id":        "target-1",
+				"integration_id":   "integration-1",
+			}),
+		},
+	}
+	for _, event := range replayer.events {
+		event.SourceId = "grc"
+		event.TenantId = "writer"
+	}
+	service := New(nil, &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-grc": {
+				Id:       "writer-grc",
+				SourceId: "grc",
+				TenantId: "writer",
+			},
+		},
+	}, replayer)
+
+	result, err := service.RebuildDryRun(context.Background(), Request{
+		Mode:         modeReplay,
+		RuntimeID:    "writer-grc",
+		EventLimit:   2,
+		PreviewLimit: 20,
+	})
+	if err != nil {
+		t.Fatalf("RebuildDryRun() error = %v", err)
+	}
+
+	targetURN := "urn:cerebro:writer:grc_target:vanta:target-1"
+	integrationURN := "urn:cerebro:writer:source:vanta:integration:integration-1"
+	if result.GraphNodes != 5 {
+		t.Fatalf("GraphNodes = %d, want 5", result.GraphNodes)
+	}
+	if result.GraphLinks != 6 {
+		t.Fatalf("GraphLinks = %d, want 6", result.GraphLinks)
+	}
+	if !containsEntityPreview(result.PreviewEntities, integrationURN, "source", "GitHub Dependabot") {
+		t.Fatalf("PreviewEntities missing named integration: %#v", result.PreviewEntities)
+	}
+	if !containsLinkPreview(result.PreviewLinks, targetURN, "belongs_to", integrationURN) {
+		t.Fatalf("PreviewLinks missing target belongs_to integration: %#v", result.PreviewLinks)
+	}
+}
+
 func TestRebuildDryRunRejectsNilEventWithPageContext(t *testing.T) {
 	registry, err := sourcecdk.NewRegistry(&testSource{
 		spec:  &cerebrov1.SourceSpec{Id: "github", Name: "GitHub"},
@@ -891,6 +949,24 @@ func containsAssertion(assertions []*AssertionPreview, name string, actual int64
 func containsPathPatternPreview(patterns []*PathPatternPreview, label string, count int64) bool {
 	for _, pattern := range patterns {
 		if pattern != nil && pattern.Pattern == label && pattern.Count == count {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEntityPreview(entities []*EntityPreview, urn string, entityType string, label string) bool {
+	for _, entity := range entities {
+		if entity != nil && entity.URN == urn && entity.EntityType == entityType && entity.Label == label {
+			return true
+		}
+	}
+	return false
+}
+
+func containsLinkPreview(links []*LinkPreview, fromURN string, relation string, toURN string) bool {
+	for _, link := range links {
+		if link != nil && link.FromURN == fromURN && link.Relation == relation && link.ToURN == toURN {
 			return true
 		}
 	}

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -2,12 +2,31 @@ package sourceprojection
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+type endpointCheckingGraphRecorder struct {
+	projectionRecorder
+}
+
+func (r *endpointCheckingGraphRecorder) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	if r.entities[link.FromURN] == nil {
+		return fmt.Errorf("graph link source entity %q missing", link.FromURN)
+	}
+	if r.entities[link.ToURN] == nil {
+		return fmt.Errorf("graph link target entity %q missing", link.ToURN)
+	}
+	return r.projectionRecorder.UpsertProjectedLink(ctx, link)
+}
 
 func TestProjectGRCVendorWithOwner(t *testing.T) {
 	state := &projectionRecorder{}
@@ -368,6 +387,44 @@ func TestProjectGRCVulnerabilityLinksTargetPackageAndIntegration(t *testing.T) {
 	assertProjectedLink(t, state, targetURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, targetURN, relationContains, packageURN)
 	assertProjectedLink(t, state, targetURN, relationBelongsTo, integrationURN)
+}
+
+func TestProjectGRCVulnerabilityWritesGraphTargetIntegrationLinks(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &endpointCheckingGraphRecorder{}
+	service := New(state, graph)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerability-vuln-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerability",
+		Attributes: map[string]string{
+			"provider":         "vanta",
+			"vulnerability_id": "vuln-1",
+			"name":             "CVE-2026-4242",
+			"package":          "example/module",
+			"target_id":        "target-1",
+			"integration_id":   "integration-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	targetURN := "urn:cerebro:writer:grc_target:vanta:target-1"
+	integrationURN := "urn:cerebro:writer:source:vanta:integration:integration-1"
+	packageURN := "urn:cerebro:writer:package:grc:example/module"
+	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+	if graph.entities[targetURN] == nil {
+		t.Fatalf("graph target entity missing")
+	}
+	if graph.entities[integrationURN] == nil {
+		t.Fatalf("graph integration entity missing")
+	}
+	assertProjectedLink(t, &graph.projectionRecorder, targetURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, &graph.projectionRecorder, targetURN, relationContains, packageURN)
+	assertProjectedLink(t, &graph.projectionRecorder, targetURN, relationBelongsTo, integrationURN)
 }
 
 func TestProjectGRCVulnerabilityDoesNotRegressIntegrationLabel(t *testing.T) {

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -118,6 +118,9 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"sentinelone.site":                     sentinelOneSiteProjections,
 	"sentinelone.threat":                   sentinelOneThreatProjections,
 	"sentinelone.vulnerability":            sentinelOneVulnerabilityProjections,
+	"vulnview.asset":                       vulnViewAssetProjections,
+	"vulnview.dns_alert":                   vulnViewDNSAlertProjections,
+	"vulnview.vulnerability":               vulnViewVulnerabilityProjections,
 }}
 
 // BuiltinRegistry returns the default source event projector registry.

--- a/internal/sourceprojection/vulnview.go
+++ b/internal/sourceprojection/vulnview.go
@@ -1,0 +1,157 @@
+package sourceprojection
+
+import (
+	"net/url"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func vulnViewVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	assetURN := vulnViewAssetURN(tenantID, attrs)
+	if assetURN != "" {
+		addEntity(entities, vulnViewAssetEntity(tenantID, event.GetSourceId(), assetURN, attrs))
+	}
+
+	findingURN := projectionURN(tenantID, "vulnview_finding", firstAttribute(attrs, "external_id", "template_id", "name"))
+	if findingURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        findingURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "vulnview.finding",
+			Label:      firstAttribute(attrs, "name", "template_id", "external_id"),
+			Attributes: map[string]string{
+				"description": firstAttribute(attrs, "description"),
+				"matched_at":  firstAttribute(attrs, "matched_at"),
+				"scan_id":     firstAttribute(attrs, "scan_id"),
+				"scan_name":   firstAttribute(attrs, "scan_name"),
+				"severity":    firstAttribute(attrs, "severity"),
+				"site_id":     firstAttribute(attrs, "site_id"),
+				"template_id": firstAttribute(attrs, "template_id", "vulnerability_id"),
+				"type":        firstAttribute(attrs, "type", "vulnerability_type"),
+			},
+		})
+		if assetURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), assetURN, findingURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, assetURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+
+	vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), attrs)
+	if vulnerabilityURN != "" {
+		evidenceAttrs := vulnerabilityEvidenceAttributes(event, attrs)
+		if assetURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), assetURN, vulnerabilityURN, relationAffectedBy, evidenceAttrs))
+		}
+		if findingURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, vulnerabilityURN, relationAffectedBy, evidenceAttrs))
+		}
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func vulnViewAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	if assetURN := vulnViewAssetURN(tenantID, attrs); assetURN != "" {
+		addEntity(entities, vulnViewAssetEntity(tenantID, event.GetSourceId(), assetURN, attrs))
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, nil)
+	return projectedEntities, projectedLinks, nil
+}
+
+func vulnViewDNSAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	assetURN := vulnViewAssetURN(tenantID, attrs)
+	if assetURN != "" {
+		addEntity(entities, vulnViewAssetEntity(tenantID, event.GetSourceId(), assetURN, attrs))
+	}
+	alertID := firstAttribute(attrs, "external_id", "alert", "name")
+	alertURN := projectionURN(tenantID, "vulnview_dns_alert", alertID)
+	if alertURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        alertURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "vulnview.dns_alert",
+			Label:      firstAttribute(attrs, "name", "alert", "external_id"),
+			Attributes: map[string]string{
+				"alert":        firstAttribute(attrs, "alert", "name"),
+				"description":  firstAttribute(attrs, "description"),
+				"record_type":  firstAttribute(attrs, "record_type"),
+				"record_value": firstAttribute(attrs, "record_value"),
+				"severity":     firstAttribute(attrs, "severity"),
+			},
+		})
+		if assetURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), assetURN, alertURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, assetURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func vulnViewAssetURN(tenantID string, attrs map[string]string) string {
+	assetID := vulnViewAssetID(attrs)
+	if assetID == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "external_asset", assetID)
+}
+
+func vulnViewAssetID(attrs map[string]string) string {
+	raw := firstAttribute(attrs, "asset_id", "target_id", "host", "matched_at", "target_name")
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Hostname() != "" {
+		if parsed.Port() != "" {
+			return strings.ToLower(parsed.Hostname() + ":" + parsed.Port())
+		}
+		return strings.ToLower(parsed.Hostname())
+	}
+	return strings.ToLower(strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(raw, "https://"), "http://")))
+}
+
+func vulnViewAssetEntity(tenantID string, sourceID string, urn string, attrs map[string]string) *ports.ProjectedEntity {
+	assetID := vulnViewAssetID(attrs)
+	return &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "external.asset",
+		Label:      firstNonEmpty(firstAttribute(attrs, "asset_name", "target_name", "host"), assetID),
+		Attributes: map[string]string{
+			"asset_id":         assetID,
+			"asset_type":       "external_asset",
+			"findings_count":   firstAttribute(attrs, "findings_count"),
+			"highest_severity": firstAttribute(attrs, "highest_severity", "severity"),
+			"source_system":    "vulnview",
+			"sites":            firstAttribute(attrs, "sites", "site_name", "site_id"),
+		},
+	}
+}

--- a/internal/sourceprojection/vulnview_test.go
+++ b/internal/sourceprojection/vulnview_test.go
@@ -1,0 +1,86 @@
+package sourceprojection
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestProjectVulnViewVulnerabilityLinksAssetFindingAndCanonicalCVE(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "vulnview-vuln-1",
+		TenantId: "writer",
+		SourceId: "vulnview",
+		Kind:     "vulnview.vulnerability",
+		Attributes: map[string]string{
+			"external_id":      "scan-1:cve-2026-1234:https://app.writer.com/login",
+			"host":             "app.writer.com",
+			"matched_at":       "https://app.writer.com/login",
+			"name":             "Test CVE",
+			"scan_id":          "scan-1",
+			"severity":         "high",
+			"template_id":      "cve-2026-1234",
+			"vulnerability_id": "cve-2026-1234",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesProjected != 3 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 4 {
+		t.Fatalf("Project().LinksProjected = %d, want 4", result.LinksProjected)
+	}
+	assetURN := "urn:cerebro:writer:external_asset:app.writer.com"
+	findingURN := "urn:cerebro:writer:vulnview_finding:scan-1:cve-2026-1234:https://app.writer.com/login"
+	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-1234"
+	if entity := state.entities[assetURN]; entity == nil || entity.EntityType != "external.asset" {
+		t.Fatalf("external asset entity missing: %#v", entity)
+	}
+	if entity := state.entities[findingURN]; entity == nil || entity.EntityType != "vulnview.finding" {
+		t.Fatalf("finding entity missing: %#v", entity)
+	}
+	if entity := state.entities[vulnerabilityURN]; entity == nil || entity.EntityType != "vulnerability" {
+		t.Fatalf("canonical vulnerability entity missing: %#v", entity)
+	}
+	assertProjectedLink(t, state, assetURN, relationHasEvidence, findingURN)
+	assertProjectedLink(t, state, findingURN, relationObservedOn, assetURN)
+	assertProjectedLink(t, state, assetURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, findingURN, relationAffectedBy, vulnerabilityURN)
+}
+
+func TestProjectVulnViewDNSAlertLinksAssetEvidence(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "vulnview-dns-1",
+		TenantId: "writer",
+		SourceId: "vulnview",
+		Kind:     "vulnview.dns_alert",
+		Attributes: map[string]string{
+			"asset_id":    "stale.writer.com",
+			"external_id": "stale.writer.com:dangling_cname:0",
+			"name":        "dangling_cname",
+			"severity":    "high",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesProjected != 2 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 2", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 2 {
+		t.Fatalf("Project().LinksProjected = %d, want 2", result.LinksProjected)
+	}
+	assetURN := "urn:cerebro:writer:external_asset:stale.writer.com"
+	alertURN := "urn:cerebro:writer:vulnview_dns_alert:stale.writer.com:dangling_cname:0"
+	assertProjectedLink(t, state, assetURN, relationHasEvidence, alertURN)
+	assertProjectedLink(t, state, alertURN, relationObservedOn, assetURN)
+}

--- a/internal/sourceregistry/registry.go
+++ b/internal/sourceregistry/registry.go
@@ -13,6 +13,7 @@ import (
 	oktasource "github.com/writer/cerebro/sources/okta"
 	sdksource "github.com/writer/cerebro/sources/sdk"
 	sentineloneSource "github.com/writer/cerebro/sources/sentinelone"
+	vulnviewsource "github.com/writer/cerebro/sources/vulnview"
 )
 
 type builtinSourceLoader struct {
@@ -73,6 +74,12 @@ var builtinSourceLoaders = []builtinSourceLoader{
 		name: "sentinelone",
 		load: func() (sourcecdk.Source, error) {
 			return sentineloneSource.New()
+		},
+	},
+	{
+		name: "vulnview",
+		load: func() (sourcecdk.Source, error) {
+			return vulnviewsource.New()
 		},
 	},
 }

--- a/sources/vulnview/catalog.yaml
+++ b/sources/vulnview/catalog.yaml
@@ -1,0 +1,9 @@
+id: vulnview
+name: VulnView
+description: VulnView attack-surface, scan, vulnerability, asset, and DNS alert source.
+emitted_kinds:
+  - vulnview.site
+  - vulnview.scan
+  - vulnview.vulnerability
+  - vulnview.asset
+  - vulnview.dns_alert

--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -1,0 +1,1057 @@
+package vulnview
+
+import (
+	"context"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/primitives"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+//go:embed catalog.yaml
+var catalogFS embed.FS
+
+const (
+	sourceID           = "vulnview"
+	defaultBaseURL     = "https://vulnview.writer-security.com/api"
+	defaultScope       = "vulnview"
+	defaultFamily      = familyVulnerability
+	defaultPageSize    = 100
+	maxPageSize        = 500
+	httpTimeout        = 30 * time.Second
+	maxBodyBytes       = 8 << 20
+	tokenRefreshLeeway = time.Minute
+
+	familySite          = "site"
+	familyScan          = "scan"
+	familyVulnerability = "vulnerability"
+	familyAsset         = "asset"
+	familyDNSAlert      = "dns_alert"
+)
+
+// Source reads VulnView attack-surface and vulnerability data.
+type Source struct {
+	spec                 *cerebrov1.SourceSpec
+	client               *http.Client
+	families             *sourcecdk.FamilyEngine[settings]
+	allowLoopbackBaseURL bool
+	lookupIPAddrs        func(context.Context, string) ([]net.IPAddr, error)
+	mu                   sync.Mutex
+	tokenKey             string
+	accessToken          string
+	tokenExpiresAt       time.Time
+}
+
+type settings struct {
+	tenantID     string
+	family       string
+	baseURL      string
+	tokenURL     string
+	clientID     string
+	clientSecret string
+	scope        string
+	siteID       string
+	scanName     string
+	severity     string
+	search       string
+	perPage      int
+}
+
+type record struct {
+	Raw    json.RawMessage
+	Values map[string]any
+	ID     string
+}
+
+type listResponse struct {
+	Items      []json.RawMessage `json:"items"`
+	NextCursor string            `json:"nextCursor"`
+}
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+}
+
+type responseError struct {
+	statusCode int
+	message    string
+}
+
+func (e *responseError) Error() string {
+	return e.message
+}
+
+func (e *responseError) StatusCode() int {
+	return e.statusCode
+}
+
+// New constructs the VulnView source.
+func New() (*Source, error) {
+	spec, err := loadSpec()
+	if err != nil {
+		return nil, err
+	}
+	source := &Source{
+		spec:          spec,
+		lookupIPAddrs: net.DefaultResolver.LookupIPAddr,
+	}
+	source.families, err = source.newFamilyEngine()
+	if err != nil {
+		return nil, err
+	}
+	return source, nil
+}
+
+// Spec returns static VulnView source metadata.
+func (s *Source) Spec() *cerebrov1.SourceSpec {
+	return s.spec
+}
+
+// Check validates that the configured VulnView family is reachable.
+func (s *Source) Check(ctx context.Context, cfg sourcecdk.Config) error {
+	return s.families.Check(ctx, cfg)
+}
+
+// Discover returns canonical VulnView URNs for one configured page.
+func (s *Source) Discover(ctx context.Context, cfg sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return s.families.Discover(ctx, cfg)
+}
+
+// Read pages VulnView records and emits vulnview.* events.
+func (s *Source) Read(ctx context.Context, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return s.families.Read(ctx, cfg, cursor)
+}
+
+func loadSpec() (*cerebrov1.SourceSpec, error) {
+	specBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read catalog: %w", err)
+	}
+	spec, err := sourcecdk.LoadCatalog(specBytes)
+	if err != nil {
+		return nil, fmt.Errorf("load catalog: %w", err)
+	}
+	return spec, nil
+}
+
+func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
+	return sourcecdk.NewFamilyEngine(s.parseSettings, func(settings settings) string {
+		return settings.family
+	},
+		s.family(familySite, "/sites"),
+		s.family(familyScan, "/scans"),
+		s.family(familyVulnerability, "/vulnerabilities"),
+		s.family(familyAsset, "/assets"),
+		s.dnsAlertFamily(),
+	)
+}
+
+func (s *Source) family(name string, path string) sourcecdk.Family[settings] {
+	return sourcecdk.Family[settings]{
+		Name: name,
+		Check: func(ctx context.Context, settings settings) error {
+			_, _, err := s.list(ctx, settings, path, "", 1)
+			if err != nil {
+				return fmt.Errorf("vulnview %s: %w", name, err)
+			}
+			return nil
+		},
+		Discover: func(ctx context.Context, settings settings) ([]sourcecdk.URN, error) {
+			records, _, err := s.list(ctx, settings, path, "", settings.perPage)
+			if err != nil {
+				return nil, fmt.Errorf("vulnview %s: %w", name, err)
+			}
+			return urnsFor(settings, name, records)
+		},
+		Read: func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+			records, next, err := s.list(ctx, settings, path, strings.TrimSpace(cursor.GetOpaque()), settings.perPage)
+			if err != nil {
+				return sourcecdk.Pull{}, fmt.Errorf("vulnview %s: %w", name, err)
+			}
+			return pullFromRecords(settings, name, records, next)
+		},
+	}
+}
+
+func (s *Source) dnsAlertFamily() sourcecdk.Family[settings] {
+	return sourcecdk.Family[settings]{
+		Name: familyDNSAlert,
+		Check: func(ctx context.Context, settings settings) error {
+			_, _, err := s.listDNSAlerts(ctx, settings, "", 1)
+			if err != nil {
+				return fmt.Errorf("vulnview dns_alert: %w", err)
+			}
+			return nil
+		},
+		Discover: func(ctx context.Context, settings settings) ([]sourcecdk.URN, error) {
+			records, _, err := s.listDNSAlerts(ctx, settings, "", settings.perPage)
+			if err != nil {
+				return nil, fmt.Errorf("vulnview dns_alert: %w", err)
+			}
+			return urnsFor(settings, familyDNSAlert, records)
+		},
+		Read: func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+			records, next, err := s.listDNSAlerts(ctx, settings, strings.TrimSpace(cursor.GetOpaque()), settings.perPage)
+			if err != nil {
+				return sourcecdk.Pull{}, fmt.Errorf("vulnview dns_alert: %w", err)
+			}
+			return pullFromRecords(settings, familyDNSAlert, records, next)
+		},
+	}
+}
+
+func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
+	return parseSettings(cfg, s != nil && s.allowLoopbackBaseURL)
+}
+
+func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
+	resolved := settings{
+		tenantID:     configValue(cfg, "tenant_id"),
+		family:       configValue(cfg, "family"),
+		baseURL:      configValue(cfg, "base_url"),
+		tokenURL:     configValue(cfg, "token_url"),
+		clientID:     configValue(cfg, "client_id"),
+		clientSecret: configValue(cfg, "client_secret"),
+		scope:        configValue(cfg, "scope"),
+		siteID:       configValue(cfg, "site_id"),
+		scanName:     configValue(cfg, "scan_name"),
+		severity:     strings.ToLower(configValue(cfg, "severity")),
+		search:       configValue(cfg, "search"),
+		perPage:      defaultPageSize,
+	}
+	if resolved.tenantID == "" {
+		return resolved, fmt.Errorf("vulnview tenant_id is required")
+	}
+	if resolved.family == "" {
+		resolved.family = defaultFamily
+	}
+	if !isSupportedFamily(resolved.family) {
+		return resolved, fmt.Errorf("vulnview family must be one of %s", strings.Join(supportedFamilies(), ", "))
+	}
+	if resolved.baseURL == "" {
+		resolved.baseURL = defaultBaseURL
+	}
+	normalizedBase, err := normalizeBaseURL(resolved.baseURL, allowLoopback)
+	if err != nil {
+		return resolved, err
+	}
+	resolved.baseURL = normalizedBase
+	if resolved.scope == "" {
+		resolved.scope = defaultScope
+	}
+	if resolved.clientID == "" {
+		return resolved, fmt.Errorf("vulnview client_id is required")
+	}
+	if resolved.clientSecret == "" {
+		return resolved, fmt.Errorf("vulnview client_secret is required")
+	}
+	if resolved.tokenURL == "" {
+		issuer := strings.TrimRight(configValue(cfg, "okta_issuer"), "/")
+		if issuer == "" {
+			return resolved, fmt.Errorf("vulnview okta_issuer or token_url is required")
+		}
+		resolved.tokenURL = issuer + "/v1/token"
+	}
+	normalizedTokenURL, err := normalizeAbsoluteURL(resolved.tokenURL, allowLoopback)
+	if err != nil {
+		return resolved, err
+	}
+	resolved.tokenURL = normalizedTokenURL
+	if rawPerPage, ok := cfg.Lookup("per_page"); ok && strings.TrimSpace(rawPerPage) != "" {
+		perPage, err := strconv.Atoi(strings.TrimSpace(rawPerPage))
+		if err != nil {
+			return resolved, fmt.Errorf("parse vulnview per_page: %w", err)
+		}
+		if perPage < 1 || perPage > maxPageSize {
+			return resolved, fmt.Errorf("vulnview per_page must be between 1 and %d", maxPageSize)
+		}
+		resolved.perPage = perPage
+	}
+	return resolved, nil
+}
+
+func isSupportedFamily(family string) bool {
+	switch family {
+	case familySite, familyScan, familyVulnerability, familyAsset, familyDNSAlert:
+		return true
+	default:
+		return false
+	}
+}
+
+func supportedFamilies() []string {
+	return []string{familySite, familyScan, familyVulnerability, familyAsset, familyDNSAlert}
+}
+
+func (s *Source) list(ctx context.Context, settings settings, path string, cursor string, pageSize int) ([]record, string, error) {
+	var response listResponse
+	query := settings.query()
+	query.Set("limit", strconv.Itoa(pageSize))
+	addQuery(query, "cursor", cursor)
+	if err := s.getJSON(ctx, settings, path, query, &response); err != nil {
+		return nil, "", err
+	}
+	records := make([]record, 0, len(response.Items))
+	for _, item := range response.Items {
+		rec, err := recordFromRaw(settings.family, item)
+		if err != nil {
+			return nil, "", err
+		}
+		if rec.ID == "" {
+			continue
+		}
+		records = append(records, rec)
+	}
+	if serverPaged(cursor, pageSize, len(records), response.NextCursor) {
+		return records, strings.TrimSpace(response.NextCursor), nil
+	}
+	return pageRecords(records, cursor, pageSize)
+}
+
+func (s *Source) listDNSAlerts(ctx context.Context, settings settings, cursor string, pageSize int) ([]record, string, error) {
+	familySettings := settings
+	familySettings.family = familyAsset
+	var response listResponse
+	query := familySettings.query()
+	query.Set("limit", strconv.Itoa(pageSize))
+	addQuery(query, "cursor", cursor)
+	if err := s.getJSON(ctx, familySettings, "/assets", query, &response); err != nil {
+		return nil, "", err
+	}
+	records := []record{}
+	for _, item := range response.Items {
+		var asset map[string]any
+		if err := json.Unmarshal(item, &asset); err != nil {
+			return nil, "", fmt.Errorf("decode VulnView asset: %w", err)
+		}
+		alerts, _ := asset["dnsAlerts"].([]any)
+		for index, rawAlert := range alerts {
+			alert, ok := rawAlert.(map[string]any)
+			if !ok {
+				continue
+			}
+			values := map[string]any{
+				"asset":     asset["asset"],
+				"siteNames": asset["sites"],
+				"scanNames": asset["scanNames"],
+			}
+			maps.Copy(values, alert)
+			raw, err := json.Marshal(values)
+			if err != nil {
+				return nil, "", fmt.Errorf("marshal VulnView DNS alert: %w", err)
+			}
+			id := firstValueString(values, "id", "alert", "name", "type")
+			assetID := valueString(asset["asset"])
+			records = append(records, record{
+				Raw:    raw,
+				Values: values,
+				ID:     stableID(assetID, id, strconv.Itoa(index)),
+			})
+		}
+	}
+	if serverPaged(cursor, pageSize, len(records), response.NextCursor) {
+		return records, strings.TrimSpace(response.NextCursor), nil
+	}
+	return pageRecords(records, cursor, pageSize)
+}
+
+func serverPaged(cursor string, pageSize int, recordCount int, nextCursor string) bool {
+	return strings.TrimSpace(nextCursor) != "" || (strings.TrimSpace(cursor) != "" && recordCount <= pageSize)
+}
+
+func pageRecords(records []record, cursor string, pageSize int) ([]record, string, error) {
+	offset := 0
+	if strings.TrimSpace(cursor) != "" {
+		parsed, err := strconv.Atoi(strings.TrimSpace(cursor))
+		if err != nil || parsed < 0 {
+			return nil, "", fmt.Errorf("invalid VulnView cursor %q", cursor)
+		}
+		offset = parsed
+	}
+	if offset >= len(records) {
+		return nil, "", nil
+	}
+	end := offset + pageSize
+	if end > len(records) {
+		end = len(records)
+	}
+	next := ""
+	if end < len(records) {
+		next = strconv.Itoa(end)
+	}
+	return records[offset:end], next, nil
+}
+
+func (s *Source) getJSON(ctx context.Context, settings settings, requestPath string, query url.Values, target any) error {
+	token, err := s.token(ctx, settings)
+	if err != nil {
+		return err
+	}
+	err = s.getJSONWithToken(ctx, settings, requestPath, query, token, target)
+	if err != nil && isUnauthorizedResponse(err) {
+		s.invalidateToken(settings)
+		token, tokenErr := s.token(ctx, settings)
+		if tokenErr != nil {
+			return tokenErr
+		}
+		err = s.getJSONWithToken(ctx, settings, requestPath, query, token, target)
+	}
+	return err
+}
+
+func (s *Source) getJSONWithToken(ctx context.Context, settings settings, requestPath string, query url.Values, token string, target any) error {
+	endpoint := settings.baseURL + requestPath
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("build request %s: %w", requestPath, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	client := s.httpClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", requestPath, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	body, err := readLimitedBody(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read %s response: %w", requestPath, err)
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return decodeResponseError("VulnView API", resp.StatusCode, body)
+	}
+	if target == nil || len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, target); err != nil {
+		return fmt.Errorf("decode %s response: %w", requestPath, err)
+	}
+	return nil
+}
+
+func (s *Source) token(ctx context.Context, settings settings) (string, error) {
+	key := strings.Join([]string{settings.tokenURL, settings.clientID, settings.scope}, "\x00")
+	now := time.Now().UTC()
+	s.mu.Lock()
+	if key == s.tokenKey && s.accessToken != "" && now.Add(tokenRefreshLeeway).Before(s.tokenExpiresAt) {
+		token := s.accessToken
+		s.mu.Unlock()
+		return token, nil
+	}
+	s.mu.Unlock()
+	token, expiresAt, err := s.fetchToken(ctx, settings)
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	s.tokenKey = key
+	s.accessToken = token
+	s.tokenExpiresAt = expiresAt
+	s.mu.Unlock()
+	return token, nil
+}
+
+func (s *Source) invalidateToken(settings settings) {
+	key := strings.Join([]string{settings.tokenURL, settings.clientID, settings.scope}, "\x00")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.tokenKey == key {
+		s.tokenKey = ""
+		s.accessToken = ""
+		s.tokenExpiresAt = time.Time{}
+	}
+}
+
+func (s *Source) fetchToken(ctx context.Context, settings settings) (string, time.Time, error) {
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("scope", settings.scope)
+	form.Set("client_id", settings.clientID)
+	form.Set("client_secret", settings.clientSecret)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, settings.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("build VulnView token request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	client := s.httpClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("request VulnView token: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	body, err := readLimitedBody(resp.Body)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("read VulnView token response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return "", time.Time{}, decodeResponseError("VulnView token endpoint", resp.StatusCode, body)
+	}
+	var decoded tokenResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return "", time.Time{}, fmt.Errorf("decode VulnView token response: %w", err)
+	}
+	if decoded.AccessToken == "" {
+		return "", time.Time{}, fmt.Errorf("VulnView token endpoint returned empty access_token")
+	}
+	if decoded.TokenType != "" && !strings.EqualFold(decoded.TokenType, "Bearer") {
+		return "", time.Time{}, fmt.Errorf("VulnView token endpoint returned unsupported token_type %q", decoded.TokenType)
+	}
+	expiresIn := decoded.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 3600
+	}
+	return decoded.AccessToken, time.Now().UTC().Add(time.Duration(expiresIn) * time.Second), nil
+}
+
+func (s *Source) httpClient() *http.Client {
+	var client *http.Client
+	allowLoopback := false
+	if s != nil {
+		client = s.client
+		allowLoopback = s.allowLoopbackBaseURL
+	}
+	if client == nil {
+		client = &http.Client{Timeout: httpTimeout}
+	}
+	cloned := *client
+	if cloned.CheckRedirect == nil {
+		cloned.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+	transport := cloned.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	cloned.Transport = safeRoundTripper{base: transport, allowLoopback: allowLoopback, lookupIPAddrs: lookupIPAddrs(s)}
+	return &cloned
+}
+
+func (settings settings) query() url.Values {
+	query := url.Values{}
+	addQuery(query, "siteId", settings.siteID)
+	addQuery(query, "scanName", settings.scanName)
+	addQuery(query, "name", settings.scanName)
+	addQuery(query, "severity", settings.severity)
+	addQuery(query, "search", settings.search)
+	return query
+}
+
+func recordFromRaw(family string, raw json.RawMessage) (record, error) {
+	values := map[string]any{}
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return record{}, fmt.Errorf("decode VulnView %s record: %w", family, err)
+	}
+	return record{Raw: cloneRaw(raw), Values: values, ID: recordID(family, values)}, nil
+}
+
+func recordID(family string, values map[string]any) string {
+	switch family {
+	case familySite:
+		return firstValueString(values, "siteId", "id", "name")
+	case familyScan:
+		return firstValueString(values, "scanId", "id", "name")
+	case familyVulnerability:
+		return stableID(
+			firstValueString(values, "scanId"),
+			firstValueString(values, "templateId", "template-id", "id", "name"),
+			firstValueString(values, "matchedAt", "matched-at", "host"),
+		)
+	case familyAsset:
+		return firstValueString(values, "asset", "host", "matchedAt", "matched-at")
+	default:
+		return firstValueString(values, "id", "name")
+	}
+}
+
+func urnsFor(settings settings, family string, records []record) ([]sourcecdk.URN, error) {
+	urns := make([]sourcecdk.URN, 0, len(records))
+	for _, record := range records {
+		urn, err := sourcecdk.ParseURN(fmt.Sprintf("urn:cerebro:%s:vulnview_%s:%s", settings.tenantID, family, normalizeID(record.ID)))
+		if err != nil {
+			return nil, err
+		}
+		urns = append(urns, urn)
+	}
+	return urns, nil
+}
+
+func pullFromRecords(settings settings, family string, records []record, next string) (sourcecdk.Pull, error) {
+	if len(records) == 0 {
+		pull := sourcecdk.Pull{}
+		if strings.TrimSpace(next) != "" {
+			pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strings.TrimSpace(next)}
+		}
+		return pull, nil
+	}
+	events := make([]*primitives.Event, 0, len(records))
+	for _, record := range records {
+		event, err := eventFromRecord(settings, family, record)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		events = append(events, event)
+	}
+	pull := sourcecdk.Pull{
+		Events: events,
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    events[len(events)-1].OccurredAt,
+			CursorOpaque: checkpointCursor(next, records[len(records)-1].ID),
+		},
+	}
+	if next != "" {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
+	}
+	return pull, nil
+}
+
+func eventFromRecord(settings settings, family string, record record) (*primitives.Event, error) {
+	occurredAt := occurredAtFor(record.Values)
+	return &primitives.Event{
+		Id:         eventID(settings, family, record.ID),
+		TenantId:   settings.tenantID,
+		SourceId:   sourceID,
+		Kind:       sourceID + "." + family,
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  sourceID + "/" + family + "/v1",
+		Payload:    cloneRaw(record.Raw),
+		Attributes: attributesFor(family, record),
+	}, nil
+}
+
+func eventID(settings settings, family string, recordID string) string {
+	return strings.Join([]string{
+		sourceID,
+		normalizeID(settings.tenantID),
+		runtimeScope(settings),
+		normalizeID(family),
+		normalizeID(recordID),
+	}, "-")
+}
+
+func runtimeScope(settings settings) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		settings.baseURL,
+		settings.clientID,
+		settings.scope,
+	}, "\x00")))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+func attributesFor(family string, record record) map[string]string {
+	values := record.Values
+	attrs := map[string]string{
+		"external_id":     record.ID,
+		"family":          family,
+		"provider":        sourceID,
+		"source_provider": sourceID,
+	}
+	switch family {
+	case familySite:
+		copyFields(attrs, values, map[string]string{
+			"site_id": "siteId",
+			"name":    "name",
+		})
+	case familyScan:
+		copyFields(attrs, values, map[string]string{
+			"scan_id":          "scanId",
+			"site_id":          "siteId",
+			"name":             "name",
+			"scan_type":        "scanType",
+			"target":           "target",
+			"status":           "status",
+			"findings_count":   "findingsCount",
+			"results_key":      "resultsKey",
+			"created_at":       "createdAt",
+			"started_at":       "startedAt",
+			"completed_at":     "completedAt",
+			"cloud_account_id": "cloudAccountId",
+		})
+	case familyVulnerability:
+		copyFields(attrs, values, map[string]string{
+			"vulnerability_id": "templateId",
+			"template_id":      "templateId",
+			"name":             "name",
+			"severity":         "severity",
+			"type":             "type",
+			"target_id":        "host",
+			"target_name":      "host",
+			"host":             "host",
+			"matched_at":       "matchedAt",
+			"description":      "description",
+			"remediation":      "remediation",
+			"scan_id":          "scanId",
+			"scan_name":        "scanName",
+			"site_id":          "siteId",
+			"site_name":        "siteName",
+			"timestamp":        "timestamp",
+		})
+		if attrs["template_id"] == "" {
+			copyFields(attrs, values, map[string]string{"template_id": "template-id", "vulnerability_id": "template-id"})
+		}
+		if attrs["matched_at"] == "" {
+			copyFields(attrs, values, map[string]string{"matched_at": "matched-at"})
+		}
+		attrs["target_type"] = "external_asset"
+		attrs["vulnerability_type"] = firstNonEmpty(attrs["type"], "vulnview")
+	case familyAsset:
+		copyFields(attrs, values, map[string]string{
+			"asset_id":          "asset",
+			"asset_name":        "asset",
+			"target_id":         "asset",
+			"target_name":       "asset",
+			"highest_severity":  "highestSeverity",
+			"findings_count":    "findingsCount",
+			"sites":             "sites",
+			"scan_names":        "scanNames",
+			"critical_count":    "severityCounts.critical",
+			"high_count":        "severityCounts.high",
+			"medium_count":      "severityCounts.medium",
+			"low_count":         "severityCounts.low",
+			"info_count":        "severityCounts.info",
+			"dns_alerts_count":  "dnsAlertSummary.total",
+			"dns_highest_alert": "dnsAlertSummary.highestSeverity",
+		})
+		attrs["target_type"] = "external_asset"
+	case familyDNSAlert:
+		copyFields(attrs, values, map[string]string{
+			"asset_id":     "asset",
+			"asset_name":   "asset",
+			"target_id":    "asset",
+			"target_name":  "asset",
+			"alert":        "alert",
+			"name":         "alert",
+			"severity":     "severity",
+			"description":  "description",
+			"record_type":  "recordType",
+			"record_value": "recordValue",
+			"sites":        "siteNames",
+			"scan_names":   "scanNames",
+		})
+		attrs["target_type"] = "external_asset"
+	}
+	trimEmptyAttributes(attrs)
+	return attrs
+}
+
+func occurredAtFor(values map[string]any) time.Time {
+	for _, key := range []string{"timestamp", "completedAt", "startedAt", "createdAt", "matchedAt", "matched-at"} {
+		if parsed, ok := parseTime(valueString(valueAt(values, key))); ok {
+			return parsed
+		}
+	}
+	return time.Now().UTC()
+}
+
+func parseTime(raw string) (time.Time, bool) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func normalizeBaseURL(raw string, allowLoopback bool) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse vulnview base_url: %w", err)
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || parsed.User != nil {
+		return "", fmt.Errorf("vulnview base_url must not include user info, query, or fragment")
+	}
+	normalized, err := normalizeParsedURL(parsed, allowLoopback)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(normalized, "/"), nil
+}
+
+func normalizeAbsoluteURL(raw string, allowLoopback bool) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("parse vulnview url: %w", err)
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || parsed.User != nil {
+		return "", fmt.Errorf("vulnview url must not include user info, query, or fragment")
+	}
+	return normalizeParsedURL(parsed, allowLoopback)
+}
+
+func normalizeParsedURL(parsed *url.URL, allowLoopback bool) (string, error) {
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	allowInsecureLoopback := allowLoopback && parsed.Scheme == "http" && isLoopbackHost(host)
+	if parsed.Scheme != "https" && !allowInsecureLoopback {
+		return "", fmt.Errorf("vulnview url must use https")
+	}
+	if host == "" {
+		return "", fmt.Errorf("vulnview url must include a host")
+	}
+	allowCustomPort := allowLoopback && isLoopbackHost(host)
+	if strings.TrimSpace(parsed.Port()) != "" && parsed.Port() != "443" && !allowCustomPort {
+		return "", fmt.Errorf("vulnview url must not include a custom port")
+	}
+	if isUnsafeHost(host) && (!allowLoopback || !isLoopbackHost(host)) {
+		return "", fmt.Errorf("vulnview url must not target loopback, private, or link-local hosts")
+	}
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+type safeRoundTripper struct {
+	base          http.RoundTripper
+	allowLoopback bool
+	lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)
+}
+
+func (rt safeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req != nil && req.URL != nil {
+		if err := rejectResolvedUnsafeHost(req.Context(), req.URL.Hostname(), rt.allowLoopback, rt.lookupIPAddrs); err != nil {
+			return nil, err
+		}
+	}
+	return rt.base.RoundTrip(req)
+}
+
+func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {
+	if source != nil && source.lookupIPAddrs != nil {
+		return source.lookupIPAddrs
+	}
+	return net.DefaultResolver.LookupIPAddr
+}
+
+func rejectResolvedUnsafeHost(ctx context.Context, host string, allowLoopback bool, lookup func(context.Context, string) ([]net.IPAddr, error)) error {
+	normalized := strings.ToLower(strings.TrimSpace(host))
+	if normalized == "" {
+		return fmt.Errorf("vulnview host is required")
+	}
+	if ip := net.ParseIP(normalized); ip != nil {
+		if unsafeIP(ip, allowLoopback) {
+			return fmt.Errorf("vulnview host must not target loopback, private, or link-local addresses")
+		}
+		return nil
+	}
+	if lookup == nil {
+		lookup = net.DefaultResolver.LookupIPAddr
+	}
+	addrs, err := lookup(ctx, normalized)
+	if err != nil {
+		return fmt.Errorf("resolve vulnview host %q: %w", normalized, err)
+	}
+	for _, addr := range addrs {
+		if unsafeIP(addr.IP, allowLoopback) {
+			return fmt.Errorf("vulnview host must not resolve to loopback, private, or link-local addresses")
+		}
+	}
+	return nil
+}
+
+func isUnsafeHost(host string) bool {
+	value := strings.Trim(strings.ToLower(strings.TrimSpace(host)), "[]")
+	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(value)
+	return ip != nil && unsafeIP(ip, false)
+}
+
+func unsafeIP(ip net.IP, allowLoopback bool) bool {
+	if ip == nil {
+		return true
+	}
+	if allowLoopback && ip.IsLoopback() {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(strings.Trim(host, "[]"))
+	return ip != nil && ip.IsLoopback()
+}
+
+func readLimitedBody(body io.Reader) ([]byte, error) {
+	limited := io.LimitReader(body, maxBodyBytes+1)
+	payload, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if len(payload) > maxBodyBytes {
+		return nil, fmt.Errorf("vulnview response body exceeds %d bytes", maxBodyBytes)
+	}
+	return payload, nil
+}
+
+func decodeResponseError(service string, statusCode int, body []byte) error {
+	message := strings.TrimSpace(string(body))
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err == nil {
+		for _, key := range []string{"message", "error_description", "error", "detail"} {
+			if value := valueString(payload[key]); value != "" {
+				message = value
+				break
+			}
+		}
+	}
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+	return &responseError{statusCode: statusCode, message: fmt.Sprintf("%s returned %d: %s", service, statusCode, message)}
+}
+
+func isUnauthorizedResponse(err error) bool {
+	var responseErr *responseError
+	return errors.As(err, &responseErr) && responseErr.statusCode == http.StatusUnauthorized
+}
+
+func copyFields(attrs map[string]string, values map[string]any, fields map[string]string) {
+	for attr, field := range fields {
+		if value := valueString(valueAt(values, field)); value != "" {
+			attrs[attr] = value
+		}
+	}
+}
+
+func valueAt(values map[string]any, path string) any {
+	current := any(values)
+	for _, part := range strings.Split(path, ".") {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil
+		}
+		current = object[part]
+	}
+	return current
+}
+
+func firstValueString(values map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := valueString(valueAt(values, key)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func valueString(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(v)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(v)
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			if value := valueString(item); value != "" {
+				parts = append(parts, value)
+			}
+		}
+		return strings.Join(parts, ",")
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}
+
+func addQuery(query url.Values, key string, value string) {
+	if strings.TrimSpace(value) != "" {
+		query.Set(key, strings.TrimSpace(value))
+	}
+}
+
+func checkpointCursor(next string, fallback string) string {
+	if strings.TrimSpace(next) != "" {
+		return strings.TrimSpace(next)
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func stableID(parts ...string) string {
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if value := strings.TrimSpace(part); value != "" {
+			values = append(values, value)
+		}
+	}
+	if len(values) == 0 {
+		return ""
+	}
+	return strings.Join(values, ":")
+}
+
+func normalizeID(value string) string {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return "unknown"
+	}
+	replacer := strings.NewReplacer(" ", "-", "/", "-", ":", "-", "\n", "-", "\t", "-")
+	return replacer.Replace(normalized)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func trimEmptyAttributes(attrs map[string]string) {
+	for key, value := range attrs {
+		if strings.TrimSpace(value) == "" {
+			delete(attrs, key)
+			continue
+		}
+		attrs[key] = strings.TrimSpace(value)
+	}
+}
+
+func configValue(cfg sourcecdk.Config, key string) string {
+	value, _ := cfg.Lookup(key)
+	return strings.TrimSpace(value)
+}
+
+func cloneRaw(raw json.RawMessage) json.RawMessage {
+	if raw == nil {
+		return nil
+	}
+	return append(json.RawMessage(nil), raw...)
+}

--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -261,6 +261,9 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 		return resolved, err
 	}
 	resolved.baseURL = normalizedBase
+	if err := validateBaseURL(resolved.baseURL, allowLoopback); err != nil {
+		return resolved, err
+	}
 	if resolved.scope == "" {
 		resolved.scope = defaultScope
 	}
@@ -270,8 +273,11 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 	if resolved.clientSecret == "" {
 		return resolved, fmt.Errorf("vulnview client_secret is required")
 	}
+	issuer := strings.TrimRight(configValue(cfg, "okta_issuer"), "/")
+	if issuer == "" && !allowLoopback {
+		return resolved, fmt.Errorf("vulnview okta_issuer is required")
+	}
 	if resolved.tokenURL == "" {
-		issuer := strings.TrimRight(configValue(cfg, "okta_issuer"), "/")
 		if issuer == "" {
 			return resolved, fmt.Errorf("vulnview okta_issuer or token_url is required")
 		}
@@ -296,6 +302,24 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 		resolved.perPage = perPage
 	}
 	return resolved, nil
+}
+
+func validateBaseURL(baseURL string, allowLoopback bool) error {
+	if allowLoopback {
+		return nil
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Errorf("parse vulnview base_url: %w", err)
+	}
+	trusted, err := url.Parse(defaultBaseURL)
+	if err != nil {
+		return fmt.Errorf("parse default VulnView base_url: %w", err)
+	}
+	if !strings.EqualFold(parsed.Scheme, trusted.Scheme) || !strings.EqualFold(parsed.Host, trusted.Host) {
+		return fmt.Errorf("vulnview base_url must use the trusted VulnView origin")
+	}
+	return nil
 }
 
 func validateTokenURL(cfg sourcecdk.Config, tokenURL string, allowLoopback bool) error {
@@ -361,55 +385,61 @@ func (s *Source) listDNSAlerts(ctx context.Context, settings settings, cursor st
 	}
 	familySettings := settings
 	familySettings.family = familyAsset
-	var response listResponse
-	query := familySettings.query()
-	query.Set("limit", "1")
-	addQuery(query, "cursor", assetCursor)
-	if err := s.getJSON(ctx, familySettings, "/assets", query, &response); err != nil {
-		return nil, "", err
-	}
-	records := []record{}
-	for _, item := range response.Items {
-		var asset map[string]any
-		if err := json.Unmarshal(item, &asset); err != nil {
-			return nil, "", fmt.Errorf("decode VulnView asset: %w", err)
+	for {
+		var response listResponse
+		query := familySettings.query()
+		query.Set("limit", "1")
+		addQuery(query, "cursor", assetCursor)
+		if err := s.getJSON(ctx, familySettings, "/assets", query, &response); err != nil {
+			return nil, "", err
 		}
-		alerts, _ := asset["dnsAlerts"].([]any)
-		for index, rawAlert := range alerts {
-			alert, ok := rawAlert.(map[string]any)
-			if !ok {
-				continue
+		records := []record{}
+		for _, item := range response.Items {
+			var asset map[string]any
+			if err := json.Unmarshal(item, &asset); err != nil {
+				return nil, "", fmt.Errorf("decode VulnView asset: %w", err)
 			}
-			values := map[string]any{
-				"asset":     asset["asset"],
-				"siteNames": asset["sites"],
-				"scanNames": asset["scanNames"],
+			alerts, _ := asset["dnsAlerts"].([]any)
+			for index, rawAlert := range alerts {
+				alert, ok := rawAlert.(map[string]any)
+				if !ok {
+					continue
+				}
+				values := map[string]any{
+					"asset":     asset["asset"],
+					"siteNames": asset["sites"],
+					"scanNames": asset["scanNames"],
+				}
+				maps.Copy(values, alert)
+				raw, err := json.Marshal(values)
+				if err != nil {
+					return nil, "", fmt.Errorf("marshal VulnView DNS alert: %w", err)
+				}
+				id := firstValueString(values, "id", "alert", "name", "type")
+				assetID := valueString(asset["asset"])
+				records = append(records, record{
+					Raw:    raw,
+					Values: values,
+					ID:     stableID(assetID, id, strconv.Itoa(index)),
+				})
 			}
-			maps.Copy(values, alert)
-			raw, err := json.Marshal(values)
-			if err != nil {
-				return nil, "", fmt.Errorf("marshal VulnView DNS alert: %w", err)
-			}
-			id := firstValueString(values, "id", "alert", "name", "type")
-			assetID := valueString(asset["asset"])
-			records = append(records, record{
-				Raw:    raw,
-				Values: values,
-				ID:     stableID(assetID, id, strconv.Itoa(index)),
-			})
 		}
+		page, nextAlertOffset, err := pageRecords(records, strconv.Itoa(alertOffset), pageSize)
+		if err != nil {
+			return nil, "", err
+		}
+		if len(page) > 0 || strings.TrimSpace(response.NextCursor) == "" {
+			if nextAlertOffset != "" {
+				return page, encodeDNSAlertCursor(assetCursor, nextAlertOffset), nil
+			}
+			if strings.TrimSpace(response.NextCursor) != "" {
+				return page, encodeDNSAlertCursor(response.NextCursor, "0"), nil
+			}
+			return page, "", nil
+		}
+		assetCursor = strings.TrimSpace(response.NextCursor)
+		alertOffset = 0
 	}
-	page, nextAlertOffset, err := pageRecords(records, strconv.Itoa(alertOffset), pageSize)
-	if err != nil {
-		return nil, "", err
-	}
-	if nextAlertOffset != "" {
-		return page, encodeDNSAlertCursor(assetCursor, nextAlertOffset), nil
-	}
-	if strings.TrimSpace(response.NextCursor) != "" {
-		return page, encodeDNSAlertCursor(response.NextCursor, "0"), nil
-	}
-	return page, "", nil
 }
 
 func serverPaged(cursor string, pageSize int, recordCount int, nextCursor string) bool {

--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"embed"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -83,6 +84,11 @@ type record struct {
 type listResponse struct {
 	Items      []json.RawMessage `json:"items"`
 	NextCursor string            `json:"nextCursor"`
+}
+
+type dnsAlertCursor struct {
+	AssetCursor string `json:"assetCursor,omitempty"`
+	AlertOffset int    `json:"alertOffset,omitempty"`
 }
 
 type tokenResponse struct {
@@ -276,6 +282,9 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 		return resolved, err
 	}
 	resolved.tokenURL = normalizedTokenURL
+	if err := validateTokenURL(cfg, resolved.tokenURL, allowLoopback); err != nil {
+		return resolved, err
+	}
 	if rawPerPage, ok := cfg.Lookup("per_page"); ok && strings.TrimSpace(rawPerPage) != "" {
 		perPage, err := strconv.Atoi(strings.TrimSpace(rawPerPage))
 		if err != nil {
@@ -287,6 +296,24 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 		resolved.perPage = perPage
 	}
 	return resolved, nil
+}
+
+func validateTokenURL(cfg sourcecdk.Config, tokenURL string, allowLoopback bool) error {
+	issuer := strings.TrimRight(configValue(cfg, "okta_issuer"), "/")
+	if issuer == "" {
+		if allowLoopback {
+			return nil
+		}
+		return fmt.Errorf("vulnview okta_issuer is required")
+	}
+	expected, err := normalizeAbsoluteURL(issuer+"/v1/token", allowLoopback)
+	if err != nil {
+		return err
+	}
+	if tokenURL != expected {
+		return fmt.Errorf("vulnview token_url must match okta_issuer token endpoint")
+	}
+	return nil
 }
 
 func isSupportedFamily(family string) bool {
@@ -328,12 +355,16 @@ func (s *Source) list(ctx context.Context, settings settings, path string, curso
 }
 
 func (s *Source) listDNSAlerts(ctx context.Context, settings settings, cursor string, pageSize int) ([]record, string, error) {
+	assetCursor, alertOffset, err := parseDNSAlertCursor(cursor)
+	if err != nil {
+		return nil, "", err
+	}
 	familySettings := settings
 	familySettings.family = familyAsset
 	var response listResponse
 	query := familySettings.query()
-	query.Set("limit", strconv.Itoa(pageSize))
-	addQuery(query, "cursor", cursor)
+	query.Set("limit", "1")
+	addQuery(query, "cursor", assetCursor)
 	if err := s.getJSON(ctx, familySettings, "/assets", query, &response); err != nil {
 		return nil, "", err
 	}
@@ -368,14 +399,55 @@ func (s *Source) listDNSAlerts(ctx context.Context, settings settings, cursor st
 			})
 		}
 	}
-	if serverPaged(cursor, pageSize, len(records), response.NextCursor) {
-		return records, strings.TrimSpace(response.NextCursor), nil
+	page, nextAlertOffset, err := pageRecords(records, strconv.Itoa(alertOffset), pageSize)
+	if err != nil {
+		return nil, "", err
 	}
-	return pageRecords(records, cursor, pageSize)
+	if nextAlertOffset != "" {
+		return page, encodeDNSAlertCursor(assetCursor, nextAlertOffset), nil
+	}
+	if strings.TrimSpace(response.NextCursor) != "" {
+		return page, encodeDNSAlertCursor(response.NextCursor, "0"), nil
+	}
+	return page, "", nil
 }
 
 func serverPaged(cursor string, pageSize int, recordCount int, nextCursor string) bool {
 	return strings.TrimSpace(nextCursor) != "" || (strings.TrimSpace(cursor) != "" && recordCount <= pageSize)
+}
+
+func parseDNSAlertCursor(cursor string) (string, int, error) {
+	trimmed := strings.TrimSpace(cursor)
+	if trimmed == "" {
+		return "", 0, nil
+	}
+	if !strings.HasPrefix(trimmed, "dns:") {
+		return trimmed, 0, nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(trimmed, "dns:"))
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid VulnView DNS alert cursor")
+	}
+	var decoded dnsAlertCursor
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return "", 0, fmt.Errorf("invalid VulnView DNS alert cursor")
+	}
+	if decoded.AlertOffset < 0 {
+		return "", 0, fmt.Errorf("invalid VulnView DNS alert cursor")
+	}
+	return strings.TrimSpace(decoded.AssetCursor), decoded.AlertOffset, nil
+}
+
+func encodeDNSAlertCursor(assetCursor string, alertOffset string) string {
+	offset, err := strconv.Atoi(strings.TrimSpace(alertOffset))
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+	payload, err := json.Marshal(dnsAlertCursor{AssetCursor: strings.TrimSpace(assetCursor), AlertOffset: offset})
+	if err != nil {
+		return ""
+	}
+	return "dns:" + base64.RawURLEncoding.EncodeToString(payload)
 }
 
 func pageRecords(records []record, cursor string, pageSize int) ([]record, string, error) {
@@ -454,7 +526,7 @@ func (s *Source) getJSONWithToken(ctx context.Context, settings settings, reques
 }
 
 func (s *Source) token(ctx context.Context, settings settings) (string, error) {
-	key := strings.Join([]string{settings.tokenURL, settings.clientID, settings.scope}, "\x00")
+	key := tokenCacheKey(settings)
 	now := time.Now().UTC()
 	s.mu.Lock()
 	if key == s.tokenKey && s.accessToken != "" && now.Add(tokenRefreshLeeway).Before(s.tokenExpiresAt) {
@@ -476,7 +548,7 @@ func (s *Source) token(ctx context.Context, settings settings) (string, error) {
 }
 
 func (s *Source) invalidateToken(settings settings) {
-	key := strings.Join([]string{settings.tokenURL, settings.clientID, settings.scope}, "\x00")
+	key := tokenCacheKey(settings)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.tokenKey == key {
@@ -484,6 +556,21 @@ func (s *Source) invalidateToken(settings settings) {
 		s.accessToken = ""
 		s.tokenExpiresAt = time.Time{}
 	}
+}
+
+func tokenCacheKey(settings settings) string {
+	return strings.Join([]string{
+		settings.baseURL,
+		settings.tokenURL,
+		settings.clientID,
+		settings.scope,
+		hashValue(settings.clientSecret),
+	}, "\x00")
+}
+
+func hashValue(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
 }
 
 func (s *Source) fetchToken(ctx context.Context, settings settings) (string, time.Time, error) {

--- a/sources/vulnview/source_test.go
+++ b/sources/vulnview/source_test.go
@@ -1,0 +1,121 @@
+package vulnview
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+func TestParseSettingsRejectsUnsafeBaseURL(t *testing.T) {
+	_, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "writer",
+		"base_url":      "http://169.254.169.254/api",
+		"okta_issuer":   "https://example.okta.com/oauth2/default",
+		"client_id":     "client",
+		"client_secret": "secret",
+	}), false)
+	if err == nil {
+		t.Fatal("parseSettings() error = nil, want non-nil")
+	}
+}
+
+func TestReadVulnerabilitiesPaginatesAndMapsAttributes(t *testing.T) {
+	var tokenRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			tokenRequests++
+			if got := r.FormValue("grant_type"); got != "client_credentials" {
+				t.Fatalf("grant_type = %q, want client_credentials", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "access", "token_type": "Bearer", "expires_in": 3600})
+		case "/vulnerabilities":
+			if got := r.Header.Get("Authorization"); got != "Bearer access" {
+				t.Fatalf("Authorization = %q, want bearer token", got)
+			}
+			if got := r.URL.Query().Get("siteId"); got != "site-1" {
+				t.Fatalf("siteId query = %q, want site-1", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{
+				{
+					"type":        "vulnerability",
+					"templateId":  "cve-2026-1234",
+					"name":        "Test CVE",
+					"severity":    "high",
+					"host":        "app.writer.com",
+					"matchedAt":   "https://app.writer.com/login",
+					"scanId":      "scan-1",
+					"scanName":    "prod-web",
+					"siteId":      "site-1",
+					"siteName":    "prod",
+					"description": "test finding",
+					"timestamp":   "2026-05-12T00:00:00Z",
+				},
+				{
+					"type":       "vulnerability",
+					"templateId": "exposed-panel",
+					"name":       "Exposed Panel",
+					"severity":   "medium",
+					"host":       "admin.writer.com",
+					"scanId":     "scan-2",
+				},
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "writer",
+		"base_url":      server.URL,
+		"token_url":     server.URL + "/token",
+		"client_id":     "client",
+		"client_secret": "secret",
+		"family":        "vulnerability",
+		"site_id":       "site-1",
+		"per_page":      "1",
+	})
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
+	}
+	if first.NextCursor.GetOpaque() != "1" {
+		t.Fatalf("first.NextCursor = %q, want 1", first.NextCursor.GetOpaque())
+	}
+	event := first.Events[0]
+	if got, want := event.Kind, "vulnview.vulnerability"; got != want {
+		t.Fatalf("event.Kind = %q, want %q", got, want)
+	}
+	if got, want := event.Attributes["template_id"], "cve-2026-1234"; got != want {
+		t.Fatalf("template_id = %q, want %q", got, want)
+	}
+	if got, want := event.Attributes["target_id"], "app.writer.com"; got != want {
+		t.Fatalf("target_id = %q, want %q", got, want)
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if len(second.Events) != 1 {
+		t.Fatalf("len(second.Events) = %d, want 1", len(second.Events))
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second.NextCursor = %v, want nil", second.NextCursor)
+	}
+	if tokenRequests != 1 {
+		t.Fatalf("tokenRequests = %d, want cached token reuse", tokenRequests)
+	}
+}

--- a/sources/vulnview/source_test.go
+++ b/sources/vulnview/source_test.go
@@ -23,6 +23,20 @@ func TestParseSettingsRejectsUnsafeBaseURL(t *testing.T) {
 	}
 }
 
+func TestParseSettingsRejectsTokenURLOutsideOktaIssuer(t *testing.T) {
+	_, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "writer",
+		"base_url":      "https://vulnview.writer-security.com/api",
+		"okta_issuer":   "https://writer.okta.com/oauth2/default",
+		"token_url":     "https://attacker.example/token",
+		"client_id":     "client",
+		"client_secret": "secret",
+	}), false)
+	if err == nil {
+		t.Fatal("parseSettings() error = nil, want non-nil")
+	}
+}
+
 func TestReadVulnerabilitiesPaginatesAndMapsAttributes(t *testing.T) {
 	var tokenRequests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -117,5 +131,117 @@ func TestReadVulnerabilitiesPaginatesAndMapsAttributes(t *testing.T) {
 	}
 	if tokenRequests != 1 {
 		t.Fatalf("tokenRequests = %d, want cached token reuse", tokenRequests)
+	}
+}
+
+func TestAccessTokenCacheScopesByClientSecret(t *testing.T) {
+	tokenRequests := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			secret := r.FormValue("client_secret")
+			tokenRequests[secret]++
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "access-" + secret, "token_type": "Bearer", "expires_in": 3600})
+		case "/vulnerabilities":
+			want := "Bearer access-" + r.URL.Query().Get("search")
+			if got := r.Header.Get("Authorization"); got != want {
+				t.Fatalf("Authorization = %q, want %q", got, want)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{{
+				"templateId": "cve-2026-1234",
+				"name":       "Test CVE",
+				"severity":   "high",
+				"host":       "app.writer.com",
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	for _, secret := range []string{"one", "two"} {
+		cfg := sourcecdk.NewConfig(map[string]string{
+			"tenant_id":     "writer",
+			"base_url":      server.URL,
+			"token_url":     server.URL + "/token",
+			"client_id":     "client",
+			"client_secret": secret,
+			"family":        "vulnerability",
+			"search":        secret,
+		})
+		if _, err := source.Read(context.Background(), cfg, nil); err != nil {
+			t.Fatalf("Read(%s) error = %v", secret, err)
+		}
+	}
+	if tokenRequests["one"] != 1 || tokenRequests["two"] != 1 {
+		t.Fatalf("tokenRequests = %#v, want one request per secret", tokenRequests)
+	}
+}
+
+func TestReadDNSAlertsPaginatesWithinAsset(t *testing.T) {
+	var assetRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "access", "token_type": "Bearer", "expires_in": 3600})
+		case "/assets":
+			assetRequests++
+			if got := r.URL.Query().Get("limit"); got != "1" {
+				t.Fatalf("limit = %q, want 1", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{{
+				"asset": "staging.writer.com",
+				"dnsAlerts": []map[string]any{
+					{"alert": "dangling-cname", "severity": "high"},
+					{"alert": "stale-a-record", "severity": "medium"},
+				},
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "writer",
+		"base_url":      server.URL,
+		"token_url":     server.URL + "/token",
+		"client_id":     "client",
+		"client_secret": "secret",
+		"family":        "dns_alert",
+		"per_page":      "1",
+	})
+	first, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	if len(first.Events) != 1 {
+		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
+	}
+	if first.NextCursor == nil {
+		t.Fatal("first.NextCursor = nil, want cursor for second alert")
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if len(second.Events) != 1 {
+		t.Fatalf("len(second.Events) = %d, want 1", len(second.Events))
+	}
+	if first.Events[0].Attributes["alert"] == second.Events[0].Attributes["alert"] {
+		t.Fatalf("alerts were not paginated distinctly: %q", first.Events[0].Attributes["alert"])
+	}
+	if assetRequests != 2 {
+		t.Fatalf("assetRequests = %d, want 2", assetRequests)
 	}
 }

--- a/sources/vulnview/source_test.go
+++ b/sources/vulnview/source_test.go
@@ -37,6 +37,19 @@ func TestParseSettingsRejectsTokenURLOutsideOktaIssuer(t *testing.T) {
 	}
 }
 
+func TestParseSettingsRejectsUntrustedBaseURL(t *testing.T) {
+	_, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "writer",
+		"base_url":      "https://attacker.example/api",
+		"okta_issuer":   "https://writer.okta.com/oauth2/default",
+		"client_id":     "client",
+		"client_secret": "secret",
+	}), false)
+	if err == nil {
+		t.Fatal("parseSettings() error = nil, want non-nil")
+	}
+}
+
 func TestReadVulnerabilitiesPaginatesAndMapsAttributes(t *testing.T) {
 	var tokenRequests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -240,6 +253,61 @@ func TestReadDNSAlertsPaginatesWithinAsset(t *testing.T) {
 	}
 	if first.Events[0].Attributes["alert"] == second.Events[0].Attributes["alert"] {
 		t.Fatalf("alerts were not paginated distinctly: %q", first.Events[0].Attributes["alert"])
+	}
+	if assetRequests != 2 {
+		t.Fatalf("assetRequests = %d, want 2", assetRequests)
+	}
+}
+
+func TestReadDNSAlertsSkipsEmptyAssetPages(t *testing.T) {
+	var assetRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "access", "token_type": "Bearer", "expires_in": 3600})
+		case "/assets":
+			assetRequests++
+			cursor := r.URL.Query().Get("cursor")
+			if cursor == "" {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"items":      []map[string]any{{"asset": "empty.writer.com", "dnsAlerts": []map[string]any{}}},
+					"nextCursor": "1",
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{{
+				"asset":     "staging.writer.com",
+				"dnsAlerts": []map[string]any{{"alert": "dangling-cname", "severity": "high"}},
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "writer",
+		"base_url":      server.URL,
+		"token_url":     server.URL + "/token",
+		"client_id":     "client",
+		"client_secret": "secret",
+		"family":        "dns_alert",
+		"per_page":      "1",
+	})
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(pull.Events) = %d, want 1", len(pull.Events))
+	}
+	if got := pull.Events[0].Attributes["asset_id"]; got != "staging.writer.com" {
+		t.Fatalf("asset_id = %q, want staging.writer.com", got)
 	}
 	if assetRequests != 2 {
 		t.Fatalf("assetRequests = %d, want 2", assetRequests)

--- a/sources/vulnview/testdata/vulnerabilities_page.json
+++ b/sources/vulnview/testdata/vulnerabilities_page.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "type": "vulnerability",
+      "templateId": "cve-2026-1234",
+      "name": "Test CVE",
+      "severity": "high",
+      "host": "app.writer.com",
+      "matchedAt": "https://app.writer.com/login",
+      "scanId": "scan-1",
+      "scanName": "prod-web",
+      "siteId": "site-1",
+      "siteName": "prod",
+      "timestamp": "2026-05-12T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add graph-path coverage proving GRC vulnerability target/integration relationships have graph endpoints before links are written.
- Add graph rebuild dry-run replay coverage proving GRC integration labels and target->integration links appear in graph previews.

## Tests
- go test ./internal/sourceprojection -run '^TestProjectGRCVulnerabilityWritesGraphTargetIntegrationLinks$' -count=1
- go test ./internal/graphrebuild -run 'Test(RebuildDryRunReplaysGRCVulnerabilityTargetIntegrationGraph|MemoryGraphStorePreservesExistingLabelsForFallbackLabels)$' -count=1
- make verify
