### PR TITLE
Optimize GRC dashboard data reads

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -239,6 +239,9 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	runtimeSourceIDs := grcRuntimeSourceIDs(runtimes)
 	evidenceCounts := grcEvidenceCounts(evidence)
+	if aggregate != nil && len(aggregate.EvidenceCountsByFindingID) > 0 {
+		evidenceCounts = aggregate.EvidenceCountsByFindingID
+	}
 	findingItems := grcFindingItems(findings, runtimeSourceIDs, evidenceCounts)
 	evidenceItems := grcEvidenceItems(evidence, grcFindingTitleMap(findings))
 	controls := grcControlItems(findingItems, evidenceItems)
@@ -845,6 +848,7 @@ func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.Sourc
 		return &aggregate, nil
 	}
 	var aggregate ports.GRCDashboardAggregate
+	aggregate.EvidenceCountsByFindingID = map[string]int{}
 	controlKeys := map[string]struct{}{}
 	for tenantID, runtimeIDs := range runtimeIDsByTenant {
 		item, err := provider.SummarizeGRCDashboard(r.Context(), ports.GRCDashboardAggregateRequest{
@@ -878,6 +882,11 @@ func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.Sourc
 		aggregate.FindingSummary.OverdueFindings += item.FindingSummary.OverdueFindings
 		aggregate.FindingSummary.Unassigned += item.FindingSummary.Unassigned
 		aggregate.EvidenceCount += item.EvidenceCount
+		for findingID, count := range item.EvidenceCountsByFindingID {
+			if trimmed := strings.TrimSpace(findingID); trimmed != "" {
+				aggregate.EvidenceCountsByFindingID[trimmed] += count
+			}
+		}
 		for _, key := range item.FindingSummary.FailingControlKeys {
 			if trimmed := strings.TrimSpace(key); trimmed != "" {
 				controlKeys[trimmed] = struct{}{}
@@ -1060,7 +1069,11 @@ func grcControlItems(findings []grcFindingItem, evidence []grcEvidenceItem) []gr
 					control.HighFindings++
 				}
 			}
-			control.EvidenceItems += evidenceByFinding[finding.ID]
+			if finding.EvidenceCount != 0 {
+				control.EvidenceItems += finding.EvidenceCount
+			} else {
+				control.EvidenceItems += evidenceByFinding[finding.ID]
+			}
 		}
 	}
 	controls := make([]grcControlItem, 0, len(controlMap))

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -521,13 +521,14 @@ func TestGRCDashboardUsesPurposeBuiltAggregateStore(t *testing.T) {
 		},
 		findingEvidence: map[string]*cerebrov1.FindingEvidence{
 			"evidence-1": {Id: "evidence-1", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now)},
+			"evidence-2": {Id: "evidence-2", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now.Add(-time.Minute))},
 		},
 	}}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
-	resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=" + tenantID)
+	resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=" + tenantID + "&limit=1")
 	if err != nil {
 		t.Fatalf("GET /grc/dashboard error = %v", err)
 	}
