### PR TITLE
feat(sentinelone): project internet endpoint identifiers

### DIFF
--- a/internal/sourceprojection/internet.go
+++ b/internal/sourceprojection/internet.go
@@ -45,6 +45,29 @@ func internetHostIfLikely(raw string) string {
 	return ""
 }
 
+func internetIPURN(tenantID string, raw string) (string, string) {
+	ip := internetIP(raw)
+	if ip == "" {
+		return "", ""
+	}
+	return projectionURN(tenantID, "internet_ip", ip), ip
+}
+
+func internetIP(raw string) string {
+	host := internetHost(raw)
+	if host == "" {
+		return ""
+	}
+	parsed := net.ParseIP(host)
+	if parsed == nil {
+		return ""
+	}
+	if v4 := parsed.To4(); v4 != nil {
+		return v4.String()
+	}
+	return parsed.String()
+}
+
 func normalizeInternetHost(host string) string {
 	normalized := strings.ToLower(strings.TrimSpace(strings.Trim(host, ".")))
 	if normalized == "" || strings.ContainsAny(normalized, " /?#,;@") {
@@ -62,6 +85,19 @@ func addInternetHostEntity(entities map[string]*ports.ProjectedEntity, tenantID 
 		Label:      host,
 		Attributes: map[string]string{
 			"host": host,
+		},
+	})
+}
+
+func addInternetIPEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, urn string, ip string) {
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        urn,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "internet.ip",
+		Label:      ip,
+		Attributes: map[string]string{
+			"ip": ip,
 		},
 	})
 }

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -178,6 +178,7 @@ func addSentinelOneInternetContext(entities map[string]*ports.ProjectedEntity, l
 		addInternetIPEntity(entities, tenant, event.GetSourceId(), ipURN, ip)
 		addLink(links, projectedLink(tenant, event.GetSourceId(), agentURN, ipURN, relationHasIdentifier, map[string]string{
 			"confidence": "0.80",
+			"at":         eventObservedAt(event),
 			"event_id":   event.GetId(),
 			"ip":         ip,
 			"match_type": "sentinelone_agent_ip",
@@ -194,6 +195,7 @@ func addSentinelOneInternetContext(entities map[string]*ports.ProjectedEntity, l
 	addInternetHostEntity(entities, tenant, event.GetSourceId(), hostURN, host)
 	addLink(links, projectedLink(tenant, event.GetSourceId(), agentURN, hostURN, relationHasIdentifier, map[string]string{
 		"confidence": "0.70",
+		"at":         eventObservedAt(event),
 		"event_id":   event.GetId(),
 		"host":       host,
 		"match_type": "sentinelone_agent_hostname",

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -75,6 +75,7 @@ func sentinelOneAgentProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	})
 
 	addSentinelOneScopeLinks(entities, links, tenant, event, agentURN, attrs)
+	addSentinelOneInternetContext(entities, links, tenant, event, agentURN, attrs)
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
@@ -143,6 +144,7 @@ func sentinelOneThreatProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 				"is_active":      strings.TrimSpace(attrs["is_active"]),
 				"is_infected":    strings.TrimSpace(attrs["is_infected"]),
 				"active_threats": strings.TrimSpace(attrs["active_threats"]),
+				"external_ip":    firstNonEmpty(strings.TrimSpace(attrs["external_ip"]), strings.TrimSpace(attrs["agent_ip_v4"])),
 				"site_id":        strings.TrimSpace(attrs["site_id"]),
 				"group_id":       strings.TrimSpace(attrs["group_id"]),
 				"tenant_host":    strings.TrimSpace(attrs["tenant_host"]),
@@ -158,12 +160,44 @@ func sentinelOneThreatProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 			"incident_status":   strings.TrimSpace(attrs["incident_status"]),
 			"mitigation_status": strings.TrimSpace(attrs["mitigation_status"]),
 		}))
+		addSentinelOneInternetContext(entities, links, tenant, event, agentURN, attrs)
 	}
 
 	addSentinelOneScopeLinks(entities, links, tenant, event, threatURN, attrs)
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
+}
+
+func addSentinelOneInternetContext(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenant string, event *cerebrov1.EventEnvelope, agentURN string, attrs map[string]string) {
+	for _, rawIP := range []string{attrs["external_ip"], attrs["agent_ip_v4"]} {
+		ipURN, ip := internetIPURN(tenant, rawIP)
+		if ipURN == "" {
+			continue
+		}
+		addInternetIPEntity(entities, tenant, event.GetSourceId(), ipURN, ip)
+		addLink(links, projectedLink(tenant, event.GetSourceId(), agentURN, ipURN, relationHasIdentifier, map[string]string{
+			"confidence": "0.80",
+			"event_id":   event.GetId(),
+			"ip":         ip,
+			"match_type": "sentinelone_agent_ip",
+		}))
+	}
+	host := internetHostIfLikely(firstNonEmpty(attrs["computer_name"], attrs["agent_name"], attrs["hostname"]))
+	if host == "" {
+		return
+	}
+	hostURN, host := internetHostURN(tenant, host)
+	if hostURN == "" {
+		return
+	}
+	addInternetHostEntity(entities, tenant, event.GetSourceId(), hostURN, host)
+	addLink(links, projectedLink(tenant, event.GetSourceId(), agentURN, hostURN, relationHasIdentifier, map[string]string{
+		"confidence": "0.70",
+		"event_id":   event.GetId(),
+		"host":       host,
+		"match_type": "sentinelone_agent_hostname",
+	}))
 }
 
 func sentinelOneSiteProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -3,19 +3,23 @@ package sourceprojection
 import (
 	"context"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestProjectSentinelOneAgentBuildsAgentEntity(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
+	occurred := time.Date(2026, time.April, 23, 1, 0, 0, 0, time.UTC)
 
 	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
-		Id:       "s1-agent-1",
-		TenantId: "writer",
-		SourceId: "sentinelone",
-		Kind:     "sentinelone.agent",
+		Id:         "s1-agent-1",
+		TenantId:   "writer",
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.agent",
+		OccurredAt: timestamppb.New(occurred),
 		Attributes: map[string]string{
 			"agent_id":          "agent-1",
 			"computer_name":     "host-1",
@@ -64,6 +68,9 @@ func TestProjectSentinelOneAgentBuildsAgentEntity(t *testing.T) {
 	assertProjectedLink(t, state, agentURN, relationBelongsTo, siteURN)
 	assertProjectedLink(t, state, agentURN, relationMemberOf, groupURN)
 	assertProjectedLink(t, state, agentURN, relationHasIdentifier, ipURN)
+	if got := state.links[agentURN+"|"+relationHasIdentifier+"|"+ipURN].Attributes["at"]; got != occurred.Format(time.RFC3339) {
+		t.Fatalf("identifier link at = %q, want %q", got, occurred.Format(time.RFC3339))
+	}
 }
 
 func TestProjectSentinelOneAgentSkipsWhenAgentIDMissing(t *testing.T) {
@@ -87,12 +94,14 @@ func TestProjectSentinelOneAgentSkipsWhenAgentIDMissing(t *testing.T) {
 func TestProjectSentinelOneThreatLinksThreatToAgent(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
+	occurred := time.Date(2026, time.April, 24, 2, 0, 0, 0, time.UTC)
 
 	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
-		Id:       "s1-threat-1",
-		TenantId: "writer",
-		SourceId: "sentinelone",
-		Kind:     "sentinelone.threat",
+		Id:         "s1-threat-1",
+		TenantId:   "writer",
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.threat",
+		OccurredAt: timestamppb.New(occurred),
 		Attributes: map[string]string{
 			"threat_id":             "threat-1",
 			"agent_id":              "agent-1",
@@ -130,6 +139,9 @@ func TestProjectSentinelOneThreatLinksThreatToAgent(t *testing.T) {
 	}
 	assertProjectedLink(t, state, agentURN, relationAffectedBy, threatURN)
 	assertProjectedLink(t, state, agentURN, relationHasIdentifier, ipURN)
+	if got := state.links[agentURN+"|"+relationHasIdentifier+"|"+ipURN].Attributes["at"]; got != occurred.Format(time.RFC3339) {
+		t.Fatalf("identifier link at = %q, want %q", got, occurred.Format(time.RFC3339))
+	}
 	assertProjectedLink(t, state, threatURN, relationBelongsTo, siteURN)
 	assertProjectedLink(t, state, threatURN, relationMemberOf, groupURN)
 	if got := state.entities[threatURN].Attributes["classification"]; got != "Malware" {

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -26,6 +26,7 @@ func TestProjectSentinelOneAgentBuildsAgentEntity(t *testing.T) {
 			"is_up_to_date":     "true",
 			"infected":          "false",
 			"active_threats":    "0",
+			"external_ip":       "203.0.113.10",
 			"last_active_date":  "2026-04-23T01:00:00Z",
 			"site_id":           "site-1",
 			"site_name":         "Production",
@@ -37,16 +38,17 @@ func TestProjectSentinelOneAgentBuildsAgentEntity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 3 {
-		t.Fatalf("EntitiesProjected = %d, want 3", result.EntitiesProjected)
+	if result.EntitiesProjected != 4 {
+		t.Fatalf("EntitiesProjected = %d, want 4", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 2 {
-		t.Fatalf("LinksProjected = %d, want 2", result.LinksProjected)
+	if result.LinksProjected != 3 {
+		t.Fatalf("LinksProjected = %d, want 3", result.LinksProjected)
 	}
 
 	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
 	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
 	groupURN := "urn:cerebro:writer:sentinelone_group:group-1"
+	ipURN := "urn:cerebro:writer:internet_ip:203.0.113.10"
 	if state.entities[agentURN] == nil {
 		t.Fatalf("agent entity missing: %#v", state.entities)
 	}
@@ -56,8 +58,12 @@ func TestProjectSentinelOneAgentBuildsAgentEntity(t *testing.T) {
 	if state.entities[agentURN].Attributes["computer_name"] != "host-1" {
 		t.Fatalf("agent computer_name = %q, want host-1", state.entities[agentURN].Attributes["computer_name"])
 	}
+	if entity := state.entities[ipURN]; entity == nil || entity.EntityType != "internet.ip" {
+		t.Fatalf("internet ip entity missing: %#v", entity)
+	}
 	assertProjectedLink(t, state, agentURN, relationBelongsTo, siteURN)
 	assertProjectedLink(t, state, agentURN, relationMemberOf, groupURN)
+	assertProjectedLink(t, state, agentURN, relationHasIdentifier, ipURN)
 }
 
 func TestProjectSentinelOneAgentSkipsWhenAgentIDMissing(t *testing.T) {
@@ -92,6 +98,7 @@ func TestProjectSentinelOneThreatLinksThreatToAgent(t *testing.T) {
 			"agent_id":              "agent-1",
 			"agent_name":            "host-1",
 			"computer_name":         "host-1",
+			"external_ip":           "203.0.113.20",
 			"classification":        "Malware",
 			"classification_source": "Engine",
 			"analyst_verdict":       "true_positive",
@@ -111,6 +118,7 @@ func TestProjectSentinelOneThreatLinksThreatToAgent(t *testing.T) {
 	}
 	threatURN := "urn:cerebro:writer:sentinelone_threat:threat-1"
 	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
+	ipURN := "urn:cerebro:writer:internet_ip:203.0.113.20"
 	siteURN := "urn:cerebro:writer:sentinelone_site:site-1"
 	groupURN := "urn:cerebro:writer:sentinelone_group:group-1"
 
@@ -121,6 +129,7 @@ func TestProjectSentinelOneThreatLinksThreatToAgent(t *testing.T) {
 		t.Fatalf("agent entity missing")
 	}
 	assertProjectedLink(t, state, agentURN, relationAffectedBy, threatURN)
+	assertProjectedLink(t, state, agentURN, relationHasIdentifier, ipURN)
 	assertProjectedLink(t, state, threatURN, relationBelongsTo, siteURN)
 	assertProjectedLink(t, state, threatURN, relationMemberOf, groupURN)
 	if got := state.entities[threatURN].Attributes["classification"]; got != "Malware" {


### PR DESCRIPTION
## Summary
- Project SentinelOne agent external/agent IPs to canonical `internet.ip` identifiers.
- Link host-like SentinelOne computer names to canonical `internet.host` identifiers.

## Tests
- `go test ./internal/sourceprojection`
- `make verify`
