### PR TITLE
fix(grc): separate sync and watermark freshness

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -108,8 +108,10 @@ type grcConnector struct {
 	TenantID            string     `json:"tenant_id,omitempty"`
 	Status              string     `json:"status"`
 	Freshness           string     `json:"freshness"`
+	SyncLagSeconds      *int64     `json:"sync_lag_seconds,omitempty"`
 	CheckpointWatermark *time.Time `json:"checkpoint_watermark,omitempty"`
 	WatermarkLagSeconds *int64     `json:"watermark_lag_seconds,omitempty"`
+	WatermarkFreshness  string     `json:"watermark_freshness,omitempty"`
 	LastSyncedAt        *time.Time `json:"last_synced_at,omitempty"`
 }
 
@@ -862,10 +864,12 @@ func grcConnectorItems(runtimes []*cerebrov1.SourceRuntime) []grcConnector {
 			RuntimeID:           runtime.GetId(),
 			SourceID:            runtime.GetSourceId(),
 			TenantID:            runtime.GetTenantId(),
-			Status:              connectorStatus(checkpointWatermark),
-			Freshness:           connectorFreshness(checkpointWatermark),
+			Status:              connectorStatus(lastSyncedAt),
+			Freshness:           connectorFreshness(lastSyncedAt),
+			SyncLagSeconds:      timestampLagSeconds(lastSyncedAt),
 			CheckpointWatermark: checkpointWatermark,
-			WatermarkLagSeconds: watermarkLagSeconds(checkpointWatermark),
+			WatermarkLagSeconds: timestampLagSeconds(checkpointWatermark),
+			WatermarkFreshness:  connectorFreshness(checkpointWatermark),
 			LastSyncedAt:        lastSyncedAt,
 		})
 	}
@@ -912,7 +916,7 @@ func grcBuildSummary(findings []grcFindingItem, controls []grcControlItem, evide
 		}
 	}
 	for _, runtime := range runtimes {
-		if connectorStatus(grcRuntimeCheckpointWatermark(runtime)) == "stale" {
+		if connectorStatus(timestampPtr(runtime.GetLastSyncedAt())) == "stale" {
 			summary.StaleConnectors++
 		}
 	}
@@ -1029,7 +1033,7 @@ func grcRuntimeCheckpointWatermark(runtime *cerebrov1.SourceRuntime) *time.Time 
 	return timestampPtr(runtime.GetCheckpoint().GetWatermark())
 }
 
