### PR TITLE
Expand generic source graph links

### DIFF
--- a/internal/findings/cloud_signal_rule.go
+++ b/internal/findings/cloud_signal_rule.go
@@ -317,7 +317,7 @@ func cloudEffectivePermissionPrincipalURN(event *cerebrov1.EventEnvelope, attrib
 }
 
 func cloudEffectivePermissionPrincipalType(value string) string {
-	normalized := strings.ToLower(strings.TrimSpace(strings.ReplaceAll(value, "-", "_")))
+	normalized := strings.ToLower(strings.TrimSpace(value))
 	if strings.Contains(normalized, "group") {
 		return "group"
 	}

--- a/internal/findings/cloud_signal_rule.go
+++ b/internal/findings/cloud_signal_rule.go
@@ -251,12 +251,12 @@ func cloudFingerprintAttributes(fields []string, values []string) map[string]str
 
 func cloudEffectiveAdminPermissionFingerprintInputs(event *cerebrov1.EventEnvelope, attributes map[string]string, projection findingProjectionContext) []string {
 	tenantID := strings.TrimSpace(event.GetTenantId())
-	accountID := firstNonEmpty(attributes["scope"], attributes["domain"])
+	accountID := cloudEffectivePermissionAccountID(attributes)
 	accountURN := projection.EntityURNByType("cloud.account")
 	if accountURN == "" && accountID != "" && tenantID != "" {
 		accountURN = fmt.Sprintf("urn:cerebro:%s:cloud_account:%s", tenantID, strings.TrimSpace(accountID))
 	}
-	principalURN := projection.PrimaryActorURN
+	principalURN := firstNonEmpty(cloudEffectivePermissionPrincipalURN(event, attributes), projection.PrimaryActorURN)
 	permissionKey := strings.ToLower(strings.TrimSpace(firstNonEmpty(
 		attributes["permission"],
 		attributes["actions"],
@@ -273,6 +273,73 @@ func cloudEffectiveAdminPermissionFingerprintInputs(event *cerebrov1.EventEnvelo
 		}
 	}
 	return []string{accountURN, principalURN, permissionURN}
+}
+
+func cloudEffectivePermissionAccountID(attributes map[string]string) string {
+	return firstNonEmpty(
+		attributes["domain"],
+		attributes["aws_account_id"],
+		attributes["subscription_id"],
+		attributes["project_id"],
+		attributes["gcp_project_id"],
+		attributes["account_id"],
+		attributes["scope"],
+	)
+}
+
+func cloudEffectivePermissionPrincipalURN(event *cerebrov1.EventEnvelope, attributes map[string]string) string {
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	provider := strings.TrimSpace(event.GetSourceId())
+	principalID := firstNonEmpty(attributes["subject_id"], attributes["principal_id"], attributes["assigned_to"], attributes["email"])
+	principalEmail := firstNonEmpty(attributes["subject_email"], attributes["principal_email"], attributes["email"])
+	principalType := cloudEffectivePermissionPrincipalType(firstNonEmpty(attributes["subject_type"], attributes["principal_type"], "user"))
+	if tenantID == "" || provider == "" {
+		return ""
+	}
+	switch principalType {
+	case "group":
+		return identityProjectionURN(tenantID, provider+"_group", firstNonEmpty(principalID, principalEmail))
+	case "application":
+		return identityProjectionURN(tenantID, provider+"_application", principalID)
+	case "service_principal":
+		return identityProjectionURN(tenantID, provider+"_service_principal", firstNonEmpty(principalID, principalEmail))
+	case "service_account":
+		return identityProjectionURN(tenantID, provider+"_service_account", firstNonEmpty(principalID, principalEmail))
+	case "role":
+		return identityProjectionURN(tenantID, provider+"_role", principalID)
+	case "account":
+		return identityProjectionURN(tenantID, provider+"_account", principalID)
+	case "public":
+		return identityProjectionURN(tenantID, provider+"_public_principal", principalID)
+	default:
+		return identityProjectionURN(tenantID, provider+"_user", firstNonEmpty(principalEmail, principalID))
+	}
+}
+
+func cloudEffectivePermissionPrincipalType(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(strings.ReplaceAll(value, "-", "_")))
+	if strings.Contains(normalized, "group") {
+		return "group"
+	}
+	if strings.Contains(normalized, "service_principal") || strings.Contains(normalized, "serviceprincipal") {
+		return "service_principal"
+	}
+	if strings.Contains(normalized, "service_account") || strings.Contains(normalized, "serviceaccount") {
+		return "service_account"
+	}
+	if strings.Contains(normalized, "application") {
+		return "application"
+	}
+	if strings.Contains(normalized, "role") {
+		return "role"
+	}
+	if strings.Contains(normalized, "account") {
+		return "account"
+	}
+	if strings.Contains(normalized, "public") || strings.Contains(normalized, "allusers") || strings.Contains(normalized, "allauthenticatedusers") {
+		return "public"
+	}
+	return "user"
 }
 
 func cloudPublicResourceExposureFingerprintInputs(_ *cerebrov1.EventEnvelope, attributes map[string]string, projection findingProjectionContext) []string {

--- a/internal/findings/cloud_signal_rule.go
+++ b/internal/findings/cloud_signal_rule.go
@@ -312,7 +312,7 @@ func cloudEffectivePermissionPrincipalURN(event *cerebrov1.EventEnvelope, attrib
 	case "public":
 		return identityProjectionURN(tenantID, provider+"_public_principal", principalID)
 	default:
-		return identityProjectionURN(tenantID, provider+"_user", firstNonEmpty(principalEmail, principalID))
+		return identityProjectionURN(tenantID, provider+"_user", firstNonEmpty(principalID, principalEmail))
 	}
 }
 

--- a/internal/findings/cloud_signal_rule_test.go
+++ b/internal/findings/cloud_signal_rule_test.go
@@ -431,6 +431,22 @@ func TestCloudEffectiveAdminPermission(t *testing.T) {
 	}
 }
 
+func TestCloudEffectivePermissionPrincipalURNPrefersSubjectID(t *testing.T) {
+	event := &cerebrov1.EventEnvelope{
+		TenantId: "writer",
+		SourceId: "aws",
+	}
+	attributes := map[string]string{
+		"subject_email": "admin@writer.com",
+		"subject_id":    "AIDAEXAMPLE",
+		"subject_type":  "user",
+	}
+
+	if got, want := cloudEffectivePermissionPrincipalURN(event, attributes), "urn:cerebro:writer:aws_user:AIDAEXAMPLE"; got != want {
+		t.Fatalf("cloudEffectivePermissionPrincipalURN() = %q, want %q", got, want)
+	}
+}
+
 func TestCloudPrivilegePathGranted(t *testing.T) {
 	rules := cloudRulesByID(t)
 	rule := rules[cloudPrivilegePathGrantedRuleID]

--- a/internal/findings/cloud_signal_rule_test.go
+++ b/internal/findings/cloud_signal_rule_test.go
@@ -447,6 +447,21 @@ func TestCloudEffectivePermissionPrincipalURNPrefersSubjectID(t *testing.T) {
 	}
 }
 
+func TestCloudEffectivePermissionPrincipalTypeMatchesProjectionHyphenBehavior(t *testing.T) {
+	event := &cerebrov1.EventEnvelope{
+		TenantId: "writer",
+		SourceId: "gcp",
+	}
+	attributes := map[string]string{
+		"subject_id":   "payments-sa@writer-prod.iam.gserviceaccount.com",
+		"subject_type": "service-account",
+	}
+
+	if got, want := cloudEffectivePermissionPrincipalURN(event, attributes), "urn:cerebro:writer:gcp_account:payments-sa@writer-prod.iam.gserviceaccount.com"; got != want {
+		t.Fatalf("cloudEffectivePermissionPrincipalURN() = %q, want %q", got, want)
+	}
+}
+
 func TestCloudPrivilegePathGranted(t *testing.T) {
 	rules := cloudRulesByID(t)
 	rule := rules[cloudPrivilegePathGrantedRuleID]

--- a/internal/sourceprojection/asset.go
+++ b/internal/sourceprojection/asset.go
@@ -61,6 +61,9 @@ func assetClassificationProjections(event *cerebrov1.EventEnvelope, crownJewelEv
 	if resourceURN != "" && classificationURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, classificationURN, relationHasClassification, map[string]string{"event_id": event.GetId()}))
 	}
+	if accountID := assetCloudAccountID(provider, resourceID, resourceURN, attributes); resourceURN != "" && accountID != "" {
+		addCloudAccountLink(entities, links, tenantID, event.GetSourceId(), event, resourceURN, accountID, provider)
+	}
 	if crownJewel && resourceURN != "" {
 		tagURN := projectionURN(tenantID, "asset_tag", "crown_jewel")
 		addEntity(entities, &ports.ProjectedEntity{URN: tagURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "asset.tag", Label: "crown_jewel", Attributes: map[string]string{"tag": "crown_jewel"}})
@@ -72,4 +75,31 @@ func assetClassificationProjections(event *cerebrov1.EventEnvelope, crownJewelEv
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, ownerURN, relationOwnedBy, map[string]string{"event_id": event.GetId()}))
 	}
 	return identityProjectionResult(entities, links)
+}
+
+func assetCloudAccountID(provider string, resourceID string, resourceURN string, attributes map[string]string) string {
+	provider = normalizeIdentifier(provider)
+	switch provider {
+	case "aws":
+		return firstNonEmpty(
+			awsAccountID(attributes["aws_account_id"]),
+			awsAccountIDFromARN(resourceID),
+			awsAccountIDFromARN(resourceURN),
+		)
+	case "azure":
+		return firstNonEmpty(
+			attributes["subscription_id"],
+			azureSubscriptionIDFromScope(resourceID),
+			azureSubscriptionIDFromScope(resourceURN),
+		)
+	case "gcp":
+		return firstNonEmpty(
+			attributes["gcp_project_id"],
+			attributes["project_id"],
+			gcpProjectIDFromResource(resourceID),
+			gcpProjectIDFromResource(resourceURN),
+		)
+	default:
+		return ""
+	}
 }

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -406,7 +406,10 @@ func cloudEffectivePermissionProjections(event *cerebrov1.EventEnvelope, profile
 		addCloudAccountLink(entities, links, tenantID, event.GetSourceId(), event, resourceURN, cloudEffectivePermissionAccountID(attributes, provider), provider)
 	}
 	roleID := strings.TrimSpace(attributes["role_id"])
-	roleURN := identityPrincipalURN(tenantID, provider, "role", roleID, "")
+	roleURN := ""
+	if roleID != "" {
+		roleURN = identityPrincipalURN(tenantID, provider, "role", roleID, "")
+	}
 	if roleURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        roleURN,

--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -403,21 +403,54 @@ func cloudEffectivePermissionProjections(event *cerebrov1.EventEnvelope, profile
 			Label:      firstNonEmpty(attributes["resource_name"], attributes["target_name"], resourceID),
 			Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "scope": strings.TrimSpace(attributes["scope"])},
 		})
