### PR TITLE
fix(okta): suppress ephemeral oauth resources

### DIFF
--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -28,6 +28,7 @@ const (
 	DefaultStatusLimit       = 25
 	MaxStatusLimit           = 500
 	terminalRunUpdateTimeout = 15 * time.Second
+	defaultCleanupLimit      = 1000
 )
 
 var (
@@ -63,6 +64,14 @@ type Service struct {
 
 type projectionRecordProjector interface {
 	ProjectRecords(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error)
+}
+
+type projectionRecordCleanupProjector interface {
+	ProjectCleanupRecords(*cerebrov1.EventEnvelope) ([]string, error)
+}
+
+type projectionRecordCleanupRequestProjector interface {
+	ProjectCleanupRequests(*cerebrov1.EventEnvelope) ([]ports.ProjectionCleanupRequest, error)
 }
 
 type pageProjectionResult struct {
@@ -444,6 +453,7 @@ func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*Ing
 		result.GraphNodesBefore = counts.Nodes
 		result.GraphLinksBefore = counts.Relations
 	}
+	completedCleanupRequests := map[string]struct{}{}
 	for i := uint32(0); i < request.PageLimit; i++ {
 		response, err := s.sourceService.Read(ctx, &cerebrov1.ReadSourceRequest{
 			SourceId: request.SourceID,
@@ -455,7 +465,7 @@ func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*Ing
 		}
 		result.PagesRead++
 		if recordProjector, ok := s.projector.(projectionRecordProjector); ok {
-			projected, err := s.projectResponseCoalesced(ctx, request, response, recordProjector)
+			projected, err := s.projectResponseCoalesced(ctx, request, response, recordProjector, completedCleanupRequests)
 			result.EventsRead += projected.EventsRead
 			result.EntitiesProjected += projected.EntitiesProjected
 			result.LinksProjected += projected.LinksProjected
@@ -497,13 +507,15 @@ func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*Ing
 	return result, nil
 }
 
-func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRequest, response *cerebrov1.ReadSourceResponse, projector projectionRecordProjector) (pageProjectionResult, error) {
+func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRequest, response *cerebrov1.ReadSourceResponse, projector projectionRecordProjector, completedCleanupRequests map[string]struct{}) (pageProjectionResult, error) {
 	graphStore, ok := s.graphStore.(ports.ProjectionGraphStore)
 	if !ok {
 		return pageProjectionResult{}, ErrRuntimeUnavailable
 	}
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
+	cleanupURNs := map[string]struct{}{}
+	cleanupRequests := map[string]ports.ProjectionCleanupRequest{}
 	result := pageProjectionResult{}
 	for _, event := range response.GetEvents() {
 		ingested := ingestEvent(event, request.TenantID, request.RuntimeID)
@@ -517,7 +529,52 @@ func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRe
 		for _, link := range projectedLinks {
 			mergeProjectedLink(links, link)
 		}
+		if cleanupProjector, ok := projector.(projectionRecordCleanupProjector); ok {
+			projectedCleanupURNs, err := cleanupProjector.ProjectCleanupRecords(ingested)
+			if err != nil {
+				return result, fmt.Errorf("project cleanup records for source event %q: %w", event.GetId(), err)
+			}
+			for _, urn := range projectedCleanupURNs {
+				normalizedURN := strings.TrimSpace(urn)
+				if normalizedURN != "" {
+					cleanupURNs[normalizedURN] = struct{}{}
+				}
+			}
+		}
+		if cleanupRequestProjector, ok := projector.(projectionRecordCleanupRequestProjector); ok {
+			projectedCleanupRequests, err := cleanupRequestProjector.ProjectCleanupRequests(ingested)
+			if err != nil {
+				return result, fmt.Errorf("project cleanup requests for source event %q: %w", event.GetId(), err)
+			}
+			for _, request := range projectedCleanupRequests {
+				key := projectionCleanupRequestKey(request)
+				if _, completed := completedCleanupRequests[key]; completed {
+					continue
+				}
+				cleanupRequests[key] = request
+			}
+		}
 		result.EventsRead++
+	}
+	if deleter, ok := graphStore.(ports.ProjectionEntityDeleter); ok {
+		for _, urn := range sortedMapKeys(cleanupURNs) {
+			if _, willUpsert := entities[urn]; willUpsert {
+				continue
+			}
+			if err := deleter.DeleteProjectedEntity(ctx, urn); err != nil {
+				return result, fmt.Errorf("delete coalesced projected entity %q: %w", urn, err)
+			}
+		}
+	}
+	if cleaner, ok := graphStore.(ports.ProjectionCleaner); ok {
+		for _, key := range sortedMapKeys(cleanupRequests) {
+			if _, err := cleanupProjectedEntities(ctx, cleaner, cleanupRequests[key]); err != nil {
+				return result, fmt.Errorf("cleanup coalesced projected entities: %w", err)
+			}
+			if completedCleanupRequests != nil {
+				completedCleanupRequests[key] = struct{}{}
+			}
+		}
 	}
 	entityKeys := sortedMapKeys(entities)
 	for _, key := range entityKeys {
@@ -534,6 +591,47 @@ func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRe
 		result.LinksProjected++
 	}
 	return result, nil
+}
+
+func cleanupProjectedEntities(ctx context.Context, cleaner ports.ProjectionCleaner, request ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
+	result := ports.ProjectionCleanupResult{}
+	limit := projectionCleanupBatchLimit(request)
+	for {
+		cleanup, err := cleaner.CleanupProjectedEntities(ctx, request)
+		if err != nil {
+			return result, err
+		}
+		result.EntitiesDeleted += cleanup.EntitiesDeleted
+		result.LinksDeleted += cleanup.LinksDeleted
+		if cleanup.EntitiesDeleted < limit {
+			return result, nil
+		}
+	}
+}
+
+func projectionCleanupBatchLimit(request ports.ProjectionCleanupRequest) uint32 {
+	if request.Limit == 0 {
+		return defaultCleanupLimit
+	}
+	return request.Limit
+}
+
+func projectionCleanupRequestKey(request ports.ProjectionCleanupRequest) string {
+	entityTypes := append([]string(nil), request.EntityTypes...)
+	urnPrefixes := append([]string(nil), request.URNPrefixes...)
+	sort.Strings(entityTypes)
+	sort.Strings(urnPrefixes)
+	values := []string{
+		strings.TrimSpace(request.TenantID),
+		strings.TrimSpace(request.SourceID),
+		strings.TrimSpace(request.RuntimeID),
+		strings.TrimSpace(request.FindingID),
+		strings.Join(entityTypes, ","),
+		strings.Join(urnPrefixes, ","),
+		fmt.Sprintf("%t", request.OnlyIsolated),
+		fmt.Sprintf("%d", request.Limit),
+	}
+	return strings.Join(values, "|")
 }
 
 func mergeProjectedEntity(entities map[string]*ports.ProjectedEntity, entity *ports.ProjectedEntity) {

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -65,10 +66,36 @@ func (f recordProjectorFunc) ProjectRecords(event *cerebrov1.EventEnvelope) ([]*
 	return f(event)
 }
 
+type cleanupRecordProjector struct {
+	records  func(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error)
+	cleanup  func(*cerebrov1.EventEnvelope) ([]string, error)
+	requests func(*cerebrov1.EventEnvelope) ([]ports.ProjectionCleanupRequest, error)
+}
+
+func (p cleanupRecordProjector) ProjectRecords(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return p.records(event)
+}
+
+func (p cleanupRecordProjector) ProjectCleanupRecords(event *cerebrov1.EventEnvelope) ([]string, error) {
+	if p.cleanup == nil {
+		return nil, nil
+	}
+	return p.cleanup(event)
+}
+
+func (p cleanupRecordProjector) ProjectCleanupRequests(event *cerebrov1.EventEnvelope) ([]ports.ProjectionCleanupRequest, error) {
+	if p.requests == nil {
+		return nil, nil
+	}
+	return p.requests(event)
+}
+
 type recordingProjectionGraphStore struct {
-	entities      map[string]*ports.ProjectedEntity
-	links         map[string]*ports.ProjectedLink
-	upsertLinkErr error
+	entities        map[string]*ports.ProjectedEntity
+	links           map[string]*ports.ProjectedLink
+	upsertLinkErr   error
+	deletedEntities map[string]struct{}
+	cleanupRequests []ports.ProjectionCleanupRequest
 }
 
 func (s *recordingProjectionGraphStore) Ping(context.Context) error { return nil }
@@ -127,6 +154,72 @@ func (s *singlePageSource) Discover(context.Context, sourcecdk.Config) ([]source
 
 func (s *singlePageSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	return sourcecdk.Pull{Events: s.events}, nil
+}
+
+func (s *recordingProjectionGraphStore) DeleteProjectedEntity(_ context.Context, urn string) error {
+	if s.deletedEntities == nil {
+		s.deletedEntities = map[string]struct{}{}
+	}
+	s.deletedEntities[urn] = struct{}{}
+	delete(s.entities, urn)
+	for key, link := range s.links {
+		if link.FromURN == urn || link.ToURN == urn {
+			delete(s.links, key)
+		}
+	}
+	return nil
+}
+
+func (s *recordingProjectionGraphStore) CleanupProjectedEntities(_ context.Context, request ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
+	s.cleanupRequests = append(s.cleanupRequests, request)
+	var result ports.ProjectionCleanupResult
+	limit := projectionCleanupBatchLimit(request)
+	for key, entity := range s.entities {
+		if result.EntitiesDeleted >= limit {
+			break
+		}
+		if !projectionCleanupTestMatches(request, entity) {
+			continue
+		}
+		delete(s.entities, key)
+		result.EntitiesDeleted++
+	}
+	for key, link := range s.links {
+		if _, ok := s.entities[link.FromURN]; !ok {
+			delete(s.links, key)
+			result.LinksDeleted++
+			continue
+		}
+		if _, ok := s.entities[link.ToURN]; !ok {
+			delete(s.links, key)
+			result.LinksDeleted++
+		}
+	}
+	return result, nil
+}
+
+func projectionCleanupTestMatches(request ports.ProjectionCleanupRequest, entity *ports.ProjectedEntity) bool {
+	if request.TenantID != "" && entity.TenantID != request.TenantID {
+		return false
+	}
+	if request.SourceID != "" && entity.SourceID != request.SourceID {
+		return false
+	}
+	if request.RuntimeID != "" && entity.RuntimeID != request.RuntimeID {
+		return false
+	}
+	if len(request.EntityTypes) != 0 && !slices.Contains(request.EntityTypes, entity.EntityType) {
+		return false
+	}
+	if len(request.URNPrefixes) == 0 {
+		return true
+	}
+	for _, prefix := range request.URNPrefixes {
+		if strings.HasPrefix(entity.URN, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSensitiveConfigKeyTreatsSecretMarkersAsSensitive(t *testing.T) {
@@ -243,7 +336,7 @@ func TestProjectResponseCoalescedUpsertsUniqueRecords(t *testing.T) {
 	}, &cerebrov1.ReadSourceResponse{Events: []*cerebrov1.EventEnvelope{
 		{Id: "event-1", SourceId: "github"},
 		{Id: "event-2", SourceId: "github"},
-	}}, projector)
+	}}, projector, nil)
 	if err != nil {
 		t.Fatalf("projectResponseCoalesced() error = %v", err)
 	}
@@ -269,6 +362,260 @@ func TestProjectResponseCoalescedUpsertsUniqueRecords(t *testing.T) {
 	}
 	if got := link.Attributes["event_id"]; got != "event-2" {
 		t.Fatalf("coalesced link event_id = %q, want latest event-2", got)
+	}
+}
+
+func TestProjectResponseCoalescedDeletesCleanupRecords(t *testing.T) {
+	staleURN := "urn:cerebro:writer:okta_resource:access_token:token-123"
+	staleLink := &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "okta",
+		FromURN:  "urn:cerebro:writer:okta_application:0oa-client",
+		Relation: "acted_on",
+		ToURN:    staleURN,
+	}
+	store := &recordingProjectionGraphStore{
+		entities: map[string]*ports.ProjectedEntity{staleURN: {
+			URN:        staleURN,
+			TenantID:   "writer",
+			SourceID:   "okta",
+			RuntimeID:  "okta-audit-runtime",
+			EntityType: "okta.resource",
+			Label:      "token-123",
+		}},
+		links: map[string]*ports.ProjectedLink{"urn:cerebro:writer:okta_application:0oa-client|acted_on|" + staleURN: staleLink},
+	}
+	service := &Service{graphStore: store}
+	projector := cleanupRecordProjector{
+		records: func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+			return []*ports.ProjectedEntity{{
+					URN:        "urn:cerebro:writer:okta_application:0oa-client",
+					TenantID:   event.GetTenantId(),
+					SourceID:   event.GetSourceId(),
+					RuntimeID:  event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+					EntityType: "okta.application",
+					Label:      "Production Client",
+				}},
+				[]*ports.ProjectedLink{{
+					TenantID:  event.GetTenantId(),
+					SourceID:  event.GetSourceId(),
+					RuntimeID: event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+					FromURN:   "urn:cerebro:writer:okta_actor:publicclientapp:0oa-client",
+					Relation:  "acted_on",
+					ToURN:     "urn:cerebro:writer:okta_application:0oa-client",
+				}}, nil
+		},
+		cleanup: func(*cerebrov1.EventEnvelope) ([]string, error) {
+			return []string{staleURN}, nil
+		},
+	}
+
+	_, err := service.projectResponseCoalesced(context.Background(), sourceRequest{
+		SourceID:  "okta",
+		RuntimeID: "okta-audit-runtime",
+		TenantID:  "writer",
+	}, &cerebrov1.ReadSourceResponse{Events: []*cerebrov1.EventEnvelope{{
+		Id:       "okta-oauth-grant",
+		SourceId: "okta",
+	}}}, projector, nil)
+	if err != nil {
+		t.Fatalf("projectResponseCoalesced() error = %v", err)
+	}
+	if _, ok := store.deletedEntities[staleURN]; !ok {
+		t.Fatalf("cleanup entity %q was not deleted", staleURN)
+	}
+	if _, ok := store.entities[staleURN]; ok {
+		t.Fatalf("cleanup entity %q still present", staleURN)
+	}
+	if _, ok := store.links["urn:cerebro:writer:okta_application:0oa-client|acted_on|"+staleURN]; ok {
+		t.Fatalf("stale cleanup link still present")
+	}
+	if _, ok := store.links["urn:cerebro:writer:okta_actor:publicclientapp:0oa-client|acted_on|urn:cerebro:writer:okta_application:0oa-client"]; !ok {
+		t.Fatalf("replacement durable link missing")
+	}
+}
+
+func TestProjectResponseCoalescedRunsCleanupRequestsOnce(t *testing.T) {
+	staleURN := "urn:cerebro:writer:okta_resource:access_token:token-123"
+	appURN := "urn:cerebro:writer:okta_application:0oa-client"
+	store := &recordingProjectionGraphStore{
+		entities: map[string]*ports.ProjectedEntity{
+			staleURN: {
+				URN:        staleURN,
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.resource",
+				Label:      "token-123",
+			},
+			appURN: {
+				URN:        appURN,
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.application",
+				Label:      "Production Client",
+			},
+		},
+		links: map[string]*ports.ProjectedLink{
+			appURN + "|acted_on|" + staleURN: {
+				TenantID: "writer",
+				SourceID: "okta",
+				FromURN:  appURN,
+				Relation: "acted_on",
+				ToURN:    staleURN,
+			},
+		},
+	}
+	service := &Service{graphStore: store}
+	projector := cleanupRecordProjector{
+		records: func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+			return []*ports.ProjectedEntity{{
+				URN:        appURN,
+				TenantID:   event.GetTenantId(),
+				SourceID:   event.GetSourceId(),
+				RuntimeID:  event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				EntityType: "okta.application",
+				Label:      "Production Client",
+			}}, nil, nil
+		},
+		requests: func(event *cerebrov1.EventEnvelope) ([]ports.ProjectionCleanupRequest, error) {
+			return []ports.ProjectionCleanupRequest{{
+				TenantID:    event.GetTenantId(),
+				SourceID:    event.GetSourceId(),
+				RuntimeID:   event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				EntityTypes: []string{"okta.resource"},
+				URNPrefixes: []string{"urn:cerebro:writer:okta_resource:access_token:"},
+				Limit:       1000,
+			}}, nil
+		},
+	}
+
+	_, err := service.projectResponseCoalesced(context.Background(), sourceRequest{
+		SourceID:  "okta",
+		RuntimeID: "okta-audit-runtime",
+		TenantID:  "writer",
+	}, &cerebrov1.ReadSourceResponse{Events: []*cerebrov1.EventEnvelope{
+		{Id: "okta-oauth-grant-1", SourceId: "okta"},
+		{Id: "okta-oauth-grant-2", SourceId: "okta"},
+	}}, projector, nil)
+	if err != nil {
+		t.Fatalf("projectResponseCoalesced() error = %v", err)
+	}
+	if got := len(store.cleanupRequests); got != 1 {
+		t.Fatalf("cleanup requests = %d, want 1 deduped request", got)
+	}
+	if _, ok := store.entities[staleURN]; ok {
+		t.Fatalf("stale cleanup entity %q still present", staleURN)
+	}
+	if _, ok := store.links[appURN+"|acted_on|"+staleURN]; ok {
+		t.Fatalf("stale cleanup link still present")
+	}
+	if _, ok := store.entities[appURN]; !ok {
+		t.Fatalf("durable app entity was deleted")
+	}
+}
+
+func TestProjectResponseCoalescedSkipsCompletedCleanupRequests(t *testing.T) {
+	store := &recordingProjectionGraphStore{
+		entities: map[string]*ports.ProjectedEntity{
+			"urn:cerebro:writer:okta_resource:access_token:token-123": {
+				URN:        "urn:cerebro:writer:okta_resource:access_token:token-123",
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.resource",
+				Label:      "token-123",
+			},
+		},
+	}
+	service := &Service{graphStore: store}
+	projector := cleanupRecordProjector{
+		records: func(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+			return nil, nil, nil
+		},
+		requests: func(event *cerebrov1.EventEnvelope) ([]ports.ProjectionCleanupRequest, error) {
+			return []ports.ProjectionCleanupRequest{{
+				TenantID:    event.GetTenantId(),
+				SourceID:    event.GetSourceId(),
+				RuntimeID:   event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				EntityTypes: []string{"okta.resource"},
+				URNPrefixes: []string{"urn:cerebro:writer:okta_resource:access_token:"},
+				Limit:       1000,
+			}}, nil
+		},
+	}
+	completedCleanupRequests := map[string]struct{}{}
+	request := sourceRequest{SourceID: "okta", RuntimeID: "okta-audit-runtime", TenantID: "writer"}
+	response := func(id string) *cerebrov1.ReadSourceResponse {
+		return &cerebrov1.ReadSourceResponse{Events: []*cerebrov1.EventEnvelope{{Id: id, SourceId: "okta"}}}
+	}
+
+	if _, err := service.projectResponseCoalesced(context.Background(), request, response("okta-oauth-grant-page-1"), projector, completedCleanupRequests); err != nil {
+		t.Fatalf("projectResponseCoalesced(page 1) error = %v", err)
+	}
+	if _, err := service.projectResponseCoalesced(context.Background(), request, response("okta-oauth-grant-page-2"), projector, completedCleanupRequests); err != nil {
+		t.Fatalf("projectResponseCoalesced(page 2) error = %v", err)
+	}
+	if got := len(store.cleanupRequests); got != 1 {
+		t.Fatalf("cleanup requests = %d, want 1 across pages", got)
+	}
+}
+
+func TestProjectResponseCoalescedRunsCleanupRequestsUntilExhausted(t *testing.T) {
+	store := &recordingProjectionGraphStore{
+		entities: map[string]*ports.ProjectedEntity{
+			"urn:cerebro:writer:okta_resource:access_token:token-1": {
+				URN:        "urn:cerebro:writer:okta_resource:access_token:token-1",
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.resource",
+				Label:      "token-1",
+			},
+			"urn:cerebro:writer:okta_resource:access_token:token-2": {
+				URN:        "urn:cerebro:writer:okta_resource:access_token:token-2",
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.resource",
+				Label:      "token-2",
+			},
+		},
+	}
+	service := &Service{graphStore: store}
+	projector := cleanupRecordProjector{
+		records: func(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+			return nil, nil, nil
+		},
+		requests: func(event *cerebrov1.EventEnvelope) ([]ports.ProjectionCleanupRequest, error) {
+			return []ports.ProjectionCleanupRequest{{
+				TenantID:    event.GetTenantId(),
+				SourceID:    event.GetSourceId(),
+				RuntimeID:   event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				EntityTypes: []string{"okta.resource"},
+				URNPrefixes: []string{"urn:cerebro:writer:okta_resource:access_token:"},
+				Limit:       1,
+			}}, nil
+		},
+	}
+
+	_, err := service.projectResponseCoalesced(context.Background(), sourceRequest{
+		SourceID:  "okta",
+		RuntimeID: "okta-audit-runtime",
+		TenantID:  "writer",
+	}, &cerebrov1.ReadSourceResponse{Events: []*cerebrov1.EventEnvelope{{
+		Id:       "okta-oauth-grant",
+		SourceId: "okta",
+	}}}, projector, nil)
+	if err != nil {
+		t.Fatalf("projectResponseCoalesced() error = %v", err)
+	}
+	if got := len(store.cleanupRequests); got != 3 {
+		t.Fatalf("cleanup calls = %d, want 3 calls to confirm exhaustion", got)
+	}
+	if len(store.entities) != 0 {
+		t.Fatalf("store retained %d cleanup entities", len(store.entities))
 	}
 }
 
@@ -318,7 +665,7 @@ func TestProjectResponseCoalescedPreservesNewestObservationAttributes(t *testing
 	}, &cerebrov1.ReadSourceResponse{Events: []*cerebrov1.EventEnvelope{
 		{Id: "newer-event", SourceId: "github"},
 		{Id: "older-event", SourceId: "github"},
-	}}, projector)
+	}}, projector, nil)
 	if err != nil {
 		t.Fatalf("projectResponseCoalesced() error = %v", err)
 	}

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -490,13 +490,15 @@ func (s *Store) CleanupProjectedEntities(ctx context.Context, request ports.Proj
 	runtimeID := strings.TrimSpace(request.RuntimeID)
 	findingID := strings.TrimSpace(request.FindingID)
 	entityTypes := normalizeCleanupEntityTypes(request.EntityTypes)
-	if tenantID == "" && sourceID == "" && runtimeID == "" && findingID == "" && len(entityTypes) == 0 {
+	urnPrefixes := normalizeCleanupValues(request.URNPrefixes)
+	if tenantID == "" && sourceID == "" && runtimeID == "" && findingID == "" && len(entityTypes) == 0 && len(urnPrefixes) == 0 {
 		return ports.ProjectionCleanupResult{}, errors.New("projection cleanup scope is required")
 	}
 	conditions := []string{}
 	params := map[string]any{
 		"limit":        limit,
 		"entity_types": entityTypes,
+		"urn_prefixes": urnPrefixes,
 	}
 	if tenantID != "" {
 		conditions = append(conditions, "e.tenant_id = $tenant_id")
@@ -516,6 +518,9 @@ func (s *Store) CleanupProjectedEntities(ctx context.Context, request ports.Proj
 	}
 	if len(entityTypes) != 0 {
 		conditions = append(conditions, "e.entity_type IN $entity_types")
+	}
+	if len(urnPrefixes) != 0 {
+		conditions = append(conditions, "any(prefix IN $urn_prefixes WHERE e.urn STARTS WITH prefix)")
 	}
 	if request.OnlyIsolated && findingID == "" {
 		conditions = append(conditions, "NOT (e)-[:RELATION]-()")
@@ -1057,6 +1062,10 @@ func validateProjectedLinkIdentity(link *ports.ProjectedLink) (fromURN string, t
 }
 
 func normalizeCleanupEntityTypes(values []string) []string {
+	return normalizeCleanupValues(values)
+}
+
+func normalizeCleanupValues(values []string) []string {
 	seen := make(map[string]struct{}, len(values))
 	normalized := make([]string, 0, len(values))
 	for _, value := range values {

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -43,6 +43,7 @@ type ProjectionCleanupRequest struct {
 	RuntimeID    string
 	FindingID    string
 	EntityTypes  []string
+	URNPrefixes  []string
 	OnlyIsolated bool
 	Limit        uint32
 }

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -45,13 +47,16 @@ const (
 	relationTaggedAs           = "tagged_as"
 	relationTargeted           = "targeted"
 	relationCNAMETo            = "cname_to"
+	defaultCleanupLimit        = 1000
 )
 
 // Service materializes synced source events into current-state and graph stores.
 type Service struct {
-	state    ports.ProjectionStateStore
-	graph    ports.ProjectionGraphStore
-	registry *Registry
+	state             ports.ProjectionStateStore
+	graph             ports.ProjectionGraphStore
+	registry          *Registry
+	cleanupMu         sync.Mutex
+	cleanupRequestRun map[string]struct{}
 }
 
 // New constructs a source projector.
@@ -79,6 +84,23 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 	if err != nil {
 		return ports.ProjectionResult{}, err
 	}
+	cleanupURNs, err := s.ProjectCleanupRecords(event)
+	if err != nil {
+		return ports.ProjectionResult{}, err
+	}
+	entitiesDeleted, err := s.deleteProjectedEntities(ctx, cleanupURNs)
+	if err != nil {
+		return ports.ProjectionResult{}, err
+	}
+	cleanupRequests, err := s.ProjectCleanupRequests(event)
+	if err != nil {
+		return ports.ProjectionResult{}, err
+	}
+	cleanupDeleted, err := s.cleanupProjectedEntities(ctx, cleanupRequests)
+	if err != nil {
+		return ports.ProjectionResult{}, err
+	}
+	entitiesDeleted += cleanupDeleted.EntitiesDeleted
 	for _, entity := range entities {
 		if s.state != nil {
 			if err := s.state.UpsertProjectedEntity(ctx, entity); err != nil {
@@ -106,6 +128,8 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 	return ports.ProjectionResult{
 		EntitiesProjected: uint32(len(entities)),
 		LinksProjected:    uint32(len(links)),
+		EntitiesDeleted:   entitiesDeleted,
+		LinksDeleted:      cleanupDeleted.LinksDeleted,
 	}, nil
 }
 
@@ -125,6 +149,194 @@ func (s *Service) ProjectRecords(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	}
 	stampProjectionRuntime(event, entities, links)
 	return entities, links, nil
+}
+
+// ProjectCleanupRecords returns stale projection entity URNs that should be
+// removed while applying this event.
+func (s *Service) ProjectCleanupRecords(event *cerebrov1.EventEnvelope) ([]string, error) {
+	if event == nil {
+		return nil, fmt.Errorf("event is required")
+	}
+	if event.GetKind() != "okta.audit" {
+		return nil, nil
+	}
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, err
+	}
+	attributes := event.GetAttributes()
+	resourceType := strings.TrimSpace(attributes["resource_type"])
+	if !oktaEphemeralOAuthRuntimeResource(resourceType, attributes) {
+		return nil, nil
+	}
+	resourceURN := oktaResourceURN(tenantID, resourceType, strings.TrimSpace(attributes["resource_id"]))
+	if resourceURN == "" {
+		return nil, nil
+	}
+	return []string{resourceURN}, nil
+}
+
+// ProjectCleanupRequests returns scoped cleanup passes that should run while applying this event.
+func (s *Service) ProjectCleanupRequests(event *cerebrov1.EventEnvelope) ([]ports.ProjectionCleanupRequest, error) {
+	if event == nil {
+		return nil, fmt.Errorf("event is required")
+	}
+	if event.GetKind() != "okta.audit" {
+		return nil, nil
+	}
+	attributes := event.GetAttributes()
+	if !oktaRuntimeGrant(attributes) {
+		return nil, nil
+	}
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, err
+	}
+	return []ports.ProjectionCleanupRequest{{
+		TenantID:    tenantID,
+		SourceID:    strings.TrimSpace(event.GetSourceId()),
+		RuntimeID:   strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID]),
+		EntityTypes: []string{"okta.resource"},
+		URNPrefixes: oktaEphemeralOAuthRuntimeResourceURNPrefixes(tenantID),
+		Limit:       1000,
+	}}, nil
+}
+
+func (s *Service) deleteProjectedEntities(ctx context.Context, urns []string) (uint32, error) {
+	if len(urns) == 0 {
+		return 0, nil
+	}
+	deleted := uint32(0)
+	seen := map[string]struct{}{}
+	for _, urn := range urns {
+		normalizedURN := strings.TrimSpace(urn)
+		if normalizedURN == "" {
+			continue
+		}
+		if _, ok := seen[normalizedURN]; ok {
+			continue
+		}
+		seen[normalizedURN] = struct{}{}
+		stateDeleted, err := deleteProjectedEntity(ctx, s.state, normalizedURN)
+		if err != nil {
+			return deleted, err
+		}
+		graphDeleted, err := deleteProjectedEntity(ctx, s.graph, normalizedURN)
+		if err != nil {
+			return deleted, err
+		}
+		if stateDeleted || graphDeleted {
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+func (s *Service) cleanupProjectedEntities(ctx context.Context, requests []ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
+	requests = s.pendingCleanupRequests(requests)
+	if len(requests) == 0 {
+		return ports.ProjectionCleanupResult{}, nil
+	}
+	result := ports.ProjectionCleanupResult{}
+	for _, store := range []any{s.state, s.graph} {
+		cleaner, ok := store.(ports.ProjectionCleaner)
+		if !ok {
+			continue
+		}
+		cleanup, err := cleanupProjectedEntitiesInStore(ctx, cleaner, requests)
+		if err != nil {
+			return result, err
+		}
+		result.EntitiesDeleted += cleanup.EntitiesDeleted
+		result.LinksDeleted += cleanup.LinksDeleted
+	}
+	s.markCleanupRequests(requests)
+	return result, nil
+}
+
+func cleanupProjectedEntitiesInStore(ctx context.Context, cleaner ports.ProjectionCleaner, requests []ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
+	result := ports.ProjectionCleanupResult{}
+	for _, request := range requests {
+		limit := cleanupBatchLimit(request)
+		for {
+			cleanup, err := cleaner.CleanupProjectedEntities(ctx, request)
+			if err != nil {
+				return result, err
+			}
+			result.EntitiesDeleted += cleanup.EntitiesDeleted
+			result.LinksDeleted += cleanup.LinksDeleted
+			if cleanup.EntitiesDeleted < limit {
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func cleanupBatchLimit(request ports.ProjectionCleanupRequest) uint32 {
+	if request.Limit == 0 {
+		return defaultCleanupLimit
+	}
+	return request.Limit
+}
+
+func (s *Service) pendingCleanupRequests(requests []ports.ProjectionCleanupRequest) []ports.ProjectionCleanupRequest {
+	if s == nil || len(requests) == 0 {
+		return nil
+	}
+	s.cleanupMu.Lock()
+	defer s.cleanupMu.Unlock()
+	pending := make([]ports.ProjectionCleanupRequest, 0, len(requests))
+	for _, request := range requests {
+		if _, ok := s.cleanupRequestRun[projectionCleanupRequestKey(request)]; ok {
+			continue
+		}
+		pending = append(pending, request)
+	}
+	return pending
+}
+
+func (s *Service) markCleanupRequests(requests []ports.ProjectionCleanupRequest) {
+	if s == nil || len(requests) == 0 {
+		return
+	}
+	s.cleanupMu.Lock()
+	defer s.cleanupMu.Unlock()
+	if s.cleanupRequestRun == nil {
+		s.cleanupRequestRun = map[string]struct{}{}
+	}
+	for _, request := range requests {
+		s.cleanupRequestRun[projectionCleanupRequestKey(request)] = struct{}{}
+	}
+}
+
+func projectionCleanupRequestKey(request ports.ProjectionCleanupRequest) string {
+	entityTypes := append([]string(nil), request.EntityTypes...)
+	urnPrefixes := append([]string(nil), request.URNPrefixes...)
+	sort.Strings(entityTypes)
+	sort.Strings(urnPrefixes)
+	values := []string{
+		strings.TrimSpace(request.TenantID),
+		strings.TrimSpace(request.SourceID),
+		strings.TrimSpace(request.RuntimeID),
+		strings.TrimSpace(request.FindingID),
+		strings.Join(entityTypes, ","),
+		strings.Join(urnPrefixes, ","),
+		fmt.Sprintf("%t", request.OnlyIsolated),
+		fmt.Sprintf("%d", request.Limit),
+	}
+	return strings.Join(values, "|")
+}
+
+func deleteProjectedEntity(ctx context.Context, store any, urn string) (bool, error) {
+	deleter, ok := store.(ports.ProjectionEntityDeleter)
+	if !ok {
+		return false, nil
+	}
+	if err := deleter.DeleteProjectedEntity(ctx, urn); err != nil {
+		return true, fmt.Errorf("delete projected entity %q: %w", urn, err)
+	}
+	return true, nil
 }
 
 func stampProjectionRuntime(event *cerebrov1.EventEnvelope, entities []*ports.ProjectedEntity, links []*ports.ProjectedLink) {
@@ -801,7 +1013,11 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		})
 	}
 
-	resourceURN := oktaResourceURN(tenantID, resourceType, resourceID)
+	suppressResource := oktaEphemeralOAuthRuntimeResource(resourceType, attributes)
+	resourceURN := ""
+	if !suppressResource {
+		resourceURN = oktaResourceURN(tenantID, resourceType, resourceID)
+	}
 	if resourceURN != "" {
 		entityType := "okta.resource"
 		if strings.EqualFold(resourceType, "user") {
@@ -843,10 +1059,7 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), oauthClientURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
 		if resourceURN != "" {
-			addLink(links, projectedLink(tenantID, event.GetSourceId(), oauthClientURN, resourceURN, relationActedOn, oktaAuditRelationAttributes(event, attributes, map[string]string{
-				"oauth_event_category": attributes["oauth_event_category"],
-				"grant_type":           attributes["grant_type"],
-			})))
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), oauthClientURN, resourceURN, relationActedOn, oktaOAuthRelationAttributes(event, attributes)))
 		}
 	}
 
@@ -869,6 +1082,9 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		}
 		if resourceURN != "" && resourceURN != actorURN {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, resourceURN, relationActedOn, oktaAuditRelationAttributes(event, attributes, nil)))
+		}
+		if suppressResource && oauthClientURN != "" && oauthClientURN != actorURN {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, oauthClientURN, relationActedOn, oktaOAuthRelationAttributes(event, attributes)))
 		}
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorAlternateID, event.GetOccurredAt())
 	}
