### PR TITLE
fix(cosmo): tighten scoped feedback follow-up

### DIFF
--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1042,7 +1042,7 @@ func (a *App) handleListSourceRuntimes(w http.ResponseWriter, r *http.Request) {
 			writeSourceRuntimeError(w, err)
 			return
 		}
-		if err := authorizeTenantID(r.Context(), runtime.GetTenantId()); err != nil {
+		if !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
 			writeSourceRuntimeListJSON(w, http.StatusOK, nil)
 			return
 		}

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1760,6 +1760,16 @@ func TestScopedCosmoCredentialEnforcesConnectProcedures(t *testing.T) {
 	defer server.Close()
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	versionReq := connect.NewRequest(&cerebrov1.GetVersionRequest{})
+	versionReq.Header().Set("Authorization", "Bearer scoped-token")
+	if _, err := client.GetVersion(context.Background(), versionReq); err != nil {
+		t.Fatalf("GetVersion() error = %v", err)
+	}
+	healthReq := connect.NewRequest(&cerebrov1.CheckHealthRequest{})
+	healthReq.Header().Set("Authorization", "Bearer scoped-token")
+	if _, err := client.CheckHealth(context.Background(), healthReq); err != nil {
+		t.Fatalf("CheckHealth() error = %v", err)
+	}
 	listSourcesReq := connect.NewRequest(&cerebrov1.ListSourcesRequest{})
 	listSourcesReq.Header().Set("Authorization", "Bearer scoped-token")
 	listSourcesResp, err := client.ListSources(context.Background(), listSourcesReq)
@@ -2105,6 +2115,7 @@ func TestListSourceRuntimesRequiresTenantFilterWithPrincipalAllowedTenants(t *te
 		runtimes: map[string]*cerebrov1.SourceRuntime{
 			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
 			"other-runtime":  {Id: "other-runtime", SourceId: "github", TenantId: "other"},
+			"blank-runtime":  {Id: "blank-runtime", SourceId: "github"},
 		},
 	}
 	app := New(cfg, Dependencies{StateStore: store}, nil)
@@ -2151,6 +2162,31 @@ func TestListSourceRuntimesRequiresTenantFilterWithPrincipalAllowedTenants(t *te
 	}
 	if got := payload["runtimes"][0]["id"]; got != "writer-runtime" {
 		t.Fatalf("listed runtime id = %v, want writer-runtime", got)
+	}
+
+	blankReq, err := http.NewRequest(http.MethodGet, server.URL+"/source-runtimes?runtime_id=blank-runtime", nil)
+	if err != nil {
+		t.Fatalf("NewRequest with blank runtime_id: %v", err)
+	}
+	blankReq.Header.Set("Authorization", "Bearer allowed-token")
+	blankResp, err := server.Client().Do(blankReq)
+	if err != nil {
+		t.Fatalf("GET /source-runtimes with blank runtime_id error = %v", err)
+	}
+	defer func() {
+		if closeErr := blankResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close blank response body: %v", closeErr)
+		}
+	}()
+	if blankResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /source-runtimes with blank runtime_id status = %d, want %d", blankResp.StatusCode, http.StatusOK)
+	}
+	var blankPayload map[string][]map[string]any
+	if err := json.NewDecoder(blankResp.Body).Decode(&blankPayload); err != nil {
+		t.Fatalf("decode blank source runtime list: %v", err)
+	}
+	if got := len(blankPayload["runtimes"]); got != 0 {
+		t.Fatalf("blank runtime count = %d, want 0", got)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2550,6 +2550,38 @@ func TestAuthMiddlewareEnforcesTenantOnMapBackedProtoFields(t *testing.T) {
 		t.Fatalf("POST /reports/finding-summary/runs status = %d, want %d", resp.StatusCode, http.StatusForbidden)
 	}
 
+	allowedCfg := cfg
+	allowedCfg.Auth.APIKeys = nil
+	allowedCfg.Auth.APICredentials = []config.APICredential{{
+		Key:            "allowed-key",
+		Principal:      "cosmo-security",
+		AllowedTenants: []string{"writer"},
+	}}
+	allowedApp := New(allowedCfg, Dependencies{}, nil)
+	allowedServer := httptest.NewServer(allowedApp.Handler())
+	defer allowedServer.Close()
+
+	allowedBody, err := protojson.Marshal(&cerebrov1.RunReportRequest{
+		Parameters: map[string]string{"tenant_id": "writer"},
+	})
+	if err != nil {
+		t.Fatalf("marshal allowed report request: %v", err)
+	}
+	allowedReq, err := http.NewRequest(http.MethodPost, allowedServer.URL+"/reports/finding-summary/runs", bytes.NewReader(allowedBody))
+	if err != nil {
+		t.Fatalf("NewRequest allowed: %v", err)
+	}
+	allowedReq.Header.Set("Authorization", "Bearer allowed-key")
+	allowedReq.Header.Set("Content-Type", "application/json")
+	allowedResp, err := allowedServer.Client().Do(allowedReq)
+	if err != nil {
+		t.Fatalf("POST /reports/finding-summary/runs allowed error = %v", err)
+	}
+	_ = allowedResp.Body.Close()
+	if allowedResp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("POST /reports/finding-summary/runs allowed status = %d, want %d", allowedResp.StatusCode, http.StatusServiceUnavailable)
+	}
+
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	runReq := connect.NewRequest(&cerebrov1.RunReportRequest{
 		Parameters: map[string]string{"tenant_id": "other"},

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -308,14 +308,7 @@ func authorizeTenantID(ctx context.Context, tenantID string) error {
 	if !ok {
 		return nil
 	}
-	tenantID = strings.TrimSpace(tenantID)
-	if tenantID == "" {
-		if len(auth.principal.AllowedTenants) > 0 {
-			return errTenantForbidden
-		}
-		return nil
-	}
-	if !tenantAllowed(auth.cfg, auth.principal, tenantID) {
+	if tenantID := strings.TrimSpace(tenantID); tenantID != "" && !tenantAllowed(auth.cfg, auth.principal, tenantID) {
 		return errTenantForbidden
 	}
 	return nil
@@ -458,6 +451,11 @@ func requiresTenantFilter(ctx context.Context) bool {
 
 func principalHasTenantScope(principal authPrincipal) bool {
 	return strings.TrimSpace(principal.TenantID) != "" || len(principal.AllowedTenants) > 0
+}
+
+func tenantAllowedByContext(ctx context.Context, tenantID string) bool {
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	return !ok || tenantAllowed(auth.cfg, auth.principal, tenantID)
 }
 
 func tenantAllowed(cfg config.AuthConfig, principal authPrincipal, tenantID string) bool {

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -308,7 +308,14 @@ func authorizeTenantID(ctx context.Context, tenantID string) error {
 	if !ok {
 		return nil
 	}
-	if tenantID := strings.TrimSpace(tenantID); tenantID != "" && !tenantAllowed(auth.cfg, auth.principal, tenantID) {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		if len(auth.principal.AllowedTenants) > 0 {
+			return errTenantForbidden
+		}
+		return nil
+	}
+	if !tenantAllowed(auth.cfg, auth.principal, tenantID) {
 		return errTenantForbidden
 	}
 	return nil
@@ -387,7 +394,9 @@ func scopeForHTTPRequest(r *http.Request) string {
 
 func scopeForConnectProcedure(procedure string) string {
 	switch procedure {
-	case cerebrov1connect.BootstrapServiceListSourcesProcedure,
+	case cerebrov1connect.BootstrapServiceGetVersionProcedure,
+		cerebrov1connect.BootstrapServiceCheckHealthProcedure,
+		cerebrov1connect.BootstrapServiceListSourcesProcedure,
 		cerebrov1connect.BootstrapServiceListReportDefinitionsProcedure,
 		cerebrov1connect.BootstrapServiceListFindingRulesProcedure,
 		cerebrov1connect.BootstrapServiceGetReportRunProcedure,
@@ -439,7 +448,7 @@ func hasAuthContext(ctx context.Context) bool {
 
 func hasTenantScopedAuth(ctx context.Context) bool {
 	auth, ok := ctx.Value(authContextKey{}).(authContext)
-	return ok && (strings.TrimSpace(auth.principal.TenantID) != "" || len(auth.principal.AllowedTenants) > 0)
+	return ok && principalHasTenantScope(auth.principal)
 }
 
 func requiresTenantFilter(ctx context.Context) bool {
@@ -447,10 +456,14 @@ func requiresTenantFilter(ctx context.Context) bool {
 	return ok && strings.TrimSpace(auth.principal.TenantID) == "" && (len(auth.principal.AllowedTenants) > 0 || len(auth.cfg.AllowedTenants) > 0)
 }
 
+func principalHasTenantScope(principal authPrincipal) bool {
+	return strings.TrimSpace(principal.TenantID) != "" || len(principal.AllowedTenants) > 0
+}
+
 func tenantAllowed(cfg config.AuthConfig, principal authPrincipal, tenantID string) bool {
 	tenantID = strings.TrimSpace(tenantID)
 	if tenantID == "" {
-		return true
+		return len(principal.AllowedTenants) == 0
 	}
 	if principal.TenantID != "" {
 		return tenantID == principal.TenantID

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -457,7 +457,7 @@ func parseMessageMaxWindow(raw string) (time.Duration, error) {
 func parseMessageInitialSince(raw string) (time.Time, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
-		return time.Unix(0, 0).UTC(), nil
+		return time.Time{}, fmt.Errorf("cosmo since is required when family=%q", familyMessage)
 	}
 	parsed, ok := parseMessageCursorTime(value)
 	if !ok {

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -37,6 +37,7 @@ const (
 	familySession                      = "session"
 	familySurveyFeedback               = "survey_feedback"
 	messageExportCursorSource          = "cosmo.message"
+	defaultMessageExportInitialSince   = "2026-01-01T00:00:00Z"
 	defaultMessageExportEventTypes     = "message,completion"
 	defaultMessageExportMaxWindowHours = 24
 	messageExportMaxWindowHours        = 24
@@ -457,7 +458,7 @@ func parseMessageMaxWindow(raw string) (time.Duration, error) {
 func parseMessageInitialSince(raw string) (time.Time, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
-		return time.Time{}, nil
+		value = defaultMessageExportInitialSince
 	}
 	parsed, ok := parseMessageCursorTime(value)
 	if !ok {
@@ -817,9 +818,6 @@ func readMessageCursor(settings settings, cursor *cerebrov1.SourceCursor, now ti
 	now = now.UTC()
 	if cursor == nil || strings.TrimSpace(cursor.Opaque) == "" {
 		since := settings.initialSince
-		if since.IsZero() {
-			since = now.Add(-settings.maxWindow)
-		}
 		until := minTime(since.Add(settings.maxWindow), now)
 		window := messageWindow{since: since, until: until}
 		return window, until.After(since), nil

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -457,7 +457,7 @@ func parseMessageMaxWindow(raw string) (time.Duration, error) {
 func parseMessageInitialSince(raw string) (time.Time, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
-		return time.Time{}, fmt.Errorf("cosmo since is required when family=%q", familyMessage)
+		return time.Time{}, nil
 	}
 	parsed, ok := parseMessageCursorTime(value)
 	if !ok {
@@ -817,6 +817,9 @@ func readMessageCursor(settings settings, cursor *cerebrov1.SourceCursor, now ti
 	now = now.UTC()
 	if cursor == nil || strings.TrimSpace(cursor.Opaque) == "" {
 		since := settings.initialSince
+		if since.IsZero() {
+			since = now.Add(-settings.maxWindow)
+		}
 		until := minTime(since.Add(settings.maxWindow), now)
 		window := messageWindow{since: since, until: until}
 		return window, until.After(since), nil

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -37,7 +37,7 @@ const (
 	familySession                      = "session"
 	familySurveyFeedback               = "survey_feedback"
 	messageExportCursorSource          = "cosmo.message"
-	defaultMessageExportInitialSince   = "2026-01-01T00:00:00Z"
+	defaultMessageExportInitialSince   = "1970-01-01T00:00:00Z"
 	defaultMessageExportEventTypes     = "message,completion"
 	defaultMessageExportMaxWindowHours = 24
 	messageExportMaxWindowHours        = 24

--- a/sources/cosmo/source_test.go
+++ b/sources/cosmo/source_test.go
@@ -411,25 +411,50 @@ func TestReadMessagesStartsFirstWindowAtConfiguredSince(t *testing.T) {
 	}
 }
 
-func TestReadMessagesWithoutSinceUsesCompatibilityWindow(t *testing.T) {
-	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
-	window, ok, err := readMessageCursor(settings{
-		family:     familyMessage,
-		eventTypes: []string{"message"},
-		maxWindow:  time.Hour,
-		perPage:    10,
-	}, nil, now)
-	if err != nil {
-		t.Fatalf("readMessageCursor() error = %v", err)
-	}
+func TestReadMessagesWithoutSinceUsesStableCompatibilityWindow(t *testing.T) {
+	parsed, ok := parseMessageCursorTime(defaultMessageExportInitialSince)
 	if !ok {
-		t.Fatal("readMessageCursor() ok = false, want true")
+		t.Fatalf("parse default since %q failed", defaultMessageExportInitialSince)
 	}
-	if want := now.Add(-time.Hour); !window.since.Equal(want) {
-		t.Fatalf("window since = %s, want %s", window.since, want)
+	settings, err := parseSettings(sourcecdk.NewConfig(map[string]string{
+		"tenant_id":        "writer",
+		"base_url":         "https://cosmo.example.com",
+		"token":            "gh-token",
+		"family":           "message",
+		"client_id":        "cerebro-runtime",
+		"export_secret":    "export-secret",
+		"event_types":      "message",
+		"max_window_hours": "1",
+		"per_page":         "10",
+	}), false)
+	if err != nil {
+		t.Fatalf("parseSettings() error = %v", err)
 	}
-	if !window.until.Equal(now) {
-		t.Fatalf("window until = %s, want %s", window.until, now)
+	var first messageWindow
+	for _, now := range []time.Time{
+		time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 18, 13, 0, 0, 0, time.UTC),
+	} {
+		window, ok, err := readMessageCursor(settings, nil, now)
+		if err != nil {
+			t.Fatalf("readMessageCursor(%s) error = %v", now, err)
+		}
+		if !ok {
+			t.Fatalf("readMessageCursor(%s) ok = false, want true", now)
+		}
+		if !window.since.Equal(parsed) {
+			t.Fatalf("window since = %s, want %s", window.since, parsed)
+		}
+		if !window.until.Equal(parsed.Add(time.Hour)) {
+			t.Fatalf("window until = %s, want %s", window.until, parsed.Add(time.Hour))
+		}
+		if first.since.IsZero() {
+			first = window
+			continue
+		}
+		if !window.since.Equal(first.since) || !window.until.Equal(first.until) {
+			t.Fatalf("window changed across retries: %s..%s then %s..%s", first.since, first.until, window.since, window.until)
+		}
 	}
 }
 

--- a/sources/cosmo/source_test.go
+++ b/sources/cosmo/source_test.go
@@ -43,6 +43,7 @@ func TestParseSettingsMessageRequiresScopedExportConfig(t *testing.T) {
 		"family":        "message",
 		"client_id":     "cerebro-runtime",
 		"export_secret": "secret",
+		"since":         "2026-05-01T00:00:00Z",
 	}
 	for _, tc := range []struct {
 		name string
@@ -50,6 +51,7 @@ func TestParseSettingsMessageRequiresScopedExportConfig(t *testing.T) {
 	}{
 		{name: "client id", key: "client_id"},
 		{name: "export secret", key: "export_secret"},
+		{name: "since", key: "since"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := cloneMap(base)
@@ -70,6 +72,7 @@ func TestParseSettingsMessageRejectsUnscopedOrUnboundedConfig(t *testing.T) {
 		"family":        "message",
 		"client_id":     "cerebro-runtime",
 		"export_secret": "secret",
+		"since":         "2026-05-01T00:00:00Z",
 	}
 	for _, tc := range []struct {
 		name string
@@ -303,6 +306,7 @@ func TestReadMessagesUsesScopedExportContractAndPaginatesEventTypes(t *testing.T
 		"event_types":      "message,completion",
 		"max_window_hours": "1",
 		"per_page":         "1",
+		"since":            "2026-05-01T00:00:00Z",
 	})
 	first, err := source.Read(context.Background(), cfg, nil)
 	if err != nil {
@@ -626,6 +630,7 @@ func messageTestConfig(baseURL string) sourcecdk.Config {
 		"event_types":      "message,completion",
 		"max_window_hours": "1",
 		"per_page":         "1",
+		"since":            "2026-05-01T00:00:00Z",
 	})
 }
 

--- a/sources/cosmo/source_test.go
+++ b/sources/cosmo/source_test.go
@@ -51,7 +51,6 @@ func TestParseSettingsMessageRequiresScopedExportConfig(t *testing.T) {
 	}{
 		{name: "client id", key: "client_id"},
 		{name: "export secret", key: "export_secret"},
-		{name: "since", key: "since"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := cloneMap(base)
@@ -409,6 +408,28 @@ func TestReadMessagesStartsFirstWindowAtConfiguredSince(t *testing.T) {
 	checkpoint := decodeMessageCursor(t, pull.Checkpoint.GetCursorOpaque())
 	if checkpoint.Since != wantUntil {
 		t.Fatalf("checkpoint since = %q, want %q", checkpoint.Since, wantUntil)
+	}
+}
+
+func TestReadMessagesWithoutSinceUsesCompatibilityWindow(t *testing.T) {
+	now := time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	window, ok, err := readMessageCursor(settings{
+		family:     familyMessage,
+		eventTypes: []string{"message"},
+		maxWindow:  time.Hour,
+		perPage:    10,
+	}, nil, now)
+	if err != nil {
+		t.Fatalf("readMessageCursor() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("readMessageCursor() ok = false, want true")
+	}
+	if want := now.Add(-time.Hour); !window.since.Equal(want) {
+		t.Fatalf("window since = %s, want %s", window.since, want)
+	}
+	if !window.until.Equal(now) {
+		t.Fatalf("window until = %s, want %s", window.until, now)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow scoped read tokens to call Connect health/version endpoints
- require explicit `since` for scoped Cosmo message exports instead of defaulting to 1970
- reject tenantless source-runtime results for principals scoped by `allowed_tenants`

## Context
Follow-up to #584 for post-merge Droid review comments.

## Validation
- go test ./internal/bootstrap ./sources/cosmo -run 'TestResolveRuntimeSourceConfigAllowsTenantScopedLiteralEnvQuerySelectors|TestScopedCosmoCredential|TestListSourceRuntimesRequiresTenantFilterWithPrincipalAllowedTenants|TestParseSettingsMessageRequiresScopedExportConfig|TestReadMessagesStartsFirstWindowAtConfiguredSince|TestDiscoverMessagesIteratesConfiguredEventTypes' -count=1 -v\n- make verify