### PR TITLE
Link security contact emails

### DIFF
--- a/internal/sourceprojection/aurelius.go
+++ b/internal/sourceprojection/aurelius.go
@@ -242,6 +242,7 @@ func aureliusPolicyExceptionProjections(event *cerebrov1.EventEnvelope) ([]*port
 		if vulnerabilityURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), exceptionURN, vulnerabilityURN, relationRepresents, map[string]string{"event_id": event.GetId()}))
 		}
+		addSecurityContactEmailLink(entities, links, tenantID, event.GetSourceId(), event, exceptionURN, firstAttribute(attrs, "approver"), "approver")
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)

--- a/internal/sourceprojection/aurelius_test.go
+++ b/internal/sourceprojection/aurelius_test.go
@@ -526,3 +526,32 @@ func TestProjectAureliusPolicyExceptionPrefersExceptionIDIdentity(t *testing.T) 
 		t.Fatalf("policy exception keyed by cve_id despite exception_id; entities=%v", state.entities)
 	}
 }
+
+func TestProjectAureliusPolicyExceptionLinksApproverEmailIdentity(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "aurelius-policy-exception-approver",
+		TenantId: "writer",
+		SourceId: "aurelius",
+		Kind:     "aurelius.policy_exception",
+		Payload: mustJSON(t, map[string]any{
+			"approver":   "security@example.com",
+			"cve_id":     "CVE-2026-1111",
+			"expires_at": "2026-06-01T00:00:00Z",
+			"status":     "active",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	exceptionURN := "urn:cerebro:writer:aurelius_policy_exception:CVE-2026-1111"
+	identityURN := "urn:cerebro:writer:identity:email:security@example.com"
+	assertProjectedLink(t, state, exceptionURN, relationAssociatedWith, identityURN)
+	link := state.links[exceptionURN+"|"+relationAssociatedWith+"|"+identityURN]
+	if got := link.Attributes["contact_type"]; got != "approver" {
+		t.Fatalf("contact_type = %q, want approver", got)
+	}
+}

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -243,6 +243,7 @@ func grcVendorProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEnt
 		addEntity(entities, grcUserEntity(tenantID, event.GetSourceId(), ownerURN, ownerID, map[string]string{"user_id": ownerID, "source_system": provider}))
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), vendorURN, ownerURN, relationOwnedBy, map[string]string{"event_id": event.GetId()}))
 	}
+	addSecurityContactEmailLink(entities, links, tenantID, event.GetSourceId(), event, vendorURN, firstAttribute(attrs, "account_manager_email", "security_contact_email", "contact_email"), "account_manager")
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
@@ -1076,6 +1077,31 @@ func addGRCUserOwnerLink(entities map[string]*ports.ProjectedEntity, links map[s
 	ownerURN := grcUserURN(tenantID, provider, ownerID)
 	addEntity(entities, grcUserEntity(tenantID, sourceID, ownerURN, ownerID, map[string]string{"user_id": ownerID, "source_system": provider}))
 	addLink(links, projectedLink(tenantID, sourceID, fromURN, ownerURN, relationOwnedBy, map[string]string{"event_id": event.GetId()}))
+}
+
+func addSecurityContactEmailLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, email string, contactType string) {
+	normalizedEmail := normalizeIdentifier(extractEmailIdentifier(email))
+	fromURN = strings.TrimSpace(fromURN)
+	if fromURN == "" || normalizedEmail == "" {
+		return
+	}
+	identityURN := projectionURN(tenantID, "identity", "email", normalizedEmail)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        identityURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "identity.email",
+		Label:      normalizedEmail,
+		Attributes: map[string]string{"value": normalizedEmail},
+	})
+	linkAttrs := map[string]string{
+		"confidence":   "0.90",
+		"contact_type": strings.TrimSpace(contactType),
+		"event_id":     event.GetId(),
+		"match_type":   "contact_email",
+	}
+	addProjectedAttribute(linkAttrs, "at", eventObservedAt(event))
+	addLink(links, projectedLink(tenantID, sourceID, fromURN, identityURN, relationAssociatedWith, linkAttrs))
 }
 
 func addGRCIntegrationLinks(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, provider string, rawIntegrations string, relationshipBy string) {

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -68,6 +68,35 @@ func TestProjectGRCVendorWithOwner(t *testing.T) {
 	assertProjectedLink(t, state, vendorURN, relationHasIdentifier, hostURN)
 }
 
+func TestProjectGRCVendorLinksAccountManagerEmail(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vendor-contact",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vendor",
+		Attributes: map[string]string{
+			"provider":              "vanta",
+			"vendor_id":             "vendor-1",
+			"name":                  "Acme SaaS",
+			"account_manager_email": "manager@example.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	vendorURN := "urn:cerebro:writer:vendor:vanta:vendor-1"
+	identityURN := "urn:cerebro:writer:identity:email:manager@example.com"
+	assertProjectedLink(t, state, vendorURN, relationAssociatedWith, identityURN)
+	link := state.links[vendorURN+"|"+relationAssociatedWith+"|"+identityURN]
+	if got := link.Attributes["contact_type"]; got != "account_manager" {
+		t.Fatalf("contact_type = %q, want account_manager", got)
+	}
+}
+
 func TestProjectGRCDocumentLinksURLAndCategory(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)


### PR DESCRIPTION
## Summary
- Associate policy-exception approver emails and vendor contact emails with canonical email identities.
- Use existing graph relation vocabulary and add focused regression coverage.

## Testing
- go test ./internal/sourceprojection -run 'TestProjectAureliusPolicyExceptionLinksApproverEmailIdentity|TestProjectGRCVendorLinksAccountManagerEmail|TestProjectAureliusPolicyExceptionOmitsBlankOptionalMetadata|TestProjectGRCVendorWithOwner' -count=1 -v\n- make test\n- make lint