### PR TITLE
fix(orchestrator): coalesce graph writes after sync

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceregistry"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
@@ -234,12 +235,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		return nil, sourceruntime.ErrRuntimeUnavailable
 	}
 	leaseOwner := orchestratorLeaseOwner()
-	runtimeService := sourceruntime.New(
-		registry,
-		lister,
-		deps.AppendLog,
-		sourceProjector(deps.StateStore, deps.GraphStore),
-	).WithConfigResolver(config.ResolveSourceRuntimeConfigSecretReferences)
+	runtimeService := newOrchestratorRuntimeService(registry, lister, deps.AppendLog, deps.StateStore)
 	findingService := findings.New(
 		lister,
 		eventReplayer(deps.AppendLog),
@@ -298,6 +294,52 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 	}
 	spanAttributes = withTelemetryField(spanAttributes, "iterations_completed", iteration)
 	return result, runErr
+}
+
+func newOrchestratorRuntimeService(registry *sourcecdk.Registry, store ports.SourceRuntimeStore, appendLog ports.AppendLog, stateStore ports.StateStore) *sourceruntime.Service {
+	return sourceruntime.New(
+		registry,
+		store,
+		appendLog,
+		newOrchestratorSyncProjector(stateStore),
+	).WithConfigResolver(config.ResolveSourceRuntimeConfigSecretReferences)
+}
+
+func newOrchestratorSyncProjector(stateStore ports.StateStore) ports.SourceProjector {
+	// Source sync can project current state, but Neo4j writes are handled by
+	// the coalescing graph ingest phase below.
+	return sourceProjector(stateStore, nil)
+}
+
+func orchestratorGraphPageLimit(configured uint32, syncedPages uint32) uint32 {
+	if syncedPages > configured {
+		return syncedPages
+	}
+	return configured
+}
+
+func graphIngestReadyForGraphRules(result *graphingest.RunResult, syncCursor *cerebrov1.SourceCursor) bool {
+	if result == nil || result.Ingest == nil {
+		return false
+	}
+	if !result.Ingest.CheckpointPersisted && !result.Ingest.CheckpointAlreadyFresh {
+		return false
+	}
+	syncCursorOpaque := ""
+	if syncCursor != nil {
+		syncCursorOpaque = strings.TrimSpace(syncCursor.GetOpaque())
+	}
+	return strings.TrimSpace(result.Ingest.CheckpointCursor) == syncCursorOpaque
+}
+
+func orchestratorRuntimeStartCursorOpaque(runtime *cerebrov1.SourceRuntime) string {
+	if runtime == nil {
+		return ""
+	}
+	if cursor := runtime.GetNextCursor(); cursor != nil {
+		return strings.TrimSpace(cursor.GetOpaque())
+	}
+	return strings.TrimSpace(runtime.GetCheckpoint().GetCursorOpaque())
 }
 
 func appendOrchestratorRun(runs []*orchestratorIterationResult, run *orchestratorIterationResult, runForever bool) []*orchestratorIterationResult {
@@ -392,6 +434,7 @@ func runOrchestratorIteration(
 		acquiredCount++
 		runtimeCtx, cancelRuntime := context.WithCancel(runtimeCtx)
 		stopLeaseRenewal := startOrchestratorRuntimeLeaseRenewal(ctx, leaser, runtime, leaseOwner, cancelRuntime)
+		syncStartCursorOpaque := orchestratorRuntimeStartCursorOpaque(runtime)
 		syncResult, err := runtimeService.Sync(runtimeCtx, &cerebrov1.SyncSourceRuntimeRequest{Id: runtime.GetId(), PageLimit: options.PageLimit})
 		if err != nil {
 			runtimeResult.Sync = "failed"
@@ -419,6 +462,12 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "pages_read", runtimeResult.PagesRead)
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "events_appended", runtimeResult.EventsAppended)
 		}
+		graphPageLimit := orchestratorGraphPageLimit(options.GraphPageLimit, runtimeResult.PagesRead)
+		resetGraphCheckpoint := runtimeResult.EventsAppended > 0 && syncStartCursorOpaque == ""
+		resetCompletedGraphCheckpoint := runtimeResult.EventsAppended > 0
+		runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "effective_graph_page_limit", graphPageLimit)
+		runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reset_graph_checkpoint", resetGraphCheckpoint)
+		runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reset_completed_graph_checkpoint", resetCompletedGraphCheckpoint)
 		// Each post-sync phase runs under its own telemetry span and a
 		// dedicated context timeout. Both are intentional: the span gives
 		// operators a span_end event per phase so a stall shows up as a
