### PR TITLE
feat(auth): emit access audit telemetry

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1803,13 +1803,43 @@ func TestAuthMiddlewareSkipsAccessAuditForPublicRoutes(t *testing.T) {
 }
 
 func TestAccessAuditOutcomeClassifiesDownstreamAuthorizationFailures(t *testing.T) {
-	outcome, reason := accessAuditOutcome(http.StatusForbidden, "allowed", "")
+	outcome, reason := accessAuditOutcome(http.StatusForbidden, "allowed", "", "")
 	if outcome != "denied" || reason != "authorization_failed" {
 		t.Fatalf("accessAuditOutcome(403) = (%q, %q), want denied authorization_failed", outcome, reason)
 	}
-	outcome, reason = accessAuditOutcome(http.StatusInternalServerError, "allowed", "")
+	outcome, reason = accessAuditOutcome(http.StatusInternalServerError, "allowed", "", "")
 	if outcome != "error" || reason != "" {
 		t.Fatalf("accessAuditOutcome(500) = (%q, %q), want error empty reason", outcome, reason)
+	}
+	outcome, reason = accessAuditOutcome(http.StatusOK, "allowed", "", "permission_denied")
+	if outcome != "denied" || reason != "authorization_failed" {
+		t.Fatalf("accessAuditOutcome(gRPC permission_denied) = (%q, %q), want denied authorization_failed", outcome, reason)
+	}
+}
+
+func TestAccessAuditConnectProcedureSanitizesUnknownProcedures(t *testing.T) {
+	if got := accessAuditConnectProcedure(cerebrov1connect.BootstrapServiceListSourcesProcedure); got != "cerebro.v1.BootstrapService/ListSources" {
+		t.Fatalf("known connect procedure = %q, want ListSources", got)
+	}
+	raw := "/cerebro.v1.BootstrapService/secret-token-value"
+	if got := accessAuditConnectProcedure(raw); got != "unknown" {
+		t.Fatalf("unknown connect procedure = %q, want unknown", got)
+	}
+}
+
+func TestAccessAuditRemoteIPDropsPort(t *testing.T) {
+	for _, tt := range []struct {
+		raw  string
+		want string
+	}{
+		{raw: "203.0.113.10:54321", want: "203.0.113.10"},
+		{raw: "[2001:db8::1]:443", want: "2001:db8::1"},
+		{raw: "203.0.113.20", want: "203.0.113.20"},
+		{raw: "not an address", want: ""},
+	} {
+		if got := accessAuditRemoteIP(tt.raw); got != tt.want {
+			t.Fatalf("accessAuditRemoteIP(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
 	}
 }
 
@@ -1979,6 +2009,60 @@ func TestScopedCosmoCredentialEnforcesConnectProcedures(t *testing.T) {
 	syncReq.Header().Set("Authorization", "Bearer scoped-token")
 	if _, err := client.SyncSourceRuntime(context.Background(), syncReq); connect.CodeOf(err) != connect.CodePermissionDenied {
 		t.Fatalf("SyncSourceRuntime() code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodePermissionDenied, err)
+	}
+}
+
+func TestScopedCosmoCredentialAuditsGRPCProcedureDenials(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APICredentials: []config.APICredential{{
+				Key:       "scoped-token",
+				Principal: "cosmo-security",
+				TenantID:  "writer",
+				Scopes:    []string{scopeCosmoSecurityRead},
+			}},
+		},
+	}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-runtime": {Id: "writer-runtime", SourceId: "github", TenantId: "writer"},
+		},
+	}
+	app := New(cfg, Dependencies{StateStore: store}, nil)
+	server := httptest.NewUnstartedServer(app.Handler())
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL, connect.WithGRPC())
+	syncReq := connect.NewRequest(&cerebrov1.SyncSourceRuntimeRequest{Id: "writer-runtime"})
+	syncReq.Header().Set("Authorization", "Bearer scoped-token")
+	stderr := captureBootstrapStderr(t, func() {
+		if _, err := client.SyncSourceRuntime(context.Background(), syncReq); connect.CodeOf(err) != connect.CodePermissionDenied {
+			t.Fatalf("SyncSourceRuntime() code = %s, want %s (err: %v)", connect.CodeOf(err), connect.CodePermissionDenied, err)
+		}
+	})
+	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"name":              "cerebro.api.access",
+		"outcome":           "denied",
+		"status":            float64(http.StatusOK),
+		"route":             "/cerebro.v1.BootstrapService/{Procedure}",
+		"connect_procedure": "cerebro.v1.BootstrapService/SyncSourceRuntime",
+		"connect_code":      "permission_denied",
+		"denial_reason":     "authorization_failed",
+		"principal":         "cosmo-security",
+		"auth_mode":         "api_credential",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("gRPC audit payload[%q] = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if strings.Contains(stderr, "scoped-token") {
+		t.Fatalf("gRPC audit log leaked bearer token: %s", stderr)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -8,8 +8,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -1626,6 +1628,188 @@ func TestAuthMiddlewareProtectsNonPublicRoutes(t *testing.T) {
 	_ = authResp.Body.Close()
 	if authResp.StatusCode != http.StatusOK {
 		t.Fatalf("GET /sources with auth status = %d, want %d", authResp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestAuthMiddlewareEmitsAccessAuditEvents(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APIKeys: []config.APIKey{{
+				Key:       "test-key",
+				Principal: "ci",
+				TenantID:  "writer",
+			}},
+		},
+	}
+	app := New(cfg, Dependencies{}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	stderr := captureBootstrapStderr(t, func() {
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/sources?tenant_id=writer&api_key=leaked", nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer test-key")
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			t.Fatalf("GET /sources with auth error = %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET /sources with auth status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+	})
+	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"kind":      "event",
+		"name":      "cerebro.api.access",
+		"outcome":   "allowed",
+		"status":    float64(http.StatusOK),
+		"method":    http.MethodGet,
+		"route":     "GET /sources",
+		"tenant_id": "writer",
+		"principal": "ci",
+		"auth_mode": "api_key",
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("audit payload[%q] = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	if _, ok := payload["duration_ms"].(float64); !ok {
+		t.Fatalf("audit payload duration_ms = %#v, want numeric; payload=%#v", payload["duration_ms"], payload)
+	}
+	for _, forbidden := range []string{"test-key", "leaked", "api_key=leaked", "Authorization"} {
+		if strings.Contains(stderr, forbidden) {
+			t.Fatalf("audit log leaked %q in %s", forbidden, stderr)
+		}
+	}
+}
+
+func TestAuthMiddlewareEmitsDeniedAccessAuditEvents(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APIKeys: []config.APIKey{{
+				Key:       "test-key",
+				Principal: "ci",
+				TenantID:  "writer",
+			}},
+		},
+	}
+	app := New(cfg, Dependencies{}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	unauthStderr := captureBootstrapStderr(t, func() {
+		resp, err := server.Client().Get(server.URL + "/sources?tenant_id=writer")
+		if err != nil {
+			t.Fatalf("GET /sources without auth error = %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("GET /sources without auth status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+		}
+	})
+	unauthPayload := decodeBootstrapTelemetryPayload(t, unauthStderr)
+	for key, want := range map[string]any{
+		"name":          "cerebro.api.access",
+		"outcome":       "denied",
+		"status":        float64(http.StatusUnauthorized),
+		"route":         "GET /sources",
+		"tenant_id":     "writer",
+		"denial_reason": "unauthenticated",
+	} {
+		if got := unauthPayload[key]; got != want {
+			t.Fatalf("unauth audit payload[%q] = %#v, want %#v; payload=%#v", key, got, want, unauthPayload)
+		}
+	}
+	if _, ok := unauthPayload["principal"]; ok {
+		t.Fatalf("unauth audit payload included principal: %#v", unauthPayload)
+	}
+
+	forbiddenStderr := captureBootstrapStderr(t, func() {
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/sources?tenant_id=other", nil)
+		if err != nil {
+			t.Fatalf("NewRequest forbidden: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer test-key")
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			t.Fatalf("GET /sources forbidden error = %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("GET /sources forbidden status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+		}
+	})
+	forbiddenPayload := decodeBootstrapTelemetryPayload(t, forbiddenStderr)
+	for key, want := range map[string]any{
+		"name":                "cerebro.api.access",
+		"outcome":             "denied",
+		"status":              float64(http.StatusForbidden),
+		"route":               "GET /sources",
+		"tenant_id":           "other",
+		"principal":           "ci",
+		"principal_tenant_id": "writer",
+		"auth_mode":           "api_key",
+		"denial_reason":       "tenant_forbidden",
+	} {
+		if got := forbiddenPayload[key]; got != want {
+			t.Fatalf("forbidden audit payload[%q] = %#v, want %#v; payload=%#v", key, got, want, forbiddenPayload)
+		}
+	}
+	if strings.Contains(forbiddenStderr, "test-key") {
+		t.Fatalf("forbidden audit log leaked bearer token: %s", forbiddenStderr)
+	}
+}
+
+func TestAuthMiddlewareSkipsAccessAuditForPublicRoutes(t *testing.T) {
+	cfg := config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth:            config.AuthConfig{Enabled: true},
+	}
+	app := New(cfg, Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	stderr := captureBootstrapStderr(t, func() {
+		resp, err := server.Client().Get(server.URL + "/health")
+		if err != nil {
+			t.Fatalf("GET /health error = %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET /health status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+	})
+	if strings.Contains(stderr, "cerebro.api.access") {
+		t.Fatalf("public route emitted access audit event: %s", stderr)
+	}
+}
+
+func TestAccessAuditOutcomeClassifiesDownstreamAuthorizationFailures(t *testing.T) {
+	outcome, reason := accessAuditOutcome(http.StatusForbidden, "allowed", "")
+	if outcome != "denied" || reason != "authorization_failed" {
+		t.Fatalf("accessAuditOutcome(403) = (%q, %q), want denied authorization_failed", outcome, reason)
+	}
+	outcome, reason = accessAuditOutcome(http.StatusInternalServerError, "allowed", "")
+	if outcome != "error" || reason != "" {
+		t.Fatalf("accessAuditOutcome(500) = (%q, %q), want error empty reason", outcome, reason)
 	}
 }
 
@@ -5608,4 +5792,39 @@ func cloneEntityRef(ref *cerebrov1.EntityRef) *cerebrov1.EntityRef {
 		return nil
 	}
 	return proto.Clone(ref).(*cerebrov1.EntityRef)
+}
+
+func captureBootstrapStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stderr: %v", err)
+	}
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	payload, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	return string(payload)
+}
+
+func decodeBootstrapTelemetryPayload(t *testing.T, stderr string) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(stderr), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) == "" {
+		t.Fatal("telemetry stderr is empty")
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &payload); err != nil {
+		t.Fatalf("unmarshal telemetry payload %q: %v", lines[len(lines)-1], err)
+	}
+	return payload
 }

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -27,6 +28,11 @@ var errTenantForbidden = errors.New("tenant forbidden")
 var errScopeForbidden = errors.New("scope forbidden")
 
 type authContextKey struct{}
+type accessAuditContextKey struct{}
+
+type accessAuditResult struct {
+	ConnectCode string
+}
 
 type authPrincipal struct {
 	Name           string
@@ -56,13 +62,14 @@ func authMiddleware(cfg config.AuthConfig, next http.Handler) http.Handler {
 		}
 		started := time.Now()
 		recorder := &accessAuditResponseWriter{ResponseWriter: w}
+		auditResult := &accessAuditResult{}
 		principal := authPrincipal{}
 		outcome := "denied"
 		denialReason := ""
 		defer func() {
 			status := recorder.Status()
-			finalOutcome, finalDenialReason := accessAuditOutcome(status, outcome, denialReason)
-			emitAccessAuditEvent(r, principal, status, time.Since(started), finalOutcome, finalDenialReason)
+			finalOutcome, finalDenialReason := accessAuditOutcome(status, outcome, denialReason, auditResult.ConnectCode)
+			emitAccessAuditEvent(r, principal, status, time.Since(started), finalOutcome, finalDenialReason, auditResult.ConnectCode)
 		}()
 		principal, ok := authenticateRequest(cfg, r)
 		if !ok {
@@ -83,6 +90,7 @@ func authMiddleware(cfg config.AuthConfig, next http.Handler) http.Handler {
 		}
 		outcome = "allowed"
 		ctx := context.WithValue(r.Context(), authContextKey{}, auth)
+		ctx = context.WithValue(ctx, accessAuditContextKey{}, auditResult)
 		next.ServeHTTP(recorder, r.WithContext(ctx))
 	})
 }
@@ -92,13 +100,18 @@ func authInterceptor(cfg config.AuthConfig) connect.Interceptor {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			if cfg.Enabled {
 				if err := authorizeConnectProcedureScope(ctx, req.Spec().Procedure); err != nil {
-					return nil, connect.NewError(connect.CodePermissionDenied, nil)
+					connectErr := connect.NewError(connect.CodePermissionDenied, nil)
+					recordConnectAccessAuditResult(ctx, connectErr)
+					return nil, connectErr
 				}
 				if err := authorizeProtoTenant(ctx, cfg, req.Any()); err != nil {
+					recordConnectAccessAuditResult(ctx, err)
 					return nil, err
 				}
 			}
-			return next(ctx, req)
+			response, err := next(ctx, req)
+			recordConnectAccessAuditResult(ctx, err)
+			return response, err
 		}
 	})
 }
@@ -653,7 +666,18 @@ func (w *accessAuditResponseWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }
 
-func emitAccessAuditEvent(r *http.Request, principal authPrincipal, status int, duration time.Duration, outcome string, denialReason string) {
+func recordConnectAccessAuditResult(ctx context.Context, err error) {
+	if err == nil {
+		return
+	}
+	result, _ := ctx.Value(accessAuditContextKey{}).(*accessAuditResult)
+	if result == nil {
+		return
+	}
+	result.ConnectCode = strings.ToLower(connect.CodeOf(err).String())
+}
+
+func emitAccessAuditEvent(r *http.Request, principal authPrincipal, status int, duration time.Duration, outcome string, denialReason string, connectCode string) {
 	if r == nil {
 		return
 	}
@@ -664,8 +688,8 @@ func emitAccessAuditEvent(r *http.Request, principal authPrincipal, status int, 
 		telemetry.Field{Key: "route", Value: accessAuditRoute(r)},
 		telemetry.Field{Key: "duration_ms", Value: duration.Milliseconds()},
 	)
-	if remoteAddr := strings.TrimSpace(r.RemoteAddr); remoteAddr != "" {
-		attrs = attrs.WithField(telemetry.Field{Key: "remote_addr", Value: remoteAddr})
+	if remoteIP := accessAuditRemoteIP(r.RemoteAddr); remoteIP != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "remote_ip", Value: remoteIP})
 	}
 	if tenantID := firstNonEmpty(requestTenantHint(r), principal.TenantID); tenantID != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "tenant_id", Value: tenantID})
