### PR TITLE
m4-fix-backfill-collision-merge: handle fingerprint collisions

### DIFF
--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -169,6 +169,17 @@ const findingSelectColumns = `id, fingerprint, tenant_id, runtime_id, rule_id, t
   status_updated_at, first_observed_at, last_observed_at,
   tombstoned, tombstoned_at, tombstoned_by, tombstoned_reason, tombstoned_run_id, prior_status, tombstone_generation`
 
+type findingStatusReason string
+
+const findingStatusReasonBackfillCollision findingStatusReason = "backfill_collision"
+
+const (
+	tenantScopedFingerprintBackfillActor = "tenant_scoped_fingerprint_backfill"
+	tenantScopedFingerprintBackfillRunID = "tenant_scoped_fingerprint_backfill"
+)
+
+var errTenantScopedFingerprintBackfillRetry = errors.New("retry tenant-scoped fingerprint backfill")
+
 // upsertFindingStatement persists one finding row, preserving runtime_id on conflict.
 //
 // runtime_id is intentionally pinned on first insert. Event-rule fingerprints already include
@@ -1078,59 +1089,287 @@ func (s *Store) backfillTenantScopedFindingFingerprints(ctx context.Context) err
 		placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
 	}
 	query := fmt.Sprintf(`
-SELECT id, tenant_id, rule_id, fingerprint, attributes_json
+SELECT id, tenant_id, rule_id, fingerprint, attributes_json, resource_urns_json, status, created_at, updated_at
 FROM findings
 WHERE tombstoned = FALSE
-  AND rule_id IN (%s)`, strings.Join(placeholders, ", "))
-	rows, err := s.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return fmt.Errorf("list tenant-scoped fingerprint backfill rows: %w", err)
-	}
-	type fingerprintUpdate struct {
-		id          string
-		fingerprint string
-	}
-	updates := []fingerprintUpdate{}
-	for rows.Next() {
-		var id, tenantID, ruleID, currentFingerprint string
-		var rawAttributes []byte
-		if err := rows.Scan(&id, &tenantID, &ruleID, &currentFingerprint, &rawAttributes); err != nil {
-			_ = rows.Close()
-			return fmt.Errorf("scan tenant-scoped fingerprint backfill row: %w", err)
-		}
-		attributes := map[string]string{}
-		if len(rawAttributes) != 0 {
-			if err := json.Unmarshal(rawAttributes, &attributes); err != nil {
-				_ = rows.Close()
-				return fmt.Errorf("decode tenant-scoped fingerprint backfill attributes for %q: %w", id, err)
+  AND rule_id IN (%s)
+ORDER BY tenant_id, rule_id, id
+FOR UPDATE`, strings.Join(placeholders, ", "))
+	const maxAttempts = 4
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := s.backfillTenantScopedFindingFingerprintsOnce(ctx, query, args); err != nil {
+			lastErr = err
+			if errors.Is(err, errTenantScopedFingerprintBackfillRetry) || isPartialUniqueIndexConflict(err) {
+				continue
 			}
+			return err
 		}
-		fingerprint := tenantScopedFingerprintBackfill(ruleID, tenantID, attributes)
-		if fingerprint == "" || fingerprint == strings.TrimSpace(currentFingerprint) {
-			continue
-		}
-		updates = append(updates, fingerprintUpdate{id: strings.TrimSpace(id), fingerprint: fingerprint})
+		return nil
 	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return fmt.Errorf("iterate tenant-scoped fingerprint backfill rows: %w", err)
-	}
-	if err := rows.Close(); err != nil {
-		return fmt.Errorf("close tenant-scoped fingerprint backfill rows: %w", err)
-	}
-	for _, update := range updates {
-		if update.id == "" || update.fingerprint == "" {
-			continue
-		}
-		if _, err := s.db.ExecContext(ctx,
-			`UPDATE findings SET fingerprint = $2, updated_at = NOW() WHERE id = $1 AND tombstoned = FALSE`,
-			update.id,
-			update.fingerprint,
-		); err != nil {
-			return fmt.Errorf("backfill tenant-scoped fingerprint for finding %q: %w", update.id, err)
-		}
+	if lastErr != nil {
+		return lastErr
 	}
 	return nil
+}
+
+func (s *Store) backfillTenantScopedFindingFingerprintsOnce(ctx context.Context, query string, args []any) (err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tenant-scoped fingerprint backfill: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	groups, err := loadTenantScopedFingerprintBackfillGroups(ctx, tx, query, args)
+	if err != nil {
+		return err
+	}
+
+	keys := make([]tenantScopedFingerprintBackfillGroupKey, 0, len(groups))
+	for key := range groups {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].tenantID != keys[j].tenantID {
+			return keys[i].tenantID < keys[j].tenantID
+		}
+		return keys[i].fingerprint < keys[j].fingerprint
+	})
+	for _, key := range keys {
+		rows := groups[key]
+		if len(rows) == 0 {
+			continue
+		}
+		if len(rows) == 1 {
+			if err := updateTenantScopedBackfillWinnerFingerprint(ctx, tx, rows[0], key.fingerprint); err != nil {
+				return err
+			}
+			continue
+		}
+		sort.SliceStable(rows, func(i, j int) bool {
+			return tenantScopedBackfillRowWins(rows[i], rows[j])
+		})
+		winner := rows[0]
+		now := time.Now().UTC()
+		for _, loser := range rows[1:] {
+			if err := tombstoneTenantScopedBackfillCollisionLoser(ctx, tx, loser, now); err != nil {
+				return err
+			}
+		}
+		if err := updateTenantScopedBackfillWinnerFingerprint(ctx, tx, winner, key.fingerprint); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tenant-scoped fingerprint backfill: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+type tenantScopedFingerprintBackfillGroupKey struct {
+	tenantID    string
+	fingerprint string
+}
+
+type tenantScopedFingerprintBackfillRow struct {
+	id                 string
+	tenantID           string
+	ruleID             string
+	currentFingerprint string
+	newFingerprint     string
+	status             string
+	attributes         map[string]string
+	resourceURNs       []string
+	createdAt          time.Time
+	updatedAt          time.Time
+}
+
+type tenantScopedBackfillQuerier interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func loadTenantScopedFingerprintBackfillGroups(ctx context.Context, querier tenantScopedBackfillQuerier, query string, args []any) (map[tenantScopedFingerprintBackfillGroupKey][]tenantScopedFingerprintBackfillRow, error) {
+	rows, err := querier.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list tenant-scoped fingerprint backfill rows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	groups := map[tenantScopedFingerprintBackfillGroupKey][]tenantScopedFingerprintBackfillRow{}
+	for rows.Next() {
+		var row tenantScopedFingerprintBackfillRow
+		var rawAttributes []byte
+		var rawResourceURNs []byte
+		if err := rows.Scan(
+			&row.id,
+			&row.tenantID,
+			&row.ruleID,
+			&row.currentFingerprint,
+			&rawAttributes,
+			&rawResourceURNs,
+			&row.status,
+			&row.createdAt,
+			&row.updatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan tenant-scoped fingerprint backfill row: %w", err)
+		}
+		attributes, err := decodeTenantScopedBackfillAttributes(rawAttributes)
+		if err != nil {
+			return nil, fmt.Errorf("decode tenant-scoped fingerprint backfill attributes for %q: %w", strings.TrimSpace(row.id), err)
+		}
+		resourceURNs, err := decodeTenantScopedBackfillResourceURNs(rawResourceURNs)
+		if err != nil {
+			return nil, fmt.Errorf("decode tenant-scoped fingerprint backfill resource urns for %q: %w", strings.TrimSpace(row.id), err)
+		}
+		row.id = strings.TrimSpace(row.id)
+		row.tenantID = strings.TrimSpace(row.tenantID)
+		row.ruleID = strings.TrimSpace(row.ruleID)
+		row.currentFingerprint = strings.TrimSpace(row.currentFingerprint)
+		row.status = strings.TrimSpace(row.status)
+		row.attributes = attributes
+		row.resourceURNs = resourceURNs
+		row.createdAt = row.createdAt.UTC()
+		row.updatedAt = row.updatedAt.UTC()
+		row.newFingerprint = tenantScopedFingerprintBackfill(row.ruleID, row.tenantID, row.attributes)
+		if row.id == "" || row.tenantID == "" || row.newFingerprint == "" {
+			continue
+		}
+		key := tenantScopedFingerprintBackfillGroupKey{tenantID: row.tenantID, fingerprint: row.newFingerprint}
+		groups[key] = append(groups[key], row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tenant-scoped fingerprint backfill rows: %w", err)
+	}
+	return groups, nil
+}
+
+func decodeTenantScopedBackfillAttributes(raw []byte) (map[string]string, error) {
+	attributes := map[string]string{}
+	if len(raw) == 0 {
+		return attributes, nil
+	}
+	if err := json.Unmarshal(raw, &attributes); err != nil {
+		return nil, err
+	}
+	return attributes, nil
+}
+
+func decodeTenantScopedBackfillResourceURNs(raw []byte) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	resourceURNs := []string{}
+	if err := json.Unmarshal(raw, &resourceURNs); err != nil {
+		return nil, err
+	}
+	return normalizedNonEmptyStrings(resourceURNs), nil
+}
+
+func tenantScopedBackfillRowWins(a tenantScopedFingerprintBackfillRow, b tenantScopedFingerprintBackfillRow) bool {
+	if !a.updatedAt.Equal(b.updatedAt) {
+		return a.updatedAt.After(b.updatedAt)
+	}
+	if !a.createdAt.Equal(b.createdAt) {
+		return a.createdAt.After(b.createdAt)
+	}
+	return strings.TrimSpace(a.id) < strings.TrimSpace(b.id)
+}
+
+func updateTenantScopedBackfillWinnerFingerprint(ctx context.Context, tx *sql.Tx, row tenantScopedFingerprintBackfillRow, fingerprint string) error {
+	id := strings.TrimSpace(row.id)
+	fingerprint = strings.TrimSpace(fingerprint)
+	if id == "" || fingerprint == "" || strings.TrimSpace(row.currentFingerprint) == fingerprint {
+		return nil
+	}
+	result, err := tx.ExecContext(ctx,
+		`UPDATE findings SET fingerprint = $2, updated_at = NOW() WHERE id = $1 AND tombstoned = FALSE`,
+		id,
+		fingerprint,
+	)
+	if err != nil {
+		return fmt.Errorf("backfill tenant-scoped fingerprint for finding %q: %w", id, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("backfill tenant-scoped fingerprint for finding %q rowsAffected: %w", id, err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("backfill tenant-scoped fingerprint for finding %q: %w", id, errTenantScopedFingerprintBackfillRetry)
+	}
+	return nil
+}
+
+func tombstoneTenantScopedBackfillCollisionLoser(ctx context.Context, tx *sql.Tx, row tenantScopedFingerprintBackfillRow, tombstonedAt time.Time) error {
+	id := strings.TrimSpace(row.id)
+	if id == "" {
+		return nil
+	}
+	reason := string(findingStatusReasonBackfillCollision)
+	tombstonedAt = tombstonedAt.UTC()
+	if tombstonedAt.IsZero() {
+		tombstonedAt = time.Now().UTC()
+	}
+	priorStatus := strings.TrimSpace(row.status)
+	if priorStatus == "" {
+		priorStatus = "open"
+	}
+	updated, err := tombstoneFindingStatusInTx(ctx, tx, ports.FindingStatusUpdate{
+		FindingID: id,
+		Status:    "resolved",
+		Reason:    reason,
+		UpdatedAt: tombstonedAt,
+		Tombstone: &ports.FindingTombstoneApply{
+			By:           tenantScopedFingerprintBackfillActor,
+			Reason:       reason,
+			RunID:        tenantScopedFingerprintBackfillRunID,
+			PriorStatus:  priorStatus,
+			TombstonedAt: tombstonedAt,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("tombstone tenant-scoped fingerprint backfill collision finding %q: %w", id, err)
+	}
+	anchorURI := tenantScopedBackfillAnchorURI(row.resourceURNs, row.attributes)
+	if anchorURI == "" && updated != nil {
+		anchorURI = tenantScopedBackfillAnchorURI(updated.ResourceURNs, updated.Attributes)
+	}
+	if err := insertFindingTombstoneEvent(ctx, tx, ports.FindingTombstoneEvent{
+		FindingID:    id,
+		TenantID:     strings.TrimSpace(row.tenantID),
+		RuleID:       strings.TrimSpace(row.ruleID),
+		AnchorURI:    anchorURI,
+		PriorStatus:  priorStatus,
+		Reason:       reason,
+		Actor:        tenantScopedFingerprintBackfillActor,
+		RunID:        tenantScopedFingerprintBackfillRunID,
+		TombstonedAt: tombstonedAt,
+	}); err != nil {
+		return fmt.Errorf("audit tenant-scoped fingerprint backfill collision finding %q: %w", id, err)
+	}
+	return nil
+}
+
+func tenantScopedBackfillAnchorURI(resourceURNs []string, attributes map[string]string) string {
+	for _, urn := range resourceURNs {
+		if trimmed := strings.TrimSpace(urn); trimmed != "" {
+			return trimmed
+		}
+	}
+	if attributes == nil {
+		return ""
+	}
+	return firstNonEmptyPostgres(
+		attributes["primary_resource_urn"],
+		attributes["resource_urn"],
+		attributes["resource_id"],
+		attributes["user_urn"],
+		attributes["group_urn"],
+	)
 }
 
 func tenantScopedFingerprintBackfillRuleIDs() []string {

--- a/internal/statestore/postgres/tenant_scoped_fingerprint_test.go
+++ b/internal/statestore/postgres/tenant_scoped_fingerprint_test.go
@@ -1,0 +1,482 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	tenantScopedBackfillTestRuleID = "identity-api-token-or-oauth-app-created"
+	wantBackfillCollisionReason    = "backfill_collision"
+	wantBackfillCollisionActor     = "tenant_scoped_fingerprint_backfill"
+	wantBackfillCollisionRunID     = "tenant_scoped_fingerprint_backfill"
+)
+
+func TestBackfillTenantScopedFindingFingerprints_CollisionKeepsMostRecent(t *testing.T) {
+	ctx := context.Background()
+	store := tombstoneStoreFromEnv(t)
+	resetTombstoneSchema(t, ctx, store)
+
+	nonce := time.Now().UnixNano()
+	tenantID := fmt.Sprintf("example-backfill-collision-two-%d", nonce)
+	userURN := testIdentityProjectionURN(tenantID, "okta_user", "00u-collision-two")
+	wantFingerprint := testFindingFingerprint(tenantScopedBackfillTestRuleID, tenantID, userURN, "cred-collision-two")
+	base := time.Date(2026, 5, 24, 10, 0, 0, 0, time.UTC)
+
+	insertTenantScopedBackfillFinding(t, ctx, store, tenantScopedBackfillFinding{
+		id:           "older-two-row",
+		tenantID:     tenantID,
+		userID:       "00u-collision-two",
+		credentialID: "cred-collision-two",
+		resourceURN:  "urn:cerebro:" + tenantID + ":okta_user:00u-collision-two",
+		createdAt:    base,
+		updatedAt:    base.Add(1 * time.Minute),
+	})
+	insertTenantScopedBackfillFinding(t, ctx, store, tenantScopedBackfillFinding{
+		id:           "winner-two-row",
+		tenantID:     tenantID,
+		userID:       "00u-collision-two",
+		credentialID: "cred-collision-two",
+		resourceURN:  "urn:cerebro:" + tenantID + ":okta_user:00u-collision-two",
+		createdAt:    base.Add(2 * time.Minute),
+		updatedAt:    base.Add(3 * time.Minute),
+	})
+
+	runTenantScopedBackfillForTest(t, ctx, store)
+
+	assertTenantScopedBackfillWinner(t, ctx, store, "winner-two-row", wantFingerprint)
+	assertTenantScopedBackfillLoser(t, ctx, store, "older-two-row")
+	events := loadBackfillCollisionEvents(t, ctx, store, wantBackfillCollisionRunID)
+	if got, want := len(events), 1; got != want {
+		t.Fatalf("backfill tombstone events = %d, want %d: %#v", got, want, events)
+	}
+	if got := events[0].findingID; got != "older-two-row" {
+		t.Fatalf("event finding_id = %q, want older-two-row", got)
+	}
+}
+
+func TestBackfillTenantScopedFindingFingerprints_CollisionUsesUpdatedThenCreatedTieBreak(t *testing.T) {
+	ctx := context.Background()
+	store := tombstoneStoreFromEnv(t)
+	resetTombstoneSchema(t, ctx, store)
+
+	nonce := time.Now().UnixNano()
+	tenantID := fmt.Sprintf("example-backfill-collision-three-%d", nonce)
+	userURN := testIdentityProjectionURN(tenantID, "okta_user", "00u-collision-three")
+	wantFingerprint := testFindingFingerprint(tenantScopedBackfillTestRuleID, tenantID, userURN, "cred-collision-three")
+	base := time.Date(2026, 5, 24, 11, 0, 0, 0, time.UTC)
+
+	rows := []tenantScopedBackfillFinding{
+		{
+			id:           "old-updated-new-created-loser",
+			tenantID:     tenantID,
+			userID:       "00u-collision-three",
+			credentialID: "cred-collision-three",
+			resourceURN:  "urn:cerebro:" + tenantID + ":okta_user:old-updated",
+			createdAt:    base.Add(30 * time.Minute),
+			updatedAt:    base.Add(1 * time.Minute),
+		},
+		{
+			id:           "new-updated-old-created-loser",
+			tenantID:     tenantID,
+			userID:       "00u-collision-three",
+			credentialID: "cred-collision-three",
+			resourceURN:  "urn:cerebro:" + tenantID + ":okta_user:new-updated-old-created",
+			createdAt:    base.Add(2 * time.Minute),
+			updatedAt:    base.Add(40 * time.Minute),
+		},
+		{
+			id:           "new-updated-new-created-winner",
+			tenantID:     tenantID,
+			userID:       "00u-collision-three",
+			credentialID: "cred-collision-three",
+			resourceURN:  "urn:cerebro:" + tenantID + ":okta_user:new-updated-new-created",
+			createdAt:    base.Add(3 * time.Minute),
+			updatedAt:    base.Add(40 * time.Minute),
+		},
+	}
+	for _, row := range rows {
+		insertTenantScopedBackfillFinding(t, ctx, store, row)
+	}
+
+	runTenantScopedBackfillForTest(t, ctx, store)
+
+	assertTenantScopedBackfillWinner(t, ctx, store, "new-updated-new-created-winner", wantFingerprint)
+	assertTenantScopedBackfillLoser(t, ctx, store, "old-updated-new-created-loser")
+	assertTenantScopedBackfillLoser(t, ctx, store, "new-updated-old-created-loser")
+	events := loadBackfillCollisionEvents(t, ctx, store, wantBackfillCollisionRunID)
+	if got, want := len(events), 2; got != want {
+		t.Fatalf("backfill tombstone events = %d, want %d: %#v", got, want, events)
+	}
+	gotLosers := []string{events[0].findingID, events[1].findingID}
+	sort.Strings(gotLosers)
+	wantLosers := []string{"new-updated-old-created-loser", "old-updated-new-created-loser"}
+	for i := range wantLosers {
+		if gotLosers[i] != wantLosers[i] {
+			t.Fatalf("event loser IDs = %#v, want %#v", gotLosers, wantLosers)
+		}
+	}
+}
+
+func TestBackfillTenantScopedFindingFingerprints_CollisionTieBreaksByID(t *testing.T) {
+	ctx := context.Background()
+	store := tombstoneStoreFromEnv(t)
+	resetTombstoneSchema(t, ctx, store)
+
+	nonce := time.Now().UnixNano()
+	tenantID := fmt.Sprintf("example-backfill-collision-tie-%d", nonce)
+	userURN := testIdentityProjectionURN(tenantID, "okta_user", "00u-collision-tie")
+	wantFingerprint := testFindingFingerprint(tenantScopedBackfillTestRuleID, tenantID, userURN, "cred-collision-tie")
+	ts := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+
+	for _, id := range []string{"b-loser", "a-winner", "c-loser"} {
+		insertTenantScopedBackfillFinding(t, ctx, store, tenantScopedBackfillFinding{
+			id:           id,
+			tenantID:     tenantID,
+			userID:       "00u-collision-tie",
+			credentialID: "cred-collision-tie",
+			resourceURN:  "urn:cerebro:" + tenantID + ":okta_user:" + id,
+			createdAt:    ts,
+			updatedAt:    ts,
+		})
+	}
+
+	runTenantScopedBackfillForTest(t, ctx, store)
+
+	assertTenantScopedBackfillWinner(t, ctx, store, "a-winner", wantFingerprint)
+	assertTenantScopedBackfillLoser(t, ctx, store, "b-loser")
+	assertTenantScopedBackfillLoser(t, ctx, store, "c-loser")
+}
+
+func TestBackfillTenantScopedFindingFingerprints_NoCollisionUpdatesOnlyLegacyRows(t *testing.T) {
+	ctx := context.Background()
+	store := tombstoneStoreFromEnv(t)
+	resetTombstoneSchema(t, ctx, store)
+
+	nonce := time.Now().UnixNano()
+	tenantID := fmt.Sprintf("example-backfill-no-collision-%d", nonce)
+	base := time.Date(2026, 5, 24, 13, 0, 0, 0, time.UTC).Truncate(time.Microsecond)
+	alreadyCurrentUserURN := testIdentityProjectionURN(tenantID, "okta_user", "00u-current")
+	alreadyCurrentFingerprint := testFindingFingerprint(tenantScopedBackfillTestRuleID, tenantID, alreadyCurrentUserURN, "cred-current")
+	legacyUserURN := testIdentityProjectionURN(tenantID, "okta_user", "00u-legacy")
+	legacyWantFingerprint := testFindingFingerprint(tenantScopedBackfillTestRuleID, tenantID, legacyUserURN, "cred-legacy")
+
+	insertTenantScopedBackfillFinding(t, ctx, store, tenantScopedBackfillFinding{
+		id:           "already-current",
+		tenantID:     tenantID,
+		fingerprint:  alreadyCurrentFingerprint,
+		userID:       "00u-current",
+		credentialID: "cred-current",
+		resourceURN:  "urn:cerebro:" + tenantID + ":okta_user:current",
+		createdAt:    base,
+		updatedAt:    base.Add(1 * time.Minute),
+	})
+	insertTenantScopedBackfillFinding(t, ctx, store, tenantScopedBackfillFinding{
+		id:           "legacy-no-collision",
+		tenantID:     tenantID,
+		userID:       "00u-legacy",
+		credentialID: "cred-legacy",
+		resourceURN:  "urn:cerebro:" + tenantID + ":okta_user:legacy",
+		createdAt:    base.Add(2 * time.Minute),
+		updatedAt:    base.Add(3 * time.Minute),
+	})
+
+	beforeCurrent := loadTenantScopedBackfillRow(t, ctx, store, "already-current")
+	runTenantScopedBackfillForTest(t, ctx, store)
+
+	afterCurrent := loadTenantScopedBackfillRow(t, ctx, store, "already-current")
+	if afterCurrent.fingerprint != alreadyCurrentFingerprint {
+		t.Fatalf("already-current fingerprint = %q, want %q", afterCurrent.fingerprint, alreadyCurrentFingerprint)
+	}
+	if !afterCurrent.updatedAt.Equal(beforeCurrent.updatedAt) {
+		t.Fatalf("already-current updated_at = %s, want unchanged %s", afterCurrent.updatedAt, beforeCurrent.updatedAt)
+	}
+	assertTenantScopedBackfillWinner(t, ctx, store, "legacy-no-collision", legacyWantFingerprint)
+	var tombstoned int
+	if err := store.db.QueryRowContext(ctx, `SELECT count(*) FROM findings WHERE tenant_id = $1 AND tombstoned = TRUE`, tenantID).Scan(&tombstoned); err != nil {
+		t.Fatalf("count tombstoned rows: %v", err)
+	}
+	if tombstoned != 0 {
+		t.Fatalf("tombstoned rows in no-collision case = %d, want 0", tombstoned)
+	}
+	if events := loadBackfillCollisionEvents(t, ctx, store, wantBackfillCollisionRunID); len(events) != 0 {
+		t.Fatalf("backfill collision events in no-collision case = %#v, want none", events)
+	}
+}
+
+func TestBackfillTenantScopedFindingFingerprints_IdempotentSkipsTombstonedLosers(t *testing.T) {
+	ctx := context.Background()
+	store := tombstoneStoreFromEnv(t)
+	resetTombstoneSchema(t, ctx, store)
+
+	nonce := time.Now().UnixNano()
+	tenantID := fmt.Sprintf("example-backfill-idempotent-%d", nonce)
+	userURN := testIdentityProjectionURN(tenantID, "okta_user", "00u-idempotent")
+	wantFingerprint := testFindingFingerprint(tenantScopedBackfillTestRuleID, tenantID, userURN, "cred-idempotent")
+	base := time.Date(2026, 5, 24, 14, 0, 0, 0, time.UTC)
+
+	insertTenantScopedBackfillFinding(t, ctx, store, tenantScopedBackfillFinding{
+		id:           "idempotent-loser",
+		tenantID:     tenantID,
+		userID:       "00u-idempotent",
+		credentialID: "cred-idempotent",
+		resourceURN:  "urn:cerebro:" + tenantID + ":okta_user:idempotent-loser",
+		createdAt:    base,
+		updatedAt:    base.Add(1 * time.Minute),
+	})
+	insertTenantScopedBackfillFinding(t, ctx, store, tenantScopedBackfillFinding{
+		id:           "idempotent-winner",
+		tenantID:     tenantID,
+		userID:       "00u-idempotent",
+		credentialID: "cred-idempotent",
+		resourceURN:  "urn:cerebro:" + tenantID + ":okta_user:idempotent-winner",
+		createdAt:    base.Add(2 * time.Minute),
+		updatedAt:    base.Add(3 * time.Minute),
+	})
+
+	runTenantScopedBackfillForTest(t, ctx, store)
+	assertTenantScopedBackfillWinner(t, ctx, store, "idempotent-winner", wantFingerprint)
+	assertTenantScopedBackfillLoser(t, ctx, store, "idempotent-loser")
+	eventsAfterFirst := loadBackfillCollisionEvents(t, ctx, store, wantBackfillCollisionRunID)
+	if len(eventsAfterFirst) != 1 {
+		t.Fatalf("events after first backfill = %d, want 1", len(eventsAfterFirst))
+	}
+
+	runTenantScopedBackfillForTest(t, ctx, store)
+	assertTenantScopedBackfillWinner(t, ctx, store, "idempotent-winner", wantFingerprint)
+	assertTenantScopedBackfillLoser(t, ctx, store, "idempotent-loser")
+	eventsAfterSecond := loadBackfillCollisionEvents(t, ctx, store, wantBackfillCollisionRunID)
+	if len(eventsAfterSecond) != len(eventsAfterFirst) {
+		t.Fatalf("events after second backfill = %d, want unchanged %d", len(eventsAfterSecond), len(eventsAfterFirst))
+	}
+}
+
+type tenantScopedBackfillFinding struct {
+	id           string
+	tenantID     string
+	fingerprint  string
+	userID       string
+	credentialID string
+	resourceURN  string
+	createdAt    time.Time
+	updatedAt    time.Time
+}
+
+func insertTenantScopedBackfillFinding(t *testing.T, ctx context.Context, store *Store, row tenantScopedBackfillFinding) {
+	t.Helper()
+	if strings.TrimSpace(row.fingerprint) == "" {
+		row.fingerprint = testFindingFingerprint(tenantScopedBackfillTestRuleID, row.id, row.userID, row.credentialID)
+	}
+	attributes := map[string]string{
+		"source_id":     "okta",
+		"user_id":       row.userID,
+		"credential_id": row.credentialID,
+	}
+	attributesJSON, err := json.Marshal(attributes)
+	if err != nil {
+		t.Fatalf("marshal attributes: %v", err)
+	}
+	resourceURNs := []string{}
+	if strings.TrimSpace(row.resourceURN) != "" {
+		resourceURNs = append(resourceURNs, row.resourceURN)
+	}
+	resourceURNsJSON, err := json.Marshal(resourceURNs)
+	if err != nil {
+		t.Fatalf("marshal resource urns: %v", err)
+	}
+	createdAt := row.createdAt.UTC().Truncate(time.Microsecond)
+	updatedAt := row.updatedAt.UTC().Truncate(time.Microsecond)
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC().Truncate(time.Microsecond)
+	}
+	if updatedAt.IsZero() {
+		updatedAt = createdAt
+	}
+	if _, err := store.db.ExecContext(ctx, `
+        INSERT INTO findings (
+            id, fingerprint, tenant_id, runtime_id, rule_id, title, severity, status, summary,
+            resource_urns_json, attributes_json, first_observed_at, last_observed_at, created_at, updated_at
+        )
+        VALUES (
+            $1, $2, $3, $4, $5, 'Tenant-scoped backfill test', 'HIGH', 'open', 'summary',
+            $6::jsonb, $7::jsonb, $8, $9, $10, $11
+        )`,
+		row.id,
+		row.fingerprint,
+		row.tenantID,
+		"runtime-"+row.id,
+		tenantScopedBackfillTestRuleID,
+		string(resourceURNsJSON),
+		string(attributesJSON),
+		createdAt,
+		updatedAt,
+		createdAt,
+		updatedAt,
+	); err != nil {
+		t.Fatalf("insert tenant-scoped backfill row %q: %v", row.id, err)
+	}
+}
+
+func runTenantScopedBackfillForTest(t *testing.T, ctx context.Context, store *Store) {
+	t.Helper()
+	store.schemaMu.Lock()
+	store.findingTablesReady = false
+	store.schemaMu.Unlock()
+	ensureTombstoneSchema(t, ctx, store)
+}
+
+type tenantScopedBackfillRow struct {
+	id               string
+	fingerprint      string
+	status           string
+	statusReason     string
+	tombstoned       bool
+	tombstonedAt     sql.NullTime
+	tombstonedReason string
+	tombstonedBy     string
+	tombstonedRunID  string
+	priorStatus      string
+	createdAt        time.Time
+	updatedAt        time.Time
+}
+
+func loadTenantScopedBackfillRow(t *testing.T, ctx context.Context, store *Store, id string) tenantScopedBackfillRow {
+	t.Helper()
+	var row tenantScopedBackfillRow
+	if err := store.db.QueryRowContext(ctx, `
+        SELECT id, fingerprint, status, status_reason, tombstoned, tombstoned_at,
+               tombstoned_reason, tombstoned_by, tombstoned_run_id, prior_status,
+               created_at, updated_at
+        FROM findings
+        WHERE id = $1`, id,
+	).Scan(
+		&row.id,
+		&row.fingerprint,
+		&row.status,
+		&row.statusReason,
+		&row.tombstoned,
+		&row.tombstonedAt,
+		&row.tombstonedReason,
+		&row.tombstonedBy,
+		&row.tombstonedRunID,
+		&row.priorStatus,
+		&row.createdAt,
+		&row.updatedAt,
+	); err != nil {
+		t.Fatalf("load backfill row %q: %v", id, err)
+	}
+	row.createdAt = row.createdAt.UTC()
+	row.updatedAt = row.updatedAt.UTC()
+	return row
+}
+
+func assertTenantScopedBackfillWinner(t *testing.T, ctx context.Context, store *Store, id string, wantFingerprint string) {
+	t.Helper()
+	row := loadTenantScopedBackfillRow(t, ctx, store, id)
+	if row.fingerprint != wantFingerprint {
+		t.Fatalf("%s fingerprint = %q, want %q", id, row.fingerprint, wantFingerprint)
+	}
+	if row.tombstoned {
+		t.Fatalf("%s tombstoned = true, want active winner", id)
+	}
+	if row.status != "open" {
+		t.Fatalf("%s status = %q, want open", id, row.status)
+	}
+}
+
+func assertTenantScopedBackfillLoser(t *testing.T, ctx context.Context, store *Store, id string) {
+	t.Helper()
+	row := loadTenantScopedBackfillRow(t, ctx, store, id)
+	if !row.tombstoned {
+		t.Fatalf("%s tombstoned = false, want true", id)
+	}
+	if !row.tombstonedAt.Valid || row.tombstonedAt.Time.IsZero() {
+		t.Fatalf("%s tombstoned_at = %#v, want non-zero timestamp", id, row.tombstonedAt)
+	}
+	if row.status != "resolved" {
+		t.Fatalf("%s status = %q, want resolved", id, row.status)
+	}
+	if row.statusReason != wantBackfillCollisionReason {
+		t.Fatalf("%s status_reason = %q, want %q", id, row.statusReason, wantBackfillCollisionReason)
+	}
+	if row.tombstonedReason != wantBackfillCollisionReason {
+		t.Fatalf("%s tombstoned_reason = %q, want %q", id, row.tombstonedReason, wantBackfillCollisionReason)
+	}
+	if row.tombstonedBy != wantBackfillCollisionActor {
+		t.Fatalf("%s tombstoned_by = %q, want %q", id, row.tombstonedBy, wantBackfillCollisionActor)
+	}
+	if row.tombstonedRunID != wantBackfillCollisionRunID {
+		t.Fatalf("%s tombstoned_run_id = %q, want %q", id, row.tombstonedRunID, wantBackfillCollisionRunID)
+	}
+	if row.priorStatus != "open" {
+		t.Fatalf("%s prior_status = %q, want open", id, row.priorStatus)
+	}
+}
+
+type backfillCollisionEvent struct {
+	findingID    string
+	tenantID     string
+	ruleID       string
+	anchorURI    string
+	priorStatus  string
+	reason       string
+	actor        string
+	runID        string
+	tombstonedAt time.Time
+}
+
+func loadBackfillCollisionEvents(t *testing.T, ctx context.Context, store *Store, runID string) []backfillCollisionEvent {
+	t.Helper()
+	rows, err := store.db.QueryContext(ctx, `
+        SELECT finding_id, tenant_id, rule_id, anchor_uri, prior_status, reason, actor, run_id, tombstoned_at
+        FROM finding_tombstone_events
+        WHERE run_id = $1
+        ORDER BY finding_id`, runID)
+	if err != nil {
+		t.Fatalf("query backfill collision events: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var events []backfillCollisionEvent
+	for rows.Next() {
+		var event backfillCollisionEvent
+		if err := rows.Scan(
+			&event.findingID,
+			&event.tenantID,
+			&event.ruleID,
+			&event.anchorURI,
+			&event.priorStatus,
+			&event.reason,
+			&event.actor,
+			&event.runID,
+			&event.tombstonedAt,
+		); err != nil {
+			t.Fatalf("scan backfill collision event: %v", err)
+		}
+		if event.reason != wantBackfillCollisionReason {
+			t.Fatalf("event %q reason = %q, want %q", event.findingID, event.reason, wantBackfillCollisionReason)
+		}
+		if event.actor != wantBackfillCollisionActor {
+			t.Fatalf("event %q actor = %q, want %q", event.findingID, event.actor, wantBackfillCollisionActor)
+		}
+		if event.runID != wantBackfillCollisionRunID {
+			t.Fatalf("event %q run_id = %q, want %q", event.findingID, event.runID, wantBackfillCollisionRunID)
+		}
+		if event.priorStatus != "open" {
+			t.Fatalf("event %q prior_status = %q, want open", event.findingID, event.priorStatus)
+		}
+		if event.tombstonedAt.IsZero() {
+			t.Fatalf("event %q tombstoned_at is zero", event.findingID)
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate backfill collision events: %v", err)
+	}
+	return events
+}


### PR DESCRIPTION
## Summary
- handle tenant-scoped fingerprint backfill collisions deterministically before closeout selectors run
- add regression coverage for collision selection, audit rows, and idempotency

## Validation
- Prior worker committed this fix locally for M4 release prep; this PR lets CI validate and release v2.1.63 after merge.

Mission evidence: /Users/jonathan/cerebro-finding-cleanup/_logs/m4-prep-release-bump/