### PR TITLE
Run GRC warmup asynchronously

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -97,11 +97,9 @@ func serve() error {
 	if err != nil {
 		return fmt.Errorf("bootstrap app: %w", err)
 	}
-	if err := prepareGRCReadModels(context.Background(), deps.StateStore); err != nil {
-		return err
-	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	startGRCReadModelWarmup(ctx, deps.StateStore, log.Printf)
 	startFindingRiskBackfill(ctx, app, log.Printf)
 
 	errCh := make(chan error, 1)
@@ -145,6 +143,17 @@ func prepareGRCReadModels(ctx context.Context, stateStore ports.StateStore) erro
 		return fmt.Errorf("prepare grc read models: %w", err)
 	}
 	return nil
+}
+
+func startGRCReadModelWarmup(ctx context.Context, stateStore ports.StateStore, logf func(string, ...any)) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := prepareGRCReadModels(ctx, stateStore); err != nil && ctx.Err() == nil {
+			logf("%v", err)
+		}
+	}()
+	return done
 }
 
 func startFindingRiskBackfill(ctx context.Context, backfiller findingRiskBackfiller, logf func(string, ...any)) <-chan struct{} {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -101,6 +101,56 @@ func TestPrepareGRCReadModelsWrapsErrors(t *testing.T) {
 	}
 }
 
+func TestStartGRCReadModelWarmupDoesNotBlockStartup(t *testing.T) {
+	store := &blockingPreparingStateStore{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := startGRCReadModelWarmup(ctx, store, func(string, ...any) {})
+	select {
+	case <-store.started:
+	case <-time.After(time.Second):
+		t.Fatal("GRC read-model warmup did not start")
+	}
+	select {
+	case <-done:
+		t.Fatal("GRC read-model warmup completed while still blocked")
+	default:
+	}
+
+	close(store.release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("GRC read-model warmup did not finish after release")
+	}
+}
+
+func TestStartGRCReadModelWarmupLogsErrors(t *testing.T) {
+	store := &preparingStateStore{err: errors.New("boom")}
+	logged := make(chan string, 1)
+
+	done := startGRCReadModelWarmup(context.Background(), store, func(format string, args ...any) {
+		logged <- fmt.Sprintf(format, args...)
+	})
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("GRC read-model warmup did not finish")
+	}
+	select {
+	case message := <-logged:
+		if !strings.Contains(message, "prepare grc read models: boom") {
+			t.Fatalf("logged message = %q, want wrapped warmup error", message)
+		}
+	default:
+		t.Fatal("GRC read-model warmup error was not logged")
+	}
+}
+
 func TestParseSourceRuntimePutArgsSeparatesTenantID(t *testing.T) {
 	t.Setenv("CEREBRO_TEST_TOKEN", "test")
 	runtime, err := parseSourceRuntimePutArgs([]string{
@@ -337,6 +387,12 @@ type preparingStateStore struct {
 	err   error
 }
 
+type blockingPreparingStateStore struct {
+	basicStateStore
+	started chan struct{}
+	release chan struct{}
+}
+
 type blockingFindingRiskBackfiller struct {
 	started chan struct{}
 	release chan struct{}
@@ -367,6 +423,12 @@ func (s *basicStateStore) Ping(context.Context) error {
 func (s *preparingStateStore) PrepareGRCReadModels(context.Context) error {
 	s.calls++
 	return s.err
+}
+
+func (s *blockingPreparingStateStore) PrepareGRCReadModels(context.Context) error {
+	close(s.started)
+	<-s.release
+	return nil
 }
 
 func (s *commandRuntimeStore) PutSourceRuntime(_ context.Context, runtime *cerebrov1.SourceRuntime) error {


### PR DESCRIPTION
## Summary\n- move GRC read-model preparation out of the blocking serve startup path\n- log warmup failures instead of failing process startup after dependencies/bootstrap succeed\n- add tests that warmup starts asynchronously and reports errors\n\n## Verification\n- go test ./cmd/cerebro -run 'Test(StartGRCReadModelWarmup|PrepareGRCReadModels)' -count=5\n- go test ./cmd/cerebro\n- make verify\n\n## Deployment context\nSec-dev rolled back v2.1.130 because new API tasks failed target health checks while startup warmup was still blocking the listener. This keeps health endpoints available while the warmup runs in the background.