### PR TITLE
Fix runtime contract release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,7 +438,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh release upload "${RELEASE_TAG}" \
+          gh release upload "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" \
             .dist/cerebro-runtime-contract.json \
             .dist/cerebro-runtime-contract.json.sig \
             .dist/cerebro-runtime-contract.json.pem \


### PR DESCRIPTION
## Summary
- pass the repository explicitly when uploading runtime contract assets from the no-checkout upload job

## Validation
- actionlint .github/workflows/release.yml
- make verify (pre-commit/pre-push hook)
