### PR TITLE
feat: publish runtime deploy contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
 
   notify-infra-release:
     runs-on: ubuntu-latest
-    needs: [resolve-tag, ghcr-publish]
+    needs: [resolve-tag, ghcr-publish, runtime-contract]
     steps:
       - name: Dispatch release deployment request
         shell: bash
@@ -265,3 +265,54 @@ jobs:
           echo "ERROR: repository_dispatch was accepted, but no matching propose-image-tag.yml run appeared for ${RELEASE_TAG}" >&2
           echo "This usually means the downstream handler is absent or disabled; failing closed to avoid silent deploy loss." >&2
           exit 1
+
+  runtime-contract:
+    runs-on: ubuntu-latest
+    needs: [resolve-tag, ghcr-publish]
+    env:
+      RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Render runtime deploy contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .dist
+          go run ./cmd/sourcedeploy \
+            -env sec-dev \
+            -tenant writer \
+            -format contract-json \
+            -image-tag "${RELEASE_TAG}" \
+            -out .dist/cerebro-runtime-contract.json
+
+      - name: Keyless sign runtime deploy contract
+        shell: bash
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          set -euo pipefail
+          GOBIN="${RUNNER_TEMP}/cosign" go install github.com/sigstore/cosign/v2/cmd/cosign@v2.6.1
+          "${RUNNER_TEMP}/cosign/cosign" sign-blob --yes \
+            --output-signature .dist/cerebro-runtime-contract.json.sig \
+            --output-certificate .dist/cerebro-runtime-contract.json.pem \
+            .dist/cerebro-runtime-contract.json
+
+      - name: Upload runtime deploy contract
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" \
+            .dist/cerebro-runtime-contract.json \
+            .dist/cerebro-runtime-contract.json.sig \
+            .dist/cerebro-runtime-contract.json.pem \
+            --clobber

