### PR TITLE
fix: deepen Backstage GitHub graph links

### DIFF
--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -675,7 +675,7 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 			addLink(links, projectedLink(tenantID, sourceID, resourceURN, integrationURN, relationBelongsTo, grcIntegrationLinkAttributes(event, integrationID)))
 		}
 		addGRCGitHubRepositoryOrgLink(entities, links, tenantID, sourceID, event, resourceURN, ownerLogin)
-		addGRCGitHubRepositoryAliasLink(entities, links, tenantID, sourceID, event, resourceURN, ref.ResourceName, ownerLogin)
+		addGRCGitHubRepositoryAliasLink(entities, links, tenantID, sourceID, event, resourceURN, provider, resourceType, ref.ResourceName, ownerLogin)
 		addGRCPlatformNetworkLinks(entities, links, tenantID, sourceID, event, resourceURN, ref)
 	}
 }
@@ -719,14 +719,16 @@ func addGRCGitHubRepositoryOrgLink(entities map[string]*ports.ProjectedEntity, l
 	}))
 }
 
-func addGRCGitHubRepositoryAliasLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, codeRepositoryURN string, repository string, ownerLogin string) {
+func addGRCGitHubRepositoryAliasLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, codeRepositoryURN string, provider string, resourceType string, repository string, ownerLogin string) {
 	codeRepositoryURN = strings.TrimSpace(codeRepositoryURN)
+	provider = strings.TrimSpace(provider)
+	resourceType = strings.TrimSpace(resourceType)
 	repository = strings.TrimSpace(repository)
-	if codeRepositoryURN == "" || repository == "" || !strings.Contains(repository, "/") {
+	if provider != "github" || resourceType != "code_repository" || codeRepositoryURN == "" || repository == "" || !strings.Contains(repository, "/") {
 		return
 	}
 	if ownerLogin = strings.TrimSpace(ownerLogin); ownerLogin == "" {
-		ownerLogin = githubRepositoryOwnerLogin("github", "code_repository", repository)
+		ownerLogin = githubRepositoryOwnerLogin(provider, resourceType, repository)
 	}
 	if ownerLogin == "" {
 		return

--- a/internal/sourceprojection/grc.go
+++ b/internal/sourceprojection/grc.go
@@ -675,6 +675,7 @@ func addGRCPlatformAssetLinks(entities map[string]*ports.ProjectedEntity, links 
 			addLink(links, projectedLink(tenantID, sourceID, resourceURN, integrationURN, relationBelongsTo, grcIntegrationLinkAttributes(event, integrationID)))
 		}
 		addGRCGitHubRepositoryOrgLink(entities, links, tenantID, sourceID, event, resourceURN, ownerLogin)
+		addGRCGitHubRepositoryAliasLink(entities, links, tenantID, sourceID, event, resourceURN, ref.ResourceName, ownerLogin)
 		addGRCPlatformNetworkLinks(entities, links, tenantID, sourceID, event, resourceURN, ref)
 	}
 }
@@ -716,6 +717,41 @@ func addGRCGitHubRepositoryOrgLink(entities map[string]*ports.ProjectedEntity, l
 		"owner_login":  ownerLogin,
 		"source_scope": "platform_asset_ref",
 	}))
