### PR TITLE
fix(sources): link endpoint owner ids

### DIFF
--- a/internal/sourceprojection/endpoint.go
+++ b/internal/sourceprojection/endpoint.go
@@ -199,7 +199,9 @@ func addEndpointOwnerLinks(entities map[string]*ports.ProjectedEntity, links map
 	}
 	for _, identifier := range []string{
 		firstAttribute(attrs, "owner_email"),
+		firstAttribute(attrs, "owner_id"),
 		firstAttribute(attrs, "user_email"),
+		firstAttribute(attrs, "user_id"),
 		firstAttribute(attrs, "primary_email"),
 		firstAttribute(attrs, "assigned_user"),
 	} {

--- a/internal/sourceprojection/endpoint_test.go
+++ b/internal/sourceprojection/endpoint_test.go
@@ -38,6 +38,32 @@ func TestProjectKolideDeviceLinksOwnerIdentity(t *testing.T) {
 	assertProjectedLink(t, state, deviceURN, relationOwnedBy, identityURN)
 }
 
+func TestProjectKolideDeviceLinksOwnerIDIdentity(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "kolide-device-1",
+		TenantId: "writer",
+		SourceId: "kolide",
+		Kind:     "kolide.device",
+		Attributes: map[string]string{
+			"device_id": "device-1",
+			"user_id":   "user-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	deviceURN := "urn:cerebro:writer:kolide_device:device-1"
+	identityURN := "urn:cerebro:writer:identity:login:user-1"
+	identifierURN := "urn:cerebro:writer:identifier:login:user-1"
+	assertProjectedLink(t, state, deviceURN, relationHasIdentifier, identifierURN)
+	assertProjectedLink(t, state, deviceURN, relationRepresentsIdentity, identityURN)
+	assertProjectedLink(t, state, deviceURN, relationOwnedBy, identityURN)
+}
+
 func TestProjectKolideSoftwareLinksDevicePackageAndCanonicalPackage(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)


### PR DESCRIPTION
Follow-up to #616 for Droid feedback: endpoint owner projection now treats owner_id/user_id as stable identity identifiers, preserving owner correlations when endpoint records do not include email fields.\n\nValidation:\n- go test ./internal/sourceprojection -run TestProjectKolideDeviceLinksOwnerIDIdentity -count=1\n- make verify