### PR TITLE
feat(cosmo): add scoped Cerebro integration

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -3,6 +3,9 @@ package bootstrap
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -1491,6 +1494,260 @@ func TestAuthMiddlewareProtectsNonPublicRoutes(t *testing.T) {
 	if authResp.StatusCode != http.StatusOK {
 		t.Fatalf("GET /sources with auth status = %d, want %d", authResp.StatusCode, http.StatusOK)
 	}
+}
+
+func TestScopedCosmoCredentialAllowsOnlyReadRoutes(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APICredentials: []config.APICredential{{
+				Key:       "scoped-token",
+				Principal: "cosmo-security",
+				TenantID:  "writer",
+				Scopes:    []string{scopeCosmoSecurityRead},
+			}},
+		},
+	}
+	graph := &stubGraphStore{
+		entities: map[string]*ports.ProjectedEntity{
+			"urn:cerebro:writer:asset:app": {
+				URN:        "urn:cerebro:writer:asset:app",
+				TenantID:   "writer",
+				SourceID:   "aws",
+				EntityType: "asset",
+				Label:      "app",
+			},
+		},
+	}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
+		},
+	}
+	app := New(cfg, Dependencies{GraphStore: graph, StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	for _, path := range []string{
+		"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app",
+		"/source-runtimes/writer-runtime",
+	} {
+		req, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
+		if err != nil {
+			t.Fatalf("NewRequest(%s): %v", path, err)
+		}
+		req.Header.Set("Authorization", "Bearer scoped-token")
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			t.Fatalf("GET %s error = %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s status = %d, want %d", path, resp.StatusCode, http.StatusOK)
+		}
+	}
+
+	otherTenantReq, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:other:asset:app", nil)
+	if err != nil {
+		t.Fatalf("NewRequest other tenant: %v", err)
+	}
+	otherTenantReq.Header.Set("Authorization", "Bearer scoped-token")
+	otherTenantResp, err := server.Client().Do(otherTenantReq)
+	if err != nil {
+		t.Fatalf("GET other tenant graph error = %v", err)
+	}
+	_ = otherTenantResp.Body.Close()
+	if otherTenantResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("GET other tenant graph status = %d, want %d", otherTenantResp.StatusCode, http.StatusForbidden)
+	}
+
+	for _, tt := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodPost, path: "/source-runtimes/writer-runtime/sync"},
+		{method: http.MethodGet, path: "/sources/github/read"},
+	} {
+		req, err := http.NewRequest(tt.method, server.URL+tt.path, nil)
+		if err != nil {
+			t.Fatalf("NewRequest(%s %s): %v", tt.method, tt.path, err)
+		}
+		req.Header.Set("Authorization", "Bearer scoped-token")
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			t.Fatalf("%s %s error = %v", tt.method, tt.path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("%s %s status = %d, want %d", tt.method, tt.path, resp.StatusCode, http.StatusForbidden)
+		}
+	}
+}
+
+func TestScopedCosmoCredentialEnforcesConnectProcedures(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APICredentials: []config.APICredential{{
+				Key:       "scoped-token",
+				Principal: "cosmo-security",
+				TenantID:  "writer",
+				Scopes:    []string{scopeCosmoSecurityRead},
+			}},
+		},
+	}
+	graph := &stubGraphStore{
+		entities: map[string]*ports.ProjectedEntity{
+			"urn:cerebro:writer:asset:app": {
+				URN:        "urn:cerebro:writer:asset:app",
+				TenantID:   "writer",
+				SourceID:   "aws",
+				EntityType: "asset",
+				Label:      "app",
+			},
+		},
+	}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
+		},
+	}
+	app := New(cfg, Dependencies{GraphStore: graph, StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	readReq := connect.NewRequest(&cerebrov1.GetEntityNeighborhoodRequest{
+		RootUrn: "urn:cerebro:writer:asset:app",
+	})
+	readReq.Header().Set("Authorization", "Bearer scoped-token")
+	if _, err := client.GetEntityNeighborhood(context.Background(), readReq); err != nil {
+		t.Fatalf("GetEntityNeighborhood() error = %v", err)
+	}
+
+	syncReq := connect.NewRequest(&cerebrov1.SyncSourceRuntimeRequest{Id: "writer-runtime"})
+	syncReq.Header().Set("Authorization", "Bearer scoped-token")
+	if _, err := client.SyncSourceRuntime(context.Background(), syncReq); connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("SyncSourceRuntime() code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodePermissionDenied, err)
+	}
+}
+
+func TestCapabilityTokenRequiresSecurityGroup(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled:                 true,
+			CapabilityTokenSecrets:  []string{"capability-secret"},
+			CapabilityTokenAudience: "cerebro-api",
+		},
+	}
+	graph := &stubGraphStore{
+		entities: map[string]*ports.ProjectedEntity{
+			"urn:cerebro:writer:asset:app": {
+				URN:        "urn:cerebro:writer:asset:app",
+				TenantID:   "writer",
+				SourceID:   "aws",
+				EntityType: "asset",
+				Label:      "app",
+			},
+		},
+	}
+	app := New(cfg, Dependencies{GraphStore: graph}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	authorizedToken := signCapabilityToken(t, "capability-secret", map[string]any{
+		"aud":           "cerebro-api",
+		"sub":           "slack:U123",
+		"exp":           time.Now().Add(time.Hour).Unix(),
+		"iat":           time.Now().Add(-time.Minute).Unix(),
+		"tenant_id":     "writer",
+		"scopes":        []string{scopeCosmoSecurityRead},
+		"groups":        []string{"security"},
+		"client_id":     "cosmo",
+		"credential_id": "cosmo-capability",
+	})
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app", nil)
+	if err != nil {
+		t.Fatalf("NewRequest authorized: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+authorizedToken)
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET with authorized capability error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET with authorized capability status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	nonSecurityToken := signCapabilityToken(t, "capability-secret", map[string]any{
+		"aud":       "cerebro-api",
+		"sub":       "slack:U999",
+		"exp":       time.Now().Add(time.Hour).Unix(),
+		"tenant_id": "writer",
+		"scopes":    []string{scopeCosmoSecurityRead},
+		"groups":    []string{"engineering"},
+	})
+	forbiddenReq, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app", nil)
+	if err != nil {
+		t.Fatalf("NewRequest forbidden: %v", err)
+	}
+	forbiddenReq.Header.Set("Authorization", "Bearer "+nonSecurityToken)
+	forbiddenResp, err := server.Client().Do(forbiddenReq)
+	if err != nil {
+		t.Fatalf("GET with non-security capability error = %v", err)
+	}
+	_ = forbiddenResp.Body.Close()
+	if forbiddenResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("GET with non-security capability status = %d, want %d", forbiddenResp.StatusCode, http.StatusForbidden)
+	}
+
+	expiredToken := signCapabilityToken(t, "capability-secret", map[string]any{
+		"aud":       "cerebro-api",
+		"sub":       "slack:U123",
+		"exp":       time.Now().Add(-time.Minute).Unix(),
+		"tenant_id": "writer",
+		"scopes":    []string{scopeCosmoSecurityRead},
+		"groups":    []string{"security"},
+	})
+	expiredReq, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app", nil)
+	if err != nil {
+		t.Fatalf("NewRequest expired: %v", err)
+	}
+	expiredReq.Header.Set("Authorization", "Bearer "+expiredToken)
+	expiredResp, err := server.Client().Do(expiredReq)
+	if err != nil {
+		t.Fatalf("GET with expired capability error = %v", err)
+	}
+	_ = expiredResp.Body.Close()
+	if expiredResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("GET with expired capability status = %d, want %d", expiredResp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func signCapabilityToken(t *testing.T, secret string, claims map[string]any) string {
+	t.Helper()
+	header, err := json.Marshal(map[string]string{"alg": "HS256", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("marshal token header: %v", err)
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal token claims: %v", err)
+	}
+	encodedHeader := base64.RawURLEncoding.EncodeToString(header)
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+	signingInput := encodedHeader + "." + encodedPayload
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(signingInput))
+	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return signingInput + "." + signature
 }
 
 func TestAuthMiddlewareEnforcesTenantOnHTTPProtoBodies(t *testing.T) {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1526,11 +1526,16 @@ func TestScopedCosmoCredentialAllowsOnlyReadRoutes(t *testing.T) {
 			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
 		},
 	}
-	app := New(cfg, Dependencies{GraphStore: graph, StateStore: store}, nil)
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	app := New(cfg, Dependencies{GraphStore: graph, StateStore: store}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
 	for _, path := range []string{
+		"/sources",
 		"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app",
 		"/source-runtimes/writer-runtime",
 	} {
@@ -1616,11 +1621,25 @@ func TestScopedCosmoCredentialEnforcesConnectProcedures(t *testing.T) {
 			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
 		},
 	}
-	app := New(cfg, Dependencies{GraphStore: graph, StateStore: store}, nil)
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	app := New(cfg, Dependencies{GraphStore: graph, StateStore: store}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	listSourcesReq := connect.NewRequest(&cerebrov1.ListSourcesRequest{})
+	listSourcesReq.Header().Set("Authorization", "Bearer scoped-token")
+	listSourcesResp, err := client.ListSources(context.Background(), listSourcesReq)
+	if err != nil {
+		t.Fatalf("ListSources() error = %v", err)
+	}
+	if len(listSourcesResp.Msg.GetSources()) == 0 {
+		t.Fatal("ListSources() returned no sources, want source catalog")
+	}
+
 	readReq := connect.NewRequest(&cerebrov1.GetEntityNeighborhoodRequest{
 		RootUrn: "urn:cerebro:writer:asset:app",
 	})
@@ -1728,6 +1747,27 @@ func TestCapabilityTokenRequiresSecurityGroup(t *testing.T) {
 	_ = expiredResp.Body.Close()
 	if expiredResp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("GET with expired capability status = %d, want %d", expiredResp.StatusCode, http.StatusUnauthorized)
+	}
+
+	noScopesToken := signCapabilityToken(t, "capability-secret", map[string]any{
+		"aud":       "cerebro-api",
+		"sub":       "slack:U123",
+		"exp":       time.Now().Add(time.Hour).Unix(),
+		"tenant_id": "writer",
+		"groups":    []string{"security"},
+	})
+	noScopesReq, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app", nil)
+	if err != nil {
+		t.Fatalf("NewRequest no scopes: %v", err)
+	}
+	noScopesReq.Header.Set("Authorization", "Bearer "+noScopesToken)
+	noScopesResp, err := server.Client().Do(noScopesReq)
+	if err != nil {
+		t.Fatalf("GET with no-scope capability error = %v", err)
+	}
+	_ = noScopesResp.Body.Close()
+	if noScopesResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("GET with no-scope capability status = %d, want %d", noScopesResp.StatusCode, http.StatusUnauthorized)
 	}
 }
 
@@ -1915,6 +1955,72 @@ func TestListSourceRuntimesRequiresTenantFilterWithAllowedTenantAuth(t *testing.
 	}
 	if got := len(payload["runtimes"]); got != 1 {
 		t.Fatalf("listed runtime count = %d, want 1", got)
+	}
+}
+
+func TestListSourceRuntimesRequiresTenantFilterWithPrincipalAllowedTenants(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APICredentials: []config.APICredential{{
+				Key:            "allowed-token",
+				Principal:      "cosmo-security",
+				AllowedTenants: []string{"writer"},
+			}},
+		},
+	}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
+			"other-runtime":  {Id: "other-runtime", SourceId: "github", TenantId: "other"},
+		},
+	}
+	app := New(cfg, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes", nil)
+	if err != nil {
+		t.Fatalf("NewRequest without tenant: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer allowed-token")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes without tenant error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("GET /source-runtimes without tenant status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	scopedReq, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes?tenant_id=writer", nil)
+	if err != nil {
+		t.Fatalf("NewRequest with tenant: %v", err)
+	}
+	scopedReq.Header.Set("Authorization", "Bearer allowed-token")
+	scopedResp, err := server.Client().Do(scopedReq)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes with tenant error = %v", err)
+	}
+	defer func() {
+		if closeErr := scopedResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close scoped response body: %v", closeErr)
+		}
+	}()
+	if scopedResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /source-runtimes with tenant status = %d, want %d", scopedResp.StatusCode, http.StatusOK)
+	}
+	var payload map[string][]map[string]any
+	if err := json.NewDecoder(scopedResp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode source runtime list: %v", err)
+	}
+	if got := len(payload["runtimes"]); got != 1 {
+		t.Fatalf("listed runtime count = %d, want 1", got)
+	}
+	if got := payload["runtimes"][0]["id"]; got != "writer-runtime" {
+		t.Fatalf("listed runtime id = %v, want writer-runtime", got)
 	}
 }
 

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -2,27 +2,40 @@ package bootstrap
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
+	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
 var errTenantForbidden = errors.New("tenant forbidden")