@@ -894,6 +1110,84 @@ func oktaAuditRelationAttributes(event *cerebrov1.EventEnvelope, attributes map[
 		addProjectedAttribute(relationAttrs, key, strings.TrimSpace(value))
 	}
 	return relationAttrs
+}
+
+func oktaOAuthRelationAttributes(event *cerebrov1.EventEnvelope, attributes map[string]string) map[string]string {
+	return oktaAuditRelationAttributes(event, attributes, map[string]string{
+		"oauth_event_category": attributes["oauth_event_category"],
+		"grant_type":           attributes["grant_type"],
+	})
+}
+
+func oktaEphemeralOAuthRuntimeResource(resourceType string, attributes map[string]string) bool {
+	if !oktaRuntimeGrant(attributes) {
+		return false
+	}
+	switch compactOktaResourceType(resourceType) {
+	case "accesstoken", "refreshtoken", "authorizationcode", "idtoken", "code":
+		return true
+	default:
+		return false
+	}
+}
+
+func oktaEphemeralOAuthRuntimeResourceURNPrefixes(tenantID string) []string {
+	resourceTypes := []string{
+		"access_token",
+		"accesstoken",
+		"access-token",
+		"access token",
+		"refresh_token",
+		"refreshtoken",
+		"refresh-token",
+		"refresh token",
+		"authorization_code",
+		"authorizationcode",
+		"authorization-code",
+		"authorization code",
+		"id_token",
+		"idtoken",
+		"id-token",
+		"id token",
+		"code",
+	}
+	prefixes := make([]string, 0, len(resourceTypes))
+	for _, resourceType := range resourceTypes {
+		prefix := projectionURN(tenantID, "okta_resource", resourceType)
+		if prefix != "" {
+			prefixes = append(prefixes, prefix+":")
+		}
+	}
+	return prefixes
+}
+
+func oktaRuntimeGrant(attributes map[string]string) bool {
+	if strings.EqualFold(strings.TrimSpace(attributes["oauth_event_category"]), "runtime_grant") {
+		return true
+	}
+	eventType := strings.ToLower(strings.TrimSpace(attributes["event_type"]))
+	switch eventType {
+	case "app.oauth2.authorize.code", "app.oauth2.as.authorize.code":
+		return true
+	default:
+		return strings.HasPrefix(eventType, "app.oauth2.token.grant.") ||
+			strings.HasPrefix(eventType, "app.oauth2.as.token.grant.")
+	}
+}
+
+func compactOktaResourceType(resourceType string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + ('a' - 'A')
+		case r >= '0' && r <= '9':
+			return r
+		default:
+			return -1
+		}
+	}, strings.TrimSpace(resourceType))
 }
 
 func entitiesAndLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink) ([]*ports.ProjectedEntity, []*ports.ProjectedLink) {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -185,7 +185,8 @@ func (s *Service) ProjectCleanupRequests(event *cerebrov1.EventEnvelope) ([]port
 		return nil, nil
 	}
 	attributes := event.GetAttributes()
-	if !oktaRuntimeGrant(attributes) {
+	runtimeID := strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])
+	if runtimeID == "" {
 		return nil, nil
 	}
 	tenantID, err := tenantID(event)
