### PR TITLE
Add Droid SAST review context

### DIFF
--- a/.factory/skills/review-guidelines/SKILL.md
+++ b/.factory/skills/review-guidelines/SKILL.md
@@ -11,6 +11,7 @@ Use this context to keep Droid reviews focused and fast.
 
 - Source connectors must use `internal/sourcehttp` for outbound HTTP safety; do not reintroduce connector-local `http.Client`, transport, body-read, SSRF, or DNS-rebinding logic.
 - Production `io.ReadAll` calls must read from `io.LimitReader` or be replaced with streaming code. The fast local check is `make droid-review-preflight`.
+- Review security context should include changed-line SAST output from `make droid-review-sast`; treat it as scanner context, not a substitute for validating exploitability.
 - Graph Ask Cypher must be tenant-scoped, read-only, row-limited, and validated before execution. Prefer deterministic query templates for supported intents.
 - Ask post-processing may only run for deterministic templates; LLM fallback rows must not be reshaped by deterministic Go post-processing.
 - Candidate finding state transitions must be atomic and idempotent. Avoid split read-then-write state changes unless a store method owns the compare-and-swap.

--- a/.github/workflows/droid-create.yml
+++ b/.github/workflows/droid-create.yml
@@ -570,6 +570,7 @@ jobs:
               "- Prefer existing Go, Makefile, source connector, graph, findings, and SDK patterns.",
               "- Add or update tests for behavioral changes and for every review finding that can regress.",
               "- Run focused tests first, then run `make verify` when feasible.",
+              "- Run `make droid-review-sast` for security-sensitive changes and use the report as review context.",
               "- Keep PRs small: split business-logic fixes from static-analyzer/tooling rewrites when possible.",
               "- Preserve known invariants from `.factory/skills/review-guidelines/SKILL.md` and cite the local command that validates them.",
               "- If a validator cannot run because of the GitHub Actions environment, report the exact blocker.",

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -149,6 +149,7 @@ jobs:
           exit 0
       - name: Publish Droid SAST context
         if: always() && steps.sast.outcome != 'skipped'
+        continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -117,12 +117,6 @@ jobs:
             echo "- Status: $([ "${status}" -eq 0 ] && echo success || echo failure)"
           } >> "${GITHUB_STEP_SUMMARY}"
           exit "${status}"
-      - name: Install Semgrep
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 -m pip install --user semgrep
-          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
       - name: Run Droid SAST context
         shell: bash
         env:
@@ -144,7 +138,10 @@ jobs:
               sed 's/^/    /' "${DROID_SAST_OUT}"
             } >> "${GITHUB_STEP_SUMMARY}"
           fi
-          exit "${status}"
+          if [ "${status}" -ne 0 ]; then
+            echo "::warning::Droid SAST context reported blocking findings or failed; keeping Droid review running so findings can be validated."
+          fi
+          exit 0
 
   droid-review:
     needs: droid-review-preflight

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -118,6 +118,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
           exit "${status}"
       - name: Install Semgrep
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -117,6 +117,34 @@ jobs:
             echo "- Status: $([ "${status}" -eq 0 ] && echo success || echo failure)"
           } >> "${GITHUB_STEP_SUMMARY}"
           exit "${status}"
+      - name: Install Semgrep
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --user semgrep
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+      - name: Run Droid SAST context
+        shell: bash
+        env:
+          DROID_REVIEW_BASE: ${{ github.event.pull_request.base.sha }}
+          DROID_REVIEW_HEAD: ${{ github.event.pull_request.head.sha }}
+          DROID_SAST_OUT: tmp/droid-sast-context.md
+          DROID_SAST_POST_COMMENT: true
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set +e
+          make droid-review-sast
+          status="$?"
+          if [ -s "${DROID_SAST_OUT}" ]; then
+            {
+              echo
+              echo "### Droid SAST Context"
+              echo
+              sed 's/^/    /' "${DROID_SAST_OUT}"
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+          exit "${status}"
 
   droid-review:
     needs: droid-review-preflight

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -117,15 +117,19 @@ jobs:
             echo "- Status: $([ "${status}" -eq 0 ] && echo success || echo failure)"
           } >> "${GITHUB_STEP_SUMMARY}"
           exit "${status}"
