### PR TITLE
Link GRC and Cosmo coordination context

### DIFF
--- a/internal/sourceprojection/cosmo.go
+++ b/internal/sourceprojection/cosmo.go
@@ -49,6 +49,7 @@ func cosmoFactProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		return nil, nil, nil
 	}
 	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
 	factURN := projectionURN(tenantID, "cosmo_fact", factID)
 	addEntity(entities, cosmoEntity(event, factURN, "cosmo.fact", factID, cosmoAttributes(attrs, map[string]string{
 		"record_id":  attrs["record_id"],
@@ -57,7 +58,10 @@ func cosmoFactProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		"source":     attrs["source"],
 		"confidence": attrs["confidence"],
 	})))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, nil)
+	if sessionID := cosmoFactSessionID(attrs["source"]); sessionID != "" {
+		addCosmoSessionLink(entities, links, event, tenantID, factURN, sessionID)
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
 
@@ -158,4 +162,12 @@ func addCosmoSessionLink(entities map[string]*ports.ProjectedEntity, links map[s
 	}
 	addEntity(entities, cosmoEntity(event, sessionURN, "cosmo.session", sessionID, map[string]string{"ticket_id": strings.TrimSpace(sessionID)}))
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), fromURN, sessionURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+}
+
+func cosmoFactSessionID(source string) string {
+	source = strings.TrimSpace(source)
+	if strings.HasPrefix(source, "session:") {
+		return strings.TrimSpace(strings.TrimPrefix(source, "session:"))
+	}
+	return ""
 }

--- a/internal/sourceprojection/cosmo_test.go
+++ b/internal/sourceprojection/cosmo_test.go
@@ -51,6 +51,26 @@ func TestProjectCosmoFact(t *testing.T) {
 	}
 }
 
+func TestProjectCosmoFactLinksSourceSession(t *testing.T) {
+	entities, links, err := BuiltinRegistry().Project(&cerebrov1.EventEnvelope{
+		Id:       "cosmo-writer-fact-risk",
+		TenantId: "writer",
+		SourceId: "cosmo",
+		Kind:     "cosmo.fact",
+		Attributes: map[string]string{
+			"record_id": "risk:key",
+			"key":       "risk:key",
+			"source":    "session:slack-C123-1779126269.376359",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	assertCosmoProjectedEntity(t, entities, "urn:cerebro:writer:cosmo_fact:risk:key", "cosmo.fact")
+	assertCosmoProjectedEntity(t, entities, "urn:cerebro:writer:cosmo_session:slack-C123-1779126269.376359", "cosmo.session")
+	assertCosmoProjectedLink(t, links, "urn:cerebro:writer:cosmo_fact:risk:key", relationBelongsTo, "urn:cerebro:writer:cosmo_session:slack-C123-1779126269.376359")
+}
+
 func TestProjectCosmoMessageLinksSession(t *testing.T) {
 	entities, links, err := BuiltinRegistry().Project(&cerebrov1.EventEnvelope{
 		Id:       "cosmo-writer-message-msg-1",

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -66,6 +66,9 @@ func grcControlTestProjections(event *cerebrov1.EventEnvelope) ([]*ports.Project
 		}
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), testURN, controlURN, relationSupports, map[string]string{"event_id": event.GetId()}))
 	}
+	addGRCUserOwnerLink(entities, links, tenantID, event.GetSourceId(), event, testURN, provider, firstAttribute(attrs, "owner_id"))
+	addGRCIntegrationLinks(entities, links, tenantID, event.GetSourceId(), event, testURN, provider, firstAttribute(attrs, "integrations"), "grc_control_test")
+	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, testURN, "grc_category", firstAttribute(attrs, "category"))
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
@@ -201,10 +204,10 @@ func grcDocumentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 		Attributes: grcAttributes(attrs, map[string]string{"document_id": documentID, "source_system": provider}),
 	})
 	if ownerID := firstAttribute(attrs, "owner_id"); ownerID != "" {
-		ownerURN := grcUserURN(tenantID, provider, ownerID)
-		addEntity(entities, grcUserEntity(tenantID, event.GetSourceId(), ownerURN, ownerID, map[string]string{"user_id": ownerID, "source_system": provider}))
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), documentURN, ownerURN, relationOwnedBy, map[string]string{"event_id": event.GetId()}))
+		addGRCUserOwnerLink(entities, links, tenantID, event.GetSourceId(), event, documentURN, provider, ownerID)
 	}
