### PR TITLE
feat: surface long-running progress

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -544,7 +544,7 @@ paths:
               $ref: '#/components/schemas/GRCAskRequest'
       responses:
         '200':
-          description: Server-sent graph answer events in rationale, cypher, rows, summary, done order.
+          description: Server-sent graph answer events. Successful streams emit progress, rationale, cypher, rows, summary, and done events; failures after streaming starts emit an error event.
           content:
             text/event-stream:
               schema:

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -380,12 +380,15 @@ func TestSourceRuntimeListJSONUsesProtoJSON(t *testing.T) {
 }
 
 func TestParseOrchestratorOptions(t *testing.T) {
-	options, err := parseOrchestratorOptions([]string{"tenant_id=writer", "source_id=github", "limit=2", "page_limit=3", "event_limit=4", "graph_page_limit=5"})
+	options, err := parseOrchestratorOptions([]string{"tenant_id=writer", "source_id=github", "limit=2", "page_limit=3", "event_limit=4", "graph_page_limit=5", "phase_timeout=10m", "graph_timeout=45m"})
 	if err != nil {
 		t.Fatalf("parseOrchestratorOptions() error = %v", err)
 	}
 	if options.Filter.TenantID != "writer" || options.Filter.SourceID != "github" || options.Filter.Limit != 2 || options.PageLimit != 3 || options.EventLimit != 4 || options.GraphPageLimit != 5 {
 		t.Fatalf("options = %#v", options)
+	}
+	if options.PhaseTimeout != 10*time.Minute || options.GraphTimeout != 45*time.Minute {
+		t.Fatalf("timeouts = %v/%v, want 10m/45m", options.PhaseTimeout, options.GraphTimeout)
 	}
 }
 

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -29,24 +29,18 @@ const defaultSourceRuntimeLeaseTTL = 30 * time.Minute
 const sourceRuntimeLeaseReleaseTimeout = 5 * time.Second
 const sourceRuntimeLeaseOverscanLimit = 100
 
