### PR TITLE
Expand Cerebro MCP read tools

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -6601,6 +6601,7 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 	copy(notes, finding.Notes)
 	tickets := make([]ports.FindingTicket, len(finding.Tickets))
 	copy(tickets, finding.Tickets)
+	riskReasons := append([]string(nil), finding.RiskReasons...)
 	attributes := make(map[string]string, len(finding.Attributes))
 	for key, value := range finding.Attributes {
 		attributes[key] = value
@@ -6630,6 +6631,16 @@ func cloneFinding(finding *ports.FindingRecord) *ports.FindingRecord {
 			DueAt:           finding.DueAt,
 			StatusReason:    finding.StatusReason,
 			StatusUpdatedAt: finding.StatusUpdatedAt,
+		},
+		FindingRisk: ports.FindingRisk{
+			RiskScore:        finding.RiskScore,
+			LikelihoodScore:  finding.LikelihoodScore,
+			ImpactScore:      finding.ImpactScore,
+			ConfidenceScore:  finding.ConfidenceScore,
+			LikelihoodLevel:  finding.LikelihoodLevel,
+			ImpactLevel:      finding.ImpactLevel,
+			RiskReasons:      riskReasons,
+			RiskModelVersion: finding.RiskModelVersion,
 		},
 		Attributes:      attributes,
 		FirstObservedAt: finding.FirstObservedAt,

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -22,8 +23,15 @@ import (
 )
 
 const (
-	mcpProtocolVersion = "2025-03-26"
-	mcpEndpointPath    = "/api/v1/mcp"
+	mcpProtocolVersion       = "2025-03-26"
+	mcpEndpointPath          = "/api/v1/mcp"
+	defaultMCPListLimit      = 25
+	maxMCPListLimit          = 100
+	defaultMCPAssetLimit     = 10
+	maxMCPAssetLimit         = 50
+	defaultMCPRiskLimit      = 100
+	maxMCPRiskLimit          = 500
+	defaultMCPRecentRiskRows = 10
 )
 
 type mcpJSONRPCRequest struct {
@@ -65,6 +73,37 @@ type mcpToolResult struct {
 type mcpContent struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
+}
+
+type mcpAssetSearchResult struct {
+	URN        string            `json:"urn"`
+	TenantID   string            `json:"tenant_id"`
+	RuntimeID  string            `json:"runtime_id,omitempty"`
+	SourceID   string            `json:"source_id,omitempty"`
+	EntityType string            `json:"entity_type"`
+	Label      string            `json:"label"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+}
+
+type mcpRiskSummary struct {
+	TenantID             string               `json:"tenant_id,omitempty"`
+	RuntimeID            string               `json:"runtime_id,omitempty"`
+	TotalFindings        int                  `json:"total_findings"`
+	OpenFindings         int                  `json:"open_findings"`
+	CriticalOpenFindings int                  `json:"critical_open_findings"`
+	HighOpenFindings     int                  `json:"high_open_findings"`
+	MaxRiskScore         int                  `json:"max_risk_score"`
+	AverageRiskScore     float64              `json:"average_risk_score"`
+	BySeverity           map[string]int       `json:"by_severity"`
+	ByStatus             map[string]int       `json:"by_status"`
+	TopRiskReasons       []mcpRiskReasonCount `json:"top_risk_reasons"`
+	RecentHighRisk       []any                `json:"recent_high_risk"`
+	LimitApplied         int                  `json:"limit_applied"`
+}
+
+type mcpRiskReasonCount struct {
+	Reason string `json:"reason"`
+	Count  int    `json:"count"`
 }
 
 func (app *App) handleMCP(w http.ResponseWriter, r *http.Request) {
@@ -187,6 +226,12 @@ func (app *App) mcpToolStructuredContent(r *http.Request, name string, args map[
 		return app.mcpListSourceRuntimes(r, args)
 	case "cerebro.findings.list":
 		return app.mcpListFindings(r, args)
+	case "cerebro.findings.get":
+		return app.mcpGetFinding(r, args)
+	case "cerebro.assets.search":
+		return app.mcpSearchAssets(r, args)
+	case "cerebro.risk.summary":
+		return app.mcpRiskSummary(r, args)
 	case "cerebro.graph.neighborhood":
 		return app.mcpGraphNeighborhood(r, args)
 	default:
@@ -195,7 +240,7 @@ func (app *App) mcpToolStructuredContent(r *http.Request, name string, args map[
 }
 
 func (app *App) mcpListSourceRuntimes(r *http.Request, args map[string]any) (any, error) {
-	limit, err := mcpUint32Arg(args, "limit")
+	limit, err := mcpBoundedLimit(args, "limit", defaultMCPListLimit, maxMCPListLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +248,7 @@ func (app *App) mcpListSourceRuntimes(r *http.Request, args map[string]any) (any
 		RuntimeID: mcpStringArg(args, "runtime_id"),
 		TenantID:  mcpStringArg(args, "tenant_id"),
 		SourceID:  mcpStringArg(args, "source_id"),
-		Limit:     limit,
+		Limit:     uint32(limit),
 	}
 	if filter.TenantID == "" {
 		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok && strings.TrimSpace(auth.principal.TenantID) != "" {
@@ -269,7 +314,7 @@ func (app *App) mcpListFindings(r *http.Request, args map[string]any) (any, erro
 		}
 		order = findingOrder(parsed)
 	}
-	limit, err := mcpUint32Arg(args, "limit")
+	limit, err := mcpBoundedLimit(args, "limit", defaultMCPListLimit, maxMCPListLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -285,13 +330,144 @@ func (app *App) mcpListFindings(r *http.Request, args map[string]any) (any, erro
 		ResourceURN: mcpStringArg(args, "resource_urn"),
 		EventID:     mcpStringArg(args, "event_id"),
 		PolicyID:    mcpStringArg(args, "policy_id"),
-		Limit:       limit,
+		Limit:       uint32(limit),
 		Order:       order,
 	})
 	if err != nil {
 		return nil, err
 	}
 	return protoJSONValue(listFindingsResponse(response))
+}
+
+func (app *App) mcpGetFinding(r *http.Request, args map[string]any) (any, error) {
+	findingID := mcpStringArg(args, "finding_id")
+	if findingID == "" {
+		return nil, fmt.Errorf("%w: finding_id is required", findingdomain.ErrInvalidRequest)
+	}
+	if err := authorizeFindingIDTenant(r.Context(), findingStore(app.deps.StateStore), findingID); err != nil {
+		return nil, err
+	}
+	finding, err := app.findingService().GetFinding(r.Context(), findingID)
+	if err != nil {
+		return nil, err
+	}
+	return protoJSONValue(&cerebrov1.GetFindingResponse{Finding: findingMessage(finding)})
+}
+
+func (app *App) mcpSearchAssets(r *http.Request, args map[string]any) (any, error) {
+	query := mcpStringArg(args, "query")
+	urn := mcpStringArg(args, "urn")
+	tenantID := mcpTenantArg(r, args)
+	entityType := mcpStringArg(args, "entity_type")
+	runtimeID := mcpStringArg(args, "runtime_id")
+	limit, err := mcpBoundedLimit(args, "limit", defaultMCPAssetLimit, maxMCPAssetLimit)
+	if err != nil {
+		return nil, err
+	}
+	if urn == "" && query == "" && entityType == "" && runtimeID == "" {
+		return nil, fmt.Errorf("%w: at least one of query, urn, entity_type, or runtime_id is required", graphquery.ErrInvalidRequest)
+	}
+	if urn != "" {
+		if err := authorizeCerebroURNTenant(r.Context(), urn); err != nil {
+			return nil, err
+		}
+		if tenantID == "" {
+			tenantID = cerebroURNTenant(urn)
+		}
+	}
+	if runtimeID != "" {
+		if err := authorizeSourceRuntimeIDTenant(r.Context(), sourceRuntimeStore(app.deps.StateStore), runtimeID, false); err != nil {
+			return nil, err
+		}
+	}
+	if tenantID == "" && requiresTenantFilter(r.Context()) {
+		return nil, errTenantForbidden
+	}
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		return nil, err
+	}
+	store := graphQueryStore(app.deps.GraphStore)
+	if store == nil {
+		return nil, graphquery.ErrRuntimeUnavailable
+	}
+	rows, err := store.ExecuteReadCypher(r.Context(), ports.CypherQueryRequest{
+		Query: `MATCH (e:Entity)
+WHERE ($tenant_id = '' OR e.tenant_id = $tenant_id)
+  AND ($runtime_id = '' OR coalesce(e.runtime_id, '') = $runtime_id)
+  AND ($urn = '' OR e.urn = $urn)
+  AND ($entity_type = '' OR e.entity_type = $entity_type)
+  AND ($query = '' OR toLower(coalesce(e.urn, '')) CONTAINS $query OR toLower(coalesce(e.label, '')) CONTAINS $query OR toLower(coalesce(e.attributes_json, '')) CONTAINS $query)
+RETURN e.urn AS urn,
+       coalesce(e.tenant_id, '') AS tenant_id,
+       coalesce(e.runtime_id, '') AS runtime_id,
+       coalesce(e.source_id, '') AS source_id,
+       coalesce(e.entity_type, '') AS entity_type,
+       coalesce(e.label, '') AS label,
+       coalesce(e.attributes_json, '{}') AS attributes_json
+ORDER BY e.entity_type, e.label, e.urn`,
+		Params: map[string]any{
+			"tenant_id":   tenantID,
+			"runtime_id":  runtimeID,
+			"urn":         urn,
+			"entity_type": entityType,
+			"query":       strings.ToLower(query),
+		},
+		RowLimit: limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]mcpAssetSearchResult, 0, len(rows))
+	for _, row := range rows {
+		asset, err := mcpAssetSearchResultFromRow(row)
+		if err != nil {
+			return nil, err
+		}
+		if !tenantAllowedByContext(r.Context(), asset.TenantID) {
+			continue
+		}
+		assets = append(assets, asset)
+	}
+	return map[string]any{"assets": assets}, nil
+}
+
+func (app *App) mcpRiskSummary(r *http.Request, args map[string]any) (any, error) {
+	runtimeID := mcpStringArg(args, "runtime_id")
+	tenantID := mcpTenantArg(r, args)
+	limit, err := mcpBoundedLimit(args, "limit", defaultMCPRiskLimit, maxMCPRiskLimit)
+	if err != nil {
+		return nil, err
+	}
+	if runtimeID != "" {
+		runtimeStore := sourceRuntimeStore(app.deps.StateStore)
+		if err := authorizeSourceRuntimeIDTenant(r.Context(), runtimeStore, runtimeID, false); err != nil {
+			return nil, err
+		}
+		if tenantID == "" {
+			runtime, err := runtimeStore.GetSourceRuntime(r.Context(), runtimeID)
+			if err != nil {
+				return nil, err
+			}
+			tenantID = strings.TrimSpace(runtime.GetTenantId())
+		}
+	}
+	if tenantID == "" && runtimeID == "" && requiresTenantFilter(r.Context()) {
+		return nil, errTenantForbidden
+	}
+	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
+		return nil, err
+	}
+	findings, err := app.mcpListRiskFindings(r, ports.ListFindingsRequest{
+		TenantID:  tenantID,
+		RuntimeID: runtimeID,
+		Status:    mcpStringArg(args, "status"),
+		Limit:     uint32(limit),
+		Order:     ports.FindingOrderRiskScore,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mcpBuildRiskSummary(tenantID, runtimeID, limit, findings), nil
 }
 
 func (app *App) mcpGraphNeighborhood(r *http.Request, args map[string]any) (any, error) {
@@ -352,6 +528,35 @@ func mcpTools() []mcpTool {
 			}, []string{"runtime_id"}),
 		},
 		{
+			Name:        "cerebro.findings.get",
+			Description: "Return one finding by ID if it is visible to the authenticated caller.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"finding_id": map[string]any{"type": "string"},
+			}, []string{"finding_id"}),
+		},
+		{
+			Name:        "cerebro.assets.search",
+			Description: "Search graph assets/entities visible to the authenticated caller by query, URN, entity type, tenant, or runtime.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"query":       map[string]any{"type": "string"},
+				"urn":         map[string]any{"type": "string"},
+				"entity_type": map[string]any{"type": "string"},
+				"tenant_id":   map[string]any{"type": "string"},
+				"runtime_id":  map[string]any{"type": "string"},
+				"limit":       map[string]any{"type": "integer", "minimum": 1, "maximum": maxMCPAssetLimit},
+			}, nil),
+		},
+		{
+			Name:        "cerebro.risk.summary",
+			Description: "Summarize visible finding risk by severity, status, risk score, and top risk reasons.",
+			InputSchema: mcpObjectSchema(map[string]any{
+				"tenant_id":  map[string]any{"type": "string"},
+				"runtime_id": map[string]any{"type": "string"},
+				"status":     map[string]any{"type": "string", "enum": []string{"open", "resolved", "suppressed"}},
+				"limit":      map[string]any{"type": "integer", "minimum": 1, "maximum": maxMCPRiskLimit},
+			}, nil),
+		},
+		{
 			Name:        "cerebro.graph.neighborhood",
 			Description: "Return a bounded graph neighborhood around a Cerebro URN visible to the authenticated caller.",
 			InputSchema: mcpObjectSchema(map[string]any{
@@ -375,6 +580,227 @@ func mcpObjectSchema(properties map[string]any, required []string) map[string]an
 		schema["required"] = required
 	}
 	return schema
+}
+
+func mcpTenantArg(r *http.Request, args map[string]any) string {
+	tenantID := mcpStringArg(args, "tenant_id")
+	if tenantID != "" {
+		return tenantID
+	}
+	if r != nil {
+		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok {
+			return strings.TrimSpace(auth.principal.TenantID)
+		}
+	}
+	return ""
+}
+
+func cerebroURNTenant(urn string) string {
+	parts := strings.Split(strings.TrimSpace(urn), ":")
+	if len(parts) >= 3 && parts[0] == "urn" && parts[1] == "cerebro" {
+		return strings.TrimSpace(parts[2])
+	}
+	return ""
+}
+
+func mcpBoundedLimit(args map[string]any, key string, defaultLimit int, maxLimit int) (int, error) {
+	limit, err := mcpUint32Arg(args, key)
+	if err != nil {
+		return 0, err
+	}
+	switch {
+	case limit == 0:
+		return defaultLimit, nil
+	case int(limit) > maxLimit:
+		return maxLimit, nil
+	default:
+		return int(limit), nil
+	}
+}
+
+func mcpAssetSearchResultFromRow(row ports.CypherRow) (mcpAssetSearchResult, error) {
+	values := row.Values
+	attributes, err := mcpStringMapFromJSON(mcpAnyString(values["attributes_json"]))
+	if err != nil {
+		return mcpAssetSearchResult{}, err
+	}
+	return mcpAssetSearchResult{
+		URN:        mcpAnyString(values["urn"]),
+		TenantID:   mcpAnyString(values["tenant_id"]),
+		RuntimeID:  mcpAnyString(values["runtime_id"]),
+		SourceID:   mcpAnyString(values["source_id"]),
+		EntityType: mcpAnyString(values["entity_type"]),
+		Label:      mcpAnyString(values["label"]),
+		Attributes: attributes,
+	}, nil
+}
+
+func (app *App) mcpListRiskFindings(r *http.Request, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
+	ctx := r.Context()
+	store := findingStore(app.deps.StateStore)
+	if store == nil {
+		return nil, findingdomain.ErrRuntimeUnavailable
+	}
+	if strings.TrimSpace(request.Status) != "" {
+		parsed, err := parseFindingStatus(request.Status)
+		if err != nil {
+			return nil, err
+		}
+		request.Status = findingStatusString(parsed)
+	}
+	if strings.TrimSpace(request.RuntimeID) != "" {
+		return store.ListFindings(ctx, request)
+	}
+	runtimes, err := app.runtimeService().List(ctx, ports.SourceRuntimeFilter{
+		TenantID: request.TenantID,
+		Limit:    uint32(maxMCPRiskLimit),
+	})
+	if err != nil {
+		return nil, err
+	}
+	findings := make([]*ports.FindingRecord, 0, request.Limit)
+	for _, runtime := range runtimes {
+		if runtime == nil || strings.TrimSpace(runtime.GetId()) == "" {
+			continue
+		}
+		if !tenantAllowedByContext(ctx, runtime.GetTenantId()) {
+			continue
+		}
+		scoped := request
+		scoped.TenantID = strings.TrimSpace(runtime.GetTenantId())
+		scoped.RuntimeID = strings.TrimSpace(runtime.GetId())
+		if request.Limit != 0 {
+			if len(findings) >= int(request.Limit) {
+				break
+			}
+			scoped.Limit = request.Limit - uint32(len(findings))
+		}
+		items, err := store.ListFindings(ctx, scoped)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, items...)
+	}
+	return findings, nil
+}
+
+func mcpBuildRiskSummary(tenantID string, runtimeID string, limit int, findings []*ports.FindingRecord) mcpRiskSummary {
+	summary := mcpRiskSummary{
+		TenantID:       tenantID,
+		RuntimeID:      runtimeID,
+		BySeverity:     map[string]int{},
+		ByStatus:       map[string]int{},
+		LimitApplied:   limit,
+		RecentHighRisk: []any{},
+	}
+	reasonCounts := map[string]int{}
+	riskScoreTotal := 0
+	for _, finding := range findings {
+		if finding == nil {
+			continue
+		}
+		summary.TotalFindings++
+		status := strings.ToLower(strings.TrimSpace(finding.Status))
+		if status == "" {
+			status = "unknown"
+		}
+		severity := strings.ToLower(strings.TrimSpace(finding.Severity))
+		if severity == "" {
+			severity = "unknown"
+		}
+		summary.ByStatus[status]++
+		summary.BySeverity[severity]++
+		if status == "open" {
+			summary.OpenFindings++
+			switch severity {
+			case "critical":
+				summary.CriticalOpenFindings++
+			case "high":
+				summary.HighOpenFindings++
+			}
+		}
+		if finding.RiskScore > summary.MaxRiskScore {
+			summary.MaxRiskScore = finding.RiskScore
+		}
+		riskScoreTotal += finding.RiskScore
+		for _, reason := range finding.RiskReasons {
+			reason = strings.TrimSpace(reason)
+			if reason != "" {
+				reasonCounts[reason]++
+			}
+		}
+	}
+	if summary.TotalFindings != 0 {
+		summary.AverageRiskScore = float64(riskScoreTotal) / float64(summary.TotalFindings)
+	}
+	summary.TopRiskReasons = mcpTopRiskReasons(reasonCounts, 10)
+	recent := make([]*ports.FindingRecord, 0, len(findings))
+	for _, finding := range findings {
+		if finding != nil {
+			recent = append(recent, finding)
+		}
+	}
+	sort.Slice(recent, func(i, j int) bool {
+		left := recent[i]
+		right := recent[j]
+		switch {
+		case left.RiskScore != right.RiskScore:
+			return left.RiskScore > right.RiskScore
+		case left.LastObservedAt.Equal(right.LastObservedAt):
+			return left.ID < right.ID
+		default:
+			return left.LastObservedAt.After(right.LastObservedAt)
+		}
+	})
+	if len(recent) > defaultMCPRecentRiskRows {
+		recent = recent[:defaultMCPRecentRiskRows]
+	}
+	for _, finding := range recent {
+		summary.RecentHighRisk = append(summary.RecentHighRisk, findingMessage(finding))
+	}
+	return summary
+}
+
+func mcpTopRiskReasons(counts map[string]int, limit int) []mcpRiskReasonCount {
+	reasons := make([]mcpRiskReasonCount, 0, len(counts))
+	for reason, count := range counts {
+		reasons = append(reasons, mcpRiskReasonCount{Reason: reason, Count: count})
+	}
+	sort.Slice(reasons, func(i, j int) bool {
+		if reasons[i].Count == reasons[j].Count {
+			return reasons[i].Reason < reasons[j].Reason
+		}
+		return reasons[i].Count > reasons[j].Count
+	})
+	if len(reasons) > limit {
+		reasons = reasons[:limit]
+	}
+	return reasons
+}
+
+func mcpStringMapFromJSON(raw string) (map[string]string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	values := map[string]string{}
+	if err := json.Unmarshal([]byte(trimmed), &values); err != nil {
+		return nil, fmt.Errorf("%w: decode asset attributes", graphquery.ErrInvalidRequest)
+	}
+	return values, nil
+}
+
+func mcpAnyString(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
 }
 
 func mcpSuccessToolResult(structured any) (mcpToolResult, error) {

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -81,7 +81,7 @@ func TestMCPInitializeAndToolsList(t *testing.T) {
 	for _, item := range tools {
 		names[item.(map[string]any)["name"].(string)] = true
 	}
-	for _, want := range []string{"cerebro.health", "cerebro.version", "cerebro.source_runtimes.list", "cerebro.findings.list", "cerebro.graph.neighborhood"} {
+	for _, want := range []string{"cerebro.health", "cerebro.version", "cerebro.source_runtimes.list", "cerebro.findings.list", "cerebro.findings.get", "cerebro.assets.search", "cerebro.risk.summary", "cerebro.graph.neighborhood"} {
 		if !names[want] {
 			t.Fatalf("tools/list missing %s in %#v", want, names)
 		}
@@ -177,6 +177,187 @@ func TestMCPFindingsListUsesRuntimeScope(t *testing.T) {
 	findings := result["structuredContent"].(map[string]any)["findings"].([]any)
 	if len(findings) != 1 {
 		t.Fatalf("len(findings) = %d, want 1", len(findings))
+	}
+}
+
+func TestMCPFindingsGet(t *testing.T) {
+	store := &stubRuntimeStore{
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:        "finding-1",
+				RuntimeID: "writer-okta",
+				TenantID:  "writer",
+				RuleID:    "rule-1",
+				Title:     "Finding One",
+				Severity:  "critical",
+				Status:    "open",
+				FindingRisk: ports.FindingRisk{
+					RiskScore:       94,
+					LikelihoodScore: 87,
+					ImpactScore:     96,
+					RiskReasons:     []string{"internet exposed", "privileged asset"},
+				},
+				LastObservedAt: time.Now().UTC(),
+			},
+		},
+	}
+	server := newMCPTestServer(t, store)
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.findings.get",
+			"arguments": map[string]any{
+				"finding_id": "finding-1",
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("tools/call error = %#v", response["error"])
+	}
+	finding := response["result"].(map[string]any)["structuredContent"].(map[string]any)["finding"].(map[string]any)
+	if finding["id"] != "finding-1" || finding["risk_score"] != float64(94) {
+		t.Fatalf("finding response = %#v", finding)
+	}
+}
+
+func TestMCPAssetsSearchUsesTenantScopedCypher(t *testing.T) {
+	graph := &stubGraphStore{cypherRows: [][]ports.CypherRow{{
+		{Values: map[string]any{
+			"urn":             "urn:cerebro:writer:asset:prod-db",
+			"tenant_id":       "writer",
+			"runtime_id":      "writer-aws",
+			"source_id":       "aws",
+			"entity_type":     "aws.rds.instance",
+			"label":           "prod-db",
+			"attributes_json": `{"account_id":"123456789012","environment":"prod"}`,
+		}},
+		{Values: map[string]any{
+			"urn":             "urn:cerebro:other:asset:prod-db",
+			"tenant_id":       "other",
+			"runtime_id":      "other-aws",
+			"source_id":       "aws",
+			"entity_type":     "aws.rds.instance",
+			"label":           "other-prod-db",
+			"attributes_json": `{}`,
+		}},
+	}}}
+	server := newMCPTestServerWithGraph(t, &stubRuntimeStore{}, graph)
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.assets.search",
+			"arguments": map[string]any{
+				"query":       "prod",
+				"entity_type": "aws.rds.instance",
+				"limit":       7,
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("tools/call error = %#v", response["error"])
+	}
+	if len(graph.cypherRequests) != 1 {
+		t.Fatalf("cypher requests = %d, want 1", len(graph.cypherRequests))
+	}
+	if graph.cypherRequests[0].Params["tenant_id"] != "writer" || graph.cypherRequests[0].RowLimit != 7 {
+		t.Fatalf("cypher request = %#v", graph.cypherRequests[0])
+	}
+	assets := response["result"].(map[string]any)["structuredContent"].(map[string]any)["assets"].([]any)
+	if len(assets) != 1 {
+		t.Fatalf("len(assets) = %d, want 1", len(assets))
+	}
+	asset := assets[0].(map[string]any)
+	if asset["urn"] != "urn:cerebro:writer:asset:prod-db" {
+		t.Fatalf("asset = %#v", asset)
+	}
+	attributes := asset["attributes"].(map[string]any)
+	if attributes["environment"] != "prod" {
+		t.Fatalf("attributes = %#v", attributes)
+	}
+}
+
+func TestMCPRiskSummaryAggregatesScopedRuntimeFindings(t *testing.T) {
+	now := time.Now().UTC()
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-aws":    {Id: "writer-aws", SourceId: "aws", TenantId: "writer"},
+			"writer-github": {Id: "writer-github", SourceId: "github", TenantId: "writer"},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-critical": {
+				ID:             "finding-critical",
+				RuntimeID:      "writer-aws",
+				TenantID:       "writer",
+				RuleID:         "rule-critical",
+				Title:          "Critical",
+				Severity:       "critical",
+				Status:         "open",
+				FindingRisk:    ports.FindingRisk{RiskScore: 95, RiskReasons: []string{"internet exposed", "privileged asset"}},
+				LastObservedAt: now,
+			},
+			"finding-high": {
+				ID:             "finding-high",
+				RuntimeID:      "writer-github",
+				TenantID:       "writer",
+				RuleID:         "rule-high",
+				Title:          "High",
+				Severity:       "high",
+				Status:         "open",
+				FindingRisk:    ports.FindingRisk{RiskScore: 75, RiskReasons: []string{"internet exposed"}},
+				LastObservedAt: now.Add(-time.Minute),
+			},
+			"finding-resolved": {
+				ID:             "finding-resolved",
+				RuntimeID:      "writer-github",
+				TenantID:       "writer",
+				RuleID:         "rule-low",
+				Title:          "Resolved",
+				Severity:       "low",
+				Status:         "resolved",
+				FindingRisk:    ports.FindingRisk{RiskScore: 10},
+				LastObservedAt: now.Add(-2 * time.Minute),
+			},
+		},
+	}
+	server := newMCPTestServer(t, store)
+	defer server.Close()
+
+	response, _ := postMCP(t, server, "", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "cerebro.risk.summary",
+			"arguments": map[string]any{
+				"limit": 50,
+			},
+		},
+	})
+	if response["error"] != nil {
+		t.Fatalf("tools/call error = %#v", response["error"])
+	}
+	summary := response["result"].(map[string]any)["structuredContent"].(map[string]any)
+	if summary["total_findings"] != float64(3) || summary["open_findings"] != float64(2) || summary["critical_open_findings"] != float64(1) || summary["high_open_findings"] != float64(1) {
+		t.Fatalf("summary counts = %#v", summary)
+	}
+	if summary["max_risk_score"] != float64(95) {
+		t.Fatalf("max_risk_score = %#v", summary["max_risk_score"])
+	}
+	reasons := summary["top_risk_reasons"].([]any)
+	if len(reasons) == 0 || reasons[0].(map[string]any)["reason"] != "internet exposed" || reasons[0].(map[string]any)["count"] != float64(2) {
+		t.Fatalf("top_risk_reasons = %#v", reasons)
+	}
+	recent := summary["recent_high_risk"].([]any)
+	if len(recent) == 0 || recent[0].(map[string]any)["id"] != "finding-critical" {
+		t.Fatalf("recent_high_risk = %#v", recent)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `cerebro.findings.get`, `cerebro.assets.search`, and `cerebro.risk.summary` MCP tools
- keep tools read-only, tenant-scoped, and bounded by default/max limits
- extend MCP HTTP tests for finding details, tenant-filtered asset search, and multi-runtime risk summaries

## Validation
- `go test ./internal/bootstrap -run 'TestMCP' -count=1`\n- `go test ./... -count=1`\n- `make lint-bootstrap openapi-check openapi-lint`\n- local binary MCP smoke on `127.0.0.1:18081`: initialize + tools/list shows 8 tools including the 3 new tools\n- pre-commit checks during commit