### PR TITLE
Speed up Droid review feedback

### DIFF
--- a/.factory/skills/review-guidelines.md
+++ b/.factory/skills/review-guidelines.md
@@ -1,0 +1,19 @@
+# Cerebro Review Guidelines
+
+Use this context to keep Droid reviews focused and fast.
+
+## Known Invariants
+
+- Source connectors must use `internal/sourcehttp` for outbound HTTP safety; do not reintroduce connector-local `http.Client`, transport, body-read, SSRF, or DNS-rebinding logic.
+- Production `io.ReadAll` calls must read from `io.LimitReader` or be replaced with streaming code. The fast local check is `make droid-review-preflight`.
+- Graph Ask Cypher must be tenant-scoped, read-only, row-limited, and validated before execution. Prefer deterministic query templates for supported intents.
+- Ask post-processing may only run for deterministic templates; LLM fallback rows must not be reshaped by deterministic Go post-processing.
+- Candidate finding state transitions must be atomic and idempotent. Avoid split read-then-write state changes unless a store method owns the compare-and-swap.
+- Device auth request origins, DPoP `htu`, client IP, and proxy-derived headers must flow through the canonical request-origin helpers.
+
+## Review Triage
+
+- Prioritize concrete correctness, authorization, tenant isolation, SSRF/body-size, and state-transition bugs over style suggestions.
+- Treat matching local regression coverage as strong evidence; ask for focused tests only when the behavior can regress.
+- If a finding matches an invariant above, cite the invariant and the exact local command that would have caught it.
+- Keep comments scoped to changed code. Avoid broad architecture restatements when a PR changes only tests, docs, or workflow plumbing.

--- a/.factory/skills/review-guidelines/SKILL.md
+++ b/.factory/skills/review-guidelines/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: review-guidelines
+description: Repository-specific Cerebro review invariants and triage guidance for Droid code and security reviews.
+---
+
 # Cerebro Review Guidelines
 
 Use this context to keep Droid reviews focused and fast.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+
+## Test Plan
+
+
+## Known Invariants
+
+- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
+- Production body reads are bounded with `io.LimitReader` or streamed.
+- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
+- Ask deterministic post-processing is not applied to LLM fallback rows.
+- Candidate finding lifecycle writes remain atomic and idempotent.
+- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.
+
+## Droid Review Context
+
+- Fast local preflight: `make droid-review-preflight`.
+- Focus review on changed behavior and the invariants above.
+- Escalate to a deep manual Droid pass for broad auth, graph, source HTTP, or state-machine changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,4 @@
 
 - Fast local preflight: `make droid-review-preflight`.
 - Focus review on changed behavior and the invariants above.
-- Escalate to a deep manual Droid pass for broad auth, graph, source HTTP, or state-machine changes.
+- Escalate to a deep manual Droid tag review for broad auth, graph, source HTTP, or state-machine changes.

--- a/.github/workflows/droid-create.yml
+++ b/.github/workflows/droid-create.yml
@@ -570,6 +570,8 @@ jobs:
               "- Prefer existing Go, Makefile, source connector, graph, findings, and SDK patterns.",
               "- Add or update tests for behavioral changes and for every review finding that can regress.",
               "- Run focused tests first, then run `make verify` when feasible.",
+              "- Keep PRs small: split business-logic fixes from static-analyzer/tooling rewrites when possible.",
+              "- Preserve known invariants from `.factory/skills/review-guidelines.md` and cite the local command that validates them.",
               "- If a validator cannot run because of the GitHub Actions environment, report the exact blocker.",
               "- Do not commit, push, create a PR, merge, or edit GitHub metadata. Leave changes in the working tree; this workflow handles git operations.",
               "",

--- a/.github/workflows/droid-create.yml
+++ b/.github/workflows/droid-create.yml
@@ -571,7 +571,7 @@ jobs:
               "- Add or update tests for behavioral changes and for every review finding that can regress.",
               "- Run focused tests first, then run `make verify` when feasible.",
               "- Keep PRs small: split business-logic fixes from static-analyzer/tooling rewrites when possible.",
-              "- Preserve known invariants from `.factory/skills/review-guidelines.md` and cite the local command that validates them.",
+              "- Preserve known invariants from `.factory/skills/review-guidelines/SKILL.md` and cite the local command that validates them.",
               "- If a validator cannot run because of the GitHub Actions environment, report the exact blocker.",
               "- Do not commit, push, create a PR, merge, or edit GitHub metadata. Leave changes in the working tree; this workflow handles git operations.",
               "",

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -9,7 +9,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  droid-review-preflight:
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run fast Droid review preflight
+        env:
+          DROID_REVIEW_BASE: ${{ github.event.pull_request.base.sha }}
+          DROID_REVIEW_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: make droid-review-preflight
+
   droid-review:
+    needs: droid-review-preflight
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
@@ -90,11 +112,7 @@ jobs:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
           automatic_security_review: true
-          # Pin the review and security review models to the gpt-5.4 generation so PR scans
-          # benefit from the newer reasoning capabilities; previously the action defaulted to
-          # the gpt-5.2 generation (`review_depth: deep`). Setting `review_model` explicitly
-          # bypasses the depth preset, so re-assert reasoning_effort=high to match `deep`.
-          review_model: gpt-5.4
-          security_model: gpt-5.4
-          reasoning_effort: high
+          # Fast automatic reviews keep the feedback loop short. Escalate to a
+          # manual deep pass with @droid when a PR changes broad security logic.
+          review_depth: shallow
           allowed_bots: dependabot

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -14,34 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
-      - name: Run fast Droid review preflight
-        env:
-          DROID_REVIEW_BASE: ${{ github.event.pull_request.base.sha }}
-          DROID_REVIEW_HEAD: ${{ github.event.pull_request.head.sha }}
-        run: make droid-review-preflight
-
-  droid-review:
-    needs: droid-review-preflight
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
       pull-requests: write
       issues: write
-      id-token: write
-      actions: read
+    outputs:
+      run_droid_review: ${{ steps.preflight.outputs.run_droid_review }}
+      review_model: ${{ steps.preflight.outputs.review_model }}
+      review_reason: ${{ steps.preflight.outputs.review_reason }}
     steps:
-      - name: Supersede previous Droid security summary
+      - name: Supersede previous Droid comments
         if: github.event.action == 'synchronize'
         shell: bash
         env:
@@ -54,11 +34,15 @@ jobs:
           import os
           import urllib.request
 
-          marker = "## Security Review Summary"
-          replacement = "## Superseded Security Review Summary"
           repository = os.environ["GITHUB_REPOSITORY"]
           token = os.environ["GH_TOKEN"]
           pr_number = os.environ["PR_NUMBER"]
+
+          replacements = [
+              ("## Security Review Summary", "## Superseded Security Review Summary"),
+              ("**Droid encountered an error**", "**Superseded Droid error**"),
+              ("Droid is reviewing code and running a security check", "Superseded Droid review in progress"),
+          ]
 
           def request_json(method, path, payload=None):
               data = None if payload is None else json.dumps(payload).encode("utf-8")
@@ -87,21 +71,64 @@ jobs:
               for comment in comments:
                   user = comment.get("user") or {}
                   login = (user.get("login") or "").lower()
-                  user_type = (user.get("type") or "").lower()
+                  if login not in {"factory-droid", "factory-droid[bot]"}:
+                      continue
                   body = comment.get("body") or ""
