### PR TITLE
feat(graph): add crown jewel rankings (SEC-915)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -784,6 +784,43 @@ paths:
       responses:
         '200':
           description: Cloud attack paths.
+  /platform/graph/crown-jewel-rankings:
+    get:
+      summary: Query personalized crown-jewel graph rankings
+      tags:
+        - Graph
+      parameters:
+        - name: tenant_id
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: account_id
+          in: query
+          schema:
+            type: string
+        - name: entity_type
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+        - name: depth
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+        - name: seed_limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Personalized crown-jewel graph rankings.
   /platform/graph/aws-public-endpoint-insights:
     get:
       summary: Query AWS public endpoint overlap insights

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -125,6 +125,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("GET /platform/graph/impact/asset", app.handleGetAssetImpact)
 	mux.HandleFunc("GET /graph/impact/asset", deprecatedRoute(app.handleGetAssetImpact))
 	mux.HandleFunc("GET /platform/graph/attack-paths", app.handleGetAttackPaths)
+	mux.HandleFunc("GET /platform/graph/crown-jewel-rankings", app.handleGetCrownJewelRankings)
 	mux.HandleFunc("GET /platform/graph/aws-public-endpoint-insights", app.handleGetAWSPublicEndpointInsights)
 	mux.HandleFunc("GET /platform/graph/ingest-health", app.handleCheckGraphIngestHealth)
 	mux.HandleFunc("GET /graph/ingest-health", deprecatedRoute(app.handleCheckGraphIngestHealth))
