### PR TITLE
Speed up GRC dashboard queries

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -507,6 +507,10 @@ type grcFindingEvidenceCounter interface {
 	CountFindingEvidence(context.Context, ports.ListFindingEvidenceRequest) (int, error)
 }
 
+type grcFindingEvidenceHeaderLister interface {
+	ListGRCFindingEvidence(context.Context, ports.ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error)
+}
+
 func grcDashboardTelemetryAttrs() telemetry.Attributes {
 	return telemetry.Attrs(
 		telemetry.Field{Key: "route", Value: "/grc/dashboard"},
@@ -727,7 +731,7 @@ func (a *App) grcListEvidenceRecords(r *http.Request, runtimes []*cerebrov1.Sour
 	if filter.FindingIDs != nil && strings.TrimSpace(filter.FindingID) == "" && len(grcNonEmptyFindingIDs(filter.FindingIDs)) == 0 {
 		return nil, nil
 	}
-	records, err := store.ListFindingEvidence(r.Context(), ports.ListFindingEvidenceRequest{
+	request := ports.ListFindingEvidenceRequest{
 		RuntimeIDs:   runtimeIDs,
 		FindingID:    filter.FindingID,
 		FindingIDs:   filter.FindingIDs,
@@ -736,7 +740,16 @@ func (a *App) grcListEvidenceRecords(r *http.Request, runtimes []*cerebrov1.Sour
 		GraphRootURN: filter.GraphRootURN,
 		Limit:        limit,
 		CreatedOrder: true,
-	})
+	}
+	var (
+		records []*cerebrov1.FindingEvidence
+		err     error
+	)
+	if lister, ok := store.(grcFindingEvidenceHeaderLister); ok {
+		records, err = lister.ListGRCFindingEvidence(r.Context(), request)
+	} else {
+		records, err = store.ListFindingEvidence(r.Context(), request)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	grcDefaultLimit = uint32(100)
-	grcMaxLimit     = uint32(500)
+	grcDefaultLimit          = uint32(100)
+	grcMaxLimit              = uint32(500)
+	grcDashboardPreviewLimit = uint32(25)
 )
 
 type grcScope struct {
@@ -162,6 +163,8 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "limit", Value: scope.Limit})
+	previewLimit := grcDashboardPreviewLimitFor(scope.Limit)
+	endAttrs = endAttrs.WithField(telemetry.Field{Key: "preview_limit", Value: previewLimit})
 	ctx, runtimesSpan := telemetry.Start(r.Context(), "grc.dashboard.runtimes", grcDashboardScopeTelemetryAttrs(scope))
 	runtimesRequest := r.WithContext(ctx)
 	runtimes, err := a.grcListRuntimes(runtimesRequest, scope)
@@ -173,7 +176,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, findingsSpan := telemetry.Start(r.Context(), "grc.dashboard.findings", grcDashboardScopeTelemetryAttrs(scope))
 	findingsRequest := r.WithContext(ctx)
-	findings, err := a.grcListFindingRecords(findingsRequest, runtimes, grcFindingFilter{Status: "open", Limit: scope.Limit})
+	findings, err := a.grcListFindingRecords(findingsRequest, runtimes, grcFindingFilter{Status: "open", Limit: previewLimit})
 	telemetry.End(findingsSpan, grcTelemetryStatus(err), telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findings)}))
 	if err != nil {
 		status, endAttrs = grcTelemetryError(endAttrs, err)
@@ -195,7 +198,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		var err error
 		ctx, evidenceSpan := telemetry.Start(r.Context(), "grc.dashboard.evidence", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}))
 		evidenceRequest := r.WithContext(ctx)
