### PR TITLE
Add finding candidate promotion flow

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -245,6 +245,76 @@ paths:
       responses:
         '200':
           description: Rule evaluation result.
+  /source-runtimes/{runtimeID}/finding-candidates:
+    get:
+      summary: List candidate findings for one runtime
+      tags:
+        - Sources
+      parameters:
+        - $ref: '#/components/parameters/runtimeID'
+        - name: candidate_id
+          in: query
+          schema:
+            type: string
+        - name: rule_id
+          in: query
+          schema:
+            type: string
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [candidate, promoted]
+        - name: fingerprint
+          in: query
+          schema:
+            type: string
+        - $ref: '#/components/parameters/limitQuery'
+      responses:
+        '200':
+          description: Candidate finding list.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  candidates:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FindingCandidate'
+  /source-runtimes/{runtimeID}/finding-candidates/evaluate:
+    post:
+      summary: Evaluate candidate findings for one runtime
+      tags:
+        - Sources
+      parameters:
+        - $ref: '#/components/parameters/runtimeID'
+        - name: rule_id
+          in: query
+          schema:
+            type: string
+        - name: event_limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Candidate finding evaluation result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runtime:
+                    type: object
+                  events_evaluated:
+                    type: integer
+                    minimum: 0
+                  evaluations:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FindingCandidateRuleEvaluation'
   /source-runtimes/{runtimeID}/findings/evaluate:
     post:
       summary: Evaluate and persist findings for one runtime
@@ -348,6 +418,50 @@ paths:
                 properties:
                   finding:
                     $ref: '#/components/schemas/Finding'
+  /finding-candidates/{candidateID}:
+    get:
+      summary: Get candidate finding
+      tags:
+        - Findings
+      parameters:
+        - $ref: '#/components/parameters/candidateID'
+      responses:
+        '200':
+          description: Candidate finding.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  candidate:
+                    $ref: '#/components/schemas/FindingCandidate'
+  /finding-candidates/{candidateID}/promote:
+    post:
+      summary: Promote candidate finding
+      tags:
+        - Findings
+      parameters:
+        - $ref: '#/components/parameters/candidateID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PromoteFindingCandidateRequest'
+      responses:
+        '200':
+          description: Promoted finding and candidate metadata.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  finding:
+                    $ref: '#/components/schemas/Finding'
+                  candidate:
+                    $ref: '#/components/schemas/FindingCandidate'
+                  decision_id:
+                    type: string
   /findings/{findingID}/resolve:
     post:
       summary: Resolve finding
@@ -1318,6 +1432,12 @@ components:
       required: true
       schema:
         type: string
+    candidateID:
+      name: candidateID
+      in: path
+      required: true
+      schema:
+        type: string
     runID:
       name: runID
       in: path
@@ -1564,6 +1684,119 @@ components:
           format: date-time
         error:
           type: string
+    FindingCandidateRun:
+      type: object
+      properties:
+        id:
+          type: string
+        tenant_id:
+          type: string
+        runtime_id:
+          type: string
+        rule_id:
+          type: string
+        status:
+          type: string
+        event_limit:
+          type: integer
+          minimum: 0
+        events_evaluated:
+          type: integer
+          minimum: 0
+        events_matched:
+          type: integer
+          minimum: 0
+        candidates:
+          type: integer
+          minimum: 0
+        started_at:
+          type: string
+          format: date-time
+        finished_at:
+          type: string
+          format: date-time
+        error:
+          type: string
+    FindingCandidateRuleEvaluation:
+      type: object
+      properties:
+        rule:
+          type: object
+        run:
+          $ref: '#/components/schemas/FindingCandidateRun'
+        candidates:
+          type: array
+          items:
+            $ref: '#/components/schemas/FindingCandidate'
+    FindingCandidate:
+      type: object
+      properties:
+        id:
+          type: string
+        tenant_id:
+          type: string
+        runtime_id:
+          type: string
+        rule_id:
+          type: string
+        fingerprint:
+          type: string
+        status:
+          type: string
+          enum: [candidate, promoted]
+        finding:
+          $ref: '#/components/schemas/Finding'
+        evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/FindingEvidence'
+        last_run_id:
+          type: string
+        observation_count:
+          type: integer
+          minimum: 0
+        first_observed_at:
+          type: string
+          format: date-time
+        last_observed_at:
+          type: string
+          format: date-time
+        promoted_finding_id:
+          type: string
+        decision_id:
+          type: string
+        promoted_by:
+          type: string
+        promotion_rationale:
+          type: string
+        change_ticket:
+          type: string
+        promoted_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    PromoteFindingCandidateRequest:
+      type: object
+      required: [promoted_by, rationale, change_ticket, false_positive_reviewed, graph_coverage_reviewed]
+      properties:
+        promoted_by:
+          type: string
+          minLength: 1
+        rationale:
+          type: string
+          minLength: 1
+        change_ticket:
+          type: string
+          minLength: 1
+        false_positive_reviewed:
+          type: boolean
+        graph_coverage_reviewed:
+          type: boolean
     Finding:
       type: object
       properties:

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -4623,6 +4623,885 @@ func (x *ListFindingsResponse) GetFindings() []*Finding {
 	return nil
 }
 
