### PR TITLE
Add schema-aware Ask query conversion

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -544,7 +544,7 @@ paths:
               $ref: '#/components/schemas/GRCAskRequest'
       responses:
         '200':
-          description: Server-sent graph answer events. Successful streams emit progress, rationale, cypher, rows, summary, and done events; failures after streaming starts emit an error event.
+          description: Server-sent graph answer events. Successful streams emit progress, rationale, query_plan, cypher, rows, summary, and done events; failures after streaming starts emit an error event.
           content:
             text/event-stream:
               schema:

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -55,7 +55,7 @@ LIMIT 25`,
 		t.Fatalf("content-type = %q, want text/event-stream", got)
 	}
 	events := readSSEEvents(t, resp)
-	want := []string{"progress", "rationale", "progress", "cypher", "progress", "rows", "progress", "summary", "done"}
+	want := []string{"progress", "rationale", "query_plan", "progress", "cypher", "progress", "rows", "progress", "summary", "done"}
 	if len(events) != len(want) {
 		t.Fatalf("events = %#v, want names %v", events, want)
 	}
@@ -142,9 +142,9 @@ func TestGRCAskExplainFailureReturnsServiceUnavailable(t *testing.T) {
 		t.Fatalf("status = %d, want %d with streamed error event", resp.StatusCode, http.StatusOK)
 	}
 	events := readSSEEvents(t, resp)
-	assertSSEEventNames(t, events, []string{"progress", "rationale", "progress", "error"})
-	if !strings.Contains(string(events[3].Data), "explain cypher") {
-		t.Fatalf("error event = %s, want explain failure", events[3].Data)
+	assertSSEEventNames(t, events, []string{"progress", "rationale", "query_plan", "progress", "error"})
+	if !strings.Contains(string(events[4].Data), "explain cypher") {
+		t.Fatalf("error event = %s, want explain failure", events[4].Data)
 	}
 }
 

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -92,7 +92,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		return err
 	}
 	if cypher == "" {
-		reason := firstNonEmpty(draft.Refusal, "LLM refused to draft Cypher")
+		reason := firstNonEmpty(draft.Refusal, conversion.Refusal, "LLM refused to draft Cypher")
 		return emitRefusal(emit, traceID, started, cypher, reason)
 	}
 	if err := emitProgress(emit, started, "validating_query", "Validating generated Cypher against read-only guardrails."); err != nil {

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -122,6 +123,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		return fmt.Errorf("%w: execute cypher: %w", ErrRuntimeUnavailable, err)
 	}
 	rowMaps := cypherRowsToMaps(rows)
+	sanitizeInternalRowFields(rowMaps)
 	rowsEvent := RowsEvent{
 		Rows:   rowMaps,
 		Graph:  scopedNeighborhood(ctx, s.store, request.ScopeURN),
@@ -233,6 +235,48 @@ func cypherRowsToMaps(rows []ports.CypherRow) []map[string]any {
 		result = append(result, values)
 	}
 	return result
+}
+
+func sanitizeInternalRowFields(rows []map[string]any) {
+	for _, row := range rows {
+		mergeFindingAttributes(row, "finding_attributes_json_internal")
+	}
+}
+
+func mergeFindingAttributes(row map[string]any, key string) {
+	raw, ok := row[key].(string)
+	delete(row, key)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return
+	}
+	var attrs map[string]any
+	if err := json.Unmarshal([]byte(raw), &attrs); err != nil {
+		return
+	}
+	for _, field := range []string{"summary", "status", "severity", "effective_severity", "risk_score"} {
+		if !rowValueEmpty(row[field]) {
+			continue
+		}
+		value, ok := attrs[field]
+		if !ok {
+			continue
+		}
+		if text := strings.TrimSpace(fmt.Sprint(value)); text != "" {
+			row[field] = text
+		}
+	}
+}
+
+func rowValueEmpty(value any) bool {
+	if value == nil {
+		return true
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed) == ""
+	default:
+		return false
+	}
 }
 
 func scopedNeighborhood(ctx context.Context, store ports.GraphQueryStore, scopeURN string) *ports.EntityNeighborhood {

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -85,7 +85,11 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		return err
 	}
 
-	cypher := strings.TrimSpace(draft.Cypher)
+	conversion := convertDraftToQuery(request, draft, defaultMaxRows)
+	cypher := strings.TrimSpace(conversion.Cypher)
+	if err := emitQueryPlan(emit, conversion); err != nil {
+		return err
+	}
 	if cypher == "" {
 		reason := firstNonEmpty(draft.Refusal, "LLM refused to draft Cypher")
 		return emitRefusal(emit, traceID, started, cypher, reason)
@@ -97,6 +101,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	if err != nil {
 		return err
 	}
+	validation.Warnings = append(validation.Warnings, conversionWarnings(conversion.Diagnostics)...)
 	if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: cypher, Validator: validation}}); err != nil {
 		return err
 	}
@@ -178,6 +183,26 @@ func askParams(request AskRequest) map[string]any {
 		"tenant_id": strings.TrimSpace(request.TenantID),
 		"scope_urn": strings.TrimSpace(request.ScopeURN),
 	}
+}
+
+func emitQueryPlan(emit Emitter, conversion conversionResult) error {
+	return emit(Event{Name: EventQueryPlan, Data: QueryPlanEvent{
+		Plan:          conversion.Plan,
+		Diagnostics:   conversion.Diagnostics,
+		Source:        conversion.Source,
+		Deterministic: conversion.Deterministic,
+		Corrected:     conversion.Corrected,
+	}})
+}
+
+func conversionWarnings(diagnostics []ConversionDiagnostic) []string {
+	var warnings []string
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Level == "warn" || diagnostic.Level == "info" {
+			warnings = append(warnings, diagnostic.Code+": "+diagnostic.Message)
+		}
+	}
+	return warnings
 }
 
 func emitRefusal(emit Emitter, traceID string, started time.Time, cypher string, reason string) error {
@@ -292,11 +317,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-const graphAgentSchemaHint = `Graph shape:
-- Entity nodes use label Entity with properties tenant_id, urn, entity_type, label.
-- Relationships use label RELATION with relation and attributes_json properties.
-- Always filter at least one Entity by tenant_id: $tenant_id.
-- Prefer returning URNs and compact scalar columns.`
+var graphAgentSchemaHint = canonicalGraphOntology.PromptHint()
 
 const graphAgentGuardrail = `Rules:
 - Generate read-only Cypher only.

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -3,6 +3,7 @@ package graphagent
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -44,7 +45,7 @@ LIMIT 25`,
 	if err != nil {
 		t.Fatalf("Stream() error = %v", err)
 	}
-	assertEventNames(t, events, []string{EventProgress, EventRationale, EventProgress, EventCypher, EventProgress, EventRows, EventProgress, EventSummary, EventDone})
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventProgress, EventCypher, EventProgress, EventRows, EventProgress, EventSummary, EventDone})
 	progressEvent, ok := events[0].Data.(ProgressEvent)
 	if !ok {
 		t.Fatalf("progress event data = %T", events[0].Data)
@@ -52,9 +53,9 @@ LIMIT 25`,
 	if progressEvent.Stage != "drafting_query" {
 		t.Fatalf("first progress stage = %q, want drafting_query", progressEvent.Stage)
 	}
-	rowsEvent, ok := events[5].Data.(RowsEvent)
+	rowsEvent, ok := events[6].Data.(RowsEvent)
 	if !ok {
-		t.Fatalf("rows event data = %T", events[5].Data)
+		t.Fatalf("rows event data = %T", events[6].Data)
 	}
 	if len(rowsEvent.Rows) != 1 || rowsEvent.Rows[0]["entity_urn"] != "urn:cerebro:example:asset:alpha" {
 		t.Fatalf("rows = %#v", rowsEvent.Rows)
@@ -62,9 +63,9 @@ LIMIT 25`,
 	if rowsEvent.Graph == nil || rowsEvent.Graph.Root == nil {
 		t.Fatalf("graph neighborhood missing")
 	}
-	summaryEvent, ok := events[7].Data.(SummaryEvent)
+	summaryEvent, ok := events[8].Data.(SummaryEvent)
 	if !ok {
-		t.Fatalf("summary event data = %T", events[7].Data)
+		t.Fatalf("summary event data = %T", events[8].Data)
 	}
 	if len(summaryEvent.Citations) != 1 || summaryEvent.Citations[0].URN != "urn:cerebro:example:asset:alpha" {
 		t.Fatalf("citations = %#v", summaryEvent.Citations)
@@ -90,17 +91,71 @@ func TestServiceRefusesValidatorRejectedCypher(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stream() error = %v", err)
 	}
-	assertEventNames(t, events, []string{EventProgress, EventRationale, EventProgress, EventCypher, EventSummary, EventDone})
-	cypherEvent := events[3].Data.(CypherEvent)
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventProgress, EventCypher, EventSummary, EventDone})
+	cypherEvent := events[4].Data.(CypherEvent)
 	if cypherEvent.Validator.OK {
 		t.Fatalf("validator ok = true, want false")
 	}
-	done := events[5].Data.(DoneEvent)
+	done := events[6].Data.(DoneEvent)
 	if !done.CypherRefused {
 		t.Fatalf("done.CypherRefused = false, want true")
 	}
 	if len(store.requests) != 0 {
 		t.Fatalf("store executed rejected query: %#v", store.requests)
+	}
+}
+
+func TestServiceConvertsFindingSourceAggregationDraft(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"source_family": "okta",
+				"finding_count": int64(3),
+			},
+		}},
+	}
+	llm := &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Rationale: "Counting findings by source family.",
+			Cypher: `MATCH (f:Entity {tenant_id: $tenant_id})
+WHERE f.entity_type = 'Finding'
+OPTIONAL MATCH (f)-[r:RELATION]->(src:Entity {tenant_id: $tenant_id})
+WHERE r.relation = 'HAS_SOURCE' OR r.relation = 'BELONGS_TO_SOURCE'
+WITH f, src,
+     coalesce(src.label,
+              apoc.convert.fromJsonMap(f.attributes_json).source_family,
+              apoc.convert.fromJsonMap(f.attributes_json).sourceFamily,
+              'Unknown') AS source_family
+RETURN source_family, count(f) AS finding_count
+ORDER BY finding_count DESC
+LIMIT 10`,
+		},
+		Summary: "okta has the most findings.",
+	}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{TenantID: "writer", Question: "top finding sources"}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventProgress, EventCypher, EventProgress, EventRows, EventProgress, EventSummary, EventDone})
+	planEvent := events[2].Data.(QueryPlanEvent)
+	if planEvent.Plan.Intent != IntentAggregateFindingsBySource || !planEvent.Deterministic || !planEvent.Corrected {
+		t.Fatalf("query plan event = %#v, want deterministic corrected source aggregation", planEvent)
+	}
+	cypher := events[4].Data.(CypherEvent)
+	if !cypher.Validator.OK {
+		t.Fatalf("validator = %#v, want ok", cypher.Validator)
+	}
+	if strings.Contains(cypher.Cypher, "apoc.") || strings.Contains(cypher.Cypher, "HAS_SOURCE") || strings.Contains(cypher.Cypher, "entity_type = 'Finding'") {
+		t.Fatalf("cypher was not canonicalized:\n%s", cypher.Cypher)
+	}
+	if len(store.requests) != 1 || !strings.Contains(store.requests[0].Query, "entity_type: 'finding'") || !strings.Contains(store.requests[0].Query, "count(DISTINCT f)") {
+		t.Fatalf("store request = %#v", store.requests)
 	}
 }
 

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -105,6 +105,39 @@ func TestServiceRefusesValidatorRejectedCypher(t *testing.T) {
 	}
 }
 
+func TestServiceRefusesUnsupportedPlanOnlyDraftAsConversionFailure(t *testing.T) {
+	store := &askStore{}
+	llm := &StubLLMClient{DraftResponse: &DraftResponse{
+		Rationale: "Planning filtered high-risk findings.",
+		Plan:      &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"severity": "HIGH"}},
+	}}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{TenantID: "example", Question: "show HIGH risk findings"}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventCypher, EventSummary, EventDone})
+	planEvent := events[2].Data.(QueryPlanEvent)
+	if planEvent.Source != "conversion_refusal" || len(planEvent.Diagnostics) == 0 || planEvent.Diagnostics[0].Code != "query_plan_conversion_failed" {
+		t.Fatalf("query plan event = %#v, want conversion refusal diagnostic", planEvent)
+	}
+	cypherEvent := events[3].Data.(CypherEvent)
+	if cypherEvent.Validator.OK || strings.Contains(cypherEvent.Validator.Reason, "LLM refused") {
+		t.Fatalf("cypher validator = %#v, want backend conversion refusal", cypherEvent.Validator)
+	}
+	if !strings.Contains(cypherEvent.Validator.Reason, "could not be converted") {
+		t.Fatalf("refusal reason = %q, want conversion failure", cypherEvent.Validator.Reason)
+	}
+	if len(store.requests) != 0 {
+		t.Fatalf("store executed conversion-refused query: %#v", store.requests)
+	}
+}
+
 func TestServiceConvertsFindingSourceAggregationDraft(t *testing.T) {
 	store := &askStore{
 		rows: []ports.CypherRow{{

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -159,6 +159,53 @@ LIMIT 10`,
 	}
 }
 
