### PR TITLE
feat(graphagent): add POST /grc/ask SSE endpoint for text-to-Cypher (SEC-916)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -489,6 +489,28 @@ paths:
       responses:
         '200':
           description: GRC dashboard summary, priority findings, controls, evidence, and connector health.
+  /grc/ask:
+    post:
+      summary: Ask natural-language questions over the GRC graph
+      tags:
+        - GRC
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GRCAskRequest'
+      responses:
+        '200':
+          description: Server-sent graph answer events in rationale, cypher, rows, summary, done order.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        '400':
+          description: Invalid ask request.
+        '503':
+          description: Graph or LLM runtime unavailable.
   /grc/findings:
     get:
       summary: GRC risk inbox findings
@@ -960,6 +982,7 @@ paths:
       responses:
         '200':
           description: Outcome write result.
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1024,6 +1047,32 @@ components:
         type: integer
         minimum: 1
   schemas:
+    GRCAskRequest:
+      type: object
+      required: [tenant_id, question]
+      properties:
+        tenant_id:
+          type: string
+        question:
+          type: string
+          minLength: 1
+          maxLength: 4096
+        scope_urn:
+          type: string
+        model:
+          type: string
+          default: claude-sonnet-4-6
+        history:
+          type: array
+          items:
+            type: object
+            required: [role, content]
+            properties:
+              role:
+                type: string
+                enum: [user, assistant]
+              content:
+                type: string
     PutSourceRuntimeRequest:
       type: object
       required: [runtime]

--- a/go.mod
+++ b/go.mod
@@ -28,10 +28,12 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.51.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ connectrpc.com/connect v1.19.2 h1:McQ83FGdzL+t60peksi0gXC7MQ/iLKgLduAnThbM0mo=
 connectrpc.com/connect v1.19.2/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.32.17 h1:FpL4/758/diKwqbytU0prpuiu60fgXKUWCpDJtApclU=
 github.com/aws/aws-sdk-go-v2/config v1.32.17/go.mod h1:OXqUMzgXytfoF9JaKkhrOYsyh72t9G+MJH8mMRaexOE=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.16 h1:r3RJBuU7X9ibt8RHbMjWE6y60QbKBiII6wSrXnapxSU=
