### PR TITLE
Link AWS scoped principals in cloud paths

### DIFF
--- a/internal/sourceprojection/cloud.go
+++ b/internal/sourceprojection/cloud.go
@@ -353,6 +353,7 @@ func cloudPrivilegePathProjections(event *cerebrov1.EventEnvelope, profile ident
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID), event.GetOccurredAt())
+		addAWSPrincipalIdentifierLinks(entities, links, tenantID, event.GetSourceId(), event, subjectURN, profile, attributes, subjectType, subjectID, attributes["subject_login"], attributes["subject_name"], attributes["subject_arn"], attributes["principal_arn"])
 	}
 	if targetURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{
@@ -403,6 +404,7 @@ func cloudEffectivePermissionProjections(event *cerebrov1.EventEnvelope, profile
 			Attributes: map[string]string{"email": subjectEmail, "subject_type": subjectType},
 		})
 		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), subjectURN, firstNonEmpty(subjectEmail, subjectID), event.GetOccurredAt())
+		addAWSPrincipalIdentifierLinks(entities, links, tenantID, event.GetSourceId(), event, subjectURN, profile, attributes, subjectType, subjectID, attributes["subject_login"], attributes["subject_name"], attributes["subject_arn"], attributes["principal_arn"])
 	}
 	if resourceURN != "" {
 		addEntity(entities, &ports.ProjectedEntity{

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -2928,6 +2928,7 @@ func TestProjectCloudExposureAndPrivilegePaths(t *testing.T) {
 	assertProjectedLink(t, state, "urn:cerebro:writer:aws_network_interface:eni-1", relationAttachedTo, "urn:cerebro:writer:aws_ec2_instance:i-network-1")
 	assertProjectedLink(t, state, "urn:cerebro:writer:aws_elastic_ip:eipalloc-1", relationAssociatedWith, "urn:cerebro:writer:aws_ec2_instance:i-eip-1")
 	assertProjectedLink(t, state, "urn:cerebro:writer:aws_role:arn:aws:iam::999999999999:role/ExternalAdmin", relationCanAssume, "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/AdminRole")
+	assertProjectedLink(t, state, "urn:cerebro:writer:aws_role:arn:aws:iam::999999999999:role/ExternalAdmin", relationRepresentsIdentity, "urn:cerebro:writer:identity:login:aws:999999999999:role:externaladmin")
 	assertProjectedLink(t, state, "urn:cerebro:writer:gcp_user:admin@writer.com", relationCanImpersonate, "urn:cerebro:writer:gcp_service_account:sa@writer-prod.iam.gserviceaccount.com")
 	assertProjectedLink(t, state, "urn:cerebro:writer:azure_service_principal:sp-1", relationAssignedTo, "urn:cerebro:writer:azure_service_principal:sp-resource-1")
 }
@@ -3066,6 +3067,7 @@ func TestProjectAWSEffectivePermissionWithoutRoleIDSkipsRoleNode(t *testing.T) {
 			"resource_name": "writer-bucket",
 			"resource_type": "bucket",
 			"role_name":     "ReadOnlyAccess",
+			"subject_login": "analyst",
 			"subject_id":    "analyst@writer.com",
 			"subject_type":  "user",
 		},
@@ -3082,6 +3084,7 @@ func TestProjectAWSEffectivePermissionWithoutRoleIDSkipsRoleNode(t *testing.T) {
 	}
 	resourceURN := "urn:cerebro:writer:aws_bucket:arn:aws:s3:::writer-bucket"
 	assertProjectedLink(t, state, "urn:cerebro:writer:aws_user:analyst@writer.com", relationCanPerform, resourceURN)
+	assertProjectedLink(t, state, "urn:cerebro:writer:aws_user:analyst@writer.com", relationRepresentsIdentity, "urn:cerebro:writer:identity:login:aws:123456789012:user:analyst")
 }
 
 func TestProjectEffectivePermissionsKubernetesRuntimeAndData(t *testing.T) {


### PR DESCRIPTION
Summary:
- Adds AWS scoped principal identity links for cloud privilege paths and effective permissions.
- Covers both ARN-derived and login-derived scoped identifiers.

Tests:
- make test
- make lint