### PR TITLE
feat: detect exposed privileged compute roles

### DIFF
--- a/internal/findings/cloud_exposed_privileged_compute_graph_rule.go
+++ b/internal/findings/cloud_exposed_privileged_compute_graph_rule.go
@@ -1,0 +1,109 @@
+package findings
+
+const cloudExposedPrivilegedComputeRoleRuleID = "cloud-exposed-privileged-compute-role"
+
+func newCloudExposedPrivilegedComputeRoleRule() Rule {
+	definition := cloudRuleDefinition(
+		cloudExposedPrivilegedComputeRoleRuleID,
+		"Cloud Exposed Privileged Compute Role",
+		"Detect publicly reachable AWS compute workloads that run as admin-equivalent or privilege-escalating roles.",
+		"CRITICAL",
+		"finding.cloud_exposed_privileged_compute_role",
+		[]string{"cloud", "aws", "compute", "ecs", "lambda", "ec2", "attack-path", "public-exposure", "privilege-escalation", "attack.t1190", "attack.t1098"},
+		[]string{"compute_workload_urn", "runtime_role_urn", "permission_urn"},
+	)
+	definition.EventKinds = []string{
+		"aws.ec2_instance",
+		"aws.lambda_function",
+		"aws.ecs_service",
+		"aws.ecs_task_definition",
+		"aws.effective_permission",
+		"aws.iam_role_assignment",
+		"aws.iam_role_trust",
+		"aws.public_endpoint",
+		"aws.resource_exposure",
+	}
+	definition.FalsePositives = []string{
+		"Approved public compute endpoint whose runtime role is intentionally broad and protected by compensating controls not yet modeled in the graph.",
+		"Temporary deployment or break-glass role attachment during a documented maintenance window.",
+	}
+	definition.References = []string{
+		"https://www.cisecurity.org/benchmark/amazon_web_services",
+		"https://attack.mitre.org/techniques/T1190/",
+		"https://attack.mitre.org/techniques/T1098/",
+	}
+	definition.Runbook = "Validate the public entry point, remove unnecessary public ingress, and reduce the EC2 instance profile, Lambda role, or ECS task role to least privilege. For ECS services, review the linked task definition role first."
+	return newCoordinationGraphRule(definition, map[string][]string{
+		"aws": {
+			"ec2_instance",
+			"lambda_function",
+			"ecs_service",
+			"ecs_task_definition",
+			"effective_permission",
+			"iam_role_assignment",
+			"iam_role_trust",
+			"public_endpoint",
+			"resource_exposure",
+		},
+	}, `MATCH (public:Entity {tenant_id: $tenant_id})-[reach:RELATION {relation: 'can_reach'}]->(entry:Entity {tenant_id: $tenant_id})
+MATCH (workload:Entity {tenant_id: $tenant_id})-[:RELATION {relation: 'belongs_to'}]->(account:Entity {tenant_id: $tenant_id, entity_type: 'cloud.account'})
+WHERE public.entity_type ENDS WITH '.public_principal'
+  AND workload.entity_type IN ['aws.ec2.instance', 'aws.lambda.function', 'aws.ecs.service']
+  AND (
+    entry = workload
+    OR EXISTS {
+      MATCH (entry)-[:RELATION {relation: 'attached_to'}]->(workload)
+      WHERE entry.entity_type = 'aws.network.interface'
+    }
+    OR EXISTS {
+      MATCH (workload)-[:RELATION {relation: 'member_of'}]->(entry)
+      WHERE entry.entity_type = 'aws.security_group'
+    }
+  )
+  AND coalesce(reach.attributes_json, '') CONTAINS '"at":"'
+  AND datetime(split(split(coalesce(reach.attributes_json, ''), '"at":"')[1], '"')[0]) >= datetime() - duration('P30D')
+OPTIONAL MATCH (workload)-[directRun:RELATION {relation: 'runs_as'}]->(directRole:Entity {tenant_id: $tenant_id, entity_type: 'aws.role'})
+OPTIONAL MATCH (workload)-[taskLink:RELATION {relation: 'depends_on'}]->(taskDefinition:Entity {tenant_id: $tenant_id, entity_type: 'aws.ecs.task_definition'})-[taskRun:RELATION {relation: 'runs_as'}]->(taskRole:Entity {tenant_id: $tenant_id, entity_type: 'aws.role'})
+WITH public, reach, entry, workload, account, taskDefinition, coalesce(directRole, taskRole) AS role, coalesce(directRun.attributes_json, taskRun.attributes_json, '') AS run_attributes_json, taskLink
+WHERE role IS NOT NULL
+  AND (workload.entity_type <> 'aws.ecs.service' OR taskDefinition IS NOT NULL)
+MATCH (role)-[access:RELATION]->(permission:Entity {tenant_id: $tenant_id})
+WHERE access.relation IN ['can_admin', 'can_assume', 'can_perform']
+  AND (
+    access.relation <> 'can_perform'
+    OR coalesce(access.attributes_json, '') CONTAINS '"is_admin":"true"'
+    OR coalesce(access.attributes_json, '') CONTAINS '"privilege_level":"admin"'
+    OR coalesce(access.attributes_json, '') CONTAINS 'AdministratorAccess'
+    OR coalesce(access.attributes_json, '') CONTAINS '"permission":"*"'
+  )
+RETURN workload.urn AS primary_urn,
+       workload.label AS primary_label,
+       workload.entity_type AS primary_type,
+       workload.urn + '|' + role.urn + '|' + permission.urn AS fingerprint_key,
+       CASE WHEN access.relation = 'can_assume' THEN 'HIGH' ELSE 'CRITICAL' END AS severity,
+       'Publicly reachable compute workload ' + coalesce(workload.label, workload.urn) + ' runs as privileged role ' + coalesce(role.label, role.urn) AS summary,
+       'Remove unnecessary public reachability and reduce the compute runtime role privileges' AS action,
+       CASE
+         WHEN taskDefinition.urn IS NULL THEN [workload.urn, entry.urn, role.urn, permission.urn, account.urn]
+         ELSE [workload.urn, entry.urn, taskDefinition.urn, role.urn, permission.urn, account.urn]
+       END AS resource_urns,
+       CASE
+         WHEN taskDefinition.urn IS NULL THEN [
+           {urn: public.urn, label: public.label, entity_type: public.entity_type, relation: 'can_reach', attributes_json: coalesce(reach.attributes_json, '')},
+           {urn: entry.urn, label: entry.label, entity_type: entry.entity_type, relation: CASE WHEN entry = workload THEN 'can_reach' WHEN entry.entity_type = 'aws.network.interface' THEN 'attached_to' ELSE 'member_of' END, attributes_json: coalesce(reach.attributes_json, '')},
+           {urn: role.urn, label: role.label, entity_type: role.entity_type, relation: 'runs_as', attributes_json: run_attributes_json},
+           {urn: permission.urn, label: permission.label, entity_type: permission.entity_type, relation: access.relation, attributes_json: coalesce(access.attributes_json, '')},
+           {urn: account.urn, label: account.label, entity_type: account.entity_type, relation: 'belongs_to', attributes_json: ''}
+         ]
+         ELSE [
+           {urn: public.urn, label: public.label, entity_type: public.entity_type, relation: 'can_reach', attributes_json: coalesce(reach.attributes_json, '')},
+           {urn: entry.urn, label: entry.label, entity_type: entry.entity_type, relation: CASE WHEN entry = workload THEN 'can_reach' WHEN entry.entity_type = 'aws.network.interface' THEN 'attached_to' ELSE 'member_of' END, attributes_json: coalesce(reach.attributes_json, '')},
+           {urn: taskDefinition.urn, label: taskDefinition.label, entity_type: taskDefinition.entity_type, relation: 'depends_on', attributes_json: coalesce(taskLink.attributes_json, '')},
+           {urn: role.urn, label: role.label, entity_type: role.entity_type, relation: 'runs_as', attributes_json: run_attributes_json},
+           {urn: permission.urn, label: permission.label, entity_type: permission.entity_type, relation: access.relation, attributes_json: coalesce(access.attributes_json, '')},
+           {urn: account.urn, label: account.label, entity_type: account.entity_type, relation: 'belongs_to', attributes_json: ''}
+         ]
+       END AS evidence
+ORDER BY severity, workload.entity_type, workload.label, role.label, permission.label
+LIMIT $row_limit`, nil)
+}