@@ -18,6 +20,8 @@ github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3 h1:7MJlB7KGFd+KNKtnPgoFW
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.39.3/go.mod h1:MwilTAruv11x8EFjsk1R0VfjMdCxB6JHVtanCqsTR5o=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3 h1:JqFmDekar5Ije9SKKBUAmvuqardAXgCoJV78dt2BQSI=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.34.3/go.mod h1:+ONaMzn4bVIQwVsamP28xDWWZuYO+6cWupJpZOSlUNE=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.51.0 h1:BVUykEvDppfTIVTmOwnlR0pQOzsHQfMXY7E3GB6n9T8=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.51.0/go.mod h1:uY1fJe6m3I3w/m8UAkQ89Cm/ZAt/um6LW+AOZU33LDI=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.63.0 h1:YNpvY2mAGhoTHPEvsqPuDb8K5JBjorbVMaitP8i4OXI=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.63.0/go.mod h1:brhMG/gR2xEB5lezxL2Cx+hqsEzGUn4LhNUtu7+ePFE=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.55.11 h1:3IDx7ybn7pyrLgVShEfGmEXec1xsqgoD1ADI1SxqKT0=

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/writer/cerebro/internal/claims"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphingest"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/graphstore"
@@ -41,9 +42,10 @@ import (
 
 // Dependencies are the future store/log boundaries that will be wired into the rewrite.
 type Dependencies struct {
-	AppendLog  ports.AppendLog
-	StateStore ports.StateStore
-	GraphStore ports.GraphStore
+	AppendLog     ports.AppendLog
+	StateStore    ports.StateStore
+	GraphStore    ports.GraphStore
+	GraphAgentLLM graphagent.LLMClient
 }
 
 // App is the minimal Connect/bootstrap composition root for the rewrite skeleton.
@@ -88,6 +90,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("POST /reports/{reportID}/runs", app.handleRunReport)
 	mux.HandleFunc("GET /report-runs/{runID}", app.handleGetReportRun)
 	mux.HandleFunc("GET /grc/dashboard", app.handleGRCDashboard)
+	mux.HandleFunc("POST /grc/ask", app.handleGRCAsk)
 	mux.HandleFunc("GET /grc/findings", app.handleGRCFindings)
 	mux.HandleFunc("GET /grc/controls", app.handleGRCControls)
 	mux.HandleFunc("GET /grc/evidence", app.handleGRCEvidence)

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -1132,7 +1132,7 @@ func fallbackAccessAuditRoute(method string, path string) string {
 		return prefix + "/grc/audit-packets/{packetID}"
 	case strings.HasPrefix(path, "/grc/"):
 		switch path {
-		case "/grc/dashboard", "/grc/findings", "/grc/controls", "/grc/evidence":
+		case "/grc/dashboard", "/grc/ask", "/grc/findings", "/grc/controls", "/grc/evidence":
 			return prefix + path
 		default:
 			return prefix + "/grc/{subresource}"

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -11,6 +11,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourceruntime"
@@ -1124,10 +1125,12 @@ func writeGRCError(w http.ResponseWriter, err error) {
 		statusCode = http.StatusNotFound
 	case errors.Is(err, sourceruntime.ErrRuntimeUnavailable),
 		errors.Is(err, findings.ErrRuntimeUnavailable),
+		errors.Is(err, graphagent.ErrRuntimeUnavailable),
 		errors.Is(err, graphquery.ErrRuntimeUnavailable):
 		statusCode = http.StatusServiceUnavailable
 	case errors.Is(err, sourceruntime.ErrInvalidRequest),
 		errors.Is(err, findings.ErrInvalidRequest),
+		errors.Is(err, graphagent.ErrInvalidRequest),
 		errors.Is(err, graphquery.ErrInvalidRequest),
 		errors.Is(err, errInvalidHTTPRequest):
 		statusCode = http.StatusBadRequest

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -1,0 +1,74 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/writer/cerebro/internal/graphagent"
+	"github.com/writer/cerebro/internal/graphquery"
+)
+
+const maxGRCAskBodyBytes = 128 << 10
+
+func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
+	var request graphagent.AskRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxGRCAskBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
+		return
+	}
+	if err := authorizeTenantID(r.Context(), request.TenantID); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	if request.ScopeURN != "" {
+		if err := authorizeCerebroURNTenant(r.Context(), request.ScopeURN); err != nil {
+			writeGRCError(w, err)
+			return
+		}
+	}
+	if err := graphagent.ValidateRequest(request); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	graphStore := graphQueryStore(a.deps.GraphStore)
+	if graphStore == nil {
+		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
+		return
+	}
+	llm := a.deps.GraphAgentLLM
+	if llm == nil {
+		var err error
+		llm, err = graphagent.NewLLMClient(r.Context(), graphagent.LLMConfig{
+			Provider:    a.cfg.GraphAgentLLM.Provider,
+			Model:       a.cfg.GraphAgentLLM.Model,
+			SonnetModel: a.cfg.GraphAgentLLM.SonnetModel,
+			OpusModel:   a.cfg.GraphAgentLLM.OpusModel,
+			HaikuModel:  a.cfg.GraphAgentLLM.HaikuModel,
+			MaxTokens:   a.cfg.GraphAgentLLM.MaxTokens,
+			Temperature: a.cfg.GraphAgentLLM.Temperature,
+		})
+		if err != nil {
+			writeGRCError(w, err)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	flusher, _ := w.(http.Flusher)
+	service := graphagent.NewService(graphStore, llm, graphagent.ValidatorOptions{Explain: true})
+	_ = service.Stream(r.Context(), request, func(event graphagent.Event) error {
+		if err := graphagent.WriteSSEEvent(w, event); err != nil {
+			return err
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return nil
+	})
+}

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -1,0 +1,119 @@
+package bootstrap
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/graphagent"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestGRCAskStreamsSSE(t *testing.T) {
+	graphStore := &stubGraphStore{
+		cypherRows: [][]ports.CypherRow{nil, {
+			{Values: map[string]any{
+				"entity_urn":  "urn:cerebro:example:asset:alpha",
+				"entity_type": "asset",
+				"label":       "alpha",
+			}},
+		}},
+		neighborhood: &ports.EntityNeighborhood{
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:example:asset:alpha", EntityType: "asset", Label: "alpha"},
+		},
+	}
+	llm := &graphagent.StubLLMClient{
+		DraftResponse: &graphagent.DraftResponse{
+			Rationale: "Finding scoped graph rows.",
+			Cypher: `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS entity_urn, e.entity_type AS entity_type, e.label AS label
+LIMIT 25`,
+		},
+		Summary: "Review `urn:cerebro:example:asset:alpha` first.",
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphAgentLLM: llm}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	body := []byte(`{"tenant_id":"example","question":"What is risky?","scope_urn":"urn:cerebro:example:asset:alpha"}`)
+	resp, err := server.Client().Post(server.URL+"/grc/ask", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /grc/ask error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /grc/ask status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("content-type = %q, want text/event-stream", got)
+	}
+	events := readSSEEvents(t, resp)
+	want := []string{"rationale", "cypher", "rows", "summary", "done"}
+	if len(events) != len(want) {
+		t.Fatalf("events = %#v, want names %v", events, want)
+	}
+	for i, name := range want {
+		if events[i].Name != name {
+			t.Fatalf("event[%d] = %q, want %q", i, events[i].Name, name)
+		}
+	}
+	if len(graphStore.cypherRequests) != 2 {
+		t.Fatalf("cypher request count = %d, want EXPLAIN + execute", len(graphStore.cypherRequests))
+	}
+	if !strings.HasPrefix(graphStore.cypherRequests[0].Query, "EXPLAIN ") {
+		t.Fatalf("first cypher request = %q, want EXPLAIN", graphStore.cypherRequests[0].Query)
+	}
+}
+
+func TestGRCAskMissingTenantReturnsBadRequest(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: &stubGraphStore{}, GraphAgentLLM: graphagent.NewStubLLMClient()}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Post(server.URL+"/grc/ask", "application/json", strings.NewReader(`{"question":"hello"}`))
+	if err != nil {
+		t.Fatalf("POST /grc/ask error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+type sseRecord struct {
+	Name string
+	Data json.RawMessage
+}
+
+func readSSEEvents(t *testing.T, resp *http.Response) []sseRecord {
+	t.Helper()
+	var events []sseRecord
+	var current sseRecord
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if current.Name != "" {
+				events = append(events, current)
+				current = sseRecord{}
+			}
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, "event: "); ok {
+			current.Name = value
+		}
+		if value, ok := strings.CutPrefix(line, "data: "); ok {
+			current.Data = json.RawMessage(value)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan SSE: %v", err)
+	}
+	return events
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -29,6 +30,7 @@ type Config struct {
 	AppendLog       AppendLogConfig
 	StateStore      StateStoreConfig
 	GraphStore      GraphStoreConfig
+	GraphAgentLLM   GraphAgentLLMConfig
 	Auth            AuthConfig
 }
 
@@ -52,6 +54,17 @@ type GraphStoreConfig struct {
 	Neo4jUsername string
 	Neo4jPassword string
 	Neo4jDatabase string
+}
+
+// GraphAgentLLMConfig selects and configures the graph ask LLM adapter.
+type GraphAgentLLMConfig struct {
+	Provider    string
+	Model       string
+	SonnetModel string
+	OpusModel   string
+	HaikuModel  string
+	MaxTokens   int
+	Temperature float64
 }
 
 // APIKey grants one bearer token access to the bootstrap API.
@@ -113,6 +126,13 @@ func Load() (Config, error) {
 			Neo4jPassword: strings.TrimSpace(os.Getenv("CEREBRO_NEO4J_PASSWORD")),
 			Neo4jDatabase: strings.TrimSpace(os.Getenv("CEREBRO_NEO4J_DATABASE")),
 		},
+		GraphAgentLLM: GraphAgentLLMConfig{
+			Provider:    strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_PROVIDER")),
+			Model:       strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL")),
+			SonnetModel: strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_SONNET")),
+			OpusModel:   strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_OPUS")),
+			HaikuModel:  strings.TrimSpace(os.Getenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_HAIKU")),
+		},
 		Auth: AuthConfig{
 			APIKeys:                 parseAPIKeys(os.Getenv("CEREBRO_API_KEYS")),
 			APICredentials:          apiCredentials,
@@ -131,6 +151,12 @@ func Load() (Config, error) {
 	}
 	if cfg.HTTPAddr == "" {
 		cfg.HTTPAddr = defaultHTTPAddr
+	}
+	if cfg.GraphAgentLLM.MaxTokens, err = parseIntEnv("CEREBRO_GRAPH_AGENT_LLM_MAX_TOKENS", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.GraphAgentLLM.Temperature, err = parseFloatEnv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", 0); err != nil {
+		return Config{}, err
 	}
 	if raw, ok := os.LookupEnv("CEREBRO_SHUTDOWN_TIMEOUT"); ok && strings.TrimSpace(raw) != "" {
 		duration, err := time.ParseDuration(strings.TrimSpace(raw))
@@ -206,6 +232,36 @@ func parseBoolEnv(name string, defaultValue bool) (bool, error) {
 	default:
 		return false, fmt.Errorf("%s must be a boolean", name)
 	}
+}
+
+func parseIntEnv(name string, defaultValue int) (int, error) {
+	raw, ok := os.LookupEnv(name)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return defaultValue, nil
+	}
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", name, err)
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("%s must be greater than or equal to zero", name)
+	}
+	return value, nil
+}
+
+func parseFloatEnv(name string, defaultValue float64) (float64, error) {
+	raw, ok := os.LookupEnv(name)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return defaultValue, nil
+	}
+	value, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", name, err)
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("%s must be greater than or equal to zero", name)
+	}
+	return value, nil
 }
 
 func parseCSV(raw string) []string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_NEO4J_USERNAME", "")
 	t.Setenv("CEREBRO_NEO4J_PASSWORD", "")
 	t.Setenv("CEREBRO_NEO4J_DATABASE", "")
+	clearGraphAgentEnv(t)
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "")
 	t.Setenv("CEREBRO_API_KEYS", "")
@@ -48,6 +49,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.GraphStore.Driver != "" {
 		t.Fatalf("GraphStore.Driver = %q, want empty", cfg.GraphStore.Driver)
 	}
+	if cfg.GraphAgentLLM.Provider != "" || cfg.GraphAgentLLM.MaxTokens != 0 {
+		t.Fatalf("GraphAgentLLM = %#v, want empty/default", cfg.GraphAgentLLM)
+	}
 	if cfg.Auth.Enabled {
 		t.Fatal("Auth.Enabled = true, want false")
 	}
@@ -66,6 +70,13 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_NEO4J_USERNAME", "neo4j")
 	t.Setenv("CEREBRO_NEO4J_PASSWORD", "test-password")
 	t.Setenv("CEREBRO_NEO4J_DATABASE", "cerebro")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_PROVIDER", "stub")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL", "claude-sonnet-4-6")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_SONNET", "anthropic.claude-sonnet-example")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_OPUS", "anthropic.claude-opus-example")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_HAIKU", "anthropic.claude-haiku-example")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MAX_TOKENS", "900")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", "0.25")
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
 	t.Setenv("CEREBRO_API_KEYS", "token-1:ci:writer,token-2:ops:security")
