### PR TITLE
Harden Ask JSON post-processing

### DIFF
--- a/docs/SECURITY_REGRESSION_HARNESS.md
+++ b/docs/SECURITY_REGRESSION_HARNESS.md
@@ -5,7 +5,9 @@ This harness keeps recent Droid findings from becoming one-off fixes. Add new sc
 | Finding class | Regression check |
 | --- | --- |
 | Cypher comment/string validator bypass, unsafe procedures, and oversized branch limits | `go test ./internal/graphagent` plus `FuzzValidatorMaliciousCorpus` seeds in `internal/graphagent/validator_test.go`. |
-| Connector SSRF, DNS rebinding, redirects, and unbounded response reads | `go test ./internal/sourcehttp ./sources/... ./tools/archtests`; `TestSourcesUseSharedHTTPSafety` rejects raw source `http.Client` construction and direct response-body reads. |
+| Ask ontology drift, scoped deterministic templates, and brittle `attributes_json` extraction | `go test ./internal/graphagent`; deterministic source/top-risk templates return bounded candidate rows and parse JSON metadata in Go before emitting rows. |
+| Connector SSRF, DNS rebinding, redirects, and unbounded response reads | `go test ./internal/sourcehttp ./sources/... ./tools/archtests`; `TestSourcesUseSharedHTTPSafety` rejects raw source `http.Client` construction and direct response-body reads, while `TestProductionBodyReadsAreBounded` rejects unbounded production `io.ReadAll` calls. |
+| Oversized VulnDB advisory feeds | `go test ./internal/vulndb`; feed importers return `ErrVulnDBFeedTooLarge` before decoding over-limit OSV, CISA KEV, EPSS, or NVD payloads. |
 | Spoofable `X-Forwarded-For`, DPoP `htu`, and audit client IP drift | `go test ./internal/bootstrap ./internal/config`; request origin is resolved through `internal/bootstrap/request_origin.go` and configured by `CEREBRO_PUBLIC_ORIGIN`, `CEREBRO_TRUSTED_PROXY_CIDRS`, and `CEREBRO_TRUSTED_PROXY_COUNT`. |
 | Candidate promote/reject lost updates and partial lifecycle attempts | `go test ./internal/findings`; lifecycle decisions use stable IDs and recover completed concurrent CAS transitions. |
 
@@ -18,5 +20,5 @@ Before dismissing a future scanner report as a false positive, add one of:
 Run the focused harness locally with:
 
 ```bash
-go test ./internal/graphagent ./internal/sourcehttp ./internal/bootstrap ./internal/config ./internal/findings ./tools/archtests
+go test ./internal/graphagent ./internal/sourcehttp ./internal/bootstrap ./internal/config ./internal/findings ./internal/vulndb ./tools/archtests
 ```

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -104,7 +104,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	if err := emitProgress(emit, started, "validating_query", "Validating generated Cypher against read-only guardrails."); err != nil {
 		return err
 	}
-	validation, rowLimit, err := s.validator.validate(ctx, cypher, params)
+	validation, rowLimit, err := s.validateConversion(ctx, conversion, cypher, params)
 	if err != nil {
 		return err
 	}
@@ -127,6 +127,9 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	})
 	if err != nil {
 		return fmt.Errorf("%w: execute cypher: %w", ErrRuntimeUnavailable, err)
+	}
+	if postProcessingCandidateLimitHit(conversion.Plan, rows, rowLimit) {
+		return emitRefusal(emit, traceID, started, cypher, "The deterministic Ask query matched more graph rows than can be safely post-processed without risking an incomplete answer. Narrow the scope or ask for a more specific subset.")
 	}
 	rowMaps := cypherRowsToMaps(rows)
 	rowMaps = postProcessAskRows(conversion.Plan, rowMaps)
@@ -163,6 +166,16 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		return err
 	}
 	return emit(Event{Name: EventDone, Data: DoneEvent{TraceID: traceID, TotalMS: time.Since(started).Milliseconds()}})
+}
+
+func (s *Service) validateConversion(ctx context.Context, conversion conversionResult, cypher string, params map[string]any) (ValidatorResult, int, error) {
+	validator := s.validator
+	if usesPostProcessingCandidates(conversion.Plan) && validator != nil && validator.options.MaxRows < postProcessingCandidateRowLimit {
+		options := validator.options
+		options.MaxRows = postProcessingCandidateRowLimit
+		validator = NewValidator(validator.store, options)
+	}
+	return validator.validate(ctx, cypher, params)
 }
 
 func emitProgress(emit Emitter, started time.Time, stage string, message string) error {
@@ -261,6 +274,14 @@ func postProcessAskRows(plan AskQueryPlan, rows []map[string]any) []map[string]a
 	default:
 		return rows
 	}