+var errScopeForbidden = errors.New("scope forbidden")
 
 type authContextKey struct{}
 
 type authPrincipal struct {
-	Name     string
-	TenantID string
+	Name           string
+	TenantID       string
+	CredentialID   string
+	ClientID       string
+	AllowedTenants []string
+	Scopes         []string
+	Groups         []string
+	Capability     bool
 }
 
 type authContext struct {
@@ -48,7 +61,12 @@ func authMiddleware(cfg config.AuthConfig, next http.Handler) http.Handler {
 			writeAuthError(w, http.StatusForbidden, "tenant forbidden")
 			return
 		}
-		ctx := context.WithValue(r.Context(), authContextKey{}, authContext{cfg: cfg, principal: principal})
+		auth := authContext{cfg: cfg, principal: principal}
+		if err := authorizeHTTPRequestScope(auth, r); err != nil {
+			writeAuthError(w, http.StatusForbidden, "scope forbidden")
+			return
+		}
+		ctx := context.WithValue(r.Context(), authContextKey{}, auth)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
@@ -57,6 +75,9 @@ func authInterceptor(cfg config.AuthConfig) connect.Interceptor {
 	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			if cfg.Enabled {
+				if err := authorizeConnectProcedureScope(ctx, req.Spec().Procedure); err != nil {
+					return nil, connect.NewError(connect.CodePermissionDenied, nil)
+				}
 				if err := authorizeProtoTenant(ctx, cfg, req.Any()); err != nil {
 					return nil, err
 				}
@@ -88,7 +109,33 @@ func authenticateRequest(cfg config.AuthConfig, r *http.Request) (authPrincipal,
 			return authPrincipal{Name: key.Principal, TenantID: key.TenantID}, true
 		}
 	}
+	for _, credential := range cfg.APICredentials {
+		if apiCredentialMatches(token, credential) {
+			return authPrincipal{
+				Name:           credential.Principal,
+				TenantID:       credential.TenantID,
+				CredentialID:   credential.ID,
+				ClientID:       credential.ClientID,
+				AllowedTenants: credential.AllowedTenants,
+				Scopes:         credential.Scopes,
+			}, true
+		}
+	}
+	if principal, ok := authenticateCapabilityToken(cfg, token, time.Now()); ok {
+		return principal, true
+	}
 	return authPrincipal{}, false
+}
+
+func apiCredentialMatches(token string, credential config.APICredential) bool {
+	if credential.Key != "" && constantTimeEqual(token, credential.Key) {
+		return true
+	}
+	if credential.KeySHA256 == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(token))
+	return constantTimeEqual(hex.EncodeToString(sum[:]), strings.ToLower(credential.KeySHA256))
 }
 
 func bearerToken(header string) string {
@@ -104,6 +151,93 @@ func constantTimeEqual(a string, b string) bool {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+func authenticateCapabilityToken(cfg config.AuthConfig, token string, now time.Time) (authPrincipal, bool) {
+	if len(cfg.CapabilityTokenSecrets) == 0 || strings.Count(token, ".") != 2 {
+		return authPrincipal{}, false
+	}
+	parts := strings.Split(token, ".")
+	signingInput := parts[0] + "." + parts[1]
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return authPrincipal{}, false
+	}
+	if !validCapabilitySignature([]byte(signingInput), signature, cfg.CapabilityTokenSecrets) {
+		return authPrincipal{}, false
+	}
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return authPrincipal{}, false
+	}
+	var header struct {
+		Algorithm string `json:"alg"`
+		Type      string `json:"typ"`
+	}
+	if err := json.Unmarshal(headerBytes, &header); err != nil || header.Algorithm != "HS256" {
+		return authPrincipal{}, false
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return authPrincipal{}, false
+	}
+	var claims capabilityClaims
+	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
+		return authPrincipal{}, false
+	}
+	if claims.ExpiresAt <= 0 || !now.Before(time.Unix(claims.ExpiresAt, 0)) {
+		return authPrincipal{}, false
+	}
+	if claims.IssuedAt > 0 && now.Add(5*time.Minute).Before(time.Unix(claims.IssuedAt, 0)) {
+		return authPrincipal{}, false
+	}
+	if cfg.CapabilityTokenAudience != "" && strings.TrimSpace(claims.Audience) != cfg.CapabilityTokenAudience {
+		return authPrincipal{}, false
+	}
+	scopes := normalizeAuthList(claims.Scopes)
+	allowedTenants := normalizeAuthList(claims.AllowedTenants)
+	tenantID := strings.TrimSpace(claims.TenantID)
+	if len(scopes) > 0 && tenantID == "" && len(allowedTenants) == 0 {
+		return authPrincipal{}, false
+	}
+	return authPrincipal{
+		Name:           strings.TrimSpace(claims.Subject),
+		TenantID:       tenantID,
+		CredentialID:   strings.TrimSpace(claims.CredentialID),
+		ClientID:       strings.TrimSpace(claims.ClientID),
+		AllowedTenants: allowedTenants,
+		Scopes:         scopes,
+		Groups:         normalizeAuthList(claims.Groups),
+		Capability:     true,
+	}, true
+}
+
+type capabilityClaims struct {
+	Audience       string   `json:"aud"`
+	Subject        string   `json:"sub"`
+	ExpiresAt      int64    `json:"exp"`
+	IssuedAt       int64    `json:"iat,omitempty"`
+	CredentialID   string   `json:"credential_id,omitempty"`
+	ClientID       string   `json:"client_id,omitempty"`
+	TenantID       string   `json:"tenant_id,omitempty"`
+	AllowedTenants []string `json:"allowed_tenants,omitempty"`
+	Scopes         []string `json:"scopes,omitempty"`
+	Groups         []string `json:"groups,omitempty"`
+}
+
+func validCapabilitySignature(signingInput []byte, signature []byte, secrets []string) bool {
+	for _, secret := range secrets {
+		secret = strings.TrimSpace(secret)
+		if secret == "" {
+			continue
+		}
+		mac := hmac.New(sha256.New, []byte(secret))
+		_, _ = mac.Write(signingInput)
+		if hmac.Equal(signature, mac.Sum(nil)) {
+			return true
+		}
+	}
+	return false
 }
 
 func requestTenantHint(r *http.Request) string {
@@ -177,6 +311,100 @@ func authorizeTenantID(ctx context.Context, tenantID string) error {
 	return nil
 }
 
+const scopeCosmoSecurityRead = "cerebro.cosmo.security.read"
+
+func authorizeHTTPRequestScope(auth authContext, r *http.Request) error {
+	if !principalScopeRestricted(auth.principal) || isConnectProcedurePath(r.URL.Path) {
+		return nil
+	}
+	scope := scopeForHTTPRequest(r)
+	return authorizePrincipalScope(auth.principal, scope)
+}
+
+func authorizeConnectProcedureScope(ctx context.Context, procedure string) error {
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	if !ok || !principalScopeRestricted(auth.principal) {
+		return nil
+	}
+	return authorizePrincipalScope(auth.principal, scopeForConnectProcedure(procedure))
+}
+
+func authorizePrincipalScope(principal authPrincipal, required string) error {
+	if required == "" || !containsAuthValue(principal.Scopes, required) {
+		return errScopeForbidden
+	}
+	if required == scopeCosmoSecurityRead && principal.Capability && !containsAuthValue(principal.Groups, "security") {
+		return errScopeForbidden
+	}
+	return nil
+}
+
+func principalScopeRestricted(principal authPrincipal) bool {
+	return len(principal.Scopes) > 0
+}
+
+func isConnectProcedurePath(path string) bool {
+	return strings.HasPrefix(path, "/cerebro.v1.BootstrapService/")
+}
+
+func scopeForHTTPRequest(r *http.Request) string {
+	if r.Method != http.MethodGet {
+		return ""
+	}
+	path := strings.TrimSpace(r.URL.Path)
+	switch {
+	case path == "/reports", path == "/finding-rules":
+		return scopeCosmoSecurityRead
+	case path == "/source-runtimes" || strings.HasPrefix(path, "/source-runtimes/"):
+		return scopeCosmoSecurityRead
+	case strings.HasPrefix(path, "/findings/"):
+		return scopeCosmoSecurityRead
+	case strings.HasPrefix(path, "/finding-evaluation-runs/"), strings.HasPrefix(path, "/finding-evidence/"):
+		return scopeCosmoSecurityRead
+	case strings.HasPrefix(path, "/grc/"):
+		return scopeCosmoSecurityRead
+	case path == "/platform/graph/neighborhood", path == "/graph/neighborhood":
+		return scopeCosmoSecurityRead
+	case strings.HasPrefix(path, "/platform/graph/impact/"), strings.HasPrefix(path, "/graph/impact/"):
+		return scopeCosmoSecurityRead
+	case path == "/platform/graph/aws-public-endpoint-insights":
+		return scopeCosmoSecurityRead
+	case path == "/platform/graph/ingest-health", path == "/graph/ingest-health":
+		return scopeCosmoSecurityRead
+	case path == "/platform/graph/ingest-runs", strings.HasPrefix(path, "/platform/graph/ingest-runs/"):
+		return scopeCosmoSecurityRead
+	case path == "/graph/ingest-runs", strings.HasPrefix(path, "/graph/ingest-runs/"):
+		return scopeCosmoSecurityRead
+	case strings.HasPrefix(path, "/report-runs/"):
+		return scopeCosmoSecurityRead
+	default:
+		return ""
+	}
+}
+
+func scopeForConnectProcedure(procedure string) string {
+	switch procedure {
+	case cerebrov1connect.BootstrapServiceListReportDefinitionsProcedure,
+		cerebrov1connect.BootstrapServiceListFindingRulesProcedure,
+		cerebrov1connect.BootstrapServiceGetReportRunProcedure,
+		cerebrov1connect.BootstrapServiceGetSourceRuntimeProcedure,
+		cerebrov1connect.BootstrapServiceListClaimsProcedure,
+		cerebrov1connect.BootstrapServiceListFindingsProcedure,
+		cerebrov1connect.BootstrapServiceGetFindingProcedure,
+		cerebrov1connect.BootstrapServiceListFindingEvaluationRunsProcedure,
+		cerebrov1connect.BootstrapServiceGetFindingEvaluationRunProcedure,
+		cerebrov1connect.BootstrapServiceListFindingEvidenceProcedure,
+		cerebrov1connect.BootstrapServiceGetFindingEvidenceProcedure,
+		cerebrov1connect.BootstrapServiceGetEntityNeighborhoodProcedure,
+		cerebrov1connect.BootstrapServiceGetGraphIngestRunProcedure,
+		cerebrov1connect.BootstrapServiceListGraphIngestRunsProcedure,
+		cerebrov1connect.BootstrapServiceCheckGraphIngestHealthProcedure:
+		return scopeCosmoSecurityRead
+	default:
+		return ""
+	}
+}
+
 func tenantIDFromMetadata(metadata map[string]any) string {
 	if len(metadata) == 0 {
 		return ""
@@ -223,15 +451,40 @@ func tenantAllowed(cfg config.AuthConfig, principal authPrincipal, tenantID stri
 	if principal.TenantID != "" {
 		return tenantID == principal.TenantID
 	}
+	if len(principal.AllowedTenants) > 0 {
+		return containsAuthValue(principal.AllowedTenants, tenantID)
+	}
 	if len(cfg.AllowedTenants) == 0 {
 		return true
 	}
-	for _, allowed := range cfg.AllowedTenants {
-		if tenantID == allowed {
+	return containsAuthValue(cfg.AllowedTenants, tenantID)
+}
+
+func containsAuthValue(values []string, target string) bool {
+	target = strings.TrimSpace(target)
+	for _, value := range values {
+		if strings.TrimSpace(value) == target {
 			return true
 		}
 	}
 	return false
+}
+
+func normalizeAuthList(values []string) []string {
+	seen := map[string]struct{}{}
+	var normalized []string
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	return normalized
 }
 
 func protoTenantIDs(message proto.Message) []string {

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -197,7 +197,10 @@ func authenticateCapabilityToken(cfg config.AuthConfig, token string, now time.T
 	scopes := normalizeAuthList(claims.Scopes)
 	allowedTenants := normalizeAuthList(claims.AllowedTenants)
 	tenantID := strings.TrimSpace(claims.TenantID)
-	if len(scopes) > 0 && tenantID == "" && len(allowedTenants) == 0 {
+	if len(scopes) == 0 {
+		return authPrincipal{}, false
+	}
+	if tenantID == "" && len(allowedTenants) == 0 {
 		return authPrincipal{}, false
 	}
 	return authPrincipal{
@@ -353,7 +356,7 @@ func scopeForHTTPRequest(r *http.Request) string {
 	}
 	path := strings.TrimSpace(r.URL.Path)
 	switch {
-	case path == "/reports", path == "/finding-rules":
+	case path == "/sources", path == "/reports", path == "/finding-rules":
 		return scopeCosmoSecurityRead
 	case path == "/source-runtimes" || strings.HasPrefix(path, "/source-runtimes/"):
 		return scopeCosmoSecurityRead
@@ -384,7 +387,8 @@ func scopeForHTTPRequest(r *http.Request) string {
 
 func scopeForConnectProcedure(procedure string) string {
 	switch procedure {
-	case cerebrov1connect.BootstrapServiceListReportDefinitionsProcedure,
+	case cerebrov1connect.BootstrapServiceListSourcesProcedure,
+		cerebrov1connect.BootstrapServiceListReportDefinitionsProcedure,
 		cerebrov1connect.BootstrapServiceListFindingRulesProcedure,
 		cerebrov1connect.BootstrapServiceGetReportRunProcedure,
 		cerebrov1connect.BootstrapServiceGetSourceRuntimeProcedure,
@@ -435,12 +439,12 @@ func hasAuthContext(ctx context.Context) bool {
 
 func hasTenantScopedAuth(ctx context.Context) bool {
 	auth, ok := ctx.Value(authContextKey{}).(authContext)
-	return ok && strings.TrimSpace(auth.principal.TenantID) != ""
+	return ok && (strings.TrimSpace(auth.principal.TenantID) != "" || len(auth.principal.AllowedTenants) > 0)
 }
 
 func requiresTenantFilter(ctx context.Context) bool {
 	auth, ok := ctx.Value(authContextKey{}).(authContext)
-	return ok && strings.TrimSpace(auth.principal.TenantID) == "" && len(auth.cfg.AllowedTenants) > 0
+	return ok && strings.TrimSpace(auth.principal.TenantID) == "" && (len(auth.principal.AllowedTenants) > 0 || len(auth.cfg.AllowedTenants) > 0)
 }
 
 func tenantAllowed(cfg config.AuthConfig, principal authPrincipal, tenantID string) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -60,17 +61,38 @@ type APIKey struct {
 	TenantID  string
 }
 
+// APICredential grants scoped bearer access with stable attribution metadata.
+type APICredential struct {
+	ID             string
+	ClientID       string
+	Name           string
+	Kind           string
+	Key            string
+	KeySHA256      string
+	Principal      string
+	TenantID       string
+	AllowedTenants []string
+	Scopes         []string
+}
+
 // AuthConfig controls optional API authentication and tenant scoping.
 type AuthConfig struct {
-	Enabled        bool
-	APIKeys        []APIKey
-	AllowedTenants []string
+	Enabled                 bool
+	APIKeys                 []APIKey
+	APICredentials          []APICredential
+	CapabilityTokenSecrets  []string
+	CapabilityTokenAudience string
+	AllowedTenants          []string
 }
 
 // Load reads and validates process configuration.
 func Load() (Config, error) {
 	if strings.TrimSpace(os.Getenv("CEREBRO_KUZU_PATH")) != "" {
 		return Config{}, fmt.Errorf("%w; configure Neo4j with CEREBRO_NEO4J_URI, CEREBRO_NEO4J_USERNAME, and CEREBRO_NEO4J_PASSWORD", errLegacyKuzuPath)
+	}
+	apiCredentials, err := parseAPICredentials(os.Getenv("CEREBRO_API_CREDENTIALS_JSON"))
+	if err != nil {
+		return Config{}, err
 	}
 	cfg := Config{
 		HTTPAddr:        strings.TrimSpace(os.Getenv("CEREBRO_HTTP_ADDR")),
@@ -92,8 +114,11 @@ func Load() (Config, error) {
 			Neo4jDatabase: strings.TrimSpace(os.Getenv("CEREBRO_NEO4J_DATABASE")),
 		},
 		Auth: AuthConfig{
-			APIKeys:        parseAPIKeys(os.Getenv("CEREBRO_API_KEYS")),
-			AllowedTenants: parseCSV(os.Getenv("CEREBRO_ALLOWED_TENANTS")),
+			APIKeys:                 parseAPIKeys(os.Getenv("CEREBRO_API_KEYS")),
+			APICredentials:          apiCredentials,
+			CapabilityTokenSecrets:  parseCSV(os.Getenv("CEREBRO_CAPABILITY_TOKEN_SECRETS")),
+			CapabilityTokenAudience: strings.TrimSpace(os.Getenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE")),
+			AllowedTenants:          parseCSV(os.Getenv("CEREBRO_ALLOWED_TENANTS")),
 		},
 	}
 	authEnabled, err := parseBoolEnv("CEREBRO_API_AUTH_ENABLED", false)
@@ -101,6 +126,9 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	cfg.Auth.Enabled = authEnabled
+	if len(cfg.Auth.CapabilityTokenSecrets) > 0 && cfg.Auth.CapabilityTokenAudience == "" {
+		cfg.Auth.CapabilityTokenAudience = "cerebro-api"
+	}
 	if cfg.HTTPAddr == "" {
 		cfg.HTTPAddr = defaultHTTPAddr
 	}
@@ -159,8 +187,8 @@ func Load() (Config, error) {
 	default:
 		return Config{}, fmt.Errorf("unsupported CEREBRO_GRAPH_STORE_DRIVER %q", cfg.GraphStore.Driver)
 	}
-	if cfg.Auth.Enabled && len(cfg.Auth.APIKeys) == 0 {
-		return Config{}, fmt.Errorf("CEREBRO_API_KEYS is required when CEREBRO_API_AUTH_ENABLED=true")
+	if cfg.Auth.Enabled && len(cfg.Auth.APIKeys) == 0 && len(cfg.Auth.APICredentials) == 0 && len(cfg.Auth.CapabilityTokenSecrets) == 0 {
+		return Config{}, fmt.Errorf("CEREBRO_API_KEYS, CEREBRO_API_CREDENTIALS_JSON, or CEREBRO_CAPABILITY_TOKEN_SECRETS is required when CEREBRO_API_AUTH_ENABLED=true")
 	}
 	return cfg, nil
 }
@@ -198,6 +226,10 @@ func parseCSV(raw string) []string {
 	return values
 }
 
+func normalizeStringSlice(values []string) []string {
+	return parseCSV(strings.Join(values, ","))
+}
+
 func parseAPIKeys(raw string) []APIKey {
 	var keys []APIKey
 	for _, item := range strings.Split(raw, ",") {
@@ -215,4 +247,63 @@ func parseAPIKeys(raw string) []APIKey {
 		keys = append(keys, key)
 	}
 	return keys
+}
+
+func parseAPICredentials(raw string) ([]APICredential, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	type credentialJSON struct {
+		ID             string   `json:"id"`
+		CredentialID   string   `json:"credential_id"`
+		ClientID       string   `json:"client_id"`
+		Name           string   `json:"name"`
+		Kind           string   `json:"kind"`
+		Key            string   `json:"key"`
+		KeySHA256      string   `json:"key_sha256"`
+		Principal      string   `json:"principal"`
+		TenantID       string   `json:"tenant_id"`
+		AllowedTenants []string `json:"allowed_tenants"`
+		Scopes         []string `json:"scopes"`
+	}
+	var entries []credentialJSON
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		return nil, fmt.Errorf("parse CEREBRO_API_CREDENTIALS_JSON: %w", err)
+	}
+	credentials := make([]APICredential, 0, len(entries))
+	for index, entry := range entries {
+		credential := APICredential{
+			ID:             strings.TrimSpace(firstNonEmpty(entry.CredentialID, entry.ID)),
+			ClientID:       strings.TrimSpace(entry.ClientID),
+			Name:           strings.TrimSpace(entry.Name),
+			Kind:           strings.TrimSpace(entry.Kind),
+			Key:            strings.TrimSpace(entry.Key),
+			KeySHA256:      strings.ToLower(strings.TrimSpace(entry.KeySHA256)),
+			Principal:      strings.TrimSpace(entry.Principal),
+			TenantID:       strings.TrimSpace(entry.TenantID),
+			AllowedTenants: normalizeStringSlice(entry.AllowedTenants),
+			Scopes:         normalizeStringSlice(entry.Scopes),
+		}
+		if credential.Key == "" && credential.KeySHA256 == "" {
+			return nil, fmt.Errorf("CEREBRO_API_CREDENTIALS_JSON[%d] must set key or key_sha256", index)
+		}
+		if len(credential.Scopes) > 0 && credential.TenantID == "" && len(credential.AllowedTenants) == 0 {
+			return nil, fmt.Errorf("CEREBRO_API_CREDENTIALS_JSON[%d] scoped credentials must set tenant_id or allowed_tenants", index)
+		}
+		if credential.Principal == "" {
+			credential.Principal = firstNonEmpty(credential.Name, credential.ClientID, credential.ID)
+		}
+		credentials = append(credentials, credential)
+	}
+	return credentials, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"testing"
 	"time"
@@ -22,6 +24,9 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "")
 	t.Setenv("CEREBRO_API_KEYS", "")
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", "")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "")
 
 	cfg, err := Load()
@@ -64,6 +69,9 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
 	t.Setenv("CEREBRO_API_KEYS", "token-1:ci:writer,token-2:ops:security")
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", "")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "security,writer,writer")
 
 	cfg, err := Load()
@@ -119,6 +127,9 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "")
 	t.Setenv("CEREBRO_API_KEYS", "")
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", "")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "")
 }
 
@@ -126,6 +137,79 @@ func TestLoadRejectsAuthEnabledWithoutKeys(t *testing.T) {
 	clearDependencyEnv(t)
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
 	t.Setenv("CEREBRO_API_KEYS", "")
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadParsesStructuredAPICredentials(t *testing.T) {
+	clearDependencyEnv(t)
+	sum := sha256.Sum256([]byte("scoped-token"))
+	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", `[
+		{
+			"credential_id": "cred-cosmo-security",
+			"client_id": "cosmo",
+			"name": "Cosmo Security",
+			"kind": "agent",
+			"key_sha256": "`+hex.EncodeToString(sum[:])+`",
+			"principal": "cosmo-security",
+			"allowed_tenants": ["writer", "writer"],
+			"scopes": ["cerebro.cosmo.security.read", "cerebro.cosmo.security.read"]
+		}
+	]`)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(cfg.Auth.APICredentials) != 1 {
+		t.Fatalf("Auth.APICredentials length = %d, want 1", len(cfg.Auth.APICredentials))
+	}
+	credential := cfg.Auth.APICredentials[0]
+	if credential.ID != "cred-cosmo-security" || credential.ClientID != "cosmo" || credential.Principal != "cosmo-security" {
+		t.Fatalf("credential attribution = %#v", credential)
+	}
+	if got := credential.AllowedTenants; len(got) != 1 || got[0] != "writer" {
+		t.Fatalf("AllowedTenants = %#v, want [writer]", got)
+	}
+	if got := credential.Scopes; len(got) != 1 || got[0] != "cerebro.cosmo.security.read" {
+		t.Fatalf("Scopes = %#v, want [cerebro.cosmo.security.read]", got)
+	}
+}
+
+func TestLoadParsesCapabilityTokenConfig(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "secret-1, secret-1, secret-2")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := cfg.Auth.CapabilityTokenSecrets; len(got) != 2 || got[0] != "secret-1" || got[1] != "secret-2" {
+		t.Fatalf("CapabilityTokenSecrets = %#v, want [secret-1 secret-2]", got)
+	}
+	if cfg.Auth.CapabilityTokenAudience != "cerebro-api" {
+		t.Fatalf("CapabilityTokenAudience = %q, want cerebro-api", cfg.Auth.CapabilityTokenAudience)
+	}
+}
+
+func TestLoadRejectsScopedCredentialWithoutTenant(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", `[{"key":"token","scopes":["cerebro.cosmo.security.read"]}]`)
+
+	if _, err := Load(); err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadRejectsMalformedStructuredAPICredentials(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", `{"key":"token"}`)
 
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want non-nil")

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -248,7 +249,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	if err != nil {
 		return nil, err
 	}
-	cursor := cloneCursor(runtime.GetNextCursor())
+	cursor := runtimeStartCursor(runtime)
 	var (
 		eventsAppended    uint32
 		pagesRead         uint32
@@ -658,6 +659,27 @@ func cloneCursor(cursor *cerebrov1.SourceCursor) *cerebrov1.SourceCursor {
 		return nil
 	}
 	return proto.Clone(cursor).(*cerebrov1.SourceCursor)
+}
+
+func runtimeStartCursor(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceCursor {
+	if cursor := cloneCursor(runtime.GetNextCursor()); cursor != nil {
+		return cursor
+	}
+	opaque := strings.TrimSpace(runtime.GetCheckpoint().GetCursorOpaque())
+	if opaque == "" || !resumableCheckpointCursor(opaque) {
+		return nil
+	}
+	return &cerebrov1.SourceCursor{Opaque: opaque}
+}
+
+func resumableCheckpointCursor(opaque string) bool {
+	var payload struct {
+		ResumableCheckpoint bool `json:"resumable_checkpoint"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(opaque)), &payload); err != nil {
+		return false
+	}
+	return payload.ResumableCheckpoint
 }
 
 func cloneCheckpoint(checkpoint *cerebrov1.SourceCheckpoint) *cerebrov1.SourceCheckpoint {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -157,6 +157,27 @@ func (emptyPageSource) Read(_ context.Context, _ sourcecdk.Config, cursor *cereb
 	}, nil
 }
 
+type checkpointResumeSource struct {
+	seenCursor string
+}
+
+func (s *checkpointResumeSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "checkpoint_resume"}
+}
+
+func (s *checkpointResumeSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (s *checkpointResumeSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *checkpointResumeSource) Read(_ context.Context, _ sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	s.seenCursor = cursor.GetOpaque()
+	return sourcecdk.Pull{}, nil
+}
+
 type nilEventSource struct{}
 
 func (nilEventSource) Spec() *cerebrov1.SourceSpec {
@@ -950,6 +971,35 @@ func TestSyncRuntimeContinuesPastEmptyPagesWithCursor(t *testing.T) {
 	}
 	if got := store.runtimes["writer-empty-page"].GetNextCursor(); got != nil {
 		t.Fatalf("stored next cursor = %#v, want nil", got)
+	}
+}
+
+func TestSyncRuntimeStartsFromResumableCheckpointCursor(t *testing.T) {
+	source := &checkpointResumeSource{}
+	registry, err := sourcecdk.NewRegistry(source)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	checkpointCursor := `{"source":"cosmo.message","resumable_checkpoint":true,"since":"2026-05-14T00:00:00Z"}`
+	store := &runtimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-checkpoint": {
+				Id:       "writer-checkpoint",
+				SourceId: "checkpoint_resume",
+				TenantId: "writer",
+				Checkpoint: &cerebrov1.SourceCheckpoint{
+					CursorOpaque: checkpointCursor,
+				},
+			},
+		},
+	}
+	service := New(registry, store, &appendLog{}, nil)
+
+	if _, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-checkpoint"}); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if source.seenCursor != checkpointCursor {
+		t.Fatalf("source cursor = %q, want checkpoint cursor", source.seenCursor)
 	}
 }
 

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -32,10 +32,15 @@ const (
 	httpTimeout     = 30 * time.Second
 	maxBodyBytes    = 8 << 20
 
-	familyFact           = "fact"
-	familyMessage        = "message"
-	familySession        = "session"
-	familySurveyFeedback = "survey_feedback"
+	familyFact                         = "fact"
+	familyMessage                      = "message"
+	familySession                      = "session"
+	familySurveyFeedback               = "survey_feedback"
+	messageExportCursorSource          = "cosmo.message"
+	defaultMessageExportEventTypes     = "message,completion"
+	defaultMessageExportMaxWindowHours = 24
+	messageExportMaxWindowHours        = 24
+	messageExportMaxPageSize           = 100
 )
 
 // Source reads Cosmo memory and feedback data.
@@ -59,7 +64,27 @@ type settings struct {
 	category      string
 	ticketID      string
 	eventType     string
+	clientID      string
+	exportSecret  string
+	eventTypes    []string
+	maxWindow     time.Duration
 	perPage       int
+}
+
+type messageCursor struct {
+	Source              string `json:"source"`
+	ResumableCheckpoint bool   `json:"resumable_checkpoint,omitempty"`
+	Since               string `json:"since"`
+	Until               string `json:"until,omitempty"`
+	EventTypeIndex      int    `json:"event_type_index,omitempty"`
+	Offset              int    `json:"offset,omitempty"`
+}
+
+type messageWindow struct {
+	since          time.Time
+	until          time.Time
+	eventTypeIndex int
+	offset         int
 }
 
 type record struct {
@@ -186,29 +211,48 @@ func (s *Source) messageFamily() sourcecdk.Family[settings] {
 	return sourcecdk.Family[settings]{
 		Name: familyMessage,
 		Check: func(ctx context.Context, settings settings) error {
-			_, _, err := s.listMessages(ctx, settings, 0, 1)
+			window, ok, err := readMessageCursor(settings, nil, time.Now())
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
+			_, err = s.listMessages(ctx, settings, window, 1)
 			if err != nil {
 				return fmt.Errorf("cosmo message: %w", err)
 			}
 			return nil
 		},
 		Discover: func(ctx context.Context, settings settings) ([]sourcecdk.URN, error) {
-			records, _, err := s.listMessages(ctx, settings, 0, settings.perPage)
+			window, ok, err := readMessageCursor(settings, nil, time.Now())
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, nil
+			}
+			records, err := s.listMessages(ctx, settings, window, settings.perPage)
 			if err != nil {
 				return nil, fmt.Errorf("cosmo message: %w", err)
 			}
 			return urnsFor(settings, familyMessage, records)
 		},
 		Read: func(ctx context.Context, settings settings, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
-			offset, err := readOffset(cursor)
+			window, ok, err := readMessageCursor(settings, cursor, time.Now())
 			if err != nil {
 				return sourcecdk.Pull{}, err
 			}
-			records, next, err := s.listMessages(ctx, settings, offset, settings.perPage)
+			if !ok {
+				checkpoint := messageCheckpointCursor(window.since)
+				return messagePullFromRecords(settings, nil, "", checkpoint, window.since)
+			}
+			records, err := s.listMessages(ctx, settings, window, settings.perPage)
 			if err != nil {
 				return sourcecdk.Pull{}, fmt.Errorf("cosmo message: %w", err)
 			}
-			return pullFromRecords(settings, familyMessage, records, next)
+			next, checkpoint := nextMessageCursor(settings, window, len(records), settings.perPage)
+			return messagePullFromRecords(settings, records, next, checkpoint, window.until)
 		},
 	}
 }
@@ -263,6 +307,8 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 		category:      configValue(cfg, "category"),
 		ticketID:      configValue(cfg, "ticket_id"),
 		eventType:     configValue(cfg, "event_type"),
+		clientID:      configValue(cfg, "client_id"),
+		exportSecret:  configValue(cfg, "export_secret"),
 		perPage:       defaultPageSize,
 	}
 	if settings.tenantID == "" {
@@ -322,8 +368,73 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 		if settings.query != "" || settings.user != "" || settings.status != "" || settings.category != "" {
 			return settings, fmt.Errorf("cosmo q, user, status, and category are not supported when family=%q", familyMessage)
 		}
+		if settings.ticketID != "" {
+			return settings, fmt.Errorf("cosmo ticket_id is not supported when family=%q", familyMessage)
+		}
+		if settings.clientID == "" {
+			return settings, fmt.Errorf("cosmo client_id is required when family=%q", familyMessage)
+		}
+		if settings.exportSecret == "" {
+			return settings, fmt.Errorf("cosmo export_secret is required when family=%q", familyMessage)
+		}
+		if settings.perPage > messageExportMaxPageSize {
+			return settings, fmt.Errorf("cosmo per_page must be between 1 and %d when family=%q", messageExportMaxPageSize, familyMessage)
+		}
+		eventTypes, err := parseMessageEventTypes(configValue(cfg, "event_types"), settings.eventType)
+		if err != nil {
+			return settings, err
+		}
+		settings.eventTypes = eventTypes
+		maxWindow, err := parseMessageMaxWindow(configValue(cfg, "max_window_hours"))
+		if err != nil {
+			return settings, err
+		}
+		settings.maxWindow = maxWindow
 	}
 	return settings, nil
+}
+
+func parseMessageEventTypes(raw string, fallback string) ([]string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		value = strings.TrimSpace(fallback)
+	}
+	if value == "" {
+		value = defaultMessageExportEventTypes
+	}
+	seen := map[string]struct{}{}
+	parts := strings.Split(value, ",")
+	eventTypes := make([]string, 0, len(parts))
+	for _, part := range parts {
+		eventType := strings.TrimSpace(part)
+		if eventType == "" {
+			continue
+		}
+		if _, ok := seen[eventType]; ok {
+			continue
+		}
+		seen[eventType] = struct{}{}
+		eventTypes = append(eventTypes, eventType)
+	}
+	if len(eventTypes) == 0 {
+		return nil, fmt.Errorf("cosmo event_types must include at least one value when family=%q", familyMessage)
+	}
+	return eventTypes, nil
+}
+
+func parseMessageMaxWindow(raw string) (time.Duration, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		value = strconv.Itoa(defaultMessageExportMaxWindowHours)
+	}
+	hours, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse cosmo max_window_hours: %w", err)
+	}
+	if hours < 1 || hours > messageExportMaxWindowHours {
+		return 0, fmt.Errorf("cosmo max_window_hours must be between 1 and %d when family=%q", messageExportMaxWindowHours, familyMessage)
+	}
+	return time.Duration(hours) * time.Hour, nil
 }
 
 func normalizeBaseURL(raw string, allowLoopback bool) (string, error) {
@@ -379,26 +490,23 @@ func (s *Source) listMemory(ctx context.Context, settings settings, path string,
 	return records, next, nil
 }
 
-func (s *Source) listMessages(ctx context.Context, settings settings, offset int, limit int) ([]record, string, error) {
+func (s *Source) listMessages(ctx context.Context, settings settings, window messageWindow, limit int) ([]record, error) {
 	query := url.Values{}
 	query.Set("limit", strconv.Itoa(limit))
-	query.Set("offset", strconv.Itoa(offset))
-	addQuery(query, "ticket_id", settings.ticketID)
-	addQuery(query, "event_type", settings.eventType)
+	query.Set("offset", strconv.Itoa(window.offset))
+	query.Set("event_type", settings.eventTypes[window.eventTypeIndex])
+	query.Set("since", window.since.Format(time.RFC3339Nano))
+	query.Set("until", window.until.Format(time.RFC3339Nano))
 
 	var response listResponse
 	if err := s.getJSON(ctx, settings, http.MethodGet, "/api/ui/memory/messages", query, nil, &response); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	records, err := responseRecords(response, "messages", familyMessage)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	next := ""
-	if len(records) == limit {
-		next = strconv.Itoa(offset + limit)
-	}
-	return records, next, nil
+	return records, nil
 }
 
 func (s *Source) listSurveyFeedback(ctx context.Context, settings settings) ([]record, error) {
@@ -436,6 +544,10 @@ func (s *Source) getJSON(ctx context.Context, settings settings, method string, 
 		req.Header.Set("X-Webhook-Secret", settings.webhookSecret)
 	} else {
 		req.Header.Set("Authorization", "Bearer "+settings.token)
+	}
+	if settings.family == familyMessage {
+		req.Header.Set("X-Cosmo-Client", settings.clientID)
+		req.Header.Set("X-Cerebro-Export-Secret", settings.exportSecret)
 	}
 
 	client := s.client
@@ -670,6 +782,126 @@ func readOffset(cursor *cerebrov1.SourceCursor) (int, error) {
 		return 0, fmt.Errorf("cosmo cursor must be non-negative")
 	}
 	return offset, nil
+}
+
+func readMessageCursor(settings settings, cursor *cerebrov1.SourceCursor, now time.Time) (messageWindow, bool, error) {
+	now = now.UTC()
+	if cursor == nil || strings.TrimSpace(cursor.Opaque) == "" {
+		since := now.Add(-settings.maxWindow)
+		return messageWindow{since: since, until: now}, true, nil
+	}
+	var payload messageCursor
+	if err := json.Unmarshal([]byte(strings.TrimSpace(cursor.Opaque)), &payload); err != nil {
+		return messageWindow{}, false, fmt.Errorf("parse cosmo message cursor: %w", err)
+	}
+	if payload.Source != messageExportCursorSource {
+		return messageWindow{}, false, fmt.Errorf("cosmo message cursor source = %q, want %q", payload.Source, messageExportCursorSource)
+	}
+	if payload.EventTypeIndex < 0 || payload.EventTypeIndex >= len(settings.eventTypes) {
+		return messageWindow{}, false, fmt.Errorf("cosmo message cursor event_type_index is out of range")
+	}
+	if payload.Offset < 0 {
+		return messageWindow{}, false, fmt.Errorf("cosmo message cursor offset must be non-negative")
+	}
+	since, ok := parseMessageCursorTime(payload.Since)
+	if !ok {
+		return messageWindow{}, false, fmt.Errorf("cosmo message cursor since must be an ISO timestamp")
+	}
+	eventTypeIndex := payload.EventTypeIndex
+	offset := payload.Offset
+	var until time.Time
+	if strings.TrimSpace(payload.Until) == "" {
+		until = minTime(since.Add(settings.maxWindow), now)
+		eventTypeIndex = 0
+		offset = 0
+	} else {
+		var parsed bool
+		until, parsed = parseMessageCursorTime(payload.Until)
+		if !parsed {
+			return messageWindow{}, false, fmt.Errorf("cosmo message cursor until must be an ISO timestamp")
+		}
+		if until.Sub(since) > settings.maxWindow {
+			return messageWindow{}, false, fmt.Errorf("cosmo message cursor window exceeds max_window_hours")
+		}
+	}
+	window := messageWindow{since: since, until: until, eventTypeIndex: eventTypeIndex, offset: offset}
+	if !until.After(since) {
+		return window, false, nil
+	}
+	return window, true, nil
+}
+
+func parseMessageCursorTime(value string) (time.Time, bool) {
+	parsed, ok := parseTime(value)
+	if !ok {
+		return time.Time{}, false
+	}
+	return parsed.UTC(), true
+}
+
+func nextMessageCursor(settings settings, window messageWindow, records int, limit int) (string, string) {
+	if records == limit {
+		next := encodeMessageCursor(window.since, window.until, window.eventTypeIndex, window.offset+limit)
+		return next, next
+	}
+	if window.eventTypeIndex+1 < len(settings.eventTypes) {
+		next := encodeMessageCursor(window.since, window.until, window.eventTypeIndex+1, 0)
+		return next, next
+	}
+	checkpoint := messageCheckpointCursor(window.until)
+	return "", checkpoint
+}
+
+func messageCheckpointCursor(since time.Time) string {
+	return encodeMessageCursor(since, time.Time{}, 0, 0)
+}
+
+func encodeMessageCursor(since time.Time, until time.Time, eventTypeIndex int, offset int) string {
+	payload := messageCursor{
+		Source:              messageExportCursorSource,
+		ResumableCheckpoint: true,
+		Since:               since.UTC().Format(time.RFC3339Nano),
+		EventTypeIndex:      eventTypeIndex,
+		Offset:              offset,
+	}
+	if !until.IsZero() {
+		payload.Until = until.UTC().Format(time.RFC3339Nano)
+	}
+	encoded, _ := json.Marshal(payload)
+	return string(encoded)
+}
+
+func messagePullFromRecords(settings settings, records []record, next string, checkpoint string, watermark time.Time) (sourcecdk.Pull, error) {
+	pull := sourcecdk.Pull{
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			Watermark:    timestamppb.New(watermark.UTC()),
+			CursorOpaque: strings.TrimSpace(checkpointCursor(next, checkpoint)),
+		},
+	}
+	if strings.TrimSpace(next) != "" {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: strings.TrimSpace(next)}
+	}
+	if len(records) == 0 {
+		return pull, nil
+	}
+	events := make([]*primitives.Event, 0, len(records))
+	for _, record := range records {
+		event, err := eventFromRecord(settings, familyMessage, record)
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		events = append(events, event)
+	}
+	pull.Events = events
+	pull.Checkpoint.Watermark = events[len(events)-1].OccurredAt
+	return pull, nil
+}
+
+func minTime(left time.Time, right time.Time) time.Time {
+	if left.Before(right) {
+		return left
+	}
+	return right
 }
 
 func httpClientNoRedirect(client *http.Client, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -67,6 +67,7 @@ type settings struct {
 	clientID      string
 	exportSecret  string
 	eventTypes    []string
+	initialSince  time.Time
 	maxWindow     time.Duration
 	perPage       int
 }
@@ -232,9 +233,20 @@ func (s *Source) messageFamily() sourcecdk.Family[settings] {
 			if !ok {
 				return nil, nil
 			}
-			records, err := s.listMessages(ctx, settings, window, settings.perPage)
-			if err != nil {
-				return nil, fmt.Errorf("cosmo message: %w", err)
+			records := make([]record, 0, settings.perPage)
+			for eventTypeIndex := range settings.eventTypes {
+				if len(records) >= settings.perPage {
+					break
+				}
+				eventWindow := window
+				eventWindow.eventTypeIndex = eventTypeIndex
+				eventWindow.offset = 0
+				remaining := settings.perPage - len(records)
+				page, err := s.listMessages(ctx, settings, eventWindow, remaining)
+				if err != nil {
+					return nil, fmt.Errorf("cosmo message: %w", err)
+				}
+				records = append(records, page...)
 			}
 			return urnsFor(settings, familyMessage, records)
 		},
@@ -390,6 +402,11 @@ func parseSettings(cfg sourcecdk.Config, allowLoopback bool) (settings, error) {
 			return settings, err
 		}
 		settings.maxWindow = maxWindow
+		initialSince, err := parseMessageInitialSince(configValue(cfg, "since"))
+		if err != nil {
+			return settings, err
+		}
+		settings.initialSince = initialSince
 	}
 	return settings, nil
 }
@@ -435,6 +452,18 @@ func parseMessageMaxWindow(raw string) (time.Duration, error) {
 		return 0, fmt.Errorf("cosmo max_window_hours must be between 1 and %d when family=%q", messageExportMaxWindowHours, familyMessage)
 	}
 	return time.Duration(hours) * time.Hour, nil
+}
+
+func parseMessageInitialSince(raw string) (time.Time, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return time.Unix(0, 0).UTC(), nil
+	}
+	parsed, ok := parseMessageCursorTime(value)
+	if !ok {
+		return time.Time{}, fmt.Errorf("cosmo since must be an ISO timestamp when family=%q", familyMessage)
+	}
+	return parsed, nil
 }
 
 func normalizeBaseURL(raw string, allowLoopback bool) (string, error) {
@@ -787,8 +816,10 @@ func readOffset(cursor *cerebrov1.SourceCursor) (int, error) {
 func readMessageCursor(settings settings, cursor *cerebrov1.SourceCursor, now time.Time) (messageWindow, bool, error) {
 	now = now.UTC()
 	if cursor == nil || strings.TrimSpace(cursor.Opaque) == "" {
-		since := now.Add(-settings.maxWindow)
-		return messageWindow{since: since, until: now}, true, nil
+		since := settings.initialSince
+		until := minTime(since.Add(settings.maxWindow), now)
+		window := messageWindow{since: since, until: until}
+		return window, until.After(since), nil
 	}
 	var payload messageCursor
 	if err := json.Unmarshal([]byte(strings.TrimSpace(cursor.Opaque)), &payload); err != nil {

--- a/sources/cosmo/source_test.go
+++ b/sources/cosmo/source_test.go
@@ -3,10 +3,13 @@ package cosmo
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
@@ -29,6 +32,67 @@ func TestParseSettingsRejectsBaseURLWithPath(t *testing.T) {
 	}), false)
 	if err == nil {
 		t.Fatal("parseSettings() error = nil, want non-nil")
+	}
+}
+
+func TestParseSettingsMessageRequiresScopedExportConfig(t *testing.T) {
+	base := map[string]string{
+		"tenant_id":     "writer",
+		"base_url":      "https://cosmo.example.com",
+		"token":         "token",
+		"family":        "message",
+		"client_id":     "cerebro-runtime",
+		"export_secret": "secret",
+	}
+	for _, tc := range []struct {
+		name string
+		key  string
+	}{
+		{name: "client id", key: "client_id"},
+		{name: "export secret", key: "export_secret"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := cloneMap(base)
+			delete(cfg, tc.key)
+			_, err := parseSettings(sourcecdk.NewConfig(cfg), false)
+			if err == nil {
+				t.Fatal("parseSettings() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestParseSettingsMessageRejectsUnscopedOrUnboundedConfig(t *testing.T) {
+	base := map[string]string{
+		"tenant_id":     "writer",
+		"base_url":      "https://cosmo.example.com",
+		"token":         "token",
+		"family":        "message",
+		"client_id":     "cerebro-runtime",
+		"export_secret": "secret",
+	}
+	for _, tc := range []struct {
+		name string
+		key  string
+		val  string
+	}{
+		{name: "ticket id", key: "ticket_id", val: "COSMO-1"},
+		{name: "page size", key: "per_page", val: "101"},
+		{name: "window", key: "max_window_hours", val: "25"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := cloneMap(base)
+			cfg[tc.key] = tc.val
+			_, err := parseSettings(sourcecdk.NewConfig(cfg), false)
+			if err == nil {
+				t.Fatal("parseSettings() error = nil, want non-nil")
+			}
+		})
+	}
+	cfg := cloneMap(base)
+	cfg["per_page"] = "100"
+	if _, err := parseSettings(sourcecdk.NewConfig(cfg), false); err != nil {
+		t.Fatalf("parseSettings(per_page=100) error = %v", err)
 	}
 }
 
@@ -130,23 +194,60 @@ func TestReadSessionsPaginatesAndMapsAttributes(t *testing.T) {
 	}
 }
 
-func TestReadMessagesPaginatesWithOptionalTicketID(t *testing.T) {
+func TestReadMessagesUsesScopedExportContractAndPaginatesEventTypes(t *testing.T) {
+	var requestCount int
+	var windowSince string
+	var windowUntil string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/ui/memory/messages" {
 			http.NotFound(w, r)
 			return
 		}
+		requestCount++
+		if got := r.Header.Get("Authorization"); got != "Bearer gh-token" {
+			t.Fatalf("Authorization = %q, want bearer token", got)
+		}
+		if got := r.Header.Get("X-Cosmo-Client"); got != "cerebro-runtime" {
+			t.Fatalf("X-Cosmo-Client = %q, want approved client", got)
+		}
+		if got := r.Header.Get("X-Cerebro-Export-Secret"); got != "export-secret" {
+			t.Fatalf("X-Cerebro-Export-Secret set = %t, want true", got != "")
+		}
 		if got := r.URL.Query().Get("ticket_id"); got != "" {
 			t.Fatalf("ticket_id = %q, want empty", got)
-		}
-		if got := r.URL.Query().Get("event_type"); got != "message" {
-			t.Fatalf("event_type = %q, want message", got)
 		}
 		if got := r.URL.Query().Get("limit"); got != "1" {
 			t.Fatalf("limit = %q, want 1", got)
 		}
-		switch offset := r.URL.Query().Get("offset"); offset {
-		case "0":
+		since := r.URL.Query().Get("since")
+		until := r.URL.Query().Get("until")
+		if since == "" || until == "" {
+			t.Fatalf("since=%q until=%q, want bounded export window", since, until)
+		}
+		parsedSince, err := time.Parse(time.RFC3339Nano, since)
+		if err != nil {
+			t.Fatalf("parse since: %v", err)
+		}
+		parsedUntil, err := time.Parse(time.RFC3339Nano, until)
+		if err != nil {
+			t.Fatalf("parse until: %v", err)
+		}
+		if !parsedUntil.After(parsedSince) || parsedUntil.Sub(parsedSince) > time.Hour {
+			t.Fatalf("window = %s..%s, want positive <= 1h", parsedSince, parsedUntil)
+		}
+		if windowSince == "" {
+			windowSince = since
+			windowUntil = until
+		} else if since != windowSince || until != windowUntil {
+			t.Fatalf("window changed: %s..%s, want %s..%s", since, until, windowSince, windowUntil)
+		}
+		eventType := r.URL.Query().Get("event_type")
+		offset := r.URL.Query().Get("offset")
+		switch requestCount {
+		case 1:
+			if eventType != "message" || offset != "0" {
+				t.Fatalf("request 1 event_type=%q offset=%q, want message/0", eventType, offset)
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 1, "messages": []map[string]any{
 				{
 					"id":         10,
@@ -157,10 +258,32 @@ func TestReadMessagesPaginatesWithOptionalTicketID(t *testing.T) {
 					"created_at": "2026-05-12T12:00:00Z",
 				},
 			}})
-		case "1":
+		case 2:
+			if eventType != "message" || offset != "1" {
+				t.Fatalf("request 2 event_type=%q offset=%q, want message/1", eventType, offset)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 0, "messages": []map[string]any{}})
+		case 3:
+			if eventType != "completion" || offset != "0" {
+				t.Fatalf("request 3 event_type=%q offset=%q, want completion/0", eventType, offset)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 1, "messages": []map[string]any{
+				{
+					"id":         11,
+					"ticket_id":  "COSMO-2",
+					"event_type": "completion",
+					"role":       "assistant",
+					"summary":    "Completed issue",
+					"created_at": "2026-05-12T12:01:00Z",
+				},
+			}})
+		case 4:
+			if eventType != "completion" || offset != "1" {
+				t.Fatalf("request 4 event_type=%q offset=%q, want completion/1", eventType, offset)
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 0, "messages": []map[string]any{}})
 		default:
-			t.Fatalf("offset = %q, want 0 or 1", offset)
+			t.Fatalf("unexpected request %d", requestCount)
 		}
 	}))
 	defer server.Close()