@@ -96,6 +107,12 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.GraphStore.Driver != GraphStoreDriverNeo4j {
 		t.Fatalf("GraphStore.Driver = %q, want %q", cfg.GraphStore.Driver, GraphStoreDriverNeo4j)
 	}
+	if cfg.GraphAgentLLM.Provider != "stub" || cfg.GraphAgentLLM.MaxTokens != 900 || cfg.GraphAgentLLM.Temperature != 0.25 {
+		t.Fatalf("GraphAgentLLM = %#v", cfg.GraphAgentLLM)
+	}
+	if cfg.GraphAgentLLM.SonnetModel != "anthropic.claude-sonnet-example" || cfg.GraphAgentLLM.OpusModel == "" || cfg.GraphAgentLLM.HaikuModel == "" {
+		t.Fatalf("GraphAgentLLM model mapping = %#v", cfg.GraphAgentLLM)
+	}
 	if !cfg.Auth.Enabled {
 		t.Fatal("Auth.Enabled = false, want true")
 	}
@@ -124,6 +141,7 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_NEO4J_USERNAME", "")
 	t.Setenv("CEREBRO_NEO4J_PASSWORD", "")
 	t.Setenv("CEREBRO_NEO4J_DATABASE", "")
+	clearGraphAgentEnv(t)
 	t.Setenv("CEREBRO_KUZU_PATH", "")
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "")
 	t.Setenv("CEREBRO_API_KEYS", "")
