### PR TITLE
feat(graph): report topology and non-blocking quality drift in graph health

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -68,6 +68,10 @@ type graphIntegrityStore interface {
 	IntegrityChecks(context.Context) ([]graphstore.IntegrityCheck, error)
 }
 
+type graphTopologyStore interface {
+	Topology(context.Context) (graphstore.Topology, error)
+}
+
 type graphOpenFindingPrimaryLinkRepairStore interface {
 	RepairOpenFindingPrimaryLinks(context.Context, graphstore.OpenFindingPrimaryLinkRepairRequest) (graphstore.OpenFindingPrimaryLinkRepairResult, error)
 }
@@ -140,19 +144,23 @@ type graphHealthOptions struct {
 	IngestLimit                  int
 	MaxRunningMinutes            int
 	RequiredRelations            []string
+	ReportRelations              []string
+	MaxIsolatedRatio             float64
 	DeclaredRuntimeIDs           []string
 	AllowTransientSourceFailures bool
 }
 
 type graphHealthResult struct {
-	Status         string                    `json:"status"`
-	CheckedAt      time.Time                 `json:"checked_at"`
-	Counts         graphstore.Counts         `json:"counts"`
-	Integrity      graphIntegrityResult      `json:"integrity"`
-	RelationCounts graphstore.RelationCounts `json:"relation_counts,omitempty"`
-	Ingest         graphHealthIngestResult   `json:"ingest"`
-	Failures       []string                  `json:"failures,omitempty"`
-	Warnings       []string                  `json:"warnings,omitempty"`
+	Status                 string                    `json:"status"`
+	CheckedAt              time.Time                 `json:"checked_at"`
+	Counts                 graphstore.Counts         `json:"counts"`
+	Topology               *graphstore.Topology      `json:"topology,omitempty"`
+	Integrity              graphIntegrityResult      `json:"integrity"`
+	RelationCounts         graphstore.RelationCounts `json:"relation_counts,omitempty"`
+	ReportedRelationCounts graphstore.RelationCounts `json:"reported_relation_counts,omitempty"`
+	Ingest                 graphHealthIngestResult   `json:"ingest"`
+	Failures               []string                  `json:"failures,omitempty"`
+	Warnings               []string                  `json:"warnings,omitempty"`
 }
 
 type graphHealthIngestResult struct {
@@ -570,6 +578,22 @@ func checkGraphHealth(ctx context.Context, store ports.GraphStore, options graph
 		}
 	}
 
