### PR TITLE
fix(grc): surface stale risk signals

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -884,6 +884,57 @@ func (s *stubRuntimeStore) ListFindings(_ context.Context, request ports.ListFin
 	return findings, nil
 }
 
+func (s *stubRuntimeStore) SummarizeFindings(_ context.Context, request ports.ListFindingsRequest) (ports.FindingSummary, error) {
+	if s.err != nil {
+		return ports.FindingSummary{}, s.err
+	}
+	var summary ports.FindingSummary
+	controls := map[string]struct{}{}
+	now := time.Now().UTC()
+	for _, finding := range s.findings {
+		if !findingMatches(request, finding) {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(finding.Status), "open") {
+			continue
+		}
+		summary.OpenFindings++
+		if strings.EqualFold(strings.TrimSpace(finding.Severity), "critical") {
+			summary.CriticalFindings++
+		}
+		if strings.EqualFold(strings.TrimSpace(finding.Severity), "high") {
+			summary.HighFindings++
+		}
+		if !finding.DueAt.IsZero() && now.After(finding.DueAt.UTC()) {
+			summary.OverdueFindings++
+		}
+		if strings.TrimSpace(finding.Assignee) == "" {
+			summary.Unassigned++
+		}
+		if len(finding.ControlRefs) == 0 {
+			controls["Unmapped\x00Needs mapping"] = struct{}{}
+			continue
+		}
+		for _, ref := range finding.ControlRefs {
+			framework := strings.TrimSpace(ref.FrameworkName)
+			controlID := strings.TrimSpace(ref.ControlID)
+			if framework == "" {
+				framework = "Unmapped"
+			}
+			if controlID == "" {
+				controlID = "Needs mapping"
+			}
+			controls[framework+"\x00"+controlID] = struct{}{}
+		}
+	}
+	summary.ControlsFailing = len(controls)
+	for control := range controls {
+		summary.FailingControlKeys = append(summary.FailingControlKeys, control)
+	}
+	sort.Strings(summary.FailingControlKeys)
+	return summary, nil
+}
+
 func (s *stubRuntimeStore) UpdateFindingStatus(_ context.Context, request ports.FindingStatusUpdate) (*ports.FindingRecord, error) {
 	if s.err != nil {
 		return nil, s.err
@@ -1016,6 +1067,19 @@ func (s *stubRuntimeStore) ListFindingEvidence(_ context.Context, request ports.
 		evidence = evidence[:int(request.Limit)]
 	}
 	return evidence, nil
+}
+
+func (s *stubRuntimeStore) CountFindingEvidence(_ context.Context, request ports.ListFindingEvidenceRequest) (int, error) {
+	if s.err != nil {
+		return 0, s.err
+	}
+	count := 0
+	for _, record := range s.findingEvidence {
+		if findingEvidenceMatches(request, record) {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func (s *stubRuntimeStore) PutFindingEvaluationRun(_ context.Context, run *cerebrov1.FindingEvaluationRun) error {

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -102,12 +103,14 @@ type grcEvidenceItem struct {
 }
 
 type grcConnector struct {
-	RuntimeID    string     `json:"runtime_id"`
-	SourceID     string     `json:"source_id,omitempty"`
-	TenantID     string     `json:"tenant_id,omitempty"`
-	Status       string     `json:"status"`
-	Freshness    string     `json:"freshness"`
-	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
+	RuntimeID           string     `json:"runtime_id"`
+	SourceID            string     `json:"source_id,omitempty"`
+	TenantID            string     `json:"tenant_id,omitempty"`
+	Status              string     `json:"status"`
+	Freshness           string     `json:"freshness"`
+	CheckpointWatermark *time.Time `json:"checkpoint_watermark,omitempty"`
+	WatermarkLagSeconds *int64     `json:"watermark_lag_seconds,omitempty"`
+	LastSyncedAt        *time.Time `json:"last_synced_at,omitempty"`
 }
 
 type grcEntityImpactResponse struct {
@@ -153,9 +156,19 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	findingItems := grcFindingItems(findings, runtimeSourceIDs, evidenceCounts)
 	evidenceItems := grcEvidenceItems(evidence, grcFindingTitleMap(findings))
 	controls := grcControlItems(findingItems, evidenceItems)
+	findingSummary, err := a.grcFindingSummary(r, runtimes, grcFindingFilter{Status: "open"})
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	evidenceCount, err := a.grcEvidenceCount(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings)})
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
 
 	writeJSON(w, http.StatusOK, grcDashboardResponse{
-		Summary:     grcBuildSummary(findingItems, controls, evidenceItems, runtimes),
+		Summary:     grcBuildSummary(findingItems, controls, evidenceItems, runtimes, findingSummary, evidenceCount),
 		Findings:    grcLimitFindings(findingItems, 25),
 		Controls:    grcLimitControls(controls, 25),
 		Evidence:    grcLimitEvidence(evidenceItems, 25),
@@ -400,6 +413,14 @@ type grcEvidenceFilter struct {
 	Limit        uint32
 }
 
+type grcFindingSummaryProvider interface {
+	SummarizeFindings(context.Context, ports.ListFindingsRequest) (ports.FindingSummary, error)
+}
+
+type grcFindingEvidenceCounter interface {
+	CountFindingEvidence(context.Context, ports.ListFindingEvidenceRequest) (int, error)
+}
+
 func grcScopeFromRequest(r *http.Request) (grcScope, error) {
 	limit, err := grcLimitFromRequest(r)
 	if err != nil {
@@ -513,6 +534,56 @@ func (a *App) grcListFindingRecords(r *http.Request, runtimes []*cerebrov1.Sourc
 	return records, nil
 }
 
+func (a *App) grcFindingSummary(r *http.Request, runtimes []*cerebrov1.SourceRuntime, filter grcFindingFilter) (*ports.FindingSummary, error) {
+	store := findingStore(a.deps.StateStore)
+	provider, ok := store.(grcFindingSummaryProvider)
+	if !ok {
+		return nil, nil
+	}
+	var summary ports.FindingSummary
+	controlKeys := map[string]struct{}{}
+	runtimeIDsByTenant := map[string][]string{}
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		tenantID := strings.TrimSpace(runtime.GetTenantId())
+		runtimeID := strings.TrimSpace(runtime.GetId())
+		if tenantID == "" || runtimeID == "" {
+			continue
+		}
+		runtimeIDsByTenant[tenantID] = append(runtimeIDsByTenant[tenantID], runtimeID)
+	}
+	for tenantID, runtimeIDs := range runtimeIDsByTenant {
+		item, err := provider.SummarizeFindings(r.Context(), ports.ListFindingsRequest{
+			TenantID:    tenantID,
+			RuntimeIDs:  runtimeIDs,
+			FindingID:   filter.FindingID,
+			RuleID:      filter.RuleID,
+			Severity:    filter.Severity,
+			Status:      filter.Status,
+			ResourceURN: filter.ResourceURN,
+			EventID:     filter.EventID,
+			PolicyID:    filter.PolicyID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		summary.OpenFindings += item.OpenFindings
+		summary.CriticalFindings += item.CriticalFindings
+		summary.HighFindings += item.HighFindings
+		summary.OverdueFindings += item.OverdueFindings
+		summary.Unassigned += item.Unassigned
+		for _, key := range item.FailingControlKeys {
+			if trimmed := strings.TrimSpace(key); trimmed != "" {
+				controlKeys[trimmed] = struct{}{}
+			}
+		}
+	}
+	summary.ControlsFailing = len(controlKeys)
+	return &summary, nil
+}
+
 func (a *App) grcListEvidenceRecords(r *http.Request, runtimes []*cerebrov1.SourceRuntime, filter grcEvidenceFilter) ([]*cerebrov1.FindingEvidence, error) {
 	store := findingEvidenceStore(a.deps.StateStore)
 	if store == nil {
@@ -562,6 +633,45 @@ func (a *App) grcListEvidenceRecords(r *http.Request, runtimes []*cerebrov1.Sour
 		records = records[:int(limit)]
 	}
 	return records, nil
+}
+
+func (a *App) grcEvidenceCount(r *http.Request, runtimes []*cerebrov1.SourceRuntime, filter grcEvidenceFilter) (*int, error) {
+	store := findingEvidenceStore(a.deps.StateStore)
+	counter, ok := store.(grcFindingEvidenceCounter)
+	if !ok {
+		return nil, nil
+	}
+	if filter.FindingIDs != nil && strings.TrimSpace(filter.FindingID) == "" && len(grcNonEmptyFindingIDs(filter.FindingIDs)) == 0 {
+		count := 0
+		return &count, nil
+	}
+	var runtimeIDs []string
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		if runtimeID := strings.TrimSpace(runtime.GetId()); runtimeID != "" {
+			runtimeIDs = append(runtimeIDs, runtimeID)
+		}
+	}
+	count := 0
+	if len(runtimeIDs) == 0 {
+		return &count, nil
+	}
+	item, err := counter.CountFindingEvidence(r.Context(), ports.ListFindingEvidenceRequest{
+		RuntimeIDs:   runtimeIDs,
+		FindingID:    filter.FindingID,
+		FindingIDs:   filter.FindingIDs,
+		RunID:        filter.RunID,
+		RuleID:       filter.RuleID,
+		GraphRootURN: filter.GraphRootURN,
+		Limit:        0,
+	})
+	if err != nil {
+		return nil, err
+	}
+	count += item
+	return &count, nil
 }
 
 func grcRuntimeSourceIDs(runtimes []*cerebrov1.SourceRuntime) map[string]string {
@@ -747,46 +857,62 @@ func grcConnectorItems(runtimes []*cerebrov1.SourceRuntime) []grcConnector {
 			continue
 		}
 		lastSyncedAt := timestampPtr(runtime.GetLastSyncedAt())
+		checkpointWatermark := grcRuntimeCheckpointWatermark(runtime)
 		items = append(items, grcConnector{
-			RuntimeID:    runtime.GetId(),
-			SourceID:     runtime.GetSourceId(),
-			TenantID:     runtime.GetTenantId(),
-			Status:       connectorStatus(lastSyncedAt),
-			Freshness:    connectorFreshness(lastSyncedAt),
-			LastSyncedAt: lastSyncedAt,
+			RuntimeID:           runtime.GetId(),
+			SourceID:            runtime.GetSourceId(),
+			TenantID:            runtime.GetTenantId(),
+			Status:              connectorStatus(checkpointWatermark),
+			Freshness:           connectorFreshness(checkpointWatermark),
+			CheckpointWatermark: checkpointWatermark,
+			WatermarkLagSeconds: watermarkLagSeconds(checkpointWatermark),
+			LastSyncedAt:        lastSyncedAt,
 		})
 	}
 	return items
 }
 
-func grcBuildSummary(findings []grcFindingItem, controls []grcControlItem, evidence []grcEvidenceItem, runtimes []*cerebrov1.SourceRuntime) grcSummary {
+func grcBuildSummary(findings []grcFindingItem, controls []grcControlItem, evidence []grcEvidenceItem, runtimes []*cerebrov1.SourceRuntime, findingSummary *ports.FindingSummary, evidenceCount *int) grcSummary {
 	var summary grcSummary
-	summary.EvidenceItems = len(evidence)
+	if evidenceCount != nil {
+		summary.EvidenceItems = *evidenceCount
+	} else {
+		summary.EvidenceItems = len(evidence)
+	}
 	summary.Connectors = len(runtimes)
-	for _, finding := range findings {
-		if finding.Status == "OPEN" {
-			summary.OpenFindings++
-			if finding.Severity == "CRITICAL" {
-				summary.CriticalFindings++
-			}
-			if finding.Severity == "HIGH" {
-				summary.HighFindings++
-			}
-			if finding.SLAStatus == "overdue" {
-				summary.OverdueFindings++
-			}
-			if finding.Owner == "Unassigned" {
-				summary.Unassigned++
+	if findingSummary != nil {
+		summary.OpenFindings = findingSummary.OpenFindings
+		summary.CriticalFindings = findingSummary.CriticalFindings
+		summary.HighFindings = findingSummary.HighFindings
+		summary.OverdueFindings = findingSummary.OverdueFindings
+		summary.Unassigned = findingSummary.Unassigned
+		summary.ControlsFailing = findingSummary.ControlsFailing
+	} else {
+		for _, finding := range findings {
+			if finding.Status == "OPEN" {
+				summary.OpenFindings++
+				if finding.Severity == "CRITICAL" {
+					summary.CriticalFindings++
+				}
+				if finding.Severity == "HIGH" {
+					summary.HighFindings++
+				}
+				if finding.SLAStatus == "overdue" {
+					summary.OverdueFindings++
+				}
+				if finding.Owner == "Unassigned" {
+					summary.Unassigned++
+				}
 			}
 		}
-	}
-	for _, control := range controls {
-		if control.Status == "failing" {
-			summary.ControlsFailing++
+		for _, control := range controls {
+			if control.Status == "failing" {
+				summary.ControlsFailing++
+			}
 		}
 	}
 	for _, runtime := range runtimes {
-		if connectorStatus(timestampPtr(runtime.GetLastSyncedAt())) == "stale" {
+		if connectorStatus(grcRuntimeCheckpointWatermark(runtime)) == "stale" {
 			summary.StaleConnectors++
 		}
 	}
@@ -894,6 +1020,25 @@ func connectorFreshness(lastSyncedAt *time.Time) string {
 	default:
 		return "stale"
 	}
+}
+
+func grcRuntimeCheckpointWatermark(runtime *cerebrov1.SourceRuntime) *time.Time {
+	if runtime == nil {
+		return nil
+	}
+	return timestampPtr(runtime.GetCheckpoint().GetWatermark())
+}
+
+func watermarkLagSeconds(value *time.Time) *int64 {
+	if value == nil {
+		return nil
+	}
+	lag := time.Since(*value)
+	if lag < 0 {
+		lag = 0
+	}
+	seconds := int64(lag.Seconds())
+	return &seconds
 }
 
 func severityRank(severity string) int {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
-	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC().Truncate(time.Second)
 	store := &stubRuntimeStore{
 		runtimes: map[string]*cerebrov1.SourceRuntime{
 			"writer-okta-audit": {
@@ -23,12 +23,14 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 				SourceId:     "okta",
 				TenantId:     "writer",
 				LastSyncedAt: timestamppb.New(now.Add(-30 * time.Minute)),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now.Add(-30 * time.Minute))},
 			},
 			"writer-github": {
 				Id:           "writer-github",
 				SourceId:     "github",
 				TenantId:     "writer",
-				LastSyncedAt: timestamppb.New(now.Add(-48 * time.Hour)),
+				LastSyncedAt: timestamppb.New(now.Add(-30 * time.Minute)),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now.Add(-48 * time.Hour))},
 			},
 		},
 		findings: map[string]*ports.FindingRecord{
@@ -146,6 +148,115 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	}
 	if !store.findingEvidenceListRequest.CreatedOrder {
 		t.Fatalf("GRC dashboard did not request created-at evidence ordering")
+	}
+	if payload.Summary.StaleConnectors != 1 {
+		t.Fatalf("stale connectors = %d, want 1", payload.Summary.StaleConnectors)
+	}
+	if payload.Connectors[0].CheckpointWatermark == nil && payload.Connectors[1].CheckpointWatermark == nil {
+		t.Fatalf("connector checkpoint watermarks were not surfaced")
+	}
+}
+
+func TestGRCDashboardSummaryUsesUnpaginatedAggregates(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	runtimeID := "tenant-okta-audit"
+	secondRuntimeID := "tenant-github-audit"
+	tenantID := "tenant"
+	controlRefs := []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {
+				Id:           runtimeID,
+				SourceId:     "okta",
+				TenantId:     tenantID,
+				LastSyncedAt: timestamppb.New(now),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)},
+			},
+			secondRuntimeID: {
+				Id:           secondRuntimeID,
+				SourceId:     "github",
+				TenantId:     tenantID,
+				LastSyncedAt: timestamppb.New(now),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)},
+			},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Finding 1",
+				Severity:       "HIGH",
+				Status:         "open",
+				ControlRefs:    controlRefs,
+				LastObservedAt: now.Add(-time.Minute),
+			},
+			"finding-2": {
+				ID:             "finding-2",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Finding 2",
+				Severity:       "CRITICAL",
+				Status:         "open",
+				ControlRefs:    controlRefs,
+				LastObservedAt: now.Add(-2 * time.Minute),
+			},
+			"finding-3": {
+				ID:             "finding-3",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Finding 3",
+				Severity:       "HIGH",
+				Status:         "open",
+				ControlRefs:    controlRefs,
+				LastObservedAt: now.Add(-3 * time.Minute),
+			},
+			"finding-4": {
+				ID:             "finding-4",
+				TenantID:       tenantID,
+				RuntimeID:      secondRuntimeID,
+				Title:          "Finding 4",
+				Severity:       "HIGH",
+				Status:         "open",
+				ControlRefs:    controlRefs,
+				LastObservedAt: now.Add(-4 * time.Minute),
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-1": {Id: "evidence-1", RuntimeId: runtimeID, FindingId: "finding-2", CreatedAt: timestamppb.New(now)},
+			"evidence-2": {Id: "evidence-2", RuntimeId: secondRuntimeID, FindingId: "finding-4", CreatedAt: timestamppb.New(now)},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=" + tenantID + "&limit=1")
+	if err != nil {
+		t.Fatalf("GET /grc/dashboard error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/dashboard status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload grcDashboardResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /grc/dashboard: %v", err)
+	}
+	if len(payload.Findings) != 1 {
+		t.Fatalf("findings len = %d, want paginated row count 1", len(payload.Findings))
+	}
+	if payload.Summary.OpenFindings != 4 {
+		t.Fatalf("summary open findings = %d, want unpaginated total 4", payload.Summary.OpenFindings)
+	}
+	if payload.Summary.CriticalFindings != 1 || payload.Summary.HighFindings != 3 {
+		t.Fatalf("summary severities = critical %d high %d, want 1/3", payload.Summary.CriticalFindings, payload.Summary.HighFindings)
+	}
+	if payload.Summary.ControlsFailing != 1 {
+		t.Fatalf("summary failing controls = %d, want deduplicated total 1", payload.Summary.ControlsFailing)
+	}
+	if payload.Summary.EvidenceItems != 1 {
+		t.Fatalf("summary evidence items = %d, want visible finding evidence total 1", payload.Summary.EvidenceItems)
 	}
 }
 

--- a/internal/findings/identity_signal_rule.go
+++ b/internal/findings/identity_signal_rule.go
@@ -368,6 +368,9 @@ func matchesIdentityAPITokenOrOAuthCreated(_ *cerebrov1.EventEnvelope, attribute
 		return false
 	}
 	action := identityAction(attributes)
+	if routineIdentityAssignmentAction(action) {
+		return false
+	}
 	if strings.TrimSpace(attributes["credential_id"]) != "" || strings.TrimSpace(attributes["credential_type"]) != "" {
 		return identityCredentialActiveOrUnknown(attributes)
 	}
@@ -379,6 +382,29 @@ func matchesIdentityAPITokenOrOAuthCreated(_ *cerebrov1.EventEnvelope, attribute
 	}
 	return containsAny(action, "oauth", "api_client", "client_access", "application") &&
 		containsAny(action, "create", "add")
+}
+
+func routineIdentityAssignmentAction(action string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(action))
+	switch normalized {
+	case "application.user_membership.add",
+		"application.user_membership.remove",
+		"application.user_membership.update",
+		"application.group_membership.add",
+		"application.group_membership.remove",
+		"application.group_membership.update",
+		"group.application_assignment.add",
+		"group.application_assignment.remove",
+		"group.application_assignment.update",
+		"group.user_membership.add",
+		"group.user_membership.remove",
+		"group.user_membership.update",
+		"application.provision.group_push.mapping.created",
+		"application.provision.group_push.mapping.deleted",
+		"application.provision.group_push.mapping.updated":
+		return true
+	}
+	return false
 }
 
 func routineOAuthRuntimeGrant(action string) bool {
@@ -417,6 +443,9 @@ func matchesIdentityExternalGroupMember(_ *cerebrov1.EventEnvelope, attributes m
 
 func matchesIdentityControlTamperOrCredentialChange(event *cerebrov1.EventEnvelope, attributes map[string]string) bool {
 	if !identityOutcomeSuccessfulOrUnknown(attributes) {
+		return false
+	}
+	if routineIdentityAssignmentAction(identityAction(attributes)) {
 		return false
 	}
 	return matchesIdentityAuthControlTampering(event, attributes) ||

--- a/internal/findings/identity_signal_rule_test.go
+++ b/internal/findings/identity_signal_rule_test.go
@@ -433,6 +433,69 @@ func TestIdentitySignalRulesTreatRoutineOAuthGrantsAsTelemetry(t *testing.T) {
 	}
 }
 
+func TestIdentitySignalRulesIgnoreRoutineOktaAssignments(t *testing.T) {
+	rules := identityRulesByID(t)
+	runtime := &cerebrov1.SourceRuntime{Id: "tenant-okta-audit", SourceId: "okta", TenantId: "tenant"}
+	for _, action := range []string{
+		"application.user_membership.add",
+		"group.application_assignment.add",
+		"application.provision.group_push.mapping.created",
+	} {
+		for _, ruleID := range []string{
+			identityAPIOrOAuthCredentialCreatedRuleID,
+			identityControlTamperCredentialChangeRuleID,
+		} {
+			t.Run(action+"/"+ruleID, func(t *testing.T) {
+				event := &cerebrov1.EventEnvelope{
+					Id:       strings.ReplaceAll(action, ".", "-") + "-" + ruleID,
+					TenantId: "tenant",
+					SourceId: "okta",
+					Kind:     "okta.audit",
+					Attributes: map[string]string{
+						"domain":         "tenant.example",
+						"event_type":     action,
+						"actor":          "admin@tenant.example",
+						"actor_id":       "00u-admin",
+						"resource_id":    "0oa-app",
+						"resource_type":  "AppInstance",
+						"outcome_result": "SUCCESS",
+					},
+				}
+				records, err := rules[ruleID].Evaluate(context.Background(), runtime, event)
+				if err != nil {
+					t.Fatalf("Evaluate() error = %v", err)
+				}
+				if len(records) != 0 {
+					t.Fatalf("Evaluate(%s) returned %d findings, want routine assignment suppressed", action, len(records))
+				}
+			})
+		}
+	}
+
+	passwordView := &cerebrov1.EventEnvelope{
+		Id:       "application-user-membership-show-password",
+		TenantId: "tenant",
+		SourceId: "okta",
+		Kind:     "okta.audit",
+		Attributes: map[string]string{
+			"domain":         "tenant.example",
+			"event_type":     "application.user_membership.show_password",
+			"actor":          "admin@tenant.example",
+			"actor_id":       "00u-admin",
+			"resource_id":    "0oa-app",
+			"resource_type":  "AppInstance",
+			"outcome_result": "SUCCESS",
+		},
+	}
+	records, err := rules[identityControlTamperCredentialChangeRuleID].Evaluate(context.Background(), runtime, passwordView)
+	if err != nil {
+		t.Fatalf("Evaluate(passwordView) error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Evaluate(passwordView) returned %d findings, want password access finding", len(records))
+	}
+}
+
 func TestIdentitySignalRulesStillDetectOAuthCredentialCreation(t *testing.T) {
 	rules := identityRulesByID(t)
 	runtime := &cerebrov1.SourceRuntime{Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"}

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 const (
@@ -133,7 +134,25 @@ func (s *Service) WithConfigPreparer(prepare ConfigPreparer) *Service {
 	return s
 }
 
-func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (*RunResult, error) {
+func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (result *RunResult, err error) {
+	ctx, span := telemetry.Start(ctx, "graph.ingest_runtime", telemetry.Attrs(
+		telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(request.RuntimeID)},
+		telemetry.Field{Key: "page_limit", Value: request.PageLimit},
+		telemetry.Field{Key: "checkpoint_id", Value: strings.TrimSpace(request.CheckpointID)},
+		telemetry.Field{Key: "reset_checkpoint", Value: request.ResetCheckpoint},
+		telemetry.Field{Key: "trigger", Value: strings.TrimSpace(request.Trigger)},
+	))
+	status := "failed"
+	spanAttributes := telemetry.Attrs()
+	defer func() {
+		if result != nil {
+			spanAttributes = graphIngestTelemetryAttributes(spanAttributes, result)
+		}
+		if err != nil {
+			spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "error", Value: err.Error()})
+		}
+		telemetry.End(span, status, spanAttributes)
+	}()
 	if s == nil || s.runtimeStore == nil || s.graphStore == nil || s.projector == nil {
 		return nil, ErrRuntimeUnavailable
 	}
@@ -157,7 +176,7 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (*RunR
 		Trigger:   ingestTrigger(request.Trigger),
 		StartedAt: startedAt.Format(time.RFC3339Nano),
 	}
-	result := &RunResult{Run: run}
+	result = &RunResult{Run: run}
 	if err := runStore.PutIngestRun(ctx, run); err != nil {
 		return result, err
 	}
@@ -198,7 +217,32 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (*RunR
 	if err := s.putTerminalIngestRun(ctx, runStore, completed); err != nil {
 		return result, err
 	}
+	status = "completed"
 	return result, nil
+}
+
+func graphIngestTelemetryAttributes(attributes telemetry.Attributes, result *RunResult) telemetry.Attributes {
+	if result == nil {
+		return attributes
+	}
+	run := result.Run
+	for _, field := range []telemetry.Field{
+		{Key: "run_id", Value: run.ID},
+		{Key: "runtime_id", Value: run.RuntimeID},
+		{Key: "source_id", Value: run.SourceID},
+		{Key: "tenant_id", Value: run.TenantID},
+		{Key: "checkpoint_id", Value: run.CheckpointID},
+		{Key: "pages_read", Value: run.PagesRead},
+		{Key: "events_read", Value: run.EventsRead},
+		{Key: "entities_projected", Value: run.EntitiesProjected},
+		{Key: "links_projected", Value: run.LinksProjected},
+		{Key: "checkpoint_persisted", Value: result.Ingest != nil && result.Ingest.CheckpointPersisted},
+		{Key: "checkpoint_complete", Value: result.Ingest != nil && result.Ingest.CheckpointComplete},
+		{Key: "checkpoint_already_fresh", Value: result.Ingest != nil && result.Ingest.CheckpointAlreadyFresh},
+	} {
+		attributes = attributes.WithField(field)
+	}
+	return attributes
 }
 
 func (s *Service) GetRun(ctx context.Context, id string) (graphstore.IngestRun, error) {

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -81,6 +81,18 @@ type ListFindingsRequest struct {
 	PriorityOrder bool
 }
 
+// FindingSummary captures aggregate counts for one finding query without applying
+// pagination limits intended for UI rows.
+type FindingSummary struct {
+	OpenFindings       int
+	CriticalFindings   int
+	HighFindings       int
+	OverdueFindings    int
+	Unassigned         int
+	ControlsFailing    int
+	FailingControlKeys []string
+}
+
 // ErrFindingEvaluationRunNotFound indicates that a persisted finding evaluation run does not exist.
 var ErrFindingEvaluationRunNotFound = errors.New("finding evaluation run not found")
 

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -323,6 +324,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "entities_projected", Value: entitiesProjected})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "links_projected", Value: linksProjected})
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "has_next_cursor", Value: runtime.GetNextCursor() != nil})
+	if watermark, lagSeconds, ok := runtimeWatermarkLag(runtime, time.Now().UTC()); ok {
+		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "checkpoint_watermark", Value: watermark.Format(time.RFC3339Nano)})
+		spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "source_runtime_watermark_lag_seconds", Value: lagSeconds})
+	}
 	return &cerebrov1.SyncSourceRuntimeResponse{
 		Runtime:           redactRuntime(runtime),
 		Source:            source.Spec(),
@@ -331,6 +336,21 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		EntitiesProjected: entitiesProjected,
 		LinksProjected:    linksProjected,
 	}, nil
