### PR TITLE
fix(findings): address graph rule feedback

### DIFF
--- a/internal/findings/cloud_current_public_exposure_review_rule.go
+++ b/internal/findings/cloud_current_public_exposure_review_rule.go
@@ -17,10 +17,17 @@ func newCloudPublicResourceExposureGraphRule() Rule {
 		"aws":   {"public_endpoint", "resource_exposure"},
 		"azure": {"public_endpoint", "resource_exposure"},
 		"gcp":   {"public_endpoint", "resource_exposure"},
-	}, `MATCH (public:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'can_reach'}]->(resource:Entity {tenant_id: $tenant_id})
+	}, `MATCH (public:Entity {tenant_id: $tenant_id})-[reach:RELATION {relation: 'can_reach'}]->(resource:Entity {tenant_id: $tenant_id})
 WHERE public.entity_type ENDS WITH '.public_principal'
   AND resource.entity_type <> 'cloud.account'
   AND NOT resource.entity_type ENDS WITH '.public_principal'
+  AND (
+    coalesce(resource.attributes_json, '') CONTAINS '"internet_exposed":"true"'
+    OR coalesce(resource.attributes_json, '') CONTAINS '"external_exposure":"true"'
+    OR coalesce(resource.attributes_json, '') CONTAINS '"public":"true"'
+  )
+  AND coalesce(reach.attributes_json, '') CONTAINS '"at":"'
+  AND datetime(split(split(coalesce(reach.attributes_json, ''), '"at":"')[1], '"')[0]) >= datetime() - duration('P30D')
   AND NOT EXISTS {
     MATCH (resource)-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
     WHERE coalesce(finding.attributes_json, '') CONTAINS '"status":"open"'

--- a/internal/findings/current_state_graph_rules_test.go
+++ b/internal/findings/current_state_graph_rules_test.go
@@ -48,6 +48,21 @@ func TestCurrentStateGraphRulesEmitStableFindings(t *testing.T) {
 			}},
 		},
 		{
+			name:    "github self hosted runner",
+			rule:    newGitHubSelfHostedRunnerReviewRule(),
+			runtime: runtime,
+			row: ports.CypherRow{Values: map[string]any{
+				"primary_urn":     "urn:cerebro:writer:github_runner:repo:writer/cerebro:777",
+				"primary_label":   "prod-runner-1",
+				"primary_type":    "github.runner",
+				"fingerprint_key": "urn:cerebro:writer:github_runner:repo:writer/cerebro:777",
+				"severity":        "MEDIUM",
+				"summary":         "GitHub self-hosted runner prod-runner-1 needs security review",
+				"action":          "review",
+				"resource_urns":   []any{"urn:cerebro:writer:github_runner:repo:writer/cerebro:777"},
+			}},
+		},
+		{
 			name:    "s1 agent out of date",
 			rule:    newSentinelOneAgentNotUpToDateRule(),
 			runtime: &cerebrov1.SourceRuntime{Id: "s1-agent", SourceId: "sentinelone", TenantId: "writer", Config: map[string]string{"family": "agent"}},
@@ -95,14 +110,19 @@ func TestCurrentStateGraphRuleQueriesUseEnrichedCurrentState(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "cloud exposure uses reachability edge",
+			name: "cloud exposure uses recent reachability edge and current attributes",
 			rule: newCloudPublicResourceExposureGraphRule(),
-			want: []string{"relation: 'can_reach'", ".public_principal", "WITH DISTINCT resource"},
+			want: []string{"relation: 'can_reach'", ".public_principal", `"internet_exposed":"true"`, `duration('P30D')`, "WITH DISTINCT resource"},
 		},
 		{
 			name: "github credentials exclude inactive resources",
 			rule: newGitHubProgrammaticCredentialReviewRule(),
-			want: []string{`resource.entity_type = 'github.credential'`, `"status":"inactive"`},
+			want: []string{`entity_type: 'github.credential'`, `"status":"inactive"`},
+		},
+		{
+			name: "github self-hosted runner uses projected runner state",
+			rule: newGitHubSelfHostedRunnerReviewRule(),
+			want: []string{`entity_type: 'github.runner'`, `"runner_status":"inactive"`, `"runner_ephemeral":"true"`},
 		},
 		{
 			name: "sentinelone stale agents require active non-pending inventory",

--- a/internal/findings/github_programmatic_credential_review_rule.go
+++ b/internal/findings/github_programmatic_credential_review_rule.go
@@ -29,20 +29,15 @@ func newGitHubProgrammaticCredentialReviewRule() Rule {
 			{FrameworkName: "SOC 2", ControlID: "CC6.2"},
 			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.18"},
 		},
-	}, map[string][]string{"github": {"audit"}}, `MATCH (resource:Entity {tenant_id: $tenant_id})
+	}, map[string][]string{"github": {"audit"}}, `MATCH (resource:Entity {tenant_id: $tenant_id, entity_type: 'github.credential'})
 WHERE (
-    resource.entity_type = 'github.credential'
-    OR (
-      resource.entity_type = 'github.resource'
-      AND (
-        coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"personal_access_token"'
-        OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"org_credential_authorization"'
-        OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"integration_installation"'
-        OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"integration_installation_request"'
-        OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"oauth_application"'
-        OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"integration"'
-      )
-    )
+    coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"personal_access_token"'
+    OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"org_credential_authorization"'
+    OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"integration_installation"'
+    OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"integration_installation_request"'
+    OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"oauth_application"'
+    OR coalesce(resource.attributes_json, '') CONTAINS '"resource_type":"integration"'
+    OR coalesce(resource.attributes_json, '') CONTAINS '"credential_type":"public_key"'
   )
   AND NOT coalesce(resource.attributes_json, '') CONTAINS '"status":"inactive"'
 RETURN resource.urn AS primary_urn,

--- a/internal/findings/github_self_hosted_runner_review_rule.go
+++ b/internal/findings/github_self_hosted_runner_review_rule.go
@@ -1,0 +1,47 @@
+package findings
+
+import "github.com/writer/cerebro/internal/ports"
+
+const githubSelfHostedRunnerReviewRuleID = "github-self-hosted-runner-review-needed"
+
+func newGitHubSelfHostedRunnerReviewRule() Rule {
+	return newCoordinationGraphRule(RuleDefinition{
+		ID:                githubSelfHostedRunnerReviewRuleID,
+		Name:              "GitHub Self-Hosted Runner Needs Review",
+		Description:       "Detect active non-ephemeral or untrusted GitHub self-hosted runners from projected runner state.",
+		SourceID:          "github",
+		EventKinds:        []string{"github.audit"},
+		OutputKind:        "finding.github_self_hosted_runner_review_needed",
+		Severity:          "MEDIUM",
+		Status:            findingStatusOpen,
+		Maturity:          "test",
+		Tags:              []string{"github", "actions", "self-hosted-runner", "supply-chain", "graph-rule", "attack.t1195"},
+		References:        []string{"https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners"},
+		FalsePositives:    []string{"Approved persistent runner pools with documented owner, hardening baseline, and network isolation."},
+		Runbook:           "Validate runner ownership, scope, host trust, ephemeral posture, and recent jobs; remove or isolate unauthorized runners.",
+		FingerprintFields: []string{"runner_urn"},
+		ControlRefs:       []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.6"}, {FrameworkName: "ISO 27001:2022", ControlID: "A.8.9"}},
+		Lifecycle:         Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorGraphAnchored},
+	}, map[string][]string{"github": {"audit"}}, `MATCH (runner:Entity {tenant_id: $tenant_id, entity_type: 'github.runner'})
+OPTIONAL MATCH (runner)-[scopeRel:RELATION {relation: 'belongs_to'}]->(scope:Entity {tenant_id: $tenant_id})
+WHERE NOT coalesce(runner.attributes_json, '') CONTAINS '"runner_status":"inactive"'
+  AND (
+    NOT coalesce(runner.attributes_json, '') CONTAINS '"runner_ephemeral":"true"'
+    OR coalesce(runner.attributes_json, '') CONTAINS '"runner_untrusted":"true"'
+    OR coalesce(runner.attributes_json, '') CONTAINS '"host_trusted":"false"'
+  )
+RETURN runner.urn AS primary_urn,
+       runner.label AS primary_label,
+       runner.entity_type AS primary_type,
+       runner.urn AS fingerprint_key,
+       CASE
+         WHEN coalesce(runner.attributes_json, '') CONTAINS '"runner_untrusted":"true"' OR coalesce(runner.attributes_json, '') CONTAINS '"host_trusted":"false"' THEN 'HIGH'
+         ELSE 'MEDIUM'
+       END AS severity,
+       'GitHub self-hosted runner ' + coalesce(runner.label, runner.urn) + ' needs security review' AS summary,
+       'Validate runner ownership, trust, isolation, and ephemeral posture; remove unauthorized persistent runners' AS action,
+       CASE WHEN scope.urn IS NULL THEN [runner.urn] ELSE [runner.urn, scope.urn] END AS resource_urns,
+       CASE WHEN scope.urn IS NULL THEN [] ELSE [{urn: scope.urn, label: scope.label, entity_type: scope.entity_type, relation: 'belongs_to', attributes_json: coalesce(scopeRel.attributes_json, '')}] END AS evidence
+ORDER BY severity DESC, runner.label, runner.urn
+LIMIT $row_limit`, nil)
+}

