### PR TITLE
Redact sensitive MCP asset attributes

### DIFF
--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -25,6 +25,7 @@ import (
 const (
 	mcpProtocolVersion       = "2025-03-26"
 	mcpEndpointPath          = "/api/v1/mcp"
+	mcpRedactedValue         = "[redacted]"
 	defaultMCPListLimit      = 25
 	maxMCPListLimit          = 100
 	defaultMCPAssetLimit     = 10
@@ -631,7 +632,7 @@ func mcpAssetSearchResultFromRow(row ports.CypherRow) (mcpAssetSearchResult, err
 		SourceID:   mcpAnyString(values["source_id"]),
 		EntityType: mcpAnyString(values["entity_type"]),
 		Label:      mcpAnyString(values["label"]),
-		Attributes: attributes,
+		Attributes: mcpRedactSensitiveAttributes(attributes),
 	}, nil
 }
 
@@ -788,6 +789,21 @@ func mcpStringMapFromJSON(raw string) (map[string]string, error) {
 		return nil, fmt.Errorf("%w: decode asset attributes", graphquery.ErrInvalidRequest)
 	}
 	return values, nil
+}
+
+func mcpRedactSensitiveAttributes(attributes map[string]string) map[string]string {
+	if len(attributes) == 0 {
+		return attributes
+	}
+	redacted := make(map[string]string, len(attributes))
+	for key, value := range attributes {
+		if sensitiveSourceConfigKey(key) {
+			redacted[key] = mcpRedactedValue
+			continue
+		}
+		redacted[key] = value
+	}
+	return redacted
 }
 
 func mcpAnyString(value any) string {

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -233,7 +233,7 @@ func TestMCPAssetsSearchUsesTenantScopedCypher(t *testing.T) {
 			"source_id":       "aws",
 			"entity_type":     "aws.rds.instance",
 			"label":           "prod-db",
-			"attributes_json": `{"account_id":"123456789012","environment":"prod"}`,
+			"attributes_json": `{"account_id":"123456789012","api_key":"secret-api-key","environment":"prod","private_key":"secret-private-key","token_id":"token-123"}`,
 		}},
 		{Values: map[string]any{
 			"urn":             "urn:cerebro:other:asset:prod-db",
@@ -280,6 +280,14 @@ func TestMCPAssetsSearchUsesTenantScopedCypher(t *testing.T) {
 	}
 	attributes := asset["attributes"].(map[string]any)
 	if attributes["environment"] != "prod" {
+		t.Fatalf("attributes = %#v", attributes)
+	}
+	for _, key := range []string{"api_key", "private_key", "token_id"} {
+		if attributes[key] != "[redacted]" {
+			t.Fatalf("attributes[%q] = %#v, want redacted in %#v", key, attributes[key], attributes)
+		}
+	}
+	if attributes["account_id"] != "123456789012" {
 		t.Fatalf("attributes = %#v", attributes)
 	}
 }


### PR DESCRIPTION
## Summary
- Redact secret-looking keys in `cerebro.assets.search` structured asset attributes
- Preserve non-sensitive asset attributes
- Extend MCP asset-search test coverage for redaction

## Validation
- `go test ./internal/bootstrap -run 'TestMCP' -count=1`\n- `go test ./sources/vulnview -count=1 -run TestReadVulnerabilitiesMapsFindingStateAttributes -v` after an initial unrelated full-suite timeout\n- `go test ./... -count=1`\n- `make lint-bootstrap openapi-check openapi-lint`