### PR TITLE
feat(vulnview): enrich graph projections

### DIFF
--- a/internal/findings/registry_test.go
+++ b/internal/findings/registry_test.go
@@ -144,6 +144,9 @@ func TestBuiltinRulePacksFlattenIntoCatalog(t *testing.T) {
 	if _, ok := registry.Get(vulnViewActionableExternalFindingRuleID); !ok {
 		t.Fatalf("registry missing %q", vulnViewActionableExternalFindingRuleID)
 	}
+	if _, ok := registry.Get(vulnViewExternalAssetConcentratedSignalRuleID); !ok {
+		t.Fatalf("registry missing %q", vulnViewExternalAssetConcentratedSignalRuleID)
+	}
 	if _, ok := registry.Get(dataSensitiveAssetRiskRuleID); !ok {
 		t.Fatalf("registry missing %q", dataSensitiveAssetRiskRuleID)
 	}

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -92,7 +92,10 @@ func builtinRulePacks() []RulePack {
 			ID:          "vulnview",
 			Name:        "VulnView",
 			Description: "VulnView external attack-surface findings.",
-			Rules:       []Rule{newVulnViewActionableExternalFindingRule()},
+			Rules: []Rule{
+				newVulnViewActionableExternalFindingRule(),
+				newVulnViewExternalAssetConcentratedSignalRule(),
+			},
 		},
 		{
 			ID:          "data",

--- a/internal/findings/vulnview_graph_rule.go
+++ b/internal/findings/vulnview_graph_rule.go
@@ -1,0 +1,309 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	vulnViewExternalAssetConcentratedSignalRuleID = "vulnview-external-asset-concentrated-signal"
+	vulnViewGraphQueryRowLimit                    = 2000
+	vulnViewGraphEvidenceLimit                    = 20
+	vulnViewConcentratedEvidenceThreshold         = 5
+)
+
+type vulnViewExternalAssetConcentratedSignalRule struct {
+	definition RuleDefinition
+}
+
+type vulnViewGraphEvidence struct {
+	URN        string
+	Label      string
+	EntityType string
+	Severity   string
+	Signal     string
+	Attributes map[string]string
+}
+
+func newVulnViewExternalAssetConcentratedSignalRule() Rule {
+	return &vulnViewExternalAssetConcentratedSignalRule{definition: RuleDefinition{
+		ID:          vulnViewExternalAssetConcentratedSignalRuleID,
+		Name:        "VulnView External Asset Concentrated Signal",
+		Description: "Aggregate VulnView graph evidence to prioritize external assets with medium-or-higher or repeated attack-surface signals.",
+		SourceID:    "vulnview",
+		OutputKind:  "finding.vulnview_external_asset_concentrated_signal",
+		Severity:    "dynamic",
+		Status:      findingStatusOpen,
+		Maturity:    "test",
+		Tags:        []string{"vulnview", "graph", "attack-surface", "prioritization"},
+	}}
+}
+
+func (r *vulnViewExternalAssetConcentratedSignalRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return proto.Clone(r.definition.RuleSpec()).(*cerebrov1.RuleSpec)
+}
+
+func (r *vulnViewExternalAssetConcentratedSignalRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if runtime == nil || !strings.EqualFold(strings.TrimSpace(runtime.GetSourceId()), "vulnview") {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(runtime.GetConfig()["family"])) {
+	case "vulnerability", "dns_alert":
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *vulnViewExternalAssetConcentratedSignalRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (r *vulnViewExternalAssetConcentratedSignalRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
+	if runtime == nil || strings.TrimSpace(runtime.GetTenantId()) == "" {
+		return ports.CypherQueryRequest{}
+	}
+	return ports.CypherQueryRequest{
+		Query: `MATCH (asset:Entity {entity_type: 'external.asset', tenant_id: $tenant_id, source_id: 'vulnview'})
+MATCH (asset)-[evidence_rel:RELATION {relation: 'has_evidence', source_id: 'vulnview'}]->(evidence:Entity {tenant_id: $tenant_id, source_id: 'vulnview'})
+WHERE evidence.entity_type IN ['vulnview.finding', 'vulnview.dns_alert']
+WITH asset, collect({
+       urn: evidence.urn,
+       label: coalesce(evidence.label, ''),
+       entity_type: coalesce(evidence.entity_type, ''),
+       attributes_json: coalesce(evidence.attributes_json, ''),
+       evidence_attributes_json: coalesce(evidence_rel.attributes_json, '')
+     }) AS evidence,
+     count(evidence) AS evidence_count,
+     max(CASE
+       WHEN toLower(coalesce(evidence.attributes_json, '')) CONTAINS '"severity":"critical"' THEN 5
+       WHEN toLower(coalesce(evidence.attributes_json, '')) CONTAINS '"severity":"high"' THEN 4
+       WHEN toLower(coalesce(evidence.attributes_json, '')) CONTAINS '"severity":"medium"' THEN 3
+       WHEN toLower(coalesce(evidence.attributes_json, '')) CONTAINS '"severity":"moderate"' THEN 3
+       WHEN toLower(coalesce(evidence.attributes_json, '')) CONTAINS '"severity":"low"' THEN 2
+       WHEN toLower(coalesce(evidence.attributes_json, '')) CONTAINS '"severity":"info"' THEN 1
+       WHEN toLower(coalesce(evidence.attributes_json, '')) CONTAINS '"severity":"informational"' THEN 1
+       ELSE 0
+     END) AS max_severity_rank
+WHERE evidence_count >= $evidence_threshold OR max_severity_rank >= $severity_threshold
+RETURN asset.urn AS asset_urn,
+       asset.label AS asset_label,
+       coalesce(asset.attributes_json, '') AS asset_attributes_json,
+       evidence
+ORDER BY max_severity_rank DESC, evidence_count DESC, asset.urn
+LIMIT $row_limit`,
+		Params: map[string]any{
+			"evidence_threshold": int64(vulnViewConcentratedEvidenceThreshold),
+			"row_limit":          int64(vulnViewGraphQueryRowLimit),
+			"severity_threshold": int64(vulnViewSeverityRank("MEDIUM")),
+			"tenant_id":          strings.TrimSpace(runtime.GetTenantId()),
+		},
+		RowLimit: vulnViewGraphQueryRowLimit,
+	}
+}
+
+func (r *vulnViewExternalAssetConcentratedSignalRule) EvaluateRows(_ context.Context, runtime *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {
+	if r == nil || runtime == nil {
+		return nil, nil
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return nil, nil
+	}
+	now := time.Now().UTC()
+	findings := make([]*ports.FindingRecord, 0, len(rows))
+	for _, row := range rows {
+		assetURN := cypherRowString(row, "asset_urn")
+		if assetURN == "" {
+			continue
+		}
+		assetAttrs := edgeStringAttributes(cypherRowString(row, "asset_attributes_json"))
+		evidence := vulnViewEvidenceFromRow(row)
+		findingCount, dnsCount, maxSeverity := vulnViewEvidenceSummary(evidence)
+		evidenceCount := findingCount + dnsCount
+		if !vulnViewAssetSignalQualifies(evidenceCount, maxSeverity) {
+			continue
+		}
+		findings = append(findings, r.buildFinding(runtime, tenantID, assetURN, cypherRowString(row, "asset_label"), assetAttrs, evidence, findingCount, dnsCount, maxSeverity, now))
+	}
+	return findings, nil
+}
+
+func vulnViewEvidenceFromRow(row ports.CypherRow) []vulnViewGraphEvidence {
+	evidence := []vulnViewGraphEvidence{}
+	for _, item := range cypherRowList(row, "evidence") {
+		urn := cypherListMapString(item, "urn")
+		entityType := cypherListMapString(item, "entity_type")
+		if urn == "" || (entityType != "vulnview.finding" && entityType != "vulnview.dns_alert") {
+			continue
+		}
+		attrs := mergeFindingAttributeMaps(
+			edgeStringAttributes(cypherListMapString(item, "attributes_json")),
+			edgeStringAttributes(cypherListMapString(item, "evidence_attributes_json")),
+		)
+		evidence = append(evidence, vulnViewGraphEvidence{
+			URN:        urn,
+			Label:      cypherListMapString(item, "label"),
+			EntityType: entityType,
+			Severity:   vulnViewNormalizeEvidenceSeverity(attrs["severity"]),
+			Signal:     firstNonEmpty(attrs["template_id"], attrs["alert"], attrs["name"], attrs["external_id"]),
+			Attributes: attrs,
+		})
+	}
+	sort.Slice(evidence, func(i, j int) bool {
+		leftRank := vulnViewSeverityRank(evidence[i].Severity)
+		rightRank := vulnViewSeverityRank(evidence[j].Severity)
+		if leftRank != rightRank {
+			return leftRank > rightRank
+		}
+		return evidence[i].URN < evidence[j].URN
+	})
+	return evidence
+}
+
+func vulnViewEvidenceSummary(evidence []vulnViewGraphEvidence) (int, int, string) {
+	findingCount := 0
+	dnsCount := 0
+	maxSeverity := ""
+	for _, item := range evidence {
+		switch item.EntityType {
+		case "vulnview.finding":
+			findingCount++
+		case "vulnview.dns_alert":
+			dnsCount++
+		}
+		if vulnViewSeverityRank(item.Severity) > vulnViewSeverityRank(maxSeverity) {
+			maxSeverity = item.Severity
+		}
+	}
+	return findingCount, dnsCount, maxSeverity
+}
+
+func vulnViewAssetSignalQualifies(evidenceCount int, maxSeverity string) bool {
+	return vulnViewSeverityRank(maxSeverity) >= vulnViewSeverityRank("MEDIUM") || evidenceCount >= vulnViewConcentratedEvidenceThreshold
+}
+
+func (r *vulnViewExternalAssetConcentratedSignalRule) buildFinding(runtime *cerebrov1.SourceRuntime, tenantID string, assetURN string, assetLabel string, assetAttrs map[string]string, evidence []vulnViewGraphEvidence, findingCount int, dnsCount int, maxSeverity string, now time.Time) *ports.FindingRecord {
+	fingerprint := hashFindingFingerprint(r.definition.ID, tenantID, assetURN)
+	resourceURNs := []string{assetURN}
+	eventIDs := map[string]struct{}{}
+	signals := map[string]struct{}{}
+	graphRows := make([]*cerebrov1.GraphEvidenceRow, 0, len(evidence))
+	for index, item := range evidence {
+		resourceURNs = append(resourceURNs, item.URN)
+		if item.Signal != "" {
+			signals[item.Signal] = struct{}{}
+		}
+		if eventID := strings.TrimSpace(item.Attributes["event_id"]); eventID != "" {
+			eventIDs[eventID] = struct{}{}
+		}
+		if index >= vulnViewGraphEvidenceLimit {
+			continue
+		}
+		graphRows = append(graphRows, newGraphEvidenceRow("vulnview_asset_evidence", map[string]string{
+			"asset_urn":      assetURN,
+			"asset_label":    assetLabel,
+			"evidence_urn":   item.URN,
+			"evidence_label": item.Label,
+			"evidence_type":  item.EntityType,
+			"severity":       item.Severity,
+			"signal":         item.Signal,
+			"event_id":       item.Attributes["event_id"],
+		}, newGraphEvidencePath(assetURN, assetLabel, "external.asset", "has_evidence", item.URN, item.Label, item.EntityType, compactStringMap(item.Attributes))))
+	}
+	signalList := sortedStringSet(signals)
+	attributes := map[string]string{
+		"action":                 "Prioritize external asset with concentrated VulnView evidence",
+		"asset_host":             firstNonEmpty(assetAttrs["asset_id"], assetAttrs["host"], assetLabel),
+		"dns_alert_count":        strconv.Itoa(dnsCount),
+		"evidence_count":         strconv.Itoa(findingCount + dnsCount),
+		"finding_count":          strconv.Itoa(findingCount),
+		"graph_evidence_summary": fmt.Sprintf("%d VulnView finding(s), %d DNS alert(s)", findingCount, dnsCount),
+		"max_severity":           maxSeverity,
+		"primary_resource_urn":   assetURN,
+		"resource_label":         firstNonEmpty(assetLabel, assetAttrs["asset_id"], assetURN),
+		"resource_type":          "external.asset",
+		"signals":                strings.Join(signalList, ","),
+		"source_runtime_id":      strings.TrimSpace(runtime.GetId()),
+	}
+	for key, value := range r.definition.AttributeMap() {
+		attributes["rule_"+key] = value
+	}
+	trimEmptyAttributes(attributes)
+	label := firstNonEmpty(assetLabel, assetAttrs["asset_id"], assetURN)
+	return &ports.FindingRecord{
+		ID:                fingerprint,
+		Fingerprint:       fingerprint,
+		TenantID:          tenantID,
+		RuntimeID:         strings.TrimSpace(runtime.GetId()),
+		RuleID:            r.definition.ID,
+		Title:             r.definition.Name,
+		Severity:          vulnViewConcentratedSignalSeverity(maxSeverity),
+		Status:            r.definition.Status,
+		Summary:           fmt.Sprintf("VulnView external asset %s has %d correlated signal(s)", label, findingCount+dnsCount),
+		ResourceURNs:      deduplicateStrings(resourceURNs),
+		EventIDs:          sortedStringSet(eventIDs),
+		ObservedPolicyIDs: signalList,
+		PolicyID:          firstNonEmpty(strings.Join(signalList, ","), assetURN),
+		PolicyName:        firstNonEmpty(strings.Join(signalList, ", "), "VulnView graph evidence"),
+		CheckID:           r.definition.ID,
+		CheckName:         r.definition.Name,
+		GraphEvidenceRows: graphRows,
+		Attributes:        attributes,
+		FirstObservedAt:   now,
+		LastObservedAt:    now,
+	}
+}
+
+func vulnViewConcentratedSignalSeverity(maxSeverity string) string {
+	if vulnViewSeverityRank(maxSeverity) >= vulnViewSeverityRank("MEDIUM") {
+		return vulnViewNormalizeEvidenceSeverity(maxSeverity)
+	}
+	return "MEDIUM"
+}
+
+func vulnViewNormalizeEvidenceSeverity(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "critical":
+		return "CRITICAL"
+	case "high":
+		return "HIGH"
+	case "medium", "moderate":
+		return "MEDIUM"
+	case "low":
+		return "LOW"
+	case "info", "informational":
+		return "INFO"
+	default:
+		return ""
+	}
+}
+
+func vulnViewSeverityRank(severity string) int {
+	switch strings.ToUpper(strings.TrimSpace(severity)) {
+	case "CRITICAL":
+		return 5
+	case "HIGH":
+		return 4
+	case "MEDIUM":
+		return 3
+	case "LOW":
+		return 2
+	case "INFO", "INFORMATIONAL":
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/findings/vulnview_graph_rule_test.go
+++ b/internal/findings/vulnview_graph_rule_test.go
@@ -1,0 +1,163 @@
+package findings
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestVulnViewExternalAssetConcentratedSignalGraphRuleAggregatesRepeatedEvidence(t *testing.T) {
+	graphRule := newVulnViewExternalAssetConcentratedSignalRule().(GraphRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-vulnview-dns-alert", SourceId: "vulnview", TenantId: "writer"}
+	rows := []ports.CypherRow{vulnViewAssetEvidenceRow("urn:cerebro:writer:external_asset:app.writer.com", "app.writer.com", []map[string]string{
+		{"urn": "urn:cerebro:writer:vulnview_finding:f1", "entity_type": "vulnview.finding", "label": "open-port", "severity": "info", "template_id": "open-port", "event_id": "e1"},
+		{"urn": "urn:cerebro:writer:vulnview_finding:f2", "entity_type": "vulnview.finding", "label": "open-port", "severity": "info", "template_id": "open-port", "event_id": "e2"},
+		{"urn": "urn:cerebro:writer:vulnview_finding:f3", "entity_type": "vulnview.finding", "label": "open-port", "severity": "info", "template_id": "open-port", "event_id": "e3"},
+		{"urn": "urn:cerebro:writer:vulnview_dns_alert:d1", "entity_type": "vulnview.dns_alert", "label": "stale-a-record", "severity": "info", "alert": "stale-a-record", "event_id": "e4"},
+		{"urn": "urn:cerebro:writer:vulnview_dns_alert:d2", "entity_type": "vulnview.dns_alert", "label": "tls-mismatch", "severity": "info", "alert": "tls-mismatch", "event_id": "e5"},
+	})}
+
+	findings, err := graphRule.EvaluateRows(context.Background(), runtime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("len(findings) = %d, want 1", len(findings))
+	}
+	finding := findings[0]
+	if finding.RuleID != vulnViewExternalAssetConcentratedSignalRuleID {
+		t.Fatalf("RuleID = %q", finding.RuleID)
+	}
+	if finding.Severity != "MEDIUM" {
+		t.Fatalf("Severity = %q, want MEDIUM", finding.Severity)
+	}
+	if got := finding.Attributes["evidence_count"]; got != "5" {
+		t.Fatalf("evidence_count = %q, want 5", got)
+	}
+	if len(finding.EventIDs) != 5 {
+		t.Fatalf("len(EventIDs) = %d, want 5", len(finding.EventIDs))
+	}
+	if len(finding.GraphEvidenceRows) != 5 {
+		t.Fatalf("len(GraphEvidenceRows) = %d, want 5", len(finding.GraphEvidenceRows))
+	}
+}
+
+func TestVulnViewExternalAssetConcentratedSignalGraphRuleSupportsEvidenceRuntimesOnly(t *testing.T) {
+	rule := newVulnViewExternalAssetConcentratedSignalRule()
+	if !rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "vulnview", Config: map[string]string{"family": "vulnerability"}}) {
+		t.Fatal("SupportsRuntime(vulnerability) = false, want true")
+	}
+	if !rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "vulnview", Config: map[string]string{"family": "dns_alert"}}) {
+		t.Fatal("SupportsRuntime(dns_alert) = false, want true")
+	}
+	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "vulnview", Config: map[string]string{"family": "asset"}}) {
+		t.Fatal("SupportsRuntime(asset) = true, want false")
+	}
+	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "vulnview", Config: map[string]string{"family": "scan"}}) {
+		t.Fatal("SupportsRuntime(scan) = true, want false")
+	}
+}
+
+func TestVulnViewExternalAssetConcentratedSignalGraphRuleFiltersBeforeLimit(t *testing.T) {
+	graphRule := newVulnViewExternalAssetConcentratedSignalRule().(GraphRule)
+	request := graphRule.QueryFor(&cerebrov1.SourceRuntime{SourceId: "vulnview", TenantId: "writer", Config: map[string]string{"family": "vulnerability"}})
+	if !strings.Contains(request.Query, "WHERE evidence_count >= $evidence_threshold OR max_severity_rank >= $severity_threshold") {
+		t.Fatalf("QueryFor() does not qualify rows before LIMIT:\n%s", request.Query)
+	}
+	if got := request.Params["evidence_threshold"]; got != int64(vulnViewConcentratedEvidenceThreshold) {
+		t.Fatalf("evidence_threshold = %v", got)
+	}
+	if got := request.Params["severity_threshold"]; got != int64(vulnViewSeverityRank("MEDIUM")) {
+		t.Fatalf("severity_threshold = %v", got)
+	}
+}
+
+func TestVulnViewExternalAssetConcentratedSignalGraphRuleEmitsMediumEvidence(t *testing.T) {
+	graphRule := newVulnViewExternalAssetConcentratedSignalRule().(GraphRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-vulnview-vulnerability", SourceId: "vulnview", TenantId: "writer"}
+	rows := []ports.CypherRow{vulnViewAssetEvidenceRow("urn:cerebro:writer:external_asset:api.writer.com", "api.writer.com", []map[string]string{
+		{"urn": "urn:cerebro:writer:vulnview_finding:f1", "entity_type": "vulnview.finding", "label": "open-port", "severity": "medium", "template_id": "open-port", "event_id": "e1"},
+	})}
+
+	findings, err := graphRule.EvaluateRows(context.Background(), runtime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("len(findings) = %d, want 1", len(findings))
+	}
+	if findings[0].Severity != "MEDIUM" {
+		t.Fatalf("Severity = %q, want MEDIUM", findings[0].Severity)
+	}
+}
+
+func TestVulnViewExternalAssetConcentratedSignalGraphRuleSkipsSparseInfoEvidence(t *testing.T) {
+	graphRule := newVulnViewExternalAssetConcentratedSignalRule().(GraphRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-vulnview-dns-alert", SourceId: "vulnview", TenantId: "writer"}
+	rows := []ports.CypherRow{vulnViewAssetEvidenceRow("urn:cerebro:writer:external_asset:info.writer.com", "info.writer.com", []map[string]string{
+		{"urn": "urn:cerebro:writer:vulnview_dns_alert:d1", "entity_type": "vulnview.dns_alert", "label": "ip-geo-info", "severity": "info", "alert": "ip-geo-info", "event_id": "e1"},
+	})}
+
+	findings, err := graphRule.EvaluateRows(context.Background(), runtime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("len(findings) = %d, want 0", len(findings))
+	}
+}
+
+func TestVulnViewExternalAssetConcentratedSignalGraphRuleSkipsMissingSeverity(t *testing.T) {
+	graphRule := newVulnViewExternalAssetConcentratedSignalRule().(GraphRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-vulnview-dns-alert", SourceId: "vulnview", TenantId: "writer"}
+	rows := []ports.CypherRow{vulnViewAssetEvidenceRow("urn:cerebro:writer:external_asset:unknown.writer.com", "unknown.writer.com", []map[string]string{
+		{"urn": "urn:cerebro:writer:vulnview_dns_alert:d1", "entity_type": "vulnview.dns_alert", "label": "unknown-alert", "alert": "unknown-alert", "event_id": "e1"},
+	})}
+
+	findings, err := graphRule.EvaluateRows(context.Background(), runtime, rows)
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("len(findings) = %d, want 0", len(findings))
+	}
+}
+
+func vulnViewAssetEvidenceRow(assetURN string, assetLabel string, evidence []map[string]string) ports.CypherRow {
+	items := make([]any, 0, len(evidence))
+	for _, item := range evidence {
+		attrs := map[string]string{}
+		edgeAttrs := map[string]string{}
+		for key, value := range item {
+			switch key {
+			case "urn", "entity_type", "label":
+			case "event_id":
+				edgeAttrs[key] = value
+			default:
+				attrs[key] = value
+			}
+		}
+		payload, _ := json.Marshal(attrs)
+		edgePayload, _ := json.Marshal(edgeAttrs)
+		items = append(items, map[string]any{
+			"urn":                      item["urn"],
+			"entity_type":              item["entity_type"],
+			"label":                    item["label"],
+			"attributes_json":          string(payload),
+			"evidence_attributes_json": string(edgePayload),
+		})
+	}
+	assetPayload, _ := json.Marshal(map[string]string{"asset_id": assetLabel})
+	return ports.CypherRow{Values: map[string]any{
+		"asset_urn":             assetURN,
+		"asset_label":           assetLabel,
+		"asset_attributes_json": string(assetPayload),
+		"evidence":              items,
+		"debug":                 fmt.Sprintf("%d evidence", len(evidence)),
+	}}
+}

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -191,6 +191,7 @@ func grcVendorProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		Label:      firstAttribute(attrs, "name", "vendor_id"),
 		Attributes: grcAttributes(attrs, map[string]string{"vendor_id": vendorID, "source_system": provider}),
 	})