@@ -131,6 +149,17 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "")
+}
+
+func clearGraphAgentEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_PROVIDER", "")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL", "")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_SONNET", "")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_OPUS", "")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_HAIKU", "")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MAX_TOKENS", "")
+	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", "")
 }
 
 func TestLoadRejectsAuthEnabledWithoutKeys(t *testing.T) {

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -1,0 +1,286 @@
+package graphagent
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var (
+	ErrRuntimeUnavailable = errors.New("graph agent runtime is unavailable")
+	ErrInvalidRequest     = errors.New("invalid graph agent request")
+)
+
+type AskRequest struct {
+	TenantID string           `json:"tenant_id"`
+	Question string           `json:"question"`
+	ScopeURN string           `json:"scope_urn,omitempty"`
+	Model    string           `json:"model,omitempty"`
+	History  []HistoryMessage `json:"history,omitempty"`
+}
+
+type Emitter func(Event) error
+
+type Service struct {
+	store     ports.GraphQueryStore
+	llm       LLMClient
+	validator *Validator
+}
+
+func NewService(store ports.GraphQueryStore, llm LLMClient, options ValidatorOptions) *Service {
+	return &Service{
+		store:     store,
+		llm:       llm,
+		validator: NewValidator(store, options),
+	}
+}
+
+func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) error {
+	if emit == nil {
+		return fmt.Errorf("%w: event emitter is required", ErrInvalidRequest)
+	}
+	if err := ValidateRequest(request); err != nil {
+		return err
+	}
+	if s == nil || s.store == nil || s.llm == nil || s.validator == nil {
+		return ErrRuntimeUnavailable
+	}
+	started := time.Now()
+	model := normalizeModel(request.Model)
+	history := normalizeHistory(request.History)
+	params := askParams(request)
+	traceID := newTraceID()
+
+	draft, err := s.llm.DraftCypher(ctx, DraftRequest{
+		TenantID:  strings.TrimSpace(request.TenantID),
+		Question:  strings.TrimSpace(request.Question),
+		ScopeURN:  strings.TrimSpace(request.ScopeURN),
+		Model:     model,
+		History:   history,
+		MaxRows:   defaultMaxRows,
+		Schema:    graphAgentSchemaHint,
+		Guardrail: graphAgentGuardrail,
+	})
+	if err != nil {
+		return emitErrorAndDone(emit, traceID, started, "llm_draft_failed", err.Error(), false)
+	}
+	if draft == nil {
+		return emitErrorAndDone(emit, traceID, started, "llm_draft_empty", "LLM returned no draft", false)
+	}
+	rationale := strings.TrimSpace(draft.Rationale)
+	if rationale == "" {
+		rationale = "Drafting a bounded read-only Cypher query for the requested graph question."
+	}
+	if err := emit(Event{Name: EventRationale, Data: RationaleEvent{Text: rationale}}); err != nil {
+		return err
+	}
+
+	cypher := strings.TrimSpace(draft.Cypher)
+	if cypher == "" {
+		reason := firstNonEmpty(draft.Refusal, "LLM refused to draft Cypher")
+		return emitRefusal(emit, traceID, started, cypher, reason)
+	}
+	validation, rowLimit := s.validator.validate(ctx, cypher, params)
+	if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: cypher, Validator: validation}}); err != nil {
+		return err
+	}
+	if !validation.OK {
+		return emitRefusal(emit, traceID, started, cypher, validation.Reason)
+	}
+
+	execStarted := time.Now()
+	rows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
+		Query:    cypher,
+		Params:   params,
+		RowLimit: rowLimit,
+	})
+	if err != nil {
+		return emitErrorAndDone(emit, traceID, started, "cypher_execute_failed", err.Error(), false)
+	}
+	rowMaps := cypherRowsToMaps(rows)
+	rowsEvent := RowsEvent{
+		Rows:   rowMaps,
+		Graph:  scopedNeighborhood(ctx, s.store, request.ScopeURN),
+		ExecMS: time.Since(execStarted).Milliseconds(),
+	}
+	if err := emit(Event{Name: EventRows, Data: rowsEvent}); err != nil {
+		return err
+	}
+
+	summary, err := s.llm.Summarize(ctx, SummarizeRequest{
+		TenantID: strings.TrimSpace(request.TenantID),
+		Question: strings.TrimSpace(request.Question),
+		ScopeURN: strings.TrimSpace(request.ScopeURN),
+		Model:    model,
+		Cypher:   cypher,
+		Rows:     rowMaps,
+		History:  history,
+	})
+	if err != nil || strings.TrimSpace(summary) == "" {
+		summary = fallbackSummary(rowMaps)
+	}
+	summary = strings.TrimSpace(summary)
+	if err := emit(Event{Name: EventSummary, Data: SummaryEvent{Markdown: summary, Citations: citationsFor(summary, rowMaps)}}); err != nil {
+		return err
+	}
+	return emit(Event{Name: EventDone, Data: DoneEvent{TraceID: traceID, TotalMS: time.Since(started).Milliseconds()}})
+}
+
+func ValidateRequest(request AskRequest) error {
+	if strings.TrimSpace(request.TenantID) == "" {
+		return fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
+	}
+	question := strings.TrimSpace(request.Question)
+	if question == "" {
+		return fmt.Errorf("%w: question is required", ErrInvalidRequest)
+	}
+	if len(question) > 4096 {
+		return fmt.Errorf("%w: question exceeds 4096 characters", ErrInvalidRequest)
+	}
+	return nil
+}
+
+func askParams(request AskRequest) map[string]any {
+	return map[string]any{
+		"tenant_id": strings.TrimSpace(request.TenantID),
+		"scope_urn": strings.TrimSpace(request.ScopeURN),
+	}
+}
+
+func emitRefusal(emit Emitter, traceID string, started time.Time, cypher string, reason string) error {
+	reason = firstNonEmpty(reason, "Read-only Cypher validator refused the draft.")
+	if cypher == "" {
+		if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: "", Validator: ValidatorResult{OK: false, Reason: reason}}}); err != nil {
+			return err
+		}
+	}
+	if err := emit(Event{Name: EventSummary, Data: SummaryEvent{Markdown: reason}}); err != nil {
+		return err
+	}
+	return emit(Event{Name: EventDone, Data: DoneEvent{TraceID: traceID, TotalMS: time.Since(started).Milliseconds(), CypherRefused: true}})
+}
+
+func emitErrorAndDone(emit Emitter, traceID string, started time.Time, code string, message string, refused bool) error {
+	if err := emit(Event{Name: EventError, Data: ErrorEvent{Code: code, Message: message}}); err != nil {
+		return err
+	}
+	return emit(Event{Name: EventDone, Data: DoneEvent{TraceID: traceID, TotalMS: time.Since(started).Milliseconds(), CypherRefused: refused}})
+}
+
+func cypherRowsToMaps(rows []ports.CypherRow) []map[string]any {
+	result := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		values := make(map[string]any, len(row.Values))
+		keys := make([]string, 0, len(row.Values))
+		for key := range row.Values {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			values[key] = row.Values[key]
+		}
+		result = append(result, values)
+	}
+	return result
+}
+
+func scopedNeighborhood(ctx context.Context, store ports.GraphQueryStore, scopeURN string) *ports.EntityNeighborhood {
+	scopeURN = strings.TrimSpace(scopeURN)
+	if scopeURN == "" || store == nil {
+		return nil
+	}
+	graph, err := store.GetEntityNeighborhood(ctx, scopeURN, 25)
+	if err != nil {
+		return nil
+	}
+	return graph
+}
+
+func citationsFor(summary string, rows []map[string]any) []Citation {
+	seen := map[string]struct{}{}
+	var citations []Citation
+	for _, row := range rows {
+		for _, value := range row {
+			urn, ok := value.(string)
+			if !ok || !strings.HasPrefix(urn, "urn:cerebro:") {
+				continue
+			}
+			if _, exists := seen[urn]; exists {
+				continue
+			}
+			start := strings.Index(summary, urn)
+			if start < 0 {
+				continue
+			}
+			seen[urn] = struct{}{}
+			citations = append(citations, Citation{URN: urn, Span: [2]int{start, start + len(urn)}})
+		}
+	}
+	return citations
+}
+
+func fallbackSummary(rows []map[string]any) string {
+	if len(rows) == 0 {
+		return "The validated read-only graph query returned no rows."
+	}
+	return fmt.Sprintf("The validated read-only graph query returned %d rows.", len(rows))
+}
+
+func normalizeHistory(history []HistoryMessage) []HistoryMessage {
+	const maxHistory = 12
+	if len(history) > maxHistory {
+		history = history[len(history)-maxHistory:]
+	}
+	result := make([]HistoryMessage, 0, len(history))
+	for _, item := range history {
+		role := strings.ToLower(strings.TrimSpace(item.Role))
+		if role != "user" && role != "assistant" {
+			continue
+		}
+		content := strings.TrimSpace(item.Content)
+		if content == "" {
+			continue
+		}
+		if len(content) > 4096 {
+			content = content[:4096]
+		}
+		result = append(result, HistoryMessage{Role: role, Content: content})
+	}
+	return result
+}
+
+func newTraceID() string {
+	var buf [6]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return fmt.Sprintf("%x", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(buf[:])
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+const graphAgentSchemaHint = `Graph shape:
+- Entity nodes use label Entity with properties tenant_id, urn, entity_type, label.
+- Relationships use label RELATION with relation and attributes_json properties.
+- Always filter at least one Entity by tenant_id: $tenant_id.
+- Prefer returning URNs and compact scalar columns.`
+
+const graphAgentGuardrail = `Rules:
+- Generate read-only Cypher only.
+- Do not use CREATE, MERGE, DELETE, REMOVE, SET, DROP, FOREACH, LOAD CSV, USING PERIODIC, apoc.trigger, or apoc.periodic.
+- Always include a numeric LIMIT <= 100.
+- Use $tenant_id and, when relevant, $scope_urn parameters instead of literal tenant or entity values.`

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -1,0 +1,143 @@
+package graphagent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestServiceStreamsSuccessfulAskSequence(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"entity_urn":  "urn:cerebro:example:asset:alpha",
+				"entity_type": "asset",
+				"label":       "alpha",
+			},
+		}},
+		graph: &ports.EntityNeighborhood{
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:example:asset:alpha", EntityType: "asset", Label: "alpha"},
+		},
+	}
+	llm := &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Rationale: "Counting risky entities.",
+			Cypher: `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS entity_urn, e.entity_type AS entity_type, e.label AS label
+LIMIT 25`,
+		},
+		Summary: "Review `urn:cerebro:example:asset:alpha` first.",
+	}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{
+		TenantID: "example",
+		Question: "Which entities are risky?",
+		ScopeURN: "urn:cerebro:example:asset:alpha",
+	}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	assertEventNames(t, events, []string{EventRationale, EventCypher, EventRows, EventSummary, EventDone})
+	rowsEvent, ok := events[2].Data.(RowsEvent)
+	if !ok {
+		t.Fatalf("rows event data = %T", events[2].Data)
+	}
+	if len(rowsEvent.Rows) != 1 || rowsEvent.Rows[0]["entity_urn"] != "urn:cerebro:example:asset:alpha" {
+		t.Fatalf("rows = %#v", rowsEvent.Rows)
+	}
+	if rowsEvent.Graph == nil || rowsEvent.Graph.Root == nil {
+		t.Fatalf("graph neighborhood missing")
+	}
+	summaryEvent, ok := events[3].Data.(SummaryEvent)
+	if !ok {
+		t.Fatalf("summary event data = %T", events[3].Data)
+	}
+	if len(summaryEvent.Citations) != 1 || summaryEvent.Citations[0].URN != "urn:cerebro:example:asset:alpha" {
+		t.Fatalf("citations = %#v", summaryEvent.Citations)
+	}
+	if len(store.requests) != 1 || store.requests[0].Params["tenant_id"] != "example" {
+		t.Fatalf("store requests = %#v", store.requests)
+	}
+}
+
+func TestServiceRefusesValidatorRejectedCypher(t *testing.T) {
+	store := &askStore{}
+	llm := &StubLLMClient{DraftResponse: &DraftResponse{
+		Rationale: "Attempting a write query.",
+		Cypher:    `MATCH (e:Entity {tenant_id: $tenant_id}) DELETE e LIMIT 25`,
+	}}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{TenantID: "example", Question: "delete risky nodes"}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	assertEventNames(t, events, []string{EventRationale, EventCypher, EventSummary, EventDone})
+	cypherEvent := events[1].Data.(CypherEvent)
+	if cypherEvent.Validator.OK {
+		t.Fatalf("validator ok = true, want false")
+	}
+	done := events[3].Data.(DoneEvent)
+	if !done.CypherRefused {
+		t.Fatalf("done.CypherRefused = false, want true")
+	}
+	if len(store.requests) != 0 {
+		t.Fatalf("store executed rejected query: %#v", store.requests)
+	}
+}
+
+func TestServiceRequiresTenantID(t *testing.T) {
+	service := NewService(&askStore{}, NewStubLLMClient(), ValidatorOptions{})
+	err := service.Stream(context.Background(), AskRequest{Question: "hello"}, func(Event) error { return nil })
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Stream() error = %v, want tenant_id validation", err)
+	}
+}
+
+func assertEventNames(t *testing.T, events []Event, want []string) {
+	t.Helper()
+	if len(events) != len(want) {
+		t.Fatalf("events len = %d, want %d (%#v)", len(events), len(want), events)
+	}
+	for i, name := range want {
+		if events[i].Name != name {
+			t.Fatalf("event[%d] = %q, want %q", i, events[i].Name, name)
+		}
+	}
+}
+
+type askStore struct {
+	requests []ports.CypherQueryRequest
+	rows     []ports.CypherRow
+	graph    *ports.EntityNeighborhood
+}
+
+func (s *askStore) Ping(context.Context) error { return nil }
+
+func (s *askStore) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
+	if s.graph != nil {
+		return s.graph, nil
+	}
+	return nil, ports.ErrGraphEntityNotFound
+}
+
+func (s *askStore) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	s.requests = append(s.requests, request)
+	if len(request.Query) >= len("EXPLAIN ") && request.Query[:len("EXPLAIN ")] == "EXPLAIN " {
+		return nil, nil
+	}
+	return s.rows, nil
+}
+
+var _ ports.GraphQueryStore = (*askStore)(nil)

