### PR TITLE
fix(aws): unblock trusted runtime role assumption

### DIFF
--- a/cmd/cerebro/github_local.go
+++ b/cmd/cerebro/github_local.go
@@ -11,6 +11,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	appconfig "github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 const githubSourceID = "github"
@@ -102,7 +103,7 @@ func prepareSourceRuntimeWithCLI(ctx context.Context, runtime *cerebrov1.SourceR
 	if cli == nil {
 		return nil, fmt.Errorf("github local cli is required")
 	}
-	resolvedConfig, err := appconfig.ResolveSourceRuntimeConfigSecretReferences(ctx, cloned.GetSourceId(), cloned.GetConfig())
+	resolvedConfig, err := appconfig.ResolveSourceRuntimeConfigSecretReferences(ctx, cloned.GetSourceId(), sourceconfig.WithRuntimeTenant(cloned.GetConfig(), cloned.GetTenantId()))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -155,7 +156,7 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 	return nil
 }
 
-// Replay returns the latest matching stored envelopes in append order.
+// Replay returns the newest matching stored envelopes in append order.
 func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
 	if l == nil || l.replay == nil {
 		return nil, errors.New("jetstream is not configured")
@@ -177,9 +178,9 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	if err != nil {
 		return nil, fmt.Errorf("open replay stream %q: %w", stream.Config.Name, err)
 	}
-	events := make([]*cerebrov1.EventEnvelope, 0, limit)
+	candidates := make([]replayCandidate, 0, limit)
 	if stream.State.LastSeq == 0 || stream.State.LastSeq < stream.State.FirstSeq {
-		return events, nil
+		return nil, nil
 	}
 	for seq := stream.State.LastSeq; ; seq-- {
 		raw, err := streamRef.GetMsg(ctx, seq)
@@ -198,24 +199,56 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 				return nil, fmt.Errorf("decode replay message %s:%d: %w", stream.Config.Name, seq, err)
 			}
 			if matchesReplayRequest(event, request) {
-				events = append(events, event)
-				if uint32(len(events)) >= limit {
-					break
-				}
+				candidates = append(candidates, replayCandidate{event: event, seq: seq})
 			}
 		}
 		if seq == stream.State.FirstSeq {
 			break
 		}
 	}
-	reverseEvents(events)
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return replayCandidateNewer(candidates[i], candidates[j])
+	})
+	if uint32(len(candidates)) > limit {
+		candidates = candidates[:limit]
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].seq < candidates[j].seq
+	})
+	events := make([]*cerebrov1.EventEnvelope, 0, len(candidates))
+	for _, candidate := range candidates {
+		events = append(events, candidate.event)
+	}
 	return events, nil
 }
 
-func reverseEvents(events []*cerebrov1.EventEnvelope) {
-	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
-		events[i], events[j] = events[j], events[i]
+type replayCandidate struct {
+	event *cerebrov1.EventEnvelope
+	seq   uint64
+}
+
+func replayCandidateNewer(left replayCandidate, right replayCandidate) bool {
+	leftTime, leftHasTime := replayEventTime(left.event)
+	rightTime, rightHasTime := replayEventTime(right.event)
+	switch {
+	case leftHasTime && rightHasTime && !leftTime.Equal(rightTime):
+		return leftTime.After(rightTime)
+	case leftHasTime != rightHasTime:
+		return leftHasTime
+	default:
+		return left.seq > right.seq
 	}
+}
+
+func replayEventTime(event *cerebrov1.EventEnvelope) (time.Time, bool) {
+	if event == nil || event.GetOccurredAt() == nil {
+		return time.Time{}, false
+	}
+	occurredAt := event.GetOccurredAt().AsTime().UTC()
+	if occurredAt.IsZero() {
+		return time.Time{}, false
+	}
+	return occurredAt, true
 }
 
 func eventSubject(prefix string, kind string) (string, error) {

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	connectTimeout     = 5 * time.Second
-	defaultReplayLimit = 100
-	maxReplayLimit     = 1000
+	connectTimeout      = 5 * time.Second
+	defaultReplayLimit  = 100
+	maxReplayLimit      = 1000
+	maxReplayCandidates = 5000
 )
 
 type publisher interface {
@@ -174,6 +175,7 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 		return nil, err
 	}
 	limit := normalizeReplayLimit(request.Limit)
+	candidateLimit := normalizeReplayCandidateLimit(limit)
 	streamRef, err := l.replay.Stream(ctx, stream.Config.Name)
 	if err != nil {
 		return nil, fmt.Errorf("open replay stream %q: %w", stream.Config.Name, err)
@@ -200,6 +202,9 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 			}
 			if matchesReplayRequest(event, request) {
 				candidates = append(candidates, replayCandidate{event: event, seq: seq})
+				if uint32(len(candidates)) >= candidateLimit {
+					break
+				}
 			}
 		}
 		if seq == stream.State.FirstSeq {
@@ -249,6 +254,20 @@ func replayEventTime(event *cerebrov1.EventEnvelope) (time.Time, bool) {
 		return time.Time{}, false
 	}
 	return occurredAt, true
+}
+
+func normalizeReplayCandidateLimit(limit uint32) uint32 {
+	if limit == 0 {
+		limit = defaultReplayLimit
+	}
+	candidates := limit * 5
+	if candidates < limit {
+		return maxReplayCandidates
+	}
+	if candidates > maxReplayCandidates {
+		return maxReplayCandidates
+	}
+	return candidates
 }
 
 func eventSubject(prefix string, kind string) (string, error) {

--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -155,7 +155,7 @@ func (l *Log) Append(ctx context.Context, event *cerebrov1.EventEnvelope) error 
 	return nil
 }
 
-// Replay returns stored envelopes for one source runtime in append order.
+// Replay returns the latest matching stored envelopes in append order.
 func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
 	if l == nil || l.replay == nil {
 		return nil, errors.New("jetstream is not configured")
@@ -181,30 +181,41 @@ func (l *Log) Replay(ctx context.Context, req ports.ReplayRequest) ([]*cerebrov1
 	if stream.State.LastSeq == 0 || stream.State.LastSeq < stream.State.FirstSeq {
 		return events, nil
 	}
-	for seq := stream.State.FirstSeq; seq <= stream.State.LastSeq; seq++ {
+	for seq := stream.State.LastSeq; ; seq-- {
 		raw, err := streamRef.GetMsg(ctx, seq)
 		if err != nil {
 			if errors.Is(err, jetstream.ErrMsgNotFound) {
+				if seq == stream.State.FirstSeq {
+					break
+				}
 				continue
 			}
 			return nil, fmt.Errorf("get replay message %s:%d: %w", stream.Config.Name, seq, err)
 		}
-		if raw == nil || !strings.HasPrefix(strings.TrimSpace(raw.Subject), prefix+".") {
-			continue
+		if raw != nil && strings.HasPrefix(strings.TrimSpace(raw.Subject), prefix+".") {
+			event := &cerebrov1.EventEnvelope{}
+			if err := proto.Unmarshal(raw.Data, event); err != nil {
+				return nil, fmt.Errorf("decode replay message %s:%d: %w", stream.Config.Name, seq, err)
+			}
+			if matchesReplayRequest(event, request) {
+				events = append(events, event)
+				if uint32(len(events)) >= limit {
+					break
+				}
+			}
 		}
-		event := &cerebrov1.EventEnvelope{}
-		if err := proto.Unmarshal(raw.Data, event); err != nil {
-			return nil, fmt.Errorf("decode replay message %s:%d: %w", stream.Config.Name, seq, err)
-		}
-		if !matchesReplayRequest(event, request) {
-			continue
-		}
-		events = append(events, event)
-		if uint32(len(events)) >= limit {
+		if seq == stream.State.FirstSeq {
 			break
 		}
 	}
+	reverseEvents(events)
 	return events, nil
+}
+
+func reverseEvents(events []*cerebrov1.EventEnvelope) {
+	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
+		events[i], events[j] = events[j], events[i]
+	}
 }
 
 func eventSubject(prefix string, kind string) (string, error) {

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -234,6 +234,12 @@ func TestReplayAppliesDefaultLimit(t *testing.T) {
 	if len(events) != defaultReplayLimit {
 		t.Fatalf("len(events) = %d, want %d", len(events), defaultReplayLimit)
 	}
+	if got := events[0].GetId(); got != "evt-6" {
+		t.Fatalf("first replayed id = %q, want evt-6", got)
+	}
+	if got := events[len(events)-1].GetId(); got != "evt-105" {
+		t.Fatalf("last replayed id = %q, want evt-105", got)
+	}
 }
 
 func TestReplayFiltersWorkflowEventsByKindPrefixTenantAndAttribute(t *testing.T) {
@@ -276,7 +282,7 @@ func TestReplayFiltersWorkflowEventsByKindPrefixTenantAndAttribute(t *testing.T)
 	}
 }
 
-func TestReplayScansSparseStreamsUntilLimitMatches(t *testing.T) {
+func TestReplayScansSparseStreamsUntilLimitOrStreamStart(t *testing.T) {
 	const matchingSeq = uint64(10005)
 	replay := &fakeReplayManager{
 		streams: []*natsjetstream.StreamInfo{
@@ -305,6 +311,40 @@ func TestReplayScansSparseStreamsUntilLimitMatches(t *testing.T) {
 	}
 	if replay.getMsgCalls != int(matchingSeq) {
 		t.Fatalf("getMsgCalls = %d, want %d", replay.getMsgCalls, matchingSeq)
+	}
+}
+
+func TestReplayReturnsLatestMatchesInAppendOrder(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{
+					Name:     "CEREBRO_EVENTS",
+					Subjects: []string{"events.>"},
+				},
+				State: natsjetstream.StreamState{FirstSeq: 1, LastSeq: 4},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEvent("evt-1", "github.audit", "writer-github")),
+				2: rawReplayMsg(t, "events.github.audit", replayEvent("evt-2", "github.audit", "writer-github")),
+				3: rawReplayMsg(t, "events.github.audit", replayEvent("evt-3", "github.audit", "other-runtime")),
+				4: rawReplayMsg(t, "events.github.audit", replayEvent("evt-4", "github.audit", "writer-github")),
+			},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 2})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if events[0].GetId() != "evt-2" || events[1].GetId() != "evt-4" {
+		t.Fatalf("replayed ids = [%q, %q], want [evt-2, evt-4]", events[0].GetId(), events[1].GetId())
 	}
 }
 

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -385,6 +385,37 @@ func TestReplayReturnsNewestOccurredEventsWhenAppendedNewestFirst(t *testing.T) 
 	}
 }
 
+func TestReplayStopsAfterBoundedCandidateWindow(t *testing.T) {
+	msgs := make(map[uint64]*natsjetstream.RawStreamMsg)
+	for seq := uint64(1); seq <= 100; seq++ {
+		msgs[seq] = rawReplayMsg(t, "events.github.audit", replayEvent("evt-"+strconv.FormatUint(seq, 10), "github.audit", "writer-github"))
+	}
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{
+					Name:     "CEREBRO_EVENTS",
+					Subjects: []string{"events.>"},
+				},
+				State: natsjetstream.StreamState{FirstSeq: 1, LastSeq: 100},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{"CEREBRO_EVENTS": msgs},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 2})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if replay.getMsgCalls != 10 {
+		t.Fatalf("getMsgCalls = %d, want bounded candidate window 10", replay.getMsgCalls)
+	}
+}
+
 func TestSubjectMatchesRequiresTokenForFullWildcard(t *testing.T) {
 	if subjectMatches("events.>", "events") {
 		t.Fatal("subjectMatches(events.>, events) = true, want false")

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats.go"
 	natsjetstream "github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
@@ -348,6 +350,41 @@ func TestReplayReturnsLatestMatchesInAppendOrder(t *testing.T) {
 	}
 }
 
+func TestReplayReturnsNewestOccurredEventsWhenAppendedNewestFirst(t *testing.T) {
+	base := time.Date(2026, 5, 13, 18, 0, 0, 0, time.UTC)
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{
+					Name:     "CEREBRO_EVENTS",
+					Subjects: []string{"events.>"},
+				},
+				State: natsjetstream.StreamState{FirstSeq: 1, LastSeq: 4},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, "events.github.audit", replayEventAt("evt-newest", "github.audit", "writer-github", base.Add(4*time.Minute))),
+				2: rawReplayMsg(t, "events.github.audit", replayEventAt("evt-newer", "github.audit", "writer-github", base.Add(3*time.Minute))),
+				3: rawReplayMsg(t, "events.github.audit", replayEventAt("evt-older", "github.audit", "writer-github", base.Add(2*time.Minute))),
+				4: rawReplayMsg(t, "events.github.audit", replayEventAt("evt-oldest", "github.audit", "writer-github", base.Add(time.Minute))),
+			},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{RuntimeID: "writer-github", Limit: 2})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(events))
+	}
+	if events[0].GetId() != "evt-newest" || events[1].GetId() != "evt-newer" {
+		t.Fatalf("replayed ids = [%q, %q], want newest events [evt-newest, evt-newer]", events[0].GetId(), events[1].GetId())
+	}
+}
+
 func TestSubjectMatchesRequiresTokenForFullWildcard(t *testing.T) {
 	if subjectMatches("events.>", "events") {
 		t.Fatal("subjectMatches(events.>, events) = true, want false")
@@ -479,6 +516,12 @@ func replayEvent(id string, kind string, runtimeID string) *cerebrov1.EventEnvel
 			ports.EventAttributeSourceRuntimeID: runtimeID,
 		},
 	}
+}
+
+func replayEventAt(id string, kind string, runtimeID string, occurredAt time.Time) *cerebrov1.EventEnvelope {
+	event := replayEvent(id, kind, runtimeID)
+	event.OccurredAt = timestamppb.New(occurredAt)
+	return event
 }
 
 func rawReplayMsg(t *testing.T, subject string, event *cerebrov1.EventEnvelope) *natsjetstream.RawStreamMsg {

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -15,14 +15,14 @@ const (
 )
 
 func ResolveSourceConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
-	return resolveSourceConfigSecretReferences(ctx, sourceID, values, true)
+	return resolveSourceConfigSecretReferences(ctx, sourceID, values, true, false)
 }
 
 func ResolveSourceRuntimeConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
-	return resolveSourceConfigSecretReferences(ctx, sourceID, values, true)
+	return resolveSourceConfigSecretReferences(ctx, sourceID, values, true, true)
 }
 
