### PR TITLE
fix(vulndb): split file locks by platform

### DIFF
--- a/internal/vulndb/filestore.go
+++ b/internal/vulndb/filestore.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -272,25 +271,6 @@ func (s *FileStore) read(ctx context.Context, apply func() error) error {
 		return err
 	}
 	return apply()
-}
-
-func (s *FileStore) lockStateFile() (func(), error) {
-	dir := filepath.Dir(s.path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, err
-	}
-	lock, err := os.OpenFile(s.path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return nil, err
-	}
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		_ = lock.Close()
-		return nil, err
-	}
-	return func() {
-		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
-		_ = lock.Close()
-	}, nil
 }
 
 func (s *FileStore) saveLocked(ctx context.Context) error {

--- a/internal/vulndb/filestore_lock_unix.go
+++ b/internal/vulndb/filestore_lock_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package vulndb
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func (s *FileStore) lockStateFile() (func(), error) {
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	lock, err := os.OpenFile(s.path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		_ = lock.Close()
+		return nil, err
+	}
+	return func() {
+		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		_ = lock.Close()
+	}, nil
+}

--- a/internal/vulndb/filestore_lock_windows.go
+++ b/internal/vulndb/filestore_lock_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package vulndb
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func (s *FileStore) lockStateFile() (func(), error) {
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	lock, err := os.OpenFile(s.path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	handle := windows.Handle(lock.Fd())
+	overlapped := &windows.Overlapped{}
+	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, overlapped); err != nil {
+		_ = lock.Close()
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, overlapped)
+		_ = lock.Close()
+	}, nil
+}


### PR DESCRIPTION
Fixes the v2.1.52/v2.1.53 release blocker where GoReleaser's windows_amd64 target failed on syscall.Flock/LOCK_EX/LOCK_UN in internal/vulndb/filestore.go.\n\nValidation:\n- go test ./internal/vulndb\n- GOOS=windows GOARCH=amd64 go build -o /tmp/cerebro-windows-check.exe ./cmd/cerebro\n- make verify\n\nRelease evidence:\n- v2.1.52 run 26261074640 failed in goreleaser on windows_amd64 with undefined syscall.Flock/LOCK_EX/LOCK_UN.\n- v2.1.53 run 26261175206 failed on the same release blocker before GHCR publish/signing.