+}
+
+func usesPostProcessingCandidates(plan AskQueryPlan) bool {
+	return plan.Intent == IntentAggregateFindingsBySource || plan.Intent == IntentTopRiskFindings
+}
+
+func postProcessingCandidateLimitHit(plan AskQueryPlan, rows []ports.CypherRow, rowLimit int) bool {
+	return usesPostProcessingCandidates(plan) && rowLimit >= postProcessingCandidateRowLimit && len(rows) >= rowLimit
 }
 
 func postProcessFindingSourceRows(plan AskQueryPlan, rows []map[string]any) []map[string]any {

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,7 +20,10 @@ var (
 	ErrInvalidRequest     = errors.New("invalid graph agent request")
 )
 
-const maxInternalAttributeValueBytes = 4096
+const (
+	maxInternalAttributeValueBytes = 4096
+	maxInternalAttributesJSONBytes = 64 << 10
+)
 
 type AskRequest struct {
 	TenantID string           `json:"tenant_id"`
@@ -125,6 +129,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		return fmt.Errorf("%w: execute cypher: %w", ErrRuntimeUnavailable, err)
 	}
 	rowMaps := cypherRowsToMaps(rows)
+	rowMaps = postProcessAskRows(conversion.Plan, rowMaps)
 	sanitizeInternalRowFields(rowMaps)
 	rowsEvent := RowsEvent{
 		Rows:   rowMaps,
@@ -242,7 +247,251 @@ func cypherRowsToMaps(rows []ports.CypherRow) []map[string]any {
 func sanitizeInternalRowFields(rows []map[string]any) {
 	for _, row := range rows {
 		mergeInternalAttributes(row, "finding_attributes_json_internal", []string{"summary", "status", "severity", "effective_severity", "risk_score"})
+		mergeInternalAttributes(row, "relation_attributes_json_internal", []string{"severity", "effective_severity", "risk_score"})
 		mergeInternalAttributes(row, "source_attributes_json_internal", []string{"status", "health", "last_sync_at", "last_sync_minutes", "last_success_at", "last_error"})
+	}
+}
+
+func postProcessAskRows(plan AskQueryPlan, rows []map[string]any) []map[string]any {
+	switch plan.Intent {
+	case IntentAggregateFindingsBySource:
+		return postProcessFindingSourceRows(plan, rows)
+	case IntentTopRiskFindings:
+		return postProcessTopRiskFindingRows(plan, rows)
+	default:
+		return rows
+	}
+}
+
+func postProcessFindingSourceRows(plan AskQueryPlan, rows []map[string]any) []map[string]any {
+	counts := map[string]int64{}
+	seenFindings := map[string]struct{}{}
+	for index, row := range rows {
+		findingURN := stringRowValue(row, "finding_urn")
+		if findingURN == "" {
+			findingURN = fmt.Sprintf("row:%d", index)
+		}
+		if _, seen := seenFindings[findingURN]; seen {
+			continue
+		}
+		seenFindings[findingURN] = struct{}{}
+		attrs := decodeInternalAttributes(row["finding_attributes_json_internal"])
+		sourceFamily := firstAttributeString(attrs, "source_family", "sourceFamily", "source_system")
+		if sourceFamily == "" {
+			sourceFamily = stringRowValue(row, "source_id")
+		}
+		if sourceFamily == "" {
+			sourceFamily = "Unknown"
+		}
+		counts[sourceFamily]++
+	}
+	sourceFamilies := make([]string, 0, len(counts))
+	for sourceFamily := range counts {
+		sourceFamilies = append(sourceFamilies, sourceFamily)
+	}
+	sort.Slice(sourceFamilies, func(i, j int) bool {
+		left, right := sourceFamilies[i], sourceFamilies[j]
+		if counts[left] != counts[right] {
+			return counts[left] > counts[right]
+		}
+		return left < right
+	})
+	limit := postProcessedRowLimit(plan)
+	if plan.Intent == IntentAggregateFindingsBySource && limit > 10 {
+		limit = 10
+	}
+	if len(sourceFamilies) < limit {
+		limit = len(sourceFamilies)
+	}
+	result := make([]map[string]any, 0, limit)
+	for _, sourceFamily := range sourceFamilies[:limit] {
+		result = append(result, map[string]any{
+			"source_family": sourceFamily,
+			"finding_count": counts[sourceFamily],
+		})
+	}
+	return result
+}
+
+type topRiskFindingRow struct {
+	FindingURN     string
+	FindingLabel   string
+	ResourceURNs   []string
+	ResourceLabels []string
+	riskScore      int
+	severityRank   int
+	seenResources  map[string]struct{}
+}
+
+func postProcessTopRiskFindingRows(plan AskQueryPlan, rows []map[string]any) []map[string]any {
+	byFinding := map[string]*topRiskFindingRow{}
+	for index, row := range rows {
+		findingURN := stringRowValue(row, "finding_urn")
+		if findingURN == "" {
+			findingURN = fmt.Sprintf("row:%d", index)
+		}
+		current := byFinding[findingURN]
+		if current == nil {
+			current = &topRiskFindingRow{
+				FindingURN:    findingURN,
+				FindingLabel:  firstNonEmpty(stringRowValue(row, "finding_label"), findingURN),
+				seenResources: map[string]struct{}{},
+			}
+			byFinding[findingURN] = current
+		}
+		resourceURN := stringRowValue(row, "resource_urn")
+		if resourceURN != "" {
+			if _, seen := current.seenResources[resourceURN]; !seen {
+				current.seenResources[resourceURN] = struct{}{}
+				current.ResourceURNs = append(current.ResourceURNs, resourceURN)
+				current.ResourceLabels = append(current.ResourceLabels, firstNonEmpty(stringRowValue(row, "resource_label"), resourceURN))
+			}
+		}
+		relationAttrs := decodeInternalAttributes(row["relation_attributes_json_internal"])
+		findingAttrs := decodeInternalAttributes(row["finding_attributes_json_internal"])
+		riskScore := firstAttributeInt(relationAttrs, findingAttrs, "risk_score")
+		if riskScore > current.riskScore {
+			current.riskScore = riskScore
+		}
+		severity := firstNonEmpty(
+			firstAttributeString(relationAttrs, "effective_severity", "severity"),
+			firstAttributeString(findingAttrs, "effective_severity", "severity"),
+		)
+		if rank := severityRank(severity); rank > current.severityRank {
+			current.severityRank = rank
+		}
+	}
+	findings := make([]*topRiskFindingRow, 0, len(byFinding))
+	for _, finding := range byFinding {
+		findings = append(findings, finding)
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		left, right := findings[i], findings[j]
+		if left.riskScore != right.riskScore {
+			return left.riskScore > right.riskScore
+		}
+		if left.severityRank != right.severityRank {
+			return left.severityRank > right.severityRank
+		}
+		return left.FindingURN < right.FindingURN
+	})
+	limit := postProcessedRowLimit(plan)
+	if len(findings) < limit {
+		limit = len(findings)
+	}
+	result := make([]map[string]any, 0, limit)
+	for _, finding := range findings[:limit] {
+		result = append(result, map[string]any{
+			"finding_urn":     finding.FindingURN,
+			"finding_label":   finding.FindingLabel,
+			"resource_urns":   append([]string(nil), finding.ResourceURNs...),
+			"resource_labels": append([]string(nil), finding.ResourceLabels...),
+			"risk_score":      finding.riskScore,
+			"severity":        severityName(finding.severityRank),
+		})
+	}
+	return result
+}
+
+func postProcessedRowLimit(plan AskQueryPlan) int {
+	return boundedLimit(plan.Limit, defaultMaxRows)
+}
+
+func decodeInternalAttributes(value any) map[string]any {
+	raw, ok := value.(string)
+	if !ok {
+		return nil
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" || len(raw) > maxInternalAttributesJSONBytes {
+		return nil
+	}
+	var attrs map[string]any
+	if err := json.Unmarshal([]byte(raw), &attrs); err != nil {
+		return nil
+	}
+	return attrs
+}
+
+func firstAttributeString(attrs map[string]any, fields ...string) string {
+	for _, field := range fields {
+		value, ok := attrs[field]
+		if !ok {
+			continue
+		}
+		if text, ok := internalAttributeText(value); ok {
+			return text
+		}
+	}
+	return ""
+}
+
+func firstAttributeInt(primary map[string]any, fallback map[string]any, field string) int {
+	if value, ok := attributeInt(primary[field]); ok {
+		return value
+	}
+	if value, ok := attributeInt(fallback[field]); ok {
+		return value
+	}
+	return 0
+}
+
+func attributeInt(value any) (int, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return int(typed), true
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err == nil {
+			return int(parsed), true
+		}
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(typed))
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return 0, false
+}
+
+func stringRowValue(row map[string]any, key string) string {
+	if text, ok := internalAttributeText(row[key]); ok {
+		return text
+	}
+	return ""
+}
+
+func severityRank(severity string) int {
+	switch strings.ToUpper(strings.TrimSpace(severity)) {
+	case "CRITICAL":
+		return 4
+	case "HIGH":
+		return 3
+	case "MEDIUM":
+		return 2
+	case "LOW":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func severityName(rank int) string {
+	switch rank {
+	case 4:
+		return "CRITICAL"
+	case 3:
+		return "HIGH"
+	case 2:
+		return "MEDIUM"
+	case 1:
+		return "LOW"
+	default:
+		return ""
 	}
 }
 
@@ -275,7 +524,7 @@ func internalAttributeText(value any) (string, bool) {
 	switch typed := value.(type) {
 	case string:
 		text = typed
-	case float64, bool, json.Number:
+	case float64, int, int64, bool, json.Number:
 		text = fmt.Sprint(typed)
 	default:
 		return "", false

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -140,12 +140,29 @@ func TestServiceRefusesUnsupportedPlanOnlyDraftAsConversionFailure(t *testing.T)
 
 func TestServiceConvertsFindingSourceAggregationDraft(t *testing.T) {
 	store := &askStore{
-		rows: []ports.CypherRow{{
-			Values: map[string]any{
-				"source_family": "okta",
-				"finding_count": int64(3),
+		rows: []ports.CypherRow{
+			{
+				Values: map[string]any{
+					"finding_urn":                      "urn:cerebro:writer:finding:alpha",
+					"source_id":                        "fallback",
+					"finding_attributes_json_internal": "{\n  \"source_family\": \"okta\"\n}",
+				},
 			},
-		}},
+			{
+				Values: map[string]any{
+					"finding_urn":                      "urn:cerebro:writer:finding:beta",
+					"source_id":                        "fallback",
+					"finding_attributes_json_internal": `{"sourceFamily":"okta"}`,
+				},
+			},
+			{
+				Values: map[string]any{
+					"finding_urn":                      "urn:cerebro:writer:finding:gamma",
+					"source_id":                        "fallback",
+					"finding_attributes_json_internal": `{"source_system":"GitHub \"Enterprise\""}`,
+				},
+			},
+		},
 	}
 	llm := &StubLLMClient{
 		DraftResponse: &DraftResponse{
@@ -187,8 +204,102 @@ LIMIT 10`,
 	if strings.Contains(cypher.Cypher, "apoc.") || strings.Contains(cypher.Cypher, "HAS_SOURCE") || strings.Contains(cypher.Cypher, "entity_type = 'Finding'") {
 		t.Fatalf("cypher was not canonicalized:\n%s", cypher.Cypher)
 	}
-	if len(store.requests) != 1 || !strings.Contains(store.requests[0].Query, "entity_type: 'finding'") || !strings.Contains(store.requests[0].Query, "count(DISTINCT f)") {
+	if len(store.requests) != 1 || !strings.Contains(store.requests[0].Query, "entity_type: 'finding'") || !strings.Contains(store.requests[0].Query, "finding_attributes_json_internal") {
 		t.Fatalf("store request = %#v", store.requests)
+	}
+	if strings.Contains(store.requests[0].Query, "split(split") || strings.Contains(store.requests[0].Query, "count(DISTINCT f)") {
+		t.Fatalf("store request should leave JSON parsing and aggregation to Go:\n%s", store.requests[0].Query)
+	}
+	rowsEvent := events[6].Data.(RowsEvent)
+	if len(rowsEvent.Rows) != 2 {
+		t.Fatalf("rows = %#v, want two source groups", rowsEvent.Rows)
+	}
+	if rowsEvent.Rows[0]["source_family"] != "okta" || rowsEvent.Rows[0]["finding_count"] != int64(2) {
+		t.Fatalf("first source row = %#v, want okta count 2", rowsEvent.Rows[0])
+	}
+	if rowsEvent.Rows[1]["source_family"] != `GitHub "Enterprise"` || rowsEvent.Rows[1]["finding_count"] != int64(1) {
+		t.Fatalf("second source row = %#v, want escaped source_system fallback", rowsEvent.Rows[1])
+	}
+}
+
+func TestServicePostProcessesTopRiskFindingRows(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{
+			{
+				Values: map[string]any{
+					"finding_urn":                       "urn:cerebro:writer:finding:alpha",
+					"finding_label":                     "Alpha",
+					"resource_urn":                      "urn:cerebro:writer:asset:alpha",
+					"resource_label":                    "Alpha resource",
+					"relation_attributes_json_internal": `{}`,
+					"finding_attributes_json_internal":  `{"risk_score":"40","severity":"CRITICAL"}`,
+				},
+			},
+			{
+				Values: map[string]any{
+					"finding_urn":                       "urn:cerebro:writer:finding:beta",
+					"finding_label":                     "Beta",
+					"resource_urn":                      "urn:cerebro:writer:asset:beta",
+					"resource_label":                    "Beta resource",
+					"relation_attributes_json_internal": "{\n  \"risk_score\": 95\n}",
+					"finding_attributes_json_internal":  `{"severity":"HIGH"}`,
+				},
+			},
+			{
+				Values: map[string]any{
+					"finding_urn":                       "urn:cerebro:writer:finding:gamma",
+					"finding_label":                     "Gamma",
+					"resource_urn":                      "urn:cerebro:writer:asset:gamma",
+					"resource_label":                    "Gamma resource",
+					"relation_attributes_json_internal": `{}`,
+					"finding_attributes_json_internal":  `{}`,
+				},
+			},
+		},
+	}
+	llm := &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Rationale: "Ranking risky findings.",
+			Plan:      &AskQueryPlan{Intent: IntentTopRiskFindings, Limit: 2},
+		},
+		Summary: "Beta is highest risk.",
+	}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "Show top risk findings for this asset",
+		ScopeURN: "urn:cerebro:writer:asset:beta",
+	}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	if len(store.requests) != 1 || !strings.Contains(store.requests[0].Query, "relation_attributes_json_internal") {
+		t.Fatalf("store request = %#v, want internal relation attributes", store.requests)
+	}
+	if !strings.Contains(store.requests[0].Query, "WHERE $scope_urn = '' OR resource.urn = $scope_urn OR finding.urn = $scope_urn") {
+		t.Fatalf("store request missing scope predicate:\n%s", store.requests[0].Query)
+	}
+	if strings.Contains(store.requests[0].Query, "split(split") || strings.Contains(store.requests[0].Query, "CASE toUpper") {
+		t.Fatalf("store request should leave JSON parsing and ranking to Go:\n%s", store.requests[0].Query)
+	}
+	rowsEvent := events[6].Data.(RowsEvent)
+	if len(rowsEvent.Rows) != 2 {
+		t.Fatalf("rows = %#v, want two limited top-risk rows", rowsEvent.Rows)
+	}
+	first := rowsEvent.Rows[0]
+	if first["finding_urn"] != "urn:cerebro:writer:finding:beta" || first["risk_score"] != 95 || first["severity"] != "HIGH" {
+		t.Fatalf("first top-risk row = %#v, want beta risk 95 HIGH", first)
+	}
+	if _, exists := first["finding_attributes_json_internal"]; exists {
+		t.Fatalf("internal finding attributes leaked: %#v", first)
+	}
+	if _, exists := first["relation_attributes_json_internal"]; exists {
+		t.Fatalf("internal relation attributes leaked: %#v", first)
 	}
 }
 

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -3,6 +3,7 @@ package graphagent
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -300,6 +301,49 @@ func TestServicePostProcessesTopRiskFindingRows(t *testing.T) {
 	}
 	if _, exists := first["relation_attributes_json_internal"]; exists {
 		t.Fatalf("internal relation attributes leaked: %#v", first)
+	}
+}
+
+func TestServiceRefusesSaturatedPostProcessingCandidateWindow(t *testing.T) {
+	rows := make([]ports.CypherRow, 0, postProcessingCandidateRowLimit)
+	for i := 0; i < postProcessingCandidateRowLimit; i++ {
+		rows = append(rows, ports.CypherRow{Values: map[string]any{
+			"finding_urn":                      "urn:cerebro:writer:finding:" + strconv.Itoa(i),
+			"source_id":                        "github",
+			"finding_attributes_json_internal": `{"source_family":"github"}`,
+		}})
+	}
+	store := &askStore{rows: rows}
+	llm := &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Rationale: "Counting findings by source family.",
+			Plan:      &AskQueryPlan{Intent: IntentAggregateFindingsBySource, Limit: 10},
+		},
+	}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "top finding sources",
+	}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventProgress, EventCypher, EventProgress, EventSummary, EventDone})
+	if len(store.requests) != 1 || store.requests[0].RowLimit != postProcessingCandidateRowLimit {
+		t.Fatalf("store requests = %#v, want candidate row limit", store.requests)
+	}
+	summaryEvent := events[6].Data.(SummaryEvent)
+	if !strings.Contains(summaryEvent.Markdown, "more graph rows than can be safely post-processed") {
+		t.Fatalf("summary = %q, want saturated candidate refusal", summaryEvent.Markdown)
+	}
+	done := events[7].Data.(DoneEvent)
+	if !done.CypherRefused {
+		t.Fatalf("done.CypherRefused = false, want true")
 	}
 }
 

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -259,67 +259,25 @@ func renderDeterministicPlan(plan AskQueryPlan, maxRows int) (string, bool) {
 	limit := boundedLimit(plan.Limit, maxRows)
 	switch plan.Intent {
 	case IntentAggregateFindingsBySource:
-		if limit > 10 {
-			limit = 10
-		}
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'has_finding'}]->(f:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = '' OR resource.urn = $scope_urn OR f.urn = $scope_urn
-WITH DISTINCT f,
-     coalesce(
-       %s,
-       f.source_id,
-       'Unknown'
-     ) AS source_family
-RETURN source_family, count(DISTINCT f) AS finding_count
-ORDER BY finding_count DESC, source_family
-LIMIT %d`, cypherJSONStringAttributes("f.attributes_json", "source_family", "sourceFamily", "source_system"), limit), true
+WITH DISTINCT f
+RETURN f.urn AS finding_urn,
+       f.source_id AS source_id,
+       coalesce(f.attributes_json, '') AS finding_attributes_json_internal
+ORDER BY finding_urn
+LIMIT %d`, maxRows), true
 	case IntentTopRiskFindings:
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = '' OR resource.urn = $scope_urn OR finding.urn = $scope_urn
-WITH resource, r, finding,
-     coalesce(
-       %s,
-       0
-     ) AS risk_score,
-     coalesce(
-       %s,
-       ''
-     ) AS severity
-WITH resource, finding, risk_score, severity,
-     CASE toUpper(severity)
-       WHEN 'CRITICAL' THEN 4
-       WHEN 'HIGH' THEN 3
-       WHEN 'MEDIUM' THEN 2
-       WHEN 'LOW' THEN 1
-       ELSE 0
-     END AS severity_rank
-WITH finding,
-     collect(DISTINCT resource.urn) AS resource_urns,
-     collect(DISTINCT coalesce(resource.label, resource.urn)) AS resource_labels,
-     max(risk_score) AS risk_score,
-     max(severity_rank) AS severity_rank
-WITH finding, resource_urns, resource_labels, risk_score, severity_rank,
-     CASE severity_rank
-       WHEN 4 THEN 'CRITICAL'
-       WHEN 3 THEN 'HIGH'
-       WHEN 2 THEN 'MEDIUM'
-       WHEN 1 THEN 'LOW'
-       ELSE ''
-     END AS severity
 RETURN finding.urn AS finding_urn,
        coalesce(finding.label, finding.urn) AS finding_label,
-       resource_urns,
-       resource_labels,
-       risk_score,
-       severity
-ORDER BY risk_score DESC, severity_rank DESC, finding_urn
-LIMIT %d`, strings.Join([]string{
-			cypherJSONIntegerAttribute("r.attributes_json", "risk_score"),
-			cypherJSONIntegerAttribute("finding.attributes_json", "risk_score"),
-		}, ",\n       "), strings.Join([]string{
-			cypherJSONStringAttributes("r.attributes_json", "effective_severity", "severity"),
-			cypherJSONStringAttributes("finding.attributes_json", "effective_severity", "severity"),
-		}, ",\n       "), limit), true
+       resource.urn AS resource_urn,
+       coalesce(resource.label, resource.urn) AS resource_label,
+       coalesce(r.attributes_json, '') AS relation_attributes_json_internal,
+       coalesce(finding.attributes_json, '') AS finding_attributes_json_internal
+ORDER BY finding_urn, resource_urn
+LIMIT %d`, maxRows), true
 	case IntentExplainFinding:
 		return fmt.Sprintf(`MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = ''

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -14,6 +14,8 @@ const (
 	IntentExplainFinding            = "explain_finding"
 	IntentIdentityBridge            = "identity_bridge"
 	IntentConnectorHealth           = "connector_health"
+
+	postProcessingCandidateRowLimit = 5000
 )
 
 type AskQueryPlan struct {
@@ -266,7 +268,7 @@ RETURN f.urn AS finding_urn,
        f.source_id AS source_id,
        coalesce(f.attributes_json, '') AS finding_attributes_json_internal
 ORDER BY finding_urn
-LIMIT %d`, maxRows), true
+LIMIT %d`, postProcessingCandidateRowLimit), true
 	case IntentTopRiskFindings:
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = '' OR resource.urn = $scope_urn OR finding.urn = $scope_urn
@@ -277,7 +279,7 @@ RETURN finding.urn AS finding_urn,
        coalesce(r.attributes_json, '') AS relation_attributes_json_internal,
        coalesce(finding.attributes_json, '') AS finding_attributes_json_internal
 ORDER BY finding_urn, resource_urn
-LIMIT %d`, maxRows), true
+LIMIT %d`, postProcessingCandidateRowLimit), true
 	case IntentExplainFinding:
 		return fmt.Sprintf(`MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = ''

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
 )
 
 const (
@@ -15,7 +17,7 @@ const (
 	IntentIdentityBridge            = "identity_bridge"
 	IntentConnectorHealth           = "connector_health"
 
-	postProcessingCandidateRowLimit = 5000
+	postProcessingCandidateRowLimit = ports.MaxCypherQueryRows
 )
 
 type AskQueryPlan struct {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -134,7 +134,7 @@ RETURN apoc.convert.fromJsonMap(f.attributes_json).source_family AS source_famil
 	if strings.Contains(result.Cypher, "apoc.") || strings.Contains(result.Cypher, "HAS_SOURCE") || strings.Contains(result.Cypher, "'Finding'") {
 		t.Fatalf("converted cypher is not canonical:\n%s", result.Cypher)
 	}
-	if !strings.Contains(result.Cypher, "f.source_id AS source_id") || !strings.Contains(result.Cypher, "finding_attributes_json_internal") || !strings.Contains(result.Cypher, "LIMIT 5000") {
+	if !strings.Contains(result.Cypher, "f.source_id AS source_id") || !strings.Contains(result.Cypher, "finding_attributes_json_internal") || !strings.Contains(result.Cypher, "LIMIT 3000") {
 		t.Fatalf("converted cypher missing candidate source fields/limit:\n%s", result.Cypher)
 	}
 	if !strings.Contains(result.Cypher, "WHERE $scope_urn = '' OR resource.urn = $scope_urn OR f.urn = $scope_urn") {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -134,7 +134,7 @@ RETURN apoc.convert.fromJsonMap(f.attributes_json).source_family AS source_famil
 	if strings.Contains(result.Cypher, "apoc.") || strings.Contains(result.Cypher, "HAS_SOURCE") || strings.Contains(result.Cypher, "'Finding'") {
 		t.Fatalf("converted cypher is not canonical:\n%s", result.Cypher)
 	}
-	if !strings.Contains(result.Cypher, "f.source_id AS source_id") || !strings.Contains(result.Cypher, "finding_attributes_json_internal") || !strings.Contains(result.Cypher, "LIMIT 100") {
+	if !strings.Contains(result.Cypher, "f.source_id AS source_id") || !strings.Contains(result.Cypher, "finding_attributes_json_internal") || !strings.Contains(result.Cypher, "LIMIT 5000") {
 		t.Fatalf("converted cypher missing candidate source fields/limit:\n%s", result.Cypher)
 	}
 	if !strings.Contains(result.Cypher, "WHERE $scope_urn = '' OR resource.urn = $scope_urn OR f.urn = $scope_urn") {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -134,16 +134,14 @@ RETURN apoc.convert.fromJsonMap(f.attributes_json).source_family AS source_famil
 	if strings.Contains(result.Cypher, "apoc.") || strings.Contains(result.Cypher, "HAS_SOURCE") || strings.Contains(result.Cypher, "'Finding'") {
 		t.Fatalf("converted cypher is not canonical:\n%s", result.Cypher)
 	}
-	if !strings.Contains(result.Cypher, "f.source_id") || !strings.Contains(result.Cypher, "LIMIT 10") {
-		t.Fatalf("converted cypher missing source_id fallback/limit:\n%s", result.Cypher)
+	if !strings.Contains(result.Cypher, "f.source_id AS source_id") || !strings.Contains(result.Cypher, "finding_attributes_json_internal") || !strings.Contains(result.Cypher, "LIMIT 100") {
+		t.Fatalf("converted cypher missing candidate source fields/limit:\n%s", result.Cypher)
 	}
 	if !strings.Contains(result.Cypher, "WHERE $scope_urn = '' OR resource.urn = $scope_urn OR f.urn = $scope_urn") {
 		t.Fatalf("converted cypher missing scope predicate:\n%s", result.Cypher)
 	}
-	sourceFamilyIndex := strings.Index(result.Cypher, `"source_family":"`)
-	sourceIDIndex := strings.Index(result.Cypher, "f.source_id")
-	if sourceFamilyIndex < 0 || sourceIDIndex < 0 || sourceFamilyIndex > sourceIDIndex {
-		t.Fatalf("converted cypher should prefer source_family before source_id:\n%s", result.Cypher)
+	if strings.Contains(result.Cypher, "split(split") || strings.Contains(result.Cypher, "count(DISTINCT f)") {
+		t.Fatalf("converted cypher should leave JSON parsing and aggregation to Go:\n%s", result.Cypher)
 	}
 	if len(result.Diagnostics) == 0 {
 		t.Fatalf("expected conversion diagnostics")
@@ -181,19 +179,18 @@ func TestConvertDraftToQueryScopesTopRiskAndReturnsOnlyScalarFields(t *testing.T
 	}
 	for _, want := range []string{
 		"WHERE $scope_urn = '' OR resource.urn = $scope_urn OR finding.urn = $scope_urn",
-		"CASE toUpper(severity)",
-		"WHEN 'CRITICAL' THEN 4",
-		"collect(DISTINCT resource.urn) AS resource_urns",
-		"max(risk_score) AS risk_score",
-		"ORDER BY risk_score DESC, severity_rank DESC, finding_urn",
+		"resource.urn AS resource_urn",
+		"coalesce(r.attributes_json, '') AS relation_attributes_json_internal",
+		"coalesce(finding.attributes_json, '') AS finding_attributes_json_internal",
+		"ORDER BY finding_urn, resource_urn",
 	} {
 		if !strings.Contains(result.Cypher, want) {
 			t.Fatalf("converted cypher missing %q:\n%s", want, result.Cypher)
 		}
 	}
-	for _, forbidden := range []string{"finding_attributes_json", "relation_attributes_json", " AS attributes_json"} {
+	for _, forbidden := range []string{"split(split", "CASE toUpper", "max(risk_score)", " AS attributes_json"} {
 		if strings.Contains(result.Cypher, forbidden) {
-			t.Fatalf("converted cypher returns raw attributes %q:\n%s", forbidden, result.Cypher)
+			t.Fatalf("converted cypher still performs JSON ranking/unsafe attribute return %q:\n%s", forbidden, result.Cypher)
 		}
 	}
 }

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -171,7 +171,7 @@ func TestProductionBodyReadsAreBounded(t *testing.T) {
 			if boundedReadAllContext(lines, i) {
 				continue
 			}
-			t.Fatalf("%s uses io.ReadAll without a nearby io.LimitReader or shared limited reader", rel)
+			t.Fatalf("%s:%d uses io.ReadAll without a nearby explicit io.LimitReader", rel, i+1)
 		}
 		return nil
 	}); err != nil {
@@ -188,14 +188,13 @@ func boundedReadAllContext(lines []string, index int) bool {
 	if end >= len(lines) {
 		end = len(lines) - 1
 	}
-	context := strings.Join(lines[start:end+1], "\n")
-	for _, marker := range []string{
-		"io.LimitReader(",
-		"sourcehttp.ReadLimitedBody(",
-		"sourcehttp.ReadLimitedBodyWithLimit(",
-		"readLimitedVulnDBFeed(",
-	} {
-		if strings.Contains(context, marker) {
+	readLine := strings.TrimSpace(lines[index])
+	if strings.Contains(readLine, "io.ReadAll(io.LimitReader(") {
+		return true
+	}
+	for _, line := range lines[start : end+1] {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, ":= io.LimitReader(") || strings.Contains(trimmed, "= io.LimitReader(") {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- Move deterministic Ask source aggregation and top-risk ranking off Cypher string parsing and into bounded Go post-processing.
- Add regression coverage for pretty JSON, escaped strings, numeric risk scores, missing metadata, and scoped top-risk queries.
- Update the security regression harness and tighten bounded body-read archtest diagnostics.

## Test plan
- go test ./internal/graphagent ./tools/archtests
- make verify


Made with [Cursor](https://cursor.com)