### PR TITLE
fix: close post-merge review gaps

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -903,7 +903,11 @@ paths:
           required: true
           schema:
             type: string
-        - $ref: '#/components/parameters/tenantIDQuery'
+        - name: tenant_id
+          in: query
+          required: true
+          schema:
+            type: string
         - name: include_stale
           in: query
           schema:

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -57,45 +58,45 @@ func runVulnDB(args []string) error {
 	case "import-osv":
 		reader, closeReader, err := openVulnDBInput(ctx, options.Source, options.AllowInsecureHTTP)
 		if err != nil {
-			return err
+			return recordVulnDBCommandFailure(ctx, opened.Store, vulndb.SourceOSV, err)
 		}
 		defer closeReader()
 		result, err := vulndb.ImportOSV(ctx, opened.Store, reader)
 		if err != nil {
-			return err
+			return recordVulnDBCommandFailure(ctx, opened.Store, vulndb.SourceOSV, err)
 		}
 		return printJSON(result)
 	case "import-kev":
 		reader, closeReader, err := openVulnDBInput(ctx, options.Source, options.AllowInsecureHTTP)
 		if err != nil {
-			return err
+			return recordVulnDBCommandFailure(ctx, opened.Store, vulndb.SourceCISAKEV, err)
 		}
 		defer closeReader()
 		result, err := vulndb.ImportCISAKEV(ctx, opened.Store, reader)
 		if err != nil {
-			return err
+			return recordVulnDBCommandFailure(ctx, opened.Store, vulndb.SourceCISAKEV, err)
 		}
 		return printJSON(result)
 	case "import-epss":
 		reader, closeReader, err := openVulnDBInput(ctx, options.Source, options.AllowInsecureHTTP)
 		if err != nil {
-			return err
+			return recordVulnDBCommandFailure(ctx, opened.Store, vulndb.SourceEPSS, err)
 		}
 		defer closeReader()
 		result, err := vulndb.ImportEPSS(ctx, opened.Store, reader)
 		if err != nil {
-			return err
+			return recordVulnDBCommandFailure(ctx, opened.Store, vulndb.SourceEPSS, err)
 		}
 		return printJSON(result)
 	case "import-nvd":
 		reader, closeReader, err := openVulnDBInput(ctx, options.Source, options.AllowInsecureHTTP)
 		if err != nil {
-			return err
+			return recordVulnDBCommandFailure(ctx, opened.Store, vulndb.SourceNVD, err)
 		}
 		defer closeReader()
 		result, err := vulndb.ImportNVD(ctx, opened.Store, reader)
 		if err != nil {
-			return err
+			return recordVulnDBCommandFailure(ctx, opened.Store, vulndb.SourceNVD, err)
 		}
 		return printJSON(result)
 	case "sync":
@@ -334,10 +335,24 @@ func runVulnDBSync(ctx context.Context, store vulndb.Store, options vulnDBOption
 func runVulnDBFeedSync(ctx context.Context, store vulndb.Store, source string, location string, allowInsecureHTTP bool) (vulndb.ImportResult, error) {
 	reader, closeReader, err := openVulnDBInput(ctx, location, allowInsecureHTTP)
 	if err != nil {
-		return vulndb.ImportResult{}, err
+		return vulndb.ImportResult{}, recordVulnDBCommandFailure(ctx, store, source, err)
 	}
 	defer closeReader()
-	return vulndb.ImportFeed(ctx, store, source, reader)
+	result, err := vulndb.ImportFeed(ctx, store, source, reader)
+	if err != nil {
+		return vulndb.ImportResult{}, recordVulnDBCommandFailure(ctx, store, source, err)
+	}
+	return result, nil
+}
+
+func recordVulnDBCommandFailure(ctx context.Context, store vulndb.Store, source string, syncErr error) error {
+	if syncErr == nil {
+		return nil
+	}
+	if err := vulndb.RecordSyncFailure(ctx, store, source, syncErr); err != nil {
+		return errors.Join(syncErr, fmt.Errorf("record vulndb sync failure: %w", err))
+	}
+	return syncErr
 }
 
 func openVulnDBInput(ctx context.Context, source string, allowInsecureHTTP bool) (io.Reader, func(), error) {

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -370,7 +371,10 @@ func (vulndbInputClient) Open(ctx context.Context, source string, allowInsecureH
 	if source == "" {
 		return nil, usageError("vulndb import source is required")
 	}
-	if isRemoteVulnDBSource(source) {
+	if vulnDBSourceScheme(source) != "" {
+		if !isRemoteVulnDBSource(source) {
+			return nil, vulndb.ValidateFeedURL(source, allowInsecureHTTP)
+		}
 		return bootstrap.OpenVulnDBFeed(ctx, source, allowInsecureHTTP)
 	}
 	file, err := os.Open(source)
@@ -383,6 +387,14 @@ func (vulndbInputClient) Open(ctx context.Context, source string, allowInsecureH
 func isRemoteVulnDBSource(source string) bool {
 	source = strings.ToLower(strings.TrimSpace(source))
 	return strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://")
+}
+
+func vulnDBSourceScheme(source string) string {
+	parsed, err := url.Parse(strings.TrimSpace(source))
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(parsed.Scheme))
 }
 
 type openedVulnDBStore struct {
@@ -456,7 +468,12 @@ func putVulnDBSyncJob(ctx context.Context, jobs vulndb.SyncJobStore, options vul
 		allowInsecureHTTP = existing.AllowInsecureHTTP
 	}
 	feedURL := strings.TrimSpace(options.Source)
-	if feedURL != "" && !isRemoteVulnDBSource(feedURL) && !filepath.IsAbs(feedURL) {
+	if feedURL != "" && vulnDBSourceScheme(feedURL) != "" && !isRemoteVulnDBSource(feedURL) {
+		if err := vulndb.ValidateFeedURL(feedURL, allowInsecureHTTP); err != nil {
+			return vulndb.SyncJob{}, usageError(err.Error())
+		}
+	}
+	if feedURL != "" && vulnDBSourceScheme(feedURL) == "" && !filepath.IsAbs(feedURL) {
 		absolute, err := filepath.Abs(feedURL)
 		if err != nil {
 			return vulndb.SyncJob{}, err

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -36,6 +36,14 @@ func TestVulnDBInputClientOpenTreatsRemoteSchemeCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestVulnDBInputClientRejectsUnsupportedURLSchemes(t *testing.T) {
+	for _, source := range []string{"file:///tmp/osv.json", "ftp://mirror.example/osv.json"} {
+		if _, err := (vulndbInputClient{}).Open(context.Background(), source, true); err == nil {
+			t.Fatalf("Open(%q) error = nil, want unsupported scheme rejection", source)
+		}
+	}
+}
+
 func TestParseVulnDBOptionsSyncJobFields(t *testing.T) {
 	options, err := parseVulnDBOptions([]string{
 		"store=file",
@@ -95,6 +103,21 @@ func TestPutVulnDBSyncJobRejectsInsecureHTTPWithoutOptIn(t *testing.T) {
 	}
 	if _, ok, err := store.GetSyncJob(ctx, "osv-hourly"); err != nil || ok {
 		t.Fatalf("stored insecure job ok=%v err=%v, want not persisted", ok, err)
+	}
+}
+
+func TestPutVulnDBSyncJobRejectsUnsupportedURLSchemes(t *testing.T) {
+	ctx := context.Background()
+	store := vulndb.NewMemoryStore()
+	for _, source := range []string{"file:///tmp/osv.json", "ftp://mirror.example/osv.json"} {
+		if _, err := putVulnDBSyncJob(ctx, store, vulnDBOptions{
+			JobID:       "osv-hourly",
+			FeedSource:  vulndb.SourceOSV,
+			Source:      source,
+			JobInterval: time.Hour,
+		}); err == nil {
+			t.Fatalf("put sync job source %q error = nil, want unsupported scheme rejection", source)
+		}
 	}
 }
 

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -135,6 +136,58 @@ func TestPutVulnDBSyncJobPreservesAllowInsecureHTTPWhenOmitted(t *testing.T) {
 	}
 	if job.AllowInsecureHTTP {
 		t.Fatal("AllowInsecureHTTP = true, want explicit false to clear")
+	}
+}
+
+func TestRunVulnDBImportRecordsFailureState(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "vulndb.json")
+	feedPath := filepath.Join(dir, "bad-osv.json")
+	if err := os.WriteFile(feedPath, []byte(`[`), 0o600); err != nil {
+		t.Fatalf("write bad feed: %v", err)
+	}
+
+	err := runVulnDB([]string{"import-osv", feedPath, "state_file=" + stateFile})
+	if err == nil {
+		t.Fatal("runVulnDB(import-osv) error = nil, want malformed feed error")
+	}
+	store, err := vulndb.NewFileStore(ctx, stateFile)
+	if err != nil {
+		t.Fatalf("open file store: %v", err)
+	}
+	state, ok, err := store.GetSyncState(ctx, vulndb.SourceOSV)
+	if err != nil {
+		t.Fatalf("get sync state: %v", err)
+	}
+	if !ok || state.LastError == "" || state.LastSyncedAt.IsZero() {
+		t.Fatalf("sync state = ok:%v %+v, want recorded import failure", ok, state)
+	}
+}
+
+func TestRunVulnDBSyncRecordsFailureState(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "vulndb.json")
+	feedPath := filepath.Join(dir, "bad-nvd.json")
+	if err := os.WriteFile(feedPath, []byte(`{"vulnerabilities":[`), 0o600); err != nil {
+		t.Fatalf("write bad feed: %v", err)
+	}
+
+	err := runVulnDB([]string{"sync", "nvd=" + feedPath, "state_file=" + stateFile})
+	if err == nil {
+		t.Fatal("runVulnDB(sync) error = nil, want malformed feed error")
+	}
+	store, err := vulndb.NewFileStore(ctx, stateFile)
+	if err != nil {
+		t.Fatalf("open file store: %v", err)
+	}
+	state, ok, err := store.GetSyncState(ctx, vulndb.SourceNVD)
+	if err != nil {
+		t.Fatalf("get sync state: %v", err)
+	}
+	if !ok || state.LastError == "" || state.LastSyncedAt.IsZero() {
+		t.Fatalf("sync state = ok:%v %+v, want recorded sync failure", ok, state)
 	}
 }
 

--- a/internal/sourceprojection/endpoint.go
+++ b/internal/sourceprojection/endpoint.go
@@ -199,7 +199,9 @@ func addEndpointOwnerLinks(entities map[string]*ports.ProjectedEntity, links map
 	}
 	for _, identifier := range []string{
 		firstAttribute(attrs, "owner_email"),
+		firstAttribute(attrs, "owner_id"),
 		firstAttribute(attrs, "user_email"),
+		firstAttribute(attrs, "user_id"),
 		firstAttribute(attrs, "primary_email"),
 		firstAttribute(attrs, "assigned_user"),
 	} {

--- a/internal/sourceprojection/endpoint_test.go
+++ b/internal/sourceprojection/endpoint_test.go
@@ -38,6 +38,32 @@ func TestProjectKolideDeviceLinksOwnerIdentity(t *testing.T) {
 	assertProjectedLink(t, state, deviceURN, relationOwnedBy, identityURN)
 }
 
+func TestProjectKolideDeviceLinksOwnerIDIdentity(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "kolide-device-1",
+		TenantId: "writer",
+		SourceId: "kolide",
+		Kind:     "kolide.device",
+		Attributes: map[string]string{
+			"device_id": "device-1",
+			"user_id":   "user-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	deviceURN := "urn:cerebro:writer:kolide_device:device-1"
+	identityURN := "urn:cerebro:writer:identity:login:user-1"
+	identifierURN := "urn:cerebro:writer:identifier:login:user-1"
+	assertProjectedLink(t, state, deviceURN, relationHasIdentifier, identifierURN)
+	assertProjectedLink(t, state, deviceURN, relationRepresentsIdentity, identityURN)
+	assertProjectedLink(t, state, deviceURN, relationOwnedBy, identityURN)
+}
+
 func TestProjectKolideSoftwareLinksDevicePackageAndCanonicalPackage(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -838,7 +838,7 @@ func nvdCPEAffectedPackage(vulnerabilityID string, match nvdCPEMatch) (AffectedP
 		VulnerabilityID:     vulnerabilityID,
 		Source:              SourceNVD,
 		Ecosystem:           cpeEcosystem(cpe.Part),
-		PackageName:         cpePackageName(cpe.Vendor, cpe.Product),
+		PackageName:         cpePackageName(cpe),
 		RangeType:           "CPE",
 		Introduced:          strings.TrimSpace(match.VersionStartIncluding),
 		IntroducedExclusive: strings.TrimSpace(match.VersionStartExcluding),
@@ -855,10 +855,17 @@ func nvdCPEAffectedPackage(vulnerabilityID string, match nvdCPEMatch) (AffectedP
 }
 
 type cpe23 struct {
-	Part    string
-	Vendor  string
-	Product string
-	Version string
+	Part      string
+	Vendor    string
+	Product   string
+	Version   string
+	Update    string
+	Edition   string
+	Language  string
+	SWEdition string
+	TargetSW  string
+	TargetHW  string
+	Other     string
 }
 
 func parseCPE23(criteria string) (cpe23, bool) {
@@ -867,10 +874,17 @@ func parseCPE23(criteria string) (cpe23, bool) {
 		return cpe23{}, false
 	}
 	return cpe23{
-		Part:    strings.TrimSpace(fields[2]),
-		Vendor:  cleanCPEComponent(fields[3]),
-		Product: cleanCPEComponent(fields[4]),
-		Version: cleanCPEComponent(fields[5]),
+		Part:      strings.TrimSpace(fields[2]),
+		Vendor:    cleanCPEComponent(fields[3]),
+		Product:   cleanCPEComponent(fields[4]),
+		Version:   cleanCPEComponent(fields[5]),
+		Update:    cleanCPEField(fields, 6),
+		Edition:   cleanCPEField(fields, 7),
+		Language:  cleanCPEField(fields, 8),
+		SWEdition: cleanCPEField(fields, 9),
+		TargetSW:  cleanCPEField(fields, 10),
+		TargetHW:  cleanCPEField(fields, 11),
+		Other:     cleanCPEField(fields, 12),
 	}, true
 }
 
@@ -910,6 +924,13 @@ func cleanCPEComponent(value string) string {
 	return strings.NewReplacer("\\:", ":", "\\_", "_", "\\\\", "\\").Replace(value)
 }
 
+func cleanCPEField(fields []string, index int) string {
+	if index >= len(fields) {
+		return ""
+	}
+	return cleanCPEComponent(fields[index])
+}
+
 func cpeEcosystem(part string) string {
 	switch strings.ToLower(strings.TrimSpace(part)) {
 	case "a":
@@ -923,16 +944,35 @@ func cpeEcosystem(part string) string {
 	}
 }
 
-func cpePackageName(vendor string, product string) string {
-	vendor = strings.TrimSpace(vendor)
-	product = strings.TrimSpace(product)
+func cpePackageName(cpe cpe23) string {
+	vendor := strings.TrimSpace(cpe.Vendor)
+	product := strings.TrimSpace(cpe.Product)
 	if product == "" {
 		return ""
 	}
+	parts := []string{}
 	if vendor == "" {
-		return product
+		parts = append(parts, product)
+	} else {
+		parts = append(parts, vendor, product)
 	}
-	return vendor + ":" + product
+	for _, qualifier := range []struct {
+		key   string
+		value string
+	}{
+		{"update", cpe.Update},
+		{"edition", cpe.Edition},
+		{"language", cpe.Language},
+		{"sw_edition", cpe.SWEdition},
+		{"target_sw", cpe.TargetSW},
+		{"target_hw", cpe.TargetHW},
+		{"other", cpe.Other},
+	} {
+		if strings.TrimSpace(qualifier.value) != "" {
+			parts = append(parts, qualifier.key+"="+strings.TrimSpace(qualifier.value))
+		}
+	}
+	return strings.Join(parts, ":")
 }
 
 func csvIndexes(header []string) map[string]int {

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -1201,6 +1201,45 @@ func TestImportNVDSkipsConjunctiveConfigurations(t *testing.T) {
 	}
 }
 
+func TestImportNVDPreservesPlatformQualifiedCPEComponents(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	nvd := `{
+		"vulnerabilities":[{
+			"cve":{
+				"id":"CVE-2026-44449",
+				"configurations":[{
+					"nodes":[{
+						"cpeMatch":[{
+							"vulnerable":true,
+							"criteria":"cpe:2.3:a:vendor:agent:*:*:*:*:*:android:*:*",
+							"versionStartIncluding":"1.0.0",
+							"versionEndExcluding":"2.0.0"
+						}]
+					}]
+				}]
+			}
+		}]
+	}`
+	if _, err := ImportNVD(ctx, store, strings.NewReader(nvd)); err != nil {
+		t.Fatalf("import nvd: %v", err)
+	}
+	rows, err := store.CandidateAffectedPackages(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "vendor:agent"})
+	if err != nil {
+		t.Fatalf("candidate generic cpe package: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("generic cpe rows = %+v, want none for platform-qualified criteria", rows)
+	}
+	rows, err = store.CandidateAffectedPackages(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "vendor:agent:target_sw=android"})
+	if err != nil {
+		t.Fatalf("candidate qualified cpe package: %v", err)
+	}
+	if len(rows) != 1 || rows[0].VulnerabilityID != "CVE-2026-44449" {
+		t.Fatalf("qualified cpe rows = %+v, want preserved target_sw-qualified row", rows)
+	}
+}
+
 func TestImportEPSSReturnsCommentScanError(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()

--- a/internal/vulndb/sync.go
+++ b/internal/vulndb/sync.go
@@ -339,6 +339,11 @@ func recordSyncSuccess(ctx context.Context, store Store, source string) error {
 	return store.PutSyncState(ctx, state)
 }
 
+// RecordSyncFailure records a failed feed refresh for direct import callers.
+func RecordSyncFailure(ctx context.Context, store Store, source string, syncErr error) error {
+	return recordSyncFailure(ctx, store, source, syncErr)
+}
+
 func recordSyncFailure(ctx context.Context, store Store, source string, syncErr error) error {
 	state, _, err := store.GetSyncState(ctx, source)
 	if err != nil {

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -51,6 +51,17 @@ func TestOpenAPIContractDescribesCurrentBootstrapSurface(t *testing.T) {
 	if !strings.Contains(endpointTenantParam, "        - name: tenant_id\n          in: query\n          required: true") {
 		t.Fatal("/endpoint-vulnerability-findings must require tenant_id in the OpenAPI contract")
 	}
+	_, platformEndpoint, ok := strings.Cut(string(body), "  /platform/endpoints/{deviceKey}/vulnerability-findings:")
+	if !ok {
+		t.Fatal("api/openapi.yaml missing /platform/endpoints/{deviceKey}/vulnerability-findings section")
+	}
+	platformTenantParam, _, ok := strings.Cut(platformEndpoint, "        - name: include_stale")
+	if !ok {
+		t.Fatal("/platform/endpoints/{deviceKey}/vulnerability-findings must document include_stale")
+	}
+	if !strings.Contains(platformTenantParam, "        - name: tenant_id\n          in: query\n          required: true") {
+		t.Fatal("/platform/endpoints/{deviceKey}/vulnerability-findings must require tenant_id in the OpenAPI contract")
+	}
 }
 
 func TestSourceCDKOwnsExternalHTTPClients(t *testing.T) {


### PR DESCRIPTION
## Summary
- record direct vulndb import/sync failures in durable sync state
- reject unsupported feed URL schemes and preserve platform-qualified CPE components
- require tenant_id for platform endpoint vulnerability findings contract

## Validation
- go test ./cmd/cerebro ./internal/vulndb ./tools/archtests -run 'Test(VulnDBInputClientRejectsUnsupportedURLSchemes|RunVulnDBImportRecordsFailureState|RunVulnDBSyncRecordsFailureState|ImportNVD|OpenAPIContractDescribesCurrentBootstrapSurface)' -count=1 -v
- make openapi-check
- make verify