+}
+
+func runtimeWatermarkLag(runtime *cerebrov1.SourceRuntime, now time.Time) (time.Time, int64, bool) {
+	if runtime == nil || runtime.GetCheckpoint().GetWatermark() == nil {
+		return time.Time{}, 0, false
+	}
+	watermark := runtime.GetCheckpoint().GetWatermark().AsTime().UTC()
+	if watermark.IsZero() {
+		return time.Time{}, 0, false
+	}
+	lag := now.UTC().Sub(watermark)
+	if lag < 0 {
+		lag = 0
+	}
+	return watermark, int64(lag.Seconds()), true
 }
 
 func (s *Service) resolveConfig(ctx context.Context, sourceID string, tenantID string, config map[string]string) (map[string]string, error) {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -833,6 +833,25 @@ func TestPutIgnoresClientSuppliedProgress(t *testing.T) {
 	}
 }
 
+func TestRuntimeWatermarkLagUsesCheckpointWatermark(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	watermark := now.Add(-2 * time.Hour)
+	runtime := &cerebrov1.SourceRuntime{
+		Checkpoint: &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(watermark)},
+	}
+
+	gotWatermark, lagSeconds, ok := runtimeWatermarkLag(runtime, now)
+	if !ok {
+		t.Fatal("runtimeWatermarkLag ok = false, want true")
+	}
+	if !gotWatermark.Equal(watermark) {
+		t.Fatalf("watermark = %s, want %s", gotWatermark, watermark)
+	}
+	if lagSeconds != int64((2 * time.Hour).Seconds()) {
+		t.Fatalf("lagSeconds = %d, want 7200", lagSeconds)
+	}
+}
+
 func TestPutRestoresRedactedSensitiveConfigBeforeMerge(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -281,15 +281,54 @@ func (s *Store) ListFindingEvidence(ctx context.Context, request ports.ListFindi
 	return evidence, nil
 }
 
+// CountFindingEvidence returns the unpaginated number of evidence rows for one filtered query.
+func (s *Store) CountFindingEvidence(ctx context.Context, request ports.ListFindingEvidenceRequest) (int, error) {
+	if s == nil || s.db == nil {
+		return 0, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingEvidenceTables(ctx); err != nil {
+		return 0, err
+	}
+	clauses, args, err := findingEvidenceFilterClauses(request)
+	if err != nil {
+		return 0, err
+	}
+	var count int
+	if err := s.db.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM finding_evidence
+WHERE `+strings.Join(clauses, " AND "), args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count finding evidence for runtime %q: %w", strings.TrimSpace(request.RuntimeID), err)
+	}
+	return count, nil
+}
+
 func (s *Store) ensureFindingEvidenceTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.findingEvidenceReady, "finding evidence", ensureFindingEvidenceStatements)
 }
 
 func findingEvidenceListQuery(request ports.ListFindingEvidenceRequest) (string, []any, error) {
+	clauses, args, err := findingEvidenceFilterClauses(request)
+	if err != nil {
+		return "", nil, err
+	}
+	query := `
+SELECT finding_evidence_json::text
+FROM finding_evidence
+WHERE ` + strings.Join(clauses, " AND ") + `
+ORDER BY ` + findingEvidenceListOrder(request)
+	if request.Limit != 0 {
+		args = append(args, int64(request.Limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	return query, args, nil
+}
+
+func findingEvidenceFilterClauses(request ports.ListFindingEvidenceRequest) ([]string, []any, error) {
 	runtimeID := strings.TrimSpace(request.RuntimeID)
 	runtimeIDs := normalizedNonEmptyStrings(append(request.RuntimeIDs, runtimeID))
 	if len(runtimeIDs) == 0 {
-		return "", nil, errors.New("finding evidence runtime id is required")
+		return nil, nil, errors.New("finding evidence runtime id is required")
 	}
 	clauses := []string{}
 	args := []any{}
@@ -305,27 +344,18 @@ func findingEvidenceListQuery(request ports.ListFindingEvidenceRequest) (string,
 	addFindingEvidenceRunFilter(&clauses, &args, request.RunID)
 	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
 	if err := addFindingArrayContainsFilter(&clauses, &args, "claim_ids_json", request.ClaimID); err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
 	if err := addFindingArrayContainsFilter(&clauses, &args, "event_ids_json", request.EventID); err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
 	if err := addFindingArrayContainsFilter(&clauses, &args, "graph_root_urns_json", request.GraphRootURN); err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
 	if err := addFindingArrayContainsFilter(&clauses, &args, "graph_path_urns_json", request.GraphPathURN); err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
-	query := `
-SELECT finding_evidence_json::text
-FROM finding_evidence
-WHERE ` + strings.Join(clauses, " AND ") + `
-ORDER BY ` + findingEvidenceListOrder(request)
-	if request.Limit != 0 {
-		args = append(args, int64(request.Limit))
-		query += fmt.Sprintf(" LIMIT $%d", len(args))
-	}
-	return query, args, nil
+	return clauses, args, nil
 }
 
 func findingEvidenceListOrder(request ports.ListFindingEvidenceRequest) string {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -389,6 +390,81 @@ func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequ
 		return nil, fmt.Errorf("iterate findings rows: %w", err)
 	}
 	return findings, nil
+}
+
+// SummarizeFindings loads aggregate finding counts for one filtered query without
+// applying row pagination.
+func (s *Store) SummarizeFindings(ctx context.Context, request ports.ListFindingsRequest) (ports.FindingSummary, error) {
+	if s == nil || s.db == nil {
+		return ports.FindingSummary{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return ports.FindingSummary{}, err
+	}
+	clauses, args, err := findingFilterClauses(request)
+	if err != nil {
+		return ports.FindingSummary{}, err
+	}
+	where := strings.Join(clauses, " AND ")
+	query := `
+SELECT
+  COUNT(*) FILTER (WHERE LOWER(status) = 'open'),
+  COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND UPPER(severity) = 'CRITICAL'),
+  COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND UPPER(severity) = 'HIGH'),
+  COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND due_at IS NOT NULL AND due_at < NOW()),
+  COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND TRIM(assignee) = '')
+FROM findings
+WHERE ` + where
+	var summary ports.FindingSummary
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(
+		&summary.OpenFindings,
+		&summary.CriticalFindings,
+		&summary.HighFindings,
+		&summary.OverdueFindings,
+		&summary.Unassigned,
+	); err != nil {
+		return ports.FindingSummary{}, fmt.Errorf("summarize findings: %w", err)
+	}
+	controlQuery := `
+SELECT framework_name, control_id
+FROM (
+  SELECT DISTINCT
+    COALESCE(NULLIF(TRIM(ref->>'framework_name'), ''), 'Unmapped') AS framework_name,
+    COALESCE(NULLIF(TRIM(ref->>'control_id'), ''), 'Needs mapping') AS control_id
+  FROM findings
+  LEFT JOIN LATERAL jsonb_array_elements(
+    CASE
+      WHEN jsonb_array_length(control_refs_json) = 0
+        THEN '[{"framework_name":"Unmapped","control_id":"Needs mapping"}]'::jsonb
+      ELSE control_refs_json
+    END
+  ) AS ref ON TRUE
+  WHERE ` + where + ` AND LOWER(status) = 'open'
+) controls`
+	rows, err := s.db.QueryContext(ctx, controlQuery, args...)
+	if err != nil {
+		return ports.FindingSummary{}, fmt.Errorf("summarize finding controls: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	controlKeys := map[string]struct{}{}
+	for rows.Next() {
+		var frameworkName string
+		var controlID string
+		if err := rows.Scan(&frameworkName, &controlID); err != nil {
+			return ports.FindingSummary{}, fmt.Errorf("scan summarized finding control: %w", err)
+		}
+		key := frameworkName + "\x00" + controlID
+		controlKeys[key] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return ports.FindingSummary{}, fmt.Errorf("iterate summarized finding controls: %w", err)
+	}
+	for key := range controlKeys {
+		summary.FailingControlKeys = append(summary.FailingControlKeys, key)
+	}
+	sort.Strings(summary.FailingControlKeys)
+	summary.ControlsFailing = len(summary.FailingControlKeys)
+	return summary, nil
 }
 
 // GetFinding loads one persisted finding by durable identifier.
@@ -788,28 +864,8 @@ RETURNING
 }
 
 func findingListQuery(request ports.ListFindingsRequest) (string, []any, error) {
-	tenantID := strings.TrimSpace(request.TenantID)
-	if tenantID == "" {
-		return "", nil, errors.New("finding tenant id is required")
-	}
-	runtimeID := strings.TrimSpace(request.RuntimeID)
-	runtimeIDs := normalizedNonEmptyStrings(append(request.RuntimeIDs, runtimeID))
-	ruleID := strings.TrimSpace(request.RuleID)
-	if len(runtimeIDs) == 0 && ruleID == "" {
-		return "", nil, errors.New("finding runtime id or rule id is required")
-	}
-	clauses := []string{"tenant_id = $1"}
-	args := []any{tenantID}
-	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
-	addFindingFilter(&clauses, &args, "id", request.FindingID)
-	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
-	addFindingFilter(&clauses, &args, "severity", request.Severity)
-	addFindingFilter(&clauses, &args, "status", request.Status)
-	addFindingFilter(&clauses, &args, "policy_id", request.PolicyID)
-	if err := addFindingArrayContainsFilter(&clauses, &args, "resource_urns_json", request.ResourceURN); err != nil {
-		return "", nil, err
-	}
-	if err := addFindingArrayContainsFilter(&clauses, &args, "event_ids_json", request.EventID); err != nil {
+	clauses, args, err := findingFilterClauses(request)
+	if err != nil {
 		return "", nil, err
 	}
 	query := `
