### PR TITLE
Enforce bounded telemetry errors

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -36,6 +36,12 @@ const (
 	defaultGraphPathsTimeout        = 60 * time.Second
 )
 
+var (
+	errEndpointOwnerIDCleanupUnsupported = errors.New("endpoint owner-id link cleanup is unsupported by configured stores")
+	errEndpointOwnerIDStateCleanupFailed = errors.New("state endpoint owner-id link cleanup failed")
+	errEndpointOwnerIDGraphCleanupFailed = errors.New("graph endpoint owner-id link cleanup failed")
+)
+
 type graphCountsStore interface {
 	Counts(context.Context) (graphstore.Counts, error)
 }
@@ -543,7 +549,7 @@ func cleanupEndpointOwnerIDLinks(ctx context.Context, deps bootstrap.Dependencie
 		}
 		if err != nil {
 			status = "error"
-			fields = append(fields, telemetry.Field{Key: "error", Value: err.Error()})
+			fields = append(fields, telemetry.Field{Key: "error_kind", Value: graphEndpointOwnerIDCleanupErrorKind(err)})
 		}
 		telemetry.End(span, status, telemetry.Attrs(fields...))
 	}()
@@ -559,20 +565,33 @@ func cleanupEndpointOwnerIDLinks(ctx context.Context, deps bootstrap.Dependencie
 		cleaned = true
 		result.StateStore, err = cleaner.CleanupEndpointOwnerIDLinks(ctx, request)
 		if err != nil {
-			return result, fmt.Errorf("cleanup state endpoint owner-id links: %w", err)
+			return result, fmt.Errorf("%w: %w", errEndpointOwnerIDStateCleanupFailed, err)
 		}
 	}
 	if cleaner, ok := deps.GraphStore.(ports.EndpointOwnerIDLinkCleaner); ok {
 		cleaned = true
 		result.GraphStore, err = cleaner.CleanupEndpointOwnerIDLinks(ctx, request)
 		if err != nil {
-			return result, fmt.Errorf("cleanup graph endpoint owner-id links: %w", err)
+			return result, fmt.Errorf("%w: %w", errEndpointOwnerIDGraphCleanupFailed, err)
 		}
 	}
 	if !cleaned {
-		return result, fmt.Errorf("endpoint owner-id link cleanup is unsupported by configured stores")
+		return result, errEndpointOwnerIDCleanupUnsupported
 	}
 	return result, nil
