### PR TITLE
Add Ask answer validation telemetry

### DIFF
--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -160,9 +160,12 @@ type askResultTelemetry struct {
 	validatorWarningsCount int
 	rowCount               int
 	citationCount          int
+	citationWarningsCount  int
+	unsupportedQueryCode   string
 	traceID                string
 	cypherRefused          bool
 	terminalEvent          string
+	timings                graphagent.StageTimings
 }
 
 func (e *askWideEvent) observe(event graphagent.Event) {
@@ -182,10 +185,17 @@ func (e *askWideEvent) observe(event graphagent.Event) {
 		e.result.rowCount = len(data.Rows)
 	case graphagent.SummaryEvent:
 		e.result.citationCount = len(data.Citations)
+		if data.CitationValidation != nil {
+			e.result.citationWarningsCount = len(data.CitationValidation.Warnings)
+		}
+		if data.UnsupportedQuery != nil {
+			e.result.unsupportedQueryCode = data.UnsupportedQuery.Code
+		}
 	case graphagent.DoneEvent:
 		e.result.traceID = data.TraceID
 		e.result.cypherRefused = data.CypherRefused
 		e.result.terminalEvent = graphagent.EventDone
+		e.result.timings = data.Timings
 	case graphagent.ErrorEvent:
 		e.result.terminalEvent = graphagent.EventError
 		if e.result.validatorCode == "" {
@@ -241,9 +251,19 @@ func (e *askWideEvent) finish(r *http.Request, w http.ResponseWriter, started ti
 		WithField(telemetry.Field{Key: "validator.warnings_count", Value: e.result.validatorWarningsCount}).
 		WithField(telemetry.Field{Key: "cypher_refused", Value: e.result.cypherRefused}).
 		WithField(telemetry.Field{Key: "row_count", Value: e.result.rowCount}).
-		WithField(telemetry.Field{Key: "citation_count", Value: e.result.citationCount})
+		WithField(telemetry.Field{Key: "citation_count", Value: e.result.citationCount}).
+		WithField(telemetry.Field{Key: "citation_validation.warnings_count", Value: e.result.citationWarningsCount}).
+		WithField(telemetry.Field{Key: "stage.draft_ms", Value: e.result.timings.DraftMS}).
+		WithField(telemetry.Field{Key: "stage.conversion_ms", Value: e.result.timings.ConversionMS}).
+		WithField(telemetry.Field{Key: "stage.validate_ms", Value: e.result.timings.ValidateMS}).
+		WithField(telemetry.Field{Key: "stage.execute_ms", Value: e.result.timings.ExecuteMS}).
+		WithField(telemetry.Field{Key: "stage.summarize_ms", Value: e.result.timings.SummarizeMS}).
+		WithField(telemetry.Field{Key: "stage.citation_validation_ms", Value: e.result.timings.CitationValidationMS})
 	if e.result.validatorCode != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "validator.code", Value: e.result.validatorCode})
+	}
+	if e.result.unsupportedQueryCode != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "unsupported_query.code", Value: e.result.unsupportedQueryCode})
 	}
 	if e.failureStage != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "failure_stage", Value: e.failureStage})

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -77,7 +77,7 @@ func TestGRCAskTelemetryIncludesQueryPlanDiagnostics(t *testing.T) {
 		GraphStore: &stubGraphStore{},
 		GraphAgentLLM: &graphagent.StubLLMClient{DraftResponse: &graphagent.DraftResponse{
 			Rationale: "Planning filtered high-risk findings.",
-			Plan:      &graphagent.AskQueryPlan{Intent: graphagent.IntentTopRiskFindings, Filters: map[string]string{"severity": "HIGH"}},
+			Plan:      &graphagent.AskQueryPlan{Intent: graphagent.IntentTopRiskFindings, Filters: map[string]string{"owner": "security"}},
 		}},
 	}, nil)
 	server := httptest.NewServer(app.Handler())
