### PR TITLE
feat(grc): project vulnerable assets into graph

### DIFF
--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -159,6 +159,15 @@ func stringAt(values []string, index int) string {
 	return values[index]
 }
 
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
 func maxInt(values ...int) int {
 	max := 0
 	for _, value := range values {
@@ -382,18 +391,21 @@ func grcVulnerableAssetReferenceAttrs(attrs map[string]string) []map[string]stri
 	if err := json.Unmarshal([]byte(rawReferences), &references); err != nil {
 		return grcVulnerableAssetFlatReferenceAttrs(attrs)
 	}
+	vulnerabilityIDs := grcAttributeSequence(attrs["vulnerability_ids"])
+	vulnerabilityNames := grcAttributeSequence(attrs["vulnerability_names"])
+	packageIdentifiers := grcAttributeSequence(attrs["package_identifiers"])
 	result := make([]map[string]string, 0, len(references))
-	for _, reference := range references {
+	for i, reference := range references {
 		referenceAttrs := grcVulnerableAssetCleanReferenceAttrs(attrs)
-		if strings.TrimSpace(reference.VulnerabilityID) != "" {
-			referenceAttrs["vulnerability_id"] = reference.VulnerabilityID
+		if vulnerabilityID := firstNonEmptyString(reference.VulnerabilityID, stringAt(vulnerabilityIDs, i)); vulnerabilityID != "" {
+			referenceAttrs["vulnerability_id"] = vulnerabilityID
 		}
-		if strings.TrimSpace(reference.VulnerabilityName) != "" {
-			referenceAttrs["name"] = reference.VulnerabilityName
+		if vulnerabilityName := firstNonEmptyString(reference.VulnerabilityName, stringAt(vulnerabilityNames, i)); vulnerabilityName != "" {
+			referenceAttrs["name"] = vulnerabilityName
 		}
-		if strings.TrimSpace(reference.PackageIdentifier) != "" {
-			referenceAttrs["package"] = reference.PackageIdentifier
-			referenceAttrs["package_purl"] = reference.PackageIdentifier
+		if packageIdentifier := firstNonEmptyString(reference.PackageIdentifier, stringAt(packageIdentifiers, i)); packageIdentifier != "" {
+			referenceAttrs["package"] = packageIdentifier
+			referenceAttrs["package_purl"] = packageIdentifier
 		}
 		result = append(result, referenceAttrs)
 	}

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -547,7 +547,7 @@ func grcTargetEntity(tenantID string, sourceID string, urn string, targetID stri
 }
 
 func grcTargetHost(attrs map[string]string) string {
-	if host := internetHost(firstAttribute(attrs, "hostname", "host", "target_url", "resource_url", "url", "website_url")); host != "" {
+	if host := internetHost(firstAttribute(attrs, "hostname", "host", "target_url", "resource_url", "external_url", "url", "website_url")); host != "" {
 		return host
 	}
 	return internetHostIfLikely(firstAttribute(attrs, "target_id", "resource_id", "asset_id", "endpoint_id"))

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -1,6 +1,7 @@
 package sourceprojection
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -287,36 +288,89 @@ func grcVulnerableAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, integrationURN, relationBelongsTo, grcIntegrationLinkAttributes(event, integrationID)))
 	}
 
-	vulnerabilityAttrsList := grcVulnerableAssetVulnerabilityAttrs(attrs)
-	if len(vulnerabilityAttrsList) == 0 {
-		vulnerabilityAttrsList = []map[string]string{attrs}
+	referenceAttrsList := grcVulnerableAssetReferenceAttrs(attrs)
+	if len(referenceAttrsList) > 0 {
+		for _, referenceAttrs := range referenceAttrsList {
+			vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), referenceAttrs)
+			if vulnerabilityURN != "" {
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, referenceAttrs)))
+			}
+			for _, packageAttrs := range grcVulnerableAssetPackageAttrs(referenceAttrs) {
+				packageURN := vulnerabilityPackageURN(tenantID, packageAttrs, "grc")
+				canonicalPackageURN := addCanonicalPackageEntity(entities, tenantID, event.GetSourceId(), packageAttrs, "grc")
+				if packageURN != "" {
+					addVulnerablePackageEntity(entities, tenantID, event.GetSourceId(), packageURN, packageAttrs, "grc")
+					addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, packageURN, relationContains, grcPackageTargetAttributes(event, packageAttrs)))
+					if vulnerabilityURN != "" {
+						addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, packageAttrs)))
+					}
+				}
+				if packageURN != "" && canonicalPackageURN != "" {
+					addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, canonicalPackageURN, relationRepresents, packageIdentityAttributes(event, packageAttrs, "grc")))
+				}
+				if canonicalPackageURN != "" && vulnerabilityURN != "" {
+					addLink(links, projectedLink(tenantID, event.GetSourceId(), canonicalPackageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, packageAttrs)))
+				}
+			}
+		}
+		projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+		return projectedEntities, projectedLinks, nil
 	}
-	for _, vulnerabilityAttrs := range vulnerabilityAttrsList {
+
+	for _, vulnerabilityAttrs := range grcVulnerableAssetVulnerabilityAttrs(attrs) {
 		vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), vulnerabilityAttrs)
 		if vulnerabilityURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, vulnerabilityAttrs)))
 		}
-		for _, packageAttrs := range grcVulnerableAssetPackageAttrs(vulnerabilityAttrs) {
-			packageURN := vulnerabilityPackageURN(tenantID, packageAttrs, "grc")
-			canonicalPackageURN := addCanonicalPackageEntity(entities, tenantID, event.GetSourceId(), packageAttrs, "grc")
-			if packageURN != "" {
-				addVulnerablePackageEntity(entities, tenantID, event.GetSourceId(), packageURN, packageAttrs, "grc")
-				addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, packageURN, relationContains, grcPackageTargetAttributes(event, packageAttrs)))
-				if vulnerabilityURN != "" {
-					addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, packageAttrs)))
-				}
-			}
-			if packageURN != "" && canonicalPackageURN != "" {
-				addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, canonicalPackageURN, relationRepresents, packageIdentityAttributes(event, packageAttrs, "grc")))
-			}
-			if canonicalPackageURN != "" && vulnerabilityURN != "" {
-				addLink(links, projectedLink(tenantID, event.GetSourceId(), canonicalPackageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, packageAttrs)))
-			}
+	}
+	for _, packageAttrs := range grcVulnerableAssetPackageAttrs(attrs) {
+		packageURN := vulnerabilityPackageURN(tenantID, packageAttrs, "grc")
+		canonicalPackageURN := addCanonicalPackageEntity(entities, tenantID, event.GetSourceId(), packageAttrs, "grc")
+		if packageURN != "" {
+			addVulnerablePackageEntity(entities, tenantID, event.GetSourceId(), packageURN, packageAttrs, "grc")
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, packageURN, relationContains, grcPackageTargetAttributes(event, packageAttrs)))
+		}
+		if packageURN != "" && canonicalPackageURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, canonicalPackageURN, relationRepresents, packageIdentityAttributes(event, packageAttrs, "grc")))
 		}
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
+}
+
+func grcVulnerableAssetReferenceAttrs(attrs map[string]string) []map[string]string {
+	rawReferences := strings.TrimSpace(attrs["vulnerability_package_refs"])
+	if rawReferences == "" {
+		return nil
+	}
+	var references []struct {
+		VulnerabilityID   string `json:"vulnerability_id"`
+		VulnerabilityName string `json:"vulnerability_name"`
+		PackageIdentifier string `json:"package_identifier"`
+	}
+	if err := json.Unmarshal([]byte(rawReferences), &references); err != nil {
+		return nil
+	}
+	result := make([]map[string]string, 0, len(references))
+	for _, reference := range references {
+		referenceAttrs := grcProjectionAttrsWith(attrs)
+		delete(referenceAttrs, "vulnerability_ids")
+		delete(referenceAttrs, "vulnerability_names")
+		delete(referenceAttrs, "package_identifiers")
+		if strings.TrimSpace(reference.VulnerabilityID) != "" {
+			referenceAttrs["vulnerability_id"] = reference.VulnerabilityID
+		}
+		if strings.TrimSpace(reference.VulnerabilityName) != "" {
+			referenceAttrs["name"] = reference.VulnerabilityName
+		}
+		if strings.TrimSpace(reference.PackageIdentifier) != "" {
+			referenceAttrs["package"] = reference.PackageIdentifier
+			referenceAttrs["package_purl"] = reference.PackageIdentifier
+		}
+		result = append(result, referenceAttrs)
+	}
+	return result
 }
 
 func grcVulnerableAssetVulnerabilityAttrs(attrs map[string]string) []map[string]string {

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -262,6 +262,101 @@ func grcVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	return projectedEntities, projectedLinks, nil
 }
 