+}
+
+func graphEndpointOwnerIDCleanupErrorKind(err error) string {
+	switch {
+	case errors.Is(err, errEndpointOwnerIDCleanupUnsupported):
+		return "cleanup_unsupported"
+	case errors.Is(err, errEndpointOwnerIDStateCleanupFailed):
+		return "state_cleanup_failed"
+	case errors.Is(err, errEndpointOwnerIDGraphCleanupFailed):
+		return "graph_cleanup_failed"
+	default:
+		return "cleanup_failed"
+	}
 }
 
 func cleanupProjectedEntities(ctx context.Context, deps bootstrap.Dependencies, options graphProjectedEntityCleanupOptions) (result graphProjectedEntityCleanupResult, err error) {

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 type cleanupStateStore struct {
 	request           ports.ProjectionLinkCleanupRequest
 	result            ports.ProjectionLinkCleanupResult
+	err               error
 	projectionRequest ports.ProjectionCleanupRequest
 	projectionResult  ports.ProjectionCleanupResult
 }
@@ -22,7 +25,7 @@ func (s *cleanupStateStore) Ping(context.Context) error { return nil }
 
 func (s *cleanupStateStore) CleanupEndpointOwnerIDLinks(_ context.Context, request ports.ProjectionLinkCleanupRequest) (ports.ProjectionLinkCleanupResult, error) {
 	s.request = request
-	return s.result, nil
+	return s.result, s.err
 }
 
 func (s *cleanupStateStore) CleanupProjectedEntities(_ context.Context, request ports.ProjectionCleanupRequest) (ports.ProjectionCleanupResult, error) {
@@ -203,6 +206,33 @@ func TestCleanupEndpointOwnerIDLinksAllowsStateStoreOnly(t *testing.T) {
 	}
 	if result.StateStore.LinksMatched != 3 || result.GraphStore.LinksMatched != 0 {
 		t.Fatalf("cleanup result = %#v, want state-only result", result)
+	}
+}
+
+func TestCleanupEndpointOwnerIDLinksTelemetryClassifiesErrors(t *testing.T) {
+	state := &cleanupStateStore{err: errors.New("cleanup backend failed credential=fake-sensitive-value")}
+	stderr := captureCommandStderr(t, func() {
+		_, err := cleanupEndpointOwnerIDLinks(context.Background(), bootstrap.Dependencies{StateStore: state}, graphEndpointOwnerIDCleanupOptions{
+			TenantID: "writer",
+			DryRun:   true,
+		})
+		if !errors.Is(err, errEndpointOwnerIDStateCleanupFailed) {
+			t.Fatalf("cleanupEndpointOwnerIDLinks() error = %v, want state cleanup failure", err)
+		}
+	})
+
+	payload := lastCommandTelemetryPayload(t, stderr)
+	if got := payload["name"]; got != "projection_cleanup.endpoint_owner_id_links" {
+		t.Fatalf("telemetry name = %#v, want projection cleanup; payload=%#v", got, payload)
+	}
+	if got := payload["status"]; got != "error" {
+		t.Fatalf("telemetry status = %#v, want error; payload=%#v", got, payload)
+	}
+	if got := payload["error_kind"]; got != "state_cleanup_failed" {
+		t.Fatalf("telemetry error_kind = %#v, want state_cleanup_failed; payload=%#v", got, payload)
+	}
+	if strings.Contains(stderr, "fake-sensitive-value") || strings.Contains(stderr, "credential=") {
+		t.Fatalf("cleanup telemetry leaked raw error: %s", stderr)
 	}
 }
 

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -63,7 +63,7 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 	if llm == nil {
 		err := errors.Join(graphagent.ErrRuntimeUnavailable, errors.New("graph agent llm is not configured"))
 		evt.failureStage = "llm_init"
-		evt.llmInitError = err.Error()
+		evt.llmInitErrorKind = grcTelemetryErrorKind(err)
 		evt.finish(r, w, started, http.StatusServiceUnavailable, err)
 		writeGRCError(w, err)
 		return
@@ -138,19 +138,19 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 }
 
 type askWideEvent struct {
-	tenantID     string
-	question     string
-	scopeURN     string
-	model        string
-	historyLen   int
-	provider     string
-	graphStoreOK bool
-	llmOK        bool
-	llmPreCached bool
-	llmInitMs    int64
-	llmInitError string
-	failureStage string
-	sseEvents    int
+	tenantID         string
+	question         string
+	scopeURN         string
+	model            string
+	historyLen       int
+	provider         string
+	graphStoreOK     bool
+	llmOK            bool
+	llmPreCached     bool
+	llmInitMs        int64
+	llmInitErrorKind string
+	failureStage     string
+	sseEvents        int
 
 	queryPlan askQueryPlanTelemetry
 	result    askResultTelemetry
@@ -305,15 +305,11 @@ func (e *askWideEvent) finish(r *http.Request, w http.ResponseWriter, started ti
 	if e.failureStage != "" {
 		attrs = attrs.WithField(telemetry.Field{Key: "failure_stage", Value: e.failureStage})
 	}
-	if e.llmInitError != "" {
-		attrs = attrs.WithField(telemetry.Field{Key: "llm.init_error", Value: e.llmInitError})
+	if e.llmInitErrorKind != "" {
+		attrs = attrs.WithField(telemetry.Field{Key: "llm.init_error_kind", Value: e.llmInitErrorKind})
 	}
 	if err != nil {
-		errMsg := err.Error()
-		if len(errMsg) > 256 {
-			errMsg = errMsg[:256]
-		}
-		attrs = attrs.WithField(telemetry.Field{Key: "error", Value: errMsg})
+		attrs = attrs.WithField(telemetry.Field{Key: "error_kind", Value: grcTelemetryErrorKind(err)})
 	}
 	if r != nil {
 		attrs = attrs.WithField(telemetry.Field{Key: "http.method", Value: r.Method})

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -198,6 +198,12 @@ func TestGRCAskDraftFailureReturnsServiceUnavailable(t *testing.T) {
 	if got := payload["runtime_error.code"]; got != "ask_failed" {
 		t.Fatalf("runtime_error.code = %#v, want ask_failed; payload=%#v", got, payload)
 	}
+	if got := payload["error_kind"]; got != "runtime_unavailable" {
+		t.Fatalf("error_kind = %#v, want runtime_unavailable; payload=%#v", got, payload)
+	}
+	if _, exists := payload["error"]; exists {
+		t.Fatalf("raw error recorded in telemetry: payload=%#v", payload)
+	}
 	if _, exists := payload["validator.code"]; exists {
 		t.Fatalf("validator.code recorded runtime error: payload=%#v", payload)
 	}
@@ -248,6 +254,7 @@ func TestGRCAskTelemetryCopiesErrorEventTimings(t *testing.T) {
 	payload := decodeBootstrapTelemetryPayload(t, stderr)
 	for key, want := range map[string]any{
 		"terminal_event":      graphagent.EventError,
+		"error_kind":          "grc_request_failed",
 		"stage.draft_ms":      float64(11),
 		"stage.conversion_ms": float64(7),
 		"stage.validate_ms":   float64(5),
@@ -255,6 +262,9 @@ func TestGRCAskTelemetryCopiesErrorEventTimings(t *testing.T) {
 		if got := payload[key]; got != want {
 			t.Fatalf("telemetry %s = %#v, want %#v; payload=%#v", key, got, want, payload)
 		}
+	}
+	if _, exists := payload["error"]; exists {
+		t.Fatalf("raw error recorded in telemetry: payload=%#v", payload)
 	}
 }
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -29,6 +33,49 @@ func TestEventEmitsParseableJSONLineOnStderr(t *testing.T) {
 	}
 	if got := payload["name"]; got != "test.event" {
 		t.Fatalf("name = %v, want test.event", got)
+	}
+}
+
+func TestTelemetryFieldsDoNotUseRawErrorKey(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+	pattern := regexp.MustCompile(`telemetry\.Field\s*\{\s*Key:\s*"` + `error"`)
+	var matches []string
+	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", ".idea", ".vscode", "bin", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if pattern.Match(contents) {
+			rel, err := filepath.Rel(repoRoot, path)
+			if err != nil {
+				rel = path
+			}
+			matches = append(matches, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("telemetry raw error field is forbidden; use bounded error_kind instead: %s", strings.Join(matches, ", "))
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace remaining raw telemetry error fields with bounded error_kind values
- classify GRC Ask and graph cleanup errors without emitting raw error text
- add a telemetry contract test preventing raw error fields from being reintroduced

## Test plan
- go test ./cmd/cerebro ./internal/bootstrap ./internal/telemetry
- make verify