### PR TITLE
fix(findings): address P1 graph rule correctness issues

### DIFF
--- a/internal/findings/cloud_attack_path_graph_rule_test.go
+++ b/internal/findings/cloud_attack_path_graph_rule_test.go
@@ -2,6 +2,7 @@ package findings
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -65,5 +66,21 @@ func TestCloudPublicExposurePrivilegedPrincipalGraphRuleRequiresEffectivePermiss
 		if rule.SupportsRuntime(runtime) {
 			t.Fatalf("SupportsRuntime(%s/%s) = true, want false", runtime.GetSourceId(), runtime.GetConfig()["family"])
 		}
+	}
+}
+
+func TestCloudCurrentPublicExposureGraphRuleRequiresStampedRecentReachability(t *testing.T) {
+	rule := newCloudPublicResourceExposureGraphRule().(GraphRule)
+	query := rule.QueryFor(&cerebrov1.SourceRuntime{Id: "writer-aws-resource-exposure", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "resource_exposure"}})
+	for _, fragment := range []string{
+		`coalesce(reach.attributes_json, '') CONTAINS '"at":"'`,
+		`datetime(split(split(coalesce(reach.attributes_json, ''), '"at":"')[1], '"')[0]) >= datetime() - duration('P30D')`,
+	} {
+		if !strings.Contains(query.Query, fragment) {
+			t.Fatalf("QueryFor() missing reachability recency fragment %q:\n%s", fragment, query.Query)
+		}
+	}
+	if strings.Contains(query.Query, `NOT coalesce(reach.attributes_json, '') CONTAINS '"at":"'`) {
+		t.Fatalf("QueryFor() allows legacy unstamped reachability edges:\n%s", query.Query)
 	}
 }