+func grcVulnerableAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	provider := grcProvider(attrs)
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+
+	targetID := firstAttribute(attrs, "target_id", "asset_id", "resource_id", "endpoint_id", "external_id")
+	targetURN := grcTargetURN(tenantID, provider, targetID)
+	if targetURN == "" {
+		return nil, nil, nil
+	}
+	addEntity(entities, grcTargetEntity(tenantID, event.GetSourceId(), targetURN, targetID, attrs, provider))
+	addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, targetURN, relationRepresents, grcTargetHost(attrs), "grc_vulnerable_asset_host", "0.95")
+	addInternetIPLink(entities, links, tenantID, event.GetSourceId(), event, targetURN, firstAttribute(attrs, "ip", "ip_address", "public_ip"), "grc_vulnerable_asset_ip", "0.95")
+
+	integrationID := firstAttribute(attrs, "integration_id")
+	if integrationURN := grcIntegrationURN(tenantID, provider, integrationID); integrationURN != "" {
+		addEntity(entities, grcIntegrationReferenceEntity(tenantID, event.GetSourceId(), integrationURN, integrationID, provider))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, integrationURN, relationBelongsTo, grcIntegrationLinkAttributes(event, integrationID)))
+	}
+
+	vulnerabilityAttrsList := grcVulnerableAssetVulnerabilityAttrs(attrs)
+	if len(vulnerabilityAttrsList) == 0 {
+		vulnerabilityAttrsList = []map[string]string{attrs}
+	}
+	for _, vulnerabilityAttrs := range vulnerabilityAttrsList {
+		vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), vulnerabilityAttrs)
+		if vulnerabilityURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, vulnerabilityAttrs)))
+		}
+		for _, packageAttrs := range grcVulnerableAssetPackageAttrs(vulnerabilityAttrs) {
+			packageURN := vulnerabilityPackageURN(tenantID, packageAttrs, "grc")
+			canonicalPackageURN := addCanonicalPackageEntity(entities, tenantID, event.GetSourceId(), packageAttrs, "grc")
+			if packageURN != "" {
+				addVulnerablePackageEntity(entities, tenantID, event.GetSourceId(), packageURN, packageAttrs, "grc")
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), targetURN, packageURN, relationContains, grcPackageTargetAttributes(event, packageAttrs)))
+				if vulnerabilityURN != "" {
+					addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, packageAttrs)))
+				}
+			}
+			if packageURN != "" && canonicalPackageURN != "" {
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, canonicalPackageURN, relationRepresents, packageIdentityAttributes(event, packageAttrs, "grc")))
+			}
+			if canonicalPackageURN != "" && vulnerabilityURN != "" {
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), canonicalPackageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, packageAttrs)))
+			}
+		}
+	}
+
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
+	return projectedEntities, projectedLinks, nil
+}
+
+func grcVulnerableAssetVulnerabilityAttrs(attrs map[string]string) []map[string]string {
+	candidates := grcAttributeList(strings.Join([]string{attrs["vulnerability_ids"], attrs["vulnerability_names"]}, ","))
+	if len(candidates) == 0 && canonicalVulnerabilityIdentifier(attrs) != "" {
+		return []map[string]string{attrs}
+	}
+	result := make([]map[string]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		copy := grcProjectionAttrsWith(attrs, "vulnerability_id", candidate, "name", candidate)
+		if canonicalVulnerabilityIdentifier(copy) != "" {
+			result = append(result, copy)
+		}
+	}
+	return result
+}
+
+func grcVulnerableAssetPackageAttrs(attrs map[string]string) []map[string]string {
+	packages := grcAttributeList(strings.Join([]string{attrs["package_identifiers"], attrs["package"], attrs["package_purl"]}, ","))
+	if len(packages) == 0 && vulnerablePackageName(attrs) != "" {
+		return []map[string]string{attrs}
+	}
+	result := make([]map[string]string, 0, len(packages))
+	for _, pkg := range packages {
+		result = append(result, grcProjectionAttrsWith(attrs, "package", pkg, "package_purl", pkg))
+	}
+	return result
+}
+
+func grcProjectionAttrsWith(attrs map[string]string, pairs ...string) map[string]string {
+	copy := make(map[string]string, len(attrs)+len(pairs)/2)
+	for key, value := range attrs {
+		copy[key] = value
+	}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		copy[pairs[i]] = pairs[i+1]
+	}
+	return copy
+}
+
 func grcTargetURN(tenantID string, provider string, targetID string) string {
 	if strings.TrimSpace(targetID) == "" {
 		return ""

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -409,6 +409,20 @@ func grcVulnerableAssetReferenceAttrs(attrs map[string]string) []map[string]stri
 		}
 		result = append(result, referenceAttrs)
 	}
