### PR TITLE
Harden finding candidate operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build serve test workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun lint lint-bootstrap proto-lint proto-generate openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check oss-audit govulncheck clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: build serve test workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check oss-audit govulncheck clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -29,6 +29,7 @@ GRAPH_REBUILD_MODE ?= replay
 GRAPH_REBUILD_PAGE_LIMIT ?= 1
 GRAPH_REBUILD_EVENT_LIMIT ?= 100
 GRAPH_REBUILD_PREVIEW_LIMIT ?= 10
+CANDIDATE_SMOKE_EVENT_LIMIT ?= 25
 
 build:
 	go build -o bin/cerebro ./cmd/cerebro
@@ -79,6 +80,10 @@ workflow-neighborhood:
 graph-rebuild-dryrun: build
 	@if [ -z "$(RUNTIME_ID)" ]; then echo "RUNTIME_ID is required, e.g. make graph-rebuild-dryrun RUNTIME_ID=writer-okta-audit" >&2; exit 2; fi
 	./bin/cerebro graph rebuild "$(RUNTIME_ID)" dry_run=true mode="$(GRAPH_REBUILD_MODE)" page_limit="$(GRAPH_REBUILD_PAGE_LIMIT)" event_limit="$(GRAPH_REBUILD_EVENT_LIMIT)" preview_limit="$(GRAPH_REBUILD_PREVIEW_LIMIT)"
+
+candidate-smoke:
+	@if [ -z "$(RUNTIME_ID)" ]; then echo "RUNTIME_ID is required, e.g. make candidate-smoke RUNTIME_ID=writer-okta-audit RULE_ID=rule-id CEREBRO_BASE_URL=https://..." >&2; exit 2; fi
+	CEREBRO_CANDIDATE_SMOKE_RUNTIME_ID="$(RUNTIME_ID)" CEREBRO_CANDIDATE_SMOKE_RULE_ID="$(RULE_ID)" CEREBRO_CANDIDATE_SMOKE_EVENT_LIMIT="$(CANDIDATE_SMOKE_EVENT_LIMIT)" python3 scripts/candidate_smoke.py
 
 lint: lint-bootstrap
 	$(GOLANGCI_LINT) run --timeout 5m $(APP_PACKAGES)

--- a/docs/FINDING_CANDIDATE_OPERATIONS.md
+++ b/docs/FINDING_CANDIDATE_OPERATIONS.md
@@ -1,0 +1,87 @@
+# Finding Candidate Operations
+
+Candidate findings let operators evaluate rules against real runtime data without
+writing production findings or evidence. Promotion is the explicit handoff from a
+reviewed candidate snapshot into production finding state.
+
+## Smoke Validation
+
+Run the deployed candidate API smoke against a runtime with known replay data:
+
+```bash
+make candidate-smoke \
+  CEREBRO_BASE_URL=https://cerebro.sec-dev.example \
+  CEREBRO_API_KEY="$CEREBRO_API_KEY" \
+  RUNTIME_ID=writer-okta-audit \
+  RULE_ID=rule-id \
+  CANDIDATE_SMOKE_EVENT_LIMIT=25
+```
+
+The smoke validates:
+
+- `/health` responds.
+- Candidate evaluation completes for the runtime.
+- Candidate list/get APIs can read persisted candidates.
+- Production findings for the same runtime/rule are unchanged by candidate-only evaluation.
+
+If a quiet runtime is intentionally expected to produce no candidate rows, set
+`CEREBRO_CANDIDATE_SMOKE_ALLOW_EMPTY=true`. Do not use that for release smoke
+coverage unless the runtime/rule pair is known to be quiet.
+
+## Telemetry
+
+Candidate workflows emit structured telemetry events:
+
+- `finding_candidate.run`: one event per completed or failed candidate run, with
+  `runtime_id`, `rule_id`, `status`, `events_evaluated`, `events_matched`,
+  `candidates_emitted`, and `duration_ms`.
+- `finding_candidate.list`: list-time health signal with `candidate_count`,
+  `open_candidate_count`, `promoted_count`, and `stale_candidate_count`.
+- `finding_candidate.promotion`: one event per promotion or idempotent
+  re-promotion, with `candidate_id`, `finding_id`, `decision_id`, `outcome`,
+  `observation_count`, and `duration_ms`.
+
+These events are intentionally low-cardinality except for object IDs needed to
+debug one workflow. Dashboards should aggregate by `runtime_id`, `rule_id`,
+`status`, and `outcome`.
+
+## Promotion Authorization
+
+Promotion mutates production finding state. When API auth is enabled, promotion
+requires the dedicated scope:
+
+```text
+cerebro.finding_candidates.promote
+```
+
+Tenant authorization still applies before the scope check. Read-only security
+clients with `cerebro.cosmo.security.read` can list/get candidates but cannot
+promote them.
+
+## Next Lifecycle Slice
+
+The current durable statuses are `candidate` and `promoted`. The next lifecycle
+slice should add:
+
+- `rejected`: reviewer confirmed this candidate should not become a production finding.
+- `expired`: candidate aged out without review after a configured TTL.
+- `superseded`: a newer candidate fingerprint or rule version replaced this snapshot.
+
+Recommended follow-up API additions:
+
+- `POST /finding-candidates/{candidateID}/reject`
+- `POST /finding-candidates/{candidateID}/expire`
+- `GET /source-runtimes/{runtimeID}/finding-candidates?status=rejected`
+
+Graph projection should materialize candidate nodes before promotion:
+
+```mermaid
+flowchart LR
+  Candidate["finding_candidate"] -->|"based_on"| Evidence["evidence"]
+  Candidate -->|"targets"| Resource["resource"]
+  Decision["decision"] -->|"targets"| Candidate
+  Finding["finding"] -->|"promoted_from"| Candidate
+```
+
+This gives reviewers and agents a queryable trail for what was tested, rejected,
+expired, superseded, or promoted.

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -1611,6 +1611,10 @@ func (a *App) handlePromoteFindingCandidate(w http.ResponseWriter, r *http.Reque
 		writeFindingError(w, err)
 		return
 	}
