### PR TITLE
Speed up release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,34 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  ghcr-publish:
+      - name: Upload linux/amd64 runtime binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cerebro-linux-amd64
+          path: dist/cerebro_linux_amd64_v1/cerebro
+          if-no-files-found: error
+
+      - name: Upload linux/arm64 runtime binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cerebro-linux-arm64
+          path: dist/cerebro_linux_arm64_v8.0/cerebro
+          if-no-files-found: error
+
+  ghcr-build:
+    name: Build runtime image (${{ matrix.platform }})
     runs-on: ubuntu-latest
     needs: [resolve-tag, goreleaser]
-    outputs:
-      digest: ${{ steps.manifest.outputs.digest }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goarch: amd64
+            platform: linux/amd64
+            artifact: cerebro-linux-amd64
+          - goarch: arm64
+            platform: linux/arm64
+            artifact: cerebro-linux-arm64
     env:
       RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
     steps:
@@ -81,10 +104,15 @@ jobs:
         with:
           ref: ${{ needs.resolve-tag.outputs.tag }}
 
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Download release binary
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          go-version-file: go.mod
+          name: ${{ matrix.artifact }}
+          path: .dist
+
+      - name: Prepare release binary
+        shell: bash
+        run: chmod +x .dist/cerebro
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -99,44 +127,36 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - name: Build and push linux/amd64
+      - name: Build and push runtime image
         shell: bash
         env:
           IMAGE_BASE: ghcr.io/${{ github.repository }}
         run: |
           set -euo pipefail
-          mkdir -p .dist
-          VERSION="${RELEASE_TAG#v}"
-          COMMIT="$(git rev-parse HEAD)"
-          BUILD_DATE="$(date -u +%FT%TZ)"
-          LDFLAGS="-s -w -X github.com/writer/cerebro/internal/buildinfo.Version=${VERSION} -X github.com/writer/cerebro/internal/buildinfo.Commit=${COMMIT} -X github.com/writer/cerebro/internal/buildinfo.BuildDate=${BUILD_DATE}"
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-            go build -buildvcs=false -trimpath -ldflags="${LDFLAGS}" -o .dist/cerebro ./cmd/cerebro
-          docker buildx build --platform linux/amd64 \
+          docker buildx build --platform "${{ matrix.platform }}" \
             -f Dockerfile.runtime \
-            -t "${IMAGE_BASE}:${RELEASE_TAG}-amd64" \
+            -t "${IMAGE_BASE}:${RELEASE_TAG}-${{ matrix.goarch }}" \
             --provenance=mode=max \
             --sbom=true \
             --push .
 
-      - name: Build and push linux/arm64
-        shell: bash
-        env:
-          IMAGE_BASE: ghcr.io/${{ github.repository }}
-        run: |
-          set -euo pipefail
-          VERSION="${RELEASE_TAG#v}"
-          COMMIT="$(git rev-parse HEAD)"
-          BUILD_DATE="$(date -u +%FT%TZ)"
-          LDFLAGS="-s -w -X github.com/writer/cerebro/internal/buildinfo.Version=${VERSION} -X github.com/writer/cerebro/internal/buildinfo.Commit=${COMMIT} -X github.com/writer/cerebro/internal/buildinfo.BuildDate=${BUILD_DATE}"
-          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
-            go build -buildvcs=false -trimpath -ldflags="${LDFLAGS}" -o .dist/cerebro ./cmd/cerebro
-          docker buildx build --platform linux/arm64 \
-            -f Dockerfile.runtime \
-            -t "${IMAGE_BASE}:${RELEASE_TAG}-arm64" \
-            --provenance=mode=max \
-            --sbom=true \
-            --push .
+  ghcr-publish:
+    runs-on: ubuntu-latest
+    needs: [resolve-tag, ghcr-build]
+    outputs:
+      digest: ${{ steps.manifest.outputs.digest }}
+    env:
+      RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Create and push multi-arch manifests
         id: manifest
@@ -161,16 +181,20 @@ jobs:
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
           echo "Published ${IMAGE_BASE}:${RELEASE_TAG}@${digest}"
 
+      - name: Set up cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v2.6.1
+
       - name: Keyless sign release images
         shell: bash
         env:
           IMAGE_BASE: ghcr.io/${{ github.repository }}
+          DIGEST: ${{ steps.manifest.outputs.digest }}
           COSIGN_EXPERIMENTAL: "true"
         run: |
           set -euo pipefail
-          GOBIN="${RUNNER_TEMP}/cosign" go install github.com/sigstore/cosign/v2/cmd/cosign@v2.6.1
-          "${RUNNER_TEMP}/cosign/cosign" sign --yes "${IMAGE_BASE}:${RELEASE_TAG}"
-          "${RUNNER_TEMP}/cosign/cosign" sign --yes "${IMAGE_BASE}:latest"
+          cosign sign --yes "${IMAGE_BASE}@${DIGEST}"
 
   notify-infra-release:
     runs-on: ubuntu-latest
@@ -308,14 +332,18 @@ jobs:
             -image-tag "${RELEASE_TAG}" \
             -out .dist/cerebro-runtime-contract.json
 
+      - name: Set up cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v2.6.1
+
       - name: Keyless sign runtime deploy contract
         shell: bash
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
           set -euo pipefail
-          GOBIN="${RUNNER_TEMP}/cosign" go install github.com/sigstore/cosign/v2/cmd/cosign@v2.6.1
-          "${RUNNER_TEMP}/cosign/cosign" sign-blob --yes \
+          cosign sign-blob --yes \
             --output-signature .dist/cerebro-runtime-contract.json.sig \
             --output-certificate .dist/cerebro-runtime-contract.json.pem \
             .dist/cerebro-runtime-contract.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Binaries
 bin/
+.dist/
+dist/
 /cerebro
 !cmd/cerebro/
 !cmd/cerebro/**

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,7 +1,6 @@
 FROM alpine:3.23
 
 RUN apk upgrade --no-cache && \
-    apk add --no-cache curl && \
     addgroup -S cerebro && \
     adduser -S -G cerebro -u 10001 cerebro
 
@@ -15,7 +14,7 @@ USER cerebro
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD curl -fsS http://127.0.0.1:8080/health || exit 1
+  CMD wget -qO- http://127.0.0.1:8080/health >/dev/null || exit 1
 
 ENTRYPOINT ["/usr/local/bin/cerebro"]
 CMD ["serve"]


### PR DESCRIPTION
## Summary
- reuse GoReleaser linux binaries for runtime images instead of rebuilding them
- build amd64 and arm64 runtime images in parallel
- install cosign from the pinned installer and sign the final digest once
- drop curl from the runtime image and use busybox wget for the healthcheck

## Validation
- make verify
- actionlint -color=false .github/workflows/release.yml
- docker buildx build --platform linux/amd64 -f Dockerfile.runtime --load -t cerebro-runtime:test .
- go run github.com/goreleaser/goreleaser/v2@latest build --snapshot --clean --skip=validate --skip=before