--- a/internal/findings/cloud_exposed_privileged_compute_graph_rule_test.go
+++ b/internal/findings/cloud_exposed_privileged_compute_graph_rule_test.go
@@ -1,0 +1,183 @@
+package findings
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestCloudExposedPrivilegedComputeRoleGraphRuleSupportsAWSProducerRuntimes(t *testing.T) {
+	rule := newCloudExposedPrivilegedComputeRoleRule().(GraphRule)
+	for _, family := range []string{
+		"ec2_instance",
+		"lambda_function",
+		"ecs_service",
+		"ecs_task_definition",
+		"effective_permission",
+		"iam_role_assignment",
+		"iam_role_trust",
+		"public_endpoint",
+		"resource_exposure",
+	} {
+		runtime := &cerebrov1.SourceRuntime{SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": family}}
+		if !rule.SupportsRuntime(runtime) {
+			t.Fatalf("SupportsRuntime(aws/%s) = false, want true", family)
+		}
+	}
+	for _, runtime := range []*cerebrov1.SourceRuntime{
+		{SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "cloudtrail"}},
+		{SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "iam_user"}},
+		{SourceId: "okta", TenantId: "writer", Config: map[string]string{"family": "user"}},
+	} {
+		if rule.SupportsRuntime(runtime) {
+			t.Fatalf("SupportsRuntime(%s/%s) = true, want false", runtime.GetSourceId(), runtime.GetConfig()["family"])
+		}
+	}
+}
+
+func TestCloudExposedPrivilegedComputeRoleGraphRuleQueryShape(t *testing.T) {
+	rule := newCloudExposedPrivilegedComputeRoleRule().(GraphRule)
+	query := rule.QueryFor(&cerebrov1.SourceRuntime{Id: "writer-aws-ecs-service", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "ecs_service"}})
+	if query.Params["tenant_id"] != "writer" || query.RowLimit != coordinationGraphRowLimit {
+		t.Fatalf("QueryFor() = %#v", query)
+	}
+	for _, fragment := range []string{
+		"aws.ecs.service",
+		"aws.ecs.task_definition",
+		"aws.lambda.function",
+		"aws.ec2.instance",
+		"relation: 'can_reach'",
+		"relation: 'attached_to'",
+		"relation: 'member_of'",
+		"relation: 'depends_on'",
+		"relation: 'runs_as'",
+		"access.relation IN ['can_admin', 'can_assume', 'can_perform']",
+		`"is_admin":"true"`,
+		`"privilege_level":"admin"`,
+		"AdministratorAccess",
+		`"permission":"*"`,
+		`duration('P30D')`,
+		"LIMIT $row_limit",
+	} {
+		if !strings.Contains(query.Query, fragment) {
+			t.Fatalf("QueryFor() missing %q:\n%s", fragment, query.Query)
+		}
+	}
+}
+
+func TestCloudExposedPrivilegedComputeRoleGraphRuleEvaluateRows(t *testing.T) {
+	rule := newCloudExposedPrivilegedComputeRoleRule().(GraphRule)
+	runtime := &cerebrov1.SourceRuntime{Id: "writer-aws-ecs-service", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "ecs_service"}}
+
+	tests := []struct {
+		name            string
+		row             ports.CypherRow
+		wantSeverity    string
+		wantResourceURN string
+	}{
+		{
+			name: "ecs service task role",
+			row: ports.CypherRow{Values: map[string]any{
+				"primary_urn":     "urn:cerebro:writer:aws_ecs_service:arn:aws:ecs:us-east-1:123456789012:service/prod/orders",
+				"primary_label":   "orders",
+				"primary_type":    "aws.ecs.service",
+				"fingerprint_key": "urn:cerebro:writer:aws_ecs_service:arn:aws:ecs:us-east-1:123456789012:service/prod/orders|urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/ECSTaskRole|urn:cerebro:writer:aws_iam_policy:AdministratorAccess",
+				"severity":        "CRITICAL",
+				"summary":         "Publicly reachable compute workload orders runs as privileged role ECSTaskRole",
+				"action":          "Remove unnecessary public reachability and reduce the compute runtime role privileges",
+				"resource_urns": []any{
+					"urn:cerebro:writer:aws_ecs_service:arn:aws:ecs:us-east-1:123456789012:service/prod/orders",
+					"urn:cerebro:writer:aws_security_group:sg-public",
+					"urn:cerebro:writer:aws_ecs_task_definition:arn:aws:ecs:us-east-1:123456789012:task-definition/orders:7",
+					"urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/ECSTaskRole",
+					"urn:cerebro:writer:aws_iam_policy:AdministratorAccess",
+					"urn:cerebro:writer:cloud_account:123456789012",
+				},
+				"evidence": []any{
+					map[string]any{"urn": "urn:cerebro:writer:aws_public_principal:public_internet", "label": "public internet", "entity_type": "aws.public_principal", "relation": "can_reach", "attributes_json": `{"at":"2026-04-23T00:00:00Z"}`},
+					map[string]any{"urn": "urn:cerebro:writer:aws_security_group:sg-public", "label": "sg-public", "entity_type": "aws.security_group", "relation": "member_of", "attributes_json": `{"at":"2026-04-23T00:00:00Z"}`},
+					map[string]any{"urn": "urn:cerebro:writer:aws_ecs_task_definition:arn:aws:ecs:us-east-1:123456789012:task-definition/orders:7", "label": "orders:7", "entity_type": "aws.ecs.task_definition", "relation": "depends_on", "attributes_json": `{}`},
+					map[string]any{"urn": "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/ECSTaskRole", "label": "ECSTaskRole", "entity_type": "aws.role", "relation": "runs_as", "attributes_json": `{"role_usage":"task"}`},
+					map[string]any{"urn": "urn:cerebro:writer:aws_iam_policy:AdministratorAccess", "label": "AdministratorAccess", "entity_type": "aws.iam.policy", "relation": "can_perform", "attributes_json": `{"privilege_level":"admin"}`},
+				},
+			}},
+			wantSeverity:    "CRITICAL",
+			wantResourceURN: "urn:cerebro:writer:aws_ecs_task_definition:arn:aws:ecs:us-east-1:123456789012:task-definition/orders:7",
+		},
+		{
+			name: "ec2 instance role",
+			row: ports.CypherRow{Values: map[string]any{
+				"primary_urn":     "urn:cerebro:writer:aws_ec2_instance:i-1234567890abcdef0",
+				"primary_label":   "prod-web",
+				"primary_type":    "aws.ec2.instance",
+				"fingerprint_key": "urn:cerebro:writer:aws_ec2_instance:i-1234567890abcdef0|urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/WebInstanceRole|urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/AdminRole",
+				"severity":        "HIGH",
+				"summary":         "Publicly reachable compute workload prod-web runs as privileged role WebInstanceRole",
+				"action":          "Remove unnecessary public reachability and reduce the compute runtime role privileges",
+				"resource_urns": []any{
+					"urn:cerebro:writer:aws_ec2_instance:i-1234567890abcdef0",
+					"urn:cerebro:writer:aws_network_interface:eni-1",
+					"urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/WebInstanceRole",
+					"urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/AdminRole",
+					"urn:cerebro:writer:cloud_account:123456789012",
+				},
+				"evidence": []any{
+					map[string]any{"urn": "urn:cerebro:writer:aws_network_interface:eni-1", "label": "eni-1", "entity_type": "aws.network.interface", "relation": "attached_to", "attributes_json": `{"at":"2026-04-23T00:00:00Z"}`},
+					map[string]any{"urn": "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/WebInstanceRole", "label": "WebInstanceRole", "entity_type": "aws.role", "relation": "runs_as", "attributes_json": `{"role_usage":"primary"}`},
+					map[string]any{"urn": "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/AdminRole", "label": "AdminRole", "entity_type": "aws.role", "relation": "can_assume", "attributes_json": `{}`},
+				},
+			}},
+			wantSeverity:    "HIGH",
+			wantResourceURN: "urn:cerebro:writer:aws_network_interface:eni-1",
+		},
+		{
+			name: "lambda role",
+			row: ports.CypherRow{Values: map[string]any{
+				"primary_urn":     "urn:cerebro:writer:aws_lambda_function:arn:aws:lambda:us-east-1:123456789012:function:orders",
+				"primary_label":   "orders",
+				"primary_type":    "aws.lambda.function",
+				"fingerprint_key": "urn:cerebro:writer:aws_lambda_function:arn:aws:lambda:us-east-1:123456789012:function:orders|urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/LambdaOrdersRole|urn:cerebro:writer:aws_scope:*",
+				"severity":        "CRITICAL",
+				"summary":         "Publicly reachable compute workload orders runs as privileged role LambdaOrdersRole",
+				"action":          "Remove unnecessary public reachability and reduce the compute runtime role privileges",
+				"resource_urns": []any{
+					"urn:cerebro:writer:aws_lambda_function:arn:aws:lambda:us-east-1:123456789012:function:orders",
+					"urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/LambdaOrdersRole",
+					"urn:cerebro:writer:aws_scope:*",
+					"urn:cerebro:writer:cloud_account:123456789012",
+				},
+				"evidence": []any{
+					map[string]any{"urn": "urn:cerebro:writer:aws_public_principal:public_internet", "label": "public internet", "entity_type": "aws.public_principal", "relation": "can_reach", "attributes_json": `{"at":"2026-04-23T00:00:00Z"}`},
+					map[string]any{"urn": "urn:cerebro:writer:aws_role:arn:aws:iam::123456789012:role/LambdaOrdersRole", "label": "LambdaOrdersRole", "entity_type": "aws.role", "relation": "runs_as", "attributes_json": `{"role_usage":"primary"}`},
+					map[string]any{"urn": "urn:cerebro:writer:aws_scope:*", "label": "*", "entity_type": "aws.scope", "relation": "can_perform", "attributes_json": `{"permission":"*"}`},
+				},
+			}},
+			wantSeverity:    "CRITICAL",
+			wantResourceURN: "urn:cerebro:writer:aws_scope:*",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings, err := rule.EvaluateRows(context.Background(), runtime, []ports.CypherRow{tt.row})
+			if err != nil {
+				t.Fatalf("EvaluateRows() error = %v", err)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("len(findings) = %d, want 1", len(findings))
+			}
+			finding := findings[0]
+			if finding.RuleID != cloudExposedPrivilegedComputeRoleRuleID || finding.Severity != tt.wantSeverity || finding.Status != findingStatusOpen {
+				t.Fatalf("finding metadata = %#v", finding)
+			}
+			if !containsString(finding.ResourceURNs, tt.wantResourceURN) {
+				t.Fatalf("ResourceURNs = %#v, want %q", finding.ResourceURNs, tt.wantResourceURN)
+			}
+			if len(finding.GraphEvidenceRows) == 0 {
+				t.Fatalf("GraphEvidenceRows empty: %#v", finding)
+			}
+		})
+	}
+}

