### PR TITLE
fix: bound coordination graph finding resources

### DIFF
--- a/internal/findings/coordination_graph_rule.go
+++ b/internal/findings/coordination_graph_rule.go
@@ -15,6 +15,7 @@ import (
 const (
 	coordinationGraphRowLimit             = 500
 	coordinationGraphConcentrationMinimum = 5
+	coordinationGraphRelatedResourceLimit = 20
 )
 
 type coordinationGraphRule struct {
@@ -34,6 +35,21 @@ func newCoordinationGraphRules() []Rule {
 		newGRCIsolatedTargetEnrichmentGapRule(),
 		newFindingIsolatedOpenAnchorRule(),
 		newResourceMultipleOpenFindingsRule(),
+	}
+}
+
+func isCoordinationGraphRuleID(ruleID string) bool {
+	switch strings.TrimSpace(ruleID) {
+	case "grc-source-integration-concentrated-open-findings",
+		"grc-failing-control-test-unhealthy-integration",
+		"grc-control-missing-evidence-coverage",
+		"grc-document-needs-owner-or-upload",
+		"grc-isolated-target-enrichment-gap",
+		"finding-isolated-open-anchor",
+		"graph-resource-multiple-open-findings":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -72,7 +88,7 @@ RETURN source.urn AS primary_urn,
        'HIGH' AS severity,
        'Source integration has ' + toString(finding_count) + ' open finding(s)' AS summary,
        'Prioritize remediation at the source integration level' AS action,
-       [source.urn] + [f IN findings | f.urn] AS resource_urns,
+       [source.urn] + [f IN findings[0..20] | f.urn] AS resource_urns,
        [f IN findings[0..20] | {urn: f.urn, label: f.label, entity_type: f.entity_type, relation: 'has_finding', attributes_json: coalesce(f.attributes_json, '')}] AS evidence
 ORDER BY finding_count DESC, source.urn
 LIMIT $row_limit`, map[string]any{"finding_threshold": int64(coordinationGraphConcentrationMinimum)})
@@ -304,7 +320,7 @@ RETURN resource.urn AS primary_urn,
        'HIGH' AS severity,
        'Resource has ' + toString(finding_count) + ' open finding(s)' AS summary,
        'Coordinate remediation by the shared graph resource' AS action,
-       [resource.urn] + [f IN findings | f.urn] AS resource_urns,
+       [resource.urn] + [f IN findings[0..20] | f.urn] AS resource_urns,
        [f IN findings[0..20] | {urn: f.urn, label: f.label, entity_type: f.entity_type, relation: 'has_finding', attributes_json: coalesce(f.attributes_json, '')}] AS evidence
 ORDER BY finding_count DESC, resource.urn
 LIMIT $row_limit`, map[string]any{"finding_threshold": int64(coordinationGraphConcentrationMinimum)})
@@ -407,7 +423,7 @@ func (r *coordinationGraphRule) EvaluateRows(_ context.Context, runtime *cerebro
 		severity := firstNonEmpty(cypherRowString(row, "severity"), r.definition.Severity)
 		summary := firstNonEmpty(cypherRowString(row, "summary"), fmt.Sprintf("%s on %s", r.definition.Name, primaryURN))
 		action := firstNonEmpty(cypherRowString(row, "action"), "Review the graph evidence and remediate the shared control gap.")
-		resourceURNs := deduplicateStrings(append([]string{primaryURN}, coordinationRowStrings(row, "resource_urns")...))
+		resourceURNs := limitedCoordinationResourceURNs(primaryURN, coordinationRowStrings(row, "resource_urns"))
 		attributes := map[string]string{
 			"action":               action,
 			"graph_rule":           "true",
@@ -442,6 +458,15 @@ func (r *coordinationGraphRule) EvaluateRows(_ context.Context, runtime *cerebro
 		})
 	}
 	return findings, nil
+}
+
+func limitedCoordinationResourceURNs(primaryURN string, relatedURNs []string) []string {
+	resourceURNs := deduplicateStrings(append([]string{primaryURN}, relatedURNs...))
+	limit := coordinationGraphRelatedResourceLimit + 1
+	if len(resourceURNs) > limit {
+		resourceURNs = resourceURNs[:limit]
+	}
+	return resourceURNs
 }
 
 func coordinationRowStrings(row ports.CypherRow, key string) []string {

--- a/internal/findings/coordination_graph_rule_test.go
+++ b/internal/findings/coordination_graph_rule_test.go
@@ -2,6 +2,7 @@ package findings
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -33,6 +34,9 @@ func TestCoordinationGraphRuleQueryRequiresTenant(t *testing.T) {
 	}
 	if !strings.Contains(query.Query, "LIMIT $row_limit") {
 		t.Fatalf("query missing LIMIT $row_limit: %s", query.Query)
+	}
+	if !strings.Contains(query.Query, "findings[0..20] | f.urn") {
+		t.Fatalf("query does not cap related finding ResourceURNs: %s", query.Query)
 	}
 }
 
@@ -78,6 +82,73 @@ func TestCoordinationGraphRuleEvaluateRowsBuildsFinding(t *testing.T) {
 	}
 	if len(finding.GraphEvidenceRows) != 1 {
 		t.Fatalf("len(GraphEvidenceRows) = %d, want 1", len(finding.GraphEvidenceRows))
+	}
+}
+
+func TestCoordinationGraphRuleEvaluateRowsCapsResourceURNs(t *testing.T) {
+	rule := newResourceMultipleOpenFindingsRule().(GraphRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-cosmo-survey-feedback", TenantId: "writer", SourceId: "cosmo", Config: map[string]string{"family": "survey_feedback"}}
+	resourceURNs := []any{"urn:cerebro:writer:resource:one"}
+	for i := 1; i <= coordinationGraphRelatedResourceLimit+5; i++ {
+		resourceURNs = append(resourceURNs, fmt.Sprintf("urn:cerebro:writer:finding:%02d", i))
+	}
+
+	findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{{Values: map[string]any{
+		"primary_urn":     "urn:cerebro:writer:resource:one",
+		"primary_label":   "Resource One",
+		"primary_type":    "resource",
+		"fingerprint_key": "urn:cerebro:writer:resource:one",
+		"severity":        "HIGH",
+		"summary":         "Resource has many open finding(s)",
+		"action":          "Coordinate remediation by the shared graph resource",
+		"resource_urns":   resourceURNs,
+		"evidence":        []any{},
+	}}})
+	if err != nil {
+		t.Fatalf("EvaluateRows() error = %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("len(findings) = %d, want 1", len(findings))
+	}
+	if got, want := len(findings[0].ResourceURNs), coordinationGraphRelatedResourceLimit+1; got != want {
+		t.Fatalf("len(ResourceURNs) = %d, want %d: %#v", got, want, findings[0].ResourceURNs)
+	}
+}
+
+func TestCoordinationGraphRuleMergeDropsHistoricalResourceOverflow(t *testing.T) {
+	primaryURN := "urn:cerebro:writer:resource:one"
+	existingURNs := []string{primaryURN}
+	for i := 1; i <= coordinationGraphRelatedResourceLimit+10; i++ {
+		existingURNs = append(existingURNs, fmt.Sprintf("urn:cerebro:writer:finding:old:%02d", i))
+	}
+	incomingURNs := []string{primaryURN}
+	for i := 1; i <= coordinationGraphRelatedResourceLimit; i++ {
+		incomingURNs = append(incomingURNs, fmt.Sprintf("urn:cerebro:writer:finding:fresh:%02d", i))
+	}
+
+	merged := mergeFindingEvidenceForUpsert(&ports.FindingRecord{
+		RuleID:       "graph-resource-multiple-open-findings",
+		ResourceURNs: existingURNs,
+		EventIDs:     []string{"event-old"},
+	}, &ports.FindingRecord{
+		RuleID:       "graph-resource-multiple-open-findings",
+		ResourceURNs: incomingURNs,
+		EventIDs:     []string{"event-new"},
+		Attributes: map[string]string{
+			"primary_resource_urn": primaryURN,
+		},
+	})
+	if got, want := len(merged.ResourceURNs), coordinationGraphRelatedResourceLimit+1; got != want {
+		t.Fatalf("len(ResourceURNs) = %d, want %d: %#v", got, want, merged.ResourceURNs)
+	}
+	if containsString(merged.ResourceURNs, "urn:cerebro:writer:finding:old:01") {
+		t.Fatalf("merged ResourceURNs carried historical overflow: %#v", merged.ResourceURNs)
+	}
+	if !containsString(merged.ResourceURNs, "urn:cerebro:writer:finding:fresh:20") {
+		t.Fatalf("merged ResourceURNs missing capped fresh resource: %#v", merged.ResourceURNs)
+	}
+	if !containsString(merged.EventIDs, "event-old") || !containsString(merged.EventIDs, "event-new") {
+		t.Fatalf("EventIDs = %#v, want historical and fresh IDs preserved", merged.EventIDs)
 	}
 }
 

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -1645,7 +1645,18 @@ func mergeFindingEvidenceForUpsert(existing *ports.FindingRecord, incoming *port
 	if existing == nil || incoming == nil {
 		return incoming
 	}
-	incoming.ResourceURNs = uniqueTrimmedStringsPreserveOrder(append(append([]string(nil), existing.ResourceURNs...), incoming.ResourceURNs...))
+	if isCoordinationGraphRuleID(incoming.RuleID) {
+		primaryURN := ""
+		if incoming.Attributes != nil {
+			primaryURN = incoming.Attributes["primary_resource_urn"]
+		}
+		if primaryURN == "" && len(incoming.ResourceURNs) > 0 {
+			primaryURN = incoming.ResourceURNs[0]
+		}
+		incoming.ResourceURNs = limitedCoordinationResourceURNs(primaryURN, incoming.ResourceURNs)
+	} else {
+		incoming.ResourceURNs = uniqueTrimmedStringsPreserveOrder(append(append([]string(nil), existing.ResourceURNs...), incoming.ResourceURNs...))
+	}
 	incoming.EventIDs = uniqueTrimmedStringsPreserveOrder(append(append([]string(nil), existing.EventIDs...), incoming.EventIDs...))
 	incoming.ObservedPolicyIDs = uniqueTrimmedStringsPreserveOrder(append(append([]string(nil), existing.ObservedPolicyIDs...), incoming.ObservedPolicyIDs...))
 	incoming.Attributes = mergeFindingAttributesForUpsert(existing.Attributes, incoming.Attributes)

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -431,6 +431,64 @@ func (s *Service) ensureFindingActiveLinks(ctx context.Context, finding workflow
 			return err
 		}
 	}
+	if err := s.pruneFindingActiveLinks(ctx, tenantID, sourceID, anchorURN, resourceURNs, result); err != nil {
+		return err
+	}
+	return nil
+}
+
+type findingActiveLinkReader interface {
+	ExecuteReadCypher(context.Context, ports.CypherQueryRequest) ([]ports.CypherRow, error)
+}
+
+func (s *Service) pruneFindingActiveLinks(ctx context.Context, tenantID string, sourceID string, anchorURN string, currentResourceURNs []string, result *ports.ProjectionResult) error {
+	reader, ok := s.graph.(findingActiveLinkReader)
+	if !ok {
+		return nil
+	}
+	deleter, ok := s.graph.(ports.ProjectionLinkDeleter)
+	if !ok {
+		return nil
+	}
+	current := make(map[string]struct{}, len(currentResourceURNs))
+	for _, resourceURN := range currentResourceURNs {
+		if resourceURN = strings.TrimSpace(resourceURN); resourceURN != "" {
+			current[resourceURN] = struct{}{}
+		}
+	}
+	rows, err := reader.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
+		Query: `MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(:Entity {tenant_id: $tenant_id, urn: $finding_urn})
+RETURN resource.urn AS resource_urn
+LIMIT $row_limit`,
+		Params: map[string]any{
+			"tenant_id":   tenantID,
+			"finding_urn": anchorURN,
+			"row_limit":   int64(ports.MaxCypherQueryRows),
+		},
+		RowLimit: ports.MaxCypherQueryRows,
+	})
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		resourceURN := strings.TrimSpace(fmt.Sprintf("%v", row.Values["resource_urn"]))
+		if resourceURN == "" || resourceURN == "<nil>" {
+			continue
+		}
+		if _, keep := current[resourceURN]; keep {
+			continue
+		}
+		if err := deleter.DeleteProjectedLink(ctx, &ports.ProjectedLink{
+			TenantID: tenantID,
+			SourceID: sourceID,
+			FromURN:  resourceURN,
+			ToURN:    anchorURN,
+			Relation: relationHasFinding,
+		}); err != nil {
+			return err
+		}
+		result.LinksDeleted++
+	}
 	return nil
 }
 

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -49,6 +49,22 @@ func (r *projectionRecorder) DeleteProjectedLink(_ context.Context, link *ports.
 	return nil
 }
 
