### PR TITLE
perf: aggregate GRC dashboard counts

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourceruntime"
+	"github.com/writer/cerebro/internal/telemetry"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -147,18 +148,35 @@ type grcAuditPacketResponse struct {
 }
 
 func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
+	ctx, span := telemetry.Start(r.Context(), "grc.dashboard", grcDashboardTelemetryAttrs())
+	r = r.WithContext(ctx)
+	status := "completed"
+	endAttrs := grcDashboardTelemetryAttrs()
+	defer func() {
+		telemetry.End(span, status, endAttrs)
+	}()
 	scope, err := grcScopeFromRequest(r)
 	if err != nil {
+		status, endAttrs = grcTelemetryError(endAttrs, err)
 		writeGRCError(w, err)
 		return
 	}
-	runtimes, err := a.grcListRuntimes(r, scope)
+	endAttrs = endAttrs.WithField(telemetry.Field{Key: "limit", Value: scope.Limit})
+	ctx, runtimesSpan := telemetry.Start(r.Context(), "grc.dashboard.runtimes", grcDashboardScopeTelemetryAttrs(scope))
+	runtimesRequest := r.WithContext(ctx)
+	runtimes, err := a.grcListRuntimes(runtimesRequest, scope)
+	telemetry.End(runtimesSpan, grcTelemetryStatus(err), telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}))
 	if err != nil {
+		status, endAttrs = grcTelemetryError(endAttrs, err)
 		writeGRCError(w, err)
 		return
 	}
-	findings, err := a.grcListFindingRecords(r, runtimes, grcFindingFilter{Status: "open", Limit: scope.Limit})
+	ctx, findingsSpan := telemetry.Start(r.Context(), "grc.dashboard.findings", grcDashboardScopeTelemetryAttrs(scope))
+	findingsRequest := r.WithContext(ctx)
+	findings, err := a.grcListFindingRecords(findingsRequest, runtimes, grcFindingFilter{Status: "open", Limit: scope.Limit})
+	telemetry.End(findingsSpan, grcTelemetryStatus(err), telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findings)}))
 	if err != nil {
+		status, endAttrs = grcTelemetryError(endAttrs, err)
 		writeGRCError(w, err)
 		return
 	}
@@ -167,14 +185,18 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		evidence       []*cerebrov1.FindingEvidence
 		findingSummary *ports.FindingSummary
 		evidenceCount  *int
+		aggregate      *ports.GRCDashboardAggregate
 		wg             sync.WaitGroup
 		errs           = make(chan error, 3)
 	)
-	wg.Add(3)
+	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		var err error
-		evidence, err = a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: findingIDs, Limit: scope.Limit})
+		ctx, evidenceSpan := telemetry.Start(r.Context(), "grc.dashboard.evidence", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}))
+		evidenceRequest := r.WithContext(ctx)
+		evidence, err = a.grcListEvidenceRecords(evidenceRequest, runtimes, grcEvidenceFilter{FindingIDs: findingIDs, Limit: scope.Limit})
+		telemetry.End(evidenceSpan, grcTelemetryStatus(err), telemetry.Attrs(telemetry.Field{Key: "evidence_count", Value: len(evidence)}))
 		if err != nil {
 			errs <- err
 		}
@@ -182,15 +204,21 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		defer wg.Done()
 		var err error
-		findingSummary, err = a.grcFindingSummary(r, runtimes, grcFindingFilter{Status: "open"})
-		if err != nil {
-			errs <- err
+		ctx, aggregateSpan := telemetry.Start(r.Context(), "grc.dashboard.aggregate", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}))
+		aggregateRequest := r.WithContext(ctx)
+		aggregate, err = a.grcDashboardAggregate(aggregateRequest, runtimes, grcFindingFilter{Status: "open"}, grcEvidenceFilter{FindingIDs: findingIDs})
+		if err == nil && aggregate == nil {
+			findingSummary, err = a.grcFindingSummary(aggregateRequest, runtimes, grcFindingFilter{Status: "open"})
+			if err == nil {
+				evidenceCount, err = a.grcEvidenceCount(aggregateRequest, runtimes, grcEvidenceFilter{FindingIDs: findingIDs})
+			}
 		}