-		evidence, err = a.grcListEvidenceRecords(evidenceRequest, runtimes, grcEvidenceFilter{FindingIDs: findingIDs, Limit: scope.Limit})
+		evidence, err = a.grcListEvidenceRecords(evidenceRequest, runtimes, grcEvidenceFilter{FindingIDs: findingIDs, Limit: previewLimit})
 		telemetry.End(evidenceSpan, grcTelemetryStatus(err), telemetry.Attrs(telemetry.Field{Key: "evidence_count", Value: len(evidence)}))
 		if err != nil {
 			errs <- err
@@ -251,6 +254,13 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		Connectors:  grcConnectorItems(runtimes),
 		GeneratedAt: time.Now().UTC(),
 	})
+}
+
+func grcDashboardPreviewLimitFor(limit uint32) uint32 {
+	if limit == 0 || limit > grcDashboardPreviewLimit {
+		return grcDashboardPreviewLimit
+	}
+	return limit
 }
 
 func (a *App) handleGRCFindings(w http.ResponseWriter, r *http.Request) {

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -511,6 +511,10 @@ type grcFindingEvidenceHeaderLister interface {
 	ListGRCFindingEvidence(context.Context, ports.ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error)
 }
 
+type grcFindingHeaderLister interface {
+	ListGRCFindings(context.Context, ports.ListFindingsRequest) ([]*ports.FindingRecord, error)
+}
+
 func grcDashboardTelemetryAttrs() telemetry.Attributes {
 	return telemetry.Attrs(
 		telemetry.Field{Key: "route", Value: "/grc/dashboard"},
@@ -618,7 +622,7 @@ func (a *App) grcListFindingRecords(r *http.Request, runtimes []*cerebrov1.Sourc
 	}
 	var records []*ports.FindingRecord
 	for tenantID, runtimeIDs := range runtimeIDsByTenant {
-		items, err := store.ListFindings(r.Context(), ports.ListFindingsRequest{
+		request := ports.ListFindingsRequest{
 			TenantID:      tenantID,
 			RuntimeIDs:    runtimeIDs,
 			FindingID:     filter.FindingID,
@@ -631,7 +635,16 @@ func (a *App) grcListFindingRecords(r *http.Request, runtimes []*cerebrov1.Sourc
 			Limit:         limit,
 			PriorityOrder: true,
 			Order:         ports.FindingOrderRiskScore,
-		})
+		}
+		var (
+			items []*ports.FindingRecord
+			err   error
+		)
+		if lister, ok := store.(grcFindingHeaderLister); ok {
+			items, err = lister.ListGRCFindings(r.Context(), request)
+		} else {
+			items, err = store.ListFindings(r.Context(), request)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -444,6 +444,55 @@ func TestGRCDashboardUsesHeaderOnlyEvidenceLister(t *testing.T) {
 	}
 }
 
+func TestGRCDashboardUsesHeaderOnlyFindingLister(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	runtimeID := "runtime-alpha"
+	tenantID := "tenant"
+	store := &stubGRCFindingHeaderStore{stubGRCAggregateStore: &stubGRCAggregateStore{stubRuntimeStore: &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {
+				Id:           runtimeID,
+				SourceId:     "okta",
+				TenantId:     tenantID,
+				LastSyncedAt: timestamppb.New(now),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)},
+			},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Finding 1",
+				Severity:       "HIGH",
+				Status:         "open",
+				LastObservedAt: now,
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-1": {Id: "evidence-1", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now)},
+		},
+	}}}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=" + tenantID)
+	if err != nil {
+		t.Fatalf("GET /grc/dashboard error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/dashboard status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if store.headerFindingCalls != 1 {
+		t.Fatalf("header finding calls = %d, want 1", store.headerFindingCalls)
+	}
+	if store.fullFindingCalls != 0 {
+		t.Fatalf("full finding calls = %d, want 0", store.fullFindingCalls)
+	}
+}
+
 func TestGRCDashboardUsesPurposeBuiltAggregateStore(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	runtimeID := "tenant-okta-audit"
@@ -628,4 +677,20 @@ func (s *stubGRCEvidenceHeaderStore) ListGRCFindingEvidence(ctx context.Context,
 func (s *stubGRCEvidenceHeaderStore) ListFindingEvidence(ctx context.Context, request ports.ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error) {
 	s.fullEvidenceCalls++
 	return s.stubRuntimeStore.ListFindingEvidence(ctx, request)
+}
+
+type stubGRCFindingHeaderStore struct {
+	*stubGRCAggregateStore
+	headerFindingCalls int
+	fullFindingCalls   int
+}
+
+func (s *stubGRCFindingHeaderStore) ListGRCFindings(ctx context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	s.headerFindingCalls++
+	return s.stubRuntimeStore.ListFindings(ctx, request)
+}
+
+func (s *stubGRCFindingHeaderStore) ListFindings(ctx context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	s.fullFindingCalls++
+	return s.stubRuntimeStore.ListFindings(ctx, request)
 }

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -395,6 +395,55 @@ func TestGRCDashboardCapsPreviewWorkToRenderedLimit(t *testing.T) {
 	}
 }
 
+func TestGRCDashboardUsesHeaderOnlyEvidenceLister(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	runtimeID := "tenant-okta-audit"
+	tenantID := "tenant"
+	store := &stubGRCEvidenceHeaderStore{stubGRCAggregateStore: &stubGRCAggregateStore{stubRuntimeStore: &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {
+				Id:           runtimeID,
+				SourceId:     "okta",
+				TenantId:     tenantID,
+				LastSyncedAt: timestamppb.New(now),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)},
+			},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Finding 1",
+				Severity:       "HIGH",
+				Status:         "open",
+				LastObservedAt: now,
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-1": {Id: "evidence-1", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now)},
+		},
+	}}}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=" + tenantID)
+	if err != nil {
+		t.Fatalf("GET /grc/dashboard error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/dashboard status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if store.headerEvidenceCalls != 1 {
+		t.Fatalf("header evidence calls = %d, want 1", store.headerEvidenceCalls)
+	}
+	if store.fullEvidenceCalls != 0 {
+		t.Fatalf("full evidence calls = %d, want 0", store.fullEvidenceCalls)
+	}
+}
+
 func TestGRCDashboardUsesPurposeBuiltAggregateStore(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	runtimeID := "tenant-okta-audit"
@@ -563,4 +612,20 @@ func (s *stubGRCAggregateStore) SummarizeGRCDashboard(ctx context.Context, reque
 		return ports.GRCDashboardAggregate{}, err
 	}
 	return ports.GRCDashboardAggregate{FindingSummary: summary, EvidenceCount: count}, nil
+}
+
+type stubGRCEvidenceHeaderStore struct {
+	*stubGRCAggregateStore
+	headerEvidenceCalls int
+	fullEvidenceCalls   int
+}
+
+func (s *stubGRCEvidenceHeaderStore) ListGRCFindingEvidence(ctx context.Context, request ports.ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error) {
+	s.headerEvidenceCalls++
+	return s.stubRuntimeStore.ListFindingEvidence(ctx, request)
+}
+
+func (s *stubGRCEvidenceHeaderStore) ListFindingEvidence(ctx context.Context, request ports.ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error) {
+	s.fullEvidenceCalls++
+	return s.stubRuntimeStore.ListFindingEvidence(ctx, request)
 }

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -316,6 +317,81 @@ func TestGRCDashboardSummaryUsesUnpaginatedAggregates(t *testing.T) {
 	}
 	if payload.Summary.EvidenceItems != 1 {
 		t.Fatalf("summary evidence items = %d, want visible finding evidence total 1", payload.Summary.EvidenceItems)
+	}
+}
+
+func TestGRCDashboardCapsPreviewWorkToRenderedLimit(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	runtimeID := "tenant-okta-audit"
+	tenantID := "tenant"
+	store := &stubGRCAggregateStore{stubRuntimeStore: &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {
+				Id:           runtimeID,
+				SourceId:     "okta",
+				TenantId:     tenantID,
+				LastSyncedAt: timestamppb.New(now),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)},
+			},
+		},
+		findings:        map[string]*ports.FindingRecord{},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{},
+	}}
+	for i := range 40 {
+		id := fmt.Sprintf("finding-%02d", i)
+		store.findings[id] = &ports.FindingRecord{
+			ID:             id,
+			TenantID:       tenantID,
+			RuntimeID:      runtimeID,
+			Title:          fmt.Sprintf("Finding %02d", i),
+			Severity:       "HIGH",
+			Status:         "open",
+			ControlRefs:    []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+			LastObservedAt: now.Add(-time.Duration(i) * time.Minute),
+		}
+		store.findingEvidence["evidence-"+id] = &cerebrov1.FindingEvidence{
+			Id:        "evidence-" + id,
+			RuntimeId: runtimeID,
+			FindingId: id,
+			CreatedAt: timestamppb.New(now.Add(-time.Duration(i) * time.Minute)),
+		}
+	}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=" + tenantID + "&limit=500")
+	if err != nil {
+		t.Fatalf("GET /grc/dashboard error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/dashboard status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload grcDashboardResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /grc/dashboard: %v", err)
+	}
+	if len(payload.Findings) != 25 {
+		t.Fatalf("findings len = %d, want capped preview 25", len(payload.Findings))
+	}
+	if len(payload.Evidence) != 25 {
+		t.Fatalf("evidence len = %d, want capped preview 25", len(payload.Evidence))
+	}
+	if store.findingListRequest.Limit != grcDashboardPreviewLimit {
+		t.Fatalf("finding list limit = %d, want dashboard preview limit %d", store.findingListRequest.Limit, grcDashboardPreviewLimit)
+	}
+	if store.findingEvidenceListRequest.Limit != grcDashboardPreviewLimit {
+		t.Fatalf("evidence list limit = %d, want dashboard preview limit %d", store.findingEvidenceListRequest.Limit, grcDashboardPreviewLimit)
+	}
+	if got := len(store.findingEvidenceListRequest.FindingIDs); got != int(grcDashboardPreviewLimit) {
+		t.Fatalf("evidence finding id count = %d, want dashboard preview limit %d", got, grcDashboardPreviewLimit)
+	}
+	if payload.Summary.OpenFindings != 40 {
+		t.Fatalf("summary open findings = %d, want unpaginated total 40", payload.Summary.OpenFindings)
+	}
+	if store.aggregateCalls != 1 {
+		t.Fatalf("aggregate calls = %d, want 1", store.aggregateCalls)
 	}
 }
 

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/findingevidence"
@@ -284,6 +286,42 @@ func (s *Store) ListFindingEvidence(ctx context.Context, request ports.ListFindi
 	return evidence, nil
 }
 
