### PR TITLE
Add AWS endpoint exposure graph insights

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -688,6 +688,37 @@ paths:
       responses:
         '200':
           description: Asset vulnerability result.
+  /platform/graph/aws-public-endpoint-insights:
+    get:
+      summary: Query AWS public endpoint overlap insights
+      tags:
+        - Graph
+      parameters:
+        - name: tenant_id
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: account_id
+          in: query
+          schema:
+            type: string
+        - name: region
+          in: query
+          schema:
+            type: string
+        - name: search
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: AWS public endpoint overlap insights.
   /platform/graph/ingest-health:
     get:
       summary: Check graph ingest health

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -121,6 +121,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("GET /graph/impact/package", deprecatedRoute(app.handleGetPackageImpact))
 	mux.HandleFunc("GET /platform/graph/impact/asset", app.handleGetAssetImpact)
 	mux.HandleFunc("GET /graph/impact/asset", deprecatedRoute(app.handleGetAssetImpact))
+	mux.HandleFunc("GET /platform/graph/aws-public-endpoint-insights", app.handleGetAWSPublicEndpointInsights)
 	mux.HandleFunc("GET /platform/graph/ingest-health", app.handleCheckGraphIngestHealth)
 	mux.HandleFunc("GET /graph/ingest-health", deprecatedRoute(app.handleCheckGraphIngestHealth))
 	mux.HandleFunc("GET /platform/graph/ingest-runs", app.handleListGraphIngestRuns)