--- a/internal/findings/cloud_signal_rule.go
+++ b/internal/findings/cloud_signal_rule.go
@@ -91,6 +91,7 @@ func newCloudSignalRules() []Rule {
 		}),
 		newCloudPublicResourceExposureGraphRule(),
 		newCloudPublicExposurePrivilegedPrincipalRule(),
+		newCloudExposedPrivilegedComputeRoleRule(),
 	}
 }
 

--- a/internal/findings/coordination_graph_rule.go
+++ b/internal/findings/coordination_graph_rule.go
@@ -58,6 +58,7 @@ func isCoordinationGraphRuleID(ruleID string) bool {
 		sentinelOneAgentNotUpToDateRuleID,
 		sentinelOneUnmitigatedThreatRuleID,
 		cloudCurrentPublicExposureReviewRuleID,
+		cloudExposedPrivilegedComputeRoleRuleID,
 		"graph-resource-multiple-open-findings":
 		return true
 	default:

--- a/internal/findings/current_state_graph_rules_test.go
+++ b/internal/findings/current_state_graph_rules_test.go
@@ -33,6 +33,30 @@ func TestCurrentStateGraphRulesEmitStableFindings(t *testing.T) {
 			}},
 		},
 		{
+			name:    "cloud exposed privileged compute",
+			rule:    newCloudExposedPrivilegedComputeRoleRule(),
+			runtime: &cerebrov1.SourceRuntime{Id: "aws-ecs", SourceId: "aws", TenantId: "writer", Config: map[string]string{"family": "ecs_service"}},
+			row: ports.CypherRow{Values: map[string]any{
+				"primary_urn":     "urn:cerebro:writer:aws_ecs_service:orders",
+				"primary_label":   "orders",
+				"primary_type":    "aws.ecs.service",
+				"fingerprint_key": "urn:cerebro:writer:aws_ecs_service:orders|urn:cerebro:writer:aws_role:ECSTaskRole|urn:cerebro:writer:aws_iam_policy:AdministratorAccess",
+				"severity":        "CRITICAL",
+				"summary":         "Publicly reachable compute workload orders runs as privileged role ECSTaskRole",
+				"action":          "Remove unnecessary public reachability and reduce the compute runtime role privileges",
+				"resource_urns": []any{
+					"urn:cerebro:writer:aws_ecs_service:orders",
+					"urn:cerebro:writer:aws_ecs_task_definition:orders:7",
+					"urn:cerebro:writer:aws_role:ECSTaskRole",
+					"urn:cerebro:writer:aws_iam_policy:AdministratorAccess",
+				},
+				"evidence": []any{
+					map[string]any{"urn": "urn:cerebro:writer:aws_ecs_task_definition:orders:7", "label": "orders:7", "entity_type": "aws.ecs.task_definition", "relation": "depends_on", "attributes_json": `{}`},
+					map[string]any{"urn": "urn:cerebro:writer:aws_role:ECSTaskRole", "label": "ECSTaskRole", "entity_type": "aws.role", "relation": "runs_as", "attributes_json": `{}`},
+				},
+			}},
+		},
+		{
 			name:    "github credential",
 			rule:    newGitHubProgrammaticCredentialReviewRule(),
 			runtime: runtime,
@@ -158,6 +182,11 @@ func TestCurrentStateGraphRuleQueriesUseEnrichedCurrentState(t *testing.T) {
 			name: "cloud exposure uses recent reachability edge and current attributes",
 			rule: newCloudPublicResourceExposureGraphRule(),
 			want: []string{"relation: 'can_reach'", ".public_principal", `"internet_exposed":"true"`, `duration('P30D')`, "WITH DISTINCT resource"},
+		},
+		{
+			name: "cloud exposed privileged compute links reachability to runtime role privilege",
+			rule: newCloudExposedPrivilegedComputeRoleRule(),
+			want: []string{`entity_type: 'aws.ecs.task_definition'`, `relation: 'runs_as'`, `relation: 'depends_on'`, `relation: 'can_reach'`, `relation: 'member_of'`, `relation: 'attached_to'`, `access.relation IN ['can_admin', 'can_assume', 'can_perform']`, `duration('P30D')`},
 		},
 		{
 			name: "github credentials exclude inactive resources",

--- a/internal/findings/public_detection_catalog.json
+++ b/internal/findings/public_detection_catalog.json
@@ -98,6 +98,68 @@
       ]
     },
     {
+      "id": "cloud-exposed-privileged-compute-role",
+      "pack_id": "cloud",
+      "pack_name": "Cloud",
+      "name": "Cloud Exposed Privileged Compute Role",
+      "description": "Detect publicly reachable AWS compute workloads that run as admin-equivalent or privilege-escalating roles.",
+      "source_id": "cloud",
+      "evaluation_mode": "graph",
+      "event_kinds": [
+        "aws.ec2_instance",
+        "aws.ecs_service",
+        "aws.ecs_task_definition",
+        "aws.effective_permission",
+        "aws.iam_role_assignment",
+        "aws.iam_role_trust",
+        "aws.lambda_function",
+        "aws.public_endpoint",
+        "aws.resource_exposure"
+      ],
+      "output_kind": "finding.cloud_exposed_privileged_compute_role",
+      "severity": "CRITICAL",
+      "status": "open",
+      "maturity": "test",
+      "tags": [
+        "attack-path",
+        "attack.t1098",
+        "attack.t1190",
+        "aws",
+        "cloud",
+        "compute",
+        "ec2",
+        "ecs",
+        "lambda",
+        "privilege-escalation",
+        "public-exposure"
+      ],
+      "references": [
+        "https://attack.mitre.org/techniques/T1098/",
+        "https://attack.mitre.org/techniques/T1190/",
+        "https://www.cisecurity.org/benchmark/amazon_web_services"
+      ],
+      "false_positives": [
+        "Approved public compute endpoint whose runtime role is intentionally broad and protected by compensating controls not yet modeled in the graph.",
+        "Temporary deployment or break-glass role attachment during a documented maintenance window."
+      ],
+      "runbook": "Validate the public entry point, remove unnecessary public ingress, and reduce the EC2 instance profile, Lambda role, or ECS task role to least privilege. For ECS services, review the linked task definition role first.",
+      "fingerprint_fields": [
+        "compute_workload_urn",
+        "runtime_role_urn",
+        "permission_urn"
+      ],
+      "control_refs": [
+        {
+          "framework_name": "SOC 2",
+          "control_id": "CC6.6"
+        },
+        {
+          "framework_name": "ISO 27001:2022",
+          "control_id": "A.8.20"
+        }
+      ]
+    },
+    {
       "id": "cloud-privilege-path-granted",
       "pack_id": "cloud",
       "pack_name": "Cloud",

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -942,7 +942,7 @@ func TestNetNewRetiredRulesNoEmit(t *testing.T) {
 func TestKeepAsIsRulesUnchanged(t *testing.T) {
 	metadataByID := rulepackAuditMetadataByID(t)
 	keepRules := rulepackAuditRulesByClass(t, rulepackAuditClassKeep)
-	if got, want := len(keepRules), 35; got != want {
+	if got, want := len(keepRules), 36; got != want {
 		t.Fatalf("KEEP_AS_IS rule count = %d, want %d", got, want)
 	}
 	for _, entry := range keepRules {
@@ -1158,6 +1158,7 @@ func fallbackRulepackAuditClassifications() []rulepackAuditClassification {
 		{RuleID: "cloud-privilege-path-granted", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "cloud"},
 		{RuleID: "cloud-public-exposure-privileged-principal", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "cloud"},
 		{RuleID: "cloud-current-public-exposure-review-needed", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "cloud"},
+		{RuleID: "cloud-exposed-privileged-compute-role", Classification: "KEEP_AS_IS", BulkCloseoutThreshold: "none", Source: "cloud"},
 		{RuleID: "cloud-public-resource-exposure", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "cloud"},
 		{RuleID: "data-sensitive-asset-risk", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "asset"},
 		{RuleID: "github-app-integration-installed", Classification: "CONVERT_TO_CURRENT_STATE", BulkCloseoutThreshold: ">7d", Source: "github"},


### PR DESCRIPTION
## Summary
- add a Cloud graph rule for publicly reachable AWS compute workloads that run as privileged roles
- support ECS service -> task definition -> task role paths plus EC2/Lambda direct runtime roles
- register the rule and regenerate the public detection catalog

## Validation
- make build
- make test
- make lint
- make proto-lint openapi-check
- make openapi-lint
- make catalog-check detection-catalog-check
- make oss-audit
- make check-structural check-structural-test check-arch