+	addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, vendorURN, relationHasIdentifier, firstAttribute(attrs, "website_url", "website", "url", "domain"), "grc_vendor_website_host", "0.95")
 	for _, ownerID := range []string{firstAttribute(attrs, "security_owner_user_id"), firstAttribute(attrs, "business_owner_user_id")} {
 		if ownerID == "" {
 			continue
@@ -232,6 +233,7 @@ func grcVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	targetURN := grcTargetURN(tenantID, provider, targetID)
 	if targetURN != "" {
 		addEntity(entities, grcTargetEntity(tenantID, event.GetSourceId(), targetURN, targetID, attrs, provider))
+		addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, targetURN, relationRepresents, grcTargetHost(attrs), "grc_target_host", "0.95")
 		if vulnerabilityURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attrs)))
 		}
@@ -275,12 +277,20 @@ func grcTargetEntity(tenantID string, sourceID string, urn string, targetID stri
 		EntityType: "grc.target",
 		Label:      firstAttribute(attrs, "target_name", "resource_name", "hostname", "target_id", "resource_id"),
 		Attributes: grcAttributes(nil, map[string]string{
+			"host":           grcTargetHost(attrs),
 			"integration_id": firstAttribute(attrs, "integration_id"),
 			"source_system":  provider,
 			"target_id":      targetID,
 			"target_type":    firstAttribute(attrs, "target_type", "resource_type", "asset_type"),
 		}),
 	}
