### PR TITLE
fix: omit per_page for Backstage catalog queries

### DIFF
--- a/sources/backstage/source.go
+++ b/sources/backstage/source.go
@@ -68,6 +68,7 @@ func New() (*Source, error) {
 				},
 				StaticAttributes: map[string]string{"source_product": "backstage"},
 				StaticQuery:      map[string]string{"filter": "kind=component"},
+				PageSizeParams:   []string{"limit"},
 			},
 		},
 	})

--- a/sources/backstage/source_test.go
+++ b/sources/backstage/source_test.go
@@ -32,6 +32,12 @@ func TestReadComponentFamily(t *testing.T) {
 		if got := r.URL.Query().Get("filter"); got != "kind=component" {
 			t.Fatalf("filter query = %q, want kind=component", got)
 		}
+		if got := r.URL.Query().Get("limit"); got != "100" {
+			t.Fatalf("limit query = %q, want 100", got)
+		}
+		if got := r.URL.Query().Get("per_page"); got != "" {
+			t.Fatalf("per_page query = %q, want empty", got)
+		}
 		if got := r.Header.Get("Authorization"); got != "Bearer backstage-token" {
 			t.Fatalf("Authorization = %q, want Bearer backstage-token", got)
 		}

--- a/sources/internal/jsonapi/source.go
+++ b/sources/internal/jsonapi/source.go
@@ -38,6 +38,7 @@ type Family struct {
 	Attributes       map[string]string
 	StaticAttributes map[string]string
 	StaticQuery      map[string]string
+	PageSizeParams   []string
 	RequireID        bool
 }
 
@@ -215,8 +216,9 @@ func (s *Source) list(ctx context.Context, family Family, settings settings, cur
 			query.Set(strings.TrimSpace(key), strings.TrimSpace(value))
 		}
 	}
-	query.Set("limit", strconv.Itoa(pageSize))
-	query.Set("per_page", strconv.Itoa(pageSize))
+	for _, param := range pageSizeParams(family) {
+		query.Set(param, strconv.Itoa(pageSize))
+	}
 	if cursor := strings.TrimSpace(cursor); cursor != "" {
 		query.Set("cursor", cursor)
 	}
@@ -239,6 +241,22 @@ func (s *Source) list(ctx context.Context, family Family, settings settings, cur
 		}
 	}
 	return records, next, nil
+}
+
+func pageSizeParams(family Family) []string {
+	if len(family.PageSizeParams) == 0 {
+		return []string{"limit", "per_page"}
+	}
+	params := make([]string, 0, len(family.PageSizeParams))
+	for _, param := range family.PageSizeParams {
+		if param = strings.TrimSpace(param); param != "" {
+			params = append(params, param)
+		}
+	}
+	if len(params) == 0 {
+		return []string{"limit", "per_page"}
+	}
+	return params
 }
 
 func (s *Source) getJSON(ctx context.Context, settings settings, query url.Values, target any) error {


### PR DESCRIPTION
## Summary
- allow JSON API families to customize page-size query parameters
- configure the Backstage source to send only `limit`, avoiding Backstage Catalog API `per_page` rejection
- assert Backstage requests do not include `per_page`

## Validation
- go test ./sources/backstage ./sources/internal/jsonapi
- gofmt + git diff --check

## Production context
Cerebro go-prod Backstage bootstrap now authenticates to Backstage, but fails with `400 Unknown query parameter per_page`; this fixes the source request shape.