@@ -432,6 +481,24 @@ func runOrchestratorIteration(
 		// retries from a clean state. The phase contexts are derived
 		// from runtimeCtx (NOT ctx) so they inherit lease-renewal
 		// cancellation while still being independently bounded.
+		graphResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_ingest", iteration, runtime, orchestratorPhaseTimeout, func(phaseCtx context.Context) (*graphingest.RunResult, error) {
+			return graphService.RunRuntime(phaseCtx, graphingest.RuntimeRequest{
+				RuntimeID:                runtime.GetId(),
+				PageLimit:                graphPageLimit,
+				ResetCheckpoint:          resetGraphCheckpoint,
+				ResetCompletedCheckpoint: resetCompletedGraphCheckpoint,
+				Trigger:                  "orchestrator",
+			})
+		})
+		runtimeSpanAttrs = applyGraphIngestCounters(runtimeResult, graphResult, runtimeSpanAttrs)
+		if err != nil {
+			runtimeResult.GraphIngest = "failed"
+			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
+			runErr = err
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_error", err.Error())
+		} else {
+			runtimeResult.GraphIngest = "completed"
+		}
 		findingResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.finding_rules", iteration, runtime, orchestratorPhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateRulesResult, error) {
 			return findingService.EvaluateSourceRuntimeRules(phaseCtx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit})
 		})
@@ -452,23 +519,10 @@ func runOrchestratorIteration(
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "events_evaluated", runtimeResult.EventsEvaluated)
 			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "finding_evaluations", runtimeResult.FindingEvaluations)
 		}
