### PR TITLE
fix: stabilize cloudtrail pagination cursors

### DIFF
--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -53,6 +53,8 @@ const (
 	defaultRegion             = "us-east-1"
 	defaultPageSize           = 10
 	maxPageSize               = 200
+	cloudTrailCursorVersion   = 1
+	cloudTrailCursorMaxAge    = 55 * time.Minute
 	publicEndpointCursorV2    = 2
 	awsAssumeRoleSessionName  = "cerebro-source-runtime"
 	familyAccessKey           = "access_key"
@@ -285,6 +287,18 @@ type cloudTrailResourceRef struct {
 	Name      string `json:"resourceName"`
 	Type      string `json:"resourceType"`
 	AccountID string `json:"accountId"`
+}
+
+type cloudTrailCursor struct {
+	Version       int    `json:"version,omitempty"`
+	Token         string `json:"token,omitempty"`
+	StartTime     string `json:"start_time,omitempty"`
+	EndTime       string `json:"end_time,omitempty"`
+	StartSelector string `json:"start_selector,omitempty"`
+	EndSelector   string `json:"end_selector,omitempty"`
+	LookupKey     string `json:"lookup_key,omitempty"`
+	LookupValue   string `json:"lookup_value,omitempty"`
+	IssuedAt      string `json:"issued_at,omitempty"`
 }
 
 // New constructs the live AWS source.
@@ -1469,18 +1483,37 @@ func attachedRolePolicyAssignments(ctx context.Context, clients awsClients, role
 }
 
 func listCloudTrailEvents(ctx context.Context, clients awsClients, settings settings, cursor string, limit int) ([]cloudtrailtypes.Event, string, error) {
-	input := &cloudtrail.LookupEventsInput{MaxResults: awssdk.Int32(int32(limit)), NextToken: stringPtr(cursor)}
+	now := time.Now().UTC()
+	state, resume := parseCloudTrailCursor(cursor, settings, now)
+	input := &cloudtrail.LookupEventsInput{MaxResults: awssdk.Int32(int32(limit))}
+	if resume {
+		input.NextToken = stringPtr(state.Token)
+		if state.StartTime != "" {
+			parsed, err := time.Parse(time.RFC3339Nano, state.StartTime)
+			if err != nil {
+				return nil, "", fmt.Errorf("parse aws cloudtrail cursor start_time: %w", err)
+			}
+			input.StartTime = &parsed
+		}
+		if state.EndTime != "" {
+			parsed, err := time.Parse(time.RFC3339Nano, state.EndTime)
+			if err != nil {
+				return nil, "", fmt.Errorf("parse aws cloudtrail cursor end_time: %w", err)
+			}
+			input.EndTime = &parsed
+		}
+	}
 	if settings.lookupKey != "" && settings.lookupValue != "" {
 		input.LookupAttributes = []cloudtrailtypes.LookupAttribute{{AttributeKey: cloudtrailtypes.LookupAttributeKey(settings.lookupKey), AttributeValue: awssdk.String(settings.lookupValue)}}
 	}
-	if firstNonEmpty(settings.startTime, settings.since) != "" {
-		parsed, err := parseAWSTimeSelector(firstNonEmpty(settings.startTime, settings.since), time.Now().UTC())
+	if !resume && firstNonEmpty(settings.startTime, settings.since) != "" {
+		parsed, err := parseAWSTimeSelector(firstNonEmpty(settings.startTime, settings.since), now)
 		if err != nil {
 			return nil, "", fmt.Errorf("parse aws start_time: %w", err)
 		}
 		input.StartTime = &parsed
 	}
-	if settings.endTime != "" {
+	if !resume && settings.endTime != "" {
 		parsed, err := time.Parse(time.RFC3339, settings.endTime)
 		if err != nil {
 			return nil, "", fmt.Errorf("parse aws end_time: %w", err)
@@ -1491,7 +1524,76 @@ func listCloudTrailEvents(ctx context.Context, clients awsClients, settings sett
 	if err != nil {
 		return nil, "", err
 	}
-	return out.Events, awssdk.ToString(out.NextToken), nil
+	return out.Events, encodeCloudTrailCursor(settings, input, awssdk.ToString(out.NextToken), now), nil
+}
+
+func parseCloudTrailCursor(raw string, settings settings, now time.Time) (cloudTrailCursor, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return cloudTrailCursor{}, false
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return cloudTrailCursor{}, false
+	}
+	var cursor cloudTrailCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return cloudTrailCursor{}, false
+	}
+	if cursor.Version != cloudTrailCursorVersion || strings.TrimSpace(cursor.Token) == "" {
+		return cloudTrailCursor{}, false
+	}
+	issuedAt, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(cursor.IssuedAt))
+	if err != nil || now.Sub(issuedAt) > cloudTrailCursorMaxAge {
+		return cloudTrailCursor{}, false
+	}
+	cursor.StartTime = strings.TrimSpace(cursor.StartTime)
+	cursor.EndTime = strings.TrimSpace(cursor.EndTime)
+	if cursor.StartTime != "" {
+		if _, err := time.Parse(time.RFC3339Nano, cursor.StartTime); err != nil {
+			return cloudTrailCursor{}, false
+		}
+	}
+	if cursor.EndTime != "" {
+		if _, err := time.Parse(time.RFC3339Nano, cursor.EndTime); err != nil {
+			return cloudTrailCursor{}, false
+		}
+	}
+	if cursor.StartSelector != firstNonEmpty(settings.startTime, settings.since) ||
+		cursor.EndSelector != strings.TrimSpace(settings.endTime) ||
+		cursor.LookupKey != strings.TrimSpace(settings.lookupKey) ||
+		cursor.LookupValue != strings.TrimSpace(settings.lookupValue) {
+		return cloudTrailCursor{}, false
+	}
+	cursor.Token = strings.TrimSpace(cursor.Token)
+	return cursor, true
+}
+
+func encodeCloudTrailCursor(settings settings, input *cloudtrail.LookupEventsInput, token string, issuedAt time.Time) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	cursor := cloudTrailCursor{
+		Version:       cloudTrailCursorVersion,
+		Token:         token,
+		StartSelector: firstNonEmpty(settings.startTime, settings.since),
+		EndSelector:   strings.TrimSpace(settings.endTime),
+		LookupKey:     strings.TrimSpace(settings.lookupKey),
+		LookupValue:   strings.TrimSpace(settings.lookupValue),
+		IssuedAt:      issuedAt.UTC().Format(time.RFC3339Nano),
+	}
+	if input != nil && input.StartTime != nil {
+		cursor.StartTime = input.StartTime.UTC().Format(time.RFC3339Nano)
+	}
+	if input != nil && input.EndTime != nil {
+		cursor.EndTime = input.EndTime.UTC().Format(time.RFC3339Nano)
+	}
+	payload, err := json.Marshal(cursor)
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(payload)
 }
 
 func iamUserEvent(settings settings, user iamtypes.User) (*primitives.Event, error) {

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 )
@@ -139,6 +140,98 @@ func TestAWSPullFromRecordsPreservesNextCursorWithoutEvents(t *testing.T) {
 	}
 	if got := pull.NextCursor.GetOpaque(); got != "next-page" {
 		t.Fatalf("NextCursor = %q, want next-page", got)
+	}
+}
+
+func TestCloudTrailCursorFreezesRelativeSinceAcrossPages(t *testing.T) {
+	var inputs []cloudtrail.LookupEventsInput
+	source := newTestSource(t, fakeAWS{cloudTrailLookup: func(_ context.Context, input *cloudtrail.LookupEventsInput) (*cloudtrail.LookupEventsOutput, error) {
+		inputs = append(inputs, *input)
+		if len(inputs) == 1 {
+			return &cloudtrail.LookupEventsOutput{NextToken: awssdk.String("token-1")}, nil
+		}
+		return &cloudtrail.LookupEventsOutput{}, nil
+	}})
+	config := sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familyCloudTrail, "since": "PT2H"})
+
+	first, err := source.Read(context.Background(), config, nil)
+	if err != nil {
+		t.Fatalf("Read(cloudtrail first) error = %v", err)
+	}
+	if first.NextCursor == nil {
+		t.Fatal("first.NextCursor = nil, want encoded cursor")
+	}
+	if _, ok := parseCloudTrailCursor(first.NextCursor.GetOpaque(), settings{since: "PT2H"}, time.Now().UTC()); !ok {
+		t.Fatalf("first.NextCursor is not a resumable CloudTrail cursor: %q", first.NextCursor.GetOpaque())
+	}
+	if _, err = source.Read(context.Background(), config, first.NextCursor); err != nil {
+		t.Fatalf("Read(cloudtrail second) error = %v", err)
+	}
+
+	if len(inputs) != 2 {
+		t.Fatalf("LookupEvents calls = %d, want 2", len(inputs))
+	}
+	if got := awssdk.ToString(inputs[1].NextToken); got != "token-1" {
+		t.Fatalf("second NextToken = %q, want token-1", got)
+	}
+	if inputs[0].StartTime == nil || inputs[1].StartTime == nil {
+		t.Fatalf("StartTime values = %v, %v; want both set", inputs[0].StartTime, inputs[1].StartTime)
+	}
+	if !inputs[0].StartTime.Equal(*inputs[1].StartTime) {
+		t.Fatalf("second StartTime = %s, want frozen first StartTime %s", inputs[1].StartTime.Format(time.RFC3339Nano), inputs[0].StartTime.Format(time.RFC3339Nano))
+	}
+}
+
+func TestCloudTrailCursorInvalidatesUnsafeTokens(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		cursor string
+		config map[string]string
+	}{
+		{
+			name: "expired encoded cursor",
+			cursor: encodeCloudTrailCursor(
+				settings{since: "PT2H"},
+				&cloudtrail.LookupEventsInput{StartTime: timePtr("2026-05-24T00:00:00Z")},
+				"expired-token",
+				time.Now().UTC().Add(-2*time.Hour),
+			),
+			config: map[string]string{"account_id": "123456789012", "family": familyCloudTrail, "since": "PT2H"},
+		},
+		{
+			name: "selector changed",
+			cursor: encodeCloudTrailCursor(
+				settings{since: "PT1H"},
+				&cloudtrail.LookupEventsInput{StartTime: timePtr("2026-05-24T00:00:00Z")},
+				"mismatched-token",
+				time.Now().UTC(),
+			),
+			config: map[string]string{"account_id": "123456789012", "family": familyCloudTrail, "since": "PT2H"},
+		},
+		{
+			name:   "legacy raw token",
+			cursor: "legacy-aws-token",
+			config: map[string]string{"account_id": "123456789012", "family": familyCloudTrail, "since": "PT2H"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotInput *cloudtrail.LookupEventsInput
+			source := newTestSource(t, fakeAWS{cloudTrailLookup: func(_ context.Context, input *cloudtrail.LookupEventsInput) (*cloudtrail.LookupEventsOutput, error) {
+				copy := *input
+				gotInput = &copy
+				return &cloudtrail.LookupEventsOutput{}, nil
+			}})
+
+			if _, err := source.Read(context.Background(), sourcecdk.NewConfig(tt.config), &cerebrov1.SourceCursor{Opaque: tt.cursor}); err != nil {
+				t.Fatalf("Read(cloudtrail) error = %v", err)
+			}
+			if gotInput == nil {
+				t.Fatal("LookupEvents was not called")
+			}
+			if got := awssdk.ToString(gotInput.NextToken); got != "" {
+				t.Fatalf("NextToken = %q, want discarded token", got)
+			}
+		})
 	}
 }
 
