### PR TITLE
Harden shared HTTP body reads

### DIFF
--- a/internal/bootstrap/http_doer.go
+++ b/internal/bootstrap/http_doer.go
@@ -3,12 +3,14 @@ package bootstrap
 import (
 	"bytes"
 	"context"
-	"io"
 	"net/http"
 	"time"
 
 	"github.com/writer/cerebro/internal/graphagent"
+	"github.com/writer/cerebro/internal/sourcehttp"
 )
+
+const maxHTTPDoerResponseBytes = 4 << 20
 
 type stdHTTPDoer struct {
 	client *http.Client
@@ -31,7 +33,7 @@ func (d *stdHTTPDoer) Post(ctx context.Context, url string, headers map[string]s
 		return 0, nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxHTTPDoerResponseBytes)
 	if err != nil {
 		return resp.StatusCode, nil, err
 	}

--- a/internal/bootstrap/http_doer_test.go
+++ b/internal/bootstrap/http_doer_test.go
@@ -1,0 +1,28 @@
+package bootstrap
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHTTPDoerRejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", maxHTTPDoerResponseBytes+1)))
+	}))
+	defer server.Close()
+
+	doer := &stdHTTPDoer{client: server.Client()}
+	status, body, err := doer.Post(context.Background(), server.URL, nil, []byte("{}"))
+	if err == nil {
+		t.Fatal("Post() error = nil, want oversized response error")
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", status, http.StatusOK)
+	}
+	if body != nil {
+		t.Fatalf("body = %d bytes, want nil on oversized response", len(body))
+	}
+}

--- a/internal/sourcehttp/safe.go
+++ b/internal/sourcehttp/safe.go
@@ -246,13 +246,20 @@ func IsLoopbackHost(host string) bool {
 }
 
 func ReadLimitedBody(body io.Reader) ([]byte, error) {
-	limited := io.LimitReader(body, MaxBodyBytes+1)
+	return ReadLimitedBodyWithLimit(body, MaxBodyBytes)
+}
+
+func ReadLimitedBodyWithLimit(body io.Reader, maxBytes int) ([]byte, error) {
+	if maxBytes <= 0 {
+		maxBytes = MaxBodyBytes
+	}
+	limited := io.LimitReader(body, int64(maxBytes)+1)
 	payload, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, err
 	}
-	if len(payload) > MaxBodyBytes {
-		return nil, fmt.Errorf("response body exceeds %d bytes", MaxBodyBytes)
+	if len(payload) > maxBytes {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxBytes)
 	}
 	return payload, nil
 }

--- a/internal/sourcehttp/safe_test.go
+++ b/internal/sourcehttp/safe_test.go
@@ -35,3 +35,10 @@ func TestReadLimitedBodyRejectsOversizedResponse(t *testing.T) {
 		t.Fatal("ReadLimitedBody() error = nil, want oversized response error")
 	}
 }
+
+func TestReadLimitedBodyWithLimitRejectsCustomOversizedResponse(t *testing.T) {
+	_, err := ReadLimitedBodyWithLimit(strings.NewReader("abcdef"), 5)
+	if err == nil {
+		t.Fatal("ReadLimitedBodyWithLimit() error = nil, want oversized response error")
+	}
+}

--- a/sources/cosmo/source.go
+++ b/sources/cosmo/source.go
@@ -596,7 +596,7 @@ func (s *Source) getJSON(ctx context.Context, settings settings, method string, 
 		_ = resp.Body.Close()
 	}()
 
-	payload, err := readLimitedBody(resp.Body)
+	payload, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxBodyBytes)
 	if err != nil {
 		return fmt.Errorf("read %s response: %w", requestPath, err)
 	}
@@ -952,18 +952,6 @@ func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, 
 		return source.lookupIPAddrs
 	}
 	return net.DefaultResolver.LookupIPAddr
-}
-
-func readLimitedBody(body io.Reader) ([]byte, error) {
-	limited := io.LimitReader(body, maxBodyBytes+1)
-	payload, err := io.ReadAll(limited)
-	if err != nil {
-		return nil, err
-	}
-	if len(payload) > maxBodyBytes {
-		return nil, fmt.Errorf("cosmo response body exceeds %d bytes", maxBodyBytes)
-	}
-	return payload, nil
 }
 
 func decodeResponseError(statusCode int, body []byte) error {

--- a/sources/grc/source.go
+++ b/sources/grc/source.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -478,7 +477,7 @@ func (s *Source) doJSON(req *http.Request, target any) error {
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-	body, err := readLimitedBody(resp.Body)
+	body, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxBodyBytes)
 	if err != nil {
 		return fmt.Errorf("read %s response: %w", req.URL.Path, err)
 	}
@@ -1444,18 +1443,6 @@ func isLoopbackHost(host string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
-}
-
-func readLimitedBody(body io.Reader) ([]byte, error) {
-	limited := io.LimitReader(body, maxBodyBytes+1)
-	data, err := io.ReadAll(limited)
-	if err != nil {
-		return nil, err
-	}
-	if len(data) > maxBodyBytes {
-		return nil, fmt.Errorf("response body exceeds %d bytes", maxBodyBytes)
-	}
-	return data, nil
 }
 
 func decodeResponseError(statusCode int, body []byte) error {

--- a/sources/okta/source.go
+++ b/sources/okta/source.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -951,7 +950,7 @@ func (s *Source) getJSON(ctx context.Context, settings settings, requestPath str
 	}()
 	headers := resp.Header.Clone()
 
-	body, err := readLimitedBody(resp.Body)
+	body, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxOktaBodyBytes)
 	if err != nil {
 		return headers, fmt.Errorf("read %s response: %w", requestPath, err)
 	}
@@ -1019,18 +1018,6 @@ func oktaLookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAd
 		return source.lookupIPAddrs
 	}
 	return net.DefaultResolver.LookupIPAddr