+	if topologyStore, ok := store.(graphTopologyStore); ok {
+		topology, err := topologyStore.Topology(ctx)
+		if err != nil {
+			addWarning("compute graph topology: %v", err)
+		} else {
+			result.Topology = &topology
+			total := topology.Isolated + topology.SourcesOnly + topology.SinksOnly + topology.Intermediates
+			if total > 0 && options.MaxIsolatedRatio > 0 {
+				ratio := float64(topology.Isolated) / float64(total)
+				if ratio > options.MaxIsolatedRatio {
+					addWarning("graph isolated-node ratio %.4f exceeds max %.4f (%d isolated of %d nodes)", ratio, options.MaxIsolatedRatio, topology.Isolated, total)
+				}
+			}
+		}
+	}
+
 	integrityStore, ok := store.(graphIntegrityStore)
 	if !ok {
 		addFailure("graph store does not support integrity checks")
@@ -604,6 +628,30 @@ func checkGraphHealth(ctx context.Context, store ports.GraphStore, options graph
 					if counts[relation] <= 0 {
 						addFailure("graph relation %q has zero relationships", relation)
 					}
+				}
+			}
+		}
+	}
+
+	if len(options.ReportRelations) != 0 {
+		relationStore, ok := store.(graphRelationCountsStore)
+		if !ok {
+			addWarning("graph store does not support relation counts for reporting")
+		} else {
+			counts, err := relationStore.RelationCounts(ctx, options.ReportRelations)
+			if err != nil {
+				addWarning("count reported graph relation records: %v", err)
+			} else {
+				result.ReportedRelationCounts = counts
+				var zeroed []string
+				for _, relation := range options.ReportRelations {
+					if counts[relation] <= 0 {
+						zeroed = append(zeroed, relation)
+					}
+				}
+				if len(zeroed) != 0 {
+					sort.Strings(zeroed)
+					addWarning("graph has zero edges for %d reported relation(s): %s", len(zeroed), strings.Join(zeroed, ", "))
 				}
 			}
 		}
@@ -952,6 +1000,20 @@ func parseGraphHealthArgs(args []string) (graphHealthOptions, error) {
 			if len(options.RequiredRelations) > 50 {
 				return graphHealthOptions{}, fmt.Errorf("relations must include at most 50 values")
 			}
+		case "report_relations":
+			options.ReportRelations = appendUniqueGraphHealthValues(options.ReportRelations, splitCleanupValues(value))
+			if len(options.ReportRelations) > 50 {
+				return graphHealthOptions{}, fmt.Errorf("report_relations must include at most 50 values")
+			}
+		case "max_isolated_ratio":
+			parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+			if err != nil {
+				return graphHealthOptions{}, fmt.Errorf("parse max_isolated_ratio: %w", err)
+			}
+			if parsed < 0 || parsed > 1 {
+				return graphHealthOptions{}, fmt.Errorf("max_isolated_ratio must be between 0 and 1")
+			}
+			options.MaxIsolatedRatio = parsed
 		case "declared_runtime_ids", "runtime_ids":
 			options.DeclaredRuntimeIDs = appendUniqueGraphHealthValues(options.DeclaredRuntimeIDs, splitCleanupValues(value))
 		case "allow_transient_source_failures":

--- a/cmd/cerebro/graph_health_test.go
+++ b/cmd/cerebro/graph_health_test.go
@@ -34,6 +34,54 @@ func TestCheckGraphHealthPasses(t *testing.T) {
 	if result.Ingest.CurrentRuntimeCount != 1 {
 		t.Fatalf("current runtime count = %d, want 1", result.Ingest.CurrentRuntimeCount)
 	}
+	if result.Topology == nil || result.Topology.SourcesOnly != 1 || result.Topology.SinksOnly != 1 || result.Topology.Isolated != 0 {
+		t.Fatalf("topology = %#v, want sources_only=1 sinks_only=1 isolated=0", result.Topology)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none for report-only topology", result.Warnings)
+	}
+}
+
+func TestCheckGraphHealthReportsTopologyAndRelationDrift(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	store := graphHealthFixtureStore(t, now)
+	if err := store.UpsertProjectedEntity(ctx, &ports.ProjectedEntity{
+		URN:        "urn:cerebro:writer:identity:orphan",
+		TenantID:   "writer",
+		SourceID:   "test",
+		EntityType: "identity",
+		Label:      "orphan",
+	}); err != nil {
+		t.Fatalf("UpsertProjectedEntity(orphan) error = %v", err)
+	}
+
+	result, err := checkGraphHealth(ctx, store, graphHealthOptions{
+		IngestLimit:       10,
+		MaxRunningMinutes: 60,
+		RequiredRelations: []string{"belongs_to"},
+		ReportRelations:   []string{"belongs_to", "can_assume"},
+		MaxIsolatedRatio:  0.1,
+	}, now)
+	if err != nil {
+		t.Fatalf("checkGraphHealth() error = %v", err)
+	}
+	if result.Status != "passed" {
+		t.Fatalf("health status = %q, want passed (topology and drift are non-blocking)", result.Status)
+	}
+	if result.Topology == nil || result.Topology.Isolated != 1 {
+		t.Fatalf("topology = %#v, want isolated=1", result.Topology)
+	}
+	if result.ReportedRelationCounts["belongs_to"] != 1 || result.ReportedRelationCounts["can_assume"] != 0 {
+		t.Fatalf("reported relation counts = %#v, want belongs_to=1 can_assume=0", result.ReportedRelationCounts)
+	}
+	joined := strings.Join(result.Warnings, "; ")
+	if !strings.Contains(joined, "isolated-node ratio") {
+		t.Fatalf("warnings = %#v, want isolated-node ratio warning", result.Warnings)
+	}
+	if !strings.Contains(joined, "zero edges for 1 reported relation(s): can_assume") {
+		t.Fatalf("warnings = %#v, want can_assume drift warning", result.Warnings)
+	}
 }
 
 func TestCheckGraphHealthFailsLatestFailedRunUnlessTransientAllowed(t *testing.T) {
@@ -115,6 +163,8 @@ func TestParseGraphHealthArgs(t *testing.T) {
 		"ingest_limit=100",
 		"max_running_minutes=15",
 		"relations=belongs_to,represents,belongs_to",
+		"report_relations=belongs_to,can_assume",
+		"max_isolated_ratio=0.25",
 		"declared_runtime_ids=aws-runtime, azure-runtime ",
 		"allow_transient_source_failures=true",
 	})
@@ -123,6 +173,12 @@ func TestParseGraphHealthArgs(t *testing.T) {
 	}
 	if options.IngestLimit != 100 || options.MaxRunningMinutes != 15 || !options.AllowTransientSourceFailures {
 		t.Fatalf("options = %#v, want parsed numeric and boolean fields", options)
+	}
+	if options.MaxIsolatedRatio != 0.25 {
+		t.Fatalf("max_isolated_ratio = %v, want 0.25", options.MaxIsolatedRatio)
+	}
+	if !reflect.DeepEqual(options.ReportRelations, []string{"belongs_to", "can_assume"}) {
+		t.Fatalf("report relations = %#v", options.ReportRelations)
 	}
 	if !reflect.DeepEqual(options.RequiredRelations, []string{"belongs_to", "represents"}) {
 		t.Fatalf("relations = %#v", options.RequiredRelations)

--- a/cmd/cerebro/graph_test_store_test.go
+++ b/cmd/cerebro/graph_test_store_test.go
@@ -145,6 +145,31 @@ func (s *graphTestStore) IntegrityChecks(context.Context) ([]graphstore.Integrit
 	}, nil
 }
 
+func (s *graphTestStore) Topology(context.Context) (graphstore.Topology, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	hasOut := make(map[string]bool, len(s.links))
+	hasIn := make(map[string]bool, len(s.links))
+	for _, link := range s.links {
+		hasOut[link.FromURN] = true
+		hasIn[link.ToURN] = true
+	}
+	var topology graphstore.Topology
+	for urn := range s.entities {
+		switch {
+		case !hasOut[urn] && !hasIn[urn]:
+			topology.Isolated++
+		case hasOut[urn] && !hasIn[urn]:
+			topology.SourcesOnly++
+		case !hasOut[urn] && hasIn[urn]:
+			topology.SinksOnly++
+		default:
+			topology.Intermediates++
+		}
+	}
+	return topology, nil
+}
+
 func (s *graphTestStore) RepairOpenFindingPrimaryLinks(_ context.Context, request graphstore.OpenFindingPrimaryLinkRepairRequest) (graphstore.OpenFindingPrimaryLinkRepairResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## What

`graph health` now surfaces graph-quality signals that today are invisible until you run `graph paths`/`relation-counts` by hand.

### Changes
- **Always reports node connectivity topology** in the health result: `isolated` / `sources_only` / `sinks_only` / `intermediates`. Orphan (isolated) accumulation is now observable on every health run.
- **`max_isolated_ratio=<0..1>`** (optional): emits a non-blocking warning when the isolated-node ratio exceeds the threshold. Default unset = report-only.
- **`report_relations=a,b,c`** (optional): emits a non-blocking warning listing any reported relation with zero live edges (relation drift). Distinct from `relations=` (which remains a hard failure).

### Why
A live audit showed (a) thousands of isolated nodes accumulating in one environment and (b) several declared relations that silently produce zero edges. Both are quality regressions that the current health check can't see. These signals make them observable **without** changing existing pass/fail gating — all new output is informational/warning-only.

### Safety
- No behavior change to existing failures: topology/drift are warnings only; `max_isolated_ratio` and `report_relations` default off.
- New `graphTopologyStore` capability is optional; stores without it are simply skipped.

### Tests
- Topology populated + report-only (no warnings) path.
- Isolated-ratio + relation-drift warning path (status stays `passed`).
- Arg parsing for `report_relations` and `max_isolated_ratio`.

Validated locally: `go vet`, `cmd/cerebro` + archtests, `golangci-lint` (0 issues), gofmt clean.