### PR TITLE
fix: address post-merge review regressions

### DIFF
--- a/cmd/cerebro/vulndb_test.go
+++ b/cmd/cerebro/vulndb_test.go
@@ -38,7 +38,7 @@ func TestVulnDBInputClientOpenTreatsRemoteSchemeCaseInsensitive(t *testing.T) {
 }
 
 func TestVulnDBInputClientRejectsUnsupportedURLSchemes(t *testing.T) {
-	for _, source := range []string{"file:///tmp/osv.json", "ftp://mirror.example/osv.json"} {
+	for _, source := range []string{"file:///tmp/osv.json", "file:/tmp/osv.json", "ftp://mirror.example/osv.json", "https:/mirror.example/osv.json"} {
 		_, err := (vulndbInputClient{}).Open(context.Background(), source, true)
 		if err == nil {
 			t.Fatalf("Open(%q) error = nil, want unsupported scheme rejection", source)
@@ -61,6 +61,18 @@ func TestVulnDBInputClientTreatsWindowsDrivePathsAsLocalFiles(t *testing.T) {
 		if errors.Is(err, errUnsupportedVulnDBURLScheme) {
 			t.Fatalf("Open(%q) error = %v, want local file error", source, err)
 		}
+	}
+}
+
+func TestVulnDBSourceSchemeLeavesDriveLetterPathsLocal(t *testing.T) {
+	if got := vulnDBSourceScheme(`C:\feeds\osv.json`); got != "" {
+		t.Fatalf("vulnDBSourceScheme(windows path) = %q, want local file path", got)
+	}
+	if got := vulnDBSourceScheme("ftp://mirror.example/osv.json"); got != "ftp" {
+		t.Fatalf("vulnDBSourceScheme(ftp URL) = %q, want ftp", got)
+	}
+	if got := vulnDBSourceScheme("https:/mirror.example/osv.json"); got != "https" {
+		t.Fatalf("vulnDBSourceScheme(malformed https URL) = %q, want https", got)
 	}
 }
 

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -74,6 +74,10 @@ type projectionRecordCleanupRequestProjector interface {
 	ProjectCleanupRequests(*cerebrov1.EventEnvelope) ([]ports.ProjectionCleanupRequest, error)
 }
 
+type projectionRetractionProjector interface {
+	ProjectRetractions(*cerebrov1.EventEnvelope) ([]*ports.ProjectedLink, error)
+}
+
 type pageProjectionResult struct {
 	EventsRead        uint32
 	EntitiesProjected uint32
@@ -516,12 +520,23 @@ func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRe
 	links := map[string]*ports.ProjectedLink{}
 	cleanupURNs := map[string]struct{}{}
 	cleanupRequests := map[string]ports.ProjectionCleanupRequest{}
+	retractedLinks := map[string]*ports.ProjectedLink{}
+	retractionProjector, canProjectRetractions := projector.(projectionRetractionProjector)
 	result := pageProjectionResult{}
 	for _, event := range response.GetEvents() {
 		ingested := ingestEvent(event, request.TenantID, request.RuntimeID)
 		projectedEntities, projectedLinks, err := projector.ProjectRecords(ingested)
 		if err != nil {
 			return result, fmt.Errorf("project source event %q: %w", event.GetId(), err)
+		}
+		if canProjectRetractions {
+			linksToRetract, err := retractionProjector.ProjectRetractions(ingested)
+			if err != nil {
+				return result, fmt.Errorf("project source event retractions %q: %w", event.GetId(), err)
+			}
+			for _, link := range linksToRetract {
+				mergeProjectedLink(retractedLinks, link)
+			}
 		}
 		for _, entity := range projectedEntities {
 			mergeProjectedEntity(entities, entity)
@@ -573,6 +588,13 @@ func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRe
 			}
 			if completedCleanupRequests != nil {
 				completedCleanupRequests[key] = struct{}{}
+			}
+		}
+	}
+	if deleter, ok := graphStore.(ports.ProjectionLinkDeleter); ok {
+		for _, key := range sortedMapKeys(retractedLinks) {
+			if err := deleter.DeleteProjectedLink(ctx, retractedLinks[key]); err != nil {
+				return result, fmt.Errorf("delete coalesced projected link %q: %w", key, err)
 			}
 		}
 	}

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -90,11 +90,21 @@ func (p cleanupRecordProjector) ProjectCleanupRequests(event *cerebrov1.EventEnv
 	return p.requests(event)
 }
 
+type retractionProjector struct {
+	recordProjectorFunc
+	retractions []*ports.ProjectedLink
+}
+
+func (p retractionProjector) ProjectRetractions(*cerebrov1.EventEnvelope) ([]*ports.ProjectedLink, error) {
+	return p.retractions, nil
+}
+
 type recordingProjectionGraphStore struct {
 	entities        map[string]*ports.ProjectedEntity
 	links           map[string]*ports.ProjectedLink
 	upsertLinkErr   error
 	deletedEntities map[string]struct{}
+	deletedLinks    map[string]*ports.ProjectedLink
 	cleanupRequests []ports.ProjectionCleanupRequest
 }
 
@@ -166,6 +176,21 @@ func (s *recordingProjectionGraphStore) DeleteProjectedEntity(_ context.Context,
 		if link.FromURN == urn || link.ToURN == urn {
 			delete(s.links, key)
 		}
+	}
+	return nil
+}
+
+func (s *recordingProjectionGraphStore) DeleteProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	if s.deletedLinks == nil {
+		s.deletedLinks = map[string]*ports.ProjectedLink{}
+	}
+	key := link.FromURN + "|" + link.Relation + "|" + link.ToURN
+	s.deletedLinks[key] = link
+	if s.links != nil {
+		delete(s.links, key)
 	}
 	return nil
 }
@@ -616,6 +641,43 @@ func TestProjectResponseCoalescedRunsCleanupRequestsUntilExhausted(t *testing.T)
 	}
 	if len(store.entities) != 0 {
 		t.Fatalf("store retained %d cleanup entities", len(store.entities))
+	}
+}
+
+func TestProjectResponseCoalescedDeletesProjectedRetractions(t *testing.T) {
+	staleLink := &ports.ProjectedLink{
+		TenantID: "writer",
+		SourceID: "kolide",
+		FromURN:  "urn:cerebro:writer:kolide_device:device-1",
+		Relation: "owned_by",
+		ToURN:    "urn:cerebro:writer:identity:login:user-1",
+	}
+	key := staleLink.FromURN + "|" + staleLink.Relation + "|" + staleLink.ToURN
+	store := &recordingProjectionGraphStore{links: map[string]*ports.ProjectedLink{key: staleLink}}
+	service := &Service{graphStore: store}
+	projector := retractionProjector{
+		recordProjectorFunc: func(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+			return nil, nil, nil
+		},
+		retractions: []*ports.ProjectedLink{staleLink},
+	}
+
+	_, err := service.projectResponseCoalesced(context.Background(), sourceRequest{
+		SourceID:  "kolide",
+		RuntimeID: "kolide-runtime",
+		TenantID:  "writer",
+	}, &cerebrov1.ReadSourceResponse{Events: []*cerebrov1.EventEnvelope{{
+		Id:       "kolide-device",
+		SourceId: "kolide",
+	}}}, projector, nil)
+	if err != nil {
+		t.Fatalf("projectResponseCoalesced() error = %v", err)
+	}
+	if _, ok := store.deletedLinks[key]; !ok {
+		t.Fatalf("stale link was not deleted: %#v", store.deletedLinks)
+	}
+	if _, ok := store.links[key]; ok {
+		t.Fatalf("stale link remains after deletion")
 	}
 }
 

