### PR TITLE
Fix Ask review regressions

### DIFF
--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -103,6 +103,9 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		evt.failureStage = "stream"
 		timings, _ := graphagent.ErrorTimings(err)
+		if timings != (graphagent.StageTimings{}) {
+			evt.result.timings = timings
+		}
 		writeErr := graphagent.WriteSSEEvent(w, graphagent.Event{Name: graphagent.EventError, Data: graphagent.ErrorEvent{
 			Code:    "ask_failed",
 			Message: err.Error(),

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -102,15 +102,18 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		evt.failureStage = "stream"
+		timings, _ := graphagent.ErrorTimings(err)
 		writeErr := graphagent.WriteSSEEvent(w, graphagent.Event{Name: graphagent.EventError, Data: graphagent.ErrorEvent{
 			Code:    "ask_failed",
 			Message: err.Error(),
+			Timings: timings,
 		}})
 		if writeErr == nil {
 			eventCount++
 			evt.observe(graphagent.Event{Name: graphagent.EventError, Data: graphagent.ErrorEvent{
 				Code:    "ask_failed",
 				Message: err.Error(),
+				Timings: timings,
 			}})
 			if flusher != nil {
 				flusher.Flush()
@@ -198,6 +201,9 @@ func (e *askWideEvent) observe(event graphagent.Event) {
 		e.result.timings = data.Timings
 	case graphagent.ErrorEvent:
 		e.result.terminalEvent = graphagent.EventError
+		if data.Timings != (graphagent.StageTimings{}) {
+			e.result.timings = data.Timings
+		}
 		if e.result.validatorCode == "" {
 			e.result.validatorCode = data.Code
 		}

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -209,6 +209,35 @@ func TestGRCAskExplainFailureReturnsServiceUnavailable(t *testing.T) {
 	}
 }
 
+func TestGRCAskTelemetryCopiesErrorEventTimings(t *testing.T) {
+	evt := askWideEvent{tenantID: "example", question: "hello", graphStoreOK: true, llmOK: true}
+	evt.observe(graphagent.Event{Name: graphagent.EventError, Data: graphagent.ErrorEvent{
+		Code:    "ask_failed",
+		Message: "explain cypher failed",
+		Timings: graphagent.StageTimings{
+			DraftMS:      11,
+			ConversionMS: 7,
+			ValidateMS:   5,
+		},
+	}})
+
+	req := httptest.NewRequest(http.MethodPost, "/grc/ask", nil)
+	stderr := captureBootstrapStderr(t, func() {
+		evt.finish(req, httptest.NewRecorder(), time.Now(), http.StatusOK, errors.New("explain cypher failed"))
+	})
+	payload := decodeBootstrapTelemetryPayload(t, stderr)
+	for key, want := range map[string]any{
+		"terminal_event":      graphagent.EventError,
+		"stage.draft_ms":      float64(11),
+		"stage.conversion_ms": float64(7),
+		"stage.validate_ms":   float64(5),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+}
+
 type sseRecord struct {
 	Name string
 	Data json.RawMessage

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -83,12 +83,12 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		Schema:    graphAgentSchemaHint,
 		Guardrail: graphAgentGuardrail,
 	})
-	if err != nil {
-		return fmt.Errorf("%w: draft cypher: %w", ErrRuntimeUnavailable, err)
-	}
 	timings.DraftMS = time.Since(draftStarted).Milliseconds()
+	if err != nil {
+		return streamErrorf(timings, "%w: draft cypher: %w", ErrRuntimeUnavailable, err)
+	}
 	if draft == nil {
-		return fmt.Errorf("%w: LLM returned no draft", ErrRuntimeUnavailable)
+		return streamErrorf(timings, "%w: LLM returned no draft", ErrRuntimeUnavailable)
 	}
 	rationale := strings.TrimSpace(draft.Rationale)
 	if rationale == "" {
@@ -107,23 +107,23 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	}
 	if cypher == "" {
 		reason := firstNonEmpty(draft.Refusal, conversion.Refusal, "LLM refused to draft Cypher")
-		return emitRefusal(emit, traceID, started, cypher, reason, timings)
+		return emitRefusal(emit, traceID, started, cypher, reason, refusalCode(draft, conversion, ValidatorResult{}), timings)
 	}
 	if err := emitProgress(emit, started, "validating_query", "Validating generated Cypher against read-only guardrails."); err != nil {
 		return err
 	}
 	validateStarted := time.Now()
 	validation, rowLimit, err := s.validateConversion(ctx, conversion, cypher, params)
-	if err != nil {
-		return err
-	}
 	timings.ValidateMS = time.Since(validateStarted).Milliseconds()
+	if err != nil {
+		return streamErrorf(timings, "%w", err)
+	}
 	validation.Warnings = append(validation.Warnings, conversionWarnings(conversion.Diagnostics)...)
 	if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: cypher, Validator: validation}}); err != nil {
 		return err
 	}
 	if !validation.OK {
-		return emitRefusal(emit, traceID, started, cypher, validation.Reason, timings)
+		return emitRefusal(emit, traceID, started, cypher, validation.Reason, refusalCode(draft, conversion, validation), timings)
 	}
 
 	if err := emitProgress(emit, started, "executing_query", "Executing the validated graph query."); err != nil {
@@ -135,12 +135,12 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		Params:   params,
 		RowLimit: rowLimit,
 	})
-	if err != nil {
-		return fmt.Errorf("%w: execute cypher: %w", ErrRuntimeUnavailable, err)
-	}
 	timings.ExecuteMS = time.Since(execStarted).Milliseconds()
+	if err != nil {
+		return streamErrorf(timings, "%w: execute cypher: %w", ErrRuntimeUnavailable, err)
+	}
 	if postProcessingCandidateLimitHit(conversion.Plan, rows, rowLimit) {
-		return emitRefusal(emit, traceID, started, cypher, "The deterministic Ask query matched more graph rows than can be safely post-processed without risking an incomplete answer. Narrow the scope or ask for a more specific subset.", timings)
+		return emitRefusal(emit, traceID, started, cypher, "The deterministic Ask query matched more graph rows than can be safely post-processed without risking an incomplete answer. Narrow the scope or ask for a more specific subset.", "post_processing_candidate_limit", timings)
 	}
 	rowMaps := cypherRowsToMaps(rows)
 	rowMaps = postProcessAskRows(conversion.Plan, rowMaps)
@@ -167,10 +167,10 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		Rows:     rowMaps,
 		History:  history,
 	})
