### PR TITLE
Annotate identity link quality

### DIFF
--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -2066,22 +2066,32 @@ func addSameActorEmailLink(entities map[string]*ports.ProjectedEntity, links map
 func identifierEvidenceAttributes(rawValue string, identifierType string, normalizedValue string, eventID string, occurredAt *timestamppb.Timestamp) map[string]string {
 	matchType := "login"
 	confidence := "0.60"
+	identityQuality := "weak_login"
+	identityScope := "source_local"
+	crossSourceIdentity := "false"
 	value := strings.TrimSpace(rawValue)
 	if identifierType == "identifier.email" {
+		identityScope = "global"
+		crossSourceIdentity = "true"
 		if strings.EqualFold(normalizeIdentifier(value), normalizedValue) {
 			matchType = "exact_email"
 			confidence = "0.95"
+			identityQuality = "stable_email"
 		} else {
 			matchType = "extracted_email"
 			confidence = "0.85"
+			identityQuality = "extracted_email"
 		}
 	}
 	attributes := map[string]string{
-		"confidence":       confidence,
-		"evidence_type":    "shared_identifier",
-		"identifier_type":  strings.TrimPrefix(identifierType, "identifier."),
-		"identifier_value": normalizedValue,
-		"match_type":       matchType,
+		"confidence":            confidence,
+		"cross_source_identity": crossSourceIdentity,
+		"evidence_type":         "shared_identifier",
+		"identifier_type":       strings.TrimPrefix(identifierType, "identifier."),
+		"identifier_value":      normalizedValue,
+		"identity_quality":      identityQuality,
+		"identity_scope":        identityScope,
+		"match_type":            matchType,
 	}
 	if normalizedEventID := strings.TrimSpace(eventID); normalizedEventID != "" {
 		attributes["source_event_id"] = normalizedEventID

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -137,6 +137,40 @@ func projectionRecorderCleanupMatches(request ports.ProjectionCleanupRequest, en
 	return false
 }
 
+func TestIdentifierEvidenceAttributesMarksEmailAsGlobalCrossSource(t *testing.T) {
+	attrs := identifierEvidenceAttributes(" Alice@Writer.COM ", "identifier.email", "alice@writer.com", "event-1", nil)
+
+	if got := attrs["identity_quality"]; got != "stable_email" {
+		t.Fatalf("identity_quality = %q, want stable_email", got)
+	}
+	if got := attrs["identity_scope"]; got != "global" {
+		t.Fatalf("identity_scope = %q, want global", got)
+	}
+	if got := attrs["cross_source_identity"]; got != "true" {
+		t.Fatalf("cross_source_identity = %q, want true", got)
+	}
+	if got := attrs["confidence"]; got != "0.95" {
+		t.Fatalf("confidence = %q, want 0.95", got)
+	}
+}
+
+func TestIdentifierEvidenceAttributesMarksLoginAsSourceLocalWeak(t *testing.T) {
+	attrs := identifierEvidenceAttributes("alice", "identifier.login", "alice", "event-1", nil)
+
+	if got := attrs["identity_quality"]; got != "weak_login" {
+		t.Fatalf("identity_quality = %q, want weak_login", got)
+	}
+	if got := attrs["identity_scope"]; got != "source_local" {
+		t.Fatalf("identity_scope = %q, want source_local", got)
+	}
+	if got := attrs["cross_source_identity"]; got != "false" {
+		t.Fatalf("cross_source_identity = %q, want false", got)
+	}
+	if got := attrs["confidence"]; got != "0.60" {
+		t.Fatalf("confidence = %q, want 0.60", got)
+	}
+}
+
 func TestProjectGitHubPullRequest(t *testing.T) {
 	state := &projectionRecorder{}
 	graph := &projectionRecorder{}


### PR DESCRIPTION
## Summary
- add identity quality/scope metadata to identifier evidence links
- mark email identifiers as global cross-source anchors and login identifiers as source-local weak joins
- add regression coverage for email and login evidence metadata

## Tests
- go test ./internal/sourceprojection -count=1
- golangci-lint run --timeout 5m ./internal/sourceprojection
- git diff --check