--- a/internal/findings/identity_signal_rule.go
+++ b/internal/findings/identity_signal_rule.go
@@ -830,11 +830,11 @@ func identityCredentialRepresentsOAuthApp(attributes map[string]string) bool {
 func identityOAuthAppID(attributes map[string]string) string {
 	if oauthAppID := firstNonEmpty(
 		attributes["oauth_app_id"],
+		attributes["app_id"],
+		attributes["application_id"],
 		attributes["oauth_client_id"],
 		attributes["oauth2_client_id"],
 		attributes["client_id"],
-		attributes["app_id"],
-		attributes["application_id"],
 	); oauthAppID != "" {
 		return oauthAppID
 	}

--- a/internal/findings/identity_signal_rule_test.go
+++ b/internal/findings/identity_signal_rule_test.go
@@ -599,6 +599,7 @@ func TestIdentityApiTokenOrOauthAppCreated_OAuthTrajectory(t *testing.T) {
 	oauthAttrs := map[string]string{
 		"app_id":       "0oa-client",
 		"app_name":     "Production Client",
+		"client_id":    "oauth-client-id",
 		"domain":       "writer.okta.com",
 		"oauth2":       "true",
 		"sign_on_mode": "OPENID_CONNECT",

--- a/internal/findings/okta_oauth_public_client_review_rule.go
+++ b/internal/findings/okta_oauth_public_client_review_rule.go
@@ -29,20 +29,18 @@ func newOktaOAuthPublicClientReviewRule() Rule {
 			{FrameworkName: "SOC 2", ControlID: "CC6.1"},
 			{FrameworkName: "ISO 27001:2022", ControlID: "A.5.17"},
 		},
-	}, map[string][]string{"okta": {"application", "audit"}}, `MATCH (client:Entity {tenant_id: $tenant_id})
-WHERE client.entity_type IN ['okta.application', 'okta.publicclientapp', 'okta.publicclientappentity']
+	}, map[string][]string{"okta": {"application"}}, `MATCH (client:Entity {tenant_id: $tenant_id, entity_type: 'okta.application'})
+WHERE coalesce(client.attributes_json, '') CONTAINS '"status":"ACTIVE"'
   AND (
-    client.entity_type <> 'okta.application'
-    OR (
-      coalesce(client.attributes_json, '') CONTAINS '"status":"ACTIVE"'
-      AND (
-        coalesce(client.attributes_json, '') CONTAINS '"oauth2":"true"'
-        OR coalesce(client.attributes_json, '') CONTAINS '"oauth_client_type":"PublicClientApp"'
-        OR coalesce(client.attributes_json, '') CONTAINS '"oauth_client_type":"PublicClientAppEntity"'
-        OR coalesce(client.attributes_json, '') CONTAINS '"oauth_public_client":"true"'
-        OR coalesce(client.attributes_json, '') CONTAINS '"sign_on_mode":"OPENID_CONNECT"'
-      )
-    )
+    coalesce(client.attributes_json, '') CONTAINS '"oauth2":"true"'
+    OR coalesce(client.attributes_json, '') CONTAINS '"oauth_client_type":"PublicClientApp"'
+    OR coalesce(client.attributes_json, '') CONTAINS '"oauth_public_client":"true"'
+    OR coalesce(client.attributes_json, '') CONTAINS '"sign_on_mode":"OPENID_CONNECT"'
+  )
+  AND NOT EXISTS {
+    MATCH (client)-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+    WHERE coalesce(finding.attributes_json, '') CONTAINS '"status":"open"'
+      AND coalesce(finding.attributes_json, '') CONTAINS '"rule_id":"identity-api-token-or-oauth-app-created"'
   )
 RETURN client.urn AS primary_urn,
        client.label AS primary_label,

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -1239,6 +1239,50 @@
       ]
     },
     {
+      "id": "github-self-hosted-runner-review-needed",
+      "pack_id": "github",
+      "pack_name": "GitHub",
+      "name": "GitHub Self-Hosted Runner Needs Review",
+      "description": "Detect active non-ephemeral or untrusted GitHub self-hosted runners from projected runner state.",
+      "source_id": "github",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "github.audit"
+      ],
+      "output_kind": "finding.github_self_hosted_runner_review_needed",
+      "severity": "MEDIUM",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "actions",
+        "attack.t1195",
+        "github",
+        "graph-rule",
+        "self-hosted-runner",
+        "supply-chain"
+      ],
+      "references": [
+        "https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners"
+      ],
+      "false_positives": [
+        "Approved persistent runner pools with documented owner, hardening baseline, and network isolation."
+      ],
+      "runbook": "Validate runner ownership, scope, host trust, ephemeral posture, and recent jobs; remove or isolate unauthorized runners.",
+      "fingerprint_fields": [
+        "runner_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC6.6"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.8.9"
+        }
+      ]
+    },
+    {
       "id": "github-webhook-modified",
       "pack_id": "github",
       "pack_name": "GitHub",

--- a/internal/findings/rulepack.go
+++ b/internal/findings/rulepack.go
@@ -34,6 +34,7 @@ func builtinRulePacks() []RulePack {
 				newGitHubSecretScanningAlertCreatedRule(),
 				newGitHubSecretScanningDisabledRule(),
 				newGitHubSelfHostedRunnerChangeRule(),
+				newGitHubSelfHostedRunnerReviewRule(),
 				newGitHubWebhookModifiedRule(),
 			},
 		},

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -923,7 +923,7 @@ func TestNetNewRetiredRulesNoEmit(t *testing.T) {
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 31; got != want {
+	if got, want := len(keepRules), 32; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1106,6 +1106,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "github-secret-scanning-alert-created", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "github-secret-scanning-disabled", Classification: "RETIRE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "github-self-hosted-runner-change", Classification: "RETIRE", BulkCloseoutThreshold: ">7d", Source: "github"},
+		{RuleID: "github-self-hosted-runner-review-needed", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},
 		{RuleID: "github-programmatic-credential-review-needed", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "github"},
 		{RuleID: "github-webhook-modified", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},
 		{RuleID: "grc-control-test-needs-attention", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "grc"},

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -128,6 +128,7 @@ func cloudResourceExposureProjections(event *cerebrov1.EventEnvelope, profile id
 	if publicURN != "" && resourceURN != "" {
 		reachabilityAttrs := map[string]string{
 			"action":        strings.TrimSpace(attributes["action"]),
+			"at":            eventObservedAt(event),
 			"direction":     strings.TrimSpace(attributes["direction"]),
 			"event_id":      event.GetId(),
 			"exposure_type": strings.TrimSpace(attributes["exposure_type"]),
@@ -223,6 +224,7 @@ func cloudPublicEndpointProjections(event *cerebrov1.EventEnvelope, profile iden
 		if publicURN != "" && projectionBool(firstNonEmpty(attributes["internet_exposed"], attributes["public"], attributes["external_exposure"])) {
 			reachabilityAttrs := map[string]string{
 				"direction":     "ingress",
+				"at":            eventObservedAt(event),
 				"event_id":      event.GetId(),
 				"exposure_type": "public_endpoint",
 				"host":          strings.TrimSpace(attributes["host"]),

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -685,7 +685,7 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 			"programmatic_access_type": programmaticAccessType,
 			"resource_id":              resourceID,
 			"resource_type":            resourceType,
-			"status":                   githubProgrammaticCredentialStatus(attributes["action"]),
+			"status":                   githubProgrammaticCredentialStatus(attributes),
 		}
 		addProjectedAttribute(credentialAttrs, "actor", actor)
 		addProjectedAttribute(credentialAttrs, "github_app_id", strings.TrimSpace(attributes["github_app_id"]))
@@ -713,6 +713,21 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), programmaticCredentialURN, repoURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		} else if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), programmaticCredentialURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+	}
+	if runnerURN, runnerAttrs := githubSelfHostedRunnerProjection(tenantID, attributes); runnerURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        runnerURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: "github.runner",
+			Label:      firstNonEmpty(runnerAttrs["runner_name"], runnerAttrs["runner_id"]),
+			Attributes: runnerAttrs,
+		})
+		if repoScopePresent && repoURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), runnerURN, repoURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		} else if orgURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), runnerURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
 	}
 
