### PR TITLE
fix(vulnview): batch DNS alert asset reads

### DIFF
--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -30,15 +30,16 @@ import (
 var catalogFS embed.FS
 
 const (
-	sourceID           = "vulnview"
-	defaultBaseURL     = "https://vulnview.writer-security.com/api"
-	defaultScope       = "vulnview"
-	defaultFamily      = familyVulnerability
-	defaultPageSize    = 100
-	maxPageSize        = 500
-	httpTimeout        = 30 * time.Second
-	maxBodyBytes       = 8 << 20
-	tokenRefreshLeeway = time.Minute
+	sourceID              = "vulnview"
+	defaultBaseURL        = "https://vulnview.writer-security.com/api"
+	defaultScope          = "vulnview"
+	defaultFamily         = familyVulnerability
+	defaultPageSize       = 100
+	maxPageSize           = 500
+	dnsAlertDiscoverPages = 10
+	httpTimeout           = 30 * time.Second
+	maxBodyBytes          = 8 << 20
+	tokenRefreshLeeway    = time.Minute
 
 	familySite          = "site"
 	familyScan          = "scan"
@@ -209,7 +210,7 @@ func (s *Source) dnsAlertFamily() sourcecdk.Family[settings] {
 			return nil
 		},
 		Discover: func(ctx context.Context, settings settings) ([]sourcecdk.URN, error) {
-			records, _, err := s.listDNSAlerts(ctx, settings, "", settings.perPage)
+			records, err := s.discoverDNSAlerts(ctx, settings)
 			if err != nil {
 				return nil, fmt.Errorf("vulnview dns_alert: %w", err)
 			}
@@ -385,61 +386,70 @@ func (s *Source) listDNSAlerts(ctx context.Context, settings settings, cursor st
 	}
 	familySettings := settings
 	familySettings.family = familyAsset
-	for {
-		var response listResponse
-		query := familySettings.query()
-		query.Set("limit", "1")
-		addQuery(query, "cursor", assetCursor)
-		if err := s.getJSON(ctx, familySettings, "/assets", query, &response); err != nil {
-			return nil, "", err
-		}
-		records := []record{}
-		for _, item := range response.Items {
-			var asset map[string]any
-			if err := json.Unmarshal(item, &asset); err != nil {
-				return nil, "", fmt.Errorf("decode VulnView asset: %w", err)
-			}
-			alerts, _ := asset["dnsAlerts"].([]any)
-			for index, rawAlert := range alerts {
-				alert, ok := rawAlert.(map[string]any)
-				if !ok {
-					continue
-				}
-				values := map[string]any{
-					"asset":     asset["asset"],
-					"siteNames": asset["sites"],
-					"scanNames": asset["scanNames"],
-				}
-				maps.Copy(values, alert)
-				raw, err := json.Marshal(values)
-				if err != nil {
-					return nil, "", fmt.Errorf("marshal VulnView DNS alert: %w", err)
-				}
-				id := firstValueString(values, "id", "alert", "name", "type")
-				assetID := valueString(asset["asset"])
-				records = append(records, record{
-					Raw:    raw,
-					Values: values,
-					ID:     stableID(assetID, id, strconv.Itoa(index)),
-				})
-			}
-		}
-		page, nextAlertOffset, err := pageRecords(records, strconv.Itoa(alertOffset), pageSize)
-		if err != nil {
-			return nil, "", err
-		}
-		if len(page) > 0 || strings.TrimSpace(response.NextCursor) == "" {
-			if nextAlertOffset != "" {
-				return page, encodeDNSAlertCursor(assetCursor, nextAlertOffset), nil
-			}
-			if strings.TrimSpace(response.NextCursor) != "" {
-				return page, encodeDNSAlertCursor(response.NextCursor, "0"), nil
-			}
-			return page, "", nil
-		}
-		assetCursor = strings.TrimSpace(response.NextCursor)
-		alertOffset = 0
+	var response listResponse
+	query := familySettings.query()
+	query.Set("limit", strconv.Itoa(familySettings.perPage))
+	addQuery(query, "cursor", assetCursor)
+	if err := s.getJSON(ctx, familySettings, "/assets", query, &response); err != nil {
+		return nil, "", err
 	}
+	records := []record{}
+	for _, item := range response.Items {
+		var asset map[string]any
+		if err := json.Unmarshal(item, &asset); err != nil {
+			return nil, "", fmt.Errorf("decode VulnView asset: %w", err)
+		}
+		alerts, _ := asset["dnsAlerts"].([]any)
+		for index, rawAlert := range alerts {
+			alert, ok := rawAlert.(map[string]any)
+			if !ok {
+				continue
+			}
+			values := map[string]any{
+				"asset":     asset["asset"],
+				"siteNames": asset["sites"],
+				"scanNames": asset["scanNames"],
+			}
+			maps.Copy(values, alert)
+			raw, err := json.Marshal(values)
+			if err != nil {
+				return nil, "", fmt.Errorf("marshal VulnView DNS alert: %w", err)
+			}
+			id := firstValueString(values, "id", "alert", "name", "type")
+			assetID := valueString(asset["asset"])
+			records = append(records, record{
+				Raw:    raw,
+				Values: values,
+				ID:     stableID(assetID, id, strconv.Itoa(index)),
+			})
+		}
+	}
+	page, nextAlertOffset, err := pageRecords(records, strconv.Itoa(alertOffset), pageSize)
+	if err != nil {
+		return nil, "", err
+	}
+	if nextAlertOffset != "" {
+		return page, encodeDNSAlertCursor(assetCursor, nextAlertOffset), nil
+	}
+	if strings.TrimSpace(response.NextCursor) != "" {
+		return page, encodeDNSAlertCursor(response.NextCursor, "0"), nil
+	}
+	return page, "", nil
+}
+
+func (s *Source) discoverDNSAlerts(ctx context.Context, settings settings) ([]record, error) {
+	cursor := ""
+	for page := 0; page < dnsAlertDiscoverPages; page++ {
+		records, next, err := s.listDNSAlerts(ctx, settings, cursor, settings.perPage)
+		if err != nil {
+			return nil, err
+		}
+		if len(records) > 0 || strings.TrimSpace(next) == "" {
+			return records, nil
+		}
+		cursor = next
+	}
+	return nil, nil
 }
 
 func serverPaged(cursor string, pageSize int, recordCount int, nextCursor string) bool {

--- a/sources/vulnview/source_test.go
+++ b/sources/vulnview/source_test.go
@@ -259,7 +259,61 @@ func TestReadDNSAlertsPaginatesWithinAsset(t *testing.T) {
 	}
 }
 
-func TestReadDNSAlertsSkipsEmptyAssetPages(t *testing.T) {
+func TestReadDNSAlertsBatchesAssetPages(t *testing.T) {
+	var assetRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "access", "token_type": "Bearer", "expires_in": 3600})
+		case "/assets":
+			assetRequests++
+			if got := r.URL.Query().Get("limit"); got != "3" {
+				t.Fatalf("limit = %q, want 3", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{
+				{"asset": "empty.writer.com", "dnsAlerts": []map[string]any{}},
+				{
+					"asset":     "staging.writer.com",
+					"dnsAlerts": []map[string]any{{"alert": "dangling-cname", "severity": "high"}},
+				},
+				{
+					"asset":     "prod.writer.com",
+					"dnsAlerts": []map[string]any{{"alert": "stale-a-record", "severity": "medium"}},
+				},
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "writer",
+		"base_url":      server.URL,
+		"token_url":     server.URL + "/token",
+		"client_id":     "client",
+		"client_secret": "secret",
+		"family":        "dns_alert",
+		"per_page":      "3",
+	})
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(pull.Events) = %d, want 2", len(pull.Events))
+	}
+	if assetRequests != 1 {
+		t.Fatalf("assetRequests = %d, want 1", assetRequests)
+	}
+}
+
+func TestReadDNSAlertsReturnsCursorForEmptyAssetBatch(t *testing.T) {
 	var assetRequests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -303,11 +357,73 @@ func TestReadDNSAlertsSkipsEmptyAssetPages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Read() error = %v", err)
 	}
-	if len(pull.Events) != 1 {
-		t.Fatalf("len(pull.Events) = %d, want 1", len(pull.Events))
+	if len(pull.Events) != 0 {
+		t.Fatalf("len(pull.Events) = %d, want 0", len(pull.Events))
 	}
-	if got := pull.Events[0].Attributes["asset_id"]; got != "staging.writer.com" {
+	if pull.NextCursor == nil {
+		t.Fatal("NextCursor = nil, want cursor for next asset page")
+	}
+	next, err := source.Read(context.Background(), cfg, pull.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(next) error = %v", err)
+	}
+	if len(next.Events) != 1 {
+		t.Fatalf("len(next.Events) = %d, want 1", len(next.Events))
+	}
+	if got := next.Events[0].Attributes["asset_id"]; got != "staging.writer.com" {
 		t.Fatalf("asset_id = %q, want staging.writer.com", got)
+	}
+	if assetRequests != 2 {
+		t.Fatalf("assetRequests = %d, want 2", assetRequests)
+	}
+}
+
+func TestDiscoverDNSAlertsAdvancesPastEmptyAssetBatch(t *testing.T) {
+	var assetRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "access", "token_type": "Bearer", "expires_in": 3600})
+		case "/assets":
+			assetRequests++
+			cursor := r.URL.Query().Get("cursor")
+			if cursor == "" {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"items":      []map[string]any{{"asset": "empty.writer.com", "dnsAlerts": []map[string]any{}}},
+					"nextCursor": "1",
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{{
+				"asset":     "staging.writer.com",
+				"dnsAlerts": []map[string]any{{"alert": "dangling-cname", "severity": "high"}},
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id":     "writer",
+		"base_url":      server.URL,
+		"token_url":     server.URL + "/token",
+		"client_id":     "client",
+		"client_secret": "secret",
+		"family":        "dns_alert",
+		"per_page":      "1",
+	})
+	urns, err := source.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(urns) != 1 {
+		t.Fatalf("len(urns) = %d, want 1", len(urns))
 	}
 	if assetRequests != 2 {
 		t.Fatalf("assetRequests = %d, want 2", assetRequests)


### PR DESCRIPTION
Bounds DNS-alert source reads by fetching assets in configured batches instead of scanning one asset at a time until an alert is found. This avoids long-running /assets loops during graph ingest while preserving cursor progress through sparse asset pages.\n\nValidation:\n- go test ./sources/vulnview\n- make verify