### PR TITLE
Link Aurelius promotion contacts

### DIFF
--- a/internal/sourceprojection/aurelius.go
+++ b/internal/sourceprojection/aurelius.go
@@ -204,12 +204,36 @@ func aureliusCatalogPromotionProjections(event *cerebrov1.EventEnvelope) ([]*por
 		if trackURN != "" {
 			addLink(links, projectedLink(tenantID, event.GetSourceId(), promotionURN, trackURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
 		}
+		addAureliusContactEmailLink(entities, links, tenantID, event.GetSourceId(), event, promotionURN, firstAttribute(attrs, "promoted_by"), "promoted_by")
 	}
 
 	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
 	return projectedEntities, projectedLinks, nil
 }
 
+func addAureliusContactEmailLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, fromURN string, email string, contactType string) {
+	normalizedEmail := normalizeIdentifier(extractEmailIdentifier(email))
+	if strings.TrimSpace(fromURN) == "" || normalizedEmail == "" {
+		return
+	}
+	identityURN := projectionURN(tenantID, "identity", "email", normalizedEmail)
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        identityURN,
+		TenantID:   tenantID,
+		SourceID:   sourceID,
+		EntityType: "identity.email",
+		Label:      normalizedEmail,
+		Attributes: map[string]string{"value": normalizedEmail},
+	})
+	linkAttrs := map[string]string{
+		"confidence":   "0.90",
+		"contact_type": strings.TrimSpace(contactType),
+		"event_id":     event.GetId(),
+		"match_type":   "contact_email",
+	}
+	addProjectedAttribute(linkAttrs, "at", eventObservedAt(event))
+	addLink(links, projectedLink(tenantID, sourceID, fromURN, identityURN, relationAssociatedWith, linkAttrs))
+}
 func aureliusPolicyExceptionProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	tenantID, err := tenantID(event)
 	if err != nil {

--- a/internal/sourceprojection/aurelius_test.go
+++ b/internal/sourceprojection/aurelius_test.go
@@ -178,6 +178,34 @@ func TestProjectAureliusSparseImageOmitsEmptyImageMetadata(t *testing.T) {
 	}
 }
 
+func TestProjectAureliusCatalogPromotionLinksPromoterEmail(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "aurelius-catalog-promotion-promoter",
+		TenantId: "writer",
+		SourceId: "aurelius",
+		Kind:     "aurelius.catalog_promotion",
+		Payload: mustJSON(t, map[string]any{
+			"image_digest": "sha256:promoted",
+			"promoted_by":  "security@example.com",
+			"track":        "prod",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	promotionURN := "urn:cerebro:writer:aurelius_catalog_promotion:prod|sha256:promoted"
+	identityURN := "urn:cerebro:writer:identity:email:security@example.com"
+	assertProjectedLink(t, state, promotionURN, relationAssociatedWith, identityURN)
+	link := state.links[promotionURN+"|"+relationAssociatedWith+"|"+identityURN]
+	if got := link.Attributes["contact_type"]; got != "promoted_by" {
+		t.Fatalf("contact_type = %q, want promoted_by", got)
+	}
+}
+
 func TestProjectAureliusDigestOnlyFindingDoesNotCreateArtifactRegistryImage(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)


### PR DESCRIPTION
Summary:
- Associates catalog promotions with email-shaped promoter identities.
- Adds regression coverage for promotion contact traversal.

Tests:
- make test
- make lint