+}
+
+func grcTargetHost(attrs map[string]string) string {
+	if host := internetHost(firstAttribute(attrs, "hostname", "host", "target_url", "resource_url", "url", "website_url")); host != "" {
+		return host
+	}
+	return internetHostIfLikely(firstAttribute(attrs, "target_id", "resource_id", "asset_id", "endpoint_id"))
 }
 
 func grcIntegrationURN(tenantID string, provider string, integrationID string) string {

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -41,6 +41,7 @@ func TestProjectGRCVendorWithOwner(t *testing.T) {
 			"provider":               "vanta",
 			"vendor_id":              "vendor-1",
 			"name":                   "Acme SaaS",
+			"website_url":            "https://app.writer.com",
 			"security_owner_user_id": "user-1",
 			"inherent_risk_level":    "HIGH",
 		},
@@ -50,6 +51,7 @@ func TestProjectGRCVendorWithOwner(t *testing.T) {
 	}
 	vendorURN := "urn:cerebro:writer:vendor:vanta:vendor-1"
 	ownerURN := "urn:cerebro:writer:user:vanta:user-1"
+	hostURN := "urn:cerebro:writer:internet_host:app.writer.com"
 	if entity := state.entities[vendorURN]; entity == nil || entity.EntityType != "vendor" {
 		t.Fatalf("vendor entity missing: %#v", entity)
 	}
@@ -59,7 +61,11 @@ func TestProjectGRCVendorWithOwner(t *testing.T) {
 	if entity := state.entities[ownerURN]; entity == nil || entity.EntityType != "user" {
 		t.Fatalf("owner user entity missing: %#v", entity)
 	}
+	if entity := state.entities[hostURN]; entity == nil || entity.EntityType != "internet.host" {
+		t.Fatalf("internet host entity missing: %#v", entity)
+	}
 	assertProjectedLink(t, state, vendorURN, relationOwnedBy, ownerURN)
+	assertProjectedLink(t, state, vendorURN, relationHasIdentifier, hostURN)
 }
 
 func TestProjectGRCControlTestSupportsControlReferences(t *testing.T) {
@@ -387,6 +393,34 @@ func TestProjectGRCVulnerabilityLinksTargetPackageAndIntegration(t *testing.T) {
 	assertProjectedLink(t, state, targetURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, targetURN, relationContains, packageURN)
 	assertProjectedLink(t, state, targetURN, relationBelongsTo, integrationURN)
+}
+
+func TestProjectGRCVulnerabilityLinksHostLikeTargetID(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerability-host-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerability",
+		Attributes: map[string]string{
+			"provider":         "vanta",
+			"vulnerability_id": "vuln-1",
+			"name":             "CVE-2026-4242",
+			"target_id":        "app.writer.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	targetURN := "urn:cerebro:writer:grc_target:vanta:app.writer.com"
+	hostURN := "urn:cerebro:writer:internet_host:app.writer.com"
+	if got := state.entities[targetURN].Attributes["host"]; got != "app.writer.com" {
+		t.Fatalf("target host = %q, want app.writer.com", got)
+	}
+	assertProjectedLink(t, state, targetURN, relationRepresents, hostURN)
 }
 
 func TestProjectGRCVulnerabilityWritesGraphTargetIntegrationLinks(t *testing.T) {

--- a/internal/sourceprojection/internet.go
+++ b/internal/sourceprojection/internet.go
@@ -1,0 +1,81 @@
+package sourceprojection
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func internetHostURN(tenantID string, raw string) (string, string) {
+	host := internetHost(raw)
+	if host == "" {
+		return "", ""
+	}
+	return projectionURN(tenantID, "internet_host", host), host
+}
+
+func internetHost(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(value); err == nil && parsed.Hostname() != "" {
+		return normalizeInternetHost(parsed.Hostname())
+	}
+	if parsed, err := url.Parse("https://" + value); err == nil && parsed.Hostname() != "" {
+		return normalizeInternetHost(parsed.Hostname())
+	}
+	if host, _, err := net.SplitHostPort(value); err == nil {
+		return normalizeInternetHost(host)
+	}
+	return normalizeInternetHost(strings.Trim(value, "/"))
+}
+
+func internetHostIfLikely(raw string) string {
+	host := internetHost(raw)
+	if host == "" {
+		return ""
+	}
+	if net.ParseIP(host) != nil || strings.Contains(host, ".") {
+		return host
+	}
+	return ""
+}
+
+func normalizeInternetHost(host string) string {
+	normalized := strings.ToLower(strings.TrimSpace(strings.Trim(host, ".")))
+	if normalized == "" || strings.ContainsAny(normalized, " /?#,;@") {
+		return ""
+	}
+	return normalized
+}
+
+func addInternetHostEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, urn string, host string) {
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "internet.host",
+		Label:      host,
+		Attributes: map[string]string{
+			"host": host,
+		},
+	})
+}
+
+func addInternetHostLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, relation string, rawHost string, matchType string, confidence string) {
+	hostURN, host := internetHostURN(tenantID, rawHost)
+	if hostURN == "" || fromURN == "" {
+		return
+	}
+	addInternetHostEntity(entities, tenantID, sourceID, hostURN, host)
+	addLink(links, projectedLink(tenantID, sourceID, fromURN, hostURN, relation, map[string]string{
+		"confidence": confidence,
+		"event_id":   event.GetId(),
+		"host":       host,
+		"match_type": matchType,
+	}))
+}

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -120,6 +120,8 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"sentinelone.vulnerability":            sentinelOneVulnerabilityProjections,
 	"vulnview.asset":                       vulnViewAssetProjections,
 	"vulnview.dns_alert":                   vulnViewDNSAlertProjections,