-		addCloudAccountLink(entities, links, tenantID, event.GetSourceId(), event, resourceURN, firstNonEmpty(attributes["scope"], attributes["domain"]), provider)
+		addCloudAccountLink(entities, links, tenantID, event.GetSourceId(), event, resourceURN, cloudEffectivePermissionAccountID(attributes, provider), provider)
+	}
+	roleID := strings.TrimSpace(attributes["role_id"])
+	roleURN := identityPrincipalURN(tenantID, provider, "role", roleID, "")
+	if roleURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        roleURN,
+			TenantID:   tenantID,
+			SourceID:   event.GetSourceId(),
+			EntityType: profile.entityType("role"),
+			Label:      firstNonEmpty(attributes["role_name"], attributes["role_id"]),
+			Attributes: map[string]string{
+				"role_id":   strings.TrimSpace(attributes["role_id"]),
+				"role_name": strings.TrimSpace(attributes["role_name"]),
+			},
+		})
+		addCloudAccountLink(entities, links, tenantID, event.GetSourceId(), event, roleURN, cloudEffectivePermissionAccountID(attributes, provider), provider)
+	}
+	canPerformAttrs := map[string]string{
+		"actions":         strings.TrimSpace(attributes["actions"]),
+		"condition":       strings.TrimSpace(attributes["condition"]),
+		"effect":          strings.TrimSpace(attributes["effect"]),
+		"event_id":        event.GetId(),
+		"is_admin":        boolString(identityProjectionPrivileged(attributes)),
+		"permission":      firstNonEmpty(attributes["permission"], attributes["actions"]),
+		"policy_source":   strings.TrimSpace(attributes["policy_source"]),
+		"privilege_level": strings.TrimSpace(attributes["privilege_level"]),
+		"role_id":         strings.TrimSpace(attributes["role_id"]),
+		"role_name":       strings.TrimSpace(attributes["role_name"]),
+	}
+	if roleURN != "" {
+		canPerformAttrs["role_urn"] = roleURN
+	}
+	if subjectURN != "" && roleURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, roleURN, relationAssignedTo, map[string]string{
+			"event_id":   event.GetId(),
+			"match_type": "effective_permission_role_binding",
+			"role_id":    strings.TrimSpace(attributes["role_id"]),
+			"role_name":  strings.TrimSpace(attributes["role_name"]),
+		}))
+	}
+	if roleURN != "" && resourceURN != "" {
+		roleCanPerformAttrs := cloneStringMap(canPerformAttrs)
+		roleCanPerformAttrs["match_type"] = "effective_permission_role_resource"
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), roleURN, resourceURN, relationCanPerform, roleCanPerformAttrs))
 	}
 	if subjectURN != "" && resourceURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, resourceURN, relationCanPerform, map[string]string{
-			"actions":         strings.TrimSpace(attributes["actions"]),
-			"condition":       strings.TrimSpace(attributes["condition"]),
-			"effect":          strings.TrimSpace(attributes["effect"]),
-			"event_id":        event.GetId(),
-			"is_admin":        boolString(identityProjectionPrivileged(attributes)),
-			"permission":      firstNonEmpty(attributes["permission"], attributes["actions"]),
-			"policy_source":   strings.TrimSpace(attributes["policy_source"]),
-			"privilege_level": strings.TrimSpace(attributes["privilege_level"]),
-			"role_id":         strings.TrimSpace(attributes["role_id"]),
-			"role_name":       strings.TrimSpace(attributes["role_name"]),
-		}))
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, resourceURN, relationCanPerform, canPerformAttrs))
 	}
 	return identityProjectionResult(entities, links)
 }
@@ -443,6 +476,38 @@ func cloudPrivilegeRelation(attributes map[string]string) string {
 		return relationCanAdmin
 	default:
 		return relationAssignedTo
+	}
+}
+
+func cloudEffectivePermissionAccountID(attributes map[string]string, provider string) string {
+	switch provider {
+	case "aws":
+		return firstNonEmpty(
+			awsAccountID(attributes["domain"]),
+			awsAccountID(attributes["account_id"]),
+			awsAccountID(attributes["aws_account_id"]),
+			awsAccountIDFromARN(attributes["scope"]),
+			awsAccountIDFromARN(attributes["resource_id"]),
+			awsAccountIDFromARN(attributes["target_id"]),
+		)
+	case "azure":
+		return firstNonEmpty(
+			attributes["subscription_id"],
+			azureSubscriptionIDFromScope(attributes["scope"]),
+			azureSubscriptionIDFromScope(attributes["resource_id"]),
+			azureSubscriptionIDFromScope(attributes["target_id"]),
+		)
+	case "gcp":
+		return firstNonEmpty(
+			attributes["project_id"],
+			attributes["gcp_project_id"],
+			attributes["domain"],
+			gcpProjectIDFromResource(attributes["scope"]),
+			gcpProjectIDFromResource(attributes["resource_id"]),
+			gcpProjectIDFromResource(attributes["target_id"]),
+		)
+	default:
+		return ""
 	}
 }
 

--- a/internal/sourceprojection/entity_type_normalize_test.go
+++ b/internal/sourceprojection/entity_type_normalize_test.go
@@ -1,0 +1,20 @@
+package sourceprojection
+
+import "testing"
+
+func TestCanonicalProjectedEntityType(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{input: "aws.aws.iam.policy", want: "aws.iam.policy"},
+		{input: "okta.publicclientappentity", want: "okta.publicclientapp"},
+		{input: "okta.ip address", want: "okta.ip"},
+		{input: "github.code.repository", want: "github.code.repository"},
+	}
+	for _, tc := range cases {
+		if got := canonicalProjectedEntityType(tc.input); got != tc.want {
+			t.Fatalf("canonicalProjectedEntityType(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -711,7 +711,7 @@ func githubRepositoryOwnerLogin(provider string, resourceType string, resourceNa
 	if !ok {
 		return ""
 	}
-	return normalizeIdentifier(owner)
+	return strings.TrimSpace(owner)
 }
 
 func grcPlatformAssetReferences(attrs map[string]string) []grcPlatformAssetReference {

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -644,7 +644,8 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 			"resource_type": resourceType,
 			"resource_name": strings.TrimSpace(ref.ResourceName),
 		}
-		if ownerLogin := githubRepositoryOwnerLogin(provider, resourceType, ref.ResourceName); ownerLogin != "" {
+		ownerLogin := githubRepositoryOwnerLogin(provider, resourceType, ref.ResourceName)
+		if ownerLogin != "" {
 			entityAttrs["owner_login"] = ownerLogin
 		}
 		addEntity(entities, &ports.ProjectedEntity{
@@ -672,7 +673,34 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 			addEntity(entities, grcIntegrationReferenceEntity(tenantID, sourceID, integrationURN, integrationID, grcProviderName))
 			addLink(links, projectedLink(tenantID, sourceID, resourceURN, integrationURN, relationBelongsTo, grcIntegrationLinkAttributes(event, integrationID)))
 		}
+		addGRCGitHubRepositoryOrgLink(entities, links, tenantID, sourceID, event, resourceURN, ownerLogin)
 	}
+}
+
+func addGRCGitHubRepositoryOrgLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, repositoryURN string, ownerLogin string) {
+	ownerLogin = strings.TrimSpace(ownerLogin)
+	repositoryURN = strings.TrimSpace(repositoryURN)
+	if ownerLogin == "" || repositoryURN == "" {
+		return
+	}
+	orgURN := projectionURN(tenantID, "github_org", ownerLogin)
+	if orgURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        orgURN,
+		TenantID:   tenantID,
+		SourceID:   "github",
+		EntityType: "github.org",
+		Label:      ownerLogin,
+		Attributes: map[string]string{"org": ownerLogin, "owner_login": ownerLogin},
+	})
+	addLink(links, projectedLink(tenantID, sourceID, repositoryURN, orgURN, relationBelongsTo, map[string]string{
+		"event_id":     event.GetId(),
+		"match_type":   "grc_platform_repository_owner",
+		"owner_login":  ownerLogin,
+		"source_scope": "platform_asset_ref",
+	}))
 }
 
 func githubRepositoryOwnerLogin(provider string, resourceType string, resourceName string) string {

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -890,7 +890,7 @@ func TestProjectGRCVulnerableAssetLabelsAndLinksGitHubRepoToIntegration(t *testi
 			"provider":            "vanta",
 			"target_id":           "github-repo-asset",
 			"integration_id":      "github",
-			"platform_asset_refs": `[{"provider":"github","resource_id":"1242719606","resource_name":"writer/cerebro","resource_type":"code_repository"}]`,
+			"platform_asset_refs": `[{"provider":"github","resource_id":"1242719606","resource_name":"Writer/cerebro","resource_type":"code_repository"}]`,
 		},
 	})
 	if err != nil {
@@ -898,18 +898,18 @@ func TestProjectGRCVulnerableAssetLabelsAndLinksGitHubRepoToIntegration(t *testi
 	}
 
 	repoURN := "urn:cerebro:writer:github_code_repository:1242719606"
-	orgURN := "urn:cerebro:writer:github_org:writer"
+	orgURN := "urn:cerebro:writer:github_org:Writer"
 	integrationURN := "urn:cerebro:writer:source:vanta:integration:github"
 
 	repo := state.entities[repoURN]
 	if repo == nil {
 		t.Fatalf("github code repository entity %q missing", repoURN)
 	}
-	if repo.Label != "writer/cerebro" {
-		t.Fatalf("github repo label = %q, want resource_name %q", repo.Label, "writer/cerebro")
+	if repo.Label != "Writer/cerebro" {
+		t.Fatalf("github repo label = %q, want resource_name %q", repo.Label, "Writer/cerebro")
 	}
-	if got := repo.Attributes["owner_login"]; got != "writer" {
-		t.Fatalf("github repo owner_login = %q, want writer", got)
+	if got := repo.Attributes["owner_login"]; got != "Writer" {
+		t.Fatalf("github repo owner_login = %q, want Writer", got)
 	}
 	if org := state.entities[orgURN]; org == nil || org.EntityType != "github.org" {
 		t.Fatalf("github org entity %q missing or wrong type: %#v", orgURN, org)

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -898,6 +898,7 @@ func TestProjectGRCVulnerableAssetLabelsAndLinksGitHubRepoToIntegration(t *testi
 	}
 
 	repoURN := "urn:cerebro:writer:github_code_repository:1242719606"
+	orgURN := "urn:cerebro:writer:github_org:writer"
 	integrationURN := "urn:cerebro:writer:source:vanta:integration:github"
 
 	repo := state.entities[repoURN]
@@ -910,6 +911,10 @@ func TestProjectGRCVulnerableAssetLabelsAndLinksGitHubRepoToIntegration(t *testi
 	if got := repo.Attributes["owner_login"]; got != "writer" {
 		t.Fatalf("github repo owner_login = %q, want writer", got)
 	}
+	if org := state.entities[orgURN]; org == nil || org.EntityType != "github.org" {
+		t.Fatalf("github org entity %q missing or wrong type: %#v", orgURN, org)
+	}
+	assertProjectedLink(t, state, repoURN, relationBelongsTo, orgURN)
 	assertProjectedLink(t, state, repoURN, relationBelongsTo, integrationURN)
 }
 

--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -218,6 +218,7 @@ func identityUserProjections(event *cerebrov1.EventEnvelope, profile identityPro
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), userURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
+		addCloudIdentityAccountLink(entities, links, tenantID, event.GetSourceId(), event, userURN, profile, attributes, principalType, userID)
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, email, event.GetOccurredAt())
 		if !sameIdentifier(email, login) {
 			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), userURN, login, event.GetOccurredAt())
@@ -263,6 +264,7 @@ func identityGroupProjections(event *cerebrov1.EventEnvelope, profile identityPr
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), groupURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
+		addCloudIdentityAccountLink(entities, links, tenantID, event.GetSourceId(), event, groupURN, profile, attributes, "group", groupID)
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), groupURN, groupEmail, event.GetOccurredAt())
 	}
 	return identityProjectionResult(entities, links)