+// ListGRCFindingEvidence loads only denormalized evidence fields needed by GRC read models.
+func (s *Store) ListGRCFindingEvidence(ctx context.Context, request ports.ListFindingEvidenceRequest) (_ []*cerebrov1.FindingEvidence, err error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingEvidenceTables(ctx); err != nil {
+		return nil, err
+	}
+	query, args, err := findingEvidenceHeaderListQuery(request)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query grc finding evidence for runtime %q: %w", strings.TrimSpace(request.RuntimeID), err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close grc finding evidence rows: %w", closeErr)
+		}
+	}()
+
+	evidence := []*cerebrov1.FindingEvidence{}
+	for rows.Next() {
+		record, err := scanFindingEvidenceHeader(rows)
+		if err != nil {
+			return nil, err
+		}
+		evidence = append(evidence, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate grc finding evidence rows: %w", err)
+	}
+	return evidence, nil
+}
+
 // CountFindingEvidence returns the unpaginated number of evidence rows for one filtered query.
 func (s *Store) CountFindingEvidence(ctx context.Context, request ports.ListFindingEvidenceRequest) (int, error) {
 	if s == nil || s.db == nil {
@@ -327,6 +365,23 @@ ORDER BY ` + findingEvidenceListOrder(request)
 	return query, args, nil
 }
 
+func findingEvidenceHeaderListQuery(request ports.ListFindingEvidenceRequest) (string, []any, error) {
+	clauses, args, err := findingEvidenceFilterClauses(request)
+	if err != nil {
+		return "", nil, err
+	}
+	query := `
+SELECT id, runtime_id, rule_id, finding_id, run_id, claim_ids_json::text, event_ids_json::text, graph_root_urns_json::text, created_at
+FROM finding_evidence
+WHERE ` + strings.Join(clauses, " AND ") + `
+ORDER BY ` + findingEvidenceListOrder(request)
+	if request.Limit != 0 {
+		args = append(args, int64(request.Limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	return query, args, nil
+}
+
 func findingEvidenceFilterClauses(request ports.ListFindingEvidenceRequest) ([]string, []any, error) {
 	runtimeID := strings.TrimSpace(request.RuntimeID)
 	runtimeIDs := normalizedNonEmptyStrings(append(request.RuntimeIDs, runtimeID))
@@ -359,6 +414,55 @@ func findingEvidenceFilterClauses(request ports.ListFindingEvidenceRequest) ([]s
 		return nil, nil, err
 	}
 	return clauses, args, nil
+}
+
+func scanFindingEvidenceHeader(rows interface {
+	Scan(dest ...any) error
+}) (*cerebrov1.FindingEvidence, error) {
+	var (
+		record            cerebrov1.FindingEvidence
+		claimIDsJSON      string
+		eventIDsJSON      string
+		graphRootURNsJSON string
+		createdAt         time.Time
+	)
+	if err := rows.Scan(
+		&record.Id,
+		&record.RuntimeId,
+		&record.RuleId,
+		&record.FindingId,
+		&record.RunId,
+		&claimIDsJSON,
+		&eventIDsJSON,
+		&graphRootURNsJSON,
+		&createdAt,
+	); err != nil {
+		return nil, fmt.Errorf("scan grc finding evidence row: %w", err)
+	}
+	var err error
+	if record.ClaimIds, err = findingStringSliceFromJSON(claimIDsJSON); err != nil {
+		return nil, fmt.Errorf("decode grc finding evidence claim ids: %w", err)
+	}
+	if record.EventIds, err = findingStringSliceFromJSON(eventIDsJSON); err != nil {
+		return nil, fmt.Errorf("decode grc finding evidence event ids: %w", err)
+	}
+	if record.GraphRootUrns, err = findingStringSliceFromJSON(graphRootURNsJSON); err != nil {
+		return nil, fmt.Errorf("decode grc finding evidence graph roots: %w", err)
+	}
+	record.CreatedAt = timestamppb.New(createdAt.UTC())
+	return &record, nil
+}
+
+func findingStringSliceFromJSON(payload string) ([]string, error) {
+	payload = strings.TrimSpace(payload)
+	if payload == "" || payload == "[]" {
+		return nil, nil
+	}
+	var values []string
+	if err := json.Unmarshal([]byte(payload), &values); err != nil {
+		return nil, err
+	}
+	return normalizedNonEmptyStrings(values), nil
 }
 
 func findingEvidenceListOrder(request ports.ListFindingEvidenceRequest) string {

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -49,6 +49,13 @@ func TestListFindingEvidenceRejectsUnconfiguredStore(t *testing.T) {
 	}
 }
 
+func TestListGRCFindingEvidenceRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	if _, err := store.ListGRCFindingEvidence(context.Background(), ports.ListFindingEvidenceRequest{RuntimeID: "runtime-alpha"}); err == nil {
+		t.Fatal("ListGRCFindingEvidence() error = nil, want non-nil")
+	}
+}
+
 func TestFindingEvidenceListQueryIncludesOptionalFilters(t *testing.T) {
 	query, args, err := findingEvidenceListQuery(ports.ListFindingEvidenceRequest{
 		RuntimeID:    "runtime-alpha",
@@ -87,6 +94,35 @@ func TestFindingEvidenceListQueryIncludesOptionalFilters(t *testing.T) {
 	}
 	if got := args[8]; got != int64(25) {
 		t.Fatalf("findingEvidenceListQuery().args[8] = %#v, want 25", got)
+	}
+}
+
+func TestFindingEvidenceHeaderListQueryAvoidsFullPayload(t *testing.T) {
+	query, args, err := findingEvidenceHeaderListQuery(ports.ListFindingEvidenceRequest{
+		RuntimeIDs:   []string{"runtime-alpha", "runtime-beta"},
+		FindingIDs:   []string{"finding-high", "finding-critical"},
+		Limit:        25,
+		CreatedOrder: true,
+	})
+	if err != nil {
+		t.Fatalf("findingEvidenceHeaderListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"SELECT id, runtime_id, rule_id, finding_id, run_id, claim_ids_json::text, event_ids_json::text, graph_root_urns_json::text, created_at",
+		"runtime_id IN ($1, $2)",
+		"finding_id IN ($3, $4)",
+		"ORDER BY created_at DESC, id",
+		"LIMIT $5",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingEvidenceHeaderListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	if strings.Contains(query, "finding_evidence_json") {
+		t.Fatalf("findingEvidenceHeaderListQuery() selected full payload: %s", query)
+	}
+	if got := len(args); got != 5 {
+		t.Fatalf("len(findingEvidenceHeaderListQuery().args) = %d, want 5", got)
 	}
 }
 

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -569,6 +569,52 @@ func (s *Store) ListFindings(ctx context.Context, request ports.ListFindingsRequ
 	return findings, nil
 }
 
+// ListGRCFindings loads the denormalized finding fields needed by GRC read models.
+func (s *Store) ListGRCFindings(ctx context.Context, request ports.ListFindingsRequest) (_ []*ports.FindingRecord, err error) {
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID == "" {
+		return nil, errors.New("finding tenant id is required")
+	}
+	runtimeID := strings.TrimSpace(request.RuntimeID)
+	runtimeIDs := normalizedNonEmptyStrings(append(request.RuntimeIDs, runtimeID))
+	ruleID := strings.TrimSpace(request.RuleID)
+	if len(runtimeIDs) == 0 && ruleID == "" {
+		return nil, errors.New("finding runtime id or rule id is required")
+	}
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingTables(ctx); err != nil {
+		return nil, err
+	}
+	query, args, err := findingGRCListQuery(request)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query grc findings for tenant %q runtime %q rule %q: %w", tenantID, runtimeID, ruleID, err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close grc findings rows: %w", closeErr)
+		}
+	}()
+
+	findings := []*ports.FindingRecord{}
+	for rows.Next() {
+		record, err := scanGRCFindingRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate grc findings rows: %w", err)
+	}
+	return findings, nil
+}
+
 // SummarizeFindings loads aggregate finding counts for one filtered query without
 // applying row pagination.
 func (s *Store) SummarizeFindings(ctx context.Context, request ports.ListFindingsRequest) (ports.FindingSummary, error) {
@@ -1002,6 +1048,25 @@ func findingListQuery(request ports.ListFindingsRequest) (string, []any, error) 
 	}
 	query := `
 SELECT ` + findingSelectColumns + `
+FROM findings
+WHERE ` + strings.Join(clauses, " AND ") + `
+ORDER BY ` + findingOrderClause(request)
+	if request.Limit != 0 {
+		args = append(args, int64(request.Limit))
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	return query, args, nil
+}
+
+func findingGRCListQuery(request ports.ListFindingsRequest) (string, []any, error) {
+	clauses, args, err := findingFilterClauses(request)
+	if err != nil {
+		return "", nil, err
+	}
+	query := `
+SELECT id, tenant_id, runtime_id, rule_id, title, ` + findingEffectiveSeveritySQL() + ` AS severity, status, summary,
+  risk_score, likelihood_score, impact_score, confidence_score, likelihood_level, impact_level, risk_reasons_json::text, risk_model_version,
+  resource_urns_json::text, control_refs_json::text, policy_id, policy_name, assignee, due_at, first_observed_at, last_observed_at
 FROM findings
 WHERE ` + strings.Join(clauses, " AND ") + `
 ORDER BY ` + findingOrderClause(request)
@@ -2037,6 +2102,26 @@ type findingRow struct {
 	findingTombstoneRow
 }
 
+type grcFindingRow struct {
+	ID        string
+	TenantID  string
+	RuntimeID string
+	RuleID    string
+	Title     string
+	Severity  string
+	Status    string
+	Summary   string
+	findingRiskRow
+	ResourceURNsJSON string
+	ControlRefsJSON  string
+	PolicyID         string
+	PolicyName       string
+	Assignee         string
+	DueAt            sql.NullTime
+	FirstObservedAt  time.Time
+	LastObservedAt   time.Time
+}
+
 func scanFindingRow(scanner findingRowScanner, row *findingRow) error {
 	return scanner.Scan(
 		&row.ID,
@@ -2081,6 +2166,82 @@ func scanFindingRow(scanner findingRowScanner, row *findingRow) error {
 		&row.PriorStatus,
 		&row.TombstoneGeneration,
 	)
+}
+
+func scanGRCFindingRow(scanner findingRowScanner) (*ports.FindingRecord, error) {
+	var row grcFindingRow
+	if err := scanner.Scan(
+		&row.ID,
+		&row.TenantID,
+		&row.RuntimeID,
+		&row.RuleID,
+		&row.Title,
+		&row.Severity,
+		&row.Status,
+		&row.Summary,
+		&row.RiskScore,
+		&row.LikelihoodScore,
+		&row.ImpactScore,
+		&row.ConfidenceScore,
+		&row.LikelihoodLevel,
+		&row.ImpactLevel,
+		&row.RiskReasonsJSON,
+		&row.RiskModelVersion,
+		&row.ResourceURNsJSON,
+		&row.ControlRefsJSON,
+		&row.PolicyID,
+		&row.PolicyName,
+		&row.Assignee,
+		&row.DueAt,
+		&row.FirstObservedAt,
+		&row.LastObservedAt,
+	); err != nil {
+		return nil, fmt.Errorf("scan grc finding row: %w", err)
+	}
+	resourceURNs, err := findingStringSliceFromJSON(row.ResourceURNsJSON)
+	if err != nil {
+		return nil, fmt.Errorf("decode grc finding resource urns: %w", err)
+	}
+	controlRefs := []ports.FindingControlRef{}
+	if strings.TrimSpace(row.ControlRefsJSON) != "" {
+		if err := json.Unmarshal([]byte(row.ControlRefsJSON), &controlRefs); err != nil {
+			return nil, fmt.Errorf("decode grc finding control refs: %w", err)
+		}
+	}
+	riskReasons, err := findingStringSliceFromJSON(row.RiskReasonsJSON)
+	if err != nil {
+		return nil, fmt.Errorf("decode grc finding risk reasons: %w", err)
+	}
+	return &ports.FindingRecord{
+		ID:        row.ID,
+		TenantID:  row.TenantID,
+		RuntimeID: row.RuntimeID,
+		RuleID:    row.RuleID,
+		Title:     row.Title,
+		Severity:  row.Severity,
+		Status:    row.Status,
+		Summary:   row.Summary,
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        row.RiskScore,
+			LikelihoodScore:  row.LikelihoodScore,
+			ImpactScore:      row.ImpactScore,
+			ConfidenceScore:  row.ConfidenceScore,
+			LikelihoodLevel:  row.LikelihoodLevel,
+			ImpactLevel:      row.ImpactLevel,
+			RiskReasons:      riskReasons,
+			RiskModelVersion: row.RiskModelVersion,
+		},
+		ResourceURNs: resourceURNs,
+		PolicyID:     row.PolicyID,
+		PolicyName:   row.PolicyName,
+		ControlRefs:  controlRefs,
+		FindingWorkflow: ports.FindingWorkflow{
+			Assignee: row.Assignee,
+			DueAt:    findingTimestamp(row.DueAt),
+		},
+		FirstObservedAt: row.FirstObservedAt.UTC(),
+		LastObservedAt:  row.LastObservedAt.UTC(),
+	}, nil
 }
 
 func (r findingRow) record() (*ports.FindingRecord, error) {

--- a/internal/statestore/postgres/findings_test.go
+++ b/internal/statestore/postgres/findings_test.go
@@ -105,6 +105,13 @@ func TestListFindingsRejectsUnconfiguredStore(t *testing.T) {
 	}
 }
 
+func TestListGRCFindingsRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	if _, err := store.ListGRCFindings(context.Background(), ports.ListFindingsRequest{TenantID: "tenant", RuntimeID: "runtime-alpha"}); err == nil {
+		t.Fatal("ListGRCFindings() error = nil, want non-nil")
+	}
+}
+
 // Graph rules call ListFindings with tenant + rule (no runtime) so the contract must accept
 // that combination; only an unconfigured Store should fail at this point.
 func TestListFindingsAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
@@ -220,6 +227,52 @@ func TestFindingListQueryAcceptsTenantAndRuleWithoutRuntime(t *testing.T) {
 	}
 	if got := args[1]; got != "identity-okta-deprovisioned-active-in-github" {
 		t.Fatalf("findingListQuery().args[1] = %#v, want rule id", got)
+	}
+}
+
+func TestFindingGRCListQueryAvoidsFullPayload(t *testing.T) {
+	query, args, err := findingGRCListQuery(ports.ListFindingsRequest{
+		TenantID:   "tenant",
+		RuntimeIDs: []string{"runtime-alpha", "runtime-beta"},
+		Status:     "open",
+		Limit:      25,
+		Order:      ports.FindingOrderRiskScore,
+	})
+	if err != nil {
+		t.Fatalf("findingGRCListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"SELECT id, tenant_id, runtime_id, rule_id, title, UPPER(COALESCE(NULLIF(attributes_json->>'effective_severity', ''), severity)) AS severity",
+		"risk_reasons_json::text",
+		"resource_urns_json::text",
+		"control_refs_json::text",
+		"runtime_id IN ($2, $3)",
+		"status = $4",
+		"ORDER BY risk_score DESC",
+		"LIMIT $5",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingGRCListQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	for _, forbidden := range []string{
+		"fingerprint",
+		"event_ids_json::text",
+		"observed_policy_ids_json::text",
+		"notes_json",
+		"tickets_json",
+		"attributes_json::text",
+		"tombstoned_by",
+		"tombstoned_reason",
+		"status_reason",
+		"check_name",
+	} {
+		if strings.Contains(query, forbidden) {
+			t.Fatalf("findingGRCListQuery() selected unused payload %q: %s", forbidden, query)
+		}
+	}
+	if got := len(args); got != 5 {
+		t.Fatalf("len(findingGRCListQuery().args) = %d, want 5", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Cap GRC dashboard preview fetches to the rows rendered by the response
- Preserve aggregate summary totals while reducing preview row/evidence work
- Add a lightweight GRC evidence read path that avoids loading full evidence payload JSON for GRC views
- Add regression coverage for large dashboard limits and header-only evidence reads

## Tests
- go test ./internal/bootstrap ./internal/statestore/postgres -run 'Test(GRCDashboard|FindingEvidence)' -count=1 -v
- CEREBRO_REPO=/path/to/worktree npm --prefix /path/to/cerebro-web run e2e:grc:local
- make test
- make lint
- make openapi-check catalog-check detection-catalog-check check-arch