+	"vulnview.scan":                        vulnViewScanProjections,
+	"vulnview.site":                        vulnViewSiteProjections,
 	"vulnview.vulnerability":               vulnViewVulnerabilityProjections,
 }}
 

--- a/internal/sourceprojection/vulnview.go
+++ b/internal/sourceprojection/vulnview.go
@@ -20,7 +20,9 @@ func vulnViewVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 	assetURN := vulnViewAssetURN(tenantID, attrs)
 	if assetURN != "" {
 		addEntity(entities, vulnViewAssetEntity(tenantID, event.GetSourceId(), assetURN, attrs))
+		addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, assetURN, relationRepresents, firstAttribute(attrs, "asset_id", "host", "target_id", "matched_at"), "vulnview_asset_host", "0.95")
 	}
+	vulnViewAddSiteAndScanContext(entities, links, tenantID, event.GetSourceId(), event, assetURN, "")
 
 	findingURN := projectionURN(tenantID, "vulnview_finding", firstAttribute(attrs, "external_id", "template_id", "name"))
 	if findingURN != "" {
@@ -41,10 +43,12 @@ func vulnViewVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 				"type":        firstAttribute(attrs, "type", "vulnerability_type"),
 			},
 		})
+		vulnViewAddTemplateContext(entities, links, tenantID, event.GetSourceId(), event, findingURN, attrs)
 		if assetURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), assetURN, findingURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, assetURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
 		}
