### PR TITLE
perf: speed up GRC dashboard paths

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -161,8 +162,42 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: scope.Limit})
-	if err != nil {
+	findingIDs := grcFindingIDs(findings)
+	var (
+		evidence       []*cerebrov1.FindingEvidence
+		findingSummary *ports.FindingSummary
+		evidenceCount  *int
+		wg             sync.WaitGroup
+		errs           = make(chan error, 3)
+	)
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		var err error
+		evidence, err = a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: findingIDs, Limit: scope.Limit})
+		if err != nil {
+			errs <- err
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		findingSummary, err = a.grcFindingSummary(r, runtimes, grcFindingFilter{Status: "open"})
+		if err != nil {
+			errs <- err
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		evidenceCount, err = a.grcEvidenceCount(r, runtimes, grcEvidenceFilter{FindingIDs: findingIDs})
+		if err != nil {
+			errs <- err
+		}
+	}()
+	wg.Wait()
+	close(errs)
+	if err := <-errs; err != nil {
 		writeGRCError(w, err)
 		return
 	}
@@ -171,16 +206,6 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	findingItems := grcFindingItems(findings, runtimeSourceIDs, evidenceCounts)
 	evidenceItems := grcEvidenceItems(evidence, grcFindingTitleMap(findings))
 	controls := grcControlItems(findingItems, evidenceItems)
-	findingSummary, err := a.grcFindingSummary(r, runtimes, grcFindingFilter{Status: "open"})
-	if err != nil {
-		writeGRCError(w, err)
-		return
-	}
-	evidenceCount, err := a.grcEvidenceCount(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings)})
-	if err != nil {
-		writeGRCError(w, err)
-		return
-	}
 
 	writeJSON(w, http.StatusOK, grcDashboardResponse{
 		Summary:     grcBuildSummary(findingItems, controls, evidenceItems, runtimes, findingSummary, evidenceCount),

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -54,6 +54,9 @@ var ensureFindingEvidenceStatements = []string{
 	`CREATE INDEX IF NOT EXISTS finding_evidence_attributes_gin_idx ON finding_evidence USING GIN (attributes_json)`,
 	`CREATE INDEX IF NOT EXISTS finding_evidence_last_observed_idx ON finding_evidence (runtime_id, last_observed_at DESC)`,
 	`CREATE INDEX IF NOT EXISTS finding_evidence_runtime_observed_id_idx ON finding_evidence (runtime_id, last_observed_at DESC, created_at DESC, id)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_finding_observed_idx ON finding_evidence (runtime_id, finding_id, last_observed_at DESC, created_at DESC, id)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_finding_created_idx ON finding_evidence (runtime_id, finding_id, created_at DESC, id)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_rule_observed_idx ON finding_evidence (runtime_id, rule_id, last_observed_at DESC, created_at DESC, id)`,
 }
 
 func findingEvidenceUpsertSQL() string {

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -224,6 +224,15 @@ func TestFindingEvidenceSchemaPersistsEnrichedEvidence(t *testing.T) {
 		"finding_evidence_graph_path_urns_gin_idx",
 		"finding_evidence_run_ids_gin_idx",
 		"finding_evidence_attributes_gin_idx",
+		"finding_evidence_runtime_finding_observed_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_finding_observed_idx",
+		"runtime_id, finding_id, last_observed_at DESC, created_at DESC, id",
+		"finding_evidence_runtime_finding_created_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_finding_created_idx",
+		"runtime_id, finding_id, created_at DESC, id",
+		"finding_evidence_runtime_rule_observed_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_rule_observed_idx",
+		"runtime_id, rule_id, last_observed_at DESC, created_at DESC, id",
 	} {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("finding evidence schema missing %q:\n%s", fragment, joined)

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -19,7 +19,12 @@ var ensureSourceRuntimeStatements = []string{`CREATE TABLE IF NOT EXISTS source_
   runtime_json JSONB NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-)`, `ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_owner TEXT`, `ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ`}
+)`,
+	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_owner TEXT`,
+	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_updated_idx ON source_runtimes ((runtime_json->>'tenant_id'), updated_at ASC, id ASC)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_source_updated_idx ON source_runtimes ((runtime_json->>'tenant_id'), (runtime_json->>'source_id'), updated_at ASC, id ASC)`,
+}
 
 // PutSourceRuntime upserts one source runtime definition.
 func (s *Store) PutSourceRuntime(ctx context.Context, runtime *cerebrov1.SourceRuntime) error {

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -61,5 +62,24 @@ func TestPutSourceRuntimeRejectsMissingSourceID(t *testing.T) {
 func TestSourceRuntimeListOrderRotatesRecentlyUpdatedRows(t *testing.T) {
 	if got := sourceRuntimeListOrderClause(); got != "updated_at ASC, id ASC" {
 		t.Fatalf("sourceRuntimeListOrderClause() = %q, want least recently updated first", got)
+	}
+}
+
+func TestSourceRuntimeSchemaIndexesDashboardFilters(t *testing.T) {
+	joined := strings.Join(ensureSourceRuntimeStatements, "\n")
+	for _, fragment := range []string{
+		"source_runtimes_tenant_updated_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_updated_idx",
+		"(runtime_json->>'tenant_id'), updated_at ASC, id ASC",
+		"source_runtimes_tenant_source_updated_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_source_updated_idx",
+		"(runtime_json->>'tenant_id'), (runtime_json->>'source_id'), updated_at ASC, id ASC",
+	} {
+		if !strings.Contains(joined, fragment) {
+			t.Fatalf("source runtime schema missing %q:\n%s", fragment, joined)
+		}
+	}
+	if strings.Contains(joined, "source_runtimes_lease_expiry_idx") {
+		t.Fatalf("source runtime schema includes unused lease expiry index:\n%s", joined)
 	}
 }


### PR DESCRIPTION
## Summary
- add Postgres indexes for dashboard evidence filters and source runtime tenant/source scans
- parallelize independent `/grc/dashboard` evidence, summary, and evidence-count reads after findings are loaded
- add regression coverage for the new schema/index guardrails

## Validation
- `go test ./internal/bootstrap ./internal/statestore/postgres -count=1`
- `go test ./api/... ./cmd/... ./internal/... ./sources/... -run ^`
- pre-push hooks: `go test ./...`, `golangci-lint`, `buf lint`, OpenAPI route parity, Spectral, catalog checks, `scripts/oss_audit.py`
- `git diff --check`

## Risk / rollback
- Low-to-medium risk: adds concurrent read queries on the dashboard route and online `CREATE INDEX IF NOT EXISTS` statements during store initialization.
- Roll back by reverting this PR; indexes can remain harmlessly if already created.