### PR TITLE
fix: link audit actors by email

### DIFF
--- a/internal/sourceprojection/identity.go
+++ b/internal/sourceprojection/identity.go
@@ -568,8 +568,9 @@ func identityAuditProjections(event *cerebrov1.EventEnvelope, profile identityPr
 	provider := profile.Provider
 	entities := map[string]*ports.ProjectedEntity{}
 	links := map[string]*ports.ProjectedLink{}
-	actorEmail := firstNonEmpty(attributes["actor_email"], attributes["actor_alternate_id"], attributes["email"])
-	actorURN := identityUserURN(tenantID, provider, firstNonEmpty(attributes["actor_id"], actorEmail), actorEmail)
+	actorEmail := firstNonEmpty(attributes["actor_email"], attributes["email"])
+	actorIdentifier := firstNonEmpty(actorEmail, attributes["actor_alternate_id"])
+	actorURN := identityUserURN(tenantID, provider, firstNonEmpty(attributes["actor_id"], actorIdentifier), actorIdentifier)
 	resourceID := firstNonEmpty(attributes["resource_id"], attributes["target_id"], attributes["app_id"], attributes["group_id"], attributes["role_id"])
 	resourceType := normalizeIdentifier(firstNonEmpty(attributes["resource_type"], attributes["target_type"], "resource"))
 	resourceURN := projectionURN(tenantID, provider+"_"+resourceType, resourceID)
@@ -579,12 +580,18 @@ func identityAuditProjections(event *cerebrov1.EventEnvelope, profile identityPr
 			TenantID:   tenantID,
 			SourceID:   event.GetSourceId(),
 			EntityType: profile.entityType("user"),
-			Label:      firstNonEmpty(attributes["actor_name"], actorEmail, attributes["actor_id"]),
+			Label:      firstNonEmpty(attributes["actor_name"], actorEmail, attributes["actor_alternate_id"], attributes["actor_id"]),
 			Attributes: map[string]string{"email": actorEmail, "actor_id": strings.TrimSpace(attributes["actor_id"])},
 		})
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorEmail, event.GetOccurredAt())
-		addCloudIdentityAccountLink(entities, links, tenantID, event.GetSourceId(), event, actorURN, profile, attributes, attributes["actor_type"], firstNonEmpty(attributes["actor_id"], actorEmail))
-		addAWSPrincipalIdentifierLinks(entities, links, tenantID, event.GetSourceId(), event, actorURN, profile, attributes, attributes["actor_type"], firstNonEmpty(attributes["actor_id"], actorEmail), attributes["actor_alternate_id"], attributes["actor_name"], actorEmail)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorIdentifier, event.GetOccurredAt())
+		if !sameIdentifier(actorIdentifier, attributes["actor_alternate_id"]) {
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, attributes["actor_alternate_id"], event.GetOccurredAt())
+		}
+		if !sameIdentifier(actorIdentifier, actorEmail) {
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorEmail, event.GetOccurredAt())
+		}
+		addCloudIdentityAccountLink(entities, links, tenantID, event.GetSourceId(), event, actorURN, profile, attributes, attributes["actor_type"], firstNonEmpty(attributes["actor_id"], actorIdentifier))
+		addAWSPrincipalIdentifierLinks(entities, links, tenantID, event.GetSourceId(), event, actorURN, profile, attributes, attributes["actor_type"], firstNonEmpty(attributes["actor_id"], actorIdentifier), attributes["actor_alternate_id"], attributes["actor_name"], actorEmail)
 	}
 	if resourceURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -578,6 +578,7 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 	actorIsBot := strings.TrimSpace(attributes["actor_is_bot"])
 	actorIsAgent := strings.TrimSpace(attributes["actor_is_agent"])
 	actorType := strings.TrimSpace(attributes["actor_type"])
+	actorEmail := strings.TrimSpace(attributes["actor_email"])
 	actorExternalNameID := strings.TrimSpace(attributes["external_identity_nameid"])
 	actorExternalUsername := strings.TrimSpace(attributes["external_identity_username"])
 	orgID := strings.TrimSpace(attributes["org_id"])
