### PR TITLE
feat: add OpenRouter LLM provider for graph agent

### DIFF
--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -41,14 +41,18 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 	llm := a.deps.GraphAgentLLM
 	if llm == nil {
 		var err error
-		llm, err = graphagent.NewLLMClient(r.Context(), graphagent.LLMConfig{
-			Provider:    a.cfg.GraphAgentLLM.Provider,
-			Model:       a.cfg.GraphAgentLLM.Model,
-			SonnetModel: a.cfg.GraphAgentLLM.SonnetModel,
-			OpusModel:   a.cfg.GraphAgentLLM.OpusModel,
-			HaikuModel:  a.cfg.GraphAgentLLM.HaikuModel,
-			MaxTokens:   a.cfg.GraphAgentLLM.MaxTokens,
-			Temperature: a.cfg.GraphAgentLLM.Temperature,
+		llm, err = graphagent.NewLLMClientWithSecrets(r.Context(), graphagent.LLMConfigWithSecrets{
+			LLMConfig: graphagent.LLMConfig{
+				Provider:    a.cfg.GraphAgentLLM.Provider,
+				Model:       a.cfg.GraphAgentLLM.Model,
+				SonnetModel: a.cfg.GraphAgentLLM.SonnetModel,
+				OpusModel:   a.cfg.GraphAgentLLM.OpusModel,
+				HaikuModel:  a.cfg.GraphAgentLLM.HaikuModel,
+				MaxTokens:   a.cfg.GraphAgentLLM.MaxTokens,
+				Temperature: a.cfg.GraphAgentLLM.Temperature,
+			},
+			OpenRouterAPIKey: a.cfg.GraphAgentLLM.OpenRouterAPIKey,
+			HTTPDoer:         NewHTTPDoer(),
 		})
 		if err != nil {
 			writeGRCError(w, err)

--- a/internal/bootstrap/http_doer.go
+++ b/internal/bootstrap/http_doer.go
@@ -1,0 +1,39 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/writer/cerebro/internal/graphagent"
+)
+
+type stdHTTPDoer struct {
+	client *http.Client
+}
+
+func NewHTTPDoer() graphagent.HTTPDoer {
+	return &stdHTTPDoer{client: &http.Client{Timeout: 60 * time.Second}}
+}
+
+func (d *stdHTTPDoer) Post(ctx context.Context, url string, headers map[string]string, body []byte) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	return resp.StatusCode, respBody, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,13 +59,14 @@ type GraphStoreConfig struct {
 
 // GraphAgentLLMConfig selects and configures the graph ask LLM adapter.
 type GraphAgentLLMConfig struct {
-	Provider    string
-	Model       string
-	SonnetModel string
-	OpusModel   string
-	HaikuModel  string
-	MaxTokens   int
-	Temperature float64
+	Provider         string
+	Model            string
+	SonnetModel      string
+	OpusModel        string
+	HaikuModel       string
+	MaxTokens        int
+	Temperature      float64
+	OpenRouterAPIKey string
 }
 
 // APIKey grants one bearer token access to the bootstrap API.
@@ -224,6 +225,7 @@ func Load() (Config, error) {
 	if cfg.GraphAgentLLM.Temperature, err = parseFloatEnv("CEREBRO_GRAPH_AGENT_LLM_TEMPERATURE", 0); err != nil {
 		return Config{}, err
 	}
+	cfg.GraphAgentLLM.OpenRouterAPIKey = strings.TrimSpace(os.Getenv("CEREBRO_OPENROUTER_API_KEY"))
 	if raw, ok := os.LookupEnv("CEREBRO_SHUTDOWN_TIMEOUT"); ok && strings.TrimSpace(raw) != "" {
 		duration, err := time.ParseDuration(strings.TrimSpace(raw))
 		if err != nil {

--- a/internal/graphagent/llm.go
+++ b/internal/graphagent/llm.go
@@ -55,7 +55,17 @@ type LLMConfig struct {
 	Temperature float64
 }
 
+type LLMConfigWithSecrets struct {
+	LLMConfig
+	OpenRouterAPIKey string
+	HTTPDoer         HTTPDoer
+}
+
 func NewLLMClient(ctx context.Context, cfg LLMConfig) (LLMClient, error) {
+	return NewLLMClientWithSecrets(ctx, LLMConfigWithSecrets{LLMConfig: cfg})
+}
+
+func NewLLMClientWithSecrets(ctx context.Context, cfg LLMConfigWithSecrets) (LLMClient, error) {
 	provider := strings.ToLower(strings.TrimSpace(cfg.Provider))
 	if provider == "" {
 		provider = "bedrock"
@@ -65,6 +75,17 @@ func NewLLMClient(ctx context.Context, cfg LLMConfig) (LLMClient, error) {
 		return NewStubLLMClient(), nil
 	case "bedrock":
 		return NewBedrockLLMClient(ctx, BedrockConfig{
+			DefaultModel: cfg.Model,
+			SonnetModel:  cfg.SonnetModel,
+			OpusModel:    cfg.OpusModel,
+			HaikuModel:   cfg.HaikuModel,
+			MaxTokens:    cfg.MaxTokens,
+			Temperature:  cfg.Temperature,
+		})
+	case "openrouter":
+		return NewOpenRouterLLMClient(OpenRouterConfig{
+			APIKey:       cfg.OpenRouterAPIKey,
+			HTTPDoer:     cfg.HTTPDoer,
 			DefaultModel: cfg.Model,
 			SonnetModel:  cfg.SonnetModel,
 			OpusModel:    cfg.OpusModel,

--- a/internal/graphagent/llm_openrouter.go
+++ b/internal/graphagent/llm_openrouter.go
@@ -1,0 +1,161 @@
+package graphagent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const openRouterBaseURL = "https://openrouter.ai/api/v1/chat/completions"
+
+// HTTPDoer abstracts HTTP POST so graphagent stays outside the net/http boundary.
+type HTTPDoer interface {
+	Post(ctx context.Context, url string, headers map[string]string, body []byte) (statusCode int, respBody []byte, err error)
+}
+
+type OpenRouterLLMClient struct {
+	apiKey       string
+	httpDoer     HTTPDoer
+	defaultModel string
+	sonnetModel  string
+	opusModel    string
+	haikuModel   string
+	maxTokens    int
+	temperature  float64
+}
+
+type OpenRouterConfig struct {
+	APIKey       string
+	HTTPDoer     HTTPDoer
+	DefaultModel string
+	SonnetModel  string
+	OpusModel    string
+	HaikuModel   string
+	MaxTokens    int
+	Temperature  float64
+}
+
+func NewOpenRouterLLMClient(cfg OpenRouterConfig) (*OpenRouterLLMClient, error) {
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return nil, fmt.Errorf("%w: CEREBRO_OPENROUTER_API_KEY is required for the openrouter LLM provider", ErrRuntimeUnavailable)
+	}
+	if cfg.HTTPDoer == nil {
+		return nil, fmt.Errorf("%w: HTTPDoer is required for the openrouter LLM provider", ErrRuntimeUnavailable)
+	}
+	if cfg.DefaultModel == "" {
+		cfg.DefaultModel = "anthropic/claude-sonnet-4-20250514"
+	}
+	if cfg.MaxTokens <= 0 {
+		cfg.MaxTokens = 1200
+	}
+	return &OpenRouterLLMClient{
+		apiKey:       strings.TrimSpace(cfg.APIKey),
+		httpDoer:     cfg.HTTPDoer,
+		defaultModel: strings.TrimSpace(cfg.DefaultModel),
+		sonnetModel:  strings.TrimSpace(cfg.SonnetModel),
+		opusModel:    strings.TrimSpace(cfg.OpusModel),
+		haikuModel:   strings.TrimSpace(cfg.HaikuModel),
+		maxTokens:    cfg.MaxTokens,
+		temperature:  cfg.Temperature,
+	}, nil
+}
+
+func (c *OpenRouterLLMClient) DraftCypher(ctx context.Context, req DraftRequest) (*DraftResponse, error) {
+	prompt := draftPrompt(req)
+	text, err := c.chat(ctx, c.modelID(req.Model), prompt, c.maxTokens)
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Rationale string  `json:"rationale"`
+		Cypher    *string `json:"cypher"`
+		Refusal   string  `json:"refusal"`
+	}
+	if err := json.Unmarshal(extractJSONObject(text), &payload); err != nil {
+		return nil, fmt.Errorf("parse draft response JSON: %w", err)
+	}
+	response := &DraftResponse{Rationale: strings.TrimSpace(payload.Rationale), Refusal: strings.TrimSpace(payload.Refusal)}
+	if payload.Cypher != nil {
+		response.Cypher = strings.TrimSpace(*payload.Cypher)
+	}
+	return response, nil
+}
+
+func (c *OpenRouterLLMClient) Summarize(ctx context.Context, req SummarizeRequest) (string, error) {
+	return c.chat(ctx, c.modelID(req.Model), summarizePrompt(req), c.maxTokens)
+}
+
+func (c *OpenRouterLLMClient) modelID(requested string) string {
+	switch normalizeModel(requested) {
+	case "claude-sonnet-4-6":
+		return firstNonEmpty(c.sonnetModel, c.defaultModel)
+	case "claude-opus-4-7":
+		return firstNonEmpty(c.opusModel, c.defaultModel)
+	case "claude-haiku-4-5-20251001":
+		return firstNonEmpty(c.haikuModel, c.defaultModel)
+	default:
+		if strings.TrimSpace(requested) != "" {
+			return strings.TrimSpace(requested)
+		}
+		return c.defaultModel
+	}
+}
+
+func (c *OpenRouterLLMClient) chat(ctx context.Context, model string, prompt string, maxTokens int) (string, error) {
+	body := map[string]any{
+		"model":       model,
+		"max_tokens":  maxTokens,
+		"temperature": c.temperature,
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": prompt,
+		}},
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+
+	headers := map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer " + c.apiKey,
+		"HTTP-Referer":  "https://cerebro.writer.com",
+		"X-Title":       "Cerebro Graph Agent",
+	}
+	statusCode, respBody, err := c.httpDoer.Post(ctx, openRouterBaseURL, headers, payload)
+	if err != nil {
+		return "", fmt.Errorf("openrouter request failed: %w", err)
+	}
+	if statusCode != 200 {
+		return "", fmt.Errorf("openrouter returned %d: %s", statusCode, truncateStr(string(respBody), 200))
+	}
+
+	var result struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("parse openrouter response: %w", err)
+	}
+	if result.Error != nil && result.Error.Message != "" {
+		return "", fmt.Errorf("openrouter error: %s", result.Error.Message)
+	}
+	if len(result.Choices) == 0 || strings.TrimSpace(result.Choices[0].Message.Content) == "" {
+		return "", fmt.Errorf("openrouter response contained no text")
+	}
+	return strings.TrimSpace(result.Choices[0].Message.Content), nil
+}
+
+func truncateStr(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/graphagent/llm_openrouter_test.go
+++ b/internal/graphagent/llm_openrouter_test.go
@@ -1,0 +1,147 @@
+package graphagent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type stubHTTPDoer struct {
+	statusCode  int
+	body        []byte
+	err         error
+	lastURL     string
+	lastHeaders map[string]string
+}
+
+func (s *stubHTTPDoer) Post(_ context.Context, url string, headers map[string]string, _ []byte) (int, []byte, error) {
+	s.lastURL = url
+	s.lastHeaders = headers
+	return s.statusCode, s.body, s.err
+}
+
+func TestNewOpenRouterLLMClient_MissingAPIKey(t *testing.T) {
+	_, err := NewOpenRouterLLMClient(OpenRouterConfig{HTTPDoer: &stubHTTPDoer{}})
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+	if !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("expected ErrRuntimeUnavailable, got: %v", err)
+	}
+}
+
+func TestNewOpenRouterLLMClient_MissingHTTPDoer(t *testing.T) {
+	_, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: "test-key"})
+	if err == nil {
+		t.Fatal("expected error for missing HTTPDoer")
+	}
+	if !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("expected ErrRuntimeUnavailable, got: %v", err)
+	}
+}
+
+func TestOpenRouterLLMClient_DraftCypher(t *testing.T) {
+	respBody, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{{
+			"message": map[string]string{
+				"content": `{"rationale":"test rationale","cypher":"MATCH (n) RETURN n LIMIT 5","refusal":""}`,
+			},
+		}},
+	})
+	doer := &stubHTTPDoer{statusCode: 200, body: respBody}
+
+	client, err := NewOpenRouterLLMClient(OpenRouterConfig{
+		APIKey:    "test-key",
+		HTTPDoer:  doer,
+		MaxTokens: 100,
+	})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	resp, err := client.DraftCypher(context.Background(), DraftRequest{
+		TenantID: "test",
+		Question: "Show all nodes",
+		Model:    "claude-sonnet-4-6",
+	})
+	if err != nil {
+		t.Fatalf("draft cypher: %v", err)
+	}
+	if resp.Rationale != "test rationale" {
+		t.Errorf("expected 'test rationale', got %q", resp.Rationale)
+	}
+	if resp.Cypher != "MATCH (n) RETURN n LIMIT 5" {
+		t.Errorf("unexpected cypher: %q", resp.Cypher)
+	}
+	if doer.lastHeaders["Authorization"] != "Bearer test-key" {
+		t.Errorf("expected Bearer test-key, got %s", doer.lastHeaders["Authorization"])
+	}
+	if doer.lastURL != openRouterBaseURL {
+		t.Errorf("expected URL %s, got %s", openRouterBaseURL, doer.lastURL)
+	}
+}
+
+func TestOpenRouterLLMClient_Summarize(t *testing.T) {
+	respBody, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{{
+			"message": map[string]string{
+				"content": "Summary of results.",
+			},
+		}},
+	})
+	doer := &stubHTTPDoer{statusCode: 200, body: respBody}
+
+	client, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: "test-key", HTTPDoer: doer})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	text, err := client.Summarize(context.Background(), SummarizeRequest{
+		TenantID: "test",
+		Question: "Show nodes",
+		Cypher:   "MATCH (n) RETURN n",
+		Rows:     []map[string]any{{"urn": "test"}},
+	})
+	if err != nil {
+		t.Fatalf("summarize: %v", err)
+	}
+	if text != "Summary of results." {
+		t.Errorf("unexpected summary: %q", text)
+	}
+}
+
+func TestOpenRouterLLMClient_ErrorResponse(t *testing.T) {
+	doer := &stubHTTPDoer{statusCode: 429, body: []byte(`{"error":{"message":"rate limited"}}`)}
+
+	client, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: "test-key", HTTPDoer: doer})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.DraftCypher(context.Background(), DraftRequest{
+		TenantID: "test",
+		Question: "Show nodes",
+	})
+	if err == nil {
+		t.Fatal("expected error for 429 response")
+	}
+}
+
+func TestOpenRouterLLMClient_HTTPDoerError(t *testing.T) {
+	doer := &stubHTTPDoer{err: fmt.Errorf("connection refused")}
+
+	client, err := NewOpenRouterLLMClient(OpenRouterConfig{APIKey: "test-key", HTTPDoer: doer})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	_, err = client.DraftCypher(context.Background(), DraftRequest{
+		TenantID: "test",
+		Question: "Show nodes",
+	})
+	if err == nil {
+		t.Fatal("expected error for connection failure")
+	}
+}


### PR DESCRIPTION
Adds OpenRouter (openrouter.ai) as an alternative LLM provider for Ask Cerebro, alongside Bedrock.

**Architecture**: Uses an `HTTPDoer` interface to keep `net/http` imports in the bootstrap boundary (satisfies `TestSourceCDKOwnsExternalHTTPClients`). The concrete HTTP adapter is injected from `bootstrap/http_doer.go`.

**Config**: Set `CEREBRO_GRAPH_AGENT_LLM_PROVIDER=openrouter` and `CEREBRO_OPENROUTER_API_KEY=<key>` to switch from Bedrock.

**Tests**: 5 unit tests covering DraftCypher, Summarize, HTTP errors, missing API key, and missing HTTPDoer.