### PR TITLE
fix: harden endpoint owner link cleanup

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -25,6 +25,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceregistry"
+	"github.com/writer/cerebro/internal/telemetry"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -119,6 +120,24 @@ type graphIngestRunsOptions struct {
 	Limit     int
 }
 
+type graphEndpointOwnerIDCleanupOptions struct {
+	TenantID  string
+	SourceID  string
+	RuntimeID string
+	Limit     uint32
+	DryRun    bool
+}
+
+type graphEndpointOwnerIDCleanupResult struct {
+	TenantID   string                            `json:"tenant_id"`
+	SourceID   string                            `json:"source_id,omitempty"`
+	RuntimeID  string                            `json:"runtime_id,omitempty"`
+	Limit      uint32                            `json:"limit,omitempty"`
+	DryRun     bool                              `json:"dry_run"`
+	StateStore ports.ProjectionLinkCleanupResult `json:"state_store"`
+	GraphStore ports.ProjectionLinkCleanupResult `json:"graph_store"`
+}
+
 type graphPathsResult struct {
 	Patterns   []graphstore.PathPattern `json:"patterns"`
 	Traversals []graphstore.Traversal   `json:"traversals"`
@@ -193,6 +212,22 @@ func runGraph(args []string) error {
 		return runGraphIngestRun(args[1:])
 	case "ingest-runs":
 		return runGraphIngestRuns(args[1:])
+	case "cleanup-endpoint-owner-id-links":
+		options, err := parseGraphEndpointOwnerIDCleanupArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		ctx := context.Background()
+		deps, closeDeps, err := openGraphCleanupDependencies(ctx)
+		if err != nil {
+			return err
+		}
+		defer logClose(closeDeps)
+		result, err := cleanupEndpointOwnerIDLinks(ctx, deps, options)
+		if printErr := printJSON(result); printErr != nil {
+			return printErr
+		}
+		return err
 	case "counts", "neighborhood", "paths", "relation-counts", "integrity":
 		return runGraphInspect(args)
 	case "cve-impact", "package-exposure", "asset-vulns":
@@ -248,7 +283,7 @@ func runGraph(args []string) error {
 }
 
 func graphUsage() string {
-	return fmt.Sprintf("usage: %s graph [counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|rebuild|inspect] ...", os.Args[0])
+	return fmt.Sprintf("usage: %s graph [counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|cleanup-endpoint-owner-id-links|rebuild|inspect] ...", os.Args[0])
 }
 
 func graphIngestUsage() string {
@@ -269,6 +304,10 @@ func graphInspectUsage() string {
 
 func graphImpactUsage() string {
 	return fmt.Sprintf("usage: %s graph [cve-impact <CVE|GHSA>|package-exposure <package|purl>|asset-vulns <urn>] tenant_id=<tenant-id> [limit=N] [depth=N]", os.Args[0])
+}
+
+func graphEndpointOwnerIDCleanupUsage() string {
+	return fmt.Sprintf("usage: %s graph cleanup-endpoint-owner-id-links tenant_id=<tenant-id> [source_id=kolide|kandji] [runtime_id=<runtime-id>] [limit=N] [dry_run=true|apply=true]", os.Args[0])
 }
 
 func runGraphInspect(args []string) error {
@@ -432,6 +471,63 @@ func runGraphIngestRuns(args []string) error {
 	})
 }
 
+func cleanupEndpointOwnerIDLinks(ctx context.Context, deps bootstrap.Dependencies, options graphEndpointOwnerIDCleanupOptions) (result graphEndpointOwnerIDCleanupResult, err error) {
+	result = graphEndpointOwnerIDCleanupResult{
+		TenantID:  strings.TrimSpace(options.TenantID),
+		SourceID:  strings.TrimSpace(options.SourceID),
+		RuntimeID: strings.TrimSpace(options.RuntimeID),
+		Limit:     options.Limit,
+		DryRun:    options.DryRun,
+	}
+	ctx, span := telemetry.Start(ctx, "projection_cleanup.endpoint_owner_id_links", telemetry.Attrs(
+		telemetry.Field{Key: "tenant_id", Value: result.TenantID},
+		telemetry.Field{Key: "source_id", Value: result.SourceID},
+		telemetry.Field{Key: "runtime_id", Value: result.RuntimeID},
+		telemetry.Field{Key: "limit", Value: result.Limit},
+		telemetry.Field{Key: "dry_run", Value: result.DryRun},
+	))
+	defer func() {
+		status := "success"
+		fields := []telemetry.Field{
+			{Key: "state_links_matched", Value: result.StateStore.LinksMatched},
+			{Key: "state_links_deleted", Value: result.StateStore.LinksDeleted},
+			{Key: "graph_links_matched", Value: result.GraphStore.LinksMatched},
+			{Key: "graph_links_deleted", Value: result.GraphStore.LinksDeleted},
+		}
+		if err != nil {
+			status = "error"
+			fields = append(fields, telemetry.Field{Key: "error", Value: err.Error()})
+		}
+		telemetry.End(span, status, telemetry.Attrs(fields...))
+	}()
+	request := ports.ProjectionLinkCleanupRequest{
+		TenantID:  result.TenantID,
+		SourceID:  result.SourceID,
+		RuntimeID: result.RuntimeID,
+		Limit:     result.Limit,
+		DryRun:    result.DryRun,
+	}
+	cleaned := false
+	if cleaner, ok := deps.StateStore.(ports.EndpointOwnerIDLinkCleaner); ok {
+		cleaned = true
+		result.StateStore, err = cleaner.CleanupEndpointOwnerIDLinks(ctx, request)
+		if err != nil {
+			return result, fmt.Errorf("cleanup state endpoint owner-id links: %w", err)
+		}
+	}
+	if cleaner, ok := deps.GraphStore.(ports.EndpointOwnerIDLinkCleaner); ok {
+		cleaned = true
+		result.GraphStore, err = cleaner.CleanupEndpointOwnerIDLinks(ctx, request)
+		if err != nil {
+			return result, fmt.Errorf("cleanup graph endpoint owner-id links: %w", err)
+		}
+	}
+	if !cleaned {
+		return result, fmt.Errorf("endpoint owner-id link cleanup is unsupported by configured stores")
+	}
+	return result, nil
+}
+
 func parseGraphNeighborhoodArgs(args []string) (string, int, error) {
 	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
 		return "", 0, usageError(graphInspectUsage())
@@ -577,6 +673,18 @@ func openGraphDependencies(ctx context.Context) (bootstrap.Dependencies, func() 
 	if deps.GraphStore == nil {
 		_ = closeDeps()
 		return bootstrap.Dependencies{}, nil, fmt.Errorf("graph store is required")
+	}
+	return deps, closeDeps, nil
+}
+
+func openGraphCleanupDependencies(ctx context.Context) (bootstrap.Dependencies, func() error, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return bootstrap.Dependencies{}, nil, fmt.Errorf("load config: %w", err)
+	}
+	deps, closeDeps, err := bootstrap.OpenDependencies(ctx, cfg)
+	if err != nil {
+		return bootstrap.Dependencies{}, nil, fmt.Errorf("open dependencies: %w", err)
 	}
 	return deps, closeDeps, nil
 }
@@ -743,6 +851,66 @@ func parseGraphIngestRunsArgs(args []string) (graphIngestRunsOptions, error) {
 		default:
 			return graphIngestRunsOptions{}, usageError(fmt.Sprintf("unsupported graph ingest-runs argument %q", key))
 		}
+	}
+	return options, nil
+}
+
+func parseGraphEndpointOwnerIDCleanupArgs(args []string) (graphEndpointOwnerIDCleanupOptions, error) {
+	options := graphEndpointOwnerIDCleanupOptions{DryRun: true}
+	apply := false
+	dryRunSet := false
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return graphEndpointOwnerIDCleanupOptions{}, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		switch strings.TrimSpace(key) {
+		case "tenant_id":
+			options.TenantID = strings.TrimSpace(value)
+		case "source_id":
+			options.SourceID = strings.ToLower(strings.TrimSpace(value))
+			if options.SourceID != "" && options.SourceID != "kolide" && options.SourceID != "kandji" {
+				return graphEndpointOwnerIDCleanupOptions{}, fmt.Errorf("source_id must be kolide or kandji")
+			}
+		case "runtime_id":
+			options.RuntimeID = strings.TrimSpace(value)
+		case "limit":
+			parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+			if err != nil {
+				return graphEndpointOwnerIDCleanupOptions{}, fmt.Errorf("parse limit: %w", err)
+			}
+			if parsed == 0 {
+				return graphEndpointOwnerIDCleanupOptions{}, fmt.Errorf("limit must be positive")
+			}
+			options.Limit = uint32(parsed)
+		case "dry_run":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphEndpointOwnerIDCleanupOptions{}, fmt.Errorf("parse dry_run: %w", err)
+			}
+			options.DryRun = parsed
+			dryRunSet = true
+		case "apply":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphEndpointOwnerIDCleanupOptions{}, fmt.Errorf("parse apply: %w", err)
+			}
+			apply = parsed
+		default:
+			return graphEndpointOwnerIDCleanupOptions{}, usageError(fmt.Sprintf("unsupported graph cleanup-endpoint-owner-id-links argument %q", key))
+		}
+	}
+	if strings.TrimSpace(options.TenantID) == "" {
+		return graphEndpointOwnerIDCleanupOptions{}, usageError(graphEndpointOwnerIDCleanupUsage())
+	}
+	if apply {
+		if dryRunSet && options.DryRun {
+			return graphEndpointOwnerIDCleanupOptions{}, fmt.Errorf("apply=true conflicts with dry_run=true")
+		}
+		options.DryRun = false
+	}
+	if !options.DryRun && !apply {
+		return graphEndpointOwnerIDCleanupOptions{}, fmt.Errorf("apply=true is required before deleting endpoint owner-id links")
 	}
 	return options, nil
 }

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -7,7 +7,21 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/bootstrap"
+	"github.com/writer/cerebro/internal/ports"
 )
