### PR TITLE
feat(sources): zero-cost enrichments for GitHub and Okta

### DIFF
--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -385,21 +385,27 @@ func identityPolicyRuleProjections(event *cerebrov1.EventEnvelope, profile ident
 	policyRuleURN := projectionURN(tenantID, profile.Provider+"_policy_rule", policyID, policyRuleID)
 	entities := map[string]*ports.ProjectedEntity{}
 	if policyRuleURN != "" {
+		policyRuleAttrs := map[string]string{
+			"policy_id":      policyID,
+			"policy_rule_id": policyRuleID,
+			"policy_type":    strings.TrimSpace(attributes["policy_type"]),
+			"name":           firstNonEmpty(attributes["name"], attributes["policy_rule_name"]),
+			"status":         strings.TrimSpace(attributes["status"]),
+			"priority":       strings.TrimSpace(attributes["priority"]),
+			"system":         strings.TrimSpace(attributes["system"]),
+		}
+		for _, key := range []string{"access", "requires_mfa", "mfa_prompt", "mfa_lifetime_minutes", "session_max_lifetime_minutes", "session_idle_minutes", "session_persistent", "network_connection", "risk_level"} {
+			if v := strings.TrimSpace(attributes[key]); v != "" {
+				policyRuleAttrs[key] = v
+			}
+		}
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        policyRuleURN,
 			TenantID:   tenantID,
 			SourceID:   event.GetSourceId(),
 			EntityType: profile.entityType("policy_rule"),
 			Label:      firstNonEmpty(attributes["name"], attributes["policy_rule_name"], policyRuleID),
-			Attributes: map[string]string{
-				"policy_id":      policyID,
-				"policy_rule_id": policyRuleID,
-				"policy_type":    strings.TrimSpace(attributes["policy_type"]),
-				"name":           firstNonEmpty(attributes["name"], attributes["policy_rule_name"]),
-				"status":         strings.TrimSpace(attributes["status"]),
-				"priority":       strings.TrimSpace(attributes["priority"]),
-				"system":         strings.TrimSpace(attributes["system"]),
-			},
+			Attributes: policyRuleAttrs,
 		})
 	}
 	return identityProjectionResult(entities, nil)

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -506,26 +506,32 @@ func githubCodeRepositoryProjections(event *cerebrov1.EventEnvelope) ([]*ports.P
 
 	codeRepoURN := projectionURN(tenantID, "github_code_repository", repoID)
 	if codeRepoURN != "" {
+		codeRepoAttrs := map[string]string{
+			"archived":       strings.TrimSpace(attributes["archived"]),
+			"default_branch": strings.TrimSpace(attributes["default_branch"]),
+			"fork":           strings.TrimSpace(attributes["fork"]),
+			"html_url":       strings.TrimSpace(attributes["html_url"]),
+			"name":           strings.TrimSpace(attributes["name"]),
+			"owner_login":    owner,
+			"private":        strings.TrimSpace(attributes["private"]),
+			"repo_id":        strings.TrimSpace(attributes["repo_id"]),
+			"repository":     repository,
+			"resource_id":    repoID,
+			"resource_type":  "code_repository",
+			"visibility":     strings.TrimSpace(attributes["visibility"]),
+		}
+		for _, key := range []string{"secret_scanning", "secret_scanning_push_protection", "dependabot_security_updates"} {
+			if v := strings.TrimSpace(attributes[key]); v != "" {
+				codeRepoAttrs[key] = v
+			}
+		}
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        codeRepoURN,
 			TenantID:   tenantID,
 			SourceID:   event.GetSourceId(),
 			EntityType: "github.code.repository",
 			Label:      firstNonEmpty(repository, repoID),
-			Attributes: map[string]string{
-				"archived":       strings.TrimSpace(attributes["archived"]),
-				"default_branch": strings.TrimSpace(attributes["default_branch"]),
-				"fork":           strings.TrimSpace(attributes["fork"]),
-				"html_url":       strings.TrimSpace(attributes["html_url"]),
-				"name":           strings.TrimSpace(attributes["name"]),
-				"owner_login":    owner,
-				"private":        strings.TrimSpace(attributes["private"]),
-				"repo_id":        strings.TrimSpace(attributes["repo_id"]),
-				"repository":     repository,
-				"resource_id":    repoID,
-				"resource_type":  "code_repository",
-				"visibility":     strings.TrimSpace(attributes["visibility"]),
-			},
+			Attributes: codeRepoAttrs,
 		})
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), codeRepoURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId(), "owner_login": owner}))
@@ -1230,17 +1236,23 @@ func oktaUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnti
 
 	userURN := oktaUserURN(tenantID, userID)
 	if userURN != "" {
+		userAttrs := map[string]string{
+			"email":  email,
+			"login":  login,
+			"status": strings.TrimSpace(attributes["status"]),
+		}
+		for _, key := range []string{"mfa_enrolled", "mfa_factor_count", "mfa_factor_types", "mfa_phishing_resistant"} {
+			if v := strings.TrimSpace(attributes[key]); v != "" {
+				userAttrs[key] = v
+			}
+		}
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        userURN,
 			TenantID:   tenantID,
 			SourceID:   event.GetSourceId(),
 			EntityType: "okta.user",
 			Label:      firstNonEmpty(email, login, userID),
-			Attributes: map[string]string{
-				"email":  email,
-				"login":  login,
-				"status": strings.TrimSpace(attributes["status"]),
-			},
+			Attributes: userAttrs,
 		})
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), userURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -78,19 +78,22 @@ type pullRequestPayload struct {
 }
 
 type repositoryPayload struct {
-	ID            int64      `json:"id,omitempty"`
-	OwnerLogin    string     `json:"owner_login"`
-	Name          string     `json:"name"`
-	FullName      string     `json:"full_name"`
-	URL           string     `json:"url,omitempty"`
-	Visibility    string     `json:"visibility,omitempty"`
-	Private       bool       `json:"private"`
-	Archived      bool       `json:"archived"`
-	Fork          bool       `json:"fork"`
-	DefaultBranch string     `json:"default_branch,omitempty"`
-	CreatedAt     time.Time  `json:"created_at"`
-	UpdatedAt     time.Time  `json:"updated_at"`
-	PushedAt      *time.Time `json:"pushed_at,omitempty"`
+	ID                               int64      `json:"id,omitempty"`
+	OwnerLogin                       string     `json:"owner_login"`
+	Name                             string     `json:"name"`
+	FullName                         string     `json:"full_name"`
+	URL                              string     `json:"url,omitempty"`
+	Visibility                       string     `json:"visibility,omitempty"`
+	Private                          bool       `json:"private"`
+	Archived                         bool       `json:"archived"`
+	Fork                             bool       `json:"fork"`
+	DefaultBranch                    string     `json:"default_branch,omitempty"`
+	CreatedAt                        time.Time  `json:"created_at"`
+	UpdatedAt                        time.Time  `json:"updated_at"`
+	PushedAt                         *time.Time `json:"pushed_at,omitempty"`
+	SecretScanningEnabled            string     `json:"secret_scanning_enabled,omitempty"`
+	SecretScanningPushProtection     string     `json:"secret_scanning_push_protection,omitempty"`
+	DependabotSecurityUpdatesEnabled string     `json:"dependabot_security_updates_enabled,omitempty"`
 }
 
 // New constructs the live GitHub source.