--- a/internal/graphagent/events.go
+++ b/internal/graphagent/events.go
@@ -1,0 +1,78 @@
+package graphagent
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	EventRationale = "rationale"
+	EventCypher    = "cypher"
+	EventRows      = "rows"
+	EventSummary   = "summary"
+	EventDone      = "done"
+	EventError     = "error"
+)
+
+type Event struct {
+	Name string
+	Data any
+}
+
+type ValidatorResult struct {
+	OK     bool   `json:"ok"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type RationaleEvent struct {
+	Text string `json:"text"`
+}
+
+type CypherEvent struct {
+	Cypher    string          `json:"cypher"`
+	Validator ValidatorResult `json:"validator"`
+}
+
+type RowsEvent struct {
+	Rows   []map[string]any          `json:"rows"`
+	Graph  *ports.EntityNeighborhood `json:"graph"`
+	ExecMS int64                     `json:"exec_ms"`
+}
+
+type Citation struct {
+	URN  string `json:"urn"`
+	Span [2]int `json:"span"`
+}
+
+type SummaryEvent struct {
+	Markdown  string     `json:"markdown"`
+	Citations []Citation `json:"citations"`
+}
+
+type DoneEvent struct {
+	TraceID       string `json:"trace_id"`
+	TotalMS       int64  `json:"total_ms"`
+	CypherRefused bool   `json:"cypher_refused"`
+}
+
+type ErrorEvent struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func WriteSSEEvent(w io.Writer, event Event) error {
+	payload, err := json.Marshal(event.Data)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\n", event.Name); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/graphagent/llm.go
+++ b/internal/graphagent/llm.go
@@ -1,0 +1,85 @@
+package graphagent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const DefaultModel = "claude-sonnet-4-6"
+
+type HistoryMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type DraftRequest struct {
+	TenantID  string
+	Question  string
+	ScopeURN  string
+	Model     string
+	History   []HistoryMessage
+	MaxRows   int
+	Schema    string
+	Guardrail string
+}
+
+type DraftResponse struct {
+	Rationale string `json:"rationale"`
+	Cypher    string `json:"cypher,omitempty"`
+	Refusal   string `json:"refusal,omitempty"`
+}
+
+type SummarizeRequest struct {
+	TenantID string
+	Question string
+	ScopeURN string
+	Model    string
+	Cypher   string
+	Rows     []map[string]any
+	History  []HistoryMessage
+}
+
+type LLMClient interface {
+	DraftCypher(context.Context, DraftRequest) (*DraftResponse, error)
+	Summarize(context.Context, SummarizeRequest) (string, error)
+}
+
+type LLMConfig struct {
+	Provider    string
+	Model       string
+	SonnetModel string
+	OpusModel   string
+	HaikuModel  string
+	MaxTokens   int
+	Temperature float64
+}
+
+func NewLLMClient(ctx context.Context, cfg LLMConfig) (LLMClient, error) {
+	provider := strings.ToLower(strings.TrimSpace(cfg.Provider))
+	if provider == "" {
+		provider = "bedrock"
+	}
+	switch provider {
+	case "stub":
+		return NewStubLLMClient(), nil
+	case "bedrock":
+		return NewBedrockLLMClient(ctx, BedrockConfig{
+			DefaultModel: cfg.Model,
+			SonnetModel:  cfg.SonnetModel,
+			OpusModel:    cfg.OpusModel,
+			HaikuModel:   cfg.HaikuModel,
+			MaxTokens:    cfg.MaxTokens,
+			Temperature:  cfg.Temperature,
+		})
+	default:
+		return nil, fmt.Errorf("%w: unsupported graph agent llm provider %q", ErrInvalidRequest, provider)
+	}
+}
+
+func normalizeModel(model string) string {
+	if strings.TrimSpace(model) == "" {
+		return DefaultModel
+	}
+	return strings.TrimSpace(model)
+}

--- a/internal/graphagent/llm_bedrock.go
+++ b/internal/graphagent/llm_bedrock.go
@@ -1,0 +1,195 @@
+package graphagent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+)
+
+type BedrockLLMClient struct {
+	client       *bedrockruntime.Client
+	defaultModel string
+	sonnetModel  string
+	opusModel    string
+	haikuModel   string
+	maxTokens    int
+	temperature  float64
+}
+
+type BedrockConfig struct {
+	DefaultModel string
+	SonnetModel  string
+	OpusModel    string
+	HaikuModel   string
+	MaxTokens    int
+	Temperature  float64
+}
+
+func NewBedrockLLMClient(ctx context.Context, llmConfig BedrockConfig) (*BedrockLLMClient, error) {
+	awsConfig, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load AWS config for Bedrock: %w", err)
+	}
+	if llmConfig.DefaultModel == "" {
+		llmConfig.DefaultModel = DefaultModel
+	}
+	if llmConfig.MaxTokens <= 0 {
+		llmConfig.MaxTokens = 1200
+	}
+	return &BedrockLLMClient{
+		client:       bedrockruntime.NewFromConfig(awsConfig),
+		defaultModel: strings.TrimSpace(llmConfig.DefaultModel),
+		sonnetModel:  strings.TrimSpace(llmConfig.SonnetModel),
+		opusModel:    strings.TrimSpace(llmConfig.OpusModel),
+		haikuModel:   strings.TrimSpace(llmConfig.HaikuModel),
+		maxTokens:    llmConfig.MaxTokens,
+		temperature:  llmConfig.Temperature,
+	}, nil
+}
+
+func (c *BedrockLLMClient) DraftCypher(ctx context.Context, req DraftRequest) (*DraftResponse, error) {
+	prompt := draftPrompt(req)
+	text, err := c.invokeMessages(ctx, c.modelID(req.Model), prompt, c.maxTokens)
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Rationale string  `json:"rationale"`
+		Cypher    *string `json:"cypher"`
+		Refusal   string  `json:"refusal"`
+	}
+	if err := json.Unmarshal(extractJSONObject(text), &payload); err != nil {
+		return nil, fmt.Errorf("parse draft response JSON: %w", err)
+	}
+	response := &DraftResponse{Rationale: strings.TrimSpace(payload.Rationale), Refusal: strings.TrimSpace(payload.Refusal)}
+	if payload.Cypher != nil {
+		response.Cypher = strings.TrimSpace(*payload.Cypher)
+	}
+	return response, nil
+}
+
+func (c *BedrockLLMClient) Summarize(ctx context.Context, req SummarizeRequest) (string, error) {
+	return c.invokeMessages(ctx, c.modelID(req.Model), summarizePrompt(req), c.maxTokens)
+}
+
+func (c *BedrockLLMClient) modelID(requested string) string {
+	switch normalizeModel(requested) {
+	case "claude-sonnet-4-6":
+		return firstNonEmpty(c.sonnetModel, c.defaultModel)
+	case "claude-opus-4-7":
+		return firstNonEmpty(c.opusModel, c.defaultModel)
+	case "claude-haiku-4-5-20251001":
+		return firstNonEmpty(c.haikuModel, c.defaultModel)
+	default:
+		if strings.TrimSpace(requested) != "" {
+			return strings.TrimSpace(requested)
+		}
+		return c.defaultModel
+	}
+}
+
+func (c *BedrockLLMClient) invokeMessages(ctx context.Context, modelID string, prompt string, maxTokens int) (string, error) {
+	body := map[string]any{
+		"anthropic_version": "bedrock-2023-05-31",
+		"max_tokens":        maxTokens,
+		"temperature":       c.temperature,
+		"messages": []map[string]any{{
+			"role": "user",
+			"content": []map[string]string{{
+				"type": "text",
+				"text": prompt,
+			}},
+		}},
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+	out, err := c.client.InvokeModel(ctx, &bedrockruntime.InvokeModelInput{
+		ModelId:     aws.String(modelID),
+		ContentType: aws.String("application/json"),
+		Accept:      aws.String("application/json"),
+		Body:        payload,
+	})
+	if err != nil {
+		return "", fmt.Errorf("invoke Bedrock model: %w", err)
+	}
+	var response struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(out.Body, &response); err != nil {
+		return "", fmt.Errorf("parse Bedrock response: %w", err)
+	}
+	var text strings.Builder
+	for _, part := range response.Content {
+		if part.Type == "text" && strings.TrimSpace(part.Text) != "" {
+			if text.Len() > 0 {
+				text.WriteString("\n")
+			}
+			text.WriteString(part.Text)
+		}
+	}
+	if strings.TrimSpace(text.String()) == "" {
+		return "", fmt.Errorf("bedrock response contained no text")
+	}
+	return strings.TrimSpace(text.String()), nil
+}
+
+func draftPrompt(req DraftRequest) string {
+	var history bytes.Buffer
+	for _, item := range req.History {
+		fmt.Fprintf(&history, "- %s: %s\n", item.Role, item.Content)
+	}
+	return fmt.Sprintf(`You generate safe, read-only Neo4j Cypher for a security graph.
+
+Question: %s
+Tenant parameter: $tenant_id
+Scope URN parameter, if present: $scope_urn
+Requested model alias: %s
+
+%s
+
+%s
+
+Conversation history:
+%s
+
+Return ONLY compact JSON:
+{"rationale":"short explanation","cypher":"MATCH ... LIMIT 25","refusal":""}
+
+If the question asks for mutation, deletion, credential disclosure, or anything unsafe, return:
+{"rationale":"why refused","cypher":null,"refusal":"safe refusal message"}`, req.Question, normalizeModel(req.Model), req.Schema, req.Guardrail, history.String())
+}
+
+func summarizePrompt(req SummarizeRequest) string {
+	rows, _ := json.Marshal(req.Rows)
+	return fmt.Sprintf(`Summarize the graph query result for an operator.
+
+Question: %s
+Cypher:
+%s
+
+Rows JSON:
+%s
+
+Write concise markdown. Cite important entity URNs inline exactly as returned. Do not invent data.`, req.Question, req.Cypher, rows)
+}
+
+func extractJSONObject(text string) []byte {
+	trimmed := strings.TrimSpace(text)
+	start := strings.Index(trimmed, "{")
+	end := strings.LastIndex(trimmed, "}")
+	if start >= 0 && end >= start {
+		return []byte(trimmed[start : end+1])
+	}
+	return []byte(trimmed)
+}

--- a/internal/graphagent/llm_stub.go
+++ b/internal/graphagent/llm_stub.go
@@ -1,0 +1,56 @@
+package graphagent
+
+import (
+	"context"
+	"strings"
+)
+
+type StubLLMClient struct {
+	DraftResponse *DraftResponse
+	Summary       string
+	DraftErr      error
+	SummaryErr    error
+}
+
+func NewStubLLMClient() *StubLLMClient {
+	return &StubLLMClient{}
+}
+
+func (c *StubLLMClient) DraftCypher(_ context.Context, req DraftRequest) (*DraftResponse, error) {
+	if c != nil && c.DraftErr != nil {
+		return nil, c.DraftErr
+	}
+	if c != nil && c.DraftResponse != nil {
+		copy := *c.DraftResponse
+		return &copy, nil
+	}
+	question := strings.ToLower(req.Question)
+	if strings.Contains(question, "delete") || strings.Contains(question, "drop") || strings.Contains(question, "remove") {
+		return &DraftResponse{
+			Rationale: "Refusing to draft a destructive graph query.",
+			Cypher:    "MATCH (n:Entity {tenant_id: $tenant_id}) DETACH DELETE n LIMIT 25",
+			Refusal:   "Read-only graph questions only; destructive Cypher is forbidden.",
+		}, nil
+	}
+	return &DraftResponse{
+		Rationale: "Inspecting bounded Entity rows for the tenant and returning compact risk context.",
+		Cypher: `MATCH (e:Entity {tenant_id: $tenant_id})
+WHERE $scope_urn = '' OR e.urn = $scope_urn OR e.urn CONTAINS $scope_urn
+RETURN e.urn AS entity_urn, e.entity_type AS entity_type, coalesce(e.label, e.urn) AS label
+ORDER BY entity_urn
+LIMIT 25`,
+	}, nil
+}
+
+func (c *StubLLMClient) Summarize(_ context.Context, req SummarizeRequest) (string, error) {
+	if c != nil && c.SummaryErr != nil {
+		return "", c.SummaryErr
+	}
+	if c != nil && strings.TrimSpace(c.Summary) != "" {
+		return c.Summary, nil
+	}
+	if len(req.Rows) == 0 {
+		return "No matching graph rows were returned for this bounded read-only query.", nil
+	}
+	return "The graph query returned bounded synthetic tenant results, led by `urn:cerebro:example:asset:alpha` for review.", nil
+}

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -1,0 +1,128 @@
+package graphagent
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	defaultMaxRows           = 100
+	defaultAllNodesScanLimit = 1_000_000
+)
+
+var (
+	forbiddenTokenPattern = regexp.MustCompile(`(?i)\b(CREATE|MERGE|DELETE|REMOVE|SET|DROP|FOREACH)\b`)
+	loadCSVPattern        = regexp.MustCompile(`(?i)\bLOAD\s+CSV\b`)
+	usingPeriodicPattern  = regexp.MustCompile(`(?i)\bUSING\s+PERIODIC\b`)
+	forbiddenAPOCPattern  = regexp.MustCompile(`(?i)\bCALL\s+apoc\.(trigger|periodic)\.`)
+	limitPattern          = regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)\b`)
+	entityTenantPattern   = regexp.MustCompile(`(?is)\(\s*[A-Za-z_][A-Za-z0-9_]*\s*:\s*Entity[^)]*tenant_id\s*:`)
+	whereTenantPattern    = regexp.MustCompile(`(?i)\b[A-Za-z_][A-Za-z0-9_]*\.tenant_id\s*=\s*\$tenant_id\b`)
+	quotedLiteralPattern  = regexp.MustCompile(`'[^']*'|"[^"]*"`)
+	commentPattern        = regexp.MustCompile(`(?m)//.*$|/\*.*?\*/`)
+	integerPattern        = regexp.MustCompile(`\d+`)
+)
+
+type ValidatorOptions struct {
+	MaxRows           int
+	AllNodesScanLimit int
+	Explain           bool
+}
+
+type Validator struct {
+	store   ports.GraphQueryStore
+	options ValidatorOptions
+}
+
+func NewValidator(store ports.GraphQueryStore, options ValidatorOptions) *Validator {
+	if options.MaxRows <= 0 {
+		options.MaxRows = defaultMaxRows
+	}
+	if options.AllNodesScanLimit <= 0 {
+		options.AllNodesScanLimit = defaultAllNodesScanLimit
+	}
+	return &Validator{store: store, options: options}
+}
+
+func (v *Validator) validate(ctx context.Context, cypher string, params map[string]any) (ValidatorResult, int) {
+	query := strings.TrimSpace(cypher)
+	if query == "" {
+		return ValidatorResult{OK: false, Reason: "cypher is required"}, 0
+	}
+	safeQuery := scrubCypher(query)
+	if forbiddenTokenPattern.MatchString(safeQuery) || loadCSVPattern.MatchString(safeQuery) || usingPeriodicPattern.MatchString(safeQuery) {
+		return ValidatorResult{OK: false, Reason: "write or bulk-load Cypher clauses are forbidden"}, 0
+	}
+	if forbiddenAPOCPattern.MatchString(safeQuery) {
+		return ValidatorResult{OK: false, Reason: "apoc trigger and periodic procedures are forbidden"}, 0
+	}
+	limit, ok := queryLimit(safeQuery)
+	if !ok {
+		return ValidatorResult{OK: false, Reason: "read Cypher must include a numeric LIMIT clause"}, 0
+	}
+	if limit > v.options.MaxRows {
+		return ValidatorResult{OK: false, Reason: fmt.Sprintf("LIMIT %d exceeds maximum %d", limit, v.options.MaxRows)}, 0
+	}
+	if !hasTenantEntityFilter(safeQuery) {
+		return ValidatorResult{OK: false, Reason: "query must filter at least one Entity by tenant_id"}, 0
+	}
+	if v.options.Explain && v.store != nil {
+		rows, err := v.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
+			Query:    "EXPLAIN " + query,
+			Params:   params,
+			RowLimit: 10,
+		})
+		if err != nil {
+			return ValidatorResult{OK: false, Reason: "EXPLAIN failed: " + err.Error()}, 0
+		}
+		if allNodesScanOverLimit(rows, v.options.AllNodesScanLimit) {
+			return ValidatorResult{OK: false, Reason: fmt.Sprintf("EXPLAIN plan contains AllNodesScan over more than %d nodes", v.options.AllNodesScanLimit)}, 0
+		}
+	}
+	return ValidatorResult{OK: true}, limit
+}
+
+func scrubCypher(query string) string {
+	noComments := commentPattern.ReplaceAllString(query, " ")
+	return quotedLiteralPattern.ReplaceAllString(noComments, "''")
+}
+
+func queryLimit(query string) (int, bool) {
+	matches := limitPattern.FindAllStringSubmatch(query, -1)
+	if len(matches) == 0 {
+		return 0, false
+	}
+	value := matches[len(matches)-1][1]
+	limit, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, false
+	}
+	return limit, true
+}
+
+func hasTenantEntityFilter(query string) bool {
+	return entityTenantPattern.MatchString(query) || whereTenantPattern.MatchString(query)
+}
+
+func allNodesScanOverLimit(rows []ports.CypherRow, limit int) bool {
+	for _, row := range rows {
+		for _, value := range row.Values {
+			text := fmt.Sprint(value)
+			if !strings.Contains(text, "AllNodesScan") {
+				continue
+			}
+			for _, raw := range integerPattern.FindAllString(text, -1) {
+				n, err := strconv.Atoi(raw)
+				if err == nil && n > limit {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -1,0 +1,121 @@
+package graphagent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestValidatorRejectsUnsafeCypher(t *testing.T) {
+	tests := []struct {
+		name   string
+		cypher string
+		reason string
+	}{
+		{
+			name:   "create token",
+			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) CREATE (x) RETURN e.urn LIMIT 25`,
+			reason: "forbidden",
+		},
+		{
+			name:   "load csv",
+			cypher: `LOAD CSV FROM 'file:///tmp/x.csv' AS row MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn LIMIT 25`,
+			reason: "forbidden",
+		},
+		{
+			name:   "periodic apoc",
+			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) CALL apoc.periodic.iterate('a','b',{}) RETURN e.urn LIMIT 25`,
+			reason: "apoc",
+		},
+		{
+			name:   "missing limit",
+			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn`,
+			reason: "LIMIT",
+		},
+		{
+			name:   "limit too high",
+			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn LIMIT 101`,
+			reason: "exceeds",
+		},
+		{
+			name:   "missing tenant",
+			cypher: `MATCH (e:Entity) RETURN e.urn LIMIT 25`,
+			reason: "tenant_id",
+		},
+	}
+
+	validator := NewValidator(nil, ValidatorOptions{})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _ := validator.validate(context.Background(), tt.cypher, map[string]any{"tenant_id": "example"})
+			if result.OK {
+				t.Fatalf("Validate() ok = true, want false")
+			}
+			if !strings.Contains(result.Reason, tt.reason) {
+				t.Fatalf("reason = %q, want substring %q", result.Reason, tt.reason)
+			}
+		})
+	}
+}
+
+func TestValidatorAcceptsBoundedTenantScopedRead(t *testing.T) {
+	store := &validatorStore{}
+	validator := NewValidator(store, ValidatorOptions{Explain: true})
+	result, limit := validator.validate(context.Background(), `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS urn
+ORDER BY urn
+LIMIT 25`, map[string]any{"tenant_id": "example"})
+	if !result.OK {
+		t.Fatalf("Validate() = %#v, want ok", result)
+	}
+	if limit != 25 {
+		t.Fatalf("limit = %d, want 25", limit)
+	}
+	if len(store.requests) != 1 || !strings.HasPrefix(store.requests[0].Query, "EXPLAIN MATCH") {
+		t.Fatalf("EXPLAIN requests = %#v", store.requests)
+	}
+}
+
+func TestValidatorRejectsAllNodesScanOverLimit(t *testing.T) {
+	store := &validatorStore{rows: []ports.CypherRow{{
+		Values: map[string]any{"plan": "AllNodesScan estimatedRows=2000001"},
+	}}}
+	validator := NewValidator(store, ValidatorOptions{Explain: true, AllNodesScanLimit: 1_000_000})
+	result, _ := validator.validate(context.Background(), `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS urn
+LIMIT 25`, map[string]any{"tenant_id": "example"})
+	if result.OK {
+		t.Fatalf("Validate() ok = true, want false")
+	}
+	if !strings.Contains(result.Reason, "AllNodesScan") {
+		t.Fatalf("reason = %q, want AllNodesScan", result.Reason)
+	}
+}
+
+type validatorStore struct {
+	requests []ports.CypherQueryRequest
+	rows     []ports.CypherRow
+	err      error
+}
+
+func (s *validatorStore) Ping(context.Context) error { return nil }
+
+func (s *validatorStore) PutEntity(context.Context, *ports.ProjectedEntity) error { return nil }
+
+func (s *validatorStore) PutRelation(context.Context, *ports.ProjectedLink) error { return nil }
+
+func (s *validatorStore) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
+	return nil, ports.ErrGraphEntityNotFound
+}
+
+func (s *validatorStore) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	s.requests = append(s.requests, request)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.rows, nil
+}
+
+var _ ports.GraphQueryStore = (*validatorStore)(nil)