-                  if (
-                      login == "factory-droid[bot]"
-                      and user_type == "bot"
-                      and marker in body
-                  ):
+                  updated = body
+                  for marker, replacement in replacements:
+                      if marker in updated:
+                          updated = updated.replace(marker, replacement, 1)
+                  if updated != body and "Superseded by a newer commit." not in updated:
+                      updated = updated.rstrip() + "\n\n_Superseded by a newer commit._"
+                  if updated != body:
                       request_json(
                           "PATCH",
                           f"/repos/{repository}/issues/comments/{comment['id']}",
-                          {"body": body.replace(marker, replacement, 1)},
+                          {"body": updated},
                       )
               page += 1
           PY
 
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run fast Droid review preflight
+        id: preflight
+        shell: bash
+        env:
+          DROID_REVIEW_BASE: ${{ github.event.pull_request.base.sha }}
+          DROID_REVIEW_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set +e
+          started="$(date +%s)"
+          make droid-review-preflight
+          status="$?"
+          duration="$(( $(date +%s) - started ))"
+          {
+            echo "### Droid Review Preflight"
+            echo
+            echo "- Duration: ${duration}s"
+            echo "- Status: $([ "${status}" -eq 0 ] && echo success || echo failure)"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit "${status}"
+
+  droid-review:
+    needs: droid-review-preflight
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && needs.droid-review-preflight.outputs.run_droid_review == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -114,6 +141,6 @@ jobs:
           automatic_security_review: true
           # Fast deterministic preflight runs first; use Opus for the actual
           # bug-finding review so Droid does not fall back to stale depth presets.
-          review_model: claude-opus-4-8
+          review_model: ${{ needs.droid-review-preflight.outputs.review_model || 'claude-opus-4-8' }}
           security_model: gpt-5.4
           allowed_bots: dependabot

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -112,7 +112,8 @@ jobs:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
           automatic_security_review: true
-          # Fast automatic reviews keep the feedback loop short. Escalate to a
-          # manual deep pass with @droid when a PR changes broad security logic.
-          review_depth: shallow
+          # Fast deterministic preflight runs first; use Opus for the actual
+          # bug-finding review so Droid does not fall back to stale depth presets.
+          review_model: claude-opus-4-8
+          security_model: gpt-5.4
           allowed_bots: dependabot

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -136,10 +136,8 @@ jobs:
         uses: Factory-AI/droid-action@8ea31f351ee6636ebef918ccb64682f477af7184 # main
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
-          # Pin tag-triggered review/security runs (@droid review / @droid security) to the
-          # gpt-5.4 generation with high reasoning effort. The action's default
-          # `review_depth: deep` resolves to gpt-5.2, and setting `review_model` explicitly
-          # bypasses the depth preset, so we also re-assert reasoning_effort=high.
+          # Keep manual @droid reviews as the escalation path after the fast
+          # automatic shallow pass has already run.
           review_model: gpt-5.4
           security_model: gpt-5.4
           reasoning_effort: high

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           # Keep manual @droid reviews as the escalation path after the fast
-          # automatic shallow pass has already run.
-          review_model: gpt-5.4
+          # preflight-backed automatic pass has already run.
+          review_model: claude-opus-4-8
           security_model: gpt-5.4
           reasoning_effort: high

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build serve test workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check oss-audit govulncheck clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: build serve test workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check oss-audit govulncheck droid-review-preflight droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -30,6 +30,9 @@ GRAPH_REBUILD_PAGE_LIMIT ?= 1
 GRAPH_REBUILD_EVENT_LIMIT ?= 100
 GRAPH_REBUILD_PREVIEW_LIMIT ?= 10
 CANDIDATE_SMOKE_EVENT_LIMIT ?= 25
+DROID_REVIEW_BASE ?= origin/main
+DROID_REVIEW_HEAD ?= HEAD
+DROID_PR ?=
 
 build:
 	go build -o bin/cerebro ./cmd/cerebro
@@ -120,6 +123,14 @@ oss-audit:
 
 govulncheck:
 	$(GOVULNCHECK) ./...
+
+droid-review-preflight:
+	go test ./tools/droidreview/...
+	go run ./tools/droidreview --base "$(DROID_REVIEW_BASE)" --head "$(DROID_REVIEW_HEAD)"
+
+droid-feedback:
+	@if [ -z "$(DROID_PR)" ]; then echo "DROID_PR is required, e.g. make droid-feedback DROID_PR=719" >&2; exit 2; fi
+	python3 scripts/droid_feedback_harness.py "$(DROID_PR)"
 
 clean:
 	rm -rf bin/

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ CANDIDATE_SMOKE_EVENT_LIMIT ?= 25
 DROID_REVIEW_BASE ?= origin/main
 DROID_REVIEW_HEAD ?= HEAD
 DROID_PR ?=
+DROID_FEEDBACK_OUT ?=
 
 build:
 	go build -o bin/cerebro ./cmd/cerebro
@@ -130,7 +131,7 @@ droid-review-preflight:
 
 droid-feedback:
 	@if [ -z "$(DROID_PR)" ]; then echo "DROID_PR is required, e.g. make droid-feedback DROID_PR=719" >&2; exit 2; fi
-	python3 scripts/droid_feedback_harness.py "$(DROID_PR)"
+	python3 scripts/droid_feedback_harness.py "$(DROID_PR)" $(if $(DROID_FEEDBACK_OUT),--markdown-out "$(DROID_FEEDBACK_OUT)")
 
 clean:
 	rm -rf bin/

--- a/scripts/droid_feedback_harness.py
+++ b/scripts/droid_feedback_harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -49,17 +50,23 @@ def collect_comments(pr_number: str) -> list[DroidComment]:
     for item in review_comments:
         if not is_droid(item):
             continue
+        body = item.get("body", "")
+        if is_superseded(body):
+            continue
         comments.append(
             DroidComment(
                 kind="review",
                 url=item.get("html_url", ""),
                 path=item.get("path", ""),
                 line=item.get("line") or item.get("original_line"),
-                body=item.get("body", ""),
+                body=body,
             )
         )
     for item in issue_comments:
         if not is_droid(item):
+            continue
+        body = item.get("body", "")
+        if is_superseded(body):
             continue
         comments.append(
             DroidComment(
@@ -67,7 +74,7 @@ def collect_comments(pr_number: str) -> list[DroidComment]:
                 url=item.get("html_url", ""),
                 path="",
                 line=None,
-                body=item.get("body", ""),
+                body=body,
             )
         )
     return comments
@@ -77,7 +84,12 @@ def is_droid(item: dict[str, object]) -> bool:
     user = item.get("user") or {}
     if not isinstance(user, dict):
         return False
-    return str(user.get("login", "")).lower() == "factory-droid[bot]"
+    return str(user.get("login", "")).lower() in {"factory-droid", "factory-droid[bot]"}
+
+
+def is_superseded(body: str) -> bool:
+    lowered = body.lower()
+    return "superseded" in lowered or "view job" in lowered and "encountered an error" in lowered
 
 
 def suggested_checks(comment: DroidComment) -> list[str]:
@@ -106,9 +118,43 @@ def first_sentence(markdown: str) -> str:
     return "(empty comment)"
 
 
+def regression_checklist(comments: list[DroidComment]) -> str:
+    lines = ["# Droid Feedback Regression Checklist", ""]
+    if not comments:
+        lines.append("No active Droid comments found.")
+        lines.append("")
+        return "\n".join(lines)
+    for index, comment in enumerate(comments, start=1):
+        location = comment.path
+        if comment.line:
+            location = f"{location}:{comment.line}"
+        location = location or comment.kind
+        lines.extend(
+            [
+                f"## {index}. {location}",
+                "",
+                f"- Comment: {first_sentence(comment.body)}",
+                f"- URL: {comment.url}",
+                "- Regression checks:",
+            ]
+        )
+        for check in suggested_checks(comment):
+            lines.append(f"  - [ ] `{check}`")
+        lines.extend(
+            [
+                "- Local test added/updated:",
+                "  - [ ] Yes",
+                "- Notes:",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("pr", help="pull request number")
+    parser.add_argument("--markdown-out", help="optional path for a markdown regression checklist")
     args = parser.parse_args()
 
     try:
@@ -119,6 +165,10 @@ def main() -> int:
 
     if not comments:
         print(f"No Droid comments found on PR #{args.pr}.")
+        if args.markdown_out:
+            ensure_parent_dir(args.markdown_out)
+            with open(args.markdown_out, "w", encoding="utf-8") as handle:
+                handle.write(regression_checklist(comments))
         return 0
 
     print(f"Found {len(comments)} Droid comment(s) on PR #{args.pr}.\n")
@@ -134,7 +184,18 @@ def main() -> int:
         for check in suggested_checks(comment):
             print(f"   - {check}")
         print()
+    if args.markdown_out:
+        ensure_parent_dir(args.markdown_out)
+        with open(args.markdown_out, "w", encoding="utf-8") as handle:
+            handle.write(regression_checklist(comments))
+        print(f"Wrote regression checklist to {args.markdown_out}.")
     return 0
+
+
+def ensure_parent_dir(path: str) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
 
 
 if __name__ == "__main__":

--- a/scripts/droid_feedback_harness.py
+++ b/scripts/droid_feedback_harness.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Summarize active Droid feedback and suggest local regression checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class DroidComment:
+    kind: str
+    url: str
+    path: str
+    line: int | None
+    body: str
+
+
+def gh_json(args: list[str]) -> object:
+    completed = subprocess.run(
+        ["gh", *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def collect_comments(pr_number: str) -> list[DroidComment]:
+    review_comments = gh_json(
+        [
+            "api",
+            f"repos/writer/cerebro/pulls/{pr_number}/comments",
+            "--paginate",
+        ]
+    )
+    issue_comments = gh_json(
+        [
+            "api",
+            f"repos/writer/cerebro/issues/{pr_number}/comments",
+            "--paginate",
+        ]
+    )
+    comments: list[DroidComment] = []
+    for item in review_comments:
+        if not is_droid(item):
+            continue
+        comments.append(
+            DroidComment(
+                kind="review",
+                url=item.get("html_url", ""),
+                path=item.get("path", ""),
+                line=item.get("line") or item.get("original_line"),
+                body=item.get("body", ""),
+            )
+        )
+    for item in issue_comments:
+        if not is_droid(item):
+            continue
+        comments.append(
+            DroidComment(
+                kind="summary",
+                url=item.get("html_url", ""),
+                path="",
+                line=None,
+                body=item.get("body", ""),
+            )
+        )
+    return comments
+
+
+def is_droid(item: dict[str, object]) -> bool:
+    user = item.get("user") or {}
+    if not isinstance(user, dict):
+        return False
+    return str(user.get("login", "")).lower() == "factory-droid[bot]"
+
+
+def suggested_checks(comment: DroidComment) -> list[str]:
+    text = f"{comment.path}\n{comment.body}".lower()
+    checks: list[str] = []
+    if "io.readall" in text or "limitreader" in text or "body read" in text:
+        checks.append("make droid-review-preflight")
+        checks.append("go test ./tools/droidreview/...")
+        checks.append("go test ./tools/archtests -run '^TestProductionBodyReadsAreBounded$' -count=1 -v")
+    if "cypher" in text or "graphagent" in text or "tenant" in text:
+        checks.append("go test ./internal/graphagent -count=1")
+    if "sourcehttp" in text or "ssrf" in text or "dns" in text:
+        checks.append("go test ./tools/archtests -run '^TestSourcesUseSharedHTTPSafety$' -count=1 -v")
+    if "candidate" in text or "compare-and-swap" in text or "atomic" in text:
+        checks.append("go test ./internal/findings -count=1")
+    if not checks:
+        checks.append("add a focused regression test near the changed package")
+    return checks
+
+
+def first_sentence(markdown: str) -> str:
+    for line in markdown.splitlines():
+        stripped = line.strip(" #*>-")
+        if stripped:
+            return stripped[:180]
+    return "(empty comment)"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pr", help="pull request number")
+    args = parser.parse_args()
+
+    try:
+        comments = collect_comments(args.pr)
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr, file=sys.stderr)
+        return exc.returncode
+
+    if not comments:
+        print(f"No Droid comments found on PR #{args.pr}.")
+        return 0
+
+    print(f"Found {len(comments)} Droid comment(s) on PR #{args.pr}.\n")
+    for index, comment in enumerate(comments, start=1):
+        location = comment.path
+        if comment.line:
+            location = f"{location}:{comment.line}"
+        location = location or comment.kind
+        print(f"{index}. {location}")
+        print(f"   {first_sentence(comment.body)}")
+        print(f"   {comment.url}")
+        print("   Suggested local checks:")
+        for check in suggested_checks(comment):
+            print(f"   - {check}")
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/archtests/bootstrap_contract_guardrails_test.go
+++ b/tools/archtests/bootstrap_contract_guardrails_test.go
@@ -6,8 +6,11 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/writer/cerebro/tools/droidreview/bodyread"
 )
 
 func TestOpenAPIContractDescribesCurrentBootstrapSurface(t *testing.T) {
@@ -162,41 +165,23 @@ func TestProductionBodyReadsAreBounded(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		if !bytes.Contains(body, []byte("io.ReadAll(")) {
+			return nil
+		}
 		rel := shortPath(root, path)
-		lines := strings.Split(string(body), "\n")
-		for i, line := range lines {
-			if !strings.Contains(line, "io.ReadAll(") {
-				continue
+		findings, err := bodyread.FindUnboundedReadAll(rel, body)
+		if err != nil {
+			return err
+		}
+		if len(findings) > 0 {
+			var lines []string
+			for _, finding := range findings {
+				lines = append(lines, finding.File+":"+strconv.Itoa(finding.Line))
 			}
-			if boundedReadAllContext(lines, i) {
-				continue
-			}
-			t.Fatalf("%s:%d uses io.ReadAll without a nearby explicit io.LimitReader", rel, i+1)
+			t.Fatalf("production io.ReadAll calls must use io.LimitReader; unbounded reads: %s", strings.Join(lines, ", "))
 		}
 		return nil
 	}); err != nil {
 		t.Fatalf("scan bounded body reads: %v", err)
 	}
-}
-
-func boundedReadAllContext(lines []string, index int) bool {
-	start := index - 4
-	if start < 0 {
-		start = 0
-	}
-	end := index + 1
-	if end >= len(lines) {
-		end = len(lines) - 1
-	}
-	readLine := strings.TrimSpace(lines[index])
-	if strings.Contains(readLine, "io.ReadAll(io.LimitReader(") {
-		return true
-	}
-	for _, line := range lines[start : end+1] {
-		trimmed := strings.TrimSpace(line)
-		if strings.Contains(trimmed, ":= io.LimitReader(") || strings.Contains(trimmed, "= io.LimitReader(") {
-			return true
-		}
-	}
-	return false
 }

--- a/tools/droidreview/bodyread/bodyread.go
+++ b/tools/droidreview/bodyread/bodyread.go
@@ -1,0 +1,356 @@
+package bodyread
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+)
+
+type Finding struct {
+	File string
+	Line int
+}
+
+func FindUnboundedReadAll(filePath string, source []byte) ([]Finding, error) {
+	if !bytes.Contains(source, []byte("io.ReadAll(")) {
+		return nil, nil
+	}
+	if strings.HasSuffix(filePath, "_test.go") || !strings.HasSuffix(filePath, ".go") {
+		return nil, nil
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filePath, source, 0)
+	if err != nil {
+		return nil, err
+	}
+	var lines []int
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		collectUnboundedReadAllLines(fset, fn.Body.List, map[*ast.Object]bool{}, &lines)
+	}
+	findings := make([]Finding, 0, len(lines))
+	for _, line := range lines {
+		findings = append(findings, Finding{File: filepath.ToSlash(filePath), Line: line})
+	}
+	return findings, nil
+}
+
+func collectUnboundedReadAllLines(fset *token.FileSet, statements []ast.Stmt, limitedVars map[*ast.Object]bool, lines *[]int) {
+	for _, statement := range statements {
+		switch stmt := statement.(type) {
+		case *ast.AssignStmt:
+			recordUnboundedReadAllInNode(fset, stmt, limitedVars, lines)
+			recordLimitedAssignments(stmt.Lhs, stmt.Rhs, limitedVars)
+		case *ast.DeclStmt:
+			recordUnboundedReadAllInNode(fset, stmt, limitedVars, lines)
+			recordLimitedValueSpecs(stmt, limitedVars)
+		case *ast.BlockStmt:
+			blockVars := cloneLimitedVars(limitedVars)
+			collectUnboundedReadAllLines(fset, stmt.List, blockVars, lines)
+			mergeLimitedVars(limitedVars, blockVars)
+		case *ast.IfStmt:
+			ifVars := cloneLimitedVars(limitedVars)
+			if stmt.Init != nil {
+				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, ifVars, lines)
+			}
+			recordUnboundedReadAllInNode(fset, stmt.Cond, ifVars, lines)
+			thenVars := cloneLimitedVars(ifVars)
+			collectUnboundedReadAllLines(fset, stmt.Body.List, thenVars, lines)
+			elseVars := cloneLimitedVars(ifVars)
+			if stmt.Else != nil {
+				collectUnboundedReadAllInElse(fset, stmt.Else, elseVars, lines)
+			}
+			var branches []map[*ast.Object]bool
+			if statementsMayContinue(stmt.Body.List) {
+				branches = append(branches, thenVars)
+			}
+			if stmt.Else == nil || statementMayContinue(stmt.Else) {
+				branches = append(branches, elseVars)
+			}
+			mergeLimitedVars(limitedVars, branches...)
+		case *ast.ForStmt:
+			loopVars := cloneLimitedVars(limitedVars)
+			if stmt.Init != nil {
+				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, loopVars, lines)
+			}
+			recordUnboundedReadAllInNode(fset, stmt.Cond, loopVars, lines)
+			if stmt.Post != nil {
+				recordUnboundedReadAllInNode(fset, stmt.Post, loopVars, lines)
+			}
+			bodyVars := cloneLimitedVars(loopVars)
+			collectUnboundedReadAllLines(fset, stmt.Body.List, bodyVars, lines)
+			mergeLimitedVars(limitedVars, loopVars, bodyVars)
+		case *ast.RangeStmt:
+			recordUnboundedReadAllInNode(fset, stmt.X, limitedVars, lines)
+			bodyVars := cloneLimitedVars(limitedVars)
+			collectUnboundedReadAllLines(fset, stmt.Body.List, bodyVars, lines)
+			mergeLimitedVars(limitedVars, bodyVars)
+		case *ast.SwitchStmt:
+			switchVars := cloneLimitedVars(limitedVars)
+			if stmt.Init != nil {
+				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, switchVars, lines)
+			}
+			recordUnboundedReadAllInNode(fset, stmt.Tag, switchVars, lines)
+			caseVars, hasDefault := collectUnboundedReadAllInCaseClauses(fset, stmt.Body, switchVars, lines)
+			if !hasDefault {
+				caseVars = append(caseVars, switchVars)
+			}
+			mergeLimitedVars(limitedVars, caseVars...)
+		case *ast.TypeSwitchStmt:
+			switchVars := cloneLimitedVars(limitedVars)
+			if stmt.Init != nil {
+				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, switchVars, lines)
+			}
+			recordUnboundedReadAllInNode(fset, stmt.Assign, switchVars, lines)
+			caseVars, hasDefault := collectUnboundedReadAllInCaseClauses(fset, stmt.Body, switchVars, lines)
+			if !hasDefault {
+				caseVars = append(caseVars, switchVars)
+			}
+			mergeLimitedVars(limitedVars, caseVars...)
+		case *ast.SelectStmt:
+			commVars, hasDefault := collectUnboundedReadAllInCommClauses(fset, stmt.Body, limitedVars, lines)
+			if !hasDefault {
+				commVars = append(commVars, limitedVars)
+			}
+			mergeLimitedVars(limitedVars, commVars...)
+		default:
+			recordUnboundedReadAllInNode(fset, stmt, limitedVars, lines)
+		}
+	}
+}
+
+func collectUnboundedReadAllInCaseClauses(fset *token.FileSet, body *ast.BlockStmt, limitedVars map[*ast.Object]bool, lines *[]int) ([]map[*ast.Object]bool, bool) {
+	if body == nil {
+		return nil, false
+	}
+	var branches []map[*ast.Object]bool
+	hasDefault := false
+	var fallthroughVars map[*ast.Object]bool
+	for _, statement := range body.List {
+		clause, ok := statement.(*ast.CaseClause)
+		if !ok {
+			recordUnboundedReadAllInNode(fset, statement, limitedVars, lines)
+			continue
+		}
+		if len(clause.List) == 0 {
+			hasDefault = true
+		}
+		caseVars := cloneLimitedVars(limitedVars)
+		if fallthroughVars != nil {
+			mergeLimitedVars(caseVars, caseVars, fallthroughVars)
+			fallthroughVars = nil
+		}
+		for _, expr := range clause.List {
+			recordUnboundedReadAllInNode(fset, expr, caseVars, lines)
+		}
+		collectUnboundedReadAllLines(fset, clause.Body, caseVars, lines)
+		if statementsFallThrough(clause.Body) {
+			fallthroughVars = caseVars
+			continue
+		}
+		if statementsMayContinue(clause.Body) {
+			branches = append(branches, caseVars)
+		}
+	}
+	return branches, hasDefault
+}
+
+func collectUnboundedReadAllInCommClauses(fset *token.FileSet, body *ast.BlockStmt, limitedVars map[*ast.Object]bool, lines *[]int) ([]map[*ast.Object]bool, bool) {
+	if body == nil {
+		return nil, false
+	}
+	var branches []map[*ast.Object]bool
+	hasDefault := false
+	for _, statement := range body.List {
+		clause, ok := statement.(*ast.CommClause)
+		if !ok {
+			recordUnboundedReadAllInNode(fset, statement, limitedVars, lines)
+			continue
+		}
+		if clause.Comm == nil {
+			hasDefault = true
+		}
+		commVars := cloneLimitedVars(limitedVars)
+		if clause.Comm != nil {
+			collectUnboundedReadAllLines(fset, []ast.Stmt{clause.Comm}, commVars, lines)
+		}
+		collectUnboundedReadAllLines(fset, clause.Body, commVars, lines)
+		if statementsMayContinue(clause.Body) {
+			branches = append(branches, commVars)
+		}
+	}
+	return branches, hasDefault
+}
+
+func collectUnboundedReadAllInElse(fset *token.FileSet, statement ast.Stmt, limitedVars map[*ast.Object]bool, lines *[]int) {
+	switch stmt := statement.(type) {
+	case *ast.BlockStmt:
+		collectUnboundedReadAllLines(fset, stmt.List, limitedVars, lines)
+	case *ast.IfStmt:
+		collectUnboundedReadAllLines(fset, []ast.Stmt{stmt}, limitedVars, lines)
+	default:
+		recordUnboundedReadAllInNode(fset, stmt, limitedVars, lines)
+	}
+}
+
+func recordUnboundedReadAllInNode(fset *token.FileSet, node ast.Node, limitedVars map[*ast.Object]bool, lines *[]int) {
+	if node == nil {
+		return
+	}
+	ast.Inspect(node, func(node ast.Node) bool {
+		if fn, ok := node.(*ast.FuncLit); ok {
+			collectUnboundedReadAllLines(fset, fn.Body.List, limitedVars, lines)
+			return false
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !isSelectorCall(call.Fun, "io", "ReadAll") {
+			return true
+		}
+		if !readAllCallIsBounded(call, limitedVars) {
+			*lines = append(*lines, fset.Position(call.Pos()).Line)
+		}
+		return true
+	})
+}
+
+func recordLimitedAssignments(lhs []ast.Expr, rhs []ast.Expr, limitedVars map[*ast.Object]bool) {
+	for index, left := range lhs {
+		ident, ok := left.(*ast.Ident)
+		if !ok || ident.Obj == nil {
+			continue
+		}
+		rhsIndex := index
+		if len(rhs) == 1 {
+			rhsIndex = 0
+		}
+		limitedVars[ident.Obj] = rhsIndex < len(rhs) && isIOLimitReaderCall(rhs[rhsIndex])
+	}
+}
+
+func recordLimitedValueSpecs(statement *ast.DeclStmt, limitedVars map[*ast.Object]bool) {
+	decl, ok := statement.Decl.(*ast.GenDecl)
+	if !ok {
+		return
+	}
+	for _, spec := range decl.Specs {
+		valueSpec, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		for index, name := range valueSpec.Names {
+			if name.Obj == nil {
+				continue
+			}
+			valueIndex := index
+			if len(valueSpec.Values) == 1 {
+				valueIndex = 0
+			}
+			limitedVars[name.Obj] = valueIndex < len(valueSpec.Values) && isIOLimitReaderCall(valueSpec.Values[valueIndex])
+		}
+	}
+}
+
+func cloneLimitedVars(values map[*ast.Object]bool) map[*ast.Object]bool {
+	clone := make(map[*ast.Object]bool, len(values))
+	for key, value := range values {
+		clone[key] = value
+	}
+	return clone
+}
+
+func statementsMayContinue(statements []ast.Stmt) bool {
+	if len(statements) == 0 {
+		return true
+	}
+	return statementMayContinue(statements[len(statements)-1])
+}
+
+func statementsFallThrough(statements []ast.Stmt) bool {
+	if len(statements) == 0 {
+		return false
+	}
+	branch, ok := statements[len(statements)-1].(*ast.BranchStmt)
+	return ok && branch.Tok == token.FALLTHROUGH
+}
+
+func statementMayContinue(statement ast.Stmt) bool {
+	switch stmt := statement.(type) {
+	case *ast.ReturnStmt:
+		return false
+	case *ast.BranchStmt:
+		return true
+	case *ast.BlockStmt:
+		return statementsMayContinue(stmt.List)
+	case *ast.IfStmt:
+		return stmt.Else == nil || statementMayContinue(stmt.Body) || statementMayContinue(stmt.Else)
+	default:
+		return true
+	}
+}
+
+func mergeLimitedVars(target map[*ast.Object]bool, branches ...map[*ast.Object]bool) {
+	if len(branches) == 0 {
+		return
+	}
+	keys := map[*ast.Object]struct{}{}
+	for key := range target {
+		keys[key] = struct{}{}
+	}
+	for _, branch := range branches {
+		for key := range branch {
+			keys[key] = struct{}{}
+		}
+	}
+	for key := range keys {
+		limited := true
+		for _, branch := range branches {
+			limited = limited && branch[key]
+		}
+		target[key] = limited
+	}
+}
+
+func readAllCallIsBounded(call *ast.CallExpr, limitedVars map[*ast.Object]bool) bool {
+	if len(call.Args) == 0 {
+		return false
+	}
+	arg := unwrapParen(call.Args[0])
+	if isIOLimitReaderCall(arg) {
+		return true
+	}
+	ident, ok := arg.(*ast.Ident)
+	if !ok || ident.Obj == nil {
+		return false
+	}
+	return limitedVars[ident.Obj]
+}
+
+func isIOLimitReaderCall(expr ast.Expr) bool {
+	call, ok := unwrapParen(expr).(*ast.CallExpr)
+	return ok && isSelectorCall(call.Fun, "io", "LimitReader")
+}
+
+func isSelectorCall(expr ast.Expr, qualifier string, name string) bool {
+	selector, ok := unwrapParen(expr).(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != name {
+		return false
+	}
+	ident, ok := selector.X.(*ast.Ident)
+	return ok && ident.Name == qualifier
+}
+
+func unwrapParen(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
+	}
+}

--- a/tools/droidreview/bodyread/bodyread.go
+++ b/tools/droidreview/bodyread/bodyread.go
@@ -76,6 +76,8 @@ func collectUnboundedReadAllLines(fset *token.FileSet, statements []ast.Stmt, li
 			blockVars := cloneLimitedVars(limitedVars)
 			collectUnboundedReadAllLines(fset, stmt.List, blockVars, ioImports, lines)
 			mergeLimitedVars(limitedVars, blockVars)
+		case *ast.LabeledStmt:
+			collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Stmt}, limitedVars, ioImports, lines)
 		case *ast.IfStmt:
 			ifVars := cloneLimitedVars(limitedVars)
 			if stmt.Init != nil {
@@ -226,12 +228,20 @@ func recordUnboundedReadAllInNode(fset *token.FileSet, node ast.Node, limitedVar
 		return
 	}
 	ast.Inspect(node, func(node ast.Node) bool {
-		if fn, ok := node.(*ast.FuncLit); ok {
-			collectUnboundedReadAllLines(fset, fn.Body.List, limitedVars, ioImports, lines)
+		if _, ok := node.(*ast.FuncLit); ok {
 			return false
 		}
 		call, ok := node.(*ast.CallExpr)
-		if !ok || !isSelectorCall(call.Fun, ioImports, "ReadAll") {
+		if !ok {
+			return true
+		}
+		if fn, ok := unwrapParen(call.Fun).(*ast.FuncLit); ok {
+			funcVars := cloneLimitedVars(limitedVars)
+			collectUnboundedReadAllLines(fset, fn.Body.List, funcVars, ioImports, lines)
+			mergeLimitedVars(limitedVars, funcVars)
+			return false
+		}
+		if !isSelectorCall(call.Fun, ioImports, "ReadAll") {
 			return true
 		}
 		if !readAllCallIsBounded(call, limitedVars, ioImports) {

--- a/tools/droidreview/bodyread/bodyread.go
+++ b/tools/droidreview/bodyread/bodyread.go
@@ -26,13 +26,17 @@ func FindUnboundedReadAll(filePath string, source []byte) ([]Finding, error) {
 	if err != nil {
 		return nil, err
 	}
+	ioImports := ioImportNames(file)
+	if len(ioImports) == 0 {
+		return nil, nil
+	}
 	var lines []int
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
 			continue
 		}
-		collectUnboundedReadAllLines(fset, fn.Body.List, map[*ast.Object]bool{}, &lines)
+		collectUnboundedReadAllLines(fset, fn.Body.List, map[*ast.Object]bool{}, ioImports, &lines)
 	}
 	findings := make([]Finding, 0, len(lines))
 	for _, line := range lines {
@@ -41,30 +45,48 @@ func FindUnboundedReadAll(filePath string, source []byte) ([]Finding, error) {
 	return findings, nil
 }
 
-func collectUnboundedReadAllLines(fset *token.FileSet, statements []ast.Stmt, limitedVars map[*ast.Object]bool, lines *[]int) {
+func ioImportNames(file *ast.File) map[string]struct{} {
+	names := map[string]struct{}{}
+	for _, importSpec := range file.Imports {
+		if strings.Trim(importSpec.Path.Value, `"`) != "io" {
+			continue
+		}
+		name := "io"
+		if importSpec.Name != nil {
+			if importSpec.Name.Name == "." || importSpec.Name.Name == "_" {
+				continue
+			}
+			name = importSpec.Name.Name
+		}
+		names[name] = struct{}{}
+	}
+	return names
+}
+
+func collectUnboundedReadAllLines(fset *token.FileSet, statements []ast.Stmt, limitedVars map[*ast.Object]bool, ioImports map[string]struct{}, lines *[]int) {
 	for _, statement := range statements {
 		switch stmt := statement.(type) {
 		case *ast.AssignStmt:
-			recordUnboundedReadAllInNode(fset, stmt, limitedVars, lines)
-			recordLimitedAssignments(stmt.Lhs, stmt.Rhs, limitedVars)
+			recordUnboundedReadAllInNode(fset, stmt, limitedVars, ioImports, lines)
+			recordLimitedAssignments(stmt.Lhs, stmt.Rhs, limitedVars, ioImports)
 		case *ast.DeclStmt:
-			recordUnboundedReadAllInNode(fset, stmt, limitedVars, lines)
-			recordLimitedValueSpecs(stmt, limitedVars)
+			recordUnboundedReadAllInNode(fset, stmt, limitedVars, ioImports, lines)
+			recordLimitedValueSpecs(stmt, limitedVars, ioImports)
 		case *ast.BlockStmt:
 			blockVars := cloneLimitedVars(limitedVars)
-			collectUnboundedReadAllLines(fset, stmt.List, blockVars, lines)
+			collectUnboundedReadAllLines(fset, stmt.List, blockVars, ioImports, lines)
 			mergeLimitedVars(limitedVars, blockVars)
 		case *ast.IfStmt:
 			ifVars := cloneLimitedVars(limitedVars)
 			if stmt.Init != nil {
-				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, ifVars, lines)
+				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, ifVars, ioImports, lines)
 			}
-			recordUnboundedReadAllInNode(fset, stmt.Cond, ifVars, lines)
+			recordUnboundedReadAllInNode(fset, stmt.Cond, ifVars, ioImports, lines)
 			thenVars := cloneLimitedVars(ifVars)
-			collectUnboundedReadAllLines(fset, stmt.Body.List, thenVars, lines)
+			collectUnboundedReadAllLines(fset, stmt.Body.List, thenVars, ioImports, lines)
 			elseVars := cloneLimitedVars(ifVars)
 			if stmt.Else != nil {
-				collectUnboundedReadAllInElse(fset, stmt.Else, elseVars, lines)
+				collectUnboundedReadAllInElse(fset, stmt.Else, elseVars, ioImports, lines)
 			}
 			var branches []map[*ast.Object]bool
 			if statementsMayContinue(stmt.Body.List) {
@@ -77,27 +99,27 @@ func collectUnboundedReadAllLines(fset *token.FileSet, statements []ast.Stmt, li
 		case *ast.ForStmt:
 			loopVars := cloneLimitedVars(limitedVars)
 			if stmt.Init != nil {
-				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, loopVars, lines)
+				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, loopVars, ioImports, lines)
 			}
-			recordUnboundedReadAllInNode(fset, stmt.Cond, loopVars, lines)
+			recordUnboundedReadAllInNode(fset, stmt.Cond, loopVars, ioImports, lines)
 			if stmt.Post != nil {
-				recordUnboundedReadAllInNode(fset, stmt.Post, loopVars, lines)
+				recordUnboundedReadAllInNode(fset, stmt.Post, loopVars, ioImports, lines)
 			}
 			bodyVars := cloneLimitedVars(loopVars)
-			collectUnboundedReadAllLines(fset, stmt.Body.List, bodyVars, lines)
+			collectUnboundedReadAllLines(fset, stmt.Body.List, bodyVars, ioImports, lines)
 			mergeLimitedVars(limitedVars, loopVars, bodyVars)
 		case *ast.RangeStmt:
-			recordUnboundedReadAllInNode(fset, stmt.X, limitedVars, lines)
+			recordUnboundedReadAllInNode(fset, stmt.X, limitedVars, ioImports, lines)
 			bodyVars := cloneLimitedVars(limitedVars)
-			collectUnboundedReadAllLines(fset, stmt.Body.List, bodyVars, lines)
+			collectUnboundedReadAllLines(fset, stmt.Body.List, bodyVars, ioImports, lines)
 			mergeLimitedVars(limitedVars, bodyVars)
 		case *ast.SwitchStmt:
 			switchVars := cloneLimitedVars(limitedVars)
 			if stmt.Init != nil {
-				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, switchVars, lines)
+				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, switchVars, ioImports, lines)
 			}
-			recordUnboundedReadAllInNode(fset, stmt.Tag, switchVars, lines)
-			caseVars, hasDefault := collectUnboundedReadAllInCaseClauses(fset, stmt.Body, switchVars, lines)
+			recordUnboundedReadAllInNode(fset, stmt.Tag, switchVars, ioImports, lines)
+			caseVars, hasDefault := collectUnboundedReadAllInCaseClauses(fset, stmt.Body, switchVars, ioImports, lines)
 			if !hasDefault {
 				caseVars = append(caseVars, switchVars)
 			}
@@ -105,27 +127,27 @@ func collectUnboundedReadAllLines(fset *token.FileSet, statements []ast.Stmt, li
 		case *ast.TypeSwitchStmt:
 			switchVars := cloneLimitedVars(limitedVars)
 			if stmt.Init != nil {
-				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, switchVars, lines)
+				collectUnboundedReadAllLines(fset, []ast.Stmt{stmt.Init}, switchVars, ioImports, lines)
 			}
-			recordUnboundedReadAllInNode(fset, stmt.Assign, switchVars, lines)
-			caseVars, hasDefault := collectUnboundedReadAllInCaseClauses(fset, stmt.Body, switchVars, lines)
+			recordUnboundedReadAllInNode(fset, stmt.Assign, switchVars, ioImports, lines)
+			caseVars, hasDefault := collectUnboundedReadAllInCaseClauses(fset, stmt.Body, switchVars, ioImports, lines)
 			if !hasDefault {
 				caseVars = append(caseVars, switchVars)
 			}
 			mergeLimitedVars(limitedVars, caseVars...)
 		case *ast.SelectStmt:
-			commVars, hasDefault := collectUnboundedReadAllInCommClauses(fset, stmt.Body, limitedVars, lines)
+			commVars, hasDefault := collectUnboundedReadAllInCommClauses(fset, stmt.Body, limitedVars, ioImports, lines)
 			if !hasDefault {
 				commVars = append(commVars, limitedVars)
 			}
 			mergeLimitedVars(limitedVars, commVars...)
 		default:
-			recordUnboundedReadAllInNode(fset, stmt, limitedVars, lines)
+			recordUnboundedReadAllInNode(fset, stmt, limitedVars, ioImports, lines)
 		}
 	}
 }
 
-func collectUnboundedReadAllInCaseClauses(fset *token.FileSet, body *ast.BlockStmt, limitedVars map[*ast.Object]bool, lines *[]int) ([]map[*ast.Object]bool, bool) {
+func collectUnboundedReadAllInCaseClauses(fset *token.FileSet, body *ast.BlockStmt, limitedVars map[*ast.Object]bool, ioImports map[string]struct{}, lines *[]int) ([]map[*ast.Object]bool, bool) {
 	if body == nil {
 		return nil, false
 	}
@@ -135,7 +157,7 @@ func collectUnboundedReadAllInCaseClauses(fset *token.FileSet, body *ast.BlockSt
 	for _, statement := range body.List {
 		clause, ok := statement.(*ast.CaseClause)
 		if !ok {
-			recordUnboundedReadAllInNode(fset, statement, limitedVars, lines)
+			recordUnboundedReadAllInNode(fset, statement, limitedVars, ioImports, lines)
 			continue
 		}
 		if len(clause.List) == 0 {
@@ -147,9 +169,9 @@ func collectUnboundedReadAllInCaseClauses(fset *token.FileSet, body *ast.BlockSt
 			fallthroughVars = nil
 		}
 		for _, expr := range clause.List {
-			recordUnboundedReadAllInNode(fset, expr, caseVars, lines)
+			recordUnboundedReadAllInNode(fset, expr, caseVars, ioImports, lines)
 		}
-		collectUnboundedReadAllLines(fset, clause.Body, caseVars, lines)
+		collectUnboundedReadAllLines(fset, clause.Body, caseVars, ioImports, lines)
 		if statementsFallThrough(clause.Body) {
 			fallthroughVars = caseVars
 			continue
@@ -161,7 +183,7 @@ func collectUnboundedReadAllInCaseClauses(fset *token.FileSet, body *ast.BlockSt
 	return branches, hasDefault
 }
 
-func collectUnboundedReadAllInCommClauses(fset *token.FileSet, body *ast.BlockStmt, limitedVars map[*ast.Object]bool, lines *[]int) ([]map[*ast.Object]bool, bool) {
+func collectUnboundedReadAllInCommClauses(fset *token.FileSet, body *ast.BlockStmt, limitedVars map[*ast.Object]bool, ioImports map[string]struct{}, lines *[]int) ([]map[*ast.Object]bool, bool) {
 	if body == nil {
 		return nil, false
 	}
@@ -170,7 +192,7 @@ func collectUnboundedReadAllInCommClauses(fset *token.FileSet, body *ast.BlockSt
 	for _, statement := range body.List {
 		clause, ok := statement.(*ast.CommClause)
 		if !ok {
-			recordUnboundedReadAllInNode(fset, statement, limitedVars, lines)
+			recordUnboundedReadAllInNode(fset, statement, limitedVars, ioImports, lines)
 			continue
 		}
 		if clause.Comm == nil {
@@ -178,9 +200,9 @@ func collectUnboundedReadAllInCommClauses(fset *token.FileSet, body *ast.BlockSt
 		}
 		commVars := cloneLimitedVars(limitedVars)
 		if clause.Comm != nil {
-			collectUnboundedReadAllLines(fset, []ast.Stmt{clause.Comm}, commVars, lines)
+			collectUnboundedReadAllLines(fset, []ast.Stmt{clause.Comm}, commVars, ioImports, lines)
 		}
-		collectUnboundedReadAllLines(fset, clause.Body, commVars, lines)
+		collectUnboundedReadAllLines(fset, clause.Body, commVars, ioImports, lines)
 		if statementsMayContinue(clause.Body) {
 			branches = append(branches, commVars)
 		}
@@ -188,38 +210,38 @@ func collectUnboundedReadAllInCommClauses(fset *token.FileSet, body *ast.BlockSt
 	return branches, hasDefault
 }
 
-func collectUnboundedReadAllInElse(fset *token.FileSet, statement ast.Stmt, limitedVars map[*ast.Object]bool, lines *[]int) {
+func collectUnboundedReadAllInElse(fset *token.FileSet, statement ast.Stmt, limitedVars map[*ast.Object]bool, ioImports map[string]struct{}, lines *[]int) {
 	switch stmt := statement.(type) {
 	case *ast.BlockStmt:
-		collectUnboundedReadAllLines(fset, stmt.List, limitedVars, lines)
+		collectUnboundedReadAllLines(fset, stmt.List, limitedVars, ioImports, lines)
 	case *ast.IfStmt:
-		collectUnboundedReadAllLines(fset, []ast.Stmt{stmt}, limitedVars, lines)
+		collectUnboundedReadAllLines(fset, []ast.Stmt{stmt}, limitedVars, ioImports, lines)
 	default:
-		recordUnboundedReadAllInNode(fset, stmt, limitedVars, lines)
+		recordUnboundedReadAllInNode(fset, stmt, limitedVars, ioImports, lines)
 	}
 }
 
-func recordUnboundedReadAllInNode(fset *token.FileSet, node ast.Node, limitedVars map[*ast.Object]bool, lines *[]int) {
+func recordUnboundedReadAllInNode(fset *token.FileSet, node ast.Node, limitedVars map[*ast.Object]bool, ioImports map[string]struct{}, lines *[]int) {
 	if node == nil {
 		return
 	}
 	ast.Inspect(node, func(node ast.Node) bool {
 		if fn, ok := node.(*ast.FuncLit); ok {
-			collectUnboundedReadAllLines(fset, fn.Body.List, limitedVars, lines)
+			collectUnboundedReadAllLines(fset, fn.Body.List, limitedVars, ioImports, lines)
 			return false
 		}
 		call, ok := node.(*ast.CallExpr)
-		if !ok || !isSelectorCall(call.Fun, "io", "ReadAll") {
+		if !ok || !isSelectorCall(call.Fun, ioImports, "ReadAll") {
 			return true
 		}
-		if !readAllCallIsBounded(call, limitedVars) {
+		if !readAllCallIsBounded(call, limitedVars, ioImports) {
 			*lines = append(*lines, fset.Position(call.Pos()).Line)
 		}
 		return true
 	})
 }
 
-func recordLimitedAssignments(lhs []ast.Expr, rhs []ast.Expr, limitedVars map[*ast.Object]bool) {
+func recordLimitedAssignments(lhs []ast.Expr, rhs []ast.Expr, limitedVars map[*ast.Object]bool, ioImports map[string]struct{}) {
 	for index, left := range lhs {
 		ident, ok := left.(*ast.Ident)
 		if !ok || ident.Obj == nil {
@@ -229,11 +251,11 @@ func recordLimitedAssignments(lhs []ast.Expr, rhs []ast.Expr, limitedVars map[*a
 		if len(rhs) == 1 {
 			rhsIndex = 0
 		}
-		limitedVars[ident.Obj] = rhsIndex < len(rhs) && isIOLimitReaderCall(rhs[rhsIndex])
+		limitedVars[ident.Obj] = rhsIndex < len(rhs) && isIOLimitReaderCall(rhs[rhsIndex], ioImports)
 	}
 }
 
-func recordLimitedValueSpecs(statement *ast.DeclStmt, limitedVars map[*ast.Object]bool) {
+func recordLimitedValueSpecs(statement *ast.DeclStmt, limitedVars map[*ast.Object]bool, ioImports map[string]struct{}) {
 	decl, ok := statement.Decl.(*ast.GenDecl)
 	if !ok {
 		return
@@ -251,7 +273,7 @@ func recordLimitedValueSpecs(statement *ast.DeclStmt, limitedVars map[*ast.Objec
 			if len(valueSpec.Values) == 1 {
 				valueIndex = 0
 			}
-			limitedVars[name.Obj] = valueIndex < len(valueSpec.Values) && isIOLimitReaderCall(valueSpec.Values[valueIndex])
+			limitedVars[name.Obj] = valueIndex < len(valueSpec.Values) && isIOLimitReaderCall(valueSpec.Values[valueIndex], ioImports)
 		}
 	}
 }
@@ -316,12 +338,12 @@ func mergeLimitedVars(target map[*ast.Object]bool, branches ...map[*ast.Object]b
 	}
 }
 
-func readAllCallIsBounded(call *ast.CallExpr, limitedVars map[*ast.Object]bool) bool {
+func readAllCallIsBounded(call *ast.CallExpr, limitedVars map[*ast.Object]bool, ioImports map[string]struct{}) bool {
 	if len(call.Args) == 0 {
 		return false
 	}
 	arg := unwrapParen(call.Args[0])
-	if isIOLimitReaderCall(arg) {
+	if isIOLimitReaderCall(arg, ioImports) {
 		return true
 	}
 	ident, ok := arg.(*ast.Ident)
@@ -331,18 +353,22 @@ func readAllCallIsBounded(call *ast.CallExpr, limitedVars map[*ast.Object]bool) 
 	return limitedVars[ident.Obj]
 }
 
-func isIOLimitReaderCall(expr ast.Expr) bool {
+func isIOLimitReaderCall(expr ast.Expr, ioImports map[string]struct{}) bool {
 	call, ok := unwrapParen(expr).(*ast.CallExpr)
-	return ok && isSelectorCall(call.Fun, "io", "LimitReader")
+	return ok && isSelectorCall(call.Fun, ioImports, "LimitReader")
 }
 
-func isSelectorCall(expr ast.Expr, qualifier string, name string) bool {
+func isSelectorCall(expr ast.Expr, ioImports map[string]struct{}, name string) bool {
 	selector, ok := unwrapParen(expr).(*ast.SelectorExpr)
 	if !ok || selector.Sel.Name != name {
 		return false
 	}
 	ident, ok := selector.X.(*ast.Ident)
-	return ok && ident.Name == qualifier
+	if !ok || ident.Obj != nil {
+		return false
+	}
+	_, ok = ioImports[ident.Name]
+	return ok
 }
 
 func unwrapParen(expr ast.Expr) ast.Expr {

--- a/tools/droidreview/bodyread/bodyread_test.go
+++ b/tools/droidreview/bodyread/bodyread_test.go
@@ -202,6 +202,33 @@ func f(resp interface{ Body() io.Reader }) {
 			want: 1,
 		},
 		{
+			name: "non executed function literal is ignored",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	_ = func() {
+		reader = resp.Body()
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 0,
+		},
+		{
+			name: "labeled statement mutation is modeled",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }) {
+	reader := io.LimitReader(resp.Body(), 1024)
+raw:
+	{
+		reader = resp.Body()
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 1,
+		},
+		{
 			name: "loop mutation is conservative",
 			code: `package fixture
 import "io"

--- a/tools/droidreview/bodyread/bodyread_test.go
+++ b/tools/droidreview/bodyread/bodyread_test.go
@@ -31,6 +31,26 @@ func f(resp interface{ Body() io.Reader }) {
 			want: 0,
 		},
 		{
+			name: "aliased io import",
+			code: `package fixture
+import stdio "io"
+func f(resp interface{ Body() stdio.Reader }) {
+	_, _ = stdio.ReadAll(stdio.LimitReader(resp.Body(), 1024))
+}`,
+			want: 0,
+		},
+		{
+			name: "local io value is ignored",
+			code: `package fixture
+type localIO struct{}
+func (localIO) ReadAll(any) ([]byte, error) { return nil, nil }
+func f(body any) {
+	io := localIO{}
+	_, _ = io.ReadAll(body)
+}`,
+			want: 0,
+		},
+		{
 			name: "multiline limit reader",
 			code: `package fixture
 import "io"

--- a/tools/droidreview/bodyread/bodyread_test.go
+++ b/tools/droidreview/bodyread/bodyread_test.go
@@ -1,0 +1,232 @@
+package bodyread
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestFindUnboundedReadAllAdversarialFixtures(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want int
+	}{
+		{
+			name: "direct unbounded read",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }) {
+	_, _ = io.ReadAll(resp.Body())
+}`,
+			want: 1,
+		},
+		{
+			name: "direct limit reader",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }) {
+	_, _ = io.ReadAll(io.LimitReader(resp.Body(), 1024))
+}`,
+			want: 0,
+		},
+		{
+			name: "multiline limit reader",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }) {
+	limited := io.LimitReader(
+		resp.Body(),
+		1024,
+	)
+	_, _ = io.ReadAll(limited)
+}`,
+			want: 0,
+		},
+		{
+			name: "comments and strings are ignored",
+			code: `package fixture
+func f() {
+	_ = "io.ReadAll(resp.Body)"
+	// io.ReadAll(resp.Body)
+}`,
+			want: 0,
+		},
+		{
+			name: "shadowed reader is unsafe",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	{
+		reader := resp.Body()
+		_, _ = io.ReadAll(reader)
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 1,
+		},
+		{
+			name: "if initializer does not leak",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }, ok bool) {
+	if reader := io.LimitReader(resp.Body(), 1024); ok {
+		_, _ = io.ReadAll(reader)
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 1,
+		},
+		{
+			name: "if body reassignment escapes",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }, ok bool) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	if ok {
+		reader = resp.Body()
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 1,
+		},
+		{
+			name: "both if branches keep reader bounded",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }, ok bool) {
+	reader := resp.Body()
+	if ok {
+		reader = io.LimitReader(resp.Body(), 1024)
+	} else {
+		reader = io.LimitReader(resp.Body(), 2048)
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 0,
+		},
+		{
+			name: "bare block reassignment escapes",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	{
+		reader = resp.Body()
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 1,
+		},
+		{
+			name: "switch break continues after switch",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }, n int) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	switch n {
+	case 1:
+		reader = resp.Body()
+		break
+	default:
+		return
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 1,
+		},
+		{
+			name: "switch fallthrough carries state",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }, n int) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	switch n {
+	case 1:
+		reader = resp.Body()
+		fallthrough
+	case 2:
+		_, _ = io.ReadAll(reader)
+	}
+}`,
+			want: 1,
+		},
+		{
+			name: "select case mutation escapes",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }, ch <-chan struct{}) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	select {
+	case <-ch:
+		reader = resp.Body()
+	default:
+		return
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 1,
+		},
+		{
+			name: "immediate function literal mutation is modeled",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	func() {
+		reader = resp.Body()
+	}()
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 1,
+		},
+		{
+			name: "loop mutation is conservative",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }, ok bool) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	for ok {
+		reader = resp.Body()
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 1,
+		},
+		{
+			name: "early return keeps unsafe branch from escaping",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }, ok bool) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	if ok {
+		reader = resp.Body()
+		return
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings, err := FindUnboundedReadAll("fixture.go", []byte(tt.code))
+			if err != nil {
+				t.Fatalf("FindUnboundedReadAll: %v", err)
+			}
+			if len(findings) != tt.want {
+				t.Fatalf("findings = %d (%s), want %d", len(findings), formatFindings(findings), tt.want)
+			}
+		})
+	}
+}
+
+func formatFindings(findings []Finding) string {
+	var parts []string
+	for _, finding := range findings {
+		parts = append(parts, finding.File+":"+strconv.Itoa(finding.Line))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/tools/droidreview/main.go
+++ b/tools/droidreview/main.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -218,20 +222,54 @@ func cypherFindings(file string, body []byte) []checkFinding {
 	if strings.HasSuffix(file, "_test.go") {
 		return nil
 	}
-	upper := bytes.ToUpper(body)
-	markers := []string{"CREATE ", "MERGE ", "DELETE ", "DETACH DELETE", " SET ", "REMOVE ", "LOAD CSV", "CALL DBMS", "CALL APOC"}
 	var findings []checkFinding
-	for _, marker := range markers {
-		if index := bytes.Index(upper, []byte(marker)); index >= 0 {
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, body, 0)
+	if err != nil {
+		return findings
+	}
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		lit, ok := node.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return true
+		}
+		marker := suspiciousCypherToken(value)
+		if marker != "" {
 			findings = append(findings, checkFinding{
 				Rule:    "cypher-safety",
 				File:    file,
-				Line:    lineForIndex(upper, index),
-				Message: fmt.Sprintf("Cypher templates must stay read-only and validator-covered; suspicious token %q found", strings.TrimSpace(marker)),
+				Line:    fset.Position(lit.Pos()).Line,
+				Message: fmt.Sprintf("Cypher templates must stay read-only and validator-covered; suspicious token %q found", marker),
 			})
 		}
-	}
+		return true
+	})
 	return findings
+}
+
+func suspiciousCypherToken(value string) string {
+	upper := strings.ToUpper(value)
+	cypherSignals := []string{"MATCH ", " RETURN ", "\nRETURN ", "WHERE ", "OPTIONAL MATCH", "UNWIND ", " LIMIT "}
+	hasCypherSignal := false
+	for _, signal := range cypherSignals {
+		if strings.Contains(upper, signal) {
+			hasCypherSignal = true
+			break
+		}
+	}
+	if !hasCypherSignal {
+		return ""
+	}
+	for _, marker := range []string{"CREATE ", "MERGE ", "DELETE ", "DETACH DELETE", " SET ", "REMOVE ", "LOAD CSV", "CALL DBMS", "CALL APOC"} {
+		if strings.Contains(upper, marker) {
+			return strings.TrimSpace(marker)
+		}
+	}
+	return ""
 }
 
 func askPostProcessingFindings(file string, body []byte) []checkFinding {

--- a/tools/droidreview/main.go
+++ b/tools/droidreview/main.go
@@ -9,9 +9,28 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/writer/cerebro/tools/droidreview/bodyread"
 )
+
+const opusBugReviewModel = "claude-opus-4-8"
+
+type preflightResult struct {
+	ChangedFiles   []string
+	RunDroidReview bool
+	ReviewModel    string
+	ReviewReason   string
+	Findings       []checkFinding
+	Checks         []string
+}
+
+type checkFinding struct {
+	Rule    string
+	File    string
+	Line    int
+	Message string
+}
 
 func main() {
 	var base string
@@ -22,18 +41,28 @@ func main() {
 	flag.StringVar(&repo, "repo", ".", "repository root")
 	flag.Parse()
 
-	if err := run(base, head, repo); err != nil {
+	started := time.Now()
+	result, err := run(base, head, repo)
+	writeGitHubMetadata(result, time.Since(started), err)
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
-func run(base, head, repo string) error {
+func run(base, head, repo string) (preflightResult, error) {
 	files, err := changedFiles(base, head, repo)
 	if err != nil {
-		return err
+		return preflightResult{RunDroidReview: true, ReviewModel: opusBugReviewModel}, err
 	}
-	var findings []bodyread.Finding
+	result := classifyReview(files)
+	result.Checks = []string{
+		"bounded-body-read",
+		"source-http-safety",
+		"cypher-safety",
+		"ask-post-processing-boundary",
+		"candidate-lifecycle-atomicity",
+	}
 	for _, file := range files {
 		if !strings.HasSuffix(file, ".go") || strings.HasSuffix(file, "_test.go") {
 			continue
@@ -48,25 +77,35 @@ func run(base, head, repo string) error {
 		path := filepath.Join(repo, filepath.FromSlash(file))
 		body, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("read %s: %w", file, err)
+			return result, fmt.Errorf("read %s: %w", file, err)
 		}
 		fileFindings, err := bodyread.FindUnboundedReadAll(file, body)
 		if err != nil {
-			return fmt.Errorf("scan %s: %w", file, err)
+			return result, fmt.Errorf("scan %s: %w", file, err)
 		}
-		findings = append(findings, fileFindings...)
+		for _, finding := range fileFindings {
+			result.Findings = append(result.Findings, checkFinding{
+				Rule:    "bounded-body-read",
+				File:    finding.File,
+				Line:    finding.Line,
+				Message: "io.ReadAll must read from io.LimitReader or be replaced with streaming code",
+			})
+		}
+		result.Findings = append(result.Findings, sourceHTTPFindings(file, body)...)
+		result.Findings = append(result.Findings, cypherFindings(file, body)...)
+		result.Findings = append(result.Findings, askPostProcessingFindings(file, body)...)
+		result.Findings = append(result.Findings, candidateLifecycleFindings(file, body)...)
 	}
-	if len(findings) > 0 {
+	if len(result.Findings) > 0 {
 		var message strings.Builder
-		message.WriteString("Droid review preflight found unbounded io.ReadAll calls:\n")
-		for _, finding := range findings {
-			fmt.Fprintf(&message, "- %s:%d\n", finding.File, finding.Line)
+		message.WriteString("Droid review preflight found invariant violations:\n")
+		for _, finding := range result.Findings {
+			fmt.Fprintf(&message, "- [%s] %s:%d %s\n", finding.Rule, finding.File, finding.Line, finding.Message)
 		}
-		message.WriteString("\nWrap external/body reads in io.LimitReader or stream them instead.\n")
-		return fmt.Errorf("%s", strings.TrimRight(message.String(), "\n"))
+		return result, fmt.Errorf("%s", strings.TrimRight(message.String(), "\n"))
 	}
-	fmt.Printf("Droid review preflight passed for %d changed files.\n", len(files))
-	return nil
+	fmt.Printf("Droid review preflight passed for %d changed files. run_droid_review=%t review_model=%s reason=%q\n", len(files), result.RunDroidReview, result.ReviewModel, result.ReviewReason)
+	return result, nil
 }
 
 func changedFiles(base, head, repo string) ([]string, error) {
@@ -107,4 +146,185 @@ func gitOutput(repo string, args ...string) (string, error) {
 		return "", fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
 	}
 	return stdout.String(), nil
+}
+
+func classifyReview(files []string) preflightResult {
+	result := preflightResult{
+		ChangedFiles:   files,
+		RunDroidReview: false,
+		ReviewModel:    opusBugReviewModel,
+		ReviewReason:   "docs/templates only; fast preflight and CI are sufficient",
+	}
+	for _, file := range files {
+		if requiresBugReview(file) {
+			result.RunDroidReview = true
+			result.ReviewReason = "code, workflow, API, source, or security-sensitive paths changed"
+			break
+		}
+	}
+	return result
+}
+
+func requiresBugReview(file string) bool {
+	switch {
+	case strings.HasSuffix(file, ".go"),
+		file == "go.mod",
+		file == "go.sum",
+		file == "Makefile",
+		strings.HasPrefix(file, ".github/workflows/"),
+		strings.HasPrefix(file, "api/"),
+		strings.HasPrefix(file, "cmd/"),
+		strings.HasPrefix(file, "gen/"),
+		strings.HasPrefix(file, "internal/"),
+		strings.HasPrefix(file, "scripts/"),
+		strings.HasPrefix(file, "sources/"),
+		strings.HasPrefix(file, "tools/"):
+		return true
+	default:
+		return false
+	}
+}
+
+func sourceHTTPFindings(file string, body []byte) []checkFinding {
+	if !strings.HasPrefix(file, "sources/") {
+		return nil
+	}
+	markers := []string{
+		"http.DefaultClient",
+		"&http.Client{",
+		"io.ReadAll(resp.Body)",
+		"io.ReadAll(response.Body)",
+		"func readLimitedBody(",
+		"type safeRoundTripper",
+	}
+	var findings []checkFinding
+	for _, marker := range markers {
+		if index := bytes.Index(body, []byte(marker)); index >= 0 {
+			findings = append(findings, checkFinding{
+				Rule:    "source-http-safety",
+				File:    file,
+				Line:    lineForIndex(body, index),
+				Message: fmt.Sprintf("%s must stay centralized in internal/sourcehttp", marker),
+			})
+		}
+	}
+	return findings
+}
+
+func cypherFindings(file string, body []byte) []checkFinding {
+	if !strings.HasPrefix(file, "internal/graphagent/") && !strings.HasPrefix(file, "internal/graphquery/") {
+		return nil
+	}
+	if strings.HasSuffix(file, "_test.go") {
+		return nil
+	}
+	upper := bytes.ToUpper(body)
+	markers := []string{"CREATE ", "MERGE ", "DELETE ", "DETACH DELETE", " SET ", "REMOVE ", "LOAD CSV", "CALL DBMS", "CALL APOC"}
+	var findings []checkFinding
+	for _, marker := range markers {
+		if index := bytes.Index(upper, []byte(marker)); index >= 0 {
+			findings = append(findings, checkFinding{
+				Rule:    "cypher-safety",
+				File:    file,
+				Line:    lineForIndex(upper, index),
+				Message: fmt.Sprintf("Cypher templates must stay read-only and validator-covered; suspicious token %q found", strings.TrimSpace(marker)),
+			})
+		}
+	}
+	return findings
+}
+
+func askPostProcessingFindings(file string, body []byte) []checkFinding {
+	if file != "internal/graphagent/ask.go" && file != "internal/graphagent/query_plan.go" {
+		return nil
+	}
+	if !bytes.Contains(body, []byte("postProcessAskRows")) {
+		return nil
+	}
+	if bytes.Contains(body, []byte("conversion.Deterministic")) || bytes.Contains(body, []byte(".Deterministic")) {
+		return nil
+	}
+	return []checkFinding{{
+		Rule:    "ask-post-processing-boundary",
+		File:    file,
+		Line:    lineForIndex(body, bytes.Index(body, []byte("postProcessAskRows"))),
+		Message: "Ask post-processing must remain gated to deterministic templates, not LLM fallback rows",
+	}}
+}
+
+func candidateLifecycleFindings(file string, body []byte) []checkFinding {
+	if !strings.HasPrefix(file, "internal/findings/") && !strings.HasPrefix(file, "internal/statestore/") {
+		return nil
+	}
+	if !bytes.Contains(body, []byte("FindingCandidate")) {
+		return nil
+	}
+	hasRead := bytes.Contains(body, []byte("GetFindingCandidate")) || bytes.Contains(body, []byte("ListFindingCandidates"))
+	hasWrite := bytes.Contains(body, []byte("UpdateFindingCandidate")) || bytes.Contains(body, []byte("RejectFindingCandidate"))
+	hasAtomicHint := bytes.Contains(bytes.ToLower(body), []byte("compare-and-swap")) || bytes.Contains(bytes.ToLower(body), []byte("transaction"))
+	if !hasRead || !hasWrite || hasAtomicHint {
+		return nil
+	}
+	return []checkFinding{{
+		Rule:    "candidate-lifecycle-atomicity",
+		File:    file,
+		Line:    lineForIndex(body, bytes.Index(body, []byte("FindingCandidate"))),
+		Message: "candidate lifecycle code that reads and writes candidate state must use store-owned CAS or a transaction",
+	}}
+}
+
+func lineForIndex(body []byte, index int) int {
+	if index < 0 {
+		return 1
+	}
+	return bytes.Count(body[:index], []byte("\n")) + 1
+}
+
+func writeGitHubMetadata(result preflightResult, duration time.Duration, runErr error) {
+	if path := os.Getenv("GITHUB_OUTPUT"); path != "" {
+		_ = appendFile(path, []byte(fmt.Sprintf("run_droid_review=%t\nreview_model=%s\nreview_reason=%s\n", result.RunDroidReview, result.ReviewModel, sanitizeOutput(result.ReviewReason))))
+	}
+	if path := os.Getenv("GITHUB_STEP_SUMMARY"); path != "" {
+		var summary strings.Builder
+		summary.WriteString("\n### Droid Review Decision\n\n")
+		fmt.Fprintf(&summary, "- Changed files: %d\n", len(result.ChangedFiles))
+		fmt.Fprintf(&summary, "- Run Droid model review: `%t`\n", result.RunDroidReview)
+		fmt.Fprintf(&summary, "- Review model: `%s`\n", result.ReviewModel)
+		fmt.Fprintf(&summary, "- Reason: %s\n", result.ReviewReason)
+		fmt.Fprintf(&summary, "- Preflight duration: %.1fs\n", duration.Seconds())
+		if runErr != nil {
+			fmt.Fprintf(&summary, "- Result: failed with %d finding(s)\n", len(result.Findings))
+		} else {
+			summary.WriteString("- Result: passed\n")
+		}
+		if len(result.Checks) > 0 {
+			summary.WriteString("\nChecks:\n")
+			for _, check := range result.Checks {
+				fmt.Fprintf(&summary, "- `%s`\n", check)
+			}
+		}
+		if len(result.Findings) > 0 {
+			summary.WriteString("\nFindings:\n")
+			for _, finding := range result.Findings {
+				fmt.Fprintf(&summary, "- `%s` %s:%d %s\n", finding.Rule, finding.File, finding.Line, finding.Message)
+			}
+		}
+		_ = appendFile(path, []byte(summary.String()))
+	}
+}
+
+func appendFile(path string, body []byte) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.Write(body)
+	return err
+}
+
+func sanitizeOutput(value string) string {
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, "\r", " ")
+	return value
 }

--- a/tools/droidreview/main.go
+++ b/tools/droidreview/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/writer/cerebro/tools/droidreview/bodyread"
+)
+
+func main() {
+	var base string
+	var head string
+	var repo string
+	flag.StringVar(&base, "base", "origin/main", "base git revision for changed-file preflight")
+	flag.StringVar(&head, "head", "HEAD", "head git revision for changed-file preflight")
+	flag.StringVar(&repo, "repo", ".", "repository root")
+	flag.Parse()
+
+	if err := run(base, head, repo); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(base, head, repo string) error {
+	files, err := changedFiles(base, head, repo)
+	if err != nil {
+		return err
+	}
+	var findings []bodyread.Finding
+	for _, file := range files {
+		if !strings.HasSuffix(file, ".go") || strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(file, "vendor/"),
+			strings.HasPrefix(file, "gen/"),
+			strings.HasPrefix(file, "sdk/"),
+			strings.Contains(file, "/testdata/"):
+			continue
+		}
+		path := filepath.Join(repo, filepath.FromSlash(file))
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", file, err)
+		}
+		fileFindings, err := bodyread.FindUnboundedReadAll(file, body)
+		if err != nil {
+			return fmt.Errorf("scan %s: %w", file, err)
+		}
+		findings = append(findings, fileFindings...)
+	}
+	if len(findings) > 0 {
+		var message strings.Builder
+		message.WriteString("Droid review preflight found unbounded io.ReadAll calls:\n")
+		for _, finding := range findings {
+			fmt.Fprintf(&message, "- %s:%d\n", finding.File, finding.Line)
+		}
+		message.WriteString("\nWrap external/body reads in io.LimitReader or stream them instead.\n")
+		return fmt.Errorf("%s", strings.TrimRight(message.String(), "\n"))
+	}
+	fmt.Printf("Droid review preflight passed for %d changed files.\n", len(files))
+	return nil
+}
+
+func changedFiles(base, head, repo string) ([]string, error) {
+	files := map[string]struct{}{}
+	for _, args := range [][]string{
+		{"diff", "--name-only", "--diff-filter=ACMR", base + "..." + head},
+		{"diff", "--name-only", "--diff-filter=ACMR"},
+		{"diff", "--cached", "--name-only", "--diff-filter=ACMR"},
+		{"ls-files", "--others", "--exclude-standard"},
+	} {
+		output, err := gitOutput(repo, args...)
+		if err != nil {
+			return nil, err
+		}
+		for _, line := range strings.Split(output, "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				files[filepath.ToSlash(line)] = struct{}{}
+			}
+		}
+	}
+	ordered := make([]string, 0, len(files))
+	for file := range files {
+		ordered = append(ordered, file)
+	}
+	sort.Strings(ordered)
+	return ordered, nil
+}
+
+func gitOutput(repo string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}


### PR DESCRIPTION
## Summary
- Adds a fast, path-aware Droid review preflight that gates whether an Opus model review is needed and emits GitHub summary/output metadata.
- Pins Droid bug/code-review findings to `claude-opus-4-8`, with stale Droid progress/error comments superseded on new pushes.
- Expands deterministic preflight coverage for bounded body reads, source HTTP safety, Cypher safety, Ask post-processing boundaries, and candidate lifecycle atomicity.
- Improves the Droid feedback harness so active comments can produce a markdown regression checklist.

## Known invariants
- Production body reads must be bounded with `io.LimitReader` or streamed.
- Source HTTP safety stays centralized in `internal/sourcehttp`.
- Graph Ask queries remain tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing must not reshape LLM fallback rows.
- Candidate lifecycle updates remain atomic and idempotent.

## Test plan
- `make droid-review-preflight`
- `go test ./tools/droidreview/...`
- `go test ./tools/archtests/...`
- `python3 -m py_compile scripts/droid_feedback_harness.py`
- `make droid-feedback DROID_PR=722 DROID_FEEDBACK_OUT=tmp/droid-feedback-722.md`
- `make verify`