### PR TITLE
Harden VulnDB imports and Ask contracts

### DIFF
--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -239,11 +239,12 @@ func cypherRowsToMaps(rows []ports.CypherRow) []map[string]any {
 
 func sanitizeInternalRowFields(rows []map[string]any) {
 	for _, row := range rows {
-		mergeFindingAttributes(row, "finding_attributes_json_internal")
+		mergeInternalAttributes(row, "finding_attributes_json_internal", []string{"summary", "status", "severity", "effective_severity", "risk_score"})
+		mergeInternalAttributes(row, "source_attributes_json_internal", []string{"status", "health", "last_sync_at", "last_sync_minutes", "last_success_at", "last_error"})
 	}
 }
 
-func mergeFindingAttributes(row map[string]any, key string) {
+func mergeInternalAttributes(row map[string]any, key string, fields []string) {
 	raw, ok := row[key].(string)
 	delete(row, key)
 	if !ok || strings.TrimSpace(raw) == "" {
@@ -253,7 +254,7 @@ func mergeFindingAttributes(row map[string]any, key string) {
 	if err := json.Unmarshal([]byte(raw), &attrs); err != nil {
 		return
 	}
-	for _, field := range []string{"summary", "status", "severity", "effective_severity", "risk_score"} {
+	for _, field := range fields {
 		if !rowValueEmpty(row[field]) {
 			continue
 		}

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -239,6 +239,55 @@ func TestServiceSanitizesInternalFindingAttributes(t *testing.T) {
 	}
 }
 
+func TestServiceSanitizesInternalSourceAttributes(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"source_urn":                      "urn:cerebro:writer:source:github",
+				"source_label":                    "GitHub",
+				"source_id":                       "github",
+				"runtime_id":                      "runtime-1",
+				"source_attributes_json_internal": `{"status":"healthy","last_sync_minutes":3,"last_error":"none"}`,
+			},
+		}},
+	}
+	llm := &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Rationale: "Checking source health.",
+			Plan:      &AskQueryPlan{Intent: IntentConnectorHealth, Limit: 25},
+		},
+		Summary: "GitHub is healthy.",
+	}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "Show GitHub health",
+		ScopeURN: "urn:cerebro:writer:source:github",
+	}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	rowsEvent := events[6].Data.(RowsEvent)
+	row := rowsEvent.Rows[0]
+	if _, exists := row["source_attributes_json_internal"]; exists {
+		t.Fatalf("internal source attributes leaked in row: %#v", row)
+	}
+	if got := row["status"]; got != "healthy" {
+		t.Fatalf("status = %q, want healthy", got)
+	}
+	if got := row["last_sync_minutes"]; got != "3" {
+		t.Fatalf("last_sync_minutes = %q, want 3", got)
+	}
+	if len(store.requests) != 1 || !strings.Contains(store.requests[0].Query, "source_attributes_json_internal") {
+		t.Fatalf("store request = %#v, want internal source attributes", store.requests)
+	}
+}
+
 func TestServiceRequiresTenantID(t *testing.T) {
 	service := NewService(&askStore{}, NewStubLLMClient(), ValidatorOptions{})
 	err := service.Stream(context.Background(), AskRequest{Question: "hello"}, func(Event) error { return nil })

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -390,7 +390,7 @@ RETURN source.urn AS source_urn,
        coalesce(source.label, source.urn) AS source_label,
        source.source_id AS source_id,
        source.runtime_id AS runtime_id,
-       coalesce(source.attributes_json, '') AS source_attributes_json
+       coalesce(source.attributes_json, '') AS source_attributes_json_internal
 ORDER BY source_label, source_urn
 LIMIT %d`, limit), true
 	default:

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -63,6 +63,20 @@ func TestOntologyPromptStoresFindingMetadataInAttributesJSON(t *testing.T) {
 	}
 }
 
+func TestOntologyEntityPropertiesStayWithinProjectedContract(t *testing.T) {
+	projected := map[string]struct{}{}
+	for _, property := range canonicalGraphOntology.Properties {
+		projected[property] = struct{}{}
+	}
+	for _, entity := range canonicalGraphOntology.Entities {
+		for _, property := range entity.Properties {
+			if _, ok := projected[property]; !ok {
+				t.Fatalf("ontology entity %q advertises non-projected top-level property %q", entity.Type, property)
+			}
+		}
+	}
+}
+
 func TestOntologyPromptUsesProjectedSourceShape(t *testing.T) {
 	hint := canonicalGraphOntology.PromptHint()
 	for _, want := range []string{
@@ -272,6 +286,9 @@ func TestConvertDraftToQueryScopesConnectorHealthTemplate(t *testing.T) {
 	if !strings.Contains(result.Cypher, "WHERE $scope_urn = '' OR source.urn = $scope_urn") {
 		t.Fatalf("converted cypher missing connector scope predicate:\n%s", result.Cypher)
 	}
+	if !strings.Contains(result.Cypher, "source_attributes_json_internal") || strings.Contains(result.Cypher, " AS source_attributes_json\n") {
+		t.Fatalf("converted cypher should keep raw source attributes internal:\n%s", result.Cypher)
+	}
 }
 
 func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
@@ -300,6 +317,49 @@ func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
 	}
 	if strings.Contains(result.Cypher, "relation: 'has_identifier'") {
 		t.Fatalf("converted cypher should not bridge concrete identities via identifier anchors:\n%s", result.Cypher)
+	}
+}
+
+func TestDeterministicTemplatesUseProjectedGraphContract(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		intent string
+		scope  string
+	}{
+		{name: "source aggregation", intent: IntentAggregateFindingsBySource, scope: "urn:cerebro:writer:asset:alpha"},
+		{name: "top risk", intent: IntentTopRiskFindings, scope: "urn:cerebro:writer:asset:alpha"},
+		{name: "explain finding", intent: IntentExplainFinding, scope: "urn:cerebro:writer:finding:alpha"},
+		{name: "identity bridge", intent: IntentIdentityBridge, scope: "urn:cerebro:writer:github_user:alice"},
+		{name: "connector health", intent: IntentConnectorHealth, scope: "urn:cerebro:writer:source:github"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertDraftToQuery(AskRequest{
+				TenantID: "writer",
+				Question: tt.name,
+				ScopeURN: tt.scope,
+			}, &DraftResponse{Plan: &AskQueryPlan{Intent: tt.intent, Limit: 25}}, 100)
+			if !result.Deterministic {
+				t.Fatalf("conversion result = %#v, want deterministic template", result)
+			}
+			if !strings.Contains(result.Cypher, "$scope_urn") {
+				t.Fatalf("deterministic template ignores scope_urn:\n%s", result.Cypher)
+			}
+			for _, forbidden := range []string{
+				"finding.status",
+				"finding.summary",
+				"finding.risk_score",
+				"finding.effective_severity",
+				"source.status",
+				"source.last_sync_minutes",
+				"source.last_sync_at",
+				"repository.owner_login",
+				"repository.visibility",
+			} {
+				if strings.Contains(result.Cypher, forbidden) {
+					t.Fatalf("deterministic template references non-projected top-level field %q:\n%s", forbidden, result.Cypher)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/vulndb/importers.go
+++ b/internal/vulndb/importers.go
@@ -19,7 +19,15 @@ const (
 	SourceCISAKEV = "cisa-kev"
 	SourceEPSS    = "epss"
 	SourceNVD     = "nvd"
+
+	maxOSVImportBytes     = 256 << 20
+	maxCISAKEVImportBytes = 32 << 20
+	maxEPSSImportBytes    = 128 << 20
+	maxNVDImportBytes     = 512 << 20
 )
+
+// ErrVulnDBFeedTooLarge indicates an advisory feed exceeded its importer byte limit.
+var ErrVulnDBFeedTooLarge = errors.New("vulndb feed exceeds byte limit")
 
 // ImportResult summarizes imported feed records.
 type ImportResult struct {
@@ -33,7 +41,7 @@ func ImportOSV(ctx context.Context, store Store, reader io.Reader) (ImportResult
 	if store == nil {
 		return ImportResult{}, fmt.Errorf("vulnerability store is required")
 	}
-	data, err := io.ReadAll(reader)
+	data, err := readLimitedVulnDBFeed(SourceOSV, reader, maxOSVImportBytes)
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -80,7 +88,11 @@ func ImportCISAKEV(ctx context.Context, store Store, reader io.Reader) (ImportRe
 		return ImportResult{}, fmt.Errorf("vulnerability store is required")
 	}
 	var catalog kevCatalog
-	if err := json.NewDecoder(reader).Decode(&catalog); err != nil {
+	data, err := readLimitedVulnDBFeed(SourceCISAKEV, reader, maxCISAKEVImportBytes)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	if err := json.Unmarshal(data, &catalog); err != nil {
 		return ImportResult{}, err
 	}
 	var result ImportResult
@@ -133,7 +145,11 @@ func ImportEPSS(ctx context.Context, store Store, reader io.Reader) (ImportResul
 	if store == nil {
 		return ImportResult{}, fmt.Errorf("vulnerability store is required")
 	}
-	stripped, err := skipCommentLines(reader)
+	data, err := readLimitedVulnDBFeed(SourceEPSS, reader, maxEPSSImportBytes)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	stripped, err := skipCommentLines(strings.NewReader(string(data)))
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -208,7 +224,11 @@ func ImportNVD(ctx context.Context, store Store, reader io.Reader) (ImportResult
 		return ImportResult{}, fmt.Errorf("vulnerability store is required")
 	}
 	var feed nvdFeed
-	if err := json.NewDecoder(reader).Decode(&feed); err != nil {
+	data, err := readLimitedVulnDBFeed(SourceNVD, reader, maxNVDImportBytes)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	if err := json.Unmarshal(data, &feed); err != nil {
 		return ImportResult{}, err
 	}
 	var result ImportResult
@@ -998,6 +1018,20 @@ func skipCommentLines(reader io.Reader) (io.Reader, error) {
 		return nil, err
 	}
 	return strings.NewReader(builder.String()), nil
+}
+
+func readLimitedVulnDBFeed(source string, reader io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("%s feed byte limit must be positive", normalizeSource(source))
+	}
+	payload, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(payload)) > maxBytes {
+		return nil, fmt.Errorf("%w: %s feed exceeds %d bytes", ErrVulnDBFeedTooLarge, normalizeSource(source), maxBytes)
+	}
+	return payload, nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/vulndb/store_test.go
+++ b/internal/vulndb/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -17,11 +18,36 @@ type failUpsertStore struct {
 	failID string
 }
 
+type repeatedByteReader struct {
+	remaining int64
+}
+
+func (r *repeatedByteReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	for i := range p {
+		p[i] = 'x'
+	}
+	r.remaining -= int64(len(p))
+	return len(p), nil
+}
+
 func (s failUpsertStore) UpsertVulnerability(ctx context.Context, vulnerability Vulnerability) error {
 	if NormalizeIdentifier(vulnerability.ID) == NormalizeIdentifier(s.failID) {
 		return errors.New("upsert failed")
 	}
 	return s.MemoryStore.UpsertVulnerability(ctx, vulnerability)
+}
+
+func TestReadLimitedVulnDBFeedRejectsOversizedPayload(t *testing.T) {
+	_, err := readLimitedVulnDBFeed(SourceOSV, &repeatedByteReader{remaining: 11}, 10)
+	if !errors.Is(err, ErrVulnDBFeedTooLarge) {
+		t.Fatalf("readLimitedVulnDBFeed() error = %v, want ErrVulnDBFeedTooLarge", err)
+	}
 }
 
 func TestMemoryStoreAliasAndPackageMatching(t *testing.T) {

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -140,3 +140,64 @@ func TestSourcesUseSharedHTTPSafety(t *testing.T) {
 		t.Fatalf("scan source HTTP safety: %v", err)
 	}
 }
+
+func TestProductionBodyReadsAreBounded(t *testing.T) {
+	root := repoRoot(t)
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "vendor", "gen", "sdk", "testdata":
+				return filepath.SkipDir
+			default:
+				return nil
+			}
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel := shortPath(root, path)
+		lines := strings.Split(string(body), "\n")
+		for i, line := range lines {
+			if !strings.Contains(line, "io.ReadAll(") {
+				continue
+			}
+			if boundedReadAllContext(lines, i) {
+				continue
+			}
+			t.Fatalf("%s uses io.ReadAll without a nearby io.LimitReader or shared limited reader", rel)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("scan bounded body reads: %v", err)
+	}
+}
+
+func boundedReadAllContext(lines []string, index int) bool {
+	start := index - 4
+	if start < 0 {
+		start = 0
+	}
+	end := index + 1
+	if end >= len(lines) {
+		end = len(lines) - 1
+	}
+	context := strings.Join(lines[start:end+1], "\n")
+	for _, marker := range []string{
+		"io.LimitReader(",
+		"sourcehttp.ReadLimitedBody(",
+		"sourcehttp.ReadLimitedBodyWithLimit(",
+		"readLimitedVulnDBFeed(",
+	} {
+		if strings.Contains(context, marker) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add explicit byte limits for VulnDB feed importers and a typed oversized-feed error.
- Keep connector health attributes internal while exposing only controlled fields.
- Add Ask ontology/template drift tests and broaden bounded body-read guardrails.

## Test plan
- go test ./internal/vulndb ./internal/graphagent ./tools/archtests
- make verify


Made with [Cursor](https://cursor.com)