@@ -85,7 +85,7 @@ func TestGRCAskTelemetryIncludesQueryPlanDiagnostics(t *testing.T) {
 
 	var events []sseRecord
 	stderr := captureBootstrapStderr(t, func() {
-		resp, err := server.Client().Post(server.URL+"/grc/ask", "application/json", strings.NewReader(`{"tenant_id":"example","question":"show HIGH risk findings"}`))
+		resp, err := server.Client().Post(server.URL+"/grc/ask", "application/json", strings.NewReader(`{"tenant_id":"example","question":"show security-owned risk findings"}`))
 		if err != nil {
 			t.Fatalf("POST /grc/ask error = %v", err)
 		}

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -99,26 +99,33 @@ func TestGRCAskTelemetryIncludesQueryPlanDiagnostics(t *testing.T) {
 
 	payload := decodeBootstrapTelemetryPayload(t, stderr)
 	for key, want := range map[string]any{
-		"name":                         "cerebro.grc.ask",
-		"operation":                    "grc.ask",
-		"outcome":                      "success",
-		"status":                       float64(http.StatusOK),
-		"tenant_id":                    "example",
-		"sse_events":                   float64(6),
-		"query_plan.intent":            graphagent.IntentTopRiskFindings,
-		"query_plan.source":            "conversion_refusal",
-		"query_plan.deterministic":     false,
-		"query_plan.corrected":         false,
-		"query_plan.diagnostics_count": float64(1),
-		"query_plan.diagnostic_codes":  "query_plan_conversion_failed",
-		"terminal_event":               "done",
-		"cypher_refused":               true,
-		"validator.ok":                 false,
-		"row_count":                    float64(0),
-		"citation_count":               float64(0),
+		"name":                               "cerebro.grc.ask",
+		"operation":                          "grc.ask",
+		"outcome":                            "success",
+		"status":                             float64(http.StatusOK),
+		"tenant_id":                          "example",
+		"sse_events":                         float64(6),
+		"query_plan.intent":                  graphagent.IntentTopRiskFindings,
+		"query_plan.source":                  "conversion_refusal",
+		"query_plan.deterministic":           false,
+		"query_plan.corrected":               false,
+		"query_plan.diagnostics_count":       float64(1),
+		"query_plan.diagnostic_codes":        "query_plan_conversion_failed",
+		"terminal_event":                     "done",
+		"cypher_refused":                     true,
+		"validator.ok":                       false,
+		"row_count":                          float64(0),
+		"citation_count":                     float64(0),
+		"citation_validation.warnings_count": float64(0),
+		"unsupported_query.code":             "query_plan_conversion_failed",
 	} {
 		if got := payload[key]; got != want {
 			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	for _, key := range []string{"stage.draft_ms", "stage.conversion_ms"} {
+		if _, ok := payload[key].(float64); !ok {
+			t.Fatalf("telemetry %s = %#v, want numeric stage timing; payload=%#v", key, payload[key], payload)
 		}
 	}
 	if traceID, ok := payload["ask_trace_id"].(string); !ok || traceID == "" {

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -20,6 +21,8 @@ var (
 )
 
 const maxInternalAttributeValueBytes = 4096
+
+var summaryURNPattern = regexp.MustCompile(`urn:cerebro:[A-Za-z0-9_:@./#%+-]+`)
 
 type AskRequest struct {
 	TenantID string           `json:"tenant_id"`
@@ -56,6 +59,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		return ErrRuntimeUnavailable
 	}
 	started := time.Now()
+	var timings StageTimings
 	model := normalizeModel(request.Model)
 	history := normalizeHistory(request.History)
 	params := askParams(request)
@@ -64,6 +68,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	if err := emitProgress(emit, started, "drafting_query", "Drafting a read-only graph query."); err != nil {
 		return err
 	}
+	draftStarted := time.Now()
 	draft, err := s.llm.DraftCypher(ctx, DraftRequest{
 		TenantID:  strings.TrimSpace(request.TenantID),
 		Question:  strings.TrimSpace(request.Question),
@@ -77,6 +82,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	if err != nil {
 		return fmt.Errorf("%w: draft cypher: %w", ErrRuntimeUnavailable, err)
 	}
+	timings.DraftMS = time.Since(draftStarted).Milliseconds()
 	if draft == nil {
 		return fmt.Errorf("%w: LLM returned no draft", ErrRuntimeUnavailable)
 	}
@@ -88,28 +94,32 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		return err
 	}
 
+	conversionStarted := time.Now()
 	conversion := convertDraftToQuery(request, draft, defaultMaxRows)
+	timings.ConversionMS = time.Since(conversionStarted).Milliseconds()
 	cypher := strings.TrimSpace(conversion.Cypher)
 	if err := emitQueryPlan(emit, conversion); err != nil {
 		return err
 	}
 	if cypher == "" {
 		reason := firstNonEmpty(draft.Refusal, conversion.Refusal, "LLM refused to draft Cypher")
-		return emitRefusal(emit, traceID, started, cypher, reason)
+		return emitRefusal(emit, traceID, started, cypher, reason, timings)
 	}
 	if err := emitProgress(emit, started, "validating_query", "Validating generated Cypher against read-only guardrails."); err != nil {
 		return err
 	}
+	validateStarted := time.Now()
 	validation, rowLimit, err := s.validator.validate(ctx, cypher, params)
 	if err != nil {
 		return err
 	}
+	timings.ValidateMS = time.Since(validateStarted).Milliseconds()
 	validation.Warnings = append(validation.Warnings, conversionWarnings(conversion.Diagnostics)...)
 	if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: cypher, Validator: validation}}); err != nil {
 		return err
 	}
 	if !validation.OK {
-		return emitRefusal(emit, traceID, started, cypher, validation.Reason)
+		return emitRefusal(emit, traceID, started, cypher, validation.Reason, timings)
 	}
 
 	if err := emitProgress(emit, started, "executing_query", "Executing the validated graph query."); err != nil {
@@ -124,12 +134,13 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	if err != nil {
 		return fmt.Errorf("%w: execute cypher: %w", ErrRuntimeUnavailable, err)
 	}
+	timings.ExecuteMS = time.Since(execStarted).Milliseconds()
 	rowMaps := cypherRowsToMaps(rows)
 	sanitizeInternalRowFields(rowMaps)
 	rowsEvent := RowsEvent{
 		Rows:   rowMaps,
 		Graph:  scopedNeighborhood(ctx, s.store, request.ScopeURN),
-		ExecMS: time.Since(execStarted).Milliseconds(),
+		ExecMS: timings.ExecuteMS,
 	}
 	if err := emit(Event{Name: EventRows, Data: rowsEvent}); err != nil {
 		return err
@@ -138,6 +149,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	if err := emitProgress(emit, started, "summarizing", "Summarizing graph rows into a user-facing answer."); err != nil {
 		return err
 	}
+	summarizeStarted := time.Now()
 	summary, err := s.llm.Summarize(ctx, SummarizeRequest{
 		TenantID: strings.TrimSpace(request.TenantID),
 		Question: strings.TrimSpace(request.Question),
@@ -150,14 +162,19 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	if err != nil {
 		return fmt.Errorf("%w: summarize graph rows: %w", ErrRuntimeUnavailable, err)
 	}
+	timings.SummarizeMS = time.Since(summarizeStarted).Milliseconds()
 	if strings.TrimSpace(summary) == "" {
 		summary = fallbackSummary(rowMaps)
 	}
 	summary = strings.TrimSpace(summary)
-	if err := emit(Event{Name: EventSummary, Data: SummaryEvent{Markdown: summary, Citations: citationsFor(summary, rowMaps)}}); err != nil {
+	citationStarted := time.Now()
+	citations := citationsFor(summary, rowMaps)
+	citationValidation := validateSummaryCitations(summary, rowMaps, citations)
+	timings.CitationValidationMS = time.Since(citationStarted).Milliseconds()
+	if err := emit(Event{Name: EventSummary, Data: SummaryEvent{Markdown: summary, Citations: citations, CitationValidation: &citationValidation}}); err != nil {
 		return err
 	}
-	return emit(Event{Name: EventDone, Data: DoneEvent{TraceID: traceID, TotalMS: time.Since(started).Milliseconds()}})
+	return emit(Event{Name: EventDone, Data: DoneEvent{TraceID: traceID, TotalMS: time.Since(started).Milliseconds(), Timings: timings}})
 }
 
 func emitProgress(emit Emitter, started time.Time, stage string, message string) error {
@@ -209,17 +226,18 @@ func conversionWarnings(diagnostics []ConversionDiagnostic) []string {
 	return warnings
 }
 
-func emitRefusal(emit Emitter, traceID string, started time.Time, cypher string, reason string) error {
+func emitRefusal(emit Emitter, traceID string, started time.Time, cypher string, reason string, timings StageTimings) error {
 	reason = firstNonEmpty(reason, "Read-only Cypher validator refused the draft.")
 	if cypher == "" {
 		if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: "", Validator: ValidatorResult{OK: false, Reason: reason}}}); err != nil {
 			return err
 		}
 	}
-	if err := emit(Event{Name: EventSummary, Data: SummaryEvent{Markdown: reason}}); err != nil {
+	rescue := unsupportedQuery(reason, traceID)
+	if err := emit(Event{Name: EventSummary, Data: SummaryEvent{Markdown: reason, UnsupportedQuery: &rescue}}); err != nil {
 		return err
 	}
-	return emit(Event{Name: EventDone, Data: DoneEvent{TraceID: traceID, TotalMS: time.Since(started).Milliseconds(), CypherRefused: true}})
+	return emit(Event{Name: EventDone, Data: DoneEvent{TraceID: traceID, TotalMS: time.Since(started).Milliseconds(), CypherRefused: true, Timings: timings}})
 }
 
 func cypherRowsToMaps(rows []ports.CypherRow) []map[string]any {
@@ -331,24 +349,130 @@ func scopedNeighborhood(ctx context.Context, store ports.GraphQueryStore, scopeU
 func citationsFor(summary string, rows []map[string]any) []Citation {
 	seen := map[string]struct{}{}
 	var citations []Citation
-	for _, row := range rows {
-		for _, value := range row {
-			urn, ok := value.(string)
-			if !ok || !strings.HasPrefix(urn, "urn:cerebro:") {
-				continue
-			}
-			if _, exists := seen[urn]; exists {
-				continue
-			}
-			start := strings.Index(summary, urn)
-			if start < 0 {
-				continue
-			}
-			seen[urn] = struct{}{}
-			citations = append(citations, Citation{URN: urn, Span: [2]int{start, start + len(urn)}})
+	for _, urn := range collectRowURNs(rows) {
+		if _, exists := seen[urn]; exists {
+			continue
 		}
+		start := strings.Index(summary, urn)
+		if start < 0 {
+			continue
+		}
+		seen[urn] = struct{}{}
+		citations = append(citations, Citation{URN: urn, Span: [2]int{start, start + len(urn)}})
 	}
 	return citations
+}
+
+func validateSummaryCitations(summary string, rows []map[string]any, citations []Citation) CitationValidation {
+	rowURNs := map[string]struct{}{}
+	for _, urn := range collectRowURNs(rows) {
+		rowURNs[urn] = struct{}{}
+	}
+	referencedURNs := urnsFromSummary(summary)
+	var warnings []string
+	for _, citation := range citations {
+		if _, ok := rowURNs[citation.URN]; !ok {
+			warnings = append(warnings, "citation_not_row_backed:"+citation.URN)
+		}
+		if citation.Span[0] < 0 || citation.Span[1] <= citation.Span[0] || citation.Span[1] > len(summary) {
+			warnings = append(warnings, "citation_invalid_span:"+citation.URN)
+			continue
+		}
+		if summary[citation.Span[0]:citation.Span[1]] != citation.URN {
+			warnings = append(warnings, "citation_span_mismatch:"+citation.URN)
+		}
+	}
+	for _, urn := range referencedURNs {
+		if _, ok := rowURNs[urn]; !ok {
+			warnings = append(warnings, "summary_urn_not_row_backed:"+urn)
+		}
+	}
+	sort.Strings(warnings)
+	return CitationValidation{
+		OK:                 len(warnings) == 0,
+		Warnings:           warnings,
+		RowURNCount:        len(rowURNs),
+		ReferencedURNCount: len(referencedURNs),
+	}
+}
+
+func collectRowURNs(rows []map[string]any) []string {
+	seen := map[string]struct{}{}
+	var urns []string
+	var visit func(any)
+	visit = func(value any) {
+		switch typed := value.(type) {
+		case string:
+			if strings.HasPrefix(typed, "urn:cerebro:") {
+				if _, exists := seen[typed]; !exists {
+					seen[typed] = struct{}{}
+					urns = append(urns, typed)
+				}
+			}
+		case []string:
+			for _, item := range typed {
+				visit(item)
+			}
+		case []any:
+			for _, item := range typed {
+				visit(item)
+			}
+		case map[string]any:
+			for _, item := range typed {
+				visit(item)
+			}
+		}
+	}
+	for _, row := range rows {
+		visit(row)
+	}
+	sort.Strings(urns)
+	return urns
+}
+
+func urnsFromSummary(summary string) []string {
+	matches := summaryURNPattern.FindAllString(summary, -1)
+	seen := map[string]struct{}{}
+	var urns []string
+	for _, match := range matches {
+		urn := strings.TrimRight(match, ".,;:!?")
+		if _, exists := seen[urn]; exists {
+			continue
+		}
+		seen[urn] = struct{}{}
+		urns = append(urns, urn)
+	}
+	sort.Strings(urns)
+	return urns
+}
+
+func unsupportedQuery(reason string, traceID string) UnsupportedQuery {
+	return UnsupportedQuery{
+		Code:             unsupportedQueryCode(reason),
+		Reason:           reason,
+		SupportedIntents: []string{IntentTopRiskFindings, IntentAggregateFindingsBySource, IntentExplainFinding, IntentIdentityBridge, IntentConnectorHealth},
+		SuggestedRewrites: []string{
+			"Summarize open high-risk findings and cite the affected entities.",
+			"Count findings by source family.",
+			"Show source health and freshness for security integrations.",
+			"Explain the evidence for a specific finding URN.",
+		},
+		TraceID: traceID,
+	}
+}
+
+func unsupportedQueryCode(reason string) string {
+	lower := strings.ToLower(reason)
+	switch {
+	case strings.Contains(lower, "could not be converted"):
+		return "query_plan_conversion_failed"
+	case strings.Contains(lower, "refused"):
+		return "llm_refusal"
+	case strings.Contains(lower, "read-only") || strings.Contains(lower, "write"):
+		return "validator_refusal"
+	default:
+		return "unsupported_query"
+	}
 }
 
 func fallbackSummary(rows []map[string]any) string {

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -120,12 +120,12 @@ func TestServiceRefusesUnsupportedPlanOnlyDraftAsConversionFailure(t *testing.T)
 	store := &askStore{}
 	llm := &StubLLMClient{DraftResponse: &DraftResponse{
 		Rationale: "Planning filtered high-risk findings.",
-		Plan:      &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"severity": "HIGH"}},
+		Plan:      &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"owner": "security"}},
 	}}
 	service := NewService(store, llm, ValidatorOptions{})
 
 	var events []Event
-	err := service.Stream(context.Background(), AskRequest{TenantID: "example", Question: "show HIGH risk findings"}, func(event Event) error {
+	err := service.Stream(context.Background(), AskRequest{TenantID: "example", Question: "show security-owned risk findings"}, func(event Event) error {
 		events = append(events, event)
 		return nil
 	})

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -70,6 +70,13 @@ LIMIT 25`,
 	if len(summaryEvent.Citations) != 1 || summaryEvent.Citations[0].URN != "urn:cerebro:example:asset:alpha" {
 		t.Fatalf("citations = %#v", summaryEvent.Citations)
 	}
+	if summaryEvent.CitationValidation == nil || !summaryEvent.CitationValidation.OK {
+		t.Fatalf("citation validation = %#v, want ok", summaryEvent.CitationValidation)
+	}
+	doneEvent := events[9].Data.(DoneEvent)
+	if doneEvent.Timings.DraftMS < 0 || doneEvent.Timings.SummarizeMS < 0 || doneEvent.Timings.CitationValidationMS < 0 {
+		t.Fatalf("done timings = %#v, want non-negative timings", doneEvent.Timings)
+	}
 	if len(store.requests) != 1 || store.requests[0].Params["tenant_id"] != "example" {
 		t.Fatalf("store requests = %#v", store.requests)
 	}
@@ -95,6 +102,10 @@ func TestServiceRefusesValidatorRejectedCypher(t *testing.T) {
 	cypherEvent := events[4].Data.(CypherEvent)
 	if cypherEvent.Validator.OK {
 		t.Fatalf("validator ok = true, want false")
+	}
+	summary := events[5].Data.(SummaryEvent)
+	if summary.UnsupportedQuery == nil || summary.UnsupportedQuery.Code == "" || len(summary.UnsupportedQuery.SuggestedRewrites) == 0 {
+		t.Fatalf("unsupported query rescue = %#v, want structured suggestions", summary.UnsupportedQuery)
 	}
 	done := events[6].Data.(DoneEvent)
 	if !done.CypherRefused {
@@ -133,8 +144,51 @@ func TestServiceRefusesUnsupportedPlanOnlyDraftAsConversionFailure(t *testing.T)
 	if !strings.Contains(cypherEvent.Validator.Reason, "could not be converted") {
 		t.Fatalf("refusal reason = %q, want conversion failure", cypherEvent.Validator.Reason)
 	}
+	summaryEvent := events[4].Data.(SummaryEvent)
+	if summaryEvent.UnsupportedQuery == nil || summaryEvent.UnsupportedQuery.Code != "query_plan_conversion_failed" {
+		t.Fatalf("unsupported query = %#v, want conversion rescue", summaryEvent.UnsupportedQuery)
+	}
 	if len(store.requests) != 0 {
 		t.Fatalf("store executed conversion-refused query: %#v", store.requests)
+	}
+}
+
+func TestServiceFlagsUngroundedSummaryURNs(t *testing.T) {
+	store := &askStore{
+		rows: []ports.CypherRow{{
+			Values: map[string]any{
+				"finding_urn": "urn:cerebro:writer:finding:alpha",
+				"resource_urns": []any{
+					"urn:cerebro:writer:repo:writerinternal/cerebro",
+				},
+			},
+		}},
+	}
+	llm := &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Rationale: "Finding scoped graph rows.",
+			Cypher: `MATCH (e:Entity {tenant_id: $tenant_id})
+RETURN e.urn AS finding_urn
+LIMIT 25`,
+		},
+		Summary: "Review `urn:cerebro:writer:finding:missing` immediately.",
+	}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{TenantID: "writer", Question: "What is risky?"}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	summary := events[8].Data.(SummaryEvent)
+	if summary.CitationValidation == nil || summary.CitationValidation.OK {
+		t.Fatalf("citation validation = %#v, want ungrounded warning", summary.CitationValidation)
+	}
+	if got := strings.Join(summary.CitationValidation.Warnings, ","); !strings.Contains(got, "summary_urn_not_row_backed") {
+		t.Fatalf("warnings = %v, want summary grounding warning", summary.CitationValidation.Warnings)
 	}
 }
 

--- a/internal/graphagent/events.go
+++ b/internal/graphagent/events.go
@@ -65,15 +65,42 @@ type Citation struct {
 	Span [2]int `json:"span"`
 }
 
+type CitationValidation struct {
+	OK                 bool     `json:"ok"`
+	Warnings           []string `json:"warnings,omitempty"`
+	RowURNCount        int      `json:"row_urn_count"`
+	ReferencedURNCount int      `json:"referenced_urn_count"`
+}
+
+type UnsupportedQuery struct {
+	Code              string   `json:"code"`
+	Reason            string   `json:"reason"`
+	SupportedIntents  []string `json:"supported_intents"`
+	SuggestedRewrites []string `json:"suggested_rewrites"`
+	TraceID           string   `json:"trace_id"`
+}
+
 type SummaryEvent struct {
-	Markdown  string     `json:"markdown"`
-	Citations []Citation `json:"citations"`
+	Markdown           string              `json:"markdown"`
+	Citations          []Citation          `json:"citations"`
+	CitationValidation *CitationValidation `json:"citation_validation,omitempty"`
+	UnsupportedQuery   *UnsupportedQuery   `json:"unsupported_query,omitempty"`
+}
+
+type StageTimings struct {
+	DraftMS              int64 `json:"draft_ms,omitempty"`
+	ConversionMS         int64 `json:"conversion_ms,omitempty"`
+	ValidateMS           int64 `json:"validate_ms,omitempty"`
+	ExecuteMS            int64 `json:"execute_ms,omitempty"`
+	SummarizeMS          int64 `json:"summarize_ms,omitempty"`
+	CitationValidationMS int64 `json:"citation_validation_ms,omitempty"`
 }
 
 type DoneEvent struct {
-	TraceID       string `json:"trace_id"`
-	TotalMS       int64  `json:"total_ms"`
-	CypherRefused bool   `json:"cypher_refused"`
+	TraceID       string       `json:"trace_id"`
+	TotalMS       int64        `json:"total_ms"`
+	CypherRefused bool         `json:"cypher_refused"`
+	Timings       StageTimings `json:"timings,omitempty"`
 }
 
 type ErrorEvent struct {

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -274,6 +274,7 @@ RETURN source_family, count(DISTINCT f) AS finding_count
 ORDER BY finding_count DESC, source_family
 LIMIT %d`, cypherJSONStringAttributes("f.attributes_json", "source_family", "sourceFamily", "source_system"), limit), true
 	case IntentTopRiskFindings:
+		filterPredicate := topRiskFilterPredicate(plan.Filters)
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = '' OR resource.urn = $scope_urn OR finding.urn = $scope_urn
 WITH resource, r, finding,
@@ -284,8 +285,12 @@ WITH resource, r, finding,
      coalesce(
        %s,
        ''
-     ) AS severity
-WITH resource, finding, risk_score, severity,
+     ) AS severity,
+     coalesce(
+       %s,
+       ''
+     ) AS status
+WITH resource, finding, risk_score, severity, status,
      CASE toUpper(severity)
        WHEN 'CRITICAL' THEN 4
        WHEN 'HIGH' THEN 3
@@ -293,12 +298,14 @@ WITH resource, finding, risk_score, severity,
        WHEN 'LOW' THEN 1
        ELSE 0
      END AS severity_rank
+%s
 WITH finding,
      collect(DISTINCT resource.urn) AS resource_urns,
      collect(DISTINCT coalesce(resource.label, resource.urn)) AS resource_labels,
      max(risk_score) AS risk_score,
-     max(severity_rank) AS severity_rank
-WITH finding, resource_urns, resource_labels, risk_score, severity_rank,
+     max(severity_rank) AS severity_rank,
+     max(status) AS status
+WITH finding, resource_urns, resource_labels, risk_score, severity_rank, status,
      CASE severity_rank
        WHEN 4 THEN 'CRITICAL'
        WHEN 3 THEN 'HIGH'
@@ -311,7 +318,8 @@ RETURN finding.urn AS finding_urn,
        resource_urns,
        resource_labels,
        risk_score,
-       severity
+       severity,
+       status
 ORDER BY risk_score DESC, severity_rank DESC, finding_urn
 LIMIT %d`, strings.Join([]string{
 			cypherJSONIntegerAttribute("r.attributes_json", "risk_score"),
@@ -319,7 +327,10 @@ LIMIT %d`, strings.Join([]string{
 		}, ",\n       "), strings.Join([]string{
 			cypherJSONStringAttributes("r.attributes_json", "effective_severity", "severity"),
 			cypherJSONStringAttributes("finding.attributes_json", "effective_severity", "severity"),
-		}, ",\n       "), limit), true
+		}, ",\n       "), strings.Join([]string{
+			cypherJSONStringAttributes("r.attributes_json", "status"),
+			cypherJSONStringAttributes("finding.attributes_json", "status"),
+		}, ",\n       "), filterPredicate, limit), true
 	case IntentExplainFinding:
 		return fmt.Sprintf(`MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = ''
@@ -366,13 +377,9 @@ WHERE left.urn < right.urn
   AND NOT right.entity_type STARTS WITH 'identity'
   AND NOT left.entity_type STARTS WITH 'identifier'
   AND NOT right.entity_type STARTS WITH 'identifier'
-  AND coalesce(leftRel.attributes_json, '') CONTAINS '"at":"'
-  AND coalesce(rightRel.attributes_json, '') CONTAINS '"at":"'
 WITH left, right, identity,
-     %s AS left_seen_at,
-     %s AS right_seen_at
-WHERE datetime(left_seen_at) >= datetime() - duration('P90D')
-  AND datetime(right_seen_at) >= datetime() - duration('P90D')
+     coalesce(%s, '') AS left_seen_at,
+     coalesce(%s, '') AS right_seen_at
 RETURN left.urn AS left_urn,
        coalesce(left.label, left.urn) AS left_label,
        left.entity_type AS left_type,
@@ -384,7 +391,7 @@ RETURN left.urn AS left_urn,
        left_seen_at,
        right_seen_at
 ORDER BY identity_label, left_urn, right_urn
-LIMIT %d`, cypherJSONRawStringAttribute("leftRel.attributes_json", "at"), cypherJSONRawStringAttribute("rightRel.attributes_json", "at"), limit), true
+LIMIT %d`, cypherJSONStringAttributes("leftRel.attributes_json", "at"), cypherJSONStringAttributes("rightRel.attributes_json", "at"), limit), true
 	case IntentConnectorHealth:
 		return fmt.Sprintf(`MATCH (source:Entity {tenant_id: $tenant_id, entity_type: 'source'})
 WHERE $scope_urn = '' OR source.urn = $scope_urn
@@ -421,15 +428,63 @@ func cypherJSONQuotedStringToken(key string) string {
 	return fmt.Sprintf(`"%s":"`, key)
 }
 
+func topRiskFilterPredicate(filters map[string]string) string {
+	var predicates []string
+	if severity := planFilterValue(filters, "severity"); severity != "" {
+		predicates = append(predicates, "toUpper(severity) = "+cypherStringLiteral(strings.ToUpper(severity)))
+	}
+	if status := planFilterValue(filters, "status"); status != "" {
+		predicates = append(predicates, "toLower(status) = "+cypherStringLiteral(strings.ToLower(status)))
+	}
+	if resourceType := firstNonEmpty(planFilterValue(filters, "resource_type"), planFilterValue(filters, "entity_type")); resourceType != "" {
+		predicates = append(predicates, resourceTypePredicate(resourceType))
+	}
+	if len(predicates) == 0 {
+		return ""
+	}
+	return "WHERE " + strings.Join(predicates, "\n  AND ")
+}
+
+func resourceTypePredicate(value string) string {
+	canonical := canonicalEntityType(value)
+	switch canonical {
+	case "github.code.repository", "github.repo":
+		return "(resource.entity_type IN ['github.code.repository', 'github.repo'] OR resource.urn CONTAINS ':repo:' OR resource.urn CONTAINS ':github_repo:')"
+	default:
+		return "resource.entity_type = " + cypherStringLiteral(canonical)
+	}
+}
+
+func planFilterValue(filters map[string]string, key string) string {
+	for filterKey, value := range filters {
+		if strings.EqualFold(filterKey, key) {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func cypherStringLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "\\'") + "'"
+}
+
 func hasUnsupportedDeterministicModifiers(plan AskQueryPlan) bool {
-	if len(plan.Filters) > 0 {
+	groupBy := strings.ToLower(strings.TrimSpace(plan.GroupBy))
+	if groupBy != "" && (plan.Intent != IntentAggregateFindingsBySource || groupBy != "source_family") {
 		return true
 	}
-	groupBy := strings.ToLower(strings.TrimSpace(plan.GroupBy))
-	if groupBy == "" {
-		return false
+	for key := range plan.Filters {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		switch plan.Intent {
+		case IntentTopRiskFindings:
+			if normalized != "severity" && normalized != "status" && normalized != "resource_type" && normalized != "entity_type" {
+				return true
+			}
+		default:
+			return true
+		}
 	}
-	return plan.Intent != IntentAggregateFindingsBySource || groupBy != "source_family"
+	return false
 }
 
 func ontologyDiagnostics(cypher string) []ConversionDiagnostic {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -216,7 +216,7 @@ func TestConvertDraftToQueryScopesTopRiskAndReturnsOnlyScalarFields(t *testing.T
 	}
 }
 
-func TestConvertDraftToQuerySkipsTemplateForUnsupportedFilters(t *testing.T) {
+func TestConvertDraftToQueryRendersSupportedTopRiskFilters(t *testing.T) {
 	draftCypher := `MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 RETURN finding.urn AS finding_urn
 LIMIT 25`
@@ -224,15 +224,17 @@ LIMIT 25`
 		TenantID: "writer",
 		Question: "Show high findings",
 	}, &DraftResponse{
-		Plan:   &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"severity": "HIGH"}},
+		Plan:   &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"severity": "HIGH", "status": "open", "resource_type": "repository"}},
 		Cypher: draftCypher,
 	}, 100)
 
-	if result.Deterministic || result.Source != "llm" {
-		t.Fatalf("conversion result = %#v, want LLM fallback for filtered plan", result)
+	if !result.Deterministic || result.Source != "deterministic_template" {
+		t.Fatalf("conversion result = %#v, want deterministic filtered template", result)
 	}
-	if result.Cypher != draftCypher {
-		t.Fatalf("cypher = %q, want unmodified draft", result.Cypher)
+	for _, want := range []string{"toUpper(severity) = 'HIGH'", "toLower(status) = 'open'", "resource.entity_type IN ['github.code.repository', 'github.repo']", "status"} {
+		if !strings.Contains(result.Cypher, want) {
+			t.Fatalf("filtered cypher missing %q:\n%s", want, result.Cypher)
+		}
 	}
 }
 
@@ -241,7 +243,7 @@ func TestConvertDraftToQueryRefusesUnsupportedPlanOnlyDraft(t *testing.T) {
 		TenantID: "writer",
 		Question: "Show high risk findings",
 	}, &DraftResponse{
-		Plan: &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"severity": "HIGH"}},
+		Plan: &AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"owner": "security"}},
 	}, 100)
 
 	if result.Cypher != "" || result.Source != "conversion_refusal" {
@@ -326,7 +328,6 @@ func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
 		"left.entity_type <> right.entity_type",
 		"$scope_urn = '' OR left.urn = $scope_urn OR right.urn = $scope_urn OR identity.urn = $scope_urn",
 		"NOT left.entity_type STARTS WITH 'identifier'",
-		"datetime(left_seen_at) >= datetime() - duration('P90D')",
 		"identity.urn AS identity_urn",
 	} {
 		if !strings.Contains(result.Cypher, want) {
@@ -421,7 +422,7 @@ func TestUnsupportedPlanOnlyMutationsAreRefused(t *testing.T) {
 		name string
 		plan AskQueryPlan
 	}{
-		{name: "unsupported top risk severity filter", plan: AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"severity": "HIGH"}}},
+		{name: "unsupported top risk owner filter", plan: AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"owner": "security"}}},
 		{name: "unsupported source runtime filter", plan: AskQueryPlan{Intent: IntentConnectorHealth, Filters: map[string]string{"entity_type": "runtime"}}},
 		{name: "unsupported identity bridge group", plan: AskQueryPlan{Intent: IntentIdentityBridge, GroupBy: "email"}},
 	} {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -18,6 +18,24 @@ func TestOntologyCanonicalizesAliases(t *testing.T) {
 	}
 }
 
+func TestOntologyAliasesRoundTripToCanonicalValues(t *testing.T) {
+	for _, entity := range canonicalGraphOntology.Entities {
+		for _, alias := range append([]string{entity.Type}, entity.Aliases...) {
+			if got := canonicalEntityType(alias); got != entity.Type {
+				t.Fatalf("canonicalEntityType(%q) = %q, want %q", alias, got, entity.Type)
+			}
+		}
+	}
+	for _, relation := range canonicalGraphOntology.Relations {
+		for _, alias := range append([]string{relation.Relation}, relation.Aliases...) {
+			got, ok := canonicalRelation(alias)
+			if !ok || got != relation.Relation {
+				t.Fatalf("canonicalRelation(%q) = %q, %v; want %q, true", alias, got, ok, relation.Relation)
+			}
+		}
+	}
+}
+
 func TestOntologyPromptUsesProjectedIdentityShape(t *testing.T) {
 	hint := canonicalGraphOntology.PromptHint()
 	for _, want := range []string{
@@ -363,6 +381,62 @@ func TestDeterministicTemplatesUseProjectedGraphContract(t *testing.T) {
 	}
 }
 
+func TestOntologyMutationDiagnosticsCatchNonCanonicalDrafts(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		cypher string
+		want   string
+	}{
+		{
+			name:   "domain finding label",
+			cypher: "MATCH (f:Finding {tenant_id: $tenant_id}) RETURN f LIMIT 10",
+			want:   "non_canonical_entity_label",
+		},
+		{
+			name:   "uppercase relationship alias",
+			cypher: "MATCH (f:Entity)-[:BELONGS_TO_SOURCE]->(s:Entity) RETURN f LIMIT 10",
+			want:   "relation_alias_canonicalized",
+		},
+		{
+			name:   "apoc call",
+			cypher: "MATCH (f:Entity) RETURN apoc.convert.fromJsonMap(f.attributes_json) LIMIT 10",
+			want:   "apoc_not_allowed",
+		},
+		{
+			name:   "connector label",
+			cypher: "MATCH (c:connector {tenant_id: $tenant_id}) RETURN c LIMIT 10",
+			want:   "non_canonical_entity_label",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if !containsDiagnosticCode(ontologyDiagnostics(tt.cypher), tt.want) {
+				t.Fatalf("ontologyDiagnostics(%q) missing %q", tt.cypher, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnsupportedPlanOnlyMutationsAreRefused(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		plan AskQueryPlan
+	}{
+		{name: "unsupported top risk severity filter", plan: AskQueryPlan{Intent: IntentTopRiskFindings, Filters: map[string]string{"severity": "HIGH"}}},
+		{name: "unsupported source runtime filter", plan: AskQueryPlan{Intent: IntentConnectorHealth, Filters: map[string]string{"entity_type": "runtime"}}},
+		{name: "unsupported identity bridge group", plan: AskQueryPlan{Intent: IntentIdentityBridge, GroupBy: "email"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertDraftToQuery(AskRequest{TenantID: "writer", Question: tt.name}, &DraftResponse{Plan: &tt.plan}, 100)
+			if result.Cypher != "" || result.Source != "conversion_refusal" {
+				t.Fatalf("conversion result = %#v, want conversion refusal", result)
+			}
+			if !containsDiagnosticCode(result.Diagnostics, "query_plan_conversion_failed") {
+				t.Fatalf("diagnostics = %#v, want query_plan_conversion_failed", result.Diagnostics)
+			}
+		})
+	}
+}
+
 func TestOntologyDiagnosticsTreatsAPOCVariableAsSafe(t *testing.T) {
 	diagnostics := ontologyDiagnostics(`MATCH (apoc:Entity {tenant_id: $tenant_id})
 RETURN apoc.urn AS urn
@@ -372,6 +446,15 @@ LIMIT 25`)
 			t.Fatalf("ontologyDiagnostics() emitted APOC warning for variable property access: %#v", diagnostics)
 		}
 	}
+}
+
+func containsDiagnosticCode(diagnostics []ConversionDiagnostic, code string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 func TestConvertDraftToQueryInjectsFallbackLimit(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add Ask summary citation validation, structured unsupported-query rescue payloads, and stage timing telemetry.
- Stabilize deterministic query conversion for top-risk filters and identity bridge paths.
- Add focused graphagent/bootstrap coverage for telemetry, rescue UX, citation grounding, and ontology mutation paths.

## Test plan
- go test ./internal/graphagent ./internal/bootstrap


Made with [Cursor](https://cursor.com)