+	addInternetHostLink(entities, links, tenantID, event.GetSourceId(), event, documentURN, relationHasIdentifier, firstAttribute(attrs, "url"), "grc_document_url_host", "0.9")
+	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, documentURN, "grc_category", firstAttribute(attrs, "category"))
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
@@ -912,7 +915,9 @@ func grcIntegrationProjections(event *cerebrov1.EventEnvelope) ([]*ports.Project
 	entities := map[string]*ports.ProjectedEntity{}
 	sourceURN := grcIntegrationURN(tenantID, provider, integrationID)
 	addEntity(entities, grcIntegrationEntity(tenantID, event.GetSourceId(), sourceURN, integrationID, attrs, provider))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, nil)
+	links := map[string]*ports.ProjectedLink{}
+	addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, sourceURN, "grc_resource_kind", firstAttribute(attrs, "resource_kinds"))
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
 
@@ -942,7 +947,12 @@ func grcPolicyLikeProjections(event *cerebrov1.EventEnvelope, policyType string,
 			"source_system": provider,
 		}),
 	})
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, nil)
+	links := map[string]*ports.ProjectedLink{}
+	if policyType == "control" {
+		addGRCUserOwnerLink(entities, links, tenantID, event.GetSourceId(), event, policyURN, provider, firstAttribute(attrs, "owner_id"))
+		addGRCAssetTagLinks(entities, links, tenantID, event.GetSourceId(), event, policyURN, "grc_domain", firstAttribute(attrs, "domains"))
+	}
+	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
 
@@ -978,4 +988,84 @@ func grcUserEntity(tenantID string, sourceID string, urn string, label string, a
 		Label:      label,
 		Attributes: attrs,
 	}
+}
+
+func addGRCUserOwnerLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, provider string, ownerID string) {
+	ownerID = strings.TrimSpace(ownerID)
+	if fromURN == "" || ownerID == "" {
+		return
+	}
+	ownerURN := grcUserURN(tenantID, provider, ownerID)
+	addEntity(entities, grcUserEntity(tenantID, sourceID, ownerURN, ownerID, map[string]string{"user_id": ownerID, "source_system": provider}))
+	addLink(links, projectedLink(tenantID, sourceID, fromURN, ownerURN, relationOwnedBy, map[string]string{"event_id": event.GetId()}))
+}
+
+func addGRCIntegrationLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, provider string, rawIntegrations string, relationshipBy string) {
+	if fromURN == "" {
+		return
+	}
+	for _, integrationID := range grcAttributeSequence(rawIntegrations) {
+		integrationURN := grcIntegrationURN(tenantID, provider, integrationID)
+		if integrationURN == "" {
+			continue
+		}
+		addEntity(entities, grcIntegrationReferenceEntity(tenantID, sourceID, integrationURN, integrationID, provider))
+		addLink(links, projectedLink(tenantID, sourceID, fromURN, integrationURN, relationBelongsTo, map[string]string{
+			"event_id":         event.GetId(),
+			"integration_id":   integrationID,
+			"relationship":     relationBelongsTo,
+			"relationship_by":  relationshipBy,
+			"source_reference": "integrations",
+		}))
+	}
+}
+
+func addGRCAssetTagLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, namespace string, rawValues string) {
+	if fromURN == "" {
+		return
+	}
+	for _, value := range grcAttributeSequence(rawValues) {
+		tagID := grcAssetTagID(namespace, value)
+		if tagID == "" {
+			continue
+		}
+		tagURN := projectionURN(tenantID, "asset_tag", namespace, tagID)
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        tagURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: "asset.tag",
+			Label:      value,
+			Attributes: map[string]string{
+				"tag":           tagID,
+				"tag_namespace": namespace,
+				"tag_value":     value,
+			},
+		})
+		addLink(links, projectedLink(tenantID, sourceID, fromURN, tagURN, relationTaggedAs, map[string]string{
+			"event_id":      event.GetId(),
+			"tag_namespace": namespace,
+			"tag_value":     value,
+		}))
+	}
+}
+
+func grcAssetTagID(namespace string, value string) string {
+	normalized := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + ('a' - 'A')
+		case r >= '0' && r <= '9':
+			return r
+		default:
+			return '_'
+		}
+	}, strings.TrimSpace(value))
+	normalized = strings.Trim(normalized, "_")
+	for strings.Contains(normalized, "__") {
+		normalized = strings.ReplaceAll(normalized, "__", "_")
+	}
+	return normalized
 }

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -68,6 +68,61 @@ func TestProjectGRCVendorWithOwner(t *testing.T) {
 	assertProjectedLink(t, state, vendorURN, relationHasIdentifier, hostURN)
 }
 