-	}()
-	go func() {
-		defer wg.Done()
-		var err error
-		evidenceCount, err = a.grcEvidenceCount(r, runtimes, grcEvidenceFilter{FindingIDs: findingIDs})
+		attrs := telemetry.Attrs()
+		if aggregate != nil {
+			attrs = attrs.WithField(telemetry.Field{Key: "evidence_count", Value: aggregate.EvidenceCount})
+			attrs = attrs.WithField(telemetry.Field{Key: "open_findings", Value: aggregate.FindingSummary.OpenFindings})
+		}
+		telemetry.End(aggregateSpan, grcTelemetryStatus(err), attrs)
 		if err != nil {
 			errs <- err
 		}
@@ -198,14 +226,22 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	wg.Wait()
 	close(errs)
 	if err := <-errs; err != nil {
+		status, endAttrs = grcTelemetryError(endAttrs, err)
 		writeGRCError(w, err)
 		return
+	}
+	if aggregate != nil {
+		findingSummary = &aggregate.FindingSummary
+		evidenceCount = &aggregate.EvidenceCount
 	}
 	runtimeSourceIDs := grcRuntimeSourceIDs(runtimes)
 	evidenceCounts := grcEvidenceCounts(evidence)
 	findingItems := grcFindingItems(findings, runtimeSourceIDs, evidenceCounts)
 	evidenceItems := grcEvidenceItems(evidence, grcFindingTitleMap(findings))
 	controls := grcControlItems(findingItems, evidenceItems)
+	endAttrs = endAttrs.WithField(telemetry.Field{Key: "runtime_count", Value: len(runtimes)})
+	endAttrs = endAttrs.WithField(telemetry.Field{Key: "finding_count", Value: len(findingItems)})
+	endAttrs = endAttrs.WithField(telemetry.Field{Key: "evidence_count", Value: len(evidenceItems)})
 
 	writeJSON(w, http.StatusOK, grcDashboardResponse{
 		Summary:     grcBuildSummary(findingItems, controls, evidenceItems, runtimes, findingSummary, evidenceCount),
@@ -459,6 +495,35 @@ type grcFindingSummaryProvider interface {
 
 type grcFindingEvidenceCounter interface {
 	CountFindingEvidence(context.Context, ports.ListFindingEvidenceRequest) (int, error)
+}
+
+func grcDashboardTelemetryAttrs() telemetry.Attributes {
+	return telemetry.Attrs(
+		telemetry.Field{Key: "route", Value: "/grc/dashboard"},
+		telemetry.Field{Key: "dashboard", Value: "grc"},
+	)
+}
+
+func grcDashboardScopeTelemetryAttrs(scope grcScope) telemetry.Attributes {
+	return grcDashboardTelemetryAttrs().
+		WithField(telemetry.Field{Key: "tenant_id", Value: scope.TenantID}).
+		WithField(telemetry.Field{Key: "runtime_id", Value: scope.RuntimeID}).
+		WithField(telemetry.Field{Key: "source_id", Value: scope.SourceID}).
+		WithField(telemetry.Field{Key: "limit", Value: scope.Limit})
+}
+
+func grcTelemetryStatus(err error) string {
+	if err != nil {
+		return "failed"
+	}
+	return "completed"
+}
+
+func grcTelemetryError(attrs telemetry.Attributes, err error) (string, telemetry.Attributes) {
+	if err == nil {
+		return "completed", attrs
+	}
+	return "failed", attrs.WithField(telemetry.Field{Key: "error", Value: err.Error()})
 }
 
 func grcScopeFromRequest(r *http.Request) (grcScope, error) {
@@ -716,6 +781,79 @@ func (a *App) grcEvidenceCount(r *http.Request, runtimes []*cerebrov1.SourceRunt
 	}
 	count += item
 	return &count, nil
+}
+
+func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.SourceRuntime, findingFilter grcFindingFilter, evidenceFilter grcEvidenceFilter) (*ports.GRCDashboardAggregate, error) {
+	provider, ok := a.deps.StateStore.(ports.GRCDashboardAggregateStore)
+	if !ok {
+		return nil, nil
+	}
+	if evidenceFilter.FindingIDs != nil && strings.TrimSpace(evidenceFilter.FindingID) == "" && len(grcNonEmptyFindingIDs(evidenceFilter.FindingIDs)) == 0 {
+		aggregate := ports.GRCDashboardAggregate{}
+		return &aggregate, nil
+	}
+	runtimeIDsByTenant := map[string][]string{}
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		tenantID := strings.TrimSpace(runtime.GetTenantId())
+		runtimeID := strings.TrimSpace(runtime.GetId())
+		if tenantID == "" || runtimeID == "" {
+			continue
+		}
+		runtimeIDsByTenant[tenantID] = append(runtimeIDsByTenant[tenantID], runtimeID)
+	}
+	if len(runtimeIDsByTenant) == 0 {
+		aggregate := ports.GRCDashboardAggregate{}
+		return &aggregate, nil
+	}
+	var aggregate ports.GRCDashboardAggregate
+	controlKeys := map[string]struct{}{}
+	for tenantID, runtimeIDs := range runtimeIDsByTenant {
+		item, err := provider.SummarizeGRCDashboard(r.Context(), ports.GRCDashboardAggregateRequest{
+			FindingRequest: ports.ListFindingsRequest{
+				TenantID:    tenantID,
+				RuntimeIDs:  runtimeIDs,
+				FindingID:   findingFilter.FindingID,
+				RuleID:      findingFilter.RuleID,
+				Severity:    findingFilter.Severity,
+				Status:      findingFilter.Status,
+				ResourceURN: findingFilter.ResourceURN,
+				EventID:     findingFilter.EventID,
+				PolicyID:    findingFilter.PolicyID,
+			},
+			EvidenceRequest: ports.ListFindingEvidenceRequest{
+				RuntimeIDs:   runtimeIDs,
+				FindingID:    evidenceFilter.FindingID,
+				FindingIDs:   evidenceFilter.FindingIDs,
+				RunID:        evidenceFilter.RunID,
+				RuleID:       evidenceFilter.RuleID,
+				GraphRootURN: evidenceFilter.GraphRootURN,
+				Limit:        0,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		aggregate.FindingSummary.OpenFindings += item.FindingSummary.OpenFindings
+		aggregate.FindingSummary.CriticalFindings += item.FindingSummary.CriticalFindings
+		aggregate.FindingSummary.HighFindings += item.FindingSummary.HighFindings
+		aggregate.FindingSummary.OverdueFindings += item.FindingSummary.OverdueFindings
+		aggregate.FindingSummary.Unassigned += item.FindingSummary.Unassigned
+		aggregate.EvidenceCount += item.EvidenceCount
+		for _, key := range item.FindingSummary.FailingControlKeys {
+			if trimmed := strings.TrimSpace(key); trimmed != "" {
+				controlKeys[trimmed] = struct{}{}
+			}
+		}
+	}
+	for key := range controlKeys {
+		aggregate.FindingSummary.FailingControlKeys = append(aggregate.FindingSummary.FailingControlKeys, key)
+	}
+	sort.Strings(aggregate.FindingSummary.FailingControlKeys)
+	aggregate.FindingSummary.ControlsFailing = len(aggregate.FindingSummary.FailingControlKeys)
+	return &aggregate, nil
 }
 
 func grcRuntimeSourceIDs(runtimes []*cerebrov1.SourceRuntime) map[string]string {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -318,6 +319,60 @@ func TestGRCDashboardSummaryUsesUnpaginatedAggregates(t *testing.T) {
 	}
 }
 
+func TestGRCDashboardUsesPurposeBuiltAggregateStore(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	runtimeID := "tenant-okta-audit"
+	tenantID := "tenant"
+	store := &stubGRCAggregateStore{stubRuntimeStore: &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {
+				Id:           runtimeID,
+				SourceId:     "okta",
+				TenantId:     tenantID,
+				LastSyncedAt: timestamppb.New(now),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)},
+			},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Finding 1",
+				Severity:       "HIGH",
+				Status:         "open",
+				ControlRefs:    []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+				LastObservedAt: now,
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-1": {Id: "evidence-1", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now)},
+		},
+	}}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=" + tenantID)
+	if err != nil {
+		t.Fatalf("GET /grc/dashboard error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/dashboard status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload grcDashboardResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /grc/dashboard: %v", err)
+	}
+	if store.aggregateCalls != 1 {
+		t.Fatalf("aggregate calls = %d, want 1", store.aggregateCalls)
+	}
+	if payload.Summary.OpenFindings != 1 || payload.Summary.EvidenceItems != 1 {
+		t.Fatalf("summary = %+v, want aggregate finding/evidence counts", payload.Summary)
+	}
+}
+
 func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
 	rootURN := "urn:cerebro:writer:okta_user:00u1"
@@ -414,4 +469,22 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 	if packet.RecommendedAction == "" {
 		t.Fatalf("packet recommended action is empty")
 	}
+}
+
+type stubGRCAggregateStore struct {
+	*stubRuntimeStore
+	aggregateCalls int
+}
+
+func (s *stubGRCAggregateStore) SummarizeGRCDashboard(ctx context.Context, request ports.GRCDashboardAggregateRequest) (ports.GRCDashboardAggregate, error) {
+	s.aggregateCalls++
+	summary, err := s.SummarizeFindings(ctx, request.FindingRequest)
+	if err != nil {
+		return ports.GRCDashboardAggregate{}, err
+	}
+	count, err := s.CountFindingEvidence(ctx, request.EvidenceRequest)
+	if err != nil {
+		return ports.GRCDashboardAggregate{}, err
+	}
+	return ports.GRCDashboardAggregate{FindingSummary: summary, EvidenceCount: count}, nil
 }