@@ -817,6 +818,31 @@ func (a *App) handleGetGraphImpact(w http.ResponseWriter, r *http.Request, reque
 	request.Limit = limit
 	request.Depth = depth
 	result, err := a.graphQueryService().GetImpact(r.Context(), request)
+	if err != nil {
+		writeGraphQueryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (a *App) handleGetAWSPublicEndpointInsights(w http.ResponseWriter, r *http.Request) {
+	tenantID := r.URL.Query().Get("tenant_id")
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		writeGraphQueryError(w, err)
+		return
+	}
+	limit, err := uint32QueryParam(r, "limit")
+	if err != nil {
+		writeGraphQueryError(w, err)
+		return
+	}
+	result, err := a.graphQueryService().GetAWSPublicEndpointInsights(r.Context(), graphquery.AWSPublicEndpointInsightsRequest{
+		TenantID:  tenantID,
+		AccountID: r.URL.Query().Get("account_id"),
+		Region:    r.URL.Query().Get("region"),
+		Search:    r.URL.Query().Get("search"),
+		Limit:     limit,
+	})
 	if err != nil {
 		writeGraphQueryError(w, err)
 		return

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -968,6 +968,8 @@ type stubGraphStore struct {
 	neighborhoodRootURN string
 	neighborhoodLimit   int
 	ingestRunListFilter graphstore.IngestRunFilter
+	cypherRows          [][]ports.CypherRow
+	cypherRequests      []ports.CypherQueryRequest
 }
 
 func (s *stubGraphStore) Ping(context.Context) error {
@@ -1023,9 +1025,15 @@ func (s *stubGraphStore) GetEntityNeighborhood(_ context.Context, rootURN string
 	return cloneNeighborhood(s.neighborhood), nil
 }
 
-func (s *stubGraphStore) ExecuteReadCypher(_ context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+func (s *stubGraphStore) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
 	if s.err != nil {
 		return nil, s.err
+	}
+	s.cypherRequests = append(s.cypherRequests, request)
+	if len(s.cypherRows) > 0 {
+		rows := s.cypherRows[0]
+		s.cypherRows = s.cypherRows[1:]
+		return rows, nil
 	}
 	return nil, nil
 }
@@ -2164,6 +2172,71 @@ func TestGraphImpactEndpointRejectsExplicitZeroBounds(t *testing.T) {
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Fatalf("GET /platform/graph/impact/package?%s status = %d, want %d", query, resp.StatusCode, http.StatusBadRequest)
 		}
+	}
+}
+
+func TestGraphAWSPublicEndpointInsightsEndpoint(t *testing.T) {
+	graph := &stubGraphStore{cypherRows: [][]ports.CypherRow{
+		{{Values: map[string]any{
+			"aws_endpoint_count":                   int64(2),
+			"internet_indicator_count":             int64(2),
+			"internet_host_count":                  int64(1),
+			"internet_ip_count":                    int64(1),
+			"overlapping_aws_endpoint_count":       int64(1),
+			"overlapping_internet_indicator_count": int64(1),
+			"overlapping_vulnview_asset_count":     int64(1),
+		}}},
+		nil,
+		{{Values: map[string]any{
+			"aws_urn":               "urn:cerebro:writer:aws_application_load_balancer:alb",
+			"aws_entity_type":       "aws.application.load.balancer",
+			"aws_label":             "alb",
+			"indicator_urn":         "urn:cerebro:writer:internet_host:app.example.com",
+			"indicator_entity_type": "internet.host",
+			"indicator_label":       "app.example.com",
+			"vulnview_urn":          "urn:cerebro:writer:external_asset:app.example.com",
+			"vulnview_entity_type":  "external.asset",
+			"vulnview_label":        "app.example.com",
+		}}},
+		nil,
+		nil,
+		nil,
+	}}
+	app := New(config.Config{}, Dependencies{GraphStore: graph}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/platform/graph/aws-public-endpoint-insights?tenant_id=writer&account_id=account-a&region=us-east-1&search=app&limit=5")
+	if err != nil {
+		t.Fatalf("GET /platform/graph/aws-public-endpoint-insights error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /platform/graph/aws-public-endpoint-insights status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var body struct {
+		TenantID string `json:"tenant_id"`
+		Counts   struct {
+			AWSEndpoints              int `json:"aws_endpoints"`
+			OverlappingVulnViewAssets int `json:"overlapping_vulnview_assets"`
+		} `json:"counts"`
+		Overlaps []struct {
+			InternetIndicator struct {
+				URN string `json:"urn"`
+			} `json:"internet_indicator"`
+		} `json:"overlaps"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.TenantID != "writer" || body.Counts.AWSEndpoints != 2 || body.Counts.OverlappingVulnViewAssets != 1 {
+		t.Fatalf("body = %#v", body)
+	}
+	if len(body.Overlaps) != 1 || body.Overlaps[0].InternetIndicator.URN != "urn:cerebro:writer:internet_host:app.example.com" {
+		t.Fatalf("overlaps = %#v", body.Overlaps)
+	}
+	if len(graph.cypherRequests) != 6 || graph.cypherRequests[0].Params["tenant_id"] != "writer" {
+		t.Fatalf("cypher requests = %#v", graph.cypherRequests)
 	}
 }
 

--- a/internal/graphquery/aws_exposure.go
+++ b/internal/graphquery/aws_exposure.go
@@ -1,0 +1,407 @@
+package graphquery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	defaultAWSExposureLimit = 25
+	maxAWSExposureLimit     = 100
+)
+
+type AWSPublicEndpointInsightsRequest struct {
+	TenantID  string
+	AccountID string
+	Region    string
+	Search    string
+	Limit     uint32
+}
+
+type AWSPublicEndpointInsightsResult struct {
+	TenantID        string                             `json:"tenant_id"`
+	Filters         AWSPublicEndpointInsightFilters    `json:"filters"`
+	Counts          AWSPublicEndpointInsightCounts     `json:"counts"`
+	TypeCounts      []AWSPublicEndpointTypeCount       `json:"type_counts"`
+	Overlaps        []AWSPublicEndpointOverlapSample   `json:"overlaps"`
+	AWSOnly         []AWSPublicEndpointIndicatorSample `json:"aws_only"`
+	VulnViewOnly    []VulnViewOnlyIndicatorSample      `json:"vulnview_only"`
+	CloudAccounts   []CloudAccountCoverageSample       `json:"cloud_accounts"`
+	NeighborhoodURN string                             `json:"neighborhood_hint,omitempty"`
+}
+
+type AWSPublicEndpointInsightFilters struct {
+	AccountID string `json:"account_id,omitempty"`
+	Region    string `json:"region,omitempty"`
+	Search    string `json:"search,omitempty"`
+	Limit     int    `json:"limit"`
+}
+
+type AWSPublicEndpointInsightCounts struct {
+	AWSEndpoints                  int `json:"aws_endpoints"`
+	InternetIndicators            int `json:"internet_indicators"`
+	InternetHosts                 int `json:"internet_hosts"`
+	InternetIPs                   int `json:"internet_ips"`
+	OverlappingAWSEndpoints       int `json:"overlapping_aws_endpoints"`
+	OverlappingInternetIndicators int `json:"overlapping_internet_indicators"`
+	OverlappingVulnViewAssets     int `json:"overlapping_vulnview_assets"`
+}
+
+type AWSPublicEndpointTypeCount struct {
+	EntityType string `json:"entity_type"`
+	Count      int    `json:"count"`
+}
+
+type GraphEntityRef struct {
+	URN        string `json:"urn"`
+	EntityType string `json:"entity_type"`
+	Label      string `json:"label"`
+}
+
+type AWSPublicEndpointOverlapSample struct {
+	AWSEndpoint       GraphEntityRef `json:"aws_endpoint"`
+	InternetIndicator GraphEntityRef `json:"internet_indicator"`
+	VulnViewAsset     GraphEntityRef `json:"vulnview_asset"`
+}
+
+type AWSPublicEndpointIndicatorSample struct {
+	AWSEndpoint       GraphEntityRef `json:"aws_endpoint"`
+	InternetIndicator GraphEntityRef `json:"internet_indicator"`
+}
+
+type VulnViewOnlyIndicatorSample struct {
+	VulnViewAsset     GraphEntityRef `json:"vulnview_asset"`
+	InternetIndicator GraphEntityRef `json:"internet_indicator"`
+}
+
+type CloudAccountCoverageSample struct {
+	Account       GraphEntityRef `json:"account"`
+	AWSEndpoints  int            `json:"aws_endpoints"`
+	VulnViewScans int            `json:"vulnview_scans"`
+}
+
+func (s *Service) GetAWSPublicEndpointInsights(ctx context.Context, request AWSPublicEndpointInsightsRequest) (*AWSPublicEndpointInsightsResult, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return nil, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
+	}
+	limit := normalizeAWSExposureLimit(request.Limit)
+	params := awsExposureParams(tenantID, request)
+	result := &AWSPublicEndpointInsightsResult{
+		TenantID: tenantID,
+		Filters: AWSPublicEndpointInsightFilters{
+			AccountID: strings.TrimSpace(request.AccountID),
+			Region:    strings.TrimSpace(request.Region),
+			Search:    strings.TrimSpace(request.Search),
+			Limit:     limit,
+		},
+	}
+
+	countRows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: awsExposureCountsQuery, Params: params, RowLimit: 1})
+	if err != nil {
+		return nil, err
+	}
+	if len(countRows) > 0 {
+		result.Counts = awsExposureCountsFromRow(countRows[0])
+	}
+
+	typeRows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: awsExposureTypeCountsQuery, Params: params, RowLimit: 50})
+	if err != nil {
+		return nil, err
+	}
+	result.TypeCounts = awsExposureTypeCountsFromRows(typeRows)
+
+	overlapRows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: awsExposureOverlapSamplesQuery, Params: params, RowLimit: limit})
+	if err != nil {
+		return nil, err
+	}
+	result.Overlaps = awsExposureOverlapSamplesFromRows(overlapRows)
+
+	awsOnlyRows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: awsExposureAWSOnlySamplesQuery, Params: params, RowLimit: limit})
+	if err != nil {
+		return nil, err
+	}
+	result.AWSOnly = awsExposureAWSOnlySamplesFromRows(awsOnlyRows)
+
+	vulnViewOnlyRows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: awsExposureVulnViewOnlySamplesQuery, Params: params, RowLimit: limit})
+	if err != nil {
+		return nil, err
+	}
+	result.VulnViewOnly = awsExposureVulnViewOnlySamplesFromRows(vulnViewOnlyRows)
+
+	cloudAccountRows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: awsExposureCloudAccountSamplesQuery, Params: params, RowLimit: limit})
+	if err != nil {
+		return nil, err
+	}
+	result.CloudAccounts = awsExposureCloudAccountsFromRows(cloudAccountRows)
+
+	if len(result.Overlaps) > 0 {
+		result.NeighborhoodURN = result.Overlaps[0].InternetIndicator.URN
+	} else if len(result.AWSOnly) > 0 {
+		result.NeighborhoodURN = result.AWSOnly[0].InternetIndicator.URN
+	} else if len(result.VulnViewOnly) > 0 {
+		result.NeighborhoodURN = result.VulnViewOnly[0].InternetIndicator.URN
+	}
+	return result, nil
+}
+
+func normalizeAWSExposureLimit(limit uint32) int {
+	switch {
+	case limit == 0:
+		return defaultAWSExposureLimit
+	case limit > maxAWSExposureLimit:
+		return maxAWSExposureLimit
+	default:
+		return int(limit)
+	}
+}
+
+func awsExposureParams(tenantID string, request AWSPublicEndpointInsightsRequest) map[string]any {
+	limit := normalizeAWSExposureLimit(request.Limit)
+	return map[string]any{
+		"account_id":   strings.TrimSpace(request.AccountID),
+		"region":       strings.TrimSpace(request.Region),
+		"sample_limit": int64(limit),
+		"search":       strings.ToLower(strings.TrimSpace(request.Search)),
+		"tenant_id":    tenantID,
+	}
+}
+
+const awsExposureEndpointFilter = `endpoint.entity_type STARTS WITH 'aws.'
+  AND indicator.entity_type IN ['internet.host', 'internet.ip']
+  AND ($account_id = '' OR coalesce(endpoint.attributes_json, '') CONTAINS ('"domain":"' + $account_id + '"'))
+  AND ($region = '' OR endpoint.urn CONTAINS (':' + $region + ':') OR coalesce(endpoint.attributes_json, '') CONTAINS ('"' + $region + '"'))
+  AND ($search = '' OR toLower(coalesce(endpoint.urn, '') + ' ' + coalesce(endpoint.label, '') + ' ' + coalesce(indicator.urn, '') + ' ' + coalesce(indicator.label, '')) CONTAINS $search)`
+
+const awsExposureEndpointAccountFilter = `endpoint.entity_type STARTS WITH 'aws.'
+  AND ($account_id = '' OR account.label = $account_id OR account.urn CONTAINS $account_id OR coalesce(endpoint.attributes_json, '') CONTAINS ('"domain":"' + $account_id + '"'))
+  AND ($region = '' OR endpoint.urn CONTAINS (':' + $region + ':') OR coalesce(endpoint.attributes_json, '') CONTAINS ('"' + $region + '"'))
+  AND ($search = '' OR toLower(coalesce(endpoint.urn, '') + ' ' + coalesce(endpoint.label, '') + ' ' + coalesce(account.urn, '') + ' ' + coalesce(account.label, '')) CONTAINS $search)`
+
+const awsExposureCountsQuery = `MATCH (endpoint:Entity {tenant_id: $tenant_id, source_id: 'aws'})-[aws_rel:RELATION {relation: 'represents'}]->(indicator:Entity {tenant_id: $tenant_id})
+WHERE ` + awsExposureEndpointFilter + `
+OPTIONAL MATCH (asset:Entity {tenant_id: $tenant_id, source_id: 'vulnview', entity_type: 'external.asset'})-[:RELATION {relation: 'represents'}]->(indicator)
+RETURN count(DISTINCT endpoint) AS aws_endpoint_count,
+       count(DISTINCT indicator) AS internet_indicator_count,
+       count(DISTINCT CASE WHEN indicator.entity_type = 'internet.host' THEN indicator END) AS internet_host_count,
+       count(DISTINCT CASE WHEN indicator.entity_type = 'internet.ip' THEN indicator END) AS internet_ip_count,
+       count(DISTINCT CASE WHEN asset IS NOT NULL THEN endpoint END) AS overlapping_aws_endpoint_count,
+       count(DISTINCT CASE WHEN asset IS NOT NULL THEN indicator END) AS overlapping_internet_indicator_count,
+       count(DISTINCT asset) AS overlapping_vulnview_asset_count`
+
+const awsExposureTypeCountsQuery = `MATCH (endpoint:Entity {tenant_id: $tenant_id, source_id: 'aws'})-[:RELATION {relation: 'represents'}]->(indicator:Entity {tenant_id: $tenant_id})
+WHERE ` + awsExposureEndpointFilter + `
+RETURN endpoint.entity_type AS entity_type, count(DISTINCT endpoint) AS count
+ORDER BY count DESC, entity_type`
+
+const awsExposureOverlapSamplesQuery = `MATCH (endpoint:Entity {tenant_id: $tenant_id, source_id: 'aws'})-[:RELATION {relation: 'represents'}]->(indicator:Entity {tenant_id: $tenant_id})
+WHERE ` + awsExposureEndpointFilter + `
+MATCH (asset:Entity {tenant_id: $tenant_id, source_id: 'vulnview', entity_type: 'external.asset'})-[:RELATION {relation: 'represents'}]->(indicator)
+RETURN endpoint.urn AS aws_urn,
+       endpoint.entity_type AS aws_entity_type,
+       endpoint.label AS aws_label,
+       indicator.urn AS indicator_urn,
+       indicator.entity_type AS indicator_entity_type,
+       indicator.label AS indicator_label,
+       asset.urn AS vulnview_urn,
+       asset.entity_type AS vulnview_entity_type,
+       asset.label AS vulnview_label
+ORDER BY indicator.label, endpoint.label, asset.label
+LIMIT $sample_limit`
+
+const awsExposureAWSOnlySamplesQuery = `MATCH (endpoint:Entity {tenant_id: $tenant_id, source_id: 'aws'})-[:RELATION {relation: 'represents'}]->(indicator:Entity {tenant_id: $tenant_id})
+WHERE ` + awsExposureEndpointFilter + `
+  AND NOT EXISTS {
+    MATCH (:Entity {tenant_id: $tenant_id, source_id: 'vulnview', entity_type: 'external.asset'})-[:RELATION {relation: 'represents'}]->(indicator)
+  }
+RETURN endpoint.urn AS aws_urn,
+       endpoint.entity_type AS aws_entity_type,
+       endpoint.label AS aws_label,
+       indicator.urn AS indicator_urn,
+       indicator.entity_type AS indicator_entity_type,
+       indicator.label AS indicator_label
+ORDER BY indicator.label, endpoint.label
+LIMIT $sample_limit`
+
+const awsExposureVulnViewOnlySamplesQuery = `MATCH (asset:Entity {tenant_id: $tenant_id, source_id: 'vulnview', entity_type: 'external.asset'})-[:RELATION {relation: 'represents'}]->(indicator:Entity {tenant_id: $tenant_id})
+WHERE indicator.entity_type IN ['internet.host', 'internet.ip']
+  AND $account_id = ''
+  AND $region = ''
+  AND ($search = '' OR toLower(coalesce(asset.urn, '') + ' ' + coalesce(asset.label, '') + ' ' + coalesce(indicator.urn, '') + ' ' + coalesce(indicator.label, '')) CONTAINS $search)
+  AND NOT EXISTS {
+    MATCH (endpoint:Entity {tenant_id: $tenant_id, source_id: 'aws'})-[:RELATION {relation: 'represents'}]->(indicator)
+    WHERE endpoint.entity_type STARTS WITH 'aws.'
+  }
+RETURN asset.urn AS vulnview_urn,
+       asset.entity_type AS vulnview_entity_type,
+       asset.label AS vulnview_label,
+       indicator.urn AS indicator_urn,
+       indicator.entity_type AS indicator_entity_type,
+       indicator.label AS indicator_label
+ORDER BY indicator.label, asset.label
+LIMIT $sample_limit`
+
+const awsExposureCloudAccountSamplesQuery = `MATCH (endpoint:Entity {tenant_id: $tenant_id, source_id: 'aws'})-[:RELATION {relation: 'belongs_to'}]->(account:Entity {tenant_id: $tenant_id, entity_type: 'cloud.account'})
+WHERE ` + awsExposureEndpointAccountFilter + `
+OPTIONAL MATCH (scan:Entity {tenant_id: $tenant_id, source_id: 'vulnview', entity_type: 'vulnview.scan'})-[:RELATION {relation: 'belongs_to'}]->(account)
+RETURN account.urn AS account_urn,
+       account.entity_type AS account_entity_type,
+       account.label AS account_label,
+       count(DISTINCT endpoint) AS aws_endpoint_count,
+       count(DISTINCT scan) AS vulnview_scan_count
+ORDER BY aws_endpoint_count DESC, account.label
+LIMIT $sample_limit`
+
+func awsExposureCountsFromRow(row ports.CypherRow) AWSPublicEndpointInsightCounts {
+	return AWSPublicEndpointInsightCounts{
+		AWSEndpoints:                  cypherInt(row, "aws_endpoint_count"),
+		InternetIndicators:            cypherInt(row, "internet_indicator_count"),
+		InternetHosts:                 cypherInt(row, "internet_host_count"),
+		InternetIPs:                   cypherInt(row, "internet_ip_count"),
+		OverlappingAWSEndpoints:       cypherInt(row, "overlapping_aws_endpoint_count"),
+		OverlappingInternetIndicators: cypherInt(row, "overlapping_internet_indicator_count"),
+		OverlappingVulnViewAssets:     cypherInt(row, "overlapping_vulnview_asset_count"),
+	}
+}
+
+func awsExposureTypeCountsFromRows(rows []ports.CypherRow) []AWSPublicEndpointTypeCount {
+	result := make([]AWSPublicEndpointTypeCount, 0, len(rows))
+	for _, row := range rows {
+		entityType := cypherString(row, "entity_type")
+		if entityType == "" {
+			continue
+		}
+		result = append(result, AWSPublicEndpointTypeCount{EntityType: entityType, Count: cypherInt(row, "count")})
+	}
+	return result
+}
+
+func awsExposureOverlapSamplesFromRows(rows []ports.CypherRow) []AWSPublicEndpointOverlapSample {
+	result := make([]AWSPublicEndpointOverlapSample, 0, len(rows))
+	for _, row := range rows {
+		sample := AWSPublicEndpointOverlapSample{
+			AWSEndpoint:       awsEndpointRef(row),
+			InternetIndicator: indicatorRef(row),
+			VulnViewAsset:     vulnViewAssetRef(row),
+		}
+		if sample.AWSEndpoint.URN == "" || sample.InternetIndicator.URN == "" || sample.VulnViewAsset.URN == "" {
+			continue
+		}
+		result = append(result, sample)
+	}
+	return result
+}
+
+func awsExposureAWSOnlySamplesFromRows(rows []ports.CypherRow) []AWSPublicEndpointIndicatorSample {
+	result := make([]AWSPublicEndpointIndicatorSample, 0, len(rows))
+	for _, row := range rows {
+		sample := AWSPublicEndpointIndicatorSample{AWSEndpoint: awsEndpointRef(row), InternetIndicator: indicatorRef(row)}
+		if sample.AWSEndpoint.URN == "" || sample.InternetIndicator.URN == "" {
+			continue
+		}
+		result = append(result, sample)
+	}
+	return result
+}
+
+func awsExposureVulnViewOnlySamplesFromRows(rows []ports.CypherRow) []VulnViewOnlyIndicatorSample {
+	result := make([]VulnViewOnlyIndicatorSample, 0, len(rows))
+	for _, row := range rows {
+		sample := VulnViewOnlyIndicatorSample{VulnViewAsset: vulnViewAssetRef(row), InternetIndicator: indicatorRef(row)}
+		if sample.VulnViewAsset.URN == "" || sample.InternetIndicator.URN == "" {
+			continue
+		}
+		result = append(result, sample)
+	}
+	return result
+}
+
+func awsExposureCloudAccountsFromRows(rows []ports.CypherRow) []CloudAccountCoverageSample {
+	result := make([]CloudAccountCoverageSample, 0, len(rows))
+	for _, row := range rows {
+		account := GraphEntityRef{
+			URN:        cypherString(row, "account_urn"),
+			EntityType: cypherString(row, "account_entity_type"),
+			Label:      cypherString(row, "account_label"),
+		}
+		if account.URN == "" {
+			continue
+		}
+		result = append(result, CloudAccountCoverageSample{
+			Account:       account,
+			AWSEndpoints:  cypherInt(row, "aws_endpoint_count"),
+			VulnViewScans: cypherInt(row, "vulnview_scan_count"),
+		})
+	}
+	return result
+}
+
+func awsEndpointRef(row ports.CypherRow) GraphEntityRef {
+	return GraphEntityRef{URN: cypherString(row, "aws_urn"), EntityType: cypherString(row, "aws_entity_type"), Label: cypherString(row, "aws_label")}
+}
+
+func indicatorRef(row ports.CypherRow) GraphEntityRef {
+	return GraphEntityRef{URN: cypherString(row, "indicator_urn"), EntityType: cypherString(row, "indicator_entity_type"), Label: cypherString(row, "indicator_label")}
+}
+
+func vulnViewAssetRef(row ports.CypherRow) GraphEntityRef {
+	return GraphEntityRef{URN: cypherString(row, "vulnview_urn"), EntityType: cypherString(row, "vulnview_entity_type"), Label: cypherString(row, "vulnview_label")}
+}
+
+func cypherString(row ports.CypherRow, key string) string {
+	if row.Values == nil {
+		return ""
+	}
+	value, ok := row.Values[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func cypherInt(row ports.CypherRow, key string) int {
+	if row.Values == nil {
+		return 0
+	}
+	switch value := row.Values[key].(type) {
+	case int:
+		return value
+	case int8:
+		return int(value)
+	case int16:
+		return int(value)
+	case int32:
+		return int(value)
+	case int64:
+		return int(value)
+	case uint:
+		return int(value)
+	case uint8:
+		return int(value)
+	case uint16:
+		return int(value)
+	case uint32:
+		return int(value)
+	case uint64:
+		return int(value)
+	case float32:
+		return int(value)
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}

--- a/internal/graphquery/aws_exposure_test.go
+++ b/internal/graphquery/aws_exposure_test.go
@@ -1,0 +1,142 @@
+package graphquery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type awsExposureStubStore struct {
+	requests  []ports.CypherQueryRequest
+	responses [][]ports.CypherRow
+	err       error
+}
+
+func (s *awsExposureStubStore) Ping(context.Context) error {
+	return s.err
+}
+
+func (s *awsExposureStubStore) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
+	return nil, nil
+}
+
+func (s *awsExposureStubStore) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	s.requests = append(s.requests, request)
+	if s.err != nil {
+		return nil, s.err
+	}
+	if len(s.responses) == 0 {
+		return nil, nil
+	}
+	rows := s.responses[0]
+	s.responses = s.responses[1:]
+	return rows, nil
+}
+
+func TestGetAWSPublicEndpointInsightsRequiresTenant(t *testing.T) {
+	_, err := New(&awsExposureStubStore{}).GetAWSPublicEndpointInsights(context.Background(), AWSPublicEndpointInsightsRequest{})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("GetAWSPublicEndpointInsights() error = %v, want %v", err, ErrInvalidRequest)
+	}
+}
+
+func TestGetAWSPublicEndpointInsightsQueriesAndParsesRows(t *testing.T) {
+	store := &awsExposureStubStore{responses: [][]ports.CypherRow{
+		{{Values: map[string]any{
+			"aws_endpoint_count":                   int64(7),
+			"internet_indicator_count":             int64(8),
+			"internet_host_count":                  int64(6),
+			"internet_ip_count":                    int64(2),
+			"overlapping_aws_endpoint_count":       int64(3),
+			"overlapping_internet_indicator_count": int64(4),
+			"overlapping_vulnview_asset_count":     int64(5),
+		}}},
+		{{Values: map[string]any{"entity_type": "aws.application.load.balancer", "count": int64(4)}}},
+		{{Values: map[string]any{
+			"aws_urn":               "urn:cerebro:writer:aws_application_load_balancer:alb",
+			"aws_entity_type":       "aws.application.load.balancer",
+			"aws_label":             "alb",
+			"indicator_urn":         "urn:cerebro:writer:internet_host:app.example.com",
+			"indicator_entity_type": "internet.host",
+			"indicator_label":       "app.example.com",
+			"vulnview_urn":          "urn:cerebro:writer:external_asset:app.example.com",
+			"vulnview_entity_type":  "external.asset",
+			"vulnview_label":        "app.example.com",
+		}}},
+		{{Values: map[string]any{
+			"aws_urn":               "urn:cerebro:writer:aws_elastic_ip:eipalloc-1",
+			"aws_entity_type":       "aws.elastic.ip",
+			"aws_label":             "eipalloc-1",
+			"indicator_urn":         "urn:cerebro:writer:internet_ip:192.0.2.10",
+			"indicator_entity_type": "internet.ip",
+			"indicator_label":       "192.0.2.10",
+		}}},
+		{{Values: map[string]any{
+			"vulnview_urn":          "urn:cerebro:writer:external_asset:missing.example.com",
+			"vulnview_entity_type":  "external.asset",
+			"vulnview_label":        "missing.example.com",
+			"indicator_urn":         "urn:cerebro:writer:internet_host:missing.example.com",
+			"indicator_entity_type": "internet.host",
+			"indicator_label":       "missing.example.com",
+		}}},
+		{{Values: map[string]any{
+			"account_urn":         "urn:cerebro:writer:cloud_account:account-a",
+			"account_entity_type": "cloud.account",
+			"account_label":       "account-a",
+			"aws_endpoint_count":  int64(9),
+			"vulnview_scan_count": int64(2),
+		}}},
+	}}
+
+	result, err := New(store).GetAWSPublicEndpointInsights(context.Background(), AWSPublicEndpointInsightsRequest{
+		TenantID:  "writer",
+		AccountID: "account-a",
+		Region:    "us-east-1",
+		Search:    "App",
+		Limit:     250,
+	})
+	if err != nil {
+		t.Fatalf("GetAWSPublicEndpointInsights() error = %v", err)
+	}
+	if len(store.requests) != 6 {
+		t.Fatalf("query count = %d, want 6", len(store.requests))
+	}
+	if got := store.requests[0].Params["tenant_id"]; got != "writer" {
+		t.Fatalf("tenant_id param = %v, want writer", got)
+	}
+	if got := store.requests[0].Params["account_id"]; got != "account-a" {
+		t.Fatalf("account_id param = %v, want account-a", got)
+	}
+	if got := store.requests[0].Params["region"]; got != "us-east-1" {
+		t.Fatalf("region param = %v, want us-east-1", got)
+	}
+	if got := store.requests[0].Params["search"]; got != "app" {
+		t.Fatalf("search param = %v, want app", got)
+	}
+	if got := store.requests[2].RowLimit; got != maxAWSExposureLimit {
+		t.Fatalf("sample row limit = %d, want %d", got, maxAWSExposureLimit)
+	}
+	if result.Counts.AWSEndpoints != 7 || result.Counts.OverlappingVulnViewAssets != 5 {
+		t.Fatalf("counts = %#v", result.Counts)
+	}
+	if len(result.TypeCounts) != 1 || result.TypeCounts[0].EntityType != "aws.application.load.balancer" {
+		t.Fatalf("type counts = %#v", result.TypeCounts)
+	}
+	if len(result.Overlaps) != 1 || result.Overlaps[0].InternetIndicator.Label != "app.example.com" {
+		t.Fatalf("overlaps = %#v", result.Overlaps)
+	}
+	if len(result.AWSOnly) != 1 || result.AWSOnly[0].InternetIndicator.EntityType != "internet.ip" {
+		t.Fatalf("aws_only = %#v", result.AWSOnly)
+	}
+	if len(result.VulnViewOnly) != 1 || result.VulnViewOnly[0].VulnViewAsset.Label != "missing.example.com" {
+		t.Fatalf("vulnview_only = %#v", result.VulnViewOnly)
+	}
+	if len(result.CloudAccounts) != 1 || result.CloudAccounts[0].VulnViewScans != 2 {
+		t.Fatalf("cloud_accounts = %#v", result.CloudAccounts)
+	}
+	if result.NeighborhoodURN != "urn:cerebro:writer:internet_host:app.example.com" {
+		t.Fatalf("neighborhood hint = %q", result.NeighborhoodURN)
+	}
+}


### PR DESCRIPTION
## Summary\n- Add a graph query service and HTTP endpoint for AWS public endpoint exposure insights.\n- Return counts, AWS/VulnView overlaps, AWS-only indicators, VulnView-only assets, and cloud-account coverage samples.\n- Publish the endpoint in OpenAPI with focused service and bootstrap tests.\n\n## Validation\n- go test ./internal/graphquery ./internal/bootstrap -run 'TestGetAWSPublicEndpointInsights|TestGraphAWSPublicEndpointInsightsEndpoint' -count=1\n- go test ./internal/graphquery ./internal/bootstrap -count=1\n- make openapi-check\n- make verify