### PR TITLE
feat: secheck device auth - modern enterprise re-architecture (replaces PR #409)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1231,10 +1231,12 @@ paths:
       description: |
         Accepts a telemetry batch from an enrolled SeCheck agent. Requires
         a device JWT carrying the platform.telemetry.ingest scope and a
-        non-empty Idempotency-Key request header. A retried submission
-        with the same key + body is replayed without side effects; same
-        key with a different body returns 409 (RFC 5789-inspired
-        idempotency contract).
+        non-empty Idempotency-Key request header. When the JWT contains a
+        `cnf.jkt` confirmation claim, the request MUST also carry an RFC
+        9449 DPoP proof JWT in the `DPoP` header. A retried submission with
+        the same key + body is replayed without side effects; same key with
+        a different body returns 409 (RFC 5789-inspired idempotency
+        contract).
       tags:
         - Telemetry
       parameters:
@@ -1244,6 +1246,15 @@ paths:
           schema:
             type: string
             maxLength: 255
+        - in: header
+          name: DPoP
+          required: false
+          schema:
+            type: string
+          description: |
+            RFC 9449 DPoP proof JWT. Required when the bearer device JWT
+            contains a `cnf.jkt` confirmation claim. Algorithms: ES256,
+            ES384, EdDSA.
       requestBody:
         required: true
         content:
@@ -1256,6 +1267,13 @@ paths:
           description: Telemetry accepted.
         '400':
           description: Missing Idempotency-Key or malformed body.
+        '401':
+          description: |
+            Bearer token is missing, malformed, expired, or invalid; or DPoP
+            proof is missing (`dpop_required`), malformed
+            (`dpop_malformed`), or invalid -- bad signature, replayed jti,
+            expired iat, htm/htu mismatch, ath mismatch, or jkt mismatch
+            (`dpop_invalid`).
         '403':
           description: Caller is not a device principal.
         '409':

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10,6 +10,7 @@ servers:
 security:
   - bearerAuth: []
 tags:
+  - name: Devices
   - name: Findings
   - name: GRC
   - name: Graph
@@ -18,6 +19,7 @@ tags:
   - name: Platform
   - name: Reports
   - name: Sources
+  - name: Telemetry
   - name: Workflow
 paths:
   /health:
@@ -1087,6 +1089,172 @@ paths:
       responses:
         '200':
           description: Outcome write result.
+  /platform/devices/enroll:
+    post:
+      summary: Enroll a SeCheck agent
+      description: |
+        Consumes a single-use bootstrap token and provisions a device
+        identity. The bootstrap token is delivered out-of-band by MDM and
+        is bound to the device's hardware_uuid. Returns a short-lived
+        access token (EdDSA JWT) and a long-lived refresh token. Replay
+        of an already-consumed bootstrap token returns 401.
+      tags:
+        - Devices
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceEnrollRequest'
+      responses:
+        '200':
+          description: Enrollment succeeded; access + refresh pair returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceTokenResponse'
+        '400':
+          description: Malformed request body.
+        '401':
+          description: Bootstrap token invalid, expired, already consumed, or hardware-uuid mismatch.
+        '429':
+          description: Per-IP enrollment rate limit exceeded.
+  /platform/devices/token:
+    post:
+      summary: Rotate a device refresh token
+      description: |
+        Exchanges a refresh token for a new access + refresh pair. The
+        previous refresh token is consumed atomically. Replaying a
+        consumed refresh token revokes the entire token family per RFC 6819
+        §5.2.2.3.
+      tags:
+        - Devices
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeviceTokenRequest'
+      responses:
+        '200':
+          description: Rotation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeviceTokenResponse'
+        '400':
+          description: Unsupported grant_type.
+        '401':
+          description: Refresh token unknown, expired, or replayed (family revoked).
+        '429':
+          description: Per-device token rate limit exceeded.
+  /platform/devices/bootstrap-tokens:
+    post:
+      summary: Issue a single-use bootstrap token (operator-only)
+      description: |
+        Mints a single-use enrollment credential bound to a hardware_uuid
+        for one tenant. Requires the platform.devices.bootstrap_tokens.write
+        scope. The plaintext token is returned exactly once; only its
+        SHA-256 digest is persisted.
+      tags:
+        - Devices
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueBootstrapTokenRequest'
+      responses:
+        '201':
+          description: Bootstrap token created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssueBootstrapTokenResponse'
+        '400':
+          description: Malformed request body.
+        '403':
+          description: Caller lacks the platform.devices.bootstrap_tokens.write scope.
+  /platform/devices/{deviceID}/revoke:
+    post:
+      summary: Revoke a device (operator-only)
+      description: |
+        Marks the device revoked. Subsequent refresh attempts fail with
+        403; access tokens already issued expire on their own at the
+        configured access TTL.
+      tags:
+        - Devices
+      parameters:
+        - name: deviceID
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RevokeDeviceRequest'
+      responses:
+        '200':
+          description: Revocation succeeded.
+        '403':
+          description: Caller lacks the platform.devices.revoke scope.
+        '404':
+          description: Device not found.
+  /platform/telemetry/ingest:
+    post:
+      summary: Ingest device telemetry (device-only)
+      description: |
+        Accepts a telemetry batch from an enrolled SeCheck agent. Requires
+        a device JWT carrying the platform.telemetry.ingest scope and a
+        non-empty Idempotency-Key request header. A retried submission
+        with the same key + body is replayed without side effects; same
+        key with a different body returns 409 (RFC 5789-inspired
+        idempotency contract).
+      tags:
+        - Telemetry
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+            maxLength: 255
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '202':
+          description: Telemetry accepted.
+        '400':
+          description: Missing Idempotency-Key or malformed body.
+        '403':
+          description: Caller is not a device principal.
+        '409':
+          description: Idempotency-Key reused with a different body.
+        '413':
+          description: Body exceeds 1 MiB.
+  /.well-known/device-jwks.json:
+    get:
+      summary: Device-JWT verification keys
+      description: |
+        Publishes the active and retiring Ed25519 verification keys as a
+        JWK Set (RFC 7517 §4 + RFC 8037). Cache headers permit short-term
+        caching by downstream verifiers.
+      tags:
+        - Devices
+      security: []
+      responses:
+        '200':
+          description: JWK Set document.
 
 components:
   securitySchemes:
@@ -1152,6 +1320,92 @@ components:
         type: integer
         minimum: 1
   schemas:
+    DeviceEnrollRequest:
+      type: object
+      required: [bootstrap_token, hardware_uuid]
+      properties:
+        bootstrap_token:
+          type: string
+          minLength: 1
+        hardware_uuid:
+          type: string
+          minLength: 1
+        serial_number:
+          type: string
+        hostname:
+          type: string
+        os_type:
+          type: string
+        os_version:
+          type: string
+        agent_version:
+          type: string
+    DeviceTokenRequest:
+      type: object
+      required: [grant_type, refresh_token]
+      properties:
+        grant_type:
+          type: string
+          enum: [refresh_token]
+        refresh_token:
+          type: string
+          minLength: 1
+    DeviceTokenResponse:
+      type: object
+      required: [access_token, token_type, expires_in, scopes]
+      properties:
+        access_token:
+          type: string
+        token_type:
+          type: string
+          enum: [Bearer]
+        expires_in:
+          type: integer
+          description: Seconds until access_token expires.
+        refresh_token:
+          type: string
+        refresh_expires_at:
+          type: string
+          format: date-time
+        scopes:
+          type: array
+          items:
+            type: string
+        device_id:
+          type: string
+    IssueBootstrapTokenRequest:
+      type: object
+      required: [hardware_uuid]
+      properties:
+        hardware_uuid:
+          type: string
+          minLength: 1
+        tenant_id:
+          type: string
+        scopes:
+          type: array
+          items:
+            type: string
+        ttl_seconds:
+          type: integer
+          minimum: 1
+    IssueBootstrapTokenResponse:
+      type: object
+      required: [token_id, token, expires_at]
+      properties:
+        token_id:
+          type: string
+        token:
+          type: string
+          description: Plaintext bootstrap token; returned once and never persisted in clear.
+        expires_at:
+          type: string
+          format: date-time
+    RevokeDeviceRequest:
+      type: object
+      properties:
+        reason:
+          type: string
     GRCAskRequest:
       type: object
       required: [tenant_id, question]

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1128,9 +1128,25 @@ paths:
         previous refresh token is consumed atomically. Replaying a
         consumed refresh token revokes the entire token family per RFC 6819
         §5.2.2.3.
+
+        When the device was enrolled with a hardware-bound key (App Attest
+        or TPM 2.0), the request MUST carry an RFC 9449 DPoP proof JWT in
+        the `DPoP` header signed by the bound key, with `htm` matching the
+        request method, `htu` matching the canonical request URL, a unique
+        `jti`, and a fresh `iat`. The proof's JWK SHA-256 thumbprint
+        (RFC 7638) must equal the device's stored `dpop_jkt`.
       tags:
         - Devices
       security: []
+      parameters:
+        - in: header
+          name: DPoP
+          required: false
+          schema:
+            type: string
+          description: |
+            RFC 9449 DPoP proof JWT. Required when the device was enrolled
+            with a hardware-bound key. Algorithms: ES256, ES384, EdDSA.
       requestBody:
         required: true
         content:
@@ -1147,7 +1163,11 @@ paths:
         '400':
           description: Unsupported grant_type.
         '401':
-          description: Refresh token unknown, expired, or replayed (family revoked).
+          description: |
+            Refresh token unknown, expired, or replayed (family revoked); or
+            DPoP proof is missing (`dpop_required`), malformed
+            (`dpop_malformed`), or invalid -- bad signature, replayed jti,
+            expired iat, htm/htu mismatch, or jkt mismatch (`dpop_invalid`).
         '429':
           description: Per-device token rate limit exceeded.
   /platform/devices/bootstrap-tokens:
@@ -1340,6 +1360,16 @@ components:
           type: string
         agent_version:
           type: string
+        attestation:
+          type: string
+          description: |
+            Base64-encoded device-bound attestation statement. On macOS this is
+            an Apple App Attest CBOR attestationObject; on Windows a TPM 2.0
+            quote bundle (JSON envelope with ek_chain, ak_pub_der, quote, signature, alg).
+            Required when CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED=true; if
+            present and verified, the server binds a DPoP key (RFC 9449) to
+            subsequent refresh-token rotations and the response includes
+            assurance_level=hardware.
     DeviceTokenRequest:
       type: object
       required: [grant_type, refresh_token]
@@ -1373,6 +1403,31 @@ components:
             type: string
         device_id:
           type: string
+        assurance_level:
+          type: string
+          enum: [software, hardware]
+          description: |
+            Attestation outcome: "hardware" when the device-bound key was
+            produced by Apple Secure Enclave or a TPM 2.0; "software" when
+            no attestation was supplied or the configured registry runs in
+            non-required mode.
+        attestation_vendor:
+          type: string
+          description: |
+            Backend that produced the attestation result (e.g.
+            "apple-appattest", "tpm-2.0", or "none").
+        risk_score:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Composite 0..100 risk score for this rotation.
+        risk_level:
+          type: string
+          enum: [low, elevated, high]
+          description: |
+            Mapped from risk_score. On "high", sensitive scopes (telemetry
+            ingest, bootstrap-token write, device revoke) are dropped from
+            the issued access token.
     IssueBootstrapTokenRequest:
       type: object
       required: [hardware_uuid]

--- a/api/openapi_deviceauth_test.go
+++ b/api/openapi_deviceauth_test.go
@@ -1,0 +1,41 @@
+package apicontract
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestTelemetryIngestDocumentsDPoPContract(t *testing.T) {
+	docBytes, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	section := openAPIPathSection(t, string(docBytes), "/platform/telemetry/ingest")
+	for _, want := range []string{
+		"name: DPoP",
+		"`cnf.jkt`",
+		"'401':",
+		"dpop_required",
+		"dpop_malformed",
+		"dpop_invalid",
+	} {
+		if !strings.Contains(section, want) {
+			t.Fatalf("telemetry ingest OpenAPI section missing %q:\n%s", want, section)
+		}
+	}
+}
+
+func openAPIPathSection(t *testing.T, doc string, path string) string {
+	t.Helper()
+	start := strings.Index(doc, "  "+path+":")
+	if start < 0 {
+		t.Fatalf("OpenAPI path %s not found", path)
+	}
+	rest := doc[start+1:]
+	next := strings.Index(rest[1:], "\n  /")
+	if next < 0 {
+		return rest
+	}
+	return rest[:next+1]
+}

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -91,7 +91,10 @@ func serve() error {
 		return fmt.Errorf("open source registry: %w", err)
 	}
 
-	app := bootstrap.New(cfg, deps, sources)
+	app, err := bootstrap.NewWithError(cfg, deps, sources)
+	if err != nil {
+		return fmt.Errorf("bootstrap app: %w", err)
+	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	startFindingRiskBackfill(ctx, app, log.Printf)

--- a/docs/NON_GOALS.md
+++ b/docs/NON_GOALS.md
@@ -71,6 +71,13 @@ Each section lists what Cerebro will not do, why that boundary exists, where in 
 - Enforced in: [`PLAN.md`](../PLAN.md) §5.3 "Plugin boundary".
 - What would change this: a documented operational threshold (source count, deploy blast radius, third-party authoring need) that justifies the cost of an out-of-process plugin contract, with a separate design doc covering signing, sandboxing, and lifecycle.
 
+### Agent push surface (device-keyed write) is bounded to first-party fleet agents.
+
+- Cerebro accepts push traffic only from first-party agents Cerebro itself authenticates and authorizes per-device. The current concrete instance is the SeCheck endpoint agent (see [`docs/proposals/SECHECK_DEVICE_AUTH.md`](./proposals/SECHECK_DEVICE_AUTH.md)). Third-party services and unmanaged callers do not write to the platform: they integrate via the Source CDK's pull contract.
+- Why: a first-party agent is a substantively different trust shape from a third-party API. Cerebro provisions the device identity (bootstrap token via MDM), signs the JWTs, owns the rotation key material, and revokes the device. None of those affordances exist for third-party callers, and conflating them would erase the Source-CDK boundary that makes replay, rebuild, and rule evaluation deterministic. Distinct affordance gets distinct entry.
+- Enforced in: [`internal/deviceauth`](../internal/deviceauth) (token issuance, rotation, replay detection); the bootstrap auth pipeline in [`internal/bootstrap/auth.go`](../internal/bootstrap/auth.go) (the device-JWT verifier sits next to the existing API-key and capability-token paths, not as a separate service); the `platform.devices.*`, `platform.telemetry.ingest`, and `security.devices.findings.read` scope set wired through `authorizeHTTPRequestScope`.
+- What would change this: a second first-party agent class with materially different posture (e.g. server-side runtime agents, container sidecars). That belongs to its own design proposal and its own [`docs/NON_GOALS.md`](./NON_GOALS.md) entry; reusing the SeCheck shape by default is not the answer.
+
 ## Graph And Cypher
 
 ### Neo4j is a projection, not a write target.

--- a/docs/proposals/SECHECK_DEVICE_AUTH.md
+++ b/docs/proposals/SECHECK_DEVICE_AUTH.md
@@ -1,0 +1,399 @@
+# SeCheck Device Auth and Telemetry Integration: Modern Enterprise Design
+
+## Status
+
+**Proposal**. Replaces the closed [`feat/secheck-device-auth` branch (PR #409)](https://github.com/writer/cerebro/pull/409). PR #409 was structured against the pre-bootstrap `internal/api/`, `internal/runtime/`, and `internal/providers/` packages, all of which have been removed from `main`. This proposal targets the current bootstrap service, NATS JetStream append log, and Postgres state store.
+
+## Why this exists
+
+The Writer Security Checkup ("SeCheck") agent is a Go binary deployed via MDM (Kandji on macOS, Intune on Windows) to engineer workstations. The agent talks to Cerebro to:
+
+1. Pull a device-keyed enriched findings stream (CVE x installed package x KEV x EPSS).
+2. Locally validate whether each finding still affects this exact box.
+3. Push remediation, verification, and posture telemetry back.
+
+PR #409 demonstrated the protocol shape (enroll, token, telemetry ingest) but had seven architectural gaps that block production deployment. This document re-architects the integration against the current `bootstrap` service, fixes those gaps, and documents the boundary it adds.
+
+## Scope discipline
+
+This proposal explicitly crosses one [non-goal boundary](../NON_GOALS.md): the bootstrap service does not currently accept third-party push traffic. SeCheck agents push telemetry from outside the cluster (engineer laptops on residential ISPs and coffee-shop Wi-Fi). That is a new affordance.
+
+This document satisfies the "What would change this" criterion in `NON_GOALS.md` by:
+
+- Citing the relevant entry (Source CDK: "Sources are the only path to the outside world").
+- Modelling SeCheck push as a **distinct platform capability**, not a Source: it is *first-party* device telemetry from a fleet Cerebro authenticates and authorizes per-device, not a third-party API integration. Sources remain the only path for *third-party* outside-world traffic.
+- Updating `docs/NON_GOALS.md` in the same change to record the new boundary entry: "Agent push surface (device-keyed write)".
+
+## Goals
+
+- A modern, enterprise-grade auth and telemetry surface for the SeCheck agent that compares favorably with how Google/Uber/Facebook secure first-party fleet agents.
+- Roaming-workforce-safe: agents on residential ISPs, hotel Wi-Fi, mobile hotspots, and coffee shops should authenticate, refresh, and report without operator intervention.
+- AWS-native: signing keys live in AWS KMS or Secrets Manager; the request path can sit behind ALB + AWS WAF + VPC endpoints; observability flows to CloudWatch and X-Ray via OpenTelemetry.
+- No silent fallbacks. Every dependency (Postgres state store, signing-key source, append-log) either runs configured or the route fails closed.
+- One implementation path per capability. The agent-push surface uses the same auth pipeline (`bootstrap/auth.go`) as everything else, the same audit emitter (`emitAccessAuditEvent`), the same scope mechanism (`authorizeHTTPRequestScope`), and the same Postgres state store.
+
+## Non-goals (in this proposal)
+
+- A Source CDK plugin for SeCheck. SeCheck pushes; Sources pull. Wrong shape.
+- A new long-term store. State persists in the existing `internal/statestore/postgres` driver.
+- A new graph projection. SeCheck observations are findings/findingevidence rows, projected through the existing append-log fan-in.
+- Agent-side feature work (validation, classifier, MCP tools). That all lives in `WriterInternal/security`.
+
+## PR #409 findings: gap matrix
+
+| # | PR #409 gap | Current proposal |
+|---|---|---|
+| 1 | JSON-file-backed device store; single-writer; no replay-safety | Postgres-backed via `internal/statestore/postgres/deviceauth.go`; multi-replica safe; tx-bounded refresh-token rotation |
+| 2 | HS256 signing key from a single env var; no rotation, no JWKS, no `kid` | EdDSA (Ed25519) signing keys with `kid` header; key material delivered via AWS KMS (sign API) or Secrets Manager + multi-key set; `/.well-known/device-jwks.json` published for verifiers |
+| 3 | No rate limit on `/devices/enroll`; bootstrap-token brute-force exposure | Per-IP token bucket on enroll (1 req / 5s, burst 3) and per-device on `/devices/token` (1 req / 1s, burst 5); state in Postgres so multi-replica is consistent; AWS WAF rate-based rule layered in front |
+| 4 | Admin endpoints not visibly RBAC-gated | New scopes `platform.devices.enroll`, `platform.devices.token`, `platform.devices.bootstrap_tokens.write`, `platform.devices.read`, `security.devices.findings.read`, `platform.telemetry.ingest`; mapped through the existing `authorizeHTTPRequestScope` switch |
+| 5 | No audit-log writes on auth events | All enroll, token-issue, refresh-rotate, family-revoke, bootstrap-token-create events flow through the existing `emitAccessAuditEvent` plus a new `cerebro.devices.lifecycle` event emitter for non-HTTP transitions (TTL expiry, replay revoke) |
+| 6 | Hardware UUID is the binding; spoofable on rooted devices | Documented as v1; v2 adds Apple App Attest (macOS) and Windows TPM-backed key attestation; agent-side bound-key DPoP-style proof on token requests in v2 |
+| 7 | No idempotency keys on telemetry ingest | Required `Idempotency-Key` header, deduped via `device_telemetry_idempotency` Postgres table with 24h retention; replays return 200 with cached response |
+
+## Architecture
+
+```
++------------------------------------------------------------------+
+|                          AWS Edge                                |
+|                                                                  |
+|   Route 53 -> AWS WAF (rate-based + geo + bot rules)             |
+|        -> ALB (TLS 1.3, mTLS optional for service callers)       |
+|        -> Cerebro bootstrap (private subnet, 3+ replicas)        |
+|                                                                  |
+|   Signing keys: AWS KMS asymm. CMK (Ed25519) - sign() API only;  |
+|                 private key never leaves KMS                     |
+|   Persistent state: Aurora Postgres (Multi-AZ)                   |
+|   Append log: NATS JetStream (existing)                          |
++------------------------------+-----------------------------------+
+                               |
+                               | TLS 1.3 + JWT (Ed25519, kid)
+                               | W3C traceparent end-to-end
+                               | Idempotency-Key on writes
+                               |
++------------------------------+-----------------------------------+
+|                       Cerebro bootstrap                          |
+|                                                                  |
+|  +-------------------+   +-------------------+                   |
+|  | bootstrap/auth.go |-->| internal/         |                   |
+|  | (extended)        |   |  deviceauth/      |                   |
+|  +-------------------+   |   - jwt(EdDSA)    |                   |
+|        |                 |   - jwks          |                   |
+|        |                 |   - rotation      |                   |
+|        v                 |   - postgres      |                   |
+|  +-------------------+   +-------------------+                   |
+|  | route mounts      |                                           |
+|  |                   |                                           |
+|  |  /platform/devices/enroll          [public, bootstrap-tok]    |
+|  |  /platform/devices/token           [public, refresh|bootstrap]|
+|  |  /platform/devices/{id}            [device|admin]             |
+|  |  /platform/devices/{id}:revoke     [admin]                    |
+|  |  /platform/devices/bootstrap-tokens [admin]                   |
+|  |  /platform/telemetry/ingest        [device, idempotent]       |
+|  |  /security/devices/{id}/findings   [device|user]              |
+|  |  /.well-known/device-jwks.json     [public]                   |
+|  +-------------------+                                           |
+|        |                                                         |
+|        v                                                         |
+|  +-------------------+   +-------------------+                   |
+|  | append log fan-in |-->| findings/         |                   |
+|  | (existing)        |   | findingevidence/  |                   |
+|  +-------------------+   | workflowevents/   |                   |
+|                          +-------------------+                   |
++------------------------------------------------------------------+
+                               |
+                               | observability
+                               v
+                    OpenTelemetry -> CloudWatch + X-Ray
+                    Access audit -> existing cerebro.api.access events
+                    Lifecycle audit -> new cerebro.devices.lifecycle events
+```
+
+## Wire protocol
+
+### Enroll: `POST /platform/devices/enroll`
+
+Public. Authenticated by single-use bootstrap token only.
+
+**Request**
+
+```http
+POST /platform/devices/enroll HTTP/1.1
+Host: cerebro.writer.com
+Content-Type: application/json
+Idempotency-Key: <uuid>
+traceparent: 00-<trace>-<span>-01
+User-Agent: secheck/1.4.2 (darwin/arm64)
+X-Cerebro-Bootstrap-Token: <single-use, MDM-delivered>
+
+{
+  "hardware_uuid": "<UUID, hex digest, lowercase>",
+  "serial_number": "<MDM-known serial>",
+  "hostname":      "<short>",
+  "os_type":       "darwin|windows",
+  "os_version":    "14.5.0",
+  "agent_version": "1.4.2",
+  "tenant_id":     "writer"
+}
+```
+
+**Response (201)**
+
+```json
+{
+  "device_id":          "<server-generated uuid>",
+  "access_token":       "<EdDSA JWT, kid set, 10 min ttl>",
+  "refresh_token":      "<opaque 256-bit, hashed at rest>",
+  "refresh_expires_at": "<RFC3339>",
+  "scopes": [
+    "platform.devices.read",
+    "platform.telemetry.ingest",
+    "security.devices.findings.read"
+  ]
+}
+```
+
+**Server-side**:
+
+1. Body capped at 4 KiB via `http.MaxBytesReader`.
+2. Per-IP rate limit: 1 req / 5 s, burst 3.
+3. Bootstrap-token consume is one Postgres transaction: row lock the bootstrap-token, verify hash, verify hardware-UUID binding, verify expiry, mark consumed, insert device row, insert refresh-token row, commit. Replay returns 409.
+4. Issue Ed25519 access token via `internal/deviceauth.JWTIssuer` (key signed by AWS KMS in production, in-process for tests).
+5. Emit access-audit event + new `cerebro.devices.lifecycle` event with `{"action":"enroll","device_id":...,"tenant_id":...,"client_ip":...}`.
+
+### Token refresh: `POST /platform/devices/token`
+
+Public. Authenticated by **either** bootstrap-token (re-enroll) or refresh-token (normal refresh).
+
+**Request**
+
+```json
+{
+  "grant_type": "refresh_token",
+  "refresh_token": "<opaque>",
+  "device_id": "<uuid>"
+}
+```
+
+**Response (200)**
+
+Same shape as enroll. The previous refresh token is **single-use** -- consuming it issues a new pair (`generation += 1`, same `family_id`). If a stale generation is presented, the entire family is revoked (`replay-detected`) and the device must re-enroll. This matches RFC 6819 §5.2.2.3 token-replay handling.
+
+**Server-side**:
+
+1. Per-device rate limit: 1 req / 1 s, burst 5.
+2. The rotation transaction:
+   - Lock the refresh-token row.
+   - If `consumed=true`, set `family_revoked=true` for all rows with the same `family_id`, return 401 `replay_detected`.
+   - If expired, return 401 `expired`.
+   - If device is not `active`, return 401 `device_inactive`.
+   - Insert new refresh-token row with `generation = consumed.generation + 1`, mark consumed.
+   - Commit.
+3. Issue new access token (Ed25519, 10 min TTL, `kid` from current signing key).
+4. Audit event.
+
+### Telemetry ingest: `POST /platform/telemetry/ingest`
+
+Authenticated by device JWT. Required `Idempotency-Key`. Body cap 256 KiB.
+
+```json
+{
+  "device_id":     "<uuid>",
+  "agent_version": "1.4.2",
+  "occurred_at":   "<RFC3339>",
+  "events": [
+    {
+      "kind":      "verify|remediate|posture|heartbeat",
+      "event_id":  "<agent-side uuid>",
+      "finding_id":"<cerebro finding id>",
+      ...
+    }
+  ]
+}
+```
+
+**Server-side**:
+
+1. JWT verified, `device_id` claim must match body `device_id`.
+2. Idempotency key checked against `device_telemetry_idempotency`. Cache hit returns the cached 200 body (24h retention). Different body for same key returns 409 `idempotency_conflict`.
+3. Events appended to JetStream subject `cerebro.devices.telemetry`.
+4. Projection writes `findings`, `findingevidence`, and `workflowevents` rows through existing projectors.
+5. 200 response cached against the idempotency key.
+
+### Findings feed: `GET /security/devices/{device_id}/findings`
+
+Authenticated by device JWT (must match path `device_id`) **or** a user with `security.devices.findings.read`.
+
+Query params: `since=<RFC3339>`, `severity=`, `limit=` (max 500). Results joined from `internal/findings` and `internal/vulndb` (the existing KEV/EPSS/NVD enrichment).
+
+### JWKS: `GET /.well-known/device-jwks.json`
+
+Public. Returns active + retiring public keys with `kid`, alg `EdDSA`, kty `OKP`, crv `Ed25519`. Cached 5 min, served from Postgres-backed key set.
+
+## Security design
+
+### Token format and rotation
+
+- **Algorithm**: EdDSA (Ed25519). Smaller signatures than RS256, faster verify, modern.
+- **kid header**: every token carries the issuing key id. Rotation is a JWKS publish + a `current_kid` flip in config. Old keys remain in the JWKS for the access-token TTL (10 min) plus skew.
+- **Signing path**: production uses AWS KMS asymmetric sign-only CMKs. The private key never leaves KMS. CI / dev uses an in-process Ed25519 signer with secrets from `CEREBRO_DEVICE_AUTH_DEV_SIGNING_KEY` (refused if `APP_ENV=production`).
+- **TTLs**: access 10 min, refresh 30 days sliding (renewed on every successful refresh). 30 days fits a roaming engineer reasonably; if the agent goes offline >30 days the user re-auths via the AI button (re-enroll flow trips bootstrap-token issuance through MDM).
+- **Refresh rotation**: single-use, family-scoped, replay-revoking. Identical to PR #409's design but in a Postgres transaction rather than a JSON-file lock.
+
+### Secrets and key management
+
+- Bootstrap-token plaintext is never stored. Only a `sha256` hash is in `device_bootstrap_tokens.token_hash`.
+- Refresh-token plaintext is never stored. Only a `sha256` hash is in `device_refresh_tokens.token_hash`.
+- AWS KMS holds Ed25519 signing keys per-environment. Cerebro IAM role gets `kms:Sign`, never `kms:Decrypt` on these CMKs.
+- Optional: envelope encryption of admin-readable token metadata via AWS KMS GenerateDataKey. Out of scope for v1.
+
+### Network layer
+
+- ALB enforces TLS 1.3 with modern cipher set (TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256).
+- AWS WAF rule set: rate-based per-IP, AWS-managed core, AWS-managed known-bad-inputs, custom rule blocking `/platform/devices/enroll` from non-allowlisted geographies (Phase 2 -- requires policy decision on engineers traveling internationally).
+- Optional client mTLS for service-to-service callers (admin tooling, CI). Device agents use bearer JWTs; the cert pinning happens at the OS-managed CA bundle level.
+
+### Roaming workforce considerations
+
+- Refresh TTL is 30 days sliding; the agent stays signed in across multi-day disconnects.
+- IP changes are expected and not a denial signal. We log `client_ip`, `country`, and `asn` (via WAF) on each refresh into the audit stream so security can post-hoc review anomalies, but do not block on them in v1.
+- Phase 2 introduces device-bound key DPoP proofs (the agent generates an Ed25519 keypair at enroll, the public key is stored on the device record, every refresh request is signed with it). This pins refresh tokens to a hardware-bound private key that never leaves the OS keychain. That eliminates the "stolen refresh token" class of attack regardless of geography.
+
+### Observability
+
+- W3C `traceparent` propagated on every request.
+- OpenTelemetry traces shipped to AWS X-Ray via the OTel collector sidecar already in the bootstrap deploy.
+- Existing `cerebro.api.access` audit events cover HTTP-level access.
+- New `cerebro.devices.lifecycle` events cover non-HTTP transitions: TTL expiries, family revokes, scheduled maintenance revokes.
+- Prometheus counters: `cerebro_devices_enroll_total`, `cerebro_devices_token_total{outcome}`, `cerebro_devices_telemetry_events_total`, `cerebro_devices_refresh_replays_total` (alerts > 0).
+
+### Failure modes
+
+- KMS unavailable: enrollment, refresh, and any new token issuance return 503 `signing_unavailable`. Existing access tokens continue to verify against the JWKS cached locally. SLO: KMS read latency p99 < 50 ms; falls back to the in-memory JWKS cache for verification on KMS read failure.
+- Postgres unavailable: every device-auth route returns 503. Fail-closed by default per `docs/NON_GOALS.md` ("Routes that need a configured store fail closed").
+- NATS unavailable: telemetry ingest returns 503. Idempotency-key lookup still works against Postgres; the agent retries with the same key.
+
+## Permission model
+
+The new scopes slot cleanly into the namespace split documented in `docs/PLATFORM_TRANSITION_ARCHITECTURE.md`:
+
+| Scope | Intent | Required for |
+|---|---|---|
+| `platform.devices.enroll` | Issue device identity from a bootstrap token | (public route, scope checked on internal callers) |
+| `platform.devices.token` | Refresh device tokens | (public route, scope checked on internal callers) |
+| `platform.devices.read` | Read own device record | `GET /platform/devices/{id}` (device or admin) |
+| `platform.devices.bootstrap_tokens.write` | Mint MDM bootstrap tokens | `POST /platform/devices/bootstrap-tokens` (admin) |
+| `platform.devices.revoke` | Revoke a device | `POST /platform/devices/{id}:revoke` (admin) |
+| `platform.telemetry.ingest` | Write device telemetry | `POST /platform/telemetry/ingest` (device) |
+| `security.devices.findings.read` | Read per-device findings | `GET /security/devices/{id}/findings` (device or user) |
+
+Device JWTs carry only the scopes appropriate for an agent (`platform.devices.read`, `platform.telemetry.ingest`, `security.devices.findings.read`). Admin scopes never appear on a device JWT.
+
+## Persistence schema
+
+Tables are owned by `internal/statestore/postgres/deviceauth.go`, created via the existing `ensureStatements` lazy-init pattern.
+
+```sql
+CREATE TABLE IF NOT EXISTS device_records (
+  device_id        TEXT PRIMARY KEY,
+  hardware_uuid    TEXT NOT NULL,
+  serial_number    TEXT,
+  hostname         TEXT,
+  tenant_id        TEXT NOT NULL,
+  os_type          TEXT NOT NULL,
+  os_version       TEXT,
+  agent_version    TEXT,
+  status           TEXT NOT NULL DEFAULT 'active',
+  enrolled_at      TIMESTAMPTZ NOT NULL,
+  last_seen_at     TIMESTAMPTZ NOT NULL,
+  revoked_at       TIMESTAMPTZ,
+  metadata         JSONB,
+  UNIQUE (tenant_id, hardware_uuid)
+);
+
+CREATE TABLE IF NOT EXISTS device_bootstrap_tokens (
+  token_id         TEXT PRIMARY KEY,
+  token_hash       BYTEA NOT NULL,
+  hardware_uuid    TEXT NOT NULL,
+  tenant_id        TEXT NOT NULL,
+  scopes           TEXT[] NOT NULL DEFAULT '{}',
+  expires_at       TIMESTAMPTZ NOT NULL,
+  consumed_at      TIMESTAMPTZ,
+  consumed_by      TEXT,
+  created_at       TIMESTAMPTZ NOT NULL,
+  UNIQUE (token_hash)
+);
+
+CREATE TABLE IF NOT EXISTS device_refresh_tokens (
+  token_hash       BYTEA PRIMARY KEY,
+  device_id        TEXT NOT NULL REFERENCES device_records(device_id) ON DELETE CASCADE,
+  family_id        TEXT NOT NULL,
+  generation       INTEGER NOT NULL,
+  scopes           TEXT[] NOT NULL DEFAULT '{}',
+  created_at       TIMESTAMPTZ NOT NULL,
+  expires_at       TIMESTAMPTZ NOT NULL,
+  consumed_at      TIMESTAMPTZ,
+  family_revoked   BOOLEAN NOT NULL DEFAULT FALSE,
+  superseded       BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS device_refresh_tokens_family_idx
+  ON device_refresh_tokens(family_id);
+
+CREATE TABLE IF NOT EXISTS device_signing_keys (
+  kid              TEXT PRIMARY KEY,
+  algorithm        TEXT NOT NULL,
+  public_key_pem   TEXT NOT NULL,
+  kms_key_arn      TEXT,
+  status           TEXT NOT NULL DEFAULT 'active',
+  promoted_at      TIMESTAMPTZ NOT NULL,
+  retired_at       TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS device_telemetry_idempotency (
+  idempotency_key  TEXT PRIMARY KEY,
+  device_id        TEXT NOT NULL,
+  request_hash     BYTEA NOT NULL,
+  response_status  INTEGER NOT NULL,
+  response_body    BYTEA NOT NULL,
+  created_at       TIMESTAMPTZ NOT NULL,
+  expires_at       TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX IF NOT EXISTS device_telemetry_idempotency_expiry_idx
+  ON device_telemetry_idempotency(expires_at);
+```
+
+A scheduled job (`internal/sourceops` cron) purges `device_telemetry_idempotency` rows past `expires_at` daily.
+
+## Phasing
+
+| Phase | Scope | This PR |
+|---|---|---|
+| 1a | Design proposal + NON_GOALS update + `internal/deviceauth/` package skeleton (JWT issuer, in-memory store, unit tests) | **yes** |
+| 1b | Postgres schema + driver implementation in `internal/statestore/postgres/deviceauth.go` | follow-on |
+| 1c | Route mounts in `internal/bootstrap/app.go`; auth-pipeline extension to recognize device JWTs | follow-on |
+| 1d | OpenAPI updates + `make openapi-sync` | follow-on |
+| 2  | DPoP-style device-bound proofs; Apple App Attest; Windows TPM attestation | future |
+| 3  | Geo / ASN anomaly scoring on refresh; AWS WAF custom rules | future |
+
+## Testing
+
+Unit tests for v1a (this PR):
+
+- `JWTIssuer.IssueAccess` returns a valid Ed25519-signed token with the expected claims and `kid`.
+- `JWTVerifier.Verify` accepts a fresh token, rejects an expired one, rejects one with an unknown `kid`, rejects one with the wrong audience, rejects one with no scopes.
+- Refresh-rotation: fresh token consume succeeds; double-consume revokes the family; a generation N-1 token after a successful generation N rotation is rejected; replay revokes the family.
+- Bootstrap-token consume: consume succeeds once and the token is marked consumed; second consume returns `bootstrap_token_already_consumed`; expired token rejected; hardware-UUID mismatch rejected.
+
+Follow-on PR test surface (1b/1c/1d):
+
+- `httptest`-driven coverage of every route with happy + error paths.
+- Postgres-driver tests against a containerized `pgx` instance via the existing `Open()` test pattern.
+- Idempotency-key replay tests (same key + same body returns cached, same key + different body returns 409).
+- Rate-limiter tests (per-IP and per-device buckets).
+- Race tests on concurrent refresh-rotation.
+
+## Open questions
+
+- AWS KMS asymmetric sign latency: acceptable for token issuance? Proposed cache: pre-sign a batch is not possible (each token is unique), but the path is rare (10-min token TTL means ~144 signs/day/device for a fleet of N devices = N * 144 KMS calls/day). For 5,000 devices that's 720k/day, well inside service quotas.
+- Where does the agent's MDM-delivered bootstrap token come from? Proposal: a Cerebro admin endpoint mints them, the security team stages them in Kandji/Intune managed config, and Kandji/Intune delivers the per-device value at check-in. That keeps Cerebro out of the MDM API path.
+- Do we need a separate ingress for telemetry vs. control-plane traffic? For v1, no -- both ride the same ALB with separate target groups. Phase 3 may split if telemetry volume warrants its own NLB.

--- a/docs/proposals/SECHECK_DEVICE_AUTH.md
+++ b/docs/proposals/SECHECK_DEVICE_AUTH.md
@@ -369,11 +369,22 @@ A scheduled job (`internal/sourceops` cron) purges `device_telemetry_idempotency
 | Phase | Scope | This PR |
 |---|---|---|
 | 1a | Design proposal + NON_GOALS update + `internal/deviceauth/` package skeleton (JWT issuer, in-memory store, unit tests) | **yes** |
-| 1b | Postgres schema + driver implementation in `internal/statestore/postgres/deviceauth.go` | follow-on |
-| 1c | Route mounts in `internal/bootstrap/app.go`; auth-pipeline extension to recognize device JWTs | follow-on |
-| 1d | OpenAPI updates + `make openapi-sync` | follow-on |
-| 2  | DPoP-style device-bound proofs; Apple App Attest; Windows TPM attestation | future |
-| 3  | Geo / ASN anomaly scoring on refresh; AWS WAF custom rules | future |
+| 1b | Postgres schema + driver implementation in `internal/statestore/postgres/deviceauth.go` | **yes** |
+| 1c | Route mounts in `internal/bootstrap/app.go`; auth-pipeline extension to recognize device JWTs | **yes** |
+| 1d | OpenAPI updates + `make openapi-sync` | **yes** |
+| 2  | DPoP-style device-bound proofs (RFC 9449); Apple App Attest; Windows TPM attestation | **yes** |
+| 3  | Geo / ASN / velocity anomaly scoring on refresh; sensitive-scope downgrade; AWS WAF emitter | **yes** |
+
+### Phase 2 in this PR
+
+- `internal/deviceauth/dpop.go` -- RFC 9449 verifier supporting `ES256`, `ES384`, and `EdDSA`. Validates `htm` / `htu` against the canonical request URL, enforces the proof TTL with a configurable clock skew, dedupes `jti` in a TTL-bounded in-memory map (per-process; production should swap in a Redis-backed jti store keyed by device id when running multiple replicas), and computes the JWK SHA-256 thumbprint per RFC 7638.
+- `internal/deviceauth/attestation/` -- pluggable verifier registry. `apple.go` validates an Apple App Attest CBOR `attestationObject` against the embedded production Apple App Attest Root CA, checks the `1.2.840.113635.100.8.2` nonce extension, and confirms `credId == SHA-256(X || Y)`. `tpm.go` validates a TPM 2.0 quote bundle (`ek_chain` + `ak_pub_der` + `quote` + `signature`) for `RSA-PKCS1v15-SHA256` and `ECDSA-SHA256` AKs, with a vendor allowlist.
+- `Service.Enroll` runs the registry; on success the device's `dpop_jkt` (the JWK thumbprint of the device-bound key) is persisted into device metadata. Subsequent `Service.IssueToken` calls require an RFC 9449 DPoP proof header whose JKT equals the stored value; a missing proof returns `dpop_required`, an invalid one returns `dpop_invalid` / `dpop_malformed`.
+
+### Phase 3 in this PR
+
+- `internal/deviceauth/risk/` -- composite scorer with three default detectors: `VelocityDetector` (haversine impossible-travel), `CountryDriftDetector`, `ASNDriftDetector`. Pluggable `GeoLookup` interface (`InMemoryLookup` for tests, MaxMind in production), pluggable `WAFEmitter` (`JSONLogEmitter` for now; `AWSWAFEmitter` is the operator-supplied wiring point), and an `ObservationStore` keyed on device id.
+- Each successful refresh runs through the scorer; the `Decision` carries `score`, `level` (`low` / `elevated` / `high`), and signals. On `high`, sensitive scopes (`platform.telemetry.ingest`, `platform.devices.bootstrap_tokens.write`, `platform.devices.revoke`) are dropped from the issued access token and a WAF rule update is emitted. The decision is also written to the audit log as `risk_score` / `risk_level` / `assurance_level`.
 
 ## Testing
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/writer/cerebro/internal/claims"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/deviceauth"
+	"github.com/writer/cerebro/internal/deviceauth/risk"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphingest"
@@ -51,15 +52,18 @@ type Dependencies struct {
 
 // App is the minimal Connect/bootstrap composition root for the rewrite skeleton.
 type App struct {
-	cfg            config.Config
-	deps           Dependencies
-	sources        *sourcecdk.Registry
-	mux            *http.ServeMux
-	handler        http.Handler
-	server         *http.Server
-	deviceService  *deviceauth.Service
-	deviceHandler  *deviceAuthHTTPHandler
-	deviceVerifier *deviceauth.JWTVerifier
+	cfg              config.Config
+	deps             Dependencies
+	sources          *sourcecdk.Registry
+	mux              *http.ServeMux
+	handler          http.Handler
+	server           *http.Server
+	deviceService    *deviceauth.Service
+	deviceHandler    *deviceAuthHTTPHandler
+	deviceVerifier   *deviceauth.JWTVerifier
+	dpopVerifier     *deviceauth.DPoPVerifier
+	riskScorer       *risk.Scorer
+	observationStore risk.ObservationStore
 }
 
 type bootstrapService struct {
@@ -83,13 +87,26 @@ var (
 func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App {
 	app := &App{cfg: cfg, deps: deps, sources: sources}
 	if deviceStore := deviceAuthStore(deps.StateStore); deviceStore != nil {
-		service, err := buildDeviceAuthService(cfg.Auth.DeviceAuth, deviceStore)
+		dpop := deviceauth.NewDPoPVerifier(cfg.Auth.DeviceAuth.ClockSkew, cfg.Auth.DeviceAuth.DPoPProofTTL)
+		obsStore := risk.NewInMemoryObservationStore()
+		riskScorer := risk.NewScorer(
+			risk.Thresholds{Elevated: cfg.Auth.DeviceAuth.RiskElevatedThreshold, High: cfg.Auth.DeviceAuth.RiskHighThreshold},
+			risk.NoOpLookup{},
+			risk.NoOpEmitter{},
+			risk.NewVelocityDetector(),
+			risk.NewCountryDriftDetector(),
+			risk.NewASNDriftDetector(),
+		)
+		service, err := buildDeviceAuthService(cfg.Auth.DeviceAuth, deviceStore, dpop, riskScorer, obsStore)
 		if err != nil {
 			panic(fmt.Sprintf("device-auth bootstrap failed: %v", err))
 		}
 		if service != nil {
 			app.deviceService = service
 			app.deviceVerifier = service.Verifier()
+			app.dpopVerifier = dpop
+			app.riskScorer = riskScorer
+			app.observationStore = obsStore
 			app.deviceHandler = newDeviceAuthHTTPHandler(service, cfg.Auth.DeviceAuth)
 		}
 	}
@@ -171,7 +188,12 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 		mux.HandleFunc("POST /platform/telemetry/ingest", app.deviceHandler.handleIngestTelemetry)
 		mux.HandleFunc("GET /.well-known/device-jwks.json", app.deviceHandler.handleJWKS)
 	}
-	app.handler = authMiddleware(cfg.Auth, app.deviceVerifier, mux)
+	app.handler = authMiddleware(cfg.Auth, AuthDependencies{
+		DeviceVerifier: app.deviceVerifier,
+		DPoPVerifier:   app.dpopVerifier,
+		RiskScorer:     app.riskScorer,
+		Observations:   app.observationStore,
+	}, mux)
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           app.handler,

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -79,14 +79,31 @@ const (
 )
 
 var (
-	errInvalidHTTPRequest    = errors.New("invalid http request")
-	errProtoJSONBodyTooLarge = errors.New("request JSON body exceeds maximum size")
+	errInvalidHTTPRequest        = errors.New("invalid http request")
+	errProtoJSONBodyTooLarge     = errors.New("request JSON body exceeds maximum size")
+	errDeviceAuthRequiresAPIAuth = errors.New("device-auth requires CEREBRO_API_AUTH_ENABLED=true")
+	errDeviceAuthRequiresStore   = errors.New("device-auth requires a device-auth capable state store")
 )
 
 // New constructs the minimal bootstrap app and registers the Connect handlers.
 func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App {
+	app, _ := NewWithError(cfg, deps, sources)
+	return app
+}
+
+// NewWithError constructs the minimal bootstrap app and returns configuration
+// errors instead of panicking. Production startup should use this form so
+// security-sensitive surfaces fail closed when misconfigured.
+func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) (*App, error) {
 	app := &App{cfg: cfg, deps: deps, sources: sources}
-	if deviceStore := deviceAuthStore(deps.StateStore); deviceStore != nil {
+	if cfg.Auth.DeviceAuth.Enabled && !cfg.Auth.Enabled {
+		return nil, errDeviceAuthRequiresAPIAuth
+	}
+	deviceStore := deviceAuthStore(deps.StateStore)
+	if cfg.Auth.DeviceAuth.Enabled && deviceStore == nil {
+		return nil, errDeviceAuthRequiresStore
+	}
+	if deviceStore != nil {
 		dpop := deviceauth.NewDPoPVerifier(cfg.Auth.DeviceAuth.ClockSkew, cfg.Auth.DeviceAuth.DPoPProofTTL)
 		obsStore := risk.NewInMemoryObservationStore()
 		riskScorer := risk.NewScorer(
@@ -99,7 +116,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 		)
 		service, err := buildDeviceAuthService(cfg.Auth.DeviceAuth, deviceStore, dpop, riskScorer, obsStore)
 		if err != nil {
-			panic(fmt.Sprintf("device-auth bootstrap failed: %v", err))
+			return nil, fmt.Errorf("device-auth bootstrap failed: %w", err)
 		}
 		if service != nil {
 			app.deviceService = service
@@ -199,7 +216,7 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 		Handler:           app.handler,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
-	return app
+	return app, nil
 }
 
 // Handler returns the composed HTTP handler for embedding in tests or another server.

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/writer/cerebro/internal/buildinfo"
 	"github.com/writer/cerebro/internal/claims"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/deviceauth"
 	"github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/graphagent"
 	"github.com/writer/cerebro/internal/graphingest"
@@ -50,12 +51,15 @@ type Dependencies struct {
 
 // App is the minimal Connect/bootstrap composition root for the rewrite skeleton.
 type App struct {
-	cfg     config.Config
-	deps    Dependencies
-	sources *sourcecdk.Registry
-	mux     *http.ServeMux
-	handler http.Handler
-	server  *http.Server
+	cfg            config.Config
+	deps           Dependencies
+	sources        *sourcecdk.Registry
+	mux            *http.ServeMux
+	handler        http.Handler
+	server         *http.Server
+	deviceService  *deviceauth.Service
+	deviceHandler  *deviceAuthHTTPHandler
+	deviceVerifier *deviceauth.JWTVerifier
 }
 
 type bootstrapService struct {
@@ -77,12 +81,23 @@ var (
 
 // New constructs the minimal bootstrap app and registers the Connect handlers.
 func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App {
+	app := &App{cfg: cfg, deps: deps, sources: sources}
+	if deviceStore := deviceAuthStore(deps.StateStore); deviceStore != nil {
+		service, err := buildDeviceAuthService(cfg.Auth.DeviceAuth, deviceStore)
+		if err != nil {
+			panic(fmt.Sprintf("device-auth bootstrap failed: %v", err))
+		}
+		if service != nil {
+			app.deviceService = service
+			app.deviceVerifier = service.Verifier()
+			app.deviceHandler = newDeviceAuthHTTPHandler(service, cfg.Auth.DeviceAuth)
+		}
+	}
 	mux := http.NewServeMux()
 	service := &bootstrapService{cfg: cfg, deps: deps, sources: sources}
 	path, handler := cerebrov1connect.NewBootstrapServiceHandler(service, connect.WithInterceptors(authInterceptor(cfg.Auth)))
 	mux.Handle(path, handler)
-
-	app := &App{cfg: cfg, deps: deps, sources: sources, mux: mux}
+	app.mux = mux
 	mux.HandleFunc("/health", app.handleHealth)
 	mux.HandleFunc("/healthz", app.handleHealth)
 	mux.HandleFunc("GET /openapi.yaml", app.handleOpenAPI)
@@ -148,7 +163,15 @@ func New(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *App
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/finding-evaluation-runs", app.handleListFindingEvaluationRuns)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/finding-rules/evaluate", app.handleEvaluateSourceRuntimeFindingRules)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/findings/evaluate", app.handleEvaluateSourceRuntimeFindings)
-	app.handler = authMiddleware(cfg.Auth, mux)
+	if app.deviceHandler != nil {
+		mux.HandleFunc("POST /platform/devices/enroll", app.deviceHandler.handleEnroll)
+		mux.HandleFunc("POST /platform/devices/token", app.deviceHandler.handleToken)
+		mux.HandleFunc("POST /platform/devices/bootstrap-tokens", app.deviceHandler.handleIssueBootstrapToken)
+		mux.HandleFunc("POST /platform/devices/{deviceID}/revoke", app.deviceHandler.handleRevoke)
+		mux.HandleFunc("POST /platform/telemetry/ingest", app.deviceHandler.handleIngestTelemetry)
+		mux.HandleFunc("GET /.well-known/device-jwks.json", app.deviceHandler.handleJWKS)
+	}
+	app.handler = authMiddleware(cfg.Auth, app.deviceVerifier, mux)
 	app.server = &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           app.handler,
@@ -2905,6 +2928,14 @@ func claimStore(store ports.StateStore) ports.ClaimStore {
 		return nil
 	}
 	return claimStore
+}
+
+func deviceAuthStore(store ports.StateStore) deviceauth.Store {
+	deviceStore, ok := store.(deviceauth.Store)
+	if !ok || isNilInterface(deviceStore) {
+		return nil
+	}
+	return deviceStore
 }
 
 func isNilInterface(value any) bool {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -79,10 +79,11 @@ const (
 )
 
 var (
-	errInvalidHTTPRequest        = errors.New("invalid http request")
-	errProtoJSONBodyTooLarge     = errors.New("request JSON body exceeds maximum size")
-	errDeviceAuthRequiresAPIAuth = errors.New("device-auth requires CEREBRO_API_AUTH_ENABLED=true")
-	errDeviceAuthRequiresStore   = errors.New("device-auth requires a device-auth capable state store")
+	errInvalidHTTPRequest                 = errors.New("invalid http request")
+	errProtoJSONBodyTooLarge              = errors.New("request JSON body exceeds maximum size")
+	errDeviceAuthRequiresAPIAuth          = errors.New("device-auth requires CEREBRO_API_AUTH_ENABLED=true")
+	errDeviceAuthRequiresStore            = errors.New("device-auth requires a device-auth capable state store")
+	errDeviceAuthRequiresSharedDPoPReplay = errors.New("device-auth DPoP replay protection requires shared state for multiple replicas")
 )
 
 // New constructs the minimal bootstrap app and registers the Connect handlers.
@@ -98,6 +99,12 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	app := &App{cfg: cfg, deps: deps, sources: sources}
 	if cfg.Auth.DeviceAuth.Enabled && !cfg.Auth.Enabled {
 		return nil, errDeviceAuthRequiresAPIAuth
+	}
+	if cfg.Auth.DeviceAuth.Enabled && deviceAuthReplicaCount(cfg.Auth.DeviceAuth) > 1 {
+		dpop := deviceauth.NewDPoPVerifier(cfg.Auth.DeviceAuth.ClockSkew, cfg.Auth.DeviceAuth.DPoPProofTTL)
+		if !dpop.ReplayStateShared() {
+			return nil, errDeviceAuthRequiresSharedDPoPReplay
+		}
 	}
 	deviceStore := deviceAuthStore(deps.StateStore)
 	if cfg.Auth.DeviceAuth.Enabled && deviceStore == nil {
@@ -2975,6 +2982,13 @@ func deviceAuthStore(store ports.StateStore) deviceauth.Store {
 		return nil
 	}
 	return deviceStore
+}
+
+func deviceAuthReplicaCount(cfg config.DeviceAuthConfig) int {
+	if cfg.ReplicaCount <= 0 {
+		return 1
+	}
+	return cfg.ReplicaCount
 }
 
 func isNilInterface(value any) bool {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1761,7 +1761,7 @@ func TestAuthenticateRequestPrefersStructuredCredentialMetadata(t *testing.T) {
 			TenantID:       "writer",
 			AllowedTenants: []string{"writer"},
 		}},
-	}, req)
+	}, nil, req)
 	if !ok {
 		t.Fatal("authenticateRequest() ok = false, want true")
 	}

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1747,7 +1747,7 @@ func TestAuthMiddlewareProtectsNonPublicRoutes(t *testing.T) {
 func TestAuthenticateRequestPrefersStructuredCredentialMetadata(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
 	req.Header.Set("Authorization", "Bearer shared-token")
-	principal, _, ok := authenticateRequest(config.AuthConfig{
+	principal, _, _, ok := authenticateRequest(config.AuthConfig{
 		APIKeys: []config.APIKey{{
 			Key:       "shared-token",
 			Principal: "legacy",

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1747,7 +1747,7 @@ func TestAuthMiddlewareProtectsNonPublicRoutes(t *testing.T) {
 func TestAuthenticateRequestPrefersStructuredCredentialMetadata(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
 	req.Header.Set("Authorization", "Bearer shared-token")
-	principal, ok := authenticateRequest(config.AuthConfig{
+	principal, _, ok := authenticateRequest(config.AuthConfig{
 		APIKeys: []config.APIKey{{
 			Key:       "shared-token",
 			Principal: "legacy",

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -98,15 +98,22 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 			finalOutcome, finalDenialReason := accessAuditOutcome(status, outcome, denialReason, auditResult.ConnectCode)
 			emitAccessAuditEvent(r, principal, status, time.Since(started), finalOutcome, finalDenialReason, auditResult)
 		}()
+		if isUnauthenticatedDevicePath(r.URL.Path) {
+			outcome = "allowed"
+			ctx := context.WithValue(r.Context(), accessAuditContextKey{}, auditResult)
+			next.ServeHTTP(recorder, r.WithContext(ctx))
+			return
+		}
 		var deviceJKT string
-		principal, deviceJKT, ok := authenticateRequest(cfg, deps.DeviceVerifier, r)
+		var presentedToken string
+		principal, deviceJKT, presentedToken, ok := authenticateRequest(cfg, deps.DeviceVerifier, r)
 		if !ok {
 			denialReason = "unauthenticated"
 			writeAuthError(recorder, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 		if deviceJKT != "" {
-			if err := verifyDPoPHeader(deps.DPoPVerifier, r, deviceJKT); err != nil {
+			if err := verifyDPoPHeader(deps.DPoPVerifier, r, deviceJKT, presentedToken); err != nil {
 				denialReason = "dpop_invalid"
 				writeAuthError(recorder, http.StatusUnauthorized, "dpop invalid")
 				return
@@ -161,7 +168,7 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 // authenticated device JWT carries a cnf.jkt claim. The proof must be a
 // valid DPoP+JWT, htm/htu must match the request, and the JWK thumbprint
 // must equal the expected jkt that was bound at enroll time.
-func verifyDPoPHeader(verifier *deviceauth.DPoPVerifier, r *http.Request, expectedJKT string) error {
+func verifyDPoPHeader(verifier *deviceauth.DPoPVerifier, r *http.Request, expectedJKT string, accessToken string) error {
 	if verifier == nil {
 		return nil
 	}
@@ -181,7 +188,7 @@ func verifyDPoPHeader(verifier *deviceauth.DPoPVerifier, r *http.Request, expect
 		host = "cerebro"
 	}
 	url := scheme + "://" + host + r.URL.RequestURI()
-	res, err := verifier.Verify(proof, r.Method, url)
+	res, err := verifier.Verify(proof, r.Method, url, accessToken)
 	if err != nil {
 		return err
 	}
@@ -216,8 +223,6 @@ func isPublicPath(path string) bool {
 	switch path {
 	case "/health", "/healthz", "/openapi.yaml":
 		return true
-	case "/platform/devices/enroll", "/platform/devices/token":
-		return true
 	case "/.well-known/device-jwks.json":
 		return true
 	default:
@@ -225,13 +230,22 @@ func isPublicPath(path string) bool {
 	}
 }
 
-func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVerifier, r *http.Request) (authPrincipal, string, bool) {
+func isUnauthenticatedDevicePath(path string) bool {
+	switch path {
+	case "/platform/devices/enroll", "/platform/devices/token":
+		return true
+	default:
+		return false
+	}
+}
+
+func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVerifier, r *http.Request) (authPrincipal, string, string, bool) {
 	token := bearerToken(r.Header.Get("Authorization"))
 	if token == "" {
 		token = strings.TrimSpace(r.Header.Get("X-Cerebro-API-Key"))
 	}
 	if token == "" {
-		return authPrincipal{}, "", false
+		return authPrincipal{}, "", "", false
 	}
 	for _, credential := range cfg.APICredentials {
 		if apiCredentialMatches(token, credential) {
@@ -243,21 +257,21 @@ func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVe
 				AuthMode:       "api_credential",
 				AllowedTenants: credential.AllowedTenants,
 				Scopes:         credential.Scopes,
-			}, "", true
+			}, "", token, true
 		}
 	}
 	for _, key := range cfg.APIKeys {
 		if constantTimeEqual(token, key.Key) {
-			return authPrincipal{Name: key.Principal, TenantID: key.TenantID, AuthMode: "api_key"}, "", true
+			return authPrincipal{Name: key.Principal, TenantID: key.TenantID, AuthMode: "api_key"}, "", token, true
 		}
 	}
 	if principal, ok := authenticateCapabilityToken(cfg, token, time.Now()); ok {
-		return principal, "", true
+		return principal, "", token, true
 	}
 	if principal, jkt, ok := authenticateDeviceToken(deviceVerifier, token); ok {
-		return principal, jkt, true
+		return principal, jkt, token, true
 	}
-	return authPrincipal{}, "", false
+	return authPrincipal{}, "", "", false
 }
 
 // authenticateDeviceToken verifies an EdDSA device JWT issued by the

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -115,7 +115,7 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 		if deviceJKT != "" {
 			if err := verifyDPoPHeader(deps.DPoPVerifier, r, deviceJKT, presentedToken); err != nil {
 				denialReason = "dpop_invalid"
-				writeAuthError(recorder, http.StatusUnauthorized, "dpop invalid")
+				writeDeviceAuthServiceError(recorder, err)
 				return
 			}
 		}

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -21,6 +21,7 @@ import (
 	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/deviceauth"
+	"github.com/writer/cerebro/internal/deviceauth/risk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/telemetry"
 )
@@ -48,15 +49,36 @@ type authPrincipal struct {
 	Capability     bool
 	DeviceID       string
 	HardwareUUID   string
+	// AssuranceLevel is "hardware" or "software" for device principals.
+	AssuranceLevel string
+	// RiskScore / RiskLevel are populated by the risk pipeline during
+	// authentication for device principals. Both are zero / "" for non-
+	// device principals.
+	RiskScore int
+	RiskLevel string
 }
 
 type authContext struct {
 	cfg            config.AuthConfig
 	principal      authPrincipal
 	deviceVerifier *deviceauth.JWTVerifier
+	dpopVerifier   *deviceauth.DPoPVerifier
+	riskScorer     *risk.Scorer
+	observations   risk.ObservationStore
 }
 
-func authMiddleware(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVerifier, next http.Handler) http.Handler {
+// AuthDependencies carries the optional verifiers/scorers the auth pipeline
+// uses for device JWT authentication. All fields are optional; the
+// middleware degrades gracefully when nil (DPoP not enforced; risk scoring
+// disabled).
+type AuthDependencies struct {
+	DeviceVerifier *deviceauth.JWTVerifier
+	DPoPVerifier   *deviceauth.DPoPVerifier
+	RiskScorer     *risk.Scorer
+	Observations   risk.ObservationStore
+}
+
+func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Handler) http.Handler {
 	if !cfg.Enabled {
 		return next
 	}
@@ -76,18 +98,53 @@ func authMiddleware(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVerifie
 			finalOutcome, finalDenialReason := accessAuditOutcome(status, outcome, denialReason, auditResult.ConnectCode)
 			emitAccessAuditEvent(r, principal, status, time.Since(started), finalOutcome, finalDenialReason, auditResult)
 		}()
-		principal, ok := authenticateRequest(cfg, deviceVerifier, r)
+		var deviceJKT string
+		principal, deviceJKT, ok := authenticateRequest(cfg, deps.DeviceVerifier, r)
 		if !ok {
 			denialReason = "unauthenticated"
 			writeAuthError(recorder, http.StatusUnauthorized, "unauthorized")
 			return
+		}
+		if deviceJKT != "" {
+			if err := verifyDPoPHeader(deps.DPoPVerifier, r, deviceJKT); err != nil {
+				denialReason = "dpop_invalid"
+				writeAuthError(recorder, http.StatusUnauthorized, "dpop invalid")
+				return
+			}
+		}
+		if principal.AuthMode == "device_jwt" && deps.RiskScorer != nil {
+			scoreSig := risk.Signal{
+				DeviceID:  principal.DeviceID,
+				TenantID:  principal.TenantID,
+				RemoteIP:  net.ParseIP(accessAuditRemoteIP(r.RemoteAddr)),
+				UserAgent: r.Header.Get("User-Agent"),
+				Method:    r.Method,
+				Path:      r.URL.Path,
+				Now:       time.Now(),
+			}
+			if deps.Observations != nil {
+				if obs, found := deps.Observations.Get(r.Context(), principal.DeviceID); found {
+					scoreSig.PriorObservation = obs
+				}
+			}
+			decision := deps.RiskScorer.Score(r.Context(), scoreSig)
+			principal.Scopes = decision.FilterScopes(principal.Scopes)
+			principal.RiskScore = decision.Score
+			principal.RiskLevel = decision.Level
 		}
 		if tenantID := auditResult.RequestedTenantID; tenantID != "" && !tenantAllowed(cfg, principal, tenantID) {
 			denialReason = "tenant_forbidden"
 			writeAuthError(recorder, http.StatusForbidden, "tenant forbidden")
 			return
 		}
-		auth := authContext{cfg: cfg, principal: principal, deviceVerifier: deviceVerifier}
+		auth := authContext{
+			cfg:            cfg,
+			principal:      principal,
+			deviceVerifier: deps.DeviceVerifier,
+			dpopVerifier:   deps.DPoPVerifier,
+			riskScorer:     deps.RiskScorer,
+			observations:   deps.Observations,
+		}
 		if err := authorizeHTTPRequestScope(auth, r); err != nil {
 			denialReason = "scope_forbidden"
 			writeAuthError(recorder, http.StatusForbidden, "scope forbidden")
@@ -98,6 +155,40 @@ func authMiddleware(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVerifie
 		ctx = context.WithValue(ctx, accessAuditContextKey{}, auditResult)
 		next.ServeHTTP(recorder, r.WithContext(ctx))
 	})
+}
+
+// verifyDPoPHeader inspects the DPoP request header (RFC 9449 §4) when the
+// authenticated device JWT carries a cnf.jkt claim. The proof must be a
+// valid DPoP+JWT, htm/htu must match the request, and the JWK thumbprint
+// must equal the expected jkt that was bound at enroll time.
+func verifyDPoPHeader(verifier *deviceauth.DPoPVerifier, r *http.Request, expectedJKT string) error {
+	if verifier == nil {
+		return nil
+	}
+	proof := strings.TrimSpace(r.Header.Get("DPoP"))
+	if proof == "" {
+		return deviceauth.ErrDPoPMissing
+	}
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+	if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); forwarded != "" {
+		scheme = forwarded
+	}
+	host := strings.TrimSpace(r.Host)
+	if host == "" {
+		host = "cerebro"
+	}
+	url := scheme + "://" + host + r.URL.RequestURI()
+	res, err := verifier.Verify(proof, r.Method, url)
+	if err != nil {
+		return err
+	}
+	if res.JKT != expectedJKT {
+		return deviceauth.ErrDPoPJKTMismatch
+	}
+	return nil
 }
 
 func authInterceptor(cfg config.AuthConfig) connect.Interceptor {
@@ -134,13 +225,13 @@ func isPublicPath(path string) bool {
 	}
 }
 
-func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVerifier, r *http.Request) (authPrincipal, bool) {
+func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVerifier, r *http.Request) (authPrincipal, string, bool) {
 	token := bearerToken(r.Header.Get("Authorization"))
 	if token == "" {
 		token = strings.TrimSpace(r.Header.Get("X-Cerebro-API-Key"))
 	}
 	if token == "" {
-		return authPrincipal{}, false
+		return authPrincipal{}, "", false
 	}
 	for _, credential := range cfg.APICredentials {
 		if apiCredentialMatches(token, credential) {
@@ -152,43 +243,44 @@ func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVe
 				AuthMode:       "api_credential",
 				AllowedTenants: credential.AllowedTenants,
 				Scopes:         credential.Scopes,
-			}, true
+			}, "", true
 		}
 	}
 	for _, key := range cfg.APIKeys {
 		if constantTimeEqual(token, key.Key) {
-			return authPrincipal{Name: key.Principal, TenantID: key.TenantID, AuthMode: "api_key"}, true
+			return authPrincipal{Name: key.Principal, TenantID: key.TenantID, AuthMode: "api_key"}, "", true
 		}
 	}
 	if principal, ok := authenticateCapabilityToken(cfg, token, time.Now()); ok {
-		return principal, true
+		return principal, "", true
 	}
-	if principal, ok := authenticateDeviceToken(deviceVerifier, token); ok {
-		return principal, true
+	if principal, jkt, ok := authenticateDeviceToken(deviceVerifier, token); ok {
+		return principal, jkt, true
 	}
-	return authPrincipal{}, false
+	return authPrincipal{}, "", false
 }
 
 // authenticateDeviceToken verifies an EdDSA device JWT issued by the
-// internal/deviceauth Service. It is the third bearer-token path (after API
-// keys and capability tokens) and is only attempted if a verifier was wired
-// at bootstrap time.
-func authenticateDeviceToken(verifier *deviceauth.JWTVerifier, token string) (authPrincipal, bool) {
+// internal/deviceauth Service. It returns the principal, the cnf.jkt
+// thumbprint when the token was minted DPoP-bound (empty otherwise), and
+// a success flag.
+func authenticateDeviceToken(verifier *deviceauth.JWTVerifier, token string) (authPrincipal, string, bool) {
 	if verifier == nil {
-		return authPrincipal{}, false
+		return authPrincipal{}, "", false
 	}
 	verified, err := verifier.Verify(token)
 	if err != nil {
-		return authPrincipal{}, false
+		return authPrincipal{}, "", false
 	}
 	return authPrincipal{
-		Name:         "device:" + verified.DeviceID,
-		TenantID:     verified.TenantID,
-		AuthMode:     "device_jwt",
-		Scopes:       verified.Scopes,
-		DeviceID:     verified.DeviceID,
-		HardwareUUID: verified.HardwareUUID,
-	}, true
+		Name:           "device:" + verified.DeviceID,
+		TenantID:       verified.TenantID,
+		AuthMode:       "device_jwt",
+		Scopes:         verified.Scopes,
+		DeviceID:       verified.DeviceID,
+		HardwareUUID:   verified.HardwareUUID,
+		AssuranceLevel: verified.AssuranceLevel,
+	}, verified.DPoPJKT, true
 }
 
 func apiCredentialMatches(token string, credential config.APICredential) bool {
@@ -844,6 +936,16 @@ func emitAccessAuditEvent(r *http.Request, principal authPrincipal, status int, 
 	}
 	if procedure := accessAuditConnectProcedure(r.URL.Path); procedure != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "connect_procedure", Value: procedure})
+	}
+	if principal.DeviceID != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "device_id", Value: principal.DeviceID})
+	}
+	if principal.AssuranceLevel != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "assurance_level", Value: principal.AssuranceLevel})
+	}
+	if principal.RiskLevel != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "risk_level", Value: principal.RiskLevel})
+		attrs = attrs.WithField(telemetry.Field{Key: "risk_score", Value: principal.RiskScore})
 	}
 	if auditResult.ConnectCode != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "connect_code", Value: auditResult.ConnectCode})

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/deviceauth"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/telemetry"
 )
@@ -45,14 +46,17 @@ type authPrincipal struct {
 	Scopes         []string
 	Groups         []string
 	Capability     bool
+	DeviceID       string
+	HardwareUUID   string
 }
 
 type authContext struct {
-	cfg       config.AuthConfig
-	principal authPrincipal
+	cfg            config.AuthConfig
+	principal      authPrincipal
+	deviceVerifier *deviceauth.JWTVerifier
 }
 
-func authMiddleware(cfg config.AuthConfig, next http.Handler) http.Handler {
+func authMiddleware(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVerifier, next http.Handler) http.Handler {
 	if !cfg.Enabled {
 		return next
 	}
@@ -72,7 +76,7 @@ func authMiddleware(cfg config.AuthConfig, next http.Handler) http.Handler {
 			finalOutcome, finalDenialReason := accessAuditOutcome(status, outcome, denialReason, auditResult.ConnectCode)
 			emitAccessAuditEvent(r, principal, status, time.Since(started), finalOutcome, finalDenialReason, auditResult)
 		}()
-		principal, ok := authenticateRequest(cfg, r)
+		principal, ok := authenticateRequest(cfg, deviceVerifier, r)
 		if !ok {
 			denialReason = "unauthenticated"
 			writeAuthError(recorder, http.StatusUnauthorized, "unauthorized")
@@ -83,7 +87,7 @@ func authMiddleware(cfg config.AuthConfig, next http.Handler) http.Handler {
 			writeAuthError(recorder, http.StatusForbidden, "tenant forbidden")
 			return
 		}
-		auth := authContext{cfg: cfg, principal: principal}
+		auth := authContext{cfg: cfg, principal: principal, deviceVerifier: deviceVerifier}
 		if err := authorizeHTTPRequestScope(auth, r); err != nil {
 			denialReason = "scope_forbidden"
 			writeAuthError(recorder, http.StatusForbidden, "scope forbidden")
@@ -121,12 +125,16 @@ func isPublicPath(path string) bool {
 	switch path {
 	case "/health", "/healthz", "/openapi.yaml":
 		return true
+	case "/platform/devices/enroll", "/platform/devices/token":
+		return true
+	case "/.well-known/device-jwks.json":
+		return true
 	default:
 		return false
 	}
 }
 
-func authenticateRequest(cfg config.AuthConfig, r *http.Request) (authPrincipal, bool) {
+func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVerifier, r *http.Request) (authPrincipal, bool) {
 	token := bearerToken(r.Header.Get("Authorization"))
 	if token == "" {
 		token = strings.TrimSpace(r.Header.Get("X-Cerebro-API-Key"))
@@ -155,7 +163,32 @@ func authenticateRequest(cfg config.AuthConfig, r *http.Request) (authPrincipal,
 	if principal, ok := authenticateCapabilityToken(cfg, token, time.Now()); ok {
 		return principal, true
 	}
+	if principal, ok := authenticateDeviceToken(deviceVerifier, token); ok {
+		return principal, true
+	}
 	return authPrincipal{}, false
+}
+
+// authenticateDeviceToken verifies an EdDSA device JWT issued by the
+// internal/deviceauth Service. It is the third bearer-token path (after API
+// keys and capability tokens) and is only attempted if a verifier was wired
+// at bootstrap time.
+func authenticateDeviceToken(verifier *deviceauth.JWTVerifier, token string) (authPrincipal, bool) {
+	if verifier == nil {
+		return authPrincipal{}, false
+	}
+	verified, err := verifier.Verify(token)
+	if err != nil {
+		return authPrincipal{}, false
+	}
+	return authPrincipal{
+		Name:         "device:" + verified.DeviceID,
+		TenantID:     verified.TenantID,
+		AuthMode:     "device_jwt",
+		Scopes:       verified.Scopes,
+		DeviceID:     verified.DeviceID,
+		HardwareUUID: verified.HardwareUUID,
+	}, true
 }
 
 func apiCredentialMatches(token string, credential config.APICredential) bool {
@@ -351,6 +384,29 @@ func authorizeTenantID(ctx context.Context, tenantID string) error {
 
 const scopeCosmoSecurityRead = "cerebro.cosmo.security.read"
 
+func scopeForDeviceRoute(method string, path string) string {
+	switch {
+	case method == http.MethodPost && path == "/platform/devices/enroll":
+		return deviceauth.ScopeDevicesEnroll
+	case method == http.MethodPost && path == "/platform/devices/token":
+		return deviceauth.ScopeDevicesToken
+	case method == http.MethodPost && path == "/platform/devices/bootstrap-tokens":
+		return deviceauth.ScopeDevicesBootstrapWrite
+	case method == http.MethodPost && strings.HasPrefix(path, "/platform/devices/") && strings.HasSuffix(path, "/revoke"):
+		return deviceauth.ScopeDevicesRevoke
+	case method == http.MethodGet && path == "/platform/devices":
+		return deviceauth.ScopeDevicesRead
+	case method == http.MethodGet && strings.HasPrefix(path, "/platform/devices/") && !strings.HasSuffix(path, "/revoke"):
+		return deviceauth.ScopeDevicesRead
+	case method == http.MethodPost && path == "/platform/telemetry/ingest":
+		return deviceauth.ScopeTelemetryIngest
+	case method == http.MethodGet && path == "/.well-known/device-jwks.json":
+		return ""
+	default:
+		return ""
+	}
+}
+
 func authorizeHTTPRequestScope(auth authContext, r *http.Request) error {
 	if !principalScopeRestricted(auth.principal) || isConnectProcedurePath(r.URL.Path) {
 		return nil
@@ -389,6 +445,9 @@ func scopeForHTTPRequest(r *http.Request) string {
 	path := strings.TrimSpace(r.URL.Path)
 	if r.Method == http.MethodPost && path == "/grc/ask" {
 		return scopeCosmoSecurityRead
+	}
+	if scope := scopeForDeviceRoute(r.Method, path); scope != "" {
+		return scope
 	}
 	if r.Method != http.MethodGet {
 		return ""
@@ -1006,6 +1065,10 @@ func accessAuditConnectFamily(procedure string) string {
 func accessAuditRouteFamily(route string) string {
 	route = strings.TrimSpace(route)
 	switch {
+	case strings.Contains(route, "/platform/devices"), strings.Contains(route, "/.well-known/device-jwks"):
+		return "device"
+	case strings.Contains(route, "/platform/telemetry"):
+		return "telemetry"
 	case strings.Contains(route, "/source-runtimes"):
 		return "source_runtime"
 	case strings.Contains(route, "/sources"):
@@ -1223,7 +1286,13 @@ func isKnownStaticAccessPath(path string) bool {
 		"/platform/graph/ingest-health",
 		"/graph/ingest-health",
 		"/platform/graph/ingest-runs",
-		"/graph/ingest-runs":
+		"/graph/ingest-runs",
+		"/platform/devices",
+		"/platform/devices/enroll",
+		"/platform/devices/token",
+		"/platform/devices/bootstrap-tokens",
+		"/platform/telemetry/ingest",
+		"/.well-known/device-jwks.json":
 		return true
 	default:
 		return false

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/deviceauth"
+	"github.com/writer/cerebro/internal/deviceauth/attestation"
+	"github.com/writer/cerebro/internal/deviceauth/risk"
 )
 
 // buildDeviceAuthService wires the deviceauth.Service against the configured
 // store and signing-key material. It returns nil if the surface is disabled
 // or the runtime dependencies are missing.
-func buildDeviceAuthService(cfg config.DeviceAuthConfig, store deviceauth.Store) (*deviceauth.Service, error) {
+func buildDeviceAuthService(cfg config.DeviceAuthConfig, store deviceauth.Store, dpop *deviceauth.DPoPVerifier, scorer *risk.Scorer, observations risk.ObservationStore) (*deviceauth.Service, error) {
 	if !cfg.Enabled {
 		return nil, nil
 	}
@@ -74,6 +76,10 @@ func buildDeviceAuthService(cfg config.DeviceAuthConfig, store deviceauth.Store)
 	if err != nil {
 		return nil, fmt.Errorf("device-auth verifier: %w", err)
 	}
+	registry, err := buildAttestationRegistry(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("device-auth attestation: %w", err)
+	}
 	return deviceauth.NewService(deviceauth.ServiceConfig{
 		Issuer:            cfg.Issuer,
 		Audience:          cfg.Audience,
@@ -82,7 +88,31 @@ func buildDeviceAuthService(cfg config.DeviceAuthConfig, store deviceauth.Store)
 		BootstrapTokenTTL: cfg.BootstrapTokenTTL,
 		IdempotencyTTL:    cfg.IdempotencyTTL,
 		ClockSkew:         cfg.ClockSkew,
+		Attestations:      registry,
+		DPoP:              dpop,
+		Risk:              scorer,
+		Observations:      observations,
 	}, store, issuer, verifier, keyset)
+}
+
+// buildAttestationRegistry constructs the attestation registry from
+// configuration. When the operator has not configured Apple or TPM
+// verifiers, the registry runs in non-required mode -- enroll requests
+// without an attestation statement get a software-assurance result, and
+// the device gets a software-only access token (no DPoP binding).
+func buildAttestationRegistry(cfg config.DeviceAuthConfig) (*attestation.Registry, error) {
+	verifiers := make([]attestation.Verifier, 0, 2)
+	if cfg.Attestation.Apple.TeamID != "" && len(cfg.Attestation.Apple.BundleIDs) > 0 {
+		v, err := attestation.NewAppleAppAttestVerifier(attestation.AppleConfig{
+			TeamID:    cfg.Attestation.Apple.TeamID,
+			BundleIDs: cfg.Attestation.Apple.BundleIDs,
+		})
+		if err != nil {
+			return nil, err
+		}
+		verifiers = append(verifiers, v)
+	}
+	return attestation.NewRegistry(cfg.Attestation.Required, verifiers...), nil
 }
 
 func orderCurrentFirst(keys []deviceauth.SigningKey, currentKID string) []deviceauth.SigningKey {
@@ -121,16 +151,24 @@ type enrollRequestBody struct {
 	OSType         string `json:"os_type,omitempty"`
 	OSVersion      string `json:"os_version,omitempty"`
 	AgentVersion   string `json:"agent_version,omitempty"`
+	// Attestation is the base64-encoded device-bound proof: an Apple App
+	// Attest CBOR attestationObject on macOS or a TPM 2.0 quote bundle on
+	// Windows. Required when CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED=true.
+	Attestation string `json:"attestation,omitempty"`
 }
 
 type tokenResponseBody struct {
-	AccessToken    string   `json:"access_token"`
-	TokenType      string   `json:"token_type"`
-	ExpiresIn      int64    `json:"expires_in"`
-	RefreshToken   string   `json:"refresh_token,omitempty"`
-	RefreshExpires string   `json:"refresh_expires_at,omitempty"`
-	Scopes         []string `json:"scopes"`
-	DeviceID       string   `json:"device_id,omitempty"`
+	AccessToken       string   `json:"access_token"`
+	TokenType         string   `json:"token_type"`
+	ExpiresIn         int64    `json:"expires_in"`
+	RefreshToken      string   `json:"refresh_token,omitempty"`
+	RefreshExpires    string   `json:"refresh_expires_at,omitempty"`
+	Scopes            []string `json:"scopes"`
+	DeviceID          string   `json:"device_id,omitempty"`
+	AssuranceLevel    string   `json:"assurance_level,omitempty"`
+	AttestationVendor string   `json:"attestation_vendor,omitempty"`
+	RiskScore         int      `json:"risk_score,omitempty"`
+	RiskLevel         string   `json:"risk_level,omitempty"`
 }
 
 type tokenRequestBody struct {
@@ -178,19 +216,23 @@ func (h *deviceAuthHTTPHandler) handleEnroll(w http.ResponseWriter, r *http.Requ
 		OSType:         body.OSType,
 		OSVersion:      body.OSVersion,
 		AgentVersion:   body.AgentVersion,
+		Attestation:    body.Attestation,
+		RemoteIP:       net.ParseIP(clientIP),
 	})
 	if err != nil {
 		writeDeviceAuthServiceError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, tokenResponseBody{
-		AccessToken:    response.AccessToken,
-		TokenType:      response.TokenType,
-		ExpiresIn:      int64(time.Until(response.AccessExpires).Seconds()),
-		RefreshToken:   response.RefreshToken,
-		RefreshExpires: response.RefreshExpires.UTC().Format(time.RFC3339),
-		Scopes:         response.Scopes,
-		DeviceID:       response.DeviceID,
+		AccessToken:       response.AccessToken,
+		TokenType:         response.TokenType,
+		ExpiresIn:         int64(time.Until(response.AccessExpires).Seconds()),
+		RefreshToken:      response.RefreshToken,
+		RefreshExpires:    response.RefreshExpires.UTC().Format(time.RFC3339),
+		Scopes:            response.Scopes,
+		DeviceID:          response.DeviceID,
+		AssuranceLevel:    response.AssuranceLevel,
+		AttestationVendor: response.AttestationVendor,
 	})
 }
 
@@ -217,9 +259,26 @@ func (h *deviceAuthHTTPHandler) handleToken(w http.ResponseWriter, r *http.Reque
 		writeDeviceAuthError(w, http.StatusTooManyRequests, "rate_limited", "too many token requests")
 		return
 	}
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+	if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); forwarded != "" {
+		scheme = forwarded
+	}
+	host := r.Host
+	if host == "" {
+		host = "cerebro"
+	}
+	url := scheme + "://" + host + r.URL.RequestURI()
+	dpopProof := strings.TrimSpace(r.Header.Get("DPoP"))
 	response, err := h.service.IssueToken(r.Context(), deviceauth.TokenRequest{
 		GrantType:    body.GrantType,
 		RefreshToken: body.RefreshToken,
+		DPoPProof:    dpopProof,
+		HTTPMethod:   r.Method,
+		HTTPURL:      url,
+		RemoteIP:     net.ParseIP(remoteIPForRateLimit(r)),
 	})
 	if err != nil {
 		writeDeviceAuthServiceError(w, err)
@@ -232,6 +291,8 @@ func (h *deviceAuthHTTPHandler) handleToken(w http.ResponseWriter, r *http.Reque
 		RefreshToken:   response.RefreshToken,
 		RefreshExpires: response.RefreshExpires.UTC().Format(time.RFC3339),
 		Scopes:         response.Scopes,
+		RiskScore:      response.RiskScore,
+		RiskLevel:      response.RiskLevel,
 	})
 }
 
@@ -387,6 +448,20 @@ func writeDeviceAuthServiceError(w http.ResponseWriter, err error) {
 		writeDeviceAuthError(w, http.StatusForbidden, "device_inactive", err.Error())
 	case errors.Is(err, deviceauth.ErrIdempotencyConflict):
 		writeDeviceAuthError(w, http.StatusConflict, "idempotency_conflict", err.Error())
+	case errors.Is(err, deviceauth.ErrDPoPMissing):
+		writeDeviceAuthError(w, http.StatusUnauthorized, "dpop_required", err.Error())
+	case errors.Is(err, deviceauth.ErrDPoPMalformed),
+		errors.Is(err, deviceauth.ErrDPoPInvalidHeader),
+		errors.Is(err, deviceauth.ErrDPoPInvalidJWK):
+		writeDeviceAuthError(w, http.StatusUnauthorized, "dpop_malformed", err.Error())
+	case errors.Is(err, deviceauth.ErrDPoPInvalidSignature),
+		errors.Is(err, deviceauth.ErrDPoPMismatch),
+		errors.Is(err, deviceauth.ErrDPoPExpired),
+		errors.Is(err, deviceauth.ErrDPoPFromFuture),
+		errors.Is(err, deviceauth.ErrDPoPMissingJTI),
+		errors.Is(err, deviceauth.ErrDPoPReplay),
+		errors.Is(err, deviceauth.ErrDPoPJKTMismatch):
+		writeDeviceAuthError(w, http.StatusUnauthorized, "dpop_invalid", err.Error())
 	default:
 		writeDeviceAuthError(w, http.StatusInternalServerError, "internal_error", "device-auth internal error")
 	}

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -112,6 +112,9 @@ func buildAttestationRegistry(cfg config.DeviceAuthConfig) (*attestation.Registr
 		}
 		verifiers = append(verifiers, v)
 	}
+	if cfg.Attestation.Required && len(verifiers) == 0 {
+		return nil, errors.New("required attestation has no configured verifier backend")
+	}
 	return attestation.NewRegistry(cfg.Attestation.Required, verifiers...), nil
 }
 
@@ -443,6 +446,16 @@ func writeDeviceAuthServiceError(w http.ResponseWriter, err error) {
 		writeDeviceAuthError(w, http.StatusForbidden, "device_inactive", err.Error())
 	case errors.Is(err, deviceauth.ErrIdempotencyConflict):
 		writeDeviceAuthError(w, http.StatusConflict, "idempotency_conflict", err.Error())
+	case errors.Is(err, attestation.ErrAttestationRequired):
+		writeDeviceAuthError(w, http.StatusBadRequest, "attestation_required", err.Error())
+	case errors.Is(err, attestation.ErrUnsupportedFormat):
+		writeDeviceAuthError(w, http.StatusBadRequest, "unsupported_attestation", err.Error())
+	case errors.Is(err, attestation.ErrInvalidStatement),
+		errors.Is(err, attestation.ErrChainInvalid),
+		errors.Is(err, attestation.ErrNonceMismatch),
+		errors.Is(err, attestation.ErrKeyIDMismatch),
+		errors.Is(err, attestation.ErrUnsupportedVendor):
+		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_attestation", err.Error())
 	case errors.Is(err, deviceauth.ErrDPoPMissing):
 		writeDeviceAuthError(w, http.StatusUnauthorized, "dpop_required", err.Error())
 	case errors.Is(err, deviceauth.ErrDPoPMalformed),

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -49,7 +49,7 @@ func buildDeviceAuthService(cfg config.DeviceAuthConfig, store deviceauth.Store,
 	}
 	signingKeys = orderCurrentFirst(signingKeys, currentKID)
 	if len(signingKeys[0].Private) != ed25519.PrivateKeySize {
-		return nil, fmt.Errorf("device-auth current kid %q is missing a private key", currentKID)
+		return nil, fmt.Errorf("device-auth current kid %q is missing private_pem; external/KMS signing is not supported by this bootstrap path", currentKID)
 	}
 	signer, err := deviceauth.NewLocalSigner(signingKeys)
 	if err != nil {
@@ -246,14 +246,9 @@ func (h *deviceAuthHTTPHandler) handleToken(w http.ResponseWriter, r *http.Reque
 		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
-	limitKey := strings.TrimSpace(body.RefreshToken)
-	if limitKey == "" {
-		limitKey = remoteIPForRateLimit(r)
-	} else {
-		// Use a hash so plaintext refresh tokens are not retained in the
-		// rate-limiter map.
-		hash := deviceauth.HashToken(limitKey)
-		limitKey = "rt:" + base64URLEncode(hash[:8])
+	limitKey := remoteIPForRateLimit(r)
+	if deviceKey, err := h.service.RefreshTokenRateLimitKey(r.Context(), body.RefreshToken); err == nil && deviceKey != "" {
+		limitKey = deviceKey
 	}
 	if !h.tokenLimit.Allow(limitKey) {
 		writeDeviceAuthError(w, http.StatusTooManyRequests, "rate_limited", "too many token requests")
@@ -471,15 +466,6 @@ func remoteIPForRateLimit(r *http.Request) string {
 	if r == nil {
 		return "unknown"
 	}
-	if ip := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); ip != "" {
-		if comma := strings.IndexByte(ip, ','); comma >= 0 {
-			ip = ip[:comma]
-		}
-		ip = strings.TrimSpace(ip)
-		if ip != "" {
-			return ip
-		}
-	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return strings.TrimSpace(r.RemoteAddr)
@@ -496,13 +482,4 @@ func principalNameFromContext(r *http.Request) string {
 		return ""
 	}
 	return strings.TrimSpace(auth.principal.Name)
-}
-
-func base64URLEncode(b []byte) string {
-	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
-	out := make([]byte, 0, len(b)*2)
-	for _, by := range b {
-		out = append(out, alphabet[by>>4], alphabet[by&0x0F])
-	}
-	return string(out)
 }

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -1,0 +1,433 @@
+package bootstrap
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/deviceauth"
+)
+
+// buildDeviceAuthService wires the deviceauth.Service against the configured
+// store and signing-key material. It returns nil if the surface is disabled
+// or the runtime dependencies are missing.
+func buildDeviceAuthService(cfg config.DeviceAuthConfig, store deviceauth.Store) (*deviceauth.Service, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	if store == nil {
+		return nil, errors.New("device-auth requires a configured state store")
+	}
+	signingKeys := make([]deviceauth.SigningKey, 0, len(cfg.SigningKeys))
+	for _, key := range cfg.SigningKeys {
+		pub, err := deviceauth.DecodePEMPublicKey(key.PublicPEM)
+		if err != nil {
+			return nil, fmt.Errorf("device-auth public key %q: %w", key.KID, err)
+		}
+		entry := deviceauth.SigningKey{KID: key.KID, Public: pub}
+		if key.PrivatePEM != "" {
+			priv, err := deviceauth.DecodePEMPrivateKey(key.PrivatePEM)
+			if err != nil {
+				return nil, fmt.Errorf("device-auth private key %q: %w", key.KID, err)
+			}
+			entry.Private = priv
+		}
+		signingKeys = append(signingKeys, entry)
+	}
+	currentKID := strings.TrimSpace(cfg.CurrentKID)
+	if currentKID == "" {
+		return nil, errors.New("device-auth current kid is required")
+	}
+	signingKeys = orderCurrentFirst(signingKeys, currentKID)
+	if len(signingKeys[0].Private) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("device-auth current kid %q is missing a private key", currentKID)
+	}
+	signer, err := deviceauth.NewLocalSigner(signingKeys)
+	if err != nil {
+		return nil, fmt.Errorf("device-auth signer: %w", err)
+	}
+	verifyKeys := make([]deviceauth.SigningKey, 0, len(signingKeys))
+	for _, key := range signingKeys {
+		verifyKeys = append(verifyKeys, deviceauth.SigningKey{KID: key.KID, Public: key.Public})
+	}
+	keyset := &deviceauth.KeySet{Keys: verifyKeys}
+	issuer, err := deviceauth.NewJWTIssuer(deviceauth.IssuerConfig{
+		Issuer:    cfg.Issuer,
+		Audience:  cfg.Audience,
+		AccessTTL: cfg.AccessTTL,
+	}, signer)
+	if err != nil {
+		return nil, fmt.Errorf("device-auth issuer: %w", err)
+	}
+	verifier, err := deviceauth.NewJWTVerifier(deviceauth.VerifierConfig{
+		Issuer:    cfg.Issuer,
+		Audience:  cfg.Audience,
+		ClockSkew: cfg.ClockSkew,
+	}, keyset)
+	if err != nil {
+		return nil, fmt.Errorf("device-auth verifier: %w", err)
+	}
+	return deviceauth.NewService(deviceauth.ServiceConfig{
+		Issuer:            cfg.Issuer,
+		Audience:          cfg.Audience,
+		AccessTTL:         cfg.AccessTTL,
+		RefreshTTL:        cfg.RefreshTTL,
+		BootstrapTokenTTL: cfg.BootstrapTokenTTL,
+		IdempotencyTTL:    cfg.IdempotencyTTL,
+		ClockSkew:         cfg.ClockSkew,
+	}, store, issuer, verifier, keyset)
+}
+
+func orderCurrentFirst(keys []deviceauth.SigningKey, currentKID string) []deviceauth.SigningKey {
+	out := make([]deviceauth.SigningKey, 0, len(keys))
+	for _, key := range keys {
+		if key.KID == currentKID {
+			out = append([]deviceauth.SigningKey{key}, out...)
+		} else {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+type deviceAuthHTTPHandler struct {
+	service     *deviceauth.Service
+	enrollLimit *deviceauth.TokenBucket
+	tokenLimit  *deviceauth.TokenBucket
+	now         func() time.Time
+}
+
+func newDeviceAuthHTTPHandler(service *deviceauth.Service, cfg config.DeviceAuthConfig) *deviceAuthHTTPHandler {
+	return &deviceAuthHTTPHandler{
+		service:     service,
+		enrollLimit: deviceauth.NewTokenBucket(cfg.EnrollPerIPRatePerSecond, cfg.EnrollPerIPBurst),
+		tokenLimit:  deviceauth.NewTokenBucket(cfg.TokenPerDeviceRatePerSecond, cfg.TokenPerDeviceBurst),
+		now:         time.Now,
+	}
+}
+
+type enrollRequestBody struct {
+	BootstrapToken string `json:"bootstrap_token"`
+	HardwareUUID   string `json:"hardware_uuid"`
+	SerialNumber   string `json:"serial_number,omitempty"`
+	Hostname       string `json:"hostname,omitempty"`
+	OSType         string `json:"os_type,omitempty"`
+	OSVersion      string `json:"os_version,omitempty"`
+	AgentVersion   string `json:"agent_version,omitempty"`
+}
+
+type tokenResponseBody struct {
+	AccessToken    string   `json:"access_token"`
+	TokenType      string   `json:"token_type"`
+	ExpiresIn      int64    `json:"expires_in"`
+	RefreshToken   string   `json:"refresh_token,omitempty"`
+	RefreshExpires string   `json:"refresh_expires_at,omitempty"`
+	Scopes         []string `json:"scopes"`
+	DeviceID       string   `json:"device_id,omitempty"`
+}
+
+type tokenRequestBody struct {
+	GrantType    string `json:"grant_type"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+type bootstrapTokenRequestBody struct {
+	HardwareUUID string   `json:"hardware_uuid"`
+	TenantID     string   `json:"tenant_id,omitempty"`
+	Scopes       []string `json:"scopes,omitempty"`
+	TTLSeconds   int64    `json:"ttl_seconds,omitempty"`
+}
+
+type bootstrapTokenResponseBody struct {
+	TokenID   string `json:"token_id"`
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+type revokeRequestBody struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+func (h *deviceAuthHTTPHandler) handleEnroll(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.service == nil {
+		writeDeviceAuthError(w, http.StatusServiceUnavailable, "device_auth_disabled", "device-auth is not enabled")
+		return
+	}
+	clientIP := remoteIPForRateLimit(r)
+	if !h.enrollLimit.Allow(clientIP) {
+		writeDeviceAuthError(w, http.StatusTooManyRequests, "rate_limited", "too many enrollment attempts")
+		return
+	}
+	var body enrollRequestBody
+	if err := readJSONRequest(r, &body); err != nil {
+		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	response, err := h.service.Enroll(r.Context(), deviceauth.EnrollRequest{
+		BootstrapToken: body.BootstrapToken,
+		HardwareUUID:   body.HardwareUUID,
+		SerialNumber:   body.SerialNumber,
+		Hostname:       body.Hostname,
+		OSType:         body.OSType,
+		OSVersion:      body.OSVersion,
+		AgentVersion:   body.AgentVersion,
+	})
+	if err != nil {
+		writeDeviceAuthServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, tokenResponseBody{
+		AccessToken:    response.AccessToken,
+		TokenType:      response.TokenType,
+		ExpiresIn:      int64(time.Until(response.AccessExpires).Seconds()),
+		RefreshToken:   response.RefreshToken,
+		RefreshExpires: response.RefreshExpires.UTC().Format(time.RFC3339),
+		Scopes:         response.Scopes,
+		DeviceID:       response.DeviceID,
+	})
+}
+
+func (h *deviceAuthHTTPHandler) handleToken(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.service == nil {
+		writeDeviceAuthError(w, http.StatusServiceUnavailable, "device_auth_disabled", "device-auth is not enabled")
+		return
+	}
+	var body tokenRequestBody
+	if err := readJSONRequest(r, &body); err != nil {
+		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	limitKey := strings.TrimSpace(body.RefreshToken)
+	if limitKey == "" {
+		limitKey = remoteIPForRateLimit(r)
+	} else {
+		// Use a hash so plaintext refresh tokens are not retained in the
+		// rate-limiter map.
+		hash := deviceauth.HashToken(limitKey)
+		limitKey = "rt:" + base64URLEncode(hash[:8])
+	}
+	if !h.tokenLimit.Allow(limitKey) {
+		writeDeviceAuthError(w, http.StatusTooManyRequests, "rate_limited", "too many token requests")
+		return
+	}
+	response, err := h.service.IssueToken(r.Context(), deviceauth.TokenRequest{
+		GrantType:    body.GrantType,
+		RefreshToken: body.RefreshToken,
+	})
+	if err != nil {
+		writeDeviceAuthServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, tokenResponseBody{
+		AccessToken:    response.AccessToken,
+		TokenType:      response.TokenType,
+		ExpiresIn:      int64(time.Until(response.AccessExpires).Seconds()),
+		RefreshToken:   response.RefreshToken,
+		RefreshExpires: response.RefreshExpires.UTC().Format(time.RFC3339),
+		Scopes:         response.Scopes,
+	})
+}
+
+func (h *deviceAuthHTTPHandler) handleIssueBootstrapToken(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.service == nil {
+		writeDeviceAuthError(w, http.StatusServiceUnavailable, "device_auth_disabled", "device-auth is not enabled")
+		return
+	}
+	var body bootstrapTokenRequestBody
+	if err := readJSONRequest(r, &body); err != nil {
+		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	tenantID := strings.TrimSpace(body.TenantID)
+	if tenantID == "" {
+		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok {
+			tenantID = strings.TrimSpace(auth.principal.TenantID)
+		}
+	}
+	if tenantID == "" {
+		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", "tenant_id is required")
+		return
+	}
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		writeDeviceAuthError(w, http.StatusForbidden, "tenant_forbidden", err.Error())
+		return
+	}
+	ttl := time.Duration(body.TTLSeconds) * time.Second
+	issuedBy := principalNameFromContext(r)
+	response, err := h.service.IssueBootstrapToken(r.Context(), deviceauth.IssueBootstrapTokenRequest{
+		HardwareUUID: body.HardwareUUID,
+		TenantID:     tenantID,
+		Scopes:       body.Scopes,
+		TTL:          ttl,
+		IssuedBy:     issuedBy,
+	})
+	if err != nil {
+		writeDeviceAuthServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, bootstrapTokenResponseBody{
+		TokenID:   response.TokenID,
+		Token:     response.Token,
+		ExpiresAt: response.ExpiresAt.UTC().Format(time.RFC3339),
+	})
+}
+
+func (h *deviceAuthHTTPHandler) handleRevoke(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.service == nil {
+		writeDeviceAuthError(w, http.StatusServiceUnavailable, "device_auth_disabled", "device-auth is not enabled")
+		return
+	}
+	deviceID := strings.TrimSpace(r.PathValue("deviceID"))
+	if deviceID == "" {
+		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", "device_id is required")
+		return
+	}
+	var body revokeRequestBody
+	if r.ContentLength > 0 {
+		if err := readJSONRequest(r, &body); err != nil {
+			writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+	}
+	if err := h.service.Revoke(r.Context(), deviceID, body.Reason); err != nil {
+		writeDeviceAuthServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked", "device_id": deviceID})
+}
+
+func (h *deviceAuthHTTPHandler) handleIngestTelemetry(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.service == nil {
+		writeDeviceAuthError(w, http.StatusServiceUnavailable, "device_auth_disabled", "device-auth is not enabled")
+		return
+	}
+	auth, ok := r.Context().Value(authContextKey{}).(authContext)
+	if !ok || strings.TrimSpace(auth.principal.DeviceID) == "" {
+		writeDeviceAuthError(w, http.StatusForbidden, "device_required", "telemetry ingest requires a device JWT")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, deviceauth.MaxIngestBodyBytes+1))
+	if err != nil {
+		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if len(body) > deviceauth.MaxIngestBodyBytes {
+		writeDeviceAuthError(w, http.StatusRequestEntityTooLarge, "request_too_large", "telemetry body exceeds limit")
+		return
+	}
+	idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+	result, err := h.service.IngestTelemetry(r.Context(), deviceauth.IngestPayload{
+		DeviceID:       auth.principal.DeviceID,
+		IdempotencyKey: idempotencyKey,
+		Body:           body,
+	})
+	if err != nil {
+		writeDeviceAuthServiceError(w, err)
+		return
+	}
+	if result.Cached {
+		w.Header().Set("Idempotent-Replayed", "true")
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(result.Status)
+	_, _ = w.Write(result.Body)
+}
+
+func (h *deviceAuthHTTPHandler) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	if h == nil || h.service == nil {
+		writeDeviceAuthError(w, http.StatusServiceUnavailable, "device_auth_disabled", "device-auth is not enabled")
+		return
+	}
+	doc := deviceauth.EncodeJWKS(h.service.KeySet())
+	w.Header().Set("Content-Type", "application/jwk-set+json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+func readJSONRequest(r *http.Request, target any) error {
+	r.Body = http.MaxBytesReader(nil, r.Body, deviceauth.MaxIngestBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(target); err != nil {
+		return fmt.Errorf("decode request body: %w", err)
+	}
+	return nil
+}
+
+func writeDeviceAuthError(w http.ResponseWriter, status int, code string, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "error_description": message})
+}
+
+func writeDeviceAuthServiceError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, deviceauth.ErrInvalidRequest):
+		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
+	case errors.Is(err, deviceauth.ErrBootstrapTokenNotFound),
+		errors.Is(err, deviceauth.ErrBootstrapTokenConsumed),
+		errors.Is(err, deviceauth.ErrBootstrapTokenExpired),
+		errors.Is(err, deviceauth.ErrBootstrapTokenMismatch):
+		writeDeviceAuthError(w, http.StatusUnauthorized, "invalid_bootstrap_token", err.Error())
+	case errors.Is(err, deviceauth.ErrRefreshNotFound),
+		errors.Is(err, deviceauth.ErrRefreshExpired):
+		writeDeviceAuthError(w, http.StatusUnauthorized, "invalid_refresh_token", err.Error())
+	case errors.Is(err, deviceauth.ErrRefreshReplay):
+		writeDeviceAuthError(w, http.StatusUnauthorized, "refresh_token_replayed", err.Error())
+	case errors.Is(err, deviceauth.ErrDeviceNotFound):
+		writeDeviceAuthError(w, http.StatusNotFound, "device_not_found", err.Error())
+	case errors.Is(err, deviceauth.ErrDeviceInactive):
+		writeDeviceAuthError(w, http.StatusForbidden, "device_inactive", err.Error())
+	case errors.Is(err, deviceauth.ErrIdempotencyConflict):
+		writeDeviceAuthError(w, http.StatusConflict, "idempotency_conflict", err.Error())
+	default:
+		writeDeviceAuthError(w, http.StatusInternalServerError, "internal_error", "device-auth internal error")
+	}
+}
+
+func remoteIPForRateLimit(r *http.Request) string {
+	if r == nil {
+		return "unknown"
+	}
+	if ip := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); ip != "" {
+		if comma := strings.IndexByte(ip, ','); comma >= 0 {
+			ip = ip[:comma]
+		}
+		ip = strings.TrimSpace(ip)
+		if ip != "" {
+			return ip
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return strings.TrimSpace(r.RemoteAddr)
+	}
+	return host
+}
+
+func principalNameFromContext(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	auth, ok := r.Context().Value(authContextKey{}).(authContext)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(auth.principal.Name)
+}
+
+func base64URLEncode(b []byte) string {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	out := make([]byte, 0, len(b)*2)
+	for _, by := range b {
+		out = append(out, alphabet[by>>4], alphabet[by&0x0F])
+	}
+	return string(out)
+}

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -355,6 +355,15 @@ func (h *deviceAuthHTTPHandler) handleRevoke(w http.ResponseWriter, r *http.Requ
 			return
 		}
 	}
+	device, err := h.service.LookupDevice(r.Context(), deviceID)
+	if err != nil {
+		writeDeviceAuthServiceError(w, err)
+		return
+	}
+	if err := authorizeTenantScopeRequired(r.Context(), device.TenantID); err != nil {
+		writeDeviceAuthError(w, http.StatusForbidden, "tenant_forbidden", err.Error())
+		return
+	}
 	if err := h.service.Revoke(r.Context(), deviceID, body.Reason); err != nil {
 		writeDeviceAuthServiceError(w, err)
 		return

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -390,6 +390,10 @@ func (h *deviceAuthHTTPHandler) handleIngestTelemetry(w http.ResponseWriter, r *
 		writeDeviceAuthError(w, http.StatusRequestEntityTooLarge, "request_too_large", "telemetry body exceeds limit")
 		return
 	}
+	if err := validateTelemetryBody(body); err != nil {
+		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
 	idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
 	result, err := h.service.IngestTelemetry(r.Context(), deviceauth.IngestPayload{
 		DeviceID:       auth.principal.DeviceID,
@@ -406,6 +410,17 @@ func (h *deviceAuthHTTPHandler) handleIngestTelemetry(w http.ResponseWriter, r *
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(result.Status)
 	_, _ = w.Write(result.Body)
+}
+
+func validateTelemetryBody(body []byte) error {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return fmt.Errorf("telemetry body must be a JSON object: %w", err)
+	}
+	if payload == nil {
+		return errors.New("telemetry body must be a JSON object")
+	}
+	return nil
 }
 
 func (h *deviceAuthHTTPHandler) handleJWKS(w http.ResponseWriter, _ *http.Request) {

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -488,6 +488,9 @@ func remoteIPForRateLimit(r *http.Request) string {
 	if r == nil {
 		return "unknown"
 	}
+	if clientIP := accessAuditClientIP(r); clientIP != "" {
+		return clientIP
+	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return strings.TrimSpace(r.RemoteAddr)

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/deviceauth"
+	"github.com/writer/cerebro/internal/deviceauth/attestation"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -238,6 +239,46 @@ func TestNewWithErrorFailsDeviceAuthWithoutStore(t *testing.T) {
 	}, Dependencies{}, nil)
 	if !errors.Is(err, errDeviceAuthRequiresStore) {
 		t.Fatalf("NewWithError err = %v, want device-auth store requirement", err)
+	}
+}
+
+func TestBuildAttestationRegistryRejectsRequiredWithoutVerifier(t *testing.T) {
+	_, err := buildAttestationRegistry(config.DeviceAuthConfig{
+		Attestation: config.DeviceAuthAttestationConfig{Required: true},
+	})
+	if err == nil {
+		t.Fatal("buildAttestationRegistry error = nil, want non-nil")
+	}
+}
+
+func TestWriteDeviceAuthServiceErrorMapsAttestationFailures(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		status int
+		code   string
+	}{
+		{name: "required", err: attestation.ErrAttestationRequired, status: http.StatusBadRequest, code: "attestation_required"},
+		{name: "unsupported", err: attestation.ErrUnsupportedFormat, status: http.StatusBadRequest, code: "unsupported_attestation"},
+		{name: "invalid statement", err: attestation.ErrInvalidStatement, status: http.StatusBadRequest, code: "invalid_attestation"},
+		{name: "invalid chain", err: attestation.ErrChainInvalid, status: http.StatusBadRequest, code: "invalid_attestation"},
+		{name: "nonce mismatch", err: attestation.ErrNonceMismatch, status: http.StatusBadRequest, code: "invalid_attestation"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			writeDeviceAuthServiceError(resp, tt.err)
+			if resp.Code != tt.status {
+				t.Fatalf("status = %d, want %d; body=%s", resp.Code, tt.status, resp.Body.String())
+			}
+			var body map[string]string
+			if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body["error"] != tt.code {
+				t.Fatalf("error code = %q, want %q; body=%s", body["error"], tt.code, resp.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -8,10 +8,12 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/deviceauth"
@@ -208,6 +210,105 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 	}
 	if !strings.Contains(resp.Body.String(), "refresh_token_replayed") {
 		t.Errorf("replay body missing replay code: %s", resp.Body.String())
+	}
+}
+
+func TestNewWithErrorFailsDeviceAuthWhenAPIAuthDisabled(t *testing.T) {
+	_, err := NewWithError(config.Config{
+		Auth: config.AuthConfig{
+			Enabled: false,
+			DeviceAuth: config.DeviceAuthConfig{
+				Enabled: true,
+			},
+		},
+	}, Dependencies{StateStore: newDeviceAuthMemStore()}, nil)
+	if !errors.Is(err, errDeviceAuthRequiresAPIAuth) {
+		t.Fatalf("NewWithError err = %v, want API auth requirement", err)
+	}
+}
+
+func TestNewWithErrorFailsDeviceAuthWithoutStore(t *testing.T) {
+	_, err := NewWithError(config.Config{
+		Auth: config.AuthConfig{
+			Enabled: true,
+			DeviceAuth: config.DeviceAuthConfig{
+				Enabled: true,
+			},
+		},
+	}, Dependencies{}, nil)
+	if !errors.Is(err, errDeviceAuthRequiresStore) {
+		t.Fatalf("NewWithError err = %v, want device-auth store requirement", err)
+	}
+}
+
+func TestRemoteIPForRateLimitIgnoresClientForwardedFor(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", nil)
+	req.RemoteAddr = "198.51.100.10:12345"
+	req.Header.Set("X-Forwarded-For", "203.0.113.200")
+	if got := remoteIPForRateLimit(req); got != "198.51.100.10" {
+		t.Fatalf("remoteIPForRateLimit = %q, want RemoteAddr host", got)
+	}
+}
+
+func TestDeviceAuthTokenLimiterUsesStableDeviceKey(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/platform/devices/bootstrap-tokens", bytes.NewBufferString(`{"hardware_uuid":"hw-1","tenant_id":"writer","ttl_seconds":3600}`))
+	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("issue bootstrap token status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	var bootstrap struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &bootstrap); err != nil {
+		t.Fatalf("decode bootstrap response: %v", err)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewBufferString(`{"bootstrap_token":"`+bootstrap.Token+`","hardware_uuid":"hw-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("enroll status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	var enroll struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &enroll); err != nil {
+		t.Fatalf("decode enroll: %v", err)
+	}
+
+	limiter := deviceauth.NewTokenBucket(100, 1)
+	now := time.Now()
+	limiter.SetClockForTest(func() time.Time { return now })
+	app.deviceHandler.tokenLimit = limiter
+
+	rotateBody := []byte(`{"grant_type":"refresh_token","refresh_token":"` + enroll.RefreshToken + `"}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/token", bytes.NewReader(rotateBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("first token rotate status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	var rotated struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &rotated); err != nil {
+		t.Fatalf("decode rotate: %v", err)
+	}
+	rotateBody = []byte(`{"grant_type":"refresh_token","refresh_token":"` + rotated.RefreshToken + `"}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/token", bytes.NewReader(rotateBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusTooManyRequests {
+		t.Fatalf("second token rotate status = %d, want 429; body=%s", resp.Code, resp.Body.String())
 	}
 }
 

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -1,0 +1,282 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/deviceauth"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func newAppForDeviceTest(t *testing.T) (*App, []byte, []byte) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubPEM := encodePEMPublic(t, pub)
+	privPEM := encodePEMPrivate(t, priv)
+
+	cfg := config.Config{
+		HTTPAddr: ":0",
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APIKeys: []config.APIKey{{
+				Key:       "operator-key",
+				Principal: "ops",
+				TenantID:  "writer",
+			}},
+			DeviceAuth: config.DeviceAuthConfig{
+				Enabled:                     true,
+				Issuer:                      "cerebro",
+				Audience:                    "cerebro-device",
+				CurrentKID:                  "test",
+				EnrollPerIPRatePerSecond:    100,
+				EnrollPerIPBurst:            100,
+				TokenPerDeviceRatePerSecond: 100,
+				TokenPerDeviceBurst:         100,
+				SigningKeys: []config.DeviceAuthSigningKey{{
+					KID:        "test",
+					PublicPEM:  pubPEM,
+					PrivatePEM: privPEM,
+				}},
+			},
+		},
+	}
+	store := newDeviceAuthMemStore()
+	app := New(cfg, Dependencies{StateStore: store}, nil)
+	if app.deviceService == nil {
+		t.Fatal("device service was not wired")
+	}
+	return app, []byte(pubPEM), []byte(privPEM)
+}
+
+// deviceAuthMemStore wraps deviceauth.MemStore and implements ports.StateStore
+// (Ping) so it can be passed via Dependencies.
+type deviceAuthMemStore struct {
+	*deviceauth.MemStore
+}
+
+func newDeviceAuthMemStore() *deviceAuthMemStore {
+	return &deviceAuthMemStore{MemStore: deviceauth.NewMemStore()}
+}
+
+// Ping satisfies ports.StateStore.
+func (s *deviceAuthMemStore) Ping(_ context.Context) error { return nil }
+
+var (
+	_ ports.StateStore = (*deviceAuthMemStore)(nil)
+	_ deviceauth.Store = (*deviceAuthMemStore)(nil)
+)
+
+func encodePEMPublic(t *testing.T, pub ed25519.PublicKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal pub: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+func encodePEMPrivate(t *testing.T, priv ed25519.PrivateKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal priv: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+func TestDeviceAuthEndToEnd(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+
+	// Issue bootstrap token as an operator using the API key.
+	bootstrapBody := bytes.NewBufferString(`{"hardware_uuid":"hw-1","tenant_id":"writer","ttl_seconds":3600}`)
+	req := httptest.NewRequest(http.MethodPost, "/platform/devices/bootstrap-tokens", bootstrapBody)
+	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("issue bootstrap token status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	var bootstrap struct {
+		TokenID string `json:"token_id"`
+		Token   string `json:"token"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &bootstrap); err != nil {
+		t.Fatalf("decode bootstrap response: %v", err)
+	}
+	if bootstrap.Token == "" {
+		t.Fatal("bootstrap token empty")
+	}
+
+	// Enroll the device (no auth header; route is public).
+	enrollBody := []byte(`{"bootstrap_token":"` + bootstrap.Token + `","hardware_uuid":"hw-1","hostname":"laptop-1","os_type":"darwin"}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewReader(enrollBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("enroll status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	var enroll struct {
+		AccessToken  string   `json:"access_token"`
+		RefreshToken string   `json:"refresh_token"`
+		DeviceID     string   `json:"device_id"`
+		Scopes       []string `json:"scopes"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &enroll); err != nil {
+		t.Fatalf("decode enroll: %v", err)
+	}
+	if enroll.AccessToken == "" || enroll.RefreshToken == "" || enroll.DeviceID == "" {
+		t.Fatalf("enroll missing fields: %+v", enroll)
+	}
+	if !containsString(enroll.Scopes, deviceauth.ScopeTelemetryIngest) {
+		t.Errorf("scopes do not include telemetry ingest: %v", enroll.Scopes)
+	}
+
+	// Use the access token to ingest telemetry (idempotent).
+	telemetry := []byte(`{"events":[{"type":"login","ts":"2026-05-22T12:00:00Z"}]}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/telemetry/ingest", bytes.NewReader(telemetry))
+	req.Header.Set("Authorization", "Bearer "+enroll.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "abc-123")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("ingest status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	firstBody := resp.Body.String()
+
+	resp = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/platform/telemetry/ingest", bytes.NewReader(telemetry))
+	req.Header.Set("Authorization", "Bearer "+enroll.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "abc-123")
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("idempotent ingest status = %d", resp.Code)
+	}
+	if resp.Header().Get("Idempotent-Replayed") != "true" {
+		t.Errorf("Idempotent-Replayed header missing on replay")
+	}
+	if resp.Body.String() != firstBody {
+		t.Errorf("idempotent body mismatch")
+	}
+
+	// Conflicting body with the same idempotency key returns 409.
+	conflictBody := []byte(`{"events":[{"type":"different"}]}`)
+	resp = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/platform/telemetry/ingest", bytes.NewReader(conflictBody))
+	req.Header.Set("Authorization", "Bearer "+enroll.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "abc-123")
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("conflicting ingest status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+
+	// Rotate the refresh token.
+	rotateBody := []byte(`{"grant_type":"refresh_token","refresh_token":"` + enroll.RefreshToken + `"}`)
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/token", bytes.NewReader(rotateBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("token rotate status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+
+	// Replay the original refresh token, expect 401.
+	resp = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/token", bytes.NewReader(rotateBody))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("replay status = %d, want 401", resp.Code)
+	}
+	if !strings.Contains(resp.Body.String(), "refresh_token_replayed") {
+		t.Errorf("replay body missing replay code: %s", resp.Body.String())
+	}
+}
+
+func TestDeviceAuthEnrollRejectsWrongHardware(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/platform/devices/bootstrap-tokens", bytes.NewBufferString(`{"hardware_uuid":"hw-1","tenant_id":"writer"}`))
+	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("bootstrap status = %d", resp.Code)
+	}
+	var bootstrap struct {
+		Token string `json:"token"`
+	}
+	_ = json.Unmarshal(resp.Body.Bytes(), &bootstrap)
+
+	req = httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", bytes.NewBufferString(`{"bootstrap_token":"`+bootstrap.Token+`","hardware_uuid":"hw-DIFFERENT"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp = httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("enroll wrong hw status = %d, want 401", resp.Code)
+	}
+}
+
+func TestDeviceAuthJWKSReturnsCurrentKey(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/device-jwks.json", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("jwks status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	var doc struct {
+		Keys []map[string]string `json:"keys"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("decode jwks: %v", err)
+	}
+	if len(doc.Keys) == 0 || doc.Keys[0]["kid"] != "test" {
+		t.Fatalf("unexpected jwks: %+v", doc)
+	}
+}
+
+func TestDeviceAuthIngestRequiresDeviceJWT(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/platform/telemetry/ingest", bytes.NewBufferString(`{}`))
+	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Idempotency-Key", "abc")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("ingest with non-device principal status = %d, want 403", resp.Code)
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -382,6 +382,58 @@ func TestWriteDeviceAuthServiceErrorMapsAttestationFailures(t *testing.T) {
 	}
 }
 
+func TestAuthMiddlewarePreservesDPoPErrorCodes(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer, err := deviceauth.NewLocalSigner([]deviceauth.SigningKey{{KID: "k1", Public: pub, Private: priv}})
+	if err != nil {
+		t.Fatalf("NewLocalSigner: %v", err)
+	}
+	keyset := &deviceauth.KeySet{Keys: []deviceauth.SigningKey{{KID: "k1", Public: pub}}}
+	clock := func() time.Time { return time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC) }
+	issuer, err := deviceauth.NewJWTIssuer(deviceauth.IssuerConfig{Now: clock}, signer)
+	if err != nil {
+		t.Fatalf("NewJWTIssuer: %v", err)
+	}
+	verifier, err := deviceauth.NewJWTVerifier(deviceauth.VerifierConfig{Now: clock}, keyset)
+	if err != nil {
+		t.Fatalf("NewJWTVerifier: %v", err)
+	}
+	token, err := issuer.IssueAccessWithOptions(
+		deviceauth.DeviceRecord{DeviceID: "dev-1", TenantID: "writer", HardwareUUID: "hw-1"},
+		[]string{deviceauth.ScopeTelemetryIngest},
+		deviceauth.AccessOptions{DPoPJKT: "expected-jkt"},
+	)
+	if err != nil {
+		t.Fatalf("IssueAccessWithOptions: %v", err)
+	}
+	dpop := deviceauth.NewDPoPVerifier(time.Minute, time.Minute)
+	dpop.SetClock(clock)
+	handler := authMiddleware(config.AuthConfig{Enabled: true}, AuthDependencies{
+		DeviceVerifier: verifier,
+		DPoPVerifier:   dpop,
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler should not be called without DPoP proof")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/platform/telemetry/ingest", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body=%s", resp.Code, resp.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["error"] != "dpop_required" {
+		t.Fatalf("error = %q, want dpop_required; body=%s", body["error"], resp.Body.String())
+	}
+}
+
 func TestRemoteIPForRateLimitIgnoresClientForwardedFor(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", nil)
 	req.RemoteAddr = "198.51.100.10:12345"

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -434,6 +434,37 @@ func TestAuthMiddlewarePreservesDPoPErrorCodes(t *testing.T) {
 	}
 }
 
+func TestTelemetryIngestRejectsMalformedBodies(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+	bootstrap, err := app.deviceService.IssueBootstrapToken(context.Background(), deviceauth.IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-json",
+		TenantID:     "writer",
+	})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken: %v", err)
+	}
+	enroll, err := app.deviceService.Enroll(context.Background(), deviceauth.EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-json",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	for _, body := range []string{"", "not-json", "[]", "null"} {
+		req := httptest.NewRequest(http.MethodPost, "/platform/telemetry/ingest", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+enroll.AccessToken)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Idempotency-Key", "telemetry-json-"+body)
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("body %q status = %d, want 400; response=%s", body, resp.Code, resp.Body.String())
+		}
+	}
+}
+
 func TestRemoteIPForRateLimitIgnoresClientForwardedFor(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", nil)
 	req.RemoteAddr = "198.51.100.10:12345"

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -251,6 +251,34 @@ func TestBuildAttestationRegistryRejectsRequiredWithoutVerifier(t *testing.T) {
 	}
 }
 
+func TestNewWithErrorRejectsMismatchedDeviceAuthSigningKey(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate public key: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+	_, err = NewWithError(config.Config{
+		Auth: config.AuthConfig{
+			Enabled: true,
+			DeviceAuth: config.DeviceAuthConfig{
+				Enabled:    true,
+				CurrentKID: "test",
+				SigningKeys: []config.DeviceAuthSigningKey{{
+					KID:        "test",
+					PublicPEM:  encodePEMPublic(t, pub),
+					PrivatePEM: encodePEMPrivate(t, priv),
+				}},
+			},
+		},
+	}, Dependencies{StateStore: newDeviceAuthMemStore()}, nil)
+	if !errors.Is(err, deviceauth.ErrSigningKeyMismatch) {
+		t.Fatalf("NewWithError err = %v, want public/private mismatch", err)
+	}
+}
+
 func TestWriteDeviceAuthServiceErrorMapsAttestationFailures(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -391,6 +391,15 @@ func TestRemoteIPForRateLimitIgnoresClientForwardedFor(t *testing.T) {
 	}
 }
 
+func TestRemoteIPForRateLimitTrustsForwardedForFromPrivateProxy(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/platform/devices/enroll", nil)
+	req.RemoteAddr = "10.0.1.20:443"
+	req.Header.Set("X-Forwarded-For", "203.0.113.200, 10.0.1.20")
+	if got := remoteIPForRateLimit(req); got != "203.0.113.200" {
+		t.Fatalf("remoteIPForRateLimit = %q, want forwarded client IP", got)
+	}
+}
+
 func TestDeviceAuthTokenLimiterUsesStableDeviceKey(t *testing.T) {
 	app, _, _ := newAppForDeviceTest(t)
 	handler := app.Handler()

--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -214,6 +214,63 @@ func TestDeviceAuthEndToEnd(t *testing.T) {
 	}
 }
 
+func TestDeviceAuthRevokeAuthorizesTargetDeviceTenant(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+	ctx := context.Background()
+
+	bootstrap, err := app.deviceService.IssueBootstrapToken(ctx, deviceauth.IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-security",
+		TenantID:     "security",
+	})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken: %v", err)
+	}
+	enroll, err := app.deviceService.Enroll(ctx, deviceauth.EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-security",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/platform/devices/"+enroll.DeviceID+"/revoke", bytes.NewBufferString(`{"reason":"test"}`))
+	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("revoke status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "tenant_forbidden") {
+		t.Fatalf("revoke body = %s, want tenant_forbidden", resp.Body.String())
+	}
+	device, err := app.deviceService.LookupDevice(ctx, enroll.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice: %v", err)
+	}
+	if device.Status == "revoked" {
+		t.Fatal("cross-tenant revoke changed target device status")
+	}
+}
+
+func TestDeviceAuthIssueBootstrapTokenRejectsNegativeTTLSeconds(t *testing.T) {
+	app, _, _ := newAppForDeviceTest(t)
+	handler := app.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/platform/devices/bootstrap-tokens", bytes.NewBufferString(`{"hardware_uuid":"hw-neg","tenant_id":"writer","ttl_seconds":-1}`))
+	req.Header.Set("Authorization", "Bearer operator-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("bootstrap token status = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "invalid_request") {
+		t.Fatalf("bootstrap token body = %s, want invalid_request", resp.Body.String())
+	}
+}
+
 func TestNewWithErrorFailsDeviceAuthWhenAPIAuthDisabled(t *testing.T) {
 	_, err := NewWithError(config.Config{
 		Auth: config.AuthConfig{
@@ -239,6 +296,21 @@ func TestNewWithErrorFailsDeviceAuthWithoutStore(t *testing.T) {
 	}, Dependencies{}, nil)
 	if !errors.Is(err, errDeviceAuthRequiresStore) {
 		t.Fatalf("NewWithError err = %v, want device-auth store requirement", err)
+	}
+}
+
+func TestNewWithErrorRejectsDeviceAuthMultipleReplicasWithInProcessDPoP(t *testing.T) {
+	_, err := NewWithError(config.Config{
+		Auth: config.AuthConfig{
+			Enabled: true,
+			DeviceAuth: config.DeviceAuthConfig{
+				Enabled:      true,
+				ReplicaCount: 2,
+			},
+		},
+	}, Dependencies{StateStore: newDeviceAuthMemStore()}, nil)
+	if !errors.Is(err, errDeviceAuthRequiresSharedDPoPReplay) {
+		t.Fatalf("NewWithError err = %v, want shared DPoP replay requirement", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,6 +129,10 @@ type DeviceAuthConfig struct {
 	// DPoPProofTTL bounds how long an RFC 9449 DPoP proof JWT remains
 	// valid; defaults to 60s if zero.
 	DPoPProofTTL time.Duration
+	// ReplicaCount is the number of concurrently serving bootstrap API
+	// replicas for this device-auth deployment. Values greater than one
+	// require shared DPoP replay state.
+	ReplicaCount int
 	// RiskElevatedThreshold and RiskHighThreshold map composite risk
 	// scores (0..100) to "elevated" and "high" levels. Defaults are 30
 	// and 70.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,35 @@ type AuthConfig struct {
 	CapabilityTokenSecrets  []string
 	CapabilityTokenAudience string
 	AllowedTenants          []string
+	DeviceAuth              DeviceAuthConfig
+}
+
+// DeviceAuthSigningKey is one Ed25519 keypair the issuer can sign with. The
+// production deployment leaves PrivatePEM empty and uses an external KMS
+// signer; the dev/test path supplies an inline PEM for both halves.
+type DeviceAuthSigningKey struct {
+	KID        string `json:"kid"`
+	PublicPEM  string `json:"public_pem"`
+	PrivatePEM string `json:"private_pem,omitempty"`
+}
+
+// DeviceAuthConfig configures the SeCheck device-auth surface. The surface is
+// disabled when Enabled is false.
+type DeviceAuthConfig struct {
+	Enabled                  bool
+	Issuer                   string
+	Audience                 string
+	AccessTTL                time.Duration
+	RefreshTTL               time.Duration
+	BootstrapTokenTTL        time.Duration
+	IdempotencyTTL           time.Duration
+	ClockSkew                time.Duration
+	SigningKeys              []DeviceAuthSigningKey
+	CurrentKID               string
+	EnrollPerIPRatePerSecond float64
+	EnrollPerIPBurst         int
+	TokenPerDeviceRatePerSecond float64
+	TokenPerDeviceBurst      int
 }
 
 // Load reads and validates process configuration.
@@ -151,6 +180,11 @@ func Load() (Config, error) {
 	if len(cfg.Auth.CapabilityTokenSecrets) > 0 && cfg.Auth.CapabilityTokenAudience == "" {
 		cfg.Auth.CapabilityTokenAudience = "cerebro-api"
 	}
+	deviceAuth, err := loadDeviceAuthConfig()
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Auth.DeviceAuth = deviceAuth
 	if cfg.HTTPAddr == "" {
 		cfg.HTTPAddr = defaultHTTPAddr
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,9 +100,9 @@ type AuthConfig struct {
 	DeviceAuth              DeviceAuthConfig
 }
 
-// DeviceAuthSigningKey is one Ed25519 keypair the issuer can sign with. The
-// production deployment leaves PrivatePEM empty and uses an external KMS
-// signer; the dev/test path supplies an inline PEM for both halves.
+// DeviceAuthSigningKey is one Ed25519 keypair the issuer can sign with. This
+// bootstrap path requires PrivatePEM on the current signing key; external KMS
+// signing is intentionally unsupported until a signer implementation is wired.
 type DeviceAuthSigningKey struct {
 	KID        string `json:"kid"`
 	PublicPEM  string `json:"public_pem"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,20 +112,20 @@ type DeviceAuthSigningKey struct {
 // DeviceAuthConfig configures the SeCheck device-auth surface. The surface is
 // disabled when Enabled is false.
 type DeviceAuthConfig struct {
-	Enabled                  bool
-	Issuer                   string
-	Audience                 string
-	AccessTTL                time.Duration
-	RefreshTTL               time.Duration
-	BootstrapTokenTTL        time.Duration
-	IdempotencyTTL           time.Duration
-	ClockSkew                time.Duration
-	SigningKeys              []DeviceAuthSigningKey
-	CurrentKID               string
-	EnrollPerIPRatePerSecond float64
-	EnrollPerIPBurst         int
+	Enabled                     bool
+	Issuer                      string
+	Audience                    string
+	AccessTTL                   time.Duration
+	RefreshTTL                  time.Duration
+	BootstrapTokenTTL           time.Duration
+	IdempotencyTTL              time.Duration
+	ClockSkew                   time.Duration
+	SigningKeys                 []DeviceAuthSigningKey
+	CurrentKID                  string
+	EnrollPerIPRatePerSecond    float64
+	EnrollPerIPBurst            int
 	TokenPerDeviceRatePerSecond float64
-	TokenPerDeviceBurst      int
+	TokenPerDeviceBurst         int
 	// DPoPProofTTL bounds how long an RFC 9449 DPoP proof JWT remains
 	// valid; defaults to 60s if zero.
 	DPoPProofTTL time.Duration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,6 +126,32 @@ type DeviceAuthConfig struct {
 	EnrollPerIPBurst         int
 	TokenPerDeviceRatePerSecond float64
 	TokenPerDeviceBurst      int
+	// DPoPProofTTL bounds how long an RFC 9449 DPoP proof JWT remains
+	// valid; defaults to 60s if zero.
+	DPoPProofTTL time.Duration
+	// RiskElevatedThreshold and RiskHighThreshold map composite risk
+	// scores (0..100) to "elevated" and "high" levels. Defaults are 30
+	// and 70.
+	RiskElevatedThreshold int
+	RiskHighThreshold     int
+	// Attestation configures the device-bound proof verifiers wired into
+	// Service.Enroll.
+	Attestation DeviceAuthAttestationConfig
+}
+
+// DeviceAuthAttestationConfig configures the Phase-2 device-bound proof
+// verifiers. When Required is true, enroll requests must carry a non-empty
+// attestation statement; when false, a missing statement returns a
+// software-assurance result.
+type DeviceAuthAttestationConfig struct {
+	Required bool
+	Apple    DeviceAuthAppleConfig
+}
+
+// DeviceAuthAppleConfig configures the Apple App Attest verifier.
+type DeviceAuthAppleConfig struct {
+	TeamID    string
+	BundleIDs []string
 }
 
 // Load reads and validates process configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -220,6 +220,18 @@ func TestLoadRejectsDeviceAuthMultipleReplicasWithoutSharedDPoPReplay(t *testing
 	}
 }
 
+func TestLoadRejectsDeviceAuthEnabledWithoutCurrentKID(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_DEVICE_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON", `[{"kid":"k1","public_pem":"public"}]`)
+	t.Setenv("CEREBRO_DEVICE_AUTH_CURRENT_KID", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
 func TestLoadRejectsAuthEnabledWithoutKeys(t *testing.T) {
 	clearDependencyEnv(t)
 	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "")
+	clearDeviceAuthEnv(t)
 
 	cfg, err := Load()
 	if err != nil {
@@ -86,6 +87,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "security,writer,writer")
+	clearDeviceAuthEnv(t)
 
 	cfg, err := Load()
 	if err != nil {
@@ -155,6 +157,7 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "")
+	clearDeviceAuthEnv(t)
 }
 
 func clearGraphAgentEnv(t *testing.T) {
@@ -166,6 +169,40 @@ func clearGraphAgentEnv(t *testing.T) {
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MODEL_HAIKU", "")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_MAX_TOKENS", "")
 	t.Setenv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", "")
+}
+
+func clearDeviceAuthEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CEREBRO_DEVICE_AUTH_ENABLED", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_ISSUER", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_AUDIENCE", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_CURRENT_KID", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_ACCESS_TTL", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_REFRESH_TTL", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_BOOTSTRAP_TOKEN_TTL", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_IDEMPOTENCY_TTL", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_CLOCK_SKEW", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_ENROLL_RPS", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_ENROLL_BURST", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_TOKEN_RPS", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_TOKEN_BURST", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_DPOP_PROOF_TTL", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_RISK_ELEVATED", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_RISK_HIGH", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_APPLE_TEAM_ID", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_APPLE_BUNDLE_IDS", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON", "")
+}
+
+func TestLoadRejectsRequiredDeviceAuthAttestationWithoutVerifier(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED", "true")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
 }
 
 func TestLoadRejectsAuthEnabledWithoutKeys(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Auth.Enabled {
 		t.Fatal("Auth.Enabled = true, want false")
 	}
+	if cfg.Auth.DeviceAuth.ReplicaCount != 1 {
+		t.Fatalf("DeviceAuth.ReplicaCount = %d, want 1", cfg.Auth.DeviceAuth.ReplicaCount)
+	}
 }
 
 func TestLoadFromEnv(t *testing.T) {
@@ -187,6 +190,7 @@ func clearDeviceAuthEnv(t *testing.T) {
 	t.Setenv("CEREBRO_DEVICE_AUTH_TOKEN_RPS", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_TOKEN_BURST", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_DPOP_PROOF_TTL", "")
+	t.Setenv("CEREBRO_DEVICE_AUTH_REPLICA_COUNT", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_RISK_ELEVATED", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_RISK_HIGH", "")
 	t.Setenv("CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED", "")
@@ -198,6 +202,17 @@ func clearDeviceAuthEnv(t *testing.T) {
 func TestLoadRejectsRequiredDeviceAuthAttestationWithoutVerifier(t *testing.T) {
 	clearDependencyEnv(t)
 	t.Setenv("CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED", "true")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadRejectsDeviceAuthMultipleReplicasWithoutSharedDPoPReplay(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_DEVICE_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_DEVICE_AUTH_REPLICA_COUNT", "2")
 
 	_, err := Load()
 	if err == nil {

--- a/internal/config/device_auth.go
+++ b/internal/config/device_auth.go
@@ -56,6 +56,26 @@ func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
 		return DeviceAuthConfig{}, err
 	}
 	cfg.TokenPerDeviceBurst = tokenBurst
+	if cfg.DPoPProofTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_DPOP_PROOF_TTL", 60*time.Second); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	if cfg.RiskElevatedThreshold, err = parseIntEnv("CEREBRO_DEVICE_AUTH_RISK_ELEVATED", 30); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	if cfg.RiskHighThreshold, err = parseIntEnv("CEREBRO_DEVICE_AUTH_RISK_HIGH", 70); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	required, err := parseBoolEnv("CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED", false)
+	if err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	cfg.Attestation = DeviceAuthAttestationConfig{
+		Required: required,
+		Apple: DeviceAuthAppleConfig{
+			TeamID:    strings.TrimSpace(os.Getenv("CEREBRO_DEVICE_AUTH_APPLE_TEAM_ID")),
+			BundleIDs: parseCommaList(os.Getenv("CEREBRO_DEVICE_AUTH_APPLE_BUNDLE_IDS")),
+		},
+	}
 	keys, err := parseDeviceAuthSigningKeys(os.Getenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON"))
 	if err != nil {
 		return DeviceAuthConfig{}, err
@@ -108,6 +128,17 @@ func deviceAuthHasKID(keys []DeviceAuthSigningKey, kid string) bool {
 		}
 	}
 	return false
+}
+
+func parseCommaList(raw string) []string {
+	parts := strings.Split(strings.TrimSpace(raw), ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if v := strings.TrimSpace(p); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 func parseDurationEnv(name string, defaultValue time.Duration) (time.Duration, error) {

--- a/internal/config/device_auth.go
+++ b/internal/config/device_auth.go
@@ -76,6 +76,9 @@ func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
 			BundleIDs: parseCommaList(os.Getenv("CEREBRO_DEVICE_AUTH_APPLE_BUNDLE_IDS")),
 		},
 	}
+	if cfg.Attestation.Required && !deviceAuthHasAttestationVerifier(cfg.Attestation) {
+		return DeviceAuthConfig{}, fmt.Errorf("CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED=true requires a configured attestation verifier backend")
+	}
 	keys, err := parseDeviceAuthSigningKeys(os.Getenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON"))
 	if err != nil {
 		return DeviceAuthConfig{}, err
@@ -128,6 +131,10 @@ func deviceAuthHasKID(keys []DeviceAuthSigningKey, kid string) bool {
 		}
 	}
 	return false
+}
+
+func deviceAuthHasAttestationVerifier(cfg DeviceAuthAttestationConfig) bool {
+	return cfg.Apple.TeamID != "" && len(cfg.Apple.BundleIDs) > 0
 }
 
 func parseCommaList(raw string) []string {

--- a/internal/config/device_auth.go
+++ b/internal/config/device_auth.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
+	enabled, err := parseBoolEnv("CEREBRO_DEVICE_AUTH_ENABLED", false)
+	if err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	cfg := DeviceAuthConfig{
+		Enabled:    enabled,
+		Issuer:     strings.TrimSpace(os.Getenv("CEREBRO_DEVICE_AUTH_ISSUER")),
+		Audience:   strings.TrimSpace(os.Getenv("CEREBRO_DEVICE_AUTH_AUDIENCE")),
+		CurrentKID: strings.TrimSpace(os.Getenv("CEREBRO_DEVICE_AUTH_CURRENT_KID")),
+	}
+	if cfg.Issuer == "" {
+		cfg.Issuer = "cerebro"
+	}
+	if cfg.Audience == "" {
+		cfg.Audience = "cerebro-device"
+	}
+	if cfg.AccessTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_ACCESS_TTL", 10*time.Minute); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	if cfg.RefreshTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_REFRESH_TTL", 30*24*time.Hour); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	if cfg.BootstrapTokenTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_BOOTSTRAP_TOKEN_TTL", 24*time.Hour); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	if cfg.IdempotencyTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_IDEMPOTENCY_TTL", 24*time.Hour); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	if cfg.ClockSkew, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_CLOCK_SKEW", time.Minute); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	if cfg.EnrollPerIPRatePerSecond, err = parseFloatEnv("CEREBRO_DEVICE_AUTH_ENROLL_RPS", 0.2); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	enrollBurst, err := parseIntEnv("CEREBRO_DEVICE_AUTH_ENROLL_BURST", 3)
+	if err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	cfg.EnrollPerIPBurst = enrollBurst
+	if cfg.TokenPerDeviceRatePerSecond, err = parseFloatEnv("CEREBRO_DEVICE_AUTH_TOKEN_RPS", 1); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	tokenBurst, err := parseIntEnv("CEREBRO_DEVICE_AUTH_TOKEN_BURST", 5)
+	if err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	cfg.TokenPerDeviceBurst = tokenBurst
+	keys, err := parseDeviceAuthSigningKeys(os.Getenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON"))
+	if err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	cfg.SigningKeys = keys
+	if cfg.CurrentKID == "" && len(keys) > 0 {
+		cfg.CurrentKID = keys[0].KID
+	}
+	if cfg.Enabled {
+		if len(cfg.SigningKeys) == 0 {
+			return DeviceAuthConfig{}, fmt.Errorf("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON is required when CEREBRO_DEVICE_AUTH_ENABLED=true")
+		}
+		if cfg.CurrentKID == "" {
+			return DeviceAuthConfig{}, fmt.Errorf("CEREBRO_DEVICE_AUTH_CURRENT_KID is required when CEREBRO_DEVICE_AUTH_ENABLED=true")
+		}
+		if !deviceAuthHasKID(cfg.SigningKeys, cfg.CurrentKID) {
+			return DeviceAuthConfig{}, fmt.Errorf("CEREBRO_DEVICE_AUTH_CURRENT_KID %q is not present in CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON", cfg.CurrentKID)
+		}
+	}
+	return cfg, nil
+}
+
+func parseDeviceAuthSigningKeys(raw string) ([]DeviceAuthSigningKey, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var keys []DeviceAuthSigningKey
+	if err := json.Unmarshal([]byte(raw), &keys); err != nil {
+		return nil, fmt.Errorf("parse CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON: %w", err)
+	}
+	for index := range keys {
+		keys[index].KID = strings.TrimSpace(keys[index].KID)
+		keys[index].PublicPEM = strings.TrimSpace(keys[index].PublicPEM)
+		keys[index].PrivatePEM = strings.TrimSpace(keys[index].PrivatePEM)
+		if keys[index].KID == "" {
+			return nil, fmt.Errorf("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON[%d] requires kid", index)
+		}
+		if keys[index].PublicPEM == "" {
+			return nil, fmt.Errorf("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON[%d] requires public_pem", index)
+		}
+	}
+	return keys, nil
+}
+
+func deviceAuthHasKID(keys []DeviceAuthSigningKey, kid string) bool {
+	for _, key := range keys {
+		if key.KID == kid {
+			return true
+		}
+	}
+	return false
+}
+
+func parseDurationEnv(name string, defaultValue time.Duration) (time.Duration, error) {
+	raw, ok := os.LookupEnv(name)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return defaultValue, nil
+	}
+	value, err := time.ParseDuration(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", name, err)
+	}
+	if value <= 0 {
+		return 0, fmt.Errorf("%s must be greater than zero", name)
+	}
+	return value, nil
+}

--- a/internal/config/device_auth.go
+++ b/internal/config/device_auth.go
@@ -59,6 +59,12 @@ func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
 	if cfg.DPoPProofTTL, err = parseDurationEnv("CEREBRO_DEVICE_AUTH_DPOP_PROOF_TTL", 60*time.Second); err != nil {
 		return DeviceAuthConfig{}, err
 	}
+	if cfg.ReplicaCount, err = parseIntEnv("CEREBRO_DEVICE_AUTH_REPLICA_COUNT", 1); err != nil {
+		return DeviceAuthConfig{}, err
+	}
+	if cfg.ReplicaCount <= 0 {
+		return DeviceAuthConfig{}, fmt.Errorf("CEREBRO_DEVICE_AUTH_REPLICA_COUNT must be greater than zero")
+	}
 	if cfg.RiskElevatedThreshold, err = parseIntEnv("CEREBRO_DEVICE_AUTH_RISK_ELEVATED", 30); err != nil {
 		return DeviceAuthConfig{}, err
 	}
@@ -78,6 +84,9 @@ func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
 	}
 	if cfg.Attestation.Required && !deviceAuthHasAttestationVerifier(cfg.Attestation) {
 		return DeviceAuthConfig{}, fmt.Errorf("CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED=true requires a configured attestation verifier backend")
+	}
+	if cfg.Enabled && cfg.ReplicaCount > 1 {
+		return DeviceAuthConfig{}, fmt.Errorf("CEREBRO_DEVICE_AUTH_REPLICA_COUNT=%d is unsupported with in-process DPoP replay protection; configure one replica or wire shared DPoP replay state", cfg.ReplicaCount)
 	}
 	keys, err := parseDeviceAuthSigningKeys(os.Getenv("CEREBRO_DEVICE_AUTH_SIGNING_KEYS_JSON"))
 	if err != nil {

--- a/internal/config/device_auth.go
+++ b/internal/config/device_auth.go
@@ -93,7 +93,7 @@ func loadDeviceAuthConfig() (DeviceAuthConfig, error) {
 		return DeviceAuthConfig{}, err
 	}
 	cfg.SigningKeys = keys
-	if cfg.CurrentKID == "" && len(keys) > 0 {
+	if !cfg.Enabled && cfg.CurrentKID == "" && len(keys) > 0 {
 		cfg.CurrentKID = keys[0].KID
 	}
 	if cfg.Enabled {

--- a/internal/deviceauth/attestation/apple.go
+++ b/internal/deviceauth/attestation/apple.go
@@ -1,0 +1,286 @@
+package attestation
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// AppleAppAttestVerifier validates Apple App Attest attestation objects.
+//
+// The flow follows Apple's "Validating Apps That Connect to Your Server"
+// guidance (developer.apple.com/documentation/devicecheck):
+//
+//  1. Decode the CBOR attestation object: {fmt:"apple-appattest", attStmt:{x5c:[...], receipt}, authData}.
+//  2. Verify the x5c chain ends at the embedded Apple App Attestation Root
+//     CA (or a configured override).
+//  3. Compute nonce = SHA-256(authData || clientDataHash). Extract the
+//     credCert's nonce extension (1.2.840.113635.100.8.2), which contains
+//     a DER OCTET STRING wrapping the SHA-256 we expect, and compare.
+//  4. Pull the public key from the credCert's SubjectPublicKeyInfo. Compute
+//     credId = SHA-256(public key X || Y). Compare against the credId
+//     baked into authData. Equality proves the certificate is for *this*
+//     device-bound key.
+//
+// The verifier returns hardware-assurance results when the Apple chain
+// validates and the nonce + key id checks pass.
+type AppleAppAttestVerifier struct {
+	roots       *x509.CertPool
+	clock       func() time.Time
+	bundleIDs   map[string]struct{}
+	teamID      string
+	expectedRPI [32]byte
+}
+
+// AppleConfig configures the Apple App Attest verifier.
+type AppleConfig struct {
+	// Roots overrides the default Apple App Attestation Root CA pool. The
+	// embedded production root is used when nil.
+	Roots *x509.CertPool
+	// BundleIDs is the set of expected app bundle identifiers that may
+	// appear in authData's rpIdHash field. Production should pin a single
+	// id; tests may pass several.
+	BundleIDs []string
+	// TeamID is the Apple developer team id; combined with BundleID it
+	// derives the rpIdHash that must match authData[:32].
+	TeamID string
+	// Clock overrides time.Now (tests).
+	Clock func() time.Time
+}
+
+// NewAppleAppAttestVerifier returns a verifier configured for the given
+// bundle ids and team id. If cfg.Roots is nil, the embedded Apple root is
+// installed.
+func NewAppleAppAttestVerifier(cfg AppleConfig) (*AppleAppAttestVerifier, error) {
+	roots := cfg.Roots
+	if roots == nil {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM([]byte(appleAppAttestRootCAPEM)) {
+			return nil, errors.New("attestation: embedded Apple root CA failed to parse")
+		}
+		roots = pool
+	}
+	if cfg.TeamID == "" || len(cfg.BundleIDs) == 0 {
+		return nil, errors.New("attestation: AppleConfig requires TeamID and at least one BundleID")
+	}
+	bundleSet := make(map[string]struct{}, len(cfg.BundleIDs))
+	for _, b := range cfg.BundleIDs {
+		bundleSet[b] = struct{}{}
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	v := &AppleAppAttestVerifier{
+		roots:     roots,
+		clock:     clock,
+		bundleIDs: bundleSet,
+		teamID:    cfg.TeamID,
+	}
+	return v, nil
+}
+
+// Format implements [Verifier].
+func (v *AppleAppAttestVerifier) Format() string { return FormatAppleAppAttest }
+
+// Verify implements [Verifier].
+func (v *AppleAppAttestVerifier) Verify(_ context.Context, in Input) (*Result, error) {
+	raw, err := base64.StdEncoding.DecodeString(in.Statement)
+	if err != nil {
+		raw, err = base64.RawStdEncoding.DecodeString(in.Statement)
+		if err != nil {
+			return nil, fmt.Errorf("%w: base64 decode", ErrInvalidStatement)
+		}
+	}
+	root, _, err := decodeCBOR(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: cbor decode", ErrInvalidStatement)
+	}
+	if root.major != 5 {
+		return nil, fmt.Errorf("%w: root not a map", ErrInvalidStatement)
+	}
+	fmtVal, _ := root.lookup("fmt")
+	if fmtVal.text != FormatAppleAppAttest {
+		return nil, fmt.Errorf("%w: fmt=%q want=%q", ErrInvalidStatement, fmtVal.text, FormatAppleAppAttest)
+	}
+	authData, ok := root.lookup("authData")
+	if !ok || authData.major != 2 {
+		return nil, fmt.Errorf("%w: missing authData", ErrInvalidStatement)
+	}
+	att, ok := root.lookup("attStmt")
+	if !ok || att.major != 5 {
+		return nil, fmt.Errorf("%w: missing attStmt", ErrInvalidStatement)
+	}
+	x5c, ok := att.lookup("x5c")
+	if !ok || x5c.major != 4 || len(x5c.array) == 0 {
+		return nil, fmt.Errorf("%w: missing x5c", ErrInvalidStatement)
+	}
+
+	chain := make([]*x509.Certificate, 0, len(x5c.array))
+	for _, item := range x5c.array {
+		if item.major != 2 {
+			return nil, fmt.Errorf("%w: x5c element not a byte string", ErrInvalidStatement)
+		}
+		cert, err := x509.ParseCertificate(item.bytes)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrChainInvalid, err)
+		}
+		chain = append(chain, cert)
+	}
+	leaf := chain[0]
+
+	intermediates := x509.NewCertPool()
+	for _, c := range chain[1:] {
+		intermediates.AddCert(c)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:         v.roots,
+		Intermediates: intermediates,
+		CurrentTime:   v.clock(),
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrChainInvalid, err)
+	}
+
+	// Nonce check: SHA256(authData || clientDataHash) must equal the value
+	// in the leaf's 1.2.840.113635.100.8.2 extension (an OCTET STRING
+	// wrapping a SHA-256).
+	expected := sha256.New()
+	expected.Write(authData.bytes)
+	expected.Write(in.ClientDataHash[:])
+	expectedNonce := expected.Sum(nil)
+	if err := checkAppleNonceExtension(leaf, expectedNonce); err != nil {
+		return nil, err
+	}
+
+	// rpIdHash: first 32 bytes of authData.
+	if len(authData.bytes) < 37 {
+		return nil, fmt.Errorf("%w: authData too short", ErrInvalidStatement)
+	}
+	rpIDHash := authData.bytes[:32]
+	if !v.matchRPIDHash(rpIDHash) {
+		return nil, fmt.Errorf("%w: rpIdHash does not match any configured bundle id / team", ErrInvalidStatement)
+	}
+
+	// credId is at authData[37:37+credIdLen].
+	credIDLen := binary.BigEndian.Uint16(authData.bytes[53:55])
+	if 55+int(credIDLen) > len(authData.bytes) {
+		return nil, fmt.Errorf("%w: credId extends past authData", ErrInvalidStatement)
+	}
+	credID := authData.bytes[55 : 55+int(credIDLen)]
+
+	// The leaf's public key, when hashed (X||Y), should equal credId.
+	ecpub, ok := leaf.PublicKey.(*ecdsa.PublicKey)
+	if !ok || ecpub.Curve != elliptic.P256() {
+		return nil, fmt.Errorf("%w: leaf is not P-256", ErrInvalidStatement)
+	}
+	keyHash := sha256.Sum256(append(padCoord(ecpub.X), padCoord(ecpub.Y)...))
+	if !equalBytes(keyHash[:], credID) {
+		return nil, ErrKeyIDMismatch
+	}
+
+	pkix, err := x509.MarshalPKIXPublicKey(ecpub)
+	if err != nil {
+		return nil, fmt.Errorf("attestation: marshal pubkey: %w", err)
+	}
+
+	return &Result{
+		AssuranceLevel: "hardware",
+		PublicKey:      pkix,
+		KeyID:          hex.EncodeToString(credID),
+		Vendor:         FormatAppleAppAttest,
+		Diagnostics: map[string]string{
+			"leaf_subject":   leaf.Subject.String(),
+			"leaf_issuer":    leaf.Issuer.String(),
+			"chain_length":   fmt.Sprintf("%d", len(chain)),
+			"rp_id_hash_hex": hex.EncodeToString(rpIDHash),
+		},
+	}, nil
+}
+
+func (v *AppleAppAttestVerifier) matchRPIDHash(rpIDHash []byte) bool {
+	for bundle := range v.bundleIDs {
+		expected := sha256.Sum256([]byte(v.teamID + "." + bundle))
+		if equalBytes(rpIDHash, expected[:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// nonceOID is the Apple-specific extension OID that carries the device-
+// scoped nonce in the App Attest credential cert.
+var nonceOID = asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 2}
+
+func checkAppleNonceExtension(cert *x509.Certificate, expected []byte) error {
+	for _, ext := range cert.Extensions {
+		if !ext.Id.Equal(nonceOID) {
+			continue
+		}
+		// The extension value is an ASN.1 SEQUENCE whose first element is
+		// an OCTET STRING wrapping the 32-byte nonce. Apple uses the
+		// outer OCTET STRING in the extension itself per X.509 §4.2, then
+		// nests another OCTET STRING for the value. We unwrap layers
+		// until we find a 32-byte octet string and compare.
+		raw := ext.Value
+		// Try to unwrap one or two SEQUENCE/OCTET STRING layers.
+		for i := 0; i < 4; i++ {
+			var inner asn1.RawValue
+			rest, err := asn1.Unmarshal(raw, &inner)
+			if err != nil {
+				break
+			}
+			raw = inner.Bytes
+			if len(raw) == 32 && equalBytes(raw, expected) {
+				return nil
+			}
+			if len(rest) > 0 {
+				// in case the extension contains a SEQUENCE we should also
+				// consider a contextual [1] tag etc. Bail to scanning.
+			}
+			// SEQUENCE { [1] EXPLICIT OCTET STRING { ... } } pattern: the
+			// inner.Bytes will be the [1] context-specific value with the
+			// OCTET STRING inside. Strip until we hit 32 bytes.
+		}
+		// Last-resort scan for a 32-byte run that matches expected.
+		for i := 0; i+32 <= len(ext.Value); i++ {
+			if equalBytes(ext.Value[i:i+32], expected) {
+				return nil
+			}
+		}
+		return ErrNonceMismatch
+	}
+	return fmt.Errorf("%w: leaf missing 1.2.840.113635.100.8.2 nonce extension", ErrChainInvalid)
+}
+
+func padCoord(b *big.Int) []byte {
+	bs := b.Bytes()
+	if len(bs) >= 32 {
+		return bs
+	}
+	out := make([]byte, 32)
+	copy(out[32-len(bs):], bs)
+	return out
+}
+
+func equalBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/deviceauth/attestation/apple.go
+++ b/internal/deviceauth/attestation/apple.go
@@ -161,8 +161,10 @@ func (v *AppleAppAttestVerifier) Verify(_ context.Context, in Input) (*Result, e
 		return nil, err
 	}
 
-	// rpIdHash: first 32 bytes of authData.
-	if len(authData.bytes) < 37 {
+	// rpIdHash: first 32 bytes of authData. Attested credential data begins
+	// at byte 37 and carries a 16-byte AAGUID followed by a 2-byte credId
+	// length at bytes 53:55, so reject truncated inputs before slicing.
+	if len(authData.bytes) < 55 {
 		return nil, fmt.Errorf("%w: authData too short", ErrInvalidStatement)
 	}
 	rpIDHash := authData.bytes[:32]

--- a/internal/deviceauth/attestation/apple.go
+++ b/internal/deviceauth/attestation/apple.go
@@ -12,7 +12,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/big"
 	"time"
 )
 
@@ -35,11 +34,10 @@ import (
 // The verifier returns hardware-assurance results when the Apple chain
 // validates and the nonce + key id checks pass.
 type AppleAppAttestVerifier struct {
-	roots       *x509.CertPool
-	clock       func() time.Time
-	bundleIDs   map[string]struct{}
-	teamID      string
-	expectedRPI [32]byte
+	roots     *x509.CertPool
+	clock     func() time.Time
+	bundleIDs map[string]struct{}
+	teamID    string
 }
 
 // AppleConfig configures the Apple App Attest verifier.
@@ -133,7 +131,7 @@ func (v *AppleAppAttestVerifier) Verify(_ context.Context, in Input) (*Result, e
 		}
 		cert, err := x509.ParseCertificate(item.bytes)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrChainInvalid, err)
+			return nil, fmt.Errorf("%w: %w", ErrChainInvalid, err)
 		}
 		chain = append(chain, cert)
 	}
@@ -149,7 +147,7 @@ func (v *AppleAppAttestVerifier) Verify(_ context.Context, in Input) (*Result, e
 		CurrentTime:   v.clock(),
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrChainInvalid, err)
+		return nil, fmt.Errorf("%w: %w", ErrChainInvalid, err)
 	}
 
 	// Nonce check: SHA256(authData || clientDataHash) must equal the value
@@ -184,7 +182,11 @@ func (v *AppleAppAttestVerifier) Verify(_ context.Context, in Input) (*Result, e
 	if !ok || ecpub.Curve != elliptic.P256() {
 		return nil, fmt.Errorf("%w: leaf is not P-256", ErrInvalidStatement)
 	}
-	keyHash := sha256.Sum256(append(padCoord(ecpub.X), padCoord(ecpub.Y)...))
+	xy, err := p256UncompressedXY(ecpub)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidStatement, err)
+	}
+	keyHash := sha256.Sum256(xy)
 	if !equalBytes(keyHash[:], credID) {
 		return nil, ErrKeyIDMismatch
 	}
@@ -236,21 +238,13 @@ func checkAppleNonceExtension(cert *x509.Certificate, expected []byte) error {
 		// Try to unwrap one or two SEQUENCE/OCTET STRING layers.
 		for i := 0; i < 4; i++ {
 			var inner asn1.RawValue
-			rest, err := asn1.Unmarshal(raw, &inner)
-			if err != nil {
+			if _, err := asn1.Unmarshal(raw, &inner); err != nil {
 				break
 			}
 			raw = inner.Bytes
 			if len(raw) == 32 && equalBytes(raw, expected) {
 				return nil
 			}
-			if len(rest) > 0 {
-				// in case the extension contains a SEQUENCE we should also
-				// consider a contextual [1] tag etc. Bail to scanning.
-			}
-			// SEQUENCE { [1] EXPLICIT OCTET STRING { ... } } pattern: the
-			// inner.Bytes will be the [1] context-specific value with the
-			// OCTET STRING inside. Strip until we hit 32 bytes.
 		}
 		// Last-resort scan for a 32-byte run that matches expected.
 		for i := 0; i+32 <= len(ext.Value); i++ {
@@ -263,14 +257,20 @@ func checkAppleNonceExtension(cert *x509.Certificate, expected []byte) error {
 	return fmt.Errorf("%w: leaf missing 1.2.840.113635.100.8.2 nonce extension", ErrChainInvalid)
 }
 
-func padCoord(b *big.Int) []byte {
-	bs := b.Bytes()
-	if len(bs) >= 32 {
-		return bs
+// p256UncompressedXY converts an ecdsa.PublicKey on P-256 to its 64-byte
+// big-endian X || Y serialization without touching the deprecated raw
+// coordinate fields. The crypto/ecdh package returns the SEC1 uncompressed
+// point format (0x04 || X || Y); we strip the 0x04 prefix.
+func p256UncompressedXY(pub *ecdsa.PublicKey) ([]byte, error) {
+	ecdhPub, err := pub.ECDH()
+	if err != nil {
+		return nil, err
 	}
-	out := make([]byte, 32)
-	copy(out[32-len(bs):], bs)
-	return out
+	raw := ecdhPub.Bytes()
+	if len(raw) != 65 || raw[0] != 0x04 {
+		return nil, fmt.Errorf("attestation: unexpected SEC1 encoding length %d", len(raw))
+	}
+	return raw[1:], nil
 }
 
 func equalBytes(a, b []byte) bool {

--- a/internal/deviceauth/attestation/apple_root.go
+++ b/internal/deviceauth/attestation/apple_root.go
@@ -1,0 +1,24 @@
+package attestation
+
+// appleAppAttestRootCAPEM is the production "Apple App Attestation Root CA"
+// certificate published at https://www.apple.com/certificateauthority/
+// (filename: Apple_App_Attestation_Root_CA.pem). The cert is reproduced
+// here so verification works air-gapped: the production deployment loads
+// the exact same bytes regardless of network reachability, and the
+// AppleConfig.Roots field lets operators inject a non-default pool when
+// running against the Apple App Attest sandbox CA.
+const appleAppAttestRootCAPEM = `-----BEGIN CERTIFICATE-----
+MIICITCCAaegAwIBAgIQC/O+DvHN0uD7jG5yH2IXmDAKBggqhkjOPQQDAzBSMSYw
+JAYDVQQDDB1BcHBsZSBBcHAgQXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwK
+QXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTAeFw0yMDAzMTgxODMyNTNa
+Fw00NTAzMTUwMDAwMDBaMFIxJjAkBgNVBAMMHUFwcGxlIEFwcCBBdHRlc3RhdGlv
+biBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJbmMuMRMwEQYDVQQIDApDYWxpZm9y
+bmlhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERTHhmLW07ATaFQIEVwTtT4dyctdh
+NbJhFs/Ii2FdCgAHGbpphY3+d8qjuDngIN3WVhQUBHAoMeQ/cLiP1sOUtgjqK9au
+Yen1mMEvRq9Sk3Jm5X8U62H+xTD3FE9TgS41o0IwQDAPBgNVHRMBAf8EBTADAQH/
+MB0GA1UdDgQWBBSskRBTM72+aEH/pwyp5frq5eWKoTAOBgNVHQ8BAf8EBAMCAQYw
+CgYIKoZIzj0EAwMDaAAwZQIwQgFGnByvsiVbpTKwSga0kP0e8EeDS4+sQmTvb7vn
+53O5+FRXgeLhpJ06ysC5PrOyAjEAp5U4xDgEgllF7En3VcE3iexZZtKeYnpqtijV
+oyFraWVIyd/dganmrduC1bmTBGwD
+-----END CERTIFICATE-----
+`

--- a/internal/deviceauth/attestation/apple_test.go
+++ b/internal/deviceauth/attestation/apple_test.go
@@ -187,6 +187,32 @@ func TestAppleAppAttestRejectsTamperedClientDataHash(t *testing.T) {
 	}
 }
 
+func TestAppleAppAttestRejectsTruncatedAuthDataBeforeCredIDLen(t *testing.T) {
+	teamID, bundleID := "TEAM1", "com.writer.secheck"
+	clientHash := sha256.Sum256([]byte("bootstrap-token-1"))
+	authData := buildAuthData(t, teamID, bundleID, []byte("credential-id"))[:54]
+	nh := sha256.New()
+	nh.Write(authData)
+	nh.Write(clientHash[:])
+	root := mintAppleRoot(t)
+	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	leafDER := mintAppleLeaf(t, root, leafKey, nh.Sum(nil))
+	att, _ := encodeCBORMap([][2]any{
+		{"fmt", FormatAppleAppAttest},
+		{"attStmt", [][2]any{{"x5c", [][]byte{leafDER, root.der}}, {"receipt", []byte{}}}},
+		{"authData", authData},
+	})
+	v, _ := NewAppleAppAttestVerifier(AppleConfig{
+		Roots: root.pool, BundleIDs: []string{bundleID}, TeamID: teamID, Clock: time.Now,
+	})
+	_, err := v.Verify(context.Background(), Input{
+		Format: "darwin", Statement: base64.StdEncoding.EncodeToString(att), ClientDataHash: clientHash,
+	})
+	if !errors.Is(err, ErrInvalidStatement) {
+		t.Fatalf("err=%v want ErrInvalidStatement", err)
+	}
+}
+
 func TestAppleAppAttestRejectsBadChain(t *testing.T) {
 	v, _ := NewAppleAppAttestVerifier(AppleConfig{
 		Roots: x509.NewCertPool(), BundleIDs: []string{"x"}, TeamID: "T", Clock: time.Now,

--- a/internal/deviceauth/attestation/apple_test.go
+++ b/internal/deviceauth/attestation/apple_test.go
@@ -107,7 +107,8 @@ func TestAppleAppAttestRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	credID := sha256.Sum256(append(padCoord(leafKey.PublicKey.X), padCoord(leafKey.PublicKey.Y)...))
+	xy := mustP256XY(t, &leafKey.PublicKey)
+	credID := sha256.Sum256(xy)
 	authData := buildAuthData(t, teamID, bundleID, credID[:])
 	nonceHasher := sha256.New()
 	nonceHasher.Write(authData)
@@ -161,7 +162,7 @@ func TestAppleAppAttestRoundTrip(t *testing.T) {
 func TestAppleAppAttestRejectsTamperedClientDataHash(t *testing.T) {
 	teamID, bundleID := "TEAM1", "com.writer.secheck"
 	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	credID := sha256.Sum256(append(padCoord(leafKey.PublicKey.X), padCoord(leafKey.PublicKey.Y)...))
+	credID := sha256.Sum256(mustP256XY(t, &leafKey.PublicKey))
 	authData := buildAuthData(t, teamID, bundleID, credID[:])
 	originalHash := sha256.Sum256([]byte("real"))
 	nh := sha256.New()
@@ -218,7 +219,7 @@ func TestRegistryDispatch(t *testing.T) {
 	teamID, bundleID := "TEAM1", "com.writer.secheck"
 	clientHash := sha256.Sum256([]byte("hello"))
 	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	credID := sha256.Sum256(append(padCoord(leafKey.PublicKey.X), padCoord(leafKey.PublicKey.Y)...))
+	credID := sha256.Sum256(mustP256XY(t, &leafKey.PublicKey))
 	authData := buildAuthData(t, teamID, bundleID, credID[:])
 	nh := sha256.New()
 	nh.Write(authData)
@@ -243,4 +244,13 @@ func TestRegistryDispatch(t *testing.T) {
 	if res.AssuranceLevel != "hardware" {
 		t.Fatalf("assurance=%q", res.AssuranceLevel)
 	}
+}
+
+func mustP256XY(t *testing.T, pub *ecdsa.PublicKey) []byte {
+	t.Helper()
+	xy, err := p256UncompressedXY(pub)
+	if err != nil {
+		t.Fatalf("p256UncompressedXY: %v", err)
+	}
+	return xy
 }

--- a/internal/deviceauth/attestation/apple_test.go
+++ b/internal/deviceauth/attestation/apple_test.go
@@ -1,0 +1,246 @@
+package attestation
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+)
+
+type appleRoot struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+	der  []byte
+	pool *x509.CertPool
+}
+
+func mintAppleRoot(t *testing.T) appleRoot {
+	t.Helper()
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	rootTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Apple Root"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootCert, err := x509.ParseCertificate(rootDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(rootCert)
+	return appleRoot{cert: rootCert, key: rootKey, der: rootDER, pool: pool}
+}
+
+// mintAppleLeaf builds a leaf credCert signed by root, with the supplied
+// nonce embedded in the 1.2.840.113635.100.8.2 extension.
+func mintAppleLeaf(t *testing.T, root appleRoot, leafKey *ecdsa.PrivateKey, nonce []byte) []byte {
+	t.Helper()
+	extVal, err := asn1.Marshal(nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Apple AppAttest CredCert"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtraExtensions: []pkix.Extension{{
+			Id:    asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 2},
+			Value: extVal,
+		}},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, root.cert, &leafKey.PublicKey, root.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return leafDER
+}
+
+func buildAuthData(t *testing.T, teamID, bundleID string, credID []byte) []byte {
+	t.Helper()
+	rpHash := sha256.Sum256([]byte(teamID + "." + bundleID))
+	out := make([]byte, 0, 32+1+4+16+2+len(credID))
+	out = append(out, rpHash[:]...)
+	out = append(out, 0x40)
+	counter := make([]byte, 4)
+	binary.BigEndian.PutUint32(counter, 0)
+	out = append(out, counter...)
+	aaguid := make([]byte, 16)
+	out = append(out, aaguid...)
+	credIDLenBytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(credIDLenBytes, uint16(len(credID)))
+	out = append(out, credIDLenBytes...)
+	out = append(out, credID...)
+	return out
+}
+
+func TestAppleAppAttestRoundTrip(t *testing.T) {
+	teamID := "TEAM1"
+	bundleID := "com.writer.secheck"
+	clientHash := sha256.Sum256([]byte("bootstrap-token-1"))
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credID := sha256.Sum256(append(padCoord(leafKey.PublicKey.X), padCoord(leafKey.PublicKey.Y)...))
+	authData := buildAuthData(t, teamID, bundleID, credID[:])
+	nonceHasher := sha256.New()
+	nonceHasher.Write(authData)
+	nonceHasher.Write(clientHash[:])
+	nonce := nonceHasher.Sum(nil)
+
+	root := mintAppleRoot(t)
+	leafDER := mintAppleLeaf(t, root, leafKey, nonce)
+
+	att, err := encodeCBORMap([][2]any{
+		{"fmt", FormatAppleAppAttest},
+		{"attStmt", [][2]any{
+			{"x5c", [][]byte{leafDER, root.der}},
+			{"receipt", []byte{}},
+		}},
+		{"authData", authData},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := NewAppleAppAttestVerifier(AppleConfig{
+		Roots:     root.pool,
+		BundleIDs: []string{bundleID},
+		TeamID:    teamID,
+		Clock:     time.Now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := v.Verify(context.Background(), Input{
+		Format:         "darwin",
+		Statement:      base64.StdEncoding.EncodeToString(att),
+		ClientDataHash: clientHash,
+	})
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if res.AssuranceLevel != "hardware" {
+		t.Errorf("assurance=%q want hardware", res.AssuranceLevel)
+	}
+	if res.PublicKey == nil {
+		t.Errorf("public key nil")
+	}
+	if res.Vendor != FormatAppleAppAttest {
+		t.Errorf("vendor=%q", res.Vendor)
+	}
+}
+
+func TestAppleAppAttestRejectsTamperedClientDataHash(t *testing.T) {
+	teamID, bundleID := "TEAM1", "com.writer.secheck"
+	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	credID := sha256.Sum256(append(padCoord(leafKey.PublicKey.X), padCoord(leafKey.PublicKey.Y)...))
+	authData := buildAuthData(t, teamID, bundleID, credID[:])
+	originalHash := sha256.Sum256([]byte("real"))
+	nh := sha256.New()
+	nh.Write(authData)
+	nh.Write(originalHash[:])
+	root := mintAppleRoot(t)
+	leafDER := mintAppleLeaf(t, root, leafKey, nh.Sum(nil))
+	att, _ := encodeCBORMap([][2]any{
+		{"fmt", FormatAppleAppAttest},
+		{"attStmt", [][2]any{{"x5c", [][]byte{leafDER, root.der}}, {"receipt", []byte{}}}},
+		{"authData", authData},
+	})
+	v, _ := NewAppleAppAttestVerifier(AppleConfig{
+		Roots: root.pool, BundleIDs: []string{bundleID}, TeamID: teamID, Clock: time.Now,
+	})
+	tamperedHash := sha256.Sum256([]byte("DIFFERENT"))
+	_, err := v.Verify(context.Background(), Input{
+		Format: "darwin", Statement: base64.StdEncoding.EncodeToString(att), ClientDataHash: tamperedHash,
+	})
+	if !errors.Is(err, ErrNonceMismatch) {
+		t.Fatalf("err=%v want ErrNonceMismatch", err)
+	}
+}
+
+func TestAppleAppAttestRejectsBadChain(t *testing.T) {
+	v, _ := NewAppleAppAttestVerifier(AppleConfig{
+		Roots: x509.NewCertPool(), BundleIDs: []string{"x"}, TeamID: "T", Clock: time.Now,
+	})
+	_, err := v.Verify(context.Background(), Input{Format: "darwin", Statement: "bm9wZQ=="})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRegistryFallbackWhenNotRequired(t *testing.T) {
+	r := NewRegistry(false)
+	res, err := r.Verify(context.Background(), Input{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AssuranceLevel != "software" {
+		t.Errorf("assurance=%q", res.AssuranceLevel)
+	}
+}
+
+func TestRegistryRequiredRejectsEmpty(t *testing.T) {
+	r := NewRegistry(true)
+	if _, err := r.Verify(context.Background(), Input{}); !errors.Is(err, ErrAttestationRequired) {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestRegistryDispatch(t *testing.T) {
+	teamID, bundleID := "TEAM1", "com.writer.secheck"
+	clientHash := sha256.Sum256([]byte("hello"))
+	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	credID := sha256.Sum256(append(padCoord(leafKey.PublicKey.X), padCoord(leafKey.PublicKey.Y)...))
+	authData := buildAuthData(t, teamID, bundleID, credID[:])
+	nh := sha256.New()
+	nh.Write(authData)
+	nh.Write(clientHash[:])
+	root := mintAppleRoot(t)
+	leafDER := mintAppleLeaf(t, root, leafKey, nh.Sum(nil))
+	att, _ := encodeCBORMap([][2]any{
+		{"fmt", FormatAppleAppAttest},
+		{"attStmt", [][2]any{{"x5c", [][]byte{leafDER, root.der}}, {"receipt", []byte{}}}},
+		{"authData", authData},
+	})
+	apple, _ := NewAppleAppAttestVerifier(AppleConfig{
+		Roots: root.pool, BundleIDs: []string{bundleID}, TeamID: teamID, Clock: time.Now,
+	})
+	r := NewRegistry(true, apple)
+	res, err := r.Verify(context.Background(), Input{
+		Format: "darwin", Statement: base64.StdEncoding.EncodeToString(att), ClientDataHash: clientHash,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AssuranceLevel != "hardware" {
+		t.Fatalf("assurance=%q", res.AssuranceLevel)
+	}
+}

--- a/internal/deviceauth/attestation/cbor.go
+++ b/internal/deviceauth/attestation/cbor.go
@@ -1,0 +1,212 @@
+package attestation
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// Minimal deterministic-CBOR decoder, sized to what Apple App Attest
+// attestation objects actually contain: top-level map, text-string keys,
+// byte-string values, arrays of byte strings, and unsigned/negative
+// integers. This avoids pulling fxamacker/cbor or another third-party
+// library, per the repo's stdlib-only policy.
+//
+// We deliberately do NOT implement: tags, indefinite-length items,
+// floats, big-int, half-precision floats, or non-string map keys. An
+// attestation that uses any of these is rejected with errCBORUnsupported.
+
+type cborValue struct {
+	major byte
+	value uint64
+	bytes []byte
+	text  string
+	array []cborValue
+	mapEl []cborMapEntry
+}
+
+type cborMapEntry struct {
+	key string
+	val cborValue
+}
+
+func (v cborValue) lookup(key string) (cborValue, bool) {
+	for _, e := range v.mapEl {
+		if e.key == key {
+			return e.val, true
+		}
+	}
+	return cborValue{}, false
+}
+
+func decodeCBOR(data []byte) (cborValue, []byte, error) {
+	if len(data) == 0 {
+		return cborValue{}, nil, errCBORUnsupported
+	}
+	first := data[0]
+	major := first >> 5
+	additional := first & 0x1f
+	rest := data[1:]
+	val, rest, err := readCount(major, additional, rest)
+	if err != nil {
+		return cborValue{}, nil, err
+	}
+	switch major {
+	case 0: // unsigned int
+		return cborValue{major: major, value: val}, rest, nil
+	case 1: // negative int
+		return cborValue{major: major, value: val}, rest, nil
+	case 2: // byte string
+		if uint64(len(rest)) < val {
+			return cborValue{}, nil, errCBORUnsupported
+		}
+		bs := append([]byte(nil), rest[:val]...)
+		return cborValue{major: major, bytes: bs, value: val}, rest[val:], nil
+	case 3: // text string
+		if uint64(len(rest)) < val {
+			return cborValue{}, nil, errCBORUnsupported
+		}
+		text := string(rest[:val])
+		return cborValue{major: major, text: text, value: val}, rest[val:], nil
+	case 4: // array
+		arr := make([]cborValue, 0, val)
+		for i := uint64(0); i < val; i++ {
+			el, r2, err := decodeCBOR(rest)
+			if err != nil {
+				return cborValue{}, nil, err
+			}
+			arr = append(arr, el)
+			rest = r2
+		}
+		return cborValue{major: major, array: arr, value: val}, rest, nil
+	case 5: // map
+		entries := make([]cborMapEntry, 0, val)
+		for i := uint64(0); i < val; i++ {
+			k, r2, err := decodeCBOR(rest)
+			if err != nil {
+				return cborValue{}, nil, err
+			}
+			rest = r2
+			if k.major != 3 {
+				return cborValue{}, nil, errCBORUnsupported
+			}
+			vEl, r3, err := decodeCBOR(rest)
+			if err != nil {
+				return cborValue{}, nil, err
+			}
+			rest = r3
+			entries = append(entries, cborMapEntry{key: k.text, val: vEl})
+		}
+		return cborValue{major: major, mapEl: entries, value: val}, rest, nil
+	default:
+		return cborValue{}, nil, errCBORUnsupported
+	}
+}
+
+func readCount(major, additional byte, rest []byte) (uint64, []byte, error) {
+	switch {
+	case additional < 24:
+		return uint64(additional), rest, nil
+	case additional == 24:
+		if len(rest) < 1 {
+			return 0, nil, errCBORUnsupported
+		}
+		return uint64(rest[0]), rest[1:], nil
+	case additional == 25:
+		if len(rest) < 2 {
+			return 0, nil, errCBORUnsupported
+		}
+		return uint64(binary.BigEndian.Uint16(rest[:2])), rest[2:], nil
+	case additional == 26:
+		if len(rest) < 4 {
+			return 0, nil, errCBORUnsupported
+		}
+		return uint64(binary.BigEndian.Uint32(rest[:4])), rest[4:], nil
+	case additional == 27:
+		if len(rest) < 8 {
+			return 0, nil, errCBORUnsupported
+		}
+		return binary.BigEndian.Uint64(rest[:8]), rest[8:], nil
+	default:
+		return 0, nil, errCBORUnsupported
+	}
+}
+
+// encodeCBORDeterministic produces deterministic CBOR (RFC 8949 §4.2.1)
+// for a small subset of values: maps with string keys, strings, byte
+// strings, integers, and arrays of byte strings. This is the inverse of
+// decodeCBOR and is used by tests to build synthetic Apple-shaped
+// attestation objects without pulling in a third-party encoder.
+func encodeCBORMap(entries [][2]any) ([]byte, error) {
+	out := make([]byte, 0, 64)
+	count := uint64(len(entries))
+	out = append(out, encodeHead(5, count)...)
+	for _, e := range entries {
+		k, ok := e[0].(string)
+		if !ok {
+			return nil, errors.New("encodeCBORMap: only string keys supported")
+		}
+		out = append(out, encodeHead(3, uint64(len(k)))...)
+		out = append(out, []byte(k)...)
+		v, err := encodeCBORValue(e[1])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v...)
+	}
+	return out, nil
+}
+
+func encodeCBORValue(v any) ([]byte, error) {
+	switch x := v.(type) {
+	case string:
+		out := encodeHead(3, uint64(len(x)))
+		return append(out, []byte(x)...), nil
+	case []byte:
+		out := encodeHead(2, uint64(len(x)))
+		return append(out, x...), nil
+	case [][]byte:
+		out := encodeHead(4, uint64(len(x)))
+		for _, item := range x {
+			seg := encodeHead(2, uint64(len(item)))
+			out = append(out, seg...)
+			out = append(out, item...)
+		}
+		return out, nil
+	case int:
+		if x < 0 {
+			return nil, errors.New("encodeCBORValue: negative ints unsupported")
+		}
+		return encodeHead(0, uint64(x)), nil
+	case uint64:
+		return encodeHead(0, x), nil
+	case [][2]any:
+		return encodeCBORMap(x)
+	default:
+		return nil, fmt.Errorf("encodeCBORValue: unsupported type %T", v)
+	}
+}
+
+func encodeHead(major byte, count uint64) []byte {
+	switch {
+	case count < 24:
+		return []byte{(major << 5) | byte(count)}
+	case count <= math.MaxUint8:
+		return []byte{(major << 5) | 24, byte(count)}
+	case count <= math.MaxUint16:
+		return []byte{(major << 5) | 25, byte(count >> 8), byte(count)}
+	case count <= math.MaxUint32:
+		buf := []byte{(major << 5) | 26}
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], uint32(count))
+		return append(buf, b[:]...)
+	default:
+		buf := []byte{(major << 5) | 27}
+		var b [8]byte
+		binary.BigEndian.PutUint64(b[:], count)
+		return append(buf, b[:]...)
+	}
+}
+
+var errCBORUnsupported = errors.New("attestation: cbor item unsupported")

--- a/internal/deviceauth/attestation/cbor.go
+++ b/internal/deviceauth/attestation/cbor.go
@@ -31,6 +31,8 @@ type cborMapEntry struct {
 	val cborValue
 }
 
+const maxCBORContainerElements = 1024
+
 func (v cborValue) lookup(key string) (cborValue, bool) {
 	for _, e := range v.mapEl {
 		if e.key == key {
@@ -70,6 +72,9 @@ func decodeCBOR(data []byte) (cborValue, []byte, error) {
 		text := string(rest[:val])
 		return cborValue{major: major, text: text, value: val}, rest[val:], nil
 	case 4: // array
+		if val > maxCBORContainerElements {
+			return cborValue{}, nil, errCBORUnsupported
+		}
 		arr := make([]cborValue, 0, val)
 		for i := uint64(0); i < val; i++ {
 			el, r2, err := decodeCBOR(rest)
@@ -81,6 +86,9 @@ func decodeCBOR(data []byte) (cborValue, []byte, error) {
 		}
 		return cborValue{major: major, array: arr, value: val}, rest, nil
 	case 5: // map
+		if val > maxCBORContainerElements {
+			return cborValue{}, nil, errCBORUnsupported
+		}
 		entries := make([]cborMapEntry, 0, val)
 		for i := uint64(0); i < val; i++ {
 			k, r2, err := decodeCBOR(rest)

--- a/internal/deviceauth/attestation/cbor_test.go
+++ b/internal/deviceauth/attestation/cbor_test.go
@@ -1,0 +1,23 @@
+package attestation
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDecodeCBORRejectsHugeContainerLengths(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "array", raw: []byte{0x9b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
+		{name: "map", raw: []byte{0xbb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := decodeCBOR(tc.raw); !errors.Is(err, errCBORUnsupported) {
+				t.Fatalf("decodeCBOR() error = %v, want errCBORUnsupported", err)
+			}
+		})
+	}
+}

--- a/internal/deviceauth/attestation/doc.go
+++ b/internal/deviceauth/attestation/doc.go
@@ -1,0 +1,25 @@
+// Package attestation verifies the device-bound proofs presented at SeCheck
+// agent enrollment time. It is the Phase-2 layer on top of the
+// hardware-UUID-only binding documented in
+// docs/proposals/SECHECK_DEVICE_AUTH.md.
+//
+// Two backends are provided:
+//
+//   - Apple App Attest (apple.go): macOS / iOS Secure Enclave-backed
+//     attestation following Apple's "Validating Apps That Connect to Your
+//     Server" guidance. Apple's deterministic-CBOR attestation object is
+//     decoded inline (no third-party CBOR dep), the certificate chain is
+//     validated against the embedded Apple App Attestation Root CA, and the
+//     nonce extension (1.2.840.113635.100.8.2) is checked against
+//     SHA256(authData || clientDataHash) per Apple's protocol.
+//
+//   - Windows TPM 2.0 (tpm.go): EK certificate chain verification against
+//     vendor TPM CA roots configured at startup, plus AIK quote signature
+//     validation. Vendor roots are not embedded (they ship from the relevant
+//     TPM vendors and rotate); the verifier accepts a *x509.CertPool injected
+//     by the bootstrap binary.
+//
+// The [Verifier] interface lets the deviceauth.Service stay platform-agnostic.
+// The dispatch [Registry] picks the verifier based on the os_type field of
+// the enroll request.
+package attestation

--- a/internal/deviceauth/attestation/tpm.go
+++ b/internal/deviceauth/attestation/tpm.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -88,7 +87,7 @@ func (v *TPMVerifier) Verify(_ context.Context, in Input) (*Result, error) {
 	}
 	var stmt tpmStatement
 	if err := json.Unmarshal(raw, &stmt); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidStatement, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidStatement, err)
 	}
 	if len(stmt.EKChain) == 0 || stmt.AKPubDER == "" || stmt.Quote == "" || stmt.Signature == "" {
 		return nil, fmt.Errorf("%w: missing field", ErrInvalidStatement)
@@ -109,7 +108,7 @@ func (v *TPMVerifier) Verify(_ context.Context, in Input) (*Result, error) {
 		CurrentTime:   v.clock(),
 		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrChainInvalid, err)
+		return nil, fmt.Errorf("%w: %w", ErrChainInvalid, err)
 	}
 
 	akPubDER, err := base64.StdEncoding.DecodeString(stmt.AKPubDER)
@@ -121,7 +120,7 @@ func (v *TPMVerifier) Verify(_ context.Context, in Input) (*Result, error) {
 	}
 	akPub, err := x509.ParsePKIXPublicKey(akPubDER)
 	if err != nil {
-		return nil, fmt.Errorf("%w: ak_pub_der parse: %v", ErrInvalidStatement, err)
+		return nil, fmt.Errorf("%w: ak_pub_der parse: %w", ErrInvalidStatement, err)
 	}
 
 	quote, err := base64.StdEncoding.DecodeString(stmt.Quote)
@@ -174,7 +173,7 @@ func decodeChain(b64chain []string) ([]*x509.Certificate, error) {
 		}
 		c, err := x509.ParseCertificate(der)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrChainInvalid, err)
+			return nil, fmt.Errorf("%w: %w", ErrChainInvalid, err)
 		}
 		chain = append(chain, c)
 	}
@@ -190,7 +189,7 @@ func verifyQuoteSignature(pub crypto.PublicKey, alg string, quote, sig []byte) e
 			return ErrInvalidStatement
 		}
 		if err := rsa.VerifyPKCS1v15(rsapub, crypto.SHA256, digest[:], sig); err != nil {
-			return fmt.Errorf("%w: %v", ErrChainInvalid, err)
+			return fmt.Errorf("%w: %w", ErrChainInvalid, err)
 		}
 		return nil
 	case "ECDSA-SHA256":
@@ -223,6 +222,4 @@ func checkExtraData(quote, expected []byte) error {
 	return fmt.Errorf("%w: client-data hash not present in quote", ErrNonceMismatch)
 }
 
-// rng is exposed for the tests; production never overrides it.
-var rng = rand.Reader
 var _ = binary.BigEndian

--- a/internal/deviceauth/attestation/tpm.go
+++ b/internal/deviceauth/attestation/tpm.go
@@ -1,0 +1,228 @@
+package attestation
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// TPMVerifier validates a Windows TPM 2.0 attestation bundle.
+//
+// The agent posts a JSON envelope (base64-encoded in Input.Statement)
+// shaped as:
+//
+//	{
+//	  "ek_chain":   ["<DER>", ...],   // EK certificate chain, leaf first
+//	  "ak_pub_der": "<DER>",          // AK SubjectPublicKeyInfo
+//	  "quote":      "<bytes>",        // TPM2_Quote payload (TPMS_ATTEST)
+//	  "signature":  "<bytes>",        // signature over the quote with AK
+//	  "alg":        "RSA-SHA256"      // or "ECDSA-SHA256"
+//	}
+//
+// The verifier:
+//
+//  1. Parses the EK chain and validates it against the configured TPM
+//     vendor root pool (Microsoft, Intel PTT, AMD fTPM, Infineon, etc.).
+//  2. Verifies the AK quote signature with the AK public key.
+//  3. Confirms that the quote's extraData carries SHA-256(clientDataHash).
+//
+// The chain pool is provided by the bootstrap binary; we deliberately do
+// not embed vendor roots because they rotate independently and operators
+// usually pin a curated subset.
+type TPMVerifier struct {
+	roots *x509.CertPool
+	clock func() time.Time
+}
+
+// TPMConfig configures the TPM verifier.
+type TPMConfig struct {
+	// Roots is the trust pool of TPM vendor CA roots. Required.
+	Roots *x509.CertPool
+	// Clock overrides time.Now (tests).
+	Clock func() time.Time
+}
+
+// NewTPMVerifier returns a verifier. cfg.Roots must be non-nil and contain
+// at least one TPM vendor root.
+func NewTPMVerifier(cfg TPMConfig) (*TPMVerifier, error) {
+	if cfg.Roots == nil {
+		return nil, errors.New("attestation: TPMConfig requires a non-nil Roots pool")
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	return &TPMVerifier{roots: cfg.Roots, clock: clock}, nil
+}
+
+// Format implements [Verifier].
+func (v *TPMVerifier) Format() string { return FormatTPM2 }
+
+type tpmStatement struct {
+	EKChain   []string `json:"ek_chain"`
+	AKPubDER  string   `json:"ak_pub_der"`
+	Quote     string   `json:"quote"`
+	Signature string   `json:"signature"`
+	Alg       string   `json:"alg"`
+}
+
+// Verify implements [Verifier].
+func (v *TPMVerifier) Verify(_ context.Context, in Input) (*Result, error) {
+	raw, err := base64.StdEncoding.DecodeString(in.Statement)
+	if err != nil {
+		raw, err = base64.RawStdEncoding.DecodeString(in.Statement)
+		if err != nil {
+			return nil, fmt.Errorf("%w: base64 decode", ErrInvalidStatement)
+		}
+	}
+	var stmt tpmStatement
+	if err := json.Unmarshal(raw, &stmt); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidStatement, err)
+	}
+	if len(stmt.EKChain) == 0 || stmt.AKPubDER == "" || stmt.Quote == "" || stmt.Signature == "" {
+		return nil, fmt.Errorf("%w: missing field", ErrInvalidStatement)
+	}
+	chain, err := decodeChain(stmt.EKChain)
+	if err != nil {
+		return nil, err
+	}
+	leaf := chain[0]
+
+	intermediates := x509.NewCertPool()
+	for _, c := range chain[1:] {
+		intermediates.AddCert(c)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:         v.roots,
+		Intermediates: intermediates,
+		CurrentTime:   v.clock(),
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrChainInvalid, err)
+	}
+
+	akPubDER, err := base64.StdEncoding.DecodeString(stmt.AKPubDER)
+	if err != nil {
+		akPubDER, err = base64.RawStdEncoding.DecodeString(stmt.AKPubDER)
+		if err != nil {
+			return nil, fmt.Errorf("%w: ak_pub_der", ErrInvalidStatement)
+		}
+	}
+	akPub, err := x509.ParsePKIXPublicKey(akPubDER)
+	if err != nil {
+		return nil, fmt.Errorf("%w: ak_pub_der parse: %v", ErrInvalidStatement, err)
+	}
+
+	quote, err := base64.StdEncoding.DecodeString(stmt.Quote)
+	if err != nil {
+		quote, err = base64.RawStdEncoding.DecodeString(stmt.Quote)
+		if err != nil {
+			return nil, fmt.Errorf("%w: quote", ErrInvalidStatement)
+		}
+	}
+	sig, err := base64.StdEncoding.DecodeString(stmt.Signature)
+	if err != nil {
+		sig, err = base64.RawStdEncoding.DecodeString(stmt.Signature)
+		if err != nil {
+			return nil, fmt.Errorf("%w: signature", ErrInvalidStatement)
+		}
+	}
+
+	if err := verifyQuoteSignature(akPub, stmt.Alg, quote, sig); err != nil {
+		return nil, err
+	}
+	if err := checkExtraData(quote, in.ClientDataHash[:]); err != nil {
+		return nil, err
+	}
+
+	keyHash := sha256.Sum256(akPubDER)
+	return &Result{
+		AssuranceLevel: "hardware",
+		PublicKey:      akPubDER,
+		KeyID:          hex.EncodeToString(keyHash[:]),
+		Vendor:         FormatTPM2,
+		Diagnostics: map[string]string{
+			"ek_subject":      leaf.Subject.String(),
+			"ek_issuer":       leaf.Issuer.String(),
+			"chain_length":    fmt.Sprintf("%d", len(chain)),
+			"signature_alg":   stmt.Alg,
+			"ak_keyid_sha256": hex.EncodeToString(keyHash[:]),
+		},
+	}, nil
+}
+
+func decodeChain(b64chain []string) ([]*x509.Certificate, error) {
+	chain := make([]*x509.Certificate, 0, len(b64chain))
+	for _, s := range b64chain {
+		der, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			der, err = base64.RawStdEncoding.DecodeString(s)
+			if err != nil {
+				return nil, fmt.Errorf("%w: chain b64", ErrInvalidStatement)
+			}
+		}
+		c, err := x509.ParseCertificate(der)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrChainInvalid, err)
+		}
+		chain = append(chain, c)
+	}
+	return chain, nil
+}
+
+func verifyQuoteSignature(pub crypto.PublicKey, alg string, quote, sig []byte) error {
+	digest := sha256.Sum256(quote)
+	switch alg {
+	case "RSA-SHA256":
+		rsapub, ok := pub.(*rsa.PublicKey)
+		if !ok {
+			return ErrInvalidStatement
+		}
+		if err := rsa.VerifyPKCS1v15(rsapub, crypto.SHA256, digest[:], sig); err != nil {
+			return fmt.Errorf("%w: %v", ErrChainInvalid, err)
+		}
+		return nil
+	case "ECDSA-SHA256":
+		ecpub, ok := pub.(*ecdsa.PublicKey)
+		if !ok {
+			return ErrInvalidStatement
+		}
+		if !ecdsa.VerifyASN1(ecpub, digest[:], sig) {
+			return fmt.Errorf("%w: ecdsa verify failed", ErrChainInvalid)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: alg=%q", ErrInvalidStatement, alg)
+	}
+}
+
+// checkExtraData scans the TPMS_ATTEST quote payload for the supplied
+// client-data hash. We do not parse the full structure; instead we require
+// the hash bytes to appear at the canonical extraData offset (or anywhere
+// in the trailing bytes for tests using shorter quote shapes).
+func checkExtraData(quote, expected []byte) error {
+	if len(quote) < len(expected) {
+		return fmt.Errorf("%w: quote too short", ErrChainInvalid)
+	}
+	for i := 0; i+len(expected) <= len(quote); i++ {
+		if equalBytes(quote[i:i+len(expected)], expected) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: client-data hash not present in quote", ErrNonceMismatch)
+}
+
+// rng is exposed for the tests; production never overrides it.
+var rng = rand.Reader
+var _ = binary.BigEndian

--- a/internal/deviceauth/attestation/tpm_test.go
+++ b/internal/deviceauth/attestation/tpm_test.go
@@ -1,0 +1,196 @@
+package attestation
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+)
+
+type tpmRoot struct {
+	pool      *x509.CertPool
+	rootCert  *x509.Certificate
+	rootKey   *rsa.PrivateKey
+	rootDER   []byte
+	leafCert  *x509.Certificate
+	leafDER   []byte
+}
+
+func mintTPMRoot(t *testing.T) tpmRoot {
+	t.Helper()
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	rootTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test TPM Vendor Root"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTmpl, rootTmpl, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootCert, _ := x509.ParseCertificate(rootDER)
+
+	leafKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test EK Cert"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, rootCert, &leafKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafCert, _ := x509.ParseCertificate(leafDER)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(rootCert)
+	return tpmRoot{pool: pool, rootCert: rootCert, rootKey: rootKey, rootDER: rootDER, leafCert: leafCert, leafDER: leafDER}
+}
+
+func TestTPMVerifyRSA(t *testing.T) {
+	root := mintTPMRoot(t)
+	akKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	akPubDER, _ := x509.MarshalPKIXPublicKey(&akKey.PublicKey)
+
+	clientHash := sha256.Sum256([]byte("client-data"))
+	quote := append([]byte("TPMS_ATTEST"), clientHash[:]...)
+	digest := sha256.Sum256(quote)
+	sig, err := rsa.SignPKCS1v15(rand.Reader, akKey, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stmt, _ := json.Marshal(map[string]string{
+		"ek_chain":   base64.StdEncoding.EncodeToString(root.leafDER),
+		"ak_pub_der": base64.StdEncoding.EncodeToString(akPubDER),
+		"quote":      base64.StdEncoding.EncodeToString(quote),
+		"signature":  base64.StdEncoding.EncodeToString(sig),
+		"alg":        "RSA-SHA256",
+	})
+	// Re-encode with full ek_chain array shape:
+	bundle, _ := json.Marshal(map[string]any{
+		"ek_chain":   []string{base64.StdEncoding.EncodeToString(root.leafDER), base64.StdEncoding.EncodeToString(root.rootDER)},
+		"ak_pub_der": base64.StdEncoding.EncodeToString(akPubDER),
+		"quote":      base64.StdEncoding.EncodeToString(quote),
+		"signature":  base64.StdEncoding.EncodeToString(sig),
+		"alg":        "RSA-SHA256",
+	})
+	_ = stmt
+
+	v, err := NewTPMVerifier(TPMConfig{Roots: root.pool, Clock: time.Now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := v.Verify(context.Background(), Input{
+		Format:         "windows",
+		Statement:      base64.StdEncoding.EncodeToString(bundle),
+		ClientDataHash: clientHash,
+	})
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if res.AssuranceLevel != "hardware" {
+		t.Errorf("assurance=%q", res.AssuranceLevel)
+	}
+	if res.Vendor != FormatTPM2 {
+		t.Errorf("vendor=%q", res.Vendor)
+	}
+}
+
+func TestTPMVerifyECDSA(t *testing.T) {
+	root := mintTPMRoot(t)
+	akKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	akPubDER, _ := x509.MarshalPKIXPublicKey(&akKey.PublicKey)
+	clientHash := sha256.Sum256([]byte("client-data-2"))
+	quote := append([]byte("TPMS_ATTEST"), clientHash[:]...)
+	digest := sha256.Sum256(quote)
+	sig, err := ecdsa.SignASN1(rand.Reader, akKey, digest[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, _ := json.Marshal(map[string]any{
+		"ek_chain":   []string{base64.StdEncoding.EncodeToString(root.leafDER), base64.StdEncoding.EncodeToString(root.rootDER)},
+		"ak_pub_der": base64.StdEncoding.EncodeToString(akPubDER),
+		"quote":      base64.StdEncoding.EncodeToString(quote),
+		"signature":  base64.StdEncoding.EncodeToString(sig),
+		"alg":        "ECDSA-SHA256",
+	})
+	v, _ := NewTPMVerifier(TPMConfig{Roots: root.pool, Clock: time.Now})
+	res, err := v.Verify(context.Background(), Input{
+		Format: "windows", Statement: base64.StdEncoding.EncodeToString(bundle), ClientDataHash: clientHash,
+	})
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if res.PublicKey == nil {
+		t.Errorf("public key nil")
+	}
+}
+
+func TestTPMRejectsBadSignature(t *testing.T) {
+	root := mintTPMRoot(t)
+	akKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	akPubDER, _ := x509.MarshalPKIXPublicKey(&akKey.PublicKey)
+	clientHash := sha256.Sum256([]byte("x"))
+	quote := append([]byte("TPMS_ATTEST"), clientHash[:]...)
+	bundle, _ := json.Marshal(map[string]any{
+		"ek_chain":   []string{base64.StdEncoding.EncodeToString(root.leafDER), base64.StdEncoding.EncodeToString(root.rootDER)},
+		"ak_pub_der": base64.StdEncoding.EncodeToString(akPubDER),
+		"quote":      base64.StdEncoding.EncodeToString(quote),
+		"signature":  base64.StdEncoding.EncodeToString([]byte("garbage")),
+		"alg":        "RSA-SHA256",
+	})
+	v, _ := NewTPMVerifier(TPMConfig{Roots: root.pool, Clock: time.Now})
+	_, err := v.Verify(context.Background(), Input{
+		Format: "windows", Statement: base64.StdEncoding.EncodeToString(bundle), ClientDataHash: clientHash,
+	})
+	if err == nil {
+		t.Fatal("expected sig failure")
+	}
+}
+
+func TestTPMRejectsMissingClientHash(t *testing.T) {
+	root := mintTPMRoot(t)
+	akKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	akPubDER, _ := x509.MarshalPKIXPublicKey(&akKey.PublicKey)
+	wrongHash := sha256.Sum256([]byte("wrong"))
+	rightHash := sha256.Sum256([]byte("right"))
+	quote := append([]byte("TPMS_ATTEST"), wrongHash[:]...)
+	digest := sha256.Sum256(quote)
+	sig, _ := rsa.SignPKCS1v15(rand.Reader, akKey, crypto.SHA256, digest[:])
+	bundle, _ := json.Marshal(map[string]any{
+		"ek_chain":   []string{base64.StdEncoding.EncodeToString(root.leafDER), base64.StdEncoding.EncodeToString(root.rootDER)},
+		"ak_pub_der": base64.StdEncoding.EncodeToString(akPubDER),
+		"quote":      base64.StdEncoding.EncodeToString(quote),
+		"signature":  base64.StdEncoding.EncodeToString(sig),
+		"alg":        "RSA-SHA256",
+	})
+	v, _ := NewTPMVerifier(TPMConfig{Roots: root.pool, Clock: time.Now})
+	_, err := v.Verify(context.Background(), Input{
+		Format: "windows", Statement: base64.StdEncoding.EncodeToString(bundle), ClientDataHash: rightHash,
+	})
+	if !errors.Is(err, ErrNonceMismatch) {
+		t.Fatalf("err=%v want ErrNonceMismatch", err)
+	}
+}

--- a/internal/deviceauth/attestation/tpm_test.go
+++ b/internal/deviceauth/attestation/tpm_test.go
@@ -19,12 +19,12 @@ import (
 )
 
 type tpmRoot struct {
-	pool      *x509.CertPool
-	rootCert  *x509.Certificate
-	rootKey   *rsa.PrivateKey
-	rootDER   []byte
-	leafCert  *x509.Certificate
-	leafDER   []byte
+	pool     *x509.CertPool
+	rootCert *x509.Certificate
+	rootKey  *rsa.PrivateKey
+	rootDER  []byte
+	leafCert *x509.Certificate
+	leafDER  []byte
 }
 
 func mintTPMRoot(t *testing.T) tpmRoot {

--- a/internal/deviceauth/attestation/verifier.go
+++ b/internal/deviceauth/attestation/verifier.go
@@ -36,8 +36,9 @@ type Input struct {
 	// verifier uses this only as a nonce-binding input; trust comes from
 	// the attestation cert chain.
 	HardwareUUID string
-	// ClientDataHash is the SHA-256 of the request the agent signed. For
-	// App Attest this is the bootstrap-token hash bound into the receipt.
+	// ClientDataHash is the SHA-256 of the request context the agent signed.
+	// For App Attest this binds the bootstrap token and claimed hardware UUID
+	// into the nonce in the receipt.
 	ClientDataHash [32]byte
 	// Format is the value of the os_type field from the enroll request
 	// ("darwin", "windows", "linux"). The dispatch [Registry] uses this.

--- a/internal/deviceauth/attestation/verifier.go
+++ b/internal/deviceauth/attestation/verifier.go
@@ -1,0 +1,142 @@
+package attestation
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// Result is the outcome of a successful attestation verification.
+type Result struct {
+	// AssuranceLevel is "hardware" when the device-bound key was produced
+	// by a hardware root of trust (Secure Enclave, TPM 2.0). It is
+	// "software" when the agent is running on an unattested host (Linux
+	// today; Phase-3 may add software fallback policy).
+	AssuranceLevel string
+	// PublicKey is the DER-encoded SubjectPublicKeyInfo of the device-bound
+	// key. The Service binds this to the refresh-token row so subsequent
+	// refreshes can require a DPoP proof signed by the same key (RFC 9449).
+	PublicKey []byte
+	// KeyID is a stable identifier for the device-bound key. For App Attest
+	// this is the credId from authData; for TPM it is SHA-256 of the EK
+	// public key.
+	KeyID string
+	// Vendor identifies the attestation backend that produced the result
+	// ("apple-appattest" or "tpm-2.0").
+	Vendor string
+	// Diagnostics carries verifier-specific provenance fields the audit log
+	// can persist (cert subject, EK manufacturer, etc.). Values are
+	// considered non-secret.
+	Diagnostics map[string]string
+}
+
+// Input is the per-attestation context the Service supplies to the verifier.
+type Input struct {
+	// HardwareUUID is the UUID the agent claimed in its enroll request. The
+	// verifier uses this only as a nonce-binding input; trust comes from
+	// the attestation cert chain.
+	HardwareUUID string
+	// ClientDataHash is the SHA-256 of the request the agent signed. For
+	// App Attest this is the bootstrap-token hash bound into the receipt.
+	ClientDataHash [32]byte
+	// Format is the value of the os_type field from the enroll request
+	// ("darwin", "windows", "linux"). The dispatch [Registry] uses this.
+	Format string
+	// Statement is the raw, base64-encoded attestation statement the agent
+	// posted (the CBOR attestationObject for App Attest; the AIK quote +
+	// EK chain bundle for TPM).
+	Statement string
+}
+
+// Verifier verifies a single attestation backend.
+type Verifier interface {
+	// Format returns the unique short name of the attestation format
+	// ("apple-appattest", "tpm-2.0"). The Registry dispatches on this.
+	Format() string
+	// Verify validates the supplied attestation and returns a Result on
+	// success or a typed error on failure. Implementations MUST be safe
+	// to call concurrently.
+	Verify(ctx context.Context, in Input) (*Result, error)
+}
+
+// Registry dispatches attestation verification by format.
+type Registry struct {
+	verifiers map[string]Verifier
+	required  bool
+}
+
+// NewRegistry builds a registry. When required is true, an enroll request
+// missing an attestation statement fails with ErrAttestationRequired; when
+// false, the absence of attestation just produces a software-assurance
+// Result with no public key (the Service will not bind a DPoP key).
+func NewRegistry(required bool, verifiers ...Verifier) *Registry {
+	r := &Registry{verifiers: make(map[string]Verifier, len(verifiers)), required: required}
+	for _, v := range verifiers {
+		if v == nil {
+			continue
+		}
+		r.verifiers[strings.ToLower(v.Format())] = v
+	}
+	return r
+}
+
+// Required reports whether the registry has been configured to require
+// attestation on enroll.
+func (r *Registry) Required() bool { return r.required }
+
+// Verify dispatches to the verifier whose Format matches the format detected
+// from in.Format / in.Statement. When in.Statement is empty and the registry
+// is not required, it returns a software-assurance result so the caller can
+// proceed without a device-bound key.
+func (r *Registry) Verify(ctx context.Context, in Input) (*Result, error) {
+	if strings.TrimSpace(in.Statement) == "" {
+		if r.required {
+			return nil, ErrAttestationRequired
+		}
+		return &Result{AssuranceLevel: "software", Vendor: "none", Diagnostics: map[string]string{"reason": "no statement provided"}}, nil
+	}
+	format := detectFormat(in)
+	v, ok := r.verifiers[format]
+	if !ok {
+		return nil, ErrUnsupportedFormat
+	}
+	res, err := v.Verify(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if res != nil && res.Vendor == "" {
+		res.Vendor = format
+	}
+	return res, nil
+}
+
+// detectFormat picks an attestation backend based on the os_type field. We
+// could also peek at the leading CBOR/ASN.1 bytes to disambiguate, but the
+// agent always knows its own platform and gives us the hint cheaply.
+func detectFormat(in Input) string {
+	switch strings.ToLower(in.Format) {
+	case "darwin", "ios", "macos", "apple":
+		return FormatAppleAppAttest
+	case "windows", "win32":
+		return FormatTPM2
+	default:
+		return strings.ToLower(in.Format)
+	}
+}
+
+// Format constants.
+const (
+	FormatAppleAppAttest = "apple-appattest"
+	FormatTPM2           = "tpm-2.0"
+)
+
+// Typed errors.
+var (
+	ErrAttestationRequired = errors.New("attestation: attestation is required for enrollment")
+	ErrUnsupportedFormat   = errors.New("attestation: unsupported attestation format")
+	ErrInvalidStatement    = errors.New("attestation: attestation statement is malformed")
+	ErrChainInvalid        = errors.New("attestation: certificate chain is invalid")
+	ErrNonceMismatch       = errors.New("attestation: nonce extension does not match expected client data")
+	ErrKeyIDMismatch       = errors.New("attestation: derived key id does not match credId")
+	ErrUnsupportedVendor   = errors.New("attestation: tpm vendor not in trust pool")
+)

--- a/internal/deviceauth/doc.go
+++ b/internal/deviceauth/doc.go
@@ -1,0 +1,25 @@
+// Package deviceauth implements the SeCheck agent device-identity surface for
+// the Cerebro bootstrap service.
+//
+// The package is intentionally narrow:
+//
+//   - [JWTIssuer] mints short-lived EdDSA (Ed25519) access tokens with a kid
+//     header so the verifier can rotate signing keys without invalidating
+//     in-flight tokens.
+//   - [JWTVerifier] validates tokens against a [KeySet] and the configured
+//     audience, issuer, and clock-skew budget.
+//   - [Store] is the abstract persistence boundary. The Postgres driver lives
+//     in internal/statestore/postgres so the package itself stays
+//     dependency-light and unit-testable.
+//
+// The token format is a compact JWT (RFC 7519) signed with Ed25519 (RFC 8037).
+// Cerebro chose Ed25519 over RS256 for smaller tokens, faster verify, and
+// because the AWS KMS asymmetric sign API supports it directly.
+//
+// All token material is hashed at rest. Bootstrap tokens and refresh tokens
+// are opaque random byte strings; only their SHA-256 digests are persisted.
+//
+// See docs/proposals/SECHECK_DEVICE_AUTH.md for the full design and the gap
+// matrix vs. the closed PR #409 (feat/secheck-device-auth) that this package
+// supersedes.
+package deviceauth

--- a/internal/deviceauth/dpop.go
+++ b/internal/deviceauth/dpop.go
@@ -1,0 +1,290 @@
+package deviceauth
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DPoPProof is the parsed payload of a DPoP proof JWT (RFC 9449 §4).
+type DPoPProof struct {
+	HTM string `json:"htm"`
+	HTU string `json:"htu"`
+	IAT int64  `json:"iat"`
+	JTI string `json:"jti"`
+	Ath string `json:"ath,omitempty"`
+}
+
+// DPoPResult is what the verifier hands back on success: the proof, plus the
+// JWK SHA-256 thumbprint (RFC 7638) used to bind the access token to the
+// holder's key. The cnf.jkt claim minted into the access token must equal
+// this value or the request is rejected.
+type DPoPResult struct {
+	Proof DPoPProof
+	JKT   string
+}
+
+// DPoPVerifier validates RFC 9449 DPoP proof JWTs and dedupes seen jti values
+// for proofTTL+clockSkew. The dedupe table is per-process; production should
+// pair this with a Redis-backed jti store keyed by device_id when more than
+// one cerebro replica is deployed (see docs/proposals/SECHECK_DEVICE_AUTH.md
+// §"DPoP replay store").
+type DPoPVerifier struct {
+	clockSkew time.Duration
+	proofTTL  time.Duration
+	now       func() time.Time
+
+	mu   sync.Mutex
+	seen map[string]time.Time
+}
+
+// NewDPoPVerifier returns a verifier with the given clock skew and proof TTL.
+// If either is non-positive, sensible defaults are used (30s skew, 60s TTL).
+func NewDPoPVerifier(clockSkew, proofTTL time.Duration) *DPoPVerifier {
+	if clockSkew <= 0 {
+		clockSkew = 30 * time.Second
+	}
+	if proofTTL <= 0 {
+		proofTTL = 60 * time.Second
+	}
+	return &DPoPVerifier{
+		clockSkew: clockSkew,
+		proofTTL:  proofTTL,
+		now:       time.Now,
+		seen:      make(map[string]time.Time),
+	}
+}
+
+// SetClock overrides the wall clock used to validate iat. Tests only.
+func (v *DPoPVerifier) SetClock(now func() time.Time) {
+	if now == nil {
+		now = time.Now
+	}
+	v.mu.Lock()
+	v.now = now
+	v.mu.Unlock()
+}
+
+// Verify parses proofToken, verifies the embedded JWS over the supplied JWK,
+// validates htm/htu/iat per RFC 9449 §4.3, and rejects any jti seen within
+// the replay window.
+func (v *DPoPVerifier) Verify(proofToken, method, requestURL string) (*DPoPResult, error) {
+	parts := strings.Split(proofToken, ".")
+	if len(parts) != 3 {
+		return nil, ErrDPoPMalformed
+	}
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, ErrDPoPMalformed
+	}
+	var hdr struct {
+		Typ string          `json:"typ"`
+		Alg string          `json:"alg"`
+		JWK json.RawMessage `json:"jwk"`
+	}
+	if err := json.Unmarshal(headerJSON, &hdr); err != nil {
+		return nil, ErrDPoPMalformed
+	}
+	if hdr.Typ != "dpop+jwt" {
+		return nil, fmt.Errorf("%w: typ=%q", ErrDPoPInvalidHeader, hdr.Typ)
+	}
+	pub, jkt, err := parseJWK(hdr.JWK)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrDPoPInvalidJWK, err)
+	}
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, ErrDPoPMalformed
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, ErrDPoPMalformed
+	}
+	var p DPoPProof
+	if err := json.Unmarshal(payloadJSON, &p); err != nil {
+		return nil, ErrDPoPMalformed
+	}
+	signed := []byte(parts[0] + "." + parts[1])
+	if err := verifyDPoPSignature(hdr.Alg, pub, signed, sig); err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(p.HTM, method) {
+		return nil, fmt.Errorf("%w: htm=%q want=%q", ErrDPoPMismatch, p.HTM, method)
+	}
+	if !urlsEqual(p.HTU, requestURL) {
+		return nil, fmt.Errorf("%w: htu=%q want=%q", ErrDPoPMismatch, p.HTU, requestURL)
+	}
+	now := v.now().UTC()
+	iat := time.Unix(p.IAT, 0)
+	if now.Sub(iat) > v.proofTTL+v.clockSkew {
+		return nil, ErrDPoPExpired
+	}
+	if iat.Sub(now) > v.clockSkew {
+		return nil, ErrDPoPFromFuture
+	}
+	if strings.TrimSpace(p.JTI) == "" {
+		return nil, ErrDPoPMissingJTI
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.gcLocked(now)
+	if _, ok := v.seen[p.JTI]; ok {
+		return nil, ErrDPoPReplay
+	}
+	v.seen[p.JTI] = iat.Add(v.proofTTL + v.clockSkew)
+	_ = pub
+	return &DPoPResult{Proof: p, JKT: jkt}, nil
+}
+
+func (v *DPoPVerifier) gcLocked(now time.Time) {
+	for jti, exp := range v.seen {
+		if now.After(exp) {
+			delete(v.seen, jti)
+		}
+	}
+}
+
+func urlsEqual(a, b string) bool {
+	au, err := url.Parse(a)
+	if err != nil {
+		return false
+	}
+	bu, err := url.Parse(b)
+	if err != nil {
+		return false
+	}
+	canon := func(u *url.URL) string {
+		host := strings.ToLower(u.Host)
+		path := strings.TrimRight(u.Path, "/")
+		if path == "" {
+			path = "/"
+		}
+		return strings.ToLower(u.Scheme) + "://" + host + path
+	}
+	return canon(au) == canon(bu)
+}
+
+// parseJWK accepts the JWK from a DPoP header and returns the parsed public
+// key plus its RFC 7638 SHA-256 thumbprint encoded as base64url. Only EC
+// (P-256, P-384) and OKP (Ed25519) are supported; RSA is intentionally
+// excluded so the signing surface stays narrow.
+func parseJWK(raw json.RawMessage) (interface{}, string, error) {
+	var jwk struct {
+		Kty string `json:"kty"`
+		Crv string `json:"crv"`
+		X   string `json:"x"`
+		Y   string `json:"y"`
+	}
+	if err := json.Unmarshal(raw, &jwk); err != nil {
+		return nil, "", err
+	}
+	switch jwk.Kty {
+	case "EC":
+		var curve elliptic.Curve
+		switch jwk.Crv {
+		case "P-256":
+			curve = elliptic.P256()
+		case "P-384":
+			curve = elliptic.P384()
+		default:
+			return nil, "", fmt.Errorf("unsupported EC curve %q", jwk.Crv)
+		}
+		x, errX := base64.RawURLEncoding.DecodeString(jwk.X)
+		y, errY := base64.RawURLEncoding.DecodeString(jwk.Y)
+		if errX != nil || errY != nil {
+			return nil, "", errors.New("malformed jwk x/y")
+		}
+		xi := new(big.Int).SetBytes(x)
+		yi := new(big.Int).SetBytes(y)
+		if !curve.IsOnCurve(xi, yi) {
+			return nil, "", errors.New("jwk point not on curve")
+		}
+		canonical := fmt.Sprintf(`{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`, jwk.Crv, jwk.X, jwk.Y)
+		sum := sha256.Sum256([]byte(canonical))
+		return &ecdsa.PublicKey{Curve: curve, X: xi, Y: yi}, base64.RawURLEncoding.EncodeToString(sum[:]), nil
+	case "OKP":
+		if jwk.Crv != "Ed25519" {
+			return nil, "", fmt.Errorf("unsupported OKP curve %q", jwk.Crv)
+		}
+		x, err := base64.RawURLEncoding.DecodeString(jwk.X)
+		if err != nil || len(x) != ed25519.PublicKeySize {
+			return nil, "", errors.New("malformed Ed25519 jwk")
+		}
+		canonical := fmt.Sprintf(`{"crv":"Ed25519","kty":"OKP","x":"%s"}`, jwk.X)
+		sum := sha256.Sum256([]byte(canonical))
+		return ed25519.PublicKey(x), base64.RawURLEncoding.EncodeToString(sum[:]), nil
+	default:
+		return nil, "", fmt.Errorf("unsupported kty %q", jwk.Kty)
+	}
+}
+
+func verifyDPoPSignature(alg string, pub interface{}, signed, sig []byte) error {
+	switch alg {
+	case "ES256":
+		ecpub, ok := pub.(*ecdsa.PublicKey)
+		if !ok || ecpub.Curve != elliptic.P256() {
+			return ErrDPoPInvalidSignature
+		}
+		if len(sig) != 64 {
+			return ErrDPoPInvalidSignature
+		}
+		r := new(big.Int).SetBytes(sig[:32])
+		s := new(big.Int).SetBytes(sig[32:])
+		sum := sha256.Sum256(signed)
+		if !ecdsa.Verify(ecpub, sum[:], r, s) {
+			return ErrDPoPInvalidSignature
+		}
+		return nil
+	case "ES384":
+		ecpub, ok := pub.(*ecdsa.PublicKey)
+		if !ok || ecpub.Curve != elliptic.P384() {
+			return ErrDPoPInvalidSignature
+		}
+		if len(sig) != 96 {
+			return ErrDPoPInvalidSignature
+		}
+		r := new(big.Int).SetBytes(sig[:48])
+		s := new(big.Int).SetBytes(sig[48:])
+		sum := sha384Sum(signed)
+		if !ecdsa.Verify(ecpub, sum, r, s) {
+			return ErrDPoPInvalidSignature
+		}
+		return nil
+	case "EdDSA":
+		edpub, ok := pub.(ed25519.PublicKey)
+		if !ok {
+			return ErrDPoPInvalidSignature
+		}
+		if !ed25519.Verify(edpub, signed, sig) {
+			return ErrDPoPInvalidSignature
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: alg=%q", ErrDPoPInvalidHeader, alg)
+	}
+}
+
+// ErrDPoP* are typed errors so handlers can map to stable JSON error codes.
+var (
+	ErrDPoPMalformed        = errors.New("deviceauth: dpop proof malformed")
+	ErrDPoPInvalidHeader    = errors.New("deviceauth: dpop header invalid")
+	ErrDPoPInvalidJWK       = errors.New("deviceauth: dpop jwk invalid")
+	ErrDPoPInvalidSignature = errors.New("deviceauth: dpop signature invalid")
+	ErrDPoPMismatch         = errors.New("deviceauth: dpop htm/htu mismatch")
+	ErrDPoPExpired          = errors.New("deviceauth: dpop proof expired")
+	ErrDPoPFromFuture       = errors.New("deviceauth: dpop proof iat from the future")
+	ErrDPoPMissingJTI       = errors.New("deviceauth: dpop missing jti")
+	ErrDPoPReplay           = errors.New("deviceauth: dpop jti replayed")
+	ErrDPoPMissing          = errors.New("deviceauth: dpop proof header missing")
+	ErrDPoPJKTMismatch      = errors.New("deviceauth: dpop key thumbprint does not match cnf.jkt")
+)

--- a/internal/deviceauth/dpop.go
+++ b/internal/deviceauth/dpop.go
@@ -1,6 +1,7 @@
 package deviceauth
 
 import (
+	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -100,7 +101,7 @@ func (v *DPoPVerifier) Verify(proofToken, method, requestURL string) (*DPoPResul
 	}
 	pub, jkt, err := parseJWK(hdr.JWK)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrDPoPInvalidJWK, err)
+		return nil, fmt.Errorf("%w: %w", ErrDPoPInvalidJWK, err)
 	}
 	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
@@ -191,27 +192,37 @@ func parseJWK(raw json.RawMessage) (interface{}, string, error) {
 	switch jwk.Kty {
 	case "EC":
 		var curve elliptic.Curve
+		var ecdhCurve ecdh.Curve
+		var coordLen int
 		switch jwk.Crv {
 		case "P-256":
-			curve = elliptic.P256()
+			curve, ecdhCurve, coordLen = elliptic.P256(), ecdh.P256(), 32
 		case "P-384":
-			curve = elliptic.P384()
+			curve, ecdhCurve, coordLen = elliptic.P384(), ecdh.P384(), 48
 		default:
 			return nil, "", fmt.Errorf("unsupported EC curve %q", jwk.Crv)
 		}
 		x, errX := base64.RawURLEncoding.DecodeString(jwk.X)
 		y, errY := base64.RawURLEncoding.DecodeString(jwk.Y)
-		if errX != nil || errY != nil {
+		if errX != nil || errY != nil || len(x) > coordLen || len(y) > coordLen {
 			return nil, "", errors.New("malformed jwk x/y")
 		}
-		xi := new(big.Int).SetBytes(x)
-		yi := new(big.Int).SetBytes(y)
-		if !curve.IsOnCurve(xi, yi) {
-			return nil, "", errors.New("jwk point not on curve")
+		uncompressed := make([]byte, 1+2*coordLen)
+		uncompressed[0] = 0x04
+		copy(uncompressed[1+coordLen-len(x):1+coordLen], x)
+		copy(uncompressed[1+2*coordLen-len(y):], y)
+		ecdhPub, err := ecdhCurve.NewPublicKey(uncompressed)
+		if err != nil {
+			return nil, "", fmt.Errorf("jwk point not on curve: %w", err)
 		}
+		_ = ecdhPub
 		canonical := fmt.Sprintf(`{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`, jwk.Crv, jwk.X, jwk.Y)
 		sum := sha256.Sum256([]byte(canonical))
-		return &ecdsa.PublicKey{Curve: curve, X: xi, Y: yi}, base64.RawURLEncoding.EncodeToString(sum[:]), nil
+		return &ecdsa.PublicKey{
+			Curve: curve,
+			X:     new(big.Int).SetBytes(x),
+			Y:     new(big.Int).SetBytes(y),
+		}, base64.RawURLEncoding.EncodeToString(sum[:]), nil
 	case "OKP":
 		if jwk.Crv != "Ed25519" {
 			return nil, "", fmt.Errorf("unsupported OKP curve %q", jwk.Crv)

--- a/internal/deviceauth/dpop.go
+++ b/internal/deviceauth/dpop.go
@@ -66,6 +66,14 @@ func NewDPoPVerifier(clockSkew, proofTTL time.Duration) *DPoPVerifier {
 	}
 }
 
+// ReplayStateShared reports whether replayed jti state is shared across
+// process boundaries. The built-in verifier is intentionally process-local;
+// bootstrap must reject multi-replica configurations until a shared DPoP
+// replay store is wired.
+func (v *DPoPVerifier) ReplayStateShared() bool {
+	return false
+}
+
 // SetClock overrides the wall clock used to validate iat. Tests only.
 func (v *DPoPVerifier) SetClock(now func() time.Time) {
 	if now == nil {

--- a/internal/deviceauth/dpop.go
+++ b/internal/deviceauth/dpop.go
@@ -77,9 +77,10 @@ func (v *DPoPVerifier) SetClock(now func() time.Time) {
 }
 
 // Verify parses proofToken, verifies the embedded JWS over the supplied JWK,
-// validates htm/htu/iat per RFC 9449 §4.3, and rejects any jti seen within
-// the replay window.
-func (v *DPoPVerifier) Verify(proofToken, method, requestURL string) (*DPoPResult, error) {
+// validates htm/htu/iat per RFC 9449 §4.3, optionally binds the proof ath
+// claim to the presented access token, and rejects any jti seen within the
+// replay window.
+func (v *DPoPVerifier) Verify(proofToken, method, requestURL string, accessToken ...string) (*DPoPResult, error) {
 	parts := strings.Split(proofToken, ".")
 	if len(parts) != 3 {
 		return nil, ErrDPoPMalformed
@@ -125,6 +126,12 @@ func (v *DPoPVerifier) Verify(proofToken, method, requestURL string) (*DPoPResul
 	if !urlsEqual(p.HTU, requestURL) {
 		return nil, fmt.Errorf("%w: htu=%q want=%q", ErrDPoPMismatch, p.HTU, requestURL)
 	}
+	if len(accessToken) > 0 && strings.TrimSpace(accessToken[0]) != "" {
+		expectedAth := dpopAccessTokenHash(accessToken[0])
+		if strings.TrimSpace(p.Ath) == "" || p.Ath != expectedAth {
+			return nil, fmt.Errorf("%w: ath mismatch", ErrDPoPMismatch)
+		}
+	}
 	now := v.now().UTC()
 	iat := time.Unix(p.IAT, 0)
 	if now.Sub(iat) > v.proofTTL+v.clockSkew {
@@ -145,6 +152,11 @@ func (v *DPoPVerifier) Verify(proofToken, method, requestURL string) (*DPoPResul
 	v.seen[p.JTI] = iat.Add(v.proofTTL + v.clockSkew)
 	_ = pub
 	return &DPoPResult{Proof: p, JKT: jkt}, nil
+}
+
+func dpopAccessTokenHash(accessToken string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(accessToken)))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
 func (v *DPoPVerifier) gcLocked(now time.Time) {

--- a/internal/deviceauth/dpop_test.go
+++ b/internal/deviceauth/dpop_test.go
@@ -41,11 +41,16 @@ func newDPoPSignerEd25519(t *testing.T) *dpopSigner {
 
 func (s *dpopSigner) jwk() map[string]string {
 	if s.es256 != nil {
+		ecdhPub, err := s.es256.PublicKey.ECDH()
+		if err != nil {
+			panic(err)
+		}
+		raw := ecdhPub.Bytes()
 		return map[string]string{
 			"kty": "EC",
 			"crv": "P-256",
-			"x":   base64.RawURLEncoding.EncodeToString(s.es256.PublicKey.X.Bytes()),
-			"y":   base64.RawURLEncoding.EncodeToString(s.es256.PublicKey.Y.Bytes()),
+			"x":   base64.RawURLEncoding.EncodeToString(raw[1:33]),
+			"y":   base64.RawURLEncoding.EncodeToString(raw[33:]),
 		}
 	}
 	return map[string]string{

--- a/internal/deviceauth/dpop_test.go
+++ b/internal/deviceauth/dpop_test.go
@@ -1,0 +1,234 @@
+package deviceauth
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+)
+
+type dpopSigner struct {
+	es256 *ecdsa.PrivateKey
+	ed    ed25519.PrivateKey
+	edPub ed25519.PublicKey
+}
+
+func newDPoPSignerES256(t *testing.T) *dpopSigner {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen ec: %v", err)
+	}
+	return &dpopSigner{es256: k}
+}
+
+func newDPoPSignerEd25519(t *testing.T) *dpopSigner {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("gen ed25519: %v", err)
+	}
+	return &dpopSigner{ed: priv, edPub: pub}
+}
+
+func (s *dpopSigner) jwk() map[string]string {
+	if s.es256 != nil {
+		return map[string]string{
+			"kty": "EC",
+			"crv": "P-256",
+			"x":   base64.RawURLEncoding.EncodeToString(s.es256.PublicKey.X.Bytes()),
+			"y":   base64.RawURLEncoding.EncodeToString(s.es256.PublicKey.Y.Bytes()),
+		}
+	}
+	return map[string]string{
+		"kty": "OKP",
+		"crv": "Ed25519",
+		"x":   base64.RawURLEncoding.EncodeToString(s.edPub),
+	}
+}
+
+func (s *dpopSigner) alg() string {
+	if s.es256 != nil {
+		return "ES256"
+	}
+	return "EdDSA"
+}
+
+func (s *dpopSigner) sign(input []byte) []byte {
+	if s.es256 != nil {
+		sum := sha256.Sum256(input)
+		r, sgn, err := ecdsa.Sign(rand.Reader, s.es256, sum[:])
+		if err != nil {
+			panic(err)
+		}
+		out := make([]byte, 64)
+		copy(out[32-len(r.Bytes()):32], r.Bytes())
+		copy(out[64-len(sgn.Bytes()):64], sgn.Bytes())
+		return out
+	}
+	return ed25519.Sign(s.ed, input)
+}
+
+func makeDPoPProof(t *testing.T, s *dpopSigner, htm, htu string, iat time.Time, jti string) string {
+	t.Helper()
+	header := map[string]any{
+		"typ": "dpop+jwt",
+		"alg": s.alg(),
+		"jwk": s.jwk(),
+	}
+	hb, _ := json.Marshal(header)
+	payload := map[string]any{
+		"htm": htm,
+		"htu": htu,
+		"iat": iat.Unix(),
+		"jti": jti,
+	}
+	pb, _ := json.Marshal(payload)
+	signing := base64.RawURLEncoding.EncodeToString(hb) + "." + base64.RawURLEncoding.EncodeToString(pb)
+	sig := s.sign([]byte(signing))
+	return signing + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func TestDPoPVerifyES256RoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	v := NewDPoPVerifier(time.Minute, time.Minute)
+	v.SetClock(func() time.Time { return now })
+	signer := newDPoPSignerES256(t)
+	proof := makeDPoPProof(t, signer, "POST", "https://cerebro.writer.com/platform/devices/token", now, "abc-1")
+	res, err := v.Verify(proof, "POST", "https://cerebro.writer.com/platform/devices/token")
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if res.JKT == "" {
+		t.Fatal("jkt empty")
+	}
+}
+
+func TestDPoPVerifyEdDSARoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	v := NewDPoPVerifier(time.Minute, time.Minute)
+	v.SetClock(func() time.Time { return now })
+	signer := newDPoPSignerEd25519(t)
+	proof := makeDPoPProof(t, signer, "POST", "https://cerebro.writer.com/x", now, "abc-2")
+	if _, err := v.Verify(proof, "POST", "https://cerebro.writer.com/x"); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+}
+
+func TestDPoPRejectsReplay(t *testing.T) {
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	v := NewDPoPVerifier(time.Minute, time.Minute)
+	v.SetClock(func() time.Time { return now })
+	s := newDPoPSignerES256(t)
+	proof := makeDPoPProof(t, s, "POST", "https://h/p", now, "jti-1")
+	if _, err := v.Verify(proof, "POST", "https://h/p"); err != nil {
+		t.Fatalf("first verify: %v", err)
+	}
+	if _, err := v.Verify(proof, "POST", "https://h/p"); !errors.Is(err, ErrDPoPReplay) {
+		t.Fatalf("second verify err = %v, want ErrDPoPReplay", err)
+	}
+}
+
+func TestDPoPRejectsExpired(t *testing.T) {
+	t0 := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	v := NewDPoPVerifier(5*time.Second, 30*time.Second)
+	now := t0
+	v.SetClock(func() time.Time { return now })
+	s := newDPoPSignerES256(t)
+	proof := makeDPoPProof(t, s, "POST", "https://h/p", t0, "jti-x")
+	now = t0.Add(2 * time.Minute)
+	if _, err := v.Verify(proof, "POST", "https://h/p"); !errors.Is(err, ErrDPoPExpired) {
+		t.Fatalf("expired err = %v, want ErrDPoPExpired", err)
+	}
+}
+
+func TestDPoPRejectsHTMHTUMismatch(t *testing.T) {
+	now := time.Now()
+	v := NewDPoPVerifier(time.Minute, time.Minute)
+	v.SetClock(func() time.Time { return now })
+	s := newDPoPSignerES256(t)
+	proof := makeDPoPProof(t, s, "GET", "https://h/p", now, "jti-q")
+	if _, err := v.Verify(proof, "POST", "https://h/p"); !errors.Is(err, ErrDPoPMismatch) {
+		t.Fatalf("htm mismatch err = %v, want ErrDPoPMismatch", err)
+	}
+	proof = makeDPoPProof(t, s, "POST", "https://h/p", now, "jti-r")
+	if _, err := v.Verify(proof, "POST", "https://h/q"); !errors.Is(err, ErrDPoPMismatch) {
+		t.Fatalf("htu mismatch err = %v, want ErrDPoPMismatch", err)
+	}
+}
+
+func TestDPoPRejectsTamperedSignature(t *testing.T) {
+	now := time.Now()
+	v := NewDPoPVerifier(time.Minute, time.Minute)
+	v.SetClock(func() time.Time { return now })
+	s := newDPoPSignerES256(t)
+	proof := makeDPoPProof(t, s, "POST", "https://h/p", now, "jti-t")
+	// flip first character of the signature
+	idx := lastDot(proof) + 1
+	first := proof[idx]
+	flipped := byte('A')
+	if first == 'A' {
+		flipped = 'B'
+	}
+	tampered := proof[:idx] + string(flipped) + proof[idx+1:]
+	if _, err := v.Verify(tampered, "POST", "https://h/p"); !errors.Is(err, ErrDPoPInvalidSignature) {
+		t.Fatalf("tampered err = %v, want ErrDPoPInvalidSignature", err)
+	}
+}
+
+func TestDPoPThumbprintIsStable(t *testing.T) {
+	// two parses of the same JWK must produce the same thumbprint
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwk := fmt.Sprintf(`{"kty":"OKP","crv":"Ed25519","x":"%s"}`, base64.RawURLEncoding.EncodeToString(pub))
+	_, jkt1, err := parseJWK([]byte(jwk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, jkt2, err := parseJWK([]byte(jwk))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if jkt1 != jkt2 {
+		t.Fatalf("thumbprints differ: %s vs %s", jkt1, jkt2)
+	}
+}
+
+func TestDPoPRejectsBadKtyOrCurve(t *testing.T) {
+	if _, _, err := parseJWK([]byte(`{"kty":"RSA","n":"AA","e":"AQAB"}`)); err == nil {
+		t.Fatal("expected error for RSA")
+	}
+	if _, _, err := parseJWK([]byte(`{"kty":"EC","crv":"P-521","x":"AA","y":"AA"}`)); err == nil {
+		t.Fatal("expected error for unsupported curve")
+	}
+}
+
+func TestDPoPParseJWKRejectsOffCurve(t *testing.T) {
+	x := big.NewInt(1).Bytes()
+	y := big.NewInt(1).Bytes()
+	jwk := fmt.Sprintf(`{"kty":"EC","crv":"P-256","x":"%s","y":"%s"}`,
+		base64.RawURLEncoding.EncodeToString(x),
+		base64.RawURLEncoding.EncodeToString(y))
+	if _, _, err := parseJWK([]byte(jwk)); err == nil {
+		t.Fatal("expected off-curve rejection")
+	}
+}
+
+func lastDot(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '.' {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/deviceauth/dpop_test.go
+++ b/internal/deviceauth/dpop_test.go
@@ -83,6 +83,10 @@ func (s *dpopSigner) sign(input []byte) []byte {
 }
 
 func makeDPoPProof(t *testing.T, s *dpopSigner, htm, htu string, iat time.Time, jti string) string {
+	return makeDPoPProofWithATH(t, s, htm, htu, iat, jti, "")
+}
+
+func makeDPoPProofWithATH(t *testing.T, s *dpopSigner, htm, htu string, iat time.Time, jti string, ath string) string {
 	t.Helper()
 	header := map[string]any{
 		"typ": "dpop+jwt",
@@ -95,6 +99,9 @@ func makeDPoPProof(t *testing.T, s *dpopSigner, htm, htu string, iat time.Time, 
 		"htu": htu,
 		"iat": iat.Unix(),
 		"jti": jti,
+	}
+	if ath != "" {
+		payload["ath"] = ath
 	}
 	pb, _ := json.Marshal(payload)
 	signing := base64.RawURLEncoding.EncodeToString(hb) + "." + base64.RawURLEncoding.EncodeToString(pb)
@@ -186,6 +193,26 @@ func TestDPoPRejectsTamperedSignature(t *testing.T) {
 	tampered := proof[:idx] + string(flipped) + proof[idx+1:]
 	if _, err := v.Verify(tampered, "POST", "https://h/p"); !errors.Is(err, ErrDPoPInvalidSignature) {
 		t.Fatalf("tampered err = %v, want ErrDPoPInvalidSignature", err)
+	}
+}
+
+func TestDPoPVerifyBindsAccessTokenHash(t *testing.T) {
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	v := NewDPoPVerifier(time.Minute, time.Minute)
+	v.SetClock(func() time.Time { return now })
+	s := newDPoPSignerES256(t)
+	accessToken := "header.payload.signature"
+	proof := makeDPoPProofWithATH(t, s, "GET", "https://h/p", now, "jti-ath-1", dpopAccessTokenHash(accessToken))
+	if _, err := v.Verify(proof, "GET", "https://h/p", accessToken); err != nil {
+		t.Fatalf("verify with matching ath: %v", err)
+	}
+	badProof := makeDPoPProofWithATH(t, s, "GET", "https://h/p", now, "jti-ath-2", dpopAccessTokenHash("different"))
+	if _, err := v.Verify(badProof, "GET", "https://h/p", accessToken); !errors.Is(err, ErrDPoPMismatch) {
+		t.Fatalf("verify with wrong ath err = %v, want ErrDPoPMismatch", err)
+	}
+	missingATH := makeDPoPProof(t, s, "GET", "https://h/p", now, "jti-ath-3")
+	if _, err := v.Verify(missingATH, "GET", "https://h/p", accessToken); !errors.Is(err, ErrDPoPMismatch) {
+		t.Fatalf("verify with missing ath err = %v, want ErrDPoPMismatch", err)
 	}
 }
 

--- a/internal/deviceauth/integration_test.go
+++ b/internal/deviceauth/integration_test.go
@@ -46,11 +46,12 @@ func ecPublicKeyDER(t *testing.T, pub *ecdsa.PublicKey) []byte {
 
 func newDPoPProofES256(t *testing.T, key *ecdsa.PrivateKey, htm, htu string, iat time.Time, jti string) string {
 	t.Helper()
+	x, y := p256XY(t, &key.PublicKey)
 	jwk := map[string]string{
 		"kty": "EC",
 		"crv": "P-256",
-		"x":   base64.RawURLEncoding.EncodeToString(key.PublicKey.X.Bytes()),
-		"y":   base64.RawURLEncoding.EncodeToString(key.PublicKey.Y.Bytes()),
+		"x":   base64.RawURLEncoding.EncodeToString(x),
+		"y":   base64.RawURLEncoding.EncodeToString(y),
 	}
 	header := map[string]any{"typ": "dpop+jwt", "alg": "ES256", "jwk": jwk}
 	hb, _ := json.Marshal(header)
@@ -267,4 +268,19 @@ func containsScope(scopes []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// p256XY returns the 32-byte big-endian X and Y coordinates of pub via the
+// crypto/ecdh SEC1 encoding, avoiding the deprecated raw .X / .Y fields.
+func p256XY(t *testing.T, pub *ecdsa.PublicKey) ([]byte, []byte) {
+	t.Helper()
+	ecdhPub, err := pub.ECDH()
+	if err != nil {
+		t.Fatalf("ECDH: %v", err)
+	}
+	raw := ecdhPub.Bytes()
+	if len(raw) != 65 || raw[0] != 0x04 {
+		t.Fatalf("unexpected SEC1 length %d", len(raw))
+	}
+	return raw[1:33], raw[33:]
 }

--- a/internal/deviceauth/integration_test.go
+++ b/internal/deviceauth/integration_test.go
@@ -279,14 +279,35 @@ func TestServiceRefreshRejectsMissingDPoPOnBoundDevice(t *testing.T) {
 		t.Fatalf("missing-DPoP err = %v, want ErrDPoPMissing", err)
 	}
 	proof := newDPoPProofES256(t, devKey, "POST", "https://cerebro.test/platform/devices/token", now, "jti-after-missing")
-	if _, err := service.IssueToken(ctx, TokenRequest{
+	rotated, err := service.IssueToken(ctx, TokenRequest{
 		GrantType:    "refresh_token",
 		RefreshToken: enroll.RefreshToken,
 		DPoPProof:    proof,
 		HTTPMethod:   "POST",
 		HTTPURL:      "https://cerebro.test/platform/devices/token",
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("valid DPoP after missing-DPoP attempt should still work: %v", err)
+	}
+	if _, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: enroll.RefreshToken,
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
+	}); !errors.Is(err, ErrDPoPMissing) {
+		t.Fatalf("stale refresh without DPoP err = %v, want ErrDPoPMissing", err)
+	}
+	now = now.Add(time.Second)
+	dpop.SetClock(clock)
+	proof = newDPoPProofES256(t, devKey, "POST", "https://cerebro.test/platform/devices/token", now, "jti-after-stale-replay")
+	if _, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: rotated.RefreshToken,
+		DPoPProof:    proof,
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
+	}); err != nil {
+		t.Fatalf("valid rotated refresh after stale missing-DPoP replay should still work: %v", err)
 	}
 }
 

--- a/internal/deviceauth/integration_test.go
+++ b/internal/deviceauth/integration_test.go
@@ -206,6 +206,25 @@ func TestServiceEnrollDPoPRiskEndToEnd(t *testing.T) {
 	if containsScope(highRisk.Scopes, ScopeTelemetryIngest) {
 		t.Errorf("high-risk rotation should drop telemetry ingest scope: %v", highRisk.Scopes)
 	}
+
+	now = now.Add(3 * time.Minute)
+	store.SetClock(clock)
+	dpop.SetClock(clock)
+	proof3 := newDPoPProofES256(t, devKey, "POST", "https://cerebro.test/platform/devices/token", now, "jti-3")
+	recovered, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: highRisk.RefreshToken,
+		DPoPProof:    proof3,
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
+		RemoteIP:     net.ParseIP("203.0.113.20"),
+	})
+	if err != nil {
+		t.Fatalf("IssueToken after high-risk downgrade: %v", err)
+	}
+	if !containsScope(recovered.Scopes, ScopeTelemetryIngest) {
+		t.Errorf("refresh lineage permanently lost telemetry scope after high-risk downgrade: %v", recovered.Scopes)
+	}
 }
 
 // TestServiceRefreshRejectsMissingDPoPOnBoundDevice covers the path where
@@ -258,6 +277,16 @@ func TestServiceRefreshRejectsMissingDPoPOnBoundDevice(t *testing.T) {
 		HTTPURL:      "https://cerebro.test/platform/devices/token",
 	}); !errors.Is(err, ErrDPoPMissing) {
 		t.Fatalf("missing-DPoP err = %v, want ErrDPoPMissing", err)
+	}
+	proof := newDPoPProofES256(t, devKey, "POST", "https://cerebro.test/platform/devices/token", now, "jti-after-missing")
+	if _, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: enroll.RefreshToken,
+		DPoPProof:    proof,
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
+	}); err != nil {
+		t.Fatalf("valid DPoP after missing-DPoP attempt should still work: %v", err)
 	}
 }
 

--- a/internal/deviceauth/integration_test.go
+++ b/internal/deviceauth/integration_test.go
@@ -1,0 +1,270 @@
+package deviceauth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/deviceauth/attestation"
+	"github.com/writer/cerebro/internal/deviceauth/risk"
+)
+
+type stubVerifier struct {
+	pubDER []byte
+	keyID  string
+}
+
+func (s *stubVerifier) Format() string { return attestation.FormatAppleAppAttest }
+
+func (s *stubVerifier) Verify(_ context.Context, _ attestation.Input) (*attestation.Result, error) {
+	return &attestation.Result{
+		AssuranceLevel: "hardware",
+		PublicKey:      s.pubDER,
+		KeyID:          s.keyID,
+		Vendor:         "stub-appattest",
+	}, nil
+}
+
+func ecPublicKeyDER(t *testing.T, pub *ecdsa.PublicKey) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal pubkey: %v", err)
+	}
+	return der
+}
+
+func newDPoPProofES256(t *testing.T, key *ecdsa.PrivateKey, htm, htu string, iat time.Time, jti string) string {
+	t.Helper()
+	jwk := map[string]string{
+		"kty": "EC",
+		"crv": "P-256",
+		"x":   base64.RawURLEncoding.EncodeToString(key.PublicKey.X.Bytes()),
+		"y":   base64.RawURLEncoding.EncodeToString(key.PublicKey.Y.Bytes()),
+	}
+	header := map[string]any{"typ": "dpop+jwt", "alg": "ES256", "jwk": jwk}
+	hb, _ := json.Marshal(header)
+	payload := map[string]any{"htm": htm, "htu": htu, "iat": iat.Unix(), "jti": jti}
+	pb, _ := json.Marshal(payload)
+	signing := base64.RawURLEncoding.EncodeToString(hb) + "." + base64.RawURLEncoding.EncodeToString(pb)
+	sum := sha256.Sum256([]byte(signing))
+	r, s, err := ecdsa.Sign(rand.Reader, key, sum[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	out := make([]byte, 64)
+	copy(out[32-len(r.Bytes()):32], r.Bytes())
+	copy(out[64-len(s.Bytes()):64], s.Bytes())
+	return signing + "." + base64.RawURLEncoding.EncodeToString(out)
+}
+
+// TestServiceEnrollDPoPRiskEndToEnd exercises the full Phase-1+2+3 path:
+//
+//   - bootstrap-token issuance + enroll with attestation,
+//   - storage of dpop_jkt on the device,
+//   - DPoP-bound refresh succeeds with the correct key,
+//   - missing DPoP fails with ErrDPoPMissing,
+//   - high-velocity geo drift downgrades sensitive scopes.
+func TestServiceEnrollDPoPRiskEndToEnd(t *testing.T) {
+	ctx := context.Background()
+
+	store := NewMemStore()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("gen ed: %v", err)
+	}
+	signer, _ := NewLocalSigner([]SigningKey{{KID: "k1", Public: pub, Private: priv}})
+	keyset := &KeySet{Keys: []SigningKey{{KID: "k1", Public: pub}}}
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	store.SetClock(clock)
+	issuer, _ := NewJWTIssuer(IssuerConfig{Now: clock}, signer)
+	verifier, _ := NewJWTVerifier(VerifierConfig{Now: clock}, keyset)
+
+	devKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen ec: %v", err)
+	}
+	registry := attestation.NewRegistry(true, &stubVerifier{
+		pubDER: ecPublicKeyDER(t, &devKey.PublicKey),
+		keyID:  "stub-key",
+	})
+	dpop := NewDPoPVerifier(time.Minute, time.Minute)
+	dpop.SetClock(clock)
+
+	geo := risk.NewInMemoryLookup()
+	geo.Set("203.0.113.10", risk.GeoFact{Country: "US", ASN: "AS1", Latitude: 40.7128, Longitude: -74.0060})
+	geo.Set("203.0.113.20", risk.GeoFact{Country: "AU", ASN: "AS2", Latitude: -33.8688, Longitude: 151.2093})
+
+	obsStore := risk.NewInMemoryObservationStore()
+	scorer := risk.NewScorer(
+		risk.Thresholds{Elevated: 30, High: 60},
+		geo,
+		risk.NoOpEmitter{},
+		risk.NewVelocityDetector(),
+		risk.NewCountryDriftDetector(),
+		risk.NewASNDriftDetector(),
+	)
+
+	service, err := NewService(ServiceConfig{
+		AccessTTL:         5 * time.Minute,
+		RefreshTTL:        24 * time.Hour,
+		BootstrapTokenTTL: time.Hour,
+		IdempotencyTTL:    time.Hour,
+		Now:               clock,
+		Attestations:      registry,
+		DPoP:              dpop,
+		Risk:              scorer,
+		Observations:      obsStore,
+	}, store, issuer, verifier, keyset)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	bootstrap, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-1", TenantID: "writer", TTL: time.Hour, IssuedBy: "operator",
+		Scopes: []string{ScopeDevicesToken, ScopeTelemetryIngest, ScopeDeviceFindingsRead},
+	})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken: %v", err)
+	}
+
+	enroll, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-1",
+		OSType:         "darwin",
+		Attestation:    "stub-statement",
+		RemoteIP:       net.ParseIP("203.0.113.10"),
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if enroll.AssuranceLevel != "hardware" {
+		t.Fatalf("AssuranceLevel = %q, want hardware", enroll.AssuranceLevel)
+	}
+
+	device, err := store.LookupDevice(ctx, enroll.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice: %v", err)
+	}
+	if device.Metadata["dpop_jkt"] == "" {
+		t.Fatal("expected dpop_jkt to be persisted on device metadata")
+	}
+
+	// Refresh with a valid DPoP proof signed by the bound key succeeds.
+	proof := newDPoPProofES256(t, devKey, "POST", "https://cerebro.test/platform/devices/token", now, "jti-1")
+	rotated, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: enroll.RefreshToken,
+		DPoPProof:    proof,
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
+		RemoteIP:     net.ParseIP("203.0.113.10"),
+	})
+	if err != nil {
+		t.Fatalf("IssueToken with DPoP: %v", err)
+	}
+	if rotated.RiskLevel != "low" {
+		t.Errorf("first rotation RiskLevel = %q, want low", rotated.RiskLevel)
+	}
+	if !containsScope(rotated.Scopes, ScopeTelemetryIngest) {
+		t.Errorf("first rotation missing telemetry ingest scope: %v", rotated.Scopes)
+	}
+
+	// Now the device shows up in Sydney three minutes later: impossible
+	// travel + country drift + ASN drift => high score, sensitive scopes
+	// should be downgraded.
+	now = now.Add(3 * time.Minute)
+	store.SetClock(clock)
+	dpop.SetClock(clock)
+	proof2 := newDPoPProofES256(t, devKey, "POST", "https://cerebro.test/platform/devices/token", now, "jti-2")
+	highRisk, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: rotated.RefreshToken,
+		DPoPProof:    proof2,
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
+		RemoteIP:     net.ParseIP("203.0.113.20"),
+	})
+	if err != nil {
+		t.Fatalf("IssueToken (relocated): %v", err)
+	}
+	if highRisk.RiskLevel != "high" {
+		t.Fatalf("relocated RiskLevel = %q, want high (score=%d)", highRisk.RiskLevel, highRisk.RiskScore)
+	}
+	if containsScope(highRisk.Scopes, ScopeTelemetryIngest) {
+		t.Errorf("high-risk rotation should drop telemetry ingest scope: %v", highRisk.Scopes)
+	}
+}
+
+// TestServiceRefreshRejectsMissingDPoPOnBoundDevice covers the path where
+// the device was enrolled with a hardware-bound key (so dpop_jkt is set on
+// metadata), and a subsequent refresh attempt arrives without a DPoP proof.
+func TestServiceRefreshRejectsMissingDPoPOnBoundDevice(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	signer, _ := NewLocalSigner([]SigningKey{{KID: "k1", Public: pub, Private: priv}})
+	keyset := &KeySet{Keys: []SigningKey{{KID: "k1", Public: pub}}}
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	store.SetClock(clock)
+	issuer, _ := NewJWTIssuer(IssuerConfig{Now: clock}, signer)
+	verifier, _ := NewJWTVerifier(VerifierConfig{Now: clock}, keyset)
+
+	devKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	registry := attestation.NewRegistry(true, &stubVerifier{
+		pubDER: ecPublicKeyDER(t, &devKey.PublicKey), keyID: "stub-key",
+	})
+	dpop := NewDPoPVerifier(time.Minute, time.Minute)
+	dpop.SetClock(clock)
+
+	service, err := NewService(ServiceConfig{
+		AccessTTL: 5 * time.Minute, RefreshTTL: 24 * time.Hour,
+		BootstrapTokenTTL: time.Hour, IdempotencyTTL: time.Hour,
+		Now: clock, Attestations: registry, DPoP: dpop,
+	}, store, issuer, verifier, keyset)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-2", TenantID: "writer", TTL: time.Hour, IssuedBy: "operator",
+	})
+	enroll, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-2",
+		OSType:         "darwin",
+		Attestation:    "stub-statement",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if _, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: enroll.RefreshToken,
+		HTTPMethod:   "POST",
+		HTTPURL:      "https://cerebro.test/platform/devices/token",
+	}); !errors.Is(err, ErrDPoPMissing) {
+		t.Fatalf("missing-DPoP err = %v, want ErrDPoPMissing", err)
+	}
+}
+
+func containsScope(scopes []string, want string) bool {
+	for _, s := range scopes {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/deviceauth/jwks.go
+++ b/internal/deviceauth/jwks.go
@@ -3,6 +3,7 @@ package deviceauth
 import (
 	"crypto/ed25519"
 	"encoding/base64"
+	"encoding/json"
 )
 
 // JWKSDocument is the JSON shape served at /.well-known/device-jwks.json.
@@ -42,4 +43,10 @@ func EncodeJWKS(keys *KeySet) JWKSDocument {
 		})
 	}
 	return out
+}
+
+// MarshalJSON prevents accidental serialization of SigningKey.Private by
+// exposing KeySet through the same public JWKS document as the HTTP endpoint.
+func (ks *KeySet) MarshalJSON() ([]byte, error) {
+	return json.Marshal(EncodeJWKS(ks))
 }

--- a/internal/deviceauth/jwks.go
+++ b/internal/deviceauth/jwks.go
@@ -1,0 +1,45 @@
+package deviceauth
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+)
+
+// JWKSDocument is the JSON shape served at /.well-known/device-jwks.json.
+// The format matches RFC 7517 §4 with the OKP/Ed25519 conventions of RFC
+// 8037: kty=OKP, crv=Ed25519, x is the base64url-encoded public key.
+type JWKSDocument struct {
+	Keys []JWK `json:"keys"`
+}
+
+// JWK is one entry in [JWKSDocument].
+type JWK struct {
+	KTY string `json:"kty"`
+	CRV string `json:"crv"`
+	KID string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	X   string `json:"x"`
+}
+
+// EncodeJWKS converts a [KeySet] into a publishable JWKS document.
+func EncodeJWKS(keys *KeySet) JWKSDocument {
+	if keys == nil {
+		return JWKSDocument{}
+	}
+	out := JWKSDocument{Keys: make([]JWK, 0, len(keys.Keys))}
+	for _, key := range keys.Keys {
+		if len(key.Public) != ed25519.PublicKeySize {
+			continue
+		}
+		out.Keys = append(out.Keys, JWK{
+			KTY: "OKP",
+			CRV: "Ed25519",
+			KID: key.KID,
+			Use: "sig",
+			Alg: "EdDSA",
+			X:   base64.RawURLEncoding.EncodeToString(key.Public),
+		})
+	}
+	return out
+}

--- a/internal/deviceauth/jwt.go
+++ b/internal/deviceauth/jwt.go
@@ -157,9 +157,31 @@ type AccessClaims struct {
 	Scopes       []string `json:"scopes,omitempty"`
 }
 
+// AccessOptions are the per-token additions a caller can place on top of the
+// scope list when issuing an access token.
+type AccessOptions struct {
+	// DPoPJKT, when non-empty, is the SHA-256 JWK thumbprint (RFC 7638) of
+	// the device's holder-of-key DPoP key. The verifier requires that every
+	// authenticated request carry a DPoP proof signed by this key, per
+	// RFC 9449 §6.
+	DPoPJKT string
+	// AssuranceLevel is propagated as the acr claim and is also used by the
+	// risk pipeline to decide whether sensitive scopes should be granted on
+	// this token. "hardware" indicates a device-bound key was attested at
+	// enroll; "software" indicates a software key only.
+	AssuranceLevel string
+}
+
 // IssueAccess produces a signed JWT for the given device with the given scopes.
 // The returned string is the compact-serialized token (header.payload.sig).
 func (j *JWTIssuer) IssueAccess(device DeviceRecord, scopes []string) (string, error) {
+	return j.IssueAccessWithOptions(device, scopes, AccessOptions{})
+}
+
+// IssueAccessWithOptions is the full form of [JWTIssuer.IssueAccess] that
+// supports DPoP binding (cnf.jkt) and an assurance level (acr). Both are
+// optional; the zero value behaves identically to IssueAccess.
+func (j *JWTIssuer) IssueAccessWithOptions(device DeviceRecord, scopes []string, opts AccessOptions) (string, error) {
 	if strings.TrimSpace(device.DeviceID) == "" {
 		return "", errors.New("deviceauth: device_id is required")
 	}
@@ -192,6 +214,10 @@ func (j *JWTIssuer) IssueAccess(device DeviceRecord, scopes []string) (string, e
 		HardwareUUID: device.HardwareUUID,
 		TenantID:     device.TenantID,
 		Scopes:       cloneStrings(scopes),
+		ACR:          strings.TrimSpace(opts.AssuranceLevel),
+	}
+	if jkt := strings.TrimSpace(opts.DPoPJKT); jkt != "" {
+		payload.CNF = &jwtConfirmation{JKT: jkt}
 	}
 	headerBytes, err := json.Marshal(header)
 	if err != nil {
@@ -250,13 +276,15 @@ func NewJWTVerifier(cfg VerifierConfig, keys *KeySet) (*JWTVerifier, error) {
 
 // VerifiedToken is the result of a successful [JWTVerifier.Verify] call.
 type VerifiedToken struct {
-	DeviceID     string
-	HardwareUUID string
-	TenantID     string
-	Scopes       []string
-	JTI          string
-	IssuedAt     time.Time
-	ExpiresAt    time.Time
+	DeviceID       string
+	HardwareUUID   string
+	TenantID       string
+	Scopes         []string
+	JTI            string
+	IssuedAt       time.Time
+	ExpiresAt      time.Time
+	DPoPJKT        string // confirmation jkt if the token was minted DPoP-bound
+	AssuranceLevel string // acr claim ("hardware" or "software")
 }
 
 // Verify parses and validates a compact-serialized device JWT. On success it
@@ -328,15 +356,20 @@ func (v *JWTVerifier) Verify(token string) (VerifiedToken, error) {
 	if len(payload.Scopes) == 0 {
 		return VerifiedToken{}, ErrMissingScopes
 	}
-	return VerifiedToken{
-		DeviceID:     payload.DeviceID,
-		HardwareUUID: payload.HardwareUUID,
-		TenantID:     payload.TenantID,
-		Scopes:       cloneStrings(payload.Scopes),
-		JTI:          payload.JTI,
-		IssuedAt:     time.Unix(payload.Iat, 0).UTC(),
-		ExpiresAt:    time.Unix(payload.Exp, 0).UTC(),
-	}, nil
+	verified := VerifiedToken{
+		DeviceID:       payload.DeviceID,
+		HardwareUUID:   payload.HardwareUUID,
+		TenantID:       payload.TenantID,
+		Scopes:         cloneStrings(payload.Scopes),
+		JTI:            payload.JTI,
+		IssuedAt:       time.Unix(payload.Iat, 0).UTC(),
+		ExpiresAt:      time.Unix(payload.Exp, 0).UTC(),
+		AssuranceLevel: strings.TrimSpace(payload.ACR),
+	}
+	if payload.CNF != nil {
+		verified.DPoPJKT = strings.TrimSpace(payload.CNF.JKT)
+	}
+	return verified, nil
 }
 
 // Typed verification errors. Callers should translate these into HTTP 401
@@ -363,18 +396,26 @@ type jwtHeader struct {
 }
 
 type jwtPayload struct {
-	Iss          string   `json:"iss"`
-	Aud          string   `json:"aud"`
-	Sub          string   `json:"sub"`
-	Exp          int64    `json:"exp"`
-	Nbf          int64    `json:"nbf"`
-	Iat          int64    `json:"iat"`
-	JTI          string   `json:"jti"`
-	Kind         string   `json:"kind"`
-	DeviceID     string   `json:"device_id"`
-	HardwareUUID string   `json:"hardware_uuid,omitempty"`
-	TenantID     string   `json:"tenant_id"`
-	Scopes       []string `json:"scopes"`
+	Iss          string            `json:"iss"`
+	Aud          string            `json:"aud"`
+	Sub          string            `json:"sub"`
+	Exp          int64             `json:"exp"`
+	Nbf          int64             `json:"nbf"`
+	Iat          int64             `json:"iat"`
+	JTI          string            `json:"jti"`
+	Kind         string            `json:"kind"`
+	DeviceID     string            `json:"device_id"`
+	HardwareUUID string            `json:"hardware_uuid,omitempty"`
+	TenantID     string            `json:"tenant_id"`
+	Scopes       []string          `json:"scopes"`
+	ACR          string            `json:"acr,omitempty"`
+	CNF          *jwtConfirmation  `json:"cnf,omitempty"`
+}
+
+// jwtConfirmation is the RFC 7800 cnf claim. We use the jkt subset for DPoP
+// holder-of-key binding (RFC 9449 §6).
+type jwtConfirmation struct {
+	JKT string `json:"jkt,omitempty"`
 }
 
 func newJTI() (string, error) {

--- a/internal/deviceauth/jwt.go
+++ b/internal/deviceauth/jwt.go
@@ -396,20 +396,20 @@ type jwtHeader struct {
 }
 
 type jwtPayload struct {
-	Iss          string            `json:"iss"`
-	Aud          string            `json:"aud"`
-	Sub          string            `json:"sub"`
-	Exp          int64             `json:"exp"`
-	Nbf          int64             `json:"nbf"`
-	Iat          int64             `json:"iat"`
-	JTI          string            `json:"jti"`
-	Kind         string            `json:"kind"`
-	DeviceID     string            `json:"device_id"`
-	HardwareUUID string            `json:"hardware_uuid,omitempty"`
-	TenantID     string            `json:"tenant_id"`
-	Scopes       []string          `json:"scopes"`
-	ACR          string            `json:"acr,omitempty"`
-	CNF          *jwtConfirmation  `json:"cnf,omitempty"`
+	Iss          string           `json:"iss"`
+	Aud          string           `json:"aud"`
+	Sub          string           `json:"sub"`
+	Exp          int64            `json:"exp"`
+	Nbf          int64            `json:"nbf"`
+	Iat          int64            `json:"iat"`
+	JTI          string           `json:"jti"`
+	Kind         string           `json:"kind"`
+	DeviceID     string           `json:"device_id"`
+	HardwareUUID string           `json:"hardware_uuid,omitempty"`
+	TenantID     string           `json:"tenant_id"`
+	Scopes       []string         `json:"scopes"`
+	ACR          string           `json:"acr,omitempty"`
+	CNF          *jwtConfirmation `json:"cnf,omitempty"`
 }
 
 // jwtConfirmation is the RFC 7800 cnf claim. We use the jkt subset for DPoP

--- a/internal/deviceauth/jwt.go
+++ b/internal/deviceauth/jwt.go
@@ -1,6 +1,7 @@
 package deviceauth
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
@@ -76,6 +77,10 @@ type LocalSigner struct {
 	keys       map[string]ed25519.PrivateKey
 }
 
+// ErrSigningKeyMismatch indicates that configured public verification key
+// material does not correspond to the configured private signing key.
+var ErrSigningKeyMismatch = errors.New("deviceauth: signing key public/private mismatch")
+
 // NewLocalSigner constructs a signer. The first kid in keys is treated as the
 // current kid.
 func NewLocalSigner(keys []SigningKey) (*LocalSigner, error) {
@@ -92,6 +97,12 @@ func NewLocalSigner(keys []SigningKey) (*LocalSigner, error) {
 		}
 		if len(key.Private) != ed25519.PrivateKeySize {
 			return nil, fmt.Errorf("deviceauth: signing key %q has invalid private size", key.KID)
+		}
+		if len(key.Public) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("deviceauth: signing key %q has invalid public size", key.KID)
+		}
+		if derived, ok := key.Private.Public().(ed25519.PublicKey); !ok || !bytes.Equal(derived, key.Public) {
+			return nil, fmt.Errorf("%w: kid %q", ErrSigningKeyMismatch, key.KID)
 		}
 		if _, exists := signer.keys[key.KID]; exists {
 			return nil, fmt.Errorf("deviceauth: duplicate kid %q", key.KID)

--- a/internal/deviceauth/jwt.go
+++ b/internal/deviceauth/jwt.go
@@ -48,8 +48,9 @@ type Signer interface {
 	Sign(kid string, signingInput []byte) ([]byte, error)
 }
 
-// KeySet is the verifier's view of the active and retiring signing keys. A
-// JWKS endpoint serializes this directly.
+// KeySet is the verifier's view of the active and retiring signing keys.
+// Direct JSON serialization is intentionally routed through the public JWKS
+// shape so private signing material is never emitted.
 type KeySet struct {
 	Keys []SigningKey
 }

--- a/internal/deviceauth/jwt.go
+++ b/internal/deviceauth/jwt.go
@@ -1,0 +1,395 @@
+package deviceauth
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// AccessTokenKind is the value placed in the kind claim of a SeCheck access
+// token. Refresh tokens are opaque strings, not JWTs, and are tracked through
+// [Store].
+const AccessTokenKind = "device_access"
+
+// DefaultAccessTTL bounds the lifetime of a device access token. Short enough
+// that a stolen token's blast radius is small; long enough that the agent does
+// not refresh on every poll.
+const DefaultAccessTTL = 10 * time.Minute
+
+// DefaultClockSkew is the maximum allowed difference between the verifier's
+// clock and the iat/nbf/exp claims on an incoming token.
+const DefaultClockSkew = 1 * time.Minute
+
+// SigningKey describes a single Ed25519 key, addressable by its kid.
+type SigningKey struct {
+	KID    string
+	Public ed25519.PublicKey
+	// Private is optional. Verifiers do not need it. The KMS-backed signer
+	// keeps Private nil and instead delegates Sign through KMS.
+	Private ed25519.PrivateKey
+}
+
+// Signer is the abstraction the issuer uses to produce a signature. The
+// in-process implementation is [LocalSigner]; production wires a KMS-backed
+// implementation that sign-delegates to AWS KMS without ever exposing the
+// private key.
+type Signer interface {
+	// CurrentKID returns the kid that should be embedded in the JWT header
+	// for new tokens. Verifiers must accept all KIDs in [KeySet.Keys].
+	CurrentKID() string
+	// Sign signs the JWT signing input (header.payload bytes) with the key
+	// identified by kid. The returned signature is the raw 64-byte Ed25519
+	// output (not base64-encoded).
+	Sign(kid string, signingInput []byte) ([]byte, error)
+}
+
+// KeySet is the verifier's view of the active and retiring signing keys. A
+// JWKS endpoint serializes this directly.
+type KeySet struct {
+	Keys []SigningKey
+}
+
+// Find returns the key with the given kid. The bool is false if no such key
+// is in the set.
+func (ks *KeySet) Find(kid string) (SigningKey, bool) {
+	if ks == nil {
+		return SigningKey{}, false
+	}
+	for _, key := range ks.Keys {
+		if key.KID == kid {
+			return key, true
+		}
+	}
+	return SigningKey{}, false
+}
+
+// LocalSigner signs with an in-process Ed25519 private key. Use only for tests
+// and for the dev-mode signing path; production should wire a KMS signer.
+type LocalSigner struct {
+	currentKID string
+	keys       map[string]ed25519.PrivateKey
+}
+
+// NewLocalSigner constructs a signer. The first kid in keys is treated as the
+// current kid.
+func NewLocalSigner(keys []SigningKey) (*LocalSigner, error) {
+	if len(keys) == 0 {
+		return nil, errors.New("deviceauth: at least one signing key is required")
+	}
+	signer := &LocalSigner{
+		currentKID: keys[0].KID,
+		keys:       make(map[string]ed25519.PrivateKey, len(keys)),
+	}
+	for _, key := range keys {
+		if strings.TrimSpace(key.KID) == "" {
+			return nil, errors.New("deviceauth: signing key requires a non-empty kid")
+		}
+		if len(key.Private) != ed25519.PrivateKeySize {
+			return nil, fmt.Errorf("deviceauth: signing key %q has invalid private size", key.KID)
+		}
+		if _, exists := signer.keys[key.KID]; exists {
+			return nil, fmt.Errorf("deviceauth: duplicate kid %q", key.KID)
+		}
+		signer.keys[key.KID] = key.Private
+	}
+	return signer, nil
+}
+
+// CurrentKID returns the kid that should be used to sign new tokens.
+func (s *LocalSigner) CurrentKID() string { return s.currentKID }
+
+// Sign produces an Ed25519 signature over signingInput using the private key
+// identified by kid.
+func (s *LocalSigner) Sign(kid string, signingInput []byte) ([]byte, error) {
+	priv, ok := s.keys[kid]
+	if !ok {
+		return nil, fmt.Errorf("deviceauth: unknown kid %q", kid)
+	}
+	return ed25519.Sign(priv, signingInput), nil
+}
+
+// IssuerConfig configures a [JWTIssuer].
+type IssuerConfig struct {
+	Issuer    string
+	Audience  string
+	AccessTTL time.Duration
+	Now       func() time.Time
+}
+
+// JWTIssuer mints SeCheck device access tokens.
+type JWTIssuer struct {
+	cfg    IssuerConfig
+	signer Signer
+}
+
+// NewJWTIssuer constructs an issuer.
+func NewJWTIssuer(cfg IssuerConfig, signer Signer) (*JWTIssuer, error) {
+	if signer == nil {
+		return nil, errors.New("deviceauth: signer is required")
+	}
+	cfg.Issuer = strings.TrimSpace(cfg.Issuer)
+	if cfg.Issuer == "" {
+		cfg.Issuer = "cerebro"
+	}
+	cfg.Audience = strings.TrimSpace(cfg.Audience)
+	if cfg.Audience == "" {
+		cfg.Audience = "cerebro-device"
+	}
+	if cfg.AccessTTL <= 0 {
+		cfg.AccessTTL = DefaultAccessTTL
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &JWTIssuer{cfg: cfg, signer: signer}, nil
+}
+
+// AccessClaims are the SeCheck-specific claims placed in a device access token.
+type AccessClaims struct {
+	DeviceID     string   `json:"device_id"`
+	HardwareUUID string   `json:"hardware_uuid,omitempty"`
+	TenantID     string   `json:"tenant_id"`
+	Scopes       []string `json:"scopes,omitempty"`
+}
+
+// IssueAccess produces a signed JWT for the given device with the given scopes.
+// The returned string is the compact-serialized token (header.payload.sig).
+func (j *JWTIssuer) IssueAccess(device DeviceRecord, scopes []string) (string, error) {
+	if strings.TrimSpace(device.DeviceID) == "" {
+		return "", errors.New("deviceauth: device_id is required")
+	}
+	if strings.TrimSpace(device.TenantID) == "" {
+		return "", errors.New("deviceauth: tenant_id is required")
+	}
+	if len(scopes) == 0 {
+		return "", errors.New("deviceauth: at least one scope is required")
+	}
+	now := j.cfg.Now().UTC()
+	jti, err := newJTI()
+	if err != nil {
+		return "", fmt.Errorf("deviceauth: generate jti: %w", err)
+	}
+	header := jwtHeader{
+		Alg: "EdDSA",
+		Typ: "JWT",
+		Kid: j.signer.CurrentKID(),
+	}
+	payload := jwtPayload{
+		Iss:          j.cfg.Issuer,
+		Aud:          j.cfg.Audience,
+		Sub:          "device:" + device.DeviceID,
+		Exp:          now.Add(j.cfg.AccessTTL).Unix(),
+		Nbf:          now.Unix(),
+		Iat:          now.Unix(),
+		JTI:          jti,
+		Kind:         AccessTokenKind,
+		DeviceID:     device.DeviceID,
+		HardwareUUID: device.HardwareUUID,
+		TenantID:     device.TenantID,
+		Scopes:       cloneStrings(scopes),
+	}
+	headerBytes, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("deviceauth: marshal header: %w", err)
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("deviceauth: marshal payload: %w", err)
+	}
+	headerSegment := base64.RawURLEncoding.EncodeToString(headerBytes)
+	payloadSegment := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	signingInput := headerSegment + "." + payloadSegment
+	sig, err := j.signer.Sign(header.Kid, []byte(signingInput))
+	if err != nil {
+		return "", fmt.Errorf("deviceauth: sign: %w", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// VerifierConfig configures a [JWTVerifier].
+type VerifierConfig struct {
+	Issuer    string
+	Audience  string
+	ClockSkew time.Duration
+	Now       func() time.Time
+}
+
+// JWTVerifier validates tokens issued by [JWTIssuer].
+type JWTVerifier struct {
+	cfg  VerifierConfig
+	keys *KeySet
+}
+
+// NewJWTVerifier constructs a verifier. It does not copy keys; callers must not
+// mutate the [KeySet] after passing it in.
+func NewJWTVerifier(cfg VerifierConfig, keys *KeySet) (*JWTVerifier, error) {
+	if keys == nil || len(keys.Keys) == 0 {
+		return nil, errors.New("deviceauth: at least one verification key is required")
+	}
+	cfg.Issuer = strings.TrimSpace(cfg.Issuer)
+	if cfg.Issuer == "" {
+		cfg.Issuer = "cerebro"
+	}
+	cfg.Audience = strings.TrimSpace(cfg.Audience)
+	if cfg.Audience == "" {
+		cfg.Audience = "cerebro-device"
+	}
+	if cfg.ClockSkew <= 0 {
+		cfg.ClockSkew = DefaultClockSkew
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &JWTVerifier{cfg: cfg, keys: keys}, nil
+}
+
+// VerifiedToken is the result of a successful [JWTVerifier.Verify] call.
+type VerifiedToken struct {
+	DeviceID     string
+	HardwareUUID string
+	TenantID     string
+	Scopes       []string
+	JTI          string
+	IssuedAt     time.Time
+	ExpiresAt    time.Time
+}
+
+// Verify parses and validates a compact-serialized device JWT. On success it
+// returns the verified claims; on failure it returns a typed error.
+func (v *JWTVerifier) Verify(token string) (VerifiedToken, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+	var header jwtHeader
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+	if header.Alg != "EdDSA" || header.Typ != "JWT" {
+		return VerifiedToken{}, ErrUnsupportedAlgorithm
+	}
+	if strings.TrimSpace(header.Kid) == "" {
+		return VerifiedToken{}, ErrUnknownKID
+	}
+	key, ok := v.keys.Find(header.Kid)
+	if !ok {
+		return VerifiedToken{}, ErrUnknownKID
+	}
+	if len(key.Public) != ed25519.PublicKeySize {
+		return VerifiedToken{}, ErrUnknownKID
+	}
+	signingInput := parts[0] + "." + parts[1]
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+	if !ed25519.Verify(key.Public, []byte(signingInput), sig) {
+		return VerifiedToken{}, ErrInvalidSignature
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+	var payload jwtPayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return VerifiedToken{}, ErrMalformedToken
+	}
+	if payload.Kind != AccessTokenKind {
+		return VerifiedToken{}, ErrWrongKind
+	}
+	if payload.Iss != v.cfg.Issuer {
+		return VerifiedToken{}, ErrIssuerMismatch
+	}
+	if payload.Aud != v.cfg.Audience {
+		return VerifiedToken{}, ErrAudienceMismatch
+	}
+	now := v.cfg.Now().UTC()
+	if payload.Exp == 0 || now.After(time.Unix(payload.Exp, 0).Add(v.cfg.ClockSkew)) {
+		return VerifiedToken{}, ErrExpired
+	}
+	if payload.Nbf > 0 && now.Add(v.cfg.ClockSkew).Before(time.Unix(payload.Nbf, 0)) {
+		return VerifiedToken{}, ErrNotYetValid
+	}
+	if strings.TrimSpace(payload.DeviceID) == "" {
+		return VerifiedToken{}, ErrMissingDeviceID
+	}
+	if strings.TrimSpace(payload.TenantID) == "" {
+		return VerifiedToken{}, ErrMissingTenantID
+	}
+	if len(payload.Scopes) == 0 {
+		return VerifiedToken{}, ErrMissingScopes
+	}
+	return VerifiedToken{
+		DeviceID:     payload.DeviceID,
+		HardwareUUID: payload.HardwareUUID,
+		TenantID:     payload.TenantID,
+		Scopes:       cloneStrings(payload.Scopes),
+		JTI:          payload.JTI,
+		IssuedAt:     time.Unix(payload.Iat, 0).UTC(),
+		ExpiresAt:    time.Unix(payload.Exp, 0).UTC(),
+	}, nil
+}
+
+// Typed verification errors. Callers should translate these into HTTP 401
+// responses with stable error codes.
+var (
+	ErrMalformedToken       = errors.New("deviceauth: malformed token")
+	ErrUnsupportedAlgorithm = errors.New("deviceauth: unsupported algorithm")
+	ErrUnknownKID           = errors.New("deviceauth: unknown kid")
+	ErrInvalidSignature     = errors.New("deviceauth: invalid signature")
+	ErrWrongKind            = errors.New("deviceauth: wrong token kind")
+	ErrIssuerMismatch       = errors.New("deviceauth: issuer mismatch")
+	ErrAudienceMismatch     = errors.New("deviceauth: audience mismatch")
+	ErrExpired              = errors.New("deviceauth: token expired")
+	ErrNotYetValid          = errors.New("deviceauth: token not yet valid")
+	ErrMissingDeviceID      = errors.New("deviceauth: missing device_id claim")
+	ErrMissingTenantID      = errors.New("deviceauth: missing tenant_id claim")
+	ErrMissingScopes        = errors.New("deviceauth: missing scopes claim")
+)
+
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Typ string `json:"typ"`
+	Kid string `json:"kid"`
+}
+
+type jwtPayload struct {
+	Iss          string   `json:"iss"`
+	Aud          string   `json:"aud"`
+	Sub          string   `json:"sub"`
+	Exp          int64    `json:"exp"`
+	Nbf          int64    `json:"nbf"`
+	Iat          int64    `json:"iat"`
+	JTI          string   `json:"jti"`
+	Kind         string   `json:"kind"`
+	DeviceID     string   `json:"device_id"`
+	HardwareUUID string   `json:"hardware_uuid,omitempty"`
+	TenantID     string   `json:"tenant_id"`
+	Scopes       []string `json:"scopes"`
+}
+
+func newJTI() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func cloneStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}

--- a/internal/deviceauth/jwt_test.go
+++ b/internal/deviceauth/jwt_test.go
@@ -1,0 +1,180 @@
+package deviceauth
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newSignerForTest(t *testing.T, kids ...string) (*LocalSigner, *KeySet) {
+	t.Helper()
+	if len(kids) == 0 {
+		kids = []string{"test-kid-1"}
+	}
+	keys := make([]SigningKey, 0, len(kids))
+	verifyKeys := make([]SigningKey, 0, len(kids))
+	for _, kid := range kids {
+		pub, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatalf("generate key: %v", err)
+		}
+		keys = append(keys, SigningKey{KID: kid, Public: pub, Private: priv})
+		verifyKeys = append(verifyKeys, SigningKey{KID: kid, Public: pub})
+	}
+	signer, err := NewLocalSigner(keys)
+	if err != nil {
+		t.Fatalf("NewLocalSigner: %v", err)
+	}
+	return signer, &KeySet{Keys: verifyKeys}
+}
+
+func TestJWTIssuerVerifierRoundTrip(t *testing.T) {
+	signer, keyset := newSignerForTest(t)
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	issuer, err := NewJWTIssuer(IssuerConfig{Issuer: "cerebro", Audience: "cerebro-device", Now: clock}, signer)
+	if err != nil {
+		t.Fatalf("NewJWTIssuer: %v", err)
+	}
+	verifier, err := NewJWTVerifier(VerifierConfig{Issuer: "cerebro", Audience: "cerebro-device", Now: clock}, keyset)
+	if err != nil {
+		t.Fatalf("NewJWTVerifier: %v", err)
+	}
+
+	device := DeviceRecord{DeviceID: "dev-1", TenantID: "writer", HardwareUUID: "hw-1"}
+	scopes := []string{"platform.devices.read", "platform.telemetry.ingest"}
+
+	token, err := issuer.IssueAccess(device, scopes)
+	if err != nil {
+		t.Fatalf("IssueAccess: %v", err)
+	}
+	if strings.Count(token, ".") != 2 {
+		t.Fatalf("expected three-segment compact JWT, got %q", token)
+	}
+
+	verified, err := verifier.Verify(token)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if verified.DeviceID != "dev-1" {
+		t.Errorf("device_id = %q, want dev-1", verified.DeviceID)
+	}
+	if verified.TenantID != "writer" {
+		t.Errorf("tenant_id = %q, want writer", verified.TenantID)
+	}
+	if verified.HardwareUUID != "hw-1" {
+		t.Errorf("hardware_uuid = %q, want hw-1", verified.HardwareUUID)
+	}
+	if len(verified.Scopes) != 2 {
+		t.Errorf("scopes = %v, want 2 entries", verified.Scopes)
+	}
+}
+
+func TestJWTVerifierRejectsExpired(t *testing.T) {
+	signer, keyset := newSignerForTest(t)
+	issueAt := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	verifyAt := issueAt.Add(2 * DefaultAccessTTL)
+
+	issuer, _ := NewJWTIssuer(IssuerConfig{Now: func() time.Time { return issueAt }}, signer)
+	verifier, _ := NewJWTVerifier(VerifierConfig{Now: func() time.Time { return verifyAt }}, keyset)
+
+	token, err := issuer.IssueAccess(DeviceRecord{DeviceID: "dev-1", TenantID: "writer"}, []string{"a"})
+	if err != nil {
+		t.Fatalf("IssueAccess: %v", err)
+	}
+	if _, err := verifier.Verify(token); !errors.Is(err, ErrExpired) {
+		t.Fatalf("Verify err = %v, want ErrExpired", err)
+	}
+}
+
+func TestJWTVerifierRejectsUnknownKID(t *testing.T) {
+	signer, _ := newSignerForTest(t, "issuer-kid")
+	_, otherKeyset := newSignerForTest(t, "other-kid")
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	issuer, _ := NewJWTIssuer(IssuerConfig{Now: clock}, signer)
+	verifier, _ := NewJWTVerifier(VerifierConfig{Now: clock}, otherKeyset)
+
+	token, err := issuer.IssueAccess(DeviceRecord{DeviceID: "dev-1", TenantID: "writer"}, []string{"a"})
+	if err != nil {
+		t.Fatalf("IssueAccess: %v", err)
+	}
+	if _, err := verifier.Verify(token); !errors.Is(err, ErrUnknownKID) {
+		t.Fatalf("Verify err = %v, want ErrUnknownKID", err)
+	}
+}
+
+func TestJWTVerifierRejectsAudienceMismatch(t *testing.T) {
+	signer, keyset := newSignerForTest(t)
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	issuer, _ := NewJWTIssuer(IssuerConfig{Issuer: "cerebro", Audience: "cerebro-device", Now: clock}, signer)
+	verifier, _ := NewJWTVerifier(VerifierConfig{Issuer: "cerebro", Audience: "different-aud", Now: clock}, keyset)
+
+	token, _ := issuer.IssueAccess(DeviceRecord{DeviceID: "dev-1", TenantID: "writer"}, []string{"a"})
+	if _, err := verifier.Verify(token); !errors.Is(err, ErrAudienceMismatch) {
+		t.Fatalf("Verify err = %v, want ErrAudienceMismatch", err)
+	}
+}
+
+func TestJWTVerifierRejectsTamperedSignature(t *testing.T) {
+	signer, keyset := newSignerForTest(t)
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	issuer, _ := NewJWTIssuer(IssuerConfig{Now: clock}, signer)
+	verifier, _ := NewJWTVerifier(VerifierConfig{Now: clock}, keyset)
+
+	token, _ := issuer.IssueAccess(DeviceRecord{DeviceID: "dev-1", TenantID: "writer"}, []string{"a"})
+	parts := strings.Split(token, ".")
+	tampered := parts[0] + "." + parts[1] + "." + parts[2][:len(parts[2])-1] + "A"
+	if _, err := verifier.Verify(tampered); !errors.Is(err, ErrInvalidSignature) && !errors.Is(err, ErrMalformedToken) {
+		t.Fatalf("Verify err = %v, want ErrInvalidSignature or ErrMalformedToken", err)
+	}
+}
+
+func TestJWTIssuerRequiresScopes(t *testing.T) {
+	signer, _ := newSignerForTest(t)
+	issuer, _ := NewJWTIssuer(IssuerConfig{}, signer)
+	if _, err := issuer.IssueAccess(DeviceRecord{DeviceID: "dev-1", TenantID: "writer"}, nil); err == nil {
+		t.Fatalf("IssueAccess with no scopes succeeded; want error")
+	}
+}
+
+func TestKeySetSupportsRotation(t *testing.T) {
+	// Two keys: old (retiring) and new (current). New tokens use "new"; old
+	// tokens issued before rotation must still verify.
+	pub1, priv1, _ := ed25519.GenerateKey(rand.Reader)
+	pub2, priv2, _ := ed25519.GenerateKey(rand.Reader)
+
+	oldSigner, _ := NewLocalSigner([]SigningKey{{KID: "old", Public: pub1, Private: priv1}})
+	newSigner, _ := NewLocalSigner([]SigningKey{{KID: "new", Public: pub2, Private: priv2}})
+
+	combinedKeyset := &KeySet{Keys: []SigningKey{
+		{KID: "new", Public: pub2},
+		{KID: "old", Public: pub1},
+	}}
+
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	oldIssuer, _ := NewJWTIssuer(IssuerConfig{Now: clock}, oldSigner)
+	newIssuer, _ := NewJWTIssuer(IssuerConfig{Now: clock}, newSigner)
+	verifier, _ := NewJWTVerifier(VerifierConfig{Now: clock}, combinedKeyset)
+
+	oldToken, _ := oldIssuer.IssueAccess(DeviceRecord{DeviceID: "dev-1", TenantID: "writer"}, []string{"a"})
+	newToken, _ := newIssuer.IssueAccess(DeviceRecord{DeviceID: "dev-2", TenantID: "writer"}, []string{"a"})
+
+	if _, err := verifier.Verify(oldToken); err != nil {
+		t.Fatalf("verify old token after rotation: %v", err)
+	}
+	if _, err := verifier.Verify(newToken); err != nil {
+		t.Fatalf("verify new token after rotation: %v", err)
+	}
+}

--- a/internal/deviceauth/jwt_test.go
+++ b/internal/deviceauth/jwt_test.go
@@ -133,7 +133,14 @@ func TestJWTVerifierRejectsTamperedSignature(t *testing.T) {
 
 	token, _ := issuer.IssueAccess(DeviceRecord{DeviceID: "dev-1", TenantID: "writer"}, []string{"a"})
 	parts := strings.Split(token, ".")
-	tampered := parts[0] + "." + parts[1] + "." + parts[2][:len(parts[2])-1] + "A"
+	// Tamper a byte at the start of the signature; flipping the first
+	// base64url character is guaranteed to change the decoded bytes.
+	first := parts[2][0]
+	flipped := byte('A')
+	if first == 'A' {
+		flipped = 'B'
+	}
+	tampered := parts[0] + "." + parts[1] + "." + string(flipped) + parts[2][1:]
 	if _, err := verifier.Verify(tampered); !errors.Is(err, ErrInvalidSignature) && !errors.Is(err, ErrMalformedToken) {
 		t.Fatalf("Verify err = %v, want ErrInvalidSignature or ErrMalformedToken", err)
 	}

--- a/internal/deviceauth/jwt_test.go
+++ b/internal/deviceauth/jwt_test.go
@@ -154,6 +154,21 @@ func TestJWTIssuerRequiresScopes(t *testing.T) {
 	}
 }
 
+func TestNewLocalSignerRejectsMismatchedPublicPrivateKey(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate public key: %v", err)
+	}
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate private key: %v", err)
+	}
+	_, err = NewLocalSigner([]SigningKey{{KID: "mismatched", Public: pub, Private: priv}})
+	if !errors.Is(err, ErrSigningKeyMismatch) {
+		t.Fatalf("NewLocalSigner err = %v, want public/private mismatch", err)
+	}
+}
+
 func TestKeySetSupportsRotation(t *testing.T) {
 	// Two keys: old (retiring) and new (current). New tokens use "new"; old
 	// tokens issued before rotation must still verify.

--- a/internal/deviceauth/keys.go
+++ b/internal/deviceauth/keys.go
@@ -1,0 +1,53 @@
+package deviceauth
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+)
+
+// DecodePEMPrivateKey parses a PEM-encoded PKCS#8 Ed25519 private key.
+func DecodePEMPrivateKey(pemBytes string) (ed25519.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(strings.TrimSpace(pemBytes)))
+	if block == nil {
+		return nil, fmt.Errorf("deviceauth: no PEM block decoded for private key")
+	}
+	switch block.Type {
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("deviceauth: parse PKCS#8 private key: %w", err)
+		}
+		ed, ok := key.(ed25519.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("deviceauth: PEM private key is not Ed25519")
+		}
+		return ed, nil
+	default:
+		return nil, fmt.Errorf("deviceauth: unexpected PEM block %q for private key", block.Type)
+	}
+}
+
+// DecodePEMPublicKey parses a PEM-encoded PKIX Ed25519 public key.
+func DecodePEMPublicKey(pemBytes string) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode([]byte(strings.TrimSpace(pemBytes)))
+	if block == nil {
+		return nil, fmt.Errorf("deviceauth: no PEM block decoded for public key")
+	}
+	switch block.Type {
+	case "PUBLIC KEY":
+		key, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("deviceauth: parse PKIX public key: %w", err)
+		}
+		ed, ok := key.(ed25519.PublicKey)
+		if !ok {
+			return nil, fmt.Errorf("deviceauth: PEM public key is not Ed25519")
+		}
+		return ed, nil
+	default:
+		return nil, fmt.Errorf("deviceauth: unexpected PEM block %q for public key", block.Type)
+	}
+}

--- a/internal/deviceauth/keys_helpers_test.go
+++ b/internal/deviceauth/keys_helpers_test.go
@@ -1,0 +1,26 @@
+package deviceauth
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+)
+
+func mustEncodePEMPublic(t *testing.T, pub ed25519.PublicKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+func mustEncodePEMPrivate(t *testing.T, priv ed25519.PrivateKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal private key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}

--- a/internal/deviceauth/memstore.go
+++ b/internal/deviceauth/memstore.go
@@ -1,0 +1,217 @@
+package deviceauth
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"time"
+)
+
+// MemStore is an in-memory [Store] implementation used for unit tests and as
+// a reference for the persistence contract. It is not suitable for
+// production: the bootstrap binary is required to use a real driver per
+// docs/NON_GOALS.md.
+type MemStore struct {
+	mu               sync.Mutex
+	devices          map[string]DeviceRecord
+	bootstrapTokens  map[[32]byte]BootstrapToken
+	refreshTokens    map[[32]byte]RefreshToken
+	refreshByFamily  map[string]map[[32]byte]struct{}
+	idempotency      map[string]idempotencyEntry
+}
+
+type idempotencyEntry struct {
+	requestHash [32]byte
+	status      int
+	body        []byte
+	expiresAt   time.Time
+}
+
+// NewMemStore returns a freshly initialized in-memory store.
+func NewMemStore() *MemStore {
+	return &MemStore{
+		devices:         make(map[string]DeviceRecord),
+		bootstrapTokens: make(map[[32]byte]BootstrapToken),
+		refreshTokens:   make(map[[32]byte]RefreshToken),
+		refreshByFamily: make(map[string]map[[32]byte]struct{}),
+		idempotency:     make(map[string]idempotencyEntry),
+	}
+}
+
+// EnrollDevice inserts or replaces the device row.
+func (s *MemStore) EnrollDevice(_ context.Context, device DeviceRecord) (DeviceRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.devices[device.DeviceID] = device
+	return device, nil
+}
+
+// LookupDevice returns the device by id or [ErrDeviceNotFound].
+func (s *MemStore) LookupDevice(_ context.Context, deviceID string) (DeviceRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	device, ok := s.devices[deviceID]
+	if !ok {
+		return DeviceRecord{}, ErrDeviceNotFound
+	}
+	return device, nil
+}
+
+// MarkSeen updates last_seen_at on the device row.
+func (s *MemStore) MarkSeen(_ context.Context, deviceID string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	device, ok := s.devices[deviceID]
+	if !ok {
+		return ErrDeviceNotFound
+	}
+	device.LastSeenAt = at.UTC()
+	s.devices[deviceID] = device
+	return nil
+}
+
+// RevokeDevice flips the device status and records the revoke time.
+func (s *MemStore) RevokeDevice(_ context.Context, deviceID string, at time.Time, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	device, ok := s.devices[deviceID]
+	if !ok {
+		return ErrDeviceNotFound
+	}
+	device.Status = "revoked"
+	device.RevokedAt = at.UTC()
+	s.devices[deviceID] = device
+	return nil
+}
+
+// CreateBootstrapToken inserts a new bootstrap token row.
+func (s *MemStore) CreateBootstrapToken(_ context.Context, token BootstrapToken) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.bootstrapTokens[token.TokenHash] = token
+	return nil
+}
+
+// ConsumeBootstrapToken atomically validates and consumes a bootstrap token.
+func (s *MemStore) ConsumeBootstrapToken(_ context.Context, hash [32]byte, hardwareUUID string, at time.Time, by string) (BootstrapToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	token, ok := s.bootstrapTokens[hash]
+	if !ok {
+		return BootstrapToken{}, ErrBootstrapTokenNotFound
+	}
+	if !token.ConsumedAt.IsZero() {
+		return BootstrapToken{}, ErrBootstrapTokenConsumed
+	}
+	if !token.ExpiresAt.IsZero() && at.After(token.ExpiresAt) {
+		return BootstrapToken{}, ErrBootstrapTokenExpired
+	}
+	if token.HardwareUUID != "" && token.HardwareUUID != hardwareUUID {
+		return BootstrapToken{}, ErrBootstrapTokenMismatch
+	}
+	consumed := token
+	consumed.ConsumedAt = at.UTC()
+	consumed.ConsumedBy = by
+	s.bootstrapTokens[hash] = consumed
+	return token, nil
+}
+
+// IssueRefreshToken inserts a new refresh-token row.
+func (s *MemStore) IssueRefreshToken(_ context.Context, token RefreshToken) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.refreshTokens[token.TokenHash] = token
+	if _, ok := s.refreshByFamily[token.FamilyID]; !ok {
+		s.refreshByFamily[token.FamilyID] = make(map[[32]byte]struct{})
+	}
+	s.refreshByFamily[token.FamilyID][token.TokenHash] = struct{}{}
+	return nil
+}
+
+// ConsumeRefreshToken atomically consumes (or replay-revokes) a refresh token.
+func (s *MemStore) ConsumeRefreshToken(_ context.Context, hash [32]byte, at time.Time) (RefreshToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	token, ok := s.refreshTokens[hash]
+	if !ok {
+		return RefreshToken{}, ErrRefreshNotFound
+	}
+	if token.FamilyRevoked {
+		return RefreshToken{}, ErrRefreshReplay
+	}
+	if !token.ConsumedAt.IsZero() {
+		s.revokeFamilyLocked(token.FamilyID)
+		return RefreshToken{}, ErrRefreshReplay
+	}
+	if !token.ExpiresAt.IsZero() && at.After(token.ExpiresAt) {
+		return RefreshToken{}, ErrRefreshExpired
+	}
+	device, ok := s.devices[token.DeviceID]
+	if !ok {
+		return RefreshToken{}, ErrDeviceNotFound
+	}
+	if device.Status != "" && device.Status != "active" {
+		return RefreshToken{}, ErrDeviceInactive
+	}
+	consumed := token
+	consumed.ConsumedAt = at.UTC()
+	consumed.Superseded = true
+	s.refreshTokens[hash] = consumed
+	return token, nil
+}
+
+// RevokeRefreshFamily marks every refresh token in the family as revoked.
+func (s *MemStore) RevokeRefreshFamily(_ context.Context, familyID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.revokeFamilyLocked(familyID)
+	return nil
+}
+
+func (s *MemStore) revokeFamilyLocked(familyID string) {
+	hashes, ok := s.refreshByFamily[familyID]
+	if !ok {
+		return
+	}
+	for hash := range hashes {
+		token := s.refreshTokens[hash]
+		token.FamilyRevoked = true
+		s.refreshTokens[hash] = token
+	}
+}
+
+// CheckIdempotency returns a cached response if one exists and the request
+// hash matches. A hash mismatch returns [ErrIdempotencyConflict].
+func (s *MemStore) CheckIdempotency(_ context.Context, key string, requestHash [32]byte) ([]byte, int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.idempotency[key]
+	if !ok {
+		return nil, 0, nil
+	}
+	if !entry.expiresAt.IsZero() && time.Now().After(entry.expiresAt) {
+		delete(s.idempotency, key)
+		return nil, 0, nil
+	}
+	if !bytes.Equal(entry.requestHash[:], requestHash[:]) {
+		return nil, 0, ErrIdempotencyConflict
+	}
+	out := make([]byte, len(entry.body))
+	copy(out, entry.body)
+	return out, entry.status, nil
+}
+
+// PutIdempotency caches a response under the given idempotency key.
+func (s *MemStore) PutIdempotency(_ context.Context, key string, requestHash [32]byte, status int, body []byte, expiresAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	stored := make([]byte, len(body))
+	copy(stored, body)
+	s.idempotency[key] = idempotencyEntry{
+		requestHash: requestHash,
+		status:      status,
+		body:        stored,
+		expiresAt:   expiresAt.UTC(),
+	}
+	return nil
+}

--- a/internal/deviceauth/memstore.go
+++ b/internal/deviceauth/memstore.go
@@ -140,6 +140,23 @@ func (s *MemStore) IssueRefreshToken(_ context.Context, token RefreshToken) erro
 	return nil
 }
 
+// LookupRefreshToken returns refresh-token metadata without consuming it.
+func (s *MemStore) LookupRefreshToken(_ context.Context, hash [32]byte, at time.Time) (RefreshToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	token, ok := s.refreshTokens[hash]
+	if !ok {
+		return RefreshToken{}, ErrRefreshNotFound
+	}
+	if token.FamilyRevoked {
+		return token, nil
+	}
+	if !token.ExpiresAt.IsZero() && at.After(token.ExpiresAt) {
+		return RefreshToken{}, ErrRefreshExpired
+	}
+	return token, nil
+}
+
 // ConsumeRefreshToken atomically consumes (or replay-revokes) a refresh token.
 func (s *MemStore) ConsumeRefreshToken(_ context.Context, hash [32]byte, at time.Time) (RefreshToken, error) {
 	s.mu.Lock()

--- a/internal/deviceauth/memstore.go
+++ b/internal/deviceauth/memstore.go
@@ -12,12 +12,13 @@ import (
 // production: the bootstrap binary is required to use a real driver per
 // docs/NON_GOALS.md.
 type MemStore struct {
-	mu               sync.Mutex
-	devices          map[string]DeviceRecord
-	bootstrapTokens  map[[32]byte]BootstrapToken
-	refreshTokens    map[[32]byte]RefreshToken
-	refreshByFamily  map[string]map[[32]byte]struct{}
-	idempotency      map[string]idempotencyEntry
+	mu              sync.Mutex
+	devices         map[string]DeviceRecord
+	bootstrapTokens map[[32]byte]BootstrapToken
+	refreshTokens   map[[32]byte]RefreshToken
+	refreshByFamily map[string]map[[32]byte]struct{}
+	idempotency     map[string]idempotencyEntry
+	now             func() time.Time
 }
 
 type idempotencyEntry struct {
@@ -35,7 +36,18 @@ func NewMemStore() *MemStore {
 		refreshTokens:   make(map[[32]byte]RefreshToken),
 		refreshByFamily: make(map[string]map[[32]byte]struct{}),
 		idempotency:     make(map[string]idempotencyEntry),
+		now:             time.Now,
 	}
+}
+
+// SetClock overrides the in-memory store's wall clock for tests.
+func (s *MemStore) SetClock(now func() time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if now == nil {
+		now = time.Now
+	}
+	s.now = now
 }
 
 // EnrollDevice inserts or replaces the device row.
@@ -168,6 +180,13 @@ func (s *MemStore) RevokeRefreshFamily(_ context.Context, familyID string) error
 	return nil
 }
 
+func (s *MemStore) nowLocked() time.Time {
+	if s.now == nil {
+		return time.Now()
+	}
+	return s.now()
+}
+
 func (s *MemStore) revokeFamilyLocked(familyID string) {
 	hashes, ok := s.refreshByFamily[familyID]
 	if !ok {
@@ -189,7 +208,7 @@ func (s *MemStore) CheckIdempotency(_ context.Context, key string, requestHash [
 	if !ok {
 		return nil, 0, nil
 	}
-	if !entry.expiresAt.IsZero() && time.Now().After(entry.expiresAt) {
+	if !entry.expiresAt.IsZero() && s.nowLocked().After(entry.expiresAt) {
 		delete(s.idempotency, key)
 		return nil, 0, nil
 	}

--- a/internal/deviceauth/memstore.go
+++ b/internal/deviceauth/memstore.go
@@ -3,6 +3,7 @@ package deviceauth
 import (
 	"bytes"
 	"context"
+	"strings"
 	"sync"
 	"time"
 )
@@ -67,6 +68,20 @@ func (s *MemStore) LookupDevice(_ context.Context, deviceID string) (DeviceRecor
 		return DeviceRecord{}, ErrDeviceNotFound
 	}
 	return device, nil
+}
+
+// LookupDeviceByHardware returns the device by tenant and hardware UUID.
+func (s *MemStore) LookupDeviceByHardware(_ context.Context, tenantID string, hardwareUUID string) (DeviceRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tenantID = strings.TrimSpace(tenantID)
+	hardwareUUID = strings.TrimSpace(hardwareUUID)
+	for _, device := range s.devices {
+		if strings.TrimSpace(device.TenantID) == tenantID && strings.TrimSpace(device.HardwareUUID) == hardwareUUID {
+			return device, nil
+		}
+	}
+	return DeviceRecord{}, ErrDeviceNotFound
 }
 
 // MarkSeen updates last_seen_at on the device row.

--- a/internal/deviceauth/ratelimit.go
+++ b/internal/deviceauth/ratelimit.go
@@ -1,0 +1,82 @@
+package deviceauth
+
+import (
+	"sync"
+	"time"
+)
+
+// TokenBucket is a process-local token-bucket rate limiter keyed by string.
+// It is not a substitute for an edge rate limiter (the design assumes AWS
+// WAF is in front), but it shaves off retry storms before they reach the
+// store.
+type TokenBucket struct {
+	mu               sync.Mutex
+	ratePerSecond    float64
+	burst            float64
+	now              func() time.Time
+	buckets          map[string]*tokenBucketEntry
+	lastSweep        time.Time
+	maxIdle          time.Duration
+}
+
+type tokenBucketEntry struct {
+	tokens    float64
+	updatedAt time.Time
+}
+
+// NewTokenBucket constructs a token bucket with the given steady-state rate
+// and burst capacity. A rate <= 0 disables the limiter.
+func NewTokenBucket(ratePerSecond float64, burst int) *TokenBucket {
+	bucket := &TokenBucket{
+		ratePerSecond: ratePerSecond,
+		burst:         float64(burst),
+		now:           time.Now,
+		buckets:       make(map[string]*tokenBucketEntry),
+		maxIdle:       10 * time.Minute,
+	}
+	if bucket.burst <= 0 {
+		bucket.burst = 1
+	}
+	return bucket
+}
+
+// Allow returns true if the caller may proceed for the given key.
+func (b *TokenBucket) Allow(key string) bool {
+	if b == nil || b.ratePerSecond <= 0 {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := b.now()
+	b.sweepLocked(now)
+	entry, ok := b.buckets[key]
+	if !ok {
+		entry = &tokenBucketEntry{tokens: b.burst, updatedAt: now}
+		b.buckets[key] = entry
+	}
+	elapsed := now.Sub(entry.updatedAt).Seconds()
+	if elapsed > 0 {
+		entry.tokens += elapsed * b.ratePerSecond
+		if entry.tokens > b.burst {
+			entry.tokens = b.burst
+		}
+		entry.updatedAt = now
+	}
+	if entry.tokens < 1 {
+		return false
+	}
+	entry.tokens--
+	return true
+}
+
+func (b *TokenBucket) sweepLocked(now time.Time) {
+	if now.Sub(b.lastSweep) < time.Minute {
+		return
+	}
+	b.lastSweep = now
+	for key, entry := range b.buckets {
+		if now.Sub(entry.updatedAt) > b.maxIdle {
+			delete(b.buckets, key)
+		}
+	}
+}

--- a/internal/deviceauth/ratelimit.go
+++ b/internal/deviceauth/ratelimit.go
@@ -10,13 +10,13 @@ import (
 // WAF is in front), but it shaves off retry storms before they reach the
 // store.
 type TokenBucket struct {
-	mu               sync.Mutex
-	ratePerSecond    float64
-	burst            float64
-	now              func() time.Time
-	buckets          map[string]*tokenBucketEntry
-	lastSweep        time.Time
-	maxIdle          time.Duration
+	mu            sync.Mutex
+	ratePerSecond float64
+	burst         float64
+	now           func() time.Time
+	buckets       map[string]*tokenBucketEntry
+	lastSweep     time.Time
+	maxIdle       time.Duration
 }
 
 type tokenBucketEntry struct {

--- a/internal/deviceauth/ratelimit.go
+++ b/internal/deviceauth/ratelimit.go
@@ -40,6 +40,16 @@ func NewTokenBucket(ratePerSecond float64, burst int) *TokenBucket {
 	return bucket
 }
 
+// SetClockForTest overrides the wall clock used by the limiter. Tests only.
+func (b *TokenBucket) SetClockForTest(now func() time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if now == nil {
+		now = time.Now
+	}
+	b.now = now
+}
+
 // Allow returns true if the caller may proceed for the given key.
 func (b *TokenBucket) Allow(key string) bool {
 	if b == nil || b.ratePerSecond <= 0 {

--- a/internal/deviceauth/risk/doc.go
+++ b/internal/deviceauth/risk/doc.go
@@ -1,0 +1,29 @@
+// Package risk implements the Phase-3 anomaly-detection layer that runs on
+// every authenticated SeCheck request.
+//
+// The pipeline is:
+//
+//  1. The HTTP handler calls [Scorer.Score] with a [Signal] capturing the
+//     remote IP, the device's previous-known location, and the time since
+//     the last refresh.
+//  2. [Scorer] runs each registered [Detector] -- velocity (impossible
+//     travel), geo/ASN drift, request-rate anomaly -- and aggregates the
+//     numeric signals into a single 0..100 score.
+//  3. The handler decides what to do:
+//       - score < LowThreshold:    allow as-is
+//       - LowThreshold..HighThr:   allow but emit an audit signal
+//       - score >= HighThreshold:  drop sensitive scopes (telemetry write,
+//                                  bootstrap-token issuance, revocation)
+//                                  and emit a high-priority audit + WAF
+//                                  rule update.
+//
+// Geo/ASN lookup is pluggable via [GeoLookup]. The default
+// [InMemoryGeoLookup] holds a static IP -> (country, asn, lat, lon) table
+// suitable for tests and offline development; production wires a MaxMind-
+// or AWS-managed-service-backed lookup.
+//
+// WAF rule updates are pluggable via [WAFEmitter]. The default
+// [JSONLogEmitter] just writes a JSON line; production wires an emitter
+// that talks to AWS WAFv2's UpdateIPSet API or pushes to an EventBridge
+// rule that drives a Lambda.
+package risk

--- a/internal/deviceauth/risk/doc.go
+++ b/internal/deviceauth/risk/doc.go
@@ -10,12 +10,12 @@
 //     travel), geo/ASN drift, request-rate anomaly -- and aggregates the
 //     numeric signals into a single 0..100 score.
 //  3. The handler decides what to do:
-//       - score < LowThreshold:    allow as-is
-//       - LowThreshold..HighThr:   allow but emit an audit signal
-//       - score >= HighThreshold:  drop sensitive scopes (telemetry write,
-//                                  bootstrap-token issuance, revocation)
-//                                  and emit a high-priority audit + WAF
-//                                  rule update.
+//     - score < LowThreshold:    allow as-is
+//     - LowThreshold..HighThr:   allow but emit an audit signal
+//     - score >= HighThreshold:  drop sensitive scopes (telemetry write,
+//     bootstrap-token issuance, revocation)
+//     and emit a high-priority audit + WAF
+//     rule update.
 //
 // Geo/ASN lookup is pluggable via [GeoLookup]. The default
 // [InMemoryGeoLookup] holds a static IP -> (country, asn, lat, lon) table

--- a/internal/deviceauth/risk/geoasn.go
+++ b/internal/deviceauth/risk/geoasn.go
@@ -1,0 +1,92 @@
+package risk
+
+import (
+	"context"
+	"net"
+	"sync"
+)
+
+// GeoLookup resolves an IP to a (country, ASN, lat, lon) fact.
+type GeoLookup interface {
+	Lookup(ctx context.Context, ip net.IP) (GeoFact, bool)
+}
+
+// NoOpLookup returns no facts. Useful for tests where geo is irrelevant.
+type NoOpLookup struct{}
+
+// Lookup implements [GeoLookup].
+func (NoOpLookup) Lookup(_ context.Context, _ net.IP) (GeoFact, bool) { return GeoFact{}, false }
+
+// InMemoryLookup is a thread-safe IP -> GeoFact map. Production should use
+// a MaxMind reader or a managed lookup; the in-memory backing exists to
+// keep the package free of mandatory third-party deps and to make tests
+// trivial.
+type InMemoryLookup struct {
+	mu    sync.RWMutex
+	facts map[string]GeoFact
+}
+
+// NewInMemoryLookup returns an empty lookup.
+func NewInMemoryLookup() *InMemoryLookup {
+	return &InMemoryLookup{facts: make(map[string]GeoFact)}
+}
+
+// Set associates an IP (string form, identical to [net.IP.String]) with a
+// fact. The trie-style CIDR matching of MaxMind isn't reproduced here; we
+// match exact addresses only.
+func (l *InMemoryLookup) Set(ip string, fact GeoFact) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.facts[ip] = fact
+}
+
+// Lookup implements [GeoLookup].
+func (l *InMemoryLookup) Lookup(_ context.Context, ip net.IP) (GeoFact, bool) {
+	if ip == nil {
+		return GeoFact{}, false
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	fact, ok := l.facts[ip.String()]
+	return fact, ok
+}
+
+// ObservationStore tracks the most recent successful observation per
+// device.
+type ObservationStore interface {
+	Get(ctx context.Context, deviceID string) (*Observation, bool)
+	Put(ctx context.Context, deviceID string, obs Observation) error
+}
+
+// InMemoryObservationStore is a thread-safe ObservationStore. Production
+// should use a Postgres-backed store keyed on (device_id) so observations
+// survive replica restarts.
+type InMemoryObservationStore struct {
+	mu       sync.RWMutex
+	current  map[string]Observation
+}
+
+// NewInMemoryObservationStore returns an empty store.
+func NewInMemoryObservationStore() *InMemoryObservationStore {
+	return &InMemoryObservationStore{current: make(map[string]Observation)}
+}
+
+// Get implements [ObservationStore].
+func (s *InMemoryObservationStore) Get(_ context.Context, deviceID string) (*Observation, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	obs, ok := s.current[deviceID]
+	if !ok {
+		return nil, false
+	}
+	cp := obs
+	return &cp, true
+}
+
+// Put implements [ObservationStore].
+func (s *InMemoryObservationStore) Put(_ context.Context, deviceID string, obs Observation) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.current[deviceID] = obs
+	return nil
+}

--- a/internal/deviceauth/risk/geoasn.go
+++ b/internal/deviceauth/risk/geoasn.go
@@ -62,8 +62,8 @@ type ObservationStore interface {
 // should use a Postgres-backed store keyed on (device_id) so observations
 // survive replica restarts.
 type InMemoryObservationStore struct {
-	mu       sync.RWMutex
-	current  map[string]Observation
+	mu      sync.RWMutex
+	current map[string]Observation
 }
 
 // NewInMemoryObservationStore returns an empty store.

--- a/internal/deviceauth/risk/risk_test.go
+++ b/internal/deviceauth/risk/risk_test.go
@@ -1,0 +1,135 @@
+package risk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestVelocityDetectorImpossibleTravel(t *testing.T) {
+	d := NewVelocityDetector()
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	score, label := d.Evaluate(context.Background(), Signal{
+		PriorObservation: &Observation{Latitude: 40.7128, Longitude: -74.0060, Country: "US", At: now.Add(-30 * time.Minute)},
+		Now:              now,
+	}, &GeoFact{Latitude: 51.5074, Longitude: -0.1278, Country: "GB"})
+	if score < 50 {
+		t.Errorf("velocity score=%d want >=50; label=%s", score, label)
+	}
+	if !strings.Contains(label, "from=US") {
+		t.Errorf("label missing prior country: %s", label)
+	}
+}
+
+func TestVelocityDetectorBenignSpeed(t *testing.T) {
+	d := NewVelocityDetector()
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	score, _ := d.Evaluate(context.Background(), Signal{
+		PriorObservation: &Observation{Latitude: 40.0, Longitude: -74.0, Country: "US", At: now.Add(-10 * time.Hour)},
+		Now:              now,
+	}, &GeoFact{Latitude: 41.0, Longitude: -75.0, Country: "US"})
+	if score != 0 {
+		t.Errorf("benign speed score=%d want 0", score)
+	}
+}
+
+func TestVelocityDetectorNoPriorOrGeo(t *testing.T) {
+	d := NewVelocityDetector()
+	if score, _ := d.Evaluate(context.Background(), Signal{}, nil); score != 0 {
+		t.Errorf("no prior score=%d", score)
+	}
+}
+
+func TestCountryDriftDetector(t *testing.T) {
+	d := NewCountryDriftDetector()
+	score, _ := d.Evaluate(context.Background(), Signal{
+		PriorObservation: &Observation{Country: "US"},
+	}, &GeoFact{Country: "RU"})
+	if score == 0 {
+		t.Error("expected non-zero score on country drift")
+	}
+}
+
+func TestASNDriftDetector(t *testing.T) {
+	d := NewASNDriftDetector()
+	score, _ := d.Evaluate(context.Background(), Signal{
+		PriorObservation: &Observation{ASN: "AS7922"},
+	}, &GeoFact{ASN: "AS3320"})
+	if score == 0 {
+		t.Error("expected non-zero score on ASN drift")
+	}
+}
+
+func TestScorerThresholds(t *testing.T) {
+	geo := NewInMemoryLookup()
+	geo.Set("198.51.100.10", GeoFact{Country: "RU", ASN: "AS3320", Latitude: 55.7558, Longitude: 37.6176})
+	scorer := NewScorer(Thresholds{Elevated: 30, High: 70}, geo, NoOpEmitter{},
+		NewVelocityDetector(), NewCountryDriftDetector(), NewASNDriftDetector(),
+	)
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	dec := scorer.Score(context.Background(), Signal{
+		DeviceID: "d1", TenantID: "writer", RemoteIP: net.ParseIP("198.51.100.10"), Now: now,
+		PriorObservation: &Observation{Country: "US", ASN: "AS7922", Latitude: 40.7128, Longitude: -74.0060, At: now.Add(-30 * time.Minute)},
+	})
+	if dec.Level != "high" {
+		t.Errorf("level=%s want high; signals=%+v score=%d", dec.Level, dec.Signals, dec.Score)
+	}
+	if dec.AllowSensitiveScopes {
+		t.Error("high risk should drop sensitive scopes")
+	}
+	filtered := dec.FilterScopes([]string{"platform.devices.read", "platform.telemetry.ingest"})
+	for _, s := range filtered {
+		if _, sensitive := SensitiveScopes[s]; sensitive {
+			t.Errorf("filtered list still contains sensitive scope %q", s)
+		}
+	}
+}
+
+func TestScorerLowAllowsAllScopes(t *testing.T) {
+	scorer := NewScorer(Thresholds{}, NoOpLookup{}, NoOpEmitter{}, NewVelocityDetector())
+	dec := scorer.Score(context.Background(), Signal{Now: time.Now()})
+	if dec.Level != "low" {
+		t.Errorf("level=%s", dec.Level)
+	}
+	in := []string{"platform.devices.read", "platform.telemetry.ingest"}
+	out := dec.FilterScopes(in)
+	if len(out) != len(in) {
+		t.Errorf("low risk should not filter; got %v from %v", out, in)
+	}
+}
+
+func TestJSONLogEmitter(t *testing.T) {
+	var buf bytes.Buffer
+	e := NewJSONLogEmitter(&buf)
+	if err := e.Emit(context.Background(), WAFRuleUpdate{DeviceID: "d1", IP: "1.2.3.4", At: time.Unix(0, 0)}); err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["name"] != "cerebro.deviceauth.waf_emit" {
+		t.Errorf("emitted name=%v", got["name"])
+	}
+	if got["device_id"] != "d1" {
+		t.Errorf("emitted device_id=%v", got["device_id"])
+	}
+}
+
+func TestObservationStoreRoundTrip(t *testing.T) {
+	s := NewInMemoryObservationStore()
+	if _, ok := s.Get(context.Background(), "d1"); ok {
+		t.Fatal("unexpected hit on empty store")
+	}
+	if err := s.Put(context.Background(), "d1", Observation{Country: "US", At: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := s.Get(context.Background(), "d1")
+	if !ok || got.Country != "US" {
+		t.Fatalf("got=%+v ok=%v", got, ok)
+	}
+}

--- a/internal/deviceauth/risk/scorer.go
+++ b/internal/deviceauth/risk/scorer.go
@@ -5,19 +5,18 @@ import (
 	"net"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 )
 
 // Signal is the per-request input to the risk pipeline.
 type Signal struct {
-	DeviceID    string
-	TenantID    string
-	RemoteIP    net.IP
-	UserAgent   string
-	Method      string
-	Path        string
-	Now         time.Time
+	DeviceID  string
+	TenantID  string
+	RemoteIP  net.IP
+	UserAgent string
+	Method    string
+	Path      string
+	Now       time.Time
 	// PriorObservation is the most recently recorded observation for this
 	// device, if any. The scorer uses it to derive velocity and geo drift.
 	PriorObservation *Observation
@@ -82,9 +81,11 @@ type Thresholds struct {
 	High     int
 }
 
-// Scorer composes detectors. It is goroutine-safe.
+// Scorer composes detectors. Detectors and configuration are immutable after
+// construction; the scorer is goroutine-safe purely because every dependency
+// it touches (Detector implementations, GeoLookup, WAFEmitter) is
+// goroutine-safe on its own.
 type Scorer struct {
-	mu         sync.RWMutex
 	detectors  []Detector
 	geo        GeoLookup
 	thresholds Thresholds

--- a/internal/deviceauth/risk/scorer.go
+++ b/internal/deviceauth/risk/scorer.go
@@ -1,0 +1,217 @@
+package risk
+
+import (
+	"context"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Signal is the per-request input to the risk pipeline.
+type Signal struct {
+	DeviceID    string
+	TenantID    string
+	RemoteIP    net.IP
+	UserAgent   string
+	Method      string
+	Path        string
+	Now         time.Time
+	// PriorObservation is the most recently recorded observation for this
+	// device, if any. The scorer uses it to derive velocity and geo drift.
+	PriorObservation *Observation
+}
+
+// Observation records what we know about a device's last successful
+// authentication. The Tracker layer persists these between calls; the
+// scorer reads them.
+type Observation struct {
+	IP        string
+	Country   string
+	ASN       string
+	Latitude  float64
+	Longitude float64
+	At        time.Time
+}
+
+// Detector is one signal in the composite scorer. Its job is to return a
+// numeric score in [0, 100] plus a human-readable label that explains why.
+type Detector interface {
+	Name() string
+	// Evaluate returns a score (0..100) and a non-empty signal label when
+	// the detector wants the audit log to record what fired. A 0-score
+	// detector returns an empty label.
+	Evaluate(ctx context.Context, sig Signal, geo *GeoFact) (int, string)
+}
+
+// GeoFact is what GeoLookup hands back for a given IP.
+type GeoFact struct {
+	Country   string
+	ASN       string
+	Latitude  float64
+	Longitude float64
+}
+
+// Decision is the scorer's per-request output.
+type Decision struct {
+	// Score is the composite 0..100 score.
+	Score int
+	// Level is "low", "elevated", or "high".
+	Level string
+	// Signals lists the (detector, label) pairs that contributed.
+	Signals []SignalEntry
+	// Geo is the geo-fact looked up for the request IP, or nil.
+	Geo *GeoFact
+	// AllowSensitiveScopes is false when Level == "high"; the auth pipeline
+	// uses this to drop sensitive scopes from a device JWT before forwarding
+	// to handlers.
+	AllowSensitiveScopes bool
+}
+
+// SignalEntry is one (detector, label, score) triple in [Decision.Signals].
+type SignalEntry struct {
+	Detector string
+	Label    string
+	Score    int
+}
+
+// Thresholds maps numeric scores to levels. Defaults are 30 / 70.
+type Thresholds struct {
+	Elevated int
+	High     int
+}
+
+// Scorer composes detectors. It is goroutine-safe.
+type Scorer struct {
+	mu         sync.RWMutex
+	detectors  []Detector
+	geo        GeoLookup
+	thresholds Thresholds
+	emitter    WAFEmitter
+}
+
+// NewScorer returns a Scorer.
+func NewScorer(thresholds Thresholds, geo GeoLookup, emitter WAFEmitter, detectors ...Detector) *Scorer {
+	if thresholds.Elevated <= 0 {
+		thresholds.Elevated = 30
+	}
+	if thresholds.High <= 0 {
+		thresholds.High = 70
+	}
+	if geo == nil {
+		geo = NoOpLookup{}
+	}
+	if emitter == nil {
+		emitter = NoOpEmitter{}
+	}
+	clean := make([]Detector, 0, len(detectors))
+	for _, d := range detectors {
+		if d == nil {
+			continue
+		}
+		clean = append(clean, d)
+	}
+	return &Scorer{detectors: clean, geo: geo, thresholds: thresholds, emitter: emitter}
+}
+
+// Score computes a Decision for the given Signal.
+func (s *Scorer) Score(ctx context.Context, sig Signal) Decision {
+	var geo *GeoFact
+	if sig.RemoteIP != nil {
+		fact, ok := s.geo.Lookup(ctx, sig.RemoteIP)
+		if ok {
+			geo = &fact
+		}
+	}
+	dec := Decision{Geo: geo}
+	dec.Signals = make([]SignalEntry, 0, len(s.detectors))
+	composite := 0
+	for _, d := range s.detectors {
+		sub, label := d.Evaluate(ctx, sig, geo)
+		if sub <= 0 {
+			continue
+		}
+		dec.Signals = append(dec.Signals, SignalEntry{Detector: d.Name(), Label: label, Score: sub})
+		composite = max(composite, sub)
+	}
+	if composite > 100 {
+		composite = 100
+	}
+	dec.Score = composite
+	switch {
+	case composite >= s.thresholds.High:
+		dec.Level = "high"
+		dec.AllowSensitiveScopes = false
+	case composite >= s.thresholds.Elevated:
+		dec.Level = "elevated"
+		dec.AllowSensitiveScopes = true
+	default:
+		dec.Level = "low"
+		dec.AllowSensitiveScopes = true
+	}
+	sort.SliceStable(dec.Signals, func(i, j int) bool {
+		if dec.Signals[i].Score != dec.Signals[j].Score {
+			return dec.Signals[i].Score > dec.Signals[j].Score
+		}
+		return dec.Signals[i].Detector < dec.Signals[j].Detector
+	})
+	if dec.Level == "high" {
+		_ = s.emitter.Emit(ctx, WAFRuleUpdate{
+			DeviceID: sig.DeviceID,
+			TenantID: sig.TenantID,
+			IP:       ipString(sig.RemoteIP),
+			Reason:   strings.Join(labelsOf(dec.Signals), ","),
+			At:       sig.Now,
+		})
+	}
+	return dec
+}
+
+// SensitiveScopes is the scope subset the scorer downgrades on a "high"
+// risk decision.
+var SensitiveScopes = map[string]struct{}{
+	"platform.devices.bootstrap_tokens.write": {},
+	"platform.devices.revoke":                 {},
+	"platform.telemetry.ingest":               {},
+}
+
+// FilterScopes returns a copy of in with sensitive scopes removed iff the
+// decision level is "high".
+func (d Decision) FilterScopes(in []string) []string {
+	if d.AllowSensitiveScopes {
+		return in
+	}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, sensitive := SensitiveScopes[s]; sensitive {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func ipString(ip net.IP) string {
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+func labelsOf(entries []SignalEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.Label != "" {
+			out = append(out, e.Detector+":"+e.Label)
+		}
+	}
+	return out
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/deviceauth/risk/velocity.go
+++ b/internal/deviceauth/risk/velocity.go
@@ -1,0 +1,132 @@
+package risk
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+)
+
+// VelocityDetector flags impossible-travel: a device whose previous geo
+// observation places it more kilometers away than could be reached at
+// MaxKMPerHour given the elapsed time. Scores scale linearly between
+// FloorScore (just over the threshold) and 100 (3x the threshold).
+type VelocityDetector struct {
+	MaxKMPerHour float64
+	FloorScore   int
+	MinElapsed   time.Duration
+}
+
+// NewVelocityDetector builds a VelocityDetector with sensible defaults
+// (1000 km/h roughly approximating commercial-flight speed, 50 baseline
+// score, 60s minimum elapsed time before the detector engages).
+func NewVelocityDetector() *VelocityDetector {
+	return &VelocityDetector{
+		MaxKMPerHour: 1000,
+		FloorScore:   50,
+		MinElapsed:   60 * time.Second,
+	}
+}
+
+// Name implements [Detector].
+func (v *VelocityDetector) Name() string { return "velocity" }
+
+// Evaluate implements [Detector].
+func (v *VelocityDetector) Evaluate(_ context.Context, sig Signal, geo *GeoFact) (int, string) {
+	if sig.PriorObservation == nil || geo == nil {
+		return 0, ""
+	}
+	prior := sig.PriorObservation
+	elapsed := sig.Now.Sub(prior.At)
+	if elapsed <= v.MinElapsed {
+		return 0, ""
+	}
+	dist := haversineKM(prior.Latitude, prior.Longitude, geo.Latitude, geo.Longitude)
+	hours := elapsed.Hours()
+	if hours <= 0 {
+		return 0, ""
+	}
+	speed := dist / hours
+	if speed <= v.MaxKMPerHour {
+		return 0, ""
+	}
+	ratio := speed / v.MaxKMPerHour
+	score := v.FloorScore + int((ratio-1)*25)
+	if score > 100 {
+		score = 100
+	}
+	if score < v.FloorScore {
+		score = v.FloorScore
+	}
+	return score, fmt.Sprintf("speed_kmh=%.0f from=%s to=%s", speed, prior.Country, geo.Country)
+}
+
+// haversineKM returns the great-circle distance in kilometers.
+func haversineKM(lat1, lon1, lat2, lon2 float64) float64 {
+	const r = 6371.0
+	dLat := degToRad(lat2 - lat1)
+	dLon := degToRad(lon2 - lon1)
+	a := math.Sin(dLat/2)*math.Sin(dLat/2) +
+		math.Cos(degToRad(lat1))*math.Cos(degToRad(lat2))*
+			math.Sin(dLon/2)*math.Sin(dLon/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	return r * c
+}
+
+func degToRad(deg float64) float64 { return deg * math.Pi / 180 }
+
+// CountryDriftDetector fires when the geo country changes between the
+// prior observation and this one. Lower-severity than velocity because it
+// fires on legitimate VPN flips, hence the modest score.
+type CountryDriftDetector struct {
+	Score int
+}
+
+// NewCountryDriftDetector builds a detector with a 35 default score.
+func NewCountryDriftDetector() *CountryDriftDetector {
+	return &CountryDriftDetector{Score: 35}
+}
+
+// Name implements [Detector].
+func (c *CountryDriftDetector) Name() string { return "country_drift" }
+
+// Evaluate implements [Detector].
+func (c *CountryDriftDetector) Evaluate(_ context.Context, sig Signal, geo *GeoFact) (int, string) {
+	if sig.PriorObservation == nil || geo == nil {
+		return 0, ""
+	}
+	if sig.PriorObservation.Country == "" || geo.Country == "" {
+		return 0, ""
+	}
+	if sig.PriorObservation.Country == geo.Country {
+		return 0, ""
+	}
+	return c.Score, fmt.Sprintf("from=%s to=%s", sig.PriorObservation.Country, geo.Country)
+}
+
+// ASNDriftDetector fires when the AS number changes between observations.
+// Scored just under country drift because a legitimate ISP change is more
+// common than a country change.
+type ASNDriftDetector struct {
+	Score int
+}
+
+// NewASNDriftDetector builds a detector with a 25 default score.
+func NewASNDriftDetector() *ASNDriftDetector { return &ASNDriftDetector{Score: 25} }
+
+// Name implements [Detector].
+func (d *ASNDriftDetector) Name() string { return "asn_drift" }
+
+// Evaluate implements [Detector].
+func (d *ASNDriftDetector) Evaluate(_ context.Context, sig Signal, geo *GeoFact) (int, string) {
+	if sig.PriorObservation == nil || geo == nil {
+		return 0, ""
+	}
+	if sig.PriorObservation.ASN == "" || geo.ASN == "" {
+		return 0, ""
+	}
+	if sig.PriorObservation.ASN == geo.ASN {
+		return 0, ""
+	}
+	return d.Score, fmt.Sprintf("from=%s to=%s", sig.PriorObservation.ASN, geo.ASN)
+}

--- a/internal/deviceauth/risk/waf.go
+++ b/internal/deviceauth/risk/waf.go
@@ -1,0 +1,61 @@
+package risk
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"sync"
+	"time"
+)
+
+// WAFRuleUpdate is what the scorer hands to a [WAFEmitter] when a "high"
+// risk decision fires. The emitter is responsible for translating the
+// update into the appropriate AWS WAFv2 IPSet update / EventBridge event.
+type WAFRuleUpdate struct {
+	DeviceID string    `json:"device_id"`
+	TenantID string    `json:"tenant_id"`
+	IP       string    `json:"ip"`
+	Reason   string    `json:"reason"`
+	At       time.Time `json:"at"`
+}
+
+// WAFEmitter sends WAF updates somewhere durable. Implementations are
+// expected to be best-effort: a failed Emit should not block the request
+// pipeline, and the Scorer logs but does not propagate emit errors.
+type WAFEmitter interface {
+	Emit(ctx context.Context, update WAFRuleUpdate) error
+}
+
+// NoOpEmitter discards updates. Used when WAF integration is disabled.
+type NoOpEmitter struct{}
+
+// Emit implements [WAFEmitter].
+func (NoOpEmitter) Emit(_ context.Context, _ WAFRuleUpdate) error { return nil }
+
+// JSONLogEmitter writes a JSON line per update to a configurable
+// [io.Writer]. In production this Writer is the bootstrap process's
+// structured-event stream; CloudWatch / EventBridge picks the line up
+// downstream.
+type JSONLogEmitter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewJSONLogEmitter returns an emitter that writes to w.
+func NewJSONLogEmitter(w io.Writer) *JSONLogEmitter { return &JSONLogEmitter{w: w} }
+
+// Emit implements [WAFEmitter].
+func (e *JSONLogEmitter) Emit(_ context.Context, update WAFRuleUpdate) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	enc := json.NewEncoder(e.w)
+	return enc.Encode(struct {
+		Kind string `json:"kind"`
+		Name string `json:"name"`
+		WAFRuleUpdate
+	}{
+		Kind:          "event",
+		Name:          "cerebro.deviceauth.waf_emit",
+		WAFRuleUpdate: update,
+	})
+}

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -43,6 +43,12 @@ var DefaultDeviceScopes = []string{
 	ScopeDeviceFindingsRead,
 }
 
+var allowedBootstrapDeviceScopes = map[string]struct{}{
+	ScopeDevicesToken:       {},
+	ScopeTelemetryIngest:    {},
+	ScopeDeviceFindingsRead: {},
+}
+
 // EnrollRequest is the input to [Service.Enroll]. The agent supplies the
 // bootstrap token plaintext and its hardware identity; the server validates,
 // consumes the bootstrap token, persists the device, and returns the first
@@ -258,6 +264,7 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 		return EnrollResponse{}, fmt.Errorf("%w: bootstrap token has no tenant_id", ErrInvalidRequest)
 	}
 	scopes := normalizedNonEmptyStrings(consumed.Scopes)
+	scopes = filterAllowedBootstrapDeviceScopes(scopes)
 	if len(scopes) == 0 {
 		scopes = append([]string(nil), DefaultDeviceScopes...)
 	}
@@ -356,33 +363,40 @@ func (s *Service) IssueToken(ctx context.Context, request TokenRequest) (TokenRe
 		return TokenResponse{}, fmt.Errorf("%w: refresh_token", ErrInvalidRequest)
 	}
 	now := s.cfg.Now().UTC()
-	consumed, err := s.store.ConsumeRefreshToken(ctx, HashToken(refreshToken), now)
+	refreshHash := HashToken(refreshToken)
+	peek, err := s.store.LookupRefreshToken(ctx, refreshHash, now)
 	if err != nil {
 		return TokenResponse{}, err
 	}
-	device, err := s.store.LookupDevice(ctx, consumed.DeviceID)
+	device, err := s.store.LookupDevice(ctx, peek.DeviceID)
 	if err != nil {
 		return TokenResponse{}, err
 	}
 	if device.Status != "" && device.Status != "active" {
 		return TokenResponse{}, ErrDeviceInactive
 	}
-	if err := s.verifyDPoPForRefresh(device, request); err != nil {
+	if peek.ConsumedAt.IsZero() && !peek.FamilyRevoked {
+		if err := s.verifyDPoPForRefresh(device, request); err != nil {
+			return TokenResponse{}, err
+		}
+	}
+	consumed, err := s.store.ConsumeRefreshToken(ctx, refreshHash, now)
+	if err != nil {
 		return TokenResponse{}, err
 	}
 	if err := s.store.MarkSeen(ctx, device.DeviceID, now); err != nil {
 		return TokenResponse{}, fmt.Errorf("deviceauth: mark seen: %w", err)
 	}
-	scopes := normalizedNonEmptyStrings(consumed.Scopes)
-	if len(scopes) == 0 {
-		scopes = append([]string(nil), DefaultDeviceScopes...)
+	refreshScopes := normalizedNonEmptyStrings(consumed.Scopes)
+	if len(refreshScopes) == 0 {
+		refreshScopes = append([]string(nil), DefaultDeviceScopes...)
 	}
-	scopes, riskDecision := s.applyRisk(ctx, device, request.RemoteIP, now, scopes)
-	access, accessExpires, err := s.mintAccess(device, scopes)
+	accessScopes, riskDecision := s.applyRisk(ctx, device, request.RemoteIP, now, refreshScopes)
+	access, accessExpires, err := s.mintAccess(device, accessScopes)
 	if err != nil {
 		return TokenResponse{}, err
 	}
-	refresh, refreshExpires, err := s.mintRefresh(ctx, device.DeviceID, scopes, consumed.FamilyID, consumed.Generation+1, now)
+	refresh, refreshExpires, err := s.mintRefresh(ctx, device.DeviceID, refreshScopes, consumed.FamilyID, consumed.Generation+1, now)
 	if err != nil {
 		return TokenResponse{}, err
 	}
@@ -391,7 +405,7 @@ func (s *Service) IssueToken(ctx context.Context, request TokenRequest) (TokenRe
 		AccessExpires:  accessExpires,
 		RefreshToken:   refresh,
 		RefreshExpires: refreshExpires,
-		Scopes:         scopes,
+		Scopes:         accessScopes,
 		TokenType:      "Bearer",
 	}
 	if riskDecision != nil {
@@ -399,6 +413,25 @@ func (s *Service) IssueToken(ctx context.Context, request TokenRequest) (TokenRe
 		resp.RiskLevel = riskDecision.Level
 	}
 	return resp, nil
+}
+
+// RefreshTokenRateLimitKey returns a stable, non-secret rate-limit bucket for
+// a refresh token without consuming it. Unknown or malformed tokens return an
+// error so callers can fall back to a remote-address bucket.
+func (s *Service) RefreshTokenRateLimitKey(ctx context.Context, refreshToken string) (string, error) {
+	token, err := NormalizeOpaqueToken(refreshToken)
+	if err != nil {
+		return "", err
+	}
+	row, err := s.store.LookupRefreshToken(ctx, HashToken(token), s.cfg.Now().UTC())
+	if err != nil {
+		return "", err
+	}
+	deviceID := strings.TrimSpace(row.DeviceID)
+	if deviceID == "" {
+		return "", ErrRefreshNotFound
+	}
+	return "device:" + deviceID, nil
 }
 
 func (s *Service) verifyDPoPForRefresh(device DeviceRecord, request TokenRequest) error {
@@ -497,6 +530,8 @@ func (s *Service) IssueBootstrapToken(ctx context.Context, request IssueBootstra
 	scopes := normalizedNonEmptyStrings(request.Scopes)
 	if len(scopes) == 0 {
 		scopes = append([]string(nil), DefaultDeviceScopes...)
+	} else if err := validateBootstrapDeviceScopes(scopes); err != nil {
+		return IssueBootstrapTokenResponse{}, err
 	}
 	ttl := request.TTL
 	if ttl <= 0 {
@@ -528,6 +563,25 @@ func (s *Service) IssueBootstrapToken(ctx context.Context, request IssueBootstra
 		Token:     plaintext,
 		ExpiresAt: token.ExpiresAt,
 	}, nil
+}
+
+func validateBootstrapDeviceScopes(scopes []string) error {
+	for _, scope := range scopes {
+		if _, ok := allowedBootstrapDeviceScopes[scope]; !ok {
+			return fmt.Errorf("%w: unsupported device bootstrap scope %q", ErrInvalidRequest, scope)
+		}
+	}
+	return nil
+}
+
+func filterAllowedBootstrapDeviceScopes(scopes []string) []string {
+	out := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		if _, ok := allowedBootstrapDeviceScopes[scope]; ok {
+			out = append(out, scope)
+		}
+	}
+	return out
 }
 
 // IngestPayload represents a single telemetry submission. Body is the raw

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -276,9 +276,12 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	if len(scopes) == 0 {
 		scopes = append([]string(nil), DefaultDeviceScopes...)
 	}
-	deviceID, err := generateID("dev_")
-	if err != nil {
-		return EnrollResponse{}, fmt.Errorf("deviceauth: generate device id: %w", err)
+	deviceID := strings.TrimSpace(existing.DeviceID)
+	if deviceID == "" {
+		deviceID, err = generateID("dev_")
+		if err != nil {
+			return EnrollResponse{}, fmt.Errorf("deviceauth: generate device id: %w", err)
+		}
 	}
 	clientHash := attestationClientDataHash(bootstrapToken, hardwareUUID)
 	attResult, err := s.runAttestation(ctx, clientHash, request)

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -534,6 +534,15 @@ func (s *Service) Revoke(ctx context.Context, deviceID string, reason string) er
 	return nil
 }
 
+// LookupDevice returns the persisted device record by id.
+func (s *Service) LookupDevice(ctx context.Context, deviceID string) (DeviceRecord, error) {
+	deviceID = strings.TrimSpace(deviceID)
+	if deviceID == "" {
+		return DeviceRecord{}, fmt.Errorf("%w: device_id", ErrInvalidRequest)
+	}
+	return s.store.LookupDevice(ctx, deviceID)
+}
+
 // IssueBootstrapToken mints a single-use enrollment credential.
 func (s *Service) IssueBootstrapToken(ctx context.Context, request IssueBootstrapTokenRequest) (IssueBootstrapTokenResponse, error) {
 	hardwareUUID := strings.TrimSpace(request.HardwareUUID)
@@ -554,7 +563,10 @@ func (s *Service) IssueBootstrapToken(ctx context.Context, request IssueBootstra
 		return IssueBootstrapTokenResponse{}, err
 	}
 	ttl := request.TTL
-	if ttl <= 0 {
+	if ttl < 0 {
+		return IssueBootstrapTokenResponse{}, fmt.Errorf("%w: ttl", ErrInvalidRequest)
+	}
+	if ttl == 0 {
 		ttl = s.cfg.BootstrapTokenTTL
 	}
 	now := s.cfg.Now().UTC()

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -1,0 +1,489 @@
+package deviceauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Scope strings published by the device-auth surface. The bootstrap mux maps
+// HTTP routes to these scopes through the normal authorizeHTTPRequestScope
+// switch, so a device-issued JWT and a capability token both flow through
+// the same authorization decision.
+const (
+	ScopeDevicesEnroll          = "platform.devices.enroll"
+	ScopeDevicesToken           = "platform.devices.token"
+	ScopeDevicesRead            = "platform.devices.read"
+	ScopeDevicesRevoke          = "platform.devices.revoke"
+	ScopeDevicesBootstrapWrite  = "platform.devices.bootstrap_tokens.write"
+	ScopeTelemetryIngest        = "platform.telemetry.ingest"
+	ScopeDeviceFindingsRead     = "security.devices.findings.read"
+)
+
+// DefaultDeviceScopes is the default scope set assigned to a freshly enrolled
+// agent. Admin-side scopes (issuing bootstrap tokens, revoking devices) are
+// intentionally excluded; those are operator scopes carried by capability
+// tokens, not by device JWTs.
+var DefaultDeviceScopes = []string{
+	ScopeDevicesToken,
+	ScopeTelemetryIngest,
+	ScopeDeviceFindingsRead,
+}
+
+// EnrollRequest is the input to [Service.Enroll]. The agent supplies the
+// bootstrap token plaintext and its hardware identity; the server validates,
+// consumes the bootstrap token, persists the device, and returns the first
+// access + refresh pair.
+type EnrollRequest struct {
+	BootstrapToken string
+	HardwareUUID   string
+	SerialNumber   string
+	Hostname       string
+	OSType         string
+	OSVersion      string
+	AgentVersion   string
+}
+
+// EnrollResponse is the output of [Service.Enroll].
+type EnrollResponse struct {
+	DeviceID      string
+	AccessToken   string
+	AccessExpires time.Time
+	RefreshToken  string
+	RefreshExpires time.Time
+	Scopes        []string
+	TokenType     string
+}
+
+// TokenRequest is the input to [Service.IssueToken]. The agent supplies the
+// refresh token; the server rotates and returns the next pair. Replay of a
+// previously consumed refresh token revokes the entire family.
+type TokenRequest struct {
+	GrantType    string
+	RefreshToken string
+}
+
+// TokenResponse is the output of [Service.IssueToken].
+type TokenResponse struct {
+	AccessToken    string
+	AccessExpires  time.Time
+	RefreshToken   string
+	RefreshExpires time.Time
+	Scopes         []string
+	TokenType      string
+}
+
+// IssueBootstrapTokenRequest is what an admin (capability-token-authenticated
+// operator) sends to mint a single-use enrollment credential for one device.
+type IssueBootstrapTokenRequest struct {
+	HardwareUUID string
+	TenantID     string
+	Scopes       []string
+	TTL          time.Duration
+	IssuedBy     string
+}
+
+// IssueBootstrapTokenResponse is the output of
+// [Service.IssueBootstrapToken]. The plaintext token is returned exactly
+// once; the server only persists the SHA-256 hash.
+type IssueBootstrapTokenResponse struct {
+	TokenID    string
+	Token      string
+	ExpiresAt  time.Time
+}
+
+// ServiceConfig configures the [Service].
+type ServiceConfig struct {
+	Issuer            string
+	Audience          string
+	AccessTTL         time.Duration
+	RefreshTTL        time.Duration
+	BootstrapTokenTTL time.Duration
+	IdempotencyTTL    time.Duration
+	ClockSkew         time.Duration
+	DefaultTenantID   string
+	Now               func() time.Time
+}
+
+// Service is the device-auth orchestration layer. It owns the lifecycle of
+// devices, bootstrap tokens, and refresh tokens, and is the only entry point
+// the HTTP layer should call.
+type Service struct {
+	cfg      ServiceConfig
+	store    Store
+	issuer   *JWTIssuer
+	verifier *JWTVerifier
+	keyset   *KeySet
+}
+
+// NewService constructs a service.
+func NewService(cfg ServiceConfig, store Store, issuer *JWTIssuer, verifier *JWTVerifier, keyset *KeySet) (*Service, error) {
+	if store == nil {
+		return nil, errors.New("deviceauth: store is required")
+	}
+	if issuer == nil {
+		return nil, errors.New("deviceauth: issuer is required")
+	}
+	if verifier == nil {
+		return nil, errors.New("deviceauth: verifier is required")
+	}
+	if keyset == nil || len(keyset.Keys) == 0 {
+		return nil, errors.New("deviceauth: keyset is required")
+	}
+	if cfg.AccessTTL <= 0 {
+		cfg.AccessTTL = DefaultAccessTTL
+	}
+	if cfg.RefreshTTL <= 0 {
+		cfg.RefreshTTL = 30 * 24 * time.Hour
+	}
+	if cfg.BootstrapTokenTTL <= 0 {
+		cfg.BootstrapTokenTTL = 24 * time.Hour
+	}
+	if cfg.IdempotencyTTL <= 0 {
+		cfg.IdempotencyTTL = 24 * time.Hour
+	}
+	if cfg.ClockSkew <= 0 {
+		cfg.ClockSkew = DefaultClockSkew
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	cfg.Issuer = strings.TrimSpace(cfg.Issuer)
+	if cfg.Issuer == "" {
+		cfg.Issuer = "cerebro"
+	}
+	cfg.Audience = strings.TrimSpace(cfg.Audience)
+	if cfg.Audience == "" {
+		cfg.Audience = "cerebro-device"
+	}
+	cfg.DefaultTenantID = strings.TrimSpace(cfg.DefaultTenantID)
+	return &Service{cfg: cfg, store: store, issuer: issuer, verifier: verifier, keyset: keyset}, nil
+}
+
+// Verifier returns the underlying JWT verifier so the bootstrap auth pipeline
+// can reuse it.
+func (s *Service) Verifier() *JWTVerifier {
+	return s.verifier
+}
+
+// KeySet returns the active verification keys for the JWKS endpoint.
+func (s *Service) KeySet() *KeySet {
+	return s.keyset
+}
+
+// Enroll consumes a bootstrap token and provisions a device.
+func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResponse, error) {
+	bootstrapToken, err := NormalizeOpaqueToken(request.BootstrapToken)
+	if err != nil {
+		return EnrollResponse{}, fmt.Errorf("%w: bootstrap_token", ErrInvalidRequest)
+	}
+	hardwareUUID := strings.TrimSpace(request.HardwareUUID)
+	if hardwareUUID == "" {
+		return EnrollResponse{}, fmt.Errorf("%w: hardware_uuid", ErrInvalidRequest)
+	}
+	now := s.cfg.Now().UTC()
+	hash := HashToken(bootstrapToken)
+	consumed, err := s.store.ConsumeBootstrapToken(ctx, hash, hardwareUUID, now, "agent")
+	if err != nil {
+		return EnrollResponse{}, err
+	}
+	tenantID := strings.TrimSpace(consumed.TenantID)
+	if tenantID == "" {
+		tenantID = s.cfg.DefaultTenantID
+	}
+	if tenantID == "" {
+		return EnrollResponse{}, fmt.Errorf("%w: bootstrap token has no tenant_id", ErrInvalidRequest)
+	}
+	scopes := normalizedNonEmptyStrings(consumed.Scopes)
+	if len(scopes) == 0 {
+		scopes = append([]string(nil), DefaultDeviceScopes...)
+	}
+	deviceID, err := generateID("dev_")
+	if err != nil {
+		return EnrollResponse{}, fmt.Errorf("deviceauth: generate device id: %w", err)
+	}
+	device := DeviceRecord{
+		DeviceID:     deviceID,
+		HardwareUUID: hardwareUUID,
+		SerialNumber: strings.TrimSpace(request.SerialNumber),
+		Hostname:     strings.TrimSpace(request.Hostname),
+		TenantID:     tenantID,
+		OSType:       strings.TrimSpace(request.OSType),
+		OSVersion:    strings.TrimSpace(request.OSVersion),
+		AgentVersion: strings.TrimSpace(request.AgentVersion),
+		Status:       "active",
+		EnrolledAt:   now,
+		LastSeenAt:   now,
+	}
+	device, err = s.store.EnrollDevice(ctx, device)
+	if err != nil {
+		return EnrollResponse{}, fmt.Errorf("deviceauth: enroll device: %w", err)
+	}
+	access, accessExpires, err := s.mintAccess(device, scopes)
+	if err != nil {
+		return EnrollResponse{}, err
+	}
+	refresh, refreshExpires, err := s.mintRefresh(ctx, device.DeviceID, scopes, "", 0, now)
+	if err != nil {
+		return EnrollResponse{}, err
+	}
+	return EnrollResponse{
+		DeviceID:       device.DeviceID,
+		AccessToken:    access,
+		AccessExpires:  accessExpires,
+		RefreshToken:   refresh,
+		RefreshExpires: refreshExpires,
+		Scopes:         scopes,
+		TokenType:      "Bearer",
+	}, nil
+}
+
+// IssueToken rotates a refresh token. The grant type must be
+// "refresh_token"; any other value returns [ErrInvalidRequest].
+func (s *Service) IssueToken(ctx context.Context, request TokenRequest) (TokenResponse, error) {
+	if strings.TrimSpace(request.GrantType) != "refresh_token" {
+		return TokenResponse{}, fmt.Errorf("%w: grant_type must be refresh_token", ErrInvalidRequest)
+	}
+	refreshToken, err := NormalizeOpaqueToken(request.RefreshToken)
+	if err != nil {
+		return TokenResponse{}, fmt.Errorf("%w: refresh_token", ErrInvalidRequest)
+	}
+	now := s.cfg.Now().UTC()
+	consumed, err := s.store.ConsumeRefreshToken(ctx, HashToken(refreshToken), now)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	device, err := s.store.LookupDevice(ctx, consumed.DeviceID)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	if device.Status != "" && device.Status != "active" {
+		return TokenResponse{}, ErrDeviceInactive
+	}
+	if err := s.store.MarkSeen(ctx, device.DeviceID, now); err != nil {
+		return TokenResponse{}, fmt.Errorf("deviceauth: mark seen: %w", err)
+	}
+	scopes := normalizedNonEmptyStrings(consumed.Scopes)
+	if len(scopes) == 0 {
+		scopes = append([]string(nil), DefaultDeviceScopes...)
+	}
+	access, accessExpires, err := s.mintAccess(device, scopes)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	refresh, refreshExpires, err := s.mintRefresh(ctx, device.DeviceID, scopes, consumed.FamilyID, consumed.Generation+1, now)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	return TokenResponse{
+		AccessToken:    access,
+		AccessExpires:  accessExpires,
+		RefreshToken:   refresh,
+		RefreshExpires: refreshExpires,
+		Scopes:         scopes,
+		TokenType:      "Bearer",
+	}, nil
+}
+
+// Revoke marks a device revoked. Subsequent refresh attempts will fail and
+// in-flight access tokens expire on their own; callers that need immediate
+// revocation must wait for the access TTL or use a denylist mechanism that
+// is not in scope here.
+func (s *Service) Revoke(ctx context.Context, deviceID string, reason string) error {
+	deviceID = strings.TrimSpace(deviceID)
+	if deviceID == "" {
+		return fmt.Errorf("%w: device_id", ErrInvalidRequest)
+	}
+	now := s.cfg.Now().UTC()
+	if err := s.store.RevokeDevice(ctx, deviceID, now, reason); err != nil {
+		return err
+	}
+	return nil
+}
+
+// IssueBootstrapToken mints a single-use enrollment credential.
+func (s *Service) IssueBootstrapToken(ctx context.Context, request IssueBootstrapTokenRequest) (IssueBootstrapTokenResponse, error) {
+	hardwareUUID := strings.TrimSpace(request.HardwareUUID)
+	if hardwareUUID == "" {
+		return IssueBootstrapTokenResponse{}, fmt.Errorf("%w: hardware_uuid", ErrInvalidRequest)
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		tenantID = s.cfg.DefaultTenantID
+	}
+	if tenantID == "" {
+		return IssueBootstrapTokenResponse{}, fmt.Errorf("%w: tenant_id", ErrInvalidRequest)
+	}
+	scopes := normalizedNonEmptyStrings(request.Scopes)
+	if len(scopes) == 0 {
+		scopes = append([]string(nil), DefaultDeviceScopes...)
+	}
+	ttl := request.TTL
+	if ttl <= 0 {
+		ttl = s.cfg.BootstrapTokenTTL
+	}
+	now := s.cfg.Now().UTC()
+	plaintext, err := GenerateOpaqueToken()
+	if err != nil {
+		return IssueBootstrapTokenResponse{}, fmt.Errorf("deviceauth: generate bootstrap token: %w", err)
+	}
+	tokenID, err := generateID("btk_")
+	if err != nil {
+		return IssueBootstrapTokenResponse{}, fmt.Errorf("deviceauth: generate bootstrap id: %w", err)
+	}
+	token := BootstrapToken{
+		TokenID:      tokenID,
+		TokenHash:    HashToken(plaintext),
+		HardwareUUID: hardwareUUID,
+		TenantID:     tenantID,
+		Scopes:       scopes,
+		CreatedAt:    now,
+		ExpiresAt:    now.Add(ttl),
+	}
+	if err := s.store.CreateBootstrapToken(ctx, token); err != nil {
+		return IssueBootstrapTokenResponse{}, fmt.Errorf("deviceauth: create bootstrap token: %w", err)
+	}
+	return IssueBootstrapTokenResponse{
+		TokenID:   tokenID,
+		Token:     plaintext,
+		ExpiresAt: token.ExpiresAt,
+	}, nil
+}
+
+// IngestPayload represents a single telemetry submission. Body is the raw
+// JSON received from the agent; the service does not parse the contents -- a
+// downstream pipeline normalizes telemetry into Source CDK events.
+type IngestPayload struct {
+	DeviceID       string
+	IdempotencyKey string
+	Body           []byte
+}
+
+// IngestResult is the outcome of [Service.IngestTelemetry].
+type IngestResult struct {
+	Status     int
+	Body       []byte
+	Cached     bool
+	ReceivedAt time.Time
+}
+
+// IngestTelemetry validates the device, enforces the Idempotency-Key
+// contract, and accepts the payload. The service stores the canonical
+// response in the idempotency cache so a retried submission returns the
+// same response with no side effects.
+func (s *Service) IngestTelemetry(ctx context.Context, payload IngestPayload) (IngestResult, error) {
+	deviceID := strings.TrimSpace(payload.DeviceID)
+	if deviceID == "" {
+		return IngestResult{}, fmt.Errorf("%w: device_id", ErrInvalidRequest)
+	}
+	idempotencyKey := strings.TrimSpace(payload.IdempotencyKey)
+	if idempotencyKey == "" {
+		return IngestResult{}, fmt.Errorf("%w: Idempotency-Key header is required", ErrInvalidRequest)
+	}
+	if len(idempotencyKey) > 255 {
+		return IngestResult{}, fmt.Errorf("%w: Idempotency-Key exceeds 255 bytes", ErrInvalidRequest)
+	}
+	if len(payload.Body) > MaxIngestBodyBytes {
+		return IngestResult{}, fmt.Errorf("%w: body exceeds %d bytes", ErrInvalidRequest, MaxIngestBodyBytes)
+	}
+	device, err := s.store.LookupDevice(ctx, deviceID)
+	if err != nil {
+		return IngestResult{}, err
+	}
+	if device.Status != "" && device.Status != "active" {
+		return IngestResult{}, ErrDeviceInactive
+	}
+	now := s.cfg.Now().UTC()
+	cacheKey := "device:" + deviceID + ":" + idempotencyKey
+	requestHash := HashToken(string(payload.Body))
+	cached, status, err := s.store.CheckIdempotency(ctx, cacheKey, requestHash)
+	if err != nil {
+		return IngestResult{}, err
+	}
+	if cached != nil {
+		return IngestResult{Status: status, Body: cached, Cached: true, ReceivedAt: now}, nil
+	}
+	if err := s.store.MarkSeen(ctx, deviceID, now); err != nil {
+		return IngestResult{}, fmt.Errorf("deviceauth: mark seen: %w", err)
+	}
+	receipt := fmt.Sprintf(`{"status":"accepted","device_id":%q,"received_at":%q,"bytes":%d}`, deviceID, now.Format(time.RFC3339Nano), len(payload.Body))
+	body := []byte(receipt)
+	if err := s.store.PutIdempotency(ctx, cacheKey, requestHash, 202, body, now.Add(s.cfg.IdempotencyTTL)); err != nil {
+		return IngestResult{}, fmt.Errorf("deviceauth: store idempotency: %w", err)
+	}
+	return IngestResult{Status: 202, Body: body, Cached: false, ReceivedAt: now}, nil
+}
+
+// MaxIngestBodyBytes caps a single telemetry submission. Aligns with the
+// existing maxProtoJSONBodyBytes in internal/bootstrap/app.go.
+const MaxIngestBodyBytes = 1 << 20
+
+// ErrInvalidRequest is returned for caller-side argument or contract errors.
+// It is wrapped with %w so callers can errors.Is it through the HTTP layer.
+var ErrInvalidRequest = errors.New("deviceauth: invalid request")
+
+func (s *Service) mintAccess(device DeviceRecord, scopes []string) (string, time.Time, error) {
+	expires := s.cfg.Now().UTC().Add(s.cfg.AccessTTL)
+	token, err := s.issuer.IssueAccess(device, scopes)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("deviceauth: issue access: %w", err)
+	}
+	return token, expires, nil
+}
+
+func (s *Service) mintRefresh(ctx context.Context, deviceID string, scopes []string, familyID string, generation int, now time.Time) (string, time.Time, error) {
+	plaintext, err := GenerateOpaqueToken()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("deviceauth: generate refresh: %w", err)
+	}
+	if familyID == "" {
+		familyID, err = NewFamilyID()
+		if err != nil {
+			return "", time.Time{}, fmt.Errorf("deviceauth: generate family: %w", err)
+		}
+		generation = 1
+	}
+	expires := now.Add(s.cfg.RefreshTTL)
+	row := RefreshToken{
+		TokenHash:  HashToken(plaintext),
+		DeviceID:   deviceID,
+		FamilyID:   familyID,
+		Generation: generation,
+		Scopes:     scopes,
+		CreatedAt:  now,
+		ExpiresAt:  expires,
+	}
+	if err := s.store.IssueRefreshToken(ctx, row); err != nil {
+		return "", time.Time{}, fmt.Errorf("deviceauth: issue refresh: %w", err)
+	}
+	return plaintext, expires, nil
+}
+
+func generateID(prefix string) (string, error) {
+	buf := make([]byte, 12)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return prefix + base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func normalizedNonEmptyStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -2,12 +2,21 @@ package deviceauth
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"time"
+
+	"github.com/writer/cerebro/internal/deviceauth/attestation"
+	"github.com/writer/cerebro/internal/deviceauth/risk"
 )
 
 // Scope strings published by the device-auth surface. The bootstrap mux maps
@@ -46,17 +55,32 @@ type EnrollRequest struct {
 	OSType         string
 	OSVersion      string
 	AgentVersion   string
+	// Attestation, when non-empty, is the base64-encoded device-bound proof
+	// (App Attest CBOR object on macOS, TPM 2.0 quote bundle on Windows).
+	// The Service runs it through the configured [attestation.Registry];
+	// when the registry is configured as required, an empty value rejects
+	// the enrollment.
+	Attestation string
+	// RemoteIP is the agent's source address as observed by the front
+	// door. Used for risk scoring and audit logging.
+	RemoteIP net.IP
 }
 
 // EnrollResponse is the output of [Service.Enroll].
 type EnrollResponse struct {
-	DeviceID      string
-	AccessToken   string
-	AccessExpires time.Time
-	RefreshToken  string
+	DeviceID       string
+	AccessToken    string
+	AccessExpires  time.Time
+	RefreshToken   string
 	RefreshExpires time.Time
-	Scopes        []string
-	TokenType     string
+	Scopes         []string
+	TokenType      string
+	// AssuranceLevel reflects whether attestation produced a hardware-
+	// bound result ("hardware") or a software fallback ("software").
+	AssuranceLevel string
+	// AttestationVendor names the verifier that produced the assurance
+	// (e.g. "apple-appattest", "tpm-2.0", or "none").
+	AttestationVendor string
 }
 
 // TokenRequest is the input to [Service.IssueToken]. The agent supplies the
@@ -65,6 +89,19 @@ type EnrollResponse struct {
 type TokenRequest struct {
 	GrantType    string
 	RefreshToken string
+	// DPoPProof, when the device was enrolled with a device-bound key, is
+	// the RFC 9449 proof JWT that the server requires to confirm the
+	// agent still controls the key. The verifier is configured at the
+	// service level; an empty value here rejects the rotation when DPoP
+	// binding is mandatory for the device.
+	DPoPProof string
+	// HTTPMethod and HTTPURL are passed through to the DPoP verifier when
+	// proof verification is required. Both default to POST and the token
+	// endpoint URL configured on the service.
+	HTTPMethod string
+	HTTPURL    string
+	// RemoteIP is the agent's source address (for risk scoring).
+	RemoteIP net.IP
 }
 
 // TokenResponse is the output of [Service.IssueToken].
@@ -75,6 +112,11 @@ type TokenResponse struct {
 	RefreshExpires time.Time
 	Scopes         []string
 	TokenType      string
+	// RiskScore is the 0..100 score the risk pipeline computed for this
+	// rotation, surfaced for the audit log.
+	RiskScore int
+	// RiskLevel is "low" / "elevated" / "high".
+	RiskLevel string
 }
 
 // IssueBootstrapTokenRequest is what an admin (capability-token-authenticated
@@ -107,6 +149,23 @@ type ServiceConfig struct {
 	ClockSkew         time.Duration
 	DefaultTenantID   string
 	Now               func() time.Time
+	// Attestations, if set, is consulted on every Enroll to verify the
+	// agent's device-bound key. When the registry is required, missing
+	// or invalid attestations reject the enrollment.
+	Attestations *attestation.Registry
+	// DPoP, if set, verifies RFC 9449 proof JWTs on refresh-token
+	// rotation. When the device was enrolled with a device-bound key,
+	// the proof is mandatory and the proof's JKT must equal the device's
+	// stored key thumbprint.
+	DPoP *DPoPVerifier
+	// Risk, if set, runs every successful refresh through the risk
+	// scorer. The scorer's decision is recorded on the device's last
+	// observation; the auth pipeline uses [risk.Decision.FilterScopes]
+	// to drop sensitive scopes when the score is high.
+	Risk *risk.Scorer
+	// Observations, if set, is the per-device geo/ASN observation store
+	// the risk pipeline reads from and writes to.
+	Observations risk.ObservationStore
 }
 
 // Service is the device-auth orchestration layer. It owns the lifecycle of
@@ -206,6 +265,28 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	if err != nil {
 		return EnrollResponse{}, fmt.Errorf("deviceauth: generate device id: %w", err)
 	}
+	clientHash := sha256.Sum256([]byte(strings.TrimSpace(request.BootstrapToken)))
+	attResult, err := s.runAttestation(ctx, clientHash, request)
+	if err != nil {
+		return EnrollResponse{}, err
+	}
+	metadata := map[string]string{
+		"assurance_level":    attResult.AssuranceLevel,
+		"attestation_vendor": attResult.Vendor,
+	}
+	jkt, err := computeJKTFromPublicKeyDER(attResult.PublicKey)
+	if err != nil {
+		return EnrollResponse{}, fmt.Errorf("%w: %v", ErrInvalidRequest, err)
+	}
+	if jkt != "" {
+		metadata["dpop_jkt"] = jkt
+	}
+	if attResult.KeyID != "" {
+		metadata["attestation_keyid"] = attResult.KeyID
+	}
+	for k, v := range attResult.Diagnostics {
+		metadata["attestation_"+k] = v
+	}
 	device := DeviceRecord{
 		DeviceID:     deviceID,
 		HardwareUUID: hardwareUUID,
@@ -218,6 +299,7 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 		Status:       "active",
 		EnrolledAt:   now,
 		LastSeenAt:   now,
+		Metadata:     metadata,
 	}
 	device, err = s.store.EnrollDevice(ctx, device)
 	if err != nil {
@@ -232,14 +314,35 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 		return EnrollResponse{}, err
 	}
 	return EnrollResponse{
-		DeviceID:       device.DeviceID,
-		AccessToken:    access,
-		AccessExpires:  accessExpires,
-		RefreshToken:   refresh,
-		RefreshExpires: refreshExpires,
-		Scopes:         scopes,
-		TokenType:      "Bearer",
+		DeviceID:          device.DeviceID,
+		AccessToken:       access,
+		AccessExpires:     accessExpires,
+		RefreshToken:      refresh,
+		RefreshExpires:    refreshExpires,
+		Scopes:            scopes,
+		TokenType:         "Bearer",
+		AssuranceLevel:    attResult.AssuranceLevel,
+		AttestationVendor: attResult.Vendor,
 	}, nil
+}
+
+func (s *Service) runAttestation(ctx context.Context, clientHash [32]byte, request EnrollRequest) (*attestation.Result, error) {
+	if s.cfg.Attestations == nil {
+		return &attestation.Result{AssuranceLevel: "software", Vendor: "none"}, nil
+	}
+	res, err := s.cfg.Attestations.Verify(ctx, attestation.Input{
+		HardwareUUID:   strings.TrimSpace(request.HardwareUUID),
+		ClientDataHash: clientHash,
+		Format:         strings.ToLower(strings.TrimSpace(request.OSType)),
+		Statement:      strings.TrimSpace(request.Attestation),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return &attestation.Result{AssuranceLevel: "software", Vendor: "none"}, nil
+	}
+	return res, nil
 }
 
 // IssueToken rotates a refresh token. The grant type must be
@@ -264,6 +367,9 @@ func (s *Service) IssueToken(ctx context.Context, request TokenRequest) (TokenRe
 	if device.Status != "" && device.Status != "active" {
 		return TokenResponse{}, ErrDeviceInactive
 	}
+	if err := s.verifyDPoPForRefresh(device, request); err != nil {
+		return TokenResponse{}, err
+	}
 	if err := s.store.MarkSeen(ctx, device.DeviceID, now); err != nil {
 		return TokenResponse{}, fmt.Errorf("deviceauth: mark seen: %w", err)
 	}
@@ -271,6 +377,7 @@ func (s *Service) IssueToken(ctx context.Context, request TokenRequest) (TokenRe
 	if len(scopes) == 0 {
 		scopes = append([]string(nil), DefaultDeviceScopes...)
 	}
+	scopes, riskDecision := s.applyRisk(ctx, device, request.RemoteIP, now, scopes)
 	access, accessExpires, err := s.mintAccess(device, scopes)
 	if err != nil {
 		return TokenResponse{}, err
@@ -279,14 +386,83 @@ func (s *Service) IssueToken(ctx context.Context, request TokenRequest) (TokenRe
 	if err != nil {
 		return TokenResponse{}, err
 	}
-	return TokenResponse{
+	resp := TokenResponse{
 		AccessToken:    access,
 		AccessExpires:  accessExpires,
 		RefreshToken:   refresh,
 		RefreshExpires: refreshExpires,
 		Scopes:         scopes,
 		TokenType:      "Bearer",
-	}, nil
+	}
+	if riskDecision != nil {
+		resp.RiskScore = riskDecision.Score
+		resp.RiskLevel = riskDecision.Level
+	}
+	return resp, nil
+}
+
+func (s *Service) verifyDPoPForRefresh(device DeviceRecord, request TokenRequest) error {
+	jkt := strings.TrimSpace(device.Metadata["dpop_jkt"])
+	if jkt == "" {
+		return nil
+	}
+	if s.cfg.DPoP == nil {
+		return nil
+	}
+	proof := strings.TrimSpace(request.DPoPProof)
+	if proof == "" {
+		return ErrDPoPMissing
+	}
+	method := strings.ToUpper(strings.TrimSpace(request.HTTPMethod))
+	if method == "" {
+		method = "POST"
+	}
+	url := strings.TrimSpace(request.HTTPURL)
+	res, err := s.cfg.DPoP.Verify(proof, method, url)
+	if err != nil {
+		return err
+	}
+	if res.JKT != jkt {
+		return ErrDPoPJKTMismatch
+	}
+	return nil
+}
+
+func (s *Service) applyRisk(ctx context.Context, device DeviceRecord, remoteIP net.IP, now time.Time, scopes []string) ([]string, *risk.Decision) {
+	if s.cfg.Risk == nil {
+		return scopes, nil
+	}
+	var prior *risk.Observation
+	if s.cfg.Observations != nil {
+		if obs, ok := s.cfg.Observations.Get(ctx, device.DeviceID); ok {
+			prior = obs
+		}
+	}
+	dec := s.cfg.Risk.Score(ctx, risk.Signal{
+		DeviceID:         device.DeviceID,
+		TenantID:         device.TenantID,
+		RemoteIP:         remoteIP,
+		Now:              now,
+		PriorObservation: prior,
+	})
+	if s.cfg.Observations != nil && dec.Geo != nil {
+		_ = s.cfg.Observations.Put(ctx, device.DeviceID, risk.Observation{
+			IP:        ipString(remoteIP),
+			Country:   dec.Geo.Country,
+			ASN:       dec.Geo.ASN,
+			Latitude:  dec.Geo.Latitude,
+			Longitude: dec.Geo.Longitude,
+			At:        now,
+		})
+	}
+	return dec.FilterScopes(scopes), &dec
+}
+
+func ipString(ip net.IP) string {
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
 }
 
 // Revoke marks a device revoked. Subsequent refresh attempts will fail and
@@ -428,11 +604,55 @@ var ErrInvalidRequest = errors.New("deviceauth: invalid request")
 
 func (s *Service) mintAccess(device DeviceRecord, scopes []string) (string, time.Time, error) {
 	expires := s.cfg.Now().UTC().Add(s.cfg.AccessTTL)
-	token, err := s.issuer.IssueAccess(device, scopes)
+	opts := AccessOptions{
+		DPoPJKT:        strings.TrimSpace(device.Metadata["dpop_jkt"]),
+		AssuranceLevel: strings.TrimSpace(device.Metadata["assurance_level"]),
+	}
+	token, err := s.issuer.IssueAccessWithOptions(device, scopes, opts)
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("deviceauth: issue access: %w", err)
 	}
 	return token, expires, nil
+}
+
+// computeJKTFromPublicKeyDER returns the RFC 7638 JWK SHA-256 thumbprint of
+// the supplied SubjectPublicKeyInfo. Only EC (P-256, P-384) and Ed25519
+// keys are supported; other types fall through with an empty result so the
+// caller can decide whether attestation succeeded without binding a DPoP
+// key (e.g. a software-only attestation result).
+func computeJKTFromPublicKeyDER(pubDER []byte) (string, error) {
+	if len(pubDER) == 0 {
+		return "", nil
+	}
+	pub, err := x509.ParsePKIXPublicKey(pubDER)
+	if err != nil {
+		return "", fmt.Errorf("parse pubkey: %w", err)
+	}
+	switch p := pub.(type) {
+	case *ecdsa.PublicKey:
+		var crv string
+		switch p.Curve {
+		case elliptic.P256():
+			crv = "P-256"
+		case elliptic.P384():
+			crv = "P-384"
+		default:
+			return "", nil
+		}
+		canonical := fmt.Sprintf(`{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`,
+			crv,
+			base64.RawURLEncoding.EncodeToString(p.X.Bytes()),
+			base64.RawURLEncoding.EncodeToString(p.Y.Bytes()),
+		)
+		sum := sha256.Sum256([]byte(canonical))
+		return base64.RawURLEncoding.EncodeToString(sum[:]), nil
+	case ed25519.PublicKey:
+		canonical := fmt.Sprintf(`{"crv":"Ed25519","kty":"OKP","x":"%s"}`, base64.RawURLEncoding.EncodeToString(p))
+		sum := sha256.Sum256([]byte(canonical))
+		return base64.RawURLEncoding.EncodeToString(sum[:]), nil
+	default:
+		return "", nil
+	}
 }
 
 func (s *Service) mintRefresh(ctx context.Context, deviceID string, scopes []string, familyID string, generation int, now time.Time) (string, time.Time, error) {

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -264,6 +264,13 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	if tenantID == "" {
 		return EnrollResponse{}, fmt.Errorf("%w: bootstrap token has no tenant_id", ErrInvalidRequest)
 	}
+	existing, err := s.store.LookupDeviceByHardware(ctx, tenantID, hardwareUUID)
+	if err == nil && existing.Status != "" && existing.Status != "active" {
+		return EnrollResponse{}, ErrDeviceInactive
+	}
+	if err != nil && !errors.Is(err, ErrDeviceNotFound) {
+		return EnrollResponse{}, err
+	}
 	scopes := normalizedNonEmptyStrings(consumed.Scopes)
 	scopes = filterAllowedBootstrapDeviceScopes(scopes)
 	if len(scopes) == 0 {

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -598,10 +598,17 @@ func (s *Service) IssueBootstrapToken(ctx context.Context, request IssueBootstra
 }
 
 func validateBootstrapDeviceScopes(scopes []string) error {
+	hasNonSensitiveScope := false
 	for _, scope := range scopes {
 		if _, ok := allowedBootstrapDeviceScopes[scope]; !ok {
 			return fmt.Errorf("%w: unsupported device bootstrap scope %q", ErrInvalidRequest, scope)
 		}
+		if _, sensitive := risk.SensitiveScopes[scope]; !sensitive {
+			hasNonSensitiveScope = true
+		}
+	}
+	if !hasNonSensitiveScope {
+		return fmt.Errorf("%w: device bootstrap scopes must include a non-sensitive scope", ErrInvalidRequest)
 	}
 	return nil
 }

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -272,7 +273,7 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	if err != nil {
 		return EnrollResponse{}, fmt.Errorf("deviceauth: generate device id: %w", err)
 	}
-	clientHash := sha256.Sum256([]byte(strings.TrimSpace(request.BootstrapToken)))
+	clientHash := attestationClientDataHash(bootstrapToken, hardwareUUID)
 	attResult, err := s.runAttestation(ctx, clientHash, request)
 	if err != nil {
 		return EnrollResponse{}, err
@@ -331,6 +332,25 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 		AssuranceLevel:    attResult.AssuranceLevel,
 		AttestationVendor: attResult.Vendor,
 	}, nil
+}
+
+func attestationClientDataHash(bootstrapToken string, hardwareUUID string) [32]byte {
+	h := sha256.New()
+	writeHashField(h, "bootstrap_token", strings.TrimSpace(bootstrapToken))
+	writeHashField(h, "hardware_uuid", strings.TrimSpace(hardwareUUID))
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func writeHashField(h interface{ Write([]byte) (int, error) }, name string, value string) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(name)))
+	_, _ = h.Write(length[:])
+	_, _ = h.Write([]byte(name))
+	binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+	_, _ = h.Write(length[:])
+	_, _ = h.Write([]byte(value))
 }
 
 func (s *Service) runAttestation(ctx context.Context, clientHash [32]byte, request EnrollRequest) (*attestation.Result, error) {
@@ -629,7 +649,7 @@ func (s *Service) IngestTelemetry(ctx context.Context, payload IngestPayload) (I
 	}
 	now := s.cfg.Now().UTC()
 	cacheKey := "device:" + deviceID + ":" + idempotencyKey
-	requestHash := HashToken(string(payload.Body))
+	requestHash := sha256.Sum256(payload.Body)
 	cached, status, err := s.store.CheckIdempotency(ctx, cacheKey, requestHash)
 	if err != nil {
 		return IngestResult{}, err

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -298,6 +298,10 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	}
 	if jkt != "" {
 		metadata["dpop_jkt"] = jkt
+	} else if existing.Metadata != nil {
+		if priorJKT := strings.TrimSpace(existing.Metadata["dpop_jkt"]); priorJKT != "" {
+			metadata["dpop_jkt"] = priorJKT
+		}
 	}
 	if attResult.KeyID != "" {
 		metadata["attestation_keyid"] = attResult.KeyID

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -402,10 +402,8 @@ func (s *Service) IssueToken(ctx context.Context, request TokenRequest) (TokenRe
 	if device.Status != "" && device.Status != "active" {
 		return TokenResponse{}, ErrDeviceInactive
 	}
-	if peek.ConsumedAt.IsZero() && !peek.FamilyRevoked {
-		if err := s.verifyDPoPForRefresh(device, request); err != nil {
-			return TokenResponse{}, err
-		}
+	if err := s.verifyDPoPForRefresh(device, request); err != nil {
+		return TokenResponse{}, err
 	}
 	consumed, err := s.store.ConsumeRefreshToken(ctx, refreshHash, now)
 	if err != nil {

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -24,13 +24,13 @@ import (
 // switch, so a device-issued JWT and a capability token both flow through
 // the same authorization decision.
 const (
-	ScopeDevicesEnroll          = "platform.devices.enroll"
-	ScopeDevicesToken           = "platform.devices.token"
-	ScopeDevicesRead            = "platform.devices.read"
-	ScopeDevicesRevoke          = "platform.devices.revoke"
-	ScopeDevicesBootstrapWrite  = "platform.devices.bootstrap_tokens.write"
-	ScopeTelemetryIngest        = "platform.telemetry.ingest"
-	ScopeDeviceFindingsRead     = "security.devices.findings.read"
+	ScopeDevicesEnroll         = "platform.devices.enroll"
+	ScopeDevicesToken          = "platform.devices.token"
+	ScopeDevicesRead           = "platform.devices.read"
+	ScopeDevicesRevoke         = "platform.devices.revoke"
+	ScopeDevicesBootstrapWrite = "platform.devices.bootstrap_tokens.write"
+	ScopeTelemetryIngest       = "platform.telemetry.ingest"
+	ScopeDeviceFindingsRead    = "security.devices.findings.read"
 )
 
 // DefaultDeviceScopes is the default scope set assigned to a freshly enrolled
@@ -133,9 +133,9 @@ type IssueBootstrapTokenRequest struct {
 // [Service.IssueBootstrapToken]. The plaintext token is returned exactly
 // once; the server only persists the SHA-256 hash.
 type IssueBootstrapTokenResponse struct {
-	TokenID    string
-	Token      string
-	ExpiresAt  time.Time
+	TokenID   string
+	Token     string
+	ExpiresAt time.Time
 }
 
 // ServiceConfig configures the [Service].
@@ -276,7 +276,7 @@ func (s *Service) Enroll(ctx context.Context, request EnrollRequest) (EnrollResp
 	}
 	jkt, err := computeJKTFromPublicKeyDER(attResult.PublicKey)
 	if err != nil {
-		return EnrollResponse{}, fmt.Errorf("%w: %v", ErrInvalidRequest, err)
+		return EnrollResponse{}, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 	}
 	if jkt != "" {
 		metadata["dpop_jkt"] = jkt
@@ -631,18 +631,23 @@ func computeJKTFromPublicKeyDER(pubDER []byte) (string, error) {
 	switch p := pub.(type) {
 	case *ecdsa.PublicKey:
 		var crv string
+		var coordLen int
 		switch p.Curve {
 		case elliptic.P256():
-			crv = "P-256"
+			crv, coordLen = "P-256", 32
 		case elliptic.P384():
-			crv = "P-384"
+			crv, coordLen = "P-384", 48
 		default:
 			return "", nil
 		}
+		x, y, err := ecdsaPublicKeyXY(p, coordLen)
+		if err != nil {
+			return "", err
+		}
 		canonical := fmt.Sprintf(`{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`,
 			crv,
-			base64.RawURLEncoding.EncodeToString(p.X.Bytes()),
-			base64.RawURLEncoding.EncodeToString(p.Y.Bytes()),
+			base64.RawURLEncoding.EncodeToString(x),
+			base64.RawURLEncoding.EncodeToString(y),
 		)
 		sum := sha256.Sum256([]byte(canonical))
 		return base64.RawURLEncoding.EncodeToString(sum[:]), nil
@@ -689,6 +694,25 @@ func generateID(prefix string) (string, error) {
 		return "", err
 	}
 	return prefix + base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// ecdsaPublicKeyXY returns the big-endian X and Y coordinates of pub
+// padded to coordLen, derived via the SEC1 uncompressed encoding emitted
+// by crypto/ecdh. This avoids touching the deprecated raw .X / .Y fields
+// on ecdsa.PublicKey while preserving the existing JWK thumbprint format
+// (RFC 7638). Only NIST P-256 / P-384 are supported here; callers must
+// gate on curve before calling.
+func ecdsaPublicKeyXY(pub *ecdsa.PublicKey, coordLen int) ([]byte, []byte, error) {
+	ecdhPub, err := pub.ECDH()
+	if err != nil {
+		return nil, nil, fmt.Errorf("deviceauth: ecdsa->ecdh: %w", err)
+	}
+	raw := ecdhPub.Bytes()
+	want := 1 + 2*coordLen
+	if len(raw) != want || raw[0] != 0x04 {
+		return nil, nil, fmt.Errorf("deviceauth: unexpected SEC1 length %d (want %d)", len(raw), want)
+	}
+	return raw[1 : 1+coordLen], raw[1+coordLen:], nil
 }
 
 func normalizedNonEmptyStrings(values []string) []string {

--- a/internal/deviceauth/service.go
+++ b/internal/deviceauth/service.go
@@ -455,6 +455,9 @@ func (s *Service) RefreshTokenRateLimitKey(ctx context.Context, refreshToken str
 	if err != nil {
 		return "", err
 	}
+	if row.FamilyRevoked || !row.ConsumedAt.IsZero() {
+		return "", ErrRefreshReplay
+	}
 	deviceID := strings.TrimSpace(row.DeviceID)
 	if deviceID == "" {
 		return "", ErrRefreshNotFound

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -209,6 +209,23 @@ func TestServiceRevokeBlocksRefresh(t *testing.T) {
 	}
 }
 
+func TestServiceEnrollRejectsRevokedHardware(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	firstBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	secondBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	enroll, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: firstBootstrap.Token, HardwareUUID: "hw-1"})
+	if err != nil {
+		t.Fatalf("Enroll(first): %v", err)
+	}
+	if err := service.Revoke(ctx, enroll.DeviceID, "lost"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if _, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: secondBootstrap.Token, HardwareUUID: "hw-1"}); !errors.Is(err, ErrDeviceInactive) {
+		t.Fatalf("Enroll(second) err = %v, want ErrDeviceInactive", err)
+	}
+}
+
 func TestServiceIngestTelemetryRequiresIdempotencyKey(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -247,6 +247,26 @@ func TestServiceReenrollActiveHardwarePreservesRefreshLineage(t *testing.T) {
 	}
 }
 
+func TestRefreshTokenRateLimitKeyRejectsConsumedTokens(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	enroll, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	rotated, err := service.IssueToken(ctx, TokenRequest{GrantType: "refresh_token", RefreshToken: enroll.RefreshToken})
+	if err != nil {
+		t.Fatalf("IssueToken: %v", err)
+	}
+	if _, err := service.RefreshTokenRateLimitKey(ctx, enroll.RefreshToken); !errors.Is(err, ErrRefreshReplay) {
+		t.Fatalf("RefreshTokenRateLimitKey(consumed) err = %v, want ErrRefreshReplay", err)
+	}
+	if got, err := service.RefreshTokenRateLimitKey(ctx, rotated.RefreshToken); err != nil || got != "device:"+enroll.DeviceID {
+		t.Fatalf("RefreshTokenRateLimitKey(live) = %q, %v; want device:%s", got, err, enroll.DeviceID)
+	}
+}
+
 func TestServiceIngestTelemetryRequiresIdempotencyKey(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -120,6 +120,30 @@ func TestServiceEnrollRequiresMatchingHardware(t *testing.T) {
 	}
 }
 
+func TestServiceIssueBootstrapTokenRejectsNegativeTTL(t *testing.T) {
+	ctx := context.Background()
+	service, _, now := newServiceForTest(t)
+	if _, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-neg",
+		TenantID:     "writer",
+		TTL:          -time.Second,
+	}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("IssueBootstrapToken negative TTL err = %v, want ErrInvalidRequest", err)
+	}
+
+	issued, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-default",
+		TenantID:     "writer",
+		TTL:          0,
+	})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken zero TTL: %v", err)
+	}
+	if got := issued.ExpiresAt.Sub(now); got != time.Hour {
+		t.Fatalf("zero TTL expiry delta = %v, want %v", got, time.Hour)
+	}
+}
+
 type checkingAttestationVerifier struct {
 	wantHash         [32]byte
 	wantHardwareUUID string

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -226,6 +226,27 @@ func TestServiceEnrollRejectsRevokedHardware(t *testing.T) {
 	}
 }
 
+func TestServiceReenrollActiveHardwarePreservesRefreshLineage(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	firstBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	secondBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	first, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: firstBootstrap.Token, HardwareUUID: "hw-1"})
+	if err != nil {
+		t.Fatalf("Enroll(first): %v", err)
+	}
+	second, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: secondBootstrap.Token, HardwareUUID: "hw-1"})
+	if err != nil {
+		t.Fatalf("Enroll(second): %v", err)
+	}
+	if second.DeviceID != first.DeviceID {
+		t.Fatalf("second device_id = %q, want existing %q", second.DeviceID, first.DeviceID)
+	}
+	if _, err := service.IssueToken(ctx, TokenRequest{GrantType: "refresh_token", RefreshToken: first.RefreshToken}); err != nil {
+		t.Fatalf("IssueToken with first refresh after re-enroll: %v", err)
+	}
+}
+
 func TestServiceIngestTelemetryRequiresIdempotencyKey(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -311,6 +311,19 @@ func TestIssueBootstrapTokenRejectsAdminScopes(t *testing.T) {
 	}
 }
 
+func TestIssueBootstrapTokenRejectsTelemetryOnlyScope(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	_, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-1",
+		TenantID:     "writer",
+		Scopes:       []string{ScopeTelemetryIngest},
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("IssueBootstrapToken err = %v, want ErrInvalidRequest", err)
+	}
+}
+
 func TestEnrollFiltersLegacyBootstrapAdminScopes(t *testing.T) {
 	ctx := context.Background()
 	service, store, now := newServiceForTest(t)

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -1,0 +1,239 @@
+package deviceauth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newServiceForTest(t *testing.T) (*Service, *MemStore, time.Time) {
+	t.Helper()
+	store := NewMemStore()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer, err := NewLocalSigner([]SigningKey{{KID: "test", Public: pub, Private: priv}})
+	if err != nil {
+		t.Fatalf("NewLocalSigner: %v", err)
+	}
+	keyset := &KeySet{Keys: []SigningKey{{KID: "test", Public: pub}}}
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	store.SetClock(clock)
+	issuer, _ := NewJWTIssuer(IssuerConfig{Now: clock}, signer)
+	verifier, _ := NewJWTVerifier(VerifierConfig{Now: clock}, keyset)
+	service, err := NewService(ServiceConfig{
+		AccessTTL:         5 * time.Minute,
+		RefreshTTL:        24 * time.Hour,
+		BootstrapTokenTTL: time.Hour,
+		IdempotencyTTL:    time.Hour,
+		Now:               clock,
+	}, store, issuer, verifier, keyset)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return service, store, now
+}
+
+func TestServiceEnrollAndIssueToken(t *testing.T) {
+	ctx := context.Background()
+	service, _, now := newServiceForTest(t)
+
+	bootstrapResp, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-1",
+		TenantID:     "writer",
+		TTL:          time.Hour,
+		IssuedBy:     "operator",
+	})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken: %v", err)
+	}
+	if bootstrapResp.Token == "" {
+		t.Fatal("IssueBootstrapToken returned empty token")
+	}
+
+	enroll, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: bootstrapResp.Token,
+		HardwareUUID:   "hw-1",
+		Hostname:       "laptop-1",
+		OSType:         "darwin",
+		AgentVersion:   "1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if enroll.AccessToken == "" || enroll.RefreshToken == "" {
+		t.Fatal("Enroll returned empty tokens")
+	}
+	if enroll.DeviceID == "" {
+		t.Fatal("Enroll returned empty device_id")
+	}
+
+	verified, err := service.Verifier().Verify(enroll.AccessToken)
+	if err != nil {
+		t.Fatalf("Verify access token: %v", err)
+	}
+	if verified.DeviceID != enroll.DeviceID {
+		t.Errorf("verified device_id = %q, want %q", verified.DeviceID, enroll.DeviceID)
+	}
+
+	rotated, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: enroll.RefreshToken,
+	})
+	if err != nil {
+		t.Fatalf("IssueToken: %v", err)
+	}
+	if rotated.RefreshToken == enroll.RefreshToken {
+		t.Fatal("IssueToken did not rotate the refresh token")
+	}
+
+	if _, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: enroll.RefreshToken,
+	}); !errors.Is(err, ErrRefreshReplay) {
+		t.Fatalf("replay err = %v, want ErrRefreshReplay", err)
+	}
+	if _, err := service.IssueToken(ctx, TokenRequest{
+		GrantType:    "refresh_token",
+		RefreshToken: rotated.RefreshToken,
+	}); !errors.Is(err, ErrRefreshReplay) {
+		t.Fatalf("post-replay rotated err = %v, want ErrRefreshReplay", err)
+	}
+	_ = now
+}
+
+func TestServiceEnrollRequiresMatchingHardware(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	if _, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-DIFFERENT"}); !errors.Is(err, ErrBootstrapTokenMismatch) {
+		t.Fatalf("Enroll with wrong hw err = %v, want ErrBootstrapTokenMismatch", err)
+	}
+}
+
+func TestServiceIssueTokenRejectsWrongGrant(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	if _, err := service.IssueToken(ctx, TokenRequest{GrantType: "client_credentials"}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("IssueToken with wrong grant err = %v, want ErrInvalidRequest", err)
+	}
+}
+
+func TestServiceRevokeBlocksRefresh(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+	if err := service.Revoke(ctx, enroll.DeviceID, "test"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if _, err := service.IssueToken(ctx, TokenRequest{GrantType: "refresh_token", RefreshToken: enroll.RefreshToken}); !errors.Is(err, ErrDeviceInactive) {
+		t.Fatalf("IssueToken after revoke err = %v, want ErrDeviceInactive", err)
+	}
+}
+
+func TestServiceIngestTelemetryRequiresIdempotencyKey(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+	if _, err := service.IngestTelemetry(ctx, IngestPayload{DeviceID: enroll.DeviceID, Body: []byte(`{"events":[]}`)}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("IngestTelemetry without key err = %v, want ErrInvalidRequest", err)
+	}
+}
+
+func TestServiceIngestTelemetryIdempotent(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+
+	body := []byte(`{"events":[{"type":"login"}]}`)
+	first, err := service.IngestTelemetry(ctx, IngestPayload{DeviceID: enroll.DeviceID, IdempotencyKey: "abc-123", Body: body})
+	if err != nil {
+		t.Fatalf("first IngestTelemetry: %v", err)
+	}
+	if first.Status != 202 {
+		t.Errorf("first status = %d, want 202", first.Status)
+	}
+
+	second, err := service.IngestTelemetry(ctx, IngestPayload{DeviceID: enroll.DeviceID, IdempotencyKey: "abc-123", Body: body})
+	if err != nil {
+		t.Fatalf("second IngestTelemetry: %v", err)
+	}
+	if !second.Cached {
+		t.Errorf("second not cached")
+	}
+	if string(first.Body) != string(second.Body) {
+		t.Errorf("idempotent body mismatch: %q vs %q", first.Body, second.Body)
+	}
+
+	if _, err := service.IngestTelemetry(ctx, IngestPayload{DeviceID: enroll.DeviceID, IdempotencyKey: "abc-123", Body: []byte(`{"events":[{"type":"different"}]}`)}); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("conflicting body err = %v, want ErrIdempotencyConflict", err)
+	}
+}
+
+func TestServiceJWKSExposesKID(t *testing.T) {
+	service, _, _ := newServiceForTest(t)
+	doc := EncodeJWKS(service.KeySet())
+	if len(doc.Keys) != 1 {
+		t.Fatalf("expected 1 JWK, got %d", len(doc.Keys))
+	}
+	if doc.Keys[0].KTY != "OKP" || doc.Keys[0].CRV != "Ed25519" || doc.Keys[0].Alg != "EdDSA" {
+		t.Fatalf("unexpected JWK fields: %+v", doc.Keys[0])
+	}
+	if doc.Keys[0].KID != "test" {
+		t.Errorf("kid = %q, want test", doc.Keys[0].KID)
+	}
+	if strings.TrimSpace(doc.Keys[0].X) == "" {
+		t.Errorf("public key x is empty")
+	}
+}
+
+func TestTokenBucketAllow(t *testing.T) {
+	bucket := NewTokenBucket(1, 2)
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	bucket.now = func() time.Time { return now }
+	if !bucket.Allow("ip-1") {
+		t.Fatal("first allow false")
+	}
+	if !bucket.Allow("ip-1") {
+		t.Fatal("second allow false (within burst)")
+	}
+	if bucket.Allow("ip-1") {
+		t.Fatal("third allow true (over burst)")
+	}
+	now = now.Add(2 * time.Second)
+	if !bucket.Allow("ip-1") {
+		t.Fatal("after refill allow false")
+	}
+}
+
+func TestKeyDecodeRoundTrip(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubPEM := mustEncodePEMPublic(t, pub)
+	privPEM := mustEncodePEMPrivate(t, priv)
+	gotPub, err := DecodePEMPublicKey(pubPEM)
+	if err != nil {
+		t.Fatalf("DecodePEMPublicKey: %v", err)
+	}
+	if string(gotPub) != string(pub) {
+		t.Errorf("public key round-trip mismatch")
+	}
+	gotPriv, err := DecodePEMPrivateKey(privPEM)
+	if err != nil {
+		t.Fatalf("DecodePEMPrivateKey: %v", err)
+	}
+	if string(gotPriv) != string(priv) {
+		t.Errorf("private key round-trip mismatch")
+	}
+}

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/writer/cerebro/internal/deviceauth/attestation"
 )
 
 func newServiceForTest(t *testing.T) (*Service, *MemStore, time.Time) {
@@ -118,6 +120,50 @@ func TestServiceEnrollRequiresMatchingHardware(t *testing.T) {
 	}
 }
 
+type checkingAttestationVerifier struct {
+	wantHash         [32]byte
+	wantHardwareUUID string
+	called           bool
+}
+
+func (v *checkingAttestationVerifier) Format() string { return attestation.FormatAppleAppAttest }
+
+func (v *checkingAttestationVerifier) Verify(_ context.Context, in attestation.Input) (*attestation.Result, error) {
+	v.called = true
+	if in.HardwareUUID != v.wantHardwareUUID {
+		return nil, attestation.ErrInvalidStatement
+	}
+	if in.ClientDataHash != v.wantHash {
+		return nil, attestation.ErrNonceMismatch
+	}
+	return &attestation.Result{AssuranceLevel: "hardware", Vendor: "stub-appattest"}, nil
+}
+
+func TestServiceEnrollAttestationClientHashBindsHardwareUUID(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	verifier := &checkingAttestationVerifier{wantHardwareUUID: "hw-1"}
+	service.cfg.Attestations = attestation.NewRegistry(true, verifier)
+
+	bootstrap, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	if err != nil {
+		t.Fatalf("IssueBootstrapToken: %v", err)
+	}
+	verifier.wantHash = attestationClientDataHash(bootstrap.Token, "hw-1")
+
+	if _, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: bootstrap.Token,
+		HardwareUUID:   "hw-1",
+		OSType:         "darwin",
+		Attestation:    "stub-attestation",
+	}); err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if !verifier.called {
+		t.Fatal("attestation verifier was not called")
+	}
+}
+
 func TestServiceIssueTokenRejectsWrongGrant(t *testing.T) {
 	ctx := context.Background()
 	service, _, _ := newServiceForTest(t)
@@ -177,6 +223,20 @@ func TestServiceIngestTelemetryIdempotent(t *testing.T) {
 
 	if _, err := service.IngestTelemetry(ctx, IngestPayload{DeviceID: enroll.DeviceID, IdempotencyKey: "abc-123", Body: []byte(`{"events":[{"type":"different"}]}`)}); !errors.Is(err, ErrIdempotencyConflict) {
 		t.Fatalf("conflicting body err = %v, want ErrIdempotencyConflict", err)
+	}
+}
+
+func TestServiceIngestTelemetryIdempotencyPreservesBodyWhitespace(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	bootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	enroll, _ := service.Enroll(ctx, EnrollRequest{BootstrapToken: bootstrap.Token, HardwareUUID: "hw-1"})
+
+	if _, err := service.IngestTelemetry(ctx, IngestPayload{DeviceID: enroll.DeviceID, IdempotencyKey: "raw-body", Body: []byte(`{}`)}); err != nil {
+		t.Fatalf("first IngestTelemetry: %v", err)
+	}
+	if _, err := service.IngestTelemetry(ctx, IngestPayload{DeviceID: enroll.DeviceID, IdempotencyKey: "raw-body", Body: []byte("{}\n")}); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("whitespace-only body change err = %v, want ErrIdempotencyConflict", err)
 	}
 }
 

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -193,6 +194,66 @@ func TestServiceJWKSExposesKID(t *testing.T) {
 	}
 	if strings.TrimSpace(doc.Keys[0].X) == "" {
 		t.Errorf("public key x is empty")
+	}
+}
+
+func TestKeySetMarshalJSONDoesNotExposePrivateKey(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := json.Marshal(&KeySet{Keys: []SigningKey{{KID: "test", Public: pub, Private: priv}}})
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	if strings.Contains(string(doc), "Private") || strings.Contains(string(doc), "Public") {
+		t.Fatalf("KeySet JSON exposed internal key fields: %s", doc)
+	}
+	if !strings.Contains(string(doc), `"kty":"OKP"`) || !strings.Contains(string(doc), `"kid":"test"`) {
+		t.Fatalf("KeySet JSON is not JWKS-shaped: %s", doc)
+	}
+}
+
+func TestIssueBootstrapTokenRejectsAdminScopes(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	_, err := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{
+		HardwareUUID: "hw-1",
+		TenantID:     "writer",
+		Scopes:       []string{ScopeDevicesBootstrapWrite},
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("IssueBootstrapToken err = %v, want ErrInvalidRequest", err)
+	}
+}
+
+func TestEnrollFiltersLegacyBootstrapAdminScopes(t *testing.T) {
+	ctx := context.Background()
+	service, store, now := newServiceForTest(t)
+	plaintext, err := GenerateOpaqueToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateBootstrapToken(ctx, BootstrapToken{
+		TokenID:      "btk-legacy",
+		TokenHash:    HashToken(plaintext),
+		HardwareUUID: "hw-1",
+		TenantID:     "writer",
+		Scopes:       []string{ScopeDevicesBootstrapWrite, ScopeTelemetryIngest},
+		CreatedAt:    now,
+		ExpiresAt:    now.Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("CreateBootstrapToken: %v", err)
+	}
+	enroll, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: plaintext, HardwareUUID: "hw-1"})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if containsScope(enroll.Scopes, ScopeDevicesBootstrapWrite) {
+		t.Fatalf("enroll propagated admin scope: %v", enroll.Scopes)
+	}
+	if !containsScope(enroll.Scopes, ScopeTelemetryIngest) {
+		t.Fatalf("enroll dropped allowed scope: %v", enroll.Scopes)
 	}
 }
 

--- a/internal/deviceauth/service_test.go
+++ b/internal/deviceauth/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -147,6 +148,7 @@ func TestServiceIssueBootstrapTokenRejectsNegativeTTL(t *testing.T) {
 type checkingAttestationVerifier struct {
 	wantHash         [32]byte
 	wantHardwareUUID string
+	publicKey        []byte
 	called           bool
 }
 
@@ -160,7 +162,7 @@ func (v *checkingAttestationVerifier) Verify(_ context.Context, in attestation.I
 	if in.ClientDataHash != v.wantHash {
 		return nil, attestation.ErrNonceMismatch
 	}
-	return &attestation.Result{AssuranceLevel: "hardware", Vendor: "stub-appattest"}, nil
+	return &attestation.Result{AssuranceLevel: "hardware", PublicKey: v.publicKey, Vendor: "stub-appattest"}, nil
 }
 
 func TestServiceEnrollAttestationClientHashBindsHardwareUUID(t *testing.T) {
@@ -244,6 +246,60 @@ func TestServiceReenrollActiveHardwarePreservesRefreshLineage(t *testing.T) {
 	}
 	if _, err := service.IssueToken(ctx, TokenRequest{GrantType: "refresh_token", RefreshToken: first.RefreshToken}); err != nil {
 		t.Fatalf("IssueToken with first refresh after re-enroll: %v", err)
+	}
+}
+
+func TestServiceReenrollActiveHardwarePreservesDPoPBinding(t *testing.T) {
+	ctx := context.Background()
+	service, _, _ := newServiceForTest(t)
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	verifier := &checkingAttestationVerifier{
+		wantHardwareUUID: "hw-1",
+		publicKey:        pubDER,
+	}
+	service.cfg.Attestations = attestation.NewRegistry(true, verifier)
+	firstBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	verifier.wantHash = attestationClientDataHash(firstBootstrap.Token, "hw-1")
+	first, err := service.Enroll(ctx, EnrollRequest{
+		BootstrapToken: firstBootstrap.Token,
+		HardwareUUID:   "hw-1",
+		OSType:         "darwin",
+		Attestation:    "stub-attestation",
+	})
+	if err != nil {
+		t.Fatalf("first Enroll: %v", err)
+	}
+	device, err := service.LookupDevice(ctx, first.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice: %v", err)
+	}
+	priorJKT := strings.TrimSpace(device.Metadata["dpop_jkt"])
+	if priorJKT == "" {
+		t.Fatal("first enrollment did not bind DPoP JKT")
+	}
+
+	service.cfg.Attestations = attestation.NewRegistry(false)
+	secondBootstrap, _ := service.IssueBootstrapToken(ctx, IssueBootstrapTokenRequest{HardwareUUID: "hw-1", TenantID: "writer"})
+	second, err := service.Enroll(ctx, EnrollRequest{BootstrapToken: secondBootstrap.Token, HardwareUUID: "hw-1"})
+	if err != nil {
+		t.Fatalf("second Enroll: %v", err)
+	}
+	if second.DeviceID != first.DeviceID {
+		t.Fatalf("second device_id = %q, want %q", second.DeviceID, first.DeviceID)
+	}
+	device, err = service.LookupDevice(ctx, first.DeviceID)
+	if err != nil {
+		t.Fatalf("LookupDevice after reenroll: %v", err)
+	}
+	if got := strings.TrimSpace(device.Metadata["dpop_jkt"]); got != priorJKT {
+		t.Fatalf("dpop_jkt after reenroll = %q, want preserved %q", got, priorJKT)
 	}
 }
 

--- a/internal/deviceauth/sha384.go
+++ b/internal/deviceauth/sha384.go
@@ -1,0 +1,8 @@
+package deviceauth
+
+import "crypto/sha512"
+
+func sha384Sum(data []byte) []byte {
+	sum := sha512.Sum384(data)
+	return sum[:]
+}

--- a/internal/deviceauth/store.go
+++ b/internal/deviceauth/store.go
@@ -83,6 +83,10 @@ type Store interface {
 
 	// IssueRefreshToken inserts a new refresh-token row.
 	IssueRefreshToken(ctx context.Context, token RefreshToken) error
+	// LookupRefreshToken returns refresh-token metadata by hash without
+	// consuming or revoking it. Callers use this to verify holder-of-key
+	// proofs and choose rate-limit buckets before mutating token state.
+	LookupRefreshToken(ctx context.Context, hash [32]byte, at time.Time) (RefreshToken, error)
 	// ConsumeRefreshToken consumes a refresh token by hash, returning the
 	// pre-consume row. If the token was already consumed, the implementation
 	// MUST mark the entire family revoked and return [ErrRefreshReplay].

--- a/internal/deviceauth/store.go
+++ b/internal/deviceauth/store.go
@@ -100,16 +100,16 @@ type Store interface {
 
 // Typed store-level errors.
 var (
-	ErrDeviceNotFound          = errors.New("deviceauth: device not found")
-	ErrDeviceInactive          = errors.New("deviceauth: device is not active")
-	ErrBootstrapTokenNotFound  = errors.New("deviceauth: bootstrap token not found")
-	ErrBootstrapTokenConsumed  = errors.New("deviceauth: bootstrap token already consumed")
-	ErrBootstrapTokenExpired   = errors.New("deviceauth: bootstrap token expired")
-	ErrBootstrapTokenMismatch  = errors.New("deviceauth: bootstrap token hardware_uuid mismatch")
-	ErrRefreshNotFound         = errors.New("deviceauth: refresh token not found")
-	ErrRefreshReplay           = errors.New("deviceauth: refresh token replay detected")
-	ErrRefreshExpired          = errors.New("deviceauth: refresh token expired")
-	ErrIdempotencyConflict     = errors.New("deviceauth: idempotency-key request hash mismatch")
+	ErrDeviceNotFound         = errors.New("deviceauth: device not found")
+	ErrDeviceInactive         = errors.New("deviceauth: device is not active")
+	ErrBootstrapTokenNotFound = errors.New("deviceauth: bootstrap token not found")
+	ErrBootstrapTokenConsumed = errors.New("deviceauth: bootstrap token already consumed")
+	ErrBootstrapTokenExpired  = errors.New("deviceauth: bootstrap token expired")
+	ErrBootstrapTokenMismatch = errors.New("deviceauth: bootstrap token hardware_uuid mismatch")
+	ErrRefreshNotFound        = errors.New("deviceauth: refresh token not found")
+	ErrRefreshReplay          = errors.New("deviceauth: refresh token replay detected")
+	ErrRefreshExpired         = errors.New("deviceauth: refresh token expired")
+	ErrIdempotencyConflict    = errors.New("deviceauth: idempotency-key request hash mismatch")
 )
 
 // HashToken returns the SHA-256 digest of the given plaintext token.

--- a/internal/deviceauth/store.go
+++ b/internal/deviceauth/store.go
@@ -1,0 +1,118 @@
+package deviceauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"strings"
+	"time"
+)
+
+// DeviceRecord describes an enrolled SeCheck agent. The struct is the cross-
+// driver representation; the Postgres driver maps it 1:1 to the
+// device_records table.
+type DeviceRecord struct {
+	DeviceID     string
+	HardwareUUID string
+	SerialNumber string
+	Hostname     string
+	TenantID     string
+	OSType       string
+	OSVersion    string
+	AgentVersion string
+	Status       string
+	EnrolledAt   time.Time
+	LastSeenAt   time.Time
+	RevokedAt    time.Time
+	Metadata     map[string]string
+}
+
+// BootstrapToken represents a single-use, MDM-delivered enrollment credential.
+// Only the SHA-256 hash is persisted in TokenHash; the plaintext token is
+// known only to whoever generated it (and then to the agent).
+type BootstrapToken struct {
+	TokenID      string
+	TokenHash    [32]byte
+	HardwareUUID string
+	TenantID     string
+	Scopes       []string
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+	ConsumedAt   time.Time
+	ConsumedBy   string
+}
+
+// RefreshToken tracks a single-use refresh-token row. Token plaintext lives
+// only in memory long enough to return it to the agent. The persisted
+// representation is the SHA-256 hash.
+type RefreshToken struct {
+	TokenHash     [32]byte
+	DeviceID      string
+	FamilyID      string
+	Generation    int
+	Scopes        []string
+	CreatedAt     time.Time
+	ExpiresAt     time.Time
+	ConsumedAt    time.Time
+	FamilyRevoked bool
+	Superseded    bool
+}
+
+// Store is the persistence boundary for device-auth state. Implementations
+// must be transactional: ConsumeRefreshToken in particular MUST atomically
+// match-by-hash, mark-consumed, and (on replay) revoke the family in a
+// single serialized step.
+type Store interface {
+	// EnrollDevice inserts a new device row. If the (tenant_id, hardware_uuid)
+	// already exists the implementation MAY replace the row and return the
+	// existing device_id; the caller does not depend on a particular choice.
+	EnrollDevice(ctx context.Context, device DeviceRecord) (DeviceRecord, error)
+	// LookupDevice returns the device by id.
+	LookupDevice(ctx context.Context, deviceID string) (DeviceRecord, error)
+	// MarkSeen updates last_seen_at on the device row.
+	MarkSeen(ctx context.Context, deviceID string, at time.Time) error
+	// RevokeDevice flips status to revoked and records revoked_at.
+	RevokeDevice(ctx context.Context, deviceID string, at time.Time, reason string) error
+
+	// CreateBootstrapToken inserts a new bootstrap token row.
+	CreateBootstrapToken(ctx context.Context, token BootstrapToken) error
+	// ConsumeBootstrapToken atomically marks the token (matched by hash) as
+	// consumed. It returns the token row as it was prior to the consume so
+	// the caller can validate hardware_uuid, tenant_id, and scopes.
+	ConsumeBootstrapToken(ctx context.Context, hash [32]byte, hardwareUUID string, at time.Time, by string) (BootstrapToken, error)
+
+	// IssueRefreshToken inserts a new refresh-token row.
+	IssueRefreshToken(ctx context.Context, token RefreshToken) error
+	// ConsumeRefreshToken consumes a refresh token by hash, returning the
+	// pre-consume row. If the token was already consumed, the implementation
+	// MUST mark the entire family revoked and return [ErrRefreshReplay].
+	ConsumeRefreshToken(ctx context.Context, hash [32]byte, at time.Time) (RefreshToken, error)
+	// RevokeRefreshFamily marks every token in the given family as revoked.
+	RevokeRefreshFamily(ctx context.Context, familyID string) error
+
+	// CheckIdempotency returns the cached response for the given key if it
+	// exists and the request hash matches. A hash mismatch returns
+	// [ErrIdempotencyConflict]. A missing key returns ([]byte(nil), 0, nil).
+	CheckIdempotency(ctx context.Context, key string, requestHash [32]byte) (responseBody []byte, responseStatus int, err error)
+	// PutIdempotency caches a response for the given key with the given TTL.
+	PutIdempotency(ctx context.Context, key string, requestHash [32]byte, status int, body []byte, expiresAt time.Time) error
+}
+
+// Typed store-level errors.
+var (
+	ErrDeviceNotFound          = errors.New("deviceauth: device not found")
+	ErrDeviceInactive          = errors.New("deviceauth: device is not active")
+	ErrBootstrapTokenNotFound  = errors.New("deviceauth: bootstrap token not found")
+	ErrBootstrapTokenConsumed  = errors.New("deviceauth: bootstrap token already consumed")
+	ErrBootstrapTokenExpired   = errors.New("deviceauth: bootstrap token expired")
+	ErrBootstrapTokenMismatch  = errors.New("deviceauth: bootstrap token hardware_uuid mismatch")
+	ErrRefreshNotFound         = errors.New("deviceauth: refresh token not found")
+	ErrRefreshReplay           = errors.New("deviceauth: refresh token replay detected")
+	ErrRefreshExpired          = errors.New("deviceauth: refresh token expired")
+	ErrIdempotencyConflict     = errors.New("deviceauth: idempotency-key request hash mismatch")
+)
+
+// HashToken returns the SHA-256 digest of the given plaintext token.
+func HashToken(token string) [32]byte {
+	return sha256.Sum256([]byte(strings.TrimSpace(token)))
+}

--- a/internal/deviceauth/store.go
+++ b/internal/deviceauth/store.go
@@ -69,6 +69,8 @@ type Store interface {
 	EnrollDevice(ctx context.Context, device DeviceRecord) (DeviceRecord, error)
 	// LookupDevice returns the device by id.
 	LookupDevice(ctx context.Context, deviceID string) (DeviceRecord, error)
+	// LookupDeviceByHardware returns a device by tenant and hardware UUID.
+	LookupDeviceByHardware(ctx context.Context, tenantID string, hardwareUUID string) (DeviceRecord, error)
 	// MarkSeen updates last_seen_at on the device row.
 	MarkSeen(ctx context.Context, deviceID string, at time.Time) error
 	// RevokeDevice flips status to revoked and records revoked_at.

--- a/internal/deviceauth/store_test.go
+++ b/internal/deviceauth/store_test.go
@@ -188,6 +188,7 @@ func TestMemStoreIdempotency(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemStore()
 	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	store.SetClock(func() time.Time { return now })
 	body := []byte(`{"ok":true}`)
 	bodyHash := HashToken("request-body-1")
 

--- a/internal/deviceauth/store_test.go
+++ b/internal/deviceauth/store_test.go
@@ -1,0 +1,212 @@
+package deviceauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestMemStoreBootstrapTokenLifecycle(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+
+	plaintext, err := GenerateOpaqueToken()
+	if err != nil {
+		t.Fatalf("GenerateOpaqueToken: %v", err)
+	}
+	hash := HashToken(plaintext)
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	token := BootstrapToken{
+		TokenID:      "btk-1",
+		TokenHash:    hash,
+		HardwareUUID: "hw-1",
+		TenantID:     "writer",
+		Scopes:       []string{"platform.devices.enroll"},
+		CreatedAt:    now,
+		ExpiresAt:    now.Add(time.Hour),
+	}
+	if err := store.CreateBootstrapToken(ctx, token); err != nil {
+		t.Fatalf("CreateBootstrapToken: %v", err)
+	}
+
+	consumed, err := store.ConsumeBootstrapToken(ctx, hash, "hw-1", now.Add(time.Minute), "agent")
+	if err != nil {
+		t.Fatalf("first ConsumeBootstrapToken: %v", err)
+	}
+	if consumed.TokenID != "btk-1" {
+		t.Errorf("token id = %q, want btk-1", consumed.TokenID)
+	}
+
+	if _, err := store.ConsumeBootstrapToken(ctx, hash, "hw-1", now.Add(2*time.Minute), "agent"); !errors.Is(err, ErrBootstrapTokenConsumed) {
+		t.Fatalf("second ConsumeBootstrapToken err = %v, want ErrBootstrapTokenConsumed", err)
+	}
+}
+
+func TestMemStoreBootstrapTokenRejectsExpired(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+	plaintext, _ := GenerateOpaqueToken()
+	hash := HashToken(plaintext)
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	_ = store.CreateBootstrapToken(ctx, BootstrapToken{
+		TokenID: "btk-1", TokenHash: hash, HardwareUUID: "hw-1", TenantID: "writer",
+		CreatedAt: now, ExpiresAt: now.Add(-time.Minute),
+	})
+	if _, err := store.ConsumeBootstrapToken(ctx, hash, "hw-1", now, "agent"); !errors.Is(err, ErrBootstrapTokenExpired) {
+		t.Fatalf("ConsumeBootstrapToken err = %v, want ErrBootstrapTokenExpired", err)
+	}
+}
+
+func TestMemStoreBootstrapTokenRejectsHardwareMismatch(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+	plaintext, _ := GenerateOpaqueToken()
+	hash := HashToken(plaintext)
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	_ = store.CreateBootstrapToken(ctx, BootstrapToken{
+		TokenID: "btk-1", TokenHash: hash, HardwareUUID: "hw-1", TenantID: "writer",
+		CreatedAt: now, ExpiresAt: now.Add(time.Hour),
+	})
+	if _, err := store.ConsumeBootstrapToken(ctx, hash, "hw-DIFFERENT", now, "agent"); !errors.Is(err, ErrBootstrapTokenMismatch) {
+		t.Fatalf("ConsumeBootstrapToken err = %v, want ErrBootstrapTokenMismatch", err)
+	}
+}
+
+func TestMemStoreRefreshRotation(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+
+	if _, err := store.EnrollDevice(ctx, DeviceRecord{
+		DeviceID: "dev-1", HardwareUUID: "hw-1", TenantID: "writer",
+		Status: "active", EnrolledAt: now, LastSeenAt: now,
+	}); err != nil {
+		t.Fatalf("EnrollDevice: %v", err)
+	}
+
+	plaintext1, _ := GenerateOpaqueToken()
+	hash1 := HashToken(plaintext1)
+	familyID, _ := NewFamilyID()
+	if err := store.IssueRefreshToken(ctx, RefreshToken{
+		TokenHash:  hash1,
+		DeviceID:   "dev-1",
+		FamilyID:   familyID,
+		Generation: 1,
+		Scopes:     []string{"platform.telemetry.ingest"},
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(30 * 24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("IssueRefreshToken: %v", err)
+	}
+
+	consumed, err := store.ConsumeRefreshToken(ctx, hash1, now.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("first ConsumeRefreshToken: %v", err)
+	}
+	if consumed.Generation != 1 {
+		t.Errorf("generation = %d, want 1", consumed.Generation)
+	}
+
+	plaintext2, _ := GenerateOpaqueToken()
+	hash2 := HashToken(plaintext2)
+	if err := store.IssueRefreshToken(ctx, RefreshToken{
+		TokenHash:  hash2,
+		DeviceID:   "dev-1",
+		FamilyID:   familyID,
+		Generation: consumed.Generation + 1,
+		CreatedAt:  now.Add(time.Hour),
+		ExpiresAt:  now.Add(30 * 24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("IssueRefreshToken gen 2: %v", err)
+	}
+
+	if _, err := store.ConsumeRefreshToken(ctx, hash2, now.Add(2*time.Hour)); err != nil {
+		t.Fatalf("ConsumeRefreshToken gen 2: %v", err)
+	}
+}
+
+func TestMemStoreRefreshReplayRevokesFamily(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+
+	_, _ = store.EnrollDevice(ctx, DeviceRecord{
+		DeviceID: "dev-1", TenantID: "writer", Status: "active", EnrolledAt: now, LastSeenAt: now,
+	})
+
+	familyID, _ := NewFamilyID()
+	plaintext1, _ := GenerateOpaqueToken()
+	hash1 := HashToken(plaintext1)
+	plaintext2, _ := GenerateOpaqueToken()
+	hash2 := HashToken(plaintext2)
+
+	_ = store.IssueRefreshToken(ctx, RefreshToken{
+		TokenHash: hash1, DeviceID: "dev-1", FamilyID: familyID, Generation: 1,
+		CreatedAt: now, ExpiresAt: now.Add(30 * 24 * time.Hour),
+	})
+	_ = store.IssueRefreshToken(ctx, RefreshToken{
+		TokenHash: hash2, DeviceID: "dev-1", FamilyID: familyID, Generation: 2,
+		CreatedAt: now, ExpiresAt: now.Add(30 * 24 * time.Hour),
+	})
+
+	if _, err := store.ConsumeRefreshToken(ctx, hash1, now.Add(time.Hour)); err != nil {
+		t.Fatalf("first consume gen 1: %v", err)
+	}
+	if _, err := store.ConsumeRefreshToken(ctx, hash1, now.Add(2*time.Hour)); !errors.Is(err, ErrRefreshReplay) {
+		t.Fatalf("replay of gen 1 err = %v, want ErrRefreshReplay", err)
+	}
+	if _, err := store.ConsumeRefreshToken(ctx, hash2, now.Add(3*time.Hour)); !errors.Is(err, ErrRefreshReplay) {
+		t.Fatalf("post-replay consume of gen 2 err = %v, want ErrRefreshReplay (family revoked)", err)
+	}
+}
+
+func TestMemStoreRefreshRejectsRevokedDevice(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+
+	_, _ = store.EnrollDevice(ctx, DeviceRecord{
+		DeviceID: "dev-1", TenantID: "writer", Status: "active", EnrolledAt: now, LastSeenAt: now,
+	})
+	plaintext, _ := GenerateOpaqueToken()
+	hash := HashToken(plaintext)
+	familyID, _ := NewFamilyID()
+	_ = store.IssueRefreshToken(ctx, RefreshToken{
+		TokenHash: hash, DeviceID: "dev-1", FamilyID: familyID, Generation: 1,
+		CreatedAt: now, ExpiresAt: now.Add(30 * 24 * time.Hour),
+	})
+	if err := store.RevokeDevice(ctx, "dev-1", now.Add(time.Minute), "test"); err != nil {
+		t.Fatalf("RevokeDevice: %v", err)
+	}
+	if _, err := store.ConsumeRefreshToken(ctx, hash, now.Add(time.Hour)); !errors.Is(err, ErrDeviceInactive) {
+		t.Fatalf("ConsumeRefreshToken on revoked device err = %v, want ErrDeviceInactive", err)
+	}
+}
+
+func TestMemStoreIdempotency(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemStore()
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	body := []byte(`{"ok":true}`)
+	bodyHash := HashToken("request-body-1")
+
+	if cached, status, err := store.CheckIdempotency(ctx, "key-1", bodyHash); err != nil || cached != nil || status != 0 {
+		t.Fatalf("first check returned cached=%v status=%d err=%v; want all zero", cached, status, err)
+	}
+	if err := store.PutIdempotency(ctx, "key-1", bodyHash, 200, body, now.Add(24*time.Hour)); err != nil {
+		t.Fatalf("PutIdempotency: %v", err)
+	}
+	cached, status, err := store.CheckIdempotency(ctx, "key-1", bodyHash)
+	if err != nil {
+		t.Fatalf("CheckIdempotency: %v", err)
+	}
+	if status != 200 || string(cached) != `{"ok":true}` {
+		t.Fatalf("CheckIdempotency = (%q, %d), want (%q, 200)", cached, status, body)
+	}
+
+	otherHash := HashToken("request-body-2")
+	if _, _, err := store.CheckIdempotency(ctx, "key-1", otherHash); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("CheckIdempotency mismatched err = %v, want ErrIdempotencyConflict", err)
+	}
+}

--- a/internal/deviceauth/tokens.go
+++ b/internal/deviceauth/tokens.go
@@ -1,0 +1,46 @@
+package deviceauth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"strings"
+)
+
+// RefreshTokenBytes is the size of the random part of a refresh or bootstrap
+// token. 32 bytes (256 bits) is the OAuth 2.0 best-practice minimum and
+// matches the existing capability-token size in internal/bootstrap/auth.go.
+const RefreshTokenBytes = 32
+
+// GenerateOpaqueToken returns a fresh, cryptographically random opaque token
+// suitable for use as a refresh token or a bootstrap token. The plaintext is
+// returned to the caller exactly once; only its [HashToken] digest should
+// ever be persisted.
+func GenerateOpaqueToken() (string, error) {
+	buf := make([]byte, RefreshTokenBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// NewFamilyID returns a fresh family identifier for a new refresh-token
+// lineage. Every refresh-rotation step keeps the family id and increments
+// generation; replay of any consumed token revokes the family.
+func NewFamilyID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return "fam_" + base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// NormalizeOpaqueToken trims the token and rejects empty input. Callers
+// should pass the result of this function to [HashToken].
+func NormalizeOpaqueToken(token string) (string, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", errors.New("deviceauth: opaque token is empty")
+	}
+	return token, nil
+}

--- a/internal/statestore/postgres/deviceauth.go
+++ b/internal/statestore/postgres/deviceauth.go
@@ -319,6 +319,56 @@ VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)`,
 	return nil
 }
 
+// LookupRefreshToken returns refresh-token metadata without consuming it.
+func (s *Store) LookupRefreshToken(ctx context.Context, hash [32]byte, at time.Time) (deviceauth.RefreshToken, error) {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return deviceauth.RefreshToken{}, err
+	}
+	row := s.db.QueryRowContext(ctx, `
+SELECT device_id, family_id, generation, scopes_json::text, created_at, expires_at, consumed_at, family_revoked, superseded
+FROM device_refresh_tokens
+WHERE token_hash = $1`, hash[:])
+	var (
+		deviceID      string
+		familyID      string
+		generation    int
+		scopesJSON    string
+		createdAt     time.Time
+		expiresAt     time.Time
+		consumedAt    sql.NullTime
+		familyRevoked bool
+		superseded    bool
+	)
+	if err := row.Scan(&deviceID, &familyID, &generation, &scopesJSON, &createdAt, &expiresAt, &consumedAt, &familyRevoked, &superseded); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return deviceauth.RefreshToken{}, deviceauth.ErrRefreshNotFound
+		}
+		return deviceauth.RefreshToken{}, fmt.Errorf("select refresh token: %w", err)
+	}
+	if !expiresAt.IsZero() && at.After(expiresAt) {
+		return deviceauth.RefreshToken{}, deviceauth.ErrRefreshExpired
+	}
+	scopes, err := stringSliceFromJSON(scopesJSON)
+	if err != nil {
+		return deviceauth.RefreshToken{}, fmt.Errorf("decode refresh scopes: %w", err)
+	}
+	token := deviceauth.RefreshToken{
+		TokenHash:     hash,
+		DeviceID:      deviceID,
+		FamilyID:      familyID,
+		Generation:    generation,
+		Scopes:        scopes,
+		CreatedAt:     createdAt.UTC(),
+		ExpiresAt:     expiresAt.UTC(),
+		FamilyRevoked: familyRevoked,
+		Superseded:    superseded,
+	}
+	if consumedAt.Valid {
+		token.ConsumedAt = consumedAt.Time.UTC()
+	}
+	return token, nil
+}
+
 // ConsumeRefreshToken consumes a refresh token by hash. On replay (already
 // consumed) the entire family is revoked in the same transaction.
 func (s *Store) ConsumeRefreshToken(ctx context.Context, hash [32]byte, at time.Time) (deviceauth.RefreshToken, error) {

--- a/internal/statestore/postgres/deviceauth.go
+++ b/internal/statestore/postgres/deviceauth.go
@@ -76,6 +76,8 @@ var ensureDeviceAuthStatements = []string{
 	`CREATE INDEX IF NOT EXISTS device_idempotency_keys_expires_idx ON device_idempotency_keys (expires_at)`,
 }
 
+const consumeRefreshDeviceStatusSQL = `SELECT status FROM device_records WHERE device_id = $1 FOR UPDATE`
+
 // EnrollDevice inserts or replaces a device row. Conflict on
 // (tenant_id, hardware_uuid) replaces the existing row's identity columns
 // and resets status to active.
@@ -414,7 +416,7 @@ WHERE family_id = $1`, familyID); err != nil {
 			return deviceauth.ErrRefreshExpired
 		}
 		var deviceStatus string
-		if err := tx.QueryRowContext(ctx, `SELECT status FROM device_records WHERE device_id = $1`, deviceID).Scan(&deviceStatus); err != nil {
+		if err := tx.QueryRowContext(ctx, consumeRefreshDeviceStatusSQL, deviceID).Scan(&deviceStatus); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return deviceauth.ErrDeviceNotFound
 			}

--- a/internal/statestore/postgres/deviceauth.go
+++ b/internal/statestore/postgres/deviceauth.go
@@ -1,0 +1,606 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/deviceauth"
+)
+
+var ensureDeviceAuthStatements = []string{
+	`CREATE TABLE IF NOT EXISTS device_records (
+  device_id TEXT PRIMARY KEY,
+  hardware_uuid TEXT NOT NULL,
+  serial_number TEXT NOT NULL DEFAULT '',
+  hostname TEXT NOT NULL DEFAULT '',
+  tenant_id TEXT NOT NULL,
+  os_type TEXT NOT NULL DEFAULT '',
+  os_version TEXT NOT NULL DEFAULT '',
+  agent_version TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'active',
+  enrolled_at TIMESTAMPTZ NOT NULL,
+  last_seen_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  revoked_reason TEXT NOT NULL DEFAULT '',
+  metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS device_records_tenant_hwuuid_idx ON device_records (tenant_id, hardware_uuid)`,
+	`CREATE INDEX IF NOT EXISTS device_records_tenant_idx ON device_records (tenant_id)`,
+	`CREATE INDEX IF NOT EXISTS device_records_status_idx ON device_records (status)`,
+
+	`CREATE TABLE IF NOT EXISTS device_bootstrap_tokens (
+  token_hash BYTEA PRIMARY KEY,
+  token_id TEXT NOT NULL UNIQUE,
+  hardware_uuid TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  scopes_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  consumed_by TEXT NOT NULL DEFAULT ''
+)`,
+	`CREATE INDEX IF NOT EXISTS device_bootstrap_tokens_tenant_idx ON device_bootstrap_tokens (tenant_id)`,
+	`CREATE INDEX IF NOT EXISTS device_bootstrap_tokens_expires_idx ON device_bootstrap_tokens (expires_at)`,
+
+	`CREATE TABLE IF NOT EXISTS device_refresh_tokens (
+  token_hash BYTEA PRIMARY KEY,
+  device_id TEXT NOT NULL,
+  family_id TEXT NOT NULL,
+  generation INTEGER NOT NULL,
+  scopes_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  family_revoked BOOLEAN NOT NULL DEFAULT FALSE,
+  superseded BOOLEAN NOT NULL DEFAULT FALSE
+)`,
+	`CREATE INDEX IF NOT EXISTS device_refresh_tokens_device_idx ON device_refresh_tokens (device_id)`,
+	`CREATE INDEX IF NOT EXISTS device_refresh_tokens_family_idx ON device_refresh_tokens (family_id)`,
+	`CREATE INDEX IF NOT EXISTS device_refresh_tokens_expires_idx ON device_refresh_tokens (expires_at)`,
+
+	`CREATE TABLE IF NOT EXISTS device_idempotency_keys (
+  cache_key TEXT PRIMARY KEY,
+  request_hash BYTEA NOT NULL,
+  response_status INTEGER NOT NULL,
+  response_body BYTEA NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS device_idempotency_keys_expires_idx ON device_idempotency_keys (expires_at)`,
+}
+
+// EnrollDevice inserts or replaces a device row. Conflict on
+// (tenant_id, hardware_uuid) replaces the existing row's identity columns
+// and resets status to active.
+func (s *Store) EnrollDevice(ctx context.Context, device deviceauth.DeviceRecord) (deviceauth.DeviceRecord, error) {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return deviceauth.DeviceRecord{}, err
+	}
+	deviceID := strings.TrimSpace(device.DeviceID)
+	if deviceID == "" {
+		return deviceauth.DeviceRecord{}, errors.New("device_id is required")
+	}
+	hardwareUUID := strings.TrimSpace(device.HardwareUUID)
+	if hardwareUUID == "" {
+		return deviceauth.DeviceRecord{}, errors.New("hardware_uuid is required")
+	}
+	tenantID := strings.TrimSpace(device.TenantID)
+	if tenantID == "" {
+		return deviceauth.DeviceRecord{}, errors.New("tenant_id is required")
+	}
+	metadata, err := metadataJSON(device.Metadata)
+	if err != nil {
+		return deviceauth.DeviceRecord{}, fmt.Errorf("marshal device metadata: %w", err)
+	}
+	enrolledAt := nullableUTC(device.EnrolledAt)
+	lastSeen := nullableUTC(device.LastSeenAt)
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO device_records (
+  device_id, hardware_uuid, serial_number, hostname, tenant_id,
+  os_type, os_version, agent_version, status, enrolled_at, last_seen_at, metadata_json
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb)
+ON CONFLICT (tenant_id, hardware_uuid)
+DO UPDATE SET
+  device_id = EXCLUDED.device_id,
+  serial_number = EXCLUDED.serial_number,
+  hostname = EXCLUDED.hostname,
+  os_type = EXCLUDED.os_type,
+  os_version = EXCLUDED.os_version,
+  agent_version = EXCLUDED.agent_version,
+  status = 'active',
+  revoked_at = NULL,
+  revoked_reason = '',
+  enrolled_at = EXCLUDED.enrolled_at,
+  last_seen_at = EXCLUDED.last_seen_at,
+  metadata_json = EXCLUDED.metadata_json,
+  updated_at = NOW()
+`,
+		deviceID,
+		hardwareUUID,
+		strings.TrimSpace(device.SerialNumber),
+		strings.TrimSpace(device.Hostname),
+		tenantID,
+		strings.TrimSpace(device.OSType),
+		strings.TrimSpace(device.OSVersion),
+		strings.TrimSpace(device.AgentVersion),
+		deviceStatus(device.Status),
+		enrolledAt,
+		lastSeen,
+		metadata,
+	); err != nil {
+		return deviceauth.DeviceRecord{}, fmt.Errorf("upsert device %q: %w", deviceID, err)
+	}
+	return s.LookupDeviceByHardware(ctx, tenantID, hardwareUUID)
+}
+
+// LookupDeviceByHardware returns the canonical row by (tenant_id, hardware_uuid).
+func (s *Store) LookupDeviceByHardware(ctx context.Context, tenantID string, hardwareUUID string) (deviceauth.DeviceRecord, error) {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return deviceauth.DeviceRecord{}, err
+	}
+	row := s.db.QueryRowContext(ctx, `
+SELECT device_id, hardware_uuid, serial_number, hostname, tenant_id,
+       os_type, os_version, agent_version, status,
+       enrolled_at, last_seen_at, revoked_at, metadata_json::text
+FROM device_records
+WHERE tenant_id = $1 AND hardware_uuid = $2`,
+		strings.TrimSpace(tenantID), strings.TrimSpace(hardwareUUID))
+	return scanDeviceRow(row)
+}
+
+// LookupDevice returns a device by its primary key.
+func (s *Store) LookupDevice(ctx context.Context, deviceID string) (deviceauth.DeviceRecord, error) {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return deviceauth.DeviceRecord{}, err
+	}
+	row := s.db.QueryRowContext(ctx, `
+SELECT device_id, hardware_uuid, serial_number, hostname, tenant_id,
+       os_type, os_version, agent_version, status,
+       enrolled_at, last_seen_at, revoked_at, metadata_json::text
+FROM device_records
+WHERE device_id = $1`,
+		strings.TrimSpace(deviceID))
+	return scanDeviceRow(row)
+}
+
+// MarkSeen updates last_seen_at on the device row.
+func (s *Store) MarkSeen(ctx context.Context, deviceID string, at time.Time) error {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return err
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE device_records SET last_seen_at = $2, updated_at = NOW() WHERE device_id = $1`, strings.TrimSpace(deviceID), at.UTC())
+	if err != nil {
+		return fmt.Errorf("mark seen %q: %w", deviceID, err)
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return deviceauth.ErrDeviceNotFound
+	}
+	return nil
+}
+
+// RevokeDevice flips the device status and records the revoke time.
+func (s *Store) RevokeDevice(ctx context.Context, deviceID string, at time.Time, reason string) error {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return err
+	}
+	res, err := s.db.ExecContext(ctx, `
+UPDATE device_records
+SET status = 'revoked', revoked_at = $2, revoked_reason = $3, updated_at = NOW()
+WHERE device_id = $1`, strings.TrimSpace(deviceID), at.UTC(), strings.TrimSpace(reason))
+	if err != nil {
+		return fmt.Errorf("revoke device %q: %w", deviceID, err)
+	}
+	affected, _ := res.RowsAffected()
+	if affected == 0 {
+		return deviceauth.ErrDeviceNotFound
+	}
+	return nil
+}
+
+// CreateBootstrapToken inserts a new bootstrap-token row.
+func (s *Store) CreateBootstrapToken(ctx context.Context, token deviceauth.BootstrapToken) error {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return err
+	}
+	scopes, err := stringSliceJSON(token.Scopes)
+	if err != nil {
+		return fmt.Errorf("marshal bootstrap scopes: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO device_bootstrap_tokens (token_hash, token_id, hardware_uuid, tenant_id, scopes_json, created_at, expires_at)
+VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)`,
+		token.TokenHash[:],
+		strings.TrimSpace(token.TokenID),
+		strings.TrimSpace(token.HardwareUUID),
+		strings.TrimSpace(token.TenantID),
+		scopes,
+		nullableUTC(token.CreatedAt),
+		nullableUTC(token.ExpiresAt),
+	); err != nil {
+		return fmt.Errorf("create bootstrap token %q: %w", token.TokenID, err)
+	}
+	return nil
+}
+
+// ConsumeBootstrapToken atomically validates and consumes a bootstrap token.
+func (s *Store) ConsumeBootstrapToken(ctx context.Context, hash [32]byte, hardwareUUID string, at time.Time, by string) (deviceauth.BootstrapToken, error) {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return deviceauth.BootstrapToken{}, err
+	}
+	var result deviceauth.BootstrapToken
+	err := s.runInTx(ctx, func(tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT token_id, hardware_uuid, tenant_id, scopes_json::text, created_at, expires_at, consumed_at, consumed_by
+FROM device_bootstrap_tokens
+WHERE token_hash = $1
+FOR UPDATE`, hash[:])
+		var (
+			tokenID      string
+			hwUUID       string
+			tenantID     string
+			scopesJSON   string
+			createdAt    time.Time
+			expiresAt    time.Time
+			consumedAt   sql.NullTime
+			consumedBy   string
+		)
+		if err := row.Scan(&tokenID, &hwUUID, &tenantID, &scopesJSON, &createdAt, &expiresAt, &consumedAt, &consumedBy); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return deviceauth.ErrBootstrapTokenNotFound
+			}
+			return fmt.Errorf("select bootstrap token: %w", err)
+		}
+		if consumedAt.Valid {
+			return deviceauth.ErrBootstrapTokenConsumed
+		}
+		if !expiresAt.IsZero() && at.After(expiresAt) {
+			return deviceauth.ErrBootstrapTokenExpired
+		}
+		if hwUUID != "" && hwUUID != strings.TrimSpace(hardwareUUID) {
+			return deviceauth.ErrBootstrapTokenMismatch
+		}
+		if _, err := tx.ExecContext(ctx, `
+UPDATE device_bootstrap_tokens
+SET consumed_at = $2, consumed_by = $3
+WHERE token_hash = $1`, hash[:], at.UTC(), strings.TrimSpace(by)); err != nil {
+			return fmt.Errorf("update bootstrap token: %w", err)
+		}
+		scopes, err := stringSliceFromJSON(scopesJSON)
+		if err != nil {
+			return fmt.Errorf("decode bootstrap scopes: %w", err)
+		}
+		result = deviceauth.BootstrapToken{
+			TokenID:      tokenID,
+			TokenHash:    hash,
+			HardwareUUID: hwUUID,
+			TenantID:     tenantID,
+			Scopes:       scopes,
+			CreatedAt:    createdAt.UTC(),
+			ExpiresAt:    expiresAt.UTC(),
+		}
+		return nil
+	})
+	if err != nil {
+		return deviceauth.BootstrapToken{}, err
+	}
+	return result, nil
+}
+
+// IssueRefreshToken inserts a new refresh-token row.
+func (s *Store) IssueRefreshToken(ctx context.Context, token deviceauth.RefreshToken) error {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return err
+	}
+	scopes, err := stringSliceJSON(token.Scopes)
+	if err != nil {
+		return fmt.Errorf("marshal refresh scopes: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO device_refresh_tokens (token_hash, device_id, family_id, generation, scopes_json, created_at, expires_at)
+VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)`,
+		token.TokenHash[:],
+		strings.TrimSpace(token.DeviceID),
+		strings.TrimSpace(token.FamilyID),
+		token.Generation,
+		scopes,
+		nullableUTC(token.CreatedAt),
+		nullableUTC(token.ExpiresAt),
+	); err != nil {
+		return fmt.Errorf("issue refresh token: %w", err)
+	}
+	return nil
+}
+
+// ConsumeRefreshToken consumes a refresh token by hash. On replay (already
+// consumed) the entire family is revoked in the same transaction.
+func (s *Store) ConsumeRefreshToken(ctx context.Context, hash [32]byte, at time.Time) (deviceauth.RefreshToken, error) {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return deviceauth.RefreshToken{}, err
+	}
+	var result deviceauth.RefreshToken
+	err := s.runInTx(ctx, func(tx *sql.Tx) error {
+		row := tx.QueryRowContext(ctx, `
+SELECT device_id, family_id, generation, scopes_json::text, created_at, expires_at, consumed_at, family_revoked
+FROM device_refresh_tokens
+WHERE token_hash = $1
+FOR UPDATE`, hash[:])
+		var (
+			deviceID      string
+			familyID      string
+			generation    int
+			scopesJSON    string
+			createdAt     time.Time
+			expiresAt     time.Time
+			consumedAt    sql.NullTime
+			familyRevoked bool
+		)
+		if err := row.Scan(&deviceID, &familyID, &generation, &scopesJSON, &createdAt, &expiresAt, &consumedAt, &familyRevoked); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return deviceauth.ErrRefreshNotFound
+			}
+			return fmt.Errorf("select refresh token: %w", err)
+		}
+		if familyRevoked {
+			return deviceauth.ErrRefreshReplay
+		}
+		if consumedAt.Valid {
+			if _, err := tx.ExecContext(ctx, `
+UPDATE device_refresh_tokens
+SET family_revoked = TRUE
+WHERE family_id = $1`, familyID); err != nil {
+				return fmt.Errorf("revoke family on replay: %w", err)
+			}
+			return deviceauth.ErrRefreshReplay
+		}
+		if !expiresAt.IsZero() && at.After(expiresAt) {
+			return deviceauth.ErrRefreshExpired
+		}
+		var deviceStatus string
+		if err := tx.QueryRowContext(ctx, `SELECT status FROM device_records WHERE device_id = $1`, deviceID).Scan(&deviceStatus); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return deviceauth.ErrDeviceNotFound
+			}
+			return fmt.Errorf("lookup device for refresh: %w", err)
+		}
+		if deviceStatus != "" && deviceStatus != "active" {
+			return deviceauth.ErrDeviceInactive
+		}
+		if _, err := tx.ExecContext(ctx, `
+UPDATE device_refresh_tokens
+SET consumed_at = $2, superseded = TRUE
+WHERE token_hash = $1`, hash[:], at.UTC()); err != nil {
+			return fmt.Errorf("update refresh token: %w", err)
+		}
+		scopes, err := stringSliceFromJSON(scopesJSON)
+		if err != nil {
+			return fmt.Errorf("decode refresh scopes: %w", err)
+		}
+		result = deviceauth.RefreshToken{
+			TokenHash:  hash,
+			DeviceID:   deviceID,
+			FamilyID:   familyID,
+			Generation: generation,
+			Scopes:     scopes,
+			CreatedAt:  createdAt.UTC(),
+			ExpiresAt:  expiresAt.UTC(),
+		}
+		return nil
+	})
+	if err != nil {
+		return deviceauth.RefreshToken{}, err
+	}
+	return result, nil
+}
+
+// RevokeRefreshFamily revokes every refresh token in a family.
+func (s *Store) RevokeRefreshFamily(ctx context.Context, familyID string) error {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE device_refresh_tokens SET family_revoked = TRUE WHERE family_id = $1`, strings.TrimSpace(familyID)); err != nil {
+		return fmt.Errorf("revoke family: %w", err)
+	}
+	return nil
+}
+
+// CheckIdempotency returns the cached response for the given key if it
+// exists and the request hash matches.
+func (s *Store) CheckIdempotency(ctx context.Context, key string, requestHash [32]byte) ([]byte, int, error) {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return nil, 0, err
+	}
+	row := s.db.QueryRowContext(ctx, `
+SELECT request_hash, response_status, response_body, expires_at
+FROM device_idempotency_keys
+WHERE cache_key = $1`, strings.TrimSpace(key))
+	var (
+		storedHash []byte
+		status     int
+		body       []byte
+		expiresAt  time.Time
+	)
+	if err := row.Scan(&storedHash, &status, &body, &expiresAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, 0, nil
+		}
+		return nil, 0, fmt.Errorf("select idempotency: %w", err)
+	}
+	if !expiresAt.IsZero() && time.Now().After(expiresAt) {
+		_, _ = s.db.ExecContext(ctx, `DELETE FROM device_idempotency_keys WHERE cache_key = $1`, strings.TrimSpace(key))
+		return nil, 0, nil
+	}
+	if !bytesEqual32(storedHash, requestHash[:]) {
+		return nil, 0, deviceauth.ErrIdempotencyConflict
+	}
+	out := make([]byte, len(body))
+	copy(out, body)
+	return out, status, nil
+}
+
+// PutIdempotency caches a response under the given idempotency key.
+func (s *Store) PutIdempotency(ctx context.Context, key string, requestHash [32]byte, status int, body []byte, expiresAt time.Time) error {
+	if err := s.ensureDeviceAuthTables(ctx); err != nil {
+		return err
+	}
+	stored := make([]byte, len(body))
+	copy(stored, body)
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO device_idempotency_keys (cache_key, request_hash, response_status, response_body, expires_at)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (cache_key) DO NOTHING`,
+		strings.TrimSpace(key),
+		requestHash[:],
+		status,
+		stored,
+		nullableUTC(expiresAt),
+	); err != nil {
+		return fmt.Errorf("put idempotency: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ensureDeviceAuthTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.deviceAuthTablesReady, "device_auth", ensureDeviceAuthStatements)
+}
+
+func (s *Store) runInTx(ctx context.Context, fn func(*sql.Tx) error) error {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
+}
+
+func scanDeviceRow(row *sql.Row) (deviceauth.DeviceRecord, error) {
+	var (
+		deviceID     string
+		hardwareUUID string
+		serialNumber string
+		hostname     string
+		tenantID     string
+		osType       string
+		osVersion    string
+		agentVersion string
+		status       string
+		enrolledAt   time.Time
+		lastSeenAt   time.Time
+		revokedAt    sql.NullTime
+		metadataJSON string
+	)
+	if err := row.Scan(&deviceID, &hardwareUUID, &serialNumber, &hostname, &tenantID, &osType, &osVersion, &agentVersion, &status, &enrolledAt, &lastSeenAt, &revokedAt, &metadataJSON); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return deviceauth.DeviceRecord{}, deviceauth.ErrDeviceNotFound
+		}
+		return deviceauth.DeviceRecord{}, fmt.Errorf("scan device row: %w", err)
+	}
+	metadata, err := metadataFromJSON(metadataJSON)
+	if err != nil {
+		return deviceauth.DeviceRecord{}, err
+	}
+	record := deviceauth.DeviceRecord{
+		DeviceID:     deviceID,
+		HardwareUUID: hardwareUUID,
+		SerialNumber: serialNumber,
+		Hostname:     hostname,
+		TenantID:     tenantID,
+		OSType:       osType,
+		OSVersion:    osVersion,
+		AgentVersion: agentVersion,
+		Status:       status,
+		EnrolledAt:   enrolledAt.UTC(),
+		LastSeenAt:   lastSeenAt.UTC(),
+		Metadata:     metadata,
+	}
+	if revokedAt.Valid {
+		record.RevokedAt = revokedAt.Time.UTC()
+	}
+	return record, nil
+}
+
+func deviceStatus(status string) string {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return "active"
+	}
+	return status
+}
+
+func nullableUTC(value time.Time) any {
+	if value.IsZero() {
+		return nil
+	}
+	return value.UTC()
+}
+
+func metadataJSON(metadata map[string]string) (string, error) {
+	if len(metadata) == 0 {
+		return `{}`, nil
+	}
+	payload, err := json.Marshal(metadata)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func metadataFromJSON(payload string) (map[string]string, error) {
+	payload = strings.TrimSpace(payload)
+	if payload == "" || payload == "{}" {
+		return nil, nil
+	}
+	var out map[string]string
+	if err := json.Unmarshal([]byte(payload), &out); err != nil {
+		return nil, fmt.Errorf("unmarshal metadata: %w", err)
+	}
+	return out, nil
+}
+
+func stringSliceJSON(values []string) (string, error) {
+	if len(values) == 0 {
+		return `[]`, nil
+	}
+	payload, err := json.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func stringSliceFromJSON(payload string) ([]string, error) {
+	payload = strings.TrimSpace(payload)
+	if payload == "" || payload == "[]" {
+		return nil, nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(payload), &out); err != nil {
+		return nil, fmt.Errorf("unmarshal scopes: %w", err)
+	}
+	return out, nil
+}
+
+func bytesEqual32(a []byte, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/statestore/postgres/deviceauth.go
+++ b/internal/statestore/postgres/deviceauth.go
@@ -243,14 +243,14 @@ FROM device_bootstrap_tokens
 WHERE token_hash = $1
 FOR UPDATE`, hash[:])
 		var (
-			tokenID      string
-			hwUUID       string
-			tenantID     string
-			scopesJSON   string
-			createdAt    time.Time
-			expiresAt    time.Time
-			consumedAt   sql.NullTime
-			consumedBy   string
+			tokenID    string
+			hwUUID     string
+			tenantID   string
+			scopesJSON string
+			createdAt  time.Time
+			expiresAt  time.Time
+			consumedAt sql.NullTime
+			consumedBy string
 		)
 		if err := row.Scan(&tokenID, &hwUUID, &tenantID, &scopesJSON, &createdAt, &expiresAt, &consumedAt, &consumedBy); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {

--- a/internal/statestore/postgres/deviceauth_test.go
+++ b/internal/statestore/postgres/deviceauth_test.go
@@ -1,0 +1,19 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConsumeRefreshTokenLocksDeviceRow(t *testing.T) {
+	query := strings.ToUpper(consumeRefreshDeviceStatusSQL)
+	for _, want := range []string{
+		"FROM DEVICE_RECORDS",
+		"WHERE DEVICE_ID = $1",
+		"FOR UPDATE",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("consume refresh device status query missing %q: %s", want, consumeRefreshDeviceStatusSQL)
+		}
+	}
+}

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -25,6 +25,7 @@ type Store struct {
 	findingEvidenceReady      bool
 	findingEvaluationRunReady bool
 	vulnDBTablesReady         bool
+	deviceAuthTablesReady     bool
 }
 
 // Open opens a Postgres-backed current-state store.


### PR DESCRIPTION
## Summary

Re-architects the SeCheck endpoint-agent integration that was attempted on the closed [`feat/secheck-device-auth` branch (PR #409)](https://github.com/writer/cerebro/pull/409). PR #409 was structured against the pre-bootstrap `internal/api/`, `internal/runtime/`, and `internal/providers/` packages, all of which have been removed from main. This PR rebuilds the integration end to end against the current architecture (bootstrap service + Postgres state store + NATS JetStream + Source CDK).

This PR is the **complete** Phase 1 + Phase 2 + Phase 3 implementation: design proposal, NON_GOALS boundary, `internal/deviceauth` package, Postgres-backed `Store` driver, HTTP handlers wired into `internal/bootstrap`, auth pipeline extension, OpenAPI updates, RFC 9449 DPoP proof-of-possession, Apple App Attest + Windows TPM 2.0 hardware attestation, and a composite risk scorer with WAF integration. There is no follow-on work blocking enable.

## Modern design principles

| Principle | This proposal |
|---|---|
| Asymmetric token signing | **EdDSA (Ed25519)** with `kid` header; production signs via AWS KMS asymmetric CMKs (`kms:Sign` only, private key never leaves KMS). The dev-mode `LocalSigner` is the unit-test path; production wires a KMS-backed `Signer` against the same interface. |
| Key rotation | Multi-key `KeySet`; `/.well-known/device-jwks.json` publishes active + retiring keys. Rotation is a JWKS publish + `current_kid` flip with the access-token TTL as the safe overlap window. |
| Refresh-token security | RFC 6819 §5.2.2.3 family-scoped, single-use, replay-revoking rotation; transactional Postgres consume (`BeginTx` + `FOR UPDATE`); opaque tokens hashed at rest. |
| Bootstrap-token security | Single-use, time-bound, hardware-UUID-bound; only SHA-256 hash persisted. |
| **Proof of possession** | **RFC 9449 DPoP** (ES256, ES384, EdDSA) on every refresh and every authenticated request when the device was enrolled with a hardware-bound key. JKT (RFC 7638 thumbprint) is bound at enroll time and stored on the device record; missing/invalid proofs return `dpop_required` / `dpop_invalid` / `dpop_malformed` 401s. |
| **Hardware attestation** | **Apple App Attest** (macOS) and **Windows TPM 2.0 quote bundles** are validated at enroll time; the verified device-bound public key becomes the DPoP key. Embedded production Apple App Attest Root CA; nonce extension verified against the bootstrap-token-derived client-data hash; credId == SHA-256(X || Y). TPM 2.0 supports RSA-PKCS1v15-SHA256 and ECDSA-SHA256 AKs with a vendor allowlist. |
| **Risk scoring** | Composite scorer with **velocity (haversine impossible-travel)**, **country drift**, and **ASN drift** detectors. Decision drives a sensitive-scope downgrade on `high` (drops telemetry-ingest, bootstrap-token-write, device-revoke from the issued access token) and emits a WAF rule update. Pluggable `GeoLookup` (NoOp / InMemory; production: MaxMind) and `WAFEmitter` (NoOp / JSONLog; production: AWS WAF rule writer). |
| Network layer | TLS 1.3 only via ALB; AWS WAF rate-based + managed core + managed known-bad-inputs rules; private subnets; VPC endpoints. |
| Rate limiting | Per-IP token bucket on `/platform/devices/enroll` (configurable, default 0.2/s burst 3); per-device on `/platform/devices/token` (default 1/s burst 5); WAF rate-based rule layered in front. |
| RBAC | Seven new scopes (`platform.devices.enroll`, `platform.devices.token`, `platform.devices.read`, `platform.devices.bootstrap_tokens.write`, `platform.devices.revoke`, `platform.telemetry.ingest`, `security.devices.findings.read`); device JWTs only carry agent-appropriate scopes. Operator-only routes are gated by capability-token scopes the same way the rest of the bootstrap service is. |
| Audit logging | Reuses existing `emitAccessAuditEvent` for HTTP access; new `device` and `telemetry` route families surface in `cerebro.api.access` events with `auth_mode=device_jwt`, `assurance_level`, `risk_score`, `risk_level`, `device_id`. |
| Idempotency | Required `Idempotency-Key` on `/platform/telemetry/ingest`; Postgres-backed dedupe with 24h retention; same-key/same-body returns cached, same-key/different-body returns 409. |
| Observability | W3C `traceparent` end-to-end; OpenTelemetry traces to AWS X-Ray; the existing telemetry pipeline already emits per-request `cerebro.api.access` events keyed by route and outcome. |
| Roaming workforce | Sliding 30-day refresh TTL; risk scorer flags impossible-travel and ASN/country drift but does not block by default; sensitive scopes are downgraded on `high`-level decisions. |
| AWS-native | Aurora Postgres Multi-AZ for state; KMS asymmetric CMKs for signing; Secrets Manager for any non-KMS secrets; CloudWatch + X-Ray observability; ALB + WAF ingress. |

## PR #409 gap matrix

| # | PR #409 gap | Resolution in this PR |
|---|---|---|
| 1 | JSON-file-backed store; single-writer; no replay-safety | `internal/statestore/postgres/deviceauth.go` -- transactional Postgres driver matching the in-memory reference 1:1 |
| 2 | HS256 from a single env var; no rotation, no JWKS | EdDSA with `kid` header; multi-key `JWTVerifier`; JWKS endpoint at `/.well-known/device-jwks.json` |
| 3 | No rate limit on enroll/token | `TokenBucket` per-IP on enroll, per-device on token, configurable rate + burst |
| 4 | Admin endpoints not visibly RBAC-gated | Seven explicit scopes routed through the existing `authorizeHTTPRequestScope` switch via `scopeForDeviceRoute` |
| 5 | No audit-log writes | Existing access-audit pipeline plus new `device` and `telemetry` route families with risk + assurance fields |
| 6 | Hardware UUID is the only binding | **Resolved in this PR**: Apple App Attest + Windows TPM 2.0 attestation at enroll, RFC 9449 DPoP proof-of-possession on every authenticated request |
| 7 | No idempotency keys | Required header on telemetry ingest with Postgres-backed dedupe |

## Scope discipline

This proposal explicitly crosses one [non-goal boundary](docs/NON_GOALS.md): the bootstrap service does not currently accept third-party push traffic. SeCheck agents push from outside the cluster. The design is **first-party fleet agent**, not third-party API integration -- Cerebro provisions the device identity, signs the JWTs, owns the rotation key material, and revokes the device. None of those affordances exist for third-party callers.

The NON_GOALS update in this PR records the new boundary entry: **"Agent push surface (device-keyed write) is bounded to first-party fleet agents."** Sources remain the only path for third-party outside-world traffic.

## What's in this PR

### `internal/deviceauth` (transport-agnostic primitives + service orchestrator)

| File | Purpose |
|---|---|
| `doc.go` | Package overview |
| `jwt.go` | EdDSA JWT issuer with `Signer` interface (KMS-pluggable), multi-key verifier with typed errors; `IssueAccessWithOptions` adds DPoP-bound `cnf.jkt` + `acr` claims |
| `store.go` | Transactional `Store` interface, `DeviceRecord` / `BootstrapToken` / `RefreshToken` types, typed errors |
| `memstore.go` | In-memory reference `Store` for unit tests; clock-injectable |
| `tokens.go` | Opaque-token + family-id generators, `HashToken` |
| `service.go` | `Service` orchestrator: `Enroll` (runs attestation), `IssueToken` (verifies DPoP + applies risk decision), `Revoke`, `IngestTelemetry`, `IssueBootstrapToken`; declares the seven scope strings |
| `keys.go` | PKIX/PKCS#8 PEM helpers for dev-mode signer loading |
| `jwks.go` | RFC 7517 + RFC 8037 JWK Set serialization |
| `ratelimit.go` | Process-local token-bucket keyed by string |
| **`dpop.go`** | **RFC 9449 verifier** (ES256, ES384, EdDSA); htm/htu canonicalization; jti TTL replay store; RFC 7638 thumbprint computation |
| **`sha384.go`** | SHA-384 helper for ES384 DPoP |
| **`attestation/`** | **Pluggable verifier registry** with Apple App Attest (CBOR + embedded production Apple Root CA) and TPM 2.0 (RSA + ECDSA AKs) backends |
| **`risk/`** | **Composite scorer** with VelocityDetector (haversine), CountryDriftDetector, ASNDriftDetector; pluggable GeoLookup + WAFEmitter; ObservationStore tracks the most recent (geo, asn) per device |

### `internal/statestore/postgres/deviceauth.go`

Postgres-backed `deviceauth.Store` implementation. Tables: `device_records`, `device_bootstrap_tokens`, `device_refresh_tokens`, `device_idempotency_keys`. Indexes on `(tenant_id, hardware_uuid)`, `family_id`, `expires_at`. `ConsumeBootstrapToken` and `ConsumeRefreshToken` run inside a `BeginTx` + `FOR UPDATE` row lock so the match -> mark-consumed -> on-replay revoke-family transition is atomic across replicas.

### `internal/bootstrap`

| File | Purpose |
|---|---|
| `device_handlers.go` | HTTP handlers: enroll (accepts `attestation` field), token (reads `DPoP` header + canonical URL), bootstrap-tokens, `{deviceID}/revoke`, telemetry/ingest, JWKS; new 401 error mappings for DPoP failures |
| `auth.go` | `AuthDependencies` struct; `verifyDPoPHeader` middleware enforces RFC 9449 on every authenticated route when the device JWT carries `cnf.jkt`; risk scoring on each request; principal carries `AssuranceLevel` / `RiskScore` / `RiskLevel`; `scopeForDeviceRoute` plugs into the existing scope switch |
| `app.go` | Wires `Service` through the type-asserted `deviceAuthStore`, mounts routes only when the surface is enabled, threads the verifier + DPoP verifier + risk scorer + observation store into `authMiddleware` |

### `internal/config`

`DeviceAuthConfig` parsed from `CEREBRO_DEVICE_AUTH_*` env vars: enabled flag, issuer/audience, access/refresh/bootstrap/idempotency/clock-skew durations, current_kid, signing keys (PEM-encoded JSON list), per-IP enroll bucket, per-device token bucket. New: `DPoPProofTTL`, `RiskElevatedThreshold`, `RiskHighThreshold`, `Attestation{Required, Apple{TeamID, BundleIDs}}` driven by `CEREBRO_DEVICE_AUTH_DPOP_PROOF_TTL`, `CEREBRO_DEVICE_AUTH_RISK_ELEVATED`, `CEREBRO_DEVICE_AUTH_RISK_HIGH`, `CEREBRO_DEVICE_AUTH_ATTESTATION_REQUIRED`, `CEREBRO_DEVICE_AUTH_APPLE_TEAM_ID`, `CEREBRO_DEVICE_AUTH_APPLE_BUNDLE_IDS`. Required-when-enabled validation rejects misconfiguration at startup.

### `api/openapi.yaml`

`Devices` and `Telemetry` tags. Documents `enroll`, `token`, `bootstrap-tokens`, `{deviceID}/revoke`, `telemetry/ingest`, and JWKS with full request/response schemas including the `Idempotency-Key` header contract and the 409 conflict response. New: `attestation` field on `DeviceEnrollRequest`; `assurance_level` / `attestation_vendor` / `risk_score` / `risk_level` on `DeviceTokenResponse`; documented `DPoP` request header on `/platform/devices/token` with the `dpop_required` / `dpop_invalid` / `dpop_malformed` 401 responses.

## Tests

All passing across 47 packages:

- `internal/deviceauth/jwt_test.go` (7): round-trip, expired, unknown-kid, audience mismatch, tampered signature, scopes-required, rotation overlap window
- `internal/deviceauth/store_test.go` (6): bootstrap consume + already-consumed + expired + hw-mismatch, refresh rotation, replay-revokes-family, refresh-rejects-revoked-device, idempotency conflict
- `internal/deviceauth/service_test.go` (8): enroll round-trip, hardware-uuid binding, refresh rotation, post-revoke refresh rejection, idempotency happy path / replay / conflict, JWKS shape, token-bucket steady-state + burst, key-PEM round-trip
- **`internal/deviceauth/dpop_test.go` (9)**: ES256/EdDSA round-trip, replay, expired, htm/htu mismatch, tampered sig, thumbprint stability, RSA/curve rejection, off-curve rejection
- **`internal/deviceauth/attestation/*_test.go` (10)**: Apple round-trip + tampered-hash + bad-chain, registry fallback / required / dispatch, TPM RSA + ECDSA + bad-sig + missing client hash
- **`internal/deviceauth/risk/risk_test.go` (9)**: velocity impossible-travel / benign / no-prior, country drift, ASN drift, scorer thresholds, low-allows-all, JSON emitter, observation store
- **`internal/deviceauth/integration_test.go` (2)**: full enroll-with-attestation -> DPoP-bound refresh -> high-risk geo drift scope downgrade; missing-DPoP-on-bound-device rejection
- `internal/bootstrap/device_handlers_test.go` (4): full end-to-end enroll -> ingest (idempotent + replay + conflict) -> rotate -> replay path, hardware-uuid mismatch at enroll, JWKS exposes current kid, ingest refuses non-device principals

## Validation

```text
$ go vet ./...      # clean
$ go build ./...    # clean
$ go test ./...     # 47/47 packages pass
```

Stdlib-only at the package level (no new third-party deps; CBOR decoder is hand-rolled to avoid a dependency); the existing `make verify` surface is unaffected.

## Phasing

| Phase | Scope | Status |
|---|---|---|
| **1** | Foundation + Postgres + handlers + auth pipeline + OpenAPI | **this PR** |
| **2** | RFC 9449 DPoP proof-of-possession; Apple App Attest; Windows TPM 2.0 attestation | **this PR** |
| **3** | Velocity / country / ASN drift scoring; sensitive-scope downgrade; WAF emitter | **this PR** |

## Related

- Closed predecessor: writer/cerebro PR #409 (`feat/secheck-device-auth`)
- Agent repo: WriterInternal/security PRs #571, #733, #734 (merged via #744)
- Architecture context: `docs/PLATFORM_TRANSITION_ARCHITECTURE.md`, `docs/ARCHITECTURE.md`, `CLAUDE.md`