@@ -487,6 +489,7 @@ func identityRoleAssignmentProjections(event *cerebrov1.EventEnvelope, profile i
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: subjectAttributes,
 		})
+		addCloudIdentityAccountLink(entities, links, tenantID, event.GetSourceId(), event, subjectURN, profile, attributes, subjectType, subjectID)
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID), event.GetOccurredAt())
 	}
 	if roleURN != "" {
@@ -498,6 +501,7 @@ func identityRoleAssignmentProjections(event *cerebrov1.EventEnvelope, profile i
 			Label:      firstNonEmpty(attributes["role_name"], attributes["role_type"], roleID),
 			Attributes: map[string]string{"is_admin": boolString(privileged), "role_id": roleID, "role_type": strings.TrimSpace(attributes["role_type"])},
 		})
+		addCloudIdentityAccountLink(entities, links, tenantID, event.GetSourceId(), event, roleURN, profile, attributes, roleKind, roleID)
 	}
 	if subjectURN != "" && roleURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, roleURN, relation, map[string]string{"event_id": event.GetId()}))
@@ -530,6 +534,7 @@ func identityCredentialProjections(event *cerebrov1.EventEnvelope, profile ident
 			Label:      firstNonEmpty(attributes["subject_name"], subjectEmail, subjectID),
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
+		addCloudIdentityAccountLink(entities, links, tenantID, event.GetSourceId(), event, subjectURN, profile, attributes, subjectType, subjectID)
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID), event.GetOccurredAt())
 	}
 	if credentialURN != "" {
@@ -541,6 +546,7 @@ func identityCredentialProjections(event *cerebrov1.EventEnvelope, profile ident
 			Label:      firstNonEmpty(attributes["credential_name"], credentialID),
 			Attributes: map[string]string{"credential_id": credentialID, "credential_type": credentialType, "status": strings.TrimSpace(attributes["status"])},
 		})
+		addCloudIdentityAccountLink(entities, links, tenantID, event.GetSourceId(), event, credentialURN, profile, attributes, "credential", credentialID)
 	}
 	if subjectURN != "" && credentialURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, credentialURN, relationAssignedTo, map[string]string{"event_id": event.GetId()}))
@@ -589,6 +595,7 @@ func identityAuditProjections(event *cerebrov1.EventEnvelope, profile identityPr
 			"event_type": firstNonEmpty(attributes["event_type"], attributes["event_name"]),
 		}))
 	}
+	addAzureResourceGroupLinks(entities, links, tenantID, event.GetSourceId(), event, profile, attributes, resourceURN)
 	return identityProjectionResult(entities, links)
 }
 
@@ -609,6 +616,163 @@ func addIdentityOrg(entities map[string]*ports.ProjectedEntity, tenantID string,
 		Label:      domain,
 		Attributes: map[string]string{"domain": domain},
 	})
+}
+
+func addCloudIdentityAccountLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, profile identityProjectionProfile, attributes map[string]string, principalType string, principalID string) {
+	accountID := cloudIdentityAccountID(profile, attributes, principalType, principalID)
+	if accountID == "" {
+		return
+	}
+	addCloudAccountLink(entities, links, tenantID, sourceID, event, fromURN, accountID, profile.Provider)
+}
+
+func cloudIdentityAccountID(profile identityProjectionProfile, attributes map[string]string, principalType string, principalID string) string {
+	switch profile.Provider {
+	case "aws":
+		return firstNonEmpty(
+			awsAccountID(attributes["domain"]),
+			awsAccountID(attributes["aws_account_id"]),
+			awsAccountIDFromARN(principalID),
+			awsAccountIDFromARN(attributes["subject_id"]),
+			awsAccountIDFromARN(attributes["user_id"]),
+			awsAccountIDFromARN(attributes["resource_id"]),
+			awsAccountIDFromARN(attributes["target_id"]),
+		)
+	case "gcp":
+		if identityPrincipalType(principalType) != "service_account" && !strings.EqualFold(principalType, "credential") {
+			return ""
+		}
+		return firstNonEmpty(
+			attributes["gcp_project_id"],
+			attributes["project_id"],
+			gcpProjectIDFromResource(attributes["credential_id"]),
+			gcpProjectIDFromResource(principalID),
+			gcpProjectIDFromServiceAccountEmail(attributes["subject_email"]),
+			gcpProjectIDFromServiceAccountEmail(attributes["email"]),
+			gcpProjectIDFromServiceAccountEmail(principalID),
+			attributes["domain"],
+		)
+	case "azure":
+		return firstNonEmpty(
+			attributes["subscription_id"],
+			azureSubscriptionIDFromScope(attributes["scope"]),
+			azureSubscriptionIDFromScope(attributes["resource_id"]),
+			azureSubscriptionIDFromScope(attributes["target_id"]),
+		)
+	default:
+		return ""
+	}
+}
+
+func awsAccountID(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) != 12 {
+		return ""
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return value
+}
+
+func awsAccountIDFromARN(value string) string {
+	parts := strings.Split(strings.TrimSpace(value), ":")
+	if len(parts) < 5 || parts[0] != "arn" || parts[2] == "" {
+		return ""
+	}
+	return awsAccountID(parts[4])
+}
+
+func gcpProjectIDFromResource(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	parts := strings.Split(value, "/")
+	for index := 0; index+1 < len(parts); index++ {
+		if parts[index] == "projects" && strings.TrimSpace(parts[index+1]) != "" {
+			return strings.TrimSpace(parts[index+1])
+		}
+	}
+	return ""
+}
+
+func gcpProjectIDFromServiceAccountEmail(value string) string {
+	value = strings.TrimSpace(value)
+	if !strings.HasSuffix(value, ".iam.gserviceaccount.com") {
+		return ""
+	}
+	_, domain, ok := strings.Cut(value, "@")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSuffix(domain, ".iam.gserviceaccount.com")
+}
+
+func azureSubscriptionIDFromScope(value string) string {
+	parts := strings.Split(strings.TrimSpace(value), "/")
+	for index := 0; index+1 < len(parts); index++ {
+		if strings.EqualFold(parts[index], "subscriptions") && strings.TrimSpace(parts[index+1]) != "" {
+			return strings.TrimSpace(parts[index+1])
+		}
+	}
+	return ""
+}
+
+func addAzureResourceGroupLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, profile identityProjectionProfile, attributes map[string]string, resourceURN string) {
+	if profile.Provider != "azure" || resourceURN == "" {
+		return
+	}
+	subscriptionID := firstNonEmpty(
+		attributes["subscription_id"],
+		azureSubscriptionIDFromScope(attributes["scope"]),
+		azureSubscriptionIDFromScope(attributes["resource_id"]),
+		azureSubscriptionIDFromScope(attributes["target_id"]),
+	)
+	resourceGroup := azureResourceGroupName(attributes)
+	if subscriptionID == "" || resourceGroup == "" {
+		return
+	}
+	resourceGroupURN := projectionURN(tenantID, "azure_resource_group", subscriptionID, resourceGroup)
+	if resourceGroupURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        resourceGroupURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "azure.resource_group",
+		Label:      resourceGroup,
+		Attributes: map[string]string{
+			"resource_group":  resourceGroup,
+			"subscription_id": subscriptionID,
+		},
+	})
+	addLink(links, projectedLink(tenantID, sourceID, resourceURN, resourceGroupURN, relationBelongsTo, map[string]string{
+		"event_id":         event.GetId(),
+		"resource_group":   resourceGroup,
+		"subscription_id":  subscriptionID,
+		"relationship_by":  "azure_resource_group",
+		"source_attribute": "resource_group",
+	}))
+	addCloudAccountLink(entities, links, tenantID, sourceID, event, resourceGroupURN, subscriptionID, "azure")
+}
+
+func azureResourceGroupName(attributes map[string]string) string {
+	if resourceGroup := firstNonEmpty(attributes["resource_group"], attributes["resource_group_name"]); resourceGroup != "" {
+		return resourceGroup
+	}
+	for _, value := range []string{attributes["scope"], attributes["resource_id"], attributes["target_id"]} {
+		parts := strings.Split(strings.TrimSpace(value), "/")
+		for index := 0; index+1 < len(parts); index++ {
+			if strings.EqualFold(parts[index], "resourceGroups") && strings.TrimSpace(parts[index+1]) != "" {
+				return strings.TrimSpace(parts[index+1])
+			}
+		}
+	}
+	return ""
 }
 
 func identityOrgURN(tenantID string, provider string, domain string) string {

--- a/internal/sourceprojection/kubernetes.go
+++ b/internal/sourceprojection/kubernetes.go
@@ -17,6 +17,7 @@ func kubernetesServiceAccountProjections(event *cerebrov1.EventEnvelope) ([]*por
 	links := map[string]*ports.ProjectedLink{}
 	serviceAccountURN := kubernetesServiceAccountURN(tenantID, attributes)
 	namespaceURN := kubernetesNamespaceURN(tenantID, attributes)
+	clusterURN := kubernetesClusterURN(tenantID, attributes)
 	if serviceAccountURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        serviceAccountURN,
@@ -33,10 +34,12 @@ func kubernetesServiceAccountProjections(event *cerebrov1.EventEnvelope) ([]*por
 			},
 		})
 	}
+	addKubernetesCluster(entities, tenantID, event.GetSourceId(), attributes, clusterURN)
 	addKubernetesNamespace(entities, tenantID, event.GetSourceId(), attributes, namespaceURN)
 	if serviceAccountURN != "" && namespaceURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), serviceAccountURN, namespaceURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 	}
+	addKubernetesClusterLinks(entities, links, tenantID, event.GetSourceId(), event, attributes, namespaceURN, clusterURN)
 	return identityProjectionResult(entities, links)
 }
 