-func resolveSourceConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string, preserveLiteralQueryValues bool) (map[string]string, error) {
+func resolveSourceConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string, preserveLiteralQueryValues bool, injectRuntimeAllowlist bool) (map[string]string, error) {
 	_ = ctx
 	resolved := make(map[string]string, len(values))
 	for key, value := range values {
@@ -49,7 +49,7 @@ func resolveSourceConfigSecretReferences(ctx context.Context, sourceID string, v
 		}
 		resolved[key] = secret
 	}
-	if strings.EqualFold(strings.TrimSpace(sourceID), "aws") {
+	if injectRuntimeAllowlist && strings.EqualFold(strings.TrimSpace(sourceID), "aws") {
 		resolved[sourceconfig.AWSAssumeRoleAllowlistKey] = strings.TrimSpace(os.Getenv(awsAssumeRoleARNsEnv))
 	}
 	return resolved, nil

--- a/internal/config/source_config.go
+++ b/internal/config/source_config.go
@@ -9,7 +9,10 @@ import (
 	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
-const sourceConfigEnvAllowlistEnv = "CEREBRO_SOURCE_CONFIG_ENV_ALLOWLIST"
+const (
+	sourceConfigEnvAllowlistEnv = "CEREBRO_SOURCE_CONFIG_ENV_ALLOWLIST"
+	awsAssumeRoleARNsEnv        = "CEREBRO_AWS_ASSUME_ROLE_ARNS"
+)
 
 func ResolveSourceConfigSecretReferences(ctx context.Context, sourceID string, values map[string]string) (map[string]string, error) {
 	return resolveSourceConfigSecretReferences(ctx, sourceID, values, true)
@@ -45,6 +48,9 @@ func resolveSourceConfigSecretReferences(ctx context.Context, sourceID string, v
 			return nil, fmt.Errorf("source config %q references empty environment variable %q", strings.TrimSpace(key), envName)
 		}
 		resolved[key] = secret
+	}
+	if strings.EqualFold(strings.TrimSpace(sourceID), "aws") {
+		resolved[sourceconfig.AWSAssumeRoleAllowlistKey] = strings.TrimSpace(os.Getenv(awsAssumeRoleARNsEnv))
 	}
 	return resolved, nil
 }

--- a/internal/config/source_config_test.go
+++ b/internal/config/source_config_test.go
@@ -115,11 +115,15 @@ func TestResolveSourceRuntimeConfigInjectsAWSAssumeRoleAllowlist(t *testing.T) {
 	t.Setenv(awsAssumeRoleARNsEnv, "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role")
 	resolved, err := ResolveSourceRuntimeConfigSecretReferences(context.Background(), "aws", map[string]string{
 		sourceconfig.AWSAssumeRoleAllowlistKey: "caller-controlled",
+		sourceconfig.RuntimeTenantIDKey:        "writer",
 	})
 	if err != nil {
 		t.Fatalf("ResolveSourceRuntimeConfigSecretReferences() error = %v", err)
 	}
 	if got := resolved[sourceconfig.AWSAssumeRoleAllowlistKey]; got != "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role" {
 		t.Fatalf("resolved assume-role allowlist = %q, want deployment env value", got)
+	}
+	if got := resolved[sourceconfig.RuntimeTenantIDKey]; got != "writer" {
+		t.Fatalf("resolved runtime tenant = %q, want writer", got)
 	}
 }

--- a/internal/config/source_config_test.go
+++ b/internal/config/source_config_test.go
@@ -127,3 +127,16 @@ func TestResolveSourceRuntimeConfigInjectsAWSAssumeRoleAllowlist(t *testing.T) {
 		t.Fatalf("resolved runtime tenant = %q, want writer", got)
 	}
 }
+
+func TestResolveSourceConfigDoesNotInjectRuntimeAWSAllowlist(t *testing.T) {
+	t.Setenv(awsAssumeRoleARNsEnv, "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role")
+	resolved, err := ResolveSourceConfigSecretReferences(context.Background(), "aws", map[string]string{
+		"account_id": "123456789012",
+	})
+	if err != nil {
+		t.Fatalf("ResolveSourceConfigSecretReferences() error = %v", err)
+	}
+	if _, ok := resolved[sourceconfig.AWSAssumeRoleAllowlistKey]; ok {
+		t.Fatal("direct source config injected runtime AWS assume-role allowlist")
+	}
+}

--- a/internal/config/source_config_test.go
+++ b/internal/config/source_config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"context"
 	"testing"
+
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 func TestResolveSourceConfigSecretReferencesResolvesEnvValues(t *testing.T) {
@@ -106,5 +108,18 @@ func TestResolveSourceRuntimeConfigSecretReferencesPreservesLiteralEnvQueryValue
 	}
 	if got := resolved["phrase"]; got != "env:prod" {
 		t.Fatalf("resolved phrase = %q, want literal env:prod", got)
+	}
+}
+
+func TestResolveSourceRuntimeConfigInjectsAWSAssumeRoleAllowlist(t *testing.T) {
+	t.Setenv(awsAssumeRoleARNsEnv, "arn:aws:iam::123456789012:role/cerebro-org-scan-role")
+	resolved, err := ResolveSourceRuntimeConfigSecretReferences(context.Background(), "aws", map[string]string{
+		sourceconfig.AWSAssumeRoleAllowlistKey: "caller-controlled",
+	})
+	if err != nil {
+		t.Fatalf("ResolveSourceRuntimeConfigSecretReferences() error = %v", err)
+	}
+	if got := resolved[sourceconfig.AWSAssumeRoleAllowlistKey]; got != "arn:aws:iam::123456789012:role/cerebro-org-scan-role" {
+		t.Fatalf("resolved assume-role allowlist = %q, want deployment env value", got)
 	}
 }

