### PR TITLE
Improve graph links from findings

### DIFF
--- a/internal/sourceprojection/aurelius.go
+++ b/internal/sourceprojection/aurelius.go
@@ -288,6 +288,9 @@ func aureliusImageEntity(tenantID, sourceID, urn string, attrs map[string]string
 
 func addAureliusImageDigestEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, attrs map[string]string) string {
 	digest := firstAttribute(attrs, "image_digest", "digest")
+	if strings.TrimSpace(digest) == "" {
+		return ""
+	}
 	digestURN := projectionURN(tenantID, "container_image_digest", digest)
 	if digestURN == "" {
 		return ""

--- a/internal/sourceprojection/aurelius.go
+++ b/internal/sourceprojection/aurelius.go
@@ -21,6 +21,10 @@ func aureliusImageScanProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 		addEntity(entities, aureliusImageEntity(tenantID, event.GetSourceId(), imageURN, attrs))
 		addAureliusImageContextLinks(entities, links, tenantID, event, imageURN, attrs)
 	}
+	digestURN := addAureliusImageDigestEntity(entities, tenantID, event.GetSourceId(), attrs)
+	if imageURN != "" && digestURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), imageURN, digestURN, relationRepresents, map[string]string{"event_id": event.GetId(), "match_type": "container_image_digest"}))
+	}
 
 	scanID := firstAttribute(attrs, "scan_id", "image_digest")
 	scanURN := projectionURN(tenantID, "aurelius_image_scan", scanID)
@@ -44,6 +48,10 @@ func aureliusImageScanProjections(event *cerebrov1.EventEnvelope) ([]*ports.Proj
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), scanURN, imageURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), imageURN, scanURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
 		}
+		if digestURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), scanURN, digestURN, relationObservedOn, map[string]string{"event_id": event.GetId(), "match_type": "container_image_digest"}))
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), digestURN, scanURN, relationHasEvidence, map[string]string{"event_id": event.GetId(), "match_type": "container_image_digest"}))
+		}
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
@@ -63,6 +71,10 @@ func aureliusVerdictProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 	if imageURN != "" {
 		addEntity(entities, aureliusImageEntity(tenantID, event.GetSourceId(), imageURN, attrs))
 		addAureliusImageContextLinks(entities, links, tenantID, event, imageURN, attrs)
+	}
+	digestURN := addAureliusImageDigestEntity(entities, tenantID, event.GetSourceId(), attrs)
+	if imageURN != "" && digestURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), imageURN, digestURN, relationRepresents, map[string]string{"event_id": event.GetId(), "match_type": "container_image_digest"}))
 	}
 
 	verdictKey := firstAttribute(attrs, "image_digest")
@@ -84,6 +96,10 @@ func aureliusVerdictProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projec
 		if imageURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), verdictURN, imageURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), imageURN, verdictURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
+		}
+		if digestURN != "" {
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), verdictURN, digestURN, relationObservedOn, map[string]string{"event_id": event.GetId(), "match_type": "container_image_digest"}))
+			addLink(links, projectedLink(tenantID, event.GetSourceId(), digestURN, verdictURN, relationHasEvidence, map[string]string{"event_id": event.GetId(), "match_type": "container_image_digest"}))
 		}
 	}
 
@@ -268,6 +284,23 @@ func aureliusImageEntity(tenantID, sourceID, urn string, attrs map[string]string
 		Label:      firstAttribute(attrs, "image_uri", "image", "resource_uri", "resource_id", "artifact_uri", "image_digest"),
 		Attributes: imageAttrs,
 	}
+}
+
+func addAureliusImageDigestEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, attrs map[string]string) string {
+	digest := firstAttribute(attrs, "image_digest", "digest")
+	digestURN := projectionURN(tenantID, "container_image_digest", digest)
+	if digestURN == "" {
+		return ""
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        digestURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "container.image_digest",
+		Label:      digest,
+		Attributes: map[string]string{"digest": digest},
+	})
+	return digestURN
 }
 
 func addAureliusImageContextLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, imageURN string, attrs map[string]string) {

--- a/internal/sourceprojection/aurelius_test.go
+++ b/internal/sourceprojection/aurelius_test.go
@@ -202,6 +202,53 @@ func TestProjectAureliusDigestOnlyFindingDoesNotCreateArtifactRegistryImage(t *t
 	}
 }
 