--- a/internal/sourceprojection/endpoint.go
+++ b/internal/sourceprojection/endpoint.go
@@ -199,9 +199,7 @@ func addEndpointOwnerLinks(entities map[string]*ports.ProjectedEntity, links map
 	}
 	for _, identifier := range []string{
 		firstAttribute(attrs, "owner_email"),
-		firstAttribute(attrs, "owner_id"),
 		firstAttribute(attrs, "user_email"),
-		firstAttribute(attrs, "user_id"),
 		firstAttribute(attrs, "primary_email"),
 		firstAttribute(attrs, "assigned_user"),
 	} {
@@ -217,6 +215,71 @@ func addEndpointOwnerLinks(entities map[string]*ports.ProjectedEntity, links map
 				"match_type": "endpoint_owner_identifier",
 			}))
 		}
+	}
+	for _, identifier := range []struct {
+		kind  string
+		value string
+	}{
+		{"owner_id", firstAttribute(attrs, "owner_id")},
+		{"user_id", firstAttribute(attrs, "user_id")},
+	} {
+		identifierType := identifier.kind
+		if normalizedSourceID := normalizeIdentifier(sourceID); normalizedSourceID != "" {
+			identifierType = normalizedSourceID + "_" + identifier.kind
+		}
+		addEndpointIdentifierLink(entities, links, tenantID, sourceID, event, endpointURN, identifierType, identifier.value, "0.75")
+	}
+}
+
+func endpointOwnerIDRetractions(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedLink, error) {
+	profile, correlationOnly, ok := endpointOwnerIDRetractionProfile(event.GetKind())
+	if !ok {
+		return nil, nil
+	}
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, err
+	}
+	attrs := event.GetAttributes()
+	endpointIDKeys := profile.EndpointIDKeys
+	if correlationOnly {
+		endpointIDKeys = endpointCorrelationIDKeys(endpointIDKeys)
+	}
+	endpointURN := projectionURN(tenantID, profile.EndpointKind, firstAttribute(attrs, endpointIDKeys...))
+	if endpointURN == "" {
+		return nil, nil
+	}
+	links := map[string]*ports.ProjectedLink{}
+	for _, raw := range []string{firstAttribute(attrs, "owner_id"), firstAttribute(attrs, "user_id")} {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		identityURN, _ := canonicalIdentityURN(tenantID, raw)
+		if identityURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), endpointURN, identityURN, relationRepresentsIdentity, map[string]string{"event_id": event.GetId(), "retraction": "endpoint_owner_id"}))
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), endpointURN, identityURN, relationOwnedBy, map[string]string{"event_id": event.GetId(), "retraction": "endpoint_owner_id"}))
+		}
+		identifierURNValue, _, _ := identifierURN(tenantID, raw)
+		if identifierURNValue != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), endpointURN, identifierURNValue, relationHasIdentifier, map[string]string{"event_id": event.GetId(), "retraction": "endpoint_owner_id"}))
+		}
+	}
+	_, projectedLinks := entitiesAndLinks(nil, links)
+	return projectedLinks, nil
+}
+
+func endpointOwnerIDRetractionProfile(kind string) (endpointProjectionProfile, bool, bool) {
+	switch strings.TrimSpace(kind) {
+	case "kolide.device", "kolide.user_device":
+		return kolideEndpointProfile, false, true
+	case "kolide.software", "kolide.check":
+		return kolideEndpointProfile, true, true
+	case "kandji.device":
+		return kandjiEndpointProfile, false, true
+	case "kandji.application":
+		return kandjiEndpointProfile, true, true
+	default:
+		return endpointProjectionProfile{}, false, false
 	}
 }
 