-// orchestratorPhaseTimeout bounds each post-sync runtime phase
-// (`finding_rules`, `graph_ingest`, `graph_rules`) independently so a
-// single blocked downstream call (e.g. a Neo4j tx waiting on a row lock,
-// or a source.Read() retrying against an exhausted GitHub rate-limit
-// budget) cannot stall the orchestrator iteration indefinitely. The
-// limit is conservative: writer-org runs in production observe ~2.5 min
-// for all three phases combined, so 15 min/step leaves ~4× headroom for
-// slower tenants and concurrent contention while still cutting off
-// pathologically stuck runs well within the lease TTL. On timeout the
-// phase fails fast, the runtime lease releases, and the next iteration
-// retries from a clean context.
-const orchestratorPhaseTimeout = 15 * time.Minute
+const (
+	defaultOrchestratorPhaseTimeout       = 15 * time.Minute
+	defaultOrchestratorGraphIngestTimeout = 45 * time.Minute
+)
 
 type orchestratorOptions struct {
 	Filter         ports.SourceRuntimeFilter `json:"filter"`
 	PageLimit      uint32                    `json:"page_limit,omitempty"`
 	EventLimit     uint32                    `json:"event_limit,omitempty"`
 	GraphPageLimit uint32                    `json:"graph_page_limit,omitempty"`
+	PhaseTimeout   time.Duration             `json:"-"`
+	GraphTimeout   time.Duration             `json:"-"`
 	Interval       time.Duration             `json:"-"`
 	Iterations     uint32                    `json:"iterations"`
 	RunForever     bool                      `json:"run_forever,omitempty"`
@@ -87,7 +81,7 @@ type orchestratorRuntimeResult struct {
 
 func runOrchestrator(args []string) error {
 	if len(args) == 0 || args[0] != "run" {
-		return usageError(fmt.Sprintf("usage: %s orchestrator run [runtime_id=<runtime-id>] [tenant_id=<tenant-id>] [source_id=<source-id>] [limit=N] [page_limit=N] [event_limit=N] [graph_page_limit=N] [interval=30s] [iterations=N|forever]", os.Args[0]))
+		return usageError(fmt.Sprintf("usage: %s orchestrator run [runtime_id=<runtime-id>] [tenant_id=<tenant-id>] [source_id=<source-id>] [limit=N] [page_limit=N] [event_limit=N] [graph_page_limit=N] [phase_timeout=15m] [graph_timeout=45m] [interval=30s] [iterations=N|forever]", os.Args[0]))
 	}
 	options, err := parseOrchestratorOptions(args[1:])
 	if err != nil {
@@ -114,7 +108,11 @@ func orchestratorShutdownSignals() []os.Signal {
 }
 
 func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
-	options := orchestratorOptions{Iterations: defaultOrchestratorIterations}
+	options := orchestratorOptions{
+		Iterations:   defaultOrchestratorIterations,
+		PhaseTimeout: defaultOrchestratorPhaseTimeout,
+		GraphTimeout: defaultOrchestratorGraphIngestTimeout,
+	}
 	for _, arg := range args {
 		key, value, ok := strings.Cut(arg, "=")
 		if !ok {
@@ -154,6 +152,18 @@ func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
 				return orchestratorOptions{}, fmt.Errorf("parse graph_page_limit: %w", err)
 			}
 			options.GraphPageLimit = uint32(parsed)
+		case "phase_timeout":
+			parsed, err := parsePositiveDurationArg("phase_timeout", value)
+			if err != nil {
+				return orchestratorOptions{}, err
+			}
+			options.PhaseTimeout = parsed
+		case "graph_timeout", "graph_ingest_timeout":
+			parsed, err := parsePositiveDurationArg(key, value)
+			if err != nil {
+				return orchestratorOptions{}, err
+			}
+			options.GraphTimeout = parsed
 		case "interval":
 			parsed, err := time.ParseDuration(strings.TrimSpace(value))
 			if err != nil {
@@ -188,6 +198,17 @@ func parseOrchestratorOptions(args []string) (orchestratorOptions, error) {
 	return options, nil
 }
 
+func parsePositiveDurationArg(name string, value string) (time.Duration, error) {
+	parsed, err := time.ParseDuration(strings.TrimSpace(value))
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", name, err)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("%s must be positive", name)
+	}
+	return parsed, nil
+}
+
 func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (result *orchestratorResult, err error) {
 	ctx, span := telemetry.Start(ctx, "orchestrator.run", telemetry.Attrs(
 		telemetryField("runtime_id", options.Filter.RuntimeID),
@@ -197,6 +218,8 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		telemetryField("page_limit", options.PageLimit),
 		telemetryField("event_limit", options.EventLimit),
 		telemetryField("graph_page_limit", options.GraphPageLimit),
+		telemetryField("phase_timeout_ms", options.PhaseTimeout.Milliseconds()),
+		telemetryField("graph_timeout_ms", options.GraphTimeout.Milliseconds()),
 		telemetryField("iterations", options.Iterations),
 		telemetryField("run_forever", options.RunForever),
 	))
@@ -366,6 +389,8 @@ func runOrchestratorIteration(
 		telemetryField("tenant_id", options.Filter.TenantID),
 		telemetryField("source_id", options.Filter.SourceID),
 		telemetryField("limit", options.Filter.Limit),
+		telemetryField("phase_timeout_ms", options.PhaseTimeout.Milliseconds()),
+		telemetryField("graph_timeout_ms", options.GraphTimeout.Milliseconds()),
 	))
 	status := "failed"
 	spanAttributes := telemetry.Attrs()
@@ -468,20 +493,7 @@ func runOrchestratorIteration(
 		runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "effective_graph_page_limit", graphPageLimit)
 		runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reset_graph_checkpoint", resetGraphCheckpoint)
 		runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "reset_completed_graph_checkpoint", resetCompletedGraphCheckpoint)
-		// Each post-sync phase runs under its own telemetry span and a
-		// dedicated context timeout. Both are intentional: the span gives
-		// operators a span_end event per phase so a stall shows up as a
-		// missing span_end on the specific phase rather than an opaque
-		// silence between source_runtime.sync.span_end and
-		// orchestrator.runtime.span_end; the timeout lets a single
-		// pathologically blocked downstream (Neo4j row lock contention
-		// across concurrent runtimes writing the same tenant, or a
-		// source.Read() retry storm against an exhausted upstream rate
-		// limit) fail fast so the lease renews and the next iteration
-		// retries from a clean state. The phase contexts are derived
-		// from runtimeCtx (NOT ctx) so they inherit lease-renewal
-		// cancellation while still being independently bounded.
-		graphResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_ingest", iteration, runtime, orchestratorPhaseTimeout, func(phaseCtx context.Context) (*graphingest.RunResult, error) {
+		graphResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_ingest", iteration, runtime, options.GraphTimeout, func(phaseCtx context.Context) (*graphingest.RunResult, error) {
 			return graphService.RunRuntime(phaseCtx, graphingest.RuntimeRequest{
 				RuntimeID:                runtime.GetId(),
 				PageLimit:                graphPageLimit,
@@ -499,7 +511,7 @@ func runOrchestratorIteration(
 		} else {
 			runtimeResult.GraphIngest = "completed"
 		}
-		findingResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.finding_rules", iteration, runtime, orchestratorPhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateRulesResult, error) {
+		findingResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.finding_rules", iteration, runtime, options.PhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateRulesResult, error) {
 			return findingService.EvaluateSourceRuntimeRules(phaseCtx, findings.EvaluateRulesRequest{RuntimeID: runtime.GetId(), EventLimit: options.EventLimit})
 		})
 		if err != nil {
@@ -523,7 +535,7 @@ func runOrchestratorIteration(
 		// reached by source sync, even if a trailing PutIngestRun(completed) write
 		// failed. The graph is fresh enough for read-only rules at that point.
 		if graphIngestReadyForGraphRules(graphResult, syncResult.GetRuntime().GetNextCursor()) {
-			graphRulesResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_rules", iteration, runtime, orchestratorPhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateGraphRulesResult, error) {
+			graphRulesResult, err := runOrchestratorPhase(runtimeCtx, "orchestrator.graph_rules", iteration, runtime, options.PhaseTimeout, func(phaseCtx context.Context) (*findings.EvaluateGraphRulesResult, error) {
 				return findingService.EvaluateSourceRuntimeGraphRules(phaseCtx, findings.EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
 			})
 			runtimeSpanAttrs = applyGraphRuleCounters(runtimeResult, graphRulesResult, runtimeSpanAttrs)

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -56,6 +56,12 @@ func TestParseOrchestratorOptionsRejectsZeroLimit(t *testing.T) {
 	}
 }
 
+func TestParseOrchestratorOptionsRejectsNonPositiveTimeout(t *testing.T) {
+	if _, err := parseOrchestratorOptions([]string{"graph_timeout=0s"}); err == nil {
+		t.Fatal("parseOrchestratorOptions(graph_timeout=0s) error = nil, want error")
+	}
+}
+
 func TestParseOrchestratorOptionsAcceptsRuntimeID(t *testing.T) {
 	options, err := parseOrchestratorOptions([]string{"runtime_id=writer-okta-audit"})
 	if err != nil {

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -93,7 +93,7 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 	service := graphagent.NewService(graphStore, llm, graphagent.ValidatorOptions{Explain: true})
 	var eventCount int
 	streamStarted := false
-	if err := service.Stream(r.Context(), request, func(event graphagent.Event) error {
+	err := service.Stream(r.Context(), request, func(event graphagent.Event) error {
 		if !streamStarted {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Cache-Control", "no-cache, no-transform")
@@ -109,10 +109,29 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 			flusher.Flush()
 		}
 		return nil
-	}); err != nil && !streamStarted {
+	})
+	if err != nil && !streamStarted {
 		evt.failureStage = "stream"
 		evt.finish(r, w, started, http.StatusServiceUnavailable, err)
 		writeGRCError(w, err)
+		return
+	}
+	if err != nil {
+		evt.failureStage = "stream"
+		writeErr := graphagent.WriteSSEEvent(w, graphagent.Event{Name: graphagent.EventError, Data: graphagent.ErrorEvent{
+			Code:    "ask_failed",
+			Message: err.Error(),
+		}})
+		if writeErr == nil {
+			eventCount++
+			if flusher != nil {
+				flusher.Flush()
+			}
+		} else {
+			log.Printf("write grc ask SSE error event: %v", writeErr)
+		}
+		evt.sseEvents = eventCount
+		evt.finish(r, w, started, http.StatusOK, err)
 		return
 	}
 	evt.sseEvents = eventCount

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -55,7 +55,7 @@ LIMIT 25`,
 		t.Fatalf("content-type = %q, want text/event-stream", got)
 	}
 	events := readSSEEvents(t, resp)
-	want := []string{"rationale", "cypher", "rows", "summary", "done"}
+	want := []string{"progress", "rationale", "progress", "cypher", "progress", "rows", "progress", "summary", "done"}
 	if len(events) != len(want) {
 		t.Fatalf("events = %#v, want names %v", events, want)
 	}
@@ -100,8 +100,13 @@ func TestGRCAskDraftFailureReturnsServiceUnavailable(t *testing.T) {
 		t.Fatalf("POST /grc/ask error = %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d with streamed error event", resp.StatusCode, http.StatusOK)
+	}
+	events := readSSEEvents(t, resp)
+	assertSSEEventNames(t, events, []string{"progress", "error"})
+	if !strings.Contains(string(events[1].Data), "draft cypher") {
+		t.Fatalf("error event = %s, want draft failure", events[1].Data)
 	}
 }
 
@@ -118,8 +123,13 @@ func TestGRCAskExplainFailureReturnsServiceUnavailable(t *testing.T) {
 		t.Fatalf("POST /grc/ask error = %v", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d with streamed error event", resp.StatusCode, http.StatusOK)
+	}
+	events := readSSEEvents(t, resp)
+	assertSSEEventNames(t, events, []string{"progress", "rationale", "progress", "error"})
+	if !strings.Contains(string(events[3].Data), "explain cypher") {
+		t.Fatalf("error event = %s, want explain failure", events[3].Data)
 	}
 }
 
@@ -153,4 +163,16 @@ func readSSEEvents(t *testing.T, resp *http.Response) []sseRecord {
 		t.Fatalf("scan SSE: %v", err)
 	}
 	return events
+}
+
+func assertSSEEventNames(t *testing.T, events []sseRecord, want []string) {
+	t.Helper()
+	if len(events) != len(want) {
+		t.Fatalf("events = %#v, want names %v", events, want)
+	}
+	for i, name := range want {
+		if events[i].Name != name {
+			t.Fatalf("event[%d] = %q, want %q", i, events[i].Name, name)
+		}
+	}
 }

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -58,6 +58,9 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	params := askParams(request)
 	traceID := newTraceID()
 
+	if err := emitProgress(emit, started, "drafting_query", "Drafting a read-only graph query."); err != nil {
+		return err
+	}
 	draft, err := s.llm.DraftCypher(ctx, DraftRequest{
 		TenantID:  strings.TrimSpace(request.TenantID),
 		Question:  strings.TrimSpace(request.Question),
@@ -78,29 +81,32 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	if rationale == "" {
 		rationale = "Drafting a bounded read-only Cypher query for the requested graph question."
 	}
+	if err := emit(Event{Name: EventRationale, Data: RationaleEvent{Text: rationale}}); err != nil {
+		return err
+	}
 
 	cypher := strings.TrimSpace(draft.Cypher)
 	if cypher == "" {
-		if err := emit(Event{Name: EventRationale, Data: RationaleEvent{Text: rationale}}); err != nil {
-			return err
-		}
 		reason := firstNonEmpty(draft.Refusal, "LLM refused to draft Cypher")
 		return emitRefusal(emit, traceID, started, cypher, reason)
+	}
+	if err := emitProgress(emit, started, "validating_query", "Validating generated Cypher against read-only guardrails."); err != nil {
+		return err
 	}
 	validation, rowLimit, err := s.validator.validate(ctx, cypher, params)
 	if err != nil {
 		return err
 	}
+	if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: cypher, Validator: validation}}); err != nil {
+		return err
+	}
 	if !validation.OK {
-		if err := emit(Event{Name: EventRationale, Data: RationaleEvent{Text: rationale}}); err != nil {
-			return err
-		}
-		if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: cypher, Validator: validation}}); err != nil {
-			return err
-		}
 		return emitRefusal(emit, traceID, started, cypher, validation.Reason)
 	}
 
+	if err := emitProgress(emit, started, "executing_query", "Executing the validated graph query."); err != nil {
+		return err
+	}
 	execStarted := time.Now()
 	rows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
 		Query:    cypher,
@@ -116,7 +122,13 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		Graph:  scopedNeighborhood(ctx, s.store, request.ScopeURN),
 		ExecMS: time.Since(execStarted).Milliseconds(),
 	}
+	if err := emit(Event{Name: EventRows, Data: rowsEvent}); err != nil {
+		return err
+	}
 
+	if err := emitProgress(emit, started, "summarizing", "Summarizing graph rows into a user-facing answer."); err != nil {
+		return err
+	}
 	summary, err := s.llm.Summarize(ctx, SummarizeRequest{
 		TenantID: strings.TrimSpace(request.TenantID),
 		Question: strings.TrimSpace(request.Question),
@@ -133,19 +145,18 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		summary = fallbackSummary(rowMaps)
 	}
 	summary = strings.TrimSpace(summary)
-	if err := emit(Event{Name: EventRationale, Data: RationaleEvent{Text: rationale}}); err != nil {
-		return err
-	}
-	if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: cypher, Validator: validation}}); err != nil {
-		return err
-	}
-	if err := emit(Event{Name: EventRows, Data: rowsEvent}); err != nil {
-		return err
-	}
 	if err := emit(Event{Name: EventSummary, Data: SummaryEvent{Markdown: summary, Citations: citationsFor(summary, rowMaps)}}); err != nil {
 		return err
 	}
 	return emit(Event{Name: EventDone, Data: DoneEvent{TraceID: traceID, TotalMS: time.Since(started).Milliseconds()}})
+}
+
+func emitProgress(emit Emitter, started time.Time, stage string, message string) error {
+	return emit(Event{Name: EventProgress, Data: ProgressEvent{
+		Stage:     strings.TrimSpace(stage),
+		Message:   strings.TrimSpace(message),
+		ElapsedMS: time.Since(started).Milliseconds(),
+	}})
 }
 
 func ValidateRequest(request AskRequest) error {

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -44,10 +44,17 @@ LIMIT 25`,
 	if err != nil {
 		t.Fatalf("Stream() error = %v", err)
 	}
-	assertEventNames(t, events, []string{EventRationale, EventCypher, EventRows, EventSummary, EventDone})
-	rowsEvent, ok := events[2].Data.(RowsEvent)
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventProgress, EventCypher, EventProgress, EventRows, EventProgress, EventSummary, EventDone})
+	progressEvent, ok := events[0].Data.(ProgressEvent)
 	if !ok {
-		t.Fatalf("rows event data = %T", events[2].Data)
+		t.Fatalf("progress event data = %T", events[0].Data)
+	}
+	if progressEvent.Stage != "drafting_query" {
+		t.Fatalf("first progress stage = %q, want drafting_query", progressEvent.Stage)
+	}
+	rowsEvent, ok := events[5].Data.(RowsEvent)
+	if !ok {
+		t.Fatalf("rows event data = %T", events[5].Data)
 	}
 	if len(rowsEvent.Rows) != 1 || rowsEvent.Rows[0]["entity_urn"] != "urn:cerebro:example:asset:alpha" {
 		t.Fatalf("rows = %#v", rowsEvent.Rows)
@@ -55,9 +62,9 @@ LIMIT 25`,
 	if rowsEvent.Graph == nil || rowsEvent.Graph.Root == nil {
 		t.Fatalf("graph neighborhood missing")
 	}
-	summaryEvent, ok := events[3].Data.(SummaryEvent)
+	summaryEvent, ok := events[7].Data.(SummaryEvent)
 	if !ok {
-		t.Fatalf("summary event data = %T", events[3].Data)
+		t.Fatalf("summary event data = %T", events[7].Data)
 	}
 	if len(summaryEvent.Citations) != 1 || summaryEvent.Citations[0].URN != "urn:cerebro:example:asset:alpha" {
 		t.Fatalf("citations = %#v", summaryEvent.Citations)
@@ -83,12 +90,12 @@ func TestServiceRefusesValidatorRejectedCypher(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stream() error = %v", err)
 	}
-	assertEventNames(t, events, []string{EventRationale, EventCypher, EventSummary, EventDone})
-	cypherEvent := events[1].Data.(CypherEvent)
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventProgress, EventCypher, EventSummary, EventDone})
+	cypherEvent := events[3].Data.(CypherEvent)
 	if cypherEvent.Validator.OK {
 		t.Fatalf("validator ok = true, want false")
 	}
-	done := events[3].Data.(DoneEvent)
+	done := events[5].Data.(DoneEvent)
 	if !done.CypherRefused {
 		t.Fatalf("done.CypherRefused = false, want true")
 	}

--- a/internal/graphagent/events.go
+++ b/internal/graphagent/events.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	EventProgress  = "progress"
 	EventRationale = "rationale"
 	EventCypher    = "cypher"
 	EventRows      = "rows"
@@ -25,6 +26,12 @@ type Event struct {
 type ValidatorResult struct {
 	OK     bool   `json:"ok"`
 	Reason string `json:"reason,omitempty"`
+}
+
+type ProgressEvent struct {
+	Stage     string `json:"stage"`
+	Message   string `json:"message"`
+	ElapsedMS int64  `json:"elapsed_ms"`
 }
 
 type RationaleEvent struct {

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -27,6 +27,7 @@ const (
 	MaxPageLimit             = 100
 	DefaultStatusLimit       = 25
 	MaxStatusLimit           = 500
+	progressRunUpdateTimeout = 15 * time.Second
 	terminalRunUpdateTimeout = 15 * time.Second
 	defaultCleanupLimit      = 1000
 )
@@ -83,6 +84,8 @@ type pageProjectionResult struct {
 	EntitiesProjected uint32
 	LinksProjected    uint32
 }
+
+type progressReporter func(*IngestResult)
 
 type RuntimeRequest struct {
 	RuntimeID                string
@@ -223,7 +226,13 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (resul
 	if err := runStore.PutIngestRun(ctx, run); err != nil {
 		return result, err
 	}
-	ingest, err := s.ingestSource(ctx, ingestRequest)
+	ingest, err := s.ingestSource(ctx, ingestRequest, func(progress *IngestResult) {
+		progressRun := runningRunProgress(run, progress)
+		result.Run = progressRun
+		if err := s.putProgressIngestRun(ctx, runStore, progressRun); err != nil {
+			log.Printf("graph ingest progress update failed run_id=%q runtime_id=%q error=%v", progressRun.ID, progressRun.RuntimeID, err)
+		}
+	})
 	result.Ingest = ingest
 	if err != nil {
 		return s.failRun(ctx, runStore, run, result, ingest, err)
@@ -413,6 +422,12 @@ func (s *Service) putTerminalIngestRun(ctx context.Context, runStore RunStore, r
 	return runStore.PutIngestRun(persistCtx, run)
 }
 
+func (s *Service) putProgressIngestRun(ctx context.Context, runStore RunStore, run graphstore.IngestRun) error {
+	persistCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), progressRunUpdateTimeout)
+	defer cancel()
+	return runStore.PutIngestRun(persistCtx, run)
+}
+
 func (s *Service) preparedConfig(ctx context.Context, runtime *cerebrov1.SourceRuntime) (map[string]string, error) {
 	config := sourceconfig.WithRuntimeTenant(runtime.GetConfig(), runtime.GetTenantId())
 	config = sourceconfig.WithLegacyTenantlessAssumeRole(config, runtime.GetSourceId(), runtime.GetTenantId())
@@ -435,10 +450,14 @@ type sourceRequest struct {
 	ResetCompletedCheckpoint bool
 }
 
-func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*IngestResult, error) {
+func (s *Service) ingestSource(ctx context.Context, request sourceRequest, reporters ...progressReporter) (*IngestResult, error) {
 	result := &IngestResult{
 		SourceID: strings.TrimSpace(request.SourceID),
 		TenantID: strings.TrimSpace(request.TenantID),
+	}
+	var report progressReporter
+	if len(reporters) != 0 {
+		report = reporters[0]
 	}
 	cursor := request.Cursor
 	checkpointStore, err := s.prepareCheckpoint(ctx, request, result, &cursor)
@@ -492,6 +511,9 @@ func (s *Service) ingestSource(ctx context.Context, request sourceRequest) (*Ing
 			if err := persistCheckpoint(ctx, checkpointStore, request, result, response, cursor); err != nil {
 				return result, err
 			}
+		}
+		if report != nil {
+			report(result)
 		}
 		if cursor == nil {
 			break
@@ -1034,6 +1056,25 @@ func finishRun(run graphstore.IngestRun, result *IngestResult, status string, ru
 		finished.Error = runErr.Error()
 	}
 	return finished
+}
+
+func runningRunProgress(run graphstore.IngestRun, result *IngestResult) graphstore.IngestRun {
+	progress := run
+	progress.Status = graphstore.IngestRunStatusRunning
+	progress.FinishedAt = ""
+	progress.Error = ""
+	if result != nil {
+		progress.CheckpointID = result.CheckpointID
+		progress.PagesRead = int64(result.PagesRead)
+		progress.EventsRead = int64(result.EventsRead)
+		progress.EntitiesProjected = int64(result.EntitiesProjected)
+		progress.LinksProjected = int64(result.LinksProjected)
+		progress.GraphNodesBefore = result.GraphNodesBefore
+		progress.GraphLinksBefore = result.GraphLinksBefore
+		progress.GraphNodesAfter = result.GraphNodesAfter
+		progress.GraphLinksAfter = result.GraphLinksAfter
+	}
+	return progress
 }
 
 func configHash(config map[string]string) string {

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/sourceops"
 )
 
 type stubRunStore struct {
@@ -164,6 +165,33 @@ func (s *singlePageSource) Discover(context.Context, sourcecdk.Config) ([]source
 
 func (s *singlePageSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	return sourcecdk.Pull{Events: s.events}, nil
+}
+
+type cursorPagedSource struct {
+	id    string
+	pages [][]*cerebrov1.EventEnvelope
+}
+
+func (s *cursorPagedSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: s.id, Name: "Cursor Paged"}
+}
+
+func (s *cursorPagedSource) Check(context.Context, sourcecdk.Config) error { return nil }
+
+func (s *cursorPagedSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+
+func (s *cursorPagedSource) Read(_ context.Context, _ sourcecdk.Config, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	page := 0
+	if cursor != nil && cursor.GetOpaque() == "page-1" {
+		page = 1
+	}
+	pull := sourcecdk.Pull{Events: s.pages[page]}
+	if page+1 < len(s.pages) {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: "page-1"}
+	}
+	return pull, nil
 }
 
 func (s *recordingProjectionGraphStore) DeleteProjectedEntity(_ context.Context, urn string) error {
@@ -795,6 +823,59 @@ func TestMergeStringMapClearsOlderObservationMetadataMissingFromNewerAt(t *testi
 		if got, exists := merged[key]; exists {
 			t.Fatalf("merged[%s] = %q, want missing because newer observation omitted it", key, got)
 		}
+	}
+}
+
+func TestIngestSourceReportsProgressAfterEachPersistedPage(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(&cursorPagedSource{
+		id: "paged",
+		pages: [][]*cerebrov1.EventEnvelope{
+			{{Id: "event-1", SourceId: "paged"}},
+			{{Id: "event-2", SourceId: "paged"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &checkpointProjectionGraphStore{}
+	service := &Service{
+		sourceService: sourceops.New(registry),
+		graphStore:    store,
+		projector: recordProjectorFunc(func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+			return []*ports.ProjectedEntity{{
+				URN:        "urn:cerebro:writer:paged:" + event.GetId(),
+				TenantID:   event.GetTenantId(),
+				SourceID:   event.GetSourceId(),
+				EntityType: "paged.entity",
+				Label:      event.GetId(),
+			}}, nil, nil
+		}),
+	}
+	var snapshots []IngestResult
+	result, err := service.ingestSource(context.Background(), sourceRequest{
+		SourceID:          "paged",
+		RuntimeID:         "runtime-1",
+		TenantID:          "writer",
+		PageLimit:         2,
+		CheckpointEnabled: true,
+		CheckpointID:      "checkpoint-1",
+	}, func(progress *IngestResult) {
+		snapshots = append(snapshots, *progress)
+	})
+	if err != nil {
+		t.Fatalf("ingestSource() error = %v", err)
+	}
+	if result.PagesRead != 2 || result.EventsRead != 2 || result.EntitiesProjected != 2 {
+		t.Fatalf("result pages/events/entities = %d/%d/%d, want 2/2/2", result.PagesRead, result.EventsRead, result.EntitiesProjected)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("progress snapshots = %d, want 2", len(snapshots))
+	}
+	if snapshots[0].PagesRead != 1 || snapshots[0].EventsRead != 1 || !snapshots[0].CheckpointPersisted {
+		t.Fatalf("first progress = %#v, want one persisted page", snapshots[0])
+	}
+	if snapshots[1].PagesRead != 2 || snapshots[1].EventsRead != 2 || !snapshots[1].CheckpointComplete {
+		t.Fatalf("second progress = %#v, want completed second page", snapshots[1])
 	}
 }
 


### PR DESCRIPTION
## Summary
- make orchestrator phase timeouts configurable with a 45m graph-ingest default
- persist graph-ingest running progress after each page
- stream GRC Ask progress and post-header error events over SSE

## Tests
- make verify