### PR TITLE
fix: suppress broad graph path summaries

### DIFF
--- a/cmd/cerebro/graph_test_store_test.go
+++ b/cmd/cerebro/graph_test_store_test.go
@@ -199,6 +199,9 @@ func (s *graphTestStore) PathPatterns(_ context.Context, limit int) ([]graphstor
 			if first.ToURN != second.FromURN {
 				continue
 			}
+			if graphstore.SuppressTwoHopPath(first.Relation, second.Relation) {
+				continue
+			}
 			from := s.entities[first.FromURN]
 			via := s.entities[first.ToURN]
 			to := s.entities[second.ToURN]

--- a/internal/graphrebuild/memory_graph.go
+++ b/internal/graphrebuild/memory_graph.go
@@ -247,6 +247,9 @@ func (s *memoryGraphStore) PathPatterns(_ context.Context, limit int) ([]graphst
 			if first.ToURN != second.FromURN {
 				continue
 			}
+			if graphstore.SuppressTwoHopPath(first.Relation, second.Relation) {
+				continue
+			}
 			from := s.entities[first.FromURN]
 			via := s.entities[first.ToURN]
 			to := s.entities[second.ToURN]
@@ -312,6 +315,9 @@ func (s *memoryGraphStore) SampleTraversals(_ context.Context, limit int) ([]gra
 	for _, first := range s.links {
 		for _, second := range s.links {
 			if first.ToURN != second.FromURN {
+				continue
+			}
+			if graphstore.SuppressTwoHopPath(first.Relation, second.Relation) {
 				continue
 			}
 			from := s.entities[first.FromURN]

--- a/internal/graphrebuild/memory_graph_test.go
+++ b/internal/graphrebuild/memory_graph_test.go
@@ -90,6 +90,54 @@ func TestMemoryGraphStoreIntegrityChecksLinkageGuardrails(t *testing.T) {
 	}
 }
 
+func TestMemoryGraphStoreSuppressesBroadTwoHopPathSummaries(t *testing.T) {
+	store, err := newMemoryGraphStore()
+	if err != nil {
+		t.Fatalf("newMemoryGraphStore() error = %v", err)
+	}
+	scratch := store.(*memoryGraphStore)
+	ctx := context.Background()
+
+	for _, entity := range []*ports.ProjectedEntity{
+		{URN: "urn:target", TenantID: "writer", SourceID: "grc", EntityType: "grc.target", Label: "target"},
+		{URN: "urn:source", TenantID: "writer", SourceID: "grc", EntityType: "source", Label: "source"},
+		{URN: "urn:finding", TenantID: "writer", SourceID: "grc", EntityType: "finding", Label: "finding"},
+		{URN: "urn:vulnerability", TenantID: "writer", SourceID: "grc", EntityType: "vulnerability", Label: "vulnerability"},
+		{URN: "urn:actor", TenantID: "writer", SourceID: "github", EntityType: "github.user", Label: "actor"},
+	} {
+		if err := scratch.UpsertProjectedEntity(ctx, entity); err != nil {
+			t.Fatalf("UpsertProjectedEntity(%s) error = %v", entity.URN, err)
+		}
+	}
+	for _, link := range []*ports.ProjectedLink{
+		{TenantID: "writer", SourceID: "grc", FromURN: "urn:target", Relation: "belongs_to", ToURN: "urn:source"},
+		{TenantID: "writer", SourceID: "grc", FromURN: "urn:source", Relation: "has_finding", ToURN: "urn:finding"},
+		{TenantID: "writer", SourceID: "grc", FromURN: "urn:target", Relation: "affected_by", ToURN: "urn:vulnerability"},
+		{TenantID: "writer", SourceID: "grc", FromURN: "urn:vulnerability", Relation: "has_finding", ToURN: "urn:finding"},
+		{TenantID: "writer", SourceID: "github", FromURN: "urn:actor", Relation: "acted_on", ToURN: "urn:source"},
+	} {
+		if err := scratch.UpsertProjectedLink(ctx, link); err != nil {
+			t.Fatalf("UpsertProjectedLink(%s -> %s) error = %v", link.FromURN, link.ToURN, err)
+		}
+	}
+
+	patterns, err := scratch.PathPatterns(ctx, 10)
+	if err != nil {
+		t.Fatalf("PathPatterns() error = %v", err)
+	}
+	if len(patterns) != 1 || patterns[0].FirstRelation != "affected_by" || patterns[0].SecondRelation != "has_finding" {
+		t.Fatalf("PathPatterns() = %#v, want only direct vulnerability finding pattern", patterns)
+	}
+
+	traversals, err := scratch.SampleTraversals(ctx, 10)
+	if err != nil {
+		t.Fatalf("SampleTraversals() error = %v", err)
+	}
+	if len(traversals) != 1 || traversals[0].FirstRelation != "affected_by" || traversals[0].SecondRelation != "has_finding" {
+		t.Fatalf("SampleTraversals() = %#v, want only direct vulnerability finding traversal", traversals)
+	}
+}
+
 func memoryIntegrityActual(checks []graphstore.IntegrityCheck, name string) int64 {
 	for _, check := range checks {
 		if check.Name == name {

--- a/internal/graphrebuild/service_test.go
+++ b/internal/graphrebuild/service_test.go
@@ -198,14 +198,14 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if got := result.StageConfirmations[5].AssertionsFailed; got != 0 {
 		t.Fatalf("verify_integrity assertions_failed = %d, want 0", got)
 	}
-	if got := result.StageConfirmations[6].PatternsVerified; got != 7 {
-		t.Fatalf("verify_path_patterns patterns_verified = %d, want 7", got)
+	if got := result.StageConfirmations[6].PatternsVerified; got != 6 {
+		t.Fatalf("verify_path_patterns patterns_verified = %d, want 6", got)
 	}
 	if got := result.StageConfirmations[7].TopologyBuckets; got != 4 {
 		t.Fatalf("verify_topology topology_buckets = %d, want 4", got)
 	}
-	if got := result.StageConfirmations[8].TraversalsVerified; got != 7 {
-		t.Fatalf("verify_traversals traversals_verified = %d, want 7", got)
+	if got := result.StageConfirmations[8].TraversalsVerified; got != 6 {
+		t.Fatalf("verify_traversals traversals_verified = %d, want 6", got)
 	}
 	if len(result.ReadPages) != 2 {
 		t.Fatalf("len(ReadPages) = %d, want 2", len(result.ReadPages))
@@ -250,8 +250,8 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if !containsAssertion(result.GraphAssertions, "aws_public_endpoints_without_instance_link", 0, 0, true) {
 		t.Fatalf("GraphAssertions missing aws_public_endpoints_without_instance_link: %#v", result.GraphAssertions)
 	}
-	if len(result.GraphPathPatterns) != 7 {
-		t.Fatalf("len(GraphPathPatterns) = %d, want 7", len(result.GraphPathPatterns))
+	if len(result.GraphPathPatterns) != 6 {
+		t.Fatalf("len(GraphPathPatterns) = %d, want 6", len(result.GraphPathPatterns))
 	}
 	if !containsPathPatternPreview(result.GraphPathPatterns, "github.user -[authored]-> github.pull_request -[belongs_to]-> github.repo", 1) {
 		t.Fatalf("GraphPathPatterns missing authored pattern: %#v", result.GraphPathPatterns)
@@ -271,8 +271,8 @@ func TestRebuildDryRunProjectsRuntimeIntoTemporaryGraph(t *testing.T) {
 	if !containsTopologyPreview(result.GraphTopology, "intermediates", 4) {
 		t.Fatalf("GraphTopology missing intermediates bucket: %#v", result.GraphTopology)
 	}
-	if len(result.GraphTraversals) != 7 {
-		t.Fatalf("len(GraphTraversals) = %d, want 7", len(result.GraphTraversals))
+	if len(result.GraphTraversals) != 6 {
+		t.Fatalf("len(GraphTraversals) = %d, want 6", len(result.GraphTraversals))
 	}
 	if !containsTraversalPath(result.GraphTraversals, "octocat -[authored]-> writer/cerebro#418 -[belongs_to]-> writer/cerebro") {
 		t.Fatalf("GraphTraversals missing authored path: %#v", result.GraphTraversals)
@@ -654,23 +654,21 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 	if got := countValue(result.GraphEntityTypes, "github.repo"); got != 1 {
 		t.Fatalf("graph entity type github.repo = %d, want 1", got)
 	}
-	// The new identifier.login -> identity.login reverse edge opens
-	// additional traversal paths starting at the identifier and identity
-	// nodes (they used to be terminal sinks).
-	if len(result.GraphTraversals) != 5 {
-		t.Fatalf("len(GraphTraversals) = %d, want 5", len(result.GraphTraversals))
+	// The broad acted_on audit chain is suppressed from traversal previews.
+	if len(result.GraphTraversals) != 4 {
+		t.Fatalf("len(GraphTraversals) = %d, want 4", len(result.GraphTraversals))
 	}
 	if got := result.StageConfirmations[5].AssertionsPassed; got != 7 {
 		t.Fatalf("verify_integrity assertions_passed = %d, want 7", got)
 	}
-	if got := result.StageConfirmations[6].PatternsVerified; got != 5 {
-		t.Fatalf("verify_path_patterns patterns_verified = %d, want 5", got)
+	if got := result.StageConfirmations[6].PatternsVerified; got != 4 {
+		t.Fatalf("verify_path_patterns patterns_verified = %d, want 4", got)
 	}
 	if got := result.StageConfirmations[7].TopologyBuckets; got != 4 {
 		t.Fatalf("verify_topology topology_buckets = %d, want 4", got)
 	}
-	if got := result.StageConfirmations[8].TraversalsVerified; got != 5 {
-		t.Fatalf("verify_traversals traversals_verified = %d, want 5", got)
+	if got := result.StageConfirmations[8].TraversalsVerified; got != 4 {
+		t.Fatalf("verify_traversals traversals_verified = %d, want 4", got)
 	}
 	if len(result.ReadPages) != 1 {
 		t.Fatalf("len(ReadPages) = %d, want 1", len(result.ReadPages))
@@ -680,19 +678,19 @@ func TestRebuildDryRunDefaultsToSinglePage(t *testing.T) {
 		t.Fatalf("len(EventProjections) = %d, want 1", len(result.EventProjections))
 	}
 	assertEventProjection(t, result.EventProjections[0], "github-audit-1", "github.audit", 5, 6, 5, 6)
-	if len(result.GraphPathPatterns) != 5 {
-		t.Fatalf("len(GraphPathPatterns) = %d, want 5", len(result.GraphPathPatterns))
+	if len(result.GraphPathPatterns) != 4 {
+		t.Fatalf("len(GraphPathPatterns) = %d, want 4", len(result.GraphPathPatterns))
 	}
-	if !containsPathPatternPreview(result.GraphPathPatterns, "github.user -[acted_on]-> github.repo -[belongs_to]-> github.org", 1) {
-		t.Fatalf("GraphPathPatterns missing acted_on pattern: %#v", result.GraphPathPatterns)
+	if containsPathPatternPreview(result.GraphPathPatterns, "github.user -[acted_on]-> github.repo -[belongs_to]-> github.org", 1) {
+		t.Fatalf("GraphPathPatterns included suppressed acted_on pattern: %#v", result.GraphPathPatterns)
 	}
 	// identifier.login moved from sinks_only to intermediate after gaining
 	// the reverse represents_identity edge to identity.login.
 	if !containsTopologyPreview(result.GraphTopology, "isolated", 0) || !containsTopologyPreview(result.GraphTopology, "sources_only", 1) || !containsTopologyPreview(result.GraphTopology, "sinks_only", 1) || !containsTopologyPreview(result.GraphTopology, "intermediates", 3) {
 		t.Fatalf("GraphTopology unexpected values: %#v", result.GraphTopology)
 	}
-	if !containsTraversalPath(result.GraphTraversals, "octocat -[acted_on]-> writer/cerebro -[belongs_to]-> writer") {
-		t.Fatalf("GraphTraversals missing acted_on path: %#v", result.GraphTraversals)
+	if containsTraversalPath(result.GraphTraversals, "octocat -[acted_on]-> writer/cerebro -[belongs_to]-> writer") {
+		t.Fatalf("GraphTraversals included suppressed acted_on path: %#v", result.GraphTraversals)
 	}
 }
 

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -50,6 +50,13 @@ type IngestCheckpoint = graphstore.IngestCheckpoint
 type IngestRun = graphstore.IngestRun
 type IngestRunFilter = graphstore.IngestRunFilter
 
+func suppressedPathParams() map[string]any {
+	return map[string]any{
+		"suppressed_relation_pairs": graphstore.SuppressedTwoHopRelationPairKeys(),
+		"suppressed_relations":      graphstore.SuppressedTwoHopRelations(),
+	}
+}
+
 // Open opens a Neo4j-backed graph projection store.
 func Open(cfg config.GraphStoreConfig) (*Store, error) {
 	uri := strings.TrimSpace(cfg.Neo4jURI)
@@ -165,12 +172,16 @@ func (s *Store) SampleTraversals(ctx context.Context, limit int) (_ []Traversal,
 		return nil, nil
 	}
 	var traversals []Traversal
-	query := fmt.Sprintf(`MATCH (src:Entity)-[left:RELATION]->(mid:Entity)-[right:RELATION]->(dst:Entity)
+	query := fmt.Sprintf(`MATCH (src:Entity)-[left:RELATION]->(mid:Entity)
+WHERE NOT (left.relation IN $suppressed_relations)
+MATCH (mid)-[right:RELATION]->(dst:Entity)
+WHERE NOT (right.relation IN $suppressed_relations)
+  AND NOT ((left.relation + '|' + right.relation) IN $suppressed_relation_pairs)
 RETURN src.urn, src.label, left.relation, mid.urn, mid.label, right.relation, dst.urn, dst.label
 ORDER BY src.urn, left.relation, mid.urn, right.relation, dst.urn LIMIT %d`, limit)
 	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
 		traversals = traversals[:0]
-		result, err := tx.Run(ctx, query, nil)
+		result, err := tx.Run(ctx, query, suppressedPathParams())
 		if err != nil {
 			return nil, err
 		}
@@ -203,12 +214,16 @@ func (s *Store) PathPatterns(ctx context.Context, limit int) (_ []PathPattern, e
 		return nil, nil
 	}
 	var patterns []PathPattern
-	query := fmt.Sprintf(`MATCH (src:Entity)-[left:RELATION]->(mid:Entity)-[right:RELATION]->(dst:Entity)
+	query := fmt.Sprintf(`MATCH (src:Entity)-[left:RELATION]->(mid:Entity)
+WHERE NOT (left.relation IN $suppressed_relations)
+MATCH (mid)-[right:RELATION]->(dst:Entity)
+WHERE NOT (right.relation IN $suppressed_relations)
+  AND NOT ((left.relation + '|' + right.relation) IN $suppressed_relation_pairs)
 RETURN src.entity_type, left.relation, mid.entity_type, right.relation, dst.entity_type, count(*)
 ORDER BY count(*) DESC, src.entity_type, left.relation, mid.entity_type, right.relation, dst.entity_type LIMIT %d`, limit)
 	if _, err := s.read(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
 		patterns = patterns[:0]
-		result, err := tx.Run(ctx, query, nil)
+		result, err := tx.Run(ctx, query, suppressedPathParams())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -225,6 +225,23 @@ func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	if neighborhood.Root == nil || neighborhood.Root.URN != user.URN || len(neighborhood.Neighbors) != 1 || len(neighborhood.Relations) != 1 {
 		t.Fatalf("GetEntityNeighborhood() = %#v", neighborhood)
 	}
+	target := &ports.ProjectedEntity{URN: "urn:cerebro:writer:grc_target:target-1", TenantID: "writer", SourceID: "grc", EntityType: "grc.target", Label: "target-1"}
+	source := &ports.ProjectedEntity{URN: "urn:cerebro:writer:source:grc", TenantID: "writer", SourceID: "grc", EntityType: "source", Label: "grc"}
+	finding := &ports.ProjectedEntity{URN: "urn:cerebro:writer:finding:finding-1", TenantID: "writer", SourceID: "grc", EntityType: "finding", Label: "finding-1"}
+	for _, entity := range []*ports.ProjectedEntity{target, source, finding} {
+		if err := store.UpsertProjectedEntity(ctx, entity); err != nil {
+			t.Fatalf("UpsertProjectedEntity(%s) error = %v", entity.URN, err)
+		}
+	}
+	for _, link := range []*ports.ProjectedLink{
+		{TenantID: "writer", SourceID: "grc", FromURN: target.URN, Relation: "belongs_to", ToURN: source.URN},
+		{TenantID: "writer", SourceID: "grc", FromURN: source.URN, Relation: "has_finding", ToURN: finding.URN},
+		{TenantID: "writer", SourceID: "github", FromURN: user.URN, Relation: "acted_on", ToURN: source.URN},
+	} {
+		if err := store.UpsertProjectedLink(ctx, link); err != nil {
+			t.Fatalf("UpsertProjectedLink(%s -> %s) error = %v", link.FromURN, link.ToURN, err)
+		}
+	}
 	patterns, err := store.PathPatterns(ctx, 5)
 	if err != nil {
 		t.Fatalf("PathPatterns() error = %v", err)
@@ -243,8 +260,8 @@ func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Topology() error = %v", err)
 	}
-	if topology.SourcesOnly != 1 || topology.Intermediates != 1 || topology.SinksOnly != 1 {
-		t.Fatalf("Topology() = %#v, want one source-only, one intermediate, and one sink-only", topology)
+	if topology.SourcesOnly != 2 || topology.Intermediates != 2 || topology.SinksOnly != 2 {
+		t.Fatalf("Topology() = %#v, want two source-only, two intermediate, and two sink-only nodes", topology)
 	}
 	checks, err := store.IntegrityChecks(ctx)
 	if err != nil {

--- a/internal/graphstore/path_filter.go
+++ b/internal/graphstore/path_filter.go
@@ -1,0 +1,46 @@
+package graphstore
+
+type TwoHopRelationPair struct {
+	First  string
+	Second string
+}
+
+var suppressedTwoHopRelationPairs = []TwoHopRelationPair{
+	{First: "belongs_to", Second: "has_finding"},
+	{First: "represents", Second: "has_finding"},
+	{First: "contains", Second: "has_finding"},
+	{First: "contains", Second: "affected_by"},
+	{First: "belongs_to", Second: "affected_by"},
+	{First: "represents", Second: "affected_by"},
+}
+
+var suppressedTwoHopRelations = []string{"acted_on"}
+
+// SuppressTwoHopPath reports whether a two-hop path is too broad for summary traversal.
+func SuppressTwoHopPath(firstRelation string, secondRelation string) bool {
+	for _, relation := range suppressedTwoHopRelations {
+		if firstRelation == relation || secondRelation == relation {
+			return true
+		}
+	}
+	for _, pair := range suppressedTwoHopRelationPairs {
+		if firstRelation == pair.First && secondRelation == pair.Second {
+			return true
+		}
+	}
+	return false
+}
+
+func SuppressedTwoHopRelations() []string {
+	result := make([]string, len(suppressedTwoHopRelations))
+	copy(result, suppressedTwoHopRelations)
+	return result
+}
+
+func SuppressedTwoHopRelationPairKeys() []string {
+	result := make([]string, 0, len(suppressedTwoHopRelationPairs))
+	for _, pair := range suppressedTwoHopRelationPairs {
+		result = append(result, pair.First+"|"+pair.Second)
+	}
+	return result
+}

--- a/internal/graphstore/path_filter_test.go
+++ b/internal/graphstore/path_filter_test.go
@@ -1,0 +1,29 @@
+package graphstore
+
+import "testing"
+
+func TestSuppressTwoHopPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		first  string
+		second string
+		want   bool
+	}{
+		{name: "container finding gravity well", first: "belongs_to", second: "has_finding", want: true},
+		{name: "identity finding gravity well", first: "represents", second: "has_finding", want: true},
+		{name: "package vulnerability gravity well", first: "contains", second: "affected_by", want: true},
+		{name: "activity fanout first hop", first: "acted_on", second: "belongs_to", want: true},
+		{name: "activity fanout second hop", first: "has_identifier", second: "acted_on", want: true},
+		{name: "direct vulnerability signal", first: "affected_by", second: "has_finding", want: false},
+		{name: "attack path signal", first: "can_perform", second: "has_finding", want: false},
+		{name: "ownership signal", first: "owned_by", second: "has_finding", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := SuppressTwoHopPath(test.first, test.second); got != test.want {
+				t.Fatalf("SuppressTwoHopPath(%q, %q) = %v, want %v", test.first, test.second, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- suppress broad two-hop graph path summaries that create gravity wells
- filter matching Neo4j, memory, and test graphstore path previews
- preserve direct vulnerability, attack-path, ownership, and classification path signals

## Validation
- go test ./internal/graphstore ./internal/graphstore/neo4j ./internal/graphrebuild ./cmd/cerebro -count=1
- go test ./... -count=1
- make verify