@@ -577,6 +670,7 @@ type fakeAWS struct {
 	accessKeys        []iamtypes.AccessKeyMetadata
 	attachedPolicies  []iamtypes.AttachedPolicy
 	cloudTrailEvents  []cloudtrailtypes.Event
+	cloudTrailLookup  func(context.Context, *cloudtrail.LookupEventsInput) (*cloudtrail.LookupEventsOutput, error)
 	securityGroups    []ec2types.SecurityGroup
 	addresses         []ec2types.Address
 	networkInterfaces []ec2types.NetworkInterface
@@ -622,7 +716,10 @@ func (f fakeAWS) ListAttachedRolePolicies(context.Context, *iam.ListAttachedRole
 	return &iam.ListAttachedRolePoliciesOutput{AttachedPolicies: f.attachedPolicies}, nil
 }
 
-func (f fakeAWS) LookupEvents(context.Context, *cloudtrail.LookupEventsInput, ...func(*cloudtrail.Options)) (*cloudtrail.LookupEventsOutput, error) {
+func (f fakeAWS) LookupEvents(ctx context.Context, input *cloudtrail.LookupEventsInput, _ ...func(*cloudtrail.Options)) (*cloudtrail.LookupEventsOutput, error) {
+	if f.cloudTrailLookup != nil {
+		return f.cloudTrailLookup(ctx, input)
+	}
 	return &cloudtrail.LookupEventsOutput{Events: f.cloudTrailEvents}, nil
 }
 


### PR DESCRIPTION
## Summary\n- encode CloudTrail cursors with frozen lookup parameters instead of persisting raw AWS NextToken values\n- discard expired, selector-mismatched, malformed, or legacy raw CloudTrail cursors so runtimes heal from stale tokens\n- add regression tests for relative since pagination and unsafe cursor invalidation\n\n## Validation\n- go test ./sources/aws -count=1 -v\n- make verify\n\n## Live context\nThis addresses sec-dev CloudTrail failures from expired/mismatched AWS LookupEvents NextToken values. The duplicate finding fingerprint deploy blocker is already fixed in public main/tag v2.1.63.