### PR TITLE
Use grouped GRC evidence counts

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -297,13 +297,21 @@ func (a *App) handleGRCFindings(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: scope.Limit})
+	evidenceCounts, counted, err := a.grcEvidenceCountsByFindingID(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings)})
 	if err != nil {
 		writeGRCError(w, err)
 		return
 	}
+	if !counted {
+		evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: scope.Limit})
+		if err != nil {
+			writeGRCError(w, err)
+			return
+		}
+		evidenceCounts = grcEvidenceCounts(evidence)
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"findings":     grcFindingItems(findings, grcRuntimeSourceIDs(runtimes), grcEvidenceCounts(evidence)),
+		"findings":     grcFindingItems(findings, grcRuntimeSourceIDs(runtimes), evidenceCounts),
 		"generated_at": time.Now().UTC(),
 	})
 }
@@ -324,14 +332,24 @@ func (a *App) handleGRCControls(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: scope.Limit})
+	evidenceCounts, counted, err := a.grcEvidenceCountsByFindingID(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings)})
 	if err != nil {
 		writeGRCError(w, err)
 		return
 	}
-	items := grcFindingItems(findings, grcRuntimeSourceIDs(runtimes), grcEvidenceCounts(evidence))
+	var evidenceItems []grcEvidenceItem
+	if !counted {
+		evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: scope.Limit})
+		if err != nil {
+			writeGRCError(w, err)
+			return
+		}
+		evidenceCounts = grcEvidenceCounts(evidence)
+		evidenceItems = grcEvidenceItems(evidence, grcFindingTitleMap(findings))
+	}
+	items := grcFindingItems(findings, grcRuntimeSourceIDs(runtimes), evidenceCounts)
 	writeJSON(w, http.StatusOK, map[string]any{
-		"controls":     grcControlItems(items, grcEvidenceItems(evidence, grcFindingTitleMap(findings))),
+		"controls":     grcControlItems(items, evidenceItems),
 		"generated_at": time.Now().UTC(),
 	})
 }
@@ -508,6 +526,10 @@ type grcFindingSummaryProvider interface {
 
 type grcFindingEvidenceCounter interface {
 	CountFindingEvidence(context.Context, ports.ListFindingEvidenceRequest) (int, error)
+}
+
+type grcFindingEvidenceByFindingCounter interface {
+	CountGRCFindingEvidenceByFindingID(context.Context, ports.ListFindingEvidenceRequest) (map[string]int, error)
 }
 
 type grcFindingEvidenceHeaderLister interface {
@@ -820,6 +842,42 @@ func (a *App) grcEvidenceCount(r *http.Request, runtimes []*cerebrov1.SourceRunt
 	}
 	count += item
 	return &count, nil
+}
+
+func (a *App) grcEvidenceCountsByFindingID(r *http.Request, runtimes []*cerebrov1.SourceRuntime, filter grcEvidenceFilter) (map[string]int, bool, error) {
+	store := findingEvidenceStore(a.deps.StateStore)
+	counter, ok := store.(grcFindingEvidenceByFindingCounter)
+	if !ok {
+		return nil, false, nil
+	}
+	if filter.FindingIDs != nil && strings.TrimSpace(filter.FindingID) == "" && len(grcNonEmptyFindingIDs(filter.FindingIDs)) == 0 {
+		return map[string]int{}, true, nil
+	}
+	var runtimeIDs []string
+	for _, runtime := range runtimes {
+		if runtime == nil {
+			continue
+		}
+		if runtimeID := strings.TrimSpace(runtime.GetId()); runtimeID != "" {
+			runtimeIDs = append(runtimeIDs, runtimeID)
+		}
+	}
+	if len(runtimeIDs) == 0 {
+		return map[string]int{}, true, nil
+	}
+	counts, err := counter.CountGRCFindingEvidenceByFindingID(r.Context(), ports.ListFindingEvidenceRequest{
+		RuntimeIDs:   runtimeIDs,
+		FindingID:    filter.FindingID,
+		FindingIDs:   filter.FindingIDs,
+		RunID:        filter.RunID,
+		RuleID:       filter.RuleID,
+		GraphRootURN: filter.GraphRootURN,
+		Limit:        0,
+	})
+	if err != nil {
+		return nil, true, err
+	}
+	return counts, true, nil
 }
 
 func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.SourceRuntime, findingFilter grcFindingFilter, evidenceFilter grcEvidenceFilter) (*ports.GRCDashboardAggregate, error) {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -493,6 +493,137 @@ func TestGRCDashboardUsesHeaderOnlyFindingLister(t *testing.T) {
 	}
 }
 
