### PR TITLE
fix(graph): persist terminal ingest run status

### DIFF
--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -21,10 +21,11 @@ import (
 )
 
 const (
-	DefaultPageLimit   = 1
-	MaxPageLimit       = 100
-	DefaultStatusLimit = 25
-	MaxStatusLimit     = 500
+	DefaultPageLimit         = 1
+	MaxPageLimit             = 100
+	DefaultStatusLimit       = 25
+	MaxStatusLimit           = 500
+	terminalRunUpdateTimeout = 15 * time.Second
 )
 
 var (
@@ -193,7 +194,7 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (*RunR
 	}
 	completed := finishRun(run, ingest, graphstore.IngestRunStatusCompleted, nil)
 	result.Run = completed
-	if err := runStore.PutIngestRun(ctx, completed); err != nil {
+	if err := s.putTerminalIngestRun(ctx, runStore, completed); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -297,7 +298,13 @@ func (s *Service) failRun(ctx context.Context, runStore RunStore, run graphstore
 	failed := finishRun(run, ingest, graphstore.IngestRunStatusFailed, runErr)
 	result.Run = failed
 	log.Printf("graph ingest runtime failed run_id=%q runtime_id=%q error=%v", failed.ID, failed.RuntimeID, runErr)
-	return result, errors.Join(runErr, runStore.PutIngestRun(ctx, failed))
+	return result, errors.Join(runErr, s.putTerminalIngestRun(ctx, runStore, failed))
+}
+
+func (s *Service) putTerminalIngestRun(ctx context.Context, runStore RunStore, run graphstore.IngestRun) error {
+	persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), terminalRunUpdateTimeout)
+	defer cancel()
+	return runStore.PutIngestRun(persistCtx, run)
 }
 
 func (s *Service) preparedConfig(ctx context.Context, runtime *cerebrov1.SourceRuntime) (map[string]string, error) {

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -13,12 +13,20 @@ import (
 )
 
 type stubRunStore struct {
-	runs []graphstore.IngestRun
+	runs    []graphstore.IngestRun
+	putRuns []graphstore.IngestRun
+	putFunc func(context.Context, graphstore.IngestRun) error
 }
 
 func (s *stubRunStore) Ping(context.Context) error { return nil }
 
-func (s *stubRunStore) PutIngestRun(context.Context, graphstore.IngestRun) error { return nil }
+func (s *stubRunStore) PutIngestRun(ctx context.Context, run graphstore.IngestRun) error {
+	s.putRuns = append(s.putRuns, run)
+	if s.putFunc != nil {
+		return s.putFunc(ctx, run)
+	}
+	return nil
+}
 
 func (s *stubRunStore) GetIngestRun(context.Context, string) (graphstore.IngestRun, bool, error) {
 	return graphstore.IngestRun{}, false, nil
@@ -341,6 +349,29 @@ func TestHealthFailedCountDoesNotDependOnPagingLimit(t *testing.T) {
 	}
 	if result.Status != "degraded" {
 		t.Fatalf("Health().Status = %q, want degraded", result.Status)
+	}
+}
+
+func TestPutTerminalIngestRunIgnoresParentCancellation(t *testing.T) {
+	parentCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	store := &stubRunStore{
+		putFunc: func(ctx context.Context, _ graphstore.IngestRun) error {
+			if err := ctx.Err(); err != nil {
+				t.Fatalf("PutIngestRun context error = %v, want nil", err)
+			}
+			return nil
+		},
+	}
+	run := graphstore.IngestRun{ID: "run-1", Status: graphstore.IngestRunStatusFailed}
+	if err := New(nil, nil, nil, nil).putTerminalIngestRun(parentCtx, store, run); err != nil {
+		t.Fatalf("putTerminalIngestRun() error = %v", err)
+	}
+	if len(store.putRuns) != 1 {
+		t.Fatalf("PutIngestRun calls = %d, want 1", len(store.putRuns))
+	}
+	if got := store.putRuns[0].Status; got != graphstore.IngestRunStatusFailed {
+		t.Fatalf("persisted status = %q, want failed", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- persist completed/failed graph ingest run status with a fresh bounded context
- prevent canceled request/ingest contexts from leaving persisted runs stuck as running
- add regression coverage for terminal run persistence with a canceled parent context

## Validation
- go test ./internal/graphingest -count=1 -v
- make verify

## Investigation
Live sec-dev graph health is degraded because many persisted ingest runs are stuck running after context-canceled/deadline failures. Separate WriterInternal GitHub audit failures still show 401 and need credential/scope repair.