--- a/internal/sourceprojection/endpoint_test.go
+++ b/internal/sourceprojection/endpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func TestProjectKolideDeviceLinksOwnerIdentity(t *testing.T) {
@@ -58,10 +59,51 @@ func TestProjectKolideDeviceLinksOwnerIDIdentity(t *testing.T) {
 
 	deviceURN := "urn:cerebro:writer:kolide_device:device-1"
 	identityURN := "urn:cerebro:writer:identity:login:user-1"
-	identifierURN := "urn:cerebro:writer:identifier:login:user-1"
+	identifierURN := "urn:cerebro:writer:endpoint_identifier:kolide_user_id:user-1"
 	assertProjectedLink(t, state, deviceURN, relationHasIdentifier, identifierURN)
-	assertProjectedLink(t, state, deviceURN, relationRepresentsIdentity, identityURN)
-	assertProjectedLink(t, state, deviceURN, relationOwnedBy, identityURN)
+	assertProjectedLinkMissing(t, state, deviceURN, relationRepresentsIdentity, identityURN)
+	assertProjectedLinkMissing(t, state, deviceURN, relationOwnedBy, identityURN)
+}
+
+func TestProjectKolideDeviceOwnerIDRetractsStaleCanonicalOwnerLinks(t *testing.T) {
+	deviceURN := "urn:cerebro:writer:kolide_device:device-1"
+	identityURN := "urn:cerebro:writer:identity:login:user-1"
+	legacyIdentifierURN := "urn:cerebro:writer:identifier:login:user-1"
+	staleLinks := []*ports.ProjectedLink{
+		projectedLink("writer", "kolide", deviceURN, identityURN, relationRepresentsIdentity, nil),
+		projectedLink("writer", "kolide", deviceURN, identityURN, relationOwnedBy, nil),
+		projectedLink("writer", "kolide", deviceURN, legacyIdentifierURN, relationHasIdentifier, nil),
+	}
+	state := &projectionRecorder{links: map[string]*ports.ProjectedLink{}}
+	graph := &projectionRecorder{links: map[string]*ports.ProjectedLink{}}
+	for _, link := range staleLinks {
+		state.links[projectedLinkKey(link)] = cloneProjectedLink(link)
+		graph.links[projectedLinkKey(link)] = cloneProjectedLink(link)
+	}
+	service := New(state, graph)
+
+	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "kolide-device-1",
+		TenantId: "writer",
+		SourceId: "kolide",
+		Kind:     "kolide.device",
+		Attributes: map[string]string{
+			"device_id": "device-1",
+			"user_id":   "user-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if result.LinksDeleted != 3 {
+		t.Fatalf("LinksDeleted = %d, want 3 stale owner-id links", result.LinksDeleted)
+	}
+	for _, recorder := range []*projectionRecorder{state, graph} {
+		assertProjectedLinkMissing(t, recorder, deviceURN, relationRepresentsIdentity, identityURN)
+		assertProjectedLinkMissing(t, recorder, deviceURN, relationOwnedBy, identityURN)
+		assertProjectedLinkMissing(t, recorder, deviceURN, relationHasIdentifier, legacyIdentifierURN)
+	}
+	assertProjectedLink(t, state, deviceURN, relationHasIdentifier, "urn:cerebro:writer:endpoint_identifier:kolide_user_id:user-1")
 }
 
 func TestProjectKolideSoftwareLinksDevicePackageAndCanonicalPackage(t *testing.T) {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -101,6 +101,14 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 		return ports.ProjectionResult{}, err
 	}
 	entitiesDeleted += cleanupDeleted.EntitiesDeleted
+	retractedLinks, err := s.ProjectRetractions(event)
+	if err != nil {
+		return ports.ProjectionResult{}, err
+	}
+	retractedLinksDeleted, err := s.deleteProjectedLinks(ctx, retractedLinks)
+	if err != nil {
+		return ports.ProjectionResult{}, err
+	}
 	for _, entity := range entities {
 		if s.state != nil {
 			if err := s.state.UpsertProjectedEntity(ctx, entity); err != nil {
@@ -129,7 +137,7 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 		EntitiesProjected: uint32(len(entities)),
 		LinksProjected:    uint32(len(links)),
 		EntitiesDeleted:   entitiesDeleted,
-		LinksDeleted:      cleanupDeleted.LinksDeleted,
+		LinksDeleted:      cleanupDeleted.LinksDeleted + retractedLinksDeleted,
 	}, nil
 }
 
@@ -201,6 +209,50 @@ func (s *Service) ProjectCleanupRequests(event *cerebrov1.EventEnvelope) ([]port
 		URNPrefixes: oktaEphemeralOAuthRuntimeResourceURNPrefixes(tenantID),
 		Limit:       1000,
 	}}, nil
+}
+
+// ProjectRetractions returns stale projection links that should be removed for one event.
+func (s *Service) ProjectRetractions(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedLink, error) {
+	if event == nil {
+		return nil, fmt.Errorf("event is required")
+	}
+	links, err := endpointOwnerIDRetractions(event)
+	if err != nil {
+		return nil, err
+	}
+	stampProjectionRuntime(event, nil, links)
+	return links, nil
+}
+
+func (s *Service) deleteProjectedLinks(ctx context.Context, links []*ports.ProjectedLink) (uint32, error) {
+	if len(links) == 0 {
+		return 0, nil
+	}
+	var deleted uint32
+	stateDeleter, stateCanDelete := s.state.(ports.ProjectionLinkDeleter)
+	graphDeleter, graphCanDelete := s.graph.(ports.ProjectionLinkDeleter)
+	for _, link := range links {
+		if link == nil {
+			continue
+		}
+		deletedLink := false
+		if stateCanDelete {
+			if err := stateDeleter.DeleteProjectedLink(ctx, link); err != nil {
+				return deleted, err
+			}
+			deletedLink = true
+		}
+		if graphCanDelete {
+			if err := graphDeleter.DeleteProjectedLink(ctx, link); err != nil {
+				return deleted, err
+			}
+			deletedLink = true
+		}
+		if deletedLink {
+			deleted++
+		}
+	}
+	return deleted, nil
 }
 
 func (s *Service) deleteProjectedEntities(ctx context.Context, urns []string) (uint32, error) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -17,6 +17,7 @@ type projectionRecorder struct {
 	entities        map[string]*ports.ProjectedEntity
 	links           map[string]*ports.ProjectedLink
 	deletedEntities map[string]struct{}
+	deletedLinks    map[string]*ports.ProjectedLink
 	cleanupRequests []ports.ProjectionCleanupRequest
 }
 
