### PR TITLE
fix(cosmo): cap scoped export pagination

### DIFF
--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -42,6 +42,7 @@ const (
 	defaultMessageExportMaxWindowHours = 24
 	messageExportMaxWindowHours        = 24
 	messageExportMaxPageSize           = 100
+	messageExportMaxOffset             = 10000
 )
 
 // Source reads Cosmo memory and feedback data.
@@ -872,7 +873,7 @@ func parseMessageCursorTime(value string) (time.Time, bool) {
 }
 
 func nextMessageCursor(settings settings, window messageWindow, records int, limit int) (string, string) {
-	if records == limit {
+	if records == limit && window.offset+limit < messageExportMaxOffset {
 		next := encodeMessageCursor(window.since, window.until, window.eventTypeIndex, window.offset+limit)
 		return next, next
 	}

--- a/sources/cosmo/source_test.go
+++ b/sources/cosmo/source_test.go
@@ -534,6 +534,35 @@ func TestReadMessagesReturnsHardScopedExportFailures(t *testing.T) {
 	}
 }
 
+func TestNextMessageCursorRespectsScopedExportOffsetLimit(t *testing.T) {
+	settings := settings{eventTypes: []string{"message", "completion"}}
+	window := messageWindow{
+		since:          time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		until:          time.Date(2026, 5, 1, 1, 0, 0, 0, time.UTC),
+		eventTypeIndex: 0,
+		offset:         messageExportMaxOffset - messageExportMaxPageSize,
+	}
+
+	next, checkpoint := nextMessageCursor(settings, window, messageExportMaxPageSize, messageExportMaxPageSize)
+	if next == "" || checkpoint != next {
+		t.Fatalf("next=%q checkpoint=%q, want next event cursor", next, checkpoint)
+	}
+	cursor := decodeMessageCursor(t, next)
+	if cursor.EventTypeIndex != 1 || cursor.Offset != 0 {
+		t.Fatalf("cursor = %#v, want next event type at offset 0", cursor)
+	}
+
+	settings.eventTypes = []string{"message"}
+	next, checkpoint = nextMessageCursor(settings, window, messageExportMaxPageSize, messageExportMaxPageSize)
+	if next != "" {
+		t.Fatalf("next = %q, want empty after final event type", next)
+	}
+	cursor = decodeMessageCursor(t, checkpoint)
+	if cursor.Since != window.until.Format(time.RFC3339Nano) || cursor.Until != "" || cursor.Offset != 0 {
+		t.Fatalf("checkpoint = %#v, want next window checkpoint", cursor)
+	}
+}
+
 func TestReadMessagesRejectsInvalidScopedCursor(t *testing.T) {
 	source, err := New()
 	if err != nil {


### PR DESCRIPTION
## Summary
- stop generating Cosmo message export cursors at offsets rejected by the scoped endpoint
- advance to the next event type or time window once the 10k scoped export offset cap is reached
- add cursor coverage for the offset-cap boundary

## Context
While reviewing #587, I found the scoped `/api/cerebro/messages` endpoint rejects `offset >= 10000`; a full page at offset 9900 would previously generate a stuck `offset=10000` cursor.

## Validation
- `go test ./sources/cosmo -count=1`
- `make verify`