@@ -826,6 +882,34 @@ ORDER BY ` + findingOrderClause(request.PriorityOrder)
 		query += fmt.Sprintf(" LIMIT $%d", len(args))
 	}
 	return query, args, nil
+}
+
+func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, error) {
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return nil, nil, errors.New("finding tenant id is required")
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	runtimeIDs := normalizedNonEmptyStrings(append(request.RuntimeIDs, runtimeID))
+	ruleID := strings.TrimSpace(request.RuleID)
+	if len(runtimeIDs) == 0 && ruleID == "" {
+		return nil, nil, errors.New("finding runtime id or rule id is required")
+	}
+	clauses := []string{"tenant_id = $1"}
+	args := []any{tenantID}
+	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
+	addFindingFilter(&clauses, &args, "id", request.FindingID)
+	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
+	addFindingFilter(&clauses, &args, "severity", request.Severity)
+	addFindingFilter(&clauses, &args, "status", request.Status)
+	addFindingFilter(&clauses, &args, "policy_id", request.PolicyID)
+	if err := addFindingArrayContainsFilter(&clauses, &args, "resource_urns_json", request.ResourceURN); err != nil {
+		return nil, nil, err
+	}
+	if err := addFindingArrayContainsFilter(&clauses, &args, "event_ids_json", request.EventID); err != nil {
+		return nil, nil, err
+	}
+	return clauses, args, nil
 }
 
 func (s *Store) ensureFindingTables(ctx context.Context) error {

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -1386,6 +1386,9 @@ func adminRoleAttributes(settings settings, record adminRoleRecord) map[string]s
 
 func oktaOAuthEventCategory(eventType string) string {
 	action := strings.ToLower(strings.TrimSpace(eventType))
+	if routineOktaIdentityAssignmentAction(action) {
+		return ""
+	}
 	switch action {
 	case "app.oauth2.authorize.code", "app.oauth2.as.authorize.code":
 		return "runtime_grant"
@@ -1403,6 +1406,31 @@ func oktaOAuthEventCategory(eventType string) string {
 		return "credential_change"
 	}
 	return ""
+}
+
+func routineOktaIdentityAssignmentAction(action string) bool {
+	switch action {
+	case "application.user_membership.add",
+		"application.user_membership.remove",
+		"application.user_membership.update",
+		"application.group_membership.add",
+		"application.group_membership.remove",
+		"application.group_membership.update",
+		"group.application_assignment.add",
+		"group.application_assignment.remove",
+		"group.application_assignment.update",
+		"group.user_membership.add",
+		"group.user_membership.remove",
+		"group.user_membership.update",
+		"application.provision.group_push.mapping.created",
+		"application.provision.group_push.mapping.deleted",
+		"application.provision.group_push.mapping.updated":
+		return true
+	}
+	return strings.Contains(action, "user_membership") ||
+		strings.Contains(action, "group_membership") ||
+		strings.Contains(action, "application_assignment") ||
+		strings.Contains(action, "group_push.mapping")
 }
 
 func oktaOAuthGrantType(eventType string) string {

--- a/sources/okta/source_test.go
+++ b/sources/okta/source_test.go
@@ -248,7 +248,7 @@ func TestCheckDiscoverAndReadLiveOktaAuditPreview(t *testing.T) {
 
 func TestAuditEventNormalizesOAuthRuntimeGrantTelemetry(t *testing.T) {
 	published := mustParseTime(t, "2026-05-07T19:54:46Z")
-	event, err := auditEvent(settings{domain: "writer.okta.com"}, auditRecord{
+	event, err := auditEvent(settings{domain: "tenant.example"}, auditRecord{
 		UUID:      "evt-oauth",
 		Published: published,
 		EventType: "app.oauth2.token.grant.access_token",
@@ -284,6 +284,36 @@ func TestAuditEventNormalizesOAuthRuntimeGrantTelemetry(t *testing.T) {
 		if got := attrs[key]; got != want {
 			t.Fatalf("attribute %s = %q, want %q", key, got, want)
 		}
+	}
+}
+
+func TestAuditEventDoesNotClassifyRoutineAssignmentAsOAuthCredentialChange(t *testing.T) {
+	published := mustParseTime(t, "2026-05-07T19:54:46Z")
+	event, err := auditEvent(settings{domain: "writer.okta.com"}, auditRecord{
+		UUID:      "evt-assignment",
+		Published: published,
+		EventType: "application.user_membership.add",
+		Actor: map[string]any{
+			"id":          "00u-admin",
+			"type":        "User",
+			"alternateId": "admin@tenant.example",
+		},
+		Outcome: map[string]any{"result": "SUCCESS"},
+		Target: []map[string]any{{
+			"id":          "0oa-app",
+			"type":        "AppInstance",
+			"displayName": "Production App",
+		}},
+		raw: json.RawMessage(`{"uuid":"evt-assignment"}`),
+	})
+	if err != nil {
+		t.Fatalf("auditEvent() error = %v", err)
+	}
+	if got := event.Attributes["oauth_event_category"]; got != "" {
+		t.Fatalf("oauth_event_category = %q, want empty for routine membership assignment", got)
+	}
+	if got := oktaOAuthEventCategory("application.provision.group_push.mapping.created"); got != "" {
+		t.Fatalf("group push mapping category = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- use unpaginated finding/evidence aggregates for the GRC dashboard summary
- mark connector freshness from checkpoint watermark lag and emit watermark lag telemetry
- emit graph ingest runtime telemetry spans and suppress routine Okta assignment noise

## Validation
- go test ./internal/bootstrap ./internal/findings ./sources/okta ./internal/graphingest ./internal/sourceruntime ./internal/statestore/postgres -count=1 -v
- make verify