@@ -953,8 +968,12 @@ func githubProgrammaticCredentialID(attributes map[string]string) string {
 	return strings.Join(nonEmptyStrings(prefix, attributes["resource_id"], scope, attributes["actor"]), ":")
 }
 
-func githubProgrammaticCredentialStatus(action string) string {
-	normalized := strings.ToLower(strings.TrimSpace(action))
+func githubProgrammaticCredentialStatus(attributes map[string]string) string {
+	normalized := strings.ToLower(strings.TrimSpace(attributes["action"]))
+	operationType := strings.ToLower(strings.TrimSpace(attributes["operation_type"]))
+	if containsAny(operationType, "remove", "removed", "revoke", "revoked", "expire", "expired", "delete", "deleted") {
+		return "inactive"
+	}
 	if containsAny(normalized, "revoke", "revoked", "deauthorize", "delete", "remove", "destroy", "suspend") {
 		return "inactive"
 	}
@@ -962,6 +981,77 @@ func githubProgrammaticCredentialStatus(action string) string {
 		return "active"
 	}
 	return "unknown"
+}
+
+func githubSelfHostedRunnerProjection(tenantID string, attributes map[string]string) (string, map[string]string) {
+	runnerID := strings.TrimSpace(attributes["runner_id"])
+	if runnerID == "" {
+		return "", nil
+	}
+	scope := strings.TrimSpace(firstNonEmpty(attributes["runner_scope"], attributes["scope"], attributes["repo"], attributes["org"]))
+	if scope == "" {
+		return "", nil
+	}
+	scopeType, scopeID := githubRunnerScope(scope)
+	if scopeID == "" {
+		return "", nil
+	}
+	attrs := map[string]string{
+		"action":            strings.TrimSpace(attributes["action"]),
+		"runner_id":         runnerID,
+		"runner_name":       strings.TrimSpace(attributes["runner_name"]),
+		"runner_scope":      scopeID,
+		"runner_scope_type": scopeType,
+		"runner_status":     githubSelfHostedRunnerStatus(attributes),
+	}
+	addProjectedAttribute(attrs, "host_trusted", firstNonEmpty(attributes["runner_host_trusted"], attributes["host_trusted"], attributes["trusted_host"]))
+	addProjectedAttribute(attrs, "runner_ephemeral", firstNonEmpty(attributes["runner_ephemeral"], attributes["ephemeral"], attributes["is_ephemeral"]))
+	addProjectedAttribute(attrs, "runner_group_name", attributes["runner_group_name"])
+	addProjectedAttribute(attrs, "runner_registered", firstNonEmpty(attributes["runner_registered"], attributes["registered"], attributes["is_registered"]))
+	addProjectedAttribute(attrs, "runner_state", attributes["runner_state"])
+	addProjectedAttribute(attrs, "runner_untrusted", firstNonEmpty(attributes["runner_untrusted"], attributes["host_untrusted"], attributes["untrusted_host"]))
+	return projectionURN(tenantID, "github_runner", scopeID, runnerID), attrs
+}
+
+func githubRunnerScope(scope string) (string, string) {
+	normalized := strings.TrimSpace(scope)
+	if normalized == "" {
+		return "", ""
+	}
+	lower := strings.ToLower(normalized)
+	switch {
+	case strings.HasPrefix(lower, "repo:"), strings.Contains(normalized, "/"):
+		return "repo", normalizeGitHubRunnerScopeID(normalized, "repo")
+	case strings.HasPrefix(lower, "enterprise:"):
+		return "enterprise", normalizeGitHubRunnerScopeID(normalized, "enterprise")
+	case strings.HasPrefix(lower, "org:"):
+		return "org", normalizeGitHubRunnerScopeID(normalized, "org")
+	default:
+		return "org", "org:" + normalized
+	}
+}
+
+func normalizeGitHubRunnerScopeID(scope string, kind string) string {
+	normalized := strings.TrimSpace(scope)
+	prefix := kind + ":"
+	if strings.HasPrefix(strings.ToLower(normalized), prefix) {
+		return normalized
+	}
+	return prefix + normalized
+}
+
+func githubSelfHostedRunnerStatus(attributes map[string]string) string {
+	action := strings.ToLower(strings.TrimSpace(attributes["action"]))
+	state := strings.ToLower(strings.TrimSpace(firstNonEmpty(attributes["runner_state"], attributes["state"], attributes["status"])))
+	registered := strings.ToLower(strings.TrimSpace(firstNonEmpty(attributes["runner_registered"], attributes["registered"], attributes["is_registered"])))
+	if registered == "false" || registered == "0" || registered == "no" {
+		return "inactive"
+	}
+	if containsAny(state, "removed", "deleted", "deregistered", "unregistered") ||
+		containsAny(action, "remove_self_hosted_runner", "deregister_self_hosted_runner", "runner_removed") {
+		return "inactive"
+	}
+	return "active"
 }
 
 func containsAny(value string, needles ...string) bool {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -1861,25 +1861,91 @@ func TestProjectGitHubAuditProjectsProgrammaticResourceAsCredential(t *testing.T
 	assertProjectedLink(t, graph, credentialURN, relationBelongsTo, "urn:cerebro:writer:github_org:writer")
 
 	_, err = New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
-		Id:       "github-audit-pat-revoked",
+		Id:       "github-audit-pat-expired",
 		TenantId: "writer",
 		SourceId: "github",
 		Kind:     "github.audit",
 		Attributes: map[string]string{
-			"actor":         "octocat",
-			"action":        "personal_access_token.revoked",
-			"org":           "writer",
-			"resource_id":   "octocat",
-			"resource_type": "personal_access_token",
-			"scope":         "organization",
-			"token_id":      "555",
+			"actor":          "octocat",
+			"action":         "personal_access_token.access_granted",
+			"operation_type": "expired",
+			"org":            "writer",
+			"resource_id":    "octocat",
+			"resource_type":  "personal_access_token",
+			"scope":          "organization",
+			"token_id":       "555",
 		},
 	})
 	if err != nil {
-		t.Fatalf("Project() revoke error = %v", err)
+		t.Fatalf("Project() expired error = %v", err)
 	}
 	if got := graph.entities[credentialURN].Attributes["status"]; got != "inactive" {
-		t.Fatalf("revoked credential status = %q, want inactive", got)
+		t.Fatalf("expired credential status = %q, want inactive", got)
+	}
+}
+
+func TestProjectGitHubAuditProjectsSelfHostedRunnerState(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	_, err := New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-audit-runner",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"action":              "repo.register_self_hosted_runner",
+			"org":                 "writer",
+			"repo":                "writer/cerebro",
+			"resource_id":         "writer/cerebro",
+			"resource_type":       "repo",
+			"runner_ephemeral":    "false",
+			"runner_host_trusted": "false",
+			"runner_id":           "777",
+			"runner_name":         "prod-runner-1",
+			"runner_registered":   "true",
+			"runner_scope":        "repo:writer/cerebro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	runnerURN := "urn:cerebro:writer:github_runner:repo:writer/cerebro:777"
+	runner, ok := graph.entities[runnerURN]
+	if !ok {
+		t.Fatalf("github.runner entity %q missing: %#v", runnerURN, graph.entities)
+	}
+	for key, want := range map[string]string{
+		"host_trusted":      "false",
+		"runner_ephemeral":  "false",
+		"runner_id":         "777",
+		"runner_scope":      "repo:writer/cerebro",
+		"runner_scope_type": "repo",
+		"runner_status":     "active",
+	} {
+		if got := runner.Attributes[key]; got != want {
+			t.Fatalf("runner attributes[%s] = %q, want %q", key, got, want)
+		}
+	}
+	assertProjectedLink(t, graph, runnerURN, relationBelongsTo, "urn:cerebro:writer:github_repo:writer/cerebro")
+
+	_, err = New(state, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-audit-runner-remove",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"action":       "repo.remove_self_hosted_runner",
+			"org":          "writer",
+			"repo":         "writer/cerebro",
+			"runner_id":    "777",
+			"runner_scope": "repo:writer/cerebro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() remove error = %v", err)
+	}
+	if got := graph.entities[runnerURN].Attributes["runner_status"]; got != "inactive" {
+		t.Fatalf("removed runner status = %q, want inactive", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a graph-backed replacement for GitHub self-hosted runner review coverage
- tighten graph rules to avoid duplicate or stale current-state findings
- preserve Okta OAuth app finding continuity while keeping safe projection enrichment

## Validation
- go test ./internal/findings ./internal/sourceprojection ./sources/okta ./sources/sentinelone ./sources/github
- make verify

## Notes
- Operational rollout/closeout details are intentionally omitted from this public PR description.