### PR TITLE
fix(ci): parallelize verification and release images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,29 @@ on:
   workflow_dispatch:
 
 jobs:
-  verify:
+  verify-shard:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: build
+            command: make build
+          - name: test
+            command: make test
+          - name: lint
+            command: make lint
+          - name: proto-lint
+            command: make proto-lint
+          - name: openapi
+            command: make openapi-check openapi-lint
+          - name: catalog
+            command: make catalog-check detection-catalog-check
+          - name: oss-audit
+            command: make oss-audit
+          - name: structural
+            command: make check-structural check-structural-test check-arch
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -19,8 +40,18 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Install golangci-lint
-        run: make lint-bootstrap
+      - name: Run ${{ matrix.name }}
+        run: ${{ matrix.command }}
 
-      - name: Verify
-        run: make verify
+  verify:
+    runs-on: ubuntu-latest
+    needs: [verify-shard]
+    if: always()
+    steps:
+      - name: Check verify shards
+        run: |
+          if [ "${{ needs.verify-shard.result }}" != "success" ]; then
+            echo "One or more verify shards failed"
+            exit 1
+          fi
+          echo "All verify shards passed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,46 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "Resolved release tag: ${tag}"
 
-  goreleaser:
+  release-verify:
+    name: Verify release (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: [resolve-tag]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: build
+            command: make build
+          - name: test
+            command: make test
+          - name: lint
+            command: make lint
+          - name: proto-lint
+            command: make proto-lint
+          - name: openapi
+            command: make openapi-check openapi-lint
+          - name: catalog
+            command: make catalog-check detection-catalog-check
+          - name: oss-audit
+            command: make oss-audit
+          - name: structural
+            command: make check-structural check-structural-test check-arch
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run ${{ matrix.name }}
+        run: ${{ matrix.command }}
+
+  goreleaser:
+    runs-on: ubuntu-latest
+    needs: [resolve-tag, release-verify]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -55,11 +92,6 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-
-      - name: Run verify
-        run: |
-          make lint-bootstrap
-          make verify
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
@@ -131,11 +163,13 @@ jobs:
         shell: bash
         env:
           IMAGE_BASE: ghcr.io/${{ github.repository }}
+          GOARCH: ${{ matrix.goarch }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
           set -euo pipefail
-          docker buildx build --platform "${{ matrix.platform }}" \
+          docker buildx build --platform "${PLATFORM}" \
             -f Dockerfile.runtime \
-            -t "${IMAGE_BASE}:${RELEASE_TAG}-${{ matrix.goarch }}" \
+            -t "${IMAGE_BASE}:${RELEASE_TAG}-${GOARCH}" \
             --provenance=mode=max \
             --sbom=true \
             --push .


### PR DESCRIPTION
## Summary
- split CI verification into parallel make-target shards with an aggregate verify check
- run release verification shards before GoReleaser instead of a serial make verify step
- build amd64 and arm64 release images in parallel while preserving manifest signing and digest output

## Validation
- actionlint .github/workflows/ci.yml .github/workflows/release.yml
- git diff --check