### PR TITLE
Link Kubernetes workload identity targets

### DIFF
--- a/internal/sourceprojection/kubernetes.go
+++ b/internal/sourceprojection/kubernetes.go
@@ -119,6 +119,7 @@ func kubernetesWorkloadIdentityBindingProjections(event *cerebrov1.EventEnvelope
 			Label:      firstNonEmpty(attributes["target_name"], targetEmail, targetID),
 			Attributes: map[string]string{"target_id": targetID, "target_type": targetType},
 		})
+		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), targetURN, targetEmail, event.GetOccurredAt())
 	}
 	if serviceAccountURN != "" && targetURN != "" {
 		relation := cloudPrivilegeRelation(attributes)

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -3251,7 +3251,11 @@ func TestProjectKubernetesWorkloadIdentityBindingAddsContainmentLinks(t *testing
 	assertProjectedLink(t, state, serviceAccountURN, relationBelongsTo, namespaceURN)
 	assertProjectedLink(t, state, namespaceURN, relationBelongsTo, clusterURN)
 	assertProjectedLink(t, state, clusterURN, relationBelongsTo, "urn:cerebro:writer:cloud_account:writer-prod")
-	assertProjectedLink(t, state, serviceAccountURN, relationCanImpersonate, "urn:cerebro:writer:gcp_service_account:payments-sa@writer-prod.iam.gserviceaccount.com")
+	targetURN := "urn:cerebro:writer:gcp_service_account:payments-sa@writer-prod.iam.gserviceaccount.com"
+	targetIdentityURN := "urn:cerebro:writer:identity:email:payments-sa@writer-prod.iam.gserviceaccount.com"
+	assertProjectedLink(t, state, serviceAccountURN, relationCanImpersonate, targetURN)
+	assertProjectedLink(t, state, targetURN, relationRepresentsIdentity, targetIdentityURN)
+	assertProjectedLink(t, state, "urn:cerebro:writer:identifier:email:payments-sa@writer-prod.iam.gserviceaccount.com", relationRepresentsIdentity, targetIdentityURN)
 }
 
 func TestProjectKubernetesWorkloadFallbackURNIncludesKind(t *testing.T) {


### PR DESCRIPTION
Summary:
- Links workload identity binding target emails to canonical identities.
- Adds regression coverage for target email traversal.

Tests:
- make test
- make lint