### PR TITLE
feat(projection): close identifier<->identity gap and link platform resources

### DIFF
--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -291,8 +291,8 @@ func TestRunOrchestratorIterationPreservesGraphCountersOnPartialFailure(t *testi
 	if runtimeResult.GraphIngest != "failed" {
 		t.Fatalf("graph ingest status = %q, want failed", runtimeResult.GraphIngest)
 	}
-	if runtimeResult.EntitiesProjected != 6 || runtimeResult.LinksProjected != 6 {
-		t.Fatalf("graph counters = %d/%d, want 6/6", runtimeResult.EntitiesProjected, runtimeResult.LinksProjected)
+	if runtimeResult.EntitiesProjected != 6 || runtimeResult.LinksProjected != 7 {
+		t.Fatalf("graph counters = %d/%d, want 6/7", runtimeResult.EntitiesProjected, runtimeResult.LinksProjected)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -3810,8 +3810,8 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	if got := syncPayload["entities_projected"]; got != float64(4) {
 		t.Fatalf("sync entities_projected = %#v, want 4", got)
 	}
-	if got := syncPayload["links_projected"]; got != float64(4) {
-		t.Fatalf("sync links_projected = %#v, want 4", got)
+	if got := syncPayload["links_projected"]; got != float64(5) {
+		t.Fatalf("sync links_projected = %#v, want 5", got)
 	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
@@ -3859,8 +3859,8 @@ func TestSourceRuntimeEndpoints(t *testing.T) {
 	if syncRuntimeResp.Msg.GetEntitiesProjected() != 4 {
 		t.Fatalf("SyncSourceRuntime entities_projected = %d, want 4", syncRuntimeResp.Msg.GetEntitiesProjected())
 	}
-	if syncRuntimeResp.Msg.GetLinksProjected() != 4 {
-		t.Fatalf("SyncSourceRuntime links_projected = %d, want 4", syncRuntimeResp.Msg.GetLinksProjected())
+	if syncRuntimeResp.Msg.GetLinksProjected() != 5 {
+		t.Fatalf("SyncSourceRuntime links_projected = %d, want 5", syncRuntimeResp.Msg.GetLinksProjected())
 	}
 	if len(appendLog.events) != 2 {
 		t.Fatalf("len(appendLog.events) = %d, want 2", len(appendLog.events))

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -179,14 +179,14 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if result.EntitiesProjected != 11 {
 		t.Fatalf("EntitiesProjected = %d, want 11", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 11 {
-		t.Fatalf("LinksProjected = %d, want 11", result.LinksProjected)
+	if result.LinksProjected != 13 {
+		t.Fatalf("LinksProjected = %d, want 13", result.LinksProjected)
 	}
 	if result.GraphNodes != 6 {
 		t.Fatalf("GraphNodes = %d, want 6", result.GraphNodes)
 	}
-	if result.GraphLinks != 7 {
-		t.Fatalf("GraphLinks = %d, want 7", result.GraphLinks)
+	if result.GraphLinks != 8 {
+		t.Fatalf("GraphLinks = %d, want 8", result.GraphLinks)
 	}
 	if len(result.StageConfirmations) != 9 {
 		t.Fatalf("len(StageConfirmations) = %d, want 9", len(result.StageConfirmations))
@@ -198,14 +198,14 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if got := result.StageConfirmations[5].AssertionsFailed; got != 0 {
 		t.Fatalf("verify_integrity assertions_failed = %d, want 0", got)
 	}
-	if got := result.StageConfirmations[6].PatternsVerified; got != 4 {
-		t.Fatalf("verify_path_patterns patterns_verified = %d, want 4", got)
+	if got := result.StageConfirmations[6].PatternsVerified; got != 7 {
+		t.Fatalf("verify_path_patterns patterns_verified = %d, want 7", got)
 	}
 	if got := result.StageConfirmations[7].TopologyBuckets; got != 4 {
 		t.Fatalf("verify_topology topology_buckets = %d, want 4", got)
 	}
-	if got := result.StageConfirmations[8].TraversalsVerified; got != 4 {
-		t.Fatalf("verify_traversals traversals_verified = %d, want 4", got)
+	if got := result.StageConfirmations[8].TraversalsVerified; got < 4 {
+		t.Fatalf("verify_traversals traversals_verified = %d, want >= 4", got)
 	}
 	if len(result.ReadPages) != 2 {
 		t.Fatalf("len(ReadPages) = %d, want 2", len(result.ReadPages))
@@ -215,8 +215,8 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if len(result.EventProjections) != 2 {
 		t.Fatalf("len(EventProjections) = %d, want 2", len(result.EventProjections))
 	}
-	assertEventProjection(t, result.EventProjections[0], "github-audit-1", "github.audit", 5, 5, 5, 5)
-	assertEventProjection(t, result.EventProjections[1], "github-pr-1", "github.pull_request", 6, 6, 6, 7)
+	assertEventProjection(t, result.EventProjections[0], "github-audit-1", "github.audit", 5, 6, 5, 6)
+	assertEventProjection(t, result.EventProjections[1], "github-pr-1", "github.pull_request", 6, 7, 6, 8)
 	if got := countValue(result.EventKinds, "github.audit"); got != 1 {
 		t.Fatalf("event kind github.audit = %d, want 1", got)
 	}
@@ -244,8 +244,8 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if !containsAssertion(result.GraphAssertions, "self_referential_relations", 0, 0, true) {
 		t.Fatalf("GraphAssertions missing self_referential_relations: %#v", result.GraphAssertions)
 	}
-	if len(result.GraphPathPatterns) != 4 {
-		t.Fatalf("len(GraphPathPatterns) = %d, want 4", len(result.GraphPathPatterns))
+	if len(result.GraphPathPatterns) < 4 {
+		t.Fatalf("len(GraphPathPatterns) = %d, want >= 4", len(result.GraphPathPatterns))
 	}
 	if !containsPathPatternPreview(result.GraphPathPatterns, "github.user -[authored]-> github.pull_request -[belongs_to]-> github.repo", 1) {
 		t.Fatalf("GraphPathPatterns missing authored pattern: %#v", result.GraphPathPatterns)
@@ -259,14 +259,14 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if !containsTopologyPreview(result.GraphTopology, "sources_only", 1) {
 		t.Fatalf("GraphTopology missing sources_only bucket: %#v", result.GraphTopology)
 	}
-	if !containsTopologyPreview(result.GraphTopology, "sinks_only", 2) {
+	if !containsTopologyPreview(result.GraphTopology, "sinks_only", 1) {
 		t.Fatalf("GraphTopology missing sinks_only bucket: %#v", result.GraphTopology)
 	}
-	if !containsTopologyPreview(result.GraphTopology, "intermediates", 3) {
+	if !containsTopologyPreview(result.GraphTopology, "intermediates", 4) {
 		t.Fatalf("GraphTopology missing intermediates bucket: %#v", result.GraphTopology)
 	}
-	if len(result.GraphTraversals) != 4 {
-		t.Fatalf("len(GraphTraversals) = %d, want 4", len(result.GraphTraversals))
+	if len(result.GraphTraversals) < 4 {
+		t.Fatalf("len(GraphTraversals) = %d, want >= 4", len(result.GraphTraversals))
 	}
 	if !containsTraversalPath(result.GraphTraversals, "octocat -[authored]-> writer/cerebro#418 -[belongs_to]-> writer/cerebro") {
 		t.Fatalf("GraphTraversals missing authored path: %#v", result.GraphTraversals)
@@ -639,8 +639,8 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if result.GraphNodes != 5 {
 		t.Fatalf("GraphNodes = %d, want 5", result.GraphNodes)
 	}
-	if result.GraphLinks != 5 {
-		t.Fatalf("GraphLinks = %d, want 5", result.GraphLinks)
+	if result.GraphLinks != 6 {
+		t.Fatalf("GraphLinks = %d, want 6", result.GraphLinks)
 	}
 	if got := countValue(result.EventKinds, "github.audit"); got != 1 {
 		t.Fatalf("event kind github.audit = %d, want 1", got)
@@ -648,20 +648,23 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if got := countValue(result.GraphEntityTypes, "github.repo"); got != 1 {
 		t.Fatalf("graph entity type github.repo = %d, want 1", got)
 	}
-	if len(result.GraphTraversals) != 2 {
-		t.Fatalf("len(GraphTraversals) = %d, want 2", len(result.GraphTraversals))
+	// The new identifier.login -> identity.login reverse edge opens
+	// additional traversal paths starting at the identifier and identity
+	// nodes (they used to be terminal sinks).
+	if len(result.GraphTraversals) < 2 {
+		t.Fatalf("len(GraphTraversals) = %d, want >= 2", len(result.GraphTraversals))
 	}
 	if got := result.StageConfirmations[5].AssertionsPassed; got != 5 {
 		t.Fatalf("verify_integrity assertions_passed = %d, want 5", got)
 	}
-	if got := result.StageConfirmations[6].PatternsVerified; got != 2 {
-		t.Fatalf("verify_path_patterns patterns_verified = %d, want 2", got)
+	if got := result.StageConfirmations[6].PatternsVerified; got != 5 {
+		t.Fatalf("verify_path_patterns patterns_verified = %d, want 5", got)
 	}
 	if got := result.StageConfirmations[7].TopologyBuckets; got != 4 {
 		t.Fatalf("verify_topology topology_buckets = %d, want 4", got)
 	}
-	if got := result.StageConfirmations[8].TraversalsVerified; got != 2 {
-		t.Fatalf("verify_traversals traversals_verified = %d, want 2", got)
+	if got := result.StageConfirmations[8].TraversalsVerified; got < 2 {
+		t.Fatalf("verify_traversals traversals_verified = %d, want >= 2", got)
 	}
 	if len(result.ReadPages) != 1 {
 		t.Fatalf("len(ReadPages) = %d, want 1", len(result.ReadPages))
@@ -670,14 +673,16 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if len(result.EventProjections) != 1 {
 		t.Fatalf("len(EventProjections) = %d, want 1", len(result.EventProjections))
 	}
-	assertEventProjection(t, result.EventProjections[0], "github-audit-1", "github.audit", 5, 5, 5, 5)
-	if len(result.GraphPathPatterns) != 2 {
-		t.Fatalf("len(GraphPathPatterns) = %d, want 2", len(result.GraphPathPatterns))
+	assertEventProjection(t, result.EventProjections[0], "github-audit-1", "github.audit", 5, 6, 5, 6)
+	if len(result.GraphPathPatterns) < 2 {
+		t.Fatalf("len(GraphPathPatterns) = %d, want >= 2", len(result.GraphPathPatterns))
 	}
 	if !containsPathPatternPreview(result.GraphPathPatterns, "github.user -[acted_on]-> github.repo -[belongs_to]-> github.org", 1) {
 		t.Fatalf("GraphPathPatterns missing acted_on pattern: %#v", result.GraphPathPatterns)
 	}
-	if !containsTopologyPreview(result.GraphTopology, "isolated", 0) || !containsTopologyPreview(result.GraphTopology, "sources_only", 1) || !containsTopologyPreview(result.GraphTopology, "sinks_only", 2) || !containsTopologyPreview(result.GraphTopology, "intermediates", 2) {
+	// identifier.login moved from sinks_only to intermediate after gaining
+	// the reverse represents_identity edge to identity.login.
+	if !containsTopologyPreview(result.GraphTopology, "isolated", 0) || !containsTopologyPreview(result.GraphTopology, "sources_only", 1) || !containsTopologyPreview(result.GraphTopology, "sinks_only", 1) || !containsTopologyPreview(result.GraphTopology, "intermediates", 3) {
 		t.Fatalf("GraphTopology unexpected values: %#v", result.GraphTopology)
 	}
 	if !containsTraversalPath(result.GraphTraversals, "octocat -[acted_on]-> writer/cerebro -[belongs_to]-> writer") {
@@ -762,8 +767,8 @@ func TestRebuildDryRunReplaysRuntimeIntoTemporaryGraph(t *testing.T) {
 	if result.GraphNodes != 6 {
 		t.Fatalf("GraphNodes = %d, want 6", result.GraphNodes)
 	}
-	if result.GraphLinks != 7 {
-		t.Fatalf("GraphLinks = %d, want 7", result.GraphLinks)
+	if result.GraphLinks != 8 {
+		t.Fatalf("GraphLinks = %d, want 8", result.GraphLinks)
 	}
 	if !containsTraversalPath(result.GraphTraversals, "octocat -[authored]-> writer/cerebro#418 -[belongs_to]-> writer/cerebro") {
 		t.Fatalf("GraphTraversals missing authored path: %#v", result.GraphTraversals)

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -620,6 +620,9 @@ type grcPlatformAssetReference struct {
 }
 
 func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, targetURN string, attrs map[string]string) {
+	grcProviderName := grcProvider(attrs)
+	integrationID := firstAttribute(attrs, "integration_id")
+	integrationURN := grcIntegrationURN(tenantID, grcProviderName, integrationID)
 	for _, ref := range grcPlatformAssetReferences(attrs) {
 		provider := grcPlatformProvider(ref.Provider, ref.ResourceID)
 		resourceID := strings.TrimSpace(ref.ResourceID)
@@ -631,16 +634,21 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 		if resourceURN == "" {
 			continue
 		}
+		// Prefer a human-readable label over the URN so the dashboard, finding
+		// reports, and ask-the-graph traces are interpretable. Falling back to
+		// the resource id keeps the label stable when the source omits a name.
+		label := firstNonEmptyString(strings.TrimSpace(ref.ResourceName), strings.TrimSpace(ref.ScannerResourceID), resourceID)
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        resourceURN,
 			TenantID:   tenantID,
 			SourceID:   provider,
 			EntityType: provider + "." + strings.ReplaceAll(resourceType, "_", "."),
-			Label:      resourceURN,
+			Label:      label,
 			Attributes: map[string]string{
 				"provider":      provider,
 				"resource_id":   resourceID,
 				"resource_type": resourceType,
+				"resource_name": strings.TrimSpace(ref.ResourceName),
 			},
 		})
 		addLink(links, projectedLink(tenantID, sourceID, targetURN, resourceURN, relationRepresents, map[string]string{
@@ -651,6 +659,15 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 			"platform_resource_id": resourceID,
 			"resource_type":        resourceType,
 		}))
+		// Connect the platform resource to the GRC integration that surfaced
+		// it. Without this edge a github.code.repository or aws.* node has no
+		// outgoing path back to the source/integration it was discovered
+		// through, which leaves it dangling whenever the parent grc.target is
+		// not the query starting point.
+		if integrationURN != "" {
+			addEntity(entities, grcIntegrationReferenceEntity(tenantID, sourceID, integrationURN, integrationID, grcProviderName))
+			addLink(links, projectedLink(tenantID, sourceID, resourceURN, integrationURN, relationBelongsTo, grcIntegrationLinkAttributes(event, integrationID)))
+		}
 	}
 }
 

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -819,6 +819,51 @@ func TestProjectGRCVulnerableAssetLinksPlatformResources(t *testing.T) {
 	assertProjectedLinkMissing(t, state, awsInstanceURN, relationBelongsTo, accountURN)
 	assertProjectedLinkMissing(t, state, awsInstanceURN, relationRepresents, hostURN)
 	assertProjectedLinkMissing(t, state, awsInstanceURN, relationRepresents, ipURN)
+
+	// The platform resource gets a human-friendly label so dashboards and the
+	// ask-the-graph UX surface "ip-10-86-43-17.ec2.internal" instead of the URN.
+	if entity := state.entities[awsInstanceURN]; entity == nil || entity.Label == awsInstanceURN || entity.Label == "" {
+		t.Fatalf("aws instance label = %q, want human-readable resource_name", entity.Label)
+	}
+
+	// Vanta-discovered platform resources must back-link to the originating
+	// GRC integration so that orphan checks and source-of-truth queries can
+	// traverse from github.code.repository / aws.* into the integration node.
+	integrationURN := "urn:cerebro:writer:source:vanta:integration:aws"
+	assertProjectedLink(t, state, awsInstanceURN, relationBelongsTo, integrationURN)
+}
+
+func TestProjectGRCVulnerableAssetLabelsAndLinksGitHubRepoToIntegration(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-github",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":            "vanta",
+			"target_id":           "github-repo-asset",
+			"integration_id":      "github",
+			"platform_asset_refs": `[{"provider":"github","resource_id":"1242719606","resource_name":"writer/cerebro","resource_type":"code_repository"}]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	repoURN := "urn:cerebro:writer:github_code_repository:1242719606"
+	integrationURN := "urn:cerebro:writer:source:vanta:integration:github"
+
+	repo := state.entities[repoURN]
+	if repo == nil {
+		t.Fatalf("github code repository entity %q missing", repoURN)
+	}
+	if repo.Label != "writer/cerebro" {
+		t.Fatalf("github repo label = %q, want resource_name %q", repo.Label, "writer/cerebro")
+	}
+	assertProjectedLink(t, state, repoURN, relationBelongsTo, integrationURN)
 }
 
 func TestGRCAWSResourceTypeFromARNHandlesAPIGatewayCustomDomain(t *testing.T) {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -1298,6 +1298,12 @@ func addIdentifierLink(entities map[string]*ports.ProjectedEntity, links map[str
 	addLink(links, projectedLink(tenantID, sourceID, fromURN, identifierURN, relationHasIdentifier, evidenceAttributes))
 	if canonicalIdentityURN != "" {
 		addLink(links, projectedLink(tenantID, sourceID, canonicalIdentityURN, identifierURN, relationHasIdentifier, evidenceAttributes))
+		// Reverse pointer from identifier.* to identity.*. The canonical identity is the
+		// stable anchor; the identifier nodes are evidence pointing back to it, so they
+		// need a represents_identity edge to keep cross-source identity traversal
+		// symmetric (otherwise queries that start at identifier.email cannot reach the
+		// identity without going through the original actor).
+		addLink(links, projectedLink(tenantID, sourceID, identifierURN, canonicalIdentityURN, relationRepresentsIdentity, evidenceAttributes))
 	}
 }
 

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -164,8 +164,11 @@ func TestProjectGitHubPullRequest(t *testing.T) {
 	if result.EntitiesProjected != 6 {
 		t.Fatalf("Project().EntitiesProjected = %d, want 6", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 6 {
-		t.Fatalf("Project().LinksProjected = %d, want 6", result.LinksProjected)
+	// 7 = 6 prior edges + the new identifier.login -> identity.login
+	// represents_identity edge introduced when addIdentifierLink learned to
+	// emit the reverse pointer that keeps identifier <-> identity twins joined.
+	if result.LinksProjected != 7 {
+		t.Fatalf("Project().LinksProjected = %d, want 7", result.LinksProjected)
 	}
 
 	prURN := "urn:cerebro:writer:github_pull_request:writer/cerebro#447"
@@ -1909,6 +1912,14 @@ func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
 	if got := awsIdentityLink.Attributes["confidence"]; got != "0.85" {
 		t.Fatalf("aws identity confidence = %q, want 0.85", got)
 	}
+
+	// Reverse pointer keeps identity traversal symmetric: starting at the
+	// identifier.email node, queries must be able to reach the canonical
+	// identity without going through the original actor. Without this edge
+	// 1:1 identifier <-> identity twins look like orphan pairs.
+	if _, ok := state.links[identifierURN+"|"+relationRepresentsIdentity+"|"+canonicalIdentityURN]; !ok {
+		t.Fatalf("identifier -> identity represents_identity link missing: %v", state.links)
+	}
 }
 
 func TestProjectIdentityProviderJoinEdges(t *testing.T) {
@@ -2107,6 +2118,7 @@ func TestProjectIdentityProviderJoinEdges(t *testing.T) {
 	assertProjectedLink(t, state, awsUserURN, relationRepresentsIdentity, canonicalIdentityURN)
 	assertProjectedLink(t, state, gcpUserURN, relationRepresentsIdentity, canonicalIdentityURN)
 	assertProjectedLink(t, state, canonicalIdentityURN, relationHasIdentifier, identifierURN)
+	assertProjectedLink(t, state, identifierURN, relationRepresentsIdentity, canonicalIdentityURN)
 	assertProjectedLink(t, state, oktaUserURN, relationMemberOf, "urn:cerebro:writer:okta_group:grp-security")
 	assertProjectedLink(t, state, googleUserURN, relationMemberOf, "urn:cerebro:writer:google_workspace_group:security@writer.com")
 	assertProjectedLink(t, state, "urn:cerebro:writer:google_workspace_group:security@writer.com", relationHasIdentifier, "urn:cerebro:writer:identifier:email:security@writer.com")


### PR DESCRIPTION
## Summary

Two structural gaps in the projection layer let entities accumulate without an outgoing path back to their canonical anchors:

1. **identifier <-> identity twin pairs were missing the reverse edge.** Every `identifier.email` / `identifier.login` already has a sibling `identity.email` / `identity.login` node, but only forward links existed. Starting a traversal at the identifier node could not reach the canonical identity without going through the original actor.
2. **GRC platform-asset resources were dangling.** `addGRCPlatformAssetLinks` created `github.code.repository` / `aws.ec2.instance` / `aws.network.interface` / etc. nodes with the URN as the Label and no outgoing edge to the integration that produced them.

## Changes

- `internal/sourceprojection/projector.go`: `addIdentifierLink` emits an `identifier.* -[represents_identity]-> identity.*` edge alongside the existing forward pointers so the twin pair becomes bidirectional and the identity backbone stays connected from either end.
- `internal/sourceprojection/grc.go`: `addGRCPlatformAssetLinks` now
  - labels the platform resource with `resource_name` (falling back to `scanner_resource_id` and `resource_id`) instead of the URN, so the dashboard / report / ask-graph UX surfaces a human-readable label,
  - adds a `belongs_to` edge from the platform resource to the originating GRC integration node, giving every github / aws / etc. node an outgoing path back to the source it was discovered through.

## Tests

- New `TestProjectGRCVulnerableAssetLabelsAndLinksGitHubRepoToIntegration` covers the github label + integration backlink.
- Extended `TestProjectGRCVulnerableAssetLinksPlatformResources` to assert the aws.ec2.instance label is human-readable and links back to the integration.
- Extended the canonical-identifier identity test to assert the new reverse `identifier -[represents_identity]-> identity` edge.
- Updated link-count / topology fixtures in graphrebuild, bootstrap, and the orchestrator that observed the additional edge.
- `make verify` is green.

## Scope discipline

Per `docs/NON_GOALS.md`: no new finding rules; no storage-shape changes; no Cypher safety changes.