### PR TITLE
feat(findings): calibrate effective severity from risk

### DIFF
--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -267,6 +267,7 @@ func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sour
 	if riskScore == 0 {
 		riskScore = risk.Score
 	}
+	effectiveSeverity := firstNonEmpty(EffectiveSeverityFromRiskScore(riskScore), risk.EffectiveSeverity, finding.Attributes[FindingEffectiveSeverityAttribute])
 	likelihoodScore := finding.LikelihoodScore
 	if likelihoodScore == 0 {
 		likelihoodScore = risk.LikelihoodScore
@@ -308,14 +309,15 @@ func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sour
 		EventCount:         len(eventIDs),
 		ControlRefs:        findingControlRefSnapshots(finding.ControlRefs),
 		FindingRiskSnapshot: workflowevents.FindingRiskSnapshot{
-			RiskScore:        riskScore,
-			LikelihoodScore:  likelihoodScore,
-			ImpactScore:      impactScore,
-			ConfidenceScore:  confidenceScore,
-			LikelihoodLevel:  likelihoodLevel,
-			ImpactLevel:      impactLevel,
-			RiskModelVersion: modelVersion,
-			RiskReasons:      uniqueSortedStrings(riskReasons),
+			RiskScore:         riskScore,
+			EffectiveSeverity: effectiveSeverity,
+			LikelihoodScore:   likelihoodScore,
+			ImpactScore:       impactScore,
+			ConfidenceScore:   confidenceScore,
+			LikelihoodLevel:   likelihoodLevel,
+			ImpactLevel:       impactLevel,
+			RiskModelVersion:  modelVersion,
+			RiskReasons:       uniqueSortedStrings(riskReasons),
 		},
 		Metadata: findingRiskMetadata(finding),
 	}

