### PR TITLE
Link SentinelOne endpoint users

### DIFF
--- a/internal/sourceprojection/sentinelone.go
+++ b/internal/sourceprojection/sentinelone.go
@@ -253,7 +253,7 @@ func addSentinelOneOwnerIdentityLinks(entities map[string]*ports.ProjectedEntity
 	if agentURN == "" {
 		return
 	}
-	ownerEmail := strings.TrimSpace(firstNonEmpty(attrs["user_mail"], attrs["user_email"]))
+	ownerEmail := strings.TrimSpace(firstNonEmpty(attrs["user_mail"], attrs["user_email"], extractEmailIdentifier(attrs["user_name"])))
 	if ownerEmail != "" {
 		addIdentifierLink(entities, links, tenant, event.GetSourceId(), event.GetId(), agentURN, ownerEmail, event.GetOccurredAt())
 		identityURN, _ := canonicalIdentityURN(tenant, ownerEmail)

--- a/internal/sourceprojection/sentinelone_test.go
+++ b/internal/sourceprojection/sentinelone_test.go
@@ -143,6 +143,30 @@ func TestProjectSentinelOneAgentUserNameOnlySkipsStrongOwnerIdentityEdges(t *tes
 	}
 }
 
+func TestProjectSentinelOneAgentUserNameEmailLinksOwnerIdentity(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "s1-agent-owner-username-email",
+		TenantId: "writer",
+		SourceId: "sentinelone",
+		Kind:     "sentinelone.agent",
+		Attributes: map[string]string{
+			"agent_id":  "agent-3",
+			"user_name": "owner@writer.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	agentURN := "urn:cerebro:writer:sentinelone_agent:agent-3"
+	identityURN := "urn:cerebro:writer:identity:email:owner@writer.com"
+	identifierURN := "urn:cerebro:writer:identifier:email:owner@writer.com"
+	assertProjectedLink(t, state, agentURN, relationOwnedBy, identityURN)
+	assertProjectedLink(t, state, agentURN, relationRepresentsIdentity, identityURN)
+	assertProjectedLink(t, state, agentURN, relationHasIdentifier, identifierURN)
+}
+
 func TestProjectSentinelOneAgentSkipsWhenAgentIDMissing(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)

--- a/sources/sentinelone/records.go
+++ b/sources/sentinelone/records.go
@@ -626,6 +626,7 @@ type agentLocationPayload struct {
 	GroupName    string `json:"group_name,omitempty"`
 	SiteID       string `json:"site_id,omitempty"`
 	SiteName     string `json:"site_name,omitempty"`
+	UserName     string `json:"user_name,omitempty"`
 }
 
 type sitePayload struct {
@@ -831,6 +832,7 @@ func agentEvent(s settings, record agentRecord) (*primitives.Event, error) {
 			GroupName:    record.GroupName,
 			SiteID:       record.SiteID,
 			SiteName:     record.SiteName,
+			UserName:     sentinelOneAgentUserName(record),
 		},
 		TenantHost: s.host,
 		Tags:       record.Tags,
@@ -1348,6 +1350,9 @@ func agentAttributes(s settings, record agentRecord) map[string]string {
 	addAttribute(attrs, "site_name", record.SiteName)
 	addAttribute(attrs, "group_id", record.GroupID)
 	addAttribute(attrs, "group_name", record.GroupName)
+	userName := sentinelOneAgentUserName(record)
+	addAttribute(attrs, "user_name", userName)
+	addAttribute(attrs, "user_email", sentinelOneEmailLike(userName))
 	addAttribute(attrs, "account_id", record.AccountID)
 	addAttribute(attrs, "account_name", record.AccountName)
 	addAttribute(attrs, "machine_type", record.MachineType)
@@ -1360,6 +1365,18 @@ func agentAttributes(s settings, record agentRecord) map[string]string {
 		attrs["user_actions_needed"] = strings.Join(record.UserActionsNeeded, ",")
 	}
 	return attrs
+}
+
+func sentinelOneAgentUserName(record agentRecord) string {
+	return firstNonEmpty(record.LastLoggedInUserName, record.OSUsername)
+}
+
+func sentinelOneEmailLike(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if strings.Contains(trimmed, "@") {
+		return strings.ToLower(trimmed)
+	}
+	return ""
 }
 
 func joinedEndpointIPs(values ...string) string {

--- a/sources/sentinelone/records.go
+++ b/sources/sentinelone/records.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/writer/cerebro/internal/primitives"
 )
+
+var sentinelOneEmailPattern = regexp.MustCompile(`(?i)^[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$`)
 
 // raw types are used to capture the raw response body alongside the decoded fields so that
 // downstream projection can read details that we did not statically model.
@@ -1373,7 +1376,7 @@ func sentinelOneAgentUserName(record agentRecord) string {
 
 func sentinelOneEmailLike(value string) string {
 	trimmed := strings.TrimSpace(value)
-	if strings.Contains(trimmed, "@") {
+	if sentinelOneEmailPattern.MatchString(trimmed) {
 		return strings.ToLower(trimmed)
 	}
 	return ""

--- a/sources/sentinelone/source_test.go
+++ b/sources/sentinelone/source_test.go
@@ -285,6 +285,17 @@ func TestCheckDiscoverAndReadLiveAgents(t *testing.T) {
 	}
 }
 
+func TestSentinelOneEmailLikeRejectsUsernameOnlyUPNs(t *testing.T) {
+	for _, value := range []string{"owner@WRITER", "user@localhost", "jdoe@"} {
+		if got := sentinelOneEmailLike(value); got != "" {
+			t.Fatalf("sentinelOneEmailLike(%q) = %q, want empty", value, got)
+		}
+	}
+	if got := sentinelOneEmailLike(" Owner@Writer.COM "); got != "owner@writer.com" {
+		t.Fatalf("sentinelOneEmailLike(valid email) = %q", got)
+	}
+}
+
 func TestRecords_FirewallEnabledConditionalEmit(t *testing.T) {
 	for _, tt := range []struct {
 		name        string

--- a/sources/sentinelone/source_test.go
+++ b/sources/sentinelone/source_test.go
@@ -276,6 +276,8 @@ func TestCheckDiscoverAndReadLiveAgents(t *testing.T) {
 		"ip_addresses":  "203.0.113.10,10.0.0.10",
 		"is_active":     "true",
 		"family":        "agent",
+		"user_email":    "owner@writer.com",
+		"user_name":     "owner@writer.com",
 	} {
 		if got := attrs[k]; got != want {
 			t.Fatalf("agent attribute %s = %q, want %q", k, got, want)
@@ -673,18 +675,19 @@ func newTestAPIHandler(t *testing.T) http.Handler {
 	}
 	agents := []map[string]any{
 		{
-			"id":             "A-1",
-			"computerName":   "host-A-1",
-			"osName":         "macOS",
-			"osType":         "macos",
-			"isActive":       true,
-			"isUpToDate":     true,
-			"externalIp":     "203.0.113.10",
-			"lastIpToMgmt":   "10.0.0.10",
-			"siteId":         "S-1",
-			"groupId":        "G-1",
-			"lastActiveDate": "2026-04-23T01:00:00Z",
-			"updatedAt":      "2026-04-23T01:00:00Z",
+			"id":                   "A-1",
+			"computerName":         "host-A-1",
+			"osName":               "macOS",
+			"osType":               "macos",
+			"isActive":             true,
+			"isUpToDate":           true,
+			"externalIp":           "203.0.113.10",
+			"lastIpToMgmt":         "10.0.0.10",
+			"lastLoggedInUserName": "owner@writer.com",
+			"siteId":               "S-1",
+			"groupId":              "G-1",
+			"lastActiveDate":       "2026-04-23T01:00:00Z",
+			"updatedAt":            "2026-04-23T01:00:00Z",
 		},
 		{
 			"id":             "A-2",


### PR DESCRIPTION
## Summary
- Emit SentinelOne agent user context from logged-in/OS username fields.
- Strong-link email-like user values while preserving username-only weak identifiers.

## Testing
- go test ./sources/sentinelone -run TestCheckDiscoverAndReadLiveAgents -count=1 -v
- go test ./internal/sourceprojection -run 'TestProjectSentinelOneAgentUserNameEmailLinksOwnerIdentity|TestProjectSentinelOneAgentUserNameOnlySkipsStrongOwnerIdentityEdges|TestProjectSentinelOneAgentLinksOwnerIdentity' -count=1 -v\n- make test\n- make lint