-}
-
-func readLimitedBody(body io.Reader) ([]byte, error) {
-	limited := io.LimitReader(body, maxOktaBodyBytes+1)
-	payload, err := io.ReadAll(limited)
-	if err != nil {
-		return nil, err
-	}
-	if len(payload) > maxOktaBodyBytes {
-		return nil, fmt.Errorf("okta response body exceeds %d bytes", maxOktaBodyBytes)
-	}
-	return payload, nil
 }
 
 func decodeResponseError(statusCode int, body []byte) error {

--- a/sources/sentinelone/source.go
+++ b/sources/sentinelone/source.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -543,7 +542,7 @@ func (s *Source) getJSON(ctx context.Context, settings settings, requestPath str
 		_ = resp.Body.Close()
 	}()
 
-	body, err := readLimitedBody(resp.Body)
+	body, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxBodyBytes)
 	if err != nil {
 		return fmt.Errorf("read %s response: %w", requestPath, err)
 	}
@@ -573,18 +572,6 @@ func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, 
 		return source.lookupIPAddrs
 	}
 	return net.DefaultResolver.LookupIPAddr
-}
-
-func readLimitedBody(body io.Reader) ([]byte, error) {
-	limited := io.LimitReader(body, maxBodyBytes+1)
-	payload, err := io.ReadAll(limited)
-	if err != nil {
-		return nil, err
-	}
-	if len(payload) > maxBodyBytes {
-		return nil, fmt.Errorf("sentinelone response body exceeds %d bytes", maxBodyBytes)
-	}
-	return payload, nil
 }
 
 func decodeResponseError(statusCode int, body []byte) error {

--- a/sources/vulnview/source.go
+++ b/sources/vulnview/source.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"net"
 	"net/http"
@@ -550,7 +549,7 @@ func (s *Source) getJSONWithToken(ctx context.Context, settings settings, reques
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-	body, err := readLimitedBody(resp.Body)
+	body, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxBodyBytes)
 	if err != nil {
 		return fmt.Errorf("read %s response: %w", requestPath, err)
 	}
@@ -634,7 +633,7 @@ func (s *Source) fetchToken(ctx context.Context, settings settings) (string, tim
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-	body, err := readLimitedBody(resp.Body)
+	body, err := sourcehttp.ReadLimitedBodyWithLimit(resp.Body, maxBodyBytes)
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("read VulnView token response: %w", err)
 	}
@@ -1004,18 +1003,6 @@ func isLoopbackHost(host string) bool {
 	}
 	ip := net.ParseIP(strings.Trim(host, "[]"))
 	return ip != nil && ip.IsLoopback()
-}
-
-func readLimitedBody(body io.Reader) ([]byte, error) {
-	limited := io.LimitReader(body, maxBodyBytes+1)
-	payload, err := io.ReadAll(limited)
-	if err != nil {
-		return nil, err
-	}
-	if len(payload) > maxBodyBytes {
-		return nil, fmt.Errorf("vulnview response body exceeds %d bytes", maxBodyBytes)
-	}
-	return payload, nil
 }
 
 func decodeResponseError(service string, statusCode int, body []byte) error {

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -128,6 +128,7 @@ func TestSourcesUseSharedHTTPSafety(t *testing.T) {
 			"&http.Client{",
 			"io.ReadAll(resp.Body)",
 			"io.ReadAll(response.Body)",
+			"func readLimitedBody(",
 			"type safeRoundTripper",
 		} {
 			if bytes.Contains(body, []byte(marker)) {


### PR DESCRIPTION
## Summary
- Centralize remaining bounded source connector response reads through `internal/sourcehttp` while preserving per-connector byte limits.
- Add a custom-limit helper and archtest guardrail to prevent source-local `readLimitedBody` helpers from returning.
- Bound graph-agent HTTP doer responses and cover oversized responses with a regression test.

## Test plan
- `make verify`

Made with [Cursor](https://cursor.com)