+		vulnViewAddSiteAndScanContext(entities, links, tenantID, event.GetSourceId(), event, "", findingURN)
 	}
 
 	vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), attrs)
@@ -69,10 +73,13 @@ func vulnViewAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projecte
 	}
 	attrs := event.GetAttributes()
 	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
 	if assetURN := vulnViewAssetURN(tenantID, attrs); assetURN != "" {
 		addEntity(entities, vulnViewAssetEntity(tenantID, event.GetSourceId(), assetURN, attrs))
+		addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, assetURN, relationRepresents, firstAttribute(attrs, "asset_id", "target_id", "host", "asset_name"), "vulnview_asset_host", "0.95")
+		vulnViewAddSiteAndScanContext(entities, links, tenantID, event.GetSourceId(), event, assetURN, "")
 	}
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, nil)
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
 
@@ -87,6 +94,8 @@ func vulnViewDNSAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	assetURN := vulnViewAssetURN(tenantID, attrs)
 	if assetURN != "" {
 		addEntity(entities, vulnViewAssetEntity(tenantID, event.GetSourceId(), assetURN, attrs))
+		addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, assetURN, relationRepresents, firstAttribute(attrs, "asset_id", "target_id", "target_name", "asset_name"), "vulnview_asset_host", "0.95")
+		vulnViewAddSiteAndScanContext(entities, links, tenantID, event.GetSourceId(), event, assetURN, "")
 	}
 	alertID := firstAttribute(attrs, "external_id", "alert", "name")
 	alertURN := projectionURN(tenantID, "vulnview_dns_alert", alertID)