+	for i := len(references); i < maxInt(len(vulnerabilityIDs), len(vulnerabilityNames), len(packageIdentifiers)); i++ {
+		referenceAttrs := grcVulnerableAssetCleanReferenceAttrs(attrs)
+		if vulnerabilityID := stringAt(vulnerabilityIDs, i); vulnerabilityID != "" {
+			referenceAttrs["vulnerability_id"] = vulnerabilityID
+		}
+		if vulnerabilityName := stringAt(vulnerabilityNames, i); vulnerabilityName != "" {
+			referenceAttrs["name"] = vulnerabilityName
+		}
+		if packageIdentifier := stringAt(packageIdentifiers, i); packageIdentifier != "" {
+			referenceAttrs["package"] = packageIdentifier
+			referenceAttrs["package_purl"] = packageIdentifier
+		}
+		result = append(result, referenceAttrs)
+	}
 	if len(result) == 0 {
 		return grcVulnerableAssetFlatReferenceAttrs(attrs)
 	}

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -355,9 +355,22 @@ func grcVulnerableAssetReferenceAttrs(attrs map[string]string) []map[string]stri
 	result := make([]map[string]string, 0, len(references))
 	for _, reference := range references {
 		referenceAttrs := grcProjectionAttrsWith(attrs)
-		delete(referenceAttrs, "vulnerability_ids")
-		delete(referenceAttrs, "vulnerability_names")
-		delete(referenceAttrs, "package_identifiers")
+		for _, key := range []string{
+			"cve_id",
+			"ghsa_id",
+			"identifier",
+			"name",
+			"package",
+			"package_identifiers",
+			"package_purl",
+			"title",
+			"vulnerability_id",
+			"vulnerability_ids",
+			"vulnerability_names",
+			"vulnerability_package_refs",
+		} {
+			delete(referenceAttrs, key)
+		}
 		if strings.TrimSpace(reference.VulnerabilityID) != "" {
 			referenceAttrs["vulnerability_id"] = reference.VulnerabilityID
 		}

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -477,15 +477,23 @@ func grcVulnerableAssetCleanReferenceAttrs(attrs map[string]string) map[string]s
 }
 
 func grcVulnerableAssetVulnerabilityAttrs(attrs map[string]string) []map[string]string {
-	candidates := grcAttributeList(strings.Join([]string{attrs["vulnerability_ids"], attrs["vulnerability_names"]}, ","))
-	if len(candidates) == 0 && canonicalVulnerabilityIdentifier(attrs) != "" {
+	vulnerabilityIDs := grcAttributeSequence(attrs["vulnerability_ids"])
+	vulnerabilityNames := grcAttributeSequence(attrs["vulnerability_names"])
+	if len(vulnerabilityIDs) == 0 && len(vulnerabilityNames) == 0 && canonicalVulnerabilityIdentifier(attrs) != "" {
 		return []map[string]string{attrs}
 	}
-	result := make([]map[string]string, 0, len(candidates))
-	for _, candidate := range candidates {
-		copy := grcProjectionAttrsWith(attrs, "vulnerability_id", candidate, "name", candidate)
-		if canonicalVulnerabilityIdentifier(copy) != "" {
-			result = append(result, copy)
+	total := maxInt(len(vulnerabilityIDs), len(vulnerabilityNames))
+	result := make([]map[string]string, 0, total)
+	for i := 0; i < total; i++ {
+		referenceAttrs := grcVulnerableAssetCleanReferenceAttrs(attrs)
+		if vulnerabilityID := stringAt(vulnerabilityIDs, i); vulnerabilityID != "" {
+			referenceAttrs["vulnerability_id"] = vulnerabilityID
+		}
+		if vulnerabilityName := stringAt(vulnerabilityNames, i); vulnerabilityName != "" {
+			referenceAttrs["name"] = vulnerabilityName
+		}
+		if canonicalVulnerabilityIdentifier(referenceAttrs) != "" {
+			result = append(result, referenceAttrs)
 		}
 	}
 	return result

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -139,6 +139,36 @@ func grcAttributeList(value string) []string {
 	return values
 }
 
+func grcAttributeSequence(value string) []string {
+	fields := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t'
+	})
+	result := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if trimmed := strings.TrimSpace(field); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func stringAt(values []string, index int) string {
+	if index < 0 || index >= len(values) {
+		return ""
+	}
+	return values[index]
+}
+
+func maxInt(values ...int) int {
+	max := 0
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}
+
 func grcDocumentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	tenantID, err := tenantID(event)
 	if err != nil {
@@ -342,7 +372,7 @@ func grcVulnerableAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 func grcVulnerableAssetReferenceAttrs(attrs map[string]string) []map[string]string {
 	rawReferences := strings.TrimSpace(attrs["vulnerability_package_refs"])
 	if rawReferences == "" {
-		return nil
+		return grcVulnerableAssetFlatReferenceAttrs(attrs)
 	}
 	var references []struct {
 		VulnerabilityID   string `json:"vulnerability_id"`
@@ -350,27 +380,11 @@ func grcVulnerableAssetReferenceAttrs(attrs map[string]string) []map[string]stri
 		PackageIdentifier string `json:"package_identifier"`
 	}
 	if err := json.Unmarshal([]byte(rawReferences), &references); err != nil {
-		return nil
+		return grcVulnerableAssetFlatReferenceAttrs(attrs)
 	}
 	result := make([]map[string]string, 0, len(references))
 	for _, reference := range references {
-		referenceAttrs := grcProjectionAttrsWith(attrs)
-		for _, key := range []string{
-			"cve_id",
-			"ghsa_id",
-			"identifier",
-			"name",
-			"package",
-			"package_identifiers",
-			"package_purl",
-			"title",
-			"vulnerability_id",
-			"vulnerability_ids",
-			"vulnerability_names",
-			"vulnerability_package_refs",
-		} {
-			delete(referenceAttrs, key)
-		}
+		referenceAttrs := grcVulnerableAssetCleanReferenceAttrs(attrs)
 		if strings.TrimSpace(reference.VulnerabilityID) != "" {
 			referenceAttrs["vulnerability_id"] = reference.VulnerabilityID
 		}
@@ -383,7 +397,57 @@ func grcVulnerableAssetReferenceAttrs(attrs map[string]string) []map[string]stri
 		}
 		result = append(result, referenceAttrs)
 	}
+	if len(result) == 0 {
+		return grcVulnerableAssetFlatReferenceAttrs(attrs)
+	}
 	return result
+}
+
+func grcVulnerableAssetFlatReferenceAttrs(attrs map[string]string) []map[string]string {
+	vulnerabilityIDs := grcAttributeSequence(attrs["vulnerability_ids"])
+	vulnerabilityNames := grcAttributeSequence(attrs["vulnerability_names"])
+	packageIdentifiers := grcAttributeSequence(attrs["package_identifiers"])
+	if (len(vulnerabilityIDs) == 0 && len(vulnerabilityNames) == 0) || len(packageIdentifiers) == 0 {
+		return nil
+	}
+	total := maxInt(len(vulnerabilityIDs), len(vulnerabilityNames), len(packageIdentifiers))
+	result := make([]map[string]string, 0, total)
+	for i := 0; i < total; i++ {
+		referenceAttrs := grcVulnerableAssetCleanReferenceAttrs(attrs)
+		if vulnerabilityID := stringAt(vulnerabilityIDs, i); vulnerabilityID != "" {
+			referenceAttrs["vulnerability_id"] = vulnerabilityID
+		}
+		if vulnerabilityName := stringAt(vulnerabilityNames, i); vulnerabilityName != "" {
+			referenceAttrs["name"] = vulnerabilityName
+		}
+		if packageIdentifier := stringAt(packageIdentifiers, i); packageIdentifier != "" {
+			referenceAttrs["package"] = packageIdentifier
+			referenceAttrs["package_purl"] = packageIdentifier
+		}
+		result = append(result, referenceAttrs)
+	}
+	return result
+}
+
+func grcVulnerableAssetCleanReferenceAttrs(attrs map[string]string) map[string]string {
+	referenceAttrs := grcProjectionAttrsWith(attrs)
+	for _, key := range []string{
+		"cve_id",
+		"ghsa_id",
+		"identifier",
+		"name",
+		"package",
+		"package_identifiers",
+		"package_purl",
+		"title",
+		"vulnerability_id",
+		"vulnerability_ids",
+		"vulnerability_names",
+		"vulnerability_package_refs",
+	} {
+		delete(referenceAttrs, key)
+	}
+	return referenceAttrs
 }
 
 func grcVulnerableAssetVulnerabilityAttrs(attrs map[string]string) []map[string]string {

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -542,6 +542,37 @@ func TestProjectGRCVulnerableAssetZipsFlatPackageVulnerabilityFields(t *testing.
 	assertProjectedLinkMissing(t, state, packageTwoURN, relationAffectedBy, vulnerabilityOneURN)
 }
 
+func TestProjectGRCVulnerableAssetMergesFlatPackagesIntoReferences(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-mixed",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":                   "vanta",
+			"target_id":                  "target-mixed",
+			"package_identifiers":        "pkg:golang/example/one@1.0.0,pkg:golang/example/two@2.0.0",
+			"vulnerability_package_refs": `[{"vulnerability_id":"CVE-2026-4242"},{"vulnerability_id":"CVE-2026-4243"}]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	packageOneURN := "urn:cerebro:writer:package:grc:pkg:golang/example/one@1.0.0"
+	packageTwoURN := "urn:cerebro:writer:package:grc:pkg:golang/example/two@2.0.0"
+	vulnerabilityOneURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+	vulnerabilityTwoURN := "urn:cerebro:writer:vulnerability:cve-2026-4243"
+
+	assertProjectedLink(t, state, packageOneURN, relationAffectedBy, vulnerabilityOneURN)
+	assertProjectedLink(t, state, packageTwoURN, relationAffectedBy, vulnerabilityTwoURN)
+	assertProjectedLinkMissing(t, state, packageOneURN, relationAffectedBy, vulnerabilityTwoURN)
+	assertProjectedLinkMissing(t, state, packageTwoURN, relationAffectedBy, vulnerabilityOneURN)
+}
+
 func TestProjectGRCVulnerableAssetDoesNotInferVulnerabilityFromReferenceJSON(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -423,6 +423,58 @@ func TestProjectGRCVulnerabilityLinksHostLikeTargetID(t *testing.T) {
 	assertProjectedLink(t, state, targetURN, relationRepresents, hostURN)
 }
 
+func TestProjectGRCVulnerableAssetEnrichesVulnerabilityTarget(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":            "vanta",
+			"target_id":           "target-1",
+			"target_name":         "App Server",
+			"hostname":            "app.writer.com",
+			"ip":                  "203.0.113.10",
+			"integration_id":      "integration-1",
+			"asset_type":          "server",
+			"vulnerability_ids":   "CVE-2026-4242",
+			"package_identifiers": "pkg:golang/example/module@1.2.3",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	targetURN := "urn:cerebro:writer:grc_target:vanta:target-1"
+	hostURN := "urn:cerebro:writer:internet_host:app.writer.com"
+	ipURN := "urn:cerebro:writer:internet_ip:203.0.113.10"
+	integrationURN := "urn:cerebro:writer:source:vanta:integration:integration-1"
+	packageURN := "urn:cerebro:writer:package:grc:pkg:golang/example/module@1.2.3"
+	canonicalPackageURN := "urn:cerebro:writer:package:canonical:pkg:golang/example/module"
+	vulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+
+	if entity := state.entities[targetURN]; entity == nil || entity.EntityType != "grc.target" {
+		t.Fatalf("GRC target entity missing: %#v", entity)
+	}
+	if got := state.entities[targetURN].Attributes["host"]; got != "app.writer.com" {
+		t.Fatalf("target host = %q, want app.writer.com", got)
+	}
+	if got := state.entities[targetURN].Attributes["target_type"]; got != "server" {
+		t.Fatalf("target_type = %q, want server", got)
+	}
+	assertProjectedLink(t, state, targetURN, relationRepresents, hostURN)
+	assertProjectedLink(t, state, targetURN, relationRepresents, ipURN)
+	assertProjectedLink(t, state, targetURN, relationBelongsTo, integrationURN)
+	assertProjectedLink(t, state, targetURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, targetURN, relationContains, packageURN)
+	assertProjectedLink(t, state, packageURN, relationRepresents, canonicalPackageURN)
+	assertProjectedLink(t, state, packageURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, canonicalPackageURN, relationAffectedBy, vulnerabilityURN)
+}
+
 func TestProjectGRCVulnerabilityWritesGraphTargetIntegrationLinks(t *testing.T) {
 	state := &projectionRecorder{}
 	graph := &endpointCheckingGraphRecorder{}

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -600,6 +600,39 @@ func TestProjectGRCVulnerableAssetAppendsTrailingFlatTuples(t *testing.T) {
 	assertProjectedLink(t, state, packageTwoURN, relationAffectedBy, vulnerabilityTwoURN)
 }
 
+func TestProjectGRCVulnerableAssetZipsFlatVulnerabilityNames(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-names",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":            "vanta",
+			"target_id":           "target-names",
+			"vulnerability_ids":   "CVE-2026-4242,CVE-2026-4243",
+			"vulnerability_names": "openssl bug,nginx bug",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	targetURN := "urn:cerebro:writer:grc_target:vanta:target-names"
+	firstVulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+	secondVulnerabilityURN := "urn:cerebro:writer:vulnerability:cve-2026-4243"
+	assertProjectedLink(t, state, targetURN, relationAffectedBy, firstVulnerabilityURN)
+	assertProjectedLink(t, state, targetURN, relationAffectedBy, secondVulnerabilityURN)
+	if got := state.links[targetURN+"|"+relationAffectedBy+"|"+firstVulnerabilityURN].Attributes["name"]; got != "openssl bug" {
+		t.Fatalf("first vulnerability evidence name = %q, want openssl bug", got)
+	}
+	if got := state.links[targetURN+"|"+relationAffectedBy+"|"+secondVulnerabilityURN].Attributes["name"]; got != "nginx bug" {
+		t.Fatalf("second vulnerability evidence name = %q, want nginx bug", got)
+	}
+}
+
 func TestProjectGRCVulnerableAssetDoesNotInferVulnerabilityFromReferenceJSON(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -573,6 +573,33 @@ func TestProjectGRCVulnerableAssetMergesFlatPackagesIntoReferences(t *testing.T)
 	assertProjectedLinkMissing(t, state, packageTwoURN, relationAffectedBy, vulnerabilityOneURN)
 }
 
+func TestProjectGRCVulnerableAssetAppendsTrailingFlatTuples(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-trailing",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":                   "vanta",
+			"target_id":                  "target-trailing",
+			"vulnerability_ids":          "CVE-2026-4242,CVE-2026-4243",
+			"package_identifiers":        "pkg:golang/example/one@1.0.0,pkg:golang/example/two@2.0.0",
+			"vulnerability_package_refs": `[{"vulnerability_id":"CVE-2026-4242","package_identifier":"pkg:golang/example/one@1.0.0"}]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	packageTwoURN := "urn:cerebro:writer:package:grc:pkg:golang/example/two@2.0.0"
+	vulnerabilityTwoURN := "urn:cerebro:writer:vulnerability:cve-2026-4243"
+
+	assertProjectedLink(t, state, packageTwoURN, relationAffectedBy, vulnerabilityTwoURN)
+}
+
 func TestProjectGRCVulnerableAssetDoesNotInferVulnerabilityFromReferenceJSON(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -511,6 +511,37 @@ func TestProjectGRCVulnerableAssetPreservesPackageVulnerabilityPairs(t *testing.
 	assertProjectedLinkMissing(t, state, packageTwoURN, relationAffectedBy, vulnerabilityOneURN)
 }
 
+func TestProjectGRCVulnerableAssetZipsFlatPackageVulnerabilityFields(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-flat",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":            "vanta",
+			"target_id":           "target-flat",
+			"vulnerability_ids":   "CVE-2026-4242,CVE-2026-4243",
+			"package_identifiers": "pkg:golang/example/one@1.0.0,pkg:golang/example/two@2.0.0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	packageOneURN := "urn:cerebro:writer:package:grc:pkg:golang/example/one@1.0.0"
+	packageTwoURN := "urn:cerebro:writer:package:grc:pkg:golang/example/two@2.0.0"
+	vulnerabilityOneURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+	vulnerabilityTwoURN := "urn:cerebro:writer:vulnerability:cve-2026-4243"
+
+	assertProjectedLink(t, state, packageOneURN, relationAffectedBy, vulnerabilityOneURN)
+	assertProjectedLink(t, state, packageTwoURN, relationAffectedBy, vulnerabilityTwoURN)
+	assertProjectedLinkMissing(t, state, packageOneURN, relationAffectedBy, vulnerabilityTwoURN)
+	assertProjectedLinkMissing(t, state, packageTwoURN, relationAffectedBy, vulnerabilityOneURN)
+}
+
 func TestProjectGRCVulnerableAssetDoesNotInferVulnerabilityFromReferenceJSON(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -633,6 +633,30 @@ func TestProjectGRCVulnerableAssetZipsFlatVulnerabilityNames(t *testing.T) {
 	}
 }
 
+func TestProjectGRCVulnerableAssetLinksURLOnlyHost(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-url",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":     "vanta",
+			"target_id":    "asset-123",
+			"external_url": "https://app.writer.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	targetURN := "urn:cerebro:writer:grc_target:vanta:asset-123"
+	hostURN := "urn:cerebro:writer:internet_host:app.writer.com"
+	assertProjectedLink(t, state, targetURN, relationRepresents, hostURN)
+}
+
 func TestProjectGRCVulnerableAssetDoesNotInferVulnerabilityFromReferenceJSON(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -433,15 +433,16 @@ func TestProjectGRCVulnerableAssetEnrichesVulnerabilityTarget(t *testing.T) {
 		SourceId: "grc",
 		Kind:     "grc.vulnerable_asset",
 		Attributes: map[string]string{
-			"provider":            "vanta",
-			"target_id":           "target-1",
-			"target_name":         "App Server",
-			"hostname":            "app.writer.com",
-			"ip":                  "203.0.113.10",
-			"integration_id":      "integration-1",
-			"asset_type":          "server",
-			"vulnerability_ids":   "CVE-2026-4242",
-			"package_identifiers": "pkg:golang/example/module@1.2.3",
+			"provider":                   "vanta",
+			"target_id":                  "target-1",
+			"target_name":                "App Server",
+			"hostname":                   "app.writer.com",
+			"ip":                         "203.0.113.10",
+			"integration_id":             "integration-1",
+			"asset_type":                 "server",
+			"vulnerability_ids":          "CVE-2026-4242",
+			"package_identifiers":        "pkg:golang/example/module@1.2.3",
+			"vulnerability_package_refs": `[{"vulnerability_id":"CVE-2026-4242","package_identifier":"pkg:golang/example/module@1.2.3"}]`,
 		},
 	})
 	if err != nil {
@@ -473,6 +474,41 @@ func TestProjectGRCVulnerableAssetEnrichesVulnerabilityTarget(t *testing.T) {
 	assertProjectedLink(t, state, packageURN, relationRepresents, canonicalPackageURN)
 	assertProjectedLink(t, state, packageURN, relationAffectedBy, vulnerabilityURN)
 	assertProjectedLink(t, state, canonicalPackageURN, relationAffectedBy, vulnerabilityURN)
+}
+
+func TestProjectGRCVulnerableAssetPreservesPackageVulnerabilityPairs(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-2",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":            "vanta",
+			"target_id":           "target-2",
+			"vulnerability_ids":   "CVE-2026-4242,CVE-2026-4243",
+			"package_identifiers": "pkg:golang/example/one@1.0.0,pkg:golang/example/two@2.0.0",
+			"vulnerability_package_refs": `[` +
+				`{"vulnerability_id":"CVE-2026-4242","package_identifier":"pkg:golang/example/one@1.0.0"},` +
+				`{"vulnerability_id":"CVE-2026-4243","package_identifier":"pkg:golang/example/two@2.0.0"}` +
+				`]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	packageOneURN := "urn:cerebro:writer:package:grc:pkg:golang/example/one@1.0.0"
+	packageTwoURN := "urn:cerebro:writer:package:grc:pkg:golang/example/two@2.0.0"
+	vulnerabilityOneURN := "urn:cerebro:writer:vulnerability:cve-2026-4242"
+	vulnerabilityTwoURN := "urn:cerebro:writer:vulnerability:cve-2026-4243"
+
+	assertProjectedLink(t, state, packageOneURN, relationAffectedBy, vulnerabilityOneURN)
+	assertProjectedLink(t, state, packageTwoURN, relationAffectedBy, vulnerabilityTwoURN)
+	assertProjectedLinkMissing(t, state, packageOneURN, relationAffectedBy, vulnerabilityTwoURN)
+	assertProjectedLinkMissing(t, state, packageTwoURN, relationAffectedBy, vulnerabilityOneURN)
 }
 
 func TestProjectGRCVulnerabilityWritesGraphTargetIntegrationLinks(t *testing.T) {

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -511,6 +511,34 @@ func TestProjectGRCVulnerableAssetPreservesPackageVulnerabilityPairs(t *testing.
 	assertProjectedLinkMissing(t, state, packageTwoURN, relationAffectedBy, vulnerabilityOneURN)
 }
 
+func TestProjectGRCVulnerableAssetDoesNotInferVulnerabilityFromReferenceJSON(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-3",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":  "vanta",
+			"target_id": "target-3",
+			"vulnerability_package_refs": `[` +
+				`{"package_identifier":"pkg:golang/example/one@1.0.0"},` +
+				`{"vulnerability_id":"CVE-2026-4243","package_identifier":"pkg:golang/example/two@2.0.0"}` +
+				`]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	packageOneURN := "urn:cerebro:writer:package:grc:pkg:golang/example/one@1.0.0"
+	vulnerabilityTwoURN := "urn:cerebro:writer:vulnerability:cve-2026-4243"
+
+	assertProjectedLinkMissing(t, state, packageOneURN, relationAffectedBy, vulnerabilityTwoURN)
+}
+
 func TestProjectGRCVulnerabilityWritesGraphTargetIntegrationLinks(t *testing.T) {
 	state := &projectionRecorder{}
 	graph := &endpointCheckingGraphRecorder{}

--- a/internal/sourceprojection/registry.go
+++ b/internal/sourceprojection/registry.go
@@ -103,6 +103,7 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"grc.document":                         grcDocumentProjections,
 	"grc.vendor":                           grcVendorProjections,
 	"grc.vulnerability":                    grcVulnerabilityProjections,
+	"grc.vulnerable_asset":                 grcVulnerableAssetProjections,
 	"grc.risk_scenario":                    grcRiskScenarioProjections,
 	"grc.person":                           grcPersonProjections,
 	"grc.user":                             grcUserProjections,

--- a/sources/grc/catalog.yaml
+++ b/sources/grc/catalog.yaml
@@ -1,6 +1,6 @@
 id: grc
 name: GRC
-description: Provider-neutral GRC framework, control, evidence, vendor, vulnerability, risk, people, and integration source.
+description: Provider-neutral GRC framework, control, evidence, vendor, vulnerability, vulnerable asset, risk, people, and integration source.
 emitted_kinds:
   - grc.framework
   - grc.control
@@ -9,6 +9,7 @@ emitted_kinds:
   - grc.document
   - grc.vendor
   - grc.vulnerability
+  - grc.vulnerable_asset
   - grc.risk_scenario
   - grc.person
   - grc.user

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -1091,6 +1091,8 @@ func recordIDKeys(family string) []string {
 		return []string{"id", "userId", "emailAddress"}
 	case familyUser:
 		return []string{"id", "email"}
+	case familyVulnerableAsset:
+		return []string{"id", "assetId", "targetId", "externalId", "name"}
 	default:
 		return []string{"id", "externalId", "name"}
 	}

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -29,27 +29,28 @@ import (
 var catalogFS embed.FS
 
 const (
-	sourceID            = "grc"
-	defaultProvider     = "vanta"
-	defaultBaseURL      = "https://api.vanta.com"
-	defaultReadScope    = "vanta-api.all:read"
-	defaultPageSize     = 10
-	maxPageSize         = 100
-	httpTimeout         = 30 * time.Second
-	maxBodyBytes        = 8 << 20
-	tokenRefreshLeeway  = time.Minute
-	defaultFamily       = familyControlTest
-	familyFramework     = "framework"
-	familyControl       = "control"
-	familyControlTest   = "control_test"
-	familyPolicy        = "policy"
-	familyDocument      = "document"
-	familyVendor        = "vendor"
-	familyVulnerability = "vulnerability"
-	familyRiskScenario  = "risk_scenario"
-	familyPerson        = "person"
-	familyUser          = "user"
-	familyIntegration   = "integration"
+	sourceID              = "grc"
+	defaultProvider       = "vanta"
+	defaultBaseURL        = "https://api.vanta.com"
+	defaultReadScope      = "vanta-api.all:read"
+	defaultPageSize       = 10
+	maxPageSize           = 100
+	httpTimeout           = 30 * time.Second
+	maxBodyBytes          = 8 << 20
+	tokenRefreshLeeway    = time.Minute
+	defaultFamily         = familyControlTest
+	familyFramework       = "framework"
+	familyControl         = "control"
+	familyControlTest     = "control_test"
+	familyPolicy          = "policy"
+	familyDocument        = "document"
+	familyVendor          = "vendor"
+	familyVulnerability   = "vulnerability"
+	familyVulnerableAsset = "vulnerable_asset"
+	familyRiskScenario    = "risk_scenario"
+	familyPerson          = "person"
+	familyUser            = "user"
+	familyIntegration     = "integration"
 )
 
 var defaultTokenRetryBackoffs = []time.Duration{2 * time.Second, 5 * time.Second, 10 * time.Second, 20 * time.Second}
@@ -178,6 +179,7 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 		s.family(familyDocument, "/v1/documents"),
 		s.family(familyVendor, "/v1/vendors"),
 		s.family(familyVulnerability, "/v1/vulnerabilities"),
+		s.family(familyVulnerableAsset, "/v1/vulnerable-assets"),
 		s.family(familyRiskScenario, "/v1/risk-scenarios"),
 		s.family(familyPerson, "/v1/people"),
 		s.family(familyUser, "/v1/users"),
@@ -709,6 +711,20 @@ func attributesFor(settings settings, family string, record grcRecord) map[strin
 			"external_url":        "externalURL",
 			"scan_source":         "scanSource",
 		})
+	case familyVulnerableAsset:
+		copyFirstField(attrs, values, "asset_id", "id", "assetId", "targetId")
+		copyFirstField(attrs, values, "target_id", "id", "assetId", "targetId")
+		copyFirstField(attrs, values, "target_name", "displayName", "name", "hostname", "host", "url")
+		copyFirstField(attrs, values, "resource_name", "displayName", "name", "hostname", "host", "url")
+		copyFirstField(attrs, values, "hostname", "hostname", "host", "dnsName", "fqdn")
+		copyFirstField(attrs, values, "ip", "ipAddress", "publicIp", "publicIP", "ip")
+		copyFirstField(attrs, values, "asset_type", "assetType", "resourceType", "type")
+		copyFirstField(attrs, values, "resource_type", "assetType", "resourceType", "type")
+		copyFirstField(attrs, values, "integration_id", "integrationId", "integration.id")
+		copyFirstField(attrs, values, "external_url", "externalURL", "url")
+		copyFirstField(attrs, values, "operating_system", "operatingSystem", "os")
+		copyFirstField(attrs, values, "last_detected_at", "lastDetectedDate", "lastSeenDate", "updatedAt")
+		copyVulnerableAssetReferences(attrs, values)
 	case familyRiskScenario:
 		copyFields(attrs, values, map[string]string{
 			"risk_id":             "riskId",
@@ -807,6 +823,28 @@ func copyControlReferenceFields(attrs map[string]string, values map[string]any) 
 		if strings.TrimSpace(attrs["control_external_id"]) == "" {
 			attrs["control_external_id"] = firstDelimitedValue(externalIDs)
 		}
+	}
+}
+
+func copyVulnerableAssetReferences(attrs map[string]string, values map[string]any) {
+	if ids := firstNonEmptyString(
+		joinedObjectFieldValues(values, "vulnerabilities", "id", "vulnerabilityId"),
+		fieldString(values, "vulnerabilityIds"),
+	); ids != "" {
+		attrs["vulnerability_ids"] = ids
+	}
+	if names := firstNonEmptyString(
+		joinedObjectFieldValues(values, "vulnerabilities", "name", "title"),
+		fieldString(values, "vulnerabilityNames"),
+	); names != "" {
+		attrs["vulnerability_names"] = names
+	}
+	if packages := firstNonEmptyString(
+		joinedObjectFieldValues(values, "vulnerabilities", "packageIdentifier", "package", "packagePurl"),
+		fieldString(values, "packageIdentifiers"),
+		fieldString(values, "packages"),
+	); packages != "" {
+		attrs["package_identifiers"] = packages
 	}
 }
 
@@ -947,6 +985,8 @@ func timestampKeys(family string) []string {
 		return []string{"lastSecurityReviewCompletionDate"}
 	case familyVulnerability:
 		return []string{"lastDetectedDate", "sourceDetectedDate", "firstDetectedDate"}
+	case familyVulnerableAsset:
+		return []string{"lastDetectedDate", "lastSeenDate", "updatedAt"}
 	case familyRiskScenario:
 		return []string{"identificationDate"}
 	case familyPerson:
@@ -1056,6 +1096,7 @@ func supportedFamilies() []string {
 		familyDocument,
 		familyVendor,
 		familyVulnerability,
+		familyVulnerableAsset,
 		familyRiskScenario,
 		familyPerson,
 		familyUser,

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -911,6 +911,35 @@ func joinedVulnerableAssetReferences(values map[string]any) string {
 		refs = append(refs, ref)
 	}
 	if len(refs) == 0 {
+		vulnerabilityIDs := splitVulnerableAssetReferenceValues(fieldString(values, "vulnerabilityIds"))
+		vulnerabilityNames := splitVulnerableAssetReferenceValues(fieldString(values, "vulnerabilityNames"))
+		packageIdentifiers := splitVulnerableAssetReferenceValues(firstNonEmptyString(fieldString(values, "packageIdentifiers"), fieldString(values, "packages")))
+		for i := 0; i < maxInt(len(vulnerabilityIDs), len(vulnerabilityNames), len(packageIdentifiers)); i++ {
+			vulnerabilityID := valueAt(vulnerabilityIDs, i)
+			vulnerabilityName := valueAt(vulnerabilityNames, i)
+			packageIdentifier := valueAt(packageIdentifiers, i)
+			if vulnerabilityID == "" && vulnerabilityName == "" && packageIdentifier == "" {
+				continue
+			}
+			key := strings.Join([]string{vulnerabilityID, vulnerabilityName, packageIdentifier}, "\x00")
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			ref := map[string]string{}
+			if vulnerabilityID != "" {
+				ref["vulnerability_id"] = vulnerabilityID
+			}
+			if vulnerabilityName != "" {
+				ref["vulnerability_name"] = vulnerabilityName
+			}
+			if packageIdentifier != "" {
+				ref["package_identifier"] = packageIdentifier
+			}
+			refs = append(refs, ref)
+		}
+	}
+	if len(refs) == 0 {
 		return ""
 	}
 	raw, err := json.Marshal(refs)
@@ -918,6 +947,36 @@ func joinedVulnerableAssetReferences(values map[string]any) string {
 		return ""
 	}
 	return string(raw)
+}
+
+func splitVulnerableAssetReferenceValues(value string) []string {
+	fields := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t'
+	})
+	result := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if trimmed := strings.TrimSpace(field); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func valueAt(values []string, index int) string {
+	if index < 0 || index >= len(values) {
+		return ""
+	}
+	return values[index]
+}
+
+func maxInt(values ...int) int {
+	max := 0
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
 }
 
 func joinedObjectFieldValues(values map[string]any, arrayKey string, fields ...string) string {

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -722,6 +722,7 @@ func attributesFor(settings settings, family string, record grcRecord) map[strin
 		copyFirstField(attrs, values, "resource_type", "assetType", "resourceType", "type")
 		copyFirstField(attrs, values, "integration_id", "integrationId", "integration.id")
 		copyFirstField(attrs, values, "external_url", "externalURL", "url")
+		copyFirstField(attrs, values, "target_url", "url", "externalURL")
 		copyFirstField(attrs, values, "operating_system", "operatingSystem", "os")
 		copyFirstField(attrs, values, "last_detected_at", "lastDetectedDate", "lastSeenDate", "updatedAt")
 		copyVulnerableAssetReferences(attrs, values)

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -846,6 +846,9 @@ func copyVulnerableAssetReferences(attrs map[string]string, values map[string]an
 	); packages != "" {
 		attrs["package_identifiers"] = packages
 	}
+	if references := joinedVulnerableAssetReferences(values); references != "" {
+		attrs["vulnerability_package_refs"] = references
+	}
 }
 
 func joinedControlReferences(values map[string]any, arrayKey string) string {
@@ -873,6 +876,48 @@ func joinedControlReferences(values map[string]any, arrayKey string) string {
 		collected = append(collected, pair)
 	}
 	return strings.Join(collected, ";")
+}
+
+func joinedVulnerableAssetReferences(values map[string]any) string {
+	items := arrayValue(values, "vulnerabilities")
+	refs := make([]map[string]string, 0, len(items))
+	seen := map[string]struct{}{}
+	for _, item := range items {
+		object, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		vulnerabilityID := firstNonEmptyString(valueString(object["id"]), valueString(object["vulnerabilityId"]))
+		vulnerabilityName := firstNonEmptyString(valueString(object["name"]), valueString(object["title"]))
+		packageIdentifier := firstNonEmptyString(valueString(object["packageIdentifier"]), valueString(object["package"]), valueString(object["packagePurl"]))
+		if vulnerabilityID == "" && vulnerabilityName == "" && packageIdentifier == "" {
+			continue
+		}
+		key := strings.Join([]string{vulnerabilityID, vulnerabilityName, packageIdentifier}, "\x00")
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		ref := map[string]string{}
+		if vulnerabilityID != "" {
+			ref["vulnerability_id"] = vulnerabilityID
+		}
+		if vulnerabilityName != "" {
+			ref["vulnerability_name"] = vulnerabilityName
+		}
+		if packageIdentifier != "" {
+			ref["package_identifier"] = packageIdentifier
+		}
+		refs = append(refs, ref)
+	}
+	if len(refs) == 0 {
+		return ""
+	}
+	raw, err := json.Marshal(refs)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
 }
 
 func joinedObjectFieldValues(values map[string]any, arrayKey string, fields ...string) string {

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -882,14 +882,17 @@ func joinedVulnerableAssetReferences(values map[string]any) string {
 	items := arrayValue(values, "vulnerabilities")
 	refs := make([]map[string]string, 0, len(items))
 	seen := map[string]struct{}{}
-	for _, item := range items {
+	vulnerabilityIDs := splitVulnerableAssetReferenceValues(fieldString(values, "vulnerabilityIds"))
+	vulnerabilityNames := splitVulnerableAssetReferenceValues(fieldString(values, "vulnerabilityNames"))
+	packageIdentifiers := splitVulnerableAssetReferenceValues(firstNonEmptyString(fieldString(values, "packageIdentifiers"), fieldString(values, "packages")))
+	for i, item := range items {
 		object, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		vulnerabilityID := firstNonEmptyString(valueString(object["id"]), valueString(object["vulnerabilityId"]))
-		vulnerabilityName := firstNonEmptyString(valueString(object["name"]), valueString(object["title"]))
-		packageIdentifier := firstNonEmptyString(valueString(object["packageIdentifier"]), valueString(object["package"]), valueString(object["packagePurl"]))
+		vulnerabilityID := firstNonEmptyString(valueString(object["id"]), valueString(object["vulnerabilityId"]), valueAt(vulnerabilityIDs, i))
+		vulnerabilityName := firstNonEmptyString(valueString(object["name"]), valueString(object["title"]), valueAt(vulnerabilityNames, i))
+		packageIdentifier := firstNonEmptyString(valueString(object["packageIdentifier"]), valueString(object["package"]), valueString(object["packagePurl"]), valueAt(packageIdentifiers, i))
 		if vulnerabilityID == "" && vulnerabilityName == "" && packageIdentifier == "" {
 			continue
 		}
@@ -910,10 +913,24 @@ func joinedVulnerableAssetReferences(values map[string]any) string {
 		}
 		refs = append(refs, ref)
 	}
+	for i, ref := range refs {
+		if ref["vulnerability_id"] == "" {
+			if vulnerabilityID := valueAt(vulnerabilityIDs, i); vulnerabilityID != "" {
+				ref["vulnerability_id"] = vulnerabilityID
+			}
+		}
+		if ref["vulnerability_name"] == "" {
+			if vulnerabilityName := valueAt(vulnerabilityNames, i); vulnerabilityName != "" {
+				ref["vulnerability_name"] = vulnerabilityName
+			}
+		}
+		if ref["package_identifier"] == "" {
+			if packageIdentifier := valueAt(packageIdentifiers, i); packageIdentifier != "" {
+				ref["package_identifier"] = packageIdentifier
+			}
+		}
+	}
 	if len(refs) == 0 {
-		vulnerabilityIDs := splitVulnerableAssetReferenceValues(fieldString(values, "vulnerabilityIds"))
-		vulnerabilityNames := splitVulnerableAssetReferenceValues(fieldString(values, "vulnerabilityNames"))
-		packageIdentifiers := splitVulnerableAssetReferenceValues(firstNonEmptyString(fieldString(values, "packageIdentifiers"), fieldString(values, "packages")))
 		for i := 0; i < maxInt(len(vulnerabilityIDs), len(vulnerabilityNames), len(packageIdentifiers)); i++ {
 			vulnerabilityID := valueAt(vulnerabilityIDs, i)
 			vulnerabilityName := valueAt(vulnerabilityNames, i)

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -930,6 +930,30 @@ func joinedVulnerableAssetReferences(values map[string]any) string {
 			}
 		}
 	}
+	for i := len(refs); i < maxInt(len(vulnerabilityIDs), len(vulnerabilityNames), len(packageIdentifiers)); i++ {
+		vulnerabilityID := valueAt(vulnerabilityIDs, i)
+		vulnerabilityName := valueAt(vulnerabilityNames, i)
+		packageIdentifier := valueAt(packageIdentifiers, i)
+		if vulnerabilityID == "" && vulnerabilityName == "" && packageIdentifier == "" {
+			continue
+		}
+		key := strings.Join([]string{vulnerabilityID, vulnerabilityName, packageIdentifier}, "\x00")
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		ref := map[string]string{}
+		if vulnerabilityID != "" {
+			ref["vulnerability_id"] = vulnerabilityID
+		}
+		if vulnerabilityName != "" {
+			ref["vulnerability_name"] = vulnerabilityName
+		}
+		if packageIdentifier != "" {
+			ref["package_identifier"] = packageIdentifier
+		}
+		refs = append(refs, ref)
+	}
 	if len(refs) == 0 {
 		for i := 0; i < maxInt(len(vulnerabilityIDs), len(vulnerabilityNames), len(packageIdentifiers)); i++ {
 			vulnerabilityID := valueAt(vulnerabilityIDs, i)

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -410,6 +410,24 @@ func TestJoinedVulnerableAssetReferencesMergesFlatPackages(t *testing.T) {
 	}
 }
 
+func TestJoinedVulnerableAssetReferencesAppendsTrailingFlatTuples(t *testing.T) {
+	raw := joinedVulnerableAssetReferences(map[string]any{
+		"vulnerabilities":    []any{map[string]any{"id": "CVE-2026-4242"}},
+		"vulnerabilityIds":   []any{"CVE-2026-4242", "CVE-2026-4243"},
+		"packageIdentifiers": []any{"pkg:golang/example/one@1.0.0", "pkg:golang/example/two@2.0.0"},
+	})
+	var refs []map[string]string
+	if err := json.Unmarshal([]byte(raw), &refs); err != nil {
+		t.Fatalf("joinedVulnerableAssetReferences() produced invalid JSON: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("len(refs) = %d, want 2", len(refs))
+	}
+	if refs[1]["vulnerability_id"] != "CVE-2026-4243" || refs[1]["package_identifier"] != "pkg:golang/example/two@2.0.0" {
+		t.Fatalf("refs[1] = %#v, want trailing flat pair", refs[1])
+	}
+}
+
 func TestTokenCacheScopesRuntimeSecretsAndBaseURL(t *testing.T) {
 	tokenRequests := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -428,6 +428,20 @@ func TestJoinedVulnerableAssetReferencesAppendsTrailingFlatTuples(t *testing.T) 
 	}
 }
 
+func TestVulnerableAssetRecordIDUsesAssetID(t *testing.T) {
+	first := recordID(familyVulnerableAsset, map[string]any{
+		"assetId":      "asset-1",
+		"lastSeenDate": "2026-05-11T00:00:00Z",
+	}, json.RawMessage(`{"assetId":"asset-1","lastSeenDate":"2026-05-11T00:00:00Z"}`))
+	second := recordID(familyVulnerableAsset, map[string]any{
+		"assetId":      "asset-1",
+		"lastSeenDate": "2026-05-12T00:00:00Z",
+	}, json.RawMessage(`{"assetId":"asset-1","lastSeenDate":"2026-05-12T00:00:00Z"}`))
+	if first != "asset-1" || second != "asset-1" {
+		t.Fatalf("record IDs = %q and %q, want stable asset-1", first, second)
+	}
+}
+
 func TestTokenCacheScopesRuntimeSecretsAndBaseURL(t *testing.T) {
 	tokenRequests := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -390,6 +390,26 @@ func TestJoinedVulnerableAssetReferencesZipsFlatFields(t *testing.T) {
 	}
 }
 
+func TestJoinedVulnerableAssetReferencesMergesFlatPackages(t *testing.T) {
+	raw := joinedVulnerableAssetReferences(map[string]any{
+		"vulnerabilities":    []any{map[string]any{"id": "CVE-2026-4242"}, map[string]any{"id": "CVE-2026-4243"}},
+		"packageIdentifiers": []any{"pkg:golang/example/one@1.0.0", "pkg:golang/example/two@2.0.0"},
+	})
+	var refs []map[string]string
+	if err := json.Unmarshal([]byte(raw), &refs); err != nil {
+		t.Fatalf("joinedVulnerableAssetReferences() produced invalid JSON: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("len(refs) = %d, want 2", len(refs))
+	}
+	if refs[0]["vulnerability_id"] != "CVE-2026-4242" || refs[0]["package_identifier"] != "pkg:golang/example/one@1.0.0" {
+		t.Fatalf("refs[0] = %#v, want merged first pair", refs[0])
+	}
+	if refs[1]["vulnerability_id"] != "CVE-2026-4243" || refs[1]["package_identifier"] != "pkg:golang/example/two@2.0.0" {
+		t.Fatalf("refs[1] = %#v, want merged second pair", refs[1])
+	}
+}
+
 func TestTokenCacheScopesRuntimeSecretsAndBaseURL(t *testing.T) {
 	tokenRequests := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -324,6 +324,45 @@ func TestReadVantaVulnerabilityNormalizesFields(t *testing.T) {
 	}
 }
 
+func TestReadVantaVulnerableAssetNormalizesFields(t *testing.T) {
+	server := httptest.NewServer(newTestAPIHandler(t))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := testConfig(server.URL, familyVulnerableAsset)
+
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(vulnerable_asset) error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Read(vulnerable_asset).Events) = %d, want 1", len(pull.Events))
+	}
+	attrs := pull.Events[0].Attributes
+	if got := pull.Events[0].Kind; got != "grc.vulnerable_asset" {
+		t.Fatalf("event kind = %q, want grc.vulnerable_asset", got)
+	}
+	if got := attrs["target_id"]; got != "target-1" {
+		t.Fatalf("target_id = %q, want target-1", got)
+	}
+	if got := attrs["hostname"]; got != "app.writer.com" {
+		t.Fatalf("hostname = %q, want app.writer.com", got)
+	}
+	if got := attrs["ip"]; got != "203.0.113.10" {
+		t.Fatalf("ip = %q, want 203.0.113.10", got)
+	}
+	if got := attrs["vulnerability_ids"]; got != "CVE-2026-4242" {
+		t.Fatalf("vulnerability_ids = %q, want CVE-2026-4242", got)
+	}
+	if got := attrs["package_identifiers"]; got != "pkg:golang/example/module@1.2.3" {
+		t.Fatalf("package_identifiers = %q, want purl", got)
+	}
+}
+
 func TestTokenCacheScopesRuntimeSecretsAndBaseURL(t *testing.T) {
 	tokenRequests := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -609,6 +648,22 @@ func newTestAPIHandler(t *testing.T) http.Handler {
 				"isFixable":         true,
 				"remediateByDate":   "2026-05-30T00:00:00Z",
 				"lastDetectedDate":  "2026-05-10T00:00:00Z",
+			}})
+		case "/v1/vulnerable-assets":
+			requireBearer(t, r)
+			writePage(t, w, false, "", []map[string]any{{
+				"id":            "target-1",
+				"displayName":   "App Server",
+				"hostname":      "app.writer.com",
+				"ipAddress":     "203.0.113.10",
+				"assetType":     "server",
+				"integrationId": "integration-1",
+				"vulnerabilities": []map[string]any{{
+					"id":                "CVE-2026-4242",
+					"name":              "CVE-2026-4242",
+					"packageIdentifier": "pkg:golang/example/module@1.2.3",
+				}},
+				"lastSeenDate": "2026-05-11T00:00:00Z",
 			}})
 		case "/v1/tests":
 			requireBearer(t, r)

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -355,6 +355,9 @@ func TestReadVantaVulnerableAssetNormalizesFields(t *testing.T) {
 	if got := attrs["ip"]; got != "203.0.113.10" {
 		t.Fatalf("ip = %q, want 203.0.113.10", got)
 	}
+	if got := attrs["target_url"]; got != "https://app.writer.com" {
+		t.Fatalf("target_url = %q, want https://app.writer.com", got)
+	}
 	if got := attrs["vulnerability_ids"]; got != "CVE-2026-4242" {
 		t.Fatalf("vulnerability_ids = %q, want CVE-2026-4242", got)
 	}
@@ -735,6 +738,7 @@ func newTestAPIHandler(t *testing.T) http.Handler {
 				"displayName":   "App Server",
 				"hostname":      "app.writer.com",
 				"ipAddress":     "203.0.113.10",
+				"url":           "https://app.writer.com",
 				"assetType":     "server",
 				"integrationId": "integration-1",
 				"vulnerabilities": []map[string]any{{

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -370,6 +370,26 @@ func TestReadVantaVulnerableAssetNormalizesFields(t *testing.T) {
 	}
 }
 
+func TestJoinedVulnerableAssetReferencesZipsFlatFields(t *testing.T) {
+	raw := joinedVulnerableAssetReferences(map[string]any{
+		"vulnerabilityIds":   []any{"CVE-2026-4242", "CVE-2026-4243"},
+		"packageIdentifiers": []any{"pkg:golang/example/one@1.0.0", "pkg:golang/example/two@2.0.0"},
+	})
+	var refs []map[string]string
+	if err := json.Unmarshal([]byte(raw), &refs); err != nil {
+		t.Fatalf("joinedVulnerableAssetReferences() produced invalid JSON: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("len(refs) = %d, want 2", len(refs))
+	}
+	if refs[0]["vulnerability_id"] != "CVE-2026-4242" || refs[0]["package_identifier"] != "pkg:golang/example/one@1.0.0" {
+		t.Fatalf("refs[0] = %#v, want first vulnerability/package pair", refs[0])
+	}
+	if refs[1]["vulnerability_id"] != "CVE-2026-4243" || refs[1]["package_identifier"] != "pkg:golang/example/two@2.0.0" {
+		t.Fatalf("refs[1] = %#v, want second vulnerability/package pair", refs[1])
+	}
+}
+
 func TestTokenCacheScopesRuntimeSecretsAndBaseURL(t *testing.T) {
 	tokenRequests := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -361,6 +361,13 @@ func TestReadVantaVulnerableAssetNormalizesFields(t *testing.T) {
 	if got := attrs["package_identifiers"]; got != "pkg:golang/example/module@1.2.3" {
 		t.Fatalf("package_identifiers = %q, want purl", got)
 	}
+	var refs []map[string]string
+	if err := json.Unmarshal([]byte(attrs["vulnerability_package_refs"]), &refs); err != nil {
+		t.Fatalf("vulnerability_package_refs is invalid JSON: %v", err)
+	}
+	if len(refs) != 1 || refs[0]["vulnerability_id"] != "CVE-2026-4242" || refs[0]["package_identifier"] != "pkg:golang/example/module@1.2.3" {
+		t.Fatalf("vulnerability_package_refs = %#v, want CVE/package tuple", refs)
+	}
 }
 
 func TestTokenCacheScopesRuntimeSecretsAndBaseURL(t *testing.T) {


### PR DESCRIPTION
## Summary
- add the Vanta/GRC `vulnerable_asset` family backed by `/v1/vulnerable-assets`
- normalize vulnerable asset host/IP/integration/vulnerability/package attributes
- project vulnerable assets into GRC target, internet host/IP, integration, package, and canonical vulnerability graph links

## Testing
- `go test ./internal/sourceprojection ./sources/grc -count=1`
- `make verify`