+func TestProjectAureliusScanAndVerdictShareDigestAnchor(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	events := []*cerebrov1.EventEnvelope{
+		{
+			Id:       "aurelius-image-scan-digest",
+			TenantId: "writer",
+			SourceId: "aurelius",
+			Kind:     "aurelius.image_scan",
+			Attributes: map[string]string{
+				"image_digest": "sha256:shared",
+				"scan_id":      "scan-shared",
+			},
+		},
+		{
+			Id:       "aurelius-verdict-digest",
+			TenantId: "writer",
+			SourceId: "aurelius",
+			Kind:     "aurelius.verdict",
+			Attributes: map[string]string{
+				"image_digest": "sha256:shared",
+				"verdict":      "warn",
+			},
+		},
+	}
+	for _, event := range events {
+		if _, err := service.Project(context.Background(), event); err != nil {
+			t.Fatalf("Project(%s) error = %v", event.GetKind(), err)
+		}
+	}
+
+	digestURN := "urn:cerebro:writer:container_image_digest:sha256:shared"
+	scanURN := "urn:cerebro:writer:aurelius_image_scan:scan-shared"
+	verdictURN := "urn:cerebro:writer:aurelius_verdict:sha256:shared"
+	if entity := state.entities[digestURN]; entity == nil || entity.EntityType != "container.image_digest" {
+		t.Fatalf("digest anchor missing or wrong: %#v", entity)
+	}
+	assertProjectedLink(t, state, scanURN, relationObservedOn, digestURN)
+	assertProjectedLink(t, state, digestURN, relationHasEvidence, scanURN)
+	assertProjectedLink(t, state, verdictURN, relationObservedOn, digestURN)
+	assertProjectedLink(t, state, digestURN, relationHasEvidence, verdictURN)
+	if entity := state.entities["urn:cerebro:writer:gcp_artifact_registry_image:sha256:shared"]; entity != nil {
+		t.Fatalf("digest-only scan/verdict created non-canonical image entity: %#v", entity)
+	}
+}
+
 func TestProjectAureliusImageScanLinksImageRepositoryHierarchy(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/workflowprojection/projector.go
+++ b/internal/workflowprojection/projector.go
@@ -418,12 +418,12 @@ func (s *Service) ensureFindingActiveLinks(ctx context.Context, finding workflow
 	tenantID := strings.TrimSpace(finding.TenantID)
 	sourceID := strings.TrimSpace(finding.SourceSystem)
 	anchorURN := findingURN(tenantID, finding.FindingID)
-	resourceURNs := findingResourceURNs(finding)
-	for _, resourceURN := range resourceURNs {
+	targetURNs := findingActiveTargetURNs(finding)
+	for _, targetURN := range targetURNs {
 		if err := s.upsertLink(ctx, &ports.ProjectedLink{
 			TenantID:   tenantID,
 			SourceID:   sourceID,
-			FromURN:    resourceURN,
+			FromURN:    targetURN,
 			ToURN:      anchorURN,
 			Relation:   relationHasFinding,
 			Attributes: findingAnchorLinkAttributes(finding),
@@ -431,7 +431,7 @@ func (s *Service) ensureFindingActiveLinks(ctx context.Context, finding workflow
 			return err
 		}
 	}
-	if err := s.pruneFindingActiveLinks(ctx, tenantID, sourceID, anchorURN, resourceURNs, result); err != nil {
+	if err := s.pruneFindingActiveLinks(ctx, tenantID, sourceID, anchorURN, targetURNs, result); err != nil {
 		return err
 	}
 	return nil
@@ -513,7 +513,7 @@ func (s *Service) deleteFindingActiveLinks(ctx context.Context, finding workflow
 	sourceID := strings.TrimSpace(finding.SourceSystem)
 	anchorURN := findingURN(tenantID, finding.FindingID)
 	var deleted uint32
-	for _, resourceURN := range findingResourceURNs(finding) {
+	for _, resourceURN := range findingActiveTargetURNs(finding) {
 		if err := deleter.DeleteProjectedLink(ctx, &ports.ProjectedLink{
 			TenantID: tenantID,
 			SourceID: sourceID,
@@ -529,11 +529,46 @@ func (s *Service) deleteFindingActiveLinks(ctx context.Context, finding workflow
 }
 
 func findingTargetURNs(finding workflowevents.FindingSnapshot) []string {
-	return normalizeIDs(append(findingResourceURNs(finding), findingURN(strings.TrimSpace(finding.TenantID), finding.FindingID)))
+	return normalizeIDs(append(findingActiveTargetURNs(finding), findingURN(strings.TrimSpace(finding.TenantID), finding.FindingID)))
+}
+
+func findingActiveTargetURNs(finding workflowevents.FindingSnapshot) []string {
+	return normalizeIDs(append(findingResourceURNs(finding), findingActorURNs(finding)...))
 }
 
 func findingResourceURNs(finding workflowevents.FindingSnapshot) []string {
 	return normalizeIDs(append([]string{strings.TrimSpace(finding.PrimaryResourceURN)}, finding.ResourceURNs...))
+}
+
+func findingActorURNs(finding workflowevents.FindingSnapshot) []string {
+	if len(finding.Metadata) == 0 {
+		return nil
+	}
+	candidates := []string{
+		finding.Metadata["actor_urn"],
+		finding.Metadata["primary_actor_urn"],
+	}
+	urns := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if urn := canonicalFindingActorURN(strings.TrimSpace(finding.TenantID), candidate); urn != "" {
+			urns = append(urns, urn)
+		}
+	}
+	return normalizeIDs(urns)
+}
+
+func canonicalFindingActorURN(tenantID string, urn string) string {
+	value := strings.TrimSpace(urn)
+	if value == "" || !strings.HasPrefix(value, "urn:cerebro:") {
+		return ""
+	}
+	parts := strings.SplitN(value, ":", 6)
+	if len(parts) == 6 && parts[0] == "urn" && parts[1] == "cerebro" && parts[3] == "okta_actor" && parts[4] == "user" && strings.TrimSpace(parts[5]) != "" {
+		if tenant := strings.TrimSpace(tenantID); tenant == "" || tenant == parts[2] {
+			return fmt.Sprintf("urn:cerebro:%s:okta_user:%s", parts[2], strings.TrimSpace(parts[5]))
+		}
+	}
+	return value
 }
 
 func (s *Service) upsertEntity(ctx context.Context, entity *ports.ProjectedEntity, result *ports.ProjectionResult) error {

--- a/internal/workflowprojection/projector_test.go
+++ b/internal/workflowprojection/projector_test.go
@@ -325,6 +325,9 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	if got := resourceFindingLink.Attributes["confidence"]; got != "0.8" {
 		t.Fatalf("has_finding confidence = %q", got)
 	}
+	if _, ok := graph.links["urn:cerebro:writer:okta_user:00u1|has_finding|urn:cerebro:writer:finding:finding-1"]; !ok {
+		t.Fatal("actor finding link missing after recorded event")
+	}
 	noteEvent, err := workflowevents.NewFindingNoteAddedEvent(workflowevents.FindingNoteAdded{
 		Finding:   finding,
 		NoteID:    "note-1",
@@ -382,6 +385,9 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	}
 	if _, ok := graph.links["urn:cerebro:writer:okta_resource:policyrule:pol-1|has_finding|urn:cerebro:writer:finding:finding-1"]; ok {
 		t.Fatal("manually resolved finding should not keep active has_finding link")
+	}
+	if _, ok := graph.links["urn:cerebro:writer:okta_user:00u1|has_finding|urn:cerebro:writer:finding:finding-1"]; ok {
+		t.Fatal("manually resolved finding should not keep active actor has_finding link")
 	}
 
 	if _, err := service.Project(context.Background(), recordedEvent); err != nil {
@@ -449,6 +455,9 @@ func TestProjectFindingWorkflowEvents(t *testing.T) {
 	}
 	if _, ok := graph.links["urn:cerebro:writer:okta_resource:policyrule:pol-1|has_finding|urn:cerebro:writer:finding:finding-1"]; ok {
 		t.Fatal("resolved finding has_finding link should be pruned from graph")
+	}
+	if _, ok := graph.links["urn:cerebro:writer:okta_user:00u1|has_finding|urn:cerebro:writer:finding:finding-1"]; ok {
+		t.Fatal("resolved finding actor has_finding link should be pruned from graph")
 	}
 	if _, ok := graph.entities[annotationURN]; ok {
 		t.Fatal("isolated finding note annotation should be pruned from graph")


### PR DESCRIPTION
## Summary
- link active findings from contextual actor URNs, including Okta actor-to-user canonicalization
- add shared container image digest anchors for Aurelius scan/verdict projections
- cover actor finding links and digest-only Aurelius graph linking with focused tests

## Tests
- go test ./internal/workflowprojection ./internal/sourceprojection
- make verify