### PR TITLE
Deepen Cerebro security hardening guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ The bootstrap binary currently reads these environment variables:
 | `CEREBRO_API_AUTH_ENABLED` | require bearer/API-key auth for non-public routes | `false` |
 | `CEREBRO_API_KEYS` | comma-separated `key[:principal[:tenant_id]]` entries | unset |
 | `CEREBRO_ALLOWED_TENANTS` | optional tenant allowlist for unscoped API keys | unset |
+| `CEREBRO_PUBLIC_ORIGIN` | canonical external origin for DPoP and proxy-aware URL reconstruction | request host |
+| `CEREBRO_TRUSTED_PROXY_CIDRS` | comma-separated trusted proxy/load-balancer CIDRs for forwarded headers | private/link-local remotes |
+| `CEREBRO_TRUSTED_PROXY_COUNT` | trusted trailing `X-Forwarded-For` hops | `0` |
 | `CEREBRO_APPEND_LOG_DRIVER` | append-log driver; supported value: `jetstream` | unset |
 | `CEREBRO_JETSTREAM_URL` | NATS URL for JetStream | unset |
 | `CEREBRO_JETSTREAM_SUBJECT_PREFIX` | JetStream subject prefix | `events` |

--- a/docs/CONFIG_ENV_VARS.md
+++ b/docs/CONFIG_ENV_VARS.md
@@ -9,6 +9,9 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_API_AUTH_ENABLED` | `false` | Require bearer/API-key authentication for non-public routes. |
 | `CEREBRO_API_KEYS` | unset | Comma-separated `key[:principal[:tenant_id]]` entries. Required when auth is enabled. |
 | `CEREBRO_ALLOWED_TENANTS` | unset | Optional comma-separated tenant allowlist for unscoped API keys. |
+| `CEREBRO_PUBLIC_ORIGIN` | request host | Canonical external origin, for example `https://cerebro.example.com`, used for DPoP `htu` and public URL reconstruction. Must not include a path, query, or fragment. |
+| `CEREBRO_TRUSTED_PROXY_CIDRS` | private/link-local remotes | Optional comma-separated CIDRs whose forwarded headers are trusted. Set this explicitly in production to the load-balancer/proxy network. |
+| `CEREBRO_TRUSTED_PROXY_COUNT` | `0` | Optional count of trusted trailing `X-Forwarded-For` hops. Use `1` for a single ALB/proxy hop. |
 | `CEREBRO_APPEND_LOG_DRIVER` | inferred | Append-log driver. Supported: `jetstream`. |
 | `CEREBRO_JETSTREAM_URL` | unset | NATS JetStream URL. Setting this infers `jetstream`. |
 | `CEREBRO_JETSTREAM_SUBJECT_PREFIX` | `events` | Subject prefix for append-log events. |

--- a/docs/SECURITY_REGRESSION_HARNESS.md
+++ b/docs/SECURITY_REGRESSION_HARNESS.md
@@ -1,0 +1,22 @@
+# Security Regression Harness
+
+This harness keeps recent Droid findings from becoming one-off fixes. Add new scanner findings here only after they are backed by a repeatable check.
+
+| Finding class | Regression check |
+| --- | --- |
+| Cypher comment/string validator bypass, unsafe procedures, and oversized branch limits | `go test ./internal/graphagent` plus `FuzzValidatorMaliciousCorpus` seeds in `internal/graphagent/validator_test.go`. |
+| Connector SSRF, DNS rebinding, redirects, and unbounded response reads | `go test ./internal/sourcehttp ./sources/... ./tools/archtests`; `TestSourcesUseSharedHTTPSafety` rejects raw source `http.Client` construction and direct response-body reads. |
+| Spoofable `X-Forwarded-For`, DPoP `htu`, and audit client IP drift | `go test ./internal/bootstrap ./internal/config`; request origin is resolved through `internal/bootstrap/request_origin.go` and configured by `CEREBRO_PUBLIC_ORIGIN`, `CEREBRO_TRUSTED_PROXY_CIDRS`, and `CEREBRO_TRUSTED_PROXY_COUNT`. |
+| Candidate promote/reject lost updates and partial lifecycle attempts | `go test ./internal/findings`; lifecycle decisions use stable IDs and recover completed concurrent CAS transitions. |
+
+Before dismissing a future scanner report as a false positive, add one of:
+
+- A unit or fuzz seed proving the reported payload is blocked.
+- An archtest preventing the unsafe API pattern from being reintroduced.
+- A deployment/config assertion when the finding depends on runtime environment.
+
+Run the focused harness locally with:
+
+```bash
+go test ./internal/graphagent ./internal/sourcehttp ./internal/bootstrap ./internal/config ./internal/findings ./tools/archtests
+```

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -135,7 +135,7 @@ func NewWithError(cfg config.Config, deps Dependencies, sources *sourcecdk.Regis
 			app.dpopVerifier = dpop
 			app.riskScorer = riskScorer
 			app.observationStore = obsStore
-			app.deviceHandler = newDeviceAuthHTTPHandler(service, cfg.Auth.DeviceAuth)
+			app.deviceHandler = newDeviceAuthHTTPHandler(service, cfg.Auth.DeviceAuth, cfg.Auth.RequestOrigin)
 		}
 	}
 	mux := http.NewServeMux()

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2244,12 +2244,16 @@ func TestResolveRequestOriginInfersConfiguredTrustedProxyHops(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
 	req.RemoteAddr = "203.0.113.20:443"
 	req.Header.Set("X-Forwarded-For", "198.51.100.99, 192.0.2.10, 203.0.113.20")
+	req.Header.Set("X-Forwarded-Proto", "http, https")
 
 	origin := resolveRequestOrigin(req, config.RequestOriginConfig{
 		TrustedProxyCIDRs: []string{"192.0.2.0/24", "203.0.113.0/24"},
 	})
 	if got := origin.ClientIP; got != "198.51.100.99" {
 		t.Fatalf("ClientIP = %q, want configured trusted-proxy client", got)
+	}
+	if got := origin.PublicURL; got != "https://example.com/sources" {
+		t.Fatalf("PublicURL = %q, want trailing trusted forwarded proto", got)
 	}
 }
 

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2240,6 +2240,19 @@ func TestResolveRequestOriginUsesConfiguredPublicOrigin(t *testing.T) {
 	}
 }
 
+func TestResolveRequestOriginInfersConfiguredTrustedProxyHops(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
+	req.RemoteAddr = "203.0.113.20:443"
+	req.Header.Set("X-Forwarded-For", "198.51.100.99, 192.0.2.10, 203.0.113.20")
+
+	origin := resolveRequestOrigin(req, config.RequestOriginConfig{
+		TrustedProxyCIDRs: []string{"192.0.2.0/24", "203.0.113.0/24"},
+	})
+	if got := origin.ClientIP; got != "198.51.100.99" {
+		t.Fatalf("ClientIP = %q, want configured trusted-proxy client", got)
+	}
+}
+
 func TestResolveRequestOriginIgnoresForwardedHostFromUntrustedRemote(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://internal.local/platform/devices/token", nil)
 	req.RemoteAddr = "198.51.100.20:54321"

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2257,6 +2257,28 @@ func TestResolveRequestOriginInfersConfiguredTrustedProxyHops(t *testing.T) {
 	}
 }
 
+func TestResolveRequestOriginDoesNotTrustCallerSuppliedForwardedFor(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
+	req.RemoteAddr = "10.0.1.20:443"
+	req.Header.Set("X-Forwarded-For", "198.51.100.99, 203.0.113.200")
+
+	origin := resolveRequestOrigin(req, config.RequestOriginConfig{})
+	if got := origin.ClientIP; got != "203.0.113.200" {
+		t.Fatalf("ClientIP = %q, want proxy-appended client IP", got)
+	}
+}
+
+func TestResolveRequestOriginRejectsMalformedForwardedHost(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/sources", nil)
+	req.RemoteAddr = "10.0.1.20:443"
+	req.Header.Set("X-Forwarded-Host", "user@evil.example")
+
+	origin := resolveRequestOrigin(req, config.RequestOriginConfig{})
+	if got := origin.PublicURL; got != "http://example.com/sources" {
+		t.Fatalf("PublicURL = %q, want request host when forwarded host is malformed", got)
+	}
+}
+
 func TestResolveRequestOriginIgnoresForwardedHostFromUntrustedRemote(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://internal.local/platform/devices/token", nil)
 	req.RemoteAddr = "198.51.100.20:54321"

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2219,6 +2219,44 @@ func TestAccessAuditClientIPTrustsForwardedForFromPrivateRemote(t *testing.T) {
 	}
 }
 