@@ -195,7 +196,7 @@ func (s *Service) ProjectCleanupRequests(event *cerebrov1.EventEnvelope) ([]port
 	return []ports.ProjectionCleanupRequest{{
 		TenantID:    tenantID,
 		SourceID:    strings.TrimSpace(event.GetSourceId()),
-		RuntimeID:   strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID]),
+		RuntimeID:   runtimeID,
 		EntityTypes: []string{"okta.resource"},
 		URNPrefixes: oktaEphemeralOAuthRuntimeResourceURNPrefixes(tenantID),
 		Limit:       1000,

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -639,6 +639,51 @@ func TestProjectOktaAuditRunsScopedEphemeralOAuthResourceCleanup(t *testing.T) {
 	}
 }
 
+func TestProjectOktaAuditRunsScopedEphemeralOAuthCleanupOnNonGrantEvent(t *testing.T) {
+	staleURN := "urn:cerebro:writer:okta_resource:refresh_token:old-token"
+	state := &projectionRecorder{
+		entities: map[string]*ports.ProjectedEntity{
+			staleURN: {
+				URN:        staleURN,
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.resource",
+				Label:      "old-token",
+			},
+		},
+	}
+	service := New(state, nil)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "okta-user-update",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.audit",
+		Attributes: map[string]string{
+			ports.EventAttributeSourceRuntimeID: "okta-audit-runtime",
+			"domain":                            "writer.okta.com",
+			"event_type":                        "user.account.update_profile",
+			"actor_id":                          "00u-admin",
+			"actor_type":                        "User",
+			"resource_id":                       "00u-user",
+			"resource_type":                     "User",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesDeleted == 0 {
+		t.Fatalf("EntitiesDeleted = 0, want cleanup deletions from non-grant event")
+	}
+	if got := len(state.cleanupRequests); got != 1 {
+		t.Fatalf("state cleanup calls = %d, want 1", got)
+	}
+	if _, ok := state.entities[staleURN]; ok {
+		t.Fatalf("state retained stale cleanup token")
+	}
+}
+
 func TestCleanupProjectedEntitiesRepeatsUntilExhausted(t *testing.T) {
 	graph := &projectionRecorder{
 		entities: map[string]*ports.ProjectedEntity{

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 type projectionRecorder struct {
-	entities map[string]*ports.ProjectedEntity
-	links    map[string]*ports.ProjectedLink
+	entities        map[string]*ports.ProjectedEntity
+	links           map[string]*ports.ProjectedLink
+	deletedEntities map[string]struct{}
+	cleanupRequests []ports.ProjectionCleanupRequest
 }
 
 func (r *projectionRecorder) Ping(context.Context) error {
@@ -42,6 +44,81 @@ func (r *projectionRecorder) UpsertProjectedLink(_ context.Context, link *ports.
 	}
 	r.links[projectedLinkKey(link)] = cloneProjectedLink(link)
 	return nil
+}
+
+func (r *projectionRecorder) DeleteProjectedEntity(_ context.Context, urn string) error {
+	if r.deletedEntities == nil {
+		r.deletedEntities = make(map[string]struct{})
+	}
+	r.deletedEntities[urn] = struct{}{}
+	delete(r.entities, urn)
+	for key, link := range r.links {
+		if link.FromURN == urn || link.ToURN == urn {
+			delete(r.links, key)
+		}
+	}
+	return nil
+}
+
+func (r *projectionRecorder) CleanupProjectedEntities(_ context.Context, request ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
+	r.cleanupRequests = append(r.cleanupRequests, request)
+	var result ports.ProjectionCleanupResult
+	limit := cleanupBatchLimit(request)
+	for urn, entity := range r.entities {
+		if result.EntitiesDeleted >= limit {
+			break
+		}
+		if !projectionRecorderCleanupMatches(request, entity) {
+			continue
+		}
+		delete(r.entities, urn)
+		result.EntitiesDeleted++
+	}
+	for key, link := range r.links {
+		if _, ok := r.entities[link.FromURN]; !ok {
+			delete(r.links, key)
+			result.LinksDeleted++
+			continue
+		}
+		if _, ok := r.entities[link.ToURN]; !ok {
+			delete(r.links, key)
+			result.LinksDeleted++
+		}
+	}
+	return result, nil
+}
+
+func projectionRecorderCleanupMatches(request ports.ProjectionCleanupRequest, entity *ports.ProjectedEntity) bool {
+	if request.TenantID != "" && entity.TenantID != request.TenantID {
+		return false
+	}
+	if request.SourceID != "" && entity.SourceID != request.SourceID {
+		return false
+	}
+	if request.RuntimeID != "" && entity.RuntimeID != request.RuntimeID {
+		return false
+	}
+	if len(request.EntityTypes) != 0 {
+		matchedType := false
+		for _, entityType := range request.EntityTypes {
+			if entity.EntityType == entityType {
+				matchedType = true
+				break
+			}
+		}
+		if !matchedType {
+			return false
+		}
+	}
+	if len(request.URNPrefixes) == 0 {
+		return true
+	}
+	for _, prefix := range request.URNPrefixes {
+		if strings.HasPrefix(entity.URN, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestProjectGitHubPullRequest(t *testing.T) {
@@ -286,6 +363,480 @@ func TestProjectOktaOAuthGrantAsApplicationTelemetry(t *testing.T) {
 	}
 	assertProjectedLink(t, state, clientURN, relationActedOn, userURN)
 	assertProjectedLink(t, state, clientURN, relationBelongsTo, "urn:cerebro:writer:okta_org:writer.okta.com")
+}
+
+func TestProjectOktaAuditSuppressesEphemeralOAuthResources(t *testing.T) {
+	tests := []struct {
+		name         string
+		eventType    string
+		resourceType string
+		grantType    string
+		category     string
+	}{
+		{
+			name:         "access token",
+			eventType:    "app.oauth2.token.grant.access_token",
+			resourceType: "access_token",
+			grantType:    "access_token",
+			category:     "runtime_grant",
+		},
+		{
+			name:         "camel case access token",
+			eventType:    "app.oauth2.token.grant.access_token",
+			resourceType: "AccessToken",
+			grantType:    "access_token",
+			category:     "runtime_grant",
+		},
+		{
+			name:         "kebab case access token with event fallback",
+			eventType:    "app.oauth2.token.grant.access_token",
+			resourceType: "access-token",
+			grantType:    "access_token",
+		},
+		{
+			name:         "refresh token",
+			eventType:    "app.oauth2.token.grant.refresh_token",
+			resourceType: "refresh_token",
+			grantType:    "refresh_token",
+			category:     "runtime_grant",
+		},
+		{
+			name:         "authorization code with event fallback",
+			eventType:    "app.oauth2.authorize.code",
+			resourceType: "AuthorizationCode",
+			grantType:    "authorization_code",
+		},
+		{
+			name:         "id token",
+			eventType:    "app.oauth2.token.grant.id_token",
+			resourceType: "IdToken",
+			grantType:    "id_token",
+			category:     "runtime_grant",
+		},
+		{
+			name:         "code",
+			eventType:    "app.oauth2.authorize.code",
+			resourceType: "code",
+			grantType:    "authorization_code",
+			category:     "runtime_grant",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &projectionRecorder{}
+			service := New(state, nil)
+
+			_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+				Id:       "okta-oauth-token",
+				TenantId: "writer",
+				SourceId: "okta",
+				Kind:     "okta.audit",
+				Attributes: map[string]string{
+					"domain":               "writer.okta.com",
+					"event_type":           tt.eventType,
+					"actor_id":             "0oa-client",
+					"actor_type":           "PublicClientApp",
+					"actor_display_name":   "Production Client",
+					"resource_id":          "token-123",
+					"resource_type":        tt.resourceType,
+					"oauth_client_id":      "0oa-client",
+					"oauth_client_label":   "Production Client",
+					"oauth_client_type":    "PublicClientApp",
+					"oauth_event_category": tt.category,
+					"grant_type":           tt.grantType,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Project() error = %v", err)
+			}
+
+			clientURN := "urn:cerebro:writer:okta_application:0oa-client"
+			actorURN := "urn:cerebro:writer:okta_actor:publicclientapp:0oa-client"
+			resourceURN := oktaResourceURN("writer", tt.resourceType, "token-123")
+			if _, ok := state.entities[resourceURN]; ok {
+				t.Fatalf("ephemeral resource entity %q unexpectedly projected", resourceURN)
+			}
+			assertProjectedLinkMissing(t, state, clientURN, relationActedOn, resourceURN)
+			assertProjectedLinkMissing(t, state, actorURN, relationActedOn, resourceURN)
+			assertProjectedLinkMissing(t, state, resourceURN, relationBelongsTo, "urn:cerebro:writer:okta_org:writer.okta.com")
+			assertProjectedLink(t, state, actorURN, relationActedOn, clientURN)
+
+			link := state.links[actorURN+"|"+relationActedOn+"|"+clientURN]
+			if got := link.Attributes["grant_type"]; got != tt.grantType {
+				t.Fatalf("grant_type = %q, want %q", got, tt.grantType)
+			}
+			if tt.category != "" {
+				if got := link.Attributes["oauth_event_category"]; got != tt.category {
+					t.Fatalf("oauth_event_category = %q, want %q", got, tt.category)
+				}
+			}
+		})
+	}
+}
+
+func TestProjectOktaAuditDeletesPreviouslyProjectedEphemeralOAuthResource(t *testing.T) {
+	resourceURN := "urn:cerebro:writer:okta_resource:access_token:token-123"
+	clientURN := "urn:cerebro:writer:okta_application:0oa-client"
+	oldLink := &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "okta",
+		FromURN:  clientURN,
+		Relation: relationActedOn,
+		ToURN:    resourceURN,
+	}
+	state := &projectionRecorder{
+		entities: map[string]*ports.ProjectedEntity{resourceURN: {
+			URN:        resourceURN,
+			TenantID:   "writer",
+			SourceID:   "okta",
+			EntityType: "okta.resource",
+			Label:      "token-123",
+		}},
+		links: map[string]*ports.ProjectedLink{projectedLinkKey(oldLink): oldLink},
+	}
+	graph := &projectionRecorder{
+		entities: map[string]*ports.ProjectedEntity{resourceURN: {
+			URN:        resourceURN,
+			TenantID:   "writer",
+			SourceID:   "okta",
+			EntityType: "okta.resource",
+			Label:      "token-123",
+		}},
+		links: map[string]*ports.ProjectedLink{projectedLinkKey(oldLink): oldLink},
+	}
+	service := New(state, graph)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "okta-oauth-token",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.audit",
+		Attributes: map[string]string{
+			"domain":               "writer.okta.com",
+			"event_type":           "app.oauth2.token.grant.access_token",
+			"actor_id":             "0oa-client",
+			"actor_type":           "PublicClientApp",
+			"actor_display_name":   "Production Client",
+			"resource_id":          "token-123",
+			"resource_type":        "access_token",
+			"oauth_client_id":      "**********",
+			"oauth_client_label":   "Production Client",
+			"oauth_client_type":    "PublicClientApp",
+			"oauth_event_category": "runtime_grant",
+			"grant_type":           "access_token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesDeleted != 1 {
+		t.Fatalf("EntitiesDeleted = %d, want 1", result.EntitiesDeleted)
+	}
+	for name, recorder := range map[string]*projectionRecorder{"state": state, "graph": graph} {
+		if _, ok := recorder.deletedEntities[resourceURN]; !ok {
+			t.Fatalf("%s did not delete %q", name, resourceURN)
+		}
+		if _, ok := recorder.entities[resourceURN]; ok {
+			t.Fatalf("%s retained deleted entity %q", name, resourceURN)
+		}
+		if _, ok := recorder.links[projectedLinkKey(oldLink)]; ok {
+			t.Fatalf("%s retained deleted link %q", name, projectedLinkKey(oldLink))
+		}
+	}
+}
+
+func TestProjectOktaAuditRunsScopedEphemeralOAuthResourceCleanup(t *testing.T) {
+	staleURN := "urn:cerebro:writer:okta_resource:access_token:old-token"
+	otherRuntimeURN := "urn:cerebro:writer:okta_resource:access_token:other-runtime-token"
+	clientURN := "urn:cerebro:writer:okta_application:0oa-client"
+	oldLink := &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "okta",
+		FromURN:  clientURN,
+		Relation: relationActedOn,
+		ToURN:    staleURN,
+	}
+	graph := &projectionRecorder{
+		entities: map[string]*ports.ProjectedEntity{
+			clientURN: {
+				URN:        clientURN,
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.application",
+				Label:      "Production Client",
+			},
+			staleURN: {
+				URN:        staleURN,
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.resource",
+				Label:      "old-token",
+			},
+			otherRuntimeURN: {
+				URN:        otherRuntimeURN,
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "other-runtime",
+				EntityType: "okta.resource",
+				Label:      "other-runtime-token",
+			},
+		},
+		links: map[string]*ports.ProjectedLink{projectedLinkKey(oldLink): oldLink},
+	}
+	service := New(nil, graph)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "okta-oauth-token",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.audit",
+		Attributes: map[string]string{
+			ports.EventAttributeSourceRuntimeID: "okta-audit-runtime",
+			"domain":                            "writer.okta.com",
+			"event_type":                        "app.oauth2.token.grant.access_token",
+			"actor_id":                          "0oa-client",
+			"actor_type":                        "PublicClientApp",
+			"actor_display_name":                "Production Client",
+			"resource_id":                       "token-123",
+			"resource_type":                     "access_token",
+			"oauth_client_id":                   "**********",
+			"oauth_client_label":                "Production Client",
+			"oauth_client_type":                 "PublicClientApp",
+			"oauth_event_category":              "runtime_grant",
+			"grant_type":                        "access_token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.EntitiesDeleted == 0 {
+		t.Fatalf("EntitiesDeleted = 0, want cleanup deletions")
+	}
+	if got := len(graph.cleanupRequests); got != 1 {
+		t.Fatalf("cleanup requests = %d, want 1", got)
+	}
+	request := graph.cleanupRequests[0]
+	if request.TenantID != "writer" || request.SourceID != "okta" || request.RuntimeID != "okta-audit-runtime" {
+		t.Fatalf("cleanup request scope = (%q, %q, %q), want writer/okta/okta-audit-runtime", request.TenantID, request.SourceID, request.RuntimeID)
+	}
+	if !stringSliceContains(request.EntityTypes, "okta.resource") {
+		t.Fatalf("cleanup request entity types = %#v, want okta.resource", request.EntityTypes)
+	}
+	if !stringSliceContains(request.URNPrefixes, "urn:cerebro:writer:okta_resource:access_token:") {
+		t.Fatalf("cleanup request prefixes = %#v, missing access_token prefix", request.URNPrefixes)
+	}
+	if _, ok := graph.entities[staleURN]; ok {
+		t.Fatalf("stale scoped cleanup entity %q still present", staleURN)
+	}
+	if _, ok := graph.links[projectedLinkKey(oldLink)]; ok {
+		t.Fatalf("stale scoped cleanup link still present")
+	}
+	if _, ok := graph.entities[otherRuntimeURN]; !ok {
+		t.Fatalf("other runtime token was deleted")
+	}
+}
+
+func TestCleanupProjectedEntitiesRepeatsUntilExhausted(t *testing.T) {
+	graph := &projectionRecorder{
+		entities: map[string]*ports.ProjectedEntity{
+			"urn:cerebro:writer:okta_resource:access_token:token-1": {
+				URN:        "urn:cerebro:writer:okta_resource:access_token:token-1",
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.resource",
+				Label:      "token-1",
+			},
+			"urn:cerebro:writer:okta_resource:access_token:token-2": {
+				URN:        "urn:cerebro:writer:okta_resource:access_token:token-2",
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.resource",
+				Label:      "token-2",
+			},
+		},
+	}
+	service := New(nil, graph)
+
+	result, err := service.cleanupProjectedEntities(context.Background(), []ports.ProjectionCleanupRequest{{
+		TenantID:    "writer",
+		SourceID:    "okta",
+		RuntimeID:   "okta-audit-runtime",
+		EntityTypes: []string{"okta.resource"},
+		URNPrefixes: []string{"urn:cerebro:writer:okta_resource:access_token:"},
+		Limit:       1,
+	}})
+	if err != nil {
+		t.Fatalf("cleanupProjectedEntities() error = %v", err)
+	}
+	if result.EntitiesDeleted != 2 {
+		t.Fatalf("EntitiesDeleted = %d, want 2", result.EntitiesDeleted)
+	}
+	if got := len(graph.cleanupRequests); got != 3 {
+		t.Fatalf("cleanup calls = %d, want 3 calls to confirm exhaustion", got)
+	}
+	if len(graph.entities) != 0 {
+		t.Fatalf("graph retained %d cleanup entities", len(graph.entities))
+	}
+}
+
+func TestCleanupProjectedEntitiesRunsAgainstStateStore(t *testing.T) {
+	state := &projectionRecorder{
+		entities: map[string]*ports.ProjectedEntity{
+			"urn:cerebro:writer:okta_resource:access_token:token-1": {
+				URN:        "urn:cerebro:writer:okta_resource:access_token:token-1",
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.resource",
+				Label:      "token-1",
+			},
+		},
+	}
+	service := New(state, nil)
+
+	result, err := service.cleanupProjectedEntities(context.Background(), []ports.ProjectionCleanupRequest{{
+		TenantID:    "writer",
+		SourceID:    "okta",
+		RuntimeID:   "okta-audit-runtime",
+		EntityTypes: []string{"okta.resource"},
+		URNPrefixes: []string{"urn:cerebro:writer:okta_resource:access_token:"},
+		Limit:       1000,
+	}})
+	if err != nil {
+		t.Fatalf("cleanupProjectedEntities() error = %v", err)
+	}
+	if result.EntitiesDeleted != 1 {
+		t.Fatalf("EntitiesDeleted = %d, want 1", result.EntitiesDeleted)
+	}
+	if got := len(state.cleanupRequests); got != 1 {
+		t.Fatalf("state cleanup calls = %d, want 1", got)
+	}
+	if len(state.entities) != 0 {
+		t.Fatalf("state retained %d cleanup entities", len(state.entities))
+	}
+}
+
+func TestProjectOktaAuditRunsScopedCleanupOncePerService(t *testing.T) {
+	state := &projectionRecorder{
+		entities: map[string]*ports.ProjectedEntity{
+			"urn:cerebro:writer:okta_resource:access_token:stale-token": {
+				URN:        "urn:cerebro:writer:okta_resource:access_token:stale-token",
+				TenantID:   "writer",
+				SourceID:   "okta",
+				RuntimeID:  "okta-audit-runtime",
+				EntityType: "okta.resource",
+				Label:      "stale-token",
+			},
+		},
+	}
+	service := New(state, nil)
+	event := func(id string, resourceID string) *cerebrov1.EventEnvelope {
+		return &cerebrov1.EventEnvelope{
+			Id:       id,
+			TenantId: "writer",
+			SourceId: "okta",
+			Kind:     "okta.audit",
+			Attributes: map[string]string{
+				ports.EventAttributeSourceRuntimeID: "okta-audit-runtime",
+				"domain":                            "writer.okta.com",
+				"event_type":                        "app.oauth2.token.grant.access_token",
+				"actor_id":                          "0oa-client",
+				"actor_type":                        "PublicClientApp",
+				"actor_display_name":                "Production Client",
+				"resource_id":                       resourceID,
+				"resource_type":                     "access_token",
+				"oauth_client_id":                   "**********",
+				"oauth_client_label":                "Production Client",
+				"oauth_client_type":                 "PublicClientApp",
+				"oauth_event_category":              "runtime_grant",
+				"grant_type":                        "access_token",
+			},
+		}
+	}
+
+	if _, err := service.Project(context.Background(), event("okta-oauth-token-1", "token-1")); err != nil {
+		t.Fatalf("Project(first) error = %v", err)
+	}
+	if _, err := service.Project(context.Background(), event("okta-oauth-token-2", "token-2")); err != nil {
+		t.Fatalf("Project(second) error = %v", err)
+	}
+	if got := len(state.cleanupRequests); got != 1 {
+		t.Fatalf("state cleanup calls = %d, want 1 deduped cleanup request", got)
+	}
+	if len(state.entities) == 0 {
+		return
+	}
+	if _, ok := state.entities["urn:cerebro:writer:okta_resource:access_token:stale-token"]; ok {
+		t.Fatalf("state retained stale cleanup token")
+	}
+}
+
+func TestProjectOktaAuditDoesNotSuppressBroadTokenResources(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "okta-token-like-resource",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.audit",
+		Attributes: map[string]string{
+			"domain":               "writer.okta.com",
+			"event_type":           "app.oauth2.token.grant.access_token",
+			"actor_id":             "0oa-client",
+			"actor_type":           "PublicClientApp",
+			"resource_id":          "token-123",
+			"resource_type":        "Token",
+			"oauth_client_id":      "0oa-client",
+			"oauth_client_label":   "Production Client",
+			"oauth_client_type":    "PublicClientApp",
+			"oauth_event_category": "runtime_grant",
+			"grant_type":           "access_token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	resourceURN := "urn:cerebro:writer:okta_resource:token:token-123"
+	if _, ok := state.entities[resourceURN]; !ok {
+		t.Fatalf("broad token resource entity %q missing", resourceURN)
+	}
+	assertProjectedLink(t, state, "urn:cerebro:writer:okta_application:0oa-client", relationActedOn, resourceURN)
+}
+
+func TestProjectOktaAuditKeepsCredentialChangeResources(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "okta-api-token-create",
+		TenantId: "writer",
+		SourceId: "okta",
+		Kind:     "okta.audit",
+		Attributes: map[string]string{
+			"domain":               "writer.okta.com",
+			"event_type":           "system.api_token.create",
+			"actor_id":             "00u-admin",
+			"actor_type":           "User",
+			"actor_alternate_id":   "admin@writer.com",
+			"resource_id":          "token-123",
+			"resource_type":        "Token",
+			"oauth_event_category": "credential_change",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	resourceURN := "urn:cerebro:writer:okta_resource:token:token-123"
+	if _, ok := state.entities[resourceURN]; !ok {
+		t.Fatalf("credential change resource entity %q missing", resourceURN)
+	}
+	assertProjectedLink(t, state, "urn:cerebro:writer:okta_user:00u-admin", relationActedOn, resourceURN)
 }
 
 func TestProjectOktaAuditSuppressesSelfActedOnEdge(t *testing.T) {
@@ -1947,4 +2498,13 @@ func cloneProjectedLink(link *ports.ProjectedLink) *ports.ProjectedLink {
 
 func projectedLinkKey(link *ports.ProjectedLink) string {
 	return link.FromURN + "|" + link.Relation + "|" + link.ToURN
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,8 @@ import (
 
 	"github.com/writer/cerebro/internal/ports"
 )
+
+const defaultProjectionCleanupLimit = 1000
 
 var ensureProjectionStatements = []string{
 	`CREATE TABLE IF NOT EXISTS entities (
@@ -72,6 +75,100 @@ func projectedLinkDeleteSQL() string {
 	return `
 DELETE FROM entity_links
 WHERE from_urn = $1 AND relation = $2 AND to_urn = $3`
+}
+
+func projectedEntityLinkDeleteSQL() string {
+	return `
+DELETE FROM entity_links
+WHERE from_urn = $1 OR to_urn = $1`
+}
+
+func projectedEntityDeleteSQL() string {
+	return `
+DELETE FROM entities
+WHERE urn = $1`
+}
+
+func projectedEntityCleanupSQL(request ports.ProjectionCleanupRequest) (string, []any, error) {
+	conditions, args, scoped := projectedEntityCleanupConditions(request)
+	if !scoped {
+		return "", nil, errors.New("projection cleanup scope is required")
+	}
+	limit := request.Limit
+	if limit == 0 {
+		limit = defaultProjectionCleanupLimit
+	}
+	args = append(args, limit)
+	limitPlaceholder := len(args)
+	query := fmt.Sprintf(`
+WITH victims AS (
+  SELECT e.urn
+  FROM entities e
+  WHERE %s
+  ORDER BY e.urn
+  LIMIT $%d
+),
+deleted_links AS (
+  DELETE FROM entity_links l
+  USING victims v
+  WHERE l.from_urn = v.urn OR l.to_urn = v.urn
+  RETURNING 1
+),
+deleted_entities AS (
+  DELETE FROM entities e
+  USING victims v
+  WHERE e.urn = v.urn
+  RETURNING 1
+)
+SELECT
+  (SELECT COUNT(*) FROM deleted_entities) AS entities_deleted,
+  (SELECT COUNT(*) FROM deleted_links) AS links_deleted`, strings.Join(conditions, " AND "), limitPlaceholder)
+	return query, args, nil
+}
+
+func projectedEntityCleanupConditions(request ports.ProjectionCleanupRequest) ([]string, []any, bool) {
+	conditions := []string{}
+	args := []any{}
+	scoped := false
+	addStringCondition := func(column string, value string) {
+		normalized := strings.TrimSpace(value)
+		if normalized == "" {
+			return
+		}
+		args = append(args, normalized)
+		conditions = append(conditions, fmt.Sprintf("e.%s = $%d", column, len(args)))
+		scoped = true
+	}
+	addStringCondition("tenant_id", request.TenantID)
+	addStringCondition("source_id", request.SourceID)
+	addStringCondition("runtime_id", request.RuntimeID)
+	if findingID := strings.TrimSpace(request.FindingID); findingID != "" {
+		args = append(args, findingID)
+		conditions = append(conditions, fmt.Sprintf("e.attributes_json ->> 'finding_id' = $%d", len(args)))
+		scoped = true
+	}
+	if entityTypes := normalizeProjectionCleanupValues(request.EntityTypes); len(entityTypes) != 0 {
+		placeholders := make([]string, 0, len(entityTypes))
+		for _, entityType := range entityTypes {
+			args = append(args, entityType)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		conditions = append(conditions, fmt.Sprintf("e.entity_type IN (%s)", strings.Join(placeholders, ", ")))
+		scoped = true
+	}
+	if urnPrefixes := normalizeProjectionCleanupValues(request.URNPrefixes); len(urnPrefixes) != 0 {
+		prefixConditions := make([]string, 0, len(urnPrefixes))
+		for _, urnPrefix := range urnPrefixes {
+			args = append(args, urnPrefix)
+			prefixConditions = append(prefixConditions, fmt.Sprintf("LEFT(e.urn, LENGTH($%d)) = $%d", len(args), len(args)))
+		}
+		conditions = append(conditions, "("+strings.Join(prefixConditions, " OR ")+")")
+		scoped = true
+	}
+	if request.OnlyIsolated && strings.TrimSpace(request.FindingID) == "" {
+		conditions = append(conditions, "NOT EXISTS (SELECT 1 FROM entity_links l WHERE l.from_urn = e.urn OR l.to_urn = e.urn)")
+	}
+	return conditions, args, scoped
 }
 
 // UpsertProjectedEntity persists one normalized entity in the current-state store.
@@ -185,6 +282,57 @@ func (s *Store) DeleteProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	return nil
 }
 
+// DeleteProjectedEntity removes one normalized entity and any current-state links that reference it.
+func (s *Store) DeleteProjectedEntity(ctx context.Context, urn string) error {
+	normalizedURN := strings.TrimSpace(urn)
+	if normalizedURN == "" {
+		return errors.New("projected entity urn is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureProjectionTables(ctx); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin projected entity delete: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, projectedEntityLinkDeleteSQL(), normalizedURN); err != nil {
+		return fmt.Errorf("delete projected entity links %q: %w", normalizedURN, err)
+	}
+	if _, err := tx.ExecContext(ctx, projectedEntityDeleteSQL(), normalizedURN); err != nil {
+		return fmt.Errorf("delete projected entity %q: %w", normalizedURN, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit projected entity delete %q: %w", normalizedURN, err)
+	}
+	return nil
+}
+
+// CleanupProjectedEntities removes projected entities matching a scoped cleanup request.
+func (s *Store) CleanupProjectedEntities(ctx context.Context, request ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
+	if s == nil || s.db == nil {
+		return ports.ProjectionCleanupResult{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureProjectionTables(ctx); err != nil {
+		return ports.ProjectionCleanupResult{}, err
+	}
+	query, args, err := projectedEntityCleanupSQL(request)
+	if err != nil {
+		return ports.ProjectionCleanupResult{}, err
+	}
+	var result ports.ProjectionCleanupResult
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&result.EntitiesDeleted, &result.LinksDeleted); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ports.ProjectionCleanupResult{}, nil
+		}
+		return ports.ProjectionCleanupResult{}, fmt.Errorf("cleanup projected entities: %w", err)
+	}
+	return result, nil
+}
+
 func (s *Store) ensureProjectionTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.projectionTablesReady, "projection", ensureProjectionStatements)
 }
@@ -198,4 +346,21 @@ func projectionAttributesJSON(attributes map[string]string) (string, error) {
 		return "", err
 	}
 	return string(payload), nil
+}
+
+func normalizeProjectionCleanupValues(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	return normalized
 }

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -39,6 +39,7 @@ var ensureProjectionStatements = []string{
   PRIMARY KEY (from_urn, relation, to_urn)
 )`,
 	`CREATE INDEX IF NOT EXISTS entity_links_tenant_relation_idx ON entity_links (tenant_id, relation)`,
+	`CREATE INDEX IF NOT EXISTS entity_links_to_urn_idx ON entity_links (to_urn)`,
 	`ALTER TABLE entity_links ADD COLUMN IF NOT EXISTS runtime_id TEXT NOT NULL DEFAULT ''`,
 	`CREATE INDEX IF NOT EXISTS entity_links_tenant_runtime_idx ON entity_links (tenant_id, runtime_id)`,
 }

--- a/internal/statestore/postgres/projection_test.go
+++ b/internal/statestore/postgres/projection_test.go
@@ -69,6 +69,15 @@ func TestProjectedLinkDeleteUsesPrimaryKey(t *testing.T) {
 	}
 }
 
+func TestProjectionEnsureStatementsIndexReverseLinkLookups(t *testing.T) {
+	for _, statement := range ensureProjectionStatements {
+		if strings.Contains(statement, "entity_links_to_urn_idx") && strings.Contains(statement, "ON entity_links (to_urn)") {
+			return
+		}
+	}
+	t.Fatalf("ensureProjectionStatements missing entity_links to_urn index: %#v", ensureProjectionStatements)
+}
+
 func TestProjectedEntityCleanupSQLRequiresScope(t *testing.T) {
 	if _, _, err := projectedEntityCleanupSQL(ports.ProjectionCleanupRequest{OnlyIsolated: true}); err == nil {
 		t.Fatal("projectedEntityCleanupSQL() error = nil, want non-nil")

--- a/internal/statestore/postgres/projection_test.go
+++ b/internal/statestore/postgres/projection_test.go
@@ -68,3 +68,48 @@ func TestProjectedLinkDeleteUsesPrimaryKey(t *testing.T) {
 		t.Fatalf("link delete includes non-primary-key filters:\n%s", linkSQL)
 	}
 }
+
+func TestProjectedEntityCleanupSQLRequiresScope(t *testing.T) {
+	if _, _, err := projectedEntityCleanupSQL(ports.ProjectionCleanupRequest{OnlyIsolated: true}); err == nil {
+		t.Fatal("projectedEntityCleanupSQL() error = nil, want non-nil")
+	}
+}
+
+func TestProjectedEntityCleanupSQLIncludesScopedFilters(t *testing.T) {
+	query, args, err := projectedEntityCleanupSQL(ports.ProjectionCleanupRequest{
+		TenantID:     "writer",
+		SourceID:     "okta",
+		RuntimeID:    "okta-audit-runtime",
+		EntityTypes:  []string{"okta.resource"},
+		URNPrefixes:  []string{"urn:cerebro:writer:okta_resource:access_token:"},
+		OnlyIsolated: true,
+		Limit:        25,
+	})
+	if err != nil {
+		t.Fatalf("projectedEntityCleanupSQL() error = %v", err)
+	}
+	for _, want := range []string{
+		"e.tenant_id = $1",
+		"e.source_id = $2",
+		"e.runtime_id = $3",
+		"e.entity_type IN ($4)",
+		"LEFT(e.urn, LENGTH($5)) = $5",
+		"NOT EXISTS (SELECT 1 FROM entity_links l WHERE l.from_urn = e.urn OR l.to_urn = e.urn)",
+		"LIMIT $6",
+		"DELETE FROM entity_links",
+		"DELETE FROM entities",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("cleanup SQL missing %q:\n%s", want, query)
+		}
+	}
+	if len(args) != 6 {
+		t.Fatalf("cleanup SQL args = %d, want 6", len(args))
+	}
+	if args[4] != "urn:cerebro:writer:okta_resource:access_token:" {
+		t.Fatalf("cleanup prefix arg = %#v, want literal access_token prefix", args[4])
+	}
+	if args[5] != uint32(25) {
+		t.Fatalf("cleanup limit arg = %#v, want uint32(25)", args[5])
+	}
+}

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -1440,6 +1440,8 @@ func oktaOAuthGrantType(eventType string) string {
 		return "authorization_code"
 	case strings.HasSuffix(action, ".access_token"):
 		return "access_token"
+	case strings.HasSuffix(action, ".refresh_token"):
+		return "refresh_token"
 	case strings.HasSuffix(action, ".id_token"):
 		return "id_token"
 	default:

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -287,6 +287,33 @@ func TestAuditEventNormalizesOAuthRuntimeGrantTelemetry(t *testing.T) {
 	}
 }
 
+func TestAuditEventNormalizesRefreshTokenGrantType(t *testing.T) {
+	event, err := auditEvent(settings{domain: "tenant.example"}, auditRecord{
+		UUID:      "evt-refresh-token",
+		Published: mustParseTime(t, "2026-05-07T19:54:46Z"),
+		EventType: "app.oauth2.token.grant.refresh_token",
+		Actor: map[string]any{
+			"id":          "0oa-client",
+			"type":        "PublicClientApp",
+			"displayName": "Production Client",
+		},
+		Target: []map[string]any{{
+			"id":   "refresh-token-123",
+			"type": "RefreshToken",
+		}},
+		raw: json.RawMessage(`{"uuid":"evt-refresh-token"}`),
+	})
+	if err != nil {
+		t.Fatalf("auditEvent() error = %v", err)
+	}
+	if got := event.Attributes["oauth_event_category"]; got != "runtime_grant" {
+		t.Fatalf("oauth_event_category = %q, want runtime_grant", got)
+	}
+	if got := event.Attributes["grant_type"]; got != "refresh_token" {
+		t.Fatalf("grant_type = %q, want refresh_token", got)
+	}
+}
+
 func TestAuditEventDoesNotClassifyRoutineAssignmentAsOAuthCredentialChange(t *testing.T) {
 	published := mustParseTime(t, "2026-05-07T19:54:46Z")
 	event, err := auditEvent(settings{domain: "writer.okta.com"}, auditRecord{


### PR DESCRIPTION
## Summary
- suppress ephemeral Okta OAuth runtime-grant resource nodes for access/refresh/id tokens and auth codes
- preserve durable telemetry by linking actors to OAuth client applications when token resources are suppressed
- add focused projector regression coverage while preserving credential-change resources

## Validation
- make verify