@@ -105,9 +114,44 @@ func vulnViewDNSAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 				"severity":     firstAttribute(attrs, "severity"),
 			},
 		})
+		vulnViewAddDNSAlertTypeContext(entities, links, tenantID, event.GetSourceId(), event, alertURN, attrs)
 		if assetURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), assetURN, alertURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, assetURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
+		}
+		vulnViewAddSiteAndScanContext(entities, links, tenantID, event.GetSourceId(), event, "", alertURN)
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func vulnViewSiteProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	entities := map[string]*ports.ProjectedEntity{}
+	for _, site := range vulnViewSiteRefs(event.GetAttributes()) {
+		addEntity(entities, vulnViewSiteEntity(tenantID, event.GetSourceId(), site))
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, nil)
+	return projectedEntities, projectedLinks, nil
+}
+
+func vulnViewScanProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	for _, scan := range vulnViewScanRefs(event.GetAttributes()) {
+		scanEntity := vulnViewScanEntity(tenantID, event.GetSourceId(), scan, event.GetAttributes())
+		addEntity(entities, scanEntity)
+		for _, site := range vulnViewSiteRefs(event.GetAttributes()) {
+			siteEntity := vulnViewSiteEntity(tenantID, event.GetSourceId(), site)
+			addEntity(entities, siteEntity)
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), scanEntity.URN, siteEntity.URN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
 	}
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -154,4 +198,205 @@ func vulnViewAssetEntity(tenantID string, sourceID string, urn string, attrs map
 			"sites":            firstAttribute(attrs, "sites", "site_name", "site_id"),
 		},
 	}
