### PR TITLE
fix(grc): reduce reports query fanout

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -862,6 +862,9 @@ func (s *stubRuntimeStore) ListFindings(_ context.Context, request ports.ListFin
 	sort.Slice(findings, func(i, j int) bool {
 		left := findings[i]
 		right := findings[j]
+		if request.PriorityOrder && severityRank(left.Severity) != severityRank(right.Severity) {
+			return severityRank(left.Severity) < severityRank(right.Severity)
+		}
 		switch {
 		case left.LastObservedAt.Equal(right.LastObservedAt):
 			return left.ID < right.ID
@@ -5333,7 +5336,8 @@ func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRec
 	if request.TenantID != "" && strings.TrimSpace(finding.TenantID) != strings.TrimSpace(request.TenantID) {
 		return false
 	}
-	if strings.TrimSpace(finding.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+	runtimeIDs := normalizedTestStrings(append(request.RuntimeIDs, request.RuntimeID))
+	if len(runtimeIDs) == 0 || !containsTrimmed(runtimeIDs, finding.RuntimeID) {
 		return false
 	}
 	if request.FindingID != "" && strings.TrimSpace(finding.ID) != strings.TrimSpace(request.FindingID) {
@@ -5452,7 +5456,8 @@ func findingEvidenceMatches(request ports.ListFindingEvidenceRequest, evidence *
 	if evidence == nil {
 		return false
 	}
-	if strings.TrimSpace(evidence.GetRuntimeId()) != strings.TrimSpace(request.RuntimeID) {
+	runtimeIDs := normalizedTestStrings(append(request.RuntimeIDs, request.RuntimeID))
+	if len(runtimeIDs) == 0 || !containsTrimmed(runtimeIDs, evidence.GetRuntimeId()) {
 		return false
 	}
 	if request.FindingID != "" && strings.TrimSpace(evidence.GetFindingId()) != strings.TrimSpace(request.FindingID) {
@@ -5474,6 +5479,23 @@ func findingEvidenceMatches(request ports.ListFindingEvidenceRequest, evidence *
 		return false
 	}
 	return true
+}
+
+func normalizedTestStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := []string{}
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
 }
 
 func cloneReportRun(run *cerebrov1.ReportRun) *cerebrov1.ReportRun {

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -540,6 +540,7 @@ func (a *App) grcListEvidenceRecords(r *http.Request, runtimes []*cerebrov1.Sour
 		RuleID:       filter.RuleID,
 		GraphRootURN: filter.GraphRootURN,
 		Limit:        limit,
+		CreatedOrder: true,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -329,6 +329,11 @@ func (a *App) handleGRCAuditPacket(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, fmt.Errorf("%w: finding id is required", errInvalidHTTPRequest))
 		return
 	}
+	limit, err := grcLimitFromRequest(r)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
 	store := findingStore(a.deps.StateStore)
 	if store == nil {
 		writeGRCError(w, findings.ErrRuntimeUnavailable)
@@ -343,12 +348,12 @@ func (a *App) handleGRCAuditPacket(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	runtimes, err := a.grcListRuntimes(r, grcScope{TenantID: finding.TenantID, RuntimeID: finding.RuntimeID, Limit: grcDefaultLimit})
+	runtimes, err := a.grcListRuntimes(r, grcScope{TenantID: finding.TenantID, RuntimeID: finding.RuntimeID, Limit: limit})
 	if err != nil {
 		writeGRCError(w, err)
 		return
 	}
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingID: finding.ID, Limit: grcDefaultLimit})
+	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingID: finding.ID, Limit: limit})
 	if err != nil {
 		writeGRCError(w, err)
 		return
@@ -356,7 +361,7 @@ func (a *App) handleGRCAuditPacket(w http.ResponseWriter, r *http.Request) {
 	var graph *ports.EntityNeighborhood
 	if len(finding.ResourceURNs) > 0 {
 		if graphStore := graphQueryStore(a.deps.GraphStore); graphStore != nil {
-			graph, _ = graphStore.GetEntityNeighborhood(r.Context(), finding.ResourceURNs[0], int(grcDefaultLimit))
+			graph, _ = graphStore.GetEntityNeighborhood(r.Context(), finding.ResourceURNs[0], int(limit))
 		}
 	}
 	items := grcFindingItems([]*ports.FindingRecord{finding}, grcRuntimeSourceIDs(runtimes), grcEvidenceCounts(evidence))
@@ -458,22 +463,32 @@ func (a *App) grcListFindingRecords(r *http.Request, runtimes []*cerebrov1.Sourc
 	if limit == 0 {
 		limit = grcDefaultLimit
 	}
-	var records []*ports.FindingRecord
+	runtimeIDsByTenant := map[string][]string{}
 	for _, runtime := range runtimes {
 		if runtime == nil {
 			continue
 		}
+		tenantID := strings.TrimSpace(runtime.GetTenantId())
+		runtimeID := strings.TrimSpace(runtime.GetId())
+		if tenantID == "" || runtimeID == "" {
+			continue
+		}
+		runtimeIDsByTenant[tenantID] = append(runtimeIDsByTenant[tenantID], runtimeID)
+	}
+	var records []*ports.FindingRecord
+	for tenantID, runtimeIDs := range runtimeIDsByTenant {
 		items, err := store.ListFindings(r.Context(), ports.ListFindingsRequest{
-			TenantID:    strings.TrimSpace(runtime.GetTenantId()),
-			RuntimeID:   strings.TrimSpace(runtime.GetId()),
-			FindingID:   filter.FindingID,
-			RuleID:      filter.RuleID,
-			Severity:    filter.Severity,
-			Status:      filter.Status,
-			ResourceURN: filter.ResourceURN,
-			EventID:     filter.EventID,
-			PolicyID:    filter.PolicyID,
-			Limit:       limit,
+			TenantID:      tenantID,
+			RuntimeIDs:    runtimeIDs,
+			FindingID:     filter.FindingID,
+			RuleID:        filter.RuleID,
+			Severity:      filter.Severity,
+			Status:        filter.Status,
+			ResourceURN:   filter.ResourceURN,
+			EventID:       filter.EventID,
+			PolicyID:      filter.PolicyID,
+			Limit:         limit,
+			PriorityOrder: true,
 		})
 		if err != nil {
 			return nil, err
@@ -506,23 +521,28 @@ func (a *App) grcListEvidenceRecords(r *http.Request, runtimes []*cerebrov1.Sour
 	if limit == 0 {
 		limit = grcDefaultLimit
 	}
-	var records []*cerebrov1.FindingEvidence
+	var runtimeIDs []string
 	for _, runtime := range runtimes {
 		if runtime == nil {
 			continue
 		}
-		items, err := store.ListFindingEvidence(r.Context(), ports.ListFindingEvidenceRequest{
-			RuntimeID:    strings.TrimSpace(runtime.GetId()),
-			FindingID:    filter.FindingID,
-			RunID:        filter.RunID,
-			RuleID:       filter.RuleID,
-			GraphRootURN: filter.GraphRootURN,
-			Limit:        limit,
-		})
-		if err != nil {
-			return nil, err
+		if runtimeID := strings.TrimSpace(runtime.GetId()); runtimeID != "" {
+			runtimeIDs = append(runtimeIDs, runtimeID)
 		}
-		records = append(records, items...)
+	}
+	if len(runtimeIDs) == 0 {
+		return nil, nil
+	}
+	records, err := store.ListFindingEvidence(r.Context(), ports.ListFindingEvidenceRequest{
+		RuntimeIDs:   runtimeIDs,
+		FindingID:    filter.FindingID,
+		RunID:        filter.RunID,
+		RuleID:       filter.RuleID,
+		GraphRootURN: filter.GraphRootURN,
+		Limit:        limit,
+	})
+	if err != nil {
+		return nil, err
 	}
 	sort.Slice(records, func(i, j int) bool {
 		left := records[i].GetCreatedAt().AsTime()

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -131,6 +131,9 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	if got := len(store.findingEvidenceListRequest.RuntimeIDs); got != 2 {
 		t.Fatalf("batched evidence runtime count = %d, want 2", got)
 	}
+	if !store.findingEvidenceListRequest.CreatedOrder {
+		t.Fatalf("GRC dashboard did not request created-at evidence ordering")
+	}
 }
 
 func TestGRCEntityImpactAndAuditPacket(t *testing.T) {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -122,6 +122,15 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	if len(payload.Connectors) != 2 {
 		t.Fatalf("connectors len = %d, want 2", len(payload.Connectors))
 	}
+	if got := len(store.findingListRequest.RuntimeIDs); got != 2 {
+		t.Fatalf("batched finding runtime count = %d, want 2", got)
+	}
+	if !store.findingListRequest.PriorityOrder {
+		t.Fatalf("GRC dashboard did not request priority finding ordering")
+	}
+	if got := len(store.findingEvidenceListRequest.RuntimeIDs); got != 2 {
+		t.Fatalf("batched evidence runtime count = %d, want 2", got)
+	}
 }
 
 func TestGRCEntityImpactAndAuditPacket(t *testing.T) {

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -142,6 +142,7 @@ type ListFindingEvidenceRequest struct {
 	GraphRootURN string
 	GraphPathURN string
 	Limit        uint32
+	CreatedOrder bool
 }
 
 // FindingStore persists normalized findings in the state store.

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -67,16 +67,18 @@ type FindingRecord struct {
 
 // ListFindingsRequest scopes one finding query.
 type ListFindingsRequest struct {
-	TenantID    string
-	RuntimeID   string
-	FindingID   string
-	RuleID      string
-	Severity    string
-	Status      string
-	ResourceURN string
-	EventID     string
-	PolicyID    string
-	Limit       uint32
+	TenantID      string
+	RuntimeID     string
+	RuntimeIDs    []string
+	FindingID     string
+	RuleID        string
+	Severity      string
+	Status        string
+	ResourceURN   string
+	EventID       string
+	PolicyID      string
+	Limit         uint32
+	PriorityOrder bool
 }
 
 // ErrFindingEvaluationRunNotFound indicates that a persisted finding evaluation run does not exist.
@@ -131,6 +133,7 @@ type ListFindingEvaluationRunsRequest struct {
 // ListFindingEvidenceRequest scopes one finding evidence query.
 type ListFindingEvidenceRequest struct {
 	RuntimeID    string
+	RuntimeIDs   []string
 	FindingID    string
 	RunID        string
 	RuleID       string

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -53,6 +53,7 @@ var ensureFindingEvidenceStatements = []string{
 	`CREATE INDEX IF NOT EXISTS finding_evidence_run_ids_gin_idx ON finding_evidence USING GIN (run_ids_json)`,
 	`CREATE INDEX IF NOT EXISTS finding_evidence_attributes_gin_idx ON finding_evidence USING GIN (attributes_json)`,
 	`CREATE INDEX IF NOT EXISTS finding_evidence_last_observed_idx ON finding_evidence (runtime_id, last_observed_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS finding_evidence_runtime_observed_id_idx ON finding_evidence (runtime_id, last_observed_at DESC, created_at DESC, id)`,
 }
 
 func findingEvidenceUpsertSQL() string {
@@ -286,11 +287,13 @@ func (s *Store) ensureFindingEvidenceTables(ctx context.Context) error {
 
 func findingEvidenceListQuery(request ports.ListFindingEvidenceRequest) (string, []any, error) {
 	runtimeID := strings.TrimSpace(request.RuntimeID)
-	if runtimeID == "" {
+	runtimeIDs := normalizedNonEmptyStrings(append(request.RuntimeIDs, runtimeID))
+	if len(runtimeIDs) == 0 {
 		return "", nil, errors.New("finding evidence runtime id is required")
 	}
-	clauses := []string{"runtime_id = $1"}
-	args := []any{runtimeID}
+	clauses := []string{}
+	args := []any{}
+	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
 	addFindingFilter(&clauses, &args, "finding_id", request.FindingID)
 	addFindingEvidenceRunFilter(&clauses, &args, request.RunID)
 	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -313,12 +313,19 @@ func findingEvidenceListQuery(request ports.ListFindingEvidenceRequest) (string,
 SELECT finding_evidence_json::text
 FROM finding_evidence
 WHERE ` + strings.Join(clauses, " AND ") + `
-ORDER BY last_observed_at DESC, created_at DESC, id`
+ORDER BY ` + findingEvidenceListOrder(request)
 	if request.Limit != 0 {
 		args = append(args, int64(request.Limit))
 		query += fmt.Sprintf(" LIMIT $%d", len(args))
 	}
 	return query, args, nil
+}
+
+func findingEvidenceListOrder(request ports.ListFindingEvidenceRequest) string {
+	if request.CreatedOrder {
+		return "created_at DESC, id"
+	}
+	return "last_observed_at DESC, created_at DESC, id"
 }
 
 func addFindingEvidenceRunFilter(clauses *[]string, args *[]any, runID string) {

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -51,7 +51,7 @@ func TestListFindingEvidenceRejectsUnconfiguredStore(t *testing.T) {
 
 func TestFindingEvidenceListQueryIncludesOptionalFilters(t *testing.T) {
 	query, args, err := findingEvidenceListQuery(ports.ListFindingEvidenceRequest{
-		RuntimeID:    "writer-okta-audit",
+		RuntimeID:    "runtime-alpha",
 		FindingID:    "finding-1",
 		RunID:        "finding-evaluation-run-1",
 		RuleID:       "identity-okta-policy-rule-lifecycle-tampering",
@@ -82,11 +82,42 @@ func TestFindingEvidenceListQueryIncludesOptionalFilters(t *testing.T) {
 	if got := len(args); got != 9 {
 		t.Fatalf("len(findingEvidenceListQuery().args) = %d, want 9", got)
 	}
-	if got := args[0]; got != "writer-okta-audit" {
-		t.Fatalf("findingEvidenceListQuery().args[0] = %#v, want writer-okta-audit", got)
+	if got := args[0]; got != "runtime-alpha" {
+		t.Fatalf("findingEvidenceListQuery().args[0] = %#v, want runtime-alpha", got)
 	}
 	if got := args[8]; got != int64(25) {
 		t.Fatalf("findingEvidenceListQuery().args[8] = %#v, want 25", got)
+	}
+}
+
+func TestFindingEvidenceListQuerySupportsRuntimeBatches(t *testing.T) {
+	query, args, err := findingEvidenceListQuery(ports.ListFindingEvidenceRequest{
+		RuntimeIDs: []string{"runtime-alpha", "runtime-beta", "runtime-alpha"},
+		Limit:      25,
+	})
+	if err != nil {
+		t.Fatalf("findingEvidenceListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"runtime_id IN ($1, $2)",
+		"ORDER BY last_observed_at DESC, created_at DESC, id",
+		"LIMIT $3",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingEvidenceListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if got := len(args); got != 3 {
+		t.Fatalf("len(findingEvidenceListQuery().args) = %d, want 3", got)
+	}
+	if got := args[0]; got != "runtime-alpha" {
+		t.Fatalf("findingEvidenceListQuery().args[0] = %#v, want first runtime", got)
+	}
+	if got := args[1]; got != "runtime-beta" {
+		t.Fatalf("findingEvidenceListQuery().args[1] = %#v, want second runtime", got)
+	}
+	if got := args[2]; got != int64(25) {
+		t.Fatalf("findingEvidenceListQuery().args[2] = %#v, want 25", got)
 	}
 }
 

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -121,6 +121,32 @@ func TestFindingEvidenceListQuerySupportsRuntimeBatches(t *testing.T) {
 	}
 }
 
+func TestFindingEvidenceListQuerySupportsCreatedOrder(t *testing.T) {
+	query, args, err := findingEvidenceListQuery(ports.ListFindingEvidenceRequest{
+		RuntimeIDs:   []string{"runtime-alpha", "runtime-beta"},
+		Limit:        25,
+		CreatedOrder: true,
+	})
+	if err != nil {
+		t.Fatalf("findingEvidenceListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"runtime_id IN ($1, $2)",
+		"ORDER BY created_at DESC, id",
+		"LIMIT $3",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingEvidenceListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if strings.Contains(query, "ORDER BY last_observed_at") {
+		t.Fatalf("findingEvidenceListQuery() used last-observed order for created-order request: %s", query)
+	}
+	if got := len(args); got != 3 {
+		t.Fatalf("len(findingEvidenceListQuery().args) = %d, want 3", got)
+	}
+}
+
 func TestFindingEvidenceUpsertPreservesCreatedAtOnConflict(t *testing.T) {
 	query := findingEvidenceUpsertSQL()
 	if strings.Contains(query, "created_at = EXCLUDED.created_at") {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -62,6 +62,8 @@ var ensureFindingStatements = []string{
 	`CREATE INDEX IF NOT EXISTS findings_runtime_due_at_idx ON findings (runtime_id, due_at)`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_status_idx ON findings (runtime_id, status)`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_severity_idx ON findings (runtime_id, severity)`,
+	`CREATE INDEX IF NOT EXISTS findings_tenant_runtime_status_observed_idx ON findings (tenant_id, runtime_id, status, last_observed_at DESC, id)`,
+	`CREATE INDEX IF NOT EXISTS findings_tenant_runtime_observed_idx ON findings (tenant_id, runtime_id, last_observed_at DESC, id)`,
 	`CREATE INDEX IF NOT EXISTS findings_resource_urns_gin_idx ON findings USING GIN (resource_urns_json)`,
 	`CREATE INDEX IF NOT EXISTS findings_event_ids_gin_idx ON findings USING GIN (event_ids_json)`,
 	`CREATE INDEX IF NOT EXISTS findings_observed_policy_ids_gin_idx ON findings USING GIN (observed_policy_ids_json)`,
@@ -319,8 +321,9 @@ func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequ
 		return nil, errors.New("finding tenant id is required")
 	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
+	runtimeIDs := normalizedNonEmptyStrings(append(request.RuntimeIDs, runtimeID))
 	ruleID := strings.TrimSpace(request.RuleID)
-	if runtimeID == "" && ruleID == "" {
+	if len(runtimeIDs) == 0 && ruleID == "" {
 		return nil, errors.New("finding runtime id or rule id is required")
 	}
 	if s == nil || s.db == nil {
@@ -790,16 +793,14 @@ func findingListQuery(request ports.ListFindingsRequest) (string, []any, error) 
 		return "", nil, errors.New("finding tenant id is required")
 	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
+	runtimeIDs := normalizedNonEmptyStrings(append(request.RuntimeIDs, runtimeID))
 	ruleID := strings.TrimSpace(request.RuleID)
-	if runtimeID == "" && ruleID == "" {
+	if len(runtimeIDs) == 0 && ruleID == "" {
 		return "", nil, errors.New("finding runtime id or rule id is required")
 	}
 	clauses := []string{"tenant_id = $1"}
 	args := []any{tenantID}
-	if runtimeID != "" {
-		args = append(args, runtimeID)
-		clauses = append(clauses, fmt.Sprintf("runtime_id = $%d", len(args)))
-	}
+	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
 	addFindingFilter(&clauses, &args, "id", request.FindingID)
 	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
 	addFindingFilter(&clauses, &args, "severity", request.Severity)
@@ -819,7 +820,7 @@ SELECT
   status_updated_at, first_observed_at, last_observed_at
 FROM findings
 WHERE ` + strings.Join(clauses, " AND ") + `
-ORDER BY last_observed_at DESC, id`
+ORDER BY ` + findingOrderClause(request.PriorityOrder)
 	if request.Limit != 0 {
 		args = append(args, int64(request.Limit))
 		query += fmt.Sprintf(" LIMIT $%d", len(args))
@@ -828,12 +829,21 @@ ORDER BY last_observed_at DESC, id`
 }
 
 func (s *Store) ensureFindingTables(ctx context.Context) error {
-	for _, statement := range ensureFindingStatements {
-		if _, err := s.db.ExecContext(ctx, statement); err != nil {
-			return fmt.Errorf("ensure findings tables: %w", err)
-		}
+	return s.ensureStatements(ctx, &s.findingTablesReady, "findings", ensureFindingStatements)
+}
+
+func findingOrderClause(priorityOrder bool) string {
+	if !priorityOrder {
+		return "last_observed_at DESC, id"
 	}
-	return nil
+	return `CASE UPPER(severity)
+  WHEN 'CRITICAL' THEN 0
+  WHEN 'HIGH' THEN 1
+  WHEN 'MEDIUM' THEN 2
+  WHEN 'LOW' THEN 3
+  WHEN 'INFO' THEN 4
+  ELSE 5
+END, last_observed_at DESC, id`
 }
 
 func findingStringsJSON(values []string) (string, error) {

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -236,6 +236,43 @@ func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
 	}
 }
 
+func TestFindingListQuerySupportsRuntimeBatchesAndPriorityOrder(t *testing.T) {
+	query, args, err := findingListQuery(ports.ListFindingsRequest{
+		TenantID:      "writer",
+		RuntimeIDs:    []string{"runtime-alpha", "runtime-beta", "runtime-alpha"},
+		Status:        "open",
+		Limit:         25,
+		PriorityOrder: true,
+	})
+	if err != nil {
+		t.Fatalf("findingListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"tenant_id = $1",
+		"runtime_id IN ($2, $3)",
+		"status = $4",
+		"CASE UPPER(severity)",
+		"last_observed_at DESC, id",
+		"LIMIT $5",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if got := len(args); got != 5 {
+		t.Fatalf("len(findingListQuery().args) = %d, want 5", got)
+	}
+	if got := args[1]; got != "runtime-alpha" {
+		t.Fatalf("findingListQuery().args[1] = %#v, want first runtime", got)
+	}
+	if got := args[2]; got != "runtime-beta" {
+		t.Fatalf("findingListQuery().args[2] = %#v, want second runtime", got)
+	}
+	if got := args[4]; got != int64(25) {
+		t.Fatalf("findingListQuery().args[4] = %#v, want 25", got)
+	}
+}
+
 func TestFindingRowRecordDecodesCheckAndControlMetadata(t *testing.T) {
 	record, err := (findingRow{
 		ID:                    "finding-1",

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -19,6 +19,8 @@ type Store struct {
 	schemaMu                  sync.Mutex
 	claimTablesReady          bool
 	projectionTablesReady     bool
+	findingTablesReady        bool
+	reportRunTableReady       bool
 	sourceRuntimeTableReady   bool
 	findingEvidenceReady      bool
 	findingEvaluationRunReady bool
@@ -69,4 +71,39 @@ func (s *Store) ensureStatements(ctx context.Context, ready *bool, label string,
 	}
 	*ready = true
 	return nil
+}
+
+func normalizedNonEmptyStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
+}
+
+func addStringInFilter(clauses *[]string, args *[]any, column string, values []string) {
+	normalized := normalizedNonEmptyStrings(values)
+	switch len(normalized) {
+	case 0:
+		return
+	case 1:
+		*args = append(*args, normalized[0])
+		*clauses = append(*clauses, fmt.Sprintf("%s = $%d", column, len(*args)))
+	default:
+		placeholders := make([]string, 0, len(normalized))
+		for _, value := range normalized {
+			*args = append(*args, value)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(*args)))
+		}
+		*clauses = append(*clauses, fmt.Sprintf("%s IN (%s)", column, strings.Join(placeholders, ", ")))
+	}
 }

--- a/internal/statestore/postgres/reports.go
+++ b/internal/statestore/postgres/reports.go
@@ -13,13 +13,13 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
-const ensureReportRunTableSQL = `
+var ensureReportRunStatements = []string{`
 CREATE TABLE IF NOT EXISTS report_runs (
   id TEXT PRIMARY KEY,
   report_run_json JSONB NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-)`
+)`}
 
 // PutReportRun upserts one durable report run.
 func (s *Store) PutReportRun(ctx context.Context, run *cerebrov1.ReportRun) error {
@@ -85,8 +85,5 @@ func (s *Store) GetReportRun(ctx context.Context, reportRunID string) (*cerebrov
 }
 
 func (s *Store) ensureReportRunTable(ctx context.Context) error {
-	if _, err := s.db.ExecContext(ctx, ensureReportRunTableSQL); err != nil {
-		return fmt.Errorf("ensure report run table: %w", err)
-	}
-	return nil
+	return s.ensureStatements(ctx, &s.reportRunTableReady, "report run", ensureReportRunStatements)
 }


### PR DESCRIPTION
## Summary
- batch GRC dashboard finding/evidence reads across runtimes instead of one query per runtime
- add query shapes and indexes for tenant/runtime/status/observed report reads
- cache Postgres schema readiness for findings/report runs and allow audit packet limits

## Measured issue
`/grc/dashboard?tenant_id=writer&limit=25` was taking ~3.7s with ~144KB response from sec-dev before these changes.

## Testing
- `go test ./internal/bootstrap ./internal/statestore/postgres ./internal/reports -count=1`
- `go test ./...`
- `make verify`