--- a/internal/config/source_config_test.go
+++ b/internal/config/source_config_test.go
@@ -112,14 +112,14 @@ func TestResolveSourceRuntimeConfigSecretReferencesPreservesLiteralEnvQueryValue
 }
 
 func TestResolveSourceRuntimeConfigInjectsAWSAssumeRoleAllowlist(t *testing.T) {
-	t.Setenv(awsAssumeRoleARNsEnv, "arn:aws:iam::123456789012:role/cerebro-org-scan-role")
+	t.Setenv(awsAssumeRoleARNsEnv, "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role")
 	resolved, err := ResolveSourceRuntimeConfigSecretReferences(context.Background(), "aws", map[string]string{
 		sourceconfig.AWSAssumeRoleAllowlistKey: "caller-controlled",
 	})
 	if err != nil {
 		t.Fatalf("ResolveSourceRuntimeConfigSecretReferences() error = %v", err)
 	}
-	if got := resolved[sourceconfig.AWSAssumeRoleAllowlistKey]; got != "arn:aws:iam::123456789012:role/cerebro-org-scan-role" {
+	if got := resolved[sourceconfig.AWSAssumeRoleAllowlistKey]; got != "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role" {
 		t.Fatalf("resolved assume-role allowlist = %q, want deployment env value", got)
 	}
 }

--- a/internal/findings/cloud_signal_rule.go
+++ b/internal/findings/cloud_signal_rule.go
@@ -129,7 +129,7 @@ func (r *cloudSignalRule) Evaluate(ctx context.Context, runtime *cerebrov1.Sourc
 	if r == nil || runtime == nil || event == nil {
 		return nil, nil
 	}
-	if !r.SupportsRuntime(runtime) || !identityKindAllowed(event.GetKind(), r.config.eventKinds) {
+	if !identityKindAllowed(event.GetKind(), r.config.eventKinds) {
 		return nil, nil
 	}
 	attributes := eventAttributes(event)

--- a/internal/findings/cloud_signal_rule.go
+++ b/internal/findings/cloud_signal_rule.go
@@ -119,7 +119,7 @@ func (r *cloudSignalRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool
 	sourceID := strings.TrimSpace(runtime.GetSourceId())
 	for _, candidate := range r.config.sourceIDs {
 		if strings.EqualFold(sourceID, candidate) {
-			return true
+			return runtimeMayEmitEventKind(runtime, r.config.eventKinds)
 		}
 	}
 	return false

--- a/internal/findings/cloud_signal_rule_test.go
+++ b/internal/findings/cloud_signal_rule_test.go
@@ -210,6 +210,9 @@ func TestCloudSignalRulesRespectRuntimeFamily(t *testing.T) {
 	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws", Config: map[string]string{"family": "public_endpoint"}}) {
 		t.Fatal("SupportsRuntime(public_endpoint) = true, want false")
 	}
+	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws"}) {
+		t.Fatal("SupportsRuntime(default cloudtrail) = true, want false")
+	}
 }
 
 func TestCloudSignalRulesDetectEffectiveAdminPermissions(t *testing.T) {

--- a/internal/findings/cloud_signal_rule_test.go
+++ b/internal/findings/cloud_signal_rule_test.go
@@ -201,6 +201,17 @@ func TestCloudSignalRulesIgnoreLowContextCloudSignals(t *testing.T) {
 	}
 }
 
+func TestCloudSignalRulesRespectRuntimeFamily(t *testing.T) {
+	rules := cloudRulesByID(t)
+	rule := rules[cloudPublicResourceExposureRuleID]
+	if !rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws", Config: map[string]string{"family": "resource_exposure"}}) {
+		t.Fatal("SupportsRuntime(resource_exposure) = false, want true")
+	}
+	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws", Config: map[string]string{"family": "public_endpoint"}}) {
+		t.Fatal("SupportsRuntime(public_endpoint) = true, want false")
+	}
+}
+
 func TestCloudSignalRulesDetectEffectiveAdminPermissions(t *testing.T) {
 	rules := cloudRulesByID(t)
 	runtime := &cerebrov1.SourceRuntime{Id: "aws-runtime", SourceId: "aws", TenantId: "writer"}

--- a/internal/findings/identity_signal_rule.go
+++ b/internal/findings/identity_signal_rule.go
@@ -206,7 +206,7 @@ func (r *identitySignalRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) b
 	sourceID := strings.TrimSpace(runtime.GetSourceId())
 	for _, candidate := range r.config.sourceIDs {
 		if strings.EqualFold(sourceID, candidate) {
-			return true
+			return runtimeMayEmitEventKind(runtime, r.config.eventKinds)
 		}
 	}
 	return false

--- a/internal/findings/identity_signal_rule.go
+++ b/internal/findings/identity_signal_rule.go
@@ -216,7 +216,7 @@ func (r *identitySignalRule) Evaluate(ctx context.Context, runtime *cerebrov1.So
 	if r == nil || runtime == nil || event == nil {
 		return nil, nil
 	}
-	if !r.SupportsRuntime(runtime) || !identityKindAllowed(event.GetKind(), r.config.eventKinds) {
+	if !identityKindAllowed(event.GetKind(), r.config.eventKinds) {
 		return nil, nil
 	}
 	attributes := eventAttributes(event)

--- a/internal/findings/identity_signal_rule_test.go
+++ b/internal/findings/identity_signal_rule_test.go
@@ -371,6 +371,17 @@ func TestIdentitySignalRulesIgnoreInactiveCloudCredentials(t *testing.T) {
 	}
 }
 
+func TestIdentitySignalRulesRespectRuntimeFamily(t *testing.T) {
+	rules := identityRulesByID(t)
+	rule := rules[identityPrivilegedAccountWithoutMFARuleID]
+	if !rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws", Config: map[string]string{"family": "iam_user"}}) {
+		t.Fatal("SupportsRuntime(iam_user) = false, want true")
+	}
+	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws", Config: map[string]string{"family": "public_endpoint"}}) {
+		t.Fatal("SupportsRuntime(public_endpoint) = true, want false")
+	}
+}
+
 func TestIdentitySignalRulesTreatRoutineOAuthGrantsAsTelemetry(t *testing.T) {
 	rules := identityRulesByID(t)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"}

--- a/internal/findings/identity_signal_rule_test.go
+++ b/internal/findings/identity_signal_rule_test.go
@@ -386,6 +386,9 @@ func TestIdentitySignalRulesRespectRuntimeFamily(t *testing.T) {
 	if !rules[identityControlTamperCredentialChangeRuleID].SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws"}) {
 		t.Fatal("SupportsRuntime(default cloudtrail) = false, want true for audit rule")
 	}
+	if !rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws", Config: map[string]string{"family": "env:CEREBRO_SOURCE_AWS_FAMILY"}}) {
+		t.Fatal("SupportsRuntime(env-backed family) = false, want true until runtime config is resolved")
+	}
 }
 
 func TestIdentitySignalRulesTreatRoutineOAuthGrantsAsTelemetry(t *testing.T) {

--- a/internal/findings/identity_signal_rule_test.go
+++ b/internal/findings/identity_signal_rule_test.go
@@ -380,6 +380,12 @@ func TestIdentitySignalRulesRespectRuntimeFamily(t *testing.T) {
 	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws", Config: map[string]string{"family": "public_endpoint"}}) {
 		t.Fatal("SupportsRuntime(public_endpoint) = true, want false")
 	}
+	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws"}) {
+		t.Fatal("SupportsRuntime(default cloudtrail) = true, want false for user rule")
+	}
+	if !rules[identityControlTamperCredentialChangeRuleID].SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "aws"}) {
+		t.Fatal("SupportsRuntime(default cloudtrail) = false, want true for audit rule")
+	}
 }
 
 func TestIdentitySignalRulesTreatRoutineOAuthGrantsAsTelemetry(t *testing.T) {

--- a/internal/findings/runtime_kind.go
+++ b/internal/findings/runtime_kind.go
@@ -23,8 +23,35 @@ func runtimeConfiguredEventKind(runtime *cerebrov1.SourceRuntime) string {
 	}
 	sourceID := strings.TrimSpace(runtime.GetSourceId())
 	family := strings.TrimSpace(runtime.GetConfig()["family"])
-	if sourceID == "" || family == "" {
+	if sourceID == "" {
+		return ""
+	}
+	if family == "" {
+		family = defaultRuntimeFamily(sourceID)
+	}
+	if family == "" {
 		return ""
 	}
 	return sourceID + "." + family
+}
+
+func defaultRuntimeFamily(sourceID string) string {
+	switch strings.ToLower(strings.TrimSpace(sourceID)) {
+	case "aws":
+		return "cloudtrail"
+	case "azure":
+		return "directory_audit"
+	case "gcp":
+		return "audit"
+	case "github":
+		return "pull_request"
+	case "google_workspace":
+		return "user"
+	case "okta":
+		return "audit"
+	case "sentinelone":
+		return "threat"
+	default:
+		return ""
+	}
 }

--- a/internal/findings/runtime_kind.go
+++ b/internal/findings/runtime_kind.go
@@ -1,0 +1,30 @@
+package findings
+
+import (
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func runtimeMayEmitEventKind(runtime *cerebrov1.SourceRuntime, allowed []string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	kind := runtimeConfiguredEventKind(runtime)
+	if kind == "" {
+		return true
+	}
+	return identityKindAllowed(kind, allowed)
+}
+
+func runtimeConfiguredEventKind(runtime *cerebrov1.SourceRuntime) string {
+	if runtime == nil {
+		return ""
+	}
+	sourceID := strings.TrimSpace(runtime.GetSourceId())
+	family := strings.TrimSpace(runtime.GetConfig()["family"])
+	if sourceID == "" || family == "" {
+		return ""
+	}
+	return sourceID + "." + family
+}

--- a/internal/findings/runtime_kind.go
+++ b/internal/findings/runtime_kind.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 func runtimeMayEmitEventKind(runtime *cerebrov1.SourceRuntime, allowed []string) bool {
@@ -24,6 +25,9 @@ func runtimeConfiguredEventKind(runtime *cerebrov1.SourceRuntime) string {
 	sourceID := strings.TrimSpace(runtime.GetSourceId())
 	family := strings.TrimSpace(runtime.GetConfig()["family"])
 	if sourceID == "" {
+		return ""
+	}
+	if sourceconfig.IsSecretReference(family) {
 		return ""
 	}
 	if family == "" {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -947,6 +947,7 @@ func (s *Service) staleOpenRulesForRuntime(ctx context.Context, runtime *cerebro
 	if seen == nil {
 		seen = map[string]struct{}{}
 	}
+	candidates := make(map[string]Rule)
 	staleRules := []Rule{}
 	for _, spec := range s.rules.List() {
 		ruleID := strings.TrimSpace(spec.GetId())
@@ -963,17 +964,52 @@ func (s *Service) staleOpenRulesForRuntime(ctx context.Context, runtime *cerebro
 		if _, isGraph := asGraphRule(rule); isGraph {
 			continue
 		}
-		hasStale, err := s.hasOpenFindingsForRule(ctx, runtime, ruleID)
-		if err != nil {
-			return nil, err
+		candidates[ruleID] = rule
+	}
+	if len(candidates) == 0 {
+		return staleRules, nil
+	}
+	openRuleIDs, err := s.openFindingRuleIDsForRuntime(ctx, runtime)
+	if err != nil {
+		return nil, err
+	}
+	for _, spec := range s.rules.List() {
+		ruleID := strings.TrimSpace(spec.GetId())
+		rule, ok := candidates[ruleID]
+		if !ok {
+			continue
 		}
-		if !hasStale {
+		if _, ok := openRuleIDs[ruleID]; !ok {
 			continue
 		}
 		seen[ruleID] = struct{}{}
 		staleRules = append(staleRules, rule)
 	}
 	return staleRules, nil
+}
+
+func (s *Service) openFindingRuleIDsForRuntime(ctx context.Context, runtime *cerebrov1.SourceRuntime) (map[string]struct{}, error) {
+	ruleIDs := map[string]struct{}{}
+	if s == nil || s.store == nil || runtime == nil {
+		return ruleIDs, nil
+	}
+	findings, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
+		TenantID:  strings.TrimSpace(runtime.GetTenantId()),
+		RuntimeID: strings.TrimSpace(runtime.GetId()),
+		Status:    findingStatusOpen,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list stale candidates for runtime %q: %w", strings.TrimSpace(runtime.GetId()), err)
+	}
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		if ruleID := strings.TrimSpace(finding.RuleID); ruleID != "" {
+			ruleIDs[ruleID] = struct{}{}
+		}
+	}
+	return ruleIDs, nil
 }
 
 func (s *Service) hasOpenFindingsForRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, ruleID string) (bool, error) {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -859,13 +859,21 @@ func (s *Service) selectRule(ctx context.Context, runtime *cerebrov1.SourceRunti
 		}
 		return rule, nil
 	}
-	applicable, err := s.eventDrivenRulesForRuntime(ctx, runtime)
-	if err != nil {
-		return nil, err
-	}
+	applicable := filterEventDrivenRules(s.rules.ForRuntime(runtime))
 	switch len(applicable) {
 	case 0:
-		return nil, fmt.Errorf("%w: %s", ErrRuleUnavailable, strings.TrimSpace(runtime.GetId()))
+		staleRules, err := s.staleOpenRulesForRuntime(ctx, runtime, nil)
+		if err != nil {
+			return nil, err
+		}
+		switch len(staleRules) {
+		case 0:
+			return nil, fmt.Errorf("%w: %s", ErrRuleUnavailable, strings.TrimSpace(runtime.GetId()))
+		case 1:
+			return staleRules[0], nil
+		default:
+			return nil, fmt.Errorf("%w for runtime %q", ErrRuleSelectionRequired, strings.TrimSpace(runtime.GetId()))
+		}
 	case 1:
 		return applicable[0], nil
 	default:
@@ -928,6 +936,18 @@ func (s *Service) eventDrivenRulesForRuntime(ctx context.Context, runtime *cereb
 		}
 		seen[strings.TrimSpace(rule.Spec().GetId())] = struct{}{}
 	}
+	staleRules, err := s.staleOpenRulesForRuntime(ctx, runtime, seen)
+	if err != nil {
+		return nil, err
+	}
+	return append(applicable, staleRules...), nil
+}
+
+func (s *Service) staleOpenRulesForRuntime(ctx context.Context, runtime *cerebrov1.SourceRuntime, seen map[string]struct{}) ([]Rule, error) {
+	if seen == nil {
+		seen = map[string]struct{}{}
+	}
+	staleRules := []Rule{}
 	for _, spec := range s.rules.List() {
 		ruleID := strings.TrimSpace(spec.GetId())
 		if ruleID == "" {
@@ -951,9 +971,9 @@ func (s *Service) eventDrivenRulesForRuntime(ctx context.Context, runtime *cereb
 			continue
 		}
 		seen[ruleID] = struct{}{}
-		applicable = append(applicable, rule)
+		staleRules = append(staleRules, rule)
 	}
-	return applicable, nil
+	return staleRules, nil
 }
 
 func (s *Service) hasOpenFindingsForRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, ruleID string) (bool, error) {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -257,7 +257,7 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	if err != nil {
 		return nil, err
 	}
-	rule, err := s.selectRule(runtime, request.RuleID)
+	rule, err := s.selectRule(ctx, runtime, request.RuleID)
 	if err != nil {
 		return nil, err
 	}
@@ -287,6 +287,10 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	for _, event := range events {
 		if eventID := strings.TrimSpace(event.GetId()); eventID != "" {
 			evaluatedEventIDs[eventID] = struct{}{}
+		}
+		if !rule.SupportsRuntime(runtime) {
+			result.EventsEvaluated++
+			continue
 		}
 		emitted, err := rule.Evaluate(ctx, runtime, event)
 		if err != nil {
@@ -334,7 +338,7 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 			}
 		}
 	}
-	if err := s.resolveStaleOpenFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), runtimeID, rule.Spec().GetId(), evaluatedEventIDs, emittedFindingIDs); err != nil {
+	if err := s.resolveRuleOpenFindings(ctx, runtime, rule, evaluatedEventIDs, emittedFindingIDs); err != nil {
 		evaluationErr := fmt.Errorf("resolve stale findings for rule %q: %w", result.Rule.GetId(), err)
 		return nil, s.finishFailedRun(ctx, run, result.EventsEvaluated, eventsMatched, findingIDs(result.Findings), evaluationErr)
 	}
@@ -357,7 +361,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 	if err != nil {
 		return nil, err
 	}
-	rules, err := s.selectRules(runtime, request.RuleIDs)
+	rules, err := s.selectRules(ctx, runtime, request.RuleIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +405,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 			evaluatedEventIDs[eventID] = struct{}{}
 		}
 		for _, state := range states {
-			if state.failed {
+			if state.failed || !state.rule.SupportsRuntime(runtime) {
 				continue
 			}
 			emitted, err := state.rule.Evaluate(ctx, runtime, event)
@@ -467,7 +471,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 		if state.failed {
 			continue
 		}
-		if err := s.resolveStaleOpenFindings(ctx, strings.TrimSpace(runtime.GetTenantId()), runtimeID, state.result.Rule.GetId(), evaluatedEventIDs, state.emittedFindingIDs); err != nil {
+		if err := s.resolveRuleOpenFindings(ctx, runtime, state.rule, evaluatedEventIDs, state.emittedFindingIDs); err != nil {
 			evaluationErr := fmt.Errorf("resolve stale findings for rule %q: %w", state.result.Rule.GetId(), err)
 			return nil, s.markRuleEvaluationsFailed(ctx, unfinishedRuleEvaluations(states, state), evaluationErr)
 		}
@@ -530,6 +534,49 @@ func (s *Service) resolveStaleOpenFindings(ctx context.Context, tenantID string,
 			continue
 		}
 		if !findingReferencesEvaluatedEvent(finding, evaluatedEventIDs) {
+			continue
+		}
+		updated, err := s.store.UpdateFindingStatus(ctx, ports.FindingStatusUpdate{
+			FindingID: strings.TrimSpace(finding.ID),
+			Status:    findingStatusResolved,
+			Reason:    workflowevents.FindingStatusReasonNoLongerEmitted,
+			UpdatedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			return fmt.Errorf("resolve stale finding %q: %w", strings.TrimSpace(finding.ID), err)
+		}
+		if err := s.recordFindingStatusWorkflow(ctx, updated, workflowevents.FindingStatusSourceStaleEvaluation); err != nil {
+			return fmt.Errorf("project stale finding %q resolution: %w", strings.TrimSpace(finding.ID), err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) resolveRuleOpenFindings(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule Rule, evaluatedEventIDs map[string]struct{}, emittedFindingIDs map[string]struct{}) error {
+	if runtime == nil || rule == nil {
+		return nil
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	runtimeID := strings.TrimSpace(runtime.GetId())
+	ruleID := strings.TrimSpace(rule.Spec().GetId())
+	if rule.SupportsRuntime(runtime) {
+		return s.resolveStaleOpenFindings(ctx, tenantID, runtimeID, ruleID, evaluatedEventIDs, emittedFindingIDs)
+	}
+	return s.resolveAllOpenFindingsForRule(ctx, tenantID, runtimeID, ruleID)
+}
+
+func (s *Service) resolveAllOpenFindingsForRule(ctx context.Context, tenantID string, runtimeID string, ruleID string) error {
+	findings, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
+		TenantID:  strings.TrimSpace(tenantID),
+		RuntimeID: strings.TrimSpace(runtimeID),
+		RuleID:    strings.TrimSpace(ruleID),
+		Status:    findingStatusOpen,
+	})
+	if err != nil {
+		return fmt.Errorf("list stale candidates for unsupported rule %q: %w", strings.TrimSpace(ruleID), err)
+	}
+	for _, finding := range findings {
+		if finding == nil {
 			continue
 		}
 		updated, err := s.store.UpdateFindingStatus(ctx, ports.FindingStatusUpdate{
@@ -791,22 +838,31 @@ type ruleEvaluationState struct {
 	failed            bool
 }
 
-func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (Rule, error) {
+func (s *Service) selectRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, ruleID string) (Rule, error) {
 	trimmedRuleID := strings.TrimSpace(ruleID)
 	if trimmedRuleID != "" {
 		rule, ok := s.rules.Get(trimmedRuleID)
 		if !ok {
 			return nil, fmt.Errorf("%w: %s", ErrRuleNotFound, trimmedRuleID)
 		}
-		if !rule.SupportsRuntime(runtime) {
-			return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedRuleID)
-		}
 		if _, isGraph := asGraphRule(rule); isGraph {
 			return nil, fmt.Errorf("%w: %s is a graph rule and cannot be evaluated via event replay", ErrRuleUnsupported, trimmedRuleID)
 		}
+		if !rule.SupportsRuntime(runtime) {
+			hasStale, err := s.hasOpenFindingsForRule(ctx, runtime, trimmedRuleID)
+			if err != nil {
+				return nil, err
+			}
+			if !hasStale {
+				return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedRuleID)
+			}
+		}
 		return rule, nil
 	}
-	applicable := filterEventDrivenRules(s.rules.ForRuntime(runtime))
+	applicable, err := s.eventDrivenRulesForRuntime(ctx, runtime)
+	if err != nil {
+		return nil, err
+	}
 	switch len(applicable) {
 	case 0:
 		return nil, fmt.Errorf("%w: %s", ErrRuleUnavailable, strings.TrimSpace(runtime.GetId()))
@@ -817,9 +873,12 @@ func (s *Service) selectRule(runtime *cerebrov1.SourceRuntime, ruleID string) (R
 	}
 }
 
-func (s *Service) selectRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string) ([]Rule, error) {
+func (s *Service) selectRules(ctx context.Context, runtime *cerebrov1.SourceRuntime, ruleIDs []string) ([]Rule, error) {
 	if len(ruleIDs) == 0 {
-		applicable := filterEventDrivenRules(s.rules.ForRuntime(runtime))
+		applicable, err := s.eventDrivenRulesForRuntime(ctx, runtime)
+		if err != nil {
+			return nil, err
+		}
 		if len(applicable) == 0 {
 			return nil, fmt.Errorf("%w: %s", ErrRuleUnavailable, strings.TrimSpace(runtime.GetId()))
 		}
@@ -839,11 +898,17 @@ func (s *Service) selectRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string
 		if !ok {
 			return nil, fmt.Errorf("%w: %s", ErrRuleNotFound, trimmedID)
 		}
-		if !rule.SupportsRuntime(runtime) {
-			return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedID)
-		}
 		if _, isGraph := asGraphRule(rule); isGraph {
 			return nil, fmt.Errorf("%w: %s is a graph rule and cannot be evaluated via event replay", ErrRuleUnsupported, trimmedID)
+		}
+		if !rule.SupportsRuntime(runtime) {
+			hasStale, err := s.hasOpenFindingsForRule(ctx, runtime, trimmedID)
+			if err != nil {
+				return nil, err
+			}
+			if !hasStale {
+				return nil, fmt.Errorf("%w: %s", ErrRuleUnsupported, trimmedID)
+			}
 		}
 		seen[trimmedID] = struct{}{}
 		selected = append(selected, rule)
@@ -852,6 +917,60 @@ func (s *Service) selectRules(runtime *cerebrov1.SourceRuntime, ruleIDs []string
 		return nil, fmt.Errorf("%w for runtime %q", ErrRuleSelectionRequired, strings.TrimSpace(runtime.GetId()))
 	}
 	return selected, nil
+}
+
+func (s *Service) eventDrivenRulesForRuntime(ctx context.Context, runtime *cerebrov1.SourceRuntime) ([]Rule, error) {
+	applicable := filterEventDrivenRules(s.rules.ForRuntime(runtime))
+	seen := make(map[string]struct{}, len(applicable))
+	for _, rule := range applicable {
+		if rule == nil || rule.Spec() == nil {
+			continue
+		}
+		seen[strings.TrimSpace(rule.Spec().GetId())] = struct{}{}
+	}
+	for _, spec := range s.rules.List() {
+		ruleID := strings.TrimSpace(spec.GetId())
+		if ruleID == "" {
+			continue
+		}
+		if _, ok := seen[ruleID]; ok {
+			continue
+		}
+		rule, ok := s.rules.Get(ruleID)
+		if !ok || rule.SupportsRuntime(runtime) {
+			continue
+		}
+		if _, isGraph := asGraphRule(rule); isGraph {
+			continue
+		}
+		hasStale, err := s.hasOpenFindingsForRule(ctx, runtime, ruleID)
+		if err != nil {
+			return nil, err
+		}
+		if !hasStale {
+			continue
+		}
+		seen[ruleID] = struct{}{}
+		applicable = append(applicable, rule)
+	}
+	return applicable, nil
+}
+
+func (s *Service) hasOpenFindingsForRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, ruleID string) (bool, error) {
+	if s == nil || s.store == nil || runtime == nil {
+		return false, nil
+	}
+	findings, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
+		TenantID:  strings.TrimSpace(runtime.GetTenantId()),
+		RuntimeID: strings.TrimSpace(runtime.GetId()),
+		RuleID:    strings.TrimSpace(ruleID),
+		Status:    findingStatusOpen,
+		Limit:     1,
+	})
+	if err != nil {
+		return false, fmt.Errorf("list stale candidates for rule %q: %w", strings.TrimSpace(ruleID), err)
+	}
+	return len(findings) != 0, nil
 }
 
 // filterEventDrivenRules excludes graph rules from a rule slice. Graph rules implement Rule

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -1534,6 +1534,49 @@ func TestEvaluateSourceRuntimeFindingsRejectsUnsupportedRule(t *testing.T) {
 	}
 }
 
+func TestEvaluateSourceRuntimeFindingsAllowsExplicitUnsupportedRuleWithOpenFindings(t *testing.T) {
+	registry, err := NewRegistry(&emittingRule{
+		spec:               &cerebrov1.RuleSpec{Id: "old-family-rule", Name: "Old Family Rule"},
+		supportedSourceIDs: map[string]struct{}{"okta": {}},
+		triggerEventID:     "old-event",
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{findings: map[string]*ports.FindingRecord{
+		"finding-old": {
+			ID:        "finding-old",
+			TenantID:  "writer",
+			RuntimeID: "writer-aws-public-endpoint",
+			RuleID:    "old-family-rule",
+			Status:    findingStatusOpen,
+			EventIDs:  []string{"old-event"},
+		},
+	}}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-aws-public-endpoint": {Id: "writer-aws-public-endpoint", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "public_endpoint"}},
+		}},
+		&stubReplayer{},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{RuntimeID: "writer-aws-public-endpoint", RuleID: "old-family-rule"})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntime() error = %v", err)
+	}
+	if result.Rule.GetId() != "old-family-rule" {
+		t.Fatalf("Rule.Id = %q, want old-family-rule", result.Rule.GetId())
+	}
+	if got := store.findings["finding-old"].Status; got != findingStatusResolved {
+		t.Fatalf("stale finding status = %q, want %q", got, findingStatusResolved)
+	}
+}
+
 func TestEvaluateSourceRuntimeRulesReplaysOnceAcrossMultipleRules(t *testing.T) {
 	registry, err := NewRegistry(
 		&emittingRule{
@@ -1645,6 +1688,49 @@ func TestEvaluateSourceRuntimeRulesReplaysOnceAcrossMultipleRules(t *testing.T) 
 	}
 	if got := len(store.evidence); got != 2 {
 		t.Fatalf("len(store.evidence) = %d, want 2", got)
+	}
+}
+
+func TestEvaluateSourceRuntimeRulesIncludesUnsupportedRulesWithOpenFindings(t *testing.T) {
+	registry, err := NewRegistry(&emittingRule{
+		spec:               &cerebrov1.RuleSpec{Id: "old-family-rule", Name: "Old Family Rule"},
+		supportedSourceIDs: map[string]struct{}{"okta": {}},
+		triggerEventID:     "old-event",
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{findings: map[string]*ports.FindingRecord{
+		"finding-old": {
+			ID:        "finding-old",
+			TenantID:  "writer",
+			RuntimeID: "writer-aws-public-endpoint",
+			RuleID:    "old-family-rule",
+			Status:    findingStatusOpen,
+			EventIDs:  []string{"old-event"},
+		},
+	}}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-aws-public-endpoint": {Id: "writer-aws-public-endpoint", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "public_endpoint"}},
+		}},
+		&stubReplayer{},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	result, err := service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "writer-aws-public-endpoint"})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v", err)
+	}
+	if len(result.Evaluations) != 1 || result.Evaluations[0].Rule.GetId() != "old-family-rule" {
+		t.Fatalf("evaluations = %#v, want only old-family-rule", result.Evaluations)
+	}
+	if got := store.findings["finding-old"].Status; got != findingStatusResolved {
+		t.Fatalf("stale finding status = %q, want %q", got, findingStatusResolved)
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -65,19 +65,20 @@ func (s *recordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnv
 }
 
 type stubFindingStore struct {
-	findings         map[string]*ports.FindingRecord
-	request          ports.ListFindingsRequest
-	listFindingsErr  error
-	claims           map[string]*ports.ClaimRecord
-	claimListRequest ports.ListClaimsRequest
-	runs             map[string]*cerebrov1.FindingEvaluationRun
-	runList          ports.ListFindingEvaluationRunsRequest
-	runPutCount      int
-	failRunPutOn     int
-	failRunPutErr    error
-	failRunPutByCall map[int]error
-	evidence         map[string]*cerebrov1.FindingEvidence
-	evidenceList     ports.ListFindingEvidenceRequest
+	findings             map[string]*ports.FindingRecord
+	request              ports.ListFindingsRequest
+	listFindingsRequests []ports.ListFindingsRequest
+	listFindingsErr      error
+	claims               map[string]*ports.ClaimRecord
+	claimListRequest     ports.ListClaimsRequest
+	runs                 map[string]*cerebrov1.FindingEvaluationRun
+	runList              ports.ListFindingEvaluationRunsRequest
+	runPutCount          int
+	failRunPutOn         int
+	failRunPutErr        error
+	failRunPutByCall     map[int]error
+	evidence             map[string]*cerebrov1.FindingEvidence
+	evidenceList         ports.ListFindingEvidenceRequest
 }
 
 func (s *stubFindingStore) Ping(context.Context) error { return nil }
@@ -113,6 +114,7 @@ func (s *stubFindingStore) GetFinding(_ context.Context, id string) (*ports.Find
 
 func (s *stubFindingStore) ListFindings(_ context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
 	s.request = request
+	s.listFindingsRequests = append(s.listFindingsRequests, request)
 	if s.listFindingsErr != nil {
 		return nil, s.listFindingsErr
 	}
@@ -1781,6 +1783,53 @@ func TestEvaluateSourceRuntimeRulesIncludesUnsupportedRulesWithOpenFindings(t *t
 	}
 	if got := store.findings["finding-old"].Status; got != findingStatusResolved {
 		t.Fatalf("stale finding status = %q, want %q", got, findingStatusResolved)
+	}
+}
+
+func TestEvaluateSourceRuntimeRulesProbesStaleUnsupportedRulesOnce(t *testing.T) {
+	registry, err := NewRegistry(
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "live-rule", Name: "Live Rule"},
+			supportedSourceIDs: map[string]struct{}{"aws": {}},
+		},
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "old-rule-a", Name: "Old Rule A"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+		},
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "old-rule-b", Name: "Old Rule B"},
+			supportedSourceIDs: map[string]struct{}{"github": {}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-aws-public-endpoint": {Id: "writer-aws-public-endpoint", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "public_endpoint"}},
+		}},
+		&stubReplayer{},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	result, err := service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "writer-aws-public-endpoint"})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v", err)
+	}
+	if len(result.Evaluations) != 1 || result.Evaluations[0].Rule.GetId() != "live-rule" {
+		t.Fatalf("evaluations = %#v, want only live-rule", result.Evaluations)
+	}
+	if got := len(store.listFindingsRequests); got != 1 {
+		t.Fatalf("ListFindings calls = %d, want one stale unsupported probe", got)
+	}
+	request := store.listFindingsRequests[0]
+	if request.RuleID != "" || request.RuntimeID != "writer-aws-public-endpoint" || request.Status != findingStatusOpen {
+		t.Fatalf("stale probe request = %#v, want one runtime-wide open-finding query", request)
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -1577,6 +1577,56 @@ func TestEvaluateSourceRuntimeFindingsAllowsExplicitUnsupportedRuleWithOpenFindi
 	}
 }
 