+func TestServiceSanitizesInternalFindingAttributes(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"finding_urn":                      "urn:cerebro:writer:finding:quoted-summary",
+				"finding_label":                    "Quoted finding",
+				"summary":                          "",
+				"status":                           "",
+				"severity":                         "",
+				"finding_attributes_json_internal": `{"summary":"Okta policy rule \"Admins\" is INACTIVE","status":"open","severity":"HIGH","risk_score":"47"}`,
+			},
+		}},
+	}
+	llm := &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Rationale: "Explaining the scoped finding.",
+			Plan:      &AskQueryPlan{Intent: IntentExplainFinding, Limit: 25},
+		},
+		Summary: "Quoted finding should be reviewed.",
+	}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "Explain this finding",
+		ScopeURN: "urn:cerebro:writer:finding:quoted-summary",
+	}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	rowsEvent := events[6].Data.(RowsEvent)
+	row := rowsEvent.Rows[0]
+	if _, exists := row["finding_attributes_json_internal"]; exists {
+		t.Fatalf("internal attributes leaked in row: %#v", row)
+	}
+	if got := row["summary"]; got != `Okta policy rule "Admins" is INACTIVE` {
+		t.Fatalf("summary = %q, want full quoted summary", got)
+	}
+	if got := row["severity"]; got != "HIGH" {
+		t.Fatalf("severity = %q, want HIGH", got)
+	}
+}
+
 func TestServiceRequiresTenantID(t *testing.T) {
 	service := NewService(&askStore{}, NewStubLLMClient(), ValidatorOptions{})
 	err := service.Stream(context.Background(), AskRequest{Question: "hello"}, func(Event) error { return nil })

--- a/internal/graphagent/events.go
+++ b/internal/graphagent/events.go
@@ -11,6 +11,7 @@ import (
 const (
 	EventProgress  = "progress"
 	EventRationale = "rationale"
+	EventQueryPlan = "query_plan"
 	EventCypher    = "cypher"
 	EventRows      = "rows"
 	EventSummary   = "summary"
@@ -24,8 +25,10 @@ type Event struct {
 }
 
 type ValidatorResult struct {
-	OK     bool   `json:"ok"`
-	Reason string `json:"reason,omitempty"`
+	OK       bool     `json:"ok"`
+	Code     string   `json:"code,omitempty"`
+	Reason   string   `json:"reason,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 type ProgressEvent struct {
@@ -36,6 +39,14 @@ type ProgressEvent struct {
 
 type RationaleEvent struct {
 	Text string `json:"text"`
+}
+
+type QueryPlanEvent struct {
+	Plan          AskQueryPlan           `json:"plan"`
+	Diagnostics   []ConversionDiagnostic `json:"diagnostics,omitempty"`
+	Source        string                 `json:"source"`
+	Deterministic bool                   `json:"deterministic"`
+	Corrected     bool                   `json:"corrected"`
 }
 
 type CypherEvent struct {

--- a/internal/graphagent/llm.go
+++ b/internal/graphagent/llm.go
@@ -25,9 +25,10 @@ type DraftRequest struct {
 }
 
 type DraftResponse struct {
-	Rationale string `json:"rationale"`
-	Cypher    string `json:"cypher,omitempty"`
-	Refusal   string `json:"refusal,omitempty"`
+	Rationale string        `json:"rationale"`
+	Plan      *AskQueryPlan `json:"plan,omitempty"`
+	Cypher    string        `json:"cypher,omitempty"`
+	Refusal   string        `json:"refusal,omitempty"`
 }
 
 type SummarizeRequest struct {

--- a/internal/graphagent/llm_bedrock.go
+++ b/internal/graphagent/llm_bedrock.go
@@ -166,6 +166,7 @@ Conversation history:
 
 Return ONLY compact JSON:
 {"rationale":"short explanation","plan":{"intent":"top_risk_findings","confidence":0.8,"limit":25,"filters":{}},"cypher":"MATCH ... LIMIT 25","refusal":""}
+All plan.filters values must be JSON strings, even for numbers or booleans (for example {"risk_score":"50"}).
 
 If the question asks for mutation, deletion, credential disclosure, or anything unsafe, return:
 {"rationale":"why refused","plan":{"intent":"raw_cypher","confidence":0},"cypher":null,"refusal":"safe refusal message"}

--- a/internal/graphagent/llm_bedrock.go
+++ b/internal/graphagent/llm_bedrock.go
@@ -60,14 +60,15 @@ func (c *BedrockLLMClient) DraftCypher(ctx context.Context, req DraftRequest) (*
 		return nil, err
 	}
 	var payload struct {
-		Rationale string  `json:"rationale"`
-		Cypher    *string `json:"cypher"`
-		Refusal   string  `json:"refusal"`
+		Rationale string        `json:"rationale"`
+		Plan      *AskQueryPlan `json:"plan"`
+		Cypher    *string       `json:"cypher"`
+		Refusal   string        `json:"refusal"`
 	}
 	if err := json.Unmarshal(extractJSONObject(text), &payload); err != nil {
 		return nil, fmt.Errorf("parse draft response JSON: %w", err)
 	}
-	response := &DraftResponse{Rationale: strings.TrimSpace(payload.Rationale), Refusal: strings.TrimSpace(payload.Refusal)}
+	response := &DraftResponse{Rationale: strings.TrimSpace(payload.Rationale), Plan: payload.Plan, Refusal: strings.TrimSpace(payload.Refusal)}
 	if payload.Cypher != nil {
 		response.Cypher = strings.TrimSpace(*payload.Cypher)
 	}
@@ -164,10 +165,13 @@ Conversation history:
 %s
 
 Return ONLY compact JSON:
-{"rationale":"short explanation","cypher":"MATCH ... LIMIT 25","refusal":""}
+{"rationale":"short explanation","plan":{"intent":"top_risk_findings","confidence":0.8,"limit":25,"filters":{}},"cypher":"MATCH ... LIMIT 25","refusal":""}
 
 If the question asks for mutation, deletion, credential disclosure, or anything unsafe, return:
-{"rationale":"why refused","cypher":null,"refusal":"safe refusal message"}`, req.Question, normalizeModel(req.Model), req.Schema, req.Guardrail, history.String())
+{"rationale":"why refused","plan":{"intent":"raw_cypher","confidence":0},"cypher":null,"refusal":"safe refusal message"}
+
+Preferred plan intents: aggregate_findings_by_source, top_risk_findings, explain_finding, identity_bridge, connector_health, raw_cypher.
+Use a deterministic intent whenever the question matches one; the backend will convert that plan into canonical Cypher.`, req.Question, normalizeModel(req.Model), req.Schema, req.Guardrail, history.String())
 }
 
 func summarizePrompt(req SummarizeRequest) string {

--- a/internal/graphagent/llm_openrouter.go
+++ b/internal/graphagent/llm_openrouter.go
@@ -71,14 +71,15 @@ func (c *OpenRouterLLMClient) DraftCypher(ctx context.Context, req DraftRequest)
 		return nil, err
 	}
 	var payload struct {
-		Rationale string  `json:"rationale"`
-		Cypher    *string `json:"cypher"`
-		Refusal   string  `json:"refusal"`
+		Rationale string        `json:"rationale"`
+		Plan      *AskQueryPlan `json:"plan"`
+		Cypher    *string       `json:"cypher"`
+		Refusal   string        `json:"refusal"`
 	}
 	if err := json.Unmarshal(extractJSONObject(text), &payload); err != nil {
 		return nil, fmt.Errorf("parse draft response JSON: %w", err)
 	}
-	response := &DraftResponse{Rationale: strings.TrimSpace(payload.Rationale), Refusal: strings.TrimSpace(payload.Refusal)}
+	response := &DraftResponse{Rationale: strings.TrimSpace(payload.Rationale), Plan: payload.Plan, Refusal: strings.TrimSpace(payload.Refusal)}
 	if payload.Cypher != nil {
 		response.Cypher = strings.TrimSpace(*payload.Cypher)
 	}

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -47,6 +47,13 @@ var canonicalGraphOntology = GraphOntology{
 			Examples:    []string{"urn:cerebro:writer:github_repo:writer/cerebro"},
 		},
 		{
+			Type:        "github.repo",
+			Description: "Legacy GitHub repository anchors still emitted by source projection; include alongside github.code.repository for broad repository questions.",
+			Aliases:     []string{"legacy github repo", "github repository anchor"},
+			Properties:  []string{"source_id", "runtime_id", "label", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:github_repo:writer/cerebro"},
+		},
+		{
 			Type:        "identity.email",
 			Description: "Canonical email identity anchors linked from concrete principals through represents_identity.",
 			Aliases:     []string{"email identity", "canonical email", "identity email", "principal email"},
@@ -108,6 +115,7 @@ func (o GraphOntology) PromptHint() string {
 	fmt.Fprintf(&b, "- Entity types are stored in lowercase `entity_type`; never use labels like `:Finding`, `:repo`, or `:identity`.\n")
 	fmt.Fprintf(&b, "- Relationships use label `RELATION` and lowercase `relation` property; never use relationship types like `:HAS_SOURCE`.\n")
 	fmt.Fprintf(&b, "- Active finding shape: `(resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})`.\n")
+	fmt.Fprintf(&b, "- Repository questions should consider both `entity_type: 'github.code.repository'` and legacy `entity_type: 'github.repo'` unless the question clearly asks for only one shape.\n")
 	fmt.Fprintf(&b, "- Canonical identity anchors use `entity_type` values `identity.email` and `identity.login`; there is no generic `identity` entity_type or top-level `email` property. Match identity values through `urn`, `label`, or controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Connector/source health nodes use `entity_type: 'source'`; there is no `connector` entity_type and no top-level `status` or `last_sync_minutes` property. Read source health metadata from controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Finding source grouping should prefer controlled `attributes_json.source_family` string extraction, then fall back to `finding.source_id`.\n")

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -2,7 +2,6 @@ package graphagent
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 )
 
@@ -140,13 +139,4 @@ func canonicalRelation(value string) (string, bool) {
 		}
 	}
 	return normalized, false
-}
-
-func knownEntityTypes() []string {
-	values := make([]string, 0, len(canonicalGraphOntology.Entities))
-	for _, entity := range canonicalGraphOntology.Entities {
-		values = append(values, entity.Type)
-	}
-	sort.Strings(values)
-	return values
 }

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -47,11 +47,18 @@ var canonicalGraphOntology = GraphOntology{
 			Examples:    []string{"urn:cerebro:writer:github_repo:writer/cerebro"},
 		},
 		{
-			Type:        "identity",
-			Description: "Canonical identity/resource nodes linked through identifier relationships.",
-			Aliases:     []string{"user", "identity", "principal", "account"},
-			Properties:  []string{"email", "source_id", "runtime_id"},
-			Examples:    []string{"urn:cerebro:writer:identity:alice@writer.com"},
+			Type:        "identity.email",
+			Description: "Canonical email identity anchors linked from concrete principals through represents_identity.",
+			Aliases:     []string{"email identity", "canonical email", "identity email", "principal email"},
+			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:identity:email:alice@writer.com"},
+		},
+		{
+			Type:        "identity.login",
+			Description: "Canonical login identity anchors linked from concrete principals through represents_identity.",
+			Aliases:     []string{"login identity", "canonical login", "identity login", "username identity"},
+			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:identity:login:alice"},
 		},
 		{
 			Type:        "connector",
@@ -85,10 +92,10 @@ var canonicalGraphOntology = GraphOntology{
 		},
 		{
 			Relation:    "represents_identity",
-			Description: "Edge between concrete identities and canonical identity nodes.",
+			Description: "Edge between concrete principals, identifier anchors, and canonical identity.email/identity.login nodes.",
 			Aliases:     []string{"REPRESENTS_IDENTITY", "represents"},
 			FromTypes:   []string{"*"},
-			ToTypes:     []string{"identity"},
+			ToTypes:     []string{"identity.email", "identity.login"},
 		},
 	},
 }
@@ -101,7 +108,8 @@ func (o GraphOntology) PromptHint() string {
 	fmt.Fprintf(&b, "- Entity types are stored in lowercase `entity_type`; never use labels like `:Finding`, `:repo`, or `:identity`.\n")
 	fmt.Fprintf(&b, "- Relationships use label `RELATION` and lowercase `relation` property; never use relationship types like `:HAS_SOURCE`.\n")
 	fmt.Fprintf(&b, "- Active finding shape: `(resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})`.\n")
-	fmt.Fprintf(&b, "- Finding source grouping should prefer `finding.source_id`; only use controlled `attributes_json` string extraction as fallback.\n")
+	fmt.Fprintf(&b, "- Canonical identity anchors use `entity_type` values `identity.email` and `identity.login`; there is no generic `identity` entity_type or top-level `email` property. Match identity values through `urn`, `label`, or controlled `attributes_json` extraction.\n")
+	fmt.Fprintf(&b, "- Finding source grouping should prefer controlled `attributes_json.source_family` string extraction, then fall back to `finding.source_id`.\n")
 	for _, entity := range o.Entities {
 		fmt.Fprintf(&b, "- Entity `%s`: %s Aliases: %s. Useful properties: %s.\n", entity.Type, entity.Description, strings.Join(entity.Aliases, ", "), strings.Join(entity.Properties, ", "))
 	}

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -36,7 +36,7 @@ var canonicalGraphOntology = GraphOntology{
 			Type:        "finding",
 			Description: "Workflow finding anchors. Active findings are linked from affected resources via relation 'has_finding'.",
 			Aliases:     []string{"Finding", "FINDING", "finding", "alert", "issue"},
-			Properties:  []string{"finding_id", "severity", "status", "risk_score", "source_id", "runtime_id", "primary_resource_urn"},
+			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
 			Examples:    []string{"urn:cerebro:writer:finding:finding-1"},
 		},
 		{
@@ -115,6 +115,7 @@ func (o GraphOntology) PromptHint() string {
 	fmt.Fprintf(&b, "- Entity types are stored in lowercase `entity_type`; never use labels like `:Finding`, `:repo`, or `:identity`.\n")
 	fmt.Fprintf(&b, "- Relationships use label `RELATION` and lowercase `relation` property; never use relationship types like `:HAS_SOURCE`.\n")
 	fmt.Fprintf(&b, "- Active finding shape: `(resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})`.\n")
+	fmt.Fprintf(&b, "- Finding metadata such as `severity`, `effective_severity`, `status`, `risk_score`, `summary`, and `primary_resource_urn` is stored in `attributes_json`, not as top-level finding properties.\n")
 	fmt.Fprintf(&b, "- Repository questions should consider both `entity_type: 'github.code.repository'` and legacy `entity_type: 'github.repo'` unless the question clearly asks for only one shape.\n")
 	fmt.Fprintf(&b, "- Canonical identity anchors use `entity_type` values `identity.email` and `identity.login`; there is no generic `identity` entity_type or top-level `email` property. Match identity values through `urn`, `label`, or controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Connector/source health nodes use `entity_type: 'source'`; there is no `connector` entity_type and no top-level `status` or `last_sync_minutes` property. Read source health metadata from controlled `attributes_json` extraction.\n")

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -61,11 +61,11 @@ var canonicalGraphOntology = GraphOntology{
 			Examples:    []string{"urn:cerebro:writer:identity:login:alice"},
 		},
 		{
-			Type:        "connector",
-			Description: "Source/runtime connector-like graph nodes. Exact source runtimes may also appear as source-specific entity types.",
+			Type:        "source",
+			Description: "Projected source/integration nodes used for connector health. Freshness and health metadata are stored in attributes_json.",
 			Aliases:     []string{"source", "source runtime", "runtime", "connector"},
-			Properties:  []string{"source_id", "runtime_id", "status", "last_sync_minutes"},
-			Examples:    []string{"urn:cerebro:writer:connector:github"},
+			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:source:github"},
 		},
 	},
 	Relations: []OntologyRelation{
@@ -109,6 +109,7 @@ func (o GraphOntology) PromptHint() string {
 	fmt.Fprintf(&b, "- Relationships use label `RELATION` and lowercase `relation` property; never use relationship types like `:HAS_SOURCE`.\n")
 	fmt.Fprintf(&b, "- Active finding shape: `(resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})`.\n")
 	fmt.Fprintf(&b, "- Canonical identity anchors use `entity_type` values `identity.email` and `identity.login`; there is no generic `identity` entity_type or top-level `email` property. Match identity values through `urn`, `label`, or controlled `attributes_json` extraction.\n")
+	fmt.Fprintf(&b, "- Connector/source health nodes use `entity_type: 'source'`; there is no `connector` entity_type and no top-level `status` or `last_sync_minutes` property. Read source health metadata from controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Finding source grouping should prefer controlled `attributes_json.source_family` string extraction, then fall back to `finding.source_id`.\n")
 	for _, entity := range o.Entities {
 		fmt.Fprintf(&b, "- Entity `%s`: %s Aliases: %s. Useful properties: %s.\n", entity.Type, entity.Description, strings.Join(entity.Aliases, ", "), strings.Join(entity.Properties, ", "))

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -1,0 +1,152 @@
+package graphagent
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type OntologyEntity struct {
+	Type        string
+	Description string
+	Aliases     []string
+	Properties  []string
+	Examples    []string
+}
+
+type OntologyRelation struct {
+	Relation    string
+	Description string
+	Aliases     []string
+	FromTypes   []string
+	ToTypes     []string
+}
+
+type GraphOntology struct {
+	Label      string
+	Entities   []OntologyEntity
+	Relations  []OntologyRelation
+	Properties []string
+}
+
+var canonicalGraphOntology = GraphOntology{
+	Label:      "Entity",
+	Properties: []string{"tenant_id", "urn", "source_id", "runtime_id", "entity_type", "label", "attributes_json"},
+	Entities: []OntologyEntity{
+		{
+			Type:        "finding",
+			Description: "Workflow finding anchors. Active findings are linked from affected resources via relation 'has_finding'.",
+			Aliases:     []string{"Finding", "FINDING", "finding", "alert", "issue"},
+			Properties:  []string{"finding_id", "severity", "status", "risk_score", "source_id", "runtime_id", "primary_resource_urn"},
+			Examples:    []string{"urn:cerebro:writer:finding:finding-1"},
+		},
+		{
+			Type:        "github.code.repository",
+			Description: "GitHub code repositories and normalized repository resources.",
+			Aliases:     []string{"repo", "repository", "github repo", "code repository"},
+			Properties:  []string{"owner_login", "source_id", "runtime_id"},
+			Examples:    []string{"urn:cerebro:writer:github_repo:writer/cerebro"},
+		},
+		{
+			Type:        "identity",
+			Description: "Canonical identity/resource nodes linked through identifier relationships.",
+			Aliases:     []string{"user", "identity", "principal", "account"},
+			Properties:  []string{"email", "source_id", "runtime_id"},
+			Examples:    []string{"urn:cerebro:writer:identity:alice@writer.com"},
+		},
+		{
+			Type:        "connector",
+			Description: "Source/runtime connector-like graph nodes. Exact source runtimes may also appear as source-specific entity types.",
+			Aliases:     []string{"source", "source runtime", "runtime", "connector"},
+			Properties:  []string{"source_id", "runtime_id", "status", "last_sync_minutes"},
+			Examples:    []string{"urn:cerebro:writer:connector:github"},
+		},
+	},
+	Relations: []OntologyRelation{
+		{
+			Relation:    "has_finding",
+			Description: "Active edge from an affected resource Entity to a finding Entity.",
+			Aliases:     []string{"HAS_FINDING", "finding", "has finding"},
+			FromTypes:   []string{"*"},
+			ToTypes:     []string{"finding"},
+		},
+		{
+			Relation:    "belongs_to",
+			Description: "Ownership/scope edge, such as repository to org, finding to scan, or runtime child to parent.",
+			Aliases:     []string{"BELONGS_TO", "BELONGS_TO_SOURCE", "belongs to source", "source"},
+			FromTypes:   []string{"*"},
+			ToTypes:     []string{"*"},
+		},
+		{
+			Relation:    "has_identifier",
+			Description: "Edge from a concrete identity/resource node to a normalized identifier node.",
+			Aliases:     []string{"HAS_IDENTIFIER", "identity_email", "email", "identifier"},
+			FromTypes:   []string{"*"},
+			ToTypes:     []string{"identifier"},
+		},
+		{
+			Relation:    "represents_identity",
+			Description: "Edge between concrete identities and canonical identity nodes.",
+			Aliases:     []string{"REPRESENTS_IDENTITY", "represents"},
+			FromTypes:   []string{"*"},
+			ToTypes:     []string{"identity"},
+		},
+	},
+}
+
+func (o GraphOntology) PromptHint() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Canonical Cerebro graph ontology:\n")
+	fmt.Fprintf(&b, "- All graph nodes use label `%s`.\n", o.Label)
+	fmt.Fprintf(&b, "- Node properties: %s.\n", strings.Join(o.Properties, ", "))
+	fmt.Fprintf(&b, "- Entity types are stored in lowercase `entity_type`; never use labels like `:Finding`, `:repo`, or `:identity`.\n")
+	fmt.Fprintf(&b, "- Relationships use label `RELATION` and lowercase `relation` property; never use relationship types like `:HAS_SOURCE`.\n")
+	fmt.Fprintf(&b, "- Active finding shape: `(resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})`.\n")
+	fmt.Fprintf(&b, "- Finding source grouping should prefer `finding.source_id`; only use controlled `attributes_json` string extraction as fallback.\n")
+	for _, entity := range o.Entities {
+		fmt.Fprintf(&b, "- Entity `%s`: %s Aliases: %s. Useful properties: %s.\n", entity.Type, entity.Description, strings.Join(entity.Aliases, ", "), strings.Join(entity.Properties, ", "))
+	}
+	for _, relation := range o.Relations {
+		fmt.Fprintf(&b, "- Relation `%s`: %s Aliases: %s.\n", relation.Relation, relation.Description, strings.Join(relation.Aliases, ", "))
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func canonicalEntityType(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	for _, entity := range canonicalGraphOntology.Entities {
+		if normalized == strings.ToLower(entity.Type) {
+			return entity.Type
+		}
+		for _, alias := range entity.Aliases {
+			if normalized == strings.ToLower(alias) {
+				return entity.Type
+			}
+		}
+	}
+	return normalized
+}
+
+func canonicalRelation(value string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	for _, relation := range canonicalGraphOntology.Relations {
+		if normalized == strings.ToLower(relation.Relation) {
+			return relation.Relation, true
+		}
+		for _, alias := range relation.Aliases {
+			if normalized == strings.ToLower(alias) {
+				return relation.Relation, true
+			}
+		}
+	}
+	return normalized, false
+}
+
+func knownEntityTypes() []string {
+	values := make([]string, 0, len(canonicalGraphOntology.Entities))
+	for _, entity := range canonicalGraphOntology.Entities {
+		values = append(values, entity.Type)
+	}
+	sort.Strings(values)
+	return values
+}

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -43,8 +43,8 @@ var canonicalGraphOntology = GraphOntology{
 			Type:        "github.code.repository",
 			Description: "GitHub code repositories and normalized repository resources.",
 			Aliases:     []string{"repo", "repository", "github repo", "code repository"},
-			Properties:  []string{"owner_login", "source_id", "runtime_id"},
-			Examples:    []string{"urn:cerebro:writer:github_repo:writer/cerebro"},
+			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:github_code_repository:repo-123"},
 		},
 		{
 			Type:        "github.repo",
@@ -116,12 +116,15 @@ func (o GraphOntology) PromptHint() string {
 	fmt.Fprintf(&b, "- Relationships use label `RELATION` and lowercase `relation` property; never use relationship types like `:HAS_SOURCE`.\n")
 	fmt.Fprintf(&b, "- Active finding shape: `(resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})`.\n")
 	fmt.Fprintf(&b, "- Finding metadata such as `severity`, `effective_severity`, `status`, `risk_score`, `summary`, and `primary_resource_urn` is stored in `attributes_json`, not as top-level finding properties.\n")
-	fmt.Fprintf(&b, "- Repository questions should consider both `entity_type: 'github.code.repository'` and legacy `entity_type: 'github.repo'` unless the question clearly asks for only one shape.\n")
+	fmt.Fprintf(&b, "- Repository questions should consider both `entity_type: 'github.code.repository'` and legacy `entity_type: 'github.repo'` unless the question clearly asks for only one shape. Repository metadata such as `owner_login` is stored in `attributes_json`, not as a top-level property.\n")
 	fmt.Fprintf(&b, "- Canonical identity anchors use `entity_type` values `identity.email` and `identity.login`; there is no generic `identity` entity_type or top-level `email` property. Match identity values through `urn`, `label`, or controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Connector/source health nodes use `entity_type: 'source'`; there is no `connector` entity_type and no top-level `status` or `last_sync_minutes` property. Read source health metadata from controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Finding source grouping should prefer controlled `attributes_json.source_family` string extraction, then fall back to `finding.source_id`.\n")
 	for _, entity := range o.Entities {
 		fmt.Fprintf(&b, "- Entity `%s`: %s Aliases: %s. Useful properties: %s.\n", entity.Type, entity.Description, strings.Join(entity.Aliases, ", "), strings.Join(entity.Properties, ", "))
+		if len(entity.Examples) > 0 {
+			fmt.Fprintf(&b, "  Examples: %s.\n", strings.Join(entity.Examples, ", "))
+		}
 	}
 	for _, relation := range o.Relations {
 		fmt.Fprintf(&b, "- Relation `%s`: %s Aliases: %s.\n", relation.Relation, relation.Description, strings.Join(relation.Aliases, ", "))

--- a/internal/graphagent/ontology.go
+++ b/internal/graphagent/ontology.go
@@ -41,14 +41,14 @@ var canonicalGraphOntology = GraphOntology{
 		},
 		{
 			Type:        "github.code.repository",
-			Description: "GitHub code repositories and normalized repository resources.",
+			Description: "GitHub code repository resources emitted by code-repository events; repository metadata is stored in attributes_json.",
 			Aliases:     []string{"repo", "repository", "github repo", "code repository"},
-			Properties:  []string{"owner_login", "source_id", "runtime_id"},
-			Examples:    []string{"urn:cerebro:writer:github_repo:writer/cerebro"},
+			Properties:  []string{"urn", "label", "source_id", "runtime_id", "attributes_json"},
+			Examples:    []string{"urn:cerebro:writer:github_code_repository:1"},
 		},
 		{
 			Type:        "github.repo",
-			Description: "Legacy GitHub repository anchors still emitted by source projection; include alongside github.code.repository for broad repository questions.",
+			Description: "Legacy GitHub repository anchors used by many repository-scoped audit, pull request, and vulnerability events.",
 			Aliases:     []string{"legacy github repo", "github repository anchor"},
 			Properties:  []string{"source_id", "runtime_id", "label", "attributes_json"},
 			Examples:    []string{"urn:cerebro:writer:github_repo:writer/cerebro"},
@@ -117,6 +117,7 @@ func (o GraphOntology) PromptHint() string {
 	fmt.Fprintf(&b, "- Active finding shape: `(resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})`.\n")
 	fmt.Fprintf(&b, "- Finding metadata such as `severity`, `effective_severity`, `status`, `risk_score`, `summary`, and `primary_resource_urn` is stored in `attributes_json`, not as top-level finding properties.\n")
 	fmt.Fprintf(&b, "- Repository questions should consider both `entity_type: 'github.code.repository'` and legacy `entity_type: 'github.repo'` unless the question clearly asks for only one shape.\n")
+	fmt.Fprintf(&b, "- GitHub repository metadata such as `owner_login`, `repository`, `visibility`, and `default_branch` is stored in `attributes_json`, not as top-level repository properties. Legacy `github.repo` anchors often carry the repository name in `urn`, `label`, and `attributes_json.repository`.\n")
 	fmt.Fprintf(&b, "- Canonical identity anchors use `entity_type` values `identity.email` and `identity.login`; there is no generic `identity` entity_type or top-level `email` property. Match identity values through `urn`, `label`, or controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Connector/source health nodes use `entity_type: 'source'`; there is no `connector` entity_type and no top-level `status` or `last_sync_minutes` property. Read source health metadata from controlled `attributes_json` extraction.\n")
 	fmt.Fprintf(&b, "- Finding source grouping should prefer controlled `attributes_json.source_family` string extraction, then fall back to `finding.source_id`.\n")

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -84,6 +84,7 @@ type conversionResult struct {
 	Cypher        string
 	Diagnostics   []ConversionDiagnostic
 	Source        string
+	Refusal       string
 	Deterministic bool
 	Corrected     bool
 }
@@ -137,6 +138,14 @@ func convertDraftToQuery(request AskRequest, draft *DraftResponse, maxRows int) 
 			result.Corrected = true
 			result.Diagnostics = append(result.Diagnostics, diagnostic)
 		}
+	} else if plan.Intent != IntentRawCypher {
+		result.Source = "conversion_refusal"
+		result.Refusal = fmt.Sprintf("Ask query plan %q could not be converted to Cypher and no fallback Cypher was provided.", plan.Intent)
+		result.Diagnostics = append(result.Diagnostics, ConversionDiagnostic{
+			Level:   "warn",
+			Code:    "query_plan_conversion_failed",
+			Message: result.Refusal,
+		})
 	}
 	result.Diagnostics = append(result.Diagnostics, ontologyDiagnostics(cypher)...)
 	if result.Deterministic {

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -1,0 +1,319 @@
+package graphagent
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	IntentRawCypher                 = "raw_cypher"
+	IntentAggregateFindingsBySource = "aggregate_findings_by_source"
+	IntentTopRiskFindings           = "top_risk_findings"
+	IntentExplainFinding            = "explain_finding"
+	IntentIdentityBridge            = "identity_bridge"
+	IntentConnectorHealth           = "connector_health"
+)
+
+type AskQueryPlan struct {
+	Intent     string            `json:"intent"`
+	Confidence float64           `json:"confidence,omitempty"`
+	ScopeURN   string            `json:"scope_urn,omitempty"`
+	Limit      int               `json:"limit,omitempty"`
+	Filters    map[string]string `json:"filters,omitempty"`
+	GroupBy    string            `json:"group_by,omitempty"`
+}
+
+type ConversionDiagnostic struct {
+	Level   string `json:"level"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type conversionResult struct {
+	Plan          AskQueryPlan
+	Cypher        string
+	Diagnostics   []ConversionDiagnostic
+	Source        string
+	Deterministic bool
+	Corrected     bool
+}
+
+var (
+	upperRelationPattern  = regexp.MustCompile(`:\s*([A-Z][A-Z0-9_]+)\b`)
+	nonEntityLabelPattern = regexp.MustCompile(`\([^){}]*:\s*(Finding|FINDING|finding|repo|repository|identity|connector)\b`)
+	apocUsagePattern      = regexp.MustCompile(`(?i)\bapoc\.`)
+)
+
+func convertDraftToQuery(request AskRequest, draft *DraftResponse, maxRows int) conversionResult {
+	cypher := strings.TrimSpace(draft.Cypher)
+	plan := normalizePlan(draft.Plan, request, cypher, maxRows)
+	result := conversionResult{
+		Plan:      plan,
+		Cypher:    cypher,
+		Source:    "llm",
+		Corrected: false,
+	}
+	if rendered, ok := renderDeterministicPlan(plan, maxRows); ok {
+		result.Cypher = rendered
+		result.Source = "deterministic_template"
+		result.Deterministic = true
+		result.Corrected = strings.TrimSpace(cypher) != "" && normalizeCypherForCompare(cypher) != normalizeCypherForCompare(rendered)
+		if result.Corrected {
+			result.Diagnostics = append(result.Diagnostics, ConversionDiagnostic{
+				Level:   "info",
+				Code:    "canonicalized_to_template",
+				Message: fmt.Sprintf("Converted LLM draft into canonical %s template.", plan.Intent),
+			})
+		}
+	} else if cypher != "" {
+		limited, diagnostic, changed := enforceCypherLimit(cypher, maxRows)
+		if changed {
+			result.Cypher = limited
+			result.Corrected = true
+			result.Diagnostics = append(result.Diagnostics, diagnostic)
+		}
+	}
+	result.Diagnostics = append(result.Diagnostics, ontologyDiagnostics(cypher)...)
+	if result.Deterministic {
+		result.Diagnostics = append(result.Diagnostics, ConversionDiagnostic{
+			Level:   "info",
+			Code:    "deterministic_query_plan",
+			Message: "Graph access used a deterministic Cerebro query template; LLM variance is limited to intent extraction and summary text.",
+		})
+	}
+	return result
+}
+
+func normalizePlan(plan *AskQueryPlan, request AskRequest, cypher string, maxRows int) AskQueryPlan {
+	var out AskQueryPlan
+	if plan != nil {
+		out = *plan
+	}
+	out.Intent = canonicalIntent(out.Intent)
+	if out.Intent == "" || out.Intent == IntentRawCypher {
+		out.Intent = inferIntent(request.Question, cypher)
+	}
+	out.ScopeURN = firstNonEmpty(out.ScopeURN, strings.TrimSpace(request.ScopeURN))
+	out.Limit = boundedLimit(out.Limit, maxRows)
+	if out.Confidence == 0 && out.Intent != IntentRawCypher {
+		out.Confidence = 0.85
+	}
+	if out.Filters == nil {
+		out.Filters = map[string]string{}
+	}
+	for key, value := range out.Filters {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			delete(out.Filters, key)
+			continue
+		}
+		if strings.EqualFold(key, "entity_type") {
+			out.Filters[key] = canonicalEntityType(trimmed)
+			continue
+		}
+		if strings.EqualFold(key, "relation") {
+			if canonical, ok := canonicalRelation(trimmed); ok {
+				out.Filters[key] = canonical
+				continue
+			}
+		}
+		out.Filters[key] = trimmed
+	}
+	return out
+}
+
+func canonicalIntent(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "raw", "cypher", "raw_cypher":
+		return IntentRawCypher
+	case "aggregate_findings_by_source", "finding_source_counts", "findings_by_source", "source_breakdown":
+		return IntentAggregateFindingsBySource
+	case "top_risk_findings", "high_risk_findings", "findings":
+		return IntentTopRiskFindings
+	case "explain_finding", "finding_explanation":
+		return IntentExplainFinding
+	case "identity_bridge", "identity_bridges":
+		return IntentIdentityBridge
+	case "connector_health", "source_health", "runtime_health":
+		return IntentConnectorHealth
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func inferIntent(question string, cypher string) string {
+	haystack := strings.ToLower(question + "\n" + cypher)
+	switch {
+	case strings.Contains(haystack, "source") && strings.Contains(haystack, "finding") && (strings.Contains(haystack, "count") || strings.Contains(haystack, "breakdown") || strings.Contains(haystack, "group") || strings.Contains(haystack, "top")):
+		return IntentAggregateFindingsBySource
+	case strings.Contains(haystack, "has_source") || strings.Contains(haystack, "belongs_to_source") || strings.Contains(haystack, "source_family"):
+		return IntentAggregateFindingsBySource
+	case strings.Contains(haystack, "connector") || strings.Contains(haystack, "runtime health") || strings.Contains(haystack, "source health"):
+		return IntentConnectorHealth
+	case strings.Contains(haystack, "bridge") && (strings.Contains(haystack, "identity") || strings.Contains(haystack, "okta") || strings.Contains(haystack, "github")):
+		return IntentIdentityBridge
+	case strings.Contains(haystack, "explain") && strings.Contains(haystack, "finding"):
+		return IntentExplainFinding
+	case (strings.Contains(haystack, "high risk") || strings.Contains(haystack, "top risk") || strings.Contains(haystack, "critical")) && strings.Contains(haystack, "finding"):
+		return IntentTopRiskFindings
+	default:
+		return IntentRawCypher
+	}
+}
+
+func renderDeterministicPlan(plan AskQueryPlan, maxRows int) (string, bool) {
+	limit := boundedLimit(plan.Limit, maxRows)
+	switch plan.Intent {
+	case IntentAggregateFindingsBySource:
+		if limit > 10 {
+			limit = 10
+		}
+		return fmt.Sprintf(`MATCH (f:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WITH f,
+     coalesce(
+       f.source_id,
+       CASE WHEN coalesce(f.attributes_json, '') CONTAINS '"source_family":"' THEN split(split(f.attributes_json, '"source_family":"')[1], '"')[0] END,
+       CASE WHEN coalesce(f.attributes_json, '') CONTAINS '"sourceFamily":"' THEN split(split(f.attributes_json, '"sourceFamily":"')[1], '"')[0] END,
+       CASE WHEN coalesce(f.attributes_json, '') CONTAINS '"source_system":"' THEN split(split(f.attributes_json, '"source_system":"')[1], '"')[0] END,
+       'Unknown'
+     ) AS source_family
+RETURN source_family, count(DISTINCT f) AS finding_count
+ORDER BY finding_count DESC, source_family
+LIMIT %d`, limit), true
+	case IntentTopRiskFindings:
+		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+RETURN finding.urn AS finding_urn,
+       coalesce(finding.label, finding.urn) AS finding_label,
+       resource.urn AS resource_urn,
+       coalesce(resource.label, resource.urn) AS resource_label,
+       toInteger(coalesce(r.risk_score, finding.risk_score, '0')) AS risk_score,
+       coalesce(r.effective_severity, finding.effective_severity, r.severity, finding.severity, '') AS severity
+ORDER BY risk_score DESC, severity DESC, finding_urn
+LIMIT %d`, limit), true
+	case IntentExplainFinding:
+		return fmt.Sprintf(`MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WHERE ($scope_urn <> '' AND finding.urn = $scope_urn) OR ($scope_urn = '' AND coalesce(finding.status, '') = 'open')
+OPTIONAL MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding)
+RETURN finding.urn AS finding_urn,
+       coalesce(finding.label, finding.urn) AS finding_label,
+       finding.severity AS severity,
+       finding.status AS status,
+       finding.summary AS summary,
+       resource.urn AS resource_urn,
+       coalesce(resource.label, resource.urn) AS resource_label,
+       coalesce(r.risk_score, finding.risk_score, '') AS risk_score
+ORDER BY risk_score DESC, finding_urn
+LIMIT %d`, limit), true
+	case IntentIdentityBridge:
+		return fmt.Sprintf(`MATCH (left:Entity {tenant_id: $tenant_id})-[leftRel:RELATION {relation: 'has_identifier'}]->(identifier:Entity {tenant_id: $tenant_id})<-[rightRel:RELATION {relation: 'has_identifier'}]-(right:Entity {tenant_id: $tenant_id})
+WHERE left.urn < right.urn
+  AND (identifier.entity_type CONTAINS 'identifier' OR identifier.urn CONTAINS ':identifier:')
+RETURN left.urn AS left_urn,
+       coalesce(left.label, left.urn) AS left_label,
+       left.entity_type AS left_type,
+       right.urn AS right_urn,
+       coalesce(right.label, right.urn) AS right_label,
+       right.entity_type AS right_type,
+       identifier.urn AS identifier_urn,
+       coalesce(identifier.label, identifier.urn) AS identifier_label
+ORDER BY identifier_label, left_urn, right_urn
+LIMIT %d`, limit), true
+	case IntentConnectorHealth:
+		return fmt.Sprintf(`MATCH (connector:Entity {tenant_id: $tenant_id})
+WHERE connector.entity_type IN ['connector', 'source_runtime', 'runtime']
+   OR connector.entity_type CONTAINS 'connector'
+   OR connector.entity_type CONTAINS 'runtime'
+RETURN connector.urn AS connector_urn,
+       coalesce(connector.label, connector.urn) AS connector_label,
+       connector.entity_type AS entity_type,
+       connector.source_id AS source_id,
+       connector.runtime_id AS runtime_id,
+       connector.status AS status,
+       connector.last_sync_minutes AS last_sync_minutes
+ORDER BY connector_label, connector_urn
+LIMIT %d`, limit), true
+	default:
+		return "", false
+	}
+}
+
+func ontologyDiagnostics(cypher string) []ConversionDiagnostic {
+	if strings.TrimSpace(cypher) == "" {
+		return nil
+	}
+	var diagnostics []ConversionDiagnostic
+	if nonEntityLabelPattern.MatchString(cypher) {
+		diagnostics = append(diagnostics, ConversionDiagnostic{
+			Level:   "warn",
+			Code:    "non_canonical_entity_label",
+			Message: "Draft used domain labels like :Finding/:repo; Cerebro graph nodes must use :Entity with entity_type filters.",
+		})
+	}
+	for _, match := range upperRelationPattern.FindAllStringSubmatch(cypher, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		if _, ok := canonicalRelation(match[1]); ok {
+			diagnostics = append(diagnostics, ConversionDiagnostic{
+				Level:   "warn",
+				Code:    "relation_alias_canonicalized",
+				Message: fmt.Sprintf("Draft used relationship alias %s; Cerebro stores lowercase relation values on :RELATION.", match[1]),
+			})
+		}
+	}
+	if apocUsagePattern.MatchString(cypher) {
+		diagnostics = append(diagnostics, ConversionDiagnostic{
+			Level:   "warn",
+			Code:    "apoc_not_allowed",
+			Message: "Draft used APOC; Ask Cerebro does not depend on APOC for read-only graph answers.",
+		})
+	}
+	return diagnostics
+}
+
+func enforceCypherLimit(cypher string, maxRows int) (string, ConversionDiagnostic, bool) {
+	limit := boundedLimit(maxRows, maxRows)
+	trimmed := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(cypher), ";"))
+	if trimmed == "" {
+		return cypher, ConversionDiagnostic{}, false
+	}
+	matches := limitPattern.FindAllStringSubmatchIndex(trimmed, -1)
+	if len(matches) == 0 {
+		return trimmed + fmt.Sprintf("\nLIMIT %d", limit), ConversionDiagnostic{
+			Level:   "info",
+			Code:    "limit_injected",
+			Message: fmt.Sprintf("Added LIMIT %d to LLM fallback Cypher.", limit),
+		}, true
+	}
+	valueStart, valueEnd := matches[len(matches)-1][2], matches[len(matches)-1][3]
+	current, ok := queryLimit(trimmed)
+	if !ok || current <= limit {
+		return cypher, ConversionDiagnostic{}, false
+	}
+	return trimmed[:valueStart] + fmt.Sprintf("%d", limit) + trimmed[valueEnd:], ConversionDiagnostic{
+		Level:   "info",
+		Code:    "limit_capped",
+		Message: fmt.Sprintf("Capped LLM fallback Cypher LIMIT from %d to %d.", current, limit),
+	}, true
+}
+
+func boundedLimit(limit int, maxRows int) int {
+	if maxRows <= 0 {
+		maxRows = defaultMaxRows
+	}
+	if limit <= 0 {
+		if maxRows < 25 {
+			return maxRows
+		}
+		return 25
+	}
+	if limit > maxRows {
+		return maxRows
+	}
+	return limit
+}
+
+func normalizeCypherForCompare(value string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(value))), " ")
+}

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -240,10 +240,23 @@ WITH resource, finding, risk_score, severity,
        WHEN 'LOW' THEN 1
        ELSE 0
      END AS severity_rank
+WITH finding,
+     collect(DISTINCT resource.urn) AS resource_urns,
+     collect(DISTINCT coalesce(resource.label, resource.urn)) AS resource_labels,
+     max(risk_score) AS risk_score,
+     max(severity_rank) AS severity_rank
+WITH finding, resource_urns, resource_labels, risk_score, severity_rank,
+     CASE severity_rank
+       WHEN 4 THEN 'CRITICAL'
+       WHEN 3 THEN 'HIGH'
+       WHEN 2 THEN 'MEDIUM'
+       WHEN 1 THEN 'LOW'
+       ELSE ''
+     END AS severity
 RETURN finding.urn AS finding_urn,
        coalesce(finding.label, finding.urn) AS finding_label,
-       resource.urn AS resource_urn,
-       coalesce(resource.label, resource.urn) AS resource_label,
+       resource_urns,
+       resource_labels,
        risk_score,
        severity
 ORDER BY risk_score DESC, severity_rank DESC, finding_urn

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -226,6 +226,8 @@ func canonicalIntent(value string) string {
 func inferIntent(question string, cypher string) string {
 	haystack := strings.ToLower(question + "\n" + cypher)
 	switch {
+	case (strings.Contains(haystack, "high risk") || strings.Contains(haystack, "top risk") || strings.Contains(haystack, "critical")) && strings.Contains(haystack, "finding"):
+		return IntentTopRiskFindings
 	case strings.Contains(haystack, "source") && strings.Contains(haystack, "finding") && (strings.Contains(haystack, "count") || strings.Contains(haystack, "breakdown") || strings.Contains(haystack, "group") || strings.Contains(haystack, "top")):
 		return IntentAggregateFindingsBySource
 	case strings.Contains(haystack, "has_source") || strings.Contains(haystack, "belongs_to_source") || strings.Contains(haystack, "source_family"):
@@ -236,8 +238,6 @@ func inferIntent(question string, cypher string) string {
 		return IntentIdentityBridge
 	case strings.Contains(haystack, "explain") && strings.Contains(haystack, "finding"):
 		return IntentExplainFinding
-	case (strings.Contains(haystack, "high risk") || strings.Contains(haystack, "top risk") || strings.Contains(haystack, "critical")) && strings.Contains(haystack, "finding"):
-		return IntentTopRiskFindings
 	default:
 		return IntentRawCypher
 	}

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -194,6 +194,9 @@ func inferIntent(question string, cypher string) string {
 }
 
 func renderDeterministicPlan(plan AskQueryPlan, maxRows int) (string, bool) {
+	if hasUnsupportedDeterministicModifiers(plan) {
+		return "", false
+	}
 	limit := boundedLimit(plan.Limit, maxRows)
 	switch plan.Intent {
 	case IntentAggregateFindingsBySource:
@@ -269,7 +272,8 @@ RETURN finding.urn AS finding_urn,
        summary,
        resource.urn AS resource_urn,
        coalesce(resource.label, resource.urn) AS resource_label,
-       risk_score
+       risk_score,
+       coalesce(finding.attributes_json, '') AS finding_attributes_json_internal
 ORDER BY risk_score DESC, finding_urn
 LIMIT %d`, limit), true
 	case IntentIdentityBridge:
@@ -298,6 +302,17 @@ LIMIT %d`, limit), true
 	default:
 		return "", false
 	}
+}
+
+func hasUnsupportedDeterministicModifiers(plan AskQueryPlan) bool {
+	if len(plan.Filters) > 0 {
+		return true
+	}
+	groupBy := strings.ToLower(strings.TrimSpace(plan.GroupBy))
+	if groupBy == "" {
+		return false
+	}
+	return plan.Intent != IntentAggregateFindingsBySource || groupBy != "source_family"
 }
 
 func ontologyDiagnostics(cypher string) []ConversionDiagnostic {

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -42,7 +42,7 @@ type conversionResult struct {
 var (
 	upperRelationPattern  = regexp.MustCompile(`:\s*([A-Z][A-Z0-9_]+)\b`)
 	nonEntityLabelPattern = regexp.MustCompile(`\([^){}]*:\s*(Finding|FINDING|finding|repo|repository|identity|connector)\b`)
-	apocUsagePattern      = regexp.MustCompile(`(?i)\bapoc\.`)
+	apocUsagePattern      = regexp.MustCompile(`(?i)\bapoc\.[A-Za-z0-9_.]+\s*\(`)
 )
 
 func convertDraftToQuery(request AskRequest, draft *DraftResponse, maxRows int) conversionResult {
@@ -249,7 +249,8 @@ RETURN finding.urn AS finding_urn,
 ORDER BY risk_score DESC, severity_rank DESC, finding_urn
 LIMIT %d`, limit), true
 	case IntentExplainFinding:
-		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+		return fmt.Sprintf(`MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+OPTIONAL MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding)
 WHERE $scope_urn = '' OR finding.urn = $scope_urn OR resource.urn = $scope_urn
 WITH resource, r, finding,
      coalesce(
@@ -284,6 +285,8 @@ WHERE left.urn < right.urn
   AND left.entity_type <> right.entity_type
   AND NOT left.entity_type STARTS WITH 'identity'
   AND NOT right.entity_type STARTS WITH 'identity'
+  AND NOT left.entity_type STARTS WITH 'identifier'
+  AND NOT right.entity_type STARTS WITH 'identifier'
   AND coalesce(leftRel.attributes_json, '') CONTAINS '"at":"'
   AND coalesce(rightRel.attributes_json, '') CONTAINS '"at":"'
 WITH left, right, identity,
@@ -305,6 +308,7 @@ ORDER BY identity_label, left_urn, right_urn
 LIMIT %d`, limit), true
 	case IntentConnectorHealth:
 		return fmt.Sprintf(`MATCH (source:Entity {tenant_id: $tenant_id, entity_type: 'source'})
+WHERE $scope_urn = '' OR source.urn = $scope_urn
 RETURN source.urn AS source_urn,
        coalesce(source.label, source.urn) AS source_label,
        source.source_id AS source_id,

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -47,6 +47,20 @@ var (
 
 func convertDraftToQuery(request AskRequest, draft *DraftResponse, maxRows int) conversionResult {
 	cypher := strings.TrimSpace(draft.Cypher)
+	if cypher == "" && strings.TrimSpace(draft.Refusal) != "" {
+		plan := normalizePlanWithoutInference(draft.Plan, request, maxRows)
+		return conversionResult{
+			Plan:      plan,
+			Cypher:    "",
+			Source:    "llm_refusal",
+			Corrected: false,
+			Diagnostics: []ConversionDiagnostic{{
+				Level:   "info",
+				Code:    "llm_refusal_preserved",
+				Message: "The LLM explicitly refused to produce Cypher, so deterministic conversion was skipped.",
+			}},
+		}
+	}
 	plan := normalizePlan(draft.Plan, request, cypher, maxRows)
 	result := conversionResult{
 		Plan:      plan,
@@ -123,6 +137,23 @@ func normalizePlan(plan *AskQueryPlan, request AskRequest, cypher string, maxRow
 	return out
 }
 
+func normalizePlanWithoutInference(plan *AskQueryPlan, request AskRequest, maxRows int) AskQueryPlan {
+	out := AskQueryPlan{Intent: IntentRawCypher}
+	if plan != nil {
+		out = *plan
+	}
+	out.Intent = canonicalIntent(out.Intent)
+	if out.Intent == "" {
+		out.Intent = IntentRawCypher
+	}
+	out.ScopeURN = firstNonEmpty(out.ScopeURN, strings.TrimSpace(request.ScopeURN))
+	out.Limit = boundedLimit(out.Limit, maxRows)
+	if out.Filters == nil {
+		out.Filters = map[string]string{}
+	}
+	return out
+}
+
 func canonicalIntent(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "", "raw", "cypher", "raw_cypher":
@@ -172,10 +203,10 @@ func renderDeterministicPlan(plan AskQueryPlan, maxRows int) (string, bool) {
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(f:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WITH DISTINCT f,
      coalesce(
-       f.source_id,
        CASE WHEN coalesce(f.attributes_json, '') CONTAINS '"source_family":"' THEN split(split(f.attributes_json, '"source_family":"')[1], '"')[0] END,
        CASE WHEN coalesce(f.attributes_json, '') CONTAINS '"sourceFamily":"' THEN split(split(f.attributes_json, '"sourceFamily":"')[1], '"')[0] END,
        CASE WHEN coalesce(f.attributes_json, '') CONTAINS '"source_system":"' THEN split(split(f.attributes_json, '"source_system":"')[1], '"')[0] END,
+       f.source_id,
        'Unknown'
      ) AS source_family
 RETURN source_family, count(DISTINCT f) AS finding_count
@@ -230,10 +261,7 @@ WITH resource, r, finding,
        CASE WHEN coalesce(finding.attributes_json, '') CONTAINS '"status":"' THEN split(split(finding.attributes_json, '"status":"')[1], '"')[0] END,
        ''
      ) AS status,
-     coalesce(
-       CASE WHEN coalesce(finding.attributes_json, '') CONTAINS '"summary":"' THEN split(split(finding.attributes_json, '"summary":"')[1], '"')[0] END,
-       ''
-     ) AS summary
+     '' AS summary
 RETURN finding.urn AS finding_urn,
        coalesce(finding.label, finding.urn) AS finding_label,
        severity,

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -169,8 +169,8 @@ func renderDeterministicPlan(plan AskQueryPlan, maxRows int) (string, bool) {
 		if limit > 10 {
 			limit = 10
 		}
-		return fmt.Sprintf(`MATCH (f:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
-WITH f,
+		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(f:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WITH DISTINCT f,
      coalesce(
        f.source_id,
        CASE WHEN coalesce(f.attributes_json, '') CONTAINS '"source_family":"' THEN split(split(f.attributes_json, '"source_family":"')[1], '"')[0] END,
@@ -183,26 +183,60 @@ ORDER BY finding_count DESC, source_family
 LIMIT %d`, limit), true
 	case IntentTopRiskFindings:
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WITH resource, r, finding,
+     coalesce(
+       CASE WHEN coalesce(r.attributes_json, '') CONTAINS '"risk_score":"' THEN toInteger(split(split(r.attributes_json, '"risk_score":"')[1], '"')[0]) END,
+       CASE WHEN coalesce(finding.attributes_json, '') CONTAINS '"risk_score":"' THEN toInteger(split(split(finding.attributes_json, '"risk_score":"')[1], '"')[0]) END,
+       0
+     ) AS risk_score,
+     coalesce(
+       CASE WHEN coalesce(r.attributes_json, '') CONTAINS '"effective_severity":"' THEN split(split(r.attributes_json, '"effective_severity":"')[1], '"')[0] END,
+       CASE WHEN coalesce(finding.attributes_json, '') CONTAINS '"effective_severity":"' THEN split(split(finding.attributes_json, '"effective_severity":"')[1], '"')[0] END,
+       CASE WHEN coalesce(r.attributes_json, '') CONTAINS '"severity":"' THEN split(split(r.attributes_json, '"severity":"')[1], '"')[0] END,
+       CASE WHEN coalesce(finding.attributes_json, '') CONTAINS '"severity":"' THEN split(split(finding.attributes_json, '"severity":"')[1], '"')[0] END,
+       ''
+     ) AS severity
 RETURN finding.urn AS finding_urn,
        coalesce(finding.label, finding.urn) AS finding_label,
        resource.urn AS resource_urn,
        coalesce(resource.label, resource.urn) AS resource_label,
-       toInteger(coalesce(r.risk_score, finding.risk_score, '0')) AS risk_score,
-       coalesce(r.effective_severity, finding.effective_severity, r.severity, finding.severity, '') AS severity
+       risk_score,
+       severity,
+       coalesce(finding.attributes_json, '') AS finding_attributes_json,
+       coalesce(r.attributes_json, '') AS relation_attributes_json
 ORDER BY risk_score DESC, severity DESC, finding_urn
 LIMIT %d`, limit), true
 	case IntentExplainFinding:
-		return fmt.Sprintf(`MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
-WHERE ($scope_urn <> '' AND finding.urn = $scope_urn) OR ($scope_urn = '' AND coalesce(finding.status, '') = 'open')
-OPTIONAL MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding)
+		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WHERE $scope_urn = '' OR finding.urn = $scope_urn OR resource.urn = $scope_urn
+WITH resource, r, finding,
+     coalesce(
+       CASE WHEN coalesce(r.attributes_json, '') CONTAINS '"risk_score":"' THEN toInteger(split(split(r.attributes_json, '"risk_score":"')[1], '"')[0]) END,
+       CASE WHEN coalesce(finding.attributes_json, '') CONTAINS '"risk_score":"' THEN toInteger(split(split(finding.attributes_json, '"risk_score":"')[1], '"')[0]) END,
+       0
+     ) AS risk_score,
+     coalesce(
+       CASE WHEN coalesce(finding.attributes_json, '') CONTAINS '"severity":"' THEN split(split(finding.attributes_json, '"severity":"')[1], '"')[0] END,
+       ''
+     ) AS severity,
+     coalesce(
+       CASE WHEN coalesce(finding.attributes_json, '') CONTAINS '"status":"' THEN split(split(finding.attributes_json, '"status":"')[1], '"')[0] END,
+       ''
+     ) AS status,
+     coalesce(
+       CASE WHEN coalesce(finding.attributes_json, '') CONTAINS '"summary":"' THEN split(split(finding.attributes_json, '"summary":"')[1], '"')[0] END,
+       ''
+     ) AS summary
 RETURN finding.urn AS finding_urn,
        coalesce(finding.label, finding.urn) AS finding_label,
-       finding.severity AS severity,
-       finding.status AS status,
-       finding.summary AS summary,
+       severity,
+       status,
+       summary,
        resource.urn AS resource_urn,
        coalesce(resource.label, resource.urn) AS resource_label,
-       coalesce(r.risk_score, finding.risk_score, '') AS risk_score
+       risk_score,
+       coalesce(finding.attributes_json, '') AS finding_attributes_json,
+       coalesce(r.attributes_json, '') AS relation_attributes_json
 ORDER BY risk_score DESC, finding_urn
 LIMIT %d`, limit), true
 	case IntentIdentityBridge:
@@ -220,18 +254,13 @@ RETURN left.urn AS left_urn,
 ORDER BY identifier_label, left_urn, right_urn
 LIMIT %d`, limit), true
 	case IntentConnectorHealth:
-		return fmt.Sprintf(`MATCH (connector:Entity {tenant_id: $tenant_id})
-WHERE connector.entity_type IN ['connector', 'source_runtime', 'runtime']
-   OR connector.entity_type CONTAINS 'connector'
-   OR connector.entity_type CONTAINS 'runtime'
-RETURN connector.urn AS connector_urn,
-       coalesce(connector.label, connector.urn) AS connector_label,
-       connector.entity_type AS entity_type,
-       connector.source_id AS source_id,
-       connector.runtime_id AS runtime_id,
-       connector.status AS status,
-       connector.last_sync_minutes AS last_sync_minutes
-ORDER BY connector_label, connector_urn
+		return fmt.Sprintf(`MATCH (source:Entity {tenant_id: $tenant_id, entity_type: 'source'})
+RETURN source.urn AS source_urn,
+       coalesce(source.label, source.urn) AS source_label,
+       source.source_id AS source_id,
+       source.runtime_id AS runtime_id,
+       coalesce(source.attributes_json, '') AS source_attributes_json
+ORDER BY source_label, source_urn
 LIMIT %d`, limit), true
 	default:
 		return "", false

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -322,8 +322,12 @@ ORDER BY risk_score DESC, severity_rank DESC, finding_urn
 LIMIT %d`, limit), true
 	case IntentExplainFinding:
 		return fmt.Sprintf(`MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WHERE $scope_urn = ''
+   OR finding.urn = $scope_urn
+   OR EXISTS {
+     MATCH (scopedResource:Entity {tenant_id: $tenant_id, urn: $scope_urn})-[:RELATION {relation: 'has_finding'}]->(finding)
+   }
 OPTIONAL MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding)
-WHERE $scope_urn = '' OR finding.urn = $scope_urn OR resource.urn = $scope_urn
 WITH resource, r, finding,
      coalesce(
        CASE WHEN coalesce(r.attributes_json, '') CONTAINS '"risk_score":"' THEN toInteger(split(split(r.attributes_json, '"risk_score":"')[1], '"')[0]) END,

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -359,6 +359,7 @@ LIMIT %d`, limit), true
 MATCH (right:Entity {tenant_id: $tenant_id})-[rightRel:RELATION {relation: 'represents_identity'}]->(identity)
 WHERE left.urn < right.urn
   AND left.entity_type <> right.entity_type
+  AND ($scope_urn = '' OR left.urn = $scope_urn OR right.urn = $scope_urn OR identity.urn = $scope_urn)
   AND NOT left.entity_type STARTS WITH 'identity'
   AND NOT right.entity_type STARTS WITH 'identity'
   AND NOT left.entity_type STARTS WITH 'identifier'

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -183,6 +183,7 @@ ORDER BY finding_count DESC, source_family
 LIMIT %d`, limit), true
 	case IntentTopRiskFindings:
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WHERE $scope_urn = '' OR resource.urn = $scope_urn OR finding.urn = $scope_urn
 WITH resource, r, finding,
      coalesce(
        CASE WHEN coalesce(r.attributes_json, '') CONTAINS '"risk_score":"' THEN toInteger(split(split(r.attributes_json, '"risk_score":"')[1], '"')[0]) END,
@@ -196,15 +197,21 @@ WITH resource, r, finding,
        CASE WHEN coalesce(finding.attributes_json, '') CONTAINS '"severity":"' THEN split(split(finding.attributes_json, '"severity":"')[1], '"')[0] END,
        ''
      ) AS severity
+WITH resource, finding, risk_score, severity,
+     CASE toUpper(severity)
+       WHEN 'CRITICAL' THEN 4
+       WHEN 'HIGH' THEN 3
+       WHEN 'MEDIUM' THEN 2
+       WHEN 'LOW' THEN 1
+       ELSE 0
+     END AS severity_rank
 RETURN finding.urn AS finding_urn,
        coalesce(finding.label, finding.urn) AS finding_label,
        resource.urn AS resource_urn,
        coalesce(resource.label, resource.urn) AS resource_label,
        risk_score,
-       severity,
-       coalesce(finding.attributes_json, '') AS finding_attributes_json,
-       coalesce(r.attributes_json, '') AS relation_attributes_json
-ORDER BY risk_score DESC, severity DESC, finding_urn
+       severity
+ORDER BY risk_score DESC, severity_rank DESC, finding_urn
 LIMIT %d`, limit), true
 	case IntentExplainFinding:
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
@@ -234,9 +241,7 @@ RETURN finding.urn AS finding_urn,
        summary,
        resource.urn AS resource_urn,
        coalesce(resource.label, resource.urn) AS resource_label,
-       risk_score,
-       coalesce(finding.attributes_json, '') AS finding_attributes_json,
-       coalesce(r.attributes_json, '') AS relation_attributes_json
+       risk_score
 ORDER BY risk_score DESC, finding_urn
 LIMIT %d`, limit), true
 	case IntentIdentityBridge:

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -204,6 +204,7 @@ func renderDeterministicPlan(plan AskQueryPlan, maxRows int) (string, bool) {
 			limit = 10
 		}
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(f:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+WHERE $scope_urn = '' OR resource.urn = $scope_urn OR f.urn = $scope_urn
 WITH DISTINCT f,
      coalesce(
        CASE WHEN coalesce(f.attributes_json, '') CONTAINS '"source_family":"' THEN split(split(f.attributes_json, '"source_family":"')[1], '"')[0] END,
@@ -277,18 +278,30 @@ RETURN finding.urn AS finding_urn,
 ORDER BY risk_score DESC, finding_urn
 LIMIT %d`, limit), true
 	case IntentIdentityBridge:
-		return fmt.Sprintf(`MATCH (left:Entity {tenant_id: $tenant_id})-[leftRel:RELATION {relation: 'has_identifier'}]->(identifier:Entity {tenant_id: $tenant_id})<-[rightRel:RELATION {relation: 'has_identifier'}]-(right:Entity {tenant_id: $tenant_id})
+		return fmt.Sprintf(`MATCH (left:Entity {tenant_id: $tenant_id})-[leftRel:RELATION {relation: 'represents_identity'}]->(identity:Entity {tenant_id: $tenant_id})
+MATCH (right:Entity {tenant_id: $tenant_id})-[rightRel:RELATION {relation: 'represents_identity'}]->(identity)
 WHERE left.urn < right.urn
-  AND (identifier.entity_type CONTAINS 'identifier' OR identifier.urn CONTAINS ':identifier:')
+  AND left.entity_type <> right.entity_type
+  AND NOT left.entity_type STARTS WITH 'identity'
+  AND NOT right.entity_type STARTS WITH 'identity'
+  AND coalesce(leftRel.attributes_json, '') CONTAINS '"at":"'
+  AND coalesce(rightRel.attributes_json, '') CONTAINS '"at":"'
+WITH left, right, identity,
+     split(split(leftRel.attributes_json, '"at":"')[1], '"')[0] AS left_seen_at,
+     split(split(rightRel.attributes_json, '"at":"')[1], '"')[0] AS right_seen_at
+WHERE datetime(left_seen_at) >= datetime() - duration('P90D')
+  AND datetime(right_seen_at) >= datetime() - duration('P90D')
 RETURN left.urn AS left_urn,
        coalesce(left.label, left.urn) AS left_label,
        left.entity_type AS left_type,
        right.urn AS right_urn,
        coalesce(right.label, right.urn) AS right_label,
        right.entity_type AS right_type,
-       identifier.urn AS identifier_urn,
-       coalesce(identifier.label, identifier.urn) AS identifier_label
-ORDER BY identifier_label, left_urn, right_urn
+       identity.urn AS identity_urn,
+       coalesce(identity.label, identity.urn) AS identity_label,
+       left_seen_at,
+       right_seen_at
+ORDER BY identity_label, left_urn, right_urn
 LIMIT %d`, limit), true
 	case IntentConnectorHealth:
 		return fmt.Sprintf(`MATCH (source:Entity {tenant_id: $tenant_id, entity_type: 'source'})

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -1,6 +1,7 @@
 package graphagent
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -22,6 +23,54 @@ type AskQueryPlan struct {
 	Limit      int               `json:"limit,omitempty"`
 	Filters    map[string]string `json:"filters,omitempty"`
 	GroupBy    string            `json:"group_by,omitempty"`
+}
+
+func (p *AskQueryPlan) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Intent     string         `json:"intent"`
+		Confidence float64        `json:"confidence,omitempty"`
+		ScopeURN   string         `json:"scope_urn,omitempty"`
+		Limit      int            `json:"limit,omitempty"`
+		Filters    map[string]any `json:"filters,omitempty"`
+		GroupBy    string         `json:"group_by,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	p.Intent = raw.Intent
+	p.Confidence = raw.Confidence
+	p.ScopeURN = raw.ScopeURN
+	p.Limit = raw.Limit
+	p.GroupBy = raw.GroupBy
+	if raw.Filters == nil {
+		p.Filters = nil
+		return nil
+	}
+	p.Filters = make(map[string]string, len(raw.Filters))
+	for key, value := range raw.Filters {
+		filterValue := stringifyPlanFilter(value)
+		if filterValue != "" {
+			p.Filters[key] = filterValue
+		}
+	}
+	return nil
+}
+
+func stringifyPlanFilter(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	case float64, bool:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	default:
+		raw, err := json.Marshal(typed)
+		if err != nil {
+			return strings.TrimSpace(fmt.Sprint(typed))
+		}
+		return string(raw)
+	}
 }
 
 type ConversionDiagnostic struct {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -34,6 +34,19 @@ func TestOntologyPromptUsesProjectedIdentityShape(t *testing.T) {
 	}
 }
 
+func TestOntologyPromptMentionsLegacyRepositoryShape(t *testing.T) {
+	hint := canonicalGraphOntology.PromptHint()
+	for _, want := range []string{
+		"Entity `github.code.repository`",
+		"Entity `github.repo`",
+		"Repository questions should consider both `entity_type: 'github.code.repository'` and legacy `entity_type: 'github.repo'`",
+	} {
+		if !strings.Contains(hint, want) {
+			t.Fatalf("PromptHint() missing %q:\n%s", want, hint)
+		}
+	}
+}
+
 func TestOntologyPromptUsesProjectedSourceShape(t *testing.T) {
 	hint := canonicalGraphOntology.PromptHint()
 	for _, want := range []string{
@@ -209,7 +222,18 @@ func TestConvertDraftToQueryExplainFindingAvoidsBrittleSummaryExtraction(t *test
 	if strings.Contains(result.Cypher, `"summary":"`) || strings.Contains(result.Cypher, "split(split(finding.attributes_json, '\"summary\"") {
 		t.Fatalf("converted cypher should not split raw JSON summary values:\n%s", result.Cypher)
 	}
-	if !strings.Contains(result.Cypher, "MATCH (finding:Entity") || !strings.Contains(result.Cypher, "OPTIONAL MATCH (resource:Entity") {
+	for _, want := range []string{
+		"MATCH (finding:Entity",
+		"OR finding.urn = $scope_urn",
+		"EXISTS {",
+		"scopedResource:Entity {tenant_id: $tenant_id, urn: $scope_urn}",
+		"OPTIONAL MATCH (resource:Entity",
+	} {
+		if !strings.Contains(result.Cypher, want) {
+			t.Fatalf("converted cypher missing %q:\n%s", want, result.Cypher)
+		}
+	}
+	if strings.Contains(result.Cypher, "WHERE $scope_urn = '' OR finding.urn = $scope_urn OR resource.urn = $scope_urn") {
 		t.Fatalf("converted cypher should start from the finding anchor and optional-match resources:\n%s", result.Cypher)
 	}
 	if !strings.Contains(result.Cypher, "finding_attributes_json_internal") {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -175,6 +175,25 @@ LIMIT 25`
 	}
 }
 
+func TestConvertDraftToQueryRefusesUnsupportedPlanOnlyDraft(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Show high risk findings",
+	}, &DraftResponse{
+		Plan: &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"severity": "HIGH"}},
+	}, 100)
+
+	if result.Cypher != "" || result.Source != "conversion_refusal" {
+		t.Fatalf("conversion result = %#v, want conversion refusal without cypher", result)
+	}
+	if !strings.Contains(result.Refusal, "could not be converted") {
+		t.Fatalf("refusal = %q, want backend conversion failure", result.Refusal)
+	}
+	if len(result.Diagnostics) == 0 || result.Diagnostics[0].Code != "query_plan_conversion_failed" {
+		t.Fatalf("diagnostics = %#v, want query_plan_conversion_failed", result.Diagnostics)
+	}
+}
+
 func TestConvertDraftToQueryExplainFindingAvoidsBrittleSummaryExtraction(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{
 		TenantID: "writer",

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -33,8 +33,30 @@ RETURN apoc.convert.fromJsonMap(f.attributes_json).source_family AS source_famil
 	if !strings.Contains(result.Cypher, "f.source_id") || !strings.Contains(result.Cypher, "LIMIT 10") {
 		t.Fatalf("converted cypher missing source_id fallback/limit:\n%s", result.Cypher)
 	}
+	sourceFamilyIndex := strings.Index(result.Cypher, `"source_family":"`)
+	sourceIDIndex := strings.Index(result.Cypher, "f.source_id")
+	if sourceFamilyIndex < 0 || sourceIDIndex < 0 || sourceFamilyIndex > sourceIDIndex {
+		t.Fatalf("converted cypher should prefer source_family before source_id:\n%s", result.Cypher)
+	}
 	if len(result.Diagnostics) == 0 {
 		t.Fatalf("expected conversion diagnostics")
+	}
+}
+
+func TestConvertDraftToQueryPreservesExplicitRefusal(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Delete risky nodes and show top finding sources",
+	}, &DraftResponse{
+		Plan:    &AskQueryPlan{Intent: IntentRawCypher},
+		Refusal: "Read-only graph questions only.",
+	}, 100)
+
+	if result.Cypher != "" || result.Deterministic {
+		t.Fatalf("conversion result = %#v, want preserved refusal without deterministic cypher", result)
+	}
+	if result.Plan.Intent != IntentRawCypher || result.Source != "llm_refusal" {
+		t.Fatalf("conversion result = %#v, want raw llm refusal plan", result)
 	}
 }
 
@@ -64,6 +86,23 @@ func TestConvertDraftToQueryScopesTopRiskAndReturnsOnlyScalarFields(t *testing.T
 		if strings.Contains(result.Cypher, forbidden) {
 			t.Fatalf("converted cypher returns raw attributes %q:\n%s", forbidden, result.Cypher)
 		}
+	}
+}
+
+func TestConvertDraftToQueryExplainFindingAvoidsBrittleSummaryExtraction(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Explain this finding",
+		ScopeURN: "urn:cerebro:writer:finding:alpha",
+	}, &DraftResponse{
+		Plan: &AskQueryPlan{Intent: IntentExplainFinding, Limit: 25},
+	}, 100)
+
+	if result.Plan.Intent != IntentExplainFinding || !result.Deterministic {
+		t.Fatalf("conversion result = %#v, want deterministic explain finding template", result)
+	}
+	if strings.Contains(result.Cypher, `"summary":"`) || strings.Contains(result.Cypher, "split(split(finding.attributes_json, '\"summary\"") {
+		t.Fatalf("converted cypher should not split raw JSON summary values:\n%s", result.Cypher)
 	}
 }
 

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -34,6 +34,22 @@ func TestOntologyPromptUsesProjectedIdentityShape(t *testing.T) {
 	}
 }
 
+func TestOntologyPromptUsesProjectedSourceShape(t *testing.T) {
+	hint := canonicalGraphOntology.PromptHint()
+	for _, want := range []string{
+		"Entity `source`",
+		"Connector/source health nodes use `entity_type: 'source'`",
+		"there is no `connector` entity_type and no top-level `status` or `last_sync_minutes` property",
+	} {
+		if !strings.Contains(hint, want) {
+			t.Fatalf("PromptHint() missing %q:\n%s", want, hint)
+		}
+	}
+	if strings.Contains(hint, "Entity `connector`:") || strings.Contains(hint, "Useful properties: source_id, runtime_id, status, last_sync_minutes") {
+		t.Fatalf("PromptHint() still advertises connector node shape:\n%s", hint)
+	}
+}
+
 func TestAskQueryPlanUnmarshalCoercesFilterValues(t *testing.T) {
 	var plan AskQueryPlan
 	if err := json.Unmarshal([]byte(`{"intent":"top_risk_findings","filters":{"risk_score":50,"active":true,"source":"github"}}`), &plan); err != nil {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -50,6 +50,15 @@ func TestAskQueryPlanUnmarshalCoercesFilterValues(t *testing.T) {
 	}
 }
 
+func TestInferIntentPrefersTopRiskOverSourceBreakdown(t *testing.T) {
+	if got := inferIntent("show top risk findings from the GitHub source", ""); got != IntentTopRiskFindings {
+		t.Fatalf("inferIntent() = %q, want %q", got, IntentTopRiskFindings)
+	}
+	if got := inferIntent("show top finding sources", ""); got != IntentAggregateFindingsBySource {
+		t.Fatalf("inferIntent(top finding sources) = %q, want %q", got, IntentAggregateFindingsBySource)
+	}
+}
+
 func TestConvertDraftToQueryUsesDeterministicFindingSourceTemplate(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{
 		TenantID: "writer",

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -277,6 +277,7 @@ func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{
 		TenantID: "writer",
 		Question: "Which identities bridge Okta and GitHub?",
+		ScopeURN: "urn:cerebro:writer:github_user:alice",
 	}, &DraftResponse{
 		Plan: &AskQueryPlan{Intent: IntentIdentityBridge, Limit: 25},
 	}, 100)
@@ -287,6 +288,7 @@ func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
 	for _, want := range []string{
 		"relation: 'represents_identity'",
 		"left.entity_type <> right.entity_type",
+		"$scope_urn = '' OR left.urn = $scope_urn OR right.urn = $scope_urn OR identity.urn = $scope_urn",
 		"NOT left.entity_type STARTS WITH 'identifier'",
 		"datetime(left_seen_at) >= datetime() - duration('P90D')",
 		"identity.urn AS identity_urn",

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -1,6 +1,7 @@
 package graphagent
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -11,6 +12,22 @@ func TestOntologyCanonicalizesAliases(t *testing.T) {
 	}
 	if got, ok := canonicalRelation("BELONGS_TO_SOURCE"); !ok || got != "belongs_to" {
 		t.Fatalf("canonicalRelation(BELONGS_TO_SOURCE) = %q, %v; want belongs_to, true", got, ok)
+	}
+}
+
+func TestAskQueryPlanUnmarshalCoercesFilterValues(t *testing.T) {
+	var plan AskQueryPlan
+	if err := json.Unmarshal([]byte(`{"intent":"top_risk_findings","filters":{"risk_score":50,"active":true,"source":"github"}}`), &plan); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got := plan.Filters["risk_score"]; got != "50" {
+		t.Fatalf("risk_score filter = %q, want 50", got)
+	}
+	if got := plan.Filters["active"]; got != "true" {
+		t.Fatalf("active filter = %q, want true", got)
+	}
+	if got := plan.Filters["source"]; got != "github" {
+		t.Fatalf("source filter = %q, want github", got)
 	}
 }
 

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -79,6 +79,8 @@ func TestConvertDraftToQueryScopesTopRiskAndReturnsOnlyScalarFields(t *testing.T
 		"WHERE $scope_urn = '' OR resource.urn = $scope_urn OR finding.urn = $scope_urn",
 		"CASE toUpper(severity)",
 		"WHEN 'CRITICAL' THEN 4",
+		"collect(DISTINCT resource.urn) AS resource_urns",
+		"max(risk_score) AS risk_score",
 		"ORDER BY risk_score DESC, severity_rank DESC, finding_urn",
 	} {
 		if !strings.Contains(result.Cypher, want) {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -10,8 +10,27 @@ func TestOntologyCanonicalizesAliases(t *testing.T) {
 	if got := canonicalEntityType("Finding"); got != "finding" {
 		t.Fatalf("canonicalEntityType(Finding) = %q, want finding", got)
 	}
+	if got := canonicalEntityType("email identity"); got != "identity.email" {
+		t.Fatalf("canonicalEntityType(email identity) = %q, want identity.email", got)
+	}
 	if got, ok := canonicalRelation("BELONGS_TO_SOURCE"); !ok || got != "belongs_to" {
 		t.Fatalf("canonicalRelation(BELONGS_TO_SOURCE) = %q, %v; want belongs_to, true", got, ok)
+	}
+}
+
+func TestOntologyPromptUsesProjectedIdentityShape(t *testing.T) {
+	hint := canonicalGraphOntology.PromptHint()
+	for _, want := range []string{
+		"identity.email",
+		"identity.login",
+		"there is no generic `identity` entity_type or top-level `email` property",
+	} {
+		if !strings.Contains(hint, want) {
+			t.Fatalf("PromptHint() missing %q:\n%s", want, hint)
+		}
+	}
+	if strings.Contains(hint, "Entity `identity`:") || strings.Contains(hint, "Useful properties: email, source_id") {
+		t.Fatalf("PromptHint() still advertises generic identity shape:\n%s", hint)
 	}
 }
 

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -47,6 +47,16 @@ func TestOntologyPromptMentionsLegacyRepositoryShape(t *testing.T) {
 	}
 }
 
+func TestOntologyPromptStoresFindingMetadataInAttributesJSON(t *testing.T) {
+	hint := canonicalGraphOntology.PromptHint()
+	if !strings.Contains(hint, "Finding metadata such as `severity`, `effective_severity`, `status`, `risk_score`, `summary`, and `primary_resource_urn` is stored in `attributes_json`") {
+		t.Fatalf("PromptHint() missing finding attributes_json guidance:\n%s", hint)
+	}
+	if strings.Contains(hint, "Useful properties: finding_id, severity, status, risk_score") {
+		t.Fatalf("PromptHint() still advertises finding metadata as top-level properties:\n%s", hint)
+	}
+}
+
 func TestOntologyPromptUsesProjectedSourceShape(t *testing.T) {
 	hint := canonicalGraphOntology.PromptHint()
 	for _, want := range []string{

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -127,8 +127,28 @@ func TestConvertDraftToQueryExplainFindingAvoidsBrittleSummaryExtraction(t *test
 	if strings.Contains(result.Cypher, `"summary":"`) || strings.Contains(result.Cypher, "split(split(finding.attributes_json, '\"summary\"") {
 		t.Fatalf("converted cypher should not split raw JSON summary values:\n%s", result.Cypher)
 	}
+	if !strings.Contains(result.Cypher, "MATCH (finding:Entity") || !strings.Contains(result.Cypher, "OPTIONAL MATCH (resource:Entity") {
+		t.Fatalf("converted cypher should start from the finding anchor and optional-match resources:\n%s", result.Cypher)
+	}
 	if !strings.Contains(result.Cypher, "finding_attributes_json_internal") {
 		t.Fatalf("converted cypher should expose internal attributes for server-side summary extraction:\n%s", result.Cypher)
+	}
+}
+
+func TestConvertDraftToQueryScopesConnectorHealthTemplate(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Show this source health",
+		ScopeURN: "urn:cerebro:writer:source:github",
+	}, &DraftResponse{
+		Plan: &AskQueryPlan{Intent: IntentConnectorHealth, Limit: 25},
+	}, 100)
+
+	if result.Plan.Intent != IntentConnectorHealth || !result.Deterministic {
+		t.Fatalf("conversion result = %#v, want deterministic connector health", result)
+	}
+	if !strings.Contains(result.Cypher, "WHERE $scope_urn = '' OR source.urn = $scope_urn") {
+		t.Fatalf("converted cypher missing connector scope predicate:\n%s", result.Cypher)
 	}
 }
 
@@ -146,6 +166,7 @@ func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
 	for _, want := range []string{
 		"relation: 'represents_identity'",
 		"left.entity_type <> right.entity_type",
+		"NOT left.entity_type STARTS WITH 'identifier'",
 		"datetime(left_seen_at) >= datetime() - duration('P90D')",
 		"identity.urn AS identity_urn",
 	} {
@@ -155,6 +176,17 @@ func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
 	}
 	if strings.Contains(result.Cypher, "relation: 'has_identifier'") {
 		t.Fatalf("converted cypher should not bridge concrete identities via identifier anchors:\n%s", result.Cypher)
+	}
+}
+
+func TestOntologyDiagnosticsTreatsAPOCVariableAsSafe(t *testing.T) {
+	diagnostics := ontologyDiagnostics(`MATCH (apoc:Entity {tenant_id: $tenant_id})
+RETURN apoc.urn AS urn
+LIMIT 25`)
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == "apoc_not_allowed" {
+			t.Fatalf("ontologyDiagnostics() emitted APOC warning for variable property access: %#v", diagnostics)
+		}
 	}
 }
 

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -89,6 +89,26 @@ func TestConvertDraftToQueryScopesTopRiskAndReturnsOnlyScalarFields(t *testing.T
 	}
 }
 
+func TestConvertDraftToQuerySkipsTemplateForUnsupportedFilters(t *testing.T) {
+	draftCypher := `MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
+RETURN finding.urn AS finding_urn
+LIMIT 25`
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Show high findings",
+	}, &DraftResponse{
+		Plan:   &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"severity": "HIGH"}},
+		Cypher: draftCypher,
+	}, 100)
+
+	if result.Deterministic || result.Source != "llm" {
+		t.Fatalf("conversion result = %#v, want LLM fallback for filtered plan", result)
+	}
+	if result.Cypher != draftCypher {
+		t.Fatalf("cypher = %q, want unmodified draft", result.Cypher)
+	}
+}
+
 func TestConvertDraftToQueryExplainFindingAvoidsBrittleSummaryExtraction(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{
 		TenantID: "writer",
@@ -103,6 +123,9 @@ func TestConvertDraftToQueryExplainFindingAvoidsBrittleSummaryExtraction(t *test
 	}
 	if strings.Contains(result.Cypher, `"summary":"`) || strings.Contains(result.Cypher, "split(split(finding.attributes_json, '\"summary\"") {
 		t.Fatalf("converted cypher should not split raw JSON summary values:\n%s", result.Cypher)
+	}
+	if !strings.Contains(result.Cypher, "finding_attributes_json_internal") {
+		t.Fatalf("converted cypher should expose internal attributes for server-side summary extraction:\n%s", result.Cypher)
 	}
 }
 

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -38,6 +38,35 @@ RETURN apoc.convert.fromJsonMap(f.attributes_json).source_family AS source_famil
 	}
 }
 