@@ -794,25 +797,56 @@ func repositoryEvent(settings settings, repo *gogithub.Repository) (*primitives.
 	if repo.GetID() != 0 {
 		repoID = strconv.FormatInt(repo.GetID(), 10)
 	}
+	secretScanning, pushProtection, dependabotUpdates := repoSecurityAnalysis(repo)
 	payloadBytes, err := json.Marshal(repositoryPayload{
-		ID:            repo.GetID(),
-		OwnerLogin:    ownerLogin,
-		Name:          repo.GetName(),
-		FullName:      fullName,
-		URL:           repo.GetHTMLURL(),
-		Visibility:    repo.GetVisibility(),
-		Private:       repo.GetPrivate(),
-		Archived:      repo.GetArchived(),
-		Fork:          repo.GetFork(),
-		DefaultBranch: repo.GetDefaultBranch(),
-		CreatedAt:     createdAt,
-		UpdatedAt:     occurredAt,
-		PushedAt:      timestamp(repo.PushedAt),
+		ID:                               repo.GetID(),
+		OwnerLogin:                       ownerLogin,
+		Name:                             repo.GetName(),
+		FullName:                         fullName,
+		URL:                              repo.GetHTMLURL(),
+		Visibility:                       repo.GetVisibility(),
+		Private:                          repo.GetPrivate(),
+		Archived:                         repo.GetArchived(),
+		Fork:                             repo.GetFork(),
+		DefaultBranch:                    repo.GetDefaultBranch(),
+		CreatedAt:                        createdAt,
+		UpdatedAt:                        occurredAt,
+		PushedAt:                         timestamp(repo.PushedAt),
+		SecretScanningEnabled:            secretScanning,
+		SecretScanningPushProtection:     pushProtection,
+		DependabotSecurityUpdatesEnabled: dependabotUpdates,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal github repository payload: %w", err)
 	}
 	resourceID := firstNonEmptyString(repoID, fullName)
+	attrs := map[string]string{
+		"archived":       strconv.FormatBool(repo.GetArchived()),
+		"default_branch": repo.GetDefaultBranch(),
+		"fork":           strconv.FormatBool(repo.GetFork()),
+		"full_name":      fullName,
+		"html_url":       repo.GetHTMLURL(),
+		"name":           repo.GetName(),
+		"owner":          settings.owner,
+		"owner_login":    ownerLogin,
+		"private":        strconv.FormatBool(repo.GetPrivate()),
+		"repo":           repo.GetName(),
+		"repo_id":        repoID,
+		"repository":     fullName,
+		"resource_id":    resourceID,
+		"resource_name":  fullName,
+		"resource_type":  "code_repository",
+		"visibility":     repo.GetVisibility(),
+	}
+	if secretScanning != "" {
+		attrs["secret_scanning"] = secretScanning
+	}
+	if pushProtection != "" {
+		attrs["secret_scanning_push_protection"] = pushProtection
+	}
+	if dependabotUpdates != "" {
+		attrs["dependabot_security_updates"] = dependabotUpdates
+	}
 	return &primitives.Event{
 		Id:         fmt.Sprintf("github-code-repository-%s-%d", normalizeRepositoryEventID(resourceID), occurredAt.Unix()),
 		TenantId:   settings.owner,
@@ -821,25 +855,28 @@ func repositoryEvent(settings settings, repo *gogithub.Repository) (*primitives.
 		OccurredAt: timestamppb.New(occurredAt.UTC()),
 		SchemaRef:  "github/code_repository/v1",
 		Payload:    payloadBytes,
-		Attributes: map[string]string{
-			"archived":       strconv.FormatBool(repo.GetArchived()),
-			"default_branch": repo.GetDefaultBranch(),
-			"fork":           strconv.FormatBool(repo.GetFork()),
-			"full_name":      fullName,
-			"html_url":       repo.GetHTMLURL(),
-			"name":           repo.GetName(),
-			"owner":          settings.owner,
-			"owner_login":    ownerLogin,
-			"private":        strconv.FormatBool(repo.GetPrivate()),
-			"repo":           repo.GetName(),
-			"repo_id":        repoID,
-			"repository":     fullName,
-			"resource_id":    resourceID,
-			"resource_name":  fullName,
-			"resource_type":  "code_repository",
-			"visibility":     repo.GetVisibility(),
-		},
+		Attributes: attrs,
 	}, nil
+}
+
+func repoSecurityAnalysis(repo *gogithub.Repository) (secretScanning, pushProtection, dependabotUpdates string) {
+	if repo == nil {
+		return "", "", ""
+	}
+	sa := repo.GetSecurityAndAnalysis()
+	if sa == nil {
+		return "", "", ""
+	}
+	if ss := sa.GetSecretScanning(); ss != nil {
+		secretScanning = ss.GetStatus()
+	}
+	if pp := sa.GetSecretScanningPushProtection(); pp != nil {
+		pushProtection = pp.GetStatus()
+	}
+	if du := sa.GetDependabotSecurityUpdates(); du != nil {
+		dependabotUpdates = du.GetStatus()
+	}
+	return secretScanning, pushProtection, dependabotUpdates
 }
 
 func repositoryOwnerLogin(fallback string, repo *gogithub.Repository) string {

--- a/sources/okta/policy_rule.go
+++ b/sources/okta/policy_rule.go
@@ -380,7 +380,82 @@ func policyRuleAttributes(settings settings, entry policyRuleEntry) map[string]s
 	} else if entry.Policy.System != nil {
 		attributes["system"] = boolString(*entry.Policy.System)
 	}
+	policyRuleActionsAttributes(entry.Rule.raw, attributes)
+	policyRuleConditionsAttributes(entry.Rule.raw, attributes)
 	return attributes
+}
+
+func policyRuleActionsAttributes(raw json.RawMessage, attrs map[string]string) {
+	var rule struct {
+		Actions struct {
+			Signon struct {
+				Access        string `json:"access"`
+				RequireFactor bool   `json:"requireFactor"`
+				FactorPrompt  string `json:"factorPromptMode"`
+				FactorLife    int    `json:"factorLifetime"`
+				Session       struct {
+					UsePersistent bool `json:"usePersistentCookie"`
+					MaxLifetime   int  `json:"maxSessionLifetimeMinutes"`
+					Idle          int  `json:"maxSessionIdleMinutes"`
+				} `json:"session"`
+			} `json:"signon"`
+			AppSignOn struct {
+				Access string `json:"access"`
+			} `json:"appSignOn"`
+		} `json:"actions"`
+	}
+	if err := json.Unmarshal(raw, &rule); err != nil {
+		return
+	}
+	a := rule.Actions
+	if a.Signon.Access != "" {
+		attrs["access"] = strings.ToUpper(a.Signon.Access)
+		attrs["requires_mfa"] = boolString(a.Signon.RequireFactor)
+		if a.Signon.FactorPrompt != "" {
+			attrs["mfa_prompt"] = strings.ToUpper(a.Signon.FactorPrompt)
+		}
+		if a.Signon.FactorLife > 0 {
+			attrs["mfa_lifetime_minutes"] = strconv.Itoa(a.Signon.FactorLife)
+		}
+		if a.Signon.Session.MaxLifetime > 0 {
+			attrs["session_max_lifetime_minutes"] = strconv.Itoa(a.Signon.Session.MaxLifetime)
+		}
+		if a.Signon.Session.Idle > 0 {
+			attrs["session_idle_minutes"] = strconv.Itoa(a.Signon.Session.Idle)
+		}
+		attrs["session_persistent"] = boolString(a.Signon.Session.UsePersistent)
+	}
+	if a.AppSignOn.Access != "" {
+		attrs["access"] = strings.ToUpper(a.AppSignOn.Access)
+	}
+}
+
+func policyRuleConditionsAttributes(raw json.RawMessage, attrs map[string]string) {
+	var rule struct {
+		Conditions struct {
+			Network struct {
+				Connection string `json:"connection"`
+			} `json:"network"`
+			Risk struct {
+				Level string `json:"level"`
+			} `json:"risk"`
+			Platform struct {
+				Include []struct {
+					Type string `json:"type"`
+				} `json:"include"`
+			} `json:"platform"`
+		} `json:"conditions"`
+	}
+	if err := json.Unmarshal(raw, &rule); err != nil {
+		return
+	}
+	c := rule.Conditions
+	if c.Network.Connection != "" {
+		attrs["network_connection"] = strings.ToUpper(c.Network.Connection)
+	}
+	if c.Risk.Level != "" {
+		attrs["risk_level"] = strings.ToUpper(c.Risk.Level)
+	}
 }
 
 func policyRuleURN(settings settings, policy policyRecord, rule policyRuleRecord) string {

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -132,6 +133,8 @@ type userFactorRecord struct {
 type userMFASummary struct {
 	known             bool
 	activeFactorCount int
+	factorTypes       []string
+	phishingResistant bool
 }
 
 type groupRecord struct {
@@ -819,12 +822,19 @@ func (s *Source) userMFASummary(ctx context.Context, settings settings, userID s
 		return userMFASummary{}, fmt.Errorf("list okta user %q factors: %w", userID, err)
 	}
 	activeCount := 0
+	var factorTypes []string
+	phishingResistant := false
 	for _, factor := range factors {
 		if oktaMFAFactorEnrolled(factor) {
 			activeCount++
+			kind := strings.ToLower(strings.TrimSpace(firstNonEmpty(factor.Kind, factor.FactorType)))
+			factorTypes = append(factorTypes, kind)
+			if kind == "webauthn" || kind == "u2f" || kind == "signed_nonce" {
+				phishingResistant = true
+			}
 		}
 	}
-	return userMFASummary{known: true, activeFactorCount: activeCount}, nil
+	return userMFASummary{known: true, activeFactorCount: activeCount, factorTypes: factorTypes, phishingResistant: phishingResistant}, nil
 }
 
 func (s *Source) listGroups(ctx context.Context, settings settings, after string, limit int) ([]groupRecord, string, error) {
@@ -1402,6 +1412,11 @@ func userAttributes(settings settings, record userRecord) map[string]string {
 	if record.mfa.known {
 		attributes["mfa_enrolled"] = boolString(record.mfa.activeFactorCount > 0)
 		attributes["mfa_factor_count"] = strconv.Itoa(record.mfa.activeFactorCount)
+		if len(record.mfa.factorTypes) > 0 {
+			sort.Strings(record.mfa.factorTypes)
+			attributes["mfa_factor_types"] = strings.Join(record.mfa.factorTypes, ",")
+		}
+		attributes["mfa_phishing_resistant"] = boolString(record.mfa.phishingResistant)
 	}
 	addAttribute(attributes, "email", stringMap(record.Profile, "email"))
 	addAttribute(attributes, "login", stringMap(record.Profile, "login"))


### PR DESCRIPTION
## Summary

Extract security-relevant data already returned by existing API calls -- zero additional API requests required.

### GitHub Repository (`github.code.repository`)
- `secret_scanning` status (enabled/disabled)
- `secret_scanning_push_protection` status
- `dependabot_security_updates` status

These fields come from the `SecurityAndAnalysis` struct already present in the go-github `Repository` response but previously not extracted.

### Okta User MFA (`okta.user`)
- `mfa_factor_types` -- comma-separated list of enrolled factor kinds (e.g. `push,sms,webauthn`)
- `mfa_phishing_resistant` -- true if user has webauthn/u2f/signed_nonce enrolled

Previously only `mfa_enrolled` (bool) and `mfa_factor_count` (int) were surfaced; factor quality information was discarded after counting.

### Okta Policy Rule (`okta.policy_rule`)
- `access` -- ALLOW/DENY action
- `requires_mfa` -- whether the rule requires MFA
- `mfa_prompt` -- ALWAYS/DEVICE/SESSION factor prompt mode
- `mfa_lifetime_minutes` -- how long MFA is remembered
- `session_max_lifetime_minutes`, `session_idle_minutes`, `session_persistent` -- session settings
- `network_connection` -- network condition (ANY/ZONE/ON_NETWORK)
- `risk_level` -- risk-based condition

These fields were already in the raw JSON payload but not parsed into typed attributes.

### Projections
All new attributes flow through to their respective graph entity projections (`github.code.repository`, `okta.user`, `okta.policy_rule`).

### Verification
`make verify` passes (build, all tests, lint, catalog check, detection catalog, OSS audit).