### PR TITLE
Link Okta audit target identities

### DIFF
--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -1673,6 +1673,8 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 	actorDisplayName := strings.TrimSpace(attributes["actor_display_name"])
 	resourceID := strings.TrimSpace(attributes["resource_id"])
 	resourceType := strings.TrimSpace(attributes["resource_type"])
+	targetType := strings.TrimSpace(attributes["target_type"])
+	targetAlternateID := strings.TrimSpace(attributes["target_alternate_id"])
 	oauthClientID := firstNonEmpty(attributes["oauth_client_id"], attributes["client_id"])
 	oauthClientLabel := firstNonEmpty(attributes["oauth_client_label"], attributes["actor_display_name"], oauthClientID)
 
@@ -1714,6 +1716,9 @@ func oktaAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		})
 		if orgURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, orgURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
+		}
+		if oktaAuditTargetUser(resourceType, targetType) {
+			addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), resourceURN, targetAlternateID, event.GetOccurredAt())
 		}
 	}
 
@@ -2109,6 +2114,10 @@ func oktaResourceURN(tenantID string, resourceType string, resourceID string) st
 		return oktaUserURN(tenantID, resourceID)
 	}
 	return projectionURN(tenantID, "okta_resource", normalizeIdentifier(resourceType), strings.TrimSpace(resourceID))
+}
+
+func oktaAuditTargetUser(resourceType string, targetType string) bool {
+	return strings.EqualFold(resourceType, "user") || strings.EqualFold(targetType, "user")
 }
 
 func projectionURN(tenantID string, kind string, parts ...string) string {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -1120,6 +1120,44 @@ func TestProjectOktaAuditSuppressesSelfActedOnEdge(t *testing.T) {
 	assertProjectedLinkMissing(t, state, userURN, relationActedOn, userURN)
 }
 
+func TestProjectOktaAuditTargetUserLinksAlternateIDIdentity(t *testing.T) {
+	state := &projectionRecorder{}
+	graph := &projectionRecorder{}
+	service := New(state, graph)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:         "okta-target-user",
+		TenantId:   "writer",
+		SourceId:   "okta",
+		Kind:       "okta.audit",
+		OccurredAt: timestamppb.New(time.Date(2026, time.May, 12, 1, 2, 3, 0, time.UTC)),
+		Attributes: map[string]string{
+			"domain":              "writer.okta.com",
+			"event_type":          "user.lifecycle.update",
+			"actor_id":            "00u-admin",
+			"actor_type":          "User",
+			"actor_alternate_id":  "admin@writer.com",
+			"resource_id":         "00u-target",
+			"resource_type":       "User",
+			"target_id":           "00u-target",
+			"target_type":         "User",
+			"target_alternate_id": "alice@writer.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	targetURN := "urn:cerebro:writer:okta_user:00u-target"
+	identityURN := "urn:cerebro:writer:identity:email:alice@writer.com"
+	identifierURN := "urn:cerebro:writer:identifier:email:alice@writer.com"
+	assertProjectedLink(t, graph, "urn:cerebro:writer:okta_user:00u-admin", relationActedOn, targetURN)
+	assertProjectedLink(t, graph, targetURN, relationRepresentsIdentity, identityURN)
+	assertProjectedLink(t, graph, targetURN, relationHasIdentifier, identifierURN)
+	assertProjectedLink(t, graph, identityURN, relationHasIdentifier, identifierURN)
+	assertProjectedLink(t, graph, identifierURN, relationRepresentsIdentity, identityURN)
+}
+
 func TestProjectOktaAuditActedOnEdgesCarryTemporalContext(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)


### PR DESCRIPTION
## Summary
- Link Okta audit target user alternate IDs to canonical identity and identifier records.
- Keep existing actor/resource projection behavior intact.

## Testing
- go test ./internal/sourceprojection -run 'TestProjectOktaAuditTargetUserLinksAlternateIDIdentity|TestProjectOktaAuditSuppressesSelfActedOnEdge|TestProjectOktaAuditActedOnEdgesCarryTemporalContext' -count=1 -v\n- make test\n- make lint