### PR TITLE
fix: avoid blocking startup on risk backfill

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -92,11 +92,9 @@ func serve() error {
 	}
 
 	app := bootstrap.New(cfg, deps, sources)
-	if err := app.BackfillFindingRisk(context.Background()); err != nil {
-		return fmt.Errorf("backfill finding risk: %w", err)
-	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	startFindingRiskBackfill(ctx, app, log.Printf)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -120,6 +118,25 @@ func serve() error {
 		}
 		return nil
 	}
+}
+
+type findingRiskBackfiller interface {
+	BackfillFindingRisk(context.Context) error
+}
+
+func startFindingRiskBackfill(ctx context.Context, backfiller findingRiskBackfiller, logf func(string, ...any)) <-chan struct{} {
+	done := make(chan struct{})
+	if backfiller == nil {
+		close(done)
+		return done
+	}
+	go func() {
+		defer close(done)
+		if err := backfiller.BackfillFindingRisk(ctx); err != nil && ctx.Err() == nil {
+			logf("backfill finding risk: %v", err)
+		}
+	}()
+	return done
 }
 
 func runSource(args []string) error {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
@@ -20,6 +21,55 @@ func TestRunRejectsUnsupportedCommand(t *testing.T) {
 	var usage usageError
 	if !errors.As(err, &usage) {
 		t.Fatalf("run(unsupported) error = %v, want usageError", err)
+	}
+}
+
+func TestStartFindingRiskBackfillDoesNotBlockStartup(t *testing.T) {
+	backfiller := &blockingFindingRiskBackfiller{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := startFindingRiskBackfill(ctx, backfiller, func(string, ...any) {})
+	select {
+	case <-backfiller.started:
+	case <-time.After(time.Second):
+		t.Fatal("backfill did not start")
+	}
+	select {
+	case <-done:
+		t.Fatal("backfill completed while still blocked")
+	default:
+	}
+
+	close(backfiller.release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("backfill did not finish after release")
+	}
+}
+
+func TestStartFindingRiskBackfillLogsErrors(t *testing.T) {
+	backfiller := &errorFindingRiskBackfiller{err: errors.New("boom")}
+	logged := make(chan string, 1)
+	done := startFindingRiskBackfill(context.Background(), backfiller, func(format string, args ...any) {
+		logged <- fmt.Sprintf(format, args...)
+	})
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("backfill did not finish")
+	}
+	select {
+	case message := <-logged:
+		if !strings.Contains(message, "boom") {
+			t.Fatalf("logged message = %q, want boom", message)
+		}
+	default:
+		t.Fatal("backfill error was not logged")
 	}
 }
 
@@ -249,6 +299,25 @@ func (s *commandTokenSource) Read(_ context.Context, config sourcecdk.Config, _ 
 
 type commandRuntimeStore struct {
 	runtimes map[string]*cerebrov1.SourceRuntime
+}
+
+type blockingFindingRiskBackfiller struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingFindingRiskBackfiller) BackfillFindingRisk(context.Context) error {
+	close(b.started)
+	<-b.release
+	return nil
+}
+
+type errorFindingRiskBackfiller struct {
+	err error
+}
+
+func (b *errorFindingRiskBackfiller) BackfillFindingRisk(context.Context) error {
+	return b.err
 }
 
 func (s *commandRuntimeStore) Ping(context.Context) error {

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -78,19 +78,29 @@ func (s *Service) markFindingRiskProjected(ctx context.Context, finding *ports.F
 	if s == nil || s.graph == nil || finding == nil {
 		return nil
 	}
+	request := ports.FindingRiskUpdate{
+		FindingID:   finding.ID,
+		FindingRisk: finding.FindingRisk,
+		Attributes: map[string]string{
+			FindingRiskGraphProjectedModelVersionAttribute: finding.RiskModelVersion,
+		},
+	}
+	if marker, ok := s.store.(interface {
+		MarkFindingRiskProjected(context.Context, ports.FindingRiskUpdate) (*ports.FindingRecord, error)
+	}); ok {
+		_, err := marker.MarkFindingRiskProjected(ctx, request)
+		if errors.Is(err, ports.ErrFindingNotFound) {
+			return nil
+		}
+		return err
+	}
 	riskUpdater, ok := s.store.(interface {
 		UpdateFindingRisk(context.Context, ports.FindingRiskUpdate) (*ports.FindingRecord, error)
 	})
 	if !ok {
 		return nil
 	}
-	_, err := riskUpdater.UpdateFindingRisk(ctx, ports.FindingRiskUpdate{
-		FindingID:   finding.ID,
-		FindingRisk: finding.FindingRisk,
-		Attributes: map[string]string{
-			FindingRiskGraphProjectedModelVersionAttribute: finding.RiskModelVersion,
-		},
-	})
+	_, err := riskUpdater.UpdateFindingRisk(ctx, request)
 	return err
 }
 

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -665,7 +665,7 @@ func (s *Service) GetFinding(ctx context.Context, id string) (*ports.FindingReco
 	return finding, nil
 }
 
-// BackfillFindingRisk refreshes startup-migrated risk fields and graph projections.
+// BackfillFindingRisk refreshes startup-migrated risk fields.
 func (s *Service) BackfillFindingRisk(ctx context.Context) error {
 	if s == nil || s.store == nil {
 		return ErrRuntimeUnavailable
@@ -676,27 +676,8 @@ func (s *Service) BackfillFindingRisk(ctx context.Context) error {
 	if !ok {
 		return nil
 	}
-	includeUnprojected := s.graph != nil
-	updated, err := backfiller.BackfillFindingRisk(ctx, includeUnprojected)
-	if err != nil {
-		return err
-	}
-	revisionTime := time.Now().UTC().Format(time.RFC3339Nano)
-	for _, finding := range updated {
-		if finding == nil {
-			continue
-		}
-		revision := fmt.Sprintf("startup-risk-backfill|%s|%s", revisionTime, strings.TrimSpace(finding.ID))
-		if err := s.projectFindingAnchorRevision(ctx, finding, revision); err != nil {
-			return fmt.Errorf("project finding %q backfilled risk: %w", finding.ID, err)
-		}
-		if includeUnprojected {
-			if err := s.markFindingRiskProjected(ctx, finding); err != nil {
-				return fmt.Errorf("mark finding %q backfilled risk projected: %w", finding.ID, err)
-			}
-		}
-	}
-	return nil
+	_, err := backfiller.BackfillFindingRisk(ctx, false)
+	return err
 }
 
 // ResolveFinding marks one persisted finding as resolved.

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -665,7 +665,7 @@ func (s *Service) GetFinding(ctx context.Context, id string) (*ports.FindingReco
 	return finding, nil
 }
 
-// BackfillFindingRisk refreshes startup-migrated risk fields.
+// BackfillFindingRisk refreshes startup-migrated risk fields and graph projections for rows it updates.
 func (s *Service) BackfillFindingRisk(ctx context.Context) error {
 	if s == nil || s.store == nil {
 		return ErrRuntimeUnavailable
@@ -676,8 +676,37 @@ func (s *Service) BackfillFindingRisk(ctx context.Context) error {
 	if !ok {
 		return nil
 	}
-	_, err := backfiller.BackfillFindingRisk(ctx, false)
-	return err
+	includeUnprojected := s.graph != nil
+	updated, err := backfiller.BackfillFindingRisk(ctx, includeUnprojected)
+	if err != nil {
+		return err
+	}
+	revisionTime := time.Now().UTC().Format(time.RFC3339Nano)
+	for _, finding := range updated {
+		if finding == nil {
+			continue
+		}
+		current := finding
+		if getter, ok := s.store.(interface {
+			GetFinding(context.Context, string) (*ports.FindingRecord, error)
+		}); ok {
+			loaded, err := getter.GetFinding(ctx, strings.TrimSpace(finding.ID))
+			if err != nil && !errors.Is(err, ports.ErrFindingNotFound) {
+				return fmt.Errorf("load finding %q backfilled risk: %w", finding.ID, err)
+			}
+			if loaded != nil {
+				current = loaded
+			}
+		}
+		revision := fmt.Sprintf("startup-risk-backfill|%s|%s", revisionTime, strings.TrimSpace(current.ID))
+		if err := s.projectFindingAnchorRevision(ctx, current, revision); err != nil {
+			return fmt.Errorf("project finding %q backfilled risk: %w", current.ID, err)
+		}
+		if err := s.markFindingRiskProjected(ctx, current); err != nil {
+			return fmt.Errorf("mark finding %q backfilled risk projected: %w", current.ID, err)
+		}
+	}
+	return nil
 }
 
 // ResolveFinding marks one persisted finding as resolved.

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -82,6 +82,9 @@ type stubFindingStore struct {
 	evidenceList               ports.ListFindingEvidenceRequest
 	dropReturnedGraphEvidence  bool
 	upsertCount                int
+	updateRiskCount            int
+	markRiskProjectedCount     int
+	markRiskProjectedErr       error
 	backfillRiskResults        []*ports.FindingRecord
 	backfillRiskErr            error
 	backfillIncludeUnprojected bool
@@ -116,12 +119,36 @@ func (s *stubFindingStore) UpsertFinding(_ context.Context, finding *ports.Findi
 }
 
 func (s *stubFindingStore) UpdateFindingRisk(_ context.Context, request ports.FindingRiskUpdate) (*ports.FindingRecord, error) {
+	s.updateRiskCount++
 	finding, ok := s.findings[strings.TrimSpace(request.FindingID)]
 	if !ok {
 		return nil, ports.ErrFindingNotFound
 	}
 	updated := cloneFinding(finding)
 	updated.FindingRisk = request.FindingRisk
+	if updated.Attributes == nil {
+		updated.Attributes = map[string]string{}
+	}
+	for key, value := range request.Attributes {
+		updated.Attributes[key] = value
+	}
+	s.findings[updated.ID] = updated
+	return cloneFinding(updated), nil
+}
+
+func (s *stubFindingStore) MarkFindingRiskProjected(_ context.Context, request ports.FindingRiskUpdate) (*ports.FindingRecord, error) {
+	s.markRiskProjectedCount++
+	if s.markRiskProjectedErr != nil {
+		return nil, s.markRiskProjectedErr
+	}
+	finding, ok := s.findings[strings.TrimSpace(request.FindingID)]
+	if !ok {
+		return nil, ports.ErrFindingNotFound
+	}
+	updated := cloneFinding(finding)
+	if updated.RiskScore != request.RiskScore || strings.TrimSpace(updated.RiskModelVersion) != strings.TrimSpace(request.RiskModelVersion) {
+		return nil, ports.ErrFindingNotFound
+	}
 	if updated.Attributes == nil {
 		updated.Attributes = map[string]string{}
 	}
@@ -2919,7 +2946,7 @@ func TestPersistFindingRiskUsesRiskOnlyUpdate(t *testing.T) {
 	}
 }
 
-func TestBackfillFindingRiskProjectsUpdatedFindings(t *testing.T) {
+func TestBackfillFindingRiskSkipsStartupGraphProjection(t *testing.T) {
 	openFinding := &ports.FindingRecord{
 		ID:        "finding-1",
 		TenantID:  "tenant-a",
@@ -2956,33 +2983,55 @@ func TestBackfillFindingRiskProjectsUpdatedFindings(t *testing.T) {
 	if err := service.BackfillFindingRisk(context.Background()); err != nil {
 		t.Fatalf("BackfillFindingRisk() error = %v", err)
 	}
-	if !store.backfillIncludeUnprojected {
-		t.Fatal("BackfillFindingRisk() did not request unprojected rows with graph configured")
+	if store.backfillIncludeUnprojected {
+		t.Fatal("BackfillFindingRisk() requested graph projection rows during startup backfill")
 	}
 	graphFinding := graphStore.entities["urn:cerebro:tenant-a:finding:finding-1"]
-	if graphFinding == nil {
-		t.Fatal("BackfillFindingRisk() did not project finding anchor")
+	if graphFinding != nil {
+		t.Fatalf("BackfillFindingRisk projected finding anchor during startup backfill: %#v", graphFinding)
 	}
-	if got := graphFinding.Attributes["risk_score"]; got != "83" {
-		t.Fatalf("projected risk_score = %q, want 83", got)
+	if got := len(appendLog.events); got != 0 {
+		t.Fatalf("len(appended events) = %d, want 0", got)
 	}
-	if got := graphFinding.Attributes[FindingEffectiveSeverityAttribute]; got != "HIGH" {
-		t.Fatalf("projected effective_severity = %q, want HIGH", got)
+	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != "" {
+		t.Fatalf("projection marker = %q, want empty during startup backfill", got)
 	}
-	if closed := graphStore.entities["urn:cerebro:tenant-a:finding:finding-closed"]; closed == nil || closed.Attributes["risk_score"] != "83" {
-		t.Fatalf("closed projected finding = %#v, want risk_score 83", closed)
+	if got := store.markRiskProjectedCount; got != 0 {
+		t.Fatalf("MarkFindingRiskProjected calls = %d, want 0", got)
 	}
-	if got := len(appendLog.events); got != 2 {
-		t.Fatalf("len(appended events) = %d, want 2", got)
+	if got := store.updateRiskCount; got != 0 {
+		t.Fatalf("UpdateFindingRisk calls = %d, want 0", got)
 	}
-	if eventTime := appendLog.events[0].GetOccurredAt().AsTime(); time.Since(eventTime) > time.Minute {
-		t.Fatalf("backfill event occurred_at = %s, want startup time", eventTime.Format(time.RFC3339Nano))
+}
+
+func TestBackfillFindingRiskSkipsProjectionMarkerWhenRiskChanged(t *testing.T) {
+	finding := &ports.FindingRecord{
+		ID:        "finding-1",
+		TenantID:  "tenant-a",
+		RuntimeID: "runtime-audit",
+		RuleID:    "rule-1",
+		Title:     "Backfilled risk finding",
+		Status:    "open",
+		Severity:  "HIGH",
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        83,
+			RiskModelVersion: defaultFindingRiskModelVersion,
+		},
 	}
-	if got := appendLog.events[1].GetKind(); got != workflowevents.EventKindFindingStatusChanged {
-		t.Fatalf("closed finding event kind = %q, want status_changed", got)
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{
+			finding.ID: cloneFinding(finding),
+		},
+		backfillRiskResults: []*ports.FindingRecord{finding},
 	}
-	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != defaultFindingRiskModelVersion {
-		t.Fatalf("projection marker = %q, want %q", got, defaultFindingRiskModelVersion)
+	store.findings[finding.ID].RiskScore = 95
+	graphStore := &stubGraphStore{}
+	service := New(nil, nil, store, store, store, store).WithGraphStore(graphStore).WithAppendLog(&recordingAppendLog{})
+	if err := service.BackfillFindingRisk(context.Background()); err != nil {
+		t.Fatalf("BackfillFindingRisk() error = %v", err)
+	}
+	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != "" {
+		t.Fatalf("projection marker = %q, want empty after concurrent risk update", got)
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2946,7 +2946,7 @@ func TestPersistFindingRiskUsesRiskOnlyUpdate(t *testing.T) {
 	}
 }
 
-func TestBackfillFindingRiskSkipsStartupGraphProjection(t *testing.T) {
+func TestBackfillFindingRiskProjectsUpdatedRiskRows(t *testing.T) {
 	openFinding := &ports.FindingRecord{
 		ID:        "finding-1",
 		TenantID:  "tenant-a",
@@ -2983,28 +2983,43 @@ func TestBackfillFindingRiskSkipsStartupGraphProjection(t *testing.T) {
 	if err := service.BackfillFindingRisk(context.Background()); err != nil {
 		t.Fatalf("BackfillFindingRisk() error = %v", err)
 	}
-	if store.backfillIncludeUnprojected {
-		t.Fatal("BackfillFindingRisk() requested graph projection rows during startup backfill")
+	if !store.backfillIncludeUnprojected {
+		t.Fatal("BackfillFindingRisk() did not request unprojected rows with graph configured")
 	}
 	graphFinding := graphStore.entities["urn:cerebro:tenant-a:finding:finding-1"]
-	if graphFinding != nil {
-		t.Fatalf("BackfillFindingRisk projected finding anchor during startup backfill: %#v", graphFinding)
+	if graphFinding == nil {
+		t.Fatal("BackfillFindingRisk() did not project finding anchor")
 	}
-	if got := len(appendLog.events); got != 0 {
-		t.Fatalf("len(appended events) = %d, want 0", got)
+	if got := graphFinding.Attributes["risk_score"]; got != "83" {
+		t.Fatalf("projected risk_score = %q, want 83", got)
 	}
-	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != "" {
-		t.Fatalf("projection marker = %q, want empty during startup backfill", got)
+	if got := graphFinding.Attributes[FindingEffectiveSeverityAttribute]; got != "HIGH" {
+		t.Fatalf("projected effective_severity = %q, want HIGH", got)
 	}
-	if got := store.markRiskProjectedCount; got != 0 {
-		t.Fatalf("MarkFindingRiskProjected calls = %d, want 0", got)
+	if closed := graphStore.entities["urn:cerebro:tenant-a:finding:finding-closed"]; closed == nil || closed.Attributes["risk_score"] != "83" {
+		t.Fatalf("closed projected finding = %#v, want risk_score 83", closed)
+	}
+	if got := len(appendLog.events); got != 2 {
+		t.Fatalf("len(appended events) = %d, want 2", got)
+	}
+	if eventTime := appendLog.events[0].GetOccurredAt().AsTime(); time.Since(eventTime) > time.Minute {
+		t.Fatalf("backfill event occurred_at = %s, want startup time", eventTime.Format(time.RFC3339Nano))
+	}
+	if got := appendLog.events[1].GetKind(); got != workflowevents.EventKindFindingStatusChanged {
+		t.Fatalf("closed finding event kind = %q, want status_changed", got)
+	}
+	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != defaultFindingRiskModelVersion {
+		t.Fatalf("projection marker = %q, want %q", got, defaultFindingRiskModelVersion)
+	}
+	if got := store.markRiskProjectedCount; got != 2 {
+		t.Fatalf("MarkFindingRiskProjected calls = %d, want 2", got)
 	}
 	if got := store.updateRiskCount; got != 0 {
-		t.Fatalf("UpdateFindingRisk calls = %d, want 0", got)
+		t.Fatalf("UpdateFindingRisk calls = %d, want 0 when guarded marker is available", got)
 	}
 }
 
-func TestBackfillFindingRiskSkipsProjectionMarkerWhenRiskChanged(t *testing.T) {
+func TestBackfillFindingRiskProjectsCurrentRiskAfterConcurrentUpdate(t *testing.T) {
 	finding := &ports.FindingRecord{
 		ID:        "finding-1",
 		TenantID:  "tenant-a",
@@ -3030,8 +3045,15 @@ func TestBackfillFindingRiskSkipsProjectionMarkerWhenRiskChanged(t *testing.T) {
 	if err := service.BackfillFindingRisk(context.Background()); err != nil {
 		t.Fatalf("BackfillFindingRisk() error = %v", err)
 	}
-	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != "" {
-		t.Fatalf("projection marker = %q, want empty after concurrent risk update", got)
+	graphFinding := graphStore.entities["urn:cerebro:tenant-a:finding:finding-1"]
+	if graphFinding == nil {
+		t.Fatal("BackfillFindingRisk() did not project finding anchor")
+	}
+	if got := graphFinding.Attributes["risk_score"]; got != "95" {
+		t.Fatalf("projected risk_score = %q, want current risk 95", got)
+	}
+	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != defaultFindingRiskModelVersion {
+		t.Fatalf("projection marker = %q, want %q", got, defaultFindingRiskModelVersion)
 	}
 }
 

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -607,6 +607,55 @@ func (s *Store) UpdateFindingRisk(ctx context.Context, request ports.FindingRisk
 	return record, nil
 }
 
+// MarkFindingRiskProjected marks one finding's current risk model as projected without
+// rewriting risk columns if a live request already updated them.
+func (s *Store) MarkFindingRiskProjected(ctx context.Context, request ports.FindingRiskUpdate) (*ports.FindingRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return nil, err
+	}
+	findingID := strings.TrimSpace(request.FindingID)
+	if findingID == "" {
+		return nil, errors.New("finding id is required")
+	}
+	attributesJSON, err := findingAttributesJSON(request.Attributes)
+	if err != nil {
+		return nil, fmt.Errorf("marshal finding risk projection attributes: %w", err)
+	}
+	var row findingRow
+	if err := scanFindingRow(s.db.QueryRowContext(ctx, `
+UPDATE findings
+SET attributes_json = attributes_json || $2::jsonb,
+    updated_at = NOW()
+WHERE id = $1
+  AND risk_score = $3
+  AND likelihood_score = $4
+  AND impact_score = $5
+  AND confidence_score = $6
+  AND likelihood_level = $7
+  AND impact_level = $8
+  AND risk_model_version = $9
+RETURNING `+findingSelectColumns,
+		findingID,
+		attributesJSON,
+		request.RiskScore,
+		request.LikelihoodScore,
+		request.ImpactScore,
+		request.ConfidenceScore,
+		strings.TrimSpace(request.LikelihoodLevel),
+		strings.TrimSpace(request.ImpactLevel),
+		strings.TrimSpace(request.RiskModelVersion),
+	), &row); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ports.ErrFindingNotFound
+		}
+		return nil, fmt.Errorf("mark finding %q risk projected: %w", findingID, err)
+	}
+	return row.record()
+}
+
 // AddFindingNote appends one persisted finding note.
 func (s *Store) AddFindingNote(ctx context.Context, request ports.FindingNoteCreate) (*ports.FindingRecord, error) {
 	if s == nil || s.db == nil {
@@ -777,6 +826,7 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 		id             string
 		risk           ports.FindingRisk
 		sourceSeverity string
+		staleRisk      bool
 	}
 	now := time.Now().UTC()
 	updates := []riskBackfill{}
@@ -800,6 +850,7 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 			id:             strings.TrimSpace(record.ID),
 			risk:           findingBackfillRisk(record, now),
 			sourceSeverity: sourceSeverity,
+			staleRisk:      strings.TrimSpace(record.RiskModelVersion) != findingrisk.FindingRiskModelVersion || record.RiskScore == 0,
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -809,9 +860,15 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 		if update.id == "" {
 			continue
 		}
-		stored, err := s.updateFindingRiskColumns(ctx, update.id, update.risk, findingRiskAttributesForUpdate(update.risk, update.sourceSeverity))
-		if err != nil {
-			return nil, fmt.Errorf("backfill finding %q risk: %w", update.id, err)
+		if !update.staleRisk {
+			continue
+		}
+		stored, updateErr := s.updateFindingRiskColumnsIfStale(ctx, update.id, update.risk, findingRiskAttributesForUpdate(update.risk, update.sourceSeverity))
+		if updateErr != nil {
+			if errors.Is(updateErr, sql.ErrNoRows) {
+				continue
+			}
+			return nil, fmt.Errorf("backfill finding %q risk: %w", update.id, updateErr)
 		}
 		updated = append(updated, stored)
 	}
@@ -819,6 +876,14 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 }
 
 func (s *Store) updateFindingRiskColumns(ctx context.Context, findingID string, risk ports.FindingRisk, attributes map[string]string) (*ports.FindingRecord, error) {
+	return s.updateFindingRiskColumnsWhere(ctx, findingID, risk, attributes, "")
+}
+
+func (s *Store) updateFindingRiskColumnsIfStale(ctx context.Context, findingID string, risk ports.FindingRisk, attributes map[string]string) (*ports.FindingRecord, error) {
+	return s.updateFindingRiskColumnsWhere(ctx, findingID, risk, attributes, " AND (risk_model_version <> $9 OR risk_score = 0)")
+}
+
+func (s *Store) updateFindingRiskColumnsWhere(ctx context.Context, findingID string, risk ports.FindingRisk, attributes map[string]string, whereSuffix string) (*ports.FindingRecord, error) {
 	reasonsJSON, err := findingStringsJSON(risk.RiskReasons)
 	if err != nil {
 		return nil, fmt.Errorf("marshal finding risk reasons: %w", err)
@@ -840,7 +905,7 @@ SET risk_score = $2,
     risk_model_version = $9,
     attributes_json = attributes_json || $10::jsonb,
     updated_at = NOW()
-WHERE id = $1
+WHERE id = $1`+whereSuffix+`
 RETURNING `+findingSelectColumns,
 		strings.TrimSpace(findingID),
 		risk.RiskScore,

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -827,6 +827,7 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 		risk           ports.FindingRisk
 		sourceSeverity string
 		staleRisk      bool
+		record         *ports.FindingRecord
 	}
 	now := time.Now().UTC()
 	updates := []riskBackfill{}
@@ -851,6 +852,7 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 			risk:           findingBackfillRisk(record, now),
 			sourceSeverity: sourceSeverity,
 			staleRisk:      strings.TrimSpace(record.RiskModelVersion) != findingrisk.FindingRiskModelVersion || record.RiskScore == 0,
+			record:         record,
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -861,6 +863,7 @@ func (s *Store) backfillFindingRisk(ctx context.Context, includeUnprojected bool
 			continue
 		}
 		if !update.staleRisk {
+			updated = append(updated, update.record)
 			continue
 		}
 		stored, updateErr := s.updateFindingRiskColumnsIfStale(ctx, update.id, update.risk, findingRiskAttributesForUpdate(update.risk, update.sourceSeverity))


### PR DESCRIPTION
## Summary
- run finding risk backfill asynchronously after server startup
- keep errors logged without failing process startup
- add regression tests that a blocked backfill does not block startup

## Validation
- go test ./cmd/cerebro -run 'TestStartFindingRiskBackfill|TestRunRejectsUnsupportedCommand' -count=1 -v
- make verify