### PR TITLE
perf: cache finding metadata

### DIFF
--- a/internal/findings/correlation_catalog.go
+++ b/internal/findings/correlation_catalog.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	_ "embed"
@@ -13,6 +14,12 @@ import (
 
 //go:embed correlation_patterns/builtin.json
 var builtinCorrelationPatternCatalog []byte
+
+var builtinCorrelationPatternCache struct {
+	once     sync.Once
+	patterns []FindingCorrelationPattern
+	err      error
+}
 
 type correlationPatternCatalog struct {
 	Version  string                  `json:"version"`
@@ -32,11 +39,13 @@ type correlationPatternRaw struct {
 
 // BuiltinFindingCorrelationPatterns returns the checked-in declarative pattern catalog.
 func BuiltinFindingCorrelationPatterns() []FindingCorrelationPattern {
-	patterns, err := LoadFindingCorrelationPatterns(builtinCorrelationPatternCatalog)
-	if err != nil {
+	builtinCorrelationPatternCache.once.Do(func() {
+		builtinCorrelationPatternCache.patterns, builtinCorrelationPatternCache.err = LoadFindingCorrelationPatterns(builtinCorrelationPatternCatalog)
+	})
+	if builtinCorrelationPatternCache.err != nil {
 		return nil
 	}
-	return patterns
+	return cloneFindingCorrelationPatterns(builtinCorrelationPatternCache.patterns)
 }
 
 // BuiltinFindingCorrelationPatternCatalogJSON returns the canonical checked-in catalog bytes.
@@ -160,6 +169,35 @@ func normalizeCorrelationPattern(raw correlationPatternRaw) (FindingCorrelationP
 		}
 	}
 	return pattern, nil
+}
+
+func cloneFindingCorrelationPatterns(patterns []FindingCorrelationPattern) []FindingCorrelationPattern {
+	if len(patterns) == 0 {
+		return nil
+	}
+	cloned := make([]FindingCorrelationPattern, 0, len(patterns))
+	for _, pattern := range patterns {
+		cloned = append(cloned, FindingCorrelationPattern{
+			ID:         pattern.ID,
+			Name:       pattern.Name,
+			RuleIDs:    cloneStringSlice(pattern.RuleIDs),
+			Dimensions: cloneStringSlice(pattern.Dimensions),
+			Window:     pattern.Window,
+			ScoreBonus: pattern.ScoreBonus,
+			Reasons:    cloneStringSlice(pattern.Reasons),
+			Tests:      cloneFindingCorrelationPatternTests(pattern.Tests),
+		})
+	}
+	return cloned
+}
+
+func cloneFindingCorrelationPatternTests(tests []FindingCorrelationPatternTest) []FindingCorrelationPatternTest {
+	if len(tests) == 0 {
+		return nil
+	}
+	cloned := make([]FindingCorrelationPatternTest, len(tests))
+	copy(cloned, tests)
+	return cloned
 }
 
 func validCorrelationDimension(value string) bool {

--- a/internal/findings/correlation_catalog_test.go
+++ b/internal/findings/correlation_catalog_test.go
@@ -21,6 +21,27 @@ func TestBuiltinFindingCorrelationPatternsLoad(t *testing.T) {
 	}
 }
 
+func TestBuiltinFindingCorrelationPatternsReturnsIsolatedCopies(t *testing.T) {
+	first := BuiltinFindingCorrelationPatterns()
+	if len(first) == 0 || len(first[0].RuleIDs) == 0 || len(first[0].Tests) == 0 {
+		t.Fatal("BuiltinFindingCorrelationPatterns() missing expected test data")
+	}
+	first[0].ID = "mutated"
+	first[0].RuleIDs[0] = "mutated"
+	first[0].Tests[0].Name = "mutated"
+
+	second := BuiltinFindingCorrelationPatterns()
+	if second[0].ID == "mutated" {
+		t.Fatal("BuiltinFindingCorrelationPatterns() returned mutable cached pattern id")
+	}
+	if second[0].RuleIDs[0] == "mutated" {
+		t.Fatal("BuiltinFindingCorrelationPatterns() returned mutable cached rule ids")
+	}
+	if second[0].Tests[0].Name == "mutated" {
+		t.Fatal("BuiltinFindingCorrelationPatterns() returned mutable cached tests")
+	}
+}
+
 func TestLoadFindingCorrelationPatternsRejectsIncompletePattern(t *testing.T) {
 	_, err := LoadFindingCorrelationPatterns([]byte(`{"version":"test","patterns":[{"id":"bad","name":"Bad","rule_ids":["one"],"dimensions":["resource"],"window":"1h","score_bonus":1,"reasons":["x"],"tests":[{"name":"t","description":"d","expect_match":true}]}]}`))
 	if err == nil {

--- a/internal/findings/rule_metadata.go
+++ b/internal/findings/rule_metadata.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/writer/cerebro/internal/ports"
 )
@@ -37,6 +38,12 @@ type PublicDetection struct {
 	RequiredAttributes []string                  `json:"required_attributes,omitempty"`
 	FingerprintFields  []string                  `json:"fingerprint_fields,omitempty"`
 	ControlRefs        []ports.FindingControlRef `json:"control_refs,omitempty"`
+}
+
+var builtinRuleMetadataCache struct {
+	once      sync.Once
+	metadata  []RuleDefinition
+	sourceIDs map[string]string
 }
 
 func (r *eventRule) RuleMetadata() RuleDefinition {
@@ -131,20 +138,42 @@ func (r *vulnViewExternalAssetConcentratedSignalRule) RuleMetadata() RuleDefinit
 }
 
 func BuiltinRuleMetadata() []RuleDefinition {
-	metadatas := []RuleDefinition{}
+	builtinRuleMetadataCache.once.Do(loadBuiltinRuleMetadataCache)
+	return cloneRuleDefinitions(builtinRuleMetadataCache.metadata)
+}
+
+// BuiltinRuleSourceIDs returns a rule-id-to-source-id index for built-in metadata.
+func BuiltinRuleSourceIDs() map[string]string {
+	builtinRuleMetadataCache.once.Do(loadBuiltinRuleMetadataCache)
+	sourceIDs := make(map[string]string, len(builtinRuleMetadataCache.sourceIDs))
+	for id, sourceID := range builtinRuleMetadataCache.sourceIDs {
+		sourceIDs[id] = sourceID
+	}
+	return sourceIDs
+}
+
+func loadBuiltinRuleMetadataCache() {
+	metadata := []RuleDefinition{}
+	sourceIDs := map[string]string{}
 	for _, pack := range builtinRulePacks() {
 		for _, rule := range pack.Rules {
-			metadata, ok := ruleMetadata(rule)
-			if !ok || metadata.IsZero() {
+			definition, ok := ruleMetadata(rule)
+			if !ok || definition.IsZero() {
 				continue
 			}
-			metadatas = append(metadatas, metadata)
+			metadata = append(metadata, definition)
 		}
 	}
-	sort.Slice(metadatas, func(i int, j int) bool {
-		return metadatas[i].ID < metadatas[j].ID
+	sort.Slice(metadata, func(i int, j int) bool {
+		return metadata[i].ID < metadata[j].ID
 	})
-	return metadatas
+	for _, definition := range metadata {
+		if id := strings.TrimSpace(definition.ID); id != "" {
+			sourceIDs[id] = strings.TrimSpace(definition.SourceID)
+		}
+	}
+	builtinRuleMetadataCache.metadata = metadata
+	builtinRuleMetadataCache.sourceIDs = sourceIDs
 }
 
 func BuiltinPublicDetectionCatalog() PublicDetectionCatalog {
@@ -276,6 +305,17 @@ func cloneRuleDefinition(definition RuleDefinition) RuleDefinition {
 		FingerprintFields:  cloneStringSlice(definition.FingerprintFields),
 		ControlRefs:        cloneFindingControlRefs(definition.ControlRefs),
 	}
+}
+
+func cloneRuleDefinitions(definitions []RuleDefinition) []RuleDefinition {
+	if len(definitions) == 0 {
+		return nil
+	}
+	cloned := make([]RuleDefinition, 0, len(definitions))
+	for _, definition := range definitions {
+		cloned = append(cloned, cloneRuleDefinition(definition))
+	}
+	return cloned
 }
 
 func retiredRuleMetadata(metadata RuleDefinition) bool {

--- a/internal/findings/rule_metadata_test.go
+++ b/internal/findings/rule_metadata_test.go
@@ -15,6 +15,46 @@ func TestBuiltinRuleMetadataIsComplete(t *testing.T) {
 	}
 }
 
+func TestBuiltinRuleMetadataReturnsIsolatedCopies(t *testing.T) {
+	first := BuiltinRuleMetadata()
+	if len(first) == 0 {
+		t.Fatal("BuiltinRuleMetadata() missing expected test data")
+	}
+	index := -1
+	for i, metadata := range first {
+		if len(metadata.Tags) > 0 {
+			index = i
+			break
+		}
+	}
+	if index == -1 {
+		t.Fatal("BuiltinRuleMetadata() missing tagged rule metadata")
+	}
+	first[index].ID = "mutated"
+	first[index].Tags[0] = "mutated"
+
+	second := BuiltinRuleMetadata()
+	if second[index].ID == "mutated" {
+		t.Fatal("BuiltinRuleMetadata() returned mutable cached metadata id")
+	}
+	if second[index].Tags[0] == "mutated" {
+		t.Fatal("BuiltinRuleMetadata() returned mutable cached metadata tags")
+	}
+}
+
+func TestBuiltinRuleSourceIDsReturnsIsolatedCopies(t *testing.T) {
+	first := BuiltinRuleSourceIDs()
+	if len(first) == 0 {
+		t.Fatal("BuiltinRuleSourceIDs() = 0, want source id index")
+	}
+	first[githubAppIntegrationInstalledRuleID] = "mutated"
+
+	second := BuiltinRuleSourceIDs()
+	if second[githubAppIntegrationInstalledRuleID] == "mutated" {
+		t.Fatal("BuiltinRuleSourceIDs() returned mutable cached source id map")
+	}
+}
+
 func TestBuiltinPublicDetectionCatalogIncludesGraphRules(t *testing.T) {
 	catalog := BuiltinPublicDetectionCatalog()
 	if len(catalog.Detections) == 0 {

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -196,6 +196,7 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 	notedFindingCount := 0
 	ticketCount := 0
 	ticketedFindingCount := 0
+	ruleSourceIDs := findinganalysis.BuiltinRuleSourceIDs()
 	now := time.Now().UTC()
 	for _, finding := range findings {
 		if finding == nil {
@@ -204,7 +205,7 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 		if findingRuntimeID := strings.TrimSpace(finding.RuntimeID); findingRuntimeID != "" {
 			runtimeCounts[findingRuntimeID]++
 		}
-		if sourceID := findingSourceID(finding); sourceID != "" {
+		if sourceID := findingSourceID(finding, ruleSourceIDs); sourceID != "" {
 			sourceCounts[sourceID]++
 		}
 		severity := strings.TrimSpace(finding.Severity)
@@ -361,7 +362,7 @@ func normalizeRuntimeIDs(runtimeID string, runtimeIDs string) []string {
 	return normalized
 }
 
-func findingSourceID(finding *ports.FindingRecord) string {
+func findingSourceID(finding *ports.FindingRecord, ruleSourceIDs map[string]string) string {
 	if finding == nil {
 		return ""
 	}
@@ -370,10 +371,8 @@ func findingSourceID(finding *ports.FindingRecord) string {
 			return value
 		}
 	}
-	for _, metadata := range findinganalysis.BuiltinRuleMetadata() {
-		if metadata.ID == strings.TrimSpace(finding.RuleID) {
-			return strings.TrimSpace(metadata.SourceID)
-		}
+	if sourceID := strings.TrimSpace(ruleSourceIDs[strings.TrimSpace(finding.RuleID)]); sourceID != "" {
+		return sourceID
 	}
 	return "unknown"
 }


### PR DESCRIPTION
## Summary
- cache built-in rule metadata and correlation pattern parsing while returning isolated copies
- use a rule source-id index for finding summary reports instead of scanning metadata per finding

## Validation
- go test ./internal/findings ./internal/reports -count=1
- make test catalog-check detection-catalog-check

## Notes
- Push output reported existing default-branch Dependabot vulnerabilities; this PR does not change dependencies.