### PR TITLE
feat(grc): link vulnerable assets to platform resources

### DIFF
--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -318,8 +318,13 @@ func grcVulnerableAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 		return nil, nil, nil
 	}
 	addEntity(entities, grcTargetEntity(tenantID, event.GetSourceId(), targetURN, targetID, attrs, provider))
-	addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, targetURN, relationRepresents, grcTargetHost(attrs), "grc_vulnerable_asset_host", "0.95")
-	addInternetIPLink(entities, links, tenantID, event.GetSourceId(), event, targetURN, firstAttribute(attrs, "ip", "ip_address", "public_ip"), "grc_vulnerable_asset_ip", "0.95")
+	for _, host := range grcTargetHosts(attrs) {
+		addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, targetURN, relationRepresents, host, "grc_vulnerable_asset_host", "0.95")
+	}
+	for _, ip := range grcTargetIPs(attrs) {
+		addInternetIPLink(entities, links, tenantID, event.GetSourceId(), event, targetURN, ip, "grc_vulnerable_asset_ip", "0.95")
+	}
+	addGRCPlatformAssetLinks(entities, links, tenantID, event.GetSourceId(), event, targetURN, attrs)
 
 	integrationID := firstAttribute(attrs, "integration_id")
 	if integrationURN := grcIntegrationURN(tenantID, provider, integrationID); integrationURN != "" {
@@ -551,6 +556,219 @@ func grcTargetHost(attrs map[string]string) string {
 		return host
 	}
 	return internetHostIfLikely(firstAttribute(attrs, "target_id", "resource_id", "asset_id", "endpoint_id"))
+}
+
+func grcTargetHosts(attrs map[string]string) []string {
+	values := splitCloudAttributeList(strings.Join([]string{
+		grcTargetHost(attrs),
+		attrs["hostnames"],
+		attrs["hosts"],
+	}, ","))
+	hosts := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		host := internetHost(value)
+		if host == "" {
+			continue
+		}
+		if _, exists := seen[host]; exists {
+			continue
+		}
+		seen[host] = struct{}{}
+		hosts = append(hosts, host)
+	}
+	return hosts
+}
+
+func grcTargetIPs(attrs map[string]string) []string {
+	values := splitCloudAttributeList(strings.Join([]string{
+		attrs["ip"],
+		attrs["ip_address"],
+		attrs["ip_addresses"],
+		attrs["public_ip"],
+		attrs["public_ips"],
+		attrs["private_ip"],
+		attrs["private_ips"],
+	}, ","))
+	ips := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		ip := internetIP(value)
+		if ip == "" {
+			continue
+		}
+		if _, exists := seen[ip]; exists {
+			continue
+		}
+		seen[ip] = struct{}{}
+		ips = append(ips, ip)
+	}
+	return ips
+}
+
+type grcPlatformAssetReference struct {
+	Provider          string `json:"provider"`
+	ResourceID        string `json:"resource_id"`
+	ResourceName      string `json:"resource_name"`
+	ResourceType      string `json:"resource_type"`
+	ScannerResourceID string `json:"scanner_resource_id"`
+	Hostnames         string `json:"hostnames"`
+	IPs               string `json:"ips"`
+}
+
+func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, targetURN string, attrs map[string]string) {
+	for _, ref := range grcPlatformAssetReferences(attrs) {
+		provider := grcPlatformProvider(ref.Provider, ref.ResourceID)
+		resourceID := strings.TrimSpace(ref.ResourceID)
+		if provider == "" || provider == "vanta" || resourceID == "" {
+			continue
+		}
+		resourceType := grcPlatformResourceType(provider, resourceID, ref.ResourceType)
+		resourceURN := projectionURN(tenantID, provider+"_"+resourceType, resourceID)
+		if resourceURN == "" {
+			continue
+		}
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        resourceURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: provider + "." + strings.ReplaceAll(resourceType, "_", "."),
+			Label:      firstNonEmpty(ref.ResourceName, resourceID),
+			Attributes: map[string]string{
+				"provider":            provider,
+				"resource_id":         resourceID,
+				"resource_type":       resourceType,
+				"scanner_resource_id": strings.TrimSpace(ref.ScannerResourceID),
+				"source_system":       grcProvider(attrs),
+			},
+		})
+		addLink(links, projectedLink(tenantID, sourceID, targetURN, resourceURN, relationRepresents, map[string]string{
+			"confidence":           "0.99",
+			"event_id":             event.GetId(),
+			"match_type":           "grc_vulnerable_asset_platform_resource",
+			"platform_provider":    provider,
+			"platform_resource_id": resourceID,
+			"resource_type":        resourceType,
+		}))
+		if provider == "aws" {
+			addCloudAccountLink(entities, links, tenantID, sourceID, event, resourceURN, grcAWSAccountIDFromARN(resourceID), provider)
+		}
+		for _, host := range splitCloudAttributeList(ref.Hostnames) {
+			addInternetHostLink(entities, links, tenantID, sourceID, event, resourceURN, relationRepresents, host, "grc_platform_resource_host", "0.90")
+		}
+		for _, ip := range splitCloudAttributeList(ref.IPs) {
+			addInternetIPLink(entities, links, tenantID, sourceID, event, resourceURN, ip, "grc_platform_resource_ip", "0.90")
+		}
+	}
+}
+
+func grcPlatformAssetReferences(attrs map[string]string) []grcPlatformAssetReference {
+	if raw := strings.TrimSpace(attrs["platform_asset_refs"]); raw != "" {
+		var refs []grcPlatformAssetReference
+		if err := json.Unmarshal([]byte(raw), &refs); err == nil {
+			return refs
+		}
+	}
+	resourceID := firstAttribute(attrs, "platform_resource_id", "cloud_resource_id", "cloud_resource_arn", "target_arn", "resource_arn")
+	if resourceID == "" {
+		return nil
+	}
+	return []grcPlatformAssetReference{{
+		Provider:          firstAttribute(attrs, "platform_provider", "cloud_provider", "integration_id"),
+		ResourceID:        resourceID,
+		ResourceName:      firstAttribute(attrs, "platform_resource_name", "resource_name", "target_name"),
+		ResourceType:      firstAttribute(attrs, "platform_resource_type", "cloud_resource_type", "resource_type", "asset_type"),
+		ScannerResourceID: firstAttribute(attrs, "scanner_resource_id"),
+		Hostnames:         firstAttribute(attrs, "hostnames", "hostname", "host"),
+		IPs:               firstAttribute(attrs, "ip_addresses", "ip", "ip_address", "public_ip"),
+	}}
+}
+
+func grcPlatformProvider(provider string, resourceID string) string {
+	provider = normalizeIdentifier(provider)
+	if provider != "" && provider != "vanta" {
+		return provider
+	}
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(resourceID)), "arn:aws") {
+		return "aws"
+	}
+	return provider
+}
+
+func grcPlatformResourceType(provider string, resourceID string, fallback string) string {
+	if provider == "aws" {
+		if resourceType := grcAWSResourceTypeFromARN(resourceID); resourceType != "" {
+			return resourceType
+		}
+	}
+	if resourceType := normalizeCloudType(fallback); resourceType != "" {
+		return resourceType
+	}
+	return "resource"
+}
+
+func grcAWSResourceTypeFromARN(resourceID string) string {
+	_, service, _, _, resource, ok := grcAWSARNParts(resourceID)
+	if !ok {
+		return ""
+	}
+	resourceType := resource
+	if before, _, ok := strings.Cut(resourceType, "/"); ok {
+		resourceType = before
+	}
+	if before, _, ok := strings.Cut(resourceType, ":"); ok {
+		resourceType = before
+	}
+	switch service {
+	case "ec2":
+		switch resourceType {
+		case "security-group":
+			return "security_group"
+		case "network-interface":
+			return "network_interface"
+		case "instance":
+			return "ec2_instance"
+		default:
+			return normalizeCloudType(resourceType)
+		}
+	case "elasticloadbalancing":
+		switch {
+		case strings.HasPrefix(resource, "loadbalancer/app/"):
+			return "application_load_balancer"
+		case strings.HasPrefix(resource, "loadbalancer/net/"):
+			return "network_load_balancer"
+		default:
+			return "load_balancer"
+		}
+	case "cloudfront":
+		if resourceType == "distribution" {
+			return "cloudfront_distribution"
+		}
+	case "apigateway":
+		if resourceType == "domainname" {
+			return "apigateway_domain"
+		}
+	}
+	if resourceType != "" {
+		return normalizeCloudType(service + "_" + resourceType)
+	}
+	return normalizeCloudType(service)
+}
+
+func grcAWSAccountIDFromARN(resourceID string) string {
+	_, _, _, accountID, _, ok := grcAWSARNParts(resourceID)
+	if !ok {
+		return ""
+	}
+	return accountID
+}
+
+func grcAWSARNParts(resourceID string) (partition string, service string, region string, accountID string, resource string, ok bool) {
+	parts := strings.SplitN(strings.TrimSpace(resourceID), ":", 6)
+	if len(parts) != 6 || parts[0] != "arn" || !strings.HasPrefix(parts[1], "aws") {
+		return "", "", "", "", "", false
+	}
+	return parts[1], parts[2], parts[3], parts[4], parts[5], true
 }
 
 func grcIntegrationURN(tenantID string, provider string, integrationID string) string {

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -628,10 +628,11 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 		if resourceURN == "" {
 			continue
 		}
+		platformSourceID := provider
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        resourceURN,
 			TenantID:   tenantID,
-			SourceID:   sourceID,
+			SourceID:   platformSourceID,
 			EntityType: provider + "." + strings.ReplaceAll(resourceType, "_", "."),
 			Label:      firstNonEmpty(ref.ResourceName, resourceID),
 			Attributes: map[string]string{
@@ -651,7 +652,7 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 			"resource_type":        resourceType,
 		}))
 		if provider == "aws" {
-			addCloudAccountLink(entities, links, tenantID, sourceID, event, resourceURN, grcAWSAccountIDFromARN(resourceID), provider)
+			addCloudAccountLink(entities, links, tenantID, platformSourceID, event, resourceURN, grcAWSAccountIDFromARN(resourceID), provider)
 		}
 		for _, host := range splitCloudAttributeList(ref.Hostnames) {
 			addInternetHostLink(entities, links, tenantID, sourceID, event, resourceURN, relationRepresents, host, "grc_platform_resource_host", "0.90")

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -712,7 +712,7 @@ func grcAWSResourceTypeFromARN(resourceID string) string {
 	if !ok {
 		return ""
 	}
-	resourceType := resource
+	resourceType := strings.TrimLeft(resource, "/")
 	if before, _, ok := strings.Cut(resourceType, "/"); ok {
 		resourceType = before
 	}
@@ -745,7 +745,7 @@ func grcAWSResourceTypeFromARN(resourceID string) string {
 			return "cloudfront_distribution"
 		}
 	case "apigateway":
-		if resourceType == "domainname" {
+		if resourceType == "domainname" || resourceType == "domainnames" {
 			return "apigateway_domain"
 		}
 	}

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -628,6 +628,18 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 		if resourceURN == "" {
 			continue
 		}
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        resourceURN,
+			TenantID:   tenantID,
+			SourceID:   provider,
+			EntityType: provider + "." + strings.ReplaceAll(resourceType, "_", "."),
+			Label:      resourceURN,
+			Attributes: map[string]string{
+				"provider":      provider,
+				"resource_id":   resourceID,
+				"resource_type": resourceType,
+			},
+		})
 		addLink(links, projectedLink(tenantID, sourceID, targetURN, resourceURN, relationRepresents, map[string]string{
 			"confidence":           "0.99",
 			"event_id":             event.GetId(),

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -628,21 +628,6 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 		if resourceURN == "" {
 			continue
 		}
-		platformSourceID := provider
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        resourceURN,
-			TenantID:   tenantID,
-			SourceID:   platformSourceID,
-			EntityType: provider + "." + strings.ReplaceAll(resourceType, "_", "."),
-			Label:      firstNonEmpty(ref.ResourceName, resourceID),
-			Attributes: map[string]string{
-				"provider":            provider,
-				"resource_id":         resourceID,
-				"resource_type":       resourceType,
-				"scanner_resource_id": strings.TrimSpace(ref.ScannerResourceID),
-				"source_system":       grcProvider(attrs),
-			},
-		})
 		addLink(links, projectedLink(tenantID, sourceID, targetURN, resourceURN, relationRepresents, map[string]string{
 			"confidence":           "0.99",
 			"event_id":             event.GetId(),
@@ -651,15 +636,6 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 			"platform_resource_id": resourceID,
 			"resource_type":        resourceType,
 		}))
-		if provider == "aws" {
-			addCloudAccountLink(entities, links, tenantID, platformSourceID, event, resourceURN, grcAWSAccountIDFromARN(resourceID), provider)
-		}
-		for _, host := range splitCloudAttributeList(ref.Hostnames) {
-			addInternetHostLink(entities, links, tenantID, sourceID, event, resourceURN, relationRepresents, host, "grc_platform_resource_host", "0.90")
-		}
-		for _, ip := range splitCloudAttributeList(ref.IPs) {
-			addInternetIPLink(entities, links, tenantID, sourceID, event, resourceURN, ip, "grc_platform_resource_ip", "0.90")
-		}
 	}
 }
 
