### PR TITLE
fix: link findings to primary resource in graph projection

### DIFF
--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -418,7 +418,7 @@ func (s *Service) ensureFindingActiveLinks(ctx context.Context, finding workflow
 	tenantID := strings.TrimSpace(finding.TenantID)
 	sourceID := strings.TrimSpace(finding.SourceSystem)
 	anchorURN := findingURN(tenantID, finding.FindingID)
-	resourceURNs := normalizeIDs(finding.ResourceURNs)
+	resourceURNs := findingResourceURNs(finding)
 	for _, resourceURN := range resourceURNs {
 		if err := s.upsertLink(ctx, &ports.ProjectedLink{
 			TenantID:   tenantID,
@@ -513,7 +513,7 @@ func (s *Service) deleteFindingActiveLinks(ctx context.Context, finding workflow
 	sourceID := strings.TrimSpace(finding.SourceSystem)
 	anchorURN := findingURN(tenantID, finding.FindingID)
 	var deleted uint32
-	for _, resourceURN := range normalizeIDs(finding.ResourceURNs) {
+	for _, resourceURN := range findingResourceURNs(finding) {
 		if err := deleter.DeleteProjectedLink(ctx, &ports.ProjectedLink{
 			TenantID: tenantID,
 			SourceID: sourceID,
@@ -529,7 +529,11 @@ func (s *Service) deleteFindingActiveLinks(ctx context.Context, finding workflow
 }
 
 func findingTargetURNs(finding workflowevents.FindingSnapshot) []string {
-	return normalizeIDs(append(normalizeIDs(finding.ResourceURNs), findingURN(strings.TrimSpace(finding.TenantID), finding.FindingID)))
+	return normalizeIDs(append(findingResourceURNs(finding), findingURN(strings.TrimSpace(finding.TenantID), finding.FindingID)))
+}
+
+func findingResourceURNs(finding workflowevents.FindingSnapshot) []string {
+	return normalizeIDs(append([]string{strings.TrimSpace(finding.PrimaryResourceURN)}, finding.ResourceURNs...))
 }
 
 func (s *Service) upsertEntity(ctx context.Context, entity *ports.ProjectedEntity, result *ports.ProjectionResult) error {

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -410,6 +410,56 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	}
 }
 
+func TestProjectFindingRecordedLinksPrimaryResourceWhenResourceURNsEmpty(t *testing.T) {
+	graph := &projectionRecorder{}
+	service := New(graph)
+	finding := workflowevents.FindingSnapshot{
+		TenantID:           "example",
+		SourceSystem:       "example-okta-audit",
+		FindingID:          "finding-primary-only",
+		Fingerprint:        "fp-primary-only",
+		Title:              "Identity API Token Or OAuth App Created",
+		Summary:            "OAuth credential was created",
+		RuleID:             "identity-api-token-or-oauth-app-created",
+		Severity:           "high",
+		Status:             "open",
+		PrimaryResourceURN: "urn:cerebro:example:okta_resource:oauth2clientsecretentity:secret-1",
+	}
+	recordedEvent, err := workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
+		Finding:    finding,
+		RecordedAt: "2026-05-28T18:59:00Z",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingRecordedEvent() error = %v", err)
+	}
+	if _, err := service.Project(context.Background(), recordedEvent); err != nil {
+		t.Fatalf("Project(recorded) error = %v", err)
+	}
+	linkKey := "urn:cerebro:example:okta_resource:oauth2clientsecretentity:secret-1|has_finding|urn:cerebro:example:finding:finding-primary-only"
+	if _, ok := graph.links[linkKey]; !ok {
+		t.Fatalf("primary resource finding link %q missing", linkKey)
+	}
+
+	finding.Status = "resolved"
+	statusEvent, err := workflowevents.NewFindingStatusChangedEvent(workflowevents.FindingStatusChanged{
+		Finding:     finding,
+		Status:      "resolved",
+		Reason:      "manually resolved",
+		Source:      workflowevents.FindingStatusSourceManual,
+		UpdatedAt:   "2026-05-28T19:00:00Z",
+		OutcomeType: "finding-resolution",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingStatusChangedEvent() error = %v", err)
+	}
+	if _, err := service.Project(context.Background(), statusEvent); err != nil {
+		t.Fatalf("Project(status) error = %v", err)
+	}
+	if _, ok := graph.links[linkKey]; ok {
+		t.Fatalf("primary resource finding link %q should be removed after resolved status", linkKey)
+	}
+}
+
 func TestProjectFindingRecordedPrunesStaleActiveLinks(t *testing.T) {
 	graph := &projectionRecorder{}
 	service := New(graph)


### PR DESCRIPTION
Fixes graph integrity failures where open findings had `primary_resource_urn` set but no `has_finding` edge because `ResourceURNs` was empty.

Changes:
- Projection now treats `primary_resource_urn` as an active finding resource link.
- Link deletion uses the same primary-aware resource set.
- Regression test covers primary-only finding record and resolution.

Validation run:
- go test ./internal/workflowprojection ./internal/graphstore/neo4j -count=1
- make verify