### PR TITLE
fix(findings): suppress routine Okta OAuth grants in control-tamper rule

### DIFF
--- a/internal/findings/identity_signal_rule.go
+++ b/internal/findings/identity_signal_rule.go
@@ -330,11 +330,53 @@ func identityAction(attributes map[string]string) string {
 	return strings.ToLower(firstNonEmpty(attributes["event_type"], attributes["event_name"], attributes["action"], attributes["family"]))
 }
 
-func matchesIdentityAuthControlTampering(_ *cerebrov1.EventEnvelope, attributes map[string]string) bool {
+var oktaAuthControlEventTypes = map[string]struct{}{
+	"policy.lifecycle.activate":               {},
+	"policy.lifecycle.create":                 {},
+	"policy.lifecycle.deactivate":             {},
+	"policy.lifecycle.delete":                 {},
+	"policy.lifecycle.update":                 {},
+	"policy.rule.activate":                    {},
+	"policy.rule.create":                      {},
+	"policy.rule.deactivate":                  {},
+	"policy.rule.delete":                      {},
+	"policy.rule.lifecycle.activate":          {},
+	"policy.rule.lifecycle.create":            {},
+	"policy.rule.lifecycle.deactivate":        {},
+	"policy.rule.lifecycle.delete":            {},
+	"policy.rule.lifecycle.update":            {},
+	"policy.rule.update":                      {},
+	"security.threat.configuration.update":    {},
+	"security.threat.detected":                {},
+	"system.idp.lifecycle.activate":           {},
+	"system.idp.lifecycle.create":             {},
+	"system.idp.lifecycle.deactivate":         {},
+	"system.idp.lifecycle.delete":             {},
+	"system.idp.lifecycle.update":             {},
+	"user.account.update_two_factor_settings": {},
+	"zone.lifecycle.activate":                 {},
+	"zone.lifecycle.create":                   {},
+	"zone.lifecycle.deactivate":               {},
+	"zone.lifecycle.delete":                   {},
+	"zone.lifecycle.update":                   {},
+}
+
+func identityEventKind(event *cerebrov1.EventEnvelope, attributes map[string]string) string {
+	if event != nil {
+		return strings.ToLower(strings.TrimSpace(event.GetKind()))
+	}
+	return strings.ToLower(strings.TrimSpace(attributes["event_kind"]))
+}
+
+func matchesIdentityAuthControlTampering(event *cerebrov1.EventEnvelope, attributes map[string]string) bool {
 	if !identityOutcomeSuccessfulOrUnknown(attributes) {
 		return false
 	}
 	action := identityAction(attributes)
+	if identityEventKind(event, attributes) == "okta.audit" {
+		_, ok := oktaAuthControlEventTypes[action]
+		return ok
+	}
 	resourceType := strings.ToLower(firstNonEmpty(attributes["resource_type"], attributes["target_type"]))
 	return containsAny(action, "policy", "rule", "network_zone", "zone", "idp", "two_step", "2sv", "saml", "security_setting", "change_two_step") &&
 		containsAny(action+" "+resourceType, "update", "delete", "deactivate", "disable", "change", "remove")
@@ -416,13 +458,20 @@ func matchesIdentityExternalGroupMember(_ *cerebrov1.EventEnvelope, attributes m
 }
 
 func matchesIdentityControlTamperOrCredentialChange(event *cerebrov1.EventEnvelope, attributes map[string]string) bool {
+	action := identityAction(attributes)
+	if routineOAuthRuntimeGrant(action) {
+		return false
+	}
+	if identityEventKind(event, attributes) == "okta.audit" && strings.HasPrefix(action, "app.oauth2.") {
+		return false
+	}
 	if !identityOutcomeSuccessfulOrUnknown(attributes) {
 		return false
 	}
 	return matchesIdentityAuthControlTampering(event, attributes) ||
 		matchesIdentityMFAFactorResetOrDisabled(event, attributes) ||
 		matchesIdentityAPITokenOrOAuthCreated(event, attributes) ||
-		containsAny(identityAction(attributes), "password", "credential", "recovery", "reset")
+		containsAny(action, "password", "credential", "recovery", "reset")
 }
 
 func matchesIdentityPrivilegedNoMFAAccess(event *cerebrov1.EventEnvelope, attributes map[string]string) bool {

--- a/internal/findings/identity_signal_rule_test.go
+++ b/internal/findings/identity_signal_rule_test.go
@@ -413,6 +413,86 @@ func TestIdentitySignalRulesTreatRoutineOAuthGrantsAsTelemetry(t *testing.T) {
 	}
 }
 
+func TestIdentitySignalRulesControlTamperOktaEventTypeFiltering(t *testing.T) {
+	rules := identityRulesByID(t)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"}
+	for _, tt := range []struct {
+		name      string
+		eventType string
+		extra     map[string]string
+		want      int
+	}{
+		{
+			name:      "oauth authorize code",
+			eventType: "app.oauth2.authorize.code",
+			extra: map[string]string{
+				"credential_id":   "grant-1",
+				"credential_type": "authorization_code",
+			},
+			want: 0,
+		},
+		{
+			name:      "oauth access token grant",
+			eventType: "app.oauth2.token.grant.access_token",
+			extra: map[string]string{
+				"credential_id":   "token-1",
+				"credential_type": "access_token",
+			},
+			want: 0,
+		},
+		{
+			name:      "session start",
+			eventType: "user.session.start",
+			want:      0,
+		},
+		{
+			name:      "policy deactivated",
+			eventType: "policy.lifecycle.deactivate",
+			extra: map[string]string{
+				"resource_type": "Policy",
+			},
+			want: 1,
+		},
+		{
+			name:      "all mfa factors reset",
+			eventType: "user.mfa.factor.reset_all",
+			extra: map[string]string{
+				"resource_type": "User",
+			},
+			want: 1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			attributes := map[string]string{
+				"domain":         "writer.okta.com",
+				"event_type":     tt.eventType,
+				"actor_id":       "00u-admin",
+				"actor_type":     "User",
+				"resource_id":    "00u-user",
+				"resource_type":  "User",
+				"outcome_result": "SUCCESS",
+			}
+			for key, value := range tt.extra {
+				attributes[key] = value
+			}
+			event := &cerebrov1.EventEnvelope{
+				Id:         "okta-" + strings.ReplaceAll(tt.eventType, ".", "-"),
+				TenantId:   "writer",
+				SourceId:   "okta",
+				Kind:       "okta.audit",
+				Attributes: attributes,
+			}
+			records, err := rules[identityControlTamperCredentialChangeRuleID].Evaluate(context.Background(), runtime, event)
+			if err != nil {
+				t.Fatalf("Evaluate(%s) error = %v", tt.eventType, err)
+			}
+			if len(records) != tt.want {
+				t.Fatalf("len(records) = %d, want %d", len(records), tt.want)
+			}
+		})
+	}
+}
+
 func TestIdentitySignalRulesStillDetectOAuthCredentialCreation(t *testing.T) {
 	rules := identityRulesByID(t)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"}


### PR DESCRIPTION
## What

Stops the identity `control_tamper_or_credential_change` rule from flagging routine Okta OAuth runtime activity as security findings.

## Why

In `cerebro-sec-dev` the writer-okta-audit runtime generated ~1500 evidence rows for this single rule across normal `app.oauth2.token.grant.*` traffic (the runtime grants Okta issues for installed Writer apps). The detection logic was substring-based:

```go
containsAny(action, "policy", "rule", "network_zone", "zone", "idp",
    "two_step", "2sv", "saml", "security_setting", "change_two_step")
```

That string list intersects with normal Okta OAuth event types like `app.oauth2.token.grant.access_token`, plus any action containing the word `credential`, `recovery`, `reset`, etc. The result was a false-positive treadmill drowning out real control-tampering events.

## Changes

### `matchesIdentityControlTamperOrCredentialChange`
- Short-circuits on `routineOAuthRuntimeGrant(action)`.
- Short-circuits on `okta.audit` events whose action starts with `app.oauth2.`.
- OAuth credential creation that is **not** a runtime grant is still picked up by `matchesIdentityAPITokenOrOAuthCreated`, so we keep coverage for net-new OAuth tokens/apps issued to a human identity.

### `matchesIdentityAuthControlTampering`
- For `okta.audit`, uses an explicit allowlist of Okta event types:
  - `policy.lifecycle.*`, `policy.rule.lifecycle.*`, `policy.rule.*`
  - `system.idp.lifecycle.*`
  - `zone.lifecycle.*`
  - `user.account.update_two_factor_settings`
  - `security.threat.detected`, `security.threat.configuration.update`
- For non-Okta sources (`google_workspace.audit`, etc.) the original substring behaviour is preserved so we don't regress coverage on other identity providers.

### Tests

`TestIdentitySignalRulesControlTamperOktaEventTypeFiltering` covers both sides:

| Event | Expected findings |
|-------|-------------------|
| `app.oauth2.authorize.code` | 0 |
| `app.oauth2.token.grant.access_token` | 0 |
| `user.session.start` | 0 |
| `policy.lifecycle.deactivate` | 1 |
| `user.mfa.factor.reset_all` | 1 |

## Validation

- `go test ./internal/findings/...` passes.
- `make verify` passes.

## Out of scope

- 2-event correlation for `control_tamper → credential_change` (proposed separately).
- New `identity-github-okta-bridge-stale` rule.
