### PR TITLE
fix: bound Aurelius ingest batch size

### DIFF
--- a/sources/aurelius/source.go
+++ b/sources/aurelius/source.go
@@ -47,7 +47,7 @@ const (
 	assumeRoleSessionName = "cerebro-aurelius-source"
 	maxObjectBytes        = 64 << 20
 	maxLineBytes          = 1 << 20
-	maxEventsPerPull      = 10000
+	maxEventsPerPull      = 1000
 	cursorSource          = "aurelius/s3-ndjson/v1"
 
 	familyVerdict          = "verdict"

--- a/sources/aurelius/source_test.go
+++ b/sources/aurelius/source_test.go
@@ -556,6 +556,9 @@ func TestReadResumesFromCursor(t *testing.T) {
 }
 
 func TestReadDoesNotAdvancePastPartiallyProcessedArchive(t *testing.T) {
+	if maxEventsPerPull > 1000 {
+		t.Fatalf("maxEventsPerPull = %d, want <= 1000 to keep graph ingest batches below the orchestrator phase timeout", maxEventsPerPull)
+	}
 	src, err := New()
 	if err != nil {
 		t.Fatalf("New() error = %v", err)


### PR DESCRIPTION
## Summary
- reduce Aurelius source events per pull from 10k to 1k so graph ingest checkpoints smaller batches before the orchestrator phase timeout
- add a regression guard on the batch cap while preserving partial-archive cursor behavior

## Validation
- go test ./sources/aurelius ./internal/graphingest ./cmd/cerebro
- make verify