@@ -171,12 +294,15 @@ func TestReadMessagesPaginatesWithOptionalTicketID(t *testing.T) {
 	}
 	source.allowLoopbackBaseURL = true
 	cfg := sourcecdk.NewConfig(map[string]string{
-		"tenant_id":  "writer",
-		"base_url":   server.URL,
-		"token":      "gh-token",
-		"family":     "message",
-		"event_type": "message",
-		"per_page":   "1",
+		"tenant_id":        "writer",
+		"base_url":         server.URL,
+		"token":            "gh-token",
+		"family":           "message",
+		"client_id":        "cerebro-runtime",
+		"export_secret":    "export-secret",
+		"event_types":      "message,completion",
+		"max_window_hours": "1",
+		"per_page":         "1",
 	})
 	first, err := source.Read(context.Background(), cfg, nil)
 	if err != nil {
@@ -185,8 +311,9 @@ func TestReadMessagesPaginatesWithOptionalTicketID(t *testing.T) {
 	if len(first.Events) != 1 {
 		t.Fatalf("len(first.Events) = %d, want 1", len(first.Events))
 	}
-	if got := first.NextCursor.GetOpaque(); got != "1" {
-		t.Fatalf("NextCursor = %q, want 1", got)
+	firstCursor := decodeMessageCursor(t, first.NextCursor.GetOpaque())
+	if firstCursor.EventTypeIndex != 0 || firstCursor.Offset != 1 || firstCursor.Until == "" {
+		t.Fatalf("first cursor = %#v, want message offset 1 with fixed window", firstCursor)
 	}
 	if got := first.Events[0].Attributes["role"]; got != "assistant" {
 		t.Fatalf("role = %q, want assistant", got)
@@ -198,8 +325,86 @@ func TestReadMessagesPaginatesWithOptionalTicketID(t *testing.T) {
 	if len(second.Events) != 0 {
 		t.Fatalf("len(second.Events) = %d, want 0", len(second.Events))
 	}
-	if second.NextCursor != nil {
-		t.Fatalf("second.NextCursor = %#v, want nil", second.NextCursor)
+	secondCursor := decodeMessageCursor(t, second.NextCursor.GetOpaque())
+	if secondCursor.EventTypeIndex != 1 || secondCursor.Offset != 0 || secondCursor.Since != windowSince || secondCursor.Until != windowUntil {
+		t.Fatalf("second cursor = %#v, want completion offset 0 in same window", secondCursor)
+	}
+	third, err := source.Read(context.Background(), cfg, second.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(third) error = %v", err)
+	}
+	if len(third.Events) != 1 {
+		t.Fatalf("len(third.Events) = %d, want 1", len(third.Events))
+	}
+	if got := third.Events[0].Attributes["event_type"]; got != "completion" {
+		t.Fatalf("third event_type = %q, want completion", got)
+	}
+	fourth, err := source.Read(context.Background(), cfg, third.NextCursor)
+	if err != nil {
+		t.Fatalf("Read(fourth) error = %v", err)
+	}
+	if len(fourth.Events) != 0 {
+		t.Fatalf("len(fourth.Events) = %d, want 0", len(fourth.Events))
+	}
+	if fourth.NextCursor != nil {
+		t.Fatalf("fourth.NextCursor = %#v, want nil", fourth.NextCursor)
+	}
+	checkpoint := decodeMessageCursor(t, fourth.Checkpoint.GetCursorOpaque())
+	if !checkpoint.ResumableCheckpoint || checkpoint.Until != "" || checkpoint.EventTypeIndex != 0 || checkpoint.Offset != 0 {
+		t.Fatalf("checkpoint cursor = %#v, want resumable next-window cursor", checkpoint)
+	}
+	if checkpoint.Since != windowUntil {
+		t.Fatalf("checkpoint since = %q, want previous until %q", checkpoint.Since, windowUntil)
+	}
+}
+
+func TestReadMessagesReturnsHardScopedExportFailures(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/ui/memory/messages" {
+					http.NotFound(w, r)
+					return
+				}
+				w.WriteHeader(status)
+				_ = json.NewEncoder(w).Encode(map[string]any{"error": "scoped export rejected"})
+			}))
+			defer server.Close()
+
+			source, err := New()
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			source.allowLoopbackBaseURL = true
+			_, err = source.Read(context.Background(), messageTestConfig(server.URL), nil)
+			if err == nil {
+				t.Fatal("Read() error = nil, want non-nil")
+			}
+			var responseErr *responseError
+			if !errors.As(err, &responseErr) {
+				t.Fatalf("Read() error = %T %v, want responseError", err, err)
+			}
+			if responseErr.StatusCode() != status {
+				t.Fatalf("StatusCode() = %d, want %d", responseErr.StatusCode(), status)
+			}
+		})
+	}
+}
+
+func TestReadMessagesRejectsInvalidScopedCursor(t *testing.T) {
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	cfg := messageTestConfig("https://cosmo.example.com")
+	for _, cursor := range []*cerebrov1.SourceCursor{
+		{Opaque: "1"},
+		{Opaque: `{"source":"cosmo.message","resumable_checkpoint":true,"since":"2026-05-14T00:00:00Z","until":"2026-05-14T01:00:00Z","offset":-1}`},
+		{Opaque: `{"source":"other","resumable_checkpoint":true,"since":"2026-05-14T00:00:00Z","until":"2026-05-14T01:00:00Z"}`},
+	} {
+		if _, err := source.Read(context.Background(), cfg, cursor); err == nil {
+			t.Fatalf("Read(cursor=%q) error = nil, want non-nil", cursor.GetOpaque())
+		}
 	}
 }
 
