### PR TITLE
fix(vulndb): support windows release builds

### DIFF
--- a/internal/vulndb/filestore.go
+++ b/internal/vulndb/filestore.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -283,12 +282,12 @@ func (s *FileStore) lockStateFile() (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+	if err := lockFile(lock); err != nil {
 		_ = lock.Close()
 		return nil, err
 	}
 	return func() {
-		_ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+		_ = unlockFile(lock)
 		_ = lock.Close()
 	}, nil
 }

--- a/internal/vulndb/filestore_lock_unix.go
+++ b/internal/vulndb/filestore_lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package vulndb
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/vulndb/filestore_lock_windows.go
+++ b/internal/vulndb/filestore_lock_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package vulndb
+
+import (
+	"math"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, math.MaxUint32, math.MaxUint32, &overlapped)
+}
+
+func unlockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, math.MaxUint32, math.MaxUint32, &overlapped)
+}


### PR DESCRIPTION
## Summary
- Move file-store advisory DB locking behind OS-specific helpers so GoReleaser Windows targets compile.
- Preserve flock-based locking on non-Windows platforms; Windows uses the existing in-process mutex only.

## Validation
- go test ./internal/vulndb -count=1 -v
- GOOS=windows GOARCH=amd64 go test -c ./internal/vulndb -o /tmp/cerebro-vulndb-windows.test.exe
- make verify
