### PR TITLE
feat(graph): add deploy metadata and relation counts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,3 +160,30 @@ jobs:
           GOBIN="${RUNNER_TEMP}/cosign" go install github.com/sigstore/cosign/v2/cmd/cosign@v2.6.1
           "${RUNNER_TEMP}/cosign/cosign" sign --yes "${IMAGE_BASE}:${RELEASE_TAG}"
           "${RUNNER_TEMP}/cosign/cosign" sign --yes "${IMAGE_BASE}:latest"
+
+  promote-aws:
+    runs-on: ubuntu-latest
+    needs: [resolve-tag, ghcr-publish]
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [sec-dev, go-prod]
+    steps:
+      - name: Trigger infra image promotion
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.CEREBRO_INFRA_PROMOTION_TOKEN }}
+          RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
+          STACK_NAME: ${{ matrix.environment }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::CEREBRO_INFRA_PROMOTION_TOKEN is not configured; skipping ${STACK_NAME} promotion for ${RELEASE_TAG}"
+            exit 0
+          fi
+          gh workflow run propose-image-tag.yml \
+            --repo WriterInternal/cerebro \
+            --ref main \
+            -f environment="${STACK_NAME}" \
+            -f image_tag="${RELEASE_TAG}"
+          echo "Requested ${STACK_NAME} promotion for ${RELEASE_TAG}"

--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -39,6 +39,10 @@ type graphCountsStore interface {
 	Counts(context.Context) (graphstore.Counts, error)
 }
 
+type graphRelationCountsStore interface {
+	RelationCounts(context.Context, []string) (graphstore.RelationCounts, error)
+}
+
 type graphQueryStore interface {
 	Ping(context.Context) error
 	GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error)
@@ -121,6 +125,10 @@ type graphPathsResult struct {
 	Topology   graphstore.Topology      `json:"topology"`
 }
 
+type graphRelationCountsResult struct {
+	Relations graphstore.RelationCounts `json:"relations"`
+}
+
 type graphIntegrityResult struct {
 	Checks []graphstore.IntegrityCheck `json:"checks"`
 	Passed uint32                      `json:"passed"`
@@ -185,7 +193,7 @@ func runGraph(args []string) error {
 		return runGraphIngestRun(args[1:])
 	case "ingest-runs":
 		return runGraphIngestRuns(args[1:])
-	case "counts", "neighborhood", "paths", "integrity":
+	case "counts", "neighborhood", "paths", "relation-counts", "integrity":
 		return runGraphInspect(args)
 	case "cve-impact", "package-exposure", "asset-vulns":
 		return runGraphImpact(args)
@@ -240,7 +248,7 @@ func runGraph(args []string) error {
 }
 
 func graphUsage() string {
-	return fmt.Sprintf("usage: %s graph [counts|neighborhood|paths|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|rebuild|inspect] ...", os.Args[0])
+	return fmt.Sprintf("usage: %s graph [counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|rebuild|inspect] ...", os.Args[0])
 }
 
 func graphIngestUsage() string {
@@ -256,7 +264,7 @@ func graphIngestRunUsage() string {
 }
 
 func graphInspectUsage() string {
-	return fmt.Sprintf("usage: %s graph [counts|neighborhood <urn>|paths|integrity] [limit=N]", os.Args[0])
+	return fmt.Sprintf("usage: %s graph [counts|neighborhood <urn>|paths|relation-counts|integrity] [limit=N] [relations=a,b]", os.Args[0])
 }
 
 func graphImpactUsage() string {
@@ -320,6 +328,20 @@ func runGraphInspect(args []string) error {
 			return err
 		}
 		return printJSON(graphPathsResult{Patterns: patterns, Traversals: traversals, Topology: topology})
+	case "relation-counts":
+		relations, err := parseGraphRelationCountsArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		store, ok := deps.GraphStore.(graphRelationCountsStore)
+		if !ok {
+			return fmt.Errorf("graph store does not support relation counts")
+		}
+		counts, err := store.RelationCounts(ctx, relations)
+		if err != nil {
+			return err
+		}
+		return printJSON(graphRelationCountsResult{Relations: counts})
 	case "integrity":
 		store, ok := deps.GraphStore.(graphIntegrityStore)
 		if !ok {
@@ -429,6 +451,40 @@ func parseGraphNeighborhoodArgs(args []string) (string, int, error) {
 		return "", 0, err
 	}
 	return rootURN, limit, nil
+}
+
+func parseGraphRelationCountsArgs(args []string) ([]string, error) {
+	var relations []string
+	seen := map[string]struct{}{}
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return nil, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		switch strings.TrimSpace(key) {
+		case "relations":
+			for _, relation := range strings.Split(value, ",") {
+				relation = strings.TrimSpace(relation)
+				if relation == "" {
+					continue
+				}
+				if _, ok := seen[relation]; ok {
+					continue
+				}
+				seen[relation] = struct{}{}
+				relations = append(relations, relation)
+			}
+		default:
+			return nil, usageError(fmt.Sprintf("unsupported graph relation-counts argument %q", key))
+		}
+	}
+	if len(relations) == 0 {
+		return nil, usageError(graphInspectUsage())
+	}
+	if len(relations) > 50 {
+		return nil, fmt.Errorf("relations must include at most 50 values")
+	}
+	return relations, nil
 }
 
 func parseGraphImpactArgs(args []string) (graphquery.ImpactRequest, error) {

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
@@ -165,6 +166,23 @@ func TestParseGraphNeighborhoodArgs(t *testing.T) {
 	}
 	if limit != 7 {
 		t.Fatalf("limit = %d, want 7", limit)
+	}
+}
+
+func TestParseGraphRelationCountsArgs(t *testing.T) {
+	relations, err := parseGraphRelationCountsArgs([]string{"relations=belongs_to, represents,belongs_to,can_reach"})
+	if err != nil {
+		t.Fatalf("parseGraphRelationCountsArgs() error = %v", err)
+	}
+	want := []string{"belongs_to", "represents", "can_reach"}
+	if !reflect.DeepEqual(relations, want) {
+		t.Fatalf("relations = %#v, want %#v", relations, want)
+	}
+}
+
+func TestParseGraphRelationCountsArgsRequiresRelations(t *testing.T) {
+	if _, err := parseGraphRelationCountsArgs(nil); err == nil {
+		t.Fatal("parseGraphRelationCountsArgs() error = nil, want non-nil")
 	}
 }
 

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -345,6 +345,12 @@ type CheckHealthResponse struct {
 	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	CheckedAt     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=checked_at,json=checkedAt,proto3" json:"checked_at,omitempty"`
 	Components    []*ComponentStatus     `protobuf:"bytes,3,rep,name=components,proto3" json:"components,omitempty"`
+	ServiceName   string                 `protobuf:"bytes,4,opt,name=service_name,json=serviceName,proto3" json:"service_name,omitempty"`
+	Version       string                 `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
+	Commit        string                 `protobuf:"bytes,6,opt,name=commit,proto3" json:"commit,omitempty"`
+	BuildDate     string                 `protobuf:"bytes,7,opt,name=build_date,json=buildDate,proto3" json:"build_date,omitempty"`
+	ApiVersion    string                 `protobuf:"bytes,8,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	ImageTag      string                 `protobuf:"bytes,9,opt,name=image_tag,json=imageTag,proto3" json:"image_tag,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -398,6 +404,48 @@ func (x *CheckHealthResponse) GetComponents() []*ComponentStatus {
 		return x.Components
 	}
 	return nil
+}
+
+func (x *CheckHealthResponse) GetServiceName() string {
+	if x != nil {
+		return x.ServiceName
+	}
+	return ""
+}
+
+func (x *CheckHealthResponse) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *CheckHealthResponse) GetCommit() string {
+	if x != nil {
+		return x.Commit
+	}
+	return ""
+}
+
+func (x *CheckHealthResponse) GetBuildDate() string {
+	if x != nil {
+		return x.BuildDate
+	}
+	return ""
+}
+
+func (x *CheckHealthResponse) GetApiVersion() string {
+	if x != nil {
+		return x.ApiVersion
+	}
+	return ""
+}
+
+func (x *CheckHealthResponse) GetImageTag() string {
+	if x != nil {
+		return x.ImageTag
+	}
+	return ""
 }
 
 // ReportParameter describes one supported report input parameter.
@@ -6790,14 +6838,22 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x0fComponentStatus\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x16\n" +
-	"\x06detail\x18\x03 \x01(\tR\x06detail\"\xa5\x01\n" +
+	"\x06detail\x18\x03 \x01(\tR\x06detail\"\xd7\x02\n" +
 	"\x13CheckHealthResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x129\n" +
 	"\n" +
 	"checked_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcheckedAt\x12;\n" +
 	"\n" +
 	"components\x18\x03 \x03(\v2\x1b.cerebro.v1.ComponentStatusR\n" +
-	"components\"_\n" +
+	"components\x12!\n" +
+	"\fservice_name\x18\x04 \x01(\tR\vserviceName\x12\x18\n" +
+	"\aversion\x18\x05 \x01(\tR\aversion\x12\x16\n" +
+	"\x06commit\x18\x06 \x01(\tR\x06commit\x12\x1d\n" +
+	"\n" +
+	"build_date\x18\a \x01(\tR\tbuildDate\x12\x1f\n" +
+	"\vapi_version\x18\b \x01(\tR\n" +
+	"apiVersion\x12\x1b\n" +
+	"\timage_tag\x18\t \x01(\tR\bimageTag\"_\n" +
 	"\x0fReportParameter\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x1a\n" +

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -59,6 +59,7 @@ type App struct {
 }
 
 type bootstrapService struct {
+	cfg     config.Config
 	deps    Dependencies
 	sources *sourcecdk.Registry
 }
@@ -77,7 +78,7 @@ var (
 // New constructs the minimal bootstrap app and registers the Connect handlers.
 func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App {
 	mux := http.NewServeMux()
-	service := &bootstrapService{deps: deps, sources: sources}
+	service := &bootstrapService{cfg: cfg, deps: deps, sources: sources}
 	path, handler := cerebrov1connect.NewBootstrapServiceHandler(service, connect.WithInterceptors(authInterceptor(cfg.Auth)))
 	mux.Handle(path, handler)
 
@@ -173,7 +174,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 }
 
 func (a *App) handleHealth(w http.ResponseWriter, r *http.Request) {
-	response := healthResponse(r.Context(), a.deps)
+	response := publicHealthResponse(r.Context(), a.deps)
 	writeProtoJSON(w, http.StatusOK, response)
 }
 
@@ -1472,7 +1473,7 @@ func (s *bootstrapService) GetVersion(_ context.Context, _ *connect.Request[cere
 }
 
 func (s *bootstrapService) CheckHealth(ctx context.Context, _ *connect.Request[cerebrov1.CheckHealthRequest]) (*connect.Response[cerebrov1.CheckHealthResponse], error) {
-	return connect.NewResponse(healthResponse(ctx, s.deps)), nil
+	return connect.NewResponse(healthResponse(ctx, s.cfg, s.deps)), nil
 }
 
 func (s *bootstrapService) ListReportDefinitions(_ context.Context, _ *connect.Request[cerebrov1.ListReportDefinitionsRequest]) (*connect.Response[cerebrov1.ListReportDefinitionsResponse], error) {
@@ -2150,7 +2151,18 @@ func (s *bootstrapService) CheckGraphIngestHealth(ctx context.Context, req *conn
 	return connect.NewResponse(graphIngestHealthResponse(result)), nil
 }
 
-func healthResponse(ctx context.Context, deps Dependencies) *cerebrov1.CheckHealthResponse {
+func healthResponse(ctx context.Context, cfg config.Config, deps Dependencies) *cerebrov1.CheckHealthResponse {
+	response := publicHealthResponse(ctx, deps)
+	response.ServiceName = buildinfo.ServiceName
+	response.Version = buildinfo.Version
+	response.Commit = buildinfo.Commit
+	response.BuildDate = buildinfo.BuildDate
+	response.ApiVersion = buildinfo.APIVersion
+	response.ImageTag = healthImageTag(cfg)
+	return response
+}
+
+func publicHealthResponse(ctx context.Context, deps Dependencies) *cerebrov1.CheckHealthResponse {
 	components := []*cerebrov1.ComponentStatus{
 		componentStatus(ctx, "append_log", deps.AppendLog),
 		componentStatus(ctx, "state_store", deps.StateStore),
@@ -2168,6 +2180,21 @@ func healthResponse(ctx context.Context, deps Dependencies) *cerebrov1.CheckHeal
 		CheckedAt:  timestamppb.Now(),
 		Components: components,
 	}
+}
+
+func healthImageTag(cfg config.Config) string {
+	imageTag := strings.TrimSpace(cfg.ImageTag)
+	if imageTag != "" {
+		return imageTag
+	}
+	version := strings.TrimSpace(buildinfo.Version)
+	if version == "" || version == "dev" {
+		return ""
+	}
+	if strings.HasPrefix(version, "v") {
+		return version
+	}
+	return "v" + version
 }
 
 func writeProtoJSON(w http.ResponseWriter, statusCode int, message proto.Message) {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1348,6 +1348,11 @@ func TestBootstrapEndpoints(t *testing.T) {
 	if payload["status"] != "ready" {
 		t.Fatalf("health status = %#v, want %q", payload["status"], "ready")
 	}
+	for _, field := range []string{"service_name", "version", "commit", "build_date", "api_version", "image_tag"} {
+		if _, ok := payload[field]; ok {
+			t.Fatalf("public /health included %q metadata: %#v", field, payload[field])
+		}
+	}
 	sourcesResp, err := server.Client().Get(server.URL + "/sources")
 	if err != nil {
 		t.Fatalf("GET /sources error = %v", err)
@@ -3547,9 +3552,15 @@ func TestBackfillFindingRiskSkipsMissingStateStore(t *testing.T) {
 
 func TestBootstrapHealthPingsUseTimeoutContext(t *testing.T) {
 	stateStore := &deadlineAwareStore{}
-	response := healthResponse(context.Background(), Dependencies{StateStore: stateStore})
+	response := healthResponse(context.Background(), config.Config{ImageTag: "v9.9.9"}, Dependencies{StateStore: stateStore})
 	if response.GetStatus() != "ready" {
 		t.Fatalf("health status = %q, want ready", response.GetStatus())
+	}
+	if response.GetServiceName() != buildinfo.ServiceName || response.GetVersion() != buildinfo.Version || response.GetCommit() != buildinfo.Commit {
+		t.Fatalf("health build metadata = service:%q version:%q commit:%q", response.GetServiceName(), response.GetVersion(), response.GetCommit())
+	}
+	if response.GetApiVersion() != buildinfo.APIVersion || response.GetBuildDate() != buildinfo.BuildDate || response.GetImageTag() != "v9.9.9" {
+		t.Fatalf("health deploy metadata = api:%q build:%q image:%q", response.GetApiVersion(), response.GetBuildDate(), response.GetImageTag())
 	}
 	if !stateStore.sawDeadline {
 		t.Fatal("state store ping did not receive a deadline")
@@ -3558,12 +3569,23 @@ func TestBootstrapHealthPingsUseTimeoutContext(t *testing.T) {
 
 func TestBootstrapHealthTreatsTypedNilPingerAsUnconfigured(t *testing.T) {
 	var stateStore *typedNilPinger
-	response := healthResponse(context.Background(), Dependencies{StateStore: stateStore})
+	response := healthResponse(context.Background(), config.Config{}, Dependencies{StateStore: stateStore})
 	if response.GetStatus() != "ready" {
 		t.Fatalf("health status = %q, want ready", response.GetStatus())
 	}
 	if got := response.GetComponents()[1].GetStatus(); got != "unconfigured" {
 		t.Fatalf("state_store status = %q, want unconfigured", got)
+	}
+}
+
+func TestBootstrapHealthDefaultsImageTagFromBuildVersion(t *testing.T) {
+	previousVersion := buildinfo.Version
+	buildinfo.Version = "2.1.50"
+	t.Cleanup(func() { buildinfo.Version = previousVersion })
+
+	response := healthResponse(context.Background(), config.Config{}, Dependencies{})
+	if response.GetImageTag() != "v2.1.50" {
+		t.Fatalf("ImageTag = %q, want %q", response.GetImageTag(), "v2.1.50")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ var errLegacyKuzuPath = errors.New("CEREBRO_KUZU_PATH is no longer supported")
 type Config struct {
 	HTTPAddr        string
 	ShutdownTimeout time.Duration
+	ImageTag        string
 	AppendLog       AppendLogConfig
 	StateStore      StateStoreConfig
 	GraphStore      GraphStoreConfig
@@ -110,6 +111,7 @@ func Load() (Config, error) {
 	cfg := Config{
 		HTTPAddr:        strings.TrimSpace(os.Getenv("CEREBRO_HTTP_ADDR")),
 		ShutdownTimeout: defaultShutdownTimeout,
+		ImageTag:        strings.TrimSpace(os.Getenv("CEREBRO_IMAGE_TAG")),
 		AppendLog: AppendLogConfig{
 			Driver:                 strings.TrimSpace(os.Getenv("CEREBRO_APPEND_LOG_DRIVER")),
 			JetStreamURL:           strings.TrimSpace(os.Getenv("CEREBRO_JETSTREAM_URL")),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,7 @@ import (
 func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_HTTP_ADDR", "")
 	t.Setenv("CEREBRO_SHUTDOWN_TIMEOUT", "")
+	t.Setenv("CEREBRO_IMAGE_TAG", "")
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", "")
 	t.Setenv("CEREBRO_JETSTREAM_URL", "")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")
@@ -60,6 +61,7 @@ func TestLoadDefaults(t *testing.T) {
 func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_HTTP_ADDR", "127.0.0.1:9000")
 	t.Setenv("CEREBRO_SHUTDOWN_TIMEOUT", "3s")
+	t.Setenv("CEREBRO_IMAGE_TAG", "v9.9.9")
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", AppendLogDriverJetStream)
 	t.Setenv("CEREBRO_JETSTREAM_URL", "nats://127.0.0.1:4222")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "cerebro.events")
@@ -94,6 +96,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.ShutdownTimeout != 3*time.Second {
 		t.Fatalf("ShutdownTimeout = %v, want %v", cfg.ShutdownTimeout, 3*time.Second)
+	}
+	if cfg.ImageTag != "v9.9.9" {
+		t.Fatalf("ImageTag = %q, want %q", cfg.ImageTag, "v9.9.9")
 	}
 	if cfg.AppendLog.Driver != AppendLogDriverJetStream {
 		t.Fatalf("AppendLog.Driver = %q, want %q", cfg.AppendLog.Driver, AppendLogDriverJetStream)
@@ -131,6 +136,7 @@ func clearDependencyEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("CEREBRO_HTTP_ADDR", "")
 	t.Setenv("CEREBRO_SHUTDOWN_TIMEOUT", "")
+	t.Setenv("CEREBRO_IMAGE_TAG", "")
 	t.Setenv("CEREBRO_APPEND_LOG_DRIVER", "")
 	t.Setenv("CEREBRO_JETSTREAM_URL", "")
 	t.Setenv("CEREBRO_JETSTREAM_SUBJECT_PREFIX", "")

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -41,6 +41,7 @@ type Store struct {
 }
 
 type Counts = graphstore.Counts
+type RelationCounts = graphstore.RelationCounts
 type Traversal = graphstore.Traversal
 type IntegrityCheck = graphstore.IntegrityCheck
 type PathPattern = graphstore.PathPattern
@@ -117,6 +118,40 @@ func (s *Store) Counts(ctx context.Context) (Counts, error) {
 		return nil, nil
 	}); err != nil {
 		return Counts{}, err
+	}
+	return counts, nil
+}
+
+// RelationCounts returns exact totals for the requested projected relation names.
+func (s *Store) RelationCounts(ctx context.Context, relations []string) (_ RelationCounts, err error) {
+	if err := s.requireConfigured(); err != nil {
+		return nil, err
+	}
+	if len(relations) == 0 {
+		return RelationCounts{}, nil
+	}
+	counts := make(RelationCounts, len(relations))
+	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		result, err := tx.Run(ctx, `UNWIND $relations AS relation
+OPTIONAL MATCH ()-[r:RELATION]->()
+WHERE r.relation = relation
+RETURN relation, count(r)
+ORDER BY relation`, map[string]any{"relations": relations})
+		if err != nil {
+			return nil, err
+		}
+		for result.Next(ctx) {
+			record := result.Record()
+			counts[stringValue(record.Values[0])] = toInt64(record.Values[1])
+		}
+		return nil, result.Err()
+	}); err != nil {
+		return nil, fmt.Errorf("count graph relations: %w", err)
+	}
+	for _, relation := range relations {
+		if _, ok := counts[relation]; !ok {
+			counts[relation] = 0
+		}
 	}
 	return counts, nil
 }

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -163,6 +163,13 @@ func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	if counts.Nodes != 3 || counts.Relations != 2 {
 		t.Fatalf("Counts() = %#v, want 3 nodes and 2 relations", counts)
 	}
+	relationCounts, err := store.RelationCounts(ctx, []string{"maintains", "tracks", "missing"})
+	if err != nil {
+		t.Fatalf("RelationCounts() error = %v", err)
+	}
+	if relationCounts["maintains"] != 1 || relationCounts["tracks"] != 1 || relationCounts["missing"] != 0 {
+		t.Fatalf("RelationCounts() = %#v, want maintains=1 tracks=1 missing=0", relationCounts)
+	}
 	neighborhood, err := store.GetEntityNeighborhood(ctx, user.URN, 5)
 	if err != nil {
 		t.Fatalf("GetEntityNeighborhood() error = %v", err)

--- a/internal/graphstore/types.go
+++ b/internal/graphstore/types.go
@@ -6,6 +6,9 @@ type Counts struct {
 	Relations int64 `json:"relations"`
 }
 
+// RelationCounts summarizes totals keyed by projected relation name.
+type RelationCounts map[string]int64
+
 // Traversal captures one sampled two-hop graph path.
 type Traversal struct {
 	FromURN        string `json:"from_urn"`

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -78,6 +78,12 @@ message CheckHealthResponse {
   string status = 1;
   google.protobuf.Timestamp checked_at = 2;
   repeated ComponentStatus components = 3;
+  string service_name = 4;
+  string version = 5;
+  string commit = 6;
+  string build_date = 7;
+  string api_version = 8;
+  string image_tag = 9;
 }
 
 // ReportParameter describes one supported report input parameter.


### PR DESCRIPTION
## Summary
- add exact graph relation-counts CLI support for targeted deploy verification
- include build/version/image metadata in health responses
- trigger infra image promotion from release workflow when the cross-repo token is configured

## Validation
- make verify