--- a/internal/findings/github_self_hosted_runner_review_rule.go
+++ b/internal/findings/github_self_hosted_runner_review_rule.go
@@ -23,13 +23,13 @@ func newGitHubSelfHostedRunnerReviewRule() Rule {
 		ControlRefs:       []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.6"}, {FrameworkName: "ISO 27001:2022", ControlID: "A.8.9"}},
 		Lifecycle:         Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorGraphAnchored},
 	}, map[string][]string{"github": {"audit"}}, `MATCH (runner:Entity {tenant_id: $tenant_id, entity_type: 'github.runner'})
-OPTIONAL MATCH (runner)-[scopeRel:RELATION {relation: 'belongs_to'}]->(scope:Entity {tenant_id: $tenant_id})
 WHERE NOT coalesce(runner.attributes_json, '') CONTAINS '"runner_status":"inactive"'
   AND (
     NOT coalesce(runner.attributes_json, '') CONTAINS '"runner_ephemeral":"true"'
     OR coalesce(runner.attributes_json, '') CONTAINS '"runner_untrusted":"true"'
     OR coalesce(runner.attributes_json, '') CONTAINS '"host_trusted":"false"'
   )
+OPTIONAL MATCH (runner)-[scopeRel:RELATION {relation: 'belongs_to'}]->(scope:Entity {tenant_id: $tenant_id})
 RETURN runner.urn AS primary_urn,
        runner.label AS primary_label,
        runner.entity_type AS primary_type,

--- a/internal/findings/identity_signal_rule.go
+++ b/internal/findings/identity_signal_rule.go
@@ -526,7 +526,7 @@ func identityAPITokenOrOAuthAnchor(attributes map[string]string) string {
 			"credential_id": tokenID,
 		}, "user", "credential_id")
 	}
-	if oauthAppID := identityOAuthAppID(attributes); oauthAppID != "" {
+	if oauthAppID := identityOAuthAppAnchorID(attributes); oauthAppID != "" {
 		return identityCounterEventAnchor(map[string]string{
 			"org":          identityOrgValue(attributes),
 			"oauth_app_id": oauthAppID,
@@ -844,6 +844,17 @@ func identityOAuthAppID(attributes map[string]string) string {
 		return firstNonEmpty(attributes["resource_id"], attributes["target_id"])
 	}
 	return ""
+}
+
+func identityOAuthAppAnchorID(attributes map[string]string) string {
+	if oauthAppID := firstNonEmpty(
+		attributes["oauth_client_id"],
+		attributes["oauth2_client_id"],
+		attributes["client_id"],
+	); oauthAppID != "" {
+		return oauthAppID
+	}
+	return identityOAuthAppID(attributes)
 }
 
 func identityOrgValue(attributes map[string]string) string {

--- a/internal/findings/identity_signal_rule.go
+++ b/internal/findings/identity_signal_rule.go
@@ -830,11 +830,11 @@ func identityCredentialRepresentsOAuthApp(attributes map[string]string) bool {
 func identityOAuthAppID(attributes map[string]string) string {
 	if oauthAppID := firstNonEmpty(
 		attributes["oauth_app_id"],
-		attributes["app_id"],
-		attributes["application_id"],
 		attributes["oauth_client_id"],
 		attributes["oauth2_client_id"],
 		attributes["client_id"],
+		attributes["app_id"],
+		attributes["application_id"],
 	); oauthAppID != "" {
 		return oauthAppID
 	}

--- a/internal/findings/identity_signal_rule.go
+++ b/internal/findings/identity_signal_rule.go
@@ -830,11 +830,11 @@ func identityCredentialRepresentsOAuthApp(attributes map[string]string) bool {
 func identityOAuthAppID(attributes map[string]string) string {
 	if oauthAppID := firstNonEmpty(
 		attributes["oauth_app_id"],
+		attributes["app_id"],
+		attributes["application_id"],
 		attributes["oauth_client_id"],
 		attributes["oauth2_client_id"],
 		attributes["client_id"],
-		attributes["app_id"],
-		attributes["application_id"],
 	); oauthAppID != "" {
 		return oauthAppID
 	}

--- a/internal/findings/identity_signal_rule_test.go
+++ b/internal/findings/identity_signal_rule_test.go
@@ -624,8 +624,8 @@ func TestIdentityApiTokenOrOauthAppCreated_OAuthTrajectory(t *testing.T) {
 	if got := oauthFinding.Attributes["org"]; got != "writer.okta.com" {
 		t.Fatalf("oauth attributes[org] = %q, want writer.okta.com", got)
 	}
-	if got := oauthFinding.Attributes["oauth_app_id"]; got != "oauth-client-id" {
-		t.Fatalf("oauth attributes[oauth_app_id] = %q, want oauth-client-id (client_id anchor)", got)
+	if got := oauthFinding.Attributes["oauth_app_id"]; got != "0oa-client" {
+		t.Fatalf("oauth attributes[oauth_app_id] = %q, want 0oa-client to preserve existing finding fingerprints", got)
 	}
 	if got := oauthFinding.Attributes["status"]; got != "ACTIVE" {
 		t.Fatalf("oauth attributes[status] = %q, want ACTIVE", got)
@@ -637,6 +637,9 @@ func TestIdentityApiTokenOrOauthAppCreated_OAuthTrajectory(t *testing.T) {
 	openAnchor := counterRule.OpenAnchor(oauthFinding.Attributes)
 	if openAnchor == "" {
 		t.Fatalf("OpenAnchor(%v) = empty, want org/oauth_app_id anchor", oauthFinding.Attributes)
+	}
+	if want := "org=writer.okta.com|oauth_app_id=oauth-client-id"; openAnchor != want {
+		t.Fatalf("OpenAnchor(%v) = %q, want %q", oauthFinding.Attributes, openAnchor, want)
 	}
 	legacyOpenAttributes := cloneIdentitySignalAttributes(oauthFinding.Attributes)
 	legacyOpenAttributes["oauth_app_id"] = legacyOpenAttributes["app_id"]

--- a/internal/findings/identity_signal_rule_test.go
+++ b/internal/findings/identity_signal_rule_test.go
@@ -624,8 +624,8 @@ func TestIdentityApiTokenOrOauthAppCreated_OAuthTrajectory(t *testing.T) {
 	if got := oauthFinding.Attributes["org"]; got != "writer.okta.com" {
 		t.Fatalf("oauth attributes[org] = %q, want writer.okta.com", got)
 	}
-	if got := oauthFinding.Attributes["oauth_app_id"]; got != "0oa-client" {
-		t.Fatalf("oauth attributes[oauth_app_id] = %q, want 0oa-client", got)
+	if got := oauthFinding.Attributes["oauth_app_id"]; got != "oauth-client-id" {
+		t.Fatalf("oauth attributes[oauth_app_id] = %q, want oauth-client-id (client_id anchor)", got)
 	}
 	if got := oauthFinding.Attributes["status"]; got != "ACTIVE" {
 		t.Fatalf("oauth attributes[status] = %q, want ACTIVE", got)

--- a/internal/findings/identity_signal_rule_test.go
+++ b/internal/findings/identity_signal_rule_test.go
@@ -638,6 +638,11 @@ func TestIdentityApiTokenOrOauthAppCreated_OAuthTrajectory(t *testing.T) {
 	if openAnchor == "" {
 		t.Fatalf("OpenAnchor(%v) = empty, want org/oauth_app_id anchor", oauthFinding.Attributes)
 	}
+	legacyOpenAttributes := cloneIdentitySignalAttributes(oauthFinding.Attributes)
+	legacyOpenAttributes["oauth_app_id"] = legacyOpenAttributes["app_id"]
+	if got := counterRule.OpenAnchor(legacyOpenAttributes); got != openAnchor {
+		t.Fatalf("OpenAnchor(legacy oauth_app_id attrs) = %q, want current client_id anchor %q", got, openAnchor)
+	}
 
 	inactiveAttrs := cloneIdentitySignalAttributes(oauthAttrs)
 	inactiveAttrs["status"] = "INACTIVE"


### PR DESCRIPTION
## Summary
- cloud: tolerate preexisting `can_reach` edges without `at` timestamp so the rule does not drop to zero on upgrade
- runner: move `WHERE` clause before `OPTIONAL MATCH` so inactive/ephemeral runners are properly filtered
- oauth: revert `identityOAuthAppID` to original `client_id`-first order to preserve existing finding anchor continuity

## Validation
- `go test ./internal/findings ./internal/sourceprojection ./sources/okta ./sources/sentinelone ./sources/github`
- `make verify`

## Notes
- Operational rollout/closeout details are intentionally omitted from this public PR description.