@@ -754,14 +730,6 @@ func grcAWSResourceTypeFromARN(resourceID string) string {
 		return normalizeCloudType(service + "_" + resourceType)
 	}
 	return normalizeCloudType(service)
-}
-
-func grcAWSAccountIDFromARN(resourceID string) string {
-	_, _, _, accountID, _, ok := grcAWSARNParts(resourceID)
-	if !ok {
-		return ""
-	}
-	return accountID
 }
 
 func grcAWSARNParts(resourceID string) (partition string, service string, region string, accountID string, resource string, ok bool) {

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -699,6 +699,13 @@ func TestProjectGRCVulnerableAssetLinksPlatformResources(t *testing.T) {
 	assertProjectedLink(t, state, awsInstanceURN, relationRepresents, ipURN)
 }
 
+func TestGRCAWSResourceTypeFromARNHandlesAPIGatewayCustomDomain(t *testing.T) {
+	got := grcAWSResourceTypeFromARN("arn:aws:apigateway:us-east-1::/domainnames/api.writer.com")
+	if got != "apigateway_domain" {
+		t.Fatalf("grcAWSResourceTypeFromARN() = %q, want apigateway_domain", got)
+	}
+}
+
 func TestProjectGRCVulnerableAssetDoesNotInferVulnerabilityFromReferenceJSON(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -657,6 +657,48 @@ func TestProjectGRCVulnerableAssetLinksURLOnlyHost(t *testing.T) {
 	assertProjectedLink(t, state, targetURN, relationRepresents, hostURN)
 }
 
+func TestProjectGRCVulnerableAssetLinksPlatformResources(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-platform",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":       "vanta",
+			"target_id":      "vanta-asset-1",
+			"target_name":    "ip-10-86-43-17.ec2.internal: i-0f359ce073424f8d6",
+			"hostnames":      "ip-10-86-43-17.ec2.internal",
+			"ip_addresses":   "10.86.43.17",
+			"integration_id": "aws",
+			"platform_asset_refs": `[` +
+				`{"provider":"aws","resource_id":"arn:aws:ec2:us-east-1:381491964434:instance/i-0f359ce073424f8d6","resource_name":"ip-10-86-43-17.ec2.internal","resource_type":"SERVER","scanner_resource_id":"scanner-resource-1","hostnames":"ip-10-86-43-17.ec2.internal","ips":"10.86.43.17"}` +
+				`]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	targetURN := "urn:cerebro:writer:grc_target:vanta:vanta-asset-1"
+	awsInstanceURN := "urn:cerebro:writer:aws_ec2_instance:arn:aws:ec2:us-east-1:381491964434:instance/i-0f359ce073424f8d6"
+	hostURN := "urn:cerebro:writer:internet_host:ip-10-86-43-17.ec2.internal"
+	ipURN := "urn:cerebro:writer:internet_ip:10.86.43.17"
+	accountURN := "urn:cerebro:writer:cloud_account:381491964434"
+
+	if entity := state.entities[awsInstanceURN]; entity == nil || entity.EntityType != "aws.ec2.instance" {
+		t.Fatalf("AWS instance entity missing: %#v", entity)
+	}
+	assertProjectedLink(t, state, targetURN, relationRepresents, awsInstanceURN)
+	assertProjectedLink(t, state, awsInstanceURN, relationBelongsTo, accountURN)
+	assertProjectedLink(t, state, targetURN, relationRepresents, hostURN)
+	assertProjectedLink(t, state, targetURN, relationRepresents, ipURN)
+	assertProjectedLink(t, state, awsInstanceURN, relationRepresents, hostURN)
+	assertProjectedLink(t, state, awsInstanceURN, relationRepresents, ipURN)
+}
+
 func TestProjectGRCVulnerableAssetDoesNotInferVulnerabilityFromReferenceJSON(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -688,8 +688,11 @@ func TestProjectGRCVulnerableAssetLinksPlatformResources(t *testing.T) {
 	ipURN := "urn:cerebro:writer:internet_ip:10.86.43.17"
 	accountURN := "urn:cerebro:writer:cloud_account:381491964434"
 
-	if entity := state.entities[awsInstanceURN]; entity == nil || entity.EntityType != "aws.ec2.instance" {
+	if entity := state.entities[awsInstanceURN]; entity == nil || entity.EntityType != "aws.ec2.instance" || entity.SourceID != "aws" {
 		t.Fatalf("AWS instance entity missing: %#v", entity)
+	}
+	if entity := state.entities[accountURN]; entity == nil || entity.SourceID != "aws" {
+		t.Fatalf("AWS account entity missing: %#v", entity)
 	}
 	assertProjectedLink(t, state, targetURN, relationRepresents, awsInstanceURN)
 	assertProjectedLink(t, state, awsInstanceURN, relationBelongsTo, accountURN)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -688,8 +688,8 @@ func TestProjectGRCVulnerableAssetLinksPlatformResources(t *testing.T) {
 	ipURN := "urn:cerebro:writer:internet_ip:10.86.43.17"
 	accountURN := "urn:cerebro:writer:cloud_account:381491964434"
 
-	if entity := state.entities[awsInstanceURN]; entity != nil {
-		t.Fatalf("GRC projection must not upsert shared AWS resource entity: %#v", entity)
+	if entity := state.entities[awsInstanceURN]; entity == nil || entity.EntityType != "aws.ec2.instance" || entity.SourceID != "aws" {
+		t.Fatalf("AWS instance entity missing: %#v", entity)
 	}
 	if entity := state.entities[accountURN]; entity != nil {
 		t.Fatalf("GRC projection must not upsert shared AWS account entity: %#v", entity)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -688,18 +688,18 @@ func TestProjectGRCVulnerableAssetLinksPlatformResources(t *testing.T) {
 	ipURN := "urn:cerebro:writer:internet_ip:10.86.43.17"
 	accountURN := "urn:cerebro:writer:cloud_account:381491964434"
 
-	if entity := state.entities[awsInstanceURN]; entity == nil || entity.EntityType != "aws.ec2.instance" || entity.SourceID != "aws" {
-		t.Fatalf("AWS instance entity missing: %#v", entity)
+	if entity := state.entities[awsInstanceURN]; entity != nil {
+		t.Fatalf("GRC projection must not upsert shared AWS resource entity: %#v", entity)
 	}
-	if entity := state.entities[accountURN]; entity == nil || entity.SourceID != "aws" {
-		t.Fatalf("AWS account entity missing: %#v", entity)
+	if entity := state.entities[accountURN]; entity != nil {
+		t.Fatalf("GRC projection must not upsert shared AWS account entity: %#v", entity)
 	}
 	assertProjectedLink(t, state, targetURN, relationRepresents, awsInstanceURN)
-	assertProjectedLink(t, state, awsInstanceURN, relationBelongsTo, accountURN)
 	assertProjectedLink(t, state, targetURN, relationRepresents, hostURN)
 	assertProjectedLink(t, state, targetURN, relationRepresents, ipURN)
-	assertProjectedLink(t, state, awsInstanceURN, relationRepresents, hostURN)
-	assertProjectedLink(t, state, awsInstanceURN, relationRepresents, ipURN)
+	assertProjectedLinkMissing(t, state, awsInstanceURN, relationBelongsTo, accountURN)
+	assertProjectedLinkMissing(t, state, awsInstanceURN, relationRepresents, hostURN)
+	assertProjectedLinkMissing(t, state, awsInstanceURN, relationRepresents, ipURN)
 }
 
 func TestGRCAWSResourceTypeFromARNHandlesAPIGatewayCustomDomain(t *testing.T) {

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -847,9 +847,6 @@ func copyVulnerableAssetPlatformReferences(attrs map[string]string, values map[s
 		attrs["platform_asset_refs"] = string(raw)
 	}
 	first := refs[0]
-	if attrs["integration_id"] == "" && first.Provider != "" {
-		attrs["integration_id"] = first.Provider
-	}
 	addAttrIfMissing(attrs, "platform_provider", first.Provider)
 	addAttrIfMissing(attrs, "platform_resource_id", first.ResourceID)
 	addAttrIfMissing(attrs, "platform_resource_name", first.ResourceName)

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -725,6 +725,7 @@ func attributesFor(settings settings, family string, record grcRecord) map[strin
 		copyFirstField(attrs, values, "target_url", "url", "externalURL")
 		copyFirstField(attrs, values, "operating_system", "operatingSystem", "os")
 		copyFirstField(attrs, values, "last_detected_at", "lastDetectedDate", "lastSeenDate", "updatedAt")
+		copyVulnerableAssetPlatformReferences(attrs, values)
 		copyVulnerableAssetReferences(attrs, values)
 	case familyRiskScenario:
 		copyFields(attrs, values, map[string]string{
@@ -825,6 +826,142 @@ func copyControlReferenceFields(attrs map[string]string, values map[string]any) 
 			attrs["control_external_id"] = firstDelimitedValue(externalIDs)
 		}
 	}
+}
+
+type vulnerableAssetPlatformReference struct {
+	Provider          string `json:"provider,omitempty"`
+	ResourceID        string `json:"resource_id,omitempty"`
+	ResourceName      string `json:"resource_name,omitempty"`
+	ResourceType      string `json:"resource_type,omitempty"`
+	ScannerResourceID string `json:"scanner_resource_id,omitempty"`
+	Hostnames         string `json:"hostnames,omitempty"`
+	IPs               string `json:"ips,omitempty"`
+}
+
+func copyVulnerableAssetPlatformReferences(attrs map[string]string, values map[string]any) {
+	refs := vulnerableAssetPlatformReferences(values)
+	if len(refs) == 0 {
+		return
+	}
+	if raw, err := json.Marshal(refs); err == nil {
+		attrs["platform_asset_refs"] = string(raw)
+	}
+	first := refs[0]
+	if attrs["integration_id"] == "" && first.Provider != "" {
+		attrs["integration_id"] = first.Provider
+	}
+	addAttrIfMissing(attrs, "platform_provider", first.Provider)
+	addAttrIfMissing(attrs, "platform_resource_id", first.ResourceID)
+	addAttrIfMissing(attrs, "platform_resource_name", first.ResourceName)
+	addAttrIfMissing(attrs, "platform_resource_type", first.ResourceType)
+	addAttrIfMissing(attrs, "scanner_resource_id", first.ScannerResourceID)
+	hostnames := joinedUniqueDelimitedValues(refs, func(ref vulnerableAssetPlatformReference) string { return ref.Hostnames })
+	ips := joinedUniqueDelimitedValues(refs, func(ref vulnerableAssetPlatformReference) string { return ref.IPs })
+	if hostnames != "" {
+		attrs["hostnames"] = hostnames
+		addAttrIfMissing(attrs, "hostname", firstDelimitedValue(hostnames))
+	}
+	if ips != "" {
+		attrs["ip_addresses"] = ips
+		addAttrIfMissing(attrs, "ip", firstDelimitedValue(ips))
+	}
+}
+
+func vulnerableAssetPlatformReferences(values map[string]any) []vulnerableAssetPlatformReference {
+	items := arrayValue(values, "scanners")
+	refs := make([]vulnerableAssetPlatformReference, 0, len(items))
+	seen := map[string]struct{}{}
+	resourceName := firstNonEmptyString(fieldString(values, "displayName"), fieldString(values, "name"), fieldString(values, "hostname"), fieldString(values, "host"))
+	resourceType := firstNonEmptyString(fieldString(values, "resourceType"), fieldString(values, "assetType"), fieldString(values, "type"))
+	for _, item := range items {
+		object, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		provider := firstNonEmptyString(fieldString(object, "integrationId"), fieldString(object, "integration.id"), fieldString(object, "provider"))
+		resourceID := firstNonEmptyString(fieldString(object, "targetId"), fieldString(object, "resourceArn"), fieldString(object, "arn"))
+		scannerResourceID := fieldString(object, "resourceId")
+		if resourceID == "" && platformResourceIDLikelyExternal(scannerResourceID) {
+			resourceID = scannerResourceID
+		}
+		hostnames := firstNonEmptyString(fieldString(object, "hostnames"), fieldString(object, "fqdns"), fieldString(object, "hostname"), fieldString(object, "fqdn"))
+		ips := firstNonEmptyString(fieldString(object, "ipv4s"), fieldString(object, "ipv6s"), fieldString(object, "ipAddresses"), fieldString(object, "ipAddress"), fieldString(object, "publicIp"), fieldString(object, "publicIP"))
+		if provider == "" && resourceID == "" && scannerResourceID == "" && hostnames == "" && ips == "" {
+			continue
+		}
+		ref := vulnerableAssetPlatformReference{
+			Provider:          provider,
+			ResourceID:        resourceID,
+			ResourceName:      resourceName,
+			ResourceType:      firstNonEmptyString(fieldString(object, "resourceType"), fieldString(object, "assetType"), resourceType),
+			ScannerResourceID: scannerResourceID,
+			Hostnames:         normalizeDelimitedValues(hostnames),
+			IPs:               normalizeDelimitedValues(ips),
+		}
+		key := strings.Join([]string{ref.Provider, ref.ResourceID, ref.ScannerResourceID, ref.Hostnames, ref.IPs}, "\x00")
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func addAttrIfMissing(attrs map[string]string, key string, value string) {
+	if strings.TrimSpace(attrs[key]) == "" {
+		if value = strings.TrimSpace(value); value != "" {
+			attrs[key] = value
+		}
+	}
+}
+
+func platformResourceIDLikelyExternal(value string) bool {
+	value = strings.TrimSpace(value)
+	return strings.HasPrefix(value, "arn:") || strings.Contains(value, "://") || strings.Contains(value, "/")
+}
+
+func joinedUniqueDelimitedValues(refs []vulnerableAssetPlatformReference, selectValue func(vulnerableAssetPlatformReference) string) string {
+	values := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		values = append(values, splitDelimitedValues(selectValue(ref))...)
+	}
+	return strings.Join(uniqueStrings(values), ",")
+}
+
+func normalizeDelimitedValues(value string) string {
+	return strings.Join(uniqueStrings(splitDelimitedValues(value)), ",")
+}
+
+func splitDelimitedValues(value string) []string {
+	fields := strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t'
+	})
+	result := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if trimmed := strings.TrimSpace(field); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func uniqueStrings(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 func copyVulnerableAssetReferences(attrs map[string]string, values map[string]any) {

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -884,8 +884,8 @@ func vulnerableAssetPlatformReferences(values map[string]any) []vulnerableAssetP
 		if resourceID == "" && platformResourceIDLikelyExternal(scannerResourceID) {
 			resourceID = scannerResourceID
 		}
-		hostnames := firstNonEmptyString(fieldString(object, "hostnames"), fieldString(object, "fqdns"), fieldString(object, "hostname"), fieldString(object, "fqdn"))
-		ips := firstNonEmptyString(fieldString(object, "ipv4s"), fieldString(object, "ipv6s"), fieldString(object, "ipAddresses"), fieldString(object, "ipAddress"), fieldString(object, "publicIp"), fieldString(object, "publicIP"))
+		hostnames := joinedPlatformObjectFieldValues(object, "hostnames", "fqdns", "hostname", "fqdn")
+		ips := joinedPlatformObjectFieldValues(object, "ipv4s", "ipv6s", "ipAddresses", "ipAddress", "publicIp", "publicIP")
 		if provider == "" && resourceID == "" && scannerResourceID == "" && hostnames == "" && ips == "" {
 			continue
 		}
@@ -919,6 +919,14 @@ func addAttrIfMissing(attrs map[string]string, key string, value string) {
 func platformResourceIDLikelyExternal(value string) bool {
 	value = strings.TrimSpace(value)
 	return strings.HasPrefix(value, "arn:") || strings.Contains(value, "://") || strings.Contains(value, "/")
+}
+
+func joinedPlatformObjectFieldValues(object map[string]any, names ...string) string {
+	values := make([]string, 0, len(names))
+	for _, name := range names {
+		values = append(values, splitDelimitedValues(fieldString(object, name))...)
+	}
+	return strings.Join(uniqueStrings(values), ",")
 }
 
 func joinedUniqueDelimitedValues(refs []vulnerableAssetPlatformReference, selectValue func(vulnerableAssetPlatformReference) string) string {

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -393,6 +393,45 @@ func TestJoinedVulnerableAssetReferencesZipsFlatFields(t *testing.T) {
 	}
 }
 
+func TestCopyVulnerableAssetPlatformReferencesFlattensScannerTargets(t *testing.T) {
+	attrs := map[string]string{}
+	copyVulnerableAssetPlatformReferences(attrs, map[string]any{
+		"id":        "vanta-asset-1",
+		"name":      "ip-10-86-43-17.ec2.internal: i-0f359ce073424f8d6",
+		"assetType": "SERVER",
+		"scanners": []any{map[string]any{
+			"resourceId":    "6a0af69035545f545841fe88",
+			"integrationId": "aws",
+			"targetId":      "arn:aws:ec2:us-east-1:381491964434:instance/i-0f359ce073424f8d6",
+			"hostnames":     []any{"ip-10-86-43-17.ec2.internal"},
+			"ipv4s":         []any{"10.86.43.17"},
+		}},
+	})
+
+	if got := attrs["integration_id"]; got != "aws" {
+		t.Fatalf("integration_id = %q, want aws", got)
+	}
+	if got := attrs["platform_resource_id"]; got != "arn:aws:ec2:us-east-1:381491964434:instance/i-0f359ce073424f8d6" {
+		t.Fatalf("platform_resource_id = %q, want EC2 ARN", got)
+	}
+	if got := attrs["platform_resource_type"]; got != "SERVER" {
+		t.Fatalf("platform_resource_type = %q, want SERVER", got)
+	}
+	if got := attrs["hostname"]; got != "ip-10-86-43-17.ec2.internal" {
+		t.Fatalf("hostname = %q, want scanner hostname", got)
+	}
+	if got := attrs["ip"]; got != "10.86.43.17" {
+		t.Fatalf("ip = %q, want scanner IPv4", got)
+	}
+	var refs []map[string]string
+	if err := json.Unmarshal([]byte(attrs["platform_asset_refs"]), &refs); err != nil {
+		t.Fatalf("platform_asset_refs is invalid JSON: %v", err)
+	}
+	if len(refs) != 1 || refs[0]["provider"] != "aws" || refs[0]["resource_id"] != "arn:aws:ec2:us-east-1:381491964434:instance/i-0f359ce073424f8d6" {
+		t.Fatalf("platform_asset_refs = %#v, want AWS EC2 resource ref", refs)
+	}
+}
+
 func TestJoinedVulnerableAssetReferencesMergesFlatPackages(t *testing.T) {
 	raw := joinedVulnerableAssetReferences(map[string]any{
 		"vulnerabilities":    []any{map[string]any{"id": "CVE-2026-4242"}, map[string]any{"id": "CVE-2026-4243"}},

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -404,7 +404,9 @@ func TestCopyVulnerableAssetPlatformReferencesFlattensScannerTargets(t *testing.
 			"integrationId": "aws",
 			"targetId":      "arn:aws:ec2:us-east-1:381491964434:instance/i-0f359ce073424f8d6",
 			"hostnames":     []any{"ip-10-86-43-17.ec2.internal"},
+			"fqdns":         []any{"asset.writer.test"},
 			"ipv4s":         []any{"10.86.43.17"},
+			"ipv6s":         []any{"2001:db8::1"},
 		}},
 	})
 
@@ -420,8 +422,14 @@ func TestCopyVulnerableAssetPlatformReferencesFlattensScannerTargets(t *testing.
 	if got := attrs["hostname"]; got != "ip-10-86-43-17.ec2.internal" {
 		t.Fatalf("hostname = %q, want scanner hostname", got)
 	}
+	if got := attrs["hostnames"]; got != "ip-10-86-43-17.ec2.internal,asset.writer.test" {
+		t.Fatalf("hostnames = %q, want all scanner host fields", got)
+	}
 	if got := attrs["ip"]; got != "10.86.43.17" {
 		t.Fatalf("ip = %q, want scanner IPv4", got)
+	}
+	if got := attrs["ip_addresses"]; got != "10.86.43.17,2001:db8::1" {
+		t.Fatalf("ip_addresses = %q, want all scanner IP fields", got)
 	}
 	var refs []map[string]string
 	if err := json.Unmarshal([]byte(attrs["platform_asset_refs"]), &refs); err != nil {
@@ -429,6 +437,9 @@ func TestCopyVulnerableAssetPlatformReferencesFlattensScannerTargets(t *testing.
 	}
 	if len(refs) != 1 || refs[0]["provider"] != "aws" || refs[0]["resource_id"] != "arn:aws:ec2:us-east-1:381491964434:instance/i-0f359ce073424f8d6" {
 		t.Fatalf("platform_asset_refs = %#v, want AWS EC2 resource ref", refs)
+	}
+	if refs[0]["hostnames"] != "ip-10-86-43-17.ec2.internal,asset.writer.test" || refs[0]["ips"] != "10.86.43.17,2001:db8::1" {
+		t.Fatalf("platform_asset_refs network fields = %#v, want all scanner host/IP fields", refs[0])
 	}
 }
 

--- a/sources/grc/source_test.go
+++ b/sources/grc/source_test.go
@@ -410,8 +410,8 @@ func TestCopyVulnerableAssetPlatformReferencesFlattensScannerTargets(t *testing.
 		}},
 	})
 
-	if got := attrs["integration_id"]; got != "aws" {
-		t.Fatalf("integration_id = %q, want aws", got)
+	if got := attrs["integration_id"]; got != "" {
+		t.Fatalf("integration_id = %q, want unset without top-level Vanta integration", got)
 	}
 	if got := attrs["platform_resource_id"]; got != "arn:aws:ec2:us-east-1:381491964434:instance/i-0f359ce073424f8d6" {
 		t.Fatalf("platform_resource_id = %q, want EC2 ARN", got)


### PR DESCRIPTION
## Summary
- flatten Vanta vulnerable-asset `scanners[]` into platform asset refs, hostnames, IPs, and integration IDs
- project GRC vulnerable assets to provider resources such as AWS EC2 instance ARNs
- link both GRC targets and platform resource nodes to host/IP identities and cloud accounts

## Testing
- `go test ./sources/grc ./internal/sourceprojection -run 'Test(CopyVulnerableAssetPlatformReferencesFlattensScannerTargets|ProjectGRCVulnerableAssetLinksPlatformResources|ProjectGRCVulnerableAssetEnrichesVulnerabilityTarget|ReadGRCVulnerableAsset)' -count=1`\n- `make verify`\n- `git diff --check`