### PR TITLE
fix: wire backstage source runtime

### DIFF
--- a/sources/backstage/deploy.yaml
+++ b/sources/backstage/deploy.yaml
@@ -1,0 +1,11 @@
+sourceId: backstage
+secretKeys:
+  - BACKSTAGE_BASE_URL
+  - BACKSTAGE_EXTERNAL_ACCESS_TOKEN
+runtimes:
+  - localId: component
+    config:
+      base_url: env:BACKSTAGE_BASE_URL
+      family: component
+      per_page: "100"
+      token: env:BACKSTAGE_EXTERNAL_ACCESS_TOKEN

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -19,6 +19,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
@@ -155,7 +156,7 @@ func (s *Source) parseSettings(cfg sourcecdk.Config) (settings, error) {
 		return settings{}, fmt.Errorf("jsonapi source is required")
 	}
 	resolved := settings{
-		tenantID: strings.TrimSpace(configValue(cfg, "tenant_id")),
+		tenantID: firstNonEmpty(configValue(cfg, "tenant_id"), configValue(cfg, sourceconfig.RuntimeTenantIDKey)),
 		family:   strings.TrimSpace(configValue(cfg, "family")),
 		baseURL:  strings.TrimSpace(configValue(cfg, "base_url")),
 		token:    firstNonEmpty(configValue(cfg, "token"), configValue(cfg, "api_token")),

--- a/sources/internal/jsonapi/source_test.go
+++ b/sources/internal/jsonapi/source_test.go
@@ -11,6 +11,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourcehttp"
 )
 
@@ -191,6 +192,30 @@ func TestReadDedupesRecordsByExternalID(t *testing.T) {
 	}
 	if pull.Events[0].Attributes["external_id"] != "device-1" || pull.Events[1].Attributes["external_id"] != "device-2" {
 		t.Fatalf("Events = %#v, want first unique records by external id", pull.Events)
+	}
+}
+
+func TestReadUsesRuntimeTenantID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"id": "device-1", "name": "macbook-1"}},
+		})
+	}))
+	defer server.Close()
+
+	source := newTestSource(t, server.URL)
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		sourceconfig.RuntimeTenantIDKey: "writer",
+		"token":                         "token-1",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+	if pull.Events[0].TenantId != "writer" {
+		t.Fatalf("TenantId = %q, want writer", pull.Events[0].TenantId)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add Backstage source deploy manifest for runtime rendering
- let JSON API sources use the runtime tenant id injected by source runtime service
- add regression coverage for runtime tenant fallback

## Validation
- go test ./sources/internal/jsonapi ./sources/backstage ./tools/sourcedeploy ./cmd/sourcedeploy -count=1
- go test ./...
- make lint
- make check-structural
- make catalog-check
- make check-structural-test
- make check-arch
- go run ./cmd/sourcedeploy -env sec-prod -tenant writer