+// FindingCandidateRun is the durable audit envelope for one non-production candidate evaluation.
+type FindingCandidateRun struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Id              string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	TenantId        string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	RuntimeId       string                 `protobuf:"bytes,3,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	RuleId          string                 `protobuf:"bytes,4,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	Status          string                 `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"`
+	EventLimit      uint32                 `protobuf:"varint,6,opt,name=event_limit,json=eventLimit,proto3" json:"event_limit,omitempty"`
+	EventsEvaluated uint32                 `protobuf:"varint,7,opt,name=events_evaluated,json=eventsEvaluated,proto3" json:"events_evaluated,omitempty"`
+	EventsMatched   uint32                 `protobuf:"varint,8,opt,name=events_matched,json=eventsMatched,proto3" json:"events_matched,omitempty"`
+	Candidates      uint32                 `protobuf:"varint,9,opt,name=candidates,proto3" json:"candidates,omitempty"`
+	StartedAt       *timestamppb.Timestamp `protobuf:"bytes,10,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	FinishedAt      *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=finished_at,json=finishedAt,proto3" json:"finished_at,omitempty"`
+	Error           string                 `protobuf:"bytes,12,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *FindingCandidateRun) Reset() {
+	*x = FindingCandidateRun{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[69]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FindingCandidateRun) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FindingCandidateRun) ProtoMessage() {}
+
+func (x *FindingCandidateRun) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[69]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FindingCandidateRun.ProtoReflect.Descriptor instead.
+func (*FindingCandidateRun) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{69}
+}
+
+func (x *FindingCandidateRun) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *FindingCandidateRun) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+func (x *FindingCandidateRun) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *FindingCandidateRun) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+func (x *FindingCandidateRun) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *FindingCandidateRun) GetEventLimit() uint32 {
+	if x != nil {
+		return x.EventLimit
+	}
+	return 0
+}
+
+func (x *FindingCandidateRun) GetEventsEvaluated() uint32 {
+	if x != nil {
+		return x.EventsEvaluated
+	}
+	return 0
+}
+
+func (x *FindingCandidateRun) GetEventsMatched() uint32 {
+	if x != nil {
+		return x.EventsMatched
+	}
+	return 0
+}
+
+func (x *FindingCandidateRun) GetCandidates() uint32 {
+	if x != nil {
+		return x.Candidates
+	}
+	return 0
+}
+
+func (x *FindingCandidateRun) GetStartedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartedAt
+	}
+	return nil
+}
+
+func (x *FindingCandidateRun) GetFinishedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.FinishedAt
+	}
+	return nil
+}
+
+func (x *FindingCandidateRun) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+// FindingCandidate stores a reviewed candidate finding snapshot outside production alerts.
+type FindingCandidate struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Id                 string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	TenantId           string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	RuntimeId          string                 `protobuf:"bytes,3,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	RuleId             string                 `protobuf:"bytes,4,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	Fingerprint        string                 `protobuf:"bytes,5,opt,name=fingerprint,proto3" json:"fingerprint,omitempty"`
+	Status             string                 `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
+	Finding            *Finding               `protobuf:"bytes,7,opt,name=finding,proto3" json:"finding,omitempty"`
+	Evidence           []*FindingEvidence     `protobuf:"bytes,8,rep,name=evidence,proto3" json:"evidence,omitempty"`
+	LastRunId          string                 `protobuf:"bytes,9,opt,name=last_run_id,json=lastRunId,proto3" json:"last_run_id,omitempty"`
+	ObservationCount   uint32                 `protobuf:"varint,10,opt,name=observation_count,json=observationCount,proto3" json:"observation_count,omitempty"`
+	FirstObservedAt    *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=first_observed_at,json=firstObservedAt,proto3" json:"first_observed_at,omitempty"`
+	LastObservedAt     *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=last_observed_at,json=lastObservedAt,proto3" json:"last_observed_at,omitempty"`
+	PromotedFindingId  string                 `protobuf:"bytes,13,opt,name=promoted_finding_id,json=promotedFindingId,proto3" json:"promoted_finding_id,omitempty"`
+	DecisionId         string                 `protobuf:"bytes,14,opt,name=decision_id,json=decisionId,proto3" json:"decision_id,omitempty"`
+	PromotedBy         string                 `protobuf:"bytes,15,opt,name=promoted_by,json=promotedBy,proto3" json:"promoted_by,omitempty"`
+	PromotionRationale string                 `protobuf:"bytes,16,opt,name=promotion_rationale,json=promotionRationale,proto3" json:"promotion_rationale,omitempty"`
+	ChangeTicket       string                 `protobuf:"bytes,17,opt,name=change_ticket,json=changeTicket,proto3" json:"change_ticket,omitempty"`
+	PromotedAt         *timestamppb.Timestamp `protobuf:"bytes,18,opt,name=promoted_at,json=promotedAt,proto3" json:"promoted_at,omitempty"`
+	CreatedAt          *timestamppb.Timestamp `protobuf:"bytes,19,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt          *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *FindingCandidate) Reset() {
+	*x = FindingCandidate{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[70]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FindingCandidate) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FindingCandidate) ProtoMessage() {}
+
+func (x *FindingCandidate) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[70]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FindingCandidate.ProtoReflect.Descriptor instead.
+func (*FindingCandidate) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{70}
+}
+
+func (x *FindingCandidate) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetFingerprint() string {
+	if x != nil {
+		return x.Fingerprint
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetFinding() *Finding {
+	if x != nil {
+		return x.Finding
+	}
+	return nil
+}
+
+func (x *FindingCandidate) GetEvidence() []*FindingEvidence {
+	if x != nil {
+		return x.Evidence
+	}
+	return nil
+}
+
+func (x *FindingCandidate) GetLastRunId() string {
+	if x != nil {
+		return x.LastRunId
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetObservationCount() uint32 {
+	if x != nil {
+		return x.ObservationCount
+	}
+	return 0
+}
+
+func (x *FindingCandidate) GetFirstObservedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.FirstObservedAt
+	}
+	return nil
+}
+
+func (x *FindingCandidate) GetLastObservedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastObservedAt
+	}
+	return nil
+}
+
+func (x *FindingCandidate) GetPromotedFindingId() string {
+	if x != nil {
+		return x.PromotedFindingId
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetDecisionId() string {
+	if x != nil {
+		return x.DecisionId
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetPromotedBy() string {
+	if x != nil {
+		return x.PromotedBy
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetPromotionRationale() string {
+	if x != nil {
+		return x.PromotionRationale
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetChangeTicket() string {
+	if x != nil {
+		return x.ChangeTicket
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetPromotedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.PromotedAt
+	}
+	return nil
+}
+
+func (x *FindingCandidate) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *FindingCandidate) GetUpdatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
+// ListFindingCandidatesRequest queries isolated candidate finding snapshots for one runtime.
+type ListFindingCandidatesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RuntimeId     string                 `protobuf:"bytes,1,opt,name=runtime_id,json=runtimeId,proto3" json:"runtime_id,omitempty"`
+	CandidateId   string                 `protobuf:"bytes,2,opt,name=candidate_id,json=candidateId,proto3" json:"candidate_id,omitempty"`
+	RuleId        string                 `protobuf:"bytes,3,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	Status        string                 `protobuf:"bytes,4,opt,name=status,proto3" json:"status,omitempty"`
+	Fingerprint   string                 `protobuf:"bytes,5,opt,name=fingerprint,proto3" json:"fingerprint,omitempty"`
+	Limit         uint32                 `protobuf:"varint,6,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFindingCandidatesRequest) Reset() {
+	*x = ListFindingCandidatesRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[71]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFindingCandidatesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFindingCandidatesRequest) ProtoMessage() {}
+
+func (x *ListFindingCandidatesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[71]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFindingCandidatesRequest.ProtoReflect.Descriptor instead.
+func (*ListFindingCandidatesRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{71}
+}
+
+func (x *ListFindingCandidatesRequest) GetRuntimeId() string {
+	if x != nil {
+		return x.RuntimeId
+	}
+	return ""
+}
+
+func (x *ListFindingCandidatesRequest) GetCandidateId() string {
+	if x != nil {
+		return x.CandidateId
+	}
+	return ""
+}
+
+func (x *ListFindingCandidatesRequest) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
+func (x *ListFindingCandidatesRequest) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ListFindingCandidatesRequest) GetFingerprint() string {
+	if x != nil {
+		return x.Fingerprint
+	}
+	return ""
+}
+
+func (x *ListFindingCandidatesRequest) GetLimit() uint32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+// ListFindingCandidatesResponse returns the matched candidate finding snapshots.
+type ListFindingCandidatesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Candidates    []*FindingCandidate    `protobuf:"bytes,1,rep,name=candidates,proto3" json:"candidates,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFindingCandidatesResponse) Reset() {
+	*x = ListFindingCandidatesResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[72]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFindingCandidatesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFindingCandidatesResponse) ProtoMessage() {}
+
+func (x *ListFindingCandidatesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[72]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFindingCandidatesResponse.ProtoReflect.Descriptor instead.
+func (*ListFindingCandidatesResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{72}
+}
+
+func (x *ListFindingCandidatesResponse) GetCandidates() []*FindingCandidate {
+	if x != nil {
+		return x.Candidates
+	}
+	return nil
+}
+
+// GetFindingCandidateRequest loads one isolated candidate finding by durable identifier.
+type GetFindingCandidateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetFindingCandidateRequest) Reset() {
+	*x = GetFindingCandidateRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[73]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetFindingCandidateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetFindingCandidateRequest) ProtoMessage() {}
+
+func (x *GetFindingCandidateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[73]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetFindingCandidateRequest.ProtoReflect.Descriptor instead.
+func (*GetFindingCandidateRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{73}
+}
+
+func (x *GetFindingCandidateRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+// GetFindingCandidateResponse returns one candidate finding snapshot.
+type GetFindingCandidateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Candidate     *FindingCandidate      `protobuf:"bytes,1,opt,name=candidate,proto3" json:"candidate,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetFindingCandidateResponse) Reset() {
+	*x = GetFindingCandidateResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[74]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetFindingCandidateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetFindingCandidateResponse) ProtoMessage() {}
+
+func (x *GetFindingCandidateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[74]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetFindingCandidateResponse.ProtoReflect.Descriptor instead.
+func (*GetFindingCandidateResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{74}
+}
+
+func (x *GetFindingCandidateResponse) GetCandidate() *FindingCandidate {
+	if x != nil {
+		return x.Candidate
+	}
+	return nil
+}
+
+// EvaluateSourceRuntimeFindingCandidatesRequest replays one runtime through candidate rules without writing production findings.
+type EvaluateSourceRuntimeFindingCandidatesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	RuleIds       []string               `protobuf:"bytes,2,rep,name=rule_ids,json=ruleIds,proto3" json:"rule_ids,omitempty"`
+	EventLimit    uint32                 `protobuf:"varint,3,opt,name=event_limit,json=eventLimit,proto3" json:"event_limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesRequest) Reset() {
+	*x = EvaluateSourceRuntimeFindingCandidatesRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[75]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluateSourceRuntimeFindingCandidatesRequest) ProtoMessage() {}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[75]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluateSourceRuntimeFindingCandidatesRequest.ProtoReflect.Descriptor instead.
+func (*EvaluateSourceRuntimeFindingCandidatesRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{75}
+}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesRequest) GetRuleIds() []string {
+	if x != nil {
+		return x.RuleIds
+	}
+	return nil
+}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesRequest) GetEventLimit() uint32 {
+	if x != nil {
+		return x.EventLimit
+	}
+	return 0
+}
+
+// FindingCandidateRuleEvaluation returns one rule's isolated candidate outputs.
+type FindingCandidateRuleEvaluation struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Rule          *RuleSpec              `protobuf:"bytes,1,opt,name=rule,proto3" json:"rule,omitempty"`
+	Run           *FindingCandidateRun   `protobuf:"bytes,2,opt,name=run,proto3" json:"run,omitempty"`
+	Candidates    []*FindingCandidate    `protobuf:"bytes,3,rep,name=candidates,proto3" json:"candidates,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FindingCandidateRuleEvaluation) Reset() {
+	*x = FindingCandidateRuleEvaluation{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[76]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FindingCandidateRuleEvaluation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FindingCandidateRuleEvaluation) ProtoMessage() {}
+
+func (x *FindingCandidateRuleEvaluation) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[76]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FindingCandidateRuleEvaluation.ProtoReflect.Descriptor instead.
+func (*FindingCandidateRuleEvaluation) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{76}
+}
+
+func (x *FindingCandidateRuleEvaluation) GetRule() *RuleSpec {
+	if x != nil {
+		return x.Rule
+	}
+	return nil
+}
+
+func (x *FindingCandidateRuleEvaluation) GetRun() *FindingCandidateRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
+func (x *FindingCandidateRuleEvaluation) GetCandidates() []*FindingCandidate {
+	if x != nil {
+		return x.Candidates
+	}
+	return nil
+}
+
+// EvaluateSourceRuntimeFindingCandidatesResponse returns non-production candidate outputs for one runtime replay.
+type EvaluateSourceRuntimeFindingCandidatesResponse struct {
+	state           protoimpl.MessageState            `protogen:"open.v1"`
+	Runtime         *SourceRuntime                    `protobuf:"bytes,1,opt,name=runtime,proto3" json:"runtime,omitempty"`
+	EventsEvaluated uint32                            `protobuf:"varint,2,opt,name=events_evaluated,json=eventsEvaluated,proto3" json:"events_evaluated,omitempty"`
+	Evaluations     []*FindingCandidateRuleEvaluation `protobuf:"bytes,3,rep,name=evaluations,proto3" json:"evaluations,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesResponse) Reset() {
+	*x = EvaluateSourceRuntimeFindingCandidatesResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[77]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EvaluateSourceRuntimeFindingCandidatesResponse) ProtoMessage() {}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[77]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EvaluateSourceRuntimeFindingCandidatesResponse.ProtoReflect.Descriptor instead.
+func (*EvaluateSourceRuntimeFindingCandidatesResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{77}
+}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesResponse) GetRuntime() *SourceRuntime {
+	if x != nil {
+		return x.Runtime
+	}
+	return nil
+}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesResponse) GetEventsEvaluated() uint32 {
+	if x != nil {
+		return x.EventsEvaluated
+	}
+	return 0
+}
+
+func (x *EvaluateSourceRuntimeFindingCandidatesResponse) GetEvaluations() []*FindingCandidateRuleEvaluation {
+	if x != nil {
+		return x.Evaluations
+	}
+	return nil
+}
+
+// PromoteFindingCandidateRequest promotes one reviewed candidate into production findings.
+type PromoteFindingCandidateRequest struct {
+	state                 protoimpl.MessageState `protogen:"open.v1"`
+	Id                    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	PromotedBy            string                 `protobuf:"bytes,2,opt,name=promoted_by,json=promotedBy,proto3" json:"promoted_by,omitempty"`
+	Rationale             string                 `protobuf:"bytes,3,opt,name=rationale,proto3" json:"rationale,omitempty"`
+	ChangeTicket          string                 `protobuf:"bytes,4,opt,name=change_ticket,json=changeTicket,proto3" json:"change_ticket,omitempty"`
+	FalsePositiveReviewed bool                   `protobuf:"varint,5,opt,name=false_positive_reviewed,json=falsePositiveReviewed,proto3" json:"false_positive_reviewed,omitempty"`
+	GraphCoverageReviewed bool                   `protobuf:"varint,6,opt,name=graph_coverage_reviewed,json=graphCoverageReviewed,proto3" json:"graph_coverage_reviewed,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *PromoteFindingCandidateRequest) Reset() {
+	*x = PromoteFindingCandidateRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[78]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PromoteFindingCandidateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PromoteFindingCandidateRequest) ProtoMessage() {}
+
+func (x *PromoteFindingCandidateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[78]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PromoteFindingCandidateRequest.ProtoReflect.Descriptor instead.
+func (*PromoteFindingCandidateRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{78}
+}
+
+func (x *PromoteFindingCandidateRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *PromoteFindingCandidateRequest) GetPromotedBy() string {
+	if x != nil {
+		return x.PromotedBy
+	}
+	return ""
+}
+
+func (x *PromoteFindingCandidateRequest) GetRationale() string {
+	if x != nil {
+		return x.Rationale
+	}
+	return ""
+}
+
+func (x *PromoteFindingCandidateRequest) GetChangeTicket() string {
+	if x != nil {
+		return x.ChangeTicket
+	}
+	return ""
+}
+
+func (x *PromoteFindingCandidateRequest) GetFalsePositiveReviewed() bool {
+	if x != nil {
+		return x.FalsePositiveReviewed
+	}
+	return false
+}
+
+func (x *PromoteFindingCandidateRequest) GetGraphCoverageReviewed() bool {
+	if x != nil {
+		return x.GraphCoverageReviewed
+	}
+	return false
+}
+
+// PromoteFindingCandidateResponse returns the production finding and updated candidate.
+type PromoteFindingCandidateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Finding       *Finding               `protobuf:"bytes,1,opt,name=finding,proto3" json:"finding,omitempty"`
+	Candidate     *FindingCandidate      `protobuf:"bytes,2,opt,name=candidate,proto3" json:"candidate,omitempty"`
+	DecisionId    string                 `protobuf:"bytes,3,opt,name=decision_id,json=decisionId,proto3" json:"decision_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PromoteFindingCandidateResponse) Reset() {
+	*x = PromoteFindingCandidateResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[79]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PromoteFindingCandidateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PromoteFindingCandidateResponse) ProtoMessage() {}
+
+func (x *PromoteFindingCandidateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[79]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PromoteFindingCandidateResponse.ProtoReflect.Descriptor instead.
+func (*PromoteFindingCandidateResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{79}
+}
+
+func (x *PromoteFindingCandidateResponse) GetFinding() *Finding {
+	if x != nil {
+		return x.Finding
+	}
+	return nil
+}
+
+func (x *PromoteFindingCandidateResponse) GetCandidate() *FindingCandidate {
+	if x != nil {
+		return x.Candidate
+	}
+	return nil
+}
+
+func (x *PromoteFindingCandidateResponse) GetDecisionId() string {
+	if x != nil {
+		return x.DecisionId
+	}
+	return ""
+}
+
 // EvaluateSourceRuntimeFindingsRequest replays one stored runtime through one registered finding rule.
 type EvaluateSourceRuntimeFindingsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -4635,7 +5514,7 @@ type EvaluateSourceRuntimeFindingsRequest struct {
 
 func (x *EvaluateSourceRuntimeFindingsRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[69]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4647,7 +5526,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) String() string {
 func (*EvaluateSourceRuntimeFindingsRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[69]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4660,7 +5539,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{69}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *EvaluateSourceRuntimeFindingsRequest) GetId() string {
@@ -4696,7 +5575,7 @@ type EvaluateSourceRuntimeFindingRulesRequest struct {
 
 func (x *EvaluateSourceRuntimeFindingRulesRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingRulesRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[70]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4708,7 +5587,7 @@ func (x *EvaluateSourceRuntimeFindingRulesRequest) String() string {
 func (*EvaluateSourceRuntimeFindingRulesRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingRulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[70]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4721,7 +5600,7 @@ func (x *EvaluateSourceRuntimeFindingRulesRequest) ProtoReflect() protoreflect.M
 
 // Deprecated: Use EvaluateSourceRuntimeFindingRulesRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingRulesRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{70}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *EvaluateSourceRuntimeFindingRulesRequest) GetId() string {
@@ -4758,7 +5637,7 @@ type FindingRuleEvaluation struct {
 
 func (x *FindingRuleEvaluation) Reset() {
 	*x = FindingRuleEvaluation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[71]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4770,7 +5649,7 @@ func (x *FindingRuleEvaluation) String() string {
 func (*FindingRuleEvaluation) ProtoMessage() {}
 
 func (x *FindingRuleEvaluation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[71]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4783,7 +5662,7 @@ func (x *FindingRuleEvaluation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FindingRuleEvaluation.ProtoReflect.Descriptor instead.
 func (*FindingRuleEvaluation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{71}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *FindingRuleEvaluation) GetRule() *RuleSpec {
@@ -4826,7 +5705,7 @@ type EvaluateSourceRuntimeFindingRulesResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingRulesResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingRulesResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[72]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4838,7 +5717,7 @@ func (x *EvaluateSourceRuntimeFindingRulesResponse) String() string {
 func (*EvaluateSourceRuntimeFindingRulesResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingRulesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[72]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4851,7 +5730,7 @@ func (x *EvaluateSourceRuntimeFindingRulesResponse) ProtoReflect() protoreflect.
 
 // Deprecated: Use EvaluateSourceRuntimeFindingRulesResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingRulesResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{72}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *EvaluateSourceRuntimeFindingRulesResponse) GetRuntime() *SourceRuntime {
@@ -4891,7 +5770,7 @@ type EvaluateSourceRuntimeFindingsResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingsResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[73]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4903,7 +5782,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) String() string {
 func (*EvaluateSourceRuntimeFindingsResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[73]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4916,7 +5795,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{73}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *EvaluateSourceRuntimeFindingsResponse) GetRuntime() *SourceRuntime {
@@ -4992,7 +5871,7 @@ type WriteDecisionRequest struct {
 
 func (x *WriteDecisionRequest) Reset() {
 	*x = WriteDecisionRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[74]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5004,7 +5883,7 @@ func (x *WriteDecisionRequest) String() string {
 func (*WriteDecisionRequest) ProtoMessage() {}
 
 func (x *WriteDecisionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[74]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5017,7 +5896,7 @@ func (x *WriteDecisionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteDecisionRequest.ProtoReflect.Descriptor instead.
 func (*WriteDecisionRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{74}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *WriteDecisionRequest) GetId() string {
@@ -5136,7 +6015,7 @@ type WriteDecisionResponse struct {
 
 func (x *WriteDecisionResponse) Reset() {
 	*x = WriteDecisionResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[75]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5148,7 +6027,7 @@ func (x *WriteDecisionResponse) String() string {
 func (*WriteDecisionResponse) ProtoMessage() {}
 
 func (x *WriteDecisionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[75]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5161,7 +6040,7 @@ func (x *WriteDecisionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteDecisionResponse.ProtoReflect.Descriptor instead.
 func (*WriteDecisionResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{75}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *WriteDecisionResponse) GetDecisionId() string {
@@ -5202,7 +6081,7 @@ type WriteActionRequest struct {
 
 func (x *WriteActionRequest) Reset() {
 	*x = WriteActionRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[76]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5214,7 +6093,7 @@ func (x *WriteActionRequest) String() string {
 func (*WriteActionRequest) ProtoMessage() {}
 
 func (x *WriteActionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[76]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5227,7 +6106,7 @@ func (x *WriteActionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteActionRequest.ProtoReflect.Descriptor instead.
 func (*WriteActionRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{76}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *WriteActionRequest) GetId() string {
@@ -5347,7 +6226,7 @@ type WriteActionResponse struct {
 
 func (x *WriteActionResponse) Reset() {
 	*x = WriteActionResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[77]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5359,7 +6238,7 @@ func (x *WriteActionResponse) String() string {
 func (*WriteActionResponse) ProtoMessage() {}
 
 func (x *WriteActionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[77]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5372,7 +6251,7 @@ func (x *WriteActionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteActionResponse.ProtoReflect.Descriptor instead.
 func (*WriteActionResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{77}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *WriteActionResponse) GetActionId() string {
@@ -5418,7 +6297,7 @@ type WriteOutcomeRequest struct {
 
 func (x *WriteOutcomeRequest) Reset() {
 	*x = WriteOutcomeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[78]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5430,7 +6309,7 @@ func (x *WriteOutcomeRequest) String() string {
 func (*WriteOutcomeRequest) ProtoMessage() {}
 
 func (x *WriteOutcomeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[78]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5443,7 +6322,7 @@ func (x *WriteOutcomeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteOutcomeRequest.ProtoReflect.Descriptor instead.
 func (*WriteOutcomeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{78}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *WriteOutcomeRequest) GetId() string {
@@ -5549,7 +6428,7 @@ type WriteOutcomeResponse struct {
 
 func (x *WriteOutcomeResponse) Reset() {
 	*x = WriteOutcomeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[79]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5561,7 +6440,7 @@ func (x *WriteOutcomeResponse) String() string {
 func (*WriteOutcomeResponse) ProtoMessage() {}
 
 func (x *WriteOutcomeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[79]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5574,7 +6453,7 @@ func (x *WriteOutcomeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteOutcomeResponse.ProtoReflect.Descriptor instead.
 func (*WriteOutcomeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{79}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *WriteOutcomeResponse) GetOutcomeId() string {
@@ -5611,7 +6490,7 @@ type ReplayWorkflowEventsRequest struct {
 
 func (x *ReplayWorkflowEventsRequest) Reset() {
 	*x = ReplayWorkflowEventsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5623,7 +6502,7 @@ func (x *ReplayWorkflowEventsRequest) String() string {
 func (*ReplayWorkflowEventsRequest) ProtoMessage() {}
 
 func (x *ReplayWorkflowEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5636,7 +6515,7 @@ func (x *ReplayWorkflowEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayWorkflowEventsRequest.ProtoReflect.Descriptor instead.
 func (*ReplayWorkflowEventsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{80}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *ReplayWorkflowEventsRequest) GetKindPrefix() string {
@@ -5680,7 +6559,7 @@ type ReplayWorkflowEventsResponse struct {
 
 func (x *ReplayWorkflowEventsResponse) Reset() {
 	*x = ReplayWorkflowEventsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5692,7 +6571,7 @@ func (x *ReplayWorkflowEventsResponse) String() string {
 func (*ReplayWorkflowEventsResponse) ProtoMessage() {}
 
 func (x *ReplayWorkflowEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5705,7 +6584,7 @@ func (x *ReplayWorkflowEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayWorkflowEventsResponse.ProtoReflect.Descriptor instead.
 func (*ReplayWorkflowEventsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{81}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *ReplayWorkflowEventsResponse) GetEventsRead() uint32 {
@@ -5748,7 +6627,7 @@ type GraphEntity struct {
 
 func (x *GraphEntity) Reset() {
 	*x = GraphEntity{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5760,7 +6639,7 @@ func (x *GraphEntity) String() string {
 func (*GraphEntity) ProtoMessage() {}
 
 func (x *GraphEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5773,7 +6652,7 @@ func (x *GraphEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphEntity.ProtoReflect.Descriptor instead.
 func (*GraphEntity) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{82}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *GraphEntity) GetUrn() string {
@@ -5809,7 +6688,7 @@ type GraphRelation struct {
 
 func (x *GraphRelation) Reset() {
 	*x = GraphRelation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5821,7 +6700,7 @@ func (x *GraphRelation) String() string {
 func (*GraphRelation) ProtoMessage() {}
 
 func (x *GraphRelation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5834,7 +6713,7 @@ func (x *GraphRelation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphRelation.ProtoReflect.Descriptor instead.
 func (*GraphRelation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{83}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *GraphRelation) GetFromUrn() string {
@@ -5869,7 +6748,7 @@ type GetEntityNeighborhoodRequest struct {
 
 func (x *GetEntityNeighborhoodRequest) Reset() {
 	*x = GetEntityNeighborhoodRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5881,7 +6760,7 @@ func (x *GetEntityNeighborhoodRequest) String() string {
 func (*GetEntityNeighborhoodRequest) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5894,7 +6773,7 @@ func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodRequest.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{84}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *GetEntityNeighborhoodRequest) GetRootUrn() string {
@@ -5923,7 +6802,7 @@ type GetEntityNeighborhoodResponse struct {
 
 func (x *GetEntityNeighborhoodResponse) Reset() {
 	*x = GetEntityNeighborhoodResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5935,7 +6814,7 @@ func (x *GetEntityNeighborhoodResponse) String() string {
 func (*GetEntityNeighborhoodResponse) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5948,7 +6827,7 @@ func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodResponse.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{85}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *GetEntityNeighborhoodResponse) GetRoot() *GraphEntity {
@@ -5999,7 +6878,7 @@ type GraphIngestRun struct {
 
 func (x *GraphIngestRun) Reset() {
 	*x = GraphIngestRun{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6011,7 +6890,7 @@ func (x *GraphIngestRun) String() string {
 func (*GraphIngestRun) ProtoMessage() {}
 
 func (x *GraphIngestRun) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6024,7 +6903,7 @@ func (x *GraphIngestRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphIngestRun.ProtoReflect.Descriptor instead.
 func (*GraphIngestRun) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{86}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *GraphIngestRun) GetId() string {
@@ -6179,7 +7058,7 @@ type GraphIngestResult struct {
 
 func (x *GraphIngestResult) Reset() {
 	*x = GraphIngestResult{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6191,7 +7070,7 @@ func (x *GraphIngestResult) String() string {
 func (*GraphIngestResult) ProtoMessage() {}
 
 func (x *GraphIngestResult) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6204,7 +7083,7 @@ func (x *GraphIngestResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphIngestResult.ProtoReflect.Descriptor instead.
 func (*GraphIngestResult) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{87}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *GraphIngestResult) GetSourceId() string {
@@ -6337,7 +7216,7 @@ type GraphIngestRunResult struct {
 
 func (x *GraphIngestRunResult) Reset() {
 	*x = GraphIngestRunResult{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6349,7 +7228,7 @@ func (x *GraphIngestRunResult) String() string {
 func (*GraphIngestRunResult) ProtoMessage() {}
 
 func (x *GraphIngestRunResult) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6362,7 +7241,7 @@ func (x *GraphIngestRunResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphIngestRunResult.ProtoReflect.Descriptor instead.
 func (*GraphIngestRunResult) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{88}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *GraphIngestRunResult) GetRun() *GraphIngestRun {
@@ -6392,7 +7271,7 @@ type RunGraphIngestRuntimeRequest struct {
 
 func (x *RunGraphIngestRuntimeRequest) Reset() {
 	*x = RunGraphIngestRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6404,7 +7283,7 @@ func (x *RunGraphIngestRuntimeRequest) String() string {
 func (*RunGraphIngestRuntimeRequest) ProtoMessage() {}
 
 func (x *RunGraphIngestRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6417,7 +7296,7 @@ func (x *RunGraphIngestRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunGraphIngestRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*RunGraphIngestRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{89}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *RunGraphIngestRuntimeRequest) GetRuntimeId() string {
@@ -6458,7 +7337,7 @@ type RunGraphIngestRuntimeResponse struct {
 
 func (x *RunGraphIngestRuntimeResponse) Reset() {
 	*x = RunGraphIngestRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6470,7 +7349,7 @@ func (x *RunGraphIngestRuntimeResponse) String() string {
 func (*RunGraphIngestRuntimeResponse) ProtoMessage() {}
 
 func (x *RunGraphIngestRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6483,7 +7362,7 @@ func (x *RunGraphIngestRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunGraphIngestRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*RunGraphIngestRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{90}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *RunGraphIngestRuntimeResponse) GetResult() *GraphIngestRunResult {
@@ -6503,7 +7382,7 @@ type GetGraphIngestRunRequest struct {
 
 func (x *GetGraphIngestRunRequest) Reset() {
 	*x = GetGraphIngestRunRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6515,7 +7394,7 @@ func (x *GetGraphIngestRunRequest) String() string {
 func (*GetGraphIngestRunRequest) ProtoMessage() {}
 
 func (x *GetGraphIngestRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6528,7 +7407,7 @@ func (x *GetGraphIngestRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGraphIngestRunRequest.ProtoReflect.Descriptor instead.
 func (*GetGraphIngestRunRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{91}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *GetGraphIngestRunRequest) GetId() string {
@@ -6548,7 +7427,7 @@ type GetGraphIngestRunResponse struct {
 
 func (x *GetGraphIngestRunResponse) Reset() {
 	*x = GetGraphIngestRunResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6560,7 +7439,7 @@ func (x *GetGraphIngestRunResponse) String() string {
 func (*GetGraphIngestRunResponse) ProtoMessage() {}
 
 func (x *GetGraphIngestRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6573,7 +7452,7 @@ func (x *GetGraphIngestRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGraphIngestRunResponse.ProtoReflect.Descriptor instead.
 func (*GetGraphIngestRunResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{92}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *GetGraphIngestRunResponse) GetRun() *GraphIngestRun {
@@ -6595,7 +7474,7 @@ type ListGraphIngestRunsRequest struct {
 
 func (x *ListGraphIngestRunsRequest) Reset() {
 	*x = ListGraphIngestRunsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6607,7 +7486,7 @@ func (x *ListGraphIngestRunsRequest) String() string {
 func (*ListGraphIngestRunsRequest) ProtoMessage() {}
 
 func (x *ListGraphIngestRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6620,7 +7499,7 @@ func (x *ListGraphIngestRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGraphIngestRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListGraphIngestRunsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{93}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *ListGraphIngestRunsRequest) GetRuntimeId() string {
@@ -6655,7 +7534,7 @@ type ListGraphIngestRunsResponse struct {
 
 func (x *ListGraphIngestRunsResponse) Reset() {
 	*x = ListGraphIngestRunsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[94]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6667,7 +7546,7 @@ func (x *ListGraphIngestRunsResponse) String() string {
 func (*ListGraphIngestRunsResponse) ProtoMessage() {}
 
 func (x *ListGraphIngestRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[94]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6680,7 +7559,7 @@ func (x *ListGraphIngestRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGraphIngestRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListGraphIngestRunsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{94}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *ListGraphIngestRunsResponse) GetRuns() []*GraphIngestRun {
@@ -6707,7 +7586,7 @@ type CheckGraphIngestHealthRequest struct {
 
 func (x *CheckGraphIngestHealthRequest) Reset() {
 	*x = CheckGraphIngestHealthRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[95]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6719,7 +7598,7 @@ func (x *CheckGraphIngestHealthRequest) String() string {
 func (*CheckGraphIngestHealthRequest) ProtoMessage() {}
 
 func (x *CheckGraphIngestHealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[95]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6732,7 +7611,7 @@ func (x *CheckGraphIngestHealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckGraphIngestHealthRequest.ProtoReflect.Descriptor instead.
 func (*CheckGraphIngestHealthRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{95}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *CheckGraphIngestHealthRequest) GetLimit() uint32 {
@@ -6756,7 +7635,7 @@ type CheckGraphIngestHealthResponse struct {
 
 func (x *CheckGraphIngestHealthResponse) Reset() {
 	*x = CheckGraphIngestHealthResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[96]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6768,7 +7647,7 @@ func (x *CheckGraphIngestHealthResponse) String() string {
 func (*CheckGraphIngestHealthResponse) ProtoMessage() {}
 
 func (x *CheckGraphIngestHealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[96]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6781,7 +7660,7 @@ func (x *CheckGraphIngestHealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckGraphIngestHealthResponse.ProtoReflect.Descriptor instead.
 func (*CheckGraphIngestHealthResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{96}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *CheckGraphIngestHealthResponse) GetStatus() string {
@@ -7233,7 +8112,99 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x19LinkFindingTicketResponse\x12-\n" +
 	"\afinding\x18\x01 \x01(\v2\x13.cerebro.v1.FindingR\afinding\"G\n" +
 	"\x14ListFindingsResponse\x12/\n" +
-	"\bfindings\x18\x01 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\"p\n" +
+	"\bfindings\x18\x01 \x03(\v2\x13.cerebro.v1.FindingR\bfindings\"\xb3\x03\n" +
+	"\x13FindingCandidateRun\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
+	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x03 \x01(\tR\truntimeId\x12\x17\n" +
+	"\arule_id\x18\x04 \x01(\tR\x06ruleId\x12\x16\n" +
+	"\x06status\x18\x05 \x01(\tR\x06status\x12\x1f\n" +
+	"\vevent_limit\x18\x06 \x01(\rR\n" +
+	"eventLimit\x12)\n" +
+	"\x10events_evaluated\x18\a \x01(\rR\x0feventsEvaluated\x12%\n" +
+	"\x0eevents_matched\x18\b \x01(\rR\reventsMatched\x12\x1e\n" +
+	"\n" +
+	"candidates\x18\t \x01(\rR\n" +
+	"candidates\x129\n" +
+	"\n" +
+	"started_at\x18\n" +
+	" \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12;\n" +
+	"\vfinished_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"finishedAt\x12\x14\n" +
+	"\x05error\x18\f \x01(\tR\x05error\"\xef\x06\n" +
+	"\x10FindingCandidate\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
+	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x03 \x01(\tR\truntimeId\x12\x17\n" +
+	"\arule_id\x18\x04 \x01(\tR\x06ruleId\x12 \n" +
+	"\vfingerprint\x18\x05 \x01(\tR\vfingerprint\x12\x16\n" +
+	"\x06status\x18\x06 \x01(\tR\x06status\x12-\n" +
+	"\afinding\x18\a \x01(\v2\x13.cerebro.v1.FindingR\afinding\x127\n" +
+	"\bevidence\x18\b \x03(\v2\x1b.cerebro.v1.FindingEvidenceR\bevidence\x12\x1e\n" +
+	"\vlast_run_id\x18\t \x01(\tR\tlastRunId\x12+\n" +
+	"\x11observation_count\x18\n" +
+	" \x01(\rR\x10observationCount\x12F\n" +
+	"\x11first_observed_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\x0ffirstObservedAt\x12D\n" +
+	"\x10last_observed_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\x0elastObservedAt\x12.\n" +
+	"\x13promoted_finding_id\x18\r \x01(\tR\x11promotedFindingId\x12\x1f\n" +
+	"\vdecision_id\x18\x0e \x01(\tR\n" +
+	"decisionId\x12\x1f\n" +
+	"\vpromoted_by\x18\x0f \x01(\tR\n" +
+	"promotedBy\x12/\n" +
+	"\x13promotion_rationale\x18\x10 \x01(\tR\x12promotionRationale\x12#\n" +
+	"\rchange_ticket\x18\x11 \x01(\tR\fchangeTicket\x12;\n" +
+	"\vpromoted_at\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"promotedAt\x129\n" +
+	"\n" +
+	"created_at\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
+	"\n" +
+	"updated_at\x18\x14 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\xc9\x01\n" +
+	"\x1cListFindingCandidatesRequest\x12\x1d\n" +
+	"\n" +
+	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12!\n" +
+	"\fcandidate_id\x18\x02 \x01(\tR\vcandidateId\x12\x17\n" +
+	"\arule_id\x18\x03 \x01(\tR\x06ruleId\x12\x16\n" +
+	"\x06status\x18\x04 \x01(\tR\x06status\x12 \n" +
+	"\vfingerprint\x18\x05 \x01(\tR\vfingerprint\x12\x14\n" +
+	"\x05limit\x18\x06 \x01(\rR\x05limit\"]\n" +
+	"\x1dListFindingCandidatesResponse\x12<\n" +
+	"\n" +
+	"candidates\x18\x01 \x03(\v2\x1c.cerebro.v1.FindingCandidateR\n" +
+	"candidates\",\n" +
+	"\x1aGetFindingCandidateRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"Y\n" +
+	"\x1bGetFindingCandidateResponse\x12:\n" +
+	"\tcandidate\x18\x01 \x01(\v2\x1c.cerebro.v1.FindingCandidateR\tcandidate\"{\n" +
+	"-EvaluateSourceRuntimeFindingCandidatesRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x19\n" +
+	"\brule_ids\x18\x02 \x03(\tR\aruleIds\x12\x1f\n" +
+	"\vevent_limit\x18\x03 \x01(\rR\n" +
+	"eventLimit\"\xbb\x01\n" +
+	"\x1eFindingCandidateRuleEvaluation\x12(\n" +
+	"\x04rule\x18\x01 \x01(\v2\x14.cerebro.v1.RuleSpecR\x04rule\x121\n" +
+	"\x03run\x18\x02 \x01(\v2\x1f.cerebro.v1.FindingCandidateRunR\x03run\x12<\n" +
+	"\n" +
+	"candidates\x18\x03 \x03(\v2\x1c.cerebro.v1.FindingCandidateR\n" +
+	"candidates\"\xde\x01\n" +
+	".EvaluateSourceRuntimeFindingCandidatesResponse\x123\n" +
+	"\aruntime\x18\x01 \x01(\v2\x19.cerebro.v1.SourceRuntimeR\aruntime\x12)\n" +
+	"\x10events_evaluated\x18\x02 \x01(\rR\x0feventsEvaluated\x12L\n" +
+	"\vevaluations\x18\x03 \x03(\v2*.cerebro.v1.FindingCandidateRuleEvaluationR\vevaluations\"\x84\x02\n" +
+	"\x1ePromoteFindingCandidateRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
+	"\vpromoted_by\x18\x02 \x01(\tR\n" +
+	"promotedBy\x12\x1c\n" +
+	"\trationale\x18\x03 \x01(\tR\trationale\x12#\n" +
+	"\rchange_ticket\x18\x04 \x01(\tR\fchangeTicket\x126\n" +
+	"\x17false_positive_reviewed\x18\x05 \x01(\bR\x15falsePositiveReviewed\x126\n" +
+	"\x17graph_coverage_reviewed\x18\x06 \x01(\bR\x15graphCoverageReviewed\"\xad\x01\n" +
+	"\x1fPromoteFindingCandidateResponse\x12-\n" +
+	"\afinding\x18\x01 \x01(\v2\x13.cerebro.v1.FindingR\afinding\x12:\n" +
+	"\tcandidate\x18\x02 \x01(\v2\x1c.cerebro.v1.FindingCandidateR\tcandidate\x12\x1f\n" +
+	"\vdecision_id\x18\x03 \x01(\tR\n" +
+	"decisionId\"p\n" +
 	"$EvaluateSourceRuntimeFindingsRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vevent_limit\x18\x02 \x01(\rR\n" +
@@ -7464,7 +8435,7 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x19FINDING_ORDER_UNSPECIFIED\x10\x00\x12\x1f\n" +
 	"\x1bFINDING_ORDER_LAST_OBSERVED\x10\x01\x12\x1a\n" +
 	"\x16FINDING_ORDER_PRIORITY\x10\x02\x12\x1c\n" +
-	"\x18FINDING_ORDER_RISK_SCORE\x10\x032\xb4\x1c\n" +
+	"\x18FINDING_ORDER_RISK_SCORE\x10\x032\xa0 \n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -7486,7 +8457,11 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"ListClaims\x12\x1d.cerebro.v1.ListClaimsRequest\x1a\x1e.cerebro.v1.ListClaimsResponse\x12Q\n" +
 	"\fListFindings\x12\x1f.cerebro.v1.ListFindingsRequest\x1a .cerebro.v1.ListFindingsResponse\x12K\n" +
 	"\n" +
-	"GetFinding\x12\x1d.cerebro.v1.GetFindingRequest\x1a\x1e.cerebro.v1.GetFindingResponse\x12W\n" +
+	"GetFinding\x12\x1d.cerebro.v1.GetFindingRequest\x1a\x1e.cerebro.v1.GetFindingResponse\x12l\n" +
+	"\x15ListFindingCandidates\x12(.cerebro.v1.ListFindingCandidatesRequest\x1a).cerebro.v1.ListFindingCandidatesResponse\x12f\n" +
+	"\x13GetFindingCandidate\x12&.cerebro.v1.GetFindingCandidateRequest\x1a'.cerebro.v1.GetFindingCandidateResponse\x12\x9f\x01\n" +
+	"&EvaluateSourceRuntimeFindingCandidates\x129.cerebro.v1.EvaluateSourceRuntimeFindingCandidatesRequest\x1a:.cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse\x12r\n" +
+	"\x17PromoteFindingCandidate\x12*.cerebro.v1.PromoteFindingCandidateRequest\x1a+.cerebro.v1.PromoteFindingCandidateResponse\x12W\n" +
 	"\x0eResolveFinding\x12!.cerebro.v1.ResolveFindingRequest\x1a\".cerebro.v1.ResolveFindingResponse\x12Z\n" +
 	"\x0fSuppressFinding\x12\".cerebro.v1.SuppressFindingRequest\x1a#.cerebro.v1.SuppressFindingResponse\x12T\n" +
 	"\rAssignFinding\x12 .cerebro.v1.AssignFindingRequest\x1a!.cerebro.v1.AssignFindingResponse\x12`\n" +
@@ -7522,319 +8497,356 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 }
 
 var file_cerebro_v1_bootstrap_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 108)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 119)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
-	(FindingStatus)(0),                                // 0: cerebro.v1.FindingStatus
-	(FindingOrder)(0),                                 // 1: cerebro.v1.FindingOrder
-	(*GetVersionRequest)(nil),                         // 2: cerebro.v1.GetVersionRequest
-	(*GetVersionResponse)(nil),                        // 3: cerebro.v1.GetVersionResponse
-	(*CheckHealthRequest)(nil),                        // 4: cerebro.v1.CheckHealthRequest
-	(*ComponentStatus)(nil),                           // 5: cerebro.v1.ComponentStatus
-	(*CheckHealthResponse)(nil),                       // 6: cerebro.v1.CheckHealthResponse
-	(*ReportParameter)(nil),                           // 7: cerebro.v1.ReportParameter
-	(*ReportDefinition)(nil),                          // 8: cerebro.v1.ReportDefinition
-	(*ReportRun)(nil),                                 // 9: cerebro.v1.ReportRun
-	(*ListReportDefinitionsRequest)(nil),              // 10: cerebro.v1.ListReportDefinitionsRequest
-	(*ListReportDefinitionsResponse)(nil),             // 11: cerebro.v1.ListReportDefinitionsResponse
-	(*ListFindingRulesRequest)(nil),                   // 12: cerebro.v1.ListFindingRulesRequest
-	(*ListFindingRulesResponse)(nil),                  // 13: cerebro.v1.ListFindingRulesResponse
-	(*FindingEvaluationRun)(nil),                      // 14: cerebro.v1.FindingEvaluationRun
-	(*ListFindingEvaluationRunsRequest)(nil),          // 15: cerebro.v1.ListFindingEvaluationRunsRequest
-	(*ListFindingEvaluationRunsResponse)(nil),         // 16: cerebro.v1.ListFindingEvaluationRunsResponse
-	(*GetFindingEvaluationRunRequest)(nil),            // 17: cerebro.v1.GetFindingEvaluationRunRequest
-	(*GetFindingEvaluationRunResponse)(nil),           // 18: cerebro.v1.GetFindingEvaluationRunResponse
-	(*GraphEvidencePath)(nil),                         // 19: cerebro.v1.GraphEvidencePath
-	(*GraphEvidenceRow)(nil),                          // 20: cerebro.v1.GraphEvidenceRow
-	(*FindingEvidenceObservation)(nil),                // 21: cerebro.v1.FindingEvidenceObservation
-	(*FindingEvidence)(nil),                           // 22: cerebro.v1.FindingEvidence
-	(*ListFindingEvidenceRequest)(nil),                // 23: cerebro.v1.ListFindingEvidenceRequest
-	(*ListFindingEvidenceResponse)(nil),               // 24: cerebro.v1.ListFindingEvidenceResponse
-	(*GetFindingEvidenceRequest)(nil),                 // 25: cerebro.v1.GetFindingEvidenceRequest
-	(*GetFindingEvidenceResponse)(nil),                // 26: cerebro.v1.GetFindingEvidenceResponse
-	(*RunReportRequest)(nil),                          // 27: cerebro.v1.RunReportRequest
-	(*RunReportResponse)(nil),                         // 28: cerebro.v1.RunReportResponse
-	(*GetReportRunRequest)(nil),                       // 29: cerebro.v1.GetReportRunRequest
-	(*GetReportRunResponse)(nil),                      // 30: cerebro.v1.GetReportRunResponse
-	(*ListSourcesRequest)(nil),                        // 31: cerebro.v1.ListSourcesRequest
-	(*ListSourcesResponse)(nil),                       // 32: cerebro.v1.ListSourcesResponse
-	(*CheckSourceRequest)(nil),                        // 33: cerebro.v1.CheckSourceRequest
-	(*CheckSourceResponse)(nil),                       // 34: cerebro.v1.CheckSourceResponse
-	(*DiscoverSourceRequest)(nil),                     // 35: cerebro.v1.DiscoverSourceRequest
-	(*DiscoverSourceResponse)(nil),                    // 36: cerebro.v1.DiscoverSourceResponse
-	(*ReadSourceRequest)(nil),                         // 37: cerebro.v1.ReadSourceRequest
-	(*SourcePreviewEvent)(nil),                        // 38: cerebro.v1.SourcePreviewEvent
-	(*ReadSourceResponse)(nil),                        // 39: cerebro.v1.ReadSourceResponse
-	(*SourceRuntime)(nil),                             // 40: cerebro.v1.SourceRuntime
-	(*PutSourceRuntimeRequest)(nil),                   // 41: cerebro.v1.PutSourceRuntimeRequest
-	(*PutSourceRuntimeResponse)(nil),                  // 42: cerebro.v1.PutSourceRuntimeResponse
-	(*GetSourceRuntimeRequest)(nil),                   // 43: cerebro.v1.GetSourceRuntimeRequest
-	(*GetSourceRuntimeResponse)(nil),                  // 44: cerebro.v1.GetSourceRuntimeResponse
-	(*SyncSourceRuntimeRequest)(nil),                  // 45: cerebro.v1.SyncSourceRuntimeRequest
-	(*SyncSourceRuntimeResponse)(nil),                 // 46: cerebro.v1.SyncSourceRuntimeResponse
-	(*WriteClaimsRequest)(nil),                        // 47: cerebro.v1.WriteClaimsRequest
-	(*WriteClaimsResponse)(nil),                       // 48: cerebro.v1.WriteClaimsResponse
-	(*ListClaimsRequest)(nil),                         // 49: cerebro.v1.ListClaimsRequest
-	(*ListClaimsResponse)(nil),                        // 50: cerebro.v1.ListClaimsResponse
-	(*ListFindingsRequest)(nil),                       // 51: cerebro.v1.ListFindingsRequest
-	(*FindingControlRef)(nil),                         // 52: cerebro.v1.FindingControlRef
-	(*FindingNote)(nil),                               // 53: cerebro.v1.FindingNote
-	(*FindingTicket)(nil),                             // 54: cerebro.v1.FindingTicket
-	(*Finding)(nil),                                   // 55: cerebro.v1.Finding
-	(*GetFindingRequest)(nil),                         // 56: cerebro.v1.GetFindingRequest
-	(*GetFindingResponse)(nil),                        // 57: cerebro.v1.GetFindingResponse
-	(*ResolveFindingRequest)(nil),                     // 58: cerebro.v1.ResolveFindingRequest
-	(*ResolveFindingResponse)(nil),                    // 59: cerebro.v1.ResolveFindingResponse
-	(*SuppressFindingRequest)(nil),                    // 60: cerebro.v1.SuppressFindingRequest
-	(*SuppressFindingResponse)(nil),                   // 61: cerebro.v1.SuppressFindingResponse
-	(*AssignFindingRequest)(nil),                      // 62: cerebro.v1.AssignFindingRequest
-	(*AssignFindingResponse)(nil),                     // 63: cerebro.v1.AssignFindingResponse
-	(*SetFindingDueDateRequest)(nil),                  // 64: cerebro.v1.SetFindingDueDateRequest
-	(*SetFindingDueDateResponse)(nil),                 // 65: cerebro.v1.SetFindingDueDateResponse
-	(*AddFindingNoteRequest)(nil),                     // 66: cerebro.v1.AddFindingNoteRequest
-	(*AddFindingNoteResponse)(nil),                    // 67: cerebro.v1.AddFindingNoteResponse
-	(*LinkFindingTicketRequest)(nil),                  // 68: cerebro.v1.LinkFindingTicketRequest
-	(*LinkFindingTicketResponse)(nil),                 // 69: cerebro.v1.LinkFindingTicketResponse
-	(*ListFindingsResponse)(nil),                      // 70: cerebro.v1.ListFindingsResponse
-	(*EvaluateSourceRuntimeFindingsRequest)(nil),      // 71: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	(*EvaluateSourceRuntimeFindingRulesRequest)(nil),  // 72: cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
-	(*FindingRuleEvaluation)(nil),                     // 73: cerebro.v1.FindingRuleEvaluation
-	(*EvaluateSourceRuntimeFindingRulesResponse)(nil), // 74: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
-	(*EvaluateSourceRuntimeFindingsResponse)(nil),     // 75: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	(*WriteDecisionRequest)(nil),                      // 76: cerebro.v1.WriteDecisionRequest
-	(*WriteDecisionResponse)(nil),                     // 77: cerebro.v1.WriteDecisionResponse
-	(*WriteActionRequest)(nil),                        // 78: cerebro.v1.WriteActionRequest
-	(*WriteActionResponse)(nil),                       // 79: cerebro.v1.WriteActionResponse
-	(*WriteOutcomeRequest)(nil),                       // 80: cerebro.v1.WriteOutcomeRequest
-	(*WriteOutcomeResponse)(nil),                      // 81: cerebro.v1.WriteOutcomeResponse
-	(*ReplayWorkflowEventsRequest)(nil),               // 82: cerebro.v1.ReplayWorkflowEventsRequest
-	(*ReplayWorkflowEventsResponse)(nil),              // 83: cerebro.v1.ReplayWorkflowEventsResponse
-	(*GraphEntity)(nil),                               // 84: cerebro.v1.GraphEntity
-	(*GraphRelation)(nil),                             // 85: cerebro.v1.GraphRelation
-	(*GetEntityNeighborhoodRequest)(nil),              // 86: cerebro.v1.GetEntityNeighborhoodRequest
-	(*GetEntityNeighborhoodResponse)(nil),             // 87: cerebro.v1.GetEntityNeighborhoodResponse
-	(*GraphIngestRun)(nil),                            // 88: cerebro.v1.GraphIngestRun
-	(*GraphIngestResult)(nil),                         // 89: cerebro.v1.GraphIngestResult
-	(*GraphIngestRunResult)(nil),                      // 90: cerebro.v1.GraphIngestRunResult
-	(*RunGraphIngestRuntimeRequest)(nil),              // 91: cerebro.v1.RunGraphIngestRuntimeRequest
-	(*RunGraphIngestRuntimeResponse)(nil),             // 92: cerebro.v1.RunGraphIngestRuntimeResponse
-	(*GetGraphIngestRunRequest)(nil),                  // 93: cerebro.v1.GetGraphIngestRunRequest
-	(*GetGraphIngestRunResponse)(nil),                 // 94: cerebro.v1.GetGraphIngestRunResponse
-	(*ListGraphIngestRunsRequest)(nil),                // 95: cerebro.v1.ListGraphIngestRunsRequest
-	(*ListGraphIngestRunsResponse)(nil),               // 96: cerebro.v1.ListGraphIngestRunsResponse
-	(*CheckGraphIngestHealthRequest)(nil),             // 97: cerebro.v1.CheckGraphIngestHealthRequest
-	(*CheckGraphIngestHealthResponse)(nil),            // 98: cerebro.v1.CheckGraphIngestHealthResponse
-	nil,                                               // 99: cerebro.v1.ReportRun.ParametersEntry
-	nil,                                               // 100: cerebro.v1.GraphEvidencePath.AttributesEntry
-	nil,                                               // 101: cerebro.v1.GraphEvidenceRow.AttributesEntry
-	nil,                                               // 102: cerebro.v1.FindingEvidence.AttributesEntry
-	nil,                                               // 103: cerebro.v1.RunReportRequest.ParametersEntry
-	nil,                                               // 104: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                                               // 105: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                                               // 106: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                                               // 107: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                                               // 108: cerebro.v1.Finding.AttributesEntry
-	nil,                                               // 109: cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
-	(*timestamppb.Timestamp)(nil),                     // 110: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                           // 111: google.protobuf.Struct
-	(*RuleSpec)(nil),                                  // 112: cerebro.v1.RuleSpec
-	(*SourceSpec)(nil),                                // 113: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),                              // 114: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                             // 115: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                            // 116: google.protobuf.Value
-	(*SourceCheckpoint)(nil),                          // 117: cerebro.v1.SourceCheckpoint
-	(*Claim)(nil),                                     // 118: cerebro.v1.Claim
+	(FindingStatus)(0),                                     // 0: cerebro.v1.FindingStatus
+	(FindingOrder)(0),                                      // 1: cerebro.v1.FindingOrder
+	(*GetVersionRequest)(nil),                              // 2: cerebro.v1.GetVersionRequest
+	(*GetVersionResponse)(nil),                             // 3: cerebro.v1.GetVersionResponse
+	(*CheckHealthRequest)(nil),                             // 4: cerebro.v1.CheckHealthRequest
+	(*ComponentStatus)(nil),                                // 5: cerebro.v1.ComponentStatus
+	(*CheckHealthResponse)(nil),                            // 6: cerebro.v1.CheckHealthResponse
+	(*ReportParameter)(nil),                                // 7: cerebro.v1.ReportParameter
+	(*ReportDefinition)(nil),                               // 8: cerebro.v1.ReportDefinition
+	(*ReportRun)(nil),                                      // 9: cerebro.v1.ReportRun
+	(*ListReportDefinitionsRequest)(nil),                   // 10: cerebro.v1.ListReportDefinitionsRequest
+	(*ListReportDefinitionsResponse)(nil),                  // 11: cerebro.v1.ListReportDefinitionsResponse
+	(*ListFindingRulesRequest)(nil),                        // 12: cerebro.v1.ListFindingRulesRequest
+	(*ListFindingRulesResponse)(nil),                       // 13: cerebro.v1.ListFindingRulesResponse
+	(*FindingEvaluationRun)(nil),                           // 14: cerebro.v1.FindingEvaluationRun
+	(*ListFindingEvaluationRunsRequest)(nil),               // 15: cerebro.v1.ListFindingEvaluationRunsRequest
+	(*ListFindingEvaluationRunsResponse)(nil),              // 16: cerebro.v1.ListFindingEvaluationRunsResponse
+	(*GetFindingEvaluationRunRequest)(nil),                 // 17: cerebro.v1.GetFindingEvaluationRunRequest
+	(*GetFindingEvaluationRunResponse)(nil),                // 18: cerebro.v1.GetFindingEvaluationRunResponse
+	(*GraphEvidencePath)(nil),                              // 19: cerebro.v1.GraphEvidencePath
+	(*GraphEvidenceRow)(nil),                               // 20: cerebro.v1.GraphEvidenceRow
+	(*FindingEvidenceObservation)(nil),                     // 21: cerebro.v1.FindingEvidenceObservation
+	(*FindingEvidence)(nil),                                // 22: cerebro.v1.FindingEvidence
+	(*ListFindingEvidenceRequest)(nil),                     // 23: cerebro.v1.ListFindingEvidenceRequest
+	(*ListFindingEvidenceResponse)(nil),                    // 24: cerebro.v1.ListFindingEvidenceResponse
+	(*GetFindingEvidenceRequest)(nil),                      // 25: cerebro.v1.GetFindingEvidenceRequest
+	(*GetFindingEvidenceResponse)(nil),                     // 26: cerebro.v1.GetFindingEvidenceResponse
+	(*RunReportRequest)(nil),                               // 27: cerebro.v1.RunReportRequest
+	(*RunReportResponse)(nil),                              // 28: cerebro.v1.RunReportResponse
+	(*GetReportRunRequest)(nil),                            // 29: cerebro.v1.GetReportRunRequest
+	(*GetReportRunResponse)(nil),                           // 30: cerebro.v1.GetReportRunResponse
+	(*ListSourcesRequest)(nil),                             // 31: cerebro.v1.ListSourcesRequest
+	(*ListSourcesResponse)(nil),                            // 32: cerebro.v1.ListSourcesResponse
+	(*CheckSourceRequest)(nil),                             // 33: cerebro.v1.CheckSourceRequest
+	(*CheckSourceResponse)(nil),                            // 34: cerebro.v1.CheckSourceResponse
+	(*DiscoverSourceRequest)(nil),                          // 35: cerebro.v1.DiscoverSourceRequest
+	(*DiscoverSourceResponse)(nil),                         // 36: cerebro.v1.DiscoverSourceResponse
+	(*ReadSourceRequest)(nil),                              // 37: cerebro.v1.ReadSourceRequest
+	(*SourcePreviewEvent)(nil),                             // 38: cerebro.v1.SourcePreviewEvent
+	(*ReadSourceResponse)(nil),                             // 39: cerebro.v1.ReadSourceResponse
+	(*SourceRuntime)(nil),                                  // 40: cerebro.v1.SourceRuntime
+	(*PutSourceRuntimeRequest)(nil),                        // 41: cerebro.v1.PutSourceRuntimeRequest
+	(*PutSourceRuntimeResponse)(nil),                       // 42: cerebro.v1.PutSourceRuntimeResponse
+	(*GetSourceRuntimeRequest)(nil),                        // 43: cerebro.v1.GetSourceRuntimeRequest
+	(*GetSourceRuntimeResponse)(nil),                       // 44: cerebro.v1.GetSourceRuntimeResponse
+	(*SyncSourceRuntimeRequest)(nil),                       // 45: cerebro.v1.SyncSourceRuntimeRequest
+	(*SyncSourceRuntimeResponse)(nil),                      // 46: cerebro.v1.SyncSourceRuntimeResponse
+	(*WriteClaimsRequest)(nil),                             // 47: cerebro.v1.WriteClaimsRequest
+	(*WriteClaimsResponse)(nil),                            // 48: cerebro.v1.WriteClaimsResponse
+	(*ListClaimsRequest)(nil),                              // 49: cerebro.v1.ListClaimsRequest
+	(*ListClaimsResponse)(nil),                             // 50: cerebro.v1.ListClaimsResponse
+	(*ListFindingsRequest)(nil),                            // 51: cerebro.v1.ListFindingsRequest
+	(*FindingControlRef)(nil),                              // 52: cerebro.v1.FindingControlRef
+	(*FindingNote)(nil),                                    // 53: cerebro.v1.FindingNote
+	(*FindingTicket)(nil),                                  // 54: cerebro.v1.FindingTicket
+	(*Finding)(nil),                                        // 55: cerebro.v1.Finding
+	(*GetFindingRequest)(nil),                              // 56: cerebro.v1.GetFindingRequest
+	(*GetFindingResponse)(nil),                             // 57: cerebro.v1.GetFindingResponse
+	(*ResolveFindingRequest)(nil),                          // 58: cerebro.v1.ResolveFindingRequest
+	(*ResolveFindingResponse)(nil),                         // 59: cerebro.v1.ResolveFindingResponse
+	(*SuppressFindingRequest)(nil),                         // 60: cerebro.v1.SuppressFindingRequest
+	(*SuppressFindingResponse)(nil),                        // 61: cerebro.v1.SuppressFindingResponse
+	(*AssignFindingRequest)(nil),                           // 62: cerebro.v1.AssignFindingRequest
+	(*AssignFindingResponse)(nil),                          // 63: cerebro.v1.AssignFindingResponse
+	(*SetFindingDueDateRequest)(nil),                       // 64: cerebro.v1.SetFindingDueDateRequest
+	(*SetFindingDueDateResponse)(nil),                      // 65: cerebro.v1.SetFindingDueDateResponse
+	(*AddFindingNoteRequest)(nil),                          // 66: cerebro.v1.AddFindingNoteRequest
+	(*AddFindingNoteResponse)(nil),                         // 67: cerebro.v1.AddFindingNoteResponse
+	(*LinkFindingTicketRequest)(nil),                       // 68: cerebro.v1.LinkFindingTicketRequest
+	(*LinkFindingTicketResponse)(nil),                      // 69: cerebro.v1.LinkFindingTicketResponse
+	(*ListFindingsResponse)(nil),                           // 70: cerebro.v1.ListFindingsResponse
+	(*FindingCandidateRun)(nil),                            // 71: cerebro.v1.FindingCandidateRun
+	(*FindingCandidate)(nil),                               // 72: cerebro.v1.FindingCandidate
+	(*ListFindingCandidatesRequest)(nil),                   // 73: cerebro.v1.ListFindingCandidatesRequest
+	(*ListFindingCandidatesResponse)(nil),                  // 74: cerebro.v1.ListFindingCandidatesResponse
+	(*GetFindingCandidateRequest)(nil),                     // 75: cerebro.v1.GetFindingCandidateRequest
+	(*GetFindingCandidateResponse)(nil),                    // 76: cerebro.v1.GetFindingCandidateResponse
+	(*EvaluateSourceRuntimeFindingCandidatesRequest)(nil),  // 77: cerebro.v1.EvaluateSourceRuntimeFindingCandidatesRequest
+	(*FindingCandidateRuleEvaluation)(nil),                 // 78: cerebro.v1.FindingCandidateRuleEvaluation
+	(*EvaluateSourceRuntimeFindingCandidatesResponse)(nil), // 79: cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse
+	(*PromoteFindingCandidateRequest)(nil),                 // 80: cerebro.v1.PromoteFindingCandidateRequest
+	(*PromoteFindingCandidateResponse)(nil),                // 81: cerebro.v1.PromoteFindingCandidateResponse
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),           // 82: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingRulesRequest)(nil),       // 83: cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	(*FindingRuleEvaluation)(nil),                          // 84: cerebro.v1.FindingRuleEvaluation
+	(*EvaluateSourceRuntimeFindingRulesResponse)(nil),      // 85: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	(*EvaluateSourceRuntimeFindingsResponse)(nil),          // 86: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	(*WriteDecisionRequest)(nil),                           // 87: cerebro.v1.WriteDecisionRequest
+	(*WriteDecisionResponse)(nil),                          // 88: cerebro.v1.WriteDecisionResponse
+	(*WriteActionRequest)(nil),                             // 89: cerebro.v1.WriteActionRequest
+	(*WriteActionResponse)(nil),                            // 90: cerebro.v1.WriteActionResponse
+	(*WriteOutcomeRequest)(nil),                            // 91: cerebro.v1.WriteOutcomeRequest
+	(*WriteOutcomeResponse)(nil),                           // 92: cerebro.v1.WriteOutcomeResponse
+	(*ReplayWorkflowEventsRequest)(nil),                    // 93: cerebro.v1.ReplayWorkflowEventsRequest
+	(*ReplayWorkflowEventsResponse)(nil),                   // 94: cerebro.v1.ReplayWorkflowEventsResponse
+	(*GraphEntity)(nil),                                    // 95: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                                  // 96: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),                   // 97: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),                  // 98: cerebro.v1.GetEntityNeighborhoodResponse
+	(*GraphIngestRun)(nil),                                 // 99: cerebro.v1.GraphIngestRun
+	(*GraphIngestResult)(nil),                              // 100: cerebro.v1.GraphIngestResult
+	(*GraphIngestRunResult)(nil),                           // 101: cerebro.v1.GraphIngestRunResult
+	(*RunGraphIngestRuntimeRequest)(nil),                   // 102: cerebro.v1.RunGraphIngestRuntimeRequest
+	(*RunGraphIngestRuntimeResponse)(nil),                  // 103: cerebro.v1.RunGraphIngestRuntimeResponse
+	(*GetGraphIngestRunRequest)(nil),                       // 104: cerebro.v1.GetGraphIngestRunRequest
+	(*GetGraphIngestRunResponse)(nil),                      // 105: cerebro.v1.GetGraphIngestRunResponse
+	(*ListGraphIngestRunsRequest)(nil),                     // 106: cerebro.v1.ListGraphIngestRunsRequest
+	(*ListGraphIngestRunsResponse)(nil),                    // 107: cerebro.v1.ListGraphIngestRunsResponse
+	(*CheckGraphIngestHealthRequest)(nil),                  // 108: cerebro.v1.CheckGraphIngestHealthRequest
+	(*CheckGraphIngestHealthResponse)(nil),                 // 109: cerebro.v1.CheckGraphIngestHealthResponse
+	nil,                                                    // 110: cerebro.v1.ReportRun.ParametersEntry
+	nil,                                                    // 111: cerebro.v1.GraphEvidencePath.AttributesEntry
+	nil,                                                    // 112: cerebro.v1.GraphEvidenceRow.AttributesEntry
+	nil,                                                    // 113: cerebro.v1.FindingEvidence.AttributesEntry
+	nil,                                                    // 114: cerebro.v1.RunReportRequest.ParametersEntry
+	nil,                                                    // 115: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                                    // 116: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                                    // 117: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                                    // 118: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                                    // 119: cerebro.v1.Finding.AttributesEntry
+	nil,                                                    // 120: cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
+	(*timestamppb.Timestamp)(nil),                          // 121: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                                // 122: google.protobuf.Struct
+	(*RuleSpec)(nil),                                       // 123: cerebro.v1.RuleSpec
+	(*SourceSpec)(nil),                                     // 124: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                                   // 125: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                                  // 126: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                                 // 127: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                               // 128: cerebro.v1.SourceCheckpoint
+	(*Claim)(nil),                                          // 129: cerebro.v1.Claim
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	110, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	121, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	5,   // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
 	7,   // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
-	99,  // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
-	110, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
-	111, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
+	110, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
+	121, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
+	122, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
 	8,   // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
-	112, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
-	110, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
-	110, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
+	123, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
+	121, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
+	121, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
 	14,  // 10: cerebro.v1.ListFindingEvaluationRunsResponse.runs:type_name -> cerebro.v1.FindingEvaluationRun
 	14,  // 11: cerebro.v1.GetFindingEvaluationRunResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	100, // 12: cerebro.v1.GraphEvidencePath.attributes:type_name -> cerebro.v1.GraphEvidencePath.AttributesEntry
-	101, // 13: cerebro.v1.GraphEvidenceRow.attributes:type_name -> cerebro.v1.GraphEvidenceRow.AttributesEntry
+	111, // 12: cerebro.v1.GraphEvidencePath.attributes:type_name -> cerebro.v1.GraphEvidencePath.AttributesEntry
+	112, // 13: cerebro.v1.GraphEvidenceRow.attributes:type_name -> cerebro.v1.GraphEvidenceRow.AttributesEntry
 	19,  // 14: cerebro.v1.GraphEvidenceRow.paths:type_name -> cerebro.v1.GraphEvidencePath
-	110, // 15: cerebro.v1.FindingEvidenceObservation.observed_at:type_name -> google.protobuf.Timestamp
+	121, // 15: cerebro.v1.FindingEvidenceObservation.observed_at:type_name -> google.protobuf.Timestamp
 	20,  // 16: cerebro.v1.FindingEvidenceObservation.graph_rows:type_name -> cerebro.v1.GraphEvidenceRow
-	110, // 17: cerebro.v1.FindingEvidence.created_at:type_name -> google.protobuf.Timestamp
+	121, // 17: cerebro.v1.FindingEvidence.created_at:type_name -> google.protobuf.Timestamp
 	20,  // 18: cerebro.v1.FindingEvidence.graph_rows:type_name -> cerebro.v1.GraphEvidenceRow
-	110, // 19: cerebro.v1.FindingEvidence.last_observed_at:type_name -> google.protobuf.Timestamp
-	102, // 20: cerebro.v1.FindingEvidence.attributes:type_name -> cerebro.v1.FindingEvidence.AttributesEntry
+	121, // 19: cerebro.v1.FindingEvidence.last_observed_at:type_name -> google.protobuf.Timestamp
+	113, // 20: cerebro.v1.FindingEvidence.attributes:type_name -> cerebro.v1.FindingEvidence.AttributesEntry
 	21,  // 21: cerebro.v1.FindingEvidence.observations:type_name -> cerebro.v1.FindingEvidenceObservation
 	22,  // 22: cerebro.v1.ListFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
 	22,  // 23: cerebro.v1.GetFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	103, // 24: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
+	114, // 24: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
 	8,   // 25: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
 	9,   // 26: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
 	9,   // 27: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
-	113, // 28: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	104, // 29: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	113, // 30: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	105, // 31: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	113, // 32: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	106, // 33: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	114, // 34: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	115, // 35: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	116, // 36: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	113, // 37: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	115, // 38: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	117, // 39: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	114, // 40: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	124, // 28: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	115, // 29: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	124, // 30: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	116, // 31: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	124, // 32: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	117, // 33: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	125, // 34: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	126, // 35: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	127, // 36: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	124, // 37: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	126, // 38: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	128, // 39: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	125, // 40: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
 	38,  // 41: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	107, // 42: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	117, // 43: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	114, // 44: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	110, // 45: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	118, // 42: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	128, // 43: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	125, // 44: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	121, // 45: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
 	40,  // 46: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
 	40,  // 47: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	40,  // 48: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	40,  // 49: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	113, // 50: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	118, // 51: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	118, // 52: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	124, // 50: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	129, // 51: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	129, // 52: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
 	0,   // 53: cerebro.v1.ListFindingsRequest.status:type_name -> cerebro.v1.FindingStatus
 	1,   // 54: cerebro.v1.ListFindingsRequest.order:type_name -> cerebro.v1.FindingOrder
-	110, // 55: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
-	110, // 56: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
+	121, // 55: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
+	121, // 56: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
 	0,   // 57: cerebro.v1.Finding.status:type_name -> cerebro.v1.FindingStatus
-	108, // 58: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	110, // 59: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	110, // 60: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	110, // 61: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
+	119, // 58: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	121, // 59: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	121, // 60: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	121, // 61: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
 	52,  // 62: cerebro.v1.Finding.control_refs:type_name -> cerebro.v1.FindingControlRef
-	110, // 63: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
+	121, // 63: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
 	53,  // 64: cerebro.v1.Finding.notes:type_name -> cerebro.v1.FindingNote
 	54,  // 65: cerebro.v1.Finding.tickets:type_name -> cerebro.v1.FindingTicket
 	55,  // 66: cerebro.v1.GetFindingResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 67: cerebro.v1.ResolveFindingResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 68: cerebro.v1.SuppressFindingResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 69: cerebro.v1.AssignFindingResponse.finding:type_name -> cerebro.v1.Finding
-	110, // 70: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
+	121, // 70: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
 	55,  // 71: cerebro.v1.SetFindingDueDateResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 72: cerebro.v1.AddFindingNoteResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 73: cerebro.v1.LinkFindingTicketResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 74: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	112, // 75: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
-	55,  // 76: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
-	14,  // 77: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
-	22,  // 78: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
-	40,  // 79: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	73,  // 80: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
-	40,  // 81: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	112, // 82: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	55,  // 83: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	14,  // 84: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	22,  // 85: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	110, // 86: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	110, // 87: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	110, // 88: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	111, // 89: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
-	110, // 90: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	110, // 91: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	110, // 92: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	111, // 93: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
-	110, // 94: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
-	110, // 95: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
-	110, // 96: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
-	111, // 97: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
-	109, // 98: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
-	84,  // 99: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	84,  // 100: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	85,  // 101: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	88,  // 102: cerebro.v1.GraphIngestRunResult.run:type_name -> cerebro.v1.GraphIngestRun
-	89,  // 103: cerebro.v1.GraphIngestRunResult.ingest:type_name -> cerebro.v1.GraphIngestResult
-	90,  // 104: cerebro.v1.RunGraphIngestRuntimeResponse.result:type_name -> cerebro.v1.GraphIngestRunResult
-	88,  // 105: cerebro.v1.GetGraphIngestRunResponse.run:type_name -> cerebro.v1.GraphIngestRun
-	88,  // 106: cerebro.v1.ListGraphIngestRunsResponse.runs:type_name -> cerebro.v1.GraphIngestRun
-	110, // 107: cerebro.v1.CheckGraphIngestHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
-	88,  // 108: cerebro.v1.CheckGraphIngestHealthResponse.failed_runs:type_name -> cerebro.v1.GraphIngestRun
-	2,   // 109: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	4,   // 110: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	10,  // 111: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	12,  // 112: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
-	27,  // 113: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	29,  // 114: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	31,  // 115: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	33,  // 116: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	35,  // 117: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	37,  // 118: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	41,  // 119: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	43,  // 120: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	45,  // 121: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	47,  // 122: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	49,  // 123: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
-	51,  // 124: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
-	56,  // 125: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
-	58,  // 126: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
-	60,  // 127: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
-	62,  // 128: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
-	64,  // 129: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
-	66,  // 130: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
-	68,  // 131: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
-	15,  // 132: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
-	17,  // 133: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
-	23,  // 134: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
-	25,  // 135: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
-	72,  // 136: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
-	71,  // 137: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	76,  // 138: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
-	78,  // 139: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
-	80,  // 140: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
-	82,  // 141: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
-	86,  // 142: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	91,  // 143: cerebro.v1.BootstrapService.RunGraphIngestRuntime:input_type -> cerebro.v1.RunGraphIngestRuntimeRequest
-	93,  // 144: cerebro.v1.BootstrapService.GetGraphIngestRun:input_type -> cerebro.v1.GetGraphIngestRunRequest
-	95,  // 145: cerebro.v1.BootstrapService.ListGraphIngestRuns:input_type -> cerebro.v1.ListGraphIngestRunsRequest
-	97,  // 146: cerebro.v1.BootstrapService.CheckGraphIngestHealth:input_type -> cerebro.v1.CheckGraphIngestHealthRequest
-	3,   // 147: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	6,   // 148: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	11,  // 149: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	13,  // 150: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
-	28,  // 151: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	30,  // 152: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	32,  // 153: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	34,  // 154: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	36,  // 155: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	39,  // 156: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	42,  // 157: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	44,  // 158: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	46,  // 159: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	48,  // 160: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	50,  // 161: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
-	70,  // 162: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
-	57,  // 163: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
-	59,  // 164: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
-	61,  // 165: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
-	63,  // 166: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
-	65,  // 167: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
-	67,  // 168: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
-	69,  // 169: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
-	16,  // 170: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
-	18,  // 171: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
-	24,  // 172: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
-	26,  // 173: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
-	74,  // 174: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
-	75,  // 175: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	77,  // 176: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
-	79,  // 177: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
-	81,  // 178: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
-	83,  // 179: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
-	87,  // 180: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	92,  // 181: cerebro.v1.BootstrapService.RunGraphIngestRuntime:output_type -> cerebro.v1.RunGraphIngestRuntimeResponse
-	94,  // 182: cerebro.v1.BootstrapService.GetGraphIngestRun:output_type -> cerebro.v1.GetGraphIngestRunResponse
-	96,  // 183: cerebro.v1.BootstrapService.ListGraphIngestRuns:output_type -> cerebro.v1.ListGraphIngestRunsResponse
-	98,  // 184: cerebro.v1.BootstrapService.CheckGraphIngestHealth:output_type -> cerebro.v1.CheckGraphIngestHealthResponse
-	147, // [147:185] is the sub-list for method output_type
-	109, // [109:147] is the sub-list for method input_type
-	109, // [109:109] is the sub-list for extension type_name
-	109, // [109:109] is the sub-list for extension extendee
-	0,   // [0:109] is the sub-list for field type_name
+	121, // 75: cerebro.v1.FindingCandidateRun.started_at:type_name -> google.protobuf.Timestamp
+	121, // 76: cerebro.v1.FindingCandidateRun.finished_at:type_name -> google.protobuf.Timestamp
+	55,  // 77: cerebro.v1.FindingCandidate.finding:type_name -> cerebro.v1.Finding
+	22,  // 78: cerebro.v1.FindingCandidate.evidence:type_name -> cerebro.v1.FindingEvidence
+	121, // 79: cerebro.v1.FindingCandidate.first_observed_at:type_name -> google.protobuf.Timestamp
+	121, // 80: cerebro.v1.FindingCandidate.last_observed_at:type_name -> google.protobuf.Timestamp
+	121, // 81: cerebro.v1.FindingCandidate.promoted_at:type_name -> google.protobuf.Timestamp
+	121, // 82: cerebro.v1.FindingCandidate.created_at:type_name -> google.protobuf.Timestamp
+	121, // 83: cerebro.v1.FindingCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	72,  // 84: cerebro.v1.ListFindingCandidatesResponse.candidates:type_name -> cerebro.v1.FindingCandidate
+	72,  // 85: cerebro.v1.GetFindingCandidateResponse.candidate:type_name -> cerebro.v1.FindingCandidate
+	123, // 86: cerebro.v1.FindingCandidateRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
+	71,  // 87: cerebro.v1.FindingCandidateRuleEvaluation.run:type_name -> cerebro.v1.FindingCandidateRun
+	72,  // 88: cerebro.v1.FindingCandidateRuleEvaluation.candidates:type_name -> cerebro.v1.FindingCandidate
+	40,  // 89: cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	78,  // 90: cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse.evaluations:type_name -> cerebro.v1.FindingCandidateRuleEvaluation
+	55,  // 91: cerebro.v1.PromoteFindingCandidateResponse.finding:type_name -> cerebro.v1.Finding
+	72,  // 92: cerebro.v1.PromoteFindingCandidateResponse.candidate:type_name -> cerebro.v1.FindingCandidate
+	123, // 93: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
+	55,  // 94: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
+	14,  // 95: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
+	22,  // 96: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
+	40,  // 97: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	84,  // 98: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
+	40,  // 99: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	123, // 100: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	55,  // 101: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	14,  // 102: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
+	22,  // 103: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	121, // 104: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	121, // 105: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	121, // 106: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	122, // 107: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
+	121, // 108: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	121, // 109: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	121, // 110: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	122, // 111: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
+	121, // 112: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
+	121, // 113: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
+	121, // 114: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
+	122, // 115: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
+	120, // 116: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
+	95,  // 117: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	95,  // 118: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	96,  // 119: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	99,  // 120: cerebro.v1.GraphIngestRunResult.run:type_name -> cerebro.v1.GraphIngestRun
+	100, // 121: cerebro.v1.GraphIngestRunResult.ingest:type_name -> cerebro.v1.GraphIngestResult
+	101, // 122: cerebro.v1.RunGraphIngestRuntimeResponse.result:type_name -> cerebro.v1.GraphIngestRunResult
+	99,  // 123: cerebro.v1.GetGraphIngestRunResponse.run:type_name -> cerebro.v1.GraphIngestRun
+	99,  // 124: cerebro.v1.ListGraphIngestRunsResponse.runs:type_name -> cerebro.v1.GraphIngestRun
+	121, // 125: cerebro.v1.CheckGraphIngestHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	99,  // 126: cerebro.v1.CheckGraphIngestHealthResponse.failed_runs:type_name -> cerebro.v1.GraphIngestRun
+	2,   // 127: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	4,   // 128: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	10,  // 129: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	12,  // 130: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
+	27,  // 131: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	29,  // 132: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	31,  // 133: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	33,  // 134: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	35,  // 135: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	37,  // 136: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	41,  // 137: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	43,  // 138: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	45,  // 139: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	47,  // 140: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	49,  // 141: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	51,  // 142: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
+	56,  // 143: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
+	73,  // 144: cerebro.v1.BootstrapService.ListFindingCandidates:input_type -> cerebro.v1.ListFindingCandidatesRequest
+	75,  // 145: cerebro.v1.BootstrapService.GetFindingCandidate:input_type -> cerebro.v1.GetFindingCandidateRequest
+	77,  // 146: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingCandidates:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingCandidatesRequest
+	80,  // 147: cerebro.v1.BootstrapService.PromoteFindingCandidate:input_type -> cerebro.v1.PromoteFindingCandidateRequest
+	58,  // 148: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
+	60,  // 149: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
+	62,  // 150: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
+	64,  // 151: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
+	66,  // 152: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
+	68,  // 153: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
+	15,  // 154: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
+	17,  // 155: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
+	23,  // 156: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
+	25,  // 157: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
+	83,  // 158: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	82,  // 159: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	87,  // 160: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
+	89,  // 161: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
+	91,  // 162: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
+	93,  // 163: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
+	97,  // 164: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	102, // 165: cerebro.v1.BootstrapService.RunGraphIngestRuntime:input_type -> cerebro.v1.RunGraphIngestRuntimeRequest
+	104, // 166: cerebro.v1.BootstrapService.GetGraphIngestRun:input_type -> cerebro.v1.GetGraphIngestRunRequest
+	106, // 167: cerebro.v1.BootstrapService.ListGraphIngestRuns:input_type -> cerebro.v1.ListGraphIngestRunsRequest
+	108, // 168: cerebro.v1.BootstrapService.CheckGraphIngestHealth:input_type -> cerebro.v1.CheckGraphIngestHealthRequest
+	3,   // 169: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	6,   // 170: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	11,  // 171: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	13,  // 172: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
+	28,  // 173: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	30,  // 174: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	32,  // 175: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	34,  // 176: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	36,  // 177: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	39,  // 178: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	42,  // 179: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	44,  // 180: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	46,  // 181: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	48,  // 182: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	50,  // 183: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	70,  // 184: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
+	57,  // 185: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
+	74,  // 186: cerebro.v1.BootstrapService.ListFindingCandidates:output_type -> cerebro.v1.ListFindingCandidatesResponse
+	76,  // 187: cerebro.v1.BootstrapService.GetFindingCandidate:output_type -> cerebro.v1.GetFindingCandidateResponse
+	79,  // 188: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingCandidates:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse
+	81,  // 189: cerebro.v1.BootstrapService.PromoteFindingCandidate:output_type -> cerebro.v1.PromoteFindingCandidateResponse
+	59,  // 190: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
+	61,  // 191: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
+	63,  // 192: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
+	65,  // 193: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
+	67,  // 194: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
+	69,  // 195: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
+	16,  // 196: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
+	18,  // 197: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
+	24,  // 198: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
+	26,  // 199: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
+	85,  // 200: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	86,  // 201: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	88,  // 202: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
+	90,  // 203: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
+	92,  // 204: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
+	94,  // 205: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
+	98,  // 206: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	103, // 207: cerebro.v1.BootstrapService.RunGraphIngestRuntime:output_type -> cerebro.v1.RunGraphIngestRuntimeResponse
+	105, // 208: cerebro.v1.BootstrapService.GetGraphIngestRun:output_type -> cerebro.v1.GetGraphIngestRunResponse
+	107, // 209: cerebro.v1.BootstrapService.ListGraphIngestRuns:output_type -> cerebro.v1.ListGraphIngestRunsResponse
+	109, // 210: cerebro.v1.BootstrapService.CheckGraphIngestHealth:output_type -> cerebro.v1.CheckGraphIngestHealthResponse
+	169, // [169:211] is the sub-list for method output_type
+	127, // [127:169] is the sub-list for method input_type
+	127, // [127:127] is the sub-list for extension type_name
+	127, // [127:127] is the sub-list for extension extendee
+	0,   // [0:127] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -7851,7 +8863,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   108,
+			NumMessages:   119,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -84,6 +84,18 @@ const (
 	// BootstrapServiceGetFindingProcedure is the fully-qualified name of the BootstrapService's
 	// GetFinding RPC.
 	BootstrapServiceGetFindingProcedure = "/cerebro.v1.BootstrapService/GetFinding"
+	// BootstrapServiceListFindingCandidatesProcedure is the fully-qualified name of the
+	// BootstrapService's ListFindingCandidates RPC.
+	BootstrapServiceListFindingCandidatesProcedure = "/cerebro.v1.BootstrapService/ListFindingCandidates"
+	// BootstrapServiceGetFindingCandidateProcedure is the fully-qualified name of the
+	// BootstrapService's GetFindingCandidate RPC.
+	BootstrapServiceGetFindingCandidateProcedure = "/cerebro.v1.BootstrapService/GetFindingCandidate"
+	// BootstrapServiceEvaluateSourceRuntimeFindingCandidatesProcedure is the fully-qualified name of
+	// the BootstrapService's EvaluateSourceRuntimeFindingCandidates RPC.
+	BootstrapServiceEvaluateSourceRuntimeFindingCandidatesProcedure = "/cerebro.v1.BootstrapService/EvaluateSourceRuntimeFindingCandidates"
+	// BootstrapServicePromoteFindingCandidateProcedure is the fully-qualified name of the
+	// BootstrapService's PromoteFindingCandidate RPC.
+	BootstrapServicePromoteFindingCandidateProcedure = "/cerebro.v1.BootstrapService/PromoteFindingCandidate"
 	// BootstrapServiceResolveFindingProcedure is the fully-qualified name of the BootstrapService's
 	// ResolveFinding RPC.
 	BootstrapServiceResolveFindingProcedure = "/cerebro.v1.BootstrapService/ResolveFinding"
@@ -168,6 +180,10 @@ type BootstrapServiceClient interface {
 	ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error)
 	ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error)
 	GetFinding(context.Context, *connect.Request[v1.GetFindingRequest]) (*connect.Response[v1.GetFindingResponse], error)
+	ListFindingCandidates(context.Context, *connect.Request[v1.ListFindingCandidatesRequest]) (*connect.Response[v1.ListFindingCandidatesResponse], error)
+	GetFindingCandidate(context.Context, *connect.Request[v1.GetFindingCandidateRequest]) (*connect.Response[v1.GetFindingCandidateResponse], error)
+	EvaluateSourceRuntimeFindingCandidates(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingCandidatesRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingCandidatesResponse], error)
+	PromoteFindingCandidate(context.Context, *connect.Request[v1.PromoteFindingCandidateRequest]) (*connect.Response[v1.PromoteFindingCandidateResponse], error)
 	ResolveFinding(context.Context, *connect.Request[v1.ResolveFindingRequest]) (*connect.Response[v1.ResolveFindingResponse], error)
 	SuppressFinding(context.Context, *connect.Request[v1.SuppressFindingRequest]) (*connect.Response[v1.SuppressFindingResponse], error)
 	AssignFinding(context.Context, *connect.Request[v1.AssignFindingRequest]) (*connect.Response[v1.AssignFindingResponse], error)
@@ -304,6 +320,30 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("GetFinding")),
 			connect.WithClientOptions(opts...),
 		),
+		listFindingCandidates: connect.NewClient[v1.ListFindingCandidatesRequest, v1.ListFindingCandidatesResponse](
+			httpClient,
+			baseURL+BootstrapServiceListFindingCandidatesProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("ListFindingCandidates")),
+			connect.WithClientOptions(opts...),
+		),
+		getFindingCandidate: connect.NewClient[v1.GetFindingCandidateRequest, v1.GetFindingCandidateResponse](
+			httpClient,
+			baseURL+BootstrapServiceGetFindingCandidateProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("GetFindingCandidate")),
+			connect.WithClientOptions(opts...),
+		),
+		evaluateSourceRuntimeFindingCandidates: connect.NewClient[v1.EvaluateSourceRuntimeFindingCandidatesRequest, v1.EvaluateSourceRuntimeFindingCandidatesResponse](
+			httpClient,
+			baseURL+BootstrapServiceEvaluateSourceRuntimeFindingCandidatesProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("EvaluateSourceRuntimeFindingCandidates")),
+			connect.WithClientOptions(opts...),
+		),
+		promoteFindingCandidate: connect.NewClient[v1.PromoteFindingCandidateRequest, v1.PromoteFindingCandidateResponse](
+			httpClient,
+			baseURL+BootstrapServicePromoteFindingCandidateProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("PromoteFindingCandidate")),
+			connect.WithClientOptions(opts...),
+		),
 		resolveFinding: connect.NewClient[v1.ResolveFindingRequest, v1.ResolveFindingResponse](
 			httpClient,
 			baseURL+BootstrapServiceResolveFindingProcedure,
@@ -435,44 +475,48 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 
 // bootstrapServiceClient implements BootstrapServiceClient.
 type bootstrapServiceClient struct {
-	getVersion                        *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
-	checkHealth                       *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
-	listReportDefinitions             *connect.Client[v1.ListReportDefinitionsRequest, v1.ListReportDefinitionsResponse]
-	listFindingRules                  *connect.Client[v1.ListFindingRulesRequest, v1.ListFindingRulesResponse]
-	runReport                         *connect.Client[v1.RunReportRequest, v1.RunReportResponse]
-	getReportRun                      *connect.Client[v1.GetReportRunRequest, v1.GetReportRunResponse]
-	listSources                       *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
-	checkSource                       *connect.Client[v1.CheckSourceRequest, v1.CheckSourceResponse]
-	discoverSource                    *connect.Client[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse]
-	readSource                        *connect.Client[v1.ReadSourceRequest, v1.ReadSourceResponse]
-	putSourceRuntime                  *connect.Client[v1.PutSourceRuntimeRequest, v1.PutSourceRuntimeResponse]
-	getSourceRuntime                  *connect.Client[v1.GetSourceRuntimeRequest, v1.GetSourceRuntimeResponse]
-	syncSourceRuntime                 *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
-	writeClaims                       *connect.Client[v1.WriteClaimsRequest, v1.WriteClaimsResponse]
-	listClaims                        *connect.Client[v1.ListClaimsRequest, v1.ListClaimsResponse]
-	listFindings                      *connect.Client[v1.ListFindingsRequest, v1.ListFindingsResponse]
-	getFinding                        *connect.Client[v1.GetFindingRequest, v1.GetFindingResponse]
-	resolveFinding                    *connect.Client[v1.ResolveFindingRequest, v1.ResolveFindingResponse]
-	suppressFinding                   *connect.Client[v1.SuppressFindingRequest, v1.SuppressFindingResponse]
-	assignFinding                     *connect.Client[v1.AssignFindingRequest, v1.AssignFindingResponse]
-	setFindingDueDate                 *connect.Client[v1.SetFindingDueDateRequest, v1.SetFindingDueDateResponse]
-	addFindingNote                    *connect.Client[v1.AddFindingNoteRequest, v1.AddFindingNoteResponse]
-	linkFindingTicket                 *connect.Client[v1.LinkFindingTicketRequest, v1.LinkFindingTicketResponse]
-	listFindingEvaluationRuns         *connect.Client[v1.ListFindingEvaluationRunsRequest, v1.ListFindingEvaluationRunsResponse]
-	getFindingEvaluationRun           *connect.Client[v1.GetFindingEvaluationRunRequest, v1.GetFindingEvaluationRunResponse]
-	listFindingEvidence               *connect.Client[v1.ListFindingEvidenceRequest, v1.ListFindingEvidenceResponse]
-	getFindingEvidence                *connect.Client[v1.GetFindingEvidenceRequest, v1.GetFindingEvidenceResponse]
-	evaluateSourceRuntimeFindingRules *connect.Client[v1.EvaluateSourceRuntimeFindingRulesRequest, v1.EvaluateSourceRuntimeFindingRulesResponse]
-	evaluateSourceRuntimeFindings     *connect.Client[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse]
-	writeDecision                     *connect.Client[v1.WriteDecisionRequest, v1.WriteDecisionResponse]
-	writeAction                       *connect.Client[v1.WriteActionRequest, v1.WriteActionResponse]
-	writeOutcome                      *connect.Client[v1.WriteOutcomeRequest, v1.WriteOutcomeResponse]
-	replayWorkflowEvents              *connect.Client[v1.ReplayWorkflowEventsRequest, v1.ReplayWorkflowEventsResponse]
-	getEntityNeighborhood             *connect.Client[v1.GetEntityNeighborhoodRequest, v1.GetEntityNeighborhoodResponse]
-	runGraphIngestRuntime             *connect.Client[v1.RunGraphIngestRuntimeRequest, v1.RunGraphIngestRuntimeResponse]
-	getGraphIngestRun                 *connect.Client[v1.GetGraphIngestRunRequest, v1.GetGraphIngestRunResponse]
-	listGraphIngestRuns               *connect.Client[v1.ListGraphIngestRunsRequest, v1.ListGraphIngestRunsResponse]
-	checkGraphIngestHealth            *connect.Client[v1.CheckGraphIngestHealthRequest, v1.CheckGraphIngestHealthResponse]
+	getVersion                             *connect.Client[v1.GetVersionRequest, v1.GetVersionResponse]
+	checkHealth                            *connect.Client[v1.CheckHealthRequest, v1.CheckHealthResponse]
+	listReportDefinitions                  *connect.Client[v1.ListReportDefinitionsRequest, v1.ListReportDefinitionsResponse]
+	listFindingRules                       *connect.Client[v1.ListFindingRulesRequest, v1.ListFindingRulesResponse]
+	runReport                              *connect.Client[v1.RunReportRequest, v1.RunReportResponse]
+	getReportRun                           *connect.Client[v1.GetReportRunRequest, v1.GetReportRunResponse]
+	listSources                            *connect.Client[v1.ListSourcesRequest, v1.ListSourcesResponse]
+	checkSource                            *connect.Client[v1.CheckSourceRequest, v1.CheckSourceResponse]
+	discoverSource                         *connect.Client[v1.DiscoverSourceRequest, v1.DiscoverSourceResponse]
+	readSource                             *connect.Client[v1.ReadSourceRequest, v1.ReadSourceResponse]
+	putSourceRuntime                       *connect.Client[v1.PutSourceRuntimeRequest, v1.PutSourceRuntimeResponse]
+	getSourceRuntime                       *connect.Client[v1.GetSourceRuntimeRequest, v1.GetSourceRuntimeResponse]
+	syncSourceRuntime                      *connect.Client[v1.SyncSourceRuntimeRequest, v1.SyncSourceRuntimeResponse]
+	writeClaims                            *connect.Client[v1.WriteClaimsRequest, v1.WriteClaimsResponse]
+	listClaims                             *connect.Client[v1.ListClaimsRequest, v1.ListClaimsResponse]
+	listFindings                           *connect.Client[v1.ListFindingsRequest, v1.ListFindingsResponse]
+	getFinding                             *connect.Client[v1.GetFindingRequest, v1.GetFindingResponse]
+	listFindingCandidates                  *connect.Client[v1.ListFindingCandidatesRequest, v1.ListFindingCandidatesResponse]
+	getFindingCandidate                    *connect.Client[v1.GetFindingCandidateRequest, v1.GetFindingCandidateResponse]
+	evaluateSourceRuntimeFindingCandidates *connect.Client[v1.EvaluateSourceRuntimeFindingCandidatesRequest, v1.EvaluateSourceRuntimeFindingCandidatesResponse]
+	promoteFindingCandidate                *connect.Client[v1.PromoteFindingCandidateRequest, v1.PromoteFindingCandidateResponse]
+	resolveFinding                         *connect.Client[v1.ResolveFindingRequest, v1.ResolveFindingResponse]
+	suppressFinding                        *connect.Client[v1.SuppressFindingRequest, v1.SuppressFindingResponse]
+	assignFinding                          *connect.Client[v1.AssignFindingRequest, v1.AssignFindingResponse]
+	setFindingDueDate                      *connect.Client[v1.SetFindingDueDateRequest, v1.SetFindingDueDateResponse]
+	addFindingNote                         *connect.Client[v1.AddFindingNoteRequest, v1.AddFindingNoteResponse]
+	linkFindingTicket                      *connect.Client[v1.LinkFindingTicketRequest, v1.LinkFindingTicketResponse]
+	listFindingEvaluationRuns              *connect.Client[v1.ListFindingEvaluationRunsRequest, v1.ListFindingEvaluationRunsResponse]
+	getFindingEvaluationRun                *connect.Client[v1.GetFindingEvaluationRunRequest, v1.GetFindingEvaluationRunResponse]
+	listFindingEvidence                    *connect.Client[v1.ListFindingEvidenceRequest, v1.ListFindingEvidenceResponse]
+	getFindingEvidence                     *connect.Client[v1.GetFindingEvidenceRequest, v1.GetFindingEvidenceResponse]
+	evaluateSourceRuntimeFindingRules      *connect.Client[v1.EvaluateSourceRuntimeFindingRulesRequest, v1.EvaluateSourceRuntimeFindingRulesResponse]
+	evaluateSourceRuntimeFindings          *connect.Client[v1.EvaluateSourceRuntimeFindingsRequest, v1.EvaluateSourceRuntimeFindingsResponse]
+	writeDecision                          *connect.Client[v1.WriteDecisionRequest, v1.WriteDecisionResponse]
+	writeAction                            *connect.Client[v1.WriteActionRequest, v1.WriteActionResponse]
+	writeOutcome                           *connect.Client[v1.WriteOutcomeRequest, v1.WriteOutcomeResponse]
+	replayWorkflowEvents                   *connect.Client[v1.ReplayWorkflowEventsRequest, v1.ReplayWorkflowEventsResponse]
+	getEntityNeighborhood                  *connect.Client[v1.GetEntityNeighborhoodRequest, v1.GetEntityNeighborhoodResponse]
+	runGraphIngestRuntime                  *connect.Client[v1.RunGraphIngestRuntimeRequest, v1.RunGraphIngestRuntimeResponse]
+	getGraphIngestRun                      *connect.Client[v1.GetGraphIngestRunRequest, v1.GetGraphIngestRunResponse]
+	listGraphIngestRuns                    *connect.Client[v1.ListGraphIngestRunsRequest, v1.ListGraphIngestRunsResponse]
+	checkGraphIngestHealth                 *connect.Client[v1.CheckGraphIngestHealthRequest, v1.CheckGraphIngestHealthResponse]
 }
 
 // GetVersion calls cerebro.v1.BootstrapService.GetVersion.
@@ -558,6 +602,27 @@ func (c *bootstrapServiceClient) ListFindings(ctx context.Context, req *connect.
 // GetFinding calls cerebro.v1.BootstrapService.GetFinding.
 func (c *bootstrapServiceClient) GetFinding(ctx context.Context, req *connect.Request[v1.GetFindingRequest]) (*connect.Response[v1.GetFindingResponse], error) {
 	return c.getFinding.CallUnary(ctx, req)
+}
+
+// ListFindingCandidates calls cerebro.v1.BootstrapService.ListFindingCandidates.
+func (c *bootstrapServiceClient) ListFindingCandidates(ctx context.Context, req *connect.Request[v1.ListFindingCandidatesRequest]) (*connect.Response[v1.ListFindingCandidatesResponse], error) {
+	return c.listFindingCandidates.CallUnary(ctx, req)
+}
+
+// GetFindingCandidate calls cerebro.v1.BootstrapService.GetFindingCandidate.
+func (c *bootstrapServiceClient) GetFindingCandidate(ctx context.Context, req *connect.Request[v1.GetFindingCandidateRequest]) (*connect.Response[v1.GetFindingCandidateResponse], error) {
+	return c.getFindingCandidate.CallUnary(ctx, req)
+}
+
+// EvaluateSourceRuntimeFindingCandidates calls
+// cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingCandidates.
+func (c *bootstrapServiceClient) EvaluateSourceRuntimeFindingCandidates(ctx context.Context, req *connect.Request[v1.EvaluateSourceRuntimeFindingCandidatesRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingCandidatesResponse], error) {
+	return c.evaluateSourceRuntimeFindingCandidates.CallUnary(ctx, req)
+}
+
+// PromoteFindingCandidate calls cerebro.v1.BootstrapService.PromoteFindingCandidate.
+func (c *bootstrapServiceClient) PromoteFindingCandidate(ctx context.Context, req *connect.Request[v1.PromoteFindingCandidateRequest]) (*connect.Response[v1.PromoteFindingCandidateResponse], error) {
+	return c.promoteFindingCandidate.CallUnary(ctx, req)
 }
 
 // ResolveFinding calls cerebro.v1.BootstrapService.ResolveFinding.
@@ -685,6 +750,10 @@ type BootstrapServiceHandler interface {
 	ListClaims(context.Context, *connect.Request[v1.ListClaimsRequest]) (*connect.Response[v1.ListClaimsResponse], error)
 	ListFindings(context.Context, *connect.Request[v1.ListFindingsRequest]) (*connect.Response[v1.ListFindingsResponse], error)
 	GetFinding(context.Context, *connect.Request[v1.GetFindingRequest]) (*connect.Response[v1.GetFindingResponse], error)
+	ListFindingCandidates(context.Context, *connect.Request[v1.ListFindingCandidatesRequest]) (*connect.Response[v1.ListFindingCandidatesResponse], error)
+	GetFindingCandidate(context.Context, *connect.Request[v1.GetFindingCandidateRequest]) (*connect.Response[v1.GetFindingCandidateResponse], error)
+	EvaluateSourceRuntimeFindingCandidates(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingCandidatesRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingCandidatesResponse], error)
+	PromoteFindingCandidate(context.Context, *connect.Request[v1.PromoteFindingCandidateRequest]) (*connect.Response[v1.PromoteFindingCandidateResponse], error)
 	ResolveFinding(context.Context, *connect.Request[v1.ResolveFindingRequest]) (*connect.Response[v1.ResolveFindingResponse], error)
 	SuppressFinding(context.Context, *connect.Request[v1.SuppressFindingRequest]) (*connect.Response[v1.SuppressFindingResponse], error)
 	AssignFinding(context.Context, *connect.Request[v1.AssignFindingRequest]) (*connect.Response[v1.AssignFindingResponse], error)
@@ -815,6 +884,30 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		BootstrapServiceGetFindingProcedure,
 		svc.GetFinding,
 		connect.WithSchema(bootstrapServiceMethods.ByName("GetFinding")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceListFindingCandidatesHandler := connect.NewUnaryHandler(
+		BootstrapServiceListFindingCandidatesProcedure,
+		svc.ListFindingCandidates,
+		connect.WithSchema(bootstrapServiceMethods.ByName("ListFindingCandidates")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceGetFindingCandidateHandler := connect.NewUnaryHandler(
+		BootstrapServiceGetFindingCandidateProcedure,
+		svc.GetFindingCandidate,
+		connect.WithSchema(bootstrapServiceMethods.ByName("GetFindingCandidate")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceEvaluateSourceRuntimeFindingCandidatesHandler := connect.NewUnaryHandler(
+		BootstrapServiceEvaluateSourceRuntimeFindingCandidatesProcedure,
+		svc.EvaluateSourceRuntimeFindingCandidates,
+		connect.WithSchema(bootstrapServiceMethods.ByName("EvaluateSourceRuntimeFindingCandidates")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServicePromoteFindingCandidateHandler := connect.NewUnaryHandler(
+		BootstrapServicePromoteFindingCandidateProcedure,
+		svc.PromoteFindingCandidate,
+		connect.WithSchema(bootstrapServiceMethods.ByName("PromoteFindingCandidate")),
 		connect.WithHandlerOptions(opts...),
 	)
 	bootstrapServiceResolveFindingHandler := connect.NewUnaryHandler(
@@ -979,6 +1072,14 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceListFindingsHandler.ServeHTTP(w, r)
 		case BootstrapServiceGetFindingProcedure:
 			bootstrapServiceGetFindingHandler.ServeHTTP(w, r)
+		case BootstrapServiceListFindingCandidatesProcedure:
+			bootstrapServiceListFindingCandidatesHandler.ServeHTTP(w, r)
+		case BootstrapServiceGetFindingCandidateProcedure:
+			bootstrapServiceGetFindingCandidateHandler.ServeHTTP(w, r)
+		case BootstrapServiceEvaluateSourceRuntimeFindingCandidatesProcedure:
+			bootstrapServiceEvaluateSourceRuntimeFindingCandidatesHandler.ServeHTTP(w, r)
+		case BootstrapServicePromoteFindingCandidateProcedure:
+			bootstrapServicePromoteFindingCandidateHandler.ServeHTTP(w, r)
 		case BootstrapServiceResolveFindingProcedure:
 			bootstrapServiceResolveFindingHandler.ServeHTTP(w, r)
 		case BootstrapServiceSuppressFindingProcedure:
@@ -1096,6 +1197,22 @@ func (UnimplementedBootstrapServiceHandler) ListFindings(context.Context, *conne
 
 func (UnimplementedBootstrapServiceHandler) GetFinding(context.Context, *connect.Request[v1.GetFindingRequest]) (*connect.Response[v1.GetFindingResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.GetFinding is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) ListFindingCandidates(context.Context, *connect.Request[v1.ListFindingCandidatesRequest]) (*connect.Response[v1.ListFindingCandidatesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.ListFindingCandidates is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) GetFindingCandidate(context.Context, *connect.Request[v1.GetFindingCandidateRequest]) (*connect.Response[v1.GetFindingCandidateResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.GetFindingCandidate is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) EvaluateSourceRuntimeFindingCandidates(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingCandidatesRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingCandidatesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingCandidates is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) PromoteFindingCandidate(context.Context, *connect.Request[v1.PromoteFindingCandidateRequest]) (*connect.Response[v1.PromoteFindingCandidateResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.PromoteFindingCandidate is not implemented"))
 }
 
 func (UnimplementedBootstrapServiceHandler) ResolveFinding(context.Context, *connect.Request[v1.ResolveFindingRequest]) (*connect.Response[v1.ResolveFindingResponse], error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -158,6 +158,8 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	mux.HandleFunc("GET /grc/entities/{entityID}/impact", app.handleGRCEntityImpact)
 	mux.HandleFunc("GET /grc/audit-packets/{packetID}", app.handleGRCAuditPacket)
 	mux.HandleFunc("GET /findings/{findingID}", app.handleGetFinding)
+	mux.HandleFunc("GET /finding-candidates/{candidateID}", app.handleGetFindingCandidate)
+	mux.HandleFunc("POST /finding-candidates/{candidateID}/promote", app.handlePromoteFindingCandidate)
 	mux.HandleFunc("POST /findings/{findingID}/resolve", app.handleResolveFinding)
 	mux.HandleFunc("POST /findings/{findingID}/suppress", app.handleSuppressFinding)
 	mux.HandleFunc("PUT /findings/{findingID}/assign", app.handleAssignFinding)
@@ -204,8 +206,10 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/claims", app.handleListClaims)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/claims", app.handleWriteClaims)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/findings", app.handleListFindings)
+	mux.HandleFunc("GET /source-runtimes/{runtimeID}/finding-candidates", app.handleListFindingCandidates)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/finding-evidence", app.handleListFindingEvidence)
 	mux.HandleFunc("GET /source-runtimes/{runtimeID}/finding-evaluation-runs", app.handleListFindingEvaluationRuns)
+	mux.HandleFunc("POST /source-runtimes/{runtimeID}/finding-candidates/evaluate", app.handleEvaluateSourceRuntimeFindingCandidates)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/finding-rules/evaluate", app.handleEvaluateSourceRuntimeFindingRules)
 	mux.HandleFunc("POST /source-runtimes/{runtimeID}/findings/evaluate", app.handleEvaluateSourceRuntimeFindings)
 	if app.deviceHandler != nil {
@@ -1424,6 +1428,41 @@ func (a *App) handleEvaluateSourceRuntimeFindingRules(w http.ResponseWriter, r *
 	writeProtoJSON(w, http.StatusOK, findingRulesResponse(response))
 }
 
+func (a *App) handleEvaluateSourceRuntimeFindingCandidates(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.EvaluateSourceRuntimeFindingCandidatesRequest{}
+	if err := readProtoJSON(r, request); err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	if eventLimit := r.URL.Query().Get("event_limit"); eventLimit != "" {
+		overrides := &cerebrov1.EvaluateSourceRuntimeFindingCandidatesRequest{}
+		body := []byte(`{"event_limit":` + eventLimit + `}`)
+		if err := unmarshalHTTPProtoJSON(body, overrides); err != nil {
+			writeFindingError(w, err)
+			return
+		}
+		request.EventLimit = overrides.GetEventLimit()
+	}
+	request.Id = r.PathValue("runtimeID")
+	if ruleIDs := r.URL.Query()["rule_id"]; len(ruleIDs) != 0 {
+		request.RuleIds = ruleIDs
+	}
+	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), request.GetId(), false); err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	response, err := a.findingService().EvaluateSourceRuntimeCandidateRules(r.Context(), findings.EvaluateCandidateRulesRequest{
+		RuntimeID:  request.GetId(),
+		RuleIDs:    request.GetRuleIds(),
+		EventLimit: request.GetEventLimit(),
+	})
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, findingCandidateRulesResponse(response))
+}
+
 func (a *App) handleListFindings(w http.ResponseWriter, r *http.Request) {
 	request := &cerebrov1.ListFindingsRequest{
 		RuntimeId:   r.PathValue("runtimeID"),
@@ -1501,6 +1540,90 @@ func (a *App) handleListFindings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeProtoJSON(w, http.StatusOK, listFindingsResponse(response))
+}
+
+func (a *App) handleListFindingCandidates(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.ListFindingCandidatesRequest{
+		RuntimeId:   r.PathValue("runtimeID"),
+		CandidateId: r.URL.Query().Get("candidate_id"),
+		RuleId:      r.URL.Query().Get("rule_id"),
+		Status:      r.URL.Query().Get("status"),
+		Fingerprint: r.URL.Query().Get("fingerprint"),
+	}
+	if limit := r.URL.Query().Get("limit"); limit != "" {
+		body := []byte(`{"limit":` + limit + `}`)
+		if err := unmarshalHTTPProtoJSON(body, request); err != nil {
+			writeFindingError(w, err)
+			return
+		}
+		request.RuntimeId = r.PathValue("runtimeID")
+		request.CandidateId = r.URL.Query().Get("candidate_id")
+		request.RuleId = r.URL.Query().Get("rule_id")
+		request.Status = r.URL.Query().Get("status")
+		request.Fingerprint = r.URL.Query().Get("fingerprint")
+	}
+	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), request.GetRuntimeId(), false); err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	response, err := a.findingService().ListFindingCandidates(r.Context(), findings.ListCandidatesRequest{
+		RuntimeID:   request.GetRuntimeId(),
+		CandidateID: request.GetCandidateId(),
+		RuleID:      request.GetRuleId(),
+		Status:      request.GetStatus(),
+		Fingerprint: request.GetFingerprint(),
+		Limit:       request.GetLimit(),
+	})
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, listFindingCandidatesResponse(response))
+}
+
+func (a *App) handleGetFindingCandidate(w http.ResponseWriter, r *http.Request) {
+	candidateID := r.PathValue("candidateID")
+	candidate, err := a.findingService().GetFindingCandidate(r.Context(), candidateID)
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), candidate.RuntimeID, false); err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, &cerebrov1.GetFindingCandidateResponse{Candidate: findingCandidateMessage(candidate)})
+}
+
+func (a *App) handlePromoteFindingCandidate(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.PromoteFindingCandidateRequest{}
+	if err := readProtoJSON(r, request); err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	request.Id = r.PathValue("candidateID")
+	candidate, err := a.findingService().GetFindingCandidate(r.Context(), request.GetId())
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), candidate.RuntimeID, false); err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	response, err := a.findingService().PromoteFindingCandidate(r.Context(), findings.PromoteCandidateRequest{
+		CandidateID:           request.GetId(),
+		PromotedBy:            request.GetPromotedBy(),
+		Rationale:             request.GetRationale(),
+		ChangeTicket:          request.GetChangeTicket(),
+		FalsePositiveReviewed: request.GetFalsePositiveReviewed(),
+		GraphCoverageReviewed: request.GetGraphCoverageReviewed(),
+	})
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, promoteFindingCandidateResponse(response))
 }
 
 func (a *App) handleListFindingEvidence(w http.ResponseWriter, r *http.Request) {
@@ -1813,6 +1936,102 @@ func (s *bootstrapService) GetFinding(ctx context.Context, req *connect.Request[
 		return nil, findingConnectError(err)
 	}
 	return connect.NewResponse(&cerebrov1.GetFindingResponse{Finding: findingMessage(finding)}), nil
+}
+
+func (s *bootstrapService) ListFindingCandidates(ctx context.Context, req *connect.Request[cerebrov1.ListFindingCandidatesRequest]) (*connect.Response[cerebrov1.ListFindingCandidatesResponse], error) {
+	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetRuntimeId(), false); err != nil {
+		return nil, findingConnectError(err)
+	}
+	response, err := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
+		findingEvidenceStore(s.deps.StateStore),
+		claimStore(s.deps.StateStore),
+	).WithFindingCandidateStore(findingCandidateStore(s.deps.StateStore)).ListFindingCandidates(ctx, findings.ListCandidatesRequest{
+		RuntimeID:   req.Msg.GetRuntimeId(),
+		CandidateID: req.Msg.GetCandidateId(),
+		RuleID:      req.Msg.GetRuleId(),
+		Status:      req.Msg.GetStatus(),
+		Fingerprint: req.Msg.GetFingerprint(),
+		Limit:       req.Msg.GetLimit(),
+	})
+	if err != nil {
+		return nil, findingConnectError(err)
+	}
+	return connect.NewResponse(listFindingCandidatesResponse(response)), nil
+}
+
+func (s *bootstrapService) GetFindingCandidate(ctx context.Context, req *connect.Request[cerebrov1.GetFindingCandidateRequest]) (*connect.Response[cerebrov1.GetFindingCandidateResponse], error) {
+	service := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
+		findingEvidenceStore(s.deps.StateStore),
+		claimStore(s.deps.StateStore),
+	).WithFindingCandidateStore(findingCandidateStore(s.deps.StateStore))
+	candidate, err := service.GetFindingCandidate(ctx, req.Msg.GetId())
+	if err != nil {
+		return nil, findingConnectError(err)
+	}
+	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), candidate.RuntimeID, false); err != nil {
+		return nil, findingConnectError(err)
+	}
+	return connect.NewResponse(&cerebrov1.GetFindingCandidateResponse{Candidate: findingCandidateMessage(candidate)}), nil
+}
+
+func (s *bootstrapService) EvaluateSourceRuntimeFindingCandidates(ctx context.Context, req *connect.Request[cerebrov1.EvaluateSourceRuntimeFindingCandidatesRequest]) (*connect.Response[cerebrov1.EvaluateSourceRuntimeFindingCandidatesResponse], error) {
+	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), req.Msg.GetId(), false); err != nil {
+		return nil, findingConnectError(err)
+	}
+	response, err := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
+		findingEvidenceStore(s.deps.StateStore),
+		claimStore(s.deps.StateStore),
+	).WithFindingCandidateStore(findingCandidateStore(s.deps.StateStore)).EvaluateSourceRuntimeCandidateRules(ctx, findings.EvaluateCandidateRulesRequest{
+		RuntimeID:  req.Msg.GetId(),
+		RuleIDs:    req.Msg.GetRuleIds(),
+		EventLimit: req.Msg.GetEventLimit(),
+	})
+	if err != nil {
+		return nil, findingConnectError(err)
+	}
+	return connect.NewResponse(findingCandidateRulesResponse(response)), nil
+}
+
+func (s *bootstrapService) PromoteFindingCandidate(ctx context.Context, req *connect.Request[cerebrov1.PromoteFindingCandidateRequest]) (*connect.Response[cerebrov1.PromoteFindingCandidateResponse], error) {
+	service := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
+		findingEvidenceStore(s.deps.StateStore),
+		claimStore(s.deps.StateStore),
+	).WithFindingCandidateStore(findingCandidateStore(s.deps.StateStore)).WithGraphStore(sourceProjectionGraphStore(s.deps.GraphStore)).WithGraphQueryStore(graphQueryStore(s.deps.GraphStore)).WithAppendLog(s.deps.AppendLog)
+	candidate, err := service.GetFindingCandidate(ctx, req.Msg.GetId())
+	if err != nil {
+		return nil, findingConnectError(err)
+	}
+	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), candidate.RuntimeID, false); err != nil {
+		return nil, findingConnectError(err)
+	}
+	response, err := service.PromoteFindingCandidate(ctx, findings.PromoteCandidateRequest{
+		CandidateID:           req.Msg.GetId(),
+		PromotedBy:            req.Msg.GetPromotedBy(),
+		Rationale:             req.Msg.GetRationale(),
+		ChangeTicket:          req.Msg.GetChangeTicket(),
+		FalsePositiveReviewed: req.Msg.GetFalsePositiveReviewed(),
+		GraphCoverageReviewed: req.Msg.GetGraphCoverageReviewed(),
+	})
+	if err != nil {
+		return nil, findingConnectError(err)
+	}
+	return connect.NewResponse(promoteFindingCandidateResponse(response)), nil
 }
 
 func (s *bootstrapService) ResolveFinding(ctx context.Context, req *connect.Request[cerebrov1.ResolveFindingRequest]) (*connect.Response[cerebrov1.ResolveFindingResponse], error) {
@@ -2462,7 +2681,7 @@ func (a *App) findingService() *findings.Service {
 		findingEvaluationRunStore(a.deps.StateStore),
 		findingEvidenceStore(a.deps.StateStore),
 		claimStore(a.deps.StateStore),
-	).WithGraphStore(sourceProjectionGraphStore(a.deps.GraphStore)).WithGraphQueryStore(graphQueryStore(a.deps.GraphStore)).WithAppendLog(a.deps.AppendLog)
+	).WithFindingCandidateStore(findingCandidateStore(a.deps.StateStore)).WithGraphStore(sourceProjectionGraphStore(a.deps.GraphStore)).WithGraphQueryStore(graphQueryStore(a.deps.GraphStore)).WithAppendLog(a.deps.AppendLog)
 }
 
 const (
@@ -2718,6 +2937,7 @@ func findingConnectError(err error) error {
 	case errors.Is(err, ports.ErrSourceRuntimeNotFound),
 		errors.Is(err, findings.ErrRuleNotFound),
 		errors.Is(err, ports.ErrFindingNotFound),
+		errors.Is(err, ports.ErrFindingCandidateNotFound),
 		errors.Is(err, ports.ErrFindingEvaluationRunNotFound),
 		errors.Is(err, ports.ErrFindingEvidenceNotFound):
 		return connect.NewError(connect.CodeNotFound, err)
@@ -2988,6 +3208,14 @@ func findingEvidenceStore(store ports.StateStore) ports.FindingEvidenceStore {
 	return evidenceStore
 }
 
+func findingCandidateStore(store ports.StateStore) ports.FindingCandidateStore {
+	candidateStore, ok := store.(ports.FindingCandidateStore)
+	if !ok || isNilInterface(candidateStore) {
+		return nil
+	}
+	return candidateStore
+}
+
 func endpointVulnerabilityFindingStore(store ports.StateStore) ports.EndpointVulnerabilityFindingStore {
 	endpointStore, ok := store.(ports.EndpointVulnerabilityFindingStore)
 	if !ok || isNilInterface(endpointStore) {
@@ -3108,6 +3336,21 @@ func findingRulesResponse(result *findings.EvaluateRulesResult) *cerebrov1.Evalu
 	}
 }
 
+func findingCandidateRulesResponse(result *findings.EvaluateCandidateRulesResult) *cerebrov1.EvaluateSourceRuntimeFindingCandidatesResponse {
+	if result == nil {
+		return &cerebrov1.EvaluateSourceRuntimeFindingCandidatesResponse{}
+	}
+	evaluations := make([]*cerebrov1.FindingCandidateRuleEvaluation, 0, len(result.Evaluations))
+	for _, evaluation := range result.Evaluations {
+		evaluations = append(evaluations, findingCandidateRuleEvaluationMessage(evaluation))
+	}
+	return &cerebrov1.EvaluateSourceRuntimeFindingCandidatesResponse{
+		Runtime:         redactSourceRuntime(result.Runtime),
+		EventsEvaluated: result.EventsEvaluated,
+		Evaluations:     evaluations,
+	}
+}
+
 func redactSourceRuntime(runtime *cerebrov1.SourceRuntime) *cerebrov1.SourceRuntime {
 	if runtime == nil {
 		return nil
@@ -3140,6 +3383,17 @@ func findingRuleEvaluationMessage(result *findings.RuleEvaluationResult) *cerebr
 	}
 }
 
+func findingCandidateRuleEvaluationMessage(result *findings.FindingCandidateEvaluationResult) *cerebrov1.FindingCandidateRuleEvaluation {
+	if result == nil {
+		return &cerebrov1.FindingCandidateRuleEvaluation{}
+	}
+	return &cerebrov1.FindingCandidateRuleEvaluation{
+		Rule:       result.Rule,
+		Run:        findingCandidateRunMessage(result.Run),
+		Candidates: findingCandidateMessages(result.Candidates),
+	}
+}
+
 func listFindingsResponse(result *findings.ListResult) *cerebrov1.ListFindingsResponse {
 	if result == nil {
 		return &cerebrov1.ListFindingsResponse{}
@@ -3149,12 +3403,104 @@ func listFindingsResponse(result *findings.ListResult) *cerebrov1.ListFindingsRe
 	}
 }
 
+func listFindingCandidatesResponse(result *findings.ListCandidatesResult) *cerebrov1.ListFindingCandidatesResponse {
+	if result == nil {
+		return &cerebrov1.ListFindingCandidatesResponse{}
+	}
+	return &cerebrov1.ListFindingCandidatesResponse{
+		Candidates: findingCandidateMessages(result.Candidates),
+	}
+}
+
+func promoteFindingCandidateResponse(result *findings.PromoteCandidateResult) *cerebrov1.PromoteFindingCandidateResponse {
+	if result == nil {
+		return &cerebrov1.PromoteFindingCandidateResponse{}
+	}
+	return &cerebrov1.PromoteFindingCandidateResponse{
+		Finding:    findingMessage(result.Finding),
+		Candidate:  findingCandidateMessage(result.Candidate),
+		DecisionId: result.DecisionID,
+	}
+}
+
 func findingMessages(findings []*ports.FindingRecord) []*cerebrov1.Finding {
 	messages := make([]*cerebrov1.Finding, 0, len(findings))
 	for _, finding := range findings {
 		messages = append(messages, findingMessage(finding))
 	}
 	return messages
+}
+
+func findingCandidateMessages(candidates []*ports.FindingCandidateRecord) []*cerebrov1.FindingCandidate {
+	messages := make([]*cerebrov1.FindingCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		messages = append(messages, findingCandidateMessage(candidate))
+	}
+	return messages
+}
+
+func findingCandidateRunMessage(run *ports.FindingCandidateRun) *cerebrov1.FindingCandidateRun {
+	if run == nil {
+		return nil
+	}
+	message := &cerebrov1.FindingCandidateRun{
+		Id:              run.ID,
+		TenantId:        run.TenantID,
+		RuntimeId:       run.RuntimeID,
+		RuleId:          run.RuleID,
+		Status:          run.Status,
+		EventLimit:      run.EventLimit,
+		EventsEvaluated: run.EventsEvaluated,
+		EventsMatched:   run.EventsMatched,
+		Candidates:      run.Candidates,
+		Error:           run.Error,
+	}
+	if !run.StartedAt.IsZero() {
+		message.StartedAt = timestamppb.New(run.StartedAt.UTC())
+	}
+	if !run.FinishedAt.IsZero() {
+		message.FinishedAt = timestamppb.New(run.FinishedAt.UTC())
+	}
+	return message
+}
+
+func findingCandidateMessage(candidate *ports.FindingCandidateRecord) *cerebrov1.FindingCandidate {
+	if candidate == nil {
+		return nil
+	}
+	message := &cerebrov1.FindingCandidate{
+		Id:                 candidate.ID,
+		TenantId:           candidate.TenantID,
+		RuntimeId:          candidate.RuntimeID,
+		RuleId:             candidate.RuleID,
+		Fingerprint:        candidate.Fingerprint,
+		Status:             candidate.Status,
+		Finding:            findingMessage(candidate.Finding),
+		Evidence:           candidate.Evidence,
+		LastRunId:          candidate.LastRunID,
+		ObservationCount:   candidate.ObservationCount,
+		PromotedFindingId:  candidate.PromotedFindingID,
+		DecisionId:         candidate.DecisionID,
+		PromotedBy:         candidate.PromotedBy,
+		PromotionRationale: candidate.PromotionRationale,
+		ChangeTicket:       candidate.ChangeTicket,
+	}
+	if !candidate.FirstObservedAt.IsZero() {
+		message.FirstObservedAt = timestamppb.New(candidate.FirstObservedAt.UTC())
+	}
+	if !candidate.LastObservedAt.IsZero() {
+		message.LastObservedAt = timestamppb.New(candidate.LastObservedAt.UTC())
+	}
+	if !candidate.PromotedAt.IsZero() {
+		message.PromotedAt = timestamppb.New(candidate.PromotedAt.UTC())
+	}
+	if !candidate.CreatedAt.IsZero() {
+		message.CreatedAt = timestamppb.New(candidate.CreatedAt.UTC())
+	}
+	if !candidate.UpdatedAt.IsZero() {
+		message.UpdatedAt = timestamppb.New(candidate.UpdatedAt.UTC())
+	}
+	return message
 }
 
 func findingMessage(finding *ports.FindingRecord) *cerebrov1.Finding {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -656,6 +656,9 @@ type stubRuntimeStore struct {
 	findingEvidenceListRequest      ports.ListFindingEvidenceRequest
 	findingEvaluationRuns           map[string]*cerebrov1.FindingEvaluationRun
 	findingEvaluationRunListRequest ports.ListFindingEvaluationRunsRequest
+	findingCandidateRuns            map[string]*ports.FindingCandidateRun
+	findingCandidates               map[string]*ports.FindingCandidateRecord
+	findingCandidateListRequest     ports.ListFindingCandidatesRequest
 	reportRuns                      map[string]*cerebrov1.ReportRun
 }
 
@@ -1111,6 +1114,124 @@ func (s *stubRuntimeStore) CountFindingEvidence(_ context.Context, request ports
 		}
 	}
 	return count, nil
+}
+
+func (s *stubRuntimeStore) PutFindingCandidateRun(_ context.Context, run *ports.FindingCandidateRun) error {
+	if s.err != nil {
+		return s.err
+	}
+	if run == nil {
+		return nil
+	}
+	if s.findingCandidateRuns == nil {
+		s.findingCandidateRuns = make(map[string]*ports.FindingCandidateRun)
+	}
+	cloned := *run
+	s.findingCandidateRuns[cloned.ID] = &cloned
+	return nil
+}
+
+func (s *stubRuntimeStore) GetFindingCandidateRun(_ context.Context, id string) (*ports.FindingCandidateRun, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	run, ok := s.findingCandidateRuns[strings.TrimSpace(id)]
+	if !ok {
+		return nil, ports.ErrFindingEvaluationRunNotFound
+	}
+	cloned := *run
+	return &cloned, nil
+}
+
+func (s *stubRuntimeStore) ListFindingCandidateRuns(_ context.Context, request ports.ListFindingCandidatesRequest) ([]*ports.FindingCandidateRun, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	runs := []*ports.FindingCandidateRun{}
+	for _, run := range s.findingCandidateRuns {
+		if request.RuntimeID != "" && strings.TrimSpace(run.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+			continue
+		}
+		cloned := *run
+		runs = append(runs, &cloned)
+	}
+	return runs, nil
+}
+
+func (s *stubRuntimeStore) UpsertFindingCandidate(_ context.Context, candidate *ports.FindingCandidateRecord) (*ports.FindingCandidateRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if candidate == nil {
+		return nil, nil
+	}
+	if s.findingCandidates == nil {
+		s.findingCandidates = make(map[string]*ports.FindingCandidateRecord)
+	}
+	cloned := cloneFindingCandidate(candidate)
+	if existing := s.findingCandidates[cloned.ID]; existing != nil {
+		cloned.ObservationCount += existing.ObservationCount
+	}
+	s.findingCandidates[cloned.ID] = cloned
+	return cloneFindingCandidate(cloned), nil
+}
+
+func (s *stubRuntimeStore) GetFindingCandidate(_ context.Context, id string) (*ports.FindingCandidateRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	candidate, ok := s.findingCandidates[strings.TrimSpace(id)]
+	if !ok {
+		return nil, ports.ErrFindingCandidateNotFound
+	}
+	return cloneFindingCandidate(candidate), nil
+}
+
+func (s *stubRuntimeStore) ListFindingCandidates(_ context.Context, request ports.ListFindingCandidatesRequest) ([]*ports.FindingCandidateRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	s.findingCandidateListRequest = request
+	candidates := []*ports.FindingCandidateRecord{}
+	for _, candidate := range s.findingCandidates {
+		if request.RuntimeID != "" && strings.TrimSpace(candidate.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+			continue
+		}
+		if request.CandidateID != "" && strings.TrimSpace(candidate.ID) != strings.TrimSpace(request.CandidateID) {
+			continue
+		}
+		if request.RuleID != "" && strings.TrimSpace(candidate.RuleID) != strings.TrimSpace(request.RuleID) {
+			continue
+		}
+		if request.Status != "" && strings.TrimSpace(candidate.Status) != strings.TrimSpace(request.Status) {
+			continue
+		}
+		if request.Fingerprint != "" && strings.TrimSpace(candidate.Fingerprint) != strings.TrimSpace(request.Fingerprint) {
+			continue
+		}
+		candidates = append(candidates, cloneFindingCandidate(candidate))
+	}
+	return candidates, nil
+}
+
+func (s *stubRuntimeStore) MarkFindingCandidatePromoted(_ context.Context, promotion ports.FindingCandidatePromotion) (*ports.FindingCandidateRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	candidate, ok := s.findingCandidates[strings.TrimSpace(promotion.CandidateID)]
+	if !ok {
+		return nil, ports.ErrFindingCandidateNotFound
+	}
+	cloned := cloneFindingCandidate(candidate)
+	cloned.Status = "promoted"
+	cloned.PromotedFindingID = strings.TrimSpace(promotion.PromotedFindingID)
+	cloned.DecisionID = strings.TrimSpace(promotion.DecisionID)
+	cloned.PromotedBy = strings.TrimSpace(promotion.PromotedBy)
+	cloned.PromotionRationale = strings.TrimSpace(promotion.Rationale)
+	cloned.ChangeTicket = strings.TrimSpace(promotion.ChangeTicket)
+	cloned.PromotedAt = promotion.PromotedAt.UTC()
+	s.findingCandidates[cloned.ID] = cloned
+	return cloneFindingCandidate(cloned), nil
 }
 
 func (s *stubRuntimeStore) PutFindingEvaluationRun(_ context.Context, run *cerebrov1.FindingEvaluationRun) error {
@@ -4997,6 +5118,150 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 }
 
+func TestFindingCandidateEndpointsEvaluateListGetAndPromote(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	appendLog := &recordingAppendLog{
+		replayEvents: []*cerebrov1.EventEnvelope{
+			findingPolicyRuleTestEvent("okta-policy-rule-active", "ACTIVE"),
+			findingPolicyRuleTestEvent("okta-policy-rule-inactive", "INACTIVE"),
+		},
+	}
+	runtimeStore := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-policy-rule": {
+				Id:       "writer-okta-policy-rule",
+				SourceId: "okta",
+				TenantId: "writer",
+				Config:   map[string]string{"family": "policy_rule", "token": "super-secret"},
+			},
+		},
+		claims: map[string]*ports.ClaimRecord{
+			"claim-1": {
+				ID:            "claim-1",
+				RuntimeID:     "writer-okta-policy-rule",
+				TenantID:      "writer",
+				SubjectURN:    "urn:cerebro:writer:okta_policy_rule:pol-1:rul-1",
+				Predicate:     "status",
+				ObjectValue:   "INACTIVE",
+				ClaimType:     "attribute",
+				Status:        "asserted",
+				SourceEventID: "okta-policy-rule-inactive",
+				ObservedAt:    time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
+		AppendLog:  appendLog,
+		StateStore: runtimeStore,
+		GraphStore: &stubGraphStore{},
+	}, registry)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	evaluateReq, err := http.NewRequest(http.MethodPost, server.URL+"/source-runtimes/writer-okta-policy-rule/finding-candidates/evaluate?event_limit=2&rule_id=identity-okta-policy-rule-lifecycle-tampering", nil)
+	if err != nil {
+		t.Fatalf("new candidate evaluate request: %v", err)
+	}
+	evaluateResp, err := server.Client().Do(evaluateReq)
+	if err != nil {
+		t.Fatalf("POST /source-runtimes/{id}/finding-candidates/evaluate error = %v", err)
+	}
+	defer func() {
+		if closeErr := evaluateResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close candidate evaluate response body: %v", closeErr)
+		}
+	}()
+	if evaluateResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(evaluateResp.Body)
+		t.Fatalf("candidate evaluate status = %d body=%s", evaluateResp.StatusCode, string(body))
+	}
+	var evaluatePayload map[string]any
+	if err := json.NewDecoder(evaluateResp.Body).Decode(&evaluatePayload); err != nil {
+		t.Fatalf("decode candidate evaluate response: %v", err)
+	}
+	evaluations := evaluatePayload["evaluations"].([]any)
+	candidates := evaluations[0].(map[string]any)["candidates"].([]any)
+	candidatePayload := candidates[0].(map[string]any)
+	candidateID := candidatePayload["id"].(string)
+	if candidateID == "" {
+		t.Fatal("candidate id is empty")
+	}
+	if got := len(runtimeStore.findings); got != 0 {
+		t.Fatalf("production findings after candidate evaluate = %d, want 0", got)
+	}
+
+	listResp, err := server.Client().Get(server.URL + "/source-runtimes/writer-okta-policy-rule/finding-candidates?status=candidate&limit=1")
+	if err != nil {
+		t.Fatalf("GET /source-runtimes/{id}/finding-candidates error = %v", err)
+	}
+	defer func() {
+		if closeErr := listResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close candidate list response body: %v", closeErr)
+		}
+	}()
+	var listPayload map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&listPayload); err != nil {
+		t.Fatalf("decode candidate list response: %v", err)
+	}
+	listCandidates := listPayload["candidates"].([]any)
+	if got := len(listCandidates); got != 1 {
+		t.Fatalf("listed candidates = %d, want 1", got)
+	}
+
+	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
+	getResp, err := client.GetFindingCandidate(context.Background(), connect.NewRequest(&cerebrov1.GetFindingCandidateRequest{Id: candidateID}))
+	if err != nil {
+		t.Fatalf("GetFindingCandidate() error = %v", err)
+	}
+	if got := getResp.Msg.GetCandidate().GetId(); got != candidateID {
+		t.Fatalf("GetFindingCandidate().Candidate.Id = %q, want %q", got, candidateID)
+	}
+
+	promoteBody, err := protojson.Marshal(&cerebrov1.PromoteFindingCandidateRequest{
+		PromotedBy:            "analyst@example.com",
+		Rationale:             "Validated against source data.",
+		ChangeTicket:          "SEC-123",
+		FalsePositiveReviewed: true,
+		GraphCoverageReviewed: true,
+	})
+	if err != nil {
+		t.Fatalf("marshal promote request: %v", err)
+	}
+	promoteResp, err := server.Client().Post(server.URL+"/finding-candidates/"+candidateID+"/promote", "application/json", bytes.NewReader(promoteBody))
+	if err != nil {
+		t.Fatalf("POST /finding-candidates/{id}/promote error = %v", err)
+	}
+	defer func() {
+		if closeErr := promoteResp.Body.Close(); closeErr != nil {
+			t.Fatalf("close candidate promote response body: %v", closeErr)
+		}
+	}()
+	if promoteResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(promoteResp.Body)
+		t.Fatalf("candidate promote status = %d body=%s", promoteResp.StatusCode, string(body))
+	}
+	var promotePayload map[string]any
+	if err := json.NewDecoder(promoteResp.Body).Decode(&promotePayload); err != nil {
+		t.Fatalf("decode candidate promote response: %v", err)
+	}
+	promotedCandidate := promotePayload["candidate"].(map[string]any)
+	if got := promotedCandidate["status"]; got != "promoted" {
+		t.Fatalf("promoted candidate status = %#v, want promoted", got)
+	}
+	if got := len(runtimeStore.findings); got != 1 {
+		t.Fatalf("production findings after promote = %d, want 1", got)
+	}
+	if got := len(runtimeStore.findingEvidence); got != 1 {
+		t.Fatalf("production finding evidence after promote = %d, want 1", got)
+	}
+	if promotePayload["decision_id"] == "" {
+		t.Fatal("promotion decision_id is empty")
+	}
+}
+
 func TestEndpointVulnerabilityFindingsHTTPRoute(t *testing.T) {
 	now := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
 	store := &stubRuntimeStore{findings: map[string]*ports.FindingRecord{
@@ -6358,6 +6623,19 @@ func cloneFindingEvidence(evidence *cerebrov1.FindingEvidence) *cerebrov1.Findin
 		return nil
 	}
 	return proto.Clone(evidence).(*cerebrov1.FindingEvidence)
+}
+
+func cloneFindingCandidate(candidate *ports.FindingCandidateRecord) *ports.FindingCandidateRecord {
+	if candidate == nil {
+		return nil
+	}
+	cloned := *candidate
+	cloned.Finding = cloneFinding(candidate.Finding)
+	cloned.Evidence = make([]*cerebrov1.FindingEvidence, 0, len(candidate.Evidence))
+	for _, evidence := range candidate.Evidence {
+		cloned.Evidence = append(cloned.Evidence, cloneFindingEvidence(evidence))
+	}
+	return &cloned
 }
 
 func cloneNeighborhood(neighborhood *ports.EntityNeighborhood) *ports.EntityNeighborhood {

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -1,0 +1,552 @@
+package findings
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+const (
+	findingCandidateStatusCandidate = "candidate"
+	findingCandidateStatusPromoted  = "promoted"
+	findingCandidateDecisionType    = "finding_candidate_promotion"
+)
+
+// EvaluateCandidateRulesRequest scopes one non-production candidate evaluation.
+type EvaluateCandidateRulesRequest struct {
+	RuntimeID  string
+	RuleIDs    []string
+	EventLimit uint32
+}
+
+// FindingCandidateEvaluationResult reports one rule's candidate outputs.
+type FindingCandidateEvaluationResult struct {
+	Rule       *cerebrov1.RuleSpec
+	Run        *ports.FindingCandidateRun
+	Candidates []*ports.FindingCandidateRecord
+}
+
+// EvaluateCandidateRulesResult reports one candidate evaluation over one runtime.
+type EvaluateCandidateRulesResult struct {
+	Runtime         *cerebrov1.SourceRuntime
+	EventsEvaluated uint32
+	Evaluations     []*FindingCandidateEvaluationResult
+}
+
+// ListCandidatesRequest scopes a candidate-finding list query.
+type ListCandidatesRequest struct {
+	RuntimeID   string
+	CandidateID string
+	RuleID      string
+	Status      string
+	Fingerprint string
+	Limit       uint32
+}
+
+// ListCandidatesResult reports candidate findings.
+type ListCandidatesResult struct {
+	Candidates []*ports.FindingCandidateRecord
+}
+
+// PromoteCandidateRequest promotes one reviewed candidate into production findings.
+type PromoteCandidateRequest struct {
+	CandidateID           string
+	PromotedBy            string
+	Rationale             string
+	ChangeTicket          string
+	FalsePositiveReviewed bool
+	GraphCoverageReviewed bool
+}
+
+// PromoteCandidateResult reports the production finding and updated candidate.
+type PromoteCandidateResult struct {
+	Candidate  *ports.FindingCandidateRecord
+	Finding    *ports.FindingRecord
+	DecisionID string
+}
+
+type candidateRuleEvaluationState struct {
+	rule          Rule
+	run           *ports.FindingCandidateRun
+	result        *FindingCandidateEvaluationResult
+	eventsMatched uint32
+	failed        bool
+}
+
+// EvaluateSourceRuntimeCandidateRules evaluates real runtime events into isolated
+// candidate storage without mutating production findings, evidence, or graph anchors.
+func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, request EvaluateCandidateRulesRequest) (*EvaluateCandidateRulesResult, error) {
+	if s == nil || s.runtimeStore == nil || s.replayer == nil || s.candidateStore == nil || s.claimStore == nil || s.rules == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
+	}
+	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	rules, err := s.selectRules(ctx, runtime, request.RuleIDs)
+	if err != nil {
+		return nil, err
+	}
+	startedAt := time.Now().UTC()
+	normalizedLimit := normalizeEventLimit(request.EventLimit)
+	result := &EvaluateCandidateRulesResult{
+		Runtime:     runtime,
+		Evaluations: make([]*FindingCandidateEvaluationResult, 0, len(rules)),
+	}
+	states := make([]*candidateRuleEvaluationState, 0, len(rules))
+	for _, rule := range rules {
+		run := newFindingCandidateRun(runtime, rule.Spec().GetId(), normalizedLimit, startedAt)
+		if err := s.candidateStore.PutFindingCandidateRun(ctx, run); err != nil {
+			return nil, fmt.Errorf("persist finding candidate run %q: %w", run.ID, err)
+		}
+		evaluation := &FindingCandidateEvaluationResult{
+			Rule: rule.Spec(),
+			Run:  run,
+		}
+		states = append(states, &candidateRuleEvaluationState{
+			rule:   rule,
+			run:    run,
+			result: evaluation,
+		})
+		result.Evaluations = append(result.Evaluations, evaluation)
+	}
+	var events []*cerebrov1.EventEnvelope
+	if rulesNeedReplay(runtime, ruleEvaluationStatesFromCandidateStates(states)) {
+		events, err = s.replayer.Replay(ctx, ports.ReplayRequest{
+			RuntimeID: runtimeID,
+			Limit:     normalizedLimit,
+		})
+		if err != nil {
+			evaluationErr := fmt.Errorf("replay runtime %q events for candidates: %w", runtimeID, err)
+			return nil, s.markCandidateEvaluationsFailed(ctx, states, evaluationErr)
+		}
+	}
+	result.EventsEvaluated = uint32(len(events))
+	for _, event := range events {
+		for _, state := range states {
+			if state.failed || !state.rule.SupportsRuntime(runtime) {
+				continue
+			}
+			emitted, err := state.rule.Evaluate(ctx, runtime, event)
+			if err != nil {
+				if failErr := s.markCandidateEvaluationFailed(ctx, state, fmt.Errorf("evaluate finding candidate rule %q for event %q: %w", state.result.Rule.GetId(), event.GetId(), err)); failErr != nil {
+					return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
+				}
+				continue
+			}
+			state.run.EventsEvaluated++
+			matchedEvent := false
+			for _, record := range emitted {
+				if record == nil {
+					continue
+				}
+				if !matchedEvent {
+					state.eventsMatched++
+					matchedEvent = true
+				}
+				candidateFinding := normalizeCandidateFinding(record, runtime, startedAt)
+				evidence, err := s.buildFindingEvidence(ctx, candidateFinding, candidateEvidenceRun(state.run))
+				if err != nil {
+					if failErr := s.markCandidateEvaluationFailed(ctx, state, fmt.Errorf("build candidate evidence for finding %q: %w", candidateFinding.ID, err)); failErr != nil {
+						return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
+					}
+					break
+				}
+				candidate := newFindingCandidateRecord(candidateFinding, evidence, state.run.ID)
+				stored, err := s.candidateStore.UpsertFindingCandidate(ctx, candidate)
+				if err != nil {
+					if failErr := s.markCandidateEvaluationFailed(ctx, state, fmt.Errorf("persist finding candidate %q: %w", candidate.ID, err)); failErr != nil {
+						return nil, s.markCandidateEvaluationsFailed(ctx, states, failErr)
+					}
+					break
+				}
+				state.result.Candidates = append(state.result.Candidates, stored)
+			}
+		}
+	}
+	for _, state := range states {
+		if state.failed {
+			continue
+		}
+		state.run.EventsMatched = state.eventsMatched
+		state.run.Candidates = uint32(len(state.result.Candidates))
+		state.run.Status = "completed"
+		state.run.FinishedAt = time.Now().UTC()
+		if err := s.candidateStore.PutFindingCandidateRun(ctx, state.run); err != nil {
+			return nil, s.markCandidateEvaluationsFailed(ctx, unfinishedCandidateEvaluations(states, state), fmt.Errorf("persist finding candidate run %q: %w", state.run.ID, err))
+		}
+	}
+	return result, nil
+}
+
+// ListFindingCandidates loads isolated candidate findings for one runtime.
+func (s *Service) ListFindingCandidates(ctx context.Context, request ListCandidatesRequest) (*ListCandidatesResult, error) {
+	if s == nil || s.runtimeStore == nil || s.candidateStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	if runtimeID == "" {
+		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
+	}
+	runtime, err := s.runtimeStore.GetSourceRuntime(ctx, runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	candidates, err := s.candidateStore.ListFindingCandidates(ctx, ports.ListFindingCandidatesRequest{
+		TenantID:    strings.TrimSpace(runtime.GetTenantId()),
+		RuntimeID:   runtimeID,
+		CandidateID: strings.TrimSpace(request.CandidateID),
+		RuleID:      strings.TrimSpace(request.RuleID),
+		Status:      strings.TrimSpace(request.Status),
+		Fingerprint: strings.TrimSpace(request.Fingerprint),
+		Limit:       request.Limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list finding candidates for runtime %q: %w", runtimeID, err)
+	}
+	return &ListCandidatesResult{Candidates: candidates}, nil
+}
+
+// GetFindingCandidate loads one isolated candidate finding.
+func (s *Service) GetFindingCandidate(ctx context.Context, id string) (*ports.FindingCandidateRecord, error) {
+	if s == nil || s.candidateStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	candidateID := strings.TrimSpace(id)
+	if candidateID == "" {
+		return nil, fmt.Errorf("%w: finding candidate id is required", ErrInvalidRequest)
+	}
+	candidate, err := s.candidateStore.GetFindingCandidate(ctx, candidateID)
+	if err != nil {
+		return nil, err
+	}
+	return candidate, nil
+}
+
+// PromoteFindingCandidate turns one reviewed candidate snapshot into production
+// finding state and records an audit decision for the promotion.
+func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCandidateRequest) (*PromoteCandidateResult, error) {
+	if s == nil || s.candidateStore == nil || s.store == nil || s.evidenceStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	candidateID := strings.TrimSpace(request.CandidateID)
+	if candidateID == "" {
+		return nil, fmt.Errorf("%w: finding candidate id is required", ErrInvalidRequest)
+	}
+	if strings.TrimSpace(request.PromotedBy) == "" {
+		return nil, fmt.Errorf("%w: promoted_by is required", ErrInvalidRequest)
+	}
+	if strings.TrimSpace(request.Rationale) == "" {
+		return nil, fmt.Errorf("%w: promotion rationale is required", ErrInvalidRequest)
+	}
+	if strings.TrimSpace(request.ChangeTicket) == "" {
+		return nil, fmt.Errorf("%w: promotion change ticket is required", ErrInvalidRequest)
+	}
+	if !request.FalsePositiveReviewed {
+		return nil, fmt.Errorf("%w: false positive review is required", ErrInvalidRequest)
+	}
+	if !request.GraphCoverageReviewed {
+		return nil, fmt.Errorf("%w: graph coverage review is required", ErrInvalidRequest)
+	}
+	candidate, err := s.candidateStore.GetFindingCandidate(ctx, candidateID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.EqualFold(strings.TrimSpace(candidate.Status), findingCandidateStatusPromoted) {
+		finding, err := s.store.GetFinding(ctx, strings.TrimSpace(candidate.PromotedFindingID))
+		if err != nil {
+			return nil, err
+		}
+		return &PromoteCandidateResult{Candidate: candidate, Finding: finding, DecisionID: strings.TrimSpace(candidate.DecisionID)}, nil
+	}
+	if candidate.Finding == nil {
+		return nil, fmt.Errorf("%w: finding candidate has no finding snapshot", ErrInvalidRequest)
+	}
+	if len(candidate.Evidence) == 0 {
+		return nil, fmt.Errorf("%w: finding candidate has no evidence", ErrInvalidRequest)
+	}
+	now := time.Now().UTC()
+	production := cloneFindingRecord(candidate.Finding)
+	if production.Attributes == nil {
+		production.Attributes = map[string]string{}
+	}
+	production.Attributes["promoted_from_candidate_id"] = candidate.ID
+	production.Attributes["promotion_change_ticket"] = strings.TrimSpace(request.ChangeTicket)
+	production.Attributes["promotion_rationale"] = strings.TrimSpace(request.Rationale)
+	production.Attributes["promoted_by"] = strings.TrimSpace(request.PromotedBy)
+	production.Attributes["promoted_at"] = now.Format(time.RFC3339Nano)
+	stored, err := s.upsertFindingWithRisk(ctx, production, &cerebrov1.SourceRuntime{
+		Id:       strings.TrimSpace(candidate.RuntimeID),
+		TenantId: strings.TrimSpace(candidate.TenantID),
+	}, now)
+	if err != nil {
+		return nil, fmt.Errorf("promote finding candidate %q: %w", candidate.ID, err)
+	}
+	for _, evidence := range candidate.Evidence {
+		if evidence == nil {
+			continue
+		}
+		productionEvidence := proto.Clone(evidence).(*cerebrov1.FindingEvidence)
+		productionEvidence.FindingId = strings.TrimSpace(stored.ID)
+		if productionEvidence.GetRunId() == "" {
+			productionEvidence.RunId = strings.TrimSpace(candidate.LastRunID)
+		}
+		if err := s.evidenceStore.PutFindingEvidence(ctx, productionEvidence); err != nil {
+			return nil, fmt.Errorf("persist promoted candidate %q evidence %q: %w", candidate.ID, productionEvidence.GetId(), err)
+		}
+	}
+	if err := s.projectFindingAnchor(ctx, stored); err != nil {
+		return nil, fmt.Errorf("project promoted candidate %q finding %q: %w", candidate.ID, stored.ID, err)
+	}
+	decisionID, err := s.recordCandidatePromotionDecision(ctx, candidate, stored, request, now)
+	if err != nil {
+		return nil, err
+	}
+	promoted, err := s.candidateStore.MarkFindingCandidatePromoted(ctx, ports.FindingCandidatePromotion{
+		CandidateID:       candidate.ID,
+		PromotedFindingID: stored.ID,
+		DecisionID:        decisionID,
+		PromotedBy:        strings.TrimSpace(request.PromotedBy),
+		Rationale:         strings.TrimSpace(request.Rationale),
+		ChangeTicket:      strings.TrimSpace(request.ChangeTicket),
+		PromotedAt:        now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &PromoteCandidateResult{Candidate: promoted, Finding: stored, DecisionID: decisionID}, nil
+}
+
+func (s *Service) recordCandidatePromotionDecision(ctx context.Context, candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, request PromoteCandidateRequest, observedAt time.Time) (string, error) {
+	if candidate == nil || finding == nil {
+		return "", errors.New("candidate and finding are required")
+	}
+	tenantID := strings.TrimSpace(candidate.TenantID)
+	targetIDs := []string{
+		findingGraphFindingURN(tenantID, finding),
+		findingCandidateURN(tenantID, candidate.ID),
+	}
+	decisionID := workflowevents.CanonicalWorkflowID(tenantID, "decision", candidate.ID, findingCandidateDecisionType, targetIDs, observedAt)
+	event, err := workflowevents.NewDecisionRecordedEvent(workflowevents.DecisionRecorded{
+		TenantID:      tenantID,
+		DecisionID:    decisionID,
+		DecisionType:  findingCandidateDecisionType,
+		Status:        findingDecisionStatusCompleted,
+		MadeBy:        strings.TrimSpace(request.PromotedBy),
+		Rationale:     strings.TrimSpace(request.Rationale),
+		TargetIDs:     targetIDs,
+		EvidenceIDs:   candidateEvidenceIDs(candidate.Evidence),
+		SourceSystem:  "findings",
+		SourceEventID: strings.TrimSpace(candidate.ID),
+		ObservedAt:    observedAt.Format(time.RFC3339Nano),
+		ValidFrom:     observedAt.Format(time.RFC3339Nano),
+		Metadata: map[string]any{
+			"tenant_id":                   tenantID,
+			"candidate_id":                strings.TrimSpace(candidate.ID),
+			"finding_id":                  strings.TrimSpace(finding.ID),
+			"runtime_id":                  strings.TrimSpace(candidate.RuntimeID),
+			"rule_id":                     strings.TrimSpace(candidate.RuleID),
+			"change_ticket":               strings.TrimSpace(request.ChangeTicket),
+			"false_positive_reviewed":     request.FalsePositiveReviewed,
+			"graph_coverage_reviewed":     request.GraphCoverageReviewed,
+			"candidate_observation_count": candidate.ObservationCount,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := s.recordAndProjectWorkflowEvent(ctx, event); err != nil {
+		return "", fmt.Errorf("record finding candidate %q promotion decision: %w", candidate.ID, err)
+	}
+	return decisionID, nil
+}
+
+func normalizeCandidateFinding(record *ports.FindingRecord, runtime *cerebrov1.SourceRuntime, observedAt time.Time) *ports.FindingRecord {
+	cloned := cloneFindingRecord(record)
+	if cloned == nil {
+		return nil
+	}
+	if cloned.Attributes == nil {
+		cloned.Attributes = map[string]string{}
+	}
+	cloned.TenantID = firstNonEmpty(strings.TrimSpace(cloned.TenantID), strings.TrimSpace(runtime.GetTenantId()))
+	cloned.RuntimeID = firstNonEmpty(strings.TrimSpace(cloned.RuntimeID), strings.TrimSpace(runtime.GetId()))
+	if cloned.FirstObservedAt.IsZero() {
+		cloned.FirstObservedAt = observedAt
+	}
+	if cloned.LastObservedAt.IsZero() {
+		cloned.LastObservedAt = observedAt
+	}
+	return recomputeFindingRisk(enrichFindingRisk(cloned, runtime, observedAt), observedAt)
+}
+
+func newFindingCandidateRecord(finding *ports.FindingRecord, evidence *cerebrov1.FindingEvidence, runID string) *ports.FindingCandidateRecord {
+	evidenceRecords := []*cerebrov1.FindingEvidence{}
+	if evidence != nil {
+		evidenceRecords = append(evidenceRecords, proto.Clone(evidence).(*cerebrov1.FindingEvidence))
+	}
+	return &ports.FindingCandidateRecord{
+		ID:               findingCandidateID(finding),
+		TenantID:         strings.TrimSpace(finding.TenantID),
+		RuntimeID:        strings.TrimSpace(finding.RuntimeID),
+		RuleID:           strings.TrimSpace(finding.RuleID),
+		Fingerprint:      strings.TrimSpace(finding.Fingerprint),
+		Status:           findingCandidateStatusCandidate,
+		Finding:          cloneFindingRecord(finding),
+		Evidence:         evidenceRecords,
+		LastRunID:        strings.TrimSpace(runID),
+		ObservationCount: 1,
+		FirstObservedAt:  finding.FirstObservedAt.UTC(),
+		LastObservedAt:   finding.LastObservedAt.UTC(),
+	}
+}
+
+func newFindingCandidateRun(runtime *cerebrov1.SourceRuntime, ruleID string, eventLimit uint32, startedAt time.Time) *ports.FindingCandidateRun {
+	return &ports.FindingCandidateRun{
+		ID:         findingCandidateRunID(runtime.GetId(), ruleID, startedAt.UTC()),
+		TenantID:   strings.TrimSpace(runtime.GetTenantId()),
+		RuntimeID:  strings.TrimSpace(runtime.GetId()),
+		RuleID:     strings.TrimSpace(ruleID),
+		Status:     "running",
+		EventLimit: normalizeEventLimit(eventLimit),
+		StartedAt:  startedAt.UTC(),
+	}
+}
+
+func candidateEvidenceRun(run *ports.FindingCandidateRun) *cerebrov1.FindingEvaluationRun {
+	if run == nil {
+		return nil
+	}
+	return &cerebrov1.FindingEvaluationRun{
+		Id:         strings.TrimSpace(run.ID),
+		RuntimeId:  strings.TrimSpace(run.RuntimeID),
+		RuleId:     strings.TrimSpace(run.RuleID),
+		Status:     strings.TrimSpace(run.Status),
+		EventLimit: run.EventLimit,
+		StartedAt:  timestamppb.New(run.StartedAt.UTC()),
+	}
+}
+
+func findingCandidateID(finding *ports.FindingRecord) string {
+	if finding == nil {
+		return ""
+	}
+	parts := []string{
+		strings.TrimSpace(finding.TenantID),
+		strings.TrimSpace(finding.RuntimeID),
+		strings.TrimSpace(finding.RuleID),
+		strings.TrimSpace(finding.Fingerprint),
+	}
+	digest := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return "finding-candidate-" + hex.EncodeToString(digest[:12])
+}
+
+func findingCandidateRunID(runtimeID string, ruleID string, startedAt time.Time) string {
+	return strings.Replace(findingEvaluationRunID(runtimeID, ruleID, startedAt), "finding-evaluation-run-", "finding-candidate-run-", 1)
+}
+
+func findingCandidateURN(tenantID string, candidateID string) string {
+	return fmt.Sprintf("urn:cerebro:%s:finding_candidate:%s", strings.TrimSpace(tenantID), strings.TrimSpace(candidateID))
+}
+
+func candidateEvidenceIDs(evidence []*cerebrov1.FindingEvidence) []string {
+	ids := make([]string, 0, len(evidence))
+	for _, record := range evidence {
+		if record == nil {
+			continue
+		}
+		if id := strings.TrimSpace(record.GetId()); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return uniqueSortedStrings(ids)
+}
+
+func (s *Service) markCandidateEvaluationFailed(ctx context.Context, state *candidateRuleEvaluationState, evaluationErr error) error {
+	if state == nil || state.run == nil {
+		return evaluationErr
+	}
+	state.run.Status = "failed"
+	state.run.EventsMatched = state.eventsMatched
+	state.run.Candidates = uint32(len(state.result.Candidates))
+	state.run.Error = strings.TrimSpace(evaluationErr.Error())
+	state.run.FinishedAt = time.Now().UTC()
+	if err := s.candidateStore.PutFindingCandidateRun(ctx, state.run); err != nil {
+		return errors.Join(evaluationErr, fmt.Errorf("persist finding candidate run %q: %w", state.run.ID, err))
+	}
+	state.failed = true
+	return nil
+}
+
+func (s *Service) markCandidateEvaluationsFailed(ctx context.Context, states []*candidateRuleEvaluationState, evaluationErr error) error {
+	var cleanupErr error
+	for _, state := range states {
+		if state != nil && state.failed {
+			continue
+		}
+		if failErr := s.markCandidateEvaluationFailed(ctx, state, evaluationErr); failErr != nil {
+			cleanupErr = errors.Join(cleanupErr, failErr)
+		}
+	}
+	if cleanupErr != nil {
+		return errors.Join(evaluationErr, cleanupErr)
+	}
+	return evaluationErr
+}
+
+func unfinishedCandidateEvaluations(states []*candidateRuleEvaluationState, first *candidateRuleEvaluationState) []*candidateRuleEvaluationState {
+	for index, state := range states {
+		if state == first {
+			return states[index:]
+		}
+	}
+	return nil
+}
+
+func ruleEvaluationStatesFromCandidateStates(states []*candidateRuleEvaluationState) []*ruleEvaluationState {
+	out := make([]*ruleEvaluationState, 0, len(states))
+	for _, state := range states {
+		if state == nil {
+			continue
+		}
+		out = append(out, &ruleEvaluationState{rule: state.rule})
+	}
+	return out
+}
+
+func cloneFindingRecord(finding *ports.FindingRecord) *ports.FindingRecord {
+	if finding == nil {
+		return nil
+	}
+	cloned := *finding
+	cloned.ResourceURNs = append([]string(nil), finding.ResourceURNs...)
+	cloned.EventIDs = append([]string(nil), finding.EventIDs...)
+	cloned.ObservedPolicyIDs = append([]string(nil), finding.ObservedPolicyIDs...)
+	cloned.ControlRefs = append([]ports.FindingControlRef(nil), finding.ControlRefs...)
+	cloned.GraphEvidenceRows = cloneGraphEvidenceRows(finding.GraphEvidenceRows)
+	cloned.RiskReasons = append([]string(nil), finding.RiskReasons...)
+	cloned.Notes = append([]ports.FindingNote(nil), finding.Notes...)
+	cloned.Tickets = append([]ports.FindingTicket(nil), finding.Tickets...)
+	if finding.Attributes != nil {
+		cloned.Attributes = make(map[string]string, len(finding.Attributes))
+		for key, value := range finding.Attributes {
+			cloned.Attributes[key] = value
+		}
+	}
+	return &cloned
+}

--- a/internal/findings/rule_metadata.go
+++ b/internal/findings/rule_metadata.go
@@ -100,6 +100,15 @@ type PublicDetection struct {
 	ControlRefs        []ports.FindingControlRef `json:"control_refs,omitempty"`
 }
 
+const (
+	RuleMaturityTest         = "test"
+	RuleMaturityCandidate    = "candidate"
+	RuleMaturityExperimental = "experimental"
+	RuleMaturityGA           = "ga"
+	RuleMaturityProduction   = "production"
+	RuleMaturityRetired      = "retired"
+)
+
 var builtinRuleMetadataCache struct {
 	once      sync.Once
 	metadata  []RuleDefinition
@@ -300,6 +309,9 @@ func ValidateRuleMetadataCompleteness(metadatas []RuleDefinition) []error {
 				errs = append(errs, fmt.Errorf("rule %q %s is required", id, field))
 			}
 		}
+		if maturity := strings.TrimSpace(metadata.Maturity); maturity != "" && !validRuleMaturity(maturity) {
+			errs = append(errs, fmt.Errorf("rule %q maturity %q is not supported", id, maturity))
+		}
 		requiredSlices := map[string][]string{
 			"tags":               metadata.Tags,
 			"references":         metadata.References,
@@ -319,6 +331,15 @@ func ValidateRuleMetadataCompleteness(metadatas []RuleDefinition) []error {
 		}
 	}
 	return errs
+}
+
+func validRuleMaturity(maturity string) bool {
+	switch strings.TrimSpace(maturity) {
+	case RuleMaturityTest, RuleMaturityCandidate, RuleMaturityExperimental, RuleMaturityGA, RuleMaturityProduction, RuleMaturityRetired:
+		return true
+	default:
+		return false
+	}
 }
 
 func ruleMetadata(rule Rule) (RuleDefinition, bool) {

--- a/internal/findings/rule_metadata_test.go
+++ b/internal/findings/rule_metadata_test.go
@@ -3,6 +3,8 @@ package findings
 import (
 	"slices"
 	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func TestBuiltinRuleMetadataIsComplete(t *testing.T) {
@@ -39,6 +41,52 @@ func TestBuiltinRuleMetadataReturnsIsolatedCopies(t *testing.T) {
 	}
 	if second[index].Tags[0] == "mutated" {
 		t.Fatal("BuiltinRuleMetadata() returned mutable cached metadata tags")
+	}
+}
+
+func TestValidateRuleMetadataCompletenessAcceptsCandidateAndProductionMaturity(t *testing.T) {
+	for _, maturity := range []string{RuleMaturityTest, RuleMaturityCandidate, RuleMaturityExperimental, RuleMaturityGA, RuleMaturityProduction, RuleMaturityRetired} {
+		metadata := RuleDefinition{
+			ID:                "rule-" + maturity,
+			Name:              "Rule " + maturity,
+			Description:       "Rule description",
+			SourceID:          "okta",
+			OutputKind:        "finding",
+			Severity:          "LOW",
+			Status:            "active",
+			Maturity:          maturity,
+			Tags:              []string{"identity"},
+			References:        []string{"https://example.com"},
+			FalsePositives:    []string{"test"},
+			Runbook:           "Review source evidence.",
+			FingerprintFields: []string{"tenant_id"},
+			ControlRefs:       []ports.FindingControlRef{{FrameworkName: "SOC2", ControlID: "CC6.1"}},
+		}
+		if errs := ValidateRuleMetadataCompleteness([]RuleDefinition{metadata}); len(errs) != 0 {
+			t.Fatalf("ValidateRuleMetadataCompleteness(%q) errors = %v", maturity, errs)
+		}
+	}
+}
+
+func TestValidateRuleMetadataCompletenessRejectsUnknownMaturity(t *testing.T) {
+	metadata := RuleDefinition{
+		ID:                "rule-unknown",
+		Name:              "Rule unknown",
+		Description:       "Rule description",
+		SourceID:          "okta",
+		OutputKind:        "finding",
+		Severity:          "LOW",
+		Status:            "active",
+		Maturity:          "preview-ish",
+		Tags:              []string{"identity"},
+		References:        []string{"https://example.com"},
+		FalsePositives:    []string{"test"},
+		Runbook:           "Review source evidence.",
+		FingerprintFields: []string{"tenant_id"},
+		ControlRefs:       []ports.FindingControlRef{{FrameworkName: "SOC2", ControlID: "CC6.1"}},
+	}
+	if errs := ValidateRuleMetadataCompleteness([]RuleDefinition{metadata}); len(errs) == 0 {
+		t.Fatal("ValidateRuleMetadataCompleteness() errors = 0, want unsupported maturity")
 	}
 }
 

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -65,6 +65,7 @@ type Service struct {
 	store                     ports.FindingStore
 	runStore                  ports.FindingEvaluationRunStore
 	evidenceStore             ports.FindingEvidenceStore
+	candidateStore            ports.FindingCandidateStore
 	claimStore                ports.ClaimStore
 	graphQuery                ports.GraphQueryStore
 	graph                     ports.ProjectionGraphStore
@@ -223,6 +224,17 @@ func (s *Service) WithAppendLog(appendLog ports.AppendLog) *Service {
 		return nil
 	}
 	s.appendLog = appendLog
+	return s
+}
+
+// WithFindingCandidateStore wires the isolated candidate-finding persistence
+// boundary. Candidate evaluations do not write production findings until an
+// explicit promotion call uses the production store.
+func (s *Service) WithFindingCandidateStore(store ports.FindingCandidateStore) *Service {
+	if s == nil {
+		return nil
+	}
+	s.candidateStore = store
 	return s
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -86,8 +86,12 @@ type stubFindingStore struct {
 	failRunPutByCall           map[int]error
 	evidence                   map[string]*cerebrov1.FindingEvidence
 	evidenceList               ports.ListFindingEvidenceRequest
+	candidateRuns              map[string]*ports.FindingCandidateRun
+	candidates                 map[string]*ports.FindingCandidateRecord
+	candidateListRequest       ports.ListFindingCandidatesRequest
 	dropReturnedGraphEvidence  bool
 	upsertCount                int
+	candidateUpsertCount       int
 	updateRiskCount            int
 	markRiskProjectedCount     int
 	markRiskProjectedErr       error
@@ -536,6 +540,119 @@ func (s *stubFindingStore) ListFindingEvidence(_ context.Context, request ports.
 		evidence = evidence[:int(request.Limit)]
 	}
 	return evidence, nil
+}
+
+func (s *stubFindingStore) PutFindingCandidateRun(_ context.Context, run *ports.FindingCandidateRun) error {
+	if run == nil {
+		return errors.New("finding candidate run is required")
+	}
+	if s.candidateRuns == nil {
+		s.candidateRuns = make(map[string]*ports.FindingCandidateRun)
+	}
+	cloned := *run
+	s.candidateRuns[cloned.ID] = &cloned
+	return nil
+}
+
+func (s *stubFindingStore) GetFindingCandidateRun(_ context.Context, id string) (*ports.FindingCandidateRun, error) {
+	run, ok := s.candidateRuns[strings.TrimSpace(id)]
+	if !ok {
+		return nil, ports.ErrFindingEvaluationRunNotFound
+	}
+	cloned := *run
+	return &cloned, nil
+}
+
+func (s *stubFindingStore) ListFindingCandidateRuns(_ context.Context, request ports.ListFindingCandidatesRequest) ([]*ports.FindingCandidateRun, error) {
+	runs := make([]*ports.FindingCandidateRun, 0, len(s.candidateRuns))
+	for _, run := range s.candidateRuns {
+		if strings.TrimSpace(request.RuntimeID) != "" && strings.TrimSpace(run.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+			continue
+		}
+		if strings.TrimSpace(request.RuleID) != "" && strings.TrimSpace(run.RuleID) != strings.TrimSpace(request.RuleID) {
+			continue
+		}
+		if strings.TrimSpace(request.Status) != "" && strings.TrimSpace(run.Status) != strings.TrimSpace(request.Status) {
+			continue
+		}
+		cloned := *run
+		runs = append(runs, &cloned)
+	}
+	return runs, nil
+}
+
+func (s *stubFindingStore) UpsertFindingCandidate(_ context.Context, candidate *ports.FindingCandidateRecord) (*ports.FindingCandidateRecord, error) {
+	if candidate == nil {
+		return nil, errors.New("finding candidate is required")
+	}
+	s.candidateUpsertCount++
+	if s.candidates == nil {
+		s.candidates = make(map[string]*ports.FindingCandidateRecord)
+	}
+	cloned := cloneFindingCandidate(candidate)
+	if existing := s.candidates[cloned.ID]; existing != nil {
+		cloned.ObservationCount += existing.ObservationCount
+		if existing.Status == findingCandidateStatusPromoted {
+			cloned.Status = existing.Status
+			cloned.PromotedFindingID = existing.PromotedFindingID
+			cloned.DecisionID = existing.DecisionID
+			cloned.PromotedBy = existing.PromotedBy
+			cloned.PromotionRationale = existing.PromotionRationale
+			cloned.ChangeTicket = existing.ChangeTicket
+			cloned.PromotedAt = existing.PromotedAt
+		}
+	}
+	s.candidates[cloned.ID] = cloned
+	return cloneFindingCandidate(cloned), nil
+}
+
+func (s *stubFindingStore) GetFindingCandidate(_ context.Context, id string) (*ports.FindingCandidateRecord, error) {
+	candidate, ok := s.candidates[strings.TrimSpace(id)]
+	if !ok {
+		return nil, ports.ErrFindingCandidateNotFound
+	}
+	return cloneFindingCandidate(candidate), nil
+}
+
+func (s *stubFindingStore) ListFindingCandidates(_ context.Context, request ports.ListFindingCandidatesRequest) ([]*ports.FindingCandidateRecord, error) {
+	s.candidateListRequest = request
+	candidates := make([]*ports.FindingCandidateRecord, 0, len(s.candidates))
+	for _, candidate := range s.candidates {
+		if strings.TrimSpace(request.RuntimeID) != "" && strings.TrimSpace(candidate.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
+			continue
+		}
+		if strings.TrimSpace(request.RuleID) != "" && strings.TrimSpace(candidate.RuleID) != strings.TrimSpace(request.RuleID) {
+			continue
+		}
+		if strings.TrimSpace(request.Status) != "" && strings.TrimSpace(candidate.Status) != strings.TrimSpace(request.Status) {
+			continue
+		}
+		if strings.TrimSpace(request.CandidateID) != "" && strings.TrimSpace(candidate.ID) != strings.TrimSpace(request.CandidateID) {
+			continue
+		}
+		if strings.TrimSpace(request.Fingerprint) != "" && strings.TrimSpace(candidate.Fingerprint) != strings.TrimSpace(request.Fingerprint) {
+			continue
+		}
+		candidates = append(candidates, cloneFindingCandidate(candidate))
+	}
+	return candidates, nil
+}
+
+func (s *stubFindingStore) MarkFindingCandidatePromoted(_ context.Context, promotion ports.FindingCandidatePromotion) (*ports.FindingCandidateRecord, error) {
+	candidate, ok := s.candidates[strings.TrimSpace(promotion.CandidateID)]
+	if !ok {
+		return nil, ports.ErrFindingCandidateNotFound
+	}
+	cloned := cloneFindingCandidate(candidate)
+	cloned.Status = findingCandidateStatusPromoted
+	cloned.PromotedFindingID = strings.TrimSpace(promotion.PromotedFindingID)
+	cloned.DecisionID = strings.TrimSpace(promotion.DecisionID)
+	cloned.PromotedBy = strings.TrimSpace(promotion.PromotedBy)
+	cloned.PromotionRationale = strings.TrimSpace(promotion.Rationale)
+	cloned.ChangeTicket = strings.TrimSpace(promotion.ChangeTicket)
+	cloned.PromotedAt = promotion.PromotedAt.UTC()
+	s.candidates[cloned.ID] = cloned
+	return cloneFindingCandidate(cloned), nil
 }
 
 type emittingRule struct {
@@ -2473,6 +2590,177 @@ func TestEvaluateSourceRuntimeRulesReplaysOnceAcrossMultipleRules(t *testing.T) 
 	}
 	if got := len(store.evidence); got != 2 {
 		t.Fatalf("len(store.evidence) = %d, want 2", got)
+	}
+}
+
+func TestEvaluateSourceRuntimeCandidateRulesDoesNotWriteProductionFindings(t *testing.T) {
+	registry, err := NewRegistry(&emittingRule{
+		spec:               &cerebrov1.RuleSpec{Id: "rule-a", Name: "Rule A"},
+		supportedSourceIDs: map[string]struct{}{"okta": {}},
+		triggerEventID:     "okta-audit-2",
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	replayer := &stubReplayer{events: []*cerebrov1.EventEnvelope{newAuditEvent("okta-audit-2", "policy.rule.deactivate", "SUCCESS")}}
+	store := &stubFindingStore{
+		claims: map[string]*ports.ClaimRecord{
+			"claim-1": {
+				ID:            "claim-1",
+				RuntimeID:     "writer-okta-audit",
+				TenantID:      "writer",
+				SourceEventID: "okta-audit-2",
+				ObservedAt:    time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		replayer,
+		store,
+		store,
+		store,
+		store,
+		registry,
+	).WithFindingCandidateStore(store)
+
+	result, err := service.EvaluateSourceRuntimeCandidateRules(context.Background(), EvaluateCandidateRulesRequest{
+		RuntimeID:  "writer-okta-audit",
+		EventLimit: 1,
+	})
+	if err != nil {
+		t.Fatalf("EvaluateSourceRuntimeCandidateRules() error = %v", err)
+	}
+	if got := result.EventsEvaluated; got != 1 {
+		t.Fatalf("EventsEvaluated = %d, want 1", got)
+	}
+	if got := store.upsertCount; got != 0 {
+		t.Fatalf("production UpsertFinding calls = %d, want 0", got)
+	}
+	if got := len(store.evidence); got != 0 {
+		t.Fatalf("production evidence rows = %d, want 0", got)
+	}
+	if got := store.updateStatusCallCount; got != 0 {
+		t.Fatalf("production status updates = %d, want 0", got)
+	}
+	if got := store.candidateUpsertCount; got != 1 {
+		t.Fatalf("candidate upserts = %d, want 1", got)
+	}
+	if got := len(result.Evaluations); got != 1 {
+		t.Fatalf("evaluations = %d, want 1", got)
+	}
+	evaluation := result.Evaluations[0]
+	if got := evaluation.Run.Status; got != "completed" {
+		t.Fatalf("candidate run status = %q, want completed", got)
+	}
+	if got := len(evaluation.Candidates); got != 1 {
+		t.Fatalf("candidates = %d, want 1", got)
+	}
+	candidate := evaluation.Candidates[0]
+	if got := candidate.Status; got != findingCandidateStatusCandidate {
+		t.Fatalf("candidate status = %q, want %q", got, findingCandidateStatusCandidate)
+	}
+	if got := candidate.Evidence[0].GetClaimIds()[0]; got != "claim-1" {
+		t.Fatalf("candidate evidence claim = %q, want claim-1", got)
+	}
+}
+
+func TestPromoteFindingCandidateWritesProductionFindingEvidenceAndAudit(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	finding := &ports.FindingRecord{
+		ID:              "finding-1",
+		Fingerprint:     "fingerprint-1",
+		TenantID:        "writer",
+		RuntimeID:       "writer-okta-audit",
+		RuleID:          "rule-a",
+		Title:           "Rule A",
+		Severity:        "MEDIUM",
+		Status:          findingStatusOpen,
+		Summary:         "candidate summary",
+		ResourceURNs:    []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+		EventIDs:        []string{"okta-audit-2"},
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+	}
+	evidence := &cerebrov1.FindingEvidence{
+		Id:             "evidence-1",
+		RuntimeId:      "writer-okta-audit",
+		RuleId:         "rule-a",
+		FindingId:      "finding-1",
+		RunId:          "candidate-run-1",
+		ClaimIds:       []string{"claim-1"},
+		EventIds:       []string{"okta-audit-2"},
+		GraphRootUrns:  []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+		CreatedAt:      timestamppb.New(now),
+		LastObservedAt: timestamppb.New(now),
+	}
+	candidate := &ports.FindingCandidateRecord{
+		ID:               "candidate-1",
+		TenantID:         "writer",
+		RuntimeID:        "writer-okta-audit",
+		RuleID:           "rule-a",
+		Fingerprint:      "fingerprint-1",
+		Status:           findingCandidateStatusCandidate,
+		Finding:          cloneFinding(finding),
+		Evidence:         []*cerebrov1.FindingEvidence{evidence},
+		LastRunID:        "candidate-run-1",
+		ObservationCount: 1,
+		FirstObservedAt:  now,
+		LastObservedAt:   now,
+	}
+	store := &stubFindingStore{
+		candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
+		findings:   map[string]*ports.FindingRecord{},
+	}
+	appendLog := &recordingAppendLog{}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		nil,
+		store,
+		store,
+		store,
+		store,
+		nil,
+	).WithFindingCandidateStore(store).WithAppendLog(appendLog)
+
+	result, err := service.PromoteFindingCandidate(context.Background(), PromoteCandidateRequest{
+		CandidateID:           "candidate-1",
+		PromotedBy:            "analyst@example.com",
+		Rationale:             "Validated against source data.",
+		ChangeTicket:          "SEC-123",
+		FalsePositiveReviewed: true,
+		GraphCoverageReviewed: true,
+	})
+	if err != nil {
+		t.Fatalf("PromoteFindingCandidate() error = %v", err)
+	}
+	if result.Finding == nil {
+		t.Fatal("PromoteFindingCandidate().Finding = nil")
+	}
+	if got := store.upsertCount; got == 0 {
+		t.Fatalf("production UpsertFinding calls = %d, want > 0", got)
+	}
+	if got := len(store.evidence); got != 1 {
+		t.Fatalf("production evidence rows = %d, want 1", got)
+	}
+	if got := result.Candidate.Status; got != findingCandidateStatusPromoted {
+		t.Fatalf("candidate status = %q, want promoted", got)
+	}
+	if got := result.Candidate.PromotedFindingID; got != "finding-1" {
+		t.Fatalf("promoted finding id = %q, want finding-1", got)
+	}
+	if result.DecisionID == "" {
+		t.Fatal("DecisionID is empty")
+	}
+	if got := len(appendLog.events); got != 1 {
+		t.Fatalf("append log events = %d, want 1", got)
+	}
+	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindKnowledgeDecisionRecorded {
+		t.Fatalf("promotion audit event kind = %q, want %q", got, workflowevents.EventKindKnowledgeDecisionRecorded)
 	}
 }
 
@@ -4758,6 +5046,19 @@ func cloneFindingEvidence(evidence *cerebrov1.FindingEvidence) *cerebrov1.Findin
 		return nil
 	}
 	return proto.Clone(evidence).(*cerebrov1.FindingEvidence)
+}
+
+func cloneFindingCandidate(candidate *ports.FindingCandidateRecord) *ports.FindingCandidateRecord {
+	if candidate == nil {
+		return nil
+	}
+	cloned := *candidate
+	cloned.Finding = cloneFinding(candidate.Finding)
+	cloned.Evidence = make([]*cerebrov1.FindingEvidence, 0, len(candidate.Evidence))
+	for _, evidence := range candidate.Evidence {
+		cloned.Evidence = append(cloned.Evidence, cloneFindingEvidence(evidence))
+	}
+	return &cloned
 }
 
 func findingMatches(request ports.ListFindingsRequest, finding *ports.FindingRecord) bool {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -72,34 +72,42 @@ func (s *recordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnv
 }
 
 type stubFindingStore struct {
-	findings                   map[string]*ports.FindingRecord
-	request                    ports.ListFindingsRequest
-	listFindingsRequests       []ports.ListFindingsRequest
-	listFindingsErr            error
-	claims                     map[string]*ports.ClaimRecord
-	claimListRequest           ports.ListClaimsRequest
-	runs                       map[string]*cerebrov1.FindingEvaluationRun
-	runList                    ports.ListFindingEvaluationRunsRequest
-	runPutCount                int
-	failRunPutOn               int
-	failRunPutErr              error
-	failRunPutByCall           map[int]error
-	evidence                   map[string]*cerebrov1.FindingEvidence
-	evidenceList               ports.ListFindingEvidenceRequest
-	candidateRuns              map[string]*ports.FindingCandidateRun
-	candidates                 map[string]*ports.FindingCandidateRecord
-	candidateListRequest       ports.ListFindingCandidatesRequest
-	dropReturnedGraphEvidence  bool
-	upsertCount                int
-	candidateUpsertCount       int
-	updateRiskCount            int
-	markRiskProjectedCount     int
-	markRiskProjectedErr       error
-	backfillRiskResults        []*ports.FindingRecord
-	backfillRiskErr            error
-	backfillIncludeUnprojected bool
-	updateStatusCallCount      int
-	updateStatusCalls          []ports.FindingStatusUpdate
+	findings                  map[string]*ports.FindingRecord
+	request                   ports.ListFindingsRequest
+	listFindingsRequests      []ports.ListFindingsRequest
+	listFindingsErr           error
+	claims                    map[string]*ports.ClaimRecord
+	claimListRequest          ports.ListClaimsRequest
+	runs                      map[string]*cerebrov1.FindingEvaluationRun
+	runList                   ports.ListFindingEvaluationRunsRequest
+	runPutCount               int
+	failRunPutOn              int
+	failRunPutErr             error
+	failRunPutByCall          map[int]error
+	evidence                  map[string]*cerebrov1.FindingEvidence
+	evidenceList              ports.ListFindingEvidenceRequest
+	candidateState            stubFindingCandidateState
+	dropReturnedGraphEvidence bool
+	upsertCount               int
+	updateRiskCount           int
+	markRiskProjectedCount    int
+	markRiskProjectedErr      error
+	backfillState             stubFindingBackfillState
+	updateStatusCallCount     int
+	updateStatusCalls         []ports.FindingStatusUpdate
+}
+
+type stubFindingCandidateState struct {
+	runs        map[string]*ports.FindingCandidateRun
+	candidates  map[string]*ports.FindingCandidateRecord
+	listRequest ports.ListFindingCandidatesRequest
+	upsertCount int
+}
+
+type stubFindingBackfillState struct {
+	results            []*ports.FindingRecord
+	err                error
+	includeUnprojected bool
 }
 
 func (s *stubFindingStore) Ping(context.Context) error { return nil }
@@ -172,12 +180,12 @@ func (s *stubFindingStore) MarkFindingRiskProjected(_ context.Context, request p
 }
 
 func (s *stubFindingStore) BackfillFindingRisk(_ context.Context, includeUnprojected bool) ([]*ports.FindingRecord, error) {
-	s.backfillIncludeUnprojected = includeUnprojected
-	if s.backfillRiskErr != nil {
-		return nil, s.backfillRiskErr
+	s.backfillState.includeUnprojected = includeUnprojected
+	if s.backfillState.err != nil {
+		return nil, s.backfillState.err
 	}
-	results := make([]*ports.FindingRecord, 0, len(s.backfillRiskResults))
-	for _, finding := range s.backfillRiskResults {
+	results := make([]*ports.FindingRecord, 0, len(s.backfillState.results))
+	for _, finding := range s.backfillState.results {
 		results = append(results, cloneFinding(finding))
 	}
 	return results, nil
@@ -546,16 +554,16 @@ func (s *stubFindingStore) PutFindingCandidateRun(_ context.Context, run *ports.
 	if run == nil {
 		return errors.New("finding candidate run is required")
 	}
-	if s.candidateRuns == nil {
-		s.candidateRuns = make(map[string]*ports.FindingCandidateRun)
+	if s.candidateState.runs == nil {
+		s.candidateState.runs = make(map[string]*ports.FindingCandidateRun)
 	}
 	cloned := *run
-	s.candidateRuns[cloned.ID] = &cloned
+	s.candidateState.runs[cloned.ID] = &cloned
 	return nil
 }
 
 func (s *stubFindingStore) GetFindingCandidateRun(_ context.Context, id string) (*ports.FindingCandidateRun, error) {
-	run, ok := s.candidateRuns[strings.TrimSpace(id)]
+	run, ok := s.candidateState.runs[strings.TrimSpace(id)]
 	if !ok {
 		return nil, ports.ErrFindingEvaluationRunNotFound
 	}
@@ -564,8 +572,8 @@ func (s *stubFindingStore) GetFindingCandidateRun(_ context.Context, id string) 
 }
 
 func (s *stubFindingStore) ListFindingCandidateRuns(_ context.Context, request ports.ListFindingCandidatesRequest) ([]*ports.FindingCandidateRun, error) {
-	runs := make([]*ports.FindingCandidateRun, 0, len(s.candidateRuns))
-	for _, run := range s.candidateRuns {
+	runs := make([]*ports.FindingCandidateRun, 0, len(s.candidateState.runs))
+	for _, run := range s.candidateState.runs {
 		if strings.TrimSpace(request.RuntimeID) != "" && strings.TrimSpace(run.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
 			continue
 		}
@@ -585,12 +593,12 @@ func (s *stubFindingStore) UpsertFindingCandidate(_ context.Context, candidate *
 	if candidate == nil {
 		return nil, errors.New("finding candidate is required")
 	}
-	s.candidateUpsertCount++
-	if s.candidates == nil {
-		s.candidates = make(map[string]*ports.FindingCandidateRecord)
+	s.candidateState.upsertCount++
+	if s.candidateState.candidates == nil {
+		s.candidateState.candidates = make(map[string]*ports.FindingCandidateRecord)
 	}
 	cloned := cloneFindingCandidate(candidate)
-	if existing := s.candidates[cloned.ID]; existing != nil {
+	if existing := s.candidateState.candidates[cloned.ID]; existing != nil {
 		cloned.ObservationCount += existing.ObservationCount
 		if existing.Status == findingCandidateStatusPromoted {
 			cloned.Status = existing.Status
@@ -602,12 +610,12 @@ func (s *stubFindingStore) UpsertFindingCandidate(_ context.Context, candidate *
 			cloned.PromotedAt = existing.PromotedAt
 		}
 	}
-	s.candidates[cloned.ID] = cloned
+	s.candidateState.candidates[cloned.ID] = cloned
 	return cloneFindingCandidate(cloned), nil
 }
 
 func (s *stubFindingStore) GetFindingCandidate(_ context.Context, id string) (*ports.FindingCandidateRecord, error) {
-	candidate, ok := s.candidates[strings.TrimSpace(id)]
+	candidate, ok := s.candidateState.candidates[strings.TrimSpace(id)]
 	if !ok {
 		return nil, ports.ErrFindingCandidateNotFound
 	}
@@ -615,9 +623,9 @@ func (s *stubFindingStore) GetFindingCandidate(_ context.Context, id string) (*p
 }
 
 func (s *stubFindingStore) ListFindingCandidates(_ context.Context, request ports.ListFindingCandidatesRequest) ([]*ports.FindingCandidateRecord, error) {
-	s.candidateListRequest = request
-	candidates := make([]*ports.FindingCandidateRecord, 0, len(s.candidates))
-	for _, candidate := range s.candidates {
+	s.candidateState.listRequest = request
+	candidates := make([]*ports.FindingCandidateRecord, 0, len(s.candidateState.candidates))
+	for _, candidate := range s.candidateState.candidates {
 		if strings.TrimSpace(request.RuntimeID) != "" && strings.TrimSpace(candidate.RuntimeID) != strings.TrimSpace(request.RuntimeID) {
 			continue
 		}
@@ -639,7 +647,7 @@ func (s *stubFindingStore) ListFindingCandidates(_ context.Context, request port
 }
 
 func (s *stubFindingStore) MarkFindingCandidatePromoted(_ context.Context, promotion ports.FindingCandidatePromotion) (*ports.FindingCandidateRecord, error) {
-	candidate, ok := s.candidates[strings.TrimSpace(promotion.CandidateID)]
+	candidate, ok := s.candidateState.candidates[strings.TrimSpace(promotion.CandidateID)]
 	if !ok {
 		return nil, ports.ErrFindingCandidateNotFound
 	}
@@ -651,7 +659,7 @@ func (s *stubFindingStore) MarkFindingCandidatePromoted(_ context.Context, promo
 	cloned.PromotionRationale = strings.TrimSpace(promotion.Rationale)
 	cloned.ChangeTicket = strings.TrimSpace(promotion.ChangeTicket)
 	cloned.PromotedAt = promotion.PromotedAt.UTC()
-	s.candidates[cloned.ID] = cloned
+	s.candidateState.candidates[cloned.ID] = cloned
 	return cloneFindingCandidate(cloned), nil
 }
 
@@ -2645,7 +2653,7 @@ func TestEvaluateSourceRuntimeCandidateRulesDoesNotWriteProductionFindings(t *te
 	if got := store.updateStatusCallCount; got != 0 {
 		t.Fatalf("production status updates = %d, want 0", got)
 	}
-	if got := store.candidateUpsertCount; got != 1 {
+	if got := store.candidateState.upsertCount; got != 1 {
 		t.Fatalf("candidate upserts = %d, want 1", got)
 	}
 	if got := len(result.Evaluations); got != 1 {
@@ -2711,8 +2719,10 @@ func TestPromoteFindingCandidateWritesProductionFindingEvidenceAndAudit(t *testi
 		LastObservedAt:   now,
 	}
 	store := &stubFindingStore{
-		candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
-		findings:   map[string]*ports.FindingRecord{},
+		candidateState: stubFindingCandidateState{
+			candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
+		},
+		findings: map[string]*ports.FindingRecord{},
 	}
 	appendLog := &recordingAppendLog{}
 	service := NewWithRegistry(
@@ -3900,7 +3910,9 @@ func TestBackfillFindingRiskProjectsUpdatedRiskRows(t *testing.T) {
 			openFinding.ID:   cloneFinding(openFinding),
 			closedFinding.ID: cloneFinding(closedFinding),
 		},
-		backfillRiskResults: []*ports.FindingRecord{openFinding, closedFinding},
+		backfillState: stubFindingBackfillState{
+			results: []*ports.FindingRecord{openFinding, closedFinding},
+		},
 	}
 	graphStore := &stubGraphStore{}
 	appendLog := &recordingAppendLog{}
@@ -3908,7 +3920,7 @@ func TestBackfillFindingRiskProjectsUpdatedRiskRows(t *testing.T) {
 	if err := service.BackfillFindingRisk(context.Background()); err != nil {
 		t.Fatalf("BackfillFindingRisk() error = %v", err)
 	}
-	if !store.backfillIncludeUnprojected {
+	if !store.backfillState.includeUnprojected {
 		t.Fatal("BackfillFindingRisk() did not request unprojected rows with graph configured")
 	}
 	graphFinding := graphStore.entities["urn:cerebro:tenant-a:finding:finding-1"]
@@ -3962,7 +3974,9 @@ func TestBackfillFindingRiskProjectsCurrentRiskAfterConcurrentUpdate(t *testing.
 		findings: map[string]*ports.FindingRecord{
 			finding.ID: cloneFinding(finding),
 		},
-		backfillRiskResults: []*ports.FindingRecord{finding},
+		backfillState: stubFindingBackfillState{
+			results: []*ports.FindingRecord{finding},
+		},
 	}
 	store.findings[finding.ID].RiskScore = 95
 	graphStore := &stubGraphStore{}
@@ -3997,14 +4011,16 @@ func TestBackfillFindingRiskDoesNotMarkProjectedWithoutGraph(t *testing.T) {
 		},
 	}
 	store := &stubFindingStore{
-		findings:            map[string]*ports.FindingRecord{finding.ID: cloneFinding(finding)},
-		backfillRiskResults: []*ports.FindingRecord{finding},
+		findings: map[string]*ports.FindingRecord{finding.ID: cloneFinding(finding)},
+		backfillState: stubFindingBackfillState{
+			results: []*ports.FindingRecord{finding},
+		},
 	}
 	service := New(nil, nil, store, store, store, store)
 	if err := service.BackfillFindingRisk(context.Background()); err != nil {
 		t.Fatalf("BackfillFindingRisk() error = %v", err)
 	}
-	if store.backfillIncludeUnprojected {
+	if store.backfillState.includeUnprojected {
 		t.Fatal("BackfillFindingRisk() requested unprojected rows without graph configured")
 	}
 	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != "" {

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -137,6 +137,9 @@ var ErrFindingNotFound = errors.New("finding not found")
 // ErrFindingEvidenceNotFound indicates that persisted finding evidence does not exist.
 var ErrFindingEvidenceNotFound = errors.New("finding evidence not found")
 
+// ErrFindingCandidateNotFound indicates that a persisted finding candidate does not exist.
+var ErrFindingCandidateNotFound = errors.New("finding candidate not found")
+
 // ErrCloseoutRunInFlight indicates that another closeout run is currently running.
 var ErrCloseoutRunInFlight = errors.New("another closeout run is in flight")
 
@@ -345,6 +348,71 @@ type ListFindingEvidenceRequest struct {
 	CreatedOrder bool
 }
 
+// FindingCandidateRun records one candidate-rule evaluation pass. Candidate runs
+// are intentionally separate from production finding evaluation runs because they
+// do not upsert current-state findings.
+type FindingCandidateRun struct {
+	ID              string
+	TenantID        string
+	RuntimeID       string
+	RuleID          string
+	Status          string
+	EventLimit      uint32
+	EventsEvaluated uint32
+	EventsMatched   uint32
+	Candidates      uint32
+	StartedAt       time.Time
+	FinishedAt      time.Time
+	Error           string
+}
+
+// FindingCandidateRecord stores a reviewed-but-not-yet-production finding snapshot.
+type FindingCandidateRecord struct {
+	ID                 string
+	TenantID           string
+	RuntimeID          string
+	RuleID             string
+	Fingerprint        string
+	Status             string
+	Finding            *FindingRecord
+	Evidence           []*cerebrov1.FindingEvidence
+	LastRunID          string
+	ObservationCount   uint32
+	FirstObservedAt    time.Time
+	LastObservedAt     time.Time
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+	PromotedFindingID  string
+	DecisionID         string
+	PromotedBy         string
+	PromotionRationale string
+	ChangeTicket       string
+	PromotedAt         time.Time
+}
+
+// ListFindingCandidatesRequest scopes one candidate-finding query.
+type ListFindingCandidatesRequest struct {
+	TenantID    string
+	RuntimeID   string
+	CandidateID string
+	RuleID      string
+	Status      string
+	Fingerprint string
+	Limit       uint32
+}
+
+// FindingCandidatePromotion marks one candidate as promoted after the production
+// finding and audit decision are durable.
+type FindingCandidatePromotion struct {
+	CandidateID       string
+	PromotedFindingID string
+	DecisionID        string
+	PromotedBy        string
+	Rationale         string
+	ChangeTicket      string
+	PromotedAt        time.Time
+}
+
 // FindingStore persists normalized findings in the state store.
 type FindingStore interface {
 	StateStore
@@ -372,4 +440,16 @@ type FindingEvidenceStore interface {
 	PutFindingEvidence(context.Context, *cerebrov1.FindingEvidence) error
 	GetFindingEvidence(context.Context, string) (*cerebrov1.FindingEvidence, error)
 	ListFindingEvidence(context.Context, ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error)
+}
+
+// FindingCandidateStore persists non-production candidate finding outputs.
+type FindingCandidateStore interface {
+	StateStore
+	PutFindingCandidateRun(context.Context, *FindingCandidateRun) error
+	GetFindingCandidateRun(context.Context, string) (*FindingCandidateRun, error)
+	ListFindingCandidateRuns(context.Context, ListFindingCandidatesRequest) ([]*FindingCandidateRun, error)
+	UpsertFindingCandidate(context.Context, *FindingCandidateRecord) (*FindingCandidateRecord, error)
+	GetFindingCandidate(context.Context, string) (*FindingCandidateRecord, error)
+	ListFindingCandidates(context.Context, ListFindingCandidatesRequest) ([]*FindingCandidateRecord, error)
+	MarkFindingCandidatePromoted(context.Context, FindingCandidatePromotion) (*FindingCandidateRecord, error)
 }

--- a/internal/statestore/postgres/finding_candidates.go
+++ b/internal/statestore/postgres/finding_candidates.go
@@ -1,0 +1,560 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var ensureFindingCandidateStatements = []string{
+	`CREATE TABLE IF NOT EXISTS finding_candidate_runs (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  runtime_id TEXT NOT NULL,
+  rule_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  event_limit INTEGER NOT NULL DEFAULT 0,
+  events_evaluated INTEGER NOT NULL DEFAULT 0,
+  events_matched INTEGER NOT NULL DEFAULT 0,
+  candidates INTEGER NOT NULL DEFAULT 0,
+  started_at TIMESTAMPTZ NOT NULL,
+  finished_at TIMESTAMPTZ,
+  error TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS finding_candidate_runs_runtime_idx ON finding_candidate_runs (tenant_id, runtime_id, started_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS finding_candidate_runs_rule_idx ON finding_candidate_runs (tenant_id, rule_id, started_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS finding_candidate_runs_status_idx ON finding_candidate_runs (tenant_id, status, started_at DESC)`,
+	`CREATE TABLE IF NOT EXISTS finding_candidates (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  runtime_id TEXT NOT NULL,
+  rule_id TEXT NOT NULL,
+  fingerprint TEXT NOT NULL,
+  status TEXT NOT NULL,
+  finding_json JSONB NOT NULL,
+  evidence_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  last_run_id TEXT NOT NULL,
+  observation_count INTEGER NOT NULL DEFAULT 0,
+  first_observed_at TIMESTAMPTZ NOT NULL,
+  last_observed_at TIMESTAMPTZ NOT NULL,
+  promoted_finding_id TEXT NOT NULL DEFAULT '',
+  decision_id TEXT NOT NULL DEFAULT '',
+  promoted_by TEXT NOT NULL DEFAULT '',
+  promotion_rationale TEXT NOT NULL DEFAULT '',
+  change_ticket TEXT NOT NULL DEFAULT '',
+  promoted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`CREATE INDEX IF NOT EXISTS finding_candidates_runtime_idx ON finding_candidates (tenant_id, runtime_id, last_observed_at DESC, id)`,
+	`CREATE INDEX IF NOT EXISTS finding_candidates_rule_idx ON finding_candidates (tenant_id, rule_id, last_observed_at DESC, id)`,
+	`CREATE INDEX IF NOT EXISTS finding_candidates_status_idx ON finding_candidates (tenant_id, status, last_observed_at DESC, id)`,
+	`CREATE INDEX IF NOT EXISTS finding_candidates_fingerprint_idx ON finding_candidates (tenant_id, fingerprint)`,
+}
+
+// PutFindingCandidateRun upserts one candidate evaluation run.
+func (s *Store) PutFindingCandidateRun(ctx context.Context, run *ports.FindingCandidateRun) error {
+	if run == nil {
+		return errors.New("finding candidate run is required")
+	}
+	id := strings.TrimSpace(run.ID)
+	if id == "" {
+		return errors.New("finding candidate run id is required")
+	}
+	tenantID := strings.TrimSpace(run.TenantID)
+	if tenantID == "" {
+		return errors.New("finding candidate run tenant id is required")
+	}
+	runtimeID := strings.TrimSpace(run.RuntimeID)
+	if runtimeID == "" {
+		return errors.New("finding candidate run runtime id is required")
+	}
+	ruleID := strings.TrimSpace(run.RuleID)
+	if ruleID == "" {
+		return errors.New("finding candidate run rule id is required")
+	}
+	status := strings.TrimSpace(run.Status)
+	if status == "" {
+		return errors.New("finding candidate run status is required")
+	}
+	startedAt := run.StartedAt.UTC()
+	if startedAt.IsZero() {
+		return errors.New("finding candidate run started_at is required")
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingCandidateTables(ctx); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO finding_candidate_runs (
+  id, tenant_id, runtime_id, rule_id, status, event_limit, events_evaluated,
+  events_matched, candidates, started_at, finished_at, error
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+ON CONFLICT (id)
+DO UPDATE SET
+  tenant_id = EXCLUDED.tenant_id,
+  runtime_id = EXCLUDED.runtime_id,
+  rule_id = EXCLUDED.rule_id,
+  status = EXCLUDED.status,
+  event_limit = EXCLUDED.event_limit,
+  events_evaluated = EXCLUDED.events_evaluated,
+  events_matched = EXCLUDED.events_matched,
+  candidates = EXCLUDED.candidates,
+  started_at = EXCLUDED.started_at,
+  finished_at = EXCLUDED.finished_at,
+  error = EXCLUDED.error,
+  updated_at = NOW()`,
+		id,
+		tenantID,
+		runtimeID,
+		ruleID,
+		status,
+		int64(run.EventLimit),
+		int64(run.EventsEvaluated),
+		int64(run.EventsMatched),
+		int64(run.Candidates),
+		startedAt,
+		nullableTime(run.FinishedAt),
+		strings.TrimSpace(run.Error),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert finding candidate run %q: %w", id, err)
+	}
+	return nil
+}
+
+// GetFindingCandidateRun loads one candidate evaluation run.
+func (s *Store) GetFindingCandidateRun(ctx context.Context, runID string) (*ports.FindingCandidateRun, error) {
+	id := strings.TrimSpace(runID)
+	if id == "" {
+		return nil, errors.New("finding candidate run id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingCandidateTables(ctx); err != nil {
+		return nil, err
+	}
+	run := &ports.FindingCandidateRun{}
+	var finishedAt sql.NullTime
+	if err := s.db.QueryRowContext(ctx, `
+SELECT id, tenant_id, runtime_id, rule_id, status, event_limit, events_evaluated,
+  events_matched, candidates, started_at, finished_at, error
+FROM finding_candidate_runs
+WHERE id = $1`, id).Scan(
+		&run.ID,
+		&run.TenantID,
+		&run.RuntimeID,
+		&run.RuleID,
+		&run.Status,
+		&run.EventLimit,
+		&run.EventsEvaluated,
+		&run.EventsMatched,
+		&run.Candidates,
+		&run.StartedAt,
+		&finishedAt,
+		&run.Error,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrFindingEvaluationRunNotFound, id)
+		}
+		return nil, fmt.Errorf("query finding candidate run %q: %w", id, err)
+	}
+	if finishedAt.Valid {
+		run.FinishedAt = finishedAt.Time.UTC()
+	}
+	return run, nil
+}
+
+// ListFindingCandidateRuns lists candidate evaluation runs for one tenant/runtime scope.
+func (s *Store) ListFindingCandidateRuns(ctx context.Context, request ports.ListFindingCandidatesRequest) (_ []*ports.FindingCandidateRun, err error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingCandidateTables(ctx); err != nil {
+		return nil, err
+	}
+	query, args, err := findingCandidateRunListQuery(request)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query finding candidate runs: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close finding candidate run rows: %w", closeErr)
+		}
+	}()
+	runs := []*ports.FindingCandidateRun{}
+	for rows.Next() {
+		run := &ports.FindingCandidateRun{}
+		var finishedAt sql.NullTime
+		if err := rows.Scan(&run.ID, &run.TenantID, &run.RuntimeID, &run.RuleID, &run.Status, &run.EventLimit, &run.EventsEvaluated, &run.EventsMatched, &run.Candidates, &run.StartedAt, &finishedAt, &run.Error); err != nil {
+			return nil, fmt.Errorf("scan finding candidate run: %w", err)
+		}
+		if finishedAt.Valid {
+			run.FinishedAt = finishedAt.Time.UTC()
+		}
+		runs = append(runs, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate finding candidate run rows: %w", err)
+	}
+	return runs, nil
+}
+
+// UpsertFindingCandidate persists one non-production candidate snapshot.
+func (s *Store) UpsertFindingCandidate(ctx context.Context, candidate *ports.FindingCandidateRecord) (*ports.FindingCandidateRecord, error) {
+	if candidate == nil {
+		return nil, errors.New("finding candidate is required")
+	}
+	if err := validateFindingCandidate(candidate); err != nil {
+		return nil, err
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingCandidateTables(ctx); err != nil {
+		return nil, err
+	}
+	findingJSON, err := json.Marshal(candidate.Finding)
+	if err != nil {
+		return nil, fmt.Errorf("marshal finding candidate finding: %w", err)
+	}
+	evidenceJSON, err := json.Marshal(candidate.Evidence)
+	if err != nil {
+		return nil, fmt.Errorf("marshal finding candidate evidence: %w", err)
+	}
+	status := strings.TrimSpace(candidate.Status)
+	if status == "" {
+		status = "candidate"
+	}
+	observations := candidate.ObservationCount
+	if observations == 0 {
+		observations = 1
+	}
+	firstObservedAt := candidate.FirstObservedAt.UTC()
+	if firstObservedAt.IsZero() {
+		firstObservedAt = candidate.Finding.FirstObservedAt.UTC()
+	}
+	lastObservedAt := candidate.LastObservedAt.UTC()
+	if lastObservedAt.IsZero() {
+		lastObservedAt = candidate.Finding.LastObservedAt.UTC()
+	}
+	now := time.Now().UTC()
+	row, err := s.queryFindingCandidate(ctx, `
+INSERT INTO finding_candidates (
+  id, tenant_id, runtime_id, rule_id, fingerprint, status, finding_json, evidence_json,
+  last_run_id, observation_count, first_observed_at, last_observed_at
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11, $12)
+ON CONFLICT (id)
+DO UPDATE SET
+  tenant_id = EXCLUDED.tenant_id,
+  runtime_id = EXCLUDED.runtime_id,
+  rule_id = EXCLUDED.rule_id,
+  fingerprint = EXCLUDED.fingerprint,
+  status = CASE WHEN finding_candidates.status = 'promoted' THEN finding_candidates.status ELSE EXCLUDED.status END,
+  finding_json = EXCLUDED.finding_json,
+  evidence_json = EXCLUDED.evidence_json,
+  last_run_id = EXCLUDED.last_run_id,
+  observation_count = finding_candidates.observation_count + EXCLUDED.observation_count,
+  first_observed_at = LEAST(finding_candidates.first_observed_at, EXCLUDED.first_observed_at),
+  last_observed_at = GREATEST(finding_candidates.last_observed_at, EXCLUDED.last_observed_at),
+  updated_at = $13
+RETURNING `+findingCandidateSelectColumns,
+		strings.TrimSpace(candidate.ID),
+		strings.TrimSpace(candidate.TenantID),
+		strings.TrimSpace(candidate.RuntimeID),
+		strings.TrimSpace(candidate.RuleID),
+		strings.TrimSpace(candidate.Fingerprint),
+		status,
+		string(findingJSON),
+		string(evidenceJSON),
+		strings.TrimSpace(candidate.LastRunID),
+		int64(observations),
+		firstObservedAt,
+		lastObservedAt,
+		now,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("upsert finding candidate %q: %w", strings.TrimSpace(candidate.ID), err)
+	}
+	return row, nil
+}
+
+// GetFindingCandidate loads one candidate by id.
+func (s *Store) GetFindingCandidate(ctx context.Context, candidateID string) (*ports.FindingCandidateRecord, error) {
+	id := strings.TrimSpace(candidateID)
+	if id == "" {
+		return nil, errors.New("finding candidate id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingCandidateTables(ctx); err != nil {
+		return nil, err
+	}
+	candidate, err := s.queryFindingCandidate(ctx, `SELECT `+findingCandidateSelectColumns+` FROM finding_candidates WHERE id = $1`, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrFindingCandidateNotFound, id)
+		}
+		return nil, fmt.Errorf("query finding candidate %q: %w", id, err)
+	}
+	return candidate, nil
+}
+
+// ListFindingCandidates lists candidate finding snapshots.
+func (s *Store) ListFindingCandidates(ctx context.Context, request ports.ListFindingCandidatesRequest) (_ []*ports.FindingCandidateRecord, err error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingCandidateTables(ctx); err != nil {
+		return nil, err
+	}
+	query, args, err := findingCandidateListQuery(request)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query finding candidates: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close finding candidate rows: %w", closeErr)
+		}
+	}()
+	candidates := []*ports.FindingCandidateRecord{}
+	for rows.Next() {
+		candidate, err := scanFindingCandidate(rows)
+		if err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate finding candidate rows: %w", err)
+	}
+	return candidates, nil
+}
+
+// MarkFindingCandidatePromoted records promotion metadata on one candidate row.
+func (s *Store) MarkFindingCandidatePromoted(ctx context.Context, promotion ports.FindingCandidatePromotion) (*ports.FindingCandidateRecord, error) {
+	id := strings.TrimSpace(promotion.CandidateID)
+	if id == "" {
+		return nil, errors.New("finding candidate id is required")
+	}
+	if strings.TrimSpace(promotion.PromotedFindingID) == "" {
+		return nil, errors.New("promoted finding id is required")
+	}
+	if strings.TrimSpace(promotion.PromotedBy) == "" {
+		return nil, errors.New("promoted by is required")
+	}
+	if strings.TrimSpace(promotion.Rationale) == "" {
+		return nil, errors.New("promotion rationale is required")
+	}
+	if strings.TrimSpace(promotion.ChangeTicket) == "" {
+		return nil, errors.New("promotion change ticket is required")
+	}
+	promotedAt := promotion.PromotedAt.UTC()
+	if promotedAt.IsZero() {
+		promotedAt = time.Now().UTC()
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingCandidateTables(ctx); err != nil {
+		return nil, err
+	}
+	candidate, err := s.queryFindingCandidate(ctx, `
+UPDATE finding_candidates
+SET status = 'promoted',
+  promoted_finding_id = $2,
+  decision_id = $3,
+  promoted_by = $4,
+  promotion_rationale = $5,
+  change_ticket = $6,
+  promoted_at = $7,
+  updated_at = NOW()
+WHERE id = $1
+RETURNING `+findingCandidateSelectColumns,
+		id,
+		strings.TrimSpace(promotion.PromotedFindingID),
+		strings.TrimSpace(promotion.DecisionID),
+		strings.TrimSpace(promotion.PromotedBy),
+		strings.TrimSpace(promotion.Rationale),
+		strings.TrimSpace(promotion.ChangeTicket),
+		promotedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrFindingCandidateNotFound, id)
+		}
+		return nil, fmt.Errorf("mark finding candidate %q promoted: %w", id, err)
+	}
+	return candidate, nil
+}
+
+const findingCandidateSelectColumns = `id, tenant_id, runtime_id, rule_id, fingerprint, status,
+  finding_json::text, evidence_json::text, last_run_id, observation_count, first_observed_at,
+  last_observed_at, promoted_finding_id, decision_id, promoted_by, promotion_rationale,
+  change_ticket, promoted_at, created_at, updated_at`
+
+type findingCandidateScanner interface {
+	Scan(dest ...any) error
+}
+
+func (s *Store) queryFindingCandidate(ctx context.Context, query string, args ...any) (*ports.FindingCandidateRecord, error) {
+	return scanFindingCandidate(s.db.QueryRowContext(ctx, query, args...))
+}
+
+func scanFindingCandidate(scanner findingCandidateScanner) (*ports.FindingCandidateRecord, error) {
+	candidate := &ports.FindingCandidateRecord{}
+	var findingJSON string
+	var evidenceJSON string
+	var promotedAt sql.NullTime
+	if err := scanner.Scan(
+		&candidate.ID,
+		&candidate.TenantID,
+		&candidate.RuntimeID,
+		&candidate.RuleID,
+		&candidate.Fingerprint,
+		&candidate.Status,
+		&findingJSON,
+		&evidenceJSON,
+		&candidate.LastRunID,
+		&candidate.ObservationCount,
+		&candidate.FirstObservedAt,
+		&candidate.LastObservedAt,
+		&candidate.PromotedFindingID,
+		&candidate.DecisionID,
+		&candidate.PromotedBy,
+		&candidate.PromotionRationale,
+		&candidate.ChangeTicket,
+		&promotedAt,
+		&candidate.CreatedAt,
+		&candidate.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	finding := &ports.FindingRecord{}
+	if err := json.Unmarshal([]byte(findingJSON), finding); err != nil {
+		return nil, fmt.Errorf("decode finding candidate finding %q: %w", candidate.ID, err)
+	}
+	var evidence []*cerebrov1.FindingEvidence
+	if err := json.Unmarshal([]byte(evidenceJSON), &evidence); err != nil {
+		return nil, fmt.Errorf("decode finding candidate evidence %q: %w", candidate.ID, err)
+	}
+	candidate.Finding = finding
+	candidate.Evidence = evidence
+	if promotedAt.Valid {
+		candidate.PromotedAt = promotedAt.Time.UTC()
+	}
+	return candidate, nil
+}
+
+func validateFindingCandidate(candidate *ports.FindingCandidateRecord) error {
+	if strings.TrimSpace(candidate.ID) == "" {
+		return errors.New("finding candidate id is required")
+	}
+	if strings.TrimSpace(candidate.TenantID) == "" {
+		return errors.New("finding candidate tenant id is required")
+	}
+	if strings.TrimSpace(candidate.RuntimeID) == "" {
+		return errors.New("finding candidate runtime id is required")
+	}
+	if strings.TrimSpace(candidate.RuleID) == "" {
+		return errors.New("finding candidate rule id is required")
+	}
+	if strings.TrimSpace(candidate.Fingerprint) == "" {
+		return errors.New("finding candidate fingerprint is required")
+	}
+	if strings.TrimSpace(candidate.LastRunID) == "" {
+		return errors.New("finding candidate last run id is required")
+	}
+	if candidate.Finding == nil {
+		return errors.New("finding candidate finding is required")
+	}
+	return nil
+}
+
+func (s *Store) ensureFindingCandidateTables(ctx context.Context) error {
+	return s.ensureStatements(ctx, &s.findingCandidateReady, "finding candidate", ensureFindingCandidateStatements)
+}
+
+func findingCandidateRunListQuery(request ports.ListFindingCandidatesRequest) (string, []any, error) {
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return "", nil, errors.New("finding candidate tenant id is required")
+	}
+	clauses := []string{"tenant_id = $1"}
+	args := []any{tenantID}
+	addFindingCandidateFilter(&clauses, &args, "runtime_id", request.RuntimeID)
+	addFindingCandidateFilter(&clauses, &args, "rule_id", request.RuleID)
+	addFindingCandidateFilter(&clauses, &args, "status", request.Status)
+	query := `
+SELECT id, tenant_id, runtime_id, rule_id, status, event_limit, events_evaluated,
+  events_matched, candidates, started_at, finished_at, error
+FROM finding_candidate_runs
+WHERE ` + strings.Join(clauses, " AND ") + `
+ORDER BY started_at DESC, id`
+	if request.Limit != 0 {
+		args = append(args, int64(request.Limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	return query, args, nil
+}
+
+func findingCandidateListQuery(request ports.ListFindingCandidatesRequest) (string, []any, error) {
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return "", nil, errors.New("finding candidate tenant id is required")
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	ruleID := strings.TrimSpace(request.RuleID)
+	candidateID := strings.TrimSpace(request.CandidateID)
+	if runtimeID == "" && ruleID == "" && candidateID == "" {
+		return "", nil, errors.New("finding candidate runtime id, rule id, or candidate id is required")
+	}
+	clauses := []string{"tenant_id = $1"}
+	args := []any{tenantID}
+	addFindingCandidateFilter(&clauses, &args, "id", candidateID)
+	addFindingCandidateFilter(&clauses, &args, "runtime_id", runtimeID)
+	addFindingCandidateFilter(&clauses, &args, "rule_id", ruleID)
+	addFindingCandidateFilter(&clauses, &args, "status", request.Status)
+	addFindingCandidateFilter(&clauses, &args, "fingerprint", request.Fingerprint)
+	query := `SELECT ` + findingCandidateSelectColumns + `
+FROM finding_candidates
+WHERE ` + strings.Join(clauses, " AND ") + `
+ORDER BY last_observed_at DESC, id`
+	if request.Limit != 0 {
+		args = append(args, int64(request.Limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	return query, args, nil
+}
+
+func addFindingCandidateFilter(clauses *[]string, args *[]any, column string, value string) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return
+	}
+	*args = append(*args, trimmed)
+	*clauses = append(*clauses, fmt.Sprintf("%s = $%d", column, len(*args)))
+}

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -223,6 +223,62 @@ func TestFindingListQueryAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
 	}
 }
 
+func TestFindingCandidateListQueryRequiresTenantAndScope(t *testing.T) {
+	if _, _, err := findingCandidateListQuery(ports.ListFindingCandidatesRequest{RuntimeID: "writer-okta-audit"}); err == nil {
+		t.Fatal("findingCandidateListQuery() error = nil, want tenant error")
+	}
+	if _, _, err := findingCandidateListQuery(ports.ListFindingCandidatesRequest{TenantID: "writer"}); err == nil {
+		t.Fatal("findingCandidateListQuery() error = nil, want scope error")
+	}
+}
+
+func TestFindingCandidateListQueryFiltersRuntimeRuleStatusAndFingerprint(t *testing.T) {
+	query, args, err := findingCandidateListQuery(ports.ListFindingCandidatesRequest{
+		TenantID:    "writer",
+		RuntimeID:   "writer-okta-audit",
+		RuleID:      "rule-a",
+		Status:      "candidate",
+		Fingerprint: "fingerprint-1",
+		Limit:       5,
+	})
+	if err != nil {
+		t.Fatalf("findingCandidateListQuery() error = %v", err)
+	}
+	for _, want := range []string{"tenant_id = $1", "runtime_id = $2", "rule_id = $3", "status = $4", "fingerprint = $5", "LIMIT $6"} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("findingCandidateListQuery() missing %q in query: %s", want, query)
+		}
+	}
+	if got := len(args); got != 6 {
+		t.Fatalf("len(args) = %d, want 6", got)
+	}
+}
+
+func TestValidateFindingCandidateRequiresSnapshotAndLastRun(t *testing.T) {
+	err := validateFindingCandidate(&ports.FindingCandidateRecord{
+		ID:          "candidate-1",
+		TenantID:    "writer",
+		RuntimeID:   "writer-okta-audit",
+		RuleID:      "rule-a",
+		Fingerprint: "fingerprint-1",
+	})
+	if err == nil {
+		t.Fatal("validateFindingCandidate() error = nil, want missing last run/finding error")
+	}
+	valid := &ports.FindingCandidateRecord{
+		ID:          "candidate-1",
+		TenantID:    "writer",
+		RuntimeID:   "writer-okta-audit",
+		RuleID:      "rule-a",
+		Fingerprint: "fingerprint-1",
+		LastRunID:   "candidate-run-1",
+		Finding:     newUpsertFinding("finding-1", "fingerprint-1", "open", time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)),
+	}
+	if err := validateFindingCandidate(valid); err != nil {
+		t.Fatalf("validateFindingCandidate() error = %v", err)
+	}
+}
+
 func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
 	query, args, err := findingListQuery(ports.ListFindingsRequest{
 		TenantID:    "tenant-a",

--- a/internal/statestore/postgres/postgres.go
+++ b/internal/statestore/postgres/postgres.go
@@ -24,6 +24,7 @@ type Store struct {
 	sourceRuntimeTableReady   bool
 	findingEvidenceReady      bool
 	findingEvaluationRunReady bool
+	findingCandidateReady     bool
 	vulnDBTablesReady         bool
 	deviceAuthTablesReady     bool
 	startupLeaseTableReady    bool

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -28,6 +28,10 @@ service BootstrapService {
   rpc ListClaims(ListClaimsRequest) returns (ListClaimsResponse);
   rpc ListFindings(ListFindingsRequest) returns (ListFindingsResponse);
   rpc GetFinding(GetFindingRequest) returns (GetFindingResponse);
+  rpc ListFindingCandidates(ListFindingCandidatesRequest) returns (ListFindingCandidatesResponse);
+  rpc GetFindingCandidate(GetFindingCandidateRequest) returns (GetFindingCandidateResponse);
+  rpc EvaluateSourceRuntimeFindingCandidates(EvaluateSourceRuntimeFindingCandidatesRequest) returns (EvaluateSourceRuntimeFindingCandidatesResponse);
+  rpc PromoteFindingCandidate(PromoteFindingCandidateRequest) returns (PromoteFindingCandidateResponse);
   rpc ResolveFinding(ResolveFindingRequest) returns (ResolveFindingResponse);
   rpc SuppressFinding(SuppressFindingRequest) returns (SuppressFindingResponse);
   rpc AssignFinding(AssignFindingRequest) returns (AssignFindingResponse);
@@ -583,6 +587,109 @@ message LinkFindingTicketResponse {
 // ListFindingsResponse returns the matched persisted findings.
 message ListFindingsResponse {
   repeated Finding findings = 1;
+}
+
+// FindingCandidateRun is the durable audit envelope for one non-production candidate evaluation.
+message FindingCandidateRun {
+  string id = 1;
+  string tenant_id = 2;
+  string runtime_id = 3;
+  string rule_id = 4;
+  string status = 5;
+  uint32 event_limit = 6;
+  uint32 events_evaluated = 7;
+  uint32 events_matched = 8;
+  uint32 candidates = 9;
+  google.protobuf.Timestamp started_at = 10;
+  google.protobuf.Timestamp finished_at = 11;
+  string error = 12;
+}
+
+// FindingCandidate stores a reviewed candidate finding snapshot outside production alerts.
+message FindingCandidate {
+  string id = 1;
+  string tenant_id = 2;
+  string runtime_id = 3;
+  string rule_id = 4;
+  string fingerprint = 5;
+  string status = 6;
+  Finding finding = 7;
+  repeated FindingEvidence evidence = 8;
+  string last_run_id = 9;
+  uint32 observation_count = 10;
+  google.protobuf.Timestamp first_observed_at = 11;
+  google.protobuf.Timestamp last_observed_at = 12;
+  string promoted_finding_id = 13;
+  string decision_id = 14;
+  string promoted_by = 15;
+  string promotion_rationale = 16;
+  string change_ticket = 17;
+  google.protobuf.Timestamp promoted_at = 18;
+  google.protobuf.Timestamp created_at = 19;
+  google.protobuf.Timestamp updated_at = 20;
+}
+
+// ListFindingCandidatesRequest queries isolated candidate finding snapshots for one runtime.
+message ListFindingCandidatesRequest {
+  string runtime_id = 1;
+  string candidate_id = 2;
+  string rule_id = 3;
+  string status = 4;
+  string fingerprint = 5;
+  uint32 limit = 6;
+}
+
+// ListFindingCandidatesResponse returns the matched candidate finding snapshots.
+message ListFindingCandidatesResponse {
+  repeated FindingCandidate candidates = 1;
+}
+
+// GetFindingCandidateRequest loads one isolated candidate finding by durable identifier.
+message GetFindingCandidateRequest {
+  string id = 1;
+}
+
+// GetFindingCandidateResponse returns one candidate finding snapshot.
+message GetFindingCandidateResponse {
+  FindingCandidate candidate = 1;
+}
+
+// EvaluateSourceRuntimeFindingCandidatesRequest replays one runtime through candidate rules without writing production findings.
+message EvaluateSourceRuntimeFindingCandidatesRequest {
+  string id = 1;
+  repeated string rule_ids = 2;
+  uint32 event_limit = 3;
+}
+
+// FindingCandidateRuleEvaluation returns one rule's isolated candidate outputs.
+message FindingCandidateRuleEvaluation {
+  RuleSpec rule = 1;
+  FindingCandidateRun run = 2;
+  repeated FindingCandidate candidates = 3;
+}
+
+// EvaluateSourceRuntimeFindingCandidatesResponse returns non-production candidate outputs for one runtime replay.
+message EvaluateSourceRuntimeFindingCandidatesResponse {
+  SourceRuntime runtime = 1;
+  uint32 events_evaluated = 2;
+  repeated FindingCandidateRuleEvaluation evaluations = 3;
+}
+
+// PromoteFindingCandidateRequest promotes one reviewed candidate into production findings.
+message PromoteFindingCandidateRequest {
+  string id = 1;
+  string promoted_by = 2;
+  string rationale = 3;
+  string change_ticket = 4;
+  bool false_positive_reviewed = 5;
+  bool graph_coverage_reviewed = 6;
+}
+
+// PromoteFindingCandidateResponse returns the production finding and updated candidate.
+message PromoteFindingCandidateResponse {
+  Finding finding = 1;
+  FindingCandidate candidate = 2;
+  string decision_id = 3;
 }
 
 // EvaluateSourceRuntimeFindingsRequest replays one stored runtime through one registered finding rule.


### PR DESCRIPTION
## Summary
- Add isolated candidate-finding runs and snapshots so rules can run on real data without creating production alerts.
- Add candidate evaluate/list/get/promote APIs and wire promotion into production finding/evidence writes with audit metadata.
- Formalize rule maturity values and cover candidate evaluation, promotion, storage, and API behavior with focused tests.

## Test plan
- go test ./...
- make proto-lint
- make detection-catalog-check
- make lint
- git diff --check


Made with [Cursor](https://cursor.com)