@@ -869,6 +870,42 @@ func (a *App) handleGetAttackPaths(w http.ResponseWriter, r *http.Request) {
 		TenantID:  tenantID,
 		AccountID: r.URL.Query().Get("account_id"),
 		Limit:     limit,
+	})
+	if err != nil {
+		writeGraphQueryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (a *App) handleGetCrownJewelRankings(w http.ResponseWriter, r *http.Request) {
+	tenantID := r.URL.Query().Get("tenant_id")
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		writeGraphQueryError(w, err)
+		return
+	}
+	limit, err := uint32QueryParam(r, "limit")
+	if err != nil {
+		writeGraphQueryError(w, err)
+		return
+	}
+	depth, err := uint32QueryParam(r, "depth")
+	if err != nil {
+		writeGraphQueryError(w, err)
+		return
+	}
+	seedLimit, err := uint32QueryParam(r, "seed_limit")
+	if err != nil {
+		writeGraphQueryError(w, err)
+		return
+	}
+	result, err := a.graphQueryService().GetCrownJewelRanks(r.Context(), graphquery.CrownJewelRankRequest{
+		TenantID:   tenantID,
+		AccountID:  r.URL.Query().Get("account_id"),
+		EntityType: r.URL.Query().Get("entity_type"),
+		Limit:      limit,
+		Depth:      depth,
+		SeedLimit:  seedLimit,
 	})
 	if err != nil {
 		writeGraphQueryError(w, err)

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2079,6 +2079,7 @@ func TestScopedCosmoCredentialAllowsOnlyReadRoutes(t *testing.T) {
 	for _, path := range []string{
 		"/sources",
 		"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app",
+		"/platform/graph/crown-jewel-rankings?tenant_id=writer",
 		"/source-runtimes/writer-runtime",
 	} {
 		req, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
@@ -3274,6 +3275,59 @@ func TestGraphAWSPublicEndpointInsightsEndpoint(t *testing.T) {
 		t.Fatalf("overlaps = %#v", body.Overlaps)
 	}
 	if len(graph.cypherRequests) != 6 || graph.cypherRequests[0].Params["tenant_id"] != "writer" {
+		t.Fatalf("cypher requests = %#v", graph.cypherRequests)
+	}
+}
+
+func TestGraphCrownJewelRankingsEndpoint(t *testing.T) {
+	graph := &stubGraphStore{cypherRows: [][]ports.CypherRow{
+		{{Values: map[string]any{
+			"seed_urn":         "urn:cerebro:writer:aws_secret_store:prod-secrets",
+			"seed_entity_type": "aws.secret_store",
+			"seed_label":       "prod-secrets",
+		}}},
+		{{Values: map[string]any{
+			"seed_urn":         "urn:cerebro:writer:aws_secret_store:prod-secrets",
+			"from_urn":         "urn:cerebro:writer:aws_public_principal:public_internet",
+			"from_entity_type": "aws.public_principal",
+			"from_label":       "public_internet",
+			"relation":         "can_reach",
+			"to_urn":           "urn:cerebro:writer:aws_secret_store:prod-secrets",
+			"to_entity_type":   "aws.secret_store",
+			"to_label":         "prod-secrets",
+		}}},
+	}}
+	app := New(config.Config{}, Dependencies{GraphStore: graph}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/platform/graph/crown-jewel-rankings?tenant_id=writer&account_id=123456789012&entity_type=aws.secret_store&limit=5&depth=3&seed_limit=5")
+	if err != nil {
+		t.Fatalf("GET /platform/graph/crown-jewel-rankings error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /platform/graph/crown-jewel-rankings status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var body struct {
+		TenantID string `json:"tenant_id"`
+		Counts   struct {
+			Seeds int `json:"seeds"`
+		} `json:"counts"`
+		Rankings []struct {
+			Entity struct {
+				URN string `json:"urn"`
+			} `json:"entity"`
+			Seed bool `json:"seed"`
+		} `json:"rankings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.TenantID != "writer" || body.Counts.Seeds != 1 || len(body.Rankings) == 0 {
+		t.Fatalf("body = %#v", body)
+	}
+	if len(graph.cypherRequests) != 2 || graph.cypherRequests[0].Params["entity_type"] != "aws.secret_store" {
 		t.Fatalf("cypher requests = %#v", graph.cypherRequests)
 	}
 }

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -408,7 +408,9 @@ func scopeForHTTPRequest(r *http.Request) string {
 		return scopeCosmoSecurityRead
 	case strings.HasPrefix(path, "/platform/graph/impact/"), strings.HasPrefix(path, "/graph/impact/"):
 		return scopeCosmoSecurityRead
-	case path == "/platform/graph/attack-paths", path == "/platform/graph/aws-public-endpoint-insights":
+	case path == "/platform/graph/attack-paths",
+		path == "/platform/graph/aws-public-endpoint-insights",
+		path == "/platform/graph/crown-jewel-rankings":
 		return scopeCosmoSecurityRead
 	case path == "/platform/graph/ingest-health", path == "/graph/ingest-health":
 		return scopeCosmoSecurityRead
@@ -1211,6 +1213,7 @@ func isKnownStaticAccessPath(path string) bool {
 		"/graph/impact/asset",
 		"/platform/graph/attack-paths",
 		"/platform/graph/aws-public-endpoint-insights",
+		"/platform/graph/crown-jewel-rankings",
 		"/platform/graph/ingest-health",
 		"/graph/ingest-health",
 		"/platform/graph/ingest-runs",

--- a/internal/graphquery/crown_jewel_rank.go
+++ b/internal/graphquery/crown_jewel_rank.go
@@ -1,0 +1,529 @@
+package graphquery
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	defaultCrownJewelRankLimit     = 25
+	maxCrownJewelRankLimit         = 100
+	defaultCrownJewelRankDepth     = 2
+	maxCrownJewelRankDepth         = 3
+	defaultCrownJewelRankSeedLimit = 25
+	maxCrownJewelRankSeedLimit     = 100
+	crownJewelRankDamping          = 0.85
+	crownJewelRankIterations       = 20
+)
+
+var crownJewelRankRelations = []string{
+	"affected_by",
+	"belongs_to",
+	"can_admin",
+	"can_assume",
+	"can_impersonate",
+	"can_perform",
+	"can_reach",
+	"contains",
+	"has_classification",
+	"has_evidence",
+	"has_finding",
+	"has_identifier",
+	"observed_on",
+	"owned_by",
+	"represents",
+	"represents_identity",
+}
+
+type CrownJewelRankRequest struct {
+	TenantID   string
+	AccountID  string
+	EntityType string
+	Limit      uint32
+	Depth      uint32
+	SeedLimit  uint32
+}
+
+type CrownJewelRankResult struct {
+	TenantID string                `json:"tenant_id"`
+	Filters  CrownJewelRankFilters `json:"filters"`
+	Counts   CrownJewelRankCounts  `json:"counts"`
+	Seeds    []GraphEntityRef      `json:"seeds"`
+	Rankings []CrownJewelRank      `json:"rankings"`
+}
+
+type CrownJewelRankFilters struct {
+	AccountID  string `json:"account_id,omitempty"`
+	EntityType string `json:"entity_type,omitempty"`
+	Limit      int    `json:"limit"`
+	Depth      int    `json:"depth"`
+	SeedLimit  int    `json:"seed_limit"`
+}
+
+type CrownJewelRankCounts struct {
+	Seeds      int `json:"seeds"`
+	Candidates int `json:"candidates"`
+	Relations  int `json:"relations"`
+}
+
+type CrownJewelRank struct {
+	Entity    GraphEntityRef `json:"entity"`
+	Score     float64        `json:"score"`
+	Seed      bool           `json:"seed"`
+	Distance  int            `json:"distance"`
+	SeedHits  int            `json:"seed_hits"`
+	Relations []string       `json:"relations,omitempty"`
+}
+
+func (s *Service) GetCrownJewelRanks(ctx context.Context, request CrownJewelRankRequest) (*CrownJewelRankResult, error) {
+	if s == nil || s.store == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return nil, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
+	}
+	limit := normalizeCrownJewelRankLimit(request.Limit)
+	depth := normalizeCrownJewelRankDepth(request.Depth)
+	seedLimit := normalizeCrownJewelRankSeedLimit(request.SeedLimit)
+	params := crownJewelRankParams(tenantID, request, limit, seedLimit)
+	result := &CrownJewelRankResult{
+		TenantID: tenantID,
+		Filters: CrownJewelRankFilters{
+			AccountID:  strings.TrimSpace(request.AccountID),
+			EntityType: strings.TrimSpace(request.EntityType),
+			Limit:      limit,
+			Depth:      depth,
+			SeedLimit:  seedLimit,
+		},
+	}
+
+	seedRows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: crownJewelSeedQuery, Params: params, RowLimit: seedLimit})
+	if err != nil {
+		return nil, err
+	}
+	seeds := crownJewelSeedsFromRows(seedRows)
+	result.Seeds = seeds
+	result.Counts.Seeds = len(seeds)
+	if len(seeds) == 0 {
+		return result, nil
+	}
+	params["path_limit_per_seed"] = int64(crownJewelLimitPerSeed(len(seeds)))
+
+	edgeRows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: crownJewelEdgeQuery(depth), Params: params, RowLimit: ports.MaxCypherQueryRows})
+	if err != nil {
+		return nil, err
+	}
+	graph := newCrownJewelRankGraph(seeds)
+	graph.addRows(edgeRows)
+	rankings := graph.rank(limit)
+	result.Rankings = rankings
+	result.Counts.Candidates = len(graph.nodes)
+	result.Counts.Relations = graph.relationCount()
+	return result, nil
+}
+
+func normalizeCrownJewelRankLimit(limit uint32) int {
+	return normalizeCrownJewelBound(limit, defaultCrownJewelRankLimit, maxCrownJewelRankLimit)
+}
+
+func normalizeCrownJewelRankDepth(depth uint32) int {
+	return normalizeCrownJewelBound(depth, defaultCrownJewelRankDepth, maxCrownJewelRankDepth)
+}
+
+func normalizeCrownJewelRankSeedLimit(limit uint32) int {
+	return normalizeCrownJewelBound(limit, defaultCrownJewelRankSeedLimit, maxCrownJewelRankSeedLimit)
+}
+
+func normalizeCrownJewelBound(value uint32, fallback int, maxValue int) int {
+	switch {
+	case value == 0:
+		return fallback
+	case value > uint32(maxValue):
+		return maxValue
+	default:
+		return int(value)
+	}
+}
+
+func crownJewelRankParams(tenantID string, request CrownJewelRankRequest, limit int, seedLimit int) map[string]any {
+	return map[string]any{
+		"account_id":   strings.TrimSpace(request.AccountID),
+		"edge_limit":   int64(ports.MaxCypherQueryRows),
+		"entity_type":  strings.TrimSpace(request.EntityType),
+		"relations":    crownJewelRankRelations,
+		"sample_limit": int64(limit),
+		"seed_limit":   int64(seedLimit),
+		"tenant_id":    tenantID,
+	}
+}
+
+func crownJewelLimitPerSeed(seedCount int) int {
+	if seedCount <= 0 {
+		return ports.MaxCypherQueryRows
+	}
+	perSeed := ports.MaxCypherQueryRows / seedCount
+	if perSeed < 1 {
+		return 1
+	}
+	return perSeed
+}
+
+const crownJewelSeedMatch = `MATCH (seed:Entity {tenant_id: $tenant_id})
+WHERE (
+    coalesce(seed.attributes_json, '') CONTAINS '"crown_jewel":"true"'
+    OR coalesce(seed.attributes_json, '') CONTAINS '"crown_jewel":true'
+    OR EXISTS {
+      MATCH (seed)-[:RELATION {relation: 'tagged_as'}]->(:Entity {tenant_id: $tenant_id, entity_type: 'asset.tag', label: 'crown_jewel'})
+    }
+  )
+  AND ($entity_type = '' OR seed.entity_type = $entity_type)
+  AND (
+    $account_id = ''
+    OR seed.urn CONTAINS $account_id
+    OR EXISTS {
+      MATCH (seed)-[:RELATION {relation: 'belongs_to'}]->(account:Entity {tenant_id: $tenant_id, entity_type: 'cloud.account'})
+      WHERE account.label = $account_id OR account.urn CONTAINS $account_id
+    }
+  )`
+
+const crownJewelSeedQuery = crownJewelSeedMatch + `
+RETURN seed.urn AS seed_urn,
+       seed.entity_type AS seed_entity_type,
+       seed.label AS seed_label
+ORDER BY seed.label, seed.urn
+LIMIT $seed_limit`
+
+func crownJewelEdgeQuery(depth int) string {
+	return fmt.Sprintf(crownJewelSeedMatch+`
+WITH seed
+ORDER BY seed.label, seed.urn
+LIMIT $seed_limit
+WITH collect(seed) AS seeds
+UNWIND seeds AS seed
+CALL {
+  WITH seed
+  MATCH path=(seed)-[:RELATION*1..%d]-(candidate:Entity {tenant_id: $tenant_id})
+  WHERE all(rel IN relationships(path) WHERE rel.tenant_id = $tenant_id AND rel.relation IN $relations)
+  WITH DISTINCT seed,
+       path,
+       length(path) AS path_len,
+       reduce(path_key = '', node IN nodes(path) | path_key + node.urn + '|') AS path_key
+  ORDER BY path_len, path_key
+  LIMIT $path_limit_per_seed
+  RETURN seed.urn AS seed_urn,
+         path_len AS path_len,
+         path_key AS path_key,
+         [node IN nodes(path) | {urn: node.urn, entity_type: node.entity_type, label: node.label}] AS path_nodes,
+         [rel IN relationships(path) | rel.relation] AS path_relations
+}
+RETURN seed_urn,
+       path_nodes,
+       path_relations
+ORDER BY seed_urn, path_len, path_key
+LIMIT $edge_limit`, depth)
+}
+
+func crownJewelSeedsFromRows(rows []ports.CypherRow) []GraphEntityRef {
+	seeds := make([]GraphEntityRef, 0, len(rows))
+	seen := map[string]struct{}{}
+	for _, row := range rows {
+		seed := prefixedGraphRef(row, "seed")
+		if seed.URN == "" {
+			continue
+		}
+		if _, ok := seen[seed.URN]; ok {
+			continue
+		}
+		seen[seed.URN] = struct{}{}
+		seeds = append(seeds, seed)
+	}
+	return seeds
+}
+
+type crownJewelRankGraph struct {
+	nodes        map[string]GraphEntityRef
+	seeds        map[string]struct{}
+	edges        map[string]map[string]struct{}
+	relations    map[string]map[string]struct{}
+	seedHits     map[string]map[string]struct{}
+	relationKeys map[string]struct{}
+}
+
+func newCrownJewelRankGraph(seeds []GraphEntityRef) *crownJewelRankGraph {
+	graph := &crownJewelRankGraph{
+		nodes:        map[string]GraphEntityRef{},
+		seeds:        map[string]struct{}{},
+		edges:        map[string]map[string]struct{}{},
+		relations:    map[string]map[string]struct{}{},
+		seedHits:     map[string]map[string]struct{}{},
+		relationKeys: map[string]struct{}{},
+	}
+	for _, seed := range seeds {
+		if seed.URN == "" {
+			continue
+		}
+		graph.nodes[seed.URN] = seed
+		graph.seeds[seed.URN] = struct{}{}
+		graph.addSeedHit(seed.URN, seed.URN)
+	}
+	return graph
+}
+
+func (g *crownJewelRankGraph) addRows(rows []ports.CypherRow) {
+	for _, row := range rows {
+		if g.addPathRow(row) {
+			continue
+		}
+		g.addEdgeRow(row)
+	}
+}
+
+func (g *crownJewelRankGraph) addPathRow(row ports.CypherRow) bool {
+	seedURN := cypherString(row, "seed_urn")
+	nodes := cypherGraphRefs(row.Values["path_nodes"])
+	relations := cypherStringList(row.Values["path_relations"])
+	if seedURN == "" || len(nodes) < 2 || len(relations) != len(nodes)-1 {
+		return false
+	}
+	for idx, relation := range relations {
+		g.addRankEdge(seedURN, nodes[idx], nodes[idx+1], relation)
+	}
+	return true
+}
+
+func (g *crownJewelRankGraph) addEdgeRow(row ports.CypherRow) {
+	seedURN := cypherString(row, "seed_urn")
+	from := prefixedGraphRef(row, "from")
+	to := prefixedGraphRef(row, "to")
+	relation := cypherString(row, "relation")
+	if seedURN == "" || from.URN == "" || to.URN == "" || relation == "" {
+		return
+	}
+	g.addRankEdge(seedURN, from, to, relation)
+}
+
+func (g *crownJewelRankGraph) addRankEdge(seedURN string, from GraphEntityRef, to GraphEntityRef, relation string) {
+	if seedURN == "" || from.URN == "" || to.URN == "" || relation == "" {
+		return
+	}
+	g.nodes[from.URN] = from
+	g.nodes[to.URN] = to
+	g.addEdge(from.URN, to.URN)
+	g.addRelation(from.URN, relation)
+	g.addRelation(to.URN, relation)
+	g.addSeedHit(from.URN, seedURN)
+	g.addSeedHit(to.URN, seedURN)
+	g.relationKeys[crownJewelRelationKey(from.URN, relation, to.URN)] = struct{}{}
+}
+
+func crownJewelRelationKey(left string, relation string, right string) string {
+	if right < left {
+		left, right = right, left
+	}
+	return left + "|" + relation + "|" + right
+}
+
+func (g *crownJewelRankGraph) addEdge(left string, right string) {
+	if left == "" || right == "" || left == right {
+		return
+	}
+	if g.edges[left] == nil {
+		g.edges[left] = map[string]struct{}{}
+	}
+	if g.edges[right] == nil {
+		g.edges[right] = map[string]struct{}{}
+	}
+	g.edges[left][right] = struct{}{}
+	g.edges[right][left] = struct{}{}
+}
+
+func (g *crownJewelRankGraph) addRelation(urn string, relation string) {
+	if urn == "" || relation == "" {
+		return
+	}
+	if g.relations[urn] == nil {
+		g.relations[urn] = map[string]struct{}{}
+	}
+	g.relations[urn][relation] = struct{}{}
+}
+
+func (g *crownJewelRankGraph) addSeedHit(urn string, seedURN string) {
+	if urn == "" || seedURN == "" {
+		return
+	}
+	if g.seedHits[urn] == nil {
+		g.seedHits[urn] = map[string]struct{}{}
+	}
+	g.seedHits[urn][seedURN] = struct{}{}
+}
+
+func (g *crownJewelRankGraph) relationCount() int {
+	return len(g.relationKeys)
+}
+
+func (g *crownJewelRankGraph) rank(limit int) []CrownJewelRank {
+	if len(g.nodes) == 0 || len(g.seeds) == 0 || limit <= 0 {
+		return nil
+	}
+	seedWeight := 1.0 / float64(len(g.seeds))
+	seedWeights := map[string]float64{}
+	ranks := map[string]float64{}
+	for urn := range g.nodes {
+		if _, ok := g.seeds[urn]; ok {
+			seedWeights[urn] = seedWeight
+			ranks[urn] = seedWeight
+		} else {
+			ranks[urn] = 0
+		}
+	}
+	for i := 0; i < crownJewelRankIterations; i++ {
+		next := map[string]float64{}
+		for urn := range g.nodes {
+			next[urn] = (1 - crownJewelRankDamping) * seedWeights[urn]
+		}
+		for urn, rank := range ranks {
+			neighbors := g.edges[urn]
+			if len(neighbors) == 0 {
+				for seedURN, weight := range seedWeights {
+					next[seedURN] += crownJewelRankDamping * rank * weight
+				}
+				continue
+			}
+			share := crownJewelRankDamping * rank / float64(len(neighbors))
+			for neighbor := range neighbors {
+				next[neighbor] += share
+			}
+		}
+		ranks = next
+	}
+	distances := g.distances()
+	rankings := make([]CrownJewelRank, 0, len(g.nodes))
+	for urn, node := range g.nodes {
+		if excludedCrownJewelRankEntity(node) {
+			continue
+		}
+		_, seed := g.seeds[urn]
+		rankings = append(rankings, CrownJewelRank{
+			Entity:    node,
+			Score:     math.Round(ranks[urn]*1_000_000) / 1_000_000,
+			Seed:      seed,
+			Distance:  distances[urn],
+			SeedHits:  len(g.seedHits[urn]),
+			Relations: sortedSet(g.relations[urn]),
+		})
+	}
+	sort.Slice(rankings, func(i, j int) bool {
+		if rankings[i].Score != rankings[j].Score {
+			return rankings[i].Score > rankings[j].Score
+		}
+		if rankings[i].Distance != rankings[j].Distance {
+			return rankings[i].Distance < rankings[j].Distance
+		}
+		return rankings[i].Entity.URN < rankings[j].Entity.URN
+	})
+	if len(rankings) > limit {
+		rankings = rankings[:limit]
+	}
+	return rankings
+}
+
+func (g *crownJewelRankGraph) distances() map[string]int {
+	distances := map[string]int{}
+	queue := make([]string, 0, len(g.seeds))
+	for seedURN := range g.seeds {
+		distances[seedURN] = 0
+		queue = append(queue, seedURN)
+	}
+	for len(queue) > 0 {
+		urn := queue[0]
+		queue = queue[1:]
+		for neighbor := range g.edges[urn] {
+			if _, ok := distances[neighbor]; ok {
+				continue
+			}
+			distances[neighbor] = distances[urn] + 1
+			queue = append(queue, neighbor)
+		}
+	}
+	return distances
+}
+
+func excludedCrownJewelRankEntity(entity GraphEntityRef) bool {
+	return entity.EntityType == "asset.tag" || strings.HasSuffix(entity.URN, ":asset_tag:crown_jewel")
+}
+
+func prefixedGraphRef(row ports.CypherRow, prefix string) GraphEntityRef {
+	return GraphEntityRef{
+		URN:        cypherString(row, prefix+"_urn"),
+		EntityType: cypherString(row, prefix+"_entity_type"),
+		Label:      cypherString(row, prefix+"_label"),
+	}
+}
+
+func cypherGraphRefs(value any) []GraphEntityRef {
+	values, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	refs := make([]GraphEntityRef, 0, len(values))
+	for _, value := range values {
+		fields, ok := value.(map[string]any)
+		if !ok {
+			return nil
+		}
+		ref := GraphEntityRef{
+			URN:        cypherAnyString(fields["urn"]),
+			EntityType: cypherAnyString(fields["entity_type"]),
+			Label:      cypherAnyString(fields["label"]),
+		}
+		if ref.URN == "" {
+			return nil
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func cypherStringList(value any) []string {
+	values, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		result = append(result, cypherAnyString(value))
+	}
+	return result
+}
+
+func cypherAnyString(value any) string {
+	if value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case fmt.Stringer:
+		return typed.String()
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func sortedSet(values map[string]struct{}) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/graphquery/crown_jewel_rank_test.go
+++ b/internal/graphquery/crown_jewel_rank_test.go
@@ -1,0 +1,141 @@
+package graphquery
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestGetCrownJewelRanksRequiresTenant(t *testing.T) {
+	_, err := New(&awsExposureStubStore{}).GetCrownJewelRanks(context.Background(), CrownJewelRankRequest{})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("GetCrownJewelRanks() error = %v, want %v", err, ErrInvalidRequest)
+	}
+}
+
+func TestGetCrownJewelRanksQueriesAndRanksPersonalizedSubgraph(t *testing.T) {
+	store := &awsExposureStubStore{responses: [][]ports.CypherRow{
+		{{Values: map[string]any{
+			"seed_urn":         "urn:cerebro:writer:aws_secret_store:prod-secrets",
+			"seed_entity_type": "aws.secret_store",
+			"seed_label":       "prod-secrets",
+		}}},
+		{
+			{Values: crownJewelRankPathRow(
+				"urn:cerebro:writer:aws_secret_store:prod-secrets",
+				[]GraphEntityRef{
+					{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+					{URN: "urn:cerebro:writer:aws_public_principal:public_internet", EntityType: "aws.public_principal", Label: "public_internet"},
+				},
+				[]string{"can_reach"},
+			)},
+			{Values: crownJewelRankPathRow(
+				"urn:cerebro:writer:aws_secret_store:prod-secrets",
+				[]GraphEntityRef{
+					{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+					{URN: "urn:cerebro:writer:cloud_account:123456789012", EntityType: "cloud.account", Label: "123456789012"},
+				},
+				[]string{"belongs_to"},
+			)},
+			{Values: crownJewelRankPathRow(
+				"urn:cerebro:writer:aws_secret_store:prod-secrets",
+				[]GraphEntityRef{
+					{URN: "urn:cerebro:writer:cloud_account:123456789012", EntityType: "cloud.account", Label: "123456789012"},
+					{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+				},
+				[]string{"belongs_to"},
+			)},
+			{Values: crownJewelRankPathRow(
+				"urn:cerebro:writer:aws_secret_store:prod-secrets",
+				[]GraphEntityRef{
+					{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+					{URN: "urn:cerebro:writer:cloud_account:123456789012", EntityType: "cloud.account", Label: "123456789012"},
+					{URN: "urn:cerebro:writer:aws_iam_policy:AdministratorAccess", EntityType: "aws.iam_policy", Label: "AdministratorAccess"},
+					{URN: "urn:cerebro:writer:aws_iam_role:admin", EntityType: "aws.iam_role", Label: "admin"},
+				},
+				[]string{"belongs_to", "belongs_to", "can_perform"},
+			)},
+		},
+	}}
+
+	result, err := New(store).GetCrownJewelRanks(context.Background(), CrownJewelRankRequest{
+		TenantID:   "writer",
+		AccountID:  "123456789012",
+		EntityType: "aws.secret_store",
+		Depth:      3,
+		Limit:      5,
+		SeedLimit:  5,
+	})
+	if err != nil {
+		t.Fatalf("GetCrownJewelRanks() error = %v", err)
+	}
+	if len(store.requests) != 2 {
+		t.Fatalf("query count = %d, want 2", len(store.requests))
+	}
+	if got := store.requests[0].Params["account_id"]; got != "123456789012" {
+		t.Fatalf("account_id param = %v, want 123456789012", got)
+	}
+	if !strings.Contains(store.requests[1].Query, "*1..3") {
+		t.Fatalf("edge query = %q, want depth 3", store.requests[1].Query)
+	}
+	if !strings.Contains(store.requests[1].Query, "LIMIT $path_limit_per_seed") {
+		t.Fatalf("edge query = %q, want per-seed complete-path cap", store.requests[1].Query)
+	}
+	if got := store.requests[1].Params["path_limit_per_seed"]; got != int64(ports.MaxCypherQueryRows) {
+		t.Fatalf("path_limit_per_seed = %v, want %d", got, ports.MaxCypherQueryRows)
+	}
+	if !strings.Contains(store.requests[1].Query, "ORDER BY path_len, path_key") {
+		t.Fatalf("edge query = %q, want stable complete-path ordering", store.requests[1].Query)
+	}
+	if !strings.Contains(store.requests[1].Query, "ORDER BY seed_urn, path_len, path_key") {
+		t.Fatalf("edge query = %q, want stable path row ordering", store.requests[1].Query)
+	}
+	relations, ok := store.requests[1].Params["relations"].([]string)
+	if !ok || slices.Contains(relations, "tagged_as") {
+		t.Fatalf("traversal relations = %#v, want shared crown_jewel tag excluded", store.requests[1].Params["relations"])
+	}
+	if result.Counts.Seeds != 1 || result.Counts.Relations != 4 || len(result.Rankings) == 0 {
+		t.Fatalf("result = %#v", result)
+	}
+	secret, ok := crownJewelRankByURN(result.Rankings, "urn:cerebro:writer:aws_secret_store:prod-secrets")
+	if !ok || !secret.Seed || secret.Distance != 0 || !slices.Contains(secret.Relations, "can_reach") {
+		t.Fatalf("secret rank = %#v, ok=%t", secret, ok)
+	}
+	role, ok := crownJewelRankByURN(result.Rankings, "urn:cerebro:writer:aws_iam_role:admin")
+	if !ok || role.Score <= 0 || !slices.Contains(role.Relations, "can_perform") {
+		t.Fatalf("role rank = %#v, ok=%t", role, ok)
+	}
+}
+
+func crownJewelRankPathRow(seedURN string, nodes []GraphEntityRef, relations []string) map[string]any {
+	pathNodes := make([]any, 0, len(nodes))
+	for _, node := range nodes {
+		pathNodes = append(pathNodes, map[string]any{
+			"urn":         node.URN,
+			"entity_type": node.EntityType,
+			"label":       node.Label,
+		})
+	}
+	pathRelations := make([]any, 0, len(relations))
+	for _, relation := range relations {
+		pathRelations = append(pathRelations, relation)
+	}
+	return map[string]any{
+		"seed_urn":       seedURN,
+		"path_nodes":     pathNodes,
+		"path_relations": pathRelations,
+	}
+}
+
+func crownJewelRankByURN(ranks []CrownJewelRank, urn string) (CrownJewelRank, bool) {
+	for _, rank := range ranks {
+		if rank.Entity.URN == urn {
+			return rank, true
+		}
+	}
+	return CrownJewelRank{}, false
+}


### PR DESCRIPTION
## Summary
- add `GET /platform/graph/crown-jewel-rankings` for tenant-scoped personalized crown-jewel graph ranking
- seed ranking from crown-jewel-tagged entities / `crown_jewel` attributes, expand bounded relation neighborhoods, and run bounded personalized PageRank in Go
- include filters/counts/seeds/rankings in the response and OpenAPI route coverage

## Validation
- `go test ./internal/graphquery ./internal/bootstrap`
- `make verify`