--- a/internal/findings/risk_analysis.go
+++ b/internal/findings/risk_analysis.go
@@ -13,7 +13,13 @@ import (
 
 const defaultFindingCorrelationWindow = 24 * time.Hour
 
-const defaultFindingRiskModelVersion = "likelihood-impact-v1"
+const FindingRiskModelVersion = "likelihood-impact-v2"
+
+const defaultFindingRiskModelVersion = FindingRiskModelVersion
+
+const FindingEffectiveSeverityAttribute = "effective_severity"
+
+const FindingSourceSeverityAttribute = "source_severity"
 
 const FindingRiskGraphProjectedModelVersionAttribute = "risk_graph_projected_model_version"
 
@@ -34,14 +40,15 @@ type FindingExposureAnalysisReport struct {
 
 // FindingRiskContext captures contextual scoring signals for one finding or correlated group.
 type FindingRiskContext struct {
-	Score            int      `json:"score"`
-	LikelihoodScore  int      `json:"likelihood_score"`
-	ImpactScore      int      `json:"impact_score"`
-	ConfidenceScore  int      `json:"confidence_score"`
-	LikelihoodLevel  string   `json:"likelihood_level,omitempty"`
-	ImpactLevel      string   `json:"impact_level,omitempty"`
-	RiskModelVersion string   `json:"risk_model_version,omitempty"`
-	Reasons          []string `json:"reasons,omitempty"`
+	Score             int      `json:"score"`
+	EffectiveSeverity string   `json:"effective_severity,omitempty"`
+	LikelihoodScore   int      `json:"likelihood_score"`
+	ImpactScore       int      `json:"impact_score"`
+	ConfidenceScore   int      `json:"confidence_score"`
+	LikelihoodLevel   string   `json:"likelihood_level,omitempty"`
+	ImpactLevel       string   `json:"impact_level,omitempty"`
+	RiskModelVersion  string   `json:"risk_model_version,omitempty"`
+	Reasons           []string `json:"reasons,omitempty"`
 }
 
 // FindingEvidenceBundle is a compact, source-agnostic evidence summary for a finding group or path.
@@ -301,7 +308,7 @@ func AnalyzeFindingRiskContext(finding *ports.FindingRecord, now time.Time) Find
 	impact := 10
 	confidence := 85
 	reasons := []string{}
-	severity := strings.ToUpper(strings.TrimSpace(finding.Severity))
+	severity := strings.ToUpper(strings.TrimSpace(firstNonEmpty(attributes[FindingSourceSeverityAttribute], attributes["rule_severity"], finding.Severity)))
 	if severityScore := compoundRiskSeverityScore(severity); severityScore > 0 {
 		likelihood += severityScore * 6
 		impact += severityScore * 8
@@ -449,14 +456,15 @@ func AnalyzeFindingRiskContext(finding *ports.FindingRecord, now time.Time) Find
 	confidence = clampScore(confidence)
 	riskScore := productRiskScore(likelihood, impact)
 	return FindingRiskContext{
-		Score:            riskScore,
-		LikelihoodScore:  likelihood,
-		ImpactScore:      impact,
-		ConfidenceScore:  confidence,
-		LikelihoodLevel:  riskLevelFromScore(likelihood),
-		ImpactLevel:      riskLevelFromScore(impact),
-		RiskModelVersion: defaultFindingRiskModelVersion,
-		Reasons:          uniqueSortedStrings(reasons),
+		Score:             riskScore,
+		EffectiveSeverity: EffectiveSeverityFromRiskScore(riskScore),
+		LikelihoodScore:   likelihood,
+		ImpactScore:       impact,
+		ConfidenceScore:   confidence,
+		LikelihoodLevel:   riskLevelFromScore(likelihood),
+		ImpactLevel:       riskLevelFromScore(impact),
+		RiskModelVersion:  defaultFindingRiskModelVersion,
+		Reasons:           uniqueSortedStrings(reasons),
 	}
 }
 
@@ -527,6 +535,21 @@ func riskLevelFromScore(score int) string {
 		return "medium"
 	case score > 0:
 		return "low"
+	default:
+		return ""
+	}
+}
+
+func EffectiveSeverityFromRiskScore(score int) string {
+	switch riskLevelFromScore(score) {
+	case "critical":
+		return "CRITICAL"
+	case "high":
+		return "HIGH"
+	case "medium":
+		return "MEDIUM"
+	case "low":
+		return "LOW"
 	default:
 		return ""
 	}

--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -139,6 +139,9 @@ func TestAnalyzeFindingRiskContextUsesGenericSignals(t *testing.T) {
 	if context.Score < 80 {
 		t.Fatalf("Risk score = %d, want generic contextual score >= 80", context.Score)
 	}
+	if context.EffectiveSeverity != "CRITICAL" {
+		t.Fatalf("EffectiveSeverity = %q, want CRITICAL", context.EffectiveSeverity)
+	}
 	if context.LikelihoodScore < 80 {
 		t.Fatalf("LikelihoodScore = %d, want >= 80", context.LikelihoodScore)
 	}
@@ -150,6 +153,35 @@ func TestAnalyzeFindingRiskContextUsesGenericSignals(t *testing.T) {
 	}
 	if context.LikelihoodLevel == "" || context.ImpactLevel == "" || context.RiskModelVersion == "" {
 		t.Fatalf("Risk metadata = %#v, want levels and model version", context)
+	}
+}
+
+func TestEffectiveSeverityFromRiskScore(t *testing.T) {
+	for _, tt := range []struct {
+		score int
+		want  string
+	}{
+		{score: 95, want: "CRITICAL"},
+		{score: 75, want: "HIGH"},
+		{score: 50, want: "MEDIUM"},
+		{score: 20, want: "LOW"},
+		{score: 0, want: ""},
+	} {
+		if got := EffectiveSeverityFromRiskScore(tt.score); got != tt.want {
+			t.Fatalf("EffectiveSeverityFromRiskScore(%d) = %q, want %q", tt.score, got, tt.want)
+		}
+	}
+}
+
+func TestAnalyzeFindingRiskContextUsesSourceSeverityForScoring(t *testing.T) {
+	finding := compoundRiskFinding("finding-calibrated", "rule-1", "HIGH", "", "", "urn:cerebro:writer:asset:1", "")
+	finding.Attributes[FindingSourceSeverityAttribute] = "LOW"
+	context := AnalyzeFindingRiskContext(finding, time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC))
+	if stringSliceContains(context.Reasons, "severity:HIGH") {
+		t.Fatalf("Risk reasons = %#v, want source severity to avoid calibrated severity feedback", context.Reasons)
+	}
+	if !stringSliceContains(context.Reasons, "severity:LOW") {
+		t.Fatalf("Risk reasons = %#v, want source severity LOW", context.Reasons)
 	}
 }
 

--- a/internal/findings/risk_enrichment.go
+++ b/internal/findings/risk_enrichment.go
@@ -13,6 +13,11 @@ func enrichFindingRisk(record *ports.FindingRecord, _ *cerebrov1.SourceRuntime, 
 	if record == nil {
 		return nil
 	}
+	if record.Attributes == nil {
+		record.Attributes = map[string]string{}
+	}
+	sourceSeverity := strings.ToUpper(strings.TrimSpace(firstNonEmpty(record.Attributes[FindingSourceSeverityAttribute], record.Attributes["rule_severity"], record.Severity)))
+	setRiskStringAttribute(record.Attributes, FindingSourceSeverityAttribute, sourceSeverity)
 	evaluation := AnalyzeFindingRiskContext(record, now)
 	if record.LikelihoodScore <= 0 {
 		record.LikelihoodScore = evaluation.LikelihoodScore
@@ -35,10 +40,9 @@ func enrichFindingRisk(record *ports.FindingRecord, _ *cerebrov1.SourceRuntime, 
 	if strings.TrimSpace(record.RiskModelVersion) == "" {
 		record.RiskModelVersion = defaultFindingRiskModelVersion
 	}
+	effectiveSeverity := EffectiveSeverityFromRiskScore(record.RiskScore)
 	record.RiskReasons = uniqueSortedStrings(append(record.RiskReasons, evaluation.Reasons...))
-	if record.Attributes == nil {
-		record.Attributes = map[string]string{}
-	}
+	setRiskStringAttribute(record.Attributes, FindingEffectiveSeverityAttribute, effectiveSeverity)
 	setRiskAttribute(record.Attributes, "risk_score", record.RiskScore)
 	setRiskAttribute(record.Attributes, "likelihood_score", record.LikelihoodScore)
 	setRiskAttribute(record.Attributes, "impact_score", record.ImpactScore)
@@ -73,6 +77,7 @@ func recomputeFindingRisk(record *ports.FindingRecord, now time.Time) *ports.Fin
 		delete(record.Attributes, "impact_level")
 		delete(record.Attributes, "risk_reasons")
 		delete(record.Attributes, "risk_model_version")
+		delete(record.Attributes, FindingEffectiveSeverityAttribute)
 	}
 	return enrichFindingRisk(record, nil, now)
 }
@@ -83,6 +88,8 @@ func findingRiskAttributes(record *ports.FindingRecord) map[string]string {
 	}
 	attributes := map[string]string{}
 	attributes["risk_score"] = strconv.Itoa(clampScore(record.RiskScore))
+	attributes[FindingEffectiveSeverityAttribute] = EffectiveSeverityFromRiskScore(record.RiskScore)
+	attributes[FindingSourceSeverityAttribute] = strings.ToUpper(strings.TrimSpace(firstNonEmpty(record.Attributes[FindingSourceSeverityAttribute], record.Attributes["rule_severity"], record.Severity)))
 	attributes["likelihood_score"] = strconv.Itoa(clampScore(record.LikelihoodScore))
 	attributes["impact_score"] = strconv.Itoa(clampScore(record.ImpactScore))
 	attributes["confidence_score"] = strconv.Itoa(clampScore(record.ConfidenceScore))

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2914,6 +2914,9 @@ func TestPersistFindingRiskUsesRiskOnlyUpdate(t *testing.T) {
 	if stored.RiskScore == 0 {
 		t.Fatal("persistFindingRisk().RiskScore = 0, want refreshed risk")
 	}
+	if got, want := stored.Attributes[FindingEffectiveSeverityAttribute], EffectiveSeverityFromRiskScore(stored.RiskScore); got != want {
+		t.Fatalf("persistFindingRisk().Attributes[%s] = %q, want %q", FindingEffectiveSeverityAttribute, got, want)
+	}
 }
 
 func TestBackfillFindingRiskProjectsUpdatedFindings(t *testing.T) {
@@ -2962,6 +2965,9 @@ func TestBackfillFindingRiskProjectsUpdatedFindings(t *testing.T) {
 	}
 	if got := graphFinding.Attributes["risk_score"]; got != "83" {
 		t.Fatalf("projected risk_score = %q, want 83", got)
+	}
+	if got := graphFinding.Attributes[FindingEffectiveSeverityAttribute]; got != "HIGH" {
+		t.Fatalf("projected effective_severity = %q, want HIGH", got)
 	}
 	if closed := graphStore.entities["urn:cerebro:tenant-a:finding:finding-closed"]; closed == nil || closed.Attributes["risk_score"] != "83" {
 		t.Fatalf("closed projected finding = %#v, want risk_score 83", closed)

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -188,7 +188,7 @@ func TestRunFindingSummaryReportPersistsCompletedRun(t *testing.T) {
 					LikelihoodScore:  85,
 					ImpactScore:      75,
 					RiskReasons:      []string{"active", "external_exposure"},
-					RiskModelVersion: "likelihood-impact-v1",
+					RiskModelVersion: "likelihood-impact-v2",
 				},
 				Attributes: map[string]string{
 					"primary_resource_urn": "urn:cerebro:writer:okta_resource:policyrule:pol-1",

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -394,11 +394,12 @@ func (s *Store) SummarizeFindings(ctx context.Context, request ports.ListFinding
 		return ports.FindingSummary{}, err
 	}
 	where := strings.Join(clauses, " AND ")
+	effectiveSeverity := findingEffectiveSeveritySQL()
 	query := `
 SELECT
   COUNT(*) FILTER (WHERE LOWER(status) = 'open'),
-  COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND UPPER(severity) = 'CRITICAL'),
-  COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND UPPER(severity) = 'HIGH'),
+  COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND ` + effectiveSeverity + ` = 'CRITICAL'),
+  COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND ` + effectiveSeverity + ` = 'HIGH'),
   COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND due_at IS NOT NULL AND due_at < NOW()),
   COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND TRIM(assignee) = '')
 FROM findings
@@ -720,7 +721,7 @@ func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, e
 	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
 	addFindingFilter(&clauses, &args, "id", request.FindingID)
 	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
-	addFindingFilter(&clauses, &args, "severity", request.Severity)
+	addFindingSeverityFilter(&clauses, &args, request.Severity)
 	addFindingFilter(&clauses, &args, "status", request.Status)
 	addFindingFilter(&clauses, &args, "policy_id", request.PolicyID)
 	if err := addFindingArrayContainsFilter(&clauses, &args, "resource_urns_json", request.ResourceURN); err != nil {
@@ -763,7 +764,7 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 	if includeUnprojected {
 		query += ` OR COALESCE(attributes_json->>'` + findingrisk.FindingRiskGraphProjectedModelVersionAttribute + `', '') <> $1`
 	}
-	rows, err := s.db.QueryContext(ctx, query, "likelihood-impact-v1")
+	rows, err := s.db.QueryContext(ctx, query, findingrisk.FindingRiskModelVersion)
 	if err != nil {
 		return nil, fmt.Errorf("list findings for risk backfill: %w", err)
 	}
@@ -773,8 +774,9 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 		}
 	}()
 	type riskBackfill struct {
-		id   string
-		risk ports.FindingRisk
+		id             string
+		risk           ports.FindingRisk
+		sourceSeverity string
 	}
 	now := time.Now().UTC()
 	updates := []riskBackfill{}
@@ -787,9 +789,17 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 		if err != nil {
 			return nil, fmt.Errorf("decode finding risk backfill row: %w", err)
 		}
+		sourceSeverity := strings.TrimSpace(record.Attributes[findingrisk.FindingSourceSeverityAttribute])
+		if sourceSeverity == "" {
+			sourceSeverity = strings.TrimSpace(row.Severity)
+		}
+		if sourceSeverity != "" {
+			record.Attributes[findingrisk.FindingSourceSeverityAttribute] = sourceSeverity
+		}
 		updates = append(updates, riskBackfill{
-			id:   strings.TrimSpace(record.ID),
-			risk: findingBackfillRisk(record, now),
+			id:             strings.TrimSpace(record.ID),
+			risk:           findingBackfillRisk(record, now),
+			sourceSeverity: sourceSeverity,
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -799,7 +809,7 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 		if update.id == "" {
 			continue
 		}
-		stored, err := s.updateFindingRiskColumns(ctx, update.id, update.risk, findingRiskAttributesForUpdate(update.risk))
+		stored, err := s.updateFindingRiskColumns(ctx, update.id, update.risk, findingRiskAttributesForUpdate(update.risk, update.sourceSeverity))
 		if err != nil {
 			return nil, fmt.Errorf("backfill finding %q risk: %w", update.id, err)
 		}
@@ -862,9 +872,11 @@ func findingBackfillRisk(record *ports.FindingRecord, now time.Time) ports.Findi
 	}
 }
 
-func findingRiskAttributesForUpdate(risk ports.FindingRisk) map[string]string {
+func findingRiskAttributesForUpdate(risk ports.FindingRisk, sourceSeverity string) map[string]string {
 	attributes := map[string]string{}
 	attributes["risk_score"] = strconv.Itoa(risk.RiskScore)
+	attributes[findingrisk.FindingEffectiveSeverityAttribute] = findingrisk.EffectiveSeverityFromRiskScore(risk.RiskScore)
+	attributes[findingrisk.FindingSourceSeverityAttribute] = strings.ToUpper(strings.TrimSpace(sourceSeverity))
 	attributes["likelihood_score"] = strconv.Itoa(risk.LikelihoodScore)
 	attributes["impact_score"] = strconv.Itoa(risk.ImpactScore)
 	attributes["confidence_score"] = strconv.Itoa(risk.ConfidenceScore)
@@ -878,26 +890,27 @@ func findingRiskAttributesForUpdate(risk ports.FindingRisk) map[string]string {
 func findingOrderClause(request ports.ListFindingsRequest) string {
 	switch {
 	case request.Order == ports.FindingOrderRiskScore:
-		return `risk_score DESC, CASE UPPER(severity)
-  WHEN 'CRITICAL' THEN 0
-  WHEN 'HIGH' THEN 1
-  WHEN 'MEDIUM' THEN 2
-  WHEN 'LOW' THEN 3
-  WHEN 'INFO' THEN 4
-  ELSE 5
-END, last_observed_at DESC, id`
+		return `risk_score DESC, ` + findingSeverityRankSQL(findingEffectiveSeveritySQL()) + `, last_observed_at DESC, id`
 	case request.Order == ports.FindingOrderPriority || request.PriorityOrder:
-		return `CASE UPPER(severity)
-  WHEN 'CRITICAL' THEN 0
-  WHEN 'HIGH' THEN 1
-  WHEN 'MEDIUM' THEN 2
-  WHEN 'LOW' THEN 3
-  WHEN 'INFO' THEN 4
-  ELSE 5
-END, last_observed_at DESC, id`
+		return findingSeverityRankSQL(findingEffectiveSeveritySQL()) + `, last_observed_at DESC, id`
 	default:
 		return "last_observed_at DESC, id"
 	}
+}
+
+func findingEffectiveSeveritySQL() string {
+	return `UPPER(COALESCE(NULLIF(attributes_json->>'` + findingrisk.FindingEffectiveSeverityAttribute + `', ''), severity))`
+}
+
+func findingSeverityRankSQL(expression string) string {
+	return `CASE ` + expression + `
+  WHEN 'CRITICAL' THEN 0
+  WHEN 'HIGH' THEN 1
+  WHEN 'MEDIUM' THEN 2
+  WHEN 'LOW' THEN 3
+  WHEN 'INFO' THEN 4
+  ELSE 5
+END`
 }
 
 func findingStringsJSON(values []string) (string, error) {
@@ -1039,6 +1052,15 @@ func addFindingFilter(clauses *[]string, args *[]any, column string, value strin
 	*clauses = append(*clauses, fmt.Sprintf("%s = $%d", column, len(*args)))
 }
 
+func addFindingSeverityFilter(clauses *[]string, args *[]any, value string) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return
+	}
+	*args = append(*args, strings.ToUpper(trimmed))
+	*clauses = append(*clauses, fmt.Sprintf("%s = $%d", findingEffectiveSeveritySQL(), len(*args)))
+}
+
 func addFindingArrayContainsFilter(clauses *[]string, args *[]any, column string, value string) error {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -1176,6 +1198,10 @@ func (r findingRow) record() (*ports.FindingRecord, error) {
 	if err := json.Unmarshal([]byte(r.AttributesJSON), &attributes); err != nil {
 		return nil, fmt.Errorf("decode finding attributes: %w", err)
 	}
+	severity := strings.TrimSpace(r.Severity)
+	if effectiveSeverity := strings.TrimSpace(attributes[findingrisk.FindingEffectiveSeverityAttribute]); effectiveSeverity != "" {
+		severity = effectiveSeverity
+	}
 	return &ports.FindingRecord{
 		ID:          r.ID,
 		Fingerprint: r.Fingerprint,
@@ -1183,7 +1209,7 @@ func (r findingRow) record() (*ports.FindingRecord, error) {
 		RuntimeID:   r.RuntimeID,
 		RuleID:      r.RuleID,
 		Title:       r.Title,
-		Severity:    r.Severity,
+		Severity:    severity,
 		Status:      r.Status,
 		Summary:     r.Summary,
 		FindingRisk: ports.FindingRisk{

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -174,8 +174,18 @@ func TestFindingBackfillRiskUsesRuntimeScorerSignals(t *testing.T) {
 	if !slices.Contains(risk.RiskReasons, "private_network_context") {
 		t.Fatalf("findingBackfillRisk().RiskReasons = %#v, want private_network_context from runtime scorer", risk.RiskReasons)
 	}
-	if risk.RiskModelVersion != "likelihood-impact-v1" {
-		t.Fatalf("findingBackfillRisk().RiskModelVersion = %q, want likelihood-impact-v1", risk.RiskModelVersion)
+	if risk.RiskModelVersion != "likelihood-impact-v2" {
+		t.Fatalf("findingBackfillRisk().RiskModelVersion = %q, want likelihood-impact-v2", risk.RiskModelVersion)
+	}
+}
+
+func TestFindingRiskAttributesForUpdateIncludesEffectiveSeverity(t *testing.T) {
+	attributes := findingRiskAttributesForUpdate(ports.FindingRisk{RiskScore: 72}, "low")
+	if got := attributes["effective_severity"]; got != "HIGH" {
+		t.Fatalf("effective_severity = %q, want HIGH", got)
+	}
+	if got := attributes["source_severity"]; got != "LOW" {
+		t.Fatalf("source_severity = %q, want LOW", got)
 	}
 }
 
@@ -229,7 +239,8 @@ func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
 		"runtime_id = $2",
 		"id = $3",
 		"rule_id = $4",
-		"severity = $5",
+		"attributes_json->>'effective_severity'",
+		"= $5",
 		"status = $6",
 		"policy_id = $7",
 		"resource_urns_json @> $8::jsonb",
@@ -278,7 +289,7 @@ func TestFindingListQuerySupportsRuntimeBatchesAndPriorityOrder(t *testing.T) {
 		"tenant_id = $1",
 		"runtime_id IN ($2, $3)",
 		"status = $4",
-		"CASE UPPER(severity)",
+		"CASE UPPER(COALESCE(NULLIF(attributes_json->>'effective_severity'",
 		"last_observed_at DESC, id",
 		"LIMIT $5",
 	} {
@@ -313,7 +324,7 @@ func TestFindingListQueryRiskOrderKeepsSeverityTieBreak(t *testing.T) {
 		t.Fatalf("findingListQuery() error = %v", err)
 	}
 	riskIndex := strings.Index(query, "risk_score DESC")
-	severityIndex := strings.Index(query, "CASE UPPER(severity)")
+	severityIndex := strings.Index(query, "CASE UPPER(COALESCE(NULLIF(attributes_json->>'effective_severity'")
 	observedIndex := strings.Index(query, "last_observed_at DESC")
 	if riskIndex == -1 || severityIndex == -1 || observedIndex == -1 {
 		t.Fatalf("findingListQuery() query missing risk/severity/observed ordering: %s", query)
@@ -342,7 +353,7 @@ func TestFindingRowRecordDecodesCheckAndControlMetadata(t *testing.T) {
 			LikelihoodLevel:  "high",
 			ImpactLevel:      "critical",
 			RiskReasonsJSON:  `["external_exposure","privileged_actor"]`,
-			RiskModelVersion: "likelihood-impact-v1",
+			RiskModelVersion: "likelihood-impact-v2",
 		},
 		ResourceURNsJSON:      `["urn:cerebro:writer:okta_resource:policyrule:pol-1"]`,
 		EventIDsJSON:          `["okta-audit-2"]`,
@@ -352,7 +363,7 @@ func TestFindingRowRecordDecodesCheckAndControlMetadata(t *testing.T) {
 		PolicyName:            "pol-1",
 		CheckID:               "identity-okta-policy-rule-lifecycle-tampering-30d",
 		CheckName:             "Okta Policy Rule Lifecycle Tampering (30 days)",
-		AttributesJSON:        `{"primary_resource_urn":"urn:cerebro:writer:okta_resource:policyrule:pol-1"}`,
+		AttributesJSON:        `{"effective_severity":"MEDIUM","source_severity":"HIGH","primary_resource_urn":"urn:cerebro:writer:okta_resource:policyrule:pol-1"}`,
 		findingWorkflowRow: findingWorkflowRow{
 			NotesJSON:   `[{"id":"note-1","body":"Escalate to identity engineering.","created_at":"2026-05-01T11:00:00Z"}]`,
 			TicketsJSON: `[{"url":"https://jira.writer.com/browse/ENG-123","name":"ENG-123","external_id":"ENG-123","linked_at":"2026-05-01T11:30:00Z"}]`,
@@ -391,8 +402,11 @@ func TestFindingRowRecordDecodesCheckAndControlMetadata(t *testing.T) {
 	if got := record.ImpactLevel; got != "critical" {
 		t.Fatalf("findingRow.record().ImpactLevel = %q, want critical", got)
 	}
-	if got := record.RiskModelVersion; got != "likelihood-impact-v1" {
-		t.Fatalf("findingRow.record().RiskModelVersion = %q, want likelihood-impact-v1", got)
+	if got := record.Severity; got != "MEDIUM" {
+		t.Fatalf("findingRow.record().Severity = %q, want effective severity MEDIUM", got)
+	}
+	if got := record.RiskModelVersion; got != "likelihood-impact-v2" {
+		t.Fatalf("findingRow.record().RiskModelVersion = %q, want likelihood-impact-v2", got)
 	}
 	if !slices.Contains(record.RiskReasons, "external_exposure") || !slices.Contains(record.RiskReasons, "privileged_actor") {
 		t.Fatalf("findingRow.record().RiskReasons = %#v, want typed risk reasons", record.RiskReasons)

--- a/internal/workflowevents/events.go
+++ b/internal/workflowevents/events.go
@@ -152,14 +152,15 @@ type FindingSnapshot struct {
 
 // FindingRiskSnapshot captures normalized finding risk scoring metadata in workflow events.
 type FindingRiskSnapshot struct {
-	RiskScore        int      `json:"risk_score,omitempty"`
-	LikelihoodScore  int      `json:"likelihood_score,omitempty"`
-	ImpactScore      int      `json:"impact_score,omitempty"`
-	ConfidenceScore  int      `json:"confidence_score,omitempty"`
-	LikelihoodLevel  string   `json:"likelihood_level,omitempty"`
-	ImpactLevel      string   `json:"impact_level,omitempty"`
-	RiskModelVersion string   `json:"risk_model_version,omitempty"`
-	RiskReasons      []string `json:"risk_reasons,omitempty"`
+	RiskScore         int      `json:"risk_score,omitempty"`
+	EffectiveSeverity string   `json:"effective_severity,omitempty"`
+	LikelihoodScore   int      `json:"likelihood_score,omitempty"`
+	ImpactScore       int      `json:"impact_score,omitempty"`
+	ConfidenceScore   int      `json:"confidence_score,omitempty"`
+	LikelihoodLevel   string   `json:"likelihood_level,omitempty"`
+	ImpactLevel       string   `json:"impact_level,omitempty"`
+	RiskModelVersion  string   `json:"risk_model_version,omitempty"`
+	RiskReasons       []string `json:"risk_reasons,omitempty"`
 }
 
 // FindingControlRefSnapshot captures one generic compliance/control reference for graph projection.

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -623,6 +623,9 @@ func findingAnchorAttributes(finding workflowevents.FindingSnapshot) map[string]
 	if finding.RiskScore != 0 {
 		attributes["risk_score"] = fmt.Sprintf("%d", finding.RiskScore)
 	}
+	if strings.TrimSpace(finding.EffectiveSeverity) != "" {
+		attributes["effective_severity"] = strings.TrimSpace(finding.EffectiveSeverity)
+	}
 	if finding.LikelihoodScore != 0 {
 		attributes["likelihood_score"] = fmt.Sprintf("%d", finding.LikelihoodScore)
 	}
@@ -676,6 +679,9 @@ func findingAnchorLinkAttributes(finding workflowevents.FindingSnapshot) map[str
 	}
 	if finding.RiskScore != 0 {
 		attributes["risk_score"] = fmt.Sprintf("%d", finding.RiskScore)
+	}
+	if strings.TrimSpace(finding.EffectiveSeverity) != "" {
+		attributes["effective_severity"] = strings.TrimSpace(finding.EffectiveSeverity)
 	}
 	if finding.LikelihoodScore != 0 {
 		attributes["likelihood_score"] = fmt.Sprintf("%d", finding.LikelihoodScore)

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -207,8 +207,9 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 		ResourceCount:      1,
 		EventCount:         2,
 		FindingRiskSnapshot: workflowevents.FindingRiskSnapshot{
-			RiskScore:   47,
-			RiskReasons: []string{"privileged_actor", "risky_action"},
+			RiskScore:         47,
+			EffectiveSeverity: "MEDIUM",
+			RiskReasons:       []string{"privileged_actor", "risky_action"},
 		},
 		Metadata: map[string]string{
 			"actor_urn":     "urn:cerebro:writer:okta_actor:user:00u1",
@@ -232,6 +233,9 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	}
 	if got := findingEntity.Attributes["risk_score"]; got != "47" {
 		t.Fatalf("finding risk_score attribute = %q, want 47", got)
+	}
+	if got := findingEntity.Attributes["effective_severity"]; got != "MEDIUM" {
+		t.Fatalf("finding effective_severity attribute = %q, want MEDIUM", got)
 	}
 	if got := findingEntity.Attributes["event_count"]; got != "2" {
 		t.Fatalf("finding event_count attribute = %q, want 2", got)


### PR DESCRIPTION
## Summary
- Add risk-score-derived effective_severity and bump the finding risk model to v2 for startup backfill.
- Store and project effective_severity on finding attributes and workflow graph anchors.
- Use effective_severity for severity filters, summary critical/high counts, and priority/risk ordering tie-breaks.

## Validation
- go test ./internal/findings ./internal/statestore/postgres ./internal/workflowprojection ./internal/reports
- make verify