+func TestProjectGRCDocumentLinksURLAndCategory(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-document-doc-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.document",
+		Attributes: map[string]string{
+			"provider":    "vanta",
+			"document_id": "doc-1",
+			"title":       "AWS Architecture",
+			"category":    "Infrastructure",
+			"url":         "https://docs.writer.com/security/aws-architecture",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	documentURN := "urn:cerebro:writer:document:vanta:doc-1"
+	hostURN := "urn:cerebro:writer:internet_host:docs.writer.com"
+	categoryURN := "urn:cerebro:writer:asset_tag:grc_category:infrastructure"
+	assertProjectedLink(t, state, documentURN, relationHasIdentifier, hostURN)
+	assertProjectedLink(t, state, documentURN, relationTaggedAs, categoryURN)
+}
+
+func TestProjectGRCIntegrationTagsResourceKinds(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-integration-aws",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.integration",
+		Attributes: map[string]string{
+			"provider":       "vanta",
+			"integration_id": "aws",
+			"display_name":   "AWS",
+			"resource_kinds": "AwsAccountMetadata,CloudTrail",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	sourceURN := "urn:cerebro:writer:source:vanta:integration:aws"
+	accountMetadataURN := "urn:cerebro:writer:asset_tag:grc_resource_kind:awsaccountmetadata"
+	cloudTrailURN := "urn:cerebro:writer:asset_tag:grc_resource_kind:cloudtrail"
+	assertProjectedLink(t, state, sourceURN, relationTaggedAs, accountMetadataURN)
+	assertProjectedLink(t, state, sourceURN, relationTaggedAs, cloudTrailURN)
+}
+
 func TestProjectGRCControlTestSupportsControlReferences(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
@@ -102,6 +157,39 @@ func TestProjectGRCControlTestSupportsControlReferences(t *testing.T) {
 	}
 }
 
+func TestProjectGRCControlTestLinksOwnerIntegrationAndCategory(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-control-test-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.control_test",
+		Attributes: map[string]string{
+			"provider":     "vanta",
+			"test_id":      "test-1",
+			"name":         "AWS Config enabled",
+			"owner_id":     "user-1",
+			"integrations": "aws,gcp",
+			"category":     "Infrastructure",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	testURN := "urn:cerebro:writer:evidence:vanta:control_test:test-1"
+	ownerURN := "urn:cerebro:writer:user:vanta:user-1"
+	awsSourceURN := "urn:cerebro:writer:source:vanta:integration:aws"
+	gcpSourceURN := "urn:cerebro:writer:source:vanta:integration:gcp"
+	categoryURN := "urn:cerebro:writer:asset_tag:grc_category:infrastructure"
+	assertProjectedLink(t, state, testURN, relationOwnedBy, ownerURN)
+	assertProjectedLink(t, state, testURN, relationBelongsTo, awsSourceURN)
+	assertProjectedLink(t, state, testURN, relationBelongsTo, gcpSourceURN)
+	assertProjectedLink(t, state, testURN, relationTaggedAs, categoryURN)
+}
+
 func TestProjectGRCControlTestKeepsPairedControlReferences(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
@@ -132,6 +220,37 @@ func TestProjectGRCControlTestKeepsPairedControlReferences(t *testing.T) {
 	if got := state.entities[secondControlURN].Attributes["control_external_id"]; got != "CC7.1" {
 		t.Fatalf("second control_external_id = %q, want CC7.1", got)
 	}
+}
+
+func TestProjectGRCControlLinksOwnerAndDomains(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-control-1",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.control",
+		Attributes: map[string]string{
+			"provider":    "vanta",
+			"control_id":  "control-1",
+			"name":        "Access Reviews",
+			"owner_id":    "user-1",
+			"domains":     "COMPLIANCE, SECURITY & PRIVACY GOVERNANCE",
+			"description": "Access is reviewed periodically",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	controlURN := "urn:cerebro:writer:policy:vanta:control:control-1"
+	ownerURN := "urn:cerebro:writer:user:vanta:user-1"
+	complianceURN := "urn:cerebro:writer:asset_tag:grc_domain:compliance"
+	securityURN := "urn:cerebro:writer:asset_tag:grc_domain:security_privacy_governance"
+	assertProjectedLink(t, state, controlURN, relationOwnedBy, ownerURN)
+	assertProjectedLink(t, state, controlURN, relationTaggedAs, complianceURN)
+	assertProjectedLink(t, state, controlURN, relationTaggedAs, securityURN)
 }
 
 func TestProjectGRCControlTestDoesNotRegressControlLabelWhenExternalIDMissingLater(t *testing.T) {


### PR DESCRIPTION
## Summary
- Link Cosmo facts back to sessions when their `source` points at `session:<id>`.
- Add GRC owner/source/category/domain/resource-kind relationships for controls, control-test evidence, documents, and integrations.
- Add focused projection regression coverage for the new relationships.

## Validation
- `go test ./internal/sourceprojection`
- `make verify` passed on stacked follow-up branch `droid/graph-coordination-findings`.
