### PR TITLE
test(graph): add linkage integrity guardrails

### DIFF
--- a/internal/graphrebuild/memory_graph.go
+++ b/internal/graphrebuild/memory_graph.go
@@ -23,6 +23,7 @@ type memoryEntity struct {
 	SourceID   string
 	EntityType string
 	Label      string
+	Attributes map[string]string
 }
 
 type memoryLink struct {
@@ -81,12 +82,17 @@ func (s *memoryGraphStore) UpsertProjectedEntity(_ context.Context, entity *port
 	if existing, ok := s.entities[urn]; ok && fallbackLabel {
 		label = existing.Label
 	}
+	attributes := cloneMemoryAttributes(entity.Attributes)
+	if existing, ok := s.entities[urn]; ok {
+		attributes = mergeMemoryAttributes(existing.Attributes, attributes)
+	}
 	s.entities[urn] = memoryEntity{
 		URN:        urn,
 		TenantID:   tenantID,
 		SourceID:   sourceID,
 		EntityType: entityType,
 		Label:      label,
+		Attributes: attributes,
 	}
 	return nil
 }
@@ -142,6 +148,8 @@ func (s *memoryGraphStore) IntegrityChecks(context.Context) ([]graphstore.Integr
 		{Name: "blank_entity_types", Expected: 0},
 		{Name: "blank_relation_types", Expected: 0},
 		{Name: "self_referential_relations", Expected: 0},
+		{Name: "github_code_repositories_without_owner_link", Expected: 0},
+		{Name: "aws_public_endpoints_without_instance_link", Expected: 0},
 	}
 	for _, entity := range s.entities {
 		if entity.Label == "" {
@@ -149,6 +157,12 @@ func (s *memoryGraphStore) IntegrityChecks(context.Context) ([]graphstore.Integr
 		}
 		if entity.EntityType == "" {
 			checks[2].Actual++
+		}
+		if memoryEntityRequiresRepositoryOwnerLink(entity) && !s.memoryEntityHasOutgoingLinkTo(entity.URN, "belongs_to", "github.org") {
+			checks[5].Actual++
+		}
+		if memoryEntityRequiresInstanceLink(entity) && !s.memoryEntityHasInstanceLink(entity.URN) {
+			checks[6].Actual++
 		}
 	}
 	for _, link := range s.links {
@@ -168,6 +182,60 @@ func (s *memoryGraphStore) IntegrityChecks(context.Context) ([]graphstore.Integr
 		checks[index].Passed = checks[index].Actual == checks[index].Expected
 	}
 	return checks, nil
+}
+
+func cloneMemoryAttributes(attributes map[string]string) map[string]string {
+	if len(attributes) == 0 {
+		return nil
+	}
+	clone := make(map[string]string, len(attributes))
+	for key, value := range attributes {
+		clone[key] = value
+	}
+	return clone
+}
+
+func mergeMemoryAttributes(existing map[string]string, incoming map[string]string) map[string]string {
+	if len(existing) == 0 {
+		return cloneMemoryAttributes(incoming)
+	}
+	merged := cloneMemoryAttributes(existing)
+	for key, value := range incoming {
+		merged[key] = value
+	}
+	return merged
+}
+
+func memoryEntityRequiresInstanceLink(entity memoryEntity) bool {
+	switch entity.EntityType {
+	case "aws.elastic.ip", "aws.network.interface":
+	default:
+		return false
+	}
+	return strings.TrimSpace(entity.Attributes["attached_instance_id"]) != "" || strings.TrimSpace(entity.Attributes["associated_instance_id"]) != ""
+}
+
+func memoryEntityRequiresRepositoryOwnerLink(entity memoryEntity) bool {
+	return entity.SourceID == "github" &&
+		entity.EntityType == "github.code.repository" &&
+		strings.TrimSpace(entity.Attributes["owner_login"]) != ""
+}
+
+func (s *memoryGraphStore) memoryEntityHasInstanceLink(urn string) bool {
+	return s.memoryEntityHasOutgoingLinkTo(urn, "attached_to", "aws.ec2.instance") ||
+		s.memoryEntityHasOutgoingLinkTo(urn, "associated_with", "aws.ec2.instance")
+}
+
+func (s *memoryGraphStore) memoryEntityHasOutgoingLinkTo(urn string, relation string, targetType string) bool {
+	for _, link := range s.links {
+		if link.FromURN != urn || link.Relation != relation {
+			continue
+		}
+		if s.entities[link.ToURN].EntityType == targetType {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *memoryGraphStore) PathPatterns(_ context.Context, limit int) ([]graphstore.PathPattern, error) {

--- a/internal/graphrebuild/memory_graph_test.go
+++ b/internal/graphrebuild/memory_graph_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -36,4 +37,64 @@ func TestMemoryGraphStorePreservesExistingLabelsForFallbackLabels(t *testing.T) 
 	if got := scratch.entities[urn].Label; got != "GitHub Dependabot" {
 		t.Fatalf("memory graph label = %q, want GitHub Dependabot", got)
 	}
+}
+
+func TestMemoryGraphStoreIntegrityChecksLinkageGuardrails(t *testing.T) {
+	store, err := newMemoryGraphStore()
+	if err != nil {
+		t.Fatalf("newMemoryGraphStore() error = %v", err)
+	}
+	scratch := store.(*memoryGraphStore)
+	ctx := context.Background()
+
+	for _, entity := range []*ports.ProjectedEntity{
+		{
+			URN:        "urn:cerebro:writer:github_code_repository:repo-1",
+			TenantID:   "writer",
+			SourceID:   "github",
+			EntityType: "github.code.repository",
+			Label:      "repo-1",
+			Attributes: map[string]string{"owner_login": "org-1"},
+		},
+		{
+			URN:        "urn:cerebro:writer:aws_network_interface:eni-1",
+			TenantID:   "writer",
+			SourceID:   "aws",
+			EntityType: "aws.network.interface",
+			Label:      "eni-1",
+			Attributes: map[string]string{"attached_instance_id": "i-1"},
+		},
+		{
+			URN:        "urn:cerebro:writer:github_code_repository:grc-repo-1",
+			TenantID:   "writer",
+			SourceID:   "grc",
+			EntityType: "github.code.repository",
+			Label:      "grc-repo-1",
+			Attributes: map[string]string{"owner_login": "org-1"},
+		},
+	} {
+		if err := scratch.UpsertProjectedEntity(ctx, entity); err != nil {
+			t.Fatalf("UpsertProjectedEntity(%s) error = %v", entity.URN, err)
+		}
+	}
+
+	checks, err := scratch.IntegrityChecks(ctx)
+	if err != nil {
+		t.Fatalf("IntegrityChecks() error = %v", err)
+	}
+	if got := memoryIntegrityActual(checks, "github_code_repositories_without_owner_link"); got != 1 {
+		t.Fatalf("github_code_repositories_without_owner_link = %d, want 1", got)
+	}
+	if got := memoryIntegrityActual(checks, "aws_public_endpoints_without_instance_link"); got != 1 {
+		t.Fatalf("aws_public_endpoints_without_instance_link = %d, want 1", got)
+	}
+}
+
+func memoryIntegrityActual(checks []graphstore.IntegrityCheck, name string) int64 {
+	for _, check := range checks {
+		if check.Name == name {
+			return check.Actual
+		}
+	}
+	return -1
 }

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -192,8 +192,8 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 		t.Fatalf("len(StageConfirmations) = %d, want 9", len(result.StageConfirmations))
 	}
 	assertStageNames(t, result.StageConfirmations, "resolve_runtime", "open_graph", "read_source", "project_graph", "count_graph", "verify_integrity", "verify_path_patterns", "verify_topology", "verify_traversals")
-	if got := result.StageConfirmations[5].AssertionsPassed; got != 5 {
-		t.Fatalf("verify_integrity assertions_passed = %d, want 5", got)
+	if got := result.StageConfirmations[5].AssertionsPassed; got != 7 {
+		t.Fatalf("verify_integrity assertions_passed = %d, want 7", got)
 	}
 	if got := result.StageConfirmations[5].AssertionsFailed; got != 0 {
 		t.Fatalf("verify_integrity assertions_failed = %d, want 0", got)
@@ -235,14 +235,20 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if got := countValue(result.GraphRelationTypes, "authored"); got != 1 {
 		t.Fatalf("graph relation type authored = %d, want 1", got)
 	}
-	if len(result.GraphAssertions) != 5 {
-		t.Fatalf("len(GraphAssertions) = %d, want 5", len(result.GraphAssertions))
+	if len(result.GraphAssertions) != 7 {
+		t.Fatalf("len(GraphAssertions) = %d, want 7", len(result.GraphAssertions))
 	}
 	if !containsAssertion(result.GraphAssertions, "tenant_mismatched_relations", 0, 0, true) {
 		t.Fatalf("GraphAssertions missing tenant_mismatched_relations: %#v", result.GraphAssertions)
 	}
 	if !containsAssertion(result.GraphAssertions, "self_referential_relations", 0, 0, true) {
 		t.Fatalf("GraphAssertions missing self_referential_relations: %#v", result.GraphAssertions)
+	}
+	if !containsAssertion(result.GraphAssertions, "github_code_repositories_without_owner_link", 0, 0, true) {
+		t.Fatalf("GraphAssertions missing github_code_repositories_without_owner_link: %#v", result.GraphAssertions)
+	}
+	if !containsAssertion(result.GraphAssertions, "aws_public_endpoints_without_instance_link", 0, 0, true) {
+		t.Fatalf("GraphAssertions missing aws_public_endpoints_without_instance_link: %#v", result.GraphAssertions)
 	}
 	if len(result.GraphPathPatterns) != 7 {
 		t.Fatalf("len(GraphPathPatterns) = %d, want 7", len(result.GraphPathPatterns))
@@ -654,8 +660,8 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if len(result.GraphTraversals) != 5 {
 		t.Fatalf("len(GraphTraversals) = %d, want 5", len(result.GraphTraversals))
 	}
-	if got := result.StageConfirmations[5].AssertionsPassed; got != 5 {
-		t.Fatalf("verify_integrity assertions_passed = %d, want 5", got)
+	if got := result.StageConfirmations[5].AssertionsPassed; got != 7 {
+		t.Fatalf("verify_integrity assertions_passed = %d, want 7", got)
 	}
 	if got := result.StageConfirmations[6].PatternsVerified; got != 5 {
 		t.Fatalf("verify_path_patterns patterns_verified = %d, want 5", got)

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -271,6 +271,8 @@ func (s *Store) IntegrityChecks(ctx context.Context) ([]IntegrityCheck, error) {
 		{Name: "blank_entity_types", Expected: 0},
 		{Name: "blank_relation_types", Expected: 0},
 		{Name: "self_referential_relations", Expected: 0},
+		{Name: "github_code_repositories_without_owner_link", Expected: 0},
+		{Name: "aws_public_endpoints_without_instance_link", Expected: 0},
 	}
 	queries := []string{
 		"MATCH (src:Entity)-[r:RELATION]->(dst:Entity) WHERE src.tenant_id <> dst.tenant_id OR src.tenant_id <> r.tenant_id OR dst.tenant_id <> r.tenant_id RETURN count(r)",
@@ -278,6 +280,8 @@ func (s *Store) IntegrityChecks(ctx context.Context) ([]IntegrityCheck, error) {
 		"MATCH (e:Entity) WHERE coalesce(e.entity_type, '') = '' RETURN count(e)",
 		"MATCH (:Entity)-[r:RELATION]->(:Entity) WHERE coalesce(r.relation, '') = '' RETURN count(r)",
 		"MATCH (src:Entity)-[r:RELATION]->(dst:Entity) WHERE src.urn = dst.urn RETURN count(r)",
+		"MATCH (e:Entity) WHERE e.source_id = 'github' AND e.entity_type = 'github.code.repository' AND coalesce(e.attributes_json, '') CONTAINS '\"owner_login\":\"' AND NOT coalesce(e.attributes_json, '') CONTAINS '\"owner_login\":\"\"' AND NOT EXISTS { MATCH (e)-[:RELATION {relation: 'belongs_to'}]->(:Entity {entity_type: 'github.org'}) } RETURN count(e)",
+		"MATCH (e:Entity) WHERE e.entity_type IN ['aws.elastic.ip', 'aws.network.interface'] AND ((coalesce(e.attributes_json, '') CONTAINS '\"attached_instance_id\":\"' AND NOT coalesce(e.attributes_json, '') CONTAINS '\"attached_instance_id\":\"\"') OR (coalesce(e.attributes_json, '') CONTAINS '\"associated_instance_id\":\"' AND NOT coalesce(e.attributes_json, '') CONTAINS '\"associated_instance_id\":\"\"')) AND NOT EXISTS { MATCH (e)-[:RELATION {relation: 'attached_to'}]->(:Entity {entity_type: 'aws.ec2.instance'}) } AND NOT EXISTS { MATCH (e)-[:RELATION {relation: 'associated_with'}]->(:Entity {entity_type: 'aws.ec2.instance'}) } RETURN count(e)",
 	}
 	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
 		for i, query := range queries {


### PR DESCRIPTION
## Summary
- add graph integrity checks that detect repository entities with owner signals but no owner link
- add graph integrity checks that detect AWS endpoint entities with instance signals but no instance link
- preserve entity attributes in the dry-run memory graph so rebuild previews exercise the same guardrails as the Neo4j store

## Validation
- go test ./internal/graphrebuild ./internal/graphstore/neo4j -count=1
- make verify