+func TestGRCFindingsUsesGroupedEvidenceCounts(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	runtimeID := "runtime-alpha"
+	tenantID := "tenant"
+	store := &stubGRCEvidenceCountStore{stubRuntimeStore: &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {
+				Id:           runtimeID,
+				SourceId:     "okta",
+				TenantId:     tenantID,
+				LastSyncedAt: timestamppb.New(now),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)},
+			},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Finding 1",
+				Severity:       "HIGH",
+				Status:         "open",
+				LastObservedAt: now,
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-1": {Id: "evidence-1", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now)},
+			"evidence-2": {Id: "evidence-2", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now.Add(-time.Minute))},
+		},
+	}}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/findings?tenant_id=" + tenantID + "&limit=1")
+	if err != nil {
+		t.Fatalf("GET /grc/findings error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/findings status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload struct {
+		Findings []grcFindingItem `json:"findings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /grc/findings: %v", err)
+	}
+	if len(payload.Findings) != 1 || payload.Findings[0].EvidenceCount != 2 {
+		t.Fatalf("findings = %+v, want grouped evidence count 2", payload.Findings)
+	}
+	if store.groupedCountCalls != 1 {
+		t.Fatalf("grouped count calls = %d, want 1", store.groupedCountCalls)
+	}
+	if store.fullEvidenceCalls != 0 {
+		t.Fatalf("full evidence calls = %d, want 0", store.fullEvidenceCalls)
+	}
+	if store.groupedCountRequest.Limit != 0 {
+		t.Fatalf("grouped count limit = %d, want unpaginated 0", store.groupedCountRequest.Limit)
+	}
+	if len(store.groupedCountRequest.FindingIDs) != 1 || store.groupedCountRequest.FindingIDs[0] != "finding-1" {
+		t.Fatalf("grouped count finding ids = %#v, want finding-1", store.groupedCountRequest.FindingIDs)
+	}
+}
+
+func TestGRCControlsUsesGroupedEvidenceCounts(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	runtimeID := "runtime-alpha"
+	tenantID := "tenant"
+	store := &stubGRCEvidenceCountStore{stubRuntimeStore: &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {
+				Id:           runtimeID,
+				SourceId:     "okta",
+				TenantId:     tenantID,
+				LastSyncedAt: timestamppb.New(now),
+				Checkpoint:   &cerebrov1.SourceCheckpoint{Watermark: timestamppb.New(now)},
+			},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				TenantID:       tenantID,
+				RuntimeID:      runtimeID,
+				Title:          "Finding 1",
+				Severity:       "HIGH",
+				Status:         "open",
+				ControlRefs:    []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}},
+				LastObservedAt: now,
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{
+			"evidence-1": {Id: "evidence-1", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now)},
+			"evidence-2": {Id: "evidence-2", RuntimeId: runtimeID, FindingId: "finding-1", CreatedAt: timestamppb.New(now.Add(-time.Minute))},
+		},
+	}}
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/controls?tenant_id=" + tenantID + "&limit=1")
+	if err != nil {
+		t.Fatalf("GET /grc/controls error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/controls status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var payload struct {
+		Controls []grcControlItem `json:"controls"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /grc/controls: %v", err)
+	}
+	if len(payload.Controls) != 1 || payload.Controls[0].EvidenceItems != 2 {
+		t.Fatalf("controls = %+v, want grouped evidence count 2", payload.Controls)
+	}
+	if store.groupedCountCalls != 1 {
+		t.Fatalf("grouped count calls = %d, want 1", store.groupedCountCalls)
+	}
+	if store.fullEvidenceCalls != 0 {
+		t.Fatalf("full evidence calls = %d, want 0", store.fullEvidenceCalls)
+	}
+	if store.groupedCountRequest.Limit != 0 {
+		t.Fatalf("grouped count limit = %d, want unpaginated 0", store.groupedCountRequest.Limit)
+	}
+	if len(store.groupedCountRequest.FindingIDs) != 1 || store.groupedCountRequest.FindingIDs[0] != "finding-1" {
+		t.Fatalf("grouped count finding ids = %#v, want finding-1", store.groupedCountRequest.FindingIDs)
+	}
+}
+
 func TestGRCDashboardUsesPurposeBuiltAggregateStore(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	runtimeID := "tenant-okta-audit"
@@ -711,4 +842,31 @@ func (s *stubGRCFindingHeaderStore) ListGRCFindings(ctx context.Context, request
 func (s *stubGRCFindingHeaderStore) ListFindings(ctx context.Context, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
 	s.fullFindingCalls++
 	return s.stubRuntimeStore.ListFindings(ctx, request)
+}
+
+type stubGRCEvidenceCountStore struct {
+	*stubRuntimeStore
+	groupedCountCalls   int
+	groupedCountRequest ports.ListFindingEvidenceRequest
+	fullEvidenceCalls   int
+}
+
+func (s *stubGRCEvidenceCountStore) CountGRCFindingEvidenceByFindingID(_ context.Context, request ports.ListFindingEvidenceRequest) (map[string]int, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	s.groupedCountCalls++
+	s.groupedCountRequest = request
+	counts := map[string]int{}
+	for _, record := range s.findingEvidence {
+		if record != nil && findingEvidenceMatches(request, record) {
+			counts[record.GetFindingId()]++
+		}
+	}
+	return counts, nil
+}
+
+func (s *stubGRCEvidenceCountStore) ListFindingEvidence(ctx context.Context, request ports.ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error) {
+	s.fullEvidenceCalls++
+	return s.stubRuntimeStore.ListFindingEvidence(ctx, request)
 }

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -344,6 +344,45 @@ WHERE `+strings.Join(clauses, " AND "), args...).Scan(&count); err != nil {
 	return count, nil
 }
 
+// CountGRCFindingEvidenceByFindingID returns unpaginated evidence counts grouped by finding.
+func (s *Store) CountGRCFindingEvidenceByFindingID(ctx context.Context, request ports.ListFindingEvidenceRequest) (_ map[string]int, err error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingEvidenceTables(ctx); err != nil {
+		return nil, err
+	}
+	query, args, err := findingEvidenceCountByFindingIDQuery(request)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("count grc finding evidence by finding for runtime %q: %w", strings.TrimSpace(request.RuntimeID), err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close grc finding evidence count rows: %w", closeErr)
+		}
+	}()
+
+	counts := map[string]int{}
+	for rows.Next() {
+		var findingID string
+		var count int
+		if err := rows.Scan(&findingID, &count); err != nil {
+			return nil, fmt.Errorf("scan grc finding evidence count row: %w", err)
+		}
+		if trimmed := strings.TrimSpace(findingID); trimmed != "" {
+			counts[trimmed] = count
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate grc finding evidence count rows: %w", err)
+	}
+	return counts, nil
+}
+
 func (s *Store) ensureFindingEvidenceTables(ctx context.Context) error {
 	return s.ensureStatements(ctx, &s.findingEvidenceReady, "finding evidence", ensureFindingEvidenceStatements)
 }
@@ -379,6 +418,20 @@ ORDER BY ` + findingEvidenceListOrder(request)
 		args = append(args, int64(request.Limit))
 		query += fmt.Sprintf(" LIMIT $%d", len(args))
 	}
+	return query, args, nil
+}
+
+func findingEvidenceCountByFindingIDQuery(request ports.ListFindingEvidenceRequest) (string, []any, error) {
+	clauses, args, err := findingEvidenceFilterClauses(request)
+	if err != nil {
+		return "", nil, err
+	}
+	query := `
+SELECT finding_id, COUNT(*)
+FROM finding_evidence
+WHERE ` + strings.Join(clauses, " AND ") + `
+GROUP BY finding_id
+ORDER BY finding_id`
 	return query, args, nil
 }
 

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -56,6 +56,13 @@ func TestListGRCFindingEvidenceRejectsUnconfiguredStore(t *testing.T) {
 	}
 }
 
