### PR TITLE
feat(cosmo): support token-based survey feedback

### DIFF
--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -295,8 +295,11 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 		settings.perPage = perPage
 	}
 	if settings.family == familySurveyFeedback {
-		if settings.webhookSecret == "" {
-			return settings, fmt.Errorf("cosmo webhook_secret is required when family=%q", familySurveyFeedback)
+		if settings.token == "" && settings.webhookSecret == "" {
+			return settings, fmt.Errorf("cosmo token or webhook_secret is required when family=%q", familySurveyFeedback)
+		}
+		if settings.token != "" && settings.webhookSecret != "" {
+			return settings, fmt.Errorf("cosmo token and webhook_secret are mutually exclusive when family=%q", familySurveyFeedback)
 		}
 		return settings, nil
 	}
@@ -400,8 +403,14 @@ func (s *Source) listMessages(ctx context.Context, settings settings, offset int
 
 func (s *Source) listSurveyFeedback(ctx context.Context, settings settings) ([]record, error) {
 	var response listResponse
-	if err := s.getJSON(ctx, settings, http.MethodPost, "/api/survey-results", nil, []byte("{}"), &response); err != nil {
-		return nil, err
+	if settings.token != "" {
+		if err := s.getJSON(ctx, settings, http.MethodGet, "/api/ui/memory/survey-results", nil, nil, &response); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := s.getJSON(ctx, settings, http.MethodPost, "/api/survey-results", nil, []byte("{}"), &response); err != nil {
+			return nil, err
+		}
 	}
 	return responseRecords(response, "feedback", familySurveyFeedback)
 }
@@ -423,7 +432,7 @@ func (s *Source) getJSON(ctx context.Context, settings settings, method string, 
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	if settings.family == familySurveyFeedback {
+	if settings.family == familySurveyFeedback && settings.webhookSecret != "" {
 		req.Header.Set("X-Webhook-Secret", settings.webhookSecret)
 	} else {
 		req.Header.Set("Authorization", "Bearer "+settings.token)

--- a/sources/cosmo/source_test.go
+++ b/sources/cosmo/source_test.go
@@ -270,3 +270,49 @@ func TestReadSurveyFeedbackUsesWebhookSecret(t *testing.T) {
 		t.Fatalf("NextCursor = %q, want 1", got)
 	}
 }
+
+func TestReadSurveyFeedbackCanUseGitHubToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/ui/memory/survey-results" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer gh-token" {
+			t.Fatalf("Authorization = %q, want bearer token", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 1, "feedback": []map[string]any{
+			{
+				"key":        "feedback:C1:1",
+				"ticketId":   "COSMO-1",
+				"sentiment":  "positive",
+				"feedbackAt": "2026-05-12T12:00:00Z",
+			},
+		}})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"family":    "survey_feedback",
+		"token":     "gh-token",
+	})
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+	if got, want := pull.Events[0].Attributes["ticket_id"], "COSMO-1"; got != want {
+		t.Fatalf("ticket_id = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- allow Cosmo survey_feedback to use the GitHub token endpoint
- preserve the legacy webhook_secret endpoint for compatibility
- add unit coverage for token-based survey feedback reads

## Dependency
Requires WriterInternal/cosmo survey feedback memory UI endpoint before internal config switches survey_feedback to token auth.

## Tests
- go test ./sources/cosmo ./internal/sourceregistry -count=1 -v
- pre-push verify hook passed