### PR TITLE
ci: automate go-prod release promotion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,66 +209,81 @@ jobs:
             exit 1
           fi
 
-          requested_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          request_id="cerebro-${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          dispatch_target() {
+            local target_environment="$1"
+            local apply_mode="$2"
+            local requested_at
+            local request_id
+            local deadline
+            local run_id
+            local run_url
 
-          jq -n \
-            --arg tag "${RELEASE_TAG}" \
-            --arg digest "${IMAGE_DIGEST}" \
-            --arg release_url "https://github.com/${SOURCE_REPOSITORY}/releases/tag/${RELEASE_TAG}" \
-            --arg source_repository "${SOURCE_REPOSITORY}" \
-            --arg source_ref "refs/tags/${RELEASE_TAG}" \
-            --arg request_id "${request_id}" \
-            '{
-              event_type: "cerebro-release-published",
-              client_payload: {
-                image_tag: $tag,
-                image_digest: $digest,
-                release_url: $release_url,
-                source_repository: $source_repository,
-                source_ref: $source_ref,
-                request_id: $request_id,
-                target_environment: "sec-dev",
-                apply_mode: "direct_push"
-              }
-            }' | gh api --method POST "repos/${INFRA_REPOSITORY}/dispatches" --input -
+            requested_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            request_id="cerebro-${target_environment}-${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
-          deadline=$((SECONDS + 120))
-          while [ "${SECONDS}" -lt "${deadline}" ]; do
-            run_id="$(
-              gh run list \
-                --repo "${INFRA_REPOSITORY}" \
-                --workflow propose-image-tag.yml \
-                --event repository_dispatch \
-                --json databaseId,createdAt,displayTitle,url \
-                --limit 20 \
-                | jq -r --arg requested_at "${requested_at}" --arg request_id "${request_id}" '.[] | select(.createdAt >= $requested_at and ((.displayTitle // "") | contains($request_id))) | .databaseId' \
-                | head -n 1
-            )"
-            if [ -n "${run_id}" ]; then
-              run_url="$(
+            jq -n \
+              --arg tag "${RELEASE_TAG}" \
+              --arg digest "${IMAGE_DIGEST}" \
+              --arg release_url "https://github.com/${SOURCE_REPOSITORY}/releases/tag/${RELEASE_TAG}" \
+              --arg source_repository "${SOURCE_REPOSITORY}" \
+              --arg source_ref "refs/tags/${RELEASE_TAG}" \
+              --arg request_id "${request_id}" \
+              --arg target_environment "${target_environment}" \
+              --arg apply_mode "${apply_mode}" \
+              '{
+                event_type: "cerebro-release-published",
+                client_payload: {
+                  image_tag: $tag,
+                  image_digest: $digest,
+                  release_url: $release_url,
+                  source_repository: $source_repository,
+                  source_ref: $source_ref,
+                  request_id: $request_id,
+                  target_environment: $target_environment,
+                  apply_mode: $apply_mode
+                }
+              }' | gh api --method POST "repos/${INFRA_REPOSITORY}/dispatches" --input -
+
+            deadline=$((SECONDS + 120))
+            while [ "${SECONDS}" -lt "${deadline}" ]; do
+              run_id="$(
                 gh run list \
                   --repo "${INFRA_REPOSITORY}" \
                   --workflow propose-image-tag.yml \
                   --event repository_dispatch \
-                  --json databaseId,url \
+                  --json databaseId,createdAt,displayTitle,url \
                   --limit 20 \
-                  --jq ".[] | select(.databaseId == ${run_id}) | .url" \
+                  | jq -r --arg requested_at "${requested_at}" --arg request_id "${request_id}" '.[] | select(.createdAt >= $requested_at and ((.displayTitle // "") | contains($request_id))) | .databaseId' \
                   | head -n 1
               )"
-              echo "Dispatched sec-dev deploy request for ${RELEASE_TAG}@${IMAGE_DIGEST}: ${run_url}"
-              exit 0
-            fi
-            sleep 5
-          done
+              if [ -n "${run_id}" ]; then
+                run_url="$(
+                  gh run list \
+                    --repo "${INFRA_REPOSITORY}" \
+                    --workflow propose-image-tag.yml \
+                    --event repository_dispatch \
+                    --json databaseId,url \
+                    --limit 20 \
+                    --jq ".[] | select(.databaseId == ${run_id}) | .url" \
+                    | head -n 1
+                )"
+                echo "Dispatched ${target_environment} ${apply_mode} deploy request for ${RELEASE_TAG}@${IMAGE_DIGEST}: ${run_url}"
+                return 0
+              fi
+              sleep 5
+            done
 
-          echo "ERROR: repository_dispatch was accepted, but no matching propose-image-tag.yml run appeared for ${RELEASE_TAG}" >&2
-          echo "This usually means the downstream handler is absent or disabled; failing closed to avoid silent deploy loss." >&2
-          exit 1
+            echo "ERROR: repository_dispatch was accepted, but no matching propose-image-tag.yml run appeared for ${target_environment} ${RELEASE_TAG}" >&2
+            echo "This usually means the downstream handler is absent or disabled; failing closed to avoid silent deploy loss." >&2
+            exit 1
+          }
+
+          dispatch_target sec-dev direct_push
+          dispatch_target go-prod pull_request
 
   runtime-contract:
     runs-on: ubuntu-latest
-    needs: [resolve-tag, ghcr-publish]
+    needs: [resolve-tag, goreleaser]
     env:
       RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
     steps:


### PR DESCRIPTION
## Summary
- Dispatch both sec-dev and review-gated go-prod image promotions after signed Cerebro releases.
- Generate/sign the runtime deploy contract after GoReleaser instead of waiting for GHCR image publishing, reducing release-to-promotion latency.

## Test plan
- ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/release.yml\")'

Made with [Cursor](https://cursor.com)