@@ -872,6 +873,9 @@ func githubAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedE
 			}
 			if !sameIdentifier(actor, actorExternalUsername) && !sameIdentifier(actorExternalNameID, actorExternalUsername) {
 				addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorExternalUsername, event.GetOccurredAt())
+			}
+			if !sameIdentifier(actor, actorEmail) && !sameIdentifier(actorExternalNameID, actorEmail) && !sameIdentifier(actorExternalUsername, actorEmail) {
+				addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, actorEmail, event.GetOccurredAt())
 			}
 		}
 	}

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -2188,6 +2188,74 @@ func TestProjectReusesCrossSourceIdentifierWithinTenant(t *testing.T) {
 	}
 }
 
+func TestProjectGitHubAuditActorEmailEmitsEmailIdentity(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	event := &cerebrov1.EventEnvelope{
+		Id:       "github-audit-email",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.audit",
+		Attributes: map[string]string{
+			"actor":         "alice",
+			"actor_email":   "alice@writer.com",
+			"org":           "writer",
+			"repo":          "writer/cerebro",
+			"resource_id":   "writer/cerebro",
+			"resource_type": "repository",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	actorURN := "urn:cerebro:writer:github_user:alice"
+	emailIdentityURN := "urn:cerebro:writer:identity:email:alice@writer.com"
+	loginIdentityURN := "urn:cerebro:writer:identity:login:alice"
+	if _, ok := state.links[actorURN+"|"+relationRepresentsIdentity+"|"+emailIdentityURN]; !ok {
+		t.Fatalf("github actor email identity link missing for %q", emailIdentityURN)
+	}
+	if _, ok := state.links[actorURN+"|"+relationRepresentsIdentity+"|"+loginIdentityURN]; !ok {
+		t.Fatalf("github actor login identity link missing for %q", loginIdentityURN)
+	}
+}
+
+func TestProjectAWSCloudTrailActorEmailPreservesAlternateIdentifier(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	event := &cerebrov1.EventEnvelope{
+		Id:       "aws-cloudtrail-email",
+		TenantId: "writer",
+		SourceId: "aws",
+		Kind:     "aws.cloudtrail",
+		Attributes: map[string]string{
+			"actor_alternate_id": "AWSReservedSSO_admin/alice",
+			"actor_email":        "alice@writer.com",
+			"actor_id":           "arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_admin/alice",
+			"actor_type":         "AssumedRole",
+			"domain":             "123456789012",
+			"event_type":         "ListRoles",
+			"resource_id":        "123456789012",
+			"resource_type":      "account",
+		},
+	}
+	if _, err := service.Project(context.Background(), event); err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	actorURN := "urn:cerebro:writer:aws_user:arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_admin/alice"
+	emailIdentityURN := "urn:cerebro:writer:identity:email:alice@writer.com"
+	alternateIdentifierURN := "urn:cerebro:writer:identifier:login:awsreservedsso_admin/alice"
+	if _, ok := state.links[actorURN+"|"+relationRepresentsIdentity+"|"+emailIdentityURN]; !ok {
+		t.Fatalf("aws actor email identity link missing for %q", emailIdentityURN)
+	}
+	if _, ok := state.links[actorURN+"|"+relationHasIdentifier+"|"+alternateIdentifierURN]; !ok {
+		t.Fatalf("aws actor alternate identifier link missing for %q", alternateIdentifierURN)
+	}
+}
+
 func TestProjectIdentityProviderJoinEdges(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/sources/github/audit.go
+++ b/sources/github/audit.go
@@ -21,6 +21,7 @@ import (
 type auditPayload struct {
 	Action                   string         `json:"action"`
 	Actor                    string         `json:"actor,omitempty"`
+	ActorEmail               string         `json:"actor_email,omitempty"`
 	ActorID                  int64          `json:"actor_id,omitempty"`
 	ActorIP                  string         `json:"actor_ip,omitempty"`
 	ActorIsAgent             bool           `json:"actor_is_agent,omitempty"`
@@ -139,6 +140,7 @@ type auditActorResolution struct {
 	Login string
 	Type  string
 	ID    int64
+	Email string
 }
 
 func resolveAuditActor(ctx context.Context, client *gogithub.Client, actor string, cache map[string]auditActorResolution) auditActorResolution {
@@ -163,6 +165,7 @@ func resolveAuditActor(ctx context.Context, client *gogithub.Client, actor strin
 	}
 	resolution.Type = strings.TrimSpace(user.GetType())
 	resolution.ID = user.GetID()
+	resolution.Email = strings.TrimSpace(user.GetEmail())
 	if login := strings.TrimSpace(user.GetLogin()); login != "" {
 		resolution.Login = login
 	}
@@ -183,6 +186,7 @@ func auditEvent(settings settings, entry *gogithub.AuditEntry, actorResolution a
 	payload, err := json.Marshal(auditPayload{
 		Action:                   entry.GetAction(),
 		Actor:                    entry.GetActor(),
+		ActorEmail:               actorResolution.Email,
 		ActorID:                  actorID,
 		ActorIP:                  rawString(raw, "actor_ip"),
 		ActorIsAgent:             rawBool(raw, "actor_is_agent"),
@@ -291,6 +295,7 @@ func auditAttributes(entry *gogithub.AuditEntry, raw map[string]any, settings se
 		"scope":          auditScope(entry, raw, settings),
 	}
 	addAttribute(attributes, "actor", entry.GetActor())
+	addAttribute(attributes, "actor_email", actorResolution.Email)
 	addAttribute(attributes, "actor_id", positiveInt64String(firstPositiveInt64(entry.GetActorID(), actorResolution.ID)))
 	addAttribute(attributes, "actor_is_agent", boolString(raw, "actor_is_agent"))
 	addAttribute(attributes, "actor_is_bot", boolString(raw, "actor_is_bot"))

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -359,9 +359,15 @@ func TestCheckDiscoverAndReadLiveGitHubAuditPreview(t *testing.T) {
 	if got := first.Events[0].Attributes["actor_type"]; got != "Bot" {
 		t.Fatalf("first.Events[0].Attributes[actor_type] = %q, want Bot", got)
 	}
+	if got := first.Events[0].Attributes["actor_email"]; got != "dependabot@writer.com" {
+		t.Fatalf("first.Events[0].Attributes[actor_email] = %q, want dependabot@writer.com", got)
+	}
 	var payload map[string]any
 	if err := json.Unmarshal(first.Events[0].Payload, &payload); err != nil {
 		t.Fatalf("unmarshal audit payload: %v", err)
+	}
+	if got := payload["actor_email"]; got != "dependabot@writer.com" {
+		t.Fatalf("audit payload actor_email = %#v, want dependabot@writer.com", got)
 	}
 	if got := payload["resource_type"]; got != "repository_vulnerability_alert" {
 		t.Fatalf("audit payload resource_type = %#v, want repository_vulnerability_alert", got)
@@ -892,6 +898,7 @@ func newGitHubAPIHandler(t *testing.T) http.Handler {
 				"login": "dependabot[bot]",
 				"id":    49699333,
 				"type":  "Bot",
+				"email": "dependabot@writer.com",
 			}); err != nil {
 				t.Fatalf("encode users response: %v", err)
 			}
@@ -900,6 +907,7 @@ func newGitHubAPIHandler(t *testing.T) http.Handler {
 				"login": "octocat",
 				"id":    1,
 				"type":  "User",
+				"email": "octocat@writer.com",
 			}); err != nil {
 				t.Fatalf("encode users response: %v", err)
 			}


### PR DESCRIPTION
## Summary
- preserves explicit actor email attributes from audit source events
- projects email identifiers alongside login identifiers for audit actors when available
- keeps existing login identity links intact while enabling email-based graph pivots

## Validation
- go test ./internal/sourceprojection ./sources/github -run 'TestProjectGitHubAuditActorEmailEmitsEmailIdentity|TestProjectAWSCloudTrailActorEmailPreservesAlternateIdentifier|TestCheckDiscoverAndReadLiveGitHubAuditPreview' -count=1
- make test
- make lint