### PR TITLE
Speed up release critical path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,29 +96,57 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
-          version: latest
+          version: v2.16.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  runtime-binaries:
+    runs-on: ubuntu-latest
+    needs: [resolve-tag, release-verify]
+    env:
+      RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build linux runtime binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          commit="$(git rev-parse HEAD)"
+          build_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          ldflags="-s -w -X github.com/writer/cerebro/internal/buildinfo.Version=${version} -X github.com/writer/cerebro/internal/buildinfo.Commit=${commit} -X github.com/writer/cerebro/internal/buildinfo.BuildDate=${build_date}"
+          for arch in amd64 arm64; do
+            mkdir -p ".dist/linux-${arch}"
+            CGO_ENABLED=0 GOOS=linux GOARCH="${arch}" go build -trimpath -ldflags "${ldflags}" -o ".dist/linux-${arch}/cerebro" ./cmd/cerebro
+          done
 
       - name: Upload linux/amd64 runtime binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cerebro-linux-amd64
-          path: dist/cerebro_linux_amd64_v1/cerebro
+          path: .dist/linux-amd64/cerebro
           if-no-files-found: error
 
       - name: Upload linux/arm64 runtime binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cerebro-linux-arm64
-          path: dist/cerebro_linux_arm64_v8.0/cerebro
+          path: .dist/linux-arm64/cerebro
           if-no-files-found: error
 
   ghcr-build:
     name: Build runtime image (${{ matrix.platform }})
     runs-on: ubuntu-latest
-    needs: [resolve-tag, goreleaser]
+    needs: [resolve-tag, runtime-binaries]
     strategy:
       fail-fast: false
       matrix:
@@ -232,7 +260,7 @@ jobs:
 
   notify-infra-release:
     runs-on: ubuntu-latest
-    needs: [resolve-tag, ghcr-publish, runtime-contract]
+    needs: [resolve-tag, ghcr-publish, runtime-contract-upload]
     steps:
       - name: Dispatch release deployment request
         shell: bash
@@ -341,7 +369,7 @@ jobs:
 
   runtime-contract:
     runs-on: ubuntu-latest
-    needs: [resolve-tag, goreleaser]
+    needs: [resolve-tag, release-verify]
     env:
       RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
     steps:
@@ -383,6 +411,28 @@ jobs:
             .dist/cerebro-runtime-contract.json
 
       - name: Upload runtime deploy contract
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cerebro-runtime-contract
+          path: |
+            .dist/cerebro-runtime-contract.json
+            .dist/cerebro-runtime-contract.json.sig
+            .dist/cerebro-runtime-contract.json.pem
+          if-no-files-found: error
+
+  runtime-contract-upload:
+    runs-on: ubuntu-latest
+    needs: [resolve-tag, goreleaser, runtime-contract]
+    env:
+      RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
+    steps:
+      - name: Download runtime deploy contract
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: cerebro-runtime-contract
+          path: .dist
+
+      - name: Upload runtime deploy contract to release
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,12 +27,13 @@ builds:
 
 archives:
   - id: binaries
-    builds:
+    ids:
       - cerebro
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
## Summary
- build and upload deploy-critical Linux runtime binaries in a separate job after release verification
- let GHCR image publishing and runtime contract rendering start before GoReleaser finishes
- pin GoReleaser and update archive config away from deprecated keys

## Validation
- actionlint .github/workflows/release.yml
- go run github.com/goreleaser/goreleaser/v2@v2.16.0 check
- linux amd64/arm64 runtime go builds
- make verify
