### PR TITLE
Add finding candidate rejection flow

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -264,7 +264,7 @@ paths:
           in: query
           schema:
             type: string
-            enum: [candidate, promoted]
+            enum: [candidate, promoted, rejected]
         - name: fingerprint
           in: query
           schema:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -462,6 +462,31 @@ paths:
                     $ref: '#/components/schemas/FindingCandidate'
                   decision_id:
                     type: string
+  /finding-candidates/{candidateID}/reject:
+    post:
+      summary: Reject candidate finding
+      tags:
+        - Findings
+      parameters:
+        - $ref: '#/components/parameters/candidateID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RejectFindingCandidateRequest'
+      responses:
+        '200':
+          description: Rejected candidate metadata.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  candidate:
+                    $ref: '#/components/schemas/FindingCandidate'
+                  decision_id:
+                    type: string
   /findings/{findingID}/resolve:
     post:
       summary: Resolve finding
@@ -1743,7 +1768,7 @@ components:
           type: string
         status:
           type: string
-          enum: [candidate, promoted]
+          enum: [candidate, promoted, rejected]
         finding:
           $ref: '#/components/schemas/Finding'
         evidence:
@@ -1774,6 +1799,13 @@ components:
         promoted_at:
           type: string
           format: date-time
+        rejected_by:
+          type: string
+        rejection_rationale:
+          type: string
+        rejected_at:
+          type: string
+          format: date-time
         created_at:
           type: string
           format: date-time
@@ -1797,6 +1829,16 @@ components:
           type: boolean
         graph_coverage_reviewed:
           type: boolean
+    RejectFindingCandidateRequest:
+      type: object
+      required: [rejected_by, rationale]
+      properties:
+        rejected_by:
+          type: string
+          minLength: 1
+        rationale:
+          type: string
+          minLength: 1
     Finding:
       type: object
       properties:

--- a/docs/FINDING_CANDIDATE_OPERATIONS.md
+++ b/docs/FINDING_CANDIDATE_OPERATIONS.md
@@ -36,19 +36,24 @@ Candidate workflows emit structured telemetry events:
   `runtime_id`, `rule_id`, `status`, `events_evaluated`, `events_matched`,
   `candidates_emitted`, and `duration_ms`.
 - `finding_candidate.list`: list-time health signal with `candidate_count`,
-  `open_candidate_count`, `promoted_count`, and `stale_candidate_count`.
+  `open_candidate_count`, `promoted_count`, `rejected_count`, and
+  `stale_candidate_count`.
 - `finding_candidate.promotion`: one event per promotion or idempotent
   re-promotion, with `candidate_id`, `finding_id`, `decision_id`, `outcome`,
+  `observation_count`, and `duration_ms`.
+- `finding_candidate.rejection`: one event per rejection or idempotent
+  re-rejection, with `candidate_id`, `decision_id`, `outcome`,
   `observation_count`, and `duration_ms`.
 
 These events are intentionally low-cardinality except for object IDs needed to
 debug one workflow. Dashboards should aggregate by `runtime_id`, `rule_id`,
 `status`, and `outcome`.
 
-## Promotion Authorization
+## Candidate Lifecycle Authorization
 
-Promotion mutates production finding state. When API auth is enabled, promotion
-requires the dedicated scope:
+Promotion mutates production finding state, and rejection closes a reviewed
+candidate. When API auth is enabled, both lifecycle writes require the dedicated
+scope:
 
 ```text
 cerebro.finding_candidates.promote
@@ -56,20 +61,18 @@ cerebro.finding_candidates.promote
 
 Tenant authorization still applies before the scope check. Read-only security
 clients with `cerebro.cosmo.security.read` can list/get candidates but cannot
-promote them.
+promote or reject them.
 
 ## Next Lifecycle Slice
 
-The current durable statuses are `candidate` and `promoted`. The next lifecycle
-slice should add:
+The current durable statuses are `candidate`, `promoted`, and `rejected`. The next
+lifecycle slice should add:
 
-- `rejected`: reviewer confirmed this candidate should not become a production finding.
 - `expired`: candidate aged out without review after a configured TTL.
 - `superseded`: a newer candidate fingerprint or rule version replaced this snapshot.
 
 Recommended follow-up API additions:
 
-- `POST /finding-candidates/{candidateID}/reject`
 - `POST /finding-candidates/{candidateID}/expire`
 - `GET /source-runtimes/{runtimeID}/finding-candidates?status=rejected`
 

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -4777,11 +4777,11 @@ type FindingCandidate struct {
 	PromotionRationale string                 `protobuf:"bytes,16,opt,name=promotion_rationale,json=promotionRationale,proto3" json:"promotion_rationale,omitempty"`
 	ChangeTicket       string                 `protobuf:"bytes,17,opt,name=change_ticket,json=changeTicket,proto3" json:"change_ticket,omitempty"`
 	PromotedAt         *timestamppb.Timestamp `protobuf:"bytes,18,opt,name=promoted_at,json=promotedAt,proto3" json:"promoted_at,omitempty"`
-	RejectedBy         string                 `protobuf:"bytes,19,opt,name=rejected_by,json=rejectedBy,proto3" json:"rejected_by,omitempty"`
-	RejectionRationale string                 `protobuf:"bytes,20,opt,name=rejection_rationale,json=rejectionRationale,proto3" json:"rejection_rationale,omitempty"`
-	RejectedAt         *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=rejected_at,json=rejectedAt,proto3" json:"rejected_at,omitempty"`
-	CreatedAt          *timestamppb.Timestamp `protobuf:"bytes,22,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	UpdatedAt          *timestamppb.Timestamp `protobuf:"bytes,23,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	CreatedAt          *timestamppb.Timestamp `protobuf:"bytes,19,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt          *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	RejectedBy         string                 `protobuf:"bytes,21,opt,name=rejected_by,json=rejectedBy,proto3" json:"rejected_by,omitempty"`
+	RejectionRationale string                 `protobuf:"bytes,22,opt,name=rejection_rationale,json=rejectionRationale,proto3" json:"rejection_rationale,omitempty"`
+	RejectedAt         *timestamppb.Timestamp `protobuf:"bytes,23,opt,name=rejected_at,json=rejectedAt,proto3" json:"rejected_at,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -4942,6 +4942,20 @@ func (x *FindingCandidate) GetPromotedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *FindingCandidate) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *FindingCandidate) GetUpdatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UpdatedAt
+	}
+	return nil
+}
+
 func (x *FindingCandidate) GetRejectedBy() string {
 	if x != nil {
 		return x.RejectedBy
@@ -4959,20 +4973,6 @@ func (x *FindingCandidate) GetRejectionRationale() string {
 func (x *FindingCandidate) GetRejectedAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.RejectedAt
-	}
-	return nil
-}
-
-func (x *FindingCandidate) GetCreatedAt() *timestamppb.Timestamp {
-	if x != nil {
-		return x.CreatedAt
-	}
-	return nil
-}
-
-func (x *FindingCandidate) GetUpdatedAt() *timestamppb.Timestamp {
-	if x != nil {
-		return x.UpdatedAt
 	}
 	return nil
 }
@@ -8294,16 +8294,16 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x13promotion_rationale\x18\x10 \x01(\tR\x12promotionRationale\x12#\n" +
 	"\rchange_ticket\x18\x11 \x01(\tR\fchangeTicket\x12;\n" +
 	"\vpromoted_at\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"promotedAt\x12\x1f\n" +
-	"\vrejected_by\x18\x13 \x01(\tR\n" +
+	"promotedAt\x129\n" +
+	"\n" +
+	"created_at\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
+	"\n" +
+	"updated_at\x18\x14 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\x12\x1f\n" +
+	"\vrejected_by\x18\x15 \x01(\tR\n" +
 	"rejectedBy\x12/\n" +
-	"\x13rejection_rationale\x18\x14 \x01(\tR\x12rejectionRationale\x12;\n" +
-	"\vrejected_at\x18\x15 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"rejectedAt\x129\n" +
-	"\n" +
-	"created_at\x18\x16 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
-	"\n" +
-	"updated_at\x18\x17 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\xc9\x01\n" +
+	"\x13rejection_rationale\x18\x16 \x01(\tR\x12rejectionRationale\x12;\n" +
+	"\vrejected_at\x18\x17 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"rejectedAt\"\xc9\x01\n" +
 	"\x1cListFindingCandidatesRequest\x12\x1d\n" +
 	"\n" +
 	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12!\n" +
@@ -8868,9 +8868,9 @@ var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
 	123, // 79: cerebro.v1.FindingCandidate.first_observed_at:type_name -> google.protobuf.Timestamp
 	123, // 80: cerebro.v1.FindingCandidate.last_observed_at:type_name -> google.protobuf.Timestamp
 	123, // 81: cerebro.v1.FindingCandidate.promoted_at:type_name -> google.protobuf.Timestamp
-	123, // 82: cerebro.v1.FindingCandidate.rejected_at:type_name -> google.protobuf.Timestamp
-	123, // 83: cerebro.v1.FindingCandidate.created_at:type_name -> google.protobuf.Timestamp
-	123, // 84: cerebro.v1.FindingCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	123, // 82: cerebro.v1.FindingCandidate.created_at:type_name -> google.protobuf.Timestamp
+	123, // 83: cerebro.v1.FindingCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	123, // 84: cerebro.v1.FindingCandidate.rejected_at:type_name -> google.protobuf.Timestamp
 	72,  // 85: cerebro.v1.ListFindingCandidatesResponse.candidates:type_name -> cerebro.v1.FindingCandidate
 	72,  // 86: cerebro.v1.GetFindingCandidateResponse.candidate:type_name -> cerebro.v1.FindingCandidate
 	125, // 87: cerebro.v1.FindingCandidateRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec

--- a/gen/cerebro/v1/bootstrap.pb.go
+++ b/gen/cerebro/v1/bootstrap.pb.go
@@ -4777,8 +4777,11 @@ type FindingCandidate struct {
 	PromotionRationale string                 `protobuf:"bytes,16,opt,name=promotion_rationale,json=promotionRationale,proto3" json:"promotion_rationale,omitempty"`
 	ChangeTicket       string                 `protobuf:"bytes,17,opt,name=change_ticket,json=changeTicket,proto3" json:"change_ticket,omitempty"`
 	PromotedAt         *timestamppb.Timestamp `protobuf:"bytes,18,opt,name=promoted_at,json=promotedAt,proto3" json:"promoted_at,omitempty"`
-	CreatedAt          *timestamppb.Timestamp `protobuf:"bytes,19,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	UpdatedAt          *timestamppb.Timestamp `protobuf:"bytes,20,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	RejectedBy         string                 `protobuf:"bytes,19,opt,name=rejected_by,json=rejectedBy,proto3" json:"rejected_by,omitempty"`
+	RejectionRationale string                 `protobuf:"bytes,20,opt,name=rejection_rationale,json=rejectionRationale,proto3" json:"rejection_rationale,omitempty"`
+	RejectedAt         *timestamppb.Timestamp `protobuf:"bytes,21,opt,name=rejected_at,json=rejectedAt,proto3" json:"rejected_at,omitempty"`
+	CreatedAt          *timestamppb.Timestamp `protobuf:"bytes,22,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt          *timestamppb.Timestamp `protobuf:"bytes,23,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -4935,6 +4938,27 @@ func (x *FindingCandidate) GetChangeTicket() string {
 func (x *FindingCandidate) GetPromotedAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.PromotedAt
+	}
+	return nil
+}
+
+func (x *FindingCandidate) GetRejectedBy() string {
+	if x != nil {
+		return x.RejectedBy
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetRejectionRationale() string {
+	if x != nil {
+		return x.RejectionRationale
+	}
+	return ""
+}
+
+func (x *FindingCandidate) GetRejectedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RejectedAt
 	}
 	return nil
 }
@@ -5502,6 +5526,120 @@ func (x *PromoteFindingCandidateResponse) GetDecisionId() string {
 	return ""
 }
 
