### PR TITLE
Project security tooling consumers

### DIFF
--- a/internal/sourceprojection/security_spine.go
+++ b/internal/sourceprojection/security_spine.go
@@ -81,6 +81,7 @@ func securityToolingMapToolProjections(event *cerebrov1.EventEnvelope) ([]*ports
 			"agent_role":       attrs["agent_role"],
 			"surfaces":         attrs["surfaces"],
 			"capabilities":     attrs["capabilities"],
+			"consumed_by":      attrs["consumed_by"],
 			"source_product":   attrs["source_product"],
 		}),
 	})
@@ -95,6 +96,11 @@ func securityToolingMapToolProjections(event *cerebrov1.EventEnvelope) ([]*ports
 		dependencyURN := projectionURN(tenantID, "security_tool", dependency)
 		addEntity(entities, &ports.ProjectedEntity{URN: dependencyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "security.tool", Label: dependency, Attributes: map[string]string{"tool_id": dependency}})
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), toolURN, dependencyURN, relationDependsOn, map[string]string{"event_id": event.GetId()}))
+	}
+	for _, consumer := range splitCSV(attrs["consumed_by"]) {
+		consumerURN := projectionURN(tenantID, "security_tool", consumer)
+		addEntity(entities, &ports.ProjectedEntity{URN: consumerURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "security.tool", Label: consumer, Attributes: map[string]string{"tool_id": consumer}})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), consumerURN, toolURN, relationDependsOn, map[string]string{"event_id": event.GetId(), "relationship": "consumed_by"}))
 	}
 	for _, overlap := range splitCSV(attrs["overlaps_with"]) {
 		overlapURN := projectionURN(tenantID, "security_tool", overlap)

--- a/internal/sourceprojection/security_spine_test.go
+++ b/internal/sourceprojection/security_spine_test.go
@@ -76,6 +76,7 @@ func TestProjectSecurityToolingMapTool(t *testing.T) {
 			"lifecycle_owner": "Security",
 			"categories":      "ai_security,dlp",
 			"depends_on":      "security",
+			"consumed_by":     "cosmo,iris",
 			"overlaps_with":   "cosmo",
 		},
 		Payload: mustJSON(t, map[string]any{"id": "agent-gateway", "name": "agent-gateway"}),
@@ -85,8 +86,8 @@ func TestProjectSecurityToolingMapTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 7 {
-		t.Fatalf("EntitiesProjected = %d, want 7", result.EntitiesProjected)
+	if result.EntitiesProjected != 8 {
+		t.Fatalf("EntitiesProjected = %d, want 8", result.EntitiesProjected)
 	}
 	toolURN := "urn:cerebro:writer:security_tool:agent-gateway"
 	ownerURN := "urn:cerebro:writer:owner:security"
@@ -96,7 +97,13 @@ func TestProjectSecurityToolingMapTool(t *testing.T) {
 	assertProjectedLink(t, state, toolURN, relationHasClassification, "urn:cerebro:writer:security_category:ai_security")
 	assertProjectedLink(t, state, toolURN, relationHasClassification, "urn:cerebro:writer:security_category:dlp")
 	assertProjectedLink(t, state, toolURN, relationDependsOn, "urn:cerebro:writer:security_tool:security")
+	assertProjectedLink(t, state, "urn:cerebro:writer:security_tool:cosmo", relationDependsOn, toolURN)
+	assertProjectedLink(t, state, "urn:cerebro:writer:security_tool:iris", relationDependsOn, toolURN)
 	assertProjectedLink(t, state, toolURN, relationAffects, "urn:cerebro:writer:security_tool:cosmo")
+	consumerLink := state.links["urn:cerebro:writer:security_tool:cosmo|"+relationDependsOn+"|"+toolURN]
+	if got := consumerLink.Attributes["relationship"]; got != "consumed_by" {
+		t.Fatalf("consumer link relationship = %q, want consumed_by", got)
+	}
 }
 
 func TestProjectSecurityToolingMapControlMapping(t *testing.T) {


### PR DESCRIPTION
Summary:
- Projects security tooling map consumed_by entries as reverse dependency links.
- Preserves consumed_by context on the tool entity and edge metadata.

Tests:
- make test
- make lint