### PR TITLE
feat: dual-publish canonical finding events

### DIFF
--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -270,17 +270,18 @@ func (s *Service) recordAndProjectWorkflowEvent(ctx context.Context, event *cere
 		if err := s.appendLog.Append(ctx, event); err != nil {
 			return err
 		}
+	}
+	if s.graph != nil {
+		if _, err := workflowprojection.New(s.graph).Project(ctx, event); err != nil {
+			return err
+		}
+	}
+	if s.appendLog != nil {
 		if canonical, ok := canonicalFindingWorkflowEvent(event); ok {
 			if err := s.appendLog.Append(ctx, canonical); err != nil {
 				return err
 			}
 		}
-	}
-	if s.graph == nil {
-		return nil
-	}
-	if _, err := workflowprojection.New(s.graph).Project(ctx, event); err != nil {
-		return err
 	}
 	return nil
 }

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -12,6 +12,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/knowledge"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/workflowevents"
 	"github.com/writer/cerebro/internal/workflowprojection"
 )
@@ -269,6 +270,11 @@ func (s *Service) recordAndProjectWorkflowEvent(ctx context.Context, event *cere
 		if err := s.appendLog.Append(ctx, event); err != nil {
 			return err
 		}
+		if canonical, ok := canonicalFindingWorkflowEvent(event); ok {
+			if err := s.appendLog.Append(ctx, canonical); err != nil {
+				return err
+			}
+		}
 	}
 	if s.graph == nil {
 		return nil
@@ -277,6 +283,47 @@ func (s *Service) recordAndProjectWorkflowEvent(ctx context.Context, event *cere
 		return err
 	}
 	return nil
+}
+
+func canonicalFindingWorkflowEvent(event *cerebrov1.EventEnvelope) (*cerebrov1.EventEnvelope, bool) {
+	kind := canonicalFindingWorkflowKind(event.GetKind())
+	if kind == "" {
+		return nil, false
+	}
+	attributes := make(map[string]string, len(event.GetAttributes())+1)
+	for key, value := range event.GetAttributes() {
+		attributes[key] = value
+	}
+	attributes["canonical_kind"] = kind
+	return &cerebrov1.EventEnvelope{
+		Id:         canonicalFindingWorkflowEventID(event.GetId(), kind),
+		TenantId:   event.GetTenantId(),
+		SourceId:   event.GetSourceId(),
+		Kind:       kind,
+		OccurredAt: event.GetOccurredAt(),
+		SchemaRef:  event.GetSchemaRef(),
+		Payload:    append([]byte(nil), event.GetPayload()...),
+		Attributes: attributes,
+	}, true
+}
+
+func canonicalFindingWorkflowKind(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case workflowevents.EventKindFindingRecorded:
+		return securityevents.FindingRecorded
+	case workflowevents.EventKindFindingStatusChanged:
+		return securityevents.FindingStatusChanged
+	case workflowevents.EventKindFindingNoteAdded:
+		return securityevents.FindingNoteAdded
+	case workflowevents.EventKindFindingTicketLinked:
+		return securityevents.FindingTicketLinked
+	default:
+		return ""
+	}
+}
+
+func canonicalFindingWorkflowEventID(id string, kind string) string {
+	return strings.TrimSpace(id) + "|canonical|" + strings.TrimSpace(kind)
 }
 
 func findingWorkflowSnapshot(finding *ports.FindingRecord, tenantID string, sourceID string) workflowevents.FindingSnapshot {

--- a/internal/findings/graph_appendlog_test.go
+++ b/internal/findings/graph_appendlog_test.go
@@ -7,6 +7,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
@@ -47,8 +48,11 @@ func TestProjectFindingWorkflowAppendsEventsWithoutGraph(t *testing.T) {
 
 	wantKinds := []string{
 		workflowevents.EventKindFindingRecorded,
+		securityevents.FindingRecorded,
 		workflowevents.EventKindFindingNoteAdded,
+		securityevents.FindingNoteAdded,
 		workflowevents.EventKindFindingTicketLinked,
+		securityevents.FindingTicketLinked,
 	}
 	if len(appendLog.events) != len(wantKinds) {
 		t.Fatalf("appended events = %d, want %d", len(appendLog.events), len(wantKinds))
@@ -72,11 +76,14 @@ func TestRecordFindingStatusWorkflowAppendsWithoutGraph(t *testing.T) {
 	if err := service.recordFindingStatusWorkflow(context.Background(), finding, "manual"); err != nil {
 		t.Fatalf("recordFindingStatusWorkflow() error = %v", err)
 	}
-	if len(appendLog.events) != 1 {
-		t.Fatalf("appended events = %d, want 1", len(appendLog.events))
+	if len(appendLog.events) != 2 {
+		t.Fatalf("appended events = %d, want 2", len(appendLog.events))
 	}
 	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindFindingStatusChanged {
 		t.Fatalf("event kind = %q, want %q", got, workflowevents.EventKindFindingStatusChanged)
+	}
+	if got := appendLog.events[1].GetKind(); got != securityevents.FindingStatusChanged {
+		t.Fatalf("canonical event kind = %q, want %q", got, securityevents.FindingStatusChanged)
 	}
 }
 

--- a/internal/findings/graph_canonical_test.go
+++ b/internal/findings/graph_canonical_test.go
@@ -2,12 +2,28 @@ package findings
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
+
+type failSecondAppendLog struct {
+	events []*cerebrov1.EventEnvelope
+	err    error
+}
+
+func (l *failSecondAppendLog) Ping(context.Context) error { return nil }
+
+func (l *failSecondAppendLog) Append(_ context.Context, event *cerebrov1.EventEnvelope) error {
+	if len(l.events) == 1 {
+		return l.err
+	}
+	l.events = append(l.events, event)
+	return nil
+}
 
 func TestRecordAndProjectWorkflowEventDualPublishesCanonicalFindingAlias(t *testing.T) {
 	event, err := workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
@@ -49,6 +65,42 @@ func TestRecordAndProjectWorkflowEventDualPublishesCanonicalFindingAlias(t *test
 	}
 	if canonical.GetId() == event.GetId() {
 		t.Fatalf("canonical event reused legacy id %q", event.GetId())
+	}
+}
+
+func TestRecordAndProjectWorkflowEventProjectsLegacyBeforeCanonicalAliasFailure(t *testing.T) {
+	event, err := workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
+		Finding: workflowevents.FindingSnapshot{
+			FindingID:    "finding-1",
+			TenantID:     "tenant-1",
+			SourceSystem: "runtime-1",
+			RuleID:       "rule-1",
+			Title:        "Canonical finding alias",
+			Status:       findingStatusOpen,
+			Severity:     "high",
+		},
+		RecordedAt: "2026-05-30T12:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingRecordedEvent() error = %v", err)
+	}
+	appendErr := errors.New("canonical append failed")
+	appendLog := &failSecondAppendLog{err: appendErr}
+	graph := &stubGraphStore{}
+	service := (&Service{}).WithAppendLog(appendLog).WithGraphStore(graph)
+
+	err = service.recordAndProjectWorkflowEvent(context.Background(), event)
+	if !errors.Is(err, appendErr) {
+		t.Fatalf("recordAndProjectWorkflowEvent() error = %v, want %v", err, appendErr)
+	}
+	if len(appendLog.events) != 1 {
+		t.Fatalf("durable legacy events = %d, want 1", len(appendLog.events))
+	}
+	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindFindingRecorded {
+		t.Fatalf("legacy event kind = %q, want %q", got, workflowevents.EventKindFindingRecorded)
+	}
+	if graph.entities["urn:cerebro:tenant-1:finding:finding-1"] == nil {
+		t.Fatal("legacy finding event was not projected before canonical append failure")
 	}
 }
 

--- a/internal/findings/graph_canonical_test.go
+++ b/internal/findings/graph_canonical_test.go
@@ -1,0 +1,71 @@
+package findings
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/securityevents"
+	"github.com/writer/cerebro/internal/workflowevents"
+)
+
+func TestRecordAndProjectWorkflowEventDualPublishesCanonicalFindingAlias(t *testing.T) {
+	event, err := workflowevents.NewFindingRecordedEvent(workflowevents.FindingRecorded{
+		Finding: workflowevents.FindingSnapshot{
+			FindingID:    "finding-1",
+			TenantID:     "tenant-1",
+			SourceSystem: "runtime-1",
+			RuleID:       "rule-1",
+			Title:        "Canonical finding alias",
+			Status:       findingStatusOpen,
+			Severity:     "high",
+		},
+		RecordedAt: "2026-05-30T12:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("NewFindingRecordedEvent() error = %v", err)
+	}
+	appendLog := &recordingAppendLog{}
+	service := (&Service{}).WithAppendLog(appendLog)
+
+	if err := service.recordAndProjectWorkflowEvent(context.Background(), event); err != nil {
+		t.Fatalf("recordAndProjectWorkflowEvent() error = %v", err)
+	}
+	if len(appendLog.events) != 2 {
+		t.Fatalf("appended events = %d, want 2", len(appendLog.events))
+	}
+	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindFindingRecorded {
+		t.Fatalf("legacy event kind = %q, want %q", got, workflowevents.EventKindFindingRecorded)
+	}
+	canonical := appendLog.events[1]
+	if got := canonical.GetKind(); got != securityevents.FindingRecorded {
+		t.Fatalf("canonical event kind = %q, want %q", got, securityevents.FindingRecorded)
+	}
+	if got := canonical.GetSchemaRef(); got != event.GetSchemaRef() {
+		t.Fatalf("canonical schema_ref = %q, want %q", got, event.GetSchemaRef())
+	}
+	if got := canonical.GetAttributes()["canonical_kind"]; got != securityevents.FindingRecorded {
+		t.Fatalf("canonical_kind attribute = %q, want %q", got, securityevents.FindingRecorded)
+	}
+	if canonical.GetId() == event.GetId() {
+		t.Fatalf("canonical event reused legacy id %q", event.GetId())
+	}
+}
+
+func TestRecordAndProjectWorkflowEventDoesNotAliasNonFindingEvent(t *testing.T) {
+	appendLog := &recordingAppendLog{}
+	service := (&Service{}).WithAppendLog(appendLog)
+
+	if err := service.recordAndProjectWorkflowEvent(context.Background(), &cerebrov1.EventEnvelope{
+		Id:   "evt-1",
+		Kind: workflowevents.EventKindKnowledgeDecisionRecorded,
+	}); err != nil {
+		t.Fatalf("recordAndProjectWorkflowEvent() error = %v", err)
+	}
+	if len(appendLog.events) != 1 {
+		t.Fatalf("appended events = %d, want 1", len(appendLog.events))
+	}
+	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindKnowledgeDecisionRecorded {
+		t.Fatalf("event kind = %q, want %q", got, workflowevents.EventKindKnowledgeDecisionRecorded)
+	}
+}

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -19,6 +19,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/findingevidence"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
@@ -1285,11 +1286,14 @@ func TestEvaluateSourceRuntimeFindingsProjectsRecordedFindingToGraph(t *testing.
 	if _, ok := graph.links[primaryResourceURN+"|has_finding|"+findingURN]; !ok {
 		t.Fatalf("graph has_finding link missing for %s -> %s", primaryResourceURN, findingURN)
 	}
-	if got := len(appendLog.events); got != 1 {
-		t.Fatalf("len(appendLog.events) = %d, want 1", got)
+	if got := len(appendLog.events); got != 2 {
+		t.Fatalf("len(appendLog.events) = %d, want 2", got)
 	}
 	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindFindingRecorded {
 		t.Fatalf("appendLog.events[0].Kind = %q, want %q", got, workflowevents.EventKindFindingRecorded)
+	}
+	if got := appendLog.events[1].GetKind(); got != securityevents.FindingRecorded {
+		t.Fatalf("appendLog.events[1].Kind = %q, want %q", got, securityevents.FindingRecorded)
 	}
 }
 
@@ -4261,11 +4265,14 @@ func TestResolveFindingBridgesDecisionAndOutcomeWhenGraphConfigured(t *testing.T
 	if outcomeCount != 1 {
 		t.Fatalf("outcome entity count = %d, want 1", outcomeCount)
 	}
-	if len(appendLog.events) != 3 {
-		t.Fatalf("len(appendLog.events) = %d, want 3", len(appendLog.events))
+	if len(appendLog.events) != 4 {
+		t.Fatalf("len(appendLog.events) = %d, want 4", len(appendLog.events))
 	}
 	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindFindingStatusChanged {
 		t.Fatalf("first append event kind = %q, want %q", got, workflowevents.EventKindFindingStatusChanged)
+	}
+	if got := appendLog.events[1].GetKind(); got != securityevents.FindingStatusChanged {
+		t.Fatalf("canonical status event kind = %q, want %q", got, securityevents.FindingStatusChanged)
 	}
 }
 
@@ -4430,14 +4437,20 @@ func TestBackfillFindingRiskProjectsUpdatedRiskRows(t *testing.T) {
 	if closed := graphStore.entities["urn:cerebro:tenant-a:finding:finding-closed"]; closed == nil || closed.Attributes["risk_score"] != "83" {
 		t.Fatalf("closed projected finding = %#v, want risk_score 83", closed)
 	}
-	if got := len(appendLog.events); got != 2 {
-		t.Fatalf("len(appended events) = %d, want 2", got)
+	if got := len(appendLog.events); got != 4 {
+		t.Fatalf("len(appended events) = %d, want 4", got)
 	}
 	if eventTime := appendLog.events[0].GetOccurredAt().AsTime(); time.Since(eventTime) > time.Minute {
 		t.Fatalf("backfill event occurred_at = %s, want startup time", eventTime.Format(time.RFC3339Nano))
 	}
-	if got := appendLog.events[1].GetKind(); got != workflowevents.EventKindFindingStatusChanged {
+	if got := appendLog.events[1].GetKind(); got != securityevents.FindingRecorded {
+		t.Fatalf("canonical open finding event kind = %q, want %q", got, securityevents.FindingRecorded)
+	}
+	if got := appendLog.events[2].GetKind(); got != workflowevents.EventKindFindingStatusChanged {
 		t.Fatalf("closed finding event kind = %q, want status_changed", got)
+	}
+	if got := appendLog.events[3].GetKind(); got != securityevents.FindingStatusChanged {
+		t.Fatalf("canonical closed finding event kind = %q, want %q", got, securityevents.FindingStatusChanged)
 	}
 	if got := store.findings["finding-1"].Attributes[FindingRiskGraphProjectedModelVersionAttribute]; got != defaultFindingRiskModelVersion {
 		t.Fatalf("projection marker = %q, want %q", got, defaultFindingRiskModelVersion)
@@ -4596,10 +4609,10 @@ func TestSetFindingDueDateProjectsUpdatedRisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetFindingDueDate(second) error = %v", err)
 	}
-	if got := len(appendLog.events); got != 2 {
-		t.Fatalf("len(appended events) = %d, want 2", got)
+	if got := len(appendLog.events); got != 4 {
+		t.Fatalf("len(appended events) = %d, want 4", got)
 	}
-	if secondEventID := appendLog.events[1].GetId(); secondEventID == firstEventID {
+	if secondEventID := appendLog.events[2].GetId(); secondEventID == firstEventID {
 		t.Fatalf("SetFindingDueDate() reused finding_record event id %q, want non-deduplicated refresh event", secondEventID)
 	}
 }
@@ -4939,11 +4952,14 @@ func TestAddFindingNoteUpdatesPersistedWorkflow(t *testing.T) {
 	if _, ok := graphStore.links["urn:cerebro:writer:finding:finding-1|annotated_with|"+annotationURN]; !ok {
 		t.Fatal("finding annotation link missing")
 	}
-	if len(appendLog.events) != 1 {
-		t.Fatalf("len(appendLog.events) = %d, want 1", len(appendLog.events))
+	if len(appendLog.events) != 2 {
+		t.Fatalf("len(appendLog.events) = %d, want 2", len(appendLog.events))
 	}
 	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindFindingNoteAdded {
 		t.Fatalf("append event kind = %q, want %q", got, workflowevents.EventKindFindingNoteAdded)
+	}
+	if got := appendLog.events[1].GetKind(); got != securityevents.FindingNoteAdded {
+		t.Fatalf("canonical append event kind = %q, want %q", got, securityevents.FindingNoteAdded)
 	}
 }
 
@@ -4992,11 +5008,14 @@ func TestLinkFindingTicketUpdatesPersistedWorkflow(t *testing.T) {
 	if _, ok := graphStore.links["urn:cerebro:writer:finding:finding-1|tracked_by|"+ticketURN]; !ok {
 		t.Fatal("finding ticket link missing")
 	}
-	if len(appendLog.events) != 1 {
-		t.Fatalf("len(appendLog.events) = %d, want 1", len(appendLog.events))
+	if len(appendLog.events) != 2 {
+		t.Fatalf("len(appendLog.events) = %d, want 2", len(appendLog.events))
 	}
 	if got := appendLog.events[0].GetKind(); got != workflowevents.EventKindFindingTicketLinked {
 		t.Fatalf("append event kind = %q, want %q", got, workflowevents.EventKindFindingTicketLinked)
+	}
+	if got := appendLog.events[1].GetKind(); got != securityevents.FindingTicketLinked {
+		t.Fatalf("canonical append event kind = %q, want %q", got, securityevents.FindingTicketLinked)
 	}
 }
 

--- a/internal/findings/ttl_resolver_test.go
+++ b/internal/findings/ttl_resolver_test.go
@@ -11,6 +11,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/securityevents"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
@@ -609,6 +610,9 @@ func decodeStatusChangedPayloads(t *testing.T, events []*cerebrov1.EventEnvelope
 	payloads := make([]*workflowevents.FindingStatusChanged, 0, len(events))
 	for i, event := range events {
 		if event.GetKind() != workflowevents.EventKindFindingStatusChanged {
+			if event.GetKind() == securityevents.FindingStatusChanged {
+				continue
+			}
 			t.Fatalf("appendLog.events[%d].Kind = %q, want %q", i, event.GetKind(), workflowevents.EventKindFindingStatusChanged)
 		}
 		payload, err := workflowevents.DecodeFindingStatusChanged(event)


### PR DESCRIPTION
## Summary
- dual-publish finding workflow events under canonical `sec.findings.v1.*` event kinds
- keep the canonical aliases on the same schema/payload as the legacy workflow event for compatibility
- add coverage for finding aliases and update workflow tests for the expected dual-publish stream

## Stacking
- Stacked on #741 (`droid/sec-878-security-event-routing`) so canonical `sec.*` events route as absolute JetStream subjects.

## Validation
- `go test ./internal/findings -run 'TestRecordAndProjectWorkflowEventDualPublishesCanonicalFindingAlias|TestRecordAndProjectWorkflowEventDoesNotAliasNonFindingEvent'`
- `go test ./internal/securityevents ./internal/appendlog/jetstream ./internal/findings`
- `make verify`
