### PR TITLE
Fix rulepack replay TTL flake

### DIFF
--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -616,7 +616,7 @@ func assertRulepackConvertEventReplaySingleOpenRow(t *testing.T, rule Rule, defi
 }
 
 func rulepackConvertReplayEvents(ruleID string, fixture rulepackConvertReplayFixture, count int) []*cerebrov1.EventEnvelope {
-	baseTime := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	baseTime := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
 	events := make([]*cerebrov1.EventEnvelope, 0, count)
 	for i := 0; i < count; i++ {
 		observedAt := baseTime.Add(time.Duration(i) * time.Minute)


### PR DESCRIPTION
## Summary
- Makes rulepack conversion replay fixtures use recent event timestamps so TTL-based rules do not auto-resolve during the single-open-row audit test.
- Fixes the post-merge main CI/Cut Release failure on `identity-auth-control-lifecycle-tampering`.

## Test plan
- go test ./internal/findings -run '^TestConvertRulesReplaySingleOpenRow$/identity-auth-control-lifecycle-tampering' -count=1 -v
- go test ./internal/findings -run '^TestConvertRulesReplaySingleOpenRow$' -count=1

Made with [Cursor](https://cursor.com)