+func TestEvaluateSourceRuntimeFindingsIgnoresStaleOnlyRulesForSingleSelection(t *testing.T) {
+	registry, err := NewRegistry(
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "live-rule", Name: "Live Rule"},
+			supportedSourceIDs: map[string]struct{}{"aws": {}},
+			triggerEventID:     "live-event",
+		},
+		&emittingRule{
+			spec:               &cerebrov1.RuleSpec{Id: "old-family-rule", Name: "Old Family Rule"},
+			supportedSourceIDs: map[string]struct{}{"okta": {}},
+			triggerEventID:     "old-event",
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubFindingStore{findings: map[string]*ports.FindingRecord{
+		"finding-old": {
+			ID:        "finding-old",
+			TenantID:  "writer",
+			RuntimeID: "writer-aws-public-endpoint",
+			RuleID:    "old-family-rule",
+			Status:    findingStatusOpen,
+			EventIDs:  []string{"old-event"},
+		},
+	}}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-aws-public-endpoint": {Id: "writer-aws-public-endpoint", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "public_endpoint"}},
+		}},
+		&stubReplayer{},
+		store,
+		store,
+		store,
+		store,
+		registry,
+	)
+
+	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{RuntimeID: "writer-aws-public-endpoint"})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntime() error = %v", err)
+	}
+	if got := result.Rule.GetId(); got != "live-rule" {
+		t.Fatalf("Rule.Id = %q, want live-rule", got)
+	}
+	if got := store.findings["finding-old"].Status; got != findingStatusOpen {
+		t.Fatalf("stale finding status = %q, want still open", got)
+	}
+}
+
 func TestEvaluateSourceRuntimeRulesReplaysOnceAcrossMultipleRules(t *testing.T) {
 	registry, err := NewRegistry(
 		&emittingRule{

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
 )
 
@@ -117,7 +118,7 @@ type HealthResult struct {
 
 func New(registry *sourcecdk.Registry, runtimeStore ports.SourceRuntimeStore, projector ports.SourceProjector, graphStore ports.GraphStore) *Service {
 	return &Service{
-		sourceService: sourceops.New(registry),
+		sourceService: sourceops.New(registry).WithInternalConfigAllowed(),
 		runtimeStore:  runtimeStore,
 		projector:     projector,
 		graphStore:    graphStore,
@@ -353,7 +354,7 @@ func (s *Service) putTerminalIngestRun(ctx context.Context, runStore RunStore, r
 }
 
 func (s *Service) preparedConfig(ctx context.Context, runtime *cerebrov1.SourceRuntime) (map[string]string, error) {
-	config := cloneConfig(runtime.GetConfig())
+	config := sourceconfig.WithRuntimeTenant(runtime.GetConfig(), runtime.GetTenantId())
 	if s.prepareConfig == nil {
 		return config, nil
 	}
@@ -917,12 +918,4 @@ func validRunStatus(status string) bool {
 	default:
 		return false
 	}
-}
-
-func cloneConfig(config map[string]string) map[string]string {
-	cloned := make(map[string]string, len(config))
-	for key, value := range config {
-		cloned[key] = value
-	}
-	return cloned
 }

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -355,6 +355,7 @@ func (s *Service) putTerminalIngestRun(ctx context.Context, runStore RunStore, r
 
 func (s *Service) preparedConfig(ctx context.Context, runtime *cerebrov1.SourceRuntime) (map[string]string, error) {
 	config := sourceconfig.WithRuntimeTenant(runtime.GetConfig(), runtime.GetTenantId())
+	config = sourceconfig.WithLegacyTenantlessAssumeRole(config, runtime.GetSourceId(), runtime.GetTenantId())
 	if s.prepareConfig == nil {
 		return config, nil
 	}

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -833,7 +833,7 @@ func finishRun(run graphstore.IngestRun, result *IngestResult, status string, ru
 func configHash(config map[string]string) string {
 	keys := make([]string, 0, len(config))
 	for key := range config {
-		if !sensitiveConfigKey(key) {
+		if !sourceconfig.InternalKey(key) && !sensitiveConfigKey(key) {
 			keys = append(keys, key)
 		}
 	}

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -10,6 +10,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 type stubRunStore struct {
@@ -99,6 +100,18 @@ func TestConfigHashIgnoresSensitiveKeyValues(t *testing.T) {
 	})
 	if left != right {
 		t.Fatalf("configHash() differed when only sensitive keys changed")
+	}
+}
+
+func TestConfigHashIgnoresInternalRuntimeMetadata(t *testing.T) {
+	base := configHash(map[string]string{"domain": "writer.okta.com"})
+	withInternal := configHash(map[string]string{
+		"domain":                               "writer.okta.com",
+		sourceconfig.RuntimeTenantIDKey:        "writer",
+		sourceconfig.AWSAssumeRoleAllowlistKey: "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role",
+	})
+	if base != withInternal {
+		t.Fatal("configHash() changed when only internal runtime metadata changed")
 	}
 }
 

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -563,10 +563,12 @@ func (s *Service) readEvents(ctx context.Context, source sourcecdk.Source, runti
 }
 
 func (s *Service) prepareConfig(ctx context.Context, runtime *cerebrov1.SourceRuntime) (map[string]string, error) {
+	config := sourceconfig.WithRuntimeTenant(runtime.GetConfig(), runtime.GetTenantId())
+	config = sourceconfig.WithLegacyTenantlessAssumeRole(config, runtime.GetSourceId(), runtime.GetTenantId())
 	if s == nil || s.preparer == nil {
-		return sourceconfig.WithRuntimeTenant(runtime.GetConfig(), runtime.GetTenantId()), nil
+		return config, nil
 	}
-	return s.preparer(ctx, runtime.GetSourceId(), sourceconfig.WithRuntimeTenant(runtime.GetConfig(), runtime.GetTenantId()))
+	return s.preparer(ctx, runtime.GetSourceId(), config)
 }
 
 type projectSummary struct {

--- a/internal/graphrebuild/service.go
+++ b/internal/graphrebuild/service.go
@@ -564,17 +564,9 @@ func (s *Service) readEvents(ctx context.Context, source sourcecdk.Source, runti
 
 func (s *Service) prepareConfig(ctx context.Context, runtime *cerebrov1.SourceRuntime) (map[string]string, error) {
 	if s == nil || s.preparer == nil {
-		return cloneConfig(runtime.GetConfig()), nil
+		return sourceconfig.WithRuntimeTenant(runtime.GetConfig(), runtime.GetTenantId()), nil
 	}
-	return s.preparer(ctx, runtime.GetSourceId(), runtime.GetConfig())
-}
-
-func cloneConfig(config map[string]string) map[string]string {
-	cloned := make(map[string]string, len(config))
-	for key, value := range config {
-		cloned[key] = value
-	}
-	return cloned
+	return s.preparer(ctx, runtime.GetSourceId(), sourceconfig.WithRuntimeTenant(runtime.GetConfig(), runtime.GetTenantId()))
 }
 
 type projectSummary struct {

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -14,6 +14,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 type runtimeStore struct {
@@ -297,10 +298,14 @@ func TestRebuildDryRunResolvesRuntimeConfigReferences(t *testing.T) {
 		"writer-github": {
 			Id:       "writer-github",
 			SourceId: "github",
+			TenantId: "writer",
 			Config:   map[string]string{"token": "env:TOKEN"},
 		},
 	}}
 	service := New(registry, store, nil).WithConfigPreparer(func(_ context.Context, _ string, values map[string]string) (map[string]string, error) {
+		if got := values[sourceconfig.RuntimeTenantIDKey]; got != "writer" {
+			t.Fatalf("runtime tenant config = %q, want writer", got)
+		}
 		resolved := make(map[string]string, len(values))
 		for key, value := range values {
 			if value == "env:TOKEN" {

--- a/internal/sourceconfig/secrets.go
+++ b/internal/sourceconfig/secrets.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	envPrefix                 = "env:"
-	AWSAssumeRoleAllowlistKey = "__cerebro_aws_assume_role_arns"
-	RuntimeTenantIDKey        = "__cerebro_runtime_tenant_id"
+	envPrefix                     = "env:"
+	AWSAssumeRoleAllowlistKey     = "__cerebro_aws_assume_role_arns"
+	LegacyTenantlessAssumeRoleKey = "__cerebro_legacy_tenantless_assume_role"
+	RuntimeTenantIDKey            = "__cerebro_runtime_tenant_id"
 )
 
 type Resolver func(context.Context, string, map[string]string) (map[string]string, error)
@@ -48,6 +49,23 @@ func WithRuntimeTenant(values map[string]string, tenantID string) map[string]str
 		cloned[RuntimeTenantIDKey] = tenantID
 	}
 	return cloned
+}
+
+func WithLegacyTenantlessAssumeRole(values map[string]string, sourceID string, tenantID string) map[string]string {
+	cloned := make(map[string]string, len(values)+1)
+	for key, value := range values {
+		cloned[key] = value
+	}
+	if LegacyTenantlessAssumeRoleConfig(sourceID, tenantID, cloned) {
+		cloned[LegacyTenantlessAssumeRoleKey] = "true"
+	}
+	return cloned
+}
+
+func LegacyTenantlessAssumeRoleConfig(sourceID string, tenantID string, config map[string]string) bool {
+	return strings.TrimSpace(sourceID) == "aws" &&
+		strings.TrimSpace(tenantID) == "" &&
+		strings.TrimSpace(config["role_arn"]) != ""
 }
 
 func SensitiveKey(key string) bool {

--- a/internal/sourceconfig/secrets.go
+++ b/internal/sourceconfig/secrets.go
@@ -8,6 +8,7 @@ import (
 const (
 	envPrefix                 = "env:"
 	AWSAssumeRoleAllowlistKey = "__cerebro_aws_assume_role_arns"
+	RuntimeTenantIDKey        = "__cerebro_runtime_tenant_id"
 )
 
 type Resolver func(context.Context, string, map[string]string) (map[string]string, error)

--- a/internal/sourceconfig/secrets.go
+++ b/internal/sourceconfig/secrets.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-const envPrefix = "env:"
+const (
+	envPrefix                 = "env:"
+	AWSAssumeRoleAllowlistKey = "__cerebro_aws_assume_role_arns"
+)
 
 type Resolver func(context.Context, string, map[string]string) (map[string]string, error)
 

--- a/internal/sourceconfig/secrets.go
+++ b/internal/sourceconfig/secrets.go
@@ -35,6 +35,21 @@ func LiteralEnvPrefixKey(key string) bool {
 	}
 }
 
+func InternalKey(key string) bool {
+	return strings.HasPrefix(strings.TrimSpace(key), "__cerebro_")
+}
+
+func WithRuntimeTenant(values map[string]string, tenantID string) map[string]string {
+	cloned := make(map[string]string, len(values)+1)
+	for key, value := range values {
+		cloned[key] = value
+	}
+	if tenantID := strings.TrimSpace(tenantID); tenantID != "" {
+		cloned[RuntimeTenantIDKey] = tenantID
+	}
+	return cloned
+}
+
 func SensitiveKey(key string) bool {
 	value := strings.ToLower(strings.TrimSpace(key))
 	if value == "" {

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -11,6 +11,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 var (
@@ -20,12 +21,21 @@ var (
 
 // Service exposes typed source preview operations over a registry.
 type Service struct {
-	registry *sourcecdk.Registry
+	registry            *sourcecdk.Registry
+	allowInternalConfig bool
 }
 
 // New constructs a source operations service.
 func New(registry *sourcecdk.Registry) *Service {
 	return &Service{registry: registry}
+}
+
+func (s *Service) WithInternalConfigAllowed() *Service {
+	if s == nil {
+		return nil
+	}
+	s.allowInternalConfig = true
+	return s
 }
 
 // List returns the registered source catalog.
@@ -44,7 +54,11 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 	if err != nil {
 		return nil, err
 	}
-	if err := source.Check(ctx, sourcecdk.NewConfig(req.GetConfig())); err != nil {
+	config, err := s.previewConfig(req.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+	if err := source.Check(ctx, sourcecdk.NewConfig(config)); err != nil {
 		return nil, sourceOperationError(err)
 	}
 	return &cerebrov1.CheckSourceResponse{
@@ -59,7 +73,11 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 	if err != nil {
 		return nil, err
 	}
-	urns, err := source.Discover(ctx, sourcecdk.NewConfig(req.GetConfig()))
+	config, err := s.previewConfig(req.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+	urns, err := source.Discover(ctx, sourcecdk.NewConfig(config))
 	if err != nil {
 		return nil, sourceOperationError(err)
 	}
@@ -79,7 +97,11 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	pull, err := source.Read(ctx, sourcecdk.NewConfig(req.GetConfig()), req.GetCursor())
+	config, err := s.previewConfig(req.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+	pull, err := source.Read(ctx, sourcecdk.NewConfig(config), req.GetCursor())
 	if err != nil {
 		return nil, sourceOperationError(err)
 	}
@@ -101,6 +123,17 @@ func sourceOperationError(err error) error {
 		return fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 	}
 	return err
+}
+
+func (s *Service) previewConfig(values map[string]string) (map[string]string, error) {
+	config := make(map[string]string, len(values))
+	for key, value := range values {
+		if !s.allowInternalConfig && sourceconfig.InternalKey(key) {
+			return nil, fmt.Errorf("%w: source config %q is reserved", ErrInvalidRequest, strings.TrimSpace(key))
+		}
+		config[key] = value
+	}
+	return config, nil
 }
 
 func (s *Service) lookup(sourceID string) (sourcecdk.Source, error) {

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	githubsource "github.com/writer/cerebro/sources/github"
 	googleworkspacesource "github.com/writer/cerebro/sources/googleworkspace"
 	oktasource "github.com/writer/cerebro/sources/okta"
@@ -78,6 +79,26 @@ func TestCheckDiscoverAndRead(t *testing.T) {
 	}
 	if !readResp.PreviewEvents[0].PayloadDecoded {
 		t.Fatal("Read().PreviewEvents[0].PayloadDecoded = false, want true")
+	}
+}
+
+func TestCheckRejectsInternalRuntimeConfigKeys(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	service := New(registry)
+
+	_, err = service.Check(context.Background(), &cerebrov1.CheckSourceRequest{
+		SourceId: "github",
+		Config: map[string]string{
+			"token":                                "test",
+			sourceconfig.RuntimeTenantIDKey:        "writer",
+			sourceconfig.AWSAssumeRoleAllowlistKey: "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role",
+		},
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Check() error = %v, want ErrInvalidRequest", err)
 	}
 }
 

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -158,7 +158,7 @@ func (s *Service) preparePutRuntime(ctx context.Context, input *cerebrov1.Source
 	default:
 		return nil, err
 	}
-	resolvedConfig, err := s.resolveConfig(ctx, runtime.GetSourceId(), runtime.GetTenantId(), runtime.GetConfig())
+	resolvedConfig, err := s.resolveConfigWithOptions(ctx, runtime.GetSourceId(), runtime.GetTenantId(), runtime.GetConfig(), legacyTenantlessAssumeRoleUpdate(existing, runtime))
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	if err != nil {
 		return nil, err
 	}
-	runtimeConfig, err := s.resolveConfig(ctx, runtime.GetSourceId(), runtime.GetTenantId(), runtime.GetConfig())
+	runtimeConfig, err := s.resolveConfigWithOptions(ctx, runtime.GetSourceId(), runtime.GetTenantId(), runtime.GetConfig(), legacyTenantlessAssumeRoleRuntime(runtime))
 	if err != nil {
 		return nil, err
 	}
@@ -333,15 +333,19 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 }
 
 func (s *Service) resolveConfig(ctx context.Context, sourceID string, tenantID string, config map[string]string) (map[string]string, error) {
+	return s.resolveConfigWithOptions(ctx, sourceID, tenantID, config, false)
+}
+
+func (s *Service) resolveConfigWithOptions(ctx context.Context, sourceID string, tenantID string, config map[string]string, legacyTenantlessAssumeRole bool) (map[string]string, error) {
 	resolver := s.resolver
 	if resolver == nil {
-		return sourceRuntimeConfig(userConfig(config), tenantID), nil
+		return sourceRuntimeConfig(userConfig(config), sourceID, tenantID, legacyTenantlessAssumeRole), nil
 	}
 	resolved, err := resolver(ctx, sourceID, userConfig(config))
 	if err != nil {
 		return nil, err
 	}
-	return sourceRuntimeConfig(resolvedConfig(resolved), tenantID), nil
+	return sourceRuntimeConfig(resolvedConfig(resolved), sourceID, tenantID, legacyTenantlessAssumeRole), nil
 }
 
 func (s *Service) lookupSource(sourceID string) (sourcecdk.Source, error) {
@@ -481,7 +485,7 @@ func sameConfig(left map[string]string, right map[string]string) bool {
 func userConfig(config map[string]string) map[string]string {
 	cloned := make(map[string]string, len(config))
 	for key, value := range config {
-		if key == runtimeProgressConfigHashKey || key == sourceconfig.AWSAssumeRoleAllowlistKey || key == sourceconfig.RuntimeTenantIDKey {
+		if key == runtimeProgressConfigHashKey || sourceconfig.InternalKey(key) {
 			continue
 		}
 		cloned[key] = value
@@ -500,8 +504,29 @@ func resolvedConfig(config map[string]string) map[string]string {
 	return cloned
 }
 
-func sourceRuntimeConfig(config map[string]string, tenantID string) map[string]string {
-	return sourceconfig.WithRuntimeTenant(resolvedConfig(config), tenantID)
+func sourceRuntimeConfig(config map[string]string, sourceID string, tenantID string, legacyTenantlessAssumeRole bool) map[string]string {
+	resolved := sourceconfig.WithRuntimeTenant(resolvedConfig(config), tenantID)
+	if legacyTenantlessAssumeRole {
+		resolved = sourceconfig.WithLegacyTenantlessAssumeRole(resolved, sourceID, tenantID)
+	}
+	return resolved
+}
+
+func legacyTenantlessAssumeRoleUpdate(existing *cerebrov1.SourceRuntime, incoming *cerebrov1.SourceRuntime) bool {
+	if !legacyTenantlessAssumeRoleRuntime(existing) || incoming == nil {
+		return false
+	}
+	if strings.TrimSpace(incoming.GetTenantId()) != "" {
+		return false
+	}
+	return strings.TrimSpace(incoming.GetConfig()["role_arn"]) == strings.TrimSpace(existing.GetConfig()["role_arn"])
+}
+
+func legacyTenantlessAssumeRoleRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if runtime == nil {
+		return false
+	}
+	return sourceconfig.LegacyTenantlessAssumeRoleConfig(runtime.GetSourceId(), runtime.GetTenantId(), runtime.GetConfig())
 }
 
 func withProgressConfigHash(config map[string]string, hash string) map[string]string {

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -147,6 +147,12 @@ func (s *Service) preparePutRuntime(ctx context.Context, input *cerebrov1.Source
 	switch {
 	case err == nil:
 		restoreRedactedConfig(existing, runtime)
+		if runtime.GetTenantId() == "" {
+			runtime.TenantId = strings.TrimSpace(existing.GetTenantId())
+		}
+		if err := validateRuntimeTenantUnchanged(existing, runtime); err != nil {
+			return nil, err
+		}
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
 		existing = nil
 	default:
@@ -164,9 +170,6 @@ func (s *Service) preparePutRuntime(ctx context.Context, input *cerebrov1.Source
 	}
 	runtime.Config = configWithProgressHash(runtime.GetConfig(), resolvedConfig)
 	if existing != nil {
-		if err := validateRuntimeTenantUnchanged(existing, runtime); err != nil {
-			return nil, err
-		}
 		runtime = mergeRuntime(existing, runtime)
 	}
 	return runtime, nil

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -542,7 +542,7 @@ func progressConfigHashForRuntime(rawConfig map[string]string, resolvedConfig ma
 
 func hasProgressConfigReferences(config map[string]string, resolvedConfig map[string]string) bool {
 	for key, value := range config {
-		if key == runtimeProgressConfigHashKey || progressHashSensitiveConfigKey(key) {
+		if key == runtimeProgressConfigHashKey || sourceconfig.InternalKey(key) || progressHashSensitiveConfigKey(key) {
 			continue
 		}
 		if sourceconfig.LiteralEnvPrefixKey(key) && resolvedConfig[key] == value {
@@ -566,7 +566,7 @@ func progressConfigHashChanged(existing map[string]string, incoming map[string]s
 func progressConfigHash(config map[string]string) string {
 	keys := make([]string, 0, len(config))
 	for key := range config {
-		if key == runtimeProgressConfigHashKey || progressHashSensitiveConfigKey(key) {
+		if key == runtimeProgressConfigHashKey || sourceconfig.InternalKey(key) || progressHashSensitiveConfigKey(key) {
 			continue
 		}
 		keys = append(keys, key)

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -478,7 +478,7 @@ func sameConfig(left map[string]string, right map[string]string) bool {
 func userConfig(config map[string]string) map[string]string {
 	cloned := make(map[string]string, len(config))
 	for key, value := range config {
-		if key == runtimeProgressConfigHashKey {
+		if key == runtimeProgressConfigHashKey || key == sourceconfig.AWSAssumeRoleAllowlistKey {
 			continue
 		}
 		cloned[key] = value

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -152,7 +152,7 @@ func (s *Service) preparePutRuntime(ctx context.Context, input *cerebrov1.Source
 	default:
 		return nil, err
 	}
-	resolvedConfig, err := s.resolveConfig(ctx, runtime.GetSourceId(), runtime.GetConfig())
+	resolvedConfig, err := s.resolveConfig(ctx, runtime.GetSourceId(), runtime.GetTenantId(), runtime.GetConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	if err != nil {
 		return nil, err
 	}
-	runtimeConfig, err := s.resolveConfig(ctx, runtime.GetSourceId(), runtime.GetConfig())
+	runtimeConfig, err := s.resolveConfig(ctx, runtime.GetSourceId(), runtime.GetTenantId(), runtime.GetConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -329,16 +329,16 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	}, nil
 }
 
-func (s *Service) resolveConfig(ctx context.Context, sourceID string, config map[string]string) (map[string]string, error) {
+func (s *Service) resolveConfig(ctx context.Context, sourceID string, tenantID string, config map[string]string) (map[string]string, error) {
 	resolver := s.resolver
 	if resolver == nil {
-		return userConfig(config), nil
+		return sourceRuntimeConfig(userConfig(config), tenantID), nil
 	}
 	resolved, err := resolver(ctx, sourceID, userConfig(config))
 	if err != nil {
 		return nil, err
 	}
-	return userConfig(resolved), nil
+	return sourceRuntimeConfig(resolvedConfig(resolved), tenantID), nil
 }
 
 func (s *Service) lookupSource(sourceID string) (sourcecdk.Source, error) {
@@ -478,10 +478,29 @@ func sameConfig(left map[string]string, right map[string]string) bool {
 func userConfig(config map[string]string) map[string]string {
 	cloned := make(map[string]string, len(config))
 	for key, value := range config {
-		if key == runtimeProgressConfigHashKey || key == sourceconfig.AWSAssumeRoleAllowlistKey {
+		if key == runtimeProgressConfigHashKey || key == sourceconfig.AWSAssumeRoleAllowlistKey || key == sourceconfig.RuntimeTenantIDKey {
 			continue
 		}
 		cloned[key] = value
+	}
+	return cloned
+}
+
+func resolvedConfig(config map[string]string) map[string]string {
+	cloned := make(map[string]string, len(config))
+	for key, value := range config {
+		if key == runtimeProgressConfigHashKey {
+			continue
+		}
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func sourceRuntimeConfig(config map[string]string, tenantID string) map[string]string {
+	cloned := resolvedConfig(config)
+	if tenantID := strings.TrimSpace(tenantID); tenantID != "" {
+		cloned[sourceconfig.RuntimeTenantIDKey] = tenantID
 	}
 	return cloned
 }

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -498,11 +498,7 @@ func resolvedConfig(config map[string]string) map[string]string {
 }
 
 func sourceRuntimeConfig(config map[string]string, tenantID string) map[string]string {
-	cloned := resolvedConfig(config)
-	if tenantID := strings.TrimSpace(tenantID); tenantID != "" {
-		cloned[sourceconfig.RuntimeTenantIDKey] = tenantID
-	}
-	return cloned
+	return sourceconfig.WithRuntimeTenant(resolvedConfig(config), tenantID)
 }
 
 func withProgressConfigHash(config map[string]string, hash string) map[string]string {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -472,6 +472,7 @@ func TestUserConfigStripsInternalAssumeRoleAllowlist(t *testing.T) {
 		"family":                               "public_endpoint",
 		runtimeProgressConfigHashKey:           "hash",
 		sourceconfig.AWSAssumeRoleAllowlistKey: "caller-controlled",
+		sourceconfig.RuntimeTenantIDKey:        "writer",
 	})
 	if got := config["family"]; got != "public_endpoint" {
 		t.Fatalf("family = %q, want public_endpoint", got)
@@ -481,6 +482,38 @@ func TestUserConfigStripsInternalAssumeRoleAllowlist(t *testing.T) {
 	}
 	if _, ok := config[runtimeProgressConfigHashKey]; ok {
 		t.Fatal("userConfig preserved progress config hash key")
+	}
+	if _, ok := config[sourceconfig.RuntimeTenantIDKey]; ok {
+		t.Fatal("userConfig preserved internal runtime tenant key")
+	}
+}
+
+func TestResolveConfigPreservesTrustedInternalRuntimeConfig(t *testing.T) {
+	service := New(nil, nil, nil, nil).WithConfigResolver(func(_ context.Context, _ string, values map[string]string) (map[string]string, error) {
+		if _, ok := values[sourceconfig.AWSAssumeRoleAllowlistKey]; ok {
+			t.Fatal("resolver input preserved caller-controlled allowlist")
+		}
+		return map[string]string{
+			"family":                               "public_endpoint",
+			runtimeProgressConfigHashKey:           "hash",
+			sourceconfig.AWSAssumeRoleAllowlistKey: "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role",
+		}, nil
+	})
+
+	resolved, err := service.resolveConfig(context.Background(), "aws", "writer", map[string]string{
+		sourceconfig.AWSAssumeRoleAllowlistKey: "caller-controlled",
+	})
+	if err != nil {
+		t.Fatalf("resolveConfig() error = %v", err)
+	}
+	if got := resolved[sourceconfig.AWSAssumeRoleAllowlistKey]; got != "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role" {
+		t.Fatalf("assume-role allowlist = %q, want trusted resolver value", got)
+	}
+	if got := resolved[sourceconfig.RuntimeTenantIDKey]; got != "writer" {
+		t.Fatalf("runtime tenant = %q, want writer", got)
+	}
+	if _, ok := resolved[runtimeProgressConfigHashKey]; ok {
+		t.Fatal("resolveConfig preserved progress hash")
 	}
 }
 

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -467,6 +467,21 @@ func TestProgressConfigHashIgnoresAccessKeyIDCredentials(t *testing.T) {
 	}
 }
 
+func TestProgressConfigHashIgnoresInternalRuntimeMetadata(t *testing.T) {
+	base := progressConfigHash(map[string]string{
+		"lookup_key": "inventory",
+	})
+	withInternal := progressConfigHash(map[string]string{
+		"lookup_key":                           "inventory",
+		sourceconfig.RuntimeTenantIDKey:        "writer",
+		sourceconfig.AWSAssumeRoleAllowlistKey: "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role",
+		runtimeProgressConfigHashKey:           "old-hash",
+	})
+	if base != withInternal {
+		t.Fatal("progressConfigHash changed when only internal runtime metadata changed")
+	}
+}
+
 func TestUserConfigStripsInternalAssumeRoleAllowlist(t *testing.T) {
 	config := userConfig(map[string]string{
 		"family":                               "public_endpoint",

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -235,6 +235,30 @@ func (s *tokenSource) Read(_ context.Context, config sourcecdk.Config, _ *cerebr
 	}}}, nil
 }
 
+type tenantCheckSource struct {
+	checkedTenant string
+}
+
+func (s *tenantCheckSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "tenant_check"}
+}
+
+func (s *tenantCheckSource) Check(_ context.Context, config sourcecdk.Config) error {
+	s.checkedTenant, _ = config.Lookup(sourceconfig.RuntimeTenantIDKey)
+	if s.checkedTenant != "writer" {
+		return sourcecdk.ErrInvalidConfig
+	}
+	return nil
+}
+
+func (s *tenantCheckSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *tenantCheckSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{}, nil
+}
+
 func TestPutAndGetRuntimeRedactsSensitiveConfig(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
@@ -628,6 +652,42 @@ func TestPutPreservesProgressWhenConfigIsUnchanged(t *testing.T) {
 	}
 	if resp.GetRuntime().GetNextCursor().GetOpaque() != "1" {
 		t.Fatalf("Put().Runtime.NextCursor = %#v, want cursor 1", resp.GetRuntime().GetNextCursor())
+	}
+}
+
+func TestPutMergesStoredTenantBeforeValidation(t *testing.T) {
+	source := &tenantCheckSource{}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-tenant-check": {
+				Id:       "writer-tenant-check",
+				SourceId: "tenant_check",
+				TenantId: "writer",
+				Config:   map[string]string{"lookup_key": "inventory"},
+			},
+		},
+	}
+	service := New(registry, store, nil, nil)
+
+	resp, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{
+		Runtime: &cerebrov1.SourceRuntime{
+			Id:       "writer-tenant-check",
+			SourceId: "tenant_check",
+			Config:   map[string]string{"lookup_key": "inventory"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if source.checkedTenant != "writer" {
+		t.Fatalf("source checked tenant = %q, want writer", source.checkedTenant)
+	}
+	if resp.GetRuntime().GetTenantId() != "writer" {
+		t.Fatalf("Put().Runtime.TenantId = %q, want writer", resp.GetRuntime().GetTenantId())
 	}
 }
 

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -496,10 +496,11 @@ func TestProgressConfigHashIgnoresInternalRuntimeMetadata(t *testing.T) {
 		"lookup_key": "inventory",
 	})
 	withInternal := progressConfigHash(map[string]string{
-		"lookup_key":                           "inventory",
-		sourceconfig.RuntimeTenantIDKey:        "writer",
-		sourceconfig.AWSAssumeRoleAllowlistKey: "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role",
-		runtimeProgressConfigHashKey:           "old-hash",
+		"lookup_key":                               "inventory",
+		sourceconfig.RuntimeTenantIDKey:            "writer",
+		sourceconfig.AWSAssumeRoleAllowlistKey:     "writer=arn:aws:iam::123456789012:role/cerebro-org-scan-role",
+		sourceconfig.LegacyTenantlessAssumeRoleKey: "true",
+		runtimeProgressConfigHashKey:               "old-hash",
 	})
 	if base != withInternal {
 		t.Fatal("progressConfigHash changed when only internal runtime metadata changed")
@@ -508,10 +509,11 @@ func TestProgressConfigHashIgnoresInternalRuntimeMetadata(t *testing.T) {
 
 func TestUserConfigStripsInternalAssumeRoleAllowlist(t *testing.T) {
 	config := userConfig(map[string]string{
-		"family":                               "public_endpoint",
-		runtimeProgressConfigHashKey:           "hash",
-		sourceconfig.AWSAssumeRoleAllowlistKey: "caller-controlled",
-		sourceconfig.RuntimeTenantIDKey:        "writer",
+		"family":                                   "public_endpoint",
+		runtimeProgressConfigHashKey:               "hash",
+		sourceconfig.AWSAssumeRoleAllowlistKey:     "caller-controlled",
+		sourceconfig.LegacyTenantlessAssumeRoleKey: "true",
+		sourceconfig.RuntimeTenantIDKey:            "writer",
 	})
 	if got := config["family"]; got != "public_endpoint" {
 		t.Fatalf("family = %q, want public_endpoint", got)
@@ -524,6 +526,9 @@ func TestUserConfigStripsInternalAssumeRoleAllowlist(t *testing.T) {
 	}
 	if _, ok := config[sourceconfig.RuntimeTenantIDKey]; ok {
 		t.Fatal("userConfig preserved internal runtime tenant key")
+	}
+	if _, ok := config[sourceconfig.LegacyTenantlessAssumeRoleKey]; ok {
+		t.Fatal("userConfig preserved internal legacy tenantless role key")
 	}
 }
 

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	githubsource "github.com/writer/cerebro/sources/github"
 	oktasource "github.com/writer/cerebro/sources/okta"
 )
@@ -463,6 +464,23 @@ func TestProgressConfigHashIgnoresAccessKeyIDCredentials(t *testing.T) {
 	}
 	if hashA != hashB {
 		t.Fatal("progress config hash changed when only access_key_id changed")
+	}
+}
+
+func TestUserConfigStripsInternalAssumeRoleAllowlist(t *testing.T) {
+	config := userConfig(map[string]string{
+		"family":                               "public_endpoint",
+		runtimeProgressConfigHashKey:           "hash",
+		sourceconfig.AWSAssumeRoleAllowlistKey: "caller-controlled",
+	})
+	if got := config["family"]; got != "public_endpoint" {
+		t.Fatalf("family = %q, want public_endpoint", got)
+	}
+	if _, ok := config[sourceconfig.AWSAssumeRoleAllowlistKey]; ok {
+		t.Fatal("userConfig preserved internal assume-role allowlist key")
+	}
+	if _, ok := config[runtimeProgressConfigHashKey]; ok {
+		t.Fatal("userConfig preserved progress config hash key")
 	}
 }
 

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -85,6 +85,7 @@ type settings struct {
 	roleARN         string
 	externalID      string
 	assumeRoleARNs  string
+	tenantID        string
 	includeGlobal   bool
 	groupName       string
 	principalType   string
@@ -510,6 +511,7 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		roleARN:         configValue(cfg, "role_arn"),
 		externalID:      configValue(cfg, "external_id"),
 		assumeRoleARNs:  configValue(cfg, sourceconfig.AWSAssumeRoleAllowlistKey),
+		tenantID:        configValue(cfg, sourceconfig.RuntimeTenantIDKey),
 		includeGlobal:   configBool(cfg, "include_global", true),
 		groupName:       configValue(cfg, "group_name"),
 		principalType:   configValue(cfg, "principal_type"),
@@ -588,17 +590,29 @@ func validateAssumeRoleConfig(settings settings) error {
 	if matches[2] != settings.accountID {
 		return fmt.Errorf("aws role_arn account must match account_id")
 	}
-	if !assumeRoleARNAllowed(settings.roleARN, settings.assumeRoleARNs) {
+	if settings.tenantID == "" {
+		return fmt.Errorf("aws role_arn requires runtime tenant_id")
+	}
+	if !assumeRoleARNAllowed(settings.tenantID, settings.roleARN, settings.assumeRoleARNs) {
 		return fmt.Errorf("aws role_arn is not allowed")
 	}
 	return nil
 }
 
-func assumeRoleARNAllowed(roleARN string, allowlist string) bool {
+func assumeRoleARNAllowed(tenantID string, roleARN string, allowlist string) bool {
+	tenantID = strings.TrimSpace(tenantID)
+	roleARN = strings.TrimSpace(roleARN)
+	if tenantID == "" || roleARN == "" {
+		return false
+	}
 	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
 		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
 	}) {
-		if strings.TrimSpace(value) == roleARN {
+		tenant, arn, ok := strings.Cut(strings.TrimSpace(value), "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(tenant) == tenantID && strings.TrimSpace(arn) == roleARN {
 			return true
 		}
 	}

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -39,29 +39,32 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 //go:embed catalog.yaml
 var catalogFS embed.FS
 
 var emailPattern = regexp.MustCompile(`(?i)[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}`)
+var awsRoleARNPattern = regexp.MustCompile(`^arn:(aws|aws-us-gov|aws-cn):iam::([0-9]{12}):role/[A-Za-z0-9+=,.@_/-]+$`)
 
 const (
-	defaultFamily          = familyCloudTrail
-	defaultRegion          = "us-east-1"
-	defaultPageSize        = 10
-	maxPageSize            = 200
-	publicEndpointCursorV2 = 2
-	familyAccessKey        = "access_key"
-	familyCloudTrail       = "cloudtrail"
-	familyIAMGroup         = "iam_group"
-	familyIAMMembership    = "iam_group_membership"
-	familyIAMRoleTrust     = "iam_role_trust"
-	familyIAMRoleAssign    = "iam_role_assignment"
-	familyIAMRole          = "iam_role"
-	familyIAMUser          = "iam_user"
-	familyPublicEndpoint   = "public_endpoint"
-	familyResourceExposure = "resource_exposure"
+	defaultFamily            = familyCloudTrail
+	defaultRegion            = "us-east-1"
+	defaultPageSize          = 10
+	maxPageSize              = 200
+	publicEndpointCursorV2   = 2
+	awsAssumeRoleSessionName = "cerebro-source-runtime"
+	familyAccessKey          = "access_key"
+	familyCloudTrail         = "cloudtrail"
+	familyIAMGroup           = "iam_group"
+	familyIAMMembership      = "iam_group_membership"
+	familyIAMRoleTrust       = "iam_role_trust"
+	familyIAMRoleAssign      = "iam_role_assignment"
+	familyIAMRole            = "iam_role"
+	familyIAMUser            = "iam_user"
+	familyPublicEndpoint     = "public_endpoint"
+	familyResourceExposure   = "resource_exposure"
 )
 
 // Source reads AWS IAM inventory and CloudTrail activity through the AWS SDK for Go v2.
@@ -81,7 +84,7 @@ type settings struct {
 	sessionToken    string
 	roleARN         string
 	externalID      string
-	roleSessionName string
+	assumeRoleARNs  string
 	includeGlobal   bool
 	groupName       string
 	principalType   string
@@ -476,11 +479,9 @@ func newAWSClients(ctx context.Context, settings settings) (awsClients, error) {
 	}
 	if settings.roleARN != "" {
 		provider := stscreds.NewAssumeRoleProvider(sts.NewFromConfig(cfg), settings.roleARN, func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = awsAssumeRoleSessionName
 			if settings.externalID != "" {
 				options.ExternalID = awssdk.String(settings.externalID)
-			}
-			if settings.roleSessionName != "" {
-				options.RoleSessionName = settings.roleSessionName
 			}
 		})
 		cfg.Credentials = awssdk.NewCredentialsCache(provider)
@@ -508,7 +509,7 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		sessionToken:    configValue(cfg, "session_token"),
 		roleARN:         configValue(cfg, "role_arn"),
 		externalID:      configValue(cfg, "external_id"),
-		roleSessionName: configValue(cfg, "role_session_name"),
+		assumeRoleARNs:  configValue(cfg, sourceconfig.AWSAssumeRoleAllowlistKey),
 		includeGlobal:   configBool(cfg, "include_global", true),
 		groupName:       configValue(cfg, "group_name"),
 		principalType:   configValue(cfg, "principal_type"),
@@ -526,8 +527,15 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if settings.accountID == "" {
 		return settings, fmt.Errorf("aws account_id is required")
 	}
-	if settings.roleARN != "" && (!strings.HasPrefix(settings.roleARN, "arn:") || !strings.Contains(settings.roleARN, ":role/")) {
-		return settings, fmt.Errorf("aws role_arn must be an IAM role ARN")
+	if roleSessionName := configValue(cfg, "role_session_name"); roleSessionName != "" {
+		return settings, fmt.Errorf("aws role_session_name is no longer supported")
+	}
+	if settings.roleARN != "" {
+		if err := validateAssumeRoleConfig(settings); err != nil {
+			return settings, err
+		}
+	} else if settings.externalID != "" {
+		return settings, fmt.Errorf("aws external_id requires role_arn")
 	}
 	if settings.region == "" {
 		settings.region = defaultRegion
@@ -570,6 +578,31 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 		return settings, fmt.Errorf("aws family must be one of access_key, cloudtrail, iam_group, iam_group_membership, iam_role, iam_role_assignment, iam_role_trust, iam_user, public_endpoint, or resource_exposure")
 	}
 	return settings, nil
+}
+
+func validateAssumeRoleConfig(settings settings) error {
+	matches := awsRoleARNPattern.FindStringSubmatch(settings.roleARN)
+	if len(matches) != 3 {
+		return fmt.Errorf("aws role_arn must be an IAM role ARN")
+	}
+	if matches[2] != settings.accountID {
+		return fmt.Errorf("aws role_arn account must match account_id")
+	}
+	if !assumeRoleARNAllowed(settings.roleARN, settings.assumeRoleARNs) {
+		return fmt.Errorf("aws role_arn is not allowed")
+	}
+	return nil
+}
+
+func assumeRoleARNAllowed(roleARN string, allowlist string) bool {
+	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
+	}) {
+		if strings.TrimSpace(value) == roleARN {
+			return true
+		}
+	}
+	return false
 }
 
 func listAccessKeys(ctx context.Context, clients awsClients, settings settings, cursor string, limit int) ([]iamtypes.AccessKeyMetadata, string, error) {

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -529,9 +529,6 @@ func parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if settings.accountID == "" {
 		return settings, fmt.Errorf("aws account_id is required")
 	}
-	if roleSessionName := configValue(cfg, "role_session_name"); roleSessionName != "" {
-		return settings, fmt.Errorf("aws role_session_name is no longer supported")
-	}
 	if settings.roleARN != "" {
 		if err := validateAssumeRoleConfig(settings); err != nil {
 			return settings, err

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -75,27 +75,28 @@ type Source struct {
 }
 
 type settings struct {
-	family          string
-	accountID       string
-	region          string
-	profile         string
-	accessKeyID     string
-	secretAccessKey string
-	sessionToken    string
-	roleARN         string
-	externalID      string
-	assumeRoleARNs  string
-	tenantID        string
-	includeGlobal   bool
-	groupName       string
-	principalType   string
-	principalName   string
-	userName        string
-	lookupKey       string
-	lookupValue     string
-	startTime       string
-	endTime         string
-	perPage         int
+	family                     string
+	accountID                  string
+	region                     string
+	profile                    string
+	accessKeyID                string
+	secretAccessKey            string
+	sessionToken               string
+	roleARN                    string
+	externalID                 string
+	assumeRoleARNs             string
+	tenantID                   string
+	legacyTenantlessAssumeRole bool
+	includeGlobal              bool
+	groupName                  string
+	principalType              string
+	principalName              string
+	userName                   string
+	lookupKey                  string
+	lookupValue                string
+	startTime                  string
+	endTime                    string
+	perPage                    int
 }
 
 type awsClientFactory func(context.Context, settings) (awsClients, error)
@@ -501,27 +502,28 @@ func newAWSClients(ctx context.Context, settings settings) (awsClients, error) {
 
 func parseSettings(cfg sourcecdk.Config) (settings, error) {
 	settings := settings{
-		family:          configValue(cfg, "family"),
-		accountID:       configValue(cfg, "account_id"),
-		region:          configValue(cfg, "region"),
-		profile:         configValue(cfg, "profile"),
-		accessKeyID:     configValue(cfg, "access_key_id"),
-		secretAccessKey: configValue(cfg, "secret_access_key"),
-		sessionToken:    configValue(cfg, "session_token"),
-		roleARN:         configValue(cfg, "role_arn"),
-		externalID:      configValue(cfg, "external_id"),
-		assumeRoleARNs:  configValue(cfg, sourceconfig.AWSAssumeRoleAllowlistKey),
-		tenantID:        configValue(cfg, sourceconfig.RuntimeTenantIDKey),
-		includeGlobal:   configBool(cfg, "include_global", true),
-		groupName:       configValue(cfg, "group_name"),
-		principalType:   configValue(cfg, "principal_type"),
-		principalName:   configValue(cfg, "principal_name"),
-		userName:        configValue(cfg, "user_name"),
-		lookupKey:       configValue(cfg, "lookup_key"),
-		lookupValue:     configValue(cfg, "lookup_value"),
-		startTime:       configValue(cfg, "start_time"),
-		endTime:         configValue(cfg, "end_time"),
-		perPage:         defaultPageSize,
+		family:                     configValue(cfg, "family"),
+		accountID:                  configValue(cfg, "account_id"),
+		region:                     configValue(cfg, "region"),
+		profile:                    configValue(cfg, "profile"),
+		accessKeyID:                configValue(cfg, "access_key_id"),
+		secretAccessKey:            configValue(cfg, "secret_access_key"),
+		sessionToken:               configValue(cfg, "session_token"),
+		roleARN:                    configValue(cfg, "role_arn"),
+		externalID:                 configValue(cfg, "external_id"),
+		assumeRoleARNs:             configValue(cfg, sourceconfig.AWSAssumeRoleAllowlistKey),
+		tenantID:                   configValue(cfg, sourceconfig.RuntimeTenantIDKey),
+		legacyTenantlessAssumeRole: configBool(cfg, sourceconfig.LegacyTenantlessAssumeRoleKey, false),
+		includeGlobal:              configBool(cfg, "include_global", true),
+		groupName:                  configValue(cfg, "group_name"),
+		principalType:              configValue(cfg, "principal_type"),
+		principalName:              configValue(cfg, "principal_name"),
+		userName:                   configValue(cfg, "user_name"),
+		lookupKey:                  configValue(cfg, "lookup_key"),
+		lookupValue:                configValue(cfg, "lookup_value"),
+		startTime:                  configValue(cfg, "start_time"),
+		endTime:                    configValue(cfg, "end_time"),
+		perPage:                    defaultPageSize,
 	}
 	if settings.family == "" {
 		settings.family = defaultFamily
@@ -587,6 +589,12 @@ func validateAssumeRoleConfig(settings settings) error {
 	if matches[2] != settings.accountID {
 		return fmt.Errorf("aws role_arn account must match account_id")
 	}
+	if settings.tenantID == "" {
+		if settings.legacyTenantlessAssumeRole && legacyTenantlessAssumeRoleARNAllowed(settings.roleARN, settings.assumeRoleARNs) {
+			return nil
+		}
+		return fmt.Errorf("aws role_arn requires runtime tenant_id")
+	}
 	if !assumeRoleARNAllowed(settings.tenantID, settings.roleARN, settings.assumeRoleARNs) {
 		return fmt.Errorf("aws role_arn is not allowed")
 	}
@@ -596,7 +604,7 @@ func validateAssumeRoleConfig(settings settings) error {
 func assumeRoleARNAllowed(tenantID string, roleARN string, allowlist string) bool {
 	tenantID = strings.TrimSpace(tenantID)
 	roleARN = strings.TrimSpace(roleARN)
-	if roleARN == "" {
+	if tenantID == "" || roleARN == "" {
 		return false
 	}
 	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
@@ -605,12 +613,24 @@ func assumeRoleARNAllowed(tenantID string, roleARN string, allowlist string) boo
 		value = strings.TrimSpace(value)
 		tenant, arn, ok := strings.Cut(value, "=")
 		if !ok {
-			if tenantID == "" && value == roleARN {
-				return true
-			}
 			continue
 		}
 		if strings.TrimSpace(tenant) == tenantID && strings.TrimSpace(arn) == roleARN {
+			return true
+		}
+	}
+	return false
+}
+
+func legacyTenantlessAssumeRoleARNAllowed(roleARN string, allowlist string) bool {
+	roleARN = strings.TrimSpace(roleARN)
+	if roleARN == "" {
+		return false
+	}
+	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
+	}) {
+		if strings.TrimSpace(value) == roleARN {
 			return true
 		}
 	}

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -587,9 +587,6 @@ func validateAssumeRoleConfig(settings settings) error {
 	if matches[2] != settings.accountID {
 		return fmt.Errorf("aws role_arn account must match account_id")
 	}
-	if settings.tenantID == "" {
-		return fmt.Errorf("aws role_arn requires runtime tenant_id")
-	}
 	if !assumeRoleARNAllowed(settings.tenantID, settings.roleARN, settings.assumeRoleARNs) {
 		return fmt.Errorf("aws role_arn is not allowed")
 	}
@@ -599,14 +596,18 @@ func validateAssumeRoleConfig(settings settings) error {
 func assumeRoleARNAllowed(tenantID string, roleARN string, allowlist string) bool {
 	tenantID = strings.TrimSpace(tenantID)
 	roleARN = strings.TrimSpace(roleARN)
-	if tenantID == "" || roleARN == "" {
+	if roleARN == "" {
 		return false
 	}
 	for _, value := range strings.FieldsFunc(allowlist, func(r rune) bool {
 		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
 	}) {
-		tenant, arn, ok := strings.Cut(strings.TrimSpace(value), "=")
+		value = strings.TrimSpace(value)
+		tenant, arn, ok := strings.Cut(value, "=")
 		if !ok {
+			if tenantID == "" && value == roleARN {
+				return true
+			}
 			continue
 		}
 		if strings.TrimSpace(tenant) == tenantID && strings.TrimSpace(arn) == roleARN {

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -51,22 +51,34 @@ func TestCheckRequiresAccountID(t *testing.T) {
 
 func TestParseSettingsValidatesAssumeRoleConfig(t *testing.T) {
 	roleARN := "arn:aws:iam::123456789012:role/cerebro-org-scan-role"
-	settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
-		"account_id":                           "123456789012",
-		"role_arn":                             roleARN,
-		"external_id":                          "external-1",
-		"role_session_name":                    "legacy-session",
-		sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + roleARN,
-		sourceconfig.RuntimeTenantIDKey:        "writer",
-	}))
-	if err != nil {
-		t.Fatalf("parseSettings() error = %v", err)
-	}
-	if settings.roleARN != roleARN {
-		t.Fatalf("roleARN = %q, want %q", settings.roleARN, roleARN)
-	}
-	if settings.externalID != "external-1" {
-		t.Fatalf("externalID = %q, want external-1", settings.externalID)
+	for _, tt := range []struct {
+		name      string
+		allowlist string
+		tenantID  string
+	}{
+		{name: "tenant scoped", allowlist: "writer=" + roleARN, tenantID: "writer"},
+		{name: "empty tenant scoped", allowlist: "=" + roleARN},
+		{name: "legacy tenantless", allowlist: roleARN},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+				"account_id":                           "123456789012",
+				"role_arn":                             roleARN,
+				"external_id":                          "external-1",
+				"role_session_name":                    "legacy-session",
+				sourceconfig.AWSAssumeRoleAllowlistKey: tt.allowlist,
+				sourceconfig.RuntimeTenantIDKey:        tt.tenantID,
+			}))
+			if err != nil {
+				t.Fatalf("parseSettings() error = %v", err)
+			}
+			if settings.roleARN != roleARN {
+				t.Fatalf("roleARN = %q, want %q", settings.roleARN, roleARN)
+			}
+			if settings.externalID != "external-1" {
+				t.Fatalf("externalID = %q, want external-1", settings.externalID)
+			}
+		})
 	}
 }
 

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -55,6 +55,7 @@ func TestParseSettingsValidatesAssumeRoleConfig(t *testing.T) {
 		"account_id":                           "123456789012",
 		"role_arn":                             roleARN,
 		"external_id":                          "external-1",
+		"role_session_name":                    "legacy-session",
 		sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + roleARN,
 		sourceconfig.RuntimeTenantIDKey:        "writer",
 	}))
@@ -102,10 +103,6 @@ func TestParseSettingsRejectsUnsafeAssumeRoleConfig(t *testing.T) {
 		{
 			name:   "external id without role",
 			config: map[string]string{"account_id": "123456789012", "external_id": "external-1"},
-		},
-		{
-			name:   "caller supplied session name",
-			config: map[string]string{"account_id": "123456789012", "role_arn": allowed, "role_session_name": "caller", sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + allowed, sourceconfig.RuntimeTenantIDKey: "writer"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -26,6 +26,7 @@ import (
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 func TestNewLoadsCatalog(t *testing.T) {
@@ -48,24 +49,57 @@ func TestCheckRequiresAccountID(t *testing.T) {
 	}
 }
 
-func TestParseSettingsAllowsAssumeRoleConfig(t *testing.T) {
+func TestParseSettingsValidatesAssumeRoleConfig(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/cerebro-org-scan-role"
 	settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
-		"account_id":        "123456789012",
-		"role_arn":          "arn:aws:iam::123456789012:role/cerebro-org-scan-role",
-		"external_id":       "external",
-		"role_session_name": "cerebro",
+		"account_id":                           "123456789012",
+		"role_arn":                             roleARN,
+		"external_id":                          "external-1",
+		sourceconfig.AWSAssumeRoleAllowlistKey: roleARN,
 	}))
 	if err != nil {
-		t.Fatalf("parseSettings() error = %v, want nil", err)
+		t.Fatalf("parseSettings() error = %v", err)
 	}
-	if settings.roleARN == "" || settings.externalID != "external" || settings.roleSessionName != "cerebro" {
-		t.Fatalf("assume-role settings = %#v", settings)
+	if settings.roleARN != roleARN {
+		t.Fatalf("roleARN = %q, want %q", settings.roleARN, roleARN)
+	}
+	if settings.externalID != "external-1" {
+		t.Fatalf("externalID = %q, want external-1", settings.externalID)
 	}
 }
 
-func TestParseSettingsRejectsInvalidAssumeRoleARN(t *testing.T) {
-	if _, err := parseSettings(sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "role_arn": "not-a-role"})); err == nil {
-		t.Fatal("parseSettings() error = nil, want invalid role_arn error")
+func TestParseSettingsRejectsUnsafeAssumeRoleConfig(t *testing.T) {
+	allowed := "arn:aws:iam::123456789012:role/cerebro-org-scan-role"
+	for _, tt := range []struct {
+		name   string
+		config map[string]string
+	}{
+		{
+			name:   "unallowlisted role",
+			config: map[string]string{"account_id": "123456789012", "role_arn": "arn:aws:iam::123456789012:role/OtherRole", sourceconfig.AWSAssumeRoleAllowlistKey: allowed},
+		},
+		{
+			name:   "account mismatch",
+			config: map[string]string{"account_id": "123456789012", "role_arn": "arn:aws:iam::210987654321:role/cerebro-org-scan-role", sourceconfig.AWSAssumeRoleAllowlistKey: allowed},
+		},
+		{
+			name:   "invalid role arn",
+			config: map[string]string{"account_id": "123456789012", "role_arn": "legacy", sourceconfig.AWSAssumeRoleAllowlistKey: allowed},
+		},
+		{
+			name:   "external id without role",
+			config: map[string]string{"account_id": "123456789012", "external_id": "external-1"},
+		},
+		{
+			name:   "caller supplied session name",
+			config: map[string]string{"account_id": "123456789012", "role_arn": allowed, "role_session_name": "caller", sourceconfig.AWSAssumeRoleAllowlistKey: allowed},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseSettings(sourcecdk.NewConfig(tt.config)); err == nil {
+				t.Fatal("parseSettings() error = nil, want non-nil")
+			}
+		})
 	}
 }
 

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -51,34 +51,34 @@ func TestCheckRequiresAccountID(t *testing.T) {
 
 func TestParseSettingsValidatesAssumeRoleConfig(t *testing.T) {
 	roleARN := "arn:aws:iam::123456789012:role/cerebro-org-scan-role"
-	for _, tt := range []struct {
-		name      string
-		allowlist string
-		tenantID  string
-	}{
-		{name: "tenant scoped", allowlist: "writer=" + roleARN, tenantID: "writer"},
-		{name: "empty tenant scoped", allowlist: "=" + roleARN},
-		{name: "legacy tenantless", allowlist: roleARN},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
-				"account_id":                           "123456789012",
-				"role_arn":                             roleARN,
-				"external_id":                          "external-1",
-				"role_session_name":                    "legacy-session",
-				sourceconfig.AWSAssumeRoleAllowlistKey: tt.allowlist,
-				sourceconfig.RuntimeTenantIDKey:        tt.tenantID,
-			}))
-			if err != nil {
-				t.Fatalf("parseSettings() error = %v", err)
-			}
-			if settings.roleARN != roleARN {
-				t.Fatalf("roleARN = %q, want %q", settings.roleARN, roleARN)
-			}
-			if settings.externalID != "external-1" {
-				t.Fatalf("externalID = %q, want external-1", settings.externalID)
-			}
-		})
+	settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"account_id":                           "123456789012",
+		"role_arn":                             roleARN,
+		"external_id":                          "external-1",
+		"role_session_name":                    "legacy-session",
+		sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + roleARN,
+		sourceconfig.RuntimeTenantIDKey:        "writer",
+	}))
+	if err != nil {
+		t.Fatalf("parseSettings() error = %v", err)
+	}
+	if settings.roleARN != roleARN {
+		t.Fatalf("roleARN = %q, want %q", settings.roleARN, roleARN)
+	}
+	if settings.externalID != "external-1" {
+		t.Fatalf("externalID = %q, want external-1", settings.externalID)
+	}
+}
+
+func TestParseSettingsAllowsLegacyTenantlessAssumeRoleOnlyWithInternalMarker(t *testing.T) {
+	roleARN := "arn:aws:iam::123456789012:role/cerebro-org-scan-role"
+	if _, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"account_id":                           "123456789012",
+		"role_arn":                             roleARN,
+		sourceconfig.AWSAssumeRoleAllowlistKey: roleARN,
+		sourceconfig.LegacyTenantlessAssumeRoleKey: "true",
+	})); err != nil {
+		t.Fatalf("parseSettings() error = %v", err)
 	}
 }
 
@@ -111,6 +111,10 @@ func TestParseSettingsRejectsUnsafeAssumeRoleConfig(t *testing.T) {
 		{
 			name:   "missing runtime tenant",
 			config: map[string]string{"account_id": "123456789012", "role_arn": allowed, sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + allowed},
+		},
+		{
+			name:   "empty tenant allowlist entry",
+			config: map[string]string{"account_id": "123456789012", "role_arn": allowed, sourceconfig.AWSAssumeRoleAllowlistKey: "=" + allowed},
 		},
 		{
 			name:   "external id without role",

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -55,7 +55,8 @@ func TestParseSettingsValidatesAssumeRoleConfig(t *testing.T) {
 		"account_id":                           "123456789012",
 		"role_arn":                             roleARN,
 		"external_id":                          "external-1",
-		sourceconfig.AWSAssumeRoleAllowlistKey: roleARN,
+		sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + roleARN,
+		sourceconfig.RuntimeTenantIDKey:        "writer",
 	}))
 	if err != nil {
 		t.Fatalf("parseSettings() error = %v", err)
@@ -76,15 +77,27 @@ func TestParseSettingsRejectsUnsafeAssumeRoleConfig(t *testing.T) {
 	}{
 		{
 			name:   "unallowlisted role",
-			config: map[string]string{"account_id": "123456789012", "role_arn": "arn:aws:iam::123456789012:role/OtherRole", sourceconfig.AWSAssumeRoleAllowlistKey: allowed},
+			config: map[string]string{"account_id": "123456789012", "role_arn": "arn:aws:iam::123456789012:role/OtherRole", sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + allowed, sourceconfig.RuntimeTenantIDKey: "writer"},
 		},
 		{
 			name:   "account mismatch",
-			config: map[string]string{"account_id": "123456789012", "role_arn": "arn:aws:iam::210987654321:role/cerebro-org-scan-role", sourceconfig.AWSAssumeRoleAllowlistKey: allowed},
+			config: map[string]string{"account_id": "123456789012", "role_arn": "arn:aws:iam::210987654321:role/cerebro-org-scan-role", sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + allowed, sourceconfig.RuntimeTenantIDKey: "writer"},
 		},
 		{
 			name:   "invalid role arn",
-			config: map[string]string{"account_id": "123456789012", "role_arn": "legacy", sourceconfig.AWSAssumeRoleAllowlistKey: allowed},
+			config: map[string]string{"account_id": "123456789012", "role_arn": "legacy", sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + allowed, sourceconfig.RuntimeTenantIDKey: "writer"},
+		},
+		{
+			name:   "tenant mismatch",
+			config: map[string]string{"account_id": "123456789012", "role_arn": allowed, sourceconfig.AWSAssumeRoleAllowlistKey: "other=" + allowed, sourceconfig.RuntimeTenantIDKey: "writer"},
+		},
+		{
+			name:   "bare allowlist entry",
+			config: map[string]string{"account_id": "123456789012", "role_arn": allowed, sourceconfig.AWSAssumeRoleAllowlistKey: allowed, sourceconfig.RuntimeTenantIDKey: "writer"},
+		},
+		{
+			name:   "missing runtime tenant",
+			config: map[string]string{"account_id": "123456789012", "role_arn": allowed, sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + allowed},
 		},
 		{
 			name:   "external id without role",
@@ -92,7 +105,7 @@ func TestParseSettingsRejectsUnsafeAssumeRoleConfig(t *testing.T) {
 		},
 		{
 			name:   "caller supplied session name",
-			config: map[string]string{"account_id": "123456789012", "role_arn": allowed, "role_session_name": "caller", sourceconfig.AWSAssumeRoleAllowlistKey: allowed},
+			config: map[string]string{"account_id": "123456789012", "role_arn": allowed, "role_session_name": "caller", sourceconfig.AWSAssumeRoleAllowlistKey: "writer=" + allowed, sourceconfig.RuntimeTenantIDKey: "writer"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- allow AWS role_arn only when the deployment-injected allowlist contains the exact ARN
- thread the trusted AWS role allowlist through runtime config resolution without exposing internal keys
- skip cloud/identity finding replay for runtimes whose configured family cannot emit those rule event kinds
- replay latest matching JetStream events within the requested limit

## Validation
- go test ./sources/aws ./internal/config ./internal/sourceconfig ./internal/appendlog/jetstream ./internal/findings ./internal/sourceruntime ./cmd/cerebro -count=1
- make verify