--- a/cmd/sourcedeploy/main.go
+++ b/cmd/sourcedeploy/main.go
@@ -29,6 +29,8 @@ func run(args []string) error {
 	sourcesRoot := fs.String("sources", "sources", "directory containing per-source manifests")
 	env := fs.String("env", "", "environment to render (e.g. sec-dev, go-prod)")
 	tenant := fs.String("tenant", "writer", "tenant identifier embedded in qualified runtime ids")
+	format := fs.String("format", "yaml", "output format: yaml or contract-json")
+	imageTag := fs.String("image-tag", "", "optional runtime image tag embedded in contract-json output")
 	out := fs.String("out", "-", "output path; '-' writes to stdout")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -49,7 +51,26 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	data, err := fragment.MarshalYAML()
+	var data []byte
+	switch *format {
+	case "yaml":
+		data, err = fragment.MarshalYAML()
+	case "contract-json":
+		contract, contractErr := sourcedeploy.RenderContract(*sourcesRoot, manifests, sourcedeploy.ContractOptions{
+			Environment: *env,
+			TenantID:    *tenant,
+			ImageTag:    *imageTag,
+		})
+		if contractErr != nil {
+			return contractErr
+		}
+		data, err = contract.MarshalJSONStable()
+		if err == nil {
+			data = append(data, '\n')
+		}
+	default:
+		return fmt.Errorf("unsupported -format %q", *format)
+	}
 	if err != nil {
 		return err
 	}

--- a/sources/sentinelone/catalog.yaml
+++ b/sources/sentinelone/catalog.yaml
@@ -9,3 +9,11 @@ emitted_kinds:
   - sentinelone.group
   - sentinelone.site
   - sentinelone.threat
+runtime_families:
+  - activity
+  - agent
+  - application
+  - exclusion
+  - group
+  - site
+  - threat

--- a/tools/sourcedeploy/contract.go
+++ b/tools/sourcedeploy/contract.go
@@ -53,8 +53,9 @@ type RoleAssumption struct {
 }
 
 type contractCatalog struct {
-	ID           string   `yaml:"id"`
-	EmittedKinds []string `yaml:"emitted_kinds"`
+	ID              string   `yaml:"id"`
+	EmittedKinds    []string `yaml:"emitted_kinds"`
+	RuntimeFamilies []string `yaml:"runtime_families"`
 }
 
 func RenderContract(sourcesRoot string, manifests []Manifest, opts ContractOptions) (Contract, error) {
@@ -91,7 +92,7 @@ func RenderContract(sourcesRoot string, manifests []Manifest, opts ContractOptio
 		sources = append(sources, ContractSource{
 			SourceID:                 catalog.ID,
 			EmittedKinds:             sortedStrings(catalog.EmittedKinds),
-			SupportedFamilies:        supportedFamilies(catalog.ID, catalog.EmittedKinds, runtimesBySource[catalog.ID]),
+			SupportedFamilies:        supportedFamilies(catalog.ID, catalog.EmittedKinds, catalog.RuntimeFamilies, runtimesBySource[catalog.ID]),
 			RequiredSecrets:          sortedStrings(manifest.SecretKeys),
 			RoleAssumptionConfigKeys: roleAssumptionConfigKeys(catalog.ID),
 			Runtimes:                 runtimesBySource[catalog.ID],
@@ -145,15 +146,23 @@ func discoverCatalogs(sourcesRoot string) ([]contractCatalog, error) {
 	return catalogs, nil
 }
 
-func supportedFamilies(sourceID string, emittedKinds []string, runtimes []ContractRuntime) []string {
+func supportedFamilies(sourceID string, emittedKinds []string, runtimeFamilies []string, runtimes []ContractRuntime) []string {
 	families := map[string]struct{}{}
-	prefix := sourceID + "."
-	for _, kind := range emittedKinds {
-		kind = strings.TrimSpace(kind)
-		if strings.HasPrefix(kind, prefix) {
-			family := strings.TrimSpace(strings.TrimPrefix(kind, prefix))
-			if family != "" {
+	if len(runtimeFamilies) > 0 {
+		for _, family := range runtimeFamilies {
+			if family = strings.TrimSpace(family); family != "" {
 				families[family] = struct{}{}
+			}
+		}
+	} else {
+		prefix := sourceID + "."
+		for _, kind := range emittedKinds {
+			kind = strings.TrimSpace(kind)
+			if strings.HasPrefix(kind, prefix) {
+				family := strings.TrimSpace(strings.TrimPrefix(kind, prefix))
+				if family != "" {
+					families[family] = struct{}{}
+				}
 			}
 		}
 	}

--- a/tools/sourcedeploy/contract.go
+++ b/tools/sourcedeploy/contract.go
@@ -1,0 +1,223 @@
+package sourcedeploy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const ContractSchemaVersion = "cerebro.runtime-deploy-contract/v1"
+
+type ContractOptions struct {
+	Environment string
+	TenantID    string
+	ImageTag    string
+}
+
+type Contract struct {
+	SchemaVersion   string           `json:"schema_version"`
+	ImageTag        string           `json:"image_tag,omitempty"`
+	Environment     string           `json:"environment"`
+	TenantID        string           `json:"tenant_id"`
+	RequiredSecrets []string         `json:"required_secrets"`
+	Sources         []ContractSource `json:"sources"`
+}
+
+type ContractSource struct {
+	SourceID                 string            `json:"source_id"`
+	EmittedKinds             []string          `json:"emitted_kinds,omitempty"`
+	SupportedFamilies        []string          `json:"supported_families,omitempty"`
+	RequiredSecrets          []string          `json:"required_secrets,omitempty"`
+	RoleAssumptionConfigKeys []string          `json:"role_assumption_config_keys,omitempty"`
+	Runtimes                 []ContractRuntime `json:"runtimes,omitempty"`
+}
+
+type ContractRuntime struct {
+	ID              string            `json:"id"`
+	SourceID        string            `json:"source_id"`
+	TenantID        string            `json:"tenant_id"`
+	Family          string            `json:"family,omitempty"`
+	RequiredSecrets []string          `json:"required_secrets,omitempty"`
+	RoleAssumptions []RoleAssumption  `json:"role_assumptions,omitempty"`
+	Config          map[string]string `json:"config"`
+}
+
+type RoleAssumption struct {
+	ConfigKey string `json:"config_key"`
+	RoleARN   string `json:"role_arn"`
+}
+
+type contractCatalog struct {
+	ID           string   `yaml:"id"`
+	EmittedKinds []string `yaml:"emitted_kinds"`
+}
+
+func RenderContract(sourcesRoot string, manifests []Manifest, opts ContractOptions) (Contract, error) {
+	fragment, err := Render(manifests, RenderOptions{Environment: opts.Environment, TenantID: opts.TenantID})
+	if err != nil {
+		return Contract{}, err
+	}
+	catalogs, err := discoverCatalogs(sourcesRoot)
+	if err != nil {
+		return Contract{}, err
+	}
+
+	manifestBySource := make(map[string]Manifest, len(manifests))
+	for _, manifest := range manifests {
+		manifestBySource[manifest.SourceID] = manifest
+	}
+	runtimesBySource := make(map[string][]ContractRuntime)
+	for _, runtime := range fragment.SourceRuntimes {
+		requiredSecrets := envRefs(runtime.Config)
+		runtimesBySource[runtime.SourceID] = append(runtimesBySource[runtime.SourceID], ContractRuntime{
+			ID:              runtime.ID,
+			SourceID:        runtime.SourceID,
+			TenantID:        runtime.TenantID,
+			Family:          strings.TrimSpace(runtime.Config["family"]),
+			RequiredSecrets: requiredSecrets,
+			RoleAssumptions: roleAssumptions(runtime.Config),
+			Config:          copyConfig(runtime.Config),
+		})
+	}
+
+	sources := make([]ContractSource, 0, len(catalogs))
+	for _, catalog := range catalogs {
+		manifest := manifestBySource[catalog.ID]
+		sources = append(sources, ContractSource{
+			SourceID:                 catalog.ID,
+			EmittedKinds:             sortedStrings(catalog.EmittedKinds),
+			SupportedFamilies:        supportedFamilies(catalog.ID, catalog.EmittedKinds, runtimesBySource[catalog.ID]),
+			RequiredSecrets:          sortedStrings(manifest.SecretKeys),
+			RoleAssumptionConfigKeys: roleAssumptionConfigKeys(catalog.ID),
+			Runtimes:                 runtimesBySource[catalog.ID],
+		})
+	}
+	sort.Slice(sources, func(i, j int) bool { return sources[i].SourceID < sources[j].SourceID })
+
+	return Contract{
+		SchemaVersion:   ContractSchemaVersion,
+		ImageTag:        strings.TrimSpace(opts.ImageTag),
+		Environment:     strings.TrimSpace(opts.Environment),
+		TenantID:        strings.TrimSpace(opts.TenantID),
+		RequiredSecrets: sortedStrings(fragment.SourceSecretKeys),
+		Sources:         sources,
+	}, nil
+}
+
+func (c Contract) MarshalJSONStable() ([]byte, error) {
+	return json.MarshalIndent(c, "", "  ")
+}
+
+func discoverCatalogs(sourcesRoot string) ([]contractCatalog, error) {
+	entries, err := os.ReadDir(sourcesRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read sources root %s: %w", sourcesRoot, err)
+	}
+	catalogs := make([]contractCatalog, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(sourcesRoot, entry.Name(), "catalog.yaml")
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read source catalog %s: %w", path, err)
+		}
+		var catalog contractCatalog
+		if err := yaml.Unmarshal(data, &catalog); err != nil {
+			return nil, fmt.Errorf("decode source catalog %s: %w", path, err)
+		}
+		if strings.TrimSpace(catalog.ID) == "" {
+			catalog.ID = entry.Name()
+		}
+		catalog.ID = strings.TrimSpace(catalog.ID)
+		catalogs = append(catalogs, catalog)
+	}
+	sort.Slice(catalogs, func(i, j int) bool { return catalogs[i].ID < catalogs[j].ID })
+	return catalogs, nil
+}
+
+func supportedFamilies(sourceID string, emittedKinds []string, runtimes []ContractRuntime) []string {
+	families := map[string]struct{}{}
+	prefix := sourceID + "."
+	for _, kind := range emittedKinds {
+		kind = strings.TrimSpace(kind)
+		if strings.HasPrefix(kind, prefix) {
+			family := strings.TrimSpace(strings.TrimPrefix(kind, prefix))
+			if family != "" {
+				families[family] = struct{}{}
+			}
+		}
+	}
+	for _, runtime := range runtimes {
+		if runtime.Family != "" {
+			families[runtime.Family] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(families))
+	for family := range families {
+		out = append(out, family)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func envRefs(config map[string]string) []string {
+	refs := map[string]struct{}{}
+	for _, value := range config {
+		if strings.HasPrefix(strings.TrimSpace(value), "env:") {
+			refs[strings.TrimPrefix(strings.TrimSpace(value), "env:")] = struct{}{}
+		}
+	}
+	return sortedStringSet(refs)
+}
+
+func roleAssumptions(config map[string]string) []RoleAssumption {
+	var assumptions []RoleAssumption
+	for key, value := range config {
+		if strings.EqualFold(strings.TrimSpace(key), "role_arn") && strings.TrimSpace(value) != "" {
+			assumptions = append(assumptions, RoleAssumption{ConfigKey: key, RoleARN: strings.TrimSpace(value)})
+		}
+	}
+	sort.Slice(assumptions, func(i, j int) bool {
+		if assumptions[i].ConfigKey == assumptions[j].ConfigKey {
+			return assumptions[i].RoleARN < assumptions[j].RoleARN
+		}
+		return assumptions[i].ConfigKey < assumptions[j].ConfigKey
+	})
+	return assumptions
+}
+
+func roleAssumptionConfigKeys(sourceID string) []string {
+	if sourceID == "aws" {
+		return []string{"role_arn"}
+	}
+	return nil
+}
+
+func sortedStrings(values []string) []string {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			set[trimmed] = struct{}{}
+		}
+	}
+	return sortedStringSet(set)
+}
+
+func sortedStringSet(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/tools/sourcedeploy/contract_test.go
+++ b/tools/sourcedeploy/contract_test.go
@@ -86,6 +86,27 @@ func TestContractMarshalJSONStable(t *testing.T) {
 	}
 }
 
+func TestRenderContractUsesRuntimeFamilyCatalogOverrides(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkSource(t, root, "sentinelone", "id: sentinelone\nemitted_kinds:\n  - sentinelone.application_inventory\nruntime_families:\n  - application\n", "")
+
+	manifests, err := Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	contract, err := RenderContract(root, manifests, ContractOptions{Environment: "sec-dev", TenantID: "writer"})
+	if err != nil {
+		t.Fatalf("RenderContract: %v", err)
+	}
+	if len(contract.Sources) != 1 {
+		t.Fatalf("sources = %d, want 1", len(contract.Sources))
+	}
+	if !equalStrings(contract.Sources[0].SupportedFamilies, []string{"application"}) {
+		t.Fatalf("supported families = %v", contract.Sources[0].SupportedFamilies)
+	}
+}
+
 func mkSource(t *testing.T, root string, name string, catalog string, deploy string) {
 	t.Helper()
 	dir := filepath.Join(root, name)

--- a/tools/sourcedeploy/contract_test.go
+++ b/tools/sourcedeploy/contract_test.go
@@ -1,0 +1,103 @@
+package sourcedeploy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRenderContractIncludesCatalogsSecretsFamiliesAndRoles(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mkSource(t, root, "aws", "id: aws\nemitted_kinds:\n  - aws.public_endpoint\n  - aws.iam_role\n", "")
+	mkSource(t, root, "okta", "id: okta\nemitted_kinds:\n  - okta.audit\n  - okta.user\n", `
+sourceId: okta
+secretKeys:
+  - OKTA_API_TOKEN
+  - OKTA_DOMAIN
+runtimes:
+  - localId: audit
+    config:
+      domain: env:OKTA_DOMAIN
+      family: audit
+      token: env:OKTA_API_TOKEN
+`)
+
+	manifests, err := Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	contract, err := RenderContract(root, manifests, ContractOptions{
+		Environment: "sec-dev",
+		TenantID:    "writer",
+		ImageTag:    "v2.1.60",
+	})
+	if err != nil {
+		t.Fatalf("RenderContract: %v", err)
+	}
+
+	if contract.SchemaVersion != ContractSchemaVersion {
+		t.Fatalf("schema version = %q", contract.SchemaVersion)
+	}
+	if contract.ImageTag != "v2.1.60" {
+		t.Fatalf("image tag = %q", contract.ImageTag)
+	}
+	if len(contract.Sources) != 2 {
+		t.Fatalf("sources = %d, want 2", len(contract.Sources))
+	}
+	aws := contract.Sources[0]
+	if aws.SourceID != "aws" || !equalStrings(aws.SupportedFamilies, []string{"iam_role", "public_endpoint"}) {
+		t.Fatalf("aws source = %#v", aws)
+	}
+	if !equalStrings(aws.RoleAssumptionConfigKeys, []string{"role_arn"}) {
+		t.Fatalf("aws role keys = %v", aws.RoleAssumptionConfigKeys)
+	}
+	okta := contract.Sources[1]
+	if !equalStrings(okta.RequiredSecrets, []string{"OKTA_API_TOKEN", "OKTA_DOMAIN"}) {
+		t.Fatalf("okta secrets = %v", okta.RequiredSecrets)
+	}
+	if len(okta.Runtimes) != 1 || okta.Runtimes[0].ID != "writer-okta-audit" {
+		t.Fatalf("okta runtimes = %#v", okta.Runtimes)
+	}
+	if !equalStrings(okta.Runtimes[0].RequiredSecrets, []string{"OKTA_API_TOKEN", "OKTA_DOMAIN"}) {
+		t.Fatalf("runtime secrets = %v", okta.Runtimes[0].RequiredSecrets)
+	}
+}
+
+func TestContractMarshalJSONStable(t *testing.T) {
+	t.Parallel()
+	contract := Contract{
+		SchemaVersion: ContractSchemaVersion,
+		Environment:   "sec-dev",
+		TenantID:      "writer",
+		Sources:       []ContractSource{{SourceID: "aws"}},
+	}
+	data, err := contract.MarshalJSONStable()
+	if err != nil {
+		t.Fatalf("MarshalJSONStable: %v", err)
+	}
+	var decoded Contract
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v\n%s", err, data)
+	}
+	if decoded.SchemaVersion != ContractSchemaVersion {
+		t.Fatalf("decoded schema = %q", decoded.SchemaVersion)
+	}
+}
+
+func mkSource(t *testing.T, root string, name string, catalog string, deploy string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "catalog.yaml"), []byte(catalog), 0o644); err != nil {
+		t.Fatalf("WriteFile(catalog): %v", err)
+	}
+	if deploy != "" {
+		if err := os.WriteFile(filepath.Join(dir, "deploy.yaml"), []byte(deploy), 0o644); err != nil {
+			t.Fatalf("WriteFile(deploy): %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add contract-json output to sourcedeploy with source catalogs, supported families, required secrets, manifest runtimes, and AWS role-assumption metadata
- publish and keylessly sign cerebro-runtime-contract.json during release before dispatching infra deployment

## Validation
- make verify
- actionlint -color=false .github/workflows/release.yml
- go run ./cmd/sourcedeploy -env sec-dev -tenant writer -format contract-json -image-tag v2.1.60 | python3 -m json.tool