### PR TITLE
fix(grc): scope report evidence queries

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -5460,7 +5460,12 @@ func findingEvidenceMatches(request ports.ListFindingEvidenceRequest, evidence *
 	if len(runtimeIDs) == 0 || !containsTrimmed(runtimeIDs, evidence.GetRuntimeId()) {
 		return false
 	}
-	if request.FindingID != "" && strings.TrimSpace(evidence.GetFindingId()) != strings.TrimSpace(request.FindingID) {
+	findingIDs := normalizedTestStrings(append(request.FindingIDs, request.FindingID))
+	if len(findingIDs) > 0 {
+		if !containsTrimmed(findingIDs, evidence.GetFindingId()) {
+			return false
+		}
+	} else if request.FindingIDs != nil {
 		return false
 	}
 	if request.RunID != "" && strings.TrimSpace(evidence.GetRunId()) != strings.TrimSpace(request.RunID) {

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -143,7 +143,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{Limit: scope.Limit})
+	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: scope.Limit})
 	if err != nil {
 		writeGRCError(w, err)
 		return
@@ -195,7 +195,7 @@ func (a *App) handleGRCFindings(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{Limit: scope.Limit})
+	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: scope.Limit})
 	if err != nil {
 		writeGRCError(w, err)
 		return
@@ -222,7 +222,7 @@ func (a *App) handleGRCControls(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{Limit: scope.Limit})
+	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: scope.Limit})
 	if err != nil {
 		writeGRCError(w, err)
 		return
@@ -310,7 +310,7 @@ func (a *App) handleGRCEntityImpact(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{Limit: limit})
+	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: limit})
 	if err != nil {
 		writeGRCError(w, err)
 		return
@@ -393,6 +393,7 @@ type grcFindingFilter struct {
 
 type grcEvidenceFilter struct {
 	FindingID    string
+	FindingIDs   []string
 	RunID        string
 	RuleID       string
 	GraphRootURN string
@@ -533,9 +534,13 @@ func (a *App) grcListEvidenceRecords(r *http.Request, runtimes []*cerebrov1.Sour
 	if len(runtimeIDs) == 0 {
 		return nil, nil
 	}
+	if filter.FindingIDs != nil && strings.TrimSpace(filter.FindingID) == "" && len(grcNonEmptyFindingIDs(filter.FindingIDs)) == 0 {
+		return nil, nil
+	}
 	records, err := store.ListFindingEvidence(r.Context(), ports.ListFindingEvidenceRequest{
 		RuntimeIDs:   runtimeIDs,
 		FindingID:    filter.FindingID,
+		FindingIDs:   filter.FindingIDs,
 		RunID:        filter.RunID,
 		RuleID:       filter.RuleID,
 		GraphRootURN: filter.GraphRootURN,
@@ -577,6 +582,34 @@ func grcEvidenceCounts(evidence []*cerebrov1.FindingEvidence) map[string]int {
 		}
 	}
 	return counts
+}
+
+func grcFindingIDs(findings []*ports.FindingRecord) []string {
+	ids := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		ids = append(ids, finding.ID)
+	}
+	return grcNonEmptyFindingIDs(ids)
+}
+
+func grcNonEmptyFindingIDs(ids []string) []string {
+	values := make([]string, 0, len(ids))
+	seen := map[string]struct{}{}
+	for _, raw := range ids {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		values = append(values, id)
+	}
+	return values
 }
 
 func grcFindingTitleMap(findings []*ports.FindingRecord) map[string]string {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -80,6 +80,13 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 				GraphRootUrns: []string{"urn:cerebro:writer:okta_user:00u1"},
 				CreatedAt:     timestamppb.New(now),
 			},
+			"evidence-resolved": {
+				Id:        "evidence-resolved",
+				RuntimeId: "writer-" + "okta-audit",
+				FindingId: "finding-resolved",
+				RunId:     "run-1",
+				CreatedAt: timestamppb.New(now.Add(time.Hour)),
+			},
 		},
 	}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
@@ -119,6 +126,9 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	if payload.Findings[1].EvidenceCount != 1 {
 		t.Fatalf("evidence count = %d, want 1", payload.Findings[1].EvidenceCount)
 	}
+	if len(payload.Evidence) != 1 || payload.Evidence[0].FindingID != "finding-high" {
+		t.Fatalf("dashboard evidence = %#v, want only evidence for visible findings", payload.Evidence)
+	}
 	if len(payload.Connectors) != 2 {
 		t.Fatalf("connectors len = %d, want 2", len(payload.Connectors))
 	}
@@ -130,6 +140,9 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	}
 	if got := len(store.findingEvidenceListRequest.RuntimeIDs); got != 2 {
 		t.Fatalf("batched evidence runtime count = %d, want 2", got)
+	}
+	if got := store.findingEvidenceListRequest.FindingIDs; len(got) != 2 || got[0] != "finding-critical" || got[1] != "finding-high" {
+		t.Fatalf("batched evidence finding ids = %#v, want visible finding ids", got)
 	}
 	if !store.findingEvidenceListRequest.CreatedOrder {
 		t.Fatalf("GRC dashboard did not request created-at evidence ordering")

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -135,6 +135,7 @@ type ListFindingEvidenceRequest struct {
 	RuntimeID    string
 	RuntimeIDs   []string
 	FindingID    string
+	FindingIDs   []string
 	RunID        string
 	RuleID       string
 	ClaimID      string

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -294,7 +294,14 @@ func findingEvidenceListQuery(request ports.ListFindingEvidenceRequest) (string,
 	clauses := []string{}
 	args := []any{}
 	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
-	addFindingFilter(&clauses, &args, "finding_id", request.FindingID)
+	findingIDs := normalizedNonEmptyStrings(append(request.FindingIDs, request.FindingID))
+	if strings.TrimSpace(request.FindingID) != "" || request.FindingIDs != nil {
+		if len(findingIDs) == 0 {
+			clauses = append(clauses, "FALSE")
+		} else {
+			addStringInFilter(&clauses, &args, "finding_id", findingIDs)
+		}
+	}
 	addFindingEvidenceRunFilter(&clauses, &args, request.RunID)
 	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
 	if err := addFindingArrayContainsFilter(&clauses, &args, "claim_ids_json", request.ClaimID); err != nil {

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -121,6 +121,37 @@ func TestFindingEvidenceListQuerySupportsRuntimeBatches(t *testing.T) {
 	}
 }
 
+func TestFindingEvidenceListQuerySupportsFindingBatches(t *testing.T) {
+	query, args, err := findingEvidenceListQuery(ports.ListFindingEvidenceRequest{
+		RuntimeIDs:   []string{"runtime-alpha", "runtime-beta"},
+		FindingIDs:   []string{"finding-high", "finding-critical", "finding-high"},
+		Limit:        25,
+		CreatedOrder: true,
+	})
+	if err != nil {
+		t.Fatalf("findingEvidenceListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"runtime_id IN ($1, $2)",
+		"finding_id IN ($3, $4)",
+		"ORDER BY created_at DESC, id",
+		"LIMIT $5",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingEvidenceListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if got := len(args); got != 5 {
+		t.Fatalf("len(findingEvidenceListQuery().args) = %d, want 5", got)
+	}
+	if got := args[2]; got != "finding-high" {
+		t.Fatalf("findingEvidenceListQuery().args[2] = %#v, want first finding", got)
+	}
+	if got := args[3]; got != "finding-critical" {
+		t.Fatalf("findingEvidenceListQuery().args[3] = %#v, want second finding", got)
+	}
+}
+
 func TestFindingEvidenceListQuerySupportsCreatedOrder(t *testing.T) {
 	query, args, err := findingEvidenceListQuery(ports.ListFindingEvidenceRequest{
 		RuntimeIDs:   []string{"runtime-alpha", "runtime-beta"},


### PR DESCRIPTION
## Summary
- scope dashboard/findings/controls/entity-impact evidence reads to the findings already selected for the response
- add batched finding-id filters for finding evidence queries
- prevent resolved/off-scope evidence from filling report evidence slots

## Testing
- `go test ./internal/bootstrap ./internal/statestore/postgres -count=1`
- `make verify`