--- a/internal/ports/grc.go
+++ b/internal/ports/grc.go
@@ -1,0 +1,21 @@
+package ports
+
+import "context"
+
+// GRCDashboardAggregateRequest scopes aggregate counts needed by the GRC dashboard.
+type GRCDashboardAggregateRequest struct {
+	FindingRequest  ListFindingsRequest
+	EvidenceRequest ListFindingEvidenceRequest
+}
+
+// GRCDashboardAggregate contains dashboard summary counts fetched without row payloads.
+type GRCDashboardAggregate struct {
+	FindingSummary FindingSummary
+	EvidenceCount  int
+}
+
+// GRCDashboardAggregateStore provides a purpose-built aggregate path for the GRC dashboard.
+type GRCDashboardAggregateStore interface {
+	StateStore
+	SummarizeGRCDashboard(context.Context, GRCDashboardAggregateRequest) (GRCDashboardAggregate, error)
+}

--- a/internal/statestore/postgres/grc_dashboard.go
+++ b/internal/statestore/postgres/grc_dashboard.go
@@ -1,0 +1,167 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+// SummarizeGRCDashboard loads dashboard summary and evidence counts in one aggregate query.
+func (s *Store) SummarizeGRCDashboard(ctx context.Context, request ports.GRCDashboardAggregateRequest) (ports.GRCDashboardAggregate, error) {
+	if s == nil || s.db == nil {
+		return ports.GRCDashboardAggregate{}, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return ports.GRCDashboardAggregate{}, err
+	}
+	if err := s.ensureFindingEvidenceTables(ctx); err != nil {
+		return ports.GRCDashboardAggregate{}, err
+	}
+	query, args, err := grcDashboardAggregateQuery(request)
+	if err != nil {
+		return ports.GRCDashboardAggregate{}, err
+	}
+	var aggregate ports.GRCDashboardAggregate
+	var controlRefsJSON string
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(
+		&aggregate.FindingSummary.OpenFindings,
+		&aggregate.FindingSummary.CriticalFindings,
+		&aggregate.FindingSummary.HighFindings,
+		&aggregate.FindingSummary.OverdueFindings,
+		&aggregate.FindingSummary.Unassigned,
+		&controlRefsJSON,
+		&aggregate.EvidenceCount,
+	); err != nil {
+		return ports.GRCDashboardAggregate{}, fmt.Errorf("summarize grc dashboard: %w", err)
+	}
+	controlKeys, err := decodeGRCDashboardControlKeys(controlRefsJSON)
+	if err != nil {
+		return ports.GRCDashboardAggregate{}, fmt.Errorf("decode grc dashboard control keys: %w", err)
+	}
+	aggregate.FindingSummary.FailingControlKeys = controlKeys
+	aggregate.FindingSummary.ControlsFailing = len(controlKeys)
+	return aggregate, nil
+}
+
+func decodeGRCDashboardControlKeys(controlRefsJSON string) ([]string, error) {
+	var refs []ports.FindingControlRef
+	if err := json.Unmarshal([]byte(controlRefsJSON), &refs); err != nil {
+		return nil, err
+	}
+	controlKeys := map[string]struct{}{}
+	for _, ref := range refs {
+		frameworkName := strings.TrimSpace(ref.FrameworkName)
+		if frameworkName == "" {
+			frameworkName = "Unmapped"
+		}
+		controlID := strings.TrimSpace(ref.ControlID)
+		if controlID == "" {
+			controlID = "Needs mapping"
+		}
+		controlKeys[frameworkName+"\x00"+controlID] = struct{}{}
+	}
+	keys := make([]string, 0, len(controlKeys))
+	for key := range controlKeys {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys, nil
+}
+
+func grcDashboardAggregateQuery(request ports.GRCDashboardAggregateRequest) (string, []any, error) {
+	findingClauses, findingArgs, err := findingFilterClauses(request.FindingRequest)
+	if err != nil {
+		return "", nil, err
+	}
+	evidenceClauses, evidenceArgs, err := findingEvidenceFilterClauses(request.EvidenceRequest)
+	if err != nil {
+		return "", nil, err
+	}
+	whereFindings := strings.Join(findingClauses, " AND ")
+	whereEvidence := rebasePostgresPlaceholders(strings.Join(evidenceClauses, " AND "), len(findingArgs))
+	args := append([]any{}, findingArgs...)
+	args = append(args, evidenceArgs...)
+	effectiveSeverity := findingEffectiveSeveritySQL()
+	query := `
+WITH finding_scope AS (
+  SELECT status, ` + effectiveSeverity + ` AS effective_severity, due_at, assignee, control_refs_json
+  FROM findings
+  WHERE ` + whereFindings + `
+),
+summary AS (
+  SELECT
+    COUNT(*) FILTER (WHERE LOWER(status) = 'open') AS open_findings,
+    COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND effective_severity = 'CRITICAL') AS critical_findings,
+    COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND effective_severity = 'HIGH') AS high_findings,
+    COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND due_at IS NOT NULL AND due_at < NOW()) AS overdue_findings,
+    COUNT(*) FILTER (WHERE LOWER(status) = 'open' AND TRIM(assignee) = '') AS unassigned
+  FROM finding_scope
+),
+control_refs AS (
+  SELECT DISTINCT
+    COALESCE(NULLIF(TRIM(ref->>'framework_name'), ''), 'Unmapped') AS framework_name,
+    COALESCE(NULLIF(TRIM(ref->>'control_id'), ''), 'Needs mapping') AS control_id
+  FROM finding_scope
+  LEFT JOIN LATERAL jsonb_array_elements(
+    CASE
+      WHEN jsonb_array_length(control_refs_json) = 0
+        THEN '[{"framework_name":"Unmapped","control_id":"Needs mapping"}]'::jsonb
+      ELSE control_refs_json
+    END
+  ) AS ref ON TRUE
+  WHERE LOWER(status) = 'open'
+),
+evidence_summary AS (
+  SELECT COUNT(*) AS evidence_count
+  FROM finding_evidence
+  WHERE ` + whereEvidence + `
+)
+SELECT
+  summary.open_findings,
+  summary.critical_findings,
+  summary.high_findings,
+  summary.overdue_findings,
+  summary.unassigned,
+  COALESCE((SELECT jsonb_agg(jsonb_build_object('framework_name', framework_name, 'control_id', control_id) ORDER BY framework_name, control_id)::text FROM control_refs), '[]'),
+  evidence_summary.evidence_count
+FROM summary
+CROSS JOIN evidence_summary`
+	return query, args, nil
+}
+
+func rebasePostgresPlaceholders(query string, offset int) string {
+	if offset == 0 || query == "" {
+		return query
+	}
+	var out strings.Builder
+	for i := 0; i < len(query); i++ {
+		if query[i] != '$' {
+			out.WriteByte(query[i])
+			continue
+		}
+		j := i + 1
+		for j < len(query) && query[j] >= '0' && query[j] <= '9' {
+			j++
+		}
+		if j == i+1 {
+			out.WriteByte(query[i])
+			continue
+		}
+		index, err := strconv.Atoi(query[i+1 : j])
+		if err != nil {
+			out.WriteString(query[i:j])
+			i = j - 1
+			continue
+		}
+		out.WriteByte('$')
+		out.WriteString(strconv.Itoa(index + offset))
+		i = j - 1
+	}
+	return out.String()
+}

--- a/internal/statestore/postgres/grc_dashboard_test.go
+++ b/internal/statestore/postgres/grc_dashboard_test.go
@@ -1,0 +1,70 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T) {
+	query, args, err := grcDashboardAggregateQuery(ports.GRCDashboardAggregateRequest{
+		FindingRequest: ports.ListFindingsRequest{
+			TenantID:   "example",
+			RuntimeIDs: []string{"tenant-runtime-a", "tenant-runtime-b"},
+			Status:     "open",
+		},
+		EvidenceRequest: ports.ListFindingEvidenceRequest{
+			RuntimeIDs: []string{"tenant-runtime-a", "tenant-runtime-b"},
+			FindingIDs: []string{"finding-1", "finding-2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("grcDashboardAggregateQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"WITH finding_scope AS",
+		"COUNT(*) FILTER (WHERE LOWER(status) = 'open') AS open_findings",
+		"jsonb_array_elements",
+		"jsonb_build_object('framework_name', framework_name, 'control_id', control_id)",
+		"evidence_summary AS",
+		"FROM finding_evidence",
+		"runtime_id IN ($5, $6)",
+		"finding_id IN ($7, $8)",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("aggregate query missing %q:\n%s", fragment, query)
+		}
+	}
+	for _, forbidden := range []string{`E'\x00'`, `|| E'`, "control_key"} {
+		if strings.Contains(query, forbidden) {
+			t.Fatalf("aggregate query must not contain %q:\n%s", forbidden, query)
+		}
+	}
+	if len(args) != 8 {
+		t.Fatalf("aggregate query args len = %d, want 8 (%v)", len(args), args)
+	}
+}
+
+func TestDecodeGRCDashboardControlKeysBuildsKeysInGo(t *testing.T) {
+	got, err := decodeGRCDashboardControlKeys(`[
+		{"framework_name":" SOC 2 ","control_id":" CC6.1 "},
+		{"framework_name":"SOC 2","control_id":"CC6.1"},
+		{"framework_name":"","control_id":""}
+	]`)
+	if err != nil {
+		t.Fatalf("decodeGRCDashboardControlKeys() error = %v", err)
+	}
+	want := []string{"SOC 2\x00CC6.1", "Unmapped\x00Needs mapping"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("decodeGRCDashboardControlKeys() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRebasePostgresPlaceholders(t *testing.T) {
+	got := rebasePostgresPlaceholders("runtime_id IN ($1, $2) AND finding_id = $3", 4)
+	want := "runtime_id IN ($5, $6) AND finding_id = $7"
+	if got != want {
+		t.Fatalf("rebasePostgresPlaceholders() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add a purpose-built Postgres aggregate for GRC dashboard summary and evidence counts
- use the aggregate fast path from /grc/dashboard while preserving fallback behavior
- emit low-cardinality telemetry spans for dashboard latency and subquery timing

## Validation
- go test ./internal/bootstrap -run 'TestGRCDashboard' -count=1
- go test ./internal/statestore/postgres -run 'TestGRCDashboardAggregate|TestRebase' -count=1
- make verify