+}
+
+func addGRCGitHubRepositoryAliasLink(entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink, tenantID string, sourceID string, event *cerebrov1.EventEnvelope, codeRepositoryURN string, repository string, ownerLogin string) {
+	codeRepositoryURN = strings.TrimSpace(codeRepositoryURN)
+	repository = strings.TrimSpace(repository)
+	if codeRepositoryURN == "" || repository == "" || !strings.Contains(repository, "/") {
+		return
+	}
+	if ownerLogin = strings.TrimSpace(ownerLogin); ownerLogin == "" {
+		ownerLogin = githubRepositoryOwnerLogin("github", "code_repository", repository)
+	}
+	if ownerLogin == "" {
+		return
+	}
+	legacyRepoURN := projectionURN(tenantID, "github_repo", repository)
+	if legacyRepoURN == "" {
+		return
+	}
+	addEntity(entities, &ports.ProjectedEntity{
+		URN:        legacyRepoURN,
+		TenantID:   tenantID,
+		SourceID:   "github",
+		EntityType: "github.repo",
+		Label:      repository,
+		Attributes: map[string]string{"owner_login": ownerLogin, "repository": repository},
+	})
+	attrs := map[string]string{
+		"event_id":     event.GetId(),
+		"match_type":   "grc_platform_repository_full_name",
+		"owner_login":  ownerLogin,
+		"source_scope": "platform_asset_ref",
+	}
+	addLink(links, projectedLink(tenantID, sourceID, legacyRepoURN, codeRepositoryURN, relationRepresents, attrs))
+	addLink(links, projectedLink(tenantID, sourceID, codeRepositoryURN, legacyRepoURN, relationRepresents, attrs))
+	addGRCGitHubRepositoryOrgLink(entities, links, tenantID, sourceID, event, legacyRepoURN, ownerLogin)
 }
 
 func githubRepositoryOwnerLogin(provider string, resourceType string, resourceName string) string {

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -929,6 +929,7 @@ func TestProjectGRCVulnerableAssetLabelsAndLinksGitHubRepoToIntegration(t *testi
 	}
 
 	repoURN := "urn:cerebro:writer:github_code_repository:1242719606"
+	legacyRepoURN := "urn:cerebro:writer:github_repo:Writer/cerebro"
 	orgURN := "urn:cerebro:writer:github_org:Writer"
 	integrationURN := "urn:cerebro:writer:source:vanta:integration:github"
 
@@ -945,7 +946,13 @@ func TestProjectGRCVulnerableAssetLabelsAndLinksGitHubRepoToIntegration(t *testi
 	if org := state.entities[orgURN]; org == nil || org.EntityType != "github.org" {
 		t.Fatalf("github org entity %q missing or wrong type: %#v", orgURN, org)
 	}
+	if legacyRepo := state.entities[legacyRepoURN]; legacyRepo == nil || legacyRepo.EntityType != "github.repo" {
+		t.Fatalf("legacy github repo entity %q missing or wrong type: %#v", legacyRepoURN, legacyRepo)
+	}
 	assertProjectedLink(t, state, repoURN, relationBelongsTo, orgURN)
+	assertProjectedLink(t, state, legacyRepoURN, relationBelongsTo, orgURN)
+	assertProjectedLink(t, state, legacyRepoURN, relationRepresents, repoURN)
+	assertProjectedLink(t, state, repoURN, relationRepresents, legacyRepoURN)
 	assertProjectedLink(t, state, repoURN, relationBelongsTo, integrationURN)
 }
 

--- a/internal/sourceprojection/grc_test.go
+++ b/internal/sourceprojection/grc_test.go
@@ -956,6 +956,34 @@ func TestProjectGRCVulnerableAssetLabelsAndLinksGitHubRepoToIntegration(t *testi
 	assertProjectedLink(t, state, repoURN, relationBelongsTo, integrationURN)
 }
 
+func TestProjectGRCVulnerableAssetDoesNotCreateGitHubAliasForNonGitHubSlashName(t *testing.T) {
+	state := &projectionRecorder{}
+	service := New(state, nil)
+
+	_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+		Id:       "grc-vulnerable-asset-non-github-slash",
+		TenantId: "writer",
+		SourceId: "grc",
+		Kind:     "grc.vulnerable_asset",
+		Attributes: map[string]string{
+			"provider":            "vanta",
+			"target_id":           "non-github-slash-asset",
+			"integration_id":      "aws",
+			"platform_asset_refs": `[{"provider":"aws","resource_id":"arn:aws:s3:::prod-app","resource_name":"prod/app","resource_type":"bucket"}]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+
+	if entity := state.entities["urn:cerebro:writer:github_repo:prod/app"]; entity != nil {
+		t.Fatalf("non-github platform asset unexpectedly created github repo alias: %#v", entity)
+	}
+	if entity := state.entities["urn:cerebro:writer:github_org:prod"]; entity != nil {
+		t.Fatalf("non-github platform asset unexpectedly created github org: %#v", entity)
+	}
+}
+
 func TestGRCAWSResourceTypeFromARNHandlesAPIGatewayCustomDomain(t *testing.T) {
 	got := grcAWSResourceTypeFromARN("arn:aws:apigateway:us-east-1::/domainnames/api.writer.com")
 	if got != "apigateway_domain" {

--- a/internal/sourceprojection/security_spine.go
+++ b/internal/sourceprojection/security_spine.go
@@ -177,9 +177,26 @@ func addRepoLink(entities map[string]*ports.ProjectedEntity, links map[string]*p
 	if repository == "" {
 		return
 	}
+	owner, _, hasOwner := strings.Cut(repository, "/")
+	owner = strings.TrimSpace(owner)
 	repoURN := projectionURN(tenantID, "github_repo", repository)
-	addEntity(entities, &ports.ProjectedEntity{URN: repoURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "github.repo", Label: repository, Attributes: map[string]string{"repository": repository}})
+	repoAttrs := map[string]string{"repository": repository}
+	if hasOwner && owner != "" {
+		repoAttrs["owner_login"] = owner
+	}
+	addEntity(entities, &ports.ProjectedEntity{URN: repoURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "github.repo", Label: repository, Attributes: repoAttrs})
 	addLink(links, projectedLink(tenantID, event.GetSourceId(), fromURN, repoURN, relationBelongsTo, map[string]string{"event_id": event.GetId(), "match_type": "repository"}))
+	if !hasOwner || owner == "" {
+		return
+	}
+	orgURN := projectionURN(tenantID, "github_org", owner)
+	addEntity(entities, &ports.ProjectedEntity{URN: orgURN, TenantID: tenantID, SourceID: "github", EntityType: "github.org", Label: owner, Attributes: map[string]string{"org": owner, "owner_login": owner}})
+	addLink(links, projectedLink(tenantID, event.GetSourceId(), repoURN, orgURN, relationBelongsTo, map[string]string{
+		"event_id":     event.GetId(),
+		"match_type":   "repository_owner",
+		"owner_login":  owner,
+		"source_scope": "repository_name",
+	}))
 }
 
 func backstageComponentEntityType(componentType string) string {

--- a/internal/sourceprojection/security_spine_test.go
+++ b/internal/sourceprojection/security_spine_test.go
@@ -42,13 +42,14 @@ func TestProjectBackstageComponent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 4 {
-		t.Fatalf("EntitiesProjected = %d, want 4", result.EntitiesProjected)
+	if result.EntitiesProjected != 5 {
+		t.Fatalf("EntitiesProjected = %d, want 5", result.EntitiesProjected)
 	}
 	serviceURN := "urn:cerebro:writer:service:component/default/cerebro"
 	ownerURN := "urn:cerebro:writer:owner:platform/security"
 	systemURN := "urn:cerebro:writer:system:security"
 	repoURN := "urn:cerebro:writer:github_repo:WriterInternal/cerebro"
+	orgURN := "urn:cerebro:writer:github_org:WriterInternal"
 	entity := state.entities[serviceURN]
 	if entity == nil || entity.EntityType != "service" || entity.Attributes["lifecycle"] != "production" {
 		t.Fatalf("service entity = %#v, want production service", entity)
@@ -56,6 +57,7 @@ func TestProjectBackstageComponent(t *testing.T) {
 	assertProjectedLink(t, state, serviceURN, relationOwnedBy, ownerURN)
 	assertProjectedLink(t, state, serviceURN, relationBelongsTo, systemURN)
 	assertProjectedLink(t, state, serviceURN, relationBelongsTo, repoURN)
+	assertProjectedLink(t, state, repoURN, relationBelongsTo, orgURN)
 }
 
 func TestProjectSecurityToolingMapTool(t *testing.T) {
@@ -86,14 +88,16 @@ func TestProjectSecurityToolingMapTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Project() error = %v", err)
 	}
-	if result.EntitiesProjected != 8 {
-		t.Fatalf("EntitiesProjected = %d, want 8", result.EntitiesProjected)
+	if result.EntitiesProjected != 9 {
+		t.Fatalf("EntitiesProjected = %d, want 9", result.EntitiesProjected)
 	}
 	toolURN := "urn:cerebro:writer:security_tool:agent-gateway"
 	ownerURN := "urn:cerebro:writer:owner:security"
 	repoURN := "urn:cerebro:writer:github_repo:WriterInternal/agent-gateway"
+	orgURN := "urn:cerebro:writer:github_org:WriterInternal"
 	assertProjectedLink(t, state, toolURN, relationOwnedBy, ownerURN)
 	assertProjectedLink(t, state, toolURN, relationBelongsTo, repoURN)
+	assertProjectedLink(t, state, repoURN, relationBelongsTo, orgURN)
 	assertProjectedLink(t, state, toolURN, relationHasClassification, "urn:cerebro:writer:security_category:ai_security")
 	assertProjectedLink(t, state, toolURN, relationHasClassification, "urn:cerebro:writer:security_category:dlp")
 	assertProjectedLink(t, state, toolURN, relationDependsOn, "urn:cerebro:writer:security_tool:security")


### PR DESCRIPTION
## Summary
- Link Backstage/security-tool GitHub repo references to GitHub org nodes
- Add full-name github.repo aliases for GRC github.code.repository platform assets
- Add bidirectional represents links between legacy repo aliases and numeric code repository nodes

## Tests
- go test ./sources/backstage ./sources/github ./internal/sourceprojection
- go test ./...