@@ -56,6 +57,21 @@ func (r *projectionRecorder) DeleteProjectedEntity(_ context.Context, urn string
 		if link.FromURN == urn || link.ToURN == urn {
 			delete(r.links, key)
 		}
+	}
+	return nil
+}
+
+func (r *projectionRecorder) DeleteProjectedLink(_ context.Context, link *ports.ProjectedLink) error {
+	if link == nil {
+		return nil
+	}
+	key := projectedLinkKey(link)
+	if r.deletedLinks == nil {
+		r.deletedLinks = map[string]*ports.ProjectedLink{}
+	}
+	r.deletedLinks[key] = cloneProjectedLink(link)
+	if r.links != nil {
+		delete(r.links, key)
 	}
 	return nil
 }

--- a/internal/statestore/postgres/vulndb.go
+++ b/internal/statestore/postgres/vulndb.go
@@ -375,18 +375,40 @@ func (s *Store) CandidateAffectedPackages(ctx context.Context, query vulndb.Pack
 		return nil, errors.New("postgres is not configured")
 	}
 	ecosystem := normalizeVulnDBEcosystem(query.Ecosystem)
-	packageName := normalizeVulnDBPackageName(query.Name)
-	if ecosystem == "" || packageName == "" {
+	packageNames := vulndb.PackageLookupNames(query.Ecosystem, query.Name)
+	if ecosystem == "" || len(packageNames) == 0 {
+		return nil, nil
+	}
+	packageKeys := make([]string, 0, len(packageNames))
+	seenPackageKeys := map[string]struct{}{}
+	for _, name := range packageNames {
+		key := normalizeVulnDBPackageName(name)
+		if key == "" {
+			continue
+		}
+		if _, ok := seenPackageKeys[key]; ok {
+			continue
+		}
+		seenPackageKeys[key] = struct{}{}
+		packageKeys = append(packageKeys, key)
+	}
+	if len(packageKeys) == 0 {
 		return nil, nil
 	}
 	if err := s.ensureVulnDBTables(ctx); err != nil {
 		return nil, err
 	}
-	rows, err := s.db.QueryContext(ctx, `
+	args := []any{ecosystem}
+	placeholders := make([]string, 0, len(packageKeys))
+	for _, key := range packageKeys {
+		args = append(args, key)
+		placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+	}
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`
 SELECT affected_json::text
 FROM vulndb_affected_packages
-WHERE ecosystem = $1 AND package_name_key = $2
-ORDER BY row_key`, ecosystem, packageName)
+WHERE ecosystem = $1 AND package_name_key IN (%s)
+ORDER BY row_key`, strings.Join(placeholders, ", ")), args...)
 	if err != nil {
 		return nil, fmt.Errorf("query affected packages: %w", err)
 	}

