### PR TITLE
feat(cosmo): support message runtime pagination

### DIFF
--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -186,28 +186,29 @@ func (s *Source) messageFamily() sourcecdk.Family[settings] {
 	return sourcecdk.Family[settings]{
 		Name: familyMessage,
 		Check: func(ctx context.Context, settings settings) error {
-			_, err := s.listMessages(ctx, settings, 1)
+			_, _, err := s.listMessages(ctx, settings, 0, 1)
 			if err != nil {
 				return fmt.Errorf("cosmo message: %w", err)
 			}
 			return nil
 		},
 		Discover: func(ctx context.Context, settings settings) ([]sourcecdk.URN, error) {
-			records, err := s.listMessages(ctx, settings, settings.perPage)
+			records, _, err := s.listMessages(ctx, settings, 0, settings.perPage)
 			if err != nil {
 				return nil, fmt.Errorf("cosmo message: %w", err)
 			}
 			return urnsFor(settings, familyMessage, records)
 		},
 		Read: func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-			if _, err := readOffset(cursor); err != nil {
+			offset, err := readOffset(cursor)
+			if err != nil {
 				return sourcecdk.Pull{}, err
 			}
-			records, err := s.listMessages(ctx, settings, settings.perPage)
+			records, next, err := s.listMessages(ctx, settings, offset, settings.perPage)
 			if err != nil {
 				return sourcecdk.Pull{}, fmt.Errorf("cosmo message: %w", err)
 			}
-			return pullFromRecords(settings, familyMessage, records, "")
+			return pullFromRecords(settings, familyMessage, records, next)
 		},
 	}
 }
@@ -315,9 +316,6 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 			return settings, fmt.Errorf("cosmo user, status, ticket_id, and event_type are not supported when family=%q", familyFact)
 		}
 	case familyMessage:
-		if settings.ticketID == "" {
-			return settings, fmt.Errorf("cosmo ticket_id is required when family=%q", familyMessage)
-		}
 		if settings.query != "" || settings.user != "" || settings.status != "" || settings.category != "" {
 			return settings, fmt.Errorf("cosmo q, user, status, and category are not supported when family=%q", familyMessage)
 		}
@@ -378,17 +376,26 @@ func (s *Source) listMemory(ctx context.Context, settings settings, path string,
 	return records, next, nil
 }
 
-func (s *Source) listMessages(ctx context.Context, settings settings, limit int) ([]record, error) {
+func (s *Source) listMessages(ctx context.Context, settings settings, offset int, limit int) ([]record, string, error) {
 	query := url.Values{}
-	query.Set("ticket_id", settings.ticketID)
 	query.Set("limit", strconv.Itoa(limit))
+	query.Set("offset", strconv.Itoa(offset))
+	addQuery(query, "ticket_id", settings.ticketID)
 	addQuery(query, "event_type", settings.eventType)
 
 	var response listResponse
 	if err := s.getJSON(ctx, settings, http.MethodGet, "/api/ui/memory/messages", query, nil, &response); err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return responseRecords(response, "messages", familyMessage)
+	records, err := responseRecords(response, "messages", familyMessage)
+	if err != nil {
+		return nil, "", err
+	}
+	next := ""
+	if len(records) == limit {
+		next = strconv.Itoa(offset + limit)
+	}
+	return records, next, nil
 }
 
 func (s *Source) listSurveyFeedback(ctx context.Context, settings settings) ([]record, error) {

--- a/sources/cosmo/source_test.go
+++ b/sources/cosmo/source_test.go
@@ -130,30 +130,14 @@ func TestReadSessionsPaginatesAndMapsAttributes(t *testing.T) {
 	}
 }
 
-func TestReadMessagesRequiresTicketID(t *testing.T) {
-	source, err := New()
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
-	_, err = source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
-		"tenant_id": "writer",
-		"base_url":  "https://cosmo.example.com",
-		"token":     "gh-token",
-		"family":    "message",
-	}), nil)
-	if err == nil {
-		t.Fatal("Read() error = nil, want ticket_id validation error")
-	}
-}
-
-func TestReadMessagesUsesConfiguredPageSizeWithoutLocalCursor(t *testing.T) {
+func TestReadMessagesPaginatesWithOptionalTicketID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/ui/memory/messages" {
 			http.NotFound(w, r)
 			return
 		}
-		if got := r.URL.Query().Get("ticket_id"); got != "COSMO-1" {
-			t.Fatalf("ticket_id = %q, want COSMO-1", got)
+		if got := r.URL.Query().Get("ticket_id"); got != "" {
+			t.Fatalf("ticket_id = %q, want empty", got)
 		}
 		if got := r.URL.Query().Get("event_type"); got != "message" {
 			t.Fatalf("event_type = %q, want message", got)
@@ -161,16 +145,23 @@ func TestReadMessagesUsesConfiguredPageSizeWithoutLocalCursor(t *testing.T) {
 		if got := r.URL.Query().Get("limit"); got != "1" {
 			t.Fatalf("limit = %q, want 1", got)
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 1, "messages": []map[string]any{
-			{
-				"id":         10,
-				"ticket_id":  "COSMO-1",
-				"event_type": "message",
-				"role":       "assistant",
-				"summary":    "Investigated issue",
-				"created_at": "2026-05-12T12:00:00Z",
-			},
-		}})
+		switch offset := r.URL.Query().Get("offset"); offset {
+		case "0":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 1, "messages": []map[string]any{
+				{
+					"id":         10,
+					"ticket_id":  "COSMO-1",
+					"event_type": "message",
+					"role":       "assistant",
+					"summary":    "Investigated issue",
+					"created_at": "2026-05-12T12:00:00Z",
+				},
+			}})
+		case "1":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 0, "messages": []map[string]any{}})
+		default:
+			t.Fatalf("offset = %q, want 0 or 1", offset)
+		}
 	}))
 	defer server.Close()
 
@@ -184,7 +175,6 @@ func TestReadMessagesUsesConfiguredPageSizeWithoutLocalCursor(t *testing.T) {
 		"base_url":   server.URL,
 		"token":      "gh-token",
 		"family":     "message",
-		"ticket_id":  "COSMO-1",
 		"event_type": "message",
 		"per_page":   "1",
 	})
@@ -195,11 +185,21 @@ func TestReadMessagesUsesConfiguredPageSizeWithoutLocalCursor(t *testing.T) {
 	if len(first.Events) != 1 {
 		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
 	}
-	if first.NextCursor != nil {
-		t.Fatalf("NextCursor = %#v, want nil", first.NextCursor)
+	if got := first.NextCursor.GetOpaque(); got != "1" {
+		t.Fatalf("NextCursor = %q, want 1", got)
 	}
 	if got := first.Events[0].Attributes["role"]; got != "assistant" {
 		t.Fatalf("role = %q, want assistant", got)
+	}
+	second, err := source.Read(context.Background(), cfg, first.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if len(second.Events) != 0 {
+		t.Fatalf("len(second.Events) = %d, want 0", len(second.Events))
+	}
+	if second.NextCursor != nil {
+		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow Cosmo message reads without a ticket_id so runtime config can ingest all messages
- pass offset/limit to Cosmo and preserve cursor pagination for message events
- update tests for optional ticket_id pagination

## Dependency
Requires WriterInternal/cosmo PR for offset-capable all-message export before the message runtime is enabled.

## Tests
- go test ./sources/cosmo ./internal/sourceregistry -count=1 -v
- pre-push verify hook passed