+
+type cleanupStateStore struct {
+	request ports.ProjectionLinkCleanupRequest
+	result  ports.ProjectionLinkCleanupResult
+}
+
+func (s *cleanupStateStore) Ping(context.Context) error { return nil }
+
+func (s *cleanupStateStore) CleanupEndpointOwnerIDLinks(_ context.Context, request ports.ProjectionLinkCleanupRequest) (ports.ProjectionLinkCleanupResult, error) {
+	s.request = request
+	return s.result, nil
+}
 
 func TestParseGraphIngestArgs(t *testing.T) {
 	options, err := parseGraphIngestArgs([]string{
@@ -136,6 +150,52 @@ func TestParseGraphIngestRunsArgs(t *testing.T) {
 	}
 	if options.RuntimeID != "writer-github" || options.Status != "failed" || options.Limit != 7 {
 		t.Fatalf("options = %#v, want runtime/status/limit", options)
+	}
+}
+
+func TestParseGraphEndpointOwnerIDCleanupArgsDefaultsDryRun(t *testing.T) {
+	options, err := parseGraphEndpointOwnerIDCleanupArgs([]string{
+		"tenant_id=writer",
+		"source_id=kolide",
+		"runtime_id=writer-kolide",
+		"limit=25",
+	})
+	if err != nil {
+		t.Fatalf("parseGraphEndpointOwnerIDCleanupArgs() error = %v", err)
+	}
+	if !options.DryRun || options.TenantID != "writer" || options.SourceID != "kolide" || options.RuntimeID != "writer-kolide" || options.Limit != 25 {
+		t.Fatalf("options = %#v, want dry-run scoped cleanup", options)
+	}
+}
+
+func TestParseGraphEndpointOwnerIDCleanupArgsRequiresApplyForDeletes(t *testing.T) {
+	if _, err := parseGraphEndpointOwnerIDCleanupArgs([]string{"tenant_id=writer", "dry_run=false"}); err == nil {
+		t.Fatal("parseGraphEndpointOwnerIDCleanupArgs() error = nil, want apply requirement")
+	}
+	options, err := parseGraphEndpointOwnerIDCleanupArgs([]string{"tenant_id=writer", "apply=true"})
+	if err != nil {
+		t.Fatalf("parseGraphEndpointOwnerIDCleanupArgs(apply) error = %v", err)
+	}
+	if options.DryRun {
+		t.Fatalf("DryRun = true, want apply mode")
+	}
+}
+
+func TestCleanupEndpointOwnerIDLinksAllowsStateStoreOnly(t *testing.T) {
+	state := &cleanupStateStore{result: ports.ProjectionLinkCleanupResult{LinksMatched: 3, LinksDeleted: 0}}
+	result, err := cleanupEndpointOwnerIDLinks(context.Background(), bootstrap.Dependencies{StateStore: state}, graphEndpointOwnerIDCleanupOptions{
+		TenantID: "writer",
+		SourceID: "kolide",
+		DryRun:   true,
+	})
+	if err != nil {
+		t.Fatalf("cleanupEndpointOwnerIDLinks() error = %v", err)
+	}
+	if state.request.TenantID != "writer" || state.request.SourceID != "kolide" || !state.request.DryRun {
+		t.Fatalf("cleanup request = %#v, want scoped dry-run", state.request)
+	}
+	if result.StateStore.LinksMatched != 3 || result.GraphStore.LinksMatched != 0 {
+		t.Fatalf("cleanup result = %#v, want state-only result", result)
 	}
 }
 

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -592,10 +592,22 @@ func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRe
 		}
 	}
 	if deleter, ok := graphStore.(ports.ProjectionLinkDeleter); ok {
+		var deleted uint32
 		for _, key := range sortedMapKeys(retractedLinks) {
 			if err := deleter.DeleteProjectedLink(ctx, retractedLinks[key]); err != nil {
 				return result, fmt.Errorf("delete coalesced projected link %q: %w", key, err)
 			}
+			deleted++
+		}
+		if len(retractedLinks) != 0 {
+			telemetry.Event(ctx, "source_projection.retractions", telemetry.Attrs(
+				telemetry.Field{Key: "tenant_id", Value: request.TenantID},
+				telemetry.Field{Key: "source_id", Value: request.SourceID},
+				telemetry.Field{Key: "runtime_id", Value: request.RuntimeID},
+				telemetry.Field{Key: "reason", Value: "endpoint_owner_id"},
+				telemetry.Field{Key: "links_matched", Value: len(retractedLinks)},
+				telemetry.Field{Key: "links_deleted", Value: deleted},
+			))
 		}
 	}
 	entityKeys := sortedMapKeys(entities)

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -557,21 +557,8 @@ func (s *Store) CleanupEndpointOwnerIDLinks(ctx context.Context, request ports.P
 	if err != nil {
 		return ports.ProjectionLinkCleanupResult{}, err
 	}
-	query := `MATCH (e:Entity)-[stale:RELATION]->(target:Entity)
-WHERE ` + strings.Join(conditions, " AND ") + `
-  AND EXISTS {
-    MATCH (e)-[replacement:RELATION {relation: 'has_identifier'}]->(replacementTarget:Entity)
-    WHERE replacement.tenant_id = stale.tenant_id
-      AND replacement.source_id IN $source_ids
-      AND any(stalePrefix IN $stale_prefixes WHERE target.urn STARTS WITH stalePrefix
-        AND any(replacementPrefix IN $replacement_prefixes WHERE replacementTarget.urn STARTS WITH replacementPrefix
-          AND substring(target.urn, size(stalePrefix)) = substring(replacementTarget.urn, size(replacementPrefix))))
-  }
-WITH stale
-LIMIT $limit`
+	query := endpointOwnerIDLinkCleanupQuery(conditions, request.DryRun)
 	if request.DryRun {
-		query += `
-RETURN count(stale)`
 		var matched int64
 		if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
 			value, err := queryOneValue(ctx, tx, query, params)
@@ -585,10 +572,6 @@ RETURN count(stale)`
 		}
 		return ports.ProjectionLinkCleanupResult{LinksMatched: uint32(matched)}, nil
 	}
-	query += `
-WITH collect(stale) AS victims
-FOREACH (link IN victims | DELETE link)
-RETURN size(victims)`
 	var deleted int64
 	if _, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
 		value, err := queryOneValue(ctx, tx, query, params)
@@ -601,6 +584,30 @@ RETURN size(victims)`
 		return ports.ProjectionLinkCleanupResult{}, fmt.Errorf("cleanup endpoint owner-id links: %w", err)
 	}
 	return ports.ProjectionLinkCleanupResult{LinksMatched: uint32(deleted), LinksDeleted: uint32(deleted)}, nil
+}
+
+func endpointOwnerIDLinkCleanupQuery(conditions []string, dryRun bool) string {
+	query := `MATCH (e:Entity)-[stale:RELATION]->(target:Entity)
+WHERE ` + strings.Join(conditions, " AND ") + `
+  AND EXISTS {
+    MATCH (e)-[replacement:RELATION {relation: 'has_identifier'}]->(replacementTarget:Entity)
+    WHERE replacement.tenant_id = stale.tenant_id
+      AND replacement.source_id IN $source_ids
+      AND any(stalePrefix IN $stale_prefixes WHERE target.urn STARTS WITH stalePrefix
+        AND any(replacementPrefix IN $replacement_prefixes WHERE replacementTarget.urn STARTS WITH replacementPrefix
+          AND substring(target.urn, size(stalePrefix)) = substring(replacementTarget.urn, size(replacementPrefix))))
+  }
+WITH stale, e, target
+ORDER BY e.urn, stale.relation, target.urn, elementId(stale)
+LIMIT $limit`
+	if dryRun {
+		return query + `
+RETURN count(stale)`
+	}
+	return query + `
+WITH collect(stale) AS victims
+FOREACH (link IN victims | DELETE link)
+RETURN size(victims)`
 }
 
 func endpointOwnerIDLinkCleanupParams(request ports.ProjectionLinkCleanupRequest) (map[string]any, []string, error) {

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -545,6 +545,133 @@ RETURN size(entities)`
 	return ports.ProjectionCleanupResult{EntitiesDeleted: uint32(deleted)}, nil
 }
 
+// CleanupEndpointOwnerIDLinks removes stale endpoint owner_id/user_id canonical identity links.
+func (s *Store) CleanupEndpointOwnerIDLinks(ctx context.Context, request ports.ProjectionLinkCleanupRequest) (ports.ProjectionLinkCleanupResult, error) {
+	if err := s.requireConfigured(); err != nil {
+		return ports.ProjectionLinkCleanupResult{}, err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return ports.ProjectionLinkCleanupResult{}, err
+	}
+	params, conditions, err := endpointOwnerIDLinkCleanupParams(request)
+	if err != nil {
+		return ports.ProjectionLinkCleanupResult{}, err
+	}
+	query := `MATCH (e:Entity)-[stale:RELATION]->(target:Entity)
+WHERE ` + strings.Join(conditions, " AND ") + `
+  AND EXISTS {
+    MATCH (e)-[replacement:RELATION {relation: 'has_identifier'}]->(replacementTarget:Entity)
+    WHERE replacement.tenant_id = stale.tenant_id
+      AND replacement.source_id IN $source_ids
+      AND any(stalePrefix IN $stale_prefixes WHERE target.urn STARTS WITH stalePrefix
+        AND any(replacementPrefix IN $replacement_prefixes WHERE replacementTarget.urn STARTS WITH replacementPrefix
+          AND substring(target.urn, size(stalePrefix)) = substring(replacementTarget.urn, size(replacementPrefix))))
+  }
+WITH stale
+LIMIT $limit`
+	if request.DryRun {
+		query += `
+RETURN count(stale)`
+		var matched int64
+		if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+			value, err := queryOneValue(ctx, tx, query, params)
+			if err != nil {
+				return nil, err
+			}
+			matched = toInt64(value)
+			return nil, nil
+		}); err != nil {
+			return ports.ProjectionLinkCleanupResult{}, fmt.Errorf("cleanup endpoint owner-id links: %w", err)
+		}
+		return ports.ProjectionLinkCleanupResult{LinksMatched: uint32(matched)}, nil
+	}
+	query += `
+WITH collect(stale) AS victims
+FOREACH (link IN victims | DELETE link)
+RETURN size(victims)`
+	var deleted int64
+	if _, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		value, err := queryOneValue(ctx, tx, query, params)
+		if err != nil {
+			return nil, err
+		}
+		deleted = toInt64(value)
+		return nil, nil
+	}); err != nil {
+		return ports.ProjectionLinkCleanupResult{}, fmt.Errorf("cleanup endpoint owner-id links: %w", err)
+	}
+	return ports.ProjectionLinkCleanupResult{LinksMatched: uint32(deleted), LinksDeleted: uint32(deleted)}, nil
+}
+
+func endpointOwnerIDLinkCleanupParams(request ports.ProjectionLinkCleanupRequest) (map[string]any, []string, error) {
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return nil, nil, errors.New("tenant_id is required for endpoint owner-id link cleanup")
+	}
+	sourceIDs := endpointOwnerIDCleanupSources(request.SourceID)
+	if len(sourceIDs) == 0 {
+		return nil, nil, errors.New("unsupported endpoint owner-id cleanup source")
+	}
+	stalePrefixes, replacementPrefixes := endpointOwnerIDCleanupPrefixes(tenantID, sourceIDs)
+	limit := int64(request.Limit)
+	if limit <= 0 {
+		limit = defaultProjectionCleanupLimit
+	}
+	conditions := []string{
+		"e.tenant_id = $tenant_id",
+		"stale.tenant_id = $tenant_id",
+		"e.source_id IN $source_ids",
+		"stale.source_id IN $source_ids",
+		"e.entity_type IN $endpoint_entity_types",
+		"stale.relation IN $stale_relations",
+		"any(stalePrefix IN $stale_prefixes WHERE target.urn STARTS WITH stalePrefix)",
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID != "" {
+		conditions = append(conditions, "coalesce(stale.runtime_id, '') = $runtime_id")
+	}
+	params := map[string]any{
+		"tenant_id":             tenantID,
+		"source_ids":            sourceIDs,
+		"endpoint_entity_types": []string{"kolide.device", "kandji.device"},
+		"stale_relations":       []string{"owned_by", "represents_identity", "has_identifier"},
+		"stale_prefixes":        stalePrefixes,
+		"replacement_prefixes":  replacementPrefixes,
+		"limit":                 limit,
+	}
+	if runtimeID != "" {
+		params["runtime_id"] = runtimeID
+	}
+	return params, conditions, nil
+}
+
+func endpointOwnerIDCleanupSources(sourceID string) []string {
+	source := strings.ToLower(strings.TrimSpace(sourceID))
+	switch source {
+	case "":
+		return []string{"kolide", "kandji"}
+	case "kolide", "kandji":
+		return []string{source}
+	default:
+		return nil
+	}
+}
+
+func endpointOwnerIDCleanupPrefixes(tenantID string, sources []string) ([]string, []string) {
+	stalePrefixes := []string{
+		fmt.Sprintf("urn:cerebro:%s:identity:login:", tenantID),
+		fmt.Sprintf("urn:cerebro:%s:identifier:login:", tenantID),
+	}
+	replacementPrefixes := make([]string, 0, len(sources)*2)
+	for _, source := range sources {
+		replacementPrefixes = append(replacementPrefixes,
+			fmt.Sprintf("urn:cerebro:%s:endpoint_identifier:%s_owner_id:", tenantID, source),
+			fmt.Sprintf("urn:cerebro:%s:endpoint_identifier:%s_user_id:", tenantID, source),
+		)
+	}
+	return stalePrefixes, replacementPrefixes
+}
+
 // GetEntityNeighborhood returns one bounded root-centered graph neighborhood.
 func (s *Store) GetEntityNeighborhood(ctx context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
 	normalizedRootURN := strings.TrimSpace(rootURN)

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -36,6 +36,29 @@ func TestProjectedEntityMergePreservesExistingLabelsForFallbackLabels(t *testing
 	}
 }
 
+func TestEndpointOwnerIDLinkCleanupQueryOrdersLimitedBatch(t *testing.T) {
+	_, conditions, err := endpointOwnerIDLinkCleanupParams(ports.ProjectionLinkCleanupRequest{
+		TenantID: "writer",
+		SourceID: "kolide",
+		Limit:    25,
+	})
+	if err != nil {
+		t.Fatalf("endpointOwnerIDLinkCleanupParams() error = %v", err)
+	}
+	query := endpointOwnerIDLinkCleanupQuery(conditions, false)
+	orderIndex := strings.Index(query, "ORDER BY e.urn, stale.relation, target.urn, elementId(stale)")
+	limitIndex := strings.Index(query, "LIMIT $limit")
+	if orderIndex == -1 {
+		t.Fatalf("endpointOwnerIDLinkCleanupQuery() missing deterministic ORDER BY:\n%s", query)
+	}
+	if limitIndex == -1 {
+		t.Fatalf("endpointOwnerIDLinkCleanupQuery() missing LIMIT:\n%s", query)
+	}
+	if orderIndex > limitIndex {
+		t.Fatalf("endpointOwnerIDLinkCleanupQuery() orders after limiting:\n%s", query)
+	}
+}
+
 func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	if os.Getenv("CEREBRO_RUN_NEO4J_DOCKER") != "1" {
 		t.Skip("set CEREBRO_RUN_NEO4J_DOCKER=1 to run Neo4j Docker integration test")

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -234,6 +234,66 @@ func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	if counts.Relations != 1 {
 		t.Fatalf("Counts(after delete) = %#v, want 1 relation", counts)
 	}
+
+	endpointURN := "urn:cerebro:writer:kolide_device:device-1"
+	identityURN := "urn:cerebro:writer:identity:login:user-1"
+	identifierURN := "urn:cerebro:writer:identifier:login:user-1"
+	emailIdentityURN := "urn:cerebro:writer:identity:email:alice@example.com"
+	unmigratedIdentityURN := "urn:cerebro:writer:identity:login:user-2"
+	replacementURN := "urn:cerebro:writer:endpoint_identifier:kolide_user_id:user-1"
+	for _, entity := range []*ports.ProjectedEntity{
+		{URN: endpointURN, TenantID: "writer", SourceID: "kolide", EntityType: "kolide.device", Label: "device-1"},
+		{URN: identityURN, TenantID: "writer", SourceID: "kolide", EntityType: "identity.login", Label: "user-1"},
+		{URN: identifierURN, TenantID: "writer", SourceID: "kolide", EntityType: "identifier.login", Label: "user-1"},
+		{URN: emailIdentityURN, TenantID: "writer", SourceID: "kolide", EntityType: "identity.email", Label: "alice@example.com"},
+		{URN: unmigratedIdentityURN, TenantID: "writer", SourceID: "kolide", EntityType: "identity.login", Label: "user-2"},
+		{URN: replacementURN, TenantID: "writer", SourceID: "kolide", EntityType: "endpoint.identifier", Label: "user-1"},
+	} {
+		if err := store.UpsertProjectedEntity(ctx, entity); err != nil {
+			t.Fatalf("UpsertProjectedEntity(%s) error = %v", entity.URN, err)
+		}
+	}
+	staleLinks := []*ports.ProjectedLink{
+		{TenantID: "writer", SourceID: "kolide", FromURN: endpointURN, Relation: "owned_by", ToURN: identityURN},
+		{TenantID: "writer", SourceID: "kolide", FromURN: endpointURN, Relation: "represents_identity", ToURN: identityURN},
+		{TenantID: "writer", SourceID: "kolide", FromURN: endpointURN, Relation: "has_identifier", ToURN: identifierURN},
+	}
+	preservedLinks := []*ports.ProjectedLink{
+		{TenantID: "writer", SourceID: "kolide", FromURN: endpointURN, Relation: "owned_by", ToURN: emailIdentityURN},
+		{TenantID: "writer", SourceID: "kolide", FromURN: endpointURN, Relation: "owned_by", ToURN: unmigratedIdentityURN},
+		{TenantID: "writer", SourceID: "kolide", FromURN: endpointURN, Relation: "has_identifier", ToURN: replacementURN},
+	}
+	for _, link := range append(staleLinks, preservedLinks...) {
+		if err := store.UpsertProjectedLink(ctx, link); err != nil {
+			t.Fatalf("UpsertProjectedLink(%s %s %s) error = %v", link.FromURN, link.Relation, link.ToURN, err)
+		}
+	}
+	cleanupRequest := ports.ProjectionLinkCleanupRequest{TenantID: "writer", SourceID: "kolide", DryRun: true}
+	cleanupResult, err := store.CleanupEndpointOwnerIDLinks(ctx, cleanupRequest)
+	if err != nil {
+		t.Fatalf("CleanupEndpointOwnerIDLinks(dry-run) error = %v", err)
+	}
+	if cleanupResult.LinksMatched != uint32(len(staleLinks)) || cleanupResult.LinksDeleted != 0 {
+		t.Fatalf("dry-run CleanupEndpointOwnerIDLinks() = %#v, want %d matches and no deletes", cleanupResult, len(staleLinks))
+	}
+	cleanupRequest.DryRun = false
+	cleanupResult, err = store.CleanupEndpointOwnerIDLinks(ctx, cleanupRequest)
+	if err != nil {
+		t.Fatalf("CleanupEndpointOwnerIDLinks() error = %v", err)
+	}
+	if cleanupResult.LinksMatched != uint32(len(staleLinks)) || cleanupResult.LinksDeleted != uint32(len(staleLinks)) {
+		t.Fatalf("CleanupEndpointOwnerIDLinks() = %#v, want %d deletes", cleanupResult, len(staleLinks))
+	}
+	for _, link := range staleLinks {
+		if neo4jProjectedLinkExists(t, ctx, store, link) {
+			t.Fatalf("stale link still exists: %s %s %s", link.FromURN, link.Relation, link.ToURN)
+		}
+	}
+	for _, link := range preservedLinks {
+		if !neo4jProjectedLinkExists(t, ctx, store, link) {
+			t.Fatalf("preserved link missing: %s %s %s", link.FromURN, link.Relation, link.ToURN)
+		}
+	}
 }
 
 func projectedEntityAttributes(t *testing.T, ctx context.Context, store *Store, urn string) map[string]string {
@@ -284,6 +344,21 @@ RETURN count(r), collect(r.attributes_json)`, map[string]any{
 		t.Fatalf("decode projected link attributes: %v", err)
 	}
 	return attributes
+}
+
+func neo4jProjectedLinkExists(t *testing.T, ctx context.Context, store *Store, link *ports.ProjectedLink) bool {
+	t.Helper()
+	value, err := store.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		return queryOneValue(ctx, tx, `MATCH (:Entity {urn: $from_urn})-[r:RELATION {relation: $relation}]->(:Entity {urn: $to_urn}) RETURN count(r)`, map[string]any{
+			"from_urn": link.FromURN,
+			"relation": link.Relation,
+			"to_urn":   link.ToURN,
+		})
+	})
+	if err != nil {
+		t.Fatalf("query projected link: %v", err)
+	}
+	return toInt64(value) > 0
 }
 
 func freePort(t *testing.T) int {

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -54,6 +54,21 @@ type ProjectionCleanupResult struct {
 	LinksDeleted    uint32
 }
 
+// ProjectionLinkCleanupRequest scopes a destructive projection-link cleanup pass.
+type ProjectionLinkCleanupRequest struct {
+	TenantID  string
+	SourceID  string
+	RuntimeID string
+	Limit     uint32
+	DryRun    bool
+}
+
+// ProjectionLinkCleanupResult reports links found/deleted by one cleanup pass.
+type ProjectionLinkCleanupResult struct {
+	LinksMatched uint32
+	LinksDeleted uint32
+}
+
 // ProjectionStateStore persists normalized current-state entities and links.
 type ProjectionStateStore interface {
 	StateStore
@@ -81,6 +96,11 @@ type ProjectionEntityDeleter interface {
 // ProjectionCleaner removes stale or orphaned projection artifacts in scoped batches.
 type ProjectionCleaner interface {
 	CleanupProjectedEntities(context.Context, ProjectionCleanupRequest) (ProjectionCleanupResult, error)
+}
+
+// EndpointOwnerIDLinkCleaner removes stale endpoint owner_id/user_id canonical identity links.
+type EndpointOwnerIDLinkCleaner interface {
+	CleanupEndpointOwnerIDLinks(context.Context, ProjectionLinkCleanupRequest) (ProjectionLinkCleanupResult, error)
 }
 
 // SourceProjector materializes source events into current-state and graph stores.

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -15,6 +15,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 var emailIdentifierPattern = regexp.MustCompile(`(?i)[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}`)
@@ -108,6 +109,17 @@ func (s *Service) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (
 	retractedLinksDeleted, err := s.deleteProjectedLinks(ctx, retractedLinks)
 	if err != nil {
 		return ports.ProjectionResult{}, err
+	}
+	if len(retractedLinks) != 0 {
+		telemetry.Event(ctx, "source_projection.retractions", telemetry.Attrs(
+			telemetry.Field{Key: "tenant_id", Value: event.GetTenantId()},
+			telemetry.Field{Key: "source_id", Value: event.GetSourceId()},
+			telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(event.GetAttributes()[ports.EventAttributeSourceRuntimeID])},
+			telemetry.Field{Key: "event_kind", Value: event.GetKind()},
+			telemetry.Field{Key: "reason", Value: "endpoint_owner_id"},
+			telemetry.Field{Key: "links_matched", Value: len(retractedLinks)},
+			telemetry.Field{Key: "links_deleted", Value: retractedLinksDeleted},
+		))
 	}
 	for _, entity := range entities {
 		if s.state != nil {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -5,10 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -53,11 +51,9 @@ const (
 
 // Service materializes synced source events into current-state and graph stores.
 type Service struct {
-	state             ports.ProjectionStateStore
-	graph             ports.ProjectionGraphStore
-	registry          *Registry
-	cleanupMu         sync.Mutex
-	cleanupRequestRun map[string]struct{}
+	state    ports.ProjectionStateStore
+	graph    ports.ProjectionGraphStore
+	registry *Registry
 }
 
 // New constructs a source projector.
@@ -298,7 +294,6 @@ func (s *Service) deleteProjectedEntities(ctx context.Context, urns []string) (u
 }
 
 func (s *Service) cleanupProjectedEntities(ctx context.Context, requests []ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
-	requests = s.pendingCleanupRequests(requests)
 	if len(requests) == 0 {
 		return ports.ProjectionCleanupResult{}, nil
 	}
@@ -315,7 +310,6 @@ func (s *Service) cleanupProjectedEntities(ctx context.Context, requests []ports
 		result.EntitiesDeleted += cleanup.EntitiesDeleted
 		result.LinksDeleted += cleanup.LinksDeleted
 	}
-	s.markCleanupRequests(requests)
 	return result, nil
 }
 
@@ -343,54 +337,6 @@ func cleanupBatchLimit(request ports.ProjectionCleanupRequest) uint32 {
 		return defaultCleanupLimit
 	}
 	return request.Limit
-}
-
-func (s *Service) pendingCleanupRequests(requests []ports.ProjectionCleanupRequest) []ports.ProjectionCleanupRequest {
-	if s == nil || len(requests) == 0 {
-		return nil
-	}
-	s.cleanupMu.Lock()
-	defer s.cleanupMu.Unlock()
-	pending := make([]ports.ProjectionCleanupRequest, 0, len(requests))
-	for _, request := range requests {
-		if _, ok := s.cleanupRequestRun[projectionCleanupRequestKey(request)]; ok {
-			continue
-		}
-		pending = append(pending, request)
-	}
-	return pending
-}
-
-func (s *Service) markCleanupRequests(requests []ports.ProjectionCleanupRequest) {
-	if s == nil || len(requests) == 0 {
-		return
-	}
-	s.cleanupMu.Lock()
-	defer s.cleanupMu.Unlock()
-	if s.cleanupRequestRun == nil {
-		s.cleanupRequestRun = map[string]struct{}{}
-	}
-	for _, request := range requests {
-		s.cleanupRequestRun[projectionCleanupRequestKey(request)] = struct{}{}
-	}
-}
-
-func projectionCleanupRequestKey(request ports.ProjectionCleanupRequest) string {
-	entityTypes := append([]string(nil), request.EntityTypes...)
-	urnPrefixes := append([]string(nil), request.URNPrefixes...)
-	sort.Strings(entityTypes)
-	sort.Strings(urnPrefixes)
-	values := []string{
-		strings.TrimSpace(request.TenantID),
-		strings.TrimSpace(request.SourceID),
-		strings.TrimSpace(request.RuntimeID),
-		strings.TrimSpace(request.FindingID),
-		strings.Join(entityTypes, ","),
-		strings.Join(urnPrefixes, ","),
-		fmt.Sprintf("%t", request.OnlyIsolated),
-		fmt.Sprintf("%d", request.Limit),
-	}
-	return strings.Join(values, "|")
 }
 
 func deleteProjectedEntity(ctx context.Context, store any, urn string) (bool, error) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -782,7 +782,7 @@ func TestCleanupProjectedEntitiesRunsAgainstStateStore(t *testing.T) {
 	}
 }
 
-func TestProjectOktaAuditRunsScopedCleanupOncePerService(t *testing.T) {
+func TestProjectOktaAuditRunsScopedCleanupForLaterStaleResources(t *testing.T) {
 	state := &projectionRecorder{
 		entities: map[string]*ports.ProjectedEntity{
 			"urn:cerebro:writer:okta_resource:access_token:stale-token": {
@@ -823,17 +823,30 @@ func TestProjectOktaAuditRunsScopedCleanupOncePerService(t *testing.T) {
 	if _, err := service.Project(context.Background(), event("okta-oauth-token-1", "token-1")); err != nil {
 		t.Fatalf("Project(first) error = %v", err)
 	}
+	state.entities["urn:cerebro:writer:okta_resource:access_token:later-stale-token"] = &ports.ProjectedEntity{
+		URN:        "urn:cerebro:writer:okta_resource:access_token:later-stale-token",
+		TenantID:   "writer",
+		SourceID:   "okta",
+		RuntimeID:  "okta-audit-runtime",
+		EntityType: "okta.resource",
+		Label:      "later-stale-token",
+	}
 	if _, err := service.Project(context.Background(), event("okta-oauth-token-2", "token-2")); err != nil {
 		t.Fatalf("Project(second) error = %v", err)
 	}
-	if got := len(state.cleanupRequests); got != 1 {
-		t.Fatalf("state cleanup calls = %d, want 1 deduped cleanup request", got)
+	if got := len(state.cleanupRequests); got != 2 {
+		t.Fatalf("state cleanup calls = %d, want cleanup on each projection pass", got)
 	}
 	if len(state.entities) == 0 {
 		return
 	}
-	if _, ok := state.entities["urn:cerebro:writer:okta_resource:access_token:stale-token"]; ok {
-		t.Fatalf("state retained stale cleanup token")
+	for _, urn := range []string{
+		"urn:cerebro:writer:okta_resource:access_token:stale-token",
+		"urn:cerebro:writer:okta_resource:access_token:later-stale-token",
+	} {
+		if _, ok := state.entities[urn]; ok {
+			t.Fatalf("state retained stale cleanup token %q", urn)
+		}
 	}
 }
 

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -172,6 +172,148 @@ func projectedEntityCleanupConditions(request ports.ProjectionCleanupRequest) ([
 	return conditions, args, scoped
 }
 
+func projectedEndpointOwnerIDLinkCleanupSQL(request ports.ProjectionLinkCleanupRequest) (string, []any, error) {
+	conditions, replacementConditions, args, stalePrefixes, replacementPrefixes, err := projectedEndpointOwnerIDLinkCleanupConditions(request)
+	if err != nil {
+		return "", nil, err
+	}
+	suffixCondition := projectedEndpointOwnerIDReplacementSuffixCondition(stalePrefixes, replacementPrefixes, &args)
+	args = append(args, requestLimit(request.Limit))
+	limitPlaceholder := len(args)
+	victims := fmt.Sprintf(`
+WITH victims AS (
+  SELECT DISTINCT l.from_urn, l.relation, l.to_urn
+  FROM entity_links l
+  JOIN entities e ON e.urn = l.from_urn
+  WHERE %s
+    AND EXISTS (
+      SELECT 1
+      FROM entity_links replacement
+      WHERE replacement.from_urn = l.from_urn
+        AND replacement.tenant_id = l.tenant_id
+        AND replacement.relation = 'has_identifier'
+        AND %s
+        AND %s
+    )
+  ORDER BY l.from_urn, l.relation, l.to_urn
+  LIMIT $%d
+)`, strings.Join(conditions, " AND "), strings.Join(replacementConditions, " AND "), suffixCondition, limitPlaceholder)
+	if request.DryRun {
+		return victims + `
+SELECT COUNT(*) AS links_matched, 0 AS links_deleted
+FROM victims`, args, nil
+	}
+	return victims + `
+, deleted_links AS (
+  DELETE FROM entity_links l
+  USING victims v
+  WHERE l.from_urn = v.from_urn AND l.relation = v.relation AND l.to_urn = v.to_urn
+  RETURNING 1
+)
+SELECT
+  (SELECT COUNT(*) FROM victims) AS links_matched,
+  (SELECT COUNT(*) FROM deleted_links) AS links_deleted`, args, nil
+}
+
+func projectedEndpointOwnerIDLinkCleanupConditions(request ports.ProjectionLinkCleanupRequest) ([]string, []string, []any, []string, []string, error) {
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return nil, nil, nil, nil, nil, errors.New("tenant_id is required for endpoint owner-id link cleanup")
+	}
+	sources := endpointOwnerIDCleanupSources(request.SourceID)
+	if len(sources) == 0 {
+		return nil, nil, nil, nil, nil, errors.New("unsupported endpoint owner-id cleanup source")
+	}
+	stalePrefixes, replacementPrefixes := endpointOwnerIDCleanupPrefixes(tenantID, sources)
+	args := []any{tenantID}
+	conditions := []string{
+		"l.tenant_id = $1",
+		"e.tenant_id = $1",
+		"e.entity_type IN ('kolide.device', 'kandji.device')",
+		"l.relation IN ('owned_by', 'represents_identity', 'has_identifier')",
+		projectedPrefixCondition("l.to_urn", stalePrefixes, &args),
+	}
+	sourcePlaceholders := make([]string, 0, len(sources))
+	for _, source := range sources {
+		args = append(args, source)
+		sourcePlaceholders = append(sourcePlaceholders, fmt.Sprintf("$%d", len(args)))
+	}
+	conditions = append(conditions,
+		fmt.Sprintf("l.source_id IN (%s)", strings.Join(sourcePlaceholders, ", ")),
+		fmt.Sprintf("e.source_id IN (%s)", strings.Join(sourcePlaceholders, ", ")),
+	)
+	replacementConditions := []string{fmt.Sprintf("replacement.source_id IN (%s)", strings.Join(sourcePlaceholders, ", "))}
+	if runtimeID := strings.TrimSpace(request.RuntimeID); runtimeID != "" {
+		args = append(args, runtimeID)
+		conditions = append(conditions, fmt.Sprintf("l.runtime_id = $%d", len(args)))
+	}
+	return conditions, replacementConditions, args, stalePrefixes, replacementPrefixes, nil
+}
+
+func projectedEndpointOwnerIDReplacementSuffixCondition(stalePrefixes []string, replacementPrefixes []string, args *[]any) string {
+	pairs := make([]string, 0, len(stalePrefixes)*len(replacementPrefixes))
+	for _, stalePrefix := range stalePrefixes {
+		for _, replacementPrefix := range replacementPrefixes {
+			*args = append(*args, stalePrefix)
+			stalePlaceholder := len(*args)
+			*args = append(*args, replacementPrefix)
+			replacementPlaceholder := len(*args)
+			pairs = append(pairs, fmt.Sprintf("(LEFT(l.to_urn, LENGTH($%[1]d)) = $%[1]d AND LEFT(replacement.to_urn, LENGTH($%[2]d)) = $%[2]d AND SUBSTRING(l.to_urn FROM LENGTH($%[1]d) + 1) = SUBSTRING(replacement.to_urn FROM LENGTH($%[2]d) + 1))", stalePlaceholder, replacementPlaceholder))
+		}
+	}
+	if len(pairs) == 0 {
+		return "FALSE"
+	}
+	return "(" + strings.Join(pairs, " OR ") + ")"
+}
+
+func projectedPrefixCondition(column string, prefixes []string, args *[]any) string {
+	conditions := make([]string, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		*args = append(*args, prefix)
+		placeholder := len(*args)
+		conditions = append(conditions, fmt.Sprintf("LEFT(%s, LENGTH($%d)) = $%d", column, placeholder, placeholder))
+	}
+	if len(conditions) == 0 {
+		return "FALSE"
+	}
+	return "(" + strings.Join(conditions, " OR ") + ")"
+}
+
+func endpointOwnerIDCleanupSources(sourceID string) []string {
+	source := strings.ToLower(strings.TrimSpace(sourceID))
+	switch source {
+	case "":
+		return []string{"kolide", "kandji"}
+	case "kolide", "kandji":
+		return []string{source}
+	default:
+		return nil
+	}
+}
+
+func endpointOwnerIDCleanupPrefixes(tenantID string, sources []string) ([]string, []string) {
+	stalePrefixes := []string{
+		fmt.Sprintf("urn:cerebro:%s:identity:login:", tenantID),
+		fmt.Sprintf("urn:cerebro:%s:identifier:login:", tenantID),
+	}
+	replacementPrefixes := make([]string, 0, len(sources)*2)
+	for _, source := range sources {
+		replacementPrefixes = append(replacementPrefixes,
+			fmt.Sprintf("urn:cerebro:%s:endpoint_identifier:%s_owner_id:", tenantID, source),
+			fmt.Sprintf("urn:cerebro:%s:endpoint_identifier:%s_user_id:", tenantID, source),
+		)
+	}
+	return stalePrefixes, replacementPrefixes
+}
+
+func requestLimit(limit uint32) uint32 {
+	if limit == 0 {
+		return defaultProjectionCleanupLimit
+	}
+	return limit
+}
+
 // UpsertProjectedEntity persists one normalized entity in the current-state store.
 func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.ProjectedEntity) error {
 	if entity == nil {
@@ -330,6 +472,28 @@ func (s *Store) CleanupProjectedEntities(ctx context.Context, request ports.Proj
 			return ports.ProjectionCleanupResult{}, nil
 		}
 		return ports.ProjectionCleanupResult{}, fmt.Errorf("cleanup projected entities: %w", err)
+	}
+	return result, nil
+}
+
+// CleanupEndpointOwnerIDLinks removes stale endpoint owner_id/user_id canonical identity links.
+func (s *Store) CleanupEndpointOwnerIDLinks(ctx context.Context, request ports.ProjectionLinkCleanupRequest) (ports.ProjectionLinkCleanupResult, error) {
+	if s == nil || s.db == nil {
+		return ports.ProjectionLinkCleanupResult{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureProjectionTables(ctx); err != nil {
+		return ports.ProjectionLinkCleanupResult{}, err
+	}
+	query, args, err := projectedEndpointOwnerIDLinkCleanupSQL(request)
+	if err != nil {
+		return ports.ProjectionLinkCleanupResult{}, err
+	}
+	var result ports.ProjectionLinkCleanupResult
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&result.LinksMatched, &result.LinksDeleted); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ports.ProjectionLinkCleanupResult{}, nil
+		}
+		return ports.ProjectionLinkCleanupResult{}, fmt.Errorf("cleanup endpoint owner-id links: %w", err)
 	}
 	return result, nil
 }

--- a/internal/statestore/postgres/projection_test.go
+++ b/internal/statestore/postgres/projection_test.go
@@ -2,9 +2,13 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -121,4 +125,168 @@ func TestProjectedEntityCleanupSQLIncludesScopedFilters(t *testing.T) {
 	if args[5] != uint32(25) {
 		t.Fatalf("cleanup limit arg = %#v, want uint32(25)", args[5])
 	}
+}
+
+func TestProjectedEndpointOwnerIDLinkCleanupSQLRequiresTenant(t *testing.T) {
+	if _, _, err := projectedEndpointOwnerIDLinkCleanupSQL(ports.ProjectionLinkCleanupRequest{DryRun: true}); err == nil {
+		t.Fatal("projectedEndpointOwnerIDLinkCleanupSQL() error = nil, want tenant scope requirement")
+	}
+}
+
+func TestProjectedEndpointOwnerIDLinkCleanupSQLScopesToReplacementIdentifiers(t *testing.T) {
+	query, args, err := projectedEndpointOwnerIDLinkCleanupSQL(ports.ProjectionLinkCleanupRequest{
+		TenantID: "writer",
+		SourceID: "kolide",
+		DryRun:   true,
+		Limit:    50,
+	})
+	if err != nil {
+		t.Fatalf("projectedEndpointOwnerIDLinkCleanupSQL() error = %v", err)
+	}
+	for _, want := range []string{
+		"l.tenant_id = $1",
+		"e.entity_type IN ('kolide.device', 'kandji.device')",
+		"l.relation IN ('owned_by', 'represents_identity', 'has_identifier')",
+		"replacement.relation = 'has_identifier'",
+		"SELECT COUNT(*) AS links_matched, 0 AS links_deleted",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("endpoint owner-id cleanup SQL missing %q:\n%s", want, query)
+		}
+	}
+	argsText := fmt.Sprint(args)
+	for _, want := range []string{
+		"urn:cerebro:writer:identity:login:",
+		"urn:cerebro:writer:identifier:login:",
+		"urn:cerebro:writer:endpoint_identifier:kolide_owner_id:",
+		"urn:cerebro:writer:endpoint_identifier:kolide_user_id:",
+	} {
+		if !strings.Contains(argsText, want) {
+			t.Fatalf("endpoint owner-id cleanup args missing %q: %#v", want, args)
+		}
+	}
+	if strings.Contains(query, "DELETE FROM entity_links") {
+		t.Fatalf("dry-run endpoint owner-id cleanup SQL deletes rows:\n%s", query)
+	}
+	if len(args) == 0 || args[len(args)-1] != uint32(50) {
+		t.Fatalf("cleanup SQL limit arg = %#v, want trailing uint32(50)", args)
+	}
+}
+
+func TestProjectedEndpointOwnerIDLinkCleanupSQLRuntimeScopesOnlyStaleLinks(t *testing.T) {
+	query, _, err := projectedEndpointOwnerIDLinkCleanupSQL(ports.ProjectionLinkCleanupRequest{
+		TenantID:  "writer",
+		SourceID:  "kolide",
+		RuntimeID: "runtime-a",
+		DryRun:    true,
+	})
+	if err != nil {
+		t.Fatalf("projectedEndpointOwnerIDLinkCleanupSQL() error = %v", err)
+	}
+	if !strings.Contains(query, "l.runtime_id = $") {
+		t.Fatalf("endpoint owner-id cleanup SQL missing stale runtime scope:\n%s", query)
+	}
+	if strings.Contains(query, "replacement.runtime_id") {
+		t.Fatalf("endpoint owner-id cleanup SQL incorrectly scopes replacement runtime:\n%s", query)
+	}
+}
+
+func TestPostgresCleanupEndpointOwnerIDLinksIntegration(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CEREBRO_POSTGRES_DSN"))
+	if dsn == "" {
+		t.Skip("set CEREBRO_POSTGRES_DSN to run Postgres projection cleanup integration test")
+	}
+	ctx := context.Background()
+	store, err := Open(config.StateStoreConfig{Driver: config.StateStoreDriverPostgres, PostgresDSN: dsn})
+	if err != nil {
+		t.Fatalf("open postgres store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	tenantID := fmt.Sprintf("writer-cleanup-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_, _ = store.db.ExecContext(context.Background(), `DELETE FROM entity_links WHERE tenant_id = $1`, tenantID)
+		_, _ = store.db.ExecContext(context.Background(), `DELETE FROM entities WHERE tenant_id = $1`, tenantID)
+	})
+
+	endpointURN := fmt.Sprintf("urn:cerebro:%s:kolide_device:device-1", tenantID)
+	identityURN := fmt.Sprintf("urn:cerebro:%s:identity:login:user-1", tenantID)
+	identifierURN := fmt.Sprintf("urn:cerebro:%s:identifier:login:user-1", tenantID)
+	emailIdentityURN := fmt.Sprintf("urn:cerebro:%s:identity:email:alice@example.com", tenantID)
+	unmigratedIdentityURN := fmt.Sprintf("urn:cerebro:%s:identity:login:user-2", tenantID)
+	replacementURN := fmt.Sprintf("urn:cerebro:%s:endpoint_identifier:kolide_user_id:user-1", tenantID)
+	for _, entity := range []*ports.ProjectedEntity{
+		{URN: endpointURN, TenantID: tenantID, SourceID: "kolide", EntityType: "kolide.device", Label: "device-1"},
+		{URN: identityURN, TenantID: tenantID, SourceID: "kolide", EntityType: "identity.login", Label: "user-1"},
+		{URN: identifierURN, TenantID: tenantID, SourceID: "kolide", EntityType: "identifier.login", Label: "user-1"},
+		{URN: emailIdentityURN, TenantID: tenantID, SourceID: "kolide", EntityType: "identity.email", Label: "alice@example.com"},
+		{URN: unmigratedIdentityURN, TenantID: tenantID, SourceID: "kolide", EntityType: "identity.login", Label: "user-2"},
+		{URN: replacementURN, TenantID: tenantID, SourceID: "kolide", EntityType: "endpoint.identifier", Label: "user-1"},
+	} {
+		if err := store.UpsertProjectedEntity(ctx, entity); err != nil {
+			t.Fatalf("upsert entity %s: %v", entity.URN, err)
+		}
+	}
+	staleLinks := []*ports.ProjectedLink{
+		{TenantID: tenantID, SourceID: "kolide", FromURN: endpointURN, Relation: "owned_by", ToURN: identityURN},
+		{TenantID: tenantID, SourceID: "kolide", FromURN: endpointURN, Relation: "represents_identity", ToURN: identityURN},
+		{TenantID: tenantID, SourceID: "kolide", FromURN: endpointURN, Relation: "has_identifier", ToURN: identifierURN},
+	}
+	preservedLinks := []*ports.ProjectedLink{
+		{TenantID: tenantID, SourceID: "kolide", FromURN: endpointURN, Relation: "owned_by", ToURN: emailIdentityURN},
+		{TenantID: tenantID, SourceID: "kolide", FromURN: endpointURN, Relation: "owned_by", ToURN: unmigratedIdentityURN},
+		{TenantID: tenantID, SourceID: "kolide", FromURN: endpointURN, Relation: "has_identifier", ToURN: replacementURN},
+	}
+	for _, link := range append(staleLinks, preservedLinks...) {
+		if err := store.UpsertProjectedLink(ctx, link); err != nil {
+			t.Fatalf("upsert link %s %s %s: %v", link.FromURN, link.Relation, link.ToURN, err)
+		}
+	}
+	request := ports.ProjectionLinkCleanupRequest{TenantID: tenantID, SourceID: "kolide", DryRun: true}
+	result, err := store.CleanupEndpointOwnerIDLinks(ctx, request)
+	if err != nil {
+		t.Fatalf("dry-run cleanup endpoint owner-id links: %v", err)
+	}
+	if result.LinksMatched != uint32(len(staleLinks)) || result.LinksDeleted != 0 {
+		t.Fatalf("dry-run cleanup result = %#v, want %d matches and no deletes", result, len(staleLinks))
+	}
+	for _, link := range staleLinks {
+		assertPostgresProjectedLinkExists(t, ctx, store, link)
+	}
+	request.DryRun = false
+	result, err = store.CleanupEndpointOwnerIDLinks(ctx, request)
+	if err != nil {
+		t.Fatalf("cleanup endpoint owner-id links: %v", err)
+	}
+	if result.LinksMatched != uint32(len(staleLinks)) || result.LinksDeleted != uint32(len(staleLinks)) {
+		t.Fatalf("cleanup result = %#v, want %d deletes", result, len(staleLinks))
+	}
+	for _, link := range staleLinks {
+		assertPostgresProjectedLinkMissing(t, ctx, store, link)
+	}
+	for _, link := range preservedLinks {
+		assertPostgresProjectedLinkExists(t, ctx, store, link)
+	}
+}
+
+func assertPostgresProjectedLinkExists(t *testing.T, ctx context.Context, store *Store, link *ports.ProjectedLink) {
+	t.Helper()
+	if !postgresProjectedLinkExists(t, ctx, store, link) {
+		t.Fatalf("projected link missing: %s %s %s", link.FromURN, link.Relation, link.ToURN)
+	}
+}
+
+func assertPostgresProjectedLinkMissing(t *testing.T, ctx context.Context, store *Store, link *ports.ProjectedLink) {
+	t.Helper()
+	if postgresProjectedLinkExists(t, ctx, store, link) {
+		t.Fatalf("projected link still exists: %s %s %s", link.FromURN, link.Relation, link.ToURN)
+	}
+}
+
+func postgresProjectedLinkExists(t *testing.T, ctx context.Context, store *Store, link *ports.ProjectedLink) bool {
+	t.Helper()
+	var count int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM entity_links WHERE from_urn = $1 AND relation = $2 AND to_urn = $3`, link.FromURN, link.Relation, link.ToURN).Scan(&count); err != nil {
+		t.Fatalf("query projected link: %v", err)
+	}
+	return count > 0
 }


### PR DESCRIPTION
## Summary
- add dry-run-first graph cleanup for stale endpoint owner_id/user_id canonical identity links
- remove matching stale links from Postgres and Neo4j only when provider-scoped endpoint identifiers exist
- emit projection retraction/cleanup telemetry and add Postgres/Neo4j cleanup coverage

## Validation
- go test -count=1 -v ./internal/statestore/postgres -run 'TestProjectedEndpointOwnerIDLinkCleanupSQL|TestPostgresCleanupEndpointOwnerIDLinksIntegration'
- go test -count=1 -v ./cmd/cerebro -run 'TestParseGraphEndpointOwnerIDCleanupArgs'
- go test -count=1 -v ./internal/graphstore/neo4j -run 'TestOpenRejectsIncompleteConfig|TestNeo4jDockerProjectionAndQueries'
- go test -count=1 -v ./internal/sourceprojection -run 'TestProjectKolideDeviceOwnerIDRetractsStaleCanonicalOwnerLinks'
- go test -count=1 -v ./internal/graphingest -run 'TestProjectResponseCoalescedDeletesProjectedRetractions'
- make verify