### PR TITLE
Deepen source projection graph links

### DIFF
--- a/internal/sourceprojection/aurelius.go
+++ b/internal/sourceprojection/aurelius.go
@@ -19,6 +19,7 @@ func aureliusImageScanProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 	imageURN := aureliusImageURN(tenantID, attrs)
 	if imageURN != "" {
 		addEntity(entities, aureliusImageEntity(tenantID, event.GetSourceId(), imageURN, attrs))
+		addAureliusImageContextLinks(entities, links, tenantID, event, imageURN, attrs)
 	}
 
 	scanID := firstAttribute(attrs, "scan_id", "image_digest")
@@ -61,6 +62,7 @@ func aureliusVerdictProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 	imageURN := aureliusImageURN(tenantID, attrs)
 	if imageURN != "" {
 		addEntity(entities, aureliusImageEntity(tenantID, event.GetSourceId(), imageURN, attrs))
+		addAureliusImageContextLinks(entities, links, tenantID, event, imageURN, attrs)
 	}
 
 	verdictKey := firstAttribute(attrs, "image_digest")
@@ -101,6 +103,7 @@ func aureliusFindingProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 	imageURN := aureliusImageURN(tenantID, attrs)
 	if imageURN != "" {
 		addEntity(entities, aureliusImageEntity(tenantID, event.GetSourceId(), imageURN, attrs))
+		addAureliusImageContextLinks(entities, links, tenantID, event, imageURN, attrs)
 	}
 
 	vulnerabilityURN := addCanonicalVulnerabilityEntity(entities, tenantID, event.GetSourceId(), attrs)
@@ -141,6 +144,7 @@ func aureliusCatalogPromotionProjections(event *cerebrov1.EventEnvelope) ([]*por
 	imageURN := aureliusImageURN(tenantID, attrs)
 	if imageURN != "" {
 		addEntity(entities, aureliusImageEntity(tenantID, event.GetSourceId(), imageURN, attrs))
+		addAureliusImageContextLinks(entities, links, tenantID, event, imageURN, attrs)
 	}
 
 	track := firstAttribute(attrs, "track")
@@ -263,6 +267,10 @@ func aureliusImageEntity(tenantID, sourceID, urn string, attrs map[string]string
 	}
 }
 
