### PR TITLE
fix(vulndb): close late PR feedback

### DIFF
--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -352,6 +352,10 @@ func recordVulnDBCommandFailure(ctx context.Context, store vulndb.Store, source 
 	if syncErr == nil {
 		return nil
 	}
+	var usage usageError
+	if errors.As(syncErr, &usage) {
+		return syncErr
+	}
 	if err := vulndb.RecordSyncFailure(ctx, store, source, syncErr); err != nil {
 		return errors.Join(syncErr, fmt.Errorf("record vulndb sync failure: %w", err))
 	}
@@ -392,11 +396,22 @@ func isRemoteVulnDBSource(source string) bool {
 }
 
 func vulnDBSourceScheme(source string) string {
-	parsed, err := url.Parse(strings.TrimSpace(source))
+	source = strings.TrimSpace(source)
+	if isWindowsDrivePath(source) {
+		return ""
+	}
+	parsed, err := url.Parse(source)
 	if err != nil {
 		return ""
 	}
 	return strings.ToLower(strings.TrimSpace(parsed.Scheme))
+}
+
+func isWindowsDrivePath(source string) bool {
+	if len(source) < 2 || source[1] != ':' {
+		return false
+	}
+	return (source[0] >= 'A' && source[0] <= 'Z') || (source[0] >= 'a' && source[0] <= 'z')
 }
 
 type openedVulnDBStore struct {

--- a/cmd/cerebro/vulndb.go
+++ b/cmd/cerebro/vulndb.go
@@ -20,6 +20,8 @@ import (
 
 const defaultVulnDBStateFile = ".cerebro-vulndb.json"
 
+var errUnsupportedVulnDBURLScheme = errors.New("unsupported vulndb import URL scheme")
+
 func runVulnDB(args []string) error {
 	if len(args) == 0 {
 		return usageError(vulnDBUsage())
@@ -373,7 +375,7 @@ func (vulndbInputClient) Open(ctx context.Context, source string, allowInsecureH
 	}
 	if vulnDBSourceScheme(source) != "" {
 		if !isRemoteVulnDBSource(source) {
-			return nil, vulndb.ValidateFeedURL(source, allowInsecureHTTP)
+			return nil, fmt.Errorf("%w %q", errUnsupportedVulnDBURLScheme, vulnDBSourceScheme(source))
 		}
 		return bootstrap.OpenVulnDBFeed(ctx, source, allowInsecureHTTP)
 	}

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -38,8 +39,12 @@ func TestVulnDBInputClientOpenTreatsRemoteSchemeCaseInsensitive(t *testing.T) {
 
 func TestVulnDBInputClientRejectsUnsupportedURLSchemes(t *testing.T) {
 	for _, source := range []string{"file:///tmp/osv.json", "ftp://mirror.example/osv.json"} {
-		if _, err := (vulndbInputClient{}).Open(context.Background(), source, true); err == nil {
+		_, err := (vulndbInputClient{}).Open(context.Background(), source, true)
+		if err == nil {
 			t.Fatalf("Open(%q) error = nil, want unsupported scheme rejection", source)
+		}
+		if !errors.Is(err, errUnsupportedVulnDBURLScheme) {
+			t.Fatalf("Open(%q) error = %v, want unsupported scheme", source, err)
 		}
 	}
 }

--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -49,6 +49,21 @@ func TestVulnDBInputClientRejectsUnsupportedURLSchemes(t *testing.T) {
 	}
 }
 
+func TestVulnDBInputClientTreatsWindowsDrivePathsAsLocalFiles(t *testing.T) {
+	for _, source := range []string{`C:\feeds\osv.json`, "C:/feeds/osv.json"} {
+		if scheme := vulnDBSourceScheme(source); scheme != "" {
+			t.Fatalf("vulnDBSourceScheme(%q) = %q, want local path", source, scheme)
+		}
+		_, err := (vulndbInputClient{}).Open(context.Background(), source, true)
+		if err == nil {
+			t.Fatalf("Open(%q) error = nil, want local file open error", source)
+		}
+		if errors.Is(err, errUnsupportedVulnDBURLScheme) {
+			t.Fatalf("Open(%q) error = %v, want local file error", source, err)
+		}
+	}
+}
+
 func TestParseVulnDBOptionsSyncJobFields(t *testing.T) {
 	options, err := parseVulnDBOptions([]string{
 		"store=file",
@@ -190,6 +205,26 @@ func TestRunVulnDBImportRecordsFailureState(t *testing.T) {
 	}
 	if !ok || state.LastError == "" || state.LastSyncedAt.IsZero() {
 		t.Fatalf("sync state = ok:%v %+v, want recorded import failure", ok, state)
+	}
+}
+
+func TestRunVulnDBImportUsageErrorDoesNotRecordFailureState(t *testing.T) {
+	ctx := context.Background()
+	stateFile := filepath.Join(t.TempDir(), "vulndb.json")
+	err := runVulnDB([]string{"import-osv", "state_file=" + stateFile})
+	if err == nil {
+		t.Fatal("runVulnDB(import-osv) error = nil, want missing source usage error")
+	}
+	var usage usageError
+	if !errors.As(err, &usage) {
+		t.Fatalf("runVulnDB(import-osv) error = %v, want usage error", err)
+	}
+	store, err := vulndb.NewFileStore(ctx, stateFile)
+	if err != nil {
+		t.Fatalf("open file store: %v", err)
+	}
+	if _, ok, err := store.GetSyncState(ctx, vulndb.SourceOSV); err != nil || ok {
+		t.Fatalf("sync state ok=%v err=%v, want no recorded usage failure", ok, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- record direct vulndb import/sync failures from PR #614 follow-up feedback
- require tenant_id on platform endpoint vulnerability findings from PR #615 follow-up feedback
- reject unsupported vulndb import URL schemes and preserve platform-qualified CPE components

## Validation
- go test ./cmd/cerebro ./internal/vulndb -run 'TestVulnDBInputClientRejectsUnsupportedURLScheme|TestRunVulnDBImportRecordsFailureState|TestRunVulnDBSyncRecordsFailureState|TestImportNVDPreservesPlatformQualifiedCPEComponents' -count=1 -v\n- make verify