### PR TITLE
fix(cosmo): use scoped message export endpoint

### DIFF
--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -529,7 +529,7 @@ func (s *Source) listMessages(ctx context.Context, settings settings, window mes
 	query.Set("until", window.until.Format(time.RFC3339Nano))
 
 	var response listResponse
-	if err := s.getJSON(ctx, settings, http.MethodGet, "/api/ui/memory/messages", query, nil, &response); err != nil {
+	if err := s.getJSON(ctx, settings, http.MethodGet, "/api/cerebro/messages", query, nil, &response); err != nil {
 		return nil, err
 	}
 	records, err := responseRecords(response, "messages", familyMessage)

--- a/sources/cosmo/source_test.go
+++ b/sources/cosmo/source_test.go
@@ -201,7 +201,7 @@ func TestReadMessagesUsesScopedExportContractAndPaginatesEventTypes(t *testing.T
 	var windowSince string
 	var windowUntil string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/ui/memory/messages" {
+		if r.URL.Path != "/api/cerebro/messages" {
 			http.NotFound(w, r)
 			return
 		}
@@ -366,7 +366,7 @@ func TestReadMessagesStartsFirstWindowAtConfiguredSince(t *testing.T) {
 	wantUntil := "2026-05-01T01:00:00Z"
 	var sawRequest bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/ui/memory/messages" {
+		if r.URL.Path != "/api/cerebro/messages" {
 			http.NotFound(w, r)
 			return
 		}
@@ -461,7 +461,7 @@ func TestReadMessagesWithoutSinceUsesStableCompatibilityWindow(t *testing.T) {
 func TestDiscoverMessagesIteratesConfiguredEventTypes(t *testing.T) {
 	var eventTypes []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/ui/memory/messages" {
+		if r.URL.Path != "/api/cerebro/messages" {
 			http.NotFound(w, r)
 			return
 		}
@@ -505,7 +505,7 @@ func TestReadMessagesReturnsHardScopedExportFailures(t *testing.T) {
 	for _, status := range []int{http.StatusBadRequest, http.StatusForbidden} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/api/ui/memory/messages" {
+				if r.URL.Path != "/api/cerebro/messages" {
 					http.NotFound(w, r)
 					return
 				}


### PR DESCRIPTION
## Summary
- switch Cosmo message ingestion from the UI messages route to the dedicated Cerebro export route
- update message export tests to assert `/api/cerebro/messages`

## Context
Cosmo #286 deployed the scoped export endpoint and the old UI route now requires `ticket_id`, causing `writer-cosmo-message` syncs to fail.

## Validation
- go test ./sources/cosmo -run 'TestReadMessagesUsesScopedExportContractAndPaginatesEventTypes|TestReadMessagesStartsFirstWindowAtConfiguredSince|TestDiscoverMessagesIteratesConfiguredEventTypes|TestReadMessagesReturnsHardScopedExportFailures' -count=1 -v\n- make verify