-		graphResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_ingest", iteration, runtime, orchestratorPhaseTimeout, func(phaseCtx context.Context) (*graphingest.RunResult, error) {
-			return graphService.RunRuntime(phaseCtx, graphingest.RuntimeRequest{RuntimeID: runtime.GetId(), PageLimit: options.GraphPageLimit, Trigger: "orchestrator"})
-		})
-		runtimeSpanAttrs = applyGraphIngestCounters(runtimeResult, graphResult, runtimeSpanAttrs)
-		if err != nil {
-			runtimeResult.GraphIngest = "failed"
-			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "graph_ingest", err)
-			runErr = err
-			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_ingest_error", err.Error())
-		} else {
-			runtimeResult.GraphIngest = "completed"
-		}
-		// Run graph rules whenever the projection has updated the graph for this runtime, even
-		// if a trailing PutIngestRun(completed) write failed. The graph is already fresh and the
-		// rules are read-only, so deferring them until the next iteration would needlessly delay
-		// detection and stale-finding auto-resolution.
-		if graphResult != nil && graphResult.Ingest != nil {
+		// Run graph rules whenever the projection has caught up to the same cursor
+		// reached by source sync, even if a trailing PutIngestRun(completed) write
+		// failed. The graph is fresh enough for read-only rules at that point.
+		if graphIngestReadyForGraphRules(graphResult, syncResult.GetRuntime().GetNextCursor()) {
 			graphRulesResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_rules", iteration, runtime, orchestratorPhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateGraphRulesResult, error) {
 				return findingService.EvaluateSourceRuntimeGraphRules(phaseCtx, findings.EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
 			})
@@ -488,6 +542,7 @@ func runOrchestratorIteration(
 			}
 		} else {
 			runtimeResult.GraphRules = "skipped"
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "graph_rules_skip_reason", "graph_ingest_not_caught_up")
 		}
 		cancelRuntime()
 		if err := stopLeaseRenewal(); err != nil {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -137,6 +139,83 @@ func TestRunOrchestratorPhaseInheritsParentCancellation(t *testing.T) {
 	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("runOrchestratorPhase() error = %v, want context.Canceled (inherited from parent)", err)
+	}
+}
+
+func TestNewOrchestratorRuntimeServiceProjectsSourceSyncToStateOnly(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{
+			Id:       "runtime-1",
+			SourceId: "github",
+			TenantId: "writer",
+		},
+	}
+	eventLog := &orchestratorEventLog{}
+	stateStore := newGraphTestStore()
+
+	service := newOrchestratorRuntimeService(registry, store, eventLog, stateStore)
+	result, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-1", PageLimit: 1})
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	if result.GetEventsAppended() != 1 {
+		t.Fatalf("Sync().EventsAppended = %d, want 1", result.GetEventsAppended())
+	}
+	if result.GetEntitiesProjected() == 0 || result.GetLinksProjected() == 0 {
+		t.Fatalf("Sync() projected entities/links = %d/%d, want state projections", result.GetEntitiesProjected(), result.GetLinksProjected())
+	}
+	if len(stateStore.entities) == 0 || len(stateStore.links) == 0 {
+		t.Fatalf("state projections not stored: entities=%d links=%d", len(stateStore.entities), len(stateStore.links))
+	}
+}
+
+func TestNewOrchestratorSyncProjectorDoesNotCreateGraphOnlyProjector(t *testing.T) {
+	if projector := newOrchestratorSyncProjector(nil); projector != nil {
+		t.Fatalf("newOrchestratorSyncProjector(nil) = %#v, want nil", projector)
+	}
+}
+
+func TestOrchestratorGraphPageLimitCoversSyncedPages(t *testing.T) {
+	tests := []struct {
+		name        string
+		configured  uint32
+		syncedPages uint32
+		want        uint32
+	}{
+		{name: "uses configured when higher", configured: 10, syncedPages: 3, want: 10},
+		{name: "raises unset to synced pages", configured: 0, syncedPages: 3, want: 3},
+		{name: "raises lower configured to synced pages", configured: 1, syncedPages: 3, want: 3},
+		{name: "leaves defaulting to graph ingest when no sync pages", configured: 0, syncedPages: 0, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := orchestratorGraphPageLimit(tt.configured, tt.syncedPages); got != tt.want {
+				t.Fatalf("orchestratorGraphPageLimit(%d, %d) = %d, want %d", tt.configured, tt.syncedPages, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOrchestratorRuntimeStartCursorOpaque(t *testing.T) {
+	if got := orchestratorRuntimeStartCursorOpaque(&cerebrov1.SourceRuntime{
+		NextCursor: &cerebrov1.SourceCursor{Opaque: "next-page"},
+		Checkpoint: &cerebrov1.SourceCheckpoint{
+			CursorOpaque: "checkpoint-page",
+		},
+	}); got != "next-page" {
+		t.Fatalf("start cursor = %q, want next-page", got)
+	}
+	if got := orchestratorRuntimeStartCursorOpaque(&cerebrov1.SourceRuntime{
+		Checkpoint: &cerebrov1.SourceCheckpoint{CursorOpaque: "checkpoint-page"},
+	}); got != "checkpoint-page" {
+		t.Fatalf("start cursor = %q, want checkpoint-page", got)
+	}
+	if got := orchestratorRuntimeStartCursorOpaque(&cerebrov1.SourceRuntime{}); got != "" {
+		t.Fatalf("start cursor = %q, want empty", got)
 	}
 }
 
@@ -298,6 +377,228 @@ func TestRunOrchestratorIterationRunsGraphRulesAfterIngest(t *testing.T) {
 	}
 	if runtimeResult.Error != "" {
 		t.Fatalf("runtime error = %q, want empty", runtimeResult.Error)
+	}
+}
+
+func TestRunOrchestratorIterationRunsFindingRulesAfterGraphIngest(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	graphStore := newGraphTestStore()
+	resourceURN := "urn:cerebro:writer:github_pull_request:writer/cerebro#515"
+	findingRule := &orchestratorResourceAwareRule{
+		spec:        &cerebrov1.RuleSpec{Id: "resource-aware-rule", Name: "Resource aware rule"},
+		sourceID:    "github",
+		graph:       graphStore,
+		resourceURN: resourceURN,
+	}
+	ruleRegistry, err := findings.NewRegistry(findingRule)
+	if err != nil {
+		t.Fatalf("NewRegistry() finding rule error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{
+			Id:       "runtime-1",
+			SourceId: "github",
+			TenantId: "writer",
+		},
+		acquired: true,
+	}
+	eventLog := &orchestratorEventLog{}
+	findingStore := &orchestratorFindingStore{}
+	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithGraphStore(graphStore)
+	graphService := graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore)
+
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(registry, store, eventLog, nil),
+		findingService,
+		graphService,
+		orchestratorOptions{},
+		1,
+	)
+	if err != nil {
+		t.Fatalf("runOrchestratorIteration() error = %v, want nil", err)
+	}
+	if got := len(result.Runtimes); got != 1 {
+		t.Fatalf("runtime result count = %d, want 1", got)
+	}
+	runtimeResult := result.Runtimes[0]
+	if runtimeResult.GraphIngest != "completed" || runtimeResult.FindingRules != "completed" {
+		t.Fatalf("graph/finding statuses = %q/%q, want completed/completed", runtimeResult.GraphIngest, runtimeResult.FindingRules)
+	}
+	if !findingRule.sawResource {
+		t.Fatal("finding rule ran before graph ingest wrote the source resource")
+	}
+	linkKey := resourceURN + "|has_finding|urn:cerebro:writer:finding:finding-resource-aware"
+	if _, ok := graphStore.links[linkKey]; !ok {
+		t.Fatalf("finding resource link %q missing", linkKey)
+	}
+}
+
+func TestRunOrchestratorIterationKeepsFindingRulesIndependentOfGraphIngestFailure(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	ruleRegistry, err := findings.NewRegistry(orchestratorNoopRule{})
+	if err != nil {
+		t.Fatalf("NewRegistry() finding rule error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{
+			Id:       "runtime-1",
+			SourceId: "github",
+			TenantId: "writer",
+		},
+		acquired: true,
+	}
+	eventLog := &orchestratorEventLog{}
+	findingStore := &orchestratorFindingStore{}
+	graphStore := &failingProjectionGraphStore{
+		graphTestStore: newGraphTestStore(),
+		err:            errors.New("neo4j unavailable"),
+	}
+
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(registry, store, eventLog, nil),
+		findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry),
+		graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore),
+		orchestratorOptions{},
+		1,
+	)
+	if err == nil {
+		t.Fatal("runOrchestratorIteration() error = nil, want graph ingest failure")
+	}
+	if got := len(result.Runtimes); got != 1 {
+		t.Fatalf("runtime result count = %d, want 1", got)
+	}
+	runtimeResult := result.Runtimes[0]
+	if runtimeResult.GraphIngest != "failed" {
+		t.Fatalf("graph ingest status = %q, want failed", runtimeResult.GraphIngest)
+	}
+	if runtimeResult.FindingRules != "completed" || runtimeResult.EventsEvaluated != 1 {
+		t.Fatalf("finding status/events = %q/%d, want completed/1", runtimeResult.FindingRules, runtimeResult.EventsEvaluated)
+	}
+}
+
+func TestRunOrchestratorIterationSkipsGraphRulesUntilGraphIngestCatchesSyncCursor(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorPagedSource{pages: 3})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	graphRule := &orchestratorGraphRule{
+		spec:     &cerebrov1.RuleSpec{Id: "orchestrator-graph-rule"},
+		sourceID: "github",
+		query:    ports.CypherQueryRequest{Query: "MATCH (n) RETURN n LIMIT 1"},
+	}
+	ruleRegistry, err := findings.NewRegistry(graphRule)
+	if err != nil {
+		t.Fatalf("NewRegistry() finding rule error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{
+			Id:         "runtime-1",
+			SourceId:   "github",
+			TenantId:   "writer",
+			NextCursor: &cerebrov1.SourceCursor{Opaque: "2"},
+		},
+		acquired: true,
+	}
+	eventLog := &orchestratorEventLog{}
+	findingStore := &orchestratorFindingStore{}
+	graphStore := newGraphTestStore()
+	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithGraphQueryStore(graphStore)
+	graphService := graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore)
+
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(registry, store, eventLog, nil),
+		findingService,
+		graphService,
+		orchestratorOptions{PageLimit: 1, GraphPageLimit: 1},
+		1,
+	)
+	if err != nil {
+		t.Fatalf("runOrchestratorIteration() error = %v, want nil", err)
+	}
+	runtimeResult := result.Runtimes[0]
+	if runtimeResult.GraphIngest != "completed" {
+		t.Fatalf("graph ingest status = %q, want completed", runtimeResult.GraphIngest)
+	}
+	if runtimeResult.GraphRules != "skipped" {
+		t.Fatalf("graph rules status = %q, want skipped while graph cursor trails sync cursor", runtimeResult.GraphRules)
+	}
+	if graphRule.calls != 0 {
+		t.Fatalf("graph rule calls = %d, want 0 while graph is still catching up", graphRule.calls)
+	}
+}
+
+func TestRunOrchestratorIterationAlignsGraphIngestWithSyncPageBudget(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorPagedSource{pages: 3})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	ruleRegistry, err := findings.NewRegistry()
+	if err != nil {
+		t.Fatalf("NewRegistry() finding rule error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{
+		runtime: &cerebrov1.SourceRuntime{
+			Id:       "runtime-1",
+			SourceId: "github",
+			TenantId: "writer",
+		},
+		acquired: true,
+	}
+	eventLog := &orchestratorEventLog{}
+	findingStore := &orchestratorFindingStore{}
+	graphStore := newGraphTestStore()
+
+	result, err := runOrchestratorIteration(
+		context.Background(),
+		store,
+		store,
+		"test-owner",
+		sourceruntime.New(registry, store, eventLog, nil),
+		findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry),
+		graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore),
+		orchestratorOptions{PageLimit: 3, GraphPageLimit: 1},
+		1,
+	)
+	if err != nil {
+		t.Fatalf("runOrchestratorIteration() error = %v, want nil", err)
+	}
+	if got := len(result.Runtimes); got != 1 {
+		t.Fatalf("runtime result count = %d, want 1", got)
+	}
+	runtimeResult := result.Runtimes[0]
+	if runtimeResult.PagesRead != 3 || runtimeResult.EventsAppended != 3 {
+		t.Fatalf("sync pages/events = %d/%d, want 3/3", runtimeResult.PagesRead, runtimeResult.EventsAppended)
+	}
+	if runtimeResult.GraphIngest != "completed" {
+		t.Fatalf("graph ingest status = %q, want completed", runtimeResult.GraphIngest)
+	}
+	runs, err := graphStore.ListIngestRuns(context.Background(), graphstore.IngestRunFilter{RuntimeID: "runtime-1", Status: graphstore.IngestRunStatusCompleted})
+	if err != nil {
+		t.Fatalf("ListIngestRuns() error = %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("completed ingest runs = %d, want 1", len(runs))
+	}
+	if runs[0].PagesRead != 3 {
+		t.Fatalf("graph ingest pages read = %d, want synced page budget 3 despite graph_page_limit=1", runs[0].PagesRead)
 	}
 }
 
