### PR TITLE
feat(leak-check): scan PR titles and bodies for tenant data

### DIFF
--- a/.github/workflows/leak-check.yml
+++ b/.github/workflows/leak-check.yml
@@ -67,9 +67,18 @@ jobs:
           echo "range=${range}"
           echo "range=${range}" >> "$GITHUB_OUTPUT"
 
-      - name: Run leak check
+      - name: Run leak check (commits)
         env:
           RANGE: ${{ steps.range.outputs.range }}
         run: |
           set -euo pipefail
           ./scripts/leak_check.sh range "$RANGE"
+
+      - name: Run leak check (PR metadata)
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          ./scripts/leak_check.sh pr-body "$PR_TITLE" "$PR_BODY"

--- a/scripts/leak_check.sh
+++ b/scripts/leak_check.sh
@@ -11,6 +11,8 @@
 #   range <base..head>     scan a git revision range (used by CI; range may
 #                          be passed as a single positional argument or via
 #                          $LEAK_CHECK_BASE_REF and $LEAK_CHECK_HEAD_REF)
+#   pr-body <title> <body> scan a PR title and body (also reads PR_TITLE /
+#                          PR_BODY from the environment when args are empty)
 #
 # Bypass: set CEREBRO_LEAK_CHECK_BYPASS=1 to skip the check. Bypasses are
 # logged so they show up in shell history and CI logs.
@@ -212,8 +214,33 @@ ${commits_diff}"
     fi
     ;;
 
+  pr-body)
+    # Scans a PR title and body supplied via environment variables or
+    # positional arguments: pr-body <title> <body>
+    # Can also read PR_TITLE / PR_BODY from the environment.
+    pr_title="${1:-${PR_TITLE:-}}"
+    pr_body="${2:-${PR_BODY:-}}"
+    shift 2 2>/dev/null || true
+    pr_content="${pr_title}
+${pr_body}"
+    if [ -z "$(printf '%s' "$pr_content" | tr -d '[:space:]')" ]; then
+      exit 0
+    fi
+    if ! scan_input "<pr-body>" "$pr_content"; then
+      cat >&2 <<'EOF'
+
+leak-check: tenant data pattern matched in PR title or body.
+
+  - Review the matches above.
+  - Rewrite the PR description to remove tenant-specific data.
+  - See AGENTS.md "Public PR Data Safety" for guidance.
+EOF
+      exit 1
+    fi
+    ;;
+
   *)
-    echo "leak-check: unknown mode '$mode' (expected: staged | commit-msg | pushed | range)" >&2
+    echo "leak-check: unknown mode '$mode' (expected: staged | commit-msg | pushed | range | pr-body)" >&2
     exit 1
     ;;
 esac

--- a/scripts/leak_patterns.txt
+++ b/scripts/leak_patterns.txt
@@ -45,3 +45,9 @@
 
 # ---- Generic secret-style key/value (broad; tighten if noisy) ----
 (?i)\b(aws_secret_access_key|api[_-]?key|access[_-]?token|bearer)\b[[:space:]]*[:=][[:space:]]*['\"][A-Za-z0-9/_+=.\-]{20,}['\"]
+
+# ---- Tenant runtime data shapes ----
+# Tenant-specific patterns (domains, account IDs, runtime IDs) belong
+# in the user-local file at $HOME/.config/cerebro/leak_patterns.txt
+# (see scripts/leak_patterns.user.example.txt). The patterns below
+# only cover structural shapes that are safe for a public repo.

--- a/scripts/leak_patterns.user.example.txt
+++ b/scripts/leak_patterns.user.example.txt
@@ -32,8 +32,17 @@
 # \.mycompany-internal\.example\b
 # \bcerebro\.(dev|stg|prod)\.[a-z0-9.-]+\b
 
+# ---- IdP domain examples ----
+# \bmycompany\.okta\.com\b
+# \b[a-z][a-z0-9_-]+\.okta\.com\b
+
 # ---- Runtime ID examples ----
-# \bmycompany-(okta|github|sentinelone)-(audit|signal|graph)\b
+# Okta runtime IDs (00 + single lowercase letter + 17+ alphanum)
+# \b00[a-z][A-Za-z0-9]{17,}\b
+# Cerebro URNs
+# \burn:cerebro:[^\s]+
+# Infisical workspace IDs
+# [Ii]nfisical.*[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
 
 # ---- Cloud account ID examples (12-digit AWS account number) ----
 # \b000000000000\b


### PR DESCRIPTION
## Summary

Extends the existing leak check infrastructure to cover PR metadata, closing the gap where tenant data could leak through `gh pr create --body` bypassing all git hooks.

### Changes

**`scripts/leak_check.sh`** -- new `pr-body` mode that scans PR title and body text against the same pattern set used for staged content and commit messages. Prints redacted matches and exits non-zero on hit.

**`.github/workflows/leak-check.yml`** -- adds a PR metadata scan step that runs on `pull_request` events, feeding the PR title and body from the GitHub event payload into the new `pr-body` mode.

**`scripts/leak_patterns.user.example.txt`** -- updated with additional pattern examples for IdP domains, runtime IDs, URNs, and workspace IDs to help contributors set up their local denylist.

### Verification
`make verify` passes. Tested the new mode against synthetic samples: clean bodies pass, bodies containing IdP domains / runtime IDs / URNs are caught and redacted.