+func TestCountGRCFindingEvidenceByFindingIDRejectsUnconfiguredStore(t *testing.T) {
+	store := &Store{}
+	if _, err := store.CountGRCFindingEvidenceByFindingID(context.Background(), ports.ListFindingEvidenceRequest{RuntimeID: "runtime-alpha"}); err == nil {
+		t.Fatal("CountGRCFindingEvidenceByFindingID() error = nil, want non-nil")
+	}
+}
+
 func TestFindingEvidenceListQueryIncludesOptionalFilters(t *testing.T) {
 	query, args, err := findingEvidenceListQuery(ports.ListFindingEvidenceRequest{
 		RuntimeID:    "runtime-alpha",
@@ -123,6 +130,37 @@ func TestFindingEvidenceHeaderListQueryAvoidsFullPayload(t *testing.T) {
 	}
 	if got := len(args); got != 5 {
 		t.Fatalf("len(findingEvidenceHeaderListQuery().args) = %d, want 5", got)
+	}
+}
+
+func TestFindingEvidenceCountByFindingIDQueryUsesGroupedCounts(t *testing.T) {
+	query, args, err := findingEvidenceCountByFindingIDQuery(ports.ListFindingEvidenceRequest{
+		RuntimeIDs: []string{"runtime-alpha", "runtime-beta"},
+		FindingIDs: []string{"finding-high", "finding-critical"},
+		Limit:      25,
+	})
+	if err != nil {
+		t.Fatalf("findingEvidenceCountByFindingIDQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"SELECT finding_id, COUNT(*)",
+		"FROM finding_evidence",
+		"runtime_id IN ($1, $2)",
+		"finding_id IN ($3, $4)",
+		"GROUP BY finding_id",
+		"ORDER BY finding_id",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("findingEvidenceCountByFindingIDQuery() query missing %q: %s", fragment, query)
+		}
+	}
+	for _, forbidden := range []string{"finding_evidence_json", "LIMIT"} {
+		if strings.Contains(query, forbidden) {
+			t.Fatalf("findingEvidenceCountByFindingIDQuery() included %q: %s", forbidden, query)
+		}
+	}
+	if got := len(args); got != 4 {
+		t.Fatalf("len(findingEvidenceCountByFindingIDQuery().args) = %d, want 4", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a grouped GRC evidence-count read path keyed by finding ID
- use it for /grc/findings and /grc/controls so those routes avoid listing evidence rows just to count them
- keep existing evidence-list fallback for stores without the grouped counter

## Validation
- go test ./internal/bootstrap ./internal/statestore/postgres -run 'Test(GRC(Findings|Controls|Dashboard)|TestFindingEvidence.*(GRC|Count|Header))' -count=1
- make verify