+func TestConvertDraftToQueryScopesTopRiskAndReturnsOnlyScalarFields(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Show top risk findings for this repo",
+		ScopeURN: "urn:cerebro:writer:repo:alpha",
+	}, &DraftResponse{
+		Plan: &AskQueryPlan{Intent: IntentTopRiskFindings, Limit: 25},
+	}, 100)
+
+	if result.Plan.Intent != IntentTopRiskFindings || !result.Deterministic {
+		t.Fatalf("conversion result = %#v, want deterministic top risk template", result)
+	}
+	for _, want := range []string{
+		"WHERE $scope_urn = '' OR resource.urn = $scope_urn OR finding.urn = $scope_urn",
+		"CASE toUpper(severity)",
+		"WHEN 'CRITICAL' THEN 4",
+		"ORDER BY risk_score DESC, severity_rank DESC, finding_urn",
+	} {
+		if !strings.Contains(result.Cypher, want) {
+			t.Fatalf("converted cypher missing %q:\n%s", want, result.Cypher)
+		}
+	}
+	for _, forbidden := range []string{"finding_attributes_json", "relation_attributes_json", " AS attributes_json"} {
+		if strings.Contains(result.Cypher, forbidden) {
+			t.Fatalf("converted cypher returns raw attributes %q:\n%s", forbidden, result.Cypher)
+		}
+	}
+}
+
 func TestConvertDraftToQueryInjectsFallbackLimit(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "show entities"}, &DraftResponse{
 		Cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn AS urn`,

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -40,10 +40,15 @@ func TestOntologyPromptMentionsLegacyRepositoryShape(t *testing.T) {
 		"Entity `github.code.repository`",
 		"Entity `github.repo`",
 		"Repository questions should consider both `entity_type: 'github.code.repository'` and legacy `entity_type: 'github.repo'`",
+		"GitHub repository metadata such as `owner_login`, `repository`, `visibility`, and `default_branch` is stored in `attributes_json`",
+		"Legacy `github.repo` anchors often carry the repository name in `urn`, `label`, and `attributes_json.repository`",
 	} {
 		if !strings.Contains(hint, want) {
 			t.Fatalf("PromptHint() missing %q:\n%s", want, hint)
 		}
+	}
+	if strings.Contains(hint, "Useful properties: owner_login") {
+		t.Fatalf("PromptHint() still advertises repository metadata as top-level properties:\n%s", hint)
 	}
 }
 

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -1,0 +1,62 @@
+package graphagent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOntologyCanonicalizesAliases(t *testing.T) {
+	if got := canonicalEntityType("Finding"); got != "finding" {
+		t.Fatalf("canonicalEntityType(Finding) = %q, want finding", got)
+	}
+	if got, ok := canonicalRelation("BELONGS_TO_SOURCE"); !ok || got != "belongs_to" {
+		t.Fatalf("canonicalRelation(BELONGS_TO_SOURCE) = %q, %v; want belongs_to, true", got, ok)
+	}
+}
+
+func TestConvertDraftToQueryUsesDeterministicFindingSourceTemplate(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Count findings by source",
+	}, &DraftResponse{
+		Cypher: `MATCH (f:Entity {tenant_id: $tenant_id}) WHERE f.entity_type = 'Finding'
+OPTIONAL MATCH (f)-[:HAS_SOURCE]->(src:Entity {tenant_id: $tenant_id})
+RETURN apoc.convert.fromJsonMap(f.attributes_json).source_family AS source_family, count(f) LIMIT 10`,
+	}, 100)
+
+	if result.Plan.Intent != IntentAggregateFindingsBySource || !result.Deterministic || !result.Corrected {
+		t.Fatalf("conversion result = %#v, want deterministic corrected source aggregation", result)
+	}
+	if strings.Contains(result.Cypher, "apoc.") || strings.Contains(result.Cypher, "HAS_SOURCE") || strings.Contains(result.Cypher, "'Finding'") {
+		t.Fatalf("converted cypher is not canonical:\n%s", result.Cypher)
+	}
+	if !strings.Contains(result.Cypher, "f.source_id") || !strings.Contains(result.Cypher, "LIMIT 10") {
+		t.Fatalf("converted cypher missing source_id fallback/limit:\n%s", result.Cypher)
+	}
+	if len(result.Diagnostics) == 0 {
+		t.Fatalf("expected conversion diagnostics")
+	}
+}
+
+func TestConvertDraftToQueryInjectsFallbackLimit(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "show entities"}, &DraftResponse{
+		Cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn AS urn`,
+	}, 100)
+
+	if result.Plan.Intent != IntentRawCypher || !result.Corrected {
+		t.Fatalf("conversion result = %#v, want corrected raw cypher", result)
+	}
+	if !strings.Contains(result.Cypher, "LIMIT 100") {
+		t.Fatalf("converted cypher missing injected limit:\n%s", result.Cypher)
+	}
+}
+
+func TestConvertDraftToQueryCapsFallbackLimit(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: "show entities"}, &DraftResponse{
+		Cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn AS urn LIMIT 500`,
+	}, 100)
+
+	if !result.Corrected || !strings.Contains(result.Cypher, "LIMIT 100") || strings.Contains(result.Cypher, "LIMIT 500") {
+		t.Fatalf("converted cypher did not cap limit:\n%s", result.Cypher)
+	}
+}

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -40,10 +40,15 @@ func TestOntologyPromptMentionsLegacyRepositoryShape(t *testing.T) {
 		"Entity `github.code.repository`",
 		"Entity `github.repo`",
 		"Repository questions should consider both `entity_type: 'github.code.repository'` and legacy `entity_type: 'github.repo'`",
+		"Repository metadata such as `owner_login` is stored in `attributes_json`",
+		"urn:cerebro:writer:github_code_repository:repo-123",
 	} {
 		if !strings.Contains(hint, want) {
 			t.Fatalf("PromptHint() missing %q:\n%s", want, hint)
 		}
+	}
+	if strings.Contains(hint, "Useful properties: owner_login") {
+		t.Fatalf("PromptHint() still advertises owner_login as top-level repository property:\n%s", hint)
 	}
 }
 

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -33,6 +33,9 @@ RETURN apoc.convert.fromJsonMap(f.attributes_json).source_family AS source_famil
 	if !strings.Contains(result.Cypher, "f.source_id") || !strings.Contains(result.Cypher, "LIMIT 10") {
 		t.Fatalf("converted cypher missing source_id fallback/limit:\n%s", result.Cypher)
 	}
+	if !strings.Contains(result.Cypher, "WHERE $scope_urn = '' OR resource.urn = $scope_urn OR f.urn = $scope_urn") {
+		t.Fatalf("converted cypher missing scope predicate:\n%s", result.Cypher)
+	}
 	sourceFamilyIndex := strings.Index(result.Cypher, `"source_family":"`)
 	sourceIDIndex := strings.Index(result.Cypher, "f.source_id")
 	if sourceFamilyIndex < 0 || sourceIDIndex < 0 || sourceFamilyIndex > sourceIDIndex {
@@ -126,6 +129,32 @@ func TestConvertDraftToQueryExplainFindingAvoidsBrittleSummaryExtraction(t *test
 	}
 	if !strings.Contains(result.Cypher, "finding_attributes_json_internal") {
 		t.Fatalf("converted cypher should expose internal attributes for server-side summary extraction:\n%s", result.Cypher)
+	}
+}
+
+func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
+	result := convertDraftToQuery(AskRequest{
+		TenantID: "writer",
+		Question: "Which identities bridge Okta and GitHub?",
+	}, &DraftResponse{
+		Plan: &AskQueryPlan{Intent: IntentIdentityBridge, Limit: 25},
+	}, 100)
+
+	if result.Plan.Intent != IntentIdentityBridge || !result.Deterministic {
+		t.Fatalf("conversion result = %#v, want deterministic identity bridge", result)
+	}
+	for _, want := range []string{
+		"relation: 'represents_identity'",
+		"left.entity_type <> right.entity_type",
+		"datetime(left_seen_at) >= datetime() - duration('P90D')",
+		"identity.urn AS identity_urn",
+	} {
+		if !strings.Contains(result.Cypher, want) {
+			t.Fatalf("converted cypher missing %q:\n%s", want, result.Cypher)
+		}
+	}
+	if strings.Contains(result.Cypher, "relation: 'has_identifier'") {
+		t.Fatalf("converted cypher should not bridge concrete identities via identifier anchors:\n%s", result.Cypher)
 	}
 }
 

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -89,7 +89,7 @@ func (v *Validator) validate(ctx context.Context, cypher string, params map[stri
 		return validatorRefusal("limit_exceeded", fmt.Sprintf("LIMIT %d exceeds maximum %d", limit, v.options.MaxRows)), 0, nil
 	}
 	if oversized := oversizedLimit(safeQuery, v.options.MaxRows); oversized > 0 {
-		return ValidatorResult{OK: false, Reason: fmt.Sprintf("LIMIT %d exceeds maximum %d", oversized, v.options.MaxRows)}, 0, nil
+		return validatorRefusal("limit_exceeded", fmt.Sprintf("LIMIT %d exceeds maximum %d", oversized, v.options.MaxRows)), 0, nil
 	}
 	if !allNodePatternsTenantScoped(safeQuery) {
 		return validatorRefusal("tenant_scope_required", "every node pattern must use Entity label and inline tenant_id"), 0, nil

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -20,6 +20,7 @@ var (
 	loadCSVPattern        = regexp.MustCompile(`(?i)\bLOAD\s+CSV\b`)
 	usingPeriodicPattern  = regexp.MustCompile(`(?i)\bUSING\s+PERIODIC\b`)
 	forbiddenAPOCPattern  = regexp.MustCompile(`(?i)\bCALL\s+apoc\.(trigger|periodic)\.`)
+	apocPattern           = regexp.MustCompile(`(?i)\bapoc\.`)
 	limitPattern          = regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)\b`)
 	matchClausePattern    = regexp.MustCompile(`(?i)\b(?:OPTIONAL\s+MATCH|MATCH)\b`)
 	matchClauseEndPattern = regexp.MustCompile(`(?i)\b(?:WHERE|RETURN|WITH|ORDER\s+BY|LIMIT|UNWIND|CALL|UNION|CREATE|MERGE|DELETE|SET|REMOVE|DROP|FOREACH)\b`)
@@ -67,27 +68,30 @@ func NewValidator(store ports.GraphQueryStore, options ValidatorOptions) *Valida
 func (v *Validator) validate(ctx context.Context, cypher string, params map[string]any) (ValidatorResult, int, error) {
 	query := strings.TrimSpace(cypher)
 	if query == "" {
-		return ValidatorResult{OK: false, Reason: "cypher is required"}, 0, nil
+		return validatorRefusal("cypher_required", "cypher is required"), 0, nil
 	}
 	safeQuery := scrubCypher(query)
 	if forbiddenTokenPattern.MatchString(safeQuery) || loadCSVPattern.MatchString(safeQuery) || usingPeriodicPattern.MatchString(safeQuery) {
-		return ValidatorResult{OK: false, Reason: "write or bulk-load Cypher clauses are forbidden"}, 0, nil
+		return validatorRefusal("unsafe_clause", "write or bulk-load Cypher clauses are forbidden"), 0, nil
 	}
 	if forbiddenAPOCPattern.MatchString(safeQuery) {
-		return ValidatorResult{OK: false, Reason: "apoc trigger and periodic procedures are forbidden"}, 0, nil
+		return validatorRefusal("unsafe_apoc", "apoc trigger and periodic procedures are forbidden"), 0, nil
+	}
+	if apocPattern.MatchString(safeQuery) {
+		return validatorRefusal("apoc_not_allowed", "APOC functions and procedures are not available in Ask Cerebro"), 0, nil
 	}
 	if hasProcedureCall(safeQuery) {
-		return ValidatorResult{OK: false, Reason: "procedure CALL clauses are forbidden"}, 0, nil
+		return validatorRefusal("procedure_call_not_allowed", "procedure CALL clauses are forbidden"), 0, nil
 	}
 	limit, ok := queryLimit(safeQuery)
 	if !ok {
-		return ValidatorResult{OK: false, Reason: "read Cypher must include a numeric LIMIT clause"}, 0, nil
+		return validatorRefusal("limit_required", "read Cypher must include a numeric LIMIT clause"), 0, nil
 	}
 	if limit > v.options.MaxRows {
-		return ValidatorResult{OK: false, Reason: fmt.Sprintf("LIMIT %d exceeds maximum %d", limit, v.options.MaxRows)}, 0, nil
+		return validatorRefusal("limit_exceeded", fmt.Sprintf("LIMIT %d exceeds maximum %d", limit, v.options.MaxRows)), 0, nil
 	}
 	if !allNodePatternsTenantScoped(safeQuery) {
-		return ValidatorResult{OK: false, Reason: "every node pattern must use Entity label and inline tenant_id"}, 0, nil
+		return validatorRefusal("tenant_scope_required", "every node pattern must use Entity label and inline tenant_id"), 0, nil
 	}
 	if v.options.Explain && v.store != nil {
 		explainer, ok := v.store.(interface {
@@ -101,10 +105,14 @@ func (v *Validator) validate(ctx context.Context, cypher string, params map[stri
 			return ValidatorResult{}, 0, fmt.Errorf("%w: explain cypher: %w", ErrRuntimeUnavailable, err)
 		}
 		if allNodesScanOverLimit(plan, v.options.AllNodesScanLimit) {
-			return ValidatorResult{OK: false, Reason: fmt.Sprintf("EXPLAIN plan contains AllNodesScan over more than %d nodes", v.options.AllNodesScanLimit)}, 0, nil
+			return validatorRefusal("all_nodes_scan_over_limit", fmt.Sprintf("EXPLAIN plan contains AllNodesScan over more than %d nodes", v.options.AllNodesScanLimit)), 0, nil
 		}
 	}
 	return ValidatorResult{OK: true}, limit, nil
+}
+
+func validatorRefusal(code string, reason string) ValidatorResult {
+	return ValidatorResult{OK: false, Code: code, Reason: reason}
 }
 
 func scrubCypher(query string) string {

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -20,7 +20,7 @@ var (
 	loadCSVPattern        = regexp.MustCompile(`(?i)\bLOAD\s+CSV\b`)
 	usingPeriodicPattern  = regexp.MustCompile(`(?i)\bUSING\s+PERIODIC\b`)
 	forbiddenAPOCPattern  = regexp.MustCompile(`(?i)\bCALL\s+apoc\.(trigger|periodic)\.`)
-	apocPattern           = regexp.MustCompile(`(?i)\bapoc\.`)
+	apocInvocationPattern = regexp.MustCompile(`(?i)\bapoc\.[A-Za-z0-9_.]+\s*\(`)
 	limitPattern          = regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)\b`)
 	matchClausePattern    = regexp.MustCompile(`(?i)\b(?:OPTIONAL\s+MATCH|MATCH)\b`)
 	matchClauseEndPattern = regexp.MustCompile(`(?i)\b(?:WHERE|RETURN|WITH|ORDER\s+BY|LIMIT|UNWIND|CALL|UNION|CREATE|MERGE|DELETE|SET|REMOVE|DROP|FOREACH)\b`)
@@ -77,7 +77,7 @@ func (v *Validator) validate(ctx context.Context, cypher string, params map[stri
 	if forbiddenAPOCPattern.MatchString(safeQuery) {
 		return validatorRefusal("unsafe_apoc", "apoc trigger and periodic procedures are forbidden"), 0, nil
 	}
-	if apocPattern.MatchString(safeQuery) {
+	if apocInvocationPattern.MatchString(safeQuery) {
 		return validatorRefusal("apoc_not_allowed", "APOC functions and procedures are not available in Ask Cerebro"), 0, nil
 	}
 	if hasProcedureCall(safeQuery) {

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -144,6 +144,22 @@ LIMIT 25`, map[string]any{"tenant_id": "example"})
 	}
 }
 
+func TestValidatorAcceptsAPOCVariablePropertyAccess(t *testing.T) {
+	validator := NewValidator(nil, ValidatorOptions{})
+	result, limit, err := validator.validate(context.Background(), `MATCH (apoc:Entity {tenant_id: $tenant_id})
+RETURN apoc.urn AS urn
+LIMIT 25`, map[string]any{"tenant_id": "example"})
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("Validate() = %#v, want ok", result)
+	}
+	if limit != 25 {
+		t.Fatalf("limit = %d, want 25", limit)
+	}
+}
+
 func TestValidatorAcceptsScopedRelationshipReadWithReturnFunctions(t *testing.T) {
 	validator := NewValidator(nil, ValidatorOptions{})
 	result, limit, err := validator.validate(context.Background(), `MATCH (src:Entity {tenant_id: $tenant_id})-[r:RELATION]->(dst:Entity {tenant_id: $tenant_id})

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -145,6 +145,26 @@ RETURN b.urn AS urn LIMIT 25`,
 	}
 }
 
+func TestValidatorPreservesCodeForOversizedUnionLimit(t *testing.T) {
+	validator := NewValidator(nil, ValidatorOptions{})
+	result, _, err := validator.validate(context.Background(), `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS urn
+LIMIT 1000
+UNION
+MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS urn
+LIMIT 25`, map[string]any{"tenant_id": "example"})
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if result.OK {
+		t.Fatalf("Validate() ok = true, want false")
+	}
+	if result.Code != "limit_exceeded" {
+		t.Fatalf("code = %q, want limit_exceeded; result = %#v", result.Code, result)
+	}
+}
+
 func TestValidatorAcceptsBoundedTenantScopedRead(t *testing.T) {
 	store := &validatorStore{}
 	validator := NewValidator(store, ValidatorOptions{Explain: true})

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -30,6 +30,11 @@ func TestValidatorRejectsUnsafeCypher(t *testing.T) {
 			reason: "apoc",
 		},
 		{
+			name:   "apoc function",
+			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN apoc.convert.fromJsonMap(e.attributes_json).source_family AS source_family LIMIT 25`,
+			reason: "APOC",
+		},
+		{
 			name:   "missing limit",
 			cypher: `MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e.urn`,
 			reason: "LIMIT",


### PR DESCRIPTION
## Summary
- Add a canonical graph ontology and AskQueryPlan conversion contract for Cerebro Ask.
- Convert common Ask intents through deterministic templates before validation, including finding source aggregation.
- Emit query-plan diagnostics and structured validator refusal codes in the Ask SSE stream.

## Test plan
- go test ./internal/graphagent ./internal/bootstrap
- go test ./...


Made with [Cursor](https://cursor.com)