### PR TITLE
Add more source projection graph context

### DIFF
--- a/internal/sourceprojection/cosmo.go
+++ b/internal/sourceprojection/cosmo.go
@@ -89,6 +89,7 @@ func cosmoMessageProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projected
 		"run_url":    attrs["run_url"],
 	})))
 	addCosmoSessionLink(entities, links, event, tenantID, messageURN, firstNonEmpty(attrs["ticket_id"], stringValue(payload, "ticket_id")))
+	addCosmoMessageUserLink(entities, links, event, tenantID, messageURN, attrs, payload)
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
@@ -162,6 +163,15 @@ func addCosmoSessionLink(entities map[string]*ports.ProjectedEntity, links map[s
 	}
 	addEntity(entities, cosmoEntity(event, sessionURN, "cosmo.session", sessionID, map[string]string{"ticket_id": strings.TrimSpace(sessionID)}))
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), fromURN, sessionURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+}
+
+func addCosmoMessageUserLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, event *cerebrov1.EventEnvelope, tenantID string, messageURN string, attrs map[string]string, payload map[string]any) {
+	role := strings.ToLower(strings.TrimSpace(firstNonEmpty(attrs["role"], stringValue(payload, "role"))))
+	if role != "user" && role != "customer" {
+		return
+	}
+	user := firstNonEmpty(attrs["user"], attrs["user_id"], attrs["email"], stringValue(payload, "user"), stringValue(payload, "user_id"), stringValue(payload, "userId"), stringValue(payload, "email"))
+	addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), messageURN, user, event.GetOccurredAt())
 }
 
 func cosmoFactSessionID(source string) string {

--- a/internal/sourceprojection/cosmo_test.go
+++ b/internal/sourceprojection/cosmo_test.go
@@ -92,6 +92,27 @@ func TestProjectCosmoMessageLinksSession(t *testing.T) {
 	assertCosmoProjectedLink(t, links, "urn:cerebro:writer:cosmo_message:msg-1", relationBelongsTo, "urn:cerebro:writer:cosmo_session:ticket-1")
 }
 
+func TestProjectCosmoUserMessageLinksIdentity(t *testing.T) {
+	entities, links, err := BuiltinRegistry().Project(&cerebrov1.EventEnvelope{
+		Id:       "cosmo-writer-message-msg-2",
+		TenantId: "writer",
+		SourceId: "cosmo",
+		Kind:     "cosmo.message",
+		Attributes: map[string]string{
+			"record_id": "msg-2",
+			"ticket_id": "ticket-1",
+			"role":      "user",
+			"user":      "alice@example.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	assertCosmoProjectedEntity(t, entities, "urn:cerebro:writer:cosmo_message:msg-2", "cosmo.message")
+	assertCosmoProjectedEntity(t, entities, "urn:cerebro:writer:identity:email:alice@example.com", "identity.email")
+	assertCosmoProjectedLink(t, links, "urn:cerebro:writer:cosmo_message:msg-2", relationRepresentsIdentity, "urn:cerebro:writer:identity:email:alice@example.com")
+}
+
 func TestProjectCosmoSurveyFeedbackLinksSessionAndUser(t *testing.T) {
 	entities, links, err := BuiltinRegistry().Project(&cerebrov1.EventEnvelope{
 		Id:       "cosmo-writer-survey-feedback-feedback-1",

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -674,6 +674,20 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 			addLink(links, projectedLink(tenantID, sourceID, resourceURN, integrationURN, relationBelongsTo, grcIntegrationLinkAttributes(event, integrationID)))
 		}
 		addGRCGitHubRepositoryOrgLink(entities, links, tenantID, sourceID, event, resourceURN, ownerLogin)
+		addGRCPlatformNetworkLinks(entities, links, tenantID, sourceID, event, resourceURN, ref)
+	}
+}
+
+func addGRCPlatformNetworkLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, resourceURN string, ref grcPlatformAssetReference) {
+	resourceURN = strings.TrimSpace(resourceURN)
+	if resourceURN == "" {
+		return
+	}
+	for _, rawHost := range splitCloudAttributeList(ref.Hostnames) {
+		addInternetHostLink(entities, links, tenantID, sourceID, event, resourceURN, relationRepresents, rawHost, "grc_platform_resource_host", "0.90")
+	}
+	for _, rawIP := range splitCloudAttributeList(ref.IPs) {
+		addInternetIPLink(entities, links, tenantID, sourceID, event, resourceURN, rawIP, "grc_platform_resource_ip", "0.90")
 	}
 }
 

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -861,8 +861,8 @@ func TestProjectGRCVulnerableAssetLinksPlatformResources(t *testing.T) {
 	assertProjectedLink(t, state, targetURN, relationRepresents, hostURN)
 	assertProjectedLink(t, state, targetURN, relationRepresents, ipURN)
 	assertProjectedLinkMissing(t, state, awsInstanceURN, relationBelongsTo, accountURN)
-	assertProjectedLinkMissing(t, state, awsInstanceURN, relationRepresents, hostURN)
-	assertProjectedLinkMissing(t, state, awsInstanceURN, relationRepresents, ipURN)
+	assertProjectedLink(t, state, awsInstanceURN, relationRepresents, hostURN)
+	assertProjectedLink(t, state, awsInstanceURN, relationRepresents, ipURN)
 
 	// The platform resource gets a human-friendly label so dashboards and the
 	// ask-the-graph UX surface "ip-10-86-43-17.ec2.internal" instead of the URN.

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -1138,6 +1138,7 @@ func githubDependabotAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 	alertNumber := strings.TrimSpace(attributes["alert_number"])
 	packageName := strings.TrimSpace(attributes["package"])
 	ecosystem := strings.TrimSpace(attributes["ecosystem"])
+	manifestPath := strings.TrimSpace(attributes["manifest_path"])
 	advisoryID := firstNonEmpty(attributes["advisory_ghsa_id"], attributes["advisory_cve_id"])
 	vulnerabilityID := firstNonEmpty(canonicalVulnerabilityIdentifier(attributes), advisoryID)
 
@@ -1251,9 +1252,64 @@ func githubDependabotAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 	if packageURN != "" && canonicalPackageURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, canonicalPackageURN, relationRepresents, packageIdentityAttributes(event, attributes, ecosystem)))
 	}
+	addGitHubDependabotDependencyContext(entities, links, tenantID, event, repoURN, alertURN, packageURN, repository, manifestPath, ecosystem, packageName)
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
+}
+
+func addGitHubDependabotDependencyContext(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, repoURN string, alertURN string, packageURN string, repository string, manifestPath string, ecosystem string, packageName string) {
+	repository = strings.TrimSpace(repository)
+	manifestPath = strings.TrimSpace(manifestPath)
+	packageName = strings.TrimSpace(packageName)
+	if repository == "" || manifestPath == "" || packageName == "" {
+		return
+	}
+	manifestURN := projectionURN(tenantID, "github_dependency_manifest", repository, manifestPath)
+	dependencyURN := projectionURN(tenantID, "github_dependency", repository, manifestPath, ecosystem, packageName)
+	if manifestURN == "" || dependencyURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        manifestURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "github.dependency_manifest",
+		Label:      manifestPath,
+		Attributes: map[string]string{
+			"ecosystem":     strings.TrimSpace(ecosystem),
+			"manifest_path": manifestPath,
+			"repository":    repository,
+		},
+	})
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        dependencyURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "github.dependency",
+		Label:      packageName,
+		Attributes: map[string]string{
+			"ecosystem":     strings.TrimSpace(ecosystem),
+			"manifest_path": manifestPath,
+			"package":       packageName,
+			"repository":    repository,
+		},
+	})
+	if repoURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), manifestURN, repoURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+	}
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), dependencyURN, manifestURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+	if packageURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), dependencyURN, packageURN, relationRepresents, map[string]string{
+			"ecosystem":     strings.TrimSpace(ecosystem),
+			"event_id":      event.GetId(),
+			"manifest_path": manifestPath,
+			"package":       packageName,
+		}))
+	}
+	if alertURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, dependencyURN, relationAffects, map[string]string{"event_id": event.GetId()}))
+	}
 }
 
 func githubSecretScanningAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -383,6 +383,40 @@ func TestProjectGitHubDependabotAlert(t *testing.T) {
 	}
 }
 