+// RejectFindingCandidateRequest records a reviewed candidate as not production-worthy.
+type RejectFindingCandidateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	RejectedBy    string                 `protobuf:"bytes,2,opt,name=rejected_by,json=rejectedBy,proto3" json:"rejected_by,omitempty"`
+	Rationale     string                 `protobuf:"bytes,3,opt,name=rationale,proto3" json:"rationale,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RejectFindingCandidateRequest) Reset() {
+	*x = RejectFindingCandidateRequest{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RejectFindingCandidateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RejectFindingCandidateRequest) ProtoMessage() {}
+
+func (x *RejectFindingCandidateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RejectFindingCandidateRequest.ProtoReflect.Descriptor instead.
+func (*RejectFindingCandidateRequest) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{80}
+}
+
+func (x *RejectFindingCandidateRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *RejectFindingCandidateRequest) GetRejectedBy() string {
+	if x != nil {
+		return x.RejectedBy
+	}
+	return ""
+}
+
+func (x *RejectFindingCandidateRequest) GetRationale() string {
+	if x != nil {
+		return x.Rationale
+	}
+	return ""
+}
+
+// RejectFindingCandidateResponse returns the rejected candidate and audit decision.
+type RejectFindingCandidateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Candidate     *FindingCandidate      `protobuf:"bytes,1,opt,name=candidate,proto3" json:"candidate,omitempty"`
+	DecisionId    string                 `protobuf:"bytes,2,opt,name=decision_id,json=decisionId,proto3" json:"decision_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RejectFindingCandidateResponse) Reset() {
+	*x = RejectFindingCandidateResponse{}
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RejectFindingCandidateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RejectFindingCandidateResponse) ProtoMessage() {}
+
+func (x *RejectFindingCandidateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RejectFindingCandidateResponse.ProtoReflect.Descriptor instead.
+func (*RejectFindingCandidateResponse) Descriptor() ([]byte, []int) {
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{81}
+}
+
+func (x *RejectFindingCandidateResponse) GetCandidate() *FindingCandidate {
+	if x != nil {
+		return x.Candidate
+	}
+	return nil
+}
+
+func (x *RejectFindingCandidateResponse) GetDecisionId() string {
+	if x != nil {
+		return x.DecisionId
+	}
+	return ""
+}
+
 // EvaluateSourceRuntimeFindingsRequest replays one stored runtime through one registered finding rule.
 type EvaluateSourceRuntimeFindingsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -5514,7 +5652,7 @@ type EvaluateSourceRuntimeFindingsRequest struct {
 
 func (x *EvaluateSourceRuntimeFindingsRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5526,7 +5664,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) String() string {
 func (*EvaluateSourceRuntimeFindingsRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[80]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5539,7 +5677,7 @@ func (x *EvaluateSourceRuntimeFindingsRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{80}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *EvaluateSourceRuntimeFindingsRequest) GetId() string {
@@ -5575,7 +5713,7 @@ type EvaluateSourceRuntimeFindingRulesRequest struct {
 
 func (x *EvaluateSourceRuntimeFindingRulesRequest) Reset() {
 	*x = EvaluateSourceRuntimeFindingRulesRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5587,7 +5725,7 @@ func (x *EvaluateSourceRuntimeFindingRulesRequest) String() string {
 func (*EvaluateSourceRuntimeFindingRulesRequest) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingRulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[81]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5600,7 +5738,7 @@ func (x *EvaluateSourceRuntimeFindingRulesRequest) ProtoReflect() protoreflect.M
 
 // Deprecated: Use EvaluateSourceRuntimeFindingRulesRequest.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingRulesRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{81}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *EvaluateSourceRuntimeFindingRulesRequest) GetId() string {
@@ -5637,7 +5775,7 @@ type FindingRuleEvaluation struct {
 
 func (x *FindingRuleEvaluation) Reset() {
 	*x = FindingRuleEvaluation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5649,7 +5787,7 @@ func (x *FindingRuleEvaluation) String() string {
 func (*FindingRuleEvaluation) ProtoMessage() {}
 
 func (x *FindingRuleEvaluation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[82]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5662,7 +5800,7 @@ func (x *FindingRuleEvaluation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FindingRuleEvaluation.ProtoReflect.Descriptor instead.
 func (*FindingRuleEvaluation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{82}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *FindingRuleEvaluation) GetRule() *RuleSpec {
@@ -5705,7 +5843,7 @@ type EvaluateSourceRuntimeFindingRulesResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingRulesResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingRulesResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5717,7 +5855,7 @@ func (x *EvaluateSourceRuntimeFindingRulesResponse) String() string {
 func (*EvaluateSourceRuntimeFindingRulesResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingRulesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[83]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5730,7 +5868,7 @@ func (x *EvaluateSourceRuntimeFindingRulesResponse) ProtoReflect() protoreflect.
 
 // Deprecated: Use EvaluateSourceRuntimeFindingRulesResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingRulesResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{83}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *EvaluateSourceRuntimeFindingRulesResponse) GetRuntime() *SourceRuntime {
@@ -5770,7 +5908,7 @@ type EvaluateSourceRuntimeFindingsResponse struct {
 
 func (x *EvaluateSourceRuntimeFindingsResponse) Reset() {
 	*x = EvaluateSourceRuntimeFindingsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5782,7 +5920,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) String() string {
 func (*EvaluateSourceRuntimeFindingsResponse) ProtoMessage() {}
 
 func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[84]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5795,7 +5933,7 @@ func (x *EvaluateSourceRuntimeFindingsResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use EvaluateSourceRuntimeFindingsResponse.ProtoReflect.Descriptor instead.
 func (*EvaluateSourceRuntimeFindingsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{84}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *EvaluateSourceRuntimeFindingsResponse) GetRuntime() *SourceRuntime {
@@ -5871,7 +6009,7 @@ type WriteDecisionRequest struct {
 
 func (x *WriteDecisionRequest) Reset() {
 	*x = WriteDecisionRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5883,7 +6021,7 @@ func (x *WriteDecisionRequest) String() string {
 func (*WriteDecisionRequest) ProtoMessage() {}
 
 func (x *WriteDecisionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[85]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5896,7 +6034,7 @@ func (x *WriteDecisionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteDecisionRequest.ProtoReflect.Descriptor instead.
 func (*WriteDecisionRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{85}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *WriteDecisionRequest) GetId() string {
@@ -6015,7 +6153,7 @@ type WriteDecisionResponse struct {
 
 func (x *WriteDecisionResponse) Reset() {
 	*x = WriteDecisionResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6027,7 +6165,7 @@ func (x *WriteDecisionResponse) String() string {
 func (*WriteDecisionResponse) ProtoMessage() {}
 
 func (x *WriteDecisionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[86]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6040,7 +6178,7 @@ func (x *WriteDecisionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteDecisionResponse.ProtoReflect.Descriptor instead.
 func (*WriteDecisionResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{86}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *WriteDecisionResponse) GetDecisionId() string {
@@ -6081,7 +6219,7 @@ type WriteActionRequest struct {
 
 func (x *WriteActionRequest) Reset() {
 	*x = WriteActionRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6093,7 +6231,7 @@ func (x *WriteActionRequest) String() string {
 func (*WriteActionRequest) ProtoMessage() {}
 
 func (x *WriteActionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[87]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6106,7 +6244,7 @@ func (x *WriteActionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteActionRequest.ProtoReflect.Descriptor instead.
 func (*WriteActionRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{87}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *WriteActionRequest) GetId() string {
@@ -6226,7 +6364,7 @@ type WriteActionResponse struct {
 
 func (x *WriteActionResponse) Reset() {
 	*x = WriteActionResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6238,7 +6376,7 @@ func (x *WriteActionResponse) String() string {
 func (*WriteActionResponse) ProtoMessage() {}
 
 func (x *WriteActionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[88]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6251,7 +6389,7 @@ func (x *WriteActionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteActionResponse.ProtoReflect.Descriptor instead.
 func (*WriteActionResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{88}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *WriteActionResponse) GetActionId() string {
@@ -6297,7 +6435,7 @@ type WriteOutcomeRequest struct {
 
 func (x *WriteOutcomeRequest) Reset() {
 	*x = WriteOutcomeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6309,7 +6447,7 @@ func (x *WriteOutcomeRequest) String() string {
 func (*WriteOutcomeRequest) ProtoMessage() {}
 
 func (x *WriteOutcomeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[89]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6322,7 +6460,7 @@ func (x *WriteOutcomeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteOutcomeRequest.ProtoReflect.Descriptor instead.
 func (*WriteOutcomeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{89}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *WriteOutcomeRequest) GetId() string {
@@ -6428,7 +6566,7 @@ type WriteOutcomeResponse struct {
 
 func (x *WriteOutcomeResponse) Reset() {
 	*x = WriteOutcomeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6440,7 +6578,7 @@ func (x *WriteOutcomeResponse) String() string {
 func (*WriteOutcomeResponse) ProtoMessage() {}
 
 func (x *WriteOutcomeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[90]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6453,7 +6591,7 @@ func (x *WriteOutcomeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteOutcomeResponse.ProtoReflect.Descriptor instead.
 func (*WriteOutcomeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{90}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *WriteOutcomeResponse) GetOutcomeId() string {
@@ -6490,7 +6628,7 @@ type ReplayWorkflowEventsRequest struct {
 
 func (x *ReplayWorkflowEventsRequest) Reset() {
 	*x = ReplayWorkflowEventsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6502,7 +6640,7 @@ func (x *ReplayWorkflowEventsRequest) String() string {
 func (*ReplayWorkflowEventsRequest) ProtoMessage() {}
 
 func (x *ReplayWorkflowEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[91]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6515,7 +6653,7 @@ func (x *ReplayWorkflowEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayWorkflowEventsRequest.ProtoReflect.Descriptor instead.
 func (*ReplayWorkflowEventsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{91}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *ReplayWorkflowEventsRequest) GetKindPrefix() string {
@@ -6559,7 +6697,7 @@ type ReplayWorkflowEventsResponse struct {
 
 func (x *ReplayWorkflowEventsResponse) Reset() {
 	*x = ReplayWorkflowEventsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6571,7 +6709,7 @@ func (x *ReplayWorkflowEventsResponse) String() string {
 func (*ReplayWorkflowEventsResponse) ProtoMessage() {}
 
 func (x *ReplayWorkflowEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[92]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6584,7 +6722,7 @@ func (x *ReplayWorkflowEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayWorkflowEventsResponse.ProtoReflect.Descriptor instead.
 func (*ReplayWorkflowEventsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{92}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *ReplayWorkflowEventsResponse) GetEventsRead() uint32 {
@@ -6627,7 +6765,7 @@ type GraphEntity struct {
 
 func (x *GraphEntity) Reset() {
 	*x = GraphEntity{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6639,7 +6777,7 @@ func (x *GraphEntity) String() string {
 func (*GraphEntity) ProtoMessage() {}
 
 func (x *GraphEntity) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[93]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6652,7 +6790,7 @@ func (x *GraphEntity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphEntity.ProtoReflect.Descriptor instead.
 func (*GraphEntity) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{93}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *GraphEntity) GetUrn() string {
@@ -6688,7 +6826,7 @@ type GraphRelation struct {
 
 func (x *GraphRelation) Reset() {
 	*x = GraphRelation{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[94]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6700,7 +6838,7 @@ func (x *GraphRelation) String() string {
 func (*GraphRelation) ProtoMessage() {}
 
 func (x *GraphRelation) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[94]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6713,7 +6851,7 @@ func (x *GraphRelation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphRelation.ProtoReflect.Descriptor instead.
 func (*GraphRelation) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{94}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *GraphRelation) GetFromUrn() string {
@@ -6748,7 +6886,7 @@ type GetEntityNeighborhoodRequest struct {
 
 func (x *GetEntityNeighborhoodRequest) Reset() {
 	*x = GetEntityNeighborhoodRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[95]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6760,7 +6898,7 @@ func (x *GetEntityNeighborhoodRequest) String() string {
 func (*GetEntityNeighborhoodRequest) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[95]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6773,7 +6911,7 @@ func (x *GetEntityNeighborhoodRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodRequest.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{95}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *GetEntityNeighborhoodRequest) GetRootUrn() string {
@@ -6802,7 +6940,7 @@ type GetEntityNeighborhoodResponse struct {
 
 func (x *GetEntityNeighborhoodResponse) Reset() {
 	*x = GetEntityNeighborhoodResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[96]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6814,7 +6952,7 @@ func (x *GetEntityNeighborhoodResponse) String() string {
 func (*GetEntityNeighborhoodResponse) ProtoMessage() {}
 
 func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[96]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6827,7 +6965,7 @@ func (x *GetEntityNeighborhoodResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEntityNeighborhoodResponse.ProtoReflect.Descriptor instead.
 func (*GetEntityNeighborhoodResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{96}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *GetEntityNeighborhoodResponse) GetRoot() *GraphEntity {
@@ -6878,7 +7016,7 @@ type GraphIngestRun struct {
 
 func (x *GraphIngestRun) Reset() {
 	*x = GraphIngestRun{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[97]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6890,7 +7028,7 @@ func (x *GraphIngestRun) String() string {
 func (*GraphIngestRun) ProtoMessage() {}
 
 func (x *GraphIngestRun) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[97]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6903,7 +7041,7 @@ func (x *GraphIngestRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphIngestRun.ProtoReflect.Descriptor instead.
 func (*GraphIngestRun) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{97}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *GraphIngestRun) GetId() string {
@@ -7058,7 +7196,7 @@ type GraphIngestResult struct {
 
 func (x *GraphIngestResult) Reset() {
 	*x = GraphIngestResult{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[98]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7070,7 +7208,7 @@ func (x *GraphIngestResult) String() string {
 func (*GraphIngestResult) ProtoMessage() {}
 
 func (x *GraphIngestResult) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[98]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7083,7 +7221,7 @@ func (x *GraphIngestResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphIngestResult.ProtoReflect.Descriptor instead.
 func (*GraphIngestResult) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{98}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *GraphIngestResult) GetSourceId() string {
@@ -7216,7 +7354,7 @@ type GraphIngestRunResult struct {
 
 func (x *GraphIngestRunResult) Reset() {
 	*x = GraphIngestRunResult{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[99]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7228,7 +7366,7 @@ func (x *GraphIngestRunResult) String() string {
 func (*GraphIngestRunResult) ProtoMessage() {}
 
 func (x *GraphIngestRunResult) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[99]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7241,7 +7379,7 @@ func (x *GraphIngestRunResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GraphIngestRunResult.ProtoReflect.Descriptor instead.
 func (*GraphIngestRunResult) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{99}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *GraphIngestRunResult) GetRun() *GraphIngestRun {
@@ -7271,7 +7409,7 @@ type RunGraphIngestRuntimeRequest struct {
 
 func (x *RunGraphIngestRuntimeRequest) Reset() {
 	*x = RunGraphIngestRuntimeRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[100]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7283,7 +7421,7 @@ func (x *RunGraphIngestRuntimeRequest) String() string {
 func (*RunGraphIngestRuntimeRequest) ProtoMessage() {}
 
 func (x *RunGraphIngestRuntimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[100]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7296,7 +7434,7 @@ func (x *RunGraphIngestRuntimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunGraphIngestRuntimeRequest.ProtoReflect.Descriptor instead.
 func (*RunGraphIngestRuntimeRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{100}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *RunGraphIngestRuntimeRequest) GetRuntimeId() string {
@@ -7337,7 +7475,7 @@ type RunGraphIngestRuntimeResponse struct {
 
 func (x *RunGraphIngestRuntimeResponse) Reset() {
 	*x = RunGraphIngestRuntimeResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[101]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7349,7 +7487,7 @@ func (x *RunGraphIngestRuntimeResponse) String() string {
 func (*RunGraphIngestRuntimeResponse) ProtoMessage() {}
 
 func (x *RunGraphIngestRuntimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[101]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7362,7 +7500,7 @@ func (x *RunGraphIngestRuntimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunGraphIngestRuntimeResponse.ProtoReflect.Descriptor instead.
 func (*RunGraphIngestRuntimeResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{101}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *RunGraphIngestRuntimeResponse) GetResult() *GraphIngestRunResult {
@@ -7382,7 +7520,7 @@ type GetGraphIngestRunRequest struct {
 
 func (x *GetGraphIngestRunRequest) Reset() {
 	*x = GetGraphIngestRunRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[102]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7394,7 +7532,7 @@ func (x *GetGraphIngestRunRequest) String() string {
 func (*GetGraphIngestRunRequest) ProtoMessage() {}
 
 func (x *GetGraphIngestRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[102]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7407,7 +7545,7 @@ func (x *GetGraphIngestRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGraphIngestRunRequest.ProtoReflect.Descriptor instead.
 func (*GetGraphIngestRunRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{102}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *GetGraphIngestRunRequest) GetId() string {
@@ -7427,7 +7565,7 @@ type GetGraphIngestRunResponse struct {
 
 func (x *GetGraphIngestRunResponse) Reset() {
 	*x = GetGraphIngestRunResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[103]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7439,7 +7577,7 @@ func (x *GetGraphIngestRunResponse) String() string {
 func (*GetGraphIngestRunResponse) ProtoMessage() {}
 
 func (x *GetGraphIngestRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[103]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7452,7 +7590,7 @@ func (x *GetGraphIngestRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetGraphIngestRunResponse.ProtoReflect.Descriptor instead.
 func (*GetGraphIngestRunResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{103}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *GetGraphIngestRunResponse) GetRun() *GraphIngestRun {
@@ -7474,7 +7612,7 @@ type ListGraphIngestRunsRequest struct {
 
 func (x *ListGraphIngestRunsRequest) Reset() {
 	*x = ListGraphIngestRunsRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[104]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7486,7 +7624,7 @@ func (x *ListGraphIngestRunsRequest) String() string {
 func (*ListGraphIngestRunsRequest) ProtoMessage() {}
 
 func (x *ListGraphIngestRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[104]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7499,7 +7637,7 @@ func (x *ListGraphIngestRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGraphIngestRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListGraphIngestRunsRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{104}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *ListGraphIngestRunsRequest) GetRuntimeId() string {
@@ -7534,7 +7672,7 @@ type ListGraphIngestRunsResponse struct {
 
 func (x *ListGraphIngestRunsResponse) Reset() {
 	*x = ListGraphIngestRunsResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[105]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7546,7 +7684,7 @@ func (x *ListGraphIngestRunsResponse) String() string {
 func (*ListGraphIngestRunsResponse) ProtoMessage() {}
 
 func (x *ListGraphIngestRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[105]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7559,7 +7697,7 @@ func (x *ListGraphIngestRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGraphIngestRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListGraphIngestRunsResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{105}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *ListGraphIngestRunsResponse) GetRuns() []*GraphIngestRun {
@@ -7586,7 +7724,7 @@ type CheckGraphIngestHealthRequest struct {
 
 func (x *CheckGraphIngestHealthRequest) Reset() {
 	*x = CheckGraphIngestHealthRequest{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[106]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7598,7 +7736,7 @@ func (x *CheckGraphIngestHealthRequest) String() string {
 func (*CheckGraphIngestHealthRequest) ProtoMessage() {}
 
 func (x *CheckGraphIngestHealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[106]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7611,7 +7749,7 @@ func (x *CheckGraphIngestHealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckGraphIngestHealthRequest.ProtoReflect.Descriptor instead.
 func (*CheckGraphIngestHealthRequest) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{106}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *CheckGraphIngestHealthRequest) GetLimit() uint32 {
@@ -7635,7 +7773,7 @@ type CheckGraphIngestHealthResponse struct {
 
 func (x *CheckGraphIngestHealthResponse) Reset() {
 	*x = CheckGraphIngestHealthResponse{}
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[107]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7647,7 +7785,7 @@ func (x *CheckGraphIngestHealthResponse) String() string {
 func (*CheckGraphIngestHealthResponse) ProtoMessage() {}
 
 func (x *CheckGraphIngestHealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[107]
+	mi := &file_cerebro_v1_bootstrap_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7660,7 +7798,7 @@ func (x *CheckGraphIngestHealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckGraphIngestHealthResponse.ProtoReflect.Descriptor instead.
 func (*CheckGraphIngestHealthResponse) Descriptor() ([]byte, []int) {
-	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{107}
+	return file_cerebro_v1_bootstrap_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *CheckGraphIngestHealthResponse) GetStatus() string {
@@ -8132,7 +8270,7 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	" \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12;\n" +
 	"\vfinished_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"finishedAt\x12\x14\n" +
-	"\x05error\x18\f \x01(\tR\x05error\"\xef\x06\n" +
+	"\x05error\x18\f \x01(\tR\x05error\"\xfe\a\n" +
 	"\x10FindingCandidate\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12\x1d\n" +
@@ -8156,11 +8294,16 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x13promotion_rationale\x18\x10 \x01(\tR\x12promotionRationale\x12#\n" +
 	"\rchange_ticket\x18\x11 \x01(\tR\fchangeTicket\x12;\n" +
 	"\vpromoted_at\x18\x12 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"promotedAt\x129\n" +
+	"promotedAt\x12\x1f\n" +
+	"\vrejected_by\x18\x13 \x01(\tR\n" +
+	"rejectedBy\x12/\n" +
+	"\x13rejection_rationale\x18\x14 \x01(\tR\x12rejectionRationale\x12;\n" +
+	"\vrejected_at\x18\x15 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"rejectedAt\x129\n" +
 	"\n" +
-	"created_at\x18\x13 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
+	"created_at\x18\x16 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x129\n" +
 	"\n" +
-	"updated_at\x18\x14 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\xc9\x01\n" +
+	"updated_at\x18\x17 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\"\xc9\x01\n" +
 	"\x1cListFindingCandidatesRequest\x12\x1d\n" +
 	"\n" +
 	"runtime_id\x18\x01 \x01(\tR\truntimeId\x12!\n" +
@@ -8204,6 +8347,15 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\afinding\x18\x01 \x01(\v2\x13.cerebro.v1.FindingR\afinding\x12:\n" +
 	"\tcandidate\x18\x02 \x01(\v2\x1c.cerebro.v1.FindingCandidateR\tcandidate\x12\x1f\n" +
 	"\vdecision_id\x18\x03 \x01(\tR\n" +
+	"decisionId\"n\n" +
+	"\x1dRejectFindingCandidateRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
+	"\vrejected_by\x18\x02 \x01(\tR\n" +
+	"rejectedBy\x12\x1c\n" +
+	"\trationale\x18\x03 \x01(\tR\trationale\"}\n" +
+	"\x1eRejectFindingCandidateResponse\x12:\n" +
+	"\tcandidate\x18\x01 \x01(\v2\x1c.cerebro.v1.FindingCandidateR\tcandidate\x12\x1f\n" +
+	"\vdecision_id\x18\x02 \x01(\tR\n" +
 	"decisionId\"p\n" +
 	"$EvaluateSourceRuntimeFindingsRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
@@ -8435,7 +8587,7 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x19FINDING_ORDER_UNSPECIFIED\x10\x00\x12\x1f\n" +
 	"\x1bFINDING_ORDER_LAST_OBSERVED\x10\x01\x12\x1a\n" +
 	"\x16FINDING_ORDER_PRIORITY\x10\x02\x12\x1c\n" +
-	"\x18FINDING_ORDER_RISK_SCORE\x10\x032\xa0 \n" +
+	"\x18FINDING_ORDER_RISK_SCORE\x10\x032\x91!\n" +
 	"\x10BootstrapService\x12K\n" +
 	"\n" +
 	"GetVersion\x12\x1d.cerebro.v1.GetVersionRequest\x1a\x1e.cerebro.v1.GetVersionResponse\x12N\n" +
@@ -8461,7 +8613,8 @@ const file_cerebro_v1_bootstrap_proto_rawDesc = "" +
 	"\x15ListFindingCandidates\x12(.cerebro.v1.ListFindingCandidatesRequest\x1a).cerebro.v1.ListFindingCandidatesResponse\x12f\n" +
 	"\x13GetFindingCandidate\x12&.cerebro.v1.GetFindingCandidateRequest\x1a'.cerebro.v1.GetFindingCandidateResponse\x12\x9f\x01\n" +
 	"&EvaluateSourceRuntimeFindingCandidates\x129.cerebro.v1.EvaluateSourceRuntimeFindingCandidatesRequest\x1a:.cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse\x12r\n" +
-	"\x17PromoteFindingCandidate\x12*.cerebro.v1.PromoteFindingCandidateRequest\x1a+.cerebro.v1.PromoteFindingCandidateResponse\x12W\n" +
+	"\x17PromoteFindingCandidate\x12*.cerebro.v1.PromoteFindingCandidateRequest\x1a+.cerebro.v1.PromoteFindingCandidateResponse\x12o\n" +
+	"\x16RejectFindingCandidate\x12).cerebro.v1.RejectFindingCandidateRequest\x1a*.cerebro.v1.RejectFindingCandidateResponse\x12W\n" +
 	"\x0eResolveFinding\x12!.cerebro.v1.ResolveFindingRequest\x1a\".cerebro.v1.ResolveFindingResponse\x12Z\n" +
 	"\x0fSuppressFinding\x12\".cerebro.v1.SuppressFindingRequest\x1a#.cerebro.v1.SuppressFindingResponse\x12T\n" +
 	"\rAssignFinding\x12 .cerebro.v1.AssignFindingRequest\x1a!.cerebro.v1.AssignFindingResponse\x12`\n" +
@@ -8497,7 +8650,7 @@ func file_cerebro_v1_bootstrap_proto_rawDescGZIP() []byte {
 }
 
 var file_cerebro_v1_bootstrap_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 119)
+var file_cerebro_v1_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 121)
 var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(FindingStatus)(0),                                     // 0: cerebro.v1.FindingStatus
 	(FindingOrder)(0),                                      // 1: cerebro.v1.FindingOrder
@@ -8581,272 +8734,278 @@ var file_cerebro_v1_bootstrap_proto_goTypes = []any{
 	(*EvaluateSourceRuntimeFindingCandidatesResponse)(nil), // 79: cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse
 	(*PromoteFindingCandidateRequest)(nil),                 // 80: cerebro.v1.PromoteFindingCandidateRequest
 	(*PromoteFindingCandidateResponse)(nil),                // 81: cerebro.v1.PromoteFindingCandidateResponse
-	(*EvaluateSourceRuntimeFindingsRequest)(nil),           // 82: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	(*EvaluateSourceRuntimeFindingRulesRequest)(nil),       // 83: cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
-	(*FindingRuleEvaluation)(nil),                          // 84: cerebro.v1.FindingRuleEvaluation
-	(*EvaluateSourceRuntimeFindingRulesResponse)(nil),      // 85: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
-	(*EvaluateSourceRuntimeFindingsResponse)(nil),          // 86: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	(*WriteDecisionRequest)(nil),                           // 87: cerebro.v1.WriteDecisionRequest
-	(*WriteDecisionResponse)(nil),                          // 88: cerebro.v1.WriteDecisionResponse
-	(*WriteActionRequest)(nil),                             // 89: cerebro.v1.WriteActionRequest
-	(*WriteActionResponse)(nil),                            // 90: cerebro.v1.WriteActionResponse
-	(*WriteOutcomeRequest)(nil),                            // 91: cerebro.v1.WriteOutcomeRequest
-	(*WriteOutcomeResponse)(nil),                           // 92: cerebro.v1.WriteOutcomeResponse
-	(*ReplayWorkflowEventsRequest)(nil),                    // 93: cerebro.v1.ReplayWorkflowEventsRequest
-	(*ReplayWorkflowEventsResponse)(nil),                   // 94: cerebro.v1.ReplayWorkflowEventsResponse
-	(*GraphEntity)(nil),                                    // 95: cerebro.v1.GraphEntity
-	(*GraphRelation)(nil),                                  // 96: cerebro.v1.GraphRelation
-	(*GetEntityNeighborhoodRequest)(nil),                   // 97: cerebro.v1.GetEntityNeighborhoodRequest
-	(*GetEntityNeighborhoodResponse)(nil),                  // 98: cerebro.v1.GetEntityNeighborhoodResponse
-	(*GraphIngestRun)(nil),                                 // 99: cerebro.v1.GraphIngestRun
-	(*GraphIngestResult)(nil),                              // 100: cerebro.v1.GraphIngestResult
-	(*GraphIngestRunResult)(nil),                           // 101: cerebro.v1.GraphIngestRunResult
-	(*RunGraphIngestRuntimeRequest)(nil),                   // 102: cerebro.v1.RunGraphIngestRuntimeRequest
-	(*RunGraphIngestRuntimeResponse)(nil),                  // 103: cerebro.v1.RunGraphIngestRuntimeResponse
-	(*GetGraphIngestRunRequest)(nil),                       // 104: cerebro.v1.GetGraphIngestRunRequest
-	(*GetGraphIngestRunResponse)(nil),                      // 105: cerebro.v1.GetGraphIngestRunResponse
-	(*ListGraphIngestRunsRequest)(nil),                     // 106: cerebro.v1.ListGraphIngestRunsRequest
-	(*ListGraphIngestRunsResponse)(nil),                    // 107: cerebro.v1.ListGraphIngestRunsResponse
-	(*CheckGraphIngestHealthRequest)(nil),                  // 108: cerebro.v1.CheckGraphIngestHealthRequest
-	(*CheckGraphIngestHealthResponse)(nil),                 // 109: cerebro.v1.CheckGraphIngestHealthResponse
-	nil,                                                    // 110: cerebro.v1.ReportRun.ParametersEntry
-	nil,                                                    // 111: cerebro.v1.GraphEvidencePath.AttributesEntry
-	nil,                                                    // 112: cerebro.v1.GraphEvidenceRow.AttributesEntry
-	nil,                                                    // 113: cerebro.v1.FindingEvidence.AttributesEntry
-	nil,                                                    // 114: cerebro.v1.RunReportRequest.ParametersEntry
-	nil,                                                    // 115: cerebro.v1.CheckSourceRequest.ConfigEntry
-	nil,                                                    // 116: cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	nil,                                                    // 117: cerebro.v1.ReadSourceRequest.ConfigEntry
-	nil,                                                    // 118: cerebro.v1.SourceRuntime.ConfigEntry
-	nil,                                                    // 119: cerebro.v1.Finding.AttributesEntry
-	nil,                                                    // 120: cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
-	(*timestamppb.Timestamp)(nil),                          // 121: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                                // 122: google.protobuf.Struct
-	(*RuleSpec)(nil),                                       // 123: cerebro.v1.RuleSpec
-	(*SourceSpec)(nil),                                     // 124: cerebro.v1.SourceSpec
-	(*SourceCursor)(nil),                                   // 125: cerebro.v1.SourceCursor
-	(*EventEnvelope)(nil),                                  // 126: cerebro.v1.EventEnvelope
-	(*structpb.Value)(nil),                                 // 127: google.protobuf.Value
-	(*SourceCheckpoint)(nil),                               // 128: cerebro.v1.SourceCheckpoint
-	(*Claim)(nil),                                          // 129: cerebro.v1.Claim
+	(*RejectFindingCandidateRequest)(nil),                  // 82: cerebro.v1.RejectFindingCandidateRequest
+	(*RejectFindingCandidateResponse)(nil),                 // 83: cerebro.v1.RejectFindingCandidateResponse
+	(*EvaluateSourceRuntimeFindingsRequest)(nil),           // 84: cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	(*EvaluateSourceRuntimeFindingRulesRequest)(nil),       // 85: cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	(*FindingRuleEvaluation)(nil),                          // 86: cerebro.v1.FindingRuleEvaluation
+	(*EvaluateSourceRuntimeFindingRulesResponse)(nil),      // 87: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	(*EvaluateSourceRuntimeFindingsResponse)(nil),          // 88: cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	(*WriteDecisionRequest)(nil),                           // 89: cerebro.v1.WriteDecisionRequest
+	(*WriteDecisionResponse)(nil),                          // 90: cerebro.v1.WriteDecisionResponse
+	(*WriteActionRequest)(nil),                             // 91: cerebro.v1.WriteActionRequest
+	(*WriteActionResponse)(nil),                            // 92: cerebro.v1.WriteActionResponse
+	(*WriteOutcomeRequest)(nil),                            // 93: cerebro.v1.WriteOutcomeRequest
+	(*WriteOutcomeResponse)(nil),                           // 94: cerebro.v1.WriteOutcomeResponse
+	(*ReplayWorkflowEventsRequest)(nil),                    // 95: cerebro.v1.ReplayWorkflowEventsRequest
+	(*ReplayWorkflowEventsResponse)(nil),                   // 96: cerebro.v1.ReplayWorkflowEventsResponse
+	(*GraphEntity)(nil),                                    // 97: cerebro.v1.GraphEntity
+	(*GraphRelation)(nil),                                  // 98: cerebro.v1.GraphRelation
+	(*GetEntityNeighborhoodRequest)(nil),                   // 99: cerebro.v1.GetEntityNeighborhoodRequest
+	(*GetEntityNeighborhoodResponse)(nil),                  // 100: cerebro.v1.GetEntityNeighborhoodResponse
+	(*GraphIngestRun)(nil),                                 // 101: cerebro.v1.GraphIngestRun
+	(*GraphIngestResult)(nil),                              // 102: cerebro.v1.GraphIngestResult
+	(*GraphIngestRunResult)(nil),                           // 103: cerebro.v1.GraphIngestRunResult
+	(*RunGraphIngestRuntimeRequest)(nil),                   // 104: cerebro.v1.RunGraphIngestRuntimeRequest
+	(*RunGraphIngestRuntimeResponse)(nil),                  // 105: cerebro.v1.RunGraphIngestRuntimeResponse
+	(*GetGraphIngestRunRequest)(nil),                       // 106: cerebro.v1.GetGraphIngestRunRequest
+	(*GetGraphIngestRunResponse)(nil),                      // 107: cerebro.v1.GetGraphIngestRunResponse
+	(*ListGraphIngestRunsRequest)(nil),                     // 108: cerebro.v1.ListGraphIngestRunsRequest
+	(*ListGraphIngestRunsResponse)(nil),                    // 109: cerebro.v1.ListGraphIngestRunsResponse
+	(*CheckGraphIngestHealthRequest)(nil),                  // 110: cerebro.v1.CheckGraphIngestHealthRequest
+	(*CheckGraphIngestHealthResponse)(nil),                 // 111: cerebro.v1.CheckGraphIngestHealthResponse
+	nil,                                                    // 112: cerebro.v1.ReportRun.ParametersEntry
+	nil,                                                    // 113: cerebro.v1.GraphEvidencePath.AttributesEntry
+	nil,                                                    // 114: cerebro.v1.GraphEvidenceRow.AttributesEntry
+	nil,                                                    // 115: cerebro.v1.FindingEvidence.AttributesEntry
+	nil,                                                    // 116: cerebro.v1.RunReportRequest.ParametersEntry
+	nil,                                                    // 117: cerebro.v1.CheckSourceRequest.ConfigEntry
+	nil,                                                    // 118: cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	nil,                                                    // 119: cerebro.v1.ReadSourceRequest.ConfigEntry
+	nil,                                                    // 120: cerebro.v1.SourceRuntime.ConfigEntry
+	nil,                                                    // 121: cerebro.v1.Finding.AttributesEntry
+	nil,                                                    // 122: cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
+	(*timestamppb.Timestamp)(nil),                          // 123: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                                // 124: google.protobuf.Struct
+	(*RuleSpec)(nil),                                       // 125: cerebro.v1.RuleSpec
+	(*SourceSpec)(nil),                                     // 126: cerebro.v1.SourceSpec
+	(*SourceCursor)(nil),                                   // 127: cerebro.v1.SourceCursor
+	(*EventEnvelope)(nil),                                  // 128: cerebro.v1.EventEnvelope
+	(*structpb.Value)(nil),                                 // 129: google.protobuf.Value
+	(*SourceCheckpoint)(nil),                               // 130: cerebro.v1.SourceCheckpoint
+	(*Claim)(nil),                                          // 131: cerebro.v1.Claim
 }
 var file_cerebro_v1_bootstrap_proto_depIdxs = []int32{
-	121, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	123, // 0: cerebro.v1.CheckHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
 	5,   // 1: cerebro.v1.CheckHealthResponse.components:type_name -> cerebro.v1.ComponentStatus
 	7,   // 2: cerebro.v1.ReportDefinition.parameters:type_name -> cerebro.v1.ReportParameter
-	110, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
-	121, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
-	122, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
+	112, // 3: cerebro.v1.ReportRun.parameters:type_name -> cerebro.v1.ReportRun.ParametersEntry
+	123, // 4: cerebro.v1.ReportRun.generated_at:type_name -> google.protobuf.Timestamp
+	124, // 5: cerebro.v1.ReportRun.result:type_name -> google.protobuf.Struct
 	8,   // 6: cerebro.v1.ListReportDefinitionsResponse.reports:type_name -> cerebro.v1.ReportDefinition
-	123, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
-	121, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
-	121, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
+	125, // 7: cerebro.v1.ListFindingRulesResponse.rules:type_name -> cerebro.v1.RuleSpec
+	123, // 8: cerebro.v1.FindingEvaluationRun.started_at:type_name -> google.protobuf.Timestamp
+	123, // 9: cerebro.v1.FindingEvaluationRun.finished_at:type_name -> google.protobuf.Timestamp
 	14,  // 10: cerebro.v1.ListFindingEvaluationRunsResponse.runs:type_name -> cerebro.v1.FindingEvaluationRun
 	14,  // 11: cerebro.v1.GetFindingEvaluationRunResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	111, // 12: cerebro.v1.GraphEvidencePath.attributes:type_name -> cerebro.v1.GraphEvidencePath.AttributesEntry
-	112, // 13: cerebro.v1.GraphEvidenceRow.attributes:type_name -> cerebro.v1.GraphEvidenceRow.AttributesEntry
+	113, // 12: cerebro.v1.GraphEvidencePath.attributes:type_name -> cerebro.v1.GraphEvidencePath.AttributesEntry
+	114, // 13: cerebro.v1.GraphEvidenceRow.attributes:type_name -> cerebro.v1.GraphEvidenceRow.AttributesEntry
 	19,  // 14: cerebro.v1.GraphEvidenceRow.paths:type_name -> cerebro.v1.GraphEvidencePath
-	121, // 15: cerebro.v1.FindingEvidenceObservation.observed_at:type_name -> google.protobuf.Timestamp
+	123, // 15: cerebro.v1.FindingEvidenceObservation.observed_at:type_name -> google.protobuf.Timestamp
 	20,  // 16: cerebro.v1.FindingEvidenceObservation.graph_rows:type_name -> cerebro.v1.GraphEvidenceRow
-	121, // 17: cerebro.v1.FindingEvidence.created_at:type_name -> google.protobuf.Timestamp
+	123, // 17: cerebro.v1.FindingEvidence.created_at:type_name -> google.protobuf.Timestamp
 	20,  // 18: cerebro.v1.FindingEvidence.graph_rows:type_name -> cerebro.v1.GraphEvidenceRow
-	121, // 19: cerebro.v1.FindingEvidence.last_observed_at:type_name -> google.protobuf.Timestamp
-	113, // 20: cerebro.v1.FindingEvidence.attributes:type_name -> cerebro.v1.FindingEvidence.AttributesEntry
+	123, // 19: cerebro.v1.FindingEvidence.last_observed_at:type_name -> google.protobuf.Timestamp
+	115, // 20: cerebro.v1.FindingEvidence.attributes:type_name -> cerebro.v1.FindingEvidence.AttributesEntry
 	21,  // 21: cerebro.v1.FindingEvidence.observations:type_name -> cerebro.v1.FindingEvidenceObservation
 	22,  // 22: cerebro.v1.ListFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
 	22,  // 23: cerebro.v1.GetFindingEvidenceResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	114, // 24: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
+	116, // 24: cerebro.v1.RunReportRequest.parameters:type_name -> cerebro.v1.RunReportRequest.ParametersEntry
 	8,   // 25: cerebro.v1.RunReportResponse.report:type_name -> cerebro.v1.ReportDefinition
 	9,   // 26: cerebro.v1.RunReportResponse.run:type_name -> cerebro.v1.ReportRun
 	9,   // 27: cerebro.v1.GetReportRunResponse.run:type_name -> cerebro.v1.ReportRun
-	124, // 28: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
-	115, // 29: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
-	124, // 30: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	116, // 31: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
-	124, // 32: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	117, // 33: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
-	125, // 34: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
-	126, // 35: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
-	127, // 36: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
-	124, // 37: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
-	126, // 38: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
-	128, // 39: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	125, // 40: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
+	126, // 28: cerebro.v1.ListSourcesResponse.sources:type_name -> cerebro.v1.SourceSpec
+	117, // 29: cerebro.v1.CheckSourceRequest.config:type_name -> cerebro.v1.CheckSourceRequest.ConfigEntry
+	126, // 30: cerebro.v1.CheckSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	118, // 31: cerebro.v1.DiscoverSourceRequest.config:type_name -> cerebro.v1.DiscoverSourceRequest.ConfigEntry
+	126, // 32: cerebro.v1.DiscoverSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	119, // 33: cerebro.v1.ReadSourceRequest.config:type_name -> cerebro.v1.ReadSourceRequest.ConfigEntry
+	127, // 34: cerebro.v1.ReadSourceRequest.cursor:type_name -> cerebro.v1.SourceCursor
+	128, // 35: cerebro.v1.SourcePreviewEvent.event:type_name -> cerebro.v1.EventEnvelope
+	129, // 36: cerebro.v1.SourcePreviewEvent.payload:type_name -> google.protobuf.Value
+	126, // 37: cerebro.v1.ReadSourceResponse.source:type_name -> cerebro.v1.SourceSpec
+	128, // 38: cerebro.v1.ReadSourceResponse.events:type_name -> cerebro.v1.EventEnvelope
+	130, // 39: cerebro.v1.ReadSourceResponse.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	127, // 40: cerebro.v1.ReadSourceResponse.next_cursor:type_name -> cerebro.v1.SourceCursor
 	38,  // 41: cerebro.v1.ReadSourceResponse.preview_events:type_name -> cerebro.v1.SourcePreviewEvent
-	118, // 42: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
-	128, // 43: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
-	125, // 44: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
-	121, // 45: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
+	120, // 42: cerebro.v1.SourceRuntime.config:type_name -> cerebro.v1.SourceRuntime.ConfigEntry
+	130, // 43: cerebro.v1.SourceRuntime.checkpoint:type_name -> cerebro.v1.SourceCheckpoint
+	127, // 44: cerebro.v1.SourceRuntime.next_cursor:type_name -> cerebro.v1.SourceCursor
+	123, // 45: cerebro.v1.SourceRuntime.last_synced_at:type_name -> google.protobuf.Timestamp
 	40,  // 46: cerebro.v1.PutSourceRuntimeRequest.runtime:type_name -> cerebro.v1.SourceRuntime
 	40,  // 47: cerebro.v1.PutSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	40,  // 48: cerebro.v1.GetSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
 	40,  // 49: cerebro.v1.SyncSourceRuntimeResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	124, // 50: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
-	129, // 51: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
-	129, // 52: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
+	126, // 50: cerebro.v1.SyncSourceRuntimeResponse.source:type_name -> cerebro.v1.SourceSpec
+	131, // 51: cerebro.v1.WriteClaimsRequest.claims:type_name -> cerebro.v1.Claim
+	131, // 52: cerebro.v1.ListClaimsResponse.claims:type_name -> cerebro.v1.Claim
 	0,   // 53: cerebro.v1.ListFindingsRequest.status:type_name -> cerebro.v1.FindingStatus
 	1,   // 54: cerebro.v1.ListFindingsRequest.order:type_name -> cerebro.v1.FindingOrder
-	121, // 55: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
-	121, // 56: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
+	123, // 55: cerebro.v1.FindingNote.created_at:type_name -> google.protobuf.Timestamp
+	123, // 56: cerebro.v1.FindingTicket.linked_at:type_name -> google.protobuf.Timestamp
 	0,   // 57: cerebro.v1.Finding.status:type_name -> cerebro.v1.FindingStatus
-	119, // 58: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
-	121, // 59: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
-	121, // 60: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
-	121, // 61: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
+	121, // 58: cerebro.v1.Finding.attributes:type_name -> cerebro.v1.Finding.AttributesEntry
+	123, // 59: cerebro.v1.Finding.first_observed_at:type_name -> google.protobuf.Timestamp
+	123, // 60: cerebro.v1.Finding.last_observed_at:type_name -> google.protobuf.Timestamp
+	123, // 61: cerebro.v1.Finding.status_updated_at:type_name -> google.protobuf.Timestamp
 	52,  // 62: cerebro.v1.Finding.control_refs:type_name -> cerebro.v1.FindingControlRef
-	121, // 63: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
+	123, // 63: cerebro.v1.Finding.due_at:type_name -> google.protobuf.Timestamp
 	53,  // 64: cerebro.v1.Finding.notes:type_name -> cerebro.v1.FindingNote
 	54,  // 65: cerebro.v1.Finding.tickets:type_name -> cerebro.v1.FindingTicket
 	55,  // 66: cerebro.v1.GetFindingResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 67: cerebro.v1.ResolveFindingResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 68: cerebro.v1.SuppressFindingResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 69: cerebro.v1.AssignFindingResponse.finding:type_name -> cerebro.v1.Finding
-	121, // 70: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
+	123, // 70: cerebro.v1.SetFindingDueDateRequest.due_at:type_name -> google.protobuf.Timestamp
 	55,  // 71: cerebro.v1.SetFindingDueDateResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 72: cerebro.v1.AddFindingNoteResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 73: cerebro.v1.LinkFindingTicketResponse.finding:type_name -> cerebro.v1.Finding
 	55,  // 74: cerebro.v1.ListFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	121, // 75: cerebro.v1.FindingCandidateRun.started_at:type_name -> google.protobuf.Timestamp
-	121, // 76: cerebro.v1.FindingCandidateRun.finished_at:type_name -> google.protobuf.Timestamp
+	123, // 75: cerebro.v1.FindingCandidateRun.started_at:type_name -> google.protobuf.Timestamp
+	123, // 76: cerebro.v1.FindingCandidateRun.finished_at:type_name -> google.protobuf.Timestamp
 	55,  // 77: cerebro.v1.FindingCandidate.finding:type_name -> cerebro.v1.Finding
 	22,  // 78: cerebro.v1.FindingCandidate.evidence:type_name -> cerebro.v1.FindingEvidence
-	121, // 79: cerebro.v1.FindingCandidate.first_observed_at:type_name -> google.protobuf.Timestamp
-	121, // 80: cerebro.v1.FindingCandidate.last_observed_at:type_name -> google.protobuf.Timestamp
-	121, // 81: cerebro.v1.FindingCandidate.promoted_at:type_name -> google.protobuf.Timestamp
-	121, // 82: cerebro.v1.FindingCandidate.created_at:type_name -> google.protobuf.Timestamp
-	121, // 83: cerebro.v1.FindingCandidate.updated_at:type_name -> google.protobuf.Timestamp
-	72,  // 84: cerebro.v1.ListFindingCandidatesResponse.candidates:type_name -> cerebro.v1.FindingCandidate
-	72,  // 85: cerebro.v1.GetFindingCandidateResponse.candidate:type_name -> cerebro.v1.FindingCandidate
-	123, // 86: cerebro.v1.FindingCandidateRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
-	71,  // 87: cerebro.v1.FindingCandidateRuleEvaluation.run:type_name -> cerebro.v1.FindingCandidateRun
-	72,  // 88: cerebro.v1.FindingCandidateRuleEvaluation.candidates:type_name -> cerebro.v1.FindingCandidate
-	40,  // 89: cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	78,  // 90: cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse.evaluations:type_name -> cerebro.v1.FindingCandidateRuleEvaluation
-	55,  // 91: cerebro.v1.PromoteFindingCandidateResponse.finding:type_name -> cerebro.v1.Finding
-	72,  // 92: cerebro.v1.PromoteFindingCandidateResponse.candidate:type_name -> cerebro.v1.FindingCandidate
-	123, // 93: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
-	55,  // 94: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
-	14,  // 95: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
-	22,  // 96: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
-	40,  // 97: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	84,  // 98: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
-	40,  // 99: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
-	123, // 100: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
-	55,  // 101: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
-	14,  // 102: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
-	22,  // 103: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
-	121, // 104: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	121, // 105: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	121, // 106: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	122, // 107: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
-	121, // 108: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
-	121, // 109: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
-	121, // 110: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
-	122, // 111: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
-	121, // 112: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
-	121, // 113: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
-	121, // 114: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
-	122, // 115: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
-	120, // 116: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
-	95,  // 117: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
-	95,  // 118: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
-	96,  // 119: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
-	99,  // 120: cerebro.v1.GraphIngestRunResult.run:type_name -> cerebro.v1.GraphIngestRun
-	100, // 121: cerebro.v1.GraphIngestRunResult.ingest:type_name -> cerebro.v1.GraphIngestResult
-	101, // 122: cerebro.v1.RunGraphIngestRuntimeResponse.result:type_name -> cerebro.v1.GraphIngestRunResult
-	99,  // 123: cerebro.v1.GetGraphIngestRunResponse.run:type_name -> cerebro.v1.GraphIngestRun
-	99,  // 124: cerebro.v1.ListGraphIngestRunsResponse.runs:type_name -> cerebro.v1.GraphIngestRun
-	121, // 125: cerebro.v1.CheckGraphIngestHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
-	99,  // 126: cerebro.v1.CheckGraphIngestHealthResponse.failed_runs:type_name -> cerebro.v1.GraphIngestRun
-	2,   // 127: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
-	4,   // 128: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
-	10,  // 129: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
-	12,  // 130: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
-	27,  // 131: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
-	29,  // 132: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
-	31,  // 133: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
-	33,  // 134: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
-	35,  // 135: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
-	37,  // 136: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
-	41,  // 137: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
-	43,  // 138: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
-	45,  // 139: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
-	47,  // 140: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
-	49,  // 141: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
-	51,  // 142: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
-	56,  // 143: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
-	73,  // 144: cerebro.v1.BootstrapService.ListFindingCandidates:input_type -> cerebro.v1.ListFindingCandidatesRequest
-	75,  // 145: cerebro.v1.BootstrapService.GetFindingCandidate:input_type -> cerebro.v1.GetFindingCandidateRequest
-	77,  // 146: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingCandidates:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingCandidatesRequest
-	80,  // 147: cerebro.v1.BootstrapService.PromoteFindingCandidate:input_type -> cerebro.v1.PromoteFindingCandidateRequest
-	58,  // 148: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
-	60,  // 149: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
-	62,  // 150: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
-	64,  // 151: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
-	66,  // 152: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
-	68,  // 153: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
-	15,  // 154: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
-	17,  // 155: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
-	23,  // 156: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
-	25,  // 157: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
-	83,  // 158: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
-	82,  // 159: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
-	87,  // 160: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
-	89,  // 161: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
-	91,  // 162: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
-	93,  // 163: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
-	97,  // 164: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
-	102, // 165: cerebro.v1.BootstrapService.RunGraphIngestRuntime:input_type -> cerebro.v1.RunGraphIngestRuntimeRequest
-	104, // 166: cerebro.v1.BootstrapService.GetGraphIngestRun:input_type -> cerebro.v1.GetGraphIngestRunRequest
-	106, // 167: cerebro.v1.BootstrapService.ListGraphIngestRuns:input_type -> cerebro.v1.ListGraphIngestRunsRequest
-	108, // 168: cerebro.v1.BootstrapService.CheckGraphIngestHealth:input_type -> cerebro.v1.CheckGraphIngestHealthRequest
-	3,   // 169: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
-	6,   // 170: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
-	11,  // 171: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
-	13,  // 172: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
-	28,  // 173: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
-	30,  // 174: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
-	32,  // 175: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
-	34,  // 176: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
-	36,  // 177: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
-	39,  // 178: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
-	42,  // 179: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
-	44,  // 180: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
-	46,  // 181: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
-	48,  // 182: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
-	50,  // 183: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
-	70,  // 184: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
-	57,  // 185: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
-	74,  // 186: cerebro.v1.BootstrapService.ListFindingCandidates:output_type -> cerebro.v1.ListFindingCandidatesResponse
-	76,  // 187: cerebro.v1.BootstrapService.GetFindingCandidate:output_type -> cerebro.v1.GetFindingCandidateResponse
-	79,  // 188: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingCandidates:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse
-	81,  // 189: cerebro.v1.BootstrapService.PromoteFindingCandidate:output_type -> cerebro.v1.PromoteFindingCandidateResponse
-	59,  // 190: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
-	61,  // 191: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
-	63,  // 192: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
-	65,  // 193: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
-	67,  // 194: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
-	69,  // 195: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
-	16,  // 196: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
-	18,  // 197: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
-	24,  // 198: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
-	26,  // 199: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
-	85,  // 200: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
-	86,  // 201: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
-	88,  // 202: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
-	90,  // 203: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
-	92,  // 204: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
-	94,  // 205: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
-	98,  // 206: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
-	103, // 207: cerebro.v1.BootstrapService.RunGraphIngestRuntime:output_type -> cerebro.v1.RunGraphIngestRuntimeResponse
-	105, // 208: cerebro.v1.BootstrapService.GetGraphIngestRun:output_type -> cerebro.v1.GetGraphIngestRunResponse
-	107, // 209: cerebro.v1.BootstrapService.ListGraphIngestRuns:output_type -> cerebro.v1.ListGraphIngestRunsResponse
-	109, // 210: cerebro.v1.BootstrapService.CheckGraphIngestHealth:output_type -> cerebro.v1.CheckGraphIngestHealthResponse
-	169, // [169:211] is the sub-list for method output_type
-	127, // [127:169] is the sub-list for method input_type
-	127, // [127:127] is the sub-list for extension type_name
-	127, // [127:127] is the sub-list for extension extendee
-	0,   // [0:127] is the sub-list for field type_name
+	123, // 79: cerebro.v1.FindingCandidate.first_observed_at:type_name -> google.protobuf.Timestamp
+	123, // 80: cerebro.v1.FindingCandidate.last_observed_at:type_name -> google.protobuf.Timestamp
+	123, // 81: cerebro.v1.FindingCandidate.promoted_at:type_name -> google.protobuf.Timestamp
+	123, // 82: cerebro.v1.FindingCandidate.rejected_at:type_name -> google.protobuf.Timestamp
+	123, // 83: cerebro.v1.FindingCandidate.created_at:type_name -> google.protobuf.Timestamp
+	123, // 84: cerebro.v1.FindingCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	72,  // 85: cerebro.v1.ListFindingCandidatesResponse.candidates:type_name -> cerebro.v1.FindingCandidate
+	72,  // 86: cerebro.v1.GetFindingCandidateResponse.candidate:type_name -> cerebro.v1.FindingCandidate
+	125, // 87: cerebro.v1.FindingCandidateRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
+	71,  // 88: cerebro.v1.FindingCandidateRuleEvaluation.run:type_name -> cerebro.v1.FindingCandidateRun
+	72,  // 89: cerebro.v1.FindingCandidateRuleEvaluation.candidates:type_name -> cerebro.v1.FindingCandidate
+	40,  // 90: cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	78,  // 91: cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse.evaluations:type_name -> cerebro.v1.FindingCandidateRuleEvaluation
+	55,  // 92: cerebro.v1.PromoteFindingCandidateResponse.finding:type_name -> cerebro.v1.Finding
+	72,  // 93: cerebro.v1.PromoteFindingCandidateResponse.candidate:type_name -> cerebro.v1.FindingCandidate
+	72,  // 94: cerebro.v1.RejectFindingCandidateResponse.candidate:type_name -> cerebro.v1.FindingCandidate
+	125, // 95: cerebro.v1.FindingRuleEvaluation.rule:type_name -> cerebro.v1.RuleSpec
+	55,  // 96: cerebro.v1.FindingRuleEvaluation.findings:type_name -> cerebro.v1.Finding
+	14,  // 97: cerebro.v1.FindingRuleEvaluation.run:type_name -> cerebro.v1.FindingEvaluationRun
+	22,  // 98: cerebro.v1.FindingRuleEvaluation.evidence:type_name -> cerebro.v1.FindingEvidence
+	40,  // 99: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	86,  // 100: cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse.evaluations:type_name -> cerebro.v1.FindingRuleEvaluation
+	40,  // 101: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.runtime:type_name -> cerebro.v1.SourceRuntime
+	125, // 102: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.rule:type_name -> cerebro.v1.RuleSpec
+	55,  // 103: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.findings:type_name -> cerebro.v1.Finding
+	14,  // 104: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.run:type_name -> cerebro.v1.FindingEvaluationRun
+	22,  // 105: cerebro.v1.EvaluateSourceRuntimeFindingsResponse.evidence:type_name -> cerebro.v1.FindingEvidence
+	123, // 106: cerebro.v1.WriteDecisionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	123, // 107: cerebro.v1.WriteDecisionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	123, // 108: cerebro.v1.WriteDecisionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	124, // 109: cerebro.v1.WriteDecisionRequest.metadata:type_name -> google.protobuf.Struct
+	123, // 110: cerebro.v1.WriteActionRequest.observed_at:type_name -> google.protobuf.Timestamp
+	123, // 111: cerebro.v1.WriteActionRequest.valid_from:type_name -> google.protobuf.Timestamp
+	123, // 112: cerebro.v1.WriteActionRequest.valid_to:type_name -> google.protobuf.Timestamp
+	124, // 113: cerebro.v1.WriteActionRequest.metadata:type_name -> google.protobuf.Struct
+	123, // 114: cerebro.v1.WriteOutcomeRequest.observed_at:type_name -> google.protobuf.Timestamp
+	123, // 115: cerebro.v1.WriteOutcomeRequest.valid_from:type_name -> google.protobuf.Timestamp
+	123, // 116: cerebro.v1.WriteOutcomeRequest.valid_to:type_name -> google.protobuf.Timestamp
+	124, // 117: cerebro.v1.WriteOutcomeRequest.metadata:type_name -> google.protobuf.Struct
+	122, // 118: cerebro.v1.ReplayWorkflowEventsRequest.attribute_equals:type_name -> cerebro.v1.ReplayWorkflowEventsRequest.AttributeEqualsEntry
+	97,  // 119: cerebro.v1.GetEntityNeighborhoodResponse.root:type_name -> cerebro.v1.GraphEntity
+	97,  // 120: cerebro.v1.GetEntityNeighborhoodResponse.neighbors:type_name -> cerebro.v1.GraphEntity
+	98,  // 121: cerebro.v1.GetEntityNeighborhoodResponse.relations:type_name -> cerebro.v1.GraphRelation
+	101, // 122: cerebro.v1.GraphIngestRunResult.run:type_name -> cerebro.v1.GraphIngestRun
+	102, // 123: cerebro.v1.GraphIngestRunResult.ingest:type_name -> cerebro.v1.GraphIngestResult
+	103, // 124: cerebro.v1.RunGraphIngestRuntimeResponse.result:type_name -> cerebro.v1.GraphIngestRunResult
+	101, // 125: cerebro.v1.GetGraphIngestRunResponse.run:type_name -> cerebro.v1.GraphIngestRun
+	101, // 126: cerebro.v1.ListGraphIngestRunsResponse.runs:type_name -> cerebro.v1.GraphIngestRun
+	123, // 127: cerebro.v1.CheckGraphIngestHealthResponse.checked_at:type_name -> google.protobuf.Timestamp
+	101, // 128: cerebro.v1.CheckGraphIngestHealthResponse.failed_runs:type_name -> cerebro.v1.GraphIngestRun
+	2,   // 129: cerebro.v1.BootstrapService.GetVersion:input_type -> cerebro.v1.GetVersionRequest
+	4,   // 130: cerebro.v1.BootstrapService.CheckHealth:input_type -> cerebro.v1.CheckHealthRequest
+	10,  // 131: cerebro.v1.BootstrapService.ListReportDefinitions:input_type -> cerebro.v1.ListReportDefinitionsRequest
+	12,  // 132: cerebro.v1.BootstrapService.ListFindingRules:input_type -> cerebro.v1.ListFindingRulesRequest
+	27,  // 133: cerebro.v1.BootstrapService.RunReport:input_type -> cerebro.v1.RunReportRequest
+	29,  // 134: cerebro.v1.BootstrapService.GetReportRun:input_type -> cerebro.v1.GetReportRunRequest
+	31,  // 135: cerebro.v1.BootstrapService.ListSources:input_type -> cerebro.v1.ListSourcesRequest
+	33,  // 136: cerebro.v1.BootstrapService.CheckSource:input_type -> cerebro.v1.CheckSourceRequest
+	35,  // 137: cerebro.v1.BootstrapService.DiscoverSource:input_type -> cerebro.v1.DiscoverSourceRequest
+	37,  // 138: cerebro.v1.BootstrapService.ReadSource:input_type -> cerebro.v1.ReadSourceRequest
+	41,  // 139: cerebro.v1.BootstrapService.PutSourceRuntime:input_type -> cerebro.v1.PutSourceRuntimeRequest
+	43,  // 140: cerebro.v1.BootstrapService.GetSourceRuntime:input_type -> cerebro.v1.GetSourceRuntimeRequest
+	45,  // 141: cerebro.v1.BootstrapService.SyncSourceRuntime:input_type -> cerebro.v1.SyncSourceRuntimeRequest
+	47,  // 142: cerebro.v1.BootstrapService.WriteClaims:input_type -> cerebro.v1.WriteClaimsRequest
+	49,  // 143: cerebro.v1.BootstrapService.ListClaims:input_type -> cerebro.v1.ListClaimsRequest
+	51,  // 144: cerebro.v1.BootstrapService.ListFindings:input_type -> cerebro.v1.ListFindingsRequest
+	56,  // 145: cerebro.v1.BootstrapService.GetFinding:input_type -> cerebro.v1.GetFindingRequest
+	73,  // 146: cerebro.v1.BootstrapService.ListFindingCandidates:input_type -> cerebro.v1.ListFindingCandidatesRequest
+	75,  // 147: cerebro.v1.BootstrapService.GetFindingCandidate:input_type -> cerebro.v1.GetFindingCandidateRequest
+	77,  // 148: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingCandidates:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingCandidatesRequest
+	80,  // 149: cerebro.v1.BootstrapService.PromoteFindingCandidate:input_type -> cerebro.v1.PromoteFindingCandidateRequest
+	82,  // 150: cerebro.v1.BootstrapService.RejectFindingCandidate:input_type -> cerebro.v1.RejectFindingCandidateRequest
+	58,  // 151: cerebro.v1.BootstrapService.ResolveFinding:input_type -> cerebro.v1.ResolveFindingRequest
+	60,  // 152: cerebro.v1.BootstrapService.SuppressFinding:input_type -> cerebro.v1.SuppressFindingRequest
+	62,  // 153: cerebro.v1.BootstrapService.AssignFinding:input_type -> cerebro.v1.AssignFindingRequest
+	64,  // 154: cerebro.v1.BootstrapService.SetFindingDueDate:input_type -> cerebro.v1.SetFindingDueDateRequest
+	66,  // 155: cerebro.v1.BootstrapService.AddFindingNote:input_type -> cerebro.v1.AddFindingNoteRequest
+	68,  // 156: cerebro.v1.BootstrapService.LinkFindingTicket:input_type -> cerebro.v1.LinkFindingTicketRequest
+	15,  // 157: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:input_type -> cerebro.v1.ListFindingEvaluationRunsRequest
+	17,  // 158: cerebro.v1.BootstrapService.GetFindingEvaluationRun:input_type -> cerebro.v1.GetFindingEvaluationRunRequest
+	23,  // 159: cerebro.v1.BootstrapService.ListFindingEvidence:input_type -> cerebro.v1.ListFindingEvidenceRequest
+	25,  // 160: cerebro.v1.BootstrapService.GetFindingEvidence:input_type -> cerebro.v1.GetFindingEvidenceRequest
+	85,  // 161: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesRequest
+	84,  // 162: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:input_type -> cerebro.v1.EvaluateSourceRuntimeFindingsRequest
+	89,  // 163: cerebro.v1.BootstrapService.WriteDecision:input_type -> cerebro.v1.WriteDecisionRequest
+	91,  // 164: cerebro.v1.BootstrapService.WriteAction:input_type -> cerebro.v1.WriteActionRequest
+	93,  // 165: cerebro.v1.BootstrapService.WriteOutcome:input_type -> cerebro.v1.WriteOutcomeRequest
+	95,  // 166: cerebro.v1.BootstrapService.ReplayWorkflowEvents:input_type -> cerebro.v1.ReplayWorkflowEventsRequest
+	99,  // 167: cerebro.v1.BootstrapService.GetEntityNeighborhood:input_type -> cerebro.v1.GetEntityNeighborhoodRequest
+	104, // 168: cerebro.v1.BootstrapService.RunGraphIngestRuntime:input_type -> cerebro.v1.RunGraphIngestRuntimeRequest
+	106, // 169: cerebro.v1.BootstrapService.GetGraphIngestRun:input_type -> cerebro.v1.GetGraphIngestRunRequest
+	108, // 170: cerebro.v1.BootstrapService.ListGraphIngestRuns:input_type -> cerebro.v1.ListGraphIngestRunsRequest
+	110, // 171: cerebro.v1.BootstrapService.CheckGraphIngestHealth:input_type -> cerebro.v1.CheckGraphIngestHealthRequest
+	3,   // 172: cerebro.v1.BootstrapService.GetVersion:output_type -> cerebro.v1.GetVersionResponse
+	6,   // 173: cerebro.v1.BootstrapService.CheckHealth:output_type -> cerebro.v1.CheckHealthResponse
+	11,  // 174: cerebro.v1.BootstrapService.ListReportDefinitions:output_type -> cerebro.v1.ListReportDefinitionsResponse
+	13,  // 175: cerebro.v1.BootstrapService.ListFindingRules:output_type -> cerebro.v1.ListFindingRulesResponse
+	28,  // 176: cerebro.v1.BootstrapService.RunReport:output_type -> cerebro.v1.RunReportResponse
+	30,  // 177: cerebro.v1.BootstrapService.GetReportRun:output_type -> cerebro.v1.GetReportRunResponse
+	32,  // 178: cerebro.v1.BootstrapService.ListSources:output_type -> cerebro.v1.ListSourcesResponse
+	34,  // 179: cerebro.v1.BootstrapService.CheckSource:output_type -> cerebro.v1.CheckSourceResponse
+	36,  // 180: cerebro.v1.BootstrapService.DiscoverSource:output_type -> cerebro.v1.DiscoverSourceResponse
+	39,  // 181: cerebro.v1.BootstrapService.ReadSource:output_type -> cerebro.v1.ReadSourceResponse
+	42,  // 182: cerebro.v1.BootstrapService.PutSourceRuntime:output_type -> cerebro.v1.PutSourceRuntimeResponse
+	44,  // 183: cerebro.v1.BootstrapService.GetSourceRuntime:output_type -> cerebro.v1.GetSourceRuntimeResponse
+	46,  // 184: cerebro.v1.BootstrapService.SyncSourceRuntime:output_type -> cerebro.v1.SyncSourceRuntimeResponse
+	48,  // 185: cerebro.v1.BootstrapService.WriteClaims:output_type -> cerebro.v1.WriteClaimsResponse
+	50,  // 186: cerebro.v1.BootstrapService.ListClaims:output_type -> cerebro.v1.ListClaimsResponse
+	70,  // 187: cerebro.v1.BootstrapService.ListFindings:output_type -> cerebro.v1.ListFindingsResponse
+	57,  // 188: cerebro.v1.BootstrapService.GetFinding:output_type -> cerebro.v1.GetFindingResponse
+	74,  // 189: cerebro.v1.BootstrapService.ListFindingCandidates:output_type -> cerebro.v1.ListFindingCandidatesResponse
+	76,  // 190: cerebro.v1.BootstrapService.GetFindingCandidate:output_type -> cerebro.v1.GetFindingCandidateResponse
+	79,  // 191: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingCandidates:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingCandidatesResponse
+	81,  // 192: cerebro.v1.BootstrapService.PromoteFindingCandidate:output_type -> cerebro.v1.PromoteFindingCandidateResponse
+	83,  // 193: cerebro.v1.BootstrapService.RejectFindingCandidate:output_type -> cerebro.v1.RejectFindingCandidateResponse
+	59,  // 194: cerebro.v1.BootstrapService.ResolveFinding:output_type -> cerebro.v1.ResolveFindingResponse
+	61,  // 195: cerebro.v1.BootstrapService.SuppressFinding:output_type -> cerebro.v1.SuppressFindingResponse
+	63,  // 196: cerebro.v1.BootstrapService.AssignFinding:output_type -> cerebro.v1.AssignFindingResponse
+	65,  // 197: cerebro.v1.BootstrapService.SetFindingDueDate:output_type -> cerebro.v1.SetFindingDueDateResponse
+	67,  // 198: cerebro.v1.BootstrapService.AddFindingNote:output_type -> cerebro.v1.AddFindingNoteResponse
+	69,  // 199: cerebro.v1.BootstrapService.LinkFindingTicket:output_type -> cerebro.v1.LinkFindingTicketResponse
+	16,  // 200: cerebro.v1.BootstrapService.ListFindingEvaluationRuns:output_type -> cerebro.v1.ListFindingEvaluationRunsResponse
+	18,  // 201: cerebro.v1.BootstrapService.GetFindingEvaluationRun:output_type -> cerebro.v1.GetFindingEvaluationRunResponse
+	24,  // 202: cerebro.v1.BootstrapService.ListFindingEvidence:output_type -> cerebro.v1.ListFindingEvidenceResponse
+	26,  // 203: cerebro.v1.BootstrapService.GetFindingEvidence:output_type -> cerebro.v1.GetFindingEvidenceResponse
+	87,  // 204: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindingRules:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingRulesResponse
+	88,  // 205: cerebro.v1.BootstrapService.EvaluateSourceRuntimeFindings:output_type -> cerebro.v1.EvaluateSourceRuntimeFindingsResponse
+	90,  // 206: cerebro.v1.BootstrapService.WriteDecision:output_type -> cerebro.v1.WriteDecisionResponse
+	92,  // 207: cerebro.v1.BootstrapService.WriteAction:output_type -> cerebro.v1.WriteActionResponse
+	94,  // 208: cerebro.v1.BootstrapService.WriteOutcome:output_type -> cerebro.v1.WriteOutcomeResponse
+	96,  // 209: cerebro.v1.BootstrapService.ReplayWorkflowEvents:output_type -> cerebro.v1.ReplayWorkflowEventsResponse
+	100, // 210: cerebro.v1.BootstrapService.GetEntityNeighborhood:output_type -> cerebro.v1.GetEntityNeighborhoodResponse
+	105, // 211: cerebro.v1.BootstrapService.RunGraphIngestRuntime:output_type -> cerebro.v1.RunGraphIngestRuntimeResponse
+	107, // 212: cerebro.v1.BootstrapService.GetGraphIngestRun:output_type -> cerebro.v1.GetGraphIngestRunResponse
+	109, // 213: cerebro.v1.BootstrapService.ListGraphIngestRuns:output_type -> cerebro.v1.ListGraphIngestRunsResponse
+	111, // 214: cerebro.v1.BootstrapService.CheckGraphIngestHealth:output_type -> cerebro.v1.CheckGraphIngestHealthResponse
+	172, // [172:215] is the sub-list for method output_type
+	129, // [129:172] is the sub-list for method input_type
+	129, // [129:129] is the sub-list for extension type_name
+	129, // [129:129] is the sub-list for extension extendee
+	0,   // [0:129] is the sub-list for field type_name
 }
 
 func init() { file_cerebro_v1_bootstrap_proto_init() }
@@ -8863,7 +9022,7 @@ func file_cerebro_v1_bootstrap_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cerebro_v1_bootstrap_proto_rawDesc), len(file_cerebro_v1_bootstrap_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   119,
+			NumMessages:   121,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
+++ b/gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go
@@ -96,6 +96,9 @@ const (
 	// BootstrapServicePromoteFindingCandidateProcedure is the fully-qualified name of the
 	// BootstrapService's PromoteFindingCandidate RPC.
 	BootstrapServicePromoteFindingCandidateProcedure = "/cerebro.v1.BootstrapService/PromoteFindingCandidate"
+	// BootstrapServiceRejectFindingCandidateProcedure is the fully-qualified name of the
+	// BootstrapService's RejectFindingCandidate RPC.
+	BootstrapServiceRejectFindingCandidateProcedure = "/cerebro.v1.BootstrapService/RejectFindingCandidate"
 	// BootstrapServiceResolveFindingProcedure is the fully-qualified name of the BootstrapService's
 	// ResolveFinding RPC.
 	BootstrapServiceResolveFindingProcedure = "/cerebro.v1.BootstrapService/ResolveFinding"
@@ -184,6 +187,7 @@ type BootstrapServiceClient interface {
 	GetFindingCandidate(context.Context, *connect.Request[v1.GetFindingCandidateRequest]) (*connect.Response[v1.GetFindingCandidateResponse], error)
 	EvaluateSourceRuntimeFindingCandidates(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingCandidatesRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingCandidatesResponse], error)
 	PromoteFindingCandidate(context.Context, *connect.Request[v1.PromoteFindingCandidateRequest]) (*connect.Response[v1.PromoteFindingCandidateResponse], error)
+	RejectFindingCandidate(context.Context, *connect.Request[v1.RejectFindingCandidateRequest]) (*connect.Response[v1.RejectFindingCandidateResponse], error)
 	ResolveFinding(context.Context, *connect.Request[v1.ResolveFindingRequest]) (*connect.Response[v1.ResolveFindingResponse], error)
 	SuppressFinding(context.Context, *connect.Request[v1.SuppressFindingRequest]) (*connect.Response[v1.SuppressFindingResponse], error)
 	AssignFinding(context.Context, *connect.Request[v1.AssignFindingRequest]) (*connect.Response[v1.AssignFindingResponse], error)
@@ -344,6 +348,12 @@ func NewBootstrapServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(bootstrapServiceMethods.ByName("PromoteFindingCandidate")),
 			connect.WithClientOptions(opts...),
 		),
+		rejectFindingCandidate: connect.NewClient[v1.RejectFindingCandidateRequest, v1.RejectFindingCandidateResponse](
+			httpClient,
+			baseURL+BootstrapServiceRejectFindingCandidateProcedure,
+			connect.WithSchema(bootstrapServiceMethods.ByName("RejectFindingCandidate")),
+			connect.WithClientOptions(opts...),
+		),
 		resolveFinding: connect.NewClient[v1.ResolveFindingRequest, v1.ResolveFindingResponse](
 			httpClient,
 			baseURL+BootstrapServiceResolveFindingProcedure,
@@ -496,6 +506,7 @@ type bootstrapServiceClient struct {
 	getFindingCandidate                    *connect.Client[v1.GetFindingCandidateRequest, v1.GetFindingCandidateResponse]
 	evaluateSourceRuntimeFindingCandidates *connect.Client[v1.EvaluateSourceRuntimeFindingCandidatesRequest, v1.EvaluateSourceRuntimeFindingCandidatesResponse]
 	promoteFindingCandidate                *connect.Client[v1.PromoteFindingCandidateRequest, v1.PromoteFindingCandidateResponse]
+	rejectFindingCandidate                 *connect.Client[v1.RejectFindingCandidateRequest, v1.RejectFindingCandidateResponse]
 	resolveFinding                         *connect.Client[v1.ResolveFindingRequest, v1.ResolveFindingResponse]
 	suppressFinding                        *connect.Client[v1.SuppressFindingRequest, v1.SuppressFindingResponse]
 	assignFinding                          *connect.Client[v1.AssignFindingRequest, v1.AssignFindingResponse]
@@ -623,6 +634,11 @@ func (c *bootstrapServiceClient) EvaluateSourceRuntimeFindingCandidates(ctx cont
 // PromoteFindingCandidate calls cerebro.v1.BootstrapService.PromoteFindingCandidate.
 func (c *bootstrapServiceClient) PromoteFindingCandidate(ctx context.Context, req *connect.Request[v1.PromoteFindingCandidateRequest]) (*connect.Response[v1.PromoteFindingCandidateResponse], error) {
 	return c.promoteFindingCandidate.CallUnary(ctx, req)
+}
+
+// RejectFindingCandidate calls cerebro.v1.BootstrapService.RejectFindingCandidate.
+func (c *bootstrapServiceClient) RejectFindingCandidate(ctx context.Context, req *connect.Request[v1.RejectFindingCandidateRequest]) (*connect.Response[v1.RejectFindingCandidateResponse], error) {
+	return c.rejectFindingCandidate.CallUnary(ctx, req)
 }
 
 // ResolveFinding calls cerebro.v1.BootstrapService.ResolveFinding.
@@ -754,6 +770,7 @@ type BootstrapServiceHandler interface {
 	GetFindingCandidate(context.Context, *connect.Request[v1.GetFindingCandidateRequest]) (*connect.Response[v1.GetFindingCandidateResponse], error)
 	EvaluateSourceRuntimeFindingCandidates(context.Context, *connect.Request[v1.EvaluateSourceRuntimeFindingCandidatesRequest]) (*connect.Response[v1.EvaluateSourceRuntimeFindingCandidatesResponse], error)
 	PromoteFindingCandidate(context.Context, *connect.Request[v1.PromoteFindingCandidateRequest]) (*connect.Response[v1.PromoteFindingCandidateResponse], error)
+	RejectFindingCandidate(context.Context, *connect.Request[v1.RejectFindingCandidateRequest]) (*connect.Response[v1.RejectFindingCandidateResponse], error)
 	ResolveFinding(context.Context, *connect.Request[v1.ResolveFindingRequest]) (*connect.Response[v1.ResolveFindingResponse], error)
 	SuppressFinding(context.Context, *connect.Request[v1.SuppressFindingRequest]) (*connect.Response[v1.SuppressFindingResponse], error)
 	AssignFinding(context.Context, *connect.Request[v1.AssignFindingRequest]) (*connect.Response[v1.AssignFindingResponse], error)
@@ -908,6 +925,12 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 		BootstrapServicePromoteFindingCandidateProcedure,
 		svc.PromoteFindingCandidate,
 		connect.WithSchema(bootstrapServiceMethods.ByName("PromoteFindingCandidate")),
+		connect.WithHandlerOptions(opts...),
+	)
+	bootstrapServiceRejectFindingCandidateHandler := connect.NewUnaryHandler(
+		BootstrapServiceRejectFindingCandidateProcedure,
+		svc.RejectFindingCandidate,
+		connect.WithSchema(bootstrapServiceMethods.ByName("RejectFindingCandidate")),
 		connect.WithHandlerOptions(opts...),
 	)
 	bootstrapServiceResolveFindingHandler := connect.NewUnaryHandler(
@@ -1080,6 +1103,8 @@ func NewBootstrapServiceHandler(svc BootstrapServiceHandler, opts ...connect.Han
 			bootstrapServiceEvaluateSourceRuntimeFindingCandidatesHandler.ServeHTTP(w, r)
 		case BootstrapServicePromoteFindingCandidateProcedure:
 			bootstrapServicePromoteFindingCandidateHandler.ServeHTTP(w, r)
+		case BootstrapServiceRejectFindingCandidateProcedure:
+			bootstrapServiceRejectFindingCandidateHandler.ServeHTTP(w, r)
 		case BootstrapServiceResolveFindingProcedure:
 			bootstrapServiceResolveFindingHandler.ServeHTTP(w, r)
 		case BootstrapServiceSuppressFindingProcedure:
@@ -1213,6 +1238,10 @@ func (UnimplementedBootstrapServiceHandler) EvaluateSourceRuntimeFindingCandidat
 
 func (UnimplementedBootstrapServiceHandler) PromoteFindingCandidate(context.Context, *connect.Request[v1.PromoteFindingCandidateRequest]) (*connect.Response[v1.PromoteFindingCandidateResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.PromoteFindingCandidate is not implemented"))
+}
+
+func (UnimplementedBootstrapServiceHandler) RejectFindingCandidate(context.Context, *connect.Request[v1.RejectFindingCandidateRequest]) (*connect.Response[v1.RejectFindingCandidateResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("cerebro.v1.BootstrapService.RejectFindingCandidate is not implemented"))
 }
 
 func (UnimplementedBootstrapServiceHandler) ResolveFinding(context.Context, *connect.Request[v1.ResolveFindingRequest]) (*connect.Response[v1.ResolveFindingResponse], error) {

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -160,6 +160,7 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 	mux.HandleFunc("GET /findings/{findingID}", app.handleGetFinding)
 	mux.HandleFunc("GET /finding-candidates/{candidateID}", app.handleGetFindingCandidate)
 	mux.HandleFunc("POST /finding-candidates/{candidateID}/promote", app.handlePromoteFindingCandidate)
+	mux.HandleFunc("POST /finding-candidates/{candidateID}/reject", app.handleRejectFindingCandidate)
 	mux.HandleFunc("POST /findings/{findingID}/resolve", app.handleResolveFinding)
 	mux.HandleFunc("POST /findings/{findingID}/suppress", app.handleSuppressFinding)
 	mux.HandleFunc("PUT /findings/{findingID}/assign", app.handleAssignFinding)
@@ -1630,6 +1631,38 @@ func (a *App) handlePromoteFindingCandidate(w http.ResponseWriter, r *http.Reque
 	writeProtoJSON(w, http.StatusOK, promoteFindingCandidateResponse(response))
 }
 
+func (a *App) handleRejectFindingCandidate(w http.ResponseWriter, r *http.Request) {
+	request := &cerebrov1.RejectFindingCandidateRequest{}
+	if err := readProtoJSON(r, request); err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	request.Id = r.PathValue("candidateID")
+	candidate, err := a.findingService().GetFindingCandidate(r.Context(), request.GetId())
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(a.deps.StateStore), candidate.RuntimeID, false); err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	if err := authorizeFindingCandidatePromotion(r.Context()); err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	response, err := a.findingService().RejectFindingCandidate(r.Context(), findings.RejectCandidateRequest{
+		CandidateID: request.GetId(),
+		RejectedBy:  request.GetRejectedBy(),
+		Rationale:   request.GetRationale(),
+	})
+	if err != nil {
+		writeFindingError(w, err)
+		return
+	}
+	writeProtoJSON(w, http.StatusOK, rejectFindingCandidateResponse(response))
+}
+
 func (a *App) handleListFindingEvidence(w http.ResponseWriter, r *http.Request) {
 	request := &cerebrov1.ListFindingEvidenceRequest{
 		RuntimeId:    r.PathValue("runtimeID"),
@@ -2039,6 +2072,36 @@ func (s *bootstrapService) PromoteFindingCandidate(ctx context.Context, req *con
 		return nil, findingConnectError(err)
 	}
 	return connect.NewResponse(promoteFindingCandidateResponse(response)), nil
+}
+
+func (s *bootstrapService) RejectFindingCandidate(ctx context.Context, req *connect.Request[cerebrov1.RejectFindingCandidateRequest]) (*connect.Response[cerebrov1.RejectFindingCandidateResponse], error) {
+	service := findings.New(
+		sourceRuntimeStore(s.deps.StateStore),
+		eventReplayer(s.deps.AppendLog),
+		findingStore(s.deps.StateStore),
+		findingEvaluationRunStore(s.deps.StateStore),
+		findingEvidenceStore(s.deps.StateStore),
+		claimStore(s.deps.StateStore),
+	).WithFindingCandidateStore(findingCandidateStore(s.deps.StateStore)).WithGraphStore(sourceProjectionGraphStore(s.deps.GraphStore)).WithGraphQueryStore(graphQueryStore(s.deps.GraphStore)).WithAppendLog(s.deps.AppendLog)
+	candidate, err := service.GetFindingCandidate(ctx, req.Msg.GetId())
+	if err != nil {
+		return nil, findingConnectError(err)
+	}
+	if err := authorizeSourceRuntimeIDTenant(ctx, sourceRuntimeStore(s.deps.StateStore), candidate.RuntimeID, false); err != nil {
+		return nil, findingConnectError(err)
+	}
+	if err := authorizeFindingCandidatePromotion(ctx); err != nil {
+		return nil, findingConnectError(err)
+	}
+	response, err := service.RejectFindingCandidate(ctx, findings.RejectCandidateRequest{
+		CandidateID: req.Msg.GetId(),
+		RejectedBy:  req.Msg.GetRejectedBy(),
+		Rationale:   req.Msg.GetRationale(),
+	})
+	if err != nil {
+		return nil, findingConnectError(err)
+	}
+	return connect.NewResponse(rejectFindingCandidateResponse(response)), nil
 }
 
 func (s *bootstrapService) ResolveFinding(ctx context.Context, req *connect.Request[cerebrov1.ResolveFindingRequest]) (*connect.Response[cerebrov1.ResolveFindingResponse], error) {
@@ -3430,6 +3493,16 @@ func promoteFindingCandidateResponse(result *findings.PromoteCandidateResult) *c
 	}
 }
 
+func rejectFindingCandidateResponse(result *findings.RejectCandidateResult) *cerebrov1.RejectFindingCandidateResponse {
+	if result == nil {
+		return &cerebrov1.RejectFindingCandidateResponse{}
+	}
+	return &cerebrov1.RejectFindingCandidateResponse{
+		Candidate:  findingCandidateMessage(result.Candidate),
+		DecisionId: result.DecisionID,
+	}
+}
+
 func findingMessages(findings []*ports.FindingRecord) []*cerebrov1.Finding {
 	messages := make([]*cerebrov1.Finding, 0, len(findings))
 	for _, finding := range findings {
@@ -3491,6 +3564,8 @@ func findingCandidateMessage(candidate *ports.FindingCandidateRecord) *cerebrov1
 		PromotedBy:         candidate.PromotedBy,
 		PromotionRationale: candidate.PromotionRationale,
 		ChangeTicket:       candidate.ChangeTicket,
+		RejectedBy:         candidate.RejectedBy,
+		RejectionRationale: candidate.RejectionRationale,
 	}
 	if !candidate.FirstObservedAt.IsZero() {
 		message.FirstObservedAt = timestamppb.New(candidate.FirstObservedAt.UTC())
@@ -3500,6 +3575,9 @@ func findingCandidateMessage(candidate *ports.FindingCandidateRecord) *cerebrov1
 	}
 	if !candidate.PromotedAt.IsZero() {
 		message.PromotedAt = timestamppb.New(candidate.PromotedAt.UTC())
+	}
+	if !candidate.RejectedAt.IsZero() {
+		message.RejectedAt = timestamppb.New(candidate.RejectedAt.UTC())
 	}
 	if !candidate.CreatedAt.IsZero() {
 		message.CreatedAt = timestamppb.New(candidate.CreatedAt.UTC())

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1234,6 +1234,24 @@ func (s *stubRuntimeStore) MarkFindingCandidatePromoted(_ context.Context, promo
 	return cloneFindingCandidate(cloned), nil
 }
 
+func (s *stubRuntimeStore) MarkFindingCandidateRejected(_ context.Context, rejection ports.FindingCandidateRejection) (*ports.FindingCandidateRecord, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	candidate, ok := s.findingCandidates[strings.TrimSpace(rejection.CandidateID)]
+	if !ok {
+		return nil, ports.ErrFindingCandidateNotFound
+	}
+	cloned := cloneFindingCandidate(candidate)
+	cloned.Status = "rejected"
+	cloned.DecisionID = strings.TrimSpace(rejection.DecisionID)
+	cloned.RejectedBy = strings.TrimSpace(rejection.RejectedBy)
+	cloned.RejectionRationale = strings.TrimSpace(rejection.Rationale)
+	cloned.RejectedAt = rejection.RejectedAt.UTC()
+	s.findingCandidates[cloned.ID] = cloned
+	return cloneFindingCandidate(cloned), nil
+}
+
 func (s *stubRuntimeStore) PutFindingEvaluationRun(_ context.Context, run *cerebrov1.FindingEvaluationRun) error {
 	if s.err != nil {
 		return s.err
@@ -2347,6 +2365,7 @@ func TestCandidateScopesCoverReadAndPromotionRoutes(t *testing.T) {
 	}{
 		{method: http.MethodGet, path: "/finding-candidates/candidate-1", want: scopeCosmoSecurityRead},
 		{method: http.MethodPost, path: "/finding-candidates/candidate-1/promote", want: scopeFindingCandidatePromote},
+		{method: http.MethodPost, path: "/finding-candidates/candidate-1/reject", want: scopeFindingCandidatePromote},
 	} {
 		req := httptest.NewRequest(tt.method, tt.path, nil)
 		if got := scopeForHTTPRequest(req); got != tt.want {
@@ -2360,6 +2379,7 @@ func TestCandidateScopesCoverReadAndPromotionRoutes(t *testing.T) {
 		{procedure: cerebrov1connect.BootstrapServiceListFindingCandidatesProcedure, want: scopeCosmoSecurityRead},
 		{procedure: cerebrov1connect.BootstrapServiceGetFindingCandidateProcedure, want: scopeCosmoSecurityRead},
 		{procedure: cerebrov1connect.BootstrapServicePromoteFindingCandidateProcedure, want: scopeFindingCandidatePromote},
+		{procedure: cerebrov1connect.BootstrapServiceRejectFindingCandidateProcedure, want: scopeFindingCandidatePromote},
 	} {
 		if got := scopeForConnectProcedure(tt.procedure); got != tt.want {
 			t.Fatalf("scopeForConnectProcedure(%s) = %q, want %q", tt.procedure, got, tt.want)
@@ -5305,6 +5325,35 @@ func TestFindingCandidateEndpointsEvaluateListGetAndPromote(t *testing.T) {
 	}
 	if promotePayload["decision_id"] == "" {
 		t.Fatal("promotion decision_id is empty")
+	}
+
+	rejectCandidateID := candidateID + "-reject"
+	rejectCandidate := cloneFindingCandidate(runtimeStore.findingCandidates[candidateID])
+	rejectCandidate.ID = rejectCandidateID
+	rejectCandidate.Status = "candidate"
+	rejectCandidate.DecisionID = ""
+	rejectCandidate.PromotedFindingID = ""
+	rejectCandidate.PromotedBy = ""
+	rejectCandidate.PromotionRationale = ""
+	rejectCandidate.ChangeTicket = ""
+	rejectCandidate.PromotedAt = time.Time{}
+	runtimeStore.findingCandidates[rejectCandidateID] = rejectCandidate
+	rejectResp, err := client.RejectFindingCandidate(context.Background(), connect.NewRequest(&cerebrov1.RejectFindingCandidateRequest{
+		Id:         rejectCandidateID,
+		RejectedBy: "analyst@example.com",
+		Rationale:  "Expected inactive policy rule fixture.",
+	}))
+	if err != nil {
+		t.Fatalf("RejectFindingCandidate() error = %v", err)
+	}
+	if got := rejectResp.Msg.GetCandidate().GetStatus(); got != "rejected" {
+		t.Fatalf("RejectFindingCandidate().Candidate.Status = %q, want rejected", got)
+	}
+	if rejectResp.Msg.GetDecisionId() == "" {
+		t.Fatal("RejectFindingCandidate().DecisionId is empty")
+	}
+	if got := len(runtimeStore.findings); got != 1 {
+		t.Fatalf("production findings after reject = %d, want 1", got)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1223,6 +1223,9 @@ func (s *stubRuntimeStore) MarkFindingCandidatePromoted(_ context.Context, promo
 		return nil, ports.ErrFindingCandidateNotFound
 	}
 	cloned := cloneFindingCandidate(candidate)
+	if cloned.Status != "candidate" {
+		return nil, ports.ErrFindingCandidateNotFound
+	}
 	cloned.Status = "promoted"
 	cloned.PromotedFindingID = strings.TrimSpace(promotion.PromotedFindingID)
 	cloned.DecisionID = strings.TrimSpace(promotion.DecisionID)
@@ -1243,6 +1246,9 @@ func (s *stubRuntimeStore) MarkFindingCandidateRejected(_ context.Context, rejec
 		return nil, ports.ErrFindingCandidateNotFound
 	}
 	cloned := cloneFindingCandidate(candidate)
+	if cloned.Status != "candidate" {
+		return nil, ports.ErrFindingCandidateNotFound
+	}
 	cloned.Status = "rejected"
 	cloned.DecisionID = strings.TrimSpace(rejection.DecisionID)
 	cloned.RejectedBy = strings.TrimSpace(rejection.RejectedBy)

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -567,7 +567,7 @@ func scopeForHTTPRequest(r *http.Request) string {
 		return scope
 	}
 	if r.Method != http.MethodGet {
-		if r.Method == http.MethodPost && strings.HasPrefix(path, "/finding-candidates/") && strings.HasSuffix(path, "/promote") {
+		if r.Method == http.MethodPost && strings.HasPrefix(path, "/finding-candidates/") && (strings.HasSuffix(path, "/promote") || strings.HasSuffix(path, "/reject")) {
 			return scopeFindingCandidatePromote
 		}
 		return ""
@@ -631,7 +631,8 @@ func scopeForConnectProcedure(procedure string) string {
 		cerebrov1connect.BootstrapServiceListGraphIngestRunsProcedure,
 		cerebrov1connect.BootstrapServiceCheckGraphIngestHealthProcedure:
 		return scopeCosmoSecurityRead
-	case cerebrov1connect.BootstrapServicePromoteFindingCandidateProcedure:
+	case cerebrov1connect.BootstrapServicePromoteFindingCandidateProcedure,
+		cerebrov1connect.BootstrapServiceRejectFindingCandidateProcedure:
 		return scopeFindingCandidatePromote
 	default:
 		return ""
@@ -1294,6 +1295,7 @@ var knownAccessAuditConnectProcedures = map[string]struct{}{
 	cerebrov1connect.BootstrapServiceGetFindingCandidateProcedure:                    {},
 	cerebrov1connect.BootstrapServiceEvaluateSourceRuntimeFindingCandidatesProcedure: {},
 	cerebrov1connect.BootstrapServicePromoteFindingCandidateProcedure:                {},
+	cerebrov1connect.BootstrapServiceRejectFindingCandidateProcedure:                 {},
 	cerebrov1connect.BootstrapServiceResolveFindingProcedure:                         {},
 	cerebrov1connect.BootstrapServiceSuppressFindingProcedure:                        {},
 	cerebrov1connect.BootstrapServiceAssignFindingProcedure:                          {},
@@ -1416,8 +1418,8 @@ func fallbackFindingCandidateRoute(path string) string {
 	}
 	parts := strings.SplitN(suffix, "/", 2)
 	switch parts[1] {
-	case "promote":
-		return "/finding-candidates/{candidateID}/promote"
+	case "promote", "reject":
+		return "/finding-candidates/{candidateID}/" + parts[1]
 	default:
 		return "/finding-candidates/{candidateID}/{subresource}"
 	}

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -21,7 +21,9 @@ import (
 const (
 	findingCandidateStatusCandidate = "candidate"
 	findingCandidateStatusPromoted  = "promoted"
+	findingCandidateStatusRejected  = "rejected"
 	findingCandidateDecisionType    = "finding_candidate_promotion"
+	findingCandidateRejectionType   = "finding_candidate_rejection"
 )
 
 // EvaluateCandidateRulesRequest scopes one non-production candidate evaluation.
@@ -74,6 +76,19 @@ type PromoteCandidateRequest struct {
 type PromoteCandidateResult struct {
 	Candidate  *ports.FindingCandidateRecord
 	Finding    *ports.FindingRecord
+	DecisionID string
+}
+
+// RejectCandidateRequest rejects one reviewed candidate without production writes.
+type RejectCandidateRequest struct {
+	CandidateID string
+	RejectedBy  string
+	Rationale   string
+}
+
+// RejectCandidateResult reports the updated candidate and audit decision.
+type RejectCandidateResult struct {
+	Candidate  *ports.FindingCandidateRecord
 	DecisionID string
 }
 
@@ -279,6 +294,9 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 		emitFindingCandidatePromotionTelemetry(ctx, "already_promoted", candidate, finding, strings.TrimSpace(candidate.DecisionID), startedAt)
 		return &PromoteCandidateResult{Candidate: candidate, Finding: finding, DecisionID: strings.TrimSpace(candidate.DecisionID)}, nil
 	}
+	if strings.EqualFold(strings.TrimSpace(candidate.Status), findingCandidateStatusRejected) {
+		return nil, fmt.Errorf("%w: rejected finding candidate cannot be promoted", ErrInvalidRequest)
+	}
 	if candidate.Finding == nil {
 		return nil, fmt.Errorf("%w: finding candidate has no finding snapshot", ErrInvalidRequest)
 	}
@@ -338,6 +356,53 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	return &PromoteCandidateResult{Candidate: promoted, Finding: stored, DecisionID: decisionID}, nil
 }
 
+// RejectFindingCandidate marks a reviewed candidate as intentionally not
+// production-worthy and records the review decision for audit.
+func (s *Service) RejectFindingCandidate(ctx context.Context, request RejectCandidateRequest) (*RejectCandidateResult, error) {
+	if s == nil || s.candidateStore == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	startedAt := time.Now().UTC()
+	candidateID := strings.TrimSpace(request.CandidateID)
+	if candidateID == "" {
+		return nil, fmt.Errorf("%w: finding candidate id is required", ErrInvalidRequest)
+	}
+	if strings.TrimSpace(request.RejectedBy) == "" {
+		return nil, fmt.Errorf("%w: rejected_by is required", ErrInvalidRequest)
+	}
+	if strings.TrimSpace(request.Rationale) == "" {
+		return nil, fmt.Errorf("%w: rejection rationale is required", ErrInvalidRequest)
+	}
+	candidate, err := s.candidateStore.GetFindingCandidate(ctx, candidateID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.EqualFold(strings.TrimSpace(candidate.Status), findingCandidateStatusPromoted) {
+		return nil, fmt.Errorf("%w: promoted finding candidate cannot be rejected", ErrInvalidRequest)
+	}
+	if strings.EqualFold(strings.TrimSpace(candidate.Status), findingCandidateStatusRejected) {
+		emitFindingCandidateRejectionTelemetry(ctx, "already_rejected", candidate, strings.TrimSpace(candidate.DecisionID), startedAt)
+		return &RejectCandidateResult{Candidate: candidate, DecisionID: strings.TrimSpace(candidate.DecisionID)}, nil
+	}
+	now := time.Now().UTC()
+	decisionID, err := s.recordCandidateRejectionDecision(ctx, candidate, request, now)
+	if err != nil {
+		return nil, err
+	}
+	rejected, err := s.candidateStore.MarkFindingCandidateRejected(ctx, ports.FindingCandidateRejection{
+		CandidateID: candidate.ID,
+		DecisionID:  decisionID,
+		RejectedBy:  strings.TrimSpace(request.RejectedBy),
+		Rationale:   strings.TrimSpace(request.Rationale),
+		RejectedAt:  now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	emitFindingCandidateRejectionTelemetry(ctx, "rejected", rejected, decisionID, startedAt)
+	return &RejectCandidateResult{Candidate: rejected, DecisionID: decisionID}, nil
+}
+
 func (s *Service) recordCandidatePromotionDecision(ctx context.Context, candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, request PromoteCandidateRequest, observedAt time.Time) (string, error) {
 	if candidate == nil || finding == nil {
 		return "", errors.New("candidate and finding are required")
@@ -378,6 +443,43 @@ func (s *Service) recordCandidatePromotionDecision(ctx context.Context, candidat
 	}
 	if err := s.recordAndProjectWorkflowEvent(ctx, event); err != nil {
 		return "", fmt.Errorf("record finding candidate %q promotion decision: %w", candidate.ID, err)
+	}
+	return decisionID, nil
+}
+
+func (s *Service) recordCandidateRejectionDecision(ctx context.Context, candidate *ports.FindingCandidateRecord, request RejectCandidateRequest, observedAt time.Time) (string, error) {
+	if candidate == nil {
+		return "", errors.New("candidate is required")
+	}
+	tenantID := strings.TrimSpace(candidate.TenantID)
+	targetIDs := []string{findingCandidateURN(tenantID, candidate.ID)}
+	decisionID := workflowevents.CanonicalWorkflowID(tenantID, "decision", candidate.ID, findingCandidateRejectionType, targetIDs, observedAt)
+	event, err := workflowevents.NewDecisionRecordedEvent(workflowevents.DecisionRecorded{
+		TenantID:      tenantID,
+		DecisionID:    decisionID,
+		DecisionType:  findingCandidateRejectionType,
+		Status:        findingDecisionStatusCompleted,
+		MadeBy:        strings.TrimSpace(request.RejectedBy),
+		Rationale:     strings.TrimSpace(request.Rationale),
+		TargetIDs:     targetIDs,
+		EvidenceIDs:   candidateEvidenceIDs(candidate.Evidence),
+		SourceSystem:  "findings",
+		SourceEventID: strings.TrimSpace(candidate.ID),
+		ObservedAt:    observedAt.Format(time.RFC3339Nano),
+		ValidFrom:     observedAt.Format(time.RFC3339Nano),
+		Metadata: map[string]any{
+			"tenant_id":                   tenantID,
+			"candidate_id":                strings.TrimSpace(candidate.ID),
+			"runtime_id":                  strings.TrimSpace(candidate.RuntimeID),
+			"rule_id":                     strings.TrimSpace(candidate.RuleID),
+			"candidate_observation_count": candidate.ObservationCount,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := s.recordAndProjectWorkflowEvent(ctx, event); err != nil {
+		return "", fmt.Errorf("record finding candidate %q rejection decision: %w", candidate.ID, err)
 	}
 	return decisionID, nil
 }
@@ -506,7 +608,7 @@ func emitFindingCandidateRunTelemetry(ctx context.Context, run *ports.FindingCan
 }
 
 func emitFindingCandidateListTelemetry(ctx context.Context, runtimeID string, candidates []*ports.FindingCandidateRecord, request ListCandidatesRequest) {
-	candidateCount, promotedCount, staleCount := 0, 0, 0
+	candidateCount, promotedCount, rejectedCount, staleCount := 0, 0, 0, 0
 	now := time.Now().UTC()
 	for _, candidate := range candidates {
 		if candidate == nil {
@@ -515,6 +617,10 @@ func emitFindingCandidateListTelemetry(ctx context.Context, runtimeID string, ca
 		candidateCount++
 		if strings.EqualFold(strings.TrimSpace(candidate.Status), findingCandidateStatusPromoted) {
 			promotedCount++
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(candidate.Status), findingCandidateStatusRejected) {
+			rejectedCount++
 			continue
 		}
 		if !candidate.LastObservedAt.IsZero() && now.Sub(candidate.LastObservedAt.UTC()) > 7*24*time.Hour {
@@ -527,7 +633,8 @@ func emitFindingCandidateListTelemetry(ctx context.Context, runtimeID string, ca
 		telemetry.Field{Key: "status_filter", Value: strings.TrimSpace(request.Status)},
 		telemetry.Field{Key: "candidate_count", Value: candidateCount},
 		telemetry.Field{Key: "promoted_count", Value: promotedCount},
-		telemetry.Field{Key: "open_candidate_count", Value: candidateCount - promotedCount},
+		telemetry.Field{Key: "rejected_count", Value: rejectedCount},
+		telemetry.Field{Key: "open_candidate_count", Value: candidateCount - promotedCount - rejectedCount},
 		telemetry.Field{Key: "stale_candidate_count", Value: staleCount},
 	))
 }
@@ -549,6 +656,22 @@ func emitFindingCandidatePromotionTelemetry(ctx context.Context, outcome string,
 		attrs = attrs.WithField(telemetry.Field{Key: "finding_id", Value: strings.TrimSpace(finding.ID)})
 	}
 	telemetry.Event(ctx, "finding_candidate.promotion", attrs)
+}
+
+func emitFindingCandidateRejectionTelemetry(ctx context.Context, outcome string, candidate *ports.FindingCandidateRecord, decisionID string, startedAt time.Time) {
+	attrs := telemetry.Attrs(
+		telemetry.Field{Key: "outcome", Value: strings.TrimSpace(outcome)},
+		telemetry.Field{Key: "decision_id", Value: strings.TrimSpace(decisionID)},
+		telemetry.Field{Key: "duration_ms", Value: time.Since(startedAt).Milliseconds()},
+	)
+	if candidate != nil {
+		attrs = attrs.WithField(telemetry.Field{Key: "candidate_id", Value: strings.TrimSpace(candidate.ID)})
+		attrs = attrs.WithField(telemetry.Field{Key: "tenant_id", Value: strings.TrimSpace(candidate.TenantID)})
+		attrs = attrs.WithField(telemetry.Field{Key: "runtime_id", Value: strings.TrimSpace(candidate.RuntimeID)})
+		attrs = attrs.WithField(telemetry.Field{Key: "rule_id", Value: strings.TrimSpace(candidate.RuleID)})
+		attrs = attrs.WithField(telemetry.Field{Key: "observation_count", Value: candidate.ObservationCount})
+	}
+	telemetry.Event(ctx, "finding_candidate.rejection", attrs)
 }
 
 func (s *Service) markCandidateEvaluationFailed(ctx context.Context, state *candidateRuleEvaluationState, evaluationErr error) error {

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -313,6 +313,19 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	production.Attributes["promotion_rationale"] = strings.TrimSpace(request.Rationale)
 	production.Attributes["promoted_by"] = strings.TrimSpace(request.PromotedBy)
 	production.Attributes["promoted_at"] = now.Format(time.RFC3339Nano)
+	decisionID := candidatePromotionDecisionID(candidate, production, now)
+	promoted, err := s.candidateStore.MarkFindingCandidatePromoted(ctx, ports.FindingCandidatePromotion{
+		CandidateID:       candidate.ID,
+		PromotedFindingID: production.ID,
+		DecisionID:        decisionID,
+		PromotedBy:        strings.TrimSpace(request.PromotedBy),
+		Rationale:         strings.TrimSpace(request.Rationale),
+		ChangeTicket:      strings.TrimSpace(request.ChangeTicket),
+		PromotedAt:        now,
+	})
+	if err != nil {
+		return nil, s.findingCandidateLifecycleConflict(ctx, candidate.ID, findingCandidateStatusPromoted, err)
+	}
 	stored, err := s.upsertFindingWithRisk(ctx, production, &cerebrov1.SourceRuntime{
 		Id:       strings.TrimSpace(candidate.RuntimeID),
 		TenantId: strings.TrimSpace(candidate.TenantID),
@@ -336,20 +349,7 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	if err := s.projectFindingAnchor(ctx, stored); err != nil {
 		return nil, fmt.Errorf("project promoted candidate %q finding %q: %w", candidate.ID, stored.ID, err)
 	}
-	decisionID, err := s.recordCandidatePromotionDecision(ctx, candidate, stored, request, now)
-	if err != nil {
-		return nil, err
-	}
-	promoted, err := s.candidateStore.MarkFindingCandidatePromoted(ctx, ports.FindingCandidatePromotion{
-		CandidateID:       candidate.ID,
-		PromotedFindingID: stored.ID,
-		DecisionID:        decisionID,
-		PromotedBy:        strings.TrimSpace(request.PromotedBy),
-		Rationale:         strings.TrimSpace(request.Rationale),
-		ChangeTicket:      strings.TrimSpace(request.ChangeTicket),
-		PromotedAt:        now,
-	})
-	if err != nil {
+	if err := s.recordCandidatePromotionDecision(ctx, promoted, stored, request, now, decisionID); err != nil {
 		return nil, err
 	}
 	emitFindingCandidatePromotionTelemetry(ctx, "promoted", promoted, stored, decisionID, startedAt)
@@ -385,10 +385,7 @@ func (s *Service) RejectFindingCandidate(ctx context.Context, request RejectCand
 		return &RejectCandidateResult{Candidate: candidate, DecisionID: strings.TrimSpace(candidate.DecisionID)}, nil
 	}
 	now := time.Now().UTC()
-	decisionID, err := s.recordCandidateRejectionDecision(ctx, candidate, request, now)
-	if err != nil {
-		return nil, err
-	}
+	decisionID := candidateRejectionDecisionID(candidate, now)
 	rejected, err := s.candidateStore.MarkFindingCandidateRejected(ctx, ports.FindingCandidateRejection{
 		CandidateID: candidate.ID,
 		DecisionID:  decisionID,
@@ -397,22 +394,63 @@ func (s *Service) RejectFindingCandidate(ctx context.Context, request RejectCand
 		RejectedAt:  now,
 	})
 	if err != nil {
+		return nil, s.findingCandidateLifecycleConflict(ctx, candidate.ID, findingCandidateStatusRejected, err)
+	}
+	if err := s.recordCandidateRejectionDecision(ctx, rejected, request, now, decisionID); err != nil {
 		return nil, err
 	}
 	emitFindingCandidateRejectionTelemetry(ctx, "rejected", rejected, decisionID, startedAt)
 	return &RejectCandidateResult{Candidate: rejected, DecisionID: decisionID}, nil
 }
 
-func (s *Service) recordCandidatePromotionDecision(ctx context.Context, candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, request PromoteCandidateRequest, observedAt time.Time) (string, error) {
+func (s *Service) findingCandidateLifecycleConflict(ctx context.Context, candidateID string, attemptedStatus string, err error) error {
+	if !errors.Is(err, ports.ErrFindingCandidateNotFound) {
+		return err
+	}
+	current, lookupErr := s.candidateStore.GetFindingCandidate(ctx, candidateID)
+	if lookupErr != nil {
+		return err
+	}
+	switch strings.TrimSpace(current.Status) {
+	case findingCandidateStatusPromoted:
+		return fmt.Errorf("%w: promoted finding candidate cannot transition to %s", ErrInvalidRequest, strings.TrimSpace(attemptedStatus))
+	case findingCandidateStatusRejected:
+		return fmt.Errorf("%w: rejected finding candidate cannot transition to %s", ErrInvalidRequest, strings.TrimSpace(attemptedStatus))
+	default:
+		return fmt.Errorf("%w: finding candidate status changed before lifecycle transition", ErrInvalidRequest)
+	}
+}
+
+func candidatePromotionDecisionID(candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, observedAt time.Time) string {
 	if candidate == nil || finding == nil {
-		return "", errors.New("candidate and finding are required")
+		return ""
+	}
+	tenantID := strings.TrimSpace(candidate.TenantID)
+	return workflowevents.CanonicalWorkflowID(tenantID, "decision", candidate.ID, findingCandidateDecisionType, []string{
+		findingGraphFindingURN(tenantID, finding),
+		findingCandidateURN(tenantID, candidate.ID),
+	}, observedAt)
+}
+
+func candidateRejectionDecisionID(candidate *ports.FindingCandidateRecord, observedAt time.Time) string {
+	if candidate == nil {
+		return ""
+	}
+	tenantID := strings.TrimSpace(candidate.TenantID)
+	return workflowevents.CanonicalWorkflowID(tenantID, "decision", candidate.ID, findingCandidateRejectionType, []string{
+		findingCandidateURN(tenantID, candidate.ID),
+	}, observedAt)
+}
+
+func (s *Service) recordCandidatePromotionDecision(ctx context.Context, candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, request PromoteCandidateRequest, observedAt time.Time, decisionID string) error {
+	if candidate == nil || finding == nil {
+		return errors.New("candidate and finding are required")
 	}
 	tenantID := strings.TrimSpace(candidate.TenantID)
 	targetIDs := []string{
 		findingGraphFindingURN(tenantID, finding),
 		findingCandidateURN(tenantID, candidate.ID),
 	}
-	decisionID := workflowevents.CanonicalWorkflowID(tenantID, "decision", candidate.ID, findingCandidateDecisionType, targetIDs, observedAt)
 	event, err := workflowevents.NewDecisionRecordedEvent(workflowevents.DecisionRecorded{
 		TenantID:      tenantID,
 		DecisionID:    decisionID,
@@ -439,21 +477,20 @@ func (s *Service) recordCandidatePromotionDecision(ctx context.Context, candidat
 		},
 	})
 	if err != nil {
-		return "", err
+		return err
 	}
 	if err := s.recordAndProjectWorkflowEvent(ctx, event); err != nil {
-		return "", fmt.Errorf("record finding candidate %q promotion decision: %w", candidate.ID, err)
+		return fmt.Errorf("record finding candidate %q promotion decision: %w", candidate.ID, err)
 	}
-	return decisionID, nil
+	return nil
 }
 
-func (s *Service) recordCandidateRejectionDecision(ctx context.Context, candidate *ports.FindingCandidateRecord, request RejectCandidateRequest, observedAt time.Time) (string, error) {
+func (s *Service) recordCandidateRejectionDecision(ctx context.Context, candidate *ports.FindingCandidateRecord, request RejectCandidateRequest, observedAt time.Time, decisionID string) error {
 	if candidate == nil {
-		return "", errors.New("candidate is required")
+		return errors.New("candidate is required")
 	}
 	tenantID := strings.TrimSpace(candidate.TenantID)
 	targetIDs := []string{findingCandidateURN(tenantID, candidate.ID)}
-	decisionID := workflowevents.CanonicalWorkflowID(tenantID, "decision", candidate.ID, findingCandidateRejectionType, targetIDs, observedAt)
 	event, err := workflowevents.NewDecisionRecordedEvent(workflowevents.DecisionRecorded{
 		TenantID:      tenantID,
 		DecisionID:    decisionID,
@@ -476,12 +513,12 @@ func (s *Service) recordCandidateRejectionDecision(ctx context.Context, candidat
 		},
 	})
 	if err != nil {
-		return "", err
+		return err
 	}
 	if err := s.recordAndProjectWorkflowEvent(ctx, event); err != nil {
-		return "", fmt.Errorf("record finding candidate %q rejection decision: %w", candidate.ID, err)
+		return fmt.Errorf("record finding candidate %q rejection decision: %w", candidate.ID, err)
 	}
-	return decisionID, nil
+	return nil
 }
 
 func normalizeCandidateFinding(record *ports.FindingRecord, runtime *cerebrov1.SourceRuntime, observedAt time.Time) *ports.FindingRecord {

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -314,18 +314,6 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	production.Attributes["promoted_by"] = strings.TrimSpace(request.PromotedBy)
 	production.Attributes["promoted_at"] = now.Format(time.RFC3339Nano)
 	decisionID := candidatePromotionDecisionID(candidate, production, now)
-	promoted, err := s.candidateStore.MarkFindingCandidatePromoted(ctx, ports.FindingCandidatePromotion{
-		CandidateID:       candidate.ID,
-		PromotedFindingID: production.ID,
-		DecisionID:        decisionID,
-		PromotedBy:        strings.TrimSpace(request.PromotedBy),
-		Rationale:         strings.TrimSpace(request.Rationale),
-		ChangeTicket:      strings.TrimSpace(request.ChangeTicket),
-		PromotedAt:        now,
-	})
-	if err != nil {
-		return nil, s.findingCandidateLifecycleConflict(ctx, candidate.ID, findingCandidateStatusPromoted, err)
-	}
 	stored, err := s.upsertFindingWithRisk(ctx, production, &cerebrov1.SourceRuntime{
 		Id:       strings.TrimSpace(candidate.RuntimeID),
 		TenantId: strings.TrimSpace(candidate.TenantID),
@@ -349,8 +337,20 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	if err := s.projectFindingAnchor(ctx, stored); err != nil {
 		return nil, fmt.Errorf("project promoted candidate %q finding %q: %w", candidate.ID, stored.ID, err)
 	}
-	if err := s.recordCandidatePromotionDecision(ctx, promoted, stored, request, now, decisionID); err != nil {
+	if err := s.recordCandidatePromotionDecision(ctx, candidate, stored, request, now, decisionID); err != nil {
 		return nil, err
+	}
+	promoted, err := s.candidateStore.MarkFindingCandidatePromoted(ctx, ports.FindingCandidatePromotion{
+		CandidateID:       candidate.ID,
+		PromotedFindingID: stored.ID,
+		DecisionID:        decisionID,
+		PromotedBy:        strings.TrimSpace(request.PromotedBy),
+		Rationale:         strings.TrimSpace(request.Rationale),
+		ChangeTicket:      strings.TrimSpace(request.ChangeTicket),
+		PromotedAt:        now,
+	})
+	if err != nil {
+		return nil, s.findingCandidateLifecycleConflict(ctx, candidate.ID, findingCandidateStatusPromoted, err)
 	}
 	emitFindingCandidatePromotionTelemetry(ctx, "promoted", promoted, stored, decisionID, startedAt)
 	return &PromoteCandidateResult{Candidate: promoted, Finding: stored, DecisionID: decisionID}, nil
@@ -386,6 +386,9 @@ func (s *Service) RejectFindingCandidate(ctx context.Context, request RejectCand
 	}
 	now := time.Now().UTC()
 	decisionID := candidateRejectionDecisionID(candidate, now)
+	if err := s.recordCandidateRejectionDecision(ctx, candidate, request, now, decisionID); err != nil {
+		return nil, err
+	}
 	rejected, err := s.candidateStore.MarkFindingCandidateRejected(ctx, ports.FindingCandidateRejection{
 		CandidateID: candidate.ID,
 		DecisionID:  decisionID,
@@ -395,9 +398,6 @@ func (s *Service) RejectFindingCandidate(ctx context.Context, request RejectCand
 	})
 	if err != nil {
 		return nil, s.findingCandidateLifecycleConflict(ctx, candidate.ID, findingCandidateStatusRejected, err)
-	}
-	if err := s.recordCandidateRejectionDecision(ctx, rejected, request, now, decisionID); err != nil {
-		return nil, err
 	}
 	emitFindingCandidateRejectionTelemetry(ctx, "rejected", rejected, decisionID, startedAt)
 	return &RejectCandidateResult{Candidate: rejected, DecisionID: decisionID}, nil

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -62,11 +62,15 @@ func (s *stubReplayer) Replay(_ context.Context, request ports.ReplayRequest) ([
 
 type recordingAppendLog struct {
 	events []*cerebrov1.EventEnvelope
+	err    error
 }
 
 func (s *recordingAppendLog) Ping(context.Context) error { return nil }
 
 func (s *recordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) error {
+	if s.err != nil {
+		return s.err
+	}
 	s.events = append(s.events, proto.Clone(event).(*cerebrov1.EventEnvelope))
 	return nil
 }
@@ -86,6 +90,7 @@ type stubFindingStore struct {
 	failRunPutByCall          map[int]error
 	evidence                  map[string]*cerebrov1.FindingEvidence
 	evidenceList              ports.ListFindingEvidenceRequest
+	putEvidenceErr            error
 	candidateState            stubFindingCandidateState
 	dropReturnedGraphEvidence bool
 	upsertCount               int
@@ -98,10 +103,12 @@ type stubFindingStore struct {
 }
 
 type stubFindingCandidateState struct {
-	runs        map[string]*ports.FindingCandidateRun
-	candidates  map[string]*ports.FindingCandidateRecord
-	listRequest ports.ListFindingCandidatesRequest
-	upsertCount int
+	runs              map[string]*ports.FindingCandidateRun
+	candidates        map[string]*ports.FindingCandidateRecord
+	listRequest       ports.ListFindingCandidatesRequest
+	upsertCount       int
+	markPromotedCount int
+	markRejectedCount int
 }
 
 type stubFindingBackfillState struct {
@@ -500,6 +507,9 @@ func (s *stubFindingStore) ListFindingEvaluationRuns(_ context.Context, request 
 }
 
 func (s *stubFindingStore) PutFindingEvidence(_ context.Context, evidence *cerebrov1.FindingEvidence) error {
+	if s.putEvidenceErr != nil {
+		return s.putEvidenceErr
+	}
 	if evidence == nil {
 		return errors.New("finding evidence is required")
 	}
@@ -654,6 +664,7 @@ func (s *stubFindingStore) ListFindingCandidates(_ context.Context, request port
 }
 
 func (s *stubFindingStore) MarkFindingCandidatePromoted(_ context.Context, promotion ports.FindingCandidatePromotion) (*ports.FindingCandidateRecord, error) {
+	s.candidateState.markPromotedCount++
 	candidate, ok := s.candidateState.candidates[strings.TrimSpace(promotion.CandidateID)]
 	if !ok {
 		return nil, ports.ErrFindingCandidateNotFound
@@ -674,6 +685,7 @@ func (s *stubFindingStore) MarkFindingCandidatePromoted(_ context.Context, promo
 }
 
 func (s *stubFindingStore) MarkFindingCandidateRejected(_ context.Context, rejection ports.FindingCandidateRejection) (*ports.FindingCandidateRecord, error) {
+	s.candidateState.markRejectedCount++
 	candidate, ok := s.candidateState.candidates[strings.TrimSpace(rejection.CandidateID)]
 	if !ok {
 		return nil, ports.ErrFindingCandidateNotFound
@@ -2802,6 +2814,78 @@ func TestPromoteFindingCandidateWritesProductionFindingEvidenceAndAudit(t *testi
 	}
 }
 
+func TestPromoteFindingCandidateDoesNotMarkPromotedBeforeDownstreamSuccess(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	finding := &ports.FindingRecord{
+		ID:              "finding-1",
+		Fingerprint:     "fingerprint-1",
+		TenantID:        "writer",
+		RuntimeID:       "writer-okta-audit",
+		RuleID:          "rule-a",
+		Title:           "Rule A",
+		Severity:        "MEDIUM",
+		Status:          findingStatusOpen,
+		Summary:         "candidate summary",
+		ResourceURNs:    []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+	}
+	candidate := &ports.FindingCandidateRecord{
+		ID:               "candidate-1",
+		TenantID:         "writer",
+		RuntimeID:        "writer-okta-audit",
+		RuleID:           "rule-a",
+		Fingerprint:      "fingerprint-1",
+		Status:           findingCandidateStatusCandidate,
+		Finding:          cloneFinding(finding),
+		Evidence:         []*cerebrov1.FindingEvidence{{Id: "evidence-1", FindingId: "finding-1"}},
+		LastRunID:        "candidate-run-1",
+		ObservationCount: 1,
+		FirstObservedAt:  now,
+		LastObservedAt:   now,
+	}
+	store := &stubFindingStore{
+		candidateState: stubFindingCandidateState{
+			candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
+		},
+		findings:       map[string]*ports.FindingRecord{},
+		putEvidenceErr: errors.New("evidence write failed"),
+	}
+	appendLog := &recordingAppendLog{}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		nil,
+		store,
+		store,
+		store,
+		store,
+		nil,
+	).WithFindingCandidateStore(store).WithAppendLog(appendLog)
+
+	_, err := service.PromoteFindingCandidate(context.Background(), PromoteCandidateRequest{
+		CandidateID:           "candidate-1",
+		PromotedBy:            "analyst@example.com",
+		Rationale:             "Validated against source data.",
+		ChangeTicket:          "SEC-123",
+		FalsePositiveReviewed: true,
+		GraphCoverageReviewed: true,
+	})
+	if err == nil {
+		t.Fatal("PromoteFindingCandidate() error = nil, want downstream failure")
+	}
+	if got := store.candidateState.markPromotedCount; got != 0 {
+		t.Fatalf("MarkFindingCandidatePromoted calls = %d, want 0", got)
+	}
+	if got := store.candidateState.candidates["candidate-1"].Status; got != findingCandidateStatusCandidate {
+		t.Fatalf("candidate status = %q, want candidate", got)
+	}
+	if got := len(appendLog.events); got != 0 {
+		t.Fatalf("append log events = %d, want 0", got)
+	}
+}
+
 func TestPromoteFindingCandidateAlreadyPromotedReturnsExistingFinding(t *testing.T) {
 	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
 	finding := &ports.FindingRecord{
@@ -2956,6 +3040,68 @@ func TestRejectFindingCandidateRecordsAuditWithoutProductionWrites(t *testing.T)
 	}
 	if got := len(appendLog.events); got != 1 {
 		t.Fatalf("append log events = %d, want 1", got)
+	}
+}
+
+func TestRejectFindingCandidateDoesNotMarkRejectedBeforeAudit(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	finding := &ports.FindingRecord{
+		ID:              "finding-1",
+		Fingerprint:     "fingerprint-1",
+		TenantID:        "writer",
+		RuntimeID:       "writer-okta-audit",
+		RuleID:          "rule-a",
+		Title:           "Rule A",
+		Severity:        "LOW",
+		Status:          findingStatusOpen,
+		Summary:         "candidate summary",
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+	}
+	candidate := &ports.FindingCandidateRecord{
+		ID:               "candidate-1",
+		TenantID:         "writer",
+		RuntimeID:        "writer-okta-audit",
+		RuleID:           "rule-a",
+		Fingerprint:      "fingerprint-1",
+		Status:           findingCandidateStatusCandidate,
+		Finding:          cloneFinding(finding),
+		LastRunID:        "candidate-run-1",
+		ObservationCount: 1,
+		FirstObservedAt:  now,
+		LastObservedAt:   now,
+	}
+	store := &stubFindingStore{
+		candidateState: stubFindingCandidateState{
+			candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
+		},
+	}
+	appendLog := &recordingAppendLog{err: errors.New("append failed")}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		nil,
+		store,
+		store,
+		store,
+		store,
+		nil,
+	).WithFindingCandidateStore(store).WithAppendLog(appendLog)
+
+	_, err := service.RejectFindingCandidate(context.Background(), RejectCandidateRequest{
+		CandidateID: "candidate-1",
+		RejectedBy:  "analyst@example.com",
+		Rationale:   "Matched expected break-glass test account.",
+	})
+	if err == nil {
+		t.Fatal("RejectFindingCandidate() error = nil, want audit failure")
+	}
+	if got := store.candidateState.markRejectedCount; got != 0 {
+		t.Fatalf("MarkFindingCandidateRejected calls = %d, want 0", got)
+	}
+	if got := store.candidateState.candidates["candidate-1"].Status; got != findingCandidateStatusCandidate {
+		t.Fatalf("candidate status = %q, want candidate", got)
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -659,6 +659,9 @@ func (s *stubFindingStore) MarkFindingCandidatePromoted(_ context.Context, promo
 		return nil, ports.ErrFindingCandidateNotFound
 	}
 	cloned := cloneFindingCandidate(candidate)
+	if cloned.Status != findingCandidateStatusCandidate {
+		return nil, ports.ErrFindingCandidateNotFound
+	}
 	cloned.Status = findingCandidateStatusPromoted
 	cloned.PromotedFindingID = strings.TrimSpace(promotion.PromotedFindingID)
 	cloned.DecisionID = strings.TrimSpace(promotion.DecisionID)
@@ -676,6 +679,9 @@ func (s *stubFindingStore) MarkFindingCandidateRejected(_ context.Context, rejec
 		return nil, ports.ErrFindingCandidateNotFound
 	}
 	cloned := cloneFindingCandidate(candidate)
+	if cloned.Status != findingCandidateStatusCandidate {
+		return nil, ports.ErrFindingCandidateNotFound
+	}
 	cloned.Status = findingCandidateStatusRejected
 	cloned.DecisionID = strings.TrimSpace(rejection.DecisionID)
 	cloned.RejectedBy = strings.TrimSpace(rejection.RejectedBy)

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -600,7 +600,8 @@ func (s *stubFindingStore) UpsertFindingCandidate(_ context.Context, candidate *
 	cloned := cloneFindingCandidate(candidate)
 	if existing := s.candidateState.candidates[cloned.ID]; existing != nil {
 		cloned.ObservationCount += existing.ObservationCount
-		if existing.Status == findingCandidateStatusPromoted {
+		switch existing.Status {
+		case findingCandidateStatusPromoted:
 			cloned.Status = existing.Status
 			cloned.PromotedFindingID = existing.PromotedFindingID
 			cloned.DecisionID = existing.DecisionID
@@ -608,6 +609,12 @@ func (s *stubFindingStore) UpsertFindingCandidate(_ context.Context, candidate *
 			cloned.PromotionRationale = existing.PromotionRationale
 			cloned.ChangeTicket = existing.ChangeTicket
 			cloned.PromotedAt = existing.PromotedAt
+		case findingCandidateStatusRejected:
+			cloned.Status = existing.Status
+			cloned.DecisionID = existing.DecisionID
+			cloned.RejectedBy = existing.RejectedBy
+			cloned.RejectionRationale = existing.RejectionRationale
+			cloned.RejectedAt = existing.RejectedAt
 		}
 	}
 	s.candidateState.candidates[cloned.ID] = cloned
@@ -659,6 +666,21 @@ func (s *stubFindingStore) MarkFindingCandidatePromoted(_ context.Context, promo
 	cloned.PromotionRationale = strings.TrimSpace(promotion.Rationale)
 	cloned.ChangeTicket = strings.TrimSpace(promotion.ChangeTicket)
 	cloned.PromotedAt = promotion.PromotedAt.UTC()
+	s.candidateState.candidates[cloned.ID] = cloned
+	return cloneFindingCandidate(cloned), nil
+}
+
+func (s *stubFindingStore) MarkFindingCandidateRejected(_ context.Context, rejection ports.FindingCandidateRejection) (*ports.FindingCandidateRecord, error) {
+	candidate, ok := s.candidateState.candidates[strings.TrimSpace(rejection.CandidateID)]
+	if !ok {
+		return nil, ports.ErrFindingCandidateNotFound
+	}
+	cloned := cloneFindingCandidate(candidate)
+	cloned.Status = findingCandidateStatusRejected
+	cloned.DecisionID = strings.TrimSpace(rejection.DecisionID)
+	cloned.RejectedBy = strings.TrimSpace(rejection.RejectedBy)
+	cloned.RejectionRationale = strings.TrimSpace(rejection.Rationale)
+	cloned.RejectedAt = rejection.RejectedAt.UTC()
 	s.candidateState.candidates[cloned.ID] = cloned
 	return cloneFindingCandidate(cloned), nil
 }
@@ -2852,6 +2874,82 @@ func TestPromoteFindingCandidateAlreadyPromotedReturnsExistingFinding(t *testing
 	}
 	if got := len(appendLog.events); got != 0 {
 		t.Fatalf("append log events = %d, want 0", got)
+	}
+}
+
+func TestRejectFindingCandidateRecordsAuditWithoutProductionWrites(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	finding := &ports.FindingRecord{
+		ID:              "finding-1",
+		Fingerprint:     "fingerprint-1",
+		TenantID:        "writer",
+		RuntimeID:       "writer-okta-audit",
+		RuleID:          "rule-a",
+		Title:           "Rule A",
+		Severity:        "LOW",
+		Status:          findingStatusOpen,
+		Summary:         "candidate summary",
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+	}
+	candidate := &ports.FindingCandidateRecord{
+		ID:               "candidate-1",
+		TenantID:         "writer",
+		RuntimeID:        "writer-okta-audit",
+		RuleID:           "rule-a",
+		Fingerprint:      "fingerprint-1",
+		Status:           findingCandidateStatusCandidate,
+		Finding:          cloneFinding(finding),
+		Evidence:         []*cerebrov1.FindingEvidence{{Id: "evidence-1", FindingId: "finding-1"}},
+		LastRunID:        "candidate-run-1",
+		ObservationCount: 1,
+		FirstObservedAt:  now,
+		LastObservedAt:   now,
+	}
+	store := &stubFindingStore{
+		candidateState: stubFindingCandidateState{
+			candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
+		},
+		findings: map[string]*ports.FindingRecord{},
+	}
+	appendLog := &recordingAppendLog{}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		nil,
+		store,
+		store,
+		store,
+		store,
+		nil,
+	).WithFindingCandidateStore(store).WithAppendLog(appendLog)
+
+	result, err := service.RejectFindingCandidate(context.Background(), RejectCandidateRequest{
+		CandidateID: "candidate-1",
+		RejectedBy:  "analyst@example.com",
+		Rationale:   "Matched expected break-glass test account.",
+	})
+	if err != nil {
+		t.Fatalf("RejectFindingCandidate() error = %v", err)
+	}
+	if got := result.Candidate.Status; got != findingCandidateStatusRejected {
+		t.Fatalf("candidate status = %q, want rejected", got)
+	}
+	if got := result.Candidate.RejectedBy; got != "analyst@example.com" {
+		t.Fatalf("RejectedBy = %q, want analyst@example.com", got)
+	}
+	if result.DecisionID == "" {
+		t.Fatal("DecisionID is empty")
+	}
+	if got := store.upsertCount; got != 0 {
+		t.Fatalf("production UpsertFinding calls = %d, want 0", got)
+	}
+	if got := len(store.evidence); got != 0 {
+		t.Fatalf("production evidence rows = %d, want 0", got)
+	}
+	if got := len(appendLog.events); got != 1 {
+		t.Fatalf("append log events = %d, want 1", got)
 	}
 }
 

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -388,6 +388,9 @@ type FindingCandidateRecord struct {
 	PromotionRationale string
 	ChangeTicket       string
 	PromotedAt         time.Time
+	RejectedBy         string
+	RejectionRationale string
+	RejectedAt         time.Time
 }
 
 // ListFindingCandidatesRequest scopes one candidate-finding query.
@@ -411,6 +414,16 @@ type FindingCandidatePromotion struct {
 	Rationale         string
 	ChangeTicket      string
 	PromotedAt        time.Time
+}
+
+// FindingCandidateRejection marks one candidate as reviewed and rejected without
+// writing production finding state.
+type FindingCandidateRejection struct {
+	CandidateID string
+	DecisionID  string
+	RejectedBy  string
+	Rationale   string
+	RejectedAt  time.Time
 }
 
 // FindingStore persists normalized findings in the state store.
@@ -452,4 +465,5 @@ type FindingCandidateStore interface {
 	GetFindingCandidate(context.Context, string) (*FindingCandidateRecord, error)
 	ListFindingCandidates(context.Context, ListFindingCandidatesRequest) ([]*FindingCandidateRecord, error)
 	MarkFindingCandidatePromoted(context.Context, FindingCandidatePromotion) (*FindingCandidateRecord, error)
+	MarkFindingCandidateRejected(context.Context, FindingCandidateRejection) (*FindingCandidateRecord, error)
 }

--- a/internal/statestore/postgres/finding_candidates.go
+++ b/internal/statestore/postgres/finding_candidates.go
@@ -52,9 +52,15 @@ var ensureFindingCandidateStatements = []string{
   promotion_rationale TEXT NOT NULL DEFAULT '',
   change_ticket TEXT NOT NULL DEFAULT '',
   promoted_at TIMESTAMPTZ,
+  rejected_by TEXT NOT NULL DEFAULT '',
+  rejection_rationale TEXT NOT NULL DEFAULT '',
+  rejected_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
+	`ALTER TABLE finding_candidates ADD COLUMN IF NOT EXISTS rejected_by TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE finding_candidates ADD COLUMN IF NOT EXISTS rejection_rationale TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE finding_candidates ADD COLUMN IF NOT EXISTS rejected_at TIMESTAMPTZ`,
 	`CREATE INDEX IF NOT EXISTS finding_candidates_runtime_idx ON finding_candidates (tenant_id, runtime_id, last_observed_at DESC, id)`,
 	`CREATE INDEX IF NOT EXISTS finding_candidates_rule_idx ON finding_candidates (tenant_id, rule_id, last_observed_at DESC, id)`,
 	`CREATE INDEX IF NOT EXISTS finding_candidates_status_idx ON finding_candidates (tenant_id, status, last_observed_at DESC, id)`,
@@ -268,7 +274,7 @@ DO UPDATE SET
   runtime_id = EXCLUDED.runtime_id,
   rule_id = EXCLUDED.rule_id,
   fingerprint = EXCLUDED.fingerprint,
-  status = CASE WHEN finding_candidates.status = 'promoted' THEN finding_candidates.status ELSE EXCLUDED.status END,
+  status = CASE WHEN finding_candidates.status IN ('promoted', 'rejected') THEN finding_candidates.status ELSE EXCLUDED.status END,
   finding_json = EXCLUDED.finding_json,
   evidence_json = EXCLUDED.evidence_json,
   last_run_id = EXCLUDED.last_run_id,
@@ -411,10 +417,60 @@ RETURNING `+findingCandidateSelectColumns,
 	return candidate, nil
 }
 
+// MarkFindingCandidateRejected records rejection metadata on one candidate row.
+func (s *Store) MarkFindingCandidateRejected(ctx context.Context, rejection ports.FindingCandidateRejection) (*ports.FindingCandidateRecord, error) {
+	id := strings.TrimSpace(rejection.CandidateID)
+	if id == "" {
+		return nil, errors.New("finding candidate id is required")
+	}
+	if strings.TrimSpace(rejection.DecisionID) == "" {
+		return nil, errors.New("rejection decision id is required")
+	}
+	if strings.TrimSpace(rejection.RejectedBy) == "" {
+		return nil, errors.New("rejected by is required")
+	}
+	if strings.TrimSpace(rejection.Rationale) == "" {
+		return nil, errors.New("rejection rationale is required")
+	}
+	rejectedAt := rejection.RejectedAt.UTC()
+	if rejectedAt.IsZero() {
+		rejectedAt = time.Now().UTC()
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingCandidateTables(ctx); err != nil {
+		return nil, err
+	}
+	candidate, err := s.queryFindingCandidate(ctx, `
+UPDATE finding_candidates
+SET status = 'rejected',
+  decision_id = $2,
+  rejected_by = $3,
+  rejection_rationale = $4,
+  rejected_at = $5,
+  updated_at = NOW()
+WHERE id = $1
+RETURNING `+findingCandidateSelectColumns,
+		id,
+		strings.TrimSpace(rejection.DecisionID),
+		strings.TrimSpace(rejection.RejectedBy),
+		strings.TrimSpace(rejection.Rationale),
+		rejectedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ports.ErrFindingCandidateNotFound, id)
+		}
+		return nil, fmt.Errorf("mark finding candidate %q rejected: %w", id, err)
+	}
+	return candidate, nil
+}
+
 const findingCandidateSelectColumns = `id, tenant_id, runtime_id, rule_id, fingerprint, status,
   finding_json::text, evidence_json::text, last_run_id, observation_count, first_observed_at,
   last_observed_at, promoted_finding_id, decision_id, promoted_by, promotion_rationale,
-  change_ticket, promoted_at, created_at, updated_at`
+  change_ticket, promoted_at, rejected_by, rejection_rationale, rejected_at, created_at, updated_at`
 
 type findingCandidateScanner interface {
 	Scan(dest ...any) error
@@ -429,6 +485,7 @@ func scanFindingCandidate(scanner findingCandidateScanner) (*ports.FindingCandid
 	var findingJSON string
 	var evidenceJSON string
 	var promotedAt sql.NullTime
+	var rejectedAt sql.NullTime
 	if err := scanner.Scan(
 		&candidate.ID,
 		&candidate.TenantID,
@@ -448,6 +505,9 @@ func scanFindingCandidate(scanner findingCandidateScanner) (*ports.FindingCandid
 		&candidate.PromotionRationale,
 		&candidate.ChangeTicket,
 		&promotedAt,
+		&candidate.RejectedBy,
+		&candidate.RejectionRationale,
+		&rejectedAt,
 		&candidate.CreatedAt,
 		&candidate.UpdatedAt,
 	); err != nil {
@@ -465,6 +525,9 @@ func scanFindingCandidate(scanner findingCandidateScanner) (*ports.FindingCandid
 	candidate.Evidence = evidence
 	if promotedAt.Valid {
 		candidate.PromotedAt = promotedAt.Time.UTC()
+	}
+	if rejectedAt.Valid {
+		candidate.RejectedAt = rejectedAt.Time.UTC()
 	}
 	return candidate, nil
 }

--- a/internal/statestore/postgres/finding_candidates.go
+++ b/internal/statestore/postgres/finding_candidates.go
@@ -399,6 +399,7 @@ SET status = 'promoted',
   promoted_at = $7,
   updated_at = NOW()
 WHERE id = $1
+  AND status = 'candidate'
 RETURNING `+findingCandidateSelectColumns,
 		id,
 		strings.TrimSpace(promotion.PromotedFindingID),
@@ -451,6 +452,7 @@ SET status = 'rejected',
   rejected_at = $5,
   updated_at = NOW()
 WHERE id = $1
+  AND status = 'candidate'
 RETURNING `+findingCandidateSelectColumns,
 		id,
 		strings.TrimSpace(rejection.DecisionID),

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -279,6 +279,27 @@ func TestValidateFindingCandidateRequiresSnapshotAndLastRun(t *testing.T) {
 	}
 }
 
+func TestMarkFindingCandidateRejectedValidatesReviewMetadata(t *testing.T) {
+	store := &Store{}
+	_, err := store.MarkFindingCandidateRejected(context.Background(), ports.FindingCandidateRejection{
+		CandidateID: "candidate-1",
+		DecisionID:  "decision-1",
+		RejectedBy:  "analyst@example.com",
+	})
+	if err == nil {
+		t.Fatal("MarkFindingCandidateRejected() error = nil, want missing rationale error")
+	}
+	_, err = store.MarkFindingCandidateRejected(context.Background(), ports.FindingCandidateRejection{
+		CandidateID: "candidate-1",
+		DecisionID:  "decision-1",
+		RejectedBy:  "analyst@example.com",
+		Rationale:   "Expected fixture candidate.",
+	})
+	if err == nil {
+		t.Fatal("MarkFindingCandidateRejected() error = nil, want unconfigured postgres error")
+	}
+}
+
 func TestFindingListQueryIncludesOptionalFilters(t *testing.T) {
 	query, args, err := findingListQuery(ports.ListFindingsRequest{
 		TenantID:    "tenant-a",

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -626,11 +626,11 @@ message FindingCandidate {
   string promotion_rationale = 16;
   string change_ticket = 17;
   google.protobuf.Timestamp promoted_at = 18;
-  string rejected_by = 19;
-  string rejection_rationale = 20;
-  google.protobuf.Timestamp rejected_at = 21;
-  google.protobuf.Timestamp created_at = 22;
-  google.protobuf.Timestamp updated_at = 23;
+  google.protobuf.Timestamp created_at = 19;
+  google.protobuf.Timestamp updated_at = 20;
+  string rejected_by = 21;
+  string rejection_rationale = 22;
+  google.protobuf.Timestamp rejected_at = 23;
 }
 
 // ListFindingCandidatesRequest queries isolated candidate finding snapshots for one runtime.

--- a/proto/cerebro/v1/bootstrap.proto
+++ b/proto/cerebro/v1/bootstrap.proto
@@ -32,6 +32,7 @@ service BootstrapService {
   rpc GetFindingCandidate(GetFindingCandidateRequest) returns (GetFindingCandidateResponse);
   rpc EvaluateSourceRuntimeFindingCandidates(EvaluateSourceRuntimeFindingCandidatesRequest) returns (EvaluateSourceRuntimeFindingCandidatesResponse);
   rpc PromoteFindingCandidate(PromoteFindingCandidateRequest) returns (PromoteFindingCandidateResponse);
+  rpc RejectFindingCandidate(RejectFindingCandidateRequest) returns (RejectFindingCandidateResponse);
   rpc ResolveFinding(ResolveFindingRequest) returns (ResolveFindingResponse);
   rpc SuppressFinding(SuppressFindingRequest) returns (SuppressFindingResponse);
   rpc AssignFinding(AssignFindingRequest) returns (AssignFindingResponse);
@@ -625,8 +626,11 @@ message FindingCandidate {
   string promotion_rationale = 16;
   string change_ticket = 17;
   google.protobuf.Timestamp promoted_at = 18;
-  google.protobuf.Timestamp created_at = 19;
-  google.protobuf.Timestamp updated_at = 20;
+  string rejected_by = 19;
+  string rejection_rationale = 20;
+  google.protobuf.Timestamp rejected_at = 21;
+  google.protobuf.Timestamp created_at = 22;
+  google.protobuf.Timestamp updated_at = 23;
 }
 
 // ListFindingCandidatesRequest queries isolated candidate finding snapshots for one runtime.
@@ -690,6 +694,19 @@ message PromoteFindingCandidateResponse {
   Finding finding = 1;
   FindingCandidate candidate = 2;
   string decision_id = 3;
+}
+
+// RejectFindingCandidateRequest records a reviewed candidate as not production-worthy.
+message RejectFindingCandidateRequest {
+  string id = 1;
+  string rejected_by = 2;
+  string rationale = 3;
+}
+
+// RejectFindingCandidateResponse returns the rejected candidate and audit decision.
+message RejectFindingCandidateResponse {
+  FindingCandidate candidate = 1;
+  string decision_id = 2;
 }
 
 // EvaluateSourceRuntimeFindingsRequest replays one stored runtime through one registered finding rule.


### PR DESCRIPTION
## Summary
- Add a durable `rejected` candidate lifecycle state with rejection metadata in Postgres.
- Expose reject candidate flows through proto, Connect, REST, and OpenAPI.
- Record audited rejection decisions and emit `finding_candidate.rejection` telemetry without production finding writes.

## Test plan
- `go test ./internal/ports ./internal/findings ./internal/statestore/postgres ./internal/bootstrap`
- `make openapi-check openapi-lint`
- `make test`
- `make verify`


Made with [Cursor](https://cursor.com)