### PR TITLE
chore(precommit): add tenant-data leak check hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${CEREBRO_SKIP_COMMIT_MSG_CHECK:-}" = "1" ]; then
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+"$repo_root/scripts/leak_check.sh" commit-msg "$1"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,4 +5,10 @@ if [ "${CEREBRO_SKIP_PRE_PUSH:-}" = "1" ]; then
   exit 0
 fi
 
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+if [ "${CEREBRO_SKIP_LEAK_CHECK:-}" != "1" ]; then
+  "$repo_root/scripts/leak_check.sh" pushed
+fi
+
 make verify

--- a/.github/workflows/leak-check.yml
+++ b/.github/workflows/leak-check.yml
@@ -1,0 +1,75 @@
+name: Leak Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  leak-check:
+    name: tenant-data leak check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve range
+        id: range
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          zero="0000000000000000000000000000000000000000"
+          case "$EVENT_NAME" in
+            pull_request)
+              if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+                echo "leak-check: missing pull_request base/head sha" >&2
+                exit 1
+              fi
+              range="${BASE_SHA}...${HEAD_SHA}"
+              ;;
+            push)
+              if [ -z "${BEFORE_SHA:-}" ] || [ "${BEFORE_SHA}" = "${zero}" ]; then
+                # New branch push or no parent; scan the new commit's full
+                # diff against the merge base with origin/main (if possible).
+                if git rev-parse --verify origin/main >/dev/null 2>&1; then
+                  base="$(git merge-base origin/main "${AFTER_SHA}" 2>/dev/null || true)"
+                else
+                  base=""
+                fi
+                if [ -n "$base" ]; then
+                  range="${base}...${AFTER_SHA}"
+                else
+                  range="${AFTER_SHA}~1...${AFTER_SHA}"
+                fi
+              else
+                range="${BEFORE_SHA}...${AFTER_SHA}"
+              fi
+              ;;
+            *)
+              # workflow_dispatch / other: scan the diff between current
+              # HEAD and origin/main (no-op if HEAD == origin/main).
+              range="origin/main...HEAD"
+              ;;
+          esac
+          echo "range=${range}"
+          echo "range=${range}" >> "$GITHUB_OUTPUT"
+
+      - name: Run leak check
+        env:
+          RANGE: ${{ steps.range.outputs.range }}
+        run: |
+          set -euo pipefail
+          ./scripts/leak_check.sh range "$RANGE"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,27 @@
 repos:
   - repo: local
     hooks:
+      - id: cerebro-leak-check-staged
+        name: cerebro tenant-data leak check (staged)
+        entry: ./scripts/leak_check.sh staged
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+      - id: cerebro-leak-check-commit-msg
+        name: cerebro tenant-data leak check (commit message)
+        entry: ./scripts/leak_check.sh commit-msg
+        language: system
+        stages: [commit-msg]
       - id: cerebro-pre-commit-checks
         name: cerebro pre-commit checks
         entry: ./scripts/pre_commit_checks.sh
         language: system
         pass_filenames: false
+        stages: [pre-commit]
+      - id: cerebro-leak-check-pre-push
+        name: cerebro tenant-data leak check (pushed refs)
+        entry: ./scripts/leak_check.sh pushed
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        require_serial: true

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -9,7 +9,7 @@ cd "$repo_root"
 
 mkdir -p "$git_common_dir/hooks"
 
-for hook in pre-commit pre-push; do
+for hook in pre-commit commit-msg pre-push; do
 	if [ ! -f ".githooks/$hook" ]; then
 		echo "missing tracked hook: .githooks/$hook" >&2
 		exit 1

