### PR TITLE
fix: avoid unsupported finding replays

### DIFF
--- a/internal/findings/event_rule.go
+++ b/internal/findings/event_rule.go
@@ -174,7 +174,8 @@ func (r *eventRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
 	if r == nil || runtime == nil {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(runtime.GetSourceId()), strings.TrimSpace(r.config.sourceID))
+	return strings.EqualFold(strings.TrimSpace(runtime.GetSourceId()), strings.TrimSpace(r.config.sourceID)) &&
+		runtimeMayEmitEventKind(runtime, r.config.definition.EventKinds)
 }
 
 func (r *eventRule) RetiresOpenFindings() bool {

--- a/internal/findings/event_rule_test.go
+++ b/internal/findings/event_rule_test.go
@@ -32,6 +32,61 @@ func TestEventRuleScaffoldClonesSpecAndMatchesRuntimeSource(t *testing.T) {
 	}
 }
 
+func TestEventRuleScaffoldMatchesRuntimeEventFamily(t *testing.T) {
+	rule := newEventRule(eventRuleConfig{
+		definition: RuleDefinition{
+			ID:          "grc-vulnerability-rule",
+			Name:        "GRC Vulnerability Rule",
+			SourceID:    "grc",
+			EventKinds:  []string{"grc.vulnerability"},
+			OutputKind:  "finding.grc_vulnerability",
+			Severity:    "HIGH",
+			Status:      "open",
+			Description: "Detects GRC vulnerability events.",
+		},
+		match: func(*cerebrov1.EventEnvelope) bool { return false },
+		build: func(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+			return nil, nil
+		},
+	})
+
+	if !rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "grc", Config: map[string]string{"family": "vulnerability"}}) {
+		t.Fatal("SupportsRuntime(grc vulnerability) = false, want true")
+	}
+	if !rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "grc"}) {
+		t.Fatal("SupportsRuntime(grc without resolved family) = false, want true")
+	}
+	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "grc", Config: map[string]string{"family": "integration"}}) {
+		t.Fatal("SupportsRuntime(grc integration) = true, want false")
+	}
+	if !rule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "grc", Config: map[string]string{"family": "env:GRC_FAMILY"}}) {
+		t.Fatal("SupportsRuntime(env-backed family) = false, want true until runtime config is resolved")
+	}
+
+	githubAuditRule := newEventRule(eventRuleConfig{
+		definition: RuleDefinition{
+			ID:          "github-audit-rule",
+			Name:        "GitHub Audit Rule",
+			SourceID:    "github",
+			EventKinds:  []string{"github.audit"},
+			OutputKind:  "finding.github_audit",
+			Severity:    "HIGH",
+			Status:      "open",
+			Description: "Detects GitHub audit events.",
+		},
+		match: func(*cerebrov1.EventEnvelope) bool { return false },
+		build: func(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) (*ports.FindingRecord, error) {
+			return nil, nil
+		},
+	})
+	if githubAuditRule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "github"}) {
+		t.Fatal("SupportsRuntime(default github runtime) = true, want false for github.audit rule")
+	}
+	if !githubAuditRule.SupportsRuntime(&cerebrov1.SourceRuntime{SourceId: "github", Config: map[string]string{"family": "audit"}}) {
+		t.Fatal("SupportsRuntime(github audit) = false, want true")
+	}
+}
+
 func TestRuleDefinitionBuildsSpecAndAttributes(t *testing.T) {
 	definition := RuleDefinition{
 		ID:                 "github-rule",

--- a/internal/findings/rule_fixture_test.go
+++ b/internal/findings/rule_fixture_test.go
@@ -307,9 +307,9 @@ func TestRetiredGitHubMirrorRulesAreCatalogued(t *testing.T) {
 		if rule == nil {
 			t.Fatalf("Builtin().Get(%q) returned nil rule", id)
 		}
-		runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer"}
+		runtime := &cerebrov1.SourceRuntime{Id: "writer-github-audit", SourceId: "github", TenantId: "writer", Config: map[string]string{"family": "audit"}}
 		if !rule.SupportsRuntime(runtime) {
-			t.Fatalf("rule %q should still claim github runtimes so the runtime invokes it during replay (stale-finding sweep)", id)
+			t.Fatalf("rule %q should still claim github audit runtimes so the runtime invokes it during replay (stale-finding sweep)", id)
 		}
 	}
 }

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -268,13 +268,16 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
 		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
 	}
