### PR TITLE
fix: close missed review regressions

### DIFF
--- a/internal/vulndb/filestore_lock_unix.go
+++ b/internal/vulndb/filestore_lock_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux || darwin || freebsd || openbsd || netbsd || dragonfly
 
 package vulndb
 

--- a/internal/vulndb/filestore_lock_unsupported.go
+++ b/internal/vulndb/filestore_lock_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !windows && !linux && !darwin && !freebsd && !openbsd && !netbsd && !dragonfly
+
+package vulndb
+
+import "fmt"
+
+func (s *FileStore) lockStateFile() (func(), error) {
+	return nil, fmt.Errorf("vulndb file store locking is unsupported on this platform")
+}

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -321,6 +321,9 @@ func auditAttributes(entry *gogithub.AuditEntry, raw map[string]any, settings se
 		addAttribute(attributes, "runner_scope", auditRunnerScope(raw, settings))
 	}
 	for _, key := range auditAdditionalAttributeKeys {
+		if key == "runner_scope" && auditHasRunnerContext(action, raw) && attributes["runner_scope"] != "" {
+			continue
+		}
 		addAttribute(attributes, key, rawScalarString(raw, key))
 	}
 	return attributes

--- a/sources/github/audit_test.go
+++ b/sources/github/audit_test.go
@@ -113,6 +113,18 @@ func TestAuditAttributes_ForwardsRunnerID(t *testing.T) {
 	}
 }
 
+func TestAuditAttributes_PreservesNormalizedRunnerScope(t *testing.T) {
+	event := auditEventForTest(t, "repo.register_self_hosted_runner", map[string]any{
+		"repo":         "writer/cerebro",
+		"runner_id":    777,
+		"runner_scope": "repository",
+	}, nil)
+
+	if got := event.Attributes["runner_scope"]; got != "repo:writer/cerebro" {
+		t.Fatalf("runner_scope = %q, want normalized repo scope; attributes=%v", got, event.Attributes)
+	}
+}
+
 func TestAuditAttributes_ForwardsPostureBooleans(t *testing.T) {
 	postureAttrs := map[string]any{
 		"advanced_security_enabled":               true,


### PR DESCRIPTION
## Summary\n- preserve normalized GitHub self-hosted runner scopes when raw audit payloads include generic runner_scope values\n- narrow Unix file-lock build tags and add an unsupported-platform fallback for vulndb file locking\n\n## Validation\n- go test ./sources/github ./internal/vulndb -count=1 -v\n- GOOS=js GOARCH=wasm go test -c ./internal/vulndb\n- GOOS=aix GOARCH=ppc64 go test -c ./internal/vulndb\n- make verify