### PR TITLE
Harden forwarded origin selection

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2292,6 +2292,19 @@ func TestResolveRequestOriginRejectsMalformedTrailingForwardedOrigin(t *testing.
 	}
 }
 
+func TestResolveRequestOriginDoesNotMixForwardedOriginWithFallback(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://internal.local/sources", nil)
+	req.RemoteAddr = "10.0.1.20:443"
+	req.Host = "internal.local"
+	req.Header.Set("X-Forwarded-Proto", "https, gopher")
+	req.Header.Set("X-Forwarded-Host", "api.writer.com, api.writer.com")
+
+	origin := resolveRequestOrigin(req, config.RequestOriginConfig{})
+	if got := origin.PublicURL; got != "http://internal.local/sources" {
+		t.Fatalf("PublicURL = %q, want request origin when forwarded proto is malformed", got)
+	}
+}
+
 func TestResolveRequestOriginIgnoresForwardedHostFromUntrustedRemote(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://internal.local/platform/devices/token", nil)
 	req.RemoteAddr = "198.51.100.20:54321"

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2279,6 +2279,19 @@ func TestResolveRequestOriginRejectsMalformedForwardedHost(t *testing.T) {
 	}
 }
 
+func TestResolveRequestOriginRejectsMalformedTrailingForwardedOrigin(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://internal.local/sources", nil)
+	req.RemoteAddr = "10.0.1.20:443"
+	req.Host = "internal.local"
+	req.Header.Set("X-Forwarded-Proto", "https, gopher")
+	req.Header.Set("X-Forwarded-Host", "stale.example, user@evil.example")
+
+	origin := resolveRequestOrigin(req, config.RequestOriginConfig{})
+	if got := origin.PublicURL; got != "http://internal.local/sources" {
+		t.Fatalf("PublicURL = %q, want request origin when trailing forwarded origin is malformed", got)
+	}
+}
+
 func TestResolveRequestOriginIgnoresForwardedHostFromUntrustedRemote(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://internal.local/platform/devices/token", nil)
 	req.RemoteAddr = "198.51.100.20:54321"

--- a/internal/bootstrap/request_origin.go
+++ b/internal/bootstrap/request_origin.go
@@ -101,7 +101,10 @@ func trustedForwardedProto(header string) string {
 			return "https"
 		case "http":
 			return "http"
+		case "":
+			continue
 		}
+		return ""
 	}
 	return ""
 }
@@ -117,6 +120,7 @@ func trustedForwardedHost(header string) string {
 		if err == nil && parsed.Host != "" && parsed.User == nil && parsed.RawQuery == "" && !parsed.ForceQuery && parsed.Fragment == "" && parsed.Path == "" {
 			return parsed.Host
 		}
+		return ""
 	}
 	return ""
 }

--- a/internal/bootstrap/request_origin.go
+++ b/internal/bootstrap/request_origin.go
@@ -42,10 +42,12 @@ func resolveRequestOrigin(r *http.Request, cfg config.RequestOriginConfig) reque
 	origin.TrustedProxy = requestOriginTrustsProxy(remoteIP, cfg)
 	if origin.TrustedProxy {
 		if publicOrigin := normalizedPublicOrigin(cfg.PublicOrigin); publicOrigin == nil {
-			if forwardedProto := trustedForwardedProto(r.Header.Get("X-Forwarded-Proto")); forwardedProto != "" {
+			forwardedProto, malformedProto := trustedForwardedProto(r.Header.Get("X-Forwarded-Proto"))
+			forwardedHost, malformedHost := trustedForwardedHost(r.Header.Get("X-Forwarded-Host"))
+			if !malformedProto && !malformedHost && forwardedProto != "" {
 				origin.Scheme = forwardedProto
 			}
-			if forwardedHost := trustedForwardedHost(r.Header.Get("X-Forwarded-Host")); forwardedHost != "" {
+			if !malformedProto && !malformedHost && forwardedHost != "" {
 				origin.Host = forwardedHost
 			}
 		}
@@ -92,24 +94,24 @@ func normalizedPublicOrigin(raw string) *url.URL {
 	return parsed
 }
 
-func trustedForwardedProto(header string) string {
+func trustedForwardedProto(header string) (string, bool) {
 	parts := strings.Split(header, ",")
 	for i := len(parts) - 1; i >= 0; i-- {
 		part := parts[i]
 		switch strings.ToLower(strings.TrimSpace(part)) {
 		case "https":
-			return "https"
+			return "https", false
 		case "http":
-			return "http"
+			return "http", false
 		case "":
 			continue
 		}
-		return ""
+		return "", true
 	}
-	return ""
+	return "", false
 }
 
-func trustedForwardedHost(header string) string {
+func trustedForwardedHost(header string) (string, bool) {
 	parts := strings.Split(header, ",")
 	for i := len(parts) - 1; i >= 0; i-- {
 		host := strings.TrimSpace(parts[i])
@@ -118,11 +120,11 @@ func trustedForwardedHost(header string) string {
 		}
 		parsed, err := url.Parse("//" + host)
 		if err == nil && parsed.Host != "" && parsed.User == nil && parsed.RawQuery == "" && !parsed.ForceQuery && parsed.Fragment == "" && parsed.Path == "" {
-			return parsed.Host
+			return parsed.Host, false
 		}
-		return ""
+		return "", true
 	}
-	return ""
+	return "", false
 }
 
 func forwardedClientIP(header string, cfg config.RequestOriginConfig) string {


### PR DESCRIPTION
## Summary
- Make forwarded proto/host resolution inspect only the nearest non-empty trailing header token.
- Fail closed on malformed trailing forwarded origin values instead of falling back to stale earlier tokens.
- Add regression coverage for malformed multi-hop forwarded origin headers.

## Test plan
- `go test ./internal/bootstrap`
- `make verify`

Made with [Cursor](https://cursor.com)