@@ -51,6 +54,7 @@ func kubernetesWorkloadProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 	workloadURN := kubernetesWorkloadURN(tenantID, attributes)
 	serviceAccountURN := kubernetesServiceAccountURN(tenantID, attributes)
 	namespaceURN := kubernetesNamespaceURN(tenantID, attributes)
+	clusterURN := kubernetesClusterURN(tenantID, attributes)
 	if workloadURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
 			URN:        workloadURN,
@@ -72,6 +76,7 @@ func kubernetesWorkloadProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 	if serviceAccountURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{URN: serviceAccountURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "kubernetes.service_account", Label: firstNonEmpty(attributes["service_account_name"], "default")})
 	}
+	addKubernetesCluster(entities, tenantID, event.GetSourceId(), attributes, clusterURN)
 	addKubernetesNamespace(entities, tenantID, event.GetSourceId(), attributes, namespaceURN)
 	if workloadURN != "" && serviceAccountURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), workloadURN, serviceAccountURN, relationRunsAs, map[string]string{"event_id": event.GetId()}))
@@ -79,6 +84,7 @@ func kubernetesWorkloadProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 	if workloadURN != "" && namespaceURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), workloadURN, namespaceURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 	}
+	addKubernetesClusterLinks(entities, links, tenantID, event.GetSourceId(), event, attributes, namespaceURN, clusterURN)
 	return identityProjectionResult(entities, links)
 }
 
@@ -91,9 +97,13 @@ func kubernetesWorkloadIdentityBindingProjections(event *cerebrov1.EventEnvelope
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
 	serviceAccountURN := kubernetesServiceAccountURN(tenantID, attributes)
+	namespaceURN := kubernetesNamespaceURN(tenantID, attributes)
+	clusterURN := kubernetesClusterURN(tenantID, attributes)
 	if serviceAccountURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{URN: serviceAccountURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "kubernetes.service_account", Label: firstNonEmpty(attributes["service_account_name"], "default")})
 	}
+	addKubernetesCluster(entities, tenantID, event.GetSourceId(), attributes, clusterURN)
+	addKubernetesNamespace(entities, tenantID, event.GetSourceId(), attributes, namespaceURN)
 	provider := firstNonEmpty(attributes["cloud_provider"], "cloud")
 	profile := identityProjectionProfile{Provider: provider}
 	targetType := firstNonEmpty(attributes["target_type"], attributes["cloud_principal_type"], "role")
@@ -120,7 +130,41 @@ func kubernetesWorkloadIdentityBindingProjections(event *cerebrov1.EventEnvelope
 			"role_name":    strings.TrimSpace(attributes["role_name"]),
 		}))
 	}
+	if serviceAccountURN != "" && namespaceURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), serviceAccountURN, namespaceURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+	}
+	addKubernetesClusterLinks(entities, links, tenantID, event.GetSourceId(), event, attributes, namespaceURN, clusterURN)
 	return identityProjectionResult(entities, links)
+}
+
+func addKubernetesCluster(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, attributes map[string]string, clusterURN string) {
+	if clusterURN == "" {
+		return
+	}
+	clusterID := kubernetesClusterIdentity(attributes)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        clusterURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "kubernetes.cluster",
+		Label:      clusterID,
+		Attributes: map[string]string{
+			"cloud_account_id": kubernetesCloudAccountID(attributes),
+			"cloud_provider":   strings.TrimSpace(firstNonEmpty(attributes["cloud_provider"], attributes["provider"])),
+			"cluster_id":       strings.TrimSpace(attributes["cluster_id"]),
+			"cluster_name":     strings.TrimSpace(attributes["cluster_name"]),
+		},
+	})
+}
+
+func addKubernetesClusterLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, attributes map[string]string, namespaceURN string, clusterURN string) {
+	if clusterURN == "" {
+		return
+	}
+	if namespaceURN != "" {
+		addLink(links, projectedLink(tenantID, sourceID, namespaceURN, clusterURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+	}
+	addCloudAccountLink(entities, links, tenantID, sourceID, event, clusterURN, kubernetesCloudAccountID(attributes), firstNonEmpty(attributes["cloud_provider"], attributes["provider"]))
 }
 
 func addKubernetesNamespace(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, attributes map[string]string, namespaceURN string) {
@@ -133,18 +177,94 @@ func addKubernetesNamespace(entities map[string]*ports.ProjectedEntity, tenantID
 		SourceID:   sourceID,
 		EntityType: "kubernetes.namespace",
 		Label:      firstNonEmpty(attributes["namespace"], "default"),
-		Attributes: map[string]string{"cluster_id": strings.TrimSpace(attributes["cluster_id"]), "namespace": firstNonEmpty(attributes["namespace"], "default")},
+		Attributes: map[string]string{"cluster_id": strings.TrimSpace(attributes["cluster_id"]), "cluster_name": strings.TrimSpace(attributes["cluster_name"]), "namespace": firstNonEmpty(attributes["namespace"], "default")},
 	})
 }
 
+func kubernetesClusterURN(tenantID string, attributes map[string]string) string {
+	clusterID := kubernetesClusterIdentity(attributes)
+	if clusterID == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "kubernetes_cluster", clusterID)
+}
+
 func kubernetesServiceAccountURN(tenantID string, attributes map[string]string) string {
-	return projectionURN(tenantID, "kubernetes_service_account", firstNonEmpty(attributes["cluster_id"], attributes["cluster_name"]), firstNonEmpty(attributes["namespace"], "default"), firstNonEmpty(attributes["service_account_name"], attributes["name"], "default"))
+	clusterID := kubernetesClusterIdentity(attributes)
+	if clusterID == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "kubernetes_service_account", clusterID, firstNonEmpty(attributes["namespace"], "default"), firstNonEmpty(attributes["service_account_name"], attributes["name"], "default"))
 }
 
 func kubernetesNamespaceURN(tenantID string, attributes map[string]string) string {
-	return projectionURN(tenantID, "kubernetes_namespace", firstNonEmpty(attributes["cluster_id"], attributes["cluster_name"]), firstNonEmpty(attributes["namespace"], "default"))
+	clusterID := kubernetesClusterIdentity(attributes)
+	if clusterID == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "kubernetes_namespace", clusterID, firstNonEmpty(attributes["namespace"], "default"))
 }
 
 func kubernetesWorkloadURN(tenantID string, attributes map[string]string) string {
-	return projectionURN(tenantID, "kubernetes_workload", firstNonEmpty(attributes["cluster_id"], attributes["cluster_name"]), firstNonEmpty(attributes["namespace"], "default"), firstNonEmpty(attributes["workload_uid"], attributes["workload_kind"]+"/"+attributes["workload_name"], attributes["name"]))
+	clusterID := kubernetesClusterIdentity(attributes)
+	if clusterID == "" {
+		return ""
+	}
+	workloadID := strings.TrimSpace(attributes["workload_uid"])
+	if workloadID == "" && strings.TrimSpace(attributes["workload_kind"]) != "" && strings.TrimSpace(attributes["workload_name"]) != "" {
+		workloadID = strings.TrimSpace(attributes["workload_kind"]) + "/" + strings.TrimSpace(attributes["workload_name"])
+	}
+	workloadID = firstNonEmpty(workloadID, attributes["name"])
+	if workloadID == "" {
+		return ""
+	}
+	return projectionURN(tenantID, "kubernetes_workload", clusterID, firstNonEmpty(attributes["namespace"], "default"), workloadID)
+}
+
+func kubernetesClusterIdentity(attributes map[string]string) string {
+	if clusterID := strings.TrimSpace(attributes["cluster_id"]); clusterID != "" {
+		return clusterID
+	}
+	clusterName := strings.TrimSpace(attributes["cluster_name"])
+	if clusterName == "" {
+		return ""
+	}
+	if scope := firstNonEmpty(kubernetesCloudAccountID(attributes), attributes["cloud_provider"], attributes["provider"]); scope != "" {
+		return scope + ":" + clusterName
+	}
+	return clusterName
+}
+
+func kubernetesCloudAccountID(attributes map[string]string) string {
+	provider := normalizeIdentifier(firstNonEmpty(attributes["cloud_provider"], attributes["provider"]))
+	switch provider {
+	case "aws":
+		return firstNonEmpty(
+			awsAccountID(attributes["cloud_account_external_id"]),
+			awsAccountID(attributes["cloud_account_id"]),
+			awsAccountID(attributes["account_id"]),
+			awsAccountID(attributes["aws_account_id"]),
+		)
+	case "azure":
+		return firstNonEmpty(
+			attributes["subscription_id"],
+			attributes["cloud_account_external_id"],
+			azureSubscriptionIDFromScope(attributes["scope"]),
+			azureSubscriptionIDFromScope(attributes["resource_id"]),
+			azureSubscriptionIDFromScope(attributes["target_id"]),
+		)
+	case "gcp":
+		return firstNonEmpty(
+			attributes["gcp_project_id"],
+			attributes["project_id"],
+			attributes["cloud_account_external_id"],
+		)
+	default:
+		return firstNonEmpty(
+			attributes["subscription_id"],
+			attributes["aws_account_id"],
+			attributes["gcp_project_id"],
+			attributes["project_id"],
+		)
+	}
 }

