### PR TITLE
fix(graphagent): isolate existential bindings

### DIFF
--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -190,7 +190,7 @@ func allNodePatternsTenantScoped(query string) bool {
 		}
 		sawNode = true
 		if nodePatternHasInlineTenantScope(pattern) {
-			if pattern.variable != "" && squareBracketDepthAt(query, i) == 0 {
+			if pattern.variable != "" && !expressionLocalPattern(query, i, len(subqueries)) {
 				scopedVariables[pattern.variable] = struct{}{}
 			}
 			continue
@@ -489,6 +489,25 @@ func squareBracketDepthAt(query string, index int) int {
 		case '[':
 			depth++
 		case ']':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return depth
+}
+
+func expressionLocalPattern(query string, index int, callSubqueryDepth int) bool {
+	return squareBracketDepthAt(query, index) > 0 || braceDepthAt(query, index) > callSubqueryDepth
+}
+
+func braceDepthAt(query string, index int) int {
+	depth := 0
+	for i := 0; i < index; i++ {
+		switch query[i] {
+		case '{':
+			depth++
+		case '}':
 			if depth > 0 {
 				depth--
 			}

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -94,6 +94,11 @@ func TestValidatorRejectsUnsafeCypher(t *testing.T) {
 			cypher: `MATCH (seed:Entity {tenant_id: $tenant_id}) WITH [(tmp:Entity {tenant_id: $tenant_id})-[:RELATION]->(:Entity {tenant_id: $tenant_id}) | tmp.urn][0] AS first MATCH (tmp) RETURN tmp.urn LIMIT 25`,
 			reason: "inline tenant_id",
 		},
+		{
+			name:   "existential subquery binding cannot escape",
+			cypher: `MATCH (seed:Entity {tenant_id: $tenant_id}) WHERE EXISTS { MATCH (tmp:Entity {tenant_id: $tenant_id}) RETURN tmp LIMIT 1 } MATCH (tmp) RETURN tmp.urn LIMIT 25`,
+			reason: "inline tenant_id",
+		},
 	}
 
 	validator := NewValidator(nil, ValidatorOptions{})


### PR DESCRIPTION
## Summary
- prevent existential subquery graph variables from escaping validator scope
- add regression coverage for existential subquery binding leakage

## Validation
- make verify
- scripts/leak_check.sh