### PR TITLE
feat(findings): add likelihood impact risk scoring

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -186,6 +186,41 @@ paths:
         - Sources
       parameters:
         - $ref: '#/components/parameters/runtimeID'
+        - name: finding_id
+          in: query
+          schema:
+            type: string
+        - name: rule_id
+          in: query
+          schema:
+            type: string
+        - name: severity
+          in: query
+          schema:
+            type: string
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [open, resolved, suppressed]
+        - name: resource_urn
+          in: query
+          schema:
+            type: string
+        - name: event_id
+          in: query
+          schema:
+            type: string
+        - name: policy_id
+          in: query
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limitQuery'
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum: [last_observed, priority, risk_score]
       responses:
         '200':
           description: Finding list.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -224,6 +224,15 @@ paths:
       responses:
         '200':
           description: Finding list.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  findings:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Finding'
   /source-runtimes/{runtimeID}/finding-rules/evaluate:
     post:
       summary: Evaluate selected finding rules for one runtime
@@ -330,6 +339,13 @@ paths:
       responses:
         '200':
           description: Finding.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  finding:
+                    $ref: '#/components/schemas/Finding'
   /findings/{findingID}/resolve:
     post:
       summary: Resolve finding
@@ -1044,6 +1060,129 @@ components:
           format: date-time
         error:
           type: string
+    Finding:
+      type: object
+      properties:
+        id:
+          type: string
+        fingerprint:
+          type: string
+        tenant_id:
+          type: string
+        runtime_id:
+          type: string
+        rule_id:
+          type: string
+        title:
+          type: string
+        severity:
+          type: string
+        status:
+          type: string
+          enum: [FINDING_STATUS_OPEN, FINDING_STATUS_RESOLVED, FINDING_STATUS_SUPPRESSED]
+        summary:
+          type: string
+        resource_urns:
+          type: array
+          items:
+            type: string
+        event_ids:
+          type: array
+          items:
+            type: string
+        observed_policy_ids:
+          type: array
+          items:
+            type: string
+        policy_id:
+          type: string
+        policy_name:
+          type: string
+        check_id:
+          type: string
+        check_name:
+          type: string
+        control_refs:
+          type: array
+          items:
+            type: object
+            properties:
+              framework_name:
+                type: string
+              control_id:
+                type: string
+        notes:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              body:
+                type: string
+              created_at:
+                type: string
+                format: date-time
+        tickets:
+          type: array
+          items:
+            type: object
+            properties:
+              url:
+                type: string
+              name:
+                type: string
+              external_id:
+                type: string
+              linked_at:
+                type: string
+                format: date-time
+        risk_score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        likelihood_score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        impact_score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        confidence_score:
+          type: integer
+          minimum: 0
+          maximum: 100
+        likelihood_level:
+          type: string
+        impact_level:
+          type: string
+        risk_reasons:
+          type: array
+          items:
+            type: string
+        risk_model_version:
+          type: string
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+        assignee:
+          type: string
+        status_reason:
+          type: string
+        status_updated_at:
+          type: string
+          format: date-time
+        due_at:
+          type: string
+          format: date-time
+        first_observed_at:
+          type: string
+          format: date-time
+        last_observed_at:
+          type: string
+          format: date-time
     FindingEvidence:
       type: object
       properties:

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -84,15 +84,15 @@ func serve() error {
 			log.Printf("close dependencies: %v", err)
 		}
 	}()
-	if err := bootstrap.BackfillFindingRisk(context.Background(), deps); err != nil {
-		return fmt.Errorf("backfill finding risk: %w", err)
-	}
 	sources, err := sourceregistry.Builtin()
 	if err != nil {
 		return fmt.Errorf("open source registry: %w", err)
 	}
 
 	app := bootstrap.New(cfg, deps, sources)
+	if err := app.BackfillFindingRisk(context.Background()); err != nil {
+		return fmt.Errorf("backfill finding risk: %w", err)
+	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -84,6 +84,9 @@ func serve() error {
 			log.Printf("close dependencies: %v", err)
 		}
 	}()
+	if err := bootstrap.BackfillFindingRisk(context.Background(), deps); err != nil {
+		return fmt.Errorf("backfill finding risk: %w", err)
+	}
 	sources, err := sourceregistry.Builtin()
 	if err != nil {
 		return fmt.Errorf("open source registry: %w", err)

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -75,6 +75,58 @@ func (FindingStatus) EnumDescriptor() ([]byte, []int) {
 	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{0}
 }
 
+type FindingOrder int32
+
+const (
+	FindingOrder_FINDING_ORDER_UNSPECIFIED   FindingOrder = 0
+	FindingOrder_FINDING_ORDER_LAST_OBSERVED FindingOrder = 1
+	FindingOrder_FINDING_ORDER_PRIORITY      FindingOrder = 2
+	FindingOrder_FINDING_ORDER_RISK_SCORE    FindingOrder = 3
+)
+
+// Enum value maps for FindingOrder.
+var (
+	FindingOrder_name = map[int32]string{
+		0: "FINDING_ORDER_UNSPECIFIED",
+		1: "FINDING_ORDER_LAST_OBSERVED",
+		2: "FINDING_ORDER_PRIORITY",
+		3: "FINDING_ORDER_RISK_SCORE",
+	}
+	FindingOrder_value = map[string]int32{
+		"FINDING_ORDER_UNSPECIFIED":   0,
+		"FINDING_ORDER_LAST_OBSERVED": 1,
+		"FINDING_ORDER_PRIORITY":      2,
+		"FINDING_ORDER_RISK_SCORE":    3,
+	}
+)
+
+func (x FindingOrder) Enum() *FindingOrder {
+	p := new(FindingOrder)
+	*p = x
+	return p
+}
+
+func (x FindingOrder) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (FindingOrder) Descriptor() protoreflect.EnumDescriptor {
+	return file_cerebro_v1_bootstrap_proto_enumTypes[1].Descriptor()
+}
+
+func (FindingOrder) Type() protoreflect.EnumType {
+	return &file_cerebro_v1_bootstrap_proto_enumTypes[1]
+}
+
+func (x FindingOrder) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use FindingOrder.Descriptor instead.
+func (FindingOrder) EnumDescriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{1}
+}
+
 // GetVersionRequest requests static build metadata from the running service.
 type GetVersionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -3187,6 +3239,7 @@ type ListFindingsRequest struct {
 	EventId       string                 `protobuf:"bytes,7,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
 	Limit         uint32                 `protobuf:"varint,8,opt,name=limit,proto3" json:"limit,omitempty"`
 	PolicyId      string                 `protobuf:"bytes,9,opt,name=policy_id,json=policyId,proto3" json:"policy_id,omitempty"`
+	Order         FindingOrder           `protobuf:"varint,10,opt,name=order,proto3,enum=cerebro.v1.FindingOrder" json:"order,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3282,6 +3335,13 @@ func (x *ListFindingsRequest) GetPolicyId() string {
 		return x.PolicyId
 	}
 	return ""
+}
+
+func (x *ListFindingsRequest) GetOrder() FindingOrder {
+	if x != nil {
+		return x.Order
+	}
+	return FindingOrder_FINDING_ORDER_UNSPECIFIED
 }
 
 // FindingControlRef maps one finding to one compliance framework control.