+func (r *projectionRecorder) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	findingURN, _ := request.Params["finding_urn"].(string)
+	tenantID, _ := request.Params["tenant_id"].(string)
+	rows := []ports.CypherRow{}
+	for _, link := range r.links {
+		if link == nil || link.ToURN != findingURN || link.Relation != relationHasFinding {
+			continue
+		}
+		if tenantID != "" && link.TenantID != tenantID {
+			continue
+		}
+		rows = append(rows, ports.CypherRow{Values: map[string]any{"resource_urn": link.FromURN}})
+	}
+	return rows, nil
+}
+
 func (r *projectionRecorder) CleanupProjectedEntities(_ context.Context, request ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
 	allowed := map[string]struct{}{}
 	for _, entityType := range request.EntityTypes {
@@ -373,6 +389,72 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	}
 	if _, ok := graph.entities[annotationURN]; ok {
 		t.Fatal("isolated finding note annotation should be pruned from graph")
+	}
+}
+
+func TestProjectFindingRecordedPrunesStaleActiveLinks(t *testing.T) {
+	graph := &projectionRecorder{}
+	service := New(graph)
+	finding := workflowevents.FindingSnapshot{
+		TenantID:           "writer",
+		SourceSystem:       "findings",
+		FindingID:          "finding-shrinks",
+		Fingerprint:        "fp-shrinks",
+		Title:              "Shrinking resource finding",
+		RuleID:             "graph-resource-multiple-open-findings",
+		Severity:           "high",
+		Status:             "open",
+		RuntimeID:          "runtime-graph",
+		PrimaryResourceURN: "urn:cerebro:writer:resource:a",
+		ResourceURNs: []string{
+			"urn:cerebro:writer:resource:a",
+			"urn:cerebro:writer:resource:b",
+		},
+	}
+	recordedEvent, err := workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
+		Finding:    finding,
+		RecordedAt: "2026-04-27T11:59:00Z",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingRecordedEvent() error = %v", err)
+	}
+	if _, err := service.Project(context.Background(), recordedEvent); err != nil {
+		t.Fatalf("Project(initial recorded) error = %v", err)
+	}
+	anchorURN := "urn:cerebro:writer:finding:finding-shrinks"
+	if _, ok := graph.links["urn:cerebro:writer:resource:b|has_finding|"+anchorURN]; !ok {
+		t.Fatal("initial secondary resource finding link missing")
+	}
+
+	graph.links["urn:cerebro:writer:resource:other|has_finding|urn:cerebro:writer:finding:other"] = &ports.ProjectedLink{
+		TenantID: "writer",
+		FromURN:  "urn:cerebro:writer:resource:other",
+		ToURN:    "urn:cerebro:writer:finding:other",
+		Relation: relationHasFinding,
+	}
+	finding.ResourceURNs = []string{"urn:cerebro:writer:resource:a"}
+	recordedEvent, err = workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
+		Finding:    finding,
+		RecordedAt: "2026-04-27T12:01:00Z",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingRecordedEvent(shrunk) error = %v", err)
+	}
+	result, err := service.Project(context.Background(), recordedEvent)
+	if err != nil {
+		t.Fatalf("Project(shrunk recorded) error = %v", err)
+	}
+	if result.LinksDeleted != 1 {
+		t.Fatalf("LinksDeleted = %d, want 1", result.LinksDeleted)
+	}
+	if _, ok := graph.links["urn:cerebro:writer:resource:a|has_finding|"+anchorURN]; !ok {
+		t.Fatal("current resource finding link was pruned")
+	}
+	if _, ok := graph.links["urn:cerebro:writer:resource:b|has_finding|"+anchorURN]; ok {
+		t.Fatal("stale secondary resource finding link was not pruned")
+	}
+	if _, ok := graph.links["urn:cerebro:writer:resource:other|has_finding|urn:cerebro:writer:finding:other"]; !ok {
+		t.Fatal("unrelated finding link was pruned")
 	}
 }
 


### PR DESCRIPTION
## Summary
- cap coordination graph related ResourceURNs at 20 finding anchors plus the primary resource
- cap the graph queries for concentrated source/resource finding rules before the row reaches Go
- add regression coverage for query shape and defensive EvaluateRows bounding

## Validation
- go test ./internal/findings -run 'TestCoordinationGraphRule' -count=1 -v
- make verify

## Rollout note
This fixes the sec-dev v2.1.69 deploy verifier failure: graph-resource-multiple-open-findings produced a finding anchor event that exceeded the NATS maximum payload.