+func addAureliusImageContextLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, imageURN string, attrs map[string]string) {
+	addContainerImageContextLinks(entities, links, tenantID, event.GetSourceId(), event, imageURN, attrs)
+}
+
 func aureliusProjectionAttributes(event *cerebrov1.EventEnvelope) map[string]string {
 	attrs := make(map[string]string, len(event.GetAttributes()))
 	for key, value := range event.GetAttributes() {
@@ -287,8 +295,12 @@ func aureliusProjectionAttributes(event *cerebrov1.EventEnvelope) map[string]str
 		"image_uri",
 		"installed_version",
 		"package",
+		"gcp_project_id",
+		"image_registry",
+		"image_repository",
 		"promoted_at",
 		"promoted_by",
+		"project_id",
 		"reason",
 		"registry",
 		"repository",

--- a/internal/sourceprojection/aurelius_test.go
+++ b/internal/sourceprojection/aurelius_test.go
@@ -202,6 +202,35 @@ func TestProjectAureliusDigestOnlyFindingDoesNotCreateArtifactRegistryImage(t *t
 	}
 }
 
+func TestProjectAureliusImageScanLinksImageRepositoryHierarchy(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "aurelius-image-scan-context",
+		TenantId: "writer",
+		SourceId: "aurelius",
+		Kind:     "aurelius.image_scan",
+		Payload: mustJSON(t, map[string]any{
+			"image_digest": "sha256:scan",
+			"project_id":   "writer-prod",
+			"registry":     "us-docker.pkg.dev",
+			"repository":   "writer-prod/prod",
+			"scan_id":      "scan-context",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	imageURN := "urn:cerebro:writer:gcp_artifact_registry_image:us-docker.pkg.dev/writer-prod/prod@sha256:scan"
+	repositoryURN := "urn:cerebro:writer:container_repository:us-docker.pkg.dev:writer-prod/prod"
+	registryURN := "urn:cerebro:writer:container_registry:us-docker.pkg.dev"
+	assertProjectedLink(t, state, imageURN, relationBelongsTo, repositoryURN)
+	assertProjectedLink(t, state, repositoryURN, relationBelongsTo, registryURN)
+	assertProjectedLink(t, state, imageURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
+}
+
 func TestProjectAureliusImageScanOmitsBlankOptionalMetadata(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/endpoint.go
+++ b/internal/sourceprojection/endpoint.go
@@ -115,6 +115,7 @@ func endpointDeviceProjections(event *cerebrov1.EventEnvelope, profile endpointP
 	endpointURN := addEndpointEntity(entities, tenantID, event.GetSourceId(), attrs, profile)
 	addEndpointOwnerLinks(entities, links, tenantID, event.GetSourceId(), event, endpointURN, attrs)
 	addEndpointIdentifierLinks(entities, links, tenantID, event.GetSourceId(), event, endpointURN, attrs)
+	addKandjiBlueprintLink(entities, links, tenantID, event.GetSourceId(), event, endpointURN, attrs, profile)
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
@@ -191,6 +192,32 @@ func addEndpointAttribute(attrs map[string]string, key string, value string) {
 	if trimmed := strings.TrimSpace(value); trimmed != "" {
 		attrs[key] = trimmed
 	}
+}
+
+func addKandjiBlueprintLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, endpointURN string, attrs map[string]string, profile endpointProjectionProfile) {
+	blueprintID := firstAttribute(attrs, "blueprint_id")
+	if profile.Provider != "kandji" || endpointURN == "" || blueprintID == "" {
+		return
+	}
+	blueprintURN := projectionURN(tenantID, "kandji_blueprint", blueprintID)
+	if blueprintURN == "" {
+		return
+	}
+	blueprintName := firstAttribute(attrs, "blueprint_name")
+	blueprintAttrs := map[string]string{"blueprint_id": blueprintID}
+	addEndpointAttribute(blueprintAttrs, "blueprint_name", blueprintName)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        blueprintURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "kandji.blueprint",
+		Label:      firstNonEmpty(blueprintName, blueprintID),
+		Attributes: blueprintAttrs,
+	})
+	addLink(links, projectedLink(tenantID, sourceID, endpointURN, blueprintURN, relationBelongsTo, map[string]string{
+		"event_id":   event.GetId(),
+		"match_type": "kandji_blueprint",
+	}))
 }
 
 func addEndpointOwnerLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, endpointURN string, attrs map[string]string) {

--- a/internal/sourceprojection/endpoint_test.go
+++ b/internal/sourceprojection/endpoint_test.go
@@ -239,6 +239,8 @@ func TestProjectKandjiDeviceAndApplication(t *testing.T) {
 				"device_id":         "device-1",
 				"device_name":       "mba-1",
 				"serial_number":     "SERIAL1",
+				"blueprint_id":      "blueprint-1",
+				"blueprint_name":    "Engineering Macs",
 				"filevault_enabled": "true",
 				"user_email":        "alice@writer.com",
 			},
@@ -264,9 +266,14 @@ func TestProjectKandjiDeviceAndApplication(t *testing.T) {
 
 	deviceURN := "urn:cerebro:writer:kandji_device:device-1"
 	identityURN := "urn:cerebro:writer:identity:email:alice@writer.com"
+	blueprintURN := "urn:cerebro:writer:kandji_blueprint:blueprint-1"
 	packageURN := "urn:cerebro:writer:package:macos:Safari"
 	canonicalPackageURN := "urn:cerebro:writer:package:canonical:pkg:generic/Safari"
 	assertProjectedLink(t, state, deviceURN, relationOwnedBy, identityURN)
+	assertProjectedLink(t, state, deviceURN, relationBelongsTo, blueprintURN)
 	assertProjectedLink(t, state, deviceURN, relationContains, packageURN)
 	assertProjectedLink(t, state, packageURN, relationRepresents, canonicalPackageURN)
+	if blueprint := state.entities[blueprintURN]; blueprint == nil || blueprint.EntityType != "kandji.blueprint" || blueprint.Label != "Engineering Macs" {
+		t.Fatalf("blueprint entity missing or wrong: %#v", blueprint)
+	}
 }


### PR DESCRIPTION
## Summary
- adds repository and cloud-account context for existing container image projections
- links endpoint devices to their management grouping when strong source IDs are present
- adds focused regression coverage for the new graph edges

## Validation
- go test ./internal/sourceprojection -count=1
- make test
- make lint