### PR TITLE
Fix post-merge health workflow parse error

### DIFF
--- a/.github/workflows/droid-post-merge-health.yml
+++ b/.github/workflows/droid-post-merge-health.yml
@@ -1,51 +1,6 @@
 name: Droid Post-Merge Health
 
 on:
-  workflow_run:
-    workflows: ["CI", "Cut Release", "Leak Check"]
-    types: [completed]
-
-permissions:
-  contents: read
-  actions: read
-
-jobs:
-  summarize-main-health:
-    if: github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion != 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Build post-merge health context
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
-          DROID_POST_MERGE_BRANCH: main
-          DROID_POST_MERGE_HEAD: ${{ github.event.workflow_run.head_sha }}
-          DROID_POST_MERGE_OUT: tmp/droid-post-merge-health.md
-          DROID_POST_MERGE_JSON_OUT: tmp/droid-post-merge-health.json
-        run: |
-          set -euo pipefail
-          make droid-post-merge-health
-          if [ -s "${DROID_POST_MERGE_OUT}" ]; then
-            {
-              echo "### Droid Post-Merge Health"
-              echo
-              sed 's/^/    /' "${DROID_POST_MERGE_OUT}"
-            } >> "${GITHUB_STEP_SUMMARY}"
-          fi
-      - name: Upload post-merge health artifact
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: droid-post-merge-health
-          path: |
-            tmp/droid-post-merge-health.md
-            tmp/droid-post-merge-health.json
-name: Droid Post-Merge Health
-
-on:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- remove the duplicated YAML workflow block from `.github/workflows/droid-post-merge-health.yml`
- keep the intended `push`-on-`main` post-merge health job so GitHub can parse and execute it

## Test plan
- [x] `make droid-post-merge-health`

Made with [Cursor](https://cursor.com)