### PR TITLE
Add risk delta simulation report

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -6385,8 +6385,8 @@ func TestReportEndpoints(t *testing.T) {
 		t.Fatalf("decode /reports response: %v", err)
 	}
 	reportsPayload, ok := listPayload["reports"].([]any)
-	if !ok || len(reportsPayload) != 1 {
-		t.Fatalf("/reports payload = %#v, want 1 entry", listPayload["reports"])
+	if !ok || len(reportsPayload) != 2 {
+		t.Fatalf("/reports payload = %#v, want 2 entries", listPayload["reports"])
 	}
 
 	runReq, err := http.NewRequest(http.MethodPost, server.URL+"/reports/finding-summary/runs?tenant_id=writer&runtime_id=writer-okta-audit&graph_limit=2", nil)
@@ -6482,8 +6482,8 @@ func TestReportEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListReportDefinitions() error = %v", err)
 	}
-	if len(listReportsResp.Msg.GetReports()) != 1 {
-		t.Fatalf("len(ListReportDefinitions.Reports) = %d, want 1", len(listReportsResp.Msg.GetReports()))
+	if len(listReportsResp.Msg.GetReports()) != 2 {
+		t.Fatalf("len(ListReportDefinitions.Reports) = %d, want 2", len(listReportsResp.Msg.GetReports()))
 	}
 	runReportResp, err := client.RunReport(context.Background(), connect.NewRequest(&cerebrov1.RunReportRequest{
 		ReportId: "finding-summary",

--- a/internal/findings/risk_simulation.go
+++ b/internal/findings/risk_simulation.go
@@ -69,13 +69,14 @@ func SimulateRiskDelta(records []*ports.FindingRecord, options RiskDeltaSimulati
 	}
 	beforeRecords := cloneRiskDeltaFindings(records)
 	beforeNeighborhoods := cloneRiskDeltaNeighborhoods(options.GraphNeighborhoods)
-	beforePaths := AnalyzeFindingAttackPaths(beforeRecords, beforeNeighborhoods, FindingExposureAnalysisOptions{Limit: limit, GraphNeighborhoods: beforeNeighborhoods})
-	before := riskDeltaSnapshot(beforeRecords, beforePaths, options.Now)
+	beforeAllPaths := AnalyzeFindingAttackPaths(beforeRecords, beforeNeighborhoods, FindingExposureAnalysisOptions{GraphNeighborhoods: beforeNeighborhoods})
+	before := riskDeltaSnapshot(beforeRecords, beforeAllPaths, options.Now)
 
 	afterRecords, findingReasons := applyRiskDeltaFindingScenario(beforeRecords, scenarioType, targetURN, beforeNeighborhoods)
 	afterNeighborhoods, graphReasons := applyRiskDeltaGraphScenario(beforeNeighborhoods, scenarioType, targetURN)
-	afterPaths := AnalyzeFindingAttackPaths(afterRecords, afterNeighborhoods, FindingExposureAnalysisOptions{Limit: limit, GraphNeighborhoods: afterNeighborhoods})
-	after := riskDeltaSnapshot(afterRecords, afterPaths, options.Now)
+	afterAllPaths := AnalyzeFindingAttackPaths(afterRecords, afterNeighborhoods, FindingExposureAnalysisOptions{GraphNeighborhoods: afterNeighborhoods})
+	afterPaths := limitRiskDeltaAttackPaths(afterAllPaths, limit)
+	after := riskDeltaSnapshot(afterRecords, afterAllPaths, options.Now)
 
 	riskScoreReduction := before.TotalRiskScore - after.TotalRiskScore
 	attackPathScoreReduction := before.TotalAttackPathScore - after.TotalAttackPathScore
@@ -92,11 +93,18 @@ func SimulateRiskDelta(records []*ports.FindingRecord, options RiskDeltaSimulati
 		AttackPathScoreReduction: attackPathScoreReduction,
 		AttackPathCountReduction: attackPathCountReduction,
 		AffectedFindings:         riskDeltaFindingImpacts(beforeRecords, afterRecords, options.Now),
-		AddedAttackPaths:         addedRiskDeltaAttackPaths(beforePaths, afterPaths),
-		RemovedAttackPaths:       removedRiskDeltaAttackPaths(beforePaths, afterPaths),
+		AddedAttackPaths:         addedRiskDeltaAttackPaths(beforeAllPaths, afterAllPaths),
+		RemovedAttackPaths:       removedRiskDeltaAttackPaths(beforeAllPaths, afterAllPaths),
 		RemainingAttackPaths:     afterPaths,
 		Reasons:                  uniqueSortedStrings(append(findingReasons, graphReasons...)),
 	}
+}
+
+func limitRiskDeltaAttackPaths(paths []FindingAttackPath, limit int) []FindingAttackPath {
+	if limit <= 0 || len(paths) <= limit {
+		return paths
+	}
+	return paths[:limit]
 }
 
 func riskDeltaSnapshot(records []*ports.FindingRecord, paths []FindingAttackPath, now time.Time) RiskDeltaSnapshot {

--- a/internal/findings/risk_simulation.go
+++ b/internal/findings/risk_simulation.go
@@ -1,0 +1,534 @@
+package findings
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+const (
+	RiskDeltaScenarioCompromiseIdentity   = "compromise_identity"
+	RiskDeltaScenarioPatchVulnerability   = "patch_vulnerability"
+	RiskDeltaScenarioRemovePrivilege      = "remove_privilege"
+	RiskDeltaScenarioRemovePublicExposure = "remove_public_exposure"
+)
+
+type RiskDeltaSimulationOptions struct {
+	ScenarioType       string
+	TargetURN          string
+	Limit              int
+	GraphNeighborhoods map[string]*ports.EntityNeighborhood
+	Now                time.Time
+}
+
+type RiskDeltaSimulationReport struct {
+	ScenarioType             string                   `json:"scenario_type"`
+	TargetURN                string                   `json:"target_urn"`
+	Before                   RiskDeltaSnapshot        `json:"before"`
+	After                    RiskDeltaSnapshot        `json:"after"`
+	RiskScoreChange          int                      `json:"risk_score_change"`
+	AttackPathScoreChange    int                      `json:"attack_path_score_change"`
+	AttackPathCountChange    int                      `json:"attack_path_count_change"`
+	RiskScoreReduction       int                      `json:"risk_score_reduction"`
+	AttackPathScoreReduction int                      `json:"attack_path_score_reduction"`
+	AttackPathCountReduction int                      `json:"attack_path_count_reduction"`
+	AffectedFindings         []RiskDeltaFindingImpact `json:"affected_findings"`
+	AddedAttackPaths         []FindingAttackPath      `json:"added_attack_paths,omitempty"`
+	RemovedAttackPaths       []FindingAttackPath      `json:"removed_attack_paths,omitempty"`
+	RemainingAttackPaths     []FindingAttackPath      `json:"remaining_attack_paths,omitempty"`
+	Reasons                  []string                 `json:"reasons,omitempty"`
+}
+
+type RiskDeltaSnapshot struct {
+	FindingCount         int `json:"finding_count"`
+	TotalRiskScore       int `json:"total_risk_score"`
+	AttackPathCount      int `json:"attack_path_count"`
+	TotalAttackPathScore int `json:"total_attack_path_score"`
+}
+
+type RiskDeltaFindingImpact struct {
+	FindingID       string   `json:"finding_id"`
+	RuleID          string   `json:"rule_id,omitempty"`
+	ResourceURNs    []string `json:"resource_urns,omitempty"`
+	BeforeRiskScore int      `json:"before_risk_score"`
+	AfterRiskScore  int      `json:"after_risk_score"`
+	Reduction       int      `json:"reduction"`
+	AddedReasons    []string `json:"added_reasons,omitempty"`
+	RemovedReasons  []string `json:"removed_reasons,omitempty"`
+}
+
+func SimulateRiskDelta(records []*ports.FindingRecord, options RiskDeltaSimulationOptions) RiskDeltaSimulationReport {
+	scenarioType := strings.TrimSpace(options.ScenarioType)
+	targetURN := strings.TrimSpace(options.TargetURN)
+	limit := options.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	beforeRecords := cloneRiskDeltaFindings(records)
+	beforeNeighborhoods := cloneRiskDeltaNeighborhoods(options.GraphNeighborhoods)
+	beforePaths := AnalyzeFindingAttackPaths(beforeRecords, beforeNeighborhoods, FindingExposureAnalysisOptions{Limit: limit, GraphNeighborhoods: beforeNeighborhoods})
+	before := riskDeltaSnapshot(beforeRecords, beforePaths, options.Now)
+
+	afterRecords, findingReasons := applyRiskDeltaFindingScenario(beforeRecords, scenarioType, targetURN, beforeNeighborhoods)
+	afterNeighborhoods, graphReasons := applyRiskDeltaGraphScenario(beforeNeighborhoods, scenarioType, targetURN)
+	afterPaths := AnalyzeFindingAttackPaths(afterRecords, afterNeighborhoods, FindingExposureAnalysisOptions{Limit: limit, GraphNeighborhoods: afterNeighborhoods})
+	after := riskDeltaSnapshot(afterRecords, afterPaths, options.Now)
+
+	riskScoreReduction := before.TotalRiskScore - after.TotalRiskScore
+	attackPathScoreReduction := before.TotalAttackPathScore - after.TotalAttackPathScore
+	attackPathCountReduction := before.AttackPathCount - after.AttackPathCount
+	return RiskDeltaSimulationReport{
+		ScenarioType:             scenarioType,
+		TargetURN:                targetURN,
+		Before:                   before,
+		After:                    after,
+		RiskScoreChange:          -riskScoreReduction,
+		AttackPathScoreChange:    -attackPathScoreReduction,
+		AttackPathCountChange:    -attackPathCountReduction,
+		RiskScoreReduction:       riskScoreReduction,
+		AttackPathScoreReduction: attackPathScoreReduction,
+		AttackPathCountReduction: attackPathCountReduction,
+		AffectedFindings:         riskDeltaFindingImpacts(beforeRecords, afterRecords, options.Now),
+		AddedAttackPaths:         addedRiskDeltaAttackPaths(beforePaths, afterPaths),
+		RemovedAttackPaths:       removedRiskDeltaAttackPaths(beforePaths, afterPaths),
+		RemainingAttackPaths:     afterPaths,
+		Reasons:                  uniqueSortedStrings(append(findingReasons, graphReasons...)),
+	}
+}
+
+func riskDeltaSnapshot(records []*ports.FindingRecord, paths []FindingAttackPath, now time.Time) RiskDeltaSnapshot {
+	totalRisk := 0
+	for _, record := range records {
+		totalRisk += AnalyzeFindingRiskContext(record, now).Score
+	}
+	totalPathScore := 0
+	for _, path := range paths {
+		totalPathScore += path.Score
+	}
+	return RiskDeltaSnapshot{
+		FindingCount:         len(nonNilFindings(records)),
+		TotalRiskScore:       totalRisk,
+		AttackPathCount:      len(paths),
+		TotalAttackPathScore: totalPathScore,
+	}
+}
+
+func applyRiskDeltaFindingScenario(records []*ports.FindingRecord, scenarioType string, targetURN string, neighborhoods map[string]*ports.EntityNeighborhood) ([]*ports.FindingRecord, []string) {
+	after := cloneRiskDeltaFindings(records)
+	reasons := []string{}
+	identityBlastRadius := riskDeltaCompromiseIdentityBlastRadius(neighborhoods, targetURN)
+	for _, record := range after {
+		if record == nil {
+			continue
+		}
+		matchesTarget := riskDeltaFindingMatchesTarget(record, targetURN)
+		switch scenarioType {
+		case RiskDeltaScenarioRemovePublicExposure:
+			if !matchesTarget {
+				continue
+			}
+			if removeRiskDeltaAttributes(record.Attributes, "internet_exposed", "public", "externally_exposed", "external_exposure", "is_public", "is_internet_facing", "reachable", "directly_reachable", "internet_reachable", "can_reach") {
+				reasons = append(reasons, "removed_public_exposure_signals")
+			}
+		case RiskDeltaScenarioRemovePrivilege:
+			if !matchesTarget {
+				continue
+			}
+			if removeRiskDeltaAttributes(record.Attributes, "privileged", "actor_privileged", "admin", "is_admin", "has_admin", "can_admin", "admin_reachable", "privileged_access", "has_admin_path") {
+				reasons = append(reasons, "removed_privilege_signals")
+			}
+		case RiskDeltaScenarioPatchVulnerability:
+			if !matchesTarget {
+				continue
+			}
+			if removeRiskDeltaAttributes(record.Attributes, "is_kev", "kev", "known_exploited", "known_exploited_vulnerability", "epss_score", "epss", "exploit_probability", "exploit_available", "public_exploit", "weaponized_exploit", "cvss_score", "cvss", "base_score", "exploit_maturity", "exploit_status") {
+				reasons = append(reasons, "removed_vulnerability_exploitability_signals")
+			}
+		case RiskDeltaScenarioCompromiseIdentity:
+			if !matchesTarget && !riskDeltaFindingMatchesAnyTarget(record, identityBlastRadius.resourceURNs) {
+				continue
+			}
+			if record.Attributes == nil {
+				record.Attributes = map[string]string{}
+			}
+			record.Attributes["active_threat"] = "true"
+			record.Attributes["actor_urn"] = targetURN
+			record.Attributes["compromised_identity_urn"] = targetURN
+			record.Attributes["blast_radius"] = riskDeltaMaxIntString(record.Attributes["blast_radius"], len(identityBlastRadius.resourceURNs))
+			if identityBlastRadius.privileged {
+				record.Attributes["privileged_access"] = "true"
+			}
+			reasons = append(reasons, "modeled_compromised_identity")
+			if len(identityBlastRadius.resourceURNs) > 0 {
+				reasons = append(reasons, "modeled_identity_blast_radius")
+			}
+			if identityBlastRadius.privileged {
+				reasons = append(reasons, "modeled_privileged_identity_path")
+			}
+		}
+	}
+	return after, reasons
+}
+
+func applyRiskDeltaGraphScenario(neighborhoods map[string]*ports.EntityNeighborhood, scenarioType string, targetURN string) (map[string]*ports.EntityNeighborhood, []string) {
+	after := cloneRiskDeltaNeighborhoods(neighborhoods)
+	reasons := []string{}
+	for _, neighborhood := range after {
+		if neighborhood == nil {
+			continue
+		}
+		filtered := make([]*ports.NeighborhoodRelation, 0, len(neighborhood.Relations))
+		for _, relation := range neighborhood.Relations {
+			if relation == nil {
+				continue
+			}
+			if riskDeltaRelationRemoved(relation, scenarioType, targetURN) {
+				reasons = append(reasons, "removed_graph_relation:"+strings.TrimSpace(relation.Relation))
+				continue
+			}
+			filtered = append(filtered, relation)
+		}
+		neighborhood.Relations = filtered
+	}
+	return after, reasons
+}
+
+func riskDeltaRelationRemoved(relation *ports.NeighborhoodRelation, scenarioType string, targetURN string) bool {
+	if relation == nil || !riskDeltaRelationTouchesTarget(relation, targetURN) {
+		return false
+	}
+	switch scenarioType {
+	case RiskDeltaScenarioRemovePublicExposure:
+		return relation.Relation == "can_reach"
+	case RiskDeltaScenarioRemovePrivilege:
+		switch relation.Relation {
+		case "can_admin", "can_assume", "can_impersonate", "can_perform":
+			return true
+		}
+	case RiskDeltaScenarioPatchVulnerability:
+		switch relation.Relation {
+		case "affected_by", "found_vulnerability":
+			return true
+		}
+	}
+	return false
+}
+
+type riskDeltaIdentityBlastRadius struct {
+	resourceURNs map[string]struct{}
+	privileged   bool
+}
+
+func riskDeltaCompromiseIdentityBlastRadius(neighborhoods map[string]*ports.EntityNeighborhood, targetURN string) riskDeltaIdentityBlastRadius {
+	targetURN = strings.TrimSpace(targetURN)
+	result := riskDeltaIdentityBlastRadius{resourceURNs: map[string]struct{}{}}
+	if targetURN == "" || len(neighborhoods) == 0 {
+		return result
+	}
+	adjacency := map[string][]*ports.NeighborhoodRelation{}
+	for _, neighborhood := range neighborhoods {
+		if neighborhood == nil {
+			continue
+		}
+		for _, relation := range neighborhood.Relations {
+			if relation == nil || !riskDeltaCompromiseIdentityTraversalRelation(relation.Relation) {
+				continue
+			}
+			copyRelation := cloneRiskDeltaRelation(relation)
+			adjacency[copyRelation.FromURN] = append(adjacency[copyRelation.FromURN], copyRelation)
+			if copyRelation.Relation == "owned_by" || copyRelation.Relation == "represents_identity" {
+				reversed := cloneRiskDeltaRelation(copyRelation)
+				reversed.FromURN, reversed.ToURN = reversed.ToURN, reversed.FromURN
+				adjacency[reversed.FromURN] = append(adjacency[reversed.FromURN], reversed)
+			}
+		}
+	}
+	visited := map[string]struct{}{targetURN: {}}
+	frontier := []string{targetURN}
+	for depth := 0; depth < 3 && len(frontier) > 0 && len(result.resourceURNs) < 250; depth++ {
+		next := []string{}
+		for _, urn := range frontier {
+			for _, relation := range adjacency[urn] {
+				if relation == nil || relation.ToURN == "" {
+					continue
+				}
+				if riskDeltaCompromiseIdentityPrivilegedRelation(relation.Relation) {
+					result.privileged = true
+				}
+				if relation.ToURN != targetURN {
+					result.resourceURNs[relation.ToURN] = struct{}{}
+				}
+				if _, ok := visited[relation.ToURN]; ok {
+					continue
+				}
+				visited[relation.ToURN] = struct{}{}
+				next = append(next, relation.ToURN)
+			}
+		}
+		frontier = next
+	}
+	return result
+}
+
+func riskDeltaCompromiseIdentityTraversalRelation(relation string) bool {
+	switch strings.TrimSpace(relation) {
+	case "assigned_to", "can_admin", "can_assume", "can_impersonate", "can_perform", "can_reach", "member_of", "owned_by", "represents_identity", "runs_as":
+		return true
+	default:
+		return false
+	}
+}
+
+func riskDeltaCompromiseIdentityPrivilegedRelation(relation string) bool {
+	switch strings.TrimSpace(relation) {
+	case "can_admin", "can_assume", "can_impersonate", "can_perform":
+		return true
+	default:
+		return false
+	}
+}
+
+func riskDeltaRelationTouchesTarget(relation *ports.NeighborhoodRelation, targetURN string) bool {
+	targetURN = strings.TrimSpace(targetURN)
+	if targetURN == "" || relation == nil {
+		return false
+	}
+	return relation.FromURN == targetURN || relation.ToURN == targetURN
+}
+
+func riskDeltaFindingImpacts(before []*ports.FindingRecord, after []*ports.FindingRecord, now time.Time) []RiskDeltaFindingImpact {
+	afterByID := map[string]*ports.FindingRecord{}
+	for _, record := range after {
+		if record != nil {
+			afterByID[record.ID] = record
+		}
+	}
+	impacts := []RiskDeltaFindingImpact{}
+	for _, beforeRecord := range before {
+		if beforeRecord == nil {
+			continue
+		}
+		afterRecord := afterByID[beforeRecord.ID]
+		if afterRecord == nil {
+			continue
+		}
+		beforeContext := AnalyzeFindingRiskContext(beforeRecord, now)
+		afterContext := AnalyzeFindingRiskContext(afterRecord, now)
+		if beforeContext.Score == afterContext.Score {
+			continue
+		}
+		impacts = append(impacts, RiskDeltaFindingImpact{
+			FindingID:       strings.TrimSpace(beforeRecord.ID),
+			RuleID:          strings.TrimSpace(beforeRecord.RuleID),
+			ResourceURNs:    uniqueSortedStrings(beforeRecord.ResourceURNs),
+			BeforeRiskScore: beforeContext.Score,
+			AfterRiskScore:  afterContext.Score,
+			Reduction:       beforeContext.Score - afterContext.Score,
+			AddedReasons:    addedRiskDeltaReasons(beforeContext.Reasons, afterContext.Reasons),
+			RemovedReasons:  removedRiskDeltaReasons(beforeContext.Reasons, afterContext.Reasons),
+		})
+	}
+	sort.Slice(impacts, func(i int, j int) bool {
+		left := impacts[i]
+		right := impacts[j]
+		switch {
+		case left.Reduction != right.Reduction:
+			return left.Reduction > right.Reduction
+		default:
+			return left.FindingID < right.FindingID
+		}
+	})
+	return impacts
+}
+
+func addedRiskDeltaAttackPaths(before []FindingAttackPath, after []FindingAttackPath) []FindingAttackPath {
+	beforeKeys := map[string]struct{}{}
+	for _, path := range before {
+		beforeKeys[riskDeltaAttackPathKey(path)] = struct{}{}
+	}
+	added := []FindingAttackPath{}
+	for _, path := range after {
+		if _, ok := beforeKeys[riskDeltaAttackPathKey(path)]; !ok {
+			added = append(added, path)
+		}
+	}
+	return added
+}
+
+func removedRiskDeltaAttackPaths(before []FindingAttackPath, after []FindingAttackPath) []FindingAttackPath {
+	afterKeys := map[string]struct{}{}
+	for _, path := range after {
+		afterKeys[riskDeltaAttackPathKey(path)] = struct{}{}
+	}
+	removed := []FindingAttackPath{}
+	for _, path := range before {
+		if _, ok := afterKeys[riskDeltaAttackPathKey(path)]; !ok {
+			removed = append(removed, path)
+		}
+	}
+	return removed
+}
+
+func riskDeltaAttackPathKey(path FindingAttackPath) string {
+	parts := make([]string, 0, len(path.Steps)+1)
+	parts = append(parts, strings.TrimSpace(path.FindingID))
+	for _, step := range path.Steps {
+		parts = append(parts, step.FromURN+"|"+step.Relation+"|"+step.ToURN)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func removedRiskDeltaReasons(before []string, after []string) []string {
+	afterSet := map[string]struct{}{}
+	for _, reason := range after {
+		afterSet[reason] = struct{}{}
+	}
+	removed := []string{}
+	for _, reason := range before {
+		if _, ok := afterSet[reason]; !ok {
+			removed = append(removed, reason)
+		}
+	}
+	return uniqueSortedStrings(removed)
+}
+
+func addedRiskDeltaReasons(before []string, after []string) []string {
+	beforeSet := map[string]struct{}{}
+	for _, reason := range before {
+		beforeSet[reason] = struct{}{}
+	}
+	added := []string{}
+	for _, reason := range after {
+		if _, ok := beforeSet[reason]; !ok {
+			added = append(added, reason)
+		}
+	}
+	return uniqueSortedStrings(added)
+}
+
+func riskDeltaFindingMatchesTarget(record *ports.FindingRecord, targetURN string) bool {
+	targetURN = strings.TrimSpace(targetURN)
+	if targetURN == "" || record == nil {
+		return false
+	}
+	for _, resourceURN := range record.ResourceURNs {
+		if strings.TrimSpace(resourceURN) == targetURN {
+			return true
+		}
+	}
+	for _, key := range []string{"primary_resource_urn", "resource_urn", "target_urn", "asset_urn", "exposed_resource_urn", "principal_urn", "permission_urn", "vulnerability_urn", "package_urn", "image_urn"} {
+		if strings.TrimSpace(record.Attributes[key]) == targetURN {
+			return true
+		}
+	}
+	return false
+}
+
+func riskDeltaFindingMatchesAnyTarget(record *ports.FindingRecord, targetURNs map[string]struct{}) bool {
+	if record == nil || len(targetURNs) == 0 {
+		return false
+	}
+	for targetURN := range targetURNs {
+		if riskDeltaFindingMatchesTarget(record, targetURN) {
+			return true
+		}
+	}
+	return false
+}
+
+func removeRiskDeltaAttributes(attributes map[string]string, keys ...string) bool {
+	removed := false
+	for _, key := range keys {
+		if _, ok := attributes[key]; ok {
+			delete(attributes, key)
+			removed = true
+		}
+	}
+	return removed
+}
+
+func riskDeltaMaxIntString(current string, candidate int) string {
+	if candidate < 0 {
+		candidate = 0
+	}
+	currentValue := 0
+	if trimmed := strings.TrimSpace(current); trimmed != "" {
+		for _, r := range trimmed {
+			if r < '0' || r > '9' {
+				currentValue = 0
+				break
+			}
+			currentValue = currentValue*10 + int(r-'0')
+		}
+	}
+	if currentValue > candidate {
+		candidate = currentValue
+	}
+	return strconv.Itoa(candidate)
+}
+
+func cloneRiskDeltaFindings(records []*ports.FindingRecord) []*ports.FindingRecord {
+	cloned := make([]*ports.FindingRecord, 0, len(records))
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		copyRecord := *record
+		copyRecord.ResourceURNs = append([]string(nil), record.ResourceURNs...)
+		copyRecord.EventIDs = append([]string(nil), record.EventIDs...)
+		copyRecord.ObservedPolicyIDs = append([]string(nil), record.ObservedPolicyIDs...)
+		copyRecord.ControlRefs = append([]ports.FindingControlRef(nil), record.ControlRefs...)
+		copyRecord.RiskReasons = append([]string(nil), record.RiskReasons...)
+		copyRecord.Attributes = map[string]string{}
+		for key, value := range record.Attributes {
+			copyRecord.Attributes[key] = value
+		}
+		cloned = append(cloned, &copyRecord)
+	}
+	return cloned
+}
+
+func cloneRiskDeltaNeighborhoods(neighborhoods map[string]*ports.EntityNeighborhood) map[string]*ports.EntityNeighborhood {
+	cloned := make(map[string]*ports.EntityNeighborhood, len(neighborhoods))
+	for key, neighborhood := range neighborhoods {
+		if neighborhood == nil {
+			continue
+		}
+		copyNeighborhood := &ports.EntityNeighborhood{
+			Root:      cloneRiskDeltaNode(neighborhood.Root),
+			Neighbors: make([]*ports.NeighborhoodNode, 0, len(neighborhood.Neighbors)),
+			Relations: make([]*ports.NeighborhoodRelation, 0, len(neighborhood.Relations)),
+		}
+		for _, node := range neighborhood.Neighbors {
+			copyNeighborhood.Neighbors = append(copyNeighborhood.Neighbors, cloneRiskDeltaNode(node))
+		}
+		for _, relation := range neighborhood.Relations {
+			copyNeighborhood.Relations = append(copyNeighborhood.Relations, cloneRiskDeltaRelation(relation))
+		}
+		cloned[key] = copyNeighborhood
+	}
+	return cloned
+}
+
+func cloneRiskDeltaNode(node *ports.NeighborhoodNode) *ports.NeighborhoodNode {
+	if node == nil {
+		return nil
+	}
+	copyNode := *node
+	return &copyNode
+}
+
+func cloneRiskDeltaRelation(relation *ports.NeighborhoodRelation) *ports.NeighborhoodRelation {
+	if relation == nil {
+		return nil
+	}
+	copyRelation := *relation
+	copyRelation.Attributes = map[string]string{}
+	for key, value := range relation.Attributes {
+		copyRelation.Attributes[key] = value
+	}
+	return &copyRelation
+}

--- a/internal/findings/risk_simulation_test.go
+++ b/internal/findings/risk_simulation_test.go
@@ -94,6 +94,56 @@ func TestSimulateRiskDeltaPatchVulnerability(t *testing.T) {
 	}
 }
 
+func TestSimulateRiskDeltaDiffsUntruncatedAttackPaths(t *testing.T) {
+	target := compoundRiskFinding("runtime-kev", githubDependabotOpenAlertRuleID, "HIGH", "", "writer/cerebro", "urn:cerebro:writer:container_image:sha256:abc", "scan.detected")
+	target.Attributes["is_kev"] = "true"
+	target.Attributes["epss_score"] = "0.91"
+	target.Attributes["cvss_score"] = "9.8"
+	target.Attributes["exploit_available"] = "true"
+	other := compoundRiskFinding("privileged-role", cloudPrivilegePathGrantedRuleID, "HIGH", "", "", "urn:cerebro:writer:aws_role:admin", "can_admin")
+	neighborhoods := map[string]*ports.EntityNeighborhood{
+		"paths": {
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:container_image:sha256:abc", EntityType: "container_image", Label: "image"},
+			Neighbors: []*ports.NeighborhoodNode{
+				{URN: "urn:cerebro:writer:aws_public_principal:public_internet", EntityType: "aws.public_principal", Label: "public internet"},
+				{URN: "urn:cerebro:writer:aws_role:admin", EntityType: "aws.role", Label: "admin"},
+				{URN: "urn:cerebro:writer:aws_user:operator", EntityType: "aws.user", Label: "operator"},
+				{URN: "urn:cerebro:writer:finding:runtime-kev", EntityType: "finding", Label: "runtime-kev"},
+				{URN: "urn:cerebro:writer:finding:privileged-role", EntityType: "finding", Label: "privileged-role"},
+			},
+			Relations: []*ports.NeighborhoodRelation{
+				{FromURN: "urn:cerebro:writer:aws_public_principal:public_internet", Relation: "can_reach", ToURN: "urn:cerebro:writer:container_image:sha256:abc"},
+				{FromURN: "urn:cerebro:writer:container_image:sha256:abc", Relation: "has_finding", ToURN: "urn:cerebro:writer:finding:runtime-kev"},
+				{FromURN: "urn:cerebro:writer:aws_user:operator", Relation: "can_admin", ToURN: "urn:cerebro:writer:aws_role:admin"},
+				{FromURN: "urn:cerebro:writer:aws_role:admin", Relation: "has_finding", ToURN: "urn:cerebro:writer:finding:privileged-role"},
+			},
+		},
+	}
+	beforeTopPaths := AnalyzeFindingAttackPaths([]*ports.FindingRecord{target, other}, neighborhoods, FindingExposureAnalysisOptions{Limit: 1, GraphNeighborhoods: neighborhoods})
+	if len(beforeTopPaths) != 1 || beforeTopPaths[0].FindingID != target.ID {
+		t.Fatalf("before top paths = %#v, want vulnerability path first", beforeTopPaths)
+	}
+	report := SimulateRiskDelta([]*ports.FindingRecord{target, other}, RiskDeltaSimulationOptions{
+		ScenarioType:       RiskDeltaScenarioPatchVulnerability,
+		TargetURN:          "urn:cerebro:writer:container_image:sha256:abc",
+		Limit:              1,
+		GraphNeighborhoods: neighborhoods,
+	})
+
+	if len(report.RemainingAttackPaths) != 1 {
+		t.Fatalf("RemainingAttackPaths = %#v, want truncated top path", report.RemainingAttackPaths)
+	}
+	if report.RemainingAttackPaths[0].FindingID != other.ID {
+		t.Fatalf("RemainingAttackPaths = %#v, want non-target path after score reshuffle", report.RemainingAttackPaths)
+	}
+	if len(report.AddedAttackPaths) != 0 || len(report.RemovedAttackPaths) != 0 {
+		t.Fatalf("AddedAttackPaths = %#v, RemovedAttackPaths = %#v, want no structural path diff", report.AddedAttackPaths, report.RemovedAttackPaths)
+	}
+	if report.Before.AttackPathCount <= 1 || report.After.AttackPathCount != report.Before.AttackPathCount {
+		t.Fatalf("attack path counts = before %d after %d, want stable full counts", report.Before.AttackPathCount, report.After.AttackPathCount)
+	}
+}
+
 func TestSimulateRiskDeltaRemovePrivilege(t *testing.T) {
 	finding := compoundRiskFinding("privileged-role", cloudPrivilegePathGrantedRuleID, "HIGH", "", "", "urn:cerebro:writer:aws_role:admin", "can_admin")
 	finding.Attributes["privileged"] = "true"

--- a/internal/findings/risk_simulation_test.go
+++ b/internal/findings/risk_simulation_test.go
@@ -1,0 +1,180 @@
+package findings
+
+import (
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestSimulateRiskDeltaRemovePublicExposure(t *testing.T) {
+	finding := compoundRiskFinding("cloud-public-prod-secrets", cloudPublicResourceExposureRuleID, "HIGH", "", "", "urn:cerebro:writer:aws_secret_store:prod-secrets", "public_network_ingress")
+	finding.Attributes["internet_exposed"] = "true"
+	finding.Attributes["crown_jewel"] = "true"
+	report := SimulateRiskDelta([]*ports.FindingRecord{finding}, RiskDeltaSimulationOptions{
+		ScenarioType: RiskDeltaScenarioRemovePublicExposure,
+		TargetURN:    "urn:cerebro:writer:aws_secret_store:prod-secrets",
+		Limit:        10,
+		GraphNeighborhoods: map[string]*ports.EntityNeighborhood{
+			"cloud": {
+				Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+				Neighbors: []*ports.NeighborhoodNode{
+					{URN: "urn:cerebro:writer:aws_public_principal:public_internet", EntityType: "aws.public_principal", Label: "public internet"},
+					{URN: "urn:cerebro:writer:aws_role:admin", EntityType: "aws.role", Label: "admin"},
+					{URN: "urn:cerebro:writer:finding:cloud-public-prod-secrets", EntityType: "finding", Label: "cloud-public-prod-secrets"},
+				},
+				Relations: []*ports.NeighborhoodRelation{
+					{FromURN: "urn:cerebro:writer:aws_public_principal:public_internet", Relation: "can_reach", ToURN: "urn:cerebro:writer:aws_secret_store:prod-secrets"},
+					{FromURN: "urn:cerebro:writer:aws_role:admin", Relation: "can_admin", ToURN: "urn:cerebro:writer:aws_secret_store:prod-secrets"},
+					{FromURN: "urn:cerebro:writer:aws_secret_store:prod-secrets", Relation: "has_finding", ToURN: "urn:cerebro:writer:finding:cloud-public-prod-secrets"},
+				},
+			},
+		},
+	})
+
+	if report.RiskScoreReduction <= 0 {
+		t.Fatalf("RiskScoreReduction = %d, want positive reduction", report.RiskScoreReduction)
+	}
+	if report.AttackPathScoreReduction <= 0 {
+		t.Fatalf("AttackPathScoreReduction = %d, want positive reduction", report.AttackPathScoreReduction)
+	}
+	if report.AttackPathCountReduction <= 0 {
+		t.Fatalf("AttackPathCountReduction = %d, want public exposure path count reduction", report.AttackPathCountReduction)
+	}
+	if len(report.RemovedAttackPaths) == 0 || !riskSimulationAttackPathContainsRelation(report.RemovedAttackPaths, "can_reach") {
+		t.Fatalf("RemovedAttackPaths = %#v, want removed can_reach path", report.RemovedAttackPaths)
+	}
+	if len(report.AffectedFindings) != 1 {
+		t.Fatalf("AffectedFindings = %#v, want one affected finding", report.AffectedFindings)
+	}
+	if !stringSliceContains(report.AffectedFindings[0].RemovedReasons, "external_exposure") {
+		t.Fatalf("RemovedReasons = %#v, want external_exposure", report.AffectedFindings[0].RemovedReasons)
+	}
+}
+
+func riskSimulationAttackPathContainsRelation(paths []FindingAttackPath, relation string) bool {
+	for _, path := range paths {
+		for _, step := range path.Steps {
+			if step.Relation == relation {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestSimulateRiskDeltaPatchVulnerability(t *testing.T) {
+	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	finding := compoundRiskFinding("runtime-kev", githubDependabotOpenAlertRuleID, "HIGH", "", "writer/cerebro", "urn:cerebro:writer:container_image:sha256:abc", "scan.detected")
+	finding.LastObservedAt = now
+	finding.Attributes["is_kev"] = "true"
+	finding.Attributes["epss_score"] = "0.91"
+	finding.Attributes["cvss_score"] = "9.8"
+	finding.Attributes["exploit_available"] = "true"
+	finding.Attributes["internet_exposed"] = "true"
+	finding.Attributes["environment"] = "production"
+	finding.Attributes["crown_jewel"] = "true"
+
+	report := SimulateRiskDelta([]*ports.FindingRecord{finding}, RiskDeltaSimulationOptions{
+		ScenarioType: RiskDeltaScenarioPatchVulnerability,
+		TargetURN:    "urn:cerebro:writer:container_image:sha256:abc",
+		Now:          now,
+	})
+
+	if report.RiskScoreReduction <= 0 {
+		t.Fatalf("RiskScoreReduction = %d, want positive reduction", report.RiskScoreReduction)
+	}
+	if len(report.AffectedFindings) != 1 {
+		t.Fatalf("AffectedFindings = %#v, want one affected finding", report.AffectedFindings)
+	}
+	for _, reason := range []string{"known_exploited", "epss_high", "cvss_critical", "exploit_available"} {
+		if !stringSliceContains(report.AffectedFindings[0].RemovedReasons, reason) {
+			t.Fatalf("RemovedReasons = %#v, want %q", report.AffectedFindings[0].RemovedReasons, reason)
+		}
+	}
+}
+
+func TestSimulateRiskDeltaRemovePrivilege(t *testing.T) {
+	finding := compoundRiskFinding("privileged-role", cloudPrivilegePathGrantedRuleID, "HIGH", "", "", "urn:cerebro:writer:aws_role:admin", "can_admin")
+	finding.Attributes["privileged"] = "true"
+	finding.Attributes["can_admin"] = "true"
+	finding.Attributes["has_admin_path"] = "true"
+	report := SimulateRiskDelta([]*ports.FindingRecord{finding}, RiskDeltaSimulationOptions{
+		ScenarioType: RiskDeltaScenarioRemovePrivilege,
+		TargetURN:    "urn:cerebro:writer:aws_role:admin",
+		Limit:        10,
+		GraphNeighborhoods: map[string]*ports.EntityNeighborhood{
+			"iam": {
+				Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:aws_role:admin", EntityType: "aws.role", Label: "admin"},
+				Neighbors: []*ports.NeighborhoodNode{
+					{URN: "urn:cerebro:writer:aws_user:operator", EntityType: "aws.user", Label: "operator"},
+					{URN: "urn:cerebro:writer:finding:privileged-role", EntityType: "finding", Label: "privileged-role"},
+				},
+				Relations: []*ports.NeighborhoodRelation{
+					{FromURN: "urn:cerebro:writer:aws_user:operator", Relation: "can_admin", ToURN: "urn:cerebro:writer:aws_role:admin"},
+					{FromURN: "urn:cerebro:writer:aws_role:admin", Relation: "has_finding", ToURN: "urn:cerebro:writer:finding:privileged-role"},
+				},
+			},
+		},
+	})
+
+	if report.RiskScoreReduction <= 0 {
+		t.Fatalf("RiskScoreReduction = %d, want positive reduction", report.RiskScoreReduction)
+	}
+	if report.AttackPathScoreReduction <= 0 {
+		t.Fatalf("AttackPathScoreReduction = %d, want positive reduction", report.AttackPathScoreReduction)
+	}
+	if len(report.RemovedAttackPaths) == 0 || !riskSimulationAttackPathContainsRelation(report.RemovedAttackPaths, "can_admin") {
+		t.Fatalf("RemovedAttackPaths = %#v, want removed can_admin path", report.RemovedAttackPaths)
+	}
+	if len(report.AffectedFindings) != 1 || !stringSliceContains(report.AffectedFindings[0].RemovedReasons, "privileged_actor") {
+		t.Fatalf("AffectedFindings = %#v, want privilege reason removed", report.AffectedFindings)
+	}
+}
+
+func TestSimulateRiskDeltaCompromiseIdentity(t *testing.T) {
+	finding := compoundRiskFinding("sensitive-data", dataSensitiveAssetRiskRuleID, "HIGH", "", "", "urn:cerebro:writer:aws_secret_store:prod-secrets", "data_access")
+	finding.Attributes["data_classification"] = "restricted"
+	report := SimulateRiskDelta([]*ports.FindingRecord{finding}, RiskDeltaSimulationOptions{
+		ScenarioType: RiskDeltaScenarioCompromiseIdentity,
+		TargetURN:    "urn:cerebro:writer:okta_user:admin@example.com",
+		Limit:        10,
+		GraphNeighborhoods: map[string]*ports.EntityNeighborhood{
+			"identity": {
+				Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:okta_user:admin@example.com", EntityType: "okta.user", Label: "admin@example.com"},
+				Neighbors: []*ports.NeighborhoodNode{
+					{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+					{URN: "urn:cerebro:writer:finding:sensitive-data", EntityType: "finding", Label: "sensitive-data"},
+				},
+				Relations: []*ports.NeighborhoodRelation{
+					{FromURN: "urn:cerebro:writer:okta_user:admin@example.com", Relation: "can_admin", ToURN: "urn:cerebro:writer:aws_secret_store:prod-secrets"},
+					{FromURN: "urn:cerebro:writer:aws_secret_store:prod-secrets", Relation: "has_finding", ToURN: "urn:cerebro:writer:finding:sensitive-data"},
+				},
+			},
+		},
+	})
+
+	if report.RiskScoreChange <= 0 {
+		t.Fatalf("RiskScoreChange = %d, want positive risk increase", report.RiskScoreChange)
+	}
+	if report.RiskScoreReduction >= 0 {
+		t.Fatalf("RiskScoreReduction = %d, want negative reduction for compromise scenario", report.RiskScoreReduction)
+	}
+	if report.AttackPathScoreChange <= 0 {
+		t.Fatalf("AttackPathScoreChange = %d, want positive attack-path risk increase", report.AttackPathScoreChange)
+	}
+	if len(report.AffectedFindings) != 1 {
+		t.Fatalf("AffectedFindings = %#v, want one affected downstream finding", report.AffectedFindings)
+	}
+	if report.AffectedFindings[0].Reduction >= 0 {
+		t.Fatalf("AffectedFindings[0].Reduction = %d, want negative reduction", report.AffectedFindings[0].Reduction)
+	}
+	for _, reason := range []string{"active_threat", "blast_radius", "privilege_or_control_plane"} {
+		if !stringSliceContains(report.AffectedFindings[0].AddedReasons, reason) {
+			t.Fatalf("AddedReasons = %#v, want %q", report.AffectedFindings[0].AddedReasons, reason)
+		}
+	}
+	if !stringSliceContains(report.Reasons, "modeled_identity_blast_radius") {
+		t.Fatalf("Reasons = %#v, want modeled_identity_blast_radius", report.Reasons)
+	}
+}

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -23,10 +23,14 @@ import (
 const (
 	findingSummaryReportID           = "finding-summary"
 	findingSummaryReportName         = "Finding Summary"
+	riskDeltaReportID                = "risk-delta"
+	riskDeltaReportName              = "Risk Delta"
 	findingSummaryReportStatus       = "completed"
 	reportParameterTenantID          = "tenant_id"
 	reportParameterRuntimeID         = "runtime_id"
 	reportParameterRuntimeIDs        = "runtime_ids"
+	reportParameterScenarioType      = "scenario_type"
+	reportParameterTargetURN         = "target_urn"
 	reportParameterResourceLimit     = "resource_limit"
 	reportParameterGraphLimit        = "graph_limit"
 	defaultResourceEvidenceLimit     = 3
@@ -71,6 +75,7 @@ func (s *Service) List() *cerebrov1.ListReportDefinitionsResponse {
 	return &cerebrov1.ListReportDefinitionsResponse{
 		Reports: []*cerebrov1.ReportDefinition{
 			findingSummaryDefinition(),
+			riskDeltaDefinition(),
 		},
 	}
 }
@@ -98,6 +103,8 @@ func (s *Service) Run(ctx context.Context, request *cerebrov1.RunReportRequest) 
 	switch reportID {
 	case findingSummaryReportID:
 		result, err = s.runFindingSummary(ctx, parameters)
+	case riskDeltaReportID:
+		result, err = s.runRiskDelta(ctx, parameters)
 	default:
 		err = fmt.Errorf("%w: %s", ErrReportNotFound, reportID)
 	}
@@ -325,6 +332,94 @@ func (s *Service) runFindingSummary(ctx context.Context, parameters map[string]s
 	return result, nil
 }
 
+func (s *Service) runRiskDelta(ctx context.Context, parameters map[string]string) (*structpb.Struct, error) {
+	tenantID := strings.TrimSpace(parameters[reportParameterTenantID])
+	if tenantID == "" {
+		return nil, fmt.Errorf("%w: report parameter %q is required", ErrInvalidRequest, reportParameterTenantID)
+	}
+	runtimeID := strings.TrimSpace(parameters[reportParameterRuntimeID])
+	runtimeIDs := normalizeRuntimeIDs(runtimeID, parameters[reportParameterRuntimeIDs])
+	if len(runtimeIDs) == 0 {
+		return nil, fmt.Errorf("%w: report parameter %q or %q is required", ErrInvalidRequest, reportParameterRuntimeID, reportParameterRuntimeIDs)
+	}
+	resultRuntimeID := ""
+	if len(runtimeIDs) == 1 {
+		resultRuntimeID = runtimeIDs[0]
+	}
+	scenarioType, err := normalizeRiskDeltaScenario(parameters[reportParameterScenarioType])
+	if err != nil {
+		return nil, err
+	}
+	targetURN := strings.TrimSpace(parameters[reportParameterTargetURN])
+	if targetURN == "" {
+		return nil, fmt.Errorf("%w: report parameter %q is required", ErrInvalidRequest, reportParameterTargetURN)
+	}
+	runtimeIDsCSV := strings.Join(runtimeIDs, ",")
+	resourceLimit, err := normalizePositiveLimit(parameters[reportParameterResourceLimit], defaultResourceEvidenceLimit, maxResourceEvidenceLimit, reportParameterResourceLimit)
+	if err != nil {
+		return nil, err
+	}
+	graphLimit, err := normalizePositiveLimit(parameters[reportParameterGraphLimit], defaultNeighborhoodEvidenceLimit, maxNeighborhoodEvidenceLimit, reportParameterGraphLimit)
+	if err != nil {
+		return nil, err
+	}
+	parameters[reportParameterRuntimeIDs] = runtimeIDsCSV
+	parameters[reportParameterScenarioType] = scenarioType
+	parameters[reportParameterTargetURN] = targetURN
+	parameters[reportParameterResourceLimit] = strconv.Itoa(resourceLimit)
+	parameters[reportParameterGraphLimit] = strconv.Itoa(graphLimit)
+	listRequest := ports.ListFindingsRequest{TenantID: tenantID, Order: ports.FindingOrderRiskScore}
+	if len(runtimeIDs) == 1 {
+		listRequest.RuntimeID = runtimeIDs[0]
+	} else {
+		listRequest.RuntimeIDs = runtimeIDs
+	}
+	findings, err := s.findingStore.ListFindings(ctx, listRequest)
+	if err != nil {
+		return nil, fmt.Errorf("list findings for tenant %q runtimes %q: %w", tenantID, runtimeIDsCSV, err)
+	}
+	graphEvidenceStatus := graphEvidenceStatusUnconfigured
+	graphNeighborhoods := map[string]*ports.EntityNeighborhood{}
+	if s.graphStore != nil {
+		graphEvidenceStatus = graphEvidenceStatusIncluded
+		graphNeighborhoods, err = s.riskDeltaGraphNeighborhoods(ctx, targetURN, findings, resourceLimit, graphLimit)
+		if err != nil {
+			return nil, err
+		}
+	}
+	report := findinganalysis.SimulateRiskDelta(findings, findinganalysis.RiskDeltaSimulationOptions{
+		ScenarioType:       scenarioType,
+		TargetURN:          targetURN,
+		Limit:              10,
+		GraphNeighborhoods: graphNeighborhoods,
+	})
+	riskDelta, err := jsonPayload(report)
+	if err != nil {
+		return nil, fmt.Errorf("build risk delta report payload: %w", err)
+	}
+	result, err := structpb.NewStruct(map[string]any{
+		reportParameterTenantID:       tenantID,
+		reportParameterRuntimeID:      resultRuntimeID,
+		reportParameterRuntimeIDs:     reportStringValues(runtimeIDs),
+		reportParameterScenarioType:   scenarioType,
+		reportParameterTargetURN:      targetURN,
+		"total_findings":              len(findings),
+		"graph_evidence_status":       graphEvidenceStatus,
+		"graph_neighborhood_count":    len(graphNeighborhoods),
+		"risk_delta":                  riskDelta,
+		"risk_score_change":           report.RiskScoreChange,
+		"attack_path_score_change":    report.AttackPathScoreChange,
+		"attack_path_count_change":    report.AttackPathCountChange,
+		"risk_score_reduction":        report.RiskScoreReduction,
+		"attack_path_score_reduction": report.AttackPathScoreReduction,
+		"attack_path_count_reduction": report.AttackPathCountReduction,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build risk delta report result: %w", err)
+	}
+	return result, nil
+}
+
 func jsonPayload(value any) (any, error) {
 	content, err := json.Marshal(value)
 	if err != nil {
@@ -413,6 +508,47 @@ func (s *Service) graphEvidence(ctx context.Context, resourceCounts map[string]i
 	return evidence, neighborhoods, nil
 }
 
+func (s *Service) riskDeltaGraphNeighborhoods(ctx context.Context, targetURN string, findings []*ports.FindingRecord, resourceLimit int, graphLimit int) (map[string]*ports.EntityNeighborhood, error) {
+	roots := []string{strings.TrimSpace(targetURN)}
+	resourceCounts := map[string]int{}
+	for _, finding := range findings {
+		if resourceURN := primaryResourceURN(finding); resourceURN != "" {
+			resourceCounts[resourceURN]++
+		}
+	}
+	for _, entry := range sortedCountEntries(resourceCounts) {
+		if len(roots) >= resourceLimit {
+			break
+		}
+		roots = append(roots, entry.Key)
+	}
+	seen := map[string]struct{}{}
+	neighborhoods := map[string]*ports.EntityNeighborhood{}
+	for _, rootURN := range roots {
+		rootURN = strings.TrimSpace(rootURN)
+		if rootURN == "" {
+			continue
+		}
+		if _, ok := seen[rootURN]; ok {
+			continue
+		}
+		seen[rootURN] = struct{}{}
+		neighborhood, err := s.graphStore.GetEntityNeighborhood(ctx, rootURN, graphLimit)
+		switch {
+		case err == nil:
+			if neighborhood == nil {
+				neighborhood = &ports.EntityNeighborhood{}
+			}
+			neighborhoods[rootURN] = neighborhood
+		case errors.Is(err, ports.ErrGraphEntityNotFound):
+			continue
+		default:
+			return nil, fmt.Errorf("load risk delta graph neighborhood for %q: %w", rootURN, err)
+		}
+	}
+	return neighborhoods, nil
+}
+
 func findingSummaryDefinition() *cerebrov1.ReportDefinition {
 	return &cerebrov1.ReportDefinition{
 		Id:          findingSummaryReportID,
@@ -448,12 +584,72 @@ func findingSummaryDefinition() *cerebrov1.ReportDefinition {
 	}
 }
 
+func riskDeltaDefinition() *cerebrov1.ReportDefinition {
+	return &cerebrov1.ReportDefinition{
+		Id:          riskDeltaReportID,
+		Name:        riskDeltaReportName,
+		Description: "Simulate an in-memory remediation scenario against persisted findings and bounded graph neighborhoods, returning before/after risk, attack-path, and affected-finding deltas without mutating stores.",
+		Parameters: []*cerebrov1.ReportParameter{
+			{
+				Id:          reportParameterTenantID,
+				Description: "Tenant identifier whose persisted findings should be simulated.",
+				Required:    true,
+			},
+			{
+				Id:          reportParameterRuntimeID,
+				Description: "Optional legacy single stored source runtime identifier. Use runtime_ids as the required runtime selector for new clients.",
+				Required:    false,
+			},
+			{
+				Id:          reportParameterRuntimeIDs,
+				Description: "Required comma-separated stored source runtime identifiers for risk delta simulation.",
+				Required:    true,
+			},
+			{
+				Id:          reportParameterScenarioType,
+				Description: "Simulation scenario: remove_public_exposure, remove_privilege, patch_vulnerability, or compromise_identity.",
+				Required:    true,
+			},
+			{
+				Id:          reportParameterTargetURN,
+				Description: "Graph/resource URN targeted by the simulated remediation.",
+				Required:    true,
+			},
+			{
+				Id:          reportParameterResourceLimit,
+				Description: "Optional maximum number of resource roots to include in simulation graph context.",
+				Required:    false,
+			},
+			{
+				Id:          reportParameterGraphLimit,
+				Description: "Optional maximum neighborhood size to read for each simulation graph root.",
+				Required:    false,
+			},
+		},
+	}
+}
+
 func reportDefinition(reportID string) (*cerebrov1.ReportDefinition, error) {
 	switch strings.TrimSpace(reportID) {
 	case findingSummaryReportID:
 		return findingSummaryDefinition(), nil
+	case riskDeltaReportID:
+		return riskDeltaDefinition(), nil
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrReportNotFound, reportID)
+	}
+}
+
+func normalizeRiskDeltaScenario(value string) (string, error) {
+	scenarioType := strings.TrimSpace(value)
+	switch scenarioType {
+	case findinganalysis.RiskDeltaScenarioCompromiseIdentity,
+		findinganalysis.RiskDeltaScenarioPatchVulnerability,
+		findinganalysis.RiskDeltaScenarioRemovePrivilege,
+		findinganalysis.RiskDeltaScenarioRemovePublicExposure:
+		return scenarioType, nil
+	default:
+		return "", fmt.Errorf("%w: report parameter %q must be one of %s, %s, %s, %s", ErrInvalidRequest, reportParameterScenarioType, findinganalysis.RiskDeltaScenarioRemovePublicExposure, findinganalysis.RiskDeltaScenarioRemovePrivilege, findinganalysis.RiskDeltaScenarioPatchVulnerability, findinganalysis.RiskDeltaScenarioCompromiseIdentity)
 	}
 }
 

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -354,6 +354,9 @@ func (s *Service) runRiskDelta(ctx context.Context, parameters map[string]string
 	if targetURN == "" {
 		return nil, fmt.Errorf("%w: report parameter %q is required", ErrInvalidRequest, reportParameterTargetURN)
 	}
+	if err := validateRiskDeltaTargetTenant(tenantID, targetURN); err != nil {
+		return nil, err
+	}
 	runtimeIDsCSV := strings.Join(runtimeIDs, ",")
 	resourceLimit, err := normalizePositiveLimit(parameters[reportParameterResourceLimit], defaultResourceEvidenceLimit, maxResourceEvidenceLimit, reportParameterResourceLimit)
 	if err != nil {
@@ -651,6 +654,25 @@ func normalizeRiskDeltaScenario(value string) (string, error) {
 	default:
 		return "", fmt.Errorf("%w: report parameter %q must be one of %s, %s, %s, %s", ErrInvalidRequest, reportParameterScenarioType, findinganalysis.RiskDeltaScenarioRemovePublicExposure, findinganalysis.RiskDeltaScenarioRemovePrivilege, findinganalysis.RiskDeltaScenarioPatchVulnerability, findinganalysis.RiskDeltaScenarioCompromiseIdentity)
 	}
+}
+
+func validateRiskDeltaTargetTenant(tenantID string, targetURN string) error {
+	targetTenantID := tenantIDFromRiskDeltaTargetURN(targetURN)
+	if targetTenantID == "" {
+		return fmt.Errorf("%w: report parameter %q must be a tenant-scoped cerebro urn", ErrInvalidRequest, reportParameterTargetURN)
+	}
+	if targetTenantID != strings.TrimSpace(tenantID) {
+		return fmt.Errorf("%w: report parameter %q tenant must match %q", ErrInvalidRequest, reportParameterTargetURN, reportParameterTenantID)
+	}
+	return nil
+}
+
+func tenantIDFromRiskDeltaTargetURN(urn string) string {
+	parts := strings.SplitN(strings.TrimSpace(urn), ":", 5)
+	if len(parts) < 5 || parts[0] != "urn" || parts[1] != "cerebro" {
+		return ""
+	}
+	return strings.TrimSpace(parts[2])
 }
 
 var sensitiveReportParameterTokens = []string{

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	findinganalysis "github.com/writer/cerebro/internal/findings"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -461,6 +462,87 @@ func TestRunFindingSummaryReportDoesNotPublishMultiRuntimeListAsRuntimeID(t *tes
 	}
 }
 
+func TestRunRiskDeltaReportSimulatesPublicExposureRemoval(t *testing.T) {
+	findingStore := &stubFindingStore{
+		findings: []*ports.FindingRecord{
+			{
+				ID:           "cloud-public-prod-secrets",
+				TenantID:     "writer",
+				RuntimeID:    "writer-aws",
+				RuleID:       "cloud-public-resource-exposure",
+				Title:        "Cloud Public Resource Exposure",
+				Severity:     "HIGH",
+				Status:       "open",
+				ResourceURNs: []string{"urn:cerebro:writer:aws_secret_store:prod-secrets"},
+				Attributes: map[string]string{
+					"action":               "public_network_ingress",
+					"crown_jewel":          "true",
+					"internet_exposed":     "true",
+					"rule_source_id":       "cloud",
+					"primary_resource_urn": "urn:cerebro:writer:aws_secret_store:prod-secrets",
+				},
+			},
+		},
+	}
+	graphStore := &stubGraphStore{
+		neighborhoods: map[string]*ports.EntityNeighborhood{
+			"urn:cerebro:writer:aws_secret_store:prod-secrets": {
+				Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+				Neighbors: []*ports.NeighborhoodNode{
+					{URN: "urn:cerebro:writer:aws_public_principal:public_internet", EntityType: "aws.public_principal", Label: "public internet"},
+					{URN: "urn:cerebro:writer:finding:cloud-public-prod-secrets", EntityType: "finding", Label: "cloud-public-prod-secrets"},
+				},
+				Relations: []*ports.NeighborhoodRelation{
+					{FromURN: "urn:cerebro:writer:aws_public_principal:public_internet", Relation: "can_reach", ToURN: "urn:cerebro:writer:aws_secret_store:prod-secrets"},
+					{FromURN: "urn:cerebro:writer:aws_secret_store:prod-secrets", Relation: "has_finding", ToURN: "urn:cerebro:writer:finding:cloud-public-prod-secrets"},
+				},
+			},
+		},
+	}
+	service := New(findingStore, graphStore, &stubReportStore{})
+
+	response, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: riskDeltaReportID,
+		Parameters: map[string]string{
+			reportParameterTenantID:     "writer",
+			reportParameterRuntimeID:    "writer-aws",
+			reportParameterScenarioType: findinganalysis.RiskDeltaScenarioRemovePublicExposure,
+			reportParameterTargetURN:    "urn:cerebro:writer:aws_secret_store:prod-secrets",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	result := response.GetRun().GetResult().AsMap()
+	if got := result[reportParameterScenarioType]; got != findinganalysis.RiskDeltaScenarioRemovePublicExposure {
+		t.Fatalf("scenario_type = %#v, want remove_public_exposure", got)
+	}
+	if got := result["graph_evidence_status"]; got != graphEvidenceStatusIncluded {
+		t.Fatalf("graph_evidence_status = %#v, want included", got)
+	}
+	if got := result["graph_neighborhood_count"]; got != float64(1) {
+		t.Fatalf("graph_neighborhood_count = %#v, want 1", got)
+	}
+	if got := result["risk_score_reduction"]; got.(float64) <= 0 {
+		t.Fatalf("risk_score_reduction = %#v, want positive", got)
+	}
+	if got := result["attack_path_score_reduction"]; got.(float64) <= 0 {
+		t.Fatalf("attack_path_score_reduction = %#v, want positive", got)
+	}
+	riskDelta, ok := result["risk_delta"].(map[string]any)
+	if !ok {
+		t.Fatalf("risk_delta = %#v, want object", result["risk_delta"])
+	}
+	affected, ok := riskDelta["affected_findings"].([]any)
+	if !ok || len(affected) != 1 {
+		t.Fatalf("risk_delta.affected_findings = %#v, want one affected finding", riskDelta["affected_findings"])
+	}
+	removedPaths, ok := riskDelta["removed_attack_paths"].([]any)
+	if !ok || len(removedPaths) == 0 {
+		t.Fatalf("risk_delta.removed_attack_paths = %#v, want removed public path", riskDelta["removed_attack_paths"])
+	}
+}
+
 func TestGetReportRunRequiresAvailableStore(t *testing.T) {
 	service := New(nil, nil, nil)
 	if _, err := service.Get(context.Background(), &cerebrov1.GetReportRunRequest{Id: "report-run-1"}); !errors.Is(err, ErrRuntimeUnavailable) {
@@ -477,18 +559,29 @@ func TestRunReportValidationErrorsAreInvalidRequest(t *testing.T) {
 
 func TestListReportDefinitionsIncludesFindingSummary(t *testing.T) {
 	response := New(nil, nil, nil).List()
-	if len(response.GetReports()) != 1 {
-		t.Fatalf("len(List().Reports) = %d, want 1", len(response.GetReports()))
+	if len(response.GetReports()) != 2 {
+		t.Fatalf("len(List().Reports) = %d, want 2", len(response.GetReports()))
 	}
-	if response.GetReports()[0].GetId() != findingSummaryReportID {
-		t.Fatalf("List().Reports[0].ID = %q, want %q", response.GetReports()[0].GetId(), findingSummaryReportID)
+	reportsByID := map[string]*cerebrov1.ReportDefinition{}
+	for _, report := range response.GetReports() {
+		reportsByID[report.GetId()] = report
 	}
-	parameters := reportParametersByID(response.GetReports()[0].GetParameters())
+	if reportsByID[findingSummaryReportID] == nil {
+		t.Fatalf("List().Reports = %#v, want finding summary definition", response.GetReports())
+	}
+	if reportsByID[riskDeltaReportID] == nil {
+		t.Fatalf("List().Reports = %#v, want risk delta definition", response.GetReports())
+	}
+	parameters := reportParametersByID(reportsByID[findingSummaryReportID].GetParameters())
 	if !parameters[reportParameterRuntimeIDs].GetRequired() {
 		t.Fatalf("runtime_ids parameter Required = false, want true")
 	}
 	if parameters[reportParameterRuntimeID].GetRequired() {
 		t.Fatalf("runtime_id parameter Required = true, want false")
+	}
+	riskDeltaParameters := reportParametersByID(reportsByID[riskDeltaReportID].GetParameters())
+	if !riskDeltaParameters[reportParameterScenarioType].GetRequired() || !riskDeltaParameters[reportParameterTargetURN].GetRequired() {
+		t.Fatalf("risk delta parameters = %#v, want scenario_type and target_urn required", riskDeltaParameters)
 	}
 }
 

--- a/internal/reports/service_test.go
+++ b/internal/reports/service_test.go
@@ -543,6 +543,33 @@ func TestRunRiskDeltaReportSimulatesPublicExposureRemoval(t *testing.T) {
 	}
 }
 
+func TestRunRiskDeltaReportRejectsCrossTenantTargetURN(t *testing.T) {
+	graphStore := &stubGraphStore{
+		neighborhoods: map[string]*ports.EntityNeighborhood{
+			"urn:cerebro:other:aws_secret_store:prod-secrets": {
+				Root: &ports.NeighborhoodNode{URN: "urn:cerebro:other:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+			},
+		},
+	}
+	service := New(&stubFindingStore{}, graphStore, &stubReportStore{})
+
+	_, err := service.Run(context.Background(), &cerebrov1.RunReportRequest{
+		ReportId: riskDeltaReportID,
+		Parameters: map[string]string{
+			reportParameterTenantID:     "writer",
+			reportParameterRuntimeID:    "writer-aws",
+			reportParameterScenarioType: findinganalysis.RiskDeltaScenarioRemovePublicExposure,
+			reportParameterTargetURN:    "urn:cerebro:other:aws_secret_store:prod-secrets",
+		},
+	})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("Run() error = %v, want %v", err, ErrInvalidRequest)
+	}
+	if graphStore.rootURN != "" {
+		t.Fatalf("GetEntityNeighborhood rootURN = %q, want no cross-tenant graph read", graphStore.rootURN)
+	}
+}
+
 func TestGetReportRunRequiresAvailableStore(t *testing.T) {
 	service := New(nil, nil, nil)
 	if _, err := service.Get(context.Background(), &cerebrov1.GetReportRunRequest{Id: "report-run-1"}); !errors.Is(err, ErrRuntimeUnavailable) {


### PR DESCRIPTION
## Summary

Adds a built-in `risk-delta` report that simulates risk and attack-path changes without mutating stores.

Scenarios supported:
- `remove_public_exposure`
- `remove_privilege`
- `patch_vulnerability`
- `compromise_identity`

The report returns before/after snapshots, score changes/reductions, affected findings, added/removed attack paths, and explanatory reasons.

## Why

This gives Cerebro a first production surface for asking both remediation and adversarial what-if questions over persisted findings plus bounded graph neighborhoods:

- What risk reduction would we expect if public exposure is removed?
- What changes if a privilege path is revoked?
- What changes if a vulnerability is patched?
- What blast radius appears if an identity is compromised?

## Validation

- `go test ./internal/findings ./internal/reports ./internal/bootstrap -count=1`
- `make verify`
- Pre-commit hooks passed during commit.