@@ -3496,6 +3556,14 @@ type Finding struct {
 	DueAt             *timestamppb.Timestamp `protobuf:"bytes,24,opt,name=due_at,json=dueAt,proto3" json:"due_at,omitempty"`
 	Notes             []*FindingNote         `protobuf:"bytes,25,rep,name=notes,proto3" json:"notes,omitempty"`
 	Tickets           []*FindingTicket       `protobuf:"bytes,26,rep,name=tickets,proto3" json:"tickets,omitempty"`
+	RiskScore         int32                  `protobuf:"varint,27,opt,name=risk_score,json=riskScore,proto3" json:"risk_score,omitempty"`
+	LikelihoodScore   int32                  `protobuf:"varint,28,opt,name=likelihood_score,json=likelihoodScore,proto3" json:"likelihood_score,omitempty"`
+	ImpactScore       int32                  `protobuf:"varint,29,opt,name=impact_score,json=impactScore,proto3" json:"impact_score,omitempty"`
+	ConfidenceScore   int32                  `protobuf:"varint,30,opt,name=confidence_score,json=confidenceScore,proto3" json:"confidence_score,omitempty"`
+	LikelihoodLevel   string                 `protobuf:"bytes,31,opt,name=likelihood_level,json=likelihoodLevel,proto3" json:"likelihood_level,omitempty"`
+	ImpactLevel       string                 `protobuf:"bytes,32,opt,name=impact_level,json=impactLevel,proto3" json:"impact_level,omitempty"`
+	RiskReasons       []string               `protobuf:"bytes,33,rep,name=risk_reasons,json=riskReasons,proto3" json:"risk_reasons,omitempty"`
+	RiskModelVersion  string                 `protobuf:"bytes,34,opt,name=risk_model_version,json=riskModelVersion,proto3" json:"risk_model_version,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -3710,6 +3778,62 @@ func (x *Finding) GetTickets() []*FindingTicket {
 		return x.Tickets
 	}
 	return nil
+}
+
+func (x *Finding) GetRiskScore() int32 {
+	if x != nil {
+		return x.RiskScore
+	}
+	return 0
+}
+
+func (x *Finding) GetLikelihoodScore() int32 {
+	if x != nil {
+		return x.LikelihoodScore
+	}
+	return 0
+}
+
+func (x *Finding) GetImpactScore() int32 {
+	if x != nil {
+		return x.ImpactScore
+	}
+	return 0
+}
+
+func (x *Finding) GetConfidenceScore() int32 {
+	if x != nil {
+		return x.ConfidenceScore
+	}
+	return 0
+}
+
+func (x *Finding) GetLikelihoodLevel() string {
+	if x != nil {
+		return x.LikelihoodLevel
+	}
+	return ""
+}
+
+func (x *Finding) GetImpactLevel() string {
+	if x != nil {
+		return x.ImpactLevel
+	}
+	return ""
+}
+
+func (x *Finding) GetRiskReasons() []string {
+	if x != nil {
+		return x.RiskReasons
+	}
+	return nil
+}
+
+func (x *Finding) GetRiskModelVersion() string {
+	if x != nil {
+		return x.RiskModelVersion
+	}
+	return ""
 }
 
 // GetFindingRequest loads one persisted finding by its durable identifier.
@@ -6940,7 +7064,7 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x0fsource_event_id\x18\n" +
 	" \x01(\tR\rsourceEventId\"?\n" +
 	"\x12ListClaimsResponse\x12)\n" +
-	"\x06claims\x18\x01 \x03(\v2\x11.cerebro.v1.ClaimR\x06claims\"\xac\x02\n" +
+	"\x06claims\x18\x01 \x03(\v2\x11.cerebro.v1.ClaimR\x06claims\"\xdc\x02\n" +
 	"\x13ListFindingsRequest\x12\x1d\n" +
 	"\n" +
 	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12\x1d\n" +
@@ -6952,7 +7076,9 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\fresource_urn\x18\x06 \x01(\tR\vresourceUrn\x12\x19\n" +
 	"\bevent_id\x18\a \x01(\tR\aeventId\x12\x14\n" +
 	"\x05limit\x18\b \x01(\rR\x05limit\x12\x1b\n" +
-	"\tpolicy_id\x18\t \x01(\tR\bpolicyId\"Y\n" +
+	"\tpolicy_id\x18\t \x01(\tR\bpolicyId\x12.\n" +
+	"\x05order\x18\n" +
+	" \x01(\x0e2\x18.cerebro.v1.FindingOrderR\x05order\"Y\n" +
 	"\x11FindingControlRef\x12%\n" +
 	"\x0eframework_name\x18\x01 \x01(\tR\rframeworkName\x12\x1d\n" +
 	"\n" +
@@ -6967,7 +7093,7 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1f\n" +
 	"\vexternal_id\x18\x03 \x01(\tR\n" +
 	"externalId\x127\n" +
-	"\tlinked_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\blinkedAt\"\xed\b\n" +
+	"\tlinked_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\blinkedAt\"\xa4\v\n" +
 	"\aFinding\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12 \n" +
 	"\vfingerprint\x18\x02 \x01(\tR\vfingerprint\x12\x1b\n" +
@@ -7000,7 +7126,16 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\fcontrol_refs\x18\x17 \x03(\v2\x1d.cerebro.v1.FindingControlRefR\vcontrolRefs\x121\n" +
 	"\x06due_at\x18\x18 \x01(\v2\x1a.google.protobuf.TimestampR\x05dueAt\x12-\n" +
 	"\x05notes\x18\x19 \x03(\v2\x17.cerebro.v1.FindingNoteR\x05notes\x123\n" +
-	"\atickets\x18\x1a \x03(\v2\x19.cerebro.v1.FindingTicketR\atickets\x1a=\n" +
+	"\atickets\x18\x1a \x03(\v2\x19.cerebro.v1.FindingTicketR\atickets\x12\x1d\n" +
+	"\n" +
+	"risk_score\x18\x1b \x01(\x05R\triskScore\x12)\n" +
+	"\x10likelihood_score\x18\x1c \x01(\x05R\x0flikelihoodScore\x12!\n" +
+	"\fimpact_score\x18\x1d \x01(\x05R\vimpactScore\x12)\n" +
+	"\x10confidence_score\x18\x1e \x01(\x05R\x0fconfidenceScore\x12)\n" +
+	"\x10likelihood_level\x18\x1f \x01(\tR\x0flikelihoodLevel\x12!\n" +
+	"\fimpact_level\x18  \x01(\tR\vimpactLevel\x12!\n" +
+	"\frisk_reasons\x18! \x03(\tR\vriskReasons\x12,\n" +
+	"\x12risk_model_version\x18\" \x01(\tR\x10riskModelVersion\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"#\n" +
@@ -7268,7 +7403,12 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x1aFINDING_STATUS_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13FINDING_STATUS_OPEN\x10\x01\x12\x1b\n" +
 	"\x17FINDING_STATUS_RESOLVED\x10\x02\x12\x1d\n" +
-	"\x19FINDING_STATUS_SUPPRESSED\x10\x032\xb4\x1c\n" +
+	"\x19FINDING_STATUS_SUPPRESSED\x10\x03*\x88\x01\n" +
+	"\fFindingOrder\x12\x1d\n" +
+	"\x19FINDING_ORDER_UNSPECIFIED\x10\x00\x12\x1f\n" +
+	"\x1bFINDING_ORDER_LAST_OBSERVED\x10\x01\x12\x1a\n" +
+	"\x16FINDING_ORDER_PRIORITY\x10\x02\x12\x1c\n" +
+	"\x18FINDING_ORDER_RISK_SCORE\x10\x032\xb4\x1c\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -7325,318 +7465,320 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 	return file_cerebro_v1_bootstrap_proto_rawDescData
 }
 
-var file_cerebro_v1_bootstrap_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_cerebro_v1_bootstrap_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 108)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(FindingStatus)(0),                                // 0: cerebro.v1.FindingStatus
-	(*GetVersionRequest)(nil),                         // 1: cerebro.v1.GetVersionRequest
-	(*GetVersionResponse)(nil),                        // 2: cerebro.v1.GetVersionResponse
-	(*CheckHealthRequest)(nil),                        // 3: cerebro.v1.CheckHealthRequest
-	(*ComponentStatus)(nil),                           // 4: cerebro.v1.ComponentStatus
-	(*CheckHealthResponse)(nil),                       // 5: cerebro.v1.CheckHealthResponse
-	(*ReportParameter)(nil),                           // 6: cerebro.v1.ReportParameter
-	(*ReportDefinition)(nil),                          // 7: cerebro.v1.ReportDefinition
-	(*ReportRun)(nil),                                 // 8: cerebro.v1.ReportRun
-	(*ListReportDefinitionsRequest)(nil),              // 9: cerebro.v1.ListReportDefinitionsRequest
-	(*ListReportDefinitionsResponse)(nil),             // 10: cerebro.v1.ListReportDefinitionsResponse
-	(*ListFindingRulesRequest)(nil),                   // 11: cerebro.v1.ListFindingRulesRequest
-	(*ListFindingRulesResponse)(nil),                  // 12: cerebro.v1.ListFindingRulesResponse
-	(*FindingEvaluationRun)(nil),                      // 13: cerebro.v1.FindingEvaluationRun
-	(*ListFindingEvaluationRunsRequest)(nil),          // 14: cerebro.v1.ListFindingEvaluationRunsRequest
-	(*ListFindingEvaluationRunsResponse)(nil),         // 15: cerebro.v1.ListFindingEvaluationRunsResponse
-	(*GetFindingEvaluationRunRequest)(nil),            // 16: cerebro.v1.GetFindingEvaluationRunRequest
-	(*GetFindingEvaluationRunResponse)(nil),           // 17: cerebro.v1.GetFindingEvaluationRunResponse
-	(*GraphEvidencePath)(nil),                         // 18: cerebro.v1.GraphEvidencePath
-	(*GraphEvidenceRow)(nil),                          // 19: cerebro.v1.GraphEvidenceRow
-	(*FindingEvidenceObservation)(nil),                // 20: cerebro.v1.FindingEvidenceObservation
-	(*FindingEvidence)(nil),                           // 21: cerebro.v1.FindingEvidence
-	(*ListFindingEvidenceRequest)(nil),                // 22: cerebro.v1.ListFindingEvidenceRequest
-	(*ListFindingEvidenceResponse)(nil),               // 23: cerebro.v1.ListFindingEvidenceResponse
-	(*GetFindingEvidenceRequest)(nil),                 // 24: cerebro.v1.GetFindingEvidenceRequest
-	(*GetFindingEvidenceResponse)(nil),                // 25: cerebro.v1.GetFindingEvidenceResponse
-	(*RunReportRequest)(nil),                          // 26: cerebro.v1.RunReportRequest
-	(*RunReportResponse)(nil),                         // 27: cerebro.v1.RunReportResponse
-	(*GetReportRunRequest)(nil),                       // 28: cerebro.v1.GetReportRunRequest
-	(*GetReportRunResponse)(nil),                      // 29: cerebro.v1.GetReportRunResponse
-	(*ListSourcesRequest)(nil),                        // 30: cerebro.v1.ListSourcesRequest
-	(*ListSourcesResponse)(nil),                       // 31: cerebro.v1.ListSourcesResponse
-	(*CheckSourceRequest)(nil),                        // 32: cerebro.v1.CheckSourceRequest
-	(*CheckSourceResponse)(nil),                       // 33: cerebro.v1.CheckSourceResponse
-	(*DiscoverSourceRequest)(nil),                     // 34: cerebro.v1.DiscoverSourceRequest
-	(*DiscoverSourceResponse)(nil),                    // 35: cerebro.v1.DiscoverSourceResponse
-	(*ReadSourceRequest)(nil),                         // 36: cerebro.v1.ReadSourceRequest
-	(*SourcePreviewEvent)(nil),                        // 37: cerebro.v1.SourcePreviewEvent
-	(*ReadSourceResponse)(nil),                        // 38: cerebro.v1.ReadSourceResponse
-	(*SourceRuntime)(nil),                             // 39: cerebro.v1.SourceRuntime
-	(*PutSourceRuntimeRequest)(nil),                   // 40: cerebro.v1.PutSourceRuntimeRequest
-	(*PutSourceRuntimeResponse)(nil),                  // 41: cerebro.v1.PutSourceRuntimeResponse
-	(*GetSourceRuntimeRequest)(nil),                   // 42: cerebro.v1.GetSourceRuntimeRequest
-	(*GetSourceRuntimeResponse)(nil),                  // 43: cerebro.v1.GetSourceRuntimeResponse
-	(*SyncSourceRuntimeRequest)(nil),                  // 44: cerebro.v1.SyncSourceRuntimeRequest
-	(*SyncSourceRuntimeResponse)(nil),                 // 45: cerebro.v1.SyncSourceRuntimeResponse
-	(*WriteClaimsRequest)(nil),                        // 46: cerebro.v1.WriteClaimsRequest
-	(*WriteClaimsResponse)(nil),                       // 47: cerebro.v1.WriteClaimsResponse
-	(*ListClaimsRequest)(nil),                         // 48: cerebro.v1.ListClaimsRequest
-	(*ListClaimsResponse)(nil),                        // 49: cerebro.v1.ListClaimsResponse
-	(*ListFindingsRequest)(nil),                       // 50: cerebro.v1.ListFindingsRequest
-	(*FindingControlRef)(nil),                         // 51: cerebro.v1.FindingControlRef
-	(*FindingNote)(nil),                               // 52: cerebro.v1.FindingNote
-	(*FindingTicket)(nil),                             // 53: cerebro.v1.FindingTicket
-	(*Finding)(nil),                                   // 54: cerebro.v1.Finding
-	(*GetFindingRequest)(nil),                         // 55: cerebro.v1.GetFindingRequest
-	(*GetFindingResponse)(nil),                        // 56: cerebro.v1.GetFindingResponse
-	(*ResolveFindingRequest)(nil),                     // 57: cerebro.v1.ResolveFindingRequest
-	(*ResolveFindingResponse)(nil),                    // 58: cerebro.v1.ResolveFindingResponse
-	(*SuppressFindingRequest)(nil),                    // 59: cerebro.v1.SuppressFindingRequest
-	(*SuppressFindingResponse)(nil),                   // 60: cerebro.v1.SuppressFindingResponse
-	(*AssignFindingRequest)(nil),                      // 61: cerebro.v1.AssignFindingRequest
-	(*AssignFindingResponse)(nil),                     // 62: cerebro.v1.AssignFindingResponse
-	(*SetFindingDueDateRequest)(nil),                  // 63: cerebro.v1.SetFindingDueDateRequest
-	(*SetFindingDueDateResponse)(nil),                 // 64: cerebro.v1.SetFindingDueDateResponse
-	(*AddFindingNoteRequest)(nil),                     // 65: cerebro.v1.AddFindingNoteRequest
-	(*AddFindingNoteResponse)(nil),                    // 66: cerebro.v1.AddFindingNoteResponse
-	(*LinkFindingTicketRequest)(nil),                  // 67: cerebro.v1.LinkFindingTicketRequest
-	(*LinkFindingTicketResponse)(nil),                 // 68: cerebro.v1.LinkFindingTicketResponse
-	(*ListFindingsResponse)(nil),                      // 69: cerebro.v1.ListFindingsResponse
-	(*EvaluateSourceRuntimeFindingsRequest)(nil),      // 70: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	(*EvaluateSourceRuntimeFindingRulesRequest)(nil),  // 71: cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
-	(*FindingRuleEvaluation)(nil),                     // 72: cerebro.v1.FindingRuleEvaluation
-	(*EvaluateSourceRuntimeFindingRulesResponse)(nil), // 73: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
-	(*EvaluateSourceRuntimeFindingsResponse)(nil),     // 74: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	(*WriteDecisionRequest)(nil),                      // 75: cerebro.v1.WriteDecisionRequest
-	(*WriteDecisionResponse)(nil),                     // 76: cerebro.v1.WriteDecisionResponse
-	(*WriteActionRequest)(nil),                        // 77: cerebro.v1.WriteActionRequest
-	(*WriteActionResponse)(nil),                       // 78: cerebro.v1.WriteActionResponse
-	(*WriteOutcomeRequest)(nil),                       // 79: cerebro.v1.WriteOutcomeRequest
-	(*WriteOutcomeResponse)(nil),                      // 80: cerebro.v1.WriteOutcomeResponse
-	(*ReplayWorkflowEventsRequest)(nil),               // 81: cerebro.v1.ReplayWorkflowEventsRequest
-	(*ReplayWorkflowEventsResponse)(nil),              // 82: cerebro.v1.ReplayWorkflowEventsResponse
-	(*GraphEntity)(nil),                               // 83: cerebro.v1.GraphEntity
-	(*GraphRelation)(nil),                             // 84: cerebro.v1.GraphRelation
-	(*GetEntityNeighborhoodRequest)(nil),              // 85: cerebro.v1.GetEntityNeighborhoodRequest
-	(*GetEntityNeighborhoodResponse)(nil),             // 86: cerebro.v1.GetEntityNeighborhoodResponse
-	(*GraphIngestRun)(nil),                            // 87: cerebro.v1.GraphIngestRun
-	(*GraphIngestResult)(nil),                         // 88: cerebro.v1.GraphIngestResult
-	(*GraphIngestRunResult)(nil),                      // 89: cerebro.v1.GraphIngestRunResult
-	(*RunGraphIngestRuntimeRequest)(nil),              // 90: cerebro.v1.RunGraphIngestRuntimeRequest
-	(*RunGraphIngestRuntimeResponse)(nil),             // 91: cerebro.v1.RunGraphIngestRuntimeResponse
-	(*GetGraphIngestRunRequest)(nil),                  // 92: cerebro.v1.GetGraphIngestRunRequest
-	(*GetGraphIngestRunResponse)(nil),                 // 93: cerebro.v1.GetGraphIngestRunResponse
-	(*ListGraphIngestRunsRequest)(nil),                // 94: cerebro.v1.ListGraphIngestRunsRequest
-	(*ListGraphIngestRunsResponse)(nil),               // 95: cerebro.v1.ListGraphIngestRunsResponse
-	(*CheckGraphIngestHealthRequest)(nil),             // 96: cerebro.v1.CheckGraphIngestHealthRequest
-	(*CheckGraphIngestHealthResponse)(nil),            // 97: cerebro.v1.CheckGraphIngestHealthResponse
-	nil,                                               // 98: cerebro.v1.ReportRun.ParametersEntry
-	nil,                                               // 99: cerebro.v1.GraphEvidencePath.AttributesEntry
-	nil,                                               // 100: cerebro.v1.GraphEvidenceRow.AttributesEntry
-	nil,                                               // 101: cerebro.v1.FindingEvidence.AttributesEntry
-	nil,                                               // 102: cerebro.v1.RunReportRequest.ParametersEntry
-	nil,                                               // 103: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                                               // 104: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                                               // 105: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                                               // 106: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                                               // 107: cerebro.v1.Finding.AttributesEntry
-	nil,                                               // 108: cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
-	(*timestamppb.Timestamp)(nil),                     // 109: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                           // 110: google.protobuf.Struct
-	(*RuleSpec)(nil),                                  // 111: cerebro.v1.RuleSpec
-	(*SourceSpec)(nil),                                // 112: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),                              // 113: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                             // 114: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                            // 115: google.protobuf.Value
-	(*SourceCheckpoint)(nil),                          // 116: cerebro.v1.SourceCheckpoint
-	(*Claim)(nil),                                     // 117: cerebro.v1.Claim
+	(FindingOrder)(0),                                 // 1: cerebro.v1.FindingOrder
+	(*GetVersionRequest)(nil),                         // 2: cerebro.v1.GetVersionRequest
+	(*GetVersionResponse)(nil),                        // 3: cerebro.v1.GetVersionResponse
+	(*CheckHealthRequest)(nil),                        // 4: cerebro.v1.CheckHealthRequest
+	(*ComponentStatus)(nil),                           // 5: cerebro.v1.ComponentStatus
+	(*CheckHealthResponse)(nil),                       // 6: cerebro.v1.CheckHealthResponse
+	(*ReportParameter)(nil),                           // 7: cerebro.v1.ReportParameter
+	(*ReportDefinition)(nil),                          // 8: cerebro.v1.ReportDefinition
+	(*ReportRun)(nil),                                 // 9: cerebro.v1.ReportRun
+	(*ListReportDefinitionsRequest)(nil),              // 10: cerebro.v1.ListReportDefinitionsRequest
+	(*ListReportDefinitionsResponse)(nil),             // 11: cerebro.v1.ListReportDefinitionsResponse
+	(*ListFindingRulesRequest)(nil),                   // 12: cerebro.v1.ListFindingRulesRequest
+	(*ListFindingRulesResponse)(nil),                  // 13: cerebro.v1.ListFindingRulesResponse
+	(*FindingEvaluationRun)(nil),                      // 14: cerebro.v1.FindingEvaluationRun
+	(*ListFindingEvaluationRunsRequest)(nil),          // 15: cerebro.v1.ListFindingEvaluationRunsRequest
+	(*ListFindingEvaluationRunsResponse)(nil),         // 16: cerebro.v1.ListFindingEvaluationRunsResponse
+	(*GetFindingEvaluationRunRequest)(nil),            // 17: cerebro.v1.GetFindingEvaluationRunRequest
+	(*GetFindingEvaluationRunResponse)(nil),           // 18: cerebro.v1.GetFindingEvaluationRunResponse
+	(*GraphEvidencePath)(nil),                         // 19: cerebro.v1.GraphEvidencePath
+	(*GraphEvidenceRow)(nil),                          // 20: cerebro.v1.GraphEvidenceRow
+	(*FindingEvidenceObservation)(nil),                // 21: cerebro.v1.FindingEvidenceObservation
+	(*FindingEvidence)(nil),                           // 22: cerebro.v1.FindingEvidence
+	(*ListFindingEvidenceRequest)(nil),                // 23: cerebro.v1.ListFindingEvidenceRequest
+	(*ListFindingEvidenceResponse)(nil),               // 24: cerebro.v1.ListFindingEvidenceResponse
+	(*GetFindingEvidenceRequest)(nil),                 // 25: cerebro.v1.GetFindingEvidenceRequest
+	(*GetFindingEvidenceResponse)(nil),                // 26: cerebro.v1.GetFindingEvidenceResponse
+	(*RunReportRequest)(nil),                          // 27: cerebro.v1.RunReportRequest
+	(*RunReportResponse)(nil),                         // 28: cerebro.v1.RunReportResponse
+	(*GetReportRunRequest)(nil),                       // 29: cerebro.v1.GetReportRunRequest
+	(*GetReportRunResponse)(nil),                      // 30: cerebro.v1.GetReportRunResponse
+	(*ListSourcesRequest)(nil),                        // 31: cerebro.v1.ListSourcesRequest
+	(*ListSourcesResponse)(nil),                       // 32: cerebro.v1.ListSourcesResponse
+	(*CheckSourceRequest)(nil),                        // 33: cerebro.v1.CheckSourceRequest
+	(*CheckSourceResponse)(nil),                       // 34: cerebro.v1.CheckSourceResponse
+	(*DiscoverSourceRequest)(nil),                     // 35: cerebro.v1.DiscoverSourceRequest
+	(*DiscoverSourceResponse)(nil),                    // 36: cerebro.v1.DiscoverSourceResponse
+	(*ReadSourceRequest)(nil),                         // 37: cerebro.v1.ReadSourceRequest
+	(*SourcePreviewEvent)(nil),                        // 38: cerebro.v1.SourcePreviewEvent
+	(*ReadSourceResponse)(nil),                        // 39: cerebro.v1.ReadSourceResponse
+	(*SourceRuntime)(nil),                             // 40: cerebro.v1.SourceRuntime
+	(*PutSourceRuntimeRequest)(nil),                   // 41: cerebro.v1.PutSourceRuntimeRequest
+	(*PutSourceRuntimeResponse)(nil),                  // 42: cerebro.v1.PutSourceRuntimeResponse
+	(*GetSourceRuntimeRequest)(nil),                   // 43: cerebro.v1.GetSourceRuntimeRequest
+	(*GetSourceRuntimeResponse)(nil),                  // 44: cerebro.v1.GetSourceRuntimeResponse
+	(*SyncSourceRuntimeRequest)(nil),                  // 45: cerebro.v1.SyncSourceRuntimeRequest
+	(*SyncSourceRuntimeResponse)(nil),                 // 46: cerebro.v1.SyncSourceRuntimeResponse
+	(*WriteClaimsRequest)(nil),                        // 47: cerebro.v1.WriteClaimsRequest
+	(*WriteClaimsResponse)(nil),                       // 48: cerebro.v1.WriteClaimsResponse
+	(*ListClaimsRequest)(nil),                         // 49: cerebro.v1.ListClaimsRequest
+	(*ListClaimsResponse)(nil),                        // 50: cerebro.v1.ListClaimsResponse
+	(*ListFindingsRequest)(nil),                       // 51: cerebro.v1.ListFindingsRequest
+	(*FindingControlRef)(nil),                         // 52: cerebro.v1.FindingControlRef
+	(*FindingNote)(nil),                               // 53: cerebro.v1.FindingNote
+	(*FindingTicket)(nil),                             // 54: cerebro.v1.FindingTicket
+	(*Finding)(nil),                                   // 55: cerebro.v1.Finding
+	(*GetFindingRequest)(nil),                         // 56: cerebro.v1.GetFindingRequest
+	(*GetFindingResponse)(nil),                        // 57: cerebro.v1.GetFindingResponse
+	(*ResolveFindingRequest)(nil),                     // 58: cerebro.v1.ResolveFindingRequest
+	(*ResolveFindingResponse)(nil),                    // 59: cerebro.v1.ResolveFindingResponse
+	(*SuppressFindingRequest)(nil),                    // 60: cerebro.v1.SuppressFindingRequest
+	(*SuppressFindingResponse)(nil),                   // 61: cerebro.v1.SuppressFindingResponse
+	(*AssignFindingRequest)(nil),                      // 62: cerebro.v1.AssignFindingRequest
+	(*AssignFindingResponse)(nil),                     // 63: cerebro.v1.AssignFindingResponse
+	(*SetFindingDueDateRequest)(nil),                  // 64: cerebro.v1.SetFindingDueDateRequest
+	(*SetFindingDueDateResponse)(nil),                 // 65: cerebro.v1.SetFindingDueDateResponse
+	(*AddFindingNoteRequest)(nil),                     // 66: cerebro.v1.AddFindingNoteRequest
+	(*AddFindingNoteResponse)(nil),                    // 67: cerebro.v1.AddFindingNoteResponse
+	(*LinkFindingTicketRequest)(nil),                  // 68: cerebro.v1.LinkFindingTicketRequest
+	(*LinkFindingTicketResponse)(nil),                 // 69: cerebro.v1.LinkFindingTicketResponse
+	(*ListFindingsResponse)(nil),                      // 70: cerebro.v1.ListFindingsResponse
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),      // 71: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingRulesRequest)(nil),  // 72: cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	(*FindingRuleEvaluation)(nil),                     // 73: cerebro.v1.FindingRuleEvaluation
+	(*EvaluateSourceRuntimeFindingRulesResponse)(nil), // 74: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	(*EvaluateSourceRuntimeFindingsResponse)(nil),     // 75: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	(*WriteDecisionRequest)(nil),                      // 76: cerebro.v1.WriteDecisionRequest
+	(*WriteDecisionResponse)(nil),                     // 77: cerebro.v1.WriteDecisionResponse
+	(*WriteActionRequest)(nil),                        // 78: cerebro.v1.WriteActionRequest
+	(*WriteActionResponse)(nil),                       // 79: cerebro.v1.WriteActionResponse
+	(*WriteOutcomeRequest)(nil),                       // 80: cerebro.v1.WriteOutcomeRequest
+	(*WriteOutcomeResponse)(nil),                      // 81: cerebro.v1.WriteOutcomeResponse
+	(*ReplayWorkflowEventsRequest)(nil),               // 82: cerebro.v1.ReplayWorkflowEventsRequest
+	(*ReplayWorkflowEventsResponse)(nil),              // 83: cerebro.v1.ReplayWorkflowEventsResponse
+	(*GraphEntity)(nil),                               // 84: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                             // 85: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),              // 86: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),             // 87: cerebro.v1.GetEntityNeighborhoodResponse
+	(*GraphIngestRun)(nil),                            // 88: cerebro.v1.GraphIngestRun
+	(*GraphIngestResult)(nil),                         // 89: cerebro.v1.GraphIngestResult
+	(*GraphIngestRunResult)(nil),                      // 90: cerebro.v1.GraphIngestRunResult
+	(*RunGraphIngestRuntimeRequest)(nil),              // 91: cerebro.v1.RunGraphIngestRuntimeRequest
+	(*RunGraphIngestRuntimeResponse)(nil),             // 92: cerebro.v1.RunGraphIngestRuntimeResponse
+	(*GetGraphIngestRunRequest)(nil),                  // 93: cerebro.v1.GetGraphIngestRunRequest
+	(*GetGraphIngestRunResponse)(nil),                 // 94: cerebro.v1.GetGraphIngestRunResponse
+	(*ListGraphIngestRunsRequest)(nil),                // 95: cerebro.v1.ListGraphIngestRunsRequest
+	(*ListGraphIngestRunsResponse)(nil),               // 96: cerebro.v1.ListGraphIngestRunsResponse
+	(*CheckGraphIngestHealthRequest)(nil),             // 97: cerebro.v1.CheckGraphIngestHealthRequest
+	(*CheckGraphIngestHealthResponse)(nil),            // 98: cerebro.v1.CheckGraphIngestHealthResponse
+	nil,                                               // 99: cerebro.v1.ReportRun.ParametersEntry
+	nil,                                               // 100: cerebro.v1.GraphEvidencePath.AttributesEntry
+	nil,                                               // 101: cerebro.v1.GraphEvidenceRow.AttributesEntry
+	nil,                                               // 102: cerebro.v1.FindingEvidence.AttributesEntry
+	nil,                                               // 103: cerebro.v1.RunReportRequest.ParametersEntry
+	nil,                                               // 104: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                               // 105: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                               // 106: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                               // 107: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                               // 108: cerebro.v1.Finding.AttributesEntry
+	nil,                                               // 109: cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
+	(*timestamppb.Timestamp)(nil),                     // 110: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                           // 111: google.protobuf.Struct
+	(*RuleSpec)(nil),                                  // 112: cerebro.v1.RuleSpec
+	(*SourceSpec)(nil),                                // 113: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                              // 114: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                             // 115: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                            // 116: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                          // 117: cerebro.v1.SourceCheckpoint
+	(*Claim)(nil),                                     // 118: cerebro.v1.Claim
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	109, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
-	4,   // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
-	6,   // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
-	98,  // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
-	109, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
-	110, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
-	7,   // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
-	111, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
-	109, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
-	109, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
-	13,  // 10: cerebro.v1.ListFindingEvaluationRunsResponse.runs:type_name -> cerebro.v1.FindingEvaluationRun
-	13,  // 11: cerebro.v1.GetFindingEvaluationRunResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	99,  // 12: cerebro.v1.GraphEvidencePath.attributes:type_name -> cerebro.v1.GraphEvidencePath.AttributesEntry
-	100, // 13: cerebro.v1.GraphEvidenceRow.attributes:type_name -> cerebro.v1.GraphEvidenceRow.AttributesEntry
-	18,  // 14: cerebro.v1.GraphEvidenceRow.paths:type_name -> cerebro.v1.GraphEvidencePath
-	109, // 15: cerebro.v1.FindingEvidenceObservation.observed_at:type_name -> google.protobuf.Timestamp
-	19,  // 16: cerebro.v1.FindingEvidenceObservation.graph_rows:type_name -> cerebro.v1.GraphEvidenceRow
-	109, // 17: cerebro.v1.FindingEvidence.created_at:type_name -> google.protobuf.Timestamp
-	19,  // 18: cerebro.v1.FindingEvidence.graph_rows:type_name -> cerebro.v1.GraphEvidenceRow
-	109, // 19: cerebro.v1.FindingEvidence.last_observed_at:type_name -> google.protobuf.Timestamp
-	101, // 20: cerebro.v1.FindingEvidence.attributes:type_name -> cerebro.v1.FindingEvidence.AttributesEntry
-	20,  // 21: cerebro.v1.FindingEvidence.observations:type_name -> cerebro.v1.FindingEvidenceObservation
-	21,  // 22: cerebro.v1.ListFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	21,  // 23: cerebro.v1.GetFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	102, // 24: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
-	7,   // 25: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
-	8,   // 26: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
-	8,   // 27: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
-	112, // 28: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	103, // 29: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	112, // 30: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	104, // 31: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	112, // 32: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	105, // 33: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	113, // 34: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	114, // 35: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	115, // 36: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	112, // 37: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	114, // 38: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	116, // 39: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	113, // 40: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
-	37,  // 41: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	106, // 42: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	116, // 43: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	113, // 44: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	109, // 45: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
-	39,  // 46: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
-	39,  // 47: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	39,  // 48: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	39,  // 49: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	112, // 50: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	117, // 51: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	117, // 52: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	110, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	5,   // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
+	7,   // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
+	99,  // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
+	110, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
+	111, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
+	8,   // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
+	112, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
+	110, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
+	110, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
+	14,  // 10: cerebro.v1.ListFindingEvaluationRunsResponse.runs:type_name -> cerebro.v1.FindingEvaluationRun
+	14,  // 11: cerebro.v1.GetFindingEvaluationRunResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
+	100, // 12: cerebro.v1.GraphEvidencePath.attributes:type_name -> cerebro.v1.GraphEvidencePath.AttributesEntry
+	101, // 13: cerebro.v1.GraphEvidenceRow.attributes:type_name -> cerebro.v1.GraphEvidenceRow.AttributesEntry
+	19,  // 14: cerebro.v1.GraphEvidenceRow.paths:type_name -> cerebro.v1.GraphEvidencePath
+	110, // 15: cerebro.v1.FindingEvidenceObservation.observed_at:type_name -> google.protobuf.Timestamp
+	20,  // 16: cerebro.v1.FindingEvidenceObservation.graph_rows:type_name -> cerebro.v1.GraphEvidenceRow
+	110, // 17: cerebro.v1.FindingEvidence.created_at:type_name -> google.protobuf.Timestamp
+	20,  // 18: cerebro.v1.FindingEvidence.graph_rows:type_name -> cerebro.v1.GraphEvidenceRow
+	110, // 19: cerebro.v1.FindingEvidence.last_observed_at:type_name -> google.protobuf.Timestamp
+	102, // 20: cerebro.v1.FindingEvidence.attributes:type_name -> cerebro.v1.FindingEvidence.AttributesEntry
+	21,  // 21: cerebro.v1.FindingEvidence.observations:type_name -> cerebro.v1.FindingEvidenceObservation
+	22,  // 22: cerebro.v1.ListFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	22,  // 23: cerebro.v1.GetFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	103, // 24: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
+	8,   // 25: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
+	9,   // 26: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
+	9,   // 27: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
+	113, // 28: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	104, // 29: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	113, // 30: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	105, // 31: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	113, // 32: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	106, // 33: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	114, // 34: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	115, // 35: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	116, // 36: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	113, // 37: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	115, // 38: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	117, // 39: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	114, // 40: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	38,  // 41: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
+	107, // 42: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	117, // 43: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	114, // 44: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	110, // 45: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	40,  // 46: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
+	40,  // 47: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	40,  // 48: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	40,  // 49: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	113, // 50: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	118, // 51: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	118, // 52: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
 	0,   // 53: cerebro.v1.ListFindingsRequest.status:type_name -> cerebro.v1.FindingStatus
-	109, // 54: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
-	109, // 55: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
-	0,   // 56: cerebro.v1.Finding.status:type_name -> cerebro.v1.FindingStatus
-	107, // 57: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	109, // 58: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	109, // 59: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	109, // 60: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
-	51,  // 61: cerebro.v1.Finding.control_refs:type_name -> cerebro.v1.FindingControlRef
-	109, // 62: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
-	52,  // 63: cerebro.v1.Finding.notes:type_name -> cerebro.v1.FindingNote
-	53,  // 64: cerebro.v1.Finding.tickets:type_name -> cerebro.v1.FindingTicket
-	54,  // 65: cerebro.v1.GetFindingResponse.finding:type_name -> cerebro.v1.Finding
-	54,  // 66: cerebro.v1.ResolveFindingResponse.finding:type_name -> cerebro.v1.Finding
-	54,  // 67: cerebro.v1.SuppressFindingResponse.finding:type_name -> cerebro.v1.Finding
-	54,  // 68: cerebro.v1.AssignFindingResponse.finding:type_name -> cerebro.v1.Finding
-	109, // 69: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
-	54,  // 70: cerebro.v1.SetFindingDueDateResponse.finding:type_name -> cerebro.v1.Finding
-	54,  // 71: cerebro.v1.AddFindingNoteResponse.finding:type_name -> cerebro.v1.Finding
-	54,  // 72: cerebro.v1.LinkFindingTicketResponse.finding:type_name -> cerebro.v1.Finding
-	54,  // 73: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	111, // 74: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
-	54,  // 75: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
-	13,  // 76: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
-	21,  // 77: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
-	39,  // 78: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	72,  // 79: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
-	39,  // 80: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	111, // 81: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	54,  // 82: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	13,  // 83: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	21,  // 84: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	109, // 85: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	109, // 86: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	109, // 87: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	110, // 88: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
-	109, // 89: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	109, // 90: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	109, // 91: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	110, // 92: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
-	109, // 93: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
-	109, // 94: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
-	109, // 95: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
-	110, // 96: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
-	108, // 97: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
-	83,  // 98: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	83,  // 99: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	84,  // 100: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	87,  // 101: cerebro.v1.GraphIngestRunResult.run:type_name -> cerebro.v1.GraphIngestRun
-	88,  // 102: cerebro.v1.GraphIngestRunResult.ingest:type_name -> cerebro.v1.GraphIngestResult
-	89,  // 103: cerebro.v1.RunGraphIngestRuntimeResponse.result:type_name -> cerebro.v1.GraphIngestRunResult
-	87,  // 104: cerebro.v1.GetGraphIngestRunResponse.run:type_name -> cerebro.v1.GraphIngestRun
-	87,  // 105: cerebro.v1.ListGraphIngestRunsResponse.runs:type_name -> cerebro.v1.GraphIngestRun
-	109, // 106: cerebro.v1.CheckGraphIngestHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
-	87,  // 107: cerebro.v1.CheckGraphIngestHealthResponse.failed_runs:type_name -> cerebro.v1.GraphIngestRun
-	1,   // 108: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	3,   // 109: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	9,   // 110: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	11,  // 111: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
-	26,  // 112: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	28,  // 113: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	30,  // 114: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	32,  // 115: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	34,  // 116: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	36,  // 117: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	40,  // 118: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	42,  // 119: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	44,  // 120: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	46,  // 121: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	48,  // 122: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
-	50,  // 123: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
-	55,  // 124: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
-	57,  // 125: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
-	59,  // 126: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
-	61,  // 127: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
-	63,  // 128: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
-	65,  // 129: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
-	67,  // 130: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
-	14,  // 131: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
-	16,  // 132: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
-	22,  // 133: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
-	24,  // 134: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
-	71,  // 135: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
-	70,  // 136: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	75,  // 137: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
-	77,  // 138: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
-	79,  // 139: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
-	81,  // 140: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
-	85,  // 141: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	90,  // 142: cerebro.v1.BootstrapService.RunGraphIngestRuntime:input_type -> cerebro.v1.RunGraphIngestRuntimeRequest
-	92,  // 143: cerebro.v1.BootstrapService.GetGraphIngestRun:input_type -> cerebro.v1.GetGraphIngestRunRequest
-	94,  // 144: cerebro.v1.BootstrapService.ListGraphIngestRuns:input_type -> cerebro.v1.ListGraphIngestRunsRequest
-	96,  // 145: cerebro.v1.BootstrapService.CheckGraphIngestHealth:input_type -> cerebro.v1.CheckGraphIngestHealthRequest
-	2,   // 146: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	5,   // 147: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	10,  // 148: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	12,  // 149: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
-	27,  // 150: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	29,  // 151: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	31,  // 152: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	33,  // 153: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	35,  // 154: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	38,  // 155: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	41,  // 156: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	43,  // 157: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	45,  // 158: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	47,  // 159: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	49,  // 160: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
-	69,  // 161: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
-	56,  // 162: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
-	58,  // 163: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
-	60,  // 164: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
-	62,  // 165: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
-	64,  // 166: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
-	66,  // 167: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
-	68,  // 168: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
-	15,  // 169: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
-	17,  // 170: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
-	23,  // 171: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
-	25,  // 172: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
-	73,  // 173: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
-	74,  // 174: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	76,  // 175: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
-	78,  // 176: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
-	80,  // 177: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
-	82,  // 178: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
-	86,  // 179: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	91,  // 180: cerebro.v1.BootstrapService.RunGraphIngestRuntime:output_type -> cerebro.v1.RunGraphIngestRuntimeResponse
-	93,  // 181: cerebro.v1.BootstrapService.GetGraphIngestRun:output_type -> cerebro.v1.GetGraphIngestRunResponse
-	95,  // 182: cerebro.v1.BootstrapService.ListGraphIngestRuns:output_type -> cerebro.v1.ListGraphIngestRunsResponse
-	97,  // 183: cerebro.v1.BootstrapService.CheckGraphIngestHealth:output_type -> cerebro.v1.CheckGraphIngestHealthResponse
-	146, // [146:184] is the sub-list for method output_type
-	108, // [108:146] is the sub-list for method input_type
-	108, // [108:108] is the sub-list for extension type_name
-	108, // [108:108] is the sub-list for extension extendee
-	0,   // [0:108] is the sub-list for field type_name
+	1,   // 54: cerebro.v1.ListFindingsRequest.order:type_name -> cerebro.v1.FindingOrder
+	110, // 55: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
+	110, // 56: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
+	0,   // 57: cerebro.v1.Finding.status:type_name -> cerebro.v1.FindingStatus
+	108, // 58: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	110, // 59: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	110, // 60: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	110, // 61: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
+	52,  // 62: cerebro.v1.Finding.control_refs:type_name -> cerebro.v1.FindingControlRef
+	110, // 63: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
+	53,  // 64: cerebro.v1.Finding.notes:type_name -> cerebro.v1.FindingNote
+	54,  // 65: cerebro.v1.Finding.tickets:type_name -> cerebro.v1.FindingTicket
+	55,  // 66: cerebro.v1.GetFindingResponse.finding:type_name -> cerebro.v1.Finding
+	55,  // 67: cerebro.v1.ResolveFindingResponse.finding:type_name -> cerebro.v1.Finding
+	55,  // 68: cerebro.v1.SuppressFindingResponse.finding:type_name -> cerebro.v1.Finding
+	55,  // 69: cerebro.v1.AssignFindingResponse.finding:type_name -> cerebro.v1.Finding
+	110, // 70: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
+	55,  // 71: cerebro.v1.SetFindingDueDateResponse.finding:type_name -> cerebro.v1.Finding
+	55,  // 72: cerebro.v1.AddFindingNoteResponse.finding:type_name -> cerebro.v1.Finding
+	55,  // 73: cerebro.v1.LinkFindingTicketResponse.finding:type_name -> cerebro.v1.Finding
+	55,  // 74: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	112, // 75: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
+	55,  // 76: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
+	14,  // 77: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
+	22,  // 78: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
+	40,  // 79: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	73,  // 80: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
+	40,  // 81: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	112, // 82: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	55,  // 83: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	14,  // 84: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
+	22,  // 85: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	110, // 86: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	110, // 87: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	110, // 88: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	111, // 89: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
+	110, // 90: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	110, // 91: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	110, // 92: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	111, // 93: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
+	110, // 94: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
+	110, // 95: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
+	110, // 96: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
+	111, // 97: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
+	109, // 98: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
+	84,  // 99: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	84,  // 100: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	85,  // 101: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	88,  // 102: cerebro.v1.GraphIngestRunResult.run:type_name -> cerebro.v1.GraphIngestRun
+	89,  // 103: cerebro.v1.GraphIngestRunResult.ingest:type_name -> cerebro.v1.GraphIngestResult
+	90,  // 104: cerebro.v1.RunGraphIngestRuntimeResponse.result:type_name -> cerebro.v1.GraphIngestRunResult
+	88,  // 105: cerebro.v1.GetGraphIngestRunResponse.run:type_name -> cerebro.v1.GraphIngestRun
+	88,  // 106: cerebro.v1.ListGraphIngestRunsResponse.runs:type_name -> cerebro.v1.GraphIngestRun
+	110, // 107: cerebro.v1.CheckGraphIngestHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	88,  // 108: cerebro.v1.CheckGraphIngestHealthResponse.failed_runs:type_name -> cerebro.v1.GraphIngestRun
+	2,   // 109: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	4,   // 110: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	10,  // 111: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	12,  // 112: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
+	27,  // 113: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	29,  // 114: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	31,  // 115: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	33,  // 116: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	35,  // 117: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	37,  // 118: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	41,  // 119: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	43,  // 120: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	45,  // 121: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	47,  // 122: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	49,  // 123: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	51,  // 124: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
+	56,  // 125: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
+	58,  // 126: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
+	60,  // 127: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
+	62,  // 128: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
+	64,  // 129: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
+	66,  // 130: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
+	68,  // 131: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
+	15,  // 132: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
+	17,  // 133: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
+	23,  // 134: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
+	25,  // 135: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
+	72,  // 136: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	71,  // 137: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	76,  // 138: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
+	78,  // 139: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
+	80,  // 140: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
+	82,  // 141: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
+	86,  // 142: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	91,  // 143: cerebro.v1.BootstrapService.RunGraphIngestRuntime:input_type -> cerebro.v1.RunGraphIngestRuntimeRequest
+	93,  // 144: cerebro.v1.BootstrapService.GetGraphIngestRun:input_type -> cerebro.v1.GetGraphIngestRunRequest
+	95,  // 145: cerebro.v1.BootstrapService.ListGraphIngestRuns:input_type -> cerebro.v1.ListGraphIngestRunsRequest
+	97,  // 146: cerebro.v1.BootstrapService.CheckGraphIngestHealth:input_type -> cerebro.v1.CheckGraphIngestHealthRequest
+	3,   // 147: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	6,   // 148: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	11,  // 149: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	13,  // 150: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
+	28,  // 151: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	30,  // 152: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	32,  // 153: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	34,  // 154: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	36,  // 155: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	39,  // 156: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	42,  // 157: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	44,  // 158: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	46,  // 159: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	48,  // 160: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	50,  // 161: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	70,  // 162: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
+	57,  // 163: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
+	59,  // 164: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
+	61,  // 165: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
+	63,  // 166: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
+	65,  // 167: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
+	67,  // 168: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
+	69,  // 169: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
+	16,  // 170: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
+	18,  // 171: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
+	24,  // 172: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
+	26,  // 173: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
+	74,  // 174: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	75,  // 175: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	77,  // 176: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
+	79,  // 177: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
+	81,  // 178: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
+	83,  // 179: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
+	87,  // 180: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	92,  // 181: cerebro.v1.BootstrapService.RunGraphIngestRuntime:output_type -> cerebro.v1.RunGraphIngestRuntimeResponse
+	94,  // 182: cerebro.v1.BootstrapService.GetGraphIngestRun:output_type -> cerebro.v1.GetGraphIngestRunResponse
+	96,  // 183: cerebro.v1.BootstrapService.ListGraphIngestRuns:output_type -> cerebro.v1.ListGraphIngestRunsResponse
+	98,  // 184: cerebro.v1.BootstrapService.CheckGraphIngestHealth:output_type -> cerebro.v1.CheckGraphIngestHealthResponse
+	147, // [147:185] is the sub-list for method output_type
+	109, // [109:147] is the sub-list for method input_type
+	109, // [109:109] is the sub-list for extension type_name
+	109, // [109:109] is the sub-list for extension extendee
+	0,   // [0:109] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -7652,7 +7794,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   108,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2238,6 +2238,9 @@ func (a *App) findingService() *findings.Service {
 
 // BackfillFindingRisk runs server-start finding risk migration work.
 func (a *App) BackfillFindingRisk(ctx context.Context) error {
+	if findingStore(a.deps.StateStore) == nil {
+		return nil
+	}
 	return a.findingService().BackfillFindingRisk(ctx)
 }
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2236,6 +2236,11 @@ func (a *App) findingService() *findings.Service {
 	).WithGraphStore(sourceProjectionGraphStore(a.deps.GraphStore)).WithGraphQueryStore(graphQueryStore(a.deps.GraphStore)).WithAppendLog(a.deps.AppendLog)
 }
 
+// BackfillFindingRisk runs server-start finding risk migration work.
+func (a *App) BackfillFindingRisk(ctx context.Context) error {
+	return a.findingService().BackfillFindingRisk(ctx)
+}
+
 func (a *App) knowledgeService() *knowledge.Service {
 	return knowledge.New(
 		graphQueryStore(a.deps.GraphStore),

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1252,6 +1252,14 @@ func (a *App) handleListFindings(w http.ResponseWriter, r *http.Request) {
 		}
 		request.Status = status
 	}
+	if rawOrder := r.URL.Query().Get("order"); rawOrder != "" {
+		order, err := parseFindingOrder(rawOrder)
+		if err != nil {
+			writeFindingError(w, err)
+			return
+		}
+		request.Order = order
+	}
 	if limit := r.URL.Query().Get("limit"); limit != "" {
 		body := []byte(`{"limit":` + limit + `}`)
 		if err := unmarshalHTTPProtoJSON(body, request); err != nil {
@@ -1273,6 +1281,14 @@ func (a *App) handleListFindings(w http.ResponseWriter, r *http.Request) {
 			}
 			request.Status = status
 		}
+		if rawOrder := r.URL.Query().Get("order"); rawOrder != "" {
+			order, err := parseFindingOrder(rawOrder)
+			if err != nil {
+				writeFindingError(w, err)
+				return
+			}
+			request.Order = order
+		}
 	}
 	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), request.GetRuntimeId(), false); err != nil {
 		writeFindingError(w, err)
@@ -1288,6 +1304,7 @@ func (a *App) handleListFindings(w http.ResponseWriter, r *http.Request) {
 		EventID:     request.GetEventId(),
 		PolicyID:    request.GetPolicyId(),
 		Limit:       request.GetLimit(),
+		Order:       findingOrder(request.GetOrder()),
 	})
 	if err != nil {
 		writeFindingError(w, err)
@@ -1581,6 +1598,7 @@ func (s *bootstrapService) ListFindings(ctx context.Context, req *connect.Reques
 		EventID:     req.Msg.GetEventId(),
 		PolicyID:    req.Msg.GetPolicyId(),
 		Limit:       req.Msg.GetLimit(),
+		Order:       findingOrder(req.Msg.GetOrder()),
 	})
 	if err != nil {
 		return nil, findingConnectError(err)
@@ -2854,6 +2872,14 @@ func findingMessage(finding *ports.FindingRecord) *cerebrov1.Finding {
 		ControlRefs:       findingControlRefMessages(finding.ControlRefs),
 		Notes:             findingNoteMessages(finding.Notes),
 		Tickets:           findingTicketMessages(finding.Tickets),
+		RiskScore:         int32(finding.RiskScore),
+		LikelihoodScore:   int32(finding.LikelihoodScore),
+		ImpactScore:       int32(finding.ImpactScore),
+		ConfidenceScore:   int32(finding.ConfidenceScore),
+		LikelihoodLevel:   finding.LikelihoodLevel,
+		ImpactLevel:       finding.ImpactLevel,
+		RiskReasons:       append([]string(nil), finding.RiskReasons...),
+		RiskModelVersion:  finding.RiskModelVersion,
 		Attributes:        make(map[string]string, len(finding.Attributes)),
 		Assignee:          finding.Assignee,
 		StatusReason:      finding.StatusReason,
@@ -2966,6 +2992,19 @@ func findingStatusString(status cerebrov1.FindingStatus) string {
 	}
 }
 
+func findingOrder(order cerebrov1.FindingOrder) ports.FindingOrder {
+	switch order {
+	case cerebrov1.FindingOrder_FINDING_ORDER_PRIORITY:
+		return ports.FindingOrderPriority
+	case cerebrov1.FindingOrder_FINDING_ORDER_RISK_SCORE:
+		return ports.FindingOrderRiskScore
+	case cerebrov1.FindingOrder_FINDING_ORDER_LAST_OBSERVED:
+		return ports.FindingOrderLastObserved
+	default:
+		return ""
+	}
+}
+
 func parseFindingStatus(raw string) (cerebrov1.FindingStatus, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "open", "finding_status_open":
@@ -2976,6 +3015,19 @@ func parseFindingStatus(raw string) (cerebrov1.FindingStatus, error) {
 		return cerebrov1.FindingStatus_FINDING_STATUS_SUPPRESSED, nil
 	default:
 		return cerebrov1.FindingStatus_FINDING_STATUS_UNSPECIFIED, fmt.Errorf("%w: unsupported finding status %q", errInvalidHTTPRequest, raw)
+	}
+}
+
+func parseFindingOrder(raw string) (cerebrov1.FindingOrder, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "last_observed", "finding_order_last_observed":
+		return cerebrov1.FindingOrder_FINDING_ORDER_LAST_OBSERVED, nil
+	case "priority", "finding_order_priority":
+		return cerebrov1.FindingOrder_FINDING_ORDER_PRIORITY, nil
+	case "risk_score", "risk", "finding_order_risk_score":
+		return cerebrov1.FindingOrder_FINDING_ORDER_RISK_SCORE, nil
+	default:
+		return cerebrov1.FindingOrder_FINDING_ORDER_UNSPECIFIED, fmt.Errorf("%w: unsupported finding order %q", errInvalidHTTPRequest, raw)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -3342,6 +3342,13 @@ func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
 	}
 }
 
+func TestBackfillFindingRiskSkipsMissingStateStore(t *testing.T) {
+	app := New(config.Config{}, Dependencies{}, nil)
+	if err := app.BackfillFindingRisk(context.Background()); err != nil {
+		t.Fatalf("BackfillFindingRisk() error = %v, want nil without state store", err)
+	}
+}
+
 func TestBootstrapHealthPingsUseTimeoutContext(t *testing.T) {
 	stateStore := &deadlineAwareStore{}
 	response := healthResponse(context.Background(), Dependencies{StateStore: stateStore})

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -78,6 +78,11 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 	if err := pingDependency(ctx, "state store", deps.StateStore); err != nil {
 		return fail(err)
 	}
+	if backfiller, ok := deps.StateStore.(interface{ BackfillFindingRisk(context.Context) error }); ok {
+		if err := backfiller.BackfillFindingRisk(ctx); err != nil {
+			return fail(fmt.Errorf("backfill finding risk: %w", err))
+		}
+	}
 	if err := pingDependency(ctx, "graph store", deps.GraphStore); err != nil {
 		return fail(err)
 	}

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -84,15 +84,6 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 	return deps, closeAll, nil
 }
 
-// BackfillFindingRisk runs startup-only persisted finding risk migration work.
-func BackfillFindingRisk(ctx context.Context, deps Dependencies) error {
-	backfiller, ok := deps.StateStore.(interface{ BackfillFindingRisk(context.Context) error })
-	if !ok {
-		return nil
-	}
-	return backfiller.BackfillFindingRisk(ctx)
-}
-
 // pingDependency runs Ping with its own dependencyPingTimeout-bounded context so
 // the second/third dependency check still gets the full configured budget even
 // if an earlier ping consumed most of the original deadline.

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -78,15 +78,19 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 	if err := pingDependency(ctx, "state store", deps.StateStore); err != nil {
 		return fail(err)
 	}
-	if backfiller, ok := deps.StateStore.(interface{ BackfillFindingRisk(context.Context) error }); ok {
-		if err := backfiller.BackfillFindingRisk(ctx); err != nil {
-			return fail(fmt.Errorf("backfill finding risk: %w", err))
-		}
-	}
 	if err := pingDependency(ctx, "graph store", deps.GraphStore); err != nil {
 		return fail(err)
 	}
 	return deps, closeAll, nil
+}
+
+// BackfillFindingRisk runs startup-only persisted finding risk migration work.
+func BackfillFindingRisk(ctx context.Context, deps Dependencies) error {
+	backfiller, ok := deps.StateStore.(interface{ BackfillFindingRisk(context.Context) error })
+	if !ok {
+		return nil
+	}
+	return backfiller.BackfillFindingRisk(ctx)
 }
 
 // pingDependency runs Ping with its own dependencyPingTimeout-bounded context so

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -51,26 +51,38 @@ type grcSummary struct {
 }
 
 type grcFindingItem struct {
-	ID              string          `json:"id"`
-	Title           string          `json:"title"`
-	Severity        string          `json:"severity"`
-	Status          string          `json:"status"`
-	Summary         string          `json:"summary,omitempty"`
-	TenantID        string          `json:"tenant_id,omitempty"`
-	RuntimeID       string          `json:"runtime_id,omitempty"`
-	SourceID        string          `json:"source_id,omitempty"`
-	Entity          string          `json:"entity,omitempty"`
-	ResourceURNs    []string        `json:"resource_urns,omitempty"`
-	RuleID          string          `json:"rule_id,omitempty"`
-	PolicyID        string          `json:"policy_id,omitempty"`
-	PolicyName      string          `json:"policy_name,omitempty"`
-	Controls        []grcControlRef `json:"controls,omitempty"`
-	EvidenceCount   int             `json:"evidence_count"`
-	Owner           string          `json:"owner"`
-	SLAStatus       string          `json:"sla_status"`
-	DueAt           *time.Time      `json:"due_at,omitempty"`
-	FirstObservedAt *time.Time      `json:"first_observed_at,omitempty"`
-	LastObservedAt  *time.Time      `json:"last_observed_at,omitempty"`
+	ID           string          `json:"id"`
+	Title        string          `json:"title"`
+	Severity     string          `json:"severity"`
+	Status       string          `json:"status"`
+	Summary      string          `json:"summary,omitempty"`
+	TenantID     string          `json:"tenant_id,omitempty"`
+	RuntimeID    string          `json:"runtime_id,omitempty"`
+	SourceID     string          `json:"source_id,omitempty"`
+	Entity       string          `json:"entity,omitempty"`
+	ResourceURNs []string        `json:"resource_urns,omitempty"`
+	RuleID       string          `json:"rule_id,omitempty"`
+	PolicyID     string          `json:"policy_id,omitempty"`
+	PolicyName   string          `json:"policy_name,omitempty"`
+	Controls     []grcControlRef `json:"controls,omitempty"`
+	GRCFindingRisk
+	EvidenceCount   int        `json:"evidence_count"`
+	Owner           string     `json:"owner"`
+	SLAStatus       string     `json:"sla_status"`
+	DueAt           *time.Time `json:"due_at,omitempty"`
+	FirstObservedAt *time.Time `json:"first_observed_at,omitempty"`
+	LastObservedAt  *time.Time `json:"last_observed_at,omitempty"`
+}
+
+type GRCFindingRisk struct {
+	RiskScore       int      `json:"risk_score,omitempty"`
+	LikelihoodScore int      `json:"likelihood_score,omitempty"`
+	ImpactScore     int      `json:"impact_score,omitempty"`
+	ConfidenceScore int      `json:"confidence_score,omitempty"`
+	LikelihoodLevel string   `json:"likelihood_level,omitempty"`
+	ImpactLevel     string   `json:"impact_level,omitempty"`
+	RiskReasons     []string `json:"risk_reasons,omitempty"`
+	RiskModel       string   `json:"risk_model_version,omitempty"`
 }
 
 type grcControlRef struct {
@@ -513,6 +525,7 @@ func (a *App) grcListFindingRecords(r *http.Request, runtimes []*cerebrov1.Sourc
 			PolicyID:      filter.PolicyID,
 			Limit:         limit,
 			PriorityOrder: true,
+			Order:         ports.FindingOrderRiskScore,
 		})
 		if err != nil {
 			return nil, err
@@ -522,6 +535,9 @@ func (a *App) grcListFindingRecords(r *http.Request, runtimes []*cerebrov1.Sourc
 	sort.Slice(records, func(i, j int) bool {
 		left := records[i]
 		right := records[j]
+		if left.RiskScore != right.RiskScore {
+			return left.RiskScore > right.RiskScore
+		}
 		if severityRank(left.Severity) != severityRank(right.Severity) {
 			return severityRank(left.Severity) < severityRank(right.Severity)
 		}
@@ -741,20 +757,30 @@ func grcFindingItems(findings []*ports.FindingRecord, sourceIDs map[string]strin
 			continue
 		}
 		items = append(items, grcFindingItem{
-			ID:              finding.ID,
-			Title:           fallbackString(finding.Title, finding.RuleID, finding.ID),
-			Severity:        strings.ToUpper(strings.TrimSpace(finding.Severity)),
-			Status:          normalizedFindingStatus(finding.Status),
-			Summary:         finding.Summary,
-			TenantID:        finding.TenantID,
-			RuntimeID:       finding.RuntimeID,
-			SourceID:        sourceIDs[finding.RuntimeID],
-			Entity:          primaryEntity(finding),
-			ResourceURNs:    append([]string(nil), finding.ResourceURNs...),
-			RuleID:          finding.RuleID,
-			PolicyID:        finding.PolicyID,
-			PolicyName:      finding.PolicyName,
-			Controls:        grcControlRefs(finding.ControlRefs),
+			ID:           finding.ID,
+			Title:        fallbackString(finding.Title, finding.RuleID, finding.ID),
+			Severity:     strings.ToUpper(strings.TrimSpace(finding.Severity)),
+			Status:       normalizedFindingStatus(finding.Status),
+			Summary:      finding.Summary,
+			TenantID:     finding.TenantID,
+			RuntimeID:    finding.RuntimeID,
+			SourceID:     sourceIDs[finding.RuntimeID],
+			Entity:       primaryEntity(finding),
+			ResourceURNs: append([]string(nil), finding.ResourceURNs...),
+			RuleID:       finding.RuleID,
+			PolicyID:     finding.PolicyID,
+			PolicyName:   finding.PolicyName,
+			Controls:     grcControlRefs(finding.ControlRefs),
+			GRCFindingRisk: GRCFindingRisk{
+				RiskScore:       finding.RiskScore,
+				LikelihoodScore: finding.LikelihoodScore,
+				ImpactScore:     finding.ImpactScore,
+				ConfidenceScore: finding.ConfidenceScore,
+				LikelihoodLevel: finding.LikelihoodLevel,
+				ImpactLevel:     finding.ImpactLevel,
+				RiskReasons:     append([]string(nil), finding.RiskReasons...),
+				RiskModel:       finding.RiskModelVersion,
+			},
 			EvidenceCount:   evidenceCounts[finding.ID],
 			Owner:           fallbackString(finding.Assignee, "Unassigned"),
 			SLAStatus:       grcSLAStatus(finding),

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -370,7 +370,7 @@ func (a *App) handleGRCAuditPacket(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	finding, err := store.GetFinding(r.Context(), findingID)
+	finding, err := a.findingService().GetFinding(r.Context(), findingID)
 	if err != nil {
 		writeGRCError(w, err)
 		return

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -211,6 +211,25 @@ func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sour
 	resourceURNs := uniqueSortedStrings(finding.ResourceURNs)
 	eventIDs := uniqueSortedStrings(finding.EventIDs)
 	risk := AnalyzeFindingRiskContext(finding, time.Time{})
+	riskScore := finding.RiskScore
+	if riskScore == 0 {
+		riskScore = risk.Score
+	}
+	likelihoodScore := finding.LikelihoodScore
+	if likelihoodScore == 0 {
+		likelihoodScore = risk.LikelihoodScore
+	}
+	impactScore := finding.ImpactScore
+	if impactScore == 0 {
+		impactScore = risk.ImpactScore
+	}
+	confidenceScore := finding.ConfidenceScore
+	if confidenceScore == 0 {
+		confidenceScore = risk.ConfidenceScore
+	}
+	likelihoodLevel := firstNonEmpty(finding.LikelihoodLevel, risk.LikelihoodLevel)
+	impactLevel := firstNonEmpty(finding.ImpactLevel, risk.ImpactLevel)
+	modelVersion := firstNonEmpty(finding.RiskModelVersion, risk.RiskModelVersion)
 	return workflowevents.FindingSnapshot{
 		TenantID:           strings.TrimSpace(tenantID),
 		SourceSystem:       strings.TrimSpace(sourceID),
@@ -232,9 +251,17 @@ func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sour
 		ResourceCount:      len(resourceURNs),
 		EventCount:         len(eventIDs),
 		ControlRefs:        findingControlRefSnapshots(finding.ControlRefs),
-		RiskScore:          risk.Score,
-		RiskReasons:        risk.Reasons,
-		Metadata:           findingRiskMetadata(finding),
+		FindingRiskSnapshot: workflowevents.FindingRiskSnapshot{
+			RiskScore:        riskScore,
+			LikelihoodScore:  likelihoodScore,
+			ImpactScore:      impactScore,
+			ConfidenceScore:  confidenceScore,
+			LikelihoodLevel:  likelihoodLevel,
+			ImpactLevel:      impactLevel,
+			RiskModelVersion: modelVersion,
+			RiskReasons:      uniqueSortedStrings(append(finding.RiskReasons, risk.Reasons...)),
+		},
+		Metadata: findingRiskMetadata(finding),
 	}
 }
 

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -48,12 +48,27 @@ func (s *Service) projectFindingAnchorRevision(ctx context.Context, finding *por
 	if strings.TrimSpace(revision) == "" {
 		event, err = workflowevents.NewFindingRecordedEvent(payload)
 	} else {
-		event, err = workflowevents.NewFindingRecordedRevisionEvent(payload, revision, time.Now().UTC())
+		refreshTime := time.Now().UTC()
+		if findingClosedStatus(payload.Finding.Status) {
+			event, err = workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{
+				Finding:   payload.Finding,
+				Status:    payload.Finding.Status,
+				Reason:    strings.TrimSpace(finding.StatusReason),
+				Source:    "risk_refresh",
+				UpdatedAt: refreshTime.Format(time.RFC3339Nano),
+			})
+		} else {
+			event, err = workflowevents.NewFindingRecordedRevisionEvent(payload, revision, refreshTime)
+		}
 	}
 	if err != nil {
 		return err
 	}
 	return s.recordAndProjectWorkflowEvent(ctx, event)
+}
+
+func findingClosedStatus(status string) bool {
+	return strings.EqualFold(strings.TrimSpace(status), findingStatusResolved) || strings.EqualFold(strings.TrimSpace(status), findingStatusSuppressed)
 }
 
 func (s *Service) projectFindingNote(ctx context.Context, finding *ports.FindingRecord, note ports.FindingNote) error {

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -210,7 +210,10 @@ func (s *Service) recordAndProjectWorkflowEvent(ctx context.Context, event *cere
 func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sourceID string) workflowevents.FindingSnapshot {
 	resourceURNs := uniqueSortedStrings(finding.ResourceURNs)
 	eventIDs := uniqueSortedStrings(finding.EventIDs)
-	risk := AnalyzeFindingRiskContext(finding, time.Time{})
+	var risk FindingRiskContext
+	if finding.RiskScore == 0 || finding.LikelihoodScore == 0 || finding.ImpactScore == 0 || finding.ConfidenceScore == 0 {
+		risk = AnalyzeFindingRiskContext(finding, time.Time{})
+	}
 	riskScore := finding.RiskScore
 	if riskScore == 0 {
 		riskScore = risk.Score
@@ -230,6 +233,10 @@ func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sour
 	likelihoodLevel := firstNonEmpty(finding.LikelihoodLevel, risk.LikelihoodLevel)
 	impactLevel := firstNonEmpty(finding.ImpactLevel, risk.ImpactLevel)
 	modelVersion := firstNonEmpty(finding.RiskModelVersion, risk.RiskModelVersion)
+	riskReasons := finding.RiskReasons
+	if len(riskReasons) == 0 {
+		riskReasons = risk.Reasons
+	}
 	return workflowevents.FindingSnapshot{
 		TenantID:           strings.TrimSpace(tenantID),
 		SourceSystem:       strings.TrimSpace(sourceID),
@@ -259,7 +266,7 @@ func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sour
 			LikelihoodLevel:  likelihoodLevel,
 			ImpactLevel:      impactLevel,
 			RiskModelVersion: modelVersion,
-			RiskReasons:      uniqueSortedStrings(append(finding.RiskReasons, risk.Reasons...)),
+			RiskReasons:      uniqueSortedStrings(riskReasons),
 		},
 		Metadata: findingRiskMetadata(finding),
 	}

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -48,7 +48,7 @@ func (s *Service) projectFindingAnchorRevision(ctx context.Context, finding *por
 	if strings.TrimSpace(revision) == "" {
 		event, err = workflowevents.NewFindingRecordedEvent(payload)
 	} else {
-		event, err = workflowevents.NewFindingRecordedRevisionEvent(payload, revision)
+		event, err = workflowevents.NewFindingRecordedRevisionEvent(payload, revision, time.Now().UTC())
 	}
 	if err != nil {
 		return err

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -21,7 +21,10 @@ const (
 )
 
 func (s *Service) projectFindingAnchor(ctx context.Context, finding *ports.FindingRecord) error {
-	return s.projectFindingAnchorRevision(ctx, finding, "")
+	if err := s.projectFindingAnchorRevision(ctx, finding, ""); err != nil {
+		return err
+	}
+	return s.markFindingRiskProjected(ctx, finding)
 }
 
 func (s *Service) projectFindingAnchorRevision(ctx context.Context, finding *ports.FindingRecord, revision string) error {
@@ -69,6 +72,26 @@ func (s *Service) projectFindingAnchorRevision(ctx context.Context, finding *por
 
 func findingClosedStatus(status string) bool {
 	return strings.EqualFold(strings.TrimSpace(status), findingStatusResolved) || strings.EqualFold(strings.TrimSpace(status), findingStatusSuppressed)
+}
+
+func (s *Service) markFindingRiskProjected(ctx context.Context, finding *ports.FindingRecord) error {
+	if s == nil || s.graph == nil || finding == nil {
+		return nil
+	}
+	riskUpdater, ok := s.store.(interface {
+		UpdateFindingRisk(context.Context, ports.FindingRiskUpdate) (*ports.FindingRecord, error)
+	})
+	if !ok {
+		return nil
+	}
+	_, err := riskUpdater.UpdateFindingRisk(ctx, ports.FindingRiskUpdate{
+		FindingID:   finding.ID,
+		FindingRisk: finding.FindingRisk,
+		Attributes: map[string]string{
+			FindingRiskGraphProjectedModelVersionAttribute: finding.RiskModelVersion,
+		},
+	})
+	return err
 }
 
 func (s *Service) projectFindingNote(ctx context.Context, finding *ports.FindingRecord, note ports.FindingNote) error {

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -21,6 +21,10 @@ const (
 )
 
 func (s *Service) projectFindingAnchor(ctx context.Context, finding *ports.FindingRecord) error {
+	return s.projectFindingAnchorRevision(ctx, finding, "")
+}
+
+func (s *Service) projectFindingAnchorRevision(ctx context.Context, finding *ports.FindingRecord, revision string) error {
 	if s == nil || s.graph == nil {
 		return nil
 	}
@@ -35,10 +39,17 @@ func (s *Service) projectFindingAnchor(ctx context.Context, finding *ports.Findi
 	if recordedAt.IsZero() {
 		recordedAt = time.Now().UTC()
 	}
-	event, err := workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
+	payload := workflowevents.FindingRecorded{
 		Finding:    findingWorkflowSnapshot(finding, tenantID, sourceID),
 		RecordedAt: recordedAt.Format(time.RFC3339Nano),
-	})
+	}
+	var event *cerebrov1.EventEnvelope
+	var err error
+	if strings.TrimSpace(revision) == "" {
+		event, err = workflowevents.NewFindingRecordedEvent(payload)
+	} else {
+		event, err = workflowevents.NewFindingRecordedRevisionEvent(payload, revision)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -118,8 +118,7 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 			evaluationErr := fmt.Errorf("reconcile finding identity for graph rule %q: %w", spec.GetId(), err)
 			return result, s.finishFailedGraphRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
 		}
-		record = enrichFindingRisk(record, runtime, startedAt)
-		stored, err := s.store.UpsertFinding(ctx, record)
+		stored, err := s.upsertFindingWithRisk(ctx, record, runtime, startedAt)
 		if err != nil {
 			evaluationErr := fmt.Errorf("persist finding for graph rule %q: %w", spec.GetId(), err)
 			return result, s.finishFailedGraphRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -118,6 +118,7 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 			evaluationErr := fmt.Errorf("reconcile finding identity for graph rule %q: %w", spec.GetId(), err)
 			return result, s.finishFailedGraphRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
 		}
+		record = enrichFindingRisk(record, runtime, startedAt)
 		stored, err := s.store.UpsertFinding(ctx, record)
 		if err != nil {
 			evaluationErr := fmt.Errorf("persist finding for graph rule %q: %w", spec.GetId(), err)

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -236,7 +236,7 @@ func (s *Service) resolveStaleGraphFindings(ctx context.Context, tenantID string
 		if _, emitted := emittedFindingIDs[strings.TrimSpace(finding.ID)]; emitted {
 			continue
 		}
-		updated, err := s.store.UpdateFindingStatus(ctx, ports.FindingStatusUpdate{
+		updated, err := s.updateFindingStatusAndRisk(ctx, ports.FindingStatusUpdate{
 			FindingID: strings.TrimSpace(finding.ID),
 			Status:    findingStatusResolved,
 			Reason:    "graph_rule_no_longer_matches",

--- a/internal/findings/risk_analysis.go
+++ b/internal/findings/risk_analysis.go
@@ -1,6 +1,7 @@
 package findings
 
 import (
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -10,6 +11,8 @@ import (
 )
 
 const defaultFindingCorrelationWindow = 24 * time.Hour
+
+const defaultFindingRiskModelVersion = "likelihood-impact-v1"
 
 // FindingExposureAnalysisOptions scopes source-agnostic risk correlation output.
 type FindingExposureAnalysisOptions struct {
@@ -28,8 +31,14 @@ type FindingExposureAnalysisReport struct {
 
 // FindingRiskContext captures contextual scoring signals for one finding or correlated group.
 type FindingRiskContext struct {
-	Score   int      `json:"score"`
-	Reasons []string `json:"reasons,omitempty"`
+	Score            int      `json:"score"`
+	LikelihoodScore  int      `json:"likelihood_score"`
+	ImpactScore      int      `json:"impact_score"`
+	ConfidenceScore  int      `json:"confidence_score"`
+	LikelihoodLevel  string   `json:"likelihood_level,omitempty"`
+	ImpactLevel      string   `json:"impact_level,omitempty"`
+	RiskModelVersion string   `json:"risk_model_version,omitempty"`
+	Reasons          []string `json:"reasons,omitempty"`
 }
 
 // FindingEvidenceBundle is a compact, source-agnostic evidence summary for a finding group or path.
@@ -285,87 +294,197 @@ func AnalyzeFindingRiskContext(finding *ports.FindingRecord, now time.Time) Find
 		now = time.Now().UTC()
 	}
 	attributes := finding.Attributes
-	score := 0
+	likelihood := 10
+	impact := 10
+	confidence := 85
 	reasons := []string{}
 	severity := strings.ToUpper(strings.TrimSpace(finding.Severity))
 	if severityScore := compoundRiskSeverityScore(severity); severityScore > 0 {
-		score += severityScore * 10
+		likelihood += severityScore * 6
+		impact += severityScore * 8
 		reasons = append(reasons, "severity:"+severity)
 	}
 	status := strings.ToLower(strings.TrimSpace(finding.Status))
 	if status == "" || status == findingStatusOpen {
-		score += 2
+		likelihood += 5
 		reasons = append(reasons, "active")
 	}
 	if !finding.DueAt.IsZero() && finding.DueAt.Before(now) {
-		score += 5
+		impact += 5
 		reasons = append(reasons, "overdue")
 	}
 	if observedAt := findingObservedAt(finding); !observedAt.IsZero() {
 		age := now.Sub(observedAt)
 		switch {
 		case age >= 0 && age <= 24*time.Hour:
-			score += 5
+			likelihood += 5
 			reasons = append(reasons, "recent_24h")
 		case age >= 0 && age <= 7*24*time.Hour:
-			score += 2
+			likelihood += 2
 			reasons = append(reasons, "recent_7d")
 		}
 	}
 	if eventCount := len(uniqueSortedStrings(finding.EventIDs)); eventCount > 1 {
-		score += min(eventCount, 10)
+		likelihood += min(eventCount*2, 10)
+		confidence += 3
 		reasons = append(reasons, "multiple_events")
 	}
 	if resourceCount := len(uniqueSortedStrings(finding.ResourceURNs)); resourceCount > 1 {
-		score += min(resourceCount, 8)
+		impact += min(resourceCount*2, 12)
 		reasons = append(reasons, "multiple_resources")
 	}
 	if len(finding.ControlRefs) > 0 {
-		score += min(len(finding.ControlRefs)*2, 8)
+		impact += min(len(finding.ControlRefs)*2, 8)
 		reasons = append(reasons, "mapped_controls")
 	}
 	action := strings.ToLower(compoundRiskAction(finding))
 	if containsAny(action, "disable", "delete", "destroy", "remove", "revoke", "bypass", "override", "public", "expose") {
-		score += 8
+		likelihood += 12
 		reasons = append(reasons, "risky_action")
 	}
 	criticality := strings.ToLower(firstNonEmpty(attributes["asset_criticality"], attributes["criticality"], attributes["business_criticality"], attributes["tier"]))
 	if containsAny(criticality, "critical", "high", "crown", "tier0", "tier-0") {
-		score += 10
+		impact += 35
 		reasons = append(reasons, "critical_asset")
 	}
-	if findingAttributeBool(attributes, "internet_exposed", "public", "externally_exposed", "external_exposure") {
-		score += 8
+	publicExposure := findingAttributeBool(attributes, "internet_exposed", "public", "externally_exposed", "external_exposure", "is_public", "is_internet_facing")
+	reachabilityPath := publicExposure || findingAttributeBool(attributes, "reachable", "directly_reachable", "internet_reachable", "can_reach")
+	if containsAny(action, "can_reach", "public_network_ingress", "internet_facing") {
+		reachabilityPath = true
+	}
+	if publicExposure {
+		likelihood += 35
 		reasons = append(reasons, "external_exposure")
 	}
 	if findingAttributeBool(attributes, "privileged", "actor_privileged", "admin", "is_admin", "has_admin") {
-		score += 7
+		likelihood += 10
+		impact += 15
 		reasons = append(reasons, "privileged_actor")
 	}
+	activeExploit := findingAttributeBool(attributes, "active_exploit", "active_threat", "exploit_detected", "credential_use", "token_exchange", "suspicious_process")
+	if activeExploit {
+		likelihood += 25
+		reasons = append(reasons, "active_threat")
+	}
 	if findingAttributeBool(attributes, "is_kev", "kev", "known_exploited", "known_exploited_vulnerability") {
-		score += 12
+		likelihood += 35
 		reasons = append(reasons, "known_exploited")
 	}
 	if epss, ok := findingAttributeFloat(attributes, "epss_score", "epss", "exploit_probability"); ok {
 		switch {
 		case epss >= 0.7:
-			score += 10
+			likelihood += 25
 			reasons = append(reasons, "epss_high")
 		case epss >= 0.2:
-			score += 5
+			likelihood += 12
 			reasons = append(reasons, "epss_elevated")
+		}
+	}
+	if findingAttributeBool(attributes, "exploit_available", "public_exploit", "weaponized_exploit") {
+		likelihood += 20
+		reasons = append(reasons, "exploit_available")
+	}
+	exploitMaturity := strings.ToLower(firstNonEmpty(attributes["exploit_maturity"], attributes["exploit_status"]))
+	if containsAny(exploitMaturity, "weaponized", "functional", "poc", "proof") {
+		likelihood += 15
+		reasons = append(reasons, "exploit_maturity:"+exploitMaturity)
+	}
+	if cvss, ok := findingAttributeFloat(attributes, "cvss_score", "cvss", "base_score"); ok {
+		switch {
+		case cvss >= 9:
+			likelihood += 10
+			impact += 10
+			reasons = append(reasons, "cvss_critical")
+		case cvss >= 7:
+			likelihood += 5
+			impact += 5
+			reasons = append(reasons, "cvss_high")
 		}
 	}
 	dataClass := strings.ToLower(firstNonEmpty(attributes["data_classification"], attributes["sensitivity"], attributes["data_sensitivity"]))
 	if containsAny(dataClass, "secret", "sensitive", "confidential", "restricted") {
-		score += 6
+		impact += 25
 		reasons = append(reasons, "sensitive_data")
 	}
 	if findingAttributeBool(attributes, "crown_jewel", "contains_secrets") {
-		score += 12
+		impact += 35
 		reasons = append(reasons, "crown_jewel")
 	}
-	return FindingRiskContext{Score: score, Reasons: uniqueSortedStrings(reasons)}
+	if findingAttributeBool(attributes, "contains_pii", "contains_phi", "contains_pci", "has_sensitive_data", "has_sensitive_data_access") {
+		impact += 20
+		reasons = append(reasons, "regulated_or_sensitive_data")
+	}
+	environment := strings.ToLower(firstNonEmpty(attributes["environment"], attributes["env"], attributes["stage"], attributes["site_name"]))
+	if containsAny(environment, "prod", "production") {
+		impact += 15
+		reasons = append(reasons, "production_environment")
+	}
+	if findingAttributeBool(attributes, "can_admin", "admin_reachable", "privileged_access", "has_admin_path") || containsAny(action, "can_admin", "can_assume", "can_impersonate") {
+		impact += 20
+		reasons = append(reasons, "privilege_or_control_plane")
+	}
+	if blastRadius, ok := findingAttributeInt(attributes, "blast_radius", "affected_users", "reachable_resource_count", "admin_reachable_count", "sensitive_data_path_count"); ok && blastRadius > 0 {
+		impact += min(blastRadius, 20)
+		reasons = append(reasons, "blast_radius")
+	}
+	networkScope := strings.ToLower(firstNonEmpty(attributes["network_scope"], attributes["cidr_scope"], attributes["ip_scope"], attributes["subnet_scope"], attributes["exposure_scope"]))
+	privateNetwork := findingAttributeBool(attributes, "private_network", "private_subnet") || containsAny(networkScope, "private", "rfc1918", "loopback", "link-local", "unique-local")
+	if privateNetwork && !reachabilityPath && !activeExploit {
+		likelihood = min(likelihood, 35)
+		reasons = append(reasons, "private_network_context")
+	}
+	if len(finding.GraphEvidenceRows) > 0 {
+		confidence += 5
+		reasons = append(reasons, "graph_evidence")
+	}
+	if len(finding.ResourceURNs) == 0 && len(finding.EventIDs) == 0 {
+		confidence -= 15
+		reasons = append(reasons, "limited_evidence")
+	}
+	likelihood = clampScore(likelihood)
+	impact = clampScore(impact)
+	confidence = clampScore(confidence)
+	riskScore := productRiskScore(likelihood, impact)
+	return FindingRiskContext{
+		Score:            riskScore,
+		LikelihoodScore:  likelihood,
+		ImpactScore:      impact,
+		ConfidenceScore:  confidence,
+		LikelihoodLevel:  riskLevelFromScore(likelihood),
+		ImpactLevel:      riskLevelFromScore(impact),
+		RiskModelVersion: defaultFindingRiskModelVersion,
+		Reasons:          uniqueSortedStrings(reasons),
+	}
+}
+
+func productRiskScore(likelihood int, impact int) int {
+	return clampScore(int(math.Round(math.Sqrt(float64(clampScore(likelihood) * clampScore(impact))))))
+}
+
+func clampScore(score int) int {
+	switch {
+	case score < 0:
+		return 0
+	case score > 100:
+		return 100
+	default:
+		return score
+	}
+}
+
+func riskLevelFromScore(score int) string {
+	switch {
+	case score >= 85:
+		return "critical"
+	case score >= 70:
+		return "high"
+	case score >= 40:
+		return "medium"
+	case score > 0:
+		return "low"
+	default:
+		return ""
+	}
 }
 
 func weightedAttackPathScore(steps []FindingAttackPathStep) (int, []string) {
@@ -708,6 +827,21 @@ func findingAttributeFloat(attributes map[string]string, keys ...string) (float6
 			continue
 		}
 		value, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			continue
+		}
+		return value, true
+	}
+	return 0, false
+}
+
+func findingAttributeInt(attributes map[string]string, keys ...string) (int, bool) {
+	for _, key := range keys {
+		raw := strings.TrimSpace(attributes[key])
+		if raw == "" {
+			continue
+		}
+		value, err := strconv.Atoi(raw)
 		if err != nil {
 			continue
 		}

--- a/internal/findings/risk_analysis.go
+++ b/internal/findings/risk_analysis.go
@@ -15,6 +15,8 @@ const defaultFindingCorrelationWindow = 24 * time.Hour
 
 const defaultFindingRiskModelVersion = "likelihood-impact-v1"
 
+const FindingRiskGraphProjectedModelVersionAttribute = "risk_graph_projected_model_version"
+
 // FindingExposureAnalysisOptions scopes source-agnostic risk correlation output.
 type FindingExposureAnalysisOptions struct {
 	Limit              int
@@ -469,11 +471,11 @@ func findingActiveThreatSignal(attributes map[string]string, action string) bool
 	if count, ok := findingAttributeInt(attributes, "active_threats", "active_threat_count"); ok && count > 0 {
 		return true
 	}
-	evidenceType := strings.ToLower(firstNonEmpty(attributes["evidence_type"], attributes["evidence_kind"], attributes["signal"], attributes["classification"]))
-	if containsAny(evidenceType, "exploit", "secret_access", "credential_use", "token_exchange", "suspicious_process", "active_threat", "infected", "malware") {
+	evidenceType := strings.ToLower(firstNonEmpty(attributes["evidence_type"], attributes["evidence_kind"], attributes["signal"]))
+	if containsAny(evidenceType, "exploit", "secret_access", "credential_use", "token_exchange", "suspicious_process", "active_threat", "infected") {
 		return true
 	}
-	return containsAny(action, "credential_use", "token_exchange", "suspicious_process", "active_threat", "exploit", "malware")
+	return containsAny(action, "credential_use", "token_exchange", "suspicious_process", "active_threat", "exploit")
 }
 
 func isProductionEnvironment(value string) bool {

--- a/internal/findings/risk_analysis.go
+++ b/internal/findings/risk_analysis.go
@@ -403,7 +403,7 @@ func AnalyzeFindingRiskContext(finding *ports.FindingRecord, now time.Time) Find
 		}
 	}
 	dataClass := strings.ToLower(firstNonEmpty(attributes["data_classification"], attributes["sensitivity"], attributes["data_sensitivity"]))
-	if containsAny(dataClass, "secret", "sensitive", "confidential", "restricted") {
+	if dataClassificationSensitive(dataClass) {
 		impact += 25
 		reasons = append(reasons, "sensitive_data")
 	}

--- a/internal/findings/risk_analysis.go
+++ b/internal/findings/risk_analysis.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -415,7 +416,7 @@ func AnalyzeFindingRiskContext(finding *ports.FindingRecord, now time.Time) Find
 		reasons = append(reasons, "regulated_or_sensitive_data")
 	}
 	environment := strings.ToLower(firstNonEmpty(attributes["environment"], attributes["env"], attributes["stage"], attributes["site_name"]))
-	if containsAny(environment, "prod", "production") {
+	if isProductionEnvironment(environment) {
 		impact += 15
 		reasons = append(reasons, "production_environment")
 	}
@@ -459,6 +460,34 @@ func AnalyzeFindingRiskContext(finding *ports.FindingRecord, now time.Time) Find
 
 func productRiskScore(likelihood int, impact int) int {
 	return clampScore(int(math.Round(math.Sqrt(float64(clampScore(likelihood) * clampScore(impact))))))
+}
+
+func isProductionEnvironment(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		return false
+	}
+	tokens := strings.FieldsFunc(normalized, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	if len(tokens) == 0 {
+		return false
+	}
+	for i, token := range tokens {
+		switch token {
+		case "nonprod", "nonproduction", "preprod", "preproduction", "staging", "stage", "dev", "development", "test", "testing", "qa", "sandbox", "uat":
+			return false
+		case "prod", "production", "prd", "live":
+			if i > 0 {
+				switch tokens[i-1] {
+				case "non", "not", "pre":
+					return false
+				}
+			}
+			return true
+		}
+	}
+	return false
 }
 
 func clampScore(score int) int {

--- a/internal/findings/risk_analysis.go
+++ b/internal/findings/risk_analysis.go
@@ -362,7 +362,7 @@ func AnalyzeFindingRiskContext(finding *ports.FindingRecord, now time.Time) Find
 		impact += 15
 		reasons = append(reasons, "privileged_actor")
 	}
-	activeExploit := findingAttributeBool(attributes, "active_exploit", "active_threat", "exploit_detected", "credential_use", "token_exchange", "suspicious_process")
+	activeExploit := findingActiveThreatSignal(attributes, action)
 	if activeExploit {
 		likelihood += 25
 		reasons = append(reasons, "active_threat")
@@ -460,6 +460,20 @@ func AnalyzeFindingRiskContext(finding *ports.FindingRecord, now time.Time) Find
 
 func productRiskScore(likelihood int, impact int) int {
 	return clampScore(int(math.Round(math.Sqrt(float64(clampScore(likelihood) * clampScore(impact))))))
+}
+
+func findingActiveThreatSignal(attributes map[string]string, action string) bool {
+	if findingAttributeBool(attributes, "active_exploit", "active_threat", "exploit_detected", "credential_use", "token_exchange", "suspicious_process", "is_infected", "infected") {
+		return true
+	}
+	if count, ok := findingAttributeInt(attributes, "active_threats", "active_threat_count"); ok && count > 0 {
+		return true
+	}
+	evidenceType := strings.ToLower(firstNonEmpty(attributes["evidence_type"], attributes["evidence_kind"], attributes["signal"], attributes["classification"]))
+	if containsAny(evidenceType, "exploit", "secret_access", "credential_use", "token_exchange", "suspicious_process", "active_threat", "infected", "malware") {
+		return true
+	}
+	return containsAny(action, "credential_use", "token_exchange", "suspicious_process", "active_threat", "exploit", "malware")
 }
 
 func isProductionEnvironment(value string) bool {

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -171,6 +171,29 @@ func TestAnalyzeFindingRiskContextDoesNotTreatNonProductionAsProduction(t *testi
 	}
 }
 
+func TestAnalyzeFindingRiskContextRecognizesActiveThreatSignals(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	for name, attributes := range map[string]map[string]string{
+		"runtime_evidence_type": {
+			"evidence_type": "credential_use",
+		},
+		"runtime_action": {
+			"action": "token_exchange",
+		},
+		"sentinelone_infected": {
+			"is_infected":    "true",
+			"active_threats": "2",
+		},
+	} {
+		finding := compoundRiskFinding("finding-"+name, "runtime-active-threat", "HIGH", "", "", "urn:cerebro:writer:runtime_evidence:"+name, "")
+		finding.Attributes = attributes
+		context := AnalyzeFindingRiskContext(finding, now)
+		if !stringSliceContains(context.Reasons, "active_threat") {
+			t.Fatalf("Risk reasons for %s = %#v, want active_threat", name, context.Reasons)
+		}
+	}
+}
+
 func TestAnalyzeFindingRiskContextCapsPrivateNetworkWithoutReachability(t *testing.T) {
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	finding := compoundRiskFinding("finding-private", "cloud-private-exposure", "CRITICAL", "", "", "urn:cerebro:writer:aws_instance:i-1", "scan.detected")

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -153,6 +153,24 @@ func TestAnalyzeFindingRiskContextUsesGenericSignals(t *testing.T) {
 	}
 }
 
+func TestAnalyzeFindingRiskContextDoesNotTreatNonProductionAsProduction(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	for _, environment := range []string{"nonprod", "non-prod", "preprod", "pre-production", "staging"} {
+		finding := compoundRiskFinding("finding-"+environment, "cloud-env", "MEDIUM", "", "", "urn:cerebro:writer:asset:"+environment, "scan.detected")
+		finding.Attributes["environment"] = environment
+		context := AnalyzeFindingRiskContext(finding, now)
+		if stringSliceContains(context.Reasons, "production_environment") {
+			t.Fatalf("Risk reasons for environment %q = %#v, want no production_environment", environment, context.Reasons)
+		}
+	}
+	production := compoundRiskFinding("finding-prod", "cloud-env", "MEDIUM", "", "", "urn:cerebro:writer:asset:prod", "scan.detected")
+	production.Attributes["environment"] = "writer-prod"
+	context := AnalyzeFindingRiskContext(production, now)
+	if !stringSliceContains(context.Reasons, "production_environment") {
+		t.Fatalf("Risk reasons for production environment = %#v, want production_environment", context.Reasons)
+	}
+}
+
 func TestAnalyzeFindingRiskContextCapsPrivateNetworkWithoutReachability(t *testing.T) {
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	finding := compoundRiskFinding("finding-private", "cloud-private-exposure", "CRITICAL", "", "", "urn:cerebro:writer:aws_instance:i-1", "scan.detected")

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -139,6 +139,36 @@ func TestAnalyzeFindingRiskContextUsesGenericSignals(t *testing.T) {
 	if context.Score < 80 {
 		t.Fatalf("Risk score = %d, want generic contextual score >= 80", context.Score)
 	}
+	if context.LikelihoodScore < 80 {
+		t.Fatalf("LikelihoodScore = %d, want >= 80", context.LikelihoodScore)
+	}
+	if context.ImpactScore < 80 {
+		t.Fatalf("ImpactScore = %d, want >= 80", context.ImpactScore)
+	}
+	if context.ConfidenceScore == 0 {
+		t.Fatal("ConfidenceScore = 0, want populated confidence")
+	}
+	if context.LikelihoodLevel == "" || context.ImpactLevel == "" || context.RiskModelVersion == "" {
+		t.Fatalf("Risk metadata = %#v, want levels and model version", context)
+	}
+}
+
+func TestAnalyzeFindingRiskContextCapsPrivateNetworkWithoutReachability(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	finding := compoundRiskFinding("finding-private", "cloud-private-exposure", "CRITICAL", "", "", "urn:cerebro:writer:aws_instance:i-1", "scan.detected")
+	finding.LastObservedAt = now
+	finding.Attributes["network_scope"] = "private"
+	finding.Attributes["is_kev"] = "true"
+	finding.Attributes["epss_score"] = "0.91"
+	finding.Attributes["asset_criticality"] = "critical"
+
+	context := AnalyzeFindingRiskContext(finding, now)
+	if context.LikelihoodScore > 35 {
+		t.Fatalf("LikelihoodScore = %d, want private network cap <= 35 without reachability", context.LikelihoodScore)
+	}
+	if !stringSliceContains(context.Reasons, "private_network_context") {
+		t.Fatalf("Risk reasons = %#v, want private_network_context", context.Reasons)
+	}
 }
 
 func TestAnalyzeFindingAttackPathsUsesRelationWeights(t *testing.T) {

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -194,6 +194,18 @@ func TestAnalyzeFindingRiskContextRecognizesActiveThreatSignals(t *testing.T) {
 	}
 }
 
+func TestAnalyzeFindingRiskContextIgnoresExplicitNonSensitiveData(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	for _, classification := range []string{"not_sensitive", "non_sensitive", "no_sensitive_data"} {
+		finding := compoundRiskFinding("finding-"+classification, "data-classification", "MEDIUM", "", "", "urn:cerebro:writer:dataset:"+classification, "")
+		finding.Attributes = map[string]string{"data_classification": classification}
+		context := AnalyzeFindingRiskContext(finding, now)
+		if stringSliceContains(context.Reasons, "sensitive_data") {
+			t.Fatalf("Risk reasons for %q = %#v, want no sensitive_data", classification, context.Reasons)
+		}
+	}
+}
+
 func TestAnalyzeFindingRiskContextCapsPrivateNetworkWithoutReachability(t *testing.T) {
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	finding := compoundRiskFinding("finding-private", "cloud-private-exposure", "CRITICAL", "", "", "urn:cerebro:writer:aws_instance:i-1", "scan.detected")

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -194,6 +194,16 @@ func TestAnalyzeFindingRiskContextRecognizesActiveThreatSignals(t *testing.T) {
 	}
 }
 
+func TestAnalyzeFindingRiskContextDoesNotTreatGenericMalwareClassificationAsActiveThreat(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	finding := compoundRiskFinding("finding-sentinelone-mitigation", "sentinelone-mitigation-failed", "HIGH", "", "", "urn:cerebro:writer:sentinelone_agent:agent-1", "")
+	finding.Attributes = map[string]string{"classification": "Malware"}
+	context := AnalyzeFindingRiskContext(finding, now)
+	if stringSliceContains(context.Reasons, "active_threat") {
+		t.Fatalf("Risk reasons = %#v, want no active_threat for generic malware classification", context.Reasons)
+	}
+}
+
 func TestAnalyzeFindingRiskContextIgnoresExplicitNonSensitiveData(t *testing.T) {
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	for _, classification := range []string{"not_sensitive", "non_sensitive", "no_sensitive_data"} {

--- a/internal/findings/risk_enrichment.go
+++ b/internal/findings/risk_enrichment.go
@@ -52,6 +52,31 @@ func enrichFindingRisk(record *ports.FindingRecord, _ *cerebrov1.SourceRuntime, 
 	return record
 }
 
+func recomputeFindingRisk(record *ports.FindingRecord, now time.Time) *ports.FindingRecord {
+	if record == nil {
+		return nil
+	}
+	record.RiskScore = 0
+	record.LikelihoodScore = 0
+	record.ImpactScore = 0
+	record.ConfidenceScore = 0
+	record.LikelihoodLevel = ""
+	record.ImpactLevel = ""
+	record.RiskReasons = nil
+	record.RiskModelVersion = ""
+	if record.Attributes != nil {
+		delete(record.Attributes, "risk_score")
+		delete(record.Attributes, "likelihood_score")
+		delete(record.Attributes, "impact_score")
+		delete(record.Attributes, "confidence_score")
+		delete(record.Attributes, "likelihood_level")
+		delete(record.Attributes, "impact_level")
+		delete(record.Attributes, "risk_reasons")
+		delete(record.Attributes, "risk_model_version")
+	}
+	return enrichFindingRisk(record, nil, now)
+}
+
 func setRiskAttribute(attributes map[string]string, key string, value int) {
 	if value <= 0 {
 		return

--- a/internal/findings/risk_enrichment.go
+++ b/internal/findings/risk_enrichment.go
@@ -77,6 +77,22 @@ func recomputeFindingRisk(record *ports.FindingRecord, now time.Time) *ports.Fin
 	return enrichFindingRisk(record, nil, now)
 }
 
+func findingRiskAttributes(record *ports.FindingRecord) map[string]string {
+	if record == nil {
+		return map[string]string{}
+	}
+	attributes := map[string]string{}
+	attributes["risk_score"] = strconv.Itoa(clampScore(record.RiskScore))
+	attributes["likelihood_score"] = strconv.Itoa(clampScore(record.LikelihoodScore))
+	attributes["impact_score"] = strconv.Itoa(clampScore(record.ImpactScore))
+	attributes["confidence_score"] = strconv.Itoa(clampScore(record.ConfidenceScore))
+	attributes["likelihood_level"] = strings.TrimSpace(record.LikelihoodLevel)
+	attributes["impact_level"] = strings.TrimSpace(record.ImpactLevel)
+	attributes["risk_model_version"] = strings.TrimSpace(record.RiskModelVersion)
+	attributes["risk_reasons"] = strings.Join(record.RiskReasons, ",")
+	return attributes
+}
+
 func setRiskAttribute(attributes map[string]string, key string, value int) {
 	if value <= 0 {
 		return

--- a/internal/findings/risk_enrichment.go
+++ b/internal/findings/risk_enrichment.go
@@ -1,0 +1,66 @@
+package findings
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func enrichFindingRisk(record *ports.FindingRecord, _ *cerebrov1.SourceRuntime, now time.Time) *ports.FindingRecord {
+	if record == nil {
+		return nil
+	}
+	evaluation := AnalyzeFindingRiskContext(record, now)
+	if record.LikelihoodScore <= 0 {
+		record.LikelihoodScore = evaluation.LikelihoodScore
+	}
+	if record.ImpactScore <= 0 {
+		record.ImpactScore = evaluation.ImpactScore
+	}
+	if record.ConfidenceScore <= 0 {
+		record.ConfidenceScore = evaluation.ConfidenceScore
+	}
+	if strings.TrimSpace(record.LikelihoodLevel) == "" {
+		record.LikelihoodLevel = riskLevelFromScore(record.LikelihoodScore)
+	}
+	if strings.TrimSpace(record.ImpactLevel) == "" {
+		record.ImpactLevel = riskLevelFromScore(record.ImpactScore)
+	}
+	if record.RiskScore <= 0 {
+		record.RiskScore = productRiskScore(record.LikelihoodScore, record.ImpactScore)
+	}
+	if strings.TrimSpace(record.RiskModelVersion) == "" {
+		record.RiskModelVersion = defaultFindingRiskModelVersion
+	}
+	record.RiskReasons = uniqueSortedStrings(append(record.RiskReasons, evaluation.Reasons...))
+	if record.Attributes == nil {
+		record.Attributes = map[string]string{}
+	}
+	setRiskAttribute(record.Attributes, "risk_score", record.RiskScore)
+	setRiskAttribute(record.Attributes, "likelihood_score", record.LikelihoodScore)
+	setRiskAttribute(record.Attributes, "impact_score", record.ImpactScore)
+	setRiskAttribute(record.Attributes, "confidence_score", record.ConfidenceScore)
+	setRiskStringAttribute(record.Attributes, "likelihood_level", record.LikelihoodLevel)
+	setRiskStringAttribute(record.Attributes, "impact_level", record.ImpactLevel)
+	setRiskStringAttribute(record.Attributes, "risk_model_version", record.RiskModelVersion)
+	if len(record.RiskReasons) != 0 {
+		record.Attributes["risk_reasons"] = strings.Join(record.RiskReasons, ",")
+	}
+	return record
+}
+
+func setRiskAttribute(attributes map[string]string, key string, value int) {
+	if value <= 0 {
+		return
+	}
+	attributes[key] = strconv.Itoa(clampScore(value))
+}
+
+func setRiskStringAttribute(attributes map[string]string, key string, value string) {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		attributes[key] = trimmed
+	}
+}

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -313,8 +313,7 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 				evaluationErr := fmt.Errorf("reconcile finding identity for rule %q event %q: %w", result.Rule.GetId(), event.GetId(), err)
 				return nil, s.finishFailedRun(ctx, run, result.EventsEvaluated, eventsMatched, findingIDs(result.Findings), evaluationErr)
 			}
-			record = enrichFindingRisk(record, runtime, startedAt)
-			stored, err := s.store.UpsertFinding(ctx, record)
+			stored, err := s.upsertFindingWithRisk(ctx, record, runtime, startedAt)
 			if err != nil {
 				evaluationErr := fmt.Errorf("persist finding for rule %q event %q: %w", result.Rule.GetId(), event.GetId(), err)
 				return nil, s.finishFailedRun(ctx, run, result.EventsEvaluated, eventsMatched, findingIDs(result.Findings), evaluationErr)
@@ -434,8 +433,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 					}
 					break
 				}
-				record = enrichFindingRisk(record, runtime, startedAt)
-				stored, err := s.store.UpsertFinding(ctx, record)
+				stored, err := s.upsertFindingWithRisk(ctx, record, runtime, startedAt)
 				if err != nil {
 					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("persist finding for rule %q event %q: %w", state.result.Rule.GetId(), event.GetId(), err)); failErr != nil {
 						return nil, s.markRuleEvaluationsFailed(ctx, states, failErr)
@@ -1135,6 +1133,15 @@ func (s *Service) updateFindingStatusAndRisk(ctx context.Context, request ports.
 		return nil, err
 	}
 	return s.persistFindingRisk(ctx, finding, request.UpdatedAt)
+}
+
+func (s *Service) upsertFindingWithRisk(ctx context.Context, finding *ports.FindingRecord, runtime *cerebrov1.SourceRuntime, now time.Time) (*ports.FindingRecord, error) {
+	enriched := enrichFindingRisk(finding, runtime, now)
+	stored, err := s.store.UpsertFinding(ctx, enriched)
+	if err != nil {
+		return nil, err
+	}
+	return s.persistFindingRisk(ctx, stored, now)
 }
 
 func (s *Service) persistFindingRisk(ctx context.Context, finding *ports.FindingRecord, now time.Time) (*ports.FindingRecord, error) {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -96,6 +96,7 @@ type ListRequest struct {
 	EventID     string
 	PolicyID    string
 	Limit       uint32
+	Order       ports.FindingOrder
 }
 
 // EvaluateResult reports the persisted findings emitted for one runtime evaluation.
@@ -312,6 +313,7 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 				evaluationErr := fmt.Errorf("reconcile finding identity for rule %q event %q: %w", result.Rule.GetId(), event.GetId(), err)
 				return nil, s.finishFailedRun(ctx, run, result.EventsEvaluated, eventsMatched, findingIDs(result.Findings), evaluationErr)
 			}
+			record = enrichFindingRisk(record, runtime, startedAt)
 			stored, err := s.store.UpsertFinding(ctx, record)
 			if err != nil {
 				evaluationErr := fmt.Errorf("persist finding for rule %q event %q: %w", result.Rule.GetId(), event.GetId(), err)
@@ -432,6 +434,7 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 					}
 					break
 				}
+				record = enrichFindingRisk(record, runtime, startedAt)
 				stored, err := s.store.UpsertFinding(ctx, record)
 				if err != nil {
 					if failErr := s.markRuleEvaluationFailed(ctx, state, fmt.Errorf("persist finding for rule %q event %q: %w", state.result.Rule.GetId(), event.GetId(), err)); failErr != nil {
@@ -506,6 +509,7 @@ func (s *Service) ListFindings(ctx context.Context, request ListRequest) (*ListR
 		EventID:     strings.TrimSpace(request.EventID),
 		PolicyID:    strings.TrimSpace(request.PolicyID),
 		Limit:       request.Limit,
+		Order:       request.Order,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list findings for tenant %q runtime %q: %w", strings.TrimSpace(runtime.GetTenantId()), runtimeID, err)

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -662,7 +662,7 @@ func (s *Service) GetFinding(ctx context.Context, id string) (*ports.FindingReco
 	if err != nil {
 		return nil, err
 	}
-	return s.persistFindingRisk(ctx, finding, time.Now().UTC())
+	return finding, nil
 }
 
 // ResolveFinding marks one persisted finding as resolved.

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -538,7 +538,7 @@ func (s *Service) resolveRetiredOpenFindings(ctx context.Context, tenantID strin
 		if _, emitted := emittedFindingIDs[strings.TrimSpace(finding.ID)]; emitted {
 			continue
 		}
-		updated, err := s.store.UpdateFindingStatus(ctx, ports.FindingStatusUpdate{
+		updated, err := s.updateFindingStatusAndRisk(ctx, ports.FindingStatusUpdate{
 			FindingID: strings.TrimSpace(finding.ID),
 			Status:    findingStatusResolved,
 			Reason:    workflowevents.FindingStatusReasonNoLongerEmitted,
@@ -577,7 +577,7 @@ func (s *Service) resolveStaleOpenFindings(ctx context.Context, tenantID string,
 		if !findingReferencesEvaluatedEvent(finding, evaluatedEventIDs) {
 			continue
 		}
-		updated, err := s.store.UpdateFindingStatus(ctx, ports.FindingStatusUpdate{
+		updated, err := s.updateFindingStatusAndRisk(ctx, ports.FindingStatusUpdate{
 			FindingID: strings.TrimSpace(finding.ID),
 			Status:    findingStatusResolved,
 			Reason:    workflowevents.FindingStatusReasonNoLongerEmitted,
@@ -623,7 +623,7 @@ func (s *Service) resolveAllOpenFindingsForRule(ctx context.Context, tenantID st
 		if finding == nil {
 			continue
 		}
-		updated, err := s.store.UpdateFindingStatus(ctx, ports.FindingStatusUpdate{
+		updated, err := s.updateFindingStatusAndRisk(ctx, ports.FindingStatusUpdate{
 			FindingID: strings.TrimSpace(finding.ID),
 			Status:    findingStatusResolved,
 			Reason:    workflowevents.FindingStatusReasonNoLongerEmitted,
@@ -715,6 +715,10 @@ func (s *Service) SetFindingDueDate(ctx context.Context, id string, dueAt time.T
 	})
 	if err != nil {
 		return nil, fmt.Errorf("set finding %q due date: %w", findingID, err)
+	}
+	finding, err = s.persistFindingRisk(ctx, finding, time.Now().UTC())
+	if err != nil {
+		return nil, fmt.Errorf("refresh finding %q risk after due date update: %w", findingID, err)
 	}
 	return finding, nil
 }
@@ -1110,7 +1114,7 @@ func (s *Service) updateFindingStatus(ctx context.Context, id string, status str
 	if findingID == "" {
 		return nil, fmt.Errorf("%w: finding id is required", ErrInvalidRequest)
 	}
-	finding, err := s.store.UpdateFindingStatus(ctx, ports.FindingStatusUpdate{
+	finding, err := s.updateFindingStatusAndRisk(ctx, ports.FindingStatusUpdate{
 		FindingID: findingID,
 		Status:    strings.TrimSpace(status),
 		Reason:    strings.TrimSpace(reason),
@@ -1123,6 +1127,29 @@ func (s *Service) updateFindingStatus(ctx context.Context, id string, status str
 		return nil, fmt.Errorf("record finding %q status workflow: %w", findingID, err)
 	}
 	return finding, nil
+}
+
+func (s *Service) updateFindingStatusAndRisk(ctx context.Context, request ports.FindingStatusUpdate) (*ports.FindingRecord, error) {
+	finding, err := s.store.UpdateFindingStatus(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	return s.persistFindingRisk(ctx, finding, request.UpdatedAt)
+}
+
+func (s *Service) persistFindingRisk(ctx context.Context, finding *ports.FindingRecord, now time.Time) (*ports.FindingRecord, error) {
+	if finding == nil {
+		return nil, errors.New("finding is required")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	recomputed := recomputeFindingRisk(finding, now)
+	stored, err := s.store.UpsertFinding(ctx, recomputed)
+	if err != nil {
+		return nil, err
+	}
+	return stored, nil
 }
 
 func newFindingEvaluationRun(runtimeID string, ruleID string, eventLimit uint32, startedAt time.Time) *cerebrov1.FindingEvaluationRun {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -680,6 +680,9 @@ func (s *Service) BackfillFindingRisk(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	riskUpdater, _ := s.store.(interface {
+		UpdateFindingRisk(context.Context, ports.FindingRiskUpdate) (*ports.FindingRecord, error)
+	})
 	revisionTime := time.Now().UTC().Format(time.RFC3339Nano)
 	for _, finding := range updated {
 		if finding == nil {
@@ -688,6 +691,18 @@ func (s *Service) BackfillFindingRisk(ctx context.Context) error {
 		revision := fmt.Sprintf("startup-risk-backfill|%s|%s", revisionTime, strings.TrimSpace(finding.ID))
 		if err := s.projectFindingAnchorRevision(ctx, finding, revision); err != nil {
 			return fmt.Errorf("project finding %q backfilled risk: %w", finding.ID, err)
+		}
+		if riskUpdater != nil {
+			_, err := riskUpdater.UpdateFindingRisk(ctx, ports.FindingRiskUpdate{
+				FindingID:   finding.ID,
+				FindingRisk: finding.FindingRisk,
+				Attributes: map[string]string{
+					FindingRiskGraphProjectedModelVersionAttribute: finding.RiskModelVersion,
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("mark finding %q backfilled risk projected: %w", finding.ID, err)
+			}
 		}
 	}
 	return nil

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -718,6 +718,9 @@ func (s *Service) SetFindingDueDate(ctx context.Context, id string, dueAt time.T
 	if err != nil {
 		return nil, fmt.Errorf("refresh finding %q risk after due date update: %w", findingID, err)
 	}
+	if err := s.projectFindingAnchor(ctx, finding); err != nil {
+		return nil, fmt.Errorf("project finding %q due date risk update: %w", findingID, err)
+	}
 	return finding, nil
 }
 

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -671,12 +671,13 @@ func (s *Service) BackfillFindingRisk(ctx context.Context) error {
 		return ErrRuntimeUnavailable
 	}
 	backfiller, ok := s.store.(interface {
-		BackfillFindingRisk(context.Context) ([]*ports.FindingRecord, error)
+		BackfillFindingRisk(context.Context, bool) ([]*ports.FindingRecord, error)
 	})
 	if !ok {
 		return nil
 	}
-	updated, err := backfiller.BackfillFindingRisk(ctx)
+	includeUnprojected := s.graph != nil
+	updated, err := backfiller.BackfillFindingRisk(ctx, includeUnprojected)
 	if err != nil {
 		return err
 	}
@@ -692,7 +693,7 @@ func (s *Service) BackfillFindingRisk(ctx context.Context) error {
 		if err := s.projectFindingAnchorRevision(ctx, finding, revision); err != nil {
 			return fmt.Errorf("project finding %q backfilled risk: %w", finding.ID, err)
 		}
-		if riskUpdater != nil {
+		if includeUnprojected && riskUpdater != nil {
 			_, err := riskUpdater.UpdateFindingRisk(ctx, ports.FindingRiskUpdate{
 				FindingID:   finding.ID,
 				FindingRisk: finding.FindingRisk,

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -662,7 +662,7 @@ func (s *Service) GetFinding(ctx context.Context, id string) (*ports.FindingReco
 	if err != nil {
 		return nil, err
 	}
-	return finding, nil
+	return s.persistFindingRisk(ctx, finding, time.Now().UTC())
 }
 
 // ResolveFinding marks one persisted finding as resolved.
@@ -718,7 +718,7 @@ func (s *Service) SetFindingDueDate(ctx context.Context, id string, dueAt time.T
 	if err != nil {
 		return nil, fmt.Errorf("refresh finding %q risk after due date update: %w", findingID, err)
 	}
-	if err := s.projectFindingAnchor(ctx, finding); err != nil {
+	if err := s.projectFindingAnchorRevision(ctx, finding, "due-risk-refresh|"+time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
 		return nil, fmt.Errorf("project finding %q due date risk update: %w", findingID, err)
 	}
 	return finding, nil

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -665,6 +665,34 @@ func (s *Service) GetFinding(ctx context.Context, id string) (*ports.FindingReco
 	return finding, nil
 }
 
+// BackfillFindingRisk refreshes startup-migrated risk fields and graph projections.
+func (s *Service) BackfillFindingRisk(ctx context.Context) error {
+	if s == nil || s.store == nil {
+		return ErrRuntimeUnavailable
+	}
+	backfiller, ok := s.store.(interface {
+		BackfillFindingRisk(context.Context) ([]*ports.FindingRecord, error)
+	})
+	if !ok {
+		return nil
+	}
+	updated, err := backfiller.BackfillFindingRisk(ctx)
+	if err != nil {
+		return err
+	}
+	revisionTime := time.Now().UTC().Format(time.RFC3339Nano)
+	for _, finding := range updated {
+		if finding == nil {
+			continue
+		}
+		revision := fmt.Sprintf("startup-risk-backfill|%s|%s", revisionTime, strings.TrimSpace(finding.ID))
+		if err := s.projectFindingAnchorRevision(ctx, finding, revision); err != nil {
+			return fmt.Errorf("project finding %q backfilled risk: %w", finding.ID, err)
+		}
+	}
+	return nil
+}
+
 // ResolveFinding marks one persisted finding as resolved.
 func (s *Service) ResolveFinding(ctx context.Context, id string, reason string) (*ports.FindingRecord, error) {
 	return s.updateFindingStatus(ctx, id, findingStatusResolved, reason)

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -681,9 +681,6 @@ func (s *Service) BackfillFindingRisk(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	riskUpdater, _ := s.store.(interface {
-		UpdateFindingRisk(context.Context, ports.FindingRiskUpdate) (*ports.FindingRecord, error)
-	})
 	revisionTime := time.Now().UTC().Format(time.RFC3339Nano)
 	for _, finding := range updated {
 		if finding == nil {
@@ -693,15 +690,8 @@ func (s *Service) BackfillFindingRisk(ctx context.Context) error {
 		if err := s.projectFindingAnchorRevision(ctx, finding, revision); err != nil {
 			return fmt.Errorf("project finding %q backfilled risk: %w", finding.ID, err)
 		}
-		if includeUnprojected && riskUpdater != nil {
-			_, err := riskUpdater.UpdateFindingRisk(ctx, ports.FindingRiskUpdate{
-				FindingID:   finding.ID,
-				FindingRisk: finding.FindingRisk,
-				Attributes: map[string]string{
-					FindingRiskGraphProjectedModelVersionAttribute: finding.RiskModelVersion,
-				},
-			})
-			if err != nil {
+		if includeUnprojected {
+			if err := s.markFindingRiskProjected(ctx, finding); err != nil {
 				return fmt.Errorf("mark finding %q backfilled risk projected: %w", finding.ID, err)
 			}
 		}
@@ -764,6 +754,9 @@ func (s *Service) SetFindingDueDate(ctx context.Context, id string, dueAt time.T
 	}
 	if err := s.projectFindingAnchorRevision(ctx, finding, "due-risk-refresh|"+time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
 		return nil, fmt.Errorf("project finding %q due date risk update: %w", findingID, err)
+	}
+	if err := s.markFindingRiskProjected(ctx, finding); err != nil {
+		return nil, fmt.Errorf("mark finding %q due date risk projected: %w", findingID, err)
 	}
 	return finding, nil
 }

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -1158,6 +1158,15 @@ func (s *Service) persistFindingRisk(ctx context.Context, finding *ports.Finding
 		now = time.Now().UTC()
 	}
 	recomputed := recomputeFindingRisk(finding, now)
+	if updater, ok := s.store.(interface {
+		UpdateFindingRisk(context.Context, ports.FindingRiskUpdate) (*ports.FindingRecord, error)
+	}); ok {
+		return updater.UpdateFindingRisk(ctx, ports.FindingRiskUpdate{
+			FindingID:   strings.TrimSpace(recomputed.ID),
+			FindingRisk: recomputed.FindingRisk,
+			Attributes:  findingRiskAttributes(recomputed),
+		})
+	}
 	stored, err := s.store.UpsertFinding(ctx, recomputed)
 	if err != nil {
 		return nil, err

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -1141,6 +1141,9 @@ func (s *Service) upsertFindingWithRisk(ctx context.Context, finding *ports.Find
 	if err != nil {
 		return nil, err
 	}
+	if stored != nil {
+		stored.GraphEvidenceRows = append([]*cerebrov1.GraphEvidenceRow(nil), enriched.GraphEvidenceRows...)
+	}
 	return s.persistFindingRisk(ctx, stored, now)
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2941,6 +2941,17 @@ func TestSetFindingDueDateProjectsUpdatedRisk(t *testing.T) {
 	if !strings.Contains(graphFinding.Attributes["risk_reasons"], "overdue") {
 		t.Fatalf("projected risk_reasons = %q, want overdue", graphFinding.Attributes["risk_reasons"])
 	}
+	firstEventID := appendLog.events[0].GetId()
+	_, err = service.SetFindingDueDate(context.Background(), "finding-1", time.Now().UTC().Add(-2*time.Hour))
+	if err != nil {
+		t.Fatalf("SetFindingDueDate(second) error = %v", err)
+	}
+	if got := len(appendLog.events); got != 2 {
+		t.Fatalf("len(appended events) = %d, want 2", got)
+	}
+	if secondEventID := appendLog.events[1].GetId(); secondEventID == firstEventID {
+		t.Fatalf("SetFindingDueDate() reused finding_record event id %q, want non-deduplicated refresh event", secondEventID)
+	}
 }
 
 func TestFindingWorkflowSnapshotDoesNotMergeFreshReasonsWithStoredRisk(t *testing.T) {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -81,6 +81,7 @@ type stubFindingStore struct {
 	evidence                  map[string]*cerebrov1.FindingEvidence
 	evidenceList              ports.ListFindingEvidenceRequest
 	dropReturnedGraphEvidence bool
+	upsertCount               int
 }
 
 func (s *stubFindingStore) Ping(context.Context) error { return nil }
@@ -89,6 +90,7 @@ func (s *stubFindingStore) UpsertFinding(_ context.Context, finding *ports.Findi
 	if finding == nil {
 		return nil, errors.New("finding is required")
 	}
+	s.upsertCount++
 	if s.findings == nil {
 		s.findings = make(map[string]*ports.FindingRecord)
 	}
@@ -108,6 +110,23 @@ func (s *stubFindingStore) UpsertFinding(_ context.Context, finding *ports.Findi
 		returned.GraphEvidenceRows = nil
 	}
 	return returned, nil
+}
+
+func (s *stubFindingStore) UpdateFindingRisk(_ context.Context, request ports.FindingRiskUpdate) (*ports.FindingRecord, error) {
+	finding, ok := s.findings[strings.TrimSpace(request.FindingID)]
+	if !ok {
+		return nil, ports.ErrFindingNotFound
+	}
+	updated := cloneFinding(finding)
+	updated.FindingRisk = request.FindingRisk
+	if updated.Attributes == nil {
+		updated.Attributes = map[string]string{}
+	}
+	for key, value := range request.Attributes {
+		updated.Attributes[key] = value
+	}
+	s.findings[updated.ID] = updated
+	return cloneFinding(updated), nil
 }
 
 func (s *stubFindingStore) GetFinding(_ context.Context, id string) (*ports.FindingRecord, error) {
@@ -2844,6 +2863,41 @@ func TestSetFindingDueDateRecomputesPersistedRisk(t *testing.T) {
 	}
 	if finding.RiskScore <= 1 {
 		t.Fatalf("SetFindingDueDate().RiskScore = %d, want recomputed score > 1", finding.RiskScore)
+	}
+}
+
+func TestPersistFindingRiskUsesRiskOnlyUpdate(t *testing.T) {
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:         "finding-1",
+				Title:      "Current title",
+				Summary:    "Current summary",
+				Status:     "open",
+				Severity:   "LOW",
+				Attributes: map[string]string{"owner": "secops"},
+			},
+		},
+	}
+	service := New(nil, nil, store, store, store, store)
+	staleSnapshot := cloneFinding(store.findings["finding-1"])
+	staleSnapshot.Title = "Stale title"
+	staleSnapshot.Summary = "Stale summary"
+	stored, err := service.persistFindingRisk(context.Background(), staleSnapshot, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("persistFindingRisk() error = %v", err)
+	}
+	if store.upsertCount != 0 {
+		t.Fatalf("persistFindingRisk() called UpsertFinding %d times, want risk-only update", store.upsertCount)
+	}
+	if got := stored.Summary; got != "Current summary" {
+		t.Fatalf("persistFindingRisk().Summary = %q, want current summary preserved", got)
+	}
+	if got := stored.Attributes["owner"]; got != "secops" {
+		t.Fatalf("persistFindingRisk().Attributes[owner] = %q, want preserved", got)
+	}
+	if stored.RiskScore == 0 {
+		t.Fatal("persistFindingRisk().RiskScore = 0, want refreshed risk")
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2841,6 +2841,56 @@ func TestSetFindingDueDateRecomputesPersistedRisk(t *testing.T) {
 	}
 }
 
+func TestUpsertFindingWithRiskRecomputesAfterWorkflowPreservation(t *testing.T) {
+	dueAt := time.Now().UTC().Add(-time.Hour)
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:          "finding-1",
+				Fingerprint: "fingerprint-1",
+				TenantID:    "tenant-a",
+				RuntimeID:   "runtime-audit",
+				RuleID:      "rule-1",
+				Title:       "Existing triaged finding",
+				Severity:    "LOW",
+				Status:      "resolved",
+				Summary:     "resolved finding",
+				FindingWorkflow: ports.FindingWorkflow{
+					DueAt:           dueAt,
+					StatusReason:    "triaged",
+					StatusUpdatedAt: dueAt,
+				},
+			},
+		},
+	}
+	service := New(nil, nil, store, store, store, store)
+	emitted := &ports.FindingRecord{
+		ID:          "finding-1",
+		Fingerprint: "fingerprint-1",
+		TenantID:    "tenant-a",
+		RuntimeID:   "runtime-audit",
+		RuleID:      "rule-1",
+		Title:       "Existing triaged finding",
+		Severity:    "LOW",
+		Status:      "open",
+		Summary:     "reemitted finding",
+		Attributes:  map[string]string{},
+	}
+	stored, err := service.upsertFindingWithRisk(context.Background(), emitted, nil, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("upsertFindingWithRisk() error = %v", err)
+	}
+	if got := stored.Status; got != "resolved" {
+		t.Fatalf("upsertFindingWithRisk().Status = %q, want preserved resolved", got)
+	}
+	if !slices.Contains(stored.RiskReasons, "overdue") {
+		t.Fatalf("upsertFindingWithRisk().RiskReasons = %#v, want overdue from preserved due date", stored.RiskReasons)
+	}
+	if slices.Contains(stored.RiskReasons, "active") {
+		t.Fatalf("upsertFindingWithRisk().RiskReasons = %#v, want no active reason after preserved resolution", stored.RiskReasons)
+	}
+}
+
 func TestAddFindingNoteUpdatesPersistedWorkflow(t *testing.T) {
 	store := &stubFindingStore{
 		findings: map[string]*ports.FindingRecord{

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -3010,6 +3010,31 @@ func TestBackfillFindingRiskDoesNotMarkProjectedWithoutGraph(t *testing.T) {
 	}
 }
 
+func TestProjectFindingAnchorMarksRiskProjected(t *testing.T) {
+	finding := &ports.FindingRecord{
+		ID:        "finding-1",
+		TenantID:  "tenant-a",
+		RuntimeID: "runtime-audit",
+		RuleID:    "rule-1",
+		Title:     "Projected risk finding",
+		Status:    "open",
+		Severity:  "HIGH",
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        74,
+			RiskModelVersion: defaultFindingRiskModelVersion,
+		},
+		LastObservedAt: time.Now().UTC(),
+	}
+	store := &stubFindingStore{findings: map[string]*ports.FindingRecord{finding.ID: cloneFinding(finding)}}
+	service := New(nil, nil, store, store, store, store).WithGraphStore(&stubGraphStore{})
+	if err := service.projectFindingAnchor(context.Background(), finding); err != nil {
+		t.Fatalf("projectFindingAnchor() error = %v", err)
+	}
+	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != defaultFindingRiskModelVersion {
+		t.Fatalf("projection marker = %q, want %q", got, defaultFindingRiskModelVersion)
+	}
+}
+
 func TestSetFindingDueDateProjectsUpdatedRisk(t *testing.T) {
 	store := &stubFindingStore{
 		findings: map[string]*ports.FindingRecord{

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -65,20 +65,21 @@ func (s *recordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnv
 }
 
 type stubFindingStore struct {
-	findings             map[string]*ports.FindingRecord
-	request              ports.ListFindingsRequest
-	listFindingsRequests []ports.ListFindingsRequest
-	listFindingsErr      error
-	claims               map[string]*ports.ClaimRecord
-	claimListRequest     ports.ListClaimsRequest
-	runs                 map[string]*cerebrov1.FindingEvaluationRun
-	runList              ports.ListFindingEvaluationRunsRequest
-	runPutCount          int
-	failRunPutOn         int
-	failRunPutErr        error
-	failRunPutByCall     map[int]error
-	evidence             map[string]*cerebrov1.FindingEvidence
-	evidenceList         ports.ListFindingEvidenceRequest
+	findings                  map[string]*ports.FindingRecord
+	request                   ports.ListFindingsRequest
+	listFindingsRequests      []ports.ListFindingsRequest
+	listFindingsErr           error
+	claims                    map[string]*ports.ClaimRecord
+	claimListRequest          ports.ListClaimsRequest
+	runs                      map[string]*cerebrov1.FindingEvaluationRun
+	runList                   ports.ListFindingEvaluationRunsRequest
+	runPutCount               int
+	failRunPutOn              int
+	failRunPutErr             error
+	failRunPutByCall          map[int]error
+	evidence                  map[string]*cerebrov1.FindingEvidence
+	evidenceList              ports.ListFindingEvidenceRequest
+	dropReturnedGraphEvidence bool
 }
 
 func (s *stubFindingStore) Ping(context.Context) error { return nil }
@@ -101,7 +102,11 @@ func (s *stubFindingStore) UpsertFinding(_ context.Context, finding *ports.Findi
 		}
 	}
 	s.findings[cloned.ID] = cloned
-	return cloneFinding(cloned), nil
+	returned := cloneFinding(cloned)
+	if s.dropReturnedGraphEvidence {
+		returned.GraphEvidenceRows = nil
+	}
+	return returned, nil
 }
 
 func (s *stubFindingStore) GetFinding(_ context.Context, id string) (*ports.FindingRecord, error) {
@@ -2888,6 +2893,33 @@ func TestUpsertFindingWithRiskRecomputesAfterWorkflowPreservation(t *testing.T) 
 	}
 	if slices.Contains(stored.RiskReasons, "active") {
 		t.Fatalf("upsertFindingWithRisk().RiskReasons = %#v, want no active reason after preserved resolution", stored.RiskReasons)
+	}
+}
+
+func TestUpsertFindingWithRiskPreservesGraphEvidenceDuringRecompute(t *testing.T) {
+	store := &stubFindingStore{dropReturnedGraphEvidence: true}
+	service := New(nil, nil, store, store, store, store)
+	emitted := &ports.FindingRecord{
+		ID:          "finding-graph",
+		Fingerprint: "fingerprint-graph",
+		TenantID:    "tenant-a",
+		RuntimeID:   "runtime-graph",
+		RuleID:      "rule-graph",
+		Title:       "Graph-backed finding",
+		Severity:    "MEDIUM",
+		Status:      "open",
+		Summary:     "graph finding",
+		Attributes:  map[string]string{},
+		GraphEvidenceRows: []*cerebrov1.GraphEvidenceRow{
+			newGraphEvidenceRow("identity_path", map[string]string{"label": "path"}),
+		},
+	}
+	stored, err := service.upsertFindingWithRisk(context.Background(), emitted, nil, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("upsertFindingWithRisk() error = %v", err)
+	}
+	if !slices.Contains(stored.RiskReasons, "graph_evidence") {
+		t.Fatalf("upsertFindingWithRisk().RiskReasons = %#v, want graph_evidence", stored.RiskReasons)
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2659,6 +2659,52 @@ func TestResolveFindingUpdatesPersistedWorkflow(t *testing.T) {
 	}
 }
 
+func TestResolveFindingRecomputesPersistedRisk(t *testing.T) {
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:       "finding-1",
+				Status:   "open",
+				Severity: "LOW",
+				FindingRisk: ports.FindingRisk{
+					RiskScore:        99,
+					LikelihoodScore:  99,
+					ImpactScore:      99,
+					ConfidenceScore:  99,
+					LikelihoodLevel:  "critical",
+					ImpactLevel:      "critical",
+					RiskReasons:      []string{"active", "stale_reason"},
+					RiskModelVersion: defaultFindingRiskModelVersion,
+				},
+				Attributes:        map[string]string{"risk_score": "99", "risk_reasons": "active,stale_reason"},
+				FirstObservedAt:   time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+				LastObservedAt:    time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+				ResourceURNs:      []string{"urn:cerebro:test:resource:one"},
+				EventIDs:          []string{"event-1"},
+				ObservedPolicyIDs: []string{"policy-1"},
+			},
+		},
+	}
+	service := New(nil, nil, store, store, store, store)
+	finding, err := service.ResolveFinding(context.Background(), "finding-1", "verified remediation")
+	if err != nil {
+		t.Fatalf("ResolveFinding() error = %v", err)
+	}
+	if got := finding.Status; got != "resolved" {
+		t.Fatalf("ResolveFinding().Status = %q, want resolved", got)
+	}
+	if finding.RiskScore == 99 || finding.LikelihoodScore == 99 || finding.ImpactScore == 99 {
+		t.Fatalf("ResolveFinding() kept stale risk = score %d likelihood %d impact %d", finding.RiskScore, finding.LikelihoodScore, finding.ImpactScore)
+	}
+	if slices.Contains(finding.RiskReasons, "active") || slices.Contains(finding.RiskReasons, "stale_reason") {
+		t.Fatalf("ResolveFinding().RiskReasons = %#v, want stale reasons removed", finding.RiskReasons)
+	}
+	stored := store.findings["finding-1"]
+	if stored == nil || stored.RiskScore != finding.RiskScore {
+		t.Fatalf("stored risk score = %#v, want recomputed score %d", stored, finding.RiskScore)
+	}
+}
+
 func TestResolveFindingBridgesDecisionAndOutcomeWhenGraphConfigured(t *testing.T) {
 	store := &stubFindingStore{
 		findings: map[string]*ports.FindingRecord{
@@ -2757,6 +2803,41 @@ func TestSetFindingDueDateUpdatesPersistedWorkflow(t *testing.T) {
 	}
 	if got := finding.DueAt; !got.Equal(dueAt) {
 		t.Fatalf("SetFindingDueDate().DueAt = %v, want %v", got, dueAt)
+	}
+}
+
+func TestSetFindingDueDateRecomputesPersistedRisk(t *testing.T) {
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:       "finding-1",
+				Status:   "open",
+				Severity: "MEDIUM",
+				FindingRisk: ports.FindingRisk{
+					RiskScore:        1,
+					LikelihoodScore:  1,
+					ImpactScore:      1,
+					RiskReasons:      []string{"stale_reason"},
+					RiskModelVersion: defaultFindingRiskModelVersion,
+				},
+				Attributes: map[string]string{"risk_score": "1", "risk_reasons": "stale_reason"},
+			},
+		},
+	}
+	service := New(nil, nil, store, store, store, store)
+	dueAt := time.Now().UTC().Add(-time.Hour)
+	finding, err := service.SetFindingDueDate(context.Background(), "finding-1", dueAt)
+	if err != nil {
+		t.Fatalf("SetFindingDueDate() error = %v", err)
+	}
+	if !slices.Contains(finding.RiskReasons, "overdue") {
+		t.Fatalf("SetFindingDueDate().RiskReasons = %#v, want overdue", finding.RiskReasons)
+	}
+	if slices.Contains(finding.RiskReasons, "stale_reason") {
+		t.Fatalf("SetFindingDueDate().RiskReasons = %#v, want stale reason removed", finding.RiskReasons)
+	}
+	if finding.RiskScore <= 1 {
+		t.Fatalf("SetFindingDueDate().RiskScore = %d, want recomputed score > 1", finding.RiskScore)
 	}
 }
 
@@ -3274,15 +3355,25 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 		attributes[key] = value
 	}
 	return &ports.FindingRecord{
-		ID:                finding.ID,
-		Fingerprint:       finding.Fingerprint,
-		TenantID:          finding.TenantID,
-		RuntimeID:         finding.RuntimeID,
-		RuleID:            finding.RuleID,
-		Title:             finding.Title,
-		Severity:          finding.Severity,
-		Status:            finding.Status,
-		Summary:           finding.Summary,
+		ID:          finding.ID,
+		Fingerprint: finding.Fingerprint,
+		TenantID:    finding.TenantID,
+		RuntimeID:   finding.RuntimeID,
+		RuleID:      finding.RuleID,
+		Title:       finding.Title,
+		Severity:    finding.Severity,
+		Status:      finding.Status,
+		Summary:     finding.Summary,
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        finding.RiskScore,
+			LikelihoodScore:  finding.LikelihoodScore,
+			ImpactScore:      finding.ImpactScore,
+			ConfidenceScore:  finding.ConfidenceScore,
+			LikelihoodLevel:  finding.LikelihoodLevel,
+			ImpactLevel:      finding.ImpactLevel,
+			RiskReasons:      append([]string(nil), finding.RiskReasons...),
+			RiskModelVersion: finding.RiskModelVersion,
+		},
 		ResourceURNs:      resourceURNs,
 		EventIDs:          eventIDs,
 		ObservedPolicyIDs: observedPolicyIDs,

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2917,7 +2917,8 @@ func TestSetFindingDueDateProjectsUpdatedRisk(t *testing.T) {
 					RiskReasons:      []string{"stale_reason"},
 					RiskModelVersion: defaultFindingRiskModelVersion,
 				},
-				Attributes: map[string]string{"risk_score": "1", "risk_reasons": "stale_reason"},
+				Attributes:     map[string]string{"risk_score": "1", "risk_reasons": "stale_reason"},
+				LastObservedAt: time.Now().UTC().Add(-14 * 24 * time.Hour),
 			},
 		},
 	}
@@ -2940,6 +2941,9 @@ func TestSetFindingDueDateProjectsUpdatedRisk(t *testing.T) {
 	}
 	if !strings.Contains(graphFinding.Attributes["risk_reasons"], "overdue") {
 		t.Fatalf("projected risk_reasons = %q, want overdue", graphFinding.Attributes["risk_reasons"])
+	}
+	if eventTime := appendLog.events[0].GetOccurredAt().AsTime(); time.Since(eventTime) > time.Minute {
+		t.Fatalf("revision event occurred_at = %s, want refresh time", eventTime.Format(time.RFC3339Nano))
 	}
 	firstEventID := appendLog.events[0].GetId()
 	_, err = service.SetFindingDueDate(context.Background(), "finding-1", time.Now().UTC().Add(-2*time.Hour))

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2843,6 +2844,48 @@ func TestSetFindingDueDateRecomputesPersistedRisk(t *testing.T) {
 	}
 	if finding.RiskScore <= 1 {
 		t.Fatalf("SetFindingDueDate().RiskScore = %d, want recomputed score > 1", finding.RiskScore)
+	}
+}
+
+func TestSetFindingDueDateProjectsUpdatedRisk(t *testing.T) {
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:        "finding-1",
+				TenantID:  "tenant-a",
+				RuntimeID: "runtime-audit",
+				RuleID:    "rule-1",
+				Title:     "Due date finding",
+				Status:    "open",
+				Severity:  "MEDIUM",
+				FindingRisk: ports.FindingRisk{
+					RiskScore:        1,
+					RiskReasons:      []string{"stale_reason"},
+					RiskModelVersion: defaultFindingRiskModelVersion,
+				},
+				Attributes: map[string]string{"risk_score": "1", "risk_reasons": "stale_reason"},
+			},
+		},
+	}
+	graphStore := &stubGraphStore{}
+	appendLog := &recordingAppendLog{}
+	service := New(nil, nil, store, store, store, store).WithGraphStore(graphStore).WithAppendLog(appendLog)
+	finding, err := service.SetFindingDueDate(context.Background(), "finding-1", time.Now().UTC().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("SetFindingDueDate() error = %v", err)
+	}
+	if len(appendLog.events) == 0 {
+		t.Fatal("SetFindingDueDate() appended no workflow event, want finding anchor refresh")
+	}
+	graphFinding := graphStore.entities["urn:cerebro:tenant-a:finding:finding-1"]
+	if graphFinding == nil {
+		t.Fatal("SetFindingDueDate() did not project finding anchor")
+	}
+	if got := graphFinding.Attributes["risk_score"]; got != strconv.Itoa(finding.RiskScore) {
+		t.Fatalf("projected risk_score = %q, want %d", got, finding.RiskScore)
+	}
+	if !strings.Contains(graphFinding.Attributes["risk_reasons"], "overdue") {
+		t.Fatalf("projected risk_reasons = %q, want overdue", graphFinding.Attributes["risk_reasons"])
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2915,29 +2915,35 @@ func TestPersistFindingRiskUsesRiskOnlyUpdate(t *testing.T) {
 }
 
 func TestBackfillFindingRiskProjectsUpdatedFindings(t *testing.T) {
-	store := &stubFindingStore{
-		backfillRiskResults: []*ports.FindingRecord{
-			{
-				ID:        "finding-1",
-				TenantID:  "tenant-a",
-				RuntimeID: "runtime-audit",
-				RuleID:    "rule-1",
-				Title:     "Backfilled risk finding",
-				Status:    "open",
-				Severity:  "HIGH",
-				FindingRisk: ports.FindingRisk{
-					RiskScore:        83,
-					LikelihoodScore:  80,
-					ImpactScore:      86,
-					ConfidenceScore:  70,
-					LikelihoodLevel:  "high",
-					ImpactLevel:      "critical",
-					RiskReasons:      []string{"external_exposure"},
-					RiskModelVersion: defaultFindingRiskModelVersion,
-				},
-				LastObservedAt: time.Now().UTC().Add(-7 * 24 * time.Hour),
-			},
+	openFinding := &ports.FindingRecord{
+		ID:        "finding-1",
+		TenantID:  "tenant-a",
+		RuntimeID: "runtime-audit",
+		RuleID:    "rule-1",
+		Title:     "Backfilled risk finding",
+		Status:    "open",
+		Severity:  "HIGH",
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        83,
+			LikelihoodScore:  80,
+			ImpactScore:      86,
+			ConfidenceScore:  70,
+			LikelihoodLevel:  "high",
+			ImpactLevel:      "critical",
+			RiskReasons:      []string{"external_exposure"},
+			RiskModelVersion: defaultFindingRiskModelVersion,
 		},
+		LastObservedAt: time.Now().UTC().Add(-7 * 24 * time.Hour),
+	}
+	closedFinding := cloneFinding(openFinding)
+	closedFinding.ID = "finding-closed"
+	closedFinding.Status = findingStatusResolved
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{
+			openFinding.ID:   cloneFinding(openFinding),
+			closedFinding.ID: cloneFinding(closedFinding),
+		},
+		backfillRiskResults: []*ports.FindingRecord{openFinding, closedFinding},
 	}
 	graphStore := &stubGraphStore{}
 	appendLog := &recordingAppendLog{}
@@ -2952,11 +2958,20 @@ func TestBackfillFindingRiskProjectsUpdatedFindings(t *testing.T) {
 	if got := graphFinding.Attributes["risk_score"]; got != "83" {
 		t.Fatalf("projected risk_score = %q, want 83", got)
 	}
-	if got := len(appendLog.events); got != 1 {
-		t.Fatalf("len(appended events) = %d, want 1", got)
+	if closed := graphStore.entities["urn:cerebro:tenant-a:finding:finding-closed"]; closed == nil || closed.Attributes["risk_score"] != "83" {
+		t.Fatalf("closed projected finding = %#v, want risk_score 83", closed)
+	}
+	if got := len(appendLog.events); got != 2 {
+		t.Fatalf("len(appended events) = %d, want 2", got)
 	}
 	if eventTime := appendLog.events[0].GetOccurredAt().AsTime(); time.Since(eventTime) > time.Minute {
 		t.Fatalf("backfill event occurred_at = %s, want startup time", eventTime.Format(time.RFC3339Nano))
+	}
+	if got := appendLog.events[1].GetKind(); got != workflowevents.EventKindFindingStatusChanged {
+		t.Fatalf("closed finding event kind = %q, want status_changed", got)
+	}
+	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != defaultFindingRiskModelVersion {
+		t.Fatalf("projection marker = %q, want %q", got, defaultFindingRiskModelVersion)
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -82,6 +82,8 @@ type stubFindingStore struct {
 	evidenceList              ports.ListFindingEvidenceRequest
 	dropReturnedGraphEvidence bool
 	upsertCount               int
+	backfillRiskResults       []*ports.FindingRecord
+	backfillRiskErr           error
 }
 
 func (s *stubFindingStore) Ping(context.Context) error { return nil }
@@ -127,6 +129,17 @@ func (s *stubFindingStore) UpdateFindingRisk(_ context.Context, request ports.Fi
 	}
 	s.findings[updated.ID] = updated
 	return cloneFinding(updated), nil
+}
+
+func (s *stubFindingStore) BackfillFindingRisk(context.Context) ([]*ports.FindingRecord, error) {
+	if s.backfillRiskErr != nil {
+		return nil, s.backfillRiskErr
+	}
+	results := make([]*ports.FindingRecord, 0, len(s.backfillRiskResults))
+	for _, finding := range s.backfillRiskResults {
+		results = append(results, cloneFinding(finding))
+	}
+	return results, nil
 }
 
 func (s *stubFindingStore) GetFinding(_ context.Context, id string) (*ports.FindingRecord, error) {
@@ -2898,6 +2911,52 @@ func TestPersistFindingRiskUsesRiskOnlyUpdate(t *testing.T) {
 	}
 	if stored.RiskScore == 0 {
 		t.Fatal("persistFindingRisk().RiskScore = 0, want refreshed risk")
+	}
+}
+
+func TestBackfillFindingRiskProjectsUpdatedFindings(t *testing.T) {
+	store := &stubFindingStore{
+		backfillRiskResults: []*ports.FindingRecord{
+			{
+				ID:        "finding-1",
+				TenantID:  "tenant-a",
+				RuntimeID: "runtime-audit",
+				RuleID:    "rule-1",
+				Title:     "Backfilled risk finding",
+				Status:    "open",
+				Severity:  "HIGH",
+				FindingRisk: ports.FindingRisk{
+					RiskScore:        83,
+					LikelihoodScore:  80,
+					ImpactScore:      86,
+					ConfidenceScore:  70,
+					LikelihoodLevel:  "high",
+					ImpactLevel:      "critical",
+					RiskReasons:      []string{"external_exposure"},
+					RiskModelVersion: defaultFindingRiskModelVersion,
+				},
+				LastObservedAt: time.Now().UTC().Add(-7 * 24 * time.Hour),
+			},
+		},
+	}
+	graphStore := &stubGraphStore{}
+	appendLog := &recordingAppendLog{}
+	service := New(nil, nil, store, store, store, store).WithGraphStore(graphStore).WithAppendLog(appendLog)
+	if err := service.BackfillFindingRisk(context.Background()); err != nil {
+		t.Fatalf("BackfillFindingRisk() error = %v", err)
+	}
+	graphFinding := graphStore.entities["urn:cerebro:tenant-a:finding:finding-1"]
+	if graphFinding == nil {
+		t.Fatal("BackfillFindingRisk() did not project finding anchor")
+	}
+	if got := graphFinding.Attributes["risk_score"]; got != "83" {
+		t.Fatalf("projected risk_score = %q, want 83", got)
+	}
+	if got := len(appendLog.events); got != 1 {
+		t.Fatalf("len(appended events) = %d, want 1", got)
+	}
+	if eventTime := appendLog.events[0].GetOccurredAt().AsTime(); time.Since(eventTime) > time.Minute {
+		t.Fatalf("backfill event occurred_at = %s, want startup time", eventTime.Format(time.RFC3339Nano))
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2943,6 +2943,38 @@ func TestSetFindingDueDateProjectsUpdatedRisk(t *testing.T) {
 	}
 }
 
+func TestFindingWorkflowSnapshotDoesNotMergeFreshReasonsWithStoredRisk(t *testing.T) {
+	dueAt := time.Now().UTC().Add(-time.Hour)
+	snapshot := findingWorkflowSnapshot(&ports.FindingRecord{
+		ID:       "finding-1",
+		TenantID: "tenant-a",
+		Status:   "open",
+		Severity: "LOW",
+		FindingWorkflow: ports.FindingWorkflow{
+			DueAt: dueAt,
+		},
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        20,
+			LikelihoodScore:  20,
+			ImpactScore:      20,
+			ConfidenceScore:  70,
+			LikelihoodLevel:  "low",
+			ImpactLevel:      "low",
+			RiskReasons:      []string{"stored_reason"},
+			RiskModelVersion: defaultFindingRiskModelVersion,
+		},
+	}, "tenant-a", "runtime-audit")
+	if snapshot.RiskScore != 20 || snapshot.ImpactScore != 20 {
+		t.Fatalf("findingWorkflowSnapshot() risk = score %d impact %d, want stored values", snapshot.RiskScore, snapshot.ImpactScore)
+	}
+	if slices.Contains(snapshot.RiskReasons, "overdue") {
+		t.Fatalf("findingWorkflowSnapshot().RiskReasons = %#v, want no mixed fresh overdue reason", snapshot.RiskReasons)
+	}
+	if !slices.Contains(snapshot.RiskReasons, "stored_reason") {
+		t.Fatalf("findingWorkflowSnapshot().RiskReasons = %#v, want stored_reason", snapshot.RiskReasons)
+	}
+}
+
 func TestUpsertFindingWithRiskRecomputesAfterWorkflowPreservation(t *testing.T) {
 	dueAt := time.Now().UTC().Add(-time.Hour)
 	store := &stubFindingStore{

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -66,24 +66,25 @@ func (s *recordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnv
 }
 
 type stubFindingStore struct {
-	findings                  map[string]*ports.FindingRecord
-	request                   ports.ListFindingsRequest
-	listFindingsRequests      []ports.ListFindingsRequest
-	listFindingsErr           error
-	claims                    map[string]*ports.ClaimRecord
-	claimListRequest          ports.ListClaimsRequest
-	runs                      map[string]*cerebrov1.FindingEvaluationRun
-	runList                   ports.ListFindingEvaluationRunsRequest
-	runPutCount               int
-	failRunPutOn              int
-	failRunPutErr             error
-	failRunPutByCall          map[int]error
-	evidence                  map[string]*cerebrov1.FindingEvidence
-	evidenceList              ports.ListFindingEvidenceRequest
-	dropReturnedGraphEvidence bool
-	upsertCount               int
-	backfillRiskResults       []*ports.FindingRecord
-	backfillRiskErr           error
+	findings                   map[string]*ports.FindingRecord
+	request                    ports.ListFindingsRequest
+	listFindingsRequests       []ports.ListFindingsRequest
+	listFindingsErr            error
+	claims                     map[string]*ports.ClaimRecord
+	claimListRequest           ports.ListClaimsRequest
+	runs                       map[string]*cerebrov1.FindingEvaluationRun
+	runList                    ports.ListFindingEvaluationRunsRequest
+	runPutCount                int
+	failRunPutOn               int
+	failRunPutErr              error
+	failRunPutByCall           map[int]error
+	evidence                   map[string]*cerebrov1.FindingEvidence
+	evidenceList               ports.ListFindingEvidenceRequest
+	dropReturnedGraphEvidence  bool
+	upsertCount                int
+	backfillRiskResults        []*ports.FindingRecord
+	backfillRiskErr            error
+	backfillIncludeUnprojected bool
 }
 
 func (s *stubFindingStore) Ping(context.Context) error { return nil }
@@ -131,7 +132,8 @@ func (s *stubFindingStore) UpdateFindingRisk(_ context.Context, request ports.Fi
 	return cloneFinding(updated), nil
 }
 
-func (s *stubFindingStore) BackfillFindingRisk(context.Context) ([]*ports.FindingRecord, error) {
+func (s *stubFindingStore) BackfillFindingRisk(_ context.Context, includeUnprojected bool) ([]*ports.FindingRecord, error) {
+	s.backfillIncludeUnprojected = includeUnprojected
 	if s.backfillRiskErr != nil {
 		return nil, s.backfillRiskErr
 	}
@@ -2951,6 +2953,9 @@ func TestBackfillFindingRiskProjectsUpdatedFindings(t *testing.T) {
 	if err := service.BackfillFindingRisk(context.Background()); err != nil {
 		t.Fatalf("BackfillFindingRisk() error = %v", err)
 	}
+	if !store.backfillIncludeUnprojected {
+		t.Fatal("BackfillFindingRisk() did not request unprojected rows with graph configured")
+	}
 	graphFinding := graphStore.entities["urn:cerebro:tenant-a:finding:finding-1"]
 	if graphFinding == nil {
 		t.Fatal("BackfillFindingRisk() did not project finding anchor")
@@ -2972,6 +2977,36 @@ func TestBackfillFindingRiskProjectsUpdatedFindings(t *testing.T) {
 	}
 	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != defaultFindingRiskModelVersion {
 		t.Fatalf("projection marker = %q, want %q", got, defaultFindingRiskModelVersion)
+	}
+}
+
+func TestBackfillFindingRiskDoesNotMarkProjectedWithoutGraph(t *testing.T) {
+	finding := &ports.FindingRecord{
+		ID:        "finding-1",
+		TenantID:  "tenant-a",
+		RuntimeID: "runtime-audit",
+		RuleID:    "rule-1",
+		Title:     "Backfilled risk finding",
+		Status:    "open",
+		Severity:  "HIGH",
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        83,
+			RiskModelVersion: defaultFindingRiskModelVersion,
+		},
+	}
+	store := &stubFindingStore{
+		findings:            map[string]*ports.FindingRecord{finding.ID: cloneFinding(finding)},
+		backfillRiskResults: []*ports.FindingRecord{finding},
+	}
+	service := New(nil, nil, store, store, store, store)
+	if err := service.BackfillFindingRisk(context.Background()); err != nil {
+		t.Fatalf("BackfillFindingRisk() error = %v", err)
+	}
+	if store.backfillIncludeUnprojected {
+		t.Fatal("BackfillFindingRisk() requested unprojected rows without graph configured")
+	}
+	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != "" {
+		t.Fatalf("projection marker = %q, want empty without graph", got)
 	}
 }
 

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -39,6 +39,18 @@ type FindingWorkflow struct {
 	StatusUpdatedAt time.Time
 }
 
+// FindingRisk carries normalized likelihood × impact scoring metadata.
+type FindingRisk struct {
+	RiskScore        int
+	LikelihoodScore  int
+	ImpactScore      int
+	ConfidenceScore  int
+	LikelihoodLevel  string
+	ImpactLevel      string
+	RiskReasons      []string
+	RiskModelVersion string
+}
+
 // FindingRecord is the normalized persisted finding shape.
 type FindingRecord struct {
 	ID                string
@@ -59,6 +71,7 @@ type FindingRecord struct {
 	CheckName         string
 	ControlRefs       []FindingControlRef
 	GraphEvidenceRows []*cerebrov1.GraphEvidenceRow
+	FindingRisk
 	FindingWorkflow
 	Attributes      map[string]string
 	FirstObservedAt time.Time
@@ -79,7 +92,17 @@ type ListFindingsRequest struct {
 	PolicyID      string
 	Limit         uint32
 	PriorityOrder bool
+	Order         FindingOrder
 }
+
+// FindingOrder controls persisted finding list sort order.
+type FindingOrder string
+
+const (
+	FindingOrderLastObserved FindingOrder = "last_observed"
+	FindingOrderPriority     FindingOrder = "priority"
+	FindingOrderRiskScore    FindingOrder = "risk_score"
+)
 
 // FindingSummary captures aggregate counts for one finding query without applying
 // pagination limits intended for UI rows.

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -145,6 +145,13 @@ type FindingDueDateUpdate struct {
 	DueAt     time.Time
 }
 
+// FindingRiskUpdate scopes a risk-only finding metadata mutation.
+type FindingRiskUpdate struct {
+	FindingID string
+	FindingRisk
+	Attributes map[string]string
+}
+
 // FindingNoteCreate scopes one appended finding note.
 type FindingNoteCreate struct {
 	FindingID string

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -161,7 +161,7 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 	}
 	parameters[reportParameterResourceLimit] = strconv.Itoa(resourceLimit)
 	parameters[reportParameterGraphLimit] = strconv.Itoa(graphLimit)
-	findings, err := s.findingStore.ListFindings(ctx, ports.ListFindingsRequest{TenantID: tenantID, RuntimeID: runtimeID})
+	findings, err := s.findingStore.ListFindings(ctx, ports.ListFindingsRequest{TenantID: tenantID, RuntimeID: runtimeID, Order: ports.FindingOrderRiskScore})
 	if err != nil {
 		return nil, fmt.Errorf("list findings for tenant %q runtime %q: %w", tenantID, runtimeID, err)
 	}
@@ -173,6 +173,7 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 	checkCounts := make(map[string]*checkCountEntry, len(findings))
 	controlCounts := make(map[string]*controlCountEntry, len(findings))
 	resourceCounts := make(map[string]int, len(findings))
+	riskCounts := make(map[string]int, len(findings))
 	noteCount := 0
 	notedFindingCount := 0
 	ticketCount := 0
@@ -234,6 +235,9 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 		if resourceURN := primaryResourceURN(finding); resourceURN != "" {
 			resourceCounts[resourceURN]++
 		}
+		if finding.RiskScore != 0 {
+			riskCounts[reportRiskLevel(finding.RiskScore)]++
+		}
 		if len(finding.Notes) != 0 {
 			notedFindingCount++
 			noteCount += len(finding.Notes)
@@ -268,6 +272,8 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 		"ticketed_finding_count": ticketedFindingCount,
 		"ticket_count":           ticketCount,
 		"resource_counts":        countEntries(resourceCounts, "resource_urn"),
+		"risk_counts":            countEntries(riskCounts, "risk_level"),
+		"top_risk_findings":      topRiskFindingEntries(findings, 10),
 		"graph_evidence_status":  graphEvidenceStatus,
 		"graph_evidence":         graphEvidence,
 	})
@@ -434,6 +440,73 @@ func countEntries(counts map[string]int, keyName string) []any {
 		})
 	}
 	return values
+}
+
+func topRiskFindingEntries(findings []*ports.FindingRecord, limit int) []any {
+	records := append([]*ports.FindingRecord(nil), findings...)
+	slices.SortFunc(records, func(left *ports.FindingRecord, right *ports.FindingRecord) int {
+		if left == nil || right == nil {
+			switch {
+			case left == nil && right == nil:
+				return 0
+			case left == nil:
+				return 1
+			default:
+				return -1
+			}
+		}
+		switch {
+		case left.RiskScore > right.RiskScore:
+			return -1
+		case left.RiskScore < right.RiskScore:
+			return 1
+		case left.LastObservedAt.After(right.LastObservedAt):
+			return -1
+		case left.LastObservedAt.Before(right.LastObservedAt):
+			return 1
+		case left.ID < right.ID:
+			return -1
+		case left.ID > right.ID:
+			return 1
+		default:
+			return 0
+		}
+	})
+	if len(records) > limit {
+		records = records[:limit]
+	}
+	values := make([]any, 0, len(records))
+	for _, finding := range records {
+		if finding == nil || finding.RiskScore == 0 {
+			continue
+		}
+		values = append(values, map[string]any{
+			"finding_id":       finding.ID,
+			"title":            finding.Title,
+			"severity":         finding.Severity,
+			"risk_score":       finding.RiskScore,
+			"likelihood_score": finding.LikelihoodScore,
+			"impact_score":     finding.ImpactScore,
+			"risk_level":       reportRiskLevel(finding.RiskScore),
+			"risk_reasons":     append([]string(nil), finding.RiskReasons...),
+		})
+	}
+	return values
+}
+
+func reportRiskLevel(score int) string {
+	switch {
+	case score >= 85:
+		return "critical"
+	case score >= 70:
+		return "high"
+	case score >= 40:
+		return "medium"
+	case score > 0:
+		return "low"
+	default:
+		return "unknown"
+	}
 }
 
 func checkCountEntries(counts map[string]*checkCountEntry) []any {

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -460,6 +460,10 @@ func topRiskFindingEntries(findings []*ports.FindingRecord, limit int) []any {
 			return -1
 		case left.RiskScore < right.RiskScore:
 			return 1
+		case reportSeverityRank(left.Severity) > reportSeverityRank(right.Severity):
+			return -1
+		case reportSeverityRank(left.Severity) < reportSeverityRank(right.Severity):
+			return 1
 		case left.LastObservedAt.After(right.LastObservedAt):
 			return -1
 		case left.LastObservedAt.Before(right.LastObservedAt):
@@ -488,10 +492,36 @@ func topRiskFindingEntries(findings []*ports.FindingRecord, limit int) []any {
 			"likelihood_score": finding.LikelihoodScore,
 			"impact_score":     finding.ImpactScore,
 			"risk_level":       reportRiskLevel(finding.RiskScore),
-			"risk_reasons":     append([]string(nil), finding.RiskReasons...),
+			"risk_reasons":     reportStringValues(finding.RiskReasons),
 		})
 	}
 	return values
+}
+
+func reportSeverityRank(severity string) int {
+	switch strings.ToUpper(strings.TrimSpace(severity)) {
+	case "CRITICAL":
+		return 4
+	case "HIGH":
+		return 3
+	case "MEDIUM":
+		return 2
+	case "LOW":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func reportStringValues(values []string) []any {
+	if len(values) == 0 {
+		return []any{}
+	}
+	converted := make([]any, 0, len(values))
+	for _, value := range values {
+		converted = append(converted, value)
+	}
+	return converted
 }
 
 func reportRiskLevel(score int) string {

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -3,6 +3,7 @@ package reports
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -182,6 +183,13 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 				Severity:     "HIGH",
 				Status:       "open",
 				ResourceURNs: []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+				FindingRisk: ports.FindingRisk{
+					RiskScore:        80,
+					LikelihoodScore:  85,
+					ImpactScore:      75,
+					RiskReasons:      []string{"active", "external_exposure"},
+					RiskModelVersion: "likelihood-impact-v1",
+				},
 				Attributes: map[string]string{
 					"primary_resource_urn": "urn:cerebro:writer:okta_resource:policyrule:pol-1",
 				},
@@ -356,6 +364,18 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 	if !ok || len(resourceCounts) != 1 {
 		t.Fatalf("Run().Run.Result[resource_counts] = %#v, want 1 entry", result["resource_counts"])
 	}
+	topRiskFindings, ok := result["top_risk_findings"].([]any)
+	if !ok || len(topRiskFindings) != 1 {
+		t.Fatalf("Run().Run.Result[top_risk_findings] = %#v, want 1 entry", result["top_risk_findings"])
+	}
+	topRiskFinding, ok := topRiskFindings[0].(map[string]any)
+	if !ok {
+		t.Fatalf("top risk finding = %#v, want object", topRiskFindings[0])
+	}
+	riskReasons, ok := topRiskFinding["risk_reasons"].([]any)
+	if !ok || len(riskReasons) != 2 {
+		t.Fatalf("top risk reasons = %#v, want serialized reasons", topRiskFinding["risk_reasons"])
+	}
 	graphEvidence, ok := result["graph_evidence"].([]any)
 	if !ok || len(graphEvidence) != 1 {
 		t.Fatalf("Run().Run.Result[graph_evidence] = %#v, want 1 entry", result["graph_evidence"])
@@ -453,6 +473,46 @@ func TestRunFindingSummaryReportWithoutGraphStoreMarksEvidenceUnconfigured(t *te
 	}
 }
 
+func TestTopRiskFindingEntriesKeepsSeverityTieBreakBeforeLimit(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	findings := []*ports.FindingRecord{}
+	for i := 0; i < 11; i++ {
+		findings = append(findings, &ports.FindingRecord{
+			ID:             fmt.Sprintf("low-%02d", i),
+			Title:          "Low risk tie",
+			Severity:       "LOW",
+			LastObservedAt: now.Add(time.Duration(i) * time.Minute),
+			FindingRisk: ports.FindingRisk{
+				RiskScore: 70,
+			},
+		})
+	}
+	findings = append(findings, &ports.FindingRecord{
+		ID:             "critical-old",
+		Title:          "Critical risk tie",
+		Severity:       "CRITICAL",
+		LastObservedAt: now.Add(-time.Hour),
+		FindingRisk: ports.FindingRisk{
+			RiskScore: 70,
+		},
+	})
+	entries := topRiskFindingEntries(findings, 10)
+	foundCritical := false
+	for _, raw := range entries {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("top risk entry = %#v, want object", raw)
+		}
+		if entry["finding_id"] == "critical-old" {
+			foundCritical = true
+			break
+		}
+	}
+	if !foundCritical {
+		t.Fatalf("topRiskFindingEntries() = %#v, want critical tie included before newer lows", entries)
+	}
+}
+
 func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 	if finding == nil {
 		return nil
@@ -482,6 +542,16 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 			DueAt:           finding.DueAt,
 			StatusReason:    finding.StatusReason,
 			StatusUpdatedAt: finding.StatusUpdatedAt,
+		},
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        finding.RiskScore,
+			LikelihoodScore:  finding.LikelihoodScore,
+			ImpactScore:      finding.ImpactScore,
+			ConfidenceScore:  finding.ConfidenceScore,
+			LikelihoodLevel:  finding.LikelihoodLevel,
+			ImpactLevel:      finding.ImpactLevel,
+			RiskReasons:      append([]string(nil), finding.RiskReasons...),
+			RiskModelVersion: finding.RiskModelVersion,
 		},
 		Attributes:      cloneAttributes(finding.Attributes),
 		FirstObservedAt: finding.FirstObservedAt,

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -347,6 +348,9 @@ func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequ
 	if err := s.ensureFindingTables(ctx); err != nil {
 		return nil, err
 	}
+	if err := s.refreshFindingRiskForList(ctx, request); err != nil {
+		return nil, err
+	}
 	query, args, err := findingListQuery(request)
 	if err != nil {
 		return nil, err
@@ -466,6 +470,9 @@ func (s *Store) GetFinding(ctx context.Context, id string) (*ports.FindingRecord
 	if findingID == "" {
 		return nil, errors.New("finding id is required")
 	}
+	if err := s.refreshFindingRiskForID(ctx, findingID); err != nil {
+		return nil, err
+	}
 	var row findingRow
 	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
 SELECT `+findingSelectColumns+`
@@ -581,6 +588,28 @@ RETURNING `+findingSelectColumns,
 		return nil, fmt.Errorf("update finding %q due date: %w", findingID, err)
 	}
 	return row.record()
