### PR TITLE
Link GitHub alert actors

### DIFF
--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -1257,6 +1257,7 @@ func githubDependabotAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), packageURN, canonicalPackageURN, relationRepresents, packageIdentityAttributes(event, attributes, ecosystem)))
 	}
 	addGitHubDependabotDependencyContext(entities, links, tenantID, event, repoURN, alertURN, packageURN, canonicalPackageURN, repository, manifestPath, ecosystem, packageName)
+	addGitHubAlertActorLinks(entities, links, tenantID, event, alertURN, attributes["dismissed_by"], attributes["dismissed_by_id"], "dismissed_by")
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
@@ -1417,9 +1418,43 @@ func githubSecretScanningAlertProjections(event *cerebrov1.EventEnvelope) ([]*po
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, repoURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
 	}
+	addGitHubAlertActorLinks(entities, links, tenantID, event, alertURN, attributes["resolved_by"], attributes["resolved_by_id"], "resolved_by")
+	addGitHubAlertActorLinks(entities, links, tenantID, event, alertURN, attributes["push_protection_bypassed_by"], attributes["push_protection_bypassed_by_id"], "push_protection_bypassed_by")
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
+}
+
+func addGitHubAlertActorLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, event *cerebrov1.EventEnvelope, alertURN string, login string, userID string, actorRole string) {
+	login = strings.TrimSpace(login)
+	alertURN = strings.TrimSpace(alertURN)
+	if login == "" || alertURN == "" {
+		return
+	}
+	userID = strings.TrimSpace(userID)
+	actorRole = strings.TrimSpace(actorRole)
+	actorURN := projectionURN(tenantID, "github_user", login)
+	actorAttrs := map[string]string{"login": login}
+	if userID != "" {
+		actorAttrs["user_id"] = userID
+	}
+	if actorRole != "" {
+		actorAttrs["actor_role"] = actorRole
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        actorURN,
+		TenantID:   tenantID,
+		SourceID:   event.GetSourceId(),
+		EntityType: "github.user",
+		Label:      login,
+		Attributes: actorAttrs,
+	})
+	linkAttrs := map[string]string{"event_id": event.GetId()}
+	if actorRole != "" {
+		linkAttrs["actor_role"] = actorRole
+	}
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, alertURN, relationActedOn, linkAttrs))
+	addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, login, event.GetOccurredAt())
 }
 
 func githubOrgMemberProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -1453,8 +1453,32 @@ func addGitHubAlertActorLinks(entities map[string]*ports.ProjectedEntity, links 
 	if actorRole != "" {
 		linkAttrs["actor_role"] = actorRole
 	}
+	linkKey := actorURN + "|" + relationActedOn + "|" + alertURN
+	if existing := links[linkKey]; existing != nil {
+		mergeCSVLinkAttribute(existing.Attributes, "event_id", event.GetId())
+		mergeCSVLinkAttribute(existing.Attributes, "actor_role", actorRole)
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, login, event.GetOccurredAt())
+		return
+	}
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), actorURN, alertURN, relationActedOn, linkAttrs))
 	addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), actorURN, login, event.GetOccurredAt())
+}
+
+func mergeCSVLinkAttribute(attributes map[string]string, key string, value string) {
+	value = strings.TrimSpace(value)
+	if attributes == nil || key == "" || value == "" {
+		return
+	}
+	for _, existing := range strings.Split(attributes[key], ",") {
+		if strings.TrimSpace(existing) == value {
+			return
+		}
+	}
+	if strings.TrimSpace(attributes[key]) == "" {
+		attributes[key] = value
+		return
+	}
+	attributes[key] += "," + value
 }
 
 func githubOrgMemberProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -505,6 +505,41 @@ func TestProjectGitHubSecretScanningAlertLinksResolverAndBypasser(t *testing.T) 
 	}
 }
 