+}
+
+type vulnViewRef struct {
+	URN   string
+	ID    string
+	Name  string
+	Label string
+}
+
+func vulnViewAddSiteAndScanContext(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, assetURN string, evidenceURN string) {
+	attrs := event.GetAttributes()
+	sites := vulnViewSiteRefs(attrs)
+	scans := vulnViewScanRefs(attrs)
+	for _, site := range sites {
+		siteEntity := vulnViewSiteEntity(tenantID, sourceID, site)
+		addEntity(entities, siteEntity)
+		if assetURN != "" {
+			addLink(links, projectedLink(tenantID, sourceID, assetURN, siteEntity.URN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+		if evidenceURN != "" {
+			addLink(links, projectedLink(tenantID, sourceID, evidenceURN, siteEntity.URN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+	for _, scan := range scans {
+		scanEntity := vulnViewScanEntity(tenantID, sourceID, scan, attrs)
+		addEntity(entities, scanEntity)
+		if assetURN != "" {
+			addLink(links, projectedLink(tenantID, sourceID, assetURN, scanEntity.URN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+		if evidenceURN != "" {
+			addLink(links, projectedLink(tenantID, sourceID, evidenceURN, scanEntity.URN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+}
+
+func vulnViewAddTemplateContext(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, findingURN string, attrs map[string]string) {
+	templateID := firstAttribute(attrs, "template_id", "vulnerability_id", "type")
+	templateURN := projectionURN(tenantID, "vulnview_template", templateID)
+	if templateURN == "" || findingURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        templateURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "vulnview.template",
+		Label:      firstAttribute(attrs, "template_id", "name", "vulnerability_id", "type"),
+		Attributes: vulnViewAttributes(map[string]string{
+			"name":        firstAttribute(attrs, "name"),
+			"severity":    firstAttribute(attrs, "severity"),
+			"template_id": templateID,
+			"type":        firstAttribute(attrs, "type"),
+		}),
+	})
+	addLink(links, projectedLink(tenantID, sourceID, findingURN, templateURN, relationHasClassification, map[string]string{"event_id": event.GetId(), "template_id": templateID}))
+}
+
+func vulnViewAddDNSAlertTypeContext(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, alertURN string, attrs map[string]string) {
+	alertType := firstAttribute(attrs, "alert", "name")
+	typeURN := projectionURN(tenantID, "vulnview_dns_alert_type", alertType)
+	if typeURN == "" || alertURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        typeURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "vulnview.dns_alert_type",
+		Label:      alertType,
+		Attributes: vulnViewAttributes(map[string]string{
+			"alert_type": alertType,
+			"severity":   firstAttribute(attrs, "severity"),
+		}),
+	})
+	addLink(links, projectedLink(tenantID, sourceID, alertURN, typeURN, relationHasClassification, map[string]string{"alert_type": alertType, "event_id": event.GetId()}))
+}
+
+func vulnViewSiteRefs(attrs map[string]string) []vulnViewRef {
+	refs := []vulnViewRef{}
+	seen := map[string]struct{}{}
+	add := func(id string, name string) {
+		id = strings.TrimSpace(id)
+		name = strings.TrimSpace(name)
+		key := firstNonEmpty(id, name)
+		if key == "" {
+			return
+		}
+		dedupe := normalizeIdentifier(firstNonEmpty(id, name))
+		if _, ok := seen[dedupe]; ok {
+			return
+		}
+		seen[dedupe] = struct{}{}
+		refs = append(refs, vulnViewRef{ID: id, Name: name, Label: firstNonEmpty(name, id)})
+	}
+	siteNameKeys := []string{"site_name"}
+	if strings.EqualFold(strings.TrimSpace(attrs["family"]), "site") {
+		siteNameKeys = append(siteNameKeys, "name")
+	}
+	add(firstAttribute(attrs, "site_id"), firstAttribute(attrs, siteNameKeys...))
+	for _, name := range splitVulnViewList(firstAttribute(attrs, "sites")) {
+		add("", name)
+	}
+	return refs
+}
+
+func vulnViewScanRefs(attrs map[string]string) []vulnViewRef {
+	refs := []vulnViewRef{}
+	seen := map[string]struct{}{}
+	add := func(id string, name string) {
+		id = strings.TrimSpace(id)
+		name = strings.TrimSpace(name)
+		key := firstNonEmpty(id, name)
+		if key == "" {
+			return
+		}
+		dedupe := normalizeIdentifier(key)
+		if _, ok := seen[dedupe]; ok {
+			return
+		}
+		seen[dedupe] = struct{}{}
+		refs = append(refs, vulnViewRef{ID: id, Name: name, Label: firstNonEmpty(name, id)})
+	}
+	scanNameKeys := []string{"scan_name"}
+	if strings.EqualFold(strings.TrimSpace(attrs["family"]), "scan") {
+		scanNameKeys = append(scanNameKeys, "name")
+	}
+	add(firstAttribute(attrs, "scan_id"), firstAttribute(attrs, scanNameKeys...))
+	for _, name := range splitVulnViewList(firstAttribute(attrs, "scan_names")) {
+		add("", name)
+	}
+	return refs
+}
+
+func vulnViewSiteEntity(tenantID string, sourceID string, ref vulnViewRef) *ports.ProjectedEntity {
+	ref.URN = projectionURN(tenantID, "vulnview_site", firstNonEmpty(ref.Name, ref.ID))
+	return &ports.ProjectedEntity{
+		URN:        ref.URN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "vulnview.site",
+		Label:      ref.Label,
+		Attributes: vulnViewAttributes(map[string]string{
+			"site_id":       ref.ID,
+			"site_name":     ref.Name,
+			"source_system": "vulnview",
+		}),
+	}
+}
+
+func vulnViewScanEntity(tenantID string, sourceID string, ref vulnViewRef, attrs map[string]string) *ports.ProjectedEntity {
+	ref.URN = projectionURN(tenantID, "vulnview_scan", firstNonEmpty(ref.Name, ref.ID))
+	return &ports.ProjectedEntity{
+		URN:        ref.URN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "vulnview.scan",
+		Label:      ref.Label,
+		Attributes: vulnViewAttributes(map[string]string{
+			"cloud_account_id": firstAttribute(attrs, "cloud_account_id"),
+			"completed_at":     firstAttribute(attrs, "completed_at"),
+			"created_at":       firstAttribute(attrs, "created_at"),
+			"findings_count":   firstAttribute(attrs, "findings_count"),
+			"results_key":      firstAttribute(attrs, "results_key"),
+			"scan_id":          ref.ID,
+			"scan_name":        ref.Name,
+			"scan_type":        firstAttribute(attrs, "scan_type"),
+			"source_system":    "vulnview",
+			"started_at":       firstAttribute(attrs, "started_at"),
+			"status":           firstAttribute(attrs, "status"),
+			"target":           firstAttribute(attrs, "target"),
+		}),
+	}
+}
+
+func vulnViewAttributes(attrs map[string]string) map[string]string {
+	out := make(map[string]string, len(attrs))
+	for key, value := range attrs {
+		if strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		out[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return out
+}
+
+func splitVulnViewList(raw string) []string {
+	values := []string{}
+	seen := map[string]struct{}{}
+	for _, part := range strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == ';' }) {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		key := normalizeIdentifier(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		values = append(values, value)
+	}
+	return values
 }

--- a/internal/sourceprojection/vulnview_test.go
+++ b/internal/sourceprojection/vulnview_test.go
@@ -30,26 +30,42 @@ func TestProjectVulnViewVulnerabilityLinksAssetFindingAndCanonicalCVE(t *testing
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 3 {
-		t.Fatalf("Project().EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	if result.EntitiesProjected != 6 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 6", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 4 {
-		t.Fatalf("Project().LinksProjected = %d, want 4", result.LinksProjected)
+	if result.LinksProjected != 8 {
+		t.Fatalf("Project().LinksProjected = %d, want 8", result.LinksProjected)
 	}
 	assetURN := "urn:cerebro:writer:external_asset:app.writer.com"
+	hostURN := "urn:cerebro:writer:internet_host:app.writer.com"
 	findingURN := "urn:cerebro:writer:vulnview_finding:scan-1:cve-2026-1234:https://app.writer.com/login"
+	scanURN := "urn:cerebro:writer:vulnview_scan:scan-1"
+	templateURN := "urn:cerebro:writer:vulnview_template:cve-2026-1234"
 	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-1234"
 	if entity := state.entities[assetURN]; entity == nil || entity.EntityType != "external.asset" {
 		t.Fatalf("external asset entity missing: %#v", entity)
 	}
+	if entity := state.entities[hostURN]; entity == nil || entity.EntityType != "internet.host" {
+		t.Fatalf("internet host entity missing: %#v", entity)
+	}
 	if entity := state.entities[findingURN]; entity == nil || entity.EntityType != "vulnview.finding" {
 		t.Fatalf("finding entity missing: %#v", entity)
+	}
+	if entity := state.entities[scanURN]; entity == nil || entity.EntityType != "vulnview.scan" {
+		t.Fatalf("scan entity missing: %#v", entity)
+	}
+	if entity := state.entities[templateURN]; entity == nil || entity.EntityType != "vulnview.template" {
+		t.Fatalf("template entity missing: %#v", entity)
 	}
 	if entity := state.entities[vulnerabilityURN]; entity == nil || entity.EntityType != "vulnerability" {
 		t.Fatalf("canonical vulnerability entity missing: %#v", entity)
 	}
+	assertProjectedLink(t, state, assetURN, relationRepresents, hostURN)
 	assertProjectedLink(t, state, assetURN, relationHasEvidence, findingURN)
 	assertProjectedLink(t, state, findingURN, relationObservedOn, assetURN)
+	assertProjectedLink(t, state, assetURN, relationBelongsTo, scanURN)
+	assertProjectedLink(t, state, findingURN, relationBelongsTo, scanURN)
+	assertProjectedLink(t, state, findingURN, relationHasClassification, templateURN)
 	assertProjectedLink(t, state, assetURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, findingURN, relationAffectedBy, vulnerabilityURN)
 }
@@ -73,14 +89,98 @@ func TestProjectVulnViewDNSAlertLinksAssetEvidence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
+	if result.EntitiesProjected != 4 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 4", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 4 {
+		t.Fatalf("Project().LinksProjected = %d, want 4", result.LinksProjected)
+	}
+	assetURN := "urn:cerebro:writer:external_asset:stale.writer.com"
+	hostURN := "urn:cerebro:writer:internet_host:stale.writer.com"
+	alertURN := "urn:cerebro:writer:vulnview_dns_alert:stale.writer.com:dangling_cname:0"
+	alertTypeURN := "urn:cerebro:writer:vulnview_dns_alert_type:dangling_cname"
+	assertProjectedLink(t, state, assetURN, relationRepresents, hostURN)
+	assertProjectedLink(t, state, assetURN, relationHasEvidence, alertURN)
+	assertProjectedLink(t, state, alertURN, relationObservedOn, assetURN)
+	assertProjectedLink(t, state, alertURN, relationHasClassification, alertTypeURN)
+}
+
+func TestProjectVulnViewAssetLinksSitesScansAndInternetHost(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "vulnview-asset-1",
+		TenantId: "writer",
+		SourceId: "vulnview",
+		Kind:     "vulnview.asset",
+		Attributes: map[string]string{
+			"asset_id":   "https://app.writer.com/login",
+			"scan_names": "dns-writer.com, port-scan",
+			"sites":      "writer.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesProjected != 5 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 5", result.EntitiesProjected)
+	}
+	if result.LinksProjected != 4 {
+		t.Fatalf("Project().LinksProjected = %d, want 4", result.LinksProjected)
+	}
+	assetURN := "urn:cerebro:writer:external_asset:app.writer.com"
+	hostURN := "urn:cerebro:writer:internet_host:app.writer.com"
+	siteURN := "urn:cerebro:writer:vulnview_site:writer.com"
+	scanURN := "urn:cerebro:writer:vulnview_scan:dns-writer.com"
+	if _, ok := state.entities[siteURN].Attributes["site_id"]; ok {
+		t.Fatal("context site entity should not project blank site_id")
+	}
+	if _, ok := state.entities[scanURN].Attributes["scan_id"]; ok {
+		t.Fatal("context scan entity should not project blank scan_id")
+	}
+	assertProjectedLink(t, state, assetURN, relationRepresents, hostURN)
+	assertProjectedLink(t, state, assetURN, relationBelongsTo, siteURN)
+	assertProjectedLink(t, state, assetURN, relationBelongsTo, scanURN)
+}
+
+func TestProjectVulnViewScanLinksSite(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "vulnview-scan-1",
+		TenantId: "writer",
+		SourceId: "vulnview",
+		Kind:     "vulnview.scan",
+		Attributes: map[string]string{
+			"family":    "scan",
+			"name":      "dns-writer.com",
+			"scan_id":   "scan-1",
+			"scan_type": "dns",
+			"site_id":   "site-1",
+			"site_name": "writer.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
 	if result.EntitiesProjected != 2 {
 		t.Fatalf("Project().EntitiesProjected = %d, want 2", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 2 {
-		t.Fatalf("Project().LinksProjected = %d, want 2", result.LinksProjected)
+	if result.LinksProjected != 1 {
+		t.Fatalf("Project().LinksProjected = %d, want 1", result.LinksProjected)
 	}
-	assetURN := "urn:cerebro:writer:external_asset:stale.writer.com"
-	alertURN := "urn:cerebro:writer:vulnview_dns_alert:stale.writer.com:dangling_cname:0"
-	assertProjectedLink(t, state, assetURN, relationHasEvidence, alertURN)
-	assertProjectedLink(t, state, alertURN, relationObservedOn, assetURN)
+	scanURN := "urn:cerebro:writer:vulnview_scan:dns-writer.com"
+	siteURN := "urn:cerebro:writer:vulnview_site:writer.com"
+	if got := state.entities[scanURN].Attributes["scan_name"]; got != "dns-writer.com" {
+		t.Fatalf("scan_name = %q, want dns-writer.com", got)
+	}
+	if got := state.entities[scanURN].Attributes["scan_id"]; got != "scan-1" {
+		t.Fatalf("scan_id = %q, want scan-1", got)
+	}
+	if got := state.entities[siteURN].Attributes["site_id"]; got != "site-1" {
+		t.Fatalf("site_id = %q, want site-1", got)
+	}
+	assertProjectedLink(t, state, scanURN, relationBelongsTo, siteURN)
 }


### PR DESCRIPTION
Adds graph enrichment for VulnView and deterministic host joins across existing data.\n\nChanges:\n- Project canonical internet.host nodes for VulnView assets and GRC vendor/target host fields\n- Project VulnView site, scan, template, and DNS alert type nodes\n- Link VulnView assets/evidence to scans/sites/taxonomy\n- Add a graph-backed concentrated external asset signal rule\n\nValidation:\n- go test ./internal/sourceprojection ./internal/findings\n- make verify