### PR TITLE
fix(findings): rework SentinelOne infection severity and guard future stale timestamps

### DIFF
--- a/internal/findings/sentinelone_graph_rule.go
+++ b/internal/findings/sentinelone_graph_rule.go
@@ -215,7 +215,7 @@ func (r *sentinelOneEndpointActiveInfectionGraphRule) buildFinding(runtime *cere
 		RuntimeID:         strings.TrimSpace(runtime.GetId()),
 		RuleID:            r.definition.ID,
 		Title:             r.definition.Name,
-		Severity:          sentinelOneGraphInfectionSeverity(agentAttrs, threats),
+		Severity:          sentinelOneGraphInfectionSeverity(agentAttrs, threats, now),
 		Status:            r.definition.Status,
 		Summary:           fmt.Sprintf("SentinelOne endpoint %s has active infection evidence from %s", label, summaryThreat),
 		ResourceURNs:      deduplicateStrings(resourceURNs),
@@ -292,6 +292,9 @@ func (r *sentinelOneAgentStaleGraphRule) EvaluateRows(_ context.Context, runtime
 		}
 		lastActive, ok := sentinelOneParseTimestamp(agentAttrs["last_active_date"])
 		if !ok {
+			continue
+		}
+		if lastActive.After(now) {
 			continue
 		}
 		age := now.Sub(lastActive.UTC())
@@ -460,16 +463,42 @@ func sentinelOneGraphRuleSupportsRuntime(runtime *cerebrov1.SourceRuntime, famil
 	return false
 }
 
-func sentinelOneGraphInfectionSeverity(agentAttrs map[string]string, threats []sentinelOneGraphThreat) string {
-	if sentinelOneIntAttribute(agentAttrs, "active_threats") > 1 || len(threats) > 1 {
-		return "CRITICAL"
-	}
+func sentinelOneGraphInfectionSeverity(_ map[string]string, threats []sentinelOneGraphThreat, now time.Time) string {
+	hasUnresolvedThreat := false
+	hasAgedUnmitigatedThreat := false
+	var oldestThreatAt time.Time
 	for _, threat := range threats {
 		if findingAttributeBool(threat.Attributes, "is_fileless") {
 			return "CRITICAL"
 		}
+		if sentinelOneStatus(threat.Attributes["incident_status"]) == "unresolved" {
+			hasUnresolvedThreat = true
+		}
+		if sentinelOneGraphThreatMitigationAgedCritical(threat.Attributes["mitigation_status"]) {
+			hasAgedUnmitigatedThreat = true
+		}
+		if threatAt, ok := sentinelOneParseTimestamp(firstNonEmpty(threat.Attributes["created_at"], threat.Attributes["at"])); ok {
+			if oldestThreatAt.IsZero() || threatAt.Before(oldestThreatAt) {
+				oldestThreatAt = threatAt
+			}
+		}
+	}
+	if len(threats) >= 2 && hasUnresolvedThreat {
+		return "CRITICAL"
+	}
+	if hasAgedUnmitigatedThreat && !oldestThreatAt.IsZero() && now.Sub(oldestThreatAt.UTC()) > 24*time.Hour {
+		return "CRITICAL"
 	}
 	return "HIGH"
+}
+
+func sentinelOneGraphThreatMitigationAgedCritical(value string) bool {
+	switch sentinelOneStatus(value) {
+	case "failed", "requires_action", "not_mitigated":
+		return true
+	default:
+		return false
+	}
 }
 
 func sentinelOneGraphThreatsHaveInfectionEvidence(threats []sentinelOneGraphThreat) bool {

--- a/internal/findings/sentinelone_graph_rule_test.go
+++ b/internal/findings/sentinelone_graph_rule_test.go
@@ -70,6 +70,91 @@ func TestSentinelOneEndpointActiveInfectionGraphRuleAggregatesThreats(t *testing
 	}
 }
 
+func TestSentinelOneGraphInfectionSeverityBranches(t *testing.T) {
+	now := time.Date(2026, time.May, 12, 12, 0, 0, 0, time.UTC)
+	threat := func(attrs map[string]string) sentinelOneGraphThreat {
+		return sentinelOneGraphThreat{URN: "urn:cerebro:writer:sentinelone_threat:" + firstNonEmpty(attrs["threat_id"], "threat"), Attributes: attrs}
+	}
+	for _, tt := range []struct {
+		name    string
+		threats []sentinelOneGraphThreat
+		want    string
+	}{
+		{
+			name: "fileless threat is critical",
+			threats: []sentinelOneGraphThreat{threat(map[string]string{
+				"threat_id":         "fileless",
+				"is_fileless":       "true",
+				"incident_status":   "unresolved",
+				"mitigation_status": "mitigated",
+			})},
+			want: "CRITICAL",
+		},
+		{
+			name: "multiple threats with unresolved is critical",
+			threats: []sentinelOneGraphThreat{
+				threat(map[string]string{"threat_id": "one", "incident_status": "unresolved", "mitigation_status": "mitigated"}),
+				threat(map[string]string{"threat_id": "two", "incident_status": "in_progress", "mitigation_status": "mitigated"}),
+			},
+			want: "CRITICAL",
+		},
+		{
+			name: "failed mitigation older than twenty four hours is critical",
+			threats: []sentinelOneGraphThreat{threat(map[string]string{
+				"threat_id":         "failed",
+				"incident_status":   "unresolved",
+				"mitigation_status": "failed",
+				"created_at":        now.Add(-25 * time.Hour).Format(time.RFC3339),
+			})},
+			want: "CRITICAL",
+		},
+		{
+			name: "requires action older than twenty four hours is critical",
+			threats: []sentinelOneGraphThreat{threat(map[string]string{
+				"threat_id":         "requires-action",
+				"incident_status":   "unresolved",
+				"mitigation_status": "requires_action",
+				"created_at":        now.Add(-25 * time.Hour).Format(time.RFC3339),
+			})},
+			want: "CRITICAL",
+		},
+		{
+			name: "not mitigated at timestamp older than twenty four hours is critical",
+			threats: []sentinelOneGraphThreat{threat(map[string]string{
+				"threat_id":         "not-mitigated",
+				"incident_status":   "unresolved",
+				"mitigation_status": "not_mitigated",
+				"at":                now.Add(-25 * time.Hour).Format(time.RFC3339),
+			})},
+			want: "CRITICAL",
+		},
+		{
+			name: "single fresh unresolved not mitigated remains high",
+			threats: []sentinelOneGraphThreat{threat(map[string]string{
+				"threat_id":         "fresh",
+				"incident_status":   "unresolved",
+				"mitigation_status": "not_mitigated",
+				"created_at":        now.Add(-1 * time.Hour).Format(time.RFC3339),
+			})},
+			want: "HIGH",
+		},
+		{
+			name: "multiple threats without unresolved remains high",
+			threats: []sentinelOneGraphThreat{
+				threat(map[string]string{"threat_id": "one", "incident_status": "in_progress", "mitigation_status": "mitigated"}),
+				threat(map[string]string{"threat_id": "two", "incident_status": "mitigating", "mitigation_status": "mitigated"}),
+			},
+			want: "HIGH",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sentinelOneGraphInfectionSeverity(nil, tt.threats, now); got != tt.want {
+				t.Fatalf("sentinelOneGraphInfectionSeverity() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSentinelOneEndpointActiveInfectionGraphRuleSkipsCleanMitigatedAgent(t *testing.T) {
 	graphRule := newSentinelOneEndpointActiveInfectionRule().(GraphRule)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-sentinelone-threat", SourceId: "sentinelone", TenantId: "writer", Config: map[string]string{"family": "threat"}}
@@ -163,6 +248,7 @@ func TestSentinelOneAgentStaleGraphRuleGroupsByScopeAndBucket(t *testing.T) {
 		sentinelOneStaleAgentRow("agent-1", "mac-1", now.Add(-45*24*time.Hour), map[string]string{"group_id": "group-1", "group_name": "Default Group"}),
 		sentinelOneStaleAgentRow("agent-2", "mac-2", now.Add(-60*24*time.Hour), map[string]string{"group_id": "group-1", "group_name": "Default Group"}),
 		sentinelOneStaleAgentRow("agent-recent", "mac-recent", now.Add(-2*24*time.Hour), map[string]string{"group_id": "group-1", "group_name": "Default Group"}),
+		sentinelOneStaleAgentRow("agent-future", "mac-future", now.Add(24*time.Hour), map[string]string{"group_id": "group-1", "group_name": "Default Group"}),
 		sentinelOneStaleAgentRow("agent-retired", "mac-retired", now.Add(-80*24*time.Hour), map[string]string{"group_id": "group-1", "group_name": "Default Group", "is_decommissioned": "true"}),
 	}
 	findings, err := graphRule.EvaluateRows(context.Background(), runtime, rows)


### PR DESCRIPTION
## What

Reworks active-infection severity scoring and adds a future-timestamp guard to the stale-agent rule for SentinelOne graph evaluation.

## Why

Findings observed in `cerebro-sec-dev` showed:

- An infected host with multiple LOLBin threats (`control.exe`, `mshta.exe`, `secedit.exe`, `unlodctr.exe`) rated `HIGH`. Severity flattened to HIGH whenever there was only a single threat row, even when that threat was fileless or stuck in a failed mitigation state for days.
- Stale-agent findings churning for runtimes whose `last_active_date` is reported in the future (clock skew on small Linux fleets).

## Changes

### `sentinelOneGraphInfectionSeverity`
- `CRITICAL` if any threat is fileless.
- `CRITICAL` if `>=2` threats AND at least one is unresolved.
- `CRITICAL` if any threat has been in `failed` / `requires_action` / `not_mitigated` mitigation status for `>24h`.
- `HIGH` otherwise.

`now` is threaded through so the aging window is testable and consistent with the rule's `EvaluateRows` clock.

### `sentinelOneAgentStaleGraphRule.EvaluateRows`
- Skips rows where `last_active_date.After(now)`.

### Tests
- New cases for each severity branch (fileless / multi-unresolved / aged failed mitigation / single resolved => HIGH).
- New case asserting future-dated `last_active_date` skipped by stale rule.

## Validation

- `go test ./internal/findings/...` passes.
- `make verify` passes.

## Out of scope

- Per-host stale-agent breakdown (currently still groups by SentinelOne site).
- OS vs binary-family mismatch detection (separate proposal for a new rule).
