### PR TITLE
Repair missing primary finding graph links

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -68,6 +68,10 @@ type graphIntegrityStore interface {
 	IntegrityChecks(context.Context) ([]graphstore.IntegrityCheck, error)
 }
 
+type graphOpenFindingPrimaryLinkRepairStore interface {
+	RepairOpenFindingPrimaryLinks(context.Context, graphstore.OpenFindingPrimaryLinkRepairRequest) (graphstore.OpenFindingPrimaryLinkRepairResult, error)
+}
+
 type graphIngestRunStore interface {
 	ListIngestRuns(context.Context, graphstore.IngestRunFilter) ([]graphstore.IngestRun, error)
 }
@@ -192,6 +196,11 @@ type graphProjectedEntityCleanupOptions struct {
 	AllowDetach  bool
 }
 
+type graphOpenFindingPrimaryLinkRepairOptions struct {
+	Limit  uint32
+	DryRun bool
+}
+
 type graphProjectedEntityCleanupResult struct {
 	TenantID     string                        `json:"tenant_id"`
 	SourceID     string                        `json:"source_id,omitempty"`
@@ -312,6 +321,22 @@ func runGraph(args []string) error {
 			return printErr
 		}
 		return err
+	case "repair-open-finding-primary-links":
+		options, err := parseGraphOpenFindingPrimaryLinkRepairArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		ctx := context.Background()
+		deps, closeDeps, err := openGraphCleanupDependencies(ctx)
+		if err != nil {
+			return err
+		}
+		defer logClose(closeDeps)
+		result, err := repairOpenFindingPrimaryLinks(ctx, deps, options)
+		if printErr := printJSON(result); printErr != nil {
+			return printErr
+		}
+		return err
 	case "health":
 		return runGraphHealth(args[1:])
 	case "counts", "neighborhood", "paths", "relation-counts", "integrity":
@@ -369,7 +394,7 @@ func runGraph(args []string) error {
 }
 
 func graphUsage() string {
-	return fmt.Sprintf("usage: %s graph [health|counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|cleanup-endpoint-owner-id-links|cleanup-projected-entities|rebuild|inspect] ...", os.Args[0])
+	return fmt.Sprintf("usage: %s graph [health|counts|neighborhood|paths|relation-counts|integrity|cve-impact|package-exposure|asset-vulns|ingest|ingest-runtime|ingest-run|ingest-runs|cleanup-endpoint-owner-id-links|cleanup-projected-entities|repair-open-finding-primary-links|rebuild|inspect] ...", os.Args[0])
 }
 
 func graphIngestUsage() string {
@@ -825,6 +850,17 @@ func cleanupProjectedEntities(ctx context.Context, deps bootstrap.Dependencies, 
 		return result, fmt.Errorf("projected entity cleanup is unsupported by configured stores")
 	}
 	return result, nil
+}
+
+func repairOpenFindingPrimaryLinks(ctx context.Context, deps bootstrap.Dependencies, options graphOpenFindingPrimaryLinkRepairOptions) (graphstore.OpenFindingPrimaryLinkRepairResult, error) {
+	repairer, ok := deps.GraphStore.(graphOpenFindingPrimaryLinkRepairStore)
+	if !ok {
+		return graphstore.OpenFindingPrimaryLinkRepairResult{DryRun: options.DryRun}, fmt.Errorf("open finding primary link repair is unsupported by configured graph store")
+	}
+	return repairer.RepairOpenFindingPrimaryLinks(ctx, graphstore.OpenFindingPrimaryLinkRepairRequest{
+		Limit:  options.Limit,
+		DryRun: options.DryRun,
+	})
 }
 
 func parseGraphNeighborhoodArgs(args []string) (string, int, error) {
@@ -1347,6 +1383,54 @@ func parseGraphProjectedEntityCleanupArgs(args []string) (graphProjectedEntityCl
 	}
 	if !options.DryRun && strings.TrimSpace(options.FindingID) != "" && !options.AllowDetach {
 		return graphProjectedEntityCleanupOptions{}, fmt.Errorf("allow_detach=true is required before deleting finding-scoped projected entities")
+	}
+	return options, nil
+}
+
+func parseGraphOpenFindingPrimaryLinkRepairArgs(args []string) (graphOpenFindingPrimaryLinkRepairOptions, error) {
+	options := graphOpenFindingPrimaryLinkRepairOptions{DryRun: true}
+	apply := false
+	dryRunSet := false
+	for _, arg := range args {
+		key, value, ok := strings.Cut(arg, "=")
+		if !ok {
+			return graphOpenFindingPrimaryLinkRepairOptions{}, usageError(fmt.Sprintf("expected key=value argument, got %q", arg))
+		}
+		switch strings.TrimSpace(key) {
+		case "limit":
+			parsed, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+			if err != nil {
+				return graphOpenFindingPrimaryLinkRepairOptions{}, fmt.Errorf("parse limit: %w", err)
+			}
+			if parsed == 0 {
+				return graphOpenFindingPrimaryLinkRepairOptions{}, fmt.Errorf("limit must be positive")
+			}
+			options.Limit = uint32(parsed)
+		case "dry_run":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphOpenFindingPrimaryLinkRepairOptions{}, fmt.Errorf("parse dry_run: %w", err)
+			}
+			options.DryRun = parsed
+			dryRunSet = true
+		case "apply":
+			parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+			if err != nil {
+				return graphOpenFindingPrimaryLinkRepairOptions{}, fmt.Errorf("parse apply: %w", err)
+			}
+			apply = parsed
+		default:
+			return graphOpenFindingPrimaryLinkRepairOptions{}, usageError(fmt.Sprintf("unsupported graph repair-open-finding-primary-links argument %q", key))
+		}
+	}
+	if apply {
+		if dryRunSet && options.DryRun {
+			return graphOpenFindingPrimaryLinkRepairOptions{}, fmt.Errorf("apply=true conflicts with dry_run=true")
+		}
+		options.DryRun = false
+	}
+	if !options.DryRun && !apply {
+		return graphOpenFindingPrimaryLinkRepairOptions{}, fmt.Errorf("apply=true is required before repairing open finding primary links")
 	}
 	return options, nil
 }