+func TestResolveRequestOriginUsesConfiguredPublicOrigin(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://internal.local/platform/devices/token?rotate=true", nil)
+	req.RemoteAddr = "10.0.0.5:54321"
+	req.Host = "internal.local"
+	req.Header.Set("X-Forwarded-Proto", "http")
+	req.Header.Set("X-Forwarded-Host", "attacker.example")
+	req.Header.Set("X-Forwarded-For", "198.51.100.10, 10.0.0.5")
+
+	origin := resolveRequestOrigin(req, config.RequestOriginConfig{
+		PublicOrigin:      "https://api.writer.com",
+		TrustedProxyCIDRs: []string{"10.0.0.0/8"},
+		TrustedProxyCount: 1,
+	})
+	if got := origin.PublicURL; got != "https://api.writer.com/platform/devices/token?rotate=true" {
+		t.Fatalf("PublicURL = %q, want configured public origin URL", got)
+	}
+	if got := origin.ClientIP; got != "198.51.100.10" {
+		t.Fatalf("ClientIP = %q, want forwarded client", got)
+	}
+}
+
+func TestResolveRequestOriginIgnoresForwardedHostFromUntrustedRemote(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://internal.local/platform/devices/token", nil)
+	req.RemoteAddr = "198.51.100.20:54321"
+	req.Host = "internal.local"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "attacker.example")
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+
+	origin := resolveRequestOrigin(req, config.RequestOriginConfig{TrustedProxyCIDRs: []string{"10.0.0.0/8"}})
+	if got := origin.PublicURL; got != "http://internal.local/platform/devices/token" {
+		t.Fatalf("PublicURL = %q, want direct request URL", got)
+	}
+	if got := origin.ClientIP; got != "198.51.100.20" {
+		t.Fatalf("ClientIP = %q, want remote address", got)
+	}
+}
+
 func TestAccessAuditOperationClassifiesFamiliesAndSensitiveActions(t *testing.T) {
 	for _, tt := range []struct {
 		method        string

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -90,13 +90,14 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 		started := time.Now()
 		recorder := &accessAuditResponseWriter{ResponseWriter: w}
 		auditResult := &accessAuditResult{RequestedTenantID: requestTenantHint(r)}
+		origin := resolveRequestOrigin(r, cfg.RequestOrigin)
 		principal := authPrincipal{}
 		outcome := "denied"
 		denialReason := ""
 		defer func() {
 			status := recorder.Status()
 			finalOutcome, finalDenialReason := accessAuditOutcome(status, outcome, denialReason, auditResult.ConnectCode)
-			emitAccessAuditEvent(r, principal, status, time.Since(started), finalOutcome, finalDenialReason, auditResult)
+			emitAccessAuditEvent(r, origin, principal, status, time.Since(started), finalOutcome, finalDenialReason, auditResult)
 		}()
 		if isUnauthenticatedDevicePath(r.URL.Path) {
 			outcome = "allowed"
@@ -113,7 +114,7 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 			return
 		}
 		if deviceJKT != "" {
-			if err := verifyDPoPHeader(deps.DPoPVerifier, r, deviceJKT, presentedToken); err != nil {
+			if err := verifyDPoPHeader(deps.DPoPVerifier, r, origin.PublicURL, deviceJKT, presentedToken); err != nil {
 				denialReason = "dpop_invalid"
 				writeDeviceAuthServiceError(recorder, err)
 				return
@@ -123,7 +124,7 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 			scoreSig := risk.Signal{
 				DeviceID:  principal.DeviceID,
 				TenantID:  principal.TenantID,
-				RemoteIP:  net.ParseIP(accessAuditRemoteIP(r.RemoteAddr)),
+				RemoteIP:  net.ParseIP(origin.ClientIP),
 				UserAgent: r.Header.Get("User-Agent"),
 				Method:    r.Method,
 				Path:      r.URL.Path,
@@ -168,7 +169,7 @@ func authMiddleware(cfg config.AuthConfig, deps AuthDependencies, next http.Hand
 // authenticated device JWT carries a cnf.jkt claim. The proof must be a
 // valid DPoP+JWT, htm/htu must match the request, and the JWK thumbprint
 // must equal the expected jkt that was bound at enroll time.
-func verifyDPoPHeader(verifier *deviceauth.DPoPVerifier, r *http.Request, expectedJKT string, accessToken string) error {
+func verifyDPoPHeader(verifier *deviceauth.DPoPVerifier, r *http.Request, publicURL string, expectedJKT string, accessToken string) error {
 	if verifier == nil {
 		return nil
 	}
@@ -176,19 +177,10 @@ func verifyDPoPHeader(verifier *deviceauth.DPoPVerifier, r *http.Request, expect
 	if proof == "" {
 		return deviceauth.ErrDPoPMissing
 	}
-	scheme := "https"
-	if r.TLS == nil {
-		scheme = "http"
+	if strings.TrimSpace(publicURL) == "" && r != nil {
+		publicURL = resolveRequestOrigin(r, config.RequestOriginConfig{}).PublicURL
 	}
-	if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); forwarded != "" {
-		scheme = forwarded
-	}
-	host := strings.TrimSpace(r.Host)
-	if host == "" {
-		host = "cerebro"
-	}
-	url := scheme + "://" + host + r.URL.RequestURI()
-	res, err := verifier.Verify(proof, r.Method, url, accessToken)
+	res, err := verifier.Verify(proof, r.Method, publicURL, accessToken)
 	if err != nil {
 		return err
 	}
@@ -910,7 +902,7 @@ func mergeAccessAuditTenantID(existing string, tenantID string) string {
 	return "multiple"
 }
 
-func emitAccessAuditEvent(r *http.Request, principal authPrincipal, status int, duration time.Duration, outcome string, denialReason string, auditResult *accessAuditResult) {
+func emitAccessAuditEvent(r *http.Request, origin requestOrigin, principal authPrincipal, status int, duration time.Duration, outcome string, denialReason string, auditResult *accessAuditResult) {
 	if r == nil {
 		return
 	}
@@ -928,10 +920,10 @@ func emitAccessAuditEvent(r *http.Request, principal authPrincipal, status int, 
 		telemetry.Field{Key: "operation_type", Value: operation.Type},
 		telemetry.Field{Key: "duration_ms", Value: duration.Milliseconds()},
 	)
-	if remoteIP := accessAuditRemoteIP(r.RemoteAddr); remoteIP != "" {
+	if remoteIP := strings.TrimSpace(origin.RemoteIP); remoteIP != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "remote_ip", Value: remoteIP})
 	}
-	if clientIP := accessAuditClientIP(r); clientIP != "" {
+	if clientIP := strings.TrimSpace(origin.ClientIP); clientIP != "" && clientIP != strings.TrimSpace(origin.RemoteIP) {
 		attrs = attrs.WithField(telemetry.Field{Key: "client_ip", Value: clientIP})
 	}
 	if requestID := accessAuditRequestID(r); requestID != "" {

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -253,7 +253,8 @@ func (h *deviceAuthHTTPHandler) handleToken(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	origin := resolveRequestOrigin(r, h.originConfig)
-	limitKey := firstNonEmpty(origin.ClientIP, "unknown")
+	requestIP := firstNonEmpty(origin.ClientIP, "unknown")
+	limitKey := requestIP
 	if deviceKey, err := h.service.RefreshTokenRateLimitKey(r.Context(), body.RefreshToken); err == nil && deviceKey != "" {
 		limitKey = deviceKey
 	}
@@ -268,7 +269,7 @@ func (h *deviceAuthHTTPHandler) handleToken(w http.ResponseWriter, r *http.Reque
 		DPoPProof:    dpopProof,
 		HTTPMethod:   r.Method,
 		HTTPURL:      origin.PublicURL,
-		RemoteIP:     net.ParseIP(limitKey),
+		RemoteIP:     net.ParseIP(requestIP),
 	})
 	if err != nil {
 		writeDeviceAuthServiceError(w, err)

--- a/internal/bootstrap/device_handlers.go
+++ b/internal/bootstrap/device_handlers.go
@@ -131,18 +131,20 @@ func orderCurrentFirst(keys []deviceauth.SigningKey, currentKID string) []device
 }
 
 type deviceAuthHTTPHandler struct {
-	service     *deviceauth.Service
-	enrollLimit *deviceauth.TokenBucket
-	tokenLimit  *deviceauth.TokenBucket
-	now         func() time.Time
+	service      *deviceauth.Service
+	enrollLimit  *deviceauth.TokenBucket
+	tokenLimit   *deviceauth.TokenBucket
+	originConfig config.RequestOriginConfig
+	now          func() time.Time
 }
 
-func newDeviceAuthHTTPHandler(service *deviceauth.Service, cfg config.DeviceAuthConfig) *deviceAuthHTTPHandler {
+func newDeviceAuthHTTPHandler(service *deviceauth.Service, cfg config.DeviceAuthConfig, originConfig config.RequestOriginConfig) *deviceAuthHTTPHandler {
 	return &deviceAuthHTTPHandler{
-		service:     service,
-		enrollLimit: deviceauth.NewTokenBucket(cfg.EnrollPerIPRatePerSecond, cfg.EnrollPerIPBurst),
-		tokenLimit:  deviceauth.NewTokenBucket(cfg.TokenPerDeviceRatePerSecond, cfg.TokenPerDeviceBurst),
-		now:         time.Now,
+		service:      service,
+		enrollLimit:  deviceauth.NewTokenBucket(cfg.EnrollPerIPRatePerSecond, cfg.EnrollPerIPBurst),
+		tokenLimit:   deviceauth.NewTokenBucket(cfg.TokenPerDeviceRatePerSecond, cfg.TokenPerDeviceBurst),
+		originConfig: originConfig,
+		now:          time.Now,
 	}
 }
 
@@ -201,7 +203,8 @@ func (h *deviceAuthHTTPHandler) handleEnroll(w http.ResponseWriter, r *http.Requ
 		writeDeviceAuthError(w, http.StatusServiceUnavailable, "device_auth_disabled", "device-auth is not enabled")
 		return
 	}
-	clientIP := remoteIPForRateLimit(r)
+	origin := resolveRequestOrigin(r, h.originConfig)
+	clientIP := firstNonEmpty(origin.ClientIP, "unknown")
 	if !h.enrollLimit.Allow(clientIP) {
 		writeDeviceAuthError(w, http.StatusTooManyRequests, "rate_limited", "too many enrollment attempts")
 		return
@@ -249,7 +252,8 @@ func (h *deviceAuthHTTPHandler) handleToken(w http.ResponseWriter, r *http.Reque
 		writeDeviceAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
-	limitKey := remoteIPForRateLimit(r)
+	origin := resolveRequestOrigin(r, h.originConfig)
+	limitKey := firstNonEmpty(origin.ClientIP, "unknown")
 	if deviceKey, err := h.service.RefreshTokenRateLimitKey(r.Context(), body.RefreshToken); err == nil && deviceKey != "" {
 		limitKey = deviceKey
 	}
@@ -257,26 +261,14 @@ func (h *deviceAuthHTTPHandler) handleToken(w http.ResponseWriter, r *http.Reque
 		writeDeviceAuthError(w, http.StatusTooManyRequests, "rate_limited", "too many token requests")
 		return
 	}
-	scheme := "https"
-	if r.TLS == nil {
-		scheme = "http"
-	}
-	if forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); forwarded != "" {
-		scheme = forwarded
-	}
-	host := r.Host
-	if host == "" {
-		host = "cerebro"
-	}
-	url := scheme + "://" + host + r.URL.RequestURI()
 	dpopProof := strings.TrimSpace(r.Header.Get("DPoP"))
 	response, err := h.service.IssueToken(r.Context(), deviceauth.TokenRequest{
 		GrantType:    body.GrantType,
 		RefreshToken: body.RefreshToken,
 		DPoPProof:    dpopProof,
 		HTTPMethod:   r.Method,
-		HTTPURL:      url,
-		RemoteIP:     net.ParseIP(remoteIPForRateLimit(r)),
+		HTTPURL:      origin.PublicURL,
+		RemoteIP:     net.ParseIP(limitKey),
 	})
 	if err != nil {
 		writeDeviceAuthServiceError(w, err)
@@ -503,14 +495,7 @@ func remoteIPForRateLimit(r *http.Request) string {
 	if r == nil {
 		return "unknown"
 	}
-	if clientIP := accessAuditClientIP(r); clientIP != "" {
-		return clientIP
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return strings.TrimSpace(r.RemoteAddr)
-	}
-	return host
+	return firstNonEmpty(resolveRequestOrigin(r, config.RequestOriginConfig{}).ClientIP, "unknown")
 }
 
 func principalNameFromContext(r *http.Request) string {

--- a/internal/bootstrap/request_origin.go
+++ b/internal/bootstrap/request_origin.go
@@ -1,0 +1,157 @@
+package bootstrap
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+type requestOrigin struct {
+	RemoteIP     string
+	ClientIP     string
+	Scheme       string
+	Host         string
+	PublicURL    string
+	TrustedProxy bool
+}
+
+func resolveRequestOrigin(r *http.Request, cfg config.RequestOriginConfig) requestOrigin {
+	origin := requestOrigin{
+		RemoteIP: accessAuditRemoteIP(""),
+		Scheme:   "https",
+		Host:     "cerebro",
+	}
+	if r == nil {
+		return origin
+	}
+	origin.RemoteIP = accessAuditRemoteIP(r.RemoteAddr)
+	if r.TLS == nil {
+		origin.Scheme = "http"
+	}
+	if host := strings.TrimSpace(r.Host); host != "" {
+		origin.Host = host
+	}
+	if publicOrigin := normalizedPublicOrigin(cfg.PublicOrigin); publicOrigin != nil {
+		origin.Scheme = publicOrigin.Scheme
+		origin.Host = publicOrigin.Host
+	}
+	remoteIP := net.ParseIP(origin.RemoteIP)
+	origin.TrustedProxy = requestOriginTrustsProxy(remoteIP, cfg)
+	if origin.TrustedProxy {
+		if publicOrigin := normalizedPublicOrigin(cfg.PublicOrigin); publicOrigin == nil {
+			if forwardedProto := trustedForwardedProto(r.Header.Get("X-Forwarded-Proto")); forwardedProto != "" {
+				origin.Scheme = forwardedProto
+			}
+			if forwardedHost := trustedForwardedHost(r.Header.Get("X-Forwarded-Host")); forwardedHost != "" {
+				origin.Host = forwardedHost
+			}
+		}
+		origin.ClientIP = forwardedClientIP(r.Header.Get("X-Forwarded-For"), cfg)
+	}
+	if origin.ClientIP == "" {
+		origin.ClientIP = origin.RemoteIP
+	}
+	origin.PublicURL = origin.Scheme + "://" + origin.Host + r.URL.RequestURI()
+	return origin
+}
+
+func requestOriginTrustsProxy(remoteIP net.IP, cfg config.RequestOriginConfig) bool {
+	if remoteIP == nil {
+		return false
+	}
+	for _, rawCIDR := range cfg.TrustedProxyCIDRs {
+		_, network, err := net.ParseCIDR(strings.TrimSpace(rawCIDR))
+		if err == nil && network.Contains(remoteIP) {
+			return true
+		}
+	}
+	if len(cfg.TrustedProxyCIDRs) > 0 {
+		return false
+	}
+	return remoteIP.IsLoopback() || remoteIP.IsPrivate() || remoteIP.IsLinkLocalUnicast()
+}
+
+func normalizedPublicOrigin(raw string) *url.URL {
+	value := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if value == "" {
+		return nil
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || strings.Trim(parsed.Path, "/") != "" {
+		return nil
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return nil
+	}
+	return parsed
+}
+
+func trustedForwardedProto(header string) string {
+	for _, part := range strings.Split(header, ",") {
+		switch strings.ToLower(strings.TrimSpace(part)) {
+		case "https":
+			return "https"
+		case "http":
+			return "http"
+		}
+	}
+	return ""
+}
+
+func trustedForwardedHost(header string) string {
+	parts := strings.Split(header, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		host := strings.TrimSpace(parts[i])
+		if host == "" {
+			continue
+		}
+		if _, err := url.Parse("//" + host); err == nil {
+			return host
+		}
+	}
+	return ""
+}
+
+func forwardedClientIP(header string, cfg config.RequestOriginConfig) string {
+	parts := strings.Split(header, ",")
+	if len(parts) == 0 {
+		return ""
+	}
+	trustedProxyCount := cfg.TrustedProxyCount
+	if trustedProxyCount <= 0 {
+		trustedProxyCount = trailingTrustedForwardedHops(parts)
+		if trustedProxyCount == 0 {
+			trustedProxyCount = 1
+		}
+	}
+	for i := len(parts) - 1 - trustedProxyCount; i >= 0; i-- {
+		if ip := net.ParseIP(strings.TrimSpace(parts[i])); ip != nil {
+			return ip.String()
+		}
+	}
+	for i := len(parts) - 1; i >= 0; i-- {
+		ip := net.ParseIP(strings.TrimSpace(parts[i]))
+		if ip != nil && !accessAuditTrustsForwardedFor(ip) {
+			return ip.String()
+		}
+	}
+	return ""
+}
+
+func trailingTrustedForwardedHops(parts []string) int {
+	count := 0
+	for i := len(parts) - 1; i >= 0; i-- {
+		ip := net.ParseIP(strings.TrimSpace(parts[i]))
+		if ip == nil || !accessAuditTrustsForwardedFor(ip) {
+			break
+		}
+		count++
+	}
+	return count
+}

--- a/internal/bootstrap/request_origin.go
+++ b/internal/bootstrap/request_origin.go
@@ -93,7 +93,9 @@ func normalizedPublicOrigin(raw string) *url.URL {
 }
 
 func trustedForwardedProto(header string) string {
-	for _, part := range strings.Split(header, ",") {
+	parts := strings.Split(header, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		part := parts[i]
 		switch strings.ToLower(strings.TrimSpace(part)) {
 		case "https":
 			return "https"

--- a/internal/bootstrap/request_origin.go
+++ b/internal/bootstrap/request_origin.go
@@ -113,8 +113,9 @@ func trustedForwardedHost(header string) string {
 		if host == "" {
 			continue
 		}
-		if _, err := url.Parse("//" + host); err == nil {
-			return host
+		parsed, err := url.Parse("//" + host)
+		if err == nil && parsed.Host != "" && parsed.User == nil && parsed.RawQuery == "" && !parsed.ForceQuery && parsed.Fragment == "" && parsed.Path == "" {
+			return parsed.Host
 		}
 	}
 	return ""
@@ -128,9 +129,6 @@ func forwardedClientIP(header string, cfg config.RequestOriginConfig) string {
 	trustedProxyCount := cfg.TrustedProxyCount
 	if trustedProxyCount <= 0 {
 		trustedProxyCount = trailingTrustedForwardedHops(parts, cfg)
-		if trustedProxyCount == 0 {
-			trustedProxyCount = 1
-		}
 	}
 	for i := len(parts) - 1 - trustedProxyCount; i >= 0; i-- {
 		if ip := net.ParseIP(strings.TrimSpace(parts[i])); ip != nil {

--- a/internal/bootstrap/request_origin.go
+++ b/internal/bootstrap/request_origin.go
@@ -125,7 +125,7 @@ func forwardedClientIP(header string, cfg config.RequestOriginConfig) string {
 	}
 	trustedProxyCount := cfg.TrustedProxyCount
 	if trustedProxyCount <= 0 {
-		trustedProxyCount = trailingTrustedForwardedHops(parts)
+		trustedProxyCount = trailingTrustedForwardedHops(parts, cfg)
 		if trustedProxyCount == 0 {
 			trustedProxyCount = 1
 		}
@@ -144,14 +144,30 @@ func forwardedClientIP(header string, cfg config.RequestOriginConfig) string {
 	return ""
 }
 
-func trailingTrustedForwardedHops(parts []string) int {
+func trailingTrustedForwardedHops(parts []string, cfg config.RequestOriginConfig) int {
 	count := 0
 	for i := len(parts) - 1; i >= 0; i-- {
 		ip := net.ParseIP(strings.TrimSpace(parts[i]))
-		if ip == nil || !accessAuditTrustsForwardedFor(ip) {
+		if ip == nil || !forwardedHopTrusted(ip, cfg) {
 			break
 		}
 		count++
 	}
 	return count
+}
+
+func forwardedHopTrusted(ip net.IP, cfg config.RequestOriginConfig) bool {
+	if ip == nil {
+		return false
+	}
+	for _, rawCIDR := range cfg.TrustedProxyCIDRs {
+		_, network, err := net.ParseCIDR(strings.TrimSpace(rawCIDR))
+		if err == nil && network.Contains(ip) {
+			return true
+		}
+	}
+	if len(cfg.TrustedProxyCIDRs) > 0 {
+		return false
+	}
+	return accessAuditTrustsForwardedFor(ip)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"sort"
 	"strconv"
@@ -99,6 +101,15 @@ type AuthConfig struct {
 	CapabilityTokenAudience string
 	AllowedTenants          []string
 	DeviceAuth              DeviceAuthConfig
+	RequestOrigin           RequestOriginConfig
+}
+
+// RequestOriginConfig controls how bootstrap reconstructs client IPs and public
+// request URLs when requests traverse reverse proxies.
+type RequestOriginConfig struct {
+	PublicOrigin      string
+	TrustedProxyCIDRs []string
+	TrustedProxyCount int
 }
 
 // DeviceAuthSigningKey is one Ed25519 keypair the issuer can sign with. This
@@ -201,6 +212,10 @@ func Load() (Config, error) {
 			CapabilityTokenSecrets:  parseCSV(os.Getenv("CEREBRO_CAPABILITY_TOKEN_SECRETS")),
 			CapabilityTokenAudience: strings.TrimSpace(os.Getenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE")),
 			AllowedTenants:          parseCSV(os.Getenv("CEREBRO_ALLOWED_TENANTS")),
+			RequestOrigin: RequestOriginConfig{
+				PublicOrigin:      strings.TrimRight(strings.TrimSpace(os.Getenv("CEREBRO_PUBLIC_ORIGIN")), "/"),
+				TrustedProxyCIDRs: parseCSV(os.Getenv("CEREBRO_TRUSTED_PROXY_CIDRS")),
+			},
 		},
 	}
 	authEnabled, err := parseBoolEnv("CEREBRO_API_AUTH_ENABLED", false)
@@ -208,6 +223,15 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 	cfg.Auth.Enabled = authEnabled
+	if cfg.Auth.RequestOrigin.TrustedProxyCount, err = parseIntEnv("CEREBRO_TRUSTED_PROXY_COUNT", 0); err != nil {
+		return Config{}, err
+	}
+	if cfg.Auth.RequestOrigin.TrustedProxyCount < 0 {
+		return Config{}, fmt.Errorf("CEREBRO_TRUSTED_PROXY_COUNT must be greater than or equal to zero")
+	}
+	if err := validateRequestOriginConfig(cfg.Auth.RequestOrigin); err != nil {
+		return Config{}, err
+	}
 	if len(cfg.Auth.CapabilityTokenSecrets) > 0 && cfg.Auth.CapabilityTokenAudience == "" {
 		cfg.Auth.CapabilityTokenAudience = "cerebro-api"
 	}
@@ -285,6 +309,27 @@ func Load() (Config, error) {
 		return Config{}, fmt.Errorf("CEREBRO_API_KEYS, CEREBRO_API_CREDENTIALS_JSON, or CEREBRO_CAPABILITY_TOKEN_SECRETS is required when CEREBRO_API_AUTH_ENABLED=true")
 	}
 	return cfg, nil
+}
+
+func validateRequestOriginConfig(cfg RequestOriginConfig) error {
+	if raw := strings.TrimSpace(cfg.PublicOrigin); raw != "" {
+		parsed, err := url.Parse(strings.TrimRight(raw, "/"))
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			return fmt.Errorf("CEREBRO_PUBLIC_ORIGIN must be an http(s) origin")
+		}
+		if parsed.Scheme != "https" && parsed.Scheme != "http" {
+			return fmt.Errorf("CEREBRO_PUBLIC_ORIGIN must use http or https")
+		}
+		if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || strings.Trim(parsed.Path, "/") != "" {
+			return fmt.Errorf("CEREBRO_PUBLIC_ORIGIN must not include user info, path, query, or fragment")
+		}
+	}
+	for _, rawCIDR := range cfg.TrustedProxyCIDRs {
+		if _, _, err := net.ParseCIDR(strings.TrimSpace(rawCIDR)); err != nil {
+			return fmt.Errorf("CEREBRO_TRUSTED_PROXY_CIDRS contains invalid CIDR %q: %w", rawCIDR, err)
+		}
+	}
+	return nil
 }
 
 func parseBoolEnv(name string, defaultValue bool) (bool, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,9 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "")
+	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "")
+	t.Setenv("CEREBRO_TRUSTED_PROXY_CIDRS", "")
+	t.Setenv("CEREBRO_TRUSTED_PROXY_COUNT", "")
 	clearDeviceAuthEnv(t)
 
 	cfg, err := Load()
@@ -90,6 +93,9 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "security,writer,writer")
+	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "https://api.writer.com")
+	t.Setenv("CEREBRO_TRUSTED_PROXY_CIDRS", "10.0.0.0/8, 192.168.0.0/16")
+	t.Setenv("CEREBRO_TRUSTED_PROXY_COUNT", "1")
 	clearDeviceAuthEnv(t)
 
 	cfg, err := Load()
@@ -126,6 +132,15 @@ func TestLoadFromEnv(t *testing.T) {
 	if !cfg.Auth.Enabled {
 		t.Fatal("Auth.Enabled = false, want true")
 	}
+	if got := cfg.Auth.RequestOrigin.PublicOrigin; got != "https://api.writer.com" {
+		t.Fatalf("PublicOrigin = %q, want https://api.writer.com", got)
+	}
+	if got := cfg.Auth.RequestOrigin.TrustedProxyCount; got != 1 {
+		t.Fatalf("TrustedProxyCount = %d, want 1", got)
+	}
+	if got := cfg.Auth.RequestOrigin.TrustedProxyCIDRs; len(got) != 2 || got[0] != "10.0.0.0/8" || got[1] != "192.168.0.0/16" {
+		t.Fatalf("TrustedProxyCIDRs = %#v, want two configured CIDRs", got)
+	}
 	if len(cfg.Auth.APIKeys) != 2 {
 		t.Fatalf("Auth.APIKeys length = %d, want 2", len(cfg.Auth.APIKeys))
 	}
@@ -160,6 +175,9 @@ func clearDependencyEnv(t *testing.T) {
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_SECRETS", "")
 	t.Setenv("CEREBRO_CAPABILITY_TOKEN_AUDIENCE", "")
 	t.Setenv("CEREBRO_ALLOWED_TENANTS", "")
+	t.Setenv("CEREBRO_PUBLIC_ORIGIN", "")
+	t.Setenv("CEREBRO_TRUSTED_PROXY_CIDRS", "")
+	t.Setenv("CEREBRO_TRUSTED_PROXY_COUNT", "")
 	clearDeviceAuthEnv(t)
 }
 
@@ -239,6 +257,26 @@ func TestLoadRejectsAuthEnabledWithoutKeys(t *testing.T) {
 
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want non-nil")
+	}
+}
+
+func TestLoadRejectsInvalidRequestOriginConfig(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		key  string
+		val  string
+	}{
+		{name: "public origin with path", key: "CEREBRO_PUBLIC_ORIGIN", val: "https://api.writer.com/cerebro"},
+		{name: "invalid proxy cidr", key: "CEREBRO_TRUSTED_PROXY_CIDRS", val: "not-cidr"},
+		{name: "negative proxy count", key: "CEREBRO_TRUSTED_PROXY_COUNT", val: "-1"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clearDependencyEnv(t)
+			t.Setenv(tt.key, tt.val)
+			if _, err := Load(); err == nil {
+				t.Fatal("Load() error = nil, want invalid request-origin config error")
+			}
+		})
 	}
 }
 

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -313,7 +313,7 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	production.Attributes["promotion_rationale"] = strings.TrimSpace(request.Rationale)
 	production.Attributes["promoted_by"] = strings.TrimSpace(request.PromotedBy)
 	production.Attributes["promoted_at"] = now.Format(time.RFC3339Nano)
-	decisionID := candidatePromotionDecisionID(candidate, production, now)
+	decisionID := candidatePromotionDecisionID(candidate, production, request, now)
 	stored, err := s.upsertFindingWithRisk(ctx, production, &cerebrov1.SourceRuntime{
 		Id:       strings.TrimSpace(candidate.RuntimeID),
 		TenantId: strings.TrimSpace(candidate.TenantID),
@@ -350,7 +350,7 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 		PromotedAt:        now,
 	})
 	if err != nil {
-		recovered, recoverErr := s.recoverPromotedCandidate(ctx, candidate.ID, stored.ID, decisionID)
+		recovered, recoverErr := s.recoverPromotedCandidate(ctx, candidate.ID, stored.ID, decisionID, request)
 		if recoverErr == nil {
 			recoveredFinding, loadErr := s.store.GetFinding(ctx, strings.TrimSpace(recovered.PromotedFindingID))
 			if loadErr != nil {
@@ -394,7 +394,7 @@ func (s *Service) RejectFindingCandidate(ctx context.Context, request RejectCand
 		return &RejectCandidateResult{Candidate: candidate, DecisionID: strings.TrimSpace(candidate.DecisionID)}, nil
 	}
 	now := time.Now().UTC()
-	decisionID := candidateRejectionDecisionID(candidate, now)
+	decisionID := candidateRejectionDecisionID(candidate, request, now)
 	if err := s.recordCandidateRejectionDecision(ctx, candidate, request, now, decisionID); err != nil {
 		return nil, err
 	}
@@ -406,7 +406,7 @@ func (s *Service) RejectFindingCandidate(ctx context.Context, request RejectCand
 		RejectedAt:  now,
 	})
 	if err != nil {
-		recovered, recoverErr := s.recoverRejectedCandidate(ctx, candidate.ID, decisionID)
+		recovered, recoverErr := s.recoverRejectedCandidate(ctx, candidate.ID, decisionID, request)
 		if recoverErr == nil {
 			emitFindingCandidateRejectionTelemetry(ctx, "rejected_recovered", recovered, decisionID, startedAt)
 			return &RejectCandidateResult{Candidate: recovered, DecisionID: decisionID}, nil
@@ -435,7 +435,7 @@ func (s *Service) findingCandidateLifecycleConflict(ctx context.Context, candida
 	}
 }
 
-func (s *Service) recoverPromotedCandidate(ctx context.Context, candidateID string, findingID string, decisionID string) (*ports.FindingCandidateRecord, error) {
+func (s *Service) recoverPromotedCandidate(ctx context.Context, candidateID string, findingID string, decisionID string, request PromoteCandidateRequest) (*ports.FindingCandidateRecord, error) {
 	current, err := s.candidateStore.GetFindingCandidate(ctx, candidateID)
 	if err != nil {
 		return nil, err
@@ -446,10 +446,15 @@ func (s *Service) recoverPromotedCandidate(ctx context.Context, candidateID stri
 	if strings.TrimSpace(current.PromotedFindingID) != strings.TrimSpace(findingID) || strings.TrimSpace(current.DecisionID) != strings.TrimSpace(decisionID) {
 		return nil, ErrInvalidRequest
 	}
+	if strings.TrimSpace(current.PromotedBy) != strings.TrimSpace(request.PromotedBy) ||
+		strings.TrimSpace(current.PromotionRationale) != strings.TrimSpace(request.Rationale) ||
+		strings.TrimSpace(current.ChangeTicket) != strings.TrimSpace(request.ChangeTicket) {
+		return nil, ErrInvalidRequest
+	}
 	return current, nil
 }
 
-func (s *Service) recoverRejectedCandidate(ctx context.Context, candidateID string, decisionID string) (*ports.FindingCandidateRecord, error) {
+func (s *Service) recoverRejectedCandidate(ctx context.Context, candidateID string, decisionID string, request RejectCandidateRequest) (*ports.FindingCandidateRecord, error) {
 	current, err := s.candidateStore.GetFindingCandidate(ctx, candidateID)
 	if err != nil {
 		return nil, err
@@ -457,28 +462,52 @@ func (s *Service) recoverRejectedCandidate(ctx context.Context, candidateID stri
 	if !strings.EqualFold(strings.TrimSpace(current.Status), findingCandidateStatusRejected) || strings.TrimSpace(current.DecisionID) != strings.TrimSpace(decisionID) {
 		return nil, ErrInvalidRequest
 	}
+	if strings.TrimSpace(current.RejectedBy) != strings.TrimSpace(request.RejectedBy) ||
+		strings.TrimSpace(current.RejectionRationale) != strings.TrimSpace(request.Rationale) {
+		return nil, ErrInvalidRequest
+	}
 	return current, nil
 }
 
-func candidatePromotionDecisionID(candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, observedAt time.Time) string {
+func candidatePromotionDecisionID(candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, request PromoteCandidateRequest, observedAt time.Time) string {
 	if candidate == nil || finding == nil {
 		return ""
 	}
 	tenantID := strings.TrimSpace(candidate.TenantID)
-	return workflowevents.CanonicalWorkflowID(tenantID, "decision", strings.TrimSpace(candidate.ID)+"-promotion", findingCandidateDecisionType, []string{
+	reviewID := candidateReviewDecisionSuffix(
+		"promotion",
+		candidate.ID,
+		finding.ID,
+		request.PromotedBy,
+		request.Rationale,
+		request.ChangeTicket,
+		fmt.Sprint(request.FalsePositiveReviewed),
+		fmt.Sprint(request.GraphCoverageReviewed),
+	)
+	return workflowevents.CanonicalWorkflowID(tenantID, "decision", reviewID, findingCandidateDecisionType, []string{
 		findingGraphFindingURN(tenantID, finding),
 		findingCandidateURN(tenantID, candidate.ID),
 	}, observedAt)
 }
 
-func candidateRejectionDecisionID(candidate *ports.FindingCandidateRecord, observedAt time.Time) string {
+func candidateRejectionDecisionID(candidate *ports.FindingCandidateRecord, request RejectCandidateRequest, observedAt time.Time) string {
 	if candidate == nil {
 		return ""
 	}
 	tenantID := strings.TrimSpace(candidate.TenantID)
-	return workflowevents.CanonicalWorkflowID(tenantID, "decision", strings.TrimSpace(candidate.ID)+"-rejection", findingCandidateRejectionType, []string{
+	reviewID := candidateReviewDecisionSuffix("rejection", candidate.ID, request.RejectedBy, request.Rationale)
+	return workflowevents.CanonicalWorkflowID(tenantID, "decision", reviewID, findingCandidateRejectionType, []string{
 		findingCandidateURN(tenantID, candidate.ID),
 	}, observedAt)
+}
+
+func candidateReviewDecisionSuffix(parts ...string) string {
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		normalized = append(normalized, strings.TrimSpace(part))
+	}
+	digest := sha256.Sum256([]byte(strings.Join(normalized, "\x00")))
+	return strings.TrimSpace(parts[1]) + "-" + strings.TrimSpace(parts[0]) + "-" + hex.EncodeToString(digest[:8])
 }
 
 func (s *Service) recordCandidatePromotionDecision(ctx context.Context, candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, request PromoteCandidateRequest, observedAt time.Time, decisionID string) error {

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -352,8 +352,12 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	if err != nil {
 		recovered, recoverErr := s.recoverPromotedCandidate(ctx, candidate.ID, stored.ID, decisionID)
 		if recoverErr == nil {
-			emitFindingCandidatePromotionTelemetry(ctx, "promoted_recovered", recovered, stored, decisionID, startedAt)
-			return &PromoteCandidateResult{Candidate: recovered, Finding: stored, DecisionID: decisionID}, nil
+			recoveredFinding, loadErr := s.store.GetFinding(ctx, strings.TrimSpace(recovered.PromotedFindingID))
+			if loadErr != nil {
+				return nil, loadErr
+			}
+			emitFindingCandidatePromotionTelemetry(ctx, "promoted_recovered", recovered, recoveredFinding, decisionID, startedAt)
+			return &PromoteCandidateResult{Candidate: recovered, Finding: recoveredFinding, DecisionID: decisionID}, nil
 		}
 		return nil, s.findingCandidateLifecycleConflict(ctx, candidate.ID, findingCandidateStatusPromoted, err)
 	}

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -303,7 +303,7 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	if len(candidate.Evidence) == 0 {
 		return nil, fmt.Errorf("%w: finding candidate has no evidence", ErrInvalidRequest)
 	}
-	now := time.Now().UTC()
+	now := candidateLifecycleObservedAt(candidate, time.Now().UTC())
 	production := cloneFindingRecord(candidate.Finding)
 	if production.Attributes == nil {
 		production.Attributes = map[string]string{}
@@ -350,6 +350,11 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 		PromotedAt:        now,
 	})
 	if err != nil {
+		recovered, recoverErr := s.recoverPromotedCandidate(ctx, candidate.ID, stored.ID, decisionID)
+		if recoverErr == nil {
+			emitFindingCandidatePromotionTelemetry(ctx, "promoted_recovered", recovered, stored, decisionID, startedAt)
+			return &PromoteCandidateResult{Candidate: recovered, Finding: stored, DecisionID: decisionID}, nil
+		}
 		return nil, s.findingCandidateLifecycleConflict(ctx, candidate.ID, findingCandidateStatusPromoted, err)
 	}
 	emitFindingCandidatePromotionTelemetry(ctx, "promoted", promoted, stored, decisionID, startedAt)
@@ -384,7 +389,7 @@ func (s *Service) RejectFindingCandidate(ctx context.Context, request RejectCand
 		emitFindingCandidateRejectionTelemetry(ctx, "already_rejected", candidate, strings.TrimSpace(candidate.DecisionID), startedAt)
 		return &RejectCandidateResult{Candidate: candidate, DecisionID: strings.TrimSpace(candidate.DecisionID)}, nil
 	}
-	now := time.Now().UTC()
+	now := candidateLifecycleObservedAt(candidate, time.Now().UTC())
 	decisionID := candidateRejectionDecisionID(candidate, now)
 	if err := s.recordCandidateRejectionDecision(ctx, candidate, request, now, decisionID); err != nil {
 		return nil, err
@@ -397,6 +402,11 @@ func (s *Service) RejectFindingCandidate(ctx context.Context, request RejectCand
 		RejectedAt:  now,
 	})
 	if err != nil {
+		recovered, recoverErr := s.recoverRejectedCandidate(ctx, candidate.ID, decisionID)
+		if recoverErr == nil {
+			emitFindingCandidateRejectionTelemetry(ctx, "rejected_recovered", recovered, decisionID, startedAt)
+			return &RejectCandidateResult{Candidate: recovered, DecisionID: decisionID}, nil
+		}
 		return nil, s.findingCandidateLifecycleConflict(ctx, candidate.ID, findingCandidateStatusRejected, err)
 	}
 	emitFindingCandidateRejectionTelemetry(ctx, "rejected", rejected, decisionID, startedAt)
@@ -421,12 +431,37 @@ func (s *Service) findingCandidateLifecycleConflict(ctx context.Context, candida
 	}
 }
 
+func (s *Service) recoverPromotedCandidate(ctx context.Context, candidateID string, findingID string, decisionID string) (*ports.FindingCandidateRecord, error) {
+	current, err := s.candidateStore.GetFindingCandidate(ctx, candidateID)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(current.Status), findingCandidateStatusPromoted) {
+		return nil, ErrInvalidRequest
+	}
+	if strings.TrimSpace(current.PromotedFindingID) != strings.TrimSpace(findingID) || strings.TrimSpace(current.DecisionID) != strings.TrimSpace(decisionID) {
+		return nil, ErrInvalidRequest
+	}
+	return current, nil
+}
+
+func (s *Service) recoverRejectedCandidate(ctx context.Context, candidateID string, decisionID string) (*ports.FindingCandidateRecord, error) {
+	current, err := s.candidateStore.GetFindingCandidate(ctx, candidateID)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(current.Status), findingCandidateStatusRejected) || strings.TrimSpace(current.DecisionID) != strings.TrimSpace(decisionID) {
+		return nil, ErrInvalidRequest
+	}
+	return current, nil
+}
+
 func candidatePromotionDecisionID(candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, observedAt time.Time) string {
 	if candidate == nil || finding == nil {
 		return ""
 	}
 	tenantID := strings.TrimSpace(candidate.TenantID)
-	return workflowevents.CanonicalWorkflowID(tenantID, "decision", candidate.ID, findingCandidateDecisionType, []string{
+	return workflowevents.CanonicalWorkflowID(tenantID, "decision", strings.TrimSpace(candidate.ID)+"-promotion", findingCandidateDecisionType, []string{
 		findingGraphFindingURN(tenantID, finding),
 		findingCandidateURN(tenantID, candidate.ID),
 	}, observedAt)
@@ -437,9 +472,23 @@ func candidateRejectionDecisionID(candidate *ports.FindingCandidateRecord, obser
 		return ""
 	}
 	tenantID := strings.TrimSpace(candidate.TenantID)
-	return workflowevents.CanonicalWorkflowID(tenantID, "decision", candidate.ID, findingCandidateRejectionType, []string{
+	return workflowevents.CanonicalWorkflowID(tenantID, "decision", strings.TrimSpace(candidate.ID)+"-rejection", findingCandidateRejectionType, []string{
 		findingCandidateURN(tenantID, candidate.ID),
 	}, observedAt)
+}
+
+func candidateLifecycleObservedAt(candidate *ports.FindingCandidateRecord, fallback time.Time) time.Time {
+	if candidate != nil {
+		for _, value := range []time.Time{candidate.PromotedAt, candidate.RejectedAt, candidate.UpdatedAt, candidate.CreatedAt, candidate.LastObservedAt, candidate.FirstObservedAt} {
+			if !value.IsZero() {
+				return value.UTC()
+			}
+		}
+	}
+	if fallback.IsZero() {
+		return time.Now().UTC()
+	}
+	return fallback.UTC()
 }
 
 func (s *Service) recordCandidatePromotionDecision(ctx context.Context, candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, request PromoteCandidateRequest, observedAt time.Time, decisionID string) error {

--- a/internal/findings/candidates.go
+++ b/internal/findings/candidates.go
@@ -303,7 +303,7 @@ func (s *Service) PromoteFindingCandidate(ctx context.Context, request PromoteCa
 	if len(candidate.Evidence) == 0 {
 		return nil, fmt.Errorf("%w: finding candidate has no evidence", ErrInvalidRequest)
 	}
-	now := candidateLifecycleObservedAt(candidate, time.Now().UTC())
+	now := time.Now().UTC()
 	production := cloneFindingRecord(candidate.Finding)
 	if production.Attributes == nil {
 		production.Attributes = map[string]string{}
@@ -389,7 +389,7 @@ func (s *Service) RejectFindingCandidate(ctx context.Context, request RejectCand
 		emitFindingCandidateRejectionTelemetry(ctx, "already_rejected", candidate, strings.TrimSpace(candidate.DecisionID), startedAt)
 		return &RejectCandidateResult{Candidate: candidate, DecisionID: strings.TrimSpace(candidate.DecisionID)}, nil
 	}
-	now := candidateLifecycleObservedAt(candidate, time.Now().UTC())
+	now := time.Now().UTC()
 	decisionID := candidateRejectionDecisionID(candidate, now)
 	if err := s.recordCandidateRejectionDecision(ctx, candidate, request, now, decisionID); err != nil {
 		return nil, err
@@ -475,20 +475,6 @@ func candidateRejectionDecisionID(candidate *ports.FindingCandidateRecord, obser
 	return workflowevents.CanonicalWorkflowID(tenantID, "decision", strings.TrimSpace(candidate.ID)+"-rejection", findingCandidateRejectionType, []string{
 		findingCandidateURN(tenantID, candidate.ID),
 	}, observedAt)
-}
-
-func candidateLifecycleObservedAt(candidate *ports.FindingCandidateRecord, fallback time.Time) time.Time {
-	if candidate != nil {
-		for _, value := range []time.Time{candidate.PromotedAt, candidate.RejectedAt, candidate.UpdatedAt, candidate.CreatedAt, candidate.LastObservedAt, candidate.FirstObservedAt} {
-			if !value.IsZero() {
-				return value.UTC()
-			}
-		}
-	}
-	if fallback.IsZero() {
-		return time.Now().UTC()
-	}
-	return fallback.UTC()
 }
 
 func (s *Service) recordCandidatePromotionDecision(ctx context.Context, candidate *ports.FindingCandidateRecord, finding *ports.FindingRecord, request PromoteCandidateRequest, observedAt time.Time, decisionID string) error {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -109,6 +109,8 @@ type stubFindingCandidateState struct {
 	upsertCount       int
 	markPromotedCount int
 	markRejectedCount int
+	beforeMarkPromote func()
+	beforeMarkReject  func()
 }
 
 type stubFindingBackfillState struct {
@@ -665,6 +667,9 @@ func (s *stubFindingStore) ListFindingCandidates(_ context.Context, request port
 
 func (s *stubFindingStore) MarkFindingCandidatePromoted(_ context.Context, promotion ports.FindingCandidatePromotion) (*ports.FindingCandidateRecord, error) {
 	s.candidateState.markPromotedCount++
+	if s.candidateState.beforeMarkPromote != nil {
+		s.candidateState.beforeMarkPromote()
+	}
 	candidate, ok := s.candidateState.candidates[strings.TrimSpace(promotion.CandidateID)]
 	if !ok {
 		return nil, ports.ErrFindingCandidateNotFound
@@ -686,6 +691,9 @@ func (s *stubFindingStore) MarkFindingCandidatePromoted(_ context.Context, promo
 
 func (s *stubFindingStore) MarkFindingCandidateRejected(_ context.Context, rejection ports.FindingCandidateRejection) (*ports.FindingCandidateRecord, error) {
 	s.candidateState.markRejectedCount++
+	if s.candidateState.beforeMarkReject != nil {
+		s.candidateState.beforeMarkReject()
+	}
 	candidate, ok := s.candidateState.candidates[strings.TrimSpace(rejection.CandidateID)]
 	if !ok {
 		return nil, ports.ErrFindingCandidateNotFound
@@ -2967,6 +2975,79 @@ func TestPromoteFindingCandidateAlreadyPromotedReturnsExistingFinding(t *testing
 	}
 }
 
+func TestPromoteFindingCandidateRecoversConcurrentCompletedPromotion(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	finding := &ports.FindingRecord{
+		ID:              "finding-1",
+		Fingerprint:     "fingerprint-1",
+		TenantID:        "writer",
+		RuntimeID:       "writer-okta-audit",
+		RuleID:          "rule-a",
+		Status:          findingStatusOpen,
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+	}
+	candidate := &ports.FindingCandidateRecord{
+		ID:               "candidate-1",
+		TenantID:         "writer",
+		RuntimeID:        "writer-okta-audit",
+		RuleID:           "rule-a",
+		Fingerprint:      "fingerprint-1",
+		Status:           findingCandidateStatusCandidate,
+		Finding:          cloneFinding(finding),
+		Evidence:         []*cerebrov1.FindingEvidence{{Id: "evidence-1", FindingId: "finding-1"}},
+		LastRunID:        "candidate-run-1",
+		ObservationCount: 1,
+		FirstObservedAt:  now,
+		LastObservedAt:   now,
+	}
+	decisionID := candidatePromotionDecisionID(candidate, finding, candidateLifecycleObservedAt(candidate, now))
+	store := &stubFindingStore{
+		candidateState: stubFindingCandidateState{
+			candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
+		},
+		findings: map[string]*ports.FindingRecord{},
+	}
+	store.candidateState.beforeMarkPromote = func() {
+		updated := cloneFindingCandidate(candidate)
+		updated.Status = findingCandidateStatusPromoted
+		updated.PromotedFindingID = finding.ID
+		updated.DecisionID = decisionID
+		updated.PromotedBy = "analyst@example.com"
+		updated.PromotedAt = now
+		store.candidateState.candidates[updated.ID] = updated
+	}
+	service := NewWithRegistry(
+		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta-audit": {Id: "writer-okta-audit", SourceId: "okta", TenantId: "writer"},
+		}},
+		nil,
+		store,
+		store,
+		store,
+		store,
+		nil,
+	).WithFindingCandidateStore(store).WithAppendLog(&recordingAppendLog{})
+
+	result, err := service.PromoteFindingCandidate(context.Background(), PromoteCandidateRequest{
+		CandidateID:           "candidate-1",
+		PromotedBy:            "analyst@example.com",
+		Rationale:             "Validated against source data.",
+		ChangeTicket:          "SEC-123",
+		FalsePositiveReviewed: true,
+		GraphCoverageReviewed: true,
+	})
+	if err != nil {
+		t.Fatalf("PromoteFindingCandidate() error = %v", err)
+	}
+	if got := result.Candidate.Status; got != findingCandidateStatusPromoted {
+		t.Fatalf("candidate status = %q, want promoted", got)
+	}
+	if got := result.DecisionID; got != decisionID {
+		t.Fatalf("decision id = %q, want recovered %q", got, decisionID)
+	}
+}
+
 func TestRejectFindingCandidateRecordsAuditWithoutProductionWrites(t *testing.T) {
 	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
 	finding := &ports.FindingRecord{
@@ -3102,6 +3183,67 @@ func TestRejectFindingCandidateDoesNotMarkRejectedBeforeAudit(t *testing.T) {
 	}
 	if got := store.candidateState.candidates["candidate-1"].Status; got != findingCandidateStatusCandidate {
 		t.Fatalf("candidate status = %q, want candidate", got)
+	}
+}
+
+func TestRejectFindingCandidateRecoversConcurrentCompletedRejection(t *testing.T) {
+	now := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	finding := &ports.FindingRecord{
+		ID:              "finding-1",
+		Fingerprint:     "fingerprint-1",
+		TenantID:        "writer",
+		RuntimeID:       "writer-okta-audit",
+		RuleID:          "rule-a",
+		Status:          findingStatusOpen,
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+	}
+	candidate := &ports.FindingCandidateRecord{
+		ID:               "candidate-1",
+		TenantID:         "writer",
+		RuntimeID:        "writer-okta-audit",
+		RuleID:           "rule-a",
+		Fingerprint:      "fingerprint-1",
+		Status:           findingCandidateStatusCandidate,
+		Finding:          cloneFinding(finding),
+		Evidence:         []*cerebrov1.FindingEvidence{{Id: "evidence-1", FindingId: "finding-1"}},
+		LastRunID:        "candidate-run-1",
+		ObservationCount: 1,
+		FirstObservedAt:  now,
+		LastObservedAt:   now,
+	}
+	decisionID := candidateRejectionDecisionID(candidate, candidateLifecycleObservedAt(candidate, now))
+	store := &stubFindingStore{
+		candidateState: stubFindingCandidateState{
+			candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
+		},
+		findings: map[string]*ports.FindingRecord{},
+	}
+	store.candidateState.beforeMarkReject = func() {
+		updated := cloneFindingCandidate(candidate)
+		updated.Status = findingCandidateStatusRejected
+		updated.DecisionID = decisionID
+		updated.RejectedBy = "analyst@example.com"
+		updated.RejectedAt = now
+		store.candidateState.candidates[updated.ID] = updated
+	}
+	service := NewWithRegistry(nil, nil, store, store, store, store, nil).
+		WithFindingCandidateStore(store).
+		WithAppendLog(&recordingAppendLog{})
+
+	result, err := service.RejectFindingCandidate(context.Background(), RejectCandidateRequest{
+		CandidateID: "candidate-1",
+		RejectedBy:  "analyst@example.com",
+		Rationale:   "Confirmed false positive.",
+	})
+	if err != nil {
+		t.Fatalf("RejectFindingCandidate() error = %v", err)
+	}
+	if got := result.Candidate.Status; got != findingCandidateStatusRejected {
+		t.Fatalf("candidate status = %q, want rejected", got)
+	}
+	if got := result.DecisionID; got != decisionID {
+		t.Fatalf("decision id = %q, want recovered %q", got, decisionID)
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -3016,6 +3016,9 @@ func TestPromoteFindingCandidateRecoversConcurrentCompletedPromotion(t *testing.
 		updated.PromotedBy = "analyst@example.com"
 		updated.PromotedAt = now
 		store.candidateState.candidates[updated.ID] = updated
+		winningFinding := cloneFinding(finding)
+		winningFinding.Attributes = map[string]string{"promoted_by": "winner@example.com"}
+		store.findings[winningFinding.ID] = winningFinding
 	}
 	service := NewWithRegistry(
 		&stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
@@ -3045,6 +3048,9 @@ func TestPromoteFindingCandidateRecoversConcurrentCompletedPromotion(t *testing.
 	}
 	if got := result.DecisionID; got != decisionID {
 		t.Fatalf("decision id = %q, want recovered %q", got, decisionID)
+	}
+	if got := result.Finding.Attributes["promoted_by"]; got != "winner@example.com" {
+		t.Fatalf("recovered finding promoted_by = %q, want winning persisted finding", got)
 	}
 }
 

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -3001,7 +3001,15 @@ func TestPromoteFindingCandidateRecoversConcurrentCompletedPromotion(t *testing.
 		FirstObservedAt:  now,
 		LastObservedAt:   now,
 	}
-	decisionID := candidatePromotionDecisionID(candidate, finding, now)
+	request := PromoteCandidateRequest{
+		CandidateID:           "candidate-1",
+		PromotedBy:            "analyst@example.com",
+		Rationale:             "Validated against source data.",
+		ChangeTicket:          "SEC-123",
+		FalsePositiveReviewed: true,
+		GraphCoverageReviewed: true,
+	}
+	decisionID := candidatePromotionDecisionID(candidate, finding, request, now)
 	store := &stubFindingStore{
 		candidateState: stubFindingCandidateState{
 			candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
@@ -3014,6 +3022,8 @@ func TestPromoteFindingCandidateRecoversConcurrentCompletedPromotion(t *testing.
 		updated.PromotedFindingID = finding.ID
 		updated.DecisionID = decisionID
 		updated.PromotedBy = "analyst@example.com"
+		updated.PromotionRationale = "Validated against source data."
+		updated.ChangeTicket = "SEC-123"
 		updated.PromotedAt = now
 		store.candidateState.candidates[updated.ID] = updated
 		winningFinding := cloneFinding(finding)
@@ -3032,14 +3042,7 @@ func TestPromoteFindingCandidateRecoversConcurrentCompletedPromotion(t *testing.
 		nil,
 	).WithFindingCandidateStore(store).WithAppendLog(&recordingAppendLog{})
 
-	result, err := service.PromoteFindingCandidate(context.Background(), PromoteCandidateRequest{
-		CandidateID:           "candidate-1",
-		PromotedBy:            "analyst@example.com",
-		Rationale:             "Validated against source data.",
-		ChangeTicket:          "SEC-123",
-		FalsePositiveReviewed: true,
-		GraphCoverageReviewed: true,
-	})
+	result, err := service.PromoteFindingCandidate(context.Background(), request)
 	if err != nil {
 		t.Fatalf("PromoteFindingCandidate() error = %v", err)
 	}
@@ -3218,7 +3221,12 @@ func TestRejectFindingCandidateRecoversConcurrentCompletedRejection(t *testing.T
 		FirstObservedAt:  now,
 		LastObservedAt:   now,
 	}
-	decisionID := candidateRejectionDecisionID(candidate, now)
+	request := RejectCandidateRequest{
+		CandidateID: "candidate-1",
+		RejectedBy:  "analyst@example.com",
+		Rationale:   "Confirmed false positive.",
+	}
+	decisionID := candidateRejectionDecisionID(candidate, request, now)
 	store := &stubFindingStore{
 		candidateState: stubFindingCandidateState{
 			candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
@@ -3230,6 +3238,7 @@ func TestRejectFindingCandidateRecoversConcurrentCompletedRejection(t *testing.T
 		updated.Status = findingCandidateStatusRejected
 		updated.DecisionID = decisionID
 		updated.RejectedBy = "analyst@example.com"
+		updated.RejectionRationale = "Confirmed false positive."
 		updated.RejectedAt = now
 		store.candidateState.candidates[updated.ID] = updated
 	}
@@ -3237,11 +3246,7 @@ func TestRejectFindingCandidateRecoversConcurrentCompletedRejection(t *testing.T
 		WithFindingCandidateStore(store).
 		WithAppendLog(&recordingAppendLog{})
 
-	result, err := service.RejectFindingCandidate(context.Background(), RejectCandidateRequest{
-		CandidateID: "candidate-1",
-		RejectedBy:  "analyst@example.com",
-		Rationale:   "Confirmed false positive.",
-	})
+	result, err := service.RejectFindingCandidate(context.Background(), request)
 	if err != nil {
 		t.Fatalf("RejectFindingCandidate() error = %v", err)
 	}

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -3001,7 +3001,7 @@ func TestPromoteFindingCandidateRecoversConcurrentCompletedPromotion(t *testing.
 		FirstObservedAt:  now,
 		LastObservedAt:   now,
 	}
-	decisionID := candidatePromotionDecisionID(candidate, finding, candidateLifecycleObservedAt(candidate, now))
+	decisionID := candidatePromotionDecisionID(candidate, finding, now)
 	store := &stubFindingStore{
 		candidateState: stubFindingCandidateState{
 			candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},
@@ -3212,7 +3212,7 @@ func TestRejectFindingCandidateRecoversConcurrentCompletedRejection(t *testing.T
 		FirstObservedAt:  now,
 		LastObservedAt:   now,
 	}
-	decisionID := candidateRejectionDecisionID(candidate, candidateLifecycleObservedAt(candidate, now))
+	decisionID := candidateRejectionDecisionID(candidate, now)
 	store := &stubFindingStore{
 		candidateState: stubFindingCandidateState{
 			candidates: map[string]*ports.FindingCandidateRecord{candidate.ID: cloneFindingCandidate(candidate)},

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -181,6 +181,8 @@ func lexCypher(query string) []cypherToken {
 			continue
 		case ch == '\'' || ch == '"':
 			i = skipQuotedLiteral(query, i, ch)
+		case ch == '`':
+			i = skipEscapedIdentifier(query, i)
 		case ch == '/' && i+1 < len(query) && query[i+1] == '/':
 			for i+1 < len(query) && query[i+1] != '\n' && query[i+1] != '\r' {
 				i++
@@ -220,6 +222,19 @@ func lexCypher(query string) []cypherToken {
 		}
 	}
 	return tokens
+}
+
+func skipEscapedIdentifier(query string, start int) int {
+	for i := start + 1; i < len(query); i++ {
+		if query[i] == '`' {
+			if i+1 < len(query) && query[i+1] == '`' {
+				i++
+				continue
+			}
+			return i
+		}
+	}
+	return len(query) - 1
 }
 
 func hasForbiddenWriteOrBulkLoad(tokens []cypherToken) bool {

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -16,11 +16,6 @@ const (
 )
 
 var (
-	forbiddenTokenPattern = regexp.MustCompile(`(?i)\b(CREATE|MERGE|DELETE|REMOVE|SET|DROP|FOREACH)\b`)
-	loadCSVPattern        = regexp.MustCompile(`(?i)\bLOAD\s+CSV\b`)
-	usingPeriodicPattern  = regexp.MustCompile(`(?i)\bUSING\s+PERIODIC\b`)
-	forbiddenAPOCPattern  = regexp.MustCompile(`(?i)\bCALL\s+apoc\.(trigger|periodic)\.`)
-	limitPattern          = regexp.MustCompile(`(?i)\bLIMIT\s+(\d+)\b`)
 	matchClausePattern    = regexp.MustCompile(`(?i)\b(?:OPTIONAL\s+MATCH|MATCH)\b`)
 	matchClauseEndPattern = regexp.MustCompile(`(?i)\b(?:WHERE|RETURN|WITH|ORDER\s+BY|LIMIT|UNWIND|CALL|UNION|CREATE|MERGE|DELETE|SET|REMOVE|DROP|FOREACH)\b`)
 	nodeBodyPattern       = regexp.MustCompile(`(?is)^\s*([A-Za-z_][A-Za-z0-9_]*)?\s*((?::\s*[A-Za-z_][A-Za-z0-9_]*)*)\s*(\{[^{}]*\})?\s*$`)
@@ -39,6 +34,21 @@ type subqueryScope struct {
 	imports   map[string]struct{}
 	bodyStart int
 	end       int
+}
+
+type cypherTokenKind int
+
+const (
+	cypherTokenIdentifier cypherTokenKind = iota
+	cypherTokenNumber
+	cypherTokenSymbol
+	cypherTokenParameter
+)
+
+type cypherToken struct {
+	kind cypherTokenKind
+	text string
+	pos  int
 }
 
 type ValidatorOptions struct {
@@ -68,23 +78,24 @@ func (v *Validator) validate(ctx context.Context, cypher string, params map[stri
 		return ValidatorResult{OK: false, Reason: "cypher is required"}, 0, nil
 	}
 	safeQuery := scrubCypher(query)
-	if forbiddenTokenPattern.MatchString(safeQuery) || loadCSVPattern.MatchString(safeQuery) || usingPeriodicPattern.MatchString(safeQuery) {
+	tokens := lexCypher(query)
+	if hasForbiddenWriteOrBulkLoad(tokens) {
 		return ValidatorResult{OK: false, Reason: "write or bulk-load Cypher clauses are forbidden"}, 0, nil
 	}
-	if forbiddenAPOCPattern.MatchString(safeQuery) {
+	if hasForbiddenAPOCCall(tokens) {
 		return ValidatorResult{OK: false, Reason: "apoc trigger and periodic procedures are forbidden"}, 0, nil
 	}
-	if hasProcedureCall(safeQuery) {
+	if hasProcedureCall(tokens) {
 		return ValidatorResult{OK: false, Reason: "procedure CALL clauses are forbidden"}, 0, nil
 	}
-	limit, limitsOK := queryLimit(safeQuery)
+	limit, limitsOK := queryLimit(tokens)
 	if !limitsOK {
 		return ValidatorResult{OK: false, Reason: "read Cypher must include a numeric LIMIT clause"}, 0, nil
 	}
 	if limit > v.options.MaxRows {
 		return ValidatorResult{OK: false, Reason: fmt.Sprintf("LIMIT %d exceeds maximum %d", limit, v.options.MaxRows)}, 0, nil
 	}
-	if oversized := oversizedLimit(safeQuery, v.options.MaxRows); oversized > 0 {
+	if oversized := oversizedLimit(tokens, v.options.MaxRows); oversized > 0 {
 		return ValidatorResult{OK: false, Reason: fmt.Sprintf("LIMIT %d exceeds maximum %d", oversized, v.options.MaxRows)}, 0, nil
 	}
 	if !allNodePatternsTenantScoped(safeQuery) {
@@ -106,16 +117,6 @@ func (v *Validator) validate(ctx context.Context, cypher string, params map[stri
 		}
 	}
 	return ValidatorResult{OK: true}, limit, nil
-}
-
-func oversizedLimit(query string, maxRows int) int {
-	for _, match := range limitPattern.FindAllStringSubmatch(query, -1) {
-		limit, err := strconv.Atoi(match[1])
-		if err == nil && limit > maxRows {
-			return limit
-		}
-	}
-	return 0
 }
 
 func scrubCypher(query string) string {
@@ -171,17 +172,121 @@ func skipQuotedLiteral(query string, start int, quote byte) int {
 	return len(query) - 1
 }
 
-func queryLimit(query string) (int, bool) {
-	matches := limitPattern.FindAllStringSubmatch(query, -1)
-	if len(matches) == 0 {
-		return 0, false
+func lexCypher(query string) []cypherToken {
+	tokens := make([]cypherToken, 0, len(query)/4)
+	for i := 0; i < len(query); i++ {
+		ch := query[i]
+		switch {
+		case isWhitespace(ch):
+			continue
+		case ch == '\'' || ch == '"':
+			i = skipQuotedLiteral(query, i, ch)
+		case ch == '/' && i+1 < len(query) && query[i+1] == '/':
+			for i+1 < len(query) && query[i+1] != '\n' && query[i+1] != '\r' {
+				i++
+			}
+		case ch == '/' && i+1 < len(query) && query[i+1] == '*':
+			i += 2
+			for i+1 < len(query) && (query[i] != '*' || query[i+1] != '/') {
+				i++
+			}
+			if i+1 < len(query) {
+				i++
+			}
+		case ch == '$':
+			start := i
+			i++
+			for i < len(query) && isIdentifierByte(query[i]) {
+				i++
+			}
+			tokens = append(tokens, cypherToken{kind: cypherTokenParameter, text: query[start:i], pos: start})
+			i--
+		case isIdentifierStart(ch):
+			start := i
+			for i < len(query) && (isIdentifierByte(query[i]) || query[i] == '.') {
+				i++
+			}
+			tokens = append(tokens, cypherToken{kind: cypherTokenIdentifier, text: query[start:i], pos: start})
+			i--
+		case ch >= '0' && ch <= '9':
+			start := i
+			for i < len(query) && (query[i] >= '0' && query[i] <= '9' || query[i] == '.') {
+				i++
+			}
+			tokens = append(tokens, cypherToken{kind: cypherTokenNumber, text: query[start:i], pos: start})
+			i--
+		default:
+			tokens = append(tokens, cypherToken{kind: cypherTokenSymbol, text: string(ch), pos: i})
+		}
 	}
-	value := matches[len(matches)-1][1]
-	limit, err := strconv.Atoi(value)
-	if err != nil {
-		return 0, false
+	return tokens
+}
+
+func hasForbiddenWriteOrBulkLoad(tokens []cypherToken) bool {
+	for i, token := range tokens {
+		if token.kind != cypherTokenIdentifier {
+			continue
+		}
+		switch upperToken(token) {
+		case "CREATE", "MERGE", "DELETE", "REMOVE", "SET", "DROP", "FOREACH":
+			return true
+		case "LOAD":
+			if keywordTokenAt(tokens, i+1, "CSV") {
+				return true
+			}
+		case "USING":
+			if keywordTokenAt(tokens, i+1, "PERIODIC") {
+				return true
+			}
+		}
 	}
-	return limit, true
+	return false
+}
+
+func hasForbiddenAPOCCall(tokens []cypherToken) bool {
+	for i, token := range tokens {
+		if !keywordToken(token, "CALL") || i+1 >= len(tokens) {
+			continue
+		}
+		procedure := strings.ToLower(tokens[i+1].text)
+		if strings.HasPrefix(procedure, "apoc.trigger.") || strings.HasPrefix(procedure, "apoc.periodic.") {
+			return true
+		}
+	}
+	return false
+}
+
+func queryLimit(tokens []cypherToken) (int, bool) {
+	limit := 0
+	found := false
+	for i, token := range tokens {
+		if !keywordToken(token, "LIMIT") {
+			continue
+		}
+		if i+1 >= len(tokens) || tokens[i+1].kind != cypherTokenNumber {
+			return 0, false
+		}
+		value, err := strconv.Atoi(tokens[i+1].text)
+		if err != nil {
+			return 0, false
+		}
+		limit = value
+		found = true
+	}
+	return limit, found
+}
+
+func oversizedLimit(tokens []cypherToken, maxRows int) int {
+	for i, token := range tokens {
+		if !keywordToken(token, "LIMIT") || i+1 >= len(tokens) || tokens[i+1].kind != cypherTokenNumber {
+			continue
+		}
+		limit, err := strconv.Atoi(tokens[i+1].text)
+		if err == nil && limit > maxRows {
+			return limit
+		}
+	}
+	return 0
 }
 
 func allNodePatternsTenantScoped(query string) bool {
@@ -267,9 +372,9 @@ func allNodePatternsTenantScoped(query string) bool {
 	return sawNode
 }
 
-func hasProcedureCall(query string) bool {
-	for i := 0; i < len(query); i++ {
-		if keywordAt(query, i, "CALL") && subqueryStartBrace(query, i+len("CALL")) < 0 {
+func hasProcedureCall(tokens []cypherToken) bool {
+	for i, token := range tokens {
+		if keywordToken(token, "CALL") && !symbolTokenAt(tokens, i+1, "{") {
 			return true
 		}
 	}
@@ -528,6 +633,22 @@ func keywordAt(query string, index int, keyword string) bool {
 	return true
 }
 
+func keywordTokenAt(tokens []cypherToken, index int, keyword string) bool {
+	return index >= 0 && index < len(tokens) && keywordToken(tokens[index], keyword)
+}
+
+func keywordToken(token cypherToken, keyword string) bool {
+	return token.kind == cypherTokenIdentifier && strings.EqualFold(token.text, keyword)
+}
+
+func upperToken(token cypherToken) string {
+	return strings.ToUpper(token.text)
+}
+
+func symbolTokenAt(tokens []cypherToken, index int, symbol string) bool {
+	return index >= 0 && index < len(tokens) && tokens[index].kind == cypherTokenSymbol && tokens[index].text == symbol
+}
+
 func isWhitespaceOrSubqueryStart(value byte) bool {
 	return isWhitespace(value) || value == '{'
 }
@@ -579,6 +700,12 @@ func isIdentifierByte(value byte) bool {
 	return value >= 'a' && value <= 'z' ||
 		value >= 'A' && value <= 'Z' ||
 		value >= '0' && value <= '9' ||
+		value == '_'
+}
+
+func isIdentifierStart(value byte) bool {
+	return value >= 'a' && value <= 'z' ||
+		value >= 'A' && value <= 'Z' ||
 		value == '_'
 }
 

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -140,6 +140,26 @@ RETURN b.urn AS urn LIMIT 25`,
 	}
 }
 
+func FuzzValidatorMaliciousCorpus(f *testing.F) {
+	for _, cypher := range []string{
+		`MATCH (a:Entity {tenant_id:$tenant_id}) WITH 'x //' AS c CREATE (b:Entity) RETURN b LIMIT 25`,
+		`MATCH (a:Entity {tenant_id:$tenant_id}) WITH "/*" AS c MATCH (b:Entity) RETURN b LIMIT 25`,
+		`MATCH (e:Entity {tenant_id: $tenant_id}) RETURN e LIMIT 25 UNION MATCH (x:Entity {tenant_id: $tenant_id}) RETURN x LIMIT 1000`,
+		`MATCH (seed:Entity {tenant_id: $tenant_id}) RETURN [(x:Entity {metadata: {tenant_id: $tenant_id}}) | x.urn] AS urn LIMIT 25`,
+		`LOAD CSV FROM 'https://example.test/x.csv' AS row RETURN row LIMIT 1`,
+		`MATCH (e:Entity {tenant_id:$tenant_id}) CALL db.labels() YIELD label RETURN label LIMIT 25`,
+	} {
+		f.Add(cypher)
+	}
+	validator := NewValidator(nil, ValidatorOptions{})
+	f.Fuzz(func(t *testing.T, cypher string) {
+		if len(cypher) > 4096 {
+			t.Skip("query too large for validator fuzz seed")
+		}
+		_, _, _ = validator.validate(context.Background(), cypher, map[string]any{"tenant_id": "example"})
+	})
+}
+
 func TestValidatorAcceptsBoundedTenantScopedRead(t *testing.T) {
 	store := &validatorStore{}
 	validator := NewValidator(store, ValidatorOptions{Explain: true})

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -198,6 +198,22 @@ LIMIT 25`, map[string]any{"tenant_id": "example"})
 	}
 }
 
+func TestValidatorAcceptsEscapedLimitAlias(t *testing.T) {
+	validator := NewValidator(nil, ValidatorOptions{})
+	result, limit, err := validator.validate(context.Background(), `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS `+"`limit`"+`
+LIMIT 25`, map[string]any{"tenant_id": "example"})
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if !result.OK {
+		t.Fatalf("Validate() = %#v, want ok", result)
+	}
+	if limit != 25 {
+		t.Fatalf("limit = %d, want 25", limit)
+	}
+}
+
 func TestValidatorAcceptsBoundVariableReuse(t *testing.T) {
 	validator := NewValidator(nil, ValidatorOptions{})
 	result, limit, err := validator.validate(context.Background(), `MATCH (e:Entity {tenant_id: $tenant_id})

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -8,9 +8,59 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 const MaxBodyBytes = 8 << 20
+const DefaultTimeout = 30 * time.Second
+
+type ClientOptions struct {
+	SourceID      string
+	Timeout       time.Duration
+	BaseTransport http.RoundTripper
+	AllowLoopback bool
+	LookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)
+}
+
+func NewClient(options ClientOptions) *http.Client {
+	return HardenClient(nil, options)
+}
+
+func HardenClient(client *http.Client, options ClientOptions) *http.Client {
+	if client == nil {
+		client = &http.Client{}
+	}
+	cloned := *client
+	if cloned.Timeout <= 0 {
+		cloned.Timeout = firstDuration(options.Timeout, DefaultTimeout)
+	}
+	if cloned.CheckRedirect == nil {
+		cloned.CheckRedirect = NoRedirect
+	}
+	transport := options.BaseTransport
+	if transport == nil {
+		transport = cloned.Transport
+	}
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	cloned.Transport = SafeRoundTripper{
+		Base:          transport,
+		SourceID:      strings.TrimSpace(options.SourceID),
+		AllowLoopback: options.AllowLoopback,
+		LookupIPAddrs: options.LookupIPAddrs,
+	}
+	return &cloned
+}
+
+func firstDuration(values ...time.Duration) time.Duration {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}
 
 // NormalizeBaseURL validates source-configured API origins before credentials are
 // attached to requests.
@@ -48,8 +98,8 @@ func NormalizeRequestPath(sourceID string, raw string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse %s request path: %w", sourceID, err)
 	}
-	if parsed.IsAbs() || parsed.Host != "" || parsed.User != nil || parsed.Fragment != "" {
-		return "", fmt.Errorf("%s request path must be an absolute path without host or fragment", sourceID)
+	if parsed.IsAbs() || parsed.Host != "" || parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", fmt.Errorf("%s request path must be an absolute path without query or fragment", sourceID)
 	}
 	if !strings.HasPrefix(value, "/") {
 		return "", fmt.Errorf("%s request path must start with /", sourceID)

--- a/sources/azure/source.go
+++ b/sources/azure/source.go
@@ -1127,7 +1127,7 @@ func getJSON(ctx context.Context, source *Source, baseURL string, token string, 
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	client := http.DefaultClient
+	client := sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: "azure"})
 	if source != nil && source.client != nil {
 		client = source.client
 	}
@@ -1150,20 +1150,12 @@ func getJSON(ctx context.Context, source *Source, baseURL string, token string, 
 }
 
 func (s *Source) safeClient() *http.Client {
-	return &http.Client{
-		Timeout:       30 * time.Second,
-		Transport:     s.safeTransport(),
-		CheckRedirect: sourcehttp.NoRedirect,
-	}
-}
-
-func (s *Source) safeTransport() http.RoundTripper {
-	return sourcehttp.SafeRoundTripper{
-		Base:          http.DefaultTransport,
+	return sourcehttp.NewClient(sourcehttp.ClientOptions{
 		SourceID:      "azure",
+		Timeout:       30 * time.Second,
 		AllowLoopback: s != nil && s.allowLoopbackBaseURL,
 		LookupIPAddrs: lookupIPAddrs(s),
-	}
+	})
 }
 
 func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -939,21 +939,12 @@ func minTime(left time.Time, right time.Time) time.Time {
 }
 
 func httpClientNoRedirect(client *http.Client, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
-	if client == nil {
-		client = &http.Client{Timeout: httpTimeout}
-	}
-	cloned := *client
-	if cloned.CheckRedirect == nil {
-		cloned.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
-	}
-	transport := cloned.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-	cloned.Transport = sourcehttp.SafeRoundTripper{Base: transport, SourceID: "cosmo", AllowLoopback: allowLoopback, LookupIPAddrs: lookupIPAddrs}
-	return &cloned
+	return sourcehttp.HardenClient(client, sourcehttp.ClientOptions{
+		SourceID:      "cosmo",
+		Timeout:       httpTimeout,
+		AllowLoopback: allowLoopback,
+		LookupIPAddrs: lookupIPAddrs,
+	})
 }
 
 func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {

--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -779,7 +779,7 @@ func getJSON(ctx context.Context, source *Source, settings settings, defaultBase
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	client := http.DefaultClient
+	client := sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: "gcp"})
 	if source != nil && source.client != nil {
 		client = source.client
 	}
@@ -802,20 +802,12 @@ func getJSON(ctx context.Context, source *Source, settings settings, defaultBase
 }
 
 func (s *Source) safeClient() *http.Client {
-	return &http.Client{
-		Timeout:       30 * time.Second,
-		Transport:     s.safeTransport(),
-		CheckRedirect: sourcehttp.NoRedirect,
-	}
-}
-
-func (s *Source) safeTransport() http.RoundTripper {
-	return sourcehttp.SafeRoundTripper{
-		Base:          http.DefaultTransport,
+	return sourcehttp.NewClient(sourcehttp.ClientOptions{
 		SourceID:      "gcp",
+		Timeout:       30 * time.Second,
 		AllowLoopback: s != nil && s.allowLoopbackBaseURL,
 		LookupIPAddrs: lookupIPAddrs(s),
-	}
+	})
 }
 
 func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {

--- a/sources/github/source.go
+++ b/sources/github/source.go
@@ -338,9 +338,6 @@ func (s *Source) newClient(cfg sourcecdk.Config, requireRepo bool) (*gogithub.Cl
 	if s != nil {
 		httpClient = s.client
 	}
-	if httpClient == nil {
-		httpClient = &http.Client{Timeout: sourceHTTPTimeout}
-	}
 	httpClient = sourceHTTPClientNoRedirect(httpClient, allowLoopbackBaseURL, lookupIPAddrs)
 	client := gogithub.NewClient(httpClient)
 	if settings.token != "" {
@@ -357,21 +354,12 @@ func (s *Source) newClient(cfg sourcecdk.Config, requireRepo bool) (*gogithub.Cl
 }
 
 func sourceHTTPClientNoRedirect(client *http.Client, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
-	if client == nil {
-		client = &http.Client{Timeout: sourceHTTPTimeout}
-	}
-	cloned := *client
-	if cloned.CheckRedirect == nil {
-		cloned.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
-	}
-	transport := cloned.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-	cloned.Transport = sourcehttp.SafeRoundTripper{Base: transport, SourceID: "github", AllowLoopback: allowLoopback, LookupIPAddrs: lookupIPAddrs}
-	return &cloned
+	return sourcehttp.HardenClient(client, sourcehttp.ClientOptions{
+		SourceID:      "github",
+		Timeout:       sourceHTTPTimeout,
+		AllowLoopback: allowLoopback,
+		LookupIPAddrs: lookupIPAddrs,
+	})
 }
 
 func parseSettings(cfg sourcecdk.Config, requireRepo bool, allowLoopbackBaseURL bool) (_ settings, err error) {

--- a/sources/googleworkspace/source.go
+++ b/sources/googleworkspace/source.go
@@ -373,7 +373,7 @@ func (s *Source) getJSON(ctx context.Context, settings settings, path string, qu
 	req.Header.Set("Authorization", "Bearer "+settings.token)
 	client := s.client
 	if client == nil {
-		client = http.DefaultClient
+		client = sourcehttp.NewClient(sourcehttp.ClientOptions{SourceID: "google_workspace"})
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -394,20 +394,12 @@ func (s *Source) getJSON(ctx context.Context, settings settings, path string, qu
 }
 
 func (s *Source) safeClient() *http.Client {
-	return &http.Client{
-		Timeout:       30 * time.Second,
-		Transport:     s.safeTransport(),
-		CheckRedirect: sourcehttp.NoRedirect,
-	}
-}
-
-func (s *Source) safeTransport() http.RoundTripper {
-	return sourcehttp.SafeRoundTripper{
-		Base:          http.DefaultTransport,
+	return sourcehttp.NewClient(sourcehttp.ClientOptions{
 		SourceID:      "google_workspace",
+		Timeout:       30 * time.Second,
 		AllowLoopback: s != nil && s.allowLoopbackBaseURL,
 		LookupIPAddrs: lookupIPAddrs(s),
-	}
+	})
 }
 
 func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -465,20 +465,12 @@ func (s *Source) doJSON(req *http.Request, target any) error {
 		return fmt.Errorf("grc source is required")
 	}
 	client := s.client
-	if client == nil {
-		client = &http.Client{Timeout: httpTimeout}
-	}
-	cloned := *client
-	if cloned.CheckRedirect == nil {
-		cloned.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
-	}
-	transport := cloned.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-	cloned.Transport = sourcehttp.SafeRoundTripper{Base: transport, SourceID: "grc", AllowLoopback: s.allowLoopbackBaseURL, LookupIPAddrs: lookupIPAddrs(s)}
+	cloned := sourcehttp.HardenClient(client, sourcehttp.ClientOptions{
+		SourceID:      "grc",
+		Timeout:       httpTimeout,
+		AllowLoopback: s.allowLoopbackBaseURL,
+		LookupIPAddrs: lookupIPAddrs(s),
+	})
 	resp, err := cloned.Do(req)
 	if err != nil {
 		return fmt.Errorf("request %s: %w", req.URL.Path, err)

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -20,13 +19,12 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
 const (
 	defaultPageSize = 100
 	maxPageSize     = 500
-	httpTimeout     = 30 * time.Second
-	maxBodyBytes    = 8 << 20
 )
 
 // Family describes one JSON API collection exposed by a first-class source.
@@ -178,7 +176,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 	if resolved.baseURL == "" {
 		return resolved, fmt.Errorf("%s base_url is required", s.options.SourceID)
 	}
-	baseURL, host, err := normalizeBaseURL(s.options.SourceID, resolved.baseURL, s.AllowLoopbackBaseURL)
+	baseURL, host, err := sourcehttp.NormalizeBaseURL(s.options.SourceID, resolved.baseURL, s.AllowLoopbackBaseURL)
 	if err != nil {
 		return resolved, err
 	}
@@ -201,7 +199,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 		resolved.perPage = perPage
 	}
 	path := firstNonEmpty(configValue(cfg, resolved.family+"_path"), configValue(cfg, "path"), family.Path)
-	resolved.path, err = normalizeRequestPath(s.options.SourceID, path)
+	resolved.path, err = sourcehttp.NormalizeRequestPath(s.options.SourceID, path)
 	if err != nil {
 		return resolved, err
 	}
@@ -253,22 +251,18 @@ func (s *Source) getJSON(ctx context.Context, settings settings, query url.Value
 	req.Header.Set("Authorization", tokenScheme+" "+settings.token)
 	client := s.client
 	if client == nil {
-		client = &http.Client{
-			Timeout: httpTimeout,
-			Transport: safeRoundTripper{
-				base:          http.DefaultTransport,
-				sourceID:      s.options.SourceID,
-				allowLoopback: s.AllowLoopbackBaseURL,
-				lookupIPAddrs: lookupIPAddrs(s),
-			},
-		}
+		client = sourcehttp.NewClient(sourcehttp.ClientOptions{
+			SourceID:      s.options.SourceID,
+			AllowLoopback: s.AllowLoopbackBaseURL,
+			LookupIPAddrs: lookupIPAddrs(s),
+		})
 	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, err := readLimitedBody(resp.Body)
+	body, err := sourcehttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -452,176 +446,11 @@ func parseTime(raw string) (time.Time, bool) {
 	return time.Time{}, false
 }
 
-func normalizeBaseURL(sourceID string, raw string, allowLoopback bool) (string, string, error) {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil {
-		return "", "", fmt.Errorf("parse %s base_url: %w", sourceID, err)
-	}
-	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
-	allowInsecureLoopback := allowLoopback && parsed.Scheme == "http" && isLoopbackHost(host)
-	if parsed.Scheme != "https" && !allowInsecureLoopback {
-		return "", "", fmt.Errorf("%s base_url must use https", sourceID)
-	}
-	if host == "" {
-		return "", "", fmt.Errorf("%s base_url must include a host", sourceID)
-	}
-	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", "", fmt.Errorf("%s base_url must not include user info, query, or fragment", sourceID)
-	}
-	if strings.TrimSpace(parsed.Port()) != "" && parsed.Port() != "443" && (!allowLoopback || !isLoopbackHost(host)) {
-		return "", "", fmt.Errorf("%s base_url must not include a custom port", sourceID)
-	}
-	if isUnsafeHost(host) && (!allowLoopback || !isLoopbackHost(host)) {
-		return "", "", fmt.Errorf("%s base_url must not target loopback, private, or link-local hosts", sourceID)
-	}
-	return strings.TrimRight(parsed.String(), "/"), host, nil
-}
-
-func normalizeRequestPath(sourceID string, raw string) (string, error) {
-	value := strings.TrimSpace(raw)
-	if value == "" {
-		return "", fmt.Errorf("%s request path is required", sourceID)
-	}
-	parsed, err := url.Parse(value)
-	if err != nil {
-		return "", fmt.Errorf("parse %s request path: %w", sourceID, err)
-	}
-	if parsed.IsAbs() || parsed.Host != "" || parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", fmt.Errorf("%s request path must be an absolute path without query or fragment", sourceID)
-	}
-	if !strings.HasPrefix(value, "/") {
-		return "", fmt.Errorf("%s request path must start with /", sourceID)
-	}
-	return value, nil
-}
-
-type safeRoundTripper struct {
-	base          http.RoundTripper
-	sourceID      string
-	allowLoopback bool
-	lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)
-}
-
-func (rt safeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	base := rt.base
-	if base == nil {
-		base = http.DefaultTransport
-	}
-	if req != nil && req.URL != nil {
-		addrs, err := safeResolvedHostAddrs(req.Context(), rt.sourceID, req.URL.Hostname(), rt.allowLoopback, rt.lookupIPAddrs)
-		if err != nil {
-			return nil, err
-		}
-		if len(addrs) > 0 {
-			pinned, err := pinnedHostTransport(base, req.URL.Hostname(), addrs[0].IP)
-			if err != nil {
-				return nil, err
-			}
-			base = pinned
-		}
-	}
-	return base.RoundTrip(req)
-}
-
-func pinnedHostTransport(base http.RoundTripper, host string, ip net.IP) (http.RoundTripper, error) {
-	transport, ok := base.(*http.Transport)
-	if !ok {
-		return nil, fmt.Errorf("jsonapi transport must support pinned host dialing")
-	}
-	clone := transport.Clone()
-	clone.Proxy = nil
-	clone.DialTLSContext = nil
-	dialContext := clone.DialContext
-	if dialContext == nil {
-		dialer := &net.Dialer{}
-		dialContext = dialer.DialContext
-	}
-	requestHost := strings.ToLower(strings.Trim(strings.TrimSpace(host), "[]"))
-	pinnedIP := ip.String()
-	clone.DialContext = func(ctx context.Context, network string, address string) (net.Conn, error) {
-		addressHost, addressPort, err := net.SplitHostPort(address)
-		if err == nil && strings.EqualFold(strings.Trim(addressHost, "[]"), requestHost) {
-			return dialContext(ctx, network, net.JoinHostPort(pinnedIP, addressPort))
-		}
-		return dialContext(ctx, network, address)
-	}
-	return clone, nil
-}
-
 func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {
 	if source != nil && source.lookupIPAddrs != nil {
 		return source.lookupIPAddrs
 	}
 	return net.DefaultResolver.LookupIPAddr
-}
-
-func safeResolvedHostAddrs(ctx context.Context, sourceID string, host string, allowLoopback bool, lookup func(context.Context, string) ([]net.IPAddr, error)) ([]net.IPAddr, error) {
-	normalized := strings.ToLower(strings.TrimSpace(host))
-	if normalized == "" {
-		return nil, fmt.Errorf("%s host is required", sourceID)
-	}
-	if ip := net.ParseIP(strings.Trim(normalized, "[]")); ip != nil {
-		if unsafeIP(ip, allowLoopback) {
-			return nil, fmt.Errorf("%s host must not target loopback, private, or link-local addresses", sourceID)
-		}
-		return nil, nil
-	}
-	if lookup == nil {
-		lookup = net.DefaultResolver.LookupIPAddr
-	}
-	addrs, err := lookup(ctx, normalized)
-	if err != nil {
-		return nil, fmt.Errorf("resolve %s host %q: %w", sourceID, normalized, err)
-	}
-	if len(addrs) == 0 {
-		return nil, fmt.Errorf("resolve %s host %q: no addresses", sourceID, normalized)
-	}
-	for _, addr := range addrs {
-		if unsafeIP(addr.IP, allowLoopback) {
-			return nil, fmt.Errorf("%s host must not resolve to loopback, private, or link-local addresses", sourceID)
-		}
-	}
-	return addrs, nil
-}
-
-func isUnsafeHost(host string) bool {
-	value := strings.Trim(strings.ToLower(strings.TrimSpace(host)), "[]")
-	if value == "" || value == "localhost" || strings.HasSuffix(value, ".localhost") {
-		return true
-	}
-	ip := net.ParseIP(value)
-	return ip != nil && unsafeIP(ip, false)
-}
-
-func unsafeIP(ip net.IP, allowLoopback bool) bool {
-	if ip == nil {
-		return true
-	}
-	if allowLoopback && ip.IsLoopback() {
-		return false
-	}
-	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast()
-}
-
-func isLoopbackHost(host string) bool {
-	value := strings.Trim(strings.ToLower(strings.TrimSpace(host)), "[]")
-	if value == "localhost" || strings.HasSuffix(value, ".localhost") {
-		return true
-	}
-	ip := net.ParseIP(value)
-	return ip != nil && ip.IsLoopback()
-}
-
-func readLimitedBody(body io.Reader) ([]byte, error) {
-	limited := io.LimitReader(body, maxBodyBytes+1)
-	payload, err := io.ReadAll(limited)
-	if err != nil {
-		return nil, err
-	}
-	if len(payload) > maxBodyBytes {
-		return nil, fmt.Errorf("response body exceeds %d bytes", maxBodyBytes)
-	}
-	return payload, nil
 }
 
 type responseError struct {

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -11,6 +11,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
 func TestReadPagesJSONAPIRecords(t *testing.T) {
@@ -274,13 +275,13 @@ func TestRejectsUnsafeBaseURL(t *testing.T) {
 
 func TestSafeRoundTripperPinsValidatedHostnameAddress(t *testing.T) {
 	var dialed string
-	rt := safeRoundTripper{
-		sourceID: "test",
-		base: &http.Transport{DialContext: func(_ context.Context, _ string, address string) (net.Conn, error) {
+	rt := sourcehttp.SafeRoundTripper{
+		SourceID: "test",
+		Base: &http.Transport{DialContext: func(_ context.Context, _ string, address string) (net.Conn, error) {
 			dialed = address
 			return nil, errors.New("stop")
 		}},
-		lookupIPAddrs: func(context.Context, string) ([]net.IPAddr, error) {
+		LookupIPAddrs: func(context.Context, string) ([]net.IPAddr, error) {
 			return []net.IPAddr{{IP: net.ParseIP("203.0.113.10")}}, nil
 		},
 	}
@@ -302,13 +303,13 @@ func TestSafeRoundTripperPinsValidatedHostnameAddress(t *testing.T) {
 
 func TestSafeRoundTripperRejectsUnsafeResolvedHostnameBeforeDial(t *testing.T) {
 	var dialed bool
-	rt := safeRoundTripper{
-		sourceID: "test",
-		base: &http.Transport{DialContext: func(_ context.Context, _ string, _ string) (net.Conn, error) {
+	rt := sourcehttp.SafeRoundTripper{
+		SourceID: "test",
+		Base: &http.Transport{DialContext: func(_ context.Context, _ string, _ string) (net.Conn, error) {
 			dialed = true
 			return nil, errors.New("should not dial")
 		}},
-		lookupIPAddrs: func(context.Context, string) ([]net.IPAddr, error) {
+		LookupIPAddrs: func(context.Context, string) ([]net.IPAddr, error) {
 			return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
 		},
 	}

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -1006,21 +1006,12 @@ func sleepContext(ctx context.Context, delay time.Duration) error {
 }
 
 func oktaHTTPClientNoRedirect(client *http.Client, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
-	if client == nil {
-		client = &http.Client{Timeout: oktaHTTPTimeout}
-	}
-	cloned := *client
-	if cloned.CheckRedirect == nil {
-		cloned.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
-	}
-	transport := cloned.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-	cloned.Transport = sourcehttp.SafeRoundTripper{Base: transport, SourceID: "okta", AllowLoopback: allowLoopback, LookupIPAddrs: lookupIPAddrs}
-	return &cloned
+	return sourcehttp.HardenClient(client, sourcehttp.ClientOptions{
+		SourceID:      "okta",
+		Timeout:       oktaHTTPTimeout,
+		AllowLoopback: allowLoopback,
+		LookupIPAddrs: lookupIPAddrs,
+	})
 }
 
 func oktaLookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {

--- a/sources/sentinelone/source.go
+++ b/sources/sentinelone/source.go
@@ -560,21 +560,12 @@ func (s *Source) getJSON(ctx context.Context, settings settings, requestPath str
 }
 
 func httpClientNoRedirect(client *http.Client, allowLoopback bool, lookupIPAddrs func(context.Context, string) ([]net.IPAddr, error)) *http.Client {
-	if client == nil {
-		client = &http.Client{Timeout: httpTimeout}
-	}
-	cloned := *client
-	if cloned.CheckRedirect == nil {
-		cloned.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
-	}
-	transport := cloned.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-	cloned.Transport = sourcehttp.SafeRoundTripper{Base: transport, SourceID: "sentinelone", AllowLoopback: allowLoopback, LookupIPAddrs: lookupIPAddrs}
-	return &cloned
+	return sourcehttp.HardenClient(client, sourcehttp.ClientOptions{
+		SourceID:      "sentinelone",
+		Timeout:       httpTimeout,
+		AllowLoopback: allowLoopback,
+		LookupIPAddrs: lookupIPAddrs,
+	})
 }
 
 func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, error) {

--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -665,21 +665,12 @@ func (s *Source) httpClient() *http.Client {
 		client = s.client
 		allowLoopback = s.allowLoopbackBaseURL
 	}
-	if client == nil {
-		client = &http.Client{Timeout: httpTimeout}
-	}
-	cloned := *client
-	if cloned.CheckRedirect == nil {
-		cloned.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
-	}
-	transport := cloned.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-	cloned.Transport = sourcehttp.SafeRoundTripper{Base: transport, SourceID: "vulnview", AllowLoopback: allowLoopback, LookupIPAddrs: lookupIPAddrs(s)}
-	return &cloned
+	return sourcehttp.HardenClient(client, sourcehttp.ClientOptions{
+		SourceID:      "vulnview",
+		Timeout:       httpTimeout,
+		AllowLoopback: allowLoopback,
+		LookupIPAddrs: lookupIPAddrs(s),
+	})
 }
 
 func (settings settings) query() url.Values {

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -102,3 +102,40 @@ func TestSourceCDKOwnsExternalHTTPClients(t *testing.T) {
 		t.Fatalf("scan net/http imports: %v", err)
 	}
 }
+
+func TestSourcesUseSharedHTTPSafety(t *testing.T) {
+	root := repoRoot(t)
+	if err := filepath.WalkDir(filepath.Join(root, "sources"), func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel := shortPath(root, path)
+		for _, marker := range []string{
+			"http.DefaultClient",
+			"&http.Client{",
+			"io.ReadAll(resp.Body)",
+			"io.ReadAll(response.Body)",
+			"type safeRoundTripper",
+		} {
+			if bytes.Contains(body, []byte(marker)) {
+				t.Fatalf("%s uses %s; source connectors must go through internal/sourcehttp", rel, marker)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("scan source HTTP safety: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Centralize canonical request origin/trusted proxy handling for DPoP, device rate limits, and access audit IPs.
- Enforce shared source HTTP safety with hardened client constructors and archtests for unsafe client/body-read patterns.
- Move Cypher clause checks to a token stream, add malicious fuzz seeds, and make candidate lifecycle transitions recover completed concurrent attempts.
- Document the security regression harness and new origin/proxy envs.

## Test plan
- `make verify`
- `go test ./internal/graphagent ./internal/sourcehttp ./internal/bootstrap ./internal/config ./internal/findings ./tools/archtests`


Made with [Cursor](https://cursor.com)