+func TestProjectGitHubDependabotAlertLinksRepoScopedDependency(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-dependabot-alert-manifest",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.dependabot_alert",
+		Attributes: map[string]string{
+			"alert_number":  "7",
+			"ecosystem":     "go",
+			"manifest_path": "go.mod",
+			"owner":         "writer",
+			"package":       "golang.org/x/crypto",
+			"repository":    "writer/cerebro",
+			"state":         "open",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	alertURN := "urn:cerebro:writer:github_dependabot_alert:writer/cerebro:7"
+	repoURN := "urn:cerebro:writer:github_repo:writer/cerebro"
+	manifestURN := "urn:cerebro:writer:github_dependency_manifest:writer/cerebro:go.mod"
+	dependencyURN := "urn:cerebro:writer:github_dependency:writer/cerebro:go.mod:go:golang.org/x/crypto"
+	packageURN := "urn:cerebro:writer:package:go:golang.org/x/crypto"
+	assertProjectedLink(t, state, manifestURN, relationBelongsTo, repoURN)
+	assertProjectedLink(t, state, dependencyURN, relationBelongsTo, manifestURN)
+	assertProjectedLink(t, state, dependencyURN, relationRepresents, packageURN)
+	assertProjectedLink(t, state, alertURN, relationAffects, dependencyURN)
+}
+
 func TestProjectOktaOAuthGrantAsApplicationTelemetry(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)


### PR DESCRIPTION
## Summary
- adds repo-scoped dependency and manifest context for dependency alert projections
- links platform resources to explicitly provided host/IP context
- links user-authored support messages to identity context

## Validation
- go test ./internal/sourceprojection -count=1
- make test
- make lint