-	if err != nil {
-		return fmt.Errorf("%w: summarize graph rows: %w", ErrRuntimeUnavailable, err)
-	}
 	timings.SummarizeMS = time.Since(summarizeStarted).Milliseconds()
+	if err != nil {
+		return streamErrorf(timings, "%w: summarize graph rows: %w", ErrRuntimeUnavailable, err)
+	}
 	if strings.TrimSpace(summary) == "" {
 		summary = fallbackSummary(rowMaps)
 	}
@@ -193,6 +193,31 @@ func (s *Service) validateConversion(ctx context.Context, conversion conversionR
 		validator = NewValidator(validator.store, options)
 	}
 	return validator.validate(ctx, cypher, params)
+}
+
+type timedStreamError struct {
+	err     error
+	timings StageTimings
+}
+
+func (e timedStreamError) Error() string {
+	return e.err.Error()
+}
+
+func (e timedStreamError) Unwrap() error {
+	return e.err
+}
+
+func streamErrorf(timings StageTimings, format string, args ...any) error {
+	return timedStreamError{err: fmt.Errorf(format, args...), timings: timings}
+}
+
+func ErrorTimings(err error) (StageTimings, bool) {
+	var timed timedStreamError
+	if errors.As(err, &timed) {
+		return timed.timings, true
+	}
+	return StageTimings{}, false
 }
 
 func emitProgress(emit Emitter, started time.Time, stage string, message string) error {
@@ -244,14 +269,14 @@ func conversionWarnings(diagnostics []ConversionDiagnostic) []string {
 	return warnings
 }
 
-func emitRefusal(emit Emitter, traceID string, started time.Time, cypher string, reason string, timings StageTimings) error {
+func emitRefusal(emit Emitter, traceID string, started time.Time, cypher string, reason string, code string, timings StageTimings) error {
 	reason = firstNonEmpty(reason, "Read-only Cypher validator refused the draft.")
 	if cypher == "" {
-		if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: "", Validator: ValidatorResult{OK: false, Reason: reason}}}); err != nil {
+		if err := emit(Event{Name: EventCypher, Data: CypherEvent{Cypher: "", Validator: ValidatorResult{OK: false, Code: code, Reason: reason}}}); err != nil {
 			return err
 		}
 	}
-	rescue := unsupportedQuery(reason, traceID)
+	rescue := unsupportedQuery(reason, traceID, code)
 	if err := emit(Event{Name: EventSummary, Data: SummaryEvent{Markdown: reason, UnsupportedQuery: &rescue}}); err != nil {
 		return err
 	}
@@ -299,7 +324,37 @@ func usesPostProcessingCandidates(plan AskQueryPlan) bool {
 }
 
 func postProcessingCandidateLimitHit(plan AskQueryPlan, rows []ports.CypherRow, rowLimit int) bool {
-	return usesPostProcessingCandidates(plan) && rowLimit >= postProcessingCandidateRowLimit && len(rows) >= rowLimit
+	if !usesPostProcessingCandidates(plan) || rowLimit < postProcessingCandidateRowLimit || len(rows) < rowLimit {
+		return false
+	}
+	if plan.Intent == IntentTopRiskFindings {
+		return topRiskFilteredCandidateCount(plan, rows) >= rowLimit
+	}
+	return true
+}
+
+func topRiskFilteredCandidateCount(plan AskQueryPlan, rows []ports.CypherRow) int {
+	count := 0
+	for _, row := range rows {
+		rowMap := map[string]any{}
+		for key, value := range row.Values {
+			rowMap[key] = value
+		}
+		relationAttrs := decodeInternalAttributes(rowMap["relation_attributes_json_internal"])
+		findingAttrs := decodeInternalAttributes(rowMap["finding_attributes_json_internal"])
+		severity := firstNonEmpty(
+			firstAttributeString(relationAttrs, "effective_severity", "severity"),
+			firstAttributeString(findingAttrs, "effective_severity", "severity"),
+		)
+		status := firstNonEmpty(
+			firstAttributeString(relationAttrs, "status"),
+			firstAttributeString(findingAttrs, "status"),
+		)
+		if matchesTopRiskFilters(plan, rowMap, severity, status) {
+			count++
+		}
+	}
+	return count
 }
 
 func postProcessFindingSourceRows(plan AskQueryPlan, rows []map[string]any) []map[string]any {
@@ -744,9 +799,31 @@ func urnsFromSummary(summary string) []string {
 	return urns
 }
 
-func unsupportedQuery(reason string, traceID string) UnsupportedQuery {
+func refusalCode(draft *DraftResponse, conversion conversionResult, validation ValidatorResult) string {
+	if validation.Code != "" {
+		return "validator_refusal"
+	}
+	if conversionDiagnosticsContain(conversion.Diagnostics, "query_plan_conversion_failed") {
+		return "query_plan_conversion_failed"
+	}
+	if draft != nil && strings.TrimSpace(draft.Refusal) != "" {
+		return "llm_refusal"
+	}
+	return unsupportedQueryCode(conversion.Refusal)
+}
+
+func conversionDiagnosticsContain(diagnostics []ConversionDiagnostic, code string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func unsupportedQuery(reason string, traceID string, code string) UnsupportedQuery {
 	return UnsupportedQuery{
-		Code:             unsupportedQueryCode(reason),
+		Code:             firstNonEmpty(code, unsupportedQueryCode(reason)),
 		Reason:           reason,
 		SupportedIntents: []string{IntentTopRiskFindings, IntentAggregateFindingsBySource, IntentExplainFinding, IntentIdentityBridge, IntentConnectorHealth},
 		SuggestedRewrites: []string{

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -480,7 +480,7 @@ func matchesTopRiskFilters(plan AskQueryPlan, row map[string]any, severity strin
 func resourceTypeMatchesFilter(resourceType string, resourceURN string, filter string) bool {
 	canonical := canonicalEntityType(filter)
 	if canonical == "github.code.repository" || canonical == "github.repo" {
-		return resourceType == "github.code.repository" || resourceType == "github.repo" || strings.Contains(resourceURN, ":repo:") || strings.Contains(resourceURN, ":github_repo:")
+		return resourceType == "github.code.repository" || resourceType == "github.repo"
 	}
 	return strings.EqualFold(resourceType, canonical)
 }

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -107,7 +107,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	}
 	if cypher == "" {
 		reason := firstNonEmpty(draft.Refusal, conversion.Refusal, "LLM refused to draft Cypher")
-		return emitRefusal(emit, traceID, started, cypher, reason, refusalCode(draft, conversion, ValidatorResult{}), timings)
+		return emitRefusal(emit, traceID, started, cypher, reason, refusalCode(reason, draft, conversion, ValidatorResult{}), timings)
 	}
 	if err := emitProgress(emit, started, "validating_query", "Validating generated Cypher against read-only guardrails."); err != nil {
 		return err
@@ -123,7 +123,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		return err
 	}
 	if !validation.OK {
-		return emitRefusal(emit, traceID, started, cypher, validation.Reason, refusalCode(draft, conversion, validation), timings)
+		return emitRefusal(emit, traceID, started, cypher, validation.Reason, refusalCode(validation.Reason, draft, conversion, validation), timings)
 	}
 
 	if err := emitProgress(emit, started, "executing_query", "Executing the validated graph query."); err != nil {
@@ -769,7 +769,7 @@ func urnsFromSummary(summary string) []string {
 	return urns
 }
 
-func refusalCode(draft *DraftResponse, conversion conversionResult, validation ValidatorResult) string {
+func refusalCode(reason string, draft *DraftResponse, conversion conversionResult, validation ValidatorResult) string {
 	if validation.Code != "" {
 		return "validator_refusal"
 	}
@@ -779,7 +779,7 @@ func refusalCode(draft *DraftResponse, conversion conversionResult, validation V
 	if draft != nil && strings.TrimSpace(draft.Refusal) != "" {
 		return "llm_refusal"
 	}
-	return unsupportedQueryCode(conversion.Refusal)
+	return unsupportedQueryCode(firstNonEmpty(reason, conversion.Refusal))
 }
 
 func conversionDiagnosticsContain(diagnostics []ConversionDiagnostic, code string) bool {

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -324,37 +324,7 @@ func usesPostProcessingCandidates(plan AskQueryPlan) bool {
 }
 
 func postProcessingCandidateLimitHit(plan AskQueryPlan, rows []ports.CypherRow, rowLimit int) bool {
-	if !usesPostProcessingCandidates(plan) || rowLimit < postProcessingCandidateRowLimit || len(rows) < rowLimit {
-		return false
-	}
-	if plan.Intent == IntentTopRiskFindings {
-		return topRiskFilteredCandidateCount(plan, rows) >= rowLimit
-	}
-	return true
-}
-
-func topRiskFilteredCandidateCount(plan AskQueryPlan, rows []ports.CypherRow) int {
-	count := 0
-	for _, row := range rows {
-		rowMap := map[string]any{}
-		for key, value := range row.Values {
-			rowMap[key] = value
-		}
-		relationAttrs := decodeInternalAttributes(rowMap["relation_attributes_json_internal"])
-		findingAttrs := decodeInternalAttributes(rowMap["finding_attributes_json_internal"])
-		severity := firstNonEmpty(
-			firstAttributeString(relationAttrs, "effective_severity", "severity"),
-			firstAttributeString(findingAttrs, "effective_severity", "severity"),
-		)
-		status := firstNonEmpty(
-			firstAttributeString(relationAttrs, "status"),
-			firstAttributeString(findingAttrs, "status"),
-		)
-		if matchesTopRiskFilters(plan, rowMap, severity, status) {
-			count++
-		}
-	}
-	return count
+	return usesPostProcessingCandidates(plan) && rowLimit >= postProcessingCandidateRowLimit && len(rows) >= rowLimit
 }
 
 func postProcessFindingSourceRows(plan AskQueryPlan, rows []map[string]any) []map[string]any {

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -401,23 +401,18 @@ func TestServiceRefusesSaturatedPostProcessingCandidateWindow(t *testing.T) {
 	}
 }
 
-func TestServiceAppliesTopRiskFiltersBeforeSaturationRefusal(t *testing.T) {
-	rows := make([]ports.CypherRow, 0, postProcessingCandidateRowLimit)
-	for i := 0; i < postProcessingCandidateRowLimit; i++ {
-		status := "closed"
-		if i == 42 {
-			status = "open"
-		}
-		rows = append(rows, ports.CypherRow{Values: map[string]any{
-			"finding_urn":                       "urn:cerebro:writer:finding:" + strconv.Itoa(i),
-			"finding_label":                     "Finding " + strconv.Itoa(i),
-			"resource_urn":                      "urn:cerebro:writer:repo:" + strconv.Itoa(i),
-			"resource_label":                    "repo-" + strconv.Itoa(i),
+func TestServicePushesTopRiskFiltersBeforeCandidateLimit(t *testing.T) {
+	rows := []ports.CypherRow{{
+		Values: map[string]any{
+			"finding_urn":                       "urn:cerebro:writer:finding:open-repo",
+			"finding_label":                     "Open repository finding",
+			"resource_urn":                      "urn:cerebro:writer:repo:alpha",
+			"resource_label":                    "repo-alpha",
 			"resource_type":                     "github.repo",
-			"relation_attributes_json_internal": `{"risk_score":88,"severity":"HIGH","status":"` + status + `"}`,
+			"relation_attributes_json_internal": `{"risk_score":88,"severity":"HIGH","status":"open"}`,
 			"finding_attributes_json_internal":  `{}`,
-		}})
-	}
+		},
+	}}
 	store := &askStore{rows: rows}
 	llm := &StubLLMClient{
 		DraftResponse: &DraftResponse{
@@ -440,6 +435,9 @@ func TestServiceAppliesTopRiskFiltersBeforeSaturationRefusal(t *testing.T) {
 		t.Fatalf("Stream() error = %v", err)
 	}
 	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventProgress, EventCypher, EventProgress, EventRows, EventProgress, EventSummary, EventDone})
+	if !strings.Contains(store.requests[0].Query, "toLower(filter_status) = 'open'") || !strings.Contains(store.requests[0].Query, "CASE WHEN resource.entity_type IN ['github.code.repository', 'github.repo'] THEN true") {
+		t.Fatalf("store request should push supported filters into Cypher:\n%s", store.requests[0].Query)
+	}
 	rowsEvent := events[6].Data.(RowsEvent)
 	if len(rowsEvent.Rows) != 1 {
 		t.Fatalf("rows = %#v, want one filtered top-risk row", rowsEvent.Rows)

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -435,7 +435,7 @@ func TestServicePushesTopRiskFiltersBeforeCandidateLimit(t *testing.T) {
 		t.Fatalf("Stream() error = %v", err)
 	}
 	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventProgress, EventCypher, EventProgress, EventRows, EventProgress, EventSummary, EventDone})
-	if !strings.Contains(store.requests[0].Query, "toLower(filter_status) = 'open'") || !strings.Contains(store.requests[0].Query, "CASE WHEN resource.entity_type IN ['github.code.repository', 'github.repo'] THEN true") {
+	if !strings.Contains(store.requests[0].Query, "toLower(filter_status) = 'open'") || !strings.Contains(store.requests[0].Query, "resource.entity_type IN ['github.code.repository', 'github.repo']") {
 		t.Fatalf("store request should push supported filters into Cypher:\n%s", store.requests[0].Query)
 	}
 	rowsEvent := events[6].Data.(RowsEvent)
@@ -445,6 +445,15 @@ func TestServicePushesTopRiskFiltersBeforeCandidateLimit(t *testing.T) {
 	done := events[9].Data.(DoneEvent)
 	if done.CypherRefused {
 		t.Fatalf("done.CypherRefused = true, want filtered saturated candidate window to proceed")
+	}
+}
+
+func TestResourceTypeMatchesRepositoryFilterByEntityTypeOnly(t *testing.T) {
+	if resourceTypeMatchesFilter("github.runner", "urn:cerebro:writer:github_runner:repo:writer/cerebro:777", "repository") {
+		t.Fatal("repository filter matched github.runner because its URN contains repo")
+	}
+	if !resourceTypeMatchesFilter("github.repo", "urn:cerebro:writer:github_runner:repo:writer/cerebro:777", "repository") {
+		t.Fatal("repository filter did not match github.repo entity type")
 	}
 }
 

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -105,8 +105,8 @@ func TestServiceRefusesValidatorRejectedCypher(t *testing.T) {
 		t.Fatalf("validator ok = true, want false")
 	}
 	summary := events[5].Data.(SummaryEvent)
-	if summary.UnsupportedQuery == nil || summary.UnsupportedQuery.Code == "" || len(summary.UnsupportedQuery.SuggestedRewrites) == 0 {
-		t.Fatalf("unsupported query rescue = %#v, want structured suggestions", summary.UnsupportedQuery)
+	if summary.UnsupportedQuery == nil || summary.UnsupportedQuery.Code != "validator_refusal" || len(summary.UnsupportedQuery.SuggestedRewrites) == 0 {
+		t.Fatalf("unsupported query rescue = %#v, want validator refusal with structured suggestions", summary.UnsupportedQuery)
 	}
 	done := events[6].Data.(DoneEvent)
 	if !done.CypherRefused {
@@ -398,6 +398,55 @@ func TestServiceRefusesSaturatedPostProcessingCandidateWindow(t *testing.T) {
 	done := events[7].Data.(DoneEvent)
 	if !done.CypherRefused {
 		t.Fatalf("done.CypherRefused = false, want true")
+	}
+}
+
+func TestServiceAppliesTopRiskFiltersBeforeSaturationRefusal(t *testing.T) {
+	rows := make([]ports.CypherRow, 0, postProcessingCandidateRowLimit)
+	for i := 0; i < postProcessingCandidateRowLimit; i++ {
+		status := "closed"
+		if i == 42 {
+			status = "open"
+		}
+		rows = append(rows, ports.CypherRow{Values: map[string]any{
+			"finding_urn":                       "urn:cerebro:writer:finding:" + strconv.Itoa(i),
+			"finding_label":                     "Finding " + strconv.Itoa(i),
+			"resource_urn":                      "urn:cerebro:writer:repo:" + strconv.Itoa(i),
+			"resource_label":                    "repo-" + strconv.Itoa(i),
+			"resource_type":                     "github.repo",
+			"relation_attributes_json_internal": `{"risk_score":88,"severity":"HIGH","status":"` + status + `"}`,
+			"finding_attributes_json_internal":  `{}`,
+		}})
+	}
+	store := &askStore{rows: rows}
+	llm := &StubLLMClient{
+		DraftResponse: &DraftResponse{
+			Rationale: "Filtering open repository risk.",
+			Plan:      &AskQueryPlan{Intent: IntentTopRiskFindings, Limit: 10, Filters: map[string]string{"status": "open", "resource_type": "repository"}},
+		},
+		Summary: "One open repository finding remains.",
+	}
+	service := NewService(store, llm, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{
+		TenantID: "writer",
+		Question: "Show open high-risk repository findings",
+	}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventProgress, EventCypher, EventProgress, EventRows, EventProgress, EventSummary, EventDone})
+	rowsEvent := events[6].Data.(RowsEvent)
+	if len(rowsEvent.Rows) != 1 {
+		t.Fatalf("rows = %#v, want one filtered top-risk row", rowsEvent.Rows)
+	}
+	done := events[9].Data.(DoneEvent)
+	if done.CypherRefused {
+		t.Fatalf("done.CypherRefused = true, want filtered saturated candidate window to proceed")
 	}
 }
 

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -154,6 +154,24 @@ func TestServiceRefusesUnsupportedPlanOnlyDraftAsConversionFailure(t *testing.T)
 	}
 }
 
+func TestServiceClassifiesEmptyDraftAsLLMRefusal(t *testing.T) {
+	service := NewService(&askStore{}, &StubLLMClient{DraftResponse: &DraftResponse{}}, ValidatorOptions{})
+
+	var events []Event
+	err := service.Stream(context.Background(), AskRequest{TenantID: "example", Question: "what is risky?"}, func(event Event) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	assertEventNames(t, events, []string{EventProgress, EventRationale, EventQueryPlan, EventCypher, EventSummary, EventDone})
+	summary := events[4].Data.(SummaryEvent)
+	if summary.UnsupportedQuery == nil || summary.UnsupportedQuery.Code != "llm_refusal" {
+		t.Fatalf("unsupported query = %#v, want llm_refusal", summary.UnsupportedQuery)
+	}
+}
+
 func TestServiceFlagsUngroundedSummaryURNs(t *testing.T) {
 	store := &askStore{
 		rows: []ports.CypherRow{{

--- a/internal/graphagent/events.go
+++ b/internal/graphagent/events.go
@@ -104,8 +104,9 @@ type DoneEvent struct {
 }
 
 type ErrorEvent struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Code    string       `json:"code"`
+	Message string       `json:"message"`
+	Timings StageTimings `json:"timings,omitempty"`
 }
 
 func WriteSSEEvent(w io.Writer, event Event) error {

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -272,8 +272,11 @@ RETURN f.urn AS finding_urn,
 ORDER BY finding_urn
 LIMIT %d`, postProcessingCandidateRowLimit), true
 	case IntentTopRiskFindings:
+		filterProjection, filterPredicate := topRiskFilterClauses(plan.Filters)
 		return fmt.Sprintf(`MATCH (resource:Entity {tenant_id: $tenant_id})-[r:RELATION {relation: 'has_finding'}]->(finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = '' OR resource.urn = $scope_urn OR finding.urn = $scope_urn
+WITH resource, r, finding%s
+%s
 RETURN finding.urn AS finding_urn,
        coalesce(finding.label, finding.urn) AS finding_label,
        resource.urn AS resource_urn,
@@ -282,7 +285,7 @@ RETURN finding.urn AS finding_urn,
        coalesce(r.attributes_json, '') AS relation_attributes_json_internal,
        coalesce(finding.attributes_json, '') AS finding_attributes_json_internal
 ORDER BY finding_urn, resource_urn
-LIMIT %d`, postProcessingCandidateRowLimit), true
+LIMIT %d`, filterProjection, filterPredicate, postProcessingCandidateRowLimit), true
 	case IntentExplainFinding:
 		return fmt.Sprintf(`MATCH (finding:Entity {tenant_id: $tenant_id, entity_type: 'finding'})
 WHERE $scope_urn = ''
@@ -384,6 +387,45 @@ func cypherJSONQuotedStringToken(key string) string {
 	return fmt.Sprintf(`"%s":"`, key)
 }
 
+func topRiskFilterClauses(filters map[string]string) (string, string) {
+	var projection []string
+	var predicates []string
+	if severity := planFilterValue(filters, "severity"); severity != "" {
+		projection = append(projection, fmt.Sprintf("coalesce(\n       %s,\n       ''\n     ) AS filter_severity", strings.Join([]string{
+			cypherJSONStringAttributes("r.attributes_json", "effective_severity", "severity"),
+			cypherJSONStringAttributes("finding.attributes_json", "effective_severity", "severity"),
+		}, ",\n       ")))
+		predicates = append(predicates, "toUpper(filter_severity) = "+cypherStringLiteral(strings.ToUpper(severity)))
+	}
+	if status := planFilterValue(filters, "status"); status != "" {
+		projection = append(projection, fmt.Sprintf("coalesce(\n       %s,\n       ''\n     ) AS filter_status", strings.Join([]string{
+			cypherJSONStringAttributes("r.attributes_json", "status"),
+			cypherJSONStringAttributes("finding.attributes_json", "status"),
+		}, ",\n       ")))
+		predicates = append(predicates, "toLower(filter_status) = "+cypherStringLiteral(strings.ToLower(status)))
+	}
+	if resourceType := firstNonEmpty(planFilterValue(filters, "resource_type"), planFilterValue(filters, "entity_type")); resourceType != "" {
+		predicates = append(predicates, resourceTypePredicate(resourceType))
+	}
+	if len(predicates) == 0 {
+		return "", ""
+	}
+	if len(projection) == 0 {
+		return "", "WHERE " + strings.Join(predicates, "\n  AND ")
+	}
+	return ",\n     " + strings.Join(projection, ",\n     "), "WHERE " + strings.Join(predicates, "\n  AND ")
+}
+
+func resourceTypePredicate(value string) string {
+	canonical := canonicalEntityType(value)
+	switch canonical {
+	case "github.code.repository", "github.repo":
+		return "CASE WHEN resource.entity_type IN ['github.code.repository', 'github.repo'] THEN true WHEN resource.urn CONTAINS ':repo:' THEN true WHEN resource.urn CONTAINS ':github_repo:' THEN true ELSE false END"
+	default:
+		return "resource.entity_type = " + cypherStringLiteral(canonical)
+	}
+}
+
 func planFilterValue(filters map[string]string, key string) string {
 	for filterKey, value := range filters {
 		if strings.EqualFold(filterKey, key) {
@@ -391,6 +433,10 @@ func planFilterValue(filters map[string]string, key string) string {
 		}
 	}
 	return ""
+}
+
+func cypherStringLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "\\'") + "'"
 }
 
 func hasUnsupportedDeterministicModifiers(plan AskQueryPlan) bool {

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -420,7 +420,7 @@ func resourceTypePredicate(value string) string {
 	canonical := canonicalEntityType(value)
 	switch canonical {
 	case "github.code.repository", "github.repo":
-		return "CASE WHEN resource.entity_type IN ['github.code.repository', 'github.repo'] THEN true WHEN resource.urn CONTAINS ':repo:' THEN true WHEN resource.urn CONTAINS ':github_repo:' THEN true ELSE false END"
+		return "resource.entity_type IN ['github.code.repository', 'github.repo']"
 	default:
 		return "resource.entity_type = " + cypherStringLiteral(canonical)
 	}

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -332,6 +332,10 @@ WHERE left.urn < right.urn
 WITH left, right, identity,
      coalesce(%s, '') AS left_seen_at,
      coalesce(%s, '') AS right_seen_at
+WHERE left_seen_at =~ '^\\d{4}-\\d{2}-\\d{2}T.*'
+  AND right_seen_at =~ '^\\d{4}-\\d{2}-\\d{2}T.*'
+  AND datetime(left_seen_at) >= datetime() - duration('P90D')
+  AND datetime(right_seen_at) >= datetime() - duration('P90D')
 RETURN left.urn AS left_urn,
        coalesce(left.label, left.urn) AS left_label,
        left.entity_type AS left_type,

--- a/internal/graphagent/query_plan.go
+++ b/internal/graphagent/query_plan.go
@@ -436,7 +436,9 @@ func planFilterValue(filters map[string]string, key string) string {
 }
 
 func cypherStringLiteral(value string) string {
-	return "'" + strings.ReplaceAll(value, "'", "\\'") + "'"
+	escaped := strings.ReplaceAll(value, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "'", "\\'")
+	return "'" + escaped + "'"
 }
 
 func hasUnsupportedDeterministicModifiers(plan AskQueryPlan) bool {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -330,6 +330,9 @@ func TestConvertDraftToQueryUsesCanonicalIdentityBridgeTemplate(t *testing.T) {
 		"left.entity_type <> right.entity_type",
 		"$scope_urn = '' OR left.urn = $scope_urn OR right.urn = $scope_urn OR identity.urn = $scope_urn",
 		"NOT left.entity_type STARTS WITH 'identifier'",
+		"left_seen_at =~ '^\\\\d{4}-\\\\d{2}-\\\\d{2}T.*'",
+		"datetime(left_seen_at) >= datetime() - duration('P90D')",
+		"datetime(right_seen_at) >= datetime() - duration('P90D')",
 		"identity.urn AS identity_urn",
 	} {
 		if !strings.Contains(result.Cypher, want) {

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -231,7 +231,7 @@ LIMIT 25`
 	for _, want := range []string{
 		"toUpper(filter_severity) = 'HIGH'",
 		"toLower(filter_status) = 'open'",
-		"CASE WHEN resource.entity_type IN ['github.code.repository', 'github.repo'] THEN true",
+		"resource.entity_type IN ['github.code.repository', 'github.repo']",
 		"resource.entity_type AS resource_type",
 		"relation_attributes_json_internal",
 		"finding_attributes_json_internal",

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -228,14 +228,21 @@ LIMIT 25`
 	if !result.Deterministic || result.Source != "deterministic_template" {
 		t.Fatalf("conversion result = %#v, want deterministic filtered template", result)
 	}
-	for _, want := range []string{"resource.entity_type AS resource_type", "relation_attributes_json_internal", "finding_attributes_json_internal"} {
+	for _, want := range []string{
+		"toUpper(filter_severity) = 'HIGH'",
+		"toLower(filter_status) = 'open'",
+		"CASE WHEN resource.entity_type IN ['github.code.repository', 'github.repo'] THEN true",
+		"resource.entity_type AS resource_type",
+		"relation_attributes_json_internal",
+		"finding_attributes_json_internal",
+	} {
 		if !strings.Contains(result.Cypher, want) {
 			t.Fatalf("filtered cypher missing %q:\n%s", want, result.Cypher)
 		}
 	}
-	for _, forbidden := range []string{"toUpper(severity)", "toLower(status)", "resource.entity_type IN", "split(split"} {
+	for _, forbidden := range []string{"max(risk_score)", "CASE toUpper"} {
 		if strings.Contains(result.Cypher, forbidden) {
-			t.Fatalf("filtered cypher should leave filter evaluation to Go; found %q:\n%s", forbidden, result.Cypher)
+			t.Fatalf("filtered cypher should leave ranking to Go; found %q:\n%s", forbidden, result.Cypher)
 		}
 	}
 }

--- a/internal/graphagent/query_plan_test.go
+++ b/internal/graphagent/query_plan_test.go
@@ -247,6 +247,14 @@ LIMIT 25`
 	}
 }
 
+func TestCypherStringLiteralEscapesBackslashBeforeQuote(t *testing.T) {
+	got := cypherStringLiteral(`open\' OR true`)
+	want := `'open\\\' OR true'`
+	if got != want {
+		t.Fatalf("cypherStringLiteral() = %q, want %q", got, want)
+	}
+}
+
 func TestConvertDraftToQueryRefusesUnsupportedPlanOnlyDraft(t *testing.T) {
 	result := convertDraftToQuery(AskRequest{
 		TenantID: "writer",


### PR DESCRIPTION
## Summary
- Restore 90-day recency gating for deterministic identity bridge joins while preserving defensive timestamp extraction.
- Let supported top-risk filters reduce saturated candidate windows before returning the post-processing refusal.
- Classify validator refusals explicitly and carry Ask stage timings through streamed error events/telemetry.

## Test plan
- go test ./internal/graphagent ./internal/bootstrap
- make verify


Made with [Cursor](https://cursor.com)