+      - name: Install Semgrep
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --user 'semgrep==1.136.0'
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
       - name: Run Droid SAST context
+        id: sast
         shell: bash
         env:
           DROID_REVIEW_BASE: ${{ github.event.pull_request.base.sha }}
           DROID_REVIEW_HEAD: ${{ github.event.pull_request.head.sha }}
           DROID_SAST_OUT: tmp/droid-sast-context.md
-          DROID_SAST_POST_COMMENT: true
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set +e
           make droid-review-sast
@@ -142,6 +146,20 @@ jobs:
             echo "::warning::Droid SAST context reported blocking findings or failed; keeping Droid review running so findings can be validated."
           fi
           exit 0
+      - name: Publish Droid SAST context
+        if: always() && steps.sast.outcome != 'skipped'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DROID_SAST_OUT: tmp/droid-sast-context.md
+        run: |
+          set -euo pipefail
+          if [ -s "${DROID_SAST_OUT}" ]; then
+            python3 scripts/droid_sast_context.py --post-existing "${DROID_SAST_OUT}"
+          else
+            echo "No SAST context report to publish."
+          fi
 
   droid-review:
     needs: droid-review-preflight

--- a/.semgrep/cerebro.yml
+++ b/.semgrep/cerebro.yml
@@ -28,9 +28,9 @@ rules:
         - sources/**/*.go
       exclude:
         - "**/*_test.go"
-    patterns:
-      - pattern: io.ReadAll($BODY)
-      - pattern-not: io.ReadAll(io.LimitReader(...))
+    pattern-either:
+      - pattern: io.ReadAll($RESP.Body)
+      - pattern: io.ReadAll($RESP.Body())
 
   - id: cerebro.github-actions.unpinned-action
     languages: [yaml]

