### PR TITLE
fix(findings): stabilize coordination graph rule output

### DIFF
--- a/internal/findings/coordination_graph_rule.go
+++ b/internal/findings/coordination_graph_rule.go
@@ -79,6 +79,8 @@ func newGRCSourceConcentratedOpenFindingsRule() Rule {
 	}, map[string][]string{"grc": {"integration", "vulnerability", "vulnerable_asset"}}, `MATCH (source:Entity {tenant_id: $tenant_id, entity_type: 'source'})
 MATCH (source)-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE coalesce(finding.attributes_json, '') CONTAINS '"status":"open"'
+WITH source, finding
+ORDER BY finding.urn
 WITH source, collect(DISTINCT finding) AS findings, count(DISTINCT finding) AS finding_count
 WHERE finding_count >= $finding_threshold
 RETURN source.urn AS primary_urn,
@@ -311,6 +313,8 @@ func newResourceMultipleOpenFindingsRule() Rule {
 		},
 	}, nil, `MATCH (resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE coalesce(finding.attributes_json, '') CONTAINS '"status":"open"'
+WITH resource, finding
+ORDER BY finding.urn
 WITH resource, collect(DISTINCT finding) AS findings, count(DISTINCT finding) AS finding_count
 WHERE finding_count >= $finding_threshold
 RETURN resource.urn AS primary_urn,

--- a/internal/findings/coordination_graph_rule_test.go
+++ b/internal/findings/coordination_graph_rule_test.go
@@ -38,6 +38,32 @@ func TestCoordinationGraphRuleQueryRequiresTenant(t *testing.T) {
 	if !strings.Contains(query.Query, "findings[0..20] | f.urn") {
 		t.Fatalf("query does not cap related finding ResourceURNs: %s", query.Query)
 	}
+	if !strings.Contains(query.Query, "ORDER BY finding.urn") {
+		t.Fatalf("query does not deterministically order findings before capping: %s", query.Query)
+	}
+}
+
+func TestCoordinationGraphRuleQueryOrdersFindingsBeforeSlice(t *testing.T) {
+	for _, ruleID := range []string{
+		"grc-source-integration-concentrated-open-findings",
+		"graph-resource-multiple-open-findings",
+	} {
+		registry := Builtin()
+		rule, ok := registry.Get(ruleID)
+		if !ok {
+			t.Fatalf("Builtin() missing rule %s", ruleID)
+		}
+		graphRule, ok := rule.(GraphRule)
+		if !ok {
+			t.Fatalf("rule %s is not a GraphRule", ruleID)
+		}
+		query := graphRule.QueryFor(&cerebrov1.SourceRuntime{TenantId: "writer"}).Query
+		collectIdx := strings.Index(query, "collect(DISTINCT finding)")
+		orderIdx := strings.Index(query, "ORDER BY finding.urn")
+		if collectIdx < 0 || orderIdx < 0 || orderIdx > collectIdx {
+			t.Fatalf("rule %s must ORDER BY finding.urn before collecting findings: %s", ruleID, query)
+		}
+	}
 }
 
 func TestCoordinationGraphRuleEvaluateRowsBuildsFinding(t *testing.T) {

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -456,40 +456,52 @@ func (s *Service) pruneFindingActiveLinks(ctx context.Context, tenantID string, 
 			current[resourceURN] = struct{}{}
 		}
 	}
-	rows, err := reader.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
-		Query: `MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(:Entity {tenant_id: $tenant_id, urn: $finding_urn})
+	lastSeen := ""
+	for {
+		rows, err := reader.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
+			Query: `MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(:Entity {tenant_id: $tenant_id, urn: $finding_urn})
+WHERE resource.urn > $last_seen
 RETURN resource.urn AS resource_urn
+ORDER BY resource.urn
 LIMIT $row_limit`,
-		Params: map[string]any{
-			"tenant_id":   tenantID,
-			"finding_urn": anchorURN,
-			"row_limit":   int64(ports.MaxCypherQueryRows),
-		},
-		RowLimit: ports.MaxCypherQueryRows,
-	})
-	if err != nil {
-		return err
-	}
-	for _, row := range rows {
-		resourceURN := strings.TrimSpace(fmt.Sprintf("%v", row.Values["resource_urn"]))
-		if resourceURN == "" || resourceURN == "<nil>" {
-			continue
-		}
-		if _, keep := current[resourceURN]; keep {
-			continue
-		}
-		if err := deleter.DeleteProjectedLink(ctx, &ports.ProjectedLink{
-			TenantID: tenantID,
-			SourceID: sourceID,
-			FromURN:  resourceURN,
-			ToURN:    anchorURN,
-			Relation: relationHasFinding,
-		}); err != nil {
+			Params: map[string]any{
+				"tenant_id":   tenantID,
+				"finding_urn": anchorURN,
+				"last_seen":   lastSeen,
+				"row_limit":   int64(ports.MaxCypherQueryRows),
+			},
+			RowLimit: ports.MaxCypherQueryRows,
+		})
+		if err != nil {
 			return err
 		}
-		result.LinksDeleted++
+		if len(rows) == 0 {
+			return nil
+		}
+		for _, row := range rows {
+			resourceURN := strings.TrimSpace(fmt.Sprintf("%v", row.Values["resource_urn"]))
+			if resourceURN == "" || resourceURN == "<nil>" {
+				continue
+			}
+			lastSeen = resourceURN
+			if _, keep := current[resourceURN]; keep {
+				continue
+			}
+			if err := deleter.DeleteProjectedLink(ctx, &ports.ProjectedLink{
+				TenantID: tenantID,
+				SourceID: sourceID,
+				FromURN:  resourceURN,
+				ToURN:    anchorURN,
+				Relation: relationHasFinding,
+			}); err != nil {
+				return err
+			}
+			result.LinksDeleted++
+		}
+		if len(rows) < ports.MaxCypherQueryRows {
+			return nil
+		}
 	}
-	return nil
 }
 
 func (s *Service) deleteFindingActiveLinks(ctx context.Context, finding workflowevents.FindingSnapshot) (uint32, error) {

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -2,6 +2,8 @@ package workflowprojection
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -52,7 +54,12 @@ func (r *projectionRecorder) DeleteProjectedLink(_ context.Context, link *ports.
 func (r *projectionRecorder) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
 	findingURN, _ := request.Params["finding_urn"].(string)
 	tenantID, _ := request.Params["tenant_id"].(string)
-	rows := []ports.CypherRow{}
+	lastSeen, _ := request.Params["last_seen"].(string)
+	limit := request.RowLimit
+	if limit <= 0 {
+		limit = ports.MaxCypherQueryRows
+	}
+	matching := make([]string, 0, len(r.links))
 	for _, link := range r.links {
 		if link == nil || link.ToURN != findingURN || link.Relation != relationHasFinding {
 			continue
@@ -60,7 +67,18 @@ func (r *projectionRecorder) ExecuteReadCypher(_ context.Context, request ports.
 		if tenantID != "" && link.TenantID != tenantID {
 			continue
 		}
-		rows = append(rows, ports.CypherRow{Values: map[string]any{"resource_urn": link.FromURN}})
+		if link.FromURN <= lastSeen {
+			continue
+		}
+		matching = append(matching, link.FromURN)
+	}
+	sort.Strings(matching)
+	if len(matching) > limit {
+		matching = matching[:limit]
+	}
+	rows := make([]ports.CypherRow, 0, len(matching))
+	for _, urn := range matching {
+		rows = append(rows, ports.CypherRow{Values: map[string]any{"resource_urn": urn}})
 	}
 	return rows, nil
 }
@@ -455,6 +473,58 @@ func TestProjectFindingRecordedPrunesStaleActiveLinks(t *testing.T) {
 	}
 	if _, ok := graph.links["urn:cerebro:writer:resource:other|has_finding|urn:cerebro:writer:finding:other"]; !ok {
 		t.Fatal("unrelated finding link was pruned")
+	}
+}
+
+func TestProjectFindingRecordedPrunesBeyondCypherRowLimit(t *testing.T) {
+	graph := &projectionRecorder{links: map[string]*ports.ProjectedLink{}}
+	service := New(graph)
+	anchorURN := "urn:cerebro:writer:finding:legacy-overflow"
+	staleCount := ports.MaxCypherQueryRows + 25
+	for i := 0; i < staleCount; i++ {
+		resourceURN := fmt.Sprintf("urn:cerebro:writer:resource:legacy-%06d", i)
+		graph.links[resourceURN+"|has_finding|"+anchorURN] = &ports.ProjectedLink{
+			TenantID: "writer",
+			FromURN:  resourceURN,
+			ToURN:    anchorURN,
+			Relation: relationHasFinding,
+		}
+	}
+
+	finding := workflowevents.FindingSnapshot{
+		TenantID:           "writer",
+		SourceSystem:       "findings",
+		FindingID:          "legacy-overflow",
+		Fingerprint:        "fp-legacy-overflow",
+		Title:              "Legacy overflow finding",
+		RuleID:             "graph-resource-multiple-open-findings",
+		Severity:           "high",
+		Status:             "open",
+		RuntimeID:          "runtime-graph",
+		PrimaryResourceURN: "urn:cerebro:writer:resource:keep",
+		ResourceURNs:       []string{"urn:cerebro:writer:resource:keep"},
+	}
+	recordedEvent, err := workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
+		Finding:    finding,
+		RecordedAt: "2026-05-27T07:30:00Z",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingRecordedEvent() error = %v", err)
+	}
+	result, err := service.Project(context.Background(), recordedEvent)
+	if err != nil {
+		t.Fatalf("Project(legacy overflow) error = %v", err)
+	}
+	if int(result.LinksDeleted) != staleCount {
+		t.Fatalf("LinksDeleted = %d, want %d", result.LinksDeleted, staleCount)
+	}
+	for key, link := range graph.links {
+		if link == nil || link.ToURN != anchorURN {
+			continue
+		}
+		if link.FromURN != "urn:cerebro:writer:resource:keep" {
+			t.Fatalf("stale legacy link %s survived pruning", key)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up to #658 addressing two remaining factory-droid P1 review comments.

## What

1. **Deterministic top-20 selection** – `grc-source-integration-concentrated-open-findings` and `graph-resource-multiple-open-findings` now `ORDER BY finding.urn` before `collect(DISTINCT finding)`, so `findings[0..20]` returns the same subset across no-op reevaluations and no longer churns coordination `ResourceURNs` or graph `has_finding` edges.
2. **Batched stale-link pruning** – `pruneFindingActiveLinks` now paginates with a `resource.urn > $last_seen` cursor and `ORDER BY resource.urn`, so a legacy oversized coordination finding (with more than `ports.MaxCypherQueryRows` stale anchors) can fully shrink instead of leaking the 3001st+ `has_finding` edges into the graph.

## Tests

* New `TestCoordinationGraphRuleQueryOrdersFindingsBeforeSlice` covers the ordering invariant for both capped rules.
* New `TestProjectFindingRecordedPrunesBeyondCypherRowLimit` exercises the pagination by seeding `MaxCypherQueryRows + 25` stale links and asserting all are pruned.
* `make verify` passes locally (build, full test suite, golangci-lint, buf lint, OpenAPI route parity, Spectral lint, catalog/detection checks, oss-audit, repo-specific linters, archtests).

## Why now

PR #658 capped coordination `ResourceURNs` and added a single-page prune; the two issues above remained and would otherwise (a) cause spurious graph churn on every coordination reevaluation and (b) leave legacy oversized findings partially stale on the graph.