### PR TITLE
fix: deepen service runtime graph links

### DIFF
--- a/internal/findings/risk_analysis_test.go
+++ b/internal/findings/risk_analysis_test.go
@@ -414,6 +414,125 @@ func TestAnalyzeFindingAttackPathsUsesRelationWeights(t *testing.T) {
 	}
 }
 
+func TestRiskDeltaSimulationRemovesPublicExposurePath(t *testing.T) {
+	finding := compoundRiskFinding("cloud-public-prod-secrets", cloudPublicResourceExposureRuleID, "HIGH", "", "", "urn:cerebro:writer:aws_secret_store:prod-secrets", "public_network_ingress")
+	finding.Attributes["internet_exposed"] = "true"
+	finding.Attributes["crown_jewel"] = "true"
+	neighborhood := map[string]*ports.EntityNeighborhood{
+		"cloud": {
+			Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:aws_secret_store:prod-secrets", EntityType: "aws.secret_store", Label: "prod-secrets"},
+			Neighbors: []*ports.NeighborhoodNode{
+				{URN: "urn:cerebro:writer:aws_public_principal:public_internet", EntityType: "aws.public_principal", Label: "public internet"},
+				{URN: "urn:cerebro:writer:aws_role:admin", EntityType: "aws.role", Label: "admin"},
+				{URN: "urn:cerebro:writer:finding:cloud-public-prod-secrets", EntityType: "finding", Label: "cloud-public-prod-secrets"},
+			},
+			Relations: []*ports.NeighborhoodRelation{
+				{FromURN: "urn:cerebro:writer:aws_public_principal:public_internet", Relation: "can_reach", ToURN: "urn:cerebro:writer:aws_secret_store:prod-secrets"},
+				{FromURN: "urn:cerebro:writer:aws_role:admin", Relation: "can_admin", ToURN: "urn:cerebro:writer:aws_secret_store:prod-secrets"},
+				{FromURN: "urn:cerebro:writer:aws_secret_store:prod-secrets", Relation: "has_finding", ToURN: "urn:cerebro:writer:finding:cloud-public-prod-secrets"},
+			},
+		},
+	}
+	before := AnalyzeFindingAttackPaths([]*ports.FindingRecord{finding}, neighborhood, FindingExposureAnalysisOptions{Limit: 10})
+	after := AnalyzeFindingAttackPaths([]*ports.FindingRecord{finding}, cloneNeighborhoodWithoutRelation(neighborhood, "can_reach"), FindingExposureAnalysisOptions{Limit: 10})
+
+	if !attackPathContainsRelation(before, "can_reach") {
+		t.Fatalf("before paths = %#v, want public exposure path", before)
+	}
+	if attackPathContainsRelation(after, "can_reach") {
+		t.Fatalf("after paths = %#v, want public exposure path removed", after)
+	}
+	if len(before) == 0 || len(after) == 0 {
+		t.Fatalf("before=%#v after=%#v, want comparable path sets", before, after)
+	}
+	if sumAttackPathScores(before) <= sumAttackPathScores(after) {
+		t.Fatalf("total score before=%d after=%d, want public exposure removal to lower modeled attack-path score", sumAttackPathScores(before), sumAttackPathScores(after))
+	}
+}
+
+func TestRiskDeltaSimulationPatchVulnerabilityLowersModeledRisk(t *testing.T) {
+	now := time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)
+	before := compoundRiskFinding("runtime-kev", githubDependabotOpenAlertRuleID, "HIGH", "", "writer/cerebro", "urn:cerebro:writer:container_image:sha256:abc", "scan.detected")
+	before.LastObservedAt = now
+	before.Attributes["is_kev"] = "true"
+	before.Attributes["epss_score"] = "0.91"
+	before.Attributes["cvss_score"] = "9.8"
+	before.Attributes["exploit_available"] = "true"
+	before.Attributes["internet_exposed"] = "true"
+	before.Attributes["environment"] = "production"
+	before.Attributes["crown_jewel"] = "true"
+
+	after := cloneFindingWithoutAttributes(before, "is_kev", "epss_score", "cvss_score", "exploit_available")
+	beforeContext := AnalyzeFindingRiskContext(before, now)
+	afterContext := AnalyzeFindingRiskContext(after, now)
+
+	for _, reason := range []string{"known_exploited", "epss_high", "cvss_critical", "exploit_available"} {
+		if !stringSliceContains(beforeContext.Reasons, reason) {
+			t.Fatalf("before reasons = %#v, want %q", beforeContext.Reasons, reason)
+		}
+		if stringSliceContains(afterContext.Reasons, reason) {
+			t.Fatalf("after reasons = %#v, want %q removed", afterContext.Reasons, reason)
+		}
+	}
+	if beforeContext.Score <= afterContext.Score {
+		t.Fatalf("risk score before=%d after=%d, want vulnerability patch simulation to lower modeled risk", beforeContext.Score, afterContext.Score)
+	}
+	if beforeContext.LikelihoodScore <= afterContext.LikelihoodScore {
+		t.Fatalf("likelihood before=%d after=%d, want vulnerability patch simulation to lower likelihood", beforeContext.LikelihoodScore, afterContext.LikelihoodScore)
+	}
+}
+
+func cloneNeighborhoodWithoutRelation(neighborhoods map[string]*ports.EntityNeighborhood, relation string) map[string]*ports.EntityNeighborhood {
+	cloned := make(map[string]*ports.EntityNeighborhood, len(neighborhoods))
+	for key, neighborhood := range neighborhoods {
+		if neighborhood == nil {
+			continue
+		}
+		copyNeighborhood := *neighborhood
+		copyNeighborhood.Relations = nil
+		for _, edge := range neighborhood.Relations {
+			if edge == nil || edge.Relation == relation {
+				continue
+			}
+			copyEdge := *edge
+			copyNeighborhood.Relations = append(copyNeighborhood.Relations, &copyEdge)
+		}
+		cloned[key] = &copyNeighborhood
+	}
+	return cloned
+}
+
+func attackPathContainsRelation(paths []FindingAttackPath, relation string) bool {
+	for _, path := range paths {
+		for _, step := range path.Steps {
+			if step.Relation == relation {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sumAttackPathScores(paths []FindingAttackPath) int {
+	total := 0
+	for _, path := range paths {
+		total += path.Score
+	}
+	return total
+}
+
+func cloneFindingWithoutAttributes(finding *ports.FindingRecord, keys ...string) *ports.FindingRecord {
+	cloned := *finding
+	cloned.Attributes = make(map[string]string, len(finding.Attributes))
+	for key, value := range finding.Attributes {
+		cloned.Attributes[key] = value
+	}
+	for _, key := range keys {
+		delete(cloned.Attributes, key)
+	}
+	return &cloned
+}
+
 func stringSliceContains(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {

--- a/sources/aws/source.go
+++ b/sources/aws/source.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -777,6 +778,12 @@ func listAssetMetadata(ctx context.Context, clients awsClients, settings setting
 		PaginationToken:  stringPtr(cursor),
 		ResourcesPerPage: int32Ptr(assetMetadataPageSize(limit)),
 	})
+	var expired *resourcegroupstaggingapitypes.PaginationTokenExpiredException
+	if err != nil && strings.TrimSpace(cursor) != "" && errors.As(err, &expired) {
+		out, err = clients.tagging.GetResources(ctx, &resourcegroupstaggingapi.GetResourcesInput{
+			ResourcesPerPage: int32Ptr(assetMetadataPageSize(limit)),
+		})
+	}
 	if err != nil {
 		return nil, "", err
 	}

--- a/sources/aws/source_test.go
+++ b/sources/aws/source_test.go
@@ -426,6 +426,38 @@ func TestReadAWSAssetMetadataPaginatesTaggedResources(t *testing.T) {
 	}
 }
 
+func TestReadAWSAssetMetadataRestartsExpiredPaginationToken(t *testing.T) {
+	var tokens []string
+	source := newTestSource(t, fakeAWS{getResources: func(_ context.Context, input *resourcegroupstaggingapi.GetResourcesInput, _ ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+		token := awssdk.ToString(input.PaginationToken)
+		tokens = append(tokens, token)
+		if token == "expired-token" {
+			return nil, &resourcegroupstaggingapitypes.PaginationTokenExpiredException{}
+		}
+		return &resourcegroupstaggingapi.GetResourcesOutput{ResourceTagMappingList: []resourcegroupstaggingapitypes.ResourceTagMapping{{
+			ResourceARN: awssdk.String("arn:aws:s3:::prod-data"),
+		}}}, nil
+	}})
+
+	pull, err := source.Read(
+		context.Background(),
+		sourcecdk.NewConfig(map[string]string{"account_id": "123456789012", "family": familyAssetMetadata}),
+		&cerebrov1.SourceCursor{Opaque: "expired-token"},
+	)
+	if err != nil {
+		t.Fatalf("Read(asset_metadata expired cursor) error = %v", err)
+	}
+	if len(tokens) != 2 || tokens[0] != "expired-token" || tokens[1] != "" {
+		t.Fatalf("GetResources tokens = %#v, want expired token then restart without token", tokens)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(pull.Events))
+	}
+	if got := pull.Events[0].Attributes["resource_id"]; got != "arn:aws:s3:::prod-data" {
+		t.Fatalf("resource_id = %q, want arn:aws:s3:::prod-data", got)
+	}
+}
+
 func TestReadAWSRoleAndAccessKeyPreview(t *testing.T) {
 	source := newTestSource(t, fakeAWS{
 		roles: []iamtypes.Role{{
@@ -1207,6 +1239,7 @@ type fakeAWS struct {
 	apiV2Domains           []apigatewayv2types.DomainName
 	apiV2APIs              []apigatewayv2types.Api
 	taggedResources        []resourcegroupstaggingapitypes.ResourceTagMapping
+	getResources           func(context.Context, *resourcegroupstaggingapi.GetResourcesInput, ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error)
 }
 
 type recordingAWS struct {
@@ -1521,7 +1554,10 @@ func (f fakeAWS) GetRestApis(_ context.Context, _ *apigateway.GetRestApisInput, 
 	return &apigateway.GetRestApisOutput{Items: f.restAPIs}, nil
 }
 
-func (f fakeAWS) GetResources(_ context.Context, input *resourcegroupstaggingapi.GetResourcesInput, _ ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+func (f fakeAWS) GetResources(ctx context.Context, input *resourcegroupstaggingapi.GetResourcesInput, options ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	if f.getResources != nil {
+		return f.getResources(ctx, input, options...)
+	}
 	records, next := paginateResourceTags(f.taggedResources, awssdk.ToString(input.PaginationToken), int(awssdk.ToInt32(input.ResourcesPerPage)))
 	return &resourcegroupstaggingapi.GetResourcesOutput{ResourceTagMappingList: records, PaginationToken: stringPtr(next)}, nil
 }


### PR DESCRIPTION
## Summary
- adds deeper graph signal coverage tests for risk delta simulations
- hardens AWS asset_metadata ingestion against expired Resource Groups Tagging API pagination tokens
- preserves validated runtime link work on the service graph branch

## Validation
- go test ./sources/aws ./tools/archtests ./internal/findings -count=1
- make verify