@@ -688,13 +712,27 @@ func emitAccessAuditEvent(r *http.Request, principal authPrincipal, status int, 
 	if procedure := accessAuditConnectProcedure(r.URL.Path); procedure != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "connect_procedure", Value: procedure})
 	}
+	if connectCode != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "connect_code", Value: connectCode})
+	}
 	if denialReason != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "denial_reason", Value: denialReason})
 	}
 	telemetry.Event(r.Context(), "cerebro.api.access", attrs)
 }
 
-func accessAuditOutcome(status int, outcome string, denialReason string) (string, string) {
+func accessAuditOutcome(status int, outcome string, denialReason string, connectCode string) (string, string) {
+	switch strings.ToLower(strings.TrimSpace(connectCode)) {
+	case "":
+	case "unauthenticated":
+		return "denied", firstNonEmpty(denialReason, "unauthenticated")
+	case "permission_denied":
+		return "denied", firstNonEmpty(denialReason, "authorization_failed")
+	case "internal", "unavailable", "unknown", "data_loss":
+		return "error", denialReason
+	default:
+		return "rejected", denialReason
+	}
 	switch status {
 	case http.StatusUnauthorized:
 		return "denied", firstNonEmpty(denialReason, "unauthenticated")
@@ -709,6 +747,20 @@ func accessAuditOutcome(status int, outcome string, denialReason string) (string
 		}
 		return outcome, denialReason
 	}
+}
+
+func accessAuditRemoteIP(remoteAddr string) string {
+	remoteAddr = strings.TrimSpace(remoteAddr)
+	if remoteAddr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return strings.Trim(host, "[]")
+	}
+	if parsed := net.ParseIP(remoteAddr); parsed != nil {
+		return parsed.String()
+	}
+	return ""
 }
 
 func accessAuditRoute(r *http.Request) string {
@@ -732,7 +784,52 @@ func accessAuditConnectProcedure(path string) string {
 	if !isConnectProcedurePath(path) {
 		return ""
 	}
-	return strings.Trim(strings.TrimPrefix(path, "/"), "/")
+	procedure := "/" + strings.Trim(path, "/")
+	if _, ok := knownAccessAuditConnectProcedures[procedure]; !ok {
+		return "unknown"
+	}
+	return strings.TrimPrefix(procedure, "/")
+}
+
+var knownAccessAuditConnectProcedures = map[string]struct{}{
+	cerebrov1connect.BootstrapServiceGetVersionProcedure:                        {},
+	cerebrov1connect.BootstrapServiceCheckHealthProcedure:                       {},
+	cerebrov1connect.BootstrapServiceListReportDefinitionsProcedure:             {},
+	cerebrov1connect.BootstrapServiceListFindingRulesProcedure:                  {},
+	cerebrov1connect.BootstrapServiceRunReportProcedure:                         {},
+	cerebrov1connect.BootstrapServiceGetReportRunProcedure:                      {},
+	cerebrov1connect.BootstrapServiceListSourcesProcedure:                       {},
+	cerebrov1connect.BootstrapServiceCheckSourceProcedure:                       {},
+	cerebrov1connect.BootstrapServiceDiscoverSourceProcedure:                    {},
+	cerebrov1connect.BootstrapServiceReadSourceProcedure:                        {},
+	cerebrov1connect.BootstrapServicePutSourceRuntimeProcedure:                  {},
+	cerebrov1connect.BootstrapServiceGetSourceRuntimeProcedure:                  {},
+	cerebrov1connect.BootstrapServiceSyncSourceRuntimeProcedure:                 {},
+	cerebrov1connect.BootstrapServiceWriteClaimsProcedure:                       {},
+	cerebrov1connect.BootstrapServiceListClaimsProcedure:                        {},
+	cerebrov1connect.BootstrapServiceListFindingsProcedure:                      {},
+	cerebrov1connect.BootstrapServiceGetFindingProcedure:                        {},
+	cerebrov1connect.BootstrapServiceResolveFindingProcedure:                    {},
+	cerebrov1connect.BootstrapServiceSuppressFindingProcedure:                   {},
+	cerebrov1connect.BootstrapServiceAssignFindingProcedure:                     {},
+	cerebrov1connect.BootstrapServiceSetFindingDueDateProcedure:                 {},
+	cerebrov1connect.BootstrapServiceAddFindingNoteProcedure:                    {},
+	cerebrov1connect.BootstrapServiceLinkFindingTicketProcedure:                 {},
+	cerebrov1connect.BootstrapServiceListFindingEvaluationRunsProcedure:         {},
+	cerebrov1connect.BootstrapServiceGetFindingEvaluationRunProcedure:           {},
+	cerebrov1connect.BootstrapServiceListFindingEvidenceProcedure:               {},
+	cerebrov1connect.BootstrapServiceGetFindingEvidenceProcedure:                {},
+	cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingRulesProcedure: {},
+	cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingsProcedure:     {},
+	cerebrov1connect.BootstrapServiceWriteDecisionProcedure:                     {},
+	cerebrov1connect.BootstrapServiceWriteActionProcedure:                       {},
+	cerebrov1connect.BootstrapServiceWriteOutcomeProcedure:                      {},
+	cerebrov1connect.BootstrapServiceReplayWorkflowEventsProcedure:              {},
+	cerebrov1connect.BootstrapServiceGetEntityNeighborhoodProcedure:             {},
+	cerebrov1connect.BootstrapServiceRunGraphIngestRuntimeProcedure:             {},
+	cerebrov1connect.BootstrapServiceGetGraphIngestRunProcedure:                 {},
+	cerebrov1connect.BootstrapServiceListGraphIngestRunsProcedure:               {},
+	cerebrov1connect.BootstrapServiceCheckGraphIngestHealthProcedure:            {},
 }
 
 func fallbackAccessAuditRoute(method string, path string) string {

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 var errTenantForbidden = errors.New("tenant forbidden")
@@ -32,6 +33,7 @@ type authPrincipal struct {
 	TenantID       string
 	CredentialID   string
 	ClientID       string
+	AuthMode       string
 	AllowedTenants []string
 	Scopes         []string
 	Groups         []string
@@ -52,22 +54,36 @@ func authMiddleware(cfg config.AuthConfig, next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+		started := time.Now()
+		recorder := &accessAuditResponseWriter{ResponseWriter: w}
+		principal := authPrincipal{}
+		outcome := "denied"
+		denialReason := ""
+		defer func() {
+			status := recorder.Status()
+			finalOutcome, finalDenialReason := accessAuditOutcome(status, outcome, denialReason)
+			emitAccessAuditEvent(r, principal, status, time.Since(started), finalOutcome, finalDenialReason)
+		}()
 		principal, ok := authenticateRequest(cfg, r)
 		if !ok {
-			writeAuthError(w, http.StatusUnauthorized, "unauthorized")
+			denialReason = "unauthenticated"
+			writeAuthError(recorder, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 		if tenantID := requestTenantHint(r); tenantID != "" && !tenantAllowed(cfg, principal, tenantID) {
-			writeAuthError(w, http.StatusForbidden, "tenant forbidden")
+			denialReason = "tenant_forbidden"
+			writeAuthError(recorder, http.StatusForbidden, "tenant forbidden")
 			return
 		}
 		auth := authContext{cfg: cfg, principal: principal}
 		if err := authorizeHTTPRequestScope(auth, r); err != nil {
-			writeAuthError(w, http.StatusForbidden, "scope forbidden")
+			denialReason = "scope_forbidden"
+			writeAuthError(recorder, http.StatusForbidden, "scope forbidden")
 			return
 		}
+		outcome = "allowed"
 		ctx := context.WithValue(r.Context(), authContextKey{}, auth)
-		next.ServeHTTP(w, r.WithContext(ctx))
+		next.ServeHTTP(recorder, r.WithContext(ctx))
 	})
 }
 
@@ -106,7 +122,7 @@ func authenticateRequest(cfg config.AuthConfig, r *http.Request) (authPrincipal,
 	}
 	for _, key := range cfg.APIKeys {
 		if constantTimeEqual(token, key.Key) {
-			return authPrincipal{Name: key.Principal, TenantID: key.TenantID}, true
+			return authPrincipal{Name: key.Principal, TenantID: key.TenantID, AuthMode: "api_key"}, true
 		}
 	}
 	for _, credential := range cfg.APICredentials {
@@ -116,6 +132,7 @@ func authenticateRequest(cfg config.AuthConfig, r *http.Request) (authPrincipal,
 				TenantID:       credential.TenantID,
 				CredentialID:   credential.ID,
 				ClientID:       credential.ClientID,
+				AuthMode:       "api_credential",
 				AllowedTenants: credential.AllowedTenants,
 				Scopes:         credential.Scopes,
 			}, true
@@ -208,6 +225,7 @@ func authenticateCapabilityToken(cfg config.AuthConfig, token string, now time.T
 		TenantID:       tenantID,
 		CredentialID:   strings.TrimSpace(claims.CredentialID),
 		ClientID:       strings.TrimSpace(claims.ClientID),
+		AuthMode:       "capability_token",
 		AllowedTenants: allowedTenants,
 		Scopes:         scopes,
 		Groups:         normalizeAuthList(claims.Groups),
@@ -600,4 +618,238 @@ func writeAuthError(w http.ResponseWriter, status int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+type accessAuditResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *accessAuditResponseWriter) WriteHeader(status int) {
+	if w.status == 0 {
+		w.status = status
+		w.ResponseWriter.WriteHeader(status)
+	}
+}
+
+func (w *accessAuditResponseWriter) Write(data []byte) (int, error) {
+	if w.status == 0 {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *accessAuditResponseWriter) Status() int {
+	if w == nil || w.status == 0 {
+		return http.StatusOK
+	}
+	return w.status
+}
+
+func (w *accessAuditResponseWriter) Unwrap() http.ResponseWriter {
+	if w == nil {
+		return nil
+	}
+	return w.ResponseWriter
+}
+
+func emitAccessAuditEvent(r *http.Request, principal authPrincipal, status int, duration time.Duration, outcome string, denialReason string) {
+	if r == nil {
+		return
+	}
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "outcome", Value: outcome},
+		telemetry.Field{Key: "status", Value: status},
+		telemetry.Field{Key: "method", Value: r.Method},
+		telemetry.Field{Key: "route", Value: accessAuditRoute(r)},
+		telemetry.Field{Key: "duration_ms", Value: duration.Milliseconds()},
+	)
+	if remoteAddr := strings.TrimSpace(r.RemoteAddr); remoteAddr != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "remote_addr", Value: remoteAddr})
+	}
+	if tenantID := firstNonEmpty(requestTenantHint(r), principal.TenantID); tenantID != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "tenant_id", Value: tenantID})
+	}
+	if principal.Name != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "principal", Value: principal.Name})
+	}
+	if tenantHint := requestTenantHint(r); tenantHint != "" && principal.TenantID != "" && principal.TenantID != tenantHint {
+		attrs = attrs.WithField(telemetry.Field{Key: "principal_tenant_id", Value: principal.TenantID})
+	}
+	if principal.AuthMode != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "auth_mode", Value: principal.AuthMode})
+	}
+	if principal.CredentialID != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "credential_id", Value: principal.CredentialID})
+	}
+	if principal.ClientID != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "client_id", Value: principal.ClientID})
+	}
+	if procedure := accessAuditConnectProcedure(r.URL.Path); procedure != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "connect_procedure", Value: procedure})
+	}
+	if denialReason != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "denial_reason", Value: denialReason})
+	}
+	telemetry.Event(r.Context(), "cerebro.api.access", attrs)
+}
+
+func accessAuditOutcome(status int, outcome string, denialReason string) (string, string) {
+	switch status {
+	case http.StatusUnauthorized:
+		return "denied", firstNonEmpty(denialReason, "unauthenticated")
+	case http.StatusForbidden:
+		return "denied", firstNonEmpty(denialReason, "authorization_failed")
+	default:
+		if status >= 500 {
+			return "error", denialReason
+		}
+		if status >= 400 {
+			return "rejected", denialReason
+		}
+		return outcome, denialReason
+	}
+}
+
+func accessAuditRoute(r *http.Request) string {
+	if r == nil || r.URL == nil {
+		return "unknown"
+	}
+	path := strings.TrimSpace(r.URL.Path)
+	if isConnectProcedurePath(path) {
+		return "/cerebro.v1.BootstrapService/{Procedure}"
+	}
+	if pattern := strings.TrimSpace(r.Pattern); pattern != "" {
+		if strings.Contains(pattern, " ") {
+			return pattern
+		}
+		return strings.TrimSpace(r.Method + " " + pattern)
+	}
+	return fallbackAccessAuditRoute(r.Method, path)
+}
+
+func accessAuditConnectProcedure(path string) string {
+	if !isConnectProcedurePath(path) {
+		return ""
+	}
+	return strings.Trim(strings.TrimPrefix(path, "/"), "/")
+}
+
+func fallbackAccessAuditRoute(method string, path string) string {
+	prefix := strings.TrimSpace(method) + " "
+	switch {
+	case path == "/sources":
+		return prefix + "/sources"
+	case strings.HasPrefix(path, "/sources/"):
+		parts := strings.Split(strings.Trim(path, "/"), "/")
+		if len(parts) == 3 {
+			switch parts[2] {
+			case "check", "discover", "read":
+				return prefix + "/sources/{sourceID}/" + parts[2]
+			default:
+				return prefix + "/sources/{sourceID}/{subresource}"
+			}
+		}
+	case path == "/source-runtimes":
+		return prefix + "/source-runtimes"
+	case strings.HasPrefix(path, "/source-runtimes/"):
+		return prefix + fallbackRuntimeRoute(path)
+	case path == "/reports":
+		return prefix + "/reports"
+	case strings.HasPrefix(path, "/report-runs/"):
+		return prefix + "/report-runs/{runID}"
+	case path == "/finding-rules":
+		return prefix + "/finding-rules"
+	case strings.HasPrefix(path, "/findings/"):
+		return prefix + fallbackFindingRoute(path)
+	case strings.HasPrefix(path, "/finding-evaluation-runs/"):
+		return prefix + "/finding-evaluation-runs/{runID}"
+	case strings.HasPrefix(path, "/finding-evidence/"):
+		return prefix + "/finding-evidence/{evidenceID}"
+	case strings.HasPrefix(path, "/grc/entities/") && strings.HasSuffix(path, "/impact"):
+		return prefix + "/grc/entities/{entityID}/impact"
+	case strings.HasPrefix(path, "/grc/audit-packets/"):
+		return prefix + "/grc/audit-packets/{packetID}"
+	case strings.HasPrefix(path, "/grc/"):
+		switch path {
+		case "/grc/dashboard", "/grc/findings", "/grc/controls", "/grc/evidence":
+			return prefix + path
+		default:
+			return prefix + "/grc/{subresource}"
+		}
+	case strings.HasPrefix(path, "/platform/graph/ingest-runs/"):
+		return prefix + "/platform/graph/ingest-runs/{runID}"
+	case strings.HasPrefix(path, "/graph/ingest-runs/"):
+		return prefix + "/graph/ingest-runs/{runID}"
+	case isKnownStaticAccessPath(path):
+		return prefix + path
+	}
+	return prefix + "unmatched"
+}
+
+func fallbackRuntimeRoute(path string) string {
+	suffix := strings.TrimPrefix(path, "/source-runtimes/")
+	if !strings.Contains(suffix, "/") {
+		return "/source-runtimes/{runtimeID}"
+	}
+	parts := strings.SplitN(suffix, "/", 2)
+	switch parts[1] {
+	case "sync", "graph-ingest-runs", "claims", "findings", "finding-evidence", "finding-evaluation-runs":
+		return "/source-runtimes/{runtimeID}/" + parts[1]
+	case "finding-rules/evaluate":
+		return "/source-runtimes/{runtimeID}/finding-rules/evaluate"
+	case "findings/evaluate":
+		return "/source-runtimes/{runtimeID}/findings/evaluate"
+	default:
+		return "/source-runtimes/{runtimeID}/{subresource}"
+	}
+}
+
+func fallbackFindingRoute(path string) string {
+	suffix := strings.TrimPrefix(path, "/findings/")
+	if !strings.Contains(suffix, "/") {
+		return "/findings/{findingID}"
+	}
+	parts := strings.SplitN(suffix, "/", 2)
+	switch parts[1] {
+	case "resolve", "suppress", "assign", "due", "notes", "tickets":
+		return "/findings/{findingID}/" + parts[1]
+	default:
+		return "/findings/{findingID}/{subresource}"
+	}
+}
+
+func isKnownStaticAccessPath(path string) bool {
+	switch path {
+	case "/platform/knowledge/decisions",
+		"/platform/knowledge/actions",
+		"/platform/knowledge/actions/recommendation",
+		"/graph/actuate/recommendation",
+		"/platform/knowledge/outcomes",
+		"/graph/write/outcome",
+		"/platform/workflow/replay",
+		"/platform/graph/neighborhood",
+		"/graph/neighborhood",
+		"/platform/graph/impact/package",
+		"/graph/impact/package",
+		"/platform/graph/impact/asset",
+		"/graph/impact/asset",
+		"/platform/graph/aws-public-endpoint-insights",
+		"/platform/graph/ingest-health",
+		"/graph/ingest-health",
+		"/platform/graph/ingest-runs",
+		"/graph/ingest-runs":
+		return true
+	default:
+		return false
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary
- emit structured `cerebro.api.access` telemetry for authenticated non-public Cerebro API requests
- log safe audit fields: outcome, status, method, sanitized route, duration, tenant/principal/auth mode, credential/client IDs, and Connect procedure
- classify downstream 401/403 responses as access denials while avoiding auth headers, request bodies, query strings, and raw resource paths

## Validation
- `make verify`