### PR TITLE
Enrich cloud role assignment identities

### DIFF
--- a/sources/azure/source.go
+++ b/sources/azure/source.go
@@ -190,6 +190,7 @@ type armRoleAssignmentRecord struct {
 	Type       string                `json:"type"`
 	Properties armRoleAssignmentProp `json:"properties"`
 	RoleName   string
+	Principal  graphPrincipalRecord
 	raw        json.RawMessage
 }
 
@@ -721,6 +722,9 @@ func listIAMRoleAssignments(ctx context.Context, source *Source, settings settin
 	}
 	for i := range records {
 		records[i].RoleName = firstNonEmpty(records[i].RoleName, resolveARMRoleName(ctx, source, settings, records[i].Properties.RoleDefinitionID))
+		if principal, ok := resolveAzurePrincipal(ctx, source, settings, records[i].Properties.PrincipalID, records[i].Properties.PrincipalType); ok {
+			records[i].Principal = principal
+		}
 	}
 	return records, response.Next, nil
 }
@@ -825,21 +829,27 @@ func groupMembershipEvent(settings settings, record graphPrincipalRecord) (*prim
 
 func appRoleAssignmentEvent(settings settings, record appRoleAssignmentRecord) (*primitives.Event, error) {
 	subjectType := azurePrincipalType(record.PrincipalType, graphPrincipalRecord{})
+	subjectEmail := ""
+	if subjectType == "user" {
+		subjectEmail = emailLike(record.PrincipalDisplayName)
+	}
 	attributes := map[string]string{
-		"domain":       tenantID(settings),
-		"family":       familyAppRoleAssignment,
-		"is_admin":     "true",
-		"path_type":    "app_role_assignment",
-		"relationship": "assigned_to",
-		"role_id":      record.AppRoleID,
-		"role_name":    record.AppRoleID,
-		"role_type":    "azure_app_role",
-		"subject_id":   record.PrincipalID,
-		"subject_name": record.PrincipalDisplayName,
-		"subject_type": subjectType,
-		"target_id":    firstNonEmpty(record.ResourceID, settings.servicePrincipalID),
-		"target_name":  record.ResourceDisplayName,
-		"target_type":  "service_principal",
+		"domain":        tenantID(settings),
+		"family":        familyAppRoleAssignment,
+		"is_admin":      "true",
+		"path_type":     "app_role_assignment",
+		"relationship":  "assigned_to",
+		"role_id":       record.AppRoleID,
+		"role_name":     record.AppRoleID,
+		"role_type":     "azure_app_role",
+		"subject_email": subjectEmail,
+		"subject_id":    record.PrincipalID,
+		"subject_login": subjectEmail,
+		"subject_name":  record.PrincipalDisplayName,
+		"subject_type":  subjectType,
+		"target_id":     firstNonEmpty(record.ResourceID, settings.servicePrincipalID),
+		"target_name":   record.ResourceDisplayName,
+		"target_type":   "service_principal",
 	}
 	payload, err := payloadWithRaw(record.raw, map[string]any{"tenant_id": settings.tenantID, "service_principal_id": settings.servicePrincipalID})
 	if err != nil {
@@ -952,6 +962,8 @@ func directoryRoleAssignmentEvent(settings settings, record directoryRoleAssignm
 
 func iamRoleAssignmentEvent(settings settings, record armRoleAssignmentRecord) (*primitives.Event, error) {
 	roleName := firstNonEmpty(record.RoleName, record.Properties.RoleDefinitionID)
+	principal := record.Principal
+	subjectEmail := firstNonEmpty(emailLike(principal.Mail), emailLike(principal.UserPrincipalName), emailLike(record.Properties.PrincipalID))
 	attributes := map[string]string{
 		"domain":             tenantID(settings),
 		"family":             familyIAMRoleAssign,
@@ -961,8 +973,11 @@ func iamRoleAssignmentEvent(settings settings, record armRoleAssignmentRecord) (
 		"role_name":          roleName,
 		"role_type":          "azure_rbac_role",
 		"scope":              record.Properties.Scope,
+		"subject_email":      subjectEmail,
 		"subject_id":         record.Properties.PrincipalID,
-		"subject_type":       azurePrincipalType(record.Properties.PrincipalType, graphPrincipalRecord{}),
+		"subject_login":      subjectEmail,
+		"subject_name":       firstNonEmpty(principal.DisplayName, principal.UserPrincipalName),
+		"subject_type":       azurePrincipalType(record.Properties.PrincipalType, principal),
 		"subscription_id":    settings.subscriptionID,
 	}
 	payload, err := payloadWithRaw(record.raw, map[string]any{"subscription_id": settings.subscriptionID})
@@ -1306,6 +1321,32 @@ func resolveARMRoleName(ctx context.Context, source *Source, settings settings, 
 		return ""
 	}
 	return record.Properties.RoleName
+}
+
+func resolveAzurePrincipal(ctx context.Context, source *Source, settings settings, principalID string, principalType string) (graphPrincipalRecord, bool) {
+	principalID = strings.TrimSpace(principalID)
+	if principalID == "" || graphToken(settings) == "" {
+		return graphPrincipalRecord{}, false
+	}
+	var path string
+	switch azurePrincipalType(principalType, graphPrincipalRecord{}) {
+	case "user":
+		path = "/v1.0/users/" + url.PathEscape(principalID)
+	case "group":
+		path = "/v1.0/groups/" + url.PathEscape(principalID)
+	case "service_principal", "application":
+		path = "/v1.0/servicePrincipals/" + url.PathEscape(principalID)
+	default:
+		path = "/v1.0/directoryObjects/" + url.PathEscape(principalID)
+	}
+	var record graphPrincipalRecord
+	if err := getGraphJSON(ctx, source, settings, http.MethodGet, path, nil, nil, &record); err != nil {
+		return graphPrincipalRecord{}, false
+	}
+	if strings.TrimSpace(record.ID) == "" {
+		record.ID = principalID
+	}
+	return record, true
 }
 
 func graphListQuery(settings settings, limit int) url.Values {

--- a/sources/azure/source.go
+++ b/sources/azure/source.go
@@ -325,6 +325,7 @@ type azureFamilyOptions[T any] struct {
 	Name     string
 	Label    string
 	List     func(context.Context, *Source, settings, string, int) ([]T, string, error)
+	Check    func(context.Context, *Source, settings, string, int) ([]T, string, error)
 	Event    func(settings, T) (*primitives.Event, error)
 	URN      func(settings, T) (string, error)
 	Discover func(context.Context, *Source, settings) ([]sourcecdk.URN, error)
@@ -461,9 +462,19 @@ func (s *Source) newFamilyEngine() (*sourcecdk.FamilyEngine[settings], error) {
 			Name:  familyIAMRoleAssign,
 			Label: "azure rbac role assignments",
 			List:  listIAMRoleAssignments,
+			Check: listIAMRoleAssignmentsBase,
 			Event: iamRoleAssignmentEvent,
 			URN: func(settings settings, assignment armRoleAssignmentRecord) (string, error) {
 				return fmt.Sprintf("urn:cerebro:%s:azure_iam_role_assignment:%s", tenantID(settings), firstNonEmpty(assignment.ID, assignment.Name)), nil
+			},
+			Discover: func(ctx context.Context, source *Source, cfg settings) ([]sourcecdk.URN, error) {
+				records, _, err := listIAMRoleAssignmentsBase(ctx, source, cfg, "", cfg.perPage)
+				if err != nil {
+					return nil, fmt.Errorf("lookup azure rbac role assignments for %s: %w", tenantID(cfg), err)
+				}
+				return azureURNsFor(cfg, records, func(cfg settings, assignment armRoleAssignmentRecord) (string, error) {
+					return fmt.Sprintf("urn:cerebro:%s:azure_iam_role_assignment:%s", tenantID(cfg), firstNonEmpty(assignment.ID, assignment.Name)), nil
+				})
 			},
 		}),
 		azureFamily(s, azureFamilyOptions[azureResourceExposure]{
@@ -500,7 +511,11 @@ func azureFamily[T any](source *Source, options azureFamilyOptions[T]) sourcecdk
 	return sourcecdk.Family[settings]{
 		Name: options.Name,
 		Check: func(ctx context.Context, settings settings) error {
-			return azureCheck(ctx, source, settings, options.List, options.Label)
+			checkList := options.List
+			if options.Check != nil {
+				checkList = options.Check
+			}
+			return azureCheck(ctx, source, settings, checkList, options.Label)
 		},
 		Discover: func(ctx context.Context, settings settings) ([]sourcecdk.URN, error) {
 			if options.Discover != nil {
@@ -707,7 +722,7 @@ func listDirectoryAudits(ctx context.Context, source *Source, settings settings,
 	return records, graphNext(response), err
 }
 
-func listIAMRoleAssignments(ctx context.Context, source *Source, settings settings, pageToken string, _ int) ([]armRoleAssignmentRecord, string, error) {
+func listIAMRoleAssignmentsBase(ctx context.Context, source *Source, settings settings, pageToken string, _ int) ([]armRoleAssignmentRecord, string, error) {
 	query := url.Values{"api-version": {"2022-04-01"}}
 	var response armPage
 	path := "/subscriptions/" + url.PathEscape(settings.subscriptionID) + "/providers/Microsoft.Authorization/roleAssignments"
@@ -720,13 +735,48 @@ func listIAMRoleAssignments(ctx context.Context, source *Source, settings settin
 	if err != nil {
 		return nil, "", err
 	}
+	return records, response.Next, nil
+}
+
+func listIAMRoleAssignments(ctx context.Context, source *Source, settings settings, pageToken string, limit int) ([]armRoleAssignmentRecord, string, error) {
+	records, next, err := listIAMRoleAssignmentsBase(ctx, source, settings, pageToken, limit)
+	if err != nil {
+		return nil, "", err
+	}
+	roleNames := map[string]string{}
+	principals := map[string]azurePrincipalLookup{}
 	for i := range records {
-		records[i].RoleName = firstNonEmpty(records[i].RoleName, resolveARMRoleName(ctx, source, settings, records[i].Properties.RoleDefinitionID))
-		if principal, ok := resolveAzurePrincipal(ctx, source, settings, records[i].Properties.PrincipalID, records[i].Properties.PrincipalType); ok {
+		roleDefinitionID := strings.TrimSpace(records[i].Properties.RoleDefinitionID)
+		if roleDefinitionID != "" {
+			roleName, ok := roleNames[roleDefinitionID]
+			if !ok {
+				roleName = resolveARMRoleName(ctx, source, settings, roleDefinitionID)
+				roleNames[roleDefinitionID] = roleName
+			}
+			records[i].RoleName = firstNonEmpty(records[i].RoleName, roleName)
+		}
+		principalID := strings.TrimSpace(records[i].Properties.PrincipalID)
+		if principalID == "" {
+			continue
+		}
+		principalKey := strings.ToLower(strings.TrimSpace(records[i].Properties.PrincipalType)) + ":" + principalID
+		resolved, ok := principals[principalKey]
+		if !ok {
+			principal, found := resolveAzurePrincipal(ctx, source, settings, principalID, records[i].Properties.PrincipalType)
+			resolved = azurePrincipalLookup{record: principal, ok: found}
+			principals[principalKey] = resolved
+		}
+		if resolved.ok {
+			principal := resolved.record
 			records[i].Principal = principal
 		}
 	}
-	return records, response.Next, nil
+	return records, next, nil
+}
+
+type azurePrincipalLookup struct {
+	record graphPrincipalRecord
+	ok     bool
 }
 
 func listResourceExposures(ctx context.Context, source *Source, settings settings, pageToken string, _ int) ([]azureResourceExposure, string, error) {

--- a/sources/azure/source_test.go
+++ b/sources/azure/source_test.go
@@ -185,6 +185,52 @@ func TestReadLiveAzureARMPreview(t *testing.T) {
 	}
 }
 
+func TestAzureAppRoleAssignmentDerivesUserPrincipalEmail(t *testing.T) {
+	event, err := appRoleAssignmentEvent(settings{tenantID: "tenant-1"}, appRoleAssignmentRecord{
+		ID:                   "app-role-assignment-1",
+		PrincipalID:          "user-1",
+		PrincipalDisplayName: "admin@writer.com",
+		PrincipalType:        "User",
+		ResourceID:           "sp-resource-1",
+		ResourceDisplayName:  "Graph API",
+		AppRoleID:            "role-1",
+	})
+	if err != nil {
+		t.Fatalf("appRoleAssignmentEvent() error = %v", err)
+	}
+	if got := event.Attributes["subject_email"]; got != "admin@writer.com" {
+		t.Fatalf("subject_email = %q, want admin@writer.com", got)
+	}
+	if got := event.Attributes["subject_login"]; got != "admin@writer.com" {
+		t.Fatalf("subject_login = %q, want admin@writer.com", got)
+	}
+}
+
+func TestReadAzureIAMRoleAssignmentResolvesPrincipalEmail(t *testing.T) {
+	server := httptest.NewServer(newAzureAPIHandler(t))
+	defer server.Close()
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url":        server.URL,
+		"family":          familyIAMRoleAssign,
+		"subscription_id": "sub-1",
+		"tenant_id":       "tenant-1",
+		"token":           "test-token",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read(%s) error = %v", familyIAMRoleAssign, err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(pull.Events))
+	}
+	if got := pull.Events[0].Attributes["subject_email"]; got != "admin@writer.com" {
+		t.Fatalf("subject_email = %q, want admin@writer.com", got)
+	}
+}
+
 func newLiveTestSource() (*Source, error) {
 	source, err := New()
 	if err != nil {
@@ -207,6 +253,8 @@ func newAzureAPIHandler(t *testing.T) http.Handler {
 		switch r.URL.Path {
 		case "/v1.0/users":
 			writeJSON(t, w, map[string]any{"value": []map[string]any{{"id": "user-1", "userPrincipalName": "admin@writer.com", "mail": "admin@writer.com", "displayName": "Admin", "accountEnabled": true, "createdDateTime": "2026-04-23T00:00:00Z", "signInActivity": map[string]any{"lastSignInDateTime": "2026-04-24T00:00:00Z"}}}})
+		case "/v1.0/users/user-1":
+			writeJSON(t, w, map[string]any{"@odata.type": "#microsoft.graph.user", "id": "user-1", "userPrincipalName": "admin@writer.com", "mail": "admin@writer.com", "displayName": "Admin"})
 		case "/v1.0/groups":
 			writeJSON(t, w, map[string]any{"value": []map[string]any{{"id": "group-1", "mail": "security@writer.com", "displayName": "Security", "securityEnabled": true, "mailEnabled": true}}})
 		case "/v1.0/groups/group-1/members":
@@ -222,7 +270,7 @@ func newAzureAPIHandler(t *testing.T) http.Handler {
 		case "/v1.0/auditLogs/directoryAudits":
 			writeJSON(t, w, map[string]any{"value": []map[string]any{{"id": "audit-1", "activityDateTime": "2026-04-23T00:00:00Z", "activityDisplayName": "Update conditional access policy", "operationType": "Update", "category": "Policy", "initiatedBy": map[string]any{"user": map[string]any{"id": "user-1", "userPrincipalName": "admin@writer.com", "displayName": "Admin"}}, "targetResources": []map[string]any{{"id": "policy-1", "displayName": "Require MFA", "type": "conditional_access_policy"}}}}})
 		case "/subscriptions/sub-1/providers/Microsoft.Authorization/roleAssignments":
-			writeJSON(t, w, map[string]any{"value": []map[string]any{{"id": "/subscriptions/sub-1/providers/Microsoft.Authorization/roleAssignments/ra-1", "name": "ra-1", "type": "Microsoft.Authorization/roleAssignments", "properties": map[string]any{"principalId": "sp-1", "principalType": "ServicePrincipal", "roleDefinitionId": "/subscriptions/sub-1/providers/Microsoft.Authorization/roleDefinitions/owner-role", "scope": "/subscriptions/sub-1"}}}})
+			writeJSON(t, w, map[string]any{"value": []map[string]any{{"id": "/subscriptions/sub-1/providers/Microsoft.Authorization/roleAssignments/ra-1", "name": "ra-1", "type": "Microsoft.Authorization/roleAssignments", "properties": map[string]any{"principalId": "user-1", "principalType": "User", "roleDefinitionId": "/subscriptions/sub-1/providers/Microsoft.Authorization/roleDefinitions/owner-role", "scope": "/subscriptions/sub-1"}}}})
 		case "/subscriptions/sub-1/providers/Microsoft.Authorization/roleDefinitions/owner-role":
 			writeJSON(t, w, map[string]any{"id": "/subscriptions/sub-1/providers/Microsoft.Authorization/roleDefinitions/owner-role", "name": "owner-role", "properties": map[string]any{"roleName": "Owner", "type": "BuiltInRole"}})
 		case "/subscriptions/sub-1/providers/Microsoft.Network/networkSecurityGroups":

--- a/sources/azure/source_test.go
+++ b/sources/azure/source_test.go
@@ -231,6 +231,60 @@ func TestReadAzureIAMRoleAssignmentResolvesPrincipalEmail(t *testing.T) {
 	}
 }
 
+func TestListAzureIAMRoleAssignmentsCachesResolvedMetadata(t *testing.T) {
+	var roleDefinitionLookups int
+	var principalLookups int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/subscriptions/sub-1/providers/Microsoft.Authorization/roleAssignments":
+			writeJSON(t, w, map[string]any{"value": []map[string]any{
+				{"id": "/subscriptions/sub-1/providers/Microsoft.Authorization/roleAssignments/ra-1", "name": "ra-1", "properties": map[string]any{"principalId": "user-1", "principalType": "User", "roleDefinitionId": "/subscriptions/sub-1/providers/Microsoft.Authorization/roleDefinitions/owner-role", "scope": "/subscriptions/sub-1"}},
+				{"id": "/subscriptions/sub-1/providers/Microsoft.Authorization/roleAssignments/ra-2", "name": "ra-2", "properties": map[string]any{"principalId": "user-1", "principalType": "User", "roleDefinitionId": "/subscriptions/sub-1/providers/Microsoft.Authorization/roleDefinitions/owner-role", "scope": "/subscriptions/sub-1"}},
+			}})
+		case "/subscriptions/sub-1/providers/Microsoft.Authorization/roleDefinitions/owner-role":
+			roleDefinitionLookups++
+			writeJSON(t, w, map[string]any{"properties": map[string]any{"roleName": "Owner"}})
+		case "/v1.0/users/user-1":
+			principalLookups++
+			writeJSON(t, w, map[string]any{"@odata.type": "#microsoft.graph.user", "id": "user-1", "userPrincipalName": "admin@writer.com", "mail": "admin@writer.com"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	settings := settings{baseURL: server.URL, tenantID: "tenant-1", subscriptionID: "sub-1", token: "test-token"}
+
+	baseRecords, _, err := listIAMRoleAssignmentsBase(context.Background(), source, settings, "", 10)
+	if err != nil {
+		t.Fatalf("listIAMRoleAssignmentsBase() error = %v", err)
+	}
+	if len(baseRecords) != 2 {
+		t.Fatalf("len(baseRecords) = %d, want 2", len(baseRecords))
+	}
+	if roleDefinitionLookups != 0 || principalLookups != 0 {
+		t.Fatalf("base list made enrichment calls: role=%d principal=%d", roleDefinitionLookups, principalLookups)
+	}
+
+	records, _, err := listIAMRoleAssignments(context.Background(), source, settings, "", 10)
+	if err != nil {
+		t.Fatalf("listIAMRoleAssignments() error = %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("len(records) = %d, want 2", len(records))
+	}
+	if roleDefinitionLookups != 1 {
+		t.Fatalf("role definition lookups = %d, want 1", roleDefinitionLookups)
+	}
+	if principalLookups != 1 {
+		t.Fatalf("principal lookups = %d, want 1", principalLookups)
+	}
+}
+
 func newLiveTestSource() (*Source, error) {
 	source, err := New()
 	if err != nil {

--- a/sources/googleworkspace/source.go
+++ b/sources/googleworkspace/source.go
@@ -102,6 +102,8 @@ type roleAssignmentRecord struct {
 	AssigneeType     string `json:"assigneeType"`
 	ScopeType        string `json:"scopeType"`
 	OrgUnitID        string `json:"orgUnitId"`
+	SubjectEmail     string
+	SubjectName      string
 	raw              json.RawMessage
 }
 
@@ -225,7 +227,7 @@ func (s *Source) readFamily(ctx context.Context, settings settings, cursor *cere
 	}
 	events := make([]*primitives.Event, 0, len(rawRecords))
 	for _, raw := range rawRecords {
-		event, err := sourceEvent(settings, raw)
+		event, err := s.sourceEvent(ctx, settings, raw)
 		if err != nil {
 			return sourcecdk.Pull{}, err
 		}
@@ -407,6 +409,36 @@ func lookupIPAddrs(source *Source) func(context.Context, string) ([]net.IPAddr, 
 		return source.lookupIPAddrs
 	}
 	return net.DefaultResolver.LookupIPAddr
+}
+
+func (s *Source) sourceEvent(ctx context.Context, settings settings, raw json.RawMessage) (*primitives.Event, error) {
+	if settings.family != familyRoleAssign {
+		return sourceEvent(settings, raw)
+	}
+	var record roleAssignmentRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		return nil, fmt.Errorf("decode google_workspace role assignment: %w", err)
+	}
+	record.raw = append(json.RawMessage(nil), raw...)
+	if strings.EqualFold(record.AssigneeType, "user") {
+		if user, ok := s.lookupUser(ctx, settings, record.AssignedTo); ok {
+			record.SubjectEmail = user.PrimaryEmail
+			record.SubjectName = user.Name.FullName
+		}
+	}
+	return roleAssignmentEvent(settings, record)
+}
+
+func (s *Source) lookupUser(ctx context.Context, settings settings, userKey string) (userRecord, bool) {
+	userKey = strings.TrimSpace(userKey)
+	if userKey == "" {
+		return userRecord{}, false
+	}
+	var user userRecord
+	if err := s.getJSON(ctx, settings, "/admin/directory/v1/users/"+url.PathEscape(userKey), nil, &user); err != nil {
+		return userRecord{}, false
+	}
+	return user, true
 }
 
 func sourceEvent(settings settings, raw json.RawMessage) (*primitives.Event, error) {
@@ -599,12 +631,16 @@ func groupMemberAttributes(settings settings, record memberRecord) map[string]st
 }
 
 func roleAssignmentAttributes(settings settings, record roleAssignmentRecord) map[string]string {
+	subjectEmail := firstNonEmpty(record.SubjectEmail, emailLike(record.AssignedTo))
 	return trimEmpty(map[string]string{
 		"domain":             settings.domain,
 		"family":             familyRoleAssign,
 		"role_assignment_id": record.RoleAssignmentID,
 		"role_id":            record.RoleID,
+		"subject_email":      subjectEmail,
 		"subject_id":         record.AssignedTo,
+		"subject_login":      subjectEmail,
+		"subject_name":       record.SubjectName,
 		"assigned_to":        record.AssignedTo,
 		"subject_type":       strings.ToLower(record.AssigneeType),
 		"principal_type":     strings.ToLower(record.AssigneeType),
@@ -722,6 +758,14 @@ func firstNonEmpty(values ...string) string {
 		if strings.TrimSpace(value) != "" {
 			return strings.TrimSpace(value)
 		}
+	}
+	return ""
+}
+
+func emailLike(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if strings.Contains(trimmed, "@") {
+		return strings.ToLower(trimmed)
 	}
 	return ""
 }

--- a/sources/googleworkspace/source.go
+++ b/sources/googleworkspace/source.go
@@ -226,8 +226,15 @@ func (s *Source) readFamily(ctx context.Context, settings settings, cursor *cere
 		return sourcecdk.Pull{}, nil
 	}
 	events := make([]*primitives.Event, 0, len(rawRecords))
+	userCache := map[string]googleWorkspaceUserLookup{}
 	for _, raw := range rawRecords {
-		event, err := s.sourceEvent(ctx, settings, raw)
+		var event *primitives.Event
+		var err error
+		if settings.family == familyRoleAssign {
+			event, err = s.roleAssignmentEvent(ctx, settings, raw, userCache)
+		} else {
+			event, err = s.sourceEvent(ctx, settings, raw)
+		}
 		if err != nil {
 			return sourcecdk.Pull{}, err
 		}
@@ -415,18 +422,43 @@ func (s *Source) sourceEvent(ctx context.Context, settings settings, raw json.Ra
 	if settings.family != familyRoleAssign {
 		return sourceEvent(settings, raw)
 	}
+	return s.roleAssignmentEvent(ctx, settings, raw, nil)
+}
+
+func (s *Source) roleAssignmentEvent(ctx context.Context, settings settings, raw json.RawMessage, userCache map[string]googleWorkspaceUserLookup) (*primitives.Event, error) {
 	var record roleAssignmentRecord
 	if err := json.Unmarshal(raw, &record); err != nil {
 		return nil, fmt.Errorf("decode google_workspace role assignment: %w", err)
 	}
 	record.raw = append(json.RawMessage(nil), raw...)
 	if strings.EqualFold(record.AssigneeType, "user") {
-		if user, ok := s.lookupUser(ctx, settings, record.AssignedTo); ok {
+		if user, ok := s.lookupUserCached(ctx, settings, record.AssignedTo, userCache); ok {
 			record.SubjectEmail = user.PrimaryEmail
 			record.SubjectName = user.Name.FullName
 		}
 	}
 	return roleAssignmentEvent(settings, record)
+}
+
+type googleWorkspaceUserLookup struct {
+	record userRecord
+	ok     bool
+}
+
+func (s *Source) lookupUserCached(ctx context.Context, settings settings, userKey string, cache map[string]googleWorkspaceUserLookup) (userRecord, bool) {
+	userKey = strings.TrimSpace(userKey)
+	if userKey == "" {
+		return userRecord{}, false
+	}
+	if cache == nil {
+		return s.lookupUser(ctx, settings, userKey)
+	}
+	if cached, ok := cache[userKey]; ok {
+		return cached.record, cached.ok
+	}
+	user, ok := s.lookupUser(ctx, settings, userKey)
+	cache[userKey] = googleWorkspaceUserLookup{record: user, ok: ok}
+	return user, ok
 }
 
 func (s *Source) lookupUser(ctx context.Context, settings settings, userKey string) (userRecord, bool) {

--- a/sources/googleworkspace/source_test.go
+++ b/sources/googleworkspace/source_test.go
@@ -147,6 +147,34 @@ func TestReadLiveGoogleWorkspaceRoleAndAuditPreview(t *testing.T) {
 	}
 }
 
+func TestGoogleWorkspaceRoleAssignmentResolvesAssignedUserEmail(t *testing.T) {
+	server := httptest.NewServer(newGoogleWorkspaceAPIHandler(t))
+	defer server.Close()
+
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"domain":   "writer.com",
+		"family":   familyRoleAssign,
+		"token":    "test-token",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read(%s) error = %v", familyRoleAssign, err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(pull.Events))
+	}
+	if got := pull.Events[0].Attributes["subject_email"]; got != "admin@writer.com" {
+		t.Fatalf("subject_email = %q, want admin@writer.com", got)
+	}
+	if got := pull.Events[0].Attributes["subject_name"]; got != "Admin Writer" {
+		t.Fatalf("subject_name = %q, want Admin Writer", got)
+	}
+}
+
 func newLiveTestSource() (*Source, error) {
 	source, err := New()
 	if err != nil {
@@ -192,6 +220,12 @@ func newGoogleWorkspaceAPIHandler(t *testing.T) http.Handler {
 				}},
 			}); err != nil {
 				t.Fatalf("encode users page 2: %v", err)
+			}
+		case "/admin/directory/v1/users/1001":
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"id": "1001", "primaryEmail": "admin@writer.com", "name": map[string]any{"fullName": "Admin Writer"},
+			}); err != nil {
+				t.Fatalf("encode user lookup: %v", err)
 			}
 		case "/admin/directory/v1/customer/my_customer/roleassignments":
 			if err := json.NewEncoder(w).Encode(map[string]any{

--- a/sources/googleworkspace/source_test.go
+++ b/sources/googleworkspace/source_test.go
@@ -175,6 +175,55 @@ func TestGoogleWorkspaceRoleAssignmentResolvesAssignedUserEmail(t *testing.T) {
 	}
 }
 
+func TestGoogleWorkspaceRoleAssignmentCachesUserLookupsPerPage(t *testing.T) {
+	var userLookups int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/admin/directory/v1/customer/my_customer/roleassignments":
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{"roleAssignmentId": "ra-1", "roleId": "super-admin", "assignedTo": "1001", "assigneeType": "USER", "scopeType": "CUSTOMER"},
+					{"roleAssignmentId": "ra-2", "roleId": "groups-admin", "assignedTo": "1001", "assigneeType": "USER", "scopeType": "CUSTOMER"},
+				},
+			}); err != nil {
+				t.Fatalf("encode role assignments: %v", err)
+			}
+		case "/admin/directory/v1/users/1001":
+			userLookups++
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"id": "1001", "primaryEmail": "admin@writer.com", "name": map[string]any{"fullName": "Admin Writer"},
+			}); err != nil {
+				t.Fatalf("encode user lookup: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"domain":   "writer.com",
+		"family":   familyRoleAssign,
+		"per_page": "2",
+		"token":    "test-token",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read(%s) error = %v", familyRoleAssign, err)
+	}
+	if len(pull.Events) != 2 {
+		t.Fatalf("len(events) = %d, want 2", len(pull.Events))
+	}
+	if userLookups != 1 {
+		t.Fatalf("user lookups = %d, want 1", userLookups)
+	}
+}
+
 func newLiveTestSource() (*Source, error) {
 	source, err := New()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Enrich Azure role assignment subjects with email/login evidence when available.
- Resolve Google Workspace role assignment user subjects to email/name context.

## Testing
- go test ./sources/azure -run 'TestAzureAppRoleAssignmentDerivesUserPrincipalEmail|TestReadAzureIAMRoleAssignmentResolvesPrincipalEmail|TestReadLiveAzureARMPreview' -count=1 -v\n- go test ./sources/googleworkspace -run 'TestGoogleWorkspaceRoleAssignmentResolvesAssignedUserEmail|TestReadLiveGoogleWorkspaceRoleAndAuditPreview' -count=1 -v\n- make test\n- make lint