### PR DESCRIPTION
## Summary

Implements SEC-916 backend support for the Ask Cerebro / graph_ask flow consumed by the parallel SEC-924 cerebro-web UI work.

## API contract

`POST /grc/ask`

Request JSON:

```json
{
  "tenant_id": "example",
  "question": "What assets are risky?",
  "scope_urn": "urn:cerebro:example:asset:alpha",
  "model": "claude-sonnet-4-6",
  "history": [{"role":"user","content":"previous question"}]
}
```

Response is `text/event-stream` with events emitted in this order:

```text
event: rationale  data: {"text":"..."}
event: cypher     data: {"cypher":"...","validator":{"ok":true}}
event: rows       data: {"rows":[...],"graph":{...},"exec_ms":0}
event: summary    data: {"markdown":"...","citations":[...]}
event: done       data: {"trace_id":"...","total_ms":0,"cypher_refused":false}
```

On refusal or validator rejection, rows are skipped and `done.cypher_refused=true`.

## Implementation notes

- Adds `internal/graphagent` service, SSE event types, Cypher validator, deterministic stub LLM, and Bedrock Claude adapter.
- Wires `POST /grc/ask` through bootstrap GRC routing with existing `/grc/` auth scope.
- Validator rejects write/bulk clauses, unsafe APOC procedures, missing/oversized limits, missing tenant filters, and high-risk `EXPLAIN` plans.
- Adds OpenAPI contract coverage and synthetic tests only.
- Frontend is being built in parallel in WriterInternal/cerebro-web for SEC-924.
- No Writer-internal data is included; tests and examples use synthetic `urn:cerebro:example:*` fixtures.

## Validation

- `go test ./internal/graphagent ./internal/bootstrap ./internal/config -count=1`
- `make openapi-check`
- `make openapi-lint`
- `make lint-bootstrap`
- `make verify`
- `scripts/leak_check.sh`
- Browser E2E through cerebro-web proxy against local synthetic backend: `/ask?q=What+assets+are+risky%3F&scope_urn=urn%3Acerebro%3Aexample%3Aasset%3Aalpha`

Note: requested `python3 scripts/oss_audit.py` was not available in this checkout, so I ran `scripts/leak_check.sh` instead.
