### PR TITLE
Warm GRC dashboard read models

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -97,6 +97,9 @@ func serve() error {
 	if err != nil {
 		return fmt.Errorf("bootstrap app: %w", err)
 	}
+	if err := prepareGRCReadModels(context.Background(), deps.StateStore); err != nil {
+		return err
+	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	startFindingRiskBackfill(ctx, app, log.Printf)
@@ -127,6 +130,21 @@ func serve() error {
 
 type findingRiskBackfiller interface {
 	BackfillFindingRisk(context.Context) error
+}
+
+type grcReadModelPreparer interface {
+	PrepareGRCReadModels(context.Context) error
+}
+
+func prepareGRCReadModels(ctx context.Context, stateStore ports.StateStore) error {
+	preparer, ok := stateStore.(grcReadModelPreparer)
+	if !ok {
+		return nil
+	}
+	if err := preparer.PrepareGRCReadModels(ctx); err != nil {
+		return fmt.Errorf("prepare grc read models: %w", err)
+	}
+	return nil
 }
 
 func startFindingRiskBackfill(ctx context.Context, backfiller findingRiskBackfiller, logf func(string, ...any)) <-chan struct{} {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -73,6 +73,34 @@ func TestStartFindingRiskBackfillLogsErrors(t *testing.T) {
 	}
 }
 
+func TestPrepareGRCReadModelsSkipsStoresWithoutPreparer(t *testing.T) {
+	if err := prepareGRCReadModels(context.Background(), &basicStateStore{}); err != nil {
+		t.Fatalf("prepareGRCReadModels() error = %v", err)
+	}
+}
+
+func TestPrepareGRCReadModelsCallsPreparer(t *testing.T) {
+	store := &preparingStateStore{}
+	if err := prepareGRCReadModels(context.Background(), store); err != nil {
+		t.Fatalf("prepareGRCReadModels() error = %v", err)
+	}
+	if store.calls != 1 {
+		t.Fatalf("PrepareGRCReadModels calls = %d, want 1", store.calls)
+	}
+}
+
+func TestPrepareGRCReadModelsWrapsErrors(t *testing.T) {
+	boom := errors.New("boom")
+	store := &preparingStateStore{err: boom}
+	err := prepareGRCReadModels(context.Background(), store)
+	if err == nil {
+		t.Fatal("prepareGRCReadModels() error = nil, want error")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("prepareGRCReadModels() error = %v, want wrapped boom", err)
+	}
+}
+
 func TestParseSourceRuntimePutArgsSeparatesTenantID(t *testing.T) {
 	t.Setenv("CEREBRO_TEST_TOKEN", "test")
 	runtime, err := parseSourceRuntimePutArgs([]string{
@@ -301,6 +329,14 @@ type commandRuntimeStore struct {
 	runtimes map[string]*cerebrov1.SourceRuntime
 }
 
+type basicStateStore struct{}
+
+type preparingStateStore struct {
+	basicStateStore
+	calls int
+	err   error
+}
+
 type blockingFindingRiskBackfiller struct {
 	started chan struct{}
 	release chan struct{}
@@ -322,6 +358,15 @@ func (b *errorFindingRiskBackfiller) BackfillFindingRisk(context.Context) error 
 
 func (s *commandRuntimeStore) Ping(context.Context) error {
 	return nil
+}
+
+func (s *basicStateStore) Ping(context.Context) error {
+	return nil
+}
+
+func (s *preparingStateStore) PrepareGRCReadModels(context.Context) error {
+	s.calls++
+	return s.err
 }
 
 func (s *commandRuntimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {

--- a/internal/statestore/postgres/grc_dashboard.go
+++ b/internal/statestore/postgres/grc_dashboard.go
@@ -12,6 +12,23 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 )
 
+// PrepareGRCReadModels warms the read-model tables used by dashboard requests.
+func (s *Store) PrepareGRCReadModels(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+		return err
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return err
+	}
+	if err := s.ensureFindingEvidenceTables(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
 // SummarizeGRCDashboard loads dashboard summary and evidence counts in one aggregate query.
 func (s *Store) SummarizeGRCDashboard(ctx context.Context, request ports.GRCDashboardAggregateRequest) (ports.GRCDashboardAggregate, error) {
 	if s == nil || s.db == nil {


### PR DESCRIPTION
## Summary
- add a Postgres GRC read-model warmup for source runtimes, findings, and finding evidence
- run the warmup during service startup so first dashboard requests do not pay schema/index preparation
- cover startup warmup behavior with command tests

## Validation
- go test ./cmd/cerebro ./internal/statestore/postgres ./internal/bootstrap -run 'TestPrepareGRCReadModels|TestGRCDashboard|TestSourceRuntimeSchemaIndexesDashboardFilters' -count=1 -v
- make test
- make lint