+func TestProjectGitHubSecretScanningAlertPreservesMultipleActorRolesForSameUser(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	service := New(state, graph)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-secret-scanning-alert-same-actor",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.secret_scanning_alert",
+		Attributes: map[string]string{
+			"alert_number":                   "43",
+			"owner":                          "writer",
+			"push_protection_bypassed":       "true",
+			"push_protection_bypassed_by":    "alice",
+			"push_protection_bypassed_by_id": "123",
+			"repository":                     "writer/cerebro",
+			"resolved_by":                    "alice",
+			"resolved_by_id":                 "123",
+			"state":                          "resolved",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	alertURN := "urn:cerebro:writer:github_secret_scanning_alert:writer:43"
+	actorURN := "urn:cerebro:writer:github_user:alice"
+	assertProjectedLink(t, graph, actorURN, relationActedOn, alertURN)
+	link := graph.links[actorURN+"|"+relationActedOn+"|"+alertURN]
+	if got := link.Attributes["actor_role"]; got != "resolved_by,push_protection_bypassed_by" {
+		t.Fatalf("actor_role = %q, want both roles", got)
+	}
+}
+
 func TestProjectOktaOAuthGrantAsApplicationTelemetry(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -424,6 +424,87 @@ func TestProjectGitHubDependabotAlertLinksRepoScopedDependency(t *testing.T) {
 	assertProjectedLink(t, state, alertURN, relationAffects, canonicalPackageURN)
 }
 
+func TestProjectGitHubDependabotAlertLinksDismissedByActor(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	service := New(state, graph)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-dependabot-alert-dismissed",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.dependabot_alert",
+		Attributes: map[string]string{
+			"alert_number":    "7",
+			"dismissed_by":    "alice",
+			"dismissed_by_id": "123",
+			"owner":           "writer",
+			"repository":      "writer/cerebro",
+			"state":           "dismissed",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	actorURN := "urn:cerebro:writer:github_user:alice"
+	alertURN := "urn:cerebro:writer:github_dependabot_alert:writer/cerebro:7"
+	identityURN := "urn:cerebro:writer:identity:login:alice"
+	identifierURN := "urn:cerebro:writer:identifier:login:alice"
+	assertProjectedLink(t, graph, actorURN, relationActedOn, alertURN)
+	assertProjectedLink(t, graph, actorURN, relationRepresentsIdentity, identityURN)
+	assertProjectedLink(t, graph, actorURN, relationHasIdentifier, identifierURN)
+	if got := graph.entities[actorURN].Attributes["user_id"]; got != "123" {
+		t.Fatalf("github actor user_id = %q, want 123", got)
+	}
+	if got := graph.links[actorURN+"|"+relationActedOn+"|"+alertURN].Attributes["actor_role"]; got != "dismissed_by" {
+		t.Fatalf("actor_role = %q, want dismissed_by", got)
+	}
+}
+
+func TestProjectGitHubSecretScanningAlertLinksResolverAndBypasser(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	service := New(state, graph)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "github-secret-scanning-alert-resolved",
+		TenantId: "writer",
+		SourceId: "github",
+		Kind:     "github.secret_scanning_alert",
+		Attributes: map[string]string{
+			"alert_number":                   "42",
+			"owner":                          "writer",
+			"push_protection_bypassed":       "true",
+			"push_protection_bypassed_by":    "bob",
+			"push_protection_bypassed_by_id": "456",
+			"repository":                     "writer/cerebro",
+			"resolved_by":                    "alice",
+			"resolved_by_id":                 "123",
+			"state":                          "resolved",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	alertURN := "urn:cerebro:writer:github_secret_scanning_alert:writer:42"
+	resolverURN := "urn:cerebro:writer:github_user:alice"
+	bypasserURN := "urn:cerebro:writer:github_user:bob"
+	assertProjectedLink(t, graph, resolverURN, relationActedOn, alertURN)
+	assertProjectedLink(t, graph, resolverURN, relationRepresentsIdentity, "urn:cerebro:writer:identity:login:alice")
+	assertProjectedLink(t, graph, resolverURN, relationHasIdentifier, "urn:cerebro:writer:identifier:login:alice")
+	assertProjectedLink(t, graph, bypasserURN, relationActedOn, alertURN)
+	assertProjectedLink(t, graph, bypasserURN, relationRepresentsIdentity, "urn:cerebro:writer:identity:login:bob")
+	assertProjectedLink(t, graph, bypasserURN, relationHasIdentifier, "urn:cerebro:writer:identifier:login:bob")
+	if got := graph.links[resolverURN+"|"+relationActedOn+"|"+alertURN].Attributes["actor_role"]; got != "resolved_by" {
+		t.Fatalf("resolver actor_role = %q, want resolved_by", got)
+	}
+	if got := graph.links[bypasserURN+"|"+relationActedOn+"|"+alertURN].Attributes["actor_role"]; got != "push_protection_bypassed_by" {
+		t.Fatalf("bypasser actor_role = %q, want push_protection_bypassed_by", got)
+	}
+}
+
 func TestProjectOktaOAuthGrantAsApplicationTelemetry(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/sources/github/dependabot_alert.go
+++ b/sources/github/dependabot_alert.go
@@ -36,6 +36,8 @@ type dependabotAlertPayload struct {
 	CreatedAt              time.Time  `json:"created_at"`
 	UpdatedAt              time.Time  `json:"updated_at"`
 	DismissedAt            *time.Time `json:"dismissed_at,omitempty"`
+	DismissedBy            string     `json:"dismissed_by,omitempty"`
+	DismissedByID          int64      `json:"dismissed_by_id,omitempty"`
 	FixedAt                *time.Time `json:"fixed_at,omitempty"`
 }
 
@@ -157,6 +159,8 @@ func dependabotAlertEvent(settings settings, alert *gogithub.DependabotAlert) (*
 		CreatedAt:              createdAt,
 		UpdatedAt:              occurredAt,
 		DismissedAt:            timestamp(alert.DismissedAt),
+		DismissedBy:            githubUserLogin(alert.DismissedBy),
+		DismissedByID:          githubUserID(alert.DismissedBy),
 		FixedAt:                timestamp(alert.FixedAt),
 	}
 	payloadBytes, err := json.Marshal(payload)
@@ -177,6 +181,10 @@ func dependabotAlertEvent(settings settings, alert *gogithub.DependabotAlert) (*
 	addAttribute(attributes, "advisory_ghsa_id", payload.GHSAID)
 	addAttribute(attributes, "advisory_severity", payload.AdvisorySeverity)
 	addAttribute(attributes, "dependency_scope", payload.DependencyScope)
+	addAttribute(attributes, "dismissed_by", payload.DismissedBy)
+	if payload.DismissedByID != 0 {
+		addAttribute(attributes, "dismissed_by_id", strconv.FormatInt(payload.DismissedByID, 10))
+	}
 	addAttribute(attributes, "ecosystem", payload.Ecosystem)
 	addAttribute(attributes, "first_patched_version", payload.FirstPatchedVersion)
 	addAttribute(attributes, "html_url", payload.HTMLURL)

--- a/sources/github/secret_scanning_alert.go
+++ b/sources/github/secret_scanning_alert.go
@@ -18,20 +18,24 @@ import (
 const familySecretScanning = "secret_scanning_alert"
 
 type secretScanningAlertPayload struct {
-	Number                   int        `json:"number"`
-	Repository               string     `json:"repository"`
-	State                    string     `json:"state"`
-	SecretType               string     `json:"secret_type,omitempty"`
-	SecretTypeDisplayName    string     `json:"secret_type_display_name,omitempty"`
-	Resolution               string     `json:"resolution,omitempty"`
-	ResolutionComment        string     `json:"resolution_comment,omitempty"`
-	PushProtectionBypassed   bool       `json:"push_protection_bypassed"`
-	URL                      string     `json:"url,omitempty"`
-	HTMLURL                  string     `json:"html_url,omitempty"`
-	CreatedAt                time.Time  `json:"created_at"`
-	UpdatedAt                time.Time  `json:"updated_at"`
-	ResolvedAt               *time.Time `json:"resolved_at,omitempty"`
-	PushProtectionBypassedAt *time.Time `json:"push_protection_bypassed_at,omitempty"`
+	Number                     int        `json:"number"`
+	Repository                 string     `json:"repository"`
+	State                      string     `json:"state"`
+	SecretType                 string     `json:"secret_type,omitempty"`
+	SecretTypeDisplayName      string     `json:"secret_type_display_name,omitempty"`
+	Resolution                 string     `json:"resolution,omitempty"`
+	ResolutionComment          string     `json:"resolution_comment,omitempty"`
+	ResolvedBy                 string     `json:"resolved_by,omitempty"`
+	ResolvedByID               int64      `json:"resolved_by_id,omitempty"`
+	PushProtectionBypassed     bool       `json:"push_protection_bypassed"`
+	PushProtectionBypassedBy   string     `json:"push_protection_bypassed_by,omitempty"`
+	PushProtectionBypassedByID int64      `json:"push_protection_bypassed_by_id,omitempty"`
+	URL                        string     `json:"url,omitempty"`
+	HTMLURL                    string     `json:"html_url,omitempty"`
+	CreatedAt                  time.Time  `json:"created_at"`
+	UpdatedAt                  time.Time  `json:"updated_at"`
+	ResolvedAt                 *time.Time `json:"resolved_at,omitempty"`
+	PushProtectionBypassedAt   *time.Time `json:"push_protection_bypassed_at,omitempty"`
 }
 
 func (s *Source) checkSecretScanningAlerts(ctx context.Context, client *gogithub.Client, settings settings) error {
@@ -108,20 +112,24 @@ func secretScanningAlertEvent(settings settings, alert *gogithub.SecretScanningA
 		repoName = repo.GetFullName()
 	}
 	payload := secretScanningAlertPayload{
-		Number:                   alert.GetNumber(),
-		Repository:               repoName,
-		State:                    alert.GetState(),
-		SecretType:               alert.GetSecretType(),
-		SecretTypeDisplayName:    alert.GetSecretTypeDisplayName(),
-		Resolution:               alert.GetResolution(),
-		ResolutionComment:        alert.GetResolutionComment(),
-		PushProtectionBypassed:   alert.GetPushProtectionBypassed(),
-		URL:                      alert.GetURL(),
-		HTMLURL:                  alert.GetHTMLURL(),
-		CreatedAt:                createdAt,
-		UpdatedAt:                occurredAt,
-		ResolvedAt:               secretScanningTimestamp(alert.ResolvedAt),
-		PushProtectionBypassedAt: secretScanningTimestamp(alert.PushProtectionBypassedAt),
+		Number:                     alert.GetNumber(),
+		Repository:                 repoName,
+		State:                      alert.GetState(),
+		SecretType:                 alert.GetSecretType(),
+		SecretTypeDisplayName:      alert.GetSecretTypeDisplayName(),
+		Resolution:                 alert.GetResolution(),
+		ResolutionComment:          alert.GetResolutionComment(),
+		ResolvedBy:                 githubUserLogin(alert.ResolvedBy),
+		ResolvedByID:               githubUserID(alert.ResolvedBy),
+		PushProtectionBypassed:     alert.GetPushProtectionBypassed(),
+		PushProtectionBypassedBy:   githubUserLogin(alert.PushProtectionBypassedBy),
+		PushProtectionBypassedByID: githubUserID(alert.PushProtectionBypassedBy),
+		URL:                        alert.GetURL(),
+		HTMLURL:                    alert.GetHTMLURL(),
+		CreatedAt:                  createdAt,
+		UpdatedAt:                  occurredAt,
+		ResolvedAt:                 secretScanningTimestamp(alert.ResolvedAt),
+		PushProtectionBypassedAt:   secretScanningTimestamp(alert.PushProtectionBypassedAt),
 	}
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -140,9 +148,17 @@ func secretScanningAlertEvent(settings settings, alert *gogithub.SecretScanningA
 	addAttribute(attributes, "html_url", payload.HTMLURL)
 	addAttribute(attributes, "repository", repoName)
 	addAttribute(attributes, "resolution", payload.Resolution)
+	addAttribute(attributes, "resolved_by", payload.ResolvedBy)
+	if payload.ResolvedByID != 0 {
+		addAttribute(attributes, "resolved_by_id", strconv.FormatInt(payload.ResolvedByID, 10))
+	}
 	addAttribute(attributes, "secret_type", payload.SecretType)
 	addAttribute(attributes, "secret_type_display_name", payload.SecretTypeDisplayName)
 	addAttribute(attributes, "push_protection_bypassed", strconv.FormatBool(payload.PushProtectionBypassed))
+	addAttribute(attributes, "push_protection_bypassed_by", payload.PushProtectionBypassedBy)
+	if payload.PushProtectionBypassedByID != 0 {
+		addAttribute(attributes, "push_protection_bypassed_by_id", strconv.FormatInt(payload.PushProtectionBypassedByID, 10))
+	}
 	return &primitives.Event{
 		Id:         fmt.Sprintf("github-secret-scanning-%s-%d-%d", normalizeRepositoryEventID(repo), alert.GetNumber(), occurredAt.Unix()),
 		TenantId:   settings.owner,

--- a/sources/github/source_test.go
+++ b/sources/github/source_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	gogithub "github.com/google/go-github/v66/github"
 
@@ -539,6 +540,72 @@ func TestCheckDiscoverAndReadLiveGitHubDependabotAlertPreview(t *testing.T) {
 	}
 	if len(second.Events) != 0 {
 		t.Fatalf("len(Read(dependabot_alert second).Events) = %d, want 0", len(second.Events))
+	}
+}
+
+func TestDependabotAlertEventIncludesDismissedBy(t *testing.T) {
+	observedAt := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	event, err := dependabotAlertEvent(settings{owner: "writer", repo: "cerebro"}, &gogithub.DependabotAlert{
+		Number:      gogithub.Int(7),
+		State:       gogithub.String("dismissed"),
+		CreatedAt:   &gogithub.Timestamp{Time: observedAt},
+		UpdatedAt:   &gogithub.Timestamp{Time: observedAt},
+		DismissedBy: &gogithub.User{Login: gogithub.String("alice"), ID: gogithub.Int64(123)},
+	})
+	if err != nil {
+		t.Fatalf("dependabotAlertEvent() error = %v", err)
+	}
+	if got := event.Attributes["dismissed_by"]; got != "alice" {
+		t.Fatalf("dismissed_by = %q, want alice", got)
+	}
+	if got := event.Attributes["dismissed_by_id"]; got != "123" {
+		t.Fatalf("dismissed_by_id = %q, want 123", got)
+	}
+	var payload dependabotAlertPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal dependabot payload: %v", err)
+	}
+	if payload.DismissedBy != "alice" || payload.DismissedByID != 123 {
+		t.Fatalf("dependabot dismissed actor = %q/%d, want alice/123", payload.DismissedBy, payload.DismissedByID)
+	}
+}
+
+func TestSecretScanningAlertEventIncludesActorLogins(t *testing.T) {
+	observedAt := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	event, err := secretScanningAlertEvent(settings{owner: "writer"}, &gogithub.SecretScanningAlert{
+		Number:                   gogithub.Int(42),
+		State:                    gogithub.String("resolved"),
+		CreatedAt:                &gogithub.Timestamp{Time: observedAt},
+		UpdatedAt:                &gogithub.Timestamp{Time: observedAt},
+		Repository:               &gogithub.Repository{FullName: gogithub.String("writer/cerebro")},
+		ResolvedBy:               &gogithub.User{Login: gogithub.String("alice"), ID: gogithub.Int64(123)},
+		PushProtectionBypassed:   gogithub.Bool(true),
+		PushProtectionBypassedBy: &gogithub.User{Login: gogithub.String("bob"), ID: gogithub.Int64(456)},
+	})
+	if err != nil {
+		t.Fatalf("secretScanningAlertEvent() error = %v", err)
+	}
+	if got := event.Attributes["resolved_by"]; got != "alice" {
+		t.Fatalf("resolved_by = %q, want alice", got)
+	}
+	if got := event.Attributes["resolved_by_id"]; got != "123" {
+		t.Fatalf("resolved_by_id = %q, want 123", got)
+	}
+	if got := event.Attributes["push_protection_bypassed_by"]; got != "bob" {
+		t.Fatalf("push_protection_bypassed_by = %q, want bob", got)
+	}
+	if got := event.Attributes["push_protection_bypassed_by_id"]; got != "456" {
+		t.Fatalf("push_protection_bypassed_by_id = %q, want 456", got)
+	}
+	var payload secretScanningAlertPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal secret scanning payload: %v", err)
+	}
+	if payload.ResolvedBy != "alice" || payload.ResolvedByID != 123 {
+		t.Fatalf("secret resolved actor = %q/%d, want alice/123", payload.ResolvedBy, payload.ResolvedByID)
+	}
+	if payload.PushProtectionBypassedBy != "bob" || payload.PushProtectionBypassedByID != 456 {
+		t.Fatalf("secret bypass actor = %q/%d, want bob/456", payload.PushProtectionBypassedBy, payload.PushProtectionBypassedByID)
 	}
 }
 

--- a/sources/github/user_helpers.go
+++ b/sources/github/user_helpers.go
@@ -1,0 +1,21 @@
+package github
+
+import (
+	"strings"
+
+	gogithub "github.com/google/go-github/v66/github"
+)
+
+func githubUserLogin(user *gogithub.User) string {
+	if user == nil {
+		return ""
+	}
+	return strings.TrimSpace(user.GetLogin())
+}
+
+func githubUserID(user *gogithub.User) int64 {
+	if user == nil {
+		return 0
+	}
+	return user.GetID()
+}


### PR DESCRIPTION
## Summary
- Preserve Dependabot and secret-scanning alert actor logins in source events.
- Project those actors as GitHub users with alert context and identity links.

## Testing
- go test ./sources/github -run 'TestDependabotAlertEventIncludesDismissedBy|TestSecretScanningAlertEventIncludesActorLogins' -count=1 -v\n- go test ./internal/sourceprojection -run 'TestProjectGitHubDependabotAlertLinksDismissedByActor|TestProjectGitHubSecretScanningAlertLinksResolverAndBypasser|TestProjectGitHubDependabotAlert$' -count=1 -v\n- make test\n- make lint