### PR TITLE
fix: harden source runtime lease renewal

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -717,11 +717,7 @@ func startOrchestratorRuntimeLeaseRenewalWithTTL(ctx context.Context, store port
 }
 
 func sourceRuntimeLeaseRenewalInterval(ttl time.Duration) time.Duration {
-	interval := ttl / 2
-	if interval <= 0 {
-		return ttl
-	}
-	return interval
+	return sourceruntime.LeaseRenewalInterval(ttl)
 }
 
 func releaseOrchestratorRuntimeLease(ctx context.Context, store ports.SourceRuntimeLeaseStore, runtime *cerebrov1.SourceRuntime, owner string) error {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -754,8 +754,11 @@ func TestReleaseOrchestratorRuntimeLeaseIgnoresCancellation(t *testing.T) {
 }
 
 func TestSourceRuntimeLeaseRenewalIntervalUsesHalfTTL(t *testing.T) {
-	if got := sourceRuntimeLeaseRenewalInterval(30 * time.Minute); got != 15*time.Minute {
-		t.Fatalf("sourceRuntimeLeaseRenewalInterval() = %s, want 15m", got)
+	if got := sourceRuntimeLeaseRenewalInterval(time.Minute); got != 30*time.Second {
+		t.Fatalf("sourceRuntimeLeaseRenewalInterval() = %s, want 30s", got)
+	}
+	if got := sourceRuntimeLeaseRenewalInterval(30 * time.Minute); got != sourceruntime.LeaseRenewalMaxInterval {
+		t.Fatalf("sourceRuntimeLeaseRenewalInterval() = %s, want %s", got, sourceruntime.LeaseRenewalMaxInterval)
 	}
 }
 

--- a/internal/sourceruntime/lease.go
+++ b/internal/sourceruntime/lease.go
@@ -24,6 +24,12 @@ const (
 	// LeaseReleaseTimeout bounds the best-effort lease release on shutdown
 	// paths so a slow database cannot block the caller indefinitely.
 	LeaseReleaseTimeout = 5 * time.Second
+
+	// LeaseRenewalMaxInterval keeps renewal attempts comfortably ahead of
+	// the runtime lease TTL. Long-lived backfills can overlap scheduled or
+	// verification tasks; renewing more often than TTL/2 narrows the window
+	// where a delayed renewal lets another task acquire the runtime.
+	LeaseRenewalMaxInterval = 5 * time.Minute
 )
 
 // ErrSyncInProgress is returned by SyncWithLease when the runtime is
@@ -128,10 +134,7 @@ func startLeaseRenewal(ctx context.Context, store ports.SourceRuntimeLeaseStore,
 	}
 	renewCtx, cancel := context.WithCancel(ctx)
 	done := make(chan error, 1)
-	interval := ttl / 2
-	if interval <= 0 {
-		interval = ttl
-	}
+	interval := LeaseRenewalInterval(ttl)
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -159,6 +162,17 @@ func startLeaseRenewal(ctx context.Context, store ports.SourceRuntimeLeaseStore,
 		cancel()
 		return <-done
 	}
+}
+
+func LeaseRenewalInterval(ttl time.Duration) time.Duration {
+	interval := ttl / 2
+	if interval <= 0 {
+		return ttl
+	}
+	if LeaseRenewalMaxInterval > 0 && interval > LeaseRenewalMaxInterval {
+		return LeaseRenewalMaxInterval
+	}
+	return interval
 }
 
 func releaseLease(parent context.Context, store ports.SourceRuntimeLeaseStore, runtimeID string, owner string) error {

--- a/internal/sourceruntime/lease_test.go
+++ b/internal/sourceruntime/lease_test.go
@@ -188,6 +188,15 @@ func TestStartLeaseRenewalStopsWhenSyncContextCancels(t *testing.T) {
 	}
 }
 
+func TestLeaseRenewalIntervalCapsLongTTL(t *testing.T) {
+	if got := LeaseRenewalInterval(time.Minute); got != 30*time.Second {
+		t.Fatalf("LeaseRenewalInterval(1m) = %s, want 30s", got)
+	}
+	if got := LeaseRenewalInterval(DefaultLeaseTTL); got != LeaseRenewalMaxInterval {
+		t.Fatalf("LeaseRenewalInterval(default) = %s, want %s", got, LeaseRenewalMaxInterval)
+	}
+}
+
 func TestSyncWithLeaseSerializesConcurrentCallers(t *testing.T) {
 	store := &stubLeaseStore{}
 	service := New(nil, nil, nil, nil)

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -215,8 +215,7 @@ func (s *Store) RenewSourceRuntimeLease(ctx context.Context, runtimeID string, o
 UPDATE source_runtimes
 SET lease_expires_at = NOW() + $3::interval
 WHERE id = $1
-  AND lease_owner = $2
-  AND lease_expires_at > NOW()`, id, leaseOwner, sourceRuntimeLeaseInterval(ttl))
+  AND lease_owner = $2`, id, leaseOwner, sourceRuntimeLeaseInterval(ttl))
 	if err != nil {
 		return false, fmt.Errorf("renew source runtime lease %q: %w", id, err)
 	}


### PR DESCRIPTION
## Summary
- cap source runtime lease renewal intervals at five minutes for long TTLs
- allow the current owner to renew its lease even if the lease timestamp just passed before another owner claims it
- share renewal interval behavior between API sync and orchestrator paths

## Validation
- `go test ./internal/sourceruntime ./cmd/cerebro ./internal/statestore/postgres`
- `make verify`