### PR TITLE
fix(aws): harden public endpoint discovery

### DIFF
--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -16,7 +16,6 @@ import (
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	apigatewaytypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
@@ -33,7 +32,6 @@ import (
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -78,9 +76,6 @@ type settings struct {
 	accessKeyID     string
 	secretAccessKey string
 	sessionToken    string
-	roleARN         string
-	externalID      string
-	roleSessionName string
 	includeGlobal   bool
 	groupName       string
 	principalType   string
@@ -142,9 +137,11 @@ type awsELBV2API interface {
 
 type awsAPIGatewayAPI interface {
 	GetDomainNames(context.Context, *apigateway.GetDomainNamesInput, ...func(*apigateway.Options)) (*apigateway.GetDomainNamesOutput, error)
+	GetRestApis(context.Context, *apigateway.GetRestApisInput, ...func(*apigateway.Options)) (*apigateway.GetRestApisOutput, error)
 }
 
 type awsAPIGatewayV2API interface {
+	GetApis(context.Context, *apigatewayv2.GetApisInput, ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApisOutput, error)
 	GetDomainNames(context.Context, *apigatewayv2.GetDomainNamesInput, ...func(*apigatewayv2.Options)) (*apigatewayv2.GetDomainNamesOutput, error)
 }
 
@@ -200,13 +197,15 @@ type awsPublicEndpoint struct {
 }
 
 const (
-	publicEndpointStageRoute53      = "route53"
-	publicEndpointStageCloudFront   = "cloudfront"
-	publicEndpointStageELB          = "load_balancer"
-	publicEndpointStageAPIGateway   = "apigateway"
-	publicEndpointStageAPIGatewayV2 = "apigatewayv2"
-	publicEndpointStageEIP          = "elastic_ip"
-	publicEndpointStageENI          = "network_interface"
+	publicEndpointStageRoute53           = "route53"
+	publicEndpointStageCloudFront        = "cloudfront"
+	publicEndpointStageELB               = "load_balancer"
+	publicEndpointStageAPIGateway        = "apigateway"
+	publicEndpointStageAPIGatewayRestAPI = "apigateway_rest_api"
+	publicEndpointStageAPIGatewayV2      = "apigatewayv2"
+	publicEndpointStageAPIGatewayV2API   = "apigatewayv2_api"
+	publicEndpointStageEIP               = "elastic_ip"
+	publicEndpointStageENI               = "network_interface"
 )
 
 type publicEndpointCursor struct {
@@ -468,17 +467,6 @@ func newAWSClients(ctx context.Context, settings settings) (awsClients, error) {
 	if err != nil {
 		return awsClients{}, fmt.Errorf("load aws config: %w", err)
 	}
-	if settings.roleARN != "" {
-		provider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), settings.roleARN, func(options *stscreds.AssumeRoleOptions) {
-			if settings.externalID != "" {
-				options.ExternalID = awssdk.String(settings.externalID)
-			}
-			if settings.roleSessionName != "" {
-				options.RoleSessionName = settings.roleSessionName
-			}
-		})
-		cfg.Credentials = awssdk.NewCredentialsCache(provider)
-	}
 	return awsClients{
 		iam:          iam.NewFromConfig(cfg),
 		cloudTrail:   cloudtrail.NewFromConfig(cfg),
@@ -500,9 +488,6 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		accessKeyID:     configValue(cfg, "access_key_id"),
 		secretAccessKey: configValue(cfg, "secret_access_key"),
 		sessionToken:    configValue(cfg, "session_token"),
-		roleARN:         configValue(cfg, "role_arn"),
-		externalID:      configValue(cfg, "external_id"),
-		roleSessionName: configValue(cfg, "role_session_name"),
 		includeGlobal:   configBool(cfg, "include_global", true),
 		groupName:       configValue(cfg, "group_name"),
 		principalType:   configValue(cfg, "principal_type"),
@@ -520,14 +505,8 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if settings.accountID == "" {
 		return settings, fmt.Errorf("aws account_id is required")
 	}
-	if settings.roleARN != "" && (!strings.HasPrefix(settings.roleARN, "arn:") || !strings.Contains(settings.roleARN, ":role/")) {
-		return settings, fmt.Errorf("aws role_arn must be an IAM role ARN")
-	}
 	if settings.region == "" {
 		settings.region = defaultRegion
-	}
-	if settings.roleARN != "" && settings.roleSessionName == "" {
-		settings.roleSessionName = awsRoleSessionName(settings.accountID, settings.family)
 	}
 	if rawPerPage, ok := cfg.Lookup("per_page"); ok && strings.TrimSpace(rawPerPage) != "" {
 		perPage, err := strconv.Atoi(strings.TrimSpace(rawPerPage))
@@ -698,9 +677,35 @@ func listPublicEndpoints(ctx context.Context, clients awsClients, settings setti
 				}
 				continue
 			}
+			state = publicEndpointCursor{Stage: publicEndpointStageAPIGatewayRestAPI}
+		case publicEndpointStageAPIGatewayRestAPI:
+			endpoints, next, err := listAPIGatewayRestAPIPublicEndpoints(ctx, clients, settings, state, limit)
+			if err != nil || len(endpoints) != 0 {
+				return endpoints, next, err
+			}
+			if next != "" {
+				state, err = parsePublicEndpointCursor(next)
+				if err != nil {
+					return nil, "", err
+				}
+				continue
+			}
 			state = publicEndpointCursor{Stage: publicEndpointStageAPIGatewayV2}
 		case publicEndpointStageAPIGatewayV2:
 			endpoints, next, err := listAPIGatewayV2PublicEndpoints(ctx, clients, settings, state, limit)
+			if err != nil || len(endpoints) != 0 {
+				return endpoints, next, err
+			}
+			if next != "" {
+				state, err = parsePublicEndpointCursor(next)
+				if err != nil {
+					return nil, "", err
+				}
+				continue
+			}
+			state = publicEndpointCursor{Stage: publicEndpointStageAPIGatewayV2API}
+		case publicEndpointStageAPIGatewayV2API:
+			endpoints, next, err := listAPIGatewayV2APIPublicEndpoints(ctx, clients, settings, state, limit)
 			if err != nil || len(endpoints) != 0 {
 				return endpoints, next, err
 			}
@@ -811,6 +816,9 @@ func listCloudFrontPublicEndpoints(ctx context.Context, clients awsClients, sett
 	}
 	endpoints := make([]awsPublicEndpoint, 0, len(out.DistributionList.Items))
 	for _, distribution := range out.DistributionList.Items {
+		if !awssdk.ToBool(distribution.Enabled) {
+			continue
+		}
 		endpoints = append(endpoints, cloudFrontPublicEndpoint(settings, distribution))
 	}
 	if awssdk.ToBool(out.DistributionList.IsTruncated) && awssdk.ToString(out.DistributionList.NextMarker) != "" {
@@ -852,6 +860,28 @@ func listAPIGatewayPublicEndpoints(ctx context.Context, clients awsClients, sett
 	if awssdk.ToString(out.Position) != "" {
 		return endpoints, encodePublicEndpointCursor(publicEndpointCursor{Stage: publicEndpointStageAPIGateway, Token: awssdk.ToString(out.Position)}), nil
 	}
+	return endpoints, encodePublicEndpointCursor(publicEndpointCursor{Stage: publicEndpointStageAPIGatewayRestAPI}), nil
+}
+
+func listAPIGatewayRestAPIPublicEndpoints(ctx context.Context, clients awsClients, settings settings, state publicEndpointCursor, limit int) ([]awsPublicEndpoint, string, error) {
+	out, err := clients.apiGateway.GetRestApis(ctx, &apigateway.GetRestApisInput{Position: stringPtr(state.Token), Limit: int32Ptr(limit)})
+	if err != nil {
+		return nil, "", err
+	}
+	endpoints := make([]awsPublicEndpoint, 0, len(out.Items))
+	for _, api := range out.Items {
+		if api.DisableExecuteApiEndpoint || apiGatewayDomainPrivate(api.EndpointConfiguration) {
+			continue
+		}
+		endpoint := apiGatewayRestAPIPublicEndpoint(settings, api)
+		if endpoint.ResourceID == "" || endpoint.Host == "" {
+			continue
+		}
+		endpoints = append(endpoints, endpoint)
+	}
+	if awssdk.ToString(out.Position) != "" {
+		return endpoints, encodePublicEndpointCursor(publicEndpointCursor{Stage: publicEndpointStageAPIGatewayRestAPI, Token: awssdk.ToString(out.Position)}), nil
+	}
 	return endpoints, encodePublicEndpointCursor(publicEndpointCursor{Stage: publicEndpointStageAPIGatewayV2}), nil
 }
 
@@ -866,6 +896,28 @@ func listAPIGatewayV2PublicEndpoints(ctx context.Context, clients awsClients, se
 	}
 	if awssdk.ToString(out.NextToken) != "" {
 		return endpoints, encodePublicEndpointCursor(publicEndpointCursor{Stage: publicEndpointStageAPIGatewayV2, Token: awssdk.ToString(out.NextToken)}), nil
+	}
+	return endpoints, encodePublicEndpointCursor(publicEndpointCursor{Stage: publicEndpointStageAPIGatewayV2API}), nil
+}
+
+func listAPIGatewayV2APIPublicEndpoints(ctx context.Context, clients awsClients, settings settings, state publicEndpointCursor, limit int) ([]awsPublicEndpoint, string, error) {
+	out, err := clients.apiGatewayV2.GetApis(ctx, &apigatewayv2.GetApisInput{NextToken: stringPtr(state.Token), MaxResults: stringPtr(strconv.Itoa(limit))})
+	if err != nil {
+		return nil, "", err
+	}
+	endpoints := make([]awsPublicEndpoint, 0, len(out.Items))
+	for _, api := range out.Items {
+		if awssdk.ToBool(api.DisableExecuteApiEndpoint) {
+			continue
+		}
+		endpoint := apiGatewayV2APIPublicEndpoint(settings, api)
+		if endpoint.ResourceID == "" || endpoint.Host == "" {
+			continue
+		}
+		endpoints = append(endpoints, endpoint)
+	}
+	if awssdk.ToString(out.NextToken) != "" {
+		return endpoints, encodePublicEndpointCursor(publicEndpointCursor{Stage: publicEndpointStageAPIGatewayV2API, Token: awssdk.ToString(out.NextToken)}), nil
 	}
 	return endpoints, encodePublicEndpointCursor(publicEndpointCursor{Stage: publicEndpointStageEIP}), nil
 }
@@ -1060,6 +1112,25 @@ func apiGatewayPublicEndpoint(settings settings, domain apigatewaytypes.DomainNa
 	}
 }
 
+func apiGatewayRestAPIPublicEndpoint(settings settings, api apigatewaytypes.RestApi) awsPublicEndpoint {
+	apiID := awssdk.ToString(api.Id)
+	host := ""
+	if apiID != "" {
+		host = fmt.Sprintf("%s.execute-api.%s.amazonaws.com", apiID, settings.region)
+	}
+	return awsPublicEndpoint{
+		ResourceID:   firstNonEmpty(apiID, host),
+		ResourceName: firstNonEmpty(awssdk.ToString(api.Name), apiID, host),
+		ResourceType: "apigateway_rest_api",
+		EndpointID:   firstNonEmpty(apiID, host),
+		EndpointType: firstNonEmpty(apiGatewayEndpointTypes(api.EndpointConfiguration), "execute_api"),
+		Host:         host,
+		Region:       settings.region,
+		Scope:        settings.accountID,
+		Service:      "apigateway",
+	}
+}
+
 func apiGatewayV2PublicEndpoint(settings settings, domain apigatewayv2types.DomainName) awsPublicEndpoint {
 	targetHosts := make([]string, 0, len(domain.DomainNameConfigurations))
 	endpointTypes := make([]string, 0, len(domain.DomainNameConfigurations))
@@ -1079,6 +1150,26 @@ func apiGatewayV2PublicEndpoint(settings settings, domain apigatewayv2types.Doma
 		Host:         dnsHost(awssdk.ToString(domain.DomainName)),
 		TargetHost:   firstString(targetHosts),
 		TargetHosts:  targetHosts,
+		Region:       settings.region,
+		Scope:        settings.accountID,
+		Service:      "apigatewayv2",
+	}
+}
+
+func apiGatewayV2APIPublicEndpoint(settings settings, api apigatewayv2types.Api) awsPublicEndpoint {
+	apiID := awssdk.ToString(api.ApiId)
+	host := dnsHost(awssdk.ToString(api.ApiEndpoint))
+	if host == "" && apiID != "" {
+		host = fmt.Sprintf("%s.execute-api.%s.amazonaws.com", apiID, settings.region)
+	}
+	protocol := string(api.ProtocolType)
+	return awsPublicEndpoint{
+		ResourceID:   firstNonEmpty(apiID, host),
+		ResourceName: firstNonEmpty(awssdk.ToString(api.Name), apiID, host),
+		ResourceType: "apigatewayv2_api",
+		EndpointID:   firstNonEmpty(apiID, host),
+		EndpointType: firstNonEmpty(protocol, "execute_api"),
+		Host:         host,
 		Region:       settings.region,
 		Scope:        settings.accountID,
 		Service:      "apigatewayv2",
@@ -1667,14 +1758,6 @@ func normalizeAWSResourceType(value string) string {
 	normalized = strings.ReplaceAll(normalized, "-", "_")
 	normalized = strings.ReplaceAll(normalized, ".", "_")
 	return strings.Trim(normalized, "_")
-}
-
-func awsRoleSessionName(accountID string, family string) string {
-	name := sanitizeEventID("cerebro-" + firstNonEmpty(family, "source") + "-" + accountID)
-	if len(name) > 64 {
-		return name[:64]
-	}
-	return name
 }
 
 func cloudTrailActor(event cloudtrailtypes.Event, detail cloudTrailDetail) cloudTrailUserIdentity {

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -49,6 +49,7 @@ const (
 	defaultRegion          = "us-east-1"
 	defaultPageSize        = 10
 	maxPageSize            = 200
+	publicEndpointCursorV2 = 2
 	familyAccessKey        = "access_key"
 	familyCloudTrail       = "cloudtrail"
 	familyIAMGroup         = "iam_group"
@@ -209,6 +210,7 @@ const (
 )
 
 type publicEndpointCursor struct {
+	Version                 int    `json:"version,omitempty"`
 	Stage                   string `json:"stage,omitempty"`
 	Token                   string `json:"token,omitempty"`
 	Route53ZoneMarker       string `json:"route53_zone_marker,omitempty"`
@@ -504,6 +506,11 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 	}
 	if settings.accountID == "" {
 		return settings, fmt.Errorf("aws account_id is required")
+	}
+	for _, key := range []string{"role_arn", "external_id", "role_session_name"} {
+		if value, ok := cfg.Lookup(key); ok && strings.TrimSpace(value) != "" {
+			return settings, fmt.Errorf("aws %s is no longer supported", key)
+		}
 	}
 	if settings.region == "" {
 		settings.region = defaultRegion
@@ -1114,10 +1121,7 @@ func apiGatewayPublicEndpoint(settings settings, domain apigatewaytypes.DomainNa
 
 func apiGatewayRestAPIPublicEndpoint(settings settings, api apigatewaytypes.RestApi) awsPublicEndpoint {
 	apiID := awssdk.ToString(api.Id)
-	host := ""
-	if apiID != "" {
-		host = fmt.Sprintf("%s.execute-api.%s.amazonaws.com", apiID, settings.region)
-	}
+	host := executeAPIHost(apiID, settings.region)
 	return awsPublicEndpoint{
 		ResourceID:   firstNonEmpty(apiID, host),
 		ResourceName: firstNonEmpty(awssdk.ToString(api.Name), apiID, host),
@@ -1160,7 +1164,7 @@ func apiGatewayV2APIPublicEndpoint(settings settings, api apigatewayv2types.Api)
 	apiID := awssdk.ToString(api.ApiId)
 	host := dnsHost(awssdk.ToString(api.ApiEndpoint))
 	if host == "" && apiID != "" {
-		host = fmt.Sprintf("%s.execute-api.%s.amazonaws.com", apiID, settings.region)
+		host = executeAPIHost(apiID, settings.region)
 	}
 	protocol := string(api.ProtocolType)
 	return awsPublicEndpoint{
@@ -1621,10 +1625,10 @@ func configBool(cfg sourcecdk.Config, key string, fallback bool) bool {
 func parsePublicEndpointCursor(raw string) (publicEndpointCursor, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return publicEndpointCursor{Stage: publicEndpointStageRoute53}, nil
+		return publicEndpointCursor{Version: publicEndpointCursorV2, Stage: publicEndpointStageRoute53}, nil
 	}
 	if strings.HasPrefix(raw, "eni:") {
-		return publicEndpointCursor{Stage: publicEndpointStageENI, Token: strings.TrimPrefix(raw, "eni:")}, nil
+		return publicEndpointCursor{Version: publicEndpointCursorV2, Stage: publicEndpointStageAPIGatewayRestAPI}, nil
 	}
 	decoded, err := base64.RawURLEncoding.DecodeString(raw)
 	if err != nil {
@@ -1637,6 +1641,7 @@ func parsePublicEndpointCursor(raw string) (publicEndpointCursor, error) {
 	if cursor.Stage == "" {
 		cursor.Stage = publicEndpointStageRoute53
 	}
+	cursor = upgradePublicEndpointCursor(cursor)
 	return cursor, nil
 }
 
@@ -1644,11 +1649,27 @@ func encodePublicEndpointCursor(cursor publicEndpointCursor) string {
 	if cursor.Stage == "" {
 		return ""
 	}
+	if cursor.Version == 0 {
+		cursor.Version = publicEndpointCursorV2
+	}
 	payload, err := json.Marshal(cursor)
 	if err != nil {
 		return ""
 	}
 	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func upgradePublicEndpointCursor(cursor publicEndpointCursor) publicEndpointCursor {
+	if cursor.Version != 0 {
+		return cursor
+	}
+	switch cursor.Stage {
+	case publicEndpointStageAPIGatewayV2, publicEndpointStageEIP, publicEndpointStageENI:
+		return publicEndpointCursor{Version: publicEndpointCursorV2, Stage: publicEndpointStageAPIGatewayRestAPI}
+	default:
+		cursor.Version = publicEndpointCursorV2
+		return cursor
+	}
 }
 
 func route53HostedZoneID(raw string) string {
@@ -1758,6 +1779,22 @@ func normalizeAWSResourceType(value string) string {
 	normalized = strings.ReplaceAll(normalized, "-", "_")
 	normalized = strings.ReplaceAll(normalized, ".", "_")
 	return strings.Trim(normalized, "_")
+}
+
+func executeAPIHost(apiID string, region string) string {
+	apiID = strings.TrimSpace(apiID)
+	region = strings.TrimSpace(region)
+	if apiID == "" || region == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s.execute-api.%s.%s", apiID, region, awsDNSSuffix(region))
+}
+
+func awsDNSSuffix(region string) string {
+	if strings.HasPrefix(strings.TrimSpace(region), "cn-") {
+		return "amazonaws.com.cn"
+	}
+	return "amazonaws.com"
 }
 
 func cloudTrailActor(event cloudtrailtypes.Event, detail cloudTrailDetail) cloudTrailUserIdentity {

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -259,6 +259,11 @@ func TestReadAWSPublicEndpointCollectsDNSAndEdgeHosts(t *testing.T) {
 			DomainName: awssdk.String("d111111abcdef8.cloudfront.net"),
 			Aliases:    &cloudfronttypes.Aliases{Items: []string{"app.writer.com"}},
 			Enabled:    awssdk.Bool(true),
+		}, {
+			ARN:        awssdk.String("arn:aws:cloudfront::123456789012:distribution/DISABLED"),
+			Id:         awssdk.String("DISABLED"),
+			DomainName: awssdk.String("disabled.cloudfront.net"),
+			Enabled:    awssdk.Bool(false),
 		}},
 	})
 
@@ -293,6 +298,74 @@ func TestReadAWSPublicEndpointCollectsDNSAndEdgeHosts(t *testing.T) {
 	}
 	if got := cloudfrontEvent.Attributes["alternate_hosts"]; got != "app.writer.com" {
 		t.Fatalf("cloudfront alternate_hosts = %q, want app.writer.com", got)
+	}
+}
+
+func TestReadAWSPublicEndpointCollectsDefaultAPIGatewayHosts(t *testing.T) {
+	source := newTestSource(t, fakeAWS{
+		restAPIs: []apigatewaytypes.RestApi{{
+			Id:   awssdk.String("rest123"),
+			Name: awssdk.String("orders"),
+			EndpointConfiguration: &apigatewaytypes.EndpointConfiguration{
+				Types: []apigatewaytypes.EndpointType{apigatewaytypes.EndpointTypeRegional},
+			},
+		}, {
+			Id:                        awssdk.String("restdisabled"),
+			Name:                      awssdk.String("disabled"),
+			DisableExecuteApiEndpoint: true,
+		}, {
+			Id:   awssdk.String("restprivate"),
+			Name: awssdk.String("private"),
+			EndpointConfiguration: &apigatewaytypes.EndpointConfiguration{
+				Types: []apigatewaytypes.EndpointType{apigatewaytypes.EndpointTypePrivate},
+			},
+		}},
+		apiV2APIs: []apigatewayv2types.Api{{
+			ApiId:        awssdk.String("v2abc"),
+			ApiEndpoint:  awssdk.String("https://v2abc.execute-api.us-east-1.amazonaws.com"),
+			Name:         awssdk.String("events"),
+			ProtocolType: apigatewayv2types.ProtocolTypeHttp,
+		}, {
+			ApiId:                     awssdk.String("v2disabled"),
+			ApiEndpoint:               awssdk.String("https://v2disabled.execute-api.us-east-1.amazonaws.com"),
+			Name:                      awssdk.String("disabled"),
+			ProtocolType:              apigatewayv2types.ProtocolTypeHttp,
+			DisableExecuteApiEndpoint: awssdk.Bool(true),
+		}},
+	})
+	config := sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familyPublicEndpoint})
+
+	pull, err := source.Read(context.Background(), config, nil)
+	if err != nil {
+		t.Fatalf("Read(public_endpoint rest api) error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(rest api events) = %d, want 1", len(pull.Events))
+	}
+	restEvent := pull.Events[0]
+	if got := restEvent.Attributes["host"]; got != "rest123.execute-api.us-east-1.amazonaws.com" {
+		t.Fatalf("rest api host = %q, want rest123.execute-api.us-east-1.amazonaws.com", got)
+	}
+	if got := restEvent.Attributes["resource_type"]; got != "apigateway_rest_api" {
+		t.Fatalf("rest api resource_type = %q, want apigateway_rest_api", got)
+	}
+	if pull.NextCursor == nil {
+		t.Fatal("rest api NextCursor = nil, want apigatewayv2 cursor")
+	}
+
+	pull, err = source.Read(context.Background(), config, pull.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(public_endpoint api v2) error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(api v2 events) = %d, want 1", len(pull.Events))
+	}
+	apiV2Event := pull.Events[0]
+	if got := apiV2Event.Attributes["host"]; got != "v2abc.execute-api.us-east-1.amazonaws.com" {
+		t.Fatalf("api v2 host = %q, want v2abc.execute-api.us-east-1.amazonaws.com", got)
+	}
+	if got := apiV2Event.Attributes["resource_type"]; got != "apigatewayv2_api" {
+		t.Fatalf("api v2 resource_type = %q, want apigatewayv2_api", got)
 	}
 }
 
@@ -344,7 +417,7 @@ func newTestSource(t *testing.T, fake fakeAWS) *Source {
 		t.Fatalf("loadSpec() error = %v", err)
 	}
 	source := &Source{spec: spec, clients: func(context.Context, settings) (awsClients, error) {
-		return awsClients{iam: fake, cloudTrail: fake, ec2: fake, route53: fake, cloudFront: fake, elbv2: fake, apiGateway: fake, apiGatewayV2: fakeAPIGatewayV2{domains: fake.apiV2Domains}}, nil
+		return awsClients{iam: fake, cloudTrail: fake, ec2: fake, route53: fake, cloudFront: fake, elbv2: fake, apiGateway: fake, apiGatewayV2: fakeAPIGatewayV2{domains: fake.apiV2Domains, apis: fake.apiV2APIs}}, nil
 	}}
 	source.families, err = source.newFamilyEngine()
 	if err != nil {
@@ -368,7 +441,9 @@ type fakeAWS struct {
 	distributions     []cloudfronttypes.DistributionSummary
 	loadBalancers     []elbv2types.LoadBalancer
 	apiDomains        []apigatewaytypes.DomainName
+	restAPIs          []apigatewaytypes.RestApi
 	apiV2Domains      []apigatewayv2types.DomainName
+	apiV2APIs         []apigatewayv2types.Api
 }
 
 func (f fakeAWS) ListUsers(context.Context, *iam.ListUsersInput, ...func(*iam.Options)) (*iam.ListUsersOutput, error) {
@@ -439,8 +514,17 @@ func (f fakeAWS) GetDomainNames(_ context.Context, _ *apigateway.GetDomainNamesI
 	return &apigateway.GetDomainNamesOutput{Items: f.apiDomains}, nil
 }
 
+func (f fakeAWS) GetRestApis(_ context.Context, _ *apigateway.GetRestApisInput, _ ...func(*apigateway.Options)) (*apigateway.GetRestApisOutput, error) {
+	return &apigateway.GetRestApisOutput{Items: f.restAPIs}, nil
+}
+
 type fakeAPIGatewayV2 struct {
 	domains []apigatewayv2types.DomainName
+	apis    []apigatewayv2types.Api
+}
+
+func (f fakeAPIGatewayV2) GetApis(_ context.Context, _ *apigatewayv2.GetApisInput, _ ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApisOutput, error) {
+	return &apigatewayv2.GetApisOutput{Items: f.apis}, nil
 }
 
 func (f fakeAPIGatewayV2) GetDomainNames(_ context.Context, _ *apigatewayv2.GetDomainNamesInput, _ ...func(*apigatewayv2.Options)) (*apigatewayv2.GetDomainNamesOutput, error) {

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 	"time"
@@ -47,6 +48,20 @@ func TestCheckRequiresAccountID(t *testing.T) {
 	}
 }
 
+func TestCheckRejectsDeprecatedAssumeRoleConfig(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	for _, key := range []string{"role_arn", "external_id", "role_session_name"} {
+		t.Run(key, func(t *testing.T) {
+			if err := source.Check(context.Background(), sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", key: "legacy"})); err == nil {
+				t.Fatalf("Check() error = nil, want unsupported %s error", key)
+			}
+		})
+	}
+}
+
 func TestAWSPullFromRecordsPreservesNextCursorWithoutEvents(t *testing.T) {
 	pull, err := awsPullFromRecords[string](nil, "next-page", nil, nil)
 	if err != nil {
@@ -58,6 +73,56 @@ func TestAWSPullFromRecordsPreservesNextCursorWithoutEvents(t *testing.T) {
 	if got := pull.NextCursor.GetOpaque(); got != "next-page" {
 		t.Fatalf("NextCursor = %q, want next-page", got)
 	}
+}
+
+func TestParsePublicEndpointCursorUpgradesLegacyStages(t *testing.T) {
+	legacyPastAPIGateway := legacyPublicEndpointCursor(t, publicEndpointCursor{Stage: publicEndpointStageEIP, Token: "old-token"})
+	got, err := parsePublicEndpointCursor(legacyPastAPIGateway)
+	if err != nil {
+		t.Fatalf("parsePublicEndpointCursor(legacy eip) error = %v", err)
+	}
+	if got.Stage != publicEndpointStageAPIGatewayRestAPI {
+		t.Fatalf("legacy eip stage = %q, want %q", got.Stage, publicEndpointStageAPIGatewayRestAPI)
+	}
+	if got.Token != "" {
+		t.Fatalf("legacy eip token = %q, want empty backfill token", got.Token)
+	}
+
+	legacyAPIGateway := legacyPublicEndpointCursor(t, publicEndpointCursor{Stage: publicEndpointStageAPIGateway, Token: "domain-page"})
+	got, err = parsePublicEndpointCursor(legacyAPIGateway)
+	if err != nil {
+		t.Fatalf("parsePublicEndpointCursor(legacy apigateway) error = %v", err)
+	}
+	if got.Stage != publicEndpointStageAPIGateway || got.Token != "domain-page" {
+		t.Fatalf("legacy apigateway cursor = %#v, want stage %q token domain-page", got, publicEndpointStageAPIGateway)
+	}
+
+	versioned := encodePublicEndpointCursor(publicEndpointCursor{Stage: publicEndpointStageEIP, Token: "new-token"})
+	got, err = parsePublicEndpointCursor(versioned)
+	if err != nil {
+		t.Fatalf("parsePublicEndpointCursor(versioned eip) error = %v", err)
+	}
+	if got.Stage != publicEndpointStageEIP || got.Token != "new-token" || got.Version != publicEndpointCursorV2 {
+		t.Fatalf("versioned eip cursor = %#v, want stage %q token new-token version %d", got, publicEndpointStageEIP, publicEndpointCursorV2)
+	}
+
+	got, err = parsePublicEndpointCursor("eni:legacy-token")
+	if err != nil {
+		t.Fatalf("parsePublicEndpointCursor(legacy eni) error = %v", err)
+	}
+	if got.Stage != publicEndpointStageAPIGatewayRestAPI {
+		t.Fatalf("legacy eni stage = %q, want %q", got.Stage, publicEndpointStageAPIGatewayRestAPI)
+	}
+}
+
+func legacyPublicEndpointCursor(t *testing.T, cursor publicEndpointCursor) string {
+	t.Helper()
+	cursor.Version = 0
+	payload, err := json.Marshal(cursor)
+	if err != nil {
+		t.Fatalf("marshal legacy cursor: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(payload)
 }
 
 func TestEmailLikeExtractsSSOSessionEmail(t *testing.T) {
@@ -366,6 +431,16 @@ func TestReadAWSPublicEndpointCollectsDefaultAPIGatewayHosts(t *testing.T) {
 	}
 	if got := apiV2Event.Attributes["resource_type"]; got != "apigatewayv2_api" {
 		t.Fatalf("api v2 resource_type = %q, want apigatewayv2_api", got)
+	}
+}
+
+func TestAPIGatewayRestAPIPublicEndpointUsesPartitionSuffix(t *testing.T) {
+	endpoint := apiGatewayRestAPIPublicEndpoint(settings{accountID: "123456789012", region: "cn-north-1"}, apigatewaytypes.RestApi{
+		Id:   awssdk.String("rest123"),
+		Name: awssdk.String("orders"),
+	})
+	if endpoint.Host != "rest123.execute-api.cn-north-1.amazonaws.com.cn" {
+		t.Fatalf("Host = %q, want rest123.execute-api.cn-north-1.amazonaws.com.cn", endpoint.Host)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #571 after Droid review.\n\n- Skip disabled CloudFront distributions.\n- Enumerate default REST/API Gateway v2 execute-api hosts while skipping disabled/private endpoints.\n- Remove the source-config role_arn AssumeRole path so callers cannot drive ambient STS role assumption.\n\nValidation:\n- go test ./sources/aws ./internal/sourceprojection\n- make verify