@@ -315,4 +520,35 @@ func TestReadSurveyFeedbackCanUseGitHubToken(t *testing.T) {
 	if got, want := pull.Events[0].Attributes["ticket_id"], "COSMO-1"; got != want {
 		t.Fatalf("ticket_id = %q, want %q", got, want)
 	}
+}
+
+func messageTestConfig(baseURL string) sourcecdk.Config {
+	return sourcecdk.NewConfig(map[string]string{
+		"tenant_id":        "writer",
+		"base_url":         baseURL,
+		"token":            "gh-token",
+		"family":           "message",
+		"client_id":        "cerebro-runtime",
+		"export_secret":    "export-secret",
+		"event_types":      "message,completion",
+		"max_window_hours": "1",
+		"per_page":         "1",
+	})
+}
+
+func decodeMessageCursor(t *testing.T, opaque string) messageCursor {
+	t.Helper()
+	var cursor messageCursor
+	if err := json.Unmarshal([]byte(opaque), &cursor); err != nil {
+		t.Fatalf("decode message cursor %q: %v", opaque, err)
+	}
+	return cursor
+}
+
+func cloneMap(input map[string]string) map[string]string {
+	clone := make(map[string]string, len(input))
+	for key, value := range input {
+		clone[key] = value
+	}
+	return clone
 }