-	events, err := s.replayer.Replay(ctx, ports.ReplayRequest{
-		RuntimeID: runtimeID,
-		Limit:     normalizedLimit,
-	})
-	if err != nil {
-		evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
-		return nil, s.finishFailedRun(ctx, run, 0, 0, nil, evaluationErr)
+	var events []*cerebrov1.EventEnvelope
+	if rule.SupportsRuntime(runtime) {
+		events, err = s.replayer.Replay(ctx, ports.ReplayRequest{
+			RuntimeID: runtimeID,
+			Limit:     normalizedLimit,
+		})
+		if err != nil {
+			evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
+			return nil, s.finishFailedRun(ctx, run, 0, 0, nil, evaluationErr)
+		}
 	}
 	result := &EvaluateResult{
 		Runtime: runtime,
@@ -288,10 +291,6 @@ func (s *Service) EvaluateSourceRuntime(ctx context.Context, request EvaluateReq
 	for _, event := range events {
 		if eventID := strings.TrimSpace(event.GetId()); eventID != "" {
 			evaluatedEventIDs[eventID] = struct{}{}
-		}
-		if !rule.SupportsRuntime(runtime) {
-			result.EventsEvaluated++
-			continue
 		}
 		emitted, err := rule.Evaluate(ctx, runtime, event)
 		if err != nil {
@@ -391,13 +390,16 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 		states = append(states, state)
 		result.Evaluations = append(result.Evaluations, state.result)
 	}
-	events, err := s.replayer.Replay(ctx, ports.ReplayRequest{
-		RuntimeID: runtimeID,
-		Limit:     normalizedLimit,
-	})
-	if err != nil {
-		evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
-		return nil, s.markRuleEvaluationsFailed(ctx, states, evaluationErr)
+	var events []*cerebrov1.EventEnvelope
+	if rulesNeedReplay(runtime, states) {
+		events, err = s.replayer.Replay(ctx, ports.ReplayRequest{
+			RuntimeID: runtimeID,
+			Limit:     normalizedLimit,
+		})
+		if err != nil {
+			evaluationErr := fmt.Errorf("replay runtime %q events: %w", runtimeID, err)
+			return nil, s.markRuleEvaluationsFailed(ctx, states, evaluationErr)
+		}
 	}
 	result.EventsEvaluated = uint32(len(events))
 	evaluatedEventIDs := map[string]struct{}{}
@@ -481,6 +483,15 @@ func (s *Service) EvaluateSourceRuntimeRules(ctx context.Context, request Evalua
 		}
 	}
 	return result, nil
+}
+
+func rulesNeedReplay(runtime *cerebrov1.SourceRuntime, states []*ruleEvaluationState) bool {
+	for _, state := range states {
+		if state != nil && state.rule != nil && state.rule.SupportsRuntime(runtime) {
+			return true
+		}
+	}
+	return false
 }
 
 // ListFindings loads persisted findings for one runtime.

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -43,10 +43,16 @@ func (s *stubRuntimeStore) GetSourceRuntime(_ context.Context, id string) (*cere
 type stubReplayer struct {
 	request ports.ReplayRequest
 	events  []*cerebrov1.EventEnvelope
+	calls   int
+	err     error
 }
 
 func (s *stubReplayer) Replay(_ context.Context, request ports.ReplayRequest) ([]*cerebrov1.EventEnvelope, error) {
+	s.calls++
 	s.request = request
+	if s.err != nil {
+		return nil, s.err
+	}
 	events := make([]*cerebrov1.EventEnvelope, 0, len(s.events))
 	for _, event := range s.events {
 		events = append(events, proto.Clone(event).(*cerebrov1.EventEnvelope))
@@ -835,6 +841,7 @@ func TestEvaluateSourceRuntimeFindingsReplaysGitHubDependabotAlert(t *testing.T)
 					Id:       "writer-github",
 					SourceId: "github",
 					TenantId: "writer",
+					Config:   map[string]string{"family": "dependabot_alert"},
 				},
 			},
 		},
@@ -898,6 +905,7 @@ func TestEvaluateSourceRuntimeFindingsProjectsRecordedFindingToGraph(t *testing.
 					Id:       "writer-github",
 					SourceId: "github",
 					TenantId: "writer",
+					Config:   map[string]string{"family": "dependabot_alert"},
 				},
 			},
 		},
@@ -1058,7 +1066,7 @@ func TestEvaluateSourceRuntimeRetiredRuleResolvesOpenFindingsOutsideReplayWindow
 	store := &stubFindingStore{findings: map[string]*ports.FindingRecord{retiredFinding.ID: retiredFinding}}
 	service := NewWithRegistry(
 		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
-			"writer-github-audit": {Id: "writer-github-audit", SourceId: "github", TenantId: "writer"},
+			"writer-github-audit": {Id: "writer-github-audit", SourceId: "github", TenantId: "writer", Config: map[string]string{"family": "audit"}},
 		}},
 		&stubReplayer{events: []*cerebrov1.EventEnvelope{{
 			Id:       "github-recent-event",
@@ -1647,6 +1655,7 @@ func TestEvaluateSourceRuntimeFindingsRejectsUnsupportedRule(t *testing.T) {
 					Id:       "writer-github-audit",
 					SourceId: "github",
 					TenantId: "writer",
+					Config:   map[string]string{"family": "audit"},
 				},
 			},
 		},
@@ -1683,11 +1692,12 @@ func TestEvaluateSourceRuntimeFindingsAllowsExplicitUnsupportedRuleWithOpenFindi
 			EventIDs:  []string{"old-event"},
 		},
 	}}
