### PR TITLE
fix(findings): scale shadow GitHub severity to sensitive repos and tighten recency

### DIFF
--- a/internal/findings/identity_github_active_without_okta_link_rule.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule.go
@@ -27,8 +27,21 @@ const (
 	// change and have no `at` at all, are treated as stale history rather
 	// than current access. Without this, a single historical commit would
 	// hold the finding open indefinitely.
-	identityGitHubActiveWithoutOktaRecencyWindow = 30 * 24 * time.Hour
+	identityGitHubActiveWithoutOktaRecencyWindow = 14 * 24 * time.Hour
 )
+
+var sensitiveRepoSubstrings = []string{
+	"security",
+	"k8s",
+	"devops-terraform",
+	"cerebro",
+	"terraform",
+	"infra",
+	"billing",
+	"mcp-gateway",
+	"secrets",
+	"keys",
+}
 
 // githubActiveWithoutOktaLinkRule fires when a GitHub identity is currently active
 // against repositories or organization resources but has no represents_identity
@@ -727,6 +740,7 @@ func (r *githubActiveWithoutOktaLinkRule) buildFinding(runtime *cerebrov1.Source
 	sort.Slice(targetDetails, func(i, j int) bool {
 		return targetDetails[i]["urn"] < targetDetails[j]["urn"]
 	})
+	severity := githubActiveWithoutOktaSeverity(r.definition.Severity, group.targets)
 	resourceURNs = append(resourceURNs, targetURNs...)
 	primaryGitHubLabel := firstNonEmpty(group.githubUserLabel, group.githubUserURN)
 	summary := fmt.Sprintf(
@@ -765,7 +779,7 @@ func (r *githubActiveWithoutOktaLinkRule) buildFinding(runtime *cerebrov1.Source
 		RuntimeID:         triggeringRuntimeID,
 		RuleID:            r.definition.ID,
 		Title:             r.definition.Name,
-		Severity:          r.definition.Severity,
+		Severity:          severity,
 		Status:            r.definition.Status,
 		Summary:           summary,
 		ResourceURNs:      deduplicateStrings(resourceURNs),
@@ -778,6 +792,43 @@ func (r *githubActiveWithoutOktaLinkRule) buildFinding(runtime *cerebrov1.Source
 		CheckID:           r.definition.ID,
 		CheckName:         r.definition.Name,
 	}
+}
+
+func githubActiveWithoutOktaSeverity(defaultSeverity string, targets map[string]githubActiveWithoutOktaTarget) string {
+	hasGitHubRepo := false
+	for urn, target := range targets {
+		if githubActiveWithoutOktaSensitiveTargetURN(urn) {
+			return "CRITICAL"
+		}
+		if githubActiveWithoutOktaTargetIsRepo(urn, target.entityType) {
+			hasGitHubRepo = true
+		}
+	}
+	if len(targets) >= 5 && hasGitHubRepo {
+		return "CRITICAL"
+	}
+	return defaultSeverity
+}
+
+func githubActiveWithoutOktaSensitiveTargetURN(urn string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(urn))
+	if marker := ":github_repo:"; strings.Contains(normalized, marker) {
+		normalized = strings.TrimSpace(strings.SplitN(normalized, marker, 2)[1])
+	}
+	for _, substring := range sensitiveRepoSubstrings {
+		if strings.Contains(normalized, strings.ToLower(substring)) {
+			return true
+		}
+	}
+	return false
+}
+
+func githubActiveWithoutOktaTargetIsRepo(urn string, entityType string) bool {
+	normalizedType := strings.ToLower(strings.TrimSpace(entityType))
+	if normalizedType == "github.repo" || normalizedType == "github_repo" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(strings.TrimSpace(urn)), ":github_repo:")
 }
 
 func githubBridgeClueFromCypher(bridge any, githubIdentityJSON string, oktaIdentityJSON string) map[string]string {

--- a/internal/findings/identity_github_active_without_okta_link_rule_test.go
+++ b/internal/findings/identity_github_active_without_okta_link_rule_test.go
@@ -3,6 +3,7 @@ package findings
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -196,6 +197,72 @@ func TestGitHubActiveWithoutOktaLinkRuleFindingStampsTriggeringRuntimeID(t *test
 	}
 	if got := githubTriggered.Attributes["source_runtime_id"]; got != "writer-github-audit" {
 		t.Fatalf("attributes[source_runtime_id] = %q, want triggering runtime preserved for telemetry", got)
+	}
+}
+
+func TestGitHubActiveWithoutOktaLinkRuleRecencyWindowBoundary(t *testing.T) {
+	now := githubActiveWithoutOktaRuleFixedNow()
+	atBoundary := githubActiveWithoutOktaRuleActedAttrs(now.Add(-14 * 24 * time.Hour))
+	justStale := githubActiveWithoutOktaRuleActedAttrs(now.Add(-14*24*time.Hour - time.Second))
+	if !edgeIsRecent(atBoundary, now, identityGitHubActiveWithoutOktaRecencyWindow) {
+		t.Fatal("edge exactly 14 days old should remain inside the active GitHub access window")
+	}
+	if edgeIsRecent(justStale, now, identityGitHubActiveWithoutOktaRecencyWindow) {
+		t.Fatal("edge older than 14 days should be stale")
+	}
+}
+
+func TestGitHubActiveWithoutOktaLinkRuleSensitiveRepoEscalatesCritical(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	group := githubActiveWithoutOktaRuleGroupWithTargets("urn:cerebro:writer:github_repo:writer/security-tools")
+	finding := rule.buildFinding(runtime, "writer", group, githubActiveWithoutOktaRuleFixedNow())
+	if got := finding.Severity; got != "CRITICAL" {
+		t.Fatalf("Severity = %q, want CRITICAL for sensitive repo target", got)
+	}
+}
+
+func TestGitHubActiveWithoutOktaLinkRuleFiveRepoTargetsEscalatesCritical(t *testing.T) {
+	rule := newGitHubActiveWithoutOktaLinkRule().(*githubActiveWithoutOktaLinkRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+	cases := []struct {
+		name    string
+		targets []string
+		want    string
+	}{
+		{
+			name: "four boring repos stays high",
+			targets: []string{
+				"urn:cerebro:writer:github_repo:writer/service-a",
+				"urn:cerebro:writer:github_repo:writer/service-b",
+				"urn:cerebro:writer:github_repo:writer/service-c",
+				"urn:cerebro:writer:github_repo:writer/service-d",
+			},
+			want: "HIGH",
+		},
+		{
+			name: "five boring repos escalates critical",
+			targets: []string{
+				"urn:cerebro:writer:github_repo:writer/service-a",
+				"urn:cerebro:writer:github_repo:writer/service-b",
+				"urn:cerebro:writer:github_repo:writer/service-c",
+				"urn:cerebro:writer:github_repo:writer/service-d",
+				"urn:cerebro:writer:github_repo:writer/service-e",
+			},
+			want: "CRITICAL",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			group := githubActiveWithoutOktaRuleGroupWithTargets(tc.targets...)
+			finding := rule.buildFinding(runtime, "writer", group, githubActiveWithoutOktaRuleFixedNow())
+			if got := finding.Severity; got != tc.want {
+				t.Fatalf("Severity = %q, want %s", got, tc.want)
+			}
+			if got, want := finding.Attributes["target_count"], fmt.Sprintf("%d", len(tc.targets)); got != want {
+				t.Fatalf("target_count = %q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -409,7 +476,7 @@ func TestGitHubActiveWithoutOktaLinkRuleEvaluateRowsEmitsForRecentActedOn(t *tes
 		githubActiveWithoutOktaRuleActedAttrs(time.Now().UTC().Add(-1*time.Hour)),
 		"urn:cerebro:writer:github.user:alice",
 		"alice",
-		"urn:cerebro:writer:github_repo:writer/cerebro",
+		"urn:cerebro:writer:github_repo:writer/product-app",
 	)
 	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{row})
 	if err != nil {


### PR DESCRIPTION
## What

Scales shadow-GitHub identity finding severity by the targets each actor can reach, and tightens the recency window from 30d to 14d.

## Why

`identity-github-active-without-okta-link` previously emitted every finding at the rule's static severity, regardless of which repositories the actor was authenticated against. In `cerebro-sec-dev`:

- Actor `da-albert-writer` retained active push to **14** critical infrastructure repos (security tooling, k8s, devops-terraform, cerebro, mcp-gateway).
- That finding sorted at the same severity as 11 lower-impact personal-fork findings for the same actor surface area.

Triage couldn't differentiate "this account can push to cerebro" from "this account is in someone's read-only fork".

Separately, the 30d recency window kept findings open when the only recent activity was a webhook ping or a single push from a month ago. Effective signal of "still actively using" was poor.

## Changes

### `identityGitHubActiveWithoutOktaRecencyWindow`
- `30 * 24 * time.Hour` → `14 * 24 * time.Hour`.

### `buildFinding` + new `githubActiveWithoutOktaSeverity`
Severity is now computed per call from the actor's targets:

1. `CRITICAL` if any target URN substring matches `sensitiveRepoSubstrings`:
   - `security`
   - `k8s`
   - `devops-terraform`
   - `cerebro`
   - `terraform`
   - `infra`
   - `billing`
   - `mcp-gateway`
   - `secrets`
   - `keys`
2. `CRITICAL` if the actor has `>= 5` distinct GitHub repo targets (blast radius).
3. Otherwise the definition's default severity (currently HIGH).

### Tests

- `TestGitHubActiveWithoutOktaLinkRuleRecencyWindowBoundary` — 14d boundary edges.
- `TestGitHubActiveWithoutOktaLinkRuleSensitiveRepoEscalatesCritical` — sensitive-substring path.
- 5-target escalation path test (new).

## Validation

- `go test ./internal/findings/...` passes.
- `make verify` passes.

## Out of scope

- Tenant-level overrides for `sensitiveRepoSubstrings` (currently a package-level var; future RFC if we go multi-tenant).
- New `identity-github-okta-bridge-stale` rule for accounts whose Okta link existed and decayed (proposed separately).