+}
+
+// UpdateFindingRisk updates only persisted risk fields for one finding.
+func (s *Store) UpdateFindingRisk(ctx context.Context, request ports.FindingRiskUpdate) (*ports.FindingRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return nil, err
+	}
+	findingID := strings.TrimSpace(request.FindingID)
+	if findingID == "" {
+		return nil, errors.New("finding id is required")
+	}
+	record, err := s.updateFindingRiskColumns(ctx, findingID, request.FindingRisk, request.Attributes)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ports.ErrFindingNotFound
+		}
+		return nil, fmt.Errorf("update finding %q risk: %w", findingID, err)
+	}
+	return record, nil
 }
 
 // AddFindingNote appends one persisted finding note.
@@ -764,11 +793,24 @@ func (s *Store) backfillFindingRisk(ctx context.Context) (err error) {
 		if update.id == "" {
 			continue
 		}
-		reasonsJSON, err := findingStringsJSON(update.risk.RiskReasons)
-		if err != nil {
-			return fmt.Errorf("marshal finding %q risk backfill reasons: %w", update.id, err)
+		if _, err := s.updateFindingRiskColumns(ctx, update.id, update.risk, findingRiskAttributesForUpdate(update.risk)); err != nil {
+			return fmt.Errorf("backfill finding %q risk: %w", update.id, err)
 		}
-		if _, err := s.db.ExecContext(ctx, `
+	}
+	return nil
+}
+
+func (s *Store) updateFindingRiskColumns(ctx context.Context, findingID string, risk ports.FindingRisk, attributes map[string]string) (*ports.FindingRecord, error) {
+	reasonsJSON, err := findingStringsJSON(risk.RiskReasons)
+	if err != nil {
+		return nil, fmt.Errorf("marshal finding risk reasons: %w", err)
+	}
+	attributesJSON, err := findingAttributesJSON(attributes)
+	if err != nil {
+		return nil, fmt.Errorf("marshal finding risk attributes: %w", err)
+	}
+	var row findingRow
+	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
 UPDATE findings
 SET risk_score = $2,
     likelihood_score = $3,
@@ -778,22 +820,24 @@ SET risk_score = $2,
     impact_level = $7,
     risk_reasons_json = $8::jsonb,
     risk_model_version = $9,
+    attributes_json = attributes_json || $10::jsonb,
     updated_at = NOW()
-WHERE id = $1 AND (risk_model_version <> $9 OR risk_score = 0)`,
-			update.id,
-			update.risk.RiskScore,
-			update.risk.LikelihoodScore,
-			update.risk.ImpactScore,
-			update.risk.ConfidenceScore,
-			strings.TrimSpace(update.risk.LikelihoodLevel),
-			strings.TrimSpace(update.risk.ImpactLevel),
-			reasonsJSON,
-			strings.TrimSpace(update.risk.RiskModelVersion),
-		); err != nil {
-			return fmt.Errorf("backfill finding %q risk: %w", update.id, err)
-		}
+WHERE id = $1
+RETURNING `+findingSelectColumns,
+		strings.TrimSpace(findingID),
+		risk.RiskScore,
+		risk.LikelihoodScore,
+		risk.ImpactScore,
+		risk.ConfidenceScore,
+		strings.TrimSpace(risk.LikelihoodLevel),
+		strings.TrimSpace(risk.ImpactLevel),
+		reasonsJSON,
+		strings.TrimSpace(risk.RiskModelVersion),
+		attributesJSON,
+	), &row); err != nil {
+		return nil, err
 	}
-	return nil
+	return row.record()
 }
 
 func findingBackfillRisk(record *ports.FindingRecord, now time.Time) ports.FindingRisk {
@@ -808,6 +852,99 @@ func findingBackfillRisk(record *ports.FindingRecord, now time.Time) ports.Findi
 		RiskReasons:      risk.Reasons,
 		RiskModelVersion: risk.RiskModelVersion,
 	}
+}
+
+func (s *Store) refreshFindingRiskForID(ctx context.Context, findingID string) error {
+	return s.refreshFindingRiskRows(ctx, `SELECT `+findingSelectColumns+` FROM findings WHERE id = $1 AND `+findingTimeSensitiveRiskPredicate(), strings.TrimSpace(findingID))
+}
+
+func (s *Store) refreshFindingRiskForList(ctx context.Context, request ports.ListFindingsRequest) error {
+	clauses, args, err := findingFilterClauses(request)
+	if err != nil {
+		return err
+	}
+	clauses = append(clauses, findingTimeSensitiveRiskPredicate())
+	return s.refreshFindingRiskRows(ctx, `SELECT `+findingSelectColumns+` FROM findings WHERE `+strings.Join(clauses, " AND "), args...)
+}
+
+func findingTimeSensitiveRiskPredicate() string {
+	return `(due_at IS NOT NULL OR last_observed_at IS NOT NULL)`
+}
+
+func (s *Store) refreshFindingRiskRows(ctx context.Context, query string, args ...any) (err error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("list findings for risk refresh: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close finding risk refresh rows: %w", closeErr)
+		}
+	}()
+	type riskRefresh struct {
+		id   string
+		risk ports.FindingRisk
+	}
+	now := time.Now().UTC()
+	updates := []riskRefresh{}
+	for rows.Next() {
+		var row findingRow
+		if err := scanFindingRow(rows, &row); err != nil {
+			return fmt.Errorf("scan finding risk refresh row: %w", err)
+		}
+		record, err := row.record()
+		if err != nil {
+			return fmt.Errorf("decode finding risk refresh row: %w", err)
+		}
+		refreshed := findingBackfillRisk(record, now)
+		if !findingRiskEqual(record.FindingRisk, refreshed) {
+			updates = append(updates, riskRefresh{id: strings.TrimSpace(record.ID), risk: refreshed})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate finding risk refresh rows: %w", err)
+	}
+	for _, update := range updates {
+		if update.id == "" {
+			continue
+		}
+		if _, err := s.updateFindingRiskColumns(ctx, update.id, update.risk, findingRiskAttributesForUpdate(update.risk)); err != nil {
+			return fmt.Errorf("refresh finding %q risk: %w", update.id, err)
+		}
+	}
+	return nil
+}
+
+func findingRiskEqual(left ports.FindingRisk, right ports.FindingRisk) bool {
+	if left.RiskScore != right.RiskScore ||
+		left.LikelihoodScore != right.LikelihoodScore ||
+		left.ImpactScore != right.ImpactScore ||
+		left.ConfidenceScore != right.ConfidenceScore ||
+		strings.TrimSpace(left.LikelihoodLevel) != strings.TrimSpace(right.LikelihoodLevel) ||
+		strings.TrimSpace(left.ImpactLevel) != strings.TrimSpace(right.ImpactLevel) ||
+		strings.TrimSpace(left.RiskModelVersion) != strings.TrimSpace(right.RiskModelVersion) ||
+		len(left.RiskReasons) != len(right.RiskReasons) {
+		return false
+	}
+	for index := range left.RiskReasons {
+		if strings.TrimSpace(left.RiskReasons[index]) != strings.TrimSpace(right.RiskReasons[index]) {
+			return false
+		}
+	}
+	return true
+}
+
+func findingRiskAttributesForUpdate(risk ports.FindingRisk) map[string]string {
+	attributes := map[string]string{}
+	attributes["risk_score"] = strconv.Itoa(risk.RiskScore)
+	attributes["likelihood_score"] = strconv.Itoa(risk.LikelihoodScore)
+	attributes["impact_score"] = strconv.Itoa(risk.ImpactScore)
+	attributes["confidence_score"] = strconv.Itoa(risk.ConfidenceScore)
+	attributes["likelihood_level"] = strings.TrimSpace(risk.LikelihoodLevel)
+	attributes["impact_level"] = strings.TrimSpace(risk.ImpactLevel)
+	attributes["risk_model_version"] = strings.TrimSpace(risk.RiskModelVersion)
+	attributes["risk_reasons"] = strings.Join(risk.RiskReasons, ",")
+	return attributes
 }
 
 func findingOrderClause(request ports.ListFindingsRequest) string {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -822,7 +822,7 @@ func findingOrderClause(request ports.ListFindingsRequest) string {
   ELSE 5
 END, last_observed_at DESC, id`
 	case request.Order == ports.FindingOrderPriority || request.PriorityOrder:
-		return `risk_score DESC, CASE UPPER(severity)
+		return `CASE UPPER(severity)
   WHEN 'CRITICAL' THEN 0
   WHEN 'HIGH' THEN 1
   WHEN 'MEDIUM' THEN 2

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -748,20 +748,20 @@ func (s *Store) ensureFindingTables(ctx context.Context) error {
 }
 
 // BackfillFindingRisk updates existing findings with the current risk model.
-func (s *Store) BackfillFindingRisk(ctx context.Context) error {
+func (s *Store) BackfillFindingRisk(ctx context.Context) ([]*ports.FindingRecord, error) {
 	if s == nil || s.db == nil {
-		return errors.New("postgres is not configured")
+		return nil, errors.New("postgres is not configured")
 	}
 	if err := s.ensureFindingTables(ctx); err != nil {
-		return err
+		return nil, err
 	}
 	return s.backfillFindingRisk(ctx)
 }
 
-func (s *Store) backfillFindingRisk(ctx context.Context) (err error) {
+func (s *Store) backfillFindingRisk(ctx context.Context) (updated []*ports.FindingRecord, err error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT `+findingSelectColumns+` FROM findings WHERE risk_model_version <> $1 OR risk_score = 0`, "likelihood-impact-v1")
 	if err != nil {
-		return fmt.Errorf("list findings for risk backfill: %w", err)
+		return nil, fmt.Errorf("list findings for risk backfill: %w", err)
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil && err == nil {
@@ -777,11 +777,11 @@ func (s *Store) backfillFindingRisk(ctx context.Context) (err error) {
 	for rows.Next() {
 		var row findingRow
 		if err := scanFindingRow(rows, &row); err != nil {
-			return fmt.Errorf("scan finding risk backfill row: %w", err)
+			return nil, fmt.Errorf("scan finding risk backfill row: %w", err)
 		}
 		record, err := row.record()
 		if err != nil {
-			return fmt.Errorf("decode finding risk backfill row: %w", err)
+			return nil, fmt.Errorf("decode finding risk backfill row: %w", err)
 		}
 		updates = append(updates, riskBackfill{
 			id:   strings.TrimSpace(record.ID),
@@ -789,17 +789,19 @@ func (s *Store) backfillFindingRisk(ctx context.Context) (err error) {
 		})
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate finding risk backfill rows: %w", err)
+		return nil, fmt.Errorf("iterate finding risk backfill rows: %w", err)
 	}
 	for _, update := range updates {
 		if update.id == "" {
 			continue
 		}
-		if _, err := s.updateFindingRiskColumns(ctx, update.id, update.risk, findingRiskAttributesForUpdate(update.risk)); err != nil {
-			return fmt.Errorf("backfill finding %q risk: %w", update.id, err)
+		stored, err := s.updateFindingRiskColumns(ctx, update.id, update.risk, findingRiskAttributesForUpdate(update.risk))
+		if err != nil {
+			return nil, fmt.Errorf("backfill finding %q risk: %w", update.id, err)
 		}
+		updated = append(updated, stored)
 	}
-	return nil
+	return updated, nil
 }
 
 func (s *Store) updateFindingRiskColumns(ctx context.Context, findingID string, risk ports.FindingRisk, attributes map[string]string) (*ports.FindingRecord, error) {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	findingrisk "github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -72,111 +73,6 @@ var ensureFindingStatements = []string{
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS impact_level TEXT NOT NULL DEFAULT ''`,
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS risk_reasons_json JSONB NOT NULL DEFAULT '[]'::jsonb`,
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS risk_model_version TEXT NOT NULL DEFAULT ''`,
-	`WITH risk_signals AS (
-  SELECT
-    id,
-    CASE UPPER(severity)
-      WHEN 'CRITICAL' THEN 4
-      WHEN 'HIGH' THEN 3
-      WHEN 'MEDIUM' THEN 2
-      WHEN 'LOW' THEN 1
-      ELSE 0
-    END AS severity_score,
-    UPPER(severity) AS severity_level,
-    status = 'open' AS is_open,
-    due_at IS NOT NULL AND due_at < NOW() AS is_overdue,
-    jsonb_array_length(event_ids_json) AS event_count,
-    jsonb_array_length(resource_urns_json) AS resource_count,
-    jsonb_array_length(control_refs_json) AS control_count,
-    LOWER(COALESCE(attributes_json->>'internet_exposed', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'public', 'external')
-      OR LOWER(COALESCE(attributes_json->>'public', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'public', 'external')
-      OR LOWER(COALESCE(attributes_json->>'externally_exposed', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'public', 'external')
-      AS external_exposure,
-    LOWER(COALESCE(attributes_json->>'actor_privileged', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'critical')
-      OR LOWER(COALESCE(attributes_json->>'privileged', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'critical')
-      AS privileged_actor,
-    LOWER(COALESCE(attributes_json->>'is_kev', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled')
-      OR LOWER(COALESCE(attributes_json->>'known_exploited', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled')
-      AS known_exploited,
-    LOWER(COALESCE(attributes_json->>'asset_criticality', attributes_json->>'criticality', '')) IN ('critical', 'high', 'crown', 'tier0', 'tier-0')
-      AS critical_asset,
-    LOWER(COALESCE(attributes_json->>'data_classification', attributes_json->>'sensitivity', attributes_json->>'data_sensitivity', '')) ~ '(secret|sensitive|confidential|restricted)'
-      AS sensitive_data,
-    LOWER(COALESCE(attributes_json->>'crown_jewel', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'critical')
-      OR LOWER(COALESCE(attributes_json->>'contains_secrets', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled')
-      AS crown_jewel,
-    LOWER(COALESCE(attributes_json->>'environment', attributes_json->>'env', attributes_json->>'stage', '')) ~ '(prod|production)'
-      AS production_environment
-  FROM findings
-  WHERE risk_model_version = '' OR risk_score = 0
-),
-risk_scored AS (
-  SELECT
-    id,
-    LEAST(100, GREATEST(0,
-      10
-      + severity_score * 6
-      + CASE WHEN is_open THEN 5 ELSE 0 END
-      + CASE WHEN event_count > 1 THEN LEAST(event_count * 2, 10) ELSE 0 END
-      + CASE WHEN external_exposure THEN 35 ELSE 0 END
-      + CASE WHEN privileged_actor THEN 10 ELSE 0 END
-      + CASE WHEN known_exploited THEN 35 ELSE 0 END
-    ))::int AS likelihood_score,
-    LEAST(100, GREATEST(0,
-      10
-      + severity_score * 8
-      + CASE WHEN is_overdue THEN 5 ELSE 0 END
-      + CASE WHEN resource_count > 1 THEN LEAST(resource_count * 2, 12) ELSE 0 END
-      + CASE WHEN control_count > 0 THEN LEAST(control_count * 2, 8) ELSE 0 END
-      + CASE WHEN critical_asset THEN 35 ELSE 0 END
-      + CASE WHEN privileged_actor THEN 15 ELSE 0 END
-      + CASE WHEN sensitive_data THEN 25 ELSE 0 END
-      + CASE WHEN crown_jewel THEN 35 ELSE 0 END
-      + CASE WHEN production_environment THEN 15 ELSE 0 END
-    ))::int AS impact_score,
-    70 AS confidence_score,
-    to_jsonb(array_remove(ARRAY[
-      CASE WHEN severity_score > 0 THEN 'severity:' || severity_level END,
-      CASE WHEN is_open THEN 'active' END,
-      CASE WHEN is_overdue THEN 'overdue' END,
-      CASE WHEN event_count > 1 THEN 'multiple_events' END,
-      CASE WHEN resource_count > 1 THEN 'multiple_resources' END,
-      CASE WHEN control_count > 0 THEN 'mapped_controls' END,
-      CASE WHEN external_exposure THEN 'external_exposure' END,
-      CASE WHEN privileged_actor THEN 'privileged_actor' END,
-      CASE WHEN known_exploited THEN 'known_exploited' END,
-      CASE WHEN critical_asset THEN 'critical_asset' END,
-      CASE WHEN sensitive_data THEN 'sensitive_data' END,
-      CASE WHEN crown_jewel THEN 'crown_jewel' END,
-      CASE WHEN production_environment THEN 'production_environment' END
-    ], NULL)) AS risk_reasons_json
-  FROM risk_signals
-)
-UPDATE findings
-SET
-  likelihood_score = risk_scored.likelihood_score,
-  impact_score = risk_scored.impact_score,
-  confidence_score = risk_scored.confidence_score,
-  risk_score = LEAST(100, GREATEST(0, ROUND(SQRT((risk_scored.likelihood_score * risk_scored.impact_score)::double precision))::int)),
-  likelihood_level = CASE
-    WHEN risk_scored.likelihood_score >= 85 THEN 'critical'
-    WHEN risk_scored.likelihood_score >= 70 THEN 'high'
-    WHEN risk_scored.likelihood_score >= 40 THEN 'medium'
-    WHEN risk_scored.likelihood_score > 0 THEN 'low'
-    ELSE ''
-  END,
-  impact_level = CASE
-    WHEN risk_scored.impact_score >= 85 THEN 'critical'
-    WHEN risk_scored.impact_score >= 70 THEN 'high'
-    WHEN risk_scored.impact_score >= 40 THEN 'medium'
-    WHEN risk_scored.impact_score > 0 THEN 'low'
-    ELSE ''
-  END,
-  risk_reasons_json = risk_scored.risk_reasons_json,
-  risk_model_version = 'likelihood-impact-v1',
-  updated_at = NOW()
-FROM risk_scored
-WHERE findings.id = risk_scored.id`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_rule_idx ON findings (runtime_id, rule_id)`,
 	`CREATE INDEX IF NOT EXISTS findings_tenant_rule_idx ON findings (tenant_id, rule_id)`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_policy_idx ON findings (runtime_id, policy_id)`,
@@ -814,7 +710,104 @@ func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, e
 }
 
 func (s *Store) ensureFindingTables(ctx context.Context) error {
-	return s.ensureStatements(ctx, &s.findingTablesReady, "findings", ensureFindingStatements)
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	if s.findingTablesReady {
+		return nil
+	}
+	for _, statement := range ensureFindingStatements {
+		if _, err := s.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("ensure findings tables: %w", err)
+		}
+	}
+	if err := s.backfillFindingRisk(ctx); err != nil {
+		return err
+	}
+	s.findingTablesReady = true
+	return nil
+}
+
+func (s *Store) backfillFindingRisk(ctx context.Context) (err error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+findingSelectColumns+` FROM findings WHERE risk_model_version <> $1 OR risk_score = 0`, "likelihood-impact-v1")
+	if err != nil {
+		return fmt.Errorf("list findings for risk backfill: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close finding risk backfill rows: %w", closeErr)
+		}
+	}()
+	type riskBackfill struct {
+		id   string
+		risk ports.FindingRisk
+	}
+	now := time.Now().UTC()
+	updates := []riskBackfill{}
+	for rows.Next() {
+		var row findingRow
+		if err := scanFindingRow(rows, &row); err != nil {
+			return fmt.Errorf("scan finding risk backfill row: %w", err)
+		}
+		record, err := row.record()
+		if err != nil {
+			return fmt.Errorf("decode finding risk backfill row: %w", err)
+		}
+		updates = append(updates, riskBackfill{
+			id:   strings.TrimSpace(record.ID),
+			risk: findingBackfillRisk(record, now),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate finding risk backfill rows: %w", err)
+	}
+	for _, update := range updates {
+		if update.id == "" {
+			continue
+		}
+		reasonsJSON, err := findingStringsJSON(update.risk.RiskReasons)
+		if err != nil {
+			return fmt.Errorf("marshal finding %q risk backfill reasons: %w", update.id, err)
+		}
+		if _, err := s.db.ExecContext(ctx, `
+UPDATE findings
+SET risk_score = $2,
+    likelihood_score = $3,
+    impact_score = $4,
+    confidence_score = $5,
+    likelihood_level = $6,
+    impact_level = $7,
+    risk_reasons_json = $8::jsonb,
+    risk_model_version = $9,
+    updated_at = NOW()
+WHERE id = $1 AND (risk_model_version <> $9 OR risk_score = 0)`,
+			update.id,
+			update.risk.RiskScore,
+			update.risk.LikelihoodScore,
+			update.risk.ImpactScore,
+			update.risk.ConfidenceScore,
+			strings.TrimSpace(update.risk.LikelihoodLevel),
+			strings.TrimSpace(update.risk.ImpactLevel),
+			reasonsJSON,
+			strings.TrimSpace(update.risk.RiskModelVersion),
+		); err != nil {
+			return fmt.Errorf("backfill finding %q risk: %w", update.id, err)
+		}
+	}
+	return nil
+}
+
+func findingBackfillRisk(record *ports.FindingRecord, now time.Time) ports.FindingRisk {
+	risk := findingrisk.AnalyzeFindingRiskContext(record, now)
+	return ports.FindingRisk{
+		RiskScore:        risk.Score,
+		LikelihoodScore:  risk.LikelihoodScore,
+		ImpactScore:      risk.ImpactScore,
+		ConfidenceScore:  risk.ConfidenceScore,
+		LikelihoodLevel:  risk.LikelihoodLevel,
+		ImpactLevel:      risk.ImpactLevel,
+		RiskReasons:      risk.Reasons,
+		RiskModelVersion: risk.RiskModelVersion,
+	}
 }
 
 func findingOrderClause(request ports.ListFindingsRequest) string {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -748,18 +748,22 @@ func (s *Store) ensureFindingTables(ctx context.Context) error {
 }
 
 // BackfillFindingRisk updates existing findings with the current risk model.
-func (s *Store) BackfillFindingRisk(ctx context.Context) ([]*ports.FindingRecord, error) {
+func (s *Store) BackfillFindingRisk(ctx context.Context, includeUnprojected bool) ([]*ports.FindingRecord, error) {
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
 	}
 	if err := s.ensureFindingTables(ctx); err != nil {
 		return nil, err
 	}
-	return s.backfillFindingRisk(ctx)
+	return s.backfillFindingRisk(ctx, includeUnprojected)
 }
 
-func (s *Store) backfillFindingRisk(ctx context.Context) (updated []*ports.FindingRecord, err error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT `+findingSelectColumns+` FROM findings WHERE risk_model_version <> $1 OR risk_score = 0 OR COALESCE(attributes_json->>'`+findingrisk.FindingRiskGraphProjectedModelVersionAttribute+`', '') <> $1`, "likelihood-impact-v1")
+func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool) (updated []*ports.FindingRecord, err error) {
+	query := `SELECT ` + findingSelectColumns + ` FROM findings WHERE risk_model_version <> $1 OR risk_score = 0`
+	if includeUnprojected {
+		query += ` OR COALESCE(attributes_json->>'` + findingrisk.FindingRiskGraphProjectedModelVersionAttribute + `', '') <> $1`
+	}
+	rows, err := s.db.QueryContext(ctx, query, "likelihood-impact-v1")
 	if err != nil {
 		return nil, fmt.Errorf("list findings for risk backfill: %w", err)
 	}

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -377,10 +377,6 @@ func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequ
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate findings rows: %w", err)
 	}
-	findings, err = s.refreshFindingRiskRecords(ctx, findings)
-	if err != nil {
-		return nil, err
-	}
 	return findings, nil
 }
 
@@ -747,11 +743,19 @@ func (s *Store) ensureFindingTables(ctx context.Context) error {
 			return fmt.Errorf("ensure findings tables: %w", err)
 		}
 	}
-	if err := s.backfillFindingRisk(ctx); err != nil {
-		return err
-	}
 	s.findingTablesReady = true
 	return nil
+}
+
+// BackfillFindingRisk updates existing findings with the current risk model.
+func (s *Store) BackfillFindingRisk(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return err
+	}
+	return s.backfillFindingRisk(ctx)
 }
 
 func (s *Store) backfillFindingRisk(ctx context.Context) (err error) {
@@ -850,47 +854,6 @@ func findingBackfillRisk(record *ports.FindingRecord, now time.Time) ports.Findi
 		RiskReasons:      risk.Reasons,
 		RiskModelVersion: risk.RiskModelVersion,
 	}
-}
-
-func (s *Store) refreshFindingRiskRecords(ctx context.Context, findings []*ports.FindingRecord) ([]*ports.FindingRecord, error) {
-	if len(findings) == 0 {
-		return findings, nil
-	}
-	now := time.Now().UTC()
-	refreshedFindings := append([]*ports.FindingRecord(nil), findings...)
-	for index, record := range refreshedFindings {
-		if record == nil {
-			continue
-		}
-		refreshed := findingBackfillRisk(record, now)
-		if !findingRiskEqual(record.FindingRisk, refreshed) {
-			stored, err := s.updateFindingRiskColumns(ctx, strings.TrimSpace(record.ID), refreshed, findingRiskAttributesForUpdate(refreshed))
-			if err != nil {
-				return nil, fmt.Errorf("refresh finding %q risk: %w", strings.TrimSpace(record.ID), err)
-			}
-			refreshedFindings[index] = stored
-		}
-	}
-	return refreshedFindings, nil
-}
-
-func findingRiskEqual(left ports.FindingRisk, right ports.FindingRisk) bool {
-	if left.RiskScore != right.RiskScore ||
-		left.LikelihoodScore != right.LikelihoodScore ||
-		left.ImpactScore != right.ImpactScore ||
-		left.ConfidenceScore != right.ConfidenceScore ||
-		strings.TrimSpace(left.LikelihoodLevel) != strings.TrimSpace(right.LikelihoodLevel) ||
-		strings.TrimSpace(left.ImpactLevel) != strings.TrimSpace(right.ImpactLevel) ||
-		strings.TrimSpace(left.RiskModelVersion) != strings.TrimSpace(right.RiskModelVersion) ||
-		len(left.RiskReasons) != len(right.RiskReasons) {
-		return false
-	}
-	for index := range left.RiskReasons {
-		if strings.TrimSpace(left.RiskReasons[index]) != strings.TrimSpace(right.RiskReasons[index]) {
-			return false
-		}
-	}
-	return true
 }
 
 func findingRiskAttributesForUpdate(risk ports.FindingRisk) map[string]string {

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -24,6 +24,14 @@ var ensureFindingStatements = []string{
   severity TEXT NOT NULL,
   status TEXT NOT NULL,
   summary TEXT NOT NULL,
+  risk_score INTEGER NOT NULL DEFAULT 0,
+  likelihood_score INTEGER NOT NULL DEFAULT 0,
+  impact_score INTEGER NOT NULL DEFAULT 0,
+  confidence_score INTEGER NOT NULL DEFAULT 0,
+  likelihood_level TEXT NOT NULL DEFAULT '',
+  impact_level TEXT NOT NULL DEFAULT '',
+  risk_reasons_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  risk_model_version TEXT NOT NULL DEFAULT '',
   resource_urns_json JSONB NOT NULL DEFAULT '[]'::jsonb,
   event_ids_json JSONB NOT NULL DEFAULT '[]'::jsonb,
   observed_policy_ids_json JSONB NOT NULL DEFAULT '[]'::jsonb,
@@ -56,6 +64,14 @@ var ensureFindingStatements = []string{
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS due_at TIMESTAMPTZ`,
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS status_reason TEXT NOT NULL DEFAULT ''`,
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS status_updated_at TIMESTAMPTZ`,
+	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS risk_score INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS likelihood_score INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS impact_score INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS confidence_score INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS likelihood_level TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS impact_level TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS risk_reasons_json JSONB NOT NULL DEFAULT '[]'::jsonb`,
+	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS risk_model_version TEXT NOT NULL DEFAULT ''`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_rule_idx ON findings (runtime_id, rule_id)`,
 	`CREATE INDEX IF NOT EXISTS findings_tenant_rule_idx ON findings (tenant_id, rule_id)`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_policy_idx ON findings (runtime_id, policy_id)`,
@@ -65,6 +81,7 @@ var ensureFindingStatements = []string{
 	`CREATE INDEX IF NOT EXISTS findings_runtime_severity_idx ON findings (runtime_id, severity)`,
 	`CREATE INDEX IF NOT EXISTS findings_tenant_runtime_status_observed_idx ON findings (tenant_id, runtime_id, status, last_observed_at DESC, id)`,
 	`CREATE INDEX IF NOT EXISTS findings_tenant_runtime_observed_idx ON findings (tenant_id, runtime_id, last_observed_at DESC, id)`,
+	`CREATE INDEX IF NOT EXISTS findings_priority_idx ON findings (tenant_id, runtime_id, status, risk_score DESC, last_observed_at DESC, id)`,
 	`CREATE INDEX IF NOT EXISTS findings_resource_urns_gin_idx ON findings USING GIN (resource_urns_json)`,
 	`CREATE INDEX IF NOT EXISTS findings_event_ids_gin_idx ON findings USING GIN (event_ids_json)`,
 	`CREATE INDEX IF NOT EXISTS findings_observed_policy_ids_gin_idx ON findings USING GIN (observed_policy_ids_json)`,
@@ -72,6 +89,12 @@ var ensureFindingStatements = []string{
 	`CREATE INDEX IF NOT EXISTS findings_notes_gin_idx ON findings USING GIN (notes_json)`,
 	`CREATE INDEX IF NOT EXISTS findings_tickets_gin_idx ON findings USING GIN (tickets_json)`,
 }
+
+const findingSelectColumns = `id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
+  risk_score, likelihood_score, impact_score, confidence_score, likelihood_level, impact_level, risk_reasons_json::text, risk_model_version,
+  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
+  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
+  status_updated_at, first_observed_at, last_observed_at`
 
 // upsertFindingStatement persists one finding row, preserving runtime_id on conflict.
 //
@@ -86,11 +109,12 @@ var ensureFindingStatements = []string{
 const upsertFindingStatement = `
 INSERT INTO findings (
   id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
+  risk_score, likelihood_score, impact_score, confidence_score, likelihood_level, impact_level, risk_reasons_json, risk_model_version,
   resource_urns_json, event_ids_json, observed_policy_ids_json, control_refs_json, notes_json, tickets_json, attributes_json,
   policy_id, policy_name, check_id, check_name, assignee, due_at, status_reason,
   status_updated_at, first_observed_at, last_observed_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb, $12::jsonb, $13::jsonb, $14::jsonb, $15::jsonb, $16::jsonb, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16::jsonb, $17, $18::jsonb, $19::jsonb, $20::jsonb, $21::jsonb, $22::jsonb, $23::jsonb, $24::jsonb, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34)
 ON CONFLICT (id)
 DO UPDATE SET
   fingerprint = EXCLUDED.fingerprint,
@@ -104,6 +128,14 @@ DO UPDATE SET
     ELSE EXCLUDED.status
   END,
   summary = EXCLUDED.summary,
+  risk_score = EXCLUDED.risk_score,
+  likelihood_score = EXCLUDED.likelihood_score,
+  impact_score = EXCLUDED.impact_score,
+  confidence_score = EXCLUDED.confidence_score,
+  likelihood_level = EXCLUDED.likelihood_level,
+  impact_level = EXCLUDED.impact_level,
+  risk_reasons_json = EXCLUDED.risk_reasons_json,
+  risk_model_version = EXCLUDED.risk_model_version,
   resource_urns_json = EXCLUDED.resource_urns_json,
   event_ids_json = EXCLUDED.event_ids_json,
   observed_policy_ids_json = EXCLUDED.observed_policy_ids_json,
@@ -137,11 +169,7 @@ DO UPDATE SET
   first_observed_at = LEAST(findings.first_observed_at, EXCLUDED.first_observed_at),
   last_observed_at = GREATEST(findings.last_observed_at, EXCLUDED.last_observed_at),
   updated_at = NOW()
-RETURNING
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
-  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
-  status_updated_at, first_observed_at, last_observed_at`
+RETURNING ` + findingSelectColumns
 
 // UpsertFinding persists one normalized finding in the current-state store.
 func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord) (*ports.FindingRecord, error) {
@@ -218,6 +246,10 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord)
 	if err != nil {
 		return nil, fmt.Errorf("marshal finding attributes: %w", err)
 	}
+	riskReasonsJSON, err := findingStringsJSON(finding.RiskReasons)
+	if err != nil {
+		return nil, fmt.Errorf("marshal finding risk reasons: %w", err)
+	}
 	policyID := strings.TrimSpace(finding.PolicyID)
 	policyName := strings.TrimSpace(finding.PolicyName)
 	checkID := strings.TrimSpace(finding.CheckID)
@@ -234,7 +266,7 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord)
 	}
 	firstObservedAt, lastObservedAt := normalizeFindingObservationWindow(finding.FirstObservedAt, finding.LastObservedAt, time.Now().UTC())
 	var stored findingRow
-	if err := s.db.QueryRowContext(ctx, upsertFindingStatement,
+	if err := scanFindingRow(s.db.QueryRowContext(ctx, upsertFindingStatement,
 		id,
 		fingerprint,
 		tenantID,
@@ -244,6 +276,14 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord)
 		severity,
 		status,
 		summary,
+		finding.RiskScore,
+		finding.LikelihoodScore,
+		finding.ImpactScore,
+		finding.ConfidenceScore,
+		strings.TrimSpace(finding.LikelihoodLevel),
+		strings.TrimSpace(finding.ImpactLevel),
+		riskReasonsJSON,
+		strings.TrimSpace(finding.RiskModelVersion),
 		resourceURNsJSON,
 		eventIDsJSON,
 		observedPolicyIDsJSON,
@@ -261,34 +301,7 @@ func (s *Store) UpsertFinding(ctx context.Context, finding *ports.FindingRecord)
 		statusUpdatedAt,
 		firstObservedAt,
 		lastObservedAt,
-	).Scan(
-		&stored.ID,
-		&stored.Fingerprint,
-		&stored.TenantID,
-		&stored.RuntimeID,
-		&stored.RuleID,
-		&stored.Title,
-		&stored.Severity,
-		&stored.Status,
-		&stored.Summary,
-		&stored.ResourceURNsJSON,
-		&stored.EventIDsJSON,
-		&stored.ObservedPolicyIDsJSON,
-		&stored.ControlRefsJSON,
-		&stored.NotesJSON,
-		&stored.TicketsJSON,
-		&stored.PolicyID,
-		&stored.PolicyName,
-		&stored.CheckID,
-		&stored.CheckName,
-		&stored.AttributesJSON,
-		&stored.Assignee,
-		&stored.DueAt,
-		&stored.StatusReason,
-		&stored.StatusUpdatedAt,
-		&stored.FirstObservedAt,
-		&stored.LastObservedAt,
-	); err != nil {
+	), &stored); err != nil {
 		return nil, fmt.Errorf("upsert finding %q: %w", id, err)
 	}
 	return stored.record()
@@ -350,34 +363,7 @@ func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequ
 	findings := []*ports.FindingRecord{}
 	for rows.Next() {
 		var row findingRow
-		if err := rows.Scan(
-			&row.ID,
-			&row.Fingerprint,
-			&row.TenantID,
-			&row.RuntimeID,
-			&row.RuleID,
-			&row.Title,
-			&row.Severity,
-			&row.Status,
-			&row.Summary,
-			&row.ResourceURNsJSON,
-			&row.EventIDsJSON,
-			&row.ObservedPolicyIDsJSON,
-			&row.ControlRefsJSON,
-			&row.NotesJSON,
-			&row.TicketsJSON,
-			&row.PolicyID,
-			&row.PolicyName,
-			&row.CheckID,
-			&row.CheckName,
-			&row.AttributesJSON,
-			&row.Assignee,
-			&row.DueAt,
-			&row.StatusReason,
-			&row.StatusUpdatedAt,
-			&row.FirstObservedAt,
-			&row.LastObservedAt,
-		); err != nil {
+		if err := scanFindingRow(rows, &row); err != nil {
 			return nil, fmt.Errorf("scan finding row: %w", err)
 		}
 		record, err := row.record()
@@ -480,43 +466,12 @@ func (s *Store) GetFinding(ctx context.Context, id string) (*ports.FindingRecord
 		return nil, errors.New("finding id is required")
 	}
 	var row findingRow
-	if err := s.db.QueryRowContext(ctx, `
-SELECT
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
-  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
-  status_updated_at, first_observed_at, last_observed_at
+	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
+SELECT `+findingSelectColumns+`
 FROM findings
 WHERE id = $1`,
 		findingID,
-	).Scan(
-		&row.ID,
-		&row.Fingerprint,
-		&row.TenantID,
-		&row.RuntimeID,
-		&row.RuleID,
-		&row.Title,
-		&row.Severity,
-		&row.Status,
-		&row.Summary,
-		&row.ResourceURNsJSON,
-		&row.EventIDsJSON,
-		&row.ObservedPolicyIDsJSON,
-		&row.ControlRefsJSON,
-		&row.NotesJSON,
-		&row.TicketsJSON,
-		&row.PolicyID,
-		&row.PolicyName,
-		&row.CheckID,
-		&row.CheckName,
-		&row.AttributesJSON,
-		&row.Assignee,
-		&row.DueAt,
-		&row.StatusReason,
-		&row.StatusUpdatedAt,
-		&row.FirstObservedAt,
-		&row.LastObservedAt,
-	); err != nil {
+	), &row); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ports.ErrFindingNotFound
 		}
@@ -547,47 +502,16 @@ func (s *Store) UpdateFindingStatus(ctx context.Context, request ports.FindingSt
 		updatedAt = time.Now().UTC()
 	}
 	var row findingRow
-	if err := s.db.QueryRowContext(ctx, `
+	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
 UPDATE findings
 SET status = $2, status_reason = $3, status_updated_at = $4, updated_at = NOW()
 WHERE id = $1
-RETURNING
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
-  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
-  status_updated_at, first_observed_at, last_observed_at`,
+RETURNING `+findingSelectColumns,
 		findingID,
 		status,
 		statusReason,
 		updatedAt,
-	).Scan(
-		&row.ID,
-		&row.Fingerprint,
-		&row.TenantID,
-		&row.RuntimeID,
-		&row.RuleID,
-		&row.Title,
-		&row.Severity,
-		&row.Status,
-		&row.Summary,
-		&row.ResourceURNsJSON,
-		&row.EventIDsJSON,
-		&row.ObservedPolicyIDsJSON,
-		&row.ControlRefsJSON,
-		&row.NotesJSON,
-		&row.TicketsJSON,
-		&row.PolicyID,
-		&row.PolicyName,
-		&row.CheckID,
-		&row.CheckName,
-		&row.AttributesJSON,
-		&row.Assignee,
-		&row.DueAt,
-		&row.StatusReason,
-		&row.StatusUpdatedAt,
-		&row.FirstObservedAt,
-		&row.LastObservedAt,
-	); err != nil {
+	), &row); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ports.ErrFindingNotFound
 		}
@@ -609,45 +533,14 @@ func (s *Store) UpdateFindingAssignee(ctx context.Context, request ports.Finding
 		return nil, errors.New("finding id is required")
 	}
 	var row findingRow
-	if err := s.db.QueryRowContext(ctx, `
+	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
 UPDATE findings
 SET assignee = $2, updated_at = NOW()
 WHERE id = $1
-RETURNING
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
-  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
-  status_updated_at, first_observed_at, last_observed_at`,
+RETURNING `+findingSelectColumns,
 		findingID,
 		strings.TrimSpace(request.Assignee),
-	).Scan(
-		&row.ID,
-		&row.Fingerprint,
-		&row.TenantID,
-		&row.RuntimeID,
-		&row.RuleID,
-		&row.Title,
-		&row.Severity,
-		&row.Status,
-		&row.Summary,
-		&row.ResourceURNsJSON,
-		&row.EventIDsJSON,
-		&row.ObservedPolicyIDsJSON,
-		&row.ControlRefsJSON,
-		&row.NotesJSON,
-		&row.TicketsJSON,
-		&row.PolicyID,
-		&row.PolicyName,
-		&row.CheckID,
-		&row.CheckName,
-		&row.AttributesJSON,
-		&row.Assignee,
-		&row.DueAt,
-		&row.StatusReason,
-		&row.StatusUpdatedAt,
-		&row.FirstObservedAt,
-		&row.LastObservedAt,
-	); err != nil {
+	), &row); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ports.ErrFindingNotFound
 		}
@@ -673,45 +566,14 @@ func (s *Store) UpdateFindingDueDate(ctx context.Context, request ports.FindingD
 		return nil, errors.New("finding due date is required")
 	}
 	var row findingRow
-	if err := s.db.QueryRowContext(ctx, `
+	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
 UPDATE findings
 SET due_at = $2, updated_at = NOW()
 WHERE id = $1
-RETURNING
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
-  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
-  status_updated_at, first_observed_at, last_observed_at`,
+RETURNING `+findingSelectColumns,
 		findingID,
 		dueAt,
-	).Scan(
-		&row.ID,
-		&row.Fingerprint,
-		&row.TenantID,
-		&row.RuntimeID,
-		&row.RuleID,
-		&row.Title,
-		&row.Severity,
-		&row.Status,
-		&row.Summary,
-		&row.ResourceURNsJSON,
-		&row.EventIDsJSON,
-		&row.ObservedPolicyIDsJSON,
-		&row.ControlRefsJSON,
-		&row.NotesJSON,
-		&row.TicketsJSON,
-		&row.PolicyID,
-		&row.PolicyName,
-		&row.CheckID,
-		&row.CheckName,
-		&row.AttributesJSON,
-		&row.Assignee,
-		&row.DueAt,
-		&row.StatusReason,
-		&row.StatusUpdatedAt,
-		&row.FirstObservedAt,
-		&row.LastObservedAt,
-	); err != nil {
+	), &row); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ports.ErrFindingNotFound
 		}
@@ -740,45 +602,14 @@ func (s *Store) AddFindingNote(ctx context.Context, request ports.FindingNoteCre
 		return nil, errors.New("finding note is required")
 	}
 	var row findingRow
-	if err := s.db.QueryRowContext(ctx, `
+	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
 UPDATE findings
 SET notes_json = COALESCE(notes_json, '[]'::jsonb) || $2::jsonb, updated_at = NOW()
 WHERE id = $1
-RETURNING
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
-  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
-  status_updated_at, first_observed_at, last_observed_at`,
+RETURNING `+findingSelectColumns,
 		findingID,
 		notesJSON,
-	).Scan(
-		&row.ID,
-		&row.Fingerprint,
-		&row.TenantID,
-		&row.RuntimeID,
-		&row.RuleID,
-		&row.Title,
-		&row.Severity,
-		&row.Status,
-		&row.Summary,
-		&row.ResourceURNsJSON,
-		&row.EventIDsJSON,
-		&row.ObservedPolicyIDsJSON,
-		&row.ControlRefsJSON,
-		&row.NotesJSON,
-		&row.TicketsJSON,
-		&row.PolicyID,
-		&row.PolicyName,
-		&row.CheckID,
-		&row.CheckName,
-		&row.AttributesJSON,
-		&row.Assignee,
-		&row.DueAt,
-		&row.StatusReason,
-		&row.StatusUpdatedAt,
-		&row.FirstObservedAt,
-		&row.LastObservedAt,
-	); err != nil {
+	), &row); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ports.ErrFindingNotFound
 		}
@@ -811,7 +642,7 @@ func (s *Store) LinkFindingTicket(ctx context.Context, request ports.FindingTick
 		return nil, fmt.Errorf("marshal finding ticket dedupe: %w", err)
 	}
 	var row findingRow
-	if err := s.db.QueryRowContext(ctx, `
+	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
 UPDATE findings
 SET tickets_json = CASE
       WHEN COALESCE(tickets_json, '[]'::jsonb) @> $3::jsonb THEN COALESCE(tickets_json, '[]'::jsonb)
@@ -819,42 +650,11 @@ SET tickets_json = CASE
     END,
     updated_at = NOW()
 WHERE id = $1
-RETURNING
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
-  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
-  status_updated_at, first_observed_at, last_observed_at`,
+RETURNING `+findingSelectColumns,
 		findingID,
 		ticketsJSON,
 		dedupeJSON,
-	).Scan(
-		&row.ID,
-		&row.Fingerprint,
-		&row.TenantID,
-		&row.RuntimeID,
-		&row.RuleID,
-		&row.Title,
-		&row.Severity,
-		&row.Status,
-		&row.Summary,
-		&row.ResourceURNsJSON,
-		&row.EventIDsJSON,
-		&row.ObservedPolicyIDsJSON,
-		&row.ControlRefsJSON,
-		&row.NotesJSON,
-		&row.TicketsJSON,
-		&row.PolicyID,
-		&row.PolicyName,
-		&row.CheckID,
-		&row.CheckName,
-		&row.AttributesJSON,
-		&row.Assignee,
-		&row.DueAt,
-		&row.StatusReason,
-		&row.StatusUpdatedAt,
-		&row.FirstObservedAt,
-		&row.LastObservedAt,
-	); err != nil {
+	), &row); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ports.ErrFindingNotFound
 		}
