### PR TITLE
fix finding evidence graph path filter

### DIFF
--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1465,6 +1465,7 @@ func (a *App) handleListFindingEvidence(w http.ResponseWriter, r *http.Request) 
 		ClaimID:      request.GetClaimId(),
 		EventID:      request.GetEventId(),
 		GraphRootURN: request.GetGraphRootUrn(),
+		GraphPathURN: request.GetGraphPathUrn(),
 		Limit:        request.GetLimit(),
 	})
 	if err != nil {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -4410,7 +4410,7 @@ func TestFindingEndpoints(t *testing.T) {
 	if got, present := runEntry["graph_rows_read"]; !present || got != float64(0) {
 		t.Fatalf("list evaluation run graph_rows_read = %#v (present=%t), want 0 present", got, present)
 	}
-	evidenceListResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-okta-policy-rule/finding-evidence?finding_id=" + findingPayload["id"].(string) + "&run_id=" + runID + "&claim_id=claim-1&event_id=okta-policy-rule-inactive&graph_root_urn=urn:cerebro:writer:okta_policy_rule:pol-1:rul-1&limit=1")
+	evidenceListResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-okta-policy-rule/finding-evidence?finding_id=" + findingPayload["id"].(string) + "&run_id=" + runID + "&claim_id=claim-1&event_id=okta-policy-rule-inactive&graph_root_urn=urn:cerebro:writer:okta_policy_rule:pol-1:rul-1&graph_path_urn=urn:cerebro:writer:okta_user:00u2&limit=1")
 	if err != nil {
 		t.Fatalf("GET /source-runtimes/{id}/finding-evidence error = %v", err)
 	}
@@ -4433,6 +4433,9 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	if got := listedEvidence["id"]; got != evidenceID {
 		t.Fatalf("list finding evidence id = %#v, want %q", got, evidenceID)
+	}
+	if got := runtimeStore.findingEvidenceListRequest.GraphPathURN; got != "urn:cerebro:writer:okta_user:00u2" {
+		t.Fatalf("runtimeStore.findingEvidenceListRequest.GraphPathURN = %q, want graph path urn", got)
 	}
 	getEvidenceResp, err := server.Client().Get(server.URL + "/finding-evidence/" + evidenceID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Pass HTTP graph_path_urn through to findings ListEvidence requests.
- Add regression coverage proving the /finding-evidence query parameter reaches the service/store request.

## Validation
- go test ./internal/bootstrap -run FindingEvidence -count=1 -v (passes; no matching tests)
- go test ./internal/bootstrap -run '^TestFindingEndpoints$' -count=1 -v
- make openapi-check
- make verify