### PR TITLE
fix(findings): preserve VulnView evidence (SEC-936)

### DIFF
--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -1685,6 +1686,7 @@ func mergeFindingAttributesForUpsert(existing map[string]string, incoming map[st
 		}
 	}
 	mergeFindingListAttribute(merged, existing, incoming, "matched_locations", "matched_at")
+	mergeFindingJSONListAttribute(merged, existing, incoming, "matched_locations_json", "matched_at")
 	trimEmptyAttributes(merged)
 	return merged
 }
@@ -1700,6 +1702,35 @@ func mergeFindingListAttribute(merged map[string]string, existing map[string]str
 		return
 	}
 	merged[listKey] = strings.Join(values, ",")
+}
+
+func mergeFindingJSONListAttribute(merged map[string]string, existing map[string]string, incoming map[string]string, listKey string, scalarKeys ...string) {
+	values := append(splitFindingJSONListAttribute(existing[listKey]), splitFindingJSONListAttribute(incoming[listKey])...)
+	for _, key := range scalarKeys {
+		values = append(values, existing[key], incoming[key])
+	}
+	values = uniqueTrimmedStringsPreserveOrder(values)
+	if len(values) == 0 {
+		delete(merged, listKey)
+		return
+	}
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		delete(merged, listKey)
+		return
+	}
+	merged[listKey] = string(encoded)
+}
+
+func splitFindingJSONListAttribute(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	var values []string
+	if err := json.Unmarshal([]byte(value), &values); err != nil {
+		return nil
+	}
+	return values
 }
 
 func splitFindingListAttribute(value string) []string {

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -1628,6 +1628,12 @@ func (s *Service) mergeExistingFindingEvidence(ctx context.Context, finding *por
 	if s == nil || s.store == nil || finding == nil {
 		return finding, nil
 	}
+	if finding.RuleID == vulnViewActionableExternalFindingRuleID {
+		if existing := s.activeVulnViewActionableFinding(ctx, finding); existing != nil {
+			return mergeFindingEvidenceForUpsert(existing, finding), nil
+		}
+		return finding, nil
+	}
 	findingID := strings.TrimSpace(finding.ID)
 	if findingID == "" {
 		return finding, nil
@@ -1689,6 +1695,44 @@ func mergeFindingAttributesForUpsert(existing map[string]string, incoming map[st
 	mergeFindingJSONListAttribute(merged, existing, incoming, "matched_locations_json", "matched_at")
 	trimEmptyAttributes(merged)
 	return merged
+}
+
+func (s *Service) activeVulnViewActionableFinding(ctx context.Context, incoming *ports.FindingRecord) *ports.FindingRecord {
+	if s == nil || s.store == nil || incoming == nil {
+		return nil
+	}
+	fingerprint := strings.TrimSpace(incoming.Fingerprint)
+	resourceURN := firstNonEmpty(incoming.ResourceURNs...)
+	if strings.TrimSpace(incoming.TenantID) != "" &&
+		strings.TrimSpace(incoming.RuntimeID) != "" &&
+		strings.TrimSpace(incoming.PolicyID) != "" &&
+		resourceURN != "" {
+		candidates, err := s.store.ListFindings(ctx, ports.ListFindingsRequest{
+			TenantID:    strings.TrimSpace(incoming.TenantID),
+			RuntimeID:   strings.TrimSpace(incoming.RuntimeID),
+			RuleID:      vulnViewActionableExternalFindingRuleID,
+			PolicyID:    strings.TrimSpace(incoming.PolicyID),
+			ResourceURN: resourceURN,
+			Limit:       25,
+		})
+		if err == nil {
+			for _, candidate := range candidates {
+				if candidate == nil || candidate.Tombstoned {
+					continue
+				}
+				candidateFingerprint := strings.TrimSpace(candidate.Fingerprint)
+				if fingerprint != "" && candidateFingerprint != "" && candidateFingerprint != fingerprint {
+					continue
+				}
+				return candidate
+			}
+		}
+	}
+	existing, err := s.store.GetFinding(ctx, strings.TrimSpace(incoming.ID))
+	if err == nil && existing != nil && !existing.Tombstoned {
+		return existing
+	}
+	return nil
 }
 
 func mergeFindingListAttribute(merged map[string]string, existing map[string]string, incoming map[string]string, listKey string, scalarKeys ...string) {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -4073,7 +4073,10 @@ func TestMergeVulnViewActionableEvidenceUsesActiveGeneratedRow(t *testing.T) {
 		},
 		LastObservedAt: now.Add(time.Minute),
 	}
-	merged := service.mergeVulnViewActionableEvidence(context.Background(), incoming)
+	merged, err := service.mergeExistingFindingEvidence(context.Background(), incoming)
+	if err != nil {
+		t.Fatalf("mergeExistingFindingEvidence() error = %v", err)
+	}
 	if containsTrimmed(merged.EventIDs, "event-stale") {
 		t.Fatalf("EventIDs = %#v, want no tombstoned stale event id", merged.EventIDs)
 	}

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -4017,6 +4017,85 @@ func TestUpsertFindingWithRiskMergesVulnViewMatchedLocationEvidence(t *testing.T
 	}
 }
 
+func TestMergeVulnViewActionableEvidenceUsesActiveGeneratedRow(t *testing.T) {
+	now := time.Now().UTC()
+	baseID := "vulnview-finding"
+	activeID := baseID + "#g2"
+	assetURN := "urn:cerebro:tenant-a:external_asset:app.writer.com"
+	store := &stubFindingStore{
+		findings: map[string]*ports.FindingRecord{
+			baseID: {
+				ID:           baseID,
+				Fingerprint:  baseID,
+				TenantID:     "tenant-a",
+				RuntimeID:    "runtime-vulnview",
+				RuleID:       vulnViewActionableExternalFindingRuleID,
+				PolicyID:     "template-1",
+				Status:       findingStatusResolved,
+				ResourceURNs: []string{assetURN},
+				EventIDs:     []string{"event-stale"},
+				Attributes: map[string]string{
+					"matched_locations_json": `["https://app.writer.com/stale"]`,
+				},
+				FindingTombstone: ports.FindingTombstone{Tombstoned: true},
+				LastObservedAt:   now.Add(-2 * time.Hour),
+			},
+			activeID: {
+				ID:           activeID,
+				Fingerprint:  baseID,
+				TenantID:     "tenant-a",
+				RuntimeID:    "runtime-vulnview",
+				RuleID:       vulnViewActionableExternalFindingRuleID,
+				PolicyID:     "template-1",
+				Status:       findingStatusOpen,
+				ResourceURNs: []string{assetURN},
+				EventIDs:     []string{"event-live"},
+				Attributes: map[string]string{
+					"matched_locations_json": `["https://app.writer.com/live"]`,
+				},
+				LastObservedAt: now,
+			},
+		},
+	}
+	service := New(nil, nil, store, store, store, store)
+	incoming := &ports.FindingRecord{
+		ID:           baseID,
+		Fingerprint:  baseID,
+		TenantID:     "tenant-a",
+		RuntimeID:    "runtime-vulnview",
+		RuleID:       vulnViewActionableExternalFindingRuleID,
+		PolicyID:     "template-1",
+		Status:       findingStatusOpen,
+		ResourceURNs: []string{assetURN},
+		EventIDs:     []string{"event-new"},
+		Attributes: map[string]string{
+			"matched_at": "https://app.writer.com/new",
+		},
+		LastObservedAt: now.Add(time.Minute),
+	}
+	merged := service.mergeVulnViewActionableEvidence(context.Background(), incoming)
+	if containsTrimmed(merged.EventIDs, "event-stale") {
+		t.Fatalf("EventIDs = %#v, want no tombstoned stale event id", merged.EventIDs)
+	}
+	for _, eventID := range []string{"event-live", "event-new"} {
+		if !containsTrimmed(merged.EventIDs, eventID) {
+			t.Fatalf("EventIDs = %#v, missing %q", merged.EventIDs, eventID)
+		}
+	}
+	var locations []string
+	if err := json.Unmarshal([]byte(merged.Attributes["matched_locations_json"]), &locations); err != nil {
+		t.Fatalf("matched_locations_json = %q is invalid JSON array: %v", merged.Attributes["matched_locations_json"], err)
+	}
+	if slices.Contains(locations, "https://app.writer.com/stale") {
+		t.Fatalf("matched_locations_json = %#v, want no tombstoned stale location", locations)
+	}
+	for _, location := range []string{"https://app.writer.com/live", "https://app.writer.com/new"} {
+		if !slices.Contains(locations, location) {
+			t.Fatalf("matched_locations_json = %#v, missing %q", locations, location)
+		}
+	}
+}
+
 func TestAddFindingNoteUpdatesPersistedWorkflow(t *testing.T) {
 	store := &stubFindingStore{
 		findings: map[string]*ports.FindingRecord{

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -3970,6 +3970,53 @@ func TestUpsertFindingWithRiskPreservesGraphEvidenceDuringRecompute(t *testing.T
 	}
 }
 
+func TestUpsertFindingWithRiskMergesVulnViewMatchedLocationEvidence(t *testing.T) {
+	store := &stubFindingStore{}
+	service := New(nil, nil, store, store, store, store)
+	now := time.Now().UTC()
+	first := &ports.FindingRecord{
+		ID:           "vulnview-finding",
+		Fingerprint:  "vulnview-finding",
+		TenantID:     "tenant-a",
+		RuntimeID:    "runtime-vulnview",
+		RuleID:       vulnViewActionableExternalFindingRuleID,
+		Title:        "VulnView Actionable External Finding",
+		Severity:     "HIGH",
+		Status:       "open",
+		Summary:      "first finding",
+		ResourceURNs: []string{"urn:cerebro:tenant-a:external_asset:app.writer.com"},
+		EventIDs:     []string{"event-1"},
+		Attributes: map[string]string{
+			"matched_at": "https://app.writer.com/login",
+		},
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+	}
+	if _, err := service.upsertFindingWithRisk(context.Background(), first, nil, now); err != nil {
+		t.Fatalf("upsertFindingWithRisk(first) error = %v", err)
+	}
+	second := cloneFinding(first)
+	second.EventIDs = []string{"event-2"}
+	second.Attributes["matched_at"] = "https://app.writer.com/admin"
+	second.LastObservedAt = now.Add(time.Minute)
+	stored, err := service.upsertFindingWithRisk(context.Background(), second, nil, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("upsertFindingWithRisk(second) error = %v", err)
+	}
+	if !containsTrimmed(stored.EventIDs, "event-1") || !containsTrimmed(stored.EventIDs, "event-2") {
+		t.Fatalf("EventIDs = %#v, want both event IDs", stored.EventIDs)
+	}
+	var locations []string
+	if err := json.Unmarshal([]byte(stored.Attributes["matched_locations_json"]), &locations); err != nil {
+		t.Fatalf("matched_locations_json = %q is invalid JSON array: %v", stored.Attributes["matched_locations_json"], err)
+	}
+	for _, location := range []string{"https://app.writer.com/login", "https://app.writer.com/admin"} {
+		if !slices.Contains(locations, location) {
+			t.Fatalf("matched_locations_json = %#v, missing %q", locations, location)
+		}
+	}
+}
+
 func TestAddFindingNoteUpdatesPersistedWorkflow(t *testing.T) {
 	store := &stubFindingStore{
 		findings: map[string]*ports.FindingRecord{


### PR DESCRIPTION
### Why
SEC-936 tracks VulnView finding stability and /openapi.yaml contract hardening. The stale PR no longer applied cleanly and risked losing repeated matched-location evidence.

### What changed
- Merge repeated VulnView event IDs and matched locations before persistence.
- Add regression coverage for matched-location aggregation.
- Assert /openapi.yaml remains public when auth is enabled, matching the advertised contract.

### Validation
- go test ./internal/findings ./internal/bootstrap

### Security
- Reviewed staged diff for secrets; none found.