+	replayer := &stubReplayer{err: errors.New("unexpected replay")}
 	service := NewWithRegistry(
 		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
 			"writer-aws-public-endpoint": {Id: "writer-aws-public-endpoint", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "public_endpoint"}},
 		}},
-		&stubReplayer{},
+		replayer,
 		store,
 		store,
 		store,
@@ -1704,6 +1714,9 @@ func TestEvaluateSourceRuntimeFindingsAllowsExplicitUnsupportedRuleWithOpenFindi
 	}
 	if got := store.findings["finding-old"].Status; got != findingStatusResolved {
 		t.Fatalf("stale finding status = %q, want %q", got, findingStatusResolved)
+	}
+	if replayer.calls != 0 {
+		t.Fatalf("Replay() calls = %d, want 0 for unsupported stale-only cleanup", replayer.calls)
 	}
 }
 
@@ -1890,11 +1903,12 @@ func TestEvaluateSourceRuntimeRulesIncludesUnsupportedRulesWithOpenFindings(t *t
 			EventIDs:  []string{"old-event"},
 		},
 	}}
+	replayer := &stubReplayer{err: errors.New("unexpected replay")}
 	service := NewWithRegistry(
 		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
 			"writer-aws-public-endpoint": {Id: "writer-aws-public-endpoint", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "public_endpoint"}},
 		}},
-		&stubReplayer{},
+		replayer,
 		store,
 		store,
 		store,
@@ -1911,6 +1925,37 @@ func TestEvaluateSourceRuntimeRulesIncludesUnsupportedRulesWithOpenFindings(t *t
 	}
 	if got := store.findings["finding-old"].Status; got != findingStatusResolved {
 		t.Fatalf("stale finding status = %q, want %q", got, findingStatusResolved)
+	}
+	if replayer.calls != 0 {
+		t.Fatalf("Replay() calls = %d, want 0 for unsupported stale-only cleanup", replayer.calls)
+	}
+}
+
+func TestEvaluateSourceRuntimeRulesSkipsBuiltinRulesForExplicitUnmatchedFamily(t *testing.T) {
+	replayer := &stubReplayer{err: errors.New("unexpected replay")}
+	store := &stubFindingStore{}
+	service := New(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-grc-integration": {
+				Id:       "writer-grc-integration",
+				SourceId: "grc",
+				TenantId: "writer",
+				Config:   map[string]string{"family": "integration"},
+			},
+		}},
+		replayer,
+		store,
+		store,
+		store,
+		store,
+	)
+
+	_, err := service.EvaluateSourceRuntimeRules(context.Background(), EvaluateRulesRequest{RuntimeID: "writer-grc-integration"})
+	if !errors.Is(err, ErrRuleUnavailable) {
+		t.Fatalf("EvaluateSourceRuntimeRules() error = %v, want %v", err, ErrRuleUnavailable)
+	}
+	if replayer.calls != 0 {
+		t.Fatalf("Replay() calls = %d, want 0 when no builtin rule can emit for explicit runtime family", replayer.calls)
 	}
 }
 
@@ -2444,6 +2489,7 @@ func TestEvaluateSourceRuntimeRulesReplaysGitHubAuditSOTASignals(t *testing.T) {
 					Id:       "writer-github-audit",
 					SourceId: "github",
 					TenantId: "writer",
+					Config:   map[string]string{"family": "audit"},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- skip append-log replay when selected finding rules are stale-only/unsupported for the runtime
- tighten event-rule runtime matching for explicit source families so unrelated runtimes do not trigger replay
- add coverage for explicit GRC family matching and no-replay stale cleanup paths

## Validation
- go test ./internal/findings -count=1
- make verify