--- a/internal/vulndb/models.go
+++ b/internal/vulndb/models.go
@@ -123,6 +123,81 @@ func normalizePackageName(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
 }
 
+// PackageLookupNames returns package-name keys that should be considered for a query.
+func PackageLookupNames(ecosystem string, packageName string) []string {
+	name := normalizePackageName(packageName)
+	if name == "" {
+		return nil
+	}
+	names := []string{name}
+	if strings.HasPrefix(normalizeEcosystem(ecosystem), "cpe:") {
+		names = append(names, cpePackageLookupPrefixes(name)...)
+	}
+	return dedupeStrings(names)
+}
+
+func cpePackageLookupPrefixes(name string) []string {
+	parts := strings.Split(name, ":")
+	firstQualifier := len(parts)
+	for i, part := range parts {
+		if strings.Contains(part, "=") {
+			firstQualifier = i
+			break
+		}
+	}
+	if firstQualifier == len(parts) {
+		return nil
+	}
+	base := parts[:firstQualifier]
+	qualifiers := parts[firstQualifier:]
+	prefixes := make([]string, 0, 1<<len(qualifiers))
+	for size := len(qualifiers) - 1; size >= 0; size-- {
+		cpeQualifierCombinations(qualifiers, size, func(selected []string) {
+			candidate := append(append([]string{}, base...), selected...)
+			prefix := strings.Join(candidate, ":")
+			if prefix != "" {
+				prefixes = append(prefixes, prefix)
+			}
+		})
+	}
+	return prefixes
+}
+
+func cpeQualifierCombinations(qualifiers []string, size int, visit func([]string)) {
+	if size == 0 {
+		visit(nil)
+		return
+	}
+	var walk func(start int, selected []string)
+	walk = func(start int, selected []string) {
+		if len(selected) == size {
+			visit(selected)
+			return
+		}
+		remaining := size - len(selected)
+		for i := start; i <= len(qualifiers)-remaining; i++ {
+			walk(i+1, append(selected, qualifiers[i]))
+		}
+	}
+	walk(0, nil)
+}
+
+func dedupeStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
 func packageKey(ecosystem string, packageName string) string {
 	return normalizeEcosystem(ecosystem) + "\x00" + normalizePackageName(packageName)
 }