--- a/.semgrep/cerebro.yml
+++ b/.semgrep/cerebro.yml
@@ -1,0 +1,45 @@
+rules:
+  - id: cerebro.source.raw-http-client
+    languages: [go]
+    severity: ERROR
+    message: Source connectors must use internal/sourcehttp rather than local HTTP clients.
+    metadata:
+      confidence: high
+      category: security
+    paths:
+      include:
+        - sources/**/*.go
+      exclude:
+        - "**/*_test.go"
+    pattern-either:
+      - pattern: http.DefaultClient
+      - pattern: '&http.Client{...}'
+      - pattern: http.Client{...}
+
+  - id: cerebro.source.direct-readall
+    languages: [go]
+    severity: ERROR
+    message: Source connectors should not read response bodies directly; use internal/sourcehttp bounded helpers.
+    metadata:
+      confidence: high
+      category: security
+    paths:
+      include:
+        - sources/**/*.go
+      exclude:
+        - "**/*_test.go"
+    patterns:
+      - pattern: io.ReadAll($BODY)
+      - pattern-not: io.ReadAll(io.LimitReader(...))
+
+  - id: cerebro.github-actions.unpinned-action
+    languages: [yaml]
+    severity: WARNING
+    message: GitHub Actions should be pinned to immutable commit SHAs unless the workflow documents an exception.
+    metadata:
+      confidence: high
+      category: supply-chain
+    paths:
+      include:
+        - .github/workflows/*.yml
+    pattern-regex: 'uses:\s+[^@\s]+@(main|master|v[0-9]+(?:\.[0-9]+){0,2})\s*$'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build serve test workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check oss-audit govulncheck droid-review-preflight droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
+.PHONY: build serve test workflow-e2e-test workflow-replay-test finding-rule-test github-findings-e2e github-findings-graph-preview github-audit-findings-graph-preview workflow-replay workflow-neighborhood graph-rebuild-dryrun candidate-smoke lint lint-bootstrap proto-lint proto-generate openapi-check openapi-lint openapi-sync catalog-check detection-catalog-generate detection-catalog-check oss-audit govulncheck droid-review-preflight droid-review-sast droid-feedback clean hooks pre-commit verify check check-structural check-structural-build check-structural-test check-arch check-hook-integrity
 
 GO_BIN ?= $(shell go env GOPATH)/bin
 GOLANGCI_LINT := $(GO_BIN)/golangci-lint
@@ -34,6 +34,8 @@ DROID_REVIEW_BASE ?= origin/main
 DROID_REVIEW_HEAD ?= HEAD
 DROID_PR ?=
 DROID_FEEDBACK_OUT ?=
+DROID_SAST_OUT ?= tmp/droid-sast-context.md
+DROID_SAST_POST_COMMENT ?= false
 
 build:
 	go build -o bin/cerebro ./cmd/cerebro
@@ -128,6 +130,9 @@ govulncheck:
 droid-review-preflight:
 	go test ./tools/droidreview/...
 	go run ./tools/droidreview --base "$(DROID_REVIEW_BASE)" --head "$(DROID_REVIEW_HEAD)"
+
+droid-review-sast:
+	python3 scripts/droid_sast_context.py --base "$(DROID_REVIEW_BASE)" --head "$(DROID_REVIEW_HEAD)" --markdown-out "$(DROID_SAST_OUT)" $(if $(filter true,$(DROID_SAST_POST_COMMENT)),--post-comment,)
 
 droid-feedback:
 	@if [ -z "$(DROID_PR)" ]; then echo "DROID_PR is required, e.g. make droid-feedback DROID_PR=719" >&2; exit 2; fi

--- a/scripts/droid_sast_context.py
+++ b/scripts/droid_sast_context.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Build a concise SAST context report for Droid PR reviews."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+COMMENT_MARKER = "<!-- droid-sast-context -->"
+GOSEC_CMD = [
+    "go",
+    "run",
+    "github.com/securego/gosec/v2/cmd/gosec@v2.24.7",
+]
+GOVULNCHECK_CMD = [
+    "go",
+    "run",
+    "golang.org/x/vuln/cmd/govulncheck@v1.1.4",
+]
+
+
+@dataclass
+class ToolResult:
+    name: str
+    scope: str
+    status: str
+    findings: list[dict[str, object]]
+    notes: list[str]
+
+
+def run_command(args: list[str], timeout: int = 180) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(args, 127, "", str(exc))
+
+
+def git_output(args: list[str]) -> str:
+    completed = run_command(["git", *args], timeout=60)
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr.strip() or completed.stdout.strip())
+    return completed.stdout
+
+
+def changed_files(base: str, head: str) -> list[str]:
+    files: set[str] = set()
+    for args in [
+        ["diff", "--name-only", "--diff-filter=ACMR", f"{base}...{head}"],
+        ["diff", "--name-only", "--diff-filter=ACMR"],
+        ["diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        ["ls-files", "--others", "--exclude-standard"],
+    ]:
+        output = git_output(args)
+        files.update(line.strip() for line in output.splitlines() if line.strip())
+    return sorted(files)
+
+
+def changed_lines(base: str, head: str) -> dict[str, set[int]]:
+    result: dict[str, set[int]] = {}
+    for args in [
+        ["diff", "--unified=0", "--diff-filter=ACMR", f"{base}...{head}", "--"],
+        ["diff", "--unified=0", "--diff-filter=ACMR", "--"],
+        ["diff", "--cached", "--unified=0", "--diff-filter=ACMR", "--"],
+    ]:
+        merge_changed_lines(result, parse_changed_lines(git_output(args)))
+    untracked = git_output(["ls-files", "--others", "--exclude-standard"])
+    for file_path in [line.strip() for line in untracked.splitlines() if line.strip()]:
+        try:
+            line_count = len(Path(file_path).read_text(encoding="utf-8").splitlines())
+        except UnicodeDecodeError:
+            line_count = 0
+        if line_count:
+            result[file_path] = set(range(1, line_count + 1))
+    return result
+
+
+def parse_changed_lines(output: str) -> dict[str, set[int]]:
+    result: dict[str, set[int]] = {}
+    current_file = ""
+    new_line = 0
+    for line in output.splitlines():
+        if line.startswith("+++ b/"):
+            current_file = line.removeprefix("+++ b/")
+            result.setdefault(current_file, set())
+            continue
+        if line.startswith("@@"):
+            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if not match:
+                continue
+            new_line = int(match.group(1))
+            continue
+        if not current_file or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            result.setdefault(current_file, set()).add(new_line)
+            new_line += 1
+        elif line.startswith("-"):
+            continue
+        else:
+            new_line += 1
+    return result
+
+
+def merge_changed_lines(target: dict[str, set[int]], source: dict[str, set[int]]) -> None:
+    for file_path, lines in source.items():
+        target.setdefault(file_path, set()).update(lines)
+
+
+def changed_go_packages(files: list[str]) -> list[str]:
+    dirs = sorted({str(Path(path).parent) for path in files if path.endswith(".go")})
+    packages: set[str] = set()
+    for directory in dirs:
+        package_arg = "." if directory == "." else f"./{directory}"
+        completed = run_command(["go", "list", "-f", "{{.ImportPath}}", package_arg], timeout=60)
+        if completed.returncode == 0:
+            package = completed.stdout.strip()
+            if package:
+                packages.add(package)
+    return sorted(packages)
+
+
+def relpath(path: str) -> str:
+    try:
+        return Path(path).resolve().relative_to(Path.cwd().resolve()).as_posix()
+    except ValueError:
+        return Path(path).as_posix()
+
+
+def line_is_changed(lines_by_file: dict[str, set[int]], file_path: str, line: int | None) -> bool:
+    if line is None:
+        return False
+    return line in lines_by_file.get(file_path, set())
+
+
+def run_gosec(packages: list[str], lines_by_file: dict[str, set[int]]) -> ToolResult:
+    if not packages:
+        return ToolResult("gosec", "changed Go packages", "skipped", [], ["No changed Go packages."])
+    package_args = [package.replace("github.com/writer/cerebro", ".") for package in packages]
+    with tempfile.NamedTemporaryFile(prefix="gosec-", suffix=".json", delete=False) as handle:
+        report_path = handle.name
+    try:
+        completed = run_command(
+            [
+                *GOSEC_CMD,
+                "-severity",
+                "medium",
+                "-confidence",
+                "medium",
+                "-exclude-generated",
+                "-fmt=json",
+                "-out",
+                report_path,
+                *package_args,
+            ],
+            timeout=240,
+        )
+        try:
+            with open(report_path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            data = {"Issues": []}
+        findings: list[dict[str, object]] = []
+        for issue in data.get("Issues") or []:
+            file_path = relpath(str(issue.get("file", "")))
+            try:
+                line = int(issue.get("line", 0))
+            except (TypeError, ValueError):
+                line = None
+            severity = str(issue.get("severity", "")).upper()
+            confidence = str(issue.get("confidence", "")).upper()
+            finding = {
+                "tool": "gosec",
+                "rule": issue.get("rule_id", ""),
+                "file": file_path,
+                "line": line,
+                "severity": severity,
+                "confidence": confidence,
+                "message": str(issue.get("details", "")).strip(),
+                "changed_line": line_is_changed(lines_by_file, file_path, line),
+            }
+            findings.append(finding)
+        notes = []
+        if completed.returncode not in (0, 1):
+            notes.append((completed.stderr or completed.stdout).strip()[:800])
+        return ToolResult("gosec", ", ".join(package_args), "completed", findings, notes)
+    finally:
+        try:
+            os.unlink(report_path)
+        except OSError:
+            pass
+
+
+def run_govulncheck(packages: list[str]) -> ToolResult:
+    if not packages:
+        return ToolResult("govulncheck", "changed Go packages", "skipped", [], ["No changed Go packages."])
+    package_args = [package.replace("github.com/writer/cerebro", ".") for package in packages]
+    completed = run_command([*GOVULNCHECK_CMD, *package_args], timeout=240)
+    findings: list[dict[str, object]] = []
+    combined = "\n".join(part for part in [completed.stdout, completed.stderr] if part).strip()
+    if completed.returncode != 0:
+        findings.append(
+            {
+                "tool": "govulncheck",
+                "rule": "reachable-vulnerability",
+                "file": "",
+                "line": None,
+                "severity": "UNKNOWN",
+                "confidence": "HIGH",
+                "message": first_nonempty_line(combined) or "govulncheck reported reachable vulnerabilities",
+                "changed_line": False,
+            }
+        )
+    notes = trim_lines(combined, 30)
+    return ToolResult("govulncheck", ", ".join(package_args), "completed", findings, notes)
+
+
+def run_semgrep(lines_by_file: dict[str, set[int]]) -> ToolResult:
+    config = Path(".semgrep/cerebro.yml")
+    if not config.exists():
+        return ToolResult("semgrep", "repo-specific rules", "skipped", [], ["No .semgrep/cerebro.yml config found."])
+    completed = run_command(
+        ["semgrep", "--config", str(config), "--json", "--quiet"],
+        timeout=240,
+    )
+    if completed.returncode == 127:
+        return ToolResult("semgrep", str(config), "skipped", [], ["semgrep is not installed."])
+    try:
+        data = json.loads(completed.stdout or "{}")
+    except json.JSONDecodeError:
+        data = {}
+    findings: list[dict[str, object]] = []
+    for item in data.get("results") or []:
+        file_path = relpath(str(item.get("path", "")))
+        start = item.get("start") or {}
+        line = start.get("line") if isinstance(start, dict) else None
+        extra = item.get("extra") or {}
+        metadata = extra.get("metadata") if isinstance(extra, dict) else {}
+        metadata = metadata if isinstance(metadata, dict) else {}
+        severity = str(extra.get("severity", "")).upper() if isinstance(extra, dict) else ""
+        confidence = str(metadata.get("confidence", "")).upper()
+        finding = {
+            "tool": "semgrep",
+            "rule": item.get("check_id", ""),
+            "file": file_path,
+            "line": line,
+            "severity": severity,
+            "confidence": confidence,
+            "message": str(extra.get("message", "")).strip() if isinstance(extra, dict) else "",
+            "changed_line": line_is_changed(lines_by_file, file_path, line),
+        }
+        if finding["changed_line"]:
+            findings.append(finding)
+    notes = []
+    if completed.returncode not in (0, 1):
+        notes.append((completed.stderr or completed.stdout).strip()[:800])
+    return ToolResult("semgrep", str(config), "completed", findings, notes)
+
+
+def first_nonempty_line(value: str) -> str:
+    for line in value.splitlines():
+        line = line.strip()
+        if line:
+            return line[:240]
+    return ""
+
+
+def trim_lines(value: str, limit: int) -> list[str]:
+    lines = [line.rstrip() for line in value.splitlines() if line.strip()]
+    if len(lines) <= limit:
+        return lines
+    return [*lines[:limit], f"... truncated {len(lines) - limit} line(s)"]
+
+
+def blocking_findings(results: list[ToolResult]) -> list[dict[str, object]]:
+    blockers: list[dict[str, object]] = []
+    for result in results:
+        for finding in result.findings:
+            severity = str(finding.get("severity", "")).upper()
+            confidence = str(finding.get("confidence", "")).upper()
+            if finding.get("changed_line") and severity in {"HIGH", "ERROR"} and confidence == "HIGH":
+                blockers.append(finding)
+    return blockers
+
+
+def render_markdown(base: str, head: str, files: list[str], packages: list[str], results: list[ToolResult]) -> str:
+    blockers = blocking_findings(results)
+    lines = [
+        COMMENT_MARKER,
+        "## Droid SAST Context",
+        "",
+        "Use this as scanner context for review. Validate findings before commenting.",
+        "",
+        f"- Base: `{base}`",
+        f"- Head: `{head}`",
+        f"- Changed files: `{len(files)}`",
+        f"- Changed Go packages: `{len(packages)}`",
+        f"- Blocking changed-line findings: `{len(blockers)}`",
+        "",
+        "### Tool Summary",
+        "",
+        "| Tool | Scope | Status | Findings | Notes |",
+        "| --- | --- | --- | ---: | --- |",
+    ]
+    for result in results:
+        note = "; ".join(result.notes[:2]) if result.notes else ""
+        lines.append(
+            f"| `{result.name}` | {escape_pipe(result.scope)} | {result.status} | {len(result.findings)} | {escape_pipe(note[:160])} |"
+        )
+    if blockers:
+        lines.extend(["", "### Blocking Findings", ""])
+        for finding in blockers:
+            lines.append(format_finding(finding))
+    review_findings = [
+        finding
+        for result in results
+        for finding in result.findings
+        if finding not in blockers
+    ]
+    if review_findings:
+        lines.extend(["", "### Review Context Findings", ""])
+        for finding in review_findings[:20]:
+            lines.append(format_finding(finding))
+        if len(review_findings) > 20:
+            lines.append(f"- ... truncated {len(review_findings) - 20} finding(s)")
+    if not blockers and not review_findings:
+        lines.extend(["", "### Review Context Findings", "", "No changed-line SAST findings."])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def escape_pipe(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def format_finding(finding: dict[str, object]) -> str:
+    file_path = str(finding.get("file") or "")
+    line = finding.get("line")
+    location = f"{file_path}:{line}" if file_path and line else file_path or "(repo)"
+    return (
+        f"- `{finding.get('tool')}` `{finding.get('rule')}` at `{location}` "
+        f"({finding.get('severity')}/{finding.get('confidence')}): {finding.get('message')}"
+    )
+
+
+def post_sticky_comment(markdown: str) -> None:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    pr_number = os.environ.get("PR_NUMBER")
+    if not token or not repository or not pr_number:
+        raise RuntimeError("GH_TOKEN/GITHUB_REPOSITORY/PR_NUMBER are required to post SAST context")
+
+    def request_json(method: str, path: str, payload: dict[str, object] | None = None) -> object:
+        data = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"https://api.github.com/{path.lstrip('/')}",
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urllib.request.urlopen(request, timeout=20) as response:
+            return json.load(response)
+
+    page = 1
+    while True:
+        comments = request_json(
+            "GET",
+            f"/repos/{repository}/issues/{pr_number}/comments?per_page=100&page={page}",
+        )
+        if not isinstance(comments, list) or not comments:
+            break
+        for comment in comments:
+            if not isinstance(comment, dict):
+                continue
+            body = str(comment.get("body") or "")
+            if COMMENT_MARKER in body:
+                request_json(
+                    "PATCH",
+                    f"/repos/{repository}/issues/comments/{comment['id']}",
+                    {"body": markdown},
+                )
+                return
+        page += 1
+    request_json(
+        "POST",
+        f"/repos/{repository}/issues/{pr_number}/comments",
+        {"body": markdown},
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", default=os.environ.get("DROID_REVIEW_BASE", "origin/main"))
+    parser.add_argument("--head", default=os.environ.get("DROID_REVIEW_HEAD", "HEAD"))
+    parser.add_argument("--markdown-out", default=os.environ.get("DROID_SAST_OUT", "tmp/droid-sast-context.md"))
+    parser.add_argument("--post-comment", action="store_true")
+    args = parser.parse_args()
+
+    files = changed_files(args.base, args.head)
+    lines_by_file = changed_lines(args.base, args.head)
+    packages = changed_go_packages(files)
+    results = [
+        run_gosec(packages, lines_by_file),
+        run_govulncheck(packages),
+        run_semgrep(lines_by_file),
+    ]
+    markdown = render_markdown(args.base, args.head, files, packages, results)
+    out_path = Path(args.markdown_out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(markdown, encoding="utf-8")
+    print(markdown)
+    if args.post_comment:
+        post_sticky_comment(markdown)
+    return 1 if blocking_findings(results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/droid_sast_context.py
+++ b/scripts/droid_sast_context.py
@@ -414,7 +414,13 @@ def main() -> int:
     parser.add_argument("--head", default=os.environ.get("DROID_REVIEW_HEAD", "HEAD"))
     parser.add_argument("--markdown-out", default=os.environ.get("DROID_SAST_OUT", "tmp/droid-sast-context.md"))
     parser.add_argument("--post-comment", action="store_true")
+    parser.add_argument("--post-existing", help="post an existing SAST markdown report and exit")
     args = parser.parse_args()
+
+    if args.post_existing:
+        markdown = Path(args.post_existing).read_text(encoding="utf-8")
+        post_sticky_comment(markdown)
+        return 0
 
     files = changed_files(args.base, args.head)
     lines_by_file = changed_lines(args.base, args.head)

--- a/scripts/droid_sast_context.py
+++ b/scripts/droid_sast_context.py
@@ -212,7 +212,7 @@ def run_govulncheck(packages: list[str]) -> ToolResult:
     completed = run_command([*GOVULNCHECK_CMD, *package_args], timeout=240)
     findings: list[dict[str, object]] = []
     combined = "\n".join(part for part in [completed.stdout, completed.stderr] if part).strip()
-    if completed.returncode != 0:
+    if completed.returncode == 3:
         findings.append(
             {
                 "tool": "govulncheck",
@@ -226,6 +226,8 @@ def run_govulncheck(packages: list[str]) -> ToolResult:
             }
         )
     notes = trim_lines(combined, 30)
+    if completed.returncode not in (0, 3):
+        notes.insert(0, f"govulncheck exited {completed.returncode}; treating as tool error, not a confirmed vulnerability.")
     return ToolResult("govulncheck", ", ".join(package_args), "completed", findings, notes)
 
 

--- a/tools/droidreview/bodyread/bodyread.go
+++ b/tools/droidreview/bodyread/bodyread.go
@@ -112,9 +112,10 @@ func collectUnboundedReadAllLines(fset *token.FileSet, statements []ast.Stmt, li
 			mergeLimitedVars(limitedVars, loopVars, bodyVars)
 		case *ast.RangeStmt:
 			recordUnboundedReadAllInNode(fset, stmt.X, limitedVars, ioImports, lines)
-			bodyVars := cloneLimitedVars(limitedVars)
+			rangeVars := cloneLimitedVars(limitedVars)
+			bodyVars := cloneLimitedVars(rangeVars)
 			collectUnboundedReadAllLines(fset, stmt.Body.List, bodyVars, ioImports, lines)
-			mergeLimitedVars(limitedVars, bodyVars)
+			mergeLimitedVars(limitedVars, rangeVars, bodyVars)
 		case *ast.SwitchStmt:
 			switchVars := cloneLimitedVars(limitedVars)
 			if stmt.Init != nil {

--- a/tools/droidreview/bodyread/bodyread_test.go
+++ b/tools/droidreview/bodyread/bodyread_test.go
@@ -242,6 +242,32 @@ func f(resp interface{ Body() io.Reader }, ok bool) {
 			want: 1,
 		},
 		{
+			name: "range body may not execute",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }, values []string) {
+	reader := resp.Body()
+	for range values {
+		reader = io.LimitReader(resp.Body(), 1024)
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 1,
+		},
+		{
+			name: "range keeps reader bounded when already bounded",
+			code: `package fixture
+import "io"
+func f(resp interface{ Body() io.Reader }, values []string) {
+	reader := io.LimitReader(resp.Body(), 1024)
+	for range values {
+		reader = io.LimitReader(resp.Body(), 2048)
+	}
+	_, _ = io.ReadAll(reader)
+}`,
+			want: 0,
+		},
+		{
 			name: "early return keeps unsafe branch from escaping",
 			code: `package fixture
 import "io"


### PR DESCRIPTION
## Summary
- Fixes the missed body-read analyzer feedback by modeling zero-iteration range loops.
- Adds `make droid-review-sast` to produce changed-line SAST context from gosec, govulncheck, and repo-specific Semgrep rules.
- Wires the Droid review workflow to post/update a sticky SAST context comment before the review agent runs.

## Test plan
- `python3 -m py_compile scripts/droid_sast_context.py scripts/droid_feedback_harness.py`
- `go test ./tools/droidreview/...`
- `make droid-review-preflight`
- `make droid-review-sast`
- `make verify`

Made with [Cursor](https://cursor.com)