### PR TITLE
fix(findings): bound workflow finding payloads

### DIFF
--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	findingDecisionStatusCompleted = "completed"
+	maxFindingSnapshotEventIDs     = 256
 )
 
 func (s *Service) projectFindingAnchor(ctx context.Context, finding *ports.FindingRecord) error {
@@ -269,6 +270,8 @@ func (s *Service) recordAndProjectWorkflowEvent(ctx context.Context, event *cere
 func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sourceID string) workflowevents.FindingSnapshot {
 	resourceURNs := uniqueSortedStrings(finding.ResourceURNs)
 	eventIDs := uniqueSortedStrings(finding.EventIDs)
+	eventCount := len(eventIDs)
+	eventIDs = boundedFindingSnapshotIDs(eventIDs, maxFindingSnapshotEventIDs)
 	var risk FindingRiskContext
 	if finding.RiskScore == 0 || finding.LikelihoodScore == 0 || finding.ImpactScore == 0 || finding.ConfidenceScore == 0 {
 		risk = AnalyzeFindingRiskContext(finding, time.Time{})
@@ -316,7 +319,7 @@ func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sour
 		FirstObservedAt:    findingSnapshotTimestamp(finding.FirstObservedAt),
 		LastObservedAt:     findingSnapshotTimestamp(finding.LastObservedAt),
 		ResourceCount:      len(resourceURNs),
-		EventCount:         len(eventIDs),
+		EventCount:         eventCount,
 		ControlRefs:        findingControlRefSnapshots(finding.ControlRefs),
 		FindingRiskSnapshot: workflowevents.FindingRiskSnapshot{
 			RiskScore:         riskScore,
@@ -331,6 +334,13 @@ func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sour
 		},
 		Metadata: findingRiskMetadata(finding),
 	}
+}
+
+func boundedFindingSnapshotIDs(ids []string, max int) []string {
+	if len(ids) <= max {
+		return ids
+	}
+	return append([]string(nil), ids[:max]...)
 }
 
 func findingSnapshotTimestamp(value time.Time) string {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -3838,6 +3838,61 @@ func TestFindingWorkflowSnapshotDoesNotMergeFreshReasonsWithStoredRisk(t *testin
 	}
 }
 
+func TestFindingWorkflowSnapshotBoundsEventIDsAndPreservesResourceURNs(t *testing.T) {
+	resourceURNs := make([]string, 0, maxFindingSnapshotEventIDs+10)
+	for i := 0; i < maxFindingSnapshotEventIDs+10; i++ {
+		resourceURNs = append(resourceURNs, "urn:cerebro:tenant-a:asset:"+strconv.Itoa(i))
+	}
+	primaryResourceURN := "urn:cerebro:tenant-a:asset:primary"
+	resourceURNs = append(resourceURNs, primaryResourceURN)
+	eventIDs := make([]string, 0, maxFindingSnapshotEventIDs+10)
+	for i := 0; i < maxFindingSnapshotEventIDs+10; i++ {
+		eventIDs = append(eventIDs, "event-"+strconv.Itoa(i))
+	}
+
+	snapshot := findingWorkflowSnapshot(&ports.FindingRecord{
+		ID:           "finding-1",
+		TenantID:     "tenant-a",
+		RuntimeID:    "runtime-audit",
+		RuleID:       "graph-rule",
+		Status:       "open",
+		Severity:     "HIGH",
+		ResourceURNs: resourceURNs,
+		EventIDs:     eventIDs,
+		Attributes: map[string]string{
+			"primary_resource_urn": primaryResourceURN,
+		},
+	}, "tenant-a", "runtime-audit")
+
+	if got := len(snapshot.ResourceURNs); got != len(resourceURNs) {
+		t.Fatalf("len(ResourceURNs) = %d, want all %d resources preserved for graph links", got, len(resourceURNs))
+	}
+	if got := len(snapshot.EventIDs); got != maxFindingSnapshotEventIDs {
+		t.Fatalf("len(EventIDs) = %d, want %d", got, maxFindingSnapshotEventIDs)
+	}
+	if snapshot.ResourceCount != len(resourceURNs) {
+		t.Fatalf("ResourceCount = %d, want full count %d", snapshot.ResourceCount, len(resourceURNs))
+	}
+	if snapshot.EventCount != len(eventIDs) {
+		t.Fatalf("EventCount = %d, want full count %d", snapshot.EventCount, len(eventIDs))
+	}
+	for _, resourceURN := range resourceURNs {
+		if !slices.Contains(snapshot.ResourceURNs, resourceURN) {
+			t.Fatalf("snapshot ResourceURNs missing %q", resourceURN)
+		}
+	}
+	event, err := workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
+		Finding:    snapshot,
+		RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		t.Fatalf("NewFindingRecordedEvent() error = %v", err)
+	}
+	if got := len(event.GetPayload()); got > 128<<10 {
+		t.Fatalf("finding recorded payload = %d bytes, want below 128KiB", got)
+	}
+}
+
 func TestUpsertFindingWithRiskRecomputesAfterWorkflowPreservation(t *testing.T) {
 	dueAt := time.Now().UTC().Add(-time.Hour)
 	store := &stubFindingStore{


### PR DESCRIPTION
## Summary
- cap resource/event ID lists embedded in workflow finding snapshots while preserving full counts
- keep the primary resource in bounded snapshots for graph anchors
- add regression coverage for oversized finding-recorded payloads

## Validation
- go test ./internal/findings -run 'TestFindingWorkflowSnapshotBoundsEvidenceLists|TestFindingWorkflowSnapshotDoesNotMergeFreshReasonsWithStoredRisk' -count=1
- go test ./internal/findings ./internal/workflowevents ./internal/workflowprojection ./internal/appendlog/jetstream -count=1
- make verify