### PR TITLE
Add graph coordination finding rules

### DIFF
--- a/internal/findings/coordination_graph_rule.go
+++ b/internal/findings/coordination_graph_rule.go
@@ -1,0 +1,478 @@
+package findings
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	coordinationGraphRowLimit             = 500
+	coordinationGraphConcentrationMinimum = 5
+)
+
+type coordinationGraphRule struct {
+	definition RuleDefinition
+	sourceID   string
+	families   map[string]map[string]struct{}
+	query      string
+	params     map[string]any
+}
+
+func newCoordinationGraphRules() []Rule {
+	return []Rule{
+		newGRCSourceConcentratedOpenFindingsRule(),
+		newGRCFailingControlTestUnhealthyIntegrationRule(),
+		newGRCControlMissingEvidenceCoverageRule(),
+		newGRCDocumentNeedsOwnerOrUploadRule(),
+		newGRCIsolatedTargetEnrichmentGapRule(),
+		newFindingIsolatedOpenAnchorRule(),
+		newResourceMultipleOpenFindingsRule(),
+	}
+}
+
+func newGRCSourceConcentratedOpenFindingsRule() Rule {
+	return newCoordinationGraphRule(RuleDefinition{
+		ID:          "grc-source-integration-concentrated-open-findings",
+		Name:        "GRC Source Integration Concentrated Open Findings",
+		Description: "Detect GRC source integrations that accumulate many active findings and should be prioritized as a coordinated remediation surface.",
+		SourceID:    "grc",
+		EventKinds:  []string{"grc.integration", "grc.vulnerability", "grc.vulnerable_asset"},
+		OutputKind:  "finding.grc_source_integration_concentrated_open_findings",
+		Severity:    "HIGH",
+		Status:      findingStatusOpen,
+		Maturity:    "test",
+		Tags:        []string{"grc", "graph-rule", "coordination", "prioritization"},
+		References:  []string{"https://www.iso.org/standard/27001"},
+		FalsePositives: []string{
+			"Multiple findings may represent duplicate upstream vulnerability records on the same integration.",
+			"The source integration may be intentionally broad and owned by an active remediation program.",
+		},
+		Runbook:           "Review the integration owner, cluster the active findings by vulnerability and target, and drive remediation at the source integration level rather than ticketing each duplicate individually.",
+		FingerprintFields: []string{"source_urn"},
+		ControlRefs: []ports.FindingControlRef{
+			{FrameworkName: "SOC 2", ControlID: "CC7.1"},
+			{FrameworkName: "ISO 27001:2022", ControlID: "A.8.8"},
+		},
+	}, map[string][]string{"grc": {"integration", "vulnerability", "vulnerable_asset"}}, `MATCH (source:Entity {tenant_id: $tenant_id, entity_type: 'source'})
+MATCH (source)-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WHERE coalesce(finding.attributes_json, '') CONTAINS '"status":"open"'
+WITH source, collect(DISTINCT finding) AS findings, count(DISTINCT finding) AS finding_count
+WHERE finding_count >= $finding_threshold
+RETURN source.urn AS primary_urn,
+       source.label AS primary_label,
+       source.entity_type AS primary_type,
+       source.urn AS fingerprint_key,
+       'HIGH' AS severity,
+       'Source integration has ' + toString(finding_count) + ' open finding(s)' AS summary,
+       'Prioritize remediation at the source integration level' AS action,
+       [source.urn] + [f IN findings | f.urn] AS resource_urns,
+       [f IN findings[0..20] | {urn: f.urn, label: f.label, entity_type: f.entity_type, relation: 'has_finding', attributes_json: coalesce(f.attributes_json, '')}] AS evidence
+ORDER BY finding_count DESC, source.urn
+LIMIT $row_limit`, map[string]any{"finding_threshold": int64(coordinationGraphConcentrationMinimum)})
+}
+
+func newGRCFailingControlTestUnhealthyIntegrationRule() Rule {
+	return newCoordinationGraphRule(RuleDefinition{
+		ID:          "grc-failing-control-test-unhealthy-integration",
+		Name:        "GRC Failing Control Test On Unhealthy Integration",
+		Description: "Detect failing GRC control-test evidence that belongs to an integration with disabled or errored connections.",
+		SourceID:    "grc",
+		EventKinds:  []string{"grc.control_test", "grc.integration"},
+		OutputKind:  "finding.grc_failing_control_test_unhealthy_integration",
+		Severity:    "HIGH",
+		Status:      findingStatusOpen,
+		Maturity:    "test",
+		Tags:        []string{"grc", "control", "integration", "graph-rule"},
+		References:  []string{"https://www.iso.org/standard/27001"},
+		FalsePositives: []string{
+			"The integration error count may be stale if the upstream GRC provider has not refreshed connection status yet.",
+		},
+		Runbook:           "Repair the unhealthy source integration, rerun the failing control test, and verify whether the control failure clears once evidence collection is healthy.",
+		FingerprintFields: []string{"test_urn", "integration_urn"},
+		ControlRefs: []ports.FindingControlRef{
+			{FrameworkName: "SOC 2", ControlID: "CC7.2"},
+			{FrameworkName: "ISO 27001:2022", ControlID: "A.8.15"},
+		},
+	}, map[string][]string{"grc": {"control_test", "integration"}}, `MATCH (test:Entity {tenant_id: $tenant_id, source_id: 'grc', entity_type: 'evidence'})
+MATCH (test)-[:RELATION {relation: 'belongs_to'}]->(source:Entity {tenant_id: $tenant_id, entity_type: 'source'})
+WHERE coalesce(test.attributes_json, '') CONTAINS '"status":"NEEDS_ATTENTION"'
+  AND (coalesce(source.attributes_json, '') CONTAINS '"connection_error_count":"1"' OR coalesce(source.attributes_json, '') CONTAINS '"disabled_connection_count":"1"')
+RETURN test.urn AS primary_urn,
+       test.label AS primary_label,
+       test.entity_type AS primary_type,
+       test.urn + '|' + source.urn AS fingerprint_key,
+       'HIGH' AS severity,
+       'Failing control test depends on unhealthy integration ' + coalesce(source.label, source.urn) AS summary,
+       'Fix the integration health before treating the control failure as authoritative' AS action,
+       [test.urn, source.urn] AS resource_urns,
+       [{urn: source.urn, label: source.label, entity_type: source.entity_type, relation: 'belongs_to', attributes_json: coalesce(source.attributes_json, '')}] AS evidence
+ORDER BY test.urn, source.urn
+LIMIT $row_limit`, nil)
+}
+
+func newGRCControlMissingEvidenceCoverageRule() Rule {
+	return newCoordinationGraphRule(RuleDefinition{
+		ID:          "grc-control-missing-evidence-coverage",
+		Name:        "GRC Control Missing Evidence Coverage",
+		Description: "Detect GRC controls that have an owner but no linked control-test evidence in the graph.",
+		SourceID:    "grc",
+		EventKinds:  []string{"grc.control", "grc.control_test"},
+		OutputKind:  "finding.grc_control_missing_evidence_coverage",
+		Severity:    "MEDIUM",
+		Status:      findingStatusOpen,
+		Maturity:    "test",
+		Tags:        []string{"grc", "control", "evidence", "graph-rule"},
+		References:  []string{"https://www.iso.org/standard/27001"},
+		FalsePositives: []string{
+			"The control may be manually assessed outside Vanta or intentionally not test-backed.",
+		},
+		Runbook:           "Confirm whether the control should have automated or manual test evidence, then map the control test or document the accepted exception.",
+		FingerprintFields: []string{"control_urn"},
+		ControlRefs: []ports.FindingControlRef{
+			{FrameworkName: "SOC 2", ControlID: "CC1.2"},
+			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.36"},
+		},
+	}, map[string][]string{"grc": {"control", "control_test"}}, `MATCH (control:Entity {tenant_id: $tenant_id, source_id: 'grc', entity_type: 'policy'})
+WHERE coalesce(control.attributes_json, '') CONTAINS '"policy_type":"control"'
+  AND coalesce(control.attributes_json, '') CONTAINS '"owner_id":'
+  AND NOT EXISTS {
+    MATCH (:Entity {tenant_id: $tenant_id, entity_type: 'evidence'})-[:RELATION {relation: 'supports'}]->(control)
+  }
+RETURN control.urn AS primary_urn,
+       control.label AS primary_label,
+       control.entity_type AS primary_type,
+       control.urn AS fingerprint_key,
+       'MEDIUM' AS severity,
+       'Owned GRC control has no linked test evidence' AS summary,
+       'Map the control to test evidence or document why it is manually assessed' AS action,
+       [control.urn] AS resource_urns,
+       [] AS evidence
+ORDER BY control.urn
+LIMIT $row_limit`, nil)
+}
+
+func newGRCDocumentNeedsOwnerOrUploadRule() Rule {
+	return newCoordinationGraphRule(RuleDefinition{
+		ID:          "grc-document-needs-owner-or-upload",
+		Name:        "GRC Document Needs Owner Or Upload",
+		Description: "Detect GRC document records that still need a document upload or lack an accountable owner.",
+		SourceID:    "grc",
+		EventKinds:  []string{"grc.document"},
+		OutputKind:  "finding.grc_document_needs_owner_or_upload",
+		Severity:    "MEDIUM",
+		Status:      findingStatusOpen,
+		Maturity:    "test",
+		Tags:        []string{"grc", "document", "ownership", "graph-rule"},
+		References:  []string{"https://www.iso.org/standard/27001"},
+		FalsePositives: []string{
+			"Some document placeholders may intentionally track future evidence collection.",
+		},
+		Runbook:           "Assign an owner for the document, upload the missing evidence, or close the placeholder if the document is no longer required.",
+		FingerprintFields: []string{"document_urn"},
+		ControlRefs: []ports.FindingControlRef{
+			{FrameworkName: "SOC 2", ControlID: "CC2.2"},
+			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.37"},
+		},
+	}, map[string][]string{"grc": {"document"}}, `MATCH (doc:Entity {tenant_id: $tenant_id, source_id: 'grc', entity_type: 'document'})
+WHERE coalesce(doc.attributes_json, '') CONTAINS '"upload_status":"Needs document"'
+   OR NOT (doc)-[:RELATION {relation: 'owned_by'}]->(:Entity {tenant_id: $tenant_id})
+RETURN doc.urn AS primary_urn,
+       doc.label AS primary_label,
+       doc.entity_type AS primary_type,
+       doc.urn AS fingerprint_key,
+       'MEDIUM' AS severity,
+       'GRC document needs upload or owner' AS summary,
+       'Assign an owner and complete the missing document evidence' AS action,
+       [doc.urn] AS resource_urns,
+       [] AS evidence
+ORDER BY doc.urn
+LIMIT $row_limit`, nil)
+}
+
+func newGRCIsolatedTargetEnrichmentGapRule() Rule {
+	return newCoordinationGraphRule(RuleDefinition{
+		ID:          "grc-isolated-target-enrichment-gap",
+		Name:        "GRC Target Enrichment Gap",
+		Description: "Detect GRC vulnerable-asset targets that are isolated and therefore cannot coordinate to assets, sources, vulnerabilities, or packages.",
+		SourceID:    "grc",
+		EventKinds:  []string{"grc.vulnerable_asset"},
+		OutputKind:  "finding.grc_isolated_target_enrichment_gap",
+		Severity:    "LOW",
+		Status:      findingStatusOpen,
+		Maturity:    "test",
+		Tags:        []string{"grc", "graph-hygiene", "enrichment", "graph-rule"},
+		References:  []string{"https://www.iso.org/standard/27001"},
+		FalsePositives: []string{
+			"Some upstream targets may be placeholders that intentionally lack asset, integration, or vulnerability references.",
+		},
+		Runbook:           "Inspect the upstream vulnerable asset payload and add host, IP, platform resource, integration, vulnerability, or package fields so the target can be coordinated.",
+		FingerprintFields: []string{"target_urn"},
+		ControlRefs: []ports.FindingControlRef{
+			{FrameworkName: "SOC 2", ControlID: "CC7.1"},
+			{FrameworkName: "ISO 27001:2022", ControlID: "A.8.8"},
+		},
+	}, map[string][]string{"grc": {"vulnerable_asset"}}, `MATCH (target:Entity {tenant_id: $tenant_id, source_id: 'grc', entity_type: 'grc.target'})
+WHERE NOT (target)-[:RELATION]-()
+RETURN target.urn AS primary_urn,
+       target.label AS primary_label,
+       target.entity_type AS primary_type,
+       target.urn AS fingerprint_key,
+       'LOW' AS severity,
+       'GRC target has no graph relationships' AS summary,
+       'Enrich the target with representable asset, integration, vulnerability, or package references' AS action,
+       [target.urn] AS resource_urns,
+       [] AS evidence
+ORDER BY target.urn
+LIMIT $row_limit`, nil)
+}
+
+func newFindingIsolatedOpenAnchorRule() Rule {
+	return newCoordinationGraphRule(RuleDefinition{
+		ID:          "finding-isolated-open-anchor",
+		Name:        "Open Finding Isolated From Resources",
+		Description: "Detect open finding anchors that have no graph resource relationship.",
+		SourceID:    "graph",
+		EventKinds:  []string{"finding"},
+		OutputKind:  "finding.graph_isolated_open_finding_anchor",
+		Severity:    "LOW",
+		Status:      findingStatusOpen,
+		Maturity:    "test",
+		Tags:        []string{"finding", "graph-hygiene", "graph-rule"},
+		References:  []string{"https://www.iso.org/standard/27001"},
+		FalsePositives: []string{
+			"Resolved or suppressed historical finding anchors may intentionally remain without active resource links.",
+		},
+		Runbook:           "Check why the rule emitted no ResourceURNs for an open finding, fix the rule projection context, or resolve stale anchors.",
+		FingerprintFields: []string{"finding_urn"},
+		ControlRefs: []ports.FindingControlRef{
+			{FrameworkName: "SOC 2", ControlID: "CC7.1"},
+			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.35"},
+		},
+	}, nil, `MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WHERE NOT (finding)-[:RELATION]-()
+  AND coalesce(finding.attributes_json, '') CONTAINS '"status":"open"'
+RETURN finding.urn AS primary_urn,
+       finding.label AS primary_label,
+       finding.entity_type AS primary_type,
+       finding.urn AS fingerprint_key,
+       'LOW' AS severity,
+       'Open finding has no graph resource anchor' AS summary,
+       'Fix ResourceURN projection or resolve the stale finding anchor' AS action,
+       [finding.urn] AS resource_urns,
+       [] AS evidence
+ORDER BY finding.urn
+LIMIT $row_limit`, nil)
+}
+
+func newResourceMultipleOpenFindingsRule() Rule {
+	return newCoordinationGraphRule(RuleDefinition{
+		ID:          "graph-resource-multiple-open-findings",
+		Name:        "Graph Resource Has Multiple Open Findings",
+		Description: "Detect resources with multiple active findings so remediation can be coordinated by shared resource rather than by individual alert.",
+		SourceID:    "graph",
+		EventKinds:  []string{"finding"},
+		OutputKind:  "finding.graph_resource_multiple_open_findings",
+		Severity:    "HIGH",
+		Status:      findingStatusOpen,
+		Maturity:    "test",
+		Tags:        []string{"finding", "coordination", "graph-rule", "prioritization"},
+		References:  []string{"https://www.iso.org/standard/27001"},
+		FalsePositives: []string{
+			"Multiple findings may be duplicate projections of one upstream issue until deduplication rules converge.",
+		},
+		Runbook:           "Prioritize the shared resource, group the findings by rule and owner, and remediate the common root cause.",
+		FingerprintFields: []string{"resource_urn"},
+		ControlRefs: []ports.FindingControlRef{
+			{FrameworkName: "SOC 2", ControlID: "CC7.1"},
+			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.7"},
+		},
+	}, nil, `MATCH (resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WHERE coalesce(finding.attributes_json, '') CONTAINS '"status":"open"'
+WITH resource, collect(DISTINCT finding) AS findings, count(DISTINCT finding) AS finding_count
+WHERE finding_count >= $finding_threshold
+RETURN resource.urn AS primary_urn,
+       resource.label AS primary_label,
+       resource.entity_type AS primary_type,
+       resource.urn AS fingerprint_key,
+       'HIGH' AS severity,
+       'Resource has ' + toString(finding_count) + ' open finding(s)' AS summary,
+       'Coordinate remediation by the shared graph resource' AS action,
+       [resource.urn] + [f IN findings | f.urn] AS resource_urns,
+       [f IN findings[0..20] | {urn: f.urn, label: f.label, entity_type: f.entity_type, relation: 'has_finding', attributes_json: coalesce(f.attributes_json, '')}] AS evidence
+ORDER BY finding_count DESC, resource.urn
+LIMIT $row_limit`, map[string]any{"finding_threshold": int64(coordinationGraphConcentrationMinimum)})
+}
+
+func newCoordinationGraphRule(definition RuleDefinition, families map[string][]string, query string, params map[string]any) Rule {
+	if definition.Lifecycle.Kind == "" {
+		definition.Lifecycle = Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorGraphAnchored}
+	}
+	allowed := map[string]map[string]struct{}{}
+	for sourceID, sourceFamilies := range families {
+		sourceID = strings.ToLower(strings.TrimSpace(sourceID))
+		if sourceID == "" {
+			continue
+		}
+		allowed[sourceID] = map[string]struct{}{}
+		for _, family := range sourceFamilies {
+			if family = strings.ToLower(strings.TrimSpace(family)); family != "" {
+				allowed[sourceID][family] = struct{}{}
+			}
+		}
+	}
+	return &coordinationGraphRule{
+		definition: definition,
+		sourceID:   strings.TrimSpace(definition.SourceID),
+		families:   allowed,
+		query:      query,
+		params:     params,
+	}
+}
+
+func (r *coordinationGraphRule) Spec() *cerebrov1.RuleSpec {
+	if r == nil {
+		return nil
+	}
+	return proto.Clone(r.definition.RuleSpec()).(*cerebrov1.RuleSpec)
+}
+
+func (r *coordinationGraphRule) RuleMetadata() RuleDefinition {
+	if r == nil {
+		return RuleDefinition{}
+	}
+	return cloneRuleDefinition(r.definition)
+}
+
+func (r *coordinationGraphRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
+	if r == nil || runtime == nil {
+		return false
+	}
+	if len(r.families) == 0 {
+		return true
+	}
+	sourceID := strings.ToLower(strings.TrimSpace(runtime.GetSourceId()))
+	allowedFamilies, ok := r.families[sourceID]
+	if !ok {
+		return false
+	}
+	if len(allowedFamilies) == 0 {
+		return true
+	}
+	_, ok = allowedFamilies[strings.ToLower(strings.TrimSpace(runtime.GetConfig()["family"]))]
+	return ok
+}
+
+func (r *coordinationGraphRule) Evaluate(context.Context, *cerebrov1.SourceRuntime, *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+	return nil, nil
+}
+
+func (r *coordinationGraphRule) QueryFor(runtime *cerebrov1.SourceRuntime) ports.CypherQueryRequest {
+	if r == nil || runtime == nil || strings.TrimSpace(runtime.GetTenantId()) == "" {
+		return ports.CypherQueryRequest{}
+	}
+	params := map[string]any{
+		"tenant_id": strings.TrimSpace(runtime.GetTenantId()),
+		"row_limit": int64(coordinationGraphRowLimit),
+	}
+	for key, value := range r.params {
+		params[key] = value
+	}
+	return ports.CypherQueryRequest{Query: r.query, Params: params, RowLimit: coordinationGraphRowLimit}
+}
+
+func (r *coordinationGraphRule) EvaluateRows(_ context.Context, runtime *cerebrov1.SourceRuntime, rows []ports.CypherRow) ([]*ports.FindingRecord, error) {
+	if r == nil || runtime == nil || len(rows) == 0 {
+		return nil, nil
+	}
+	tenantID := strings.TrimSpace(runtime.GetTenantId())
+	if tenantID == "" {
+		return nil, nil
+	}
+	now := time.Now().UTC()
+	findings := make([]*ports.FindingRecord, 0, len(rows))
+	for _, row := range rows {
+		primaryURN := cypherRowString(row, "primary_urn")
+		if primaryURN == "" {
+			continue
+		}
+		fingerprintKey := firstNonEmpty(cypherRowString(row, "fingerprint_key"), primaryURN)
+		fingerprint := hashFindingFingerprint(r.definition.ID, tenantID, fingerprintKey)
+		severity := firstNonEmpty(cypherRowString(row, "severity"), r.definition.Severity)
+		summary := firstNonEmpty(cypherRowString(row, "summary"), fmt.Sprintf("%s on %s", r.definition.Name, primaryURN))
+		action := firstNonEmpty(cypherRowString(row, "action"), "Review the graph evidence and remediate the shared control gap.")
+		resourceURNs := deduplicateStrings(append([]string{primaryURN}, coordinationRowStrings(row, "resource_urns")...))
+		attributes := map[string]string{
+			"action":               action,
+			"graph_rule":           "true",
+			"graph_evidence_count": fmt.Sprintf("%d", len(cypherRowList(row, "evidence"))),
+			"primary_resource_urn": primaryURN,
+			"resource_label":       cypherRowString(row, "primary_label"),
+			"resource_type":        cypherRowString(row, "primary_type"),
+			"source_runtime_id":    strings.TrimSpace(runtime.GetId()),
+		}
+		for key, value := range r.definition.AttributeMap() {
+			attributes["rule_"+key] = value
+		}
+		trimEmptyAttributes(attributes)
+		findings = append(findings, &ports.FindingRecord{
+			ID:                fingerprint,
+			Fingerprint:       fingerprint,
+			TenantID:          tenantID,
+			RuntimeID:         strings.TrimSpace(runtime.GetId()),
+			RuleID:            r.definition.ID,
+			Title:             r.definition.Name,
+			Severity:          severity,
+			Status:            r.definition.Status,
+			Summary:           summary,
+			ResourceURNs:      resourceURNs,
+			CheckID:           r.definition.ID,
+			CheckName:         r.definition.Name,
+			ControlRefs:       cloneFindingControlRefs(r.definition.ControlRefs),
+			GraphEvidenceRows: coordinationGraphEvidenceRows(primaryURN, cypherRowString(row, "primary_label"), cypherRowString(row, "primary_type"), row),
+			Attributes:        attributes,
+			FirstObservedAt:   now,
+			LastObservedAt:    now,
+		})
+	}
+	return findings, nil
+}
+
+func coordinationRowStrings(row ports.CypherRow, key string) []string {
+	values := cypherRowList(row, key)
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		text := strings.TrimSpace(fmt.Sprintf("%v", value))
+		if text != "" && text != "<nil>" {
+			result = append(result, text)
+		}
+	}
+	return result
+}
+
+func coordinationGraphEvidenceRows(primaryURN string, primaryLabel string, primaryType string, row ports.CypherRow) []*cerebrov1.GraphEvidenceRow {
+	evidence := cypherRowList(row, "evidence")
+	rows := make([]*cerebrov1.GraphEvidenceRow, 0, len(evidence))
+	for _, item := range evidence {
+		urn := cypherListMapString(item, "urn")
+		if urn == "" {
+			continue
+		}
+		label := cypherListMapString(item, "label")
+		entityType := cypherListMapString(item, "entity_type")
+		relation := firstNonEmpty(cypherListMapString(item, "relation"), "related_to")
+		rows = append(rows, newGraphEvidenceRow("coordination_graph_evidence", map[string]string{
+			"evidence_urn":   urn,
+			"evidence_label": label,
+			"evidence_type":  entityType,
+			"relation":       relation,
+		}, newGraphEvidencePath(primaryURN, primaryLabel, primaryType, relation, urn, label, entityType, edgeStringAttributes(cypherListMapString(item, "attributes_json")))))
+	}
+	return rows
+}

