### PR TITLE
fix: append finding events without graph

### DIFF
--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -29,13 +29,16 @@ func (s *Service) projectFindingAnchor(ctx context.Context, finding *ports.Findi
 }
 
 func (s *Service) projectFindingAnchorRevision(ctx context.Context, finding *ports.FindingRecord, revision string) error {
-	if s == nil || s.graph == nil {
+	if s == nil {
 		return nil
 	}
 	if finding == nil {
 		return errors.New("finding is required")
 	}
 	tenantID, sourceID := findingGraphScope(finding)
+	if !findingWorkflowEventScopeValid(tenantID, sourceID, finding) {
+		return nil
+	}
 	recordedAt := finding.LastObservedAt.UTC()
 	if recordedAt.IsZero() {
 		recordedAt = finding.FirstObservedAt.UTC()
@@ -106,7 +109,7 @@ func (s *Service) markFindingRiskProjected(ctx context.Context, finding *ports.F
 }
 
 func (s *Service) projectFindingNote(ctx context.Context, finding *ports.FindingRecord, note ports.FindingNote) error {
-	if s == nil || s.graph == nil {
+	if s == nil {
 		return nil
 	}
 	if finding == nil {
@@ -121,6 +124,9 @@ func (s *Service) projectFindingNote(ctx context.Context, finding *ports.Finding
 		return nil
 	}
 	tenantID, sourceID := findingGraphScope(finding)
+	if !findingWorkflowEventScopeValid(tenantID, sourceID, finding) {
+		return nil
+	}
 	event, err := workflowevents.NewFindingNoteAddedEvent(workflowevents.FindingNoteAdded{
 		Finding:   findingWorkflowSnapshot(finding, tenantID, sourceID),
 		NoteID:    strings.TrimSpace(note.ID),
@@ -134,7 +140,7 @@ func (s *Service) projectFindingNote(ctx context.Context, finding *ports.Finding
 }
 
 func (s *Service) projectFindingTicket(ctx context.Context, finding *ports.FindingRecord, ticket ports.FindingTicket) error {
-	if s == nil || s.graph == nil {
+	if s == nil {
 		return nil
 	}
 	if finding == nil {
@@ -149,6 +155,9 @@ func (s *Service) projectFindingTicket(ctx context.Context, finding *ports.Findi
 		return nil
 	}
 	tenantID, sourceID := findingGraphScope(finding)
+	if !findingWorkflowEventScopeValid(tenantID, sourceID, finding) {
+		return nil
+	}
 	event, err := workflowevents.NewFindingTicketLinkedEvent(workflowevents.FindingTicketLinked{
 		Finding:    findingWorkflowSnapshot(finding, tenantID, sourceID),
 		URL:        normalizedURL,
@@ -163,7 +172,7 @@ func (s *Service) projectFindingTicket(ctx context.Context, finding *ports.Findi
 }
 
 func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *ports.FindingRecord, statusSource string) error {
-	if s == nil || s.graph == nil || finding == nil {
+	if s == nil || finding == nil {
 		return nil
 	}
 	status := strings.TrimSpace(finding.Status)
@@ -171,6 +180,9 @@ func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *port
 		return nil
 	}
 	tenantID, sourceID := findingGraphScope(finding)
+	if !findingWorkflowEventScopeValid(tenantID, sourceID, finding) {
+		return nil
+	}
 	targetURNs := []string{findingGraphFindingURN(tenantID, finding)}
 	decisionType := "finding-resolution"
 	if status == findingStatusSuppressed {
@@ -202,7 +214,7 @@ func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *port
 	if pruneGraph {
 		return nil
 	}
-	if s.graphQuery == nil {
+	if s.graph == nil || s.graphQuery == nil {
 		return nil
 	}
 	workflowMetadata := map[string]any{
@@ -382,6 +394,10 @@ func findingGraphScope(finding *ports.FindingRecord) (string, string) {
 		sourceID = "finding:" + strings.TrimSpace(finding.ID)
 	}
 	return tenantID, sourceID
+}
+
+func findingWorkflowEventScopeValid(tenantID string, sourceID string, finding *ports.FindingRecord) bool {
+	return strings.TrimSpace(tenantID) != "" && strings.TrimSpace(sourceID) != "" && finding != nil && strings.TrimSpace(finding.ID) != ""
 }
 
 func findingGraphFindingURN(tenantID string, finding *ports.FindingRecord) string {

--- a/internal/findings/graph_appendlog_test.go
+++ b/internal/findings/graph_appendlog_test.go
@@ -1,0 +1,100 @@
+package findings
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+type graphlessRecordingAppendLog struct {
+	events []*cerebrov1.EventEnvelope
+}
+
+func (l *graphlessRecordingAppendLog) Ping(context.Context) error { return nil }
+
+func (l *graphlessRecordingAppendLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) error {
+	l.events = append(l.events, event)
+	return nil
+}
+
+func TestProjectFindingWorkflowAppendsEventsWithoutGraph(t *testing.T) {
+	now := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	finding := graphlessWorkflowFinding(now)
+	appendLog := &graphlessRecordingAppendLog{}
+	service := (&Service{}).WithAppendLog(appendLog)
+
+	if err := service.projectFindingAnchor(context.Background(), finding); err != nil {
+		t.Fatalf("projectFindingAnchor() error = %v", err)
+	}
+	if err := service.projectFindingNote(context.Background(), finding, ports.FindingNote{
+		ID:        "note-1",
+		Body:      "Reviewed by security.",
+		CreatedAt: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("projectFindingNote() error = %v", err)
+	}
+	if err := service.projectFindingTicket(context.Background(), finding, ports.FindingTicket{
+		URL:      "https://jira.example/browse/SEC-844",
+		Name:     "SEC-844",
+		LinkedAt: now.Add(2 * time.Minute),
+	}); err != nil {
+		t.Fatalf("projectFindingTicket() error = %v", err)
+	}
+
+	wantKinds := []string{
+		workflowevents.EventKindFindingRecorded,
+		workflowevents.EventKindFindingNoteAdded,
+		workflowevents.EventKindFindingTicketLinked,
+	}
+	if len(appendLog.events) != len(wantKinds) {
+		t.Fatalf("appended events = %d, want %d", len(appendLog.events), len(wantKinds))
+	}
+	for i, want := range wantKinds {
+		if got := appendLog.events[i].GetKind(); got != want {
+			t.Fatalf("event[%d].kind = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestRecordFindingStatusWorkflowAppendsWithoutGraph(t *testing.T) {
+	now := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	finding := graphlessWorkflowFinding(now)
+	finding.Status = findingStatusResolved
+	finding.StatusReason = "accepted risk remediated"
+	finding.StatusUpdatedAt = now.Add(time.Hour)
+	appendLog := &graphlessRecordingAppendLog{}
+	service := (&Service{}).WithAppendLog(appendLog)
+
+	if err := service.recordFindingStatusWorkflow(context.Background(), finding, "manual"); err != nil {
+		t.Fatalf("recordFindingStatusWorkflow() error = %v", err)
+	}
+	if len(appendLog.events) != 1 {
+		t.Fatalf("appended events = %d, want 1", len(appendLog.events))
+	}
+	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindFindingStatusChanged {
+		t.Fatalf("event kind = %q, want %q", got, workflowevents.EventKindFindingStatusChanged)
+	}
+}
+
+func graphlessWorkflowFinding(now time.Time) *ports.FindingRecord {
+	return &ports.FindingRecord{
+		ID:              "finding-1",
+		Fingerprint:     "fp-1",
+		TenantID:        "tenant-1",
+		RuntimeID:       "runtime-1",
+		RuleID:          "rule-1",
+		Title:           "Graphless finding",
+		Severity:        "high",
+		Status:          findingStatusOpen,
+		Summary:         "A finding that should emit workflow events without graph projection.",
+		ResourceURNs:    []string{"urn:cerebro:tenant-1:resource:identity-1"},
+		EventIDs:        []string{"event-1"},
+		FirstObservedAt: now,
+		LastObservedAt:  now,
+		Attributes:      map[string]string{},
+	}
+}

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -2814,12 +2814,22 @@ func TestPromoteFindingCandidateWritesProductionFindingEvidenceAndAudit(t *testi
 	if result.DecisionID == "" {
 		t.Fatal("DecisionID is empty")
 	}
-	if got := len(appendLog.events); got != 1 {
-		t.Fatalf("append log events = %d, want 1", got)
+	if got := countWorkflowEventsByKind(appendLog.events, workflowevents.EventKindKnowledgeDecisionRecorded); got != 1 {
+		t.Fatalf("promotion audit events = %d, want 1", got)
 	}
-	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindKnowledgeDecisionRecorded {
-		t.Fatalf("promotion audit event kind = %q, want %q", got, workflowevents.EventKindKnowledgeDecisionRecorded)
+	if got := countWorkflowEventsByKind(appendLog.events, workflowevents.EventKindFindingRecorded); got != 1 {
+		t.Fatalf("finding recorded events = %d, want 1", got)
 	}
+}
+
+func countWorkflowEventsByKind(events []*cerebrov1.EventEnvelope, kind string) int {
+	count := 0
+	for _, event := range events {
+		if event.GetKind() == kind {
+			count++
+		}
+	}
+	return count
 }
 
 func TestPromoteFindingCandidateDoesNotMarkPromotedBeforeDownstreamSuccess(t *testing.T) {


### PR DESCRIPTION
## Summary
- append finding workflow events even when graph projection is not configured
- keep graph projection and knowledge decision/outcome writes gated on graph availability
- preserve legacy no-op behavior for findings that lack enough event scope to build durable workflow events

## Validation
- `go test ./internal/findings -run 'TestProjectFindingWorkflowAppendsEventsWithoutGraph|TestRecordFindingStatusWorkflowAppendsWithoutGraph'`
- `go test ./internal/findings`
- `make verify`