--- a/sources/cosmo/source_test.go
+++ b/sources/cosmo/source_test.go
@@ -358,6 +358,99 @@ func TestReadMessagesUsesScopedExportContractAndPaginatesEventTypes(t *testing.T
 	}
 }
 
+func TestReadMessagesStartsFirstWindowAtConfiguredSince(t *testing.T) {
+	configuredSince := "2026-05-01T00:00:00Z"
+	wantUntil := "2026-05-01T01:00:00Z"
+	var sawRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/ui/memory/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		sawRequest = true
+		if got := r.URL.Query().Get("since"); got != configuredSince {
+			t.Fatalf("since = %q, want %q", got, configuredSince)
+		}
+		if got := r.URL.Query().Get("until"); got != wantUntil {
+			t.Fatalf("until = %q, want %q", got, wantUntil)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 0, "messages": []map[string]any{}})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"tenant_id":        "writer",
+		"base_url":         server.URL,
+		"token":            "gh-token",
+		"family":           "message",
+		"client_id":        "cerebro-runtime",
+		"export_secret":    "export-secret",
+		"event_types":      "message",
+		"max_window_hours": "1",
+		"per_page":         "10",
+		"since":            configuredSince,
+	})
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !sawRequest {
+		t.Fatal("server saw no message export request")
+	}
+	checkpoint := decodeMessageCursor(t, pull.Checkpoint.GetCursorOpaque())
+	if checkpoint.Since != wantUntil {
+		t.Fatalf("checkpoint since = %q, want %q", checkpoint.Since, wantUntil)
+	}
+}
+
+func TestDiscoverMessagesIteratesConfiguredEventTypes(t *testing.T) {
+	var eventTypes []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/ui/memory/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		eventType := r.URL.Query().Get("event_type")
+		eventTypes = append(eventTypes, eventType)
+		if eventType == "completion" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 1, "messages": []map[string]any{
+				{
+					"id":         20,
+					"ticket_id":  "COSMO-2",
+					"event_type": "completion",
+					"role":       "assistant",
+					"summary":    "Completed issue",
+					"created_at": "2026-05-12T12:01:00Z",
+				},
+			}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "count": 0, "messages": []map[string]any{}})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	urns, err := source.Discover(context.Background(), messageTestConfig(server.URL))
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if got, want := eventTypes, []string{"message", "completion"}; !slicesEqual(got, want) {
+		t.Fatalf("event types queried = %#v, want %#v", got, want)
+	}
+	if len(urns) != 1 {
+		t.Fatalf("len(urns) = %d, want 1", len(urns))
+	}
+}
+
 func TestReadMessagesReturnsHardScopedExportFailures(t *testing.T) {
 	for _, status := range []int{http.StatusBadRequest, http.StatusForbidden} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
@@ -551,4 +644,16 @@ func cloneMap(input map[string]string) map[string]string {
 		clone[key] = value
 	}
 	return clone
+}
+
+func slicesEqual(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary
- add structured scoped API credentials and short-lived HMAC capability-token auth
- enforce dedicated `cerebro.cosmo.security.read` scope on read-only HTTP and Connect surfaces while denying write/sync/evaluate/source-read routes
- require Security group claims on Cosmo capability tokens and preserve tenant scoping
- update the Cosmo `message` source family to use the scoped cross-ticket export contract (`X-Cosmo-Client`, `X-Cerebro-Export-Secret`, allow-listed `event_type`, bounded `since`/`until`, `per_page <= 100`)
- persist resumable message-export checkpoint cursors so scheduled source runtimes advance by high-water mark instead of re-reading unbounded history

## Why
Cosmo should be able to query Cerebro only through a data-plane-enforced, read-only Security capability, and Cerebro should ingest Cosmo messages only through the reviewed scoped export contract.

## Validation
- `go test ./sources/cosmo ./internal/sourceruntime`
- `make test`
- `make lint`
- `make openapi-check`
- `make verify`
- push hook `make verify`

## Related
- Companion Cosmo agent PR: https://github.com/WriterInternal/cosmo/pull/289
- Scoped Cosmo message export PR: https://github.com/WriterInternal/cosmo/pull/286
- Infra/config PR: https://github.com/WriterInternal/cerebro/pull/536
- Runtime contract issue: https://github.com/WriterInternal/cerebro/issues/534
