### PR TITLE
feat: add projected entity cleanup CLI

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -138,6 +138,33 @@ type graphEndpointOwnerIDCleanupResult struct {
 	GraphStore ports.ProjectionLinkCleanupResult `json:"graph_store"`
 }
 
+type graphProjectedEntityCleanupOptions struct {
+	TenantID     string
+	SourceID     string
+	RuntimeID    string
+	FindingID    string
+	EntityTypes  []string
+	URNPrefixes  []string
+	OnlyIsolated bool
+	Limit        uint32
+	DryRun       bool
+	AllowDetach  bool
+}
+
+type graphProjectedEntityCleanupResult struct {
+	TenantID     string                        `json:"tenant_id"`
+	SourceID     string                        `json:"source_id,omitempty"`
+	RuntimeID    string                        `json:"runtime_id,omitempty"`
+	FindingID    string                        `json:"finding_id,omitempty"`
+	EntityTypes  []string                      `json:"entity_types,omitempty"`
+	URNPrefixes  []string                      `json:"urn_prefixes,omitempty"`
+	OnlyIsolated bool                          `json:"only_isolated"`
+	Limit        uint32                        `json:"limit,omitempty"`
+	DryRun       bool                          `json:"dry_run"`
+	StateStore   ports.ProjectionCleanupResult `json:"state_store"`
+	GraphStore   ports.ProjectionCleanupResult `json:"graph_store"`
+}
+
 type graphPathsResult struct {
 	Patterns   []graphstore.PathPattern `json:"patterns"`
 	Traversals []graphstore.Traversal   `json:"traversals"`
@@ -228,6 +255,22 @@ func runGraph(args []string) error {
 			return printErr
 		}
 		return err
+	case "cleanup-projected-entities":
+		options, err := parseGraphProjectedEntityCleanupArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		ctx := context.Background()
+		deps, closeDeps, err := openGraphCleanupDependencies(ctx)
+		if err != nil {
+			return err
+		}
+		defer logClose(closeDeps)
+		result, err := cleanupProjectedEntities(ctx, deps, options)
+		if printErr := printJSON(result); printErr != nil {
+			return printErr
+		}
+		return err
 	case "counts", "neighborhood", "paths", "relation-counts", "integrity":
 		return runGraphInspect(args)
 	case "cve-impact", "package-exposure", "asset-vulns":
@@ -283,7 +326,7 @@ func runGraph(args []string) error {
 }
 
 func graphUsage() string {
-	return fmt.Sprintf("usage: %s graph [counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|cleanup-endpoint-owner-id-links|rebuild|inspect] ...", os.Args[0])
+	return fmt.Sprintf("usage: %s graph [counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|cleanup-endpoint-owner-id-links|cleanup-projected-entities|rebuild|inspect] ...", os.Args[0])
 }
 
 func graphIngestUsage() string {
@@ -308,6 +351,10 @@ func graphImpactUsage() string {
 
 func graphEndpointOwnerIDCleanupUsage() string {
 	return fmt.Sprintf("usage: %s graph cleanup-endpoint-owner-id-links tenant_id=<tenant-id> [source_id=kolide|kandji] [runtime_id=<runtime-id>] [limit=N] [dry_run=true|apply=true]", os.Args[0])
+}
+
+func graphProjectedEntityCleanupUsage() string {
+	return fmt.Sprintf("usage: %s graph cleanup-projected-entities tenant_id=<tenant-id> [source_id=<source-id>] [runtime_id=<runtime-id>] [finding_id=<finding-id>] [entity_type=a,b] [urn_prefix=a,b] [only_isolated=true] [limit=N] [dry_run=true|apply=true] [allow_detach=true]", os.Args[0])
 }
 
 func runGraphInspect(args []string) error {
@@ -524,6 +571,50 @@ func cleanupEndpointOwnerIDLinks(ctx context.Context, deps bootstrap.Dependencie
 	}
 	if !cleaned {
 		return result, fmt.Errorf("endpoint owner-id link cleanup is unsupported by configured stores")
+	}
+	return result, nil
+}
+
+func cleanupProjectedEntities(ctx context.Context, deps bootstrap.Dependencies, options graphProjectedEntityCleanupOptions) (result graphProjectedEntityCleanupResult, err error) {
+	result = graphProjectedEntityCleanupResult{
+		TenantID:     strings.TrimSpace(options.TenantID),
+		SourceID:     strings.TrimSpace(options.SourceID),
+		RuntimeID:    strings.TrimSpace(options.RuntimeID),
+		FindingID:    strings.TrimSpace(options.FindingID),
+		EntityTypes:  append([]string(nil), options.EntityTypes...),
+		URNPrefixes:  append([]string(nil), options.URNPrefixes...),
+		OnlyIsolated: options.OnlyIsolated,
+		Limit:        options.Limit,
+		DryRun:       options.DryRun,
+	}
+	request := ports.ProjectionCleanupRequest{
+		TenantID:     result.TenantID,
+		SourceID:     result.SourceID,
+		RuntimeID:    result.RuntimeID,
+		FindingID:    result.FindingID,
+		EntityTypes:  result.EntityTypes,
+		URNPrefixes:  result.URNPrefixes,
+		OnlyIsolated: result.OnlyIsolated,
+		Limit:        result.Limit,
+		DryRun:       result.DryRun,
+	}
+	cleaned := false
+	if cleaner, ok := deps.StateStore.(ports.ProjectionCleaner); ok {
+		cleaned = true
+		result.StateStore, err = cleaner.CleanupProjectedEntities(ctx, request)
+		if err != nil {
+			return result, fmt.Errorf("cleanup state projected entities: %w", err)
+		}
+	}
+	if cleaner, ok := deps.GraphStore.(ports.ProjectionCleaner); ok {
+		cleaned = true
+		result.GraphStore, err = cleaner.CleanupProjectedEntities(ctx, request)
+		if err != nil {
+			return result, fmt.Errorf("cleanup graph projected entities: %w", err)
+		}
+	}
+	if !cleaned {
+		return result, fmt.Errorf("projected entity cleanup is unsupported by configured stores")
 	}
 	return result, nil
 }
@@ -913,6 +1004,112 @@ func parseGraphEndpointOwnerIDCleanupArgs(args []string) (graphEndpointOwnerIDCl
 		return graphEndpointOwnerIDCleanupOptions{}, fmt.Errorf("apply=true is required before deleting endpoint owner-id links")
 	}
 	return options, nil
+}
+
+func parseGraphProjectedEntityCleanupArgs(args []string) (graphProjectedEntityCleanupOptions, error) {
+	options := graphProjectedEntityCleanupOptions{DryRun: true, OnlyIsolated: true}
+	apply := false
+	dryRunSet := false
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return graphProjectedEntityCleanupOptions{}, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		switch strings.TrimSpace(key) {
+		case "tenant_id":
+			options.TenantID = strings.TrimSpace(value)
+		case "source_id":
+			options.SourceID = strings.TrimSpace(value)
+		case "runtime_id":
+			options.RuntimeID = strings.TrimSpace(value)
+		case "finding_id":
+			options.FindingID = strings.TrimSpace(value)
+		case "entity_type", "entity_types":
+			options.EntityTypes = append(options.EntityTypes, splitCleanupValues(value)...)
+		case "urn_prefix", "urn_prefixes":
+			options.URNPrefixes = append(options.URNPrefixes, splitCleanupValues(value)...)
+		case "only_isolated":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphProjectedEntityCleanupOptions{}, fmt.Errorf("parse only_isolated: %w", err)
+			}
+			options.OnlyIsolated = parsed
+		case "allow_detach":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphProjectedEntityCleanupOptions{}, fmt.Errorf("parse allow_detach: %w", err)
+			}
+			options.AllowDetach = parsed
+		case "limit":
+			parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+			if err != nil {
+				return graphProjectedEntityCleanupOptions{}, fmt.Errorf("parse limit: %w", err)
+			}
+			if parsed == 0 {
+				return graphProjectedEntityCleanupOptions{}, fmt.Errorf("limit must be positive")
+			}
+			options.Limit = uint32(parsed)
+		case "dry_run":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphProjectedEntityCleanupOptions{}, fmt.Errorf("parse dry_run: %w", err)
+			}
+			options.DryRun = parsed
+			dryRunSet = true
+		case "apply":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphProjectedEntityCleanupOptions{}, fmt.Errorf("parse apply: %w", err)
+			}
+			apply = parsed
+		default:
+			return graphProjectedEntityCleanupOptions{}, usageError(fmt.Sprintf("unsupported graph cleanup-projected-entities argument %q", key))
+		}
+	}
+	if strings.TrimSpace(options.TenantID) == "" {
+		return graphProjectedEntityCleanupOptions{}, usageError(graphProjectedEntityCleanupUsage())
+	}
+	if strings.TrimSpace(options.SourceID) == "" &&
+		strings.TrimSpace(options.RuntimeID) == "" &&
+		strings.TrimSpace(options.FindingID) == "" &&
+		len(options.EntityTypes) == 0 &&
+		len(options.URNPrefixes) == 0 {
+		return graphProjectedEntityCleanupOptions{}, usageError(graphProjectedEntityCleanupUsage())
+	}
+	if !options.OnlyIsolated && strings.TrimSpace(options.FindingID) == "" && !options.AllowDetach {
+		return graphProjectedEntityCleanupOptions{}, fmt.Errorf("allow_detach=true is required when only_isolated=false without finding_id")
+	}
+	if apply {
+		if dryRunSet && options.DryRun {
+			return graphProjectedEntityCleanupOptions{}, fmt.Errorf("apply=true conflicts with dry_run=true")
+		}
+		options.DryRun = false
+	}
+	if !options.DryRun && !apply {
+		return graphProjectedEntityCleanupOptions{}, fmt.Errorf("apply=true is required before deleting projected entities")
+	}
+	if !options.DryRun && strings.TrimSpace(options.FindingID) != "" && !options.AllowDetach {
+		return graphProjectedEntityCleanupOptions{}, fmt.Errorf("allow_detach=true is required before deleting finding-scoped projected entities")
+	}
+	return options, nil
+}
+
+func splitCleanupValues(value string) []string {
+	parts := strings.Split(value, ",")
+	values := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if _, ok := seen[part]; ok {
+			continue
+		}
+		seen[part] = struct{}{}
+		values = append(values, part)
+	}
+	return values
 }
 
 func ingestGraph(

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 type cleanupStateStore struct {
-	request ports.ProjectionLinkCleanupRequest
-	result  ports.ProjectionLinkCleanupResult
+	request           ports.ProjectionLinkCleanupRequest
+	result            ports.ProjectionLinkCleanupResult
+	projectionRequest ports.ProjectionCleanupRequest
+	projectionResult  ports.ProjectionCleanupResult
 }
 
 func (s *cleanupStateStore) Ping(context.Context) error { return nil }
@@ -21,6 +23,11 @@ func (s *cleanupStateStore) Ping(context.Context) error { return nil }
 func (s *cleanupStateStore) CleanupEndpointOwnerIDLinks(_ context.Context, request ports.ProjectionLinkCleanupRequest) (ports.ProjectionLinkCleanupResult, error) {
 	s.request = request
 	return s.result, nil
+}
+
+func (s *cleanupStateStore) CleanupProjectedEntities(_ context.Context, request ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
+	s.projectionRequest = request
+	return s.projectionResult, nil
 }
 
 func TestParseGraphIngestArgs(t *testing.T) {
@@ -195,6 +202,97 @@ func TestCleanupEndpointOwnerIDLinksAllowsStateStoreOnly(t *testing.T) {
 		t.Fatalf("cleanup request = %#v, want scoped dry-run", state.request)
 	}
 	if result.StateStore.LinksMatched != 3 || result.GraphStore.LinksMatched != 0 {
+		t.Fatalf("cleanup result = %#v, want state-only result", result)
+	}
+}
+
+func TestParseGraphProjectedEntityCleanupArgsDefaultsSafeDryRun(t *testing.T) {
+	options, err := parseGraphProjectedEntityCleanupArgs([]string{
+		"tenant_id=writer",
+		"source_id=example-okta-audit",
+		"entity_type=finding,evidence",
+		"urn_prefix=urn:cerebro:example:finding:",
+		"limit=25",
+	})
+	if err != nil {
+		t.Fatalf("parseGraphProjectedEntityCleanupArgs() error = %v", err)
+	}
+	if !options.DryRun || !options.OnlyIsolated || options.TenantID != "writer" || options.SourceID != "example-okta-audit" || options.Limit != 25 {
+		t.Fatalf("options = %#v, want safe dry-run scoped cleanup", options)
+	}
+	if !reflect.DeepEqual(options.EntityTypes, []string{"finding", "evidence"}) {
+		t.Fatalf("EntityTypes = %#v, want finding/evidence", options.EntityTypes)
+	}
+	if !reflect.DeepEqual(options.URNPrefixes, []string{"urn:cerebro:example:finding:"}) {
+		t.Fatalf("URNPrefixes = %#v, want finding prefix", options.URNPrefixes)
+	}
+}
+
+func TestParseGraphProjectedEntityCleanupArgsRequiresApplyForDeletes(t *testing.T) {
+	args := []string{"tenant_id=writer", "source_id=example-okta-audit", "entity_type=finding", "dry_run=false"}
+	if _, err := parseGraphProjectedEntityCleanupArgs(args); err == nil {
+		t.Fatal("parseGraphProjectedEntityCleanupArgs() error = nil, want apply requirement")
+	}
+	options, err := parseGraphProjectedEntityCleanupArgs([]string{"tenant_id=writer", "source_id=example-okta-audit", "entity_type=finding", "apply=true"})
+	if err != nil {
+		t.Fatalf("parseGraphProjectedEntityCleanupArgs(apply) error = %v", err)
+	}
+	if options.DryRun {
+		t.Fatalf("DryRun = true, want apply mode")
+	}
+}
+
+func TestParseGraphProjectedEntityCleanupArgsRequiresAllowDetachForBroadDetach(t *testing.T) {
+	_, err := parseGraphProjectedEntityCleanupArgs([]string{
+		"tenant_id=writer",
+		"source_id=example-okta-audit",
+		"entity_type=finding",
+		"only_isolated=false",
+	})
+	if err == nil {
+		t.Fatal("parseGraphProjectedEntityCleanupArgs() error = nil, want allow_detach requirement")
+	}
+}
+
+func TestParseGraphProjectedEntityCleanupArgsRequiresAllowDetachForFindingDeletes(t *testing.T) {
+	_, err := parseGraphProjectedEntityCleanupArgs([]string{
+		"tenant_id=writer",
+		"finding_id=finding-1",
+		"apply=true",
+	})
+	if err == nil {
+		t.Fatal("parseGraphProjectedEntityCleanupArgs() error = nil, want finding detach opt-in requirement")
+	}
+	options, err := parseGraphProjectedEntityCleanupArgs([]string{
+		"tenant_id=writer",
+		"finding_id=finding-1",
+		"apply=true",
+		"allow_detach=true",
+	})
+	if err != nil {
+		t.Fatalf("parseGraphProjectedEntityCleanupArgs(allow_detach) error = %v", err)
+	}
+	if options.DryRun || !options.AllowDetach {
+		t.Fatalf("options = %#v, want apply mode with detach opt-in", options)
+	}
+}
+
+func TestCleanupProjectedEntitiesAllowsStateStoreOnly(t *testing.T) {
+	state := &cleanupStateStore{projectionResult: ports.ProjectionCleanupResult{EntitiesMatched: 3}}
+	result, err := cleanupProjectedEntities(context.Background(), bootstrap.Dependencies{StateStore: state}, graphProjectedEntityCleanupOptions{
+		TenantID:     "writer",
+		SourceID:     "example-okta-audit",
+		EntityTypes:  []string{"finding"},
+		OnlyIsolated: true,
+		DryRun:       true,
+	})
+	if err != nil {
+		t.Fatalf("cleanupProjectedEntities() error = %v", err)
+	}
+	if state.projectionRequest.TenantID != "writer" || state.projectionRequest.SourceID != "example-okta-audit" || !state.projectionRequest.DryRun || !state.projectionRequest.OnlyIsolated {
+		t.Fatalf("cleanup request = %#v, want scoped dry-run", state.projectionRequest)
+	}
+	if result.StateStore.EntitiesMatched != 3 || result.GraphStore.EntitiesMatched != 0 {
 		t.Fatalf("cleanup result = %#v, want state-only result", result)
 	}
 }

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -528,21 +528,61 @@ func (s *Store) CleanupProjectedEntities(ctx context.Context, request ports.Proj
 	query := `MATCH (e:Entity)
 WHERE ` + strings.Join(conditions, " AND ") + `
 WITH e LIMIT $limit
-WITH collect(e) AS entities
+OPTIONAL MATCH (e)-[rel:RELATION]-()
+WITH collect(DISTINCT e) AS entities, count(DISTINCT rel) AS links
+`
+	if request.DryRun {
+		var matchedEntities, matchedLinks int64
+		if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+			result, err := tx.Run(ctx, query+`RETURN size(entities), links`, params)
+			if err != nil {
+				return nil, err
+			}
+			record, err := result.Single(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if len(record.Values) > 0 {
+				matchedEntities = toInt64(record.Values[0])
+			}
+			if len(record.Values) > 1 {
+				matchedLinks = toInt64(record.Values[1])
+			}
+			return nil, nil
+		}); err != nil {
+			return ports.ProjectionCleanupResult{}, fmt.Errorf("cleanup projected entities: %w", err)
+		}
+		return ports.ProjectionCleanupResult{EntitiesMatched: uint32(matchedEntities), LinksMatched: uint32(matchedLinks)}, nil
+	}
+	query += `
 FOREACH (entity IN entities | DETACH DELETE entity)
-RETURN size(entities)`
-	var deleted int64
+RETURN size(entities), links`
+	var deletedEntities, deletedLinks int64
 	if _, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
-		value, err := queryOneValue(ctx, tx, query, params)
+		result, err := tx.Run(ctx, query, params)
 		if err != nil {
 			return nil, err
 		}
-		deleted = toInt64(value)
+		record, err := result.Single(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if len(record.Values) > 0 {
+			deletedEntities = toInt64(record.Values[0])
+		}
+		if len(record.Values) > 1 {
+			deletedLinks = toInt64(record.Values[1])
+		}
 		return nil, nil
 	}); err != nil {
 		return ports.ProjectionCleanupResult{}, fmt.Errorf("cleanup projected entities: %w", err)
 	}
-	return ports.ProjectionCleanupResult{EntitiesDeleted: uint32(deleted)}, nil
+	return ports.ProjectionCleanupResult{
+		EntitiesMatched: uint32(deletedEntities),
+		LinksMatched:    uint32(deletedLinks),
+		EntitiesDeleted: uint32(deletedEntities),
+		LinksDeleted:    uint32(deletedLinks),
+	}, nil
 }
 
 // CleanupEndpointOwnerIDLinks removes stale endpoint owner_id/user_id canonical identity links.

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -47,10 +47,13 @@ type ProjectionCleanupRequest struct {
 	URNPrefixes  []string
 	OnlyIsolated bool
 	Limit        uint32
+	DryRun       bool
 }
 
 // ProjectionCleanupResult reports graph objects removed by one cleanup pass.
 type ProjectionCleanupResult struct {
+	EntitiesMatched uint32
+	LinksMatched    uint32
 	EntitiesDeleted uint32
 	LinksDeleted    uint32
 }

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -109,6 +109,22 @@ WITH victims AS (
   ORDER BY e.urn
   LIMIT $%d
 ),
+matched_links AS (
+  SELECT COUNT(DISTINCT (l.from_urn, l.relation, l.to_urn)) AS count
+  FROM entity_links l
+  JOIN victims v ON l.from_urn = v.urn OR l.to_urn = v.urn
+)
+`, strings.Join(conditions, " AND "), limitPlaceholder)
+	if request.DryRun {
+		return query + `
+SELECT
+  (SELECT COUNT(*) FROM victims) AS entities_matched,
+  (SELECT count FROM matched_links) AS links_matched,
+  0 AS entities_deleted,
+  0 AS links_deleted`, args, nil
+	}
+	query += `
+,
 deleted_links AS (
   DELETE FROM entity_links l
   USING victims v
@@ -122,8 +138,10 @@ deleted_entities AS (
   RETURNING 1
 )
 SELECT
+  (SELECT COUNT(*) FROM deleted_entities) AS entities_matched,
+  (SELECT count FROM matched_links) AS links_matched,
   (SELECT COUNT(*) FROM deleted_entities) AS entities_deleted,
-  (SELECT COUNT(*) FROM deleted_links) AS links_deleted`, strings.Join(conditions, " AND "), limitPlaceholder)
+  (SELECT COUNT(*) FROM deleted_links) AS links_deleted`
 	return query, args, nil
 }
 
@@ -467,7 +485,7 @@ func (s *Store) CleanupProjectedEntities(ctx context.Context, request ports.Proj
 		return ports.ProjectionCleanupResult{}, err
 	}
 	var result ports.ProjectionCleanupResult
-	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&result.EntitiesDeleted, &result.LinksDeleted); err != nil {
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&result.EntitiesMatched, &result.LinksMatched, &result.EntitiesDeleted, &result.LinksDeleted); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ports.ProjectionCleanupResult{}, nil
 		}


### PR DESCRIPTION
## Summary
- add a scoped graph cleanup-projected-entities CLI command for projection cleanup
- support dry-run matched counts before destructive cleanup
- report matched/deleted entity and link counts from Postgres and Neo4j cleanup stores

## Validation
- go test ./cmd/cerebro ./internal/sourceprojection ./internal/graphingest ./internal/workflowprojection ./internal/statestore/postgres ./internal/graphstore/neo4j -count=1
- make verify