--- a/internal/sourceprojection/kubernetes.go
+++ b/internal/sourceprojection/kubernetes.go
@@ -229,10 +229,11 @@ func kubernetesClusterIdentity(attributes map[string]string) string {
 	if clusterName == "" {
 		return ""
 	}
-	if scope := firstNonEmpty(kubernetesCloudAccountID(attributes), attributes["cloud_provider"], attributes["provider"]); scope != "" {
-		return scope + ":" + clusterName
+	accountID := kubernetesCloudAccountID(attributes)
+	if accountID == "" {
+		return ""
 	}
-	return clusterName
+	return accountID + ":" + clusterName
 }
 
 func kubernetesCloudAccountID(attributes map[string]string) string {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -791,8 +791,9 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 			}
 		}
 	} else if actorIsAutomation {
-		credentialURN := githubCredentialURN(tenantID, githubAutomationCredentialID(attributes))
-		if credentialURN != "" {
+		credentialID := githubAutomationCredentialID(attributes)
+		if credentialID != "" {
+			credentialURN := githubCredentialURN(tenantID, credentialID)
 			credentialAttrs := map[string]string{
 				"actor":                    actor,
 				"actor_is_agent":           actorIsAgent,

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -166,6 +166,7 @@ func (s *Service) ProjectRecords(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 	if err != nil {
 		return nil, nil, err
 	}
+	normalizeProjectedEntityTypes(entities)
 	stampProjectionRuntime(event, entities, links)
 	return entities, links, nil
 }
@@ -790,9 +791,40 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 			}
 		}
 	} else if actorIsAutomation {
-		// Automation actors are GitHub Apps/agents, not human identities. Keep the
-		// audit event in the append log but do not project them into the identity
-		// graph or repeatedly rewrite hot bot->repo acted_on edges.
+		credentialURN := githubCredentialURN(tenantID, githubAutomationCredentialID(attributes))
+		if credentialURN != "" {
+			credentialAttrs := map[string]string{
+				"actor":                    actor,
+				"actor_is_agent":           actorIsAgent,
+				"actor_is_bot":             actorIsBot,
+				"actor_type":               actorType,
+				"credential_type":          "automation_actor",
+				"programmatic_access_type": programmaticAccessType,
+			}
+			addProjectedAttribute(credentialAttrs, "github_app_id", strings.TrimSpace(attributes["github_app_id"]))
+			addProjectedAttribute(credentialAttrs, "org", org)
+			addProjectedAttribute(credentialAttrs, "org_id", orgID)
+			addProjectedAttribute(credentialAttrs, "repository", repo)
+			addProjectedAttribute(credentialAttrs, "token_id", tokenID)
+			addEntity(entities, &ports.ProjectedEntity{
+				URN:        credentialURN,
+				TenantID:   tenantID,
+				SourceID:   event.GetSourceId(),
+				EntityType: "github.credential",
+				Label:      firstNonEmpty(strings.TrimSpace(attributes["github_app_name"]), strings.TrimSpace(attributes["github_app_id"]), actor, tokenID),
+				Attributes: credentialAttrs,
+			})
+			if resourceURN != "" && resourceURN != credentialURN {
+				automationActedAttrs := cloneStringMap(actedAttrs)
+				automationActedAttrs["match_type"] = "automation_actor"
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), credentialURN, resourceURN, relationActedOn, automationActedAttrs))
+			}
+			if repoScopePresent && repoURN != "" {
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), credentialURN, repoURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+			} else if orgURN != "" {
+				addLink(links, projectedLink(tenantID, event.GetSourceId(), credentialURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+			}
+		}
 	} else {
 		actorURN := githubUserURN(tenantID, actor)
 		if actorURN != "" {
@@ -972,6 +1004,21 @@ func githubProgrammaticCredentialID(attributes map[string]string) string {
 	}
 	scope := firstNonEmpty(attributes["repo"], attributes["org"], attributes["scope"])
 	return strings.Join(nonEmptyStrings(prefix, attributes["resource_id"], scope, attributes["actor"]), ":")
+}
+
+func githubAutomationCredentialID(attributes map[string]string) string {
+	if appID := strings.TrimSpace(attributes["github_app_id"]); appID != "" {
+		return "automation_app:" + appID
+	}
+	if tokenID := strings.TrimSpace(attributes["token_id"]); tokenID != "" {
+		return "automation_token:" + tokenID
+	}
+	actor := strings.TrimSpace(attributes["actor"])
+	scope := strings.TrimSpace(firstNonEmpty(attributes["repo"], attributes["resource_id"], attributes["org"], attributes["scope"]))
+	if actor == "" && scope == "" {
+		return ""
+	}
+	return strings.Join(nonEmptyStrings("automation_actor", actor, scope), ":")
 }
 
 func githubProgrammaticCredentialStatus(attributes map[string]string) string {
@@ -2026,6 +2073,34 @@ func sameIdentifier(left string, right string) bool {
 
 func normalizeIdentifier(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeProjectedEntityTypes(entities []*ports.ProjectedEntity) {
+	for _, entity := range entities {
+		if entity == nil {
+			continue
+		}
+		entity.EntityType = canonicalProjectedEntityType(entity.EntityType)
+	}
+}
+
+func canonicalProjectedEntityType(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == "" {
+		return normalized
+	}
+	normalized = strings.ReplaceAll(normalized, " ", "_")
+	normalized = strings.ReplaceAll(normalized, "..", ".")
+	if strings.HasPrefix(normalized, "aws.aws.") {
+		normalized = strings.TrimPrefix(normalized, "aws.")
+	}
+	switch normalized {
+	case "okta.publicclientappentity":
+		return "okta.publicclientapp"
+	case "okta.ip_address":
+		return "okta.ip"
+	}
+	return normalized
 }
 
 func payloadMap(event *cerebrov1.EventEnvelope) map[string]any {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -1509,6 +1509,25 @@ func TestGitHubAutomationCredentialIDSkipsEmptyFallback(t *testing.T) {
 	}
 }
 
+func TestProjectGitHubAuditSkipsSparseAutomationCredential(t *testing.T) {
+	graph := &projectionRecorder{}
+	_, err := New(nil, graph).Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-audit-sparse-automation",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"actor_is_bot": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if credential := graph.entities["urn:cerebro:writer:github_credential"]; credential != nil {
+		t.Fatalf("sparse automation event should not create placeholder credential: %#v", credential)
+	}
+}
+
 func TestProjectGitHubAuditSkipsSyntheticTargetUsersFromIdentityGraph(t *testing.T) {
 	for _, targetLogin := range []string{"pullrequest[bot]", "Renovate[Bot]", "deploy_key", "deploy-key"} {
 		t.Run(targetLogin, func(t *testing.T) {
@@ -2924,6 +2943,9 @@ func TestProjectAWSEffectivePermissionWithoutRoleIDSkipsRoleNode(t *testing.T) {
 	roleURN := "urn:cerebro:writer:aws_role:ReadOnlyAccess"
 	if role := state.entities[roleURN]; role != nil {
 		t.Fatalf("role entity should not be created when role_id is missing: %#v", role)
+	}
+	if role := state.entities["urn:cerebro:writer:aws_role"]; role != nil {
+		t.Fatalf("placeholder role entity should not be created when role_id is missing: %#v", role)
 	}
 	resourceURN := "urn:cerebro:writer:aws_bucket:arn:aws:s3:::writer-bucket"
 	assertProjectedLink(t, state, "urn:cerebro:writer:aws_user:analyst@writer.com", relationCanPerform, resourceURN)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -3180,6 +3180,36 @@ func TestProjectKubernetesClusterNameFallbackIsScopedByAccount(t *testing.T) {
 	assertProjectedLinkMissing(t, state, "urn:cerebro:writer:kubernetes_cluster:prod", relationBelongsTo, "urn:cerebro:writer:cloud_account:account-a")
 }
 
+func TestProjectKubernetesClusterNameFallbackRequiresAccountScope(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "k8s-cluster-name-provider-only",
+		TenantId: "writer",
+		SourceId: "kubernetes",
+		Kind:     "kubernetes.workload",
+		Attributes: map[string]string{
+			"cloud_provider":       "aws",
+			"cluster_name":         "prod",
+			"namespace":            "payments",
+			"service_account_name": "api",
+			"workload_kind":        "Deployment",
+			"workload_name":        "payments-api",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	if entity := state.entities["urn:cerebro:writer:kubernetes_cluster:aws:prod"]; entity != nil {
+		t.Fatalf("provider-only cluster_name fallback should not create scoped cluster: %#v", entity)
+	}
+	if entity := state.entities["urn:cerebro:writer:kubernetes_cluster:prod"]; entity != nil {
+		t.Fatalf("provider-only cluster_name fallback should not create unscoped cluster: %#v", entity)
+	}
+}
+
 func TestProjectKubernetesCloudAccountIDUsesProjectIDFallback(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -1422,7 +1422,7 @@ func TestProjectGitHubAuditOmitsAtWhenOccurredAtMissing(t *testing.T) {
 	}
 }
 
-func TestProjectGitHubAuditSkipsAutomationActorsFromIdentityGraph(t *testing.T) {
+func TestProjectGitHubAuditProjectsAutomationActorsAsCredentials(t *testing.T) {
 	cases := []struct {
 		name  string
 		actor string
@@ -1484,15 +1484,28 @@ func TestProjectGitHubAuditSkipsAutomationActorsFromIdentityGraph(t *testing.T) 
 			if _, ok := graph.entities[actorURN]; ok {
 				t.Fatalf("automation actor %q should not be projected as github.user: %#v", actorURN, graph.entities[actorURN])
 			}
-			if _, ok := graph.links[actorURN+"|"+relationActedOn+"|urn:cerebro:writer:github_repo:writer/cerebro"]; ok {
-				t.Fatalf("automation actor %q should not emit acted_on repo links", actorURN)
+			credentialID := githubAutomationCredentialID(attrs)
+			credentialURN := "urn:cerebro:writer:github_credential:" + credentialID
+			credential := graph.entities[credentialURN]
+			if credential == nil {
+				t.Fatalf("automation actor should project github.credential %q; got entities=%#v", credentialURN, graph.entities)
 			}
+			if got := credential.EntityType; got != "github.credential" {
+				t.Fatalf("credential entity_type = %q, want github.credential", got)
+			}
+			assertProjectedLink(t, graph, credentialURN, relationActedOn, "urn:cerebro:writer:github_repo:writer/cerebro")
 			for key := range graph.links {
 				if strings.HasPrefix(key, actorURN+"|") {
 					t.Fatalf("automation actor %q emitted identity graph link %q", actorURN, key)
 				}
 			}
 		})
+	}
+}
+
+func TestGitHubAutomationCredentialIDSkipsEmptyFallback(t *testing.T) {
+	if got := githubAutomationCredentialID(map[string]string{}); got != "" {
+		t.Fatalf("githubAutomationCredentialID(empty) = %q, want empty", got)
 	}
 }
 
@@ -2299,6 +2312,9 @@ func TestProjectIdentityProviderJoinEdges(t *testing.T) {
 	assertProjectedLink(t, state, awsUserURN, relationCanAdmin, "urn:cerebro:writer:aws_admin_role:AdministratorAccess")
 	assertProjectedLink(t, state, gcpUserURN, relationCanAdmin, "urn:cerebro:writer:gcp_admin_role:roles/owner")
 	assertProjectedLink(t, state, googleUserURN, relationActedOn, "urn:cerebro:writer:google_workspace_security_setting:two_step")
+	assertProjectedLink(t, state, awsUserURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:123456789012")
+	assertProjectedLink(t, state, "urn:cerebro:writer:aws_admin_role:AdministratorAccess", relationBelongsTo, "urn:cerebro:writer:cloud_account:123456789012")
+	assertProjectedLinkMissing(t, state, gcpUserURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
 }
 
 func TestProjectCloudReadOnlyRoleAssignmentsAvoidAdminEdges(t *testing.T) {
@@ -2404,6 +2420,11 @@ func TestProjectCloudReadOnlyRoleAssignmentsAvoidAdminEdges(t *testing.T) {
 	assertProjectedLink(t, state, "urn:cerebro:writer:gcp_service_account:sa@writer-prod.iam.gserviceaccount.com", relationHasIdentifier, "urn:cerebro:writer:identifier:email:sa@writer-prod.iam.gserviceaccount.com")
 	assertProjectedLink(t, state, "urn:cerebro:writer:aws_user:analyst@writer.com", relationAssignedTo, "urn:cerebro:writer:aws_credential:AKIAEXAMPLE")
 	assertProjectedLink(t, state, "urn:cerebro:writer:gcp_service_account:sa@writer-prod.iam.gserviceaccount.com", relationAssignedTo, "urn:cerebro:writer:gcp_credential:projects/writer-prod/serviceAccounts/sa@writer-prod.iam.gserviceaccount.com/keys/key-1")
+	assertProjectedLink(t, state, "urn:cerebro:writer:aws_user:analyst@writer.com", relationBelongsTo, "urn:cerebro:writer:cloud_account:123456789012")
+	assertProjectedLink(t, state, "urn:cerebro:writer:aws_role:ReadOnlyAccess", relationBelongsTo, "urn:cerebro:writer:cloud_account:123456789012")
+	assertProjectedLink(t, state, "urn:cerebro:writer:aws_credential:AKIAEXAMPLE", relationBelongsTo, "urn:cerebro:writer:cloud_account:123456789012")
+	assertProjectedLink(t, state, "urn:cerebro:writer:gcp_service_account:sa@writer-prod.iam.gserviceaccount.com", relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
+	assertProjectedLink(t, state, "urn:cerebro:writer:gcp_credential:projects/writer-prod/serviceAccounts/sa@writer-prod.iam.gserviceaccount.com/keys/key-1", relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
 }
 
 func TestProjectAzureIdentityEdges(t *testing.T) {
@@ -2466,12 +2487,13 @@ func TestProjectAzureIdentityEdges(t *testing.T) {
 			SourceId: "azure",
 			Kind:     "azure.service_principal",
 			Attributes: map[string]string{
-				"app_id":         "app-client-1",
-				"display_name":   "Prod App",
-				"domain":         "tenant-1",
-				"login":          "app-client-1",
-				"principal_type": "service_principal",
-				"user_id":        "sp-1",
+				"app_id":          "app-client-1",
+				"display_name":    "Prod App",
+				"domain":          "tenant-1",
+				"login":           "app-client-1",
+				"principal_type":  "service_principal",
+				"subscription_id": "sub-1",
+				"user_id":         "sp-1",
 			},
 		},
 		{
@@ -2496,13 +2518,14 @@ func TestProjectAzureIdentityEdges(t *testing.T) {
 			SourceId: "azure",
 			Kind:     "azure.iam_role_assignment",
 			Attributes: map[string]string{
-				"domain":       "tenant-1",
-				"is_admin":     "false",
-				"role_id":      "Reader",
-				"role_name":    "Reader",
-				"role_type":    "azure_rbac_role",
-				"subject_id":   "sp-1",
-				"subject_type": "service_principal",
+				"domain":          "tenant-1",
+				"is_admin":        "false",
+				"role_id":         "Reader",
+				"role_name":       "Reader",
+				"role_type":       "azure_rbac_role",
+				"subscription_id": "sub-1",
+				"subject_id":      "sp-1",
+				"subject_type":    "service_principal",
 			},
 		},
 		{
@@ -2514,6 +2537,7 @@ func TestProjectAzureIdentityEdges(t *testing.T) {
 				"credential_id":   "app-password-1",
 				"credential_type": "azure_application_password",
 				"domain":          "tenant-1",
+				"subscription_id": "sub-1",
 				"subject_id":      "app-client-1",
 				"subject_type":    "application",
 			},
@@ -2530,6 +2554,19 @@ func TestProjectAzureIdentityEdges(t *testing.T) {
 				"event_type":    "Update conditional access policy",
 				"resource_id":   "policy-1",
 				"resource_type": "conditional_access_policy",
+			},
+		},
+		{
+			Id:       "azure-activity",
+			TenantId: "writer",
+			SourceId: "azure",
+			Kind:     "azure.activity_log",
+			Attributes: map[string]string{
+				"actor_id":      "sp-1",
+				"event_type":    "Microsoft.Compute/virtualMachines/write",
+				"resource_id":   "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-1",
+				"resource_name": "vm-1",
+				"resource_type": "virtual_machine",
 			},
 		},
 	}
@@ -2550,6 +2587,37 @@ func TestProjectAzureIdentityEdges(t *testing.T) {
 	assertProjectedLinkMissing(t, state, azureServicePrincipalURN, relationCanAdmin, "urn:cerebro:writer:azure_admin_role:Reader")
 	assertProjectedLink(t, state, azureApplicationURN, relationAssignedTo, "urn:cerebro:writer:azure_credential:app-password-1")
 	assertProjectedLink(t, state, azureUserURN, relationActedOn, "urn:cerebro:writer:azure_conditional_access_policy:policy-1")
+	assertProjectedLink(t, state, azureServicePrincipalURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:sub-1")
+	assertProjectedLink(t, state, "urn:cerebro:writer:azure_role:Reader", relationBelongsTo, "urn:cerebro:writer:cloud_account:sub-1")
+	assertProjectedLink(t, state, "urn:cerebro:writer:azure_credential:app-password-1", relationBelongsTo, "urn:cerebro:writer:cloud_account:sub-1")
+	assertProjectedLinkMissing(t, state, azureUserURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:tenant-1")
+	azureVMURN := "urn:cerebro:writer:azure_virtual_machine:/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Compute/virtualMachines/vm-1"
+	resourceGroupURN := "urn:cerebro:writer:azure_resource_group:sub-1:rg-prod"
+	assertProjectedLink(t, state, azureVMURN, relationBelongsTo, resourceGroupURN)
+	assertProjectedLink(t, state, resourceGroupURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:sub-1")
+}
+
+func TestProjectAzureActivitySkipsResourceGroupWithoutSubscription(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "azure-activity-no-subscription",
+		TenantId: "writer",
+		SourceId: "azure",
+		Kind:     "azure.activity_log",
+		Attributes: map[string]string{
+			"event_type":     "Microsoft.Compute/virtualMachines/write",
+			"resource_group": "rg-prod",
+			"resource_id":    "vm-1",
+			"resource_type":  "virtual_machine",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	assertProjectedLinkMissing(t, state, "urn:cerebro:writer:azure_virtual_machine:vm-1", relationBelongsTo, "urn:cerebro:writer:azure_resource_group:rg-prod")
 }
 
 func TestProjectCloudExposureAndPrivilegePaths(t *testing.T) {
@@ -2794,6 +2862,7 @@ func TestProjectAWSInlineEffectivePermission(t *testing.T) {
 			"resource_type": "aws_iam_policy",
 			"role_id":       "inline:user:admin@writer.com:InlineAdmin",
 			"role_name":     "InlineAdmin",
+			"scope":         "arn:aws:s3:::writer-bucket",
 			"subject_id":    "admin@writer.com",
 			"subject_type":  "user",
 		},
@@ -2804,6 +2873,7 @@ func TestProjectAWSInlineEffectivePermission(t *testing.T) {
 	}
 
 	policyURN := "urn:cerebro:writer:aws_aws_iam_policy:inline:user:admin@writer.com:InlineAdmin"
+	roleURN := "urn:cerebro:writer:aws_role:inline:user:admin@writer.com:InlineAdmin"
 	permissionLink := state.links["urn:cerebro:writer:aws_user:admin@writer.com|"+relationCanPerform+"|"+policyURN]
 	if permissionLink == nil {
 		t.Fatalf("inline effective permission link missing")
@@ -2817,6 +2887,46 @@ func TestProjectAWSInlineEffectivePermission(t *testing.T) {
 	if got := permissionLink.Attributes["is_admin"]; got != "true" {
 		t.Fatalf("permission link is_admin = %q, want true", got)
 	}
+	if role := state.entities[roleURN]; role == nil || role.EntityType != "aws.role" {
+		t.Fatalf("role entity missing or wrong type: %#v", role)
+	}
+	assertProjectedLink(t, state, "urn:cerebro:writer:aws_user:admin@writer.com", relationAssignedTo, roleURN)
+	assertProjectedLink(t, state, roleURN, relationCanPerform, policyURN)
+	assertProjectedLink(t, state, roleURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:123456789012")
+	assertProjectedLinkMissing(t, state, roleURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:arn:aws:s3:::writer-bucket")
+}
+
+func TestProjectAWSEffectivePermissionWithoutRoleIDSkipsRoleNode(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	event := &cerebrov1.EventEnvelope{
+		Id:       "aws-effective-permission-no-role-id",
+		TenantId: "writer",
+		SourceId: "aws",
+		Kind:     "aws.effective_permission",
+		Attributes: map[string]string{
+			"actions":       "s3:GetObject",
+			"domain":        "123456789012",
+			"effect":        "allow",
+			"permission":    "s3:GetObject",
+			"policy_source": "managed",
+			"resource_id":   "arn:aws:s3:::writer-bucket",
+			"resource_name": "writer-bucket",
+			"resource_type": "bucket",
+			"role_name":     "ReadOnlyAccess",
+			"subject_id":    "analyst@writer.com",
+			"subject_type":  "user",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	roleURN := "urn:cerebro:writer:aws_role:ReadOnlyAccess"
+	if role := state.entities[roleURN]; role != nil {
+		t.Fatalf("role entity should not be created when role_id is missing: %#v", role)
+	}
+	resourceURN := "urn:cerebro:writer:aws_bucket:arn:aws:s3:::writer-bucket"
+	assertProjectedLink(t, state, "urn:cerebro:writer:aws_user:analyst@writer.com", relationCanPerform, resourceURN)
 }
 
 func TestProjectEffectivePermissionsKubernetesRuntimeAndData(t *testing.T) {
@@ -2920,6 +3030,310 @@ func TestProjectEffectivePermissionsKubernetesRuntimeAndData(t *testing.T) {
 	assertProjectedLink(t, state, "urn:cerebro:writer:runtime_evidence:evidence-1", relationObservedOn, "urn:cerebro:writer:kubernetes_workload:prod-cluster:payments:workload-1")
 	assertProjectedLink(t, state, "urn:cerebro:writer:aws_secret_store:prod-secrets", relationHasClassification, "urn:cerebro:writer:data_classification:restricted")
 	assertProjectedLink(t, state, "urn:cerebro:writer:aws_secret_store:prod-secrets", relationTaggedAs, "urn:cerebro:writer:asset_tag:crown_jewel")
+}
+
+func TestProjectKubernetesWorkloadBuildsClusterAndCloudAccountLinks(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "k8s-workload-cluster",
+		TenantId: "writer",
+		SourceId: "kubernetes",
+		Kind:     "kubernetes.workload",
+		Attributes: map[string]string{
+			"cloud_account_external_id": "123456789012",
+			"cloud_provider":            "aws",
+			"cluster_id":                "prod-cluster",
+			"namespace":                 "payments",
+			"service_account_name":      "api",
+			"workload_kind":             "Deployment",
+			"workload_name":             "payments-api",
+			"workload_uid":              "workload-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	clusterURN := "urn:cerebro:writer:kubernetes_cluster:prod-cluster"
+	namespaceURN := "urn:cerebro:writer:kubernetes_namespace:prod-cluster:payments"
+	assertProjectedLink(t, state, namespaceURN, relationBelongsTo, clusterURN)
+	assertProjectedLink(t, state, clusterURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:123456789012")
+	if got := state.entities[clusterURN].EntityType; got != "kubernetes.cluster" {
+		t.Fatalf("cluster entity_type = %q, want kubernetes.cluster", got)
+	}
+}
+
+func TestProjectKubernetesWorkloadIdentityBindingAddsContainmentLinks(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "k8s-wid-cluster",
+		TenantId: "writer",
+		SourceId: "kubernetes",
+		Kind:     "kubernetes.workload_identity_binding",
+		Attributes: map[string]string{
+			"cloud_provider":       "gcp",
+			"cluster_id":           "prod-cluster",
+			"gcp_project_id":       "writer-prod",
+			"namespace":            "payments",
+			"relationship":         "can_impersonate",
+			"service_account_name": "api",
+			"target_email":         "payments-sa@writer-prod.iam.gserviceaccount.com",
+			"target_id":            "payments-sa@writer-prod.iam.gserviceaccount.com",
+			"target_type":          "service_account",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	serviceAccountURN := "urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:api"
+	namespaceURN := "urn:cerebro:writer:kubernetes_namespace:prod-cluster:payments"
+	clusterURN := "urn:cerebro:writer:kubernetes_cluster:prod-cluster"
+	assertProjectedLink(t, state, serviceAccountURN, relationBelongsTo, namespaceURN)
+	assertProjectedLink(t, state, namespaceURN, relationBelongsTo, clusterURN)
+	assertProjectedLink(t, state, clusterURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
+	assertProjectedLink(t, state, serviceAccountURN, relationCanImpersonate, "urn:cerebro:writer:gcp_service_account:payments-sa@writer-prod.iam.gserviceaccount.com")
+}
+
+func TestProjectKubernetesWorkloadFallbackURNIncludesKind(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	for _, kind := range []string{"Deployment", "CronJob"} {
+		_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+			Id:       "k8s-workload-" + kind,
+			TenantId: "writer",
+			SourceId: "kubernetes",
+			Kind:     "kubernetes.workload",
+			Attributes: map[string]string{
+				"cluster_id":           "prod-cluster",
+				"name":                 "payments-api",
+				"namespace":            "payments",
+				"service_account_name": "api",
+				"workload_kind":        kind,
+				"workload_name":        "payments-api",
+			},
+		})
+		if err != nil {
+			t.Fatalf("Project() error = %v", err)
+		}
+	}
+
+	assertProjectedLink(t, state, "urn:cerebro:writer:kubernetes_workload:prod-cluster:payments:Deployment/payments-api", relationRunsAs, "urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:api")
+	assertProjectedLink(t, state, "urn:cerebro:writer:kubernetes_workload:prod-cluster:payments:CronJob/payments-api", relationRunsAs, "urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:api")
+	assertProjectedLinkMissing(t, state, "urn:cerebro:writer:kubernetes_workload:prod-cluster:payments:payments-api", relationRunsAs, "urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:api")
+}
+
+func TestProjectKubernetesClusterNameFallbackIsScopedByAccount(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	for _, accountID := range []string{"account-a", "account-b"} {
+		_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+			Id:       "k8s-cluster-name-" + accountID,
+			TenantId: "writer",
+			SourceId: "kubernetes",
+			Kind:     "kubernetes.workload",
+			Attributes: map[string]string{
+				"cloud_account_external_id": accountID,
+				"cloud_provider":            "azure",
+				"cluster_name":              "prod",
+				"namespace":                 "payments",
+				"service_account_name":      "api",
+				"workload_kind":             "Deployment",
+				"workload_name":             "payments-api",
+			},
+		})
+		if err != nil {
+			t.Fatalf("Project() error = %v", err)
+		}
+	}
+
+	assertProjectedLink(t, state, "urn:cerebro:writer:kubernetes_cluster:account-a:prod", relationBelongsTo, "urn:cerebro:writer:cloud_account:account-a")
+	assertProjectedLink(t, state, "urn:cerebro:writer:kubernetes_cluster:account-b:prod", relationBelongsTo, "urn:cerebro:writer:cloud_account:account-b")
+	assertProjectedLinkMissing(t, state, "urn:cerebro:writer:kubernetes_cluster:prod", relationBelongsTo, "urn:cerebro:writer:cloud_account:account-a")
+}
+
+func TestProjectKubernetesCloudAccountIDUsesProjectIDFallback(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "k8s-gcp-project-id",
+		TenantId: "writer",
+		SourceId: "kubernetes",
+		Kind:     "kubernetes.workload",
+		Attributes: map[string]string{
+			"cluster_id":           "gke-prod",
+			"namespace":            "payments",
+			"project_id":           "writer-prod",
+			"service_account_name": "api",
+			"workload_kind":        "Deployment",
+			"workload_name":        "payments-api",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	assertProjectedLink(t, state, "urn:cerebro:writer:kubernetes_cluster:gke-prod", relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
+}
+
+func TestProjectKubernetesAzureSkipsGenericAccountID(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "k8s-azure-generic-account",
+		TenantId: "writer",
+		SourceId: "kubernetes",
+		Kind:     "kubernetes.workload",
+		Attributes: map[string]string{
+			"account_id":           "tenant-or-local-account",
+			"cloud_provider":       "azure",
+			"cluster_id":           "aks-prod",
+			"namespace":            "payments",
+			"service_account_name": "api",
+			"workload_kind":        "Deployment",
+			"workload_name":        "payments-api",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	assertProjectedLinkMissing(t, state, "urn:cerebro:writer:kubernetes_cluster:aks-prod", relationBelongsTo, "urn:cerebro:writer:cloud_account:tenant-or-local-account")
+}
+
+func TestProjectKubernetesSparseEventsSkipPlaceholderURNs(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	events := []*cerebrov1.EventEnvelope{
+		{
+			Id:       "k8s-workload-no-cluster",
+			TenantId: "writer",
+			SourceId: "kubernetes",
+			Kind:     "kubernetes.workload",
+			Attributes: map[string]string{
+				"namespace":     "payments",
+				"workload_kind": "Deployment",
+				"workload_name": "payments-api",
+			},
+		},
+		{
+			Id:       "k8s-workload-no-id",
+			TenantId: "writer",
+			SourceId: "kubernetes",
+			Kind:     "kubernetes.workload",
+			Attributes: map[string]string{
+				"cluster_id":     "prod-cluster",
+				"namespace":      "payments",
+				"workload_kind":  "Deployment",
+				"workload_name":  "",
+				"workload_uid":   "",
+				"workload_image": "api",
+			},
+		},
+		{
+			Id:       "k8s-service-account-no-cluster",
+			TenantId: "writer",
+			SourceId: "kubernetes",
+			Kind:     "kubernetes.service_account",
+			Attributes: map[string]string{
+				"namespace":            "payments",
+				"service_account_name": "api",
+			},
+		},
+	}
+	for _, event := range events {
+		if _, err := service.Project(context.Background(), event); err != nil {
+			t.Fatalf("Project(%s) error = %v", event.GetId(), err)
+		}
+	}
+
+	for _, urn := range []string{
+		"urn:cerebro:writer:kubernetes_workload:payments:Deployment/payments-api",
+		"urn:cerebro:writer:kubernetes_workload:prod-cluster:payments:/",
+		"urn:cerebro:writer:kubernetes_service_account:payments:api",
+		"urn:cerebro:writer:kubernetes_namespace:payments",
+	} {
+		if _, ok := state.entities[urn]; ok {
+			t.Fatalf("sparse event minted placeholder entity %q", urn)
+		}
+	}
+}
+
+func TestProjectAssetClassificationLinksStrongCloudResourceIDsToAccounts(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	events := []*cerebrov1.EventEnvelope{
+		{
+			Id:       "asset-aws-arn",
+			TenantId: "writer",
+			SourceId: "asset",
+			Kind:     "asset.data_sensitivity",
+			Attributes: map[string]string{
+				"data_classification": "restricted",
+				"resource_id":         "arn:aws:s3:::writer-bucket",
+				"resource_name":       "writer-bucket",
+				"resource_type":       "bucket",
+				"source_provider":     "aws",
+				"aws_account_id":      "123456789012",
+			},
+		},
+		{
+			Id:       "asset-azure-arm",
+			TenantId: "writer",
+			SourceId: "asset",
+			Kind:     "asset.data_sensitivity",
+			Attributes: map[string]string{
+				"data_classification": "confidential",
+				"resource_id":         "/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Storage/storageAccounts/data",
+				"resource_type":       "storage_account",
+				"source_provider":     "azure",
+			},
+		},
+		{
+			Id:       "asset-gcp-resource",
+			TenantId: "writer",
+			SourceId: "asset",
+			Kind:     "asset.data_sensitivity",
+			Attributes: map[string]string{
+				"data_classification": "internal",
+				"resource_id":         "projects/writer-prod/buckets/data",
+				"resource_type":       "bucket",
+				"source_provider":     "gcp",
+			},
+		},
+		{
+			Id:       "asset-bare-name",
+			TenantId: "writer",
+			SourceId: "asset",
+			Kind:     "asset.data_sensitivity",
+			Attributes: map[string]string{
+				"data_classification": "restricted",
+				"resource_id":         "prod-secrets",
+				"resource_type":       "secret_store",
+				"source_provider":     "aws",
+			},
+		},
+	}
+	for _, event := range events {
+		if _, err := service.Project(context.Background(), event); err != nil {
+			t.Fatalf("Project(%s) error = %v", event.GetId(), err)
+		}
+	}
+
+	assertProjectedLink(t, state, "urn:cerebro:writer:aws_bucket:arn:aws:s3:::writer-bucket", relationBelongsTo, "urn:cerebro:writer:cloud_account:123456789012")
+	assertProjectedLink(t, state, "urn:cerebro:writer:azure_storage_account:/subscriptions/sub-1/resourceGroups/rg-prod/providers/Microsoft.Storage/storageAccounts/data", relationBelongsTo, "urn:cerebro:writer:cloud_account:sub-1")
+	assertProjectedLink(t, state, "urn:cerebro:writer:gcp_bucket:projects/writer-prod/buckets/data", relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
+	assertProjectedLinkMissing(t, state, "urn:cerebro:writer:aws_secret_store:prod-secrets", relationBelongsTo, "urn:cerebro:writer:cloud_account:prod-secrets")
 }
 
 func assertProjectedLink(t *testing.T, recorder *projectionRecorder, fromURN string, relation string, toURN string) {

--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -88,6 +88,7 @@ func sentinelOneAgentProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proje
 
 	addSentinelOneScopeLinks(entities, links, tenant, event, agentURN, attrs)
 	addSentinelOneInternetContext(entities, links, tenant, event, agentURN, attrs)
+	addSentinelOneOwnerIdentityLinks(entities, links, tenant, event, agentURN, attrs)
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
@@ -202,6 +203,7 @@ func sentinelOneThreatProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 			"mitigation_status_norm": strings.TrimSpace(attrs["mitigation_status_norm"]),
 		}))
 		addSentinelOneInternetContext(entities, links, tenant, event, agentURN, attrs)
+		addSentinelOneOwnerIdentityLinks(entities, links, tenant, event, agentURN, attrs)
 	}
 
 	addSentinelOneScopeLinks(entities, links, tenant, event, threatURN, attrs)
@@ -245,6 +247,31 @@ func addSentinelOneInternetContext(entities map[string]*ports.ProjectedEntity, l
 		"host":       host,
 		"match_type": "sentinelone_agent_hostname",
 	}))
+}
+
+func addSentinelOneOwnerIdentityLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenant string, event *cerebrov1.EventEnvelope, agentURN string, attrs map[string]string) {
+	if agentURN == "" {
+		return
+	}
+	ownerEmail := strings.TrimSpace(firstNonEmpty(attrs["user_mail"], attrs["user_email"]))
+	if ownerEmail != "" {
+		addIdentifierLink(entities, links, tenant, event.GetSourceId(), event.GetId(), agentURN, ownerEmail, event.GetOccurredAt())
+		identityURN, _ := canonicalIdentityURN(tenant, ownerEmail)
+		if identityURN != "" {
+			linkAttrs := map[string]string{
+				"at":         eventObservedAt(event),
+				"confidence": "0.85",
+				"event_id":   event.GetId(),
+				"match_type": "sentinelone_owner_email",
+			}
+			addLink(links, projectedLink(tenant, event.GetSourceId(), agentURN, identityURN, relationOwnedBy, linkAttrs))
+		}
+	}
+	ownerUser := strings.TrimSpace(attrs["user_name"])
+	if ownerUser != "" {
+		addEndpointIdentifierLink(entities, links, tenant, event.GetSourceId(), event, agentURN, "sentinelone_user_name", ownerUser, "0.60")
+	}
+	addEndpointIdentifierLink(entities, links, tenant, event.GetSourceId(), event, agentURN, "sentinelone_user_id", attrs["user_id"], "0.70")
 }
 
 func sentinelOneSiteProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -12,7 +12,7 @@ import (
 func TestProjectSentinelOneAgentBuildsAgentEntity(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
-	occurred := time.Date(2026, time.April, 23, 1, 0, 0, 0, time.UTC)
+	occurred := time.Unix(1_700_000_000, 0).UTC()
 
 	result, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
 		Id:         "s1-agent-1",
@@ -90,6 +90,59 @@ func TestProjectSentinelOneAgentBuildsAgentEntity(t *testing.T) {
 	}
 }
 
+func TestProjectSentinelOneAgentLinksOwnerIdentity(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	occurred := time.Date(2026, time.April, 23, 1, 0, 0, 0, time.UTC)
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "s1-agent-owner",
+		TenantId:   "writer",
+		SourceId:   "sentinelone",
+		Kind:       "sentinelone.agent",
+		OccurredAt: timestamppb.New(occurred),
+		Attributes: map[string]string{
+			"agent_id":  "agent-1",
+			"user_mail": "owner@writer.com",
+			"user_name": "owner",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-1"
+	identityURN := "urn:cerebro:writer:identity:email:owner@writer.com"
+	identifierURN := "urn:cerebro:writer:identifier:email:owner@writer.com"
+	assertProjectedLink(t, state, agentURN, relationOwnedBy, identityURN)
+	assertProjectedLink(t, state, agentURN, relationRepresentsIdentity, identityURN)
+	assertProjectedLink(t, state, agentURN, relationHasIdentifier, identifierURN)
+}
+
+func TestProjectSentinelOneAgentUserNameOnlySkipsStrongOwnerIdentityEdges(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "s1-agent-owner-username",
+		TenantId: "writer",
+		SourceId: "sentinelone",
+		Kind:     "sentinelone.agent",
+		Attributes: map[string]string{
+			"agent_id":  "agent-2",
+			"user_name": "owner",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-2"
+	identityURN := "urn:cerebro:writer:identity:login:owner"
+	if _, ok := state.links[agentURN+"|"+relationOwnedBy+"|"+identityURN]; ok {
+		t.Fatalf("user_name-only owner edge should not emit owned_by: %#v", state.links)
+	}
+	if _, ok := state.links[agentURN+"|"+relationRepresentsIdentity+"|"+identityURN]; ok {
+		t.Fatalf("user_name-only owner edge should not emit represents_identity: %#v", state.links)
+	}
+}
+
 func TestProjectSentinelOneAgentSkipsWhenAgentIDMissing(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
@@ -145,6 +198,7 @@ func TestProjectSentinelOneThreatLinksThreatToAgent(t *testing.T) {
 			"mitre_techniques":       "Native API",
 			"is_active":              "true",
 			"is_fileless":            "false",
+			"user_mail":              "owner@writer.com",
 		},
 	})
 	if err != nil {
@@ -165,6 +219,8 @@ func TestProjectSentinelOneThreatLinksThreatToAgent(t *testing.T) {
 		t.Fatalf("agent entity missing")
 	}
 	assertProjectedLink(t, state, agentURN, relationAffectedBy, threatURN)
+	assertProjectedLink(t, state, agentURN, relationOwnedBy, "urn:cerebro:writer:identity:email:owner@writer.com")
+	assertProjectedLink(t, state, agentURN, relationRepresentsIdentity, "urn:cerebro:writer:identity:email:owner@writer.com")
 	assertProjectedLink(t, state, agentURN, relationHasIdentifier, ipURN)
 	assertProjectedLink(t, state, agentURN, relationHasIdentifier, ipv6URN)
 	assertProjectedLink(t, state, agentURN, relationHasIdentifier, hostIdentifierURN)

--- a/internal/sourceprojection/vulnerability.go
+++ b/internal/sourceprojection/vulnerability.go
@@ -80,6 +80,7 @@ func gcpContainerVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*po
 		if vulnerabilityURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), imageURN, vulnerabilityURN, relationAffectedBy, vulnerabilityEvidenceAttributes(event, attributes)))
 		}
+		addContainerImageContextLinks(entities, links, tenantID, event.GetSourceId(), event, imageURN, attributes)
 	}
 
 	packageURN := vulnerabilityPackageURN(tenantID, attributes, "container")
@@ -102,6 +103,46 @@ func gcpContainerVulnerabilityProjections(event *cerebrov1.EventEnvelope) ([]*po
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
+}
+
+func addContainerImageContextLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, imageURN string, attributes map[string]string) {
+	if imageURN == "" {
+		return
+	}
+	addCloudAccountLink(entities, links, tenantID, sourceID, event, imageURN, firstNonEmpty(attributes["project_id"], attributes["gcp_project_id"]), "gcp")
+	registry := firstAttribute(attributes, "registry", "image_registry")
+	repository := firstAttribute(attributes, "repository", "image_repository")
+	if registry == "" || repository == "" {
+		return
+	}
+	registryURN := projectionURN(tenantID, "container_registry", registry)
+	repositoryURN := projectionURN(tenantID, "container_repository", registry, repository)
+	if registryURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        registryURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: "container.registry",
+			Label:      registry,
+			Attributes: map[string]string{"registry": registry},
+		})
+	}
+	if repositoryURN != "" {
+		addEntity(entities, &ports.ProjectedEntity{
+			URN:        repositoryURN,
+			TenantID:   tenantID,
+			SourceID:   sourceID,
+			EntityType: "container.repository",
+			Label:      repository,
+			Attributes: map[string]string{"registry": registry, "repository": repository},
+		})
+	}
+	if imageURN != "" && repositoryURN != "" {
+		addLink(links, projectedLink(tenantID, sourceID, imageURN, repositoryURN, relationBelongsTo, map[string]string{"event_id": event.GetId(), "match_type": "container_image_repository"}))
+	}
+	if repositoryURN != "" && registryURN != "" {
+		addLink(links, projectedLink(tenantID, sourceID, repositoryURN, registryURN, relationBelongsTo, map[string]string{"event_id": event.GetId(), "match_type": "container_repository_registry"}))
+	}
 }
 
 type endpointVulnerabilityProfile struct {

--- a/internal/sourceprojection/vulnerability_test.go
+++ b/internal/sourceprojection/vulnerability_test.go
@@ -184,11 +184,11 @@ func TestProjectGCPContainerVulnerabilityUsesCanonicalCVE(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 4 {
-		t.Fatalf("Project().EntitiesProjected = %d, want 4", result.EntitiesProjected)
+	if result.EntitiesProjected != 5 {
+		t.Fatalf("Project().EntitiesProjected = %d, want 5", result.EntitiesProjected)
 	}
-	if result.LinksProjected != 5 {
-		t.Fatalf("Project().LinksProjected = %d, want 5", result.LinksProjected)
+	if result.LinksProjected != 6 {
+		t.Fatalf("Project().LinksProjected = %d, want 6", result.LinksProjected)
 	}
 
 	imageURN := "urn:cerebro:writer:gcp_artifact_registry_image:us-docker.pkg.dev/writer/prod/api@sha256:abc"
@@ -200,6 +200,38 @@ func TestProjectGCPContainerVulnerabilityUsesCanonicalCVE(t *testing.T) {
 	assertProjectedLink(t, state, imageURN, relationContains, packageURN)
 	assertProjectedLink(t, state, packageURN, relationRepresents, canonicalPackageURN)
 	assertProjectedLink(t, state, canonicalPackageURN, relationAffectedBy, vulnerabilityURN)
+	assertProjectedLink(t, state, imageURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
+}
+
+func TestProjectGCPContainerVulnerabilityLinksImageRepositoryHierarchy(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "gcp-vuln-repo",
+		TenantId: "writer",
+		SourceId: "gcp",
+		Kind:     "gcp.container_vulnerability",
+		Attributes: map[string]string{
+			"cve_id":     "CVE-2025-45679",
+			"image_uri":  "us-docker.pkg.dev/writer-prod/prod/api@sha256:abc",
+			"package":    "openssl",
+			"project_id": "writer-prod",
+			"registry":   "us-docker.pkg.dev",
+			"repository": "writer-prod/prod",
+			"severity":   "medium",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	imageURN := "urn:cerebro:writer:gcp_artifact_registry_image:us-docker.pkg.dev/writer-prod/prod/api@sha256:abc"
+	repositoryURN := "urn:cerebro:writer:container_repository:us-docker.pkg.dev:writer-prod/prod"
+	registryURN := "urn:cerebro:writer:container_registry:us-docker.pkg.dev"
+	assertProjectedLink(t, state, imageURN, relationBelongsTo, repositoryURN)
+	assertProjectedLink(t, state, repositoryURN, relationBelongsTo, registryURN)
+	assertProjectedLink(t, state, imageURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
 }
 
 func TestProjectAureliusFindingUsesVulnerabilityAttributes(t *testing.T) {


### PR DESCRIPTION
## Summary
- expands generic sourceprojection graph links for Kubernetes, cloud identities, effective permissions, assets, SentinelOne ownership, GitHub automation credentials, and container image context
- hardens account inference guardrails to avoid weak placeholder/colliding cloud account links
- stabilizes cloud effective admin fingerprint inputs and adds focused regression tests

## Validation
- go test ./internal/sourceprojection -count=1
- go test ./internal/findings -count=1
- make test
- make lint