--- a/scripts/leak_check.sh
+++ b/scripts/leak_check.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Scans staged content, commit messages, and refs being pushed for
+# tenant-specific identifiers that must not land in the public cerebro
+# repository (e.g. internal runtime IDs, environment hostnames,
+# credential formats).
+#
+# Modes (first positional argument):
+#   staged                 scan staged diff content (pre-commit)
+#   commit-msg <path>      scan a commit message file (commit-msg)
+#   pushed                 read pre-push stdin and scan commits being pushed
+#   range <base..head>     scan a git revision range (used by CI; range may
+#                          be passed as a single positional argument or via
+#                          $LEAK_CHECK_BASE_REF and $LEAK_CHECK_HEAD_REF)
+#
+# Bypass: set CEREBRO_LEAK_CHECK_BYPASS=1 to skip the check. Bypasses are
+# logged so they show up in shell history and CI logs.
+#
+# Additional patterns may be supplied via a user-local file at
+# $CEREBRO_LEAK_USER_PATTERNS (default: $HOME/.config/cerebro/leak_patterns.txt).
+# That file is intended for entries that should NOT be tracked in the repo
+# (e.g. specific human handles).
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+patterns_file="${repo_root}/scripts/leak_patterns.txt"
+user_patterns_file="${CEREBRO_LEAK_USER_PATTERNS:-$HOME/.config/cerebro/leak_patterns.txt}"
+
+if [ "${CEREBRO_LEAK_CHECK_BYPASS:-}" = "1" ]; then
+  echo "leak-check: BYPASS via CEREBRO_LEAK_CHECK_BYPASS=1 (mode=${1:-?})" >&2
+  exit 0
+fi
+
+if [ ! -f "$patterns_file" ]; then
+  echo "leak-check: patterns file missing at $patterns_file" >&2
+  exit 1
+fi
+
+mode="${1:-staged}"
+shift || true
+
+collect_patterns() {
+  grep -vE '^[[:space:]]*(#|$)' "$patterns_file"
+  if [ -f "$user_patterns_file" ]; then
+    grep -vE '^[[:space:]]*(#|$)' "$user_patterns_file" || true
+  fi
+}
+
+patterns="$(collect_patterns || true)"
+
+if [ -z "$patterns" ]; then
+  echo "leak-check: no patterns configured (mode=$mode)" >&2
+  exit 0
+fi
+
+# redact_matches <input> <pattern>
+# Replaces each occurrence of <pattern> in <input> with a length-only
+# placeholder so the hook never echoes the offending substring back to
+# stderr (which would land in shell history / CI logs).
+#
+# Uses perl for portable, ERE-equivalent regex with \b support and
+# falls back to a coarse line-level scrub if perl is unavailable.
+redact_matches() {
+  local input="$1"
+  local pattern="$2"
+  if command -v perl >/dev/null 2>&1; then
+    PATTERN="$pattern" perl -ne '
+      BEGIN { $p = $ENV{PATTERN} }
+      s/$p/"<REDACTED:len=" . length($&) . ">"/ge;
+      print;
+    ' <<<"$input"
+  else
+    printf '%s\n' "$input" | sed -E "s/$pattern/<REDACTED>/g"
+  fi
+}
+
+# scan_input <label> <input>
+# Returns 0 if clean, 1 if any pattern matched. Matches are printed to
+# stderr with the offending substring replaced by <REDACTED:len=N>.
+scan_input() {
+  local label="$1"
+  local input="$2"
+  local matched=0
+  while IFS= read -r pattern; do
+    [ -z "$pattern" ] && continue
+    local hits
+    hits="$(printf '%s\n' "$input" | grep -E -n -- "$pattern" || true)"
+    if [ -n "$hits" ]; then
+      matched=1
+      printf '%s: pattern matched (%d hit(s))\n' "$label" "$(printf '%s\n' "$hits" | wc -l | tr -d ' ')" >&2
+      local redacted
+      redacted="$(redact_matches "$hits" "$pattern")"
+      printf '%s\n' "$redacted" | sed 's/^/  /' >&2
+    fi
+  done <<<"$patterns"
+  [ "$matched" -eq 0 ]
+}
+
+ignored_path_re='^(vendor/|scripts/leak_patterns\.txt$|go\.sum$|.*\.pem$|.*\.crt$)'
+
+case "$mode" in
+  staged)
+    staged_files="$(git diff --cached --name-only --diff-filter=ACM | grep -vE "$ignored_path_re" || true)"
+    if [ -z "$staged_files" ]; then
+      exit 0
+    fi
+    diff_content="$(git diff --cached --no-color -- $staged_files | grep '^+' | grep -v '^+++' || true)"
+    if [ -z "$diff_content" ]; then
+      exit 0
+    fi
+    if ! scan_input "<staged>" "$diff_content"; then
+      cat >&2 <<'EOF'
+
+leak-check: tenant data pattern matched in staged changes.
+
+  - Review the matches above.
+  - If the match is a false positive, narrow the pattern in
+    scripts/leak_patterns.txt or use synthetic data.
+  - If the match is intentional (e.g. fixture-only), you can bypass
+    with: CEREBRO_LEAK_CHECK_BYPASS=1 git commit ...
+    Bypasses are logged.
+EOF
+      exit 1
+    fi
+    ;;
+
+  commit-msg)
+    msg_file="${1:?commit-msg mode requires a path to the commit message file}"
+    if [ ! -f "$msg_file" ]; then
+      echo "leak-check: commit message file not found: $msg_file" >&2
+      exit 1
+    fi
+    msg="$(cat "$msg_file")"
+    if ! scan_input "<commit-msg>" "$msg"; then
+      echo "" >&2
+      echo "leak-check: tenant data pattern matched in commit message." >&2
+      echo "leak-check: rewrite the message or bypass with CEREBRO_LEAK_CHECK_BYPASS=1" >&2
+      exit 1
+    fi
+    ;;
+
+  range)
+    if [ "$#" -ge 1 ] && [ -n "${1:-}" ]; then
+      range="$1"
+    else
+      base_ref="${LEAK_CHECK_BASE_REF:-origin/main}"
+      head_ref="${LEAK_CHECK_HEAD_REF:-HEAD}"
+      range="${base_ref}...${head_ref}"
+    fi
+    base_part="${range%%.*}"
+    head_part="${range##*.}"
+    if [ -z "$base_part" ] || ! git rev-parse --verify "$base_part" >/dev/null 2>&1; then
+      echo "leak-check: cannot resolve base ref for range '$range'" >&2
+      exit 1
+    fi
+    if [ -z "$head_part" ] || ! git rev-parse --verify "$head_part" >/dev/null 2>&1; then
+      echo "leak-check: cannot resolve head ref for range '$range'" >&2
+      exit 1
+    fi
+    commits_meta="$(git log --format='%H%n%s%n%b%n%an %ae%n---' "$range" 2>/dev/null || true)"
+    commits_diff="$(git diff --no-color "$range" 2>/dev/null | grep '^+' | grep -v '^+++' || true)"
+    combined="${commits_meta}
+${commits_diff}"
+    if [ -z "$(printf '%s' "$commits_meta$commits_diff" | tr -d '[:space:]')" ]; then
+      echo "leak-check: range '$range' has no commits/diff to scan" >&2
+      exit 0
+    fi
+    if ! scan_input "<range:$range>" "$combined"; then
+      echo "" >&2
+      echo "leak-check: tenant data pattern matched in range $range" >&2
+      echo "leak-check: amend or drop the offending commits, or set CEREBRO_LEAK_CHECK_BYPASS=1 (logged)" >&2
+      exit 1
+    fi
+    ;;
+
+  pushed)
+    # git invokes pre-push with: <remote> <url>; refs come on stdin as
+    # <local-ref> <local-sha> <remote-ref> <remote-sha>.
+    zero="0000000000000000000000000000000000000000"
+    saw_any=0
+    while read -r local_ref local_sha remote_ref remote_sha; do
+      saw_any=1
+      if [ "$local_sha" = "$zero" ]; then
+        continue
+      fi
+      if [ "$remote_sha" = "$zero" ]; then
+        base=""
+        if git rev-parse --verify origin/HEAD >/dev/null 2>&1; then
+          base="$(git merge-base origin/HEAD "$local_sha" 2>/dev/null || true)"
+        fi
+        if [ -n "$base" ]; then
+          range="${base}..${local_sha}"
+        else
+          range="$local_sha"
+        fi
+      else
+        range="${remote_sha}..${local_sha}"
+      fi
+      commits_meta="$(git log --format='%H%n%s%n%b%n%an %ae%n---' "$range" 2>/dev/null || true)"
+      commits_diff="$(git diff --no-color "$range" 2>/dev/null | grep '^+' | grep -v '^+++' || true)"
+      combined="${commits_meta}
+${commits_diff}"
+      if ! scan_input "<pushed:$local_ref>" "$combined"; then
+        echo "" >&2
+        echo "leak-check: tenant data pattern matched in commits pushed to $remote_ref" >&2
+        echo "leak-check: amend or drop the offending commits, or bypass with CEREBRO_LEAK_CHECK_BYPASS=1" >&2
+        exit 1
+      fi
+    done
+    if [ "$saw_any" = "0" ]; then
+      exit 0
+    fi
+    ;;
+
+  *)
+    echo "leak-check: unknown mode '$mode' (expected: staged | commit-msg | pushed | range)" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/scripts/leak_patterns.txt
+++ b/scripts/leak_patterns.txt
@@ -1,0 +1,47 @@
+# Generic credential/secret regex denylist for scripts/leak_check.sh.
+# One POSIX-ERE pattern per line. Lines starting with '#' and blank
+# lines are ignored.
+#
+# This file is committed to the public cerebro repository and MUST
+# only contain regex shapes for industry-standard credential formats
+# that are themselves public knowledge (AWS access-key prefix, GitHub
+# token prefixes, PEM headers, etc).
+#
+# Do NOT add any of the following to this file:
+#   - Specific tenant runtime IDs, hostnames, subdomains, or account IDs
+#   - Customer / employee names, emails, or handles
+#   - Internal environment names or URL slugs
+#   - Anything whose presence here would itself disclose tenant data
+#
+# Site-specific and tenant-specific patterns belong in a user-local
+# file at:
+#
+#   $HOME/.config/cerebro/leak_patterns.txt
+#
+# (or override the path with $CEREBRO_LEAK_USER_PATTERNS). That file
+# is not tracked; see scripts/leak_patterns.user.example.txt for the
+# expected layout.
+
+# ---- AWS credential prefixes (public format) ----
+\bAKIA[0-9A-Z]{16}\b
+\bASIA[0-9A-Z]{16}\b
+
+# ---- GitHub token prefixes (public format) ----
+\bgho_[A-Za-z0-9]{20,}\b
+\bghp_[A-Za-z0-9]{20,}\b
+\bghs_[A-Za-z0-9]{20,}\b
+\bghu_[A-Za-z0-9]{20,}\b
+\bghr_[A-Za-z0-9]{20,}\b
+\bgithub_pat_[A-Za-z0-9_]{20,}\b
+
+# ---- Slack token prefixes (public format) ----
+\bxox[abprs]-[A-Za-z0-9-]{10,}\b
+
+# ---- OpenAI / Anthropic / generic API key prefixes (public format) ----
+\bsk-(proj-|ant-|live-|test-)?[A-Za-z0-9_-]{20,}\b
+
+# ---- Private key PEM headers (public format) ----
+-----BEGIN ([A-Z]+ )?PRIVATE KEY-----
+
+# ---- Generic secret-style key/value (broad; tighten if noisy) ----
+(?i)\b(aws_secret_access_key|api[_-]?key|access[_-]?token|bearer)\b[[:space:]]*[:=][[:space:]]*['\"][A-Za-z0-9/_+=.\-]{20,}['\"]

--- a/scripts/leak_patterns.user.example.txt
+++ b/scripts/leak_patterns.user.example.txt
@@ -1,0 +1,43 @@
+# Example layout for the user-local tenant-data denylist consumed by
+# scripts/leak_check.sh.
+#
+# Copy this file to (a path that is NOT tracked by git), populate the
+# entries for your environment, and the leak check will pick it up:
+#
+#   mkdir -p "$HOME/.config/cerebro"
+#   cp scripts/leak_patterns.user.example.txt \
+#      "$HOME/.config/cerebro/leak_patterns.txt"
+#   $EDITOR "$HOME/.config/cerebro/leak_patterns.txt"
+#
+# Override the path via $CEREBRO_LEAK_USER_PATTERNS if you keep your
+# secrets denylist elsewhere.
+#
+# One POSIX-ERE pattern per line. Lines starting with '#' and blank
+# lines are ignored. Entries here SHOULD include:
+#
+#   - Specific environment slugs (dev/stg/prod identifiers)
+#   - Internal subdomains and Tailscale / VPN hostnames
+#   - Tenant runtime IDs (the exact ID strings used in your secrets manager)
+#   - Cloud account IDs you own
+#   - Customer / employee handles you do not want appearing in commits
+#
+# Keep these regexes specific enough that they do not collide with
+# public-facing code. The file is consulted only locally, so site-
+# specific entries never leave your workstation.
+
+# ---- Environment slug examples ----
+# \bmycompany-(sec|grc)-(dev|stg|stage|staging|prod|prd|production)\b
+
+# ---- Internal domain examples ----
+# \.mycompany-internal\.example\b
+# \bcerebro\.(dev|stg|prod)\.[a-z0-9.-]+\b
+
+# ---- Runtime ID examples ----
+# \bmycompany-(okta|github|sentinelone)-(audit|signal|graph)\b
+
+# ---- Cloud account ID examples (12-digit AWS account number) ----
+# \b000000000000\b
+
+# ---- Email / handle examples ----
+# \b[A-Za-z0-9._%+-]+@mycompany\.(com|io|ai)\b
+# \bsome-internal-handle\b

--- a/scripts/pre_commit_checks.sh
+++ b/scripts/pre_commit_checks.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 export PATH="${GOPATH:-$HOME/go}/bin:$PATH"
 
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+if [ "${CEREBRO_SKIP_LEAK_CHECK:-}" != "1" ]; then
+  "$repo_root/scripts/leak_check.sh" staged
+fi
+
 staged_go="$(git diff --cached --name-only --diff-filter=ACM -- '*.go' | grep -v '^vendor/' || true)"
 if [ -n "$staged_go" ]; then
   unformatted="$(printf '%s\n' "$staged_go" | xargs gofmt -l 2>/dev/null || true)"

--- a/tools/archtests/hooks_integrity_test.go
+++ b/tools/archtests/hooks_integrity_test.go
@@ -31,7 +31,7 @@ func TestHookIntegrityManifestMatchesTrackedHooks(t *testing.T) {
 		entries[parts[1]] = parts[0]
 	}
 
-	for _, path := range []string{".githooks/pre-commit", ".githooks/pre-push"} {
+	for _, path := range []string{".githooks/pre-commit", ".githooks/commit-msg", ".githooks/pre-push"} {
 		want, ok := entries[path]
 		if !ok {
 			t.Fatalf("manifest missing %s", path)

--- a/tools/hooks/integrity.sha256
+++ b/tools/hooks/integrity.sha256
@@ -1,2 +1,3 @@
 f38c423c4be0e37f915a9c337e9449dd32756b339469121a3429fea6707084cb  .githooks/pre-commit
-e7a5f841e82e4a03d76cb82b4e397126ec0b646f9e37fead177ec4a5a9781051  .githooks/pre-push
+02d562fd952df6d0b8e7cfa8e4b332f6bfc449fb18e6ada042849ace0cbc3029  .githooks/commit-msg
+45a20a1be273eb3c41ec7a9272e36c137045ef91a04957c58de17a5d9be7c32e  .githooks/pre-push


### PR DESCRIPTION
## What

Adds a `pre-commit` / `commit-msg` / `pre-push` hook and a GitHub Actions workflow that scan staged content, commit messages, and PR diffs for credential formats and (optional) site-specific patterns. Matches block the operation, and the offending substring is replaced with `<REDACTED:len=N>` so real secrets never echo back to the terminal or CI logs.

## Why

Without a guard at the hook layer, an automated workflow or an inattentive operator can commit and push tenant-derived identifiers (internal hostnames, environment slugs, runtime IDs, cloud account numbers) into this public repository. The existing pre-commit checks cover `gofmt` and `make verify` but do not scan for secrets or tenant-shaped strings. This PR closes that gap at both the local-hook layer and the CI layer.

## How

### `scripts/leak_check.sh`
Four modes:
- `staged` (default) - scans the staged diff content.
- `commit-msg <path>` - scans a commit message file.
- `pushed` - reads pre-push stdin and scans every commit being pushed.
- `range <base...head>` - scans a git revision range; used by CI.

Bypass: `CEREBRO_LEAK_CHECK_BYPASS=1`, logged on stderr so it leaves a paper trail.

Match output is redacted via Perl (with a coarse `sed` fallback) so the matched substring is never re-emitted verbatim.

### `scripts/leak_patterns.txt`
Tracked file. Contains **only** generic credential-format regexes:
- AWS access-key prefixes (`AKIA*`, `ASIA*`)
- GitHub token prefixes (`gho_*`, `ghp_*`, `ghs_*`, `ghu_*`, `ghr_*`, `github_pat_*`)
- Slack token prefixes (`xox[abprs]-*`)
- OpenAI / Anthropic / generic API key prefixes (`sk-*`, `sk-ant-*`, etc.)
- PEM private-key headers
- Loose `api_key = "..."` style key/value patterns

No tenant identifiers, hostnames, or account numbers live in this file.

### `scripts/leak_patterns.user.example.txt`
Documented template for a user-local denylist at `$HOME/.config/cerebro/leak_patterns.txt` (override path with `$CEREBRO_LEAK_USER_PATTERNS`). Operators copy this and populate site-specific entries - environment slugs, internal subdomains, runtime IDs, cloud account IDs, customer handles. That file is intentionally untracked.

### Hook wiring
- `.githooks/commit-msg` - new shim calling `leak_check.sh commit-msg`.
- `.githooks/pre-push` - runs `leak_check.sh pushed` before `make verify`.
- `scripts/pre_commit_checks.sh` - runs `leak_check.sh staged` first, then existing gofmt + `make verify`.
- `scripts/install_hooks.sh` - also installs the new `commit-msg` hook.
- `.pre-commit-config.yaml` - adds three entries for the pre-commit framework path.

### CI workflow (`.github/workflows/leak-check.yml`)
New workflow that runs on every `pull_request`, on `push` to `main`, and on `workflow_dispatch`:
- For pull requests: scans `<base.sha>...<head.sha>` (three-dot range, same semantic as GitHub's PR diff).
- For pushes to main: scans `<before.sha>...<after.sha>`, or merge-base if pushing a new branch.
- For workflow_dispatch: scans `origin/main...HEAD`.

The job is named `tenant-data leak check`. To make it a hard gate, add it to required status checks under Settings -> Branches -> main protection rules.

### Integrity manifest
`tools/hooks/integrity.sha256` updated for the new/changed hook files, and the corresponding archtest now also checks `.githooks/commit-msg`.

## Skip toggles

| Env var | Effect |
|---|---|
| `CEREBRO_LEAK_CHECK_BYPASS=1` | Skip leak check, logs to stderr |
| `CEREBRO_SKIP_LEAK_CHECK=1` | Skip leak check inside `pre_commit_checks.sh` / `pre-push` only |
| `CEREBRO_SKIP_COMMIT_MSG_CHECK=1` | Skip the commit-msg hook only |
| `CEREBRO_SKIP_PRE_PUSH=1` | Skip the entire pre-push hook (existing) |

## Verification

- Synthetic AWS access-key prefix, GitHub token prefix, and PEM private-key header in a commit message all block with `<REDACTED:len=N>` output and exit 1.
- Synthetic GitHub token prefix in a staged file blocks with redacted output and exit 1.
- Empty pre-push stdin returns 0.
- Clean staged tree returns 0.
- `CEREBRO_LEAK_CHECK_BYPASS=1` allows the operation and logs the bypass.
- This PR was pushed with the new pre-push leak check active against its own content (exit 0).
- The CI workflow runs against this PR's own diff and passes in ~8 seconds.

## Follow-ups (not in this PR)

- Make `tenant-data leak check` a required status check in branch protection.
- Add an audit log sink for `CEREBRO_LEAK_CHECK_BYPASS=1` usage outside dev workstations.
- Consider an allowlist mechanism for test fixtures that legitimately need credential-shaped strings.
- Investigate distributing tenant-specific patterns to CI via a secret-backed denylist (the user-local file is operator-only today).
