### PR TITLE
Add bootstrap MCP endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -16,6 +16,7 @@ tags:
   - name: Graph
   - name: Health
   - name: Knowledge
+  - name: MCP
   - name: Platform
   - name: Reports
   - name: Sources
@@ -49,6 +50,37 @@ paths:
       responses:
         '200':
           description: Embedded OpenAPI YAML.
+  /api/v1/mcp:
+    get:
+      summary: Open MCP Streamable HTTP event stream
+      tags:
+        - MCP
+      responses:
+        '200':
+          description: MCP server-sent event stream.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+    post:
+      summary: Invoke MCP JSON-RPC method
+      tags:
+        - MCP
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: MCP JSON-RPC response.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
   /sources:
     get:
       summary: List registered sources

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -552,6 +552,9 @@ func isConnectProcedurePath(path string) bool {
 
 func scopeForHTTPRequest(r *http.Request) string {
 	path := strings.TrimSpace(r.URL.Path)
+	if path == "/api/v1/mcp" {
+		return scopeCosmoSecurityRead
+	}
 	if r.Method == http.MethodPost && path == "/grc/ask" {
 		return scopeCosmoSecurityRead
 	}
@@ -1152,6 +1155,9 @@ func accessAuditOperation(r *http.Request, route string) accessAuditOperationInf
 		}
 	}
 	operationType := accessAuditHTTPOperationType(r.Method)