-func watermarkLagSeconds(value *time.Time) *int64 {
+func timestampLagSeconds(value *time.Time) *int64 {
 	if value == nil {
 		return nil
 	}

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -134,6 +134,17 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	if len(payload.Connectors) != 2 {
 		t.Fatalf("connectors len = %d, want 2", len(payload.Connectors))
 	}
+	connectors := map[string]grcConnector{}
+	for _, connector := range payload.Connectors {
+		connectors[connector.RuntimeID] = connector
+	}
+	githubConnector := connectors["writer-github"]
+	if githubConnector.Status != "healthy" || githubConnector.Freshness == "stale" {
+		t.Fatalf("github connector sync health = %q/%q, want healthy non-stale despite old checkpoint", githubConnector.Status, githubConnector.Freshness)
+	}
+	if githubConnector.WatermarkFreshness != "stale" || githubConnector.WatermarkLagSeconds == nil {
+		t.Fatalf("github connector watermark = %q/%v, want stale lag surfaced separately", githubConnector.WatermarkFreshness, githubConnector.WatermarkLagSeconds)
+	}
 	if got := len(store.findingListRequest.RuntimeIDs); got != 2 {
 		t.Fatalf("batched finding runtime count = %d, want 2", got)
 	}
@@ -149,11 +160,58 @@ func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	if !store.findingEvidenceListRequest.CreatedOrder {
 		t.Fatalf("GRC dashboard did not request created-at evidence ordering")
 	}
-	if payload.Summary.StaleConnectors != 1 {
-		t.Fatalf("stale connectors = %d, want 1", payload.Summary.StaleConnectors)
+	if payload.Summary.StaleConnectors != 0 {
+		t.Fatalf("stale connectors = %d, want 0", payload.Summary.StaleConnectors)
 	}
 	if payload.Connectors[0].CheckpointWatermark == nil && payload.Connectors[1].CheckpointWatermark == nil {
 		t.Fatalf("connector checkpoint watermarks were not surfaced")
+	}
+}
+
+func TestGRCConnectorHealthUsesLastSyncedAtSeparatelyFromWatermark(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	runtimes := []*cerebrov1.SourceRuntime{
+		{
+			Id:           "historical-backfill",
+			SourceId:     "okta",
+			TenantId:     "tenant",
+			LastSyncedAt: timestamppb.New(now.Add(-10 * time.Minute)),
+			Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now.Add(-90 * 24 * time.Hour))},
+		},
+		{
+			Id:           "stalled-sync",
+			SourceId:     "github",
+			TenantId:     "tenant",
+			LastSyncedAt: timestamppb.New(now.Add(-48 * time.Hour)),
+			Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now.Add(-10 * time.Minute))},
+		},
+	}
+
+	connectors := grcConnectorItems(runtimes)
+	byID := map[string]grcConnector{}
+	for _, connector := range connectors {
+		byID[connector.RuntimeID] = connector
+	}
+
+	historical := byID["historical-backfill"]
+	if historical.Status != "healthy" || historical.Freshness != "fresh" {
+		t.Fatalf("historical sync health = %q/%q, want healthy/fresh", historical.Status, historical.Freshness)
+	}
+	if historical.WatermarkFreshness != "stale" || historical.WatermarkLagSeconds == nil {
+		t.Fatalf("historical watermark health = %q/%v, want stale lag surfaced", historical.WatermarkFreshness, historical.WatermarkLagSeconds)
+	}
+
+	stalled := byID["stalled-sync"]
+	if stalled.Status != "stale" || stalled.Freshness != "stale" {
+		t.Fatalf("stalled sync health = %q/%q, want stale/stale", stalled.Status, stalled.Freshness)
+	}
+	if stalled.WatermarkFreshness != "fresh" {
+		t.Fatalf("stalled watermark freshness = %q, want fresh", stalled.WatermarkFreshness)
+	}
+
+	summary := grcBuildSummary(nil, nil, nil, runtimes, nil, nil)
+	if summary.StaleConnectors != 1 {
+		t.Fatalf("summary stale connectors = %d, want 1", summary.StaleConnectors)
 	}
 }
 

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -447,22 +447,22 @@ func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*Ing
 			Cursor:   cursor,
 		})
 		if err != nil {
-			return nil, err
+			return result, err
 		}
 		result.PagesRead++
 		if recordProjector, ok := s.projector.(projectionRecordProjector); ok {
 			projected, err := s.projectResponseCoalesced(ctx, request, response, recordProjector)
-			if err != nil {
-				return nil, err
-			}
 			result.EventsRead += projected.EventsRead
 			result.EntitiesProjected += projected.EntitiesProjected
 			result.LinksProjected += projected.LinksProjected
+			if err != nil {
+				return result, err
+			}
 		} else {
 			for _, event := range response.GetEvents() {
 				projected, err := s.projector.Project(ctx, ingestEvent(event, request.TenantID, request.RuntimeID))
 				if err != nil {
-					return nil, fmt.Errorf("project source event %q: %w", event.GetId(), err)
+					return result, fmt.Errorf("project source event %q: %w", event.GetId(), err)
 				}
 				result.EventsRead++
 				result.EntitiesProjected += projected.EntitiesProjected
@@ -472,7 +472,7 @@ func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*Ing
 		cursor = response.GetNextCursor()
 		if checkpointStore != nil {
 			if err := persistCheckpoint(ctx, checkpointStore, request, result, response, cursor); err != nil {
-				return nil, err
+				return result, err
 			}
 		}
 		if cursor == nil {
@@ -485,7 +485,7 @@ func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*Ing
 	if hasCounts {
 		counts, err := countsStore.Counts(ctx)
 		if err != nil {
-			return nil, err
+			return result, err
 		}
 		result.GraphNodesAfter = counts.Nodes
 		result.GraphLinksAfter = counts.Relations

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -10,6 +10,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 )
 
@@ -52,13 +53,22 @@ func (s *stubRunStore) ListIngestRuns(_ context.Context, filter graphstore.Inges
 
 type recordProjectorFunc func(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error)
 
+func (f recordProjectorFunc) Project(_ context.Context, event *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
+	entities, links, err := f(event)
+	return ports.ProjectionResult{
+		EntitiesProjected: uint32(len(entities)),
+		LinksProjected:    uint32(len(links)),
+	}, err
+}
+
 func (f recordProjectorFunc) ProjectRecords(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return f(event)
 }
 
 type recordingProjectionGraphStore struct {
-	entities map[string]*ports.ProjectedEntity
-	links    map[string]*ports.ProjectedLink
+	entities      map[string]*ports.ProjectedEntity
+	links         map[string]*ports.ProjectedLink
+	upsertLinkErr error
 }
 
 func (s *recordingProjectionGraphStore) Ping(context.Context) error { return nil }
@@ -72,11 +82,33 @@ func (s *recordingProjectionGraphStore) UpsertProjectedEntity(_ context.Context,
 }
 
 func (s *recordingProjectionGraphStore) UpsertProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if s.upsertLinkErr != nil {
+		return s.upsertLinkErr
+	}
 	if s.links == nil {
 		s.links = map[string]*ports.ProjectedLink{}
 	}
 	s.links[link.FromURN+"|"+link.Relation+"|"+link.ToURN] = link
 	return nil
+}
+
+type singlePageSource struct {
+	id     string
+	events []*cerebrov1.EventEnvelope
+}
+
+func (s *singlePageSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: s.id, Name: "Single Page"}
+}
+
+func (s *singlePageSource) Check(context.Context, sourcecdk.Config) error { return nil }
+
+func (s *singlePageSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *singlePageSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{Events: s.events}, nil
 }
 
 func TestSensitiveConfigKeyTreatsSecretMarkersAsSensitive(t *testing.T) {
@@ -336,6 +368,56 @@ func TestMergeStringMapClearsOlderObservationMetadataMissingFromNewerAt(t *testi
 		if got, exists := merged[key]; exists {
 			t.Fatalf("merged[%s] = %q, want missing because newer observation omitted it", key, got)
 		}
+	}
+}
+
+func TestIngestSourceReturnsPartialCountersOnProjectionFailure(t *testing.T) {
+	upsertErr := errors.New("neo4j timeout")
+	registry, err := sourcecdk.NewRegistry(&singlePageSource{
+		id: "partial",
+		events: []*cerebrov1.EventEnvelope{{
+			Id:       "event-1",
+			SourceId: "partial",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &recordingProjectionGraphStore{upsertLinkErr: upsertErr}
+	projector := recordProjectorFunc(func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		return []*ports.ProjectedEntity{{
+				URN:        "urn:cerebro:tenant:partial_entity:one",
+				TenantID:   event.GetTenantId(),
+				SourceID:   event.GetSourceId(),
+				RuntimeID:  event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				EntityType: "partial.entity",
+				Label:      "one",
+			}},
+			[]*ports.ProjectedLink{{
+				TenantID:  event.GetTenantId(),
+				SourceID:  event.GetSourceId(),
+				RuntimeID: event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+				FromURN:   "urn:cerebro:tenant:partial_entity:one",
+				Relation:  "related_to",
+				ToURN:     "urn:cerebro:tenant:partial_entity:one",
+			}}, nil
+	})
+	service := New(registry, nil, projector, store)
+
+	result, err := service.ingestSource(context.Background(), sourceRequest{
+		SourceID:  "partial",
+		RuntimeID: "tenant-partial",
+		TenantID:  "tenant",
+		PageLimit: 1,
+	})
+	if !errors.Is(err, upsertErr) {
+		t.Fatalf("ingestSource() error = %v, want %v", err, upsertErr)
+	}
+	if result == nil {
+		t.Fatal("ingestSource() result = nil, want partial counters")
+	}
+	if result.PagesRead != 1 || result.EventsRead != 1 || result.EntitiesProjected != 1 || result.LinksProjected != 0 {
+		t.Fatalf("partial counters = pages %d events %d entities %d links %d, want 1/1/1/0", result.PagesRead, result.EventsRead, result.EntitiesProjected, result.LinksProjected)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- Treat GRC connector health as sync recency from last_synced_at\n- Surface checkpoint watermark freshness separately from sync freshness\n- Preserve partial graph ingest counters when projection fails\n\n## Validation\n- make verify