### PR TITLE
feat: route canonical security events

### DIFF
--- a/internal/appendlog/jetstream/jetstream.go
+++ b/internal/appendlog/jetstream/jetstream.go
@@ -16,6 +16,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
@@ -238,6 +239,9 @@ func replaySubjectPrefix(prefix string, kindPrefix string) string {
 	if kindPrefix == "" {
 		return normalized
 	}
+	if securityevents.IsCanonicalKind(kindPrefix) {
+		return kindPrefix
+	}
 	return normalized + "." + kindPrefix
 }
 
@@ -347,6 +351,9 @@ func eventSubject(prefix string, kind string) (string, error) {
 	normalizedKind := strings.TrimSpace(kind)
 	if err := validateEventKind(normalizedKind); err != nil {
 		return "", err
+	}
+	if securityevents.IsCanonicalKind(normalizedKind) {
+		return normalizedKind, nil
 	}
 	return normalizedPrefix + "." + normalizedKind, nil
 }

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -14,6 +14,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
@@ -96,6 +97,33 @@ func TestAppendPublishesEnvelope(t *testing.T) {
 	}
 	if !proto.Equal(&decoded, event) {
 		t.Fatalf("decoded envelope = %#v, want %#v", &decoded, event)
+	}
+}
+
+func TestAppendPublishesCanonicalSecuritySubjectWithoutLegacyPrefix(t *testing.T) {
+	pub := &fakePublisher{}
+	log := &Log{js: pub, subjectPrefix: "events"}
+
+	event := &cerebrov1.EventEnvelope{
+		Id:       "evt-1",
+		TenantId: "tenant-1",
+		Kind:     securityevents.FindingRecorded,
+	}
+	if err := log.Append(context.Background(), event); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	if pub.published == nil {
+		t.Fatal("published message = nil")
+	}
+	if pub.published.Subject != securityevents.FindingRecorded {
+		t.Fatalf("subject = %q, want %q", pub.published.Subject, securityevents.FindingRecorded)
+	}
+	var decoded cerebrov1.EventEnvelope
+	if err := proto.Unmarshal(pub.published.Data, &decoded); err != nil {
+		t.Fatalf("proto.Unmarshal() error = %v", err)
+	}
+	if got := decoded.GetKind(); got != securityevents.FindingRecorded {
+		t.Fatalf("decoded kind = %q, want %q", got, securityevents.FindingRecorded)
 	}
 }
 
@@ -205,6 +233,16 @@ func TestEventSubjectDefaultsAndValidatesPrefix(t *testing.T) {
 	}
 	if _, err := eventSubject("events.", "entity.update"); err == nil {
 		t.Fatal("eventSubject(invalid prefix) error = nil, want non-nil")
+	}
+}
+
+func TestEventSubjectKeepsCanonicalSecurityKindAbsolute(t *testing.T) {
+	subject, err := eventSubject("events", securityevents.APIAccessAudit)
+	if err != nil {
+		t.Fatalf("eventSubject() error = %v", err)
+	}
+	if subject != securityevents.APIAccessAudit {
+		t.Fatalf("eventSubject() = %q, want %q", subject, securityevents.APIAccessAudit)
 	}
 }
 
@@ -318,6 +356,39 @@ func TestReplayFiltersWorkflowEventsByKindPrefixTenantAndAttribute(t *testing.T)
 			"workflow_kind": "knowledge_decision",
 		},
 	})
+	if err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+	if got := events[0].GetId(); got != "evt-1" {
+		t.Fatalf("replayed id = %q, want evt-1", got)
+	}
+}
+
+func TestReplayFiltersCanonicalSecurityEventsByKindPrefix(t *testing.T) {
+	replay := &fakeReplayManager{
+		streams: []*natsjetstream.StreamInfo{
+			{
+				Config: natsjetstream.StreamConfig{
+					Name:     "CEREBRO_EVENTS",
+					Subjects: []string{"events.>", "sec.>"},
+				},
+				State: natsjetstream.StreamState{FirstSeq: 1, LastSeq: 3},
+			},
+		},
+		msgs: map[string]map[uint64]*natsjetstream.RawStreamMsg{
+			"CEREBRO_EVENTS": {
+				1: rawReplayMsg(t, securityevents.FindingRecorded, replayEvent("evt-1", securityevents.FindingRecorded, "writer-github")),
+				2: rawReplayMsg(t, securityevents.APIAccessAudit, replayEvent("evt-2", securityevents.APIAccessAudit, "")),
+				3: rawReplayMsg(t, "events.github.audit", replayEvent("evt-3", "github.audit", "writer-github")),
+			},
+		},
+	}
+	log := &Log{js: &fakePublisher{}, replay: replay, subjectPrefix: "events"}
+
+	events, err := log.Replay(context.Background(), ports.ReplayRequest{KindPrefix: securityevents.FindingsV1Prefix})
 	if err != nil {
 		t.Fatalf("Replay() error = %v", err)
 	}

--- a/internal/securityevents/taxonomy.go
+++ b/internal/securityevents/taxonomy.go
@@ -1,0 +1,31 @@
+package securityevents
+
+import "strings"
+
+const (
+	SubjectPrefix = "sec"
+
+	FindingsV1Prefix     = "sec.findings.v1"
+	AuditV1Prefix        = "sec.audit.v1"
+	ToolsV1Prefix        = "sec.tools.v1"
+	ServicesV1Prefix     = "sec.services.v1"
+	ObservationsV1Prefix = "sec.observations.v1"
+	WorkflowsV1Prefix    = "sec.workflows.v1"
+)
+
+const (
+	FindingRecorded      = FindingsV1Prefix + ".recorded"
+	FindingStatusChanged = FindingsV1Prefix + ".status_changed"
+	FindingNoteAdded     = FindingsV1Prefix + ".note_added"
+	FindingTicketLinked  = FindingsV1Prefix + ".ticket_linked"
+
+	APIAccessAudit = AuditV1Prefix + ".api_access"
+
+	ToolRegistered = ToolsV1Prefix + ".registered"
+	ToolHealth     = ToolsV1Prefix + ".health"
+)
+
+// IsCanonicalKind reports whether an event kind already names a security-platform subject.
+func IsCanonicalKind(kind string) bool {
+	return strings.HasPrefix(strings.TrimSpace(kind), SubjectPrefix+".")
+}

--- a/internal/securityevents/taxonomy_test.go
+++ b/internal/securityevents/taxonomy_test.go
@@ -1,0 +1,23 @@
+package securityevents
+
+import "testing"
+
+func TestIsCanonicalKind(t *testing.T) {
+	tests := []struct {
+		kind string
+		want bool
+	}{
+		{kind: "sec.findings.v1.recorded", want: true},
+		{kind: " sec.audit.v1.api_access ", want: true},
+		{kind: "github.audit", want: false},
+		{kind: "section.audit", want: false},
+		{kind: "sec", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			if got := IsCanonicalKind(tt.kind); got != tt.want {
+				t.Fatalf("IsCanonicalKind(%q) = %v, want %v", tt.kind, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a small `internal/securityevents` package for canonical `sec.*` subject taxonomy constants
- publish canonical `sec.*` event kinds as absolute JetStream subjects instead of under the legacy `events.` prefix
- keep legacy `events.*` routing and replay behavior unchanged while allowing replay by canonical `sec.*` kind prefix

## Validation
- `go test ./internal/securityevents ./internal/appendlog/jetstream`
- `make verify`