--- a/internal/vulndb/store.go
+++ b/internal/vulndb/store.go
@@ -241,21 +241,26 @@ func (s *MemoryStore) CandidateAffectedPackages(ctx context.Context, query Packa
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	key := packageKey(query.Ecosystem, query.Name)
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	rows := s.affected[key]
-	if len(rows) == 0 {
+	names := PackageLookupNames(query.Ecosystem, query.Name)
+	if len(names) == 0 {
 		return nil, nil
 	}
-	keys := make([]string, 0, len(rows))
-	for rowKey := range rows {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	merged := map[string]AffectedPackage{}
+	for _, name := range names {
+		for rowKey, row := range s.affected[packageKey(query.Ecosystem, name)] {
+			merged[rowKey] = row
+		}
+	}
+	keys := make([]string, 0, len(merged))
+	for rowKey := range merged {
 		keys = append(keys, rowKey)
 	}
 	sort.Strings(keys)
 	out := make([]AffectedPackage, 0, len(keys))
 	for _, rowKey := range keys {
-		out = append(out, rows[rowKey])
+		out = append(out, merged[rowKey])
 	}
 	return out, nil
 }

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -1240,6 +1240,61 @@ func TestImportNVDPreservesPlatformQualifiedCPEComponents(t *testing.T) {
 	}
 }
 
+func TestCandidateAffectedPackagesIncludesGenericCPEForQualifiedLookup(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID: "CVE-2026-44450",
+		Source:          SourceNVD,
+		Ecosystem:       "cpe:application",
+		PackageName:     "vendor:agent",
+		Fixed:           "2.0.0",
+	}); err != nil {
+		t.Fatalf("upsert generic cpe: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID: "CVE-2026-44451",
+		Source:          SourceNVD,
+		Ecosystem:       "cpe:application",
+		PackageName:     "vendor:agent:update=sp1",
+		Fixed:           "2.1.0",
+	}); err != nil {
+		t.Fatalf("upsert partially qualified cpe: %v", err)
+	}
+	if err := store.UpsertAffectedPackage(ctx, AffectedPackage{
+		VulnerabilityID: "CVE-2026-44452",
+		Source:          SourceNVD,
+		Ecosystem:       "cpe:application",
+		PackageName:     "vendor:agent:target_sw=android",
+		Fixed:           "3.0.0",
+	}); err != nil {
+		t.Fatalf("upsert qualified cpe: %v", err)
+	}
+	rows, err := store.CandidateAffectedPackages(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "vendor:agent:update=sp1:target_sw=android"})
+	if err != nil {
+		t.Fatalf("candidate qualified cpe package: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("qualified cpe rows = %+v, want later-qualified, partially qualified, and generic rows", rows)
+	}
+	matched := map[string]bool{}
+	for _, row := range rows {
+		matched[row.VulnerabilityID] = true
+	}
+	for _, id := range []string{"CVE-2026-44450", "CVE-2026-44451", "CVE-2026-44452"} {
+		if !matched[id] {
+			t.Fatalf("qualified cpe rows = %+v, missing %s", rows, id)
+		}
+	}
+	rows, err = store.CandidateAffectedPackages(ctx, PackageQuery{Ecosystem: "cpe:application", Name: "vendor:agent"})
+	if err != nil {
+		t.Fatalf("candidate generic cpe package: %v", err)
+	}
+	if len(rows) != 1 || rows[0].VulnerabilityID != "CVE-2026-44450" {
+		t.Fatalf("generic cpe rows = %+v, want only generic row", rows)
+	}
+}
+
 func TestImportEPSSReturnsCommentScanError(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()


### PR DESCRIPTION
## Summary
- Preserve Windows drive-letter VulnDB feed paths as local files while still rejecting unsupported URL schemes.
- Include generic CPE advisories when matching platform-qualified CPE package queries.
- Keep endpoint owner_id/user_id values as provider-scoped endpoint identifiers instead of canonical owners.

## Validation
- make verify