+	if route == "GET /api/v1/mcp" || route == "POST /api/v1/mcp" {
+		operationType = "read"
+	}
 	return accessAuditOperationInfo{
 		Family:          accessAuditRouteFamily(route),
 		Type:            operationType,
@@ -1251,6 +1257,8 @@ func accessAuditRouteFamily(route string) string {
 		return "workflow"
 	case strings.Contains(route, "/platform/graph"):
 		return "graph"
+	case strings.Contains(route, "/api/v1/mcp"):
+		return "mcp"
 	case route == "":
 		return "unknown"
 	default:
@@ -1347,6 +1355,8 @@ var knownAccessAuditConnectProcedures = map[string]struct{}{
 func fallbackAccessAuditRoute(method string, path string) string {
 	prefix := strings.TrimSpace(method) + " "
 	switch {
+	case path == "/api/v1/mcp":
+		return prefix + "/api/v1/mcp"
 	case path == "/sources":
 		return prefix + "/sources"
 	case strings.HasPrefix(path, "/sources/"):

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -1,0 +1,522 @@
+package bootstrap
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/buildinfo"
+	findingdomain "github.com/writer/cerebro/internal/findings"
+	"github.com/writer/cerebro/internal/graphquery"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourceruntime"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	mcpProtocolVersion = "2025-03-26"
+	mcpEndpointPath    = "/api/v1/mcp"
+)
+
+type mcpJSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type mcpJSONRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *mcpError       `json:"error,omitempty"`
+}
+
+type mcpError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type mcpTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+type mcpToolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type mcpToolResult struct {
+	Content           []mcpContent `json:"content"`
+	StructuredContent any          `json:"structuredContent,omitempty"`
+	IsError           bool         `json:"isError,omitempty"`
+}
+
+type mcpContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func (app *App) handleMCP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxProtoJSONBodyBytes))
+	decoder.UseNumber()
+	var request mcpJSONRPCRequest
+	if err := decoder.Decode(&request); err != nil {
+		mcpWriteJSONRPC(w, r, mcpJSONRPCResponse{
+			JSONRPC: "2.0",
+			Error:   &mcpError{Code: -32700, Message: "parse error"},
+		})
+		return
+	}
+	if len(request.ID) == 0 && strings.HasPrefix(request.Method, "notifications/") {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	response := app.handleMCPRequest(r, request)
+	mcpWriteJSONRPC(w, r, response)
+}
+
+func (app *App) handleMCPStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	sessionID := mcpSessionID(r)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Mcp-Session-Id", sessionID)
+	_, _ = fmt.Fprintf(w, "event: ready\ndata: %s\n\n", mcpEndpointPath)
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (app *App) handleMCPRequest(r *http.Request, request mcpJSONRPCRequest) mcpJSONRPCResponse {
+	response := mcpJSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      request.ID,
+	}
+	if request.JSONRPC != "2.0" || strings.TrimSpace(request.Method) == "" {
+		response.Error = &mcpError{Code: -32600, Message: "invalid request"}
+		return response
+	}
+	switch request.Method {
+	case "initialize":
+		response.Result = app.mcpInitializeResult(r)
+	case "ping":
+		response.Result = map[string]any{}
+	case "tools/list":
+		response.Result = map[string]any{"tools": mcpTools()}
+	case "tools/call":
+		result, err := app.mcpCallTool(r, request.Params)
+		if err != nil {
+			response.Error = &mcpError{Code: -32602, Message: err.Error()}
+			return response
+		}
+		response.Result = result
+	case "notifications/initialized":
+		response.Result = map[string]any{}
+	default:
+		response.Error = &mcpError{Code: -32601, Message: "method not found"}
+	}
+	return response
+}
+
+func (app *App) mcpInitializeResult(r *http.Request) map[string]any {
+	return map[string]any{
+		"protocolVersion": mcpNegotiatedProtocolVersion(r),
+		"capabilities": map[string]any{
+			"tools": map[string]any{},
+		},
+		"serverInfo": map[string]any{
+			"name":    buildinfo.ServiceName,
+			"version": buildinfo.Version,
+		},
+	}
+}
+
+func (app *App) mcpCallTool(r *http.Request, rawParams json.RawMessage) (mcpToolResult, error) {
+	var params mcpToolCallParams
+	if err := decodeMCPJSON(rawParams, &params); err != nil {
+		return mcpToolResult{}, fmt.Errorf("invalid tool call params")
+	}
+	args := map[string]any{}
+	if len(params.Arguments) != 0 {
+		if err := decodeMCPJSON(params.Arguments, &args); err != nil {
+			return mcpToolResult{}, fmt.Errorf("invalid tool arguments")
+		}
+	}
+	structured, err := app.mcpToolStructuredContent(r, strings.TrimSpace(params.Name), args)
+	if err != nil {
+		return mcpErrorToolResult(safeMCPToolError(err)), nil
+	}
+	return mcpSuccessToolResult(structured)
+}
+
+func (app *App) mcpToolStructuredContent(r *http.Request, name string, args map[string]any) (any, error) {
+	switch name {
+	case "cerebro.health":
+		return protoJSONValue(healthResponse(r.Context(), app.cfg, app.deps))
+	case "cerebro.version":
+		return protoJSONValue(&cerebrov1.GetVersionResponse{
+			ServiceName: buildinfo.ServiceName,
+			Version:     buildinfo.Version,
+			Commit:      buildinfo.Commit,
+			BuildDate:   buildinfo.BuildDate,
+			ApiVersion:  buildinfo.APIVersion,
+		})
+	case "cerebro.source_runtimes.list":
+		return app.mcpListSourceRuntimes(r, args)
+	case "cerebro.findings.list":
+		return app.mcpListFindings(r, args)
+	case "cerebro.graph.neighborhood":
+		return app.mcpGraphNeighborhood(r, args)
+	default:
+		return nil, fmt.Errorf("%w: unknown tool %q", errInvalidHTTPRequest, name)
+	}
+}
+
+func (app *App) mcpListSourceRuntimes(r *http.Request, args map[string]any) (any, error) {
+	limit, err := mcpUint32Arg(args, "limit")
+	if err != nil {
+		return nil, err
+	}
+	filter := ports.SourceRuntimeFilter{
+		RuntimeID: mcpStringArg(args, "runtime_id"),
+		TenantID:  mcpStringArg(args, "tenant_id"),
+		SourceID:  mcpStringArg(args, "source_id"),
+		Limit:     limit,
+	}
+	if filter.TenantID == "" {
+		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok && strings.TrimSpace(auth.principal.TenantID) != "" {
+			filter.TenantID = strings.TrimSpace(auth.principal.TenantID)
+		}
+	}
+	if filter.TenantID == "" && filter.RuntimeID != "" && requiresTenantFilter(r.Context()) {
+		store := sourceRuntimeStore(app.deps.StateStore)
+		if store == nil {
+			return nil, sourceruntime.ErrRuntimeUnavailable
+		}
+		runtime, err := store.GetSourceRuntime(r.Context(), filter.RuntimeID)
+		if errors.Is(err, ports.ErrSourceRuntimeNotFound) {
+			return map[string]any{"runtimes": []any{}}, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		if !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
+			return map[string]any{"runtimes": []any{}}, nil
+		}
+		filter.TenantID = strings.TrimSpace(runtime.GetTenantId())
+	}
+	if filter.TenantID == "" && filter.RuntimeID == "" && requiresTenantFilter(r.Context()) {
+		return nil, errTenantForbidden
+	}
+	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
+		return nil, err
+	}
+	runtimes, err := app.runtimeService().List(r.Context(), filter)
+	if err != nil {
+		return nil, err
+	}
+	values := make([]any, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		value, err := protoJSONValue(redactSourceRuntime(runtime))
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+	return map[string]any{"runtimes": values}, nil
+}
+
+func (app *App) mcpListFindings(r *http.Request, args map[string]any) (any, error) {
+	runtimeID := mcpStringArg(args, "runtime_id")
+	if strings.TrimSpace(runtimeID) == "" {
+		return nil, fmt.Errorf("%w: runtime_id is required", findingdomain.ErrInvalidRequest)
+	}
+	status := ""
+	if rawStatus := mcpStringArg(args, "status"); rawStatus != "" {
+		parsed, err := parseFindingStatus(rawStatus)
+		if err != nil {
+			return nil, err
+		}
+		status = findingStatusString(parsed)
+	}
+	order := ports.FindingOrder("")
+	if rawOrder := mcpStringArg(args, "order"); rawOrder != "" {
+		parsed, err := parseFindingOrder(rawOrder)
+		if err != nil {
+			return nil, err
+		}
+		order = findingOrder(parsed)
+	}
+	limit, err := mcpUint32Arg(args, "limit")
+	if err != nil {
+		return nil, err
+	}
+	if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(app.deps.StateStore), runtimeID, false); err != nil {
+		return nil, err
+	}
+	response, err := app.findingService().ListFindings(r.Context(), findingdomain.ListRequest{
+		RuntimeID:   runtimeID,
+		FindingID:   mcpStringArg(args, "finding_id"),
+		RuleID:      mcpStringArg(args, "rule_id"),
+		Severity:    mcpStringArg(args, "severity"),
+		Status:      status,
+		ResourceURN: mcpStringArg(args, "resource_urn"),
+		EventID:     mcpStringArg(args, "event_id"),
+		PolicyID:    mcpStringArg(args, "policy_id"),
+		Limit:       limit,
+		Order:       order,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return protoJSONValue(listFindingsResponse(response))
+}
+
+func (app *App) mcpGraphNeighborhood(r *http.Request, args map[string]any) (any, error) {
+	rootURN := mcpStringArg(args, "root_urn")
+	limit, err := mcpUint32Arg(args, "limit")
+	if err != nil {
+		return nil, err
+	}
+	if err := authorizeCerebroURNTenant(r.Context(), rootURN); err != nil {
+		return nil, err
+	}
+	response, err := app.graphQueryService().GetEntityNeighborhood(r.Context(), graphquery.NeighborhoodRequest{
+		RootURN: rootURN,
+		Limit:   limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return protoJSONValue(graphNeighborhoodResponse(response))
+}
+
+func mcpTools() []mcpTool {
+	return []mcpTool{
+		{
+			Name:        "cerebro.health",
+			Description: "Return Cerebro service health and dependency status.",
+			InputSchema: mcpObjectSchema(nil, nil),
+		},
+		{
+			Name:        "cerebro.version",
+			Description: "Return Cerebro service build and API version metadata.",
+			InputSchema: mcpObjectSchema(nil, nil),
+		},
+		{
+			Name:        "cerebro.source_runtimes.list",
+			Description: "List source runtimes visible to the authenticated caller. Runtime config values are redacted.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"runtime_id": map[string]any{"type": "string"},
+				"tenant_id":  map[string]any{"type": "string"},
+				"source_id":  map[string]any{"type": "string"},
+				"limit":      map[string]any{"type": "integer", "minimum": 1},
+			}, nil),
+		},
+		{
+			Name:        "cerebro.findings.list",
+			Description: "List findings for one source runtime visible to the authenticated caller.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"runtime_id":   map[string]any{"type": "string"},
+				"finding_id":   map[string]any{"type": "string"},
+				"rule_id":      map[string]any{"type": "string"},
+				"severity":     map[string]any{"type": "string"},
+				"status":       map[string]any{"type": "string", "enum": []string{"open", "resolved", "suppressed"}},
+				"resource_urn": map[string]any{"type": "string"},
+				"event_id":     map[string]any{"type": "string"},
+				"policy_id":    map[string]any{"type": "string"},
+				"limit":        map[string]any{"type": "integer", "minimum": 1},
+				"order":        map[string]any{"type": "string", "enum": []string{"last_observed", "priority", "risk_score"}},
+			}, []string{"runtime_id"}),
+		},
+		{
+			Name:        "cerebro.graph.neighborhood",
+			Description: "Return a bounded graph neighborhood around a Cerebro URN visible to the authenticated caller.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"root_urn": map[string]any{"type": "string"},
+				"limit":    map[string]any{"type": "integer", "minimum": 1},
+			}, []string{"root_urn"}),
+		},
+	}
+}
+
+func mcpObjectSchema(properties map[string]any, required []string) map[string]any {
+	if properties == nil {
+		properties = map[string]any{}
+	}
+	schema := map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"additionalProperties": false,
+	}
+	if len(required) != 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func mcpSuccessToolResult(structured any) (mcpToolResult, error) {
+	text, err := json.Marshal(structured)
+	if err != nil {
+		return mcpToolResult{}, err
+	}
+	return mcpToolResult{
+		Content: []mcpContent{{
+			Type: "text",
+			Text: string(text),
+		}},
+		StructuredContent: structured,
+	}, nil
+}
+
+func mcpErrorToolResult(message string) mcpToolResult {
+	return mcpToolResult{
+		Content: []mcpContent{{
+			Type: "text",
+			Text: message,
+		}},
+		IsError: true,
+	}
+}
+
+func protoJSONValue(message proto.Message) (any, error) {
+	payload, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	var value any
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func decodeMCPJSON(raw json.RawMessage, value any) error {
+	if len(raw) == 0 {
+		raw = []byte("{}")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	return decoder.Decode(value)
+}
+
+func mcpStringArg(args map[string]any, key string) string {
+	value, ok := args[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return strings.TrimSpace(typed.String())
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func mcpUint32Arg(args map[string]any, key string) (uint32, error) {
+	value, ok := args[key]
+	if !ok || value == nil || value == "" {
+		return 0, nil
+	}
+	var raw string
+	switch typed := value.(type) {
+	case json.Number:
+		raw = typed.String()
+	case float64:
+		raw = fmt.Sprintf("%.0f", typed)
+	case string:
+		raw = strings.TrimSpace(typed)
+	default:
+		raw = strings.TrimSpace(fmt.Sprint(typed))
+	}
+	if raw == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s must be a positive integer", errInvalidHTTPRequest, key)
+	}
+	if parsed == 0 || parsed > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("%w: %s must be between 1 and %d", errInvalidHTTPRequest, key, uint64(^uint32(0)))
+	}
+	return uint32(parsed), nil
+}
+
+func mcpWriteJSONRPC(w http.ResponseWriter, r *http.Request, response mcpJSONRPCResponse) {
+	sessionID := mcpSessionID(r)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Mcp-Session-Id", sessionID)
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func mcpSessionID(r *http.Request) string {
+	if r != nil {
+		if sessionID := strings.TrimSpace(r.Header.Get("Mcp-Session-Id")); sessionID != "" {
+			return sessionID
+		}
+	}
+	var bytes [16]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return "cerebro-session"
+	}
+	return hex.EncodeToString(bytes[:])
+}
+
+func mcpNegotiatedProtocolVersion(r *http.Request) string {
+	version := strings.TrimSpace(r.Header.Get("MCP-Protocol-Version"))
+	if version != "" {
+		return version
+	}
+	return mcpProtocolVersion
+}
+
+func safeMCPToolError(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, errTenantForbidden):
+		return "tenant forbidden"
+	case errors.Is(err, errInvalidHTTPRequest),
+		errors.Is(err, graphquery.ErrInvalidRequest),
+		errors.Is(err, sourceruntime.ErrInvalidRequest),
+		errors.Is(err, findingdomain.ErrInvalidRequest):
+		return err.Error()
+	case errors.Is(err, ports.ErrSourceRuntimeNotFound):
+		return "source runtime not found"
+	case errors.Is(err, ports.ErrFindingNotFound):
+		return "finding not found"
+	case errors.Is(err, ports.ErrGraphEntityNotFound):
+		return "graph entity not found"
+	case errors.Is(err, graphquery.ErrRuntimeUnavailable),
+		errors.Is(err, sourceruntime.ErrRuntimeUnavailable),
+		errors.Is(err, findingdomain.ErrRuntimeUnavailable):
+		return "runtime unavailable"
+	default:
+		return "tool execution failed"
+	}
+}

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -1,0 +1,276 @@
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestMCPRequiresAuth(t *testing.T) {
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APIKeys: []config.APIKey{{
+				Key:       "test-key",
+				Principal: "tester",
+				TenantID:  "writer",
+			}},
+		},
+	}, Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Post(server.URL+mcpEndpointPath, "application/json", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	if err != nil {
+		t.Fatalf("POST /api/v1/mcp without auth error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("POST /api/v1/mcp without auth status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestMCPInitializeAndToolsList(t *testing.T) {
+	server := newMCPTestServer(t, &stubRuntimeStore{})
+	defer server.Close()
+
+	initResp, sessionID := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": mcpProtocolVersion,
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "unit-test", "version": "0"},
+		},
+	})
+	if initResp["error"] != nil {
+		t.Fatalf("initialize error = %#v", initResp["error"])
+	}
+	result := initResp["result"].(map[string]any)
+	serverInfo := result["serverInfo"].(map[string]any)
+	if serverInfo["name"] != "cerebro" {
+		t.Fatalf("serverInfo.name = %#v, want cerebro", serverInfo["name"])
+	}
+	if sessionID == "" {
+		t.Fatal("Mcp-Session-Id header empty")
+	}
+
+	toolsResp, _ := postMCP(t, server, sessionID, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+		"params":  map[string]any{},
+	})
+	if toolsResp["error"] != nil {
+		t.Fatalf("tools/list error = %#v", toolsResp["error"])
+	}
+	tools := toolsResp["result"].(map[string]any)["tools"].([]any)
+	names := map[string]bool{}
+	for _, item := range tools {
+		names[item.(map[string]any)["name"].(string)] = true
+	}
+	for _, want := range []string{"cerebro.health", "cerebro.version", "cerebro.source_runtimes.list", "cerebro.findings.list", "cerebro.graph.neighborhood"} {
+		if !names[want] {
+			t.Fatalf("tools/list missing %s in %#v", want, names)
+		}
+	}
+}
+
+func TestMCPSourceRuntimesListRedactsConfig(t *testing.T) {
+	store := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-okta": {
+			Id:       "writer-okta",
+			SourceId: "okta",
+			TenantId: "writer",
+			Config: map[string]string{
+				"domain": "writer.okta.com",
+				"token":  "secret-value",
+			},
+		},
+	}}
+	server := newMCPTestServer(t, store)
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.source_runtimes.list",
+			"arguments": map[string]any{
+				"tenant_id": "writer",
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("tools/call error = %#v", response["error"])
+	}
+	body, _ := json.Marshal(response)
+	if strings.Contains(string(body), "secret-value") {
+		t.Fatalf("MCP response leaked runtime secret: %s", body)
+	}
+	result := response["result"].(map[string]any)
+	structured := result["structuredContent"].(map[string]any)
+	runtimes := structured["runtimes"].([]any)
+	if len(runtimes) != 1 {
+		t.Fatalf("len(runtimes) = %d, want 1", len(runtimes))
+	}
+	config := runtimes[0].(map[string]any)["config"].(map[string]any)
+	if config["token"] != "[redacted]" {
+		t.Fatalf("redacted token = %#v, want [redacted]", config["token"])
+	}
+}
+
+func TestMCPFindingsListUsesRuntimeScope(t *testing.T) {
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta": {Id: "writer-okta", SourceId: "okta", TenantId: "writer"},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:             "finding-1",
+				RuntimeID:      "writer-okta",
+				TenantID:       "writer",
+				RuleID:         "rule-1",
+				Title:          "Finding One",
+				Severity:       "high",
+				Status:         "open",
+				LastObservedAt: time.Now().UTC(),
+			},
+		},
+	}
+	server := newMCPTestServer(t, store)
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.findings.list",
+			"arguments": map[string]any{
+				"runtime_id": "writer-okta",
+				"status":     "open",
+				"limit":      10,
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("tools/call error = %#v", response["error"])
+	}
+	if store.findingListRequest.RuntimeID != "writer-okta" || store.findingListRequest.Status != "open" || store.findingListRequest.Limit != 10 {
+		t.Fatalf("finding list request = %#v", store.findingListRequest)
+	}
+	result := response["result"].(map[string]any)
+	findings := result["structuredContent"].(map[string]any)["findings"].([]any)
+	if len(findings) != 1 {
+		t.Fatalf("len(findings) = %d, want 1", len(findings))
+	}
+}
+
+func TestMCPGraphNeighborhood(t *testing.T) {
+	store := &stubRuntimeStore{}
+	graph := &stubGraphStore{neighborhood: &ports.EntityNeighborhood{
+		Root: &ports.NeighborhoodNode{URN: "urn:cerebro:writer:asset:prod-db", EntityType: "asset", Label: "prod-db"},
+		Neighbors: []*ports.NeighborhoodNode{
+			{URN: "urn:cerebro:writer:finding:finding-1", EntityType: "finding", Label: "finding-1"},
+		},
+	}}
+	server := newMCPTestServerWithGraph(t, store, graph)
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.graph.neighborhood",
+			"arguments": map[string]any{
+				"root_urn": "urn:cerebro:writer:asset:prod-db",
+				"limit":    5,
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("tools/call error = %#v", response["error"])
+	}
+	if graph.neighborhoodRootURN != "urn:cerebro:writer:asset:prod-db" || graph.neighborhoodLimit != 5 {
+		t.Fatalf("graph query = (%q, %d)", graph.neighborhoodRootURN, graph.neighborhoodLimit)
+	}
+}
+
+func TestMCPRouteUsesReadScope(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, mcpEndpointPath, nil)
+	if got := scopeForHTTPRequest(req); got != scopeCosmoSecurityRead {
+		t.Fatalf("scopeForHTTPRequest(POST %s) = %q, want %q", mcpEndpointPath, got, scopeCosmoSecurityRead)
+	}
+}
+
+func newMCPTestServer(t *testing.T, store *stubRuntimeStore) *httptest.Server {
+	t.Helper()
+	return newMCPTestServerWithGraph(t, store, nil)
+}
+
+func newMCPTestServerWithGraph(t *testing.T, store *stubRuntimeStore, graph *stubGraphStore) *httptest.Server {
+	t.Helper()
+	app := New(config.Config{
+		HTTPAddr:        "127.0.0.1:0",
+		ShutdownTimeout: time.Second,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			APIKeys: []config.APIKey{{
+				Key:       "test-key",
+				Principal: "tester",
+				TenantID:  "writer",
+			}},
+		},
+	}, Dependencies{StateStore: store, GraphStore: graph}, nil)
+	return httptest.NewServer(app.Handler())
+}
+
+func postMCP(t *testing.T, server *httptest.Server, sessionID string, payload map[string]any) (map[string]any, string) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal MCP request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, server.URL+mcpEndpointPath, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer test-key")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/v1/mcp error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll MCP response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /api/v1/mcp status = %d body = %s", resp.StatusCode, raw)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal MCP response %s: %v", raw, err)
+	}
+	return decoded, resp.Header.Get("Mcp-Session-Id")
+}

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -28,6 +28,7 @@ func (app *App) registerRoutes(mux *http.ServeMux, cfg config.Config, deps Depen
 	app.registerKnowledgeRoutes(mux)
 	app.registerGraphRoutes(mux)
 	app.registerSourceRuntimeRoutes(mux)
+	app.registerMCPRoutes(mux)
 	app.registerDeviceRoutes(mux)
 }
 