+	if err := authorizeFindingCandidatePromotion(r.Context()); err != nil {
+		writeFindingError(w, err)
+		return
+	}
 	response, err := a.findingService().PromoteFindingCandidate(r.Context(), findings.PromoteCandidateRequest{
 		CandidateID:           request.GetId(),
 		PromotedBy:            request.GetPromotedBy(),
@@ -2018,6 +2022,9 @@ func (s *bootstrapService) PromoteFindingCandidate(ctx context.Context, req *con
 		return nil, findingConnectError(err)
 	}
 	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), candidate.RuntimeID, false); err != nil {
+		return nil, findingConnectError(err)
+	}
+	if err := authorizeFindingCandidatePromotion(ctx); err != nil {
 		return nil, findingConnectError(err)
 	}
 	response, err := service.PromoteFindingCandidate(ctx, findings.PromoteCandidateRequest{

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2321,6 +2321,52 @@ func TestScopeForHTTPRequestIncludesGRCAskPost(t *testing.T) {
 	}
 }
 
+func TestCandidatePromotionRequiresExplicitScope(t *testing.T) {
+	readOnly := context.WithValue(context.Background(), authContextKey{}, authContext{
+		principal: authPrincipal{Scopes: []string{scopeCosmoSecurityRead}},
+	})
+	if err := authorizeFindingCandidatePromotion(readOnly); !errors.Is(err, errScopeForbidden) {
+		t.Fatalf("authorizeFindingCandidatePromotion(read-only) error = %v, want %v", err, errScopeForbidden)
+	}
+	promoter := context.WithValue(context.Background(), authContextKey{}, authContext{
+		principal: authPrincipal{Scopes: []string{scopeFindingCandidatePromote}},
+	})
+	if err := authorizeFindingCandidatePromotion(promoter); err != nil {
+		t.Fatalf("authorizeFindingCandidatePromotion(promoter) error = %v", err)
+	}
+	if err := authorizeFindingCandidatePromotion(context.Background()); err != nil {
+		t.Fatalf("authorizeFindingCandidatePromotion(no auth) error = %v", err)
+	}
+}
+
+func TestCandidateScopesCoverReadAndPromotionRoutes(t *testing.T) {
+	for _, tt := range []struct {
+		method string
+		path   string
+		want   string
+	}{
+		{method: http.MethodGet, path: "/finding-candidates/candidate-1", want: scopeCosmoSecurityRead},
+		{method: http.MethodPost, path: "/finding-candidates/candidate-1/promote", want: scopeFindingCandidatePromote},
+	} {
+		req := httptest.NewRequest(tt.method, tt.path, nil)
+		if got := scopeForHTTPRequest(req); got != tt.want {
+			t.Fatalf("scopeForHTTPRequest(%s %s) = %q, want %q", tt.method, tt.path, got, tt.want)
+		}
+	}
+	for _, tt := range []struct {
+		procedure string
+		want      string
+	}{
+		{procedure: cerebrov1connect.BootstrapServiceListFindingCandidatesProcedure, want: scopeCosmoSecurityRead},
+		{procedure: cerebrov1connect.BootstrapServiceGetFindingCandidateProcedure, want: scopeCosmoSecurityRead},
+		{procedure: cerebrov1connect.BootstrapServicePromoteFindingCandidateProcedure, want: scopeFindingCandidatePromote},
+	} {
+		if got := scopeForConnectProcedure(tt.procedure); got != tt.want {
+			t.Fatalf("scopeForConnectProcedure(%s) = %q, want %q", tt.procedure, got, tt.want)
+		}
+	}
+}
+
 func TestScopedCosmoCredentialEnforcesConnectProcedures(t *testing.T) {
 	cfg := config.Config{
 		HTTPAddr:        "127.0.0.1:0",

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -488,7 +488,18 @@ func authorizeTenantID(ctx context.Context, tenantID string) error {
 	return nil
 }
 
-const scopeCosmoSecurityRead = "cerebro.cosmo.security.read"
+func authorizeFindingCandidatePromotion(ctx context.Context) error {
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	if !ok {
+		return nil
+	}
+	return authorizePrincipalScope(auth.principal, scopeFindingCandidatePromote)
+}
+
+const (
+	scopeCosmoSecurityRead       = "cerebro.cosmo.security.read"
+	scopeFindingCandidatePromote = "cerebro.finding_candidates.promote"
+)
 
 func scopeForDeviceRoute(method string, path string) string {
 	switch {
@@ -556,6 +567,9 @@ func scopeForHTTPRequest(r *http.Request) string {
 		return scope
 	}
 	if r.Method != http.MethodGet {
+		if r.Method == http.MethodPost && strings.HasPrefix(path, "/finding-candidates/") && strings.HasSuffix(path, "/promote") {
+			return scopeFindingCandidatePromote
+		}
 		return ""
 	}
 	switch {
@@ -564,6 +578,8 @@ func scopeForHTTPRequest(r *http.Request) string {
 	case path == "/source-runtimes" || strings.HasPrefix(path, "/source-runtimes/"):
 		return scopeCosmoSecurityRead
 	case strings.HasPrefix(path, "/findings/"):
+		return scopeCosmoSecurityRead
+	case strings.HasPrefix(path, "/finding-candidates/"):
 		return scopeCosmoSecurityRead
 	case strings.HasPrefix(path, "/finding-evaluation-runs/"), strings.HasPrefix(path, "/finding-evidence/"):
 		return scopeCosmoSecurityRead
@@ -604,6 +620,8 @@ func scopeForConnectProcedure(procedure string) string {
 		cerebrov1connect.BootstrapServiceListClaimsProcedure,
 		cerebrov1connect.BootstrapServiceListFindingsProcedure,
 		cerebrov1connect.BootstrapServiceGetFindingProcedure,
+		cerebrov1connect.BootstrapServiceListFindingCandidatesProcedure,
+		cerebrov1connect.BootstrapServiceGetFindingCandidateProcedure,
 		cerebrov1connect.BootstrapServiceListFindingEvaluationRunsProcedure,
 		cerebrov1connect.BootstrapServiceGetFindingEvaluationRunProcedure,
 		cerebrov1connect.BootstrapServiceListFindingEvidenceProcedure,
@@ -613,6 +631,8 @@ func scopeForConnectProcedure(procedure string) string {
 		cerebrov1connect.BootstrapServiceListGraphIngestRunsProcedure,
 		cerebrov1connect.BootstrapServiceCheckGraphIngestHealthProcedure:
 		return scopeCosmoSecurityRead
+	case cerebrov1connect.BootstrapServicePromoteFindingCandidateProcedure:
+		return scopeFindingCandidatePromote
 	default:
 		return ""
 	}
@@ -1195,7 +1215,7 @@ func accessAuditRouteFamily(route string) string {
 		return "finding_evaluation"
 	case strings.Contains(route, "/finding-evidence"):
 		return "finding_evidence"
-	case strings.Contains(route, "/finding-rules"), strings.Contains(route, "/findings"), strings.Contains(route, "/vulnerability-findings"):
+	case strings.Contains(route, "/finding-rules"), strings.Contains(route, "/finding-candidates"), strings.Contains(route, "/findings"), strings.Contains(route, "/vulnerability-findings"):
 		return "finding"
 	case strings.Contains(route, "/grc/"):
 		return "grc"
@@ -1253,44 +1273,48 @@ func accessAuditConnectProcedure(path string) string {
 }
 
 var knownAccessAuditConnectProcedures = map[string]struct{}{
-	cerebrov1connect.BootstrapServiceGetVersionProcedure:                        {},
-	cerebrov1connect.BootstrapServiceCheckHealthProcedure:                       {},
-	cerebrov1connect.BootstrapServiceListReportDefinitionsProcedure:             {},
-	cerebrov1connect.BootstrapServiceListFindingRulesProcedure:                  {},
-	cerebrov1connect.BootstrapServiceRunReportProcedure:                         {},
-	cerebrov1connect.BootstrapServiceGetReportRunProcedure:                      {},
-	cerebrov1connect.BootstrapServiceListSourcesProcedure:                       {},
-	cerebrov1connect.BootstrapServiceCheckSourceProcedure:                       {},
-	cerebrov1connect.BootstrapServiceDiscoverSourceProcedure:                    {},
-	cerebrov1connect.BootstrapServiceReadSourceProcedure:                        {},
-	cerebrov1connect.BootstrapServicePutSourceRuntimeProcedure:                  {},
-	cerebrov1connect.BootstrapServiceGetSourceRuntimeProcedure:                  {},
-	cerebrov1connect.BootstrapServiceSyncSourceRuntimeProcedure:                 {},
-	cerebrov1connect.BootstrapServiceWriteClaimsProcedure:                       {},
-	cerebrov1connect.BootstrapServiceListClaimsProcedure:                        {},
-	cerebrov1connect.BootstrapServiceListFindingsProcedure:                      {},
-	cerebrov1connect.BootstrapServiceGetFindingProcedure:                        {},
-	cerebrov1connect.BootstrapServiceResolveFindingProcedure:                    {},
-	cerebrov1connect.BootstrapServiceSuppressFindingProcedure:                   {},
-	cerebrov1connect.BootstrapServiceAssignFindingProcedure:                     {},
-	cerebrov1connect.BootstrapServiceSetFindingDueDateProcedure:                 {},
-	cerebrov1connect.BootstrapServiceAddFindingNoteProcedure:                    {},
-	cerebrov1connect.BootstrapServiceLinkFindingTicketProcedure:                 {},
-	cerebrov1connect.BootstrapServiceListFindingEvaluationRunsProcedure:         {},
-	cerebrov1connect.BootstrapServiceGetFindingEvaluationRunProcedure:           {},
-	cerebrov1connect.BootstrapServiceListFindingEvidenceProcedure:               {},
-	cerebrov1connect.BootstrapServiceGetFindingEvidenceProcedure:                {},
-	cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingRulesProcedure: {},
-	cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingsProcedure:     {},
-	cerebrov1connect.BootstrapServiceWriteDecisionProcedure:                     {},
-	cerebrov1connect.BootstrapServiceWriteActionProcedure:                       {},
-	cerebrov1connect.BootstrapServiceWriteOutcomeProcedure:                      {},
-	cerebrov1connect.BootstrapServiceReplayWorkflowEventsProcedure:              {},
-	cerebrov1connect.BootstrapServiceGetEntityNeighborhoodProcedure:             {},
-	cerebrov1connect.BootstrapServiceRunGraphIngestRuntimeProcedure:             {},
-	cerebrov1connect.BootstrapServiceGetGraphIngestRunProcedure:                 {},
-	cerebrov1connect.BootstrapServiceListGraphIngestRunsProcedure:               {},
-	cerebrov1connect.BootstrapServiceCheckGraphIngestHealthProcedure:            {},
+	cerebrov1connect.BootstrapServiceGetVersionProcedure:                             {},
+	cerebrov1connect.BootstrapServiceCheckHealthProcedure:                            {},
+	cerebrov1connect.BootstrapServiceListReportDefinitionsProcedure:                  {},
+	cerebrov1connect.BootstrapServiceListFindingRulesProcedure:                       {},
+	cerebrov1connect.BootstrapServiceRunReportProcedure:                              {},
+	cerebrov1connect.BootstrapServiceGetReportRunProcedure:                           {},
+	cerebrov1connect.BootstrapServiceListSourcesProcedure:                            {},
+	cerebrov1connect.BootstrapServiceCheckSourceProcedure:                            {},
+	cerebrov1connect.BootstrapServiceDiscoverSourceProcedure:                         {},
+	cerebrov1connect.BootstrapServiceReadSourceProcedure:                             {},
+	cerebrov1connect.BootstrapServicePutSourceRuntimeProcedure:                       {},
+	cerebrov1connect.BootstrapServiceGetSourceRuntimeProcedure:                       {},
+	cerebrov1connect.BootstrapServiceSyncSourceRuntimeProcedure:                      {},
+	cerebrov1connect.BootstrapServiceWriteClaimsProcedure:                            {},
+	cerebrov1connect.BootstrapServiceListClaimsProcedure:                             {},
+	cerebrov1connect.BootstrapServiceListFindingsProcedure:                           {},
+	cerebrov1connect.BootstrapServiceGetFindingProcedure:                             {},
+	cerebrov1connect.BootstrapServiceListFindingCandidatesProcedure:                  {},
+	cerebrov1connect.BootstrapServiceGetFindingCandidateProcedure:                    {},
+	cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingCandidatesProcedure: {},
+	cerebrov1connect.BootstrapServicePromoteFindingCandidateProcedure:                {},
+	cerebrov1connect.BootstrapServiceResolveFindingProcedure:                         {},
+	cerebrov1connect.BootstrapServiceSuppressFindingProcedure:                        {},
+	cerebrov1connect.BootstrapServiceAssignFindingProcedure:                          {},
+	cerebrov1connect.BootstrapServiceSetFindingDueDateProcedure:                      {},
+	cerebrov1connect.BootstrapServiceAddFindingNoteProcedure:                         {},
+	cerebrov1connect.BootstrapServiceLinkFindingTicketProcedure:                      {},
+	cerebrov1connect.BootstrapServiceListFindingEvaluationRunsProcedure:              {},
+	cerebrov1connect.BootstrapServiceGetFindingEvaluationRunProcedure:                {},
+	cerebrov1connect.BootstrapServiceListFindingEvidenceProcedure:                    {},
+	cerebrov1connect.BootstrapServiceGetFindingEvidenceProcedure:                     {},
+	cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingRulesProcedure:      {},
+	cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingsProcedure:          {},
+	cerebrov1connect.BootstrapServiceWriteDecisionProcedure:                          {},
+	cerebrov1connect.BootstrapServiceWriteActionProcedure:                            {},
+	cerebrov1connect.BootstrapServiceWriteOutcomeProcedure:                           {},
+	cerebrov1connect.BootstrapServiceReplayWorkflowEventsProcedure:                   {},
+	cerebrov1connect.BootstrapServiceGetEntityNeighborhoodProcedure:                  {},
+	cerebrov1connect.BootstrapServiceRunGraphIngestRuntimeProcedure:                  {},
+	cerebrov1connect.BootstrapServiceGetGraphIngestRunProcedure:                      {},
+	cerebrov1connect.BootstrapServiceListGraphIngestRunsProcedure:                    {},
+	cerebrov1connect.BootstrapServiceCheckGraphIngestHealthProcedure:                 {},
 }
 
 func fallbackAccessAuditRoute(method string, path string) string {
@@ -1320,6 +1344,8 @@ func fallbackAccessAuditRoute(method string, path string) string {
 		return prefix + "/finding-rules"
 	case strings.HasPrefix(path, "/findings/"):
 		return prefix + fallbackFindingRoute(path)
+	case strings.HasPrefix(path, "/finding-candidates/"):
+		return prefix + fallbackFindingCandidateRoute(path)
 	case strings.HasPrefix(path, "/finding-evaluation-runs/"):
 		return prefix + "/finding-evaluation-runs/{runID}"
 	case strings.HasPrefix(path, "/finding-evidence/"):
@@ -1356,10 +1382,12 @@ func fallbackRuntimeRoute(path string) string {
 	}
 	parts := strings.SplitN(suffix, "/", 2)
 	switch parts[1] {
-	case "sync", "graph-ingest-runs", "claims", "findings", "finding-evidence", "finding-evaluation-runs":
+	case "sync", "graph-ingest-runs", "claims", "findings", "finding-candidates", "finding-evidence", "finding-evaluation-runs":
 		return "/source-runtimes/{runtimeID}/" + parts[1]
 	case "finding-rules/evaluate":
 		return "/source-runtimes/{runtimeID}/finding-rules/evaluate"
+	case "finding-candidates/evaluate":
+		return "/source-runtimes/{runtimeID}/finding-candidates/evaluate"
 	case "findings/evaluate":
 		return "/source-runtimes/{runtimeID}/findings/evaluate"
 	default:
@@ -1378,6 +1406,20 @@ func fallbackFindingRoute(path string) string {
 		return "/findings/{findingID}/" + parts[1]
 	default:
 		return "/findings/{findingID}/{subresource}"
+	}
+}
+
+func fallbackFindingCandidateRoute(path string) string {
+	suffix := strings.TrimPrefix(path, "/finding-candidates/")
+	if !strings.Contains(suffix, "/") {
+		return "/finding-candidates/{candidateID}"
+	}
+	parts := strings.SplitN(suffix, "/", 2)
+	switch parts[1] {
+	case "promote":
+		return "/finding-candidates/{candidateID}/promote"
+	default:
+		return "/finding-candidates/{candidateID}/{subresource}"
 	}
 }
 

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -14,6 +14,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
@@ -190,6 +191,7 @@ func (s *Service) EvaluateSourceRuntimeCandidateRules(ctx context.Context, reque
 		if err := s.candidateStore.PutFindingCandidateRun(ctx, state.run); err != nil {
 			return nil, s.markCandidateEvaluationsFailed(ctx, unfinishedCandidateEvaluations(states, state), fmt.Errorf("persist finding candidate run %q: %w", state.run.ID, err))
 		}
+		emitFindingCandidateRunTelemetry(ctx, state.run)
 	}
 	return result, nil
 }
@@ -219,6 +221,7 @@ func (s *Service) ListFindingCandidates(ctx context.Context, request ListCandida
 	if err != nil {
 		return nil, fmt.Errorf("list finding candidates for runtime %q: %w", runtimeID, err)
 	}
+	emitFindingCandidateListTelemetry(ctx, runtimeID, candidates, request)
 	return &ListCandidatesResult{Candidates: candidates}, nil
 }
 
@@ -244,6 +247,7 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	if s == nil || s.candidateStore == nil || s.store == nil || s.evidenceStore == nil {
 		return nil, ErrRuntimeUnavailable
 	}
+	startedAt := time.Now().UTC()
 	candidateID := strings.TrimSpace(request.CandidateID)
 	if candidateID == "" {
 		return nil, fmt.Errorf("%w: finding candidate id is required", ErrInvalidRequest)
@@ -272,6 +276,7 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 		if err != nil {
 			return nil, err
 		}
+		emitFindingCandidatePromotionTelemetry(ctx, "already_promoted", candidate, finding, strings.TrimSpace(candidate.DecisionID), startedAt)
 		return &PromoteCandidateResult{Candidate: candidate, Finding: finding, DecisionID: strings.TrimSpace(candidate.DecisionID)}, nil
 	}
 	if candidate.Finding == nil {
@@ -329,6 +334,7 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	if err != nil {
 		return nil, err
 	}
+	emitFindingCandidatePromotionTelemetry(ctx, "promoted", promoted, stored, decisionID, startedAt)
 	return &PromoteCandidateResult{Candidate: promoted, Finding: stored, DecisionID: decisionID}, nil
 }
 
@@ -477,6 +483,74 @@ func candidateEvidenceIDs(evidence []*cerebrov1.FindingEvidence) []string {
 	return uniqueSortedStrings(ids)
 }
 
+func emitFindingCandidateRunTelemetry(ctx context.Context, run *ports.FindingCandidateRun) {
+	if run == nil {
+		return
+	}
+	durationMS := int64(0)
+	if !run.StartedAt.IsZero() && !run.FinishedAt.IsZero() {
+		durationMS = run.FinishedAt.Sub(run.StartedAt).Milliseconds()
+	}
+	telemetry.Event(ctx, "finding_candidate.run", telemetry.Attrs(
+		telemetry.Field{Key: "run_id", Value: strings.TrimSpace(run.ID)},
+		telemetry.Field{Key: "tenant_id", Value: strings.TrimSpace(run.TenantID)},
+		telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(run.RuntimeID)},
+		telemetry.Field{Key: "rule_id", Value: strings.TrimSpace(run.RuleID)},
+		telemetry.Field{Key: "status", Value: strings.TrimSpace(run.Status)},
+		telemetry.Field{Key: "event_limit", Value: run.EventLimit},
+		telemetry.Field{Key: "events_evaluated", Value: run.EventsEvaluated},
+		telemetry.Field{Key: "events_matched", Value: run.EventsMatched},
+		telemetry.Field{Key: "candidates_emitted", Value: run.Candidates},
+		telemetry.Field{Key: "duration_ms", Value: durationMS},
+	))
+}
+
+func emitFindingCandidateListTelemetry(ctx context.Context, runtimeID string, candidates []*ports.FindingCandidateRecord, request ListCandidatesRequest) {
+	candidateCount, promotedCount, staleCount := 0, 0, 0
+	now := time.Now().UTC()
+	for _, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		candidateCount++
+		if strings.EqualFold(strings.TrimSpace(candidate.Status), findingCandidateStatusPromoted) {
+			promotedCount++
+			continue
+		}
+		if !candidate.LastObservedAt.IsZero() && now.Sub(candidate.LastObservedAt.UTC()) > 7*24*time.Hour {
+			staleCount++
+		}
+	}
+	telemetry.Event(ctx, "finding_candidate.list", telemetry.Attrs(
+		telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(runtimeID)},
+		telemetry.Field{Key: "rule_id", Value: strings.TrimSpace(request.RuleID)},
+		telemetry.Field{Key: "status_filter", Value: strings.TrimSpace(request.Status)},
+		telemetry.Field{Key: "candidate_count", Value: candidateCount},
+		telemetry.Field{Key: "promoted_count", Value: promotedCount},
+		telemetry.Field{Key: "open_candidate_count", Value: candidateCount - promotedCount},
+		telemetry.Field{Key: "stale_candidate_count", Value: staleCount},
+	))
+}
+
+func emitFindingCandidatePromotionTelemetry(ctx context.Context, outcome string, candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, decisionID string, startedAt time.Time) {
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "outcome", Value: strings.TrimSpace(outcome)},
+		telemetry.Field{Key: "decision_id", Value: strings.TrimSpace(decisionID)},
+		telemetry.Field{Key: "duration_ms", Value: time.Since(startedAt).Milliseconds()},
+	)
+	if candidate != nil {
+		attrs = attrs.WithField(telemetry.Field{Key: "candidate_id", Value: strings.TrimSpace(candidate.ID)})
+		attrs = attrs.WithField(telemetry.Field{Key: "tenant_id", Value: strings.TrimSpace(candidate.TenantID)})
+		attrs = attrs.WithField(telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(candidate.RuntimeID)})
+		attrs = attrs.WithField(telemetry.Field{Key: "rule_id", Value: strings.TrimSpace(candidate.RuleID)})
+		attrs = attrs.WithField(telemetry.Field{Key: "observation_count", Value: candidate.ObservationCount})
+	}
+	if finding != nil {
+		attrs = attrs.WithField(telemetry.Field{Key: "finding_id", Value: strings.TrimSpace(finding.ID)})
+	}
+	telemetry.Event(ctx, "finding_candidate.promotion", attrs)
+}
+
 func (s *Service) markCandidateEvaluationFailed(ctx context.Context, state *candidateRuleEvaluationState, evaluationErr error) error {
 	if state == nil || state.run == nil {
 		return evaluationErr
@@ -489,6 +563,7 @@ func (s *Service) markCandidateEvaluationFailed(ctx context.Context, state *cand
 	if err := s.candidateStore.PutFindingCandidateRun(ctx, state.run); err != nil {
 		return errors.Join(evaluationErr, fmt.Errorf("persist finding candidate run %q: %w", state.run.ID, err))
 	}
+	emitFindingCandidateRunTelemetry(ctx, state.run)
 	state.failed = true
 	return nil
 }

--- a/scripts/candidate_smoke.py
+++ b/scripts/candidate_smoke.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Smoke-test finding candidate APIs against a deployed Cerebro service."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+BASE_URL = env("CEREBRO_BASE_URL", "http://127.0.0.1:8080").rstrip("/")
+API_KEY = env("CEREBRO_API_KEY") or env("CEREBRO_AUTH_TOKEN")
+RUNTIME_ID = env("CEREBRO_CANDIDATE_SMOKE_RUNTIME_ID") or env("RUNTIME_ID")
+RULE_ID = env("CEREBRO_CANDIDATE_SMOKE_RULE_ID") or env("RULE_ID")
+EVENT_LIMIT = env("CEREBRO_CANDIDATE_SMOKE_EVENT_LIMIT", "25")
+ALLOW_EMPTY = env("CEREBRO_CANDIDATE_SMOKE_ALLOW_EMPTY", "false").lower() in {"1", "true", "yes"}
+
+
+def fail(message: str) -> None:
+    print(f"candidate-smoke: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def request(method: str, path: str, query: dict[str, str] | None = None, body: dict | None = None) -> dict:
+    url = BASE_URL + path
+    if query:
+        filtered = {key: value for key, value in query.items() if value}
+        if filtered:
+            url += "?" + urllib.parse.urlencode(filtered, doseq=True)
+    data = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if API_KEY:
+        headers["Authorization"] = "Bearer " + API_KEY
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        fail(f"{method} {url} failed with HTTP {exc.code}: {detail}")
+    except urllib.error.URLError as exc:
+        fail(f"{method} {url} failed: {exc}")
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        fail(f"{method} {url} returned invalid JSON: {exc}")
+
+
+def require_runtime() -> None:
+    if not RUNTIME_ID:
+        fail("CEREBRO_CANDIDATE_SMOKE_RUNTIME_ID or RUNTIME_ID is required")
+    if not EVENT_LIMIT.isdigit() or int(EVENT_LIMIT) <= 0:
+        fail("CEREBRO_CANDIDATE_SMOKE_EVENT_LIMIT must be a positive integer")
+
+
+def finding_ids(payload: dict) -> set[str]:
+    return {
+        str(finding.get("id") or "")
+        for finding in payload.get("findings", [])
+        if finding.get("id")
+    }
+
+
+def candidates(payload: dict) -> list[dict]:
+    return [candidate for candidate in payload.get("candidates", []) if isinstance(candidate, dict)]
+
+
+def candidate_id(candidate: dict) -> str:
+    return str(candidate.get("id") or candidate.get("candidateId") or "")
+
+
+def main() -> None:
+    require_runtime()
+    runtime_path = "/source-runtimes/" + urllib.parse.quote(RUNTIME_ID, safe="")
+    candidate_query = {"rule_id": RULE_ID, "status": "candidate", "limit": "10"}
+    finding_query = {"rule_id": RULE_ID, "limit": "100"}
+
+    request("GET", "/health")
+    before_findings = finding_ids(request("GET", runtime_path + "/findings", finding_query))
+
+    request(
+        "POST",
+        runtime_path + "/finding-candidates/evaluate",
+        {"rule_id": RULE_ID, "event_limit": EVENT_LIMIT},
+        {},
+    )
+
+    listed = candidates(request("GET", runtime_path + "/finding-candidates", candidate_query))
+    if not listed and not ALLOW_EMPTY:
+        fail(
+            "candidate evaluation produced no persisted candidates; set "
+            "CEREBRO_CANDIDATE_SMOKE_ALLOW_EMPTY=true only for known quiet runtimes"
+        )
+    if listed:
+        first_id = candidate_id(listed[0])
+        if not first_id:
+            fail("listed candidate is missing id")
+        response = request("GET", "/finding-candidates/" + urllib.parse.quote(first_id, safe=""))
+        if not response.get("candidate"):
+            fail(f"get candidate {first_id} returned no candidate")
+
+    after_findings = finding_ids(request("GET", runtime_path + "/findings", finding_query))
+    if before_findings != after_findings:
+        fail("production findings changed during candidate-only evaluation")
+
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "base_url": BASE_URL,
+                "runtime_id": RUNTIME_ID,
+                "rule_id": RULE_ID,
+                "event_limit": int(EVENT_LIMIT),
+                "candidates_checked": len(listed),
+                "production_findings_unchanged": True,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a deployed-runtime candidate smoke validator and `make candidate-smoke` target.
- Emit structured telemetry for candidate runs, candidate list health, and promotion outcomes.
- Require explicit `cerebro.finding_candidates.promote` scope for candidate promotion when auth is enabled, while documenting the next lifecycle and graph projection slice.

## Test plan
- python3 -m py_compile scripts/candidate_smoke.py
- go test ./internal/findings ./internal/bootstrap
- go test ./...
- make check-structural
- make lint
- make check-arch check-structural-test
- make openapi-check openapi-lint
- git diff --check


Made with [Cursor](https://cursor.com)