@@ -869,14 +669,10 @@ func findingListQuery(request ports.ListFindingsRequest) (string, []any, error) 
 		return "", nil, err
 	}
 	query := `
-SELECT
-  id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
-  resource_urns_json::text, event_ids_json::text, observed_policy_ids_json::text, control_refs_json::text,
-  notes_json::text, tickets_json::text, policy_id, policy_name, check_id, check_name, attributes_json::text, assignee, due_at, status_reason,
-  status_updated_at, first_observed_at, last_observed_at
+SELECT ` + findingSelectColumns + `
 FROM findings
 WHERE ` + strings.Join(clauses, " AND ") + `
-ORDER BY ` + findingOrderClause(request.PriorityOrder)
+ORDER BY ` + findingOrderClause(request)
 	if request.Limit != 0 {
 		args = append(args, int64(request.Limit))
 		query += fmt.Sprintf(" LIMIT $%d", len(args))
@@ -916,11 +712,12 @@ func (s *Store) ensureFindingTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.findingTablesReady, "findings", ensureFindingStatements)
 }
 
-func findingOrderClause(priorityOrder bool) string {
-	if !priorityOrder {
-		return "last_observed_at DESC, id"
-	}
-	return `CASE UPPER(severity)
+func findingOrderClause(request ports.ListFindingsRequest) string {
+	switch {
+	case request.Order == ports.FindingOrderRiskScore:
+		return "risk_score DESC, last_observed_at DESC, id"
+	case request.Order == ports.FindingOrderPriority || request.PriorityOrder:
+		return `risk_score DESC, CASE UPPER(severity)
   WHEN 'CRITICAL' THEN 0
   WHEN 'HIGH' THEN 1
   WHEN 'MEDIUM' THEN 2
@@ -928,6 +725,9 @@ func findingOrderClause(priorityOrder bool) string {
   WHEN 'INFO' THEN 4
   ELSE 5
 END, last_observed_at DESC, id`
+	default:
+		return "last_observed_at DESC, id"
+	}
 }
 
 func findingStringsJSON(values []string) (string, error) {
@@ -1092,16 +892,32 @@ type findingWorkflowRow struct {
 	StatusUpdatedAt sql.NullTime
 }
 
+type findingRowScanner interface {
+	Scan(dest ...any) error
+}
+
+type findingRiskRow struct {
+	RiskScore        int
+	LikelihoodScore  int
+	ImpactScore      int
+	ConfidenceScore  int
+	LikelihoodLevel  string
+	ImpactLevel      string
+	RiskReasonsJSON  string
+	RiskModelVersion string
+}
+
 type findingRow struct {
-	ID                    string
-	Fingerprint           string
-	TenantID              string
-	RuntimeID             string
-	RuleID                string
-	Title                 string
-	Severity              string
-	Status                string
-	Summary               string
+	ID          string
+	Fingerprint string
+	TenantID    string
+	RuntimeID   string
+	RuleID      string
+	Title       string
+	Severity    string
+	Status      string
+	Summary     string
+	findingRiskRow
 	ResourceURNsJSON      string
 	EventIDsJSON          string
 	ObservedPolicyIDsJSON string
@@ -1114,6 +930,45 @@ type findingRow struct {
 	findingWorkflowRow
 	FirstObservedAt time.Time
 	LastObservedAt  time.Time
+}
+
+func scanFindingRow(scanner findingRowScanner, row *findingRow) error {
+	return scanner.Scan(
+		&row.ID,
+		&row.Fingerprint,
+		&row.TenantID,
+		&row.RuntimeID,
+		&row.RuleID,
+		&row.Title,
+		&row.Severity,
+		&row.Status,
+		&row.Summary,
+		&row.RiskScore,
+		&row.LikelihoodScore,
+		&row.ImpactScore,
+		&row.ConfidenceScore,
+		&row.LikelihoodLevel,
+		&row.ImpactLevel,
+		&row.RiskReasonsJSON,
+		&row.RiskModelVersion,
+		&row.ResourceURNsJSON,
+		&row.EventIDsJSON,
+		&row.ObservedPolicyIDsJSON,
+		&row.ControlRefsJSON,
+		&row.NotesJSON,
+		&row.TicketsJSON,
+		&row.PolicyID,
+		&row.PolicyName,
+		&row.CheckID,
+		&row.CheckName,
+		&row.AttributesJSON,
+		&row.Assignee,
+		&row.DueAt,
+		&row.StatusReason,
+		&row.StatusUpdatedAt,
+		&row.FirstObservedAt,
+		&row.LastObservedAt,
+	)
 }
 
 func (r findingRow) record() (*ports.FindingRecord, error) {
@@ -1133,6 +988,12 @@ func (r findingRow) record() (*ports.FindingRecord, error) {
 	if err := json.Unmarshal([]byte(r.ControlRefsJSON), &controlRefs); err != nil {
 		return nil, fmt.Errorf("decode finding control refs: %w", err)
 	}
+	riskReasons := []string{}
+	if strings.TrimSpace(r.RiskReasonsJSON) != "" {
+		if err := json.Unmarshal([]byte(r.RiskReasonsJSON), &riskReasons); err != nil {
+			return nil, fmt.Errorf("decode finding risk reasons: %w", err)
+		}
+	}
 	notes := []ports.FindingNote{}
 	if err := json.Unmarshal([]byte(r.NotesJSON), &notes); err != nil {
 		return nil, fmt.Errorf("decode finding notes: %w", err)
@@ -1146,15 +1007,25 @@ func (r findingRow) record() (*ports.FindingRecord, error) {
 		return nil, fmt.Errorf("decode finding attributes: %w", err)
 	}
 	return &ports.FindingRecord{
-		ID:                r.ID,
-		Fingerprint:       r.Fingerprint,
-		TenantID:          r.TenantID,
-		RuntimeID:         r.RuntimeID,
-		RuleID:            r.RuleID,
-		Title:             r.Title,
-		Severity:          r.Severity,
-		Status:            r.Status,
-		Summary:           r.Summary,
+		ID:          r.ID,
+		Fingerprint: r.Fingerprint,
+		TenantID:    r.TenantID,
+		RuntimeID:   r.RuntimeID,
+		RuleID:      r.RuleID,
+		Title:       r.Title,
+		Severity:    r.Severity,
+		Status:      r.Status,
+		Summary:     r.Summary,
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        r.RiskScore,
+			LikelihoodScore:  r.LikelihoodScore,
+			ImpactScore:      r.ImpactScore,
+			ConfidenceScore:  r.ConfidenceScore,
+			LikelihoodLevel:  r.LikelihoodLevel,
+			ImpactLevel:      r.ImpactLevel,
+			RiskReasons:      riskReasons,
+			RiskModelVersion: r.RiskModelVersion,
+		},
 		ResourceURNs:      resourceURNs,
 		EventIDs:          eventIDs,
 		ObservedPolicyIDs: observedPolicyIDs,

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -72,6 +72,111 @@ var ensureFindingStatements = []string{
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS impact_level TEXT NOT NULL DEFAULT ''`,
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS risk_reasons_json JSONB NOT NULL DEFAULT '[]'::jsonb`,
 	`ALTER TABLE findings ADD COLUMN IF NOT EXISTS risk_model_version TEXT NOT NULL DEFAULT ''`,
+	`WITH risk_signals AS (
+  SELECT
+    id,
+    CASE UPPER(severity)
+      WHEN 'CRITICAL' THEN 4
+      WHEN 'HIGH' THEN 3
+      WHEN 'MEDIUM' THEN 2
+      WHEN 'LOW' THEN 1
+      ELSE 0
+    END AS severity_score,
+    UPPER(severity) AS severity_level,
+    status = 'open' AS is_open,
+    due_at IS NOT NULL AND due_at < NOW() AS is_overdue,
+    jsonb_array_length(event_ids_json) AS event_count,
+    jsonb_array_length(resource_urns_json) AS resource_count,
+    jsonb_array_length(control_refs_json) AS control_count,
+    LOWER(COALESCE(attributes_json->>'internet_exposed', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'public', 'external')
+      OR LOWER(COALESCE(attributes_json->>'public', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'public', 'external')
+      OR LOWER(COALESCE(attributes_json->>'externally_exposed', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'public', 'external')
+      AS external_exposure,
+    LOWER(COALESCE(attributes_json->>'actor_privileged', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'critical')
+      OR LOWER(COALESCE(attributes_json->>'privileged', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'critical')
+      AS privileged_actor,
+    LOWER(COALESCE(attributes_json->>'is_kev', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled')
+      OR LOWER(COALESCE(attributes_json->>'known_exploited', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled')
+      AS known_exploited,
+    LOWER(COALESCE(attributes_json->>'asset_criticality', attributes_json->>'criticality', '')) IN ('critical', 'high', 'crown', 'tier0', 'tier-0')
+      AS critical_asset,
+    LOWER(COALESCE(attributes_json->>'data_classification', attributes_json->>'sensitivity', attributes_json->>'data_sensitivity', '')) ~ '(secret|sensitive|confidential|restricted)'
+      AS sensitive_data,
+    LOWER(COALESCE(attributes_json->>'crown_jewel', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled', 'critical')
+      OR LOWER(COALESCE(attributes_json->>'contains_secrets', '')) IN ('1', 't', 'true', 'yes', 'y', 'enabled')
+      AS crown_jewel,
+    LOWER(COALESCE(attributes_json->>'environment', attributes_json->>'env', attributes_json->>'stage', '')) ~ '(prod|production)'
+      AS production_environment
+  FROM findings
+  WHERE risk_model_version = '' OR risk_score = 0
+),
+risk_scored AS (
+  SELECT
+    id,
+    LEAST(100, GREATEST(0,
+      10
+      + severity_score * 6
+      + CASE WHEN is_open THEN 5 ELSE 0 END
+      + CASE WHEN event_count > 1 THEN LEAST(event_count * 2, 10) ELSE 0 END
+      + CASE WHEN external_exposure THEN 35 ELSE 0 END
+      + CASE WHEN privileged_actor THEN 10 ELSE 0 END
+      + CASE WHEN known_exploited THEN 35 ELSE 0 END
+    ))::int AS likelihood_score,
+    LEAST(100, GREATEST(0,
+      10
+      + severity_score * 8
+      + CASE WHEN is_overdue THEN 5 ELSE 0 END
+      + CASE WHEN resource_count > 1 THEN LEAST(resource_count * 2, 12) ELSE 0 END
+      + CASE WHEN control_count > 0 THEN LEAST(control_count * 2, 8) ELSE 0 END
+      + CASE WHEN critical_asset THEN 35 ELSE 0 END
+      + CASE WHEN privileged_actor THEN 15 ELSE 0 END
+      + CASE WHEN sensitive_data THEN 25 ELSE 0 END
+      + CASE WHEN crown_jewel THEN 35 ELSE 0 END
+      + CASE WHEN production_environment THEN 15 ELSE 0 END
+    ))::int AS impact_score,
+    70 AS confidence_score,
+    to_jsonb(array_remove(ARRAY[
+      CASE WHEN severity_score > 0 THEN 'severity:' || severity_level END,
+      CASE WHEN is_open THEN 'active' END,
+      CASE WHEN is_overdue THEN 'overdue' END,
+      CASE WHEN event_count > 1 THEN 'multiple_events' END,
+      CASE WHEN resource_count > 1 THEN 'multiple_resources' END,
+      CASE WHEN control_count > 0 THEN 'mapped_controls' END,
+      CASE WHEN external_exposure THEN 'external_exposure' END,
+      CASE WHEN privileged_actor THEN 'privileged_actor' END,
+      CASE WHEN known_exploited THEN 'known_exploited' END,
+      CASE WHEN critical_asset THEN 'critical_asset' END,
+      CASE WHEN sensitive_data THEN 'sensitive_data' END,
+      CASE WHEN crown_jewel THEN 'crown_jewel' END,
+      CASE WHEN production_environment THEN 'production_environment' END
+    ], NULL)) AS risk_reasons_json
+  FROM risk_signals
+)
+UPDATE findings
+SET
+  likelihood_score = risk_scored.likelihood_score,
+  impact_score = risk_scored.impact_score,
+  confidence_score = risk_scored.confidence_score,
+  risk_score = LEAST(100, GREATEST(0, ROUND(SQRT((risk_scored.likelihood_score * risk_scored.impact_score)::double precision))::int)),
+  likelihood_level = CASE
+    WHEN risk_scored.likelihood_score >= 85 THEN 'critical'
+    WHEN risk_scored.likelihood_score >= 70 THEN 'high'
+    WHEN risk_scored.likelihood_score >= 40 THEN 'medium'
+    WHEN risk_scored.likelihood_score > 0 THEN 'low'
+    ELSE ''
+  END,
+  impact_level = CASE
+    WHEN risk_scored.impact_score >= 85 THEN 'critical'
+    WHEN risk_scored.impact_score >= 70 THEN 'high'
+    WHEN risk_scored.impact_score >= 40 THEN 'medium'
+    WHEN risk_scored.impact_score > 0 THEN 'low'
+    ELSE ''
+  END,
+  risk_reasons_json = risk_scored.risk_reasons_json,
+  risk_model_version = 'likelihood-impact-v1',
+  updated_at = NOW()
+FROM risk_scored
+WHERE findings.id = risk_scored.id`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_rule_idx ON findings (runtime_id, rule_id)`,
 	`CREATE INDEX IF NOT EXISTS findings_tenant_rule_idx ON findings (tenant_id, rule_id)`,
 	`CREATE INDEX IF NOT EXISTS findings_runtime_policy_idx ON findings (runtime_id, policy_id)`,
@@ -715,7 +820,14 @@ func (s *Store) ensureFindingTables(ctx context.Context) error {
 func findingOrderClause(request ports.ListFindingsRequest) string {
 	switch {
 	case request.Order == ports.FindingOrderRiskScore:
-		return "risk_score DESC, last_observed_at DESC, id"
+		return `risk_score DESC, CASE UPPER(severity)
+  WHEN 'CRITICAL' THEN 0
+  WHEN 'HIGH' THEN 1
+  WHEN 'MEDIUM' THEN 2
+  WHEN 'LOW' THEN 3
+  WHEN 'INFO' THEN 4
+  ELSE 5
+END, last_observed_at DESC, id`
 	case request.Order == ports.FindingOrderPriority || request.PriorityOrder:
 		return `risk_score DESC, CASE UPPER(severity)
   WHEN 'CRITICAL' THEN 0

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -759,7 +759,7 @@ func (s *Store) BackfillFindingRisk(ctx context.Context) ([]*ports.FindingRecord
 }
 
 func (s *Store) backfillFindingRisk(ctx context.Context) (updated []*ports.FindingRecord, err error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT `+findingSelectColumns+` FROM findings WHERE risk_model_version <> $1 OR risk_score = 0`, "likelihood-impact-v1")
+	rows, err := s.db.QueryContext(ctx, `SELECT `+findingSelectColumns+` FROM findings WHERE risk_model_version <> $1 OR risk_score = 0 OR COALESCE(attributes_json->>'`+findingrisk.FindingRiskGraphProjectedModelVersionAttribute+`', '') <> $1`, "likelihood-impact-v1")
 	if err != nil {
 		return nil, fmt.Errorf("list findings for risk backfill: %w", err)
 	}

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -348,9 +348,6 @@ func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequ
 	if err := s.ensureFindingTables(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.refreshFindingRiskForList(ctx, request); err != nil {
-		return nil, err
-	}
 	query, args, err := findingListQuery(request)
 	if err != nil {
 		return nil, err
@@ -379,6 +376,10 @@ func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequ
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate findings rows: %w", err)
+	}
+	findings, err = s.refreshFindingRiskRecords(ctx, findings)
+	if err != nil {
+		return nil, err
 	}
 	return findings, nil
 }
@@ -469,9 +470,6 @@ func (s *Store) GetFinding(ctx context.Context, id string) (*ports.FindingRecord
 	findingID := strings.TrimSpace(id)
 	if findingID == "" {
 		return nil, errors.New("finding id is required")
-	}
-	if err := s.refreshFindingRiskForID(ctx, findingID); err != nil {
-		return nil, err
 	}
 	var row findingRow
 	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
@@ -854,65 +852,26 @@ func findingBackfillRisk(record *ports.FindingRecord, now time.Time) ports.Findi
 	}
 }
 
-func (s *Store) refreshFindingRiskForID(ctx context.Context, findingID string) error {
-	return s.refreshFindingRiskRows(ctx, `SELECT `+findingSelectColumns+` FROM findings WHERE id = $1 AND `+findingTimeSensitiveRiskPredicate(), strings.TrimSpace(findingID))
-}
-
-func (s *Store) refreshFindingRiskForList(ctx context.Context, request ports.ListFindingsRequest) error {
-	clauses, args, err := findingFilterClauses(request)
-	if err != nil {
-		return err
-	}
-	clauses = append(clauses, findingTimeSensitiveRiskPredicate())
-	return s.refreshFindingRiskRows(ctx, `SELECT `+findingSelectColumns+` FROM findings WHERE `+strings.Join(clauses, " AND "), args...)
-}
-
-func findingTimeSensitiveRiskPredicate() string {
-	return `(due_at IS NOT NULL OR last_observed_at IS NOT NULL)`
-}
-
-func (s *Store) refreshFindingRiskRows(ctx context.Context, query string, args ...any) (err error) {
-	rows, err := s.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return fmt.Errorf("list findings for risk refresh: %w", err)
-	}
-	defer func() {
-		if closeErr := rows.Close(); closeErr != nil && err == nil {
-			err = fmt.Errorf("close finding risk refresh rows: %w", closeErr)
-		}
-	}()
-	type riskRefresh struct {
-		id   string
-		risk ports.FindingRisk
+func (s *Store) refreshFindingRiskRecords(ctx context.Context, findings []*ports.FindingRecord) ([]*ports.FindingRecord, error) {
+	if len(findings) == 0 {
+		return findings, nil
 	}
 	now := time.Now().UTC()
-	updates := []riskRefresh{}
-	for rows.Next() {
-		var row findingRow
-		if err := scanFindingRow(rows, &row); err != nil {
-			return fmt.Errorf("scan finding risk refresh row: %w", err)
-		}
-		record, err := row.record()
-		if err != nil {
-			return fmt.Errorf("decode finding risk refresh row: %w", err)
+	refreshedFindings := append([]*ports.FindingRecord(nil), findings...)
+	for index, record := range refreshedFindings {
+		if record == nil {
+			continue
 		}
 		refreshed := findingBackfillRisk(record, now)
 		if !findingRiskEqual(record.FindingRisk, refreshed) {
-			updates = append(updates, riskRefresh{id: strings.TrimSpace(record.ID), risk: refreshed})
+			stored, err := s.updateFindingRiskColumns(ctx, strings.TrimSpace(record.ID), refreshed, findingRiskAttributesForUpdate(refreshed))
+			if err != nil {
+				return nil, fmt.Errorf("refresh finding %q risk: %w", strings.TrimSpace(record.ID), err)
+			}
+			refreshedFindings[index] = stored
 		}
 	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate finding risk refresh rows: %w", err)
-	}
-	for _, update := range updates {
-		if update.id == "" {
-			continue
-		}
-		if _, err := s.updateFindingRiskColumns(ctx, update.id, update.risk, findingRiskAttributesForUpdate(update.risk)); err != nil {
-			return fmt.Errorf("refresh finding %q risk: %w", update.id, err)
-		}
-	}
-	return nil
+	return refreshedFindings, nil
 }
 
 func findingRiskEqual(left ports.FindingRisk, right ports.FindingRisk) bool {

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -183,8 +184,8 @@ func TestFindingListQueryAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
 
 func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
 	query, args, err := findingListQuery(ports.ListFindingsRequest{
-		TenantID:    "writer",
-		RuntimeID:   "writer-okta-audit",
+		TenantID:    "tenant-a",
+		RuntimeID:   "runtime-audit",
 		FindingID:   "finding-1",
 		RuleID:      "identity-okta-policy-rule-lifecycle-tampering",
 		Severity:    "HIGH",
@@ -216,11 +217,11 @@ func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
 	if got := len(args); got != 10 {
 		t.Fatalf("len(findingListQuery().args) = %d, want 10", got)
 	}
-	if got := args[0]; got != "writer" {
-		t.Fatalf("findingListQuery().args[0] = %#v, want writer", got)
+	if got := args[0]; got != "tenant-a" {
+		t.Fatalf("findingListQuery().args[0] = %#v, want tenant-a", got)
 	}
-	if got := args[1]; got != "writer-okta-audit" {
-		t.Fatalf("findingListQuery().args[1] = %#v, want writer-okta-audit", got)
+	if got := args[1]; got != "runtime-audit" {
+		t.Fatalf("findingListQuery().args[1] = %#v, want runtime-audit", got)
 	}
 	if got := args[6]; got != "pol-1" {
 		t.Fatalf("findingListQuery().args[6] = %#v, want pol-1", got)
@@ -251,6 +252,7 @@ func TestFindingListQuerySupportsRuntimeBatchesAndPriorityOrder(t *testing.T) {
 		"tenant_id = $1",
 		"runtime_id IN ($2, $3)",
 		"status = $4",
+		"risk_score DESC",
 		"CASE UPPER(severity)",
 		"last_observed_at DESC, id",
 		"LIMIT $5",
@@ -275,15 +277,25 @@ func TestFindingListQuerySupportsRuntimeBatchesAndPriorityOrder(t *testing.T) {
 
 func TestFindingRowRecordDecodesCheckAndControlMetadata(t *testing.T) {
 	record, err := (findingRow{
-		ID:                    "finding-1",
-		Fingerprint:           "fingerprint-1",
-		TenantID:              "writer",
-		RuntimeID:             "writer-okta-audit",
-		RuleID:                "identity-okta-policy-rule-lifecycle-tampering",
-		Title:                 "Okta Policy Rule Lifecycle Tampering",
-		Severity:              "HIGH",
-		Status:                "open",
-		Summary:               "admin@writer.com performed policy.rule.update on pol-1",
+		ID:          "finding-1",
+		Fingerprint: "fingerprint-1",
+		TenantID:    "tenant-a",
+		RuntimeID:   "runtime-audit",
+		RuleID:      "identity-okta-policy-rule-lifecycle-tampering",
+		Title:       "Okta Policy Rule Lifecycle Tampering",
+		Severity:    "HIGH",
+		Status:      "open",
+		Summary:     "admin@example.invalid performed policy.rule.update on pol-1",
+		findingRiskRow: findingRiskRow{
+			RiskScore:        82,
+			LikelihoodScore:  78,
+			ImpactScore:      86,
+			ConfidenceScore:  93,
+			LikelihoodLevel:  "high",
+			ImpactLevel:      "critical",
+			RiskReasonsJSON:  `["external_exposure","privileged_actor"]`,
+			RiskModelVersion: "likelihood-impact-v1",
+		},
 		ResourceURNsJSON:      `["urn:cerebro:writer:okta_resource:policyrule:pol-1"]`,
 		EventIDsJSON:          `["okta-audit-2"]`,
 		ObservedPolicyIDsJSON: `["pol-1"]`,
@@ -312,6 +324,30 @@ func TestFindingRowRecordDecodesCheckAndControlMetadata(t *testing.T) {
 	}
 	if got := len(record.ControlRefs); got != 2 {
 		t.Fatalf("len(findingRow.record().ControlRefs) = %d, want 2", got)
+	}
+	if got := record.RiskScore; got != 82 {
+		t.Fatalf("findingRow.record().RiskScore = %d, want 82", got)
+	}
+	if got := record.LikelihoodScore; got != 78 {
+		t.Fatalf("findingRow.record().LikelihoodScore = %d, want 78", got)
+	}
+	if got := record.ImpactScore; got != 86 {
+		t.Fatalf("findingRow.record().ImpactScore = %d, want 86", got)
+	}
+	if got := record.ConfidenceScore; got != 93 {
+		t.Fatalf("findingRow.record().ConfidenceScore = %d, want 93", got)
+	}
+	if got := record.LikelihoodLevel; got != "high" {
+		t.Fatalf("findingRow.record().LikelihoodLevel = %q, want high", got)
+	}
+	if got := record.ImpactLevel; got != "critical" {
+		t.Fatalf("findingRow.record().ImpactLevel = %q, want critical", got)
+	}
+	if got := record.RiskModelVersion; got != "likelihood-impact-v1" {
+		t.Fatalf("findingRow.record().RiskModelVersion = %q, want likelihood-impact-v1", got)
+	}
+	if !slices.Contains(record.RiskReasons, "external_exposure") || !slices.Contains(record.RiskReasons, "privileged_actor") {
+		t.Fatalf("findingRow.record().RiskReasons = %#v, want typed risk reasons", record.RiskReasons)
 	}
 	if got := record.ControlRefs[0].FrameworkName; got != "SOC 2" {
 		t.Fatalf("findingRow.record().ControlRefs[0].FrameworkName = %q, want SOC 2", got)

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -153,17 +153,29 @@ func TestUpsertFindingStatementPreservesRuntimeIDOnConflict(t *testing.T) {
 	}
 }
 
-func TestEnsureFindingStatementsBackfillRiskColumns(t *testing.T) {
-	statements := strings.Join(ensureFindingStatements, "\n")
-	for _, fragment := range []string{
-		"UPDATE findings",
-		"risk_model_version = 'likelihood-impact-v1'",
-		"risk_score = LEAST",
-		"risk_reasons_json = risk_scored.risk_reasons_json",
-	} {
-		if !strings.Contains(statements, fragment) {
-			t.Fatalf("ensureFindingStatements missing risk backfill fragment %q", fragment)
-		}
+func TestFindingBackfillRiskUsesRuntimeScorerSignals(t *testing.T) {
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	risk := findingBackfillRisk(&ports.FindingRecord{
+		ID:             "finding-1",
+		Status:         "open",
+		Severity:       "HIGH",
+		LastObservedAt: now.Add(-30 * time.Minute),
+		Attributes: map[string]string{
+			"epss_score":    "0.9",
+			"network_scope": "private",
+		},
+	}, now)
+	if !slices.Contains(risk.RiskReasons, "epss_high") {
+		t.Fatalf("findingBackfillRisk().RiskReasons = %#v, want epss_high from runtime scorer", risk.RiskReasons)
+	}
+	if !slices.Contains(risk.RiskReasons, "recent_24h") {
+		t.Fatalf("findingBackfillRisk().RiskReasons = %#v, want recent_24h from runtime scorer", risk.RiskReasons)
+	}
+	if !slices.Contains(risk.RiskReasons, "private_network_context") {
+		t.Fatalf("findingBackfillRisk().RiskReasons = %#v, want private_network_context from runtime scorer", risk.RiskReasons)
+	}
+	if risk.RiskModelVersion != "likelihood-impact-v1" {
+		t.Fatalf("findingBackfillRisk().RiskModelVersion = %q, want likelihood-impact-v1", risk.RiskModelVersion)
 	}
 }
 

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -153,6 +153,20 @@ func TestUpsertFindingStatementPreservesRuntimeIDOnConflict(t *testing.T) {
 	}
 }
 
+func TestEnsureFindingStatementsBackfillRiskColumns(t *testing.T) {
+	statements := strings.Join(ensureFindingStatements, "\n")
+	for _, fragment := range []string{
+		"UPDATE findings",
+		"risk_model_version = 'likelihood-impact-v1'",
+		"risk_score = LEAST",
+		"risk_reasons_json = risk_scored.risk_reasons_json",
+	} {
+		if !strings.Contains(statements, fragment) {
+			t.Fatalf("ensureFindingStatements missing risk backfill fragment %q", fragment)
+		}
+	}
+}
+
 func TestFindingListQueryAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
 	query, args, err := findingListQuery(ports.ListFindingsRequest{
 		TenantID: "writer",
@@ -272,6 +286,26 @@ func TestFindingListQuerySupportsRuntimeBatchesAndPriorityOrder(t *testing.T) {
 	}
 	if got := args[4]; got != int64(25) {
 		t.Fatalf("findingListQuery().args[4] = %#v, want 25", got)
+	}
+}
+
+func TestFindingListQueryRiskOrderKeepsSeverityTieBreak(t *testing.T) {
+	query, _, err := findingListQuery(ports.ListFindingsRequest{
+		TenantID:  "tenant-a",
+		RuntimeID: "runtime-audit",
+		Order:     ports.FindingOrderRiskScore,
+	})
+	if err != nil {
+		t.Fatalf("findingListQuery() error = %v", err)
+	}
+	riskIndex := strings.Index(query, "risk_score DESC")
+	severityIndex := strings.Index(query, "CASE UPPER(severity)")
+	observedIndex := strings.Index(query, "last_observed_at DESC")
+	if riskIndex == -1 || severityIndex == -1 || observedIndex == -1 {
+		t.Fatalf("findingListQuery() query missing risk/severity/observed ordering: %s", query)
+	}
+	if riskIndex >= severityIndex || severityIndex >= observedIndex {
+		t.Fatalf("findingListQuery() ordering = %s, want risk then severity tie-break then recency", query)
 	}
 }
 

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -278,7 +278,6 @@ func TestFindingListQuerySupportsRuntimeBatchesAndPriorityOrder(t *testing.T) {
 		"tenant_id = $1",
 		"runtime_id IN ($2, $3)",
 		"status = $4",
-		"risk_score DESC",
 		"CASE UPPER(severity)",
 		"last_observed_at DESC, id",
 		"LIMIT $5",
@@ -286,6 +285,9 @@ func TestFindingListQuerySupportsRuntimeBatchesAndPriorityOrder(t *testing.T) {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("findingListQuery() query missing %q: %s", fragment, query)
 		}
+	}
+	if strings.Contains(query, "risk_score DESC") {
+		t.Fatalf("findingListQuery() priority order includes risk score ordering: %s", query)
 	}
 	if got := len(args); got != 5 {
 		t.Fatalf("len(findingListQuery().args) = %d, want 5", got)

--- a/internal/workflowevents/events.go
+++ b/internal/workflowevents/events.go
@@ -146,9 +146,20 @@ type FindingSnapshot struct {
 	ResourceCount      int                         `json:"resource_count,omitempty"`
 	EventCount         int                         `json:"event_count,omitempty"`
 	ControlRefs        []FindingControlRefSnapshot `json:"control_refs,omitempty"`
-	RiskScore          int                         `json:"risk_score,omitempty"`
-	RiskReasons        []string                    `json:"risk_reasons,omitempty"`
-	Metadata           map[string]string           `json:"metadata,omitempty"`
+	FindingRiskSnapshot
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// FindingRiskSnapshot captures normalized finding risk scoring metadata in workflow events.
+type FindingRiskSnapshot struct {
+	RiskScore        int      `json:"risk_score,omitempty"`
+	LikelihoodScore  int      `json:"likelihood_score,omitempty"`
+	ImpactScore      int      `json:"impact_score,omitempty"`
+	ConfidenceScore  int      `json:"confidence_score,omitempty"`
+	LikelihoodLevel  string   `json:"likelihood_level,omitempty"`
+	ImpactLevel      string   `json:"impact_level,omitempty"`
+	RiskModelVersion string   `json:"risk_model_version,omitempty"`
+	RiskReasons      []string `json:"risk_reasons,omitempty"`
 }
 
 // FindingControlRefSnapshot captures one generic compliance/control reference for graph projection.

--- a/internal/workflowevents/events.go
+++ b/internal/workflowevents/events.go
@@ -240,6 +240,18 @@ func NewFindingRecordedEvent(payload FindingRecorded) (*cerebrov1.EventEnvelope,
 	})
 }
 
+// NewFindingRecordedRevisionEvent builds a non-deduplicated finding record event.
+func NewFindingRecordedRevisionEvent(payload FindingRecorded, revision string) (*cerebrov1.EventEnvelope, error) {
+	primaryID := payload.Finding.FindingID
+	if trimmed := strings.TrimSpace(revision); trimmed != "" {
+		primaryID += "|" + trimmed
+	}
+	return newEvent(EventKindFindingRecorded, SchemaFindingRecorded, payload.Finding.TenantID, payload.Finding.SourceSystem, primaryID, payload.RecordedAt, payload, map[string]string{
+		EventAttributeWorkflowKind: "finding_record",
+		EventAttributeFindingID:    payload.Finding.FindingID,
+	})
+}
+
 // NewFindingNoteAddedEvent builds the durable event envelope for one finding note.
 func NewFindingNoteAddedEvent(payload FindingNoteAdded) (*cerebrov1.EventEnvelope, error) {
 	return newEvent(EventKindFindingNoteAdded, SchemaFindingNoteAdded, payload.Finding.TenantID, payload.Finding.SourceSystem, payload.Finding.FindingID+"|"+payload.NoteID, payload.CreatedAt, payload, map[string]string{

--- a/internal/workflowevents/events.go
+++ b/internal/workflowevents/events.go
@@ -241,12 +241,15 @@ func NewFindingRecordedEvent(payload FindingRecorded) (*cerebrov1.EventEnvelope,
 }
 
 // NewFindingRecordedRevisionEvent builds a non-deduplicated finding record event.
-func NewFindingRecordedRevisionEvent(payload FindingRecorded, revision string) (*cerebrov1.EventEnvelope, error) {
+func NewFindingRecordedRevisionEvent(payload FindingRecorded, revision string, occurredAt time.Time) (*cerebrov1.EventEnvelope, error) {
 	primaryID := payload.Finding.FindingID
 	if trimmed := strings.TrimSpace(revision); trimmed != "" {
 		primaryID += "|" + trimmed
 	}
-	return newEvent(EventKindFindingRecorded, SchemaFindingRecorded, payload.Finding.TenantID, payload.Finding.SourceSystem, primaryID, payload.RecordedAt, payload, map[string]string{
+	if occurredAt.IsZero() {
+		occurredAt = time.Now().UTC()
+	}
+	return newEvent(EventKindFindingRecorded, SchemaFindingRecorded, payload.Finding.TenantID, payload.Finding.SourceSystem, primaryID, occurredAt.UTC().Format(time.RFC3339Nano), payload, map[string]string{
 		EventAttributeWorkflowKind: "finding_record",
 		EventAttributeFindingID:    payload.Finding.FindingID,
 	})

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -623,6 +623,24 @@ func findingAnchorAttributes(finding workflowevents.FindingSnapshot) map[string]
 	if finding.RiskScore != 0 {
 		attributes["risk_score"] = fmt.Sprintf("%d", finding.RiskScore)
 	}
+	if finding.LikelihoodScore != 0 {
+		attributes["likelihood_score"] = fmt.Sprintf("%d", finding.LikelihoodScore)
+	}
+	if finding.ImpactScore != 0 {
+		attributes["impact_score"] = fmt.Sprintf("%d", finding.ImpactScore)
+	}
+	if finding.ConfidenceScore != 0 {
+		attributes["confidence_score"] = fmt.Sprintf("%d", finding.ConfidenceScore)
+	}
+	if strings.TrimSpace(finding.LikelihoodLevel) != "" {
+		attributes["likelihood_level"] = strings.TrimSpace(finding.LikelihoodLevel)
+	}
+	if strings.TrimSpace(finding.ImpactLevel) != "" {
+		attributes["impact_level"] = strings.TrimSpace(finding.ImpactLevel)
+	}
+	if strings.TrimSpace(finding.RiskModelVersion) != "" {
+		attributes["risk_model_version"] = strings.TrimSpace(finding.RiskModelVersion)
+	}
 	if len(finding.EventIDs) != 0 {
 		attributes["event_ids"] = strings.Join(normalizeIDs(finding.EventIDs), ",")
 	}
@@ -658,6 +676,12 @@ func findingAnchorLinkAttributes(finding workflowevents.FindingSnapshot) map[str
 	}
 	if finding.RiskScore != 0 {
 		attributes["risk_score"] = fmt.Sprintf("%d", finding.RiskScore)
+	}
+	if finding.LikelihoodScore != 0 {
+		attributes["likelihood_score"] = fmt.Sprintf("%d", finding.LikelihoodScore)
+	}
+	if finding.ImpactScore != 0 {
+		attributes["impact_score"] = fmt.Sprintf("%d", finding.ImpactScore)
 	}
 	if finding.EventCount != 0 {
 		attributes["event_count"] = fmt.Sprintf("%d", finding.EventCount)

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -206,8 +206,10 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 		LastObservedAt:     "2026-04-27T11:59:00Z",
 		ResourceCount:      1,
 		EventCount:         2,
-		RiskScore:          47,
-		RiskReasons:        []string{"privileged_actor", "risky_action"},
+		FindingRiskSnapshot: workflowevents.FindingRiskSnapshot{
+			RiskScore:   47,
+			RiskReasons: []string{"privileged_actor", "risky_action"},
+		},
 		Metadata: map[string]string{
 			"actor_urn":     "urn:cerebro:writer:okta_actor:user:00u1",
 			"resource_type": "okta_resource",

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -420,6 +420,7 @@ message ListFindingsRequest {
   string event_id = 7;
   uint32 limit = 8;
   string policy_id = 9;
+  FindingOrder order = 10;
 }
 
 enum FindingStatus {
@@ -427,6 +428,13 @@ enum FindingStatus {
   FINDING_STATUS_OPEN = 1;
   FINDING_STATUS_RESOLVED = 2;
   FINDING_STATUS_SUPPRESSED = 3;
+}
+
+enum FindingOrder {
+  FINDING_ORDER_UNSPECIFIED = 0;
+  FINDING_ORDER_LAST_OBSERVED = 1;
+  FINDING_ORDER_PRIORITY = 2;
+  FINDING_ORDER_RISK_SCORE = 3;
 }
 
 // FindingControlRef maps one finding to one compliance framework control.
@@ -478,6 +486,14 @@ message Finding {
   google.protobuf.Timestamp due_at = 24;
   repeated FindingNote notes = 25;
   repeated FindingTicket tickets = 26;
+  int32 risk_score = 27;
+  int32 likelihood_score = 28;
+  int32 impact_score = 29;
+  int32 confidence_score = 30;
+  string likelihood_level = 31;
+  string impact_level = 32;
+  repeated string risk_reasons = 33;
+  string risk_model_version = 34;
 }
 
 // GetFindingRequest loads one persisted finding by its durable identifier.


### PR DESCRIPTION
## Summary
- Add a persisted likelihood × impact finding risk model with confidence, levels, reasons, and model version.
- Centrally enrich findings before upsert and expose risk order/fields through PostgreSQL, proto/API, OpenAPI, GRC, reports, and workflow graph projection.
- Add focused scorer, private-network reachability, persistence, ordering, and projection coverage.

## Validation
- make verify