@@ -120,6 +121,11 @@ func (app *App) registerSourceRuntimeRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /source-runtimes/{runtimeID}/finding-candidates/evaluate", routeSurfacePlatformHTTP, app.handleEvaluateSourceRuntimeFindingCandidates)
 	registerHTTPRoute(mux, "POST /source-runtimes/{runtimeID}/finding-rules/evaluate", routeSurfacePlatformHTTP, app.handleEvaluateSourceRuntimeFindingRules)
 	registerHTTPRoute(mux, "POST /source-runtimes/{runtimeID}/findings/evaluate", routeSurfacePlatformHTTP, app.handleEvaluateSourceRuntimeFindings)
+}
+
+func (app *App) registerMCPRoutes(mux *http.ServeMux) {
+	registerHTTPRoute(mux, "GET /api/v1/mcp", routeSurfacePlatformHTTP, app.handleMCPStream)
+	registerHTTPRoute(mux, "POST /api/v1/mcp", routeSurfacePlatformHTTP, app.handleMCP)
 }
 
 func (app *App) registerDeviceRoutes(mux *http.ServeMux) {

--- a/scripts/openapi_route_parity.go
+++ b/scripts/openapi_route_parity.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	routePattern   = regexp.MustCompile(`mux\.HandleFunc\("(?:(GET|POST|PUT|PATCH|DELETE) )?([^"]+)"`)
+	routePattern   = regexp.MustCompile(`(?:mux\.HandleFunc\(|registerHTTPRoute\(mux,\s*)"(?:(GET|POST|PUT|PATCH|DELETE) )?([^"]+)"`)
 	pathPattern    = regexp.MustCompile(`^  (/[^:]+):\s*$`)
 	methodPattern  = regexp.MustCompile(`^    (get|post|put|patch|delete):\s*$`)
 	componentsLine = []byte("\ncomponents:\n")
@@ -26,7 +26,7 @@ func main() {
 	write := flag.Bool("write", false, "add placeholder OpenAPI paths for missing routes")
 	flag.Parse()
 
-	routes, err := registeredRoutes("internal/bootstrap/app.go")
+	routes, err := registeredRoutes("internal/bootstrap/app.go", "internal/bootstrap/routes.go")
 	if err != nil {
 		fail(err)
 	}
@@ -63,20 +63,22 @@ func main() {
 	os.Exit(1)
 }
 
-func registeredRoutes(path string) ([]route, error) {
-	payload, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	matches := routePattern.FindAllStringSubmatch(string(payload), -1)
+func registeredRoutes(paths ...string) ([]route, error) {
 	seen := map[route]struct{}{}
-	for _, match := range matches {
-		method := strings.ToLower(strings.TrimSpace(match[1]))
-		routePath := strings.TrimSpace(match[2])
-		if routePath == "" {
-			continue
+	for _, path := range paths {
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
 		}
-		seen[route{Method: method, Path: routePath}] = struct{}{}
+		matches := routePattern.FindAllStringSubmatch(string(payload), -1)
+		for _, match := range matches {
+			method := strings.ToLower(strings.TrimSpace(match[1]))
+			routePath := strings.TrimSpace(match[2])
+			if routePath == "" {
+				continue
+			}
+			seen[route{Method: method, Path: routePath}] = struct{}{}
+		}
 	}
 	routes := make([]route, 0, len(seen))
 	for route := range seen {


### PR DESCRIPTION
## Summary
- add authenticated `/api/v1/mcp` GET/POST endpoints in bootstrap
- expose read-only MCP tools for health, version, source runtimes, findings, and graph neighborhood
- update OpenAPI coverage and route-parity scanning for current route registrations

## Validation
- `go test ./... -count=1`
- `make lint-bootstrap openapi-check openapi-lint`
- pre-commit checks during commit
- local MCP smoke against tmux server: initialize/tools/list/cerebro.health