@@ -542,8 +543,14 @@ func TestGRCDashboardUsesPurposeBuiltAggregateStore(t *testing.T) {
 	if store.aggregateCalls != 1 {
 		t.Fatalf("aggregate calls = %d, want 1", store.aggregateCalls)
 	}
-	if payload.Summary.OpenFindings != 1 || payload.Summary.EvidenceItems != 1 {
+	if payload.Summary.OpenFindings != 1 || payload.Summary.EvidenceItems != 2 {
 		t.Fatalf("summary = %+v, want aggregate finding/evidence counts", payload.Summary)
+	}
+	if len(payload.Findings) != 1 || payload.Findings[0].EvidenceCount != 2 {
+		t.Fatalf("findings = %+v, want aggregate evidence count 2", payload.Findings)
+	}
+	if len(payload.Controls) != 1 || payload.Controls[0].EvidenceItems != 2 {
+		t.Fatalf("controls = %+v, want aggregate evidence count 2", payload.Controls)
 	}
 }
 
@@ -660,7 +667,18 @@ func (s *stubGRCAggregateStore) SummarizeGRCDashboard(ctx context.Context, reque
 	if err != nil {
 		return ports.GRCDashboardAggregate{}, err
 	}
-	return ports.GRCDashboardAggregate{FindingSummary: summary, EvidenceCount: count}, nil
+	countsByFindingID := map[string]int{}
+	for _, evidence := range s.findingEvidence {
+		if evidence == nil {
+			continue
+		}
+		for _, findingID := range request.EvidenceRequest.FindingIDs {
+			if evidence.GetFindingId() == findingID {
+				countsByFindingID[findingID]++
+			}
+		}
+	}
+	return ports.GRCDashboardAggregate{FindingSummary: summary, EvidenceCount: count, EvidenceCountsByFindingID: countsByFindingID}, nil
 }
 
 type stubGRCEvidenceHeaderStore struct {

--- a/internal/ports/grc.go
+++ b/internal/ports/grc.go
@@ -10,8 +10,9 @@ type GRCDashboardAggregateRequest struct {
 
 // GRCDashboardAggregate contains dashboard summary counts fetched without row payloads.
 type GRCDashboardAggregate struct {
-	FindingSummary FindingSummary
-	EvidenceCount  int
+	FindingSummary            FindingSummary
+	EvidenceCount             int
+	EvidenceCountsByFindingID map[string]int
 }
 
 // GRCDashboardAggregateStore provides a purpose-built aggregate path for the GRC dashboard.

--- a/internal/statestore/postgres/grc_dashboard.go
+++ b/internal/statestore/postgres/grc_dashboard.go
@@ -46,6 +46,7 @@ func (s *Store) SummarizeGRCDashboard(ctx context.Context, request ports.GRCDash
 	}
 	var aggregate ports.GRCDashboardAggregate
 	var controlRefsJSON string
+	var evidenceCountsJSON string
 	if err := s.db.QueryRowContext(ctx, query, args...).Scan(
 		&aggregate.FindingSummary.OpenFindings,
 		&aggregate.FindingSummary.CriticalFindings,
@@ -54,6 +55,7 @@ func (s *Store) SummarizeGRCDashboard(ctx context.Context, request ports.GRCDash
 		&aggregate.FindingSummary.Unassigned,
 		&controlRefsJSON,
 		&aggregate.EvidenceCount,
+		&evidenceCountsJSON,
 	); err != nil {
 		return ports.GRCDashboardAggregate{}, fmt.Errorf("summarize grc dashboard: %w", err)
 	}
@@ -63,6 +65,11 @@ func (s *Store) SummarizeGRCDashboard(ctx context.Context, request ports.GRCDash
 	}
 	aggregate.FindingSummary.FailingControlKeys = controlKeys
 	aggregate.FindingSummary.ControlsFailing = len(controlKeys)
+	evidenceCounts, err := decodeGRCDashboardEvidenceCounts(evidenceCountsJSON)
+	if err != nil {
+		return ports.GRCDashboardAggregate{}, fmt.Errorf("decode grc dashboard evidence counts: %w", err)
+	}
+	aggregate.EvidenceCountsByFindingID = evidenceCounts
 	return aggregate, nil
 }
 
@@ -89,6 +96,22 @@ func decodeGRCDashboardControlKeys(controlRefsJSON string) ([]string, error) {
 	}
 	sort.Strings(keys)
 	return keys, nil
+}
+
+func decodeGRCDashboardEvidenceCounts(evidenceCountsJSON string) (map[string]int, error) {
+	counts := map[string]int{}
+	if strings.TrimSpace(evidenceCountsJSON) == "" {
+		return counts, nil
+	}
+	if err := json.Unmarshal([]byte(evidenceCountsJSON), &counts); err != nil {
+		return nil, err
+	}
+	for findingID := range counts {
+		if strings.TrimSpace(findingID) == "" {
+			delete(counts, findingID)
+		}
+	}
+	return counts, nil
 }
 
 func grcDashboardAggregateQuery(request ports.GRCDashboardAggregateRequest) (string, []any, error) {
@@ -135,9 +158,15 @@ control_refs AS (
   WHERE LOWER(status) = 'open'
 ),
 evidence_summary AS (
-  SELECT COUNT(*) AS evidence_count
-  FROM finding_evidence
-  WHERE ` + whereEvidence + `
+  SELECT
+    COALESCE(SUM(evidence_count), 0)::bigint AS evidence_count,
+    COALESCE(jsonb_object_agg(finding_id, evidence_count), '{}'::jsonb)::text AS evidence_counts_json
+  FROM (
+    SELECT finding_id, COUNT(*) AS evidence_count
+    FROM finding_evidence
+    WHERE ` + whereEvidence + `
+    GROUP BY finding_id
+  ) counts
 )
 SELECT
   summary.open_findings,
@@ -146,7 +175,8 @@ SELECT
   summary.overdue_findings,
   summary.unassigned,
   COALESCE((SELECT jsonb_agg(jsonb_build_object('framework_name', framework_name, 'control_id', control_id) ORDER BY framework_name, control_id)::text FROM control_refs), '[]'),
-  evidence_summary.evidence_count
+  evidence_summary.evidence_count,
+  evidence_summary.evidence_counts_json
 FROM summary
 CROSS JOIN evidence_summary`
 	return query, args, nil

--- a/internal/statestore/postgres/grc_dashboard_test.go
+++ b/internal/statestore/postgres/grc_dashboard_test.go
@@ -28,6 +28,8 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 		"jsonb_array_elements",
 		"jsonb_build_object('framework_name', framework_name, 'control_id', control_id)",
 		"evidence_summary AS",
+		"jsonb_object_agg(finding_id, evidence_count)",
+		"GROUP BY finding_id",
 		"FROM finding_evidence",
 		"runtime_id IN ($5, $6)",
 		"finding_id IN ($7, $8)",
@@ -58,6 +60,16 @@ func TestDecodeGRCDashboardControlKeysBuildsKeysInGo(t *testing.T) {
 	want := []string{"SOC 2\x00CC6.1", "Unmapped\x00Needs mapping"}
 	if strings.Join(got, "|") != strings.Join(want, "|") {
 		t.Fatalf("decodeGRCDashboardControlKeys() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDecodeGRCDashboardEvidenceCounts(t *testing.T) {
+	got, err := decodeGRCDashboardEvidenceCounts(`{"finding-1":2,"":5}`)
+	if err != nil {
+		t.Fatalf("decodeGRCDashboardEvidenceCounts() error = %v", err)
+	}
+	if len(got) != 1 || got["finding-1"] != 2 {
+		t.Fatalf("decodeGRCDashboardEvidenceCounts() = %#v, want finding-1=2 only", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add lightweight dashboard-specific finding and evidence read paths
- include per-finding evidence counts in the dashboard aggregate
- use aggregate evidence counts for dashboard finding/control totals

## Validation
- go test ./internal/bootstrap ./internal/statestore/postgres ./cmd/cerebro -run 'TestGRC|TestGRCDashboard|TestPrepareGRCReadModels|TestDecodeGRCDashboard|TestRebasePostgresPlaceholders' -count=5
- go test -race ./internal/bootstrap ./internal/statestore/postgres ./cmd/cerebro -run 'TestGRCDashboard|TestPrepareGRCReadModels|TestDecodeGRCDashboard|TestRebasePostgresPlaceholders' -count=1
- make verify