--- a/internal/findings/coordination_graph_rule_test.go
+++ b/internal/findings/coordination_graph_rule_test.go
@@ -1,0 +1,99 @@
+package findings
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestCoordinationGraphRuleSupportsRuntime(t *testing.T) {
+	rule := newGRCSourceConcentratedOpenFindingsRule()
+	if !rule.SupportsRuntime(&cerebrov1.SourceRuntime{TenantId: "writer", SourceId: "grc", Config: map[string]string{"family": "integration"}}) {
+		t.Fatal("SupportsRuntime(grc integration) = false, want true")
+	}
+	if rule.SupportsRuntime(&cerebrov1.SourceRuntime{TenantId: "writer", SourceId: "grc", Config: map[string]string{"family": "document"}}) {
+		t.Fatal("SupportsRuntime(grc document) = true, want false")
+	}
+}
+
+func TestCoordinationGraphRuleQueryRequiresTenant(t *testing.T) {
+	rule := newResourceMultipleOpenFindingsRule().(GraphRule)
+	if got := rule.QueryFor(&cerebrov1.SourceRuntime{}); got.Query != "" {
+		t.Fatalf("QueryFor(runtime without tenant) = %q, want empty", got.Query)
+	}
+	query := rule.QueryFor(&cerebrov1.SourceRuntime{TenantId: "writer"})
+	if query.Query == "" {
+		t.Fatal("QueryFor(runtime with tenant) returned empty query")
+	}
+	if query.Params["tenant_id"] != "writer" {
+		t.Fatalf("tenant_id param = %#v, want writer", query.Params["tenant_id"])
+	}
+	if !strings.Contains(query.Query, "LIMIT $row_limit") {
+		t.Fatalf("query missing LIMIT $row_limit: %s", query.Query)
+	}
+}
+
+func TestCoordinationGraphRuleEvaluateRowsBuildsFinding(t *testing.T) {
+	rule := newGRCSourceConcentratedOpenFindingsRule().(GraphRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-grc-integration", TenantId: "writer", SourceId: "grc", Config: map[string]string{"family": "integration"}}
+
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{{Values: map[string]any{
+		"primary_urn":     "urn:cerebro:writer:source:vanta:integration:aws",
+		"primary_label":   "AWS",
+		"primary_type":    "source",
+		"fingerprint_key": "urn:cerebro:writer:source:vanta:integration:aws",
+		"severity":        "HIGH",
+		"summary":         "Source integration has 5 open finding(s)",
+		"action":          "Prioritize remediation at the source integration level",
+		"resource_urns": []any{
+			"urn:cerebro:writer:source:vanta:integration:aws",
+			"urn:cerebro:writer:finding:one",
+		},
+		"evidence": []any{map[string]any{
+			"urn":             "urn:cerebro:writer:finding:one",
+			"label":           "Finding One",
+			"entity_type":     "finding",
+			"relation":        "has_finding",
+			"attributes_json": `{"status":"open","rule_id":"example"}`,
+		}},
+	}}})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("len(findings) = %d, want 1", len(findings))
+	}
+	finding := findings[0]
+	if finding.RuleID != "grc-source-integration-concentrated-open-findings" || finding.Severity != "HIGH" || finding.Status != findingStatusOpen {
+		t.Fatalf("finding metadata = %#v", finding)
+	}
+	if finding.Attributes["primary_resource_urn"] != "urn:cerebro:writer:source:vanta:integration:aws" {
+		t.Fatalf("primary_resource_urn = %q", finding.Attributes["primary_resource_urn"])
+	}
+	if len(finding.ResourceURNs) != 2 {
+		t.Fatalf("ResourceURNs = %#v, want primary and evidence", finding.ResourceURNs)
+	}
+	if len(finding.GraphEvidenceRows) != 1 {
+		t.Fatalf("len(GraphEvidenceRows) = %d, want 1", len(finding.GraphEvidenceRows))
+	}
+}
+
+func TestCoordinationGraphRulesAreRegistered(t *testing.T) {
+	registry := Builtin()
+	for _, id := range []string{
+		"grc-source-integration-concentrated-open-findings",
+		"grc-failing-control-test-unhealthy-integration",
+		"grc-control-missing-evidence-coverage",
+		"grc-document-needs-owner-or-upload",
+		"grc-isolated-target-enrichment-gap",
+		"finding-isolated-open-anchor",
+		"graph-resource-multiple-open-findings",
+	} {
+		if _, ok := registry.Get(id); !ok {
+			t.Fatalf("Builtin() missing rule %s", id)
+		}
+	}
+}

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -1194,6 +1194,132 @@
       ]
     },
     {
+      "id": "finding-isolated-open-anchor",
+      "pack_id": "grc",
+      "pack_name": "GRC",
+      "name": "Open Finding Isolated From Resources",
+      "description": "Detect open finding anchors that have no graph resource relationship.",
+      "source_id": "graph",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "finding"
+      ],
+      "output_kind": "finding.graph_isolated_open_finding_anchor",
+      "severity": "LOW",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "finding",
+        "graph-hygiene",
+        "graph-rule"
+      ],
+      "references": [
+        "https://www.iso.org/standard/27001"
+      ],
+      "false_positives": [
+        "Resolved or suppressed historical finding anchors may intentionally remain without active resource links."
+      ],
+      "runbook": "Check why the rule emitted no ResourceURNs for an open finding, fix the rule projection context, or resolve stale anchors.",
+      "fingerprint_fields": [
+        "finding_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC7.1"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.5.35"
+        }
+      ]
+    },
+    {
+      "id": "graph-resource-multiple-open-findings",
+      "pack_id": "grc",
+      "pack_name": "GRC",
+      "name": "Graph Resource Has Multiple Open Findings",
+      "description": "Detect resources with multiple active findings so remediation can be coordinated by shared resource rather than by individual alert.",
+      "source_id": "graph",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "finding"
+      ],
+      "output_kind": "finding.graph_resource_multiple_open_findings",
+      "severity": "HIGH",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "coordination",
+        "finding",
+        "graph-rule",
+        "prioritization"
+      ],
+      "references": [
+        "https://www.iso.org/standard/27001"
+      ],
+      "false_positives": [
+        "Multiple findings may be duplicate projections of one upstream issue until deduplication rules converge."
+      ],
+      "runbook": "Prioritize the shared resource, group the findings by rule and owner, and remediate the common root cause.",
+      "fingerprint_fields": [
+        "resource_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC7.1"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.5.7"
+        }
+      ]
+    },
+    {
+      "id": "grc-control-missing-evidence-coverage",
+      "pack_id": "grc",
+      "pack_name": "GRC",
+      "name": "GRC Control Missing Evidence Coverage",
+      "description": "Detect GRC controls that have an owner but no linked control-test evidence in the graph.",
+      "source_id": "grc",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "grc.control",
+        "grc.control_test"
+      ],
+      "output_kind": "finding.grc_control_missing_evidence_coverage",
+      "severity": "MEDIUM",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "control",
+        "evidence",
+        "graph-rule",
+        "grc"
+      ],
+      "references": [
+        "https://www.iso.org/standard/27001"
+      ],
+      "false_positives": [
+        "The control may be manually assessed outside Vanta or intentionally not test-backed."
+      ],
+      "runbook": "Confirm whether the control should have automated or manual test evidence, then map the control test or document the accepted exception.",
+      "fingerprint_fields": [
+        "control_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC1.2"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.5.36"
+        }
+      ]
+    },
+    {
       "id": "grc-control-test-needs-attention",
       "pack_id": "grc",
       "pack_name": "GRC",
@@ -1239,6 +1365,48 @@
         {
           "framework_name": "ISO 27001:2022",
           "control_id": "A.5.35"
+        }
+      ]
+    },
+    {
+      "id": "grc-document-needs-owner-or-upload",
+      "pack_id": "grc",
+      "pack_name": "GRC",
+      "name": "GRC Document Needs Owner Or Upload",
+      "description": "Detect GRC document records that still need a document upload or lack an accountable owner.",
+      "source_id": "grc",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "grc.document"
+      ],
+      "output_kind": "finding.grc_document_needs_owner_or_upload",
+      "severity": "MEDIUM",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "document",
+        "graph-rule",
+        "grc",
+        "ownership"
+      ],
+      "references": [
+        "https://www.iso.org/standard/27001"
+      ],
+      "false_positives": [
+        "Some document placeholders may intentionally track future evidence collection."
+      ],
+      "runbook": "Assign an owner for the document, upload the missing evidence, or close the placeholder if the document is no longer required.",
+      "fingerprint_fields": [
+        "document_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC2.2"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.5.37"
         }
       ]
     },
