### PR TITLE
feat(vulndb): add shared advisory store and sync

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -63,11 +63,13 @@ func run(args []string) error {
 		return runSource(args[1:])
 	case "source-runtime":
 		return runSourceRuntime(args[1:])
+	case "vulndb":
+		return runVulnDB(args[1:])
 	case "version":
 		fmt.Printf("%s %s\n", buildinfo.ServiceName, buildinfo.Version)
 		return nil
 	}
-	return usageError(fmt.Sprintf("usage: %s [serve|version|graph|orchestrator|finding-rule|source|source-runtime]", os.Args[0]))
+	return usageError(fmt.Sprintf("usage: %s [serve|version|graph|orchestrator|finding-rule|source|source-runtime|vulndb]", os.Args[0]))
 }
 
 func serve() error {

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/writer/cerebro/internal/bootstrap"
 	appconfig "github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/statestore/postgres"
 	"github.com/writer/cerebro/internal/vulndb"
 )
 
@@ -404,21 +405,15 @@ func openStateVulnDBStore(ctx context.Context) (openedVulnDBStore, error) {
 	if err != nil {
 		return openedVulnDBStore{}, err
 	}
-	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+	store, err := postgres.Open(cfg.StateStore)
 	if err != nil {
 		return openedVulnDBStore{}, err
 	}
-	store, ok := deps.StateStore.(vulndb.Store)
-	if !ok || store == nil {
-		_ = closeDeps()
-		return openedVulnDBStore{}, fmt.Errorf("configured state store does not implement vulndb.Store")
+	if err := store.Ping(ctx); err != nil {
+		_ = store.Close()
+		return openedVulnDBStore{}, err
 	}
-	jobs, ok := deps.StateStore.(vulndb.SyncJobStore)
-	if !ok || jobs == nil {
-		_ = closeDeps()
-		return openedVulnDBStore{}, fmt.Errorf("configured state store does not implement vulndb.SyncJobStore")
-	}
-	return openedVulnDBStore{Store: store, Jobs: jobs, close: closeDeps}, nil
+	return openedVulnDBStore{Store: store, Jobs: store, close: store.Close}, nil
 }
 
 func putVulnDBSyncJob(ctx context.Context, jobs vulndb.SyncJobStore, options vulnDBOptions) (vulndb.SyncJob, error) {

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -458,8 +458,19 @@ func putVulnDBSyncJob(ctx context.Context, jobs vulndb.SyncJobStore, options vul
 	if job.Source == "" {
 		return vulndb.SyncJob{}, usageError("feed_source is required")
 	}
+	if !vulndb.IsSupportedFeedSource(job.Source) {
+		return vulndb.SyncJob{}, usageError(fmt.Sprintf("unsupported feed_source %q", job.Source))
+	}
 	if job.FeedURL == "" {
 		return vulndb.SyncJob{}, usageError("url is required")
+	}
+	if job.Interval <= 0 {
+		return vulndb.SyncJob{}, usageError("interval must be positive")
+	}
+	if isRemoteVulnDBSource(job.FeedURL) {
+		if err := vulndb.ValidateFeedURL(job.FeedURL, job.AllowInsecureHTTP); err != nil {
+			return vulndb.SyncJob{}, usageError(err.Error())
+		}
 	}
 	if err := jobs.PutSyncJob(ctx, job); err != nil {
 		return vulndb.SyncJob{}, err

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -420,10 +421,18 @@ func putVulnDBSyncJob(ctx context.Context, jobs vulndb.SyncJobStore, options vul
 	if jobs == nil {
 		return vulndb.SyncJob{}, fmt.Errorf("vulndb sync job store is unavailable")
 	}
+	feedURL := strings.TrimSpace(options.Source)
+	if feedURL != "" && !strings.HasPrefix(feedURL, "http://") && !strings.HasPrefix(feedURL, "https://") && !filepath.IsAbs(feedURL) {
+		absolute, err := filepath.Abs(feedURL)
+		if err != nil {
+			return vulndb.SyncJob{}, err
+		}
+		feedURL = absolute
+	}
 	job := vulndb.SyncJob{
 		ID:                strings.TrimSpace(options.JobID),
 		Source:            strings.TrimSpace(options.FeedSource),
-		FeedURL:           strings.TrimSpace(options.Source),
+		FeedURL:           feedURL,
 		AllowInsecureHTTP: options.AllowInsecureHTTP,
 		Interval:          options.JobInterval,
 	}

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -355,7 +355,7 @@ func (vulndbInputClient) Open(ctx context.Context, source string, allowInsecureH
 	if source == "" {
 		return nil, usageError("vulndb import source is required")
 	}
-	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+	if isRemoteVulnDBSource(source) {
 		return bootstrap.OpenVulnDBFeed(ctx, source, allowInsecureHTTP)
 	}
 	file, err := os.Open(source)
@@ -363,6 +363,11 @@ func (vulndbInputClient) Open(ctx context.Context, source string, allowInsecureH
 		return nil, err
 	}
 	return file, nil
+}
+
+func isRemoteVulnDBSource(source string) bool {
+	source = strings.ToLower(strings.TrimSpace(source))
+	return strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
 }
 
 type openedVulnDBStore struct {
@@ -436,7 +441,7 @@ func putVulnDBSyncJob(ctx context.Context, jobs vulndb.SyncJobStore, options vul
 		allowInsecureHTTP = existing.AllowInsecureHTTP
 	}
 	feedURL := strings.TrimSpace(options.Source)
-	if feedURL != "" && !strings.HasPrefix(feedURL, "http://") && !strings.HasPrefix(feedURL, "https://") && !filepath.IsAbs(feedURL) {
+	if feedURL != "" && !isRemoteVulnDBSource(feedURL) && !filepath.IsAbs(feedURL) {
 		absolute, err := filepath.Abs(feedURL)
 		if err != nil {
 			return vulndb.SyncJob{}, err

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -40,6 +40,18 @@ func runVulnDB(args []string) error {
 			return err
 		}
 		return printJSON(stats)
+	case "get":
+		vulnerability, err := getVulnDBVulnerability(ctx, opened.Store, options)
+		if err != nil {
+			return err
+		}
+		return printJSON(vulnerability)
+	case "match":
+		matches, err := matchVulnDBPackage(ctx, opened.Store, options)
+		if err != nil {
+			return err
+		}
+		return printJSON(matches)
 	case "import-osv":
 		reader, closeReader, err := openVulnDBInput(ctx, options.Source, options.AllowInsecureHTTP)
 		if err != nil {
@@ -129,6 +141,10 @@ type vulnDBOptions struct {
 	JobInterval       time.Duration
 	JobLeaseTTL       time.Duration
 	Limit             int
+	AdvisoryID        string
+	Ecosystem         string
+	PackageName       string
+	PackageVersion    string
 }
 
 type vulnDBSyncResult struct {
@@ -214,6 +230,14 @@ func parseVulnDBOptions(args []string) (vulnDBOptions, error) {
 				return vulnDBOptions{}, usageError("limit must be non-negative")
 			}
 			options.Limit = int(parsed)
+		case "id", "advisory_id", "vulnerability_id":
+			options.AdvisoryID = value
+		case "ecosystem":
+			options.Ecosystem = value
+		case "package", "package_name", "name":
+			options.PackageName = value
+		case "version", "package_version":
+			options.PackageVersion = value
 		case "allow_insecure_http":
 			parsed, err := strconv.ParseBool(value)
 			if err != nil {
@@ -225,6 +249,46 @@ func parseVulnDBOptions(args []string) (vulnDBOptions, error) {
 		}
 	}
 	return options, nil
+}
+
+func getVulnDBVulnerability(ctx context.Context, store vulndb.Store, options vulnDBOptions) (vulndb.Vulnerability, error) {
+	id := strings.TrimSpace(options.AdvisoryID)
+	if id == "" {
+		id = strings.TrimSpace(options.Source)
+	}
+	if id == "" {
+		return vulndb.Vulnerability{}, usageError("id is required")
+	}
+	vulnerability, ok, err := store.FindVulnerability(ctx, id)
+	if err != nil {
+		return vulndb.Vulnerability{}, err
+	}
+	if !ok {
+		return vulndb.Vulnerability{}, fmt.Errorf("vulnerability %q not found", id)
+	}
+	return vulnerability, nil
+}
+
+func matchVulnDBPackage(ctx context.Context, store vulndb.Store, options vulnDBOptions) ([]vulndb.Match, error) {
+	query := vulndb.PackageQuery{
+		Ecosystem: strings.TrimSpace(options.Ecosystem),
+		Name:      strings.TrimSpace(options.PackageName),
+		Version:   strings.TrimSpace(options.PackageVersion),
+	}
+	if query.Ecosystem == "" {
+		return nil, usageError("ecosystem is required")
+	}
+	if query.Name == "" {
+		return nil, usageError("package is required")
+	}
+	if query.Version == "" {
+		return nil, usageError("version is required")
+	}
+	matcher, err := vulndb.NewMatcher(store)
+	if err != nil {
+		return nil, err
+	}
+	return matcher.MatchPackage(ctx, query)
 }
 
 func runVulnDBSync(ctx context.Context, store vulndb.Store, options vulnDBOptions) (vulnDBSyncResult, error) {
@@ -426,5 +490,5 @@ func newVulnDBSyncRunner(store vulndb.Store, jobs vulndb.SyncJobStore, options v
 }
 
 func vulnDBUsage() string {
-	return fmt.Sprintf("usage: %s vulndb [stats|import-osv|import-kev|import-epss|import-nvd|sync|job-put|job-run|job-run-due] [store=auto|file|state] [state_file=<path>] [path=<path>|url=<url>] [allow_insecure_http=true]", os.Args[0])
+	return fmt.Sprintf("usage: %s vulndb [stats|get|match|import-osv|import-kev|import-epss|import-nvd|sync|job-put|job-run|job-run-due] [store=auto|file|state] [state_file=<path>] [path=<path>|url=<url>] [allow_insecure_http=true]", os.Args[0])
 }

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/bootstrap"
+	appconfig "github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/vulndb"
+)
+
+const defaultVulnDBStateFile = ".cerebro-vulndb.json"
+
+func runVulnDB(args []string) error {
+	if len(args) == 0 {
+		return usageError(vulnDBUsage())
+	}
+	command := strings.TrimSpace(args[0])
+	options, err := parseVulnDBOptions(args[1:])
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	opened, err := openVulnDBStore(ctx, options)
+	if err != nil {
+		return fmt.Errorf("open vulndb store: %w", err)
+	}
+	defer func() {
+		_ = opened.Close()
+	}()
+	switch command {
+	case "stats":
+		stats, err := opened.Store.Stats(ctx)
+		if err != nil {
+			return err
+		}
+		return printJSON(stats)
+	case "import-osv":
+		reader, closeReader, err := openVulnDBInput(ctx, options.Source, options.AllowInsecureHTTP)
+		if err != nil {
+			return err
+		}
+		defer closeReader()
+		result, err := vulndb.ImportOSV(ctx, opened.Store, reader)
+		if err != nil {
+			return err
+		}
+		return printJSON(result)
+	case "import-kev":
+		reader, closeReader, err := openVulnDBInput(ctx, options.Source, options.AllowInsecureHTTP)
+		if err != nil {
+			return err
+		}
+		defer closeReader()
+		result, err := vulndb.ImportCISAKEV(ctx, opened.Store, reader)
+		if err != nil {
+			return err
+		}
+		return printJSON(result)
+	case "import-epss":
+		reader, closeReader, err := openVulnDBInput(ctx, options.Source, options.AllowInsecureHTTP)
+		if err != nil {
+			return err
+		}
+		defer closeReader()
+		result, err := vulndb.ImportEPSS(ctx, opened.Store, reader)
+		if err != nil {
+			return err
+		}
+		return printJSON(result)
+	case "import-nvd":
+		reader, closeReader, err := openVulnDBInput(ctx, options.Source, options.AllowInsecureHTTP)
+		if err != nil {
+			return err
+		}
+		defer closeReader()
+		result, err := vulndb.ImportNVD(ctx, opened.Store, reader)
+		if err != nil {
+			return err
+		}
+		return printJSON(result)
+	case "sync":
+		result, err := runVulnDBSync(ctx, opened.Store, options)
+		if err != nil {
+			return err
+		}
+		return printJSON(result)
+	case "job-put":
+		job, err := putVulnDBSyncJob(ctx, opened.Jobs, options)
+		if err != nil {
+			return err
+		}
+		return printJSON(job)
+	case "job-run":
+		result, err := runVulnDBSyncJob(ctx, opened.Store, opened.Jobs, options)
+		if err != nil {
+			return err
+		}
+		return printJSON(result)
+	case "job-run-due":
+		result, err := runDueVulnDBSyncJobs(ctx, opened.Store, opened.Jobs, options)
+		if err != nil {
+			return err
+		}
+		return printJSON(result)
+	default:
+		return usageError(vulnDBUsage())
+	}
+}
+
+type vulnDBOptions struct {
+	StateFile         string
+	StateFileExplicit bool
+	StoreMode         string
+	Source            string
+	FeedSource        string
+	OSVSource         string
+	KEVSource         string
+	EPSSSource        string
+	NVDSource         string
+	AllowInsecureHTTP bool
+	JobID             string
+	JobOwner          string
+	JobInterval       time.Duration
+	JobLeaseTTL       time.Duration
+	Limit             int
+}
+
+type vulnDBSyncResult struct {
+	OSV  *vulndb.ImportResult `json:"osv,omitempty"`
+	KEV  *vulndb.ImportResult `json:"kev,omitempty"`
+	EPSS *vulndb.ImportResult `json:"epss,omitempty"`
+	NVD  *vulndb.ImportResult `json:"nvd,omitempty"`
+}
+
+func parseVulnDBOptions(args []string) (vulnDBOptions, error) {
+	options := vulnDBOptions{StateFile: strings.TrimSpace(os.Getenv("VULNDB_STATE_FILE"))}
+	options.StateFileExplicit = options.StateFile != ""
+	if options.StateFile == "" {
+		options.StateFile = defaultVulnDBStateFile
+	}
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			if options.Source != "" {
+				return vulnDBOptions{}, usageError(vulnDBUsage())
+			}
+			options.Source = strings.TrimSpace(arg)
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		switch key {
+		case "state_file":
+			if value == "" {
+				return vulnDBOptions{}, usageError("state_file is required")
+			}
+			options.StateFile = value
+			options.StateFileExplicit = true
+		case "store":
+			switch value {
+			case "", "auto":
+				options.StoreMode = ""
+			case "file", "state", "postgres":
+				options.StoreMode = value
+			default:
+				return vulnDBOptions{}, usageError("store must be auto, file, state, or postgres")
+			}
+		case "file", "path", "url", "source":
+			options.Source = value
+		case "feed_source":
+			options.FeedSource = value
+		case "osv":
+			options.OSVSource = value
+		case "kev", "cisa_kev":
+			options.KEVSource = value
+		case "epss":
+			options.EPSSSource = value
+		case "nvd":
+			options.NVDSource = value
+		case "job_id":
+			options.JobID = value
+		case "owner":
+			options.JobOwner = value
+		case "interval":
+			parsed, err := time.ParseDuration(value)
+			if err != nil {
+				return vulnDBOptions{}, fmt.Errorf("parse interval: %w", err)
+			}
+			if parsed < 0 {
+				return vulnDBOptions{}, usageError("interval must be non-negative")
+			}
+			options.JobInterval = parsed
+		case "lease_ttl":
+			parsed, err := time.ParseDuration(value)
+			if err != nil {
+				return vulnDBOptions{}, fmt.Errorf("parse lease_ttl: %w", err)
+			}
+			if parsed <= 0 {
+				return vulnDBOptions{}, usageError("lease_ttl must be positive")
+			}
+			options.JobLeaseTTL = parsed
+		case "limit":
+			parsed, err := strconv.ParseInt(value, 10, 32)
+			if err != nil {
+				return vulnDBOptions{}, fmt.Errorf("parse limit: %w", err)
+			}
+			if parsed < 0 {
+				return vulnDBOptions{}, usageError("limit must be non-negative")
+			}
+			options.Limit = int(parsed)
+		case "allow_insecure_http":
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return vulnDBOptions{}, fmt.Errorf("parse allow_insecure_http: %w", err)
+			}
+			options.AllowInsecureHTTP = parsed
+		default:
+			return vulnDBOptions{}, usageError(fmt.Sprintf("unsupported vulndb argument %q", key))
+		}
+	}
+	return options, nil
+}
+
+func runVulnDBSync(ctx context.Context, store vulndb.Store, options vulnDBOptions) (vulnDBSyncResult, error) {
+	var result vulnDBSyncResult
+	if options.OSVSource == "" && options.KEVSource == "" && options.EPSSSource == "" && options.NVDSource == "" {
+		return result, usageError("usage: cerebro vulndb sync [osv=<path-or-url>] [kev=<path-or-url>] [epss=<path-or-url>] [nvd=<path-or-url>] [state_file=<path>]")
+	}
+	if options.OSVSource != "" {
+		imported, err := runVulnDBFeedSync(ctx, store, vulndb.SourceOSV, options.OSVSource, options.AllowInsecureHTTP)
+		if err != nil {
+			return result, err
+		}
+		result.OSV = &imported
+	}
+	if options.KEVSource != "" {
+		imported, err := runVulnDBFeedSync(ctx, store, vulndb.SourceCISAKEV, options.KEVSource, options.AllowInsecureHTTP)
+		if err != nil {
+			return result, err
+		}
+		result.KEV = &imported
+	}
+	if options.EPSSSource != "" {
+		imported, err := runVulnDBFeedSync(ctx, store, vulndb.SourceEPSS, options.EPSSSource, options.AllowInsecureHTTP)
+		if err != nil {
+			return result, err
+		}
+		result.EPSS = &imported
+	}
+	if options.NVDSource != "" {
+		imported, err := runVulnDBFeedSync(ctx, store, vulndb.SourceNVD, options.NVDSource, options.AllowInsecureHTTP)
+		if err != nil {
+			return result, err
+		}
+		result.NVD = &imported
+	}
+	return result, nil
+}
+
+func runVulnDBFeedSync(ctx context.Context, store vulndb.Store, source string, location string, allowInsecureHTTP bool) (vulndb.ImportResult, error) {
+	reader, closeReader, err := openVulnDBInput(ctx, location, allowInsecureHTTP)
+	if err != nil {
+		return vulndb.ImportResult{}, err
+	}
+	defer closeReader()
+	return vulndb.ImportFeed(ctx, store, source, reader)
+}
+
+func openVulnDBInput(ctx context.Context, source string, allowInsecureHTTP bool) (io.Reader, func(), error) {
+	reader, err := (vulndbInputClient{}).Open(ctx, source, allowInsecureHTTP)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return reader, func() { _ = reader.Close() }, nil
+}
+
+type vulndbInputClient struct{}
+
+func (vulndbInputClient) Open(ctx context.Context, source string, allowInsecureHTTP bool) (io.ReadCloser, error) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return nil, usageError("vulndb import source is required")
+	}
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		return bootstrap.OpenVulnDBFeed(ctx, source, allowInsecureHTTP)
+	}
+	file, err := os.Open(source)
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+type openedVulnDBStore struct {
+	Store vulndb.Store
+	Jobs  vulndb.SyncJobStore
+	close func() error
+}
+
+func (s openedVulnDBStore) Close() error {
+	if s.close == nil {
+		return nil
+	}
+	return s.close()
+}
+
+func openVulnDBStore(ctx context.Context, options vulnDBOptions) (openedVulnDBStore, error) {
+	if shouldUseStateVulnDBStore(options) {
+		return openStateVulnDBStore(ctx)
+	}
+	store, err := vulndb.NewFileStore(ctx, options.StateFile)
+	if err != nil {
+		return openedVulnDBStore{}, err
+	}
+	return openedVulnDBStore{Store: store, Jobs: store}, nil
+}
+
+func shouldUseStateVulnDBStore(options vulnDBOptions) bool {
+	switch options.StoreMode {
+	case "state", "postgres":
+		return true
+	case "file":
+		return false
+	}
+	if options.StateFileExplicit {
+		return false
+	}
+	return strings.TrimSpace(os.Getenv("CEREBRO_STATE_STORE_DRIVER")) != "" ||
+		strings.TrimSpace(os.Getenv("CEREBRO_POSTGRES_DSN")) != ""
+}
+
+func openStateVulnDBStore(ctx context.Context) (openedVulnDBStore, error) {
+	cfg, err := appconfig.Load()
+	if err != nil {
+		return openedVulnDBStore{}, err
+	}
+	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+	if err != nil {
+		return openedVulnDBStore{}, err
+	}
+	store, ok := deps.StateStore.(vulndb.Store)
+	if !ok || store == nil {
+		_ = closeDeps()
+		return openedVulnDBStore{}, fmt.Errorf("configured state store does not implement vulndb.Store")
+	}
+	jobs, ok := deps.StateStore.(vulndb.SyncJobStore)
+	if !ok || jobs == nil {
+		_ = closeDeps()
+		return openedVulnDBStore{}, fmt.Errorf("configured state store does not implement vulndb.SyncJobStore")
+	}
+	return openedVulnDBStore{Store: store, Jobs: jobs, close: closeDeps}, nil
+}
+
+func putVulnDBSyncJob(ctx context.Context, jobs vulndb.SyncJobStore, options vulnDBOptions) (vulndb.SyncJob, error) {
+	if jobs == nil {
+		return vulndb.SyncJob{}, fmt.Errorf("vulndb sync job store is unavailable")
+	}
+	job := vulndb.SyncJob{
+		ID:                strings.TrimSpace(options.JobID),
+		Source:            strings.TrimSpace(options.FeedSource),
+		FeedURL:           strings.TrimSpace(options.Source),
+		AllowInsecureHTTP: options.AllowInsecureHTTP,
+		Interval:          options.JobInterval,
+	}
+	if job.ID == "" {
+		return vulndb.SyncJob{}, usageError("job_id is required")
+	}
+	if job.Source == "" {
+		return vulndb.SyncJob{}, usageError("feed_source is required")
+	}
+	if job.FeedURL == "" {
+		return vulndb.SyncJob{}, usageError("url is required")
+	}
+	if err := jobs.PutSyncJob(ctx, job); err != nil {
+		return vulndb.SyncJob{}, err
+	}
+	stored, ok, err := jobs.GetSyncJob(ctx, job.ID)
+	if err != nil {
+		return vulndb.SyncJob{}, err
+	}
+	if !ok {
+		return vulndb.SyncJob{}, fmt.Errorf("%w: %s", vulndb.ErrSyncJobNotFound, job.ID)
+	}
+	return stored, nil
+}
+
+func runVulnDBSyncJob(ctx context.Context, store vulndb.Store, jobs vulndb.SyncJobStore, options vulnDBOptions) (vulndb.SyncJobRunResult, error) {
+	if strings.TrimSpace(options.JobID) == "" {
+		return vulndb.SyncJobRunResult{}, usageError("job_id is required")
+	}
+	runner, err := newVulnDBSyncRunner(store, jobs, options)
+	if err != nil {
+		return vulndb.SyncJobRunResult{}, err
+	}
+	return runner.RunJob(ctx, options.JobID)
+}
+
+func runDueVulnDBSyncJobs(ctx context.Context, store vulndb.Store, jobs vulndb.SyncJobStore, options vulnDBOptions) (vulndb.SyncDueJobsResult, error) {
+	runner, err := newVulnDBSyncRunner(store, jobs, options)
+	if err != nil {
+		return vulndb.SyncDueJobsResult{}, err
+	}
+	return runner.RunDue(ctx, options.Limit)
+}
+
+func newVulnDBSyncRunner(store vulndb.Store, jobs vulndb.SyncJobStore, options vulnDBOptions) (*vulndb.SyncRunner, error) {
+	runner, err := vulndb.NewSyncRunner(store, jobs, func(ctx context.Context, job vulndb.SyncJob) (io.ReadCloser, error) {
+		return (vulndbInputClient{}).Open(ctx, job.FeedURL, job.AllowInsecureHTTP)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(options.JobOwner) != "" {
+		runner = runner.WithOwner(options.JobOwner)
+	}
+	if options.JobLeaseTTL > 0 {
+		runner = runner.WithLeaseTTL(options.JobLeaseTTL)
+	}
+	return runner, nil
+}
+
+func vulnDBUsage() string {
+	return fmt.Sprintf("usage: %s vulndb [stats|import-osv|import-kev|import-epss|import-nvd|sync|job-put|job-run|job-run-due] [store=auto|file|state] [state_file=<path>] [path=<path>|url=<url>] [allow_insecure_http=true]", os.Args[0])
+}

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -128,25 +128,26 @@ func runVulnDB(args []string) error {
 }
 
 type vulnDBOptions struct {
-	StateFile         string
-	StateFileExplicit bool
-	StoreMode         string
-	Source            string
-	FeedSource        string
-	OSVSource         string
-	KEVSource         string
-	EPSSSource        string
-	NVDSource         string
-	AllowInsecureHTTP bool
-	JobID             string
-	JobOwner          string
-	JobInterval       time.Duration
-	JobLeaseTTL       time.Duration
-	Limit             int
-	AdvisoryID        string
-	Ecosystem         string
-	PackageName       string
-	PackageVersion    string
+	StateFile                 string
+	StateFileExplicit         bool
+	StoreMode                 string
+	Source                    string
+	FeedSource                string
+	OSVSource                 string
+	KEVSource                 string
+	EPSSSource                string
+	NVDSource                 string
+	AllowInsecureHTTP         bool
+	AllowInsecureHTTPExplicit bool
+	JobID                     string
+	JobOwner                  string
+	JobInterval               time.Duration
+	JobLeaseTTL               time.Duration
+	Limit                     int
+	AdvisoryID                string
+	Ecosystem                 string
+	PackageName               string
+	PackageVersion            string
 }
 
 type vulnDBSyncResult struct {
@@ -246,6 +247,7 @@ func parseVulnDBOptions(args []string) (vulnDBOptions, error) {
 				return vulnDBOptions{}, fmt.Errorf("parse allow_insecure_http: %w", err)
 			}
 			options.AllowInsecureHTTP = parsed
+			options.AllowInsecureHTTPExplicit = true
 		default:
 			return vulnDBOptions{}, usageError(fmt.Sprintf("unsupported vulndb argument %q", key))
 		}
@@ -421,6 +423,18 @@ func putVulnDBSyncJob(ctx context.Context, jobs vulndb.SyncJobStore, options vul
 	if jobs == nil {
 		return vulndb.SyncJob{}, fmt.Errorf("vulndb sync job store is unavailable")
 	}
+	jobID := strings.TrimSpace(options.JobID)
+	if jobID == "" {
+		return vulndb.SyncJob{}, usageError("job_id is required")
+	}
+	existing, hasExisting, err := jobs.GetSyncJob(ctx, jobID)
+	if err != nil {
+		return vulndb.SyncJob{}, err
+	}
+	allowInsecureHTTP := options.AllowInsecureHTTP
+	if hasExisting && !options.AllowInsecureHTTPExplicit {
+		allowInsecureHTTP = existing.AllowInsecureHTTP
+	}
 	feedURL := strings.TrimSpace(options.Source)
 	if feedURL != "" && !strings.HasPrefix(feedURL, "http://") && !strings.HasPrefix(feedURL, "https://") && !filepath.IsAbs(feedURL) {
 		absolute, err := filepath.Abs(feedURL)
@@ -430,14 +444,11 @@ func putVulnDBSyncJob(ctx context.Context, jobs vulndb.SyncJobStore, options vul
 		feedURL = absolute
 	}
 	job := vulndb.SyncJob{
-		ID:                strings.TrimSpace(options.JobID),
+		ID:                jobID,
 		Source:            strings.TrimSpace(options.FeedSource),
 		FeedURL:           feedURL,
-		AllowInsecureHTTP: options.AllowInsecureHTTP,
+		AllowInsecureHTTP: allowInsecureHTTP,
 		Interval:          options.JobInterval,
-	}
-	if job.ID == "" {
-		return vulndb.SyncJob{}, usageError("job_id is required")
 	}
 	if job.Source == "" {
 		return vulndb.SyncJob{}, usageError("feed_source is required")

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -208,8 +208,8 @@ func parseVulnDBOptions(args []string) (vulnDBOptions, error) {
 			if err != nil {
 				return vulnDBOptions{}, fmt.Errorf("parse interval: %w", err)
 			}
-			if parsed < 0 {
-				return vulnDBOptions{}, usageError("interval must be non-negative")
+			if parsed <= 0 {
+				return vulnDBOptions{}, usageError("interval must be positive")
 			}
 			options.JobInterval = parsed
 		case "lease_ttl":

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -81,6 +81,22 @@ func TestPutVulnDBSyncJobStoresAbsoluteFilePath(t *testing.T) {
 	}
 }
 
+func TestPutVulnDBSyncJobRejectsInsecureHTTPWithoutOptIn(t *testing.T) {
+	ctx := context.Background()
+	store := vulndb.NewMemoryStore()
+	if _, err := putVulnDBSyncJob(ctx, store, vulnDBOptions{
+		JobID:       "osv-hourly",
+		FeedSource:  vulndb.SourceOSV,
+		Source:      "http://localhost/osv.json",
+		JobInterval: time.Hour,
+	}); err == nil {
+		t.Fatal("put sync job error = nil, want insecure HTTP rejection")
+	}
+	if _, ok, err := store.GetSyncJob(ctx, "osv-hourly"); err != nil || ok {
+		t.Fatalf("stored insecure job ok=%v err=%v, want not persisted", ok, err)
+	}
+}
+
 func TestPutVulnDBSyncJobPreservesAllowInsecureHTTPWhenOmitted(t *testing.T) {
 	ctx := context.Background()
 	store := vulndb.NewMemoryStore()
@@ -109,7 +125,7 @@ func TestPutVulnDBSyncJobPreservesAllowInsecureHTTPWhenOmitted(t *testing.T) {
 	job, err = putVulnDBSyncJob(ctx, store, vulnDBOptions{
 		JobID:                     "osv-hourly",
 		FeedSource:                vulndb.SourceOSV,
-		Source:                    "http://localhost/osv-updated.json",
+		Source:                    "https://localhost/osv-updated.json",
 		AllowInsecureHTTP:         false,
 		AllowInsecureHTTPExplicit: true,
 		JobInterval:               time.Hour,

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseVulnDBOptionsSyncJobFields(t *testing.T) {
+	options, err := parseVulnDBOptions([]string{
+		"store=file",
+		"job_id=osv-hourly",
+		"feed_source=osv",
+		"url=/tmp/osv.json",
+		"interval=1h",
+		"lease_ttl=5m",
+		"limit=2",
+		"allow_insecure_http=true",
+	})
+	if err != nil {
+		t.Fatalf("parseVulnDBOptions() error = %v", err)
+	}
+	if options.StoreMode != "file" || options.JobID != "osv-hourly" || options.FeedSource != "osv" || options.Source != "/tmp/osv.json" {
+		t.Fatalf("unexpected parsed options: %+v", options)
+	}
+	if options.JobInterval != time.Hour || options.JobLeaseTTL != 5*time.Minute || options.Limit != 2 || !options.AllowInsecureHTTP {
+		t.Fatalf("unexpected parsed durations/flags: %+v", options)
+	}
+}
+
+func TestShouldUseStateVulnDBStoreHonorsExplicitStateFile(t *testing.T) {
+	t.Setenv("CEREBRO_POSTGRES_DSN", "postgres://127.0.0.1:5432/cerebro?sslmode=disable")
+	if shouldUseStateVulnDBStore(vulnDBOptions{StateFileExplicit: true, StateFile: "local.json"}) {
+		t.Fatal("expected explicit state_file to keep file store in auto mode")
+	}
+	if !shouldUseStateVulnDBStore(vulnDBOptions{StateFileExplicit: true, StateFile: "local.json", StoreMode: "state"}) {
+		t.Fatal("expected store=state to force configured state store")
+	}
+}

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -34,6 +35,24 @@ func TestParseVulnDBOptionsSyncJobFields(t *testing.T) {
 func TestParseVulnDBOptionsRejectsZeroInterval(t *testing.T) {
 	if _, err := parseVulnDBOptions([]string{"interval=0s"}); err == nil {
 		t.Fatal("parseVulnDBOptions() error = nil, want positive interval requirement")
+	}
+}
+
+func TestPutVulnDBSyncJobStoresAbsoluteFilePath(t *testing.T) {
+	ctx := context.Background()
+	store := vulndb.NewMemoryStore()
+	t.Chdir(t.TempDir())
+	job, err := putVulnDBSyncJob(ctx, store, vulnDBOptions{
+		JobID:       "osv-hourly",
+		FeedSource:  vulndb.SourceOSV,
+		Source:      "feeds/osv.json",
+		JobInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("put sync job: %v", err)
+	}
+	if !filepath.IsAbs(job.FeedURL) || filepath.Base(job.FeedURL) != "osv.json" {
+		t.Fatalf("FeedURL = %q, want absolute file path", job.FeedURL)
 	}
 }
 

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -9,6 +12,28 @@ import (
 
 	"github.com/writer/cerebro/internal/vulndb"
 )
+
+func TestVulnDBInputClientOpenTreatsRemoteSchemeCaseInsensitive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+	source := "HTTP" + strings.TrimPrefix(server.URL, "http")
+	reader, err := (vulndbInputClient{}).Open(context.Background(), source, true)
+	if err != nil {
+		t.Fatalf("open uppercase-scheme feed: %v", err)
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read uppercase-scheme feed: %v", err)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want ok", string(body))
+	}
+}
 
 func TestParseVulnDBOptionsSyncJobFields(t *testing.T) {
 	options, err := parseVulnDBOptions([]string{

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -56,6 +56,47 @@ func TestPutVulnDBSyncJobStoresAbsoluteFilePath(t *testing.T) {
 	}
 }
 
+func TestPutVulnDBSyncJobPreservesAllowInsecureHTTPWhenOmitted(t *testing.T) {
+	ctx := context.Background()
+	store := vulndb.NewMemoryStore()
+	if _, err := putVulnDBSyncJob(ctx, store, vulnDBOptions{
+		JobID:                     "osv-hourly",
+		FeedSource:                vulndb.SourceOSV,
+		Source:                    "http://localhost/osv.json",
+		AllowInsecureHTTP:         true,
+		AllowInsecureHTTPExplicit: true,
+		JobInterval:               time.Hour,
+	}); err != nil {
+		t.Fatalf("put initial sync job: %v", err)
+	}
+	job, err := putVulnDBSyncJob(ctx, store, vulnDBOptions{
+		JobID:       "osv-hourly",
+		FeedSource:  vulndb.SourceOSV,
+		Source:      "http://localhost/osv-updated.json",
+		JobInterval: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("put updated sync job: %v", err)
+	}
+	if !job.AllowInsecureHTTP {
+		t.Fatal("AllowInsecureHTTP = false, want preserved true when option omitted")
+	}
+	job, err = putVulnDBSyncJob(ctx, store, vulnDBOptions{
+		JobID:                     "osv-hourly",
+		FeedSource:                vulndb.SourceOSV,
+		Source:                    "http://localhost/osv-updated.json",
+		AllowInsecureHTTP:         false,
+		AllowInsecureHTTPExplicit: true,
+		JobInterval:               time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("put explicit sync job update: %v", err)
+	}
+	if job.AllowInsecureHTTP {
+		t.Fatal("AllowInsecureHTTP = true, want explicit false to clear")
+	}
+}
+
 func TestParseVulnDBOptionsQueryFields(t *testing.T) {
 	options, err := parseVulnDBOptions([]string{
 		"id=cve-2026-12345",

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/writer/cerebro/internal/vulndb"
 )
 
 func TestParseVulnDBOptionsSyncJobFields(t *testing.T) {
@@ -24,6 +28,52 @@ func TestParseVulnDBOptionsSyncJobFields(t *testing.T) {
 	}
 	if options.JobInterval != time.Hour || options.JobLeaseTTL != 5*time.Minute || options.Limit != 2 || !options.AllowInsecureHTTP {
 		t.Fatalf("unexpected parsed durations/flags: %+v", options)
+	}
+}
+
+func TestParseVulnDBOptionsQueryFields(t *testing.T) {
+	options, err := parseVulnDBOptions([]string{
+		"id=cve-2026-12345",
+		"ecosystem=NPM",
+		"package=lodash",
+		"version=4.17.20",
+	})
+	if err != nil {
+		t.Fatalf("parseVulnDBOptions() error = %v", err)
+	}
+	if options.AdvisoryID != "cve-2026-12345" || options.Ecosystem != "NPM" || options.PackageName != "lodash" || options.PackageVersion != "4.17.20" {
+		t.Fatalf("unexpected query options: %+v", options)
+	}
+}
+
+func TestVulnDBGetAndMatchHelpersQuerySharedStore(t *testing.T) {
+	ctx := context.Background()
+	store := vulndb.NewMemoryStore()
+	osv := `[{
+		"id":"GHSA-AAAA-BBBB-CCCC",
+		"aliases":["CVE-2026-11111"],
+		"summary":"lodash vulnerability",
+		"affected":[{
+			"package":{"ecosystem":"npm","name":"lodash"},
+			"ranges":[{"type":"SEMVER","events":[{"introduced":"0"},{"fixed":"4.17.21"}]}]
+		}]
+	}]`
+	if _, err := vulndb.ImportOSV(ctx, store, strings.NewReader(osv)); err != nil {
+		t.Fatalf("import osv: %v", err)
+	}
+	vulnerability, err := getVulnDBVulnerability(ctx, store, vulnDBOptions{AdvisoryID: "cve-2026-11111"})
+	if err != nil {
+		t.Fatalf("get vulnerability: %v", err)
+	}
+	if vulnerability.ID != "GHSA-AAAA-BBBB-CCCC" || vulnerability.Summary != "lodash vulnerability" {
+		t.Fatalf("unexpected vulnerability: %+v", vulnerability)
+	}
+	matches, err := matchVulnDBPackage(ctx, store, vulnDBOptions{Ecosystem: "npm", PackageName: "lodash", PackageVersion: "4.17.20"})
+	if err != nil {
+		t.Fatalf("match package: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Vulnerability.ID != "GHSA-AAAA-BBBB-CCCC" || matches[0].AffectedPackage.PackageName != "lodash" {
+		t.Fatalf("unexpected matches: %+v", matches)
 	}
 }
 

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -31,6 +31,12 @@ func TestParseVulnDBOptionsSyncJobFields(t *testing.T) {
 	}
 }
 
+func TestParseVulnDBOptionsRejectsZeroInterval(t *testing.T) {
+	if _, err := parseVulnDBOptions([]string{"interval=0s"}); err == nil {
+		t.Fatal("parseVulnDBOptions() error = nil, want positive interval requirement")
+	}
+}
+
 func TestParseVulnDBOptionsQueryFields(t *testing.T) {
 	options, err := parseVulnDBOptions([]string{
 		"id=cve-2026-12345",

--- a/internal/bootstrap/vulndbfeed.go
+++ b/internal/bootstrap/vulndbfeed.go
@@ -22,7 +22,7 @@ func OpenVulnDBFeed(ctx context.Context, rawURL string, allowInsecureHTTP bool) 
 	}
 	initialScheme := strings.ToLower(request.URL.Scheme)
 	client := &http.Client{
-		Timeout: 30 * time.Second,
+		Transport: vulndbFeedTransport(),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if initialScheme == "https" && strings.EqualFold(req.URL.Scheme, "http") {
 				return fmt.Errorf("refusing vulnerability feed redirect from https to http")
@@ -39,4 +39,14 @@ func OpenVulnDBFeed(ctx context.Context, rawURL string, allowInsecureHTTP bool) 
 		return nil, fmt.Errorf("fetch vulnerability feed: %s", response.Status)
 	}
 	return response.Body, nil
+}
+
+func vulndbFeedTransport() http.RoundTripper {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return http.DefaultTransport
+	}
+	clone := transport.Clone()
+	clone.ResponseHeaderTimeout = 30 * time.Second
+	return clone
 }

--- a/internal/bootstrap/vulndbfeed.go
+++ b/internal/bootstrap/vulndbfeed.go
@@ -1,0 +1,37 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/writer/cerebro/internal/vulndb"
+)
+
+// OpenVulnDBFeed fetches a remote vulnerability feed with Cerebro's feed transport policy.
+func OpenVulnDBFeed(ctx context.Context, rawURL string, allowInsecureHTTP bool) (io.ReadCloser, error) {
+	if err := vulndb.ValidateFeedURL(rawURL, allowInsecureHTTP); err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return vulndb.ValidateFeedURL(req.URL.String(), allowInsecureHTTP)
+		},
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_ = response.Body.Close()
+		return nil, fmt.Errorf("fetch vulnerability feed: %s", response.Status)
+	}
+	return response.Body, nil
+}

--- a/internal/bootstrap/vulndbfeed.go
+++ b/internal/bootstrap/vulndbfeed.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/writer/cerebro/internal/vulndb"
@@ -19,9 +20,13 @@ func OpenVulnDBFeed(ctx context.Context, rawURL string, allowInsecureHTTP bool) 
 	if err != nil {
 		return nil, err
 	}
+	initialScheme := strings.ToLower(request.URL.Scheme)
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if initialScheme == "https" && strings.EqualFold(req.URL.Scheme, "http") {
+				return fmt.Errorf("refusing vulnerability feed redirect from https to http")
+			}
 			return vulndb.ValidateFeedURL(req.URL.String(), allowInsecureHTTP)
 		},
 	}

--- a/internal/bootstrap/vulndbfeed_test.go
+++ b/internal/bootstrap/vulndbfeed_test.go
@@ -6,7 +6,22 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
+
+func TestVulnDBFeedTransportUsesHeaderTimeoutWithoutBodyTimeout(t *testing.T) {
+	client := &http.Client{Transport: vulndbFeedTransport()}
+	if client.Timeout != 0 {
+		t.Fatalf("client.Timeout = %v, want no whole-body timeout", client.Timeout)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport.ResponseHeaderTimeout != 30*time.Second {
+		t.Fatalf("ResponseHeaderTimeout = %v, want 30s", transport.ResponseHeaderTimeout)
+	}
+}
 
 func TestOpenVulnDBFeedFetchesSuccessfulHTTPWhenExplicitlyAllowed(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/bootstrap/vulndbfeed_test.go
+++ b/internal/bootstrap/vulndbfeed_test.go
@@ -53,3 +53,34 @@ func TestOpenVulnDBFeedValidatesRedirectTargets(t *testing.T) {
 		t.Fatal("OpenVulnDBFeed() error = nil, want redirect policy error")
 	}
 }
+
+func TestOpenVulnDBFeedRejectsHTTPSDowngradeRedirect(t *testing.T) {
+	targetHit := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetHit = true
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer target.Close()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer server.Close()
+
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	defer func() {
+		http.DefaultTransport = previousTransport
+	}()
+
+	body, err := OpenVulnDBFeed(context.Background(), server.URL, true)
+	if body != nil {
+		_ = body.Close()
+	}
+	if err == nil {
+		t.Fatal("OpenVulnDBFeed() error = nil, want https-to-http downgrade rejection")
+	}
+	if targetHit {
+		t.Fatal("OpenVulnDBFeed() followed https-to-http downgrade redirect")
+	}
+}

--- a/internal/bootstrap/vulndbfeed_test.go
+++ b/internal/bootstrap/vulndbfeed_test.go
@@ -1,0 +1,55 @@
+package bootstrap
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOpenVulnDBFeedFetchesSuccessfulHTTPWhenExplicitlyAllowed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	body, err := OpenVulnDBFeed(context.Background(), server.URL, true)
+	if err != nil {
+		t.Fatalf("OpenVulnDBFeed() error = %v", err)
+	}
+	defer func() {
+		_ = body.Close()
+	}()
+	data, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(data) != `{"ok":true}` {
+		t.Fatalf("body = %q, want ok payload", data)
+	}
+}
+
+func TestOpenVulnDBFeedRejectsNonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusTeapot)
+	}))
+	defer server.Close()
+
+	_, err := OpenVulnDBFeed(context.Background(), server.URL, true)
+	if err == nil {
+		t.Fatal("OpenVulnDBFeed() error = nil, want status error")
+	}
+}
+
+func TestOpenVulnDBFeedValidatesRedirectTargets(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "file:///tmp/vulndb.json", http.StatusFound)
+	}))
+	defer server.Close()
+
+	_, err := OpenVulnDBFeed(context.Background(), server.URL, true)
+	if err == nil {
+		t.Fatal("OpenVulnDBFeed() error = nil, want redirect policy error")
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -24,6 +24,7 @@ type Store struct {
 	sourceRuntimeTableReady   bool
 	findingEvidenceReady      bool
 	findingEvaluationRunReady bool
+	vulnDBTablesReady         bool
 }
 
 // Open opens a Postgres-backed current-state store.

--- a/internal/statestore/postgres/vulndb.go
+++ b/internal/statestore/postgres/vulndb.go
@@ -285,6 +285,90 @@ DO UPDATE SET
 	return nil
 }
 
+// MoveAffectedPackages reassigns all affected package rows from one advisory ID to another.
+func (s *Store) MoveAffectedPackages(ctx context.Context, fromID string, toID string) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	fromID = vulndb.NormalizeIdentifier(fromID)
+	toID = vulndb.NormalizeIdentifier(toID)
+	if fromID == "" || toID == "" || fromID == toID {
+		return nil
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin affected package move: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	rows, err := tx.QueryContext(ctx, `SELECT affected_json::text FROM vulndb_affected_packages WHERE vulnerability_id = $1`, fromID)
+	if err != nil {
+		return fmt.Errorf("query affected packages for move %q: %w", fromID, err)
+	}
+	moved := []vulndb.AffectedPackage{}
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan affected package for move: %w", err)
+		}
+		var affected vulndb.AffectedPackage
+		if err := json.Unmarshal([]byte(payload), &affected); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("decode affected package for move: %w", err)
+		}
+		affected.VulnerabilityID = toID
+		affected.Source = strings.TrimSpace(affected.Source)
+		affected.Ecosystem = normalizeVulnDBEcosystem(affected.Ecosystem)
+		affected.PackageName = strings.TrimSpace(affected.PackageName)
+		moved = append(moved, affected)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate affected packages for move: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close affected packages for move: %w", err)
+	}
+	for _, affected := range moved {
+		if affected.Ecosystem == "" {
+			return errors.New("affected package ecosystem is required")
+		}
+		if affected.PackageName == "" {
+			return errors.New("affected package name is required")
+		}
+		payload, err := json.Marshal(affected)
+		if err != nil {
+			return fmt.Errorf("marshal moved affected package: %w", err)
+		}
+		rowKey := postgresAffectedPackageKey(affected)
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO vulndb_affected_packages (row_key, vulnerability_id, ecosystem, package_name, package_name_key, affected_json)
+VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+ON CONFLICT (row_key)
+DO UPDATE SET
+  vulnerability_id = EXCLUDED.vulnerability_id,
+  ecosystem = EXCLUDED.ecosystem,
+  package_name = EXCLUDED.package_name,
+  package_name_key = EXCLUDED.package_name_key,
+  affected_json = EXCLUDED.affected_json,
+  updated_at = NOW()`, rowKey, affected.VulnerabilityID, affected.Ecosystem, affected.PackageName, normalizeVulnDBPackageName(affected.PackageName), string(payload)); err != nil {
+			return fmt.Errorf("move affected package %q: %w", rowKey, err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM vulndb_affected_packages WHERE vulnerability_id = $1`, fromID); err != nil {
+		return fmt.Errorf("delete moved affected packages %q: %w", fromID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit affected package move: %w", err)
+	}
+	return nil
+}
+
 // CandidateAffectedPackages returns all advisory package rows for an ecosystem/name pair.
 func (s *Store) CandidateAffectedPackages(ctx context.Context, query vulndb.PackageQuery) ([]vulndb.AffectedPackage, error) {
 	if s == nil || s.db == nil {

--- a/internal/statestore/postgres/vulndb.go
+++ b/internal/statestore/postgres/vulndb.go
@@ -1,0 +1,675 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/vulndb"
+)
+
+var ensureVulnDBStatements = []string{
+	`CREATE TABLE IF NOT EXISTS vulndb_vulnerabilities (
+  id TEXT PRIMARY KEY,
+  vulnerability_json JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE TABLE IF NOT EXISTS vulndb_aliases (
+  alias TEXT PRIMARY KEY,
+  vulnerability_id TEXT NOT NULL REFERENCES vulndb_vulnerabilities(id) ON DELETE CASCADE
+)`,
+	`CREATE INDEX IF NOT EXISTS vulndb_aliases_vulnerability_idx ON vulndb_aliases (vulnerability_id)`,
+	`CREATE TABLE IF NOT EXISTS vulndb_affected_packages (
+  row_key TEXT PRIMARY KEY,
+  vulnerability_id TEXT NOT NULL,
+  ecosystem TEXT NOT NULL,
+  package_name TEXT NOT NULL,
+  package_name_key TEXT NOT NULL,
+  affected_json JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS vulndb_affected_packages_lookup_idx ON vulndb_affected_packages (ecosystem, package_name_key)`,
+	`CREATE TABLE IF NOT EXISTS vulndb_sync_states (
+  source TEXT PRIMARY KEY,
+  cursor_value TEXT NOT NULL DEFAULT '',
+  etag TEXT NOT NULL DEFAULT '',
+  last_synced_at TIMESTAMPTZ,
+  last_success_at TIMESTAMPTZ,
+  last_error TEXT NOT NULL DEFAULT '',
+  sync_state_json JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE TABLE IF NOT EXISTS vulndb_sync_jobs (
+  id TEXT PRIMARY KEY,
+  source TEXT NOT NULL,
+  feed_url TEXT NOT NULL,
+  allow_insecure_http BOOLEAN NOT NULL DEFAULT FALSE,
+  interval_ns BIGINT NOT NULL DEFAULT 0,
+  next_run_at TIMESTAMPTZ,
+  lease_owner TEXT NOT NULL DEFAULT '',
+  lease_expires_at TIMESTAMPTZ,
+  last_started_at TIMESTAMPTZ,
+  last_finished_at TIMESTAMPTZ,
+  last_success_at TIMESTAMPTZ,
+  last_error TEXT NOT NULL DEFAULT '',
+  runs BIGINT NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS vulndb_sync_jobs_due_idx ON vulndb_sync_jobs (next_run_at, lease_expires_at)`,
+}
+
+// UpsertVulnerability inserts or replaces a normalized advisory.
+func (s *Store) UpsertVulnerability(ctx context.Context, vulnerability vulndb.Vulnerability) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	vulnerability.ID = vulndb.NormalizeIdentifier(vulnerability.ID)
+	if vulnerability.ID == "" {
+		return errors.New("vulnerability id is required")
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(vulnerability)
+	if err != nil {
+		return fmt.Errorf("marshal vulnerability: %w", err)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin vulndb vulnerability upsert: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO vulndb_vulnerabilities (id, vulnerability_json)
+VALUES ($1, $2::jsonb)
+ON CONFLICT (id)
+DO UPDATE SET vulnerability_json = EXCLUDED.vulnerability_json, updated_at = NOW()`, vulnerability.ID, string(payload)); err != nil {
+		return fmt.Errorf("upsert vulnerability %q: %w", vulnerability.ID, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM vulndb_aliases WHERE vulnerability_id = $1`, vulnerability.ID); err != nil {
+		return fmt.Errorf("replace vulnerability aliases %q: %w", vulnerability.ID, err)
+	}
+	aliases := append([]string{vulnerability.ID}, vulnerability.Aliases...)
+	for _, alias := range normalizedVulnAliases(aliases) {
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO vulndb_aliases (alias, vulnerability_id)
+VALUES ($1, $2)
+ON CONFLICT (alias)
+DO UPDATE SET vulnerability_id = EXCLUDED.vulnerability_id`, alias, vulnerability.ID); err != nil {
+			return fmt.Errorf("upsert vulnerability alias %q: %w", alias, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit vulnerability %q: %w", vulnerability.ID, err)
+	}
+	return nil
+}
+
+// FindVulnerability returns an advisory by canonical ID or alias.
+func (s *Store) FindVulnerability(ctx context.Context, idOrAlias string) (vulndb.Vulnerability, bool, error) {
+	if s == nil || s.db == nil {
+		return vulndb.Vulnerability{}, false, errors.New("postgres is not configured")
+	}
+	lookup := vulndb.NormalizeIdentifier(idOrAlias)
+	if lookup == "" {
+		return vulndb.Vulnerability{}, false, nil
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return vulndb.Vulnerability{}, false, err
+	}
+	var payload string
+	if err := s.db.QueryRowContext(ctx, `
+SELECT v.vulnerability_json::text
+FROM vulndb_aliases a
+JOIN vulndb_vulnerabilities v ON v.id = a.vulnerability_id
+WHERE a.alias = $1`, lookup).Scan(&payload); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return vulndb.Vulnerability{}, false, nil
+		}
+		return vulndb.Vulnerability{}, false, fmt.Errorf("query vulnerability %q: %w", lookup, err)
+	}
+	var vulnerability vulndb.Vulnerability
+	if err := json.Unmarshal([]byte(payload), &vulnerability); err != nil {
+		return vulndb.Vulnerability{}, false, fmt.Errorf("decode vulnerability %q: %w", lookup, err)
+	}
+	return vulnerability, true, nil
+}
+
+// UpsertAffectedPackage inserts or replaces an affected package row.
+func (s *Store) UpsertAffectedPackage(ctx context.Context, affected vulndb.AffectedPackage) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	affected.VulnerabilityID = vulndb.NormalizeIdentifier(affected.VulnerabilityID)
+	affected.Ecosystem = normalizeVulnDBEcosystem(affected.Ecosystem)
+	affected.PackageName = strings.TrimSpace(affected.PackageName)
+	if affected.VulnerabilityID == "" {
+		return errors.New("affected package vulnerability id is required")
+	}
+	if affected.Ecosystem == "" {
+		return errors.New("affected package ecosystem is required")
+	}
+	if affected.PackageName == "" {
+		return errors.New("affected package name is required")
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(affected)
+	if err != nil {
+		return fmt.Errorf("marshal affected package: %w", err)
+	}
+	rowKey := postgresAffectedPackageKey(affected)
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO vulndb_affected_packages (row_key, vulnerability_id, ecosystem, package_name, package_name_key, affected_json)
+VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+ON CONFLICT (row_key)
+DO UPDATE SET
+  vulnerability_id = EXCLUDED.vulnerability_id,
+  ecosystem = EXCLUDED.ecosystem,
+  package_name = EXCLUDED.package_name,
+  package_name_key = EXCLUDED.package_name_key,
+  affected_json = EXCLUDED.affected_json,
+  updated_at = NOW()`, rowKey, affected.VulnerabilityID, affected.Ecosystem, affected.PackageName, normalizeVulnDBPackageName(affected.PackageName), string(payload)); err != nil {
+		return fmt.Errorf("upsert affected package %q: %w", rowKey, err)
+	}
+	return nil
+}
+
+// CandidateAffectedPackages returns all advisory package rows for an ecosystem/name pair.
+func (s *Store) CandidateAffectedPackages(ctx context.Context, query vulndb.PackageQuery) ([]vulndb.AffectedPackage, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	ecosystem := normalizeVulnDBEcosystem(query.Ecosystem)
+	packageName := normalizeVulnDBPackageName(query.Name)
+	if ecosystem == "" || packageName == "" {
+		return nil, nil
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT affected_json::text
+FROM vulndb_affected_packages
+WHERE ecosystem = $1 AND package_name_key = $2
+ORDER BY row_key`, ecosystem, packageName)
+	if err != nil {
+		return nil, fmt.Errorf("query affected packages: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+	var out []vulndb.AffectedPackage
+	for rows.Next() {
+		var payload string
+		if err := rows.Scan(&payload); err != nil {
+			return nil, fmt.Errorf("scan affected package: %w", err)
+		}
+		var affected vulndb.AffectedPackage
+		if err := json.Unmarshal([]byte(payload), &affected); err != nil {
+			return nil, fmt.Errorf("decode affected package: %w", err)
+		}
+		out = append(out, affected)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate affected packages: %w", err)
+	}
+	return out, nil
+}
+
+// GetSyncState returns feed synchronization progress by logical source label.
+func (s *Store) GetSyncState(ctx context.Context, source string) (vulndb.SyncState, bool, error) {
+	if s == nil || s.db == nil {
+		return vulndb.SyncState{}, false, errors.New("postgres is not configured")
+	}
+	source = normalizeVulnDBSource(source)
+	if source == "" {
+		return vulndb.SyncState{}, false, nil
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return vulndb.SyncState{}, false, err
+	}
+	var payload string
+	if err := s.db.QueryRowContext(ctx, `SELECT sync_state_json::text FROM vulndb_sync_states WHERE source = $1`, source).Scan(&payload); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return vulndb.SyncState{}, false, nil
+		}
+		return vulndb.SyncState{}, false, fmt.Errorf("query sync state %q: %w", source, err)
+	}
+	var state vulndb.SyncState
+	if err := json.Unmarshal([]byte(payload), &state); err != nil {
+		return vulndb.SyncState{}, false, fmt.Errorf("decode sync state %q: %w", source, err)
+	}
+	return state, true, nil
+}
+
+// PutSyncState records feed synchronization progress by logical source label.
+func (s *Store) PutSyncState(ctx context.Context, state vulndb.SyncState) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	state.Source = normalizeVulnDBSource(state.Source)
+	if state.Source == "" {
+		return errors.New("sync state source is required")
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal sync state: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO vulndb_sync_states (source, cursor_value, etag, last_synced_at, last_success_at, last_error, sync_state_json)
+VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+ON CONFLICT (source)
+DO UPDATE SET
+  cursor_value = EXCLUDED.cursor_value,
+  etag = EXCLUDED.etag,
+  last_synced_at = EXCLUDED.last_synced_at,
+  last_success_at = EXCLUDED.last_success_at,
+  last_error = EXCLUDED.last_error,
+  sync_state_json = EXCLUDED.sync_state_json,
+  updated_at = NOW()`, state.Source, strings.TrimSpace(state.Cursor), strings.TrimSpace(state.ETag), nullableTime(state.LastSyncedAt), nullableTime(state.LastSuccessAt), strings.TrimSpace(state.LastError), string(payload)); err != nil {
+		return fmt.Errorf("put sync state %q: %w", state.Source, err)
+	}
+	return nil
+}
+
+// Stats returns counts for persisted advisory data.
+func (s *Store) Stats(ctx context.Context) (vulndb.Stats, error) {
+	if s == nil || s.db == nil {
+		return vulndb.Stats{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return vulndb.Stats{}, err
+	}
+	var stats vulndb.Stats
+	if err := s.db.QueryRowContext(ctx, `
+SELECT
+  (SELECT COUNT(*) FROM vulndb_vulnerabilities),
+  (SELECT COUNT(*) FROM vulndb_affected_packages),
+  (SELECT COUNT(*) FROM vulndb_sync_states),
+  (SELECT COUNT(*) FROM vulndb_sync_jobs)`).Scan(&stats.Vulnerabilities, &stats.AffectedPackages, &stats.SyncSources, &stats.SyncJobs); err != nil {
+		return vulndb.Stats{}, fmt.Errorf("query vulndb stats: %w", err)
+	}
+	return stats, nil
+}
+
+// PutSyncJob upserts a durable advisory feed synchronization job.
+func (s *Store) PutSyncJob(ctx context.Context, job vulndb.SyncJob) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	job = normalizePostgresSyncJob(job)
+	if job.ID == "" {
+		return errors.New("sync job id is required")
+	}
+	if job.Source == "" {
+		return errors.New("sync job source is required")
+	}
+	if job.FeedURL == "" {
+		return errors.New("sync job feed url is required")
+	}
+	if job.Interval < 0 {
+		return errors.New("sync job interval must be non-negative")
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO vulndb_sync_jobs (
+  id, source, feed_url, allow_insecure_http, interval_ns, next_run_at,
+  lease_owner, lease_expires_at, last_started_at, last_finished_at,
+  last_success_at, last_error, runs
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+ON CONFLICT (id)
+DO UPDATE SET
+  source = EXCLUDED.source,
+  feed_url = EXCLUDED.feed_url,
+  allow_insecure_http = EXCLUDED.allow_insecure_http,
+  interval_ns = EXCLUDED.interval_ns,
+  next_run_at = EXCLUDED.next_run_at,
+  lease_owner = CASE WHEN EXCLUDED.lease_owner = '' THEN vulndb_sync_jobs.lease_owner ELSE EXCLUDED.lease_owner END,
+  lease_expires_at = CASE WHEN EXCLUDED.lease_owner = '' THEN vulndb_sync_jobs.lease_expires_at ELSE EXCLUDED.lease_expires_at END,
+  last_started_at = COALESCE(EXCLUDED.last_started_at, vulndb_sync_jobs.last_started_at),
+  last_finished_at = COALESCE(EXCLUDED.last_finished_at, vulndb_sync_jobs.last_finished_at),
+  last_success_at = COALESCE(EXCLUDED.last_success_at, vulndb_sync_jobs.last_success_at),
+  last_error = CASE WHEN EXCLUDED.last_error = '' THEN vulndb_sync_jobs.last_error ELSE EXCLUDED.last_error END,
+  runs = CASE WHEN EXCLUDED.runs = 0 THEN vulndb_sync_jobs.runs ELSE EXCLUDED.runs END,
+  updated_at = NOW()`,
+		job.ID,
+		job.Source,
+		job.FeedURL,
+		job.AllowInsecureHTTP,
+		job.Interval.Nanoseconds(),
+		nullableTime(job.NextRunAt),
+		job.LeaseOwner,
+		nullableTime(job.LeaseExpiresAt),
+		nullableTime(job.LastStartedAt),
+		nullableTime(job.LastFinishedAt),
+		nullableTime(job.LastSuccessAt),
+		job.LastError,
+		job.Runs,
+	); err != nil {
+		return fmt.Errorf("put sync job %q: %w", job.ID, err)
+	}
+	return nil
+}
+
+// GetSyncJob returns a durable advisory feed synchronization job.
+func (s *Store) GetSyncJob(ctx context.Context, id string) (vulndb.SyncJob, bool, error) {
+	if s == nil || s.db == nil {
+		return vulndb.SyncJob{}, false, errors.New("postgres is not configured")
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return vulndb.SyncJob{}, false, nil
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return vulndb.SyncJob{}, false, err
+	}
+	row := s.db.QueryRowContext(ctx, syncJobSelectSQL()+` WHERE id = $1`, id)
+	job, err := scanSyncJob(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return vulndb.SyncJob{}, false, nil
+		}
+		return vulndb.SyncJob{}, false, fmt.Errorf("get sync job %q: %w", id, err)
+	}
+	return job, true, nil
+}
+
+// ListDueSyncJobs returns sync jobs whose next run is due and whose lease is free or expired.
+func (s *Store) ListDueSyncJobs(ctx context.Context, now time.Time, limit int) ([]vulndb.SyncJob, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if limit <= 0 {
+		limit = vulndb.DefaultSyncJobLimit
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, syncJobSelectSQL()+`
+ WHERE (lease_expires_at IS NULL OR lease_expires_at <= $1)
+   AND (next_run_at IS NULL OR next_run_at <= $1)
+ ORDER BY next_run_at NULLS FIRST, id
+ LIMIT $2`, now.UTC(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list due sync jobs: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+	var jobs []vulndb.SyncJob
+	for rows.Next() {
+		job, err := scanSyncJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate due sync jobs: %w", err)
+	}
+	return jobs, nil
+}
+
+// AcquireSyncJobLease leases a sync job for a worker.
+func (s *Store) AcquireSyncJobLease(ctx context.Context, id string, owner string, ttl time.Duration) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, errors.New("postgres is not configured")
+	}
+	id = strings.TrimSpace(id)
+	owner = strings.TrimSpace(owner)
+	if id == "" {
+		return false, errors.New("sync job id is required")
+	}
+	if owner == "" {
+		return false, errors.New("sync job lease owner is required")
+	}
+	if ttl <= 0 {
+		return false, errors.New("sync job lease ttl must be positive")
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return false, err
+	}
+	result, err := s.db.ExecContext(ctx, `
+UPDATE vulndb_sync_jobs
+SET lease_owner = $2,
+    lease_expires_at = NOW() + $3::interval,
+    last_started_at = NOW(),
+    updated_at = NOW()
+WHERE id = $1
+  AND (lease_expires_at IS NULL OR lease_expires_at <= NOW() OR lease_owner = $2)`, id, owner, postgresInterval(ttl))
+	if err != nil {
+		return false, fmt.Errorf("acquire sync job lease %q: %w", id, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("acquire sync job lease %q rows affected: %w", id, err)
+	}
+	return rows > 0, nil
+}
+
+// ReleaseSyncJobLease releases a sync job lease held by owner.
+func (s *Store) ReleaseSyncJobLease(ctx context.Context, id string, owner string) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	id = strings.TrimSpace(id)
+	owner = strings.TrimSpace(owner)
+	if id == "" {
+		return errors.New("sync job id is required")
+	}
+	if owner == "" {
+		return errors.New("sync job lease owner is required")
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `
+UPDATE vulndb_sync_jobs
+SET lease_owner = '',
+    lease_expires_at = NULL,
+    updated_at = NOW()
+WHERE id = $1 AND lease_owner = $2`, id, owner); err != nil {
+		return fmt.Errorf("release sync job lease %q: %w", id, err)
+	}
+	return nil
+}
+
+// CompleteSyncJob records a successful sync job run.
+func (s *Store) CompleteSyncJob(ctx context.Context, id string, owner string, nextRunAt time.Time) error {
+	return s.finishSyncJob(ctx, id, owner, nextRunAt, nil)
+}
+
+// FailSyncJob records a failed sync job run.
+func (s *Store) FailSyncJob(ctx context.Context, id string, owner string, nextRunAt time.Time, syncErr error) error {
+	if syncErr == nil {
+		syncErr = errors.New("sync job failed")
+	}
+	return s.finishSyncJob(ctx, id, owner, nextRunAt, syncErr)
+}
+
+func (s *Store) finishSyncJob(ctx context.Context, id string, owner string, nextRunAt time.Time, syncErr error) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	id = strings.TrimSpace(id)
+	owner = strings.TrimSpace(owner)
+	if id == "" {
+		return errors.New("sync job id is required")
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return err
+	}
+	statusErr := ""
+	successAt := any(nil)
+	if syncErr != nil {
+		statusErr = syncErr.Error()
+	} else {
+		successAt = time.Now().UTC()
+	}
+	result, err := s.db.ExecContext(ctx, `
+UPDATE vulndb_sync_jobs
+SET lease_owner = '',
+    lease_expires_at = NULL,
+    last_finished_at = NOW(),
+    last_success_at = COALESCE($4, last_success_at),
+    last_error = $5,
+    runs = runs + 1,
+    next_run_at = $3,
+    updated_at = NOW()
+WHERE id = $1
+  AND (lease_owner = '' OR lease_owner = $2)`, id, owner, nullableTime(nextRunAt), successAt, statusErr)
+	if err != nil {
+		return fmt.Errorf("finish sync job %q: %w", id, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("finish sync job %q rows affected: %w", id, err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("sync job %q is leased by another owner", id)
+	}
+	return nil
+}
+
+func (s *Store) ensureVulnDBTables(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	return s.ensureStatements(ctx, &s.vulnDBTablesReady, "vulndb", ensureVulnDBStatements)
+}
+
+type syncJobScanner interface {
+	Scan(dest ...any) error
+}
+
+func syncJobSelectSQL() string {
+	return `SELECT id, source, feed_url, allow_insecure_http, interval_ns, next_run_at,
+       lease_owner, lease_expires_at, last_started_at, last_finished_at,
+       last_success_at, last_error, runs
+FROM vulndb_sync_jobs`
+}
+
+func scanSyncJob(scanner syncJobScanner) (vulndb.SyncJob, error) {
+	var (
+		job            vulndb.SyncJob
+		intervalNS     int64
+		nextRunAt      sql.NullTime
+		leaseExpiresAt sql.NullTime
+		lastStartedAt  sql.NullTime
+		lastFinishedAt sql.NullTime
+		lastSuccessAt  sql.NullTime
+		leaseOwner     string
+		lastError      string
+	)
+	if err := scanner.Scan(
+		&job.ID,
+		&job.Source,
+		&job.FeedURL,
+		&job.AllowInsecureHTTP,
+		&intervalNS,
+		&nextRunAt,
+		&leaseOwner,
+		&leaseExpiresAt,
+		&lastStartedAt,
+		&lastFinishedAt,
+		&lastSuccessAt,
+		&lastError,
+		&job.Runs,
+	); err != nil {
+		return vulndb.SyncJob{}, err
+	}
+	job.Interval = time.Duration(intervalNS)
+	job.NextRunAt = nullTime(nextRunAt)
+	job.LeaseOwner = strings.TrimSpace(leaseOwner)
+	job.LeaseExpiresAt = nullTime(leaseExpiresAt)
+	job.LastStartedAt = nullTime(lastStartedAt)
+	job.LastFinishedAt = nullTime(lastFinishedAt)
+	job.LastSuccessAt = nullTime(lastSuccessAt)
+	job.LastError = strings.TrimSpace(lastError)
+	return job, nil
+}
+
+func nullTime(value sql.NullTime) time.Time {
+	if !value.Valid {
+		return time.Time{}
+	}
+	return value.Time.UTC()
+}
+
+func normalizedVulnAliases(values []string) []string {
+	seen := map[string]struct{}{}
+	aliases := make([]string, 0, len(values))
+	for _, value := range values {
+		alias := vulndb.NormalizeIdentifier(value)
+		if alias == "" {
+			continue
+		}
+		if _, ok := seen[alias]; ok {
+			continue
+		}
+		seen[alias] = struct{}{}
+		aliases = append(aliases, alias)
+	}
+	return aliases
+}
+
+func postgresAffectedPackageKey(pkg vulndb.AffectedPackage) string {
+	parts := []string{
+		vulndb.NormalizeIdentifier(pkg.VulnerabilityID),
+		normalizeVulnDBEcosystem(pkg.Ecosystem),
+		normalizeVulnDBPackageName(pkg.PackageName),
+		strings.TrimSpace(pkg.RangeType),
+		strings.TrimSpace(pkg.Introduced),
+		strings.TrimSpace(pkg.Fixed),
+		strings.TrimSpace(pkg.LastAffected),
+		strings.TrimSpace(pkg.VulnerableVersion),
+		strings.TrimSpace(pkg.DistroName),
+		strings.TrimSpace(pkg.DistroVersion),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizePostgresSyncJob(job vulndb.SyncJob) vulndb.SyncJob {
+	job.ID = strings.TrimSpace(job.ID)
+	job.Source = normalizeVulnDBSource(job.Source)
+	job.FeedURL = strings.TrimSpace(job.FeedURL)
+	job.LeaseOwner = strings.TrimSpace(job.LeaseOwner)
+	job.LastError = strings.TrimSpace(job.LastError)
+	return job
+}
+
+func normalizeVulnDBSource(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeVulnDBEcosystem(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeVulnDBPackageName(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func postgresInterval(duration time.Duration) string {
+	return fmt.Sprintf("%f seconds", duration.Seconds())
+}

--- a/internal/statestore/postgres/vulndb.go
+++ b/internal/statestore/postgres/vulndb.go
@@ -114,6 +114,37 @@ DO UPDATE SET vulnerability_id = EXCLUDED.vulnerability_id`, alias, vulnerabilit
 	return nil
 }
 
+// DeleteVulnerability removes an advisory, aliases, and affected packages.
+func (s *Store) DeleteVulnerability(ctx context.Context, id string) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	id = vulndb.NormalizeIdentifier(id)
+	if id == "" {
+		return nil
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin delete vulnerability %q: %w", id, err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM vulndb_affected_packages WHERE vulnerability_id = $1`, id); err != nil {
+		return fmt.Errorf("delete affected packages for vulnerability %q: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM vulndb_vulnerabilities WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("delete vulnerability %q: %w", id, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit delete vulnerability %q: %w", id, err)
+	}
+	return nil
+}
+
 // FindVulnerability returns an advisory by canonical ID or alias.
 func (s *Store) FindVulnerability(ctx context.Context, idOrAlias string) (vulndb.Vulnerability, bool, error) {
 	if s == nil || s.db == nil {
@@ -386,6 +417,9 @@ func (s *Store) PutSyncJob(ctx context.Context, job vulndb.SyncJob) error {
 	}
 	if job.Source == "" {
 		return errors.New("sync job source is required")
+	}
+	if !vulndb.IsSupportedFeedSource(job.Source) {
+		return fmt.Errorf("unsupported vulndb feed source %q", job.Source)
 	}
 	if job.FeedURL == "" {
 		return errors.New("sync job feed url is required")

--- a/internal/statestore/postgres/vulndb.go
+++ b/internal/statestore/postgres/vulndb.go
@@ -150,6 +150,7 @@ func (s *Store) UpsertAffectedPackage(ctx context.Context, affected vulndb.Affec
 		return errors.New("postgres is not configured")
 	}
 	affected.VulnerabilityID = vulndb.NormalizeIdentifier(affected.VulnerabilityID)
+	affected.Source = strings.TrimSpace(affected.Source)
 	affected.Ecosystem = normalizeVulnDBEcosystem(affected.Ecosystem)
 	affected.PackageName = strings.TrimSpace(affected.PackageName)
 	if affected.VulnerabilityID == "" {
@@ -181,6 +182,74 @@ DO UPDATE SET
   affected_json = EXCLUDED.affected_json,
   updated_at = NOW()`, rowKey, affected.VulnerabilityID, affected.Ecosystem, affected.PackageName, normalizeVulnDBPackageName(affected.PackageName), string(payload)); err != nil {
 		return fmt.Errorf("upsert affected package %q: %w", rowKey, err)
+	}
+	return nil
+}
+
+// ReplaceAffectedPackages replaces affected package rows for one vulnerability/source.
+func (s *Store) ReplaceAffectedPackages(ctx context.Context, vulnerabilityID string, source string, packages []vulndb.AffectedPackage) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	vulnerabilityID = vulndb.NormalizeIdentifier(vulnerabilityID)
+	source = strings.TrimSpace(source)
+	if vulnerabilityID == "" {
+		return errors.New("affected package vulnerability id is required")
+	}
+	if source == "" {
+		return errors.New("affected package source is required")
+	}
+	normalized := make([]vulndb.AffectedPackage, 0, len(packages))
+	for _, affected := range packages {
+		affected.VulnerabilityID = vulnerabilityID
+		affected.Source = source
+		affected.Ecosystem = normalizeVulnDBEcosystem(affected.Ecosystem)
+		affected.PackageName = strings.TrimSpace(affected.PackageName)
+		if affected.Ecosystem == "" {
+			return errors.New("affected package ecosystem is required")
+		}
+		if affected.PackageName == "" {
+			return errors.New("affected package name is required")
+		}
+		normalized = append(normalized, affected)
+	}
+	if err := s.ensureVulnDBTables(ctx); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin affected package replacement: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	if _, err := tx.ExecContext(ctx, `
+DELETE FROM vulndb_affected_packages
+WHERE vulnerability_id = $1 AND (COALESCE(affected_json->>'Source', '') = $2 OR COALESCE(affected_json->>'Source', '') = '')`, vulnerabilityID, source); err != nil {
+		return fmt.Errorf("delete affected packages %q/%q: %w", vulnerabilityID, source, err)
+	}
+	for _, affected := range normalized {
+		payload, err := json.Marshal(affected)
+		if err != nil {
+			return fmt.Errorf("marshal affected package: %w", err)
+		}
+		rowKey := postgresAffectedPackageKey(affected)
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO vulndb_affected_packages (row_key, vulnerability_id, ecosystem, package_name, package_name_key, affected_json)
+VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+ON CONFLICT (row_key)
+DO UPDATE SET
+  vulnerability_id = EXCLUDED.vulnerability_id,
+  ecosystem = EXCLUDED.ecosystem,
+  package_name = EXCLUDED.package_name,
+  package_name_key = EXCLUDED.package_name_key,
+  affected_json = EXCLUDED.affected_json,
+  updated_at = NOW()`, rowKey, affected.VulnerabilityID, affected.Ecosystem, affected.PackageName, normalizeVulnDBPackageName(affected.PackageName), string(payload)); err != nil {
+			return fmt.Errorf("replace affected package %q: %w", rowKey, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit affected package replacement: %w", err)
 	}
 	return nil
 }
@@ -636,10 +705,12 @@ func normalizedVulnAliases(values []string) []string {
 func postgresAffectedPackageKey(pkg vulndb.AffectedPackage) string {
 	parts := []string{
 		vulndb.NormalizeIdentifier(pkg.VulnerabilityID),
+		strings.TrimSpace(pkg.Source),
 		normalizeVulnDBEcosystem(pkg.Ecosystem),
 		normalizeVulnDBPackageName(pkg.PackageName),
 		strings.TrimSpace(pkg.RangeType),
 		strings.TrimSpace(pkg.Introduced),
+		strings.TrimSpace(pkg.IntroducedExclusive),
 		strings.TrimSpace(pkg.Fixed),
 		strings.TrimSpace(pkg.LastAffected),
 		strings.TrimSpace(pkg.VulnerableVersion),

--- a/internal/statestore/postgres/vulndb.go
+++ b/internal/statestore/postgres/vulndb.go
@@ -390,8 +390,8 @@ func (s *Store) PutSyncJob(ctx context.Context, job vulndb.SyncJob) error {
 	if job.FeedURL == "" {
 		return errors.New("sync job feed url is required")
 	}
-	if job.Interval < 0 {
-		return errors.New("sync job interval must be non-negative")
+	if job.Interval <= 0 {
+		return errors.New("sync job interval must be positive")
 	}
 	if err := s.ensureVulnDBTables(ctx); err != nil {
 		return err

--- a/internal/statestore/postgres/vulndb.go
+++ b/internal/statestore/postgres/vulndb.go
@@ -73,6 +73,7 @@ func (s *Store) UpsertVulnerability(ctx context.Context, vulnerability vulndb.Vu
 	if vulnerability.ID == "" {
 		return errors.New("vulnerability id is required")
 	}
+	vulnerability.Aliases = normalizedVulnAliases(vulnerability.Aliases)
 	if err := s.ensureVulnDBTables(ctx); err != nil {
 		return err
 	}

--- a/internal/statestore/postgres/vulndb.go
+++ b/internal/statestore/postgres/vulndb.go
@@ -409,7 +409,7 @@ DO UPDATE SET
   feed_url = EXCLUDED.feed_url,
   allow_insecure_http = EXCLUDED.allow_insecure_http,
   interval_ns = EXCLUDED.interval_ns,
-  next_run_at = EXCLUDED.next_run_at,
+  next_run_at = COALESCE(EXCLUDED.next_run_at, vulndb_sync_jobs.next_run_at),
   lease_owner = CASE WHEN EXCLUDED.lease_owner = '' THEN vulndb_sync_jobs.lease_owner ELSE EXCLUDED.lease_owner END,
   lease_expires_at = CASE WHEN EXCLUDED.lease_owner = '' THEN vulndb_sync_jobs.lease_expires_at ELSE EXCLUDED.lease_expires_at END,
   last_started_at = COALESCE(EXCLUDED.last_started_at, vulndb_sync_jobs.last_started_at),

--- a/internal/statestore/postgres/vulndb_test.go
+++ b/internal/statestore/postgres/vulndb_test.go
@@ -1,0 +1,37 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/writer/cerebro/internal/vulndb"
+)
+
+func TestVulnDBAffectedPackageRowKeyNormalizesLookupFields(t *testing.T) {
+	left := postgresAffectedPackageKey(vulndb.AffectedPackage{
+		VulnerabilityID: "CVE-2026-12345",
+		Ecosystem:       "NPM",
+		PackageName:     " Lodash ",
+		Introduced:      "0",
+		Fixed:           "4.17.21",
+	})
+	right := postgresAffectedPackageKey(vulndb.AffectedPackage{
+		VulnerabilityID: "CVE-2026-12345",
+		Ecosystem:       "npm",
+		PackageName:     "lodash",
+		Introduced:      "0",
+		Fixed:           "4.17.21",
+	})
+	if left != right {
+		t.Fatalf("row keys differ after normalization: %q != %q", left, right)
+	}
+	if len(left) != 64 {
+		t.Fatalf("row key length = %d, want sha256 hex", len(left))
+	}
+}
+
+func TestNormalizedVulnDBAliasesIncludesCanonicalID(t *testing.T) {
+	aliases := normalizedVulnAliases([]string{"cve-2026-12345", " cve-2026-12345 ", "ghsa-aaaa-bbbb-cccc"})
+	if len(aliases) != 2 || aliases[0] != "CVE-2026-12345" || aliases[1] != "GHSA-AAAA-BBBB-CCCC" {
+		t.Fatalf("aliases = %#v, want canonical plus unique aliases", aliases)
+	}
+}

--- a/internal/vulndb/filestore.go
+++ b/internal/vulndb/filestore.go
@@ -62,6 +62,14 @@ func (s *FileStore) UpsertAffectedPackage(ctx context.Context, pkg AffectedPacka
 	return s.save(ctx)
 }
 
+// ReplaceAffectedPackages replaces affected package rows for one vulnerability/source and persists the state file.
+func (s *FileStore) ReplaceAffectedPackages(ctx context.Context, vulnerabilityID string, source string, packages []AffectedPackage) error {
+	if err := s.mem.ReplaceAffectedPackages(ctx, vulnerabilityID, source, packages); err != nil {
+		return err
+	}
+	return s.save(ctx)
+}
+
 // CandidateAffectedPackages returns all advisory package rows for an ecosystem/name pair.
 func (s *FileStore) CandidateAffectedPackages(ctx context.Context, query PackageQuery) ([]AffectedPackage, error) {
 	return s.mem.CandidateAffectedPackages(ctx, query)

--- a/internal/vulndb/filestore.go
+++ b/internal/vulndb/filestore.go
@@ -49,6 +49,13 @@ func (s *FileStore) UpsertVulnerability(ctx context.Context, v Vulnerability) er
 	})
 }
 
+// DeleteVulnerability removes an advisory and persists the state file.
+func (s *FileStore) DeleteVulnerability(ctx context.Context, id string) error {
+	return s.update(ctx, func() error {
+		return s.mem.DeleteVulnerability(ctx, id)
+	})
+}
+
 // FindVulnerability returns an advisory by canonical ID or alias.
 func (s *FileStore) FindVulnerability(ctx context.Context, idOrAlias string) (Vulnerability, bool, error) {
 	return s.mem.FindVulnerability(ctx, idOrAlias)

--- a/internal/vulndb/filestore.go
+++ b/internal/vulndb/filestore.go
@@ -1,0 +1,237 @@
+package vulndb
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// FileStore persists advisory data as a local JSON state file.
+type FileStore struct {
+	path string
+	mem  *MemoryStore
+}
+
+type fileState struct {
+	Vulnerabilities  []Vulnerability   `json:"vulnerabilities,omitempty"`
+	AffectedPackages []AffectedPackage `json:"affected_packages,omitempty"`
+	SyncStates       []SyncState       `json:"sync_states,omitempty"`
+	SyncJobs         []SyncJob         `json:"sync_jobs,omitempty"`
+}
+
+// NewFileStore opens or initializes a file-backed vulnerability store.
+func NewFileStore(ctx context.Context, path string) (*FileStore, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return nil, fmt.Errorf("vulndb state path is required")
+	}
+	store := &FileStore{path: path, mem: NewMemoryStore()}
+	if err := store.load(ctx); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// UpsertVulnerability inserts or replaces a normalized advisory and persists the state file.
+func (s *FileStore) UpsertVulnerability(ctx context.Context, v Vulnerability) error {
+	if err := s.mem.UpsertVulnerability(ctx, v); err != nil {
+		return err
+	}
+	return s.save(ctx)
+}
+
+// FindVulnerability returns an advisory by canonical ID or alias.
+func (s *FileStore) FindVulnerability(ctx context.Context, idOrAlias string) (Vulnerability, bool, error) {
+	return s.mem.FindVulnerability(ctx, idOrAlias)
+}
+
+// UpsertAffectedPackage inserts or replaces an affected package row and persists the state file.
+func (s *FileStore) UpsertAffectedPackage(ctx context.Context, pkg AffectedPackage) error {
+	if err := s.mem.UpsertAffectedPackage(ctx, pkg); err != nil {
+		return err
+	}
+	return s.save(ctx)
+}
+
+// CandidateAffectedPackages returns all advisory package rows for an ecosystem/name pair.
+func (s *FileStore) CandidateAffectedPackages(ctx context.Context, query PackageQuery) ([]AffectedPackage, error) {
+	return s.mem.CandidateAffectedPackages(ctx, query)
+}
+
+// GetSyncState returns feed synchronization progress by logical source label.
+func (s *FileStore) GetSyncState(ctx context.Context, source string) (SyncState, bool, error) {
+	return s.mem.GetSyncState(ctx, source)
+}
+
+// PutSyncState records feed synchronization progress and persists the state file.
+func (s *FileStore) PutSyncState(ctx context.Context, state SyncState) error {
+	if err := s.mem.PutSyncState(ctx, state); err != nil {
+		return err
+	}
+	return s.save(ctx)
+}
+
+// Stats returns counts for persisted advisory data.
+func (s *FileStore) Stats(ctx context.Context) (Stats, error) {
+	return s.mem.Stats(ctx)
+}
+
+// PutSyncJob upserts a durable advisory feed synchronization job and persists the state file.
+func (s *FileStore) PutSyncJob(ctx context.Context, job SyncJob) error {
+	if err := s.mem.PutSyncJob(ctx, job); err != nil {
+		return err
+	}
+	return s.save(ctx)
+}
+
+// GetSyncJob returns a durable advisory feed synchronization job.
+func (s *FileStore) GetSyncJob(ctx context.Context, id string) (SyncJob, bool, error) {
+	return s.mem.GetSyncJob(ctx, id)
+}
+
+// ListDueSyncJobs returns sync jobs whose next run is due and whose lease is free or expired.
+func (s *FileStore) ListDueSyncJobs(ctx context.Context, now time.Time, limit int) ([]SyncJob, error) {
+	return s.mem.ListDueSyncJobs(ctx, now, limit)
+}
+
+// AcquireSyncJobLease leases a sync job for a worker and persists the state file.
+func (s *FileStore) AcquireSyncJobLease(ctx context.Context, id string, owner string, ttl time.Duration) (bool, error) {
+	acquired, err := s.mem.AcquireSyncJobLease(ctx, id, owner, ttl)
+	if err != nil || !acquired {
+		return acquired, err
+	}
+	return acquired, s.save(ctx)
+}
+
+// ReleaseSyncJobLease releases a sync job lease held by owner and persists the state file.
+func (s *FileStore) ReleaseSyncJobLease(ctx context.Context, id string, owner string) error {
+	if err := s.mem.ReleaseSyncJobLease(ctx, id, owner); err != nil {
+		return err
+	}
+	return s.save(ctx)
+}
+
+// CompleteSyncJob records a successful sync job run and persists the state file.
+func (s *FileStore) CompleteSyncJob(ctx context.Context, id string, owner string, nextRunAt time.Time) error {
+	if err := s.mem.CompleteSyncJob(ctx, id, owner, nextRunAt); err != nil {
+		return err
+	}
+	return s.save(ctx)
+}
+
+// FailSyncJob records a failed sync job run and persists the state file.
+func (s *FileStore) FailSyncJob(ctx context.Context, id string, owner string, nextRunAt time.Time, syncErr error) error {
+	if err := s.mem.FailSyncJob(ctx, id, owner, nextRunAt, syncErr); err != nil {
+		return err
+	}
+	return s.save(ctx)
+}
+
+func (s *FileStore) load(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var state fileState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("decode vulndb state: %w", err)
+	}
+	for _, vulnerability := range state.Vulnerabilities {
+		if err := s.mem.UpsertVulnerability(ctx, vulnerability); err != nil {
+			return err
+		}
+	}
+	for _, affected := range state.AffectedPackages {
+		if err := s.mem.UpsertAffectedPackage(ctx, affected); err != nil {
+			return err
+		}
+	}
+	for _, syncState := range state.SyncStates {
+		if err := s.mem.PutSyncState(ctx, syncState); err != nil {
+			return err
+		}
+	}
+	for _, syncJob := range state.SyncJobs {
+		if err := s.mem.PutSyncJob(ctx, syncJob); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *FileStore) save(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	state := s.snapshot()
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+func (s *FileStore) snapshot() fileState {
+	s.mem.mu.RLock()
+	defer s.mem.mu.RUnlock()
+	state := fileState{
+		Vulnerabilities:  make([]Vulnerability, 0, len(s.mem.vulnerabilities)),
+		AffectedPackages: make([]AffectedPackage, 0),
+		SyncStates:       make([]SyncState, 0, len(s.mem.syncStates)),
+		SyncJobs:         make([]SyncJob, 0, len(s.mem.syncJobs)),
+	}
+	for _, vulnerability := range s.mem.vulnerabilities {
+		state.Vulnerabilities = append(state.Vulnerabilities, cloneVulnerability(vulnerability))
+	}
+	for _, rows := range s.mem.affected {
+		for _, affected := range rows {
+			state.AffectedPackages = append(state.AffectedPackages, affected)
+		}
+	}
+	for _, syncState := range s.mem.syncStates {
+		state.SyncStates = append(state.SyncStates, syncState)
+	}
+	for _, syncJob := range s.mem.syncJobs {
+		state.SyncJobs = append(state.SyncJobs, syncJob)
+	}
+	sort.Slice(state.Vulnerabilities, func(i, j int) bool {
+		return state.Vulnerabilities[i].ID < state.Vulnerabilities[j].ID
+	})
+	sort.Slice(state.AffectedPackages, func(i, j int) bool {
+		return affectedPackageKey(state.AffectedPackages[i]) < affectedPackageKey(state.AffectedPackages[j])
+	})
+	sort.Slice(state.SyncStates, func(i, j int) bool {
+		return state.SyncStates[i].Source < state.SyncStates[j].Source
+	})
+	sort.Slice(state.SyncJobs, func(i, j int) bool {
+		return state.SyncJobs[i].ID < state.SyncJobs[j].ID
+	})
+	return state
+}

--- a/internal/vulndb/filestore.go
+++ b/internal/vulndb/filestore.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -15,6 +16,7 @@ import (
 type FileStore struct {
 	path string
 	mem  *MemoryStore
+	mu   sync.Mutex
 }
 
 type fileState struct {
@@ -179,23 +181,53 @@ func (s *FileStore) save(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	state := s.snapshot()
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
+	file, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := os.Rename(tmp, s.path); err != nil {
 		_ = os.Remove(tmp)
 		return err
 	}
+	syncDir(dir)
 	return nil
+}
+
+func syncDir(path string) {
+	dir, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = dir.Close()
+	}()
+	_ = dir.Sync()
 }
 
 func (s *FileStore) snapshot() fileState {

--- a/internal/vulndb/filestore.go
+++ b/internal/vulndb/filestore.go
@@ -58,7 +58,14 @@ func (s *FileStore) DeleteVulnerability(ctx context.Context, id string) error {
 
 // FindVulnerability returns an advisory by canonical ID or alias.
 func (s *FileStore) FindVulnerability(ctx context.Context, idOrAlias string) (Vulnerability, bool, error) {
-	return s.mem.FindVulnerability(ctx, idOrAlias)
+	var vulnerability Vulnerability
+	found := false
+	err := s.read(ctx, func() error {
+		var err error
+		vulnerability, found, err = s.mem.FindVulnerability(ctx, idOrAlias)
+		return err
+	})
+	return vulnerability, found, err
 }
 
 // UpsertAffectedPackage inserts or replaces an affected package row and persists the state file.
@@ -77,12 +84,25 @@ func (s *FileStore) ReplaceAffectedPackages(ctx context.Context, vulnerabilityID
 
 // CandidateAffectedPackages returns all advisory package rows for an ecosystem/name pair.
 func (s *FileStore) CandidateAffectedPackages(ctx context.Context, query PackageQuery) ([]AffectedPackage, error) {
-	return s.mem.CandidateAffectedPackages(ctx, query)
+	var packages []AffectedPackage
+	err := s.read(ctx, func() error {
+		var err error
+		packages, err = s.mem.CandidateAffectedPackages(ctx, query)
+		return err
+	})
+	return packages, err
 }
 
 // GetSyncState returns feed synchronization progress by logical source label.
 func (s *FileStore) GetSyncState(ctx context.Context, source string) (SyncState, bool, error) {
-	return s.mem.GetSyncState(ctx, source)
+	var state SyncState
+	found := false
+	err := s.read(ctx, func() error {
+		var err error
+		state, found, err = s.mem.GetSyncState(ctx, source)
+		return err
+	})
+	return state, found, err
 }
 
 // PutSyncState records feed synchronization progress and persists the state file.
@@ -94,7 +114,13 @@ func (s *FileStore) PutSyncState(ctx context.Context, state SyncState) error {
 
 // Stats returns counts for persisted advisory data.
 func (s *FileStore) Stats(ctx context.Context) (Stats, error) {
-	return s.mem.Stats(ctx)
+	var stats Stats
+	err := s.read(ctx, func() error {
+		var err error
+		stats, err = s.mem.Stats(ctx)
+		return err
+	})
+	return stats, err
 }
 
 // PutSyncJob upserts a durable advisory feed synchronization job and persists the state file.
@@ -106,12 +132,25 @@ func (s *FileStore) PutSyncJob(ctx context.Context, job SyncJob) error {
 
 // GetSyncJob returns a durable advisory feed synchronization job.
 func (s *FileStore) GetSyncJob(ctx context.Context, id string) (SyncJob, bool, error) {
-	return s.mem.GetSyncJob(ctx, id)
+	var job SyncJob
+	found := false
+	err := s.read(ctx, func() error {
+		var err error
+		job, found, err = s.mem.GetSyncJob(ctx, id)
+		return err
+	})
+	return job, found, err
 }
 
 // ListDueSyncJobs returns sync jobs whose next run is due and whose lease is free or expired.
 func (s *FileStore) ListDueSyncJobs(ctx context.Context, now time.Time, limit int) ([]SyncJob, error) {
-	return s.mem.ListDueSyncJobs(ctx, now, limit)
+	var jobs []SyncJob
+	err := s.read(ctx, func() error {
+		var err error
+		jobs, err = s.mem.ListDueSyncJobs(ctx, now, limit)
+		return err
+	})
+	return jobs, err
 }
 
 // AcquireSyncJobLease leases a sync job for a worker and persists the state file.
@@ -209,6 +248,23 @@ func (s *FileStore) update(ctx context.Context, apply func() error) error {
 		return err
 	}
 	return s.saveLocked(ctx)
+}
+
+func (s *FileStore) read(ctx context.Context, apply func() error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	unlock, err := s.lockStateFile()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if err := s.load(ctx); err != nil {
+		return err
+	}
+	return apply()
 }
 
 func (s *FileStore) lockStateFile() (func(), error) {

--- a/internal/vulndb/filestore.go
+++ b/internal/vulndb/filestore.go
@@ -82,6 +82,13 @@ func (s *FileStore) ReplaceAffectedPackages(ctx context.Context, vulnerabilityID
 	})
 }
 
+// MoveAffectedPackages reassigns affected package rows and persists the state file.
+func (s *FileStore) MoveAffectedPackages(ctx context.Context, fromID string, toID string) error {
+	return s.update(ctx, func() error {
+		return s.mem.MoveAffectedPackages(ctx, fromID, toID)
+	})
+}
+
 // CandidateAffectedPackages returns all advisory package rows for an ecosystem/name pair.
 func (s *FileStore) CandidateAffectedPackages(ctx context.Context, query PackageQuery) ([]AffectedPackage, error) {
 	var packages []AffectedPackage

--- a/internal/vulndb/filestore.go
+++ b/internal/vulndb/filestore.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -43,10 +44,9 @@ func NewFileStore(ctx context.Context, path string) (*FileStore, error) {
 
 // UpsertVulnerability inserts or replaces a normalized advisory and persists the state file.
 func (s *FileStore) UpsertVulnerability(ctx context.Context, v Vulnerability) error {
-	if err := s.mem.UpsertVulnerability(ctx, v); err != nil {
-		return err
-	}
-	return s.save(ctx)
+	return s.update(ctx, func() error {
+		return s.mem.UpsertVulnerability(ctx, v)
+	})
 }
 
 // FindVulnerability returns an advisory by canonical ID or alias.
@@ -56,18 +56,16 @@ func (s *FileStore) FindVulnerability(ctx context.Context, idOrAlias string) (Vu
 
 // UpsertAffectedPackage inserts or replaces an affected package row and persists the state file.
 func (s *FileStore) UpsertAffectedPackage(ctx context.Context, pkg AffectedPackage) error {
-	if err := s.mem.UpsertAffectedPackage(ctx, pkg); err != nil {
-		return err
-	}
-	return s.save(ctx)
+	return s.update(ctx, func() error {
+		return s.mem.UpsertAffectedPackage(ctx, pkg)
+	})
 }
 
 // ReplaceAffectedPackages replaces affected package rows for one vulnerability/source and persists the state file.
 func (s *FileStore) ReplaceAffectedPackages(ctx context.Context, vulnerabilityID string, source string, packages []AffectedPackage) error {
-	if err := s.mem.ReplaceAffectedPackages(ctx, vulnerabilityID, source, packages); err != nil {
-		return err
-	}
-	return s.save(ctx)
+	return s.update(ctx, func() error {
+		return s.mem.ReplaceAffectedPackages(ctx, vulnerabilityID, source, packages)
+	})
 }
 
 // CandidateAffectedPackages returns all advisory package rows for an ecosystem/name pair.
@@ -82,10 +80,9 @@ func (s *FileStore) GetSyncState(ctx context.Context, source string) (SyncState,
 
 // PutSyncState records feed synchronization progress and persists the state file.
 func (s *FileStore) PutSyncState(ctx context.Context, state SyncState) error {
-	if err := s.mem.PutSyncState(ctx, state); err != nil {
-		return err
-	}
-	return s.save(ctx)
+	return s.update(ctx, func() error {
+		return s.mem.PutSyncState(ctx, state)
+	})
 }
 
 // Stats returns counts for persisted advisory data.
@@ -95,10 +92,9 @@ func (s *FileStore) Stats(ctx context.Context) (Stats, error) {
 
 // PutSyncJob upserts a durable advisory feed synchronization job and persists the state file.
 func (s *FileStore) PutSyncJob(ctx context.Context, job SyncJob) error {
-	if err := s.mem.PutSyncJob(ctx, job); err != nil {
-		return err
-	}
-	return s.save(ctx)
+	return s.update(ctx, func() error {
+		return s.mem.PutSyncJob(ctx, job)
+	})
 }
 
 // GetSyncJob returns a durable advisory feed synchronization job.
@@ -113,35 +109,34 @@ func (s *FileStore) ListDueSyncJobs(ctx context.Context, now time.Time, limit in
 
 // AcquireSyncJobLease leases a sync job for a worker and persists the state file.
 func (s *FileStore) AcquireSyncJobLease(ctx context.Context, id string, owner string, ttl time.Duration) (bool, error) {
-	acquired, err := s.mem.AcquireSyncJobLease(ctx, id, owner, ttl)
-	if err != nil || !acquired {
-		return acquired, err
-	}
-	return acquired, s.save(ctx)
+	acquired := false
+	err := s.update(ctx, func() error {
+		var err error
+		acquired, err = s.mem.AcquireSyncJobLease(ctx, id, owner, ttl)
+		return err
+	})
+	return acquired, err
 }
 
 // ReleaseSyncJobLease releases a sync job lease held by owner and persists the state file.
 func (s *FileStore) ReleaseSyncJobLease(ctx context.Context, id string, owner string) error {
-	if err := s.mem.ReleaseSyncJobLease(ctx, id, owner); err != nil {
-		return err
-	}
-	return s.save(ctx)
+	return s.update(ctx, func() error {
+		return s.mem.ReleaseSyncJobLease(ctx, id, owner)
+	})
 }
 
 // CompleteSyncJob records a successful sync job run and persists the state file.
 func (s *FileStore) CompleteSyncJob(ctx context.Context, id string, owner string, nextRunAt time.Time) error {
-	if err := s.mem.CompleteSyncJob(ctx, id, owner, nextRunAt); err != nil {
-		return err
-	}
-	return s.save(ctx)
+	return s.update(ctx, func() error {
+		return s.mem.CompleteSyncJob(ctx, id, owner, nextRunAt)
+	})
 }
 
 // FailSyncJob records a failed sync job run and persists the state file.
 func (s *FileStore) FailSyncJob(ctx context.Context, id string, owner string, nextRunAt time.Time, syncErr error) error {
-	if err := s.mem.FailSyncJob(ctx, id, owner, nextRunAt, syncErr); err != nil {
-		return err
-	}
-	return s.save(ctx)
+	return s.update(ctx, func() error {
+		return s.mem.FailSyncJob(ctx, id, owner, nextRunAt, syncErr)
+	})
 }
 
 func (s *FileStore) load(ctx context.Context) error {
@@ -150,47 +145,88 @@ func (s *FileStore) load(ctx context.Context) error {
 	}
 	data, err := os.ReadFile(s.path)
 	if errors.Is(err, os.ErrNotExist) {
+		s.mem = NewMemoryStore()
 		return nil
 	}
 	if err != nil {
 		return err
 	}
 	if len(data) == 0 {
+		s.mem = NewMemoryStore()
 		return nil
 	}
 	var state fileState
 	if err := json.Unmarshal(data, &state); err != nil {
 		return fmt.Errorf("decode vulndb state: %w", err)
 	}
+	mem := NewMemoryStore()
 	for _, vulnerability := range state.Vulnerabilities {
-		if err := s.mem.UpsertVulnerability(ctx, vulnerability); err != nil {
+		if err := mem.UpsertVulnerability(ctx, vulnerability); err != nil {
 			return err
 		}
 	}
 	for _, affected := range state.AffectedPackages {
-		if err := s.mem.UpsertAffectedPackage(ctx, affected); err != nil {
+		if err := mem.UpsertAffectedPackage(ctx, affected); err != nil {
 			return err
 		}
 	}
 	for _, syncState := range state.SyncStates {
-		if err := s.mem.PutSyncState(ctx, syncState); err != nil {
+		if err := mem.PutSyncState(ctx, syncState); err != nil {
 			return err
 		}
 	}
 	for _, syncJob := range state.SyncJobs {
-		if err := s.mem.PutSyncJob(ctx, syncJob); err != nil {
+		if err := mem.PutSyncJob(ctx, syncJob); err != nil {
 			return err
 		}
 	}
+	s.mem = mem
 	return nil
 }
 
-func (s *FileStore) save(ctx context.Context) error {
+func (s *FileStore) update(ctx context.Context, apply func() error) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	unlock, err := s.lockStateFile()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if err := s.load(ctx); err != nil {
+		return err
+	}
+	if err := apply(); err != nil {
+		return err
+	}
+	return s.saveLocked(ctx)
+}
+
+func (s *FileStore) lockStateFile() (func(), error) {
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	lock, err := os.OpenFile(s.path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		_ = lock.Close()
+		return nil, err
+	}
+	return func() {
+		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		_ = lock.Close()
+	}, nil
+}
+
+func (s *FileStore) saveLocked(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	state := s.snapshot()
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -451,6 +451,9 @@ func findVulnerabilityByAnyIdentifier(ctx context.Context, store Store, id strin
 		}
 	}
 	for _, duplicateID := range duplicateIDs {
+		if err := store.MoveAffectedPackages(ctx, duplicateID, merged.ID); err != nil {
+			return Vulnerability{}, false, err
+		}
 		if err := store.DeleteVulnerability(ctx, duplicateID); err != nil {
 			return Vulnerability{}, false, err
 		}

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -220,7 +220,7 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 		if sourceID == "" {
 			continue
 		}
-		existing, ok, err := findVulnerabilityByAnyIdentifier(ctx, store, sourceID, nil)
+		existing, ok, duplicateIDs, err := findVulnerabilityByAnyIdentifier(ctx, store, sourceID, nil)
 		if err != nil {
 			return ImportResult{}, err
 		}
@@ -263,6 +263,9 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 			}
 		}
 		if err := store.UpsertVulnerability(ctx, vulnerability); err != nil {
+			return ImportResult{}, err
+		}
+		if err := mergeDuplicateVulnerabilities(ctx, store, id, duplicateIDs); err != nil {
 			return ImportResult{}, err
 		}
 		result.Vulnerabilities++
@@ -318,7 +321,7 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 	if sourceID == "" {
 		return ImportResult{}, nil
 	}
-	existing, ok, err := findVulnerabilityByAnyIdentifier(ctx, store, sourceID, advisory.Aliases)
+	existing, ok, duplicateIDs, err := findVulnerabilityByAnyIdentifier(ctx, store, sourceID, advisory.Aliases)
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -366,6 +369,9 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 		})
 	}
 	if err := store.UpsertVulnerability(ctx, vulnerability); err != nil {
+		return ImportResult{}, err
+	}
+	if err := mergeDuplicateVulnerabilities(ctx, store, id, duplicateIDs); err != nil {
 		return ImportResult{}, err
 	}
 	result := ImportResult{Vulnerabilities: 1}
@@ -417,7 +423,7 @@ func replaceAffectedPackagesForCanonical(ctx context.Context, store Store, canon
 	return store.ReplaceAffectedPackages(ctx, canonicalID, source, packages)
 }
 
-func findVulnerabilityByAnyIdentifier(ctx context.Context, store Store, id string, aliases []string) (Vulnerability, bool, error) {
+func findVulnerabilityByAnyIdentifier(ctx context.Context, store Store, id string, aliases []string) (Vulnerability, bool, []string, error) {
 	identifiers := append([]string{id}, aliases...)
 	seen := map[string]struct{}{}
 	var merged Vulnerability
@@ -434,7 +440,7 @@ func findVulnerabilityByAnyIdentifier(ctx context.Context, store Store, id strin
 		seen[lookup] = struct{}{}
 		vulnerability, ok, err := store.FindVulnerability(ctx, lookup)
 		if err != nil {
-			return Vulnerability{}, false, err
+			return Vulnerability{}, false, nil, err
 		}
 		if ok {
 			if !found {
@@ -449,15 +455,24 @@ func findVulnerabilityByAnyIdentifier(ctx context.Context, store Store, id strin
 			merged = mergeVulnerabilityRecords(merged, vulnerability)
 		}
 	}
+	return merged, found, duplicateIDs, nil
+}
+
+func mergeDuplicateVulnerabilities(ctx context.Context, store Store, canonicalID string, duplicateIDs []string) error {
+	canonicalID = NormalizeIdentifier(canonicalID)
 	for _, duplicateID := range duplicateIDs {
-		if err := store.MoveAffectedPackages(ctx, duplicateID, merged.ID); err != nil {
-			return Vulnerability{}, false, err
+		duplicateID = NormalizeIdentifier(duplicateID)
+		if duplicateID == "" || duplicateID == canonicalID {
+			continue
+		}
+		if err := store.MoveAffectedPackages(ctx, duplicateID, canonicalID); err != nil {
+			return err
 		}
 		if err := store.DeleteVulnerability(ctx, duplicateID); err != nil {
-			return Vulnerability{}, false, err
+			return err
 		}
 	}
-	return merged, found, nil
+	return nil
 }
 
 func mergeVulnerabilityRecords(canonical Vulnerability, duplicate Vulnerability) Vulnerability {

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -238,6 +238,7 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 		if ok {
 			vulnerability.EPSS = existing.EPSS
 			vulnerability.KEV = existing.KEV
+			vulnerability.WithdrawnAt = existing.WithdrawnAt
 			if vulnerability.Summary == "" {
 				vulnerability.Summary = existing.Summary
 			}
@@ -258,12 +259,11 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 			return ImportResult{}, err
 		}
 		result.Vulnerabilities++
-		for _, affected := range nvdAffectedPackages(id, item.CVE.Configurations) {
-			if err := store.UpsertAffectedPackage(ctx, affected); err != nil {
-				return ImportResult{}, err
-			}
-			result.AffectedPackages++
+		affectedPackages := nvdAffectedPackages(id, item.CVE.Configurations)
+		if err := store.ReplaceAffectedPackages(ctx, id, SourceNVD, affectedPackages); err != nil {
+			return ImportResult{}, err
 		}
+		result.AffectedPackages += len(affectedPackages)
 	}
 	return result, recordSyncSuccess(ctx, store, SourceNVD)
 }
@@ -333,6 +333,9 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 	if ok {
 		vulnerability.EPSS = existing.EPSS
 		vulnerability.KEV = existing.KEV
+		if vulnerability.WithdrawnAt.IsZero() {
+			vulnerability.WithdrawnAt = existing.WithdrawnAt
+		}
 		if vulnerability.Summary == "" {
 			vulnerability.Summary = existing.Summary
 		}
@@ -363,6 +366,7 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 		return ImportResult{}, err
 	}
 	result := ImportResult{Vulnerabilities: 1}
+	affectedPackages := []AffectedPackage{}
 	for _, affected := range advisory.Affected {
 		ecosystem := normalizeEcosystem(affected.Package.Ecosystem)
 		name := strings.TrimSpace(affected.Package.Name)
@@ -373,25 +377,22 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 			if strings.TrimSpace(version) == "" {
 				continue
 			}
-			if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+			affectedPackages = append(affectedPackages, AffectedPackage{
 				VulnerabilityID:   id,
+				Source:            SourceOSV,
 				Ecosystem:         ecosystem,
 				PackageName:       name,
 				VulnerableVersion: strings.TrimSpace(version),
-			}); err != nil {
-				return ImportResult{}, err
-			}
-			result.AffectedPackages++
+			})
 		}
 		for _, affectedRange := range affected.Ranges {
-			for _, row := range osvRangeAffectedPackages(id, ecosystem, name, affectedRange) {
-				if err := store.UpsertAffectedPackage(ctx, row); err != nil {
-					return ImportResult{}, err
-				}
-				result.AffectedPackages++
-			}
+			affectedPackages = append(affectedPackages, osvRangeAffectedPackages(id, ecosystem, name, affectedRange)...)
 		}
 	}
+	if err := store.ReplaceAffectedPackages(ctx, id, SourceOSV, affectedPackages); err != nil {
+		return ImportResult{}, err
+	}
+	result.AffectedPackages = len(affectedPackages)
 	return result, nil
 }
 
@@ -444,6 +445,7 @@ func mergeVulnerabilityAliases(canonicalID string, groups ...[]string) []string 
 func osvRangeAffectedPackages(vulnerabilityID string, ecosystem string, packageName string, affectedRange osvRange) []AffectedPackage {
 	base := AffectedPackage{
 		VulnerabilityID: vulnerabilityID,
+		Source:          SourceOSV,
 		Ecosystem:       ecosystem,
 		PackageName:     packageName,
 		RangeType:       strings.TrimSpace(affectedRange.Type),
@@ -719,15 +721,17 @@ func nvdCPEAffectedPackage(vulnerabilityID string, match nvdCPEMatch) (AffectedP
 		return AffectedPackage{}, false
 	}
 	row := AffectedPackage{
-		VulnerabilityID: vulnerabilityID,
-		Ecosystem:       cpeEcosystem(cpe.Part),
-		PackageName:     cpePackageName(cpe.Vendor, cpe.Product),
-		RangeType:       "CPE",
-		Introduced:      firstNonEmpty(match.VersionStartIncluding, match.VersionStartExcluding),
-		Fixed:           strings.TrimSpace(match.VersionEndExcluding),
-		LastAffected:    strings.TrimSpace(match.VersionEndIncluding),
+		VulnerabilityID:     vulnerabilityID,
+		Source:              SourceNVD,
+		Ecosystem:           cpeEcosystem(cpe.Part),
+		PackageName:         cpePackageName(cpe.Vendor, cpe.Product),
+		RangeType:           "CPE",
+		Introduced:          strings.TrimSpace(match.VersionStartIncluding),
+		IntroducedExclusive: strings.TrimSpace(match.VersionStartExcluding),
+		Fixed:               strings.TrimSpace(match.VersionEndExcluding),
+		LastAffected:        strings.TrimSpace(match.VersionEndIncluding),
 	}
-	if row.Introduced == "" && row.Fixed == "" && row.LastAffected == "" && cpe.Version != "" && cpe.Version != "*" && cpe.Version != "-" {
+	if row.Introduced == "" && row.IntroducedExclusive == "" && row.Fixed == "" && row.LastAffected == "" && cpe.Version != "" && cpe.Version != "*" && cpe.Version != "-" {
 		row.VulnerableVersion = cpe.Version
 	}
 	if row.Ecosystem == "" || row.PackageName == "" {

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -238,7 +238,10 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 			ModifiedAt:  parseTime(item.CVE.LastModified),
 			References:  nvdReferences(item.CVE.References),
 		}
-		vulnerability.CVSSScore, vulnerability.Severity, vulnerability.CVSSVector = nvdCVSS(item.CVE.Metrics)
+		cvssScore, severity, cvssVector, hasCVSSScore := nvdCVSS(item.CVE.Metrics)
+		vulnerability.CVSSScore = cvssScore
+		vulnerability.Severity = severity
+		vulnerability.CVSSVector = cvssVector
 		if ok {
 			vulnerability.EPSS = existing.EPSS
 			vulnerability.KEV = existing.KEV
@@ -249,7 +252,7 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 			if vulnerability.Details == "" {
 				vulnerability.Details = existing.Details
 			}
-			if vulnerability.CVSSScore == 0 {
+			if !hasCVSSScore {
 				vulnerability.CVSSScore = existing.CVSSScore
 			}
 			if vulnerability.CVSSVector == "" {
@@ -325,7 +328,7 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 	}
 	vulnerability := Vulnerability{
 		ID:          id,
-		Aliases:     mergeVulnerabilityAliases(id, existing.Aliases, []string{sourceID}, advisory.Aliases),
+		Aliases:     mergeVulnerabilityAliases(id, []string{sourceID}, advisory.Aliases),
 		Summary:     strings.TrimSpace(advisory.Summary),
 		Details:     strings.TrimSpace(advisory.Details),
 		Source:      SourceOSV,
@@ -337,9 +340,6 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 	if ok {
 		vulnerability.EPSS = existing.EPSS
 		vulnerability.KEV = existing.KEV
-		if vulnerability.WithdrawnAt.IsZero() {
-			vulnerability.WithdrawnAt = existing.WithdrawnAt
-		}
 		if vulnerability.Summary == "" {
 			vulnerability.Summary = existing.Summary
 		}
@@ -571,6 +571,14 @@ func osvRangeAffectedPackages(vulnerabilityID string, ecosystem string, packageN
 			current.LastAffected = lastAffected
 			appendCurrent()
 		}
+		if limit := strings.TrimSpace(event.Limit); limit != "" {
+			if !hasCurrent {
+				current = base
+				hasCurrent = true
+			}
+			current.Fixed = limit
+			appendCurrent()
+		}
 	}
 	if hasCurrent {
 		appendCurrent()
@@ -622,6 +630,7 @@ type osvEvent struct {
 	Introduced   string `json:"introduced"`
 	Fixed        string `json:"fixed"`
 	LastAffected string `json:"last_affected"`
+	Limit        string `json:"limit"`
 }
 
 type kevCatalog struct {
@@ -757,7 +766,7 @@ func nvdReferences(references []nvdReference) []Reference {
 	return out
 }
 
-func nvdCVSS(metrics nvdMetrics) (float64, string, string) {
+func nvdCVSS(metrics nvdMetrics) (float64, string, string, bool) {
 	for _, candidates := range [][]nvdCVSSMetric{
 		metrics.CVSSMetricV40,
 		metrics.CVSSMetricV31,
@@ -768,9 +777,9 @@ func nvdCVSS(metrics nvdMetrics) (float64, string, string) {
 			continue
 		}
 		data := candidates[0].CVSSData
-		return data.BaseScore, strings.TrimSpace(data.BaseSeverity), strings.TrimSpace(data.VectorString)
+		return data.BaseScore, strings.TrimSpace(data.BaseSeverity), strings.TrimSpace(data.VectorString), true
 	}
-	return 0, "", ""
+	return 0, "", "", false
 }
 
 func nvdAffectedPackages(vulnerabilityID string, configurations []nvdConfiguration) []AffectedPackage {

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -1,0 +1,586 @@
+package vulndb
+
+import (
+	"bufio"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	SourceOSV     = "osv"
+	SourceCISAKEV = "cisa-kev"
+	SourceEPSS    = "epss"
+	SourceNVD     = "nvd"
+)
+
+// ImportResult summarizes imported feed records.
+type ImportResult struct {
+	Vulnerabilities  int
+	AffectedPackages int
+	Enrichments      int
+}
+
+// ImportOSV reads OSV JSON or JSONL advisories into the store.
+func ImportOSV(ctx context.Context, store Store, reader io.Reader) (ImportResult, error) {
+	if store == nil {
+		return ImportResult{}, fmt.Errorf("vulnerability store is required")
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	var advisories []osvAdvisory
+	if err := json.Unmarshal(data, &advisories); err == nil {
+		return importOSVAdvisories(ctx, store, advisories)
+	}
+
+	var result ImportResult
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return ImportResult{}, err
+		}
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var advisory osvAdvisory
+		if err := json.Unmarshal([]byte(line), &advisory); err != nil {
+			return ImportResult{}, err
+		}
+		imported, err := importOSVAdvisory(ctx, store, advisory)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		result.Vulnerabilities += imported.Vulnerabilities
+		result.AffectedPackages += imported.AffectedPackages
+	}
+	if err := scanner.Err(); err != nil {
+		return ImportResult{}, err
+	}
+	return result, recordSyncSuccess(ctx, store, SourceOSV)
+}
+
+// ImportCISAKEV reads the CISA Known Exploited Vulnerabilities catalog into the store.
+func ImportCISAKEV(ctx context.Context, store Store, reader io.Reader) (ImportResult, error) {
+	if store == nil {
+		return ImportResult{}, fmt.Errorf("vulnerability store is required")
+	}
+	var catalog kevCatalog
+	if err := json.NewDecoder(reader).Decode(&catalog); err != nil {
+		return ImportResult{}, err
+	}
+	var result ImportResult
+	now := time.Now().UTC()
+	for _, entry := range catalog.Vulnerabilities {
+		if err := ctx.Err(); err != nil {
+			return ImportResult{}, err
+		}
+		id := NormalizeIdentifier(entry.CVEID)
+		if id == "" {
+			continue
+		}
+		vulnerability, ok, err := store.FindVulnerability(ctx, id)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		if !ok {
+			vulnerability = Vulnerability{ID: id, Source: SourceCISAKEV}
+			result.Vulnerabilities++
+		}
+		if vulnerability.Summary == "" {
+			vulnerability.Summary = strings.TrimSpace(entry.VulnerabilityName)
+		}
+		if vulnerability.Details == "" {
+			vulnerability.Details = strings.TrimSpace(entry.ShortDescription)
+		}
+		dueDate, _ := parseDate(entry.DueDate)
+		updatedAt, _ := parseDate(firstNonEmpty(entry.DateUpdated, entry.DateAdded))
+		if updatedAt.IsZero() {
+			updatedAt = now
+		}
+		vulnerability.KEV = &KEV{
+			Listed:                     true,
+			KnownRansomwareCampaignUse: strings.TrimSpace(entry.KnownRansomwareCampaignUse),
+			RequiredAction:             strings.TrimSpace(entry.RequiredAction),
+			DueDate:                    dueDate,
+			UpdatedAt:                  updatedAt,
+			Notes:                      strings.TrimSpace(entry.Notes),
+		}
+		if err := store.UpsertVulnerability(ctx, vulnerability); err != nil {
+			return ImportResult{}, err
+		}
+		result.Enrichments++
+	}
+	return result, recordSyncSuccess(ctx, store, SourceCISAKEV)
+}
+
+// ImportEPSS reads FIRST EPSS CSV data into the store.
+func ImportEPSS(ctx context.Context, store Store, reader io.Reader) (ImportResult, error) {
+	if store == nil {
+		return ImportResult{}, fmt.Errorf("vulnerability store is required")
+	}
+	csvReader := csv.NewReader(skipCommentLines(reader))
+	csvReader.TrimLeadingSpace = true
+	header, err := csvReader.Read()
+	if err != nil {
+		return ImportResult{}, err
+	}
+	indexes := csvIndexes(header)
+	cveIndex, ok := indexes["cve"]
+	if !ok {
+		return ImportResult{}, fmt.Errorf("epss csv missing cve column")
+	}
+	epssIndex, ok := indexes["epss"]
+	if !ok {
+		return ImportResult{}, fmt.Errorf("epss csv missing epss column")
+	}
+	percentileIndex, ok := indexes["percentile"]
+	if !ok {
+		return ImportResult{}, fmt.Errorf("epss csv missing percentile column")
+	}
+	requiredIndex := maxInt(cveIndex, epssIndex, percentileIndex)
+	var result ImportResult
+	now := time.Now().UTC()
+	for {
+		if err := ctx.Err(); err != nil {
+			return ImportResult{}, err
+		}
+		record, err := csvReader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return ImportResult{}, err
+		}
+		if len(record) <= requiredIndex {
+			continue
+		}
+		id := NormalizeIdentifier(record[cveIndex])
+		if id == "" {
+			continue
+		}
+		score, err := strconv.ParseFloat(strings.TrimSpace(record[epssIndex]), 64)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		percentile, err := strconv.ParseFloat(strings.TrimSpace(record[percentileIndex]), 64)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		vulnerability, ok, err := store.FindVulnerability(ctx, id)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		if !ok {
+			vulnerability = Vulnerability{ID: id, Source: SourceEPSS}
+			result.Vulnerabilities++
+		}
+		vulnerability.EPSS = &EPSS{Score: score, Percentile: percentile, UpdatedAt: now}
+		if err := store.UpsertVulnerability(ctx, vulnerability); err != nil {
+			return ImportResult{}, err
+		}
+		result.Enrichments++
+	}
+	return result, recordSyncSuccess(ctx, store, SourceEPSS)
+}
+
+// ImportNVD reads NVD 2.0 CVE JSON data into the store.
+func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult, error) {
+	if store == nil {
+		return ImportResult{}, fmt.Errorf("vulnerability store is required")
+	}
+	var feed nvdFeed
+	if err := json.NewDecoder(reader).Decode(&feed); err != nil {
+		return ImportResult{}, err
+	}
+	var result ImportResult
+	for _, item := range feed.Vulnerabilities {
+		if err := ctx.Err(); err != nil {
+			return ImportResult{}, err
+		}
+		id := NormalizeIdentifier(item.CVE.ID)
+		if id == "" {
+			continue
+		}
+		vulnerability := Vulnerability{
+			ID:          id,
+			Summary:     nvdEnglishDescription(item.CVE.Descriptions),
+			Details:     nvdEnglishDescription(item.CVE.Descriptions),
+			Source:      SourceNVD,
+			PublishedAt: parseTime(item.CVE.Published),
+			ModifiedAt:  parseTime(item.CVE.LastModified),
+			References:  nvdReferences(item.CVE.References),
+		}
+		vulnerability.CVSSScore, vulnerability.Severity, vulnerability.CVSSVector = nvdCVSS(item.CVE.Metrics)
+		if existing, ok, err := store.FindVulnerability(ctx, id); err != nil {
+			return ImportResult{}, err
+		} else if ok {
+			vulnerability.Aliases = existing.Aliases
+			vulnerability.EPSS = existing.EPSS
+			vulnerability.KEV = existing.KEV
+			if vulnerability.Summary == "" {
+				vulnerability.Summary = existing.Summary
+			}
+			if vulnerability.Details == "" {
+				vulnerability.Details = existing.Details
+			}
+		}
+		if err := store.UpsertVulnerability(ctx, vulnerability); err != nil {
+			return ImportResult{}, err
+		}
+		result.Vulnerabilities++
+	}
+	return result, recordSyncSuccess(ctx, store, SourceNVD)
+}
+
+// ValidateFeedURL enforces transport policy for remote feed sync.
+func ValidateFeedURL(rawURL string, allowInsecureHTTP bool) error {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("feed URL must be absolute")
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "https":
+		return nil
+	case "http":
+		if allowInsecureHTTP {
+			return nil
+		}
+		return fmt.Errorf("insecure http feed URL requires allow-insecure-http")
+	default:
+		return fmt.Errorf("unsupported feed URL scheme %q", parsed.Scheme)
+	}
+}
+
+func importOSVAdvisories(ctx context.Context, store Store, advisories []osvAdvisory) (ImportResult, error) {
+	var result ImportResult
+	for _, advisory := range advisories {
+		imported, err := importOSVAdvisory(ctx, store, advisory)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		result.Vulnerabilities += imported.Vulnerabilities
+		result.AffectedPackages += imported.AffectedPackages
+	}
+	return result, recordSyncSuccess(ctx, store, SourceOSV)
+}
+
+func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (ImportResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ImportResult{}, err
+	}
+	id := NormalizeIdentifier(advisory.ID)
+	if id == "" {
+		return ImportResult{}, nil
+	}
+	vulnerability := Vulnerability{
+		ID:          id,
+		Aliases:     advisory.Aliases,
+		Summary:     strings.TrimSpace(advisory.Summary),
+		Details:     strings.TrimSpace(advisory.Details),
+		Source:      SourceOSV,
+		PublishedAt: parseTime(advisory.Published),
+		ModifiedAt:  parseTime(advisory.Modified),
+		WithdrawnAt: parseTime(advisory.Withdrawn),
+		References:  make([]Reference, 0, len(advisory.References)),
+	}
+	if existing, ok, err := store.FindVulnerability(ctx, id); err != nil {
+		return ImportResult{}, err
+	} else if ok {
+		vulnerability.EPSS = existing.EPSS
+		vulnerability.KEV = existing.KEV
+		if len(vulnerability.Aliases) == 0 {
+			vulnerability.Aliases = existing.Aliases
+		}
+	}
+	if len(advisory.Severity) > 0 {
+		vulnerability.CVSSVector = strings.TrimSpace(advisory.Severity[0].Score)
+		vulnerability.Severity = strings.TrimSpace(advisory.Severity[0].Type)
+	}
+	for _, reference := range advisory.References {
+		vulnerability.References = append(vulnerability.References, Reference{
+			URL:  strings.TrimSpace(reference.URL),
+			Type: strings.TrimSpace(reference.Type),
+		})
+	}
+	if err := store.UpsertVulnerability(ctx, vulnerability); err != nil {
+		return ImportResult{}, err
+	}
+	result := ImportResult{Vulnerabilities: 1}
+	for _, affected := range advisory.Affected {
+		ecosystem := normalizeEcosystem(affected.Package.Ecosystem)
+		name := strings.TrimSpace(affected.Package.Name)
+		if ecosystem == "" || name == "" {
+			continue
+		}
+		for _, version := range affected.Versions {
+			if strings.TrimSpace(version) == "" {
+				continue
+			}
+			if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+				VulnerabilityID:   id,
+				Ecosystem:         ecosystem,
+				PackageName:       name,
+				VulnerableVersion: strings.TrimSpace(version),
+			}); err != nil {
+				return ImportResult{}, err
+			}
+			result.AffectedPackages++
+		}
+		for _, affectedRange := range affected.Ranges {
+			events := affectedRange.Events
+			row := AffectedPackage{
+				VulnerabilityID: id,
+				Ecosystem:       ecosystem,
+				PackageName:     name,
+				RangeType:       strings.TrimSpace(affectedRange.Type),
+			}
+			for _, event := range events {
+				if event.Introduced != "" {
+					row.Introduced = strings.TrimSpace(event.Introduced)
+				}
+				if event.Fixed != "" {
+					row.Fixed = strings.TrimSpace(event.Fixed)
+				}
+				if event.LastAffected != "" {
+					row.LastAffected = strings.TrimSpace(event.LastAffected)
+				}
+			}
+			if row.Introduced == "" && row.Fixed == "" && row.LastAffected == "" {
+				continue
+			}
+			if err := store.UpsertAffectedPackage(ctx, row); err != nil {
+				return ImportResult{}, err
+			}
+			result.AffectedPackages++
+		}
+	}
+	return result, nil
+}
+
+type osvAdvisory struct {
+	ID         string         `json:"id"`
+	Aliases    []string       `json:"aliases"`
+	Summary    string         `json:"summary"`
+	Details    string         `json:"details"`
+	Modified   string         `json:"modified"`
+	Published  string         `json:"published"`
+	Withdrawn  string         `json:"withdrawn"`
+	Severity   []osvSeverity  `json:"severity"`
+	References []osvReference `json:"references"`
+	Affected   []osvAffected  `json:"affected"`
+}
+
+type osvSeverity struct {
+	Type  string `json:"type"`
+	Score string `json:"score"`
+}
+
+type osvReference struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+type osvAffected struct {
+	Package  osvPackage `json:"package"`
+	Ranges   []osvRange `json:"ranges"`
+	Versions []string   `json:"versions"`
+}
+
+type osvPackage struct {
+	Ecosystem string `json:"ecosystem"`
+	Name      string `json:"name"`
+	PURL      string `json:"purl"`
+}
+
+type osvRange struct {
+	Type   string     `json:"type"`
+	Events []osvEvent `json:"events"`
+}
+
+type osvEvent struct {
+	Introduced   string `json:"introduced"`
+	Fixed        string `json:"fixed"`
+	LastAffected string `json:"last_affected"`
+}
+
+type kevCatalog struct {
+	Vulnerabilities []kevEntry `json:"vulnerabilities"`
+}
+
+type kevEntry struct {
+	CVEID                      string `json:"cveID"`
+	VulnerabilityName          string `json:"vulnerabilityName"`
+	ShortDescription           string `json:"shortDescription"`
+	RequiredAction             string `json:"requiredAction"`
+	DueDate                    string `json:"dueDate"`
+	DateAdded                  string `json:"dateAdded"`
+	DateUpdated                string `json:"dateUpdated"`
+	KnownRansomwareCampaignUse string `json:"knownRansomwareCampaignUse"`
+	Notes                      string `json:"notes"`
+}
+
+type nvdFeed struct {
+	Vulnerabilities []nvdVulnerability `json:"vulnerabilities"`
+}
+
+type nvdVulnerability struct {
+	CVE nvdCVE `json:"cve"`
+}
+
+type nvdCVE struct {
+	ID           string           `json:"id"`
+	Published    string           `json:"published"`
+	LastModified string           `json:"lastModified"`
+	Descriptions []nvdDescription `json:"descriptions"`
+	Metrics      nvdMetrics       `json:"metrics"`
+	References   []nvdReference   `json:"references"`
+}
+
+type nvdDescription struct {
+	Lang  string `json:"lang"`
+	Value string `json:"value"`
+}
+
+type nvdReference struct {
+	URL    string   `json:"url"`
+	Source string   `json:"source"`
+	Tags   []string `json:"tags"`
+}
+
+type nvdMetrics struct {
+	CVSSMetricV40 []nvdCVSSMetric `json:"cvssMetricV40"`
+	CVSSMetricV31 []nvdCVSSMetric `json:"cvssMetricV31"`
+	CVSSMetricV30 []nvdCVSSMetric `json:"cvssMetricV30"`
+	CVSSMetricV2  []nvdCVSSMetric `json:"cvssMetricV2"`
+}
+
+type nvdCVSSMetric struct {
+	CVSSData nvdCVSSData `json:"cvssData"`
+}
+
+type nvdCVSSData struct {
+	BaseScore    float64 `json:"baseScore"`
+	BaseSeverity string  `json:"baseSeverity"`
+	VectorString string  `json:"vectorString"`
+}
+
+func parseTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05.000", "2006-01-02T15:04:05", "2006-01-02"} {
+		t, err := time.Parse(layout, value)
+		if err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func parseDate(value string) (time.Time, bool) {
+	t := parseTime(value)
+	return t, !t.IsZero()
+}
+
+func nvdEnglishDescription(descriptions []nvdDescription) string {
+	for _, description := range descriptions {
+		if strings.EqualFold(strings.TrimSpace(description.Lang), "en") && strings.TrimSpace(description.Value) != "" {
+			return strings.TrimSpace(description.Value)
+		}
+	}
+	for _, description := range descriptions {
+		if strings.TrimSpace(description.Value) != "" {
+			return strings.TrimSpace(description.Value)
+		}
+	}
+	return ""
+}
+
+func nvdReferences(references []nvdReference) []Reference {
+	if len(references) == 0 {
+		return nil
+	}
+	out := make([]Reference, 0, len(references))
+	for _, reference := range references {
+		refType := ""
+		if len(reference.Tags) > 0 {
+			refType = strings.Join(reference.Tags, ",")
+		} else {
+			refType = strings.TrimSpace(reference.Source)
+		}
+		out = append(out, Reference{URL: strings.TrimSpace(reference.URL), Type: refType})
+	}
+	return out
+}
+
+func nvdCVSS(metrics nvdMetrics) (float64, string, string) {
+	for _, candidates := range [][]nvdCVSSMetric{
+		metrics.CVSSMetricV40,
+		metrics.CVSSMetricV31,
+		metrics.CVSSMetricV30,
+		metrics.CVSSMetricV2,
+	} {
+		if len(candidates) == 0 {
+			continue
+		}
+		data := candidates[0].CVSSData
+		return data.BaseScore, strings.TrimSpace(data.BaseSeverity), strings.TrimSpace(data.VectorString)
+	}
+	return 0, "", ""
+}
+
+func csvIndexes(header []string) map[string]int {
+	indexes := make(map[string]int, len(header))
+	for i, column := range header {
+		indexes[strings.ToLower(strings.TrimSpace(column))] = i
+	}
+	return indexes
+}
+
+func skipCommentLines(reader io.Reader) io.Reader {
+	scanner := bufio.NewScanner(reader)
+	var builder strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+	}
+	return strings.NewReader(builder.String())
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func maxInt(values ...int) int {
+	max := 0
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -358,7 +358,6 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 	}
 	if len(advisory.Severity) > 0 {
 		vulnerability.CVSSVector = strings.TrimSpace(advisory.Severity[0].Score)
-		vulnerability.Severity = strings.TrimSpace(advisory.Severity[0].Type)
 	}
 	for _, reference := range advisory.References {
 		vulnerability.References = append(vulnerability.References, Reference{

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -212,12 +212,21 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 		if err := ctx.Err(); err != nil {
 			return ImportResult{}, err
 		}
-		id := NormalizeIdentifier(item.CVE.ID)
-		if id == "" {
+		sourceID := NormalizeIdentifier(item.CVE.ID)
+		if sourceID == "" {
 			continue
+		}
+		existing, ok, err := findVulnerabilityByAnyIdentifier(ctx, store, sourceID, nil)
+		if err != nil {
+			return ImportResult{}, err
+		}
+		id := sourceID
+		if ok {
+			id = existing.ID
 		}
 		vulnerability := Vulnerability{
 			ID:          id,
+			Aliases:     mergeVulnerabilityAliases(id, existing.Aliases, []string{sourceID}),
 			Summary:     nvdEnglishDescription(item.CVE.Descriptions),
 			Details:     nvdEnglishDescription(item.CVE.Descriptions),
 			Source:      SourceNVD,
@@ -226,10 +235,7 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 			References:  nvdReferences(item.CVE.References),
 		}
 		vulnerability.CVSSScore, vulnerability.Severity, vulnerability.CVSSVector = nvdCVSS(item.CVE.Metrics)
-		if existing, ok, err := store.FindVulnerability(ctx, id); err != nil {
-			return ImportResult{}, err
-		} else if ok {
-			vulnerability.Aliases = existing.Aliases
+		if ok {
 			vulnerability.EPSS = existing.EPSS
 			vulnerability.KEV = existing.KEV
 			if vulnerability.Summary == "" {
@@ -237,6 +243,15 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 			}
 			if vulnerability.Details == "" {
 				vulnerability.Details = existing.Details
+			}
+			if vulnerability.CVSSScore == 0 {
+				vulnerability.CVSSScore = existing.CVSSScore
+			}
+			if vulnerability.CVSSVector == "" {
+				vulnerability.CVSSVector = existing.CVSSVector
+			}
+			if vulnerability.Severity == "" {
+				vulnerability.Severity = existing.Severity
 			}
 		}
 		if err := store.UpsertVulnerability(ctx, vulnerability); err != nil {
@@ -292,13 +307,21 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 	if err := ctx.Err(); err != nil {
 		return ImportResult{}, err
 	}
-	id := NormalizeIdentifier(advisory.ID)
-	if id == "" {
+	sourceID := NormalizeIdentifier(advisory.ID)
+	if sourceID == "" {
 		return ImportResult{}, nil
+	}
+	existing, ok, err := findVulnerabilityByAnyIdentifier(ctx, store, sourceID, advisory.Aliases)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	id := sourceID
+	if ok {
+		id = existing.ID
 	}
 	vulnerability := Vulnerability{
 		ID:          id,
-		Aliases:     advisory.Aliases,
+		Aliases:     mergeVulnerabilityAliases(id, existing.Aliases, []string{sourceID}, advisory.Aliases),
 		Summary:     strings.TrimSpace(advisory.Summary),
 		Details:     strings.TrimSpace(advisory.Details),
 		Source:      SourceOSV,
@@ -307,13 +330,23 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 		WithdrawnAt: parseTime(advisory.Withdrawn),
 		References:  make([]Reference, 0, len(advisory.References)),
 	}
-	if existing, ok, err := store.FindVulnerability(ctx, id); err != nil {
-		return ImportResult{}, err
-	} else if ok {
+	if ok {
 		vulnerability.EPSS = existing.EPSS
 		vulnerability.KEV = existing.KEV
-		if len(vulnerability.Aliases) == 0 {
-			vulnerability.Aliases = existing.Aliases
+		if vulnerability.Summary == "" {
+			vulnerability.Summary = existing.Summary
+		}
+		if vulnerability.Details == "" {
+			vulnerability.Details = existing.Details
+		}
+		if vulnerability.CVSSScore == 0 {
+			vulnerability.CVSSScore = existing.CVSSScore
+		}
+		if vulnerability.CVSSVector == "" {
+			vulnerability.CVSSVector = existing.CVSSVector
+		}
+		if vulnerability.Severity == "" {
+			vulnerability.Severity = existing.Severity
 		}
 	}
 	if len(advisory.Severity) > 0 {
@@ -351,34 +384,113 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 			result.AffectedPackages++
 		}
 		for _, affectedRange := range affected.Ranges {
-			events := affectedRange.Events
-			row := AffectedPackage{
-				VulnerabilityID: id,
-				Ecosystem:       ecosystem,
-				PackageName:     name,
-				RangeType:       strings.TrimSpace(affectedRange.Type),
-			}
-			for _, event := range events {
-				if event.Introduced != "" {
-					row.Introduced = strings.TrimSpace(event.Introduced)
+			for _, row := range osvRangeAffectedPackages(id, ecosystem, name, affectedRange) {
+				if err := store.UpsertAffectedPackage(ctx, row); err != nil {
+					return ImportResult{}, err
 				}
-				if event.Fixed != "" {
-					row.Fixed = strings.TrimSpace(event.Fixed)
-				}
-				if event.LastAffected != "" {
-					row.LastAffected = strings.TrimSpace(event.LastAffected)
-				}
+				result.AffectedPackages++
 			}
-			if row.Introduced == "" && row.Fixed == "" && row.LastAffected == "" {
-				continue
-			}
-			if err := store.UpsertAffectedPackage(ctx, row); err != nil {
-				return ImportResult{}, err
-			}
-			result.AffectedPackages++
 		}
 	}
 	return result, nil
+}
+
+func findVulnerabilityByAnyIdentifier(ctx context.Context, store Store, id string, aliases []string) (Vulnerability, bool, error) {
+	identifiers := append([]string{id}, aliases...)
+	seen := map[string]struct{}{}
+	for _, identifier := range identifiers {
+		lookup := NormalizeIdentifier(identifier)
+		if lookup == "" {
+			continue
+		}
+		if _, ok := seen[lookup]; ok {
+			continue
+		}
+		seen[lookup] = struct{}{}
+		vulnerability, ok, err := store.FindVulnerability(ctx, lookup)
+		if err != nil {
+			return Vulnerability{}, false, err
+		}
+		if ok {
+			return vulnerability, true, nil
+		}
+	}
+	return Vulnerability{}, false, nil
+}
+
+func mergeVulnerabilityAliases(canonicalID string, groups ...[]string) []string {
+	canonicalID = NormalizeIdentifier(canonicalID)
+	seen := map[string]struct{}{}
+	if canonicalID != "" {
+		seen[canonicalID] = struct{}{}
+	}
+	aliases := []string{}
+	for _, group := range groups {
+		for _, value := range group {
+			alias := NormalizeIdentifier(value)
+			if alias == "" {
+				continue
+			}
+			if _, ok := seen[alias]; ok {
+				continue
+			}
+			seen[alias] = struct{}{}
+			aliases = append(aliases, alias)
+		}
+	}
+	return aliases
+}
+
+func osvRangeAffectedPackages(vulnerabilityID string, ecosystem string, packageName string, affectedRange osvRange) []AffectedPackage {
+	base := AffectedPackage{
+		VulnerabilityID: vulnerabilityID,
+		Ecosystem:       ecosystem,
+		PackageName:     packageName,
+		RangeType:       strings.TrimSpace(affectedRange.Type),
+	}
+	rows := []AffectedPackage{}
+	current := base
+	hasCurrent := false
+	appendCurrent := func() {
+		if current.Introduced == "" && current.Fixed == "" && current.LastAffected == "" {
+			current = base
+			hasCurrent = false
+			return
+		}
+		rows = append(rows, current)
+		current = base
+		hasCurrent = false
+	}
+	for _, event := range affectedRange.Events {
+		if introduced := strings.TrimSpace(event.Introduced); introduced != "" {
+			if hasCurrent {
+				appendCurrent()
+			}
+			current = base
+			current.Introduced = introduced
+			hasCurrent = true
+		}
+		if fixed := strings.TrimSpace(event.Fixed); fixed != "" {
+			if !hasCurrent {
+				current = base
+				hasCurrent = true
+			}
+			current.Fixed = fixed
+			appendCurrent()
+		}
+		if lastAffected := strings.TrimSpace(event.LastAffected); lastAffected != "" {
+			if !hasCurrent {
+				current = base
+				hasCurrent = true
+			}
+			current.LastAffected = lastAffected
+			appendCurrent()
+		}
+	}
+	if hasCurrent {
+		appendCurrent()
+	}
+	return rows
 }
 
 type osvAdvisory struct {

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -133,7 +133,11 @@ func ImportEPSS(ctx context.Context, store Store, reader io.Reader) (ImportResul
 	if store == nil {
 		return ImportResult{}, fmt.Errorf("vulnerability store is required")
 	}
-	csvReader := csv.NewReader(skipCommentLines(reader))
+	stripped, err := skipCommentLines(reader)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	csvReader := csv.NewReader(stripped)
 	csvReader.TrimLeadingSpace = true
 	header, err := csvReader.Read()
 	if err != nil {
@@ -608,6 +612,8 @@ type nvdConfiguration struct {
 }
 
 type nvdNode struct {
+	Operator string        `json:"operator"`
+	Negate   bool          `json:"negate"`
 	CPEMatch []nvdCPEMatch `json:"cpeMatch"`
 	Children []nvdNode     `json:"children"`
 }
@@ -699,6 +705,9 @@ func nvdAffectedPackages(vulnerabilityID string, configurations []nvdConfigurati
 }
 
 func nvdNodeAffectedPackages(vulnerabilityID string, node nvdNode) []AffectedPackage {
+	if node.Negate || strings.EqualFold(strings.TrimSpace(node.Operator), "AND") {
+		return nil
+	}
 	rows := make([]AffectedPackage, 0, len(node.CPEMatch))
 	for _, match := range node.CPEMatch {
 		row, ok := nvdCPEAffectedPackage(vulnerabilityID, match)
@@ -829,7 +838,7 @@ func csvIndexes(header []string) map[string]int {
 	return indexes
 }
 
-func skipCommentLines(reader io.Reader) io.Reader {
+func skipCommentLines(reader io.Reader) (io.Reader, error) {
 	scanner := bufio.NewScanner(reader)
 	var builder strings.Builder
 	for scanner.Scan() {
@@ -840,7 +849,10 @@ func skipCommentLines(reader io.Reader) io.Reader {
 		builder.WriteString(line)
 		builder.WriteByte('\n')
 	}
-	return strings.NewReader(builder.String())
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return strings.NewReader(builder.String()), nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -41,6 +41,10 @@ func ImportOSV(ctx context.Context, store Store, reader io.Reader) (ImportResult
 	if err := json.Unmarshal(data, &advisories); err == nil {
 		return importOSVAdvisories(ctx, store, advisories)
 	}
+	var advisory osvAdvisory
+	if err := json.Unmarshal(data, &advisory); err == nil && NormalizeIdentifier(advisory.ID) != "" {
+		return importOSVAdvisories(ctx, store, []osvAdvisory{advisory})
+	}
 
 	var result ImportResult
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
@@ -239,6 +243,12 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 			return ImportResult{}, err
 		}
 		result.Vulnerabilities++
+		for _, affected := range nvdAffectedPackages(id, item.CVE.Configurations) {
+			if err := store.UpsertAffectedPackage(ctx, affected); err != nil {
+				return ImportResult{}, err
+			}
+			result.AffectedPackages++
+		}
 	}
 	return result, recordSyncSuccess(ctx, store, SourceNVD)
 }
@@ -442,12 +452,13 @@ type nvdVulnerability struct {
 }
 
 type nvdCVE struct {
-	ID           string           `json:"id"`
-	Published    string           `json:"published"`
-	LastModified string           `json:"lastModified"`
-	Descriptions []nvdDescription `json:"descriptions"`
-	Metrics      nvdMetrics       `json:"metrics"`
-	References   []nvdReference   `json:"references"`
+	ID             string             `json:"id"`
+	Published      string             `json:"published"`
+	LastModified   string             `json:"lastModified"`
+	Descriptions   []nvdDescription   `json:"descriptions"`
+	Metrics        nvdMetrics         `json:"metrics"`
+	References     []nvdReference     `json:"references"`
+	Configurations []nvdConfiguration `json:"configurations"`
 }
 
 type nvdDescription struct {
@@ -476,6 +487,25 @@ type nvdCVSSData struct {
 	BaseScore    float64 `json:"baseScore"`
 	BaseSeverity string  `json:"baseSeverity"`
 	VectorString string  `json:"vectorString"`
+}
+
+type nvdConfiguration struct {
+	Nodes []nvdNode `json:"nodes"`
+}
+
+type nvdNode struct {
+	CPEMatch []nvdCPEMatch `json:"cpeMatch"`
+	Children []nvdNode     `json:"children"`
+}
+
+type nvdCPEMatch struct {
+	Vulnerable            bool   `json:"vulnerable"`
+	Criteria              string `json:"criteria"`
+	VersionStartIncluding string `json:"versionStartIncluding"`
+	VersionStartExcluding string `json:"versionStartExcluding"`
+	VersionEndIncluding   string `json:"versionEndIncluding"`
+	VersionEndExcluding   string `json:"versionEndExcluding"`
+	MatchCriteriaID       string `json:"matchCriteriaId"`
 }
 
 func parseTime(value string) time.Time {
@@ -542,6 +572,137 @@ func nvdCVSS(metrics nvdMetrics) (float64, string, string) {
 		return data.BaseScore, strings.TrimSpace(data.BaseSeverity), strings.TrimSpace(data.VectorString)
 	}
 	return 0, "", ""
+}
+
+func nvdAffectedPackages(vulnerabilityID string, configurations []nvdConfiguration) []AffectedPackage {
+	rows := []AffectedPackage{}
+	for _, configuration := range configurations {
+		for _, node := range configuration.Nodes {
+			rows = append(rows, nvdNodeAffectedPackages(vulnerabilityID, node)...)
+		}
+	}
+	return rows
+}
+
+func nvdNodeAffectedPackages(vulnerabilityID string, node nvdNode) []AffectedPackage {
+	rows := make([]AffectedPackage, 0, len(node.CPEMatch))
+	for _, match := range node.CPEMatch {
+		row, ok := nvdCPEAffectedPackage(vulnerabilityID, match)
+		if ok {
+			rows = append(rows, row)
+		}
+	}
+	for _, child := range node.Children {
+		rows = append(rows, nvdNodeAffectedPackages(vulnerabilityID, child)...)
+	}
+	return rows
+}
+
+func nvdCPEAffectedPackage(vulnerabilityID string, match nvdCPEMatch) (AffectedPackage, bool) {
+	if !match.Vulnerable {
+		return AffectedPackage{}, false
+	}
+	cpe, ok := parseCPE23(match.Criteria)
+	if !ok {
+		return AffectedPackage{}, false
+	}
+	row := AffectedPackage{
+		VulnerabilityID: vulnerabilityID,
+		Ecosystem:       cpeEcosystem(cpe.Part),
+		PackageName:     cpePackageName(cpe.Vendor, cpe.Product),
+		RangeType:       "CPE",
+		Introduced:      firstNonEmpty(match.VersionStartIncluding, match.VersionStartExcluding),
+		Fixed:           strings.TrimSpace(match.VersionEndExcluding),
+		LastAffected:    strings.TrimSpace(match.VersionEndIncluding),
+	}
+	if row.Introduced == "" && row.Fixed == "" && row.LastAffected == "" && cpe.Version != "" && cpe.Version != "*" && cpe.Version != "-" {
+		row.VulnerableVersion = cpe.Version
+	}
+	if row.Ecosystem == "" || row.PackageName == "" {
+		return AffectedPackage{}, false
+	}
+	return row, true
+}
+
+type cpe23 struct {
+	Part    string
+	Vendor  string
+	Product string
+	Version string
+}
+
+func parseCPE23(criteria string) (cpe23, bool) {
+	fields := splitCPE23(criteria)
+	if len(fields) < 6 || fields[0] != "cpe" || fields[1] != "2.3" {
+		return cpe23{}, false
+	}
+	return cpe23{
+		Part:    strings.TrimSpace(fields[2]),
+		Vendor:  cleanCPEComponent(fields[3]),
+		Product: cleanCPEComponent(fields[4]),
+		Version: cleanCPEComponent(fields[5]),
+	}, true
+}
+
+func splitCPE23(value string) []string {
+	var fields []string
+	var current strings.Builder
+	escaped := false
+	for _, r := range strings.TrimSpace(value) {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if r == ':' {
+			fields = append(fields, current.String())
+			current.Reset()
+			continue
+		}
+		current.WriteRune(r)
+	}
+	if escaped {
+		current.WriteRune('\\')
+	}
+	fields = append(fields, current.String())
+	return fields
+}
+
+func cleanCPEComponent(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "*" || value == "-" {
+		return ""
+	}
+	return strings.NewReplacer("\\:", ":", "\\_", "_", "\\\\", "\\").Replace(value)
+}
+
+func cpeEcosystem(part string) string {
+	switch strings.ToLower(strings.TrimSpace(part)) {
+	case "a":
+		return "cpe:application"
+	case "o":
+		return "cpe:operating-system"
+	case "h":
+		return "cpe:hardware"
+	default:
+		return ""
+	}
+}
+
+func cpePackageName(vendor string, product string) string {
+	vendor = strings.TrimSpace(vendor)
+	product = strings.TrimSpace(product)
+	if product == "" {
+		return ""
+	}
+	if vendor == "" {
+		return product
+	}
+	return vendor + ":" + product
 }
 
 func csvIndexes(header []string) map[string]int {

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -411,6 +411,9 @@ func replaceAffectedPackagesForCanonical(ctx context.Context, store Store, canon
 		if err := store.ReplaceAffectedPackages(ctx, id, source, nil); err != nil {
 			return err
 		}
+		if err := store.DeleteVulnerability(ctx, id); err != nil {
+			return err
+		}
 	}
 	return store.ReplaceAffectedPackages(ctx, canonicalID, source, packages)
 }
@@ -418,6 +421,9 @@ func replaceAffectedPackagesForCanonical(ctx context.Context, store Store, canon
 func findVulnerabilityByAnyIdentifier(ctx context.Context, store Store, id string, aliases []string) (Vulnerability, bool, error) {
 	identifiers := append([]string{id}, aliases...)
 	seen := map[string]struct{}{}
+	var merged Vulnerability
+	found := false
+	duplicateIDs := []string{}
 	for _, identifier := range identifiers {
 		lookup := NormalizeIdentifier(identifier)
 		if lookup == "" {
@@ -432,10 +438,68 @@ func findVulnerabilityByAnyIdentifier(ctx context.Context, store Store, id strin
 			return Vulnerability{}, false, err
 		}
 		if ok {
-			return vulnerability, true, nil
+			if !found {
+				merged = vulnerability
+				found = true
+				continue
+			}
+			if vulnerability.ID == merged.ID {
+				continue
+			}
+			duplicateIDs = append(duplicateIDs, vulnerability.ID)
+			merged = mergeVulnerabilityRecords(merged, vulnerability)
 		}
 	}
-	return Vulnerability{}, false, nil
+	for _, duplicateID := range duplicateIDs {
+		if err := store.DeleteVulnerability(ctx, duplicateID); err != nil {
+			return Vulnerability{}, false, err
+		}
+	}
+	return merged, found, nil
+}
+
+func mergeVulnerabilityRecords(canonical Vulnerability, duplicate Vulnerability) Vulnerability {
+	merged := canonical
+	merged.Aliases = mergeVulnerabilityAliases(merged.ID, []string{canonical.ID}, canonical.Aliases, []string{duplicate.ID}, duplicate.Aliases)
+	if merged.Summary == "" {
+		merged.Summary = duplicate.Summary
+	}
+	if merged.Details == "" {
+		merged.Details = duplicate.Details
+	}
+	if merged.Severity == "" {
+		merged.Severity = duplicate.Severity
+	}
+	if merged.CVSSScore == 0 {
+		merged.CVSSScore = duplicate.CVSSScore
+	}
+	if merged.CVSSVector == "" {
+		merged.CVSSVector = duplicate.CVSSVector
+	}
+	if merged.PublishedAt.IsZero() {
+		merged.PublishedAt = duplicate.PublishedAt
+	}
+	if merged.ModifiedAt.IsZero() {
+		merged.ModifiedAt = duplicate.ModifiedAt
+	}
+	if merged.WithdrawnAt.IsZero() {
+		merged.WithdrawnAt = duplicate.WithdrawnAt
+	}
+	if merged.Source == "" {
+		merged.Source = duplicate.Source
+	}
+	if len(merged.References) == 0 {
+		merged.References = append([]Reference(nil), duplicate.References...)
+	}
+	if merged.EPSS == nil && duplicate.EPSS != nil {
+		epss := *duplicate.EPSS
+		merged.EPSS = &epss
+	}
+	if merged.KEV == nil && duplicate.KEV != nil {
+		kev := *duplicate.KEV
+		merged.KEV = &kev
+	}
+	return merged
 }
 
 func mergeVulnerabilityAliases(canonicalID string, groups ...[]string) []string {

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -264,7 +264,7 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 		}
 		result.Vulnerabilities++
 		affectedPackages := nvdAffectedPackages(id, item.CVE.Configurations)
-		if err := store.ReplaceAffectedPackages(ctx, id, SourceNVD, affectedPackages); err != nil {
+		if err := replaceAffectedPackagesForCanonical(ctx, store, id, SourceNVD, affectedPackages, []string{sourceID}); err != nil {
 			return ImportResult{}, err
 		}
 		result.AffectedPackages += len(affectedPackages)
@@ -393,11 +393,26 @@ func importOSVAdvisory(ctx context.Context, store Store, advisory osvAdvisory) (
 			affectedPackages = append(affectedPackages, osvRangeAffectedPackages(id, ecosystem, name, affectedRange)...)
 		}
 	}
-	if err := store.ReplaceAffectedPackages(ctx, id, SourceOSV, affectedPackages); err != nil {
+	identifiers := append([]string{sourceID}, advisory.Aliases...)
+	if err := replaceAffectedPackagesForCanonical(ctx, store, id, SourceOSV, affectedPackages, identifiers); err != nil {
 		return ImportResult{}, err
 	}
 	result.AffectedPackages = len(affectedPackages)
 	return result, nil
+}
+
+func replaceAffectedPackagesForCanonical(ctx context.Context, store Store, canonicalID string, source string, packages []AffectedPackage, identifiers []string) error {
+	canonicalID = NormalizeIdentifier(canonicalID)
+	for _, identifier := range identifiers {
+		id := NormalizeIdentifier(identifier)
+		if id == "" || id == canonicalID {
+			continue
+		}
+		if err := store.ReplaceAffectedPackages(ctx, id, source, nil); err != nil {
+			return err
+		}
+	}
+	return store.ReplaceAffectedPackages(ctx, canonicalID, source, packages)
 }
 
 func findVulnerabilityByAnyIdentifier(ctx context.Context, store Store, id string, aliases []string) (Vulnerability, bool, error) {

--- a/internal/vulndb/matcher.go
+++ b/internal/vulndb/matcher.go
@@ -1,0 +1,146 @@
+package vulndb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Matcher evaluates installed package inventory against the advisory store.
+type Matcher struct {
+	store Store
+}
+
+// NewMatcher constructs a package vulnerability matcher.
+func NewMatcher(store Store) (*Matcher, error) {
+	if store == nil {
+		return nil, fmt.Errorf("vulnerability store is required")
+	}
+	return &Matcher{store: store}, nil
+}
+
+// MatchPackage returns non-withdrawn vulnerability matches for an installed package.
+func (m *Matcher) MatchPackage(ctx context.Context, query PackageQuery) ([]Match, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	query.Ecosystem = normalizeEcosystem(query.Ecosystem)
+	query.Name = strings.TrimSpace(query.Name)
+	query.Version = strings.TrimSpace(query.Version)
+	if query.Ecosystem == "" || query.Name == "" || query.Version == "" {
+		return nil, nil
+	}
+	candidates, err := m.store.CandidateAffectedPackages(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]Match, 0, len(candidates))
+	for _, candidate := range candidates {
+		if !affectsVersion(query, candidate) {
+			continue
+		}
+		vulnerability, ok, err := m.store.FindVulnerability(ctx, candidate.VulnerabilityID)
+		if err != nil {
+			return nil, err
+		}
+		if !ok || !vulnerability.WithdrawnAt.IsZero() {
+			continue
+		}
+		matches = append(matches, Match{
+			Vulnerability:   vulnerability,
+			AffectedPackage: candidate,
+		})
+	}
+	return matches, nil
+}
+
+func affectsVersion(query PackageQuery, affected AffectedPackage) bool {
+	version := strings.TrimSpace(query.Version)
+	if version == "" {
+		return false
+	}
+	if exact := strings.TrimSpace(affected.VulnerableVersion); exact != "" {
+		return normalizeVersion(version) == normalizeVersion(exact)
+	}
+	if fixed := strings.TrimSpace(affected.Fixed); fixed != "" {
+		cmp, ok := compareVersion(version, fixed)
+		if !ok || cmp >= 0 {
+			return false
+		}
+	}
+	if introduced := strings.TrimSpace(affected.Introduced); introduced != "" {
+		cmp, ok := compareVersion(version, introduced)
+		if !ok || cmp < 0 {
+			return false
+		}
+	}
+	if lastAffected := strings.TrimSpace(affected.LastAffected); lastAffected != "" {
+		cmp, ok := compareVersion(version, lastAffected)
+		if !ok || cmp > 0 {
+			return false
+		}
+	}
+	return strings.TrimSpace(affected.Fixed) != "" ||
+		strings.TrimSpace(affected.Introduced) != "" ||
+		strings.TrimSpace(affected.LastAffected) != ""
+}
+
+func compareVersion(left string, right string) (int, bool) {
+	leftParts, ok := numericVersionParts(left)
+	if !ok {
+		return 0, false
+	}
+	rightParts, ok := numericVersionParts(right)
+	if !ok {
+		return 0, false
+	}
+	maxParts := len(leftParts)
+	if len(rightParts) > maxParts {
+		maxParts = len(rightParts)
+	}
+	for i := 0; i < maxParts; i++ {
+		leftPart := 0
+		if i < len(leftParts) {
+			leftPart = leftParts[i]
+		}
+		rightPart := 0
+		if i < len(rightParts) {
+			rightPart = rightParts[i]
+		}
+		if leftPart < rightPart {
+			return -1, true
+		}
+		if leftPart > rightPart {
+			return 1, true
+		}
+	}
+	return 0, true
+}
+
+func numericVersionParts(version string) ([]int, bool) {
+	version = normalizeVersion(version)
+	version = strings.TrimPrefix(version, "v")
+	if version == "" {
+		return nil, false
+	}
+	fields := strings.FieldsFunc(version, func(r rune) bool {
+		return r == '.' || r == '-' || r == '_' || r == '+'
+	})
+	parts := make([]int, 0, len(fields))
+	for _, field := range fields {
+		if field == "" {
+			continue
+		}
+		value, err := strconv.Atoi(field)
+		if err != nil {
+			break
+		}
+		parts = append(parts, value)
+	}
+	return parts, len(parts) > 0
+}
+
+func normalizeVersion(version string) string {
+	return strings.ToLower(strings.TrimSpace(version))
+}

--- a/internal/vulndb/matcher.go
+++ b/internal/vulndb/matcher.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 // Matcher evaluates installed package inventory against the advisory store.
@@ -75,6 +76,12 @@ func affectsVersion(query PackageQuery, affected AffectedPackage) bool {
 			return false
 		}
 	}
+	if introducedExclusive := strings.TrimSpace(affected.IntroducedExclusive); introducedExclusive != "" {
+		cmp, ok := compareVersion(version, introducedExclusive)
+		if !ok || cmp <= 0 {
+			return false
+		}
+	}
 	if lastAffected := strings.TrimSpace(affected.LastAffected); lastAffected != "" {
 		cmp, ok := compareVersion(version, lastAffected)
 		if !ok || cmp > 0 {
@@ -83,61 +90,112 @@ func affectsVersion(query PackageQuery, affected AffectedPackage) bool {
 	}
 	return strings.TrimSpace(affected.Fixed) != "" ||
 		strings.TrimSpace(affected.Introduced) != "" ||
+		strings.TrimSpace(affected.IntroducedExclusive) != "" ||
 		strings.TrimSpace(affected.LastAffected) != ""
 }
 
 func compareVersion(left string, right string) (int, bool) {
-	leftParts, ok := numericVersionParts(left)
+	leftParts, ok := versionParts(left)
 	if !ok {
 		return 0, false
 	}
-	rightParts, ok := numericVersionParts(right)
+	rightParts, ok := versionParts(right)
 	if !ok {
 		return 0, false
 	}
-	maxParts := len(leftParts)
-	if len(rightParts) > maxParts {
-		maxParts = len(rightParts)
+	for len(leftParts) > 0 && leftParts[len(leftParts)-1].numeric && leftParts[len(leftParts)-1].number == 0 {
+		leftParts = leftParts[:len(leftParts)-1]
 	}
+	for len(rightParts) > 0 && rightParts[len(rightParts)-1].numeric && rightParts[len(rightParts)-1].number == 0 {
+		rightParts = rightParts[:len(rightParts)-1]
+	}
+	maxParts := maxInt(len(leftParts), len(rightParts))
 	for i := 0; i < maxParts; i++ {
-		leftPart := 0
-		if i < len(leftParts) {
-			leftPart = leftParts[i]
-		}
-		rightPart := 0
-		if i < len(rightParts) {
-			rightPart = rightParts[i]
-		}
-		if leftPart < rightPart {
+		if i >= len(leftParts) {
+			if rightParts[i].numeric && rightParts[i].number == 0 {
+				continue
+			}
 			return -1, true
 		}
-		if leftPart > rightPart {
+		if i >= len(rightParts) {
+			if leftParts[i].numeric && leftParts[i].number == 0 {
+				continue
+			}
 			return 1, true
+		}
+		cmp := compareVersionPart(leftParts[i], rightParts[i])
+		if cmp != 0 {
+			return cmp, true
 		}
 	}
 	return 0, true
 }
 
-func numericVersionParts(version string) ([]int, bool) {
+type versionPart struct {
+	numeric bool
+	number  int
+	text    string
+}
+
+func compareVersionPart(left versionPart, right versionPart) int {
+	if left.numeric && right.numeric {
+		if left.number < right.number {
+			return -1
+		}
+		if left.number > right.number {
+			return 1
+		}
+		return 0
+	}
+	if left.numeric != right.numeric {
+		if left.numeric {
+			return -1
+		}
+		return 1
+	}
+	return strings.Compare(left.text, right.text)
+}
+
+func versionParts(version string) ([]versionPart, bool) {
 	version = normalizeVersion(version)
 	version = strings.TrimPrefix(version, "v")
 	if version == "" {
 		return nil, false
 	}
-	fields := strings.FieldsFunc(version, func(r rune) bool {
-		return r == '.' || r == '-' || r == '_' || r == '+'
-	})
-	parts := make([]int, 0, len(fields))
-	for _, field := range fields {
-		if field == "" {
+	parts := []versionPart{}
+	var current strings.Builder
+	currentNumeric := false
+	hasCurrent := false
+	flush := func() {
+		if !hasCurrent {
+			return
+		}
+		text := current.String()
+		if currentNumeric {
+			value, err := strconv.Atoi(text)
+			if err == nil {
+				parts = append(parts, versionPart{numeric: true, number: value})
+			}
+		} else {
+			parts = append(parts, versionPart{text: text})
+		}
+		current.Reset()
+		hasCurrent = false
+	}
+	for _, r := range version {
+		if r == '.' || r == '-' || r == '_' || r == '+' {
+			flush()
 			continue
 		}
-		value, err := strconv.Atoi(field)
-		if err != nil {
-			break
+		numeric := unicode.IsDigit(r)
+		if hasCurrent && numeric != currentNumeric {
+			flush()
 		}
-		parts = append(parts, value)
+		currentNumeric = numeric
+		hasCurrent = true
+		current.WriteRune(r)
 	}
+	flush()
 	return parts, len(parts) > 0
 }
 

--- a/internal/vulndb/matcher.go
+++ b/internal/vulndb/matcher.go
@@ -236,6 +236,9 @@ func compareVersionPart(left versionPart, right versionPart) int {
 func versionParts(version string) ([]versionPart, bool) {
 	version = normalizeVersion(version)
 	version = strings.TrimPrefix(version, "v")
+	if plus := strings.Index(version, "+"); plus >= 0 {
+		version = version[:plus]
+	}
 	if version == "" {
 		return nil, false
 	}

--- a/internal/vulndb/matcher.go
+++ b/internal/vulndb/matcher.go
@@ -110,8 +110,8 @@ func compareVersion(left string, right string) (int, bool) {
 		rightParts = rightParts[:len(rightParts)-1]
 	}
 	if equalVersionCore(leftParts, rightParts) {
-		leftPrerelease := hasSemverPrerelease(left)
-		rightPrerelease := hasSemverPrerelease(right)
+		leftPrerelease := hasPrerelease(left)
+		rightPrerelease := hasPrerelease(right)
 		if leftPrerelease != rightPrerelease {
 			if leftPrerelease {
 				return -1, true
@@ -156,12 +156,33 @@ func versionCoreParts(parts []versionPart) []versionPart {
 	return parts
 }
 
-func hasSemverPrerelease(version string) bool {
+func hasPrerelease(version string) bool {
 	version = strings.TrimPrefix(normalizeVersion(version), "v")
 	if plus := strings.Index(version, "+"); plus >= 0 {
 		version = version[:plus]
 	}
-	return strings.Contains(version, "-")
+	if strings.Contains(version, "-") {
+		return true
+	}
+	parts, ok := versionParts(version)
+	if !ok {
+		return false
+	}
+	for _, part := range parts {
+		if !part.numeric && isPrereleaseToken(part.text) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPrereleaseToken(token string) bool {
+	switch token {
+	case "a", "alpha", "b", "beta", "c", "pre", "preview", "rc", "dev":
+		return true
+	default:
+		return false
+	}
 }
 
 func compareVersionParts(leftParts []versionPart, rightParts []versionPart) int {

--- a/internal/vulndb/matcher.go
+++ b/internal/vulndb/matcher.go
@@ -109,6 +109,16 @@ func compareVersion(left string, right string) (int, bool) {
 	for len(rightParts) > 0 && rightParts[len(rightParts)-1].numeric && rightParts[len(rightParts)-1].number == 0 {
 		rightParts = rightParts[:len(rightParts)-1]
 	}
+	if equalVersionCore(leftParts, rightParts) {
+		leftPrerelease := hasSemverPrerelease(left)
+		rightPrerelease := hasSemverPrerelease(right)
+		if leftPrerelease != rightPrerelease {
+			if leftPrerelease {
+				return -1, true
+			}
+			return 1, true
+		}
+	}
 	maxParts := maxInt(len(leftParts), len(rightParts))
 	for i := 0; i < maxParts; i++ {
 		if i >= len(leftParts) {
@@ -129,6 +139,52 @@ func compareVersion(left string, right string) (int, bool) {
 		}
 	}
 	return 0, true
+}
+
+func equalVersionCore(leftParts []versionPart, rightParts []versionPart) bool {
+	leftCore := versionCoreParts(leftParts)
+	rightCore := versionCoreParts(rightParts)
+	return compareVersionParts(leftCore, rightCore) == 0
+}
+
+func versionCoreParts(parts []versionPart) []versionPart {
+	for i, part := range parts {
+		if !part.numeric {
+			return parts[:i]
+		}
+	}
+	return parts
+}
+
+func hasSemverPrerelease(version string) bool {
+	version = strings.TrimPrefix(normalizeVersion(version), "v")
+	if plus := strings.Index(version, "+"); plus >= 0 {
+		version = version[:plus]
+	}
+	return strings.Contains(version, "-")
+}
+
+func compareVersionParts(leftParts []versionPart, rightParts []versionPart) int {
+	maxParts := maxInt(len(leftParts), len(rightParts))
+	for i := 0; i < maxParts; i++ {
+		if i >= len(leftParts) {
+			if rightParts[i].numeric && rightParts[i].number == 0 {
+				continue
+			}
+			return -1
+		}
+		if i >= len(rightParts) {
+			if leftParts[i].numeric && leftParts[i].number == 0 {
+				continue
+			}
+			return 1
+		}
+		cmp := compareVersionPart(leftParts[i], rightParts[i])
+		if cmp != 0 {
+			return cmp
+		}
+	}
+	return 0
 }
 
 type versionPart struct {

--- a/internal/vulndb/models.go
+++ b/internal/vulndb/models.go
@@ -1,0 +1,164 @@
+package vulndb
+
+import (
+	"strings"
+	"time"
+)
+
+// Vulnerability is a normalized advisory record keyed by a stable vulnerability ID.
+type Vulnerability struct {
+	ID          string
+	Aliases     []string
+	Summary     string
+	Details     string
+	Severity    string
+	CVSSScore   float64
+	CVSSVector  string
+	PublishedAt time.Time
+	ModifiedAt  time.Time
+	WithdrawnAt time.Time
+	Source      string
+	References  []Reference
+	EPSS        *EPSS
+	KEV         *KEV
+}
+
+// Reference points to upstream advisory or vendor context.
+type Reference struct {
+	URL  string
+	Type string
+}
+
+// EPSS stores Exploit Prediction Scoring System enrichment.
+type EPSS struct {
+	Score      float64
+	Percentile float64
+	UpdatedAt  time.Time
+}
+
+// KEV stores CISA Known Exploited Vulnerability enrichment.
+type KEV struct {
+	Listed                     bool
+	KnownRansomwareCampaignUse string
+	RequiredAction             string
+	DueDate                    time.Time
+	UpdatedAt                  time.Time
+	Notes                      string
+}
+
+// AffectedPackage describes one package/version range affected by a vulnerability.
+type AffectedPackage struct {
+	VulnerabilityID   string
+	Ecosystem         string
+	PackageName       string
+	RangeType         string
+	Introduced        string
+	Fixed             string
+	LastAffected      string
+	VulnerableVersion string
+	DistroName        string
+	DistroVersion     string
+}
+
+// PackageQuery identifies an installed package to match against advisories.
+type PackageQuery struct {
+	Ecosystem string
+	Name      string
+	Version   string
+}
+
+// Match ties an installed package to a matching advisory and affected range.
+type Match struct {
+	Vulnerability   Vulnerability
+	AffectedPackage AffectedPackage
+}
+
+// SyncState tracks durable per-source feed synchronization progress.
+type SyncState struct {
+	Source        string
+	Cursor        string
+	ETag          string
+	LastSyncedAt  time.Time
+	LastSuccessAt time.Time
+	LastError     string
+}
+
+// SyncJob tracks durable advisory feed synchronization work.
+type SyncJob struct {
+	ID                string
+	Source            string
+	FeedURL           string
+	AllowInsecureHTTP bool
+	Interval          time.Duration
+	NextRunAt         time.Time
+	LeaseOwner        string
+	LeaseExpiresAt    time.Time
+	LastStartedAt     time.Time
+	LastFinishedAt    time.Time
+	LastSuccessAt     time.Time
+	LastError         string
+	Runs              int64
+}
+
+// Stats summarizes persisted advisory data.
+type Stats struct {
+	Vulnerabilities  int
+	AffectedPackages int
+	SyncSources      int
+	SyncJobs         int
+}
+
+// NormalizeIdentifier canonicalizes vulnerability identifiers and aliases.
+func NormalizeIdentifier(value string) string {
+	return strings.ToUpper(strings.TrimSpace(value))
+}
+
+func normalizeEcosystem(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizePackageName(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func packageKey(ecosystem string, packageName string) string {
+	return normalizeEcosystem(ecosystem) + "\x00" + normalizePackageName(packageName)
+}
+
+func cloneVulnerability(v Vulnerability) Vulnerability {
+	v.ID = NormalizeIdentifier(v.ID)
+	v.Aliases = cloneStrings(v.Aliases)
+	for i, alias := range v.Aliases {
+		v.Aliases[i] = NormalizeIdentifier(alias)
+	}
+	v.References = append([]Reference(nil), v.References...)
+	if v.EPSS != nil {
+		epss := *v.EPSS
+		v.EPSS = &epss
+	}
+	if v.KEV != nil {
+		kev := *v.KEV
+		v.KEV = &kev
+	}
+	return v
+}
+
+func cloneStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	return append([]string(nil), values...)
+}
+
+func normalizeSyncJob(job SyncJob) SyncJob {
+	job.ID = strings.TrimSpace(job.ID)
+	job.Source = normalizeSource(job.Source)
+	job.FeedURL = strings.TrimSpace(job.FeedURL)
+	job.LeaseOwner = strings.TrimSpace(job.LeaseOwner)
+	job.LastError = strings.TrimSpace(job.LastError)
+	return job
+}
+
+func normalizeSource(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/internal/vulndb/models.go
+++ b/internal/vulndb/models.go
@@ -48,16 +48,18 @@ type KEV struct {
 
 // AffectedPackage describes one package/version range affected by a vulnerability.
 type AffectedPackage struct {
-	VulnerabilityID   string
-	Ecosystem         string
-	PackageName       string
-	RangeType         string
-	Introduced        string
-	Fixed             string
-	LastAffected      string
-	VulnerableVersion string
-	DistroName        string
-	DistroVersion     string
+	VulnerabilityID     string
+	Source              string
+	Ecosystem           string
+	PackageName         string
+	RangeType           string
+	Introduced          string
+	IntroducedExclusive string
+	Fixed               string
+	LastAffected        string
+	VulnerableVersion   string
+	DistroName          string
+	DistroVersion       string
 }
 
 // PackageQuery identifies an installed package to match against advisories.

--- a/internal/vulndb/store.go
+++ b/internal/vulndb/store.go
@@ -20,6 +20,7 @@ type Store interface {
 	FindVulnerability(context.Context, string) (Vulnerability, bool, error)
 	UpsertAffectedPackage(context.Context, AffectedPackage) error
 	ReplaceAffectedPackages(context.Context, string, string, []AffectedPackage) error
+	MoveAffectedPackages(context.Context, string, string) error
 	CandidateAffectedPackages(context.Context, PackageQuery) ([]AffectedPackage, error)
 	GetSyncState(context.Context, string) (SyncState, bool, error)
 	PutSyncState(context.Context, SyncState) error
@@ -199,6 +200,38 @@ func (s *MemoryStore) ReplaceAffectedPackages(ctx context.Context, vulnerability
 			s.affected[key] = map[string]AffectedPackage{}
 		}
 		s.affected[key][affectedPackageKey(pkg)] = pkg
+	}
+	return nil
+}
+
+// MoveAffectedPackages reassigns all affected package rows from one advisory ID to another.
+func (s *MemoryStore) MoveAffectedPackages(ctx context.Context, fromID string, toID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	fromID = NormalizeIdentifier(fromID)
+	toID = NormalizeIdentifier(toID)
+	if fromID == "" || toID == "" || fromID == toID {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, rows := range s.affected {
+		moved := []AffectedPackage{}
+		for rowKey, row := range rows {
+			if row.VulnerabilityID != fromID {
+				continue
+			}
+			delete(rows, rowKey)
+			row.VulnerabilityID = toID
+			moved = append(moved, row)
+		}
+		for _, row := range moved {
+			rows[affectedPackageKey(row)] = row
+		}
+		if len(rows) == 0 {
+			delete(s.affected, key)
+		}
 	}
 	return nil
 }

--- a/internal/vulndb/store.go
+++ b/internal/vulndb/store.go
@@ -276,6 +276,9 @@ func (s *MemoryStore) PutSyncJob(ctx context.Context, job SyncJob) error {
 		if job.LastSuccessAt.IsZero() {
 			job.LastSuccessAt = existing.LastSuccessAt
 		}
+		if job.NextRunAt.IsZero() {
+			job.NextRunAt = existing.NextRunAt
+		}
 		if job.LastError == "" {
 			job.LastError = existing.LastError
 		}

--- a/internal/vulndb/store.go
+++ b/internal/vulndb/store.go
@@ -18,6 +18,7 @@ type Store interface {
 	UpsertVulnerability(context.Context, Vulnerability) error
 	FindVulnerability(context.Context, string) (Vulnerability, bool, error)
 	UpsertAffectedPackage(context.Context, AffectedPackage) error
+	ReplaceAffectedPackages(context.Context, string, string, []AffectedPackage) error
 	CandidateAffectedPackages(context.Context, PackageQuery) ([]AffectedPackage, error)
 	GetSyncState(context.Context, string) (SyncState, bool, error)
 	PutSyncState(context.Context, SyncState) error
@@ -109,17 +110,9 @@ func (s *MemoryStore) UpsertAffectedPackage(ctx context.Context, pkg AffectedPac
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	pkg.VulnerabilityID = NormalizeIdentifier(pkg.VulnerabilityID)
-	pkg.Ecosystem = normalizeEcosystem(pkg.Ecosystem)
-	pkg.PackageName = strings.TrimSpace(pkg.PackageName)
-	if pkg.VulnerabilityID == "" {
-		return fmt.Errorf("affected package vulnerability id is required")
-	}
-	if pkg.Ecosystem == "" {
-		return fmt.Errorf("affected package ecosystem is required")
-	}
-	if pkg.PackageName == "" {
-		return fmt.Errorf("affected package name is required")
+	pkg, err := normalizeAffectedPackage(pkg)
+	if err != nil {
+		return err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -128,6 +121,51 @@ func (s *MemoryStore) UpsertAffectedPackage(ctx context.Context, pkg AffectedPac
 		s.affected[key] = map[string]AffectedPackage{}
 	}
 	s.affected[key][affectedPackageKey(pkg)] = pkg
+	return nil
+}
+
+// ReplaceAffectedPackages replaces all affected package rows for one vulnerability/source.
+func (s *MemoryStore) ReplaceAffectedPackages(ctx context.Context, vulnerabilityID string, source string, packages []AffectedPackage) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	vulnerabilityID = NormalizeIdentifier(vulnerabilityID)
+	source = strings.TrimSpace(source)
+	if vulnerabilityID == "" {
+		return fmt.Errorf("affected package vulnerability id is required")
+	}
+	if source == "" {
+		return fmt.Errorf("affected package source is required")
+	}
+	normalized := make([]AffectedPackage, 0, len(packages))
+	for _, pkg := range packages {
+		pkg.VulnerabilityID = vulnerabilityID
+		pkg.Source = source
+		row, err := normalizeAffectedPackage(pkg)
+		if err != nil {
+			return err
+		}
+		normalized = append(normalized, row)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, rows := range s.affected {
+		for rowKey, row := range rows {
+			if row.VulnerabilityID == vulnerabilityID && (strings.TrimSpace(row.Source) == source || strings.TrimSpace(row.Source) == "") {
+				delete(rows, rowKey)
+			}
+		}
+		if len(rows) == 0 {
+			delete(s.affected, key)
+		}
+	}
+	for _, pkg := range normalized {
+		key := packageKey(pkg.Ecosystem, pkg.PackageName)
+		if s.affected[key] == nil {
+			s.affected[key] = map[string]AffectedPackage{}
+		}
+		s.affected[key][affectedPackageKey(pkg)] = pkg
+	}
 	return nil
 }
 
@@ -160,7 +198,7 @@ func (s *MemoryStore) GetSyncState(ctx context.Context, source string) (SyncStat
 	if err := ctx.Err(); err != nil {
 		return SyncState{}, false, err
 	}
-	source = strings.TrimSpace(source)
+	source = normalizeSource(source)
 	if source == "" {
 		return SyncState{}, false, nil
 	}
@@ -175,7 +213,7 @@ func (s *MemoryStore) PutSyncState(ctx context.Context, state SyncState) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	state.Source = strings.TrimSpace(state.Source)
+	state.Source = normalizeSource(state.Source)
 	if state.Source == "" {
 		return fmt.Errorf("sync state source is required")
 	}
@@ -411,13 +449,32 @@ func (s *MemoryStore) finishSyncJob(ctx context.Context, id string, owner string
 	return nil
 }
 
+func normalizeAffectedPackage(pkg AffectedPackage) (AffectedPackage, error) {
+	pkg.VulnerabilityID = NormalizeIdentifier(pkg.VulnerabilityID)
+	pkg.Source = strings.TrimSpace(pkg.Source)
+	pkg.Ecosystem = normalizeEcosystem(pkg.Ecosystem)
+	pkg.PackageName = strings.TrimSpace(pkg.PackageName)
+	if pkg.VulnerabilityID == "" {
+		return AffectedPackage{}, fmt.Errorf("affected package vulnerability id is required")
+	}
+	if pkg.Ecosystem == "" {
+		return AffectedPackage{}, fmt.Errorf("affected package ecosystem is required")
+	}
+	if pkg.PackageName == "" {
+		return AffectedPackage{}, fmt.Errorf("affected package name is required")
+	}
+	return pkg, nil
+}
+
 func affectedPackageKey(pkg AffectedPackage) string {
 	parts := []string{
 		pkg.VulnerabilityID,
+		strings.TrimSpace(pkg.Source),
 		normalizeEcosystem(pkg.Ecosystem),
 		normalizePackageName(pkg.PackageName),
 		strings.TrimSpace(pkg.RangeType),
 		strings.TrimSpace(pkg.Introduced),
+		strings.TrimSpace(pkg.IntroducedExclusive),
 		strings.TrimSpace(pkg.Fixed),
 		strings.TrimSpace(pkg.LastAffected),
 		strings.TrimSpace(pkg.VulnerableVersion),

--- a/internal/vulndb/store.go
+++ b/internal/vulndb/store.go
@@ -1,0 +1,428 @@
+package vulndb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrSyncJobNotFound indicates that a persisted vulnerability sync job does not exist.
+var ErrSyncJobNotFound = errors.New("vulndb sync job not found")
+
+// Store persists normalized vulnerability advisory data.
+type Store interface {
+	UpsertVulnerability(context.Context, Vulnerability) error
+	FindVulnerability(context.Context, string) (Vulnerability, bool, error)
+	UpsertAffectedPackage(context.Context, AffectedPackage) error
+	CandidateAffectedPackages(context.Context, PackageQuery) ([]AffectedPackage, error)
+	GetSyncState(context.Context, string) (SyncState, bool, error)
+	PutSyncState(context.Context, SyncState) error
+	Stats(context.Context) (Stats, error)
+}
+
+// SyncJobStore persists durable advisory feed synchronization jobs.
+type SyncJobStore interface {
+	PutSyncJob(context.Context, SyncJob) error
+	GetSyncJob(context.Context, string) (SyncJob, bool, error)
+	ListDueSyncJobs(context.Context, time.Time, int) ([]SyncJob, error)
+	AcquireSyncJobLease(context.Context, string, string, time.Duration) (bool, error)
+	ReleaseSyncJobLease(context.Context, string, string) error
+	CompleteSyncJob(context.Context, string, string, time.Time) error
+	FailSyncJob(context.Context, string, string, time.Time, error) error
+}
+
+// MemoryStore is a deterministic in-process Store useful for tests and local callers.
+type MemoryStore struct {
+	mu              sync.RWMutex
+	vulnerabilities map[string]Vulnerability
+	aliases         map[string]string
+	affected        map[string]map[string]AffectedPackage
+	syncStates      map[string]SyncState
+	syncJobs        map[string]SyncJob
+}
+
+// NewMemoryStore constructs an empty in-memory vulnerability store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		vulnerabilities: map[string]Vulnerability{},
+		aliases:         map[string]string{},
+		affected:        map[string]map[string]AffectedPackage{},
+		syncStates:      map[string]SyncState{},
+		syncJobs:        map[string]SyncJob{},
+	}
+}
+
+// UpsertVulnerability inserts or replaces a normalized advisory.
+func (s *MemoryStore) UpsertVulnerability(ctx context.Context, v Vulnerability) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	v = cloneVulnerability(v)
+	if v.ID == "" {
+		return fmt.Errorf("vulnerability id is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for alias, id := range s.aliases {
+		if id == v.ID {
+			delete(s.aliases, alias)
+		}
+	}
+	s.vulnerabilities[v.ID] = v
+	s.aliases[v.ID] = v.ID
+	for _, alias := range v.Aliases {
+		if alias != "" {
+			s.aliases[alias] = v.ID
+		}
+	}
+	return nil
+}
+
+// FindVulnerability returns an advisory by canonical ID or alias.
+func (s *MemoryStore) FindVulnerability(ctx context.Context, idOrAlias string) (Vulnerability, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return Vulnerability{}, false, err
+	}
+	lookup := NormalizeIdentifier(idOrAlias)
+	if lookup == "" {
+		return Vulnerability{}, false, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	id, ok := s.aliases[lookup]
+	if !ok {
+		return Vulnerability{}, false, nil
+	}
+	v, ok := s.vulnerabilities[id]
+	if !ok {
+		return Vulnerability{}, false, nil
+	}
+	return cloneVulnerability(v), true, nil
+}
+
+// UpsertAffectedPackage inserts or replaces an affected package row.
+func (s *MemoryStore) UpsertAffectedPackage(ctx context.Context, pkg AffectedPackage) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	pkg.VulnerabilityID = NormalizeIdentifier(pkg.VulnerabilityID)
+	pkg.Ecosystem = normalizeEcosystem(pkg.Ecosystem)
+	pkg.PackageName = strings.TrimSpace(pkg.PackageName)
+	if pkg.VulnerabilityID == "" {
+		return fmt.Errorf("affected package vulnerability id is required")
+	}
+	if pkg.Ecosystem == "" {
+		return fmt.Errorf("affected package ecosystem is required")
+	}
+	if pkg.PackageName == "" {
+		return fmt.Errorf("affected package name is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := packageKey(pkg.Ecosystem, pkg.PackageName)
+	if s.affected[key] == nil {
+		s.affected[key] = map[string]AffectedPackage{}
+	}
+	s.affected[key][affectedPackageKey(pkg)] = pkg
+	return nil
+}
+
+// CandidateAffectedPackages returns all advisory package rows for an ecosystem/name pair.
+func (s *MemoryStore) CandidateAffectedPackages(ctx context.Context, query PackageQuery) ([]AffectedPackage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	key := packageKey(query.Ecosystem, query.Name)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rows := s.affected[key]
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, 0, len(rows))
+	for rowKey := range rows {
+		keys = append(keys, rowKey)
+	}
+	sort.Strings(keys)
+	out := make([]AffectedPackage, 0, len(keys))
+	for _, rowKey := range keys {
+		out = append(out, rows[rowKey])
+	}
+	return out, nil
+}
+
+// GetSyncState returns feed synchronization progress by logical source label.
+func (s *MemoryStore) GetSyncState(ctx context.Context, source string) (SyncState, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SyncState{}, false, err
+	}
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return SyncState{}, false, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	state, ok := s.syncStates[source]
+	return state, ok, nil
+}
+
+// PutSyncState records feed synchronization progress by logical source label.
+func (s *MemoryStore) PutSyncState(ctx context.Context, state SyncState) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	state.Source = strings.TrimSpace(state.Source)
+	if state.Source == "" {
+		return fmt.Errorf("sync state source is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.syncStates[state.Source] = state
+	return nil
+}
+
+// Stats returns counts for persisted advisory data.
+func (s *MemoryStore) Stats(ctx context.Context) (Stats, error) {
+	if err := ctx.Err(); err != nil {
+		return Stats{}, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	count := 0
+	for _, rows := range s.affected {
+		count += len(rows)
+	}
+	return Stats{
+		Vulnerabilities:  len(s.vulnerabilities),
+		AffectedPackages: count,
+		SyncSources:      len(s.syncStates),
+		SyncJobs:         len(s.syncJobs),
+	}, nil
+}
+
+// PutSyncJob upserts a durable advisory feed synchronization job.
+func (s *MemoryStore) PutSyncJob(ctx context.Context, job SyncJob) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	job = normalizeSyncJob(job)
+	if job.ID == "" {
+		return fmt.Errorf("sync job id is required")
+	}
+	if job.Source == "" {
+		return fmt.Errorf("sync job source is required")
+	}
+	if job.FeedURL == "" {
+		return fmt.Errorf("sync job feed url is required")
+	}
+	if job.Interval < 0 {
+		return fmt.Errorf("sync job interval must be non-negative")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.syncJobs[job.ID]; ok {
+		if job.LeaseOwner == "" {
+			job.LeaseOwner = existing.LeaseOwner
+			job.LeaseExpiresAt = existing.LeaseExpiresAt
+		}
+		if job.LastStartedAt.IsZero() {
+			job.LastStartedAt = existing.LastStartedAt
+		}
+		if job.LastFinishedAt.IsZero() {
+			job.LastFinishedAt = existing.LastFinishedAt
+		}
+		if job.LastSuccessAt.IsZero() {
+			job.LastSuccessAt = existing.LastSuccessAt
+		}
+		if job.LastError == "" {
+			job.LastError = existing.LastError
+		}
+		if job.Runs == 0 {
+			job.Runs = existing.Runs
+		}
+	}
+	s.syncJobs[job.ID] = job
+	return nil
+}
+
+// GetSyncJob returns a durable advisory feed synchronization job.
+func (s *MemoryStore) GetSyncJob(ctx context.Context, id string) (SyncJob, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SyncJob{}, false, err
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return SyncJob{}, false, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	job, ok := s.syncJobs[id]
+	return job, ok, nil
+}
+
+// ListDueSyncJobs returns sync jobs whose next run is due and whose lease is free or expired.
+func (s *MemoryStore) ListDueSyncJobs(ctx context.Context, now time.Time, limit int) ([]SyncJob, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	jobs := make([]SyncJob, 0, len(s.syncJobs))
+	for _, job := range s.syncJobs {
+		if !job.LeaseExpiresAt.IsZero() && job.LeaseExpiresAt.After(now) {
+			continue
+		}
+		if !job.NextRunAt.IsZero() && job.NextRunAt.After(now) {
+			continue
+		}
+		jobs = append(jobs, job)
+	}
+	sort.Slice(jobs, func(i, j int) bool {
+		left := jobs[i]
+		right := jobs[j]
+		if left.NextRunAt.IsZero() != right.NextRunAt.IsZero() {
+			return left.NextRunAt.IsZero()
+		}
+		if !left.NextRunAt.Equal(right.NextRunAt) {
+			return left.NextRunAt.Before(right.NextRunAt)
+		}
+		return left.ID < right.ID
+	})
+	if limit > 0 && len(jobs) > limit {
+		jobs = jobs[:limit]
+	}
+	return jobs, nil
+}
+
+// AcquireSyncJobLease leases a sync job for a worker.
+func (s *MemoryStore) AcquireSyncJobLease(ctx context.Context, id string, owner string, ttl time.Duration) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	id = strings.TrimSpace(id)
+	owner = strings.TrimSpace(owner)
+	if id == "" {
+		return false, fmt.Errorf("sync job id is required")
+	}
+	if owner == "" {
+		return false, fmt.Errorf("sync job lease owner is required")
+	}
+	if ttl <= 0 {
+		return false, fmt.Errorf("sync job lease ttl must be positive")
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.syncJobs[id]
+	if !ok {
+		return false, fmt.Errorf("%w: %s", ErrSyncJobNotFound, id)
+	}
+	if !job.LeaseExpiresAt.IsZero() && job.LeaseExpiresAt.After(now) && job.LeaseOwner != owner {
+		return false, nil
+	}
+	job.LeaseOwner = owner
+	job.LeaseExpiresAt = now.Add(ttl)
+	job.LastStartedAt = now
+	s.syncJobs[id] = job
+	return true, nil
+}
+
+// ReleaseSyncJobLease releases a sync job lease held by owner.
+func (s *MemoryStore) ReleaseSyncJobLease(ctx context.Context, id string, owner string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	id = strings.TrimSpace(id)
+	owner = strings.TrimSpace(owner)
+	if id == "" {
+		return fmt.Errorf("sync job id is required")
+	}
+	if owner == "" {
+		return fmt.Errorf("sync job lease owner is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.syncJobs[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrSyncJobNotFound, id)
+	}
+	if job.LeaseOwner == owner {
+		job.LeaseOwner = ""
+		job.LeaseExpiresAt = time.Time{}
+		s.syncJobs[id] = job
+	}
+	return nil
+}
+
+// CompleteSyncJob records a successful sync job run.
+func (s *MemoryStore) CompleteSyncJob(ctx context.Context, id string, owner string, nextRunAt time.Time) error {
+	return s.finishSyncJob(ctx, id, owner, nextRunAt, nil)
+}
+
+// FailSyncJob records a failed sync job run.
+func (s *MemoryStore) FailSyncJob(ctx context.Context, id string, owner string, nextRunAt time.Time, syncErr error) error {
+	if syncErr == nil {
+		syncErr = errors.New("sync job failed")
+	}
+	return s.finishSyncJob(ctx, id, owner, nextRunAt, syncErr)
+}
+
+func (s *MemoryStore) finishSyncJob(ctx context.Context, id string, owner string, nextRunAt time.Time, syncErr error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	id = strings.TrimSpace(id)
+	owner = strings.TrimSpace(owner)
+	if id == "" {
+		return fmt.Errorf("sync job id is required")
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.syncJobs[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrSyncJobNotFound, id)
+	}
+	if job.LeaseOwner != "" && owner != "" && job.LeaseOwner != owner {
+		return fmt.Errorf("sync job %q is leased by another owner", id)
+	}
+	job.LastFinishedAt = now
+	job.Runs++
+	if syncErr == nil {
+		job.LastSuccessAt = now
+		job.LastError = ""
+	} else {
+		job.LastError = syncErr.Error()
+	}
+	job.LeaseOwner = ""
+	job.LeaseExpiresAt = time.Time{}
+	if nextRunAt.IsZero() && job.Interval > 0 {
+		nextRunAt = now.Add(job.Interval)
+	}
+	job.NextRunAt = nextRunAt
+	s.syncJobs[id] = job
+	return nil
+}
+
+func affectedPackageKey(pkg AffectedPackage) string {
+	parts := []string{
+		pkg.VulnerabilityID,
+		normalizeEcosystem(pkg.Ecosystem),
+		normalizePackageName(pkg.PackageName),
+		strings.TrimSpace(pkg.RangeType),
+		strings.TrimSpace(pkg.Introduced),
+		strings.TrimSpace(pkg.Fixed),
+		strings.TrimSpace(pkg.LastAffected),
+		strings.TrimSpace(pkg.VulnerableVersion),
+		strings.TrimSpace(pkg.DistroName),
+		strings.TrimSpace(pkg.DistroVersion),
+	}
+	return strings.Join(parts, "\x00")
+}

--- a/internal/vulndb/store.go
+++ b/internal/vulndb/store.go
@@ -16,6 +16,7 @@ var ErrSyncJobNotFound = errors.New("vulndb sync job not found")
 // Store persists normalized vulnerability advisory data.
 type Store interface {
 	UpsertVulnerability(context.Context, Vulnerability) error
+	DeleteVulnerability(context.Context, string) error
 	FindVulnerability(context.Context, string) (Vulnerability, bool, error)
 	UpsertAffectedPackage(context.Context, AffectedPackage) error
 	ReplaceAffectedPackages(context.Context, string, string, []AffectedPackage) error
@@ -78,6 +79,39 @@ func (s *MemoryStore) UpsertVulnerability(ctx context.Context, v Vulnerability) 
 	for _, alias := range v.Aliases {
 		if alias != "" {
 			s.aliases[alias] = v.ID
+		}
+	}
+	return nil
+}
+
+// DeleteVulnerability removes an advisory, aliases, and affected package rows by canonical ID.
+func (s *MemoryStore) DeleteVulnerability(ctx context.Context, id string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	id = NormalizeIdentifier(id)
+	if id == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.vulnerabilities[id]; !ok {
+		return nil
+	}
+	delete(s.vulnerabilities, id)
+	for alias, vulnerabilityID := range s.aliases {
+		if vulnerabilityID == id {
+			delete(s.aliases, alias)
+		}
+	}
+	for key, rows := range s.affected {
+		for rowKey, row := range rows {
+			if row.VulnerabilityID == id {
+				delete(rows, rowKey)
+			}
+		}
+		if len(rows) == 0 {
+			delete(s.affected, key)
 		}
 	}
 	return nil
@@ -253,6 +287,9 @@ func (s *MemoryStore) PutSyncJob(ctx context.Context, job SyncJob) error {
 	}
 	if job.Source == "" {
 		return fmt.Errorf("sync job source is required")
+	}
+	if !IsSupportedFeedSource(job.Source) {
+		return fmt.Errorf("unsupported vulndb feed source %q", job.Source)
 	}
 	if job.FeedURL == "" {
 		return fmt.Errorf("sync job feed url is required")

--- a/internal/vulndb/store.go
+++ b/internal/vulndb/store.go
@@ -257,8 +257,8 @@ func (s *MemoryStore) PutSyncJob(ctx context.Context, job SyncJob) error {
 	if job.FeedURL == "" {
 		return fmt.Errorf("sync job feed url is required")
 	}
-	if job.Interval < 0 {
-		return fmt.Errorf("sync job interval must be non-negative")
+	if job.Interval <= 0 {
+		return fmt.Errorf("sync job interval must be positive")
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -109,6 +109,41 @@ func TestMatcherExcludesWithdrawnAdvisories(t *testing.T) {
 	}
 }
 
+func TestMatcherComparesNonNumericVersionSegments(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "CVE-2026-10001"}); err != nil {
+		t.Fatalf("upsert vulnerability: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID: "CVE-2026-10001",
+		Ecosystem:       "apk",
+		PackageName:     "demo",
+		Introduced:      "0",
+		Fixed:           "1.0-r1",
+	}); err != nil {
+		t.Fatalf("upsert affected package: %v", err)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "apk", Name: "demo", Version: "1.0-r0"})
+	if err != nil {
+		t.Fatalf("match revision before fixed: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected revision before fixed to match, got %+v", matches)
+	}
+	matches, err = matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "apk", Name: "demo", Version: "1.0-r1"})
+	if err != nil {
+		t.Fatalf("match fixed revision: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected fixed revision to be excluded, got %+v", matches)
+	}
+}
+
 func TestFileStorePersistsSyncStateAndAdvisories(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "vulndb.json")
@@ -151,6 +186,38 @@ func TestFileStorePersistsSyncStateAndAdvisories(t *testing.T) {
 	}
 	if _, ok, err := reopened.FindVulnerability(ctx, "ghsa-1111-2222-3333"); err != nil || !ok {
 		t.Fatalf("expected alias after reopen, ok=%v err=%v", ok, err)
+	}
+}
+
+func TestMemoryStoreSyncStateNormalizesSource(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.PutSyncState(ctx, SyncState{Source: " OSV ", Cursor: "first"}); err != nil {
+		t.Fatalf("put sync state: %v", err)
+	}
+	state, ok, err := store.GetSyncState(ctx, "osv")
+	if err != nil {
+		t.Fatalf("get sync state: %v", err)
+	}
+	if !ok || state.Source != SourceOSV || state.Cursor != "first" {
+		t.Fatalf("unexpected normalized sync state: ok=%v state=%+v", ok, state)
+	}
+	if err := store.PutSyncState(ctx, SyncState{Source: "osv", Cursor: "second"}); err != nil {
+		t.Fatalf("replace sync state: %v", err)
+	}
+	stats, err := store.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.SyncSources != 1 {
+		t.Fatalf("stats.SyncSources = %d, want one normalized source", stats.SyncSources)
+	}
+	state, ok, err = store.GetSyncState(ctx, " OSV ")
+	if err != nil {
+		t.Fatalf("get replacement sync state: %v", err)
+	}
+	if !ok || state.Cursor != "second" {
+		t.Fatalf("unexpected replacement sync state: ok=%v state=%+v", ok, state)
 	}
 }
 
@@ -403,6 +470,53 @@ func TestImportOSVMultiIntervalRanges(t *testing.T) {
 	}
 }
 
+func TestImportOSVReplacesStaleAffectedPackages(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	first := `[{
+		"id":"CVE-2026-33336",
+		"affected":[{
+			"package":{"ecosystem":"npm","name":"stale-demo"},
+			"ranges":[{"type":"SEMVER","events":[{"introduced":"0"},{"fixed":"2.0.0"}]}]
+		}]
+	}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(first)); err != nil {
+		t.Fatalf("import initial osv: %v", err)
+	}
+	second := `[{
+		"id":"CVE-2026-33336",
+		"affected":[{
+			"package":{"ecosystem":"npm","name":"stale-demo"},
+			"ranges":[{"type":"SEMVER","events":[{"introduced":"0"},{"fixed":"1.0.0"}]}]
+		}]
+	}]`
+	imported, err := ImportOSV(ctx, store, strings.NewReader(second))
+	if err != nil {
+		t.Fatalf("import replacement osv: %v", err)
+	}
+	if imported.AffectedPackages != 1 {
+		t.Fatalf("imported.AffectedPackages = %d, want replacement row", imported.AffectedPackages)
+	}
+	stats, err := store.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.AffectedPackages != 1 {
+		t.Fatalf("stats.AffectedPackages = %d, want stale row removed", stats.AffectedPackages)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "stale-demo", Version: "1.5.0"})
+	if err != nil {
+		t.Fatalf("match stale range version: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected stale range to be removed, got %+v", matches)
+	}
+}
+
 func TestImportNVDEnrichesExistingOSVAlias(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()
@@ -459,6 +573,62 @@ func TestImportNVDEnrichesExistingOSVAlias(t *testing.T) {
 	}
 	if len(matches) != 1 || matches[0].Vulnerability.ID != "GHSA-4444-5555-6666" {
 		t.Fatalf("unexpected cpe alias matches: %+v", matches)
+	}
+}
+
+func TestImportNVDPreservesWithdrawnOSVAlias(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	osv := `[{
+		"id":"GHSA-5555-6666-7777",
+		"aliases":["CVE-2026-44446"],
+		"withdrawn":"2026-05-01T00:00:00Z",
+		"affected":[{
+			"package":{"ecosystem":"npm","name":"withdrawn-demo"},
+			"ranges":[{"type":"SEMVER","events":[{"introduced":"0"},{"fixed":"1.0.0"}]}]
+		}]
+	}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(osv)); err != nil {
+		t.Fatalf("import withdrawn osv: %v", err)
+	}
+	nvd := `{
+		"vulnerabilities":[{
+			"cve":{
+				"id":"CVE-2026-44446",
+				"descriptions":[{"lang":"en","value":"NVD should not reactivate"}],
+				"configurations":[{
+					"nodes":[{
+						"cpeMatch":[{
+							"vulnerable":true,
+							"criteria":"cpe:2.3:a:demo:withdrawn:*:*:*:*:*:*:*:*",
+							"versionStartIncluding":"1.0.0",
+							"versionEndExcluding":"2.0.0"
+						}]
+					}]
+				}]
+			}
+		}]
+	}`
+	if _, err := ImportNVD(ctx, store, strings.NewReader(nvd)); err != nil {
+		t.Fatalf("import nvd: %v", err)
+	}
+	vulnerability, ok, err := store.FindVulnerability(ctx, "CVE-2026-44446")
+	if err != nil {
+		t.Fatalf("find merged vulnerability: %v", err)
+	}
+	if !ok || vulnerability.WithdrawnAt.IsZero() {
+		t.Fatalf("expected withdrawn merged vulnerability, ok=%v vulnerability=%+v", ok, vulnerability)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "demo:withdrawn", Version: "1.5.0"})
+	if err != nil {
+		t.Fatalf("match withdrawn cpe package: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected withdrawn alias to be excluded, got %+v", matches)
 	}
 }
 
@@ -527,6 +697,49 @@ func TestImportNVD(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("expected fixed cpe version to be excluded, got %+v", matches)
+	}
+}
+
+func TestImportNVDKeepsVersionStartExcludingExclusive(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	nvd := `{
+		"vulnerabilities":[{
+			"cve":{
+				"id":"CVE-2026-44447",
+				"configurations":[{
+					"nodes":[{
+						"cpeMatch":[{
+							"vulnerable":true,
+							"criteria":"cpe:2.3:a:demo:exclusive:*:*:*:*:*:*:*:*",
+							"versionStartExcluding":"1.0.0",
+							"versionEndExcluding":"1.0.2"
+						}]
+					}]
+				}]
+			}
+		}]
+	}`
+	if _, err := ImportNVD(ctx, store, strings.NewReader(nvd)); err != nil {
+		t.Fatalf("import nvd: %v", err)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "demo:exclusive", Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("match exclusive lower boundary: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected exclusive lower boundary to be excluded, got %+v", matches)
+	}
+	matches, err = matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "demo:exclusive", Version: "1.0.1"})
+	if err != nil {
+		t.Fatalf("match inside exclusive range: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected inside exclusive range to match, got %+v", matches)
 	}
 }
 

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -1,0 +1,273 @@
+package vulndb
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreAliasAndPackageMatching(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{
+		ID:      "GHSA-AAAA-BBBB-CCCC",
+		Aliases: []string{"CVE-2026-12345"},
+		Summary: "test advisory",
+	}); err != nil {
+		t.Fatalf("upsert vulnerability: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID: "GHSA-AAAA-BBBB-CCCC",
+		Ecosystem:       "npm",
+		PackageName:     "lodash",
+		Introduced:      "0",
+		Fixed:           "4.17.21",
+	}); err != nil {
+		t.Fatalf("upsert affected package: %v", err)
+	}
+
+	vulnerability, ok, err := store.FindVulnerability(ctx, "cve-2026-12345")
+	if err != nil {
+		t.Fatalf("find alias: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected alias lookup to find vulnerability")
+	}
+	if vulnerability.ID != "GHSA-AAAA-BBBB-CCCC" {
+		t.Fatalf("unexpected vulnerability id %q", vulnerability.ID)
+	}
+
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "lodash", Version: "4.17.20"})
+	if err != nil {
+		t.Fatalf("match vulnerable version: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected one match, got %d", len(matches))
+	}
+
+	matches, err = matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "lodash", Version: "4.17.21"})
+	if err != nil {
+		t.Fatalf("match fixed version: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no fixed-version matches, got %d", len(matches))
+	}
+}
+
+func TestMemoryStoreUpsertReplacesStaleAliases(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "CVE-2026-12345", Aliases: []string{"GHSA-AAAA-BBBB-CCCC"}}); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "CVE-2026-12345", Aliases: []string{"GHSA-DDDD-EEEE-FFFF"}}); err != nil {
+		t.Fatalf("replacement upsert: %v", err)
+	}
+	if _, ok, err := store.FindVulnerability(ctx, "GHSA-AAAA-BBBB-CCCC"); err != nil || ok {
+		t.Fatalf("stale alias lookup ok=%v err=%v, want not found", ok, err)
+	}
+	if _, ok, err := store.FindVulnerability(ctx, "GHSA-DDDD-EEEE-FFFF"); err != nil || !ok {
+		t.Fatalf("new alias lookup ok=%v err=%v, want found", ok, err)
+	}
+}
+
+func TestMatcherExcludesWithdrawnAdvisories(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{
+		ID:          "CVE-2026-99999",
+		WithdrawnAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("upsert withdrawn vulnerability: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID:   "CVE-2026-99999",
+		Ecosystem:         "pypi",
+		PackageName:       "demo",
+		VulnerableVersion: "1.2.3",
+	}); err != nil {
+		t.Fatalf("upsert affected package: %v", err)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "pypi", Name: "demo", Version: "1.2.3"})
+	if err != nil {
+		t.Fatalf("match exact version: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected withdrawn advisory to be excluded, got %d", len(matches))
+	}
+}
+
+func TestFileStorePersistsSyncStateAndAdvisories(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "vulndb.json")
+	store, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("new file store: %v", err)
+	}
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "CVE-2026-22222", Aliases: []string{"GHSA-1111-2222-3333"}}); err != nil {
+		t.Fatalf("upsert vulnerability: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID:   "CVE-2026-22222",
+		Ecosystem:         "golang",
+		PackageName:       "example.com/mod",
+		VulnerableVersion: "1.0.0",
+	}); err != nil {
+		t.Fatalf("upsert affected package: %v", err)
+	}
+	if err := store.PutSyncState(ctx, SyncState{Source: SourceOSV, Cursor: "next"}); err != nil {
+		t.Fatalf("put sync state: %v", err)
+	}
+
+	reopened, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("reopen file store: %v", err)
+	}
+	stats, err := reopened.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Vulnerabilities != 1 || stats.AffectedPackages != 1 || stats.SyncSources != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+	state, ok, err := reopened.GetSyncState(ctx, SourceOSV)
+	if err != nil {
+		t.Fatalf("get sync state: %v", err)
+	}
+	if !ok || state.Cursor != "next" {
+		t.Fatalf("unexpected sync state: ok=%v state=%+v", ok, state)
+	}
+	if _, ok, err := reopened.FindVulnerability(ctx, "ghsa-1111-2222-3333"); err != nil || !ok {
+		t.Fatalf("expected alias after reopen, ok=%v err=%v", ok, err)
+	}
+}
+
+func TestImportOSVKEVAndEPSS(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	osv := `[
+		{
+			"id":"GHSA-AAAA-BBBB-CCCC",
+			"aliases":["CVE-2026-11111"],
+			"summary":"lodash vulnerability",
+			"affected":[{
+				"package":{"ecosystem":"npm","name":"lodash"},
+				"ranges":[{"type":"SEMVER","events":[{"introduced":"0"},{"fixed":"4.17.21"}]}]
+			}]
+		}
+	]`
+	imported, err := ImportOSV(ctx, store, strings.NewReader(osv))
+	if err != nil {
+		t.Fatalf("import osv: %v", err)
+	}
+	if imported.Vulnerabilities != 1 || imported.AffectedPackages != 1 {
+		t.Fatalf("unexpected osv import result: %+v", imported)
+	}
+
+	epss := "cve,epss,percentile\nCVE-2026-11111,0.42,0.98\n"
+	if _, err := ImportEPSS(ctx, store, strings.NewReader(epss)); err != nil {
+		t.Fatalf("import epss: %v", err)
+	}
+	kev := `{"vulnerabilities":[{"cveID":"CVE-2026-11111","vulnerabilityName":"Known exploit","requiredAction":"Apply updates","dueDate":"2026-06-01","knownRansomwareCampaignUse":"Known"}]}`
+	if _, err := ImportCISAKEV(ctx, store, strings.NewReader(kev)); err != nil {
+		t.Fatalf("import kev: %v", err)
+	}
+
+	vulnerability, ok, err := store.FindVulnerability(ctx, "GHSA-AAAA-BBBB-CCCC")
+	if err != nil {
+		t.Fatalf("find enriched vulnerability: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected enriched vulnerability")
+	}
+	if vulnerability.EPSS == nil || vulnerability.EPSS.Score != 0.42 || vulnerability.EPSS.Percentile != 0.98 {
+		t.Fatalf("unexpected epss enrichment: %+v", vulnerability.EPSS)
+	}
+	if vulnerability.KEV == nil || !vulnerability.KEV.Listed || vulnerability.KEV.RequiredAction != "Apply updates" {
+		t.Fatalf("unexpected kev enrichment: %+v", vulnerability.KEV)
+	}
+}
+
+func TestImportOSVPreservesExistingEnrichment(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if _, err := ImportEPSS(ctx, store, strings.NewReader("cve,epss,percentile\nCVE-2026-33333,0.7,0.9\n")); err != nil {
+		t.Fatalf("import epss: %v", err)
+	}
+	osv := `[{"id":"CVE-2026-33333","summary":"later osv import"}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(osv)); err != nil {
+		t.Fatalf("import osv: %v", err)
+	}
+	vulnerability, ok, err := store.FindVulnerability(ctx, "CVE-2026-33333")
+	if err != nil {
+		t.Fatalf("find vulnerability: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected vulnerability")
+	}
+	if vulnerability.EPSS == nil || vulnerability.EPSS.Score != 0.7 {
+		t.Fatalf("expected epss enrichment to survive osv import, got %+v", vulnerability.EPSS)
+	}
+}
+
+func TestImportNVD(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	nvd := `{
+		"vulnerabilities":[{
+			"cve":{
+				"id":"CVE-2026-44444",
+				"published":"2026-05-01T00:00:00.000",
+				"lastModified":"2026-05-02T00:00:00.000",
+				"descriptions":[{"lang":"en","value":"NVD description"}],
+				"metrics":{"cvssMetricV31":[{"cvssData":{"baseScore":9.8,"baseSeverity":"CRITICAL","vectorString":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}}]},
+				"references":[{"url":"https://example.com/advisory","source":"nvd","tags":["Vendor Advisory"]}]
+			}
+		}]
+	}`
+	imported, err := ImportNVD(ctx, store, strings.NewReader(nvd))
+	if err != nil {
+		t.Fatalf("import nvd: %v", err)
+	}
+	if imported.Vulnerabilities != 1 {
+		t.Fatalf("unexpected nvd import result: %+v", imported)
+	}
+	vulnerability, ok, err := store.FindVulnerability(ctx, "cve-2026-44444")
+	if err != nil {
+		t.Fatalf("find nvd vulnerability: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected nvd vulnerability")
+	}
+	if vulnerability.Summary != "NVD description" || vulnerability.Severity != "CRITICAL" || vulnerability.CVSSScore != 9.8 {
+		t.Fatalf("unexpected nvd vulnerability: %+v", vulnerability)
+	}
+	if len(vulnerability.References) != 1 || vulnerability.References[0].Type != "Vendor Advisory" {
+		t.Fatalf("unexpected references: %+v", vulnerability.References)
+	}
+}
+
+func TestValidateFeedURLTransportPolicy(t *testing.T) {
+	if err := ValidateFeedURL("https://example.com/feed.json", false); err != nil {
+		t.Fatalf("https feed should be allowed: %v", err)
+	}
+	if err := ValidateFeedURL("http://example.com/feed.json", false); err == nil {
+		t.Fatal("expected http feed to be rejected without allow-insecure-http")
+	}
+	if err := ValidateFeedURL("http://example.com/feed.json", true); err != nil {
+		t.Fatalf("http feed should be allowed with opt-in: %v", err)
+	}
+	if err := ValidateFeedURL("file:///tmp/feed.json", true); err == nil {
+		t.Fatal("expected file URL to be rejected")
+	}
+}

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -180,6 +180,43 @@ func TestMatcherTreatsPrereleaseBeforeFinalRelease(t *testing.T) {
 	}
 }
 
+func TestMatcherTreatsPyPIPreReleaseBeforeFinalRelease(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "CVE-2026-10003"}); err != nil {
+		t.Fatalf("upsert vulnerability: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID: "CVE-2026-10003",
+		Ecosystem:       "pypi",
+		PackageName:     "demo",
+		Introduced:      "0",
+		Fixed:           "1.0.0",
+	}); err != nil {
+		t.Fatalf("upsert affected package: %v", err)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	for _, version := range []string{"1.0.0rc1", "1.0.0b1"} {
+		matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "pypi", Name: "demo", Version: version})
+		if err != nil {
+			t.Fatalf("match prerelease %s: %v", version, err)
+		}
+		if len(matches) != 1 {
+			t.Fatalf("expected prerelease %s before fixed final to match, got %+v", version, matches)
+		}
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "pypi", Name: "demo", Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("match final release: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected fixed final release to be excluded, got %+v", matches)
+	}
+}
+
 func TestFileStorePersistsSyncStateAndAdvisories(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "vulndb.json")

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/iotest"
 	"time"
 )
 
@@ -740,6 +741,56 @@ func TestImportNVDKeepsVersionStartExcludingExclusive(t *testing.T) {
 	}
 	if len(matches) != 1 {
 		t.Fatalf("expected inside exclusive range to match, got %+v", matches)
+	}
+}
+
+func TestImportNVDSkipsConjunctiveConfigurations(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	nvd := `{
+		"vulnerabilities":[{
+			"cve":{
+				"id":"CVE-2026-44448",
+				"configurations":[{
+					"nodes":[{
+						"operator":"AND",
+						"cpeMatch":[{
+							"vulnerable":true,
+							"criteria":"cpe:2.3:a:demo:platform_bound:*:*:*:*:*:*:*:*"
+						},{
+							"vulnerable":false,
+							"criteria":"cpe:2.3:o:demo:required_os:*:*:*:*:*:*:*:*"
+						}]
+					}]
+				}]
+			}
+		}]
+	}`
+	imported, err := ImportNVD(ctx, store, strings.NewReader(nvd))
+	if err != nil {
+		t.Fatalf("import nvd: %v", err)
+	}
+	if imported.AffectedPackages != 0 {
+		t.Fatalf("affected packages = %d, want conjunctive configuration skipped", imported.AffectedPackages)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "demo:platform_bound", Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("match skipped conjunctive package: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no match for conjunctive platform-bound CPE, got %+v", matches)
+	}
+}
+
+func TestImportEPSSReturnsCommentScanError(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if _, err := ImportEPSS(ctx, store, iotest.ErrReader(fmt.Errorf("read failed"))); err == nil {
+		t.Fatal("ImportEPSS() error = nil, want scanner read failure")
 	}
 }
 

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -217,6 +217,34 @@ func TestMatcherTreatsPyPIPreReleaseBeforeFinalRelease(t *testing.T) {
 	}
 }
 
+func TestMatcherIgnoresSemverBuildMetadataInRangeComparisons(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "CVE-2026-10004"}); err != nil {
+		t.Fatalf("upsert vulnerability: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID: "CVE-2026-10004",
+		Ecosystem:       "npm",
+		PackageName:     "demo",
+		Introduced:      "0",
+		LastAffected:    "1.0.0",
+	}); err != nil {
+		t.Fatalf("upsert affected package: %v", err)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "demo", Version: "1.0.0+build.7"})
+	if err != nil {
+		t.Fatalf("match build metadata version: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected build metadata to be ignored at inclusive upper bound, got %+v", matches)
+	}
+}
+
 func TestFileStorePersistsSyncStateAndAdvisories(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "vulndb.json")
@@ -445,6 +473,37 @@ func TestImportOSVPreservesExistingEnrichment(t *testing.T) {
 	}
 	if vulnerability.EPSS == nil || vulnerability.EPSS.Score != 0.7 {
 		t.Fatalf("expected epss enrichment to survive osv import, got %+v", vulnerability.EPSS)
+	}
+}
+
+func TestImportOSVDoesNotStoreScoringSchemeAsSeverity(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{
+		ID:       "CVE-2026-33341",
+		Severity: "HIGH",
+	}); err != nil {
+		t.Fatalf("upsert existing vulnerability: %v", err)
+	}
+	osv := `[{
+		"id":"CVE-2026-33341",
+		"severity":[{"type":"CVSS_V3","score":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}]
+	}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(osv)); err != nil {
+		t.Fatalf("import osv: %v", err)
+	}
+	vulnerability, ok, err := store.FindVulnerability(ctx, "CVE-2026-33341")
+	if err != nil {
+		t.Fatalf("find vulnerability: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected vulnerability")
+	}
+	if vulnerability.Severity != "HIGH" {
+		t.Fatalf("Severity = %q, want existing label HIGH", vulnerability.Severity)
+	}
+	if vulnerability.CVSSVector != "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" {
+		t.Fatalf("CVSSVector = %q, want OSV score vector", vulnerability.CVSSVector)
 	}
 }
 

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -2,6 +2,7 @@ package vulndb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,18 @@ import (
 	"testing/iotest"
 	"time"
 )
+
+type failUpsertStore struct {
+	*MemoryStore
+	failID string
+}
+
+func (s failUpsertStore) UpsertVulnerability(ctx context.Context, vulnerability Vulnerability) error {
+	if NormalizeIdentifier(vulnerability.ID) == NormalizeIdentifier(s.failID) {
+		return errors.New("upsert failed")
+	}
+	return s.MemoryStore.UpsertVulnerability(ctx, vulnerability)
+}
 
 func TestMemoryStoreAliasAndPackageMatching(t *testing.T) {
 	ctx := context.Background()
@@ -77,6 +90,46 @@ func TestMemoryStoreUpsertReplacesStaleAliases(t *testing.T) {
 	}
 	if _, ok, err := store.FindVulnerability(ctx, "GHSA-DDDD-EEEE-FFFF"); err != nil || !ok {
 		t.Fatalf("new alias lookup ok=%v err=%v, want found", ok, err)
+	}
+}
+
+func TestImportOSVDoesNotDeleteDuplicateBeforeCanonicalUpsertSucceeds(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "GHSA-AAAA-BBBB-CCCC"}); err != nil {
+		t.Fatalf("upsert ghsa: %v", err)
+	}
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "CVE-2026-12345"}); err != nil {
+		t.Fatalf("upsert cve: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID:   "CVE-2026-12345",
+		Source:            SourceOSV,
+		Ecosystem:         "npm",
+		PackageName:       "demo",
+		VulnerableVersion: "1.0.0",
+	}); err != nil {
+		t.Fatalf("upsert affected package: %v", err)
+	}
+
+	_, err := importOSVAdvisory(ctx, failUpsertStore{MemoryStore: store, failID: "GHSA-AAAA-BBBB-CCCC"}, osvAdvisory{
+		ID:      "GHSA-AAAA-BBBB-CCCC",
+		Aliases: []string{"CVE-2026-12345"},
+		Summary: "merged advisory",
+	})
+	if err == nil {
+		t.Fatal("importOSVAdvisory() error = nil, want upsert failure")
+	}
+
+	if _, ok, err := store.FindVulnerability(ctx, "CVE-2026-12345"); err != nil || !ok {
+		t.Fatalf("duplicate vulnerability lookup ok=%v err=%v, want preserved", ok, err)
+	}
+	packages, err := store.CandidateAffectedPackages(ctx, PackageQuery{Ecosystem: "npm", Name: "demo", Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("candidate affected packages: %v", err)
+	}
+	if len(packages) != 1 || packages[0].VulnerabilityID != "CVE-2026-12345" {
+		t.Fatalf("duplicate affected package = %+v, want preserved CVE package", packages)
 	}
 }
 

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -508,6 +508,59 @@ func TestImportOSVRemovesAliasSupersededAffectedPackages(t *testing.T) {
 	}
 }
 
+func TestImportOSVMigratesDuplicateAffectedPackages(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if _, err := ImportOSV(ctx, store, strings.NewReader(`[{"id":"GHSA-3333-4444-8888"}]`)); err != nil {
+		t.Fatalf("import initial osv: %v", err)
+	}
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "CVE-2026-33340"}); err != nil {
+		t.Fatalf("upsert standalone nvd advisory: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID: "CVE-2026-33340",
+		Source:          SourceNVD,
+		Ecosystem:       "npm",
+		PackageName:     "nvd-demo",
+		Introduced:      "0",
+		Fixed:           "1.0.0",
+	}); err != nil {
+		t.Fatalf("upsert standalone nvd affected package: %v", err)
+	}
+	refreshed := `[{
+		"id":"GHSA-3333-4444-8888",
+		"aliases":["CVE-2026-33340"]
+	}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(refreshed)); err != nil {
+		t.Fatalf("import refreshed osv: %v", err)
+	}
+	stats, err := store.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Vulnerabilities != 1 {
+		t.Fatalf("stats.Vulnerabilities = %d, want merged advisory", stats.Vulnerabilities)
+	}
+	rows, err := store.CandidateAffectedPackages(ctx, PackageQuery{Ecosystem: "npm", Name: "nvd-demo"})
+	if err != nil {
+		t.Fatalf("candidate affected packages: %v", err)
+	}
+	if len(rows) != 1 || rows[0].VulnerabilityID != "GHSA-3333-4444-8888" || rows[0].Source != SourceNVD {
+		t.Fatalf("migrated rows = %+v, want preserved NVD row on canonical advisory", rows)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "nvd-demo", Version: "0.5.0"})
+	if err != nil {
+		t.Fatalf("match migrated nvd package: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Vulnerability.ID != "GHSA-3333-4444-8888" {
+		t.Fatalf("matches = %+v, want migrated canonical advisory", matches)
+	}
+}
+
 func TestImportOSVMultiIntervalRanges(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -308,6 +308,160 @@ func TestImportOSVPreservesExistingEnrichment(t *testing.T) {
 	}
 }
 
+func TestImportOSVMergesExistingAliasEnrichment(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if _, err := ImportEPSS(ctx, store, strings.NewReader("cve,epss,percentile\nCVE-2026-33334,0.8,0.95\n")); err != nil {
+		t.Fatalf("import epss: %v", err)
+	}
+	osv := `[{
+		"id":"GHSA-3333-4444-5555",
+		"aliases":["CVE-2026-33334"],
+		"summary":"later osv alias import",
+		"affected":[{
+			"package":{"ecosystem":"npm","name":"demo"},
+			"ranges":[{"type":"SEMVER","events":[{"introduced":"0"},{"fixed":"1.2.0"}]}]
+		}]
+	}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(osv)); err != nil {
+		t.Fatalf("import osv: %v", err)
+	}
+	stats, err := store.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Vulnerabilities != 1 {
+		t.Fatalf("stats.Vulnerabilities = %d, want 1 merged advisory", stats.Vulnerabilities)
+	}
+	vulnerability, ok, err := store.FindVulnerability(ctx, "GHSA-3333-4444-5555")
+	if err != nil {
+		t.Fatalf("find ghsa alias: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ghsa alias lookup")
+	}
+	if vulnerability.EPSS == nil || vulnerability.EPSS.Score != 0.8 {
+		t.Fatalf("expected epss enrichment to survive alias merge, got %+v", vulnerability.EPSS)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "demo", Version: "1.1.0"})
+	if err != nil {
+		t.Fatalf("match alias-merged package: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Vulnerability.EPSS == nil {
+		t.Fatalf("unexpected alias-merged matches: %+v", matches)
+	}
+}
+
+func TestImportOSVMultiIntervalRanges(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	osv := `[{
+		"id":"CVE-2026-33335",
+		"summary":"multi interval advisory",
+		"affected":[{
+			"package":{"ecosystem":"npm","name":"interval-demo"},
+			"ranges":[{"type":"SEMVER","events":[
+				{"introduced":"0"},
+				{"fixed":"1.0.0"},
+				{"introduced":"2.0.0"},
+				{"fixed":"2.5.0"}
+			]}]
+		}]
+	}]`
+	imported, err := ImportOSV(ctx, store, strings.NewReader(osv))
+	if err != nil {
+		t.Fatalf("import osv: %v", err)
+	}
+	if imported.AffectedPackages != 2 {
+		t.Fatalf("imported.AffectedPackages = %d, want 2 intervals", imported.AffectedPackages)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	for _, version := range []string{"0.5.0", "2.1.0"} {
+		matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "interval-demo", Version: version})
+		if err != nil {
+			t.Fatalf("match vulnerable version %s: %v", version, err)
+		}
+		if len(matches) != 1 {
+			t.Fatalf("matches for %s = %+v, want one", version, matches)
+		}
+	}
+	for _, version := range []string{"1.5.0", "2.5.0"} {
+		matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "interval-demo", Version: version})
+		if err != nil {
+			t.Fatalf("match non-vulnerable version %s: %v", version, err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("matches for %s = %+v, want none", version, matches)
+		}
+	}
+}
+
+func TestImportNVDEnrichesExistingOSVAlias(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	osv := `[{"id":"GHSA-4444-5555-6666","aliases":["CVE-2026-44445"],"summary":"osv advisory"}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(osv)); err != nil {
+		t.Fatalf("import osv: %v", err)
+	}
+	nvd := `{
+		"vulnerabilities":[{
+			"cve":{
+				"id":"CVE-2026-44445",
+				"descriptions":[{"lang":"en","value":"NVD alias description"}],
+				"metrics":{"cvssMetricV31":[{"cvssData":{"baseScore":7.5,"baseSeverity":"HIGH","vectorString":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"}}]},
+				"configurations":[{
+					"nodes":[{
+						"cpeMatch":[{
+							"vulnerable":true,
+							"criteria":"cpe:2.3:a:demo:agent:*:*:*:*:*:*:*:*",
+							"versionStartIncluding":"3.0.0",
+							"versionEndExcluding":"3.1.0"
+						}]
+					}]
+				}]
+			}
+		}]
+	}`
+	if _, err := ImportNVD(ctx, store, strings.NewReader(nvd)); err != nil {
+		t.Fatalf("import nvd: %v", err)
+	}
+	stats, err := store.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Vulnerabilities != 1 {
+		t.Fatalf("stats.Vulnerabilities = %d, want 1 merged advisory", stats.Vulnerabilities)
+	}
+	vulnerability, ok, err := store.FindVulnerability(ctx, "CVE-2026-44445")
+	if err != nil {
+		t.Fatalf("find cve alias: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected cve alias lookup")
+	}
+	if vulnerability.ID != "GHSA-4444-5555-6666" || vulnerability.CVSSScore != 7.5 || vulnerability.Severity != "HIGH" {
+		t.Fatalf("unexpected merged nvd vulnerability: %+v", vulnerability)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "demo:agent", Version: "3.0.1"})
+	if err != nil {
+		t.Fatalf("match cpe alias package: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Vulnerability.ID != "GHSA-4444-5555-6666" {
+		t.Fatalf("unexpected cpe alias matches: %+v", matches)
+	}
+}
+
 func TestImportNVD(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -454,6 +454,13 @@ func TestImportOSVRemovesAliasSupersededAffectedPackages(t *testing.T) {
 	if _, err := ImportOSV(ctx, store, strings.NewReader(osv)); err != nil {
 		t.Fatalf("import osv alias refresh: %v", err)
 	}
+	stats, err := store.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Vulnerabilities != 1 {
+		t.Fatalf("stats.Vulnerabilities = %d, want duplicate alias record removed", stats.Vulnerabilities)
+	}
 	rows, err := store.CandidateAffectedPackages(ctx, PackageQuery{Ecosystem: "npm", Name: "demo"})
 	if err != nil {
 		t.Fatalf("candidate affected packages: %v", err)

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -2,8 +2,10 @@ package vulndb
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -152,6 +154,47 @@ func TestFileStorePersistsSyncStateAndAdvisories(t *testing.T) {
 	}
 }
 
+func TestFileStoreSerializesConcurrentWrites(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "vulndb.json")
+	store, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("new file store: %v", err)
+	}
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				source := fmt.Sprintf("source-%d-%d", i, j)
+				if err := store.PutSyncState(ctx, SyncState{Source: source}); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent write failed: %v", err)
+	}
+	reopened, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("reopen file store: %v", err)
+	}
+	stats, err := reopened.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.SyncSources != 160 {
+		t.Fatalf("stats.SyncSources = %d, want 160", stats.SyncSources)
+	}
+}
+
 func TestImportOSVKEVAndEPSS(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()
@@ -198,6 +241,51 @@ func TestImportOSVKEVAndEPSS(t *testing.T) {
 	}
 }
 
+func TestImportOSVSinglePrettyPrintedAdvisory(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	osv := `{
+		"id":"CVE-2026-55555",
+		"summary":"single advisory",
+		"affected":[{
+			"package":{"ecosystem":"PyPI","name":"demo"},
+			"versions":["1.2.3"]
+		}]
+	}`
+	imported, err := ImportOSV(ctx, store, strings.NewReader(osv))
+	if err != nil {
+		t.Fatalf("import osv: %v", err)
+	}
+	if imported.Vulnerabilities != 1 || imported.AffectedPackages != 1 {
+		t.Fatalf("unexpected osv import result: %+v", imported)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "pypi", Name: "demo", Version: "1.2.3"})
+	if err != nil {
+		t.Fatalf("match single advisory package: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Vulnerability.ID != "CVE-2026-55555" {
+		t.Fatalf("unexpected matches: %+v", matches)
+	}
+}
+
+func TestImportOSVLargeJSONLAdvisory(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	osv := `{"id":"CVE-2026-55556","summary":"` + strings.Repeat("a", 70*1024) + `"}` + "\n" +
+		`{"id":"CVE-2026-55557","summary":"small"}`
+	imported, err := ImportOSV(ctx, store, strings.NewReader(osv))
+	if err != nil {
+		t.Fatalf("import large osv jsonl: %v", err)
+	}
+	if imported.Vulnerabilities != 2 {
+		t.Fatalf("unexpected osv import result: %+v", imported)
+	}
+}
+
 func TestImportOSVPreservesExistingEnrichment(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()
@@ -231,7 +319,20 @@ func TestImportNVD(t *testing.T) {
 				"lastModified":"2026-05-02T00:00:00.000",
 				"descriptions":[{"lang":"en","value":"NVD description"}],
 				"metrics":{"cvssMetricV31":[{"cvssData":{"baseScore":9.8,"baseSeverity":"CRITICAL","vectorString":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}}]},
-				"references":[{"url":"https://example.com/advisory","source":"nvd","tags":["Vendor Advisory"]}]
+				"references":[{"url":"https://example.com/advisory","source":"nvd","tags":["Vendor Advisory"]}],
+				"configurations":[{
+					"nodes":[{
+						"cpeMatch":[{
+							"vulnerable":true,
+							"criteria":"cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*",
+							"versionStartIncluding":"1.0.1",
+							"versionEndExcluding":"1.0.2"
+						},{
+							"vulnerable":false,
+							"criteria":"cpe:2.3:a:openssl:openssl:3.0.0:*:*:*:*:*:*:*"
+						}]
+					}]
+				}]
 			}
 		}]
 	}`
@@ -239,7 +340,7 @@ func TestImportNVD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("import nvd: %v", err)
 	}
-	if imported.Vulnerabilities != 1 {
+	if imported.Vulnerabilities != 1 || imported.AffectedPackages != 1 {
 		t.Fatalf("unexpected nvd import result: %+v", imported)
 	}
 	vulnerability, ok, err := store.FindVulnerability(ctx, "cve-2026-44444")
@@ -254,6 +355,24 @@ func TestImportNVD(t *testing.T) {
 	}
 	if len(vulnerability.References) != 1 || vulnerability.References[0].Type != "Vendor Advisory" {
 		t.Fatalf("unexpected references: %+v", vulnerability.References)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "openssl:openssl", Version: "1.0.1"})
+	if err != nil {
+		t.Fatalf("match nvd cpe range: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Vulnerability.ID != "CVE-2026-44444" {
+		t.Fatalf("unexpected vulnerable cpe matches: %+v", matches)
+	}
+	matches, err = matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "openssl:openssl", Version: "1.0.2"})
+	if err != nil {
+		t.Fatalf("match fixed nvd cpe range: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected fixed cpe version to be excluded, got %+v", matches)
 	}
 }
 

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -145,6 +145,41 @@ func TestMatcherComparesNonNumericVersionSegments(t *testing.T) {
 	}
 }
 
+func TestMatcherTreatsPrereleaseBeforeFinalRelease(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "CVE-2026-10002"}); err != nil {
+		t.Fatalf("upsert vulnerability: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID: "CVE-2026-10002",
+		Ecosystem:       "npm",
+		PackageName:     "demo",
+		Introduced:      "0",
+		Fixed:           "1.0.0",
+	}); err != nil {
+		t.Fatalf("upsert affected package: %v", err)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "demo", Version: "1.0.0-rc1"})
+	if err != nil {
+		t.Fatalf("match prerelease: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected prerelease before fixed final to match, got %+v", matches)
+	}
+	matches, err = matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "demo", Version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("match final release: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected fixed final release to be excluded, got %+v", matches)
+	}
+}
+
 func TestFileStorePersistsSyncStateAndAdvisories(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "vulndb.json")
@@ -520,6 +555,77 @@ func TestImportOSVMultiIntervalRanges(t *testing.T) {
 	}
 }
 
+func TestImportOSVLimitBoundsRange(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	osv := `[{
+		"id":"CVE-2026-33337",
+		"affected":[{
+			"package":{"ecosystem":"npm","name":"limit-demo"},
+			"ranges":[{"type":"SEMVER","events":[{"introduced":"0"},{"limit":"2.0.0"}]}]
+		}]
+	}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(osv)); err != nil {
+		t.Fatalf("import osv: %v", err)
+	}
+	matcher, err := NewMatcher(store)
+	if err != nil {
+		t.Fatalf("new matcher: %v", err)
+	}
+	matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "limit-demo", Version: "1.9.9"})
+	if err != nil {
+		t.Fatalf("match vulnerable version: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("matches below limit = %+v, want one", matches)
+	}
+	for _, version := range []string{"2.0.0", "2.0.1"} {
+		matches, err := matcher.MatchPackage(ctx, PackageQuery{Ecosystem: "npm", Name: "limit-demo", Version: version})
+		if err != nil {
+			t.Fatalf("match non-vulnerable version %s: %v", version, err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("matches for %s = %+v, want none", version, matches)
+		}
+	}
+}
+
+func TestImportOSVRefreshDropsRemovedAliasesAndWithdrawn(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	first := `[{
+		"id":"GHSA-3333-4444-7777",
+		"aliases":["CVE-2026-33338","CVE-2026-33339"],
+		"withdrawn":"2026-05-01T00:00:00Z"
+	}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(first)); err != nil {
+		t.Fatalf("import first osv: %v", err)
+	}
+	second := `[{
+		"id":"GHSA-3333-4444-7777",
+		"aliases":["CVE-2026-33338"]
+	}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(second)); err != nil {
+		t.Fatalf("import refreshed osv: %v", err)
+	}
+	vulnerability, ok, err := store.FindVulnerability(ctx, "GHSA-3333-4444-7777")
+	if err != nil {
+		t.Fatalf("find refreshed advisory: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected refreshed advisory")
+	}
+	if !vulnerability.WithdrawnAt.IsZero() {
+		t.Fatalf("WithdrawnAt = %v, want cleared active advisory", vulnerability.WithdrawnAt)
+	}
+	if _, ok, err := store.FindVulnerability(ctx, "CVE-2026-33339"); err != nil || ok {
+		t.Fatalf("removed alias lookup ok=%v err=%v, want missing", ok, err)
+	}
+	if _, ok, err := store.FindVulnerability(ctx, "CVE-2026-33338"); err != nil || !ok {
+		t.Fatalf("current alias lookup ok=%v err=%v, want found", ok, err)
+	}
+}
+
 func TestImportOSVReplacesStaleAffectedPackages(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()
@@ -679,6 +785,41 @@ func TestImportNVDPreservesWithdrawnOSVAlias(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("expected withdrawn alias to be excluded, got %+v", matches)
+	}
+}
+
+func TestImportNVDPreservesExplicitZeroCVSS(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{
+		ID:          "CVE-2026-44449",
+		CVSSScore:   9.8,
+		Severity:    "CRITICAL",
+		CVSSVector:  "old-vector",
+		PublishedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("upsert existing vulnerability: %v", err)
+	}
+	nvd := `{
+		"vulnerabilities":[{
+			"cve":{
+				"id":"CVE-2026-44449",
+				"metrics":{"cvssMetricV31":[{"cvssData":{"baseScore":0.0,"baseSeverity":"NONE","vectorString":"CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"}}]}
+			}
+		}]
+	}`
+	if _, err := ImportNVD(ctx, store, strings.NewReader(nvd)); err != nil {
+		t.Fatalf("import nvd: %v", err)
+	}
+	vulnerability, ok, err := store.FindVulnerability(ctx, "CVE-2026-44449")
+	if err != nil {
+		t.Fatalf("find vulnerability: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected vulnerability")
+	}
+	if vulnerability.CVSSScore != 0 || vulnerability.Severity != "NONE" || vulnerability.CVSSVector == "old-vector" {
+		t.Fatalf("expected explicit zero cvss update, got %+v", vulnerability)
 	}
 }
 

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -424,6 +424,48 @@ func TestImportOSVMergesExistingAliasEnrichment(t *testing.T) {
 	}
 }
 
+func TestImportOSVRemovesAliasSupersededAffectedPackages(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "GHSA-3333-4444-6666"}); err != nil {
+		t.Fatalf("upsert original advisory: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID: "GHSA-3333-4444-6666",
+		Source:          SourceOSV,
+		Ecosystem:       "npm",
+		PackageName:     "demo",
+		Introduced:      "0",
+		Fixed:           "1.0.0",
+	}); err != nil {
+		t.Fatalf("upsert original affected package: %v", err)
+	}
+	if err := store.UpsertVulnerability(ctx, Vulnerability{ID: "CVE-2026-33336", Aliases: []string{"GHSA-3333-4444-6666"}}); err != nil {
+		t.Fatalf("upsert canonical alias advisory: %v", err)
+	}
+	osv := `[{
+		"id":"GHSA-3333-4444-6666",
+		"aliases":["CVE-2026-33336"],
+		"affected":[{
+			"package":{"ecosystem":"npm","name":"demo"},
+			"ranges":[{"type":"SEMVER","events":[{"introduced":"0"},{"fixed":"2.0.0"}]}]
+		}]
+	}]`
+	if _, err := ImportOSV(ctx, store, strings.NewReader(osv)); err != nil {
+		t.Fatalf("import osv alias refresh: %v", err)
+	}
+	rows, err := store.CandidateAffectedPackages(ctx, PackageQuery{Ecosystem: "npm", Name: "demo"})
+	if err != nil {
+		t.Fatalf("candidate affected packages: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("affected rows = %+v, want one canonical OSV row", rows)
+	}
+	if rows[0].VulnerabilityID != "CVE-2026-33336" || rows[0].Fixed != "2.0.0" {
+		t.Fatalf("unexpected canonical affected row: %+v", rows[0])
+	}
+}
+
 func TestImportOSVMultiIntervalRanges(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()

--- a/internal/vulndb/sync.go
+++ b/internal/vulndb/sync.go
@@ -188,7 +188,15 @@ func (r *SyncRunner) RunDue(ctx context.Context, limit int) (SyncDueJobsResult, 
 	}
 	result := SyncDueJobsResult{Jobs: make([]SyncJobRunResult, 0, len(jobs))}
 	for _, job := range jobs {
-		run, _ := r.RunJob(ctx, job.ID)
+		run, err := r.RunJob(ctx, job.ID)
+		if err != nil {
+			run = SyncJobRunResult{
+				JobID:  strings.TrimSpace(job.ID),
+				Source: strings.TrimSpace(job.Source),
+				Status: "failed",
+				Error:  err.Error(),
+			}
+		}
 		result.Jobs = append(result.Jobs, run)
 	}
 	return result, nil

--- a/internal/vulndb/sync.go
+++ b/internal/vulndb/sync.go
@@ -263,7 +263,10 @@ func (r *SyncRunner) runJob(ctx context.Context, id string, requireDue bool) (Sy
 			run.Status = "completed"
 			run.Imported = &imported
 			run.NextRunAt = nextRunAt
-			if completeErr := r.jobs.CompleteSyncJob(ctx, job.ID, owner, nextRunAt); completeErr != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cancel()
+			if completeErr := r.jobs.CompleteSyncJob(cleanupCtx, job.ID, owner, nextRunAt); completeErr != nil {
+				_ = r.jobs.ReleaseSyncJobLease(cleanupCtx, job.ID, owner)
 				return run, completeErr
 			}
 			return run, nil

--- a/internal/vulndb/sync.go
+++ b/internal/vulndb/sync.go
@@ -272,10 +272,12 @@ func (r *SyncRunner) runJob(ctx context.Context, id string, requireDue bool) (Sy
 	if err == nil {
 		err = fmt.Errorf("sync job failed")
 	}
-	_ = recordSyncFailure(ctx, r.store, job.Source, err)
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	_ = recordSyncFailure(cleanupCtx, r.store, job.Source, err)
 	run.Error = err.Error()
 	run.NextRunAt = nextRunAt
-	if failErr := r.jobs.FailSyncJob(ctx, job.ID, owner, nextRunAt, err); failErr != nil {
+	if failErr := r.jobs.FailSyncJob(cleanupCtx, job.ID, owner, nextRunAt, err); failErr != nil {
 		return run, failErr
 	}
 	return run, nil

--- a/internal/vulndb/sync.go
+++ b/internal/vulndb/sync.go
@@ -188,7 +188,7 @@ func (r *SyncRunner) RunDue(ctx context.Context, limit int) (SyncDueJobsResult, 
 	}
 	result := SyncDueJobsResult{Jobs: make([]SyncJobRunResult, 0, len(jobs))}
 	for _, job := range jobs {
-		run, err := r.RunJob(ctx, job.ID)
+		run, err := r.runJob(ctx, job.ID, true)
 		if err != nil {
 			run = SyncJobRunResult{
 				JobID:  strings.TrimSpace(job.ID),
@@ -204,6 +204,10 @@ func (r *SyncRunner) RunDue(ctx context.Context, limit int) (SyncDueJobsResult, 
 
 // RunJob runs one durable sync job by ID with lease protection.
 func (r *SyncRunner) RunJob(ctx context.Context, id string) (SyncJobRunResult, error) {
+	return r.runJob(ctx, id, false)
+}
+
+func (r *SyncRunner) runJob(ctx context.Context, id string, requireDue bool) (SyncJobRunResult, error) {
 	if r == nil {
 		return SyncJobRunResult{}, fmt.Errorf("vulndb sync runner is required")
 	}
@@ -229,6 +233,22 @@ func (r *SyncRunner) RunJob(ctx context.Context, id string) (SyncJobRunResult, e
 			Source: job.Source,
 			Status: "leased",
 		}, nil
+	}
+	if requireDue {
+		refreshed, ok, err := r.jobs.GetSyncJob(ctx, job.ID)
+		if err != nil {
+			_ = r.jobs.ReleaseSyncJobLease(ctx, job.ID, owner)
+			return SyncJobRunResult{}, err
+		}
+		if !ok {
+			_ = r.jobs.ReleaseSyncJobLease(ctx, job.ID, owner)
+			return SyncJobRunResult{}, fmt.Errorf("%w: %s", ErrSyncJobNotFound, job.ID)
+		}
+		if !refreshed.NextRunAt.IsZero() && refreshed.NextRunAt.After(r.now()) {
+			_ = r.jobs.ReleaseSyncJobLease(ctx, job.ID, owner)
+			return SyncJobRunResult{JobID: refreshed.ID, Source: refreshed.Source, Status: "not_due", NextRunAt: refreshed.NextRunAt}, nil
+		}
+		job = refreshed
 	}
 	run := SyncJobRunResult{JobID: job.ID, Source: job.Source, Status: "failed"}
 	nextRunAt := r.nextRunAt(job)
@@ -288,6 +308,16 @@ func ImportFeed(ctx context.Context, store Store, source string, reader io.Reade
 		return ImportNVD(ctx, store, reader)
 	default:
 		return ImportResult{}, fmt.Errorf("unsupported vulndb feed source %q", strings.TrimSpace(source))
+	}
+}
+
+// IsSupportedFeedSource reports whether source can be imported by ImportFeed.
+func IsSupportedFeedSource(source string) bool {
+	switch normalizeSource(source) {
+	case SourceOSV, SourceCISAKEV, SourceEPSS, SourceNVD:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/vulndb/sync.go
+++ b/internal/vulndb/sync.go
@@ -1,0 +1,310 @@
+package vulndb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultSyncJobLeaseTTL = 30 * time.Minute
+	DefaultSyncJobLimit    = 10
+)
+
+// FeedOpener opens one advisory feed URL or path for import.
+type FeedOpener func(context.Context, SyncJob) (io.ReadCloser, error)
+
+// FeedClient opens advisory feed URLs or paths.
+type FeedClient interface {
+	Open(context.Context, string, bool) (io.ReadCloser, error)
+}
+
+// SyncFeed identifies one advisory feed to import.
+type SyncFeed struct {
+	Source            string
+	URL               string
+	AllowInsecureHTTP bool
+}
+
+// SyncResult summarizes a direct multi-feed sync operation.
+type SyncResult struct {
+	Results map[string]ImportResult `json:"results"`
+}
+
+// SyncService imports direct feeds and executes durable sync jobs.
+type SyncService struct {
+	store  Store
+	client FeedClient
+}
+
+// NewSyncService constructs a vulnerability advisory feed sync service.
+func NewSyncService(store Store, client FeedClient) (*SyncService, error) {
+	if store == nil {
+		return nil, fmt.Errorf("vulnerability store is required")
+	}
+	if client == nil {
+		return nil, fmt.Errorf("vulndb feed client is required")
+	}
+	return &SyncService{store: store, client: client}, nil
+}
+
+// Sync imports all supplied feeds into the shared vulnerability store.
+func (s *SyncService) Sync(ctx context.Context, feeds []SyncFeed) (SyncResult, error) {
+	if s == nil {
+		return SyncResult{}, fmt.Errorf("vulndb sync service is required")
+	}
+	result := SyncResult{Results: make(map[string]ImportResult, len(feeds))}
+	for _, feed := range feeds {
+		source := normalizeSource(feed.Source)
+		if source == "" {
+			return SyncResult{}, fmt.Errorf("feed source is required")
+		}
+		reader, err := s.client.Open(ctx, feed.URL, feed.AllowInsecureHTTP)
+		if err != nil {
+			_ = recordSyncFailure(ctx, s.store, source, err)
+			return result, err
+		}
+		imported, importErr := ImportFeed(ctx, s.store, source, reader)
+		closeErr := reader.Close()
+		if importErr != nil {
+			_ = recordSyncFailure(ctx, s.store, source, importErr)
+			return result, importErr
+		}
+		if closeErr != nil {
+			_ = recordSyncFailure(ctx, s.store, source, closeErr)
+			return result, closeErr
+		}
+		result.Results[source] = imported
+	}
+	return result, nil
+}
+
+// RunSyncJob executes one durable sync job.
+func (s *SyncService) RunSyncJob(ctx context.Context, jobs SyncJobStore, jobID string, owner string, leaseTTL time.Duration) (ImportResult, error) {
+	runner, err := NewSyncRunner(s.store, jobs, s.openJobFeed)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	run, err := runner.WithOwner(owner).WithLeaseTTL(leaseTTL).RunJob(ctx, jobID)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	if run.Imported == nil {
+		if run.Error != "" {
+			return ImportResult{}, fmt.Errorf("%s", run.Error)
+		}
+		return ImportResult{}, fmt.Errorf("sync job %q was not run: %s", jobID, run.Status)
+	}
+	return *run.Imported, nil
+}
+
+// RunDueSyncJobs executes currently due durable sync jobs.
+func (s *SyncService) RunDueSyncJobs(ctx context.Context, jobs SyncJobStore, _ time.Time, owner string, leaseTTL time.Duration, limit int) (SyncDueJobsResult, error) {
+	runner, err := NewSyncRunner(s.store, jobs, s.openJobFeed)
+	if err != nil {
+		return SyncDueJobsResult{}, err
+	}
+	return runner.WithOwner(owner).WithLeaseTTL(leaseTTL).RunDue(ctx, limit)
+}
+
+func (s *SyncService) openJobFeed(ctx context.Context, job SyncJob) (io.ReadCloser, error) {
+	return s.client.Open(ctx, job.FeedURL, job.AllowInsecureHTTP)
+}
+
+// SyncJobRunResult describes one attempted advisory feed sync job run.
+type SyncJobRunResult struct {
+	JobID     string        `json:"job_id"`
+	Source    string        `json:"source"`
+	Status    string        `json:"status"`
+	Imported  *ImportResult `json:"imported,omitempty"`
+	NextRunAt time.Time     `json:"next_run_at,omitempty"`
+	Error     string        `json:"error,omitempty"`
+}
+
+// SyncDueJobsResult summarizes one due-job polling pass.
+type SyncDueJobsResult struct {
+	Jobs []SyncJobRunResult `json:"jobs"`
+}
+
+// SyncRunner executes durable advisory feed sync jobs against a shared store.
+type SyncRunner struct {
+	store    Store
+	jobs     SyncJobStore
+	openFeed FeedOpener
+	owner    string
+	leaseTTL time.Duration
+	now      func() time.Time
+}
+
+// NewSyncRunner constructs a durable advisory feed sync runner.
+func NewSyncRunner(store Store, jobs SyncJobStore, openFeed FeedOpener) (*SyncRunner, error) {
+	if store == nil {
+		return nil, fmt.Errorf("vulnerability store is required")
+	}
+	if jobs == nil {
+		return nil, fmt.Errorf("vulndb sync job store is required")
+	}
+	if openFeed == nil {
+		return nil, fmt.Errorf("vulndb feed opener is required")
+	}
+	return &SyncRunner{
+		store:    store,
+		jobs:     jobs,
+		openFeed: openFeed,
+		leaseTTL: DefaultSyncJobLeaseTTL,
+		now:      func() time.Time { return time.Now().UTC() },
+	}, nil
+}
+
+// WithOwner configures the lease owner used for job execution.
+func (r *SyncRunner) WithOwner(owner string) *SyncRunner {
+	if r != nil {
+		r.owner = strings.TrimSpace(owner)
+	}
+	return r
+}
+
+// WithLeaseTTL configures the per-job lease TTL.
+func (r *SyncRunner) WithLeaseTTL(ttl time.Duration) *SyncRunner {
+	if r != nil && ttl > 0 {
+		r.leaseTTL = ttl
+	}
+	return r
+}
+
+// RunDue runs currently due sync jobs up to the supplied limit.
+func (r *SyncRunner) RunDue(ctx context.Context, limit int) (SyncDueJobsResult, error) {
+	if r == nil {
+		return SyncDueJobsResult{}, fmt.Errorf("vulndb sync runner is required")
+	}
+	if limit <= 0 {
+		limit = DefaultSyncJobLimit
+	}
+	jobs, err := r.jobs.ListDueSyncJobs(ctx, r.now(), limit)
+	if err != nil {
+		return SyncDueJobsResult{}, err
+	}
+	result := SyncDueJobsResult{Jobs: make([]SyncJobRunResult, 0, len(jobs))}
+	for _, job := range jobs {
+		run, _ := r.RunJob(ctx, job.ID)
+		result.Jobs = append(result.Jobs, run)
+	}
+	return result, nil
+}
+
+// RunJob runs one durable sync job by ID with lease protection.
+func (r *SyncRunner) RunJob(ctx context.Context, id string) (SyncJobRunResult, error) {
+	if r == nil {
+		return SyncJobRunResult{}, fmt.Errorf("vulndb sync runner is required")
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return SyncJobRunResult{}, fmt.Errorf("sync job id is required")
+	}
+	job, ok, err := r.jobs.GetSyncJob(ctx, id)
+	if err != nil {
+		return SyncJobRunResult{}, err
+	}
+	if !ok {
+		return SyncJobRunResult{}, fmt.Errorf("%w: %s", ErrSyncJobNotFound, id)
+	}
+	owner := r.leaseOwner()
+	acquired, err := r.jobs.AcquireSyncJobLease(ctx, job.ID, owner, r.leaseTTL)
+	if err != nil {
+		return SyncJobRunResult{}, err
+	}
+	if !acquired {
+		return SyncJobRunResult{
+			JobID:  job.ID,
+			Source: job.Source,
+			Status: "leased",
+		}, nil
+	}
+	run := SyncJobRunResult{JobID: job.ID, Source: job.Source, Status: "failed"}
+	nextRunAt := r.nextRunAt(job)
+	reader, err := r.openFeed(ctx, job)
+	if err == nil {
+		defer func() {
+			_ = reader.Close()
+		}()
+		var imported ImportResult
+		imported, err = ImportFeed(ctx, r.store, job.Source, reader)
+		if err == nil {
+			run.Status = "completed"
+			run.Imported = &imported
+			run.NextRunAt = nextRunAt
+			if completeErr := r.jobs.CompleteSyncJob(ctx, job.ID, owner, nextRunAt); completeErr != nil {
+				return run, completeErr
+			}
+			return run, nil
+		}
+	}
+	if err == nil {
+		err = fmt.Errorf("sync job failed")
+	}
+	_ = recordSyncFailure(ctx, r.store, job.Source, err)
+	run.Error = err.Error()
+	run.NextRunAt = nextRunAt
+	if failErr := r.jobs.FailSyncJob(ctx, job.ID, owner, nextRunAt, err); failErr != nil {
+		return run, failErr
+	}
+	return run, nil
+}
+
+func (r *SyncRunner) leaseOwner() string {
+	if strings.TrimSpace(r.owner) != "" {
+		return strings.TrimSpace(r.owner)
+	}
+	return fmt.Sprintf("vulndb-sync:%d", time.Now().UnixNano())
+}
+
+func (r *SyncRunner) nextRunAt(job SyncJob) time.Time {
+	if job.Interval <= 0 {
+		return time.Time{}
+	}
+	return r.now().Add(job.Interval)
+}
+
+// ImportFeed imports one advisory feed by normalized source label.
+func ImportFeed(ctx context.Context, store Store, source string, reader io.Reader) (ImportResult, error) {
+	switch normalizeSource(source) {
+	case SourceOSV:
+		return ImportOSV(ctx, store, reader)
+	case SourceCISAKEV:
+		return ImportCISAKEV(ctx, store, reader)
+	case SourceEPSS:
+		return ImportEPSS(ctx, store, reader)
+	case SourceNVD:
+		return ImportNVD(ctx, store, reader)
+	default:
+		return ImportResult{}, fmt.Errorf("unsupported vulndb feed source %q", strings.TrimSpace(source))
+	}
+}
+
+func recordSyncSuccess(ctx context.Context, store Store, source string) error {
+	state, _, err := store.GetSyncState(ctx, source)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	state.Source = normalizeSource(source)
+	state.LastSyncedAt = now
+	state.LastSuccessAt = now
+	state.LastError = ""
+	return store.PutSyncState(ctx, state)
+}
+
+func recordSyncFailure(ctx context.Context, store Store, source string, syncErr error) error {
+	state, _, err := store.GetSyncState(ctx, source)
+	if err != nil {
+		return err
+	}
+	state.Source = normalizeSource(source)
+	state.LastSyncedAt = time.Now().UTC()
+	if syncErr != nil {
+		state.LastError = syncErr.Error()
+	}
+	return store.PutSyncState(ctx, state)
+}

--- a/internal/vulndb/sync_test.go
+++ b/internal/vulndb/sync_test.go
@@ -1,0 +1,135 @@
+package vulndb
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type staticFeedClient map[string]string
+
+func (c staticFeedClient) Open(_ context.Context, source string, _ bool) (io.ReadCloser, error) {
+	payload, ok := c[source]
+	if !ok {
+		return nil, errors.New("feed not found")
+	}
+	return io.NopCloser(strings.NewReader(payload)), nil
+}
+
+type failingFeedClient struct{}
+
+func (failingFeedClient) Open(context.Context, string, bool) (io.ReadCloser, error) {
+	return nil, errors.New("feed down")
+}
+
+func TestSyncServiceRecordsFailureState(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	service, err := NewSyncService(store, failingFeedClient{})
+	if err != nil {
+		t.Fatalf("new sync service: %v", err)
+	}
+	if _, err := service.Sync(ctx, []SyncFeed{{Source: SourceOSV, URL: "https://example.com/osv.json"}}); err == nil {
+		t.Fatal("Sync() error = nil, want feed failure")
+	}
+	state, ok, err := store.GetSyncState(ctx, SourceOSV)
+	if err != nil {
+		t.Fatalf("get sync state: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected sync state after failure")
+	}
+	if !strings.Contains(state.LastError, "feed down") || state.LastSyncedAt.IsZero() {
+		t.Fatalf("unexpected failure sync state: %+v", state)
+	}
+}
+
+func TestSyncRunnerLeasesAndCompletesJob(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.PutSyncJob(ctx, SyncJob{
+		ID:       "osv-hourly",
+		Source:   SourceOSV,
+		FeedURL:  "osv-feed",
+		Interval: time.Hour,
+	}); err != nil {
+		t.Fatalf("put sync job: %v", err)
+	}
+	service, err := NewSyncService(store, staticFeedClient{
+		"osv-feed": `[{"id":"CVE-2026-12121","summary":"synced vuln"}]`,
+	})
+	if err != nil {
+		t.Fatalf("new sync service: %v", err)
+	}
+	imported, err := service.RunSyncJob(ctx, store, "osv-hourly", "worker-1", time.Minute)
+	if err != nil {
+		t.Fatalf("run sync job: %v", err)
+	}
+	if imported.Vulnerabilities != 1 {
+		t.Fatalf("imported = %+v, want one vulnerability", imported)
+	}
+	job, ok, err := store.GetSyncJob(ctx, "osv-hourly")
+	if err != nil {
+		t.Fatalf("get sync job: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected stored sync job")
+	}
+	if job.Runs != 1 || job.LastSuccessAt.IsZero() || !job.LeaseExpiresAt.IsZero() || job.LeaseOwner != "" || job.NextRunAt.IsZero() {
+		t.Fatalf("unexpected completed job: %+v", job)
+	}
+	if _, ok, err := store.FindVulnerability(ctx, "CVE-2026-12121"); err != nil || !ok {
+		t.Fatalf("synced vulnerability lookup ok=%v err=%v, want found", ok, err)
+	}
+	due, err := store.ListDueSyncJobs(ctx, time.Now().UTC(), 10)
+	if err != nil {
+		t.Fatalf("list due sync jobs: %v", err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("due jobs = %+v, want none before next_run_at", due)
+	}
+}
+
+func TestFileStorePersistsSyncJobRecovery(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "vulndb.json")
+	store, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("new file store: %v", err)
+	}
+	if err := store.PutSyncJob(ctx, SyncJob{ID: "nvd-daily", Source: SourceNVD, FeedURL: "nvd-feed", Interval: 24 * time.Hour}); err != nil {
+		t.Fatalf("put sync job: %v", err)
+	}
+	acquired, err := store.AcquireSyncJobLease(ctx, "nvd-daily", "worker-1", time.Minute)
+	if err != nil {
+		t.Fatalf("acquire sync job lease: %v", err)
+	}
+	if !acquired {
+		t.Fatal("expected sync job lease")
+	}
+	if err := store.ReleaseSyncJobLease(ctx, "nvd-daily", "worker-1"); err != nil {
+		t.Fatalf("release sync job lease: %v", err)
+	}
+	reopened, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("reopen file store: %v", err)
+	}
+	job, ok, err := reopened.GetSyncJob(ctx, "nvd-daily")
+	if err != nil {
+		t.Fatalf("get sync job: %v", err)
+	}
+	if !ok || job.Source != SourceNVD || job.FeedURL != "nvd-feed" || job.Interval != 24*time.Hour {
+		t.Fatalf("unexpected recovered sync job: ok=%v job=%+v", ok, job)
+	}
+	stats, err := reopened.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.SyncJobs != 1 {
+		t.Fatalf("stats.SyncJobs = %d, want 1", stats.SyncJobs)
+	}
+}

--- a/internal/vulndb/sync_test.go
+++ b/internal/vulndb/sync_test.go
@@ -139,6 +139,14 @@ func TestMemoryStoreRejectsZeroIntervalSyncJob(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreRejectsUnsupportedSyncJobSource(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.PutSyncJob(ctx, SyncJob{ID: "bad", Source: "typo", FeedURL: "feed", Interval: time.Hour}); err == nil {
+		t.Fatal("PutSyncJob() error = nil, want unsupported source rejection")
+	}
+}
+
 func TestMemoryStorePutSyncJobPreservesNextRunAt(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()
@@ -172,6 +180,38 @@ func TestMemoryStorePutSyncJobPreservesNextRunAt(t *testing.T) {
 	}
 	if job.FeedURL != "osv-feed-updated" || job.Interval != 2*time.Hour {
 		t.Fatalf("expected editable fields to update, got %+v", job)
+	}
+}
+
+func TestSyncRunnerRunDueRechecksNextRunAtAfterLease(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	future := time.Now().UTC().Add(time.Hour)
+	if err := store.PutSyncJob(ctx, SyncJob{
+		ID:        "osv-hourly",
+		Source:    SourceOSV,
+		FeedURL:   "osv-feed",
+		Interval:  time.Hour,
+		NextRunAt: future,
+	}); err != nil {
+		t.Fatalf("put sync job: %v", err)
+	}
+	runner, err := NewSyncRunner(store, store, func(context.Context, SyncJob) (io.ReadCloser, error) {
+		t.Fatal("openFeed should not be called for no-longer-due job")
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("new sync runner: %v", err)
+	}
+	if err := store.CompleteSyncJob(ctx, "osv-hourly", "", future); err != nil {
+		t.Fatalf("complete sync job: %v", err)
+	}
+	run, err := runner.runJob(ctx, "osv-hourly", true)
+	if err != nil {
+		t.Fatalf("run due job: %v", err)
+	}
+	if run.Status != "not_due" {
+		t.Fatalf("Status = %q, want not_due", run.Status)
 	}
 }
 

--- a/internal/vulndb/sync_test.go
+++ b/internal/vulndb/sync_test.go
@@ -288,3 +288,47 @@ func TestFileStoreSyncJobLeaseReloadsBeforeAcquire(t *testing.T) {
 		t.Fatal("expected worker2 to observe persisted lease and skip acquisition")
 	}
 }
+
+func TestFileStoreReloadsSyncJobsBeforeRead(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "vulndb.json")
+	seed, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("new seed file store: %v", err)
+	}
+	if err := seed.PutSyncJob(ctx, SyncJob{ID: "osv-hourly", Source: SourceOSV, FeedURL: "old-feed", Interval: time.Hour}); err != nil {
+		t.Fatalf("put seed sync job: %v", err)
+	}
+	reader, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("new reader store: %v", err)
+	}
+	writer, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("new writer store: %v", err)
+	}
+	nextRunAt := time.Now().UTC().Add(time.Hour)
+	if err := writer.PutSyncJob(ctx, SyncJob{
+		ID:        "osv-hourly",
+		Source:    SourceOSV,
+		FeedURL:   "new-feed",
+		Interval:  time.Hour,
+		NextRunAt: nextRunAt,
+	}); err != nil {
+		t.Fatalf("update sync job: %v", err)
+	}
+	job, ok, err := reader.GetSyncJob(ctx, "osv-hourly")
+	if err != nil {
+		t.Fatalf("reader get sync job: %v", err)
+	}
+	if !ok || job.FeedURL != "new-feed" || !job.NextRunAt.Equal(nextRunAt) {
+		t.Fatalf("reader observed stale job: ok=%v job=%+v", ok, job)
+	}
+	due, err := reader.ListDueSyncJobs(ctx, time.Now().UTC(), 10)
+	if err != nil {
+		t.Fatalf("reader list due sync jobs: %v", err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("due jobs = %+v, want none after reload of future next_run_at", due)
+	}
+}

--- a/internal/vulndb/sync_test.go
+++ b/internal/vulndb/sync_test.go
@@ -26,6 +26,14 @@ func (failingFeedClient) Open(context.Context, string, bool) (io.ReadCloser, err
 	return nil, errors.New("feed down")
 }
 
+type brokenGetSyncJobStore struct {
+	*MemoryStore
+}
+
+func (s brokenGetSyncJobStore) GetSyncJob(context.Context, string) (SyncJob, bool, error) {
+	return SyncJob{}, false, errors.New("metadata unavailable")
+}
+
 func TestSyncServiceRecordsFailureState(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()
@@ -45,6 +53,35 @@ func TestSyncServiceRecordsFailureState(t *testing.T) {
 	}
 	if !strings.Contains(state.LastError, "feed down") || state.LastSyncedAt.IsZero() {
 		t.Fatalf("unexpected failure sync state: %+v", state)
+	}
+}
+
+func TestSyncRunnerRunDueSurfacesJobMetadataErrors(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.PutSyncJob(ctx, SyncJob{
+		ID:       "osv-hourly",
+		Source:   SourceOSV,
+		FeedURL:  "osv-feed",
+		Interval: time.Hour,
+	}); err != nil {
+		t.Fatalf("put sync job: %v", err)
+	}
+	runner, err := NewSyncRunner(store, brokenGetSyncJobStore{MemoryStore: store}, func(context.Context, SyncJob) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(`[]`)), nil
+	})
+	if err != nil {
+		t.Fatalf("new sync runner: %v", err)
+	}
+	result, err := runner.RunDue(ctx, 10)
+	if err != nil {
+		t.Fatalf("run due: %v", err)
+	}
+	if len(result.Jobs) != 1 {
+		t.Fatalf("jobs = %+v, want one failure", result.Jobs)
+	}
+	if result.Jobs[0].JobID != "osv-hourly" || result.Jobs[0].Status != "failed" || !strings.Contains(result.Jobs[0].Error, "metadata unavailable") {
+		t.Fatalf("unexpected job result: %+v", result.Jobs[0])
 	}
 }
 

--- a/internal/vulndb/sync_test.go
+++ b/internal/vulndb/sync_test.go
@@ -34,6 +34,29 @@ func (s brokenGetSyncJobStore) GetSyncJob(context.Context, string) (SyncJob, boo
 	return SyncJob{}, false, errors.New("metadata unavailable")
 }
 
+type cancelAfterSyncStateStore struct {
+	*MemoryStore
+	cancel context.CancelFunc
+}
+
+func (s cancelAfterSyncStateStore) PutSyncState(ctx context.Context, state SyncState) error {
+	if err := s.MemoryStore.PutSyncState(ctx, state); err != nil {
+		return err
+	}
+	s.cancel()
+	return nil
+}
+
+type failingCompleteSyncJobStore struct {
+	*MemoryStore
+}
+
+var errCompleteFailed = errors.New("complete failed")
+
+func (s failingCompleteSyncJobStore) CompleteSyncJob(context.Context, string, string, time.Time) error {
+	return errCompleteFailed
+}
+
 func TestSyncServiceRecordsFailureState(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()
@@ -175,6 +198,81 @@ func TestSyncRunnerRecordsFailureWithCanceledRunContext(t *testing.T) {
 	}
 	if !ok || !strings.Contains(state.LastError, "context canceled") {
 		t.Fatalf("expected canceled sync state, ok=%v state=%+v", ok, state)
+	}
+}
+
+func TestSyncRunnerCompletesSuccessfulJobWithCanceledRunContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := NewMemoryStore()
+	if err := store.PutSyncJob(context.Background(), SyncJob{
+		ID:       "osv-hourly",
+		Source:   SourceOSV,
+		FeedURL:  "osv-feed",
+		Interval: time.Hour,
+	}); err != nil {
+		t.Fatalf("put sync job: %v", err)
+	}
+	runner, err := NewSyncRunner(cancelAfterSyncStateStore{MemoryStore: store, cancel: cancel}, store, func(context.Context, SyncJob) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(`[{"id":"CVE-2026-12121","summary":"synced vuln"}]`)), nil
+	})
+	if err != nil {
+		t.Fatalf("new sync runner: %v", err)
+	}
+	run, err := runner.WithOwner("worker-1").RunJob(ctx, "osv-hourly")
+	if err != nil {
+		t.Fatalf("run sync job: %v", err)
+	}
+	if run.Status != "completed" || run.Imported == nil || run.Imported.Vulnerabilities != 1 {
+		t.Fatalf("unexpected run result: %+v", run)
+	}
+	job, ok, err := store.GetSyncJob(context.Background(), "osv-hourly")
+	if err != nil {
+		t.Fatalf("get sync job: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected stored sync job")
+	}
+	if job.LeaseOwner != "" || !job.LeaseExpiresAt.IsZero() || job.LastSuccessAt.IsZero() || job.NextRunAt.IsZero() {
+		t.Fatalf("expected canceled successful run to complete and release lease, got %+v", job)
+	}
+}
+
+func TestSyncRunnerReleasesLeaseWhenSuccessfulCompletionFails(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.PutSyncJob(ctx, SyncJob{
+		ID:       "osv-hourly",
+		Source:   SourceOSV,
+		FeedURL:  "osv-feed",
+		Interval: time.Hour,
+	}); err != nil {
+		t.Fatalf("put sync job: %v", err)
+	}
+	runner, err := NewSyncRunner(store, failingCompleteSyncJobStore{MemoryStore: store}, func(context.Context, SyncJob) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(`[{"id":"CVE-2026-12121","summary":"synced vuln"}]`)), nil
+	})
+	if err != nil {
+		t.Fatalf("new sync runner: %v", err)
+	}
+	run, err := runner.WithOwner("worker-1").RunJob(ctx, "osv-hourly")
+	if err == nil {
+		t.Fatal("RunJob() error = nil, want completion failure")
+	}
+	if !errors.Is(err, errCompleteFailed) {
+		t.Fatalf("RunJob() error = %v, want completion failure", err)
+	}
+	if run.Status != "completed" || run.Imported == nil || run.Imported.Vulnerabilities != 1 {
+		t.Fatalf("unexpected run result after completion failure: %+v", run)
+	}
+	job, ok, err := store.GetSyncJob(ctx, "osv-hourly")
+	if err != nil {
+		t.Fatalf("get sync job: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected stored sync job")
+	}
+	if job.LeaseOwner != "" || !job.LeaseExpiresAt.IsZero() {
+		t.Fatalf("expected completion failure to release lease, got %+v", job)
 	}
 }
 

--- a/internal/vulndb/sync_test.go
+++ b/internal/vulndb/sync_test.go
@@ -131,6 +131,53 @@ func TestSyncRunnerLeasesAndCompletesJob(t *testing.T) {
 	}
 }
 
+func TestSyncRunnerRecordsFailureWithCanceledRunContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := NewMemoryStore()
+	if err := store.PutSyncJob(context.Background(), SyncJob{
+		ID:       "osv-hourly",
+		Source:   SourceOSV,
+		FeedURL:  "osv-feed",
+		Interval: time.Hour,
+	}); err != nil {
+		t.Fatalf("put sync job: %v", err)
+	}
+	runner, err := NewSyncRunner(store, store, func(context.Context, SyncJob) (io.ReadCloser, error) {
+		cancel()
+		return nil, context.Canceled
+	})
+	if err != nil {
+		t.Fatalf("new sync runner: %v", err)
+	}
+	run, err := runner.WithOwner("worker-1").RunJob(ctx, "osv-hourly")
+	if err != nil {
+		t.Fatalf("run sync job: %v", err)
+	}
+	if run.Status != "failed" || !strings.Contains(run.Error, "context canceled") {
+		t.Fatalf("unexpected run result: %+v", run)
+	}
+	job, ok, err := store.GetSyncJob(context.Background(), "osv-hourly")
+	if err != nil {
+		t.Fatalf("get sync job: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected stored sync job")
+	}
+	if job.LeaseOwner != "" || !job.LeaseExpiresAt.IsZero() {
+		t.Fatalf("expected canceled failure to release lease, got %+v", job)
+	}
+	if !strings.Contains(job.LastError, "context canceled") || job.LastFinishedAt.IsZero() {
+		t.Fatalf("expected canceled failure metadata, got %+v", job)
+	}
+	state, ok, err := store.GetSyncState(context.Background(), SourceOSV)
+	if err != nil {
+		t.Fatalf("get sync state: %v", err)
+	}
+	if !ok || !strings.Contains(state.LastError, "context canceled") {
+		t.Fatalf("expected canceled sync state, ok=%v state=%+v", ok, state)
+	}
+}
+
 func TestMemoryStoreRejectsZeroIntervalSyncJob(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()

--- a/internal/vulndb/sync_test.go
+++ b/internal/vulndb/sync_test.go
@@ -131,6 +131,14 @@ func TestSyncRunnerLeasesAndCompletesJob(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreRejectsZeroIntervalSyncJob(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.PutSyncJob(ctx, SyncJob{ID: "osv", Source: SourceOSV, FeedURL: "osv-feed"}); err == nil {
+		t.Fatal("PutSyncJob() error = nil, want positive interval requirement")
+	}
+}
+
 func TestFileStorePersistsSyncJobRecovery(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "vulndb.json")
@@ -168,5 +176,39 @@ func TestFileStorePersistsSyncJobRecovery(t *testing.T) {
 	}
 	if stats.SyncJobs != 1 {
 		t.Fatalf("stats.SyncJobs = %d, want 1", stats.SyncJobs)
+	}
+}
+
+func TestFileStoreSyncJobLeaseReloadsBeforeAcquire(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "vulndb.json")
+	seed, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("new seed file store: %v", err)
+	}
+	if err := seed.PutSyncJob(ctx, SyncJob{ID: "osv-hourly", Source: SourceOSV, FeedURL: "osv-feed", Interval: time.Hour}); err != nil {
+		t.Fatalf("put sync job: %v", err)
+	}
+	worker1, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("new worker1 store: %v", err)
+	}
+	worker2, err := NewFileStore(ctx, path)
+	if err != nil {
+		t.Fatalf("new worker2 store: %v", err)
+	}
+	acquired, err := worker1.AcquireSyncJobLease(ctx, "osv-hourly", "worker-1", time.Minute)
+	if err != nil {
+		t.Fatalf("worker1 acquire: %v", err)
+	}
+	if !acquired {
+		t.Fatal("expected worker1 to acquire lease")
+	}
+	acquired, err = worker2.AcquireSyncJobLease(ctx, "osv-hourly", "worker-2", time.Minute)
+	if err != nil {
+		t.Fatalf("worker2 acquire: %v", err)
+	}
+	if acquired {
+		t.Fatal("expected worker2 to observe persisted lease and skip acquisition")
 	}
 }

--- a/internal/vulndb/sync_test.go
+++ b/internal/vulndb/sync_test.go
@@ -139,6 +139,42 @@ func TestMemoryStoreRejectsZeroIntervalSyncJob(t *testing.T) {
 	}
 }
 
+func TestMemoryStorePutSyncJobPreservesNextRunAt(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	nextRunAt := time.Date(2026, 5, 21, 20, 0, 0, 0, time.UTC)
+	if err := store.PutSyncJob(ctx, SyncJob{
+		ID:        "osv-hourly",
+		Source:    SourceOSV,
+		FeedURL:   "osv-feed",
+		Interval:  time.Hour,
+		NextRunAt: nextRunAt,
+	}); err != nil {
+		t.Fatalf("put scheduled sync job: %v", err)
+	}
+	if err := store.PutSyncJob(ctx, SyncJob{
+		ID:       "osv-hourly",
+		Source:   SourceOSV,
+		FeedURL:  "osv-feed-updated",
+		Interval: 2 * time.Hour,
+	}); err != nil {
+		t.Fatalf("update sync job: %v", err)
+	}
+	job, ok, err := store.GetSyncJob(ctx, "osv-hourly")
+	if err != nil {
+		t.Fatalf("get sync job: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected sync job")
+	}
+	if !job.NextRunAt.Equal(nextRunAt) {
+		t.Fatalf("NextRunAt = %v, want preserved %v", job.NextRunAt, nextRunAt)
+	}
+	if job.FeedURL != "osv-feed-updated" || job.Interval != 2*time.Hour {
+		t.Fatalf("expected editable fields to update, got %+v", job)
+	}
+}
+
 func TestFileStorePersistsSyncJobRecovery(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "vulndb.json")


### PR DESCRIPTION
### Why
Cerebro needs a shared vulnerability intelligence foundation for endpoint/package correlation and downstream enriched finding APIs.

### What changed
- Adds `internal/vulndb` models, memory/file stores, matching, feed importers, sync state, and durable sync jobs.
- Adds Postgres state-store support and bootstrap HTTP feed opener with transport guardrails.
- Adds `cerebro vulndb` CLI commands for stats, feed imports, sync, and sync-job execution.

### Validation
Commands run:
- `go -C /Users/jonathan/cerebro-graph-ask test ./internal/vulndb ./internal/bootstrap ./cmd/cerebro ./internal/statestore/postgres`
- `make -C /Users/jonathan/cerebro-graph-ask test`
- Pre-commit/pre-push hooks ran build, tests, lint, proto lint, OpenAPI checks, and arch tests.

Closes #612