@@ -684,6 +985,53 @@ func (orchestratorTestSource) Read(context.Context, sourcecdk.Config, *cerebrov1
 	}}}, nil
 }
 
+type orchestratorPagedSource struct {
+	pages int
+}
+
+func (orchestratorPagedSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "github", Name: "GitHub"}
+}
+
+func (orchestratorPagedSource) Check(context.Context, sourcecdk.Config) error {
+	return nil
+}
+
+func (orchestratorPagedSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s orchestratorPagedSource) Read(_ context.Context, _ sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	page := 1
+	if cursor != nil && cursor.GetOpaque() != "" {
+		parsed, err := strconv.Atoi(cursor.GetOpaque())
+		if err != nil {
+			return sourcecdk.Pull{}, err
+		}
+		page = parsed
+	}
+	var nextCursor *cerebrov1.SourceCursor
+	if page < s.pages {
+		nextCursor = &cerebrov1.SourceCursor{Opaque: strconv.Itoa(page + 1)}
+	}
+	return sourcecdk.Pull{
+		Events: []*cerebrov1.EventEnvelope{{
+			Id:       "github-pr-page-" + strconv.Itoa(page),
+			TenantId: "writer",
+			SourceId: "github",
+			Kind:     "github.pull_request",
+			Attributes: map[string]string{
+				"author":      "alice-" + strconv.Itoa(page),
+				"owner":       "writer",
+				"pull_number": strconv.Itoa(500 + page),
+				"repository":  "writer/cerebro",
+				"state":       "open",
+			},
+		}},
+		NextCursor: nextCursor,
+	}, nil
+}
+
 type orchestratorNoopRule struct{}
 
 func (orchestratorNoopRule) Spec() *cerebrov1.RuleSpec {
@@ -727,6 +1075,45 @@ func (r *orchestratorGraphRule) EvaluateRows(_ context.Context, _ *cerebrov1.Sou
 	return r.emit, nil
 }
 
+type orchestratorResourceAwareRule struct {
+	spec        *cerebrov1.RuleSpec
+	sourceID    string
+	graph       *graphTestStore
+	resourceURN string
+	sawResource bool
+}
+
+func (r *orchestratorResourceAwareRule) Spec() *cerebrov1.RuleSpec {
+	return r.spec
+}
+
+func (r *orchestratorResourceAwareRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	return runtime != nil && runtime.GetSourceId() == r.sourceID
+}
+
+func (r *orchestratorResourceAwareRule) Evaluate(_ context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	r.graph.mu.Lock()
+	_, ok := r.graph.entities[r.resourceURN]
+	r.graph.mu.Unlock()
+	r.sawResource = ok
+	if !ok {
+		return nil, errors.New("resource graph entity missing before finding evaluation")
+	}
+	return []*ports.FindingRecord{{
+		ID:           "finding-resource-aware",
+		Fingerprint:  "fp-resource-aware",
+		TenantID:     runtime.GetTenantId(),
+		RuntimeID:    runtime.GetId(),
+		RuleID:       r.spec.GetId(),
+		Title:        "Resource-aware finding",
+		Severity:     "HIGH",
+		Status:       "open",
+		Summary:      "resource-aware finding",
+		ResourceURNs: []string{r.resourceURN},
+		EventIDs:     []string{event.GetId()},
+	}}, nil
+}
+
 type orchestratorEventLog struct {
 	events []*cerebrov1.EventEnvelope
 }
@@ -740,8 +1127,24 @@ func (l *orchestratorEventLog) Append(_ context.Context, event *cerebrov1.EventE
 	return nil
 }
 
-func (l *orchestratorEventLog) Replay(context.Context, ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
-	return nil, nil
+func (l *orchestratorEventLog) Replay(_ context.Context, request ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
+	events := make([]*cerebrov1.EventEnvelope, 0, len(l.events))
+	for _, event := range l.events {
+		if request.RuntimeID != "" && event.GetAttributes()[ports.EventAttributeSourceRuntimeID] != request.RuntimeID {
+			continue
+		}
+		if request.TenantID != "" && event.GetTenantId() != request.TenantID {
+			continue
+		}
+		if request.KindPrefix != "" && !strings.HasPrefix(event.GetKind(), request.KindPrefix) {
+			continue
+		}
+		events = append(events, event)
+		if request.Limit > 0 && uint32(len(events)) >= request.Limit {
+			break
+		}
+	}
+	return events, nil
 }
 
 type orchestratorFindingStore struct{}
@@ -821,4 +1224,13 @@ func (s *failingCompletedIngestGraphStore) PutIngestRun(ctx context.Context, run
 		return errors.New("run completion failed")
 	}
 	return s.graphTestStore.PutIngestRun(ctx, run)
+}
+
+type failingProjectionGraphStore struct {
+	*graphTestStore
+	err error
+}
+
+func (s *failingProjectionGraphStore) UpsertProjectedEntity(context.Context, *ports.ProjectedEntity) error {
+	return s.err
 }

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -72,11 +72,12 @@ type pageProjectionResult struct {
 }
 
 type RuntimeRequest struct {
-	RuntimeID       string
-	PageLimit       uint32
-	CheckpointID    string
-	ResetCheckpoint bool
-	Trigger         string
+	RuntimeID                string
+	PageLimit                uint32
+	CheckpointID             string
+	ResetCheckpoint          bool
+	ResetCompletedCheckpoint bool
+	Trigger                  string
 }
 
 type IngestResult struct {
@@ -140,6 +141,7 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (resul
 		telemetry.Field{Key: "page_limit", Value: request.PageLimit},
 		telemetry.Field{Key: "checkpoint_id", Value: strings.TrimSpace(request.CheckpointID)},
 		telemetry.Field{Key: "reset_checkpoint", Value: request.ResetCheckpoint},
+		telemetry.Field{Key: "reset_completed_checkpoint", Value: request.ResetCompletedCheckpoint},
 		telemetry.Field{Key: "trigger", Value: strings.TrimSpace(request.Trigger)},
 	))
 	status := "failed"
@@ -191,14 +193,15 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (resul
 		return s.failRun(ctx, runStore, run, result, nil, err)
 	}
 	ingestRequest := sourceRequest{
-		SourceID:          strings.TrimSpace(runtime.GetSourceId()),
-		RuntimeID:         runtimeID,
-		SourceConfig:      runtimeConfig,
-		TenantID:          strings.TrimSpace(runtime.GetTenantId()),
-		PageLimit:         pageLimit,
-		CheckpointEnabled: true,
-		CheckpointID:      runtimeCheckpointID(request, runtime, runtimeConfig),
-		ResetCheckpoint:   request.ResetCheckpoint,
+		SourceID:                 strings.TrimSpace(runtime.GetSourceId()),
+		RuntimeID:                runtimeID,
+		SourceConfig:             runtimeConfig,
+		TenantID:                 strings.TrimSpace(runtime.GetTenantId()),
+		PageLimit:                pageLimit,
+		CheckpointEnabled:        true,
+		CheckpointID:             runtimeCheckpointID(request, runtime, runtimeConfig),
+		ResetCheckpoint:          request.ResetCheckpoint,
+		ResetCompletedCheckpoint: request.ResetCompletedCheckpoint,
 	}
 	run.SourceID = ingestRequest.SourceID
 	run.TenantID = ingestRequest.TenantID
@@ -407,15 +410,16 @@ func (s *Service) preparedConfig(ctx context.Context, runtime *cerebrov1.SourceR
 }
 
 type sourceRequest struct {
-	SourceID          string
-	RuntimeID         string
-	SourceConfig      map[string]string
-	TenantID          string
-	PageLimit         uint32
-	Cursor            *cerebrov1.SourceCursor
-	CheckpointEnabled bool
-	CheckpointID      string
-	ResetCheckpoint   bool
+	SourceID                 string
+	RuntimeID                string
+	SourceConfig             map[string]string
+	TenantID                 string
+	PageLimit                uint32
+	Cursor                   *cerebrov1.SourceCursor
+	CheckpointEnabled        bool
+	CheckpointID             string
+	ResetCheckpoint          bool
+	ResetCompletedCheckpoint bool
 }
 
 func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*IngestResult, error) {
@@ -724,7 +728,13 @@ func (s *Service) prepareCheckpoint(ctx context.Context, request sourceRequest, 
 	}
 	checkpointID := checkpointID(request)
 	result.CheckpointID = checkpointID
-	if request.ResetCheckpoint || *cursor != nil {
+	if request.ResetCheckpoint {
+		if err := resetStoredCheckpoint(ctx, checkpointStore, request); err != nil {
+			return nil, err
+		}
+		return checkpointStore, nil
+	}
+	if *cursor != nil {
 		return checkpointStore, nil
 	}
 	checkpoint, found, err := checkpointStore.GetIngestCheckpoint(ctx, checkpointID)
@@ -736,6 +746,14 @@ func (s *Service) prepareCheckpoint(ctx context.Context, request sourceRequest, 
 	}
 	result.CheckpointResumed = true
 	result.CheckpointCursor = strings.TrimSpace(checkpoint.CursorOpaque)
+	if request.ResetCompletedCheckpoint && checkpoint.Completed {
+		result.CheckpointResumed = false
+		result.CheckpointCursor = ""
+		if err := resetStoredCheckpoint(ctx, checkpointStore, request); err != nil {
+			return nil, err
+		}
+		return checkpointStore, nil
+	}
 	if checkpoint.Completed && checkpoint.CursorOpaque == "" {
 		result.CheckpointComplete = true
 		result.CheckpointAlreadyFresh = true
@@ -745,6 +763,17 @@ func (s *Service) prepareCheckpoint(ctx context.Context, request sourceRequest, 
 		*cursor = &cerebrov1.SourceCursor{Opaque: checkpoint.CursorOpaque}
 	}
 	return checkpointStore, nil
+}
+
+func resetStoredCheckpoint(ctx context.Context, checkpointStore CheckpointStore, request sourceRequest) error {
+	checkpoint := graphstore.IngestCheckpoint{
+		ID:        checkpointID(request),
+		SourceID:  strings.TrimSpace(request.SourceID),
+		TenantID:  strings.TrimSpace(request.TenantID),
+		Completed: false,
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	return checkpointStore.PutIngestCheckpoint(ctx, checkpoint)
 }
 
 func normalizePageLimit(pageLimit uint32) (uint32, error) {

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -92,6 +92,24 @@ func (s *recordingProjectionGraphStore) UpsertProjectedLink(_ context.Context, l
 	return nil
 }
 
+type checkpointProjectionGraphStore struct {
+	recordingProjectionGraphStore
+	checkpoints map[string]graphstore.IngestCheckpoint
+}
+
+func (s *checkpointProjectionGraphStore) GetIngestCheckpoint(_ context.Context, id string) (graphstore.IngestCheckpoint, bool, error) {
+	checkpoint, ok := s.checkpoints[id]
+	return checkpoint, ok, nil
+}
+
+func (s *checkpointProjectionGraphStore) PutIngestCheckpoint(_ context.Context, checkpoint graphstore.IngestCheckpoint) error {
+	if s.checkpoints == nil {
+		s.checkpoints = map[string]graphstore.IngestCheckpoint{}
+	}
+	s.checkpoints[checkpoint.ID] = checkpoint
+	return nil
+}
+
 type singlePageSource struct {
 	id     string
 	events []*cerebrov1.EventEnvelope
@@ -418,6 +436,171 @@ func TestIngestSourceReturnsPartialCountersOnProjectionFailure(t *testing.T) {
 	}
 	if result.PagesRead != 1 || result.EventsRead != 1 || result.EntitiesProjected != 1 || result.LinksProjected != 0 {
 		t.Fatalf("partial counters = pages %d events %d entities %d links %d, want 1/1/1/0", result.PagesRead, result.EventsRead, result.EntitiesProjected, result.LinksProjected)
+	}
+}
+
+func TestIngestSourceCanResetCompletedCheckpoint(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(&singlePageSource{
+		id: "checkpointed",
+		events: []*cerebrov1.EventEnvelope{{
+			Id:       "event-1",
+			SourceId: "checkpointed",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &checkpointProjectionGraphStore{
+		checkpoints: map[string]graphstore.IngestCheckpoint{
+			"checkpoint-1": {ID: "checkpoint-1", Completed: true},
+		},
+	}
+	projector := recordProjectorFunc(func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		return []*ports.ProjectedEntity{{
+			URN:        "urn:cerebro:writer:checkpointed:event-1",
+			TenantID:   event.GetTenantId(),
+			SourceID:   event.GetSourceId(),
+			RuntimeID:  event.GetAttributes()[ports.EventAttributeSourceRuntimeID],
+			EntityType: "checkpointed.event",
+			Label:      event.GetId(),
+		}}, nil, nil
+	})
+	service := New(registry, nil, projector, store)
+
+	freshResult, err := service.ingestSource(context.Background(), sourceRequest{
+		SourceID:          "checkpointed",
+		RuntimeID:         "runtime-1",
+		TenantID:          "writer",
+		PageLimit:         1,
+		CheckpointEnabled: true,
+		CheckpointID:      "checkpoint-1",
+	})
+	if err != nil {
+		t.Fatalf("ingestSource(default checkpoint) error = %v", err)
+	}
+	if !freshResult.CheckpointAlreadyFresh || freshResult.EventsRead != 0 {
+		t.Fatalf("default checkpoint result fresh=%v events=%d, want already fresh with no reads", freshResult.CheckpointAlreadyFresh, freshResult.EventsRead)
+	}
+
+	resetResult, err := service.ingestSource(context.Background(), sourceRequest{
+		SourceID:                 "checkpointed",
+		RuntimeID:                "runtime-1",
+		TenantID:                 "writer",
+		PageLimit:                1,
+		CheckpointEnabled:        true,
+		CheckpointID:             "checkpoint-1",
+		ResetCompletedCheckpoint: true,
+	})
+	if err != nil {
+		t.Fatalf("ingestSource(reset completed checkpoint) error = %v", err)
+	}
+	if resetResult.CheckpointAlreadyFresh {
+		t.Fatal("reset completed checkpoint was treated as already fresh")
+	}
+	if resetResult.PagesRead != 1 || resetResult.EventsRead != 1 || !resetResult.CheckpointPersisted {
+		t.Fatalf("reset checkpoint result pages=%d events=%d persisted=%v, want 1/1/persisted", resetResult.PagesRead, resetResult.EventsRead, resetResult.CheckpointPersisted)
+	}
+}
+
+func TestResetCompletedCheckpointClearsStoredFreshnessBeforeProjection(t *testing.T) {
+	projectionErr := errors.New("projection failed")
+	registry, err := sourcecdk.NewRegistry(&singlePageSource{
+		id: "checkpointed",
+		events: []*cerebrov1.EventEnvelope{{
+			Id:       "event-1",
+			SourceId: "checkpointed",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &checkpointProjectionGraphStore{
+		checkpoints: map[string]graphstore.IngestCheckpoint{
+			"checkpoint-1": {ID: "checkpoint-1", Completed: true},
+		},
+	}
+	projector := recordProjectorFunc(func(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		return nil, nil, projectionErr
+	})
+	service := New(registry, nil, projector, store)
+
+	result, err := service.ingestSource(context.Background(), sourceRequest{
+		SourceID:                 "checkpointed",
+		RuntimeID:                "runtime-1",
+		TenantID:                 "writer",
+		PageLimit:                1,
+		CheckpointEnabled:        true,
+		CheckpointID:             "checkpoint-1",
+		ResetCompletedCheckpoint: true,
+	})
+	if !errors.Is(err, projectionErr) {
+		t.Fatalf("ingestSource() error = %v, want %v", err, projectionErr)
+	}
+	if result.CheckpointPersisted {
+		t.Fatal("failed projection should not report a persisted page checkpoint")
+	}
+	stored := store.checkpoints["checkpoint-1"]
+	if stored.Completed {
+		t.Fatal("stored checkpoint remained completed after reset marker")
+	}
+
+	freshCheck := &IngestResult{}
+	var cursor *cerebrov1.SourceCursor
+	if _, err := service.prepareCheckpoint(context.Background(), sourceRequest{
+		SourceID:          "checkpointed",
+		RuntimeID:         "runtime-1",
+		TenantID:          "writer",
+		PageLimit:         1,
+		CheckpointEnabled: true,
+		CheckpointID:      "checkpoint-1",
+	}, freshCheck, &cursor); err != nil {
+		t.Fatalf("prepareCheckpoint() error = %v", err)
+	}
+	if freshCheck.CheckpointAlreadyFresh {
+		t.Fatal("cleared checkpoint was still treated as already fresh")
+	}
+}
+
+func TestResetCheckpointClearsPartialCheckpointBeforeProjection(t *testing.T) {
+	projectionErr := errors.New("projection failed")
+	registry, err := sourcecdk.NewRegistry(&singlePageSource{
+		id: "checkpointed",
+		events: []*cerebrov1.EventEnvelope{{
+			Id:       "event-1",
+			SourceId: "checkpointed",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &checkpointProjectionGraphStore{
+		checkpoints: map[string]graphstore.IngestCheckpoint{
+			"checkpoint-1": {ID: "checkpoint-1", CursorOpaque: "2", Completed: false, PagesRead: 1, EventsRead: 1},
+		},
+	}
+	projector := recordProjectorFunc(func(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+		return nil, nil, projectionErr
+	})
+	service := New(registry, nil, projector, store)
+
+	result, err := service.ingestSource(context.Background(), sourceRequest{
+		SourceID:          "checkpointed",
+		RuntimeID:         "runtime-1",
+		TenantID:          "writer",
+		PageLimit:         1,
+		CheckpointEnabled: true,
+		CheckpointID:      "checkpoint-1",
+		ResetCheckpoint:   true,
+	})
+	if !errors.Is(err, projectionErr) {
+		t.Fatalf("ingestSource() error = %v, want %v", err, projectionErr)
+	}
+	if result.CheckpointPersisted {
+		t.Fatal("failed projection should not report a persisted page checkpoint")
+	}
+	stored := store.checkpoints["checkpoint-1"]
+	if stored.CursorOpaque != "" || stored.Completed || stored.PagesRead != 0 || stored.EventsRead != 0 {
+		t.Fatalf("stored checkpoint = %#v, want cleared reset marker", stored)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- Make scheduled orchestrator source sync project current state only\n- Leave Neo4j writes to the existing coalesced graph ingest phase\n- Add regression coverage for the orchestrator runtime service projector\n\n## Measured basis\nCloudWatch analysis showed source sync was writing uncoalesced graph records before graph ingest. For writer-github-audit-writerinternal, source sync wrote 9,828 projected graph records for 1,000 logs, while coalesced graph ingest wrote 1,290 records for the same page budget (7.6x fewer graph writes). This removes the duplicate/uncoalesced Neo4j write path from scheduled orchestrator syncs.\n\n## Validation\n- go test ./cmd/cerebro ./internal/sourceruntime ./internal/sourceprojection ./internal/graphingest -count=1\n- make verify