@@ -1293,6 +1461,50 @@
         {
           "framework_name": "SOC 2",
           "control_id": "CC7.2"
+        }
+      ]
+    },
+    {
+      "id": "grc-failing-control-test-unhealthy-integration",
+      "pack_id": "grc",
+      "pack_name": "GRC",
+      "name": "GRC Failing Control Test On Unhealthy Integration",
+      "description": "Detect failing GRC control-test evidence that belongs to an integration with disabled or errored connections.",
+      "source_id": "grc",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "grc.control_test",
+        "grc.integration"
+      ],
+      "output_kind": "finding.grc_failing_control_test_unhealthy_integration",
+      "severity": "HIGH",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "control",
+        "graph-rule",
+        "grc",
+        "integration"
+      ],
+      "references": [
+        "https://www.iso.org/standard/27001"
+      ],
+      "false_positives": [
+        "The integration error count may be stale if the upstream GRC provider has not refreshed connection status yet."
+      ],
+      "runbook": "Repair the unhealthy source integration, rerun the failing control test, and verify whether the control failure clears once evidence collection is healthy.",
+      "fingerprint_fields": [
+        "test_urn",
+        "integration_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC7.2"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.8.15"
         }
       ]
     },
@@ -1358,6 +1570,48 @@
         {
           "framework_name": "ISO 27001:2022",
           "control_id": "A.5.18"
+        }
+      ]
+    },
+    {
+      "id": "grc-isolated-target-enrichment-gap",
+      "pack_id": "grc",
+      "pack_name": "GRC",
+      "name": "GRC Target Enrichment Gap",
+      "description": "Detect GRC vulnerable-asset targets that are isolated and therefore cannot coordinate to assets, sources, vulnerabilities, or packages.",
+      "source_id": "grc",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "grc.vulnerable_asset"
+      ],
+      "output_kind": "finding.grc_isolated_target_enrichment_gap",
+      "severity": "LOW",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "enrichment",
+        "graph-hygiene",
+        "graph-rule",
+        "grc"
+      ],
+      "references": [
+        "https://www.iso.org/standard/27001"
+      ],
+      "false_positives": [
+        "Some upstream targets may be placeholders that intentionally lack asset, integration, or vulnerability references."
+      ],
+      "runbook": "Inspect the upstream vulnerable asset payload and add host, IP, platform resource, integration, vulnerability, or package fields so the target can be coordinated.",
+      "fingerprint_fields": [
+        "target_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC7.1"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.8.8"
         }
       ]
     },
@@ -1475,6 +1729,51 @@
         {
           "framework_name": "ISO 27001:2022",
           "control_id": "A.5.18"
+        }
+      ]
+    },
+    {
+      "id": "grc-source-integration-concentrated-open-findings",
+      "pack_id": "grc",
+      "pack_name": "GRC",
+      "name": "GRC Source Integration Concentrated Open Findings",
+      "description": "Detect GRC source integrations that accumulate many active findings and should be prioritized as a coordinated remediation surface.",
+      "source_id": "grc",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "grc.integration",
+        "grc.vulnerability",
+        "grc.vulnerable_asset"
+      ],
+      "output_kind": "finding.grc_source_integration_concentrated_open_findings",
+      "severity": "HIGH",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "coordination",
+        "graph-rule",
+        "grc",
+        "prioritization"
+      ],
+      "references": [
+        "https://www.iso.org/standard/27001"
+      ],
+      "false_positives": [
+        "Multiple findings may represent duplicate upstream vulnerability records on the same integration.",
+        "The source integration may be intentionally broad and owned by an active remediation program."
+      ],
+      "runbook": "Review the integration owner, cluster the active findings by vulnerability and target, and drive remediation at the source integration level rather than ticketing each duplicate individually.",
+      "fingerprint_fields": [
+        "source_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC7.1"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.8.8"
         }
       ]
     },

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -63,7 +63,7 @@ func builtinRulePacks() []RulePack {
 			ID:          "grc",
 			Name:        "GRC",
 			Description: "Provider-neutral GRC control, vulnerability, and vendor-risk findings.",
-			Rules: []Rule{
+			Rules: append([]Rule{
 				newGRCControlTestNeedsAttentionRule(),
 				newGRCVulnerabilitySLAOverdueRule(),
 				newGRCVendorReviewOverdueRule(),
@@ -71,7 +71,7 @@ func builtinRulePacks() []RulePack {
 				newGRCPrivilegedAccountMissingPersonRule(),
 				newGRCOverdueVulnerabilityLiveOnAssetsRule(),
 				newGRCFailingControlOpenOperationalFindingsRule(),
-			},
+			}, newCoordinationGraphRules()...),
 		},
 		{
 			ID:          "sentinelone",

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -933,7 +933,7 @@ func TestNetNewRetiredRulesNoEmit(t *testing.T) {
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 17; got != want {
+	if got, want := len(keepRules), 24; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1118,9 +1118,14 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "github-webhook-modified", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "grc-control-test-needs-attention", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
 		{RuleID: "grc-failing-control-open-operational-findings", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
+		{RuleID: "grc-failing-control-test-unhealthy-integration", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
+		{RuleID: "grc-control-missing-evidence-coverage", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
+		{RuleID: "grc-document-needs-owner-or-upload", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
 		{RuleID: "grc-inactive-identity-active-access", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
+		{RuleID: "grc-isolated-target-enrichment-gap", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
 		{RuleID: "grc-overdue-vulnerability-live-on-assets", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
 		{RuleID: "grc-privileged-account-missing-person", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
+		{RuleID: "grc-source-integration-concentrated-open-findings", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
 		{RuleID: "grc-vendor-review-overdue", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
 		{RuleID: "grc-vulnerability-sla-overdue", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},
 		{RuleID: "identity-admin-privilege-granted", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "identity"},
@@ -1135,6 +1140,8 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "identity-privileged-account-without-mfa", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">24h", Source: "identity"},
 		{RuleID: "identity-privileged-no-mfa-plus-sensitive-access", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">24h", Source: "identity"},
 		{RuleID: "identity-stale-privileged-account", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">24h", Source: "identity"},
+		{RuleID: "finding-isolated-open-anchor", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "graph"},
+		{RuleID: "graph-resource-multiple-open-findings", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "graph"},
 		{RuleID: "runtime-active-threat-evidence", Classification: "TTL_EVIDENCE_ONLY", BulkCloseoutThreshold: ">24h", Source: "runtime"},
 		{RuleID: "sentinelone-agent-detect-only-mode", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "sentinelone"},
 		{RuleID: "sentinelone-agent-stale", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "sentinelone"},


### PR DESCRIPTION
## Summary
- Add seven graph coordination findings for source-risk concentration, unhealthy GRC integrations, missing control evidence, incomplete GRC documents, isolated GRC targets, isolated open finding anchors, and resources with multiple open findings.
- Register the rules in the GRC pack and refresh the generated public detection catalog.
- Add focused tests for runtime support, query construction, row evaluation, and registry wiring.

## Notes
- This PR is stacked on #654 because the rule set uses the new graph links added there.
- I intentionally kept the speculative Cosmo/ticket and public-cloud-vulnerability rules out of this first implementation until upstream payload/link coverage is confirmed.

## Validation
- `go test ./internal/sourceprojection ./internal/findings`
- `make test`
- `make verify`