--- a/cmd/cerebro/graph_test.go
+++ b/cmd/cerebro/graph_test.go
@@ -327,6 +327,74 @@ func TestCleanupProjectedEntitiesAllowsStateStoreOnly(t *testing.T) {
 	}
 }
 
+func TestParseGraphOpenFindingPrimaryLinkRepairArgsDefaultsDryRun(t *testing.T) {
+	options, err := parseGraphOpenFindingPrimaryLinkRepairArgs([]string{"limit=7"})
+	if err != nil {
+		t.Fatalf("parseGraphOpenFindingPrimaryLinkRepairArgs() error = %v", err)
+	}
+	if !options.DryRun || options.Limit != 7 {
+		t.Fatalf("options = %#v, want dry-run limit 7", options)
+	}
+}
+
+func TestParseGraphOpenFindingPrimaryLinkRepairArgsRequiresApply(t *testing.T) {
+	if _, err := parseGraphOpenFindingPrimaryLinkRepairArgs([]string{"dry_run=false"}); err == nil {
+		t.Fatal("parseGraphOpenFindingPrimaryLinkRepairArgs() error = nil, want apply requirement")
+	}
+	options, err := parseGraphOpenFindingPrimaryLinkRepairArgs([]string{"apply=true"})
+	if err != nil {
+		t.Fatalf("parseGraphOpenFindingPrimaryLinkRepairArgs(apply) error = %v", err)
+	}
+	if options.DryRun {
+		t.Fatalf("DryRun = true, want apply mode")
+	}
+}
+
+func TestRepairOpenFindingPrimaryLinksCreatesMissingEdge(t *testing.T) {
+	store := newGraphTestStore()
+	resourceURN := "urn:cerebro:writer:resource:primary"
+	findingURN := "urn:cerebro:writer:finding:finding-1"
+	if err := store.UpsertProjectedEntity(context.Background(), &ports.ProjectedEntity{
+		URN:        resourceURN,
+		TenantID:   "writer",
+		SourceID:   "example",
+		EntityType: "resource",
+	}); err != nil {
+		t.Fatalf("UpsertProjectedEntity(resource) error = %v", err)
+	}
+	if err := store.UpsertProjectedEntity(context.Background(), &ports.ProjectedEntity{
+		URN:        findingURN,
+		TenantID:   "writer",
+		SourceID:   "example",
+		RuntimeID:  "example-runtime",
+		EntityType: "finding",
+		Attributes: map[string]string{
+			"status":               "open",
+			"primary_resource_urn": resourceURN,
+		},
+	}); err != nil {
+		t.Fatalf("UpsertProjectedEntity(finding) error = %v", err)
+	}
+
+	dryRun, err := repairOpenFindingPrimaryLinks(context.Background(), bootstrap.Dependencies{GraphStore: store}, graphOpenFindingPrimaryLinkRepairOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("repairOpenFindingPrimaryLinks(dry-run) error = %v", err)
+	}
+	if dryRun.LinksMatched != 1 || dryRun.LinksCreated != 0 || !dryRun.DryRun {
+		t.Fatalf("dryRun result = %#v, want one matched and no creates", dryRun)
+	}
+	applied, err := repairOpenFindingPrimaryLinks(context.Background(), bootstrap.Dependencies{GraphStore: store}, graphOpenFindingPrimaryLinkRepairOptions{DryRun: false})
+	if err != nil {
+		t.Fatalf("repairOpenFindingPrimaryLinks(apply) error = %v", err)
+	}
+	if applied.LinksMatched != 1 || applied.LinksCreated != 1 || applied.DryRun {
+		t.Fatalf("applied result = %#v, want one created", applied)
+	}
+	if _, ok := store.links[resourceURN+"|has_finding|"+findingURN]; !ok {
+		t.Fatal("missing repaired has_finding edge")
+	}
+}
+
 func TestGraphIngestCheckpointIDScrubsSensitiveConfig(t *testing.T) {
 	options := graphIngestOptions{
 		SourceID: "github",

--- a/cmd/cerebro/graph_test_store_test.go
+++ b/cmd/cerebro/graph_test_store_test.go
@@ -145,6 +145,51 @@ func (s *graphTestStore) IntegrityChecks(context.Context) ([]graphstore.Integrit
 	}, nil
 }
 
+func (s *graphTestStore) RepairOpenFindingPrimaryLinks(_ context.Context, request graphstore.OpenFindingPrimaryLinkRepairRequest) (graphstore.OpenFindingPrimaryLinkRepairResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	limit := int(request.Limit)
+	if limit <= 0 {
+		limit = 25
+	}
+	result := graphstore.OpenFindingPrimaryLinkRepairResult{DryRun: request.DryRun}
+	for _, finding := range s.entities {
+		if result.LinksMatched >= uint32(limit) {
+			break
+		}
+		if finding.EntityType != "finding" || finding.Attributes["status"] != "open" {
+			continue
+		}
+		primaryURN := strings.TrimSpace(finding.Attributes["primary_resource_urn"])
+		if primaryURN == "" {
+			continue
+		}
+		resource := s.entities[primaryURN]
+		if resource == nil || resource.TenantID != finding.TenantID {
+			continue
+		}
+		link := &ports.ProjectedLink{
+			TenantID:  finding.TenantID,
+			SourceID:  finding.SourceID,
+			RuntimeID: finding.RuntimeID,
+			FromURN:   primaryURN,
+			ToURN:     finding.URN,
+			Relation:  "has_finding",
+		}
+		key := testLinkKey(link)
+		if _, ok := s.links[key]; ok {
+			continue
+		}
+		result.LinksMatched++
+		if request.DryRun {
+			continue
+		}
+		s.links[key] = link
+		result.LinksCreated++
+	}
+	return result, nil
+}
+
 func (s *graphTestStore) PathPatterns(_ context.Context, limit int) ([]graphstore.PathPattern, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -282,6 +282,58 @@ func (s *Store) IntegrityChecks(ctx context.Context) ([]IntegrityCheck, error) {
 	return checks, nil
 }
 
+// RepairOpenFindingPrimaryLinks restores missing has_finding edges for open findings whose primary resource node exists.
+func (s *Store) RepairOpenFindingPrimaryLinks(ctx context.Context, request graphstore.OpenFindingPrimaryLinkRepairRequest) (graphstore.OpenFindingPrimaryLinkRepairResult, error) {
+	if err := s.requireConfigured(); err != nil {
+		return graphstore.OpenFindingPrimaryLinkRepairResult{}, err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return graphstore.OpenFindingPrimaryLinkRepairResult{}, err
+	}
+	limit := int64(request.Limit)
+	if limit <= 0 {
+		limit = 25
+	}
+	params := map[string]any{"limit": limit}
+	result := graphstore.OpenFindingPrimaryLinkRepairResult{DryRun: request.DryRun}
+	query := `MATCH (finding:Entity {entity_type: 'finding'})
+WITH finding, coalesce(finding.attributes_json, '') AS attrs
+WHERE attrs CONTAINS '"status":"open"' AND attrs CONTAINS '"primary_resource_urn":"'
+WITH finding, split(split(attrs, '"primary_resource_urn":"')[1], '"')[0] AS primary_urn
+WHERE primary_urn <> ''
+MATCH (resource:Entity {tenant_id: finding.tenant_id, urn: primary_urn})
+WHERE NOT EXISTS { MATCH (resource)-[:RELATION {relation: 'has_finding'}]->(finding) }
+WITH resource, finding
+ORDER BY finding.urn
+LIMIT $limit`
+	if request.DryRun {
+		value, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+			return queryOneValue(ctx, tx, query+`
+RETURN count(finding)`, params)
+		})
+		if err != nil {
+			return graphstore.OpenFindingPrimaryLinkRepairResult{}, fmt.Errorf("query open finding primary link repair candidates: %w", err)
+		}
+		result.LinksMatched = uint32(toInt64(value))
+		return result, nil
+	}
+	value, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		return queryOneValue(ctx, tx, query+`
+MERGE (resource)-[r:RELATION {relation: 'has_finding'}]->(finding)
+ON CREATE SET r.attributes_json = '{}', r.attributes_version = 0
+SET r.tenant_id = finding.tenant_id,
+    r.source_id = coalesce(finding.source_id, ''),
+    r.runtime_id = coalesce(finding.runtime_id, '')
+RETURN count(r)`, params)
+	})
+	if err != nil {
+		return graphstore.OpenFindingPrimaryLinkRepairResult{}, fmt.Errorf("repair open finding primary links: %w", err)
+	}
+	result.LinksMatched = uint32(toInt64(value))
+	result.LinksCreated = result.LinksMatched
+	return result, nil
+}
+
 func integrityCheckDefinitions() ([]IntegrityCheck, []string) {
 	checks := []IntegrityCheck{
 		{Name: "tenant_mismatched_relations", Expected: 0},

--- a/internal/graphstore/types.go
+++ b/internal/graphstore/types.go
@@ -29,6 +29,19 @@ type IntegrityCheck struct {
 	Passed   bool   `json:"passed"`
 }
 
+// OpenFindingPrimaryLinkRepairRequest scopes an idempotent finding graph repair pass.
+type OpenFindingPrimaryLinkRepairRequest struct {
+	Limit  uint32
+	DryRun bool
+}
+
+// OpenFindingPrimaryLinkRepairResult reports missing primary finding links found or created.
+type OpenFindingPrimaryLinkRepairResult struct {
+	LinksMatched uint32 `json:"links_matched"`
+	LinksCreated uint32 `json:"links_created"`
+	DryRun       bool   `json:"dry_run"`
+}
+
 // PathPattern captures one grouped two-hop graph pattern.
 type PathPattern struct {
 	FromType       string `json:"from_type"`


### PR DESCRIPTION
## Summary
- add an idempotent graph repair command for missing primary finding links
- keep repair dry-run by default and require explicit apply mode
- add focused coverage for parsing and link repair behavior

## Testing
- go test ./cmd/cerebro ./internal/graphstore/... -count=1
- make test