### PR TITLE
fix: encode nested workflow metadata

### DIFF
--- a/internal/eventregistry/avro.go
+++ b/internal/eventregistry/avro.go
@@ -3,6 +3,7 @@ package eventregistry
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -177,6 +178,14 @@ func (w *avroWriter) metadataValue(value any) {
 	case bool:
 		w.long(4)
 		w.boolean(v)
+	case map[string]any:
+		w.jsonMetadata(v)
+	case []any:
+		w.jsonMetadata(v)
+	case map[string]string:
+		w.jsonMetadata(v)
+	case []string:
+		w.jsonMetadata(v)
 	default:
 		w.setErr(fmt.Errorf("unsupported metadata value type %T", value))
 	}
@@ -202,6 +211,16 @@ func (w *avroWriter) uintMetadata(value any) {
 	}
 	w.long(2)
 	w.long(int64(u))
+}
+
+func (w *avroWriter) jsonMetadata(value any) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		w.setErr(fmt.Errorf("marshal metadata value %T: %w", value, err))
+		return
+	}
+	w.long(1)
+	w.string(string(payload))
 }
 
 func sortedKeys[V any](values map[string]V) []string {

--- a/internal/workflowevents/events_test.go
+++ b/internal/workflowevents/events_test.go
@@ -53,6 +53,36 @@ func TestNewDecisionRecordedEventIsStableAndDecodable(t *testing.T) {
 	}
 }
 
+func TestNewDecisionRecordedEventEncodesNestedMetadata(t *testing.T) {
+	payload := DecisionRecorded{
+		TenantID:     "writer",
+		DecisionID:   "urn:cerebro:writer:decision:decision-1",
+		DecisionType: "finding-triage",
+		Status:       "approved",
+		TargetIDs:    []string{"urn:cerebro:writer:resource:target-1"},
+		SourceSystem: "findings",
+		ObservedAt:   "2026-04-27T12:00:00Z",
+		ValidFrom:    "2026-04-27T12:00:00Z",
+		Metadata: map[string]any{
+			"context": map[string]any{
+				"nested": true,
+				"owners": []any{"sec", "eng"},
+			},
+		},
+	}
+	event, err := NewDecisionRecordedEvent(payload)
+	if err != nil {
+		t.Fatalf("NewDecisionRecordedEvent() error = %v", err)
+	}
+	decoded, err := DecodeDecisionRecorded(event)
+	if err != nil {
+		t.Fatalf("DecodeDecisionRecorded() error = %v", err)
+	}
+	if got := decoded.Metadata["context"]; got != `{"nested":true,"owners":["sec","eng"]}` {
+		t.Fatalf("decoded nested metadata = %#v", got)
+	}
+}
+
 func TestCanonicalWorkflowIDUsesProvidedURN(t *testing.T) {
 	urn := "urn:cerebro:writer:decision:decision-1"
 	if got := CanonicalWorkflowID("writer", "decision", urn, "decision", nil, time.Time{}); got != urn {


### PR DESCRIPTION
## Summary
- support nested workflow metadata in Avro encoding by storing compound metadata values as deterministic JSON strings
- add regression coverage for nested decision metadata round